### PR TITLE
feat: add Result<T, E> type system foundation

### DIFF
--- a/src/result/catalog.ts
+++ b/src/result/catalog.ts
@@ -1,0 +1,396 @@
+/**
+ * Centralized error catalog - single source of truth for error codes,
+ * messages, and recovery hints.
+ *
+ * This module provides:
+ * - ErrorCatalogEntry: Structure for each error definition
+ * - ERROR_CATALOG: Complete catalog of all error codes
+ * - Helper functions: getUserMessage(), getRecoveryHint(), formatErrorMessage()
+ *
+ * The catalog is designed to be i18n-ready. User messages can be replaced
+ * with translation keys in the future without changing error handling code.
+ */
+
+/**
+ * Entry in the error catalog.
+ */
+export interface ErrorCatalogEntry {
+  /** Unique error code */
+  code: string;
+  /** Default message for logging/debugging */
+  defaultMessage: string;
+  /** User-friendly message (if different from default) */
+  userMessage?: string;
+  /** Hint for how the user can recover from this error */
+  recoveryHint?: string;
+  /** Whether this operation can be retried */
+  retryable: boolean;
+  /** Severity level for UI display */
+  severity: 'error' | 'warning' | 'info';
+}
+
+/**
+ * Complete error catalog with all error codes and their metadata.
+ *
+ * Error codes follow the pattern: DOMAIN_ERROR_TYPE
+ * - STORAGE_*: Browser storage operations
+ * - VALIDATION_*: Data validation errors
+ * - LAYOUT_*: Layout operation errors
+ * - API_*: Cloud API errors
+ * - UNKNOWN_*: Fallback errors
+ */
+export const ERROR_CATALOG: Record<string, ErrorCatalogEntry> = {
+  // ===========================================================================
+  // Storage Errors
+  // ===========================================================================
+
+  STORAGE_QUOTA_EXCEEDED: {
+    code: 'STORAGE_QUOTA_EXCEEDED',
+    defaultMessage: 'Browser storage is full',
+    userMessage: 'Storage full. Export your layout to save it.',
+    recoveryHint: 'Export layouts or delete unused layouts to free up space',
+    retryable: false,
+    severity: 'error',
+  },
+
+  STORAGE_NOT_FOUND: {
+    code: 'STORAGE_NOT_FOUND',
+    defaultMessage: 'Layout not found in storage',
+    userMessage: 'Layout not found',
+    recoveryHint: 'The layout may have been deleted',
+    retryable: false,
+    severity: 'error',
+  },
+
+  STORAGE_CORRUPTED: {
+    code: 'STORAGE_CORRUPTED',
+    defaultMessage: 'Layout data is corrupted',
+    userMessage: 'Layout data is corrupted',
+    recoveryHint: 'Try importing from a JSON backup',
+    retryable: false,
+    severity: 'error',
+  },
+
+  STORAGE_UNAVAILABLE: {
+    code: 'STORAGE_UNAVAILABLE',
+    defaultMessage: 'Storage backend unavailable',
+    userMessage: 'Storage is unavailable',
+    recoveryHint: 'Check browser settings and ensure storage is enabled',
+    retryable: true,
+    severity: 'error',
+  },
+
+  STORAGE_NETWORK_ERROR: {
+    code: 'STORAGE_NETWORK_ERROR',
+    defaultMessage: 'Network error during storage operation',
+    userMessage: 'Network error',
+    recoveryHint: 'Check your internet connection and retry',
+    retryable: true,
+    severity: 'error',
+  },
+
+  // ===========================================================================
+  // Validation Errors
+  // ===========================================================================
+
+  VALIDATION_OUT_OF_BOUNDS: {
+    code: 'VALIDATION_OUT_OF_BOUNDS',
+    defaultMessage: 'Bin placement is out of bounds',
+    userMessage: 'Bin does not fit in the drawer',
+    recoveryHint: 'Resize the bin or expand the drawer',
+    retryable: false,
+    severity: 'warning',
+  },
+
+  VALIDATION_COLLISION: {
+    code: 'VALIDATION_COLLISION',
+    defaultMessage: 'Bin collides with existing bins',
+    userMessage: 'Bin overlaps with another bin',
+    recoveryHint: 'Move or resize the bin to avoid overlap',
+    retryable: false,
+    severity: 'warning',
+  },
+
+  VALIDATION_INVALID_LAYER: {
+    code: 'VALIDATION_INVALID_LAYER',
+    defaultMessage: 'Layer does not exist',
+    userMessage: 'Invalid layer',
+    recoveryHint: 'Select a different layer',
+    retryable: false,
+    severity: 'error',
+  },
+
+  VALIDATION_HEIGHT_EXCEEDED: {
+    code: 'VALIDATION_HEIGHT_EXCEEDED',
+    defaultMessage: 'Bin height exceeds drawer height',
+    userMessage: 'Bin is too tall',
+    recoveryHint: 'Reduce bin height or increase drawer height',
+    retryable: false,
+    severity: 'warning',
+  },
+
+  VALIDATION_BLOCKED_ZONE: {
+    code: 'VALIDATION_BLOCKED_ZONE',
+    defaultMessage: 'Bin placement blocked by clearance zone',
+    userMessage: 'Space blocked by tall bin above',
+    recoveryHint: 'Move bin or reduce clearance height of blocking bin',
+    retryable: false,
+    severity: 'warning',
+  },
+
+  VALIDATION_IMPORT_FAILED: {
+    code: 'VALIDATION_IMPORT_FAILED',
+    defaultMessage: 'Layout import validation failed',
+    userMessage: 'Invalid layout file',
+    recoveryHint: 'Check the JSON file format',
+    retryable: false,
+    severity: 'error',
+  },
+
+  // ===========================================================================
+  // Layout Errors
+  // ===========================================================================
+
+  LAYOUT_LAYER_LIMIT: {
+    code: 'LAYOUT_LAYER_LIMIT',
+    defaultMessage: 'Maximum layer count reached',
+    userMessage: 'Cannot add more layers (max 10)',
+    recoveryHint: 'Remove unused layers',
+    retryable: false,
+    severity: 'warning',
+  },
+
+  LAYOUT_CATEGORY_LIMIT: {
+    code: 'LAYOUT_CATEGORY_LIMIT',
+    defaultMessage: 'Maximum category count reached',
+    userMessage: 'Cannot add more categories (max 20)',
+    recoveryHint: 'Remove unused categories',
+    retryable: false,
+    severity: 'warning',
+  },
+
+  LAYOUT_LIBRARY_LIMIT: {
+    code: 'LAYOUT_LIBRARY_LIMIT',
+    defaultMessage: 'Maximum layout count reached',
+    userMessage: 'Cannot add more layouts (max 100)',
+    recoveryHint: 'Delete unused layouts',
+    retryable: false,
+    severity: 'warning',
+  },
+
+  LAYOUT_LAST_ENTITY: {
+    code: 'LAYOUT_LAST_ENTITY',
+    defaultMessage: 'Cannot delete last entity',
+    userMessage: 'Cannot delete the only {entityType}',
+    recoveryHint: 'Create a new {entityType} first',
+    retryable: false,
+    severity: 'warning',
+  },
+
+  LAYOUT_INVALID_OPERATION: {
+    code: 'LAYOUT_INVALID_OPERATION',
+    defaultMessage: 'Invalid layout operation',
+    userMessage: 'Operation not allowed',
+    recoveryHint: 'Check operation requirements',
+    retryable: false,
+    severity: 'error',
+  },
+
+  // ===========================================================================
+  // API Errors
+  // ===========================================================================
+
+  API_RATE_LIMITED: {
+    code: 'API_RATE_LIMITED',
+    defaultMessage: 'Rate limit exceeded',
+    userMessage: 'Too many requests. Try again later.',
+    recoveryHint: 'Wait {retryAfter} seconds before retrying',
+    retryable: true,
+    severity: 'warning',
+  },
+
+  API_UNAUTHORIZED: {
+    code: 'API_UNAUTHORIZED',
+    defaultMessage: 'Unauthorized',
+    userMessage: 'Invalid delete token',
+    recoveryHint: 'Verify you have permission to modify this share',
+    retryable: false,
+    severity: 'error',
+  },
+
+  API_NOT_FOUND: {
+    code: 'API_NOT_FOUND',
+    defaultMessage: 'Resource not found',
+    userMessage: 'Share not found or has expired',
+    recoveryHint: 'Check the share URL',
+    retryable: false,
+    severity: 'error',
+  },
+
+  API_SERVER_ERROR: {
+    code: 'API_SERVER_ERROR',
+    defaultMessage: 'Server error',
+    userMessage: 'Server error. Try again later.',
+    recoveryHint: 'Wait a moment and retry',
+    retryable: true,
+    severity: 'error',
+  },
+
+  API_NETWORK_ERROR: {
+    code: 'API_NETWORK_ERROR',
+    defaultMessage: 'Network error',
+    userMessage: 'Network error. Check your connection.',
+    recoveryHint: 'Verify internet connection',
+    retryable: true,
+    severity: 'error',
+  },
+
+  API_VALIDATION_ERROR: {
+    code: 'API_VALIDATION_ERROR',
+    defaultMessage: 'Validation error',
+    userMessage: 'Invalid data',
+    recoveryHint: 'Check input data',
+    retryable: false,
+    severity: 'error',
+  },
+
+  API_CONTENT_BLOCKED: {
+    code: 'API_CONTENT_BLOCKED',
+    defaultMessage: 'Content blocked',
+    userMessage: 'Content blocked. Check bin labels and notes.',
+    recoveryHint: 'Remove inappropriate content',
+    retryable: false,
+    severity: 'error',
+  },
+
+  // ===========================================================================
+  // Unknown/Generic Errors
+  // ===========================================================================
+
+  UNKNOWN_ERROR: {
+    code: 'UNKNOWN_ERROR',
+    defaultMessage: 'An unexpected error occurred',
+    userMessage: 'Something went wrong',
+    recoveryHint: 'Try again or refresh the page',
+    retryable: true,
+    severity: 'error',
+  },
+};
+
+/**
+ * Get error catalog entry by code.
+ * Returns UNKNOWN_ERROR entry if code is not found.
+ *
+ * @param code - The error code to look up
+ * @returns The catalog entry for this error
+ */
+export function getErrorInfo(code: string): ErrorCatalogEntry {
+  return ERROR_CATALOG[code] || ERROR_CATALOG.UNKNOWN_ERROR;
+}
+
+/**
+ * Format an error message template with variable interpolation.
+ *
+ * @param template - Message template with {variable} placeholders
+ * @param vars - Object with values to interpolate
+ * @returns Formatted message string
+ *
+ * @example
+ * ```ts
+ * formatErrorMessage('Cannot delete the only {entityType}', { entityType: 'layer' });
+ * // Returns: 'Cannot delete the only layer'
+ * ```
+ */
+export function formatErrorMessage(
+  template: string,
+  vars?: Record<string, string | number>
+): string {
+  if (!vars) return template;
+
+  return template.replace(/\{(\w+)\}/g, (_, key) => {
+    const value = vars[key];
+    return value !== undefined ? String(value) : `{${key}}`;
+  });
+}
+
+/**
+ * Get user-facing error message from an error object.
+ * Uses the error catalog to look up the user-friendly message
+ * and interpolates any metadata variables.
+ *
+ * @param error - Error object with code and optional metadata
+ * @returns User-friendly error message
+ *
+ * @example
+ * ```ts
+ * const error = layoutLastEntity('layer');
+ * getUserMessage(error); // 'Cannot delete the only layer'
+ * ```
+ */
+export function getUserMessage(error: {
+  code: string;
+  metadata?: Record<string, unknown>;
+}): string {
+  const info = getErrorInfo(error.code);
+  const message = info.userMessage || info.defaultMessage;
+
+  if (error.metadata) {
+    return formatErrorMessage(
+      message,
+      error.metadata as Record<string, string | number>
+    );
+  }
+
+  return message;
+}
+
+/**
+ * Get recovery hint from an error object.
+ * Recovery hints tell users how to fix the problem.
+ *
+ * @param error - Error object with code and optional metadata
+ * @returns Recovery hint string, or undefined if not available
+ *
+ * @example
+ * ```ts
+ * const error = apiRateLimited(60);
+ * getRecoveryHint(error); // 'Wait 60 seconds before retrying'
+ * ```
+ */
+export function getRecoveryHint(error: {
+  code: string;
+  metadata?: Record<string, unknown>;
+}): string | undefined {
+  const info = getErrorInfo(error.code);
+
+  if (!info.recoveryHint) return undefined;
+
+  if (error.metadata) {
+    return formatErrorMessage(
+      info.recoveryHint,
+      error.metadata as Record<string, string | number>
+    );
+  }
+
+  return info.recoveryHint;
+}
+
+/**
+ * Check if an error is retryable.
+ *
+ * @param code - The error code to check
+ * @returns Whether the operation can be retried
+ */
+export function isRetryable(code: string): boolean {
+  return getErrorInfo(code).retryable;
+}
+
+/**
+ * Get error severity for UI display.
+ *
+ * @param code - The error code to check
+ * @returns Severity level ('error', 'warning', or 'info')
+ */
+export function getSeverity(code: string): 'error' | 'warning' | 'info' {
+  return getErrorInfo(code).severity;
+}

