### PR TITLE
refactor: extract BinContextMenuWrapper to shared component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import { DropZones } from './components/DropZones';
 import { DragPreview } from './components/DragPreview';
 import { ToastContainer } from './components/Toast';
 import { PanelErrorBoundary } from './components/PanelErrorBoundary';
-import { BinContextMenu, MultiBinContextMenu } from './components/mobile';
+import { BinContextMenuWrapper } from './components/mobile';
 import { TabletPanelOverlay, TabletPanelTriggers } from './components/tablet';
 import { LiveRegion } from './components/LiveRegion';
 import { SharedLayoutImporter } from './components/SharedLayoutImporter';
@@ -342,39 +342,4 @@ export default function App() {
       <LabsDrawer />
     </div>
   );
-}
-
-/**
- * Context menu wrapper that routes to single or multi-bin menu.
- */
-function BinContextMenuWrapper({
-  binIds,
-  position,
-  onClose,
-  source,
-}: {
-  binIds: string[];
-  position: { x: number; y: number };
-  onClose: () => void;
-  source?: 'grid' | 'staging';
-}) {
-  const bins = useLayoutStore(state => state.layout.bins);
-  const selectedBinIds = useUIStore(state => state.selectedBinIds);
-
-  // Guard: ensure binIds is valid
-  if (!binIds || binIds.length === 0) return null;
-
-  // Multi-select detection: if first bin is selected AND multiple bins selected
-  const isMultiSelect = selectedBinIds.includes(binIds[0]) && selectedBinIds.length > 1;
-
-  if (isMultiSelect) {
-    const selectedBins = bins.filter(b => selectedBinIds.includes(b.id));
-    return <MultiBinContextMenu binIds={selectedBins.map(b => b.id)} position={position} onClose={onClose} source={source} />;
-  }
-
-  // Single bin context menu
-  const bin = bins.find(b => b.id === binIds[0]);
-  if (!bin) return null;
-
-  return <BinContextMenu bin={bin} position={position} onClose={onClose} source={source} />;
 }

--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react';
-import { useUIStore, useLayoutStore } from '../store';
+import { useUIStore } from '../store';
 import { lazyWithRetry, namedExport } from '../utils/lazyWithRetry';
 import { Grid } from './Grid';
 import { Staging } from './Staging';
@@ -20,8 +20,7 @@ import {
   MobilePrintList,
   MobileSettingsPanel,
   MobileLayoutsPanel,
-  BinContextMenu,
-  MultiBinContextMenu,
+  BinContextMenuWrapper,
 } from './mobile';
 import { LabsDrawer } from './labs';
 import { PresenceAvatarList } from './collab';
@@ -175,39 +174,4 @@ function MobilePanelContent({ panel }: { panel: string }) {
       {content}
     </PanelErrorBoundary>
   );
-}
-
-/**
- * Context menu wrapper that routes to single or multi-bin menu.
- */
-function BinContextMenuWrapper({
-  binIds,
-  position,
-  onClose,
-  source,
-}: {
-  binIds: string[];
-  position: { x: number; y: number };
-  onClose: () => void;
-  source?: 'grid' | 'staging';
-}) {
-  const bins = useLayoutStore(state => state.layout.bins);
-  const selectedBinIds = useUIStore(state => state.selectedBinIds);
-
-  // Guard: ensure binIds is valid
-  if (!binIds || binIds.length === 0) return null;
-
-  // Multi-select detection: if first bin is selected AND multiple bins selected
-  const isMultiSelect = selectedBinIds.includes(binIds[0]) && selectedBinIds.length > 1;
-
-  if (isMultiSelect) {
-    const selectedBins = bins.filter(b => selectedBinIds.includes(b.id));
-    return <MultiBinContextMenu binIds={selectedBins.map(b => b.id)} position={position} onClose={onClose} source={source} />;
-  }
-
-  // Single bin context menu
-  const bin = bins.find(b => b.id === binIds[0]);
-  if (!bin) return null;
-
-  return <BinContextMenu bin={bin} position={position} onClose={onClose} source={source} />;
 }

