### PR TITLE
feat(analytics): add app_loaded event for DAU tracking

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -40,6 +40,12 @@ export function initAnalytics(): void {
       });
       posthogInstance = posthog;
 
+      // Track app load for DAU metrics
+      posthog.capture('app_loaded', {
+        device_type: getDeviceType(),
+        is_returning: Boolean(localStorage.getItem('gridfinity-library-v1')),
+      });
+
       // Flush queued events
       for (const event of eventQueue) {
         posthog.capture(event.name, event.properties);


### PR DESCRIPTION
## Summary
- Add `app_loaded` event on PostHog initialization for accurate DAU/WAU/MAU metrics
- Includes `device_type` and `is_returning` properties

Previously, only `session_engaged` events were tracked which filtered out users with <5 bins, making user counts unreliable.

## Test plan
- [x] Lint passes
- [x] All tests pass
- [x] Build succeeds