### PR TITLE
fix: add missing party name to PartySocket - THIS IS THE REAL FIX

### DIFF
--- a/src/hooks/usePartySync.ts
+++ b/src/hooks/usePartySync.ts
@@ -123,6 +123,7 @@ export function usePartySync() {
   // PartySocket connection
   const socket = usePartySocket({
     host: PARTYKIT_HOST,
+    party: 'collection', // Must match the party name from party/collection.ts
     room: stableRoomId,
     // Don't connect if no collection (represented by '__none__' sentinel)
     startClosed: stableRoomId === '__none__',


### PR DESCRIPTION
## The Actual Root Cause

**The client and PartyKit server were never talking to each other.**

PartyKit server is defined at `party/collection.ts`, which means the party name is `collection`.

But `usePartySocket` was missing the `party` option, so it defaulted to `"main"`.

```
Client connecting to: wss://.../parties/main/{collectionId}   ❌
Server listening at:  wss://.../parties/collection/{collectionId}  ✅
```

**One line fix:** Add `party: 'collection'` to the socket config.

## Why previous fixes didn't help

All the other fixes (HTTPS protocol, PARTYKIT_HOST env var, poll fetch logic, push timeout refs) were addressing symptoms of "sync not working" but the fundamental issue was that the WebSocket was connecting to the wrong endpoint entirely.

## Test Plan

After this deploys:
1. Open collection on Browser A
2. Open same collection on Browser B  
3. Move a bin on Browser A
4. Browser B should see it move in ~3 seconds (push debounce + network)

Watch console for:
- `[PartySync] Received message: {"type":"layout-updated"...}`
- `[PartySync] Importing updated layout from server`