### PR TITLE
docs: add systems architecture for Labs feature flags

### DIFF
--- a/docs/projects/labs-feature-flags/README.md
+++ b/docs/projects/labs-feature-flags/README.md
@@ -1,0 +1,64 @@
+# Labs Feature Flags
+
+A client-side feature flagging system that allows users to opt into experimental features before they're ready for general availability.
+
+## Overview
+
+The Labs system provides a "Google Search Labs"-style experience where users can:
+- Browse available experimental features
+- Understand risks before opting in
+- Toggle features on/off with immediate effect
+- Have preferences persist across sessions and sync across tabs
+
+### Initial Features
+
+1. **Collaborative Editing** - Real-time multi-user layout editing
+2. **Drawer-to-Print** - STL generation and export system
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [PRD](./prd.md) | Product requirements, user stories, acceptance criteria |
+| [Architecture](./architecture.md) | Technical implementation, data models, component design |
+| [Design Requirements](./design-requirements.md) | UI/UX specifications, visual design, accessibility |
+
+## Quick Links
+
+### Key Design Decisions
+
+- **Entry Point**: Labs button in sidebar settings area
+- **UI Pattern**: Side drawer sliding from right
+- **Acknowledgment**: Simple toggle, no confirmation dialogs
+- **Active Indicator**: Badge on Labs button showing enabled count
+- **Feature Organization**: Flat list with graduated section
+- **Feature Info**: Rich cards with name, description, status, risk, warnings
+- **Activation**: Immediate effect, no page refresh required
+- **Tab Sync**: Yes, via localStorage storage events
+- **Config Location**: TypeScript code constants
+- **Graduation**: Features marked as "graduated" always return enabled
+- **Analytics**: Track via PostHog (drawer opens, feature toggles)
+
+### Technical Stack
+
+- **State**: Zustand store (`useLabsStore`)
+- **Storage**: localStorage (`gridfinity-labs-v1`)
+- **Sync**: Browser storage events (existing pattern)
+- **Analytics**: PostHog (existing integration)
+- **UI**: React components following existing patterns
+
+## Status
+
+**Current Phase**: Planning / Architecture Design
+
+- [x] Requirements gathered
+- [x] Architecture documented
+- [x] Design requirements documented
+- [ ] Implementation
+- [ ] Testing
+- [ ] Release
+
+## Related Projects
+
+- [Collaborative Editing](../collaborative-editing/) - First Labs feature
+- [Drawer-to-Print](../../drawer-to-print/) - Second Labs feature

