### PR TITLE
feat: allow stash bins to have any height and remove auto-adjustment

### DIFF
--- a/src/components/Sidebar/LayerPanel.tsx
+++ b/src/components/Sidebar/LayerPanel.tsx
@@ -261,7 +261,7 @@ export function LayerPanel() {
                     }
                   }}
                   aria-pressed={isActive}
-                  aria-label={`${layer.name}, ${layer.height} height units, ${layerCoverage}% coverage${isActive ? ', active - click to rename' : ''}`}
+                  aria-label={`${layer.name}, ${layer.height} height units for new bins, ${layerCoverage}% coverage${isActive ? ', active - click to rename' : ''}`}
                   title={isActive ? 'Click to rename' : `Select ${layer.name}`}
                 >
                   {layer.name}
@@ -282,19 +282,19 @@ export function LayerPanel() {
                     onClick={() => handleHeightChange(layer.id, -1)}
                     disabled={layer.height <= 1}
                     className="w-5 h-5 flex items-center justify-center text-content-tertiary hover:text-content disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                    aria-label="Decrease layer height"
+                    aria-label="Decrease new bin height"
                   >
                     <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
                     </svg>
                   </button>
-                  <span className="text-[10px] tabular-nums min-w-[24px] text-center text-content-secondary" title="Minimum bin height for this layer">
+                  <span className="text-[10px] tabular-nums min-w-[24px] text-center text-content-secondary" title="Height for new bins placed on this layer">
                     {layer.height}u
                   </span>
                   <button
                     onClick={() => handleHeightChange(layer.id, 1)}
                     className="w-5 h-5 flex items-center justify-center text-content-tertiary hover:text-content transition-colors"
-                    aria-label="Increase layer height"
+                    aria-label="Increase new bin height"
                   >
                     <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
@@ -302,7 +302,7 @@ export function LayerPanel() {
                   </button>
                 </div>
               ) : (
-                <span className="px-1.5 py-0.5 rounded text-[10px] bg-surface-hover">
+                <span className="px-1.5 py-0.5 rounded text-[10px] bg-surface-hover" title="Height for new bins placed on this layer">
                   {layer.height}u
                 </span>
               )}

