### PR TITLE
chore: add Vercel and local env files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ playwright/.cache/
 coverage/
 
 .env
+.vercel
+.env*.local


### PR DESCRIPTION
## Summary
- Add `.vercel` directory to prevent committing Vercel deployment config
- Add `.env*.local` pattern to prevent committing local environment files

## Test plan
- [x] Build passes
- [x] All tests pass