--- a/docs/projects/labs-feature-flags/architecture.md
+++ b/docs/projects/labs-feature-flags/architecture.md
@@ -1,0 +1,771 @@
+# Labs Feature Flags - Systems Architecture
+
+## Executive Summary
+
+This document describes the architecture for a client-side feature flagging system that allows users to opt into experimental features. The system is designed as a "Labs" feature similar to Google Search Labs, providing a low-friction way to test new features with real users before general availability.
+
+### Key Characteristics
+
+- **User-controlled**: Users explicitly opt into experimental features
+- **Client-side only**: No server-side flag evaluation needed
+- **Local storage**: Preferences persist across sessions in localStorage
+- **Cross-tab sync**: Changes sync automatically via storage events
+- **Analytics integration**: Track feature adoption via PostHog
+- **Graduation support**: Features can be marked as "graduated" when ready for GA
+
+---
+
+## 1. URL & Entry Points
+
+### Access Patterns
+
+```
+Primary entry point:
+  Settings menu (new "Labs" button in Sidebar) → Opens Labs drawer
+
+Future entry points:
+  - Keyboard shortcut (e.g., Ctrl+Shift+L) - optional
+  - Direct link: /#labs (for sharing/docs)
+```
+
+### URL Structure
+
+The Labs drawer doesn't require a dedicated route. It operates as an overlay that can be opened from anywhere in the app, preserving the user's current context.
+
+---
+
+## 2. Data Model
+
+### Feature Flag Definition
+
+Feature flags are defined in code as TypeScript constants, providing type safety and versioning with the codebase.
+
+```typescript
+// src/labs/types.ts
+
+/**
+ * Lifecycle states for experimental features.
+ */
+export type FeatureStatus =
+  | 'experimental'  // Active experiment, may have bugs
+  | 'preview'       // More stable, nearing graduation
+  | 'graduated'     // Now available to everyone
+  | 'deprecated';   // Being phased out
+
+/**
+ * Risk level indicators for user awareness.
+ */
+export type RiskLevel = 'low' | 'medium' | 'high';
+
+/**
+ * Definition of an experimental feature.
+ */
+export interface FeatureFlag {
+  /** Unique identifier (snake_case, matches analytics) */
+  id: string;
+
+  /** Display name shown in Labs UI */
+  name: string;
+
+  /** Brief description of what the feature does */
+  description: string;
+
+  /** Current lifecycle status */
+  status: FeatureStatus;
+
+  /** Risk level for user awareness */
+  risk: RiskLevel;
+
+  /** Optional warning message for high-risk features */
+  warning?: string;
+
+  /** Optional link to documentation or feedback form */
+  learnMoreUrl?: string;
+
+  /** Date feature was added to Labs */
+  addedAt: string;
+
+  /** Date feature graduated (if applicable) */
+  graduatedAt?: string;
+
+  /** Whether enabling requires page refresh */
+  requiresRefresh: boolean;
+
+  /** Optional feature dependencies (must be enabled first) */
+  dependencies?: string[];
+}
+```
+
+### Feature Registry
+
+```typescript
+// src/labs/features.ts
+
+import type { FeatureFlag } from './types';
+
+/**
+ * Registry of all experimental features.
+ * Add new features here to make them available in Labs.
+ */
+export const FEATURE_FLAGS: readonly FeatureFlag[] = [
+  {
+    id: 'collaborative_editing',
+    name: 'Collaborative Editing',
+    description: 'Work on layouts together in real-time with other people. Share a link and see each other\'s cursors as you design.',
+    status: 'experimental',
+    risk: 'medium',
+    warning: 'Sessions are temporary and expire after 24 hours. Save your layout locally before ending a session.',
+    learnMoreUrl: 'https://github.com/...',
+    addedAt: '2026-01',
+    requiresRefresh: false,
+  },
+  {
+    id: 'drawer_to_print',
+    name: 'Drawer-to-Print Export',
+    description: 'Generate STL files for all bins in your layout. Download a complete package with everything you need to 3D print your drawer.',
+    status: 'experimental',
+    risk: 'low',
+    learnMoreUrl: 'https://github.com/...',
+    addedAt: '2026-01',
+    requiresRefresh: false,
+  },
+] as const;
+
+/**
+ * Type-safe feature IDs derived from the registry.
+ */
+export type FeatureId = (typeof FEATURE_FLAGS)[number]['id'];
+
+/**
+ * Get a feature by ID with type safety.
+ */
+export function getFeature(id: FeatureId): FeatureFlag | undefined {
+  return FEATURE_FLAGS.find(f => f.id === id);
+}
+
+/**
+ * Get all active (non-deprecated) features.
+ */
+export function getActiveFeatures(): FeatureFlag[] {
+  return FEATURE_FLAGS.filter(f => f.status !== 'deprecated');
+}
+
+/**
+ * Get graduated features (for "What's New" display).
+ */
+export function getGraduatedFeatures(): FeatureFlag[] {
+  return FEATURE_FLAGS.filter(f => f.status === 'graduated');
+}
+```
+
+### User Preferences
+
+```typescript
+// src/labs/types.ts (continued)
+
+/**
+ * User's Labs preferences stored in localStorage.
+ */
+export interface LabsPreferences {
+  /** Map of feature ID → enabled state */
+  enabledFeatures: Record<string, boolean>;
+
+  /** Timestamp of last modification (for sync) */
+  lastModified: string;
+
+  /** Version for migration support */
+  version: number;
+}
+
+/**
+ * Default preferences for new users.
+ */
+export const DEFAULT_LABS_PREFERENCES: LabsPreferences = {
+  enabledFeatures: {},
+  lastModified: new Date().toISOString(),
+  version: 1,
+};
+```
+
+---
+
+## 3. State Management
+
+### Labs Store
+
+A new Zustand store manages Labs state, following existing patterns from `settings.ts`.
+
+```typescript
+// src/store/labs.ts
+
+import { create } from 'zustand';
+import type { LabsPreferences, FeatureId } from '../labs/types';
+import { DEFAULT_LABS_PREFERENCES, FEATURE_FLAGS, getFeature } from '../labs/features';
+import { trackEvent } from '../utils/analytics';
+
+const LABS_STORAGE_KEY = 'gridfinity-labs-v1';
+
+/**
+ * Load preferences from localStorage with migration support.
+ */
+function loadPreferences(): LabsPreferences {
+  try {
+    const stored = localStorage.getItem(LABS_STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      // Migration: handle version upgrades here
+      return { ...DEFAULT_LABS_PREFERENCES, ...parsed };
+    }
+  } catch (e) {
+    console.warn('Failed to load Labs preferences:', e);
+  }
+  return { ...DEFAULT_LABS_PREFERENCES };
+}
+
+/**
+ * Save preferences to localStorage.
+ */
+function savePreferences(prefs: LabsPreferences): void {
+  try {
+    prefs.lastModified = new Date().toISOString();
+    localStorage.setItem(LABS_STORAGE_KEY, JSON.stringify(prefs));
+  } catch (e) {
+    console.warn('Failed to save Labs preferences:', e);
+  }
+}
+
+interface LabsState {
+  /** User's preferences */
+  preferences: LabsPreferences;
+
+  /** Whether Labs drawer is open */
+  isDrawerOpen: boolean;
+
+  /** Open the Labs drawer */
+  openDrawer: () => void;
+
+  /** Close the Labs drawer */
+  closeDrawer: () => void;
+
+  /** Toggle a feature on/off */
+  toggleFeature: (featureId: FeatureId) => void;
+
+  /** Enable a specific feature */
+  enableFeature: (featureId: FeatureId) => void;
+
+  /** Disable a specific feature */
+  disableFeature: (featureId: FeatureId) => void;
+
+  /** Check if a feature is enabled */
+  isFeatureEnabled: (featureId: FeatureId) => boolean;
+
+  /** Get count of enabled experimental features */
+  getEnabledCount: () => number;
+
+  /** Sync preferences from another tab */
+  syncFromStorage: (prefs: LabsPreferences) => void;
+}
+
+export const useLabsStore = create<LabsState>()((set, get) => ({
+  preferences: loadPreferences(),
+  isDrawerOpen: false,
+
+  openDrawer: () => set({ isDrawerOpen: true }),
+  closeDrawer: () => set({ isDrawerOpen: false }),
+
+  toggleFeature: (featureId) => {
+    const { preferences } = get();
+    const currentlyEnabled = preferences.enabledFeatures[featureId] ?? false;
+    const newEnabled = !currentlyEnabled;
+
+    const newPrefs: LabsPreferences = {
+      ...preferences,
+      enabledFeatures: {
+        ...preferences.enabledFeatures,
+        [featureId]: newEnabled,
+      },
+    };
+
+    savePreferences(newPrefs);
+    set({ preferences: newPrefs });
+
+    // Track analytics
+    trackEvent('labs_feature_toggle', {
+      feature_id: featureId,
+      enabled: newEnabled,
+      feature_status: getFeature(featureId)?.status ?? 'unknown',
+    });
+  },
+
+  enableFeature: (featureId) => {
+    const { preferences } = get();
+    if (preferences.enabledFeatures[featureId]) return;
+
+    const newPrefs: LabsPreferences = {
+      ...preferences,
+      enabledFeatures: {
+        ...preferences.enabledFeatures,
+        [featureId]: true,
+      },
+    };
+
+    savePreferences(newPrefs);
+    set({ preferences: newPrefs });
+
+    trackEvent('labs_feature_enabled', {
+      feature_id: featureId,
+      feature_status: getFeature(featureId)?.status ?? 'unknown',
+    });
+  },
+
+  disableFeature: (featureId) => {
+    const { preferences } = get();
+    if (!preferences.enabledFeatures[featureId]) return;
+
+    const newPrefs: LabsPreferences = {
+      ...preferences,
+      enabledFeatures: {
+        ...preferences.enabledFeatures,
+        [featureId]: false,
+      },
+    };
+
+    savePreferences(newPrefs);
+    set({ preferences: newPrefs });
+
+    trackEvent('labs_feature_disabled', {
+      feature_id: featureId,
+      feature_status: getFeature(featureId)?.status ?? 'unknown',
+    });
+  },
+
+  isFeatureEnabled: (featureId) => {
+    const { preferences } = get();
+    const feature = getFeature(featureId);
+
+    // Graduated features are always enabled
+    if (feature?.status === 'graduated') return true;
+
+    // Deprecated features are always disabled
+    if (feature?.status === 'deprecated') return false;
+
+    return preferences.enabledFeatures[featureId] ?? false;
+  },
+
+  getEnabledCount: () => {
+    const { preferences } = get();
+    return Object.entries(preferences.enabledFeatures)
+      .filter(([id, enabled]) => {
+        if (!enabled) return false;
+        const feature = getFeature(id as FeatureId);
+        // Only count experimental/preview features
+        return feature?.status === 'experimental' || feature?.status === 'preview';
+      })
+      .length;
+  },
+
+  syncFromStorage: (prefs) => {
+    set({ preferences: prefs });
+  },
+}));
+```
+
+### Usage Hook
+
+```typescript
+// src/hooks/useFeatureFlag.ts
+
+import { useLabsStore } from '../store/labs';
+import type { FeatureId } from '../labs/types';
+
+/**
+ * Hook to check if a feature flag is enabled.
+ * Returns true if the feature is enabled or graduated.
+ *
+ * @example
+ * const isCollabEnabled = useFeatureFlag('collaborative_editing');
+ * if (isCollabEnabled) {
+ *   // Render collaboration UI
+ * }
+ */
+export function useFeatureFlag(featureId: FeatureId): boolean {
+  return useLabsStore((state) => state.isFeatureEnabled(featureId));
+}
+
+/**
+ * Imperative check for use outside React components.
+ *
+ * @example
+ * if (isFeatureEnabled('drawer_to_print')) {
+ *   // Show export option
+ * }
+ */
+export function isFeatureEnabled(featureId: FeatureId): boolean {
+  return useLabsStore.getState().isFeatureEnabled(featureId);
+}
+```
+
+---
+
+## 4. Cross-Tab Synchronization
+
+Extend the existing `useCrossTabSync` hook to handle Labs preferences.
+
+```typescript
+// src/hooks/useCrossTabSync.ts (extended)
+
+// Add to existing storage event handler:
+if (e.key === 'gridfinity-labs-v1') {
+  try {
+    const newPrefs = JSON.parse(e.newValue || '{}');
+    useLabsStore.getState().syncFromStorage(newPrefs);
+  } catch {
+    // Ignore parse errors
+  }
+  return;
+}
+```
+
+This ensures that when a user toggles a feature in one tab, all other tabs immediately reflect the change.
+
+---
+
+## 5. Analytics Integration
+
+### Events
+
+Labs integrates with the existing PostHog analytics system.
+
+| Event | Properties | When |
+|-------|------------|------|
+| `labs_drawer_opened` | `enabled_count`, `device_type` | User opens Labs drawer |
+| `labs_feature_toggle` | `feature_id`, `enabled`, `feature_status` | User toggles a feature |
+| `labs_feature_enabled` | `feature_id`, `feature_status` | Feature specifically enabled |
+| `labs_feature_disabled` | `feature_id`, `feature_status` | Feature specifically disabled |
+
+### Periodic Snapshot
+
+Include Labs state in the existing `layout_snapshot` event:
+
+```typescript
+// Extend computeLayoutMetrics or add separate function
+export function computeLabsMetrics(): LabsMetrics {
+  const prefs = useLabsStore.getState().preferences;
+  return {
+    labs_enabled_features: Object.entries(prefs.enabledFeatures)
+      .filter(([_, enabled]) => enabled)
+      .map(([id]) => id),
+    labs_enabled_count: Object.values(prefs.enabledFeatures)
+      .filter(Boolean).length,
+  };
+}
+```
+
+---
+
+## 6. Component Architecture
+
+### New Components
+
+```
+src/components/
+├── labs/
+│   ├── LabsDrawer.tsx          # Main drawer container (slide-in from right)
+│   ├── LabsButton.tsx          # Entry point button with badge
+│   ├── FeatureCard.tsx         # Individual feature card with toggle
+│   ├── FeatureStatusBadge.tsx  # Status indicator (Experimental, Preview, etc.)
+│   └── GraduatedSection.tsx    # Optional "What's New" for graduated features
+```
+
+### LabsButton Integration
+
+The Labs button should be added to the Sidebar component (desktop) and mobile settings panel (mobile).
+
+```typescript
+// Placement in Sidebar
+<LabsButton />
+// Shows: Flask icon + "Labs" + badge with enabled count
+// Badge only visible when count > 0
+```
+
+### LabsDrawer Pattern
+
+The drawer follows the existing side panel pattern but slides from the right:
+
+```typescript
+// Simplified structure
+<div className={`labs-drawer ${isOpen ? 'open' : ''}`}>
+  <header>
+    <h2>Labs</h2>
+    <button onClick={closeDrawer}>×</button>
+  </header>
+
+  <p className="description">
+    Try experimental features before they're ready for everyone.
+    These may be buggy or change without notice.
+  </p>
+
+  <div className="features">
+    {getActiveFeatures().map(feature => (
+      <FeatureCard key={feature.id} feature={feature} />
+    ))}
+  </div>
+
+  {getGraduatedFeatures().length > 0 && (
+    <GraduatedSection features={getGraduatedFeatures()} />
+  )}
+</div>
+```
+
+---
+
+## 7. Feature Integration Pattern
+
+When adding a new experimental feature, follow this pattern:
+
+### 1. Define the Feature
+
+```typescript
+// src/labs/features.ts
+{
+  id: 'new_feature',
+  name: 'New Feature',
+  description: 'Description of what it does.',
+  status: 'experimental',
+  risk: 'low',
+  addedAt: '2026-02',
+  requiresRefresh: false,
+}
+```
+
+### 2. Gate the Feature
+
+```typescript
+// In component
+import { useFeatureFlag } from '../hooks/useFeatureFlag';
+
+function MyComponent() {
+  const isNewFeatureEnabled = useFeatureFlag('new_feature');
+
+  if (!isNewFeatureEnabled) {
+    return null; // Or render fallback
+  }
+
+  return <NewFeatureUI />;
+}
+```
+
+### 3. Gate in Non-React Code
+
+```typescript
+// In utility or service
+import { isFeatureEnabled } from '../hooks/useFeatureFlag';
+
+function doSomething() {
+  if (isFeatureEnabled('new_feature')) {
+    // New behavior
+  } else {
+    // Existing behavior
+  }
+}
+```
+
+---
+
+## 8. Graduation Process
+
+When a feature is ready for general availability:
+
+### 1. Update Feature Status
+
+```typescript
+{
+  id: 'collaborative_editing',
+  status: 'graduated',  // Changed from 'experimental'
+  graduatedAt: '2026-03',
+  // ... rest unchanged
+}
+```
+
+### 2. Feature Behavior
+
+- **Graduated features always return `true`** from `isFeatureEnabled()`
+- User's previous toggle state is preserved but ignored
+- Feature still appears in Labs with "Now available to everyone!" messaging
+- Can be hidden from Labs UI after a cooldown period
+
+### 3. Code Cleanup (Optional)
+
+After graduation, feature flag checks can be removed:
+
+```typescript
+// Before (with flag)
+const isEnabled = useFeatureFlag('collaborative_editing');
+if (isEnabled) {
+  return <CollabUI />;
+}
+
+// After (graduated, flag removed)
+return <CollabUI />;
+```
+
+---
+
+## 9. Storage Schema
+
+### localStorage Keys
+
+| Key | Content |
+|-----|---------|
+| `gridfinity-labs-v1` | JSON-serialized `LabsPreferences` |
+
+### Example Stored Data
+
+```json
+{
+  "enabledFeatures": {
+    "collaborative_editing": true,
+    "drawer_to_print": false
+  },
+  "lastModified": "2026-01-14T10:30:00.000Z",
+  "version": 1
+}
+```
+
+### Migration Support
+
+The `version` field enables future migrations:
+
+```typescript
+function migratePreferences(stored: unknown): LabsPreferences {
+  const prefs = stored as LabsPreferences;
+
+  // v1 → v2 migration (example)
+  if (prefs.version === 1) {
+    // Perform migration
+    prefs.version = 2;
+  }
+
+  return prefs;
+}
+```
+
+---
+
+## 10. File Structure
+
+```
+src/
+├── labs/
+│   ├── index.ts                # Public API exports
+│   ├── types.ts                # Type definitions
+│   └── features.ts             # Feature registry
+│
+├── store/
+│   └── labs.ts                 # Zustand store
+│
+├── hooks/
+│   └── useFeatureFlag.ts       # React hook + imperative helper
+│
+├── components/
+│   └── labs/
+│       ├── LabsDrawer.tsx      # Main drawer
+│       ├── LabsButton.tsx      # Entry point with badge
+│       ├── FeatureCard.tsx     # Feature toggle card
+│       ├── FeatureStatusBadge.tsx
+│       └── GraduatedSection.tsx
+│
+└── utils/
+    └── analytics.ts            # Extended with Labs events
+```
+
+---
+
+## 11. Security & Privacy
+
+### No Sensitive Data
+
+- Labs stores only feature toggle states
+- No user-identifying information
+- No server-side persistence
+
+### Analytics Consent
+
+Labs events follow existing PostHog consent patterns:
+- Only tracked in production
+- Events are anonymized
+- Users can disable via browser settings
+
+---
+
+## 12. Performance Considerations
+
+### Bundle Impact
+
+- **Labs store**: ~2KB (similar to existing stores)
+- **Labs components**: ~5KB (lazy-loadable)
+- **Feature registry**: ~1KB
+
+### Lazy Loading
+
+The Labs drawer can be lazy-loaded since it's not needed on initial render:
+
+```typescript
+const LabsDrawer = lazy(() => import('./components/labs/LabsDrawer'));
+```
+
+### Storage Event Performance
+
+Storage events are lightweight and handled efficiently by the existing cross-tab sync mechanism.
+
+---
+
+## 13. Testing Strategy
+
+### Unit Tests
+
+- Store actions (toggle, enable, disable, sync)
+- Feature lookup functions
+- Graduation logic
+
+### Integration Tests
+
+- Cross-tab sync behavior
+- Analytics event emission
+- Feature flag checks
+
+### E2E Tests
+
+- Open Labs drawer
+- Toggle feature and verify UI change
+- Cross-tab sync verification
+
+---
+
+## Appendix: Alternatives Considered
+
+### Server-Side Feature Flags
+
+**Rejected because:**
+- App is client-side only, no backend auth
+- Users should control their own experiments
+- Would require additional infrastructure
+
+### Environment Variables
+
+**Rejected because:**
+- Can't be changed at runtime
+- No per-user control
+- Requires rebuild to change
+
+### Third-Party Services (LaunchDarkly, Split)
+
+**Rejected because:**
+- User specifically requested no 3rd party dependencies
+- Overkill for user-controlled experiments
+- Adds external dependency
+
+---
+
+*Document created: 2026-01-14*
+*Status: Architecture Plan - Ready for Review*

