### PR TITLE
feat(analytics): enable PostHog pageview and pageleave tracking

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -34,9 +34,10 @@ export function initAnalytics(): void {
     .then(({ default: posthog }) => {
       posthog.init(key, {
         api_host: host,
-        capture_pageview: false, // Vercel Analytics handles this
+        capture_pageview: true,
+        capture_pageleave: true,
         persistence: 'localStorage',
-        autocapture: false, // We'll track manually
+        autocapture: false, // We'll track specific events manually
       });
       posthogInstance = posthog;
 


### PR DESCRIPTION
## Summary
- Enable automatic `$pageview` and `$pageleave` events in PostHog
- Adds `app_loaded` custom event for DAU tracking with device type and returning user info

## Test plan
- [x] Build passes
- [x] All unit tests pass
- [ ] Verify events appear in PostHog dashboard after deploy