### PR TITLE
fix: address e2e test failures and Copilot review comments

### DIFF
--- a/e2e/add-bins.spec.ts
+++ b/e2e/add-bins.spec.ts
@@ -48,8 +48,9 @@ test.describe('Add Bins Flow', () => {
   });
 
   test('can select a bin size from palette', async ({ page }) => {
-    // Find the bin palette section
-    await expect(page.getByRole('heading', { name: 'Bin Palette' })).toBeVisible();
+    // Find the bin palette section (CollapsibleSection uses button with text, not heading)
+    const sidebar = getSidebar(page);
+    await expect(sidebar.getByRole('button', { name: /Bin Palette/i })).toBeVisible();
 
     // Click on a 2x2 square size button
     await selectBinSize(page, 2, 2);

--- a/e2e/create-layout.spec.ts
+++ b/e2e/create-layout.spec.ts
@@ -84,8 +84,26 @@ test.describe('Create Layout Flow', () => {
     // Wait for the UI to update with the new name
     await expect(page.getByRole('button', { name: 'Persisted Layout' })).toBeVisible();
 
-    // Wait for auto-save to complete (observes actual localStorage state)
-    await waitForAutoSave(page);
+    // Wait for auto-save debounce (1000ms) to complete
+    await waitForAutoSave(page, 3000);
+
+    // Extra wait to ensure the debounce has fired and saved
+    await page.waitForTimeout(1500);
+
+    // Verify the layout name is saved in localStorage before reloading
+    await page.waitForFunction(
+      () => {
+        const library = localStorage.getItem('gridfinity-library-v1');
+        if (!library) return false;
+        const parsed = JSON.parse(library);
+        const activeId = parsed.activeLayoutId;
+        const layoutData = localStorage.getItem(`gridfinity-layout-${activeId}`);
+        if (!layoutData) return false;
+        const layout = JSON.parse(layoutData);
+        return layout.name === 'Persisted Layout';
+      },
+      { timeout: 5000 }
+    );
 
     // Reload page (DON'T clear localStorage this time since we want to test persistence)
     await page.reload();

--- a/e2e/drawer-settings.spec.ts
+++ b/e2e/drawer-settings.spec.ts
@@ -31,29 +31,29 @@ test.describe('Drawer Settings', () => {
   test('grid settings section is visible in sidebar', async ({ page }) => {
     const sidebar = getSidebar(page);
 
-    // Grid Settings is at the bottom of the sidebar - scroll it into view
-    const gridSettingsHeading = sidebar.getByText('Grid Settings');
-    await gridSettingsHeading.scrollIntoViewIfNeeded();
-    await expect(gridSettingsHeading).toBeVisible({ timeout: 10000 });
+    // Grid Size section contains drawer dimensions
+    const gridSizeButton = sidebar.getByRole('button', { name: /Grid Size/i });
+    await gridSizeButton.scrollIntoViewIfNeeded();
+    await expect(gridSizeButton).toBeVisible({ timeout: 10000 });
 
-    // Scroll to the bottom label to ensure all settings are visible
-    const heightLabel = sidebar.getByText('1u height');
-    await heightLabel.scrollIntoViewIfNeeded();
+    // Physical Units section contains unit settings
+    const physicalUnitsButton = sidebar.getByRole('button', { name: /Physical Units/i });
+    await physicalUnitsButton.scrollIntoViewIfNeeded();
+    await expect(physicalUnitsButton).toBeVisible({ timeout: 5000 });
 
-    // Now verify all setting labels are present (use exact match to avoid "Print bed: 256mm" in preferences)
-    await expect(sidebar.getByText('Max height')).toBeVisible({ timeout: 5000 });
-    await expect(sidebar.getByText('Print bed', { exact: true })).toBeVisible({ timeout: 5000 });
-    await expect(sidebar.getByText('1 grid unit')).toBeVisible({ timeout: 5000 });
-    await expect(heightLabel).toBeVisible({ timeout: 5000 });
+    // Verify setting labels are present (use exact match to avoid partial matches)
+    await expect(sidebar.getByText('Width', { exact: true })).toBeVisible({ timeout: 5000 });
+    await expect(sidebar.getByText('Depth', { exact: true })).toBeVisible({ timeout: 5000 });
+    await expect(sidebar.getByText('Height', { exact: true })).toBeVisible({ timeout: 5000 });
   });
 
-  test('can increase max height', async ({ page }) => {
+  test('can increase height', async ({ page }) => {
     const sidebar = getSidebar(page);
 
     // The max height is displayed between the +/- buttons with min-w-[28px]
     // It's the only span with that width class showing "Nu" format in the Grid Settings section
-    const increaseButton = sidebar.getByRole('button', { name: /increase max height/i });
-    const decreaseButton = sidebar.getByRole('button', { name: /decrease max height/i });
+    const increaseButton = sidebar.getByRole('button', { name: /increase height/i });
+    const decreaseButton = sidebar.getByRole('button', { name: /decrease height/i });
 
     // Get parent container of the buttons to find the height display
     // The height display is between decrease and increase buttons
@@ -72,11 +72,11 @@ test.describe('Drawer Settings', () => {
     }).toPass({ timeout: 2000 });
   });
 
-  test('can decrease max height', async ({ page }) => {
+  test('can decrease height', async ({ page }) => {
     const sidebar = getSidebar(page);
 
-    const increaseButton = sidebar.getByRole('button', { name: /increase max height/i });
-    const decreaseButton = sidebar.getByRole('button', { name: /decrease max height/i });
+    const increaseButton = sidebar.getByRole('button', { name: /increase height/i });
+    const decreaseButton = sidebar.getByRole('button', { name: /decrease height/i });
 
     // First increase height to ensure we can decrease
     await increaseButton.click();
@@ -107,7 +107,7 @@ test.describe('Drawer Settings', () => {
   test('max height has minimum constraint', async ({ page }) => {
     const sidebar = getSidebar(page);
 
-    const decreaseButton = sidebar.getByRole('button', { name: /decrease max height/i });
+    const decreaseButton = sidebar.getByRole('button', { name: /decrease height/i });
     const heightDisplay = decreaseButton.locator('+ span');
 
     // Decrease 15 times to approach minimum
@@ -212,8 +212,26 @@ test.describe('Drawer Settings', () => {
     await gridUnitInput.blur();
     await expect(gridUnitInput).toHaveValue('45');
 
-    // Wait for auto-save to complete (observes actual localStorage state)
-    await waitForAutoSave(page);
+    // Wait for auto-save debounce (1000ms) to complete
+    await waitForAutoSave(page, 3000);
+
+    // Extra wait to ensure the debounce has fired and saved
+    await page.waitForTimeout(1500);
+
+    // Verify settings are saved in localStorage before reloading
+    await page.waitForFunction(
+      () => {
+        const library = localStorage.getItem('gridfinity-library-v1');
+        if (!library) return false;
+        const parsed = JSON.parse(library);
+        const activeId = parsed.activeLayoutId;
+        const layoutData = localStorage.getItem(`gridfinity-layout-${activeId}`);
+        if (!layoutData) return false;
+        const layout = JSON.parse(layoutData);
+        return layout.printBedSize === 180 && layout.gridUnitMm === 45;
+      },
+      { timeout: 5000 }
+    );
 
     // Reload the page
     await page.reload();
@@ -234,7 +252,7 @@ test.describe('Drawer Settings', () => {
 
     // Increase max height several times
     const sidebar = getSidebar(page);
-    const increaseMaxHeight = sidebar.getByRole('button', { name: /increase max height/i });
+    const increaseMaxHeight = sidebar.getByRole('button', { name: /increase height/i });
 
     for (let i = 0; i < 3; i++) {
       await increaseMaxHeight.click();
@@ -243,8 +261,8 @@ test.describe('Drawer Settings', () => {
     // Verify bin is still present (max height increase shouldn't remove bins)
     await waitForBinCount(page, 1);
 
-    // Now decrease max height
-    const decreaseMaxHeight = sidebar.getByRole('button', { name: /decrease max height/i });
+    // Now decrease height
+    const decreaseMaxHeight = sidebar.getByRole('button', { name: /decrease height/i });
     for (let i = 0; i < 3; i++) {
       if (await decreaseMaxHeight.isEnabled()) {
         await decreaseMaxHeight.click();
@@ -284,19 +302,20 @@ test.describe('Drawer Settings', () => {
   test('collapsing sidebar hides grid settings', async ({ page }) => {
     const sidebar = getSidebar(page);
 
-    // Verify grid settings are visible
-    await expect(sidebar.getByText('Grid Settings')).toBeVisible();
+    // Verify grid settings sections are visible
+    const gridSizeButton = sidebar.getByRole('button', { name: /Grid Size/i });
+    await expect(gridSizeButton).toBeVisible();
 
     // Collapse the sidebar
     await sidebar.getByRole('button', { name: /collapse left panel/i }).click();
 
     // Grid settings should not be visible
-    await expect(sidebar.getByText('Grid Settings')).not.toBeVisible();
+    await expect(gridSizeButton).not.toBeVisible();
 
     // Expand again
     await page.getByRole('button', { name: /expand left panel/i }).click();
 
     // Grid settings should be visible again
-    await expect(sidebar.getByText('Grid Settings')).toBeVisible();
+    await expect(gridSizeButton).toBeVisible();
   });
 });

--- a/src/components/modals/BinListModal/BinListDashboard.tsx
+++ b/src/components/modals/BinListModal/BinListDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useId } from 'react';
 import { StatCard, BinIcon, FilamentIcon, CostIcon, TimeIcon, SpoolIcon } from '../../BinList';
 import { CategoryBreakdownChart, CategoryStackedBar, CategoryLegend } from '../../BinList';
 import type { CategoryBreakdown } from '../../../utils/binListOperations';
@@ -49,6 +49,7 @@ export function BinListDashboard({
   defaultCollapsed = false,
 }: BinListDashboardProps) {
   const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
+  const contentId = useId();
 
   const toggleCollapsed = useCallback(() => {
     setIsCollapsed((c) => !c);
@@ -79,6 +80,7 @@ export function BinListDashboard({
           onClick={toggleCollapsed}
           className="p-1 text-content-tertiary hover:text-content rounded transition-colors"
           aria-expanded={!isCollapsed}
+          aria-controls={contentId}
           aria-label={isCollapsed ? 'Expand statistics' : 'Collapse statistics'}
         >
           <svg
@@ -111,7 +113,7 @@ export function BinListDashboard({
       {collapsible && <div className="px-1">{header}</div>}
 
       {/* Stats grid */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+      <div id={contentId} className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
         <StatCard
           icon={<BinIcon />}
           label="Bin Types"

--- a/src/components/modals/BinListModal/BinListFilters.tsx
+++ b/src/components/modals/BinListModal/BinListFilters.tsx
@@ -43,12 +43,13 @@ export function BinListFilters({
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Auto-focus search input on mount
+  // Delay ensures modal open animation/transition completes before focusing
+  const FOCUS_DELAY_MS = 100;
   useEffect(() => {
     if (autoFocus && searchInputRef.current) {
-      // Delay to ensure modal animation completes
       const timer = setTimeout(() => {
         searchInputRef.current?.focus();
-      }, 100);
+      }, FOCUS_DELAY_MS);
       return () => clearTimeout(timer);
     }
   }, [autoFocus]);

--- a/src/components/modals/BinListModal/BinListTable.tsx
+++ b/src/components/modals/BinListModal/BinListTable.tsx
@@ -220,14 +220,14 @@ export function BinListTable({
                 `}
                 onClick={(e) => handleRowClick(row, index, e)}
               >
-                {/* Checkbox */}
+                {/* Checkbox - onClick handles shift-click, readOnly keeps it controlled without onChange warning */}
                 <td className="px-3 py-2">
                   <input
                     type="checkbox"
                     checked={isSelected}
-                    onChange={() => {}}
+                    readOnly
                     onClick={(e) => handleCheckboxClick(index, e)}
-                    className="rounded border-stroke focus:ring-accent"
+                    className="rounded border-stroke focus:ring-accent cursor-pointer"
                     aria-label={`Select ${row.size} bin`}
                   />
                 </td>

--- a/src/components/modals/BinListModal/BulkActions.tsx
+++ b/src/components/modals/BinListModal/BulkActions.tsx
@@ -234,9 +234,15 @@ export function BulkActions({
                     value={notesValue}
                     onChange={(e) => setNotesValue(e.target.value)}
                     onKeyDown={(e) => {
-                      if (e.key === 'Escape') setOpenDropdown(null);
+                      if (e.key === 'Escape') {
+                        setOpenDropdown(null);
+                      } else if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                        // Ctrl/Cmd+Enter to submit for textarea
+                        e.preventDefault();
+                        handleNotesSubmit();
+                      }
                     }}
-                    placeholder="Enter notes..."
+                    placeholder="Enter notes... (⌘+Enter to apply)"
                     className="w-full px-2 py-1.5 text-sm bg-surface border border-stroke rounded focus:outline-none focus:ring-2 focus:ring-accent resize-none"
                     rows={2}
                     maxLength={256}

--- a/src/components/modals/BinListModal/index.tsx
+++ b/src/components/modals/BinListModal/index.tsx
@@ -66,6 +66,10 @@ function BinListModalContent({ onClose }: { onClose: () => void }) {
     updateBulkLabel,
     updateBulkNotes,
 
+    // Inline editing
+    updateBinLabel,
+    updateBinNotes,
+
     // Export
     downloadExport,
     copyToClipboard,
@@ -114,10 +118,14 @@ function BinListModalContent({ onClose }: { onClose: () => void }) {
         }
       }
 
-      // Select all with Ctrl+A
+      // Select all with Ctrl+A (but not when inside text inputs)
       if ((e.metaKey || e.ctrlKey) && e.key === 'a' && rows.length > 0) {
-        e.preventDefault();
-        selectAllRows();
+        const target = e.target as HTMLElement;
+        const isInTextInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
+        if (!isInTextInput) {
+          e.preventDefault();
+          selectAllRows();
+        }
       }
     };
 
@@ -130,26 +138,20 @@ function BinListModalContent({ onClose }: { onClose: () => void }) {
     closeButtonRef.current?.focus();
   }, []);
 
-  // Handler for inline label editing
+  // Handler for inline label editing (updates specific bins in the row)
   const handleEditLabel = useCallback(
     (binIds: string[], label: string) => {
-      // Update all bins in the row with the new label
-      // This uses the same pattern as updateBulkLabel but for a specific row
-      if (binIds.length > 0) {
-        updateBulkLabel(label);
-      }
+      updateBinLabel(binIds, label);
     },
-    [updateBulkLabel]
+    [updateBinLabel]
   );
 
-  // Handler for inline notes editing
+  // Handler for inline notes editing (updates specific bins in the row)
   const handleEditNotes = useCallback(
     (binIds: string[], notes: string) => {
-      if (binIds.length > 0) {
-        updateBulkNotes(notes);
-      }
+      updateBinNotes(binIds, notes);
     },
-    [updateBulkNotes]
+    [updateBinNotes]
   );
 
   // Clear filters including search
@@ -223,8 +225,8 @@ function BinListModalContent({ onClose }: { onClose: () => void }) {
           </div>
         </header>
 
-        {/* Dashboard - collapsible on mobile, always visible on desktop when showDashboard is true */}
-        {(isMobile || showDashboard) && (
+        {/* Dashboard - collapsible on mobile, toggleable via showDashboard */}
+        {showDashboard && (
           <div className="px-4 md:px-6 py-3 md:py-4 border-b border-stroke">
             <BinListDashboard
               totalBinTypes={rows.length}

--- a/src/hooks/useBinList.ts
+++ b/src/hooks/useBinList.ts
@@ -41,11 +41,15 @@ export interface UseBinListReturn extends Omit<UsePrintListReturn, 'rows'> {
   isAllSelected: boolean;
   selectionCount: number;
 
-  // Bulk actions
+  // Bulk actions (operate on selected bins)
   deleteBulkSelection: () => void;
   changeBulkCategory: (categoryId: string) => void;
   updateBulkLabel: (label: string) => void;
   updateBulkNotes: (notes: string) => void;
+
+  // Inline editing (operate on specific bin IDs)
+  updateBinLabel: (binIds: string[], label: string) => void;
+  updateBinNotes: (binIds: string[], notes: string) => void;
 
   // Export
   exportToTSV: () => string;
@@ -192,6 +196,33 @@ export function useBinList(): UseBinListReturn {
     addToast(`Updated notes for ${count} bin${count !== 1 ? 's' : ''}`, 'success');
   }, [selectedBinIds, execute, updateBin, addToast]);
 
+  // Inline editing handlers (for specific bin IDs, not selection-based)
+  const updateBinLabel = useCallback((binIds: string[], label: string) => {
+    if (binIds.length === 0) return;
+
+    const count = binIds.length;
+    execute(() => {
+      for (const binId of binIds) {
+        updateBin(binId, { label });
+      }
+    });
+
+    addToast(`Updated label for ${count} bin${count !== 1 ? 's' : ''}`, 'success');
+  }, [execute, updateBin, addToast]);
+
+  const updateBinNotes = useCallback((binIds: string[], notes: string) => {
+    if (binIds.length === 0) return;
+
+    const count = binIds.length;
+    execute(() => {
+      for (const binId of binIds) {
+        updateBin(binId, { notes });
+      }
+    });
+
+    addToast(`Updated notes for ${count} bin${count !== 1 ? 's' : ''}`, 'success');
+  }, [execute, updateBin, addToast]);
+
   // Export handlers
   const exportToTSV = useCallback(() => {
     return exportPrintListTSV(filteredRows);
@@ -282,11 +313,15 @@ export function useBinList(): UseBinListReturn {
     isAllSelected,
     selectionCount,
 
-    // Bulk actions
+    // Bulk actions (operate on selected bins)
     deleteBulkSelection,
     changeBulkCategory,
     updateBulkLabel,
     updateBulkNotes,
+
+    // Inline editing (operate on specific bin IDs)
+    updateBinLabel,
+    updateBinNotes,
 
     // Export
     exportToTSV,


### PR DESCRIPTION
## Summary

Follow-up fixes for the expanded bin list feature (PR #49):

**E2E Test Fixes:**
- Update drawer-settings tests to use "Grid Size" and "Physical Units" instead of deprecated "Grid Settings" section name
- Update add-bins test to use button role instead of heading for CollapsibleSection titles
- Fix create-layout persistence test to properly wait for auto-save
- Use exact matching for text selectors to avoid strict mode violations

**Copilot Review Fixes:**
- Add `updateBinLabel`/`updateBinNotes` functions for inline editing that operate on specific bin IDs (not selection-based)
- Fix Ctrl+A handler to not intercept when focus is in text inputs
- Fix dashboard visibility logic (was always showing on mobile)
- Add Ctrl/Cmd+Enter to submit notes textarea
- Use readOnly for checkbox instead of empty onChange
- Add aria-controls to dashboard collapse button
- Document magic timeout with named constant

## Test Plan

- [x] All 1312 unit tests pass
- [x] All 178 e2e tests pass (2 skipped)
- [x] TypeScript compiles with no errors
- [x] ESLint passes with no errors