### PR TITLE
Setup PostHog reverse proxy with Vercel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 # Posthog Analytics (optional - analytics disabled if not set)
+# API calls are proxied through Vercel (/ph) to avoid ad blockers
 VITE_PUBLIC_POSTHOG_KEY=phc_your_key_here
-VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -22,10 +22,9 @@ export function initAnalytics(): void {
   if (import.meta.env.DEV) return; // Skip in development
 
   const key = import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
-  const host = import.meta.env.VITE_PUBLIC_POSTHOG_HOST;
 
-  if (!key || !host) {
-    console.warn('Posthog env vars not set, analytics disabled');
+  if (!key) {
+    console.warn('Posthog API key not set, analytics disabled');
     return;
   }
 
@@ -33,7 +32,8 @@ export function initAnalytics(): void {
   initPromise = import('posthog-js')
     .then(({ default: posthog }) => {
       posthog.init(key, {
-        api_host: host,
+        api_host: '/ph',
+        ui_host: 'https://us.posthog.com',
         capture_pageview: true,
         capture_pageleave: true,
         persistence: 'localStorage',

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,14 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] && [ -z \"$VERCEL_GIT_PULL_REQUEST_ID\" ]",
   "rewrites": [
+    {
+      "source": "/ph/static/:path(.*)",
+      "destination": "https://us-assets.i.posthog.com/static/:path"
+    },
+    {
+      "source": "/ph/:path(.*)",
+      "destination": "https://us.i.posthog.com/:path"
+    },
     { "source": "/s/:id", "destination": "/" }
   ]
 }


### PR DESCRIPTION
Configure Vercel rewrites to proxy PostHog requests through /ph path to avoid ad blockers.

Changes:
- Add PostHog proxy rewrites to vercel.json (/ph/static and /ph)
- Update analytics.ts to use proxy path (/ph) instead of direct host
- Remove VITE_PUBLIC_POSTHOG_HOST env var (no longer needed)
- Add ui_host configuration for PostHog UI features

The proxy routes requests to us.i.posthog.com and us-assets.i.posthog.com through the Vercel edge network, making analytics more reliable by bypassing common ad blocker domain filters.