--- a/src/result/constructors.ts
+++ b/src/result/constructors.ts
@@ -1,0 +1,530 @@
+/**
+ * Factory functions to construct domain errors.
+ *
+ * These functions ensure consistent error structure and automatically
+ * populate messages from the error catalog. Use these instead of
+ * manually creating error objects.
+ *
+ * @example
+ * ```ts
+ * import { storageNotFound, validationCollision, apiRateLimited } from './result';
+ *
+ * // Storage error
+ * const error1 = storageNotFound('gridfinity-layout-abc123');
+ *
+ * // Validation error with context
+ * const error2 = validationCollision(['bin-1', 'bin-2']);
+ *
+ * // API error with retry info
+ * const error3 = apiRateLimited(60);
+ * ```
+ */
+
+import type {
+  StorageQuotaExceededError,
+  StorageNotFoundError,
+  StorageCorruptedError,
+  StorageUnavailableError,
+  StorageNetworkError,
+  ValidationOutOfBoundsError,
+  ValidationCollisionError,
+  ValidationInvalidLayerError,
+  ValidationHeightExceededError,
+  ValidationBlockedZoneError,
+  ValidationImportError,
+  LayoutLayerLimitError,
+  LayoutCategoryLimitError,
+  LayoutLibraryLimitError,
+  LayoutLastEntityError,
+  LayoutInvalidOperationError,
+  ApiRateLimitedError,
+  ApiUnauthorizedError,
+  ApiNotFoundError,
+  ApiServerError,
+  ApiNetworkError,
+  ApiValidationError,
+  ApiContentBlockedError,
+  UnknownError,
+  ValidationFailureReason,
+} from './errors';
+import { getErrorInfo } from './catalog';
+
+// =============================================================================
+// Storage Error Constructors
+// =============================================================================
+
+/**
+ * Create a storage quota exceeded error.
+ *
+ * @param usageBytes - Current storage usage in bytes
+ * @param limitBytes - Storage limit in bytes
+ * @param cause - Original error that caused this
+ */
+export function storageQuotaExceeded(
+  usageBytes?: number,
+  limitBytes?: number,
+  cause?: unknown
+): StorageQuotaExceededError {
+  return {
+    kind: 'StorageError',
+    code: 'STORAGE_QUOTA_EXCEEDED',
+    message: getErrorInfo('STORAGE_QUOTA_EXCEEDED').defaultMessage,
+    timestamp: Date.now(),
+    usageBytes,
+    limitBytes,
+    cause,
+  };
+}
+
+/**
+ * Create a storage not found error.
+ *
+ * @param key - The storage key that was not found
+ * @param cause - Original error that caused this
+ */
+export function storageNotFound(
+  key: string,
+  cause?: unknown
+): StorageNotFoundError {
+  return {
+    kind: 'StorageError',
+    code: 'STORAGE_NOT_FOUND',
+    message: getErrorInfo('STORAGE_NOT_FOUND').defaultMessage,
+    timestamp: Date.now(),
+    key,
+    cause,
+  };
+}
+
+/**
+ * Create a storage corrupted error.
+ *
+ * @param key - The storage key with corrupted data
+ * @param validationErrors - List of validation errors
+ * @param cause - Original error that caused this
+ */
+export function storageCorrupted(
+  key: string,
+  validationErrors?: string[],
+  cause?: unknown
+): StorageCorruptedError {
+  return {
+    kind: 'StorageError',
+    code: 'STORAGE_CORRUPTED',
+    message: getErrorInfo('STORAGE_CORRUPTED').defaultMessage,
+    timestamp: Date.now(),
+    key,
+    validationErrors,
+    cause,
+  };
+}
+
+/**
+ * Create a storage unavailable error.
+ *
+ * @param backend - Which storage backend is unavailable
+ * @param cause - Original error that caused this
+ */
+export function storageUnavailable(
+  backend: 'localStorage' | 'indexedDB',
+  cause?: unknown
+): StorageUnavailableError {
+  return {
+    kind: 'StorageError',
+    code: 'STORAGE_UNAVAILABLE',
+    message: getErrorInfo('STORAGE_UNAVAILABLE').defaultMessage,
+    timestamp: Date.now(),
+    backend,
+    cause,
+  };
+}
+
+/**
+ * Create a storage network error.
+ *
+ * @param cause - Original error that caused this
+ */
+export function storageNetworkError(cause?: unknown): StorageNetworkError {
+  return {
+    kind: 'StorageError',
+    code: 'STORAGE_NETWORK_ERROR',
+    message: getErrorInfo('STORAGE_NETWORK_ERROR').defaultMessage,
+    timestamp: Date.now(),
+    cause,
+  };
+}
+
+// =============================================================================
+// Validation Error Constructors
+// =============================================================================
+
+/**
+ * Create a validation out of bounds error.
+ *
+ * @param reason - Specific reason for the bounds violation
+ * @param binData - The bin data that failed validation
+ */
+export function validationOutOfBounds(
+  reason: ValidationFailureReason,
+  binData?: { x: number; y: number; width: number; depth: number }
+): ValidationOutOfBoundsError {
+  return {
+    kind: 'ValidationError',
+    code: 'VALIDATION_OUT_OF_BOUNDS',
+    message: getErrorInfo('VALIDATION_OUT_OF_BOUNDS').defaultMessage,
+    timestamp: Date.now(),
+    reason,
+    binData,
+  };
+}
+
+/**
+ * Create a validation collision error.
+ *
+ * @param collidingBinIds - IDs of bins that would collide
+ */
+export function validationCollision(
+  collidingBinIds?: string[]
+): ValidationCollisionError {
+  return {
+    kind: 'ValidationError',
+    code: 'VALIDATION_COLLISION',
+    message: getErrorInfo('VALIDATION_COLLISION').defaultMessage,
+    timestamp: Date.now(),
+    collidingBinIds,
+  };
+}
+
+/**
+ * Create a validation invalid layer error.
+ *
+ * @param layerId - The invalid layer ID
+ */
+export function validationInvalidLayer(
+  layerId: string
+): ValidationInvalidLayerError {
+  return {
+    kind: 'ValidationError',
+    code: 'VALIDATION_INVALID_LAYER',
+    message: getErrorInfo('VALIDATION_INVALID_LAYER').defaultMessage,
+    timestamp: Date.now(),
+    layerId,
+  };
+}
+
+/**
+ * Create a validation height exceeded error.
+ *
+ * @param requested - Requested height
+ * @param max - Maximum allowed height
+ */
+export function validationHeightExceeded(
+  requested: number,
+  max: number
+): ValidationHeightExceededError {
+  return {
+    kind: 'ValidationError',
+    code: 'VALIDATION_HEIGHT_EXCEEDED',
+    message: getErrorInfo('VALIDATION_HEIGHT_EXCEEDED').defaultMessage,
+    timestamp: Date.now(),
+    requested,
+    max,
+  };
+}
+
+/**
+ * Create a validation blocked zone error.
+ *
+ * @param blockingBinIds - IDs of bins creating the blocked zone
+ */
+export function validationBlockedZone(
+  blockingBinIds?: string[]
+): ValidationBlockedZoneError {
+  return {
+    kind: 'ValidationError',
+    code: 'VALIDATION_BLOCKED_ZONE',
+    message: getErrorInfo('VALIDATION_BLOCKED_ZONE').defaultMessage,
+    timestamp: Date.now(),
+    blockingBinIds,
+  };
+}
+
+/**
+ * Create a validation import failed error.
+ *
+ * @param errors - List of validation errors
+ */
+export function validationImportFailed(errors: string[]): ValidationImportError {
+  return {
+    kind: 'ValidationError',
+    code: 'VALIDATION_IMPORT_FAILED',
+    message: getErrorInfo('VALIDATION_IMPORT_FAILED').defaultMessage,
+    timestamp: Date.now(),
+    errors,
+  };
+}
+
+// =============================================================================
+// Layout Error Constructors
+// =============================================================================
+
+/**
+ * Create a layout layer limit error.
+ *
+ * @param currentCount - Current number of layers
+ * @param maxCount - Maximum allowed layers
+ */
+export function layoutLayerLimit(
+  currentCount: number,
+  maxCount: number
+): LayoutLayerLimitError {
+  return {
+    kind: 'LayoutError',
+    code: 'LAYOUT_LAYER_LIMIT',
+    message: getErrorInfo('LAYOUT_LAYER_LIMIT').defaultMessage,
+    timestamp: Date.now(),
+    currentCount,
+    maxCount,
+  };
+}
+
+/**
+ * Create a layout category limit error.
+ *
+ * @param currentCount - Current number of categories
+ * @param maxCount - Maximum allowed categories
+ */
+export function layoutCategoryLimit(
+  currentCount: number,
+  maxCount: number
+): LayoutCategoryLimitError {
+  return {
+    kind: 'LayoutError',
+    code: 'LAYOUT_CATEGORY_LIMIT',
+    message: getErrorInfo('LAYOUT_CATEGORY_LIMIT').defaultMessage,
+    timestamp: Date.now(),
+    currentCount,
+    maxCount,
+  };
+}
+
+/**
+ * Create a layout library limit error.
+ *
+ * @param currentCount - Current number of layouts
+ * @param maxCount - Maximum allowed layouts
+ */
+export function layoutLibraryLimit(
+  currentCount: number,
+  maxCount: number
+): LayoutLibraryLimitError {
+  return {
+    kind: 'LayoutError',
+    code: 'LAYOUT_LIBRARY_LIMIT',
+    message: getErrorInfo('LAYOUT_LIBRARY_LIMIT').defaultMessage,
+    timestamp: Date.now(),
+    currentCount,
+    maxCount,
+  };
+}
+
+/**
+ * Create a layout last entity error.
+ *
+ * @param entityType - Type of entity that cannot be deleted
+ */
+export function layoutLastEntity(
+  entityType: 'layer' | 'category' | 'layout'
+): LayoutLastEntityError {
+  return {
+    kind: 'LayoutError',
+    code: 'LAYOUT_LAST_ENTITY',
+    message: getErrorInfo('LAYOUT_LAST_ENTITY').defaultMessage,
+    timestamp: Date.now(),
+    entityType,
+    metadata: { entityType },
+  };
+}
+
+/**
+ * Create a layout invalid operation error.
+ *
+ * @param operation - Name of the operation that failed
+ * @param reason - Additional reason for failure
+ */
+export function layoutInvalidOperation(
+  operation: string,
+  reason?: string
+): LayoutInvalidOperationError {
+  return {
+    kind: 'LayoutError',
+    code: 'LAYOUT_INVALID_OPERATION',
+    message: getErrorInfo('LAYOUT_INVALID_OPERATION').defaultMessage,
+    timestamp: Date.now(),
+    operation,
+    reason,
+  };
+}
+
+// =============================================================================
+// API Error Constructors
+// =============================================================================
+
+/**
+ * Create an API rate limited error.
+ *
+ * @param retryAfter - Seconds until rate limit resets
+ */
+export function apiRateLimited(retryAfter?: number): ApiRateLimitedError {
+  return {
+    kind: 'ApiError',
+    code: 'API_RATE_LIMITED',
+    message: getErrorInfo('API_RATE_LIMITED').defaultMessage,
+    timestamp: Date.now(),
+    retryAfter,
+    metadata: retryAfter !== undefined ? { retryAfter } : undefined,
+  };
+}
+
+/**
+ * Create an API unauthorized error.
+ *
+ * @param cause - Original error that caused this
+ */
+export function apiUnauthorized(cause?: unknown): ApiUnauthorizedError {
+  return {
+    kind: 'ApiError',
+    code: 'API_UNAUTHORIZED',
+    message: getErrorInfo('API_UNAUTHORIZED').defaultMessage,
+    timestamp: Date.now(),
+    cause,
+  };
+}
+
+/**
+ * Create an API not found error.
+ *
+ * @param resourceId - ID of the resource that was not found
+ */
+export function apiNotFound(resourceId?: string): ApiNotFoundError {
+  return {
+    kind: 'ApiError',
+    code: 'API_NOT_FOUND',
+    message: getErrorInfo('API_NOT_FOUND').defaultMessage,
+    timestamp: Date.now(),
+    resourceId,
+  };
+}
+
+/**
+ * Create an API server error.
+ *
+ * @param status - HTTP status code
+ * @param cause - Original error that caused this
+ */
+export function apiServerError(
+  status?: number,
+  cause?: unknown
+): ApiServerError {
+  return {
+    kind: 'ApiError',
+    code: 'API_SERVER_ERROR',
+    message: getErrorInfo('API_SERVER_ERROR').defaultMessage,
+    timestamp: Date.now(),
+    status,
+    cause,
+  };
+}
+
+/**
+ * Create an API network error.
+ *
+ * @param cause - Original error that caused this
+ */
+export function apiNetworkError(cause?: unknown): ApiNetworkError {
+  return {
+    kind: 'ApiError',
+    code: 'API_NETWORK_ERROR',
+    message: getErrorInfo('API_NETWORK_ERROR').defaultMessage,
+    timestamp: Date.now(),
+    cause,
+  };
+}
+
+/**
+ * Create an API validation error.
+ *
+ * @param fields - Fields that failed validation
+ * @param cause - Original error that caused this
+ */
+export function apiValidationError(
+  fields?: string[],
+  cause?: unknown
+): ApiValidationError {
+  return {
+    kind: 'ApiError',
+    code: 'API_VALIDATION_ERROR',
+    message: getErrorInfo('API_VALIDATION_ERROR').defaultMessage,
+    timestamp: Date.now(),
+    fields,
+    cause,
+  };
+}
+
+/**
+ * Create an API content blocked error.
+ *
+ * @param blockedFields - Fields that were blocked
+ */
+export function apiContentBlocked(
+  blockedFields?: string[]
+): ApiContentBlockedError {
+  return {
+    kind: 'ApiError',
+    code: 'API_CONTENT_BLOCKED',
+    message: getErrorInfo('API_CONTENT_BLOCKED').defaultMessage,
+    timestamp: Date.now(),
+    blockedFields,
+  };
+}
+
+// =============================================================================
+// Unknown Error Constructor
+// =============================================================================
+
+/**
+ * Create an unknown error.
+ * Use this as a fallback when wrapping unknown exceptions.
+ *
+ * @param cause - Original error that caused this
+ */
+export function unknownError(cause?: unknown): UnknownError {
+  return {
+    kind: 'UnknownError',
+    code: 'UNKNOWN_ERROR',
+    message: getErrorInfo('UNKNOWN_ERROR').defaultMessage,
+    timestamp: Date.now(),
+    cause,
+  };
+}
+
+/**
+ * Wrap any unknown error into a domain error.
+ * Useful in try-catch blocks where the error type is unknown.
+ *
+ * @param error - The unknown error to wrap
+ * @returns An UnknownError with the original error as cause
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await riskyOperation();
+ *   return ok(result);
+ * } catch (error) {
+ *   return err(fromUnknown(error));
+ * }
+ * ```
+ */
+export function fromUnknown(error: unknown): UnknownError {
+  return unknownError(error);
+}

