### PR TITLE
fix: skip heartbeat when offline, add try/catch for safety

### DIFF
--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -32,15 +32,21 @@ export function useAnalytics(): void {
 
     // --- Vercel Heartbeat (every 3 min while visible) ---
     const sendHeartbeat = () => {
+      // Skip if tab not visible or offline
       if (document.visibilityState !== 'visible') return;
+      if (!navigator.onLine) return;
 
-      const startTime = sessionStartRef.current ?? Date.now();
-      const sessionMinutes = Math.floor((Date.now() - startTime) / 60000);
+      try {
+        const startTime = sessionStartRef.current ?? Date.now();
+        const sessionMinutes = Math.floor((Date.now() - startTime) / 60000);
 
-      track('heartbeat', {
-        context: getActivityContext(),
-        session_minutes: sessionMinutes,
-      });
+        track('heartbeat', {
+          context: getActivityContext(),
+          session_minutes: sessionMinutes,
+        });
+      } catch {
+        // Silently ignore analytics failures (blocked, etc.)
+      }
     };
 
     // Send initial heartbeat after a short delay (let app stabilize)


### PR DESCRIPTION
## Summary
- Check `navigator.onLine` before attempting to send heartbeat (matches pattern used elsewhere in codebase)
- Wrap `track()` in try/catch for graceful failure handling (ad blockers, etc.)

## Test plan
- [x] Type check passes
- [x] Tests pass
- [ ] Works normally when online
- [ ] Silently skips heartbeat when offline (no errors in console)