### PR TITLE
feat: improve bin interactions and add grid size inputs

### DIFF
--- a/src/components/DragPreview.tsx
+++ b/src/components/DragPreview.tsx
@@ -67,12 +67,22 @@ export function DragPreview() {
   // but share the same visual top edge
   const maxYTop = Math.max(...draggedBins.map(b => b.y + b.depth));
 
+  // Use clickOffset from interaction if available for smooth dragging
+  // Otherwise fall back to centering on cursor
+  let previewOffsetX = cellSize / 2;
+  let previewOffsetY = cellSize / 2;
+
+  if (interaction.type === 'drag' && interaction.clickOffset) {
+    previewOffsetX = interaction.clickOffset.x;
+    previewOffsetY = interaction.clickOffset.y;
+  }
+
   return (
     <div
       className="fixed pointer-events-none z-[100]"
       style={{
-        left: mousePos.x - cellSize / 2,
-        top: mousePos.y - cellSize / 2,
+        left: mousePos.x - previewOffsetX,
+        top: mousePos.y - previewOffsetY,
       }}
     >
       {draggedBins.map((bin) => {

--- a/src/components/Grid/Bin.tsx
+++ b/src/components/Grid/Bin.tsx
@@ -60,6 +60,7 @@ function BinComponent({ bin, category, layer, drawer, cellSize, isGhost, isSelec
   const showContextMenu = useUIStore((state) => state.showContextMenu);
   const setFocusedBin = useUIStore((state) => state.setFocusedBin);
   const setActiveMobilePanel = useUIStore((state) => state.setActiveMobilePanel);
+  const showQuickLabel = useUIStore((state) => state.showQuickLabel);
 
   // Consolidate layout state selectors with shallow comparison
   const { printBedSize, gridUnitMm } = useLayoutStore(
@@ -353,6 +354,16 @@ function BinComponent({ bin, category, layer, drawer, cellSize, isGhost, isSelec
       onPointerUp={handlePointerUp}
       onPointerCancel={handlePointerCancel}
       onContextMenu={handleContextMenu}
+      onDoubleClick={(e) => {
+        if (isGhost) return;
+        e.preventDefault();
+        e.stopPropagation();
+        // Select the bin if not selected and show quick label popover
+        if (!isSelected) {
+          setSelectedBin(bin.id);
+        }
+        showQuickLabel(bin.id);
+      }}
       onMouseEnter={() => !isTouchDevice && setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onFocus={() => !isGhost && setFocusedBin(bin.id)}
@@ -450,20 +461,20 @@ function BinComponent({ bin, category, layer, drawer, cellSize, isGhost, isSelec
       {/* Disable pointer events during any interaction to avoid blocking draw operations */}
       {isSelected && !isGhost && !isMultiSelect && !interaction && (
         <>
-          {/* Right edge handle - 44px touch target, 10px visual */}
+          {/* Left edge handle (w) */}
           <div
             className="absolute transition-transform hover:scale-110 flex items-center justify-center"
             style={{
-              right: -22,
+              left: -22,
               top: '25%',
               width: 44,
               height: '50%',
               minHeight: 44,
               cursor: 'ew-resize',
             }}
-            onPointerDown={(e) => handleResizePointerDown(e, 'e')}
+            onPointerDown={(e) => handleResizePointerDown(e, 'w')}
             role="slider"
-            aria-label="Resize width"
+            aria-label="Resize left edge"
             aria-orientation="horizontal"
           >
             <div
@@ -477,20 +488,47 @@ function BinComponent({ bin, category, layer, drawer, cellSize, isGhost, isSelec
               }}
             />
           </div>
-          {/* Bottom edge handle - 44px touch target, 10px visual */}
+          {/* Right edge handle (e) */}
           <div
             className="absolute transition-transform hover:scale-110 flex items-center justify-center"
             style={{
-              bottom: -22,
+              right: -22,
+              top: '25%',
+              width: 44,
+              height: '50%',
+              minHeight: 44,
+              cursor: 'ew-resize',
+            }}
+            onPointerDown={(e) => handleResizePointerDown(e, 'e')}
+            role="slider"
+            aria-label="Resize right edge"
+            aria-orientation="horizontal"
+          >
+            <div
+              style={{
+                width: 10,
+                height: '45%',
+                minHeight: 20,
+                background: 'var(--selection-ring)',
+                borderRadius: 'var(--radius-sm)',
+                boxShadow: 'var(--shadow-sm)',
+              }}
+            />
+          </div>
+          {/* Top edge handle (n) - visually at top, increases Y */}
+          <div
+            className="absolute transition-transform hover:scale-110 flex items-center justify-center"
+            style={{
+              top: -22,
               left: '25%',
               width: '50%',
               minWidth: 44,
               height: 44,
               cursor: 'ns-resize',
             }}
-            onPointerDown={(e) => handleResizePointerDown(e, 's')}
+            onPointerDown={(e) => handleResizePointerDown(e, 'n')}
             role="slider"
-            aria-label="Resize depth"
+            aria-label="Resize top edge"
             aria-orientation="vertical"
           >
             <div
@@ -504,7 +542,106 @@ function BinComponent({ bin, category, layer, drawer, cellSize, isGhost, isSelec
               }}
             />
           </div>
-          {/* SE corner handle - 44px touch target, 12px visual */}
+          {/* Bottom edge handle (s) - visually at bottom, decreases Y */}
+          <div
+            className="absolute transition-transform hover:scale-110 flex items-center justify-center"
+            style={{
+              bottom: -22,
+              left: '25%',
+              width: '50%',
+              minWidth: 44,
+              height: 44,
+              cursor: 'ns-resize',
+            }}
+            onPointerDown={(e) => handleResizePointerDown(e, 's')}
+            role="slider"
+            aria-label="Resize bottom edge"
+            aria-orientation="vertical"
+          >
+            <div
+              style={{
+                width: '45%',
+                minWidth: 20,
+                height: 10,
+                background: 'var(--selection-ring)',
+                borderRadius: 'var(--radius-sm)',
+                boxShadow: 'var(--shadow-sm)',
+              }}
+            />
+          </div>
+          {/* NW corner handle (top-left) */}
+          <div
+            className="absolute transition-transform hover:scale-125 flex items-center justify-center"
+            style={{
+              left: -22,
+              top: -22,
+              width: 44,
+              height: 44,
+              cursor: 'nwse-resize',
+            }}
+            onPointerDown={(e) => handleResizePointerDown(e, 'nw')}
+            role="slider"
+            aria-label="Resize top-left corner"
+          >
+            <div
+              style={{
+                width: 12,
+                height: 12,
+                background: 'var(--selection-ring)',
+                borderRadius: 'var(--radius-sm)',
+                boxShadow: 'var(--shadow-md)',
+              }}
+            />
+          </div>
+          {/* NE corner handle (top-right) */}
+          <div
+            className="absolute transition-transform hover:scale-125 flex items-center justify-center"
+            style={{
+              right: -22,
+              top: -22,
+              width: 44,
+              height: 44,
+              cursor: 'nesw-resize',
+            }}
+            onPointerDown={(e) => handleResizePointerDown(e, 'ne')}
+            role="slider"
+            aria-label="Resize top-right corner"
+          >
+            <div
+              style={{
+                width: 12,
+                height: 12,
+                background: 'var(--selection-ring)',
+                borderRadius: 'var(--radius-sm)',
+                boxShadow: 'var(--shadow-md)',
+              }}
+            />
+          </div>
+          {/* SW corner handle (bottom-left) */}
+          <div
+            className="absolute transition-transform hover:scale-125 flex items-center justify-center"
+            style={{
+              left: -22,
+              bottom: -22,
+              width: 44,
+              height: 44,
+              cursor: 'nesw-resize',
+            }}
+            onPointerDown={(e) => handleResizePointerDown(e, 'sw')}
+            role="slider"
+            aria-label="Resize bottom-left corner"
+          >
+            <div
+              style={{
+                width: 12,
+                height: 12,
+                background: 'var(--selection-ring)',
+                borderRadius: 'var(--radius-sm)',
+                boxShadow: 'var(--shadow-md)',
+              }}
+            />
+          </div>
+          {/* SE corner handle (bottom-right) */}
           <div
             className="absolute transition-transform hover:scale-125 flex items-center justify-center"
             style={{
@@ -516,7 +653,7 @@ function BinComponent({ bin, category, layer, drawer, cellSize, isGhost, isSelec
             }}
             onPointerDown={(e) => handleResizePointerDown(e, 'se')}
             role="slider"
-            aria-label="Resize width and depth"
+            aria-label="Resize bottom-right corner"
           >
             <div
               style={{
@@ -531,19 +668,22 @@ function BinComponent({ bin, category, layer, drawer, cellSize, isGhost, isSelec
         </>
       )}
 
-      {/* Ghost resize handles - show on hover for non-selected bins (desktop only) */}
-      {!isSelected && !isGhost && isHovered && !isTouchDevice && (
+      {/* Functional resize handles - show on hover for non-selected bins (desktop only) */}
+      {/* These are semi-transparent but fully functional, allowing resize without selection */}
+      {!isSelected && !isGhost && isHovered && !isTouchDevice && !interaction && (
         <>
-          {/* Right edge ghost handle */}
+          {/* Left edge handle (w) */}
           <div
-            className="absolute flex items-center justify-center pointer-events-none"
+            className="absolute flex items-center justify-center transition-transform hover:scale-110"
             style={{
-              right: -22,
+              left: -22,
               top: '25%',
               width: 44,
               height: '50%',
               minHeight: 44,
+              cursor: 'ew-resize',
             }}
+            onPointerDown={(e) => handleResizePointerDown(e, 'w')}
           >
             <div
               style={{
@@ -552,20 +692,46 @@ function BinComponent({ bin, category, layer, drawer, cellSize, isGhost, isSelec
                 minHeight: 20,
                 background: 'var(--selection-ring)',
                 borderRadius: 'var(--radius-sm)',
-                opacity: 0.4,
+                opacity: 0.5,
               }}
             />
           </div>
-          {/* Bottom edge ghost handle */}
+          {/* Right edge handle (e) */}
           <div
-            className="absolute flex items-center justify-center pointer-events-none"
+            className="absolute flex items-center justify-center transition-transform hover:scale-110"
             style={{
-              bottom: -22,
+              right: -22,
+              top: '25%',
+              width: 44,
+              height: '50%',
+              minHeight: 44,
+              cursor: 'ew-resize',
+            }}
+            onPointerDown={(e) => handleResizePointerDown(e, 'e')}
+          >
+            <div
+              style={{
+                width: 10,
+                height: '45%',
+                minHeight: 20,
+                background: 'var(--selection-ring)',
+                borderRadius: 'var(--radius-sm)',
+                opacity: 0.5,
+              }}
+            />
+          </div>
+          {/* Top edge handle (n) */}
+          <div
+            className="absolute flex items-center justify-center transition-transform hover:scale-110"
+            style={{
+              top: -22,
               left: '25%',
               width: '50%',
               minWidth: 44,
               height: 44,
+              cursor: 'ns-resize',
             }}
+            onPointerDown={(e) => handleResizePointerDown(e, 'n')}
           >
             <div
               style={{
@@ -574,19 +740,45 @@ function BinComponent({ bin, category, layer, drawer, cellSize, isGhost, isSelec
                 height: 10,
                 background: 'var(--selection-ring)',
                 borderRadius: 'var(--radius-sm)',
-                opacity: 0.4,
+                opacity: 0.5,
               }}
             />
           </div>
-          {/* SE corner ghost handle */}
+          {/* Bottom edge handle (s) */}
           <div
-            className="absolute flex items-center justify-center pointer-events-none"
+            className="absolute flex items-center justify-center transition-transform hover:scale-110"
             style={{
-              right: -22,
               bottom: -22,
+              left: '25%',
+              width: '50%',
+              minWidth: 44,
+              height: 44,
+              cursor: 'ns-resize',
+            }}
+            onPointerDown={(e) => handleResizePointerDown(e, 's')}
+          >
+            <div
+              style={{
+                width: '45%',
+                minWidth: 20,
+                height: 10,
+                background: 'var(--selection-ring)',
+                borderRadius: 'var(--radius-sm)',
+                opacity: 0.5,
+              }}
+            />
+          </div>
+          {/* NW corner handle (top-left) */}
+          <div
+            className="absolute flex items-center justify-center transition-transform hover:scale-125"
+            style={{
+              left: -22,
+              top: -22,
               width: 44,
               height: 44,
+              cursor: 'nwse-resize',
             }}
+            onPointerDown={(e) => handleResizePointerDown(e, 'nw')}
           >
             <div
               style={{
@@ -594,7 +786,73 @@ function BinComponent({ bin, category, layer, drawer, cellSize, isGhost, isSelec
                 height: 12,
                 background: 'var(--selection-ring)',
                 borderRadius: 'var(--radius-sm)',
-                opacity: 0.4,
+                opacity: 0.5,
+              }}
+            />
+          </div>
+          {/* NE corner handle (top-right) */}
+          <div
+            className="absolute flex items-center justify-center transition-transform hover:scale-125"
+            style={{
+              right: -22,
+              top: -22,
+              width: 44,
+              height: 44,
+              cursor: 'nesw-resize',
+            }}
+            onPointerDown={(e) => handleResizePointerDown(e, 'ne')}
+          >
+            <div
+              style={{
+                width: 12,
+                height: 12,
+                background: 'var(--selection-ring)',
+                borderRadius: 'var(--radius-sm)',
+                opacity: 0.5,
+              }}
+            />
+          </div>
+          {/* SW corner handle (bottom-left) */}
+          <div
+            className="absolute flex items-center justify-center transition-transform hover:scale-125"
+            style={{
+              left: -22,
+              bottom: -22,
+              width: 44,
+              height: 44,
+              cursor: 'nesw-resize',
+            }}
+            onPointerDown={(e) => handleResizePointerDown(e, 'sw')}
+          >
+            <div
+              style={{
+                width: 12,
+                height: 12,
+                background: 'var(--selection-ring)',
+                borderRadius: 'var(--radius-sm)',
+                opacity: 0.5,
+              }}
+            />
+          </div>
+          {/* SE corner handle (bottom-right) */}
+          <div
+            className="absolute flex items-center justify-center transition-transform hover:scale-125"
+            style={{
+              right: -22,
+              bottom: -22,
+              width: 44,
+              height: 44,
+              cursor: 'nwse-resize',
+            }}
+            onPointerDown={(e) => handleResizePointerDown(e, 'se')}
+          >
+            <div
+              style={{
+                width: 12,
+                height: 12,
+                background: 'var(--selection-ring)',
+                borderRadius: 'var(--radius-sm)',
+                opacity: 0.5,
               }}
             />
           </div>

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,6 +1,6 @@
 import { useShallow } from 'zustand/shallow';
 import { useUIStore, useLayoutStore } from '../../store';
-import { calcMaxGridUnits } from '../../constants';
+import { calcMaxGridUnits, CONSTRAINTS } from '../../constants';
 import { ActiveLayerPanel } from './ActiveLayerPanel';
 import { LayerPanel } from './LayerPanel';
 import { CategoriesPanel } from './CategoriesPanel';
@@ -18,6 +18,8 @@ export function Sidebar() {
     gridUnitMm,
     heightUnitMm,
     printBedSize,
+    drawerWidth,
+    drawerDepth,
     drawerHeight,
     setGridUnitMm,
     setHeightUnitMm,
@@ -28,6 +30,8 @@ export function Sidebar() {
       gridUnitMm: state.layout.gridUnitMm,
       heightUnitMm: state.layout.heightUnitMm,
       printBedSize: state.layout.printBedSize,
+      drawerWidth: state.layout.drawer.width,
+      drawerDepth: state.layout.drawer.depth,
       drawerHeight: state.layout.drawer.height,
       setGridUnitMm: state.setGridUnitMm,
       setHeightUnitMm: state.setHeightUnitMm,
@@ -39,6 +43,14 @@ export function Sidebar() {
   const handleDrawerHeightChange = (delta: number) => {
     const newHeight = Math.max(1, drawerHeight + delta);
     updateDrawer({ height: newHeight });
+  };
+
+  const handleDrawerWidthChange = (width: number) => {
+    updateDrawer({ width: Math.max(1, Math.min(CONSTRAINTS.GRID_MAX, width)) });
+  };
+
+  const handleDrawerDepthChange = (depth: number) => {
+    updateDrawer({ depth: Math.max(1, Math.min(CONSTRAINTS.GRID_MAX, depth)) });
   };
 
   return (
@@ -95,6 +107,46 @@ export function Sidebar() {
                 Grid Settings
               </h2>
               <div className="text-xs text-content-secondary space-y-2">
+                <div className="flex items-center justify-between">
+                  <label
+                    htmlFor="gridWidth"
+                    className="text-content-tertiary"
+                    title="Number of grid units wide (you can also drag the grid edge handles)"
+                  >
+                    Grid width
+                  </label>
+                  <div className="flex items-center gap-1">
+                    <DeferredNumberInput
+                      id="gridWidth"
+                      value={drawerWidth}
+                      onChange={handleDrawerWidthChange}
+                      min={1}
+                      max={CONSTRAINTS.GRID_MAX}
+                      className="input w-12 py-0.5 px-1 text-xs text-right"
+                    />
+                    <span className="text-content-tertiary">units</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <label
+                    htmlFor="gridDepth"
+                    className="text-content-tertiary"
+                    title="Number of grid units deep (you can also drag the grid edge handles)"
+                  >
+                    Grid depth
+                  </label>
+                  <div className="flex items-center gap-1">
+                    <DeferredNumberInput
+                      id="gridDepth"
+                      value={drawerDepth}
+                      onChange={handleDrawerDepthChange}
+                      min={1}
+                      max={CONSTRAINTS.GRID_MAX}
+                      className="input w-12 py-0.5 px-1 text-xs text-right"
+                    />
+                    <span className="text-content-tertiary">units</span>
+                  </div>
+                </div>
                 <div className="flex items-center justify-between">
                   <span
                     className="text-content-tertiary"

--- a/src/hooks/useInteraction.ts
+++ b/src/hooks/useInteraction.ts
@@ -5,7 +5,7 @@ import { useUIStore, useLayoutStore, useUndoableAction } from '../store';
 import { useGridCoords } from './useGridCoords';
 import { canPlaceBin, clamp } from '../utils/validation';
 import { constrainGroupDelta } from '../utils/selection';
-import { STAGING_ID } from '../constants';
+import { STAGING_ID, getBaseCellSize } from '../constants';
 
 /**
  * Hook for managing all grid interactions including bin creation, movement, and resizing.
@@ -144,6 +144,32 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
       }
     }
 
+    // Calculate pixel offset from bin origin to click position
+    // This allows the bin to stay at the same relative position under the cursor
+    let clickOffset: { x: number; y: number } | undefined;
+    if (gridRef.current) {
+      const rect = gridRef.current.getBoundingClientRect();
+      const zoom = useUIStore.getState().zoom;
+      const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1280;
+      const cellSize = Math.round(getBaseCellSize(viewportWidth) * zoom);
+      const gap = 1;
+
+      // Calculate the pixel position of the bin's visual top-left corner
+      // Note: Y is inverted - bin.y is from bottom, but visual top is at drawer.depth - bin.y - bin.depth
+      const binVisualLeft = gap + bin.x * (cellSize + gap);
+      const binVisualTop = gap + (layout.drawer.depth - bin.y - bin.depth) * (cellSize + gap);
+
+      // Calculate click position relative to grid
+      const clickRelX = clientX - rect.left;
+      const clickRelY = clientY - rect.top;
+
+      // Store offset from bin's visual corner to click point
+      clickOffset = {
+        x: clickRelX - binVisualLeft,
+        y: clickRelY - binVisualTop,
+      };
+    }
+
     // Use click position as startCoord so delta is calculated from where user clicked
     const startCoord = clickCoord;
 
@@ -164,8 +190,9 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
       currentCoord: { x: 0, y: 0 }, // Delta starts at zero (no movement yet)
       valid: true,
       isOverGrid: true,
+      clickOffset,
     });
-  }, [layout.bins, selectedBinIds, setSelectedBin, setInteraction, getGridCoords]);
+  }, [layout.bins, layout.drawer.depth, selectedBinIds, setSelectedBin, setInteraction, getGridCoords, gridRef]);
 
   // Start resizing bins (single or multiple)
   const startResize = useCallback((binId: string, handle: ResizeHandle, pointerId?: number) => {

--- a/src/test/mobile-touch.test.tsx
+++ b/src/test/mobile-touch.test.tsx
@@ -442,9 +442,9 @@ describe('Mobile Touch Interactions', () => {
       );
 
       // Find resize handles by their aria-label
-      const rightHandle = container.querySelector('[aria-label="Resize width"]');
-      const bottomHandle = container.querySelector('[aria-label="Resize depth"]');
-      const cornerHandle = container.querySelector('[aria-label="Resize width and depth"]');
+      const rightHandle = container.querySelector('[aria-label="Resize right edge"]');
+      const bottomHandle = container.querySelector('[aria-label="Resize bottom edge"]');
+      const cornerHandle = container.querySelector('[aria-label="Resize bottom-right corner"]');
 
       expect(rightHandle).not.toBeNull();
       expect(bottomHandle).not.toBeNull();
@@ -471,7 +471,7 @@ describe('Mobile Touch Interactions', () => {
         />
       );
 
-      const cornerHandle = container.querySelector('[aria-label="Resize width and depth"]');
+      const cornerHandle = container.querySelector('[aria-label="Resize bottom-right corner"]');
 
       act(() => {
         fireEvent.pointerDown(cornerHandle!, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,7 +69,7 @@ export type ResizeHandle = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
 
 export type Interaction =
   | { type: 'draw'; start: Coord; current: Coord }
-  | { type: 'drag'; binIds: string[]; startCoord: Coord; currentCoord: Coord; valid: boolean; isOverGrid: boolean }
+  | { type: 'drag'; binIds: string[]; startCoord: Coord; currentCoord: Coord; valid: boolean; isOverGrid: boolean; clickOffset?: { x: number; y: number } }
   | { type: 'resize'; binIds: string[]; handle: ResizeHandle; startRects: Map<string, Rect>; currentRects: Map<string, Rect>; valid: boolean }
   | { type: 'stagingDrag'; binId: string; currentCoord: Coord | null; valid: boolean }
   | { type: 'paint'; paintSize: { width: number; depth: number }; start: Coord; current: Coord };


### PR DESCRIPTION
- Fix drag anchor to use click position for smooth dragging
  - Track clickOffset when starting drag to maintain cursor position
  - Update DragPreview to use clickOffset instead of centering on cursor
  - Bins no longer "jump" when dragging starts

- Add resize handles on all edges (8 total: 4 edges + 4 corners)
  - Left (w), Right (e), Top (n), Bottom (s) edges
  - NW, NE, SW, SE corner handles
  - Enables resizing in any direction without moving first

- Make resize handles functional on hover
  - Remove pointer-events-none from hover handles
  - Bins can now be resized without selecting first
  - Semi-transparent handles appear on hover, fully functional

- Add numeric inputs for grid size in Grid Settings
  - New "Grid width" and "Grid depth" inputs in sidebar
  - Easier to set exact dimensions without using drag handles

- Add double-click on bin to edit label
  - Double-clicking any bin opens the quick label popover
  - Bin is selected automatically if not already

- Update tests to match new aria-labels for resize handles