### PR TITLE
refactor: extract SettingsRow component for label + input patterns

### DIFF
--- a/src/components/SettingsRow.tsx
+++ b/src/components/SettingsRow.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from 'react';
+
+interface SettingsRowProps {
+  /** Label text displayed on the left */
+  label: string;
+  /** Optional tooltip shown on hover */
+  tooltip?: string;
+  /** Optional unit suffix shown after the input (e.g., "mm") */
+  unit?: string;
+  /** Input or control element */
+  children: ReactNode;
+  /** Platform variant affects sizing and spacing */
+  variant?: 'desktop' | 'mobile';
+  /** Optional id for label htmlFor attribute */
+  htmlFor?: string;
+}
+
+/**
+ * Settings row with label on left and input/control on right.
+ * Provides consistent layout for configuration panels.
+ */
+export function SettingsRow({
+  label,
+  tooltip,
+  unit,
+  children,
+  variant = 'desktop',
+  htmlFor,
+}: SettingsRowProps) {
+  const isMobile = variant === 'mobile';
+
+  // Sizing based on variant
+  const labelClass = isMobile
+    ? 'text-sm text-content-secondary'
+    : 'text-xs text-content-tertiary';
+  const gapClass = isMobile ? 'gap-2' : 'gap-1';
+
+  return (
+    <div className="flex items-center justify-between">
+      {htmlFor ? (
+        <label
+          htmlFor={htmlFor}
+          className={labelClass}
+          title={tooltip}
+        >
+          {label}
+        </label>
+      ) : (
+        <span
+          className={labelClass}
+          title={tooltip}
+        >
+          {label}
+        </span>
+      )}
+      <div className={`flex items-center ${gapClass}`}>
+        {children}
+        {unit && (
+          <span className="text-content-tertiary">{unit}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -14,6 +14,7 @@ import { CollapsibleSection } from '../CollapsibleSection';
 import { useResponsive } from '../../hooks/useResponsive';
 import { LabsButton } from '../labs';
 import { Checkbox } from '../Checkbox';
+import { SettingsRow } from '../SettingsRow';
 import type { STLSearchSite } from '../../store/settings';
 
 export function Sidebar() {
@@ -288,67 +289,52 @@ export function Sidebar() {
             <div data-units-panel className="px-4 py-4 border-t border-stroke-subtle">
               <CollapsibleSection title="Physical Units" variant="default" defaultExpanded={isDesktop}>
                 <div className="text-xs text-content-secondary space-y-2">
-                  <div className="flex items-center justify-between">
-                    <label
-                      htmlFor="gridUnit"
-                      className="text-content-tertiary"
-                      title="Size of one grid unit in mm (standard Gridfinity = 42mm)"
-                    >
-                      Grid unit
-                    </label>
-                    <div className="flex items-center gap-1">
-                      <DeferredNumberInput
-                        id="gridUnit"
-                        value={gridUnitMm}
-                        onChange={setGridUnitMm}
-                        min={1}
-                        max={200}
-                        className="input w-14 py-0.5 px-1 text-xs text-right"
-                      />
-                      <span className="text-content-tertiary">mm</span>
-                    </div>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <label
-                      htmlFor="heightUnit"
-                      className="text-content-tertiary"
-                      title="Height of one vertical unit in mm (standard = 7mm)"
-                    >
-                      Height unit
-                    </label>
-                    <div className="flex items-center gap-1">
-                      <DeferredNumberInput
-                        id="heightUnit"
-                        value={heightUnitMm}
-                        onChange={setHeightUnitMm}
-                        min={1}
-                        max={50}
-                        className="input w-14 py-0.5 px-1 text-xs text-right"
-                      />
-                      <span className="text-content-tertiary">mm</span>
-                    </div>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <label
-                      htmlFor="printBedSize"
-                      className="text-content-tertiary"
-                      title={`Bins larger than ${Math.floor((printBedSize - 10) / gridUnitMm)}×${Math.floor((printBedSize - 10) / gridUnitMm)} will be split for printing`}
-                    >
-                      Print bed
-                    </label>
-                    <div className="flex items-center gap-1">
-                      <DeferredNumberInput
-                        id="printBedSize"
-                        value={printBedSize}
-                        onChange={setPrintBedSize}
-                        min={42}
-                        max={500}
-                        step={10}
-                        className="input w-14 py-0.5 px-1 text-xs text-right"
-                      />
-                      <span className="text-content-tertiary">mm</span>
-                    </div>
-                  </div>
+                  <SettingsRow
+                    label="Grid unit"
+                    htmlFor="gridUnit"
+                    tooltip="Size of one grid unit in mm (standard Gridfinity = 42mm)"
+                    unit="mm"
+                  >
+                    <DeferredNumberInput
+                      id="gridUnit"
+                      value={gridUnitMm}
+                      onChange={setGridUnitMm}
+                      min={1}
+                      max={200}
+                      className="input w-14 py-0.5 px-1 text-xs text-right"
+                    />
+                  </SettingsRow>
+                  <SettingsRow
+                    label="Height unit"
+                    htmlFor="heightUnit"
+                    tooltip="Height of one vertical unit in mm (standard = 7mm)"
+                    unit="mm"
+                  >
+                    <DeferredNumberInput
+                      id="heightUnit"
+                      value={heightUnitMm}
+                      onChange={setHeightUnitMm}
+                      min={1}
+                      max={50}
+                      className="input w-14 py-0.5 px-1 text-xs text-right"
+                    />
+                  </SettingsRow>
+                  <SettingsRow
+                    label="Print bed"
+                    htmlFor="printBedSize"
+                    tooltip={`Bins larger than ${Math.floor((printBedSize - 10) / gridUnitMm)}×${Math.floor((printBedSize - 10) / gridUnitMm)} will be split for printing`}
+                    unit="mm"
+                  >
+                    <DeferredNumberInput
+                      id="printBedSize"
+                      value={printBedSize}
+                      onChange={setPrintBedSize}
+                      min={42}
+                      max={500}
+                      step={10}
+                      className="input w-14 py-0.5 px-1 text-xs text-right"
+                    />
+                  </SettingsRow>
                 </div>
               </CollapsibleSection>
             </div>

--- a/src/components/mobile/MobileSettingsPanel.tsx
+++ b/src/components/mobile/MobileSettingsPanel.tsx
@@ -10,6 +10,7 @@ import { DeferredNumberInput } from '../DeferredNumberInput';
 import { StepperControl } from '../StepperControl';
 import { Checkbox } from '../Checkbox';
 import { SectionHeader } from '../SectionHeader';
+import { SettingsRow } from '../SettingsRow';
 import type { STLSearchSite } from '../../store/settings';
 
 /**
@@ -161,54 +162,36 @@ export function MobileSettingsPanel() {
         <SectionHeader title="Grid Settings" />
 
         <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <label className="text-sm text-content-secondary">
-              1 grid unit
-            </label>
-            <div className="flex items-center gap-2">
-              <DeferredNumberInput
-                value={gridUnitMm}
-                onChange={setGridUnitMm}
-                className="input w-20 h-10 text-center"
-                min={1}
-                max={200}
-              />
-              <span className="text-content-tertiary">mm</span>
-            </div>
-          </div>
+          <SettingsRow label="1 grid unit" unit="mm" variant="mobile">
+            <DeferredNumberInput
+              value={gridUnitMm}
+              onChange={setGridUnitMm}
+              className="input w-20 h-10 text-center"
+              min={1}
+              max={200}
+            />
+          </SettingsRow>
 
-          <div className="flex items-center justify-between">
-            <label className="text-sm text-content-secondary">
-              1u height
-            </label>
-            <div className="flex items-center gap-2">
-              <DeferredNumberInput
-                value={heightUnitMm}
-                onChange={setHeightUnitMm}
-                className="input w-20 h-10 text-center"
-                min={1}
-                max={50}
-              />
-              <span className="text-content-tertiary">mm</span>
-            </div>
-          </div>
+          <SettingsRow label="1u height" unit="mm" variant="mobile">
+            <DeferredNumberInput
+              value={heightUnitMm}
+              onChange={setHeightUnitMm}
+              className="input w-20 h-10 text-center"
+              min={1}
+              max={50}
+            />
+          </SettingsRow>
 
-          <div className="flex items-center justify-between">
-            <label className="text-sm text-content-secondary">
-              Print bed size
-            </label>
-            <div className="flex items-center gap-2">
-              <DeferredNumberInput
-                value={printBedSize}
-                onChange={setPrintBedSize}
-                className="input w-20 h-10 text-center"
-                min={42}
-                max={500}
-                step={10}
-              />
-              <span className="text-content-tertiary">mm</span>
-            </div>
-          </div>
+          <SettingsRow label="Print bed size" unit="mm" variant="mobile">
+            <DeferredNumberInput
+              value={printBedSize}
+              onChange={setPrintBedSize}
+              className="input w-20 h-10 text-center"
+              min={42}
+              max={500}
+              step={10}
+            />
+          </SettingsRow>
 
           <div className="text-sm text-right text-content-disabled">
             Max bin size: {maxGridUnits}×{maxGridUnits}


### PR DESCRIPTION
## Summary
- Creates a reusable `SettingsRow` component for the label + input/control pattern
- Updates `MobileSettingsPanel` (3 Grid Settings rows) and `Sidebar` (3 Physical Units rows) to use the new component

## Features
- Label on left, input/control on right with optional unit suffix
- Desktop/mobile variants with appropriate sizing
- Proper `htmlFor` association (renders `<label>` when provided, `<span>` otherwise)
- Tooltip support via `title` attribute

## Test plan
- [x] All unit tests pass (3343 tests)
- [x] Lint passes
- [x] Build succeeds
- [ ] Verify settings rows render correctly in both mobile and desktop views