### PR TITLE
feat: add Claude Code hooks for pre-PR quality checks

### DIFF
--- a/.claude/hooks/a11y-check.sh
+++ b/.claude/hooks/a11y-check.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Accessibility check hook - blocks commits with a11y issues
+# Trigger: PreToolUse on Bash when command contains 'git commit'
+# Exit codes: 0 = allow, 2 = block
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Extract command from JSON
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Only run for git commit commands
+[[ "$COMMAND" != *"git commit"* ]] && exit 0
+
+# Skip if --no-verify flag is present
+[[ "$COMMAND" == *"--no-verify"* ]] && exit 0
+
+# Get staged TSX files (excluding tests)
+STAGED=$(git diff --cached --name-only --diff-filter=d 2>/dev/null | grep '\.tsx$' | grep -v '\.test\.')
+
+# No staged TSX files - allow
+[[ -z "$STAGED" ]] && exit 0
+
+ISSUES=""
+
+for file in $STAGED; do
+  [[ ! -f "$file" ]] && continue
+
+  # Get only the staged changes for this file
+  STAGED_CONTENT=$(git diff --cached "$file" 2>/dev/null | grep '^+' | grep -v '^+++')
+
+  # Check: tabIndex={0} without role= on non-interactive elements
+  while IFS= read -r line; do
+    if echo "$line" | grep -q 'tabIndex.*0' && ! echo "$line" | grep -q 'role='; then
+      if ! echo "$line" | grep -qE '<(button|a|input|select|textarea|summary)'; then
+        ISSUES+="  $file: tabIndex without role on non-interactive element\n"
+        break
+      fi
+    fi
+  done <<< "$STAGED_CONTENT"
+
+  # Check: onClick on div/span without role or tabIndex
+  while IFS= read -r line; do
+    if echo "$line" | grep -qE '<(div|span)[^>]*onClick' && ! echo "$line" | grep -qE 'role=|tabIndex'; then
+      ISSUES+="  $file: onClick on div/span without role or tabIndex\n"
+      break
+    fi
+  done <<< "$STAGED_CONTENT"
+
+  # Check: Empty aria-label
+  if echo "$STAGED_CONTENT" | grep -q 'aria-label=""'; then
+    ISSUES+="  $file: empty aria-label attribute\n"
+  fi
+
+  # Check: Image without alt attribute
+  while IFS= read -r line; do
+    if echo "$line" | grep -qE '<img[^>]*>' && ! echo "$line" | grep -q 'alt='; then
+      ISSUES+="  $file: img without alt attribute\n"
+      break
+    fi
+  done <<< "$STAGED_CONTENT"
+
+  # Check: Self-closing button without aria-label
+  while IFS= read -r line; do
+    if echo "$line" | grep -qE '<button[^>]*/>' && ! echo "$line" | grep -q 'aria-label='; then
+      ISSUES+="  $file: self-closing button without aria-label\n"
+      break
+    fi
+  done <<< "$STAGED_CONTENT"
+done
+
+if [[ -n "$ISSUES" ]]; then
+  echo ""
+  echo "⚠️  Accessibility issues detected in staged files:"
+  echo "─────────────────────────────────────────────────"
+  echo -e "$ISSUES"
+  echo "─────────────────────────────────────────────────"
+  echo "Fix these issues or use --no-verify to skip (not recommended)"
+  exit 2  # Block the commit
+fi
+
+exit 0

