### PR TITLE
Reorganize grid settings UI and improve checkbox styling

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -315,30 +315,39 @@ export function Sidebar() {
                     </div>
                   </div>
 
+                  {/* Real-world drawer dimensions */}
+                  <div className="flex items-center justify-center gap-1 pt-2 text-content-tertiary">
+                    <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 12h16M4 12v-2M8 12v-1M12 12v-2M16 12v-1M20 12v-2" />
+                    </svg>
+                    <span className="tabular-nums">
+                      {(drawerWidth * gridUnitMm).toFixed(0)} × {(drawerDepth * gridUnitMm).toFixed(0)} × {(drawerHeight * heightUnitMm).toFixed(0)} mm
+                    </span>
+                  </div>
+
                   {/* Half-bin mode toggle */}
-                  <label className="flex items-center justify-between pt-2 mt-2 border-t border-stroke-subtle cursor-pointer">
+                  <label className="flex items-center justify-between pt-2 cursor-pointer">
                     <div className="flex items-center gap-1.5">
                       <span
-                        className="text-content-tertiary"
+                        className="text-content-tertiary leading-none"
                         title="Enable 0.5 grid unit precision for half-size bins (H)"
                       >
                         Half-bin mode
                       </span>
-                      <span className="text-[9px] text-amber-500/80 bg-amber-500/10 px-1 py-0.5 rounded">experimental</span>
-                      <kbd className="text-[9px] text-content-disabled bg-surface-elevated px-1 py-0.5 rounded border border-stroke-subtle">H</kbd>
+                      <span className="text-[9px] leading-none text-amber-500/80 bg-amber-500/10 px-1 py-0.5 rounded">experimental</span>
+                      <kbd className="text-[9px] leading-none text-content-disabled bg-surface-elevated px-1 py-0.5 rounded border border-stroke-subtle">H</kbd>
                     </div>
                     <input
                       type="checkbox"
                       checked={halfBinMode}
                       onChange={handleHalfBinToggle}
-                      className="w-4 h-4 rounded accent-accent"
                       aria-label="Toggle half-bin mode"
                     />
                   </label>
 
                   {/* Fractional edge position toggles - only shown when dimensions are fractional */}
                   {(hasFractionalWidth || hasFractionalDepth) && (
-                    <div className="pt-2 mt-2 border-t border-stroke-subtle space-y-1.5">
+                    <div className="pt-2 space-y-1.5">
                       <div className="text-content-tertiary text-[10px] mb-1">Half-unit edge position</div>
                       {hasFractionalWidth && (
                         <div className="flex items-center justify-between">
@@ -400,16 +409,6 @@ export function Sidebar() {
                       )}
                     </div>
                   )}
-
-                  {/* Real-world drawer dimensions */}
-                  <div className="flex items-center justify-center gap-1 pt-1 text-content-tertiary">
-                    <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 12h16M4 12v-2M8 12v-1M12 12v-2M16 12v-1M20 12v-2" />
-                    </svg>
-                    <span className="tabular-nums">
-                      {(drawerWidth * gridUnitMm).toFixed(0)} × {(drawerDepth * gridUnitMm).toFixed(0)} × {(drawerHeight * heightUnitMm).toFixed(0)} mm
-                    </span>
-                  </div>
                 </div>
               </CollapsibleSection>
             </div>

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -145,7 +145,7 @@ function ToastItem({ toast, position, onRemove }: ToastItemProps) {
       {/* Close button */}
       <button
         onClick={handleDismiss}
-        className="absolute top-3 right-3 p-1 rounded-md text-current opacity-60 hover:opacity-100 hover:bg-white/10 transition-all"
+        className="absolute top-4 right-3 p-1 rounded-md text-current opacity-60 hover:opacity-100 hover:bg-white/10 transition-all"
         aria-label="Dismiss notification"
       >
         <CloseIcon />

--- a/src/index.css
+++ b/src/index.css
@@ -812,6 +812,42 @@ input[type="number"] {
   outline: none;
 }
 
+/* Checkbox styling */
+input[type="checkbox"] {
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-default);
+  background: var(--bg-primary);
+  cursor: pointer;
+  position: relative;
+  flex-shrink: 0;
+}
+
+input[type="checkbox"]:checked {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+input[type="checkbox"]:checked::after {
+  content: '✓';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 10px;
+  font-weight: bold;
+}
+
+input[type="checkbox"]:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-primary-muted);
+  outline: none;
+}
+
 /* Selection indicator */
 .selected-ring {
   box-shadow:


### PR DESCRIPTION
## Summary
- Move real-world dimensions display directly below drawer size inputs for better information hierarchy
- Remove unnecessary horizontal dividers for cleaner visual appearance
- Fix vertical alignment of half-bin mode label elements (badge, keyboard shortcut)
- Fix toast close button vertical alignment
- Add global checkbox styling with dark background to match input fields

## Test plan
- [ ] Verify real dimensions appear below W/D/H inputs in Grid Size section
- [ ] Verify half-bin mode toggle and edge position controls appear below dimensions
- [ ] Verify checkbox has dark background matching other inputs
- [ ] Verify toast close button is vertically aligned with content
- [ ] Verify no visual regressions in sidebar panels