### PR TITLE
refactor: create layouts/ directory for responsive shells (Phase 3)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ const HelpModal = lazyWithRetry(() =>
 
 // Lazy load mobile layout - only loaded on mobile devices
 const MobileLayout = lazyWithRetry(() =>
-  import('./components/MobileLayout').then(namedExport('MobileLayout'))
+  import('./layouts/MobileLayout').then(namedExport('MobileLayout'))
 );
 
 // Lazy load collaborative editing provider - only loaded when Labs feature enabled

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -1,13 +1,13 @@
 import { Suspense } from 'react';
 import { useUIStore } from '../core/store';
 import { lazyWithRetry, namedExport } from '../utils/lazyWithRetry';
-import { Grid } from './Grid';
-import { Staging } from './Staging';
-import { DropZones } from './DropZones';
-import { DragPreview } from './DragPreview';
+import { Grid } from '../components/Grid';
+import { Staging } from '../components/Staging';
+import { DropZones } from '../components/DropZones';
+import { DragPreview } from '../components/DragPreview';
 import { ToastContainer } from '../shared/components/Toast';
-import { PanelErrorBoundary } from './PanelErrorBoundary';
-import { SharedLayoutImporter, SharedLayoutBanner } from './Share';
+import { PanelErrorBoundary } from '../components/PanelErrorBoundary';
+import { SharedLayoutImporter, SharedLayoutBanner } from '../components/Share';
 import {
   MobileHeader,
   BottomNavBar,
@@ -20,9 +20,9 @@ import {
   MobileSettingsPanel,
   MobileLayoutsPanel,
   BinContextMenuWrapper,
-} from './Mobile';
-import { LabsDrawer } from './Labs';
-import { PresenceAvatarList } from './Collab';
+} from '../components/Mobile';
+import { LabsDrawer } from '../components/Labs';
+import { PresenceAvatarList } from '../components/Collab';
 import { usePresence } from '../hooks/usePresence';
 import { useCollabMode } from '../hooks/useCollabMode';
 import type { SaveStatus } from '../shared/hooks';
@@ -35,10 +35,10 @@ interface LegacyContextMenuState {
 
 // Lazy load mobile help modal (with retry for chunk load failures)
 const MobileHelpModal = lazyWithRetry(() =>
-  import('./Mobile/MobileHelpModal').then(namedExport('MobileHelpModal'))
+  import('../components/Mobile/MobileHelpModal').then(namedExport('MobileHelpModal'))
 );
 
-interface MobileLayoutProps {
+export interface MobileLayoutProps {
   isMobileHelpOpen: boolean;
   setIsMobileHelpOpen: (open: boolean) => void;
   saveStatus: SaveStatus;

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -1,0 +1,5 @@
+export { MobileLayout } from './MobileLayout';
+export type { MobileLayoutProps } from './MobileLayout';
+
+// Future: Desktop and Tablet layouts can be extracted here
+// Currently they are defined inline in App.tsx


### PR DESCRIPTION
## Summary
- Create `src/layouts/` directory for responsive layout components
- Move `MobileLayout` from `components/` to `layouts/`
- Update imports in `App.tsx` and `MobileLayout.tsx`

## Changes
```
src/layouts/
├── index.ts           (barrel export)
└── MobileLayout.tsx   (moved from components/)
```

The tablet and desktop layouts remain inline in `App.tsx` for now as they share significant state management logic (isHelpOpen, wrapWithMutations helper, etc.). They can be extracted in a future refactor if needed.

## Test plan
- [x] All 3356 unit tests pass
- [x] Build succeeds
- [x] Pre-commit hooks pass
- [ ] E2E tests

Part of folder structure redesign (Phase 1: #189, Phase 2: #190).