### PR TITLE
feat: add save indicator, scroll shadows, and dual help shortcut

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,7 @@ Dark theme by default. Use Tailwind classes, not inline styles.
 - Space: Expand 3D preview
 - 1-4: Camera presets (isometric, top, front, side)
 - Escape: Clear selection, exit paint mode
-- ?: Toggle help modal
+- ? or /: Toggle help modal
 
 ## Testing
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,7 +99,7 @@ export default function App() {
   useKeyboard();
 
   // Auto-save to localStorage
-  useAutoSave();
+  const saveStatus = useAutoSave();
 
   // Cross-tab sync detection
   useCrossTabSync();
@@ -118,7 +118,7 @@ export default function App() {
     if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
       return;
     }
-    if (e.key === SHORTCUTS.HELP) {
+    if ((SHORTCUTS.HELP as readonly string[]).includes(e.key)) {
       e.preventDefault();
       setIsHelpOpen(prev => !prev);
     }
@@ -144,7 +144,7 @@ export default function App() {
   if (isMobile) {
     return (
       <Suspense fallback={<div className="h-screen bg-surface" />}>
-        <MobileLayout isMobileHelpOpen={isMobileHelpOpen} setIsMobileHelpOpen={setIsMobileHelpOpen} />
+        <MobileLayout isMobileHelpOpen={isMobileHelpOpen} setIsMobileHelpOpen={setIsMobileHelpOpen} saveStatus={saveStatus} />
       </Suspense>
     );
   }
@@ -157,7 +157,7 @@ export default function App() {
         <SharedLayoutBanner />
 
         {/* Header */}
-        <Header onHelpClick={() => setIsHelpOpen(true)} />
+        <Header onHelpClick={() => setIsHelpOpen(true)} saveStatus={saveStatus} />
 
         {/* Main content area - Grid takes full width */}
         <div className="flex-1 flex overflow-hidden">
@@ -235,7 +235,7 @@ export default function App() {
       <SharedLayoutBanner />
 
       {/* Header */}
-      <Header onHelpClick={() => setIsHelpOpen(true)} />
+      <Header onHelpClick={() => setIsHelpOpen(true)} saveStatus={saveStatus} />
 
       {/* Main content area */}
       <div className="flex-1 flex overflow-hidden">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,12 +4,14 @@ import { useLayoutStore, useHistoryStore, useUIStore, useLibraryStore } from '..
 import { useResponsive } from '../hooks';
 import { CONSTRAINTS } from '../constants';
 import { LayoutManagerModal } from './modals/LayoutManagerModal';
+import type { SaveStatus } from '../hooks/useAutoSave';
 
 interface HeaderProps {
   onHelpClick: () => void;
+  saveStatus: SaveStatus;
 }
 
-export function Header({ onHelpClick }: HeaderProps) {
+export function Header({ onHelpClick, saveStatus }: HeaderProps) {
   const { isTablet } = useResponsive();
 
   const { layout, setName } = useLayoutStore(
@@ -174,6 +176,24 @@ export function Header({ onHelpClick }: HeaderProps) {
           </div>
         )}
 
+        {/* Save status indicator */}
+        {saveStatus !== 'idle' && (
+          <div
+            className="flex items-center gap-1 px-2 py-1 text-[11px] mr-2 text-content-secondary"
+            aria-live="polite"
+          >
+            <svg
+              className="w-3 h-3 text-success"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+            </svg>
+            <span>Saved</span>
+          </div>
+        )}
+
         {/* Undo/Redo buttons */}
         <div className="flex items-center mr-2 border-r border-stroke-subtle pr-2">
           <button
@@ -201,7 +221,6 @@ export function Header({ onHelpClick }: HeaderProps) {
         </div>
 
         {/* Reddit feedback link */}
-        <div className="w-px h-6 bg-stroke-subtle" />
         <a
           href="https://www.reddit.com/r/gridfinity/comments/1q93nz6/i_built_a_free_layout_planner_for_gridfinity/"
           target="_blank"
@@ -222,7 +241,7 @@ export function Header({ onHelpClick }: HeaderProps) {
           title="Show keyboard shortcuts"
           aria-label="Show help and keyboard shortcuts"
         >
-          Press <kbd className="mx-1 px-2 py-1 text-xs font-mono rounded text-content leading-none" style={{ backgroundColor: 'var(--bg-primary)', border: '1px solid var(--border-default)', boxShadow: 'var(--shadow-sm)' }}>?</kbd> for help
+          Press <kbd className="mx-1 px-2 py-1 text-xs font-mono rounded text-content leading-none" style={{ backgroundColor: 'var(--bg-primary)', border: '1px solid var(--border-default)', boxShadow: 'var(--shadow-sm)' }}>?</kbd> or <kbd className="mx-1 px-2 py-1 text-xs font-mono rounded text-content leading-none" style={{ backgroundColor: 'var(--bg-primary)', border: '1px solid var(--border-default)', boxShadow: 'var(--shadow-sm)' }}>/</kbd> for help
         </button>
       </div>
 

--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -22,6 +22,7 @@ import {
   MobileLayoutsPanel,
   BinContextMenu,
 } from './mobile';
+import type { SaveStatus } from '../hooks/useAutoSave';
 
 // Lazy load mobile help modal (with retry for chunk load failures)
 const MobileHelpModal = lazyWithRetry(() =>
@@ -31,9 +32,10 @@ const MobileHelpModal = lazyWithRetry(() =>
 interface MobileLayoutProps {
   isMobileHelpOpen: boolean;
   setIsMobileHelpOpen: (open: boolean) => void;
+  saveStatus: SaveStatus;
 }
 
-export function MobileLayout({ isMobileHelpOpen, setIsMobileHelpOpen }: MobileLayoutProps) {
+export function MobileLayout({ isMobileHelpOpen, setIsMobileHelpOpen, saveStatus }: MobileLayoutProps) {
   const activeMobilePanel = useUIStore(state => state.activeMobilePanel);
   const setActiveMobilePanel = useUIStore(state => state.setActiveMobilePanel);
   const contextMenu = useUIStore(state => state.contextMenu);
@@ -45,7 +47,7 @@ export function MobileLayout({ isMobileHelpOpen, setIsMobileHelpOpen }: MobileLa
       <SharedLayoutBanner />
 
       {/* Mobile Header */}
-      <MobileHeader onMenuClick={() => setActiveMobilePanel('settings')} onHelpClick={() => setIsMobileHelpOpen(true)} />
+      <MobileHeader onMenuClick={() => setActiveMobilePanel('settings')} onHelpClick={() => setIsMobileHelpOpen(true)} saveStatus={saveStatus} />
 
       {/* Main content area - Grid takes full width */}
       <main className="flex-1 flex flex-col overflow-hidden bg-surface">

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { useUIStore, useLayoutStore } from '../store';
 import { DEFAULT_CATEGORY_COLOR } from '../constants';
@@ -21,6 +21,14 @@ export function RightPanel() {
   const [copyFeedback, setCopyFeedback] = useState(false);
   const [expandedSplitRow, setExpandedSplitRow] = useState<number | null>(null);
   const [binListModalOpen, setBinListModalOpen] = useState(false);
+  const [isScrolled, setIsScrolled] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const handleScroll = useCallback(() => {
+    if (scrollRef.current) {
+      setIsScrolled(scrollRef.current.scrollTop > 0);
+    }
+  }, []);
 
   const { collapsed, toggle } = useUIStore(
     useShallow((state) => ({
@@ -85,15 +93,23 @@ export function RightPanel() {
       style={{ width: '288px' }}
     >
       {/* Header */}
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-stroke-subtle">
+      <div className={`flex items-center gap-3 px-4 py-3 border-b border-stroke-subtle transition-shadow duration-200 ${
+        isScrolled ? 'shadow-[0_2px_8px_rgba(0,0,0,0.5)]' : ''
+      }`}>
         {collapseButton}
         <h2 className="text-xs font-semibold text-content-tertiary uppercase tracking-wider">
           Inspector
         </h2>
       </div>
 
-      {/* Selection Panel - Collapsible */}
-      <div className="px-4 py-3 border-b border-stroke-subtle">
+      {/* Scrollable content area */}
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto scrollbar-thin flex flex-col min-h-0"
+      >
+        {/* Selection Panel - Collapsible */}
+        <div className="px-4 py-3 border-b border-stroke-subtle">
         <CollapsibleSection
           title={isMultiSelect ? "Multi-Selection" : bin ? "Bin Properties" : "Selection"}
           variant="default"
@@ -117,7 +133,7 @@ export function RightPanel() {
       </div>
 
       {/* Print List - Collapsible */}
-      <div className="flex-1 flex flex-col min-h-0">
+      <div className="flex flex-col">
         <div className={`flex items-center justify-between px-4 py-3 ${printListExpanded ? 'border-b border-stroke-subtle' : ''}`}>
           <button
             className="flex items-center gap-2 transition-colors bg-transparent"
@@ -182,9 +198,9 @@ export function RightPanel() {
         </div>
 
         <div
-          className={`flex-1 flex flex-col min-h-0 transition-all duration-200 ${printListExpanded ? 'opacity-100' : 'opacity-0 max-h-0 overflow-hidden'}`}
+          className={`flex flex-col transition-all duration-200 ${printListExpanded ? 'opacity-100' : 'opacity-0 max-h-0 overflow-hidden'}`}
         >
-          <div className="flex-1 overflow-y-auto scrollbar-thin min-h-0">
+          <div>
             {printList.rows.length === 0 ? (
               <PrintListEmpty />
             ) : (
@@ -345,6 +361,7 @@ export function RightPanel() {
             />
           )}
         </div>
+      </div>
       </div>
 
       {/* Confirm Dialog */}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { useUIStore, useLayoutStore, useSettingsStore, useToastStore } from '../../store';
 import { useUndoableAction } from '../../store/history';
@@ -18,7 +18,15 @@ export function Sidebar() {
   const [showSaveDefaultsConfirm, setShowSaveDefaultsConfirm] = useState(false);
   const [showHalfBinBlockedModal, setShowHalfBinBlockedModal] = useState(false);
   const [halfBinViolation, setHalfBinViolation] = useState<HalfBinConstraintViolation | null>(null);
+  const [isScrolled, setIsScrolled] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
   const { isDesktop } = useResponsive();
+
+  const handleScroll = useCallback(() => {
+    if (scrollRef.current) {
+      setIsScrolled(scrollRef.current.scrollTop > 0);
+    }
+  }, []);
 
   const { collapsed, toggle, halfBinMode, toggleHalfBinMode, setHalfBinMode } = useUIStore(
     useShallow((state) => ({
@@ -180,7 +188,11 @@ export function Sidebar() {
       ) : (
         // Expanded state
         <>
-          <div className="flex items-center gap-3 px-4 py-3 border-b border-stroke-subtle">
+          <div
+            className={`flex items-center gap-3 px-4 py-3 border-b border-stroke-subtle transition-shadow duration-200 ${
+              isScrolled ? 'shadow-[0_2px_8px_rgba(0,0,0,0.5)]' : ''
+            }`}
+          >
             <h2 className="flex-1 text-xs font-semibold text-content-tertiary uppercase tracking-wider">
               Tools
             </h2>
@@ -195,7 +207,11 @@ export function Sidebar() {
               </svg>
             </button>
           </div>
-          <div className="flex-1 overflow-y-auto scrollbar-thin flex flex-col">
+          <div
+            ref={scrollRef}
+            onScroll={handleScroll}
+            className="flex-1 overflow-y-auto scrollbar-thin flex flex-col"
+          >
             <div className="px-4 py-4 border-b border-stroke-subtle">
               <ActiveLayerPanel />
             </div>

--- a/src/components/mobile/MobileHeader.tsx
+++ b/src/components/mobile/MobileHeader.tsx
@@ -2,17 +2,19 @@ import { useState, useRef, useEffect } from 'react';
 import { useLayoutStore, useHistoryStore, useUIStore } from '../../store';
 import { CONSTRAINTS } from '../../constants';
 import type { MobilePanel } from '../../store/ui';
+import type { SaveStatus } from '../../hooks/useAutoSave';
 
 interface MobileHeaderProps {
   onMenuClick: () => void;
   onHelpClick: () => void;
+  saveStatus: SaveStatus;
 }
 
 /**
  * Compact header for mobile layout.
  * Shows app title, tip link, layout name (editable) and essential actions.
  */
-export function MobileHeader({ onMenuClick, onHelpClick }: MobileHeaderProps) {
+export function MobileHeader({ onMenuClick, onHelpClick, saveStatus }: MobileHeaderProps) {
   const layout = useLayoutStore(state => state.layout);
   const setName = useLayoutStore(state => state.setName);
 
@@ -175,8 +177,25 @@ export function MobileHeader({ onMenuClick, onHelpClick }: MobileHeaderProps) {
         )}
       </div>
 
-      {/* Right: Undo/Redo + Help */}
+      {/* Right: Save status + Undo/Redo + Help */}
       <div className="flex items-center gap-1">
+        {/* Save status indicator (icon only on mobile) */}
+        {saveStatus !== 'idle' && (
+          <div
+            className="flex items-center justify-center w-7 h-7"
+            aria-live="polite"
+            aria-label="Saved"
+          >
+            <svg
+              className="w-3.5 h-3.5 text-success"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+        )}
         <button
           onClick={undo}
           disabled={!canUndo}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -205,7 +205,7 @@ export const SHORTCUTS = {
   ROTATE: 'r',      // Rotate bin (swap width/depth) - standalone key, no Ctrl/Cmd
   ZOOM_IN: ['+', '='],
   ZOOM_OUT: ['-'],
-  HELP: '?',
+  HELP: ['?', '/'],
   // Navigation
   LAYER_UP: 'w',
   LAYER_DOWN: 's',

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -1,15 +1,19 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { useLayoutStore, useLibraryStore, useToastStore } from '../store';
 import { saveLayoutById, saveLibrary, computeLayoutPreview } from '../utils/storage';
 
 const SAVE_DEBOUNCE_MS = 1000;
+const SAVED_DISPLAY_MS = 2500;
+
+export type SaveStatus = 'idle' | 'saving' | 'saved';
 
 /**
  * Auto-save hook for the multi-layout system.
  * Saves the active layout to its individual storage key and updates the library entry.
+ * Returns the current save status for UI display.
  */
-export function useAutoSave() {
+export function useAutoSave(): SaveStatus {
   const { layout, activeLayoutId } = useLayoutStore(
     useShallow(state => ({
       layout: state.layout,
@@ -20,7 +24,10 @@ export function useAutoSave() {
   const updateEntry = useLibraryStore(state => state.updateEntry);
   const addToast = useToastStore(state => state.addToast);
 
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+
   const timeoutRef = useRef<number | undefined>(undefined);
+  const savedTimeoutRef = useRef<number | undefined>(undefined);
   const hasShownErrorRef = useRef(false);
   const failureCountRef = useRef(0);
 
@@ -28,6 +35,12 @@ export function useAutoSave() {
     // Clear any pending save
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
+    }
+
+    // Clear any pending "saved" timeout when new changes come in
+    if (savedTimeoutRef.current) {
+      clearTimeout(savedTimeoutRef.current);
+      savedTimeoutRef.current = undefined;
     }
 
     // Don't save if no active layout ID (shouldn't happen, but safety check)
@@ -38,6 +51,9 @@ export function useAutoSave() {
 
     // Schedule save
     timeoutRef.current = window.setTimeout(() => {
+      // Reset to idle first (in case we were showing "saved"), then show "saving"
+      setSaveStatus('saving');
+
       try {
         // Save layout to its individual key
         saveLayoutById(activeLayoutId, layout);
@@ -55,8 +71,17 @@ export function useAutoSave() {
         // Reset error flags on successful save
         hasShownErrorRef.current = false;
         failureCountRef.current = 0;
+
+        // Show "saved" status
+        setSaveStatus('saved');
+
+        // Clear "saved" status after delay
+        savedTimeoutRef.current = window.setTimeout(() => {
+          setSaveStatus('idle');
+        }, SAVED_DISPLAY_MS);
       } catch (error) {
         failureCountRef.current++;
+        setSaveStatus('idle');
 
         // Show warning after multiple failures
         if (failureCountRef.current >= 3 && !hasShownErrorRef.current) {
@@ -77,4 +102,15 @@ export function useAutoSave() {
       }
     };
   }, [layout, activeLayoutId, updateEntry, addToast]);
+
+  // Cleanup saved timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (savedTimeoutRef.current) {
+        clearTimeout(savedTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  return saveStatus;
 }


### PR DESCRIPTION
## Summary
- Add "Saved" indicator before undo/redo buttons showing when layout is auto-saved
  - Desktop: checkmark icon + "Saved" text
  - Mobile: checkmark icon only
- Add scroll shadows to TOOLS and INSPECTOR panel headers when content is scrolled below
- Update help shortcut to accept both `?` and `/` keys
- Remove redundant divider next to Reddit link in header

## Test plan
- [ ] Verify "Saved" indicator appears briefly after making changes (2.5s display)
- [ ] Verify scroll shadows appear on TOOLS header when scrolling panel content
- [ ] Verify scroll shadows appear on INSPECTOR header when scrolling panel content
- [ ] Verify both `?` and `/` keys open the help modal
- [ ] Verify mobile layout shows icon-only save indicator