--- a/src/result/errors.ts
+++ b/src/result/errors.ts
@@ -1,0 +1,379 @@
+/**
+ * Domain-specific error types with rich metadata.
+ *
+ * This module defines structured error types for each domain in the application:
+ * - StorageError: Browser storage operations (localStorage, IndexedDB)
+ * - ValidationError: Bin placement and layout validation
+ * - LayoutError: Layout, layer, and category operations
+ * - ApiError: Cloud sharing API operations
+ *
+ * All errors extend the base AppError interface which includes:
+ * - kind: Discriminant for the error domain
+ * - code: Unique error code from the catalog
+ * - message: Default message for logging
+ * - timestamp: When the error occurred
+ * - metadata: Optional additional context
+ * - cause: Optional original error for debugging
+ */
+
+/**
+ * Reason codes for validation failures.
+ * Matches the existing ValidationResult.reason type.
+ */
+export type ValidationFailureReason =
+  | 'out_of_bounds'
+  | 'exceeds_width'
+  | 'exceeds_depth'
+  | 'exceeds_height'
+  | 'invalid_layer'
+  | 'collision'
+  | 'blocked_zone';
+
+/**
+ * Base interface for all application errors.
+ * Provides a consistent structure for error handling and logging.
+ */
+export interface AppError {
+  /** Discriminant for the error domain (StorageError, ValidationError, etc.) */
+  readonly kind: string;
+  /** Unique error code from the error catalog */
+  readonly code: string;
+  /** Default message for logging/debugging */
+  readonly message: string;
+  /** Unix timestamp when the error occurred */
+  readonly timestamp: number;
+  /** Optional additional context for the error */
+  readonly metadata?: Record<string, unknown>;
+  /** Optional original error for debugging */
+  readonly cause?: unknown;
+}
+
+// =============================================================================
+// Storage Errors
+// =============================================================================
+
+/**
+ * Error when browser storage quota is exceeded.
+ * Common with large layouts in localStorage (5MB limit).
+ */
+export interface StorageQuotaExceededError extends AppError {
+  readonly kind: 'StorageError';
+  readonly code: 'STORAGE_QUOTA_EXCEEDED';
+  /** Current storage usage in bytes, if known */
+  readonly usageBytes?: number;
+  /** Storage limit in bytes, if known */
+  readonly limitBytes?: number;
+}
+
+/**
+ * Error when requested data is not found in storage.
+ */
+export interface StorageNotFoundError extends AppError {
+  readonly kind: 'StorageError';
+  readonly code: 'STORAGE_NOT_FOUND';
+  /** The storage key that was not found */
+  readonly key: string;
+}
+
+/**
+ * Error when stored data fails validation or parsing.
+ */
+export interface StorageCorruptedError extends AppError {
+  readonly kind: 'StorageError';
+  readonly code: 'STORAGE_CORRUPTED';
+  /** The storage key with corrupted data */
+  readonly key: string;
+  /** Validation errors that caused the corruption detection */
+  readonly validationErrors?: string[];
+}
+
+/**
+ * Error when a storage backend is unavailable.
+ * Can occur in private browsing or with disabled storage.
+ */
+export interface StorageUnavailableError extends AppError {
+  readonly kind: 'StorageError';
+  readonly code: 'STORAGE_UNAVAILABLE';
+  /** Which backend is unavailable */
+  readonly backend: 'localStorage' | 'indexedDB';
+}
+
+/**
+ * Error during network-related storage operations.
+ * Primarily for IndexedDB which can have async issues.
+ */
+export interface StorageNetworkError extends AppError {
+  readonly kind: 'StorageError';
+  readonly code: 'STORAGE_NETWORK_ERROR';
+}
+
+/**
+ * Union of all storage-related errors.
+ */
+export type StorageError =
+  | StorageQuotaExceededError
+  | StorageNotFoundError
+  | StorageCorruptedError
+  | StorageUnavailableError
+  | StorageNetworkError;
+
+// =============================================================================
+// Validation Errors
+// =============================================================================
+
+/**
+ * Error when bin placement is outside drawer bounds.
+ */
+export interface ValidationOutOfBoundsError extends AppError {
+  readonly kind: 'ValidationError';
+  readonly code: 'VALIDATION_OUT_OF_BOUNDS';
+  /** Specific reason for the bounds violation */
+  readonly reason: ValidationFailureReason;
+  /** The bin data that failed validation */
+  readonly binData?: {
+    x: number;
+    y: number;
+    width: number;
+    depth: number;
+  };
+}
+
+/**
+ * Error when bin placement would collide with existing bins.
+ */
+export interface ValidationCollisionError extends AppError {
+  readonly kind: 'ValidationError';
+  readonly code: 'VALIDATION_COLLISION';
+  /** IDs of bins that would collide */
+  readonly collidingBinIds?: string[];
+}
+
+/**
+ * Error when referencing a layer that doesn't exist.
+ */
+export interface ValidationInvalidLayerError extends AppError {
+  readonly kind: 'ValidationError';
+  readonly code: 'VALIDATION_INVALID_LAYER';
+  /** The invalid layer ID */
+  readonly layerId: string;
+}
+
+/**
+ * Error when bin height exceeds available space.
+ */
+export interface ValidationHeightExceededError extends AppError {
+  readonly kind: 'ValidationError';
+  readonly code: 'VALIDATION_HEIGHT_EXCEEDED';
+  /** Requested height */
+  readonly requested: number;
+  /** Maximum allowed height */
+  readonly max: number;
+}
+
+/**
+ * Error when placement is blocked by clearance zone from tall bins.
+ */
+export interface ValidationBlockedZoneError extends AppError {
+  readonly kind: 'ValidationError';
+  readonly code: 'VALIDATION_BLOCKED_ZONE';
+  /** IDs of bins creating the blocked zone */
+  readonly blockingBinIds?: string[];
+}
+
+/**
+ * Error when imported layout fails validation.
+ */
+export interface ValidationImportError extends AppError {
+  readonly kind: 'ValidationError';
+  readonly code: 'VALIDATION_IMPORT_FAILED';
+  /** List of validation errors */
+  readonly errors: string[];
+}
+
+/**
+ * Union of all validation-related errors.
+ */
+export type ValidationError =
+  | ValidationOutOfBoundsError
+  | ValidationCollisionError
+  | ValidationInvalidLayerError
+  | ValidationHeightExceededError
+  | ValidationBlockedZoneError
+  | ValidationImportError;
+
+// =============================================================================
+// Layout Operation Errors
+// =============================================================================
+
+/**
+ * Error when maximum layer count is reached.
+ */
+export interface LayoutLayerLimitError extends AppError {
+  readonly kind: 'LayoutError';
+  readonly code: 'LAYOUT_LAYER_LIMIT';
+  /** Current number of layers */
+  readonly currentCount: number;
+  /** Maximum allowed layers */
+  readonly maxCount: number;
+}
+
+/**
+ * Error when maximum category count is reached.
+ */
+export interface LayoutCategoryLimitError extends AppError {
+  readonly kind: 'LayoutError';
+  readonly code: 'LAYOUT_CATEGORY_LIMIT';
+  /** Current number of categories */
+  readonly currentCount: number;
+  /** Maximum allowed categories */
+  readonly maxCount: number;
+}
+
+/**
+ * Error when maximum layout count in library is reached.
+ */
+export interface LayoutLibraryLimitError extends AppError {
+  readonly kind: 'LayoutError';
+  readonly code: 'LAYOUT_LIBRARY_LIMIT';
+  /** Current number of layouts */
+  readonly currentCount: number;
+  /** Maximum allowed layouts */
+  readonly maxCount: number;
+}
+
+/**
+ * Error when trying to delete the last entity of a type.
+ */
+export interface LayoutLastEntityError extends AppError {
+  readonly kind: 'LayoutError';
+  readonly code: 'LAYOUT_LAST_ENTITY';
+  /** Type of entity that cannot be deleted */
+  readonly entityType: 'layer' | 'category' | 'layout';
+}
+
+/**
+ * Error for invalid layout operations.
+ */
+export interface LayoutInvalidOperationError extends AppError {
+  readonly kind: 'LayoutError';
+  readonly code: 'LAYOUT_INVALID_OPERATION';
+  /** Name of the operation that failed */
+  readonly operation: string;
+  /** Additional reason for failure */
+  readonly reason?: string;
+}
+
+/**
+ * Union of all layout operation errors.
+ */
+export type LayoutError =
+  | LayoutLayerLimitError
+  | LayoutCategoryLimitError
+  | LayoutLibraryLimitError
+  | LayoutLastEntityError
+  | LayoutInvalidOperationError;
+
+// =============================================================================
+// API Errors (Cloud Sharing)
+// =============================================================================
+
+/**
+ * Error when API rate limit is exceeded.
+ */
+export interface ApiRateLimitedError extends AppError {
+  readonly kind: 'ApiError';
+  readonly code: 'API_RATE_LIMITED';
+  /** Seconds until rate limit resets */
+  readonly retryAfter?: number;
+}
+
+/**
+ * Error when API request is unauthorized.
+ */
+export interface ApiUnauthorizedError extends AppError {
+  readonly kind: 'ApiError';
+  readonly code: 'API_UNAUTHORIZED';
+}
+
+/**
+ * Error when API resource is not found.
+ */
+export interface ApiNotFoundError extends AppError {
+  readonly kind: 'ApiError';
+  readonly code: 'API_NOT_FOUND';
+  /** ID of the resource that was not found */
+  readonly resourceId?: string;
+}
+
+/**
+ * Error when API server returns an error.
+ */
+export interface ApiServerError extends AppError {
+  readonly kind: 'ApiError';
+  readonly code: 'API_SERVER_ERROR';
+  /** HTTP status code */
+  readonly status?: number;
+}
+
+/**
+ * Error when network request fails.
+ */
+export interface ApiNetworkError extends AppError {
+  readonly kind: 'ApiError';
+  readonly code: 'API_NETWORK_ERROR';
+}
+
+/**
+ * Error when API validation fails.
+ */
+export interface ApiValidationError extends AppError {
+  readonly kind: 'ApiError';
+  readonly code: 'API_VALIDATION_ERROR';
+  /** Fields that failed validation */
+  readonly fields?: string[];
+}
+
+/**
+ * Error when content is blocked by content filter.
+ */
+export interface ApiContentBlockedError extends AppError {
+  readonly kind: 'ApiError';
+  readonly code: 'API_CONTENT_BLOCKED';
+  /** Fields that were blocked */
+  readonly blockedFields?: string[];
+}
+
+/**
+ * Union of all API-related errors.
+ */
+export type ApiError =
+  | ApiRateLimitedError
+  | ApiUnauthorizedError
+  | ApiNotFoundError
+  | ApiServerError
+  | ApiNetworkError
+  | ApiValidationError
+  | ApiContentBlockedError;
+
+// =============================================================================
+// Generic Errors
+// =============================================================================
+
+/**
+ * Error for unexpected/unknown errors.
+ * Used as a fallback when wrapping unknown exceptions.
+ */
+export interface UnknownError extends AppError {
+  readonly kind: 'UnknownError';
+  readonly code: 'UNKNOWN_ERROR';
+}
+
+/**
+ * Union of all domain errors in the application.
+ */
+export type DomainError =
+  | StorageError
+  | ValidationError
+  | LayoutError
+  | ApiError
+  | UnknownError;

