### PR TITLE
feat(pwa): auto-reload on service worker update with toast notification

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useState, useCallback, useRef, Suspense } from 'react';
 import { useLayoutStore, useUIStore } from './store';
-import { useKeyboard, useAutoSave, useResponsive } from './hooks';
+import { useKeyboard, useAutoSave, useResponsive, usePWAUpdate } from './hooks';
 import { loadLayout } from './utils/storage';
 import { lazyWithRetry, namedExport } from './utils/lazyWithRetry';
 import { Grid } from './components/Grid';
@@ -99,6 +99,9 @@ export default function App() {
 
   // Auto-save to localStorage
   useAutoSave();
+
+  // PWA update detection and auto-reload
+  usePWAUpdate();
 
   // Help modal keyboard shortcut
   const handleHelpKeyboard = useCallback((e: KeyboardEvent) => {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,3 +6,4 @@ export { useResponsive, prefersTouch } from './useResponsive';
 export type { ResponsiveState, LayoutMode } from './useResponsive';
 export { usePrintList } from './usePrintList';
 export type { UsePrintListReturn } from './usePrintList';
+export { usePWAUpdate } from './usePWAUpdate';

--- a/src/hooks/usePWAUpdate.ts
+++ b/src/hooks/usePWAUpdate.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react';
+import { useRegisterSW } from 'virtual:pwa-register/react';
+import { useToastStore } from '../store/toast';
+
+// Match the default toast duration for consistent UX
+const RELOAD_DELAY_MS = 5000;
+
+/**
+ * Hook that handles PWA service worker updates.
+ * When a new version is available, it shows a toast notification
+ * and automatically reloads the page after the toast duration.
+ */
+export function usePWAUpdate(): void {
+  const addToast = useToastStore(state => state.addToast);
+  const hasTriggeredReload = useRef(false);
+
+  const {
+    needRefresh: [needRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({
+    onRegistered(registration) {
+      // Check for updates periodically (every hour)
+      if (registration) {
+        setInterval(() => {
+          registration.update();
+        }, 60 * 60 * 1000);
+      }
+    },
+    onRegisterError(error) {
+      console.error('SW registration error:', error);
+    },
+  });
+
+  useEffect(() => {
+    if (needRefresh && !hasTriggeredReload.current) {
+      hasTriggeredReload.current = true;
+
+      // Show toast notification
+      addToast('Updating to latest version...', 'info', RELOAD_DELAY_MS);
+
+      // Reload after toast duration
+      setTimeout(() => {
+        updateServiceWorker(true);
+      }, RELOAD_DELAY_MS);
+    }
+  }, [needRefresh, addToast, updateServiceWorker]);
+}

--- a/src/test/mocks/pwa-register.ts
+++ b/src/test/mocks/pwa-register.ts
@@ -1,0 +1,10 @@
+import { vi } from 'vitest';
+
+// Mock for virtual:pwa-register/react module
+export function useRegisterSW() {
+  return {
+    needRefresh: [false, vi.fn()] as [boolean, (v: boolean) => void],
+    offlineReady: [false, vi.fn()] as [boolean, (v: boolean) => void],
+    updateServiceWorker: vi.fn(),
+  };
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,21 @@
+/// <reference types="vite/client" />
+
+// Type declarations for vite-plugin-pwa virtual modules
+declare module 'virtual:pwa-register/react' {
+  import type { Dispatch, SetStateAction } from 'react';
+
+  export interface RegisterSWOptions {
+    immediate?: boolean;
+    onNeedRefresh?: () => void;
+    onOfflineReady?: () => void;
+    onRegistered?: (registration: ServiceWorkerRegistration | undefined) => void;
+    onRegisteredSW?: (swScriptUrl: string, registration: ServiceWorkerRegistration | undefined) => void;
+    onRegisterError?: (error: Error) => void;
+  }
+
+  export function useRegisterSW(options?: RegisterSWOptions): {
+    needRefresh: [boolean, Dispatch<SetStateAction<boolean>>];
+    offlineReady: [boolean, Dispatch<SetStateAction<boolean>>];
+    updateServiceWorker: (reloadPage?: boolean) => Promise<void>;
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
@@ -8,5 +9,11 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
     exclude: ['e2e/**', 'node_modules/**'],
+  },
+  resolve: {
+    alias: {
+      // Mock virtual PWA module for tests
+      'virtual:pwa-register/react': path.resolve(__dirname, 'src/test/mocks/pwa-register.ts'),
+    },
   },
 })


### PR DESCRIPTION
When a new version is deployed, the app now automatically detects the
SW update, shows an "Updating to latest version..." toast for 5 seconds,
then reloads to apply the new version. Also checks for updates hourly.