### PR TITLE
refactor(ui): hide delete token from cloud share UI

### DIFF
--- a/src/components/CloudShareTab.tsx
+++ b/src/components/CloudShareTab.tsx
@@ -8,76 +8,6 @@ import { useCloudShare } from '../hooks/useCloudShare';
 import { formatShareDate } from '../utils/cloudShare';
 import type { SharePermission } from '../types';
 
-/**
- * Expandable section for the delete token (hidden by default).
- */
-function DeleteTokenSection({
-  token,
-  tokenCopied,
-  onCopy,
-}: {
-  token: string;
-  tokenCopied: boolean;
-  onCopy: () => void;
-}) {
-  const [isExpanded, setIsExpanded] = useState(false);
-
-  return (
-    <div className="border border-stroke-subtle rounded-lg overflow-hidden">
-      <button
-        type="button"
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center justify-between p-3 text-sm text-content-secondary hover:bg-surface-hover transition-colors"
-        aria-expanded={isExpanded}
-      >
-        <span className="flex items-center gap-2">
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-            />
-          </svg>
-          <span>Advanced: Delete Token</span>
-        </span>
-        <svg
-          className={`w-4 h-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
-
-      {isExpanded && (
-        <div className="p-3 pt-0 space-y-2 border-t border-stroke-subtle">
-          <p className="text-xs text-content-tertiary">
-            Save this token if you need to delete your share from a different device.
-            Anyone with this token can delete your share.
-          </p>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={token}
-              readOnly
-              aria-label="Delete token"
-              className="flex-1 bg-surface text-content p-2 rounded font-mono text-xs focus:outline-none"
-            />
-            <button
-              onClick={onCopy}
-              className="btn btn-secondary px-3 text-sm"
-            >
-              {tokenCopied ? 'Copied!' : 'Copy'}
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
 interface CloudShareTabProps {
   layoutId: string;
   onClose: () => void;
@@ -87,7 +17,6 @@ interface CloudShareTabProps {
 export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShareTabProps) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [urlCopied, setUrlCopied] = useState(false);
-  const [tokenCopied, setTokenCopied] = useState(false);
   const urlInputRef = useRef<HTMLInputElement>(null);
 
   const {
@@ -100,7 +29,6 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
     updatePermission,
     remove,
     copyUrl,
-    copyDeleteToken,
     reset,
   } = useCloudShare(layoutId);
 
@@ -119,20 +47,13 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
     }
   }, [status]);
 
-  // Reset copy states after timeout
+  // Reset copy state after timeout
   useEffect(() => {
     if (urlCopied) {
       const timer = setTimeout(() => setUrlCopied(false), 2000);
       return () => clearTimeout(timer);
     }
   }, [urlCopied]);
-
-  useEffect(() => {
-    if (tokenCopied) {
-      const timer = setTimeout(() => setTokenCopied(false), 2000);
-      return () => clearTimeout(timer);
-    }
-  }, [tokenCopied]);
 
   const handleShare = async () => {
     await share(permission);
@@ -155,11 +76,6 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
   const handleCopyUrl = async () => {
     const success = await copyUrl();
     if (success) setUrlCopied(true);
-  };
-
-  const handleCopyToken = async () => {
-    const success = await copyDeleteToken();
-    if (success) setTokenCopied(true);
   };
 
   // Idle state - no existing share
@@ -332,12 +248,6 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
             ? 'Anyone with the link can edit'
             : 'Anyone with the link can view'}
         </div>
-
-        <DeleteTokenSection
-          token={result.deleteToken}
-          tokenCopied={tokenCopied}
-          onCopy={handleCopyToken}
-        />
 
         <div className="flex gap-3 pt-2">
           <button onClick={onClose} className="btn btn-primary">

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -10,7 +10,6 @@ import { useUIStore } from '../store/ui';
 import { useToastStore } from '../store/toast';
 import { useCloudShare } from '../hooks/useCloudShare';
 import { useCollabMode } from '../hooks/useCollabMode';
-import { copyToClipboard } from '../storage';
 import { slugify } from '../utils/slug';
 import type { SharePermission } from '../types';
 
@@ -223,8 +222,6 @@ function SharePopover({
   } = cloudShare;
 
   const [urlCopied, setUrlCopied] = useState(false);
-  const [tokenCopied, setTokenCopied] = useState(false);
-  const [showAdvanced, setShowAdvanced] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   // Determine the effective permission:
@@ -260,13 +257,6 @@ function SharePopover({
       return () => clearTimeout(timer);
     }
   }, [urlCopied]);
-
-  useEffect(() => {
-    if (tokenCopied) {
-      const timer = setTimeout(() => setTokenCopied(false), 2000);
-      return () => clearTimeout(timer);
-    }
-  }, [tokenCopied]);
 
   // Handle click outside to close popover
   useEffect(() => {
@@ -312,14 +302,6 @@ function SharePopover({
   const handleCopyUrl = async () => {
     const success = await copyUrl();
     if (success) setUrlCopied(true);
-  };
-
-  const handleCopyToken = async () => {
-    const token = existingShare?.deleteToken;
-    if (!token) return;
-
-    const success = await copyToClipboard(token);
-    if (success) setTokenCopied(true);
   };
 
   const handlePermissionChange = async (newPermission: SharePermission) => {
@@ -529,112 +511,70 @@ function SharePopover({
             </select>
           )}
 
-          {/* Advanced options (delete token, delete share) - only for own shares */}
+          {/* Delete share option - only for own shares */}
           {!isViewingSharedLayout && hasActiveShare && existingShare && (
             <div className="border-t border-stroke-subtle pt-3 mt-3">
-              <button
-                onClick={() => setShowAdvanced(!showAdvanced)}
-                className="flex items-center justify-between w-full text-sm text-content-tertiary hover:text-content-secondary transition-colors"
-                aria-expanded={showAdvanced}
-              >
-                <span>Advanced options</span>
-                <svg
-                  className={`w-4 h-4 transition-transform ${showAdvanced ? 'rotate-180' : ''}`}
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
+              {!showDeleteConfirm ? (
+                <button
+                  onClick={(e) => {
+                    // Stop propagation to prevent click-outside handler from
+                    // detecting this as an outside click (the button gets removed
+                    // from DOM when confirmation shows, so contains() would fail)
+                    e.stopPropagation();
+                    setShowDeleteConfirm(true);
+                  }}
+                  className="text-sm text-content-tertiary hover:text-error transition-colors"
                 >
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                </svg>
-              </button>
-
-              {showAdvanced && (
-                <div className="mt-3 space-y-3">
-                  {/* Delete token */}
-                  <div className="space-y-2">
-                    <div className="text-xs text-content-tertiary">
-                      Delete token (save this to delete from another device)
-                    </div>
-                    <div className="flex gap-2">
-                      <input
-                        type="text"
-                        value={existingShare.deleteToken}
-                        readOnly
-                        className="flex-1 bg-surface text-content text-xs px-2 py-1.5 rounded border border-stroke focus:outline-none font-mono truncate"
-                      />
-                      <button
-                        onClick={handleCopyToken}
-                        className="btn btn-secondary px-2 py-1 text-xs"
-                      >
-                        {tokenCopied ? 'Copied!' : 'Copy'}
-                      </button>
-                    </div>
-                  </div>
-
-                  {/* Delete share */}
-                  {!showDeleteConfirm ? (
+                  Delete share link
+                </button>
+              ) : (
+                <div className="bg-error/10 border border-error/30 rounded-lg p-3 space-y-2">
+                  <p className="text-sm text-content">
+                    Delete this share? The link will stop working.
+                  </p>
+                  <div className="flex gap-2">
                     <button
                       onClick={(e) => {
-                        // Stop propagation to prevent click-outside handler from
-                        // detecting this as an outside click (the button gets removed
-                        // from DOM when confirmation shows, so contains() would fail)
                         e.stopPropagation();
-                        setShowDeleteConfirm(true);
+                        handleDelete();
                       }}
-                      className="text-sm text-content-tertiary hover:text-error transition-colors"
+                      disabled={status === 'deleting'}
+                      className="btn btn-secondary text-error border-error hover:bg-error hover:text-white text-sm px-3 py-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                      Delete share link
+                      {status === 'deleting' ? (
+                        <span className="flex items-center gap-2">
+                          <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
+                            <circle
+                              className="opacity-25"
+                              cx="12"
+                              cy="12"
+                              r="10"
+                              stroke="currentColor"
+                              strokeWidth="4"
+                            />
+                            <path
+                              className="opacity-75"
+                              fill="currentColor"
+                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                            />
+                          </svg>
+                          Deleting...
+                        </span>
+                      ) : (
+                        'Delete'
+                      )}
                     </button>
-                  ) : (
-                    <div className="bg-error/10 border border-error/30 rounded-lg p-3 space-y-2">
-                      <p className="text-sm text-content">
-                        Delete this share? The link will stop working.
-                      </p>
-                      <div className="flex gap-2">
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleDelete();
-                          }}
-                          disabled={status === 'deleting'}
-                          className="btn btn-secondary text-error border-error hover:bg-error hover:text-white text-sm px-3 py-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          {status === 'deleting' ? (
-                            <span className="flex items-center gap-2">
-                              <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
-                                <circle
-                                  className="opacity-25"
-                                  cx="12"
-                                  cy="12"
-                                  r="10"
-                                  stroke="currentColor"
-                                  strokeWidth="4"
-                                />
-                                <path
-                                  className="opacity-75"
-                                  fill="currentColor"
-                                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                                />
-                              </svg>
-                              Deleting...
-                            </span>
-                          ) : (
-                            'Delete'
-                          )}
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setShowDeleteConfirm(false);
-                          }}
-                          disabled={status === 'deleting'}
-                          className="btn btn-secondary text-sm px-3 py-1.5 disabled:opacity-50"
-                        >
-                          Cancel
-                        </button>
-                      </div>
-                    </div>
-                  )}
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowDeleteConfirm(false);
+                      }}
+                      disabled={status === 'deleting'}
+                      className="btn btn-secondary text-sm px-3 py-1.5 disabled:opacity-50"
+                    >
+                      Cancel
+                    </button>
+                  </div>
                 </div>
               )}
             </div>

--- a/src/test/components/CloudShareTab.test.tsx
+++ b/src/test/components/CloudShareTab.test.tsx
@@ -9,7 +9,6 @@ const mockShare = vi.fn();
 const mockUpdate = vi.fn();
 const mockRemove = vi.fn();
 const mockCopyUrl = vi.fn();
-const mockCopyDeleteToken = vi.fn();
 const mockReset = vi.fn();
 
 let mockCloudShareState = {
@@ -23,7 +22,6 @@ let mockCloudShareState = {
   updatePermission: vi.fn(),
   remove: mockRemove,
   copyUrl: mockCopyUrl,
-  copyDeleteToken: mockCopyDeleteToken,
   reset: mockReset,
 };
 
@@ -57,7 +55,6 @@ describe('CloudShareTab', () => {
       updatePermission: vi.fn(),
       remove: mockRemove,
       copyUrl: mockCopyUrl,
-      copyDeleteToken: mockCopyDeleteToken,
       reset: mockReset,
     };
 
@@ -345,70 +342,6 @@ describe('CloudShareTab', () => {
       fireEvent.click(screen.getByText('Use Share Link Instead'));
 
       expect(mockOnSwitchToUrlTab).toHaveBeenCalled();
-    });
-  });
-
-  describe('DeleteTokenSection', () => {
-    beforeEach(() => {
-      mockCloudShareState.status = 'success';
-      mockCloudShareState.result = {
-        url: 'https://example.com/s/abc123',
-        deleteToken: 'delete-token-xyz',
-        permission: 'view',
-      };
-    });
-
-    it('is collapsed by default', () => {
-      render(<CloudShareTab {...defaultProps} />);
-      expect(screen.queryByText(/Save this token/)).not.toBeInTheDocument();
-    });
-
-    it('expands when clicked', () => {
-      render(<CloudShareTab {...defaultProps} />);
-
-      fireEvent.click(screen.getByText(/Advanced: Delete Token/));
-
-      expect(screen.getByText(/Save this token/)).toBeInTheDocument();
-    });
-
-    it('displays delete token when expanded', () => {
-      render(<CloudShareTab {...defaultProps} />);
-
-      fireEvent.click(screen.getByText(/Advanced: Delete Token/));
-
-      expect(screen.getByDisplayValue('delete-token-xyz')).toBeInTheDocument();
-    });
-
-    it('has Copy button for token', () => {
-      render(<CloudShareTab {...defaultProps} />);
-
-      fireEvent.click(screen.getByText(/Advanced: Delete Token/));
-
-      // There should be a Copy button in the expanded section
-      const copyButtons = screen.getAllByRole('button', { name: /Copy/i });
-      expect(copyButtons.length).toBeGreaterThan(1); // URL copy and token copy
-    });
-
-    it('collapses when clicked again', () => {
-      render(<CloudShareTab {...defaultProps} />);
-
-      // Expand
-      fireEvent.click(screen.getByText(/Advanced: Delete Token/));
-      expect(screen.getByText(/Save this token/)).toBeInTheDocument();
-
-      // Collapse
-      fireEvent.click(screen.getByText(/Advanced: Delete Token/));
-      expect(screen.queryByText(/Save this token/)).not.toBeInTheDocument();
-    });
-
-    it('has correct aria-expanded attribute', () => {
-      render(<CloudShareTab {...defaultProps} />);
-
-      const toggleButton = screen.getByRole('button', { name: /Advanced: Delete Token/ });
-      expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
-
-      fireEvent.click(toggleButton);
-      expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
     });
   });
 


### PR DESCRIPTION
## Summary
- Remove delete token display from CloudShareTab and ShareButton components
- The token is still stored internally and used for API authentication, but users no longer see it
- Simplify ShareButton by showing delete share link directly without expandable "Advanced options" section

## Test plan
- [x] All 3190 unit tests pass
- [x] Build succeeds
- [ ] Verify cloud share flow still works (create, copy link, delete)