--- a/src/result/index.ts
+++ b/src/result/index.ts
@@ -1,0 +1,220 @@
+/**
+ * Result<T, E> Type System
+ *
+ * A comprehensive error handling system for type-safe operations.
+ *
+ * @example Basic usage:
+ * ```ts
+ * import { Result, ok, err, isOk, match } from './result';
+ *
+ * function divide(a: number, b: number): Result<number, string> {
+ *   if (b === 0) return err('Division by zero');
+ *   return ok(a / b);
+ * }
+ *
+ * const result = divide(10, 2);
+ *
+ * // Pattern matching
+ * const message = match(result, {
+ *   ok: (value) => `Result: ${value}`,
+ *   err: (error) => `Error: ${error}`,
+ * });
+ *
+ * // Type guards
+ * if (isOk(result)) {
+ *   console.log(result.value);
+ * }
+ * ```
+ *
+ * @example With domain errors:
+ * ```ts
+ * import { Result, err, storageNotFound, getUserMessage } from './result';
+ * import type { StorageError } from './result';
+ *
+ * async function loadLayout(id: string): Promise<Result<Layout, StorageError>> {
+ *   const data = await storage.load(id);
+ *   if (!data) return err(storageNotFound(`gridfinity-layout-${id}`));
+ *   return ok(data);
+ * }
+ *
+ * // Handle the result
+ * const result = await loadLayout('abc123');
+ * if (isErr(result)) {
+ *   addToast(getUserMessage(result.error), 'error');
+ * }
+ * ```
+ *
+ * @example Chaining operations:
+ * ```ts
+ * import { flatMap, map, tryCatchAsync } from './result';
+ *
+ * const result = await tryCatchAsync(
+ *   () => fetchData(url),
+ *   (e) => apiNetworkError(e)
+ * );
+ *
+ * const transformed = flatMap(result, (data) =>
+ *   map(validateData(data), (valid) => processData(valid))
+ * );
+ * ```
+ *
+ * @module result
+ */
+
+// =============================================================================
+// Core Types
+// =============================================================================
+
+export type { Result, Ok, Err, Unit } from './types';
+export { ok, err, isOk, isErr, OK } from './types';
+
+// =============================================================================
+// Domain Error Types
+// =============================================================================
+
+export type {
+  // Base type
+  AppError,
+  ValidationFailureReason,
+
+  // Storage errors
+  StorageError,
+  StorageQuotaExceededError,
+  StorageNotFoundError,
+  StorageCorruptedError,
+  StorageUnavailableError,
+  StorageNetworkError,
+
+  // Validation errors
+  ValidationError,
+  ValidationOutOfBoundsError,
+  ValidationCollisionError,
+  ValidationInvalidLayerError,
+  ValidationHeightExceededError,
+  ValidationBlockedZoneError,
+  ValidationImportError,
+
+  // Layout errors
+  LayoutError,
+  LayoutLayerLimitError,
+  LayoutCategoryLimitError,
+  LayoutLibraryLimitError,
+  LayoutLastEntityError,
+  LayoutInvalidOperationError,
+
+  // API errors
+  ApiError,
+  ApiRateLimitedError,
+  ApiUnauthorizedError,
+  ApiNotFoundError,
+  ApiServerError,
+  ApiNetworkError,
+  ApiValidationError,
+  ApiContentBlockedError,
+
+  // Generic
+  UnknownError,
+  DomainError,
+} from './errors';
+
+// =============================================================================
+// Error Constructors
+// =============================================================================
+
+export {
+  // Storage errors
+  storageQuotaExceeded,
+  storageNotFound,
+  storageCorrupted,
+  storageUnavailable,
+  storageNetworkError,
+
+  // Validation errors
+  validationOutOfBounds,
+  validationCollision,
+  validationInvalidLayer,
+  validationHeightExceeded,
+  validationBlockedZone,
+  validationImportFailed,
+
+  // Layout errors
+  layoutLayerLimit,
+  layoutCategoryLimit,
+  layoutLibraryLimit,
+  layoutLastEntity,
+  layoutInvalidOperation,
+
+  // API errors
+  apiRateLimited,
+  apiUnauthorized,
+  apiNotFound,
+  apiServerError,
+  apiNetworkError,
+  apiValidationError,
+  apiContentBlocked,
+
+  // Generic
+  unknownError,
+  fromUnknown,
+} from './constructors';
+
+// =============================================================================
+// Error Catalog
+// =============================================================================
+
+export type { ErrorCatalogEntry } from './catalog';
+export {
+  ERROR_CATALOG,
+  getErrorInfo,
+  formatErrorMessage,
+  getUserMessage,
+  getRecoveryHint,
+  isRetryable,
+  getSeverity,
+} from './catalog';
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+export {
+  // Transformations
+  map,
+  mapErr,
+  flatMap,
+  andThen,
+
+  // Extraction
+  unwrap,
+  unwrapOr,
+  unwrapOrElse,
+  unwrapErr,
+
+  // Pattern matching
+  match,
+
+  // Combining
+  combine,
+  combine3,
+  collect,
+  collectAll,
+
+  // Boolean operations
+  or,
+  and,
+
+  // Try-catch wrappers
+  tryCatch,
+  tryCatchAsync,
+
+  // Unit helpers
+  toUnit,
+  tap,
+  tapErr,
+
+  // Array utilities
+  allOk,
+  anyErr,
+  filterOk,
+  filterErr,
+} from './utils';

