### PR TITLE
feat: add ML telemetry for drawer resize, fill, layer move, rotation

### DIFF
--- a/api/ml-telemetry.ts
+++ b/api/ml-telemetry.ts
@@ -175,6 +175,41 @@ interface BinMovedEvent {
   method: 'drag' | 'nudge';
 }
 
+interface DrawerResizedEvent {
+  type: 'drawer_resized';
+  old_size: string;
+  new_size: string;
+  dimensions_changed: ('width' | 'depth' | 'height')[];
+  bins_staged: number;
+  fill_pct: number;
+}
+
+interface FillOperationEvent {
+  type: 'fill_operation';
+  method: 'uniform' | 'gaps';
+  fill_size: string | null;
+  bins_created: number;
+  layer_index: number;
+  fill_pct: number;
+  drawer_size: string;
+}
+
+interface LayerMoveEvent {
+  type: 'layer_move';
+  bin_size: string;
+  from_layer_index: number;
+  to_layer_index: number;
+  batch_size: number;
+  method: 'inspector' | 'drag' | 'keyboard' | 'context_menu';
+}
+
+interface BinRotatedEvent {
+  type: 'bin_rotated';
+  old_size: string;
+  new_size: string;
+  batch_size: number;
+}
+
 type MLTelemetryEvent =
   | BinPlacementEvent
   | LabelUpdateEvent
@@ -184,7 +219,11 @@ type MLTelemetryEvent =
   | CategoryChangeEvent
   | BinResizeEvent
   | BinDeletedEvent
-  | BinMovedEvent;
+  | BinMovedEvent
+  | DrawerResizedEvent
+  | FillOperationEvent
+  | LayerMoveEvent
+  | BinRotatedEvent;
 
 // ============================================
 // REDIS CONNECTION
@@ -309,6 +348,9 @@ const VALID_QUALITY_TIERS = new Set(['high', 'medium', 'low', 'skip']);
 const VALID_DELETE_METHODS = new Set(['key', 'context_menu', 'bulk', 'inspector']);
 const VALID_MOVE_METHODS = new Set(['drag', 'nudge']);
 const VALID_POSITION_REGEX = /^\d+(\.\d+)?,\d+(\.\d+)?$/; // e.g., "3,5" or "3.5,2.5"
