### PR TITLE
fix: prevent CLS from categories panel on initial load

### DIFF
--- a/src/components/CollapsibleSection.tsx
+++ b/src/components/CollapsibleSection.tsx
@@ -28,6 +28,8 @@ export function CollapsibleSection({
   variant = 'default',
 }: CollapsibleSectionProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
+  // Track if user has toggled - only animate after first interaction to prevent CLS
+  const [hasToggled, setHasToggled] = useState(false);
   const contentId = useId();
 
   const headerClass = variant === 'small'
@@ -40,7 +42,10 @@ export function CollapsibleSection({
         <button
           type="button"
           className="flex items-center gap-2 bg-transparent hover:opacity-80 transition-opacity"
-          onClick={() => setExpanded(!expanded)}
+          onClick={() => {
+            setHasToggled(true);
+            setExpanded(!expanded);
+          }}
           aria-expanded={expanded}
           aria-controls={contentId}
         >
@@ -59,7 +64,9 @@ export function CollapsibleSection({
       </div>
       <div
         id={contentId}
-        className={`transition-all duration-200 overflow-hidden ${
+        className={`overflow-hidden ${
+          hasToggled ? 'transition-all duration-200' : ''
+        } ${
           expanded ? 'opacity-100 max-h-[2000px] mt-3' : 'opacity-0 max-h-0'
         }`}
       >

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -219,7 +219,7 @@ export function Sidebar() {
             <div data-layers-panel className="px-4 py-4 border-b border-stroke-subtle">
               <LayerPanel />
             </div>
-            <div data-categories-panel className="px-4 py-4 border-b border-stroke-subtle">
+            <div data-categories-panel className="px-4 py-4 border-b border-stroke-subtle min-h-[220px]">
               <CategoriesPanel />
             </div>
 


### PR DESCRIPTION
## Summary
- Add `min-h-[220px]` to categories panel to reserve space
- Disable transitions until first user interaction in `CollapsibleSection` to prevent `max-height` animation from causing layout shift

## Why
The categories panel was causing CLS (Cumulative Layout Shift) during initial page load because:
1. The `CollapsibleSection` component animates from `max-h-0` to `max-h-[2000px]`
2. Font loading causes text to reflow

## Test plan
- [ ] Load page, verify no layout shift in categories panel
- [ ] Collapse/expand a section, verify animation still works
- [ ] Run Lighthouse, check CLS score improvement