### PR TITLE
feat(collab): add selection rings, activity labels, and polished ghost previews

### DIFF
--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -13,7 +13,7 @@ import { QuickLabelPopover } from './QuickLabelPopover';
 import { ConfirmDialog } from '../modals/ConfirmDialog';
 import { MobileGridToolbar } from '../mobile';
 import { PanelErrorBoundary } from '../PanelErrorBoundary';
-import { CollabCursors, CollabGhosts } from '../collab';
+import { CollabCursors, CollabGhosts, CollabSelectionRings } from '../collab';
 import { useCollabMode } from '../../hooks/useCollabMode';
 import { useCollabPresence } from '../../hooks/useCollabPresence';
 import { useGridCoords } from '../../hooks/useGridCoords';
@@ -944,6 +944,8 @@ export function Grid() {
                 onStartResize={startResize}
               />
               <Overlay cellSize={cellSize} gap={gap} />
+              {/* Collaborative selection rings - shows bins selected by other users */}
+              {isCollaborative && <CollabSelectionRings />}
               {/* Collaborative ghosts overlay - shows other users' operations */}
               {isCollaborative && <CollabGhosts />}
               {/* Collaborative cursors overlay - shows other users' cursors */}

--- a/src/components/collab/CollabCursor.tsx
+++ b/src/components/collab/CollabCursor.tsx
@@ -1,56 +1,65 @@
 /**
  * Individual remote cursor component.
  *
- * Displays a cursor icon with the user's name label.
- * Uses CSS transitions for smooth movement.
+ * Displays a cursor icon with the user's name and activity label.
+ * Receives pre-interpolated pixel positions for smooth 60fps rendering.
  *
- * Cursor positions are stored as normalized coordinates (0-1 range)
- * and converted to actual pixels at render time for smooth movement.
+ * Features:
+ * - Smooth movement via interpolated positions
+ * - Fade in/out transitions
+ * - Activity indicator showing current operation (Drawing, Moving, etc.)
  */
 
-import { useMemo } from 'react';
-import type { UserPresence } from '../../liveblocks.config';
+import type { UserPresence, InteractionHint } from '../../liveblocks.config';
+import type { InterpolatedPosition } from '../../hooks/useInterpolatedPresence';
 
 interface CollabCursorProps {
   /** User presence data containing cursor position, name, and color */
   presence: UserPresence;
-  /** Total grid width in pixels (for converting normalized coords) */
-  gridWidth: number;
-  /** Total grid height in pixels (for converting normalized coords) */
-  gridHeight: number;
+  /** Pre-interpolated pixel position from useInterpolatedPresence */
+  position: InterpolatedPosition;
 }
 
 /**
- * Renders a single remote user's cursor with their name label.
- *
- * The cursor uses CSS transform for positioning, which enables
- * smooth transitions without layout thrashing.
+ * Maps interaction hint type to user-friendly activity text.
+ * Returns null for idle state (no label shown).
  */
-export function CollabCursor({ presence, gridWidth, gridHeight }: CollabCursorProps) {
-  const { cursor, name, color } = presence;
+function getActivityText(interaction?: InteractionHint): string | null {
+  if (!interaction || interaction.type === 'idle') return null;
 
-  // Convert normalized (0-1) coordinates to pixel position
-  // useMemo must be called unconditionally (React Rules of Hooks)
-  const style = useMemo(() => {
-    if (!cursor) return null;
-    // Cursor coords are normalized 0-1, multiply by grid dimensions
-    const x = cursor.x * gridWidth;
-    const y = cursor.y * gridHeight;
-
-    return {
-      transform: `translate(${x}px, ${y}px)`,
-      color,
-    };
-  }, [cursor, gridWidth, gridHeight, color]);
-
-  // Don't render if cursor is null (user is outside the grid)
-  if (!cursor || !style) {
-    return null;
+  switch (interaction.type) {
+    case 'drawing':
+      return 'Drawing...';
+    case 'dragging':
+      return 'Moving...';
+    case 'resizing':
+      return 'Resizing...';
+    case 'selecting':
+      return 'Selecting...';
+    default:
+      return null;
   }
+}
+
+/**
+ * Renders a single remote user's cursor with name and activity labels.
+ *
+ * The cursor uses pre-interpolated positions from useInterpolatedPresence
+ * for smooth 60fps animation while keeping network updates throttled.
+ */
+export function CollabCursor({ presence, position }: CollabCursorProps) {
+  const { name, color, interaction } = presence;
+  const activityText = getActivityText(interaction);
+
+  const style = {
+    transform: `translate(${position.x}px, ${position.y}px)`,
+    color,
+    opacity: position.opacity,
+  };
 
   return (
     <div
-      className="absolute transition-transform duration-[16ms] ease-linear pointer-events-none"
+      className="absolute pointer-events-none transition-opacity duration-200"
       style={style}
       aria-hidden="true"
     >
@@ -71,13 +80,23 @@ export function CollabCursor({ presence, gridWidth, gridHeight }: CollabCursorPr
         />
       </svg>
 
-      {/* Name label floating above the cursor for better visibility */}
+      {/* Name label floating above the cursor */}
       <div
         className="absolute left-3 -top-5 px-1.5 py-0.5 text-[10px] font-medium text-white rounded whitespace-nowrap max-w-[100px] truncate shadow-md"
         style={{ backgroundColor: color }}
       >
         {name}
       </div>
+
+      {/* Activity label below the name (only shown when not idle) */}
+      {activityText && (
+        <div
+          className="absolute left-3 top-0 px-1.5 py-0.5 text-[9px] font-medium text-white rounded whitespace-nowrap shadow-sm animate-in fade-in duration-150"
+          style={{ backgroundColor: color, opacity: 0.9 }}
+        >
+          {activityText}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/collab/CollabCursors.tsx
+++ b/src/components/collab/CollabCursors.tsx
@@ -7,13 +7,14 @@
  * Coordinate System:
  * - Cursor positions are stored as normalized coordinates (0-1 range)
  * - (0,0) is top-left, (1,1) is bottom-right (matches CSS/screen coords)
- * - Converted to actual pixels at render time for smooth movement
+ * - Positions are interpolated at 60fps for smooth movement
  */
 
 import { useOthers } from '../../liveblocks.config';
 import { useUIStore, useLayoutStore } from '../../store';
 import { getBaseCellSize } from '../../constants';
 import { useResponsive } from '../../hooks/useResponsive';
+import { useInterpolatedPresence } from '../../hooks/useInterpolatedPresence';
 import { CollabCursor } from './CollabCursor';
 
 interface CollabCursorsProps {
@@ -24,8 +25,8 @@ interface CollabCursorsProps {
 /**
  * Renders all remote users' cursors as an overlay on the grid.
  *
- * Uses Liveblocks' useOthers() hook to get presence data for
- * all other connected users.
+ * Uses smooth 60fps interpolation via useInterpolatedPresence hook
+ * while keeping network updates throttled to 20fps for bandwidth.
  *
  * @example
  * ```tsx
@@ -49,29 +50,36 @@ export function CollabCursors({ className }: CollabCursorsProps) {
   const gridWidth = drawer.width * (cellSize + gap) + gap;
   const gridHeight = drawer.depth * (cellSize + gap) + gap;
 
-  // Filter to users with valid cursors
-  const usersWithCursors = others.filter(
-    ({ presence }) => presence.cursor !== null
-  );
+  // Get interpolated cursor positions (60fps smooth)
+  const interpolatedPositions = useInterpolatedPresence(gridWidth, gridHeight);
 
-  if (usersWithCursors.length === 0) {
+  // Filter to users with visible cursors (either with position or fading out)
+  const visibleCursors = others.filter(({ connectionId }) => {
+    const pos = interpolatedPositions.get(connectionId);
+    return pos !== undefined;
+  });
+
+  if (visibleCursors.length === 0) {
     return null;
   }
 
   return (
     <div
       className={`absolute inset-0 pointer-events-none z-40 overflow-hidden ${className ?? ''}`}
-      aria-label={`${usersWithCursors.length} other user${usersWithCursors.length === 1 ? '' : 's'} viewing`}
+      aria-label={`${visibleCursors.length} other user${visibleCursors.length === 1 ? '' : 's'} viewing`}
     >
-      {usersWithCursors.map(({ connectionId, presence }) => (
-        // Normalized coords are already in screen space (0,0 = top-left)
-        <CollabCursor
-          key={connectionId}
-          presence={presence}
-          gridWidth={gridWidth}
-          gridHeight={gridHeight}
-        />
-      ))}
+      {visibleCursors.map(({ connectionId, presence }) => {
+        const position = interpolatedPositions.get(connectionId);
+        if (!position) return null;
+
+        return (
+          <CollabCursor
+            key={connectionId}
+            presence={presence}
+            position={position}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/src/components/collab/CollabGhosts.tsx
+++ b/src/components/collab/CollabGhosts.tsx
@@ -199,6 +199,7 @@ export function CollabGhosts({ className }: CollabGhostsProps) {
     return (
       <div
         key={key}
+        className="animate-in fade-in duration-150"
         style={{
           position: 'absolute',
           left,
@@ -206,9 +207,11 @@ export function CollabGhosts({ className }: CollabGhostsProps) {
           width: rectWidth,
           height: rectHeight,
           border: `2px dashed ${color}`,
-          borderRadius: 2,
-          backgroundColor: `${color}15`,
+          borderRadius: 4,
+          background: `linear-gradient(135deg, ${color}20, ${color}08)`,
+          boxShadow: `0 2px 8px rgba(0, 0, 0, 0.12), 0 0 0 1px ${color}30, 0 0 10px ${color}25`,
           pointerEvents: 'none',
+          willChange: 'opacity, transform',
         }}
         aria-hidden="true"
       />
@@ -240,6 +243,7 @@ export function CollabGhosts({ className }: CollabGhostsProps) {
       ghosts.push(
         <div
           key={`${keyPrefix}-${binId}`}
+          className="animate-in fade-in duration-150"
           style={{
             position: 'absolute',
             left,
@@ -247,9 +251,12 @@ export function CollabGhosts({ className }: CollabGhostsProps) {
             width: rectWidth,
             height: rectHeight,
             border: `2px solid ${color}`,
-            borderRadius: 2,
-            backgroundColor: `${color}20`,
+            borderRadius: 4,
+            background: `linear-gradient(135deg, ${color}28, ${color}10)`,
+            boxShadow: `0 4px 12px rgba(0, 0, 0, 0.15), 0 0 0 2px ${color}40, 0 0 14px ${color}30`,
             pointerEvents: 'none',
+            willChange: 'opacity, transform',
+            transform: 'translateZ(0)',
           }}
           aria-hidden="true"
         />
@@ -285,6 +292,7 @@ export function CollabGhosts({ className }: CollabGhostsProps) {
       ghosts.push(
         <div
           key={`${keyPrefix}-${binId}`}
+          className="animate-in fade-in duration-150"
           style={{
             position: 'absolute',
             left,
@@ -292,21 +300,25 @@ export function CollabGhosts({ className }: CollabGhostsProps) {
             width: rectWidth,
             height: rectHeight,
             border: `2px dashed ${color}`,
-            borderRadius: 2,
-            backgroundColor: `${color}15`,
+            borderRadius: 4,
+            background: `linear-gradient(135deg, ${color}20, ${color}08)`,
+            boxShadow: `0 2px 8px rgba(0, 0, 0, 0.12), 0 0 0 1px ${color}30, 0 0 10px ${color}25`,
             pointerEvents: 'none',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
+            willChange: 'opacity, transform',
           }}
           aria-hidden="true"
         >
           <span
+            className="animate-pulse"
             style={{
-              fontSize: 16,
+              fontSize: 18,
               color,
-              opacity: 0.8,
-              textShadow: '0 0 2px rgba(0,0,0,0.5)',
+              opacity: 0.9,
+              fontWeight: 'bold',
+              textShadow: `0 0 4px rgba(0,0,0,0.5), 0 0 8px ${color}`,
             }}
           >
             {handleIndicator}

--- a/src/components/collab/CollabProvider.tsx
+++ b/src/components/collab/CollabProvider.tsx
@@ -21,6 +21,7 @@ import {
 import { useLibraryStore } from '../../store/library';
 import { useLayoutStore } from '../../store/layout';
 import { useSettingsStore } from '../../store/settings';
+import { useUIStore } from '../../store/ui';
 import { generateId, STAGING_ID, CONSTRAINTS } from '../../constants';
 import { generateGuestName, generateGuestColor } from '../../utils/guestNames';
 import { PresenceContext, type CollabPresenceActions } from '../../contexts/PresenceContext';
@@ -218,6 +219,47 @@ function PresenceProvider({ shareId, children }: { shareId: string; children: Re
     };
   }, [updateMyPresence]);
 
+  // Create throttled selection update (100ms = 10fps, less frequent than cursor)
+  const throttledUpdateSelectionRef = useRef<((binIds: string[]) => void) | null>(null);
+
+  useEffect(() => {
+    throttledUpdateSelectionRef.current = throttle((binIds: string[]) => {
+      updateMyPresence({ selectedBinIds: binIds });
+    }, 100);
+
+    return () => {
+      throttledUpdateSelectionRef.current = null;
+    };
+  }, [updateMyPresence]);
+
+  // Auto-broadcast selection changes from UI store
+  useEffect(() => {
+    // Track previous selection to detect changes
+    let prevSelection = useUIStore.getState().selectedBinIds;
+
+    // Subscribe to entire state and filter for selection changes
+    const unsubscribe = useUIStore.subscribe((state) => {
+      const currentSelection = state.selectedBinIds;
+      // Only update if selection actually changed
+      if (
+        currentSelection.length !== prevSelection.length ||
+        currentSelection.some((id, i) => id !== prevSelection[i])
+      ) {
+        prevSelection = currentSelection;
+        if (throttledUpdateSelectionRef.current) {
+          throttledUpdateSelectionRef.current(currentSelection);
+        }
+      }
+    });
+
+    // Broadcast initial selection state
+    if (throttledUpdateSelectionRef.current) {
+      throttledUpdateSelectionRef.current(prevSelection);
+    }
+
+    return unsubscribe;
+  }, []);
+
   const updateCursor = useCallback(
     (cursor: Coord | null) => {
       if (throttledUpdateCursorRef.current) {
@@ -234,10 +276,20 @@ function PresenceProvider({ shareId, children }: { shareId: string; children: Re
     [updateMyPresence]
   );
 
+  const updateSelection = useCallback(
+    (binIds: string[]) => {
+      if (throttledUpdateSelectionRef.current) {
+        throttledUpdateSelectionRef.current(binIds);
+      }
+    },
+    []
+  );
+
   const clearPresence = useCallback(() => {
     updateMyPresence({
       cursor: null,
       interaction: { type: 'idle' },
+      selectedBinIds: [],
     });
   }, [updateMyPresence]);
 
@@ -245,9 +297,10 @@ function PresenceProvider({ shareId, children }: { shareId: string; children: Re
     () => ({
       updateCursor,
       updateInteraction,
+      updateSelection,
       clearPresence,
     }),
-    [updateCursor, updateInteraction, clearPresence]
+    [updateCursor, updateInteraction, updateSelection, clearPresence]
   );
 
   return (

--- a/src/components/collab/CollabSelectionRings.tsx
+++ b/src/components/collab/CollabSelectionRings.tsx
@@ -1,0 +1,131 @@
+/**
+ * Overlay component for rendering remote user selection rings.
+ *
+ * Shows colored rings around bins that other users have selected,
+ * similar to Figma's multi-user selection visualization.
+ *
+ * Features:
+ * - Colored rings in each user's assigned color
+ * - Multiple users selecting same bin shows multiple rings
+ * - Auto-clears when user disconnects (Liveblocks handles presence cleanup)
+ * - Memoized for performance with many selections
+ */
+
+import { useMemo } from 'react';
+import { useOthers } from '../../liveblocks.config';
+import { useLayoutStore, useUIStore } from '../../store';
+import { getBaseCellSize, STAGING_ID } from '../../constants';
+import { useResponsive } from '../../hooks/useResponsive';
+
+interface CollabSelectionRingsProps {
+  /** Optional className for the container */
+  className?: string;
+}
+
+interface SelectionRing {
+  /** Bin ID this ring is for */
+  binId: string;
+  /** Connection ID of the user who selected it */
+  userId: number;
+  /** CSS Grid column start (1-based) */
+  gridCol: number;
+  /** Number of columns this bin spans */
+  gridColSpan: number;
+  /** CSS Grid row start (1-based, from top) */
+  gridRowStart: number;
+  /** Number of rows this bin spans */
+  gridRowSpan: number;
+  /** User's assigned color */
+  color: string;
+}
+
+/**
+ * Renders colored selection rings around bins selected by remote users.
+ *
+ * Uses CSS Grid positioning (same as Bin.tsx) for accurate overlay alignment.
+ */
+export function CollabSelectionRings({ className }: CollabSelectionRingsProps) {
+  const others = useOthers();
+  const bins = useLayoutStore((state) => state.layout.bins);
+  const drawer = useLayoutStore((state) => state.layout.drawer);
+  const zoom = useUIStore((state) => state.zoom);
+  const { viewportWidth } = useResponsive();
+
+  const cellSize = Math.round(getBaseCellSize(viewportWidth) * zoom);
+  const gap = 1;
+
+  // Calculate grid dimensions
+  const integerWidth = Math.ceil(drawer.width);
+  const integerDepth = Math.ceil(drawer.depth);
+
+  // Calculate ring positions for all users' selections
+  const allRings = useMemo(() => {
+    const rings: SelectionRing[] = [];
+
+    for (const { connectionId, presence } of others) {
+      const { selectedBinIds = [], color } = presence;
+      if (selectedBinIds.length === 0) continue;
+
+      for (const binId of selectedBinIds) {
+        const bin = bins.find((b) => b.id === binId);
+        // Skip if bin not found or in staging
+        if (!bin || bin.layerId === STAGING_ID) continue;
+
+        // Calculate CSS Grid positioning (matches Bin.tsx logic)
+        // Grid uses 1-based indexing, origin at top-left
+        const getCssColForX = (x: number) => Math.floor(x) + 1;
+        const getCssRowForY = (y: number) => integerDepth - Math.floor(y + bin.depth - 0.001);
+
+        const startCol = getCssColForX(bin.x);
+        const endCol = getCssColForX(bin.x + bin.width - 0.001);
+        const topRow = getCssRowForY(bin.y);
+        const bottomRow = integerDepth - Math.floor(bin.y) + 1;
+
+        rings.push({
+          binId: bin.id,
+          userId: connectionId,
+          gridCol: startCol,
+          gridColSpan: Math.max(1, endCol - startCol + 1),
+          gridRowStart: topRow,
+          gridRowSpan: Math.max(1, bottomRow - topRow),
+          color,
+        });
+      }
+    }
+
+    return rings;
+  }, [others, bins, integerDepth]);
+
+  if (allRings.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={`absolute inset-0 pointer-events-none z-[35] ${className ?? ''}`}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(${integerWidth}, ${cellSize}px)`,
+        gridTemplateRows: `repeat(${integerDepth}, ${cellSize}px)`,
+        gap: `${gap}px`,
+        padding: `${gap}px`,
+      }}
+      aria-hidden="true"
+    >
+      {allRings.map(({ binId, userId, gridCol, gridColSpan, gridRowStart, gridRowSpan, color }) => (
+        <div
+          key={`${userId}-${binId}`}
+          className="rounded-sm animate-in fade-in duration-200"
+          style={{
+            gridColumn: `${gridCol} / span ${gridColSpan}`,
+            gridRow: `${gridRowStart} / span ${gridRowSpan}`,
+            border: `2px solid ${color}`,
+            borderRadius: 'var(--radius-sm, 4px)',
+            boxShadow: `0 0 0 1px ${color}30, 0 0 12px ${color}40`,
+            pointerEvents: 'none',
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/collab/index.ts
+++ b/src/components/collab/index.ts
@@ -9,6 +9,7 @@ export { CollabProvider } from './CollabProvider';
 export { CollabCursors } from './CollabCursors';
 export { CollabCursor } from './CollabCursor';
 export { CollabGhosts } from './CollabGhosts';
+export { CollabSelectionRings } from './CollabSelectionRings';
 
 // Presence UI components
 export { PresenceAvatars } from './PresenceAvatars';

--- a/src/contexts/PresenceContext.tsx
+++ b/src/contexts/PresenceContext.tsx
@@ -1,8 +1,9 @@
 /**
  * Context for collaborative presence actions.
  *
- * This context provides functions for updating cursor position and
- * interaction state that are broadcast to other connected users.
+ * This context provides functions for updating cursor position,
+ * interaction state, and selection that are broadcast to other
+ * connected users.
  *
  * When outside CollabProvider, no-op functions are returned.
  */
@@ -16,6 +17,8 @@ export interface CollabPresenceActions {
   updateCursor: (cursor: Coord | null) => void;
   /** Update current interaction hint for remote previews */
   updateInteraction: (interaction: InteractionHint) => void;
+  /** Update currently selected bin IDs for selection rings */
+  updateSelection: (binIds: string[]) => void;
   /** Clear presence when leaving collaborative mode */
   clearPresence: () => void;
 }
@@ -27,6 +30,7 @@ export interface CollabPresenceActions {
 const noopActions: CollabPresenceActions = {
   updateCursor: () => {},
   updateInteraction: () => {},
+  updateSelection: () => {},
   clearPresence: () => {},
 };
 

--- a/src/hooks/useInterpolatedPresence.ts
+++ b/src/hooks/useInterpolatedPresence.ts
@@ -1,0 +1,219 @@
+/**
+ * Hook for interpolating remote cursor positions at 60fps.
+ *
+ * This hook enables smooth cursor movement while keeping network updates
+ * throttled to 20fps (50ms). It uses linear interpolation (lerp) to
+ * create fluid motion between presence updates.
+ *
+ * Features:
+ * - Single RAF loop for all cursors (efficient)
+ * - Converts normalized (0-1) coords to pixels
+ * - Smooth fade-out when cursor leaves grid (null)
+ * - Auto-cleanup when users disconnect
+ *
+ * @example
+ * ```tsx
+ * const interpolated = useInterpolatedPresence(gridWidth, gridHeight);
+ *
+ * // Returns Map<connectionId, { x, y, isVisible }>
+ * for (const [id, pos] of interpolated) {
+ *   console.log(`User ${id}: (${pos.x}, ${pos.y})`);
+ * }
+ * ```
+ */
+
+import { useRef, useEffect, useState, useMemo } from 'react';
+import { useOthers } from '../liveblocks.config';
+
+/** Lerp factor - higher = snappier response (0.2 = smooth, 0.5 = responsive) */
+const INTERPOLATION_SPEED = 0.25;
+
+/** Duration for fade-out when cursor goes null (ms) */
+const FADE_OUT_DURATION = 300;
+
+/** Minimum distance to consider cursor "arrived" at target (pixels) */
+const ARRIVAL_THRESHOLD = 0.5;
+
+interface InterpolatedState {
+  /** Current interpolated position in pixels */
+  current: { x: number; y: number };
+  /** Target position (null when cursor left grid) */
+  target: { x: number; y: number } | null;
+  /** Whether cursor is visible (false during fade-out) */
+  isVisible: boolean;
+  /** Timestamp when fade-out started (for timing) */
+  fadeStartTime: number | null;
+  /** Opacity for smooth fade (1 = visible, 0 = hidden) */
+  opacity: number;
+}
+
+export interface InterpolatedPosition {
+  /** X position in pixels */
+  x: number;
+  /** Y position in pixels */
+  y: number;
+  /** Whether the cursor should be rendered */
+  isVisible: boolean;
+  /** Current opacity (0-1) for fade transitions */
+  opacity: number;
+}
+
+/**
+ * Interpolates remote cursor positions for smooth 60fps rendering.
+ *
+ * @param gridWidth - Total grid width in pixels
+ * @param gridHeight - Total grid height in pixels
+ * @returns Map of connection ID to interpolated pixel position
+ */
+export function useInterpolatedPresence(
+  gridWidth: number,
+  gridHeight: number
+): Map<number, InterpolatedPosition> {
+  const others = useOthers();
+
+  // Internal state for each cursor's interpolation
+  // Using ref to avoid re-renders on every frame
+  const stateRef = useRef<Map<number, InterpolatedState>>(new Map());
+
+  // Trigger re-render when positions change meaningfully
+  // Using a counter instead of object to provide a stable dependency for useMemo
+  const [updateTrigger, forceUpdate] = useState(0);
+
+  // Track if component is mounted (for RAF cleanup)
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    let rafId: number;
+    let lastFrameTime = performance.now();
+
+    const animate = (currentTime: number) => {
+      if (!isMountedRef.current) return;
+
+      // Calculate delta time for frame-rate independent animation
+      const deltaTime = currentTime - lastFrameTime;
+      lastFrameTime = currentTime;
+
+      // Adjust lerp factor based on frame time (normalize to 60fps)
+      const frameAdjustedSpeed = Math.min(
+        INTERPOLATION_SPEED * (deltaTime / 16.67),
+        1
+      );
+
+      const state = stateRef.current;
+      let hasChanges = false;
+
+      // Update targets from Liveblocks presence
+      for (const { connectionId, presence } of others) {
+        const cursor = presence.cursor;
+        const existing = state.get(connectionId);
+
+        if (cursor) {
+          // Convert normalized to pixels
+          const targetPixels = {
+            x: cursor.x * gridWidth,
+            y: cursor.y * gridHeight,
+          };
+
+          if (existing) {
+            // Update target for existing cursor
+            existing.target = targetPixels;
+            existing.isVisible = true;
+            existing.fadeStartTime = null;
+            existing.opacity = 1;
+          } else {
+            // New cursor - start at target position (no initial interpolation)
+            state.set(connectionId, {
+              current: { ...targetPixels },
+              target: targetPixels,
+              isVisible: true,
+              fadeStartTime: null,
+              opacity: 1,
+            });
+            hasChanges = true;
+          }
+        } else if (existing && existing.target !== null) {
+          // Cursor went null - start fade out
+          existing.target = null;
+          existing.fadeStartTime = currentTime;
+          hasChanges = true;
+        }
+      }
+
+      // Remove disconnected users
+      const activeIds = new Set(others.map((o) => o.connectionId));
+      for (const id of state.keys()) {
+        if (!activeIds.has(id)) {
+          state.delete(id);
+          hasChanges = true;
+        }
+      }
+
+      // Interpolate all cursors
+      for (const [id, cursorState] of state.entries()) {
+        if (cursorState.target) {
+          // Calculate distance to target
+          const dx = cursorState.target.x - cursorState.current.x;
+          const dy = cursorState.target.y - cursorState.current.y;
+          const distance = Math.sqrt(dx * dx + dy * dy);
+
+          if (distance > ARRIVAL_THRESHOLD) {
+            // Lerp toward target
+            cursorState.current.x += dx * frameAdjustedSpeed;
+            cursorState.current.y += dy * frameAdjustedSpeed;
+            hasChanges = true;
+          } else {
+            // Snap to target when close enough
+            cursorState.current.x = cursorState.target.x;
+            cursorState.current.y = cursorState.target.y;
+          }
+        } else if (cursorState.fadeStartTime !== null) {
+          // Handle fade out
+          const elapsed = currentTime - cursorState.fadeStartTime;
+          const progress = Math.min(elapsed / FADE_OUT_DURATION, 1);
+          cursorState.opacity = 1 - progress;
+          hasChanges = true;
+
+          if (progress >= 1) {
+            // Fully faded - remove from state
+            state.delete(id);
+          }
+        }
+      }
+
+      // Only trigger re-render if something meaningful changed
+      if (hasChanges) {
+        forceUpdate((c) => c + 1);
+      }
+
+      rafId = requestAnimationFrame(animate);
+    };
+
+    rafId = requestAnimationFrame(animate);
+
+    return () => {
+      isMountedRef.current = false;
+      cancelAnimationFrame(rafId);
+    };
+  }, [others, gridWidth, gridHeight]);
+
+  // Convert internal state to public API
+  // Memoize to prevent unnecessary downstream re-renders
+  return useMemo(() => {
+    const result = new Map<number, InterpolatedPosition>();
+
+    for (const [id, state] of stateRef.current.entries()) {
+      result.set(id, {
+        x: state.current.x,
+        y: state.current.y,
+        isVisible: state.isVisible,
+        opacity: state.opacity,
+      });
+    }
+
+    return result;
+    // Re-run when forceUpdate triggers via updateTrigger counter
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [updateTrigger]);
+}

--- a/src/liveblocks.config.ts
+++ b/src/liveblocks.config.ts
@@ -24,6 +24,8 @@ export interface UserPresence {
   color: string;
   /** Current interaction hint for showing remote operation previews */
   interaction?: InteractionHint;
+  /** Currently selected bin IDs (for Figma-style selection rings) */
+  selectedBinIds?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add 60fps cursor interpolation via `useInterpolatedPresence` hook for smooth remote cursor movement
- Show activity labels near cursors indicating current action (Drawing..., Moving..., Resizing..., Selecting...)
- Add Figma-style colored selection rings around bins that remote users have selected
- Polish ghost previews with gradients, shadows, fade animations, and animated resize direction indicators
- Broadcast local selection state to remote users via Liveblocks presence

## Test plan

- [ ] Enable `collaborative_editing` feature flag in Labs
- [ ] Open same layout in two browser windows
- [ ] Verify cursor movement is smooth (60fps interpolation)
- [ ] Verify activity labels appear when drawing/dragging/resizing
- [ ] Select bins and verify colored rings appear in other window
- [ ] Verify ghost previews have polished styling with gradients and shadows