--- a/src/components/mobile/BinContextMenuWrapper.tsx
+++ b/src/components/mobile/BinContextMenuWrapper.tsx
@@ -1,0 +1,53 @@
+import { useLayoutStore, useUIStore } from '../../store';
+import { BinContextMenu } from './BinContextMenu';
+import { MultiBinContextMenu } from './MultiBinContextMenu';
+
+export interface BinContextMenuWrapperProps {
+  binIds: string[];
+  position: { x: number; y: number };
+  onClose: () => void;
+  source?: 'grid' | 'staging';
+}
+
+/**
+ * Context menu wrapper that routes to single or multi-bin menu.
+ *
+ * Handles the logic of determining whether to show a single-bin or multi-bin
+ * context menu based on the current selection state.
+ *
+ * - If the right-clicked bin is part of a multi-selection, shows MultiBinContextMenu
+ * - Otherwise, shows the single BinContextMenu for the clicked bin
+ */
+export function BinContextMenuWrapper({
+  binIds,
+  position,
+  onClose,
+  source,
+}: BinContextMenuWrapperProps) {
+  const bins = useLayoutStore((state) => state.layout.bins);
+  const selectedBinIds = useUIStore((state) => state.selectedBinIds);
+
+  // Guard: ensure binIds is valid
+  if (!binIds || binIds.length === 0) return null;
+
+  // Multi-select detection: if first bin is selected AND multiple bins selected
+  const isMultiSelect = selectedBinIds.includes(binIds[0]) && selectedBinIds.length > 1;
+
+  if (isMultiSelect) {
+    const selectedBins = bins.filter((b) => selectedBinIds.includes(b.id));
+    return (
+      <MultiBinContextMenu
+        binIds={selectedBins.map((b) => b.id)}
+        position={position}
+        onClose={onClose}
+        source={source}
+      />
+    );
+  }
+
+  // Single bin context menu
+  const bin = bins.find((b) => b.id === binIds[0]);
+  if (!bin) return null;
+
+  return <BinContextMenu bin={bin} position={position} onClose={onClose} source={source} />;
+}

--- a/src/components/mobile/index.ts
+++ b/src/components/mobile/index.ts
@@ -11,4 +11,6 @@ export { MobileLayoutsPanel } from './MobileLayoutsPanel';
 export { MobileGridToolbar } from './MobileGridToolbar';
 export { BinContextMenu } from './BinContextMenu';
 export { MultiBinContextMenu } from './MultiBinContextMenu';
+export { BinContextMenuWrapper } from './BinContextMenuWrapper';
+export type { BinContextMenuWrapperProps } from './BinContextMenuWrapper';
 export { MobileHelpModal } from './MobileHelpModal';


### PR DESCRIPTION
## Summary

- Extracts `BinContextMenuWrapper` from being duplicated in both `App.tsx` and `MobileLayout.tsx` to a shared component
- Single source of truth ensures consistent context menu behavior and makes bug fixes easier

## What BinContextMenuWrapper does

The component routes between single-bin and multi-bin context menus based on the current selection state:
- If the right-clicked bin is part of a multi-selection → shows `MultiBinContextMenu`
- Otherwise → shows `BinContextMenu` for the clicked bin

## Changes

- **New**: `src/components/mobile/BinContextMenuWrapper.tsx` (50 lines)
- **Modified**: `src/App.tsx` (removed duplicate definition, updated import)
- **Modified**: `src/components/MobileLayout.tsx` (removed duplicate definition, updated import)
- **Modified**: `src/components/mobile/index.ts` (added export)

## Test plan

- [x] All 3,290 unit tests pass
- [x] TypeScript build succeeds
- [x] Lint passes
- [ ] Manual: Right-click single bin shows single-bin context menu
- [ ] Manual: Right-click bin in multi-selection shows multi-bin context menu
- [ ] Manual: Verify on both desktop and mobile views