### PR TITLE
refactor: extract SelectDropdown component

### DIFF
--- a/src/components/SelectDropdown.tsx
+++ b/src/components/SelectDropdown.tsx
@@ -1,0 +1,93 @@
+interface SelectOption {
+  id: string;
+  name: string;
+  /** Optional suffix to append to the name (e.g., "(current)") */
+  suffix?: string;
+}
+
+interface SelectDropdownProps {
+  /** Current selected value */
+  value: string;
+  /** Called when selection changes */
+  onChange: (value: string) => void;
+  /** List of options to display */
+  options: SelectOption[];
+  /** Optional placeholder shown when value is empty */
+  placeholder?: {
+    value: string;
+    label: string;
+    disabled?: boolean;
+  };
+  /** Color for left swatch. Pass string for solid color, null for mixed indicator, undefined for no swatch */
+  colorSwatch?: string | null;
+  /** Accessible label for the select */
+  ariaLabel: string;
+  /** Platform variant affects sizing */
+  variant?: 'desktop' | 'mobile';
+  /** Additional CSS classes for the wrapper */
+  className?: string;
+}
+
+/**
+ * Styled select dropdown with optional color swatch.
+ * Provides consistent appearance across desktop and mobile variants.
+ */
+export function SelectDropdown({
+  value,
+  onChange,
+  options,
+  placeholder,
+  colorSwatch,
+  ariaLabel,
+  variant = 'desktop',
+  className = '',
+}: SelectDropdownProps) {
+  const isMobile = variant === 'mobile';
+  const inputHeight = isMobile ? 'h-12' : '';
+  const hasColorSwatch = colorSwatch !== undefined;
+
+  return (
+    <div className={`relative ${className}`}>
+      {/* Color swatch indicator */}
+      {hasColorSwatch && (
+        colorSwatch ? (
+          <div
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 rounded pointer-events-none"
+            style={{ backgroundColor: colorSwatch }}
+          />
+        ) : (
+          // Mixed/null state indicator
+          <div className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 rounded pointer-events-none bg-surface-hover border border-stroke-subtle" />
+        )
+      )}
+
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={`input w-full pr-8 appearance-none ${hasColorSwatch ? 'pl-8' : ''} ${inputHeight}`}
+        aria-label={ariaLabel}
+      >
+        {placeholder && (
+          <option value={placeholder.value} disabled={placeholder.disabled}>
+            {placeholder.label}
+          </option>
+        )}
+        {options.map((opt) => (
+          <option key={opt.id} value={opt.id}>
+            {opt.name}{opt.suffix || ''}
+          </option>
+        ))}
+      </select>
+
+      {/* Chevron indicator */}
+      <svg
+        className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none text-content-tertiary"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+      </svg>
+    </div>
+  );
+}

--- a/src/components/inspector/MultiBinInspector.tsx
+++ b/src/components/inspector/MultiBinInspector.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { STAGING_ID, DEFAULT_CATEGORY_COLOR, CONSTRAINTS } from '../../constants';
 import type { UseBinInspectorReturn } from './useBinInspector';
 import type { Layer } from '../../types';
