### PR TITLE
fix: remove inaccurate open source claim from static page footer

### DIFF
--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -158,7 +158,7 @@ ${content}
         <a href="/guide">Planning Guide</a>
       </div>
       <p class="content-footer__copyright">
-        © ${new Date().getFullYear()} Gridfinity Layout Tool. Free and open source.
+        © ${new Date().getFullYear()} Gridfinity Layout Tool. Free to use.
       </p>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- Remove "Free and open source" claim from static page footer since the project is not open source
- Changed to "Free to use" which is accurate

## Test plan
- [x] Static content builds successfully
- [ ] Verify footer text on deployed preview