### PR TITLE
feat: add Alt+drag to duplicate bins

### DIFF
--- a/e2e/drag-bins.spec.ts
+++ b/e2e/drag-bins.spec.ts
@@ -8,6 +8,7 @@ import {
   getInspector,
   waitForBinCount,
   waitForNoSelection,
+  waitForSelectionCount,
   waitForUndoEnabled,
   clearAllStorage,
   resetViewport,
@@ -127,5 +128,112 @@ test.describe('Drag Bins Flow', () => {
 
     // Inspector should show "No bin selected"
     await expect(inspector.getByText(/no bin selected/i)).toBeVisible({ timeout: 3000 });
+  });
+
+  test('can duplicate bin with Alt+drag', async ({ page }) => {
+    const bounds = await getGridBounds(page);
+
+    // Verify we start with 1 bin
+    await waitForBinCount(page, 1);
+
+    // Select the bin we created
+    await selectBinAt(page, 70, 130);
+
+    // Alt+drag the bin to a new position (this should duplicate it)
+    await page.mouse.move(bounds.x + 70, bounds.y + 130);
+    await page.keyboard.down('Alt');
+    await page.mouse.down();
+    await page.mouse.move(bounds.x + 200, bounds.y + 50, { steps: 10 });
+    await page.mouse.up();
+    await page.keyboard.up('Alt');
+
+    // Should now have 2 bins (original + duplicate)
+    await waitForBinCount(page, 2);
+
+    // Verify the operation created an undoable action
+    await waitForUndoEnabled(page);
+  });
+
+  test('Alt+drag keeps original bin at original position', async ({ page }) => {
+    const bounds = await getGridBounds(page);
+
+    // Verify we start with 1 bin
+    await waitForBinCount(page, 1);
+
+    // Select the bin and check its position before drag
+    await selectBinAt(page, 70, 130);
+    const inspector = getInspector(page);
+    await expect(inspector.getByRole('heading', { name: /^\d×\d Bin$/i })).toBeVisible();
+
+    // Alt+drag the bin to a new position
+    await page.mouse.move(bounds.x + 70, bounds.y + 130);
+    await page.keyboard.down('Alt');
+    await page.mouse.down();
+    await page.mouse.move(bounds.x + 250, bounds.y + 50, { steps: 10 });
+    await page.mouse.up();
+    await page.keyboard.up('Alt');
+
+    // Wait for 2 bins
+    await waitForBinCount(page, 2);
+
+    // The new duplicate should be selected after the drag
+    await waitForSelectionCount(page, 1);
+  });
+
+  test('Alt+drag works with multiple selected bins', async ({ page }) => {
+    const bounds = await getGridBounds(page);
+
+    // Create a second bin
+    await drawBinOnGrid(page, 150, 150, 200, 200);
+    await waitForBinCount(page, 2);
+
+    // Select first bin
+    await selectBinAt(page, 70, 130);
+
+    // Ctrl+click to add second bin to selection
+    await page.keyboard.down('Control');
+    await page.mouse.click(bounds.x + 170, bounds.y + 170);
+    await page.keyboard.up('Control');
+
+    // Verify 2 bins are selected
+    await waitForSelectionCount(page, 2);
+
+    // Alt+drag to duplicate both bins
+    await page.mouse.move(bounds.x + 70, bounds.y + 130);
+    await page.keyboard.down('Alt');
+    await page.mouse.down();
+    await page.mouse.move(bounds.x + 70, bounds.y + 50, { steps: 10 });
+    await page.mouse.up();
+    await page.keyboard.up('Alt');
+
+    // Should now have 4 bins (2 original + 2 duplicates)
+    await waitForBinCount(page, 4);
+  });
+
+  test('Alt+drag can be undone', async ({ page }) => {
+    const bounds = await getGridBounds(page);
+
+    // Verify we start with 1 bin
+    await waitForBinCount(page, 1);
+
+    // Select the bin
+    await selectBinAt(page, 70, 130);
+
+    // Alt+drag to duplicate
+    await page.mouse.move(bounds.x + 70, bounds.y + 130);
+    await page.keyboard.down('Alt');
+    await page.mouse.down();
+    await page.mouse.move(bounds.x + 200, bounds.y + 50, { steps: 10 });
+    await page.mouse.up();
+    await page.keyboard.up('Alt');
+
+    // Wait for 2 bins
+    await waitForBinCount(page, 2);
+
+    // Undo should remove the duplicate
+    await page.keyboard.press('Control+z');
+
+    // Should be back to 1 bin
+    await waitForBinCount(page, 1);
   });
 });

