### PR TITLE
fix: prevent CLS with CSS fade-in animation and sync zoom calculation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,16 +170,18 @@ export default function App() {
   // Mobile layout - lazy loaded
   if (isMobile) {
     return (
-      <Suspense fallback={<div className="h-screen bg-surface" />}>
-        <MobileLayout isMobileHelpOpen={isMobileHelpOpen} setIsMobileHelpOpen={setIsMobileHelpOpen} saveStatus={saveStatus} />
-      </Suspense>
+      <div className="h-screen animate-fade-in">
+        <Suspense fallback={<div className="h-screen bg-surface" />}>
+          <MobileLayout isMobileHelpOpen={isMobileHelpOpen} setIsMobileHelpOpen={setIsMobileHelpOpen} saveStatus={saveStatus} />
+        </Suspense>
+      </div>
     );
   }
 
   // Tablet layout - full width grid with overlay panels
   if (isTablet) {
     return (
-      <div className="h-screen flex flex-col overflow-hidden bg-surface text-content">
+      <div className="h-screen flex flex-col overflow-hidden bg-surface text-content animate-fade-in">
         {/* Shared layout banner (shown when viewing unsaved shared layout) */}
         <SharedLayoutBanner />
 
@@ -271,7 +273,7 @@ export default function App() {
 
   // Desktop layout
   return (
-    <div className="h-screen flex flex-col overflow-hidden bg-surface text-content">
+    <div className="h-screen flex flex-col overflow-hidden bg-surface text-content animate-fade-in">
       {/* Shared layout banner (shown when viewing unsaved shared layout) */}
       <SharedLayoutBanner />
 


### PR DESCRIPTION
## Summary

Two-part fix for Cumulative Layout Shift (CLS) on page load:

1. **CSS fade-in animation on app container**
   - Uses existing `animate-fade-in` class (150ms opacity 0→1)
   - Content renders invisible initially, then smoothly fades in
   - Applied to mobile, tablet, and desktop layouts
   - Masks any state initialization shifts during the fade

2. **Synchronous zoom calculation**
   - Changed `useEffect` → `useLayoutEffect` for fitToScreen
   - Zoom is calculated before browser paint
   - Removed 100ms setTimeout delay that was causing visible shift

## Why this approach?

The fade-in approach is:
- ESLint-compliant (no setState in effects)
- Uses existing CSS animation infrastructure
- Follows common web patterns (Notion, Linear, etc.)
- Masks both grid zoom shifts and sidebar state initialization

## Changes

- `src/App.tsx`: Add `animate-fade-in` class to mobile/tablet/desktop containers
- `src/components/Grid/index.tsx`: Use `useLayoutEffect` for synchronous zoom calculation

## Test plan

- [x] Build passes
- [x] All 3092 tests pass
- [x] Coverage thresholds maintained
- [ ] Manual verification: load app and confirm smooth fade-in with no visible CLS