--- a/.claude/hooks/coverage-check.sh
+++ b/.claude/hooks/coverage-check.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Coverage gap detection hook - warns about new code without tests
+# Trigger: PreToolUse on Bash when command contains 'git commit'
+# Non-blocking: always exits 0, just warns
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Extract command from JSON
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Only run for git commit commands
+[[ "$COMMAND" != *"git commit"* ]] && exit 0
+
+WARNINGS=""
+
+# Check for new source files without corresponding test files
+NEW_FILES=$(git diff --cached --name-only --diff-filter=A 2>/dev/null | grep -E '^src/.*\.(ts|tsx)$' | grep -v '\.test\.' | grep -v '\.d\.ts$')
+
+for file in $NEW_FILES; do
+  # Skip type definition files and index files
+  [[ "$file" == *.d.ts ]] && continue
+  [[ "$(basename "$file")" == "index.ts" ]] && continue
+  [[ "$(basename "$file")" == "index.tsx" ]] && continue
+
+  # Look for test file in various locations
+  BASENAME=$(basename "$file" .tsx)
+  BASENAME=${BASENAME%.ts}
+
+  TEST_FOUND=false
+
+  # Check same directory
+  DIR=$(dirname "$file")
+  [[ -f "${DIR}/${BASENAME}.test.tsx" ]] && TEST_FOUND=true
+  [[ -f "${DIR}/${BASENAME}.test.ts" ]] && TEST_FOUND=true
+
+  # Check src/test/ directory
+  for path in "src/test/${BASENAME}.test.tsx" \
+              "src/test/${BASENAME}.test.ts" \
+              "src/test/components/${BASENAME}.test.tsx" \
+              "src/test/hooks/${BASENAME}.test.ts" \
+              "src/test/utils/${BASENAME}.test.ts"; do
+    [[ -f "$path" ]] && TEST_FOUND=true && break
+  done
+
+  if [[ "$TEST_FOUND" == false ]]; then
+    WARNINGS+="  📄 New file without tests: $file\n"
+  fi
+done
+
+# Check for new exported functions in modified files
+MODIFIED=$(git diff --cached --name-only --diff-filter=M 2>/dev/null | grep -E '^src/.*\.(ts|tsx)$' | grep -v '\.test\.' | grep -v '\.d\.ts$')
+
+for file in $MODIFIED; do
+  # Get new exports from the diff
+  NEW_EXPORTS=$(git diff --cached "$file" 2>/dev/null | grep '^+' | grep -v '^+++' | grep -E 'export (function|const|class) ' | grep -oE '(function|const|class) [a-zA-Z0-9_]+' | awk '{print $2}')
+
+  [[ -z "$NEW_EXPORTS" ]] && continue
+
+  # Find the test file
+  BASENAME=$(basename "$file" .tsx)
+  BASENAME=${BASENAME%.ts}
+
+  TEST_FILE=""
+  DIR=$(dirname "$file")
+
+  for path in "${DIR}/${BASENAME}.test.tsx" \
+              "${DIR}/${BASENAME}.test.ts" \
+              "src/test/${BASENAME}.test.tsx" \
+              "src/test/${BASENAME}.test.ts" \
+              "src/test/components/${BASENAME}.test.tsx" \
+              "src/test/hooks/${BASENAME}.test.ts" \
+              "src/test/utils/${BASENAME}.test.ts"; do
+    if [[ -f "$path" ]]; then
+      TEST_FILE="$path"
+      break
+    fi
+  done
+
+  # No test file - already warned about new files
+  [[ -z "$TEST_FILE" ]] && continue
+
+  for func in $NEW_EXPORTS; do
+    # Skip internal/private functions (starting with _)
+    [[ "$func" == _* ]] && continue
+
+    if ! grep -q "$func" "$TEST_FILE" 2>/dev/null; then
+      WARNINGS+="  🔧 New export '$func' in $file not found in tests\n"
+    fi
+  done
+done
+
+if [[ -n "$WARNINGS" ]]; then
+  echo ""
+  echo "📋 Test coverage gaps (warning only):"
+  echo "─────────────────────────────────────"
+  echo -e "$WARNINGS"
+  echo "─────────────────────────────────────"
+  echo "Consider adding tests for new code."
+  echo ""
+fi
+
+# Always exit 0 - this is a warning, not a blocker
+exit 0

