### PR TITLE
feat: add bin rotation button in stash

### DIFF
--- a/e2e/staging.spec.ts
+++ b/e2e/staging.spec.ts
@@ -281,4 +281,98 @@ test.describe('Staging Area (Stash)', () => {
     await expect(page.locator('[data-bin-id]')).toHaveCount(1);
     await expect(getStashContainer(page)).not.toBeVisible();
   });
+
+  test('can rotate stashed bin with rotate button', async ({ page }) => {
+    // Create a 2x3 bin (non-square)
+    await drawBinOnGrid(page, 50, 50, 114, 146);
+    await page.waitForTimeout(200);
+
+    // Move to stash
+    const gridBin = page.locator('[data-bin-id]').first();
+    await gridBin.click();
+    await page.waitForTimeout(100);
+
+    const inspector = page.locator('aside').last();
+    await inspector.getByRole('button', { name: /to stash/i }).click();
+    await page.waitForTimeout(300);
+
+    // Hover over the stashed bin to reveal rotate button
+    const stagingBin = page.locator('[data-staging-bin-id]').first();
+    await stagingBin.hover();
+    await page.waitForTimeout(100);
+
+    // Get dimensions before rotation
+    const textBefore = await stagingBin.textContent();
+    expect(textBefore).toContain('2×3');
+
+    // Click the rotate button
+    const rotateButton = stagingBin.getByRole('button', { name: /rotate/i });
+    await expect(rotateButton).toBeVisible();
+    await rotateButton.click();
+    await page.waitForTimeout(200);
+
+    // Dimensions should now be swapped
+    const textAfter = await stagingBin.textContent();
+    expect(textAfter).toContain('3×2');
+  });
+
+  test('rotate button is hidden for square bins', async ({ page }) => {
+    // Create a 2x2 square bin
+    await drawBinOnGrid(page, 50, 50, 114, 114);
+    await page.waitForTimeout(200);
+
+    // Move to stash
+    const gridBin = page.locator('[data-bin-id]').first();
+    await gridBin.click();
+    await page.waitForTimeout(100);
+
+    const inspector = page.locator('aside').last();
+    await inspector.getByRole('button', { name: /to stash/i }).click();
+    await page.waitForTimeout(300);
+
+    // Hover over the stashed bin
+    const stagingBin = page.locator('[data-staging-bin-id]').first();
+    await stagingBin.hover();
+    await page.waitForTimeout(100);
+
+    // Rotate button should NOT be visible for square bins
+    const rotateButton = stagingBin.getByRole('button', { name: /rotate/i });
+    await expect(rotateButton).not.toBeVisible();
+  });
+
+  test('undo reverts rotation', async ({ page }) => {
+    // Create a 2x3 bin
+    await drawBinOnGrid(page, 50, 50, 114, 146);
+    await page.waitForTimeout(200);
+
+    // Move to stash
+    const gridBin = page.locator('[data-bin-id]').first();
+    await gridBin.click();
+    await page.waitForTimeout(100);
+
+    const inspector = page.locator('aside').last();
+    await inspector.getByRole('button', { name: /to stash/i }).click();
+    await page.waitForTimeout(300);
+
+    // Hover and click rotate button
+    const stagingBin = page.locator('[data-staging-bin-id]').first();
+    await stagingBin.hover();
+    await page.waitForTimeout(100);
+
+    const rotateButton = stagingBin.getByRole('button', { name: /rotate/i });
+    await rotateButton.click();
+    await page.waitForTimeout(200);
+
+    // Verify rotation happened
+    const textAfter = await stagingBin.textContent();
+    expect(textAfter).toContain('3×2');
+
+    // Undo
+    await page.keyboard.press('Control+z');
+    await page.waitForTimeout(200);
+
+    // Should be back to original dimensions
+    const textUndo = await stagingBin.textContent();
+    expect(textUndo).toContain('2×3');
+  });
 });

--- a/src/components/Staging.tsx
+++ b/src/components/Staging.tsx
@@ -6,6 +6,15 @@ import { STAGING_ID, BASE_CELL_SIZE, DEFAULT_CATEGORY_COLOR } from '../constants
 import { getBinTextColors } from '../utils/color';
 import { ConfirmDialog } from './modals/ConfirmDialog';
 
