### PR TITLE
feat: migrate storage layer to Result-based error handling

### DIFF
--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -1,8 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { useLayoutStore, useLibraryStore, useToastStore } from '../store';
-import { saveLayoutByIdAsync, saveLibrary, computeLayoutPreview } from '../storage';
+import {
+  saveLayoutResult,
+  saveLibraryResult,
+  computeLayoutPreview,
+} from '../storage';
 import { scheduleIdleCallback, cancelIdleCallback } from '../utils/idle';
+import { isErr, getUserMessage, isRetryable } from '../result';
+import type { StorageError } from '../result';
 
 const SAVE_DEBOUNCE_MS = 1000;
 const SAVED_DISPLAY_MS = 2500;
@@ -61,44 +67,64 @@ export function useAutoSave(): SaveStatus {
       // Schedule storage operations during browser idle time to improve INP
       idleCallbackRef.current = scheduleIdleCallback(
         async () => {
-          try {
-            await saveLayoutByIdAsync(activeLayoutId, layout);
+          // Save layout using Result-based API for explicit error handling
+          const layoutResult = await saveLayoutResult(activeLayoutId, layout);
 
-            updateEntry(activeLayoutId, {
-              modifiedAt: Date.now(),
-              preview: computeLayoutPreview(layout),
-              name: layout.name,
-            });
-
-            saveLibrary(useLibraryStore.getState().library);
-
-            hasShownErrorRef.current = false;
-            failureCountRef.current = 0;
-
-            setSaveStatus('saved');
-
-            savedTimeoutRef.current = window.setTimeout(() => {
-              setSaveStatus('idle');
-            }, SAVED_DISPLAY_MS);
-          } catch (error) {
-            failureCountRef.current++;
-            setSaveStatus('idle');
-
-            // Show warning after multiple failures
-            if (failureCountRef.current >= 3 && !hasShownErrorRef.current) {
-              hasShownErrorRef.current = true;
-              const message = error instanceof Error ? error.message : 'Failed to save layout';
-              addToast(message, 'error', 0); // Don't auto-dismiss
-            } else if (!hasShownErrorRef.current && failureCountRef.current === 1) {
-              // Show transient error on first failure
-              const message = error instanceof Error ? error.message : 'Failed to save layout';
-              addToast(message, 'error');
-            }
+          if (isErr(layoutResult)) {
+            handleSaveError(layoutResult.error);
+            return;
           }
+
+          // Update library entry
+          updateEntry(activeLayoutId, {
+            modifiedAt: Date.now(),
+            preview: computeLayoutPreview(layout),
+            name: layout.name,
+          });
+
+          // Save library index
+          const libraryResult = saveLibraryResult(
+            useLibraryStore.getState().library
+          );
+
+          if (isErr(libraryResult)) {
+            // Library save failed but layout is saved - partial success
+            // Still show as saved since the important data is persisted
+            handleSaveError(libraryResult.error);
+            return;
+          }
+
+          // Success - reset error tracking
+          hasShownErrorRef.current = false;
+          failureCountRef.current = 0;
+
+          setSaveStatus('saved');
+
+          savedTimeoutRef.current = window.setTimeout(() => {
+            setSaveStatus('idle');
+          }, SAVED_DISPLAY_MS);
         },
         { timeout: IDLE_TIMEOUT_MS }
       );
     }, SAVE_DEBOUNCE_MS);
