### PR TITLE
feat(export): add layout name and grid size columns to TSV/CSV exports

### DIFF
--- a/src/hooks/useBinList.ts
+++ b/src/hooks/useBinList.ts
@@ -225,12 +225,18 @@ export function useBinList(): UseBinListReturn {
 
   // Export handlers
   const exportToTSV = useCallback(() => {
-    return exportPrintListTSV(filteredRows);
-  }, [filteredRows]);
+    return exportPrintListTSV(filteredRows, {
+      layoutName: layout.name,
+      gridSize: `${layout.drawer.width}×${layout.drawer.depth}`,
+    });
+  }, [filteredRows, layout.name, layout.drawer.width, layout.drawer.depth]);
 
   const exportToCSV = useCallback(() => {
-    return formatAsCSV(filteredRows);
-  }, [filteredRows]);
+    return formatAsCSV(filteredRows, {
+      layoutName: layout.name,
+      gridSize: `${layout.drawer.width}×${layout.drawer.depth}`,
+    });
+  }, [filteredRows, layout.name, layout.drawer.width, layout.drawer.depth]);
 
   const exportToJSON = useCallback(() => {
     return formatAsJSON(filteredRows, layout);

--- a/src/storage/ShareService.ts
+++ b/src/storage/ShareService.ts
@@ -109,8 +109,25 @@ export function importLayoutResult(json: string): Result<Layout, ValidationError
 // === TSV Export ===
 
 /**
+ * Escape a value for TSV format.
+ * Replaces tabs and newlines with spaces to prevent breaking the format.
+ */
+function escapeTSVValue(value: string): string {
+  return value.replace(/[\t\n\r]/g, ' ');
+}
+
+/**
+ * Metadata for TSV export including layout context.
+ */
+export interface PrintListTSVMeta {
+  layoutName?: string;
+  gridSize?: string;
+}
+
+/**
  * Export print list as TSV for spreadsheet paste.
  * Dynamically adds columns for custom properties that exist in any row.
+ * Optionally includes layout name and grid size columns for context.
  */
 export function exportPrintListTSV(rows: Array<{
   size: string;
@@ -120,7 +137,7 @@ export function exportPrintListTSV(rows: Array<{
   labels?: string[];
   notes?: string;
   customProperties?: Record<string, string>;
-}>): string {
+}>, meta?: PrintListTSVMeta): string {
   // Collect all unique custom property keys across all rows
   const customKeys = new Set<string>();
   for (const r of rows) {
@@ -132,24 +149,30 @@ export function exportPrintListTSV(rows: Array<{
   }
   const sortedKeys = Array.from(customKeys).sort();
 
-  // Build header with dynamic custom property columns
-  const baseHeader = 'Size\tHeight\tBins\tPieces\tLabel\tNotes';
+  // Build header with optional metadata and dynamic custom property columns
+  const metaHeader = meta ? 'Layout\tGrid Size\t' : '';
+  const baseHeader = `${metaHeader}Size\tHeight\tBins\tPieces\tLabel\tNotes`;
   const header = sortedKeys.length > 0
     ? `${baseHeader}\t${sortedKeys.join('\t')}`
     : baseHeader;
 
+  // Pre-compute metadata values if provided (with TSV escaping)
+  const layoutName = meta ? escapeTSVValue(meta.layoutName || '') : '';
+  const gridSize = meta ? escapeTSVValue(meta.gridSize || '') : '';
+
   // Build data rows
   const lines = rows.map(r => {
-    const label = r.labels?.[0] || '';
-    const notes = r.notes || '';
-    const baseLine = `${r.size}\t${r.height}u\t${r.binCount}\t${r.totalPieces}\t${label}\t${notes}`;
+    const label = escapeTSVValue(r.labels?.[0] || '');
+    const notes = escapeTSVValue(r.notes || '');
+    const metaValues = meta ? `${layoutName}\t${gridSize}\t` : '';
+    const baseLine = `${metaValues}${r.size}\t${r.height}u\t${r.binCount}\t${r.totalPieces}\t${label}\t${notes}`;
 
     if (sortedKeys.length === 0) {
       return baseLine;
     }
 
-    // Add custom property values in order
-    const customValues = sortedKeys.map(key => r.customProperties?.[key] || '');
+    // Add custom property values in order (with TSV escaping)
+    const customValues = sortedKeys.map(key => escapeTSVValue(r.customProperties?.[key] || ''));
     return `${baseLine}\t${customValues.join('\t')}`;
   });
 

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -58,6 +58,7 @@ export {
   importLayoutJSON,
   importLayoutResult,
   exportPrintListTSV,
+  type PrintListTSVMeta,
 } from './ShareService';
 
 // === URL Sharing ===

--- a/src/test/binListOperations.test.ts
+++ b/src/test/binListOperations.test.ts
@@ -366,6 +366,67 @@ describe('binListOperations', () => {
       // No custom property columns
       expect(lines[0]).toBe('Size,Height,Bins,Pieces,Filament (m),Label,Notes');
     });
+
+    it('includes layout metadata when provided', () => {
+      const rows = [
+        createTestRow({
+          size: '2×2',
+          height: 3,
+          binCount: 1,
+          totalPieces: 1,
+          filament: 4.5,
+          labels: ['Test'],
+        }),
+      ];
+      const csv = formatAsCSV(rows, {
+        layoutName: 'My Drawer',
+        gridSize: '10×8',
+      });
+      const lines = csv.split('\n');
+
+      // Header should have Layout and Grid Size columns first
+      expect(lines[0]).toBe('Layout,Grid Size,Size,Height,Bins,Pieces,Filament (m),Label,Notes');
+      // Data row should include metadata values
+      expect(lines[1]).toContain('My Drawer,10×8,');
+    });
+
+    it('includes layout metadata with custom properties', () => {
+      const rows = [
+        createTestRow({
+          labels: ['Bin 1'],
+          customProperties: { 'SKU': 'ABC123' },
+        }),
+      ];
+      const csv = formatAsCSV(rows, {
+        layoutName: 'Tool Drawer',
+        gridSize: '12×10',
+      });
+      const lines = csv.split('\n');
+
+      // Header should have metadata first, then base columns, then custom properties
+      expect(lines[0]).toBe('Layout,Grid Size,Size,Height,Bins,Pieces,Filament (m),Label,Notes,SKU');
+      expect(lines[1].startsWith('Tool Drawer,12×10,')).toBe(true);
+      expect(lines[1]).toContain('ABC123');
+    });
+
+    it('escapes layout metadata values', () => {
+      const rows = [createTestRow()];
+      const csv = formatAsCSV(rows, {
+        layoutName: 'Drawer, with comma',
+        gridSize: '10×8',
+      });
+      expect(csv).toContain('"Drawer, with comma"');
+    });
+
+    it('omits metadata columns when meta is undefined', () => {
+      const rows = [createTestRow()];
+      const csv = formatAsCSV(rows);
+      const lines = csv.split('\n');
+
+      // Should be the original format without Layout/Grid Size
+      expect(lines[0]).toBe('Size,Height,Bins,Pieces,Filament (m),Label,Notes');
+      expect(lines[1]).not.toContain('Layout');
+    });
   });
 
   describe('formatAsJSON', () => {

--- a/src/test/storage.test.ts
+++ b/src/test/storage.test.ts
@@ -422,6 +422,88 @@ describe('storage', () => {
       // Header should not have extra columns
       expect(lines[0]).toBe('Size\tHeight\tBins\tPieces\tLabel\tNotes');
     });
+
+    it('exports with layout metadata when provided', () => {
+      const rows = [
+        { size: '1x1', height: 3, binCount: 5, totalPieces: 5 },
+      ];
+      const tsv = exportPrintListTSV(rows, {
+        layoutName: 'My Drawer',
+        gridSize: '10×8',
+      });
+      const lines = tsv.split('\n');
+      expect(lines).toHaveLength(2);
+      // Header should have Layout and Grid Size columns first
+      expect(lines[0]).toBe('Layout\tGrid Size\tSize\tHeight\tBins\tPieces\tLabel\tNotes');
+      // Data row should include metadata values
+      expect(lines[1]).toBe('My Drawer\t10×8\t1x1\t3u\t5\t5\t\t');
+    });
+
+    it('exports with layout metadata and custom properties', () => {
+      const rows = [
+        {
+          size: '2x2',
+          height: 6,
+          binCount: 1,
+          totalPieces: 1,
+          labels: ['Screws'],
+          customProperties: { SKU: 'ABC123' },
+        },
+      ];
+      const tsv = exportPrintListTSV(rows, {
+        layoutName: 'Tool Drawer',
+        gridSize: '12×10',
+      });
+      const lines = tsv.split('\n');
+      // Header should have metadata first, then base columns, then custom properties
+      expect(lines[0]).toBe('Layout\tGrid Size\tSize\tHeight\tBins\tPieces\tLabel\tNotes\tSKU');
+      expect(lines[1]).toBe('Tool Drawer\t12×10\t2x2\t6u\t1\t1\tScrews\t\tABC123');
+    });
+
+    it('exports without metadata columns when meta is undefined', () => {
+      const rows = [
+        { size: '1x1', height: 3, binCount: 1, totalPieces: 1 },
+      ];
+      const tsv = exportPrintListTSV(rows);
+      const lines = tsv.split('\n');
+      // Should be the original format without Layout/Grid Size
+      expect(lines[0]).toBe('Size\tHeight\tBins\tPieces\tLabel\tNotes');
+      expect(lines[1]).toBe('1x1\t3u\t1\t1\t\t');
+    });
+
+    it('escapes tabs and newlines in metadata values', () => {
+      const rows = [
+        { size: '1x1', height: 3, binCount: 1, totalPieces: 1 },
+      ];
+      const tsv = exportPrintListTSV(rows, {
+        layoutName: 'Drawer\twith\ttabs',
+        gridSize: '10×8',
+      });
+      const lines = tsv.split('\n');
+      // Tabs should be replaced with spaces
+      expect(lines[1]).toContain('Drawer with tabs');
+      // Should still have correct number of columns (no extra tabs)
+      expect(lines[1].split('\t')).toHaveLength(8);
+    });
+
+    it('escapes tabs and newlines in label and notes', () => {
+      const rows = [
+        {
+          size: '1x1',
+          height: 3,
+          binCount: 1,
+          totalPieces: 1,
+          labels: ['Label\twith\ttab'],
+          notes: 'Notes\nwith\nnewlines',
+        },
+      ];
+      const tsv = exportPrintListTSV(rows);
+      const lines = tsv.split('\n');
+      expect(lines[1]).toContain('Label with tab');
+      expect(lines[1]).toContain('Notes with newlines');
+      // Should still have correct number of columns
+      expect(lines[1].split('\t')).toHaveLength(6);
+    });
   });
 
   describe('getStorageUsage', () => {

--- a/src/utils/binListOperations.ts
+++ b/src/utils/binListOperations.ts
@@ -146,11 +146,20 @@ function escapeCSVValue(value: string): string {
 }
 
 /**
+ * Metadata for CSV export including layout context.
+ */
+export interface CSVExportMeta {
+  layoutName?: string;
+  gridSize?: string;
+}
+
+/**
  * Format rows as CSV with proper escaping.
  * Compatible with Excel, Google Sheets, etc.
  * Dynamically adds columns for custom properties that exist in any row.
+ * Optionally includes layout name and grid size columns for context.
  */
-export function formatAsCSV(rows: EnhancedPrintRow[]): string {
+export function formatAsCSV(rows: EnhancedPrintRow[], meta?: CSVExportMeta): string {
   // Collect all unique custom property keys across all rows
   const customKeys = new Set<string>();
   for (const row of rows) {
@@ -162,17 +171,23 @@ export function formatAsCSV(rows: EnhancedPrintRow[]): string {
   }
   const sortedKeys = Array.from(customKeys).sort();
 
-  // Build header with dynamic custom property columns
-  const baseHeader = 'Size,Height,Bins,Pieces,Filament (m),Label,Notes';
+  // Build header with optional metadata and dynamic custom property columns
+  const metaHeader = meta ? 'Layout,Grid Size,' : '';
+  const baseHeader = `${metaHeader}Size,Height,Bins,Pieces,Filament (m),Label,Notes`;
   const header = sortedKeys.length > 0
     ? `${baseHeader},${sortedKeys.join(',')}`
     : baseHeader;
+
+  // Pre-compute metadata values if provided (with CSV escaping)
+  const layoutName = meta ? escapeCSVValue(meta.layoutName || '') : '';
+  const gridSize = meta ? escapeCSVValue(meta.gridSize || '') : '';
 
   // Build data rows
   const lines = rows.map(row => {
     const label = escapeCSVValue((row.labels ?? [])[0] || '');
     const notes = escapeCSVValue(row.notes || '');
-    const baseLine = `${row.size},${row.height}u,${row.binCount},${row.totalPieces},${row.filament},${label},${notes}`;
+    const metaValues = meta ? `${layoutName},${gridSize},` : '';
+    const baseLine = `${metaValues}${row.size},${row.height}u,${row.binCount},${row.totalPieces},${row.filament},${label},${notes}`;
 
     if (sortedKeys.length === 0) {
       return baseLine;


### PR DESCRIPTION
## Summary
- Add Layout and Grid Size columns to bin list TSV and CSV exports for better context when data is used in spreadsheets
- All three export formats now include this metadata consistently:
  - **TSV**: Layout and Grid Size as first two columns
  - **CSV**: Layout and Grid Size as first two columns
  - **JSON**: Already had `_meta.layoutName` and `_meta.drawerSize`
- Add proper TSV escaping for tabs/newlines in all values to prevent format corruption

## Test plan
- [x] Unit tests added for TSV metadata columns
- [x] Unit tests added for CSV metadata columns
- [x] Unit tests added for TSV escaping of tabs/newlines
- [x] All 3193 tests pass
- [x] Build succeeds