### PR TITLE
fix: PartyKit real-time sync - add HTTPS and logging

### DIFF
--- a/api/lib/partykit.ts
+++ b/api/lib/partykit.ts
@@ -56,7 +56,10 @@ export async function notifyPartyKit(
     return;
   }
 
-  const url = `http://${PARTYKIT_HOST}/parties/collection/${collectionId}`;
+  // Use HTTPS for production PartyKit servers (*.partykit.dev)
+  const protocol = PARTYKIT_HOST.includes('partykit.dev') ? 'https' : 'http';
+  const url = `${protocol}://${PARTYKIT_HOST}/parties/collection/${collectionId}`;
+  console.warn('[PartyKit] Sending notification to:', url, 'payload:', payload);
 
   try {
     const response = await fetch(url, {

--- a/src/hooks/usePartySync.ts
+++ b/src/hooks/usePartySync.ts
@@ -131,8 +131,10 @@ export function usePartySync() {
       // Send initial presence (deferred to avoid stale closure)
     },
     onMessage: (event) => {
+      console.warn('[PartySync] Received message:', event.data);
       try {
         const message = JSON.parse(event.data) as ServerMessage;
+        console.warn('[PartySync] Parsed message:', message);
         handleMessage(message);
       } catch (error) {
         console.error('[PartySync] Error parsing message:', error);
@@ -163,10 +165,19 @@ export function usePartySync() {
   // Handle incoming messages
   const handleMessage = useCallback(
     async (message: ServerMessage) => {
+      console.warn('[PartySync] handleMessage called:', message.type, message);
       switch (message.type) {
         case 'layout-updated': {
           // Someone else updated a layout
           const { layoutId, modifiedAt, modifiedBy } = message;
+          console.warn('[PartySync] layout-updated received:', {
+            layoutId,
+            modifiedAt,
+            modifiedBy,
+            isOurDevice: modifiedBy === deviceIdRef.current,
+            activeLayoutId,
+            activeCollection: !!activeCollection,
+          });
 
           // Ignore our own updates
           if (modifiedBy === deviceIdRef.current) return;


### PR DESCRIPTION
## Summary

Fixed PartyKit real-time sync not working for cross-device updates.

## Root Causes Found

1. **Missing env var**: `PARTYKIT_HOST` was not set in Vercel, so the API was using the localhost default and skipping notifications in production.

2. **Wrong protocol**: The API was using `http://` for all PartyKit notifications, but production PartyKit servers require `https://`.

## Fixes

1. Added `PARTYKIT_HOST=gridfinity-collections.andymai.partykit.dev` to Vercel env vars (production + preview)

2. Fixed protocol detection to use HTTPS for `*.partykit.dev` hosts

3. Added debug logging to trace the flow:
   - `[PartyKit] Sending notification to: <url>` - API side
   - `[PartySync] Received message: <data>` - Client side
   - `[PartySync] handleMessage called: <type>` - Client side

## How it should work now

1. Device A makes a change → push to API
2. API saves to Vercel Blob
3. API notifies PartyKit via `POST https://gridfinity-collections.andymai.partykit.dev/parties/collection/{id}`
4. PartyKit broadcasts `layout-updated` to all connected clients
5. Device B receives message via WebSocket
6. Device B fetches updated layout and imports it

## Test Plan

- [ ] Deploy and check Vercel function logs for `[PartyKit] Sending notification to:`
- [ ] Check browser console for `[PartySync] Received message:`
- [ ] Make changes on Device A, verify Device B receives update within seconds