### PR TITLE
feat: highlight bins on row/column label hover

### DIFF
--- a/src/components/Grid/Bin.tsx
+++ b/src/components/Grid/Bin.tsx
@@ -57,6 +57,32 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
     (state) => state.highlightedCategoryId !== null
   );
 
+  // Performance: Use derived selector for row/column label highlighting.
+  // Check if this bin overlaps with the highlighted row or column (1-indexed).
+  const isRowColHighlighted = useUIStore((state) => {
+    const { highlightedRowLabel, highlightedColLabel } = state;
+    if (highlightedRowLabel === null && highlightedColLabel === null) return false;
+
+    // Check row overlap: row N (1-indexed) corresponds to grid y = N-1
+    // Bin occupies rows where bin.y <= rowY < bin.y + bin.depth
+    if (highlightedRowLabel !== null) {
+      const rowY = highlightedRowLabel - 1; // Convert 1-indexed to 0-indexed
+      if (rowY >= bin.y && rowY < bin.y + bin.depth) return true;
+    }
+
+    // Check column overlap: column N (1-indexed) corresponds to grid x = N-1
+    // Bin occupies columns where bin.x <= colX < bin.x + bin.width
+    if (highlightedColLabel !== null) {
+      const colX = highlightedColLabel - 1; // Convert 1-indexed to 0-indexed
+      if (colX >= bin.x && colX < bin.x + bin.width) return true;
+    }
+
+    return false;
+  });
+  const isAnyRowColHighlighted = useUIStore(
+    (state) => state.highlightedRowLabel !== null || state.highlightedColLabel !== null
+  );
+
   // Actions are stable, select individually
   const setSelectedBin = useUIStore((state) => state.setSelectedBin);
   const toggleSelection = useUIStore((state) => state.toggleSelection);
@@ -526,6 +552,10 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
     if (isCategoryHighlighted) {
       return '0 0 0 2px var(--color-accent), 0 0 12px rgba(34, 197, 94, 0.4)';
     }
+    // Row/column label highlight (when hovering row/column label)
+    if (isRowColHighlighted) {
+      return '0 0 0 2px var(--selection-ring), 0 0 12px var(--selection-glow)';
+    }
     return 'var(--shadow-sm)';
   };
 
@@ -562,10 +592,14 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
         WebkitUserSelect: 'none',
         userSelect: 'none',
         pointerEvents: isGhost || isBeingDragged ? 'none' : 'auto',
-        opacity: isGhost ? 0.3 : isBeingDragged ? 0.5 : (isAnyCategoryHighlighted && !isCategoryHighlighted) ? 0.4 : 1,
+        opacity: isGhost ? 0.3
+          : isBeingDragged ? 0.5
+          : (isAnyCategoryHighlighted && !isCategoryHighlighted) ? 0.4
+          : (isAnyRowColHighlighted && !isRowColHighlighted) ? 0.6
+          : 1,
         // Selected bins need higher z-index (40) to ensure resize handles appear above axis labels (30)
         // Hovered bins (30) need to be above regular bins (10) so resize handles aren't clipped by neighbors
-        zIndex: isGhost ? 5 : isSelected ? 40 : isHovered ? 30 : isCategoryHighlighted ? 15 : 10,
+        zIndex: isGhost ? 5 : isSelected ? 40 : isHovered ? 30 : (isCategoryHighlighted || isRowColHighlighted) ? 15 : 10,
         boxShadow: getBoxShadow(),
         transform: getTransform(),
         // Allow resize handles to extend outside bin (text constrained by whitespace-nowrap and sizing)

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -56,6 +56,8 @@ export function Grid() {
     setKeyboardResizeMode,
     halfBinMode,
     selectedBinIds,
+    setHighlightedRowLabel,
+    setHighlightedColLabel,
   } = useUIStore(
     useShallow((state) => ({
       zoom: state.zoom,
@@ -81,6 +83,8 @@ export function Grid() {
       setKeyboardDragMode: state.setKeyboardDragMode,
       setKeyboardResizeMode: state.setKeyboardResizeMode,
       halfBinMode: state.halfBinMode,
+      setHighlightedRowLabel: state.setHighlightedRowLabel,
+      setHighlightedColLabel: state.setHighlightedColLabel,
     }))
   );
 
@@ -864,6 +868,8 @@ export function Grid() {
                         padding: 0,
                       }}
                       onClick={(e) => typeof num === 'number' && handleRowClick(Math.floor(num), e)}
+                      onMouseEnter={() => typeof num === 'number' && setHighlightedRowLabel(Math.floor(num))}
+                      onMouseLeave={() => setHighlightedRowLabel(null)}
                       title={`Click to select row ${label}. Shift-click for range. Ctrl-click to add/remove.`}
                       aria-label={`Select bins in row ${label}`}
                     >
@@ -1063,6 +1069,8 @@ export function Grid() {
                             padding: 0,
                           }}
                           onClick={(e) => typeof num === 'number' && handleColumnClick(Math.floor(num), e)}
