### PR TITLE
refactor: move sidebar settings to modal

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -123,9 +123,16 @@ test.describe('Accessibility', () => {
   });
 
   test('confirm dialog is accessible', async ({ page }) => {
-    // Scroll to see the "Save Current as Defaults" button in the sidebar
+    // Open Settings modal first
     const sidebar = getSidebar(page);
-    const saveDefaultsButton = sidebar.getByRole('button', { name: 'Save Current as Defaults' });
+    const settingsButton = sidebar.getByRole('button', { name: 'Open settings' });
+    await settingsButton.click();
+
+    // Wait for settings modal to open
+    await expect(page.getByRole('dialog', { name: 'Settings' })).toBeVisible();
+
+    // Click "Save Current as Defaults" button in the settings modal
+    const saveDefaultsButton = page.getByRole('button', { name: 'Save Current as Defaults' });
     await saveDefaultsButton.scrollIntoViewIfNeeded();
     await saveDefaultsButton.click();
 

--- a/src/components/Modals/SettingsModal.tsx
+++ b/src/components/Modals/SettingsModal.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useRef, type CSSProperties } from 'react';
+import { useShallow } from 'zustand/shallow';
+import { useSettingsStore } from '@/core/store';
+import { useLabsStore } from '@/features/labs/store/labs';
+import {
+  getToggleableFeatures,
+  getGraduatedFeatures,
+  type FeatureId,
+} from '@/features/labs/definitions/features';
+import { FeatureCard } from '@/features/labs/components/FeatureCard';
+import { GraduatedSection } from '@/features/labs/components/GraduatedSection';
+import { SparklesIcon } from '@/features/labs/components/icons';
+import { Checkbox } from '@/shared/components/Checkbox';
+import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
+import { useDrawerSettings } from '@/hooks/useDrawerSettings';
+import type { STLSearchSite } from '@/core/store/settings';
+
+// Style constants
+const STYLES = {
+  overlay: { backgroundColor: 'var(--overlay-dark)' } as CSSProperties,
+  modal: {
+    backgroundColor: 'var(--bg-secondary)',
+    border: '1px solid var(--border-default)',
+    borderRadius: 'var(--radius-xl)',
+    boxShadow: 'var(--shadow-xl)',
+  } as CSSProperties,
+  title: {
+    fontSize: 'var(--text-2xl)',
+    fontWeight: 'var(--font-bold)',
+    color: 'var(--text-primary)',
+  } as CSSProperties,
+  sectionHeader: {
+    fontSize: 'var(--text-base)',
+    fontWeight: 'var(--font-semibold)',
+    color: 'var(--text-primary)',
+  } as CSSProperties,
+} as const;
+
+interface SettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  const {
+    drawer,
+    gridUnitMm,
+    printBedSize,
+    activeLayerHeight,
+    settings,
+    toggleSTLSite,
+    handleSaveDefaults,
+    showSaveDefaultsConfirm,
+    setShowSaveDefaultsConfirm,
+  } = useDrawerSettings();
+
+  const { mlTelemetryEnabled, updateSetting } = useSettingsStore(
+    useShallow((state) => ({
+      mlTelemetryEnabled: state.settings.mlTelemetryEnabled,
+      updateSetting: state.updateSetting,
+    }))
+  );
+
+  const { toggleFeature, isFeatureEnabled } = useLabsStore(
+    useShallow((state) => ({
+      toggleFeature: state.toggleFeature,
+      isFeatureEnabled: state.isFeatureEnabled,
+    }))
+  );
+
+  // Handle escape key and body scroll lock
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    closeButtonRef.current?.focus();
+    document.body.style.overflow = 'hidden';
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const toggleableFeatures = getToggleableFeatures();
+  const graduatedFeatures = getGraduatedFeatures();
+
+  const handlePrivacyToggle = () => {
+    updateSetting('mlTelemetryEnabled', !mlTelemetryEnabled);
+  };
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 flex items-center justify-center z-50 animate-fade-in"
+        style={STYLES.overlay}
+        onClick={onClose}
+      >
+        <div
+          ref={modalRef}
+          className="max-w-lg w-full mx-4 max-h-[85vh] flex flex-col animate-scale-in"
+          style={STYLES.modal}
+          onClick={(e) => e.stopPropagation()}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="settings-title"
+        >
+          {/* Header */}
+          <div className="flex justify-between items-center p-6 pb-4 border-b border-stroke-subtle">
+            <h2 id="settings-title" style={STYLES.title}>
+              Settings
+            </h2>
+            <button
+              ref={closeButtonRef}
+              onClick={onClose}
+              className="btn btn-ghost btn-icon"
+              style={{ minWidth: 'auto', minHeight: 'auto' }}
+              aria-label="Close settings"
+            >
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Scrollable content */}
+          <div className="flex-1 overflow-y-auto scrollbar-thin p-6 space-y-8">
+            {/* Default Preferences Section */}
+            <section>
+              <h3 style={STYLES.sectionHeader} className="mb-3">
+                Default Preferences
+              </h3>
+              <p className="text-sm text-content-tertiary mb-3">
+                New layouts will use these settings:
+              </p>
+              <div className="text-sm text-content-secondary space-y-1 mb-4 p-3 rounded-lg bg-surface-elevated border border-stroke-subtle">
+                <div className="flex justify-between">
+                  <span>Drawer size</span>
+                  <span className="text-content-tertiary">
+                    {settings.defaultDrawerWidth}×{settings.defaultDrawerDepth}×{settings.defaultDrawerHeight}u
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Layer height</span>
+                  <span className="text-content-tertiary">{settings.defaultLayerHeight}u</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Print bed</span>
+                  <span className="text-content-tertiary">{settings.defaultPrintBedSize}mm</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Grid unit</span>
+                  <span className="text-content-tertiary">{settings.defaultGridUnitMm}mm</span>
+                </div>
+              </div>
+              <button
+                onClick={() => setShowSaveDefaultsConfirm(true)}
+                className="w-full text-sm py-2 px-3 rounded-lg bg-surface-elevated hover:bg-surface-hover text-content-secondary hover:text-content border border-stroke-subtle transition-colors"
+                title="Save current layout settings as defaults for new layouts"
+              >
+                Save Current as Defaults
+              </button>
+            </section>
+
+            {/* Divider */}
+            <hr className="border-stroke-subtle" />
+
+            {/* STL Search Section */}
+            <section>
+              <h3 style={STYLES.sectionHeader} className="mb-3">
+                STL Search
+              </h3>
+              <p className="text-sm text-content-tertiary mb-3">
+                Choose which sites to search for Gridfinity STL files:
+              </p>
+              <div className="space-y-2">
+                {settings.stlSearchSites.map((site: STLSearchSite) => (
+                  <div
+                    key={site.id}
+                    className="flex items-center justify-between text-sm cursor-pointer group"
+                    onClick={() => toggleSTLSite(site.id)}
+                    role="checkbox"
+                    aria-checked={site.enabled}
+                    aria-label={`Toggle ${site.name}`}
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === ' ' || e.key === 'Enter') {
+                        e.preventDefault();
+                        toggleSTLSite(site.id);
+                      }
+                    }}
+                  >
+                    <span
+                      className={`${site.enabled ? 'text-content' : 'text-content-tertiary'} group-hover:text-content transition-colors`}
+                    >
+                      {site.name}
+                    </span>
+                    <Checkbox checked={site.enabled} variant="desktop" />
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* Divider */}
+            <hr className="border-stroke-subtle" />
+
+            {/* Privacy Section */}
+            <section>
+              <h3 style={STYLES.sectionHeader} className="mb-3">
+                Privacy
+              </h3>
+              <div
+                className="flex items-center justify-between text-sm cursor-pointer group"
+                onClick={handlePrivacyToggle}
+                role="checkbox"
+                aria-checked={mlTelemetryEnabled}
+                aria-label="Toggle usage data collection"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === ' ' || e.key === 'Enter') {
+                    e.preventDefault();
+                    handlePrivacyToggle();
+                  }
+                }}
+              >
+                <div>
+                  <span
+                    className={`${mlTelemetryEnabled ? 'text-content' : 'text-content-tertiary'} group-hover:text-content transition-colors`}
+                  >
+                    Help improve suggestions
+                  </span>
+                  <p className="text-xs text-content-disabled mt-0.5">
+                    Share bin sizes and placement patterns (no personal data)
+                  </p>
+                </div>
+                <Checkbox checked={mlTelemetryEnabled} variant="desktop" />
+              </div>
+            </section>
+
+            {/* Divider */}
+            <hr className="border-stroke-subtle" />
+
+            {/* Labs Section */}
+            <section>
+              <div className="flex items-center gap-2 mb-3">
+                <SparklesIcon className="w-5 h-5 text-accent" />
+                <h3 style={STYLES.sectionHeader}>Labs</h3>
+              </div>
+              <p className="text-sm text-content-tertiary mb-4">
+                Try new features before they're released. Features may change based on feedback.
+              </p>
+
+              {toggleableFeatures.length > 0 ? (
+                <div className="space-y-3">
+                  {toggleableFeatures.map((feature) => (
+                    <FeatureCard
+                      key={feature.id}
+                      feature={feature}
+                      isEnabled={isFeatureEnabled(feature.id as FeatureId)}
+                      onToggle={() => toggleFeature(feature.id as FeatureId)}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <div className="text-center py-6 text-content-tertiary">
+                  <SparklesIcon className="w-10 h-10 mx-auto mb-2 opacity-50" />
+                  <p className="text-sm">No experimental features available right now.</p>
+                  <p className="text-xs mt-1">Check back later!</p>
+                </div>
+              )}
+
+              <GraduatedSection features={graduatedFeatures} />
+            </section>
+          </div>
+        </div>
+      </div>
+
+      <ConfirmDialog
+        isOpen={showSaveDefaultsConfirm}
+        title="Save as Defaults"
+        message={`Save current settings as defaults for new layouts?\n\nDrawer: ${drawer.width}×${drawer.depth}×${drawer.height}u\nLayer height: ${activeLayerHeight}u\nPrint bed: ${printBedSize}mm\nGrid unit: ${gridUnitMm}mm`}
+        confirmText="Save"
+        onConfirm={handleSaveDefaults}
+        onCancel={() => setShowSaveDefaultsConfirm(false)}
+      />
+    </>
+  );
+}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/shallow';
-import { useUIStore, useSettingsStore } from '@/core/store';
+import { useUIStore } from '@/core/store';
 import { useDrawerSettings } from '@/hooks/useDrawerSettings';
 import { CONSTRAINTS } from '@/core/constants';
 import { ActiveLayerPanel } from '@/features/layers/components/ActiveLayerPanel';
@@ -8,68 +8,18 @@ import { LayerPanel } from '@/features/layers/components/LayerPanel';
 import { CategoriesPanel } from '@/features/categories/components/CategoriesPanel';
 import { DeferredNumberInput } from '@/shared/components/DeferredNumberInput';
 import { StepperControl } from '@/shared/components/StepperControl';
-import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { HalfBinModeBlockedModal } from '@/components/Modals/HalfBinModeBlockedModal';
+import { SettingsModal } from '@/components/Modals/SettingsModal';
 import { CollapsibleSection } from '@/shared/components/CollapsibleSection';
 import { useResponsive } from '@/shared/hooks';
-import { LabsButton } from '@/features/labs/components';
 import { Checkbox } from '@/shared/components/Checkbox';
 import { SettingsRow } from '@/shared/components/SettingsRow';
 import { InspirationGallery } from '@/features/inspiration-gallery';
-import type { STLSearchSite } from '@/core/store/settings';
-
-/**
- * Privacy settings section with ML telemetry opt-out toggle.
- */
-function PrivacySection() {
-  const { mlTelemetryEnabled, updateSetting } = useSettingsStore(
-    useShallow((state) => ({
-      mlTelemetryEnabled: state.settings.mlTelemetryEnabled,
-      updateSetting: state.updateSetting,
-    }))
-  );
-
-  const handleToggle = () => {
-    updateSetting('mlTelemetryEnabled', !mlTelemetryEnabled);
-  };
-
-  return (
-    <div className="px-4 py-4 border-t border-stroke-subtle">
-      <CollapsibleSection title="Privacy" variant="default" defaultExpanded={false}>
-        <div className="space-y-2">
-          <div
-            className="flex items-center justify-between text-xs cursor-pointer group"
-            onClick={handleToggle}
-            role="checkbox"
-            aria-checked={mlTelemetryEnabled}
-            aria-label="Toggle usage data collection"
-            tabIndex={0}
-            onKeyDown={(e) => {
-              if (e.key === ' ' || e.key === 'Enter') {
-                e.preventDefault();
-                handleToggle();
-              }
-            }}
-          >
-            <div>
-              <span className={`${mlTelemetryEnabled ? 'text-content' : 'text-content-tertiary'} group-hover:text-content transition-colors`}>
-                Help improve suggestions
-              </span>
-              <p className="text-[10px] text-content-disabled mt-0.5">
-                Share bin sizes and placement patterns (no personal data)
-              </p>
-            </div>
-            <Checkbox checked={mlTelemetryEnabled} variant="desktop" />
-          </div>
-        </div>
-      </CollapsibleSection>
-    </div>
-  );
-}
 
 export function Sidebar() {
   const [isScrolled, setIsScrolled] = useState(false);
   const [showInspirationGallery, setShowInspirationGallery] = useState(false);
+  const [showSettingsModal, setShowSettingsModal] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const { isDesktop } = useResponsive();
 
@@ -99,8 +49,6 @@ export function Sidebar() {
     heightUnitMm,
     printBedSize,
     halfBinMode,
-    settings,
-    activeLayerHeight,
     handleDrawerWidthChange,
     handleDrawerDepthChange,
     handleDrawerHeightChange,
@@ -109,13 +57,9 @@ export function Sidebar() {
     handleFractionalEdgeChange,
     handleHalfBinToggle,
     handleRemediate,
-    handleSaveDefaults,
     setGridUnitMm,
     setHeightUnitMm,
     setPrintBedSize,
-    toggleSTLSite,
-    showSaveDefaultsConfirm,
-    setShowSaveDefaultsConfirm,
     showHalfBinBlockedModal,
     setShowHalfBinBlockedModal,
     halfBinViolation,
@@ -152,6 +96,17 @@ export function Sidebar() {
             <h2 className="flex-1 text-xs font-semibold text-content-tertiary uppercase tracking-wider">
               Tools
             </h2>
+            <button
+              onClick={() => setShowSettingsModal(true)}
+              className="p-1 rounded transition-colors text-content-tertiary hover:bg-surface-hover hover:text-content"
+              title="Settings"
+              aria-label="Open settings"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+            </button>
             <button
               onClick={toggle}
               className="p-1 rounded transition-colors text-content-tertiary hover:bg-surface-hover hover:text-content"
@@ -411,66 +366,6 @@ export function Sidebar() {
               </CollapsibleSection>
             </div>
 
-            {/* Default Preferences */}
-            <div className="px-4 py-4 border-t border-stroke-subtle">
-              <CollapsibleSection title="Default Preferences" variant="default" defaultExpanded={true}>
-                <div className="text-xs text-content-tertiary mb-2">
-                  New layouts will use:
-                </div>
-                <div className="text-xs text-content-secondary space-y-1 mb-3">
-                  <div>Drawer: {settings.defaultDrawerWidth}×{settings.defaultDrawerDepth}×{settings.defaultDrawerHeight}u</div>
-                  <div>Layer height: {settings.defaultLayerHeight}u</div>
-                  <div>Print bed: {settings.defaultPrintBedSize}mm</div>
-                  <div>Grid unit: {settings.defaultGridUnitMm}mm</div>
-                </div>
-                <button
-                  onClick={() => setShowSaveDefaultsConfirm(true)}
-                  className="w-full text-xs py-1.5 px-2 rounded bg-surface-elevated hover:bg-surface-hover text-content-secondary hover:text-content border border-stroke-subtle transition-colors"
-                  title="Save current layout settings as defaults for new layouts"
-                >
-                  Save Current as Defaults
-                </button>
-              </CollapsibleSection>
-            </div>
-
-            {/* STL Search */}
-            <div className="px-4 py-4 border-t border-stroke-subtle">
-              <CollapsibleSection title="STL Search" variant="default" defaultExpanded={false}>
-                <div className="space-y-2">
-                  {settings.stlSearchSites.map((site: STLSearchSite) => (
-                    <div
-                      key={site.id}
-                      className="flex items-center justify-between text-xs cursor-pointer group"
-                      onClick={() => toggleSTLSite(site.id)}
-                      role="checkbox"
-                      aria-checked={site.enabled}
-                      aria-label={`Toggle ${site.name}`}
-                      tabIndex={0}
-                      onKeyDown={(e) => {
-                        if (e.key === ' ' || e.key === 'Enter') {
-                          e.preventDefault();
-                          toggleSTLSite(site.id);
-                        }
-                      }}
-                    >
-                      <span className={`${site.enabled ? 'text-content' : 'text-content-tertiary'} group-hover:text-content transition-colors`}>
-                        {site.name}
-                      </span>
-                      <Checkbox checked={site.enabled} variant="desktop" />
-                    </div>
-                  ))}
-                </div>
-              </CollapsibleSection>
-            </div>
-
-            {/* Privacy */}
-            <PrivacySection />
-
-            {/* Labs */}
-            <div className="px-4 py-4 border-t border-stroke-subtle">
-              <LabsButton />
-            </div>
-
             {/* Attribution */}
             <div className="px-4 py-4 border-t border-stroke-subtle text-content-disabled text-[10px] leading-relaxed">
               Gridfinity by{' '}
@@ -509,15 +404,6 @@ export function Sidebar() {
         </>
       )}
 
-      <ConfirmDialog
-        isOpen={showSaveDefaultsConfirm}
-        title="Save as Defaults"
-        message={`Save current settings as defaults for new layouts?\n\nDrawer: ${drawer.width}×${drawer.depth}×${drawer.height}u\nLayer height: ${activeLayerHeight}u\nPrint bed: ${printBedSize}mm\nGrid unit: ${gridUnitMm}mm`}
-        confirmText="Save"
-        onConfirm={handleSaveDefaults}
-        onCancel={() => setShowSaveDefaultsConfirm(false)}
-      />
-
       {halfBinViolation && (
         <HalfBinModeBlockedModal
           isOpen={showHalfBinBlockedModal}
@@ -530,6 +416,11 @@ export function Sidebar() {
       <InspirationGallery
         isOpen={showInspirationGallery}
         onClose={() => setShowInspirationGallery(false)}
+      />
+
+      <SettingsModal
+        isOpen={showSettingsModal}
+        onClose={() => setShowSettingsModal(false)}
       />
     </aside>
   );

--- a/src/test/components/Sidebar.test.tsx
+++ b/src/test/components/Sidebar.test.tsx
@@ -63,6 +63,19 @@ vi.mock('../../components/Modals/HalfBinModeBlockedModal', () => ({
   ),
 }));
 
+vi.mock('../../components/Modals/SettingsModal', () => ({
+  SettingsModal: ({ isOpen, onClose }: {
+    isOpen: boolean;
+    onClose: () => void;
+  }) => (
+    isOpen ? (
+      <div data-testid="settings-modal">
+        <button data-testid="close-settings" onClick={onClose}>Close</button>
+      </div>
+    ) : null
+  ),
+}));
+
 vi.mock('../../hooks/useResponsive', () => ({
   useResponsive: () => ({ isDesktop: true, isMobile: false, isTablet: false }),
 }));
@@ -377,59 +390,30 @@ describe('Sidebar', () => {
     });
   });
 
-  describe('default preferences', () => {
-    it('renders Default Preferences section', () => {
+  describe('settings modal', () => {
+    it('renders settings button in header', () => {
       render(<Sidebar />);
 
-      expect(screen.getByText('Default Preferences')).toBeInTheDocument();
+      expect(screen.getByLabelText('Open settings')).toBeInTheDocument();
     });
 
-    it('shows Save Current as Defaults button', () => {
+    it('opens settings modal when settings button clicked', () => {
       render(<Sidebar />);
 
-      expect(screen.getByText('Save Current as Defaults')).toBeInTheDocument();
+      fireEvent.click(screen.getByLabelText('Open settings'));
+
+      expect(screen.getByTestId('settings-modal')).toBeInTheDocument();
     });
 
-    it('shows current default settings', () => {
+    it('closes settings modal when close button clicked', () => {
       render(<Sidebar />);
 
-      // Check for default drawer dimensions display
-      expect(screen.getByText(/Drawer:/)).toBeInTheDocument();
-      expect(screen.getByText(/Layer height:/)).toBeInTheDocument();
-      expect(screen.getByText(/Print bed:/)).toBeInTheDocument();
-    });
+      fireEvent.click(screen.getByLabelText('Open settings'));
+      expect(screen.getByTestId('settings-modal')).toBeInTheDocument();
 
-    it('opens confirm dialog when Save Defaults clicked', () => {
-      render(<Sidebar />);
+      fireEvent.click(screen.getByTestId('close-settings'));
 
-      fireEvent.click(screen.getByText('Save Current as Defaults'));
-
-      expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
-      expect(screen.getByTestId('dialog-title')).toHaveTextContent('Save as Defaults');
-    });
-
-    it('saves defaults when confirmed', () => {
-      render(<Sidebar />);
-
-      fireEvent.click(screen.getByText('Save Current as Defaults'));
-      fireEvent.click(screen.getByTestId('confirm-btn'));
-
-      // Settings should be updated
-      const settings = useSettingsStore.getState().settings;
-      expect(settings.defaultDrawerWidth).toBe(10);
-      expect(settings.defaultDrawerDepth).toBe(8);
-      expect(settings.defaultDrawerHeight).toBe(12);
-    });
-
-    it('closes dialog when cancelled', () => {
-      render(<Sidebar />);
-
-      fireEvent.click(screen.getByText('Save Current as Defaults'));
-      expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
-
-      fireEvent.click(screen.getByTestId('cancel-btn'));
-
-      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('settings-modal')).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- Move rarely-used settings from the sidebar to a dedicated Settings modal
- Add gear icon button in sidebar header to open settings
- Simplify the sidebar by focusing it on frequently-used editing tools

## Sections moved to Settings modal
- **Default Preferences** - save current layout settings as defaults
- **STL Search** - toggle which sites to search for STL files  
- **Privacy** - ML telemetry opt-out
- **Labs** - experimental feature flags

## Changes
- Create `SettingsModal` component with scrollable single-page layout
- Update `Sidebar` to remove 4 settings sections and add gear icon
- Update Sidebar unit tests for new modal behavior
- Update e2e accessibility test to open Settings modal first

## Notes
- Mobile continues to use inline settings in `MobileSettingsPanel` (different UX pattern)
- Labs drawer is still available globally but desktop users access it via Settings modal

## Test plan
- [x] Build succeeds
- [x] All 3664 unit tests pass
- [ ] E2E tests pass
- [ ] Manual verification: gear icon opens Settings modal with all sections
- [ ] Manual verification: mobile settings still work as before