--- a/docs/projects/labs-feature-flags/design-requirements.md
+++ b/docs/projects/labs-feature-flags/design-requirements.md
@@ -1,0 +1,790 @@
+# Design Requirements: Labs Feature Flags
+
+**Document Version**: 1.0
+**Last Updated**: January 2026
+**Status**: Draft
+**Related Docs**: [PRD](./prd.md) | [Architecture](./architecture.md)
+
+---
+
+## Table of Contents
+
+1. [Design Principles](#1-design-principles)
+2. [Color & Visual System](#2-color--visual-system)
+3. [Component Specifications](#3-component-specifications)
+4. [Layout & Spacing](#4-layout--spacing)
+5. [Interaction Patterns](#5-interaction-patterns)
+6. [States & Feedback](#6-states--feedback)
+7. [Motion & Animation](#7-motion--animation)
+8. [Responsive Adaptations](#8-responsive-adaptations)
+9. [Accessibility](#9-accessibility)
+10. [Design Tokens](#10-design-tokens)
+11. [Asset Specifications](#11-asset-specifications)
+
+---
+
+## 1. Design Principles
+
+### 1.1 Core Principles
+
+| Principle | Description | Application |
+|-----------|-------------|-------------|
+| **Non-Intrusive** | Labs shouldn't distract from core functionality | Subtle entry point, drawer pattern |
+| **Transparent** | Users should understand what they're opting into | Clear descriptions, risk indicators |
+| **Reversible** | Actions should be easily undoable | Simple toggle, no confirmation dialogs |
+| **Discoverable** | Users should find Labs without searching | Badge draws attention when relevant |
+| **Consistent** | Labs UI should match existing app patterns | Same drawer, button, and toggle styles |
+
+### 1.2 Design Goals
+
+1. **Zero friction opt-in** - Single click to try a feature
+2. **Clear risk communication** - Users understand what's experimental
+3. **Minimal cognitive load** - Simple list, not complex configuration
+4. **Integration with existing UI** - Feels like part of the app
+
+---
+
+## 2. Color & Visual System
+
+### 2.1 Status Colors
+
+Colors indicate feature maturity level:
+
+| Status | Color | Token | Usage |
+|--------|-------|-------|-------|
+| Experimental | Amber | `--status-experimental` | High visibility, caution |
+| Preview | Blue | `--status-preview` | Positive, nearing completion |
+| Graduated | Green | `--status-graduated` | Success, stable |
+| Deprecated | Gray | `--status-deprecated` | Low emphasis, phasing out |
+
+**Color Values (Dark Theme):**
+```css
+--status-experimental: #F59E0B;    /* Amber 500 */
+--status-experimental-bg: #78350F; /* Amber 900, 20% opacity */
+--status-preview: #3B82F6;         /* Blue 500 */
+--status-preview-bg: #1E3A8A;      /* Blue 900, 20% opacity */
+--status-graduated: #22C55E;       /* Green 500 */
+--status-graduated-bg: #14532D;    /* Green 900, 20% opacity */
+--status-deprecated: #6B7280;      /* Gray 500 */
+```
+
+### 2.2 Risk Level Colors
+
+| Risk | Icon | Color | Usage |
+|------|------|-------|-------|
+| Low | 🟢 Circle | Green | Minimal risk, safe to try |
+| Medium | ⚠️ Warning | Amber | Some risk, read description |
+| High | 🔴 Circle | Red | Significant risk, may cause issues |
+
+**Color Values:**
+```css
+--risk-low: #22C55E;
+--risk-medium: #F59E0B;
+--risk-high: #EF4444;
+```
+
+### 2.3 Badge Colors
+
+The Labs button badge uses accent colors:
+
+| State | Background | Text |
+|-------|------------|------|
+| Has enabled features | `--bg-accent/80` | `--text-on-accent` |
+| No enabled features | (no badge shown) | — |
+
+---
+
+## 3. Component Specifications
+
+### 3.1 Labs Button
+
+The entry point in the sidebar.
+
+**Default State:**
+```
+┌───────────────────────────┐
+│  🧪  Labs                 │
+└───────────────────────────┘
+```
+
+**With Enabled Features:**
+```
+┌───────────────────────────┐
+│  🧪  Labs          [2]    │
+│                     ↑     │
+│                  Badge    │
+└───────────────────────────┘
+```
+
+**Specifications:**
+
+| Property | Value |
+|----------|-------|
+| Height | 40px |
+| Padding | 8px 12px |
+| Icon size | 18px |
+| Icon-text gap | 8px |
+| Font size | 14px |
+| Font weight | 500 (medium) |
+| Border radius | 6px |
+| Background | `--bg-surface` |
+| Background (hover) | `--bg-surface-hover` |
+| Text color | `--text-content-secondary` |
+| Text color (hover) | `--text-content` |
+
+**Badge Specifications:**
+
+| Property | Value |
+|----------|-------|
+| Size | 18px × 18px (min) |
+| Padding | 2px 6px |
+| Font size | 11px |
+| Font weight | 600 (semibold) |
+| Border radius | 9px (pill) |
+| Background | `--bg-accent` |
+| Text color | white |
+| Max display | "9+" for counts > 9 |
+
+### 3.2 Labs Drawer
+
+The main container for Labs features.
+
+**Structure:**
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Header                                                  [×] │
+├─────────────────────────────────────────────────────────────┤
+│ Description text                                            │
+│                                                             │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ Feature Card 1                                          │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│                                                             │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ Feature Card 2                                          │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│                                                             │
+│ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ │
+│                                                             │
+│ ▸ Graduated Features (collapsed section)                    │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Specifications:**
+
+| Property | Value |
+|----------|-------|
+| Width | 400px (desktop), 100% (mobile) |
+| Max width | 100vw |
+| Position | Fixed, right side |
+| Background | `--bg-surface-elevated` |
+| Border left | 1px solid `--border-stroke-subtle` |
+| Shadow | `--shadow-xl` |
+| Z-index | 100 (above panels, below modals) |
+| Padding | 24px |
+
+**Header:**
+
+| Property | Value |
+|----------|-------|
+| Height | 48px |
+| Title font size | 18px |
+| Title font weight | 600 |
+| Close button | 32px × 32px |
+| Bottom border | 1px solid `--border-stroke-subtle` |
+
+**Description:**
+
+| Property | Value |
+|----------|-------|
+| Font size | 14px |
+| Line height | 1.5 |
+| Color | `--text-content-secondary` |
+| Margin bottom | 24px |
+
+### 3.3 Feature Card
+
+Individual feature display with toggle.
+
+**Structure:**
+```
+┌─────────────────────────────────────────────────────────────┐
+│ [Title]                                  [STATUS BADGE]     │
+│                                                             │
+│ Description text that explains what the feature does        │
+│ and why you might want to enable it.                        │
+│                                                             │
+│ ⚠️ Warning text for medium/high risk features              │
+│                                                             │
+│ [Learn more]                                    [━━━○━━━━]  │
+│      ↑                                              ↑       │
+│   Link (optional)                               Toggle      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Specifications:**
+
+| Property | Value |
+|----------|-------|
+| Background | `--bg-surface` |
+| Border | 1px solid `--border-stroke-subtle` |
+| Border radius | 8px |
+| Padding | 16px |
+| Margin bottom | 12px |
+
+**Title:**
+
+| Property | Value |
+|----------|-------|
+| Font size | 15px |
+| Font weight | 600 |
+| Color | `--text-content` |
+| Line height | 1.3 |
+
+**Status Badge:**
+
+| Property | Value |
+|----------|-------|
+| Font size | 10px |
+| Font weight | 600 |
+| Text transform | uppercase |
+| Letter spacing | 0.5px |
+| Padding | 4px 8px |
+| Border radius | 4px |
+| Background | Status color at 20% opacity |
+| Text color | Status color |
+
+**Description:**
+
+| Property | Value |
+|----------|-------|
+| Font size | 13px |
+| Line height | 1.5 |
+| Color | `--text-content-secondary` |
+| Margin top | 8px |
+
+**Warning:**
+
+| Property | Value |
+|----------|-------|
+| Font size | 12px |
+| Line height | 1.4 |
+| Color | `--risk-medium` or `--risk-high` |
+| Margin top | 12px |
+| Padding | 8px 12px |
+| Background | Risk color at 10% opacity |
+| Border radius | 4px |
+| Icon | ⚠️ or appropriate warning icon |
+
+**Learn More Link:**
+
+| Property | Value |
+|----------|-------|
+| Font size | 12px |
+| Color | `--text-accent` |
+| Text decoration | none (underline on hover) |
+
+### 3.4 Toggle Switch
+
+Standard toggle following existing app patterns.
+
+**Structure:**
+```
+Off state:   [━━━●━━━━]
+On state:    [━━━━━━●━]
+```
+
+**Specifications:**
+
+| Property | Value (Off) | Value (On) |
+|----------|-------------|------------|
+| Width | 44px | 44px |
+| Height | 24px | 24px |
+| Background | `--bg-surface-secondary` | `--bg-accent` |
+| Border | 1px solid `--border-stroke` | none |
+| Border radius | 12px | 12px |
+| Knob size | 20px | 20px |
+| Knob color | white | white |
+| Knob position | left (2px offset) | right (2px offset) |
+| Transition | 200ms ease | 200ms ease |
+
+**Graduated State (Always On):**
+
+| Property | Value |
+|----------|-------|
+| Background | `--bg-success/30` |
+| Knob | Checkmark icon or solid |
+| Cursor | not-allowed |
+| Opacity | 0.7 |
+
+### 3.5 Graduated Section
+
+Collapsible section for graduated features.
+
+**Structure:**
+```
+▸ What's New (2)
+─────────────────────────────────────────────────────────────
+
+Expanded:
+▾ What's New (2)
+┌─────────────────────────────────────────────────────────────┐
+│ ✓ Feature Name                                              │
+│   Now available to everyone!                                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Specifications:**
+
+| Property | Value |
+|----------|-------|
+| Header height | 40px |
+| Header font size | 14px |
+| Header font weight | 500 |
+| Header color | `--text-content-secondary` |
+| Chevron size | 16px |
+| Divider | 1px dashed `--border-stroke-subtle` |
+
+---
+
+## 4. Layout & Spacing
+
+### 4.1 Drawer Internal Layout
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│ 24px padding                                                  │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │ Header (48px)                                           │  │
+│  └─────────────────────────────────────────────────────────┘  │
+│  16px gap                                                     │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │ Description                                             │  │
+│  └─────────────────────────────────────────────────────────┘  │
+│  24px gap                                                     │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │ Feature Card 1                                          │  │
+│  └─────────────────────────────────────────────────────────┘  │
+│  12px gap                                                     │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │ Feature Card 2                                          │  │
+│  └─────────────────────────────────────────────────────────┘  │
+│  24px gap                                                     │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │ Graduated Section                                       │  │
+│  └─────────────────────────────────────────────────────────┘  │
+│ 24px padding                                                  │
+└───────────────────────────────────────────────────────────────┘
+```
+
+### 4.2 Feature Card Internal Layout
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│ 16px padding                                                  │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │ [Title]                          [STATUS BADGE]         │  │
+│  │ ← Row: justify-between, align-center                    │  │
+│  └─────────────────────────────────────────────────────────┘  │
+│  8px gap                                                      │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │ Description paragraph                                   │  │
+│  └─────────────────────────────────────────────────────────┘  │
+│  12px gap (if warning present)                                │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │ ⚠️ Warning text                                         │  │
+│  └─────────────────────────────────────────────────────────┘  │
+│  16px gap                                                     │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │ [Learn more]                            [Toggle]        │  │
+│  │ ← Row: justify-between, align-center                    │  │
+│  └─────────────────────────────────────────────────────────┘  │
+│ 16px padding                                                  │
+└───────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 5. Interaction Patterns
+
+### 5.1 Opening Labs Drawer
+
+| Trigger | Behavior |
+|---------|----------|
+| Click Labs button | Drawer slides in from right (300ms) |
+| Keyboard shortcut (future) | Same as click |
+| Deep link `/#labs` (future) | Open drawer on page load |
+
+### 5.2 Closing Labs Drawer
+
+| Trigger | Behavior |
+|---------|----------|
+| Click × button | Drawer slides out (200ms) |
+| Press Escape | Same as click × |
+| Click backdrop (outside drawer) | Same as click × |
+
+### 5.3 Toggle Feature
+
+| Action | Behavior |
+|--------|----------|
+| Click toggle (off → on) | Toggle animates to on state, feature enabled |
+| Click toggle (on → off) | Toggle animates to off state, feature disabled |
+| Click anywhere on card | No effect (only toggle is interactive) |
+
+### 5.4 Expand/Collapse Graduated
+
+| Action | Behavior |
+|--------|----------|
+| Click section header | Section expands/collapses with animation |
+| Chevron rotates | 90° rotation on expand |
+
+---
+
+## 6. States & Feedback
+
+### 6.1 Labs Button States
+
+| State | Appearance |
+|-------|------------|
+| Default | Normal text, flask icon |
+| Hover | Background highlight, slightly brighter text |
+| Active (pressed) | Slightly darker background |
+| With badge | Badge visible, shows count |
+
+### 6.2 Feature Card States
+
+| State | Appearance |
+|-------|------------|
+| Disabled | Normal card, toggle off |
+| Enabled | Card has subtle highlight border |
+| Hover (toggle) | Toggle background slightly lighter |
+| Focus (toggle) | Focus ring around toggle |
+
+### 6.3 Toggle States
+
+| State | Visual |
+|-------|--------|
+| Off | Knob left, gray track |
+| On | Knob right, accent track |
+| Hover | Track slightly lighter |
+| Focus | 2px focus ring |
+| Disabled (graduated) | Grayed out, checkmark |
+
+### 6.4 Visual Feedback on Toggle
+
+When a feature is toggled:
+
+1. **Toggle animates** (200ms)
+2. **No toast notification** (toggle state is clear)
+3. **Badge updates** (if count changes)
+4. **Feature activates** (no delay)
+
+---
+
+## 7. Motion & Animation
+
+### 7.1 Drawer Animations
+
+| Animation | Duration | Easing | Property |
+|-----------|----------|--------|----------|
+| Slide in | 300ms | ease-out | transform: translateX |
+| Slide out | 200ms | ease-in | transform: translateX |
+| Backdrop fade in | 300ms | ease-out | opacity |
+| Backdrop fade out | 200ms | ease-in | opacity |
+
+**CSS:**
+```css
+.labs-drawer {
+  transform: translateX(100%);
+  transition: transform 300ms ease-out;
+}
+
+.labs-drawer.open {
+  transform: translateX(0);
+}
+
+.labs-backdrop {
+  opacity: 0;
+  transition: opacity 300ms ease-out;
+}
+
+.labs-backdrop.visible {
+  opacity: 1;
+}
+```
+
+### 7.2 Toggle Animation
+
+| Property | Duration | Easing |
+|----------|----------|--------|
+| Knob position | 200ms | ease |
+| Track color | 200ms | ease |
+
+### 7.3 Collapse Animation
+
+| Property | Duration | Easing |
+|----------|----------|--------|
+| Section height | 200ms | ease-out |
+| Chevron rotation | 200ms | ease |
+
+### 7.4 Reduced Motion
+
+When `prefers-reduced-motion` is enabled:
+- Drawer appears instantly (no slide)
+- Toggle changes instantly
+- Section expands instantly
+
+---
+
+## 8. Responsive Adaptations
+
+### 8.1 Breakpoint Behaviors
+
+| Element | Desktop (≥900px) | Tablet (768-899px) | Mobile (<768px) |
+|---------|------------------|--------------------|--------------------|
+| Labs button | In sidebar | In sidebar | In mobile settings |
+| Drawer width | 400px | 360px | 100% |
+| Drawer position | Right side | Right side | Full screen / Bottom sheet |
+| Backdrop | Semi-transparent | Semi-transparent | Solid |
+| Close method | ×, Escape, backdrop | Same | ×, Escape, swipe down |
+
+### 8.2 Mobile Drawer
+
+On mobile, Labs opens as a full-screen modal or bottom sheet:
+
+```
+┌─────────────────────────────────────────┐
+│ ─────                                   │  ← Drag handle
+│                                         │
+│ 🧪 Labs                            [×]  │
+│                                         │
+│ Try experimental features...            │
+│                                         │
+│ ┌─────────────────────────────────────┐ │
+│ │ Collaborative Editing [EXPERIMENTAL]│ │
+│ │                                     │ │
+│ │ Work on layouts together...         │ │
+│ │                              [━━━○] │ │
+│ └─────────────────────────────────────┘ │
+│                                         │
+│ ┌─────────────────────────────────────┐ │
+│ │ Drawer-to-Print       [EXPERIMENTAL]│ │
+│ │                                     │ │
+│ │ Generate STL files...               │ │
+│ │                              [━━━○] │ │
+│ └─────────────────────────────────────┘ │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Mobile-specific specs:**
+
+| Property | Value |
+|----------|-------|
+| Padding | 16px |
+| Feature card margin | 8px |
+| Toggle size | 48px × 28px (larger touch target) |
+| Min touch target | 44px × 44px |
+
+### 8.3 Mobile Entry Point
+
+On mobile, Labs is accessed via the settings panel:
+
+```
+Settings Panel:
+┌─────────────────────────────────────────┐
+│ Grid Size                               │
+│ [width/depth/height controls]           │
+│                                         │
+│ Physical Units                          │
+│ [mm controls]                           │
+│                                         │
+│ ────────────────────────────────────    │
+│                                         │
+│ 🧪 Labs                          [2] >  │  ← Tappable row
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+---
+
+## 9. Accessibility
+
+### 9.1 ARIA Roles & Labels
+
+| Element | Role | Label |
+|---------|------|-------|
+| Labs button | `button` | "Open Labs experimental features" |
+| Labs drawer | `dialog` | "Labs experimental features" |
+| Close button | `button` | "Close Labs" |
+| Feature card | `article` | — |
+| Toggle | `switch` | "{Feature name}, {on/off}" |
+| Status badge | — | `aria-label="Status: Experimental"` |
+| Graduated section | `region` | "Graduated features" |
+
+### 9.2 Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| Tab | Move between interactive elements |
+| Enter/Space | Activate button or toggle |
+| Escape | Close drawer |
+| Arrow keys | Navigate within toggle (not needed) |
+
+**Focus Order:**
+1. Close button (×)
+2. First feature card toggle
+3. Learn more link (if present)
+4. Second feature card toggle
+5. ...continue through cards
+6. Graduated section toggle
+
+### 9.3 Focus Management
+
+- When drawer opens, focus moves to close button or first toggle
+- Focus is trapped within drawer while open
+- When drawer closes, focus returns to Labs button
+
+### 9.4 Screen Reader Announcements
+
+| Event | Announcement |
+|-------|--------------|
+| Drawer opens | "Labs dialog opened" |
+| Toggle on | "{Feature name} enabled" |
+| Toggle off | "{Feature name} disabled" |
+| Drawer closes | "Labs dialog closed" |
+
+### 9.5 Color Contrast
+
+All text meets WCAG AA standards:
+- Regular text: 4.5:1 minimum
+- Large text: 3:1 minimum
+- Status badges: Text on colored background meets 4.5:1
+
+---
+
+## 10. Design Tokens
+
+### 10.1 Labs-Specific Tokens
+
+```css
+:root {
+  /* Status colors */
+  --labs-status-experimental: #F59E0B;
+  --labs-status-experimental-bg: rgba(245, 158, 11, 0.15);
+  --labs-status-preview: #3B82F6;
+  --labs-status-preview-bg: rgba(59, 130, 246, 0.15);
+  --labs-status-graduated: #22C55E;
+  --labs-status-graduated-bg: rgba(34, 197, 94, 0.15);
+
+  /* Risk colors */
+  --labs-risk-low: #22C55E;
+  --labs-risk-medium: #F59E0B;
+  --labs-risk-high: #EF4444;
+  --labs-risk-low-bg: rgba(34, 197, 94, 0.1);
+  --labs-risk-medium-bg: rgba(245, 158, 11, 0.1);
+  --labs-risk-high-bg: rgba(239, 68, 68, 0.1);
+
+  /* Component sizes */
+  --labs-drawer-width: 400px;
+  --labs-drawer-width-tablet: 360px;
+  --labs-toggle-width: 44px;
+  --labs-toggle-height: 24px;
+  --labs-toggle-mobile-width: 48px;
+  --labs-toggle-mobile-height: 28px;
+
+  /* Animation */
+  --labs-drawer-duration: 300ms;
+  --labs-toggle-duration: 200ms;
+
+  /* Z-index */
+  --labs-drawer-z: 100;
+  --labs-backdrop-z: 99;
+}
+```
+
+### 10.2 Component Tokens
+
+```css
+/* Labs Button */
+--labs-button-height: 40px;
+--labs-button-padding: 8px 12px;
+--labs-button-icon-size: 18px;
+--labs-button-gap: 8px;
+
+/* Badge */
+--labs-badge-min-size: 18px;
+--labs-badge-padding: 2px 6px;
+--labs-badge-font-size: 11px;
+--labs-badge-radius: 9px;
+
+/* Feature Card */
+--labs-card-padding: 16px;
+--labs-card-gap: 12px;
+--labs-card-radius: 8px;
+```
+
+---
+
+## 11. Asset Specifications
+
+### 11.1 Icons
+
+| Icon | Size | Usage | Source |
+|------|------|-------|--------|
+| Flask/Beaker | 18px | Labs button | Heroicons or custom |
+| Close (×) | 20px | Drawer close | Heroicons |
+| Chevron | 16px | Collapse section | Heroicons |
+| Warning | 14px | Risk indicator | Heroicons |
+| Checkmark | 12px | Graduated toggle | Heroicons |
+| External link | 12px | Learn more link | Heroicons |
+
+### 11.2 Flask Icon SVG
+
+```svg
+<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M9 3h6v6l5 10H4L9 9V3z" />
+  <path d="M9 3h6" />
+</svg>
+```
+
+Alternative (more detailed):
+```svg
+<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
+</svg>
+```
+
+### 11.3 Status Badge Icons (Optional)
+
+If badges include icons:
+
+| Status | Icon |
+|--------|------|
+| Experimental | Beaker/Flask (tiny) |
+| Preview | Eye |
+| Graduated | Checkmark |
+| Deprecated | Archive |
+
+---
+
+## Appendix A: Google Labs Reference
+
+The design is inspired by Google Search Labs, with adaptations for our context:
+
+| Google Labs | Our Adaptation |
+|-------------|----------------|
+| Full-page experience | Side drawer |
+| Card illustrations | Text-only cards |
+| Thumbs up/down feedback | Simple toggle |
+| "Try it" button | Toggle switch |
+| Status cards | Status badges |
+
+---
+
+## Appendix B: Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-01 | Design Team | Initial draft |

--- a/docs/projects/labs-feature-flags/prd.md
+++ b/docs/projects/labs-feature-flags/prd.md
@@ -1,0 +1,553 @@
+# Product Requirements Document: Labs Feature Flags
+
+**Document Version**: 1.0
+**Last Updated**: January 2026
+**Status**: Draft
+**Author**: Product Team
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Problem Statement](#2-problem-statement)
+3. [Goals & Success Metrics](#3-goals--success-metrics)
+4. [User Personas](#4-user-personas)
+5. [User Stories](#5-user-stories)
+6. [Functional Requirements](#6-functional-requirements)
+7. [Non-Functional Requirements](#7-non-functional-requirements)
+8. [User Experience](#8-user-experience)
+9. [Edge Cases & Error Handling](#9-edge-cases--error-handling)
+10. [Out of Scope](#10-out-of-scope)
+11. [Dependencies & Risks](#11-dependencies--risks)
+12. [Release Plan](#12-release-plan)
+13. [Appendix](#13-appendix)
+
+---
+
+## 1. Overview
+
+### 1.1 Executive Summary
+
+Add a "Labs" feature to the Gridfinity Layout Tool that allows users to opt into experimental features. This provides a safe way to test new functionality with real users, gather feedback, and iterate before general availability.
+
+### 1.2 Background
+
+The Gridfinity Layout Tool is planning two major features:
+- **Collaborative Editing**: Real-time multi-user layout editing
+- **Drawer-to-Print**: STL generation and export system
+
+Both features are complex and would benefit from user testing before full release. A Labs system allows:
+- Early adopters to try new features
+- Developers to gather real-world feedback
+- Gradual rollout without big-bang releases
+
+### 1.3 Proposal
+
+Introduce a "Labs" section accessible from the sidebar settings area. Users can browse experimental features, read descriptions and warnings, and toggle them on/off. Preferences persist in local storage and sync across browser tabs.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 User Pain Points
+
+| Pain Point | Current State | Impact |
+|------------|---------------|--------|
+| **No early access** | Users must wait for full releases | Missing feedback opportunity |
+| **Binary releases** | Features are either available or not | High risk for complex features |
+| **No user control** | Users can't opt out of buggy features | Frustration with unstable features |
+
+### 2.2 Opportunity
+
+A Labs system enables:
+- **Faster iteration**: Real user feedback before GA
+- **Risk mitigation**: Bugs affect only opt-in users
+- **User engagement**: Power users feel invested in product direction
+- **Quality improvement**: More testing before wide release
+
+---
+
+## 3. Goals & Success Metrics
+
+### 3.1 Product Goals
+
+| Goal | Description | Priority |
+|------|-------------|----------|
+| **G1** | Enable users to opt into experimental features | P0 |
+| **G2** | Provide clear information about feature risks | P0 |
+| **G3** | Support immediate effect without page refresh | P1 |
+| **G4** | Track feature adoption for product decisions | P1 |
+| **G5** | Maintain stable experience for non-opt-in users | P0 |
+
+### 3.2 Success Metrics
+
+| Metric | Target | Measurement Method |
+|--------|--------|-------------------|
+| **Discovery Rate** | 20% of active users view Labs within 1 month | Analytics: `labs_drawer_opened` |
+| **Adoption Rate** | 10% of active users enable at least one feature | Analytics: `labs_feature_enabled` |
+| **Retention** | 50% of opt-in users keep feature enabled for 1+ week | Analytics: weekly snapshot |
+| **Feedback Quality** | Useful bug reports from Labs users | Manual: GitHub issues tagged `labs` |
+
+### 3.3 Non-Goals
+
+- Server-side feature flag evaluation
+- A/B testing or percentage rollouts
+- Feature flag targeting by user segment
+- Administrative UI for flag management
+
+---
+
+## 4. User Personas
+
+### 4.1 Primary Personas
+
+#### **Alex - The Power User**
+- **Background**: Uses the app daily, creates complex layouts
+- **Goal**: Try new features as soon as possible
+- **Behavior**: Actively seeks out betas and early access
+- **Needs**: Clear descriptions, easy toggle, sees value immediately
+- **Quote**: "I want to help shape the product by testing early features."
+
+#### **Jordan - The Cautious User**
+- **Background**: Uses the app occasionally, values stability
+- **Goal**: Reliable experience, only proven features
+- **Behavior**: Waits for features to be stable before trying
+- **Needs**: Clear that Labs is optional, easy to ignore
+- **Quote**: "I just want my layouts to work without surprises."
+
+### 4.2 Secondary Personas
+
+#### **Casey - The Curious Explorer**
+- **Background**: New to the app, exploring capabilities
+- **Goal**: Understand what the app can do
+- **Behavior**: Clicks around to discover features
+- **Needs**: Non-threatening Labs entry, clear what's experimental
+- **Quote**: "I wonder what else this app can do?"
+
+---
+
+## 5. User Stories
+
+### 5.1 Discovery & Access
+
+#### US-1.1: Discover Labs
+**As** a user exploring the app
+**I want to** find the Labs section easily
+**So that** I know experimental features exist
+
+**Acceptance Criteria:**
+- [ ] "Labs" button visible in sidebar/settings area
+- [ ] Button has recognizable icon (flask/beaker)
+- [ ] Badge shows count when features are enabled
+- [ ] Tooltip explains what Labs is on hover
+
+#### US-1.2: Open Labs Drawer
+**As** a user
+**I want to** open the Labs drawer
+**So that** I can see available experimental features
+
+**Acceptance Criteria:**
+- [ ] Click Labs button opens drawer from right
+- [ ] Drawer slides in smoothly (300ms)
+- [ ] Drawer can be closed via X button, Escape key, or clicking outside
+- [ ] Opening tracked for analytics
+
+### 5.2 Feature Exploration
+
+#### US-2.1: View Available Features
+**As** a user in the Labs drawer
+**I want to** see all available experimental features
+**So that** I can decide which to try
+
+**Acceptance Criteria:**
+- [ ] Features displayed as cards in a list
+- [ ] Each card shows: name, description, status badge, toggle
+- [ ] Cards grouped by status (Experimental, Preview, Graduated)
+- [ ] Empty state if no features available
+
+#### US-2.2: Understand Feature Risk
+**As** a user considering enabling a feature
+**I want to** understand the risks involved
+**So that** I can make an informed decision
+
+**Acceptance Criteria:**
+- [ ] Risk level indicated visually (Low/Medium/High)
+- [ ] Warning text shown for Medium/High risk features
+- [ ] Optional "Learn More" link opens documentation
+- [ ] Status badge indicates maturity level
+
+#### US-2.3: See Graduated Features
+**As** a user who previously tested a feature
+**I want to** know when features graduate
+**So that** I feel my testing contributed
+
+**Acceptance Criteria:**
+- [ ] Graduated features shown in separate section
+- [ ] "Now available to everyone!" messaging
+- [ ] Toggle shows "Always on" state
+- [ ] Section can be collapsed/hidden
+
+### 5.3 Feature Activation
+
+#### US-3.1: Enable Feature
+**As** a user who wants to try a feature
+**I want to** enable it with a simple toggle
+**So that** I can start using it immediately
+
+**Acceptance Criteria:**
+- [ ] Toggle switch is clearly visible
+- [ ] Single click to enable
+- [ ] Toggle state reflected immediately in UI
+- [ ] Feature becomes active without page refresh
+- [ ] Analytics event tracked
+
+#### US-3.2: Disable Feature
+**As** a user experiencing issues
+**I want to** disable a feature quickly
+**So that** I can return to stable behavior
+
+**Acceptance Criteria:**
+- [ ] Same toggle to disable
+- [ ] Single click to disable
+- [ ] Feature deactivated immediately
+- [ ] No data loss from disabling
+- [ ] Analytics event tracked
+
+#### US-3.3: Persistence Across Sessions
+**As** a user who enabled features
+**I want to** keep my preferences
+**So that** I don't have to re-enable after refresh
+
+**Acceptance Criteria:**
+- [ ] Preferences saved to localStorage
+- [ ] Restored on page load
+- [ ] Synced across browser tabs
+- [ ] Migration support for version upgrades
+
+### 5.4 Visual Feedback
+
+#### US-4.1: See Active Feature Count
+**As** a user with features enabled
+**I want to** see how many are active at a glance
+**So that** I know experimental features are running
+
+**Acceptance Criteria:**
+- [ ] Badge on Labs button shows count
+- [ ] Count only includes experimental/preview features
+- [ ] Badge hidden when count is 0
+- [ ] Updates immediately on toggle
+
+#### US-4.2: Identify Experimental UI Elements
+**As** a user with features enabled
+**I want to** know which parts of the UI are experimental
+**So that** I understand where issues might come from
+
+**Acceptance Criteria:**
+- [ ] Optional "Labs" badge on experimental UI elements
+- [ ] Badge is subtle but visible
+- [ ] Clicking badge opens Labs drawer (nice-to-have)
+
+---
+
+## 6. Functional Requirements
+
+### 6.1 Core Functionality
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| FR-1.1 | System shall display a Labs entry point in the sidebar | P0 |
+| FR-1.2 | Entry point shall show a badge with enabled feature count | P0 |
+| FR-1.3 | Labs drawer shall slide in from the right side | P0 |
+| FR-1.4 | Drawer shall list all non-deprecated experimental features | P0 |
+| FR-1.5 | Each feature shall have a toggle to enable/disable | P0 |
+| FR-1.6 | Toggles shall take effect immediately without page refresh | P0 |
+| FR-1.7 | Preferences shall persist in localStorage | P0 |
+| FR-1.8 | Preferences shall sync across browser tabs | P1 |
+
+### 6.2 Feature Display
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| FR-2.1 | Features shall display name and description | P0 |
+| FR-2.2 | Features shall display status badge (Experimental/Preview/Graduated) | P0 |
+| FR-2.3 | Features shall display risk level indicator | P1 |
+| FR-2.4 | High-risk features shall display warning text | P1 |
+| FR-2.5 | Features may display "Learn More" link | P2 |
+| FR-2.6 | Graduated features shall show "Always on" state | P1 |
+
+### 6.3 Analytics
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| FR-3.1 | System shall track Labs drawer opens | P1 |
+| FR-3.2 | System shall track feature enable events | P1 |
+| FR-3.3 | System shall track feature disable events | P1 |
+| FR-3.4 | Events shall include feature ID and status | P1 |
+
+---
+
+## 7. Non-Functional Requirements
+
+### 7.1 Performance
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| NFR-1.1 | Labs drawer open animation | < 300ms |
+| NFR-1.2 | Feature toggle response time | < 100ms |
+| NFR-1.3 | localStorage read on page load | < 50ms |
+| NFR-1.4 | Cross-tab sync latency | < 1 second |
+
+### 7.2 Reliability
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| NFR-2.1 | Non-Labs users unaffected by Labs bugs | 100% |
+| NFR-2.2 | Preferences survive browser updates | 100% |
+| NFR-2.3 | Graceful handling of corrupted preferences | Reset to defaults |
+
+### 7.3 Usability
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| NFR-3.1 | Labs discoverable without documentation | 90% of users |
+| NFR-3.2 | Feature toggle learnable on first use | 95% of users |
+| NFR-3.3 | Risk information understandable | Clear to non-technical users |
+
+### 7.4 Accessibility
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| NFR-4.1 | Keyboard navigable | Full keyboard support |
+| NFR-4.2 | Screen reader compatible | ARIA labels on all elements |
+| NFR-4.3 | Color contrast | WCAG AA compliance |
+| NFR-4.4 | Focus management | Focus trapped in drawer when open |
+
+---
+
+## 8. User Experience
+
+### 8.1 Entry Point
+
+```
+Sidebar (Desktop):
+┌─────────────────────────┐
+│ [Layers section]        │
+│ [Categories section]    │
+│ [Grid Size section]     │
+│ [Physical Units section]│
+│                         │
+│ ────────────────────    │
+│                         │
+│ [🧪 Labs]  [2]          │  ← Flask icon + badge
+│                         │
+└─────────────────────────┘
+```
+
+### 8.2 Labs Drawer
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 🧪 Labs                                                 [×] │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│ Try experimental features before they're ready for          │
+│ everyone. These may be buggy or change without notice.      │
+│                                                             │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ ○ Collaborative Editing                    [EXPERIMENTAL]│ │
+│ │                                                         │ │
+│ │ Work on layouts together in real-time with other        │ │
+│ │ people. Share a link and see each other's cursors.      │ │
+│ │                                                         │ │
+│ │ ⚠️ Medium Risk: Sessions expire after 24 hours.         │ │
+│ │                                                         │ │
+│ │ [Learn more]                              [━━━━○━━━━━]  │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│                                                             │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ ○ Drawer-to-Print Export                   [EXPERIMENTAL]│ │
+│ │                                                         │ │
+│ │ Generate STL files for all bins in your layout.         │ │
+│ │ Download a complete package for 3D printing.            │ │
+│ │                                                         │ │
+│ │ 🟢 Low Risk                                             │ │
+│ │                                                         │ │
+│ │ [Learn more]                              [━━━━━━━━━○]  │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│                                                             │
+│ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ │
+│                                                             │
+│ ▸ What's New (1)                                            │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 8.3 Feature Card States
+
+**Disabled State:**
+- Toggle switch off (left position)
+- Card at normal opacity
+- Click toggle to enable
+
+**Enabled State:**
+- Toggle switch on (right position)
+- Card may have subtle highlight
+- Click toggle to disable
+
+**Graduated State:**
+- Toggle shows "Always on" or checkmark
+- Card shows "Now available to everyone!"
+- Toggle not interactive
+
+### 8.4 Mobile Adaptation
+
+On mobile, Labs is accessed via:
+1. Bottom navigation → Settings icon
+2. Settings panel → Labs button
+3. Labs opens as full-screen modal or bottom sheet
+
+---
+
+## 9. Edge Cases & Error Handling
+
+### 9.1 Storage Errors
+
+| Scenario | Behavior |
+|----------|----------|
+| localStorage full | Show toast, preferences not saved |
+| localStorage disabled | Features work but don't persist |
+| Corrupted stored data | Reset to defaults, no error shown |
+| Version mismatch | Auto-migrate to current version |
+
+### 9.2 Feature Dependencies
+
+| Scenario | Behavior |
+|----------|----------|
+| Feature A requires Feature B | Show dependency note, auto-enable B when enabling A |
+| User disables dependency | Show warning, ask to disable dependent features |
+
+### 9.3 Cross-Tab Conflicts
+
+| Scenario | Behavior |
+|----------|----------|
+| Tabs have different states | Latest change wins (storage event) |
+| User toggles rapidly across tabs | Debounce sync to prevent flicker |
+
+---
+
+## 10. Out of Scope
+
+The following are explicitly **not** included in this version:
+
+### 10.1 Deferred to Future
+
+| Feature | Reason |
+|---------|--------|
+| Server-side flags | No backend authentication |
+| A/B testing | Not needed for user-controlled experiments |
+| Flag targeting | No user segments to target |
+| Admin UI | Features defined in code |
+
+### 10.2 Explicitly Not Planned
+
+| Feature | Reason |
+|---------|--------|
+| Third-party integration | User requested no external dependencies |
+| Percentage rollouts | User controls all experiments |
+| Feature expiration | Manual graduation instead |
+
+---
+
+## 11. Dependencies & Risks
+
+### 11.1 Dependencies
+
+| Dependency | Purpose | Status |
+|------------|---------|--------|
+| Zustand | State management | Existing |
+| localStorage | Preference persistence | Browser standard |
+| PostHog | Analytics tracking | Existing |
+| React transitions | Drawer animation | Existing |
+
+### 11.2 Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Users don't discover Labs | Medium | Low | Badge draws attention, in-app hints |
+| Experimental features break app | Low | Medium | Each feature isolated, easy disable |
+| Preferences lost on browser clear | Low | Low | Features re-toggleable, no data loss |
+| Too many experimental features | Low | Medium | Limit to 5-10 features, graduate promptly |
+
+---
+
+## 12. Release Plan
+
+### 12.1 Initial Release
+
+**Scope**: Labs infrastructure + two initial features
+- Labs UI (drawer, button, feature cards)
+- Collaborative Editing (experimental)
+- Drawer-to-Print (experimental)
+
+### 12.2 Future Features
+
+Labs will be the primary mechanism for rolling out:
+- New export formats
+- UI experiments
+- Workflow changes
+- Integration features
+
+### 12.3 Success Criteria for Launch
+
+- [ ] Labs drawer opens and closes correctly
+- [ ] Features can be toggled on/off
+- [ ] Preferences persist across sessions
+- [ ] Cross-tab sync works
+- [ ] Analytics events tracked
+- [ ] Documentation complete
+- [ ] Mobile experience works
+
+---
+
+## 13. Appendix
+
+### 13.1 Glossary
+
+| Term | Definition |
+|------|------------|
+| **Labs** | Section for experimental features |
+| **Feature Flag** | Configuration that enables/disables a feature |
+| **Experimental** | Feature in early testing, may have bugs |
+| **Preview** | Feature nearing completion, more stable |
+| **Graduated** | Feature now available to everyone |
+| **Risk Level** | Indicator of potential issues (Low/Medium/High) |
+
+### 13.2 Related Documents
+
+- [Systems Architecture: Labs Feature Flags](./architecture.md)
+- [Design Requirements: Labs Feature Flags](./design-requirements.md)
+
+### 13.3 Reference: Google Search Labs
+
+The design is inspired by Google Search Labs:
+- Side drawer access
+- Rich feature cards with descriptions
+- Simple toggle interaction
+- Clear experimental messaging
+
+### 13.4 Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-01 | Product Team | Initial draft |
+
+---
+
+## Approval
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Product Owner | | | |
+| Engineering Lead | | | |
+| Design Lead | | | |


### PR DESCRIPTION
## Summary

- Add comprehensive documentation for a client-side feature flagging system ("Labs")
- Allows users to opt into experimental features before general availability
- Follows existing project documentation patterns (PRD/Architecture/DRD)

## Documents Added

| Document | Description |
|----------|-------------|
| `README.md` | Project overview and quick reference |
| `prd.md` | Product requirements, user stories, acceptance criteria |
| `architecture.md` | Technical implementation, data models, state management |
| `design-requirements.md` | UI/UX specs, visual design, accessibility |

## Key Design Decisions

- **Entry Point**: Labs button in sidebar settings area with badge
- **UI Pattern**: Side drawer sliding from right
- **Storage**: localStorage with cross-tab sync
- **Analytics**: PostHog integration for tracking adoption
- **Graduation**: Features can be marked "graduated" when ready for GA

## Initial Features Documented

1. **Collaborative Editing** - Real-time multi-user layout editing
2. **Drawer-to-Print** - STL generation and export system

## Test Plan

- [x] Documentation files render correctly in GitHub
- [x] Links between documents work
- [x] Pre-commit hooks pass (build, tests)