--- a/src/components/Grid/Bin.tsx
+++ b/src/components/Grid/Bin.tsx
@@ -27,7 +27,7 @@ interface BinProps {
   halfBinMode?: boolean;
   isGhost: boolean;
   isSelected: boolean;
-  onStartDrag: (binId: string, clientX: number, clientY: number, pointerId?: number) => void;
+  onStartDrag: (binId: string, clientX: number, clientY: number, pointerId?: number, duplicate?: boolean) => void;
   onStartResize: (binId: string, handle: ResizeHandle, pointerId?: number) => void;
 }
 
@@ -441,6 +441,8 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
         clearLongPress();
       } else if (!isTouchDevice) {
         // Desktop: Normal click - single select and start drag immediately
+        // Alt+drag starts a duplicate operation
+        const isDuplicateDrag = e.altKey;
         if (!isSelected) {
           setSelectedBin(bin.id);
           // Show first-time hint about resize handles
@@ -450,7 +452,7 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
             localStorage.setItem('gridfinity-resize-hint-shown', 'true');
           }
         }
-        onStartDrag(bin.id, e.clientX, e.clientY, e.pointerId);
+        onStartDrag(bin.id, e.clientX, e.clientY, e.pointerId, isDuplicateDrag);
       } else {
         // Touch: Select on pointer down, drag starts on move
         if (!isSelected) {

--- a/src/components/modals/HelpModal.tsx
+++ b/src/components/modals/HelpModal.tsx
@@ -407,6 +407,7 @@ function MouseInteractionsSection() {
         <InteractionRow action="Click bin" description="Select bin" />
         <InteractionRow action="Shift + click" description="Add to selection" />
         <InteractionRow action="Drag selected" description="Move bins" />
+        <InteractionRow action="Alt + drag selected" description="Duplicate bins" />
         <InteractionRow action="Drag edges/corners" description="Resize bin" />
         <InteractionRow action="Double-click bin" description="Quick label edit" />
         <InteractionRow action="Right-click bin" description="Context menu" />

--- a/src/hooks/useInteraction.ts
+++ b/src/hooks/useInteraction.ts
@@ -125,7 +125,8 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
   }, [paintSize, setInteraction]);
 
   // Start dragging bins (single or multiple)
-  const startDrag = useCallback((binId: string, clientX: number, clientY: number, pointerId?: number) => {
+  // Set duplicate=true for Alt+drag to duplicate bins instead of moving them
+  const startDrag = useCallback((binId: string, clientX: number, clientY: number, pointerId?: number, duplicate?: boolean) => {
     const bin = layout.bins.find(b => b.id === binId);
     if (!bin) return;
 
@@ -192,6 +193,7 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
       valid: true,
       isOverGrid: true,
       clickOffset,
+      duplicate,
     });
   }, [layout.bins, layout.drawer.depth, selectedBinIds, setSelectedBin, setInteraction, getGridCoords, gridRef]);
 
@@ -582,21 +584,54 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
 
           if (deltaX !== 0 || deltaY !== 0) {
             const layer = layout.layers.find(l => l.id === activeLayerId);
-            execute(() => {
-              // Update all dragged bins with uniform delta (preserves arrangement)
-              for (const binId of interaction.binIds) {
-                const bin = layout.bins.find(b => b.id === binId);
-                if (!bin) continue;
 
-                // Apply uniform delta - NO individual clamping
-                updateBin(binId, {
-                  x: bin.x + deltaX,
-                  y: bin.y + deltaY,
-                  layerId: activeLayerId,
-                  height: Math.max(bin.height, layer?.height ?? bin.height),
-                });
+            if (interaction.duplicate) {
+              // Duplicate mode: create copies at new position, keep originals in place
+              const newBinIds: string[] = [];
+              execute(() => {
+                for (const binId of interaction.binIds) {
+                  const bin = layout.bins.find(b => b.id === binId);
+                  if (!bin) continue;
+
+                  const newBinId = addBin({
+                    layerId: activeLayerId,
+                    x: bin.x + deltaX,
+                    y: bin.y + deltaY,
+                    width: bin.width,
+                    depth: bin.depth,
+                    height: Math.max(bin.height, layer?.height ?? bin.height),
+                    clearanceHeight: bin.clearanceHeight,
+                    category: bin.category,
+                    label: bin.label,
+                    notes: bin.notes,
+                  });
+                  if (newBinId) {
+                    newBinIds.push(newBinId);
+                  }
+                }
+              });
+              // Select the newly created duplicates
+              if (newBinIds.length > 0) {
+                setSelectedBins(newBinIds);
               }
-            });
+            } else {
+              // Normal mode: move bins to new position
+              execute(() => {
+                // Update all dragged bins with uniform delta (preserves arrangement)
+                for (const binId of interaction.binIds) {
+                  const bin = layout.bins.find(b => b.id === binId);
+                  if (!bin) continue;
+
+                  // Apply uniform delta - NO individual clamping
+                  updateBin(binId, {
+                    x: bin.x + deltaX,
+                    y: bin.y + deltaY,
+                    layerId: activeLayerId,
+                    height: Math.max(bin.height, layer?.height ?? bin.height),
+                  });
+                }
+              });
+            }
           }
         }
         // If not valid, interaction ends without changes (bins stay in original positions)

--- a/src/test/hooks/useInteraction.test.ts
+++ b/src/test/hooks/useInteraction.test.ts
@@ -1099,6 +1099,424 @@ describe('stagingDrag interaction', () => {
   });
 });
 
