### PR TITLE
feat(collab): smooth pixel-perfect cursor movement

### DIFF
--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -109,16 +109,18 @@ export function Grid() {
   // Collaborative editing hooks
   const { isCollaborative } = useCollabMode();
   const { updateCursor, clearPresence } = useCollabPresence();
-  const { getGridCoords } = useGridCoords(gridRef);
+  const { getPixelCoords } = useGridCoords(gridRef);
 
-  // Track cursor position for collaborative presence
+  // Track cursor position for collaborative presence (normalized 0-1 coords for smooth movement)
   const handlePointerMoveForCollab = useCallback(
     (e: React.PointerEvent) => {
       if (!isCollaborative) return;
-      const coords = getGridCoords(e.clientX, e.clientY);
-      updateCursor(coords);
+      const coords = getPixelCoords(e.clientX, e.clientY);
+      if (coords) {
+        updateCursor({ x: coords.nx, y: coords.ny });
+      }
     },
-    [isCollaborative, getGridCoords, updateCursor]
+    [isCollaborative, getPixelCoords, updateCursor]
   );
 
   const handlePointerLeaveForCollab = useCallback(() => {

--- a/src/components/collab/CollabCursor.tsx
+++ b/src/components/collab/CollabCursor.tsx
@@ -3,6 +3,9 @@
  *
  * Displays a cursor icon with the user's name label.
  * Uses CSS transitions for smooth movement.
+ *
+ * Cursor positions are stored as normalized coordinates (0-1 range)
+ * and converted to actual pixels at render time for smooth movement.
  */
 
 import { useMemo } from 'react';
@@ -11,10 +14,10 @@ import type { UserPresence } from '../../liveblocks.config';
 interface CollabCursorProps {
   /** User presence data containing cursor position, name, and color */
   presence: UserPresence;
-  /** Current cell size in pixels (accounts for zoom) */
-  cellSize: number;
-  /** Gap between cells in pixels */
-  gap: number;
+  /** Total grid width in pixels (for converting normalized coords) */
+  gridWidth: number;
+  /** Total grid height in pixels (for converting normalized coords) */
+  gridHeight: number;
 }
 
 /**
@@ -23,23 +26,22 @@ interface CollabCursorProps {
  * The cursor uses CSS transform for positioning, which enables
  * smooth transitions without layout thrashing.
  */
-export function CollabCursor({ presence, cellSize, gap }: CollabCursorProps) {
+export function CollabCursor({ presence, gridWidth, gridHeight }: CollabCursorProps) {
   const { cursor, name, color } = presence;
 
-  // Convert grid coordinates to pixel position
-  // Grid origin (0,0) is bottom-left, but CSS origin is top-left
-  // The parent overlay handles the coordinate system conversion
+  // Convert normalized (0-1) coordinates to pixel position
   // useMemo must be called unconditionally (React Rules of Hooks)
   const style = useMemo(() => {
     if (!cursor) return null;
-    const x = cursor.x * (cellSize + gap) + gap;
-    const y = cursor.y * (cellSize + gap) + gap;
+    // Cursor coords are normalized 0-1, multiply by grid dimensions
+    const x = cursor.x * gridWidth;
+    const y = cursor.y * gridHeight;
 
     return {
       transform: `translate(${x}px, ${y}px)`,
       color,
     };
-  }, [cursor, cellSize, gap, color]);
+  }, [cursor, gridWidth, gridHeight, color]);
 
   // Don't render if cursor is null (user is outside the grid)
   if (!cursor || !style) {
@@ -48,7 +50,7 @@ export function CollabCursor({ presence, cellSize, gap }: CollabCursorProps) {
 
   return (
     <div
-      className="absolute transition-transform duration-75 ease-out pointer-events-none"
+      className="absolute transition-transform duration-[16ms] ease-linear pointer-events-none"
       style={style}
       aria-hidden="true"
     >

--- a/src/components/collab/CollabCursors.tsx
+++ b/src/components/collab/CollabCursors.tsx
@@ -5,9 +5,9 @@
  * for each connected user who has their cursor on the grid.
  *
  * Coordinate System:
- * - Grid uses bottom-left origin (y=0 at bottom)
- * - CSS uses top-left origin (y=0 at top)
- * - We transform coordinates when rendering
+ * - Cursor positions are stored as normalized coordinates (0-1 range)
+ * - (0,0) is top-left, (1,1) is bottom-right (matches CSS/screen coords)
+ * - Converted to actual pixels at render time for smooth movement
  */
 
 import { useOthers } from '../../liveblocks.config';
@@ -45,6 +45,9 @@ export function CollabCursors({ className }: CollabCursorsProps) {
   const cellSize = Math.round(getBaseCellSize(viewportWidth) * zoom);
   const gap = 1; // 1px gap between cells
 
+  // Calculate total grid dimensions for converting normalized coords to pixels
+  const gridWidth = drawer.width * (cellSize + gap) + gap;
+  const gridHeight = drawer.depth * (cellSize + gap) + gap;
 
   // Filter to users with valid cursors
   const usersWithCursors = others.filter(
@@ -60,29 +63,15 @@ export function CollabCursors({ className }: CollabCursorsProps) {
       className={`absolute inset-0 pointer-events-none z-40 overflow-hidden ${className ?? ''}`}
       aria-label={`${usersWithCursors.length} other user${usersWithCursors.length === 1 ? '' : 's'} viewing`}
     >
-      {usersWithCursors.map(({ connectionId, presence }) => {
-        // Transform y coordinate from bottom-left to top-left origin
-        // Grid y=0 is at bottom, CSS y=0 is at top
-        const transformedPresence = {
-          ...presence,
-          cursor: presence.cursor
-            ? {
-                x: presence.cursor.x,
-                // Flip y: grid bottom (y=0) should be CSS bottom (y=gridHeight)
-                y: drawer.depth - 1 - presence.cursor.y,
-              }
-            : null,
-        };
-
-        return (
-          <CollabCursor
-            key={connectionId}
-            presence={transformedPresence}
-            cellSize={cellSize}
-            gap={gap}
-          />
-        );
-      })}
+      {usersWithCursors.map(({ connectionId, presence }) => (
+        // Normalized coords are already in screen space (0,0 = top-left)
+        <CollabCursor
+          key={connectionId}
+          presence={presence}
+          gridWidth={gridWidth}
+          gridHeight={gridHeight}
+        />
+      ))}
     </div>
   );
 }

--- a/src/hooks/useGridCoords.ts
+++ b/src/hooks/useGridCoords.ts
@@ -217,5 +217,27 @@ export function useGridCoords(gridRef: RefObject<HTMLDivElement | null>) {
            coord.y >= 0 && coord.y < drawer.depth;
   }, [drawer.width, drawer.depth]);
 
-  return { getGridCoords, clampCoords, isInBounds, cellSize, halfBinMode, visualCellSize };
+  /**
+   * Get normalized pixel coordinates (0-1 range) for cursor tracking.
+   * Unlike getGridCoords which snaps to grid cells, this preserves
+   * sub-pixel precision for smooth cursor movement.
+   *
+   * @returns Normalized coordinates where (0,0) is top-left and (1,1) is bottom-right
+   */
+  const getPixelCoords = useCallback((clientX: number, clientY: number): {
+    nx: number;
+    ny: number;
+    isInGrid: boolean;
+  } | null => {
+    if (!gridRef.current) return null;
+
+    const rect = gridRef.current.getBoundingClientRect();
+    const nx = (clientX - rect.left) / rect.width;
+    const ny = (clientY - rect.top) / rect.height;
+    const isInGrid = nx >= 0 && nx <= 1 && ny >= 0 && ny <= 1;
+
+    return { nx, ny, isInGrid };
+  }, [gridRef]);
+
+  return { getGridCoords, getPixelCoords, clampCoords, isInBounds, cellSize, halfBinMode, visualCellSize };
 }

--- a/src/liveblocks.config.ts
+++ b/src/liveblocks.config.ts
@@ -16,7 +16,7 @@ import type { Layout, Coord, ResizeHandle } from './types';
  * Presence is automatically cleared when a user disconnects.
  */
 export interface UserPresence {
-  /** Current cursor position in grid coordinates, null if outside grid */
+  /** Cursor position as normalized coords (0-1 range), null if outside grid */
   cursor: Coord | null;
   /** User's display name */
   name: string;


### PR DESCRIPTION
## Summary
- Replace integer grid coordinates with normalized (0-1) coordinates for collaborative cursors
- Eliminates ~32-50px snapping behavior, providing smooth sub-pixel precision
- Change CSS transition to 16ms linear for 60fps smoothness

## Test plan
- [ ] Enable collaborative editing in Labs
- [ ] Open shared layout in two browser windows
- [ ] Move cursor slowly - should track smoothly without visible jumping
- [ ] Change zoom level - cursor should remain at correct relative position
- [ ] Verify existing bin operations still work (grid coords unchanged)