### PR TITLE
refactor: extract useTabletPanels hook from App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useLayoutEffect, useState, useCallback, useRef, Suspense } from 'react';
+import { useEffect, useLayoutEffect, useState, useCallback, Suspense } from 'react';
 import { useLayoutStore, useUIStore, useLibraryStore } from './store';
-import { useKeyboard, useAutoSave, useResponsive, useCrossTabSync, useLayoutRouting, usePWAUpdate, useAnalytics, useStorageMigration } from './hooks';
+import { useKeyboard, useAutoSave, useResponsive, useCrossTabSync, useLayoutRouting, usePWAUpdate, useAnalytics, useStorageMigration, useTabletPanels } from './hooks';
 import { useCollabMode } from './hooks/useCollabMode';
 import { useOwnedShareSync } from './hooks/useOwnedShareSync';
 import { initializeLayoutLibrary, loadSharedWithMe } from './storage';
@@ -67,34 +67,15 @@ export default function App() {
   // Auto-sync owned shared layouts to Blob storage (Google Docs-like behavior)
   useOwnedShareSync();
 
-  // Tablet panel state (use collapsed state inverted - collapsed means hidden in overlay mode)
-  const leftPanelCollapsed = useUIStore(state => state.leftPanelCollapsed);
-  const rightPanelCollapsed = useUIStore(state => state.rightPanelCollapsed);
-  const toggleLeftPanel = useUIStore(state => state.toggleLeftPanel);
-  const toggleRightPanel = useUIStore(state => state.toggleRightPanel);
-
-  // For tablet, we want panels to start collapsed (hidden as overlays)
-  // leftPanelCollapsed=true means sidebar is hidden, false means visible as overlay
-  const tabletLeftPanelOpen = isTablet && !leftPanelCollapsed;
-  const tabletRightPanelOpen = isTablet && !rightPanelCollapsed;
-
-  // Track previous tablet state to detect mode entry
-  const wasTabletRef = useRef(isTablet);
-
-  // Tablet panel management: Collapse both panels when entering tablet mode
-  // Note: Mutual exclusion (only one panel open at a time) is handled in store actions
-  useEffect(() => {
-    const justEnteredTablet = isTablet && !wasTabletRef.current;
-    wasTabletRef.current = isTablet;
-
-    if (!isTablet) return;
-
-    // When entering tablet mode, collapse both panels
-    if (justEnteredTablet) {
-      if (!leftPanelCollapsed) toggleLeftPanel();
-      if (!rightPanelCollapsed) toggleRightPanel();
-    }
-  }, [isTablet, leftPanelCollapsed, rightPanelCollapsed, toggleLeftPanel, toggleRightPanel]);
+  // Tablet panel state (auto-collapses on tablet mode entry)
+  const {
+    leftPanelOpen: tabletLeftPanelOpen,
+    rightPanelOpen: tabletRightPanelOpen,
+    openLeftPanel,
+    closeLeftPanel,
+    openRightPanel,
+    closeRightPanel,
+  } = useTabletPanels(isTablet);
 
   const layout = useLayoutStore(state => state.layout);
   const activeLayerId = useUIStore(state => state.activeLayerId);
@@ -214,7 +195,7 @@ export default function App() {
         {/* Left sidebar as overlay */}
         <TabletPanelOverlay
           isOpen={tabletLeftPanelOpen}
-          onClose={toggleLeftPanel}
+          onClose={closeLeftPanel}
           side="left"
         >
           <PanelErrorBoundary panelName="Sidebar">
@@ -225,7 +206,7 @@ export default function App() {
         {/* Right panel as overlay */}
         <TabletPanelOverlay
           isOpen={tabletRightPanelOpen}
-          onClose={toggleRightPanel}
+          onClose={closeRightPanel}
           side="right"
         >
           <PanelErrorBoundary panelName="Inspector">
@@ -243,8 +224,8 @@ export default function App() {
         <TabletPanelTriggers
           leftPanelOpen={tabletLeftPanelOpen}
           rightPanelOpen={tabletRightPanelOpen}
-          onOpenLeftPanel={toggleLeftPanel}
-          onOpenRightPanel={toggleRightPanel}
+          onOpenLeftPanel={openLeftPanel}
+          onOpenRightPanel={openRightPanel}
         />
 
         {/* Modals */}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -12,6 +12,8 @@ export { useLayoutRouting } from './useLayoutRouting';
 export { usePWAUpdate } from './usePWAUpdate';
 export { useAnalytics } from './useAnalytics';
 export { useStorageMigration } from './useStorageMigration';
+export { useTabletPanels } from './useTabletPanels';
+export type { TabletPanelsState } from './useTabletPanels';
 export { useFeatureFlag, isFeatureEnabled } from './useFeatureFlag';
 export { useSharedWithMe } from './useSharedWithMe';
 export type { SharedWithMeStatus } from './useSharedWithMe';

--- a/src/hooks/useTabletPanels.ts
+++ b/src/hooks/useTabletPanels.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from 'react';
+import { useUIStore } from '../store/ui';
+
+export interface TabletPanelsState {
+  leftPanelOpen: boolean;
+  rightPanelOpen: boolean;
+  openLeftPanel: () => void;
+  closeLeftPanel: () => void;
+  openRightPanel: () => void;
+  closeRightPanel: () => void;
+}
+
+/**
+ * Manages tablet panel state with auto-collapse on tablet mode entry.
+ *
+ * In tablet mode, panels are overlays. This hook:
+ * - Tracks open/closed state (inverted from store's "collapsed" state)
+ * - Auto-collapses both panels when entering tablet mode
+ * - Provides semantic open/close actions
+ *
+ * @param isTablet - Whether device is in tablet mode (768-899px)
+ * @returns Panel state and control actions
+ */
+export function useTabletPanels(isTablet: boolean): TabletPanelsState {
+  // Read collapsed state from store (collapsed=true means hidden overlay)
+  const leftPanelCollapsed = useUIStore(state => state.leftPanelCollapsed);
+  const rightPanelCollapsed = useUIStore(state => state.rightPanelCollapsed);
+  const toggleLeftPanel = useUIStore(state => state.toggleLeftPanel);
+  const toggleRightPanel = useUIStore(state => state.toggleRightPanel);
+
+  // Track previous tablet state to detect mode entry
+  const wasTabletRef = useRef(isTablet);
+
+  // Auto-collapse panels when entering tablet mode
+  useEffect(() => {
+    const justEnteredTablet = isTablet && !wasTabletRef.current;
+    wasTabletRef.current = isTablet;
+
+    if (!isTablet) return;
+
+    // When entering tablet mode, collapse both panels
+    if (justEnteredTablet) {
+      if (!leftPanelCollapsed) toggleLeftPanel();
+      if (!rightPanelCollapsed) toggleRightPanel();
+    }
+  }, [isTablet, leftPanelCollapsed, rightPanelCollapsed, toggleLeftPanel, toggleRightPanel]);
+
+  // Compute open state (inverted from collapsed)
+  const leftPanelOpen = isTablet && !leftPanelCollapsed;
+  const rightPanelOpen = isTablet && !rightPanelCollapsed;
+
+  // Provide semantic actions (only toggle if needed)
+  const openLeftPanel = () => {
+    if (leftPanelCollapsed) toggleLeftPanel();
+  };
+
+  const closeLeftPanel = () => {
+    if (!leftPanelCollapsed) toggleLeftPanel();
+  };
+
+  const openRightPanel = () => {
+    if (rightPanelCollapsed) toggleRightPanel();
+  };
+
+  const closeRightPanel = () => {
+    if (!rightPanelCollapsed) toggleRightPanel();
+  };
+
+  return {
+    leftPanelOpen,
+    rightPanelOpen,
+    openLeftPanel,
+    closeLeftPanel,
+    openRightPanel,
+    closeRightPanel,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract tablet panel state management logic from `App.tsx` into a dedicated `useTabletPanels` hook
- Encapsulates mode-transition behavior (auto-collapse panels when entering tablet mode)
- Provides semantic `openLeftPanel`/`closeLeftPanel` actions instead of raw toggles
- Reduces `App.tsx` complexity by ~20 lines

## Test plan
- [x] Build passes
- [x] All 3195 unit tests pass
- [x] ESLint passes
- [x] Pre-commit hooks pass (lint-staged, build, test:coverage)