### PR TITLE
fix: remove min-height from categories panel causing overflow

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -219,7 +219,7 @@ export function Sidebar() {
             <div data-layers-panel className="px-4 py-4 border-b border-stroke-subtle">
               <LayerPanel />
             </div>
-            <div data-categories-panel className="px-4 py-4 border-b border-stroke-subtle min-h-[220px]">
+            <div data-categories-panel className="px-4 py-4 border-b border-stroke-subtle">
               <CategoriesPanel />
             </div>
 


### PR DESCRIPTION
## Summary
Remove `min-h-[220px]` from categories panel that was causing it to clip into the Grid Size panel below.

## Why
The previous PR (#70) added both:
1. Disabled transitions on first render (good - prevents CLS)
2. Added `min-h-[220px]` (bad - conflicted with flex layout)

The transition fix alone is sufficient to prevent CLS. The min-height was causing overflow issues.

## Test plan
- [x] Build passes
- [x] Tests pass
- [ ] Verify categories panel no longer clips into Grid Size panel