### PR TITLE
fix: use full page width for print output instead of preview width

### DIFF
--- a/src/components/modals/PrintModal.tsx
+++ b/src/components/modals/PrintModal.tsx
@@ -168,14 +168,13 @@ export function PrintModal({ isOpen, onClose }: PrintModalProps) {
   const noLayersSelected = selectedLayerIds.length === 0;
 
   // Always render the print portal so Cmd+P works even when modal is closed
-  // Use same width as preview so they match exactly
+  // Don't pass availableWidth - let PrintLayout use full page width based on orientation
   const printPortal = createPortal(
     <div className="print-portal hidden">
       <PrintLayout
         layout={layout}
         selectedLayerIds={selectedLayerIds}
         settings={printViewSettings}
-        availableWidth={previewWidth}
       />
     </div>,
     document.body


### PR DESCRIPTION
## Summary
Print output now uses the full landscape (950px) or portrait (670px) page width instead of the narrow preview panel width.

## Test plan
- [x] Build passes
- [x] Tests pass
- [ ] Manual test: print should fill page width