### PR TITLE
feat: collapsible panels, compact inspector, and bin rotate command

### DIFF
--- a/e2e/rotate-bins.spec.ts
+++ b/e2e/rotate-bins.spec.ts
@@ -1,0 +1,130 @@
+import {
+  test,
+  expect,
+  waitForAppReady,
+  drawBinOnGrid,
+  getInspector,
+  waitForPaintModeExited,
+  waitForBinSelected,
+  waitForToast,
+  waitForUndoEnabled,
+} from './fixtures';
+
+test.describe('Rotate Bins', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+    await waitForAppReady(page);
+  });
+
+  test('can rotate a bin using R key', async ({ page }) => {
+    // Draw a 2x4 rectangular bin (non-square so rotation is visible)
+    const bin = await drawBinOnGrid(page, 50, 50, 130, 210);
+    await waitForBinSelected(bin);
+
+    // Get the inspector to verify dimensions before rotation
+    const inspector = getInspector(page);
+
+    // Verify initial dimensions - header shows "WxD Bin"
+    await expect(inspector.getByText(/2×4 Bin/i)).toBeVisible();
+
+    // Press R to rotate
+    await page.keyboard.press('r');
+
+    // Verify dimensions swapped - should now be 4x2
+    await expect(inspector.getByText(/4×2 Bin/i)).toBeVisible();
+  });
+
+  test('can rotate using the rotate button in inspector', async ({ page }) => {
+    // Draw a rectangular bin
+    const bin = await drawBinOnGrid(page, 50, 50, 130, 210);
+    await waitForBinSelected(bin);
+
+    const inspector = getInspector(page);
+    await expect(inspector.getByText(/2×4 Bin/i)).toBeVisible();
+
+    // Click the rotate button
+    const rotateButton = inspector.getByRole('button', { name: /rotate/i });
+    await rotateButton.click();
+
+    // Verify dimensions swapped
+    await expect(inspector.getByText(/4×2 Bin/i)).toBeVisible();
+  });
+
+  test('rotation can be undone', async ({ page }) => {
+    // Draw a bin and select it
+    const bin = await drawBinOnGrid(page, 50, 50, 130, 210);
+    await waitForBinSelected(bin);
+
+    const inspector = getInspector(page);
+    await expect(inspector.getByText(/2×4 Bin/i)).toBeVisible();
+
+    // Rotate
+    await page.keyboard.press('r');
+    await expect(inspector.getByText(/4×2 Bin/i)).toBeVisible();
+
+    // Wait for undo to be available
+    await waitForUndoEnabled(page);
+
+    // Undo
+    await page.keyboard.press('Control+z');
+
+    // Should be back to original dimensions
+    await expect(inspector.getByText(/2×4 Bin/i)).toBeVisible();
+  });
+
+  test('shows error toast when rotation would exceed bounds', async ({ page }) => {
+    // Draw a tall narrow bin near the right edge
+    // At position (8,0), a 2x5 bin when rotated would be 5x2, exceeding drawer width of 10
+    const bin = await drawBinOnGrid(page, 300, 50, 360, 200);
+    await waitForBinSelected(bin);
+
+    // Try to rotate
+    await page.keyboard.press('r');
+
+    // Should show error toast about bounds
+    await waitForToast(page, /cannot rotate.*bounds/i);
+  });
+
+  test('shows error toast when rotation would cause collision', async ({ page }) => {
+    // Draw first bin: 2x4 at origin
+    const bin1 = await drawBinOnGrid(page, 50, 50, 130, 210);
+
+    // Exit any selection
+    await page.keyboard.press('Escape');
+    await waitForPaintModeExited(page);
+
+    // Draw second bin: adjacent at (3,0) - 2x2 bin
+    await drawBinOnGrid(page, 150, 50, 210, 110);
+
+    // Exit selection
+    await page.keyboard.press('Escape');
+    await waitForPaintModeExited(page);
+
+    // Select first bin by clicking on it
+    await bin1.click();
+    await waitForBinSelected(bin1);
+
+    // Try to rotate first bin - this would make it 4x2 and collide with bin2
+    await page.keyboard.press('r');
+
+    // Should show error toast about collision
+    await waitForToast(page, /cannot rotate.*collide/i);
+  });
+
+  test('square bin rotation is a no-op', async ({ page }) => {
+    // Draw a 2x2 square bin
+    const bin = await drawBinOnGrid(page, 50, 50, 130, 130);
+    await waitForBinSelected(bin);
+
+    const inspector = getInspector(page);
+    await expect(inspector.getByText(/2×2 Bin/i)).toBeVisible();
+
+    // Rotate
+    await page.keyboard.press('r');
+
+    // Should still be 2x2 (no visible change, but no error either)
+    await expect(inspector.getByText(/2×2 Bin/i)).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
       "name": "Main bundle (gzip)",
       "path": "dist/assets/index-*.js",
       "gzip": true,
-      "limit": "68 kB"
+      "limit": "70 kB"
     },
     {
       "name": "Total JS (gzip)",

--- a/src/components/CollapsibleSection.tsx
+++ b/src/components/CollapsibleSection.tsx
@@ -1,0 +1,67 @@
+import { useState, type ReactNode } from 'react';
+
+interface CollapsibleSectionProps {
+  /** Section title */
+  title: string;
+  /** Whether section starts expanded (default: true) */
+  defaultExpanded?: boolean;
+  /** Content to render inside the section */
+  children: ReactNode;
+  /** Optional badge to show next to title */
+  badge?: ReactNode;
+  /** Optional actions to show on the right side of header */
+  actions?: ReactNode;
+  /** Size variant for the header */
+  variant?: 'default' | 'small';
+}
+
+/**
+ * Collapsible section with animated expand/collapse.
+ * Used for sidebar panels to save vertical space.
+ */
+export function CollapsibleSection({
+  title,
+  defaultExpanded = true,
+  children,
+  badge,
+  actions,
+  variant = 'default',
+}: CollapsibleSectionProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  const headerClass = variant === 'small'
+    ? 'text-xs font-semibold text-content-tertiary uppercase tracking-wider'
+    : 'text-sm font-semibold text-content-secondary tracking-wide';
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          className="flex items-center gap-2 bg-transparent hover:opacity-80 transition-opacity"
+          onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
+        >
+          <svg
+            className={`w-3.5 h-3.5 transition-transform duration-200 text-content-tertiary ${expanded ? 'rotate-0' : '-rotate-90'}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+          <span className={headerClass}>{title}</span>
+          {badge}
+        </button>
+        {actions}
+      </div>
+      <div
+        className={`transition-all duration-200 overflow-hidden ${
+          expanded ? 'opacity-100 mt-3' : 'opacity-0 max-h-0'
+        }`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/DeferredNumberInput.tsx
+++ b/src/components/DeferredNumberInput.tsx
@@ -8,6 +8,7 @@ interface DeferredNumberInputProps {
   step?: number;
   className?: string;
   id?: string;
+  'aria-label'?: string;
 }
 
 /**
@@ -22,23 +23,29 @@ export function DeferredNumberInput({
   step,
   className,
   id,
+  'aria-label': ariaLabel,
 }: DeferredNumberInputProps) {
   const [localValue, setLocalValue] = useState(String(value));
 
+  // Format a number for display (show decimal only if fractional)
+  const formatValue = (val: number) => val % 1 === 0 ? String(val) : val.toFixed(1);
+
   // Sync local state when external value changes (e.g., from undo/redo)
+  // This is intentional: we need to reset local input state when the controlled value changes
   useEffect(() => {
-    setLocalValue(String(value));
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Legitimate sync with controlled prop
+    setLocalValue(formatValue(value));
   }, [value]);
 
   const commit = useCallback(() => {
-    const parsed = parseInt(localValue, 10);
+    const parsed = parseFloat(localValue);
     if (!isNaN(parsed)) {
       const clamped = Math.max(min, Math.min(max, parsed));
       onChange(clamped);
-      setLocalValue(String(clamped));
+      setLocalValue(formatValue(clamped));
     } else {
       // Invalid input - reset to current value
-      setLocalValue(String(value));
+      setLocalValue(formatValue(value));
     }
   }, [localValue, min, max, onChange, value]);
 
@@ -47,7 +54,7 @@ export function DeferredNumberInput({
       commit();
       e.currentTarget.blur();
     } else if (e.key === 'Escape') {
-      setLocalValue(String(value));
+      setLocalValue(formatValue(value));
       e.currentTarget.blur();
     }
   };
@@ -58,12 +65,14 @@ export function DeferredNumberInput({
       type="number"
       value={localValue}
       onChange={(e) => setLocalValue(e.target.value)}
+      onFocus={(e) => e.target.select()}
       onBlur={commit}
       onKeyDown={handleKeyDown}
       min={min}
       max={max}
       step={step}
       className={className}
+      aria-label={ariaLabel}
     />
   );
 }

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -7,6 +7,7 @@ import { trackLayoutSnapshot } from '../utils/analytics';
 import { ConfirmDialog } from './modals/ConfirmDialog';
 import { usePrintList } from '../hooks/usePrintList';
 import { SplitPreview, PrintListSummary, PrintListEmpty } from './PrintList';
+import { CollapsibleSection } from './CollapsibleSection';
 import {
   useBinInspector,
   SingleBinInspector,
@@ -89,23 +90,28 @@ export function RightPanel() {
         </h2>
       </div>
 
-      {/* Selection Panel */}
-      <div className="p-4 border-b border-stroke-subtle">
-        {isMultiSelect ? (
-          <MultiBinInspector
-            inspector={inspector}
-            variant="desktop"
-            onClose={clearSelection}
-          />
-        ) : bin ? (
-          <SingleBinInspector
-            inspector={inspector}
-            variant="desktop"
-            onClose={clearSelection}
-          />
-        ) : (
-          <EmptyState variant="desktop" />
-        )}
+      {/* Selection Panel - Collapsible */}
+      <div className="px-4 py-3 border-b border-stroke-subtle">
+        <CollapsibleSection
+          title={isMultiSelect ? "Multi-Selection" : bin ? "Bin Properties" : "Selection"}
+          variant="default"
+        >
+          {isMultiSelect ? (
+            <MultiBinInspector
+              inspector={inspector}
+              variant="desktop"
+              onClose={clearSelection}
+            />
+          ) : bin ? (
+            <SingleBinInspector
+              inspector={inspector}
+              variant="desktop"
+              onClose={clearSelection}
+            />
+          ) : (
+            <EmptyState variant="desktop" />
+          )}
+        </CollapsibleSection>
       </div>
 
       {/* Print List - Collapsible */}

--- a/src/components/Sidebar/ActiveLayerPanel.tsx
+++ b/src/components/Sidebar/ActiveLayerPanel.tsx
@@ -4,6 +4,7 @@ import { useLayoutStore, useUIStore, useUndoableAction } from '../../store';
 import { useToastStore } from '../../store/toast';
 import { STAGING_ID } from '../../constants';
 import { ConfirmDialog } from '../modals/ConfirmDialog';
+import { CollapsibleSection } from '../CollapsibleSection';
 
 // Square sizes
 const SQUARE_SIZES = [1, 2, 3, 4, 5, 6];
@@ -141,81 +142,79 @@ export function ActiveLayerPanel() {
 
   return (
     <div>
-      {/* Bin Palette header */}
-      <div className="mb-3">
-        <h2 className="text-sm font-semibold text-content-secondary tracking-wide mb-1">Bin Palette</h2>
-        <p className="text-xs text-content-tertiary">
+      <CollapsibleSection title="Bin Palette" variant="default">
+        <p className="text-xs text-content-tertiary mb-3">
           Select a size, then click or drag on grid
         </p>
-      </div>
 
-      {/* Squares section */}
-      <div className="text-xs text-content-tertiary mb-1.5">Squares</div>
-      <div className="grid grid-cols-6 gap-1.5">
-        {SQUARE_SIZES.map(size => (
-          <SizeButton key={`${size}×${size}`} w={size} d={size} className="w-full" />
-        ))}
-      </div>
+        {/* Squares section */}
+        <div className="text-xs text-content-tertiary mb-1.5">Squares</div>
+        <div className="grid grid-cols-6 gap-1.5">
+          {SQUARE_SIZES.map(size => (
+            <SizeButton key={`${size}×${size}`} w={size} d={size} className="w-full" />
+          ))}
+        </div>
 
-      {/* Rectangles section */}
-      <div className="flex items-center justify-between mt-3 mb-1.5">
-        <span className="text-xs text-content-tertiary">Rectangles</span>
+        {/* Rectangles section */}
+        <div className="flex items-center justify-between mt-3 mb-1.5">
+          <span className="text-xs text-content-tertiary">Rectangles</span>
+          <button
+            onClick={() => setRotated(!rotated)}
+            className="text-xs text-content-tertiary hover:text-content flex items-center gap-1 transition-colors"
+            title={rotated ? 'Showing tall bins (click for wide)' : 'Showing wide bins (click for tall)'}
+            aria-label={rotated ? 'Switch to wide rectangles' : 'Switch to tall rectangles'}
+          >
+            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            {rotated ? 'Tall' : 'Wide'}
+          </button>
+        </div>
+        <div className="grid grid-cols-5 gap-1.5">
+          {RECTANGLE_SIZES.map(({ w, d }) => {
+            const dims = getRectDims(w, d);
+            return <SizeButton key={`${w}×${d}`} w={dims.w} d={dims.d} className="w-full" />;
+          })}
+        </div>
+
+        {/* Fill button when size selected */}
+        {paintSize && (
+          <button
+            onClick={() => handleFill(paintSize.width, paintSize.depth)}
+            className="btn btn-primary w-full justify-center mt-3 text-sm"
+            title={`Fill empty space with ${paintSize.width}×${paintSize.depth} bins`}
+            aria-label={`Fill layer with ${paintSize.width} by ${paintSize.depth} bins`}
+          >
+            Fill with {paintSize.width}×{paintSize.depth}
+          </button>
+        )}
+
+        {/* Fill gaps button */}
         <button
-          onClick={() => setRotated(!rotated)}
-          className="text-xs text-content-tertiary hover:text-content flex items-center gap-1 transition-colors"
-          title={rotated ? 'Showing tall bins (click for wide)' : 'Showing wide bins (click for tall)'}
-          aria-label={rotated ? 'Switch to wide rectangles' : 'Switch to tall rectangles'}
+          onClick={handleFillGaps}
+          disabled={emptyCells === 0}
+          className="btn btn-secondary w-full justify-center mt-2 text-sm"
+          title={emptyCells > 0 ? `Fill ${emptyCells} empty cells with optimally-sized bins` : 'No gaps to fill'}
         >
-          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          <svg className="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
           </svg>
-          {rotated ? 'Tall' : 'Wide'}
+          {emptyCells > 0 ? `Fill ${emptyCells} gaps` : 'No gaps'}
         </button>
-      </div>
-      <div className="grid grid-cols-5 gap-1.5">
-        {RECTANGLE_SIZES.map(({ w, d }) => {
-          const dims = getRectDims(w, d);
-          return <SizeButton key={`${w}×${d}`} w={dims.w} d={dims.d} className="w-full" />;
-        })}
-      </div>
 
-      {/* Fill button when size selected */}
-      {paintSize && (
+        {/* Clear layer button */}
         <button
-          onClick={() => handleFill(paintSize.width, paintSize.depth)}
-          className="btn btn-primary w-full justify-center mt-3 text-sm"
-          title={`Fill empty space with ${paintSize.width}×${paintSize.depth} bins`}
-          aria-label={`Fill layer with ${paintSize.width} by ${paintSize.depth} bins`}
+          onClick={() => setShowClearConfirm(true)}
+          disabled={layerBins.length === 0}
+          className="btn btn-ghost w-full justify-center mt-2 text-sm text-error hover:bg-error/10"
+          title={layerBins.length > 0 ? `Remove all ${layerBins.length} bins from this layer` : 'No bins to clear'}
         >
-          Fill with {paintSize.width}×{paintSize.depth}
+          <svg className="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+          </svg>
+          {layerBins.length > 0 ? `Clear ${layerBins.length} bins` : 'No bins'}
         </button>
-      )}
-
-      {/* Fill gaps button */}
-      <button
-        onClick={handleFillGaps}
-        disabled={emptyCells === 0}
-        className="btn btn-secondary w-full justify-center mt-2 text-sm"
-        title={emptyCells > 0 ? `Fill ${emptyCells} empty cells with optimally-sized bins` : 'No gaps to fill'}
-      >
-        <svg className="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
-        </svg>
-        {emptyCells > 0 ? `Fill ${emptyCells} gaps` : 'No gaps'}
-      </button>
-
-      {/* Clear layer button */}
-      <button
-        onClick={() => setShowClearConfirm(true)}
-        disabled={layerBins.length === 0}
-        className="btn btn-ghost w-full justify-center mt-2 text-sm text-error hover:bg-error/10"
-        title={layerBins.length > 0 ? `Remove all ${layerBins.length} bins from this layer` : 'No bins to clear'}
-      >
-        <svg className="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-        </svg>
-        {layerBins.length > 0 ? `Clear ${layerBins.length} bins` : 'No bins'}
-      </button>
+      </CollapsibleSection>
 
       {/* Clear confirmation dialog */}
       <ConfirmDialog

--- a/src/components/Sidebar/CategoriesPanel.tsx
+++ b/src/components/Sidebar/CategoriesPanel.tsx
@@ -4,6 +4,7 @@ import { useLayoutStore, useUIStore, useUndoableAction } from '../../store';
 import { CONSTRAINTS, DEFAULT_CATEGORY_COLOR } from '../../constants';
 import { ConfirmDialog } from '../modals/ConfirmDialog';
 import { useToastStore } from '../../store/toast';
+import { CollapsibleSection } from '../CollapsibleSection';
 
 // Curated color palette optimized for dark UI backgrounds
 // Colors chosen for: visual distinction, balanced saturation, good contrast
@@ -139,24 +140,24 @@ export function CategoriesPanel() {
 
   const canAddCategory = categories.length < CONSTRAINTS.CATEGORIES_MAX;
 
+  const addCategoryButton = (
+    <button
+      onClick={handleAddCategory}
+      disabled={!canAddCategory}
+      className="btn btn-ghost w-7 h-7 p-0 min-w-0 min-h-0"
+      title="Add a new category"
+      aria-label="Add new category"
+    >
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+      </svg>
+    </button>
+  );
+
   return (
     <div>
-      <div className="flex justify-between items-center mb-3">
-        <h2 className="text-sm font-semibold text-content-secondary tracking-wide" title="Color-code your bins by category. New bins use the selected category.">Categories</h2>
-        <button
-          onClick={handleAddCategory}
-          disabled={!canAddCategory}
-          className="btn btn-ghost w-7 h-7 p-0 min-w-0 min-h-0"
-          title="Add a new category"
-          aria-label="Add new category"
-        >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-        </button>
-      </div>
-
-      <div className="space-y-1">
+      <CollapsibleSection title="Categories" variant="default" actions={addCategoryButton}>
+        <div className="space-y-1">
         {categories.map((category) => {
           const isActive = category.id === activeCategoryId;
           const isEditing = editingId === category.id;
@@ -280,7 +281,8 @@ export function CategoriesPanel() {
             </div>
           );
         })}
-      </div>
+        </div>
+      </CollapsibleSection>
 
       <ConfirmDialog
         isOpen={deleteConfirm !== null}

--- a/src/components/Sidebar/LayerPanel.tsx
+++ b/src/components/Sidebar/LayerPanel.tsx
@@ -4,6 +4,7 @@ import { useLayoutStore, useUIStore, useUndoableAction } from '../../store';
 import { CONSTRAINTS, STAGING_ID } from '../../constants';
 import { getDisplayLayers } from '../../utils/collision';
 import { ConfirmDialog } from '../modals/ConfirmDialog';
+import { CollapsibleSection } from '../CollapsibleSection';
 
 export function LayerPanel() {
   const [deleteLayerId, setDeleteLayerId] = useState<string | null>(null);
@@ -152,27 +153,27 @@ export function LayerPanel() {
 
   if (!activeLayer) return null;
 
+  const addLayerButton = (
+    <button
+      onClick={handleAddLayer}
+      disabled={!canAddLayer}
+      className="btn btn-ghost w-7 h-7 p-0 min-w-0 min-h-0"
+      title={!canAddLayer
+        ? (heightFull ? `Max height full (${totalLayerHeight}/${drawerHeight}u)` : `Maximum ${CONSTRAINTS.LAYERS_MAX} layers`)
+        : "Add a new layer"}
+      aria-label="Add new layer"
+    >
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+      </svg>
+    </button>
+  );
+
   return (
     <div>
-      <div className="flex justify-between items-center mb-3">
-        <h2 className="text-sm font-semibold text-content-secondary tracking-wide" title="Layers stack vertically in your drawer. Tall bins on lower layers block placement above.">Layers</h2>
-        <button
-          onClick={handleAddLayer}
-          disabled={!canAddLayer}
-          className="btn btn-ghost w-7 h-7 p-0 min-w-0 min-h-0"
-          title={!canAddLayer
-            ? (heightFull ? `Max height full (${totalLayerHeight}/${drawerHeight}u)` : `Maximum ${CONSTRAINTS.LAYERS_MAX} layers`)
-            : "Add a new layer"}
-          aria-label="Add new layer"
-        >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-        </button>
-      </div>
-
-      {/* Height capacity indicator - only show for multiple layers */}
-      {hasMultipleLayers && (
+      <CollapsibleSection title="Layers" variant="default" actions={addLayerButton}>
+        {/* Height capacity indicator - only show for multiple layers */}
+        {hasMultipleLayers && (
         <div className="flex items-center gap-2 mb-3">
           <div className="flex-1 h-1.5 rounded-full overflow-hidden bg-surface-elevated">
             <div
@@ -340,16 +341,17 @@ export function LayerPanel() {
         }
       </div>
 
-      {/* Coverage bar */}
-      <div className="h-1.5 rounded-full overflow-hidden bg-surface-elevated">
-        <div
-          className="h-full rounded-full transition-all"
-          style={{
-            width: `${hasMultipleLayers ? totalCoverage : coverage}%`,
-            backgroundColor: (hasMultipleLayers ? totalCoverage : coverage) === 100 ? 'var(--color-success)' : 'var(--text-tertiary)',
-          }}
-        />
-      </div>
+        {/* Coverage bar */}
+        <div className="h-1.5 rounded-full overflow-hidden bg-surface-elevated">
+          <div
+            className="h-full rounded-full transition-all"
+            style={{
+              width: `${hasMultipleLayers ? totalCoverage : coverage}%`,
+              backgroundColor: (hasMultipleLayers ? totalCoverage : coverage) === 100 ? 'var(--color-success)' : 'var(--text-tertiary)',
+            }}
+          />
+        </div>
+      </CollapsibleSection>
 
       {/* Delete layer confirmation */}
       <ConfirmDialog

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -7,6 +7,7 @@ import { LayerPanel } from './LayerPanel';
 import { CategoriesPanel } from './CategoriesPanel';
 import { DeferredNumberInput } from '../DeferredNumberInput';
 import { ConfirmDialog } from '../modals/ConfirmDialog';
+import { CollapsibleSection } from '../CollapsibleSection';
 
 export function Sidebar() {
   const [showSaveDefaultsConfirm, setShowSaveDefaultsConfirm] = useState(false);
@@ -122,224 +123,221 @@ export function Sidebar() {
 
             {/* Grid Size */}
             <div className="mt-auto px-4 py-4">
-              <h2 className="text-sm font-semibold text-content-secondary tracking-wide mb-3">
-                Grid Size
-              </h2>
-              <div className="text-xs text-content-secondary space-y-2">
-                {/* Width / Depth / Height in compact grid with minimal steppers */}
-                <div className="grid grid-cols-3 gap-1.5">
-                  <div>
-                    <label className="block text-content-tertiary mb-1" title="Number of grid units wide">
-                      Width
-                    </label>
-                    <div className="flex items-center h-6">
-                      <button
-                        onClick={() => handleDrawerWidthChange(drawerWidth - 1)}
-                        disabled={drawerWidth <= 1}
-                        className="h-full px-1 rounded-l border border-r-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
-                        aria-label="Decrease width"
-                      >
-                        <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                          <path strokeLinecap="round" d="M20 12H4" />
-                        </svg>
-                      </button>
-                      <span className="flex-1 h-full flex items-center justify-center border-y border-stroke-subtle bg-surface text-center tabular-nums text-content-secondary text-xs">
-                        {drawerWidth}
-                      </span>
-                      <button
-                        onClick={() => handleDrawerWidthChange(drawerWidth + 1)}
-                        disabled={drawerWidth >= CONSTRAINTS.GRID_MAX}
-                        className="h-full px-1 rounded-r border border-l-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
-                        aria-label="Increase width"
-                      >
-                        <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                          <path strokeLinecap="round" d="M12 4v16m8-8H4" />
-                        </svg>
-                      </button>
+              <CollapsibleSection title="Grid Size" variant="default">
+                <div className="text-xs text-content-secondary space-y-2">
+                  {/* Width / Depth / Height in compact grid with minimal steppers */}
+                  <div className="grid grid-cols-3 gap-1.5">
+                    <div>
+                      <label className="block text-content-tertiary mb-1" title="Number of grid units wide">
+                        Width
+                      </label>
+                      <div className="flex items-center h-6">
+                        <button
+                          onClick={() => handleDrawerWidthChange(drawerWidth - 1)}
+                          disabled={drawerWidth <= 1}
+                          className="h-full px-1 rounded-l border border-r-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
+                          aria-label="Decrease width"
+                        >
+                          <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                            <path strokeLinecap="round" d="M20 12H4" />
+                          </svg>
+                        </button>
+                        <span className="flex-1 h-full flex items-center justify-center border-y border-stroke-subtle bg-surface text-center tabular-nums text-content-secondary text-xs">
+                          {drawerWidth}
+                        </span>
+                        <button
+                          onClick={() => handleDrawerWidthChange(drawerWidth + 1)}
+                          disabled={drawerWidth >= CONSTRAINTS.GRID_MAX}
+                          className="h-full px-1 rounded-r border border-l-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
+                          aria-label="Increase width"
+                        >
+                          <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                            <path strokeLinecap="round" d="M12 4v16m8-8H4" />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                    <div>
+                      <label className="block text-content-tertiary mb-1" title="Number of grid units deep">
+                        Depth
+                      </label>
+                      <div className="flex items-center h-6">
+                        <button
+                          onClick={() => handleDrawerDepthChange(drawerDepth - 1)}
+                          disabled={drawerDepth <= 1}
+                          className="h-full px-1 rounded-l border border-r-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
+                          aria-label="Decrease depth"
+                        >
+                          <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                            <path strokeLinecap="round" d="M20 12H4" />
+                          </svg>
+                        </button>
+                        <span className="flex-1 h-full flex items-center justify-center border-y border-stroke-subtle bg-surface text-center tabular-nums text-content-secondary text-xs">
+                          {drawerDepth}
+                        </span>
+                        <button
+                          onClick={() => handleDrawerDepthChange(drawerDepth + 1)}
+                          disabled={drawerDepth >= CONSTRAINTS.GRID_MAX}
+                          className="h-full px-1 rounded-r border border-l-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
+                          aria-label="Increase depth"
+                        >
+                          <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                            <path strokeLinecap="round" d="M12 4v16m8-8H4" />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                    <div>
+                      <label className="block text-content-tertiary mb-1" title="Maximum height in units">
+                        Height
+                      </label>
+                      <div className="flex items-center h-6">
+                        <button
+                          onClick={() => handleDrawerHeightChange(-1)}
+                          disabled={drawerHeight <= 1}
+                          className="h-full px-1 rounded-l border border-r-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
+                          aria-label="Decrease height"
+                        >
+                          <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                            <path strokeLinecap="round" d="M20 12H4" />
+                          </svg>
+                        </button>
+                        <span className="flex-1 h-full flex items-center justify-center border-y border-stroke-subtle bg-surface text-center tabular-nums text-content-secondary text-xs">
+                          {drawerHeight}u
+                        </span>
+                        <button
+                          onClick={() => handleDrawerHeightChange(1)}
+                          className="h-full px-1 rounded-r border border-l-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover transition-colors"
+                          aria-label="Increase height"
+                        >
+                          <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                            <path strokeLinecap="round" d="M12 4v16m8-8H4" />
+                          </svg>
+                        </button>
+                      </div>
                     </div>
                   </div>
-                  <div>
-                    <label className="block text-content-tertiary mb-1" title="Number of grid units deep">
-                      Depth
-                    </label>
-                    <div className="flex items-center h-6">
-                      <button
-                        onClick={() => handleDrawerDepthChange(drawerDepth - 1)}
-                        disabled={drawerDepth <= 1}
-                        className="h-full px-1 rounded-l border border-r-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
-                        aria-label="Decrease depth"
-                      >
-                        <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                          <path strokeLinecap="round" d="M20 12H4" />
-                        </svg>
-                      </button>
-                      <span className="flex-1 h-full flex items-center justify-center border-y border-stroke-subtle bg-surface text-center tabular-nums text-content-secondary text-xs">
-                        {drawerDepth}
-                      </span>
-                      <button
-                        onClick={() => handleDrawerDepthChange(drawerDepth + 1)}
-                        disabled={drawerDepth >= CONSTRAINTS.GRID_MAX}
-                        className="h-full px-1 rounded-r border border-l-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
-                        aria-label="Increase depth"
-                      >
-                        <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                          <path strokeLinecap="round" d="M12 4v16m8-8H4" />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                  <div>
-                    <label className="block text-content-tertiary mb-1" title="Maximum height in units">
-                      Height
-                    </label>
-                    <div className="flex items-center h-6">
-                      <button
-                        onClick={() => handleDrawerHeightChange(-1)}
-                        disabled={drawerHeight <= 1}
-                        className="h-full px-1 rounded-l border border-r-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
-                        aria-label="Decrease height"
-                      >
-                        <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                          <path strokeLinecap="round" d="M20 12H4" />
-                        </svg>
-                      </button>
-                      <span className="flex-1 h-full flex items-center justify-center border-y border-stroke-subtle bg-surface text-center tabular-nums text-content-secondary text-xs">
-                        {drawerHeight}u
-                      </span>
-                      <button
-                        onClick={() => handleDrawerHeightChange(1)}
-                        className="h-full px-1 rounded-r border border-l-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover transition-colors"
-                        aria-label="Increase height"
-                      >
-                        <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                          <path strokeLinecap="round" d="M12 4v16m8-8H4" />
-                        </svg>
-                      </button>
-                    </div>
+                  {/* Real-world drawer dimensions */}
+                  <div className="flex items-center justify-center gap-1 pt-1 text-content-tertiary">
+                    <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 12h16M4 12v-2M8 12v-1M12 12v-2M16 12v-1M20 12v-2" />
+                    </svg>
+                    <span className="tabular-nums">
+                      {(drawerWidth * gridUnitMm).toFixed(0)} × {(drawerDepth * gridUnitMm).toFixed(0)} × {(drawerHeight * heightUnitMm).toFixed(0)} mm
+                    </span>
                   </div>
                 </div>
-                {/* Real-world drawer dimensions */}
-                <div className="flex items-center justify-center gap-1 pt-1 text-content-tertiary">
-                  <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 12h16M4 12v-2M8 12v-1M12 12v-2M16 12v-1M20 12v-2" />
-                  </svg>
-                  <span className="tabular-nums">
-                    {(drawerWidth * gridUnitMm).toFixed(0)} × {(drawerDepth * gridUnitMm).toFixed(0)} × {(drawerHeight * heightUnitMm).toFixed(0)} mm
-                  </span>
-                </div>
-              </div>
+              </CollapsibleSection>
             </div>
 
             {/* Physical Units */}
             <div className="px-4 py-4 border-t border-stroke-subtle">
-              <h2 className="text-sm font-semibold text-content-secondary tracking-wide mb-3">
-                Physical Units
-              </h2>
-              <div className="text-xs text-content-secondary space-y-2">
-                <div className="flex items-center justify-between">
-                  <label
-                    htmlFor="gridUnit"
-                    className="text-content-tertiary"
-                    title="Size of one grid unit in mm (standard Gridfinity = 42mm)"
-                  >
-                    Grid unit
-                  </label>
-                  <div className="flex items-center gap-1">
-                    <DeferredNumberInput
-                      id="gridUnit"
-                      value={gridUnitMm}
-                      onChange={setGridUnitMm}
-                      min={1}
-                      max={200}
-                      className="input w-14 py-0.5 px-1 text-xs text-right"
-                    />
-                    <span className="text-content-tertiary">mm</span>
-                  </div>
-                </div>
-                <div className="flex items-center justify-between">
-                  <label
-                    htmlFor="heightUnit"
-                    className="text-content-tertiary"
-                    title="Height of one vertical unit in mm (standard = 7mm)"
-                  >
-                    Height unit
-                  </label>
-                  <div className="flex items-center gap-1">
-                    <DeferredNumberInput
-                      id="heightUnit"
-                      value={heightUnitMm}
-                      onChange={setHeightUnitMm}
-                      min={1}
-                      max={50}
-                      className="input w-14 py-0.5 px-1 text-xs text-right"
-                    />
-                    <span className="text-content-tertiary">mm</span>
-                  </div>
-                </div>
-                <div className="flex items-center justify-between">
-                  <label
-                    htmlFor="printBedSize"
-                    className="text-content-tertiary"
-                    title={`Bins larger than ${calcMaxGridUnits(printBedSize, gridUnitMm)}×${calcMaxGridUnits(printBedSize, gridUnitMm)} will be split for printing`}
-                  >
-                    Print bed
-                  </label>
-                  <div className="flex items-center gap-1">
-                    <DeferredNumberInput
-                      id="printBedSize"
-                      value={printBedSize}
-                      onChange={setPrintBedSize}
-                      min={42}
-                      max={500}
-                      step={10}
-                      className="input w-14 py-0.5 px-1 text-xs text-right"
-                    />
-                    <span className="text-content-tertiary">mm</span>
-                  </div>
-                </div>
-                {/* Half-bin mode checkbox */}
-                <label className="flex items-center justify-between pt-2 mt-2 border-t border-stroke-subtle cursor-pointer">
-                  <div className="flex items-center gap-1.5">
-                    <span
+              <CollapsibleSection title="Physical Units" variant="default" defaultExpanded={false}>
+                <div className="text-xs text-content-secondary space-y-2">
+                  <div className="flex items-center justify-between">
+                    <label
+                      htmlFor="gridUnit"
                       className="text-content-tertiary"
-                      title="Enable 0.5 grid unit precision for half-size bins (H)"
+                      title="Size of one grid unit in mm (standard Gridfinity = 42mm)"
                     >
-                      Half-bin mode
-                    </span>
-                    <span className="text-[9px] text-amber-500/80 bg-amber-500/10 px-1 py-0.5 rounded">experimental</span>
-                    <kbd className="text-[9px] text-content-disabled bg-surface-elevated px-1 py-0.5 rounded border border-stroke-subtle">H</kbd>
+                      Grid unit
+                    </label>
+                    <div className="flex items-center gap-1">
+                      <DeferredNumberInput
+                        id="gridUnit"
+                        value={gridUnitMm}
+                        onChange={setGridUnitMm}
+                        min={1}
+                        max={200}
+                        className="input w-14 py-0.5 px-1 text-xs text-right"
+                      />
+                      <span className="text-content-tertiary">mm</span>
+                    </div>
                   </div>
-                  <input
-                    type="checkbox"
-                    checked={halfBinMode}
-                    onChange={toggleHalfBinMode}
-                    className="w-4 h-4 rounded accent-accent"
-                    aria-label="Toggle half-bin mode"
-                  />
-                </label>
-              </div>
+                  <div className="flex items-center justify-between">
+                    <label
+                      htmlFor="heightUnit"
+                      className="text-content-tertiary"
+                      title="Height of one vertical unit in mm (standard = 7mm)"
+                    >
+                      Height unit
+                    </label>
+                    <div className="flex items-center gap-1">
+                      <DeferredNumberInput
+                        id="heightUnit"
+                        value={heightUnitMm}
+                        onChange={setHeightUnitMm}
+                        min={1}
+                        max={50}
+                        className="input w-14 py-0.5 px-1 text-xs text-right"
+                      />
+                      <span className="text-content-tertiary">mm</span>
+                    </div>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <label
+                      htmlFor="printBedSize"
+                      className="text-content-tertiary"
+                      title={`Bins larger than ${calcMaxGridUnits(printBedSize, gridUnitMm)}×${calcMaxGridUnits(printBedSize, gridUnitMm)} will be split for printing`}
+                    >
+                      Print bed
+                    </label>
+                    <div className="flex items-center gap-1">
+                      <DeferredNumberInput
+                        id="printBedSize"
+                        value={printBedSize}
+                        onChange={setPrintBedSize}
+                        min={42}
+                        max={500}
+                        step={10}
+                        className="input w-14 py-0.5 px-1 text-xs text-right"
+                      />
+                      <span className="text-content-tertiary">mm</span>
+                    </div>
+                  </div>
+                  {/* Half-bin mode checkbox */}
+                  <label className="flex items-center justify-between pt-2 mt-2 border-t border-stroke-subtle cursor-pointer">
+                    <div className="flex items-center gap-1.5">
+                      <span
+                        className="text-content-tertiary"
+                        title="Enable 0.5 grid unit precision for half-size bins (H)"
+                      >
+                        Half-bin mode
+                      </span>
+                      <span className="text-[9px] text-amber-500/80 bg-amber-500/10 px-1 py-0.5 rounded">experimental</span>
+                      <kbd className="text-[9px] text-content-disabled bg-surface-elevated px-1 py-0.5 rounded border border-stroke-subtle">H</kbd>
+                    </div>
+                    <input
+                      type="checkbox"
+                      checked={halfBinMode}
+                      onChange={toggleHalfBinMode}
+                      className="w-4 h-4 rounded accent-accent"
+                      aria-label="Toggle half-bin mode"
+                    />
+                  </label>
+                </div>
+              </CollapsibleSection>
             </div>
 
             {/* Default Preferences */}
             <div className="px-4 py-4 border-t border-stroke-subtle">
-              <h2 className="text-sm font-semibold text-content-secondary tracking-wide mb-3">
-                Default Preferences
-              </h2>
-              <div className="text-xs text-content-tertiary mb-2">
-                New layouts will use:
-              </div>
-              <div className="text-xs text-content-secondary space-y-1 mb-3">
-                <div>Drawer: {settings.defaultDrawerWidth}×{settings.defaultDrawerDepth}×{settings.defaultDrawerHeight}u</div>
-                <div>Print bed: {settings.defaultPrintBedSize}mm</div>
-                <div>Grid unit: {settings.defaultGridUnitMm}mm</div>
-              </div>
-              <button
-                onClick={() => setShowSaveDefaultsConfirm(true)}
-                className="w-full text-xs py-1.5 px-2 rounded bg-surface-elevated hover:bg-surface-hover text-content-secondary hover:text-content border border-stroke-subtle transition-colors"
-                title="Save current layout settings as defaults for new layouts"
-              >
-                Save Current as Defaults
-              </button>
+              <CollapsibleSection title="Default Preferences" variant="default" defaultExpanded={false}>
+                <div className="text-xs text-content-tertiary mb-2">
+                  New layouts will use:
+                </div>
+                <div className="text-xs text-content-secondary space-y-1 mb-3">
+                  <div>Drawer: {settings.defaultDrawerWidth}×{settings.defaultDrawerDepth}×{settings.defaultDrawerHeight}u</div>
+                  <div>Print bed: {settings.defaultPrintBedSize}mm</div>
+                  <div>Grid unit: {settings.defaultGridUnitMm}mm</div>
+                </div>
+                <button
+                  onClick={() => setShowSaveDefaultsConfirm(true)}
+                  className="w-full text-xs py-1.5 px-2 rounded bg-surface-elevated hover:bg-surface-hover text-content-secondary hover:text-content border border-stroke-subtle transition-colors"
+                  title="Save current layout settings as defaults for new layouts"
+                >
+                  Save Current as Defaults
+                </button>
+              </CollapsibleSection>
             </div>
 
             {/* Attribution */}

--- a/src/components/inspector/SingleBinInspector.tsx
+++ b/src/components/inspector/SingleBinInspector.tsx
@@ -2,6 +2,7 @@ import { STAGING_ID, CONSTRAINTS, DEFAULT_CATEGORY_COLOR } from '../../constants
 import { useUIStore } from '../../store';
 import type { UseBinInspectorReturn } from './useBinInspector';
 import { SplitWarning } from './SplitWarning';
+import { DeferredNumberInput } from '../DeferredNumberInput';
 
 interface SingleBinInspectorProps {
   inspector: UseBinInspectorReturn;
@@ -30,6 +31,7 @@ export function SingleBinInspector({
     requestDelete,
     moveToStaging,
     clearSelection,
+    rotateBin,
   } = inspector;
 
   const halfBinMode = useUIStore(state => state.halfBinMode);
@@ -44,12 +46,9 @@ export function SingleBinInspector({
   const minSize = halfBinMode ? 0.5 : 1;
   const stepSize = halfBinMode ? 0.5 : 1;
 
-  // Button sizing for mobile vs desktop
-  const btnSize = isMobile ? 'w-12 h-12' : 'w-10 h-10';
-  const btnMinSize = isMobile ? 'min-w-[48px] min-h-[48px]' : 'min-w-[40px] min-h-[40px]';
+  // Sizing for mobile vs desktop
   const inputHeight = isMobile ? 'h-12' : '';
   const labelSize = isMobile ? 'text-sm mb-2' : 'text-xs mb-1';
-  const valueSize = isMobile ? 'text-xl' : 'text-lg';
 
   return (
     <div className="animate-fade-in">
@@ -78,36 +77,50 @@ export function SingleBinInspector({
       </div>
 
       <div className="space-y-4">
-        {/* Size inputs */}
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className={`block ${labelSize} text-content-tertiary`}>
-              Width
-            </label>
-            <input
-              type="number"
-              value={bin.width}
-              onChange={(e) => updateField('width', e.target.value)}
-              className={`input w-full ${inputHeight}`}
-              min={minSize}
-              step={stepSize}
-              aria-label="Bin width"
-            />
+        {/* Size inputs with rotate button */}
+        <div className="flex items-end gap-2">
+          <div className="grid grid-cols-2 gap-3 flex-1">
+            <div>
+              <label className={`block ${labelSize} text-content-tertiary`}>
+                Width
+              </label>
+              <DeferredNumberInput
+                value={bin.width}
+                onChange={(val) => updateField('width', val)}
+                min={minSize}
+                max={layout.drawer.width}
+                step={stepSize}
+                className={`input w-full ${inputHeight}`}
+                aria-label="Bin width"
+              />
+            </div>
+            <div>
+              <label className={`block ${labelSize} text-content-tertiary`}>
+                Depth
+              </label>
+              <DeferredNumberInput
+                value={bin.depth}
+                onChange={(val) => updateField('depth', val)}
+                min={minSize}
+                max={layout.drawer.depth}
+                step={stepSize}
+                className={`input w-full ${inputHeight}`}
+                aria-label="Bin depth"
+              />
+            </div>
           </div>
-          <div>
-            <label className={`block ${labelSize} text-content-tertiary`}>
-              Depth
-            </label>
-            <input
-              type="number"
-              value={bin.depth}
-              onChange={(e) => updateField('depth', e.target.value)}
-              className={`input w-full ${inputHeight}`}
-              min={minSize}
-              step={stepSize}
-              aria-label="Bin depth"
-            />
-          </div>
+          <button
+            type="button"
+            onClick={rotateBin}
+            disabled={bin.layerId === STAGING_ID}
+            className={`btn btn-ghost p-0 text-content-tertiary hover:text-content ${isMobile ? 'w-12 h-12' : 'w-[38px] h-[38px]'}`}
+            title="Rotate 90° (R)"
+            aria-label="Rotate bin"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+          </button>
         </div>
 
         {/* Real-world dimensions */}
@@ -120,84 +133,87 @@ export function SingleBinInspector({
           </span>
         </div>
 
-        {/* Height control with +/- buttons */}
-        <div>
-          <label className={`block ${labelSize} text-content-tertiary`}>
-            Height
-          </label>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => updateField('height', bin.height - 1)}
-              disabled={bin.height <= constraints.minHeight}
-              className={`btn btn-secondary ${btnSize} p-0 ${btnMinSize}`}
-              aria-label="Decrease height"
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-              </svg>
-            </button>
-            <span className={`flex-1 text-center font-semibold ${valueSize} text-content`}>
-              {bin.height}u
-            </span>
-            <button
-              type="button"
-              onClick={() => updateField('height', bin.height + 1)}
-              disabled={bin.height >= constraints.maxHeight}
-              className={`btn btn-secondary ${btnSize} p-0 ${btnMinSize}`}
-              aria-label="Increase height"
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-              </svg>
-            </button>
-          </div>
-          <div className="text-center mt-1 text-xs text-content-disabled">
-            Range: {constraints.heightRange}
-          </div>
-        </div>
-
-        {/* Clearance control */}
-        {constraints.maxClearance > 0 && (
+        {/* Height and Clearance - compact inline controls */}
+        <div className={`grid gap-3 ${constraints.maxClearance > 0 ? 'grid-cols-2' : 'grid-cols-1'}`}>
+          {/* Height control */}
           <div>
-            <label
-              className={`block ${labelSize} text-content-tertiary`}
-              title="Extra blocked space above this bin for tall contents (e.g., scissors, tools)"
-            >
-              Clearance
+            <label className={`block ${labelSize} text-content-tertiary`}>
+              Height
             </label>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center h-8">
               <button
                 type="button"
-                onClick={() => updateField('clearanceHeight', (bin.clearanceHeight || 0) - 1)}
-                disabled={(bin.clearanceHeight || 0) <= 0}
-                className={`btn btn-secondary ${btnSize} p-0 ${btnMinSize}`}
-                aria-label="Decrease clearance"
+                onClick={() => updateField('height', bin.height - 1)}
+                disabled={bin.height <= constraints.minHeight}
+                className="h-full px-2 rounded-l border border-r-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
+                aria-label="Decrease height"
               >
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
+                <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                  <path strokeLinecap="round" d="M20 12H4" />
                 </svg>
               </button>
-              <span className={`flex-1 text-center font-semibold ${valueSize} text-content`}>
-                {bin.clearanceHeight || 0}u
+              <span className="flex-1 h-full flex items-center justify-center border-y border-stroke-subtle bg-surface text-center tabular-nums text-content font-medium text-sm">
+                {bin.height}u
               </span>
               <button
                 type="button"
-                onClick={() => updateField('clearanceHeight', (bin.clearanceHeight || 0) + 1)}
-                disabled={(bin.clearanceHeight || 0) >= constraints.maxClearance}
-                className={`btn btn-secondary ${btnSize} p-0 ${btnMinSize}`}
-                aria-label="Increase clearance"
+                onClick={() => updateField('height', bin.height + 1)}
+                disabled={bin.height >= constraints.maxHeight}
+                className="h-full px-2 rounded-r border border-l-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
+                aria-label="Increase height"
               >
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                  <path strokeLinecap="round" d="M12 4v16m8-8H4" />
                 </svg>
               </button>
             </div>
-            <div className="text-center mt-1 text-xs text-content-disabled">
-              Blocks {bin.clearanceHeight || 0}u above bin ({((bin.clearanceHeight || 0) * layout.heightUnitMm).toFixed(0)} mm)
+            <div className="text-center mt-1 text-[10px] text-content-disabled">
+              {constraints.heightRange}
             </div>
           </div>
-        )}
+
+          {/* Clearance control */}
+          {constraints.maxClearance > 0 && (
+            <div>
+              <label
+                className={`block ${labelSize} text-content-tertiary`}
+                title="Extra blocked space above for tall contents"
+              >
+                Clearance
+              </label>
+              <div className="flex items-center h-8">
+                <button
+                  type="button"
+                  onClick={() => updateField('clearanceHeight', (bin.clearanceHeight || 0) - 1)}
+                  disabled={(bin.clearanceHeight || 0) <= 0}
+                  className="h-full px-2 rounded-l border border-r-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
+                  aria-label="Decrease clearance"
+                >
+                  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                    <path strokeLinecap="round" d="M20 12H4" />
+                  </svg>
+                </button>
+                <span className="flex-1 h-full flex items-center justify-center border-y border-stroke-subtle bg-surface text-center tabular-nums text-content font-medium text-sm">
+                  {bin.clearanceHeight || 0}u
+                </span>
+                <button
+                  type="button"
+                  onClick={() => updateField('clearanceHeight', (bin.clearanceHeight || 0) + 1)}
+                  disabled={(bin.clearanceHeight || 0) >= constraints.maxClearance}
+                  className="h-full px-2 rounded-r border border-l-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
+                  aria-label="Increase clearance"
+                >
+                  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                    <path strokeLinecap="round" d="M12 4v16m8-8H4" />
+                  </svg>
+                </button>
+              </div>
+              <div className="text-center mt-1 text-[10px] text-content-disabled">
+                +{((bin.clearanceHeight || 0) * layout.heightUnitMm).toFixed(0)}mm above
+              </div>
+            </div>
+          )}
+        </div>
 
         {/* Split warning with print bed visualization */}
         <SplitWarning

--- a/src/components/inspector/useBinInspector.ts
+++ b/src/components/inspector/useBinInspector.ts
@@ -1,9 +1,9 @@
 import { useState, useCallback, useMemo } from 'react';
 import { useShallow } from 'zustand/shallow';
-import { useUIStore, useLayoutStore, useUndoableAction } from '../../store';
-import { calcMaxGridUnits } from '../../constants';
+import { useUIStore, useLayoutStore, useUndoableAction, useToastStore } from '../../store';
+import { calcMaxGridUnits, STAGING_ID } from '../../constants';
 import { getLayerZStart } from '../../utils/collision';
-import { clamp } from '../../utils/validation';
+import { clamp, canPlaceBin } from '../../utils/validation';
 import type { Bin, Category, Layer, Layout } from '../../types';
 
 export type BinField = 'width' | 'depth' | 'height' | 'clearanceHeight' | 'category' | 'label' | 'notes';
@@ -45,6 +45,7 @@ export interface UseBinInspectorReturn {
   cancelDelete: () => void;
   moveToStaging: () => void;
   clearSelection: () => void;
+  rotateBin: () => boolean;
 
   // Confirmation state
   deleteConfirmState: ConfirmDeleteState | null;
@@ -263,6 +264,53 @@ export function useBinInspector(): UseBinInspectorReturn {
     setSelectedBins([]);
   }, [setSelectedBins]);
 
+  // Get toast store for error messages
+  const addToast = useToastStore((state) => state.addToast);
+
+  // Rotate bin (swap width and depth)
+  // Returns true if rotation succeeded, false if blocked by collision
+  const rotateBin = useCallback(() => {
+    if (!bin || bin.layerId === STAGING_ID) return false;
+
+    // Check if rotated bin would fit (swap width and depth)
+    const rotatedRect = {
+      x: bin.x,
+      y: bin.y,
+      width: bin.depth,  // Swapped
+      depth: bin.width,  // Swapped
+      height: bin.height,
+      clearanceHeight: bin.clearanceHeight,
+    };
+
+    const validation = canPlaceBin(rotatedRect, bin.layerId, layout, bin.id);
+
+    if (!validation.valid) {
+      // Show appropriate error message based on reason
+      let message = 'Cannot rotate bin';
+      switch (validation.reason) {
+        case 'exceeds_width':
+        case 'exceeds_depth':
+        case 'out_of_bounds':
+          message = 'Cannot rotate: bin would exceed drawer bounds';
+          break;
+        case 'collision':
+          message = 'Cannot rotate: would collide with another bin';
+          break;
+        case 'blocked_zone':
+          message = 'Cannot rotate: space is blocked by a bin below';
+          break;
+      }
+      addToast(message, 'error');
+      return false;
+    }
+
+    // Rotation is valid, perform it
+    execute(() => {
+      updateBin(bin.id, { width: bin.depth, depth: bin.width });
+    });
+    return true;
+  }, [bin, layout, execute, updateBin, addToast]);
+
   return {
     // Selection state
     selectedBins,
@@ -286,6 +334,7 @@ export function useBinInspector(): UseBinInspectorReturn {
     cancelDelete,
     moveToStaging,
     clearSelection,
+    rotateBin,
 
     // Confirmation state
     deleteConfirmState,

--- a/src/components/mobile/BinContextMenu.tsx
+++ b/src/components/mobile/BinContextMenu.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from 'react';
-import { useLayoutStore, useUIStore, useUndoableAction } from '../../store';
+import { useLayoutStore, useUIStore, useUndoableAction, useToastStore } from '../../store';
 import { useResponsive } from '../../hooks/useResponsive';
 import { STAGING_ID } from '../../constants';
+import { canPlaceBin } from '../../utils/validation';
 import type { Bin } from '../../types';
 
 interface BinContextMenuProps {
@@ -16,13 +17,16 @@ interface BinContextMenuProps {
 export function BinContextMenu({ bin, position, onClose }: BinContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
 
+  const layout = useLayoutStore(state => state.layout);
   const deleteBin = useLayoutStore(state => state.deleteBin);
   const moveBinToStaging = useLayoutStore(state => state.moveBinToStaging);
   const duplicateBin = useLayoutStore(state => state.duplicateBin);
+  const updateBin = useLayoutStore(state => state.updateBin);
   const setSelectedBins = useUIStore(state => state.setSelectedBins);
   const toggleMobilePanel = useUIStore(state => state.toggleMobilePanel);
   const rightPanelCollapsed = useUIStore(state => state.rightPanelCollapsed);
   const toggleRightPanel = useUIStore(state => state.toggleRightPanel);
+  const addToast = useToastStore(state => state.addToast);
 
   const { execute } = useUndoableAction();
   const { isDesktop } = useResponsive();
@@ -93,6 +97,47 @@ export function BinContextMenu({ bin, position, onClose }: BinContextMenuProps) 
     onClose();
   };
 
+  const handleRotate = () => {
+    // Check if rotated bin would fit (swap width and depth)
+    const rotatedRect = {
+      x: bin.x,
+      y: bin.y,
+      width: bin.depth,  // Swapped
+      depth: bin.width,  // Swapped
+      height: bin.height,
+      clearanceHeight: bin.clearanceHeight,
+    };
+
+    const validation = canPlaceBin(rotatedRect, bin.layerId, layout, bin.id);
+
+    if (!validation.valid) {
+      // Show appropriate error message based on reason
+      let message = 'Cannot rotate bin';
+      switch (validation.reason) {
+        case 'exceeds_width':
+        case 'exceeds_depth':
+        case 'out_of_bounds':
+          message = 'Cannot rotate: bin would exceed drawer bounds';
+          break;
+        case 'collision':
+          message = 'Cannot rotate: would collide with another bin';
+          break;
+        case 'blocked_zone':
+          message = 'Cannot rotate: space is blocked by a bin below';
+          break;
+      }
+      addToast(message, 'error');
+      onClose();
+      return;
+    }
+
+    // Rotation is valid, perform it
+    execute(() => {
+      updateBin(bin.id, { width: bin.depth, depth: bin.width });
+    });
+    onClose();
+  };
+
   // On desktop, only show Edit Properties when right panel is collapsed
   const showEditOption = !isDesktop || rightPanelCollapsed;
 
@@ -153,6 +198,18 @@ export function BinContextMenu({ bin, position, onClose }: BinContextMenuProps) 
             </svg>
             Duplicate
           </button>
+
+          {isOnGrid && (
+            <button
+              onClick={handleRotate}
+              className="w-full px-4 py-3 flex items-center gap-3 transition-colors text-content hover:bg-surface-hover"
+            >
+              <svg className="w-5 h-5 text-content-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+              Rotate
+            </button>
+          )}
 
           {isOnGrid && (
             <button

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -201,6 +201,7 @@ export const SHORTCUTS = {
   REDO: 'y',        // with Ctrl/Cmd
   REDO_ALT: 'Z',    // Shift+Ctrl/Cmd+Z
   DUPLICATE: 'd',   // with Ctrl/Cmd
+  ROTATE: 'r',      // Rotate bin (swap width/depth)
   ZOOM_IN: ['+', '='],
   ZOOM_OUT: ['-'],
   HELP: '?',

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -1,5 +1,5 @@
 import { useEffect, useCallback } from 'react';
-import { useUIStore, useLayoutStore, useHistoryStore, useLibraryStore, useUndoableAction } from '../store';
+import { useUIStore, useLayoutStore, useHistoryStore, useLibraryStore, useUndoableAction, useToastStore } from '../store';
 import { canPlaceBin } from '../utils/validation';
 import { SHORTCUTS, STAGING_ID, hasFractionalDimensions } from '../constants';
 import { useGridNavigation } from './useGridNavigation';
@@ -63,6 +63,7 @@ export function useKeyboard() {
   const toggleHalfBinMode = useUIStore(state => state.toggleHalfBinMode);
 
   const setShowLayoutManager = useLibraryStore(state => state.setShowLayoutManager);
+  const addToast = useToastStore(state => state.addToast);
 
   // Grid navigation hook for spatial arrow key navigation
   const { handleNavigationKey } = useGridNavigation();
@@ -145,6 +146,51 @@ export function useKeyboard() {
         if (newIds.length > 0) {
           setSelectedBins(newIds);
         }
+      });
+      return;
+    }
+
+    // Rotate selected bin (R) - swap width and depth
+    if (key.toLowerCase() === SHORTCUTS.ROTATE && !ctrlOrMeta && selectedBinIds.length === 1) {
+      e.preventDefault();
+      const bin = layout.bins.find(b => b.id === selectedBinIds[0]);
+      if (!bin || bin.layerId === STAGING_ID) return;
+
+      // Check if rotated bin would fit (swap width and depth)
+      const rotatedRect = {
+        x: bin.x,
+        y: bin.y,
+        width: bin.depth,  // Swapped
+        depth: bin.width,  // Swapped
+        height: bin.height,
+        clearanceHeight: bin.clearanceHeight,
+      };
+
+      const validation = canPlaceBin(rotatedRect, bin.layerId, layout, bin.id);
+
+      if (!validation.valid) {
+        // Show appropriate error message based on reason
+        let message = 'Cannot rotate bin';
+        switch (validation.reason) {
+          case 'exceeds_width':
+          case 'exceeds_depth':
+          case 'out_of_bounds':
+            message = 'Cannot rotate: bin would exceed drawer bounds';
+            break;
+          case 'collision':
+            message = 'Cannot rotate: would collide with another bin';
+            break;
+          case 'blocked_zone':
+            message = 'Cannot rotate: space is blocked by a bin below';
+            break;
+        }
+        addToast(message, 'error');
+        return;
+      }
+
+      // Rotation is valid, perform it
+      execute(() => {
+        updateBin(bin.id, { width: bin.depth, depth: bin.width });
       });
       return;
     }
@@ -358,7 +404,7 @@ export function useKeyboard() {
       }
       return;
     }
-  }, [selectedBinIds, focusedBinId, layout, canUndo, canRedo, undo, redo, zoomIn, zoomOut, deleteBin, duplicateBin, updateBin, setSelectedBins, setInteraction, setPaintSize, execute, handleNavigationKey, activeLayerId, setActiveLayer, showQuickLabel, activeCategoryId, setActiveCategory, toggleHalfBinMode, setShowLayoutManager]);
+  }, [selectedBinIds, focusedBinId, layout, canUndo, canRedo, undo, redo, zoomIn, zoomOut, deleteBin, duplicateBin, updateBin, setSelectedBins, setInteraction, setPaintSize, execute, handleNavigationKey, activeLayerId, setActiveLayer, showQuickLabel, activeCategoryId, setActiveCategory, toggleHalfBinMode, setShowLayoutManager, addToast]);
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);

--- a/src/test/validation.test.ts
+++ b/src/test/validation.test.ts
@@ -277,3 +277,134 @@ describe('truncate', () => {
     expect(truncate('hi', 5)).toBe('hi');
   });
 });
+
+describe('canPlaceBin - rotation scenarios', () => {
+  it('allows rotation of square bin (no-op)', () => {
+    const layout = createTestLayout();
+    layout.bins = [
+      { id: 'bin1', layerId: 'layer1', x: 0, y: 0, width: 2, depth: 2, height: 3, category: 'cat1', label: '', notes: '' },
+    ];
+    // Rotation swaps width/depth, but for square it's the same
+    const result = canPlaceBin(
+      { x: 0, y: 0, width: 2, depth: 2, height: 3 },
+      'layer1',
+      layout,
+      'bin1'
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('allows rotation of rectangular bin that fits after rotation', () => {
+    const layout = createTestLayout();
+    layout.bins = [
+      { id: 'bin1', layerId: 'layer1', x: 0, y: 0, width: 2, depth: 4, height: 3, category: 'cat1', label: '', notes: '' },
+    ];
+    // Rotate: 2x4 -> 4x2 at (0,0), should fit in 10x10 drawer
+    const result = canPlaceBin(
+      { x: 0, y: 0, width: 4, depth: 2, height: 3 },
+      'layer1',
+      layout,
+      'bin1'
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects rotation that would exceed drawer width', () => {
+    const layout = createTestLayout();
+    layout.bins = [
+      // 2x8 bin at position (8,0) - rotation would make it 8x2 which exceeds width
+      { id: 'bin1', layerId: 'layer1', x: 8, y: 0, width: 2, depth: 8, height: 3, category: 'cat1', label: '', notes: '' },
+    ];
+    const result = canPlaceBin(
+      { x: 8, y: 0, width: 8, depth: 2, height: 3 },
+      'layer1',
+      layout,
+      'bin1'
+    );
+    expect(result).toEqual({ valid: false, reason: 'exceeds_width' });
+  });
+
+  it('rejects rotation that would exceed drawer depth', () => {
+    const layout = createTestLayout();
+    layout.bins = [
+      // 8x2 bin at position (0,8) - rotation would make it 2x8 which exceeds depth
+      { id: 'bin1', layerId: 'layer1', x: 0, y: 8, width: 8, depth: 2, height: 3, category: 'cat1', label: '', notes: '' },
+    ];
+    const result = canPlaceBin(
+      { x: 0, y: 8, width: 2, depth: 8, height: 3 },
+      'layer1',
+      layout,
+      'bin1'
+    );
+    expect(result).toEqual({ valid: false, reason: 'exceeds_depth' });
+  });
+
+  it('rejects rotation that would cause collision', () => {
+    const layout = createTestLayout();
+    layout.bins = [
+      // Bin to rotate: 2x4 at (0,0)
+      { id: 'bin1', layerId: 'layer1', x: 0, y: 0, width: 2, depth: 4, height: 3, category: 'cat1', label: '', notes: '' },
+      // Adjacent bin at (3,0) - would collide with rotated bin (4x2)
+      { id: 'bin2', layerId: 'layer1', x: 3, y: 0, width: 2, depth: 2, height: 3, category: 'cat1', label: '', notes: '' },
+    ];
+    // Rotate bin1: 2x4 -> 4x2
+    const result = canPlaceBin(
+      { x: 0, y: 0, width: 4, depth: 2, height: 3 },
+      'layer1',
+      layout,
+      'bin1'
+    );
+    expect(result).toEqual({ valid: false, reason: 'collision' });
+  });
+
+  it('allows rotation when adjacent bins do not collide', () => {
+    const layout = createTestLayout();
+    layout.bins = [
+      // Bin to rotate: 2x4 at (0,0)
+      { id: 'bin1', layerId: 'layer1', x: 0, y: 0, width: 2, depth: 4, height: 3, category: 'cat1', label: '', notes: '' },
+      // Adjacent bin at (5,0) - won't collide with rotated bin (4x2)
+      { id: 'bin2', layerId: 'layer1', x: 5, y: 0, width: 2, depth: 2, height: 3, category: 'cat1', label: '', notes: '' },
+    ];
+    // Rotate bin1: 2x4 -> 4x2
+    const result = canPlaceBin(
+      { x: 0, y: 0, width: 4, depth: 2, height: 3 },
+      'layer1',
+      layout,
+      'bin1'
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects rotation into blocked zone', () => {
+    const layout = createTestLayout();
+    layout.bins = [
+      // Tall bin on layer 1 that blocks part of layer 2
+      { id: 'tall', layerId: 'layer1', x: 0, y: 0, width: 4, depth: 4, height: 6, category: 'cat1', label: '', notes: '' },
+      // Bin on layer 2 to rotate: 2x4 at (5,0) - rotation would be 4x2 which doesn't overlap with blocked zone
+      { id: 'bin1', layerId: 'layer2', x: 5, y: 0, width: 2, depth: 4, height: 6, category: 'cat1', label: '', notes: '' },
+    ];
+    // This should work since rotated position doesn't overlap blocked zone
+    const result = canPlaceBin(
+      { x: 5, y: 0, width: 4, depth: 2, height: 6 },
+      'layer2',
+      layout,
+      'bin1'
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('handles rotation with clearance height', () => {
+    const layout = createTestLayout();
+    layout.bins = [
+      { id: 'bin1', layerId: 'layer1', x: 0, y: 0, width: 2, depth: 4, height: 3, clearanceHeight: 2, category: 'cat1', label: '', notes: '' },
+    ];
+    // Rotate preserving clearance
+    const result = canPlaceBin(
+      { x: 0, y: 0, width: 4, depth: 2, height: 3, clearanceHeight: 2 },
+      'layer1',
+      layout,
+      'bin1'
+    );
+    expect(result.valid).toBe(true);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -70,6 +70,8 @@ export default defineConfig({
     }),
   ],
   build: {
+    // Three.js is ~720KB minified, which is expected for a 3D library
+    chunkSizeWarningLimit: 750,
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
## Summary

UX improvements for the inspector and sidebar panels:

- **Collapsible panels**: All sidebar panels (Bin Palette, Layers, Categories, Grid Size, Physical Units, Default Preferences) and the bin properties panel are now collapsible with animated expand/collapse
- **Compact height/clearance controls**: Changed from large buttons to inline steppers, displayed side-by-side when both are available
- **Bin rotate command**: Press `R` to swap width ↔ depth on selected bin, with collision detection and error toasts

### New Features

- `CollapsibleSection` reusable component with chevron animation
- Rotate button added next to width/depth inputs in inspector
- Rotate option added to mobile context menu
- Error toasts when rotation would exceed bounds or cause collision

### Input Improvements

- `DeferredNumberInput` now auto-selects text on focus
- Supports float values for half-bin mode

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 1228 unit tests pass (`npm run test:run`)
- [x] ESLint passes (`npm run lint`)
- [ ] Verify collapsible panels work on desktop
- [ ] Verify compact height/clearance controls look correct
- [ ] Test rotate with R key on selected bin
- [ ] Test rotate button in inspector
- [ ] Test rotation error cases (bounds, collision)
- [ ] Test on mobile (rotate in context menu)