### PR TITLE
fix: collection sync timeout uses stale pushChanges callback

### DIFF
--- a/src/hooks/useCollectionSync.ts
+++ b/src/hooks/useCollectionSync.ts
@@ -120,6 +120,11 @@ export function useCollectionSync() {
   // Track if we're currently editing
   const isEditingRef = useRef(false);
 
+  // Ref to track if this is the initial mount (to skip triggering on first render)
+  const isInitialMount = useRef(true);
+  // Ref to track the previous layout ID (to skip triggering when switching layouts)
+  const prevLayoutIdRef = useRef<string | null>(null);
+
   /**
    * Poll for changes from server.
    */
@@ -339,6 +344,15 @@ export function useCollectionSync() {
     updateActiveCollectionLayout,
   ]);
 
+  // Ref to hold the pushChanges callback so the timeout always calls the latest version.
+  // This is necessary because pushChanges depends on `layout`, which changes on every edit.
+  const pushChangesRef = useRef(pushChanges);
+
+  // Keep the ref updated with the latest pushChanges.
+  useEffect(() => {
+    pushChangesRef.current = pushChanges;
+  }, [pushChanges]);
+
   /**
    * Mark layout as modified and schedule debounced push.
    */
@@ -356,22 +370,19 @@ export function useCollectionSync() {
 
     // Cancel any pending push
     if (pushTimeoutRef.current) {
+      console.warn('[CollectionSync] Clearing previous timeout:', pushTimeoutRef.current);
       window.clearTimeout(pushTimeoutRef.current);
     }
 
-    // Schedule new push
+    // Schedule new push - use pushChangesRef to always call latest version
     console.warn('[CollectionSync] Scheduling push in', PUSH_DEBOUNCE_MS, 'ms');
     pushTimeoutRef.current = window.setTimeout(() => {
       console.warn('[CollectionSync] Push timeout fired, calling pushChanges');
-      pushChanges();
+      pushChangesRef.current();
       pushTimeoutRef.current = null;
     }, PUSH_DEBOUNCE_MS);
-  }, [activeCollection, activeLayoutId, markLayoutModified, pushChanges]);
+  }, [activeCollection, activeLayoutId, markLayoutModified]);
 
-  // Ref to track if this is the initial mount (to skip triggering on first render)
-  const isInitialMount = useRef(true);
-  // Ref to track the previous layout ID (to skip triggering when switching layouts)
-  const prevLayoutIdRef = useRef<string | null>(null);
   // Ref to hold the onLayoutChange callback so the subscription doesn't depend on it.
   // This is the React "latest ref" pattern for callbacks that change frequently but
   // shouldn't cause subscribers to re-subscribe.


### PR DESCRIPTION
## Summary

- Fixed sync persistence issue where changes to collection layouts (bin movements, name changes) weren't being saved to the server
- The setTimeout callback in `onLayoutChange` was capturing a stale `pushChanges` function that depended on the old layout state

## Root Cause

The `pushChanges` callback depends on `layout`, which changes on every edit. When `onLayoutChange` schedules a debounced push with `setTimeout`, it captures the current `pushChanges`. By the time the 2.5s timeout fires, `pushChanges` has been recreated many times but the timeout still has the old stale version.

## Fix

Applied the same "latest ref" pattern used for `onLayoutChangeRef`:
1. Added `pushChangesRef` to hold the current `pushChanges` function
2. Added an effect to keep `pushChangesRef.current` updated whenever `pushChanges` changes
3. Changed the setTimeout to call `pushChangesRef.current()` instead of `pushChanges()`
4. Removed `pushChanges` from `onLayoutChange` dependencies (since we use the ref now)

## Test Plan

- [ ] Load a collection URL directly
- [ ] Make changes (move bins, rename layout)
- [ ] Wait 2.5+ seconds for debounce
- [ ] Check console for "[CollectionSync] Push timeout fired, calling pushChanges"
- [ ] Check console for successful API response
- [ ] Refresh page - changes should persist
- [ ] Check on another device - changes should be visible