### PR TITLE
feat: add Result-returning validation functions

### DIFF
--- a/src/test/validation.test.ts
+++ b/src/test/validation.test.ts
@@ -1,7 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { canPlaceBin, validateImport, clamp, truncate, validateLayoutIntegrity, validateCustomProperties } from '../utils/validation';
+import {
+  canPlaceBin,
+  canPlaceBinResult,
+  validateImport,
+  validateImportResult,
+  clamp,
+  truncate,
+  validateLayoutIntegrity,
+  validateLayoutIntegrityResult,
+  validateCustomProperties,
+  validateCustomPropertiesResult,
+} from '../utils/validation';
 import { CONSTRAINTS } from '../constants';
 import type { Layout } from '../types';
+import { isOk, isErr } from '../result';
 
 const createTestLayout = (): Layout => ({
   version: '1.0',
@@ -618,5 +630,311 @@ describe('validateCustomProperties', () => {
     const maxValue = 'a'.repeat(CONSTRAINTS.CUSTOM_PROPERTY_VALUE_MAX_LENGTH);
     const result = validateCustomProperties({ key: maxValue });
     expect(result.success).toBe(true);
+  });
+});
+
+// =============================================================================
+// Result-returning validation functions
+// =============================================================================
+
+describe('canPlaceBinResult', () => {
+  it('returns Ok for valid placement', () => {
+    const layout = createTestLayout();
+    const result = canPlaceBinResult(
+      { x: 0, y: 0, width: 2, depth: 2, height: 3 },
+      'layer1',
+      layout
+    );
+    expect(isOk(result)).toBe(true);
+  });
+
+  it('returns Err with VALIDATION_OUT_OF_BOUNDS for negative coordinates', () => {
+    const layout = createTestLayout();
+    const result = canPlaceBinResult(
+      { x: -1, y: 0, width: 2, depth: 2, height: 3 },
+      'layer1',
+      layout
+    );
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_OUT_OF_BOUNDS');
+      expect(result.error.kind).toBe('ValidationError');
+      if ('reason' in result.error) {
+        expect(result.error.reason).toBe('out_of_bounds');
+      }
+    }
+  });
+
+  it('returns Err with VALIDATION_OUT_OF_BOUNDS for exceeds_width', () => {
+    const layout = createTestLayout();
+    const result = canPlaceBinResult(
+      { x: 9, y: 0, width: 2, depth: 2, height: 3 },
+      'layer1',
+      layout
+    );
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_OUT_OF_BOUNDS');
+      if ('reason' in result.error) {
+        expect(result.error.reason).toBe('exceeds_width');
+      }
+    }
+  });
+
+  it('returns Err with VALIDATION_OUT_OF_BOUNDS for exceeds_depth', () => {
+    const layout = createTestLayout();
+    const result = canPlaceBinResult(
+      { x: 0, y: 9, width: 2, depth: 2, height: 3 },
+      'layer1',
+      layout
+    );
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_OUT_OF_BOUNDS');
+      if ('reason' in result.error) {
+        expect(result.error.reason).toBe('exceeds_depth');
+      }
+    }
+  });
+
+  it('returns Err with VALIDATION_INVALID_LAYER for nonexistent layer', () => {
+    const layout = createTestLayout();
+    const result = canPlaceBinResult(
+      { x: 0, y: 0, width: 2, depth: 2, height: 3 },
+      'nonexistent-layer',
+      layout
+    );
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_INVALID_LAYER');
+      if ('layerId' in result.error) {
+        expect(result.error.layerId).toBe('nonexistent-layer');
+      }
+    }
+  });
+
+  it('returns Err with VALIDATION_HEIGHT_EXCEEDED for height exceeding drawer', () => {
+    const layout = createTestLayout();
+    const result = canPlaceBinResult(
+      { x: 0, y: 0, width: 2, depth: 2, height: 20 },
+      'layer1',
+      layout
+    );
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_HEIGHT_EXCEEDED');
+    }
+  });
+
+  it('returns Err with VALIDATION_COLLISION with colliding bin IDs', () => {
+    const layout = createTestLayout();
+    layout.bins = [
+      { id: 'existing-bin', layerId: 'layer1', x: 0, y: 0, width: 3, depth: 3, height: 3, category: 'cat1', label: '', notes: '' },
+    ];
+    const result = canPlaceBinResult(
+      { x: 1, y: 1, width: 2, depth: 2, height: 3 },
+      'layer1',
+      layout
+    );
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_COLLISION');
+      if ('collidingBinIds' in result.error) {
+        expect(result.error.collidingBinIds).toContain('existing-bin');
+      }
+    }
+  });
+
+  it('returns Err with VALIDATION_BLOCKED_ZONE for blocked area', () => {
+    const layout = createTestLayout();
+    layout.bins = [
+      // Tall bin on layer 1 that protrudes into layer 2
+      { id: 'tall', layerId: 'layer1', x: 0, y: 0, width: 3, depth: 3, height: 6, category: 'cat1', label: '', notes: '' },
+    ];
+    const result = canPlaceBinResult(
+      { x: 1, y: 1, width: 2, depth: 2, height: 6 },
+      'layer2',
+      layout
+    );
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_BLOCKED_ZONE');
+    }
+  });
+
+  it('excludes specified bin from collision check', () => {
+    const layout = createTestLayout();
+    layout.bins = [
+      { id: 'moving', layerId: 'layer1', x: 0, y: 0, width: 2, depth: 2, height: 3, category: 'cat1', label: '', notes: '' },
+    ];
+    const result = canPlaceBinResult(
+      { x: 1, y: 1, width: 2, depth: 2, height: 3 },
+      'layer1',
+      layout,
+      'moving'
+    );
+    expect(isOk(result)).toBe(true);
+  });
+
+  it('excludes set of bin IDs from collision check', () => {
+    const layout = createTestLayout();
+    layout.bins = [
+      { id: 'bin1', layerId: 'layer1', x: 0, y: 0, width: 2, depth: 2, height: 3, category: 'cat1', label: '', notes: '' },
+      { id: 'bin2', layerId: 'layer1', x: 2, y: 0, width: 2, depth: 2, height: 3, category: 'cat1', label: '', notes: '' },
+    ];
+    const result = canPlaceBinResult(
+      { x: 1, y: 0, width: 2, depth: 2, height: 3 },
+      'layer1',
+      layout,
+      undefined,
+      new Set(['bin1', 'bin2'])
+    );
+    expect(isOk(result)).toBe(true);
+  });
+});
+
+describe('validateImportResult', () => {
+  it('returns Ok for valid layout data', () => {
+    const validLayout = {
+      version: '1.0',
+      name: 'Test Layout',
+      drawer: { width: 10, depth: 10, height: 12 },
+      layers: [{ id: 'l1', name: 'Layer 1', height: 3 }],
+      bins: [],
+      categories: [{ id: 'c1', name: 'Category 1', color: '#ff0000' }],
+    };
+    const result = validateImportResult(validLayout);
+    expect(isOk(result)).toBe(true);
+  });
+
+  it('returns Err with VALIDATION_IMPORT_FAILED for invalid data', () => {
+    const result = validateImportResult(null);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_IMPORT_FAILED');
+      expect(result.error.kind).toBe('ValidationError');
+      if ('errors' in result.error) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('returns Err with detailed errors for multiple issues', () => {
+    const invalidLayout = {
+      version: '1.0',
+      // missing name
+      drawer: { width: 100, depth: -5, height: 12 }, // invalid dimensions
+      layers: [], // empty layers (violates min constraint)
+      bins: [],
+      categories: [],
+    };
+    const result = validateImportResult(invalidLayout);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result) && 'errors' in result.error) {
+      // Should have at least 1 error (missing name is caught first)
+      expect(result.error.errors.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe('validateLayoutIntegrityResult', () => {
+  it('returns Ok for valid layout', () => {
+    const layout = createTestLayout();
+    const result = validateLayoutIntegrityResult(layout);
+    expect(isOk(result)).toBe(true);
+  });
+
+  it('returns Err with VALIDATION_IMPORT_FAILED for missing layer reference', () => {
+    const layout = createTestLayout();
+    layout.bins = [
+      { id: 'bin1', layerId: 'nonexistent', x: 0, y: 0, width: 2, depth: 2, height: 3, category: 'cat1', label: '', notes: '' },
+    ];
+    const result = validateLayoutIntegrityResult(layout);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_IMPORT_FAILED');
+    }
+  });
+
+  it('returns Err with VALIDATION_IMPORT_FAILED for missing category reference', () => {
+    const layout = createTestLayout();
+    layout.bins = [
+      { id: 'bin1', layerId: 'layer1', x: 0, y: 0, width: 2, depth: 2, height: 3, category: 'nonexistent', label: '', notes: '' },
+    ];
+    const result = validateLayoutIntegrityResult(layout);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_IMPORT_FAILED');
+    }
+  });
+
+  it('returns Err with VALIDATION_IMPORT_FAILED for empty layers', () => {
+    const layout = createTestLayout();
+    layout.layers = [];
+    const result = validateLayoutIntegrityResult(layout);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_IMPORT_FAILED');
+      if ('errors' in result.error) {
+        expect(result.error.errors.some(e => e.includes('no layers'))).toBe(true);
+      }
+    }
+  });
+
+  it('returns Err with VALIDATION_IMPORT_FAILED for empty categories', () => {
+    const layout = createTestLayout();
+    layout.categories = [];
+    const result = validateLayoutIntegrityResult(layout);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_IMPORT_FAILED');
+      if ('errors' in result.error) {
+        expect(result.error.errors.some(e => e.includes('no categories'))).toBe(true);
+      }
+    }
+  });
+});
+
+describe('validateCustomPropertiesResult', () => {
+  it('returns Ok for valid custom properties', () => {
+    const result = validateCustomPropertiesResult({ key: 'value', another: 'prop' });
+    expect(isOk(result)).toBe(true);
+  });
+
+  it('returns Ok for empty properties', () => {
+    const result = validateCustomPropertiesResult({});
+    expect(isOk(result)).toBe(true);
+  });
+
+  it('returns Err with VALIDATION_IMPORT_FAILED for too many properties', () => {
+    const props: Record<string, string> = {};
+    for (let i = 0; i <= CONSTRAINTS.CUSTOM_PROPERTY_MAX_COUNT; i++) {
+      props[`key${i}`] = 'value';
+    }
+    const result = validateCustomPropertiesResult(props);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_IMPORT_FAILED');
+    }
+  });
+
+  it('returns Err with VALIDATION_IMPORT_FAILED for key exceeding max length', () => {
+    const longKey = 'a'.repeat(CONSTRAINTS.CUSTOM_PROPERTY_KEY_MAX_LENGTH + 1);
+    const result = validateCustomPropertiesResult({ [longKey]: 'value' });
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_IMPORT_FAILED');
+    }
+  });
+
+  it('returns Err with VALIDATION_IMPORT_FAILED for reserved keys', () => {
+    const result = validateCustomPropertiesResult({ id: 'value' });
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('VALIDATION_IMPORT_FAILED');
+      if ('errors' in result.error) {
+        expect(result.error.errors[0]).toContain('reserved');
+      }
+    }
   });
 });

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,6 +1,17 @@
 import type { Bin, Layout, ValidationResult, Rect, OperationResult } from '../types';
 import { CONSTRAINTS, STAGING_ID, RESERVED_PROPERTY_KEYS } from '../constants';
 import { binsCollide, getLayerZStart, getBlockedZones, isInBlockedZone } from './collision';