+/** Rotation icon SVG for bin rotation button */
+function RotateIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+    </svg>
+  );
+}
+
 interface PackedBin {
   id: string;
   x: number; // Position in staging grid
@@ -70,6 +79,7 @@ function packBins(bins: PackedBin[], gridWidth: number): PackedBin[] {
 export function Staging() {
   const layout = useLayoutStore(state => state.layout);
   const deleteBin = useLayoutStore(state => state.deleteBin);
+  const rotateBin = useLayoutStore(state => state.rotateBin);
   const { zoom, interaction, setInteraction, dropTarget, setDropTarget } = useUIStore(
     useShallow((state) => ({
       zoom: state.zoom,
@@ -128,6 +138,14 @@ export function Staging() {
       binId,
       currentCoord: null,
       valid: false,
+    });
+  };
+
+  const handleRotateBin = (binId: string, e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    execute(() => {
+      rotateBin(binId);
     });
   };
 
@@ -307,12 +325,13 @@ export function Staging() {
             const hasLabel = !!bin.label;
             const primaryText = hasLabel ? bin.label : `${bin.width}×${bin.depth}`;
             const secondaryText = hasLabel ? `${bin.width}×${bin.depth}` : null;
+            const isSquare = bin.width === bin.depth;
 
             return (
               <div
                 key={bin.id}
                 data-staging-bin-id={bin.id}
-                className={`relative flex flex-col items-center justify-center transition-all duration-150 cursor-move rounded-sm z-10 touch-none ${
+                className={`group relative flex flex-col items-center justify-center transition-all duration-150 cursor-move rounded-sm z-10 touch-none ${
                   isDragging
                     ? 'bg-transparent border-2 border-dashed border-accent pointer-events-none'
                     : 'border border-[var(--border-on-color)] shadow-sm'
@@ -325,6 +344,19 @@ export function Staging() {
                 onPointerDown={(e) => handleBinPointerDown(bin.id, e)}
                 title={`${bin.label || 'Unlabeled'} — ${bin.width}×${bin.depth}×${bin.height}u\nDrag to place on grid`}
               >
+                {/* Rotate button - only show for non-square bins */}
+                {/* Always visible on touch devices (no hover), hidden until hover on desktop */}
+                {!isDragging && !isSquare && (
+                  <button
+                    className="absolute -top-1.5 -right-1.5 w-6 h-6 flex items-center justify-center rounded-full bg-surface-elevated border border-stroke shadow-sm transition-all opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:focus:opacity-100 hover:scale-110 hover:shadow-md focus:scale-110 focus:shadow-md"
+                    onClick={(e) => handleRotateBin(bin.id, e)}
+                    onPointerDown={(e) => e.stopPropagation()}
+                    title="Rotate 90°"
+                    aria-label="Rotate bin 90 degrees"
+                  >
+                    <RotateIcon className="w-3.5 h-3.5 text-content-secondary" />
+                  </button>
+                )}
                 {/* Adaptive label: primary (label or dimensions) + optional secondary */}
                 {!isDragging && (
                   <div className="text-center pointer-events-none select-none overflow-hidden max-w-[95%]">

--- a/src/store/layout.ts
+++ b/src/store/layout.ts
@@ -14,6 +14,7 @@ interface LayoutState {
   updateBin: (id: string, updates: Partial<Bin>) => void;
   deleteBin: (id: string) => void;
   duplicateBin: (id: string) => string | null;
+  rotateBin: (id: string) => boolean;
   moveBinToStaging: (id: string) => void;
   moveBinFromStaging: (id: string, layerId: string, x: number, y: number) => boolean;
 
@@ -154,6 +155,49 @@ export const useLayoutStore = create<LayoutState>()(
         label: bin.label,
         notes: bin.notes,
       });
+    },
+
+    rotateBin: (id) => {
+      const { layout } = get();
+      const bin = layout.bins.find(b => b.id === id);
+      if (!bin) return false;
+
+      // For staging bins, always allow rotation
+      if (bin.layerId === STAGING_ID) {
+        set(state => {
+          const b = state.layout.bins.find(b => b.id === id);
+          if (b) {
+            const temp = b.width;
+            b.width = b.depth;
+            b.depth = temp;
+          }
+        });
+        return true;
+      }
+
+      // For grid bins, check if rotated dimensions fit
+      const rotatedWidth = bin.depth;
+      const rotatedDepth = bin.width;
+
+      const result = canPlaceBin(
+        { x: bin.x, y: bin.y, width: rotatedWidth, depth: rotatedDepth, height: bin.height },
+        bin.layerId,
+        layout,
+        id // Exclude self from collision check
+      );
+
+      if (!result.valid) return false;
+
+      set(state => {
+        const b = state.layout.bins.find(b => b.id === id);
+        if (b) {
+          const temp = b.width;
+          b.width = b.depth;
+          b.depth = temp;
+        }
+      });
+
+      return true;
     },
 
     moveBinToStaging: (id) => {

--- a/src/test/store/layout.test.ts
+++ b/src/test/store/layout.test.ts
@@ -255,6 +255,195 @@ describe('layout store', () => {
     });
   });
 
+  describe('rotateBin', () => {
+    it('rotates a staging bin by swapping width and depth', () => {
+      const { addBin, rotateBin, layout } = useLayoutStore.getState();
+      const categoryId = layout.categories[0].id;
+
+      const binId = addBin({
+        layerId: STAGING_ID,
+        x: 0,
+        y: 0,
+        width: 3,
+        depth: 2,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      const result = rotateBin(binId!);
+      expect(result).toBe(true);
+
+      const bin = useLayoutStore.getState().layout.bins[0];
+      expect(bin.width).toBe(2);
+      expect(bin.depth).toBe(3);
+    });
+
+    it('rotates a staging bin twice to return to original dimensions', () => {
+      const { addBin, rotateBin, layout } = useLayoutStore.getState();
+      const categoryId = layout.categories[0].id;
+
+      const binId = addBin({
+        layerId: STAGING_ID,
+        x: 0,
+        y: 0,
+        width: 4,
+        depth: 1,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      rotateBin(binId!);
+      rotateBin(binId!);
+
+      const bin = useLayoutStore.getState().layout.bins[0];
+      expect(bin.width).toBe(4);
+      expect(bin.depth).toBe(1);
+    });
+
+    it('rotates a grid bin when there is space', () => {
+      const { addBin, rotateBin, layout } = useLayoutStore.getState();
+      const layerId = layout.layers[0].id;
+      const categoryId = layout.categories[0].id;
+
+      // Add a 3x2 bin at origin (plenty of space to rotate to 2x3)
+      const binId = addBin({
+        layerId,
+        x: 0,
+        y: 0,
+        width: 3,
+        depth: 2,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      const result = rotateBin(binId!);
+      expect(result).toBe(true);
+
+      const bin = useLayoutStore.getState().layout.bins[0];
+      expect(bin.width).toBe(2);
+      expect(bin.depth).toBe(3);
+    });
+
+    it('returns false when rotating grid bin would exceed bounds', () => {
+      const { addBin, rotateBin, layout } = useLayoutStore.getState();
+      const layerId = layout.layers[0].id;
+      const categoryId = layout.categories[0].id;
+
+      // Add a 2x3 bin at y=5 on an 8-deep drawer (this one can rotate fine)
+      addBin({
+        layerId,
+        x: 0,
+        y: 5,
+        width: 2,
+        depth: 3,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      // Add a bin that would go out of bounds when rotated
+      const binId2 = addBin({
+        layerId,
+        x: 2,
+        y: 7,
+        width: 2,
+        depth: 1,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      // Rotating 2x1 at y=7 to 1x2 would need y+2=9, which exceeds depth 8
+      const result = rotateBin(binId2!);
+      expect(result).toBe(false);
+
+      // Original dimensions should be preserved
+      const bin = useLayoutStore.getState().layout.bins.find(b => b.id === binId2);
+      expect(bin!.width).toBe(2);
+      expect(bin!.depth).toBe(1);
+    });
+
+    it('returns false when rotating grid bin would cause collision', () => {
+      const { addBin, rotateBin, layout } = useLayoutStore.getState();
+      const layerId = layout.layers[0].id;
+      const categoryId = layout.categories[0].id;
+
+      // Add a 3x1 bin at origin
+      const binId1 = addBin({
+        layerId,
+        x: 0,
+        y: 0,
+        width: 3,
+        depth: 1,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      // Add another bin at (0, 2) that would block rotation
+      addBin({
+        layerId,
+        x: 0,
+        y: 2,
+        width: 1,
+        depth: 1,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      // Rotating first bin from 3x1 to 1x3 would collide with bin at (0, 2)
+      const result = rotateBin(binId1!);
+      expect(result).toBe(false);
+
+      // Original dimensions should be preserved
+      const bin = useLayoutStore.getState().layout.bins.find(b => b.id === binId1);
+      expect(bin!.width).toBe(3);
+      expect(bin!.depth).toBe(1);
+    });
+
+    it('returns false for non-existent bin', () => {
+      const { rotateBin } = useLayoutStore.getState();
+
+      const result = rotateBin('nonexistent-id');
+      expect(result).toBe(false);
+    });
+
+    it('preserves bin position when rotating', () => {
+      const { addBin, rotateBin, layout } = useLayoutStore.getState();
+      const layerId = layout.layers[0].id;
+      const categoryId = layout.categories[0].id;
+
+      const binId = addBin({
+        layerId,
+        x: 2,
+        y: 3,
+        width: 2,
+        depth: 1,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      rotateBin(binId!);
+
+      const bin = useLayoutStore.getState().layout.bins[0];
+      expect(bin.x).toBe(2);
+      expect(bin.y).toBe(3);
+    });
+  });
+
   describe('fillLayer', () => {
     it('fills empty layer with bins of specified size', () => {
       const { fillLayer, layout } = useLayoutStore.getState();


### PR DESCRIPTION
- Add rotateBin() store action that swaps width/depth dimensions
- For staging bins: always allow rotation
- For grid bins: validate bounds and collisions before rotating
- Add rotate button on non-square stashed bins
- Button visible on mobile, hover-reveal on desktop
- Polished styling: rounded pill, positioned at corner, scale on hover
- Include comprehensive unit and e2e tests