### PR TITLE
feat: add Result-returning functions to useLayoutSwitcher hook

### DIFF
--- a/src/hooks/useLayoutSwitcher.ts
+++ b/src/hooks/useLayoutSwitcher.ts
@@ -14,6 +14,13 @@ import { validateLayoutIntegrity } from '../utils/validation';
 import { generateUUID } from '../utils/uuid';
 import { createLayoutWithSettings } from '../constants';
 import { trackLayoutAction } from '../utils/analytics';
+import type { Result, Unit, LayoutError, StorageError, ValidationError, UnknownError } from '../result';
+import {
+  ok, err, OK,
+  layoutLastEntity, layoutInvalidOperation,
+  storageNotFound, storageCorrupted,
+  fromUnknown,
+} from '../result';
 
 /**
  * Orchestration hook for layout switching and management.
@@ -172,6 +179,94 @@ export function useLayoutSwitcher() {
     addToast,
   ]);
 
+  /**
+   * Switch to a different layout with Result-based error handling.
+   */
+  const switchLayoutResult = useCallback(async (
+    targetId: string
+  ): Promise<Result<Unit, LayoutError | StorageError | ValidationError | UnknownError>> => {
+    // 1. Validate target exists
+    const targetEntry = getEntry(targetId);
+    if (!targetEntry) {
+      return err(layoutInvalidOperation('switchLayout', 'Layout not found'));
+    }
+
+    // 2. Cancel any pending auto-save (prevent race)
+    if (pendingSaveRef.current) {
+      clearTimeout(pendingSaveRef.current);
+      pendingSaveRef.current = null;
+    }
+
+    try {
+      // 3. Clear any shared layout preview state
+      clearSharedLayoutPreview();
+
+      // 4. Save current layout immediately (skip if shared preview)
+      if (activeLayoutId && activeLayoutId !== '__shared_preview__') {
+        await saveLayoutByIdAsync(activeLayoutId, layout);
+        updateEntry(activeLayoutId, {
+          modifiedAt: Date.now(),
+          preview: computeLayoutPreview(layout),
+          name: layout.name,
+        });
+      }
+
+      // 5. Load target layout from storage
+      const targetLayout = await loadLayoutByIdAsync(targetId);
+      if (!targetLayout) {
+        return err(storageNotFound(`gridfinity-layout-${targetId}`));
+      }
+
+      // 6. Validate layout integrity
+      const validation = validateLayoutIntegrity(targetLayout);
+      if (!validation.valid) {
+        return err(storageCorrupted(
+          `gridfinity-layout-${targetId}`,
+          validation.error ? [validation.error] : ['Layout data is corrupted']
+        ));
+      }
+
+      // 7. Update stores (atomic sequence)
+      importLayout(targetLayout, targetId, 'init');
+      setLibraryActiveId(targetId);
+
+      // 8. Reset UI state
+      clearSelection();
+      setActiveLayer(targetLayout.layers[0]?.id ?? '');
+      setActiveCategory(targetLayout.categories[0]?.id ?? '');
+
+      // 9. Clear undo history
+      clearHistory();
+
+      // 10. Save library index
+      saveLibrary(useLibraryStore.getState().library);
+
+      // 11. Update URL hash
+      setLayoutHash(targetId, true);
+
+      // 12. Track analytics
+      trackLayoutAction('switched');
+
+      return OK;
+    } catch (error) {
+      addToast('Failed to switch layout', 'error');
+      return err(fromUnknown(error));
+    }
+  }, [
+    activeLayoutId,
+    layout,
+    getEntry,
+    updateEntry,
+    importLayout,
+    setLibraryActiveId,
+    clearSelection,
+    setActiveLayer,
+    setActiveCategory,
+    clearHistory,
+    clearSharedLayoutPreview,
+    addToast,
+  ]);
+
   // Settings store
   const settings = useSettingsStore((state) => state.settings);
 
