### PR TITLE
feat(ui): add hover-revealed edit icon to category rows

### DIFF
--- a/src/components/Sidebar/CategoriesPanel.tsx
+++ b/src/components/Sidebar/CategoriesPanel.tsx
@@ -262,11 +262,22 @@ export function CategoriesPanel() {
                           ? `${category.name} (selected for new bins)`
                           : `Select ${category.name} for new bins`
                     }
-                    title={selectedBinIds.length > 0 ? `Apply to ${selectedBinIds.length} selected bin${selectedBinIds.length > 1 ? 's' : ''}` : 'Double-click to edit'}
+                    title={selectedBinIds.length > 0 ? `Apply to ${selectedBinIds.length} selected bin${selectedBinIds.length > 1 ? 's' : ''}` : undefined}
                   >
                     <span className="text-sm truncate text-content block">
                       {category.name}
                     </span>
+                  </button>
+                  {/* Edit button - appears on hover */}
+                  <button
+                    onClick={(e) => { e.stopPropagation(); setEditingId(category.id); }}
+                    className="opacity-0 group-hover:opacity-100 p-1 -my-1 rounded hover:bg-surface-elevated transition-opacity flex-shrink-0"
+                    title="Edit category"
+                    aria-label={`Edit ${category.name}`}
+                  >
+                    <svg className="w-3.5 h-3.5 text-content-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                    </svg>
                   </button>
                   {/* Bin count badge */}
                   <span

--- a/src/test/components/CategoriesPanel.test.tsx
+++ b/src/test/components/CategoriesPanel.test.tsx
@@ -153,9 +153,20 @@ describe('CategoriesPanel', () => {
     it('enters edit mode on double click', () => {
       render(<CategoriesPanel />);
 
-      // Double-click the category name button
-      const categoryButton = screen.getByRole('button', { name: /Coral/i });
+      // Double-click the category name button (not the edit icon)
+      const categoryButton = screen.getByRole('button', { name: /Coral \(selected for new bins\)/i });
       fireEvent.doubleClick(categoryButton);
+
+      // Should show input field
+      expect(screen.getByDisplayValue('Coral')).toBeInTheDocument();
+    });
+
+    it('enters edit mode on edit icon click', () => {
+      render(<CategoriesPanel />);
+
+      // Click the edit icon button
+      const editButton = screen.getByRole('button', { name: /Edit Coral/i });
+      fireEvent.click(editButton);
 
       // Should show input field
       expect(screen.getByDisplayValue('Coral')).toBeInTheDocument();
@@ -164,9 +175,9 @@ describe('CategoriesPanel', () => {
     it('updates category name', () => {
       render(<CategoriesPanel />);
 
-      // Enter edit mode
-      const categoryButton = screen.getByRole('button', { name: /Coral/i });
-      fireEvent.doubleClick(categoryButton);
+      // Enter edit mode via edit icon
+      const editButton = screen.getByRole('button', { name: /Edit Coral/i });
+      fireEvent.click(editButton);
 
       // Change name
       const input = screen.getByDisplayValue('Coral');
@@ -178,9 +189,9 @@ describe('CategoriesPanel', () => {
     it('exits edit mode on Enter key', () => {
       render(<CategoriesPanel />);
 
-      // Enter edit mode
-      const categoryButton = screen.getByRole('button', { name: /Coral/i });
-      fireEvent.doubleClick(categoryButton);
+      // Enter edit mode via edit icon
+      const editButton = screen.getByRole('button', { name: /Edit Coral/i });
+      fireEvent.click(editButton);
 
       // Press Enter
       const input = screen.getByDisplayValue('Coral');
@@ -193,9 +204,9 @@ describe('CategoriesPanel', () => {
     it('exits edit mode on Done button click', () => {
       render(<CategoriesPanel />);
 
-      // Enter edit mode
-      const categoryButton = screen.getByRole('button', { name: /Coral/i });
-      fireEvent.doubleClick(categoryButton);
+      // Enter edit mode via edit icon
+      const editButton = screen.getByRole('button', { name: /Edit Coral/i });
+      fireEvent.click(editButton);
 
       // Click Done
       fireEvent.click(screen.getByText('Done'));
@@ -212,9 +223,9 @@ describe('CategoriesPanel', () => {
 
       render(<CategoriesPanel />);
 
-      // Enter edit mode for the third category
-      const thirdCategoryButton = screen.getByRole('button', { name: /Third/i });
-      fireEvent.doubleClick(thirdCategoryButton);
+      // Enter edit mode for the third category via edit icon
+      const editButton = screen.getByRole('button', { name: /Edit Third/i });
+      fireEvent.click(editButton);
 
       // Click delete
       fireEvent.click(screen.getByText('Delete'));
@@ -229,9 +240,9 @@ describe('CategoriesPanel', () => {
 
       render(<CategoriesPanel />);
 
-      // Enter edit mode and delete
-      const thirdCategoryButton = screen.getByRole('button', { name: /Third/i });
-      fireEvent.doubleClick(thirdCategoryButton);
+      // Enter edit mode and delete via edit icon
+      const editButton = screen.getByRole('button', { name: /Edit Third/i });
+      fireEvent.click(editButton);
       fireEvent.click(screen.getByText('Delete'));
 
       // Confirm deletion
@@ -256,9 +267,9 @@ describe('CategoriesPanel', () => {
 
       render(<CategoriesPanel />);
 
-      // Enter edit mode for coral
-      const coralButton = screen.getByRole('button', { name: /Coral/i });
-      fireEvent.doubleClick(coralButton);
+      // Enter edit mode for coral via edit icon
+      const editButton = screen.getByRole('button', { name: /Edit Coral/i });
+      fireEvent.click(editButton);
 
       // Delete button should show disabled state
       const deleteButton = screen.getByText('Delete');
@@ -276,9 +287,9 @@ describe('CategoriesPanel', () => {
 
       render(<CategoriesPanel />);
 
-      // Enter edit mode
-      const coralButton = screen.getByRole('button', { name: /Coral/i });
-      fireEvent.doubleClick(coralButton);
+      // Enter edit mode via edit icon
+      const editButton = screen.getByRole('button', { name: /Edit Coral/i });
+      fireEvent.click(editButton);
 
       // Delete button should show disabled state
       const deleteButton = screen.getByText('Delete');


### PR DESCRIPTION
## Summary
- Add a hover-revealed pencil icon to category rows, making the edit affordance discoverable
- Previously required double-clicking the name or clicking the color swatch (both hidden gestures)
- Uses Tailwind's `group-hover:opacity-100` pattern for smooth reveal on hover

## Test plan
- [x] Build passes
- [x] All 3196 tests pass
- [ ] Visual verification: hover over category → pencil icon appears → click → enters edit mode