### PR TITLE
feat: improve print feature with dynamic grid sizing and header controls

### DIFF
--- a/src/components/modals/PrintModal.tsx
+++ b/src/components/modals/PrintModal.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState, useMemo, useCallback, type CSSProperties } from 'react';
+import { useEffect, useState, useMemo, useCallback, useRef, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import { useShallow } from 'zustand/shallow';
 import { useLayoutStore } from '../../store';
 import { useSettingsStore, type PrintViewSettings, type BinListSortOrder } from '../../store/settings';
 import { PrintLayout } from '../print/PrintLayout';
 import { SortOrderConfig } from '../print/SortOrderConfig';
-import { getOrientationForDrawer, getBinCountByLayer } from '../../utils/printLayout';
+import { getBinCountByLayer } from '../../utils/printLayout';
 import '../../styles/print.css';
 
 // Style constants
@@ -76,11 +76,35 @@ export function PrintModal({ isOpen, onClose }: PrintModalProps) {
     [layout.bins, layout.layers]
   );
 
-  // Calculate suggested orientation
-  const suggestedOrientation = useMemo(
-    () => getOrientationForDrawer(layout.drawer),
-    [layout.drawer]
-  );
+  // Measure preview container for scaling
+  const previewRef = useRef<HTMLDivElement>(null);
+  const [previewWidth, setPreviewWidth] = useState<number>(600);
+
+  useEffect(() => {
+    if (!isOpen || !previewRef.current) return;
+
+    // Track last width to prevent oscillation from scrollbar appearing/disappearing
+    let lastWidth = 0;
+    const SCROLLBAR_THRESHOLD = 20; // Ignore changes smaller than scrollbar width
+
+    const measureWidth = () => {
+      if (previewRef.current) {
+        // Subtract outer container padding (p-4 = 16px each side = 32px)
+        // and inner .print-preview padding (24px each side = 48px)
+        const width = previewRef.current.clientWidth - 80;
+        // Only update if width changed significantly (prevents scrollbar oscillation)
+        if (width > 0 && Math.abs(width - lastWidth) > SCROLLBAR_THRESHOLD) {
+          lastWidth = width;
+          setPreviewWidth(width);
+        }
+      }
+    };
+
+    measureWidth();
+    const resizeObserver = new ResizeObserver(measureWidth);
+    resizeObserver.observe(previewRef.current);
+    return () => resizeObserver.disconnect();
+  }, [isOpen]);
 
   // Handle escape key and body scroll lock
   useEffect(() => {
@@ -144,13 +168,14 @@ export function PrintModal({ isOpen, onClose }: PrintModalProps) {
   const noLayersSelected = selectedLayerIds.length === 0;
 
   // Always render the print portal so Cmd+P works even when modal is closed
-  // The portal content uses selected layers (defaults to all when modal closed)
+  // Use same width as preview so they match exactly
   const printPortal = createPortal(
     <div className="print-portal hidden">
       <PrintLayout
         layout={layout}
         selectedLayerIds={selectedLayerIds}
         settings={printViewSettings}
+        availableWidth={previewWidth}
       />
     </div>,
     document.body
@@ -279,6 +304,37 @@ export function PrintModal({ isOpen, onClose }: PrintModalProps) {
                   </div>
                 </div>
 
+                {/* Header Options */}
+                <div className="mb-4">
+                  <div className="text-xs text-content-tertiary mb-2 uppercase tracking-wide">Header</div>
+                  <div className="space-y-2">
+                    <CheckboxOption
+                      label="Show Header"
+                      checked={printViewSettings.showHeader}
+                      onChange={(v) => updatePrintSetting('showHeader', v)}
+                    />
+                    {printViewSettings.showHeader && (
+                      <div className="ml-4 space-y-2 border-l border-stroke-subtle pl-3">
+                        <CheckboxOption
+                          label="Layout Name"
+                          checked={printViewSettings.showLayoutName}
+                          onChange={(v) => updatePrintSetting('showLayoutName', v)}
+                        />
+                        <CheckboxOption
+                          label="Drawer Info"
+                          checked={printViewSettings.showDrawerInfo}
+                          onChange={(v) => updatePrintSetting('showDrawerInfo', v)}
+                        />
+                        <CheckboxOption
+                          label="Date"
+                          checked={printViewSettings.showDate}
+                          onChange={(v) => updatePrintSetting('showDate', v)}
+                        />
+                      </div>
+                    )}
+                  </div>
+                </div>
+
                 {/* Layout Options */}
                 <div>
                   <div className="text-xs text-content-tertiary mb-2 uppercase tracking-wide">Layout</div>
@@ -298,11 +354,6 @@ export function PrintModal({ isOpen, onClose }: PrintModalProps) {
                       checked={printViewSettings.showBinList}
                       onChange={(v) => updatePrintSetting('showBinList', v)}
                     />
-                    <CheckboxOption
-                      label="Print Date"
-                      checked={printViewSettings.showDate}
-                      onChange={(v) => updatePrintSetting('showDate', v)}
-                    />
                   </div>
                 </div>
               </div>
@@ -320,24 +371,16 @@ export function PrintModal({ isOpen, onClose }: PrintModalProps) {
                 </div>
               )}
 
-              {/* Orientation hint */}
-              <div className="text-xs text-content-tertiary">
-                <p className="mb-1">
-                  Suggested orientation: <strong>{suggestedOrientation}</strong>
-                </p>
-                <p>
-                  Set page orientation in your browser's print dialog.
-                </p>
-              </div>
             </div>
 
-            {/* Preview panel */}
-            <div className="flex-1 p-4 overflow-y-auto scrollbar-thin bg-surface">
+            {/* Preview panel - grid fills available width */}
+            <div ref={previewRef} className="flex-1 p-4 overflow-y-auto overflow-x-hidden bg-surface">
               <div className="print-preview">
                 <PrintLayout
                   layout={layout}
                   selectedLayerIds={selectedLayerIds}
                   settings={printViewSettings}
+                  availableWidth={previewWidth}
                 />
               </div>
             </div>

--- a/src/components/print/PrintLayout.tsx
+++ b/src/components/print/PrintLayout.tsx
@@ -11,12 +11,20 @@ import {
   sortBinsForPrint,
 } from '../../utils/printLayout';
 
+// Page widths for print (in pixels at 96 DPI, accounting for 0.5" margins)
+const PORTRAIT_WIDTH_PX = 670;  // 8.5" - 1" margins = 7" ≈ 670px
+const LANDSCAPE_WIDTH_PX = 950; // 11" - 1" margins = 10" ≈ 950px
+const ROW_LABELS_WIDTH = 22;    // Width reserved for row labels
+const MIN_CELL_SIZE = 20;
+const MAX_CELL_SIZE = 120;
+const DEFAULT_GAP = 1;
+
 interface PrintLayoutProps {
   layout: Layout;
   selectedLayerIds: string[];
   settings: PrintViewSettings;
-  cellSize?: number;
-  gap?: number;
+  /** Available width in pixels. If not provided, uses default print width. */
+  availableWidth?: number;
 }
 
 /**
@@ -26,10 +34,26 @@ export function PrintLayout({
   layout,
   selectedLayerIds,
   settings,
-  cellSize = 28,
-  gap = 1,
+  availableWidth,
 }: PrintLayoutProps) {
   const { drawer, bins, layers, categories } = layout;
+  const gap = DEFAULT_GAP;
+
+  // Calculate grid dimensions
+  const gridCols = Math.ceil(drawer.width);
+
+  // Determine target width: use measured width if available, otherwise use orientation setting
+  const defaultWidth = settings.orientation === 'landscape' ? LANDSCAPE_WIDTH_PX : PORTRAIT_WIDTH_PX;
+  const targetWidth = availableWidth ?? defaultWidth;
+
+  // Calculate optimal cell size to fill available width
+  // Account for row labels if grid coordinates are shown
+  const labelsWidth = settings.showGridCoordinates ? ROW_LABELS_WIDTH : 0;
+  const gridAreaWidth = targetWidth - labelsWidth;
+  // Formula: gridWidth = gridCols * cellSize + (gridCols - 1) * gap
+  // Solving for cellSize: cellSize = (gridWidth - (gridCols - 1) * gap) / gridCols
+  const calculatedCellSize = (gridAreaWidth - (gridCols - 1) * gap) / gridCols;
+  const cellSize = Math.max(MIN_CELL_SIZE, Math.min(MAX_CELL_SIZE, Math.floor(calculatedCellSize)));
 
   // Get visible layers and bins
   const visibleLayers = useMemo(
@@ -48,8 +72,7 @@ export function PrintLayout({
     [allVisibleBins, categories]
   );
 
-  // Calculate grid dimensions
-  const gridCols = Math.ceil(drawer.width);
+  // Calculate remaining grid dimensions
   const gridRows = Math.ceil(drawer.depth);
   const integerWidth = Math.floor(drawer.width);
   const integerDepth = Math.floor(drawer.depth);
@@ -162,7 +185,7 @@ export function PrintLayout({
     const labels: React.ReactNode[] = [];
     for (let x = 0; x < integerWidth; x++) {
       labels.push(
-        <div key={`col-${x}`} className="print-axis-label print-col-label">
+        <div key={`col-${x}`} className="print-axis-label print-col-label" style={{ width: cellSize }}>
           {x + 1}
         </div>
       );
@@ -175,7 +198,7 @@ export function PrintLayout({
       );
     }
     return labels;
-  }, [integerWidth, hasFractionalWidth, fractionalCellWidth]);
+  }, [integerWidth, hasFractionalWidth, fractionalCellWidth, cellSize]);
 
   // Generate row labels (1, 2, 3, ... from bottom)
   const rowLabels = useMemo(() => {
@@ -189,13 +212,13 @@ export function PrintLayout({
     }
     for (let y = integerDepth - 1; y >= 0; y--) {
       labels.push(
-        <div key={`row-${y}`} className="print-axis-label print-row-label">
+        <div key={`row-${y}`} className="print-axis-label print-row-label" style={{ height: cellSize }}>
           {y + 1}
         </div>
       );
     }
     return labels;
-  }, [integerDepth, hasFractionalDepth, fractionalCellHeight]);
+  }, [integerDepth, hasFractionalDepth, fractionalCellHeight, cellSize]);
 
   // Group bins by category for summary
   const binsByCategory = useMemo(() => {
@@ -242,12 +265,6 @@ export function PrintLayout({
 
     return (
       <div key={layer.id} className="print-grid-with-labels">
-        {/* Column labels */}
-        {settings.showGridCoordinates && (
-          <div className="print-col-labels" style={{ marginLeft: 20, gap: `${gap}px` }}>
-            {columnLabels}
-          </div>
-        )}
         <div className="print-grid-row">
           {/* Row labels */}
           {settings.showGridCoordinates && (
@@ -282,6 +299,12 @@ export function PrintLayout({
             })}
           </div>
         </div>
+        {/* Column labels - at bottom like 2D grid */}
+        {settings.showGridCoordinates && (
+          <div className="print-col-labels" style={{ marginLeft: ROW_LABELS_WIDTH, gap: `${gap}px` }}>
+            {columnLabels}
+          </div>
+        )}
       </div>
     );
   };
@@ -289,36 +312,40 @@ export function PrintLayout({
   return (
     <div className="print-layout-content">
       {/* Header */}
-      <div className="print-header">
-        <div className="print-header-top">
-          <h1>{layout.name}</h1>
-          {settings.showDate && (
-            <span className="print-header-date">{formatPrintDate()}</span>
+      {settings.showHeader && (
+        <div className="print-header">
+          <div className="print-header-top">
+            {settings.showLayoutName && <h1>{layout.name}</h1>}
+            {settings.showDate && (
+              <span className="print-header-date">{formatPrintDate()}</span>
+            )}
+          </div>
+          {settings.showDrawerInfo && (
+            <div className="print-header-info">
+              <div className="print-header-group">
+                <span className="print-header-label">Drawer</span>
+                <span className="print-header-value">{formatDrawerDimensions(drawer, layout.gridUnitMm)}</span>
+              </div>
+              <div className="print-header-group">
+                <span className="print-header-label">Height</span>
+                <span className="print-header-value">{drawer.height}u ({drawer.height * layout.heightUnitMm}mm)</span>
+              </div>
+              <div className="print-header-group">
+                <span className="print-header-label">Bins</span>
+                <span className="print-header-value">{allVisibleBins.length}</span>
+              </div>
+              <div className="print-header-group">
+                <span className="print-header-label">Layers</span>
+                <span className="print-header-value">
+                  {visibleLayers.length === layers.length
+                    ? `All (${layers.length})`
+                    : visibleLayers.map((l) => l.name).join(', ')}
+                </span>
+              </div>
+            </div>
           )}
         </div>
-        <div className="print-header-info">
-          <div className="print-header-group">
-            <span className="print-header-label">Drawer</span>
-            <span className="print-header-value">{formatDrawerDimensions(drawer, layout.gridUnitMm)}</span>
-          </div>
-          <div className="print-header-group">
-            <span className="print-header-label">Height</span>
-            <span className="print-header-value">{drawer.height}u ({drawer.height * layout.heightUnitMm}mm)</span>
-          </div>
-          <div className="print-header-group">
-            <span className="print-header-label">Bins</span>
-            <span className="print-header-value">{allVisibleBins.length}</span>
-          </div>
-          <div className="print-header-group">
-            <span className="print-header-label">Layers</span>
-            <span className="print-header-value">
-              {visibleLayers.length === layers.length
-                ? `All (${layers.length})`
-                : visibleLayers.map((l) => l.name).join(', ')}
-            </span>
-          </div>
-        </div>
-      </div>
+      )}
 
       {/* Grid(s) - one per layer if multiple selected */}
       {visibleLayers.length === 1 ? (

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -46,6 +46,11 @@ export const DEFAULT_BIN_LIST_SORT_ORDER: BinListSortOrder = [
 ];
 
 /**
+ * Page orientation for print.
+ */
+export type PrintOrientation = 'portrait' | 'landscape';
+
+/**
  * Print view settings for configuring what to display when printing.
  */
 export interface PrintViewSettings {
@@ -56,11 +61,17 @@ export interface PrintViewSettings {
   showHeight: boolean;
   showNotes: boolean;
   showCustomProperties: boolean;
+  // Header options (what shows in the header section)
+  showHeader: boolean;
+  showLayoutName: boolean;
+  showDrawerInfo: boolean;
+  showDate: boolean;
   // Layout options (what shows around/below the grid)
   showGridCoordinates: boolean;
   showLegend: boolean;
   showBinList: boolean;
-  showDate: boolean;
+  // Page orientation (affects grid sizing for print)
+  orientation: PrintOrientation;
   // Bin list sorting
   binListSortOrder: BinListSortOrder;
 }
@@ -76,11 +87,17 @@ export const DEFAULT_PRINT_VIEW_SETTINGS: PrintViewSettings = {
   showHeight: true,
   showNotes: true,
   showCustomProperties: true,
-  // Layout - all on by default
-  showGridCoordinates: true,
-  showLegend: true,
-  showBinList: true,
+  // Header - all on by default
+  showHeader: true,
+  showLayoutName: true,
+  showDrawerInfo: true,
   showDate: true,
+  // Layout options
+  showGridCoordinates: true,
+  showLegend: false,
+  showBinList: false,
+  // Page orientation for print sizing
+  orientation: 'landscape',
   // Bin list sorting - category then position by default
   binListSortOrder: [...DEFAULT_BIN_LIST_SORT_ORDER],
 };

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -18,16 +18,6 @@
     size: auto;
   }
 
-  /* Landscape orientation hint (browser may ignore) */
-  @page landscape {
-    size: landscape;
-  }
-
-  /* Portrait orientation hint */
-  @page portrait {
-    size: portrait;
-  }
-
   /* Force white background on everything */
   html,
   body,
@@ -393,10 +383,7 @@
   color: black;
   padding: 24px;
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-  min-height: 400px;
-  max-height: calc(100vh - 300px);
-  overflow: auto;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 /* Print header for preview */

--- a/src/test/printLayout.test.ts
+++ b/src/test/printLayout.test.ts
@@ -1,14 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
-  getOrientationForDrawer,
   getVisibleBinsForPrint,
   getVisibleLayers,
   getUsedCategories,
   formatDrawerDimensions,
   formatPrintDate,
-  calculatePrintScale,
   getBinCountByLayer,
-  getTotalBinCount,
   sortBinsForPrint,
 } from '../utils/printLayout';
 import type { Bin, Layer, Category, Drawer } from '../types';
@@ -54,25 +51,6 @@ describe('printLayout utilities', () => {
     id,
     name,
     color,
-  });
-
-  describe('getOrientationForDrawer', () => {
-    it('returns landscape when width > depth', () => {
-      expect(getOrientationForDrawer(createDrawer(10, 8))).toBe('landscape');
-    });
-
-    it('returns portrait when depth > width', () => {
-      expect(getOrientationForDrawer(createDrawer(8, 10))).toBe('portrait');
-    });
-
-    it('returns portrait when width equals depth', () => {
-      expect(getOrientationForDrawer(createDrawer(10, 10))).toBe('portrait');
-    });
-
-    it('handles fractional dimensions', () => {
-      expect(getOrientationForDrawer(createDrawer(10.5, 8))).toBe('landscape');
-      expect(getOrientationForDrawer(createDrawer(8, 10.5))).toBe('portrait');
-    });
   });
 
   describe('getVisibleBinsForPrint', () => {
@@ -206,36 +184,6 @@ describe('printLayout utilities', () => {
     });
   });
 
-  describe('calculatePrintScale', () => {
-    it('returns 1.0 when grid fits within available space', () => {
-      const scale = calculatePrintScale(10, 8, 1000, 800, 32, 1);
-      expect(scale).toBe(1.0);
-    });
-
-    it('scales down when grid is larger than available space', () => {
-      // Grid would be ~330px wide (10 * 33), available is 200px
-      const scale = calculatePrintScale(10, 8, 200, 200, 32, 1);
-      expect(scale).toBeLessThan(1.0);
-      expect(scale).toBeGreaterThan(0.1);
-    });
-
-    it('uses smaller scale when constrained by both dimensions', () => {
-      const scale = calculatePrintScale(20, 20, 200, 300, 32, 1);
-      // Width more constrained (200 / ~660)
-      expect(scale).toBeLessThan(0.5);
-    });
-
-    it('does not scale above 1.0', () => {
-      const scale = calculatePrintScale(2, 2, 1000, 1000, 32, 1);
-      expect(scale).toBe(1.0);
-    });
-
-    it('does not scale below 0.1', () => {
-      const scale = calculatePrintScale(100, 100, 10, 10, 32, 1);
-      expect(scale).toBe(0.1);
-    });
-  });
-
   describe('getBinCountByLayer', () => {
     const layers: Layer[] = [
       createLayer('l1', 'Layer 1'),
@@ -274,37 +222,6 @@ describe('printLayout utilities', () => {
       const result = getBinCountByLayer([], layers);
       expect(result.get('l1')).toBe(0);
       expect(result.get('l2')).toBe(0);
-    });
-  });
-
-  describe('getTotalBinCount', () => {
-    it('counts all non-staging bins', () => {
-      const bins: Bin[] = [
-        createBin('b1', 'l1', 'cat1'),
-        createBin('b2', 'l2', 'cat1'),
-        createBin('b3', 'l1', 'cat2'),
-      ];
-      expect(getTotalBinCount(bins)).toBe(3);
-    });
-
-    it('excludes staging bins', () => {
-      const bins: Bin[] = [
-        createBin('b1', 'l1', 'cat1'),
-        createBin('b2', STAGING_ID, 'cat1'),
-      ];
-      expect(getTotalBinCount(bins)).toBe(1);
-    });
-
-    it('returns 0 for empty array', () => {
-      expect(getTotalBinCount([])).toBe(0);
-    });
-
-    it('returns 0 when all bins are staging', () => {
-      const bins: Bin[] = [
-        createBin('b1', STAGING_ID, 'cat1'),
-        createBin('b2', STAGING_ID, 'cat2'),
-      ];
-      expect(getTotalBinCount(bins)).toBe(0);
     });
   });
 

--- a/src/test/store/settings.test.ts
+++ b/src/test/store/settings.test.ts
@@ -246,7 +246,7 @@ describe('settings store', () => {
       expect(settings.printViewSettings).toBeDefined();
       expect(settings.printViewSettings.showLabel).toBe(true);
       expect(settings.printViewSettings.showCategoryColor).toBe(true);
-      expect(settings.printViewSettings.showBinList).toBe(true);
+      expect(settings.printViewSettings.showBinList).toBe(false);
     });
 
     it('has default bin list sort order', () => {
@@ -301,8 +301,8 @@ describe('settings store', () => {
 
     it('has all layout options', () => {
       expect(DEFAULT_PRINT_VIEW_SETTINGS.showGridCoordinates).toBe(true);
-      expect(DEFAULT_PRINT_VIEW_SETTINGS.showLegend).toBe(true);
-      expect(DEFAULT_PRINT_VIEW_SETTINGS.showBinList).toBe(true);
+      expect(DEFAULT_PRINT_VIEW_SETTINGS.showLegend).toBe(false);
+      expect(DEFAULT_PRINT_VIEW_SETTINGS.showBinList).toBe(false);
       expect(DEFAULT_PRINT_VIEW_SETTINGS.showDate).toBe(true);
     });
 

--- a/src/utils/printLayout.ts
+++ b/src/utils/printLayout.ts
@@ -3,14 +3,6 @@ import type { BinListSortOrder, BinSortField } from '../store/settings';
 import { STAGING_ID } from '../constants';
 
 /**
- * Get the suggested page orientation based on drawer dimensions.
- * Landscape if drawer is wider than deep, portrait otherwise.
- */
-export function getOrientationForDrawer(drawer: Drawer): 'portrait' | 'landscape' {
-  return drawer.width > drawer.depth ? 'landscape' : 'portrait';
-}
-
-/**
  * Filter bins to only include those on the specified layers.
  * Excludes staging bins.
  */
@@ -60,31 +52,6 @@ export function formatPrintDate(): string {
 }
 
 /**
- * Calculate scale factor to fit drawer in available width.
- * Returns a scale between 0.1 and 1.0.
- */
-export function calculatePrintScale(
-  drawerWidth: number,
-  drawerDepth: number,
-  availableWidth: number,
-  availableHeight: number,
-  cellSize: number,
-  gap: number
-): number {
-  const gridWidth = drawerWidth * (cellSize + gap) + gap;
-  const gridHeight = drawerDepth * (cellSize + gap) + gap;
-
-  const scaleX = availableWidth / gridWidth;
-  const scaleY = availableHeight / gridHeight;
-
-  // Use the smaller scale to fit both dimensions
-  const scale = Math.min(scaleX, scaleY, 1.0);
-
-  // Clamp to reasonable range
-  return Math.max(0.1, Math.min(1.0, scale));
-}
-
-/**
  * Get bin count per layer for display.
  */
 export function getBinCountByLayer(
@@ -107,13 +74,6 @@ export function getBinCountByLayer(
   }
 
   return counts;
-}
-
-/**
- * Get total bin count excluding staging.
- */
-export function getTotalBinCount(bins: Bin[]): number {
-  return bins.filter((bin) => bin.layerId !== STAGING_ID).length;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Grid now maximizes available width with dynamic cell sizing
- Add header toggle with sub-options (layout name, drawer info, date)
- Move column labels to bottom like 2D grid view
- Default bin details table and category legend to off
- Fix scrollbar oscillation with threshold-based width measurement

## Cleanup
- Remove unused utility functions (getOrientationForDrawer, calculatePrintScale, getTotalBinCount)
- Remove ineffective CSS @page named rules

## Test plan
- [x] All tests pass
- [x] Build succeeds
- [ ] Manual testing of print preview