+
+    function handleSaveError(error: StorageError): void {
+      failureCountRef.current++;
+      setSaveStatus('idle');
+
+      const message = getUserMessage(error);
+      const canRetry = isRetryable(error.code);
+
+      // Show warning after multiple failures (persistent toast)
+      if (failureCountRef.current >= 3 && !hasShownErrorRef.current) {
+        hasShownErrorRef.current = true;
+        addToast(message, 'error', 0); // Don't auto-dismiss
+      } else if (!hasShownErrorRef.current && failureCountRef.current === 1) {
+        // Show transient error on first failure
+        // Auto-dismiss if retryable (will retry on next change)
+        addToast(message, 'error', canRetry ? undefined : 0);
+      }
+    }
 
     return () => {
       if (timeoutRef.current) {

--- a/src/storage/LayoutService.ts
+++ b/src/storage/LayoutService.ts
@@ -5,10 +5,12 @@
  * - Async operations (saveLayoutAsync, loadLayoutAsync): Runtime use
  * - Sync operations (saveLayoutSync, loadLayoutSync): Initialization only
  * - Library management (saveLibrary, loadLibrary, initializeLayoutLibrary)
+ * - Result-based operations (*Result suffix): Type-safe error handling
  *
  * Naming convention:
  * - *Async suffix: Uses IndexedDB + localStorage dual-write, returns Promise
  * - *Sync suffix: Uses localStorage only, synchronous
+ * - *Result suffix: Returns Result<T, StorageError> for explicit error handling
  */
 
 import * as backend from './backend';
@@ -22,6 +24,17 @@ import type {
   LayoutPreview,
   ThumbnailBin,
 } from '../types';
+import type { Result } from '../result';
+import type { StorageError } from '../result';
+import {
+  ok,
+  err,
+  tryCatchAsync,
+  storageQuotaExceeded,
+  storageNotFound,
+  storageCorrupted,
+  storageUnavailable,
+} from '../result';
 
 // Storage keys
 const LEGACY_STORAGE_KEY = 'gridfinity-layout-v1';
@@ -111,6 +124,128 @@ export async function deleteLayoutAsync(layoutId: string): Promise<void> {
   await backend.deleteAsync(key);
 }
 
+// === Result-Based Async Operations ===
+// These functions return Result<T, StorageError> for explicit error handling.
+// Use these when you need detailed error information for user feedback.
+
+/**
+ * Save a layout asynchronously with Result-based error handling.
+ * Returns Ok on success, or Err with specific StorageError on failure.
+ *
+ * @example
+ * ```ts
+ * const result = await saveLayoutResult(id, layout);
+ * if (isErr(result)) {
+ *   addToast(getUserMessage(result.error), 'error');
+ * }
+ * ```
+ */
+export async function saveLayoutResult(
+  layoutId: string,
+  layout: Layout
+): Promise<Result<void, StorageError>> {
+  const key = getLayoutStorageKey(layoutId);
+
+  return tryCatchAsync(
+    () => backend.saveAsync(key, layout),
+    (error): StorageError => {
+      const message = error instanceof Error ? error.message : String(error);
+
+      // Detect quota exceeded errors
+      if (
+        message.includes('quota') ||
+        message.includes('QuotaExceeded') ||
+        message.includes('Storage full')
+      ) {
+        return storageQuotaExceeded(undefined, undefined, error);
+      }
+
+      // Detect storage unavailable errors
+      if (
+        message.includes('unavailable') ||
+        message.includes('SecurityError') ||
+        message.includes('access')
+      ) {
+        return storageUnavailable('indexedDB', error);
+      }
+
+      // Default to unavailable for unknown errors
+      return storageUnavailable('indexedDB', error);
+    }
+  );
+}
+
+/**
+ * Load a layout asynchronously with Result-based error handling.
+ * Returns Ok with the layout, or Err with specific StorageError.
+ *
+ * Unlike loadLayoutAsync which returns null for both "not found" and "corrupted",
+ * this function distinguishes between these cases for better error handling.
+ *
+ * @example
+ * ```ts
+ * const result = await loadLayoutResult(id);
+ * match(result, {
+ *   ok: (layout) => setLayout(layout),
+ *   err: (error) => {
+ *     if (error.code === 'STORAGE_NOT_FOUND') {
+ *       // Handle missing layout
+ *     } else if (error.code === 'STORAGE_CORRUPTED') {
+ *       // Offer recovery options
+ *     }
+ *   }
+ * });
+ * ```
+ */
+export async function loadLayoutResult(
+  layoutId: string
+): Promise<Result<Layout, StorageError>> {
+  const key = getLayoutStorageKey(layoutId);
+
+  let data: Layout | null;
+  try {
+    data = await backend.loadAsync(key);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (message.includes('unavailable') || message.includes('SecurityError')) {
+      return err(storageUnavailable('indexedDB', error));
+    }
+
+    return err(storageUnavailable('indexedDB', error));
+  }
+
+  if (!data) {
+    return err(storageNotFound(key));
+  }
+
+  const migrated = migrateLayout(data as unknown as Record<string, unknown>);
+  const validation = validateImport(migrated);
+
+  if (!validation.valid) {
+    return err(storageCorrupted(key, validation.errors));
+  }
+
+  return ok(migrated as unknown as Layout);
+}
+
+/**
+ * Delete a layout asynchronously with Result-based error handling.
+ * Returns Ok on success (including when layout doesn't exist).
+ */
+export async function deleteLayoutResult(
+  layoutId: string
+): Promise<Result<void, StorageError>> {
+  const key = getLayoutStorageKey(layoutId);
+
+  return tryCatchAsync(
+    () => backend.deleteAsync(key),
+    (error): StorageError => {
+      return storageUnavailable('indexedDB', error);
+    }
+  );
+}
+
 // === Sync Layout Operations (Initialization Only) ===
 
 /**
@@ -168,6 +303,31 @@ export function saveLibrary(library: LayoutLibrary): void {
     backend.saveSyncGeneric(LIBRARY_STORAGE_KEY, library);
   } catch {
     throw new Error('Storage full. Export your layouts to save them.');
+  }
+}
+
+/**
+ * Save the layout library index with Result-based error handling.
+ * Returns Ok on success, or Err with StorageError on failure.
+ */
+export function saveLibraryResult(
+  library: LayoutLibrary
+): Result<void, StorageError> {
+  try {
+    backend.saveSyncGeneric(LIBRARY_STORAGE_KEY, library);
+    return ok(undefined);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (
+      message.includes('quota') ||
+      message.includes('QuotaExceeded') ||
+      message.includes('Storage full')
+    ) {
+      return err(storageQuotaExceeded(undefined, undefined, error));
+    }
+
+    return err(storageUnavailable('localStorage', error));
   }
 }
 

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -21,6 +21,14 @@ export {
   deleteLayoutAsync,
 } from './LayoutService';
 
+// === Layout CRUD (Async - Result-Based) ===
+// Use these when you need explicit error handling with Result types
+export {
+  saveLayoutResult,
+  loadLayoutResult,
+  deleteLayoutResult,
+} from './LayoutService';
+
 // === Layout CRUD (Sync - Initialization Only) ===
 // Use only during app startup when async is not available
 export {
@@ -32,6 +40,7 @@ export {
 // === Library Management ===
 export {
   saveLibrary,
+  saveLibraryResult,
   loadLibrary,
   initializeLayoutLibrary,
   computeLayoutPreview,

--- a/src/test/hooks/useAutoSave.test.ts
+++ b/src/test/hooks/useAutoSave.test.ts
@@ -6,12 +6,16 @@ import { useLibraryStore } from '../../store/library';
 import { useToastStore } from '../../store/toast';
 import { resetAllStores, setupFakeTimers } from '../testUtils';
 import * as storage from '../../storage';
+import { ok, err, storageQuotaExceeded, storageUnavailable } from '../../result';
 
 // Mock the storage module
 vi.mock('../../storage', () => ({
   saveLayoutById: vi.fn(),
   saveLayoutByIdAsync: vi.fn().mockResolvedValue(undefined),
   saveLibrary: vi.fn(),
+  // Result-based functions used by updated useAutoSave
+  saveLayoutResult: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
+  saveLibraryResult: vi.fn(() => ({ ok: true, value: undefined })),
   computeLayoutPreview: vi.fn(() => ({
     drawerWidth: 10,
     drawerDepth: 8,
@@ -74,7 +78,7 @@ describe('useAutoSave', () => {
       renderHook(() => useAutoSave());
 
       // Immediately after mount, save should not have been called
-      expect(storage.saveLayoutByIdAsync).not.toHaveBeenCalled();
+      expect(storage.saveLayoutResult).not.toHaveBeenCalled();
 
       // Advance time past debounce
       await act(async () => {
@@ -83,8 +87,8 @@ describe('useAutoSave', () => {
       });
 
       // Now save should have been called
-      expect(storage.saveLayoutByIdAsync).toHaveBeenCalledTimes(1);
-      expect(storage.saveLayoutByIdAsync).toHaveBeenCalledWith(
+      expect(storage.saveLayoutResult).toHaveBeenCalledTimes(1);
+      expect(storage.saveLayoutResult).toHaveBeenCalledWith(
         TEST_LAYOUT_ID,
         useLayoutStore.getState().layout
       );
@@ -98,7 +102,7 @@ describe('useAutoSave', () => {
         timerUtils.advanceTime(SAVE_DEBOUNCE_MS - 100);
       });
 
-      expect(storage.saveLayoutByIdAsync).not.toHaveBeenCalled();
+      expect(storage.saveLayoutResult).not.toHaveBeenCalled();
     });
 
     it('resets debounce timer on layout change', async () => {
@@ -120,7 +124,7 @@ describe('useAutoSave', () => {
       });
 
       // Save should NOT have been called (timer was reset)
-      expect(storage.saveLayoutByIdAsync).not.toHaveBeenCalled();
+      expect(storage.saveLayoutResult).not.toHaveBeenCalled();
 
       // Advance to complete the new debounce
       await act(async () => {
@@ -129,7 +133,7 @@ describe('useAutoSave', () => {
       });
 
       // Now save should be called
-      expect(storage.saveLayoutByIdAsync).toHaveBeenCalledTimes(1);
+      expect(storage.saveLayoutResult).toHaveBeenCalledTimes(1);
     });
 
     it('saves with latest layout data after multiple rapid changes', async () => {
@@ -155,8 +159,8 @@ describe('useAutoSave', () => {
       });
 
       // Should only save once with final values
-      expect(storage.saveLayoutByIdAsync).toHaveBeenCalledTimes(1);
-      const savedLayout = (storage.saveLayoutByIdAsync as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(storage.saveLayoutResult).toHaveBeenCalledTimes(1);
+      const savedLayout = (storage.saveLayoutResult as ReturnType<typeof vi.fn>).mock.calls[0][1];
       expect(savedLayout.drawer.width).toBe(16);
       expect(savedLayout.drawer.depth).toBe(14);
     });
@@ -181,7 +185,7 @@ describe('useAutoSave', () => {
       });
 
       // Save should not have been called
-      expect(storage.saveLayoutByIdAsync).not.toHaveBeenCalled();
+      expect(storage.saveLayoutResult).not.toHaveBeenCalled();
     });
 
     it('does not throw when unmounted after save completed', async () => {
@@ -193,7 +197,7 @@ describe('useAutoSave', () => {
         await Promise.resolve();
       });
 
-      expect(storage.saveLayoutByIdAsync).toHaveBeenCalledTimes(1);
+      expect(storage.saveLayoutResult).toHaveBeenCalledTimes(1);
 
       // Unmount should not throw
       expect(() => unmount()).not.toThrow();
@@ -201,7 +205,7 @@ describe('useAutoSave', () => {
   });
 
   describe('localStorage integration', () => {
-    it('calls saveLayoutByIdAsync with current layout', async () => {
+    it('calls saveLayoutResult with current layout', async () => {
       const layout = useLayoutStore.getState().layout;
       renderHook(() => useAutoSave());
 
@@ -210,7 +214,7 @@ describe('useAutoSave', () => {
         await Promise.resolve();
       });
 
-      expect(storage.saveLayoutByIdAsync).toHaveBeenCalledWith(TEST_LAYOUT_ID, layout);
+      expect(storage.saveLayoutResult).toHaveBeenCalledWith(TEST_LAYOUT_ID, layout);
     });
 
     it('saves updated layout after modification', async () => {
@@ -237,7 +241,7 @@ describe('useAutoSave', () => {
         await Promise.resolve();
       });
 
-      const savedLayout = (storage.saveLayoutByIdAsync as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      const savedLayout = (storage.saveLayoutResult as ReturnType<typeof vi.fn>).mock.calls[0][1];
       expect(savedLayout.bins.length).toBeGreaterThan(0);
       expect(savedLayout.bins[0].label).toBe('Test');
     });
@@ -254,7 +258,7 @@ describe('useAutoSave', () => {
       });
 
       // Should not have called save
-      expect(storage.saveLayoutByIdAsync).not.toHaveBeenCalled();
+      expect(storage.saveLayoutResult).not.toHaveBeenCalled();
     });
 
     it('does not save when activeLayoutId is __shared_preview__', async () => {
@@ -269,32 +273,35 @@ describe('useAutoSave', () => {
       });
 
       // Should not have called save for temporary shared preview
-      expect(storage.saveLayoutByIdAsync).not.toHaveBeenCalled();
+      expect(storage.saveLayoutResult).not.toHaveBeenCalled();
     });
   });
 
   describe('error handling', () => {
-    it('shows error toast when save fails', async () => {
-      vi.mocked(storage.saveLayoutByIdAsync).mockRejectedValue(
-        new Error('Storage full. Export your layout to save it.')
+    it('shows error toast when save fails with quota exceeded', async () => {
+      // Return an Err result with quota exceeded error
+      vi.mocked(storage.saveLayoutResult).mockResolvedValue(
+        err(storageQuotaExceeded())
       );
 
       renderHook(() => useAutoSave());
 
       await act(async () => {
         timerUtils.advanceTime(SAVE_DEBOUNCE_MS);
-        // Allow async rejection to propagate
         await Promise.resolve();
       });
 
       const toasts = useToastStore.getState().toasts;
       expect(toasts).toHaveLength(1);
       expect(toasts[0].type).toBe('error');
-      expect(toasts[0].message).toBe('Storage full. Export your layout to save it.');
+      // The message comes from getUserMessage which reads from ERROR_CATALOG
+      expect(toasts[0].message).toContain('Storage');
     });
 
-    it('shows generic error message for non-Error exceptions', async () => {
-      vi.mocked(storage.saveLayoutByIdAsync).mockRejectedValue('string error');
+    it('shows error toast when save fails with storage unavailable', async () => {
+      vi.mocked(storage.saveLayoutResult).mockResolvedValue(
+        err(storageUnavailable('indexedDB'))
+      );
 
       renderHook(() => useAutoSave());
 
@@ -305,12 +312,12 @@ describe('useAutoSave', () => {
 
       const toasts = useToastStore.getState().toasts;
       expect(toasts).toHaveLength(1);
-      expect(toasts[0].message).toBe('Failed to save layout');
+      expect(toasts[0].type).toBe('error');
     });
 
     it('only shows error toast once per failure session', async () => {
-      vi.mocked(storage.saveLayoutByIdAsync).mockRejectedValue(
-        new Error('Storage full')
+      vi.mocked(storage.saveLayoutResult).mockResolvedValue(
+        err(storageQuotaExceeded())
       );
 
       renderHook(() => useAutoSave());
@@ -338,8 +345,8 @@ describe('useAutoSave', () => {
     });
 
     it('shows persistent toast after 3 consecutive failures', async () => {
-      vi.mocked(storage.saveLayoutByIdAsync).mockRejectedValue(
-        new Error('Persistent storage error')
+      vi.mocked(storage.saveLayoutResult).mockResolvedValue(
+        err(storageQuotaExceeded())
       );
 
       renderHook(() => useAutoSave());
@@ -383,10 +390,10 @@ describe('useAutoSave', () => {
     });
 
     it('resets error flag after successful save', async () => {
-      const saveLayoutByIdAsyncMock = vi.mocked(storage.saveLayoutByIdAsync);
+      const saveLayoutResultMock = vi.mocked(storage.saveLayoutResult);
 
       // First call fails
-      saveLayoutByIdAsyncMock.mockRejectedValueOnce(new Error('Storage full'));
+      saveLayoutResultMock.mockResolvedValueOnce(err(storageQuotaExceeded()));
 
       renderHook(() => useAutoSave());
 
@@ -401,8 +408,8 @@ describe('useAutoSave', () => {
       // Clear toasts for clean test
       useToastStore.setState({ toasts: [] });
 
-      // Next save succeeds (default mock)
-      saveLayoutByIdAsyncMock.mockResolvedValue(undefined);
+      // Next save succeeds
+      saveLayoutResultMock.mockResolvedValue(ok(undefined));
 
       act(() => {
         useLayoutStore.getState().updateDrawer({ width: 12, depth: 10 });
@@ -417,7 +424,7 @@ describe('useAutoSave', () => {
       expect(useToastStore.getState().toasts).toHaveLength(0);
 
       // Make it fail again
-      saveLayoutByIdAsyncMock.mockRejectedValue(new Error('Storage full again'));
+      saveLayoutResultMock.mockResolvedValue(err(storageQuotaExceeded()));
 
       act(() => {
         useLayoutStore.getState().updateDrawer({ width: 14, depth: 12 });
@@ -430,7 +437,6 @@ describe('useAutoSave', () => {
 
       // Should show error toast again (flag was reset)
       expect(useToastStore.getState().toasts).toHaveLength(1);
-      expect(useToastStore.getState().toasts[0].message).toBe('Storage full again');
     });
   });
 
@@ -445,7 +451,7 @@ describe('useAutoSave', () => {
       });
 
       // Both instances should trigger save
-      expect(storage.saveLayoutByIdAsync).toHaveBeenCalledTimes(2);
+      expect(storage.saveLayoutResult).toHaveBeenCalledTimes(2);
 
       unmount1();
       unmount2();

--- a/src/test/storage-result.test.ts
+++ b/src/test/storage-result.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Tests for Result-based storage functions.
+ *
+ * These tests verify the new Result<T, StorageError> returning functions
+ * in the storage layer, ensuring they properly map errors to domain types.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  saveLayoutResult,
+  loadLayoutResult,
+  deleteLayoutResult,
+  saveLibraryResult,
+  getLayoutStorageKey,
+} from '../storage';
+import { createDefaultLayout } from '../constants';
+import {
+  isOk,
+  isErr,
+  getUserMessage,
+  isRetryable,
+} from '../result';
+import type { Layout, LayoutLibrary } from '../types';
+
+// Mock the backend module
+vi.mock('../storage/backend', () => ({
+  saveAsync: vi.fn(),
+  loadAsync: vi.fn(),
+  deleteAsync: vi.fn(),
+  saveSyncGeneric: vi.fn(),
+  loadSyncGeneric: vi.fn(),
+}));
+
+// Import the mocked backend
+import * as backend from '../storage/backend';
+
+describe('Result-based storage functions', () => {
+  let defaultLayout: Layout;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    defaultLayout = createDefaultLayout();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('saveLayoutResult', () => {
+    it('returns Ok on successful save', async () => {
+      vi.mocked(backend.saveAsync).mockResolvedValue(undefined);
+
+      const result = await saveLayoutResult('test-id', defaultLayout);
+
+      expect(isOk(result)).toBe(true);
+      expect(backend.saveAsync).toHaveBeenCalledWith(
+        getLayoutStorageKey('test-id'),
+        defaultLayout
+      );
+    });
+
+    it('returns Err with quota exceeded error', async () => {
+      vi.mocked(backend.saveAsync).mockRejectedValue(
+        new Error('QuotaExceededError: Storage full')
+      );
+
+      const result = await saveLayoutResult('test-id', defaultLayout);
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('STORAGE_QUOTA_EXCEEDED');
+        expect(result.error.kind).toBe('StorageError');
+        // Verify it has user message
+        expect(getUserMessage(result.error)).toBeTruthy();
+      }
+    });
+
+    it('returns Err with unavailable error for generic failures', async () => {
+      vi.mocked(backend.saveAsync).mockRejectedValue(
+        new Error('Unknown storage error')
+      );
+
+      const result = await saveLayoutResult('test-id', defaultLayout);
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('STORAGE_UNAVAILABLE');
+      }
+    });
+
+    it('preserves original error as cause', async () => {
+      const originalError = new Error('Original error');
+      vi.mocked(backend.saveAsync).mockRejectedValue(originalError);
+
+      const result = await saveLayoutResult('test-id', defaultLayout);
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.cause).toBe(originalError);
+      }
+    });
+  });
+
+  describe('loadLayoutResult', () => {
+    it('returns Ok with layout on successful load', async () => {
+      vi.mocked(backend.loadAsync).mockResolvedValue(defaultLayout);
+
+      const result = await loadLayoutResult('test-id');
+
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        expect(result.value.name).toBe(defaultLayout.name);
+      }
+    });
+
+    it('returns Err with not found error when layout does not exist', async () => {
+      vi.mocked(backend.loadAsync).mockResolvedValue(null);
+
+      const result = await loadLayoutResult('missing-id');
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('STORAGE_NOT_FOUND');
+        expect(result.error.kind).toBe('StorageError');
+        // Verify the key is preserved in the error
+        if ('key' in result.error) {
+          expect(result.error.key).toBe(getLayoutStorageKey('missing-id'));
+        }
+      }
+    });
+
+    it('returns Err with corrupted error for invalid layout data', async () => {
+      // Return data that will fail validation
+      vi.mocked(backend.loadAsync).mockResolvedValue({
+        invalid: 'structure',
+        missing: 'required fields',
+      } as unknown as Layout);
+
+      const result = await loadLayoutResult('corrupted-id');
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('STORAGE_CORRUPTED');
+        // Verify validation errors are included
+        if ('validationErrors' in result.error) {
+          expect(result.error.validationErrors).toBeDefined();
+        }
+      }
+    });
+
+    it('returns Err with unavailable error on backend failure', async () => {
+      vi.mocked(backend.loadAsync).mockRejectedValue(
+        new Error('SecurityError: Storage access denied')
+      );
+
+      const result = await loadLayoutResult('test-id');
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('STORAGE_UNAVAILABLE');
+      }
+    });
+
+    it('migrates old layout format and returns Ok', async () => {
+      // Layout without new fields that need migration
+      const oldLayout = {
+        ...defaultLayout,
+        maxPrintSize: 6, // Old format used grid units
+      };
+      // Remove new fields to simulate old format
+      delete (oldLayout as Record<string, unknown>).printBedSize;
+      delete (oldLayout as Record<string, unknown>).gridUnitMm;
+      delete (oldLayout as Record<string, unknown>).heightUnitMm;
+
+      vi.mocked(backend.loadAsync).mockResolvedValue(oldLayout as Layout);
+
+      const result = await loadLayoutResult('old-layout');
+
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        // Migration should have added default values
+        expect(result.value.gridUnitMm).toBe(42);
+        expect(result.value.heightUnitMm).toBe(7);
+        // And converted maxPrintSize to printBedSize
+        expect(result.value.printBedSize).toBe(252); // 6 * 42
+      }
+    });
+  });
+
+  describe('deleteLayoutResult', () => {
+    it('returns Ok on successful delete', async () => {
+      vi.mocked(backend.deleteAsync).mockResolvedValue(undefined);
+
+      const result = await deleteLayoutResult('test-id');
+
+      expect(isOk(result)).toBe(true);
+      expect(backend.deleteAsync).toHaveBeenCalledWith(
+        getLayoutStorageKey('test-id')
+      );
+    });
+
+    it('returns Ok even when layout does not exist', async () => {
+      // Delete should succeed even if key doesn't exist
+      vi.mocked(backend.deleteAsync).mockResolvedValue(undefined);
+
+      const result = await deleteLayoutResult('non-existent');
+
+      expect(isOk(result)).toBe(true);
+    });
+
+    it('returns Err with unavailable error on backend failure', async () => {
+      vi.mocked(backend.deleteAsync).mockRejectedValue(
+        new Error('Storage error')
+      );
+
+      const result = await deleteLayoutResult('test-id');
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('STORAGE_UNAVAILABLE');
+      }
+    });
+  });
+
+  describe('saveLibraryResult', () => {
+    const testLibrary: LayoutLibrary = {
+      version: '1.0',
+      activeLayoutId: 'test-id',
+      settings: {},
+      entries: [],
+    };
+
+    it('returns Ok on successful save', () => {
+      vi.mocked(backend.saveSyncGeneric).mockImplementation(() => {
+        // Success - no throw
+      });
+
+      const result = saveLibraryResult(testLibrary);
+
+      expect(isOk(result)).toBe(true);
+    });
+
+    it('returns Err with quota exceeded error', () => {
+      vi.mocked(backend.saveSyncGeneric).mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+
+      const result = saveLibraryResult(testLibrary);
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('STORAGE_QUOTA_EXCEEDED');
+      }
+    });
+
+    it('returns Err with unavailable error for generic failures', () => {
+      vi.mocked(backend.saveSyncGeneric).mockImplementation(() => {
+        throw new Error('Unknown error');
+      });
+
+      const result = saveLibraryResult(testLibrary);
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('STORAGE_UNAVAILABLE');
+        // For localStorage errors, backend should be localStorage
+        if ('backend' in result.error) {
+          expect(result.error.backend).toBe('localStorage');
+        }
+      }
+    });
+  });
+
+  describe('error properties', () => {
+    it('storage errors have timestamp', async () => {
+      vi.mocked(backend.loadAsync).mockResolvedValue(null);
+
+      const result = await loadLayoutResult('test-id');
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.timestamp).toBeDefined();
+        expect(typeof result.error.timestamp).toBe('number');
+        // Should be recent (within last minute)
+        expect(Date.now() - result.error.timestamp).toBeLessThan(60000);
+      }
+    });
+
+    it('retryable errors are marked correctly', async () => {
+      // Unavailable errors should be retryable
+      vi.mocked(backend.loadAsync).mockRejectedValue(new Error('Temporary failure'));
+
+      const result = await loadLayoutResult('test-id');
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(isRetryable(result.error.code)).toBe(true);
+      }
+    });
+
+    it('not found errors are not retryable', async () => {
+      vi.mocked(backend.loadAsync).mockResolvedValue(null);
+
+      const result = await loadLayoutResult('missing-id');
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(isRetryable(result.error.code)).toBe(false);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add Result-returning versions of storage functions (`saveLayoutResult`, `loadLayoutResult`, `deleteLayoutResult`, `saveLibraryResult`)
- Migrate `useAutoSave` hook from try/catch pattern to Result-based error handling
- Error messages now use centralized error catalog with user-friendly messages

This is Phase 2 of the Result<T, E> error handling migration, building on the foundation from #111.

## Test plan
- [x] 18 new unit tests for Result-based storage functions
- [x] Updated useAutoSave tests for Result-based error handling
- [x] All 2936 tests pass
- [x] Build passes
- [x] ESLint passes

## Migration notes
This is an additive change - existing storage functions remain unchanged for backward compatibility. The `useAutoSave` hook demonstrates the new error handling pattern which can be applied to other consumers incrementally.