### PR TITLE
fix: persist and restore active layout when rejoining collections

### DIFF
--- a/src/components/modals/LayoutManagerModal/index.tsx
+++ b/src/components/modals/LayoutManagerModal/index.tsx
@@ -38,13 +38,14 @@ function LayoutManagerModalContent({ onClose }: { onClose: () => void }) {
   const modalRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
-  const { isInCollectionMode, activeCollection, activeCollectionLayouts, leaveCollection, addLayoutToCollection } = useCollectionStore(
+  const { isInCollectionMode, activeCollection, activeCollectionLayouts, leaveCollection, addLayoutToCollection, setMembershipActiveLayout } = useCollectionStore(
     useShallow((state) => ({
       isInCollectionMode: state.isInCollectionMode(),
       activeCollection: state.activeCollection,
       activeCollectionLayouts: state.activeCollectionLayouts,
       leaveCollection: state.leaveCollection,
       addLayoutToCollection: state.addLayoutToCollection,
+      setMembershipActiveLayout: state.setMembershipActiveLayout,
     }))
   );
 
@@ -131,11 +132,13 @@ function LayoutManagerModalContent({ onClose }: { onClose: () => void }) {
 
       if (result.success) {
         importLayout(result.data.layout as Layout, layoutId);
+        // Save active layout ID for restoration on reload
+        setMembershipActiveLayout(activeCollection.id, layoutId);
         announceToScreenReader(`Switched to ${layoutRef?.name || 'layout'}`);
         onClose();
       }
     },
-    [activeCollection, activeCollectionLayouts, importLayout, announceToScreenReader, onClose]
+    [activeCollection, activeCollectionLayouts, importLayout, setMembershipActiveLayout, announceToScreenReader, onClose]
   );
 
   const handleCreate = useCallback(() => {

--- a/src/hooks/useCollectionRouting.ts
+++ b/src/hooks/useCollectionRouting.ts
@@ -9,11 +9,13 @@
  * - Detects collection URLs on mount and joins the collection
  * - Handles browser back/forward navigation
  * - Updates URL when leaving collection mode
+ * - Restores the previously active layout when rejoining a collection
  */
 
 import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { useCollectionStore } from '../store/collection';
+import { useLayoutStore } from '../store/layout';
 import { useToastStore } from '../store/toast';
 import { useUIStore } from '../store/ui';
 import {
@@ -23,28 +25,37 @@ import {
   getCollectionFromHistoryState,
   isCollectionURL,
 } from '../utils/url';
-import { getCollectionErrorMessage } from '../api/collection';
+import { getCollectionErrorMessage, fetchLayout } from '../api/collection';
+import type { Layout } from '../types';
 
 export function useCollectionRouting() {
   const hasInitialized = useRef(false);
+  const isRestoringLayoutRef = useRef(false);
 
   const {
     activeCollection,
+    activeCollectionLayouts,
     joinCollection,
     leaveCollection,
     loadingState,
     setPendingInvite,
     getMembership,
+    setMembershipActiveLayout,
   } = useCollectionStore(
     useShallow((state) => ({
       activeCollection: state.activeCollection,
+      activeCollectionLayouts: state.activeCollectionLayouts,
       joinCollection: state.joinCollection,
       leaveCollection: state.leaveCollection,
       loadingState: state.loadingState,
       setPendingInvite: state.setPendingInvite,
       getMembership: state.getMembership,
+      setMembershipActiveLayout: state.setMembershipActiveLayout,
     }))
   );
+
+  const importLayout = useLayoutStore((state) => state.importLayout);
+  const activeLayoutId = useLayoutStore((state) => state.activeLayoutId);
 
   const addToast = useToastStore((state) => state.addToast);
   const announceToScreenReader = useUIStore((state) => state.announceToScreenReader);
@@ -134,6 +145,66 @@ export function useCollectionRouting() {
       clearCollectionURL();
     }
   }, [activeCollection]);
+
+  // Restore previously active layout when rejoining a collection
+  useEffect(() => {
+    // Skip if no active collection or layouts not yet loaded
+    if (!activeCollection || activeCollectionLayouts.length === 0) return;
+    // Prevent running multiple times during restoration
+    if (isRestoringLayoutRef.current) return;
+
+    const membership = getMembership(activeCollection.id);
+    if (!membership) return;
+
+    // Determine which layout to load
+    let layoutIdToLoad = membership.activeLayoutId;
+
+    // Verify the saved layout still exists in the collection
+    if (layoutIdToLoad) {
+      const layoutExists = activeCollectionLayouts.some((l) => l.id === layoutIdToLoad);
+      if (!layoutExists) {
+        // Saved layout was deleted, fall back to first layout
+        layoutIdToLoad = activeCollectionLayouts[0].id;
+      }
+    } else {
+      // No saved layout, use first layout in collection
+      layoutIdToLoad = activeCollectionLayouts[0].id;
+    }
+
+    // Skip if no layout to load or already loaded
+    if (!layoutIdToLoad || activeLayoutId === layoutIdToLoad) return;
+
+    // Fetch and load the layout
+    isRestoringLayoutRef.current = true;
+    const targetLayoutId = layoutIdToLoad;
+
+    const restoreLayout = async () => {
+      try {
+        const result = await fetchLayout(activeCollection.id, targetLayoutId);
+        if (result.success) {
+          importLayout(result.data.layout as Layout, targetLayoutId);
+          // Update membership with the loaded layout ID
+          setMembershipActiveLayout(activeCollection.id, targetLayoutId);
+          const layoutRef = activeCollectionLayouts.find((l) => l.id === targetLayoutId);
+          announceToScreenReader(`Loaded layout: ${layoutRef?.name || 'Untitled'}`);
+        }
+      } catch {
+        // Silently fail - user can manually select a layout
+      } finally {
+        isRestoringLayoutRef.current = false;
+      }
+    };
+
+    restoreLayout();
+  }, [
+    activeCollection,
+    activeCollectionLayouts,
+    activeLayoutId,
+    getMembership,
+    importLayout,
+    setMembershipActiveLayout,
+    announceToScreenReader,
+  ]);
 
   return {
     navigateToCollection,

--- a/src/store/collection.ts
+++ b/src/store/collection.ts
@@ -80,6 +80,7 @@ interface CollectionState {
   addMembership: (membership: CollectionMembership) => void;
   removeMembership: (collectionId: string) => void;
   updateMembershipAccess: (collectionId: string) => void;
+  setMembershipActiveLayout: (collectionId: string, layoutId: string) => void;
   getRecentMemberships: (count: number) => CollectionMembership[];
   getMembership: (collectionId: string) => CollectionMembership | undefined;
 
@@ -189,6 +190,20 @@ export const useCollectionStore = create<CollectionState>()(
           (m) => m.collectionId === collectionId
         );
         if (membership) {
+          membership.lastAccessedAt = Date.now();
+        }
+      });
+      // Persist after update
+      saveCollectionMemberships(get().memberships);
+    },
+
+    setMembershipActiveLayout: (collectionId, layoutId) => {
+      set((state) => {
+        const membership = state.memberships.find(
+          (m) => m.collectionId === collectionId
+        );
+        if (membership) {
+          membership.activeLayoutId = layoutId;
           membership.lastAccessedAt = Date.now();
         }
       });

--- a/src/test/store/collection.test.ts
+++ b/src/test/store/collection.test.ts
@@ -163,6 +163,43 @@ describe('Collection Store', () => {
       const after = useCollectionStore.getState().memberships[0].lastAccessedAt;
       expect(after).toBeGreaterThan(before);
     });
+
+    it('should set active layout ID for a membership', () => {
+      const { addMembership, setMembershipActiveLayout } = useCollectionStore.getState();
+
+      addMembership(mockMembership);
+      setMembershipActiveLayout('abc123def456', 'layout-123');
+
+      const membership = useCollectionStore.getState().getMembership('abc123def456');
+      expect(membership?.activeLayoutId).toBe('layout-123');
+    });
+
+    it('should update activeLayoutId and lastAccessedAt together', () => {
+      const { addMembership, setMembershipActiveLayout } = useCollectionStore.getState();
+
+      const olderMembership = {
+        ...mockMembership,
+        lastAccessedAt: Date.now() - 10000,
+      };
+      addMembership(olderMembership);
+      const before = useCollectionStore.getState().memberships[0].lastAccessedAt;
+
+      setMembershipActiveLayout('abc123def456', 'layout-456');
+
+      const membership = useCollectionStore.getState().getMembership('abc123def456');
+      expect(membership?.activeLayoutId).toBe('layout-456');
+      expect(membership?.lastAccessedAt).toBeGreaterThan(before);
+    });
+
+    it('should do nothing when setting activeLayoutId for non-existent membership', () => {
+      const { setMembershipActiveLayout } = useCollectionStore.getState();
+
+      // Should not throw
+      setMembershipActiveLayout('nonexistent', 'layout-123');
+
+      const { memberships } = useCollectionStore.getState();
+      expect(memberships).toHaveLength(0);
+    });
   });
 
   describe('Sync State Tracking', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -348,6 +348,7 @@ export interface CollectionMembership {
   joinedAt: number;
   lastSyncAt: number;
   lastAccessedAt: number;          // For sorting collections by recency
+  activeLayoutId?: string;         // Last viewed layout in this collection (for restore on reload)
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes issue where layouts in a collection were not being persisted after reload
- Adds `activeLayoutId` to `CollectionMembership` type to track the last viewed layout
- Automatically restores the previously active layout when rejoining a collection
- Falls back to the first layout if the saved layout was deleted from the collection

## Changes

1. **Type update** (`src/types.ts`): Added `activeLayoutId?: string` to `CollectionMembership`

2. **Store update** (`src/store/collection.ts`): Added `setMembershipActiveLayout()` function to save the active layout ID and persist to localStorage

3. **Routing hook** (`src/hooks/useCollectionRouting.ts`): Added effect to auto-load saved layout after joining a collection

4. **Layout switching** (`src/components/modals/LayoutManagerModal/index.tsx`): Saves active layout ID when user switches layouts within a collection

## Test plan

- [x] All 3092 tests pass
- [x] Build succeeds
- [ ] Manual testing: Join a collection, switch layouts, reload page - should restore last viewed layout
- [ ] Manual testing: Delete the active layout from collection, reload - should fall back to first layout