### PR TITLE
Fix sitemap.xml accessibility issue

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,5 +4,11 @@
 User-agent: *
 Allow: /
 
-# Sitemap (single-page app, main page only)
+# Disallow API endpoints (not useful for search engines)
+Disallow: /api/
+
+# Disallow shared layout URLs (user-generated content, dynamic)
+Disallow: /s/
+
+# Sitemap location
 Sitemap: https://gridfinitylayouttool.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,13 +3,13 @@
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://gridfinitylayouttool.com/</loc>
-    <lastmod>2026-01-11</lastmod>
+    <lastmod>2026-01-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <image:image>
       <image:loc>https://gridfinitylayouttool.com/og-image.png</image:loc>
       <image:title>Gridfinity Layout Tool - Design Drawer Layouts for 3D Printing</image:title>
-      <image:caption>Free online tool to design Gridfinity drawer organizer layouts with drag-and-drop bin placement</image:caption>
+      <image:caption>Free online tool to design Gridfinity drawer organizer layouts with drag-and-drop bin placement, multi-layer support, and 3D preview</image:caption>
     </image:image>
   </url>
 </urlset>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,8 +52,12 @@ export default defineConfig({
         cleanupOutdatedCaches: true,
         // SPA navigation fallback - serve index.html for all navigation requests
         navigateFallback: '/index.html',
-        // Don't intercept API calls with navigation fallback
-        navigateFallbackDenylist: [/^\/api\//],
+        // Don't intercept these paths with navigation fallback
+        navigateFallbackDenylist: [
+          /^\/api\//,
+          /^\/sitemap\.xml$/,
+          /^\/robots\.txt$/,
+        ],
         runtimeCaching: [
           {
             // Cache shared layout API responses for offline viewing


### PR DESCRIPTION
The PWA service worker's navigateFallback was intercepting requests to /sitemap.xml and /robots.txt, returning index.html instead of the actual files. Added these paths to navigateFallbackDenylist.

Also improved SEO:
- robots.txt: Disallow /api/ and /s/ (user-generated shared layouts)
- sitemap.xml: Updated lastmod and improved image caption