+import { SelectDropdown } from '../SelectDropdown';
 
 interface MultiBinInspectorProps {
   inspector: UseBinInspectorReturn;
@@ -147,39 +148,15 @@ export function MultiBinInspector({
           <label className={`block ${labelSize} text-content-tertiary`}>
             Category
           </label>
-          <div className="relative">
-            {categoryColor ? (
-              <div
-                className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 rounded pointer-events-none"
-                style={{ backgroundColor: categoryColor }}
-              />
-            ) : (
-              <div className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 rounded pointer-events-none bg-surface-hover border border-stroke-subtle" />
-            )}
-            <select
-              value={commonCategory || ''}
-              onChange={(e) => updateMultiCategory(e.target.value)}
-              className={`input w-full pl-8 pr-8 appearance-none ${inputHeight}`}
-              aria-label="Category for selected bins"
-            >
-              {!commonCategory && (
-                <option value="" disabled>
-                  {getMixedLabel()}
-                </option>
-              )}
-              {categories.map((c) => (
-                <option key={c.id} value={c.id}>{c.name}</option>
-              ))}
-            </select>
-            <svg
-              className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none text-content-tertiary"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-            </svg>
-          </div>
+          <SelectDropdown
+            value={commonCategory || ''}
+            onChange={updateMultiCategory}
+            options={categories.map((c) => ({ id: c.id, name: c.name }))}
+            placeholder={!commonCategory ? { value: '', label: getMixedLabel(), disabled: true } : undefined}
+            colorSwatch={categoryColor}
+            ariaLabel="Category for selected bins"
+            variant={variant}
+          />
         </div>
 
         {/* Layer - only show when there are bins on grid and multiple layers */}
@@ -188,33 +165,18 @@ export function MultiBinInspector({
             <label className={`block ${labelSize} text-content-tertiary`}>
               Layer
             </label>
-            <div className="relative">
-              <select
-                value={commonLayer?.id || ''}
-                onChange={(e) => updateMultiLayer(e.target.value)}
-                className={`input w-full pr-8 appearance-none ${inputHeight}`}
-                aria-label="Layer for selected bins"
-              >
-                {!commonLayer && (
-                  <option value="" disabled>
-                    {getMixedLayerLabel()}
-                  </option>
-                )}
-                {layout.layers.map((l) => (
-                  <option key={l.id} value={l.id}>
-                    {l.name}{l.id === commonLayer?.id ? ' (current)' : ''}
-                  </option>
-                ))}
-              </select>
-              <svg
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none text-content-tertiary"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-              </svg>
-            </div>
+            <SelectDropdown
+              value={commonLayer?.id || ''}
+              onChange={updateMultiLayer}
+              options={layout.layers.map((l) => ({
+                id: l.id,
+                name: l.name,
+                suffix: l.id === commonLayer?.id ? ' (current)' : '',
+              }))}
+              placeholder={!commonLayer ? { value: '', label: getMixedLayerLabel(), disabled: true } : undefined}
+              ariaLabel="Layer for selected bins"
+              variant={variant}
+            />
           </div>
         )}
 

--- a/src/components/inspector/SingleBinInspector.tsx
+++ b/src/components/inspector/SingleBinInspector.tsx
@@ -4,6 +4,7 @@ import { getBinLocationContext } from '../../utils/binLocation';
 import type { UseBinInspectorReturn } from './useBinInspector';
 import { SplitWarning } from './SplitWarning';
 import { StepperControl } from '../StepperControl';
+import { SelectDropdown } from '../SelectDropdown';
 import { CustomPropertiesEditor } from './CustomPropertiesEditor';
 import { STLSearchDropdown } from '../STLSearchDropdown';
 
@@ -209,30 +210,14 @@ export function SingleBinInspector({
           <label className={`block ${labelSize} text-content-tertiary`}>
             Category
           </label>
-          <div className="relative">
-            <div
-              className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 rounded pointer-events-none"
-              style={{ backgroundColor: category?.color || DEFAULT_CATEGORY_COLOR }}
-            />
-            <select
-              value={bin.category}
-              onChange={(e) => updateField('category', e.target.value)}
-              className={`input w-full pl-8 pr-8 appearance-none ${inputHeight}`}
-              aria-label="Bin category"
-            >
-              {categories.map((c) => (
-                <option key={c.id} value={c.id}>{c.name}</option>
-              ))}
-            </select>
-            <svg
-              className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none text-content-tertiary"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-            </svg>
-          </div>
+          <SelectDropdown
+            value={bin.category}
+            onChange={(value) => updateField('category', value)}
+            options={categories.map((c) => ({ id: c.id, name: c.name }))}
+            colorSwatch={category?.color || DEFAULT_CATEGORY_COLOR}
+            ariaLabel="Bin category"
+            variant={variant}
+          />
         </div>
 
         {/* Layer - only show for bins on grid (not in staging) */}
@@ -241,28 +226,17 @@ export function SingleBinInspector({
             <label className={`block ${labelSize} text-content-tertiary`}>
               Layer
             </label>
-            <div className="relative">
-              <select
-                value={bin.layerId}
-                onChange={(e) => moveToLayer(e.target.value)}
-                className={`input w-full pr-8 appearance-none ${inputHeight}`}
-                aria-label="Bin layer"
-              >
-                {layout.layers.map((l) => (
-                  <option key={l.id} value={l.id}>
-                    {l.name}{l.id === layer?.id ? ' (current)' : ''}
-                  </option>
-                ))}
-              </select>
-              <svg
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none text-content-tertiary"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-              </svg>
-            </div>
+            <SelectDropdown
+              value={bin.layerId}
+              onChange={moveToLayer}
+              options={layout.layers.map((l) => ({
+                id: l.id,
+                name: l.name,
+                suffix: l.id === layer?.id ? ' (current)' : '',
+              }))}
+              ariaLabel="Bin layer"
+              variant={variant}
+            />
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Create reusable `SelectDropdown` component for consistent select styling
- Replace 4 select implementations across SingleBinInspector and MultiBinInspector
- Net reduction of ~65 lines of duplicate code

## Features
- Optional color swatch indicator (solid color or mixed state)
- Desktop/mobile variant support with appropriate sizing
- Optional placeholder with disabled state (for multi-selection "mixed" values)
- Option suffix support (e.g., "(current)" for layer selection)
- Consistent chevron indicator styling

## Changes
- `src/components/SelectDropdown.tsx` - New reusable component
- `src/components/inspector/SingleBinInspector.tsx` - Use SelectDropdown for Category and Layer
- `src/components/inspector/MultiBinInspector.tsx` - Use SelectDropdown for Category and Layer

## Test plan
- [x] All 3343 tests pass
- [x] Coverage thresholds met
- [x] Build succeeds
- [ ] Manual testing: verify select dropdowns work in both inspectors on desktop and mobile