### PR TITLE
fix(ui): improve multi-bin custom property form layout

### DIFF
--- a/src/components/inspector/MultiBinInspector.tsx
+++ b/src/components/inspector/MultiBinInspector.tsx
@@ -228,31 +228,29 @@ export function MultiBinInspector({
           </div>
           {showPropertyForm ? (
             <div className="bg-surface-elevated border border-stroke-subtle rounded p-2.5 space-y-2">
-              <div className="flex gap-2">
-                <input
-                  type="text"
-                  value={propertyKey}
-                  onChange={(e) => setPropertyKey(e.target.value.slice(0, CONSTRAINTS.CUSTOM_PROPERTY_KEY_MAX_LENGTH))}
-                  className={`input flex-1 ${inputHeight}`}
-                  placeholder="Property name"
-                  aria-label="Property name"
-                  list="property-key-suggestions"
-                  autoFocus
-                />
-                <datalist id="property-key-suggestions">
-                  {existingPropertyKeys.map((key) => (
-                    <option key={key} value={key} />
-                  ))}
-                </datalist>
-                <input
-                  type="text"
-                  value={propertyValue}
-                  onChange={(e) => setPropertyValue(e.target.value.slice(0, CONSTRAINTS.CUSTOM_PROPERTY_VALUE_MAX_LENGTH))}
-                  className={`input flex-1 ${inputHeight}`}
-                  placeholder="Value"
-                  aria-label="Property value"
-                />
-              </div>
+              <input
+                type="text"
+                value={propertyKey}
+                onChange={(e) => setPropertyKey(e.target.value.slice(0, CONSTRAINTS.CUSTOM_PROPERTY_KEY_MAX_LENGTH))}
+                className={`input w-full ${inputHeight}`}
+                placeholder="Property name"
+                aria-label="Property name"
+                list="property-key-suggestions"
+                autoFocus
+              />
+              <datalist id="property-key-suggestions">
+                {existingPropertyKeys.map((key) => (
+                  <option key={key} value={key} />
+                ))}
+              </datalist>
+              <input
+                type="text"
+                value={propertyValue}
+                onChange={(e) => setPropertyValue(e.target.value.slice(0, CONSTRAINTS.CUSTOM_PROPERTY_VALUE_MAX_LENGTH))}
+                className={`input w-full ${inputHeight}`}
+                placeholder="Value"
+                aria-label="Property value"
+              />
               <div className="flex gap-2">
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
Fixes the wonky layout of the custom property entry form when multiple bins are selected.

## Problem
The property name and value inputs were:
1. Cramped side-by-side in a horizontal flex layout
2. Had a `<datalist>` element placed inside the flex container between inputs, causing layout issues

## Solution
Stack the inputs vertically (matching `CustomPropertiesEditor` pattern):
- Changed from `flex-1` to `w-full` for full-width inputs
- Moved `<datalist>` outside the flex container
- Now uses consistent vertical stacking with `space-y-2`

## Before
![before](https://github.com/user-attachments/assets/cramped-side-by-side)
Inputs cramped side-by-side

## After
Inputs stacked vertically for better readability

## Test plan
- [x] All unit tests pass (3343 tests)
- [x] Build succeeds
- [ ] Manually verify multi-bin selection custom property form looks correct