### PR TITLE
fix: exit paint mode when clicking off grid or selecting a bin

### DIFF
--- a/src/components/Grid/Bin.tsx
+++ b/src/components/Grid/Bin.tsx
@@ -63,6 +63,8 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
   const setFocusedBin = useUIStore((state) => state.setFocusedBin);
   const setActiveMobilePanel = useUIStore((state) => state.setActiveMobilePanel);
   const showQuickLabel = useUIStore((state) => state.showQuickLabel);
+  const paintSize = useUIStore((state) => state.paintSize);
+  const setPaintSize = useUIStore((state) => state.setPaintSize);
 
   // Consolidate layout state selectors with shallow comparison
   const { printBedSize, gridUnitMm } = useLayoutStore(
@@ -221,6 +223,11 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
     if (e.button === 0) {
       const isMultiSelectKey = e.ctrlKey || e.metaKey;
       const isRangeSelectKey = e.shiftKey;
+
+      // Exit paint mode when selecting a bin
+      if (paintSize) {
+        setPaintSize(null);
+      }
 
       if (isMultiSelectKey) {
         // Ctrl/Cmd+click: toggle this bin in selection

--- a/src/components/Grid/GridCanvas.tsx
+++ b/src/components/Grid/GridCanvas.tsx
@@ -79,8 +79,14 @@ export function GridCanvas({ gridRef, cellSize, gap, onStartDraw, onStartDrag, o
     // Ignore non-primary pointer (second finger) - allow two-finger pan
     if (!e.isPrimary) return;
 
-    // In paint mode, intercept all clicks to start paint interaction
+    // In paint mode, intercept clicks on empty space to start paint interaction
+    // But allow clicks on bins to fall through (to select the bin and exit paint mode)
     if (paintSize) {
+      const target = e.target as HTMLElement;
+      if (target.closest('[data-bin-id]')) {
+        // Click is on a bin - don't intercept, let it select the bin
+        return;
+      }
       const coords = getGridCoords(e.clientX, e.clientY);
       if (coords) {
         e.preventDefault();

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -769,6 +769,10 @@ export function Grid() {
           // Don't deselect if clicking on buttons, inputs, or bin elements
           if (!target.closest('button') && !target.closest('input') && !target.closest('[data-bin-id]')) {
             clearSelection();
+            // Exit paint mode when clicking off the grid
+            if (paintSize) {
+              setPaintSize(null);
+            }
           }
         }}
       >

--- a/src/test/components/GridCanvas.test.tsx
+++ b/src/test/components/GridCanvas.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { createRef } from 'react';
 import { GridCanvas } from '../../components/Grid/GridCanvas';
 import { useLayoutStore } from '../../store/layout';
@@ -344,6 +344,130 @@ describe('GridCanvas', () => {
 
       const wrapper = container.firstChild as HTMLElement;
       expect(wrapper.style.touchAction).toBe('none');
+    });
+  });
+
+  describe('Paint mode bin click behavior', () => {
+    it('allows bin clicks to pass through in paint mode (does not intercept)', () => {
+      // Set up paint mode
+      useUIStore.setState({
+        paintSize: { width: 2, depth: 2 },
+      });
+
+      // Add a bin to the layout
+      const testBin: Bin = {
+        id: 'test-bin-paint',
+        x: 2,
+        y: 2,
+        width: 2,
+        depth: 2,
+        height: 3,
+        layerId: defaultLayout.layers[0].id,
+        category: defaultLayout.categories[0].id,
+        label: 'Test Bin',
+        notes: '',
+      };
+
+      useLayoutStore.setState({
+        layout: {
+          ...defaultLayout,
+          bins: [testBin],
+        },
+      });
+
+      const { container } = renderGridCanvas();
+
+      // Verify paint mode is active
+      expect(useUIStore.getState().paintSize).toEqual({ width: 2, depth: 2 });
+
+      // Verify bin is rendered and can receive clicks
+      const binElement = container.querySelector('[data-bin-id="test-bin-paint"]');
+      expect(binElement).not.toBeNull();
+
+      // The capture phase handler should check for bin elements and allow clicks through
+      // This test verifies the bin element exists and is clickable (has pointer-events: auto)
+      expect(binElement).toHaveProperty('style');
+    });
+
+    it('clears paint mode when clicking on a bin', () => {
+      // Set up paint mode
+      useUIStore.setState({
+        paintSize: { width: 2, depth: 2 },
+      });
+
+      // Add a bin to the layout
+      const testBin: Bin = {
+        id: 'test-bin-click',
+        x: 2,
+        y: 2,
+        width: 2,
+        depth: 2,
+        height: 3,
+        layerId: defaultLayout.layers[0].id,
+        category: defaultLayout.categories[0].id,
+        label: 'Test Bin',
+        notes: '',
+      };
+
+      useLayoutStore.setState({
+        layout: {
+          ...defaultLayout,
+          bins: [testBin],
+        },
+      });
+
+      const { container } = renderGridCanvas();
+
+      // Verify paint mode is active
+      expect(useUIStore.getState().paintSize).toEqual({ width: 2, depth: 2 });
+
+      // Click on the bin
+      const binElement = container.querySelector('[data-bin-id="test-bin-click"]');
+      expect(binElement).not.toBeNull();
+
+      // Fire pointer down event to simulate clicking the bin
+      fireEvent.pointerDown(binElement!, { button: 0, isPrimary: true });
+
+      // Paint mode should be cleared
+      expect(useUIStore.getState().paintSize).toBeNull();
+    });
+
+    it('selects the bin when clicking in paint mode', () => {
+      // Set up paint mode
+      useUIStore.setState({
+        paintSize: { width: 2, depth: 2 },
+        selectedBinIds: [],
+      });
+
+      // Add a bin to the layout
+      const testBin: Bin = {
+        id: 'test-bin-select',
+        x: 2,
+        y: 2,
+        width: 2,
+        depth: 2,
+        height: 3,
+        layerId: defaultLayout.layers[0].id,
+        category: defaultLayout.categories[0].id,
+        label: 'Test Bin',
+        notes: '',
+      };
+
+      useLayoutStore.setState({
+        layout: {
+          ...defaultLayout,
+          bins: [testBin],
+        },
+      });
+
+      const { container } = renderGridCanvas();
+
+      // Click on the bin
+      const binElement = container.querySelector('[data-bin-id="test-bin-select"]');
+      fireEvent.pointerDown(binElement!, { button: 0, isPrimary: true });
+
+      // Bin should be selected
+      expect(useUIStore.getState().selectedBinIds).toContain('test-bin-select');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Paint mode now exits when clicking on empty space outside the grid
- Paint mode now exits when clicking on an existing bin (and the bin gets selected)
- Previously, paint mode remained active which was confusing for users

## Test plan
- [x] Unit tests added for paint mode bin click behavior
- [ ] Enter paint mode, click on an existing bin - paint mode should exit and bin should be selected
- [ ] Enter paint mode, click on empty space outside the grid - paint mode should exit
- [ ] Enter paint mode, click on empty grid cells - paint interaction should still work