### PR TITLE
fix: gracefully handle missing Liveblocks API key in production

### DIFF
--- a/src/components/collab/CollabProvider.tsx
+++ b/src/components/collab/CollabProvider.tsx
@@ -12,6 +12,7 @@ import {
   useUpdateMyPresence,
   useMutation,
   useStorage,
+  isLiveblocksConfigured,
   type LiveblocksStorage,
   type UserPresence,
   type InteractionHint,
@@ -21,7 +22,7 @@ import { useLayoutStore } from '../../store/layout';
 import { useSettingsStore } from '../../store/settings';
 import { generateId, STAGING_ID, CONSTRAINTS } from '../../constants';
 import { PresenceContext, type CollabPresenceActions } from '../../contexts/PresenceContext';
-import { MutationsContext, type Mutations } from '../../context/MutationsContext';
+import { MutationsContext, type Mutations, LocalMutationsProvider } from '../../context/MutationsContext';
 import type { Coord, Layout, Bin, Layer, Category, Drawer } from '../../types';
 import type { Result, ValidationError, LayoutError } from '../../result';
 import {
@@ -81,6 +82,9 @@ function useUserName(): string {
  * CollabProvider wraps the app with Liveblocks RoomProvider
  * to enable real-time collaboration.
  *
+ * If Liveblocks is not configured (no API key), falls back to
+ * LocalMutationsProvider for local-only mode.
+ *
  * @example
  * ```tsx
  * <CollabProvider shareId="abc123xyz">
@@ -89,6 +93,20 @@ function useUserName(): string {
  * ```
  */
 export function CollabProvider({ shareId, children }: CollabProviderProps) {
+  // If Liveblocks is not configured, fall back to local-only mode
+  // This allows the app to function without collaborative features
+  if (!isLiveblocksConfigured) {
+    return <LocalMutationsProvider>{children}</LocalMutationsProvider>;
+  }
+
+  return <LiveblocksCollabProvider shareId={shareId}>{children}</LiveblocksCollabProvider>;
+}
+
+/**
+ * Inner component that actually uses Liveblocks.
+ * This is separated to avoid conditional hooks in the outer component.
+ */
+function LiveblocksCollabProvider({ shareId, children }: CollabProviderProps) {
   const roomId = `gridfinity-${shareId}`;
   const userId = useMemo(() => getUserId(), []);
   const userName = useUserName();

--- a/src/liveblocks.config.ts
+++ b/src/liveblocks.config.ts
@@ -58,17 +58,28 @@ export interface LiveblocksStorage {
 }
 
 /**
+ * Check if Liveblocks is configured.
+ * Collaborative features are disabled when the public key is not set.
+ */
+const LIVEBLOCKS_PUBLIC_KEY = import.meta.env.VITE_LIVEBLOCKS_PUBLIC_KEY;
+export const isLiveblocksConfigured = Boolean(LIVEBLOCKS_PUBLIC_KEY);
+
+/**
  * Liveblocks client configuration.
  *
  * Uses public key for simpler setup. For production with server-side
  * permission control, switch to authEndpoint: '/api/liveblocks-auth'
  * and set LIVEBLOCKS_SECRET_KEY environment variable.
+ *
+ * Client is only created when the public key is available.
  */
-const client = createClient({
-  publicApiKey: import.meta.env.VITE_LIVEBLOCKS_PUBLIC_KEY || '',
-  // Throttle presence updates to 20fps (50ms) to balance smoothness and bandwidth
-  throttle: 50,
-});
+const client = isLiveblocksConfigured
+  ? createClient({
+      publicApiKey: LIVEBLOCKS_PUBLIC_KEY,
+      // Throttle presence updates to 20fps (50ms) to balance smoothness and bandwidth
+      throttle: 50,
+    })
+  : null;
 
 /**
  * Create typed room context with our presence and storage types.
@@ -84,43 +95,68 @@ const client = createClient({
  *
  * TODO: When Liveblocks adds better TypeScript support for strict types,
  * update this to use UserPresence and LiveblocksStorage directly.
+ *
+ * Context is only created when the client is available.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const context = createRoomContext<any, any>(client);
+const context = client ? createRoomContext<any, any>(client) : null;
+
+/**
+ * Stub RoomProvider for when Liveblocks is not configured.
+ * Just renders children without any collaborative features.
+ */
+const StubRoomProvider: React.ComponentType<{
+  id: string;
+  initialPresence: UserPresence;
+  initialStorage?: LiveblocksStorage;
+  children: React.ReactNode;
+}> = ({ children }) => children as React.ReactElement;
+
+/**
+ * Helper to create a stub hook that throws when called without Liveblocks configured.
+ * This helps catch programming errors where hooks are used without checking isLiveblocksConfigured.
+ */
+const createUnconfiguredHook = (hookName: string) => () => {
+  throw new Error(
+    `${hookName} called but Liveblocks is not configured. ` +
+    `Check isLiveblocksConfigured before using collaborative features.`
+  );
+};
 
 // Re-export hooks with proper typing via type assertions
-export const RoomProvider = context.RoomProvider as React.ComponentType<{
+// When Liveblocks is not configured, provide stubs that throw helpful errors
+export const RoomProvider = (context?.RoomProvider ?? StubRoomProvider) as React.ComponentType<{
   id: string;
   initialPresence: UserPresence;
   initialStorage?: LiveblocksStorage;
   children: React.ReactNode;
 }>;
-export const useMyPresence = context.useMyPresence as () => [
+export const useMyPresence = (context?.useMyPresence ?? createUnconfiguredHook('useMyPresence')) as () => [
   UserPresence,
   (patch: Partial<UserPresence>) => void,
 ];
-export const useUpdateMyPresence = context.useUpdateMyPresence as () => (
+export const useUpdateMyPresence = (context?.useUpdateMyPresence ?? createUnconfiguredHook('useUpdateMyPresence')) as () => (
   patch: Partial<UserPresence>
 ) => void;
-export const useOthers = context.useOthers as () => readonly {
+export const useOthers = (context?.useOthers ?? createUnconfiguredHook('useOthers')) as () => readonly {
   connectionId: number;
   presence: UserPresence;
 }[];
-export const useOthersMapped = context.useOthersMapped;
-export const useOthersConnectionIds = context.useOthersConnectionIds;
-export const useOther = context.useOther;
-export const useSelf = context.useSelf as () => {
+export const useOthersMapped = context?.useOthersMapped ?? createUnconfiguredHook('useOthersMapped');
+export const useOthersConnectionIds = context?.useOthersConnectionIds ?? createUnconfiguredHook('useOthersConnectionIds');
+export const useOther = context?.useOther ?? createUnconfiguredHook('useOther');
+export const useSelf = (context?.useSelf ?? createUnconfiguredHook('useSelf')) as () => {
   connectionId: number;
   presence: UserPresence;
 } | null;
-export const useStorage = context.useStorage;
-export const useMutation = context.useMutation;
-export const useRoom = context.useRoom;
-export const useBroadcastEvent = context.useBroadcastEvent;
-export const useEventListener = context.useEventListener;
-export const useStatus = context.useStatus;
-export const useHistory = context.useHistory;
-export const useUndo = context.useUndo;
-export const useRedo = context.useRedo;
-export const useCanUndo = context.useCanUndo;
-export const useCanRedo = context.useCanRedo;
+export const useStorage = context?.useStorage ?? createUnconfiguredHook('useStorage');
+export const useMutation = context?.useMutation ?? createUnconfiguredHook('useMutation');
+export const useRoom = context?.useRoom ?? createUnconfiguredHook('useRoom');
+export const useBroadcastEvent = context?.useBroadcastEvent ?? createUnconfiguredHook('useBroadcastEvent');
+export const useEventListener = context?.useEventListener ?? createUnconfiguredHook('useEventListener');
+export const useStatus = context?.useStatus ?? createUnconfiguredHook('useStatus');
+export const useHistory = context?.useHistory ?? createUnconfiguredHook('useHistory');
+export const useUndo = context?.useUndo ?? createUnconfiguredHook('useUndo');
+export const useRedo = context?.useRedo ?? createUnconfiguredHook('useRedo');
+export const useCanUndo = context?.useCanUndo ?? createUnconfiguredHook('useCanUndo');
+export const useCanRedo = context?.useCanRedo ?? createUnconfiguredHook('useCanRedo');


### PR DESCRIPTION
## Summary
Fixes production error when `VITE_LIVEBLOCKS_PUBLIC_KEY` is not set.

**Changes:**
- Liveblocks client is only created when API key is available
- CollabProvider falls back to LocalMutationsProvider when unconfigured
- Stub hooks throw helpful errors if accidentally called
- App works normally without collaborative features

## Root Cause
The Liveblocks `createClient()` throws when passed an empty string instead of a valid API key. Since the env var wasn't set in Vercel, production crashed.

## Test plan
- [x] Build succeeds
- [x] All 3161 tests pass
- [x] App functions without Liveblocks configured (local-only mode)