+const VALID_FILL_METHODS = new Set(['uniform', 'gaps']);
+const VALID_LAYER_MOVE_METHODS = new Set(['inspector', 'drag', 'keyboard', 'context_menu']);
+const VALID_FILL_SIZE_REGEX = /^\d+(\.\d+)?x\d+(\.\d+)?$/; // WxD (no height)
 
 /**
  * Validate nullable string field used in Redis keys.
@@ -552,6 +594,75 @@ function validateEvent(event: unknown): event is MLTelemetryEvent {
       e.batch_size < 1000 &&
       typeof e.method === 'string' &&
       VALID_MOVE_METHODS.has(e.method)
+    );
+  }
+
+  if (e.type === 'drawer_resized') {
+    const validDimensions = Array.isArray(e.dimensions_changed) &&
+      e.dimensions_changed.length > 0 &&
+      e.dimensions_changed.every((d: unknown) => d === 'width' || d === 'depth' || d === 'height');
+    return (
+      typeof e.old_size === 'string' &&
+      VALID_DRAWER_SIZE_REGEX.test(e.old_size) &&
+      typeof e.new_size === 'string' &&
+      VALID_DRAWER_SIZE_REGEX.test(e.new_size) &&
+      validDimensions &&
+      typeof e.bins_staged === 'number' &&
+      e.bins_staged >= 0 &&
+      e.bins_staged < 10000 &&
+      typeof e.fill_pct === 'number' &&
+      e.fill_pct >= 0 &&
+      e.fill_pct <= 100
+    );
+  }
+
+  if (e.type === 'fill_operation') {
+    return (
+      typeof e.method === 'string' &&
+      VALID_FILL_METHODS.has(e.method) &&
+      (e.fill_size === null ||
+        (typeof e.fill_size === 'string' && VALID_FILL_SIZE_REGEX.test(e.fill_size))) &&
+      typeof e.bins_created === 'number' &&
+      e.bins_created > 0 &&
+      e.bins_created < 10000 &&
+      typeof e.layer_index === 'number' &&
+      e.layer_index >= 0 &&
+      e.layer_index <= 20 &&
+      typeof e.fill_pct === 'number' &&
+      e.fill_pct >= 0 &&
+      e.fill_pct <= 100 &&
+      typeof e.drawer_size === 'string' &&
+      VALID_DRAWER_SIZE_REGEX.test(e.drawer_size)
+    );
+  }
+
+  if (e.type === 'layer_move') {
+    return (
+      typeof e.bin_size === 'string' &&
+      VALID_BIN_SIZE_REGEX.test(e.bin_size) &&
+      typeof e.from_layer_index === 'number' &&
+      e.from_layer_index >= -1 && // -1 = staging
+      e.from_layer_index <= 20 &&
+      typeof e.to_layer_index === 'number' &&
+      e.to_layer_index >= -1 && // -1 = staging
+      e.to_layer_index <= 20 &&
+      typeof e.batch_size === 'number' &&
+      e.batch_size > 0 &&
+      e.batch_size < 1000 &&
+      typeof e.method === 'string' &&
+      VALID_LAYER_MOVE_METHODS.has(e.method)
+    );
+  }
+
+  if (e.type === 'bin_rotated') {
+    return (
+      typeof e.old_size === 'string' &&
+      VALID_BIN_SIZE_REGEX.test(e.old_size) &&
+      typeof e.new_size === 'string' &&
+      VALID_BIN_SIZE_REGEX.test(e.new_size) &&
+      typeof e.batch_size === 'number' &&
+      e.batch_size > 0 &&
+      e.batch_size < 1000
     );
   }
 
@@ -881,6 +992,120 @@ function aggregateBinMove(event: BinMovedEvent, inc: Increments): void {
   inc['ml:moves']['total'] = (inc['ml:moves']['total'] || 0) + 1;
 }
 
+function aggregateDrawerResize(event: DrawerResizedEvent, inc: Increments): void {
+  const { old_size, new_size, dimensions_changed, bins_staged } = event;
+
+  // Track resize transitions (what drawer sizes users resize to)
+  const drawerResizeKey = `ml:drawer_resize:${old_size}`;
+  inc[drawerResizeKey] = inc[drawerResizeKey] || {};
+  inc[drawerResizeKey][new_size] = (inc[drawerResizeKey][new_size] || 0) + 1;
+
+  // Track which dimensions are changed most often
+  for (const dim of dimensions_changed) {
+    inc['ml:drawer_resize_dims'] = inc['ml:drawer_resize_dims'] || {};
+    inc['ml:drawer_resize_dims'][dim] = (inc['ml:drawer_resize_dims'][dim] || 0) + 1;
+  }
+
+  // Track how often bins are staged due to resize
+  if (bins_staged > 0) {
+    inc['ml:drawer_resize_staged'] = inc['ml:drawer_resize_staged'] || {};
+    inc['ml:drawer_resize_staged']['with_bins'] = (inc['ml:drawer_resize_staged']['with_bins'] || 0) + 1;
+  } else {
+    inc['ml:drawer_resize_staged'] = inc['ml:drawer_resize_staged'] || {};
+    inc['ml:drawer_resize_staged']['no_bins'] = (inc['ml:drawer_resize_staged']['no_bins'] || 0) + 1;
+  }
+
+  // Track total drawer resizes
+  inc['ml:drawer_resizes'] = inc['ml:drawer_resizes'] || {};
+  inc['ml:drawer_resizes']['total'] = (inc['ml:drawer_resizes']['total'] || 0) + 1;
+
+  // Track resulting drawer sizes (what sizes users resize to)
+  inc['ml:drawer_resize_results'] = inc['ml:drawer_resize_results'] || {};
+  inc['ml:drawer_resize_results'][new_size] = (inc['ml:drawer_resize_results'][new_size] || 0) + 1;
+}
+
+function aggregateFillOperation(event: FillOperationEvent, inc: Increments): void {
+  const { method, fill_size, bins_created, drawer_size } = event;
+
+  // Track fill method distribution (uniform vs gaps)
+  inc['ml:fill_methods'] = inc['ml:fill_methods'] || {};
+  inc['ml:fill_methods'][method] = (inc['ml:fill_methods'][method] || 0) + 1;
+
+  // Track which sizes users fill with (for uniform fill - strong preference signal!)
+  if (fill_size) {
+    inc['ml:fill_sizes'] = inc['ml:fill_sizes'] || {};
+    inc['ml:fill_sizes'][fill_size] = (inc['ml:fill_sizes'][fill_size] || 0) + 1;
+
+    // Track fill size by drawer size (size preferences depend on container)
+    const fillByDrawerKey = `ml:fill_by_drawer:${drawer_size}`;
+    inc[fillByDrawerKey] = inc[fillByDrawerKey] || {};
+    inc[fillByDrawerKey][fill_size] = (inc[fillByDrawerKey][fill_size] || 0) + 1;
+  }
+
+  // Track bins created per fill (helps understand fill efficiency)
+  const binsBucket = bins_created <= 10 ? 'small' :
+    bins_created <= 50 ? 'medium' :
+    bins_created <= 100 ? 'large' : 'xlarge';
+  inc['ml:fill_bins'] = inc['ml:fill_bins'] || {};
+  inc['ml:fill_bins'][binsBucket] = (inc['ml:fill_bins'][binsBucket] || 0) + 1;
+
+  // Track total fill operations
+  inc['ml:fills'] = inc['ml:fills'] || {};
+  inc['ml:fills']['total'] = (inc['ml:fills']['total'] || 0) + 1;
+}
+
+function aggregateLayerMove(event: LayerMoveEvent, inc: Increments): void {
+  const { bin_size, from_layer_index, to_layer_index, method } = event;
+
+  // Track layer movement patterns (which layers users move bins between)
+  const fromKey = from_layer_index === -1 ? 'staging' : `layer${from_layer_index}`;
+  const toKey = to_layer_index === -1 ? 'staging' : `layer${to_layer_index}`;
+
+  // Track from→to transitions
+  const layerTransKey = `ml:layer_trans:${fromKey}`;
+  inc[layerTransKey] = inc[layerTransKey] || {};
+  inc[layerTransKey][toKey] = (inc[layerTransKey][toKey] || 0) + 1;
+
+  // Track sizes moved between layers
+  inc['ml:layer_moved_sizes'] = inc['ml:layer_moved_sizes'] || {};
+  inc['ml:layer_moved_sizes'][bin_size] = (inc['ml:layer_moved_sizes'][bin_size] || 0) + 1;
+
+  // Track layer move method distribution
+  inc['ml:layer_move_methods'] = inc['ml:layer_move_methods'] || {};
+  inc['ml:layer_move_methods'][method] = (inc['ml:layer_move_methods'][method] || 0) + 1;
+
+  // Track staging in/out specifically (important for understanding stash usage)
+  if (from_layer_index === -1) {
+    inc['ml:staging_out'] = inc['ml:staging_out'] || {};
+    inc['ml:staging_out'][toKey] = (inc['ml:staging_out'][toKey] || 0) + 1;
+  }
+  if (to_layer_index === -1) {
+    inc['ml:staging_in'] = inc['ml:staging_in'] || {};
+    inc['ml:staging_in'][fromKey] = (inc['ml:staging_in'][fromKey] || 0) + 1;
+  }
+
+  // Track total layer moves
+  inc['ml:layer_moves'] = inc['ml:layer_moves'] || {};
+  inc['ml:layer_moves']['total'] = (inc['ml:layer_moves']['total'] || 0) + 1;
+}
+
+function aggregateBinRotation(event: BinRotatedEvent, inc: Increments): void {
+  const { old_size, new_size } = event;
+
+  // Track rotation transitions (shows which sizes users rotate)
+  const rotateKey = `ml:rotate:${old_size}`;
+  inc[rotateKey] = inc[rotateKey] || {};
+  inc[rotateKey][new_size] = (inc[rotateKey][new_size] || 0) + 1;
+
+  // Track total rotations
+  inc['ml:rotations'] = inc['ml:rotations'] || {};
+  inc['ml:rotations']['total'] = (inc['ml:rotations']['total'] || 0) + 1;
+
+  // Track rotated sizes (which sizes users rotate most)
+  inc['ml:rotated_sizes'] = inc['ml:rotated_sizes'] || {};
+  inc['ml:rotated_sizes'][old_size] = (inc['ml:rotated_sizes'][old_size] || 0) + 1;
+}
+
 // ============================================
 // HANDLER
 // ============================================
@@ -963,6 +1188,18 @@ export default async function handler(
         break;
       case 'bin_moved':
         aggregateBinMove(event, increments);
+        break;
+      case 'drawer_resized':
+        aggregateDrawerResize(event, increments);
+        break;
+      case 'fill_operation':
+        aggregateFillOperation(event, increments);
+        break;
+      case 'layer_move':
+        aggregateLayerMove(event, increments);
+        break;
+      case 'bin_rotated':
+        aggregateBinRotation(event, increments);
         break;
     }
   }

--- a/src/core/store/layout.ts
+++ b/src/core/store/layout.ts
@@ -6,6 +6,7 @@ import { canPlaceBin, clamp } from '@/shared/utils/validation';
 import { fillAllWithSize, fillGaps } from '@/features/grid-editor/utils/fill';
 import { checkLayerReorderCollisions } from '@/features/grid-editor/utils/collision';
 import { useSettingsStore } from './settings';
+import { mlTracking } from '@/shared/analytics/useMLTracking';
 import type { Result, LayoutError, ValidationError } from '@/core/result';
 import {
   ok,
@@ -508,6 +509,9 @@ export const useLayoutStore = create<LayoutState>()(
           state.layout.bins.push(...result.bins);
           state.lastEditSource = 'local';
         });
+
+        // Track fill operation after bins are added
+        mlTracking.trackFill('uniform', result.bins.length, layerId, { width, depth });
       }
 
       return result.bins.length;
@@ -524,6 +528,9 @@ export const useLayoutStore = create<LayoutState>()(
           state.layout.bins.push(...result.bins);
           state.lastEditSource = 'local';
         });
+
+        // Track fill operation after bins are added
+        mlTracking.trackFill('gaps', result.bins.length, layerId);
       }
 
       return result.addedCount;

--- a/src/features/bin-inspector/hooks/useBinInspector.ts
+++ b/src/features/bin-inspector/hooks/useBinInspector.ts
@@ -354,12 +354,18 @@ export function useBinInspector(): UseBinInspectorReturn {
         return;
       }
 
+      // Track layer move BEFORE executing (capture original layer)
+      const fromLayerId = bin.layerId;
+
       execute(() => {
         updateBin(bin.id, {
           layerId: targetLayerId,
           // Keep bin's original height - don't auto-adjust to layer minimum
         });
       });
+
+      // Track layer movement after execution
+      mlTracking.trackLayerMove(bin, fromLayerId, targetLayerId, 'inspector', 1);
 
       addToast(`Moved to ${targetLayer.name}`, 'success');
     },
@@ -404,6 +410,10 @@ export function useBinInspector(): UseBinInspectorReturn {
         return;
       }
 
+      // Capture original layer IDs for tracking (use first bin as representative)
+      const firstBin = movable[0];
+      const fromLayerId = firstBin.layerId;
+
       execute(() => {
         for (const b of movable) {
           updateBin(b.id, {
@@ -412,6 +422,9 @@ export function useBinInspector(): UseBinInspectorReturn {
           });
         }
       });
+
+      // Track layer movement after execution
+      mlTracking.trackLayerMove(firstBin, fromLayerId, targetLayerId, 'inspector', movable.length);
 
       if (blocked.length > 0) {
         addToast(`Moved ${movable.length} of ${binsToMove.length} bins (${blocked.length} blocked)`, 'info');
@@ -484,6 +497,9 @@ export function useBinInspector(): UseBinInspectorReturn {
       addToast(result.message, 'error');
       return false;
     }
+
+    // Track rotation BEFORE executing (capture original dimensions)
+    mlTracking.trackRotation(bin, 1);
 
     // Rotation is valid, perform it
     execute(() => {

--- a/src/features/grid-editor/hooks/useGridResize.ts
+++ b/src/features/grid-editor/hooks/useGridResize.ts
@@ -4,6 +4,7 @@ import { useLayoutStore } from '@/core/store';
 import { useUndoableAction } from '@/core/store';
 import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
 import { clamp } from '@/shared/utils/validation';
+import { mlTracking } from '@/shared/analytics/useMLTracking';
 
 /**
  * Grid Resize Hook
@@ -167,6 +168,19 @@ export function useGridResize(options: UseGridResizeOptions): GridResizeState {
         });
         // Revert to original size temporarily (user will confirm or cancel)
         updateDrawer({ width: resizeStart.width, depth: resizeStart.depth });
+      } else {
+        // No clipped bins - track the completed resize
+        // Only track if dimensions actually changed
+        if (
+          resizeStart.width !== currentDrawer.width ||
+          resizeStart.depth !== currentDrawer.depth
+        ) {
+          mlTracking.trackDrawerResize(
+            { width: resizeStart.width, depth: resizeStart.depth, height: currentDrawer.height },
+            currentDrawer,
+            0
+          );
+        }
       }
       setResizeDirection(null);
       setResizeStart(null);
@@ -183,6 +197,10 @@ export function useGridResize(options: UseGridResizeOptions): GridResizeState {
   // Confirm pending resize - move clipped bins to staging
   const confirmResize = useCallback(() => {
     if (!pendingResize) return;
+
+    // Capture old dimensions for tracking (current state before applying resize)
+    const oldDrawer = { ...drawerRef.current };
+
     execute(() => {
       // Move clipped bins to staging
       for (const binId of pendingResize.clippedBinIds) {
@@ -191,6 +209,14 @@ export function useGridResize(options: UseGridResizeOptions): GridResizeState {
       // Apply the resize
       updateDrawer({ width: pendingResize.newWidth, depth: pendingResize.newDepth });
     });
+
+    // Track drawer resize after execution
+    mlTracking.trackDrawerResize(
+      oldDrawer,
+      { width: pendingResize.newWidth, depth: pendingResize.newDepth, height: oldDrawer.height },
+      pendingResize.clippedBinIds.length
+    );
+
     setPendingResize(null);
   }, [pendingResize, execute, updateBin, updateDrawer]);
 

--- a/src/features/staging/hooks/useStagingDragInteraction.ts
+++ b/src/features/staging/hooks/useStagingDragInteraction.ts
@@ -139,6 +139,8 @@ export function useStagingDragInteraction(
       const bin = layout.bins.find((b) => b.id === interaction.binId);
       if (bin) {
         const { x, y } = interaction.currentCoord;
+        const fromLayerId = bin.layerId; // Should be STAGING_ID
+
         execute(() => {
           updateBin(interaction.binId, {
             x,
@@ -153,6 +155,8 @@ export function useStagingDragInteraction(
           { ...bin, x, y, layerId: activeLayerId },
           'staging'
         );
+        // Also track layer movement (from staging to active layer)
+        mlTracking.trackLayerMove(bin, fromLayerId, activeLayerId, 'drag', 1);
       }
     }
     // If invalid or no position, bin stays in staging (no action needed)

--- a/src/hooks/interactions/useDragInteraction.ts
+++ b/src/hooks/interactions/useDragInteraction.ts
@@ -254,11 +254,24 @@ export function useDragInteraction(
 
     // Handle drop to staging
     if (currentDropTarget === 'staging') {
-      execute(() => {
-        for (const binId of interaction.binIds) {
-          updateBin(binId, { layerId: STAGING_ID });
-        }
-      });
+      // Capture original layer for tracking (use first bin as representative)
+      const binsToStage = interaction.binIds
+        .map((id) => layout.bins.find((b) => b.id === id))
+        .filter((b): b is Bin => b !== undefined);
+
+      if (binsToStage.length > 0) {
+        const firstBin = binsToStage[0];
+        const fromLayerId = firstBin.layerId;
+
+        execute(() => {
+          for (const binId of interaction.binIds) {
+            updateBin(binId, { layerId: STAGING_ID });
+          }
+        });
+
+        // Track layer movement to staging
+        mlTracking.trackLayerMove(firstBin, fromLayerId, STAGING_ID, 'drag', binsToStage.length);
+      }
       setSelectedBins([]);
       setDropTarget(null);
       setInteraction(null);

--- a/src/shared/analytics/mlTelemetry.ts
+++ b/src/shared/analytics/mlTelemetry.ts
@@ -320,6 +320,95 @@ export interface BinMovedEvent {
   method: MoveMethod;
 }
 
+/**
+ * Drawer resize event - when user changes drawer dimensions.
+ * Essential context for understanding container constraints.
+ */
+export interface DrawerResizedEvent {
+  type: 'drawer_resized';
+
+  /** Old size as "WxDxH" string */
+  old_size: string;
+
+  /** New size as "WxDxH" string */
+  new_size: string;
+
+  /** Which dimension(s) changed */
+  dimensions_changed: ('width' | 'depth' | 'height')[];
+
+  /** Number of bins moved to staging due to resize */
+  bins_staged: number;
+
+  /** Fill percentage after resize */
+  fill_pct: number;
+}
+
+/**
+ * Fill operation event - when user uses fill to populate the grid.
+ * Direct statement of user's preferred bin size for the area.
+ */
+export interface FillOperationEvent {
+  type: 'fill_operation';
+
+  /** Fill method: 'uniform' for fillAllWithSize, 'gaps' for fillGaps */
+  method: FillMethod;
+
+  /** Bin size used for uniform fill as "WxD" (no height - layer determines it) */
+  fill_size: string | null;
+
+  /** Number of bins created by the fill */
+  bins_created: number;
+
+  /** Layer index where fill was applied */
+  layer_index: number;
+
+  /** Fill percentage after operation */
+  fill_pct: number;
+
+  /** Drawer size for context */
+  drawer_size: string;
+}
+
+/**
+ * Layer movement event - when bins are moved between layers.
+ * Reveals organizational strategy and layer usage patterns.
+ */
+export interface LayerMoveEvent {
+  type: 'layer_move';
+
+  /** Bin size as "WxDxH" string */
+  bin_size: string;
+
+  /** Source layer index (0 = bottom, -1 = staging) */
+  from_layer_index: number;
+
+  /** Target layer index (0 = bottom, -1 = staging) */
+  to_layer_index: number;
+
+  /** Number of bins moved together */
+  batch_size: number;
+
+  /** How the move was initiated */
+  method: LayerMoveMethod;
+}
+
+/**
+ * Bin rotation event - when user swaps width and depth.
+ * Completes the picture of dimension adjustments.
+ */
+export interface BinRotatedEvent {
+  type: 'bin_rotated';
+
+  /** Original size as "WxDxH" string */
+  old_size: string;
+
+  /** New size (rotated) as "WxDxH" string */
+  new_size: string;
+
+  /** Number of bins rotated together (for multi-select) */
+  batch_size: number;
+}
+
 export type MLTelemetryEvent =
   | BinPlacementEvent
   | LabelUpdateEvent
