### PR TITLE
refactor: extract BulkIncrementControl component

### DIFF
--- a/src/components/BulkIncrementControl.tsx
+++ b/src/components/BulkIncrementControl.tsx
@@ -1,0 +1,64 @@
+interface BulkIncrementControlProps {
+  /** Display value (can include range like "3–5u" or single value like "4u") */
+  displayValue: string;
+  /** Called with -1 or +1 when step buttons are clicked */
+  onStep: (delta: number) => void;
+  /** Aria label prefix (e.g., "height for all bins" → "Decrease height for all bins") */
+  ariaLabelPrefix: string;
+  /** Whether decrease button is disabled */
+  decreaseDisabled?: boolean;
+  /** Whether increase button is disabled */
+  increaseDisabled?: boolean;
+  /** Platform variant affects button sizing */
+  variant?: 'desktop' | 'mobile';
+}
+
+/**
+ * Bulk increment/decrement control with +/- buttons flanking a value display.
+ * Used for adjusting properties across multiple selected items.
+ */
+export function BulkIncrementControl({
+  displayValue,
+  onStep,
+  ariaLabelPrefix,
+  decreaseDisabled = false,
+  increaseDisabled = false,
+  variant = 'desktop',
+}: BulkIncrementControlProps) {
+  const isMobile = variant === 'mobile';
+
+  // Button sizing for mobile vs desktop
+  const btnSize = isMobile ? 'w-12 h-12' : 'w-10 h-10';
+  const btnMinSize = isMobile ? 'min-w-[48px] min-h-[48px]' : 'min-w-[40px] min-h-[40px]';
+  const valueSize = isMobile ? 'text-xl' : 'text-lg';
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={() => onStep(-1)}
+        disabled={decreaseDisabled}
+        className={`btn btn-secondary ${btnSize} p-0 ${btnMinSize}`}
+        aria-label={`Decrease ${ariaLabelPrefix}`}
+      >
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
+        </svg>
+      </button>
+      <span className={`flex-1 text-center font-semibold ${valueSize} text-content`}>
+        {displayValue}
+      </span>
+      <button
+        type="button"
+        onClick={() => onStep(1)}
+        disabled={increaseDisabled}
+        className={`btn btn-secondary ${btnSize} p-0 ${btnMinSize}`}
+        aria-label={`Increase ${ariaLabelPrefix}`}
+      >
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/src/components/inspector/MultiBinInspector.tsx
+++ b/src/components/inspector/MultiBinInspector.tsx
@@ -3,6 +3,7 @@ import { STAGING_ID, DEFAULT_CATEGORY_COLOR, CONSTRAINTS } from '../../constants
 import type { UseBinInspectorReturn } from './useBinInspector';
 import type { Layer } from '../../types';
 import { SelectDropdown } from '../SelectDropdown';
+import { BulkIncrementControl } from '../BulkIncrementControl';
 
 interface MultiBinInspectorProps {
   inspector: UseBinInspectorReturn;
@@ -44,12 +45,9 @@ export function MultiBinInspector({
 
   const isMobile = variant === 'mobile';
 
-  // Button sizing for mobile vs desktop
-  const btnSize = isMobile ? 'w-12 h-12' : 'w-10 h-10';
-  const btnMinSize = isMobile ? 'min-w-[48px] min-h-[48px]' : 'min-w-[40px] min-h-[40px]';
+  // Sizing for mobile vs desktop
   const inputHeight = isMobile ? 'h-12' : '';
   const labelSize = isMobile ? 'text-sm mb-2' : 'text-xs mb-1';
-  const valueSize = isMobile ? 'text-xl' : 'text-lg';
 
   // Check if all bins have the same category
   const commonCategory = selectedBins.every((b) => b.category === selectedBins[0]?.category)
@@ -185,31 +183,12 @@ export function MultiBinInspector({
           <label className={`block ${labelSize} text-content-tertiary`}>
             Height
           </label>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => updateMultiHeight(-1)}
-              className={`btn btn-secondary ${btnSize} p-0 ${btnMinSize}`}
-              aria-label="Decrease height for all bins"
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-              </svg>
-            </button>
-            <span className={`flex-1 text-center font-semibold ${valueSize} text-content`}>
-              {sameHeight ? `${minHeight}u` : `${minHeight}–${maxHeight}u`}
-            </span>
-            <button
-              type="button"
-              onClick={() => updateMultiHeight(1)}
-              className={`btn btn-secondary ${btnSize} p-0 ${btnMinSize}`}
-              aria-label="Increase height for all bins"
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-              </svg>
-            </button>
-          </div>
+          <BulkIncrementControl
+            displayValue={sameHeight ? `${minHeight}u` : `${minHeight}–${maxHeight}u`}
+            onStep={updateMultiHeight}
+            ariaLabelPrefix="height for all bins"
+            variant={variant}
+          />
         </div>
 
         {/* Clearance control - show if any bin has clearance or if user might want to add it */}
@@ -221,32 +200,13 @@ export function MultiBinInspector({
             >
               Clearance
             </label>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => updateMultiClearance(-1)}
-                disabled={maxClearance <= 0}
-                className={`btn btn-secondary ${btnSize} p-0 ${btnMinSize}`}
-                aria-label="Decrease clearance for all bins"
-              >
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-                </svg>
-              </button>
-              <span className={`flex-1 text-center font-semibold ${valueSize} text-content`}>
-                {sameClearance ? `${minClearance}u` : `${minClearance}–${maxClearance}u`}
-              </span>
-              <button
-                type="button"
-                onClick={() => updateMultiClearance(1)}
-                className={`btn btn-secondary ${btnSize} p-0 ${btnMinSize}`}
-                aria-label="Increase clearance for all bins"
-              >
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                </svg>
-              </button>
-            </div>
+            <BulkIncrementControl
+              displayValue={sameClearance ? `${minClearance}u` : `${minClearance}–${maxClearance}u`}
+              onStep={updateMultiClearance}
+              ariaLabelPrefix="clearance for all bins"
+              decreaseDisabled={maxClearance <= 0}
+              variant={variant}
+            />
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Create reusable `BulkIncrementControl` for +/- button controls
- Replace height and clearance controls in MultiBinInspector
- Net reduction of ~40 lines of duplicate code

## Features
- Desktop/mobile variant support with appropriate button sizing
- Optional disable states for increase/decrease buttons  
- Configurable aria-label prefix for accessibility
- Flexible display value (supports ranges like "3–5u")

## Changes
- `src/components/BulkIncrementControl.tsx` - New reusable component
- `src/components/inspector/MultiBinInspector.tsx` - Use BulkIncrementControl for Height and Clearance

## Notes
- LayerPanel was evaluated but uses a different inline compact pattern that wouldn't benefit from this component

## Test plan
- [x] All 3343 tests pass
- [x] Coverage thresholds met
- [x] Build succeeds
- [ ] Manual testing: verify height/clearance controls work in multi-selection on desktop and mobile