### PR TITLE
fix: prevent #local hash in collection URLs + add sync debug logging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useLayoutStore, useUIStore, useLibraryStore } from './store';
 import { useKeyboard, useAutoSave, useResponsive, useCrossTabSync, useLayoutRouting, usePWAUpdate, useAnalytics, useCollectionRouting } from './hooks';
 import { useCollectionStore } from './store/collection';
 import { initializeLayoutLibrary } from './utils/storage';
+import { isCollectionURL } from './utils/url';
 import { lazyWithRetry, namedExport } from './utils/lazyWithRetry';
 import { Grid } from './components/Grid';
 import { Sidebar } from './components/Sidebar';
@@ -45,7 +46,14 @@ let initialLoadError: Error | null = null;
 try {
   const { library, activeLayout } = initializeLayoutLibrary();
   useLibraryStore.getState().initLibrary(library);
-  useLayoutStore.getState().importLayout(activeLayout, library.activeLayoutId);
+
+  // Skip loading local layout if we're on a collection URL
+  // The collection routing will handle loading the appropriate layout
+  // This prevents the visual flash of the local layout before the collection layout loads
+  if (!isCollectionURL()) {
+    useLayoutStore.getState().importLayout(activeLayout, library.activeLayoutId);
+  }
+
   // Initialize collection memberships from localStorage
   useCollectionStore.getState().initMemberships();
 } catch (e) {

--- a/src/hooks/useCollectionSync.ts
+++ b/src/hooks/useCollectionSync.ts
@@ -257,24 +257,41 @@ export function useCollectionSync() {
    * Push local changes to server.
    */
   const pushChanges = useCallback(async () => {
-    if (!activeCollection || !activeLayoutId) return;
-    if (!hasLocalChanges(activeLayoutId)) return;
+    console.warn('[CollectionSync] pushChanges called', { activeCollection: !!activeCollection, activeLayoutId });
+    if (!activeCollection || !activeLayoutId) {
+      console.warn('[CollectionSync] pushChanges early return - no collection or layout');
+      return;
+    }
+    const hasChanges = hasLocalChanges(activeLayoutId);
+    console.warn('[CollectionSync] hasLocalChanges:', hasChanges);
+    if (!hasChanges) {
+      console.warn('[CollectionSync] pushChanges early return - no local changes');
+      return;
+    }
 
     // Check online status
     if (!navigator.onLine) {
+      console.warn('[CollectionSync] pushChanges - offline');
       setSyncState((prev) => ({ ...prev, status: 'offline' }));
       return;
     }
 
+    console.warn('[CollectionSync] Starting push to server...');
     setSyncState((prev) => ({ ...prev, status: 'syncing' }));
 
     const currentSyncState = syncStates[activeLayoutId];
+    console.warn('[CollectionSync] Calling updateLayout API', {
+      collectionId: activeCollection.id,
+      layoutId: activeLayoutId,
+      expectedModifiedAt: currentSyncState?.modifiedAt
+    });
     const result = await collectionApi.updateLayout(
       activeCollection.id,
       activeLayoutId,
       layout,
       { expectedModifiedAt: currentSyncState?.modifiedAt }
     );
+    console.warn('[CollectionSync] API result:', result);
 
     if (result.success) {
       // Update sync state with new server timestamp
@@ -326,9 +343,14 @@ export function useCollectionSync() {
    * Mark layout as modified and schedule debounced push.
    */
   const onLayoutChange = useCallback(() => {
-    if (!activeCollection || !activeLayoutId) return;
+    console.warn('[CollectionSync] onLayoutChange called', { activeCollection: !!activeCollection, activeLayoutId });
+    if (!activeCollection || !activeLayoutId) {
+      console.warn('[CollectionSync] onLayoutChange early return - no collection or layout');
+      return;
+    }
 
     // Mark as locally modified
+    console.warn('[CollectionSync] Marking layout as modified:', activeLayoutId);
     markLayoutModified(activeLayoutId);
     isEditingRef.current = true;
 
@@ -338,7 +360,9 @@ export function useCollectionSync() {
     }
 
     // Schedule new push
+    console.warn('[CollectionSync] Scheduling push in', PUSH_DEBOUNCE_MS, 'ms');
     pushTimeoutRef.current = window.setTimeout(() => {
+      console.warn('[CollectionSync] Push timeout fired, calling pushChanges');
       pushChanges();
       pushTimeoutRef.current = null;
     }, PUSH_DEBOUNCE_MS);
@@ -370,13 +394,16 @@ export function useCollectionSync() {
    * recreated on every edit, resetting the change detection state.
    */
   useEffect(() => {
+    console.warn('[CollectionSync] Subscription effect running', { activeCollection: !!activeCollection, activeLayoutId });
     // Skip if not in collection mode
     if (!activeCollection || !activeLayoutId) {
+      console.warn('[CollectionSync] Not in collection mode, skipping subscription');
       isInitialMount.current = true;
       prevLayoutIdRef.current = null;
       return;
     }
 
+    console.warn('[CollectionSync] Setting up layout store subscription');
     // Track the previous layout for comparison
     let prevLayout = useLayoutStore.getState().layout;
 
@@ -389,10 +416,12 @@ export function useCollectionSync() {
       if (currentLayout === prevLayout) {
         return;
       }
+      console.warn('[CollectionSync] Layout changed (reference equality check passed)');
       prevLayout = currentLayout;
 
       // Skip the initial mount
       if (isInitialMount.current) {
+        console.warn('[CollectionSync] Skipping initial mount change');
         isInitialMount.current = false;
         prevLayoutIdRef.current = currentLayoutId;
         return;
@@ -400,15 +429,18 @@ export function useCollectionSync() {
 
       // Skip if we just switched layouts (the layout ID changed)
       if (currentLayoutId !== prevLayoutIdRef.current) {
+        console.warn('[CollectionSync] Layout ID changed, skipping', { current: currentLayoutId, prev: prevLayoutIdRef.current });
         prevLayoutIdRef.current = currentLayoutId;
         return;
       }
 
       // This is a real edit - trigger the sync via ref
+      console.warn('[CollectionSync] Real edit detected, triggering onLayoutChange');
       onLayoutChangeRef.current();
     });
 
     return () => {
+      console.warn('[CollectionSync] Cleaning up subscription');
       unsubscribe();
     };
   }, [activeCollection, activeLayoutId]);

--- a/src/hooks/useLayoutRouting.ts
+++ b/src/hooks/useLayoutRouting.ts
@@ -9,6 +9,7 @@ import {
   clearLayoutHash,
   getLayoutIdFromHistoryState,
   hasShareHash,
+  isCollectionURL,
 } from '../utils/url';
 
 /**
@@ -111,6 +112,9 @@ export function useLayoutRouting() {
     // Share links take precedence - let SharedLayoutImporter handle them
     if (hasShareHash()) return;
 
+    // Collection URLs are handled by useCollectionRouting - don't interfere
+    if (isCollectionURL()) return;
+
     const hashLayoutId = parseLayoutIdFromHash();
     if (!hashLayoutId) {
       // No layout in URL - set URL to current active layout
@@ -154,6 +158,9 @@ export function useLayoutRouting() {
     const handlePopState = (event: PopStateEvent) => {
       // Don't handle during shared preview
       if (sharedLayoutPreview) return;
+
+      // Collection navigation is handled by useCollectionRouting
+      if (isCollectionURL()) return;
 
       // Try to get layout ID from history state first
       let layoutId = getLayoutIdFromHistoryState(event.state);
@@ -205,6 +212,16 @@ export function useLayoutRouting() {
 
     // Skip if library not loaded yet
     if (!isLoaded) return;
+
+    // Collection URLs are handled by useCollectionRouting - don't add #local/ hash
+    // Collection layouts are cloud-synced, not local-only
+    if (isCollectionURL()) {
+      // Clear any existing local hash (e.g., when switching from local to collection)
+      if (parseLayoutIdFromHash()) {
+        clearLayoutHash();
+      }
+      return;
+    }
 
     // Update URL to match current layout (without adding to history)
     // History is only added during explicit layout switches

--- a/src/test/hooks/useLayoutRouting.test.ts
+++ b/src/test/hooks/useLayoutRouting.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../utils/url', () => ({
   clearLayoutHash: vi.fn(),
   getLayoutIdFromHistoryState: vi.fn(),
   hasShareHash: vi.fn(),
+  isCollectionURL: vi.fn(),
 }));
 
 // Mock validation module
@@ -54,6 +55,7 @@ describe('useLayoutRouting', () => {
     // Set up default mocks
     vi.mocked(url.parseLayoutIdFromHash).mockReturnValue(null);
     vi.mocked(url.hasShareHash).mockReturnValue(false);
+    vi.mocked(url.isCollectionURL).mockReturnValue(false);
     vi.mocked(storage.loadLayoutById).mockReturnValue(mockLayout);
     vi.mocked(validation.validateLayoutIntegrity).mockReturnValue({ valid: true });
 


### PR DESCRIPTION
## Summary
- Prevents `#local/{id}` hash from appearing in collection URLs (collection layouts are cloud-synced, not local)
- Skips loading local layout during initialization on collection URLs to prevent visual flash
- Adds debug logging (`console.warn`) to `useCollectionSync` to help diagnose why changes aren't persisting

## Changes
- `useLayoutRouting.ts`: Added `isCollectionURL()` checks to skip local layout routing when on collection URLs
- `App.tsx`: Skip loading local layout during initialization if on collection URL
- `useCollectionSync.ts`: Added debug logging at key points (subscription, onLayoutChange, pushChanges)

## Test plan
- [x] Build passes
- [x] All tests pass (3092)
- [ ] Navigate to collection URL - should NOT show `#local/` in URL
- [ ] Navigate directly to collection URL - should NOT flash local layout first
- [ ] Move a bin in collection mode - check browser console for `[CollectionSync]` logs to diagnose sync issue