### PR TITLE
feat: add real-world dimensions display to bin inspector and grid settings

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -198,6 +198,10 @@ export function Sidebar() {
                     </button>
                   </div>
                 </div>
+                {/* Real-world drawer dimensions */}
+                <div className="pt-1 text-content-disabled text-right">
+                  = {drawerWidth * gridUnitMm} × {drawerDepth * gridUnitMm} × {drawerHeight * heightUnitMm} mm
+                </div>
                 <div className="flex items-center justify-between">
                   <label
                     htmlFor="printBedSize"

--- a/src/components/inspector/SingleBinInspector.tsx
+++ b/src/components/inspector/SingleBinInspector.tsx
@@ -110,6 +110,14 @@ export function SingleBinInspector({
           </div>
         </div>
 
+        {/* Real-world dimensions */}
+        <div className="px-3 py-2 bg-surface-secondary rounded-md">
+          <div className="text-xs text-content-tertiary mb-1">Real dimensions</div>
+          <div className="text-sm text-content-secondary">
+            {(bin.width * layout.gridUnitMm).toFixed(0)} × {(bin.depth * layout.gridUnitMm).toFixed(0)} × {(bin.height * layout.heightUnitMm).toFixed(0)} mm
+          </div>
+        </div>
+
         {/* Height control with +/- buttons */}
         <div>
           <label className={`block ${labelSize} text-content-tertiary`}>

--- a/src/components/mobile/MobileSettingsPanel.tsx
+++ b/src/components/mobile/MobileSettingsPanel.tsx
@@ -141,6 +141,14 @@ export function MobileSettingsPanel() {
             </button>
           </div>
         </div>
+
+        {/* Real-world drawer dimensions */}
+        <div className="mt-2 px-3 py-2 bg-surface-elevated rounded-lg">
+          <div className="text-xs text-content-tertiary">Real dimensions</div>
+          <div className="text-sm text-content-secondary">
+            {layout.drawer.width * layout.gridUnitMm} × {layout.drawer.depth * layout.gridUnitMm} × {layout.drawer.height * layout.heightUnitMm} mm
+          </div>
+        </div>
       </section>
 
       {/* Grid Settings */}


### PR DESCRIPTION
Show physical mm dimensions to help users understand actual sizes:
- Bin inspector: displays width × depth × height in mm below size inputs
- Desktop sidebar: shows drawer dimensions in mm after grid settings
- Mobile settings: adds real dimensions box after drawer dimension controls