+// Test Alt+drag duplicate behavior
+describe('duplicate drag (Alt+drag)', () => {
+  beforeEach(() => {
+    const defaultLayout = createDefaultLayout();
+    useLayoutStore.setState({ layout: defaultLayout });
+    useUIStore.setState({
+      activeLayerId: defaultLayout.layers[0].id,
+      selectedBinIds: [],
+      activeCategoryId: defaultLayout.categories[0].id,
+      zoom: 1,
+      showOtherLayers: true,
+      showLabels: true,
+      leftPanelCollapsed: false,
+      rightPanelCollapsed: false,
+      interaction: null,
+      dropTarget: null,
+      paintSize: null,
+      activeMobilePanel: null,
+      contextMenu: null,
+      showIsometricPreview: true,
+      isometricRotation: 0,
+      layerViewMode: 'focus',
+      isPreviewExpanded: false,
+    });
+    useHistoryStore.setState({
+      past: [],
+      future: [],
+      canUndo: false,
+      canRedo: false,
+    });
+  });
+
+  it('initializes duplicate drag interaction with duplicate flag', () => {
+    const { addBin, layout } = useLayoutStore.getState();
+    const layerId = layout.layers[0].id;
+    const categoryId = layout.categories[0].id;
+
+    const binId = addBin({
+      layerId,
+      x: 2,
+      y: 2,
+      width: 2,
+      depth: 2,
+      height: 3,
+      category: categoryId,
+      label: 'Original',
+      notes: '',
+    });
+
+    const gridRef = createMockGridRef();
+    const { result } = renderHook(() => useInteraction(gridRef));
+
+    // Start duplicate drag (Alt+drag)
+    act(() => {
+      result.current.startDrag(binId!, 68, 68, undefined, true);
+    });
+
+    const interaction = useUIStore.getState().interaction;
+    expect(interaction).not.toBeNull();
+    expect(interaction?.type).toBe('drag');
+    if (interaction?.type === 'drag') {
+      expect(interaction.binIds).toContain(binId);
+      expect(interaction.duplicate).toBe(true);
+    }
+  });
+
+  it('creates duplicate bins at new position on drag end', () => {
+    const { addBin, layout } = useLayoutStore.getState();
+    const layerId = layout.layers[0].id;
+    const categoryId = layout.categories[0].id;
+
+    const binId = addBin({
+      layerId,
+      x: 0,
+      y: 0,
+      width: 2,
+      depth: 2,
+      height: 3,
+      category: categoryId,
+      label: 'Original',
+      notes: 'Test notes',
+    });
+
+    expect(useLayoutStore.getState().layout.bins).toHaveLength(1);
+
+    const gridRef = createMockGridRef();
+    const { result } = renderHook(() => useInteraction(gridRef));
+
+    // Start duplicate drag
+    act(() => {
+      result.current.startDrag(binId!, 34, 34, undefined, true);
+    });
+
+    // Set up a valid drop position with delta movement
+    act(() => {
+      useUIStore.setState({
+        ...useUIStore.getState(),
+        interaction: {
+          type: 'drag',
+          binIds: [binId!],
+          startCoord: { x: 0, y: 0 },
+          currentCoord: { x: 3, y: 0 }, // Delta: move 3 units right
+          valid: true,
+          isOverGrid: true,
+          duplicate: true,
+        },
+      });
+    });
+
+    // Simulate pointer up
+    act(() => {
+      const upEvent = new PointerEvent('pointerup', { bubbles: true });
+      document.dispatchEvent(upEvent);
+    });
+
+    // Should now have 2 bins
+    const bins = useLayoutStore.getState().layout.bins;
+    expect(bins).toHaveLength(2);
+
+    // Original should still be at original position
+    const original = bins.find(b => b.id === binId);
+    expect(original?.x).toBe(0);
+    expect(original?.y).toBe(0);
+
+    // New bin should be at new position with same properties
+    const duplicate = bins.find(b => b.id !== binId);
+    expect(duplicate?.x).toBe(3);
+    expect(duplicate?.y).toBe(0);
+    expect(duplicate?.width).toBe(2);
+    expect(duplicate?.depth).toBe(2);
+    expect(duplicate?.label).toBe('Original');
+    expect(duplicate?.notes).toBe('Test notes');
+    expect(duplicate?.category).toBe(categoryId);
+  });
+
+  it('duplicates multiple selected bins preserving arrangement', () => {
+    const { addBin, layout } = useLayoutStore.getState();
+    const layerId = layout.layers[0].id;
+    const categoryId = layout.categories[0].id;
+
+    const binId1 = addBin({
+      layerId,
+      x: 0,
+      y: 0,
+      width: 2,
+      depth: 2,
+      height: 3,
+      category: categoryId,
+      label: 'Bin 1',
+      notes: '',
+    });
+
+    const binId2 = addBin({
+      layerId,
+      x: 2,
+      y: 0,
+      width: 2,
+      depth: 2,
+      height: 3,
+      category: categoryId,
+      label: 'Bin 2',
+      notes: '',
+    });
+
+    expect(useLayoutStore.getState().layout.bins).toHaveLength(2);
+
+    // Select both bins
+    useUIStore.getState().setSelectedBins([binId1!, binId2!]);
+
+    const gridRef = createMockGridRef();
+    const { result } = renderHook(() => useInteraction(gridRef));
+
+    // Start duplicate drag on first bin
+    act(() => {
+      result.current.startDrag(binId1!, 34, 34, undefined, true);
+    });
+
+    // Set up valid drop with delta
+    act(() => {
+      useUIStore.setState({
+        ...useUIStore.getState(),
+        interaction: {
+          type: 'drag',
+          binIds: [binId1!, binId2!],
+          startCoord: { x: 0, y: 0 },
+          currentCoord: { x: 0, y: 3 }, // Delta: move 3 units up
+          valid: true,
+          isOverGrid: true,
+          duplicate: true,
+        },
+      });
+    });
+
+    // Simulate pointer up
+    act(() => {
+      const upEvent = new PointerEvent('pointerup', { bubbles: true });
+      document.dispatchEvent(upEvent);
+    });
+
+    // Should now have 4 bins (2 original + 2 duplicates)
+    const bins = useLayoutStore.getState().layout.bins;
+    expect(bins).toHaveLength(4);
+
+    // Originals should still be at original positions
+    const original1 = bins.find(b => b.id === binId1);
+    const original2 = bins.find(b => b.id === binId2);
+    expect(original1?.x).toBe(0);
+    expect(original1?.y).toBe(0);
+    expect(original2?.x).toBe(2);
+    expect(original2?.y).toBe(0);
+
+    // Duplicates should be at new positions preserving relative arrangement
+    const duplicates = bins.filter(b => b.id !== binId1 && b.id !== binId2);
+    expect(duplicates).toHaveLength(2);
+
+    // Find duplicates by their labels
+    const dup1 = duplicates.find(b => b.label === 'Bin 1');
+    const dup2 = duplicates.find(b => b.label === 'Bin 2');
+    expect(dup1?.x).toBe(0);
+    expect(dup1?.y).toBe(3);
+    expect(dup2?.x).toBe(2);
+    expect(dup2?.y).toBe(3);
+  });
+
+  it('does not duplicate bins when drop position is invalid', () => {
+    const { addBin, layout } = useLayoutStore.getState();
+    const layerId = layout.layers[0].id;
+    const categoryId = layout.categories[0].id;
+
+    const binId = addBin({
+      layerId,
+      x: 0,
+      y: 0,
+      width: 2,
+      depth: 2,
+      height: 3,
+      category: categoryId,
+      label: '',
+      notes: '',
+    });
+
+    expect(useLayoutStore.getState().layout.bins).toHaveLength(1);
+
+    const gridRef = createMockGridRef();
+    renderHook(() => useInteraction(gridRef));
+
+    // Set up invalid drop (collision or out of bounds)
+    act(() => {
+      useUIStore.setState({
+        ...useUIStore.getState(),
+        interaction: {
+          type: 'drag',
+          binIds: [binId!],
+          startCoord: { x: 0, y: 0 },
+          currentCoord: { x: 0, y: 0 },
+          valid: false, // Invalid position
+          isOverGrid: true,
+          duplicate: true,
+        },
+      });
+    });
+
+    // Simulate pointer up
+    act(() => {
+      const upEvent = new PointerEvent('pointerup', { bubbles: true });
+      document.dispatchEvent(upEvent);
+    });
+
+    // Should still have only 1 bin
+    expect(useLayoutStore.getState().layout.bins).toHaveLength(1);
+  });
+
+  it('does not duplicate bins when delta is zero (no movement)', () => {
+    const { addBin, layout } = useLayoutStore.getState();
+    const layerId = layout.layers[0].id;
+    const categoryId = layout.categories[0].id;
+
+    const binId = addBin({
+      layerId,
+      x: 2,
+      y: 2,
+      width: 2,
+      depth: 2,
+      height: 3,
+      category: categoryId,
+      label: '',
+      notes: '',
+    });
+
+    expect(useLayoutStore.getState().layout.bins).toHaveLength(1);
+
+    const gridRef = createMockGridRef();
+    renderHook(() => useInteraction(gridRef));
+
+    // Set up duplicate drag with no movement
+    act(() => {
+      useUIStore.setState({
+        ...useUIStore.getState(),
+        interaction: {
+          type: 'drag',
+          binIds: [binId!],
+          startCoord: { x: 2, y: 2 },
+          currentCoord: { x: 0, y: 0 }, // No delta
+          valid: true,
+          isOverGrid: true,
+          duplicate: true,
+        },
+      });
+    });
+
+    // Simulate pointer up
+    act(() => {
+      const upEvent = new PointerEvent('pointerup', { bubbles: true });
+      document.dispatchEvent(upEvent);
+    });
+
+    // Should still have only 1 bin (no duplication on zero movement)
+    expect(useLayoutStore.getState().layout.bins).toHaveLength(1);
+  });
+
+  it('duplicate drag to trash deletes original bins (not duplicate)', () => {
+    const { addBin, layout } = useLayoutStore.getState();
+    const layerId = layout.layers[0].id;
+    const categoryId = layout.categories[0].id;
+
+    const binId = addBin({
+      layerId,
+      x: 2,
+      y: 2,
+      width: 2,
+      depth: 2,
+      height: 3,
+      category: categoryId,
+      label: '',
+      notes: '',
+    });
+
+    expect(useLayoutStore.getState().layout.bins).toHaveLength(1);
+
+    const gridRef = createMockGridRef();
+    renderHook(() => useInteraction(gridRef));
+
+    // Set up duplicate drag
+    act(() => {
+      useUIStore.setState({
+        ...useUIStore.getState(),
+        interaction: {
+          type: 'drag',
+          binIds: [binId!],
+          startCoord: { x: 2, y: 2 },
+          currentCoord: { x: 3, y: 3 },
+          valid: true,
+          isOverGrid: true,
+          duplicate: true,
+        },
+        dropTarget: 'trash',
+      });
+    });
+
+    // Simulate pointer up
+    act(() => {
+      const upEvent = new PointerEvent('pointerup', { bubbles: true });
+      document.dispatchEvent(upEvent);
+    });
+
+    // Trash should still delete the bins (duplicate mode doesn't change trash behavior)
+    expect(useLayoutStore.getState().layout.bins).toHaveLength(0);
+  });
+
+  it('selects duplicated bins after successful duplicate drag', () => {
+    const { addBin, layout } = useLayoutStore.getState();
+    const layerId = layout.layers[0].id;
+    const categoryId = layout.categories[0].id;
+
+    const binId = addBin({
+      layerId,
+      x: 0,
+      y: 0,
+      width: 2,
+      depth: 2,
+      height: 3,
+      category: categoryId,
+      label: '',
+      notes: '',
+    });
+
+    const gridRef = createMockGridRef();
+    renderHook(() => useInteraction(gridRef));
+
+    // Set up duplicate drag with movement
+    act(() => {
+      useUIStore.setState({
+        ...useUIStore.getState(),
+        interaction: {
+          type: 'drag',
+          binIds: [binId!],
+          startCoord: { x: 0, y: 0 },
+          currentCoord: { x: 3, y: 0 },
+          valid: true,
+          isOverGrid: true,
+          duplicate: true,
+        },
+      });
+    });
+
+    // Simulate pointer up
+    act(() => {
+      const upEvent = new PointerEvent('pointerup', { bubbles: true });
+      document.dispatchEvent(upEvent);
+    });
+
+    // The new duplicate should be selected
+    const selectedBinIds = useUIStore.getState().selectedBinIds;
+    expect(selectedBinIds).toHaveLength(1);
+    expect(selectedBinIds[0]).not.toBe(binId); // Should be the new bin, not the original
+  });
+});
+
 // Test stagingDrag behavior
 describe('staging drag', () => {
   beforeEach(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,7 +102,7 @@ export interface HandleVisualConfig {
 
 export type Interaction =
   | { type: 'draw'; start: Coord; current: Coord }
-  | { type: 'drag'; binIds: string[]; startCoord: Coord; currentCoord: Coord; valid: boolean; isOverGrid: boolean; clickOffset?: { x: number; y: number } }
+  | { type: 'drag'; binIds: string[]; startCoord: Coord; currentCoord: Coord; valid: boolean; isOverGrid: boolean; clickOffset?: { x: number; y: number }; duplicate?: boolean }
   | { type: 'resize'; binIds: string[]; handle: ResizeHandle; startRects: Map<string, Rect>; currentRects: Map<string, Rect>; valid: boolean }
   | { type: 'stagingDrag'; binId: string; currentCoord: Coord | null; valid: boolean }
   | { type: 'paint'; paintSize: { width: number; depth: number }; start: Coord; current: Coord };


### PR DESCRIPTION
Add the ability to duplicate bins by holding Alt while dragging. This is
a common pattern in design tools like Figma and Photoshop.

Changes:
- Add duplicate flag to drag interaction type
- Detect Alt key on drag start in Bin component
- Create copies at new position when Alt+drag ends (keep originals)
- Select newly created duplicates after drag
- Support multi-bin Alt+drag (preserves arrangement)

Tests:
- Add unit tests for duplicate drag behavior
- Add E2E tests for Alt+drag workflow

Documentation:
- Add Alt+drag to Mouse interactions in Help modal