### PR TITLE
chore: remove redundant comments and dead code

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,0 +1,9 @@
+---
+active: true
+iteration: 17
+max_iterations: 0
+completion_promise: null
+started_at: "2026-01-14T01:27:59Z"
+---
+
+Find opportunities to clean up code comments that just explain the next line and dead or duplicated code

--- a/src/components/Grid/QuickLabelPopover.tsx
+++ b/src/components/Grid/QuickLabelPopover.tsx
@@ -28,7 +28,6 @@ function QuickLabelPopoverInner({ binId }: { binId: string }) {
   // Initialize value from bin label (fresh on each mount due to key)
   const [value, setValue] = useState(bin?.label || '');
 
-  // Save handler
   const handleSave = useCallback(() => {
     if (bin && value !== (bin.label || '')) {
       execute(() => {
@@ -38,7 +37,6 @@ function QuickLabelPopoverInner({ binId }: { binId: string }) {
     hideQuickLabel();
   }, [bin, value, execute, updateBin, hideQuickLabel]);
 
-  // Focus input when popover mounts
   useEffect(() => {
     requestAnimationFrame(() => {
       inputRef.current?.focus();
@@ -46,7 +44,6 @@ function QuickLabelPopoverInner({ binId }: { binId: string }) {
     });
   }, []);
 
-  // Handle click outside to close
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {

--- a/src/components/inspector/useBinInspector.ts
+++ b/src/components/inspector/useBinInspector.ts
@@ -144,10 +144,8 @@ export function useBinInspector(): UseBinInspectorReturn {
     return Array.from(keys).sort();
   }, [layout.bins]);
 
-  // Get toast store for notifications (used by custom properties and layer movement)
   const addToast = useToastStore((state) => state.addToast);
 
-  // Update single bin field
   const updateField = useCallback(
     (field: BinField, value: string | number) => {
       if (!bin) return;
@@ -189,7 +187,6 @@ export function useBinInspector(): UseBinInspectorReturn {
     [bin, layer, constraints.maxHeight, constraints.maxClearance, execute, updateBin]
   );
 
-  // Update custom properties
   const updateCustomProperties = useCallback(
     (properties: Record<string, string>) => {
       if (!bin) return;
@@ -208,7 +205,6 @@ export function useBinInspector(): UseBinInspectorReturn {
     [bin, execute, updateBin, addToast]
   );
 
-  // Update category for multiple bins
   const updateMultiCategory = useCallback(
     (categoryId: string) => {
       if (selectedBins.length === 0) return;
@@ -244,7 +240,6 @@ export function useBinInspector(): UseBinInspectorReturn {
     [selectedBins, execute, updateBin, addToast]
   );
 
-  // Update height delta for multiple bins
   const updateMultiHeight = useCallback(
     (delta: number) => {
       if (selectedBins.length === 0) return;
@@ -262,7 +257,6 @@ export function useBinInspector(): UseBinInspectorReturn {
     [selectedBins, layout.drawer.height, layout.layers, execute, updateBin]
   );
 
-  // Update clearance delta for multiple bins
   const updateMultiClearance = useCallback(
     (delta: number) => {
       if (selectedBins.length === 0) return;
@@ -415,7 +409,6 @@ export function useBinInspector(): UseBinInspectorReturn {
     setDeleteConfirmState(null);
   }, []);
 
-  // Move to staging
   const moveToStaging = useCallback(() => {
     if (selectedBins.length === 0) return;
 
@@ -428,7 +421,6 @@ export function useBinInspector(): UseBinInspectorReturn {
     closeMobilePanel();
   }, [selectedBins, execute, moveBinToStaging, closeMobilePanel]);
 
-  // Clear selection
   const clearSelection = useCallback(() => {
     setSelectedBins([]);
   }, [setSelectedBins]);

--- a/src/components/print/SortOrderConfig.tsx
+++ b/src/components/print/SortOrderConfig.tsx
@@ -15,7 +15,6 @@ export function SortOrderConfig({ sortOrder, onChange }: SortOrderConfigProps) {
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
-  // Toggle a field's enabled state
   const toggleField = useCallback(
     (field: BinSortField) => {
       const newOrder = sortOrder.map((item) =>
@@ -26,7 +25,6 @@ export function SortOrderConfig({ sortOrder, onChange }: SortOrderConfigProps) {
     [sortOrder, onChange]
   );
 
-  // Move a field up in the list
   const moveUp = useCallback(
     (index: number) => {
       if (index <= 0) return;
@@ -37,7 +35,6 @@ export function SortOrderConfig({ sortOrder, onChange }: SortOrderConfigProps) {
     [sortOrder, onChange]
   );
 
-  // Move a field down in the list
   const moveDown = useCallback(
     (index: number) => {
       if (index >= sortOrder.length - 1) return;
@@ -48,7 +45,6 @@ export function SortOrderConfig({ sortOrder, onChange }: SortOrderConfigProps) {
     [sortOrder, onChange]
   );
 
-  // Drag handlers
   const handleDragStart = useCallback((index: number) => {
     setDraggedIndex(index);
   }, []);
@@ -73,7 +69,6 @@ export function SortOrderConfig({ sortOrder, onChange }: SortOrderConfigProps) {
     setDragOverIndex(null);
   }, []);
 
-  // Get active sort fields for display
   const activeSortFields = sortOrder.filter((s) => s.enabled);
 
   return (

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -36,60 +36,47 @@ export function useAutoSave(): SaveStatus {
   const failureCountRef = useRef(0);
 
   useEffect(() => {
-    // Clear any pending save
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
 
-    // Clear any pending idle callback
     if (idleCallbackRef.current) {
       cancelIdleCallback(idleCallbackRef.current);
       idleCallbackRef.current = undefined;
     }
 
-    // Clear any pending "saved" timeout when new changes come in
     if (savedTimeoutRef.current) {
       clearTimeout(savedTimeoutRef.current);
       savedTimeoutRef.current = undefined;
     }
 
-    // Don't save if no active layout ID (shouldn't happen, but safety check)
     if (!activeLayoutId) return;
 
     // Don't save temporary shared preview layouts
     if (activeLayoutId === '__shared_preview__') return;
 
-    // Schedule save after debounce period
     timeoutRef.current = window.setTimeout(() => {
-      // Show "saving" status immediately to give user feedback
       setSaveStatus('saving');
 
-      // Schedule the actual storage operations during browser idle time
-      // This improves INP by not blocking the main thread during user interactions
+      // Schedule storage operations during browser idle time to improve INP
       idleCallbackRef.current = scheduleIdleCallback(
         async () => {
           try {
-            // Save layout to IndexedDB (async, with localStorage fallback)
             await saveLayoutByIdAsync(activeLayoutId, layout);
 
-            // Update library entry with new preview and timestamp
             updateEntry(activeLayoutId, {
               modifiedAt: Date.now(),
               preview: computeLayoutPreview(layout),
-              name: layout.name, // Keep library name in sync with layout name
+              name: layout.name,
             });
 
-            // Save library index (stays in localStorage for cross-tab sync)
             saveLibrary(useLibraryStore.getState().library);
 
-            // Reset error flags on successful save
             hasShownErrorRef.current = false;
             failureCountRef.current = 0;
 
-            // Show "saved" status
             setSaveStatus('saved');
 
-            // Clear "saved" status after delay
             savedTimeoutRef.current = window.setTimeout(() => {
               setSaveStatus('idle');
             }, SAVED_DISPLAY_MS);

--- a/src/hooks/useCloudShare.ts
+++ b/src/hooks/useCloudShare.ts
@@ -74,7 +74,6 @@ export function useCloudShare(layoutId?: string): CloudShareState & CloudShareAc
     };
   }, []);
 
-  // Get library state
   const {
     activeLayoutId,
     entries,
@@ -93,23 +92,17 @@ export function useCloudShare(layoutId?: string): CloudShareState & CloudShareAc
     }))
   );
 
-  // Get layout data
   const layout = useLayoutStore((state) => state.layout);
-
-  // Get announcer
   const announceToScreenReader = useUIStore((state) => state.announceToScreenReader);
 
-  // Determine target layout ID
   const targetLayoutId = layoutId ?? activeLayoutId;
 
-  // Get existing share info from library entry
   const existingShare = useMemo(() => {
     const entry = entries.find((e) => e.id === targetLayoutId);
     return entry?.cloudShare ?? null;
   }, [entries, targetLayoutId]);
 
-  // Check if share is still active (not expired)
-  // Note: This uses a stable reference time from mount to avoid re-render issues
+  // Use stable reference time from mount to avoid re-render issues
   const [mountTime] = useState(() => Date.now());
   const hasActiveShare = useMemo(() => {
     if (!existingShare) return false;
@@ -123,10 +116,7 @@ export function useCloudShare(layoutId?: string): CloudShareState & CloudShareAc
     }
   }, [existingShare, targetLayoutId, clearCloudShare]);
 
-  // Get the layout to share (might be from storage if not active)
   const getLayoutToShare = useCallback((): Layout => {
-    // For now, always use the active layout
-    // In future, could load from storage if different layout
     return layout;
   }, [layout]);
 
@@ -142,7 +132,6 @@ export function useCloudShare(layoutId?: string): CloudShareState & CloudShareAc
       // Save to library
       setCloudShare(targetLayoutId, shareInfo);
 
-      // Set result state
       setResult({
         id: response.id,
         url: response.url,
@@ -245,7 +234,6 @@ export function useCloudShare(layoutId?: string): CloudShareState & CloudShareAc
 
       if (response.success) {
         setLastShareExpiration(expiresInDays);
-        // Update uses same URL, keep existing deleteToken
         handleSuccess(
           {
             ...response.data,

--- a/src/hooks/useGridNavigation.ts
+++ b/src/hooks/useGridNavigation.ts
@@ -47,12 +47,10 @@ export function useGridNavigation() {
         return;
     }
 
-    // Find next bin in direction
     const nextBin = findNearestBinInDirection(currentBin, direction, bins, activeLayerId);
     if (nextBin) {
       setFocusedBin(nextBin.id);
 
-      // Announce to screen reader
       const label = nextBin.label || `${nextBin.width}×${nextBin.depth} bin`;
       announceToScreenReader(`Moved to ${label} at column ${nextBin.x + 1}, row ${nextBin.y + 1}`);
     }

--- a/src/hooks/useInteraction.ts
+++ b/src/hooks/useInteraction.ts
@@ -280,21 +280,18 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
       if (!currentInteraction) return;
 
       if (currentInteraction.type === 'drag') {
-        // Check if mouse is over the grid
         const overGrid = isInBounds(coords);
 
-        // Get all bins being dragged
         const draggedBins = currentInteraction.binIds
           .map(id => layout.bins.find(b => b.id === id))
           .filter((b): b is Bin => b !== undefined);
 
         if (draggedBins.length === 0) return;
 
-        // Calculate raw delta from start position
         const rawDeltaX = clamped.x - currentInteraction.startCoord.x;
         const rawDeltaY = clamped.y - currentInteraction.startCoord.y;
 
-        // Constrain delta to keep ENTIRE GROUP in bounds (preserves arrangement)
+        // Constrain delta to keep entire group in bounds (preserves arrangement)
         const { deltaX, deltaY } = constrainGroupDelta(
           draggedBins,
           rawDeltaX,
@@ -302,17 +299,14 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
           layout.drawer
         );
 
-        // Validate all bins at their new positions (with uniform delta applied)
-        let allValid = overGrid; // Only valid if over grid
+        let allValid = overGrid;
         const otherBinIds = new Set(currentInteraction.binIds);
 
         if (overGrid) {
           for (const bin of draggedBins) {
-            // Apply uniform delta - NO individual clamping
             const newX = bin.x + deltaX;
             const newY = bin.y + deltaY;
 
-            // Check placement excluding all bins being dragged
             const result = canPlaceBin(
               { x: newX, y: newY, width: bin.width, depth: bin.depth, height: bin.height },
               activeLayerId,
@@ -346,7 +340,6 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
           const startRect = currentInteraction.startRects.get(binId);
           if (!bin || !startRect) continue;
 
-          // Get current minSize from halfBinMode state
           const halfBinModeNow = useUIStore.getState().halfBinMode;
           const minSizeNow = halfBinModeNow ? 0.5 : 1;
           const newRect = calculateResizeRect(
@@ -502,7 +495,6 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
           const binsDown = Math.floor(areaDepth / ps.depth);
 
           if (binsAcross > 0 && binsDown > 0) {
-            // Get fresh layout state for validation
             const currentLayout = useLayoutStore.getState().layout;
             const placedBinIds: string[] = [];
 
@@ -549,9 +541,7 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
           }
         }
       } else if (interaction.type === 'drag') {
-        // Check for drop targets first
         if (currentDropTarget === 'trash') {
-          // Delete all dragged bins
           execute(() => {
             for (const binId of interaction.binIds) {
               deleteBin(binId);
@@ -616,14 +606,11 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
                 setSelectedBins(newBinIds);
               }
             } else {
-              // Normal mode: move bins to new position
               execute(() => {
-                // Update all dragged bins with uniform delta (preserves arrangement)
                 for (const binId of interaction.binIds) {
                   const bin = layout.bins.find(b => b.id === binId);
                   if (!bin) continue;
 
-                  // Apply uniform delta - NO individual clamping
                   updateBin(binId, {
                     x: bin.x + deltaX,
                     y: bin.y + deltaY,
@@ -639,7 +626,6 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
       } else if (interaction.type === 'resize' && interaction.valid) {
         let hasChanges = false;
 
-        // Check if any bin changed
         for (const binId of interaction.binIds) {
           const startRect = interaction.startRects.get(binId);
           const currentRect = interaction.currentRects.get(binId);
@@ -672,7 +658,6 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
           });
         }
       } else if (interaction.type === 'stagingDrag') {
-        // Check for trash drop first
         if (currentDropTarget === 'trash') {
           execute(() => {
             deleteBin(interaction.binId);

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -91,7 +91,6 @@ export function useKeyboard() {
     const key = e.key;
     const ctrlOrMeta = e.ctrlKey || e.metaKey;
 
-    // Delete all selected bins
     if (isShortcut(key, SHORTCUTS.DELETE) && selectedBinIds.length > 0) {
       e.preventDefault();
       execute(() => {
@@ -103,7 +102,6 @@ export function useKeyboard() {
       return;
     }
 
-    // Escape - clear selection and exit paint mode
     if (isShortcut(key, SHORTCUTS.ESCAPE)) {
       e.preventDefault();
       setInteraction(null);
@@ -112,14 +110,12 @@ export function useKeyboard() {
       return;
     }
 
-    // Undo
     if (ctrlOrMeta && key.toLowerCase() === SHORTCUTS.UNDO && !e.shiftKey) {
       e.preventDefault();
       if (canUndo) undo();
       return;
     }
 
-    // Redo (Ctrl+Y or Ctrl+Shift+Z)
     if (ctrlOrMeta && (key.toLowerCase() === SHORTCUTS.REDO || (key === SHORTCUTS.REDO_ALT && e.shiftKey))) {
       e.preventDefault();
       if (canRedo) redo();

--- a/src/hooks/useKeyboardDrag.ts
+++ b/src/hooks/useKeyboardDrag.ts
@@ -40,7 +40,6 @@ export function useKeyboardDrag() {
       return;
     }
 
-    // Check if any selected bins are in staging
     const hasStaging = selectedBinIds.some(id => {
       const bin = findBinById(layout, id);
       return bin?.layerId === STAGING_ID;
@@ -60,7 +59,6 @@ export function useKeyboardDrag() {
       `Use arrow keys to move, Enter to place, Escape to cancel.`
     );
 
-    // Set interaction to show ghost preview
     const firstBin = findBinById(layout, selectedBinIds[0]);
     const startCoord = firstBin ? { x: firstBin.x, y: firstBin.y } : { x: 0, y: 0 };
     setInteraction({
@@ -80,7 +78,6 @@ export function useKeyboardDrag() {
     if (!keyboardDragMode) return;
 
     setDragOffset(prev => {
-      // Get all selected bins
       const selectedBins = selectedBinIds
         .map(id => findBinById(layout, id))
         .filter((b): b is Bin => b !== undefined && b.layerId !== STAGING_ID);
@@ -124,14 +121,13 @@ export function useKeyboardDrag() {
         }
       }
 
-      // Update interaction to show preview with new offset (delta semantic)
       const firstBin = selectedBins[0];
       const startCoord = { x: firstBin.x, y: firstBin.y };
       setInteraction({
         type: 'drag',
         binIds: selectedBinIds,
         startCoord,
-        currentCoord: { x: deltaX, y: deltaY }, // Store delta, not absolute position
+        currentCoord: { x: deltaX, y: deltaY },
         valid: allValid,
         isOverGrid: true,
       });
@@ -163,7 +159,6 @@ export function useKeyboardDrag() {
       return;
     }
 
-    // Validate all bins can move to new positions
     const excludeIds = new Set(selectedBinIds);
     let allValid = true;
     const validationErrors: string[] = [];
@@ -201,7 +196,6 @@ export function useKeyboardDrag() {
       return;
     }
 
-    // Apply the movement
     execute(() => {
       for (const binId of selectedBinIds) {
         const bin = findBinById(layout, binId);
@@ -212,7 +206,6 @@ export function useKeyboardDrag() {
 
     announceToScreenReader(`Moved ${selectedBinIds.length} ${selectedBinIds.length === 1 ? 'bin' : 'bins'}.`);
 
-    // Exit drag mode
     setKeyboardDragMode(false);
     setInteraction(null);
     setDragOffset({ dx: 0, dy: 0 });
@@ -268,14 +261,12 @@ export function useKeyboardDrag() {
       return;
     }
 
-    // Enter - confirm
     if (e.key === 'Enter') {
       e.preventDefault();
       confirmDrag();
       return;
     }
 
-    // Escape - cancel
     if (e.key === 'Escape') {
       e.preventDefault();
       exitDragMode();

--- a/src/hooks/useKeyboardResize.ts
+++ b/src/hooks/useKeyboardResize.ts
@@ -132,7 +132,6 @@ export function useKeyboardResize() {
       return;
     }
 
-    // Validate new size fits
     const result = canPlaceBin(
       { x: bin.x, y: bin.y, width: newWidth, depth: newDepth, height: bin.height },
       bin.layerId,
@@ -145,14 +144,12 @@ export function useKeyboardResize() {
       return;
     }
 
-    // Apply the resize
     execute(() => {
       updateBin(bin.id, { width: newWidth, depth: newDepth });
     });
 
     announceToScreenReader(`Resized to ${newWidth} by ${newDepth}.`);
 
-    // Exit resize mode
     setKeyboardResizeMode(false);
     setInteraction(null);
     setResizeDelta({ dw: 0, dd: 0 });
@@ -206,14 +203,12 @@ export function useKeyboardResize() {
       return;
     }
 
-    // Enter - confirm
     if (e.key === 'Enter') {
       e.preventDefault();
       confirmResize();
       return;
     }
 
-    // Escape - cancel
     if (e.key === 'Escape') {
       e.preventDefault();
       exitResizeMode();

--- a/src/hooks/useLayoutSwitcher.ts
+++ b/src/hooks/useLayoutSwitcher.ts
@@ -179,44 +179,34 @@ export function useLayoutSwitcher() {
    * Create a new layout and switch to it.
    */
   const createNewLayout = useCallback(async (name?: string): Promise<OperationResult<string>> => {
-    // Save current layout first
     await saveCurrentLayout();
 
-    // Create new layout using user preferences
     const layoutId = generateUUID();
     const newLayout = createLayoutWithSettings(settings);
     newLayout.name = name || 'Untitled layout';
 
     try {
-      // Save the new layout to IndexedDB + localStorage
       await saveLayoutByIdAsync(layoutId, newLayout);
 
-      // Create library entry
       createEntry(
         newLayout.name,
         layoutId,
         computeLayoutPreview(newLayout)
       );
 
-      // Switch to the new layout
       importLayout(newLayout, layoutId, 'init');
       setLibraryActiveId(layoutId);
 
-      // Reset UI state
       clearSelection();
       setActiveLayer(newLayout.layers[0]?.id ?? '');
       setActiveCategory(newLayout.categories[0]?.id ?? '');
 
-      // Clear undo history
       clearHistory();
 
-      // Save library
       saveLibrary(useLibraryStore.getState().library);
 
-      // Update URL hash (add to browser history)
       setLayoutHash(layoutId, true);
 
-      // Track analytics
       trackLayoutAction('created');
 
       addToast('New layout created', 'success');
@@ -250,16 +240,13 @@ export function useLayoutSwitcher() {
     }
 
     try {
-      // Remove from storage (both IndexedDB and localStorage)
       await deleteLayoutByIdAsync(id);
 
-      // Remove from library
       const result = deleteEntry(id);
       if (!result.success) {
         return result;
       }
 
-      // If deleting active layout, switch to first remaining
       if (activeLayoutId === id) {
         const remaining = entries.filter(e => e.id !== id);
         const fallbackId = remaining[0].id;
@@ -269,10 +256,8 @@ export function useLayoutSwitcher() {
         }
       }
 
-      // Save library
       saveLibrary(useLibraryStore.getState().library);
 
-      // Track analytics
       trackLayoutAction('deleted');
 
       addToast('Layout deleted', 'success');
@@ -292,32 +277,25 @@ export function useLayoutSwitcher() {
       return { success: false, error: 'Layout not found' };
     }
 
-    // Load the source layout from IndexedDB (with localStorage fallback)
     const sourceLayout = await loadLayoutByIdAsync(id);
     if (!sourceLayout) {
       return { success: false, error: 'Failed to load layout data' };
     }
 
     try {
-      // Create new layout ID
       const newLayoutId = generateUUID();
 
-      // Clone the layout with new name
       const newLayout: Layout = {
         ...sourceLayout,
         name: `${sourceLayout.name} (copy)`,
       };
 
-      // Save the new layout to IndexedDB + localStorage
       await saveLayoutByIdAsync(newLayoutId, newLayout);
 
-      // Create library entry
       duplicateEntry(sourceEntry, newLayoutId);
 
-      // Save library
       saveLibrary(useLibraryStore.getState().library);
 
-      // Track analytics
       trackLayoutAction('duplicated');
 
       addToast('Layout duplicated', 'success');
@@ -334,14 +312,12 @@ export function useLayoutSwitcher() {
   const renameLayout = useCallback((id: string, newName: string): void => {
     updateEntry(id, { name: newName });
 
-    // If renaming active layout, also update layout store
     if (id === activeLayoutId) {
       useLayoutStore.getState().setName(newName);
     }
 
     saveLibrary(useLibraryStore.getState().library);
 
-    // Track analytics
     trackLayoutAction('renamed');
   }, [activeLayoutId, updateEntry]);
 
@@ -355,10 +331,8 @@ export function useLayoutSwitcher() {
     try {
       const layoutId = generateUUID();
 
-      // Save the layout to IndexedDB + localStorage
       await saveLayoutByIdAsync(layoutId, importedLayout);
 
-      // Create library entry
       const preview: LayoutPreview = computeLayoutPreview(importedLayout);
       createEntry(
         importedLayout.name,
@@ -367,15 +341,12 @@ export function useLayoutSwitcher() {
         library.settings.authorName
       );
 
-      // Add forkedFrom if provided
       if (forkedFrom) {
         updateEntry(layoutId, { forkedFrom });
       }
 
-      // Save library
       saveLibrary(useLibraryStore.getState().library);
 
-      // Track analytics
       trackLayoutAction('imported', forkedFrom ? 'url' : 'json');
 
       addToast(`Imported "${importedLayout.name}"`, 'success');

--- a/src/store/library.ts
+++ b/src/store/library.ts
@@ -65,34 +65,25 @@ interface LibraryState {
   isLoaded: boolean;
   showLayoutManager: boolean;
 
-  // Initialize library
   initLibrary: (library: LayoutLibrary) => void;
-
-  // Replace library (for cross-tab sync)
   setLibrary: (library: LayoutLibrary) => void;
 
-  // Entry CRUD (pure library operations, no cross-store mutations)
   createEntry: (name: string, layoutId: string, preview: LayoutPreview, author?: string) => LayoutEntry;
   deleteEntry: (id: string) => OperationResult;
   updateEntry: (id: string, updates: Partial<Omit<LayoutEntry, 'id'>>) => void;
   duplicateEntry: (sourceEntry: LayoutEntry, newLayoutId: string) => LayoutEntry;
 
-  // Query
   getEntry: (id: string) => LayoutEntry | undefined;
   getRecentEntries: (count: number) => LayoutEntry[];
 
-  // Active layout (just updates the library index, not the actual layout)
   setActiveLayoutId: (id: string) => void;
 
-  // Settings
   setAuthorName: (name: string) => void;
   setLastShareExpiration: (days: ShareExpiration) => void;
 
-  // Cloud sharing
   setCloudShare: (layoutId: string, share: CloudShareInfo) => void;
   clearCloudShare: (layoutId: string) => void;
 
-  // UI state
   setShowLayoutManager: (show: boolean) => void;
 }
 

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -158,14 +158,11 @@ export function normalizeSortOrder(stored: BinListSortOrder | undefined): BinLis
     return [...DEFAULT_BIN_LIST_SORT_ORDER];
   }
 
-  // Get all fields from default
   const allFields = new Set(DEFAULT_BIN_LIST_SORT_ORDER.map(s => s.field));
   const storedFields = new Set(stored.map(s => s.field));
 
-  // Start with stored order
   const result: BinListSortOrder = stored.filter(s => allFields.has(s.field));
 
-  // Add any missing fields at the end (disabled)
   for (const defaultConfig of DEFAULT_BIN_LIST_SORT_ORDER) {
     if (!storedFields.has(defaultConfig.field)) {
       result.push({ field: defaultConfig.field, enabled: false });
@@ -212,13 +209,8 @@ function saveSettings(settings: UserSettings): void {
 interface SettingsState {
   settings: UserSettings;
 
-  // Update a single setting
   updateSetting: <K extends keyof UserSettings>(key: K, value: UserSettings[K]) => void;
-
-  // Update multiple settings at once
   updateSettings: (updates: Partial<UserSettings>) => void;
-
-  // Reset to defaults
   resetSettings: () => void;
 
   // Save current layout defaults from the current layout

--- a/src/store/toast.ts
+++ b/src/store/toast.ts
@@ -33,10 +33,8 @@ export const useToastStore = create<ToastState>((set) => ({
     };
 
     set((state) => {
-      // Add new toast
       let updated = [...state.toasts, newToast];
 
-      // If over limit, remove oldest (they'll animate out)
       if (updated.length > MAX_TOASTS) {
         updated = updated.slice(-MAX_TOASTS);
       }

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -109,11 +109,11 @@ interface UIState {
 
   // Actions
   setActiveLayer: (id: string) => void;
-  setSelectedBin: (id: string | null) => void; // Single select (clears others)
-  setSelectedBins: (ids: string[]) => void; // Set multiple
-  addToSelection: (id: string) => void; // Add to existing selection
-  removeFromSelection: (id: string) => void; // Remove from selection
-  toggleSelection: (id: string) => void; // Toggle single bin in selection
+  setSelectedBin: (id: string | null) => void;
+  setSelectedBins: (ids: string[]) => void;
+  addToSelection: (id: string) => void;
+  removeFromSelection: (id: string) => void;
+  toggleSelection: (id: string) => void;
   setActiveCategory: (id: string) => void;
   setZoom: (zoom: number) => void;
   zoomIn: () => void;
@@ -217,25 +217,20 @@ export const useUIStore = create<UIState>((set) => ({
     selectedBinIds: [] // Clear selection on layer change (PRD: selection is layer-scoped)
   }),
 
-  // Single select - clears other selections
   setSelectedBin: (id) => set({ selectedBinIds: id ? [id] : [] }),
 
-  // Set multiple bins as selected
   setSelectedBins: (ids) => set({ selectedBinIds: ids }),
 
-  // Add a bin to existing selection
   addToSelection: (id) => set(state => ({
     selectedBinIds: state.selectedBinIds.includes(id)
       ? state.selectedBinIds
       : [...state.selectedBinIds, id]
   })),
 
-  // Remove a bin from selection
   removeFromSelection: (id) => set(state => ({
     selectedBinIds: state.selectedBinIds.filter(binId => binId !== id)
   })),
 
-  // Toggle a bin in selection (for Ctrl/Cmd+click)
   toggleSelection: (id) => set(state => ({
     selectedBinIds: state.selectedBinIds.includes(id)
       ? state.selectedBinIds.filter(binId => binId !== id)
@@ -286,7 +281,6 @@ export const useUIStore = create<UIState>((set) => ({
       : size
   })),
 
-  // Mobile panel actions
   setActiveMobilePanel: (panel) => set({ activeMobilePanel: panel }),
 
   closeMobilePanel: () => set({ activeMobilePanel: null }),
@@ -310,7 +304,6 @@ export const useUIStore = create<UIState>((set) => ({
   },
   hideContextMenu: () => set({ contextMenu: null }),
 
-  // Isometric preview actions
   toggleIsometricPreview: () => set(state => ({
     showIsometricPreview: !state.showIsometricPreview
   })),
@@ -328,7 +321,6 @@ export const useUIStore = create<UIState>((set) => ({
   })),
   setPreviewExpanded: (expanded) => set({ isPreviewExpanded: expanded }),
 
-  // Keyboard navigation actions
   setFocusedBin: (binId) => set({ focusedBinId: binId }),
   setKeyboardDragMode: (enabled) => set({
     keyboardDragMode: enabled,
@@ -348,18 +340,14 @@ export const useUIStore = create<UIState>((set) => ({
     }, 1000);
   },
 
-  // Quick label actions
   showQuickLabel: (binId) => set({ quickLabelBinId: binId }),
   hideQuickLabel: () => set({ quickLabelBinId: null }),
 
-  // Category highlighting actions
   setHighlightedCategoryId: (categoryId) => set({ highlightedCategoryId: categoryId }),
 
-  // Row/column label highlighting actions
   setHighlightedRowLabel: (row) => set({ highlightedRowLabel: row }),
   setHighlightedColLabel: (col) => set({ highlightedColLabel: col }),
 
-  // Half-bin mode actions
   toggleHalfBinMode: () => {
     const state = useUIStore.getState();
     const targetState = !state.halfBinMode;
@@ -391,7 +379,6 @@ export const useUIStore = create<UIState>((set) => ({
     set({ halfBinMode: enabled });
   },
 
-  // Shared layout preview actions
   setSharedLayoutPreview: (layout, originalName, authorName) => set({
     sharedLayoutPreview: layout,
     sharedLayoutOriginalName: originalName ?? layout?.name ?? null,
@@ -403,6 +390,5 @@ export const useUIStore = create<UIState>((set) => ({
     sharedLayoutAuthorName: null,
   }),
 
-  // Print modal actions
   setPrintModalOpen: (open) => set({ printModalOpen: open }),
 }));

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -206,20 +206,3 @@ export async function getMigrationStatus(): Promise<MigrationStatus> {
 export function clearMigrationFlag(): void {
   localStorage.removeItem(MIGRATION_FLAG_KEY);
 }
-
-/**
- * Remove migrated layouts from localStorage (optional cleanup).
- * Only call this after confirming migration was successful.
- */
-export function cleanupLocalStorage(): number {
-  const ids = getLocalStorageLayoutIds();
-  let cleaned = 0;
-
-  for (const id of ids) {
-    const key = `${LAYOUT_KEY_PREFIX}${id}`;
-    localStorage.removeItem(key);
-    cleaned++;
-  }
-
-  return cleaned;
-}

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -25,20 +25,17 @@ export function findNearestBinInDirection(
   allBins: Bin[],
   activeLayerId: string
 ): Bin | null {
-  // Filter to bins on the active layer, excluding the current bin
   const candidates = allBins.filter(
     (bin) => bin.layerId === activeLayerId && bin.id !== currentBin.id
   );
 
   if (candidates.length === 0) return null;
 
-  // Get current bin's center position
   const currentCenter = {
     x: currentBin.x + currentBin.width / 2,
     y: currentBin.y + currentBin.depth / 2,
   };
 
-  // Filter candidates in the correct direction
   const validCandidates = candidates.filter((candidate) => {
     const candidateCenter = {
       x: candidate.x + candidate.width / 2,

--- a/src/utils/split.ts
+++ b/src/utils/split.ts
@@ -146,7 +146,6 @@ export function generatePrintList(
   maxPrintSize: number,
   heightUnitMm: number = DEFAULT_HEIGHT_UNIT_MM
 ): PrintRow[] {
-  // Filter out staging bins
   const placedBins = bins.filter(b => b.layerId !== STAGING_ID);
 
   // Group by size, height, category. Labeled bins and bins with custom properties get their own rows.

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -39,7 +39,6 @@ export function saveLayout(layout: Layout): void {
  * Adds default values for any missing fields.
  */
 function migrateLayout(data: Record<string, unknown>): Record<string, unknown> {
-  // Add gridUnitMm and heightUnitMm if missing (added in later version)
   if (data.gridUnitMm === undefined) {
     data.gridUnitMm = 42;
   }
@@ -698,7 +697,6 @@ export function initializeLayoutLibrary(): { library: LayoutLibrary; activeLayou
     });
   }
 
-  // Load the active layout
   let activeLayout = loadLayoutById(library.activeLayoutId);
 
   if (!activeLayout) {


### PR DESCRIPTION
## Summary
- Remove comments that simply restate what the next line of code does
- Remove dead `cleanupLocalStorage()` function that was exported but never used

## Changes
Cleaned up 19 files, removing 172 lines of redundant comments and dead code:
- Store files: ui.ts, settings.ts, library.ts, toast.ts
- Hook files: useAutoSave.ts, useCloudShare.ts, useGridNavigation.ts, useInteraction.ts, useKeyboard.ts, useKeyboardDrag.ts, useKeyboardResize.ts, useLayoutSwitcher.ts
- Component files: useBinInspector.ts, QuickLabelPopover.tsx, SortOrderConfig.tsx  
- Utility files: storage.ts, migration.ts, navigation.ts, split.ts

## Test plan
- [x] All 2833 tests pass
- [x] Build succeeds