### PR TITLE
fix: rotate drag preview labels to match static bin logic

### DIFF
--- a/src/components/DragPreview.tsx
+++ b/src/components/DragPreview.tsx
@@ -114,11 +114,23 @@ export function DragPreview() {
               transform: 'scale(1.02)',
             }}
           >
-            {bin.label && (
-              <div className="text-center pointer-events-none select-none text-xs truncate px-1" style={{ color: textColor, opacity: 0.85 }}>
-                {bin.label}
-              </div>
-            )}
+            {bin.label && (() => {
+              // Smart rotation: match Bin.tsx logic - rotate if significantly taller than wide
+              const shouldRotate = bin.depth > bin.width * 1.5;
+              return (
+                <div
+                  className="text-center pointer-events-none select-none text-xs truncate px-1"
+                  style={{
+                    color: textColor,
+                    opacity: 0.85,
+                    transform: shouldRotate ? 'rotate(-90deg)' : 'none',
+                    width: shouldRotate ? `${(bin.depth / bin.width) * 90}%` : 'auto',
+                  }}
+                >
+                  {bin.label}
+                </div>
+              );
+            })()}
           </div>
         );
       })}


### PR DESCRIPTION
## Summary
- Apply smart rotation to dragged bin labels when `depth > width * 1.5`, matching the existing behavior in `Bin.tsx`
- Tall, narrow bins now display their labels vertically during drag operations for visual consistency

## Test plan
- [ ] Drag a tall bin (e.g., 1×3) with a label - label should rotate vertically
- [ ] Drag a wide bin (e.g., 3×1) with a label - label should remain horizontal
- [ ] Drag a square bin (e.g., 2×2) with a label - label should remain horizontal