--- a/src/result/types.ts
+++ b/src/result/types.ts
@@ -1,0 +1,134 @@
+/**
+ * Result<T, E> - Discriminated union for operations that can fail.
+ *
+ * This module provides a type-safe way to handle operations that can either
+ * succeed with a value or fail with an error. Inspired by Rust's Result type
+ * with TypeScript ergonomics.
+ *
+ * @example
+ * ```ts
+ * import { Result, ok, err, isOk } from './result';
+ *
+ * function divide(a: number, b: number): Result<number, string> {
+ *   if (b === 0) return err('Division by zero');
+ *   return ok(a / b);
+ * }
+ *
+ * const result = divide(10, 2);
+ * if (isOk(result)) {
+ *   console.log('Result:', result.value); // 5
+ * }
+ * ```
+ */
+
+/**
+ * Success variant of Result.
+ * Contains the successful value of type T.
+ */
+export interface Ok<T> {
+  readonly ok: true;
+  readonly value: T;
+}
+
+/**
+ * Failure variant of Result.
+ * Contains the error of type E.
+ */
+export interface Err<E> {
+  readonly ok: false;
+  readonly error: E;
+}
+
+/**
+ * Result type - either Ok with a value or Err with an error.
+ *
+ * @template T - The type of the success value
+ * @template E - The type of the error (defaults to Error)
+ */
+export type Result<T, E = Error> = Ok<T> | Err<E>;
+
+/**
+ * Type guard to check if a Result is Ok.
+ * Narrows the type to Ok<T>.
+ *
+ * @example
+ * ```ts
+ * const result = loadUser(id);
+ * if (isOk(result)) {
+ *   // TypeScript knows result.value is available here
+ *   console.log(result.value.name);
+ * }
+ * ```
+ */
+export function isOk<T, E>(result: Result<T, E>): result is Ok<T> {
+  return result.ok === true;
+}
+
+/**
+ * Type guard to check if a Result is Err.
+ * Narrows the type to Err<E>.
+ *
+ * @example
+ * ```ts
+ * const result = loadUser(id);
+ * if (isErr(result)) {
+ *   // TypeScript knows result.error is available here
+ *   console.error(result.error.message);
+ * }
+ * ```
+ */
+export function isErr<T, E>(result: Result<T, E>): result is Err<E> {
+  return result.ok === false;
+}
+
+/**
+ * Create a successful Result with a value.
+ *
+ * @example
+ * ```ts
+ * function findUser(id: string): Result<User, NotFoundError> {
+ *   const user = users.get(id);
+ *   if (user) return ok(user);
+ *   return err(notFoundError(id));
+ * }
+ * ```
+ */
+export function ok<T>(value: T): Ok<T> {
+  return { ok: true, value };
+}
+
+/**
+ * Create a failed Result with an error.
+ *
+ * @example
+ * ```ts
+ * function validateAge(age: number): Result<number, ValidationError> {
+ *   if (age < 0) return err(validationError('Age cannot be negative'));
+ *   return ok(age);
+ * }
+ * ```
+ */
+export function err<E>(error: E): Err<E> {
+  return { ok: false, error };
+}
+
+/**
+ * Unit type for operations that succeed without returning a value.
+ * Use undefined to represent "no value" in Result context.
+ */
+export type Unit = undefined;
+
+/**
+ * Pre-constructed Ok result with no value.
+ * Use this for operations that succeed without returning data.
+ *
+ * @example
+ * ```ts
+ * function deleteUser(id: string): Result<Unit, NotFoundError> {
+ *   if (!users.has(id)) return err(notFoundError(id));
+ *   users.delete(id);
+ *   return OK;
+ * }
+ * ```
+ */
+export const OK: Ok<Unit> = ok(undefined);