--- a/.claude/hooks/post-edit-test.sh
+++ b/.claude/hooks/post-edit-test.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Silent auto-test hook - runs related tests after Edit/Write, only shows failures
+# Trigger: PostToolUse on Edit|Write for src/**/*.{ts,tsx}
+# Exit codes: 0 = allow (always), this is informational only
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Extract file path from JSON using jq
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+
+# Skip if no file provided or jq not available
+[[ -z "$FILE" ]] && exit 0
+
+# Skip non-src files
+[[ "$FILE" != */src/* && "$FILE" != src/* ]] && exit 0
+
+# Skip test files themselves
+[[ "$FILE" == *.test.* ]] && exit 0
+
+# Skip non-TS/TSX files
+[[ "$FILE" != *.ts && "$FILE" != *.tsx ]] && exit 0
+
+# Get the project root (directory containing package.json)
+PROJECT_ROOT=$(dirname "$(dirname "$(dirname "$FILE")")")
+[[ ! -f "$PROJECT_ROOT/package.json" ]] && PROJECT_ROOT=$(pwd)
+
+# Make file path relative to project root
+REL_FILE="${FILE#$PROJECT_ROOT/}"
+
+# Find related test file
+TEST_FILE=""
+if [[ "$REL_FILE" == *.tsx ]]; then
+  TEST_FILE="${REL_FILE%.tsx}.test.tsx"
+  [[ ! -f "$PROJECT_ROOT/$TEST_FILE" ]] && TEST_FILE="${REL_FILE%.tsx}.test.ts"
+elif [[ "$REL_FILE" == *.ts ]]; then
+  TEST_FILE="${REL_FILE%.ts}.test.ts"
+  [[ ! -f "$PROJECT_ROOT/$TEST_FILE" ]] && TEST_FILE="${REL_FILE%.ts}.test.tsx"
+fi
+
+# Also check src/test/ directory for component tests
+if [[ ! -f "$PROJECT_ROOT/$TEST_FILE" ]]; then
+  BASENAME=$(basename "$REL_FILE" .tsx)
+  BASENAME=${BASENAME%.ts}
+
+  for path in "src/test/${BASENAME}.test.tsx" \
+              "src/test/${BASENAME}.test.ts" \
+              "src/test/components/${BASENAME}.test.tsx" \
+              "src/test/hooks/${BASENAME}.test.ts" \
+              "src/test/utils/${BASENAME}.test.ts"; do
+    if [[ -f "$PROJECT_ROOT/$path" ]]; then
+      TEST_FILE="$path"
+      break
+    fi
+  done
+fi
+
+# No test file found - skip silently
+[[ -z "$TEST_FILE" || ! -f "$PROJECT_ROOT/$TEST_FILE" ]] && exit 0
+
+# Run tests silently, capture output
+cd "$PROJECT_ROOT"
+OUTPUT=$(npm run test:run -- --reporter=dot "$TEST_FILE" 2>&1)
+EXIT_CODE=$?
+
+# Only show output if tests failed
+if [[ $EXIT_CODE -ne 0 ]]; then
+  echo ""
+  echo "✗ Tests failed for $(basename "$TEST_FILE")"
+  echo "─────────────────────────────────────"
+  echo "$OUTPUT" | tail -30
+  echo "─────────────────────────────────────"
+fi
+
+# Always exit 0 - PostToolUse hooks are informational
+exit 0

--- a/.claude/hooks/pre-pr-review.sh
+++ b/.claude/hooks/pre-pr-review.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Pre-PR review hook - runs checks before creating PR
+# Trigger: PreToolUse on Bash when command contains 'gh pr create'
+# Exit codes: 0 = allow (informational only)
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Extract command from JSON
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Only run for gh pr create commands
+[[ "$COMMAND" != *"gh pr create"* ]] && exit 0
+
+echo ""
+echo "🔍 Running pre-PR review..."
+echo "═══════════════════════════════════════════════════════════════"
+
+# Detect base branch
+BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+[[ -z "$BASE_BRANCH" ]] && BASE_BRANCH="main"
+
+# Gather context
+CURRENT_BRANCH=$(git branch --show-current)
+FILES_CHANGED=$(git diff --name-only "$BASE_BRANCH"..."$CURRENT_BRANCH" 2>/dev/null | head -50)
+COMMITS=$(git log --oneline "$BASE_BRANCH".."$CURRENT_BRANCH" 2>/dev/null | head -20)
+STATS=$(git diff --stat "$BASE_BRANCH"..."$CURRENT_BRANCH" 2>/dev/null | tail -1)
+
+# Count changes
+NUM_FILES=$(echo "$FILES_CHANGED" | grep -c . || echo "0")
+NUM_COMMITS=$(echo "$COMMITS" | grep -c . || echo "0")
+
+echo ""
+echo "Branch: $CURRENT_BRANCH → $BASE_BRANCH"
+echo "Files changed: $NUM_FILES"
+echo "Commits: $NUM_COMMITS"
+echo "Stats: $STATS"
+echo ""
+echo "───────────────────────────────────────────────────────────────"
+
+ISSUES=""
+
+# Check 1: Large PR warning
+if [[ $NUM_FILES -gt 20 ]]; then
+  ISSUES+="⚠️  Large PR ($NUM_FILES files) - consider splitting\n"
+fi
+
+# Check 2: Console.log in diff
+CONSOLE_LOGS=$(git diff "$BASE_BRANCH"..."$CURRENT_BRANCH" -- '*.ts' '*.tsx' 2>/dev/null | grep '^+' | grep -v '^+++' | grep 'console\.log' | head -3)
+if [[ -n "$CONSOLE_LOGS" ]]; then
+  ISSUES+="⚠️  console.log statements found:\n"
+  while IFS= read -r line; do
+    ISSUES+="    ${line:0:80}\n"
+  done <<< "$CONSOLE_LOGS"
+fi
+
+# Check 3: TODO/FIXME comments added
+TODOS=$(git diff "$BASE_BRANCH"..."$CURRENT_BRANCH" -- '*.ts' '*.tsx' 2>/dev/null | grep '^+' | grep -v '^+++' | grep -iE 'TODO|FIXME|HACK|XXX' | head -3)
+if [[ -n "$TODOS" ]]; then
+  ISSUES+="📝 TODO/FIXME comments (ensure intentional):\n"
+  while IFS= read -r line; do
+    ISSUES+="    ${line:0:80}\n"
+  done <<< "$TODOS"
+fi
+
+# Check 4: 'any' type usage
+ANY_TYPES=$(git diff "$BASE_BRANCH"..."$CURRENT_BRANCH" -- '*.ts' '*.tsx' 2>/dev/null | grep '^+' | grep -v '^+++' | grep -E ': any[^a-zA-Z]|<any>|as any' | head -3)
+if [[ -n "$ANY_TYPES" ]]; then
+  ISSUES+="⚠️  'any' type usage (use 'unknown' instead):\n"
+  while IFS= read -r line; do
+    ISSUES+="    ${line:0:80}\n"
+  done <<< "$ANY_TYPES"
+fi
+
+# Check 5: Non-null assertions
+NON_NULL=$(git diff "$BASE_BRANCH"..."$CURRENT_BRANCH" -- '*.ts' '*.tsx' 2>/dev/null | grep '^+' | grep -v '^+++' | grep -E '\w+!' | grep -v '!==' | grep -v '!=' | grep -v '<!--' | head -3)
+if [[ -n "$NON_NULL" ]]; then
+  ISSUES+="⚠️  Non-null assertions (!) - consider null checks:\n"
+  while IFS= read -r line; do
+    ISSUES+="    ${line:0:80}\n"
+  done <<< "$NON_NULL"
+fi
+
+# Check 6: Accessibility issues in changed TSX files
+A11Y_ISSUES=""
+for file in $FILES_CHANGED; do
+  [[ "$file" != *.tsx ]] && continue
+  [[ "$file" == *.test.* ]] && continue
+
+  # tabIndex without role
+  if git diff "$BASE_BRANCH"..."$CURRENT_BRANCH" -- "$file" 2>/dev/null | grep '^+' | grep 'tabIndex' | grep -v 'role=' | grep -q .; then
+    A11Y_ISSUES+="    $file: tabIndex without role\n"
+  fi
+
+  # onClick on div without role
+  if git diff "$BASE_BRANCH"..."$CURRENT_BRANCH" -- "$file" 2>/dev/null | grep '^+' | grep -E '<div[^>]*onClick' | grep -v 'role=' | grep -q .; then
+    A11Y_ISSUES+="    $file: onClick on div without role\n"
+  fi
+done
+if [[ -n "$A11Y_ISSUES" ]]; then
+  ISSUES+="♿ Accessibility concerns:\n$A11Y_ISSUES"
+fi
+
+# Check 7: New files without tests
+NEW_SRC_FILES=$(git diff --name-only --diff-filter=A "$BASE_BRANCH"..."$CURRENT_BRANCH" 2>/dev/null | grep -E '^src/.*\.(ts|tsx)$' | grep -v '\.test\.' | grep -v 'index\.')
+MISSING_TESTS=""
+for file in $NEW_SRC_FILES; do
+  BASENAME=$(basename "$file" .tsx)
+  BASENAME=${BASENAME%.ts}
+
+  # Check if any test file references this
+  if ! git diff --name-only "$BASE_BRANCH"..."$CURRENT_BRANCH" 2>/dev/null | grep -q "${BASENAME}.*\.test\."; then
+    MISSING_TESTS+="    $file\n"
+  fi
+done
+if [[ -n "$MISSING_TESTS" ]]; then
+  ISSUES+="🧪 New files without tests in this PR:\n$MISSING_TESTS"
+fi
+
+# Display findings
+if [[ -n "$ISSUES" ]]; then
+  echo ""
+  echo "Issues found:"
+  echo "───────────────────────────────────────────────────────────────"
+  echo -e "$ISSUES"
+  echo "───────────────────────────────────────────────────────────────"
+else
+  echo ""
+  echo "✅ No obvious issues found in quick checks."
+fi
+
+echo ""
+echo "Files in this PR:"
+echo "$FILES_CHANGED" | head -15
+[[ $NUM_FILES -gt 15 ]] && echo "... and $((NUM_FILES - 15)) more"
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+
+# Informational only - always allow PR creation
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,43 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/post-edit-test.sh",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/a11y-check.sh",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/coverage-check.sh",
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pre-pr-review.sh",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Add four Claude Code hooks to catch issues locally before they reach PR review:

| Hook | Trigger | Purpose | Blocking? |
|------|---------|---------|-----------|
| `post-edit-test.sh` | After Edit/Write | Run related tests, show only failures | No |
| `a11y-check.sh` | Before commit | Check for accessibility issues | Yes |
| `coverage-check.sh` | Before commit | Warn about new code without tests | No |
| `pre-pr-review.sh` | Before PR create | Comprehensive review checks | No |

### Checks performed

**Accessibility (a11y-check.sh):**
- `tabIndex` without `role` on non-interactive elements
- `onClick` on div/span without role or tabIndex
- Empty `aria-label` attributes
- Images without `alt` attribute
- Self-closing buttons without `aria-label`

**Pre-PR Review (pre-pr-review.sh):**
- `console.log` statements
- TODO/FIXME comments
- `any` type usage
- Non-null assertions (`!`)
- Accessibility issues in changed files
- New files without tests

### Expected outcome
Catch 70-80% of CodeRabbit issues locally, reducing post-PR context switches.

### Requirements
- `jq` must be installed for JSON parsing

## Test plan
- [x] Hooks pass syntax check (`bash -n`)
- [x] a11y-check.sh skips non-commit commands
- [x] coverage-check.sh skips non-commit commands  
- [x] pre-pr-review.sh runs and shows output for PR commands
- [ ] Manual testing with actual commits/PRs