### PR TITLE
fix: prevent polling effect from clearing push timeout

### DIFF
--- a/src/hooks/useCollectionSync.ts
+++ b/src/hooks/useCollectionSync.ts
@@ -581,12 +581,24 @@ export function useCollectionSync() {
         window.clearInterval(heartbeatIntervalRef.current);
         heartbeatIntervalRef.current = null;
       }
+      // NOTE: Do NOT clear pushTimeoutRef here! This effect re-runs when poll/sendHeartbeat
+      // callbacks change (which happens on layout changes), and clearing the push timeout
+      // would prevent changes from being saved. Push timeout is only cleared in onLayoutChange
+      // (when scheduling a new push) or when leaving collection mode (separate effect below).
+    };
+  }, [activeCollection, poll, sendHeartbeat]);
+
+  // Clear push timeout only when leaving collection mode (not on callback changes)
+  useEffect(() => {
+    return () => {
+      // This cleanup only runs when activeCollection changes to null/undefined
       if (pushTimeoutRef.current) {
+        console.warn('[CollectionSync] Clearing push timeout on collection exit');
         window.clearTimeout(pushTimeoutRef.current);
         pushTimeoutRef.current = null;
       }
     };
-  }, [activeCollection, poll, sendHeartbeat]);
+  }, [activeCollection]);
 
   // Reset sync state when leaving collection (outside of effect to avoid lint error)
   // We compute this as derived state based on whether we're in a collection


### PR DESCRIPTION
## Summary

The push timeout was being cleared before it could fire, preventing collection layout changes from being saved.

## Root Cause

The polling effect cleanup was clearing `pushTimeoutRef`:

```typescript
return () => {
  // ... other cleanup
  if (pushTimeoutRef.current) {
    window.clearTimeout(pushTimeoutRef.current);  // <-- Problem!
    pushTimeoutRef.current = null;
  }
};
```

This effect depends on `[activeCollection, poll, sendHeartbeat]`. When `poll` or `sendHeartbeat` callbacks change (which happens on every layout change), the effect re-runs and the cleanup clears the push timeout before it fires.

## Fix

- Removed `pushTimeoutRef` clearing from the polling effect cleanup
- Added a separate effect that only clears the push timeout when `activeCollection` changes (leaving collection mode)

Now the push timeout is only cleared when:
1. A new push is scheduled (debounce reset in `onLayoutChange`)
2. Leaving collection mode (the new separate effect)

## Test Plan

- [ ] Load collection URL
- [ ] Make edits (move bins, rename layout)
- [ ] Wait 2.5+ seconds
- [ ] Verify `[CollectionSync] Push timeout fired` appears in console
- [ ] Verify changes persist on refresh
- [ ] Verify changes sync to other devices