### PR TITLE
feat: add temporary Reddit feedback link to headers

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -184,6 +184,22 @@ export function Header({ onHelpClick }: HeaderProps) {
           </button>
         </div>
 
+        {/* Reddit feedback link */}
+        <div className="w-px h-6 bg-stroke-subtle" />
+        <a
+          href="https://www.reddit.com/r/gridfinity/comments/1q93nz6/i_built_a_free_layout_planner_for_gridfinity/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn btn-ghost px-2.5 py-1.5 text-sm gap-1.5 text-content-secondary hover:text-content flex items-center"
+          aria-label="Discuss on Reddit"
+          title="Discuss on Reddit"
+        >
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/>
+          </svg>
+          <span>Discuss on Reddit</span>
+        </a>
+
         <button
           onClick={onHelpClick}
           className="btn btn-ghost px-2.5 py-1.5 text-sm text-content-secondary"

--- a/src/components/mobile/MobileHeader.tsx
+++ b/src/components/mobile/MobileHeader.tsx
@@ -63,17 +63,31 @@ export function MobileHeader({ onMenuClick, onHelpClick }: MobileHeaderProps) {
       {/* App title bar */}
       <div className="h-7 flex items-center justify-between px-3 bg-surface border-b border-stroke-subtle">
         <span className="text-xs font-medium text-content-secondary">Gridfinity Layout Tool</span>
-        <a
-          href="https://ko-fi.com/andyaragon"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-1 text-xs text-accent hover:underline"
-        >
-          <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-          </svg>
-          Tip
-        </a>
+        <div className="flex items-center gap-3">
+          <a
+            href="https://www.reddit.com/r/gridfinity/comments/1q93nz6/i_built_a_free_layout_planner_for_gridfinity/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 text-xs text-accent hover:underline"
+            aria-label="Discuss on Reddit"
+          >
+            <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/>
+            </svg>
+            Reddit
+          </a>
+          <a
+            href="https://ko-fi.com/andyaragon"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 text-xs text-accent hover:underline"
+          >
+            <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+            </svg>
+            Tip
+          </a>
+        </div>
       </div>
       {/* Action bar */}
       <header className="mobile-header h-12 flex items-center justify-between px-3 bg-surface-secondary border-b border-stroke-subtle">


### PR DESCRIPTION
## Summary
- Add Reddit discussion link to desktop header (between undo/redo and help button)
- Add Reddit discussion link to mobile header (in title bar alongside Tip link)
- Links point to the r/gridfinity launch post for gathering user feedback

**Desktop implementation:**
- Added separator divider + link with Reddit icon + "Discuss on Reddit" text
- Uses `text-content-secondary` color to match other action buttons
- Positioned between undo/redo group and help button

**Mobile implementation:**
- Added compact "Reddit" link to title bar
- Uses `text-accent` color to match existing "Tip" link
- Wrapped both links in flex container with proper spacing

**Easy removal:**
No feature flags - can be easily removed by deleting the link elements when feedback collection period ends.

## Test plan
- [x] All unit tests pass (1237 tests)
- [x] Build succeeds with no TypeScript errors
- [ ] Visual verification on desktop: header shows `[undo/redo] | [Reddit] | [help]`
- [ ] Visual verification on mobile (< 768px): title bar shows `[App title] → [Reddit] [Tip]`
- [ ] Click test: both links open Reddit post in new tab
- [ ] Accessibility: links are keyboard navigable and have proper aria-labels