### PR TITLE
Remove collection feature and complete IndexedDB storage transition

### DIFF
--- a/src/components/mobile/MobileLayoutsPanel.tsx
+++ b/src/components/mobile/MobileLayoutsPanel.tsx
@@ -8,7 +8,7 @@ import { useLayoutSwitcher } from '../../hooks/useLayoutSwitcher';
 import { useCloudShare } from '../../hooks/useCloudShare';
 import { ConfirmDialog } from '../modals/ConfirmDialog';
 import { LayoutThumbnail } from '../LayoutThumbnail';
-import { loadLayoutById, generateShareableURL, copyToClipboard, downloadLayoutAsFile } from '../../utils/storage';
+import { loadLayoutByIdAsync, generateShareableURL, copyToClipboard, downloadLayoutAsFile } from '../../utils/storage';
 import { EXPIRATION_OPTIONS, formatShareDate, calculateDaysRemaining } from '../../utils/cloudShare';
 import type { LayoutEntry, ShareExpiration } from '../../types';
 
@@ -119,7 +119,8 @@ export function MobileLayoutsPanel() {
 
   const handleCopyLink = useCallback(async (layoutId: string) => {
     const entry = library.entries.find(e => e.id === layoutId);
-    const layout = layoutId === activeLayoutId ? currentLayout : loadLayoutById(layoutId);
+    // For active layout use current state; otherwise load from IndexedDB
+    const layout = layoutId === activeLayoutId ? currentLayout : await loadLayoutByIdAsync(layoutId);
     if (layout) {
       const url = generateShareableURL(layout);
       const success = await copyToClipboard(url);
@@ -130,9 +131,10 @@ export function MobileLayoutsPanel() {
     setShareMenuId(null);
   }, [activeLayoutId, currentLayout, library.entries, announceToScreenReader]);
 
-  const handleDownload = useCallback((layoutId: string) => {
+  const handleDownload = useCallback(async (layoutId: string) => {
     const entry = library.entries.find(e => e.id === layoutId);
-    const layout = layoutId === activeLayoutId ? currentLayout : loadLayoutById(layoutId);
+    // For active layout use current state; otherwise load from IndexedDB
+    const layout = layoutId === activeLayoutId ? currentLayout : await loadLayoutByIdAsync(layoutId);
     if (layout && entry) {
       downloadLayoutAsFile(layout, `${entry.name.replace(/[^a-z0-9]/gi, '-').toLowerCase()}.json`);
       announceToScreenReader('Layout downloaded');

--- a/src/components/modals/LayoutManagerModal/LayoutList.tsx
+++ b/src/components/modals/LayoutManagerModal/LayoutList.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useCallback } from 'react';
 import type { LayoutEntry, Layout } from '../../../types';
 import { LayoutListItem } from './LayoutListItem';
 import { useLayoutStore } from '../../../store/layout';
-import { loadLayoutById, downloadLayoutAsFile } from '../../../utils/storage';
+import { loadLayoutByIdAsync, downloadLayoutAsFile } from '../../../utils/storage';
 import { useUIStore } from '../../../store/ui';
 
 /** Threshold for showing search bar */
@@ -87,16 +87,16 @@ export function LayoutList({
   );
 
   const getLayoutData = useCallback(
-    (id: string): Layout | null => {
-      // For active layout, use current state; otherwise load from storage
-      return id === activeLayoutId ? currentLayout : loadLayoutById(id);
+    async (id: string): Promise<Layout | null> => {
+      // For active layout, use current state; otherwise load from IndexedDB
+      return id === activeLayoutId ? currentLayout : loadLayoutByIdAsync(id);
     },
     [activeLayoutId, currentLayout]
   );
 
   const handleDownload = useCallback(
-    (entry: LayoutEntry) => {
-      const layout = getLayoutData(entry.id);
+    async (entry: LayoutEntry) => {
+      const layout = await getLayoutData(entry.id);
       if (layout) {
         downloadLayoutAsFile(layout, `${entry.name.replace(/[^a-z0-9]/gi, '-').toLowerCase()}.json`);
         announceToScreenReader('Layout downloaded');

--- a/src/hooks/useCrossTabSync.ts
+++ b/src/hooks/useCrossTabSync.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useLayoutStore, useLibraryStore, useHistoryStore, useUIStore } from '../store';
-import { loadLayoutById, loadLibrary } from '../utils/storage';
+import { loadLayoutByIdAsync, loadLibrary } from '../utils/storage';
 import { validateLayoutIntegrity } from '../utils/validation';
 
 /**
@@ -20,39 +20,47 @@ export function useCrossTabSync() {
       }
 
       // A specific layout changed - check if it's the active one
+      // Note: With IndexedDB migration, localStorage events only fire for legacy writes.
+      // IndexedDB doesn't have cross-tab events, so this is backwards compatibility.
       if (e.key?.startsWith('gridfinity-layout-')) {
         const layoutId = e.key.replace('gridfinity-layout-', '');
         const activeLayoutId = useLayoutStore.getState().activeLayoutId;
 
         // Only reload if it's the currently active layout
         if (layoutId === activeLayoutId) {
-          const newLayout = loadLayoutById(layoutId);
-          if (newLayout) {
-            // Validate before applying
-            const validation = validateLayoutIntegrity(newLayout);
-            if (validation.valid) {
-              // Update layout store (from another tab, treat as remote)
-              useLayoutStore.getState().importLayout(newLayout, layoutId, 'remote');
+          // Load asynchronously from IndexedDB (with localStorage fallback)
+          loadLayoutByIdAsync(layoutId)
+            .then((newLayout) => {
+              if (newLayout) {
+                // Validate before applying
+                const validation = validateLayoutIntegrity(newLayout);
+                if (validation.valid) {
+                  // Update layout store (from another tab, treat as remote)
+                  useLayoutStore.getState().importLayout(newLayout, layoutId, 'remote');
 
-              // Clear undo history since we're syncing external changes
-              useHistoryStore.getState().clear();
+                  // Clear undo history since we're syncing external changes
+                  useHistoryStore.getState().clear();
 
-              // Update active layer/category if they no longer exist
-              const uiState = useUIStore.getState();
-              const activeLayer = uiState.activeLayerId;
-              const activeCategory = uiState.activeCategoryId;
+                  // Update active layer/category if they no longer exist
+                  const uiState = useUIStore.getState();
+                  const activeLayer = uiState.activeLayerId;
+                  const activeCategory = uiState.activeCategoryId;
 
-              if (activeLayer && !newLayout.layers.find(l => l.id === activeLayer)) {
-                uiState.setActiveLayer(newLayout.layers[0]?.id ?? '');
+                  if (activeLayer && !newLayout.layers.find(l => l.id === activeLayer)) {
+                    uiState.setActiveLayer(newLayout.layers[0]?.id ?? '');
+                  }
+                  if (activeCategory && !newLayout.categories.find(c => c.id === activeCategory)) {
+                    uiState.setActiveCategory(newLayout.categories[0]?.id ?? '');
+                  }
+
+                  // Clear selection since bins may have changed
+                  uiState.clearSelection();
+                }
               }
-              if (activeCategory && !newLayout.categories.find(c => c.id === activeCategory)) {
-                uiState.setActiveCategory(newLayout.categories[0]?.id ?? '');
-              }
-
-              // Clear selection since bins may have changed
-              uiState.clearSelection();
-            }
-          }
+            })
+            .catch((error) => {
+              console.error(`[CrossTabSync] Failed to load layout ${layoutId}:`, error);
+            });
         }
       }
     };

--- a/src/hooks/useLayoutRouting.ts
+++ b/src/hooks/useLayoutRouting.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { useLayoutStore, useLibraryStore, useUIStore, useToastStore, useHistoryStore } from '../store';
-import { loadLayoutById } from '../utils/storage';
+import { loadLayoutByIdAsync } from '../utils/storage';
 import { validateLayoutIntegrity } from '../utils/validation';
 import {
   parseLayoutIdFromHash,
@@ -58,15 +58,15 @@ export function useLayoutRouting() {
    * Switch to a layout by ID (used for URL navigation).
    * Returns true if successful, false if layout not found.
    */
-  const navigateToLayout = useCallback((layoutId: string, addToHistory = false): boolean => {
+  const navigateToLayout = useCallback(async (layoutId: string, addToHistory = false): Promise<boolean> => {
     // Check if layout exists in library
     const entry = getEntry(layoutId);
     if (!entry) {
       return false;
     }
 
-    // Load layout data
-    const layout = loadLayoutById(layoutId);
+    // Load layout data from IndexedDB (with localStorage fallback)
+    const layout = await loadLayoutByIdAsync(layoutId);
     if (!layout) {
       return false;
     }
@@ -127,21 +127,27 @@ export function useLayoutRouting() {
       return;
     }
 
-    const success = navigateToLayout(hashLayoutId, false);
-    if (!success) {
-      // Layout not found - show friendly error
-      addToast(
-        'Layout not found. Use the Share button to share layouts with others.',
-        'info',
-        8000
-      );
-      // Update URL to current layout
-      if (activeLayoutId && activeLayoutId !== '__shared_preview__') {
-        setLayoutHash(activeLayoutId, false);
-      } else {
-        clearLayoutHash();
-      }
-    }
+    // Navigate asynchronously
+    navigateToLayout(hashLayoutId, false)
+      .then((success) => {
+        if (!success) {
+          // Layout not found - show friendly error
+          addToast(
+            'Layout not found. Use the Share button to share layouts with others.',
+            'info',
+            8000
+          );
+          // Update URL to current layout
+          if (activeLayoutId && activeLayoutId !== '__shared_preview__') {
+            setLayoutHash(activeLayoutId, false);
+          } else {
+            clearLayoutHash();
+          }
+        }
+      })
+      .catch((error) => {
+        console.error('[LayoutRouting] Navigation failed:', error);
+      });
   }, [
     isLoaded,
     activeLayoutId,
@@ -171,14 +177,20 @@ export function useLayoutRouting() {
       // Already on this layout
       if (layoutId === activeLayoutId) return;
 
-      const success = navigateToLayout(layoutId, false);
-      if (!success) {
-        addToast('Layout not found', 'error');
-        // Restore URL to current layout
-        if (activeLayoutId && activeLayoutId !== '__shared_preview__') {
-          setLayoutHash(activeLayoutId, false);
-        }
-      }
+      // Navigate asynchronously
+      navigateToLayout(layoutId, false)
+        .then((success) => {
+          if (!success) {
+            addToast('Layout not found', 'error');
+            // Restore URL to current layout
+            if (activeLayoutId && activeLayoutId !== '__shared_preview__') {
+              setLayoutHash(activeLayoutId, false);
+            }
+          }
+        })
+        .catch((error) => {
+          console.error('[LayoutRouting] Popstate navigation failed:', error);
+        });
     };
 
     window.addEventListener('popstate', handlePopState);

--- a/src/hooks/useLayoutSwitcher.ts
+++ b/src/hooks/useLayoutSwitcher.ts
@@ -4,7 +4,7 @@ import { useLayoutStore, useLibraryStore, useHistoryStore, useUIStore, useToastS
 import type { Layout, OperationResult, LayoutPreview } from '../types';
 import {
   saveLayoutByIdAsync,
-  loadLayoutById,
+  loadLayoutByIdAsync,
   deleteLayoutByIdAsync,
   saveLibrary,
   computeLayoutPreview,
@@ -119,8 +119,8 @@ export function useLayoutSwitcher() {
         });
       }
 
-      // 5. Load target layout (sync from localStorage for fast switching)
-      const targetLayout = loadLayoutById(targetId);
+      // 5. Load target layout from IndexedDB (with localStorage fallback)
+      const targetLayout = await loadLayoutByIdAsync(targetId);
       if (!targetLayout) {
         return { success: false, error: 'Failed to load layout data' };
       }
@@ -292,8 +292,8 @@ export function useLayoutSwitcher() {
       return { success: false, error: 'Layout not found' };
     }
 
-    // Load the source layout
-    const sourceLayout = loadLayoutById(id);
+    // Load the source layout from IndexedDB (with localStorage fallback)
+    const sourceLayout = await loadLayoutByIdAsync(id);
     if (!sourceLayout) {
       return { success: false, error: 'Failed to load layout data' };
     }

--- a/src/hooks/useStorageMigration.ts
+++ b/src/hooks/useStorageMigration.ts
@@ -16,7 +16,6 @@ import { useEffect, useRef } from 'react';
 import {
   migrateAllLayoutsToIndexedDB,
   isMigrationNeeded,
-  // cleanupLocalStorage - uncomment when ready to remove localStorage fallback
 } from '../utils/migration';
 import { getStorageBackend } from '../utils/asyncStorage';
 
@@ -59,15 +58,19 @@ export function useStorageMigration(): void {
             `[Storage] Migration complete: ${result.migratedCount} layouts migrated, ${result.skippedCount} skipped`
           );
 
-          // Note: We intentionally keep localStorage copies for now as a fallback.
-          // This ensures backwards compatibility while sync load operations
-          // still read from localStorage. The cleanup will happen in a future
-          // version once we're confident all load operations use IndexedDB.
-          // TODO: Enable cleanup once loadLayoutById is fully async
-          // if (result.migratedCount > 0) {
-          //   const cleaned = cleanupLocalStorage();
-          //   console.info(`[Storage] Cleaned ${cleaned} layouts from localStorage`);
-          // }
+          // Note: We intentionally keep localStorage copies as a cache for fast startup.
+          // initializeLayoutLibrary() runs synchronously at module load time and reads
+          // from localStorage for immediate availability. All subsequent load/save
+          // operations use IndexedDB via async functions.
+          //
+          // The architecture is:
+          // - Initial load: localStorage (sync, fast startup)
+          // - Runtime operations: IndexedDB (async, larger capacity)
+          // - Both backends stay in sync via dual writes during saves
+          //
+          // Enabling cleanup would break the sync initial load. A future version
+          // could add async initialization with a loading state to fully remove
+          // the localStorage dependency.
         } else {
           console.error('[Storage] Migration failed:', result.errors);
         }

--- a/src/test/components/LayoutList.test.tsx
+++ b/src/test/components/LayoutList.test.tsx
@@ -7,7 +7,7 @@ import type { LayoutEntry } from '../../types';
 
 // Mock storage
 vi.mock('../../utils/storage', () => ({
-  loadLayoutById: vi.fn(() => ({
+  loadLayoutByIdAsync: vi.fn(() => Promise.resolve({
     id: 'test-layout',
     name: 'Test Layout',
     drawer: { width: 10, depth: 8, height: 12 },
@@ -412,7 +412,10 @@ describe('LayoutList', () => {
       const downloadButtons = screen.getAllByTestId('download-btn');
       fireEvent.click(downloadButtons[0]);
 
-      expect(downloadLayoutAsFile).toHaveBeenCalled();
+      // Wait for async handleDownload to complete
+      await vi.waitFor(() => {
+        expect(downloadLayoutAsFile).toHaveBeenCalled();
+      });
       expect(announceToScreenReader).toHaveBeenCalledWith('Layout downloaded');
     });
   });

--- a/src/test/components/LayoutManagerModal.test.tsx
+++ b/src/test/components/LayoutManagerModal.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../../utils/storage', () => ({
   saveLayoutById: vi.fn(),
   saveLayoutByIdAsync: vi.fn().mockResolvedValue(undefined),
   loadLayoutById: vi.fn(),
+  loadLayoutByIdAsync: vi.fn(),
   deleteLayoutById: vi.fn(),
   deleteLayoutByIdAsync: vi.fn().mockResolvedValue(undefined),
   saveLibrary: vi.fn(),
@@ -24,6 +25,7 @@ vi.mock('../../utils/storage', () => ({
     layerCount: 1,
   })),
   getLayoutStorageKey: vi.fn((id: string) => `gridfinity-layout-${id}`),
+  downloadLayoutAsFile: vi.fn(),
 }));
 
 // Mock validation
@@ -195,7 +197,7 @@ describe('LayoutManagerModal Accessibility', () => {
     });
 
     it('Enter key activates focused layout', async () => {
-      vi.mocked(storage.loadLayoutById).mockReturnValue(createDefaultLayout());
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(createDefaultLayout());
 
       render(<LayoutManagerModal isOpen={true} onClose={mockOnClose} />);
 
@@ -387,7 +389,7 @@ describe('LayoutManagerModal Accessibility', () => {
 
   describe('layout actions', () => {
     it('switches layout when clicking a different layout', async () => {
-      vi.mocked(storage.loadLayoutById).mockReturnValue(createDefaultLayout());
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(createDefaultLayout());
 
       render(<LayoutManagerModal isOpen={true} onClose={mockOnClose} />);
 

--- a/src/test/components/MobileLayoutsPanel.test.tsx
+++ b/src/test/components/MobileLayoutsPanel.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../../utils/storage', () => ({
   saveLayoutById: vi.fn(),
   saveLayoutByIdAsync: vi.fn().mockResolvedValue(undefined),
   loadLayoutById: vi.fn(),
+  loadLayoutByIdAsync: vi.fn(),
   deleteLayoutById: vi.fn(),
   deleteLayoutByIdAsync: vi.fn().mockResolvedValue(undefined),
   saveLibrary: vi.fn(),
@@ -25,6 +26,9 @@ vi.mock('../../utils/storage', () => ({
     layerCount: 1,
   })),
   getLayoutStorageKey: vi.fn((id: string) => `gridfinity-layout-${id}`),
+  generateShareableURL: vi.fn(() => 'https://example.com/share'),
+  copyToClipboard: vi.fn().mockResolvedValue(true),
+  downloadLayoutAsFile: vi.fn(),
 }));
 
 // Mock validation
@@ -126,7 +130,7 @@ describe('MobileLayoutsPanel', () => {
 
   describe('layout selection', () => {
     it('switches to selected layout', async () => {
-      vi.mocked(storage.loadLayoutById).mockReturnValue(createDefaultLayout());
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(createDefaultLayout());
 
       render(<MobileLayoutsPanel />);
 
@@ -141,7 +145,7 @@ describe('MobileLayoutsPanel', () => {
     });
 
     it('closes panel after switching', async () => {
-      vi.mocked(storage.loadLayoutById).mockReturnValue(createDefaultLayout());
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(createDefaultLayout());
 
       render(<MobileLayoutsPanel />);
 
@@ -205,7 +209,7 @@ describe('MobileLayoutsPanel', () => {
     });
 
     it('duplicates layout when clicking visible duplicate button', async () => {
-      vi.mocked(storage.loadLayoutById).mockReturnValue(createDefaultLayout());
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(createDefaultLayout());
       const entriesBefore = useLibraryStore.getState().library.entries.length;
 
       render(<MobileLayoutsPanel />);

--- a/src/test/hooks/useCrossTabSync.test.ts
+++ b/src/test/hooks/useCrossTabSync.test.ts
@@ -10,7 +10,7 @@ import * as storage from '../../utils/storage';
 import * as validation from '../../utils/validation';
 
 vi.mock('../../utils/storage', () => ({
-  loadLayoutById: vi.fn(),
+  loadLayoutByIdAsync: vi.fn(),
   loadLibrary: vi.fn(),
 }));
 
@@ -60,7 +60,7 @@ describe('useCrossTabSync', () => {
     expect(setLibrarySpy).toHaveBeenCalledWith(mockLibrary);
   });
 
-  it('syncs active layout when its storage key changes', () => {
+  it('syncs active layout when its storage key changes', async () => {
     const mockLayout = {
       name: 'Updated Layout',
       drawer: { width: 12, depth: 10, height: 14 },
@@ -71,7 +71,7 @@ describe('useCrossTabSync', () => {
       gridUnitMm: 42,
       heightUnitMm: 7,
     };
-    vi.mocked(storage.loadLayoutById).mockReturnValue(mockLayout);
+    vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(mockLayout);
     vi.mocked(validation.validateLayoutIntegrity).mockReturnValue({ valid: true });
 
     const importLayoutSpy = vi.spyOn(useLayoutStore.getState(), 'importLayout');
@@ -87,15 +87,18 @@ describe('useCrossTabSync', () => {
       }));
     });
 
-    expect(storage.loadLayoutById).toHaveBeenCalledWith('test-layout-id');
-    expect(validation.validateLayoutIntegrity).toHaveBeenCalledWith(mockLayout);
-    expect(importLayoutSpy).toHaveBeenCalledWith(mockLayout, 'test-layout-id', 'remote');
-    expect(clearHistorySpy).toHaveBeenCalled();
+    // loadLayoutByIdAsync is called with .then(), so wait for async to complete
+    await vi.waitFor(() => {
+      expect(storage.loadLayoutByIdAsync).toHaveBeenCalledWith('test-layout-id');
+      expect(validation.validateLayoutIntegrity).toHaveBeenCalledWith(mockLayout);
+      expect(importLayoutSpy).toHaveBeenCalledWith(mockLayout, 'test-layout-id', 'remote');
+      expect(clearHistorySpy).toHaveBeenCalled();
+    });
   });
 
   it('does not sync when non-active layout changes', () => {
     const mockLayout = { name: 'Other Layout' };
-    vi.mocked(storage.loadLayoutById).mockReturnValue(mockLayout);
+    vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(mockLayout);
 
     const importLayoutSpy = vi.spyOn(useLayoutStore.getState(), 'importLayout');
 
@@ -109,13 +112,13 @@ describe('useCrossTabSync', () => {
       }));
     });
 
-    expect(storage.loadLayoutById).not.toHaveBeenCalled();
+    expect(storage.loadLayoutByIdAsync).not.toHaveBeenCalled();
     expect(importLayoutSpy).not.toHaveBeenCalled();
   });
 
   it('does not sync invalid layout data', () => {
     const mockLayout = { name: 'Invalid' };
-    vi.mocked(storage.loadLayoutById).mockReturnValue(mockLayout);
+    vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(mockLayout);
     vi.mocked(validation.validateLayoutIntegrity).mockReturnValue({ valid: false, error: 'Invalid' });
 
     const importLayoutSpy = vi.spyOn(useLayoutStore.getState(), 'importLayout');
@@ -145,7 +148,7 @@ describe('useCrossTabSync', () => {
     });
 
     expect(storage.loadLibrary).not.toHaveBeenCalled();
-    expect(storage.loadLayoutById).not.toHaveBeenCalled();
+    expect(storage.loadLayoutByIdAsync).not.toHaveBeenCalled();
   });
 
   it('removes event listener on unmount', () => {
@@ -157,7 +160,7 @@ describe('useCrossTabSync', () => {
     expect(removeEventListenerSpy).toHaveBeenCalledWith('storage', expect.any(Function));
   });
 
-  it('clears selection when syncing layout', () => {
+  it('clears selection when syncing layout', async () => {
     const mockLayout = {
       name: 'Updated',
       drawer: { width: 10, depth: 8, height: 12 },
@@ -168,7 +171,7 @@ describe('useCrossTabSync', () => {
       gridUnitMm: 42,
       heightUnitMm: 7,
     };
-    vi.mocked(storage.loadLayoutById).mockReturnValue(mockLayout);
+    vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(mockLayout);
     vi.mocked(validation.validateLayoutIntegrity).mockReturnValue({ valid: true });
 
     useUIStore.setState({ selectedBinIds: ['bin-1', 'bin-2'] });
@@ -184,10 +187,12 @@ describe('useCrossTabSync', () => {
       }));
     });
 
-    expect(clearSelectionSpy).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(clearSelectionSpy).toHaveBeenCalled();
+    });
   });
 
-  it('updates active layer if it no longer exists', () => {
+  it('updates active layer if it no longer exists', async () => {
     const mockLayout = {
       name: 'Updated',
       drawer: { width: 10, depth: 8, height: 12 },
@@ -198,7 +203,7 @@ describe('useCrossTabSync', () => {
       gridUnitMm: 42,
       heightUnitMm: 7,
     };
-    vi.mocked(storage.loadLayoutById).mockReturnValue(mockLayout);
+    vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(mockLayout);
     vi.mocked(validation.validateLayoutIntegrity).mockReturnValue({ valid: true });
 
     useUIStore.setState({ activeLayerId: 'old-layer' });
@@ -214,6 +219,8 @@ describe('useCrossTabSync', () => {
       }));
     });
 
-    expect(setActiveLayerSpy).toHaveBeenCalledWith('new-layer');
+    await vi.waitFor(() => {
+      expect(setActiveLayerSpy).toHaveBeenCalledWith('new-layer');
+    });
   });
 });

--- a/src/test/hooks/useLayoutRouting.test.ts
+++ b/src/test/hooks/useLayoutRouting.test.ts
@@ -9,7 +9,7 @@ import * as validation from '../../utils/validation';
 
 // Mock storage module
 vi.mock('../../utils/storage', () => ({
-  loadLayoutById: vi.fn(),
+  loadLayoutByIdAsync: vi.fn(),
 }));
 
 // Mock url module
@@ -54,7 +54,7 @@ describe('useLayoutRouting', () => {
     // Set up default mocks
     vi.mocked(url.parseLayoutIdFromHash).mockReturnValue(null);
     vi.mocked(url.hasShareHash).mockReturnValue(false);
-    vi.mocked(storage.loadLayoutById).mockReturnValue(mockLayout);
+    vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(mockLayout);
     vi.mocked(validation.validateLayoutIntegrity).mockReturnValue({ valid: true });
 
     // Set up library with an entry (need to set library.entries, not entries)
@@ -92,25 +92,25 @@ describe('useLayoutRouting', () => {
       expect(typeof result.current.navigateToLayout).toBe('function');
     });
 
-    it('returns false when layout not in library', () => {
+    it('returns false when layout not in library', async () => {
       const { result } = renderHook(() => useLayoutRouting());
 
-      const success = result.current.navigateToLayout('nonexistent-id');
+      const success = await result.current.navigateToLayout('nonexistent-id');
 
       expect(success).toBe(false);
     });
 
-    it('returns false when layout data cannot be loaded', () => {
-      vi.mocked(storage.loadLayoutById).mockReturnValue(null);
+    it('returns false when layout data cannot be loaded', async () => {
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(null);
 
       const { result } = renderHook(() => useLayoutRouting());
 
-      const success = result.current.navigateToLayout('layout-123');
+      const success = await result.current.navigateToLayout('layout-123');
 
       expect(success).toBe(false);
     });
 
-    it('returns false when layout validation fails', () => {
+    it('returns false when layout validation fails', async () => {
       vi.mocked(validation.validateLayoutIntegrity).mockReturnValue({
         valid: false,
         errors: ['Missing layers'],
@@ -118,63 +118,63 @@ describe('useLayoutRouting', () => {
 
       const { result } = renderHook(() => useLayoutRouting());
 
-      const success = result.current.navigateToLayout('layout-123');
+      const success = await result.current.navigateToLayout('layout-123');
 
       expect(success).toBe(false);
     });
 
-    it('returns true and updates stores on success', () => {
+    it('returns true and updates stores on success', async () => {
       const { result } = renderHook(() => useLayoutRouting());
 
-      const success = result.current.navigateToLayout('layout-123');
+      const success = await result.current.navigateToLayout('layout-123');
 
       expect(success).toBe(true);
       // Active layout ID is stored in library.activeLayoutId
       expect(useLibraryStore.getState().library.activeLayoutId).toBe('layout-123');
     });
 
-    it('clears selection when navigating', () => {
+    it('clears selection when navigating', async () => {
       useUIStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
 
       const { result } = renderHook(() => useLayoutRouting());
-      result.current.navigateToLayout('layout-123');
+      await result.current.navigateToLayout('layout-123');
 
       expect(useUIStore.getState().selectedBinIds).toEqual([]);
     });
 
-    it('sets active layer to first layer', () => {
+    it('sets active layer to first layer', async () => {
       const { result } = renderHook(() => useLayoutRouting());
-      result.current.navigateToLayout('layout-123');
+      await result.current.navigateToLayout('layout-123');
 
       expect(useUIStore.getState().activeLayerId).toBe('layer1');
     });
 
-    it('sets active category to first category', () => {
+    it('sets active category to first category', async () => {
       const { result } = renderHook(() => useLayoutRouting());
-      result.current.navigateToLayout('layout-123');
+      await result.current.navigateToLayout('layout-123');
 
       expect(useUIStore.getState().activeCategoryId).toBe('coral');
     });
 
-    it('clears undo history', () => {
+    it('clears undo history', async () => {
       // The clear function is called within navigateToLayout
       // We verify navigation succeeds, which implies history was cleared
       const { result } = renderHook(() => useLayoutRouting());
-      const success = result.current.navigateToLayout('layout-123');
+      const success = await result.current.navigateToLayout('layout-123');
 
       expect(success).toBe(true);
     });
 
-    it('updates URL hash', () => {
+    it('updates URL hash', async () => {
       const { result } = renderHook(() => useLayoutRouting());
-      result.current.navigateToLayout('layout-123');
+      await result.current.navigateToLayout('layout-123');
 
       expect(url.setLayoutHash).toHaveBeenCalledWith('layout-123', false);
     });
 
-    it('adds to history when requested', () => {
+    it('adds to history when requested', async () => {
       const { result } = renderHook(() => useLayoutRouting());
-      result.current.navigateToLayout('layout-123', true);
+      await result.current.navigateToLayout('layout-123', true);
 
       expect(url.setLayoutHash).toHaveBeenCalledWith('layout-123', true);
     });
@@ -232,21 +232,24 @@ describe('useLayoutRouting', () => {
       renderHook(() => useLayoutRouting());
 
       // Should have attempted to navigate to the URL layout
-      expect(storage.loadLayoutById).toHaveBeenCalledWith('layout-123');
+      expect(storage.loadLayoutByIdAsync).toHaveBeenCalledWith('layout-123');
     });
 
-    it('shows toast when URL layout not found', () => {
+    it('shows toast when URL layout not found', async () => {
       vi.mocked(url.parseLayoutIdFromHash).mockReturnValue('nonexistent');
       const addToastSpy = vi.fn();
       useToastStore.setState({ addToast: addToastSpy });
 
       renderHook(() => useLayoutRouting());
 
-      expect(addToastSpy).toHaveBeenCalledWith(
-        expect.stringContaining('not found'),
-        'info',
-        expect.any(Number)
-      );
+      // navigateToLayout is async, so wait for the toast to be called
+      await vi.waitFor(() => {
+        expect(addToastSpy).toHaveBeenCalledWith(
+          expect.stringContaining('not found'),
+          'info',
+          expect.any(Number)
+        );
+      });
     });
   });
 
@@ -278,7 +281,7 @@ describe('useLayoutRouting', () => {
       });
 
       // Should not navigate during shared preview
-      expect(storage.loadLayoutById).not.toHaveBeenCalled();
+      expect(storage.loadLayoutByIdAsync).not.toHaveBeenCalled();
     });
 
     it('falls back to parsing hash when no state', () => {

--- a/src/test/hooks/useLayoutSwitcher.test.ts
+++ b/src/test/hooks/useLayoutSwitcher.test.ts
@@ -15,6 +15,7 @@ vi.mock('../../utils/storage', () => ({
   saveLayoutById: vi.fn(),
   saveLayoutByIdAsync: vi.fn().mockResolvedValue(undefined),
   loadLayoutById: vi.fn(),
+  loadLayoutByIdAsync: vi.fn(),
   deleteLayoutById: vi.fn(),
   deleteLayoutByIdAsync: vi.fn().mockResolvedValue(undefined),
   saveLibrary: vi.fn(),
@@ -113,7 +114,7 @@ describe('useLayoutSwitcher', () => {
   describe('switchLayout', () => {
     it('switches to target layout successfully', async () => {
       const targetLayout = createTestLayout('Second Layout');
-      vi.mocked(storage.loadLayoutById).mockReturnValue(targetLayout);
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(targetLayout);
 
       const { result } = renderHook(() => useLayoutSwitcher());
 
@@ -141,7 +142,7 @@ describe('useLayoutSwitcher', () => {
     });
 
     it('returns error when layout fails to load', async () => {
-      vi.mocked(storage.loadLayoutById).mockReturnValue(null);
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(null);
 
       const { result } = renderHook(() => useLayoutSwitcher());
 
@@ -158,7 +159,7 @@ describe('useLayoutSwitcher', () => {
 
     it('saves current layout before switching', async () => {
       const targetLayout = createTestLayout('Second');
-      vi.mocked(storage.loadLayoutById).mockReturnValue(targetLayout);
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(targetLayout);
 
       const { result } = renderHook(() => useLayoutSwitcher());
 
@@ -175,7 +176,7 @@ describe('useLayoutSwitcher', () => {
     it('clears selection on switch', async () => {
       useUIStore.setState({ selectedBinIds: ['bin-1', 'bin-2'] });
       const targetLayout = createTestLayout('Second');
-      vi.mocked(storage.loadLayoutById).mockReturnValue(targetLayout);
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(targetLayout);
 
       const { result } = renderHook(() => useLayoutSwitcher());
 
@@ -192,7 +193,7 @@ describe('useLayoutSwitcher', () => {
         future: [createDefaultLayout()],
       });
       const targetLayout = createTestLayout('Second');
-      vi.mocked(storage.loadLayoutById).mockReturnValue(targetLayout);
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(targetLayout);
 
       const { result } = renderHook(() => useLayoutSwitcher());
 
@@ -208,7 +209,7 @@ describe('useLayoutSwitcher', () => {
       const targetLayout = createTestLayout('Second');
       targetLayout.layers = [{ id: 'new-layer', name: 'New Layer', height: 5 }];
       targetLayout.categories = [{ id: 'new-cat', name: 'New Cat', color: '#fff' }];
-      vi.mocked(storage.loadLayoutById).mockReturnValue(targetLayout);
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(targetLayout);
 
       const { result } = renderHook(() => useLayoutSwitcher());
 
@@ -229,7 +230,7 @@ describe('useLayoutSwitcher', () => {
       });
 
       const targetLayout = createTestLayout('Second');
-      vi.mocked(storage.loadLayoutById).mockReturnValue(targetLayout);
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(targetLayout);
 
       const { result } = renderHook(() => useLayoutSwitcher());
 
@@ -246,7 +247,7 @@ describe('useLayoutSwitcher', () => {
       useLayoutStore.setState({ activeLayoutId: '__shared_preview__' });
 
       const targetLayout = createTestLayout('Second');
-      vi.mocked(storage.loadLayoutById).mockReturnValue(targetLayout);
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(targetLayout);
 
       const { result } = renderHook(() => useLayoutSwitcher());
 
@@ -360,7 +361,7 @@ describe('useLayoutSwitcher', () => {
     });
 
     it('switches to another layout when deleting active', async () => {
-      vi.mocked(storage.loadLayoutById).mockReturnValue(createTestLayout('Second'));
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(createTestLayout('Second'));
 
       const { result } = renderHook(() => useLayoutSwitcher());
 
@@ -386,7 +387,7 @@ describe('useLayoutSwitcher', () => {
 
   describe('duplicateLayout', () => {
     it('duplicates layout successfully', async () => {
-      vi.mocked(storage.loadLayoutById).mockReturnValue(createTestLayout('Original'));
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(createTestLayout('Original'));
 
       const { result } = renderHook(() => useLayoutSwitcher());
 
@@ -416,7 +417,7 @@ describe('useLayoutSwitcher', () => {
     });
 
     it('returns error when source layout fails to load', async () => {
-      vi.mocked(storage.loadLayoutById).mockReturnValue(null);
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(null);
 
       const { result } = renderHook(() => useLayoutSwitcher());
 
@@ -432,7 +433,7 @@ describe('useLayoutSwitcher', () => {
     });
 
     it('saves duplicated layout with (copy) suffix', async () => {
-      vi.mocked(storage.loadLayoutById).mockReturnValue(createTestLayout('Original'));
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(createTestLayout('Original'));
 
       const { result } = renderHook(() => useLayoutSwitcher());
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -638,6 +638,10 @@ export async function copyToClipboard(text: string): Promise<boolean> {
  * Initialize the layout library system.
  * Handles migration from legacy storage if needed.
  * Returns the library and the active layout.
+ *
+ * Note: This function is synchronous for fast startup. It reads/writes to
+ * localStorage for immediate availability. New layouts are also saved to
+ * IndexedDB asynchronously for future-proofing.
  */
 export function initializeLayoutLibrary(): { library: LayoutLibrary; activeLayout: Layout } {
   // Try to load existing library
@@ -684,8 +688,14 @@ export function initializeLayoutLibrary(): { library: LayoutLibrary; activeLayou
       }],
     };
 
+    // Save to localStorage (sync for immediate availability)
     saveLayoutById(layoutId, defaultLayout);
     saveLibrary(library);
+
+    // Also save to IndexedDB (async, fire-and-forget)
+    saveLayoutByIdAsync(layoutId, defaultLayout).catch(() => {
+      // Ignore errors - localStorage save is sufficient for now
+    });
   }
 
   // Load the active layout
@@ -733,8 +743,14 @@ export function initializeLayoutLibrary(): { library: LayoutLibrary; activeLayou
         preview: computeLayoutPreview(activeLayout),
       }];
 
+      // Save to localStorage (sync)
       saveLayoutById(layoutId, activeLayout);
       saveLibrary(library);
+
+      // Also save to IndexedDB (async, fire-and-forget)
+      saveLayoutByIdAsync(layoutId, activeLayout).catch(() => {
+        // Ignore errors - localStorage save is sufficient for now
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- Removes the PartyKit-based collection feature and all associated code (API routes, components, hooks, store, tests)
- Completes the IndexedDB storage migration for layout data:
  - All runtime load operations now use async `loadLayoutByIdAsync` (IndexedDB with localStorage fallback)
  - All save operations write to both localStorage (sync startup) and IndexedDB (runtime)
  - Adds `useStorageMigration` hook to migrate existing localStorage layouts to IndexedDB on app startup

## Changes
- **Removed**: Collection feature (~12k lines removed)
  - API routes: `api/collection.ts`, `api/collection/[id]/*`
  - PartyKit: `party/collection.ts`, `partykit.json`
  - Components: `CollectionBanner`, `CreateCollectionModal`, `JoinCollectionModal`, etc.
  - Hooks: `useCollectionSync`, `useCollectionRouting`, `usePartySync`
  - Store: `src/store/collection.ts`
  - All associated tests

- **Added**: IndexedDB storage migration
  - `useStorageMigration` hook for background migration on startup
  - Updated `useLayoutSwitcher`, `useLayoutRouting`, `useCrossTabSync` to use async storage
  - Updated `LayoutList` and `MobileLayoutsPanel` for async download/copy operations
  - Proper error handling with `.catch()` on all async storage operations

## Test plan
- [x] All unit tests pass (`npm run test:run`)
- [x] Build succeeds (`npm run build`)
- [x] Coverage thresholds met
- [ ] Manual testing: Create, switch, duplicate, delete layouts
- [ ] Manual testing: Verify layouts persist after refresh
- [ ] Manual testing: Check DevTools IndexedDB has layout data