@@ -229,6 +324,61 @@ export function useLayoutSwitcher() {
   ]);
 
   /**
+   * Create a new layout and switch to it with Result-based error handling.
+   */
+  const createNewLayoutResult = useCallback(async (
+    name?: string
+  ): Promise<Result<string, StorageError | UnknownError>> => {
+    await saveCurrentLayout();
+
+    const layoutId = generateUUID();
+    const newLayout = createLayoutWithSettings(settings);
+    newLayout.name = name || 'Untitled layout';
+
+    try {
+      await saveLayoutByIdAsync(layoutId, newLayout);
+
+      createEntry(
+        newLayout.name,
+        layoutId,
+        computeLayoutPreview(newLayout)
+      );
+
+      importLayout(newLayout, layoutId, 'init');
+      setLibraryActiveId(layoutId);
+
+      clearSelection();
+      setActiveLayer(newLayout.layers[0]?.id ?? '');
+      setActiveCategory(newLayout.categories[0]?.id ?? '');
+
+      clearHistory();
+
+      saveLibrary(useLibraryStore.getState().library);
+
+      setLayoutHash(layoutId, true);
+
+      trackLayoutAction('created');
+
+      addToast('New layout created', 'success');
+      return ok(layoutId);
+    } catch (error) {
+      addToast('Failed to create layout', 'error');
+      return err(fromUnknown(error));
+    }
+  }, [
+    saveCurrentLayout,
+    importLayout,
+    createEntry,
+    setLibraryActiveId,
+    clearSelection,
+    setActiveLayer,
+    setActiveCategory,
+    clearHistory,
+    addToast,
+    settings,
+  ]);
+
+  /**
    * Delete a layout.
    */
   const deleteLayout = useCallback(async (id: string): Promise<OperationResult> => {
@@ -269,6 +419,48 @@ export function useLayoutSwitcher() {
   }, [library, activeLayoutId, deleteEntry, switchLayout, addToast]);
 
   /**
+   * Delete a layout with Result-based error handling.
+   */
+  const deleteLayoutResult = useCallback(async (
+    id: string
+  ): Promise<Result<Unit, LayoutError | StorageError | ValidationError | UnknownError>> => {
+    const { entries } = library;
+
+    // Can't delete last layout
+    if (entries.length <= 1) {
+      return err(layoutLastEntity('layout'));
+    }
+
+    try {
+      await deleteLayoutByIdAsync(id);
+
+      const result = deleteEntry(id);
+      if (!result.success) {
+        return err(layoutInvalidOperation('deleteLayout', result.error || 'Delete failed'));
+      }
+
+      if (activeLayoutId === id) {
+        const remaining = entries.filter(e => e.id !== id);
+        const fallbackId = remaining[0].id;
+        const switchResult = await switchLayoutResult(fallbackId);
+        if (!switchResult.ok) {
+          return switchResult;
+        }
+      }
+
+      saveLibrary(useLibraryStore.getState().library);
+
+      trackLayoutAction('deleted');
+
+      addToast('Layout deleted', 'success');
+      return OK;
+    } catch (error) {
+      addToast('Failed to delete layout', 'error');
+      return err(fromUnknown(error));
+    }
+  }, [library, activeLayoutId, deleteEntry, switchLayoutResult, addToast]);
+
+  /**
    * Duplicate a layout.
    */
   const duplicateLayout = useCallback(async (id: string): Promise<OperationResult<string>> => {
@@ -303,6 +495,46 @@ export function useLayoutSwitcher() {
     } catch (error) {
       addToast('Failed to duplicate layout', 'error');
       return { success: false, error: String(error) };
+    }
+  }, [getEntry, duplicateEntry, addToast]);
+
+  /**
+   * Duplicate a layout with Result-based error handling.
+   */
+  const duplicateLayoutResult = useCallback(async (
+    id: string
+  ): Promise<Result<string, LayoutError | StorageError | UnknownError>> => {
+    const sourceEntry = getEntry(id);
+    if (!sourceEntry) {
+      return err(layoutInvalidOperation('duplicateLayout', 'Layout not found'));
+    }
+
+    const sourceLayout = await loadLayoutByIdAsync(id);
+    if (!sourceLayout) {
+      return err(storageNotFound(`gridfinity-layout-${id}`));
+    }
+
+    try {
+      const newLayoutId = generateUUID();
+
+      const newLayout: Layout = {
+        ...sourceLayout,
+        name: `${sourceLayout.name} (copy)`,
+      };
+
+      await saveLayoutByIdAsync(newLayoutId, newLayout);
+
+      duplicateEntry(sourceEntry, newLayoutId);
+
+      saveLibrary(useLibraryStore.getState().library);
+
+      trackLayoutAction('duplicated');
+
+      addToast('Layout duplicated', 'success');
+      return ok(newLayoutId);
+    } catch (error) {
+      addToast('Failed to duplicate layout', 'error');
+      return err(fromUnknown(error));
     }
   }, [getEntry, duplicateEntry, addToast]);
 
@@ -357,6 +589,42 @@ export function useLayoutSwitcher() {
     }
   }, [library.settings.authorName, createEntry, updateEntry, addToast]);
 
