### PR TITLE
Reduce layout not found notification noise

### DIFF
--- a/src/hooks/useLayoutRouting.ts
+++ b/src/hooks/useLayoutRouting.ts
@@ -131,13 +131,9 @@ export function useLayoutRouting() {
     navigateToLayout(hashLayoutId, false)
       .then((success) => {
         if (!success) {
-          // Layout not found - show friendly error
-          addToast(
-            'Layout not found. Use the Share button to share layouts with others.',
-            'info',
-            8000
-          );
-          // Update URL to current layout
+          // Layout not found - silently redirect to current layout.
+          // No toast needed: this commonly happens when users bookmark a layout
+          // and later delete it. The URL redirect is sufficient feedback.
           if (activeLayoutId && activeLayoutId !== '__shared_preview__') {
             setLayoutHash(activeLayoutId, false);
           } else {
@@ -152,7 +148,6 @@ export function useLayoutRouting() {
     isLoaded,
     activeLayoutId,
     navigateToLayout,
-    addToast,
   ]);
 
   // Handle browser back/forward navigation

--- a/src/test/hooks/useLayoutRouting.test.ts
+++ b/src/test/hooks/useLayoutRouting.test.ts
@@ -235,21 +235,22 @@ describe('useLayoutRouting', () => {
       expect(storage.loadLayoutByIdAsync).toHaveBeenCalledWith('layout-123');
     });
 
-    it('shows toast when URL layout not found', async () => {
+    it('silently redirects when URL layout not found', async () => {
       vi.mocked(url.parseLayoutIdFromHash).mockReturnValue('nonexistent');
       const addToastSpy = vi.fn();
       useToastStore.setState({ addToast: addToastSpy });
 
       renderHook(() => useLayoutRouting());
 
-      // navigateToLayout is async, so wait for the toast to be called
+      // navigateToLayout is async, so wait for URL redirect to happen
       await vi.waitFor(() => {
-        expect(addToastSpy).toHaveBeenCalledWith(
-          expect.stringContaining('not found'),
-          'info',
-          expect.any(Number)
-        );
+        // Should redirect to current active layout without showing a toast
+        // (bookmarked layouts that were deleted shouldn't show noisy notifications)
+        expect(url.setLayoutHash).toHaveBeenCalledWith('layout-123', false);
       });
+
+      // No toast should be shown for initial load of missing layout
+      expect(addToastSpy).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
When a user bookmarks a layout URL and later deletes that layout, the "layout not found" toast was shown on every visit. This is a common use case that doesn't warrant a notification.

The URL redirect to the current active layout is sufficient feedback. Toast is still shown for back/forward navigation where the user is actively navigating and expects something to happen.