### PR TITLE
fix: fetch updated layout data when poll detects newer server version

### DIFF
--- a/src/hooks/useCollectionSync.ts
+++ b/src/hooks/useCollectionSync.ts
@@ -125,6 +125,10 @@ export function useCollectionSync() {
   // Ref to track the previous layout ID (to skip triggering when switching layouts)
   const prevLayoutIdRef = useRef<string | null>(null);
 
+  // Refs to avoid stale closures in poll callback (which shouldn't recreate on layout changes)
+  const activeLayoutIdRef = useRef(activeLayoutId);
+  const importLayoutRef = useRef(importLayout);
+
   /**
    * Poll for changes from server.
    */
@@ -215,7 +219,28 @@ export function useCollectionSync() {
         }
 
         if (!hasLocalMods && serverIsNewer) {
-          // Server has newer version, update our sync state
+          // Server has newer version - fetch and apply it if this is the active layout
+          console.warn('[CollectionSync] Server has newer version for layout:', serverLayout.id, {
+            serverModifiedAt: serverLayout.modifiedAt,
+            localModifiedAt: localSyncState.modifiedAt,
+            isActiveLayout: serverLayout.id === activeLayoutIdRef.current,
+          });
+
+          if (serverLayout.id === activeLayoutIdRef.current && activeCollection) {
+            // Fetch the updated layout from server
+            const fetchResult = await collectionApi.fetchLayout(
+              activeCollection.id,
+              serverLayout.id
+            );
+
+            if (fetchResult.success) {
+              console.warn('[CollectionSync] Importing updated layout from server');
+              // Import the updated layout - use ref to get latest importLayout
+              importLayoutRef.current(fetchResult.data.layout, serverLayout.id);
+            }
+          }
+
+          // Update sync state
           setStoreSyncState(serverLayout.id, {
             modifiedAt: serverLayout.modifiedAt,
             lastSyncAt: Date.now(),
@@ -244,6 +269,15 @@ export function useCollectionSync() {
     setStoreSyncState,
     updateActiveCollectionLayout,
   ]);
+
+  // Keep refs updated for poll callback (avoids stale closures)
+  useEffect(() => {
+    activeLayoutIdRef.current = activeLayoutId;
+  }, [activeLayoutId]);
+
+  useEffect(() => {
+    importLayoutRef.current = importLayout;
+  }, [importLayout]);
 
   /**
    * Send heartbeat to indicate active editing.


### PR DESCRIPTION
## Summary

Changes were being saved to the server but not syncing to other devices/browsers viewing the same collection layout.

## Root Cause

When `poll()` detected that the server had a newer version of a layout (and we had no local changes), it was only updating sync metadata (timestamps) but never actually fetching and importing the updated layout data.

## Fix

When the server has a newer version of the **currently active layout**:
1. Fetch the full layout data from the server via `collectionApi.fetchLayout()`
2. Import it into the layout store via `importLayout()`

Uses refs (`activeLayoutIdRef`, `importLayoutRef`) to avoid stale closures in the poll callback, since poll shouldn't be recreated on every layout change.

## Console output to verify

When another device makes changes, you should now see:
```
[CollectionSync] Server has newer version for layout: {id} {serverModifiedAt, localModifiedAt, isActiveLayout: true}
[CollectionSync] Importing updated layout from server
```

## Test Plan

- [ ] Open collection on Device A
- [ ] Open same collection on Device B  
- [ ] Make changes on Device A, wait for push (2.5s)
- [ ] Wait for poll on Device B (up to 30s) or refresh
- [ ] Verify changes appear on Device B