+                          onMouseEnter={() => typeof num === 'number' && setHighlightedColLabel(Math.floor(num))}
+                          onMouseLeave={() => setHighlightedColLabel(null)}
                           title={`Click to select column ${label}. Shift-click for range. Ctrl-click to add/remove.`}
                           aria-label={`Select bins in column ${label}`}
                         >

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -89,6 +89,10 @@ interface UIState {
   // Category highlighting (for hover preview)
   highlightedCategoryId: string | null;
 
+  // Row/column label highlighting (for hover preview)
+  highlightedRowLabel: number | null;  // 1-indexed row number
+  highlightedColLabel: number | null;  // 1-indexed column number
+
   // Half-bin mode (power user feature for 0.5 unit increments)
   halfBinMode: boolean;
 
@@ -152,6 +156,10 @@ interface UIState {
   // Category highlighting actions
   setHighlightedCategoryId: (categoryId: string | null) => void;
 
+  // Row/column label highlighting actions
+  setHighlightedRowLabel: (row: number | null) => void;
+  setHighlightedColLabel: (col: number | null) => void;
+
   // Half-bin mode actions
   toggleHalfBinMode: () => OperationResult<void>;
   setHalfBinMode: (enabled: boolean) => void;
@@ -185,6 +193,8 @@ export const useUIStore = create<UIState>((set) => ({
   liveMessage: null,
   quickLabelBinId: null,
   highlightedCategoryId: null,
+  highlightedRowLabel: null,
+  highlightedColLabel: null,
   halfBinMode: loadHalfBinMode(),
   sharedLayoutPreview: null,
   sharedLayoutOriginalName: null,
@@ -330,6 +340,10 @@ export const useUIStore = create<UIState>((set) => ({
 
   // Category highlighting actions
   setHighlightedCategoryId: (categoryId) => set({ highlightedCategoryId: categoryId }),
+
+  // Row/column label highlighting actions
+  setHighlightedRowLabel: (row) => set({ highlightedRowLabel: row }),
+  setHighlightedColLabel: (col) => set({ highlightedColLabel: col }),
 
   // Half-bin mode actions
   toggleHalfBinMode: () => {

--- a/src/test/store/ui.test.ts
+++ b/src/test/store/ui.test.ts
@@ -393,6 +393,69 @@ describe('ui store', () => {
     });
   });
 
+  describe('row/column label highlighting', () => {
+    it('initial state has null highlighted row and column', () => {
+      const state = useUIStore.getState();
+      expect(state.highlightedRowLabel).toBeNull();
+      expect(state.highlightedColLabel).toBeNull();
+    });
+
+    it('setHighlightedRowLabel sets highlighted row', () => {
+      const { setHighlightedRowLabel } = useUIStore.getState();
+
+      setHighlightedRowLabel(3);
+      expect(useUIStore.getState().highlightedRowLabel).toBe(3);
+
+      setHighlightedRowLabel(5);
+      expect(useUIStore.getState().highlightedRowLabel).toBe(5);
+    });
+
+    it('setHighlightedRowLabel with null clears highlight', () => {
+      const { setHighlightedRowLabel } = useUIStore.getState();
+
+      setHighlightedRowLabel(3);
+      expect(useUIStore.getState().highlightedRowLabel).toBe(3);
+
+      setHighlightedRowLabel(null);
+      expect(useUIStore.getState().highlightedRowLabel).toBeNull();
+    });
+
+    it('setHighlightedColLabel sets highlighted column', () => {
+      const { setHighlightedColLabel } = useUIStore.getState();
+
+      setHighlightedColLabel(2);
+      expect(useUIStore.getState().highlightedColLabel).toBe(2);
+
+      setHighlightedColLabel(7);
+      expect(useUIStore.getState().highlightedColLabel).toBe(7);
+    });
+
+    it('setHighlightedColLabel with null clears highlight', () => {
+      const { setHighlightedColLabel } = useUIStore.getState();
+
+      setHighlightedColLabel(2);
+      expect(useUIStore.getState().highlightedColLabel).toBe(2);
+
+      setHighlightedColLabel(null);
+      expect(useUIStore.getState().highlightedColLabel).toBeNull();
+    });
+
+    it('row and column highlights are independent', () => {
+      const { setHighlightedRowLabel, setHighlightedColLabel } = useUIStore.getState();
+
+      setHighlightedRowLabel(3);
+      setHighlightedColLabel(5);
+
+      const state = useUIStore.getState();
+      expect(state.highlightedRowLabel).toBe(3);
+      expect(state.highlightedColLabel).toBe(5);
+
+      setHighlightedRowLabel(null);
+      expect(useUIStore.getState().highlightedRowLabel).toBeNull();
+      expect(useUIStore.getState().highlightedColLabel).toBe(5);
+    });
+  });
+
   describe('sharedLayoutPreview', () => {
     const mockLayout = {
       version: '1.0',

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -53,6 +53,8 @@ export function resetAllStores(): void {
     liveMessage: null,
     quickLabelBinId: null,
     highlightedCategoryId: null,
+    highlightedRowLabel: null,
+    highlightedColLabel: null,
     halfBinMode: false,
     sharedLayoutPreview: null,
     sharedLayoutOriginalName: null,


### PR DESCRIPTION
## Summary

- Add visual feedback when hovering over grid row/column labels to improve discoverability of the click-to-select feature
- When hovering a label, bins in that row/column get a selection-colored glow effect
- Other bins fade to 60% opacity to emphasize the highlighted ones

## Changes

- `src/store/ui.ts`: Add `highlightedRowLabel`/`highlightedColLabel` state and setters
- `src/components/Grid/Bin.tsx`: Add derived selectors for efficient re-renders, update styling
- `src/components/Grid/index.tsx`: Add `onMouseEnter`/`onMouseLeave` handlers to label buttons
- `src/test/store/ui.test.ts`: Add comprehensive tests for new store state
- `src/test/testUtils.ts`: Update `resetAllStores()` with new fields

## Test plan

- [x] All unit tests pass (1359 tests)
- [x] TypeScript compiles without errors
- [x] ESLint passes
- [x] Build succeeds
- [ ] Manual test: Hover over row labels - bins in that row should highlight
- [ ] Manual test: Hover over column labels - bins in that column should highlight
- [ ] Manual test: Other bins should fade when hovering a label
- [ ] Manual test: Clicking still selects bins as before