### PR TITLE
refactor: extract StepperControl component for consistent stepper UI

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -7,6 +7,7 @@ import { ActiveLayerPanel } from './ActiveLayerPanel';
 import { LayerPanel } from './LayerPanel';
 import { CategoriesPanel } from './CategoriesPanel';
 import { DeferredNumberInput } from '../DeferredNumberInput';
+import { StepperControl } from '../StepperControl';
 import { ConfirmDialog } from '../modals/ConfirmDialog';
 import { HalfBinModeBlockedModal } from '../modals/HalfBinModeBlockedModal';
 import { CollapsibleSection } from '../CollapsibleSection';
@@ -134,102 +135,45 @@ export function Sidebar() {
                       <label className="block text-content-tertiary mb-1" title={`Width in grid units (step: ${widthStep})`}>
                         Width
                       </label>
-                      <div className="flex items-center h-6">
-                        <button
-                          onClick={() => handleDrawerWidthChange(-1)}
-                          disabled={drawer.width <= 0.5}
-                          className="h-full px-1 rounded-l border border-r-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
-                          aria-label="Decrease width"
-                        >
-                          <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                            <path strokeLinecap="round" d="M20 12H4" />
-                          </svg>
-                        </button>
-                        <DeferredNumberInput
-                          value={drawer.width}
-                          onChange={handleDrawerWidthInput}
-                          min={0.5}
-                          max={CONSTRAINTS.GRID_MAX}
-                          step={widthStep}
-                          className="flex-1 h-full border-y border-stroke-subtle bg-surface text-center tabular-nums text-content-secondary text-xs focus:outline-none focus:ring-1 focus:ring-accent"
-                          aria-label="Drawer width in grid units"
-                        />
-                        <button
-                          onClick={() => handleDrawerWidthChange(1)}
-                          disabled={drawer.width >= CONSTRAINTS.GRID_MAX}
-                          className="h-full px-1 rounded-r border border-l-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
-                          aria-label="Increase width"
-                        >
-                          <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                            <path strokeLinecap="round" d="M12 4v16m8-8H4" />
-                          </svg>
-                        </button>
-                      </div>
+                      <StepperControl
+                        value={drawer.width}
+                        onChange={handleDrawerWidthInput}
+                        onStep={handleDrawerWidthChange}
+                        min={0.5}
+                        max={CONSTRAINTS.GRID_MAX}
+                        step={widthStep}
+                        variant="compact"
+                        ariaLabel="Drawer width in grid units"
+                      />
                     </div>
                     <div>
                       <label className="block text-content-tertiary mb-1" title={`Depth in grid units (step: ${depthStep})`}>
                         Depth
                       </label>
-                      <div className="flex items-center h-6">
-                        <button
-                          onClick={() => handleDrawerDepthChange(-1)}
-                          disabled={drawer.depth <= 0.5}
-                          className="h-full px-1 rounded-l border border-r-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
-                          aria-label="Decrease depth"
-                        >
-                          <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                            <path strokeLinecap="round" d="M20 12H4" />
-                          </svg>
-                        </button>
-                        <DeferredNumberInput
-                          value={drawer.depth}
-                          onChange={handleDrawerDepthInput}
-                          min={0.5}
-                          max={CONSTRAINTS.GRID_MAX}
-                          step={depthStep}
-                          className="flex-1 h-full border-y border-stroke-subtle bg-surface text-center tabular-nums text-content-secondary text-xs focus:outline-none focus:ring-1 focus:ring-accent"
-                          aria-label="Drawer depth in grid units"
-                        />
-                        <button
-                          onClick={() => handleDrawerDepthChange(1)}
-                          disabled={drawer.depth >= CONSTRAINTS.GRID_MAX}
-                          className="h-full px-1 rounded-r border border-l-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
-                          aria-label="Increase depth"
-                        >
-                          <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                            <path strokeLinecap="round" d="M12 4v16m8-8H4" />
-                          </svg>
-                        </button>
-                      </div>
+                      <StepperControl
+                        value={drawer.depth}
+                        onChange={handleDrawerDepthInput}
+                        onStep={handleDrawerDepthChange}
+                        min={0.5}
+                        max={CONSTRAINTS.GRID_MAX}
+                        step={depthStep}
+                        variant="compact"
+                        ariaLabel="Drawer depth in grid units"
+                      />
                     </div>
                     <div>
                       <label className="block text-content-tertiary mb-1" title="Maximum height in units">
                         Height
                       </label>
-                      <div className="flex items-center h-6">
-                        <button
-                          onClick={() => handleDrawerHeightChange(-1)}
-                          disabled={drawer.height <= 1}
-                          className="h-full px-1 rounded-l border border-r-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors"
-                          aria-label="Decrease height"
-                        >
-                          <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                            <path strokeLinecap="round" d="M20 12H4" />
-                          </svg>
-                        </button>
-                        <span className="flex-1 h-full flex items-center justify-center border-y border-stroke-subtle bg-surface text-center tabular-nums text-content-secondary text-xs">
-                          {drawer.height}u
-                        </span>
-                        <button
-                          onClick={() => handleDrawerHeightChange(1)}
-                          className="h-full px-1 rounded-r border border-l-0 border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover transition-colors"
-                          aria-label="Increase height"
-                        >
-                          <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                            <path strokeLinecap="round" d="M12 4v16m8-8H4" />
-                          </svg>
-                        </button>
-                      </div>
+                      <StepperControl
+                        value={drawer.height}
+                        onStep={handleDrawerHeightChange}
+                        min={1}
+                        max={CONSTRAINTS.GRID_MAX}
+                        variant="compact"
+                        ariaLabel="Drawer height in units"
+                        displayValue={`${drawer.height}u`}
+                      />
                     </div>
                   </div>
 

--- a/src/components/StepperControl.tsx
+++ b/src/components/StepperControl.tsx
@@ -1,0 +1,199 @@
+import type { ReactNode } from 'react';
+import { DeferredNumberInput } from './DeferredNumberInput';
+
+/**
+ * Variant determines the visual size and styling of the stepper:
+ * - 'compact': Small h-6 stepper for tight spaces (e.g., Sidebar grid)
+ * - 'desktop': Standard h-8 stepper for desktop panels (e.g., bin inspector)
+ * - 'mobile': Large h-12 touch-friendly stepper for mobile
+ */
+export type StepperVariant = 'compact' | 'desktop' | 'mobile';
+
+interface StepperControlProps {
+  /** Current numeric value */
+  value: number;
+  /** Called when value changes via input */
+  onChange?: (value: number) => void;
+  /** Called when stepper button is clicked, with +1 or -1 */
+  onStep: (delta: number) => void;
+  /** Minimum allowed value */
+  min: number;
+  /** Maximum allowed value */
+  max: number;
+  /** Step size for the input (default: 1) */
+  step?: number;
+  /** Visual variant */
+  variant?: StepperVariant;
+  /** Accessibility label for the input/display */
+  ariaLabel: string;
+  /**
+   * If provided, shows a static display instead of an input.
+   * Useful for values that should only change via steppers (like height).
+   */
+  displayValue?: ReactNode;
+  /** Disable the entire control */
+  disabled?: boolean;
+  /** Additional class for the container */
+  className?: string;
+}
+
+/**
+ * Minus icon SVG
+ */
+function MinusIcon({ size }: { size: 'sm' | 'md' | 'lg' }) {
+  const sizeClass = size === 'sm' ? 'w-2.5 h-2.5' : size === 'md' ? 'w-3 h-3' : 'w-5 h-5';
+  const strokeWidth = size === 'lg' ? 2 : 2.5;
+  return (
+    <svg className={sizeClass} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={strokeWidth}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M20 12H4" />
+    </svg>
+  );
+}
+
+/**
+ * Plus icon SVG
+ */
+function PlusIcon({ size }: { size: 'sm' | 'md' | 'lg' }) {
+  const sizeClass = size === 'sm' ? 'w-2.5 h-2.5' : size === 'md' ? 'w-3 h-3' : 'w-5 h-5';
+  const strokeWidth = size === 'lg' ? 2 : 2.5;
+  return (
+    <svg className={sizeClass} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={strokeWidth}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+    </svg>
+  );
+}
+
+/**
+ * A reusable stepper control with +/- buttons and either an input or display.
+ *
+ * Supports three variants:
+ * - `compact`: Small stepper for tight layouts (Sidebar drawer dimensions)
+ * - `desktop`: Standard desktop stepper (bin inspector)
+ * - `mobile`: Large touch-friendly stepper (mobile settings)
+ *
+ * @example Input mode (editable)
+ * ```tsx
+ * <StepperControl
+ *   value={width}
+ *   onChange={setWidth}
+ *   onStep={(delta) => setWidth(w => w + delta * step)}
+ *   min={0.5}
+ *   max={50}
+ *   step={0.5}
+ *   variant="compact"
+ *   ariaLabel="Drawer width"
+ * />
+ * ```
+ *
+ * @example Display mode (stepper-only)
+ * ```tsx
+ * <StepperControl
+ *   value={height}
+ *   onStep={(delta) => setHeight(h => h + delta)}
+ *   min={1}
+ *   max={50}
+ *   displayValue={`${height}u`}
+ *   variant="mobile"
+ *   ariaLabel="Drawer height"
+ * />
+ * ```
+ */
+export function StepperControl({
+  value,
+  onChange,
+  onStep,
+  min,
+  max,
+  step = 1,
+  variant = 'desktop',
+  ariaLabel,
+  displayValue,
+  disabled = false,
+  className = '',
+}: StepperControlProps) {
+  const isCompact = variant === 'compact';
+  const isMobile = variant === 'mobile';
+  const iconSize = isCompact ? 'sm' : isMobile ? 'lg' : 'md';
+
+  // Determine if buttons should be disabled
+  const decreaseDisabled = disabled || value <= min;
+  const increaseDisabled = disabled || value >= max;
+
+  // Button styles based on variant
+  const buttonBaseClass = isMobile
+    ? 'btn btn-secondary w-12 h-12 p-0'
+    : isCompact
+      ? 'h-full px-1 border border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors'
+      : 'h-full px-2 border border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-30 transition-colors';
+
+  const decreaseButtonClass = isMobile
+    ? `${buttonBaseClass} rounded-r-none`
+    : `${buttonBaseClass} rounded-l border-r-0`;
+
+  const increaseButtonClass = isMobile
+    ? `${buttonBaseClass} rounded-l-none`
+    : `${buttonBaseClass} rounded-r border-l-0`;
+
+  // Container height
+  const heightClass = isCompact ? 'h-6' : isMobile ? '' : 'h-8';
+
+  // Input/display styles
+  const inputClass = isMobile
+    ? 'input flex-1 h-12 text-center font-semibold tabular-nums border-x-0 rounded-none'
+    : isCompact
+      ? 'flex-1 h-full border-y border-stroke-subtle bg-surface text-center tabular-nums text-content-secondary text-xs focus:outline-none focus:ring-1 focus:ring-accent'
+      : 'flex-1 h-full border-y border-stroke-subtle bg-surface text-center tabular-nums text-content-secondary text-sm focus:outline-none focus:ring-1 focus:ring-accent';
+
+  const displayClass = isMobile
+    ? 'flex-1 h-12 flex items-center justify-center font-semibold bg-surface-elevated text-content'
+    : isCompact
+      ? 'flex-1 h-full flex items-center justify-center border-y border-stroke-subtle bg-surface text-center tabular-nums text-content-secondary text-xs'
+      : 'flex-1 h-full flex items-center justify-center border-y border-stroke-subtle bg-surface text-center tabular-nums text-content-secondary text-sm';
+
+  return (
+    <div className={`flex items-center ${heightClass} ${className}`}>
+      {/* Decrease button */}
+      <button
+        type="button"
+        onClick={() => onStep(-1)}
+        disabled={decreaseDisabled}
+        className={decreaseButtonClass}
+        aria-label={`Decrease ${ariaLabel}`}
+      >
+        <MinusIcon size={iconSize} />
+      </button>
+
+      {/* Input or display */}
+      {displayValue !== undefined ? (
+        <span className={displayClass} aria-label={ariaLabel}>
+          {displayValue}
+        </span>
+      ) : onChange ? (
+        <DeferredNumberInput
+          value={value}
+          onChange={onChange}
+          min={min}
+          max={max}
+          step={step}
+          className={inputClass}
+          aria-label={ariaLabel}
+        />
+      ) : (
+        <span className={displayClass} aria-label={ariaLabel}>
+          {value}
+        </span>
+      )}
+
+      {/* Increase button */}
+      <button
+        type="button"
+        onClick={() => onStep(1)}
+        disabled={increaseDisabled}
+        className={increaseButtonClass}
+        aria-label={`Increase ${ariaLabel}`}
+      >
+        <PlusIcon size={iconSize} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/mobile/MobileSettingsPanel.tsx
+++ b/src/components/mobile/MobileSettingsPanel.tsx
@@ -7,6 +7,7 @@ import { CONSTRAINTS } from '../../constants';
 import { ConfirmDialog } from '../modals/ConfirmDialog';
 import { HalfBinModeBlockedModal } from '../modals/HalfBinModeBlockedModal';
 import { DeferredNumberInput } from '../DeferredNumberInput';
+import { StepperControl } from '../StepperControl';
 import type { STLSearchSite } from '../../store/settings';
 
 /**
@@ -94,37 +95,16 @@ export function MobileSettingsPanel() {
             <label className="block text-sm mb-1 text-content-tertiary">
               Width
             </label>
-            <div className="flex items-center">
-              <button
-                onClick={() => handleDrawerWidthChange(-1)}
-                disabled={drawer.width <= 0.5}
-                className="btn btn-secondary w-12 h-12 p-0 rounded-r-none"
-                aria-label="Decrease width"
-              >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-                </svg>
-              </button>
-              <DeferredNumberInput
-                value={drawer.width}
-                onChange={handleDrawerWidthInput}
-                min={0.5}
-                max={CONSTRAINTS.GRID_MAX}
-                step={widthStep}
-                className="input flex-1 h-12 text-center font-semibold tabular-nums border-x-0 rounded-none"
-                aria-label="Drawer width in grid units"
-              />
-              <button
-                onClick={() => handleDrawerWidthChange(1)}
-                disabled={drawer.width >= CONSTRAINTS.GRID_MAX}
-                className="btn btn-secondary w-12 h-12 p-0 rounded-l-none"
-                aria-label="Increase width"
-              >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                </svg>
-              </button>
-            </div>
+            <StepperControl
+              value={drawer.width}
+              onChange={handleDrawerWidthInput}
+              onStep={handleDrawerWidthChange}
+              min={0.5}
+              max={CONSTRAINTS.GRID_MAX}
+              step={widthStep}
+              variant="mobile"
+              ariaLabel="Drawer width in grid units"
+            />
           </div>
 
           {/* Depth */}
@@ -132,37 +112,16 @@ export function MobileSettingsPanel() {
             <label className="block text-sm mb-1 text-content-tertiary">
               Depth
             </label>
-            <div className="flex items-center">
-              <button
-                onClick={() => handleDrawerDepthChange(-1)}
-                disabled={drawer.depth <= 0.5}
-                className="btn btn-secondary w-12 h-12 p-0 rounded-r-none"
-                aria-label="Decrease depth"
-              >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-                </svg>
-              </button>
-              <DeferredNumberInput
-                value={drawer.depth}
-                onChange={handleDrawerDepthInput}
-                min={0.5}
-                max={CONSTRAINTS.GRID_MAX}
-                step={depthStep}
-                className="input flex-1 h-12 text-center font-semibold tabular-nums border-x-0 rounded-none"
-                aria-label="Drawer depth in grid units"
-              />
-              <button
-                onClick={() => handleDrawerDepthChange(1)}
-                disabled={drawer.depth >= CONSTRAINTS.GRID_MAX}
-                className="btn btn-secondary w-12 h-12 p-0 rounded-l-none"
-                aria-label="Increase depth"
-              >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                </svg>
-              </button>
-            </div>
+            <StepperControl
+              value={drawer.depth}
+              onChange={handleDrawerDepthInput}
+              onStep={handleDrawerDepthChange}
+              min={0.5}
+              max={CONSTRAINTS.GRID_MAX}
+              step={depthStep}
+              variant="mobile"
+              ariaLabel="Drawer depth in grid units"
+            />
           </div>
         </div>
 
@@ -171,31 +130,15 @@ export function MobileSettingsPanel() {
           <label className="block text-sm mb-1 text-content-tertiary">
             Height
           </label>
-          <div className="flex items-center">
-            <button
-              onClick={() => handleDrawerHeightChange(-1)}
-              disabled={drawer.height <= 1}
-              className="btn btn-secondary w-12 h-12 p-0 rounded-r-none"
-              aria-label="Decrease height"
-            >
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-              </svg>
-            </button>
-            <span className="flex-1 h-12 flex items-center justify-center font-semibold bg-surface-elevated text-content">
-              {drawer.height}u
-            </span>
-            <button
-              onClick={() => handleDrawerHeightChange(1)}
-              disabled={drawer.height >= CONSTRAINTS.GRID_MAX}
-              className="btn btn-secondary w-12 h-12 p-0 rounded-l-none"
-              aria-label="Increase height"
-            >
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-              </svg>
-            </button>
-          </div>
+          <StepperControl
+            value={drawer.height}
+            onStep={handleDrawerHeightChange}
+            min={1}
+            max={CONSTRAINTS.GRID_MAX}
+            variant="mobile"
+            ariaLabel="Drawer height in units"
+            displayValue={`${drawer.height}u`}
+          />
         </div>
 
         {/* Real-world drawer dimensions */}

--- a/src/test/components/Sidebar.test.tsx
+++ b/src/test/components/Sidebar.test.tsx
@@ -156,29 +156,29 @@ describe('Sidebar', () => {
     it('renders width controls', () => {
       render(<Sidebar />);
 
-      expect(screen.getByLabelText('Decrease width')).toBeInTheDocument();
-      expect(screen.getByLabelText('Increase width')).toBeInTheDocument();
+      expect(screen.getByLabelText('Decrease Drawer width in grid units')).toBeInTheDocument();
+      expect(screen.getByLabelText('Increase Drawer width in grid units')).toBeInTheDocument();
     });
 
     it('renders depth controls', () => {
       render(<Sidebar />);
 
-      expect(screen.getByLabelText('Decrease depth')).toBeInTheDocument();
-      expect(screen.getByLabelText('Increase depth')).toBeInTheDocument();
+      expect(screen.getByLabelText('Decrease Drawer depth in grid units')).toBeInTheDocument();
+      expect(screen.getByLabelText('Increase Drawer depth in grid units')).toBeInTheDocument();
     });
 
     it('renders height controls', () => {
       render(<Sidebar />);
 
-      expect(screen.getByLabelText('Decrease height')).toBeInTheDocument();
-      expect(screen.getByLabelText('Increase height')).toBeInTheDocument();
+      expect(screen.getByLabelText('Decrease Drawer height in units')).toBeInTheDocument();
+      expect(screen.getByLabelText('Increase Drawer height in units')).toBeInTheDocument();
     });
 
     it('increases width when plus clicked', () => {
       render(<Sidebar />);
 
       const initialWidth = useLayoutStore.getState().layout.drawer.width;
-      fireEvent.click(screen.getByLabelText('Increase width'));
+      fireEvent.click(screen.getByLabelText('Increase Drawer width in grid units'));
 
       expect(useLayoutStore.getState().layout.drawer.width).toBe(initialWidth + 1);
     });
@@ -187,7 +187,7 @@ describe('Sidebar', () => {
       render(<Sidebar />);
 
       const initialWidth = useLayoutStore.getState().layout.drawer.width;
-      fireEvent.click(screen.getByLabelText('Decrease width'));
+      fireEvent.click(screen.getByLabelText('Decrease Drawer width in grid units'));
 
       expect(useLayoutStore.getState().layout.drawer.width).toBe(initialWidth - 1);
     });
@@ -196,7 +196,7 @@ describe('Sidebar', () => {
       render(<Sidebar />);
 
       const initialDepth = useLayoutStore.getState().layout.drawer.depth;
-      fireEvent.click(screen.getByLabelText('Increase depth'));
+      fireEvent.click(screen.getByLabelText('Increase Drawer depth in grid units'));
 
       expect(useLayoutStore.getState().layout.drawer.depth).toBe(initialDepth + 1);
     });
@@ -205,7 +205,7 @@ describe('Sidebar', () => {
       render(<Sidebar />);
 
       const initialDepth = useLayoutStore.getState().layout.drawer.depth;
-      fireEvent.click(screen.getByLabelText('Decrease depth'));
+      fireEvent.click(screen.getByLabelText('Decrease Drawer depth in grid units'));
 
       expect(useLayoutStore.getState().layout.drawer.depth).toBe(initialDepth - 1);
     });
@@ -214,7 +214,7 @@ describe('Sidebar', () => {
       render(<Sidebar />);
 
       const initialHeight = useLayoutStore.getState().layout.drawer.height;
-      fireEvent.click(screen.getByLabelText('Increase height'));
+      fireEvent.click(screen.getByLabelText('Increase Drawer height in units'));
 
       expect(useLayoutStore.getState().layout.drawer.height).toBe(initialHeight + 1);
     });
@@ -223,7 +223,7 @@ describe('Sidebar', () => {
       render(<Sidebar />);
 
       const initialHeight = useLayoutStore.getState().layout.drawer.height;
-      fireEvent.click(screen.getByLabelText('Decrease height'));
+      fireEvent.click(screen.getByLabelText('Decrease Drawer height in units'));
 
       expect(useLayoutStore.getState().layout.drawer.height).toBe(initialHeight - 1);
     });
@@ -233,7 +233,7 @@ describe('Sidebar', () => {
 
       render(<Sidebar />);
 
-      expect(screen.getByLabelText('Decrease width')).toBeDisabled();
+      expect(screen.getByLabelText('Decrease Drawer width in grid units')).toBeDisabled();
     });
 
     it('disables decrease depth at minimum', () => {
@@ -241,7 +241,7 @@ describe('Sidebar', () => {
 
       render(<Sidebar />);
 
-      expect(screen.getByLabelText('Decrease depth')).toBeDisabled();
+      expect(screen.getByLabelText('Decrease Drawer depth in grid units')).toBeDisabled();
     });
 
     it('shows real-world dimensions in mm', () => {
@@ -282,7 +282,7 @@ describe('Sidebar', () => {
       render(<Sidebar />);
 
       const initialWidth = useLayoutStore.getState().layout.drawer.width;
-      fireEvent.click(screen.getByLabelText('Increase width'));
+      fireEvent.click(screen.getByLabelText('Increase Drawer width in grid units'));
 
       expect(useLayoutStore.getState().layout.drawer.width).toBe(initialWidth + 0.5);
     });
@@ -293,7 +293,7 @@ describe('Sidebar', () => {
       render(<Sidebar />);
 
       const initialDepth = useLayoutStore.getState().layout.drawer.depth;
-      fireEvent.click(screen.getByLabelText('Increase depth'));
+      fireEvent.click(screen.getByLabelText('Increase Drawer depth in grid units'));
 
       expect(useLayoutStore.getState().layout.drawer.depth).toBe(initialDepth + 0.5);
     });
@@ -373,7 +373,7 @@ describe('Sidebar', () => {
     it('renders grid unit input', () => {
       render(<Sidebar />);
 
-      expect(screen.getByLabelText(/Drawer width in grid units/)).toBeInTheDocument();
+      expect(screen.getByLabelText('Grid unit')).toBeInTheDocument();
     });
   });
 

--- a/src/test/components/StepperControl.test.tsx
+++ b/src/test/components/StepperControl.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StepperControl } from '../../components/StepperControl';
+
+describe('StepperControl', () => {
+  const mockOnStep = vi.fn();
+  const mockOnChange = vi.fn();
+
+  const defaultProps = {
+    value: 5,
+    onStep: mockOnStep,
+    min: 0,
+    max: 10,
+    ariaLabel: 'Test value',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('variant rendering', () => {
+    it('renders compact variant with smaller size', () => {
+      const { container } = render(<StepperControl {...defaultProps} variant="compact" />);
+
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper).toHaveClass('h-6');
+    });
+
+    it('renders desktop variant with standard size', () => {
+      const { container } = render(<StepperControl {...defaultProps} variant="desktop" />);
+
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper).toHaveClass('h-8');
+    });
+
+    it('renders mobile variant without fixed height class', () => {
+      const { container } = render(<StepperControl {...defaultProps} variant="mobile" />);
+
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper).not.toHaveClass('h-6');
+      expect(wrapper).not.toHaveClass('h-8');
+    });
+
+    it('defaults to desktop variant', () => {
+      const { container } = render(<StepperControl {...defaultProps} />);
+
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper).toHaveClass('h-8');
+    });
+  });
+
+  describe('button states', () => {
+    it('disables decrease button when value equals min', () => {
+      render(<StepperControl {...defaultProps} value={0} />);
+
+      const decreaseButton = screen.getByRole('button', { name: 'Decrease Test value' });
+      expect(decreaseButton).toBeDisabled();
+    });
+
+    it('disables increase button when value equals max', () => {
+      render(<StepperControl {...defaultProps} value={10} />);
+
+      const increaseButton = screen.getByRole('button', { name: 'Increase Test value' });
+      expect(increaseButton).toBeDisabled();
+    });
+
+    it('enables both buttons when value is in range', () => {
+      render(<StepperControl {...defaultProps} value={5} />);
+
+      const decreaseButton = screen.getByRole('button', { name: 'Decrease Test value' });
+      const increaseButton = screen.getByRole('button', { name: 'Increase Test value' });
+      expect(decreaseButton).not.toBeDisabled();
+      expect(increaseButton).not.toBeDisabled();
+    });
+
+    it('disables both buttons when disabled prop is true', () => {
+      render(<StepperControl {...defaultProps} disabled />);
+
+      const decreaseButton = screen.getByRole('button', { name: 'Decrease Test value' });
+      const increaseButton = screen.getByRole('button', { name: 'Increase Test value' });
+      expect(decreaseButton).toBeDisabled();
+      expect(increaseButton).toBeDisabled();
+    });
+  });
+
+  describe('step behavior', () => {
+    it('calls onStep with -1 when decrease button clicked', () => {
+      render(<StepperControl {...defaultProps} />);
+
+      const decreaseButton = screen.getByRole('button', { name: 'Decrease Test value' });
+      fireEvent.click(decreaseButton);
+
+      expect(mockOnStep).toHaveBeenCalledWith(-1);
+    });
+
+    it('calls onStep with +1 when increase button clicked', () => {
+      render(<StepperControl {...defaultProps} />);
+
+      const increaseButton = screen.getByRole('button', { name: 'Increase Test value' });
+      fireEvent.click(increaseButton);
+
+      expect(mockOnStep).toHaveBeenCalledWith(1);
+    });
+
+    it('does not call onStep when decrease button is disabled', () => {
+      render(<StepperControl {...defaultProps} value={0} />);
+
+      const decreaseButton = screen.getByRole('button', { name: 'Decrease Test value' });
+      fireEvent.click(decreaseButton);
+
+      expect(mockOnStep).not.toHaveBeenCalled();
+    });
+
+    it('does not call onStep when increase button is disabled', () => {
+      render(<StepperControl {...defaultProps} value={10} />);
+
+      const increaseButton = screen.getByRole('button', { name: 'Increase Test value' });
+      fireEvent.click(increaseButton);
+
+      expect(mockOnStep).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('input mode', () => {
+    it('renders input when onChange is provided', () => {
+      render(<StepperControl {...defaultProps} onChange={mockOnChange} />);
+
+      expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+    });
+
+    it('input has correct aria-label', () => {
+      render(<StepperControl {...defaultProps} onChange={mockOnChange} />);
+
+      expect(screen.getByLabelText('Test value')).toBeInTheDocument();
+    });
+
+    it('input shows current value', () => {
+      render(<StepperControl {...defaultProps} onChange={mockOnChange} />);
+
+      expect(screen.getByRole('spinbutton')).toHaveValue(5);
+    });
+  });
+
+  describe('display mode', () => {
+    it('renders display value when displayValue is provided', () => {
+      render(<StepperControl {...defaultProps} displayValue="5u" />);
+
+      expect(screen.getByText('5u')).toBeInTheDocument();
+      expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument();
+    });
+
+    it('renders static display when neither onChange nor displayValue is provided', () => {
+      render(<StepperControl {...defaultProps} />);
+
+      // Should show the value as text without an input
+      const display = screen.getByLabelText('Test value');
+      expect(display).toBeInTheDocument();
+      expect(display.tagName.toLowerCase()).toBe('span');
+    });
+  });
+
+  describe('aria-label propagation', () => {
+    it('applies aria-label to decrease button', () => {
+      render(<StepperControl {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: 'Decrease Test value' })).toBeInTheDocument();
+    });
+
+    it('applies aria-label to increase button', () => {
+      render(<StepperControl {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: 'Increase Test value' })).toBeInTheDocument();
+    });
+
+    it('applies aria-label to display element', () => {
+      render(<StepperControl {...defaultProps} displayValue="5u" />);
+
+      expect(screen.getByLabelText('Test value')).toBeInTheDocument();
+    });
+  });
+
+  describe('className prop', () => {
+    it('applies additional className to container', () => {
+      const { container } = render(
+        <StepperControl {...defaultProps} className="custom-class" />
+      );
+
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper).toHaveClass('custom-class');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Creates reusable `StepperControl` component that consolidates the +/- stepper pattern
- Supports three variants: `compact` (h-6), `desktop` (h-8), `mobile` (h-12)
- Two modes: input mode (with DeferredNumberInput) and display mode (readonly span)
- Reduces duplicate stepper UI code in settings panels

## Component Features

| Feature | Description |
|---------|-------------|
| Variants | compact, desktop, mobile - controls size and styling |
| Input mode | Editable numeric input with DeferredNumberInput |
| Display mode | Read-only display with formatted value (e.g., "3u") |
| Accessibility | Consistent aria-labels for all elements |
| Min/max | Buttons disable when at limits |

## Changes

- **New**: `src/components/StepperControl.tsx` (190 lines)
- **Modified**: `src/components/Sidebar/index.tsx` (replaced inline steppers)
- **Modified**: `src/components/mobile/MobileSettingsPanel.tsx` (replaced inline steppers)
- **Modified**: `src/test/components/Sidebar.test.tsx` (updated aria-labels)

## Test plan

- [x] All 3,290 unit tests pass
- [x] TypeScript build succeeds
- [x] Lint passes
- [ ] Manual: Verify width/depth/height steppers work on desktop
- [ ] Manual: Verify width/depth/height steppers work on mobile
- [ ] Manual: Verify step sizes respect half-bin mode