### PR TITLE
fix: remove GitHub links from static pages and structured data

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,14 +260,7 @@
           "@type": "Person",
           "name": "Andy Aragon"
         },
-        "sameAs": [
-          "https://github.com/andymai/gridfinity-layout-tool"
-        ],
-        "contactPoint": {
-          "@type": "ContactPoint",
-          "contactType": "technical support",
-          "url": "https://github.com/andymai/gridfinity-layout-tool/issues"
-        }
+        "sameAs": []
       }
     </script>
 

--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -156,7 +156,6 @@ ${content}
       <div class="content-footer__links">
         <a href="/what-is-gridfinity">What is Gridfinity?</a>
         <a href="/guide">Planning Guide</a>
-        <a href="https://github.com/andymai/gridfinity-layout-tool" target="_blank" rel="noopener">GitHub</a>
       </div>
       <p class="content-footer__copyright">
         © ${new Date().getFullYear()} Gridfinity Layout Tool. Free and open source.


### PR DESCRIPTION
## Summary
- Remove GitHub link from content page footer (repo is private)
- Remove `sameAs` and `contactPoint` GitHub URLs from index.html structured data

## Test plan
- [x] Build succeeds
- [x] No GitHub links in generated static pages
- [x] No GitHub links in index.html