+import type { Result, ValidationError } from '../result';
+import {
+  ok,
+  err,
+  validationOutOfBounds,
+  validationCollision,
+  validationInvalidLayer,
+  validationHeightExceeded,
+  validationBlockedZone,
+  validationImportFailed,
+} from '../result';
 
 // ============================================================================
 // Type Guards for Import Validation
@@ -181,6 +192,97 @@ export function canPlaceBin(
 }
 
 /**
+ * Validate if a bin can be placed at the given position.
+ * Returns a Result type with rich error information.
+ *
+ * @param rect - The rectangle to place (x, y, width, depth, height)
+ * @param layerId - The layer to place the bin on
+ * @param layout - The current layout state
+ * @param excludeBinId - Single bin ID to exclude from collision checks
+ * @param excludeBinIds - Set of bin IDs to exclude (for multi-select operations)
+ * @returns Result<void, ValidationError> with specific error type on failure
+ */
+export function canPlaceBinResult(
+  rect: Rect & { height: number; clearanceHeight?: number },
+  layerId: string,
+  layout: Layout,
+  excludeBinId?: string,
+  excludeBinIds?: Set<string>
+): Result<void, ValidationError> {
+  const { drawer, layers, bins } = layout;
+  const binData = { x: rect.x, y: rect.y, width: rect.width, depth: rect.depth };
+
+  // Bounds check
+  if (rect.x < 0 || rect.y < 0) {
+    return err(validationOutOfBounds('out_of_bounds', binData));
+  }
+  if (rect.x + rect.width > drawer.width) {
+    return err(validationOutOfBounds('exceeds_width', binData));
+  }
+  if (rect.y + rect.depth > drawer.depth) {
+    return err(validationOutOfBounds('exceeds_depth', binData));
+  }
+
+  const layer = layers.find(l => l.id === layerId);
+  if (!layer) {
+    return err(validationInvalidLayer(layerId));
+  }
+
+  // Height check
+  const zStart = getLayerZStart(layerId, layers);
+  const maxHeight = drawer.height - zStart;
+  if (rect.height > maxHeight) {
+    return err(validationHeightExceeded(rect.height, maxHeight));
+  }
+  if (rect.height < layer.height) {
+    // Bin must be at least as tall as its base layer
+    return err(validationHeightExceeded(rect.height, layer.height));
+  }
+
+  // Blocked zone check
+  const blockedZones = getBlockedZones(layerId, bins, layers);
+  for (let x = rect.x; x < rect.x + rect.width; x++) {
+    for (let y = rect.y; y < rect.y + rect.depth; y++) {
+      if (isInBlockedZone(x, y, blockedZones)) {
+        return err(validationBlockedZone());
+      }
+    }
+  }
+
+  // Collision check with other bins
+  const testBin: Bin = {
+    id: excludeBinId || '__test__',
+    layerId,
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    depth: rect.depth,
+    height: rect.height,
+    clearanceHeight: rect.clearanceHeight,
+    category: '',
+    label: '',
+    notes: '',
+  };
+
+  const collidingBinIds: string[] = [];
+  for (const other of bins) {
+    // Skip excluded bins (single ID or set of IDs)
+    if (other.id === excludeBinId) continue;
+    if (excludeBinIds?.has(other.id)) continue;
+    if (other.layerId === STAGING_ID) continue;
+    if (binsCollide(testBin, other, layers)) {
+      collidingBinIds.push(other.id);
+    }
+  }
+
+  if (collidingBinIds.length > 0) {
+    return err(validationCollision(collidingBinIds));
+  }
+
+  return ok(undefined);
+}
+
+/**
  * Validate an imported layout against the schema and constraints.
  */
 export function validateImport(data: unknown): { valid: boolean; errors: string[] } {
@@ -289,6 +391,21 @@ export function validateImport(data: unknown): { valid: boolean; errors: string[
 }
 
 /**
+ * Validate an imported layout against the schema and constraints.
+ * Returns a Result type with structured error information.
+ *
+ * @param data - Unknown data to validate as a layout
+ * @returns Result<void, ValidationError> with VALIDATION_IMPORT_FAILED on failure
+ */
+export function validateImportResult(data: unknown): Result<void, ValidationError> {
+  const result = validateImport(data);
+  if (result.valid) {
+    return ok(undefined);
+  }
+  return err(validationImportFailed(result.errors));
+}
+
+/**
  * Validate layout integrity for switching.
  * Checks that all bins reference valid layers and categories.
  * This is a lighter check than full import validation, used before switching layouts.
@@ -317,6 +434,21 @@ export function validateLayoutIntegrity(layout: Layout): { valid: boolean; error
   }
 
   return { valid: true };
+}
+
+/**
+ * Validate layout integrity for switching.
+ * Returns a Result type with structured error information.
+ *
+ * @param layout - Layout to validate
+ * @returns Result<void, ValidationError> with VALIDATION_IMPORT_FAILED on failure
+ */
+export function validateLayoutIntegrityResult(layout: Layout): Result<void, ValidationError> {
+  const result = validateLayoutIntegrity(layout);
+  if (result.valid) {
+    return ok(undefined);
+  }
+  return err(validationImportFailed([result.error || 'Unknown validation error']));
 }
 
 /**
@@ -390,6 +522,21 @@ export function validateCustomProperties(props: Record<string, string>): Operati
   }
 
   return { success: true };
+}
+
+/**
+ * Validate custom properties for a bin.
+ * Returns a Result type with structured error information.
+ *
+ * @param props - Custom properties object to validate
+ * @returns Result<void, ValidationError> with VALIDATION_IMPORT_FAILED on failure
+ */
+export function validateCustomPropertiesResult(props: Record<string, string>): Result<void, ValidationError> {
+  const result = validateCustomProperties(props);
+  if (result.success) {
+    return ok(undefined);
+  }
+  return err(validationImportFailed([result.error ?? 'Invalid custom properties']));
 }
 
 /**


### PR DESCRIPTION
## Summary
Phase 6 of the `Result<T, E>` migration adds type-safe Result-returning functions to the validation layer.

- Add `*Result` suffix variants for validation functions
- Each variant returns `Result<void, ValidationError>` with rich error metadata
- Key improvement: `canPlaceBinResult` collects all colliding bin IDs, enabling better error messages
- Existing functions remain unchanged for backwards compatibility
- Added 23 new tests for Result-returning functions

### New Functions

| Function | Return Type | Error Codes |
|----------|-------------|-------------|
| `canPlaceBinResult` | `Result<void, ValidationError>` | OUT_OF_BOUNDS, COLLISION, INVALID_LAYER, HEIGHT_EXCEEDED, BLOCKED_ZONE |
| `validateImportResult` | `Result<void, ValidationError>` | IMPORT_FAILED (with errors array) |
| `validateLayoutIntegrityResult` | `Result<void, ValidationError>` | IMPORT_FAILED |
| `validateCustomPropertiesResult` | `Result<void, ValidationError>` | IMPORT_FAILED |

### Rich Error Metadata
`canPlaceBinResult` provides detailed error context:
```typescript
// VALIDATION_COLLISION error includes colliding bin IDs
if (isErr(result) && result.error.code === 'VALIDATION_COLLISION') {
  console.log(`Collides with: ${result.error.collidingBinIds.join(', ')}`);
}

// VALIDATION_OUT_OF_BOUNDS includes bin data
if (isErr(result) && 'binData' in result.error) {
  console.log(`Bin at (${result.error.binData.x}, ${result.error.binData.y})`);
}
```

## Test plan
- [x] All 3012 tests pass
- [x] Coverage thresholds met (86.8% lines, 75.15% branches)
- [x] Pre-commit hooks pass (lint, build, coverage)
- [x] 23 new tests for Result-returning functions