+  /**
+   * Import a layout from JSON and add to library with Result-based error handling.
+   */
+  const importLayoutFromJSONResult = useCallback(async (
+    importedLayout: Layout,
+    forkedFrom?: { name: string; author?: string }
+  ): Promise<Result<string, StorageError | UnknownError>> => {
+    try {
+      const layoutId = generateUUID();
+
+      await saveLayoutByIdAsync(layoutId, importedLayout);
+
+      const preview: LayoutPreview = computeLayoutPreview(importedLayout);
+      createEntry(
+        importedLayout.name,
+        layoutId,
+        preview,
+        library.settings.authorName
+      );
+
+      if (forkedFrom) {
+        updateEntry(layoutId, { forkedFrom });
+      }
+
+      saveLibrary(useLibraryStore.getState().library);
+
+      trackLayoutAction('imported', forkedFrom ? 'url' : 'json');
+
+      addToast(`Imported "${importedLayout.name}"`, 'success');
+      return ok(layoutId);
+    } catch (error) {
+      addToast('Failed to import layout', 'error');
+      return err(fromUnknown(error));
+    }
+  }, [library.settings.authorName, createEntry, updateEntry, addToast]);
+
   return {
     // State
     activeLayoutId,
@@ -370,6 +638,13 @@ export function useLayoutSwitcher() {
     renameLayout,
     saveCurrentLayout,
     importLayoutFromJSON,
+
+    // Result-based actions
+    switchLayoutResult,
+    createNewLayoutResult,
+    deleteLayoutResult,
+    duplicateLayoutResult,
+    importLayoutFromJSONResult,
 
     // Ref for auto-save coordination
     pendingSaveRef,

--- a/src/test/hooks/useLayoutSwitcher.test.ts
+++ b/src/test/hooks/useLayoutSwitcher.test.ts
@@ -9,6 +9,7 @@ import { useToastStore } from '../../store/toast';
 import { createDefaultLayout } from '../../constants';
 import * as storage from '../../storage';
 import type { LayoutLibrary, LayoutEntry, Layout } from '../../types';
+import { isOk, isErr } from '../../result';
 
 // Mock the storage module
 vi.mock('../../storage', () => ({
@@ -588,6 +589,213 @@ describe('useLayoutSwitcher', () => {
 
       const toasts = useToastStore.getState().toasts;
       expect(toasts.some(t => t.message.includes('Imported'))).toBe(true);
+    });
+  });
+
+  // === Result-Based Functions ===
+
+  describe('switchLayoutResult', () => {
+    it('returns Ok when switching successfully', async () => {
+      const targetLayout = createTestLayout('Second Layout');
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(targetLayout);
+
+      const { result } = renderHook(() => useLayoutSwitcher());
+
+      let switchResult: Awaited<ReturnType<typeof result.current.switchLayoutResult>>;
+      await act(async () => {
+        switchResult = await result.current.switchLayoutResult(SECOND_LAYOUT_ID);
+      });
+
+      expect(isOk(switchResult!)).toBe(true);
+      expect(useLayoutStore.getState().activeLayoutId).toBe(SECOND_LAYOUT_ID);
+    });
+
+    it('returns Err with LAYOUT_INVALID_OPERATION for non-existent layout', async () => {
+      const { result } = renderHook(() => useLayoutSwitcher());
+
+      let switchResult: Awaited<ReturnType<typeof result.current.switchLayoutResult>>;
+      await act(async () => {
+        switchResult = await result.current.switchLayoutResult('non-existent-id');
+      });
+
+      expect(isErr(switchResult!)).toBe(true);
+      if (isErr(switchResult!)) {
+        expect(switchResult!.error.code).toBe('LAYOUT_INVALID_OPERATION');
+        expect(switchResult!.error.kind).toBe('LayoutError');
+      }
+    });
+
+    it('returns Err with STORAGE_NOT_FOUND when layout fails to load', async () => {
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(null);
+
+      const { result } = renderHook(() => useLayoutSwitcher());
+
+      let switchResult: Awaited<ReturnType<typeof result.current.switchLayoutResult>>;
+      await act(async () => {
+        switchResult = await result.current.switchLayoutResult(SECOND_LAYOUT_ID);
+      });
+
+      expect(isErr(switchResult!)).toBe(true);
+      if (isErr(switchResult!)) {
+        expect(switchResult!.error.code).toBe('STORAGE_NOT_FOUND');
+        expect(switchResult!.error.kind).toBe('StorageError');
+      }
+    });
+  });
+
+  describe('createNewLayoutResult', () => {
+    it('returns Ok with layout ID on success', async () => {
+      const { result } = renderHook(() => useLayoutSwitcher());
+
+      let createResult: Awaited<ReturnType<typeof result.current.createNewLayoutResult>>;
+      await act(async () => {
+        createResult = await result.current.createNewLayoutResult('My New Layout');
+      });
+
+      expect(isOk(createResult!)).toBe(true);
+      if (isOk(createResult!)) {
+        expect(createResult!.value).toBeDefined();
+        expect(typeof createResult!.value).toBe('string');
+      }
+      expect(useLayoutStore.getState().layout.name).toBe('My New Layout');
+    });
+
+    it('uses default name if none provided', async () => {
+      const { result } = renderHook(() => useLayoutSwitcher());
+
+      await act(async () => {
+        await result.current.createNewLayoutResult();
+      });
+
+      expect(useLayoutStore.getState().layout.name).toBe('Untitled layout');
+    });
+  });
+
+  describe('deleteLayoutResult', () => {
+    it('returns Ok when deleting successfully', async () => {
+      const { result } = renderHook(() => useLayoutSwitcher());
+
+      let deleteResult: Awaited<ReturnType<typeof result.current.deleteLayoutResult>>;
+      await act(async () => {
+        deleteResult = await result.current.deleteLayoutResult(SECOND_LAYOUT_ID);
+      });
+
+      expect(isOk(deleteResult!)).toBe(true);
+      expect(storage.deleteLayoutByIdAsync).toHaveBeenCalledWith(SECOND_LAYOUT_ID);
+    });
+
+    it('returns Err with LAYOUT_LAST_ENTITY when deleting only layout', async () => {
+      useLibraryStore.setState({
+        library: createTestLibrary([createTestEntry(TEST_LAYOUT_ID, 'Only Layout')]),
+        isLoaded: true,
+        showLayoutManager: false,
+      });
+
+      const { result } = renderHook(() => useLayoutSwitcher());
+
+      let deleteResult: Awaited<ReturnType<typeof result.current.deleteLayoutResult>>;
+      await act(async () => {
+        deleteResult = await result.current.deleteLayoutResult(TEST_LAYOUT_ID);
+      });
+
+      expect(isErr(deleteResult!)).toBe(true);
+      if (isErr(deleteResult!)) {
+        expect(deleteResult!.error.code).toBe('LAYOUT_LAST_ENTITY');
+        expect(deleteResult!.error.kind).toBe('LayoutError');
+        expect(deleteResult!.error.entityType).toBe('layout');
+      }
+    });
+  });
+
+  describe('duplicateLayoutResult', () => {
+    it('returns Ok with new layout ID on success', async () => {
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(createTestLayout('Original'));
+
+      const { result } = renderHook(() => useLayoutSwitcher());
+
+      let dupResult: Awaited<ReturnType<typeof result.current.duplicateLayoutResult>>;
+      await act(async () => {
+        dupResult = await result.current.duplicateLayoutResult(TEST_LAYOUT_ID);
+      });
+
+      expect(isOk(dupResult!)).toBe(true);
+      if (isOk(dupResult!)) {
+        expect(dupResult!.value).toBeDefined();
+        expect(typeof dupResult!.value).toBe('string');
+      }
+    });
+
+    it('returns Err with LAYOUT_INVALID_OPERATION for non-existent layout', async () => {
+      const { result } = renderHook(() => useLayoutSwitcher());
+
+      let dupResult: Awaited<ReturnType<typeof result.current.duplicateLayoutResult>>;
+      await act(async () => {
+        dupResult = await result.current.duplicateLayoutResult('non-existent');
+      });
+
+      expect(isErr(dupResult!)).toBe(true);
+      if (isErr(dupResult!)) {
+        expect(dupResult!.error.code).toBe('LAYOUT_INVALID_OPERATION');
+      }
+    });
+
+    it('returns Err with STORAGE_NOT_FOUND when source fails to load', async () => {
+      vi.mocked(storage.loadLayoutByIdAsync).mockResolvedValue(null);
+
+      const { result } = renderHook(() => useLayoutSwitcher());
+
+      let dupResult: Awaited<ReturnType<typeof result.current.duplicateLayoutResult>>;
+      await act(async () => {
+        dupResult = await result.current.duplicateLayoutResult(TEST_LAYOUT_ID);
+      });
+
+      expect(isErr(dupResult!)).toBe(true);
+      if (isErr(dupResult!)) {
+        expect(dupResult!.error.code).toBe('STORAGE_NOT_FOUND');
+        expect(dupResult!.error.kind).toBe('StorageError');
+      }
+    });
+  });
+
+  describe('importLayoutFromJSONResult', () => {
+    it('returns Ok with layout ID on success', async () => {
+      const importedLayout = createTestLayout('Imported Layout');
+
+      const { result } = renderHook(() => useLayoutSwitcher());
+
+      let importResult: Awaited<ReturnType<typeof result.current.importLayoutFromJSONResult>>;
+      await act(async () => {
+        importResult = await result.current.importLayoutFromJSONResult(importedLayout);
+      });
+
+      expect(isOk(importResult!)).toBe(true);
+      if (isOk(importResult!)) {
+        expect(importResult!.value).toBeDefined();
+        expect(typeof importResult!.value).toBe('string');
+      }
+    });
+
+    it('adds forkedFrom metadata when provided', async () => {
+      const importedLayout = createTestLayout('Forked');
+
+      const { result } = renderHook(() => useLayoutSwitcher());
+
+      let importResult: Awaited<ReturnType<typeof result.current.importLayoutFromJSONResult>>;
+      await act(async () => {
+        importResult = await result.current.importLayoutFromJSONResult(importedLayout, {
+          name: 'Original Layout',
+          author: 'Original Author',
+        });
+      });
+
+      expect(isOk(importResult!)).toBe(true);
+      if (isOk(importResult!) && importResult!.value) {
+        const entry = useLibraryStore.getState().getEntry(importResult!.value);
+        expect(entry?.forkedFrom).toEqual({
+          name: 'Original Layout',
+          author: 'Original Author',
+        });
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add Result-based error handling to layout switching operations in `useLayoutSwitcher` hook
- New functions with `*Result` suffix: `switchLayoutResult`, `createNewLayoutResult`, `deleteLayoutResult`, `duplicateLayoutResult`, `importLayoutFromJSONResult`
- 12 new tests covering success and error paths for all Result functions

## Test plan
- [x] All 3037 tests pass
- [x] TypeScript compilation succeeds
- [x] Coverage thresholds maintained

Part of the ongoing Result<T, E> type system migration (Phase 9).