--- a/src/result/utils.ts
+++ b/src/result/utils.ts
@@ -1,0 +1,457 @@
+/**
+ * Utility functions for working with Result types.
+ *
+ * This module provides ergonomic helpers for:
+ * - Transformations: map, mapErr, flatMap/andThen
+ * - Extraction: unwrap, unwrapOr, unwrapOrElse
+ * - Pattern matching: match
+ * - Combining: combine, collect, collectAll
+ * - Boolean operations: or, and
+ * - Try-catch wrappers: tryCatch, tryCatchAsync
+ * - Side effects: tap, tapErr
+ *
+ * These utilities are inspired by Rust's Result type and functional
+ * programming patterns, adapted for TypeScript ergonomics.
+ */
+
+import type { Result, Unit } from './types';
+import { ok, err, isOk, isErr, OK } from './types';
+
+// =============================================================================
+// Mapping & Transformation
+// =============================================================================
+
+/**
+ * Transform the Ok value while preserving Err.
+ *
+ * @example
+ * ```ts
+ * const result = ok(5);
+ * const doubled = map(result, x => x * 2);
+ * // { ok: true, value: 10 }
+ * ```
+ */
+export function map<T, U, E>(
+  result: Result<T, E>,
+  fn: (value: T) => U
+): Result<U, E> {
+  if (isOk(result)) {
+    return ok(fn(result.value));
+  }
+  return result;
+}
+
+/**
+ * Transform the Err value while preserving Ok.
+ *
+ * @example
+ * ```ts
+ * const result = err({ code: 'NOT_FOUND' });
+ * const mapped = mapErr(result, e => ({ ...e, logged: true }));
+ * ```
+ */
+export function mapErr<T, E, F>(
+  result: Result<T, E>,
+  fn: (error: E) => F
+): Result<T, F> {
+  if (isErr(result)) {
+    return err(fn(result.error));
+  }
+  return result;
+}
+
+/**
+ * Chain operations that return Results (flatMap).
+ * This is the core function for composing Result-returning operations.
+ *
+ * @example
+ * ```ts
+ * const divide = (a: number, b: number): Result<number, string> =>
+ *   b === 0 ? err('Division by zero') : ok(a / b);
+ *
+ * const result = flatMap(ok(10), x => divide(x, 2));
+ * // { ok: true, value: 5 }
+ * ```
+ */
+export function flatMap<T, U, E>(
+  result: Result<T, E>,
+  fn: (value: T) => Result<U, E>
+): Result<U, E> {
+  if (isOk(result)) {
+    return fn(result.value);
+  }
+  return result;
+}
+
+/**
+ * Alias for flatMap (Rust terminology).
+ */
+export const andThen = flatMap;
+
+// =============================================================================
+// Value Extraction
+// =============================================================================
+
+/**
+ * Extract the Ok value, throwing if Err.
+ * Use sparingly - prefer match() or isOk() checks.
+ *
+ * @throws Error if Result is not Ok
+ *
+ * @example
+ * ```ts
+ * const result = ok(42);
+ * const value = unwrap(result); // 42
+ *
+ * const errorResult = err('failed');
+ * unwrap(errorResult); // throws Error
+ * ```
+ */
+export function unwrap<T, E>(result: Result<T, E>): T {
+  if (isOk(result)) {
+    return result.value;
+  }
+  throw new Error(`Called unwrap on an Err: ${JSON.stringify(result.error)}`);
+}
+
+/**
+ * Extract the Ok value, or return a default value if Err.
+ *
+ * @example
+ * ```ts
+ * const result = err('not found');
+ * const value = unwrapOr(result, 0); // 0
+ * ```
+ */
+export function unwrapOr<T, E>(result: Result<T, E>, defaultValue: T): T {
+  return isOk(result) ? result.value : defaultValue;
+}
+
+/**
+ * Extract the Ok value, or compute a default from the error.
+ *
+ * @example
+ * ```ts
+ * const result = err({ code: 'NOT_FOUND', defaultId: 'default' });
+ * const value = unwrapOrElse(result, e => e.defaultId);
+ * // 'default'
+ * ```
+ */
+export function unwrapOrElse<T, E>(
+  result: Result<T, E>,
+  fn: (error: E) => T
+): T {
+  return isOk(result) ? result.value : fn(result.error);
+}
+
+/**
+ * Extract the Err value, throwing if Ok.
+ * Useful for testing error paths.
+ *
+ * @throws Error if Result is Ok
+ */
+export function unwrapErr<T, E>(result: Result<T, E>): E {
+  if (isErr(result)) {
+    return result.error;
+  }
+  throw new Error(`Called unwrapErr on an Ok: ${JSON.stringify(result.value)}`);
+}
+
+// =============================================================================
+// Pattern Matching
+// =============================================================================
+
+/**
+ * Pattern match on Result - exhaustive handler.
+ * This is the most ergonomic way to handle Results.
+ *
+ * @example
+ * ```ts
+ * const message = match(loadUser(id), {
+ *   ok: (user) => `Hello ${user.name}`,
+ *   err: (error) => `Error: ${error.message}`
+ * });
+ * ```
+ */
+export function match<T, E, U>(
+  result: Result<T, E>,
+  handlers: {
+    ok: (value: T) => U;
+    err: (error: E) => U;
+  }
+): U {
+  if (isOk(result)) {
+    return handlers.ok(result.value);
+  }
+  return handlers.err(result.error);
+}
+
+// =============================================================================
+// Combining Results
+// =============================================================================
+
+/**
+ * Combine two Results into a tuple.
+ * Returns the first Err if either is Err.
+ *
+ * @example
+ * ```ts
+ * const r1 = ok(1);
+ * const r2 = ok('hello');
+ * const combined = combine(r1, r2);
+ * // { ok: true, value: [1, 'hello'] }
+ * ```
+ */
+export function combine<T1, T2, E>(
+  r1: Result<T1, E>,
+  r2: Result<T2, E>
+): Result<[T1, T2], E> {
+  if (isErr(r1)) return r1;
+  if (isErr(r2)) return r2;
+  return ok([r1.value, r2.value]);
+}
+
+/**
+ * Combine three Results into a tuple.
+ */
+export function combine3<T1, T2, T3, E>(
+  r1: Result<T1, E>,
+  r2: Result<T2, E>,
+  r3: Result<T3, E>
+): Result<[T1, T2, T3], E> {
+  if (isErr(r1)) return r1;
+  if (isErr(r2)) return r2;
+  if (isErr(r3)) return r3;
+  return ok([r1.value, r2.value, r3.value]);
+}
+
+/**
+ * Collect an array of Results into a Result of array.
+ * Returns the first Err if any Result is Err.
+ *
+ * @example
+ * ```ts
+ * const results = [ok(1), ok(2), ok(3)];
+ * const collected = collect(results);
+ * // { ok: true, value: [1, 2, 3] }
+ *
+ * const mixed = [ok(1), err('failed'), ok(3)];
+ * const failed = collect(mixed);
+ * // { ok: false, error: 'failed' }
+ * ```
+ */
+export function collect<T, E>(results: Result<T, E>[]): Result<T[], E> {
+  const values: T[] = [];
+  for (const result of results) {
+    if (isErr(result)) {
+      return result;
+    }
+    values.push(result.value);
+  }
+  return ok(values);
+}
+
+/**
+ * Collect an array of Results, accumulating all errors.
+ * Returns Ok with all values if all succeed, or Err with all errors.
+ *
+ * @example
+ * ```ts
+ * const results = [ok(1), err('a'), ok(2), err('b')];
+ * const collected = collectAll(results);
+ * // { ok: false, error: ['a', 'b'] }
+ * ```
+ */
+export function collectAll<T, E>(results: Result<T, E>[]): Result<T[], E[]> {
+  const values: T[] = [];
+  const errors: E[] = [];
+
+  for (const result of results) {
+    if (isOk(result)) {
+      values.push(result.value);
+    } else {
+      errors.push(result.error);
+    }
+  }
+
+  if (errors.length > 0) {
+    return err(errors);
+  }
+  return ok(values);
+}
+
+// =============================================================================
+// Boolean Operations
+// =============================================================================
+
+/**
+ * Return the first Ok, or the last Err if all fail.
+ * Useful for fallback chains.
+ *
+ * @example
+ * ```ts
+ * const result = or(
+ *   loadFromCache(id),
+ *   loadFromDatabase(id)
+ * );
+ * ```
+ */
+export function or<T, E>(r1: Result<T, E>, r2: Result<T, E>): Result<T, E> {
+  if (isOk(r1)) return r1;
+  return r2;
+}
+
+/**
+ * Return r2 if r1 is Ok, otherwise return r1's Err.
+ * Useful when you need both operations to succeed but only want the second value.
+ */
+export function and<T, U, E>(r1: Result<T, E>, r2: Result<U, E>): Result<U, E> {
+  if (isErr(r1)) return r1;
+  return r2;
+}
+
+// =============================================================================
+// Try-Catch Wrappers
+// =============================================================================
+
+/**
+ * Wrap a synchronous function that may throw into a Result.
+ *
+ * @example
+ * ```ts
+ * const result = tryCatch(
+ *   () => JSON.parse(jsonString),
+ *   (error) => storageCorrupted('key', [String(error)])
+ * );
+ * ```
+ */
+export function tryCatch<T, E = unknown>(
+  fn: () => T,
+  mapError?: (error: unknown) => E
+): Result<T, E> {
+  try {
+    return ok(fn());
+  } catch (error) {
+    return err(mapError ? mapError(error) : (error as E));
+  }
+}
+
+/**
+ * Wrap an async function that may throw into a Promise<Result>.
+ *
+ * @example
+ * ```ts
+ * const result = await tryCatchAsync(
+ *   () => fetch('/api/data').then(r => r.json()),
+ *   (error) => apiNetworkError(error)
+ * );
+ * ```
+ */
+export async function tryCatchAsync<T, E = unknown>(
+  fn: () => Promise<T>,
+  mapError?: (error: unknown) => E
+): Promise<Result<T, E>> {
+  try {
+    const value = await fn();
+    return ok(value);
+  } catch (error) {
+    return err(mapError ? mapError(error) : (error as E));
+  }
+}
+
+// =============================================================================
+// Void/Unit Helpers
+// =============================================================================
+
+/**
+ * Convert any Ok result to Ok<Unit>.
+ * Useful when you don't care about the value, only success/failure.
+ *
+ * @example
+ * ```ts
+ * const result = saveFile(data); // Result<FileInfo, Error>
+ * const voidResult = toUnit(result); // Result<void, Error>
+ * ```
+ */
+export function toUnit<T, E>(result: Result<T, E>): Result<Unit, E> {
+  if (isOk(result)) {
+    return OK;
+  }
+  return result;
+}
+
+/**
+ * Perform a side effect if Result is Ok, then return the original result.
+ * Useful for logging or other side effects without changing the result.
+ *
+ * @example
+ * ```ts
+ * const result = tap(loadUser(id), (user) => {
+ *   console.log('Loaded user:', user.name);
+ * });
+ * ```
+ */
+export function tap<T, E>(
+  result: Result<T, E>,
+  fn: (value: T) => void
+): Result<T, E> {
+  if (isOk(result)) {
+    fn(result.value);
+  }
+  return result;
+}
+
+/**
+ * Perform a side effect if Result is Err, then return the original result.
+ * Useful for logging errors without changing the result.
+ *
+ * @example
+ * ```ts
+ * const result = tapErr(loadUser(id), (error) => {
+ *   console.error('Failed to load user:', error.message);
+ * });
+ * ```
+ */
+export function tapErr<T, E>(
+  result: Result<T, E>,
+  fn: (error: E) => void
+): Result<T, E> {
+  if (isErr(result)) {
+    fn(result.error);
+  }
+  return result;
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * Check if all Results in an array are Ok.
+ */
+export function allOk<T, E>(results: Result<T, E>[]): boolean {
+  return results.every(isOk);
+}
+
+/**
+ * Check if any Result in an array is Err.
+ */
+export function anyErr<T, E>(results: Result<T, E>[]): boolean {
+  return results.some(isErr);
+}
+
+/**
+ * Get all Ok values from an array of Results.
+ * Filters out Err results and returns only the Ok values.
+ */
+export function filterOk<T, E>(results: Result<T, E>[]): T[] {
+  return results.filter(isOk).map((r) => r.value);
+}
+
+/**
+ * Get all Err values from an array of Results.
+ * Filters out Ok results and returns only the errors.
+ */
+export function filterErr<T, E>(results: Result<T, E>[]): E[] {
+  return results.filter(isErr).map((r) => r.error);
+}

--- a/src/test/result.test.ts
+++ b/src/test/result.test.ts
@@ -1,0 +1,724 @@
+import { describe, it, expect } from 'vitest';
+import {
+  // Core types and constructors
+  ok,
+  err,
+  isOk,
+  isErr,
+  OK,
+
+  // Utility functions
+  map,
+  mapErr,
+  flatMap,
+  andThen,
+  unwrap,
+  unwrapOr,
+  unwrapOrElse,
+  unwrapErr,
+  match,
+  combine,
+  combine3,
+  collect,
+  collectAll,
+  or,
+  and,
+  tryCatch,
+  tryCatchAsync,
+  toUnit,
+  tap,
+  tapErr,
+  allOk,
+  anyErr,
+  filterOk,
+  filterErr,
+
+  // Error constructors
+  storageNotFound,
+  storageQuotaExceeded,
+  storageCorrupted,
+  validationCollision,
+  validationOutOfBounds,
+  layoutLayerLimit,
+  layoutLastEntity,
+  apiRateLimited,
+  apiNetworkError,
+  unknownError,
+  fromUnknown,
+
+  // Catalog functions
+  getErrorInfo,
+  getUserMessage,
+  getRecoveryHint,
+  formatErrorMessage,
+  isRetryable,
+  getSeverity,
+} from '../result';
+import type { Result, StorageError, ValidationError } from '../result';
+
+// =============================================================================
+// Core Type Tests
+// =============================================================================
+
+describe('Result core types', () => {
+  describe('ok()', () => {
+    it('creates a successful result with a value', () => {
+      const result = ok(42);
+      expect(result).toEqual({ ok: true, value: 42 });
+    });
+
+    it('creates a successful result with complex objects', () => {
+      const user = { id: '1', name: 'Test' };
+      const result = ok(user);
+      expect(result).toEqual({ ok: true, value: user });
+    });
+
+    it('creates a successful result with undefined', () => {
+      const result = ok(undefined);
+      expect(result).toEqual({ ok: true, value: undefined });
+    });
+  });
+
+  describe('err()', () => {
+    it('creates a failed result with an error', () => {
+      const result = err('something went wrong');
+      expect(result).toEqual({ ok: false, error: 'something went wrong' });
+    });
+
+    it('creates a failed result with structured error', () => {
+      const error = { code: 'NOT_FOUND', message: 'Not found' };
+      const result = err(error);
+      expect(result).toEqual({ ok: false, error });
+    });
+  });
+
+  describe('isOk()', () => {
+    it('returns true for ok results', () => {
+      expect(isOk(ok(42))).toBe(true);
+    });
+
+    it('returns false for err results', () => {
+      expect(isOk(err('error'))).toBe(false);
+    });
+
+    it('narrows type correctly', () => {
+      const result: Result<number, string> = ok(42);
+      if (isOk(result)) {
+        // TypeScript should know result.value is number
+        expect(result.value).toBe(42);
+      }
+    });
+  });
+
+  describe('isErr()', () => {
+    it('returns true for err results', () => {
+      expect(isErr(err('error'))).toBe(true);
+    });
+
+    it('returns false for ok results', () => {
+      expect(isErr(ok(42))).toBe(false);
+    });
+
+    it('narrows type correctly', () => {
+      const result: Result<number, string> = err('error');
+      if (isErr(result)) {
+        // TypeScript should know result.error is string
+        expect(result.error).toBe('error');
+      }
+    });
+  });
+
+  describe('OK constant', () => {
+    it('is a pre-constructed Ok<void>', () => {
+      expect(OK).toEqual({ ok: true, value: undefined });
+    });
+  });
+});
+
+// =============================================================================
+// Utility Function Tests
+// =============================================================================
+
+describe('Result utilities', () => {
+  describe('map()', () => {
+    it('transforms ok value', () => {
+      const result = ok(5);
+      const mapped = map(result, (x) => x * 2);
+      expect(mapped).toEqual({ ok: true, value: 10 });
+    });
+
+    it('preserves err without calling function', () => {
+      const result = err('error') as Result<number, string>;
+      let called = false;
+      const mapped = map(result, () => {
+        called = true;
+        return 0;
+      });
+      expect(called).toBe(false);
+      expect(mapped).toEqual({ ok: false, error: 'error' });
+    });
+  });
+
+  describe('mapErr()', () => {
+    it('transforms err value', () => {
+      const result = err('error');
+      const mapped = mapErr(result, (e) => e.toUpperCase());
+      expect(mapped).toEqual({ ok: false, error: 'ERROR' });
+    });
+
+    it('preserves ok without calling function', () => {
+      const result = ok(42) as Result<number, string>;
+      let called = false;
+      const mapped = mapErr(result, () => {
+        called = true;
+        return 'transformed';
+      });
+      expect(called).toBe(false);
+      expect(mapped).toEqual({ ok: true, value: 42 });
+    });
+  });
+
+  describe('flatMap() / andThen()', () => {
+    it('chains successful results', () => {
+      const divide = (a: number, b: number): Result<number, string> =>
+        b === 0 ? err('Division by zero') : ok(a / b);
+
+      const result = flatMap(ok(10), (x) => divide(x, 2));
+      expect(result).toEqual({ ok: true, value: 5 });
+    });
+
+    it('short-circuits on error', () => {
+      const divide = (a: number, b: number): Result<number, string> =>
+        b === 0 ? err('Division by zero') : ok(a / b);
+
+      const result = flatMap(ok(10), (x) => divide(x, 0));
+      expect(result).toEqual({ ok: false, error: 'Division by zero' });
+    });
+
+    it('does not call function on err input', () => {
+      let called = false;
+      const result = flatMap(err('error') as Result<number, string>, () => {
+        called = true;
+        return ok(0);
+      });
+      expect(called).toBe(false);
+      expect(isErr(result)).toBe(true);
+    });
+
+    it('andThen is an alias for flatMap', () => {
+      expect(andThen).toBe(flatMap);
+    });
+  });
+
+  describe('unwrap()', () => {
+    it('returns value from ok result', () => {
+      expect(unwrap(ok(42))).toBe(42);
+    });
+
+    it('throws on err result', () => {
+      expect(() => unwrap(err('error'))).toThrow('Called unwrap on an Err');
+    });
+  });
+
+  describe('unwrapOr()', () => {
+    it('returns value from ok result', () => {
+      expect(unwrapOr(ok(42), 0)).toBe(42);
+    });
+
+    it('returns default for err result', () => {
+      expect(unwrapOr(err('error') as Result<number, string>, 0)).toBe(0);
+    });
+  });
+
+  describe('unwrapOrElse()', () => {
+    it('returns value from ok result', () => {
+      const result = unwrapOrElse(ok(42), () => 0);
+      expect(result).toBe(42);
+    });
+
+    it('computes default from error', () => {
+      const result = unwrapOrElse(
+        err({ defaultValue: 99 }) as Result<number, { defaultValue: number }>,
+        (e) => e.defaultValue
+      );
+      expect(result).toBe(99);
+    });
+  });
+
+  describe('unwrapErr()', () => {
+    it('returns error from err result', () => {
+      expect(unwrapErr(err('error'))).toBe('error');
+    });
+
+    it('throws on ok result', () => {
+      expect(() => unwrapErr(ok(42))).toThrow('Called unwrapErr on an Ok');
+    });
+  });
+
+  describe('match()', () => {
+    it('calls ok handler for ok result', () => {
+      const message = match(ok(42), {
+        ok: (v) => `Value: ${v}`,
+        err: (e) => `Error: ${e}`,
+      });
+      expect(message).toBe('Value: 42');
+    });
+
+    it('calls err handler for err result', () => {
+      const message = match(err('failed'), {
+        ok: (v) => `Value: ${v}`,
+        err: (e) => `Error: ${e}`,
+      });
+      expect(message).toBe('Error: failed');
+    });
+  });
+
+  describe('combine()', () => {
+    it('combines two ok results into tuple', () => {
+      const result = combine(ok(1), ok('hello'));
+      expect(result).toEqual({ ok: true, value: [1, 'hello'] });
+    });
+
+    it('returns first error if first is err', () => {
+      const result = combine(err('first'), ok('hello'));
+      expect(result).toEqual({ ok: false, error: 'first' });
+    });
+
+    it('returns second error if second is err', () => {
+      const result = combine(ok(1), err('second'));
+      expect(result).toEqual({ ok: false, error: 'second' });
+    });
+  });
+
+  describe('combine3()', () => {
+    it('combines three ok results into tuple', () => {
+      const result = combine3(ok(1), ok('hello'), ok(true));
+      expect(result).toEqual({ ok: true, value: [1, 'hello', true] });
+    });
+
+    it('returns first error encountered', () => {
+      const result = combine3(ok(1), err('second'), err('third'));
+      expect(result).toEqual({ ok: false, error: 'second' });
+    });
+  });
+
+  describe('collect()', () => {
+    it('collects all ok values into array', () => {
+      const results = [ok(1), ok(2), ok(3)];
+      const collected = collect(results);
+      expect(collected).toEqual({ ok: true, value: [1, 2, 3] });
+    });
+
+    it('returns first error', () => {
+      const results = [ok(1), err('error'), ok(3)];
+      const collected = collect(results);
+      expect(collected).toEqual({ ok: false, error: 'error' });
+    });
+
+    it('handles empty array', () => {
+      const collected = collect([]);
+      expect(collected).toEqual({ ok: true, value: [] });
+    });
+  });
+
+  describe('collectAll()', () => {
+    it('collects all ok values when no errors', () => {
+      const results = [ok(1), ok(2), ok(3)];
+      const collected = collectAll(results);
+      expect(collected).toEqual({ ok: true, value: [1, 2, 3] });
+    });
+
+    it('collects all errors when some fail', () => {
+      const results = [ok(1), err('a'), ok(2), err('b')];
+      const collected = collectAll(results);
+      expect(collected).toEqual({ ok: false, error: ['a', 'b'] });
+    });
+  });
+
+  describe('or()', () => {
+    it('returns first ok', () => {
+      const result = or(ok(1), ok(2));
+      expect(result).toEqual({ ok: true, value: 1 });
+    });
+
+    it('returns second if first is err', () => {
+      const result = or(err('first') as Result<number, string>, ok(2));
+      expect(result).toEqual({ ok: true, value: 2 });
+    });
+
+    it('returns last err if both fail', () => {
+      const result = or(err('first'), err('second'));
+      expect(result).toEqual({ ok: false, error: 'second' });
+    });
+  });
+
+  describe('and()', () => {
+    it('returns second if first is ok', () => {
+      const result = and(ok(1), ok('hello'));
+      expect(result).toEqual({ ok: true, value: 'hello' });
+    });
+
+    it('returns first error if first is err', () => {
+      const result = and(err('first'), ok('hello'));
+      expect(result).toEqual({ ok: false, error: 'first' });
+    });
+  });
+
+  describe('tryCatch()', () => {
+    it('returns ok for successful function', () => {
+      const result = tryCatch(() => JSON.parse('{"a": 1}'));
+      expect(isOk(result)).toBe(true);
+      expect(unwrap(result)).toEqual({ a: 1 });
+    });
+
+    it('returns err for throwing function', () => {
+      const result = tryCatch(() => JSON.parse('invalid'));
+      expect(isErr(result)).toBe(true);
+    });
+
+    it('maps error with provided function', () => {
+      const result = tryCatch(
+        () => JSON.parse('invalid'),
+        () => 'PARSE_ERROR'
+      );
+      expect(result).toEqual({ ok: false, error: 'PARSE_ERROR' });
+    });
+  });
+
+  describe('tryCatchAsync()', () => {
+    it('returns ok for successful async function', async () => {
+      const result = await tryCatchAsync(async () => 42);
+      expect(result).toEqual({ ok: true, value: 42 });
+    });
+
+    it('returns err for rejecting async function', async () => {
+      const result = await tryCatchAsync(
+        async () => {
+          throw new Error('async error');
+        },
+        () => 'ASYNC_ERROR'
+      );
+      expect(result).toEqual({ ok: false, error: 'ASYNC_ERROR' });
+    });
+  });
+
+  describe('toUnit()', () => {
+    it('converts ok to ok<void>', () => {
+      const result = toUnit(ok(42));
+      expect(result).toEqual({ ok: true, value: undefined });
+    });
+
+    it('preserves err', () => {
+      const result = toUnit(err('error'));
+      expect(result).toEqual({ ok: false, error: 'error' });
+    });
+  });
+
+  describe('tap()', () => {
+    it('calls function for ok and returns original', () => {
+      let captured = 0;
+      const original = ok(42);
+      const result = tap(original, (v) => {
+        captured = v;
+      });
+      expect(captured).toBe(42);
+      expect(result).toBe(original);
+    });
+
+    it('does not call function for err', () => {
+      let called = false;
+      const result = tap(err('error'), () => {
+        called = true;
+      });
+      expect(called).toBe(false);
+      expect(isErr(result)).toBe(true);
+    });
+  });
+
+  describe('tapErr()', () => {
+    it('calls function for err and returns original', () => {
+      let captured = '';
+      const original = err('error');
+      const result = tapErr(original, (e) => {
+        captured = e;
+      });
+      expect(captured).toBe('error');
+      expect(result).toBe(original);
+    });
+
+    it('does not call function for ok', () => {
+      let called = false;
+      const result = tapErr(ok(42), () => {
+        called = true;
+      });
+      expect(called).toBe(false);
+      expect(isOk(result)).toBe(true);
+    });
+  });
+
+  describe('array utilities', () => {
+    it('allOk returns true when all ok', () => {
+      expect(allOk([ok(1), ok(2), ok(3)])).toBe(true);
+    });
+
+    it('allOk returns false when any err', () => {
+      expect(allOk([ok(1), err('e'), ok(3)])).toBe(false);
+    });
+
+    it('anyErr returns true when any err', () => {
+      expect(anyErr([ok(1), err('e'), ok(3)])).toBe(true);
+    });
+
+    it('anyErr returns false when all ok', () => {
+      expect(anyErr([ok(1), ok(2), ok(3)])).toBe(false);
+    });
+
+    it('filterOk extracts ok values', () => {
+      const results = [ok(1), err('e'), ok(3)];
+      expect(filterOk(results)).toEqual([1, 3]);
+    });
+
+    it('filterErr extracts err values', () => {
+      const results = [ok(1), err('a'), ok(3), err('b')];
+      expect(filterErr(results)).toEqual(['a', 'b']);
+    });
+  });
+});
+
+// =============================================================================
+// Error Constructor Tests
+// =============================================================================
+
+describe('Error constructors', () => {
+  describe('Storage errors', () => {
+    it('creates storageNotFound with key', () => {
+      const error = storageNotFound('test-key');
+      expect(error.kind).toBe('StorageError');
+      expect(error.code).toBe('STORAGE_NOT_FOUND');
+      expect(error.key).toBe('test-key');
+      expect(error.timestamp).toBeGreaterThan(0);
+    });
+
+    it('creates storageQuotaExceeded with usage info', () => {
+      const error = storageQuotaExceeded(1000, 5000);
+      expect(error.code).toBe('STORAGE_QUOTA_EXCEEDED');
+      expect(error.usageBytes).toBe(1000);
+      expect(error.limitBytes).toBe(5000);
+    });
+
+    it('creates storageCorrupted with validation errors', () => {
+      const error = storageCorrupted('key', ['invalid field', 'missing data']);
+      expect(error.code).toBe('STORAGE_CORRUPTED');
+      expect(error.validationErrors).toEqual(['invalid field', 'missing data']);
+    });
+  });
+
+  describe('Validation errors', () => {
+    it('creates validationCollision with bin IDs', () => {
+      const error = validationCollision(['bin-1', 'bin-2']);
+      expect(error.kind).toBe('ValidationError');
+      expect(error.code).toBe('VALIDATION_COLLISION');
+      expect(error.collidingBinIds).toEqual(['bin-1', 'bin-2']);
+    });
+
+    it('creates validationOutOfBounds with reason', () => {
+      const error = validationOutOfBounds('exceeds_width', { x: 5, y: 0, width: 10, depth: 2 });
+      expect(error.code).toBe('VALIDATION_OUT_OF_BOUNDS');
+      expect(error.reason).toBe('exceeds_width');
+      expect(error.binData).toEqual({ x: 5, y: 0, width: 10, depth: 2 });
+    });
+  });
+
+  describe('Layout errors', () => {
+    it('creates layoutLayerLimit with counts', () => {
+      const error = layoutLayerLimit(10, 10);
+      expect(error.kind).toBe('LayoutError');
+      expect(error.code).toBe('LAYOUT_LAYER_LIMIT');
+      expect(error.currentCount).toBe(10);
+      expect(error.maxCount).toBe(10);
+    });
+
+    it('creates layoutLastEntity with entity type and metadata', () => {
+      const error = layoutLastEntity('layer');
+      expect(error.code).toBe('LAYOUT_LAST_ENTITY');
+      expect(error.entityType).toBe('layer');
+      expect(error.metadata).toEqual({ entityType: 'layer' });
+    });
+  });
+
+  describe('API errors', () => {
+    it('creates apiRateLimited with retry info', () => {
+      const error = apiRateLimited(60);
+      expect(error.kind).toBe('ApiError');
+      expect(error.code).toBe('API_RATE_LIMITED');
+      expect(error.retryAfter).toBe(60);
+      expect(error.metadata).toEqual({ retryAfter: 60 });
+    });
+
+    it('creates apiNetworkError with cause', () => {
+      const cause = new Error('fetch failed');
+      const error = apiNetworkError(cause);
+      expect(error.code).toBe('API_NETWORK_ERROR');
+      expect(error.cause).toBe(cause);
+    });
+  });
+
+  describe('Unknown errors', () => {
+    it('creates unknownError with cause', () => {
+      const cause = new TypeError('unexpected');
+      const error = unknownError(cause);
+      expect(error.kind).toBe('UnknownError');
+      expect(error.code).toBe('UNKNOWN_ERROR');
+      expect(error.cause).toBe(cause);
+    });
+
+    it('fromUnknown wraps any error', () => {
+      const error = fromUnknown('string error');
+      expect(error.code).toBe('UNKNOWN_ERROR');
+      expect(error.cause).toBe('string error');
+    });
+  });
+});
+
+// =============================================================================
+// Error Catalog Tests
+// =============================================================================
+
+describe('Error catalog', () => {
+  describe('getErrorInfo()', () => {
+    it('returns catalog entry for known code', () => {
+      const info = getErrorInfo('STORAGE_NOT_FOUND');
+      expect(info.code).toBe('STORAGE_NOT_FOUND');
+      expect(info.userMessage).toBe('Layout not found');
+    });
+
+    it('returns UNKNOWN_ERROR for unknown code', () => {
+      const info = getErrorInfo('TOTALLY_FAKE_CODE');
+      expect(info.code).toBe('UNKNOWN_ERROR');
+    });
+  });
+
+  describe('getUserMessage()', () => {
+    it('returns user message for error', () => {
+      const error = storageNotFound('key');
+      const message = getUserMessage(error);
+      expect(message).toBe('Layout not found');
+    });
+
+    it('interpolates metadata variables', () => {
+      const error = layoutLastEntity('layer');
+      const message = getUserMessage(error);
+      expect(message).toBe('Cannot delete the only layer');
+    });
+  });
+
+  describe('getRecoveryHint()', () => {
+    it('returns recovery hint for error', () => {
+      const error = storageNotFound('key');
+      const hint = getRecoveryHint(error);
+      expect(hint).toBe('The layout may have been deleted');
+    });
+
+    it('interpolates metadata in hints', () => {
+      const error = apiRateLimited(60);
+      const hint = getRecoveryHint(error);
+      expect(hint).toBe('Wait 60 seconds before retrying');
+    });
+  });
+
+  describe('formatErrorMessage()', () => {
+    it('replaces single variable', () => {
+      const result = formatErrorMessage('Hello {name}', { name: 'World' });
+      expect(result).toBe('Hello World');
+    });
+
+    it('replaces multiple variables', () => {
+      const result = formatErrorMessage('{a} + {b} = {c}', { a: 1, b: 2, c: 3 });
+      expect(result).toBe('1 + 2 = 3');
+    });
+
+    it('preserves unmatched placeholders', () => {
+      const result = formatErrorMessage('Hello {name}', {});
+      expect(result).toBe('Hello {name}');
+    });
+
+    it('handles no variables', () => {
+      const result = formatErrorMessage('No variables here');
+      expect(result).toBe('No variables here');
+    });
+  });
+
+  describe('isRetryable()', () => {
+    it('returns true for retryable errors', () => {
+      expect(isRetryable('API_RATE_LIMITED')).toBe(true);
+      expect(isRetryable('API_NETWORK_ERROR')).toBe(true);
+      expect(isRetryable('STORAGE_UNAVAILABLE')).toBe(true);
+    });
+
+    it('returns false for non-retryable errors', () => {
+      expect(isRetryable('STORAGE_NOT_FOUND')).toBe(false);
+      expect(isRetryable('VALIDATION_COLLISION')).toBe(false);
+    });
+  });
+
+  describe('getSeverity()', () => {
+    it('returns error for severe issues', () => {
+      expect(getSeverity('STORAGE_CORRUPTED')).toBe('error');
+      expect(getSeverity('API_SERVER_ERROR')).toBe('error');
+    });
+
+    it('returns warning for less severe issues', () => {
+      expect(getSeverity('VALIDATION_COLLISION')).toBe('warning');
+      expect(getSeverity('LAYOUT_LAYER_LIMIT')).toBe('warning');
+    });
+  });
+});
+
+// =============================================================================
+// Type Safety Tests (compile-time)
+// =============================================================================
+
+describe('Type safety', () => {
+  it('Result type narrows correctly with isOk', () => {
+    const result: Result<string, StorageError> = ok('test');
+
+    if (isOk(result)) {
+      // Should compile - value is string
+      const value: string = result.value;
+      expect(value).toBe('test');
+    }
+  });
+
+  it('Result type narrows correctly with isErr', () => {
+    const result: Result<string, StorageError> = err(storageNotFound('key'));
+
+    if (isErr(result)) {
+      // Should compile - error is StorageError
+      const code: string = result.error.code;
+      expect(code).toBe('STORAGE_NOT_FOUND');
+    }
+  });
+
+  it('match exhaustively handles both cases', () => {
+    const result: Result<number, string> = ok(42);
+
+    // Both branches must return the same type
+    const output: string = match(result, {
+      ok: (v) => `ok: ${v}`,
+      err: (e) => `err: ${e}`,
+    });
+
+    expect(output).toBe('ok: 42');
+  });
+
+  it('flatMap preserves error type through chain', () => {
+    type MyError = ValidationError;
+
+    const step1 = (n: number): Result<number, MyError> => ok(n * 2);
+    const step2 = (n: number): Result<string, MyError> => ok(String(n));
+
+    const result: Result<string, MyError> = flatMap(step1(5), step2);
+
+    expect(unwrap(result)).toBe('10');
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive Result<T, E> discriminated union type system for type-safe error handling
- Create 25+ domain-specific error types (Storage, Validation, Layout, API errors)
- Include centralized error catalog with user-friendly messages and recovery hints
- Provide functional utilities: `map`, `flatMap`, `match`, `collect`, `tryCatch`, etc.

## Test plan
- [x] 91 new unit tests covering all Result utilities and error constructors
- [x] All existing 2827 tests continue to pass
- [x] Build passes
- [x] ESLint passes
- [x] Code review completed (no issues found)

This is the foundation for incremental migration from `OperationResult<T>` to `Result<T, E>`.