--- a/src/components/inspector/useBinInspector.ts
+++ b/src/components/inspector/useBinInspector.ts
@@ -104,7 +104,7 @@ export function useBinInspector(): UseBinInspectorReturn {
 
   // Calculate constraints
   const constraints = useMemo<BinConstraints>(() => {
-    if (!bin || !layer) {
+    if (!bin) {
       return {
         minHeight: 1,
         maxHeight: 1,
@@ -115,11 +115,28 @@ export function useBinInspector(): UseBinInspectorReturn {
       };
     }
 
+    const maxGridUnits = calcMaxGridUnits(layout.printBedSize, layout.gridUnitMm);
+    const needsSplit = bin.width > maxGridUnits || bin.depth > maxGridUnits;
+
+    // For bins in staging, use full drawer height range
+    // They're not on a layer yet, so no layer-based constraints apply
+    if (bin.layerId === STAGING_ID || !layer) {
+      const minHeight = 1;
+      const maxHeight = layout.drawer.height;
+      const maxClearance = maxHeight - bin.height;
+      return {
+        minHeight,
+        maxHeight,
+        maxClearance,
+        maxGridUnits,
+        needsSplit,
+        heightRange: `${minHeight}u – ${maxHeight}u`,
+      };
+    }
+
     const minHeight = layer.height;
     const maxHeight = layout.drawer.height - getLayerZStart(bin.layerId, layout.layers);
     const maxClearance = maxHeight - bin.height;
-    const maxGridUnits = calcMaxGridUnits(layout.printBedSize, layout.gridUnitMm);
-    const needsSplit = bin.width > maxGridUnits || bin.depth > maxGridUnits;
 
     return {
       minHeight,
@@ -248,7 +265,10 @@ export function useBinInspector(): UseBinInspectorReturn {
         for (const b of selectedBins) {
           const binLayer = layout.layers.find((l) => l.id === b.layerId);
           const minHeight = binLayer?.height || 1;
-          const binMaxHeight = layout.drawer.height - getLayerZStart(b.layerId, layout.layers);
+          // For staging bins, use full drawer height; for placed bins, account for layer position
+          const binMaxHeight = b.layerId === STAGING_ID || !binLayer
+            ? layout.drawer.height
+            : layout.drawer.height - getLayerZStart(b.layerId, layout.layers);
           const newHeight = clamp(b.height + delta, minHeight, binMaxHeight);
           updateBin(b.id, { height: newHeight });
         }
@@ -263,7 +283,11 @@ export function useBinInspector(): UseBinInspectorReturn {
 
       execute(() => {
         for (const b of selectedBins) {
-          const binMaxHeight = layout.drawer.height - getLayerZStart(b.layerId, layout.layers);
+          const binLayer = layout.layers.find((l) => l.id === b.layerId);
+          // For staging bins, use full drawer height; for placed bins, account for layer position
+          const binMaxHeight = b.layerId === STAGING_ID || !binLayer
+            ? layout.drawer.height
+            : layout.drawer.height - getLayerZStart(b.layerId, layout.layers);
           const maxClearance = binMaxHeight - b.height;
           const newClearance = clamp((b.clearanceHeight || 0) + delta, 0, maxClearance);
           updateBin(b.id, { clearanceHeight: newClearance });
@@ -285,12 +309,9 @@ export function useBinInspector(): UseBinInspectorReturn {
       const targetLayer = layout.layers.find(l => l.id === targetLayerId);
       if (!targetLayer) return;
 
-      // Calculate final height: bin keeps its height or uses layer minimum, whichever is greater
-      const finalHeight = Math.max(bin.height, targetLayer.height);
-
-      // Validate placement on target layer using the actual height that will be assigned
+      // Validate placement on target layer using bin's actual height (no auto-adjustment)
       const result = canPlaceBin(
-        { x: bin.x, y: bin.y, width: bin.width, depth: bin.depth, height: finalHeight },
+        { x: bin.x, y: bin.y, width: bin.width, depth: bin.depth, height: bin.height },
         targetLayerId,
         layout,
         bin.id
@@ -309,7 +330,7 @@ export function useBinInspector(): UseBinInspectorReturn {
       execute(() => {
         updateBin(bin.id, {
           layerId: targetLayerId,
-          height: finalHeight,
+          // Keep bin's original height - don't auto-adjust to layer minimum
         });
       });
 
@@ -333,21 +354,19 @@ export function useBinInspector(): UseBinInspectorReturn {
 
       if (binsToMove.length === 0) return;
 
-      // Check which bins can be moved (validate each using final height)
-      const movable: { bin: Bin; finalHeight: number }[] = [];
+      // Check which bins can be moved using their actual heights (no auto-adjustment)
+      const movable: Bin[] = [];
       const blocked: Bin[] = [];
 
       for (const b of binsToMove) {
-        // Calculate final height for this bin
-        const binFinalHeight = Math.max(b.height, targetLayer.height);
         const result = canPlaceBin(
-          { x: b.x, y: b.y, width: b.width, depth: b.depth, height: binFinalHeight },
+          { x: b.x, y: b.y, width: b.width, depth: b.depth, height: b.height },
           targetLayerId,
           layout,
           b.id
         );
         if (result.valid) {
-          movable.push({ bin: b, finalHeight: binFinalHeight });
+          movable.push(b);
         } else {
           blocked.push(b);
         }
@@ -359,10 +378,10 @@ export function useBinInspector(): UseBinInspectorReturn {
       }
 
       execute(() => {
-        for (const { bin: b, finalHeight: height } of movable) {
+        for (const b of movable) {
           updateBin(b.id, {
             layerId: targetLayerId,
-            height,
+            // Keep bin's original height - don't auto-adjust to layer minimum
           });
         }
       });

--- a/src/components/mobile/MobileLayersPanel/LayersTab.tsx
+++ b/src/components/mobile/MobileLayersPanel/LayersTab.tsx
@@ -239,19 +239,19 @@ export function LayersTab() {
                   onClick={() => handleHeightChange(layer.id, -1)}
                   disabled={layer.height <= 1}
                   className="w-8 h-8 flex items-center justify-center text-content-tertiary hover:text-content disabled:opacity-30 transition-colors"
-                  aria-label="Decrease height"
+                  aria-label="Decrease new bin height"
                 >
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
                   </svg>
                 </button>
-                <span className="w-7 text-center text-xs font-medium text-content-secondary tabular-nums">
+                <span className="text-center text-xs font-medium text-content-secondary tabular-nums whitespace-nowrap" title="Height for new bins placed on this layer">
                   {layer.height}u
                 </span>
                 <button
                   onClick={() => handleHeightChange(layer.id, 1)}
                   className="w-8 h-8 flex items-center justify-center text-content-tertiary hover:text-content transition-colors"
-                  aria-label="Increase height"
+                  aria-label="Increase new bin height"
                 >
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />

--- a/src/components/mobile/MultiBinContextMenu.tsx
+++ b/src/components/mobile/MultiBinContextMenu.tsx
@@ -74,12 +74,11 @@ export function MultiBinContextMenu({ binIds, position, onClose, source }: Multi
 
     execute(() => {
       stagingBins.forEach(b => {
-        // Move to layer and ensure height meets layer minimum
+        // Move to layer - keep original height (don't auto-adjust to layer minimum)
         updateBin(b.id, {
           layerId,
           x: 0,
           y: 0,
-          height: Math.max(b.height, layer.height),
         });
       });
     });

--- a/src/hooks/interactions/useDragInteraction.ts
+++ b/src/hooks/interactions/useDragInteraction.ts
@@ -260,8 +260,6 @@ export function useDragInteraction(
       const deltaY = interaction.currentCoord.y;
 
       if (deltaX !== 0 || deltaY !== 0) {
-        const layer = layout.layers.find((l) => l.id === activeLayerId);
-
         if (interaction.duplicate) {
           // Duplicate mode: create copies at new position, keep originals in place
           const newBinIds: string[] = [];
@@ -276,7 +274,7 @@ export function useDragInteraction(
                 y: bin.y + deltaY,
                 width: bin.width,
                 depth: bin.depth,
-                height: Math.max(bin.height, layer?.height ?? bin.height),
+                height: bin.height, // Keep original height - don't auto-adjust to layer minimum
                 clearanceHeight: bin.clearanceHeight,
                 category: bin.category,
                 label: bin.label,
@@ -303,7 +301,7 @@ export function useDragInteraction(
                 x: bin.x + deltaX,
                 y: bin.y + deltaY,
                 layerId: activeLayerId,
-                height: Math.max(bin.height, layer?.height ?? bin.height),
+                // Keep original height - don't auto-adjust to layer minimum
               });
             }
           });

--- a/src/hooks/interactions/useStagingDragInteraction.ts
+++ b/src/hooks/interactions/useStagingDragInteraction.ts
@@ -95,7 +95,7 @@ export function useStagingDragInteraction(
       const targetX = clamp(clamped.x, 0, layout.drawer.width - bin.width);
       const targetY = clamp(clamped.y, 0, layout.drawer.depth - bin.depth);
 
-      // Validate placement
+      // Validate placement using bin's actual height (no auto-adjustment)
       const result = canPlaceBin(
         { x: targetX, y: targetY, width: bin.width, depth: bin.depth, height: bin.height },
         activeLayerId,
@@ -136,14 +136,13 @@ export function useStagingDragInteraction(
     if (interaction.valid && interaction.currentCoord) {
       const bin = layout.bins.find((b) => b.id === interaction.binId);
       if (bin) {
-        const layer = layout.layers.find((l) => l.id === activeLayerId);
         const { x, y } = interaction.currentCoord;
         execute(() => {
           updateBin(interaction.binId, {
             x,
             y,
             layerId: activeLayerId,
-            height: Math.max(bin.height, layer?.height ?? bin.height),
+            // Keep bin's original height - don't auto-adjust to layer minimum
           });
         });
         setSelectedBin(interaction.binId);

--- a/src/test/components/LayerPanel.test.tsx
+++ b/src/test/components/LayerPanel.test.tsx
@@ -319,15 +319,15 @@ describe('LayerPanel', () => {
     it('shows height controls for active layer', () => {
       render(<LayerPanel />);
 
-      expect(screen.getByLabelText('Increase layer height')).toBeInTheDocument();
-      expect(screen.getByLabelText('Decrease layer height')).toBeInTheDocument();
+      expect(screen.getByLabelText('Increase new bin height')).toBeInTheDocument();
+      expect(screen.getByLabelText('Decrease new bin height')).toBeInTheDocument();
     });
 
     it('increases height when plus clicked', () => {
       render(<LayerPanel />);
 
       const initialHeight = useLayoutStore.getState().layout.layers[0].height;
-      fireEvent.click(screen.getByLabelText('Increase layer height'));
+      fireEvent.click(screen.getByLabelText('Increase new bin height'));
 
       expect(useLayoutStore.getState().layout.layers[0].height).toBe(initialHeight + 1);
     });
@@ -345,7 +345,7 @@ describe('LayerPanel', () => {
 
       render(<LayerPanel />);
 
-      fireEvent.click(screen.getByLabelText('Decrease layer height'));
+      fireEvent.click(screen.getByLabelText('Decrease new bin height'));
 
       expect(useLayoutStore.getState().layout.layers[0].height).toBe(4);
     });
@@ -362,7 +362,7 @@ describe('LayerPanel', () => {
 
       render(<LayerPanel />);
 
-      expect(screen.getByLabelText('Decrease layer height')).toBeDisabled();
+      expect(screen.getByLabelText('Decrease new bin height')).toBeDisabled();
     });
   });
 
@@ -548,8 +548,8 @@ describe('LayerPanel', () => {
     it('height controls have aria-labels', () => {
       render(<LayerPanel />);
 
-      expect(screen.getByLabelText('Increase layer height')).toBeInTheDocument();
-      expect(screen.getByLabelText('Decrease layer height')).toBeInTheDocument();
+      expect(screen.getByLabelText('Increase new bin height')).toBeInTheDocument();
+      expect(screen.getByLabelText('Decrease new bin height')).toBeInTheDocument();
     });
   });
 });

--- a/src/test/hooks/useInteraction.test.ts
+++ b/src/test/hooks/useInteraction.test.ts
@@ -1175,6 +1175,69 @@ describe('stagingDrag interaction', () => {
     const bin = useLayoutStore.getState().layout.bins.find(b => b.id === binId);
     expect(bin?.layerId).toBe(STAGING_ID);
   });
+
+  it('stagingDrag allows shorter bin to be placed on layer and keeps original height', () => {
+    const { addBin, updateLayer, layout } = useLayoutStore.getState();
+    const categoryId = layout.categories[0].id;
+    const tallLayerId = layout.layers[0].id;
+
+    // Update the layer to have a higher minimum height (5u)
+    // Note: Layer "minimum height" is a default for new bins, not a constraint
+    updateLayer(tallLayerId, { height: 5 });
+
+    // Add a shorter bin (3u) to staging
+    const binId = getBinId(addBin({
+      layerId: STAGING_ID,
+      x: 0,
+      y: 0,
+      width: 2,
+      depth: 2,
+      height: 3, // Shorter than the layer's "default" height of 5
+      category: categoryId,
+      label: '',
+      notes: '',
+    }));
+
+    // Verify bin is in staging with height 3
+    const stagedBin = useLayoutStore.getState().layout.bins.find(b => b.id === binId);
+    expect(stagedBin?.layerId).toBe(STAGING_ID);
+    expect(stagedBin?.height).toBe(3);
+
+    // Set active layer to the tall layer
+    useSelectionStore.setState({
+      ...useSelectionStore.getState(),
+      activeLayerId: tallLayerId,
+    });
+
+    // Set up stagingDrag interaction with valid position
+    // Validation passes - layer height is not a constraint for existing bins
+    useInteractionStore.setState({
+      ...useInteractionStore.getState(),
+      interaction: {
+        type: 'stagingDrag',
+        binId: binId,
+        currentCoord: { x: 2, y: 2 },
+        valid: true,
+      },
+    });
+
+    const gridRef = createMockGridRef();
+    renderHook(() => useInteraction(gridRef));
+
+    // Simulate pointer up
+    act(() => {
+      const upEvent = new PointerEvent('pointerup', { bubbles: true });
+      document.dispatchEvent(upEvent);
+    });
+
+    // Bin should now be on the grid with its ORIGINAL height preserved
+    // (no auto-adjustment to layer minimum - user may have specific STL dimensions)
+    const placedBin = useLayoutStore.getState().layout.bins.find(b => b.id === binId);
+    expect(placedBin?.layerId).toBe(tallLayerId);
+    expect(placedBin?.x).toBe(2);
+    expect(placedBin?.y).toBe(2);
+    expect(placedBin?.height).toBe(3); // Height preserved, NOT adjusted to 5
+  });
 });
 
 // Test Alt+drag duplicate behavior

--- a/src/test/validation.test.ts
+++ b/src/test/validation.test.ts
@@ -147,15 +147,15 @@ describe('canPlaceBin', () => {
     expect(result).toEqual({ valid: false, reason: 'exceeds_height' });
   });
 
-  it('rejects bin shorter than layer minimum height', () => {
+  it('allows bin shorter than layer default height (layer height is a default, not constraint)', () => {
     const layout = createTestLayout();
-    // layer2 has height 6, bin must be at least 6
+    // layer2 has height 6, but bins can be any height (layer height is just a default for new bins)
     const result = canPlaceBin(
       { x: 0, y: 0, width: 2, depth: 2, height: 3 },
       'layer2',
       layout
     );
-    expect(result).toEqual({ valid: false, reason: 'exceeds_height' });
+    expect(result).toEqual({ valid: true });
   });
 
   it('excludes multiple bins from collision check via excludeBinIds', () => {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -143,14 +143,11 @@ export function canPlaceBin(
     return { valid: false, reason: 'invalid_layer' };
   }
 
-  // Height check
+  // Height check - only validate max height (bin can't exceed drawer)
+  // Layer height is a default for new bins, not a constraint for existing bins
   const zStart = getLayerZStart(layerId, layers);
   const maxHeight = drawer.height - zStart;
   if (rect.height > maxHeight) {
-    return { valid: false, reason: 'exceeds_height' };
-  }
-  if (rect.height < layer.height) {
-    // Bin must be at least as tall as its base layer
     return { valid: false, reason: 'exceeds_height' };
   }
 
@@ -228,15 +225,12 @@ export function canPlaceBinResult(
     return err(validationInvalidLayer(layerId));
   }
 
-  // Height check
+  // Height check - only validate max height (bin can't exceed drawer)
+  // Layer height is a default for new bins, not a constraint for existing bins
   const zStart = getLayerZStart(layerId, layers);
   const maxHeight = drawer.height - zStart;
   if (rect.height > maxHeight) {
     return err(validationHeightExceeded(rect.height, maxHeight));
-  }
-  if (rect.height < layer.height) {
-    // Bin must be at least as tall as its base layer
-    return err(validationHeightExceeded(rect.height, layer.height));
   }
 
   // Blocked zone check


### PR DESCRIPTION
## Summary
- Stash bins can now have height/clearance adjusted from 1u to drawer height
- Bins dragged from stash or moved between layers keep their original height (no auto-adjustment)
- Layer height is now a default for new bins placed on that layer, not a hard constraint
- Updated UI tooltips to clarify "Height for new bins placed on this layer"

This supports users with pre-defined STL files at specific heights who don't want the system to auto-adjust bin dimensions when moving bins between layers or from the stash.

## Changes
- **`useBinInspector.ts`**: Stash bins can adjust height from 1u to drawer height; removed auto-height adjustment when moving bins between layers
- **`useStagingDragInteraction.ts`**: Bins dragged from stash keep original height
- **`useDragInteraction.ts`**: Removed auto-height adjustment when dragging/duplicating bins
- **`validation.ts`**: Removed check that rejected bins shorter than layer height
- **`LayerPanel.tsx`** & **`LayersTab.tsx`**: Updated tooltips to clarify layer height behavior
- **`MultiBinContextMenu.tsx`**: Removed auto-height adjustment on mobile

## Test plan
- [x] All existing tests pass
- [x] Added test for placing shorter bins from stash onto layers
- [ ] Manually test dragging a 3u bin from stash to a layer with 5u default height - bin should stay 3u
- [ ] Manually test adjusting height/clearance on bins in the stash