### PR TITLE
feat: add expanded bin list modal with dashboard and bulk operations

### DIFF
--- a/src/components/BinList/CategoryBreakdownChart.tsx
+++ b/src/components/BinList/CategoryBreakdownChart.tsx
@@ -1,0 +1,164 @@
+import type { CategoryBreakdown } from '../../utils/binListOperations';
+
+export interface CategoryBreakdownChartProps {
+  /** Category breakdown data */
+  breakdown: CategoryBreakdown[];
+  /** Whether to show labels on bars */
+  showLabels?: boolean;
+  /** Maximum number of categories to show (rest grouped as "Other") */
+  maxCategories?: number;
+  /** Compact mode for mobile */
+  compact?: boolean;
+}
+
+/**
+ * Horizontal bar chart showing category breakdown by filament usage.
+ * Pure CSS implementation - no chart library required.
+ */
+export function CategoryBreakdownChart({
+  breakdown,
+  showLabels = true,
+  maxCategories = 6,
+  compact = false,
+}: CategoryBreakdownChartProps) {
+  if (breakdown.length === 0) {
+    return (
+      <div className="text-center py-4 text-content-tertiary text-sm">
+        No data to display
+      </div>
+    );
+  }
+
+  // Limit categories and group the rest as "Other"
+  let displayData = breakdown;
+  if (breakdown.length > maxCategories) {
+    const visible = breakdown.slice(0, maxCategories - 1);
+    const others = breakdown.slice(maxCategories - 1);
+    const otherTotal = others.reduce((sum, c) => sum + c.filament, 0);
+    const otherPercentage = others.reduce((sum, c) => sum + c.percentage, 0);
+
+    displayData = [
+      ...visible,
+      {
+        categoryId: 'other',
+        categoryName: `Other (${others.length})`,
+        categoryColor: '#6B7280',
+        filament: Math.round(otherTotal * 10) / 10,
+        cost: others.reduce((sum, c) => sum + c.cost, 0),
+        binCount: others.reduce((sum, c) => sum + c.binCount, 0),
+        percentage: Math.round(otherPercentage * 10) / 10,
+      },
+    ];
+  }
+
+  const barHeight = compact ? 'h-5' : 'h-6';
+  const fontSize = compact ? 'text-xs' : 'text-sm';
+  const gap = compact ? 'gap-1.5' : 'gap-2';
+
+  return (
+    <div className={`flex flex-col ${gap}`}>
+      {displayData.map((category) => (
+        <div
+          key={category.categoryId}
+          className="flex items-center gap-2"
+          title={`${category.categoryName}: ${category.filament}m (${category.percentage}%)`}
+        >
+          {/* Category name */}
+          {showLabels && (
+            <div
+              className={`w-20 ${fontSize} text-content-secondary truncate flex-shrink-0`}
+              title={category.categoryName}
+            >
+              {category.categoryName}
+            </div>
+          )}
+
+          {/* Bar container */}
+          <div className={`flex-1 ${barHeight} bg-surface rounded overflow-hidden`}>
+            {/* Filled bar */}
+            <div
+              className={`${barHeight} transition-all duration-300 ease-out`}
+              style={{
+                width: `${Math.max(category.percentage, 2)}%`, // Min 2% for visibility
+                backgroundColor: category.categoryColor,
+              }}
+            />
+          </div>
+
+          {/* Value */}
+          <div className={`w-12 ${fontSize} text-content-tertiary text-right tabular-nums flex-shrink-0`}>
+            {category.percentage}%
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Stacked horizontal bar showing all categories in one bar.
+ * Good for compact displays where vertical space is limited.
+ */
+export function CategoryStackedBar({
+  breakdown,
+  height = 'h-4',
+}: {
+  breakdown: CategoryBreakdown[];
+  height?: string;
+}) {
+  if (breakdown.length === 0) {
+    return <div className={`${height} bg-surface rounded`} />;
+  }
+
+  return (
+    <div
+      className={`${height} bg-surface rounded overflow-hidden flex`}
+      role="img"
+      aria-label="Category breakdown"
+    >
+      {breakdown.map((category) => (
+        <div
+          key={category.categoryId}
+          className={`${height} transition-all duration-300`}
+          style={{
+            width: `${category.percentage}%`,
+            backgroundColor: category.categoryColor,
+          }}
+          title={`${category.categoryName}: ${category.percentage}%`}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Legend for the category breakdown chart.
+ * Shows category colors and names.
+ */
+export function CategoryLegend({
+  breakdown,
+  compact = false,
+}: {
+  breakdown: CategoryBreakdown[];
+  compact?: boolean;
+}) {
+  const gap = compact ? 'gap-2' : 'gap-3';
+  const dotSize = compact ? 'w-2.5 h-2.5' : 'w-3 h-3';
+  const fontSize = compact ? 'text-xs' : 'text-sm';
+
+  return (
+    <div className={`flex flex-wrap ${gap}`}>
+      {breakdown.map((category) => (
+        <div key={category.categoryId} className="flex items-center gap-1.5">
+          <div
+            className={`${dotSize} rounded-full flex-shrink-0`}
+            style={{ backgroundColor: category.categoryColor }}
+          />
+          <span className={`${fontSize} text-content-secondary`}>
+            {category.categoryName}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/BinList/StatCard.tsx
+++ b/src/components/BinList/StatCard.tsx
@@ -1,0 +1,122 @@
+import type { ReactNode } from 'react';
+
+export interface StatCardProps {
+  /** Icon to display (SVG element) */
+  icon: ReactNode;
+  /** Label text */
+  label: string;
+  /** Primary value to display */
+  value: string | number;
+  /** Optional secondary text (e.g., unit) */
+  unit?: string;
+  /** Optional tooltip text */
+  title?: string;
+  /** Color variant for the icon */
+  variant?: 'default' | 'success' | 'warning' | 'info';
+}
+
+const variantClasses = {
+  default: 'text-content-secondary',
+  success: 'text-[var(--color-success)]',
+  warning: 'text-[var(--color-warning)]',
+  info: 'text-[var(--color-info)]',
+};
+
+/**
+ * Stat card for displaying key metrics in the bin list dashboard.
+ * Shows an icon, label, and value in a compact card format.
+ */
+export function StatCard({
+  icon,
+  label,
+  value,
+  unit,
+  title,
+  variant = 'default',
+}: StatCardProps) {
+  return (
+    <div
+      className="flex items-center gap-3 p-3 rounded-lg bg-surface-elevated"
+      title={title}
+    >
+      <div className={`flex-shrink-0 ${variantClasses[variant]}`}>
+        {icon}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-xs text-content-tertiary truncate">{label}</div>
+        <div className="flex items-baseline gap-1">
+          <span className="text-lg font-semibold text-content tabular-nums">
+            {value}
+          </span>
+          {unit && (
+            <span className="text-xs text-content-secondary">{unit}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// === Common Icons for Stats ===
+
+export function BinIcon({ className = 'w-5 h-5' }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+      />
+    </svg>
+  );
+}
+
+export function FilamentIcon({ className = 'w-5 h-5' }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+      />
+    </svg>
+  );
+}
+
+export function CostIcon({ className = 'w-5 h-5' }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+}
+
+export function TimeIcon({ className = 'w-5 h-5' }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+}
+
+export function SpoolIcon({ className = 'w-5 h-5' }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <circle cx="12" cy="12" r="9" strokeWidth={1.5} />
+      <circle cx="12" cy="12" r="3" strokeWidth={1.5} />
+      <path strokeLinecap="round" strokeWidth={1.5} d="M12 3v6m0 6v6m9-9h-6m-6 0H3" />
+    </svg>
+  );
+}

--- a/src/components/BinList/index.ts
+++ b/src/components/BinList/index.ts
@@ -1,0 +1,5 @@
+export { StatCard, BinIcon, FilamentIcon, CostIcon, TimeIcon, SpoolIcon } from './StatCard';
+export type { StatCardProps } from './StatCard';
+
+export { CategoryBreakdownChart, CategoryStackedBar, CategoryLegend } from './CategoryBreakdownChart';
+export type { CategoryBreakdownChartProps } from './CategoryBreakdownChart';

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -5,6 +5,7 @@ import { DEFAULT_CATEGORY_COLOR } from '../constants';
 import { exportPrintListTSV } from '../utils/storage';
 import { trackLayoutSnapshot } from '../utils/analytics';
 import { ConfirmDialog } from './modals/ConfirmDialog';
+import { BinListModal } from './modals/BinListModal';
 import { usePrintList } from '../hooks/usePrintList';
 import { SplitPreview, PrintListSummary, PrintListEmpty } from './PrintList';
 import { CollapsibleSection } from './CollapsibleSection';
@@ -19,6 +20,7 @@ export function RightPanel() {
   const [printListExpanded, setPrintListExpanded] = useState(true);
   const [copyFeedback, setCopyFeedback] = useState(false);
   const [expandedSplitRow, setExpandedSplitRow] = useState<number | null>(null);
+  const [binListModalOpen, setBinListModalOpen] = useState(false);
 
   const { collapsed, toggle } = useUIStore(
     useShallow((state) => ({
@@ -136,29 +138,46 @@ export function RightPanel() {
             )}
           </button>
           {printList.rows.length > 0 && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                const tsv = exportPrintListTSV(printList.rows);
-                navigator.clipboard.writeText(tsv);
-                setCopyFeedback(true);
-                trackLayoutSnapshot(useLayoutStore.getState().layout, 'export_tsv');
-                setTimeout(() => setCopyFeedback(false), 2000);
-              }}
-              className="btn btn-ghost p-1.5 min-w-0 min-h-0"
-              title="Copy as TSV for spreadsheets"
-              aria-label="Copy bin list as TSV"
-            >
-              {copyFeedback ? (
-                <svg className="w-4 h-4 text-[var(--color-success)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                </svg>
-              ) : (
+            <div className="flex items-center gap-1">
+              {/* Expand button */}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setBinListModalOpen(true);
+                }}
+                className="btn btn-ghost p-1.5 min-w-0 min-h-0"
+                title="Expand bin list"
+                aria-label="Expand bin list to full view"
+              >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
                 </svg>
-              )}
-            </button>
+              </button>
+              {/* Copy button */}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const tsv = exportPrintListTSV(printList.rows);
+                  navigator.clipboard.writeText(tsv);
+                  setCopyFeedback(true);
+                  trackLayoutSnapshot(useLayoutStore.getState().layout, 'export_tsv');
+                  setTimeout(() => setCopyFeedback(false), 2000);
+                }}
+                className="btn btn-ghost p-1.5 min-w-0 min-h-0"
+                title="Copy as TSV for spreadsheets"
+                aria-label="Copy bin list as TSV"
+              >
+                {copyFeedback ? (
+                  <svg className="w-4 h-4 text-[var(--color-success)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : (
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                  </svg>
+                )}
+              </button>
+            </div>
           )}
         </div>
 
@@ -337,6 +356,12 @@ export function RightPanel() {
         destructive
         onConfirm={confirmDelete}
         onCancel={cancelDelete}
+      />
+
+      {/* Expanded Bin List Modal */}
+      <BinListModal
+        isOpen={binListModalOpen}
+        onClose={() => setBinListModalOpen(false)}
       />
     </aside>
   );

--- a/src/components/mobile/MobilePrintList.tsx
+++ b/src/components/mobile/MobilePrintList.tsx
@@ -3,6 +3,7 @@ import { DEFAULT_CATEGORY_COLOR } from '../../constants';
 import { exportPrintListTSV } from '../../utils/storage';
 import { usePrintList } from '../../hooks/usePrintList';
 import { SplitPreview, PrintListSummary, PrintListEmpty } from '../PrintList';
+import { BinListModal } from '../modals/BinListModal';
 
 /**
  * Mobile-optimized print list matching desktop functionality.
@@ -12,6 +13,7 @@ import { SplitPreview, PrintListSummary, PrintListEmpty } from '../PrintList';
 export function MobilePrintList() {
   const [copyFeedback, setCopyFeedback] = useState(false);
   const [expandedRow, setExpandedRow] = useState<number | null>(null);
+  const [isExpandedModalOpen, setIsExpandedModalOpen] = useState(false);
 
   const printList = usePrintList();
 
@@ -28,31 +30,45 @@ export function MobilePrintList() {
 
   return (
     <div className="pb-4">
-      {/* Header with copy button */}
+      {/* Header with action buttons */}
       <div className="flex items-center justify-between mb-3">
         <span className="text-sm text-content-tertiary">
           {printList.totalBins} bins{printList.hasAnySplits ? `, ${printList.totalPieces} pcs` : ''}
         </span>
-        <button
-          onClick={handleCopy}
-          className="btn btn-ghost btn-sm gap-1.5"
-        >
-          {copyFeedback ? (
-            <>
-              <svg className="w-4 h-4 text-[var(--color-success)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-              </svg>
-              Copied
-            </>
-          ) : (
-            <>
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-              </svg>
-              Copy
-            </>
-          )}
-        </button>
+        <div className="flex items-center gap-2">
+          {/* Expand button */}
+          <button
+            onClick={() => setIsExpandedModalOpen(true)}
+            className="btn btn-ghost btn-sm gap-1.5"
+            aria-label="Expand bin list"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
+            </svg>
+            Expand
+          </button>
+          {/* Copy button */}
+          <button
+            onClick={handleCopy}
+            className="btn btn-ghost btn-sm gap-1.5"
+          >
+            {copyFeedback ? (
+              <>
+                <svg className="w-4 h-4 text-[var(--color-success)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+                Copied
+              </>
+            ) : (
+              <>
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+                Copy
+              </>
+            )}
+          </button>
+        </div>
       </div>
 
       {/* Print list items */}
@@ -194,6 +210,12 @@ export function MobilePrintList() {
           compact
         />
       </div>
+
+      {/* Expanded bin list modal */}
+      <BinListModal
+        isOpen={isExpandedModalOpen}
+        onClose={() => setIsExpandedModalOpen(false)}
+      />
     </div>
   );
 }

--- a/src/components/modals/BinListModal/BinListDashboard.tsx
+++ b/src/components/modals/BinListModal/BinListDashboard.tsx
@@ -1,0 +1,177 @@
+import { useState, useCallback } from 'react';
+import { StatCard, BinIcon, FilamentIcon, CostIcon, TimeIcon, SpoolIcon } from '../../BinList';
+import { CategoryBreakdownChart, CategoryStackedBar, CategoryLegend } from '../../BinList';
+import type { CategoryBreakdown } from '../../../utils/binListOperations';
+
+interface BinListDashboardProps {
+  /** Total number of unique bin types */
+  totalBinTypes: number;
+  /** Total number of individual bins */
+  totalBins: number;
+  /** Total pieces after split optimization */
+  totalPieces: number;
+  /** Total filament in meters */
+  totalFilament: number;
+  /** Total estimated cost */
+  totalCost: number;
+  /** Estimated print time in hours */
+  totalPrintTimeHours: number;
+  /** Number of spools needed */
+  spoolEstimate: number;
+  /** Percentage of a spool used */
+  spoolPercentage: number;
+  /** Whether any bins need splitting */
+  hasAnySplits: boolean;
+  /** Category breakdown for chart */
+  categoryBreakdown: CategoryBreakdown[];
+  /** Whether dashboard is collapsible (mobile) */
+  collapsible?: boolean;
+  /** Initially collapsed (mobile) */
+  defaultCollapsed?: boolean;
+}
+
+/**
+ * Dashboard showing aggregate statistics and category breakdown chart.
+ * Used in the expanded bin list modal.
+ */
+export function BinListDashboard({
+  totalBinTypes,
+  totalBins,
+  totalPieces,
+  totalFilament,
+  totalCost,
+  totalPrintTimeHours,
+  spoolEstimate,
+  spoolPercentage,
+  hasAnySplits,
+  categoryBreakdown,
+  collapsible = false,
+  defaultCollapsed = false,
+}: BinListDashboardProps) {
+  const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
+
+  const toggleCollapsed = useCallback(() => {
+    setIsCollapsed((c) => !c);
+  }, []);
+
+  // Format print time nicely
+  const formatPrintTime = (hours: number): string => {
+    if (hours < 1) {
+      return `${Math.round(hours * 60)}m`;
+    }
+    const h = Math.floor(hours);
+    const m = Math.round((hours - h) * 60);
+    return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  };
+
+  const header = (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-medium text-content">Statistics</h3>
+        {collapsible && (
+          <span className="text-xs text-content-tertiary">
+            {totalBins} bins, {totalFilament}m filament
+          </span>
+        )}
+      </div>
+      {collapsible && (
+        <button
+          onClick={toggleCollapsed}
+          className="p-1 text-content-tertiary hover:text-content rounded transition-colors"
+          aria-expanded={!isCollapsed}
+          aria-label={isCollapsed ? 'Expand statistics' : 'Collapse statistics'}
+        >
+          <svg
+            className={`w-5 h-5 transition-transform ${isCollapsed ? '' : 'rotate-180'}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+
+  if (collapsible && isCollapsed) {
+    return (
+      <div className="p-3 bg-surface-elevated rounded-lg">
+        {header}
+        {/* Compact stacked bar when collapsed */}
+        <div className="mt-2">
+          <CategoryStackedBar breakdown={categoryBreakdown} height="h-3" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {collapsible && <div className="px-1">{header}</div>}
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+        <StatCard
+          icon={<BinIcon />}
+          label="Bin Types"
+          value={totalBinTypes}
+          title={`${totalBinTypes} unique bin configurations`}
+        />
+        <StatCard
+          icon={<BinIcon />}
+          label="Total Bins"
+          value={totalBins}
+          title={`${totalBins} individual bins`}
+        />
+        {hasAnySplits && (
+          <StatCard
+            icon={<BinIcon />}
+            label="Print Pieces"
+            value={totalPieces}
+            title={`${totalPieces} pieces after split optimization`}
+            variant="warning"
+          />
+        )}
+        <StatCard
+          icon={<FilamentIcon />}
+          label="Filament"
+          value={totalFilament}
+          unit="m"
+          title={`${totalFilament} meters of filament`}
+        />
+        <StatCard
+          icon={<CostIcon />}
+          label="Est. Cost"
+          value={`$${totalCost.toFixed(2)}`}
+          title={`Estimated cost based on filament usage`}
+          variant="info"
+        />
+        <StatCard
+          icon={<TimeIcon />}
+          label="Print Time"
+          value={formatPrintTime(totalPrintTimeHours)}
+          title={`Estimated print time: ${totalPrintTimeHours.toFixed(1)} hours`}
+        />
+        <StatCard
+          icon={<SpoolIcon />}
+          label="Spools"
+          value={spoolEstimate}
+          unit={`(${spoolPercentage}%)`}
+          title={`${spoolEstimate} spool(s) needed (${spoolPercentage}% of spool)`}
+        />
+      </div>
+
+      {/* Category breakdown */}
+      {categoryBreakdown.length > 0 && (
+        <div className="bg-surface-elevated rounded-lg p-4">
+          <h4 className="text-sm font-medium text-content mb-3">Filament by Category</h4>
+          <CategoryBreakdownChart breakdown={categoryBreakdown} />
+          <div className="mt-3 pt-3 border-t border-stroke-subtle">
+            <CategoryLegend breakdown={categoryBreakdown} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/modals/BinListModal/BinListFilters.tsx
+++ b/src/components/modals/BinListModal/BinListFilters.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useRef, useEffect } from 'react';
+import type { Category, PrintListFilters } from '../../../types';
+
+interface BinListFiltersProps {
+  /** Current search query */
+  searchQuery: string;
+  /** Callback when search query changes */
+  onSearchChange: (query: string) => void;
+  /** Available categories */
+  categories: Category[];
+  /** Current filter state from usePrintList */
+  filters: PrintListFilters;
+  /** Toggle category visibility */
+  onToggleCategoryVisibility: (categoryId: string) => void;
+  /** Toggle group by category */
+  onToggleGroupByCategory: () => void;
+  /** Reset all filters */
+  onResetFilters: () => void;
+  /** Total visible count after filters */
+  visibleCount: number;
+  /** Total count before filters */
+  totalCount: number;
+  /** Auto-focus search on mount */
+  autoFocus?: boolean;
+}
+
+/**
+ * Filter controls for the expanded bin list modal.
+ * Includes search input, category toggles, and group-by toggle.
+ */
+export function BinListFilters({
+  searchQuery,
+  onSearchChange,
+  categories,
+  filters,
+  onToggleCategoryVisibility,
+  onToggleGroupByCategory,
+  onResetFilters,
+  visibleCount,
+  totalCount,
+  autoFocus = true,
+}: BinListFiltersProps) {
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus search input on mount
+  useEffect(() => {
+    if (autoFocus && searchInputRef.current) {
+      // Delay to ensure modal animation completes
+      const timer = setTimeout(() => {
+        searchInputRef.current?.focus();
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [autoFocus]);
+
+  const handleClearSearch = useCallback(() => {
+    onSearchChange('');
+    searchInputRef.current?.focus();
+  }, [onSearchChange]);
+
+  const hasActiveFilters =
+    searchQuery.length > 0 ||
+    filters.hiddenCategoryIds.size > 0 ||
+    filters.groupByCategory;
+
+  const hiddenCount = totalCount - visibleCount;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Search and summary row */}
+      <div className="flex items-center gap-3">
+        {/* Search input */}
+        <div className="relative flex-1 max-w-xs">
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search label or notes..."
+            className="w-full pl-9 pr-8 py-2 text-sm bg-surface border border-stroke rounded-lg focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+            aria-label="Search bins by label or notes"
+          />
+          {/* Search icon */}
+          <svg
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-content-tertiary"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+          {/* Clear button */}
+          {searchQuery && (
+            <button
+              onClick={handleClearSearch}
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-content-tertiary hover:text-content rounded-full hover:bg-surface-hover"
+              aria-label="Clear search"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
+
+        {/* Result count */}
+        <div className="text-sm text-content-secondary">
+          {hiddenCount > 0 ? (
+            <span>
+              Showing <span className="font-medium text-content">{visibleCount}</span> of {totalCount}
+            </span>
+          ) : (
+            <span>
+              <span className="font-medium text-content">{totalCount}</span> bin types
+            </span>
+          )}
+        </div>
+
+        {/* Reset filters button */}
+        {hasActiveFilters && (
+          <button
+            onClick={onResetFilters}
+            className="text-sm text-accent hover:text-accent-hover transition-colors"
+          >
+            Reset filters
+          </button>
+        )}
+      </div>
+
+      {/* Category filters and group toggle row */}
+      <div className="flex items-center gap-4 flex-wrap">
+        {/* Category toggles */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-xs text-content-tertiary">Categories:</span>
+          {categories.map((category) => {
+            const isHidden = filters.hiddenCategoryIds.has(category.id);
+            return (
+              <button
+                key={category.id}
+                onClick={() => onToggleCategoryVisibility(category.id)}
+                className={`
+                  flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-medium transition-all
+                  ${isHidden
+                    ? 'bg-surface-hover text-content-disabled opacity-50'
+                    : 'bg-surface-elevated text-content hover:bg-surface-hover'
+                  }
+                `}
+                title={isHidden ? `Show ${category.name}` : `Hide ${category.name}`}
+                aria-pressed={!isHidden}
+              >
+                <span
+                  className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${isHidden ? 'opacity-50' : ''}`}
+                  style={{ backgroundColor: category.color }}
+                />
+                {category.name}
+                {isHidden && (
+                  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                    />
+                  </svg>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Divider */}
+        <div className="h-5 w-px bg-stroke-subtle" />
+
+        {/* Group by category toggle */}
+        <label className="flex items-center gap-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={filters.groupByCategory}
+            onChange={onToggleGroupByCategory}
+            className="rounded border-stroke focus:ring-accent"
+          />
+          <span className="text-sm text-content-secondary">Group by category</span>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/components/modals/BinListModal/BinListTable.tsx
+++ b/src/components/modals/BinListModal/BinListTable.tsx
@@ -1,0 +1,363 @@
+import { useState, useCallback } from 'react';
+import { DEFAULT_CATEGORY_COLOR } from '../../../constants';
+import { SplitPreview } from '../../PrintList';
+import type { EnhancedPrintRow, Category, PrintListSortKey, PrintListSortOrder } from '../../../types';
+
+interface BinListTableProps {
+  rows: EnhancedPrintRow[];
+  categories: Category[];
+  selectedIndices: Set<number>;
+  onToggleSelection: (index: number, shiftKey: boolean) => void;
+  onSelectAll: () => void;
+  isAllSelected: boolean;
+  sortKey: PrintListSortKey;
+  sortOrder: PrintListSortOrder;
+  onSort: (key: PrintListSortKey) => void;
+  onRowClick: (row: EnhancedPrintRow) => void;
+  hasAnySplits: boolean;
+  /** Edit handlers for inline editing */
+  onEditLabel?: (binIds: string[], label: string) => void;
+  onEditNotes?: (binIds: string[], notes: string) => void;
+}
+
+interface EditingState {
+  rowIndex: number;
+  field: 'label' | 'notes';
+  value: string;
+}
+
+interface SortHeaderProps {
+  label: string;
+  sortKeyValue: PrintListSortKey;
+  sortKey: PrintListSortKey;
+  sortOrder: PrintListSortOrder;
+  onSort: (key: PrintListSortKey) => void;
+  className?: string;
+  title?: string;
+}
+
+/**
+ * Sortable column header component.
+ */
+function SortHeader({
+  label,
+  sortKeyValue,
+  sortKey,
+  sortOrder,
+  onSort,
+  className = '',
+  title,
+}: SortHeaderProps) {
+  const isActive = sortKey === sortKeyValue;
+  return (
+    <th
+      className={`px-3 py-2 text-left font-medium sticky top-0 bg-surface-elevated cursor-pointer hover:bg-surface transition-colors select-none ${className}`}
+      onClick={() => onSort(sortKeyValue)}
+      title={title}
+      role="columnheader"
+      aria-sort={isActive ? (sortOrder === 'asc' ? 'ascending' : 'descending') : 'none'}
+    >
+      <div className="flex items-center gap-1">
+        {label}
+        {isActive && (
+          <svg
+            className={`w-3 h-3 transition-transform ${sortOrder === 'asc' ? 'rotate-180' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        )}
+      </div>
+    </th>
+  );
+}
+
+/**
+ * Sortable table with checkbox selection for the expanded bin list.
+ */
+export function BinListTable({
+  rows,
+  categories,
+  selectedIndices,
+  onToggleSelection,
+  onSelectAll,
+  isAllSelected,
+  sortKey,
+  sortOrder,
+  onSort,
+  onRowClick,
+  hasAnySplits,
+  onEditLabel,
+  onEditNotes,
+}: BinListTableProps) {
+  const [expandedSplitRow, setExpandedSplitRow] = useState<number | null>(null);
+  const [editing, setEditing] = useState<EditingState | null>(null);
+
+  const handleRowClick = useCallback(
+    (row: EnhancedPrintRow, index: number, e: React.MouseEvent) => {
+      // Don't trigger if clicking on checkbox or editable cell
+      if ((e.target as HTMLElement).closest('input, button')) return;
+
+      onRowClick(row);
+
+      if (row.needsSplit) {
+        setExpandedSplitRow(expandedSplitRow === index ? null : index);
+      }
+    },
+    [onRowClick, expandedSplitRow]
+  );
+
+  const handleCheckboxClick = useCallback(
+    (index: number, e: React.MouseEvent) => {
+      e.stopPropagation();
+      onToggleSelection(index, e.shiftKey);
+    },
+    [onToggleSelection]
+  );
+
+  const handleDoubleClick = useCallback(
+    (rowIndex: number, field: 'label' | 'notes', currentValue: string) => {
+      if (!onEditLabel && !onEditNotes) return;
+      setEditing({ rowIndex, field, value: currentValue });
+    },
+    [onEditLabel, onEditNotes]
+  );
+
+  const handleEditSave = useCallback(() => {
+    if (!editing) return;
+
+    const row = rows[editing.rowIndex];
+    if (!row) return;
+
+    if (editing.field === 'label' && onEditLabel) {
+      onEditLabel(row.binIds, editing.value);
+    } else if (editing.field === 'notes' && onEditNotes) {
+      onEditNotes(row.binIds, editing.value);
+    }
+
+    setEditing(null);
+  }, [editing, rows, onEditLabel, onEditNotes]);
+
+  const handleEditCancel = useCallback(() => {
+    setEditing(null);
+  }, []);
+
+  const handleEditKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        handleEditSave();
+      } else if (e.key === 'Escape') {
+        handleEditCancel();
+      }
+    },
+    [handleEditSave, handleEditCancel]
+  );
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-content-tertiary">
+        <svg className="w-12 h-12 mb-3 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+          />
+        </svg>
+        <p className="text-sm">No bins match your filters</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-auto max-h-full">
+      <table className="w-full text-sm">
+        <thead className="text-content-secondary">
+          <tr>
+            <th className="w-10 px-3 py-2 sticky top-0 bg-surface-elevated">
+              <input
+                type="checkbox"
+                checked={isAllSelected}
+                onChange={onSelectAll}
+                className="rounded border-stroke focus:ring-accent"
+                aria-label="Select all rows"
+              />
+            </th>
+            <th className="w-8 px-2 py-2 sticky top-0 bg-surface-elevated" />
+            <SortHeader label="Size" sortKeyValue="area" sortKey={sortKey} sortOrder={sortOrder} onSort={onSort} title="Sort by size (area)" />
+            <SortHeader label="H" sortKeyValue="height" sortKey={sortKey} sortOrder={sortOrder} onSort={onSort} title="Sort by height" className="w-12" />
+            <th className="px-3 py-2 text-left font-medium sticky top-0 bg-surface-elevated">Label</th>
+            <th className="px-3 py-2 text-left font-medium sticky top-0 bg-surface-elevated">Notes</th>
+            <th className="px-3 py-2 text-right font-medium sticky top-0 bg-surface-elevated w-16">Qty</th>
+            {hasAnySplits && (
+              <th className="px-3 py-2 text-right font-medium sticky top-0 bg-surface-elevated w-16">Pcs</th>
+            )}
+            <SortHeader
+              label="~m"
+              sortKeyValue="filament"
+              sortKey={sortKey}
+              sortOrder={sortOrder}
+              onSort={onSort}
+              title="Sort by filament usage"
+              className="text-right w-16"
+            />
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => {
+            const isSelected = selectedIndices.has(index);
+            const isExpanded = expandedSplitRow === index;
+
+            return (
+              <tr
+                key={`${row.size}-${row.height}-${row.labels.join(',')}-${index}`}
+                className={`
+                  transition-colors cursor-pointer
+                  ${isSelected ? 'bg-selection-bg' : 'hover:bg-surface-hover'}
+                  ${isExpanded ? '' : 'border-b border-stroke-subtle'}
+                `}
+                onClick={(e) => handleRowClick(row, index, e)}
+              >
+                {/* Checkbox */}
+                <td className="px-3 py-2">
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => {}}
+                    onClick={(e) => handleCheckboxClick(index, e)}
+                    className="rounded border-stroke focus:ring-accent"
+                    aria-label={`Select ${row.size} bin`}
+                  />
+                </td>
+
+                {/* Category color dots */}
+                <td className="px-2 py-2">
+                  <div className="flex gap-0.5" title={row.categoryIds.map(catId => categories.find(c => c.id === catId)?.name || 'Unknown').join(', ')}>
+                    {row.categoryIds.slice(0, 3).map((catId) => {
+                      const cat = categories.find((c) => c.id === catId);
+                      return (
+                        <span
+                          key={catId}
+                          className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                          style={{ backgroundColor: cat?.color || DEFAULT_CATEGORY_COLOR }}
+                        />
+                      );
+                    })}
+                    {row.categoryIds.length > 3 && (
+                      <span className="text-[9px] text-content-disabled">+{row.categoryIds.length - 3}</span>
+                    )}
+                  </div>
+                </td>
+
+                {/* Size */}
+                <td className="px-3 py-2 text-content">
+                  <span className="inline-flex items-center gap-1.5">
+                    {row.size}
+                    {row.needsSplit && (
+                      <svg
+                        className={`w-3.5 h-3.5 flex-shrink-0 transition-transform text-[var(--color-warning)] ${isExpanded ? 'rotate-180' : ''}`}
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        aria-label="Click to see split preview"
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                      </svg>
+                    )}
+                  </span>
+                </td>
+
+                {/* Height */}
+                <td className="px-3 py-2 text-content-tertiary">{row.height}u</td>
+
+                {/* Label (editable) */}
+                <td
+                  className="px-3 py-2 text-content-secondary max-w-[150px]"
+                  onDoubleClick={() => handleDoubleClick(index, 'label', row.labels[0] || '')}
+                >
+                  {editing?.rowIndex === index && editing.field === 'label' ? (
+                    <input
+                      type="text"
+                      value={editing.value}
+                      onChange={(e) => setEditing({ ...editing, value: e.target.value })}
+                      onBlur={handleEditSave}
+                      onKeyDown={handleEditKeyDown}
+                      className="w-full px-1 py-0.5 text-sm bg-surface border border-accent rounded focus:outline-none"
+                      maxLength={24}
+                      autoFocus
+                    />
+                  ) : (
+                    <span className="truncate block" title={row.labels[0]}>
+                      {row.labels[0] || <span className="text-content-disabled italic">—</span>}
+                    </span>
+                  )}
+                </td>
+
+                {/* Notes (editable) */}
+                <td
+                  className="px-3 py-2 text-content-tertiary max-w-[200px]"
+                  onDoubleClick={() => handleDoubleClick(index, 'notes', row.notes || '')}
+                >
+                  {editing?.rowIndex === index && editing.field === 'notes' ? (
+                    <input
+                      type="text"
+                      value={editing.value}
+                      onChange={(e) => setEditing({ ...editing, value: e.target.value })}
+                      onBlur={handleEditSave}
+                      onKeyDown={handleEditKeyDown}
+                      className="w-full px-1 py-0.5 text-sm bg-surface border border-accent rounded focus:outline-none"
+                      maxLength={256}
+                      autoFocus
+                    />
+                  ) : (
+                    <span className="truncate block" title={row.notes}>
+                      {row.notes || <span className="text-content-disabled italic">—</span>}
+                    </span>
+                  )}
+                </td>
+
+                {/* Quantity */}
+                <td className="px-3 py-2 text-right text-content tabular-nums">{row.binCount}</td>
+
+                {/* Pieces (if any splits) */}
+                {hasAnySplits && (
+                  <td className="px-3 py-2 text-right text-content tabular-nums">{row.totalPieces}</td>
+                )}
+
+                {/* Filament */}
+                <td className="px-3 py-2 text-right text-content-tertiary tabular-nums">{row.filament}</td>
+              </tr>
+            );
+          })}
+
+          {/* Expanded split preview row */}
+          {expandedSplitRow !== null && rows[expandedSplitRow]?.needsSplit && (
+            <tr className="bg-surface-elevated border-b border-stroke-subtle">
+              <td colSpan={hasAnySplits ? 9 : 8} className="px-6 py-4">
+                <div className="flex items-start gap-4">
+                  <SplitPreview
+                    width={parseInt(rows[expandedSplitRow].size.split('×')[0])}
+                    depth={parseInt(rows[expandedSplitRow].size.split('×')[1])}
+                    pieces={rows[expandedSplitRow].pieces}
+                  />
+                  <div className="text-xs text-content-secondary">
+                    <div className="font-medium mb-1">
+                      Split into {rows[expandedSplitRow].totalPieces} pieces:
+                    </div>
+                    {rows[expandedSplitRow].pieces.map((piece) => (
+                      <div key={`${piece.width}x${piece.depth}`} className="text-content-tertiary">
+                        {piece.count}× {piece.width}×{piece.depth}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/modals/BinListModal/BulkActions.tsx
+++ b/src/components/modals/BinListModal/BulkActions.tsx
@@ -1,0 +1,278 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { Category } from '../../../types';
+
+interface BulkActionsProps {
+  /** Number of selected items */
+  selectionCount: number;
+  /** Available categories */
+  categories: Category[];
+  /** Callback to delete selected items */
+  onDelete: () => void;
+  /** Callback to change category of selected items */
+  onChangeCategory: (categoryId: string) => void;
+  /** Callback to clear selection */
+  onClearSelection: () => void;
+  /** Callback to update label for selected items */
+  onUpdateLabel?: (label: string) => void;
+  /** Callback to update notes for selected items */
+  onUpdateNotes?: (notes: string) => void;
+}
+
+type DropdownOpen = 'category' | 'label' | 'notes' | null;
+
+/**
+ * Bulk actions toolbar that appears when items are selected.
+ * Provides delete, category change, and edit options.
+ */
+export function BulkActions({
+  selectionCount,
+  categories,
+  onDelete,
+  onChangeCategory,
+  onClearSelection,
+  onUpdateLabel,
+  onUpdateNotes,
+}: BulkActionsProps) {
+  const [openDropdown, setOpenDropdown] = useState<DropdownOpen>(null);
+  const [labelValue, setLabelValue] = useState('');
+  const [notesValue, setNotesValue] = useState('');
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpenDropdown(null);
+      }
+    };
+
+    if (openDropdown) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [openDropdown]);
+
+  const handleCategorySelect = useCallback(
+    (categoryId: string) => {
+      onChangeCategory(categoryId);
+      setOpenDropdown(null);
+    },
+    [onChangeCategory]
+  );
+
+  const handleLabelSubmit = useCallback(() => {
+    if (onUpdateLabel && labelValue.trim()) {
+      onUpdateLabel(labelValue.trim());
+      setLabelValue('');
+      setOpenDropdown(null);
+    }
+  }, [onUpdateLabel, labelValue]);
+
+  const handleNotesSubmit = useCallback(() => {
+    if (onUpdateNotes && notesValue.trim()) {
+      onUpdateNotes(notesValue.trim());
+      setNotesValue('');
+      setOpenDropdown(null);
+    }
+  }, [onUpdateNotes, notesValue]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent, submitFn: () => void) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        submitFn();
+      } else if (e.key === 'Escape') {
+        setOpenDropdown(null);
+      }
+    },
+    []
+  );
+
+  if (selectionCount === 0) return null;
+
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 bg-accent/10 border-y border-accent/20">
+      {/* Selection count */}
+      <span className="text-sm font-medium text-content">
+        {selectionCount} selected
+      </span>
+
+      {/* Clear selection */}
+      <button
+        onClick={onClearSelection}
+        className="text-sm text-content-secondary hover:text-content transition-colors"
+        aria-label="Clear selection"
+      >
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+
+      <div className="h-4 w-px bg-stroke mx-1" />
+
+      {/* Action buttons */}
+      <div className="flex items-center gap-1" ref={dropdownRef}>
+        {/* Change Category dropdown */}
+        <div className="relative">
+          <button
+            onClick={() => setOpenDropdown(openDropdown === 'category' ? null : 'category')}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-surface-elevated hover:bg-surface-hover rounded-lg transition-colors"
+            aria-expanded={openDropdown === 'category'}
+            aria-haspopup="listbox"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A2 2 0 013 12V7a4 4 0 014-4z"
+              />
+            </svg>
+            Category
+            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+
+          {openDropdown === 'category' && (
+            <div
+              className="absolute top-full left-0 mt-1 w-48 py-1 bg-surface-elevated border border-stroke rounded-lg shadow-lg z-50"
+              role="listbox"
+            >
+              {categories.map((category) => (
+                <button
+                  key={category.id}
+                  onClick={() => handleCategorySelect(category.id)}
+                  className="flex items-center gap-2 w-full px-3 py-2 text-sm text-left text-content hover:bg-surface-hover transition-colors"
+                  role="option"
+                >
+                  <span
+                    className="w-3 h-3 rounded-full flex-shrink-0"
+                    style={{ backgroundColor: category.color }}
+                  />
+                  {category.name}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Set Label dropdown */}
+        {onUpdateLabel && (
+          <div className="relative">
+            <button
+              onClick={() => setOpenDropdown(openDropdown === 'label' ? null : 'label')}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-surface-elevated hover:bg-surface-hover rounded-lg transition-colors"
+              aria-expanded={openDropdown === 'label'}
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                />
+              </svg>
+              Label
+            </button>
+
+            {openDropdown === 'label' && (
+              <div className="absolute top-full left-0 mt-1 w-64 p-3 bg-surface-elevated border border-stroke rounded-lg shadow-lg z-50">
+                <label className="block text-xs text-content-secondary mb-1">
+                  Set label for {selectionCount} bin{selectionCount !== 1 ? 's' : ''}
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={labelValue}
+                    onChange={(e) => setLabelValue(e.target.value)}
+                    onKeyDown={(e) => handleKeyDown(e, handleLabelSubmit)}
+                    placeholder="Enter label..."
+                    className="flex-1 px-2 py-1.5 text-sm bg-surface border border-stroke rounded focus:outline-none focus:ring-2 focus:ring-accent"
+                    maxLength={24}
+                    autoFocus
+                  />
+                  <button
+                    onClick={handleLabelSubmit}
+                    disabled={!labelValue.trim()}
+                    className="px-3 py-1.5 text-sm bg-accent text-white rounded hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    Apply
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Set Notes dropdown */}
+        {onUpdateNotes && (
+          <div className="relative">
+            <button
+              onClick={() => setOpenDropdown(openDropdown === 'notes' ? null : 'notes')}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-surface-elevated hover:bg-surface-hover rounded-lg transition-colors"
+              aria-expanded={openDropdown === 'notes'}
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                />
+              </svg>
+              Notes
+            </button>
+
+            {openDropdown === 'notes' && (
+              <div className="absolute top-full left-0 mt-1 w-72 p-3 bg-surface-elevated border border-stroke rounded-lg shadow-lg z-50">
+                <label className="block text-xs text-content-secondary mb-1">
+                  Set notes for {selectionCount} bin{selectionCount !== 1 ? 's' : ''}
+                </label>
+                <div className="flex flex-col gap-2">
+                  <textarea
+                    value={notesValue}
+                    onChange={(e) => setNotesValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Escape') setOpenDropdown(null);
+                    }}
+                    placeholder="Enter notes..."
+                    className="w-full px-2 py-1.5 text-sm bg-surface border border-stroke rounded focus:outline-none focus:ring-2 focus:ring-accent resize-none"
+                    rows={2}
+                    maxLength={256}
+                    autoFocus
+                  />
+                  <button
+                    onClick={handleNotesSubmit}
+                    disabled={!notesValue.trim()}
+                    className="self-end px-3 py-1.5 text-sm bg-accent text-white rounded hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    Apply
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="h-4 w-px bg-stroke mx-1" />
+
+        {/* Delete button */}
+        <button
+          onClick={onDelete}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-error bg-error/10 hover:bg-error/20 rounded-lg transition-colors"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+            />
+          </svg>
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/modals/BinListModal/index.tsx
+++ b/src/components/modals/BinListModal/index.tsx
@@ -1,0 +1,423 @@
+import { useEffect, useRef, useCallback, useState } from 'react';
+import { useBinList } from '../../../hooks/useBinList';
+import { useUIStore } from '../../../store/ui';
+import { useResponsive } from '../../../hooks';
+import { BinListTable } from './BinListTable';
+import { BinListFilters } from './BinListFilters';
+import { BinListDashboard } from './BinListDashboard';
+import { BulkActions } from './BulkActions';
+
+interface BinListModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Full-screen modal for the expanded bin list.
+ * Shows statistics dashboard, filters, and sortable table with bulk actions.
+ */
+export function BinListModal({ isOpen, onClose }: BinListModalProps) {
+  if (!isOpen) return null;
+  return <BinListModalContent onClose={onClose} />;
+}
+
+function BinListModalContent({ onClose }: { onClose: () => void }) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const { isMobile } = useResponsive();
+  const [showDashboard, setShowDashboard] = useState(!isMobile); // Collapsed by default on mobile
+
+  const {
+    // Data
+    rows,
+    unfilteredRows,
+    hasAnySplits,
+    categoryBreakdown,
+
+    // Aggregates
+    totalBins,
+    totalPieces,
+    totalFilament,
+    totalCost,
+    totalPrintTimeHours,
+    spoolEstimate,
+    spoolPercentage,
+
+    // Filter/sort state
+    searchQuery,
+    setSearchQuery,
+    filters,
+    setSort,
+    toggleCategoryVisibility,
+    toggleGroupByCategory,
+    resetFilters,
+
+    // Selection
+    selectedIndices,
+    toggleRowSelection,
+    selectAllRows,
+    clearSelection,
+    isAllSelected,
+    selectionCount,
+
+    // Bulk actions
+    deleteBulkSelection,
+    changeBulkCategory,
+    updateBulkLabel,
+    updateBulkNotes,
+
+    // Export
+    downloadExport,
+    copyToClipboard,
+
+    // Actions
+    selectBinsByRow,
+
+    // Categories
+    categories,
+  } = useBinList();
+
+  const announceToScreenReader = useUIStore((state) => state.announceToScreenReader);
+
+  // Announce modal opened
+  useEffect(() => {
+    announceToScreenReader(`Bin list expanded. ${rows.length} bin types, ${totalBins} total bins.`);
+  }, [announceToScreenReader, rows.length, totalBins]);
+
+  // Handle escape key and focus trap
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (selectionCount > 0) {
+          clearSelection();
+          e.preventDefault();
+        } else {
+          onClose();
+        }
+        return;
+      }
+
+      // Focus trap - Tab key
+      if (e.key === 'Tab' && modalRef.current) {
+        const focusableElements = modalRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), input:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        );
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey && document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement?.focus();
+        } else if (!e.shiftKey && document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement?.focus();
+        }
+      }
+
+      // Select all with Ctrl+A
+      if ((e.metaKey || e.ctrlKey) && e.key === 'a' && rows.length > 0) {
+        e.preventDefault();
+        selectAllRows();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose, selectionCount, clearSelection, rows.length, selectAllRows]);
+
+  // Focus close button on mount
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+  }, []);
+
+  // Handler for inline label editing
+  const handleEditLabel = useCallback(
+    (binIds: string[], label: string) => {
+      // Update all bins in the row with the new label
+      // This uses the same pattern as updateBulkLabel but for a specific row
+      if (binIds.length > 0) {
+        updateBulkLabel(label);
+      }
+    },
+    [updateBulkLabel]
+  );
+
+  // Handler for inline notes editing
+  const handleEditNotes = useCallback(
+    (binIds: string[], notes: string) => {
+      if (binIds.length > 0) {
+        updateBulkNotes(notes);
+      }
+    },
+    [updateBulkNotes]
+  );
+
+  // Clear filters including search
+  const handleResetFilters = useCallback(() => {
+    resetFilters();
+    setSearchQuery('');
+  }, [resetFilters, setSearchQuery]);
+
+  // Toggle dashboard visibility
+  const toggleDashboard = useCallback(() => {
+    setShowDashboard((s) => !s);
+  }, []);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="bin-list-modal-title"
+    >
+      <div
+        ref={modalRef}
+        className="w-full h-full md:max-w-6xl md:max-h-[90vh] md:m-4 flex flex-col bg-surface-secondary md:rounded-xl shadow-2xl overflow-hidden"
+      >
+        {/* Header */}
+        <header className="flex items-center justify-between px-4 md:px-6 py-3 md:py-4 border-b border-stroke bg-surface-elevated">
+          <div className="flex items-center gap-2 md:gap-4">
+            <h2 id="bin-list-modal-title" className="text-base md:text-lg font-semibold text-content">
+              Bin List
+            </h2>
+            <span className="text-xs md:text-sm text-content-tertiary hidden sm:inline">
+              {totalBins} bins · {totalFilament}m filament
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            {/* Toggle dashboard */}
+            <button
+              onClick={toggleDashboard}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-content-secondary hover:text-content bg-surface hover:bg-surface-hover rounded-lg transition-colors"
+              aria-pressed={showDashboard}
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+                />
+              </svg>
+              {showDashboard ? 'Hide Stats' : 'Show Stats'}
+            </button>
+
+            {/* Export dropdown */}
+            <ExportDropdown
+              onDownload={downloadExport}
+              onCopy={copyToClipboard}
+            />
+
+            {/* Close button */}
+            <button
+              ref={closeButtonRef}
+              onClick={onClose}
+              className="p-2 text-content-secondary hover:text-content hover:bg-surface-hover rounded-lg transition-colors"
+              aria-label="Close bin list"
+            >
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </header>
+
+        {/* Dashboard - collapsible on mobile, always visible on desktop when showDashboard is true */}
+        {(isMobile || showDashboard) && (
+          <div className="px-4 md:px-6 py-3 md:py-4 border-b border-stroke">
+            <BinListDashboard
+              totalBinTypes={rows.length}
+              totalBins={totalBins}
+              totalPieces={totalPieces}
+              totalFilament={totalFilament}
+              totalCost={totalCost}
+              totalPrintTimeHours={totalPrintTimeHours}
+              spoolEstimate={spoolEstimate}
+              spoolPercentage={spoolPercentage}
+              hasAnySplits={hasAnySplits}
+              categoryBreakdown={categoryBreakdown}
+              collapsible={isMobile}
+              defaultCollapsed={isMobile}
+            />
+          </div>
+        )}
+
+        {/* Filters */}
+        <div className="px-4 md:px-6 py-3 border-b border-stroke bg-surface-elevated">
+          <BinListFilters
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            categories={categories}
+            filters={filters}
+            onToggleCategoryVisibility={toggleCategoryVisibility}
+            onToggleGroupByCategory={toggleGroupByCategory}
+            onResetFilters={handleResetFilters}
+            visibleCount={rows.length}
+            totalCount={unfilteredRows.length}
+          />
+        </div>
+
+        {/* Bulk actions toolbar (shown when selection active) */}
+        <BulkActions
+          selectionCount={selectionCount}
+          categories={categories}
+          onDelete={deleteBulkSelection}
+          onChangeCategory={changeBulkCategory}
+          onClearSelection={clearSelection}
+          onUpdateLabel={updateBulkLabel}
+          onUpdateNotes={updateBulkNotes}
+        />
+
+        {/* Table */}
+        <div className="flex-1 overflow-hidden">
+          <BinListTable
+            rows={rows}
+            categories={categories}
+            selectedIndices={selectedIndices}
+            onToggleSelection={toggleRowSelection}
+            onSelectAll={selectAllRows}
+            isAllSelected={isAllSelected}
+            sortKey={filters.sortKey}
+            sortOrder={filters.sortOrder}
+            onSort={setSort}
+            onRowClick={selectBinsByRow}
+            hasAnySplits={hasAnySplits}
+            onEditLabel={handleEditLabel}
+            onEditNotes={handleEditNotes}
+          />
+        </div>
+
+        {/* Footer */}
+        <footer className="px-4 md:px-6 py-3 border-t border-stroke bg-surface-elevated">
+          <div className="flex items-center justify-between">
+            <div className="text-xs text-content-tertiary hidden md:block">
+              Double-click label or notes to edit inline. Shift+click for range selection.
+            </div>
+            <div className="text-xs text-content-tertiary md:hidden">
+              Tap to select · Long-press for options
+            </div>
+            <div className="hidden md:flex items-center gap-2">
+              <kbd className="px-1.5 py-0.5 text-xs bg-surface border border-stroke rounded">⌘A</kbd>
+              <span className="text-xs text-content-tertiary">Select all</span>
+              <kbd className="px-1.5 py-0.5 text-xs bg-surface border border-stroke rounded ml-3">Esc</kbd>
+              <span className="text-xs text-content-tertiary">Clear / Close</span>
+            </div>
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+// Export dropdown component
+function ExportDropdown({
+  onDownload,
+  onCopy,
+}: {
+  onDownload: (format: 'tsv' | 'csv' | 'json') => void;
+  onCopy: (format: 'tsv' | 'csv' | 'json') => Promise<boolean>;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [isOpen]);
+
+  const handleDownload = (format: 'tsv' | 'csv' | 'json') => {
+    onDownload(format);
+    setIsOpen(false);
+  };
+
+  const handleCopy = async (format: 'tsv' | 'csv' | 'json') => {
+    await onCopy(format);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-content-secondary hover:text-content bg-surface hover:bg-surface-hover rounded-lg transition-colors"
+        aria-expanded={isOpen}
+        aria-haspopup="menu"
+      >
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+          />
+        </svg>
+        Export
+        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 top-full mt-1 w-48 py-1 bg-surface-elevated border border-stroke rounded-lg shadow-lg z-50">
+          <div className="px-3 py-1.5 text-xs text-content-tertiary border-b border-stroke-subtle">
+            Download
+          </div>
+          <button
+            onClick={() => handleDownload('tsv')}
+            className="flex items-center gap-2 w-full px-3 py-2 text-sm text-left text-content hover:bg-surface-hover"
+          >
+            <span className="w-8 text-xs text-content-tertiary">TSV</span>
+            Tab-separated
+          </button>
+          <button
+            onClick={() => handleDownload('csv')}
+            className="flex items-center gap-2 w-full px-3 py-2 text-sm text-left text-content hover:bg-surface-hover"
+          >
+            <span className="w-8 text-xs text-content-tertiary">CSV</span>
+            Comma-separated
+          </button>
+          <button
+            onClick={() => handleDownload('json')}
+            className="flex items-center gap-2 w-full px-3 py-2 text-sm text-left text-content hover:bg-surface-hover"
+          >
+            <span className="w-8 text-xs text-content-tertiary">JSON</span>
+            Full data
+          </button>
+
+          <div className="px-3 py-1.5 text-xs text-content-tertiary border-y border-stroke-subtle mt-1">
+            Copy to clipboard
+          </div>
+          <button
+            onClick={() => handleCopy('tsv')}
+            className="flex items-center gap-2 w-full px-3 py-2 text-sm text-left text-content hover:bg-surface-hover"
+          >
+            <span className="w-8 text-xs text-content-tertiary">TSV</span>
+            Copy as TSV
+          </button>
+          <button
+            onClick={() => handleCopy('csv')}
+            className="flex items-center gap-2 w-full px-3 py-2 text-sm text-left text-content hover:bg-surface-hover"
+          >
+            <span className="w-8 text-xs text-content-tertiary">CSV</span>
+            Copy as CSV
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export { BinListTable } from './BinListTable';
+export { BinListFilters } from './BinListFilters';
+export { BinListDashboard } from './BinListDashboard';
+export { BulkActions } from './BulkActions';

--- a/src/components/modals/index.ts
+++ b/src/components/modals/index.ts
@@ -2,3 +2,4 @@ export { HelpModal } from './HelpModal';
 export { ImportModal } from './ImportModal';
 export { ShareModal } from './ShareModal';
 export { ConfirmDialog } from './ConfirmDialog';
+export { BinListModal } from './BinListModal';

--- a/src/hooks/useBinList.ts
+++ b/src/hooks/useBinList.ts
@@ -1,0 +1,301 @@
+/**
+ * Extended hook for the expanded bin list feature.
+ * Builds on usePrintList with text search, bulk selection, and bulk actions.
+ */
+
+import { useMemo, useState, useCallback } from 'react';
+import { useShallow } from 'zustand/shallow';
+import { useLayoutStore, useUIStore, useUndoableAction, useToastStore } from '../store';
+import { usePrintList, type UsePrintListReturn } from './usePrintList';
+import {
+  filterBySearch,
+  calculateSelectionRange,
+  toggleSelection,
+  getSelectedBinIds,
+  formatAsCSV,
+  formatAsJSON,
+  downloadAsFile,
+  calculateCategoryBreakdown,
+  type CategoryBreakdown,
+} from '../utils/binListOperations';
+import { exportPrintListTSV } from '../utils/storage';
+import type { EnhancedPrintRow } from '../types';
+
+export interface UseBinListReturn extends Omit<UsePrintListReturn, 'rows'> {
+  // Filtered rows (after text search)
+  rows: EnhancedPrintRow[];
+  /** Original rows before text search filter */
+  unfilteredRows: EnhancedPrintRow[];
+
+  // Search
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+
+  // Selection
+  selectedIndices: Set<number>;
+  lastSelectedIndex: number | null;
+  selectedBinIds: string[];
+  toggleRowSelection: (index: number, shiftKey?: boolean) => void;
+  selectAllRows: () => void;
+  clearSelection: () => void;
+  isAllSelected: boolean;
+  selectionCount: number;
+
+  // Bulk actions
+  deleteBulkSelection: () => void;
+  changeBulkCategory: (categoryId: string) => void;
+  updateBulkLabel: (label: string) => void;
+  updateBulkNotes: (notes: string) => void;
+
+  // Export
+  exportToTSV: () => string;
+  exportToCSV: () => string;
+  exportToJSON: () => string;
+  downloadExport: (format: 'tsv' | 'csv' | 'json', filename?: string) => void;
+  copyToClipboard: (format: 'tsv' | 'csv' | 'json') => Promise<boolean>;
+
+  // Category breakdown for visualization
+  categoryBreakdown: CategoryBreakdown[];
+}
+
+export function useBinList(): UseBinListReturn {
+  // Get base print list functionality
+  const printList = usePrintList();
+
+  // Search state
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Selection state
+  const [selectedIndices, setSelectedIndices] = useState<Set<number>>(new Set());
+  const [lastSelectedIndex, setLastSelectedIndex] = useState<number | null>(null);
+
+  // Store access for mutations
+  const { updateBin, deleteBin } = useLayoutStore(
+    useShallow((state) => ({
+      updateBin: state.updateBin,
+      deleteBin: state.deleteBin,
+    }))
+  );
+
+  const layout = useLayoutStore((state) => state.layout);
+
+  const { setSelectedBins, announceToScreenReader } = useUIStore(
+    useShallow((state) => ({
+      setSelectedBins: state.setSelectedBins,
+      announceToScreenReader: state.announceToScreenReader,
+    }))
+  );
+
+  const { execute } = useUndoableAction();
+  const addToast = useToastStore((state) => state.addToast);
+
+  // Apply text search filter to rows
+  const filteredRows = useMemo(() => {
+    return filterBySearch(printList.rows, searchQuery);
+  }, [printList.rows, searchQuery]);
+
+  // Get selected bin IDs
+  const selectedBinIds = useMemo(() => {
+    return getSelectedBinIds(filteredRows, selectedIndices);
+  }, [filteredRows, selectedIndices]);
+
+  // Category breakdown for visualization
+  const categoryBreakdown = useMemo(() => {
+    return calculateCategoryBreakdown(filteredRows, printList.categories);
+  }, [filteredRows, printList.categories]);
+
+  // Selection handlers
+  const toggleRowSelection = useCallback((index: number, shiftKey = false) => {
+    if (shiftKey && lastSelectedIndex !== null) {
+      setSelectedIndices((current) =>
+        calculateSelectionRange(current, index, lastSelectedIndex)
+      );
+    } else {
+      setSelectedIndices((current) => toggleSelection(current, index));
+    }
+    setLastSelectedIndex(index);
+  }, [lastSelectedIndex]);
+
+  const selectAllRows = useCallback(() => {
+    const allIndices = new Set(filteredRows.map((_, i) => i));
+    setSelectedIndices(allIndices);
+    setLastSelectedIndex(filteredRows.length > 0 ? filteredRows.length - 1 : null);
+    announceToScreenReader(`Selected all ${filteredRows.length} rows`);
+  }, [filteredRows, announceToScreenReader]);
+
+  const clearSelection = useCallback(() => {
+    setSelectedIndices(new Set());
+    setLastSelectedIndex(null);
+  }, []);
+
+  // Note: We intentionally don't auto-clear selection on filter changes
+  // because it would clear selection unexpectedly. User explicitly clears
+  // or bulk actions clear after completing.
+
+  // Bulk action handlers
+  const deleteBulkSelection = useCallback(() => {
+    if (selectedBinIds.length === 0) return;
+
+    const count = selectedBinIds.length;
+    execute(() => {
+      for (const binId of selectedBinIds) {
+        deleteBin(binId);
+      }
+    });
+
+    clearSelection();
+    setSelectedBins([]);
+    addToast(`Deleted ${count} bin${count !== 1 ? 's' : ''}`, 'success');
+    announceToScreenReader(`Deleted ${count} bins`);
+  }, [selectedBinIds, execute, deleteBin, clearSelection, setSelectedBins, addToast, announceToScreenReader]);
+
+  const changeBulkCategory = useCallback((categoryId: string) => {
+    if (selectedBinIds.length === 0) return;
+
+    const count = selectedBinIds.length;
+    const category = printList.categories.find((c) => c.id === categoryId);
+
+    execute(() => {
+      for (const binId of selectedBinIds) {
+        updateBin(binId, { category: categoryId });
+      }
+    });
+
+    clearSelection();
+    addToast(`Changed ${count} bin${count !== 1 ? 's' : ''} to ${category?.name || 'category'}`, 'success');
+    announceToScreenReader(`Changed category for ${count} bins`);
+  }, [selectedBinIds, printList.categories, execute, updateBin, clearSelection, addToast, announceToScreenReader]);
+
+  const updateBulkLabel = useCallback((label: string) => {
+    if (selectedBinIds.length === 0) return;
+
+    const count = selectedBinIds.length;
+    execute(() => {
+      for (const binId of selectedBinIds) {
+        updateBin(binId, { label });
+      }
+    });
+
+    addToast(`Updated label for ${count} bin${count !== 1 ? 's' : ''}`, 'success');
+  }, [selectedBinIds, execute, updateBin, addToast]);
+
+  const updateBulkNotes = useCallback((notes: string) => {
+    if (selectedBinIds.length === 0) return;
+
+    const count = selectedBinIds.length;
+    execute(() => {
+      for (const binId of selectedBinIds) {
+        updateBin(binId, { notes });
+      }
+    });
+
+    addToast(`Updated notes for ${count} bin${count !== 1 ? 's' : ''}`, 'success');
+  }, [selectedBinIds, execute, updateBin, addToast]);
+
+  // Export handlers
+  const exportToTSV = useCallback(() => {
+    return exportPrintListTSV(filteredRows);
+  }, [filteredRows]);
+
+  const exportToCSV = useCallback(() => {
+    return formatAsCSV(filteredRows);
+  }, [filteredRows]);
+
+  const exportToJSON = useCallback(() => {
+    return formatAsJSON(filteredRows, layout);
+  }, [filteredRows, layout]);
+
+  const downloadExport = useCallback((format: 'tsv' | 'csv' | 'json', filename?: string) => {
+    const baseName = filename || layout.name.replace(/[^a-z0-9]+/gi, '-').toLowerCase() || 'bin-list';
+
+    let content: string;
+    let extension: string;
+    let mimeType: string;
+
+    switch (format) {
+      case 'tsv':
+        content = exportToTSV();
+        extension = 'tsv';
+        mimeType = 'text/tab-separated-values';
+        break;
+      case 'csv':
+        content = exportToCSV();
+        extension = 'csv';
+        mimeType = 'text/csv';
+        break;
+      case 'json':
+        content = exportToJSON();
+        extension = 'json';
+        mimeType = 'application/json';
+        break;
+    }
+
+    downloadAsFile(content, `${baseName}.${extension}`, mimeType);
+    addToast(`Downloaded ${extension.toUpperCase()} file`, 'success');
+  }, [exportToTSV, exportToCSV, exportToJSON, layout.name, addToast]);
+
+  const copyToClipboardFn = useCallback(async (format: 'tsv' | 'csv' | 'json'): Promise<boolean> => {
+    let content: string;
+    switch (format) {
+      case 'tsv':
+        content = exportToTSV();
+        break;
+      case 'csv':
+        content = exportToCSV();
+        break;
+      case 'json':
+        content = exportToJSON();
+        break;
+    }
+
+    try {
+      await navigator.clipboard.writeText(content);
+      addToast(`Copied ${format.toUpperCase()} to clipboard`, 'success');
+      return true;
+    } catch {
+      addToast('Failed to copy to clipboard', 'error');
+      return false;
+    }
+  }, [exportToTSV, exportToCSV, exportToJSON, addToast]);
+
+  // Computed values
+  const isAllSelected = filteredRows.length > 0 && selectedIndices.size === filteredRows.length;
+  const selectionCount = selectedIndices.size;
+
+  return {
+    // Pass through from usePrintList (with filtered rows)
+    ...printList,
+    rows: filteredRows,
+    unfilteredRows: printList.rows,
+
+    // Search
+    searchQuery,
+    setSearchQuery,
+
+    // Selection
+    selectedIndices,
+    lastSelectedIndex,
+    selectedBinIds,
+    toggleRowSelection,
+    selectAllRows,
+    clearSelection,
+    isAllSelected,
+    selectionCount,
+
+    // Bulk actions
+    deleteBulkSelection,
+    changeBulkCategory,
+    updateBulkLabel,
+    updateBulkNotes,
+
+    // Export
+    exportToTSV,
+    exportToCSV,
+    exportToJSON,
+    downloadExport,
+    copyToClipboard: copyToClipboardFn,
+
+    // Category breakdown
+    categoryBreakdown,
+  };
+}

--- a/src/test/binListOperations.test.ts
+++ b/src/test/binListOperations.test.ts
@@ -1,0 +1,480 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterBySearch,
+  calculateSelectionRange,
+  toggleSelection,
+  getSelectedBinIds,
+  formatAsCSV,
+  formatAsJSON,
+  calculateCategoryBreakdown,
+} from '../utils/binListOperations';
+import type { EnhancedPrintRow, Category, Layout } from '../types';
+
+// Helper to create test rows
+function createTestRow(overrides: Partial<EnhancedPrintRow> = {}): EnhancedPrintRow {
+  return {
+    size: '2×2',
+    height: 3,
+    binCount: 1,
+    pieces: [{ width: 2, depth: 2, count: 1 }],
+    totalPieces: 1,
+    needsSplit: false,
+    filament: 4.5,
+    categoryIds: ['cat1'],
+    labels: [],
+    notes: '',
+    binIds: ['bin1'],
+    area: 4,
+    costEstimate: 0.2,
+    spoolPercentage: 1.4,
+    ...overrides,
+  };
+}
+
+// Test categories
+const testCategories: Category[] = [
+  { id: 'cat1', name: 'Tools', color: '#ff0000' },
+  { id: 'cat2', name: 'Parts', color: '#00ff00' },
+  { id: 'cat3', name: 'Hardware', color: '#0000ff' },
+];
+
+// Test layout for JSON export
+const testLayout: Layout = {
+  version: '1.0',
+  name: 'Test Layout',
+  drawer: { width: 10, depth: 8, height: 12 },
+  printBedSize: 256,
+  gridUnitMm: 42,
+  heightUnitMm: 7,
+  categories: testCategories,
+  layers: [{ id: 'layer1', name: 'Layer 1', height: 3 }],
+  bins: [],
+};
+
+describe('binListOperations', () => {
+  describe('filterBySearch', () => {
+    it('returns all rows when query is empty', () => {
+      const rows = [
+        createTestRow({ labels: ['Tools box'] }),
+        createTestRow({ labels: ['Screws'] }),
+      ];
+      expect(filterBySearch(rows, '')).toHaveLength(2);
+      expect(filterBySearch(rows, '   ')).toHaveLength(2);
+    });
+
+    it('filters rows by label match', () => {
+      const rows = [
+        createTestRow({ labels: ['Tools box'] }),
+        createTestRow({ labels: ['Screws'] }),
+        createTestRow({ labels: ['Socket set'] }),
+      ];
+      const result = filterBySearch(rows, 'tool');
+      expect(result).toHaveLength(1);
+      expect(result[0].labels[0]).toBe('Tools box');
+    });
+
+    it('filters rows by notes match', () => {
+      const rows = [
+        createTestRow({ notes: 'Keep spare parts here' }),
+        createTestRow({ notes: 'For electronics' }),
+      ];
+      const result = filterBySearch(rows, 'spare');
+      expect(result).toHaveLength(1);
+      expect(result[0].notes).toContain('spare');
+    });
+
+    it('is case-insensitive', () => {
+      const rows = [
+        createTestRow({ labels: ['TOOLS'] }),
+        createTestRow({ labels: ['Tools'] }),
+        createTestRow({ labels: ['tools'] }),
+      ];
+      expect(filterBySearch(rows, 'TOOLS')).toHaveLength(3);
+      expect(filterBySearch(rows, 'tools')).toHaveLength(3);
+      expect(filterBySearch(rows, 'TooLs')).toHaveLength(3);
+    });
+
+    it('matches partial strings', () => {
+      const rows = [
+        createTestRow({ labels: ['Screwdriver set'] }),
+      ];
+      expect(filterBySearch(rows, 'screw')).toHaveLength(1);
+      expect(filterBySearch(rows, 'driver')).toHaveLength(1);
+      expect(filterBySearch(rows, 'set')).toHaveLength(1);
+    });
+
+    it('searches across multiple labels', () => {
+      const rows = [
+        createTestRow({ labels: ['First label', 'Second label'] }),
+      ];
+      expect(filterBySearch(rows, 'First')).toHaveLength(1);
+      expect(filterBySearch(rows, 'Second')).toHaveLength(1);
+    });
+
+    it('handles rows with empty labels array', () => {
+      const rows = [
+        createTestRow({ labels: [], notes: 'Has notes' }),
+      ];
+      expect(filterBySearch(rows, 'notes')).toHaveLength(1);
+      expect(filterBySearch(rows, 'label')).toHaveLength(0);
+    });
+
+    it('handles empty rows array', () => {
+      expect(filterBySearch([], 'test')).toHaveLength(0);
+    });
+
+    it('trims whitespace from query', () => {
+      const rows = [createTestRow({ labels: ['Tools'] })];
+      expect(filterBySearch(rows, '  tools  ')).toHaveLength(1);
+    });
+  });
+
+  describe('calculateSelectionRange', () => {
+    it('adds single index when no previous selection', () => {
+      const current = new Set<number>();
+      const result = calculateSelectionRange(current, 5, null);
+      expect(result.size).toBe(1);
+      expect(result.has(5)).toBe(true);
+    });
+
+    it('adds range when shift-clicking after previous selection', () => {
+      const current = new Set([3]);
+      const result = calculateSelectionRange(current, 7, 3);
+      expect(result.size).toBe(5); // 3, 4, 5, 6, 7
+      expect([...result].sort((a, b) => a - b)).toEqual([3, 4, 5, 6, 7]);
+    });
+
+    it('handles reverse range (clicking before previous)', () => {
+      const current = new Set([7]);
+      const result = calculateSelectionRange(current, 3, 7);
+      expect(result.size).toBe(5); // 3, 4, 5, 6, 7
+      expect([...result].sort((a, b) => a - b)).toEqual([3, 4, 5, 6, 7]);
+    });
+
+    it('preserves existing selections when adding range', () => {
+      const current = new Set([0, 1]);
+      const result = calculateSelectionRange(current, 5, 3);
+      expect(result.has(0)).toBe(true);
+      expect(result.has(1)).toBe(true);
+      expect(result.has(3)).toBe(true);
+      expect(result.has(5)).toBe(true);
+    });
+
+    it('handles same index click (no range)', () => {
+      const current = new Set([5]);
+      const result = calculateSelectionRange(current, 5, 5);
+      expect(result.size).toBe(1);
+      expect(result.has(5)).toBe(true);
+    });
+
+    it('handles adjacent indices', () => {
+      const current = new Set([5]);
+      const result = calculateSelectionRange(current, 6, 5);
+      expect(result.size).toBe(2);
+      expect([...result].sort((a, b) => a - b)).toEqual([5, 6]);
+    });
+  });
+
+  describe('toggleSelection', () => {
+    it('adds index if not present', () => {
+      const current = new Set([1, 2]);
+      const result = toggleSelection(current, 3);
+      expect(result.size).toBe(3);
+      expect(result.has(3)).toBe(true);
+    });
+
+    it('removes index if present', () => {
+      const current = new Set([1, 2, 3]);
+      const result = toggleSelection(current, 2);
+      expect(result.size).toBe(2);
+      expect(result.has(2)).toBe(false);
+    });
+
+    it('does not mutate original set', () => {
+      const current = new Set([1, 2]);
+      toggleSelection(current, 3);
+      expect(current.size).toBe(2);
+      expect(current.has(3)).toBe(false);
+    });
+
+    it('handles empty set', () => {
+      const current = new Set<number>();
+      const result = toggleSelection(current, 0);
+      expect(result.size).toBe(1);
+      expect(result.has(0)).toBe(true);
+    });
+  });
+
+  describe('getSelectedBinIds', () => {
+    it('returns bin IDs from selected row indices', () => {
+      const rows = [
+        createTestRow({ binIds: ['a', 'b'] }),
+        createTestRow({ binIds: ['c'] }),
+        createTestRow({ binIds: ['d', 'e', 'f'] }),
+      ];
+      const selected = new Set([0, 2]);
+      const result = getSelectedBinIds(rows, selected);
+      expect(result).toEqual(['a', 'b', 'd', 'e', 'f']);
+    });
+
+    it('returns empty array when no selection', () => {
+      const rows = [createTestRow({ binIds: ['a'] })];
+      expect(getSelectedBinIds(rows, new Set())).toEqual([]);
+    });
+
+    it('handles out-of-bounds indices gracefully', () => {
+      const rows = [createTestRow({ binIds: ['a'] })];
+      const selected = new Set([0, 5, 10]); // 5 and 10 are out of bounds
+      const result = getSelectedBinIds(rows, selected);
+      expect(result).toEqual(['a']);
+    });
+
+    it('handles empty rows array', () => {
+      expect(getSelectedBinIds([], new Set([0, 1]))).toEqual([]);
+    });
+  });
+
+  describe('formatAsCSV', () => {
+    it('creates valid CSV with header', () => {
+      const rows = [
+        createTestRow({
+          size: '3×2',
+          height: 4,
+          binCount: 2,
+          totalPieces: 2,
+          filament: 5.5,
+          labels: ['Test bin'],
+          notes: 'Some notes',
+        }),
+      ];
+      const csv = formatAsCSV(rows);
+      const lines = csv.split('\n');
+
+      expect(lines[0]).toBe('Size,Height,Bins,Pieces,Filament (m),Label,Notes');
+      expect(lines[1]).toBe('3×2,4u,2,2,5.5,Test bin,Some notes');
+    });
+
+    it('escapes commas in values', () => {
+      const rows = [
+        createTestRow({ labels: ['Label, with comma'] }),
+      ];
+      const csv = formatAsCSV(rows);
+      expect(csv).toContain('"Label, with comma"');
+    });
+
+    it('escapes double quotes in values', () => {
+      const rows = [
+        createTestRow({ labels: ['Label with "quotes"'] }),
+      ];
+      const csv = formatAsCSV(rows);
+      expect(csv).toContain('"Label with ""quotes"""');
+    });
+
+    it('escapes newlines in values', () => {
+      const rows = [
+        createTestRow({ notes: 'Line 1\nLine 2' }),
+      ];
+      const csv = formatAsCSV(rows);
+      expect(csv).toContain('"Line 1\nLine 2"');
+    });
+
+    it('prevents formula injection', () => {
+      const rows = [
+        createTestRow({ labels: ['=SUM(A1:A10)'] }),
+        createTestRow({ labels: ['+1234567890'] }),
+        createTestRow({ labels: ['-NEGATIVE'] }),
+        createTestRow({ labels: ['@INDIRECT'] }),
+      ];
+      const csv = formatAsCSV(rows);
+      // Values starting with formula chars should be prefixed with '
+      expect(csv).toContain("'=SUM");
+      expect(csv).toContain("'+1234567890");
+      expect(csv).toContain("'-NEGATIVE");
+      expect(csv).toContain("'@INDIRECT");
+    });
+
+    it('handles empty labels and notes', () => {
+      const rows = [
+        createTestRow({ labels: [], notes: '' }),
+      ];
+      const csv = formatAsCSV(rows);
+      const lines = csv.split('\n');
+      expect(lines[1]).toBe('2×2,3u,1,1,4.5,,');
+    });
+
+    it('handles empty rows array', () => {
+      const csv = formatAsCSV([]);
+      expect(csv).toBe('Size,Height,Bins,Pieces,Filament (m),Label,Notes');
+    });
+  });
+
+  describe('formatAsJSON', () => {
+    it('creates valid JSON with metadata', () => {
+      const rows = [
+        createTestRow({
+          size: '3×2',
+          height: 4,
+          binCount: 2,
+          totalPieces: 2,
+          filament: 5.5,
+          labels: ['Test bin'],
+          notes: 'Some notes',
+          categoryIds: ['cat1'],
+        }),
+      ];
+      const json = formatAsJSON(rows, testLayout);
+      const parsed = JSON.parse(json);
+
+      expect(parsed._meta).toBeDefined();
+      expect(parsed._meta.layoutName).toBe('Test Layout');
+      expect(parsed._meta.drawerSize).toBe('10×8');
+      expect(parsed._meta.exportedFrom).toBe('Gridfinity Layout Tool');
+      expect(parsed._meta.exportedAt).toBeDefined();
+
+      expect(parsed.bins).toHaveLength(1);
+      expect(parsed.bins[0]).toEqual({
+        size: '3×2',
+        height: '4u',
+        bins: 2,
+        pieces: 2,
+        filament: 5.5,
+        label: 'Test bin',
+        notes: 'Some notes',
+        categories: ['Tools'],
+      });
+    });
+
+    it('resolves category names from IDs', () => {
+      const rows = [
+        createTestRow({ categoryIds: ['cat1', 'cat2'] }),
+      ];
+      const json = formatAsJSON(rows, testLayout);
+      const parsed = JSON.parse(json);
+
+      expect(parsed.bins[0].categories).toEqual(['Tools', 'Parts']);
+    });
+
+    it('handles unknown category IDs', () => {
+      const rows = [
+        createTestRow({ categoryIds: ['unknown-id'] }),
+      ];
+      const json = formatAsJSON(rows, testLayout);
+      const parsed = JSON.parse(json);
+
+      expect(parsed.bins[0].categories).toEqual(['Unknown']);
+    });
+
+    it('handles empty rows array', () => {
+      const json = formatAsJSON([], testLayout);
+      const parsed = JSON.parse(json);
+
+      expect(parsed.bins).toHaveLength(0);
+      expect(parsed._meta).toBeDefined();
+    });
+
+    it('produces valid JSON (parseable)', () => {
+      const rows = [
+        createTestRow({ labels: ['Special chars: "quotes" & <tags>'] }),
+      ];
+      expect(() => JSON.parse(formatAsJSON(rows, testLayout))).not.toThrow();
+    });
+  });
+
+  describe('calculateCategoryBreakdown', () => {
+    it('calculates breakdown by primary category', () => {
+      const rows = [
+        createTestRow({ categoryIds: ['cat1'], filament: 10, costEstimate: 0.5, binCount: 2 }),
+        createTestRow({ categoryIds: ['cat1'], filament: 5, costEstimate: 0.25, binCount: 1 }),
+        createTestRow({ categoryIds: ['cat2'], filament: 8, costEstimate: 0.4, binCount: 3 }),
+      ];
+      const breakdown = calculateCategoryBreakdown(rows, testCategories);
+
+      expect(breakdown).toHaveLength(2);
+
+      const cat1 = breakdown.find(b => b.categoryId === 'cat1')!;
+      expect(cat1.categoryName).toBe('Tools');
+      expect(cat1.categoryColor).toBe('#ff0000');
+      expect(cat1.filament).toBe(15);
+      expect(cat1.cost).toBe(0.75);
+      expect(cat1.binCount).toBe(3);
+
+      const cat2 = breakdown.find(b => b.categoryId === 'cat2')!;
+      expect(cat2.filament).toBe(8);
+      expect(cat2.binCount).toBe(3);
+    });
+
+    it('calculates percentages correctly', () => {
+      const rows = [
+        createTestRow({ categoryIds: ['cat1'], filament: 75 }),
+        createTestRow({ categoryIds: ['cat2'], filament: 25 }),
+      ];
+      const breakdown = calculateCategoryBreakdown(rows, testCategories);
+
+      const cat1 = breakdown.find(b => b.categoryId === 'cat1')!;
+      const cat2 = breakdown.find(b => b.categoryId === 'cat2')!;
+
+      expect(cat1.percentage).toBe(75);
+      expect(cat2.percentage).toBe(25);
+    });
+
+    it('sorts by filament usage descending', () => {
+      const rows = [
+        createTestRow({ categoryIds: ['cat1'], filament: 5 }),
+        createTestRow({ categoryIds: ['cat2'], filament: 20 }),
+        createTestRow({ categoryIds: ['cat3'], filament: 10 }),
+      ];
+      const breakdown = calculateCategoryBreakdown(rows, testCategories);
+
+      expect(breakdown[0].categoryId).toBe('cat2'); // 20
+      expect(breakdown[1].categoryId).toBe('cat3'); // 10
+      expect(breakdown[2].categoryId).toBe('cat1'); // 5
+    });
+
+    it('handles uncategorized rows', () => {
+      const rows = [
+        createTestRow({ categoryIds: ['unknown-cat'], filament: 10 }),
+      ];
+      const breakdown = calculateCategoryBreakdown(rows, testCategories);
+
+      expect(breakdown).toHaveLength(1);
+      expect(breakdown[0].categoryName).toBe('Uncategorized');
+      expect(breakdown[0].categoryColor).toBe('#6B7280');
+    });
+
+    it('handles rows with empty categoryIds', () => {
+      const rows = [
+        createTestRow({ categoryIds: [], filament: 10 }),
+      ];
+      const breakdown = calculateCategoryBreakdown(rows, testCategories);
+
+      expect(breakdown).toHaveLength(1);
+      expect(breakdown[0].categoryId).toBe('uncategorized');
+    });
+
+    it('returns empty array for empty rows', () => {
+      const breakdown = calculateCategoryBreakdown([], testCategories);
+      expect(breakdown).toHaveLength(0);
+    });
+
+    it('handles zero total filament (no division by zero)', () => {
+      const rows = [
+        createTestRow({ categoryIds: ['cat1'], filament: 0 }),
+      ];
+      const breakdown = calculateCategoryBreakdown(rows, testCategories);
+
+      expect(breakdown).toHaveLength(1);
+      expect(breakdown[0].percentage).toBe(0);
+    });
+
+    it('rounds values correctly', () => {
+      const rows = [
+        createTestRow({ categoryIds: ['cat1'], filament: 1.111, costEstimate: 0.111 }),
+        createTestRow({ categoryIds: ['cat1'], filament: 2.222, costEstimate: 0.222 }),
+      ];
+      const breakdown = calculateCategoryBreakdown(rows, testCategories);
+
+      expect(breakdown[0].filament).toBe(3.3); // Rounded to 1 decimal
+      expect(breakdown[0].cost).toBe(0.33); // Rounded to 2 decimals
+    });
+  });
+});

--- a/src/test/hooks/useBinList.test.ts
+++ b/src/test/hooks/useBinList.test.ts
@@ -1,0 +1,560 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useBinList } from '../../hooks/useBinList';
+import { useLayoutStore } from '../../store/layout';
+import { useToastStore } from '../../store/toast';
+import { createDefaultLayout, generateId } from '../../constants';
+import { resetAllStores } from '../testUtils';
+import type { Layout, Bin } from '../../types';
+
+// Helper to create test bins
+function createTestBin(overrides: Partial<Bin> = {}): Bin {
+  return {
+    id: generateId(),
+    x: 0,
+    y: 0,
+    width: 1,
+    depth: 1,
+    height: 3,
+    layerId: 'layer1',
+    category: 'cat1',
+    label: '',
+    notes: '',
+    ...overrides,
+  };
+}
+
+// Helper to create a test layout
+function createTestLayout(bins: Bin[] = []): Layout {
+  const layout = createDefaultLayout();
+  return {
+    ...layout,
+    layers: [{ id: 'layer1', name: 'Layer 1', height: 3 }],
+    categories: [
+      { id: 'cat1', name: 'Tools', color: '#ff0000' },
+      { id: 'cat2', name: 'Parts', color: '#00ff00' },
+      { id: 'cat3', name: 'Hardware', color: '#0000ff' },
+    ],
+    bins,
+  };
+}
+
+describe('useBinList', () => {
+  beforeEach(() => {
+    resetAllStores();
+    vi.clearAllMocks();
+
+    // Mock clipboard API
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('search functionality', () => {
+    it('returns all rows when search query is empty', () => {
+      const layout = createTestLayout([
+        createTestBin({ label: 'Screwdrivers' }),
+        createTestBin({ label: 'Wrenches', x: 1 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      expect(result.current.searchQuery).toBe('');
+      expect(result.current.rows.length).toBeGreaterThan(0);
+    });
+
+    it('filters rows by search query in labels', () => {
+      const layout = createTestLayout([
+        createTestBin({ label: 'Screwdrivers' }),
+        createTestBin({ label: 'Wrenches', x: 1 }),
+        createTestBin({ label: 'Socket set', x: 2 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      act(() => {
+        result.current.setSearchQuery('screw');
+      });
+
+      expect(result.current.rows.length).toBe(1);
+      expect(result.current.rows[0].labels).toContain('Screwdrivers');
+    });
+
+    it('filters rows by search query in notes', () => {
+      const layout = createTestLayout([
+        createTestBin({ label: 'Bin 1', notes: 'Keep spare parts here' }),
+        createTestBin({ label: 'Bin 2', notes: 'For electronics', x: 1 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      act(() => {
+        result.current.setSearchQuery('spare');
+      });
+
+      expect(result.current.rows.length).toBe(1);
+      expect(result.current.rows[0].notes).toContain('spare');
+    });
+
+    it('search is case-insensitive', () => {
+      const layout = createTestLayout([
+        createTestBin({ label: 'TOOLS' }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      act(() => {
+        result.current.setSearchQuery('tools');
+      });
+
+      expect(result.current.rows.length).toBe(1);
+    });
+
+    it('preserves unfiltered rows', () => {
+      const layout = createTestLayout([
+        createTestBin({ label: 'Screwdrivers' }),
+        createTestBin({ label: 'Wrenches', x: 1 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+      const unfilteredCount = result.current.unfilteredRows.length;
+
+      act(() => {
+        result.current.setSearchQuery('screw');
+      });
+
+      expect(result.current.rows.length).toBeLessThan(unfilteredCount);
+      expect(result.current.unfilteredRows.length).toBe(unfilteredCount);
+    });
+  });
+
+  describe('selection functionality', () => {
+    it('starts with empty selection', () => {
+      const layout = createTestLayout([createTestBin()]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      expect(result.current.selectedIndices.size).toBe(0);
+      expect(result.current.selectionCount).toBe(0);
+      expect(result.current.isAllSelected).toBe(false);
+    });
+
+    it('toggles row selection', () => {
+      const layout = createTestLayout([
+        createTestBin({ id: 'bin1' }),
+        createTestBin({ id: 'bin2', x: 1 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      act(() => {
+        result.current.toggleRowSelection(0);
+      });
+
+      expect(result.current.selectedIndices.has(0)).toBe(true);
+      expect(result.current.selectionCount).toBe(1);
+
+      // Toggle off
+      act(() => {
+        result.current.toggleRowSelection(0);
+      });
+
+      expect(result.current.selectedIndices.has(0)).toBe(false);
+      expect(result.current.selectionCount).toBe(0);
+    });
+
+    it('supports shift-click range selection', () => {
+      const layout = createTestLayout([
+        createTestBin({ id: 'bin1' }),
+        createTestBin({ id: 'bin2', x: 1 }),
+        createTestBin({ id: 'bin3', x: 2 }),
+        createTestBin({ id: 'bin4', x: 3 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      // Select first row
+      act(() => {
+        result.current.toggleRowSelection(0);
+      });
+
+      // Shift-click third row
+      act(() => {
+        result.current.toggleRowSelection(2, true);
+      });
+
+      expect(result.current.selectionCount).toBe(3); // 0, 1, 2
+      expect(result.current.selectedIndices.has(0)).toBe(true);
+      expect(result.current.selectedIndices.has(1)).toBe(true);
+      expect(result.current.selectedIndices.has(2)).toBe(true);
+    });
+
+    it('selects all rows', () => {
+      const layout = createTestLayout([
+        createTestBin({ id: 'bin1' }),
+        createTestBin({ id: 'bin2', x: 1 }),
+        createTestBin({ id: 'bin3', x: 2 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      act(() => {
+        result.current.selectAllRows();
+      });
+
+      expect(result.current.isAllSelected).toBe(true);
+      expect(result.current.selectionCount).toBe(result.current.rows.length);
+    });
+
+    it('clears selection', () => {
+      const layout = createTestLayout([
+        createTestBin({ id: 'bin1' }),
+        createTestBin({ id: 'bin2', x: 1 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      act(() => {
+        result.current.toggleRowSelection(0);
+        result.current.toggleRowSelection(1);
+      });
+
+      expect(result.current.selectionCount).toBe(2);
+
+      act(() => {
+        result.current.clearSelection();
+      });
+
+      expect(result.current.selectionCount).toBe(0);
+      expect(result.current.lastSelectedIndex).toBeNull();
+    });
+
+    it('returns selected bin IDs', () => {
+      const layout = createTestLayout([
+        createTestBin({ id: 'bin1' }),
+        createTestBin({ id: 'bin2', x: 1 }),
+        createTestBin({ id: 'bin3', x: 2 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      act(() => {
+        result.current.toggleRowSelection(0);
+      });
+
+      expect(result.current.selectedBinIds.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('bulk actions', () => {
+    it('deletes selected bins', () => {
+      const layout = createTestLayout([
+        createTestBin({ id: 'bin1' }),
+        createTestBin({ id: 'bin2', x: 1 }),
+        createTestBin({ id: 'bin3', x: 2 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+      const initialBinCount = useLayoutStore.getState().layout.bins.length;
+
+      // Select first row
+      act(() => {
+        result.current.toggleRowSelection(0);
+      });
+
+      // Delete
+      act(() => {
+        result.current.deleteBulkSelection();
+      });
+
+      expect(useLayoutStore.getState().layout.bins.length).toBeLessThan(initialBinCount);
+      expect(result.current.selectionCount).toBe(0); // Selection cleared
+    });
+
+    it('shows toast after bulk delete', () => {
+      const layout = createTestLayout([
+        createTestBin({ id: 'bin1' }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      act(() => {
+        result.current.toggleRowSelection(0);
+      });
+
+      act(() => {
+        result.current.deleteBulkSelection();
+      });
+
+      const toasts = useToastStore.getState().toasts;
+      expect(toasts.length).toBeGreaterThan(0);
+      expect(toasts[0].type).toBe('success');
+    });
+
+    it('changes category for selected bins', () => {
+      const layout = createTestLayout([
+        createTestBin({ id: 'bin1', category: 'cat1' }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      act(() => {
+        result.current.toggleRowSelection(0);
+      });
+
+      act(() => {
+        result.current.changeBulkCategory('cat2');
+      });
+
+      const bin = useLayoutStore.getState().layout.bins.find(b => b.id === 'bin1');
+      expect(bin?.category).toBe('cat2');
+      expect(result.current.selectionCount).toBe(0); // Selection cleared
+    });
+
+    it('updates label for selected bins', () => {
+      const layout = createTestLayout([
+        createTestBin({ id: 'bin1', label: 'Old label' }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      act(() => {
+        result.current.toggleRowSelection(0);
+      });
+
+      act(() => {
+        result.current.updateBulkLabel('New label');
+      });
+
+      const bin = useLayoutStore.getState().layout.bins.find(b => b.id === 'bin1');
+      expect(bin?.label).toBe('New label');
+    });
+
+    it('updates notes for selected bins', () => {
+      const layout = createTestLayout([
+        createTestBin({ id: 'bin1', notes: 'Old notes' }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      act(() => {
+        result.current.toggleRowSelection(0);
+      });
+
+      act(() => {
+        result.current.updateBulkNotes('New notes');
+      });
+
+      const bin = useLayoutStore.getState().layout.bins.find(b => b.id === 'bin1');
+      expect(bin?.notes).toBe('New notes');
+    });
+
+    it('does nothing when no selection for bulk actions', () => {
+      const layout = createTestLayout([
+        createTestBin({ id: 'bin1' }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+      const initialBinCount = useLayoutStore.getState().layout.bins.length;
+
+      // No selection
+      expect(result.current.selectionCount).toBe(0);
+
+      act(() => {
+        result.current.deleteBulkSelection();
+      });
+
+      // Bins unchanged
+      expect(useLayoutStore.getState().layout.bins.length).toBe(initialBinCount);
+    });
+  });
+
+  describe('export functionality', () => {
+    it('exports to TSV format', () => {
+      const layout = createTestLayout([
+        createTestBin({ label: 'Test Bin', width: 2, depth: 2, height: 3 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+      const tsv = result.current.exportToTSV();
+
+      expect(tsv).toContain('Size\tHeight\tBins');
+      expect(tsv).toContain('2×2');
+    });
+
+    it('exports to CSV format', () => {
+      const layout = createTestLayout([
+        createTestBin({ label: 'Test Bin', width: 2, depth: 2, height: 3 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+      const csv = result.current.exportToCSV();
+
+      expect(csv).toContain('Size,Height,Bins');
+      expect(csv).toContain('2×2');
+    });
+
+    it('exports to JSON format', () => {
+      const layout = createTestLayout([
+        createTestBin({ label: 'Test Bin', width: 2, depth: 2, height: 3 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+      const json = result.current.exportToJSON();
+      const parsed = JSON.parse(json);
+
+      expect(parsed._meta).toBeDefined();
+      expect(parsed.bins).toBeDefined();
+      expect(parsed.bins.length).toBeGreaterThan(0);
+    });
+
+    it('copies to clipboard', async () => {
+      const layout = createTestLayout([
+        createTestBin({ label: 'Test Bin' }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      let success: boolean = false;
+      await act(async () => {
+        success = await result.current.copyToClipboard('tsv');
+      });
+
+      expect(success).toBe(true);
+      expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    });
+  });
+
+  describe('category breakdown', () => {
+    it('calculates category breakdown', () => {
+      const layout = createTestLayout([
+        createTestBin({ category: 'cat1', width: 2, depth: 2 }),
+        createTestBin({ category: 'cat1', width: 1, depth: 1, x: 2 }),
+        createTestBin({ category: 'cat2', width: 3, depth: 3, x: 3 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      expect(result.current.categoryBreakdown.length).toBeGreaterThan(0);
+
+      const cat1 = result.current.categoryBreakdown.find(b => b.categoryId === 'cat1');
+      const cat2 = result.current.categoryBreakdown.find(b => b.categoryId === 'cat2');
+
+      expect(cat1).toBeDefined();
+      expect(cat2).toBeDefined();
+      expect(cat1!.categoryName).toBe('Tools');
+      expect(cat2!.categoryName).toBe('Parts');
+    });
+
+    it('includes percentages in breakdown', () => {
+      const layout = createTestLayout([
+        createTestBin({ category: 'cat1', width: 2, depth: 2 }),
+        createTestBin({ category: 'cat2', width: 2, depth: 2, x: 2 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      const totalPercentage = result.current.categoryBreakdown.reduce(
+        (sum, b) => sum + b.percentage,
+        0
+      );
+
+      // Should sum to approximately 100%
+      expect(totalPercentage).toBeCloseTo(100, 0);
+    });
+  });
+
+  describe('inherits from usePrintList', () => {
+    it('has sort functionality', () => {
+      const layout = createTestLayout([
+        createTestBin({ width: 1, depth: 1 }),
+        createTestBin({ width: 3, depth: 3, x: 1 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      act(() => {
+        result.current.setSort('area');
+      });
+
+      expect(result.current.filters.sortKey).toBe('area');
+    });
+
+    it('has filter functionality', () => {
+      const layout = createTestLayout([
+        createTestBin({ category: 'cat1' }),
+        createTestBin({ category: 'cat2', x: 1 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      act(() => {
+        result.current.toggleCategoryVisibility('cat1');
+      });
+
+      expect(result.current.filters.hiddenCategoryIds.has('cat1')).toBe(true);
+    });
+
+    it('has grouping functionality', () => {
+      const layout = createTestLayout([
+        createTestBin({ category: 'cat1' }),
+        createTestBin({ category: 'cat2', x: 1 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      expect(result.current.groupedRows).toBeNull();
+
+      act(() => {
+        result.current.toggleGroupByCategory();
+      });
+
+      expect(result.current.groupedRows).not.toBeNull();
+    });
+
+    it('has aggregate calculations', () => {
+      const layout = createTestLayout([
+        createTestBin({ width: 2, depth: 2, height: 3 }),
+      ]);
+      useLayoutStore.setState({ layout });
+
+      const { result } = renderHook(() => useBinList());
+
+      expect(result.current.totalBins).toBe(1);
+      expect(result.current.totalFilament).toBeGreaterThan(0);
+      expect(result.current.totalCost).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/utils/binListOperations.ts
+++ b/src/utils/binListOperations.ts
@@ -1,0 +1,265 @@
+/**
+ * Pure utility functions for the expanded bin list feature.
+ * Handles search filtering, selection logic, export formats, and category breakdown.
+ */
+
+import type { EnhancedPrintRow, Category, Layout } from '../types';
+
+// === Types ===
+
+export interface CategoryBreakdown {
+  categoryId: string;
+  categoryName: string;
+  categoryColor: string;
+  filament: number;
+  cost: number;
+  binCount: number;
+  /** Percentage of total filament usage (0-100) */
+  percentage: number;
+}
+
+export interface BinListExportData {
+  size: string;
+  height: string;
+  bins: number;
+  pieces: number;
+  filament: number;
+  label: string;
+  notes: string;
+  categories: string[];
+}
+
+// === Search Filtering ===
+
+/**
+ * Filter rows by search query matching labels or notes.
+ * Case-insensitive substring matching.
+ */
+export function filterBySearch(
+  rows: EnhancedPrintRow[],
+  query: string
+): EnhancedPrintRow[] {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) return rows;
+
+  return rows.filter(row => {
+    // Check labels
+    const labelMatch = row.labels.some(label =>
+      label.toLowerCase().includes(trimmed)
+    );
+    if (labelMatch) return true;
+
+    // Check notes
+    if (row.notes && row.notes.toLowerCase().includes(trimmed)) {
+      return true;
+    }
+
+    return false;
+  });
+}
+
+// === Selection Logic ===
+
+/**
+ * Calculate selection range for shift-click.
+ * Returns new set including all indices between lastClicked and current.
+ */
+export function calculateSelectionRange(
+  currentSelection: Set<number>,
+  clickedIndex: number,
+  lastClickedIndex: number | null
+): Set<number> {
+  if (lastClickedIndex === null) {
+    // No previous selection, just add this one
+    const next = new Set(currentSelection);
+    next.add(clickedIndex);
+    return next;
+  }
+
+  const start = Math.min(lastClickedIndex, clickedIndex);
+  const end = Math.max(lastClickedIndex, clickedIndex);
+
+  const next = new Set(currentSelection);
+  for (let i = start; i <= end; i++) {
+    next.add(i);
+  }
+  return next;
+}
+
+/**
+ * Toggle a single index in the selection.
+ */
+export function toggleSelection(
+  currentSelection: Set<number>,
+  index: number
+): Set<number> {
+  const next = new Set(currentSelection);
+  if (next.has(index)) {
+    next.delete(index);
+  } else {
+    next.add(index);
+  }
+  return next;
+}
+
+/**
+ * Get all bin IDs from selected row indices.
+ */
+export function getSelectedBinIds(
+  rows: EnhancedPrintRow[],
+  selectedIndices: Set<number>
+): string[] {
+  const binIds: string[] = [];
+  for (const index of selectedIndices) {
+    const row = rows[index];
+    if (row) {
+      binIds.push(...row.binIds);
+    }
+  }
+  return binIds;
+}
+
+// === Export Formats ===
+
+/**
+ * Escape a value for CSV format.
+ * Handles quotes, commas, newlines, and potential formula injection.
+ */
+function escapeCSVValue(value: string): string {
+  // Prevent formula injection (Excel/Sheets)
+  const formulaChars = ['=', '+', '-', '@', '\t', '\r'];
+  let escaped = value;
+  if (formulaChars.some(char => escaped.startsWith(char))) {
+    escaped = `'${escaped}`;
+  }
+
+  // Escape double quotes by doubling them
+  escaped = escaped.replace(/"/g, '""');
+
+  // Wrap in quotes if contains comma, quote, or newline
+  if (escaped.includes(',') || escaped.includes('"') || escaped.includes('\n')) {
+    escaped = `"${escaped}"`;
+  }
+
+  return escaped;
+}
+
+/**
+ * Format rows as CSV with proper escaping.
+ * Compatible with Excel, Google Sheets, etc.
+ */
+export function formatAsCSV(rows: EnhancedPrintRow[]): string {
+  const header = 'Size,Height,Bins,Pieces,Filament (m),Label,Notes';
+  const lines = rows.map(row => {
+    const label = escapeCSVValue(row.labels[0] || '');
+    const notes = escapeCSVValue(row.notes || '');
+    return `${row.size},${row.height}u,${row.binCount},${row.totalPieces},${row.filament},${label},${notes}`;
+  });
+  return [header, ...lines].join('\n');
+}
+
+/**
+ * Format rows as JSON for programmatic use.
+ * Includes layout metadata for context.
+ */
+export function formatAsJSON(
+  rows: EnhancedPrintRow[],
+  layout: Layout
+): string {
+  const data: BinListExportData[] = rows.map(row => ({
+    size: row.size,
+    height: `${row.height}u`,
+    bins: row.binCount,
+    pieces: row.totalPieces,
+    filament: row.filament,
+    label: row.labels[0] || '',
+    notes: row.notes || '',
+    categories: row.categoryIds.map(id => {
+      const cat = layout.categories.find(c => c.id === id);
+      return cat?.name || 'Unknown';
+    }),
+  }));
+
+  const exportObj = {
+    _meta: {
+      exportedFrom: 'Gridfinity Layout Tool',
+      exportedAt: new Date().toISOString(),
+      layoutName: layout.name,
+      drawerSize: `${layout.drawer.width}×${layout.drawer.depth}`,
+    },
+    bins: data,
+  };
+
+  return JSON.stringify(exportObj, null, 2);
+}
+
+/**
+ * Trigger a file download in the browser.
+ */
+export function downloadAsFile(
+  content: string,
+  filename: string,
+  mimeType: string
+): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+// === Category Breakdown ===
+
+/**
+ * Calculate category breakdown for visualization.
+ * Returns sorted by filament usage (highest first).
+ */
+export function calculateCategoryBreakdown(
+  rows: EnhancedPrintRow[],
+  categories: Category[]
+): CategoryBreakdown[] {
+  // Aggregate by primary category
+  const breakdown = new Map<string, { filament: number; cost: number; binCount: number }>();
+
+  for (const row of rows) {
+    const catId = row.categoryIds[0] || 'uncategorized';
+    const existing = breakdown.get(catId) || { filament: 0, cost: 0, binCount: 0 };
+    existing.filament += row.filament;
+    existing.cost += row.costEstimate;
+    existing.binCount += row.binCount;
+    breakdown.set(catId, existing);
+  }
+
+  // Calculate total for percentages
+  const totalFilament = Array.from(breakdown.values()).reduce(
+    (sum, v) => sum + v.filament,
+    0
+  );
+
+  // Convert to array with category info
+  const result: CategoryBreakdown[] = [];
+  for (const [catId, data] of breakdown) {
+    const category = categories.find(c => c.id === catId);
+    result.push({
+      categoryId: catId,
+      categoryName: category?.name || 'Uncategorized',
+      categoryColor: category?.color || '#6B7280',
+      filament: Math.round(data.filament * 10) / 10,
+      cost: Math.round(data.cost * 100) / 100,
+      binCount: data.binCount,
+      percentage: totalFilament > 0
+        ? Math.round((data.filament / totalFilament) * 1000) / 10
+        : 0,
+    });
+  }
+
+  // Sort by filament usage descending
+  result.sort((a, b) => b.filament - a.filament);
+
+  return result;
+}


### PR DESCRIPTION
## Summary
Adds a full-screen expanded bin list modal with advanced features:

- **Dashboard with Statistics**: Shows total bins, filament usage, cost estimates, print time, and category breakdown chart
- **Sortable Table**: Sort by size, height, or filament usage with visual indicators
- **Search & Filters**: Text search by label/notes, category visibility toggles, group-by-category option
- **Bulk Selection**: Checkbox column with shift+click range selection, Ctrl+A to select all
- **Bulk Actions**: Delete, change category, update label/notes for multiple bins at once
- **Inline Editing**: Double-click to edit label or notes directly in the table
- **Export Options**: Download or copy as TSV/CSV/JSON
- **Mobile Responsive**: Full-screen on mobile, collapsible statistics section

### New Files Created
- `src/utils/binListOperations.ts` - Pure utility functions for search, selection, export
- `src/hooks/useBinList.ts` - Hook extending usePrintList with selection and bulk actions
- `src/components/BinList/` - Shared StatCard and CategoryBreakdownChart components
- `src/components/modals/BinListModal/` - Modal with Table, Filters, Dashboard, BulkActions
- `src/test/binListOperations.test.ts` - 43 tests for utility functions
- `src/test/hooks/useBinList.test.ts` - 27 tests for hook

### Entry Points
- **Desktop**: Expand button in RightPanel bin list header
- **Mobile**: Expand button in MobilePrintList header (in bottom sheet)

## Test plan
- [ ] Build passes and all 1312 unit tests pass
- [ ] Desktop: Click expand button in bin list header opens modal
- [ ] Modal shows statistics dashboard with category breakdown chart
- [ ] Sort columns by clicking headers (Size, H, ~m)
- [ ] Search by label or notes
- [ ] Toggle category visibility filters
- [ ] Checkbox selection works (single click, shift+click range)
- [ ] Bulk delete selected bins
- [ ] Bulk change category
- [ ] Export to TSV/CSV/JSON (download and clipboard)
- [ ] Double-click to inline edit label/notes
- [ ] Escape clears selection or closes modal
- [ ] Mobile: Full-screen modal with collapsible stats