### PR TITLE
feat(collab): add presence awareness with cursor labels and operation ghosts

### DIFF
--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -13,7 +13,7 @@ import { QuickLabelPopover } from './QuickLabelPopover';
 import { ConfirmDialog } from '../modals/ConfirmDialog';
 import { MobileGridToolbar } from '../mobile';
 import { PanelErrorBoundary } from '../PanelErrorBoundary';
-import { CollabCursors } from '../collab';
+import { CollabCursors, CollabGhosts } from '../collab';
 import { useCollabMode } from '../../hooks/useCollabMode';
 import { useCollabPresence } from '../../hooks/useCollabPresence';
 import { useGridCoords } from '../../hooks/useGridCoords';
@@ -942,6 +942,8 @@ export function Grid() {
                 onStartResize={startResize}
               />
               <Overlay cellSize={cellSize} gap={gap} />
+              {/* Collaborative ghosts overlay - shows other users' operations */}
+              {isCollaborative && <CollabGhosts />}
               {/* Collaborative cursors overlay - shows other users' cursors */}
               {isCollaborative && <CollabCursors />}
 

--- a/src/components/collab/CollabCursor.tsx
+++ b/src/components/collab/CollabCursor.tsx
@@ -69,9 +69,9 @@ export function CollabCursor({ presence, cellSize, gap }: CollabCursorProps) {
         />
       </svg>
 
-      {/* Name label positioned to the right of the cursor */}
+      {/* Name label floating above the cursor for better visibility */}
       <div
-        className="absolute left-4 top-3 px-2 py-0.5 text-xs font-medium text-white rounded whitespace-nowrap max-w-[120px] truncate shadow-md"
+        className="absolute left-3 -top-5 px-1.5 py-0.5 text-[10px] font-medium text-white rounded whitespace-nowrap max-w-[100px] truncate shadow-md"
         style={{ backgroundColor: color }}
       >
         {name}

--- a/src/components/collab/CollabGhosts.tsx
+++ b/src/components/collab/CollabGhosts.tsx
@@ -1,0 +1,372 @@
+/**
+ * Container component for rendering remote user operation ghosts.
+ *
+ * Shows semi-transparent previews of what other users are doing:
+ * - Drawing: dashed rectangle where they're creating a bin
+ * - Dragging: ghost outlines of bins at their destination position
+ * - Resizing: ghost outlines showing new size
+ *
+ * Coordinate System:
+ * - Grid uses bottom-left origin (y=0 at bottom)
+ * - CSS uses top-left origin (y=0 at top)
+ * - We transform coordinates when rendering
+ */
+
+import { useOthers } from '../../liveblocks.config';
+import { useUIStore, useLayoutStore } from '../../store';
+import { getBaseCellSize } from '../../constants';
+import { useResponsive } from '../../hooks/useResponsive';
+import type { InteractionHint } from '../../liveblocks.config';
+import type { Bin } from '../../types';
+
+interface CollabGhostsProps {
+  /** Optional className for the container */
+  className?: string;
+}
+
+/**
+ * Renders ghost outlines for remote users' in-progress operations.
+ * Uses the same coordinate system as Overlay.tsx for consistency.
+ */
+export function CollabGhosts({ className }: CollabGhostsProps) {
+  const others = useOthers();
+  const zoom = useUIStore((state) => state.zoom);
+  const drawer = useLayoutStore((state) => state.layout.drawer);
+  const bins = useLayoutStore((state) => state.layout.bins);
+  const { viewportWidth } = useResponsive();
+
+  // Calculate cell size with zoom
+  const cellSize = Math.round(getBaseCellSize(viewportWidth) * zoom);
+  const gap = 1; // 1px gap between cells
+
+  // Filter to users with active (non-idle) interactions
+  const usersWithInteractions = others.filter(
+    ({ presence }) =>
+      presence.interaction &&
+      presence.interaction.type !== 'idle'
+  );
+
+  if (usersWithInteractions.length === 0) {
+    return null;
+  }
+
+  // Calculate fractional edge settings for positioning
+  const hasFractionalWidth = drawer.width % 1 !== 0;
+  const hasFractionalDepth = drawer.depth % 1 !== 0;
+  const fractionalEdgeX = drawer.fractionalEdgeX ?? 'end';
+  const fractionalEdgeY = drawer.fractionalEdgeY ?? 'end';
+  const fractionalWidthPart = drawer.width - Math.floor(drawer.width);
+  const fractionalDepthPart = drawer.depth - Math.floor(drawer.depth);
+  const fractionalCellWidth = fractionalWidthPart * (cellSize + gap) - gap;
+  const fractionalCellHeight = fractionalDepthPart * (cellSize + gap) - gap;
+  const integerDepth = Math.floor(drawer.depth);
+  const visualDepth = drawer.depth;
+
+  // Positioning helpers (copied from Overlay.tsx for consistency)
+  const calcLeft = (x: number) => {
+    if (hasFractionalWidth && fractionalEdgeX === 'start') {
+      if (x < fractionalWidthPart) {
+        return gap + (x / fractionalWidthPart) * fractionalCellWidth;
+      } else {
+        const adjustedX = x - fractionalWidthPart;
+        return gap + fractionalCellWidth + gap + adjustedX * (cellSize + gap);
+      }
+    }
+    return gap + x * (cellSize + gap);
+  };
+
+  const calcTop = (y: number, depth: number) => {
+    const binTopGridY = y + depth;
+
+    if (hasFractionalDepth && fractionalEdgeY === 'start') {
+      if (binTopGridY <= fractionalDepthPart) {
+        const fractionalRowCssTop = gap + integerDepth * (cellSize + gap);
+        const offsetFromTop = (fractionalDepthPart - binTopGridY) / fractionalDepthPart * fractionalCellHeight;
+        return fractionalRowCssTop + offsetFromTop;
+      }
+      const integerY = binTopGridY - fractionalDepthPart;
+      const wholeRows = Math.floor(integerY);
+      const fractionalPart = integerY - wholeRows;
+      const cssTop = gap + (integerDepth - 1 - wholeRows) * (cellSize + gap) + (1 - fractionalPart) * cellSize;
+      return cssTop;
+    }
+
+    if (hasFractionalDepth && fractionalEdgeY === 'end') {
+      const topY = visualDepth - binTopGridY;
+      if (topY < fractionalDepthPart) {
+        return gap + (topY / fractionalDepthPart) * fractionalCellHeight;
+      }
+      const integerTopY = topY - fractionalDepthPart;
+      return gap + fractionalCellHeight + gap + integerTopY * (cellSize + gap);
+    }
+
+    const topY = visualDepth - binTopGridY;
+    return gap + topY * (cellSize + gap);
+  };
+
+  const calcPixelWidth = (x: number, width: number): number => {
+    if (!hasFractionalWidth) {
+      return width * cellSize + Math.max(0, width - 1) * gap;
+    }
+
+    const binEndX = x + width;
+
+    if (fractionalEdgeX === 'start') {
+      const inFractional = Math.max(0, Math.min(binEndX, fractionalWidthPart) - Math.max(x, 0));
+      const inInteger = width - inFractional;
+
+      let pixelWidth = 0;
+      if (inFractional > 0) {
+        pixelWidth += (inFractional / fractionalWidthPart) * fractionalCellWidth;
+      }
+      if (inInteger > 0) {
+        if (inFractional > 0) pixelWidth += gap;
+        pixelWidth += inInteger * cellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
+      }
+      return pixelWidth;
+    } else {
+      const integerWidth = Math.floor(drawer.width);
+      const inInteger = Math.max(0, Math.min(binEndX, integerWidth) - x);
+      const inFractional = width - inInteger;
+
+      let pixelWidth = 0;
+      if (inInteger > 0) {
+        pixelWidth += inInteger * cellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
+      }
+      if (inFractional > 0) {
+        if (inInteger > 0) pixelWidth += gap;
+        pixelWidth += (inFractional / fractionalWidthPart) * fractionalCellWidth;
+      }
+      return pixelWidth;
+    }
+  };
+
+  const calcPixelHeight = (y: number, depth: number): number => {
+    if (!hasFractionalDepth) {
+      return depth * cellSize + Math.max(0, depth - 1) * gap;
+    }
+
+    const binEndY = y + depth;
+
+    if (fractionalEdgeY === 'start') {
+      const inFractional = Math.max(0, Math.min(binEndY, fractionalDepthPart) - Math.max(y, 0));
+      const inInteger = depth - inFractional;
+
+      let pixelHeight = 0;
+      if (inFractional > 0) {
+        pixelHeight += (inFractional / fractionalDepthPart) * fractionalCellHeight;
+      }
+      if (inInteger > 0) {
+        if (inFractional > 0) pixelHeight += gap;
+        pixelHeight += inInteger * cellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
+      }
+      return pixelHeight;
+    } else {
+      const inInteger = Math.max(0, Math.min(binEndY, integerDepth) - y);
+      const inFractional = depth - inInteger;
+
+      let pixelHeight = 0;
+      if (inInteger > 0) {
+        pixelHeight += inInteger * cellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
+      }
+      if (inFractional > 0) {
+        if (inInteger > 0) pixelHeight += gap;
+        pixelHeight += (inFractional / fractionalDepthPart) * fractionalCellHeight;
+      }
+      return pixelHeight;
+    }
+  };
+
+  // Render ghost for a drawing/selecting interaction
+  const renderDrawingGhost = (
+    key: string,
+    interaction: Extract<InteractionHint, { type: 'drawing' | 'selecting' }>,
+    color: string
+  ) => {
+    const { start, current } = interaction;
+    const x1 = Math.min(start.x, current.x);
+    const y1 = Math.min(start.y, current.y);
+    const x2 = Math.max(start.x, current.x);
+    const y2 = Math.max(start.y, current.y);
+    const width = x2 - x1 + 1;
+    const depth = y2 - y1 + 1;
+
+    const left = calcLeft(x1);
+    const top = calcTop(y1, depth);
+    const rectWidth = calcPixelWidth(x1, width);
+    const rectHeight = calcPixelHeight(y1, depth);
+
+    return (
+      <div
+        key={key}
+        style={{
+          position: 'absolute',
+          left,
+          top,
+          width: rectWidth,
+          height: rectHeight,
+          border: `2px dashed ${color}`,
+          borderRadius: 2,
+          backgroundColor: `${color}15`,
+          pointerEvents: 'none',
+        }}
+        aria-hidden="true"
+      />
+    );
+  };
+
+  // Render ghosts for a dragging interaction
+  const renderDraggingGhosts = (
+    keyPrefix: string,
+    interaction: Extract<InteractionHint, { type: 'dragging' }>,
+    color: string,
+    allBins: Bin[]
+  ) => {
+    const { binIds, delta } = interaction;
+    const ghosts: React.ReactNode[] = [];
+
+    for (const binId of binIds) {
+      const bin = allBins.find((b) => b.id === binId);
+      if (!bin) continue;
+
+      const newX = bin.x + delta.x;
+      const newY = bin.y + delta.y;
+
+      const left = calcLeft(newX);
+      const top = calcTop(newY, bin.depth);
+      const rectWidth = calcPixelWidth(newX, bin.width);
+      const rectHeight = calcPixelHeight(newY, bin.depth);
+
+      ghosts.push(
+        <div
+          key={`${keyPrefix}-${binId}`}
+          style={{
+            position: 'absolute',
+            left,
+            top,
+            width: rectWidth,
+            height: rectHeight,
+            border: `2px solid ${color}`,
+            borderRadius: 2,
+            backgroundColor: `${color}20`,
+            pointerEvents: 'none',
+          }}
+          aria-hidden="true"
+        />
+      );
+    }
+
+    return ghosts;
+  };
+
+  // Render ghosts for a resizing interaction
+  const renderResizingGhosts = (
+    keyPrefix: string,
+    interaction: Extract<InteractionHint, { type: 'resizing' }>,
+    color: string,
+    allBins: Bin[]
+  ) => {
+    const { binIds, handle } = interaction;
+    const ghosts: React.ReactNode[] = [];
+
+    for (const binId of binIds) {
+      const bin = allBins.find((b) => b.id === binId);
+      if (!bin) continue;
+
+      // Show the original bin outline with a visual indicator of the resize direction
+      const left = calcLeft(bin.x);
+      const top = calcTop(bin.y, bin.depth);
+      const rectWidth = calcPixelWidth(bin.x, bin.width);
+      const rectHeight = calcPixelHeight(bin.y, bin.depth);
+
+      // Add directional arrows or indicator based on handle
+      const handleIndicator = getHandleIndicator(handle);
+
+      ghosts.push(
+        <div
+          key={`${keyPrefix}-${binId}`}
+          style={{
+            position: 'absolute',
+            left,
+            top,
+            width: rectWidth,
+            height: rectHeight,
+            border: `2px dashed ${color}`,
+            borderRadius: 2,
+            backgroundColor: `${color}15`,
+            pointerEvents: 'none',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          aria-hidden="true"
+        >
+          <span
+            style={{
+              fontSize: 16,
+              color,
+              opacity: 0.8,
+              textShadow: '0 0 2px rgba(0,0,0,0.5)',
+            }}
+          >
+            {handleIndicator}
+          </span>
+        </div>
+      );
+    }
+
+    return ghosts;
+  };
+
+  const ghostElements: React.ReactNode[] = [];
+
+  for (const { connectionId, presence } of usersWithInteractions) {
+    const { interaction, color } = presence;
+    if (!interaction || interaction.type === 'idle') continue;
+
+    const keyPrefix = `ghost-${connectionId}`;
+
+    if (interaction.type === 'drawing' || interaction.type === 'selecting') {
+      ghostElements.push(
+        renderDrawingGhost(`${keyPrefix}-draw`, interaction, color)
+      );
+    } else if (interaction.type === 'dragging') {
+      ghostElements.push(...renderDraggingGhosts(keyPrefix, interaction, color, bins));
+    } else if (interaction.type === 'resizing') {
+      ghostElements.push(...renderResizingGhosts(keyPrefix, interaction, color, bins));
+    }
+  }
+
+  return (
+    <div
+      className={`absolute inset-0 pointer-events-none z-[35] overflow-hidden ${className ?? ''}`}
+      aria-hidden="true"
+    >
+      {ghostElements}
+    </div>
+  );
+}
+
+/**
+ * Get a visual indicator character for resize direction.
+ */
+function getHandleIndicator(handle: string): string {
+  switch (handle) {
+    case 'n':
+      return '\u2195'; // ↕
+    case 's':
+      return '\u2195'; // ↕
+    case 'e':
+      return '\u2194'; // ↔
+    case 'w':
+      return '\u2194'; // ↔
+    case 'ne':
+    case 'sw':
+      return '\u2922'; // ⤢
+    case 'nw':
+    case 'se':
+      return '\u2921'; // ⤡
+    default:
+      return '\u21F2'; // ⇲
+  }
+}

--- a/src/components/collab/index.ts
+++ b/src/components/collab/index.ts
@@ -8,6 +8,7 @@
 export { CollabProvider } from './CollabProvider';
 export { CollabCursors } from './CollabCursors';
 export { CollabCursor } from './CollabCursor';
+export { CollabGhosts } from './CollabGhosts';
 
 // Presence UI components
 export { PresenceAvatars } from './PresenceAvatars';

--- a/src/hooks/useInteraction.ts
+++ b/src/hooks/useInteraction.ts
@@ -1,14 +1,16 @@
 import { useEffect, useCallback, useRef } from 'react';
 import type { RefObject } from 'react';
-import type { Bin, Coord, Rect, ResizeHandle } from '../types';
+import type { Bin, Coord, Rect, ResizeHandle, Interaction } from '../types';
 import { useUIStore, useLayoutStore, useUndoableAction } from '../store';
 import { useMutations } from '../context/MutationsContext';
 import { useGridCoords } from './useGridCoords';
+import { useCollabPresence } from './useCollabPresence';
 import { canPlaceBin, clamp } from '../utils/validation';
 import { constrainGroupDelta } from '../utils/selection';
 import { STAGING_ID, getBaseCellSize } from '../constants';
 import { throttleRAF, cancelThrottledRAF } from '../utils/throttle';
 import { isOk } from '../result';
+import type { InteractionHint } from '../liveblocks.config';
 
 /**
  * Hook for managing all grid interactions including bin creation, movement, and resizing.
@@ -80,6 +82,7 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
   // Track captured pointer for reliable event delivery
   const capturedPointerRef = useRef<{ element: HTMLElement; pointerId: number } | null>(null);
   const { getGridCoords, clampCoords, isInBounds } = useGridCoords(gridRef);
+  const { updateInteraction } = useCollabPresence();
   const interaction = useUIStore(state => state.interaction);
   const setInteraction = useUIStore(state => state.setInteraction);
   const setDropTarget = useUIStore(state => state.setDropTarget);
@@ -714,6 +717,12 @@ export function useInteraction(gridRef: RefObject<HTMLDivElement | null>) {
     };
   }, [interaction, layout, activeLayerId, activeCategoryId, addBin, updateBin, deleteBin, setInteraction, setDropTarget, setSelectedBin, setSelectedBins, getGridCoords, clampCoords, isInBounds, execute]);
 
+  // Broadcast interaction state to remote users for collaborative previews
+  useEffect(() => {
+    const hint = mapInteractionToHint(interaction);
+    updateInteraction(hint);
+  }, [interaction, updateInteraction]);
+
   return {
     interaction,
     startDraw,
@@ -762,4 +771,31 @@ function calculateResizeRect(
   depth = Math.max(minSize, depth);
 
   return { x, y, width, depth };
+}
+
+/**
+ * Convert local interaction state to InteractionHint format for broadcasting.
+ * Maps the internal interaction types to the remote-friendly hint format.
+ */
+function mapInteractionToHint(interaction: Interaction | null): InteractionHint {
+  if (!interaction) {
+    return { type: 'idle' };
+  }
+
+  switch (interaction.type) {
+    case 'draw':
+      return { type: 'drawing', start: interaction.start, current: interaction.current };
+    case 'paint':
+      // Paint mode looks like drawing to remote users
+      return { type: 'drawing', start: interaction.start, current: interaction.current };
+    case 'drag':
+      return { type: 'dragging', binIds: interaction.binIds, delta: interaction.currentCoord };
+    case 'resize':
+      return { type: 'resizing', binIds: interaction.binIds, handle: interaction.handle };
+    case 'stagingDrag':
+      // Don't broadcast staging drags (too ephemeral/confusing)
+      return { type: 'idle' };
+    default:
+      return { type: 'idle' };
+  }
 }


### PR DESCRIPTION
## Summary

- Add user names floating above remote cursors for easier identification
- Display semi-transparent ghost outlines when remote users draw, drag, or resize bins
- Broadcast interaction state to enable real-time awareness of collaborator actions

## Test plan

- [ ] Enable collaborative editing in Labs settings
- [ ] Share a layout and open in two browser windows
- [ ] Verify remote cursor shows name label above it
- [ ] Draw a bin in one window - verify ghost rectangle appears in the other
- [ ] Drag a bin - verify ghost shows at destination position
- [ ] Resize a bin - verify ghost shows resize direction indicator
- [ ] Verify ghosts disappear when operation completes