### PR TITLE
feat: add Result-returning operations to remaining stores

### DIFF
--- a/src/store/library.ts
+++ b/src/store/library.ts
@@ -3,6 +3,8 @@ import { immer } from 'zustand/middleware/immer';
 import type { LayoutLibrary, LayoutEntry, LayoutPreview, Layout, OperationResult, ThumbnailBin, CloudShareInfo, ShareExpiration } from '../types';
 import { CONSTRAINTS, STAGING_ID } from '../constants';
 import { generateUUID } from '../utils/uuid';
+import type { Result, Unit, LayoutError } from '../result';
+import { err, layoutLastEntity, OK } from '../result';
 
 /**
  * Compute preview data from a layout for display in the library.
@@ -70,6 +72,7 @@ interface LibraryState {
 
   createEntry: (name: string, layoutId: string, preview: LayoutPreview, author?: string) => LayoutEntry;
   deleteEntry: (id: string) => OperationResult;
+  deleteEntryResult: (id: string) => Result<Unit, LayoutError>;
   updateEntry: (id: string, updates: Partial<Omit<LayoutEntry, 'id'>>) => void;
   duplicateEntry: (sourceEntry: LayoutEntry, newLayoutId: string) => LayoutEntry;
 
@@ -139,6 +142,26 @@ export const useLibraryStore = create<LibraryState>()(
       });
 
       return { success: true };
+    },
+
+    deleteEntryResult: (id) => {
+      const { library } = get();
+
+      // Can't delete last layout
+      if (library.entries.length <= 1) {
+        return err(layoutLastEntity('layout'));
+      }
+
+      set(state => {
+        state.library.entries = state.library.entries.filter(e => e.id !== id);
+
+        // If deleting active layout, switch to first remaining
+        if (state.library.activeLayoutId === id) {
+          state.library.activeLayoutId = state.library.entries[0].id;
+        }
+      });
+
+      return OK;
     },
 
     updateEntry: (id, updates) => {

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -4,6 +4,8 @@ import { CONSTRAINTS } from '../constants';
 import { clamp } from '../utils/validation';
 import { validateHalfBinModeToggle } from '../utils/halfBinConstraints';
 import { useLayoutStore } from './layout';
+import type { Result, Unit, LayoutError } from '../result';
+import { err, layoutInvalidOperation, OK } from '../result';
 
 // Storage key for half-bin mode preference
 const HALF_BIN_MODE_KEY = 'gridfinity-half-bin-mode';
@@ -169,6 +171,7 @@ interface UIState {
 
   // Half-bin mode actions
   toggleHalfBinMode: () => OperationResult<void>;
+  toggleHalfBinModeResult: () => Result<Unit, LayoutError>;
   setHalfBinMode: (enabled: boolean) => void;
 
   // Shared layout preview actions
@@ -373,6 +376,32 @@ export const useUIStore = create<UIState>((set) => ({
     saveHalfBinMode(false);
     set({ halfBinMode: false });
     return { success: true };
+  },
+  toggleHalfBinModeResult: () => {
+    const state = useUIStore.getState();
+    const targetState = !state.halfBinMode;
+
+    // Turning ON: no validation needed
+    if (targetState === true) {
+      saveHalfBinMode(true);
+      set({ halfBinMode: true });
+      return OK;
+    }
+
+    // Turning OFF: validate layout for fractional bins
+    const layout = useLayoutStore.getState().layout;
+    const result = validateHalfBinModeToggle(layout, false);
+
+    if (!result.canDisable) {
+      return err(layoutInvalidOperation(
+        'toggleHalfBinMode',
+        `Cannot disable: ${result.violation?.count ?? 0} bins have fractional dimensions`
+      ));
+    }
+
+    saveHalfBinMode(false);
+    set({ halfBinMode: false });
+    return OK;
   },
   setHalfBinMode: (enabled) => {
     saveHalfBinMode(enabled);

--- a/src/test/store/library.test.ts
+++ b/src/test/store/library.test.ts
@@ -3,6 +3,7 @@ import { useLibraryStore, computePreview, createDefaultLibrary } from '../../sto
 import { createDefaultLayout, CONSTRAINTS } from '../../constants';
 import { resetAllStores } from '../testUtils';
 import type { LayoutLibrary, LayoutEntry, LayoutPreview } from '../../types';
+import { isOk, isErr } from '../../result';
 
 // Helper to create test library with multiple entries (uses testUtils createTestLibrary as base)
 function createTestLibraryWithEntries(entryCount: number): LayoutLibrary {
@@ -212,6 +213,64 @@ describe('library store', () => {
 
       useLibraryStore.getState().deleteEntry('layout-2');
 
+      expect(useLibraryStore.getState().library.activeLayoutId).toBe('layout-0');
+    });
+  });
+
+  describe('deleteEntryResult', () => {
+    beforeEach(() => {
+      useLibraryStore.setState({
+        library: createTestLibraryWithEntries(3),
+        isLoaded: true,
+        showLayoutManager: false,
+      });
+    });
+
+    it('returns Ok when deleting an entry', () => {
+      const result = useLibraryStore.getState().deleteEntryResult('layout-1');
+
+      expect(isOk(result)).toBe(true);
+      expect(useLibraryStore.getState().library.entries).toHaveLength(2);
+      expect(useLibraryStore.getState().getEntry('layout-1')).toBeUndefined();
+    });
+
+    it('returns Err with LAYOUT_LAST_ENTITY when deleting the only entry', () => {
+      useLibraryStore.setState({
+        library: createTestLibraryWithEntries(1),
+        isLoaded: true,
+        showLayoutManager: false,
+      });
+
+      const result = useLibraryStore.getState().deleteEntryResult('layout-0');
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('LAYOUT_LAST_ENTITY');
+        expect(result.error.kind).toBe('LayoutError');
+        expect(result.error.entityType).toBe('layout');
+      }
+      expect(useLibraryStore.getState().library.entries).toHaveLength(1);
+    });
+
+    it('switches activeLayoutId if deleting active layout', () => {
+      useLibraryStore.setState(state => {
+        state.library.activeLayoutId = 'layout-1';
+      });
+
+      const result = useLibraryStore.getState().deleteEntryResult('layout-1');
+
+      expect(isOk(result)).toBe(true);
+      expect(useLibraryStore.getState().library.activeLayoutId).toBe('layout-0');
+    });
+
+    it('does not change activeLayoutId if deleting inactive layout', () => {
+      useLibraryStore.setState(state => {
+        state.library.activeLayoutId = 'layout-0';
+      });
+
+      const result = useLibraryStore.getState().deleteEntryResult('layout-2');
+
+      expect(isOk(result)).toBe(true);
       expect(useLibraryStore.getState().library.activeLayoutId).toBe('layout-0');
     });
   });

--- a/src/test/store/ui.test.ts
+++ b/src/test/store/ui.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useUIStore } from '../../store/ui';
+import { useLayoutStore } from '../../store/layout';
 import { CONSTRAINTS } from '../../constants';
 import { resetAllStores } from '../testUtils';
+import { isOk, isErr } from '../../result';
 
 describe('ui store', () => {
   beforeEach(() => {
@@ -688,6 +690,64 @@ describe('ui store', () => {
 
       setHalfBinMode(false);
       expect(useUIStore.getState().halfBinMode).toBe(false);
+    });
+  });
+
+  describe('toggleHalfBinModeResult', () => {
+    it('returns Ok when enabling half-bin mode', () => {
+      const { toggleHalfBinModeResult, setHalfBinMode } = useUIStore.getState();
+
+      // Ensure off first
+      setHalfBinMode(false);
+      expect(useUIStore.getState().halfBinMode).toBe(false);
+
+      const result = toggleHalfBinModeResult();
+
+      expect(isOk(result)).toBe(true);
+      expect(useUIStore.getState().halfBinMode).toBe(true);
+    });
+
+    it('returns Ok when disabling half-bin mode with no fractional bins', () => {
+      const { toggleHalfBinModeResult, setHalfBinMode } = useUIStore.getState();
+
+      // Enable first
+      setHalfBinMode(true);
+      expect(useUIStore.getState().halfBinMode).toBe(true);
+
+      const result = toggleHalfBinModeResult();
+
+      expect(isOk(result)).toBe(true);
+      expect(useUIStore.getState().halfBinMode).toBe(false);
+    });
+
+    it('returns Err with LAYOUT_INVALID_OPERATION when fractional bins exist', () => {
+      const { toggleHalfBinModeResult, setHalfBinMode } = useUIStore.getState();
+
+      // Enable half-bin mode
+      setHalfBinMode(true);
+
+      // Add a fractional bin
+      const layerId = useLayoutStore.getState().layout.layers[0].id;
+      useLayoutStore.getState().addBin({
+        x: 0.5, // Fractional position
+        y: 0,
+        width: 1,
+        depth: 1,
+        height: 3,
+        layerId,
+        category: useLayoutStore.getState().layout.categories[0].id,
+      });
+
+      const result = toggleHalfBinModeResult();
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('LAYOUT_INVALID_OPERATION');
+        expect(result.error.kind).toBe('LayoutError');
+        expect(result.error.operation).toBe('toggleHalfBinMode');
+        expect(result.error.reason).toContain('fractional dimensions');
+      }
+      expect(useUIStore.getState().halfBinMode).toBe(true); // Should remain enabled
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `deleteEntryResult` to library store - returns `LayoutLastEntityError` when deleting the only layout
- Add `toggleHalfBinModeResult` to UI store - returns `LayoutInvalidOperationError` when fractional bins exist
- Add 7 tests for new Result functions

Part of the ongoing Result<T, E> type system migration (Phase 8: Remaining Store Operations).

## Test plan

- [x] All existing tests pass (3025 tests)
- [x] New tests cover success and error cases for both functions
- [x] Build succeeds
- [x] Pre-commit hooks pass