### PR TITLE
Improve touch interactions for mobile grid

### DIFF
--- a/src/components/Grid/Bin.tsx
+++ b/src/components/Grid/Bin.tsx
@@ -1,19 +1,25 @@
-import { memo, useRef, useState, type PointerEvent } from 'react';
+import { memo, useRef, useState, useEffect, type PointerEvent } from 'react';
 import { useShallow } from 'zustand/shallow';
 import type { Bin as BinType, Category, Layer, ResizeHandle } from '../../types';
 import { useUIStore, useLayoutStore } from '../../store';
 import { useToastStore } from '../../store/toast';
 import { useResponsive } from '../../hooks';
-import { calcMaxGridUnits, DEFAULT_CATEGORY_COLOR, HALF_BIN_SCALE } from '../../constants';
+import {
+  calcMaxGridUnits,
+  DEFAULT_CATEGORY_COLOR,
+  HALF_BIN_SCALE,
+  LONG_PRESS_DURATION,
+  DOUBLE_TAP_THRESHOLD,
+  TOUCH_MOVE_THRESHOLD,
+  SCROLL_INTENT_RATIO,
+  DIRECTION_LOCK_DISTANCE,
+} from '../../constants';
 import { getBinTextColors } from '../../utils/color';
 
 /** Clamp a value between min and max */
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
-
-const LONG_PRESS_DURATION = 500; // ms
-const DOUBLE_TAP_THRESHOLD = 300; // ms
 
 interface BinProps {
   bin: BinType;
@@ -80,9 +86,16 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
   const lastTapTimeRef = useRef<number>(0);
   // Track pointer ID for passing to useInteraction
   const activePointerIdRef = useRef<number | null>(null);
+  // Directional intent tracking for touch - prevents accidental drag when user intends to scroll
+  const directionLockedRef = useRef<'horizontal' | 'vertical' | null>(null);
+  // Track if drag has been initiated (to prevent re-triggering)
+  const dragInitiatedRef = useRef(false);
 
   // Hover state for ghost handles (desktop only)
   const [isHovered, setIsHovered] = useState(false);
+  // Track resize handle pulse animation for touch discoverability
+  const [showHandlePulse, setShowHandlePulse] = useState(false);
+  const wasSelectedRef = useRef(isSelected);
   const addToast = useToastStore(state => state.addToast);
 
   const isBeingDragged = interaction?.type === 'drag' && interaction.binIds.includes(bin.id);
@@ -90,6 +103,29 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
 
   // Hide resize handles during multi-select
   const isMultiSelect = selectedBinIds.length > 1;
+
+  // Pulse resize handles when bin becomes selected on touch device
+  // This helps users discover the resize handles
+  useEffect(() => {
+    // Check if bin just became selected (wasn't selected before, is now)
+    const justSelected = isSelected && !wasSelectedRef.current;
+    wasSelectedRef.current = isSelected;
+
+    // Only pulse on touch devices, single selection, when just selected
+    if (!isTouchDevice || !justSelected || isMultiSelect) {
+      return;
+    }
+
+    // Use setTimeout to defer state update and avoid synchronous setState in effect
+    const pulseTimer = setTimeout(() => setShowHandlePulse(true), 0);
+    // Stop pulsing after animation completes
+    const stopTimer = setTimeout(() => setShowHandlePulse(false), 1500);
+
+    return () => {
+      clearTimeout(pulseTimer);
+      clearTimeout(stopTimer);
+    };
+  }, [isSelected, isTouchDevice, isMultiSelect]);
 
   // Calculate max grid units that fit on print bed (accounting for gaps)
   const maxGridUnits = calcMaxGridUnits(printBedSize, gridUnitMm);
@@ -200,6 +236,10 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
     longPressTriggeredRef.current = false;
     pointerStartRef.current = { x: e.clientX, y: e.clientY };
 
+    // Reset directional intent tracking for touch devices
+    directionLockedRef.current = null;
+    dragInitiatedRef.current = false;
+
     // Start long-press timer on touch devices
     if (isTouchDevice && e.button === 0) {
       clearLongPress();
@@ -248,17 +288,49 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
   };
 
   const handlePointerMove = (e: PointerEvent<HTMLDivElement>) => {
-    // Cancel long-press if pointer moved too far (10px threshold)
-    if (pointerStartRef.current) {
-      const dx = e.clientX - pointerStartRef.current.x;
-      const dy = e.clientY - pointerStartRef.current.y;
-      const distance = Math.sqrt(dx * dx + dy * dy);
-      if (distance > 10) {
-        clearLongPress();
-        // Start drag on move for touch devices (pass pointer ID for capture management)
-        if (isTouchDevice && !longPressTriggeredRef.current) {
-          onStartDrag(bin.id, e.clientX, e.clientY, activePointerIdRef.current ?? e.pointerId);
+    if (!pointerStartRef.current) return;
+
+    const dx = e.clientX - pointerStartRef.current.x;
+    const dy = e.clientY - pointerStartRef.current.y;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+    const absDx = Math.abs(dx);
+    const absDy = Math.abs(dy);
+
+    // Cancel long-press if pointer moved past threshold
+    if (distance > TOUCH_MOVE_THRESHOLD) {
+      clearLongPress();
+    }
+
+    // Touch device: Use directional intent detection to distinguish scroll from drag
+    if (isTouchDevice && !longPressTriggeredRef.current && !dragInitiatedRef.current) {
+      // Determine direction once we've moved far enough
+      if (directionLockedRef.current === null && distance >= DIRECTION_LOCK_DISTANCE) {
+        // Calculate ratio of vertical movement
+        const verticalRatio = absDy / (absDx + absDy);
+
+        if (verticalRatio >= SCROLL_INTENT_RATIO) {
+          // Predominantly vertical movement = scroll intent
+          directionLockedRef.current = 'vertical';
+        } else {
+          // Predominantly horizontal or diagonal = drag intent
+          directionLockedRef.current = 'horizontal';
         }
+      }
+
+      // Start drag only if horizontal intent (or if below direction lock threshold but past move threshold)
+      if (distance > TOUCH_MOVE_THRESHOLD) {
+        // If we've locked to vertical, don't start drag - user is scrolling
+        if (directionLockedRef.current === 'vertical') {
+          return;
+        }
+
+        // If horizontal locked or not yet locked (small movement), allow drag
+        // Haptic feedback on drag start
+        if (navigator.vibrate) {
+          navigator.vibrate(30);
+        }
+        dragInitiatedRef.current = true;
+        onStartDrag(bin.id, e.clientX, e.clientY, activePointerIdRef.current ?? e.pointerId);
       }
     }
   };
@@ -274,7 +346,7 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
       const dy = e.clientY - pointerStartRef.current.y;
       const distance = Math.sqrt(dx * dx + dy * dy);
 
-      if (distance <= 10) {
+      if (distance <= TOUCH_MOVE_THRESHOLD) {
         const now = Date.now();
         if (now - lastTapTimeRef.current < DOUBLE_TAP_THRESHOLD) {
           // Double-tap detected - open inspector
@@ -287,12 +359,16 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
     }
 
     pointerStartRef.current = null;
+    directionLockedRef.current = null;
+    dragInitiatedRef.current = false;
   };
 
   const handlePointerCancel = () => {
     clearLongPress();
     activePointerIdRef.current = null;
     pointerStartRef.current = null;
+    directionLockedRef.current = null;
+    dragInitiatedRef.current = false;
   };
 
   // Right-click context menu for desktop
@@ -510,13 +586,14 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
             aria-orientation="horizontal"
           >
             <div
+              className={showHandlePulse ? 'animate-pulse' : ''}
               style={{
                 width: 10,
                 height: '45%',
                 minHeight: 20,
                 background: 'var(--selection-ring)',
                 borderRadius: 'var(--radius-sm)',
-                boxShadow: 'var(--shadow-sm)',
+                boxShadow: showHandlePulse ? '0 0 12px var(--color-accent)' : 'var(--shadow-sm)',
               }}
             />
           </div>
@@ -537,13 +614,14 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
             aria-orientation="horizontal"
           >
             <div
+              className={showHandlePulse ? 'animate-pulse' : ''}
               style={{
                 width: 10,
                 height: '45%',
                 minHeight: 20,
                 background: 'var(--selection-ring)',
                 borderRadius: 'var(--radius-sm)',
-                boxShadow: 'var(--shadow-sm)',
+                boxShadow: showHandlePulse ? '0 0 12px var(--color-accent)' : 'var(--shadow-sm)',
               }}
             />
           </div>
@@ -564,13 +642,14 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
             aria-orientation="vertical"
           >
             <div
+              className={showHandlePulse ? 'animate-pulse' : ''}
               style={{
                 width: '45%',
                 minWidth: 20,
                 height: 10,
                 background: 'var(--selection-ring)',
                 borderRadius: 'var(--radius-sm)',
-                boxShadow: 'var(--shadow-sm)',
+                boxShadow: showHandlePulse ? '0 0 12px var(--color-accent)' : 'var(--shadow-sm)',
               }}
             />
           </div>
@@ -591,13 +670,14 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
             aria-orientation="vertical"
           >
             <div
+              className={showHandlePulse ? 'animate-pulse' : ''}
               style={{
                 width: '45%',
                 minWidth: 20,
                 height: 10,
                 background: 'var(--selection-ring)',
                 borderRadius: 'var(--radius-sm)',
-                boxShadow: 'var(--shadow-sm)',
+                boxShadow: showHandlePulse ? '0 0 12px var(--color-accent)' : 'var(--shadow-sm)',
               }}
             />
           </div>
@@ -616,12 +696,13 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
             aria-label="Resize top-left corner"
           >
             <div
+              className={showHandlePulse ? 'animate-pulse' : ''}
               style={{
                 width: 12,
                 height: 12,
                 background: 'var(--selection-ring)',
                 borderRadius: 'var(--radius-sm)',
-                boxShadow: 'var(--shadow-md)',
+                boxShadow: showHandlePulse ? '0 0 12px var(--color-accent)' : 'var(--shadow-md)',
               }}
             />
           </div>
@@ -640,12 +721,13 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
             aria-label="Resize top-right corner"
           >
             <div
+              className={showHandlePulse ? 'animate-pulse' : ''}
               style={{
                 width: 12,
                 height: 12,
                 background: 'var(--selection-ring)',
                 borderRadius: 'var(--radius-sm)',
-                boxShadow: 'var(--shadow-md)',
+                boxShadow: showHandlePulse ? '0 0 12px var(--color-accent)' : 'var(--shadow-md)',
               }}
             />
           </div>
@@ -664,12 +746,13 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
             aria-label="Resize bottom-left corner"
           >
             <div
+              className={showHandlePulse ? 'animate-pulse' : ''}
               style={{
                 width: 12,
                 height: 12,
                 background: 'var(--selection-ring)',
                 borderRadius: 'var(--radius-sm)',
-                boxShadow: 'var(--shadow-md)',
+                boxShadow: showHandlePulse ? '0 0 12px var(--color-accent)' : 'var(--shadow-md)',
               }}
             />
           </div>
@@ -688,12 +771,13 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
             aria-label="Resize bottom-right corner"
           >
             <div
+              className={showHandlePulse ? 'animate-pulse' : ''}
               style={{
                 width: 12,
                 height: 12,
                 background: 'var(--selection-ring)',
                 borderRadius: 'var(--radius-sm)',
-                boxShadow: 'var(--shadow-md)',
+                boxShadow: showHandlePulse ? '0 0 12px var(--color-accent)' : 'var(--shadow-md)',
               }}
             />
           </div>

--- a/src/components/Grid/GridCanvas.tsx
+++ b/src/components/Grid/GridCanvas.tsx
@@ -1,11 +1,16 @@
 import type { RefObject, PointerEvent, JSX } from 'react';
-import { useMemo } from 'react';
+import { useMemo, useRef, useCallback, useState } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { useUIStore, useLayoutStore } from '../../store';
-import { useGridCoords } from '../../hooks';
+import { useGridCoords, useResponsive } from '../../hooks';
 import { Bin } from './Bin';
 import { getBlockedZones } from '../../utils/collision';
-import { DEFAULT_CATEGORY_COLOR, HALF_BIN_SCALE } from '../../constants';
+import {
+  DEFAULT_CATEGORY_COLOR,
+  HALF_BIN_SCALE,
+  TOUCH_DRAW_HOLD_DURATION,
+  TOUCH_MOVE_THRESHOLD,
+} from '../../constants';
 import type { Coord, ResizeHandle } from '../../types';
 
 interface GridCanvasProps {
@@ -22,6 +27,7 @@ interface GridCanvasProps {
  * Uses CSS Grid to render cells and bins.
  */
 export function GridCanvas({ gridRef, cellSize, gap, onStartDraw, onStartDrag, onStartResize }: GridCanvasProps) {
+  const { isTouchDevice } = useResponsive();
   const { drawer, bins, layers, categories } = useLayoutStore(
     useShallow((state) => ({
       drawer: state.layout.drawer,
@@ -52,6 +58,21 @@ export function GridCanvas({ gridRef, cellSize, gap, onStartDraw, onStartDrag, o
   );
 
   const { getGridCoords, halfBinMode, visualCellSize } = useGridCoords(gridRef);
+
+  // Touch hold detection for draw mode - prevents accidental draws when scrolling
+  const touchHoldTimerRef = useRef<number | null>(null);
+  const touchStartRef = useRef<{ x: number; y: number; coord: Coord; pointerId: number } | null>(null);
+  const [pendingDrawCoord, setPendingDrawCoord] = useState<Coord | null>(null);
+
+  // Clear touch hold timer
+  const clearTouchHold = useCallback(() => {
+    if (touchHoldTimerRef.current) {
+      clearTimeout(touchHoldTimerRef.current);
+      touchHoldTimerRef.current = null;
+    }
+    touchStartRef.current = null;
+    setPendingDrawCoord(null);
+  }, []);
 
   // Memoized: Filter bins for current layer
   const activeBins = useMemo(
@@ -85,7 +106,26 @@ export function GridCanvas({ gridRef, cellSize, gap, onStartDraw, onStartDrag, o
       if (coords) {
         e.preventDefault();
         e.stopPropagation();
-        onStartDraw(coords, e.pointerId);
+
+        // On touch, use hold delay for paint mode too
+        if (isTouchDevice) {
+          clearTouchHold();
+          touchStartRef.current = { x: e.clientX, y: e.clientY, coord: coords, pointerId: e.pointerId };
+          setPendingDrawCoord(coords);
+
+          touchHoldTimerRef.current = window.setTimeout(() => {
+            if (touchStartRef.current) {
+              // Haptic feedback when draw activates
+              if (navigator.vibrate) {
+                navigator.vibrate(30);
+              }
+              onStartDraw(touchStartRef.current.coord, touchStartRef.current.pointerId);
+              clearTouchHold();
+            }
+          }, TOUCH_DRAW_HOLD_DURATION);
+        } else {
+          onStartDraw(coords, e.pointerId);
+        }
       }
     }
   };
@@ -100,8 +140,52 @@ export function GridCanvas({ gridRef, cellSize, gap, onStartDraw, onStartDrag, o
 
     const coords = getGridCoords(e.clientX, e.clientY);
     if (coords) {
-      onStartDraw(coords, e.pointerId);
+      // On touch devices, require a brief hold before starting draw
+      // This prevents accidental draws when user intends to scroll
+      if (isTouchDevice) {
+        clearTouchHold();
+        touchStartRef.current = { x: e.clientX, y: e.clientY, coord: coords, pointerId: e.pointerId };
+        setPendingDrawCoord(coords);
+
+        touchHoldTimerRef.current = window.setTimeout(() => {
+          if (touchStartRef.current) {
+            // Haptic feedback when draw activates
+            if (navigator.vibrate) {
+              navigator.vibrate(30);
+            }
+            onStartDraw(touchStartRef.current.coord, touchStartRef.current.pointerId);
+            clearTouchHold();
+          }
+        }, TOUCH_DRAW_HOLD_DURATION);
+      } else {
+        // Desktop: immediate draw
+        onStartDraw(coords, e.pointerId);
+      }
     }
+  };
+
+  // Cancel touch hold if pointer moves too far (user is scrolling)
+  const handlePointerMove = (e: PointerEvent<HTMLDivElement>) => {
+    if (!touchStartRef.current) return;
+
+    const dx = e.clientX - touchStartRef.current.x;
+    const dy = e.clientY - touchStartRef.current.y;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+
+    // If moved past threshold, cancel the pending draw (user is scrolling)
+    if (distance > TOUCH_MOVE_THRESHOLD) {
+      clearTouchHold();
+    }
+  };
+
+  // Cancel touch hold on pointer up if draw hasn't started yet
+  const handlePointerUp = () => {
+    clearTouchHold();
+  };
+
+  // Cancel touch hold on pointer cancel (e.g., two-finger gesture)
+  const handlePointerCancel = () => {
+    clearTouchHold();
   };
 
   const handleBlockedZoneClick = (binId: string, layerId: string) => {
@@ -113,6 +197,7 @@ export function GridCanvas({ gridRef, cellSize, gap, onStartDraw, onStartDrag, o
   const gridCols = halfBinMode ? drawer.width * HALF_BIN_SCALE : drawer.width;
   const gridRows = halfBinMode ? drawer.depth * HALF_BIN_SCALE : drawer.depth;
   const actualCellSize = halfBinMode ? visualCellSize : cellSize;
+  const scale = halfBinMode ? HALF_BIN_SCALE : 1;
 
   // Generate grid cells for visual reference
   const cells: JSX.Element[] = [];
@@ -207,10 +292,13 @@ export function GridCanvas({ gridRef, cellSize, gap, onStartDraw, onStartDrag, o
       className="absolute inset-0"
       onPointerDownCapture={handlePointerDownCapture}
       onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
       style={{
         cursor: paintSize ? 'cell' : 'crosshair',
-        // Allow two-finger pan when no interaction active, block during draw/drag
-        touchAction: interaction ? 'none' : 'pan-x pan-y',
+        // Allow two-finger pan when no interaction active, block during draw/drag or pending draw
+        touchAction: interaction || pendingDrawCoord ? 'none' : 'pan-x pan-y',
       }}
     >
       {/* CSS Grid container */}
@@ -345,6 +433,44 @@ export function GridCanvas({ gridRef, cellSize, gap, onStartDraw, onStartDrag, o
             />
           );
         })}
+
+        {/* Touch hold indicator - shows pulsing ring while waiting to start draw */}
+        {pendingDrawCoord && isTouchDevice && (
+          <div
+            className="pointer-events-none"
+            style={{
+              position: 'absolute',
+              // Position at the center of the cell
+              left: gap + pendingDrawCoord.x * scale * (actualCellSize + gap) + (actualCellSize * scale) / 2,
+              top: gap + (drawer.depth - pendingDrawCoord.y - 1) * scale * (actualCellSize + gap) + (actualCellSize * scale) / 2,
+              transform: 'translate(-50%, -50%)',
+              zIndex: 100,
+            }}
+          >
+            {/* Expanding ring animation */}
+            <div
+              className="absolute rounded-full border-2 border-accent animate-ping"
+              style={{
+                width: 40,
+                height: 40,
+                left: -20,
+                top: -20,
+                opacity: 0.6,
+              }}
+            />
+            {/* Static center dot */}
+            <div
+              className="absolute rounded-full bg-accent"
+              style={{
+                width: 12,
+                height: 12,
+                left: -6,
+                top: -6,
+                opacity: 0.8,
+              }}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -192,3 +192,23 @@ export const SHORTCUTS = {
   // Half-bin mode
   HALF_BIN_TOGGLE: 'h',
 } as const;
+
+// === Touch Interaction Constants ===
+
+/** Duration to hold before long-press context menu appears (ms) */
+export const LONG_PRESS_DURATION = 500;
+
+/** Maximum time between taps for double-tap detection (ms) */
+export const DOUBLE_TAP_THRESHOLD = 300;
+
+/** Duration to hold on empty grid before draw mode activates on touch (ms) */
+export const TOUCH_DRAW_HOLD_DURATION = 150;
+
+/** Distance threshold before interaction starts (px) */
+export const TOUCH_MOVE_THRESHOLD = 10;
+
+/** Minimum ratio of vertical movement for scroll intent detection (0.6 = 60% vertical) */
+export const SCROLL_INTENT_RATIO = 0.6;
+
+/** Distance to travel before locking in scroll vs drag direction (px) */
+export const DIRECTION_LOCK_DISTANCE = 15;


### PR DESCRIPTION
Addresses issues with accidental bin placement when scrolling and difficulty with drag/resize operations on mobile:

- Add directional intent detection to distinguish scroll from drag
  - Tracks initial movement direction
  - If >60% vertical, assumes scroll intent and cancels drag
  - Prevents accidental bin drags when user intends to scroll

- Add touch hold delay (150ms) before starting draw mode
  - Requires brief hold on empty grid before draw activates
  - Cancels if user moves finger (scrolling)
  - Shows pulsing visual indicator during hold

- Add haptic feedback for interaction confirmations
  - 30ms vibration when drag starts
  - 30ms vibration when draw mode activates

- Improve resize handle discoverability on touch devices
  - Handles pulse with glow effect when bin is first selected
  - Helps users discover the resize functionality

New touch constants in constants.ts for tuning:
- TOUCH_DRAW_HOLD_DURATION: 150ms
- TOUCH_MOVE_THRESHOLD: 10px
- SCROLL_INTENT_RATIO: 0.6 (60% vertical = scroll)
- DIRECTION_LOCK_DISTANCE: 15px