### PR TITLE
fix: collection sync and layout switching between modes

### DIFF
--- a/src/components/modals/LayoutManagerModal/index.tsx
+++ b/src/components/modals/LayoutManagerModal/index.tsx
@@ -38,7 +38,7 @@ function LayoutManagerModalContent({ onClose }: { onClose: () => void }) {
   const modalRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
-  const { isInCollectionMode, activeCollection, activeCollectionLayouts, leaveCollection, addLayoutToCollection, setMembershipActiveLayout } = useCollectionStore(
+  const { isInCollectionMode, activeCollection, activeCollectionLayouts, leaveCollection, addLayoutToCollection, setMembershipActiveLayout, clearActiveCollection } = useCollectionStore(
     useShallow((state) => ({
       isInCollectionMode: state.isInCollectionMode(),
       activeCollection: state.activeCollection,
@@ -46,6 +46,7 @@ function LayoutManagerModalContent({ onClose }: { onClose: () => void }) {
       leaveCollection: state.leaveCollection,
       addLayoutToCollection: state.addLayoutToCollection,
       setMembershipActiveLayout: state.setMembershipActiveLayout,
+      clearActiveCollection: state.clearActiveCollection,
     }))
   );
 
@@ -112,6 +113,12 @@ function LayoutManagerModalContent({ onClose }: { onClose: () => void }) {
 
   const handleSwitch = useCallback(
     (id: string) => {
+      // Exit collection mode when switching to a local layout
+      // This prevents the collection routing hook from re-loading the collection layout
+      if (isInCollectionMode) {
+        clearActiveCollection();
+      }
+
       const entry = library.entries.find((e) => e.id === id);
       const result = switchLayout(id);
       if (result.success) {
@@ -119,7 +126,7 @@ function LayoutManagerModalContent({ onClose }: { onClose: () => void }) {
         onClose();
       }
     },
-    [library.entries, switchLayout, announceToScreenReader, onClose]
+    [library.entries, switchLayout, announceToScreenReader, onClose, isInCollectionMode, clearActiveCollection]
   );
 
   // Handle switching to a collection layout (fetches from server)

--- a/src/hooks/useCollectionSync.ts
+++ b/src/hooks/useCollectionSync.ts
@@ -108,6 +108,7 @@ export function useCollectionSync() {
 
   const layout = useLayoutStore((state) => state.layout);
   const activeLayoutId = useLayoutStore((state) => state.activeLayoutId);
+  const importLayout = useLayoutStore((state) => state.importLayout);
 
   // Refs for intervals
   const pollIntervalRef = useRef<number | null>(null);
@@ -343,6 +344,59 @@ export function useCollectionSync() {
     }, PUSH_DEBOUNCE_MS);
   }, [activeCollection, activeLayoutId, markLayoutModified, pushChanges]);
 
+  // Ref to track if this is the initial mount (to skip triggering on first render)
+  const isInitialMount = useRef(true);
+  // Ref to track the previous layout ID (to skip triggering when switching layouts)
+  const prevLayoutIdRef = useRef<string | null>(null);
+
+  /**
+   * Subscribe to layout store changes and trigger onLayoutChange.
+   * This is the critical wiring that enables collection sync.
+   */
+  useEffect(() => {
+    // Skip if not in collection mode
+    if (!activeCollection || !activeLayoutId) {
+      isInitialMount.current = true;
+      prevLayoutIdRef.current = null;
+      return;
+    }
+
+    // Track the previous layout for comparison
+    let prevLayout = useLayoutStore.getState().layout;
+
+    // Subscribe to all state changes
+    const unsubscribe = useLayoutStore.subscribe((state) => {
+      const currentLayout = state.layout;
+      const currentLayoutId = state.activeLayoutId;
+
+      // Skip if layout hasn't changed (reference equality check)
+      if (currentLayout === prevLayout) {
+        return;
+      }
+      prevLayout = currentLayout;
+
+      // Skip the initial mount
+      if (isInitialMount.current) {
+        isInitialMount.current = false;
+        prevLayoutIdRef.current = currentLayoutId;
+        return;
+      }
+
+      // Skip if we just switched layouts (the layout ID changed)
+      if (currentLayoutId !== prevLayoutIdRef.current) {
+        prevLayoutIdRef.current = currentLayoutId;
+        return;
+      }
+
+      // This is a real edit - trigger the sync
+      onLayoutChange();
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [activeCollection, activeLayoutId, onLayoutChange]);
+
   /**
    * Resolve conflict by choosing a resolution strategy.
    */
@@ -380,8 +434,10 @@ export function useCollectionSync() {
           );
 
           if (result.success) {
-            // Update the layout store with server version
-            // This would need integration with useLayoutSwitcher or similar
+            // Import the server version into the layout store
+            importLayout(result.data.layout, layoutId);
+
+            // Update sync state
             setStoreSyncState(layoutId, {
               modifiedAt: result.data.modifiedAt,
               lastSyncAt: Date.now(),
@@ -415,6 +471,7 @@ export function useCollectionSync() {
       syncState.conflict,
       setStoreSyncState,
       clearLocalModification,
+      importLayout,
     ]
   );
 


### PR DESCRIPTION
## Summary

Three critical fixes for collection functionality:

### 1. Fix switching from collection to local layouts
When switching from a collection layout to a local layout, the collection routing hook was immediately re-loading the collection layout (because `activeCollection` was still set). Now exits collection mode when switching to a local layout.

### 2. Wire layout changes to collection sync (was completely broken!)
**This was the main sync issue** - `onLayoutChange()` was defined in `useCollectionSync` but never called anywhere. Added a subscription to the layout store that triggers `onLayoutChange()` when the layout is modified in collection mode. This enables:
- Detecting local edits
- Marking layouts as locally modified
- Triggering debounced push to server

### 3. Fix "use theirs" conflict resolution
The `use-theirs` conflict resolution strategy fetched the server version but never actually imported it into the layout store. Now properly imports the fetched layout.

## Changes

- `src/components/modals/LayoutManagerModal/index.tsx`: Call `clearActiveCollection()` when switching to a local layout
- `src/hooks/useCollectionSync.ts`: 
  - Add layout store subscription to detect changes and trigger sync
  - Fix `use-theirs` to import the fetched layout

## Test plan

- [x] All 3092 tests pass
- [x] Build succeeds
- [ ] Manual testing: Edit a bin in collection mode - should sync to server after 2.5s
- [ ] Manual testing: Switch from collection to local layout - should work without snapping back
- [ ] Manual testing: Trigger a conflict and choose "use theirs" - should apply server changes