### PR TITLE
fix: update test mock paths for Phase 5 refactored modules

### DIFF
--- a/src/test/components/LayoutList.test.tsx
+++ b/src/test/components/LayoutList.test.tsx
@@ -30,8 +30,8 @@ vi.mock('../../components/LayoutThumbnail', () => ({
   ),
 }));
 
-// Mock LayoutActions to simplify tests
-vi.mock('../../components/Modals/LayoutManagerModal/LayoutActions', () => ({
+// Mock LayoutActions to simplify tests - must mock the actual source module
+vi.mock('../../features/layout-library/components/LayoutManagerModal/LayoutActions', () => ({
   LayoutActions: ({
     onCopyLink,
     onDownload,

--- a/src/test/components/LayoutListItem.test.tsx
+++ b/src/test/components/LayoutListItem.test.tsx
@@ -12,8 +12,8 @@ vi.mock('../../components/LayoutThumbnail', () => ({
   ),
 }));
 
-// Mock LayoutActions
-vi.mock('../../components/Modals/LayoutManagerModal/LayoutActions', () => ({
+// Mock LayoutActions - must mock the actual source module
+vi.mock('../../features/layout-library/components/LayoutManagerModal/LayoutActions', () => ({
   LayoutActions: ({
     isOnlyLayout,
     onCopyLink,

--- a/src/test/components/MobileLayoutsPanel.test.tsx
+++ b/src/test/components/MobileLayoutsPanel.test.tsx
@@ -137,6 +137,8 @@ vi.mock('../../core/storage', () => {
     ),
     updateCloudShare: vi.fn(() => ({ ok: true, value: {} })),
     computePreview: vi.fn(() => mockPreview),
+    getSharedLayoutFromURL: vi.fn(() => null),
+    getCloudShareIdFromURL: vi.fn(() => null),
   };
 });
 

--- a/src/test/hooks/useFeatureFlag.test.ts
+++ b/src/test/hooks/useFeatureFlag.test.ts
@@ -3,10 +3,11 @@ import { renderHook } from '@testing-library/react';
 import { useFeatureFlag, isFeatureEnabled } from '../../hooks/useFeatureFlag';
 import { useLabsStore } from '../../core/store/labs';
 import { resetAllStores } from '../testUtils';
-import * as features from '../../core/labs/features';
+import * as features from '../../features/labs/definitions/features';
 
-vi.mock('../../core/labs/features', async () => {
-  const actual = await vi.importActual<typeof features>('../../core/labs/features');
+// Must mock the actual source module that the store imports from
+vi.mock('../../features/labs/definitions/features', async () => {
+  const actual = await vi.importActual<typeof features>('../../features/labs/definitions/features');
   return {
     ...actual,
     getFeature: vi.fn(),

--- a/src/test/labs.test.ts
+++ b/src/test/labs.test.ts
@@ -12,9 +12,9 @@ import {
   getGraduatedFeatures,
   getToggleableFeatures,
   type FeatureId,
-} from '../core/labs/features';
-import { createDefaultLabsPreferences } from '../core/labs/types';
-import * as features from '../core/labs/features';
+} from '../features/labs/definitions/features';
+import { createDefaultLabsPreferences } from '../features/labs/definitions/types';
+import * as features from '../features/labs/definitions/features';
 
 // Mock trackEvent to avoid analytics calls in tests
 vi.mock('../utils/analytics', () => ({
@@ -22,8 +22,9 @@ vi.mock('../utils/analytics', () => ({
 }));
 
 // Mock getFeature for store tests to return features without comingSoon
-vi.mock('../core/labs/features', async () => {
-  const actual = await vi.importActual<typeof features>('../core/labs/features');
+// Note: Must mock the actual source module that the store imports from
+vi.mock('../features/labs/definitions/features', async () => {
+  const actual = await vi.importActual<typeof features>('../features/labs/definitions/features');
   return {
     ...actual,
     getFeature: vi.fn((id: string) => {


### PR DESCRIPTION
## Summary
Update `vi.mock` paths in test files to point to the actual source modules in `features/` directories instead of the re-export stubs in `core/`.

These tests were failing after Phase 5 because they were mocking the re-export stubs rather than the actual source modules that the components import from.

## Files fixed
- `labs.test.ts`: mock `features/labs/definitions/features` instead of `core/labs/features`
- `useFeatureFlag.test.ts`: mock `features/labs/definitions/features` instead of `core/labs/features`
- `LayoutListItem.test.tsx`: mock `features/layout-library/...LayoutActions` instead of `components/Modals/...LayoutActions`
- `LayoutList.test.tsx`: mock `features/layout-library/...LayoutActions` instead of `components/Modals/...LayoutActions`
- `MobileLayoutsPanel.test.tsx`: add missing `getSharedLayoutFromURL` and `getCloudShareIdFromURL` to storage mock

## Test plan
- [x] All 3356 tests pass
- [x] Build succeeds