@@ -329,13 +418,21 @@ export type MLTelemetryEvent =
   | CategoryChangeEvent
   | BinResizeEvent
   | BinDeletedEvent
-  | BinMovedEvent;
+  | BinMovedEvent
+  | DrawerResizedEvent
+  | FillOperationEvent
+  | LayerMoveEvent
+  | BinRotatedEvent;
 
 export type PlacementMethod = 'draw' | 'fill' | 'duplicate' | 'staging' | 'paint';
 
 export type DeleteMethod = 'key' | 'context_menu' | 'bulk' | 'inspector';
 
 export type MoveMethod = 'drag' | 'nudge';
+
+export type FillMethod = 'uniform' | 'gaps';
+
+export type LayerMoveMethod = 'inspector' | 'drag' | 'keyboard' | 'context_menu';
 
 export type LayoutSnapshotTrigger =
   | 'save'
@@ -1373,6 +1470,187 @@ export function trackBinMove(
     layer_index: layerIndex >= 0 ? layerIndex : 0,
     batch_size: batchSize,
     method,
+  };
+
+  eventBuffer.push(event);
+
+  if (eventBuffer.length >= FLUSH_THRESHOLD) {
+    flush();
+  } else {
+    scheduleFlush();
+  }
+}
+
+// ============================================
+// DRAWER RESIZE TRACKING
+// ============================================
+
+/**
+ * Track a drawer resize event.
+ *
+ * @param oldDrawer - Original drawer dimensions
+ * @param newDrawer - New drawer dimensions
+ * @param layout - Current layout state (after resize)
+ * @param binsStaged - Number of bins moved to staging due to resize
+ */
+export function trackDrawerResize(
+  oldDrawer: { width: number; depth: number; height: number },
+  newDrawer: { width: number; depth: number; height: number },
+  layout: Layout,
+  binsStaged: number = 0
+): void {
+  if (!isEnabled()) return;
+
+  // Skip if dimensions didn't actually change
+  if (
+    oldDrawer.width === newDrawer.width &&
+    oldDrawer.depth === newDrawer.depth &&
+    oldDrawer.height === newDrawer.height
+  ) return;
+
+  const dimensionsChanged: ('width' | 'depth' | 'height')[] = [];
+  if (oldDrawer.width !== newDrawer.width) dimensionsChanged.push('width');
+  if (oldDrawer.depth !== newDrawer.depth) dimensionsChanged.push('depth');
+  if (oldDrawer.height !== newDrawer.height) dimensionsChanged.push('height');
+
+  const event: DrawerResizedEvent = {
+    type: 'drawer_resized',
+    old_size: `${oldDrawer.width}x${oldDrawer.depth}x${oldDrawer.height}`,
+    new_size: `${newDrawer.width}x${newDrawer.depth}x${newDrawer.height}`,
+    dimensions_changed: dimensionsChanged,
+    bins_staged: binsStaged,
+    fill_pct: computeFillPercentage(layout),
+  };
+
+  eventBuffer.push(event);
+
+  if (eventBuffer.length >= FLUSH_THRESHOLD) {
+    flush();
+  } else {
+    scheduleFlush();
+  }
+}
+
+// ============================================
+// FILL OPERATION TRACKING
+// ============================================
+
+/**
+ * Track a fill operation.
+ *
+ * @param method - 'uniform' for fillAllWithSize, 'gaps' for fillGaps
+ * @param binsCreated - Number of bins created by the fill
+ * @param layerId - Layer where fill was applied
+ * @param layout - Current layout state (after fill)
+ * @param fillSize - Bin dimensions used for uniform fill (null for gap fill)
+ */
+export function trackFillOperation(
+  method: FillMethod,
+  binsCreated: number,
+  layerId: string,
+  layout: Layout,
+  fillSize?: { width: number; depth: number }
+): void {
+  if (!isEnabled()) return;
+
+  // Skip if no bins were created
+  if (binsCreated === 0) return;
+
+  const layerIndex = layout.layers.findIndex((l) => l.id === layerId);
+
+  const event: FillOperationEvent = {
+    type: 'fill_operation',
+    method,
+    fill_size: fillSize ? `${fillSize.width}x${fillSize.depth}` : null,
+    bins_created: binsCreated,
+    layer_index: layerIndex >= 0 ? layerIndex : 0,
+    fill_pct: computeFillPercentage(layout),
+    drawer_size: `${layout.drawer.width}x${layout.drawer.depth}x${layout.drawer.height}`,
+  };
+
+  eventBuffer.push(event);
+
+  if (eventBuffer.length >= FLUSH_THRESHOLD) {
+    flush();
+  } else {
+    scheduleFlush();
+  }
+}
+
+// ============================================
+// LAYER MOVEMENT TRACKING
+// ============================================
+
+/**
+ * Track bins moving between layers.
+ *
+ * @param bin - Representative bin that was moved
+ * @param fromLayerId - Original layer ID (or STAGING_ID)
+ * @param toLayerId - New layer ID (or STAGING_ID)
+ * @param layout - Current layout state
+ * @param method - How the move was initiated
+ * @param batchSize - Number of bins moved together
+ */
+export function trackLayerMove(
+  bin: Bin,
+  fromLayerId: string,
+  toLayerId: string,
+  layout: Layout,
+  method: LayerMoveMethod,
+  batchSize: number = 1
+): void {
+  if (!isEnabled()) return;
+
+  // Skip if layer didn't change
+  if (fromLayerId === toLayerId) return;
+
+  // Convert layer IDs to indices (-1 for staging)
+  const fromIndex = fromLayerId === STAGING_ID
+    ? -1
+    : layout.layers.findIndex((l) => l.id === fromLayerId);
+  const toIndex = toLayerId === STAGING_ID
+    ? -1
+    : layout.layers.findIndex((l) => l.id === toLayerId);
+
+  const event: LayerMoveEvent = {
+    type: 'layer_move',
+    bin_size: `${bin.width}x${bin.depth}x${bin.height}`,
+    from_layer_index: fromIndex >= 0 ? fromIndex : (fromLayerId === STAGING_ID ? -1 : 0),
+    to_layer_index: toIndex >= 0 ? toIndex : (toLayerId === STAGING_ID ? -1 : 0),
+    batch_size: batchSize,
+    method,
+  };
+
+  eventBuffer.push(event);
+
+  if (eventBuffer.length >= FLUSH_THRESHOLD) {
+    flush();
+  } else {
+    scheduleFlush();
+  }
+}
+
+// ============================================
+// BIN ROTATION TRACKING
+// ============================================
+
+/**
+ * Track a bin rotation event.
+ *
+ * @param bin - The bin before rotation
+ * @param batchSize - Number of bins rotated together
+ */
+export function trackBinRotation(
+  bin: Bin,
+  batchSize: number = 1
+): void {
+  if (!isEnabled()) return;
+
+  const event: BinRotatedEvent = {
+    type: 'bin_rotated',
+    old_size: `${bin.width}x${bin.depth}x${bin.height}`,
+    new_size: `${bin.depth}x${bin.width}x${bin.height}`, // Rotated: width/depth swapped
+    batch_size: batchSize,
   };
 
   eventBuffer.push(event);

--- a/src/shared/analytics/useMLTracking.ts
+++ b/src/shared/analytics/useMLTracking.ts
@@ -33,6 +33,10 @@ import {
   trackBinResize,
   trackBinDeletion,
   trackBinMove,
+  trackDrawerResize,
+  trackFillOperation,
+  trackLayerMove,
+  trackBinRotation,
   incrementEditCount,
   markEditActivity,
   type PlacementMethod,
@@ -40,6 +44,8 @@ import {
   type QualitySignal,
   type DeleteMethod,
   type MoveMethod,
+  type FillMethod,
+  type LayerMoveMethod,
 } from './mlTelemetry';
 
 /**
@@ -147,6 +153,61 @@ export function useMLTracking() {
     []
   );
 
+  /**
+   * Track a drawer resize.
+   */
+  const trackDrawerResizeHook = useCallback(
+    (
+      oldDrawer: { width: number; depth: number; height: number },
+      newDrawer: { width: number; depth: number; height: number },
+      binsStaged?: number
+    ) => {
+      const layout = useLayoutStore.getState().layout;
+      trackDrawerResize(oldDrawer, newDrawer, layout, binsStaged);
+    },
+    []
+  );
+
+  /**
+   * Track a fill operation.
+   */
+  const trackFill = useCallback(
+    (
+      method: FillMethod,
+      binsCreated: number,
+      layerId: string,
+      fillSize?: { width: number; depth: number }
+    ) => {
+      const layout = useLayoutStore.getState().layout;
+      trackFillOperation(method, binsCreated, layerId, layout, fillSize);
+    },
+    []
+  );
+
+  /**
+   * Track a layer move.
+   */
+  const trackLayerMoveHook = useCallback(
+    (
+      bin: Bin,
+      fromLayerId: string,
+      toLayerId: string,
+      method: LayerMoveMethod,
+      batchSize?: number
+    ) => {
+      const layout = useLayoutStore.getState().layout;
+      trackLayerMove(bin, fromLayerId, toLayerId, layout, method, batchSize);
+    },
+    []
+  );
+
+  /**
+   * Track a bin rotation.
+   */
+  const trackRotation = useCallback((bin: Bin, batchSize?: number) => {
+    trackBinRotation(bin, batchSize);
+  }, []);
+
   return {
     trackPlacement,
     trackLabel,
@@ -158,6 +219,10 @@ export function useMLTracking() {
     trackResize,
     trackDeletion,
     trackMove,
+    trackDrawerResize: trackDrawerResizeHook,
+    trackFill,
+    trackLayerMove: trackLayerMoveHook,
+    trackRotation,
   };
 }
 
@@ -265,5 +330,51 @@ export const mlTracking = {
    */
   markActivity(): void {
     markEditActivity();
+  },
+
+  /**
+   * Track a drawer resize.
+   */
+  trackDrawerResize(
+    oldDrawer: { width: number; depth: number; height: number },
+    newDrawer: { width: number; depth: number; height: number },
+    binsStaged?: number
+  ): void {
+    const layout = useLayoutStore.getState().layout;
+    trackDrawerResize(oldDrawer, newDrawer, layout, binsStaged);
+  },
+
+  /**
+   * Track a fill operation.
+   */
+  trackFill(
+    method: FillMethod,
+    binsCreated: number,
+    layerId: string,
+    fillSize?: { width: number; depth: number }
+  ): void {
+    const layout = useLayoutStore.getState().layout;
+    trackFillOperation(method, binsCreated, layerId, layout, fillSize);
+  },
+
+  /**
+   * Track a layer move.
+   */
+  trackLayerMove(
+    bin: Bin,
+    fromLayerId: string,
+    toLayerId: string,
+    method: LayerMoveMethod,
+    batchSize?: number
+  ): void {
+    const layout = useLayoutStore.getState().layout;
+    trackLayerMove(bin, fromLayerId, toLayerId, layout, method, batchSize);
+  },
+
+  /**
+   * Track a bin rotation.
+   */
+  trackRotation(bin: Bin, batchSize?: number): void {
+    trackBinRotation(bin, batchSize);
   },
 };


### PR DESCRIPTION
## Summary
- Add 4 new ML telemetry event types to capture additional user behavior for bin prediction training
- `drawer_resized`: Track drawer dimension changes with bins_staged count
- `fill_operation`: Track uniform fills and gap fills with bin counts
- `layer_move`: Track bin movement between layers (inspector, drag, staging)
- `bin_rotated`: Track bin rotation (width/depth swap)

## Implementation
- New event interfaces and tracking functions in `mlTelemetry.ts`
- Hook wrappers in `useMLTracking.ts` for React components
- Call site instrumentation in:
  - `useGridResize` - drawer resize tracking
  - `layout.ts` store - fill operations (fillLayer, fillLayerGaps)
  - `useBinInspector` - layer movement + rotation
  - `useDragInteraction` - drag-to-staging layer movement
  - `useStagingDragInteraction` - staging-to-grid layer movement
- API endpoint validation and Redis aggregation for all new events

## Files changed (8)
- `api/ml-telemetry.ts` - API validation and aggregation
- `src/shared/analytics/mlTelemetry.ts` - Core event types and tracking
- `src/shared/analytics/useMLTracking.ts` - Hook wrappers
- `src/features/grid-editor/hooks/useGridResize.ts` - Drawer resize tracking
- `src/core/store/layout.ts` - Fill operation tracking
- `src/features/bin-inspector/hooks/useBinInspector.ts` - Layer move + rotation
- `src/hooks/interactions/useDragInteraction.ts` - Drag-to-staging tracking
- `src/features/staging/hooks/useStagingDragInteraction.ts` - Staging drag tracking

## Test plan
- [x] Build passes
- [x] All 3667 tests pass
- [x] Coverage thresholds met