### PR TITLE
feat: expand physical units by default on desktop

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -8,9 +8,11 @@ import { CategoriesPanel } from './CategoriesPanel';
 import { DeferredNumberInput } from '../DeferredNumberInput';
 import { ConfirmDialog } from '../modals/ConfirmDialog';
 import { CollapsibleSection } from '../CollapsibleSection';
+import { useResponsive } from '../../hooks/useResponsive';
 
 export function Sidebar() {
   const [showSaveDefaultsConfirm, setShowSaveDefaultsConfirm] = useState(false);
+  const { isDesktop } = useResponsive();
 
   const { collapsed, toggle, halfBinMode, toggleHalfBinMode } = useUIStore(
     useShallow((state) => ({
@@ -232,7 +234,7 @@ export function Sidebar() {
 
             {/* Physical Units */}
             <div className="px-4 py-4 border-t border-stroke-subtle">
-              <CollapsibleSection title="Physical Units" variant="default" defaultExpanded={false}>
+              <CollapsibleSection title="Physical Units" variant="default" defaultExpanded={isDesktop}>
                 <div className="text-xs text-content-secondary space-y-2">
                   <div className="flex items-center justify-between">
                     <label


### PR DESCRIPTION
## Summary
- Physical Units section in the sidebar now expands by default on desktop (viewport >= 900px)
- Remains collapsed on mobile and tablet to conserve space
- Uses `useResponsive()` hook to detect device type

## Changes
- Import and use `useResponsive` hook in Sidebar component
- Set `defaultExpanded={isDesktop}` for Physical Units CollapsibleSection

## Benefits
- Improves discoverability for desktop users who have ample vertical space
- Maintains compact UI on mobile/tablet where vertical space is limited
- Better UX for users who frequently adjust grid/height units and print bed size

## Test Plan
- [x] Build passes
- [x] ESLint passes
- [ ] Verify Physical Units section is expanded by default on desktop (>= 900px viewport)
- [ ] Verify Physical Units section is collapsed by default on mobile/tablet (< 900px viewport)
- [ ] Verify users can still manually collapse/expand the section