### PR TITLE
fix: add role="img" to category color indicators for ARIA compliance

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -26,9 +26,6 @@ function filterKnownIssues(violations: Awaited<ReturnType<AxeBuilder['analyze']>
     // Color contrast: Dark theme with carefully chosen colors. axe sometimes flags
     // colors that meet requirements in practice. Would need manual review.
     'color-contrast',
-    // ARIA prohibited attr: Category color indicator spans use aria-label without role.
-    // TODO: Fix by adding role="img" to color indicator spans in RightPanel/CategoriesPanel.
-    'aria-prohibited-attr',
   ];
 
   return violations.filter(v => {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -213,6 +213,7 @@ export function RightPanel() {
                                     return (
                                       <span
                                         key={catId}
+                                        role="img"
                                         className="w-2.5 h-2.5 rounded-full flex-shrink-0"
                                         style={{ backgroundColor: cat?.color || DEFAULT_CATEGORY_COLOR }}
                                         aria-label={cat?.name || 'Unknown category'}


### PR DESCRIPTION
The category color indicator spans in RightPanel had aria-label without
a proper role, which violates ARIA specifications. Adding role="img"
makes these color swatches semantically correct as decorative images.

Removes the workaround from accessibility tests now that the issue is fixed.