### PR TITLE
fix: elevate z-index on hover so resize handles aren't clipped by neighbors

### DIFF
--- a/src/components/Grid/Bin.tsx
+++ b/src/components/Grid/Bin.tsx
@@ -564,7 +564,8 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
         pointerEvents: isGhost || isBeingDragged ? 'none' : 'auto',
         opacity: isGhost ? 0.3 : isBeingDragged ? 0.5 : (isAnyCategoryHighlighted && !isCategoryHighlighted) ? 0.4 : 1,
         // Selected bins need higher z-index (40) to ensure resize handles appear above axis labels (30)
-        zIndex: isGhost ? 5 : isSelected ? 40 : isCategoryHighlighted ? 15 : 10,
+        // Hovered bins (30) need to be above regular bins (10) so resize handles aren't clipped by neighbors
+        zIndex: isGhost ? 5 : isSelected ? 40 : isHovered ? 30 : isCategoryHighlighted ? 15 : 10,
         boxShadow: getBoxShadow(),
         transform: getTransform(),
         // Allow resize handles to extend outside bin (text constrained by whitespace-nowrap and sizing)


### PR DESCRIPTION
## Summary
- When hovering over a bin in a densely packed grid (e.g., all 1x1 bins), the ghost resize handles were hidden behind adjacent bins because they all shared the same z-index (10)
- Now hovered bins get z-index 30, placing them above regular bins but below selected bins

## Test plan
- [ ] Fill grid with 1x1 bins
- [ ] Hover over any bin in the middle of the grid
- [ ] Verify all 8 resize handles are visible and not clipped by neighboring bins