### PR TITLE
feat: add Result-returning layout store operations

### DIFF
--- a/src/store/layout.ts
+++ b/src/store/layout.ts
@@ -6,6 +6,18 @@ import { canPlaceBin, clamp } from '../utils/validation';
 import { fillAllWithSize, fillGaps } from '../utils/fill';
 import { checkLayerReorderCollisions } from '../utils/collision';
 import { useSettingsStore } from './settings';
+import type { Result, LayoutError, ValidationError } from '../result';
+import {
+  ok,
+  err,
+  layoutLayerLimit,
+  layoutLastEntity,
+  layoutInvalidOperation,
+  layoutCategoryLimit,
+  validationOutOfBounds,
+  validationCollision,
+  validationInvalidLayer,
+} from '../result';
 
 /** Source of the last edit to the layout - used to distinguish local edits from remote imports */
 export type EditSource = 'local' | 'remote' | 'init' | null;
@@ -17,25 +29,32 @@ interface LayoutState {
 
   // Bin operations
   addBin: (bin: Omit<Bin, 'id'>) => string | null;
+  addBinResult: (bin: Omit<Bin, 'id'>) => Result<string, ValidationError>;
   updateBin: (id: string, updates: Partial<Bin>) => void;
   deleteBin: (id: string) => void;
   duplicateBin: (id: string) => string | null;
   moveBinToStaging: (id: string) => void;
   moveBinFromStaging: (id: string, layerId: string, x: number, y: number) => boolean;
+  moveBinFromStagingResult: (id: string, layerId: string, x: number, y: number) => Result<void, ValidationError>;
 
   // Layer operations
   addLayer: () => string | null;
+  addLayerResult: () => Result<string, LayoutError>;
   updateLayer: (id: string, updates: Partial<Layer>) => void;
   deleteLayer: (id: string) => boolean;
+  deleteLayerResult: (id: string) => Result<void, LayoutError>;
   reorderLayers: (fromIndex: number, toIndex: number) => { success: boolean; error?: string };
+  reorderLayersResult: (fromIndex: number, toIndex: number) => Result<void, LayoutError>;
 
   // Drawer operations
   updateDrawer: (updates: Partial<Drawer>) => void;
 
   // Category operations
   addCategory: (category: Omit<Category, 'id'>) => string;
+  addCategoryResult: (category: Omit<Category, 'id'>) => Result<string, LayoutError>;
   updateCategory: (id: string, updates: Partial<Category>) => void;
   deleteCategory: (id: string) => boolean;
+  deleteCategoryResult: (id: string) => Result<void, LayoutError>;
 
   // Bulk operations
   fillLayer: (layerId: string, width: number, depth: number, categoryId: string, halfBinMode?: boolean) => number;
@@ -83,6 +102,44 @@ export const useLayoutStore = create<LayoutState>()(
       });
 
       return id;
+    },
+
+    addBinResult: (binData) => {
+      const { layout } = get();
+      const id = generateId();
+      const bin: Bin = { ...binData, id };
+
+      if (bin.layerId !== STAGING_ID) {
+        const layer = layout.layers.find(l => l.id === bin.layerId);
+        if (!layer) {
+          return err(validationInvalidLayer(bin.layerId));
+        }
+
+        const validationResult = canPlaceBin(
+          { x: bin.x, y: bin.y, width: bin.width, depth: bin.depth, height: bin.height },
+          bin.layerId,
+          layout
+        );
+        if (!validationResult.valid) {
+          const reason = validationResult.reason ?? 'out_of_bounds';
+          if (reason === 'collision') {
+            return err(validationCollision());
+          }
+          return err(validationOutOfBounds(reason, {
+            x: bin.x,
+            y: bin.y,
+            width: bin.width,
+            depth: bin.depth,
+          }));
+        }
+      }
+
+      set(state => {
+        state.layout.bins.push(bin);
+        state.lastEditSource = 'local';
+      });
+
+      return ok(id);
     },
 
     updateBin: (id, updates) => {
@@ -213,6 +270,52 @@ export const useLayoutStore = create<LayoutState>()(
       return true;
     },
 
+    moveBinFromStagingResult: (id, layerId, x, y) => {
+      const { layout } = get();
+      const bin = layout.bins.find(b => b.id === id);
+      if (!bin) {
+        return err(validationOutOfBounds('out_of_bounds', { x, y, width: 0, depth: 0 }));
+      }
+
+      const layer = layout.layers.find(l => l.id === layerId);
+      if (!layer) {
+        return err(validationInvalidLayer(layerId));
+      }
+
+      const validationResult = canPlaceBin(
+        { x, y, width: bin.width, depth: bin.depth, height: layer.height },
+        layerId,
+        layout,
+        id
+      );
+
+      if (!validationResult.valid) {
+        const reason = validationResult.reason ?? 'out_of_bounds';
+        if (reason === 'collision') {
+          return err(validationCollision());
+        }
+        return err(validationOutOfBounds(reason, {
+          x,
+          y,
+          width: bin.width,
+          depth: bin.depth,
+        }));
+      }
+
+      set(state => {
+        const b = state.layout.bins.find(b => b.id === id);
+        if (b) {
+          b.layerId = layerId;
+          b.x = x;
+          b.y = y;
+          b.height = layer.height;
+          state.lastEditSource = 'local';
+        }
+      });
+
+      return ok(undefined);
+    },
+
     addLayer: () => {
       const { layout } = get();
       if (layout.layers.length >= CONSTRAINTS.LAYERS_MAX) return null;
@@ -237,6 +340,36 @@ export const useLayoutStore = create<LayoutState>()(
       });
 
       return id;
+    },
+
+    addLayerResult: () => {
+      const { layout } = get();
+      if (layout.layers.length >= CONSTRAINTS.LAYERS_MAX) {
+        return err(layoutLayerLimit(layout.layers.length, CONSTRAINTS.LAYERS_MAX));
+      }
+
+      const totalHeight = layout.layers.reduce((sum, l) => sum + l.height, 0);
+      const remaining = layout.drawer.height - totalHeight;
+      if (remaining < 1) {
+        return err(layoutInvalidOperation('addLayer', 'No remaining height in drawer'));
+      }
+
+      // Get default layer height from settings
+      const defaultLayerHeight = useSettingsStore.getState().settings.defaultLayerHeight;
+
+      const id = generateId();
+      const newLayer: Layer = {
+        id,
+        name: `Layer ${layout.layers.length + 1}`,
+        height: Math.min(remaining, defaultLayerHeight),
+      };
+
+      set(state => {
+        state.layout.layers.push(newLayer);
+        state.lastEditSource = 'local';
+      });
+
+      return ok(id);
     },
 
     updateLayer: (id, updates) => {
@@ -269,6 +402,26 @@ export const useLayoutStore = create<LayoutState>()(
       return true;
     },
 
+    deleteLayerResult: (id) => {
+      const { layout } = get();
+      if (layout.layers.length <= CONSTRAINTS.LAYERS_MIN) {
+        return err(layoutLastEntity('layer'));
+      }
+
+      const layer = layout.layers.find(l => l.id === id);
+      if (!layer) {
+        return err(layoutInvalidOperation('deleteLayer', `Layer ${id} not found`));
+      }
+
+      set(state => {
+        state.layout.layers = state.layout.layers.filter(l => l.id !== id);
+        state.layout.bins = state.layout.bins.filter(b => b.layerId !== id);
+        state.lastEditSource = 'local';
+      });
+
+      return ok(undefined);
+    },
+
     reorderLayers: (fromIndex, toIndex) => {
       const { layout } = get();
 
@@ -294,6 +447,37 @@ export const useLayoutStore = create<LayoutState>()(
       });
 
       return { success: true };
+    },
+
+    reorderLayersResult: (fromIndex, toIndex) => {
+      const { layout } = get();
+
+      if (fromIndex === toIndex) return ok(undefined);
+      if (fromIndex < 0 || fromIndex >= layout.layers.length) {
+        return err(layoutInvalidOperation('reorderLayers', 'Invalid source index'));
+      }
+      if (toIndex < 0 || toIndex >= layout.layers.length) {
+        return err(layoutInvalidOperation('reorderLayers', 'Invalid target index'));
+      }
+
+      const newLayers = [...layout.layers];
+      const [moved] = newLayers.splice(fromIndex, 1);
+      newLayers.splice(toIndex, 0, moved);
+
+      const collisions = checkLayerReorderCollisions(layout.bins, layout.layers, newLayers);
+      if (collisions.length > 0) {
+        return err(layoutInvalidOperation(
+          'reorderLayers',
+          `Reordering would cause ${collisions.length} bin collision${collisions.length > 1 ? 's' : ''}`
+        ));
+      }
+
+      set(state => {
+        state.layout.layers = newLayers;
+        state.lastEditSource = 'local';
+      });
+
+      return ok(undefined);
     },
 
     updateDrawer: (updates) => {
@@ -339,6 +523,20 @@ export const useLayoutStore = create<LayoutState>()(
       return id;
     },
 
+    addCategoryResult: (categoryData) => {
+      const { layout } = get();
+      if (layout.categories.length >= CONSTRAINTS.CATEGORIES_MAX) {
+        return err(layoutCategoryLimit(layout.categories.length, CONSTRAINTS.CATEGORIES_MAX));
+      }
+
+      const id = generateId();
+      set(state => {
+        state.layout.categories.push({ ...categoryData, id });
+        state.lastEditSource = 'local';
+      });
+      return ok(id);
+    },
+
     updateCategory: (id, updates) => {
       set(state => {
         const cat = state.layout.categories.find(c => c.id === id);
@@ -361,6 +559,34 @@ export const useLayoutStore = create<LayoutState>()(
       });
 
       return true;
+    },
+
+    deleteCategoryResult: (id) => {
+      const { layout } = get();
+
+      const binsUsingCategory = layout.bins.filter(b => b.category === id);
+      if (binsUsingCategory.length > 0) {
+        return err(layoutInvalidOperation(
+          'deleteCategory',
+          `Category is in use by ${binsUsingCategory.length} bin${binsUsingCategory.length > 1 ? 's' : ''}`
+        ));
+      }
+
+      if (layout.categories.length <= CONSTRAINTS.CATEGORIES_MIN) {
+        return err(layoutLastEntity('category'));
+      }
+
+      const category = layout.categories.find(c => c.id === id);
+      if (!category) {
+        return err(layoutInvalidOperation('deleteCategory', `Category ${id} not found`));
+      }
+
+      set(state => {
+        state.layout.categories = state.layout.categories.filter(c => c.id !== id);
+        state.lastEditSource = 'local';
+      });
+
+      return ok(undefined);
     },
 
     fillLayer: (layerId, width, depth, categoryId, halfBinMode = false) => {

--- a/src/test/store/layout.test.ts
+++ b/src/test/store/layout.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useLayoutStore } from '../../store/layout';
 import { useSettingsStore } from '../../store/settings';
-import { createDefaultLayout, STAGING_ID } from '../../constants';
+import { createDefaultLayout, STAGING_ID, CONSTRAINTS } from '../../constants';
 import { resetAllStores } from '../testUtils';
 import type { Layout } from '../../types';
+import { isOk, isErr } from '../../result';
 
 describe('layout store', () => {
   beforeEach(() => {
@@ -1117,6 +1118,480 @@ describe('layout store', () => {
       importLayout(newLayout, 'custom-layout-id');
 
       expect(useLayoutStore.getState().activeLayoutId).toBe('custom-layout-id');
+    });
+  });
+
+  // =========================================================================
+  // Result-returning operations
+  // =========================================================================
+
+  describe('addBinResult', () => {
+    it('returns Ok with bin id on success', () => {
+      const { addBinResult, layout } = useLayoutStore.getState();
+      const layerId = layout.layers[0].id;
+      const categoryId = layout.categories[0].id;
+
+      const result = addBinResult({
+        layerId,
+        x: 0,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: categoryId,
+        label: 'Test bin',
+        notes: '',
+      });
+
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        expect(result.value).toBeDefined();
+        expect(useLayoutStore.getState().layout.bins[0].id).toBe(result.value);
+      }
+    });
+
+    it('returns Err with VALIDATION_OUT_OF_BOUNDS when out of bounds', () => {
+      const { addBinResult, layout } = useLayoutStore.getState();
+      const layerId = layout.layers[0].id;
+      const categoryId = layout.categories[0].id;
+
+      const result = addBinResult({
+        layerId,
+        x: 100,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('VALIDATION_OUT_OF_BOUNDS');
+        expect(result.error.kind).toBe('ValidationError');
+      }
+    });
+
+    it('returns Err with VALIDATION_COLLISION when bin overlaps', () => {
+      const { addBinResult, layout } = useLayoutStore.getState();
+      const layerId = layout.layers[0].id;
+      const categoryId = layout.categories[0].id;
+
+      // Add first bin successfully
+      addBinResult({
+        layerId,
+        x: 0,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      // Try to add overlapping bin
+      const result = addBinResult({
+        layerId,
+        x: 1,
+        y: 1,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('VALIDATION_COLLISION');
+      }
+    });
+
+    it('returns Err with VALIDATION_INVALID_LAYER for nonexistent layer', () => {
+      const { addBinResult, layout } = useLayoutStore.getState();
+      const categoryId = layout.categories[0].id;
+
+      const result = addBinResult({
+        layerId: 'nonexistent-layer',
+        x: 0,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('VALIDATION_INVALID_LAYER');
+      }
+    });
+
+    it('allows adding to staging without validation', () => {
+      const { addBinResult, layout } = useLayoutStore.getState();
+      const categoryId = layout.categories[0].id;
+
+      const result = addBinResult({
+        layerId: STAGING_ID,
+        x: 0,
+        y: 0,
+        width: 100, // Would fail validation on grid
+        depth: 100,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      expect(isOk(result)).toBe(true);
+    });
+  });
+
+  describe('moveBinFromStagingResult', () => {
+    it('returns Ok on successful move', () => {
+      const { addBin, moveBinFromStagingResult, layout } = useLayoutStore.getState();
+      const layerId = layout.layers[0].id;
+      const categoryId = layout.categories[0].id;
+
+      const binId = addBin({
+        layerId: STAGING_ID,
+        x: 0,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      const result = moveBinFromStagingResult(binId!, layerId, 0, 0);
+      expect(isOk(result)).toBe(true);
+
+      const bin = useLayoutStore.getState().layout.bins[0];
+      expect(bin.layerId).toBe(layerId);
+    });
+
+    it('returns Err with VALIDATION_INVALID_LAYER for nonexistent layer', () => {
+      const { addBin, moveBinFromStagingResult, layout } = useLayoutStore.getState();
+      const categoryId = layout.categories[0].id;
+
+      const binId = addBin({
+        layerId: STAGING_ID,
+        x: 0,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      const result = moveBinFromStagingResult(binId!, 'nonexistent-layer', 0, 0);
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('VALIDATION_INVALID_LAYER');
+      }
+    });
+
+    it('returns Err with VALIDATION_COLLISION when position is occupied', () => {
+      const { addBin, moveBinFromStagingResult, layout } = useLayoutStore.getState();
+      const layerId = layout.layers[0].id;
+      const categoryId = layout.categories[0].id;
+
+      // Add existing bin at position
+      addBin({
+        layerId,
+        x: 0,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      // Add bin to staging
+      const stagingBinId = addBin({
+        layerId: STAGING_ID,
+        x: 0,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      const result = moveBinFromStagingResult(stagingBinId!, layerId, 0, 0);
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('VALIDATION_COLLISION');
+      }
+    });
+  });
+
+  describe('addLayerResult', () => {
+    it('returns Ok with layer id on success', () => {
+      const { addLayerResult } = useLayoutStore.getState();
+
+      const result = addLayerResult();
+
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        expect(result.value).toBeDefined();
+        expect(useLayoutStore.getState().layout.layers).toHaveLength(2);
+      }
+    });
+
+    it('returns Err with LAYOUT_LAYER_LIMIT when at max layers', () => {
+      const { addLayerResult, addLayer, updateDrawer } = useLayoutStore.getState();
+
+      // Increase drawer height to ensure we don't run out of height before layers
+      updateDrawer({ height: 50 });
+
+      // Add layers until max (minus 1 for existing layer)
+      for (let i = 0; i < CONSTRAINTS.LAYERS_MAX - 1; i++) {
+        addLayer();
+      }
+
+      const result = addLayerResult();
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('LAYOUT_LAYER_LIMIT');
+        expect(result.error.kind).toBe('LayoutError');
+        if ('currentCount' in result.error) {
+          expect(result.error.currentCount).toBe(CONSTRAINTS.LAYERS_MAX);
+          expect(result.error.maxCount).toBe(CONSTRAINTS.LAYERS_MAX);
+        }
+      }
+    });
+
+    it('returns Err with LAYOUT_INVALID_OPERATION when no height remaining', () => {
+      const { addLayerResult, updateDrawer, updateLayer, layout } = useLayoutStore.getState();
+
+      // Set drawer height to match first layer height (no room for more)
+      updateLayer(layout.layers[0].id, { height: 12 });
+      updateDrawer({ height: 12 });
+
+      // First layer now takes all height
+      const result = addLayerResult();
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('LAYOUT_INVALID_OPERATION');
+      }
+    });
+  });
+
+  describe('deleteLayerResult', () => {
+    it('returns Ok on successful deletion', () => {
+      const { addLayer, deleteLayerResult } = useLayoutStore.getState();
+
+      // Add second layer first
+      const layer2Id = addLayer()!;
+
+      const result = deleteLayerResult(layer2Id);
+
+      expect(isOk(result)).toBe(true);
+      expect(useLayoutStore.getState().layout.layers).toHaveLength(1);
+    });
+
+    it('returns Err with LAYOUT_LAST_ENTITY when deleting last layer', () => {
+      const { deleteLayerResult, layout } = useLayoutStore.getState();
+      const layerId = layout.layers[0].id;
+
+      const result = deleteLayerResult(layerId);
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('LAYOUT_LAST_ENTITY');
+        expect(result.error.kind).toBe('LayoutError');
+        if ('entityType' in result.error) {
+          expect(result.error.entityType).toBe('layer');
+        }
+      }
+    });
+
+    it('returns Err with LAYOUT_INVALID_OPERATION for nonexistent layer', () => {
+      const { addLayer, deleteLayerResult } = useLayoutStore.getState();
+
+      // Add second layer so we're not hitting last entity error
+      addLayer();
+
+      const result = deleteLayerResult('nonexistent-layer');
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('LAYOUT_INVALID_OPERATION');
+      }
+    });
+  });
+
+  describe('reorderLayersResult', () => {
+    it('returns Ok on successful reorder', () => {
+      const { addLayer, reorderLayersResult } = useLayoutStore.getState();
+
+      addLayer();
+
+      const layer1Id = useLayoutStore.getState().layout.layers[0].id;
+      const layer2Id = useLayoutStore.getState().layout.layers[1].id;
+
+      const result = reorderLayersResult(0, 1);
+
+      expect(isOk(result)).toBe(true);
+      const layers = useLayoutStore.getState().layout.layers;
+      expect(layers[0].id).toBe(layer2Id);
+      expect(layers[1].id).toBe(layer1Id);
+    });
+
+    it('returns Ok for same index', () => {
+      const result = useLayoutStore.getState().reorderLayersResult(0, 0);
+      expect(isOk(result)).toBe(true);
+    });
+
+    it('returns Err with LAYOUT_INVALID_OPERATION for invalid source index', () => {
+      const result = useLayoutStore.getState().reorderLayersResult(-1, 0);
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('LAYOUT_INVALID_OPERATION');
+        if ('reason' in result.error) {
+          expect(result.error.reason).toContain('source index');
+        }
+      }
+    });
+
+    it('returns Err with LAYOUT_INVALID_OPERATION for invalid target index', () => {
+      const result = useLayoutStore.getState().reorderLayersResult(0, 10);
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('LAYOUT_INVALID_OPERATION');
+        if ('reason' in result.error) {
+          expect(result.error.reason).toContain('target index');
+        }
+      }
+    });
+  });
+
+  describe('addCategoryResult', () => {
+    it('returns Ok with category id on success', () => {
+      const { addCategoryResult } = useLayoutStore.getState();
+
+      const result = addCategoryResult({ name: 'New Cat', color: '#00ff00' });
+
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        expect(result.value).toBeDefined();
+        const cat = useLayoutStore.getState().layout.categories.find(c => c.id === result.value);
+        expect(cat?.name).toBe('New Cat');
+      }
+    });
+
+    it('returns Err with LAYOUT_CATEGORY_LIMIT when at max categories', () => {
+      const { addCategoryResult, addCategory } = useLayoutStore.getState();
+
+      // Add categories until max (minus 1 for existing)
+      for (let i = 0; i < CONSTRAINTS.CATEGORIES_MAX - 1; i++) {
+        addCategory({ name: `Cat ${i}`, color: '#000000' });
+      }
+
+      const result = addCategoryResult({ name: 'One Too Many', color: '#ff0000' });
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('LAYOUT_CATEGORY_LIMIT');
+        expect(result.error.kind).toBe('LayoutError');
+      }
+    });
+  });
+
+  describe('deleteCategoryResult', () => {
+    it('returns Ok on successful deletion', () => {
+      const { addCategory, deleteCategoryResult } = useLayoutStore.getState();
+
+      const catId = addCategory({ name: 'To Delete', color: '#ff0000' });
+      const result = deleteCategoryResult(catId);
+
+      expect(isOk(result)).toBe(true);
+      expect(useLayoutStore.getState().layout.categories.find(c => c.id === catId)).toBeUndefined();
+    });
+
+    it('returns Err with LAYOUT_INVALID_OPERATION when category is in use', () => {
+      const { addBin, deleteCategoryResult, layout } = useLayoutStore.getState();
+      const layerId = layout.layers[0].id;
+      const categoryId = layout.categories[0].id;
+
+      addBin({
+        layerId,
+        x: 0,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: categoryId,
+        label: '',
+        notes: '',
+      });
+
+      const result = deleteCategoryResult(categoryId);
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('LAYOUT_INVALID_OPERATION');
+        if ('reason' in result.error) {
+          expect(result.error.reason).toContain('in use');
+        }
+      }
+    });
+
+    it('returns Err with LAYOUT_LAST_ENTITY when deleting last category', () => {
+      const { deleteCategoryResult, deleteCategory, layout } = useLayoutStore.getState();
+
+      // Default layout has 5 categories, delete 4 to get to 1
+      const categories = layout.categories;
+      for (let i = 1; i < categories.length; i++) {
+        deleteCategory(categories[i].id);
+      }
+
+      // Now try to delete the last one
+      const lastCategoryId = useLayoutStore.getState().layout.categories[0].id;
+      const result = deleteCategoryResult(lastCategoryId);
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('LAYOUT_LAST_ENTITY');
+        if ('entityType' in result.error) {
+          expect(result.error.entityType).toBe('category');
+        }
+      }
+    });
+
+    it('returns Err with LAYOUT_INVALID_OPERATION for nonexistent category', () => {
+      const { addCategory, deleteCategoryResult } = useLayoutStore.getState();
+
+      // Add second category so we're not hitting last entity error
+      addCategory({ name: 'Extra', color: '#000000' });
+
+      const result = deleteCategoryResult('nonexistent-category');
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('LAYOUT_INVALID_OPERATION');
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
Phase 5 of the `Result<T, E>` migration adds type-safe Result-returning operations to the layout store.

- Add `*Result` suffix variants for layout store operations
- Each variant returns `Result<T, LayoutError | ValidationError>` with rich error metadata
- Existing operations remain unchanged for backwards compatibility
- Added 24 new tests for Result-returning operations

### New Operations

| Operation | Return Type | Error Types |
|-----------|-------------|-------------|
| `addBinResult` | `Result<string, ValidationError>` | OUT_OF_BOUNDS, COLLISION, INVALID_LAYER |
| `moveBinFromStagingResult` | `Result<void, ValidationError>` | OUT_OF_BOUNDS, COLLISION, INVALID_LAYER |
| `addLayerResult` | `Result<string, LayoutError>` | LAYER_LIMIT, INVALID_OPERATION |
| `deleteLayerResult` | `Result<void, LayoutError>` | LAST_ENTITY, INVALID_OPERATION |
| `reorderLayersResult` | `Result<void, LayoutError>` | INVALID_OPERATION |
| `addCategoryResult` | `Result<string, LayoutError>` | CATEGORY_LIMIT |
| `deleteCategoryResult` | `Result<void, LayoutError>` | LAST_ENTITY, INVALID_OPERATION |

## Test plan
- [x] All 2989 tests pass
- [x] Coverage thresholds met (86% lines, 75% branches)
- [x] Pre-commit hooks pass (lint, build, coverage)
- [x] 24 new tests for Result-returning operations