### PR TITLE
fix(collab): prevent RoomProvider missing error on shared layout refresh

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { useLayoutStore, useHistoryStore, useUIStore, useLibraryStore } from '../store';
-import { useResponsive, useFeatureFlag } from '../hooks';
+import { useResponsive, useFeatureFlag, useCollabMode } from '../hooks';
 import { CONSTRAINTS } from '../constants';
 import { LayoutManagerModal } from './modals/LayoutManagerModal';
 import { PrintModal } from './modals/PrintModal';
@@ -17,6 +17,7 @@ interface HeaderProps {
 export function Header({ onHelpClick, saveStatus }: HeaderProps) {
   const { isTablet } = useResponsive();
   const isCollabEnabled = useFeatureFlag('collaborative_editing');
+  const { isCollaborative } = useCollabMode();
 
   const { layout, setName } = useLayoutStore(
     useShallow((state) => ({
@@ -246,7 +247,8 @@ export function Header({ onHelpClick, saveStatus }: HeaderProps) {
         {/* Share button and presence avatars (only visible when collaborative_editing flag is enabled) */}
         {isCollabEnabled && <div className="w-px h-6 bg-stroke-subtle mx-2" />}
         <ShareButton />
-        {isCollabEnabled && <PresenceAvatars className="ml-2" />}
+        {/* Only render PresenceAvatars when actually in collab mode (inside RoomProvider) */}
+        {isCollabEnabled && isCollaborative && <PresenceAvatars className="ml-2" />}
         {isCollabEnabled && <div className="w-px h-6 bg-stroke-subtle mx-2" />}
 
         {/* Divider before external links (only when collab is disabled) */}

--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -26,6 +26,7 @@ import {
 import { LabsDrawer } from './labs';
 import { PresenceAvatarList } from './collab';
 import { usePresence } from '../hooks/usePresence';
+import { useCollabMode } from '../hooks/useCollabMode';
 import type { SaveStatus } from '../hooks/useAutoSave';
 
 // Legacy context menu state for backwards compatibility
@@ -112,12 +113,30 @@ export function MobileLayout({ isMobileHelpOpen, setIsMobileHelpOpen, saveStatus
 }
 
 /**
+ * Participants panel content that safely calls usePresence().
+ * Only mounted when in collaborative mode (inside RoomProvider).
+ */
+function ParticipantsPanel() {
+  const { isCollaborative } = useCollabMode();
+  const { participants } = usePresence();
+
+  // Safety check - should not reach here if not collaborative,
+  // but guard just in case
+  if (!isCollaborative) {
+    return (
+      <div className="px-4 py-8 text-center text-content-secondary text-sm">
+        Collaborative editing is not active
+      </div>
+    );
+  }
+
+  return <PresenceAvatarList participants={participants} className="px-2" />;
+}
+
+/**
  * Mobile panel content based on active panel type.
  */
 function MobilePanelContent({ panel }: { panel: string }) {
-  // Get presence data for participants panel
-  const { participants } = usePresence();
-
   const content = (() => {
     switch (panel) {
       case 'layers':
@@ -133,7 +152,7 @@ function MobilePanelContent({ panel }: { panel: string }) {
       case 'layouts':
         return <MobileLayoutsPanel />;
       case 'participants':
-        return <PresenceAvatarList participants={participants} className="px-2" />;
+        return <ParticipantsPanel />;
       default:
         return null;
     }

--- a/src/components/mobile/MobileHeader.tsx
+++ b/src/components/mobile/MobileHeader.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useLayoutStore, useHistoryStore, useUIStore } from '../../store';
+import { useCollabMode } from '../../hooks/useCollabMode';
 import { CONSTRAINTS } from '../../constants';
 import { PresenceAvatars } from '../collab';
 import type { MobilePanel } from '../../store/ui';
@@ -25,6 +26,9 @@ export function MobileHeader({ onMenuClick, onHelpClick, saveStatus }: MobileHea
   const redo = useHistoryStore(state => state.redo);
 
   const toggleMobilePanel = useUIStore(state => state.toggleMobilePanel);
+
+  // Only show presence avatars when actually in collaborative mode (inside RoomProvider)
+  const { isCollaborative } = useCollabMode();
 
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(layout.name);
@@ -180,8 +184,8 @@ export function MobileHeader({ onMenuClick, onHelpClick, saveStatus }: MobileHea
 
       {/* Right: Presence + Save status + Undo/Redo + Help */}
       <div className="flex items-center gap-1">
-        {/* Presence indicator (shown in collaborative mode) */}
-        <PresenceAvatars />
+        {/* Presence indicator (only when actually in collaborative mode, inside RoomProvider) */}
+        {isCollaborative && <PresenceAvatars />}
 
         {/* Save status indicator (icon only on mobile) */}
         {saveStatus !== 'idle' && (

--- a/src/liveblocks.config.ts
+++ b/src/liveblocks.config.ts
@@ -134,6 +134,35 @@ const safeStubHooks = {
   useStorage: <T,>(_selector: (root: LiveblocksStorage) => T) => null as T | null,
 };
 
+/**
+ * Create a safe wrapper around a Liveblocks hook that catches
+ * "RoomProvider missing" errors and returns a fallback value.
+ *
+ * This allows hooks to be called outside of RoomProvider without crashing,
+ * which is important during the loading phase when SharedLayoutImporter
+ * hasn't yet determined if we're in collaborative mode.
+ */
+function createSafeHook<TArgs extends unknown[], TReturn>(
+  realHook: ((...args: TArgs) => TReturn) | null | undefined,
+  stubHook: (...args: TArgs) => TReturn,
+): (...args: TArgs) => TReturn {
+  if (!realHook) return stubHook;
+
+  return (...args: TArgs): TReturn => {
+    try {
+      return realHook(...args);
+    } catch (error) {
+      // Check if this is the "RoomProvider missing" error
+      if (error instanceof Error && error.message.includes('RoomProvider')) {
+        // Return safe default instead of crashing
+        return stubHook(...args);
+      }
+      // Re-throw other errors
+      throw error;
+    }
+  };
+}
+
 // Re-export hooks with proper typing via type assertions
 // When Liveblocks is not configured, provide stubs that throw helpful errors
 export const RoomProvider = (context?.RoomProvider ?? StubRoomProvider) as React.ComponentType<{
@@ -149,24 +178,35 @@ export const useMyPresence = (context?.useMyPresence ?? createUnconfiguredHook('
 export const useUpdateMyPresence = (context?.useUpdateMyPresence ?? createUnconfiguredHook('useUpdateMyPresence')) as () => (
   patch: Partial<UserPresence>
 ) => void;
-// Safe hooks that return defaults when not configured (can be called unconditionally)
-export const useOthers = (context?.useOthers ?? safeStubHooks.useOthers) as () => readonly {
-  connectionId: number;
-  presence: UserPresence;
-}[];
+// Safe hooks that return defaults when not configured OR when called outside RoomProvider
+// These can be called unconditionally - they catch RoomProvider errors and return safe defaults
+export const useOthers = createSafeHook(
+  context?.useOthers as (() => readonly { connectionId: number; presence: UserPresence }[]) | undefined,
+  safeStubHooks.useOthers
+) as () => readonly { connectionId: number; presence: UserPresence }[];
+
 export const useOthersMapped = context?.useOthersMapped ?? createUnconfiguredHook('useOthersMapped');
 export const useOthersConnectionIds = context?.useOthersConnectionIds ?? createUnconfiguredHook('useOthersConnectionIds');
 export const useOther = context?.useOther ?? createUnconfiguredHook('useOther');
-export const useSelf = (context?.useSelf ?? safeStubHooks.useSelf) as () => {
-  connectionId: number;
-  presence: UserPresence;
-} | null;
-export const useStorage = (context?.useStorage ?? safeStubHooks.useStorage) as <T>(selector: (root: LiveblocksStorage) => T) => T | null;
+
+export const useSelf = createSafeHook(
+  context?.useSelf as (() => { connectionId: number; presence: UserPresence } | null) | undefined,
+  safeStubHooks.useSelf
+) as () => { connectionId: number; presence: UserPresence } | null;
+
+export const useStorage = createSafeHook(
+  context?.useStorage as (<T>(selector: (root: LiveblocksStorage) => T) => T | null) | undefined,
+  safeStubHooks.useStorage
+) as <T>(selector: (root: LiveblocksStorage) => T) => T | null;
 export const useMutation = context?.useMutation ?? createUnconfiguredHook('useMutation');
 export const useRoom = context?.useRoom ?? createUnconfiguredHook('useRoom');
 export const useBroadcastEvent = context?.useBroadcastEvent ?? createUnconfiguredHook('useBroadcastEvent');
 export const useEventListener = context?.useEventListener ?? createUnconfiguredHook('useEventListener');
-export const useStatus = (context?.useStatus ?? safeStubHooks.useStatus) as () => string;
+
+export const useStatus = createSafeHook(
+  context?.useStatus as (() => string) | undefined,
+  safeStubHooks.useStatus
+) as () => string;
 export const useHistory = context?.useHistory ?? createUnconfiguredHook('useHistory');
 export const useUndo = context?.useUndo ?? createUnconfiguredHook('useUndo');
 export const useRedo = context?.useRedo ?? createUnconfiguredHook('useRedo');

--- a/src/test/components/Header.test.tsx
+++ b/src/test/components/Header.test.tsx
@@ -11,11 +11,13 @@ vi.mock('../../components/modals/LayoutManagerModal', () => ({
   ),
 }));
 
-// Controllable mock for useFeatureFlag
+// Controllable mock for useFeatureFlag and useCollabMode
 let mockFeatureFlagValue = false;
+let mockIsCollaborative = false;
 vi.mock('../../hooks', () => ({
   useResponsive: () => ({ isTablet: false, isMobile: false }),
   useFeatureFlag: () => mockFeatureFlagValue,
+  useCollabMode: () => ({ isCollaborative: mockIsCollaborative, canEdit: true, shareId: null }),
 }));
 
 // Controllable mock for ShareButton
@@ -45,6 +47,7 @@ describe('Header', () => {
     vi.clearAllMocks();
     mockShareButtonEnabled = false;
     mockFeatureFlagValue = false;
+    mockIsCollaborative = false;
   });
 
   describe('rendering', () => {


### PR DESCRIPTION
## Summary
- Fix "RoomProvider is missing from the React tree" error when collaborators refresh a shared layout page
- Add defensive guards to conditionally render presence UI components
- Make Liveblocks hooks safe to call outside RoomProvider by catching errors and returning defaults

## Root Cause
When a collaborator refreshes `/s/{shareId}`:
1. `sharedLayoutCloudShareId` is initially `null` (SharedLayoutImporter hasn't loaded yet)
2. `useCollabMode()` returns `isCollaborative: false`
3. App renders with `LocalMutationsProvider` (no `RoomProvider`)
4. But components like `PresenceAvatars` still tried to render and call Liveblocks hooks
5. The real hooks throw when called outside `RoomProvider`

## Solution
1. **Render guards**: Only render `PresenceAvatars` when `isCollaborative` is true (inside RoomProvider)
2. **Safe hooks**: Wrap Liveblocks hooks (`useOthers`, `useSelf`, `useStorage`, `useStatus`) to catch "RoomProvider missing" errors and return safe defaults
3. **Separate component**: Extract `ParticipantsPanel` in MobileLayout to properly isolate hook calls

## Test plan
- [x] Build passes
- [x] All 3195 unit tests pass
- [ ] Manual test: Refresh page as collaborator on `/s/{shareId}` - no crash
- [ ] Manual test: PresenceAvatars appear once collaborative mode is established