### PR TITLE
fix: add missing ML telemetry tracking for labels and exports

### DIFF
--- a/src/features/bin-inspector/hooks/useBinInspector.ts
+++ b/src/features/bin-inspector/hooks/useBinInspector.ts
@@ -5,6 +5,7 @@ import { calcMaxGridUnits, STAGING_ID } from '@/core/constants';
 import { getLayerZStart } from '@/features/grid-editor/utils/collision';
 import { clamp, canPlaceBin, validateCustomProperties } from '@/shared/utils/validation';
 import { validateBinRotation } from '@/utils/binLocation';
+import { mlTracking } from '@/shared/analytics/useMLTracking';
 import type { Bin, Category, Layer, Layout } from '@/core/types';
 
 export type BinField = 'width' | 'depth' | 'height' | 'clearanceHeight' | 'category' | 'label' | 'notes';
@@ -196,6 +197,10 @@ export function useBinInspector(): UseBinInspectorReturn {
             constraints.maxClearance
           );
           updateBin(bin.id, { clearanceHeight: newClearance });
+        } else if (field === 'label') {
+          const oldLabel = bin.label;
+          updateBin(bin.id, { label: value as string });
+          mlTracking.trackLabel(bin, oldLabel, value as string);
         } else {
           updateBin(bin.id, { [field]: value });
         }

--- a/src/hooks/useBinList.ts
+++ b/src/hooks/useBinList.ts
@@ -19,6 +19,7 @@ import {
   type CategoryBreakdown,
 } from '@/utils/binListOperations';
 import { exportPrintListTSV } from '@/core/storage';
+import { mlTracking } from '@/shared/analytics/useMLTracking';
 import type { EnhancedPrintRow } from '@/core/types';
 
 export interface UseBinListReturn extends Omit<UsePrintListReturn, 'rows'> {
@@ -176,12 +177,17 @@ export function useBinList(): UseBinListReturn {
     const count = selectedBinIds.length;
     execute(() => {
       for (const binId of selectedBinIds) {
-        updateBin(binId, { label });
+        const bin = layout.bins.find((b) => b.id === binId);
+        if (bin) {
+          const oldLabel = bin.label;
+          updateBin(binId, { label });
+          mlTracking.trackLabel(bin, oldLabel, label);
+        }
       }
     });
 
     addToast(`Updated label for ${count} bin${count !== 1 ? 's' : ''}`, 'success');
-  }, [selectedBinIds, execute, updateBin, addToast]);
+  }, [selectedBinIds, layout.bins, execute, updateBin, addToast]);
 
   const updateBulkNotes = useCallback((notes: string) => {
     if (selectedBinIds.length === 0) return;
@@ -203,12 +209,17 @@ export function useBinList(): UseBinListReturn {
     const count = binIds.length;
     execute(() => {
       for (const binId of binIds) {
-        updateBin(binId, { label });
+        const bin = layout.bins.find((b) => b.id === binId);
+        if (bin) {
+          const oldLabel = bin.label;
+          updateBin(binId, { label });
+          mlTracking.trackLabel(bin, oldLabel, label);
+        }
       }
     });
 
     addToast(`Updated label for ${count} bin${count !== 1 ? 's' : ''}`, 'success');
-  }, [execute, updateBin, addToast]);
+  }, [layout.bins, execute, updateBin, addToast]);
 
   const updateBinNotes = useCallback((binIds: string[], notes: string) => {
     if (binIds.length === 0) return;
@@ -254,16 +265,22 @@ export function useBinList(): UseBinListReturn {
         content = exportToTSV();
         extension = 'tsv';
         mimeType = 'text/tab-separated-values';
+        mlTracking.trackSnapshot('export_tsv');
+        mlTracking.trackQuality('exported');
         break;
       case 'csv':
         content = exportToCSV();
         extension = 'csv';
         mimeType = 'text/csv';
+        mlTracking.trackSnapshot('export_tsv'); // CSV is similar quality signal
+        mlTracking.trackQuality('exported');
         break;
       case 'json':
         content = exportToJSON();
         extension = 'json';
         mimeType = 'application/json';
+        mlTracking.trackSnapshot('export_json');
+        mlTracking.trackQuality('exported');
         break;
     }
 


### PR DESCRIPTION
## Summary
- Add ML telemetry tracking to label update paths in Bin List Modal and Inspector
- Add export tracking for TSV/CSV/JSON downloads from bin list
- Fix gap where label→size correlations were not being captured for ML training

## Problem
Redis data showed **0 label tracking** despite users labeling bins (visible in session replays):
- `ml:label_hash:*` = 0 keys
- `ml:label:*` = 0 keys
- `ml:label_domain:*` = 0 keys

Only `QuickLabelPopover` had tracking, but most users edit labels through the Bin List Modal.

## Changes

### Label tracking added to:
| File | Function | Description |
|------|----------|-------------|
| `useBinList.ts` | `updateBulkLabel` | Bulk label operations on selected bins |
| `useBinList.ts` | `updateBinLabel` | Inline label edits in bin list rows |
| `useBinInspector.ts` | `updateField('label')` | Label edits via inspector panel |

### Export tracking added:
| Format | Snapshot Trigger | Quality Signal |
|--------|------------------|----------------|
| TSV | `export_tsv` | `exported` |
| CSV | `export_tsv` | `exported` |
| JSON | `export_json` | `exported` |

## Data Impact
After this fix, Redis will capture:
- `ml:label_hash:{hash}` → bin size correlations (any language)
- `ml:label:{normalized}` → normalized label correlations
- `ml:label_domain:{domain}` → domain→size patterns
- Quality signals for exported layouts (improved training weighting)

## Test plan
- [x] All 3667 tests pass
- [x] Build succeeds
- [ ] Verify label tracking in production after deploy