### PR TITLE
feat: preserve UI state across PWA updates

### DIFF
--- a/src/hooks/usePWAUpdate.ts
+++ b/src/hooks/usePWAUpdate.ts
@@ -4,6 +4,11 @@ import { useToastStore } from '../store/toast';
 import { useUIStore } from '../store/ui';
 import { STAGING_ID } from '../constants';
 import { useLayoutStore } from '../store/layout';
+import {
+  saveEphemeralState,
+  loadEphemeralState,
+  type EphemeralState,
+} from '../utils/ephemeralState';
 
 // Toast duration for update notification
 const UPDATE_TOAST_MS = 5000;
@@ -115,6 +120,115 @@ function waitForSafeReload(
       resolve(false);
     });
   });
+}
+
+/**
+ * Gather current UI state for preservation across PWA reload.
+ * Returns state suitable for saveEphemeralState().
+ */
+function gatherEphemeralState(): Omit<EphemeralState, 'savedAt'> {
+  const ui = useUIStore.getState();
+
+  return {
+    // Selection & navigation
+    selectedBinIds: ui.selectedBinIds,
+    activeLayerId: ui.activeLayerId,
+    activeCategoryId: ui.activeCategoryId,
+    focusedBinId: ui.focusedBinId,
+
+    // View settings
+    zoom: ui.zoom,
+    showOtherLayers: ui.showOtherLayers,
+    showLabels: ui.showLabels,
+
+    // Panel state
+    leftPanelCollapsed: ui.leftPanelCollapsed,
+    rightPanelCollapsed: ui.rightPanelCollapsed,
+
+    // 3D preview state
+    showIsometricPreview: ui.showIsometricPreview,
+    isometricRotation: ui.isometricRotation,
+    layerViewMode: ui.layerViewMode,
+
+    // Paint mode
+    paintSize: ui.paintSize,
+
+    // Note: scroll position would require ref from Grid component
+    // Could be added via a global ref or event-based approach
+  };
+}
+
+/**
+ * Restore UI state from ephemeral storage after PWA reload.
+ * Validates that bins/layers still exist before restoring selection.
+ */
+function restoreEphemeralState(): boolean {
+  const state = loadEphemeralState();
+  if (!state) return false;
+
+  const ui = useUIStore.getState();
+  const layout = useLayoutStore.getState().layout;
+
+  // Validate and restore activeLayerId
+  const layerExists = layout.layers.some((l) => l.id === state.activeLayerId);
+  if (layerExists && state.activeLayerId) {
+    ui.setActiveLayer(state.activeLayerId);
+  }
+
+  // Validate and restore selected bins (filter out any that no longer exist)
+  const existingBinIds = new Set(layout.bins.map((b) => b.id));
+  const validSelectedIds = state.selectedBinIds.filter((id) =>
+    existingBinIds.has(id)
+  );
+  if (validSelectedIds.length > 0) {
+    ui.setSelectedBins(validSelectedIds);
+  }
+
+  // Restore active category (categories might have changed, but IDs are stable)
+  const categoryExists = layout.categories.some(
+    (c) => c.id === state.activeCategoryId
+  );
+  if (categoryExists) {
+    ui.setActiveCategory(state.activeCategoryId);
+  }
+
+  // Restore focused bin if it still exists
+  if (state.focusedBinId && existingBinIds.has(state.focusedBinId)) {
+    ui.setFocusedBin(state.focusedBinId);
+  }
+
+  // Restore view settings (these don't need validation)
+  ui.setZoom(state.zoom);
+
+  // Restore toggles only if they differ from current state
+  if (state.showOtherLayers !== ui.showOtherLayers) {
+    ui.toggleShowOtherLayers();
+  }
+  if (state.showLabels !== ui.showLabels) {
+    ui.toggleShowLabels();
+  }
+
+  // Restore panel state
+  if (state.leftPanelCollapsed !== ui.leftPanelCollapsed) {
+    ui.toggleLeftPanel();
+  }
+  if (state.rightPanelCollapsed !== ui.rightPanelCollapsed) {
+    ui.toggleRightPanel();
+  }
+
+  // Restore 3D preview state
+  if (state.showIsometricPreview !== ui.showIsometricPreview) {
+    ui.toggleIsometricPreview();
+  }
+  ui.setIsometricRotation(state.isometricRotation);
+  ui.setLayerViewMode(state.layerViewMode);
+
+  // Restore paint size
+  if (state.paintSize) {
+    ui.setPaintSize(state.paintSize);
+  }
+
+  return true;
 }
 
 /**
@@ -308,6 +422,9 @@ export function usePWAUpdate(): void {
       // Don't trigger reload if aborted
       if (abortController.signal.aborted) return;
 
+      // Save current UI state before reload so we can restore it
+      saveEphemeralState(gatherEphemeralState());
+
       // Trigger the update (reloads the page)
       updateServiceWorker(true);
     };
@@ -321,4 +438,19 @@ export function usePWAUpdate(): void {
       }
     };
   }, [needRefresh, addToast, updateServiceWorker]);
+
+  // Restore ephemeral state on mount (after PWA update reload)
+  useEffect(() => {
+    // Small delay to ensure layout store is initialized
+    const timeoutId = setTimeout(() => {
+      const restored = restoreEphemeralState();
+      if (restored) {
+        addToast('Session restored', 'success', 2000);
+      }
+    }, 100);
+
+    return () => clearTimeout(timeoutId);
+    // Only run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 }

--- a/src/test/ephemeralState.test.ts
+++ b/src/test/ephemeralState.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  saveEphemeralState,
+  loadEphemeralState,
+  hasEphemeralState,
+  clearEphemeralState,
+  type EphemeralState,
+} from '../utils/ephemeralState';
+
+// Mock sessionStorage
+const sessionStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      const { [key]: _, ...rest } = store;
+      store = rest;
+      void _; // Suppress unused variable warning
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: vi.fn((index: number) => Object.keys(store)[index] || null),
+    // For testing
+    get _store() {
+      return store;
+    },
+  };
+})();
+
+Object.defineProperty(window, 'sessionStorage', { value: sessionStorageMock });
+
+describe('ephemeralState', () => {
+  const validState: Omit<EphemeralState, 'savedAt'> = {
+    selectedBinIds: ['bin-1', 'bin-2'],
+    activeLayerId: 'layer-1',
+    activeCategoryId: 'coral',
+    focusedBinId: 'bin-1',
+    zoom: 1.5,
+    showOtherLayers: true,
+    showLabels: false,
+    leftPanelCollapsed: false,
+    rightPanelCollapsed: true,
+    showIsometricPreview: true,
+    isometricRotation: 45,
+    layerViewMode: 'stack',
+    paintSize: { width: 2, depth: 2 },
+  };
+
+  beforeEach(() => {
+    sessionStorageMock.clear();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('saveEphemeralState', () => {
+    it('saves state to sessionStorage with timestamp', () => {
+      saveEphemeralState(validState);
+
+      expect(sessionStorageMock.setItem).toHaveBeenCalledTimes(1);
+      const savedData = JSON.parse(
+        sessionStorageMock._store['gridfinity-ephemeral-state-v1']
+      );
+      expect(savedData.selectedBinIds).toEqual(['bin-1', 'bin-2']);
+      expect(savedData.zoom).toBe(1.5);
+      expect(savedData.savedAt).toBe(Date.now());
+    });
+
+    it('handles storage errors gracefully', () => {
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      sessionStorageMock.setItem.mockImplementationOnce(() => {
+        throw new Error('QuotaExceeded');
+      });
+
+      // Should not throw
+      expect(() => saveEphemeralState(validState)).not.toThrow();
+      expect(consoleWarn).toHaveBeenCalledWith(
+        'Failed to save ephemeral state:',
+        expect.any(Error)
+      );
+    });
+
+    it('includes all expected fields', () => {
+      saveEphemeralState(validState);
+
+      const savedData = JSON.parse(
+        sessionStorageMock._store['gridfinity-ephemeral-state-v1']
+      );
+
+      // Verify all fields are present
+      expect(savedData).toHaveProperty('selectedBinIds');
+      expect(savedData).toHaveProperty('activeLayerId');
+      expect(savedData).toHaveProperty('activeCategoryId');
+      expect(savedData).toHaveProperty('focusedBinId');
+      expect(savedData).toHaveProperty('zoom');
+      expect(savedData).toHaveProperty('showOtherLayers');
+      expect(savedData).toHaveProperty('showLabels');
+      expect(savedData).toHaveProperty('leftPanelCollapsed');
+      expect(savedData).toHaveProperty('rightPanelCollapsed');
+      expect(savedData).toHaveProperty('showIsometricPreview');
+      expect(savedData).toHaveProperty('isometricRotation');
+      expect(savedData).toHaveProperty('layerViewMode');
+      expect(savedData).toHaveProperty('paintSize');
+      expect(savedData).toHaveProperty('savedAt');
+    });
+  });
+
+  describe('loadEphemeralState', () => {
+    it('returns null when no state exists', () => {
+      expect(loadEphemeralState()).toBeNull();
+    });
+
+    it('loads and clears state from sessionStorage', () => {
+      saveEphemeralState(validState);
+      sessionStorageMock.removeItem.mockClear();
+
+      const loaded = loadEphemeralState();
+
+      expect(loaded).not.toBeNull();
+      expect(loaded?.selectedBinIds).toEqual(['bin-1', 'bin-2']);
+      expect(loaded?.zoom).toBe(1.5);
+      expect(sessionStorageMock.removeItem).toHaveBeenCalledWith(
+        'gridfinity-ephemeral-state-v1'
+      );
+    });
+
+    it('returns null and clears if state is older than 30 seconds', () => {
+      saveEphemeralState(validState);
+
+      // Advance time by 31 seconds
+      vi.advanceTimersByTime(31 * 1000);
+
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const loaded = loadEphemeralState();
+
+      expect(loaded).toBeNull();
+      expect(consoleWarn).toHaveBeenCalledWith(
+        'Ephemeral state too old, discarding'
+      );
+    });
+
+    it('returns state if within 30 second window', () => {
+      saveEphemeralState(validState);
+
+      // Advance time by 29 seconds (just under threshold)
+      vi.advanceTimersByTime(29 * 1000);
+
+      const loaded = loadEphemeralState();
+      expect(loaded).not.toBeNull();
+      expect(loaded?.selectedBinIds).toEqual(['bin-1', 'bin-2']);
+    });
+
+    it('returns null for invalid JSON', () => {
+      sessionStorageMock._store['gridfinity-ephemeral-state-v1'] = 'not valid json{{{';
+
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const loaded = loadEphemeralState();
+
+      expect(loaded).toBeNull();
+      expect(consoleWarn).toHaveBeenCalledWith(
+        'Failed to load ephemeral state:',
+        expect.any(Error)
+      );
+    });
+
+    it('returns null for state missing required fields', () => {
+      const invalidState = {
+        selectedBinIds: 'not-an-array', // Should be array
+        activeLayerId: 'layer-1',
+        zoom: 1.0,
+        savedAt: Date.now(),
+      };
+      sessionStorageMock._store['gridfinity-ephemeral-state-v1'] =
+        JSON.stringify(invalidState);
+
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const loaded = loadEphemeralState();
+
+      expect(loaded).toBeNull();
+      expect(consoleWarn).toHaveBeenCalledWith(
+        'Ephemeral state validation failed, discarding'
+      );
+    });
+
+    it('clears corrupted data on error', () => {
+      sessionStorageMock._store['gridfinity-ephemeral-state-v1'] = 'corrupt';
+      sessionStorageMock.removeItem.mockClear();
+
+      loadEphemeralState();
+
+      expect(sessionStorageMock.removeItem).toHaveBeenCalledWith(
+        'gridfinity-ephemeral-state-v1'
+      );
+    });
+  });
+
+  describe('hasEphemeralState', () => {
+    it('returns false when no state exists', () => {
+      expect(hasEphemeralState()).toBe(false);
+    });
+
+    it('returns true when state exists', () => {
+      saveEphemeralState(validState);
+      expect(hasEphemeralState()).toBe(true);
+    });
+
+    it('handles storage errors gracefully', () => {
+      sessionStorageMock.getItem.mockImplementationOnce(() => {
+        throw new Error('Storage error');
+      });
+
+      expect(hasEphemeralState()).toBe(false);
+    });
+  });
+
+  describe('clearEphemeralState', () => {
+    it('removes state from sessionStorage', () => {
+      saveEphemeralState(validState);
+      sessionStorageMock.removeItem.mockClear();
+
+      clearEphemeralState();
+
+      expect(sessionStorageMock.removeItem).toHaveBeenCalledWith(
+        'gridfinity-ephemeral-state-v1'
+      );
+    });
+
+    it('handles storage errors gracefully', () => {
+      sessionStorageMock.removeItem.mockImplementationOnce(() => {
+        throw new Error('Storage error');
+      });
+
+      // Should not throw
+      expect(() => clearEphemeralState()).not.toThrow();
+    });
+  });
+
+  describe('round-trip', () => {
+    it('preserves all state fields through save/load cycle', () => {
+      const stateWithNulls: Omit<EphemeralState, 'savedAt'> = {
+        ...validState,
+        focusedBinId: null,
+        paintSize: null,
+      };
+
+      saveEphemeralState(stateWithNulls);
+      const loaded = loadEphemeralState();
+
+      expect(loaded).not.toBeNull();
+      expect(loaded?.selectedBinIds).toEqual(stateWithNulls.selectedBinIds);
+      expect(loaded?.activeLayerId).toBe(stateWithNulls.activeLayerId);
+      expect(loaded?.activeCategoryId).toBe(stateWithNulls.activeCategoryId);
+      expect(loaded?.focusedBinId).toBe(null);
+      expect(loaded?.zoom).toBe(stateWithNulls.zoom);
+      expect(loaded?.showOtherLayers).toBe(stateWithNulls.showOtherLayers);
+      expect(loaded?.showLabels).toBe(stateWithNulls.showLabels);
+      expect(loaded?.leftPanelCollapsed).toBe(stateWithNulls.leftPanelCollapsed);
+      expect(loaded?.rightPanelCollapsed).toBe(stateWithNulls.rightPanelCollapsed);
+      expect(loaded?.showIsometricPreview).toBe(stateWithNulls.showIsometricPreview);
+      expect(loaded?.isometricRotation).toBe(stateWithNulls.isometricRotation);
+      expect(loaded?.layerViewMode).toBe(stateWithNulls.layerViewMode);
+      expect(loaded?.paintSize).toBe(null);
+    });
+
+    it('state can only be loaded once (one-time use)', () => {
+      saveEphemeralState(validState);
+
+      const firstLoad = loadEphemeralState();
+      const secondLoad = loadEphemeralState();
+
+      expect(firstLoad).not.toBeNull();
+      expect(secondLoad).toBeNull();
+    });
+  });
+});

--- a/src/test/hooks/usePWAUpdate.test.ts
+++ b/src/test/hooks/usePWAUpdate.test.ts
@@ -6,6 +6,7 @@ import { useLayoutStore } from '../../store/layout';
 import { useToastStore } from '../../store/toast';
 import { resetAllStores, setupFakeTimers } from '../testUtils';
 import { STAGING_ID } from '../../constants';
+import { saveEphemeralState, type EphemeralState } from '../../utils/ephemeralState';
 
 // Constants from usePWAUpdate (mirrored for testing)
 const UPDATE_TOAST_MS = 5000;
@@ -589,6 +590,165 @@ describe('usePWAUpdate', () => {
       expect(mockUpdateServiceWorker).toHaveBeenCalledWith(true);
 
       consoleSpy.mockRestore();
+    });
+
+    it('saves ephemeral state before triggering update', async () => {
+      mockNeedRefresh = true;
+
+      // Set up some UI state to be saved
+      useUIStore.setState({
+        selectedBinIds: ['bin-1', 'bin-2'],
+        zoom: 2.0,
+        showIsometricPreview: true,
+      });
+
+      renderHook(() => usePWAUpdate());
+
+      act(() => {
+        mockOnRegisteredSW?.('/sw.js', mockRegistration);
+      });
+
+      // Complete the update flow
+      await act(async () => {
+        timerUtils.advanceTime(IDLE_CHECK_INTERVAL_MS);
+        await Promise.resolve();
+        timerUtils.advanceTime(UPDATE_TOAST_MS);
+        await Promise.resolve();
+      });
+
+      // Check that state was saved to sessionStorage
+      // Note: The state will be saved just before updateServiceWorker is called
+      expect(mockUpdateServiceWorker).toHaveBeenCalledWith(true);
+      // State should have been saved (we can't easily verify the contents since
+      // the real updateServiceWorker would reload the page, but we verify the call)
+    });
+  });
+
+  describe('ephemeral state restoration', () => {
+    it('restores ephemeral state on mount and shows toast', async () => {
+      // Pre-save some ephemeral state (simulating state saved before PWA reload)
+      const savedState: Omit<EphemeralState, 'savedAt'> = {
+        selectedBinIds: ['bin-1'],
+        activeLayerId: useLayoutStore.getState().layout.layers[0].id,
+        activeCategoryId: useLayoutStore.getState().layout.categories[0].id,
+        focusedBinId: null,
+        zoom: 1.5,
+        showOtherLayers: true,
+        showLabels: true,
+        leftPanelCollapsed: false,
+        rightPanelCollapsed: true,
+        showIsometricPreview: true,
+        isometricRotation: 90,
+        layerViewMode: 'all',
+        paintSize: { width: 2, depth: 2 },
+      };
+      saveEphemeralState(savedState);
+
+      // Add a bin that matches the savedState's selectedBinIds
+      const layout = useLayoutStore.getState().layout;
+      useLayoutStore.setState({
+        layout: {
+          ...layout,
+          bins: [
+            {
+              id: 'bin-1',
+              layerId: layout.layers[0].id,
+              x: 0,
+              y: 0,
+              width: 1,
+              depth: 1,
+              height: 3,
+              category: layout.categories[0].id,
+              label: '',
+              notes: '',
+            },
+          ],
+        },
+      });
+
+      renderHook(() => usePWAUpdate());
+
+      act(() => {
+        mockOnRegisteredSW?.('/sw.js', mockRegistration);
+      });
+
+      // Wait for restoration effect (100ms delay + timeout)
+      await act(async () => {
+        timerUtils.advanceTime(150);
+        await Promise.resolve();
+      });
+
+      // Check that state was restored
+      const ui = useUIStore.getState();
+      expect(ui.zoom).toBe(1.5);
+      expect(ui.showIsometricPreview).toBe(true);
+      expect(ui.isometricRotation).toBe(90);
+      expect(ui.layerViewMode).toBe('all');
+      expect(ui.rightPanelCollapsed).toBe(true);
+      expect(ui.paintSize).toEqual({ width: 2, depth: 2 });
+      expect(ui.selectedBinIds).toEqual(['bin-1']);
+
+      // Check toast was shown
+      const toasts = useToastStore.getState().toasts;
+      expect(toasts.some(t => t.message === 'Session restored')).toBe(true);
+    });
+
+    it('does not show toast when no ephemeral state exists', async () => {
+      // Ensure no ephemeral state is saved
+      sessionStorage.removeItem('gridfinity-ephemeral-state-v1');
+
+      renderHook(() => usePWAUpdate());
+
+      act(() => {
+        mockOnRegisteredSW?.('/sw.js', mockRegistration);
+      });
+
+      // Wait for restoration effect
+      await act(async () => {
+        timerUtils.advanceTime(150);
+        await Promise.resolve();
+      });
+
+      // No "Session restored" toast should appear
+      const toasts = useToastStore.getState().toasts;
+      expect(toasts.some(t => t.message === 'Session restored')).toBe(false);
+    });
+
+    it('filters out selected bins that no longer exist', async () => {
+      // Save state with bin IDs that won't exist
+      const savedState: Omit<EphemeralState, 'savedAt'> = {
+        selectedBinIds: ['non-existent-bin', 'also-non-existent'],
+        activeLayerId: useLayoutStore.getState().layout.layers[0].id,
+        activeCategoryId: useLayoutStore.getState().layout.categories[0].id,
+        focusedBinId: 'non-existent-bin',
+        zoom: 1.0,
+        showOtherLayers: true,
+        showLabels: true,
+        leftPanelCollapsed: false,
+        rightPanelCollapsed: false,
+        showIsometricPreview: false,
+        isometricRotation: 0,
+        layerViewMode: 'stack',
+        paintSize: null,
+      };
+      saveEphemeralState(savedState);
+
+      renderHook(() => usePWAUpdate());
+
+      act(() => {
+        mockOnRegisteredSW?.('/sw.js', mockRegistration);
+      });
+
+      // Wait for restoration
+      await act(async () => {
+        timerUtils.advanceTime(150);
+        await Promise.resolve();
+      });
+
+      // Selection should be empty (bins don't exist)
+      const ui = useUIStore.getState();
+      expect(ui.selectedBinIds).toEqual([]);
+      expect(ui.focusedBinId).toBeNull();
     });
   });
 });

--- a/src/utils/ephemeralState.ts
+++ b/src/utils/ephemeralState.ts
@@ -1,0 +1,134 @@
+/**
+ * Ephemeral state preservation for PWA updates.
+ *
+ * Saves UI state to sessionStorage before a PWA-triggered reload,
+ * then restores it afterward so the user's context is preserved.
+ * Uses sessionStorage (not localStorage) so state doesn't persist
+ * across browser restarts - only across PWA update reloads.
+ */
+
+import type { LayerViewMode, PaintSize } from '../store/ui';
+
+const EPHEMERAL_STATE_KEY = 'gridfinity-ephemeral-state-v1';
+
+/**
+ * UI state that should be preserved across PWA updates.
+ * Excludes transient state like active interactions, context menus,
+ * modals, and hover highlights.
+ */
+export interface EphemeralState {
+  // Selection & navigation
+  selectedBinIds: string[];
+  activeLayerId: string;
+  activeCategoryId: string;
+  focusedBinId: string | null;
+
+  // View settings
+  zoom: number;
+  showOtherLayers: boolean;
+  showLabels: boolean;
+
+  // Panel state
+  leftPanelCollapsed: boolean;
+  rightPanelCollapsed: boolean;
+
+  // 3D preview state
+  showIsometricPreview: boolean;
+  isometricRotation: number;
+  layerViewMode: LayerViewMode;
+
+  // Paint mode (user might want to keep their brush size)
+  paintSize: PaintSize | null;
+
+  // Grid scroll position (optional - requires coordination with Grid component)
+  scrollPosition?: { x: number; y: number };
+
+  // Timestamp for debugging/validation
+  savedAt: number;
+}
+
+/**
+ * Save ephemeral UI state to sessionStorage.
+ * Called before PWA update triggers a reload.
+ */
+export function saveEphemeralState(state: Omit<EphemeralState, 'savedAt'>): void {
+  try {
+    const stateWithTimestamp: EphemeralState = {
+      ...state,
+      savedAt: Date.now(),
+    };
+    sessionStorage.setItem(EPHEMERAL_STATE_KEY, JSON.stringify(stateWithTimestamp));
+  } catch (error) {
+    // Silently fail - state preservation is nice-to-have, not critical
+    console.warn('Failed to save ephemeral state:', error);
+  }
+}
+
+/**
+ * Load and clear ephemeral state from sessionStorage.
+ * Returns null if no state exists or if it's stale (> 30 seconds old).
+ * Automatically clears the stored state after reading.
+ */
+export function loadEphemeralState(): EphemeralState | null {
+  try {
+    const stored = sessionStorage.getItem(EPHEMERAL_STATE_KEY);
+    if (!stored) return null;
+
+    // Always clear after reading - one-time use
+    sessionStorage.removeItem(EPHEMERAL_STATE_KEY);
+
+    const state = JSON.parse(stored) as EphemeralState;
+
+    // Validate timestamp - reject if older than 30 seconds
+    // This prevents restoring stale state from an old session
+    const MAX_AGE_MS = 30 * 1000;
+    if (Date.now() - state.savedAt > MAX_AGE_MS) {
+      console.warn('Ephemeral state too old, discarding');
+      return null;
+    }
+
+    // Basic validation - ensure required fields exist
+    if (
+      !Array.isArray(state.selectedBinIds) ||
+      typeof state.activeLayerId !== 'string' ||
+      typeof state.zoom !== 'number'
+    ) {
+      console.warn('Ephemeral state validation failed, discarding');
+      return null;
+    }
+
+    return state;
+  } catch (error) {
+    // Clear potentially corrupted data
+    try {
+      sessionStorage.removeItem(EPHEMERAL_STATE_KEY);
+    } catch {
+      // Ignore
+    }
+    console.warn('Failed to load ephemeral state:', error);
+    return null;
+  }
+}
+
+/**
+ * Check if there's pending ephemeral state to restore.
+ * Useful for showing a brief "Restored your session" indicator.
+ */
+export function hasEphemeralState(): boolean {
+  try {
+    return sessionStorage.getItem(EPHEMERAL_STATE_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Clear any pending ephemeral state without restoring it.
+ */
+export function clearEphemeralState(): void {
+  try {
+    sessionStorage.removeItem(EPHEMERAL_STATE_KEY);
+  } catch {
+    // Ignore
+  }
+}


### PR DESCRIPTION
Saves ephemeral UI state (selection, zoom, panel state, 3D preview settings)
to sessionStorage before PWA auto-update reloads the page, then restores it
afterward. This makes updates less disruptive - users keep their context.

- Add ephemeralState utility for save/restore with validation
- Integrate with usePWAUpdate hook to save before reload
- Restore on mount with "Session restored" toast feedback
- Filter out stale references (deleted bins/layers) on restore