### PR TITLE
fix: improve mobile resize handle usability

### DIFF
--- a/src/components/Grid/Bin.tsx
+++ b/src/components/Grid/Bin.tsx
@@ -553,9 +553,13 @@ function BinComponent({ bin, category, layer, drawer, cellSize, gap = 1, halfBin
     e.preventDefault();
     e.stopPropagation();
     if (e.button === 0) {
+      // Haptic feedback on touch devices when starting resize
+      if (isTouchDevice && navigator.vibrate) {
+        navigator.vibrate(30);
+      }
       onStartResize(bin.id, handle, e.pointerId);
     }
-  }, [onStartResize, bin.id]);
+  }, [onStartResize, bin.id, isTouchDevice]);
 
   const bgColor = category?.color || DEFAULT_CATEGORY_COLOR;
   const textColors = getBinTextColors(bgColor);

--- a/src/components/Grid/ResizeHandle.tsx
+++ b/src/components/Grid/ResizeHandle.tsx
@@ -28,7 +28,7 @@ function ResizeHandleComponent({ handle, placement, variant, onPointerDown }: Re
 
   return (
     <div
-      className="absolute flex items-center justify-center group"
+      className="resize-handle absolute flex items-center justify-center group"
       style={{
         left: position.left,
         right: position.right,

--- a/src/index.css
+++ b/src/index.css
@@ -316,10 +316,15 @@
    TOUCH-SPECIFIC STYLES
    =========================================== */
 @media (pointer: coarse) {
-  /* Larger resize handles on touch devices */
+  /* Larger touch targets on touch devices (48px vs 44px default) */
   .resize-handle {
-    width: 32px !important;
-    height: 32px !important;
+    width: 48px !important;
+    height: 48px !important;
+  }
+
+  /* Larger visual indicators on touch devices */
+  .resize-handle .resize-handle-indicator {
+    transform: scale(1.5);
   }
 
   /* Disable hover effects that don't work well on touch */
@@ -355,6 +360,14 @@
   }
 }
 
+/* Touch-specific: Add outline for better visibility against colored bins */
+@media (pointer: coarse) {
+  .resize-handle-indicator {
+    outline: 2px solid rgba(0, 0, 0, 0.3);
+    outline-offset: -1px;
+  }
+}
+
 /* Active/pressed state for all devices */
 .group:active .resize-handle-indicator,
 .resize-handle-indicator:active {
@@ -362,6 +375,16 @@
   filter: brightness(1.15);
   box-shadow: 0 0 16px rgba(251, 191, 36, 0.7),
               0 4px 8px rgba(0, 0, 0, 0.4);
+}
+
+/* Touch-specific: More prominent active state */
+@media (pointer: coarse) {
+  .group:active .resize-handle-indicator,
+  .resize-handle-indicator:active {
+    transform: scale(1.8);
+    box-shadow: 0 0 24px rgba(251, 191, 36, 0.9),
+                0 6px 12px rgba(0, 0, 0, 0.5);
+  }
 }
 
 /* ===========================================

--- a/src/utils/handlePositioning.ts
+++ b/src/utils/handlePositioning.ts
@@ -12,10 +12,10 @@ const INTERNAL_OFFSET = -TOUCH_TARGET_HALF;
 /** Offset for external handles (places target fully outside) */
 const EXTERNAL_OFFSET = -TOUCH_TARGET_SIZE;
 
-/** Visual indicator sizes */
-const EDGE_VISUAL_WIDTH = 10;
-const EDGE_VISUAL_MIN = 20;
-const CORNER_VISUAL_SIZE = 12;
+/** Visual indicator sizes (scaled 1.5x on touch devices via CSS) */
+const EDGE_VISUAL_WIDTH = 12;
+const EDGE_VISUAL_MIN = 24;
+const CORNER_VISUAL_SIZE = 14;
 
 /** Corner handle types */
 const CORNER_HANDLES: ResizeHandle[] = ['nw', 'ne', 'sw', 'se'];


### PR DESCRIPTION
- Fix CSS touch override that was making handles smaller (32px) instead of
  larger. Touch targets are now 48px (vs 44px default) for easier aiming
- Add resize-handle class to component so CSS can target it properly
- Increase visual indicator sizes: corners 12px→14px, edges 10px→12px
- Scale visual indicators 1.5x on touch devices via CSS transform
- Add haptic feedback (30ms vibration) when grabbing resize handles
- Add dark outline on touch devices for visibility against colored bins
- Increase active state scale to 1.8x on touch for clearer feedback