### PR TITLE
test: add comprehensive tests for inspiration-gallery feature

### DIFF
--- a/src/features/inspiration-gallery/__tests__/InspirationGallery.test.tsx
+++ b/src/features/inspiration-gallery/__tests__/InspirationGallery.test.tsx
@@ -1,0 +1,492 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { InspirationGallery } from '../components/InspirationGallery';
+import { useUIStore } from '@/core/store/ui';
+import { useToastStore } from '@/core/store/toast';
+import type { InspirationLayout } from '../types';
+
+// Mock hooks
+vi.mock('@/shared/hooks', () => ({
+  useResponsive: () => ({ isMobile: false }),
+}));
+
+const mockImportLayoutFromJSON = vi.fn();
+const mockSwitchLayout = vi.fn();
+
+vi.mock('@/features/layout-library/hooks/useLayoutSwitcher', () => ({
+  useLayoutSwitcher: () => ({
+    importLayoutFromJSON: mockImportLayoutFromJSON,
+    switchLayout: mockSwitchLayout,
+  }),
+}));
+
+// Mock data - defined inside the mock factory to avoid hoisting issues
+vi.mock('../data/inspirationLayouts', () => {
+  const mockLayouts = [
+    {
+      id: 'workshop-1',
+      name: 'Workshop Layout 1',
+      theme: 'workshop',
+      description: 'A workshop layout',
+      shortDescription: 'Workshop desc',
+      complexity: 'beginner',
+      features: [],
+      metrics: { binCount: 10, layerCount: 1, categoryCount: 2, labeledBinCount: 5, drawerSize: { width: 10, depth: 8, height: 12 } },
+      preview: { drawerWidth: 10, drawerDepth: 8, drawerHeight: 12, binCount: 10, layerCount: 1, binMap: [] },
+      layout: { name: 'W1', drawer: { width: 10, depth: 8, height: 12 }, layers: [], categories: [], bins: [], gridUnitMm: 42, heightUnitMm: 7, printBedSize: 256 },
+      tags: [],
+    },
+    {
+      id: 'workshop-2',
+      name: 'Workshop Layout 2',
+      theme: 'workshop',
+      description: 'Another workshop layout',
+      shortDescription: 'Workshop desc 2',
+      complexity: 'intermediate',
+      features: [],
+      metrics: { binCount: 15, layerCount: 2, categoryCount: 3, labeledBinCount: 8, drawerSize: { width: 12, depth: 10, height: 15 } },
+      preview: { drawerWidth: 12, drawerDepth: 10, drawerHeight: 15, binCount: 15, layerCount: 2, binMap: [] },
+      layout: { name: 'W2', drawer: { width: 12, depth: 10, height: 15 }, layers: [], categories: [], bins: [], gridUnitMm: 42, heightUnitMm: 7, printBedSize: 256 },
+      tags: [],
+    },
+    {
+      id: 'kitchen-1',
+      name: 'Kitchen Layout 1',
+      theme: 'kitchen',
+      description: 'A kitchen layout',
+      shortDescription: 'Kitchen desc',
+      complexity: 'beginner',
+      features: [],
+      metrics: { binCount: 8, layerCount: 1, categoryCount: 2, labeledBinCount: 4, drawerSize: { width: 8, depth: 6, height: 10 } },
+      preview: { drawerWidth: 8, drawerDepth: 6, drawerHeight: 10, binCount: 8, layerCount: 1, binMap: [] },
+      layout: { name: 'K1', drawer: { width: 8, depth: 6, height: 10 }, layers: [], categories: [], bins: [], gridUnitMm: 42, heightUnitMm: 7, printBedSize: 256 },
+      tags: [],
+    },
+  ];
+  return {
+    INSPIRATION_LAYOUTS: mockLayouts,
+    getLayoutsByTheme: (theme: string) => mockLayouts.filter((l: { theme: string }) => l.theme === theme),
+  };
+});
+
+// Mock child components
+vi.mock('../components/ThemeFilterPills', () => ({
+  ThemeFilterPills: ({ selectedTheme, onThemeChange, themeCounts }: {
+    selectedTheme: string;
+    onThemeChange: (theme: string) => void;
+    themeCounts: Record<string, number>;
+  }) => (
+    <div data-testid="theme-filter-pills">
+      <button onClick={() => onThemeChange('all')} data-selected={selectedTheme === 'all'}>
+        All ({themeCounts.all})
+      </button>
+      <button onClick={() => onThemeChange('workshop')} data-selected={selectedTheme === 'workshop'}>
+        Workshop ({themeCounts.workshop})
+      </button>
+      <button onClick={() => onThemeChange('kitchen')} data-selected={selectedTheme === 'kitchen'}>
+        Kitchen ({themeCounts.kitchen})
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('../components/LayoutCard', () => ({
+  LayoutCard: ({ layout, onClick, index }: { layout: InspirationLayout; onClick: () => void; index: number }) => (
+    <button
+      data-testid={`layout-card-${layout.id}`}
+      data-layout-card
+      onClick={onClick}
+      data-index={index}
+    >
+      {layout.name}
+    </button>
+  ),
+}));
+
+vi.mock('../components/LayoutPreviewOverlay', () => ({
+  LayoutPreviewOverlay: ({ layout, onClose, onUseLayout, isImporting }: {
+    layout: InspirationLayout;
+    onClose: () => void;
+    onUseLayout: () => void;
+    isImporting: boolean;
+  }) => (
+    <div data-testid="preview-overlay">
+      <div data-testid="preview-layout-name">{layout.name}</div>
+      <button onClick={onClose} data-testid="preview-close">Close</button>
+      <button onClick={onUseLayout} disabled={isImporting} data-testid="preview-use">
+        {isImporting ? 'Importing...' : 'Use Layout'}
+      </button>
+    </div>
+  ),
+}));
+
+// Spy on store methods
+const mockAnnounceToScreenReader = vi.fn();
+const mockCloseMobilePanel = vi.fn();
+const mockAddToast = vi.fn();
+
+describe('InspirationGallery', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockImportLayoutFromJSON.mockResolvedValue({ ok: true, value: 'new-layout-id' });
+    mockSwitchLayout.mockResolvedValue({ ok: true, value: undefined });
+    // Reset body overflow
+    document.body.style.overflow = '';
+
+    // Spy on store methods
+    vi.spyOn(useUIStore.getState(), 'announceToScreenReader').mockImplementation(mockAnnounceToScreenReader);
+    vi.spyOn(useUIStore.getState(), 'closeMobilePanel').mockImplementation(mockCloseMobilePanel);
+    vi.spyOn(useToastStore.getState(), 'addToast').mockImplementation(mockAddToast);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe('visibility', () => {
+    it('returns null when not open', () => {
+      const { container } = render(<InspirationGallery isOpen={false} onClose={vi.fn()} />);
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders content when open', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  describe('rendering', () => {
+    it('renders the title', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      expect(screen.getByText('Inspiration Gallery')).toBeInTheDocument();
+    });
+
+    it('renders the subtitle', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      expect(screen.getByText("See what's possible, then make it yours")).toBeInTheDocument();
+    });
+
+    it('renders theme filter pills', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      expect(screen.getByTestId('theme-filter-pills')).toBeInTheDocument();
+    });
+
+    it('renders layout cards', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      expect(screen.getByTestId('layout-card-workshop-1')).toBeInTheDocument();
+      expect(screen.getByTestId('layout-card-workshop-2')).toBeInTheDocument();
+      expect(screen.getByTestId('layout-card-kitchen-1')).toBeInTheDocument();
+    });
+
+    it('renders layout count in footer', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      expect(screen.getByText('3 layouts')).toBeInTheDocument();
+    });
+
+    it('has close button', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      expect(screen.getByLabelText('Close gallery')).toBeInTheDocument();
+    });
+
+    it('has dialog role with aria attributes', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      expect(dialog).toHaveAttribute('aria-labelledby', 'inspiration-gallery-title');
+    });
+  });
+
+  describe('theme filtering', () => {
+    it('shows all layouts by default', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      expect(screen.getByTestId('layout-card-workshop-1')).toBeInTheDocument();
+      expect(screen.getByTestId('layout-card-workshop-2')).toBeInTheDocument();
+      expect(screen.getByTestId('layout-card-kitchen-1')).toBeInTheDocument();
+    });
+
+    it('filters layouts when theme changes', async () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      // Click workshop filter
+      fireEvent.click(screen.getByText('Workshop (2)'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('layout-card-workshop-1')).toBeInTheDocument();
+        expect(screen.getByTestId('layout-card-workshop-2')).toBeInTheDocument();
+        expect(screen.queryByTestId('layout-card-kitchen-1')).not.toBeInTheDocument();
+      });
+    });
+
+    it('updates layout count when filtered', async () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      fireEvent.click(screen.getByText('Workshop (2)'));
+
+      await waitFor(() => {
+        expect(screen.getByText(/2 layouts? in Workshop/)).toBeInTheDocument();
+      });
+    });
+
+    it('announces to screen reader when theme changes', async () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      fireEvent.click(screen.getByText('Kitchen (1)'));
+
+      await waitFor(() => {
+        expect(mockAnnounceToScreenReader).toHaveBeenCalledWith(
+          expect.stringContaining('Kitchen')
+        );
+      });
+    });
+  });
+
+  describe('modal behavior', () => {
+    it('calls onClose when backdrop is clicked', () => {
+      const onClose = vi.fn();
+      const { container } = render(<InspirationGallery isOpen={true} onClose={onClose} />);
+
+      // Click the backdrop (first fixed div)
+      const backdrop = container.querySelector('.fixed.inset-0.bg-black\\/50');
+      if (backdrop) {
+        fireEvent.click(backdrop);
+      }
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not close when clicking inside modal', () => {
+      const onClose = vi.fn();
+      render(<InspirationGallery isOpen={true} onClose={onClose} />);
+
+      const dialog = screen.getByRole('dialog');
+      fireEvent.click(dialog);
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('calls onClose when close button is clicked', () => {
+      const onClose = vi.fn();
+      render(<InspirationGallery isOpen={true} onClose={onClose} />);
+
+      fireEvent.click(screen.getByLabelText('Close gallery'));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when Escape is pressed', () => {
+      const onClose = vi.fn();
+      render(<InspirationGallery isOpen={true} onClose={onClose} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('locks body scroll when open', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      expect(document.body.style.overflow).toBe('hidden');
+    });
+
+    it('restores body scroll when unmounted', () => {
+      const { unmount } = render(<InspirationGallery {...defaultProps} />);
+
+      unmount();
+
+      expect(document.body.style.overflow).toBe('');
+    });
+  });
+
+  describe('preview overlay', () => {
+    it('opens preview when card is clicked', async () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      fireEvent.click(screen.getByTestId('layout-card-workshop-1'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('preview-overlay')).toBeInTheDocument();
+        expect(screen.getByTestId('preview-layout-name')).toHaveTextContent('Workshop Layout 1');
+      });
+    });
+
+    it('closes preview with Escape key (before closing gallery)', async () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      // Open preview
+      fireEvent.click(screen.getByTestId('layout-card-workshop-1'));
+      await waitFor(() => {
+        expect(screen.getByTestId('preview-overlay')).toBeInTheDocument();
+      });
+
+      // Press Escape - should close preview, not gallery
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('preview-overlay')).not.toBeInTheDocument();
+      });
+
+      // Gallery should still be open
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('closes preview when close button is clicked', async () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      fireEvent.click(screen.getByTestId('layout-card-workshop-1'));
+      await waitFor(() => {
+        expect(screen.getByTestId('preview-overlay')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('preview-close'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('preview-overlay')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('import flow', () => {
+    it('imports layout when use button is clicked', async () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      // Open preview
+      fireEvent.click(screen.getByTestId('layout-card-workshop-1'));
+      await waitFor(() => {
+        expect(screen.getByTestId('preview-overlay')).toBeInTheDocument();
+      });
+
+      // Click use layout
+      fireEvent.click(screen.getByTestId('preview-use'));
+
+      await waitFor(() => {
+        expect(mockImportLayoutFromJSON).toHaveBeenCalledTimes(1);
+        expect(mockSwitchLayout).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('shows success toast on successful import', async () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      fireEvent.click(screen.getByTestId('layout-card-workshop-1'));
+      await waitFor(() => {
+        expect(screen.getByTestId('preview-overlay')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('preview-use'));
+
+      await waitFor(() => {
+        expect(mockAddToast).toHaveBeenCalledWith(
+          'Added "Workshop Layout 1"',
+          'success'
+        );
+      });
+    });
+
+    it('closes gallery after successful import', async () => {
+      const onClose = vi.fn();
+      render(<InspirationGallery isOpen={true} onClose={onClose} />);
+
+      fireEvent.click(screen.getByTestId('layout-card-workshop-1'));
+      await waitFor(() => {
+        expect(screen.getByTestId('preview-overlay')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('preview-use'));
+
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalled();
+      });
+    });
+
+    it('shows error toast on failed import', async () => {
+      mockImportLayoutFromJSON.mockResolvedValue({ ok: false, error: { code: 'IMPORT_ERROR' } });
+
+      render(<InspirationGallery {...defaultProps} />);
+
+      fireEvent.click(screen.getByTestId('layout-card-workshop-1'));
+      await waitFor(() => {
+        expect(screen.getByTestId('preview-overlay')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('preview-use'));
+
+      await waitFor(() => {
+        expect(mockAddToast).toHaveBeenCalledWith('Failed to add layout', 'error');
+      });
+    });
+
+    it('closes mobile panel on import', async () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      fireEvent.click(screen.getByTestId('layout-card-workshop-1'));
+      await waitFor(() => {
+        expect(screen.getByTestId('preview-overlay')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('preview-use'));
+
+      await waitFor(() => {
+        expect(mockCloseMobilePanel).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('focus management', () => {
+    it('focuses close button on mount', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      const closeButton = screen.getByLabelText('Close gallery');
+      expect(document.activeElement).toBe(closeButton);
+    });
+
+    it('announces to screen reader on mount', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      expect(mockAnnounceToScreenReader).toHaveBeenCalledWith(
+        expect.stringContaining('Inspiration Gallery opened')
+      );
+    });
+  });
+
+  describe('grid column slider', () => {
+    it('renders grid column slider on desktop', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      expect(screen.getByLabelText('Grid columns')).toBeInTheDocument();
+    });
+
+    it('changes grid columns when slider is moved', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      const slider = screen.getByLabelText('Grid columns');
+      fireEvent.change(slider, { target: { value: '6' } });
+
+      expect(slider).toHaveValue('6');
+    });
+  });
+
+  describe('layout grid', () => {
+    it('has grid role with aria-label', () => {
+      render(<InspirationGallery {...defaultProps} />);
+
+      const grid = screen.getByRole('grid', { name: 'Layout gallery' });
+      expect(grid).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/inspiration-gallery/__tests__/LayoutCard.test.tsx
+++ b/src/features/inspiration-gallery/__tests__/LayoutCard.test.tsx
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LayoutCard } from '../components/LayoutCard';
+import type { InspirationLayout } from '../types';
+
+// Mock LayoutThumbnailWithLabels to avoid complex SVG rendering in tests
+vi.mock('../components/LayoutThumbnailWithLabels', () => ({
+  LayoutThumbnailWithLabels: ({ layout }: { layout: unknown }) => (
+    <div data-testid="layout-thumbnail" data-layout={JSON.stringify(layout)} />
+  ),
+}));
+
+const createMockLayout = (overrides: Partial<InspirationLayout> = {}): InspirationLayout => ({
+  id: 'test-layout',
+  name: 'Test Layout',
+  theme: 'workshop',
+  description: 'A detailed description of the test layout',
+  shortDescription: 'A short description',
+  complexity: 'beginner',
+  features: [],
+  metrics: {
+    binCount: 12,
+    layerCount: 2,
+    categoryCount: 3,
+    labeledBinCount: 8,
+    drawerSize: { width: 10, depth: 8, height: 12 },
+  },
+  preview: {
+    drawerWidth: 10,
+    drawerDepth: 8,
+    drawerHeight: 12,
+    binCount: 12,
+    layerCount: 2,
+    binMap: [],
+  },
+  layout: {
+    name: 'Test',
+    drawer: { width: 10, depth: 8, height: 12 },
+    layers: [],
+    categories: [],
+    bins: [],
+    gridUnitMm: 42,
+    heightUnitMm: 7,
+    printBedSize: 256,
+  },
+  tags: ['test'],
+  ...overrides,
+});
+
+describe('LayoutCard', () => {
+  const defaultProps = {
+    layout: createMockLayout(),
+    onClick: vi.fn(),
+    index: 0,
+  };
+
+  describe('rendering', () => {
+    it('renders the layout name', () => {
+      render(<LayoutCard {...defaultProps} />);
+
+      expect(screen.getByText('Test Layout')).toBeInTheDocument();
+    });
+
+    it('renders the short description', () => {
+      render(<LayoutCard {...defaultProps} />);
+
+      expect(screen.getByText('A short description')).toBeInTheDocument();
+    });
+
+    it('renders bin count and drawer size', () => {
+      render(<LayoutCard {...defaultProps} />);
+
+      expect(screen.getByText('12 bins · 10×8')).toBeInTheDocument();
+    });
+
+    it('renders theme badge', () => {
+      render(<LayoutCard {...defaultProps} />);
+
+      expect(screen.getByText('Workshop')).toBeInTheDocument();
+    });
+
+    it('renders thumbnail component', () => {
+      render(<LayoutCard {...defaultProps} />);
+
+      expect(screen.getByTestId('layout-thumbnail')).toBeInTheDocument();
+    });
+
+    it('renders different theme labels correctly', () => {
+      const themes = [
+        { theme: 'kitchen', label: 'Kitchen' },
+        { theme: 'workshop', label: 'Workshop' },
+        { theme: 'office', label: 'Office' },
+        { theme: 'hobby', label: 'Hobby' },
+        { theme: 'personal', label: 'Personal' },
+      ] as const;
+
+      themes.forEach(({ theme, label }) => {
+        const { unmount } = render(
+          <LayoutCard
+            {...defaultProps}
+            layout={createMockLayout({ theme })}
+          />
+        );
+
+        expect(screen.getByText(label)).toBeInTheDocument();
+        unmount();
+      });
+    });
+  });
+
+  describe('animation', () => {
+    it('applies animation delay based on index', () => {
+      render(<LayoutCard {...defaultProps} index={2} />);
+
+      const card = screen.getByRole('button');
+      expect(card).toHaveStyle({ animationDelay: '100ms' });
+    });
+
+    it('caps animation delay at 300ms', () => {
+      render(<LayoutCard {...defaultProps} index={10} />);
+
+      const card = screen.getByRole('button');
+      expect(card).toHaveStyle({ animationDelay: '300ms' });
+    });
+
+    it('applies 0ms delay for first card', () => {
+      render(<LayoutCard {...defaultProps} index={0} />);
+
+      const card = screen.getByRole('button');
+      expect(card).toHaveStyle({ animationDelay: '0ms' });
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onClick when clicked', () => {
+      const onClick = vi.fn();
+      render(<LayoutCard {...defaultProps} onClick={onClick} />);
+
+      fireEvent.click(screen.getByRole('button'));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClick when Enter key is pressed', () => {
+      const onClick = vi.fn();
+      render(<LayoutCard {...defaultProps} onClick={onClick} />);
+
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' });
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClick when Space key is pressed', () => {
+      const onClick = vi.fn();
+      render(<LayoutCard {...defaultProps} onClick={onClick} />);
+
+      fireEvent.keyDown(screen.getByRole('button'), { key: ' ' });
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClick for other keys', () => {
+      const onClick = vi.fn();
+      render(<LayoutCard {...defaultProps} onClick={onClick} />);
+
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'Tab' });
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'Escape' });
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'a' });
+
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('calls onFocus when focused', () => {
+      const onFocus = vi.fn();
+      render(<LayoutCard {...defaultProps} onFocus={onFocus} />);
+
+      fireEvent.focus(screen.getByRole('button'));
+
+      expect(onFocus).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has button role', () => {
+      render(<LayoutCard {...defaultProps} />);
+
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+
+    it('has descriptive aria-label', () => {
+      render(<LayoutCard {...defaultProps} />);
+
+      const card = screen.getByRole('button');
+      expect(card).toHaveAttribute(
+        'aria-label',
+        'Test Layout. Workshop. 12 bins. A short description'
+      );
+    });
+
+    it('uses custom tabIndex when provided', () => {
+      render(<LayoutCard {...defaultProps} tabIndex={-1} />);
+
+      const card = screen.getByRole('button');
+      expect(card).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('uses default tabIndex of 0', () => {
+      render(<LayoutCard {...defaultProps} />);
+
+      const card = screen.getByRole('button');
+      expect(card).toHaveAttribute('tabIndex', '0');
+    });
+
+    it('has data-layout-card attribute for query selection', () => {
+      render(<LayoutCard {...defaultProps} />);
+
+      const card = screen.getByRole('button');
+      expect(card).toHaveAttribute('data-layout-card');
+    });
+  });
+
+  describe('metrics display', () => {
+    it('displays correct metrics for different layouts', () => {
+      const layout = createMockLayout({
+        metrics: {
+          binCount: 25,
+          layerCount: 3,
+          categoryCount: 5,
+          labeledBinCount: 20,
+          drawerSize: { width: 15, depth: 12, height: 18 },
+        },
+      });
+
+      render(<LayoutCard {...defaultProps} layout={layout} />);
+
+      expect(screen.getByText('25 bins · 15×12')).toBeInTheDocument();
+    });
+
+    it('handles single bin count', () => {
+      const layout = createMockLayout({
+        metrics: {
+          ...createMockLayout().metrics,
+          binCount: 1,
+        },
+      });
+
+      render(<LayoutCard {...defaultProps} layout={layout} />);
+
+      expect(screen.getByText('1 bins · 10×8')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/inspiration-gallery/__tests__/LayoutPreviewOverlay.test.tsx
+++ b/src/features/inspiration-gallery/__tests__/LayoutPreviewOverlay.test.tsx
@@ -1,0 +1,377 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LayoutPreviewOverlay } from '../components/LayoutPreviewOverlay';
+import { resetAllStores } from '@/test/testUtils';
+import { useLayoutStore } from '@/core/store/layout';
+import type { InspirationLayout } from '../types';
+
+// Mock useResponsive hook
+vi.mock('@/shared/hooks', () => ({
+  useResponsive: () => ({ isMobile: false }),
+}));
+
+// Mock LayoutThumbnailWithLabels
+vi.mock('../components/LayoutThumbnailWithLabels', () => ({
+  LayoutThumbnailWithLabels: () => <div data-testid="layout-thumbnail" />,
+}));
+
+// Mock INSPIRATION_LAYOUTS for related layouts
+vi.mock('../data/inspirationLayouts', () => ({
+  INSPIRATION_LAYOUTS: [
+    {
+      id: 'related-1',
+      name: 'Related Layout 1',
+      theme: 'workshop',
+      metrics: { binCount: 10, layerCount: 1, categoryCount: 2, labeledBinCount: 5, drawerSize: { width: 8, depth: 6, height: 10 } },
+      layout: { name: 'R1', drawer: { width: 8, depth: 6, height: 10 }, layers: [], categories: [], bins: [], gridUnitMm: 42, heightUnitMm: 7, printBedSize: 256 },
+    },
+    {
+      id: 'related-2',
+      name: 'Related Layout 2',
+      theme: 'workshop',
+      metrics: { binCount: 15, layerCount: 2, categoryCount: 3, labeledBinCount: 8, drawerSize: { width: 10, depth: 8, height: 12 } },
+      layout: { name: 'R2', drawer: { width: 10, depth: 8, height: 12 }, layers: [], categories: [], bins: [], gridUnitMm: 42, heightUnitMm: 7, printBedSize: 256 },
+    },
+    {
+      id: 'kitchen-1',
+      name: 'Kitchen Layout',
+      theme: 'kitchen',
+      metrics: { binCount: 8, layerCount: 1, categoryCount: 2, labeledBinCount: 4, drawerSize: { width: 10, depth: 8, height: 10 } },
+      layout: { name: 'K1', drawer: { width: 10, depth: 8, height: 10 }, layers: [], categories: [], bins: [], gridUnitMm: 42, heightUnitMm: 7, printBedSize: 256 },
+    },
+  ],
+}));
+
+const createMockLayout = (overrides: Partial<InspirationLayout> = {}): InspirationLayout => ({
+  id: 'test-layout',
+  name: 'Test Layout',
+  theme: 'workshop',
+  description: 'A detailed description of the test layout for organizing workshop items.',
+  shortDescription: 'A short description',
+  complexity: 'beginner',
+  features: [],
+  metrics: {
+    binCount: 12,
+    layerCount: 2,
+    categoryCount: 3,
+    labeledBinCount: 8,
+    drawerSize: { width: 10, depth: 8, height: 12 },
+  },
+  preview: {
+    drawerWidth: 10,
+    drawerDepth: 8,
+    drawerHeight: 12,
+    binCount: 12,
+    layerCount: 2,
+    binMap: [],
+  },
+  layout: {
+    name: 'Test',
+    drawer: { width: 10, depth: 8, height: 12 },
+    layers: [{ id: 'l1', name: 'Layer 1', height: 3 }],
+    categories: [{ id: 'c1', name: 'Cat', color: '#ff0000' }],
+    bins: [
+      { id: 'b1', x: 0, y: 0, width: 2, depth: 2, height: 3, layerId: 'l1', category: 'c1', label: 'Screws', notes: '' },
+      { id: 'b2', x: 2, y: 0, width: 2, depth: 2, height: 3, layerId: 'l1', category: 'c1', label: 'Nuts', notes: '' },
+      { id: 'b3', x: 4, y: 0, width: 2, depth: 2, height: 3, layerId: 'l1', category: 'c1', label: 'Bolts', notes: '' },
+    ],
+    gridUnitMm: 42,
+    heightUnitMm: 7,
+    printBedSize: 256,
+  },
+  tags: ['test'],
+  ...overrides,
+});
+
+describe('LayoutPreviewOverlay', () => {
+  const defaultProps = {
+    layout: createMockLayout(),
+    onClose: vi.fn(),
+    onUseLayout: vi.fn(),
+    onSelectRelated: vi.fn(),
+    isImporting: false,
+  };
+
+  beforeEach(() => {
+    resetAllStores();
+    vi.clearAllMocks();
+    // Set a default drawer size
+    const layout = useLayoutStore.getState().layout;
+    layout.drawer = { width: 10, depth: 8, height: 12 };
+    useLayoutStore.setState({ layout });
+  });
+
+  describe('rendering', () => {
+    it('renders the layout name as title', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getByText('Test Layout')).toBeInTheDocument();
+    });
+
+    it('renders the description', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getByText('A detailed description of the test layout for organizing workshop items.')).toBeInTheDocument();
+    });
+
+    it('renders the theme badge', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getByText('Workshop')).toBeInTheDocument();
+    });
+
+    it('renders layout thumbnail', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getAllByTestId('layout-thumbnail').length).toBeGreaterThan(0);
+    });
+
+    it('has dialog role with aria attributes', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      expect(dialog).toHaveAttribute('aria-labelledby', 'preview-title');
+    });
+  });
+
+  describe('metrics display', () => {
+    it('displays bin count', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getByText('12')).toBeInTheDocument();
+      expect(screen.getByText('Bins')).toBeInTheDocument();
+    });
+
+    it('displays layer count', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('Layers')).toBeInTheDocument();
+    });
+
+    it('displays category count', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(screen.getByText('Categories')).toBeInTheDocument();
+    });
+  });
+
+  describe('drawer comparison', () => {
+    it('shows matching drawer message when sizes match', () => {
+      // Store drawer matches layout drawer (10x8)
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getByText('Matches your drawer')).toBeInTheDocument();
+    });
+
+    it('shows size info when drawer sizes differ', () => {
+      // Change store drawer to different size
+      const layout = useLayoutStore.getState().layout;
+      layout.drawer = { width: 12, depth: 10, height: 15 };
+      useLayoutStore.setState({ layout });
+
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getByText('10×8 drawer')).toBeInTheDocument();
+      expect(screen.getByText(/420×336mm/)).toBeInTheDocument();
+    });
+
+    it('shows comparison when sizes differ', () => {
+      const layout = useLayoutStore.getState().layout;
+      layout.drawer = { width: 15, depth: 12, height: 18 };
+      useLayoutStore.setState({ layout });
+
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getByText(/yours: 15×12/)).toBeInTheDocument();
+    });
+  });
+
+  describe('labeled bins', () => {
+    it('displays example items section', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getByText('Example Items')).toBeInTheDocument();
+    });
+
+    it('shows labeled bin names', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getByText('Screws')).toBeInTheDocument();
+      expect(screen.getByText('Nuts')).toBeInTheDocument();
+      expect(screen.getByText('Bolts')).toBeInTheDocument();
+    });
+
+    it('limits display to 8 items', () => {
+      const manyBins = Array.from({ length: 12 }, (_, i) => ({
+        id: `b${i}`,
+        x: 0,
+        y: 0,
+        width: 1,
+        depth: 1,
+        height: 3,
+        layerId: 'l1',
+        category: 'c1',
+        label: `Item ${i + 1}`,
+        notes: '',
+      }));
+
+      const layoutWithManyBins = createMockLayout({
+        layout: {
+          ...createMockLayout().layout,
+          bins: manyBins,
+        },
+      });
+
+      render(<LayoutPreviewOverlay {...defaultProps} layout={layoutWithManyBins} />);
+
+      expect(screen.getByText('+4 more')).toBeInTheDocument();
+    });
+
+    it('hides example items when no labeled bins', () => {
+      const layoutNoLabels = createMockLayout({
+        layout: {
+          ...createMockLayout().layout,
+          bins: [
+            { id: 'b1', x: 0, y: 0, width: 2, depth: 2, height: 3, layerId: 'l1', category: 'c1', label: '', notes: '' },
+          ],
+        },
+      });
+
+      render(<LayoutPreviewOverlay {...defaultProps} layout={layoutNoLabels} />);
+
+      expect(screen.queryByText('Example Items')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('related layouts', () => {
+    it('shows related layouts section', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getByText('More Workshop')).toBeInTheDocument();
+    });
+
+    it('displays related layout names', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getByText('Related Layout 1')).toBeInTheDocument();
+      expect(screen.getByText('Related Layout 2')).toBeInTheDocument();
+    });
+
+    it('calls onSelectRelated when clicking related layout', () => {
+      const onSelectRelated = vi.fn();
+      render(<LayoutPreviewOverlay {...defaultProps} onSelectRelated={onSelectRelated} />);
+
+      fireEvent.click(screen.getByText('Related Layout 1'));
+
+      expect(onSelectRelated).toHaveBeenCalledTimes(1);
+    });
+
+    it('hides related section when onSelectRelated not provided', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} onSelectRelated={undefined} />);
+
+      expect(screen.queryByText('More Workshop')).not.toBeInTheDocument();
+    });
+
+    it('only shows layouts of same theme', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      // Kitchen layout should not appear for workshop theme
+      expect(screen.queryByText('Kitchen Layout')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onClose when backdrop is clicked', () => {
+      const onClose = vi.fn();
+      const { container } = render(<LayoutPreviewOverlay {...defaultProps} onClose={onClose} />);
+
+      // Click the outer container (backdrop)
+      const backdrop = container.querySelector('.fixed.inset-0');
+      if (backdrop) {
+        fireEvent.click(backdrop);
+      }
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not close when clicking inside dialog', () => {
+      const onClose = vi.fn();
+      render(<LayoutPreviewOverlay {...defaultProps} onClose={onClose} />);
+
+      const dialog = screen.getByRole('dialog');
+      fireEvent.click(dialog);
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('calls onClose when Escape key is pressed', () => {
+      const onClose = vi.fn();
+      render(<LayoutPreviewOverlay {...defaultProps} onClose={onClose} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when back button is clicked', () => {
+      const onClose = vi.fn();
+      render(<LayoutPreviewOverlay {...defaultProps} onClose={onClose} />);
+
+      fireEvent.click(screen.getByLabelText('Back to gallery'));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onUseLayout when CTA button is clicked', () => {
+      const onUseLayout = vi.fn();
+      render(<LayoutPreviewOverlay {...defaultProps} onUseLayout={onUseLayout} />);
+
+      fireEvent.click(screen.getByText('Use as Starting Point'));
+
+      expect(onUseLayout).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('import state', () => {
+    it('shows normal button when not importing', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} isImporting={false} />);
+
+      expect(screen.getByText('Use as Starting Point')).toBeInTheDocument();
+      expect(screen.queryByText('Adding...')).not.toBeInTheDocument();
+    });
+
+    it('shows loading state when importing', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} isImporting={true} />);
+
+      expect(screen.getByText('Adding...')).toBeInTheDocument();
+      expect(screen.queryByText('Use as Starting Point')).not.toBeInTheDocument();
+    });
+
+    it('disables button when importing', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} isImporting={true} />);
+
+      const button = screen.getByRole('button', { name: /adding/i });
+      expect(button).toBeDisabled();
+    });
+  });
+
+  describe('focus management', () => {
+    it('focuses close button on mount', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      const closeButton = screen.getByLabelText('Back to gallery');
+      expect(document.activeElement).toBe(closeButton);
+    });
+  });
+
+  describe('footer', () => {
+    it('displays helpful text', () => {
+      render(<LayoutPreviewOverlay {...defaultProps} />);
+
+      expect(screen.getByText('Use as a starting point — customize to fit your items')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/inspiration-gallery/__tests__/LayoutThumbnailWithLabels.test.tsx
+++ b/src/features/inspiration-gallery/__tests__/LayoutThumbnailWithLabels.test.tsx
@@ -1,0 +1,413 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { LayoutThumbnailWithLabels } from '../components/LayoutThumbnailWithLabels';
+import type { Layout, Bin } from '@/core/types';
+
+/**
+ * Helper to create a minimal valid Layout for testing.
+ */
+function createTestLayout(overrides: Partial<Layout> = {}): Layout {
+  return {
+    version: '1.0',
+    name: 'Test Layout',
+    drawer: {
+      width: 10,
+      depth: 8,
+      height: 12,
+    },
+    layers: [{ id: 'layer-1', name: 'Layer 1', height: 3 }],
+    categories: [{ id: 'cat-1', name: 'General', color: '#6b7280' }],
+    bins: [],
+    gridUnitMm: 42,
+    heightUnitMm: 7,
+    printBedSize: 256,
+    ...overrides,
+  };
+}
+
+/**
+ * Helper to create a test bin.
+ */
+function createTestBin(overrides: Partial<Bin> = {}): Bin {
+  return {
+    id: 'bin-1',
+    x: 0,
+    y: 0,
+    width: 2,
+    depth: 2,
+    height: 3,
+    layerId: 'layer-1',
+    category: 'cat-1',
+    label: '',
+    notes: '',
+    ...overrides,
+  };
+}
+
+describe('LayoutThumbnailWithLabels', () => {
+  describe('rendering', () => {
+    it('renders an SVG element', () => {
+      const layout = createTestLayout();
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const svg = container.querySelector('svg');
+      expect(svg).toBeInTheDocument();
+    });
+
+    it('has aria-hidden for accessibility', () => {
+      const layout = createTestLayout();
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('uses fixed dimensions by default', () => {
+      const layout = createTestLayout();
+      const { container } = render(
+        <LayoutThumbnailWithLabels layout={layout} size={200} />
+      );
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('width', '200');
+    });
+
+    it('uses responsive sizing when responsive prop is true', () => {
+      const layout = createTestLayout();
+      const { container } = render(
+        <LayoutThumbnailWithLabels layout={layout} responsive />
+      );
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('width', '100%');
+      expect(svg).toHaveAttribute('height', '100%');
+      expect(svg).toHaveAttribute('preserveAspectRatio', 'xMidYMid meet');
+    });
+
+    it('applies className prop', () => {
+      const layout = createTestLayout();
+      const { container } = render(
+        <LayoutThumbnailWithLabels layout={layout} className="custom-class" />
+      );
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveClass('custom-class');
+    });
+
+    it('renders drawer background rect', () => {
+      const layout = createTestLayout();
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const rects = container.querySelectorAll('rect');
+      expect(rects.length).toBeGreaterThanOrEqual(2); // Background + inner area
+    });
+
+    it('renders grid lines', () => {
+      const layout = createTestLayout({
+        drawer: { width: 5, depth: 4, height: 12 },
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const lines = container.querySelectorAll('line');
+      // Should have (width-1) vertical + (depth-1) horizontal lines
+      expect(lines.length).toBe(4 + 3); // 4 vertical, 3 horizontal
+    });
+  });
+
+  describe('bin rendering', () => {
+    it('renders bin rectangles', () => {
+      const layout = createTestLayout({
+        bins: [createTestBin({ id: 'b1', x: 0, y: 0, width: 2, depth: 2 })],
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      // Should have: drawer bg + inner area + bin rect = 3 rects
+      const rects = container.querySelectorAll('rect');
+      expect(rects.length).toBe(3);
+    });
+
+    it('renders multiple bins', () => {
+      const layout = createTestLayout({
+        bins: [
+          createTestBin({ id: 'b1', x: 0, y: 0 }),
+          createTestBin({ id: 'b2', x: 2, y: 0 }),
+          createTestBin({ id: 'b3', x: 4, y: 0 }),
+        ],
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const rects = container.querySelectorAll('rect');
+      expect(rects.length).toBe(5); // 2 background + 3 bins
+    });
+
+    it('applies category color to bins', () => {
+      const layout = createTestLayout({
+        categories: [{ id: 'tools', name: 'Tools', color: '#ff0000' }],
+        bins: [createTestBin({ id: 'b1', category: 'tools' })],
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const rects = container.querySelectorAll('rect');
+      const binRect = rects[rects.length - 1]; // Last rect is the bin
+      expect(binRect).toHaveAttribute('fill', '#ff0000');
+    });
+
+    it('uses fallback color for unknown category', () => {
+      const layout = createTestLayout({
+        categories: [{ id: 'known', name: 'Known', color: '#ff0000' }],
+        bins: [createTestBin({ id: 'b1', category: 'unknown' })],
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const rects = container.querySelectorAll('rect');
+      const binRect = rects[rects.length - 1];
+      expect(binRect).toHaveAttribute('fill', '#94a3b8'); // fallback color
+    });
+  });
+
+  describe('staging bin filtering', () => {
+    it('excludes bins in staging area', () => {
+      const layout = createTestLayout({
+        bins: [
+          createTestBin({ id: 'b1', layerId: 'layer-1' }),
+          createTestBin({ id: 'b2', layerId: '__staging__' }),
+        ],
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      // Should only render 1 bin (not the staging one)
+      const rects = container.querySelectorAll('rect');
+      expect(rects.length).toBe(3); // 2 background + 1 bin
+    });
+
+    it('renders no bins when all are in staging', () => {
+      const layout = createTestLayout({
+        bins: [
+          createTestBin({ id: 'b1', layerId: '__staging__' }),
+          createTestBin({ id: 'b2', layerId: '__staging__' }),
+        ],
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const rects = container.querySelectorAll('rect');
+      expect(rects.length).toBe(2); // Just background rects
+    });
+  });
+
+  describe('label rendering', () => {
+    it('renders label text for bins with labels', () => {
+      const layout = createTestLayout({
+        bins: [
+          createTestBin({
+            id: 'b1',
+            width: 4, // Large enough to show label
+            depth: 4,
+            label: 'Screws',
+          }),
+        ],
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const texts = container.querySelectorAll('text');
+      expect(texts.length).toBe(1);
+    });
+
+    it('does not render label for empty label string', () => {
+      const layout = createTestLayout({
+        bins: [
+          createTestBin({
+            id: 'b1',
+            width: 4,
+            depth: 4,
+            label: '',
+          }),
+        ],
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const texts = container.querySelectorAll('text');
+      expect(texts.length).toBe(0);
+    });
+
+    it('does not render label for whitespace-only label', () => {
+      const layout = createTestLayout({
+        bins: [
+          createTestBin({
+            id: 'b1',
+            width: 4,
+            depth: 4,
+            label: '   ',
+          }),
+        ],
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const texts = container.querySelectorAll('text');
+      expect(texts.length).toBe(0);
+    });
+
+    it('does not render label for small bins', () => {
+      const layout = createTestLayout({
+        bins: [
+          createTestBin({
+            id: 'b1',
+            width: 1, // Too small
+            depth: 1,
+            label: 'Screws',
+          }),
+        ],
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const texts = container.querySelectorAll('text');
+      expect(texts.length).toBe(0);
+    });
+  });
+
+  describe('aspect ratio', () => {
+    it('calculates correct aspect ratio for square drawer', () => {
+      const layout = createTestLayout({
+        drawer: { width: 10, depth: 10, height: 12 },
+      });
+      const { container } = render(
+        <LayoutThumbnailWithLabels layout={layout} size={100} />
+      );
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('viewBox', '0 0 100 100');
+    });
+
+    it('calculates correct aspect ratio for wide drawer', () => {
+      const layout = createTestLayout({
+        drawer: { width: 20, depth: 10, height: 12 },
+      });
+      const { container } = render(
+        <LayoutThumbnailWithLabels layout={layout} size={100} />
+      );
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('viewBox', '0 0 100 50');
+    });
+
+    it('calculates correct aspect ratio for tall drawer', () => {
+      const layout = createTestLayout({
+        drawer: { width: 10, depth: 20, height: 12 },
+      });
+      const { container } = render(
+        <LayoutThumbnailWithLabels layout={layout} size={100} />
+      );
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('viewBox', '0 0 100 200');
+    });
+  });
+
+  describe('defaults', () => {
+    it('uses default size of 160', () => {
+      const layout = createTestLayout({
+        drawer: { width: 10, depth: 10, height: 12 }, // Square for easy calculation
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('width', '160');
+      expect(svg).toHaveAttribute('height', '160');
+    });
+
+    it('uses empty string as default className', () => {
+      const layout = createTestLayout();
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveClass('rounded-lg');
+    });
+  });
+
+  describe('text rotation', () => {
+    it('rotates text for tall bins (depth > width * 1.5)', () => {
+      const layout = createTestLayout({
+        bins: [
+          createTestBin({
+            id: 'b1',
+            width: 2,
+            depth: 4, // depth > width * 1.5 (4 > 3)
+            label: 'Test',
+          }),
+        ],
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const text = container.querySelector('text');
+      if (text) {
+        // Should have a rotation transform
+        const transform = text.getAttribute('transform');
+        expect(transform).toMatch(/rotate\(-90/);
+      }
+    });
+
+    it('does not rotate text for wide bins', () => {
+      const layout = createTestLayout({
+        bins: [
+          createTestBin({
+            id: 'b1',
+            width: 4,
+            depth: 2, // width > depth, should not rotate
+            label: 'Test',
+          }),
+        ],
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const text = container.querySelector('text');
+      if (text) {
+        const transform = text.getAttribute('transform');
+        expect(transform).toBeNull();
+      }
+    });
+  });
+
+  describe('contrast color helper', () => {
+    // We can test the contrast behavior indirectly by checking text fill colors
+    it('uses dark text on light background', () => {
+      const layout = createTestLayout({
+        categories: [{ id: 'light', name: 'Light', color: '#ffffff' }],
+        bins: [
+          createTestBin({
+            id: 'b1',
+            width: 4,
+            depth: 4,
+            category: 'light',
+            label: 'Test',
+          }),
+        ],
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const text = container.querySelector('text');
+      if (text) {
+        expect(text).toHaveAttribute('fill', '#1a1a1a');
+      }
+    });
+
+    it('uses light text on dark background', () => {
+      const layout = createTestLayout({
+        categories: [{ id: 'dark', name: 'Dark', color: '#000000' }],
+        bins: [
+          createTestBin({
+            id: 'b1',
+            width: 4,
+            depth: 4,
+            category: 'dark',
+            label: 'Test',
+          }),
+        ],
+      });
+      const { container } = render(<LayoutThumbnailWithLabels layout={layout} />);
+
+      const text = container.querySelector('text');
+      if (text) {
+        expect(text).toHaveAttribute('fill', '#ffffff');
+      }
+    });
+  });
+});

--- a/src/features/inspiration-gallery/__tests__/ThemeFilterPills.test.tsx
+++ b/src/features/inspiration-gallery/__tests__/ThemeFilterPills.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeFilterPills } from '../components/ThemeFilterPills';
+import type { InspirationTheme } from '../types';
+
+describe('ThemeFilterPills', () => {
+  const defaultThemeCounts: Record<InspirationTheme | 'all', number> = {
+    all: 23,
+    kitchen: 4,
+    workshop: 7,
+    office: 2,
+    hobby: 5,
+    personal: 5,
+  };
+
+  const defaultProps = {
+    selectedTheme: 'all' as const,
+    onThemeChange: vi.fn(),
+    themeCounts: defaultThemeCounts,
+  };
+
+  describe('rendering', () => {
+    it('renders all 6 filter buttons', () => {
+      render(<ThemeFilterPills {...defaultProps} />);
+
+      const tabs = screen.getAllByRole('tab');
+      expect(tabs).toHaveLength(6);
+    });
+
+    it('renders "All" label for all theme', () => {
+      render(<ThemeFilterPills {...defaultProps} />);
+
+      expect(screen.getByRole('tab', { name: /all/i })).toBeInTheDocument();
+    });
+
+    it('renders correct labels for each theme', () => {
+      render(<ThemeFilterPills {...defaultProps} />);
+
+      expect(screen.getByRole('tab', { name: /kitchen/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /workshop/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /office/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /hobby/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /personal/i })).toBeInTheDocument();
+    });
+
+    it('displays count badges for each theme', () => {
+      render(<ThemeFilterPills {...defaultProps} />);
+
+      // The counts should be visible in the document
+      expect(screen.getByText('23')).toBeInTheDocument(); // all
+      expect(screen.getByText('4')).toBeInTheDocument(); // kitchen
+      expect(screen.getByText('7')).toBeInTheDocument(); // workshop
+      expect(screen.getByText('2')).toBeInTheDocument(); // office
+      // Note: 5 appears twice (hobby and personal), so we just check it exists
+      expect(screen.getAllByText('5')).toHaveLength(2);
+    });
+
+    it('renders theme icons for non-all themes', () => {
+      render(<ThemeFilterPills {...defaultProps} />);
+
+      // Each theme button should contain an SVG icon
+      const tabs = screen.getAllByRole('tab');
+      tabs.forEach((tab) => {
+        const svg = tab.querySelector('svg');
+        expect(svg).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('selected state', () => {
+    it('marks "all" as selected by default', () => {
+      render(<ThemeFilterPills {...defaultProps} selectedTheme="all" />);
+
+      const allTab = screen.getByRole('tab', { name: /all.*23/i });
+      expect(allTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('marks selected theme with aria-selected=true', () => {
+      render(<ThemeFilterPills {...defaultProps} selectedTheme="workshop" />);
+
+      const workshopTab = screen.getByRole('tab', { name: /workshop/i });
+      expect(workshopTab).toHaveAttribute('aria-selected', 'true');
+
+      const allTab = screen.getByRole('tab', { name: /all/i });
+      expect(allTab).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('only one theme can be selected at a time', () => {
+      render(<ThemeFilterPills {...defaultProps} selectedTheme="kitchen" />);
+
+      const tabs = screen.getAllByRole('tab');
+      const selectedTabs = tabs.filter(
+        (tab) => tab.getAttribute('aria-selected') === 'true'
+      );
+
+      expect(selectedTabs).toHaveLength(1);
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onThemeChange when a theme is clicked', () => {
+      const onThemeChange = vi.fn();
+      render(
+        <ThemeFilterPills {...defaultProps} onThemeChange={onThemeChange} />
+      );
+
+      fireEvent.click(screen.getByRole('tab', { name: /workshop/i }));
+
+      expect(onThemeChange).toHaveBeenCalledTimes(1);
+      expect(onThemeChange).toHaveBeenCalledWith('workshop');
+    });
+
+    it('calls onThemeChange with "all" when All is clicked', () => {
+      const onThemeChange = vi.fn();
+      render(
+        <ThemeFilterPills
+          {...defaultProps}
+          selectedTheme="kitchen"
+          onThemeChange={onThemeChange}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('tab', { name: /all/i }));
+
+      expect(onThemeChange).toHaveBeenCalledWith('all');
+    });
+
+    it('calls onThemeChange with each theme type', () => {
+      const onThemeChange = vi.fn();
+      render(
+        <ThemeFilterPills {...defaultProps} onThemeChange={onThemeChange} />
+      );
+
+      const themes: Array<InspirationTheme | 'all'> = [
+        'kitchen',
+        'workshop',
+        'office',
+        'hobby',
+        'personal',
+      ];
+
+      themes.forEach((theme) => {
+        onThemeChange.mockClear();
+        fireEvent.click(screen.getByRole('tab', { name: new RegExp(theme, 'i') }));
+        expect(onThemeChange).toHaveBeenCalledWith(theme);
+      });
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has tablist role on container', () => {
+      render(<ThemeFilterPills {...defaultProps} />);
+
+      expect(screen.getByRole('tablist')).toBeInTheDocument();
+    });
+
+    it('has aria-label on tablist', () => {
+      render(<ThemeFilterPills {...defaultProps} />);
+
+      const tablist = screen.getByRole('tablist');
+      expect(tablist).toHaveAttribute('aria-label', 'Filter by theme');
+    });
+
+    it('all buttons have tab role', () => {
+      render(<ThemeFilterPills {...defaultProps} />);
+
+      const tabs = screen.getAllByRole('tab');
+      expect(tabs).toHaveLength(6);
+    });
+
+    it('all buttons are of type button', () => {
+      render(<ThemeFilterPills {...defaultProps} />);
+
+      const tabs = screen.getAllByRole('tab');
+      tabs.forEach((tab) => {
+        expect(tab).toHaveAttribute('type', 'button');
+      });
+    });
+  });
+
+  describe('count updates', () => {
+    it('displays updated counts when themeCounts change', () => {
+      const { rerender } = render(<ThemeFilterPills {...defaultProps} />);
+
+      expect(screen.getByText('23')).toBeInTheDocument();
+
+      const updatedCounts = {
+        ...defaultThemeCounts,
+        all: 30,
+        workshop: 10,
+      };
+
+      rerender(
+        <ThemeFilterPills
+          {...defaultProps}
+          themeCounts={updatedCounts}
+        />
+      );
+
+      expect(screen.getByText('30')).toBeInTheDocument();
+      expect(screen.getByText('10')).toBeInTheDocument();
+    });
+
+    it('handles zero counts', () => {
+      const zeroCounts: Record<InspirationTheme | 'all', number> = {
+        all: 0,
+        kitchen: 0,
+        workshop: 0,
+        office: 0,
+        hobby: 0,
+        personal: 0,
+      };
+
+      render(
+        <ThemeFilterPills {...defaultProps} themeCounts={zeroCounts} />
+      );
+
+      const zeroElements = screen.getAllByText('0');
+      expect(zeroElements).toHaveLength(6);
+    });
+  });
+});

--- a/src/features/inspiration-gallery/__tests__/layoutBuilder.test.ts
+++ b/src/features/inspiration-gallery/__tests__/layoutBuilder.test.ts
@@ -1,0 +1,658 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createBin,
+  createLayer,
+  createCategory,
+  computePreview,
+  detectFeatures,
+  calculateMetrics,
+  buildInspirationLayout,
+} from '../utils/layoutBuilder';
+import type { Layout } from '@/core/types';
+
+/**
+ * Helper to create a minimal valid Layout for testing.
+ */
+function createTestLayout(overrides: Partial<Layout> = {}): Layout {
+  const defaultLayer = { id: 'layer-1', name: 'Layer 1', height: 3 };
+  const defaultCategory = { id: 'cat-1', name: 'General', color: '#6b7280' };
+
+  return {
+    version: '1.0',
+    name: 'Test Layout',
+    drawer: {
+      width: 10,
+      depth: 8,
+      height: 12,
+    },
+    layers: [defaultLayer],
+    categories: [defaultCategory],
+    bins: [],
+    gridUnitMm: 42,
+    heightUnitMm: 7,
+    printBedSize: 256,
+    ...overrides,
+  };
+}
+
+describe('layoutBuilder', () => {
+  describe('createBin', () => {
+    it('creates a bin with required fields', () => {
+      const bin = createBin(0, 0, 2, 3, {
+        layerId: 'layer-1',
+        categoryId: 'cat-1',
+      });
+
+      expect(bin.x).toBe(0);
+      expect(bin.y).toBe(0);
+      expect(bin.width).toBe(2);
+      expect(bin.depth).toBe(3);
+      expect(bin.layerId).toBe('layer-1');
+      expect(bin.category).toBe('cat-1');
+      expect(bin.id).toMatch(/^insp-\d+$/);
+    });
+
+    it('uses default height of 3 when not specified', () => {
+      const bin = createBin(0, 0, 1, 1, {
+        layerId: 'layer-1',
+        categoryId: 'cat-1',
+      });
+
+      expect(bin.height).toBe(3);
+    });
+
+    it('uses custom height when specified', () => {
+      const bin = createBin(0, 0, 1, 1, {
+        layerId: 'layer-1',
+        categoryId: 'cat-1',
+        height: 6,
+      });
+
+      expect(bin.height).toBe(6);
+    });
+
+    it('sets label and notes with defaults', () => {
+      const bin = createBin(0, 0, 1, 1, {
+        layerId: 'layer-1',
+        categoryId: 'cat-1',
+      });
+
+      expect(bin.label).toBe('');
+      expect(bin.notes).toBe('');
+    });
+
+    it('sets custom label and notes', () => {
+      const bin = createBin(0, 0, 1, 1, {
+        layerId: 'layer-1',
+        categoryId: 'cat-1',
+        label: 'Screwdrivers',
+        notes: 'Various sizes',
+      });
+
+      expect(bin.label).toBe('Screwdrivers');
+      expect(bin.notes).toBe('Various sizes');
+    });
+
+    it('includes clearanceHeight when specified', () => {
+      const bin = createBin(0, 0, 1, 1, {
+        layerId: 'layer-1',
+        categoryId: 'cat-1',
+        clearanceHeight: 5,
+      });
+
+      expect(bin.clearanceHeight).toBe(5);
+    });
+
+    it('omits clearanceHeight when not specified', () => {
+      const bin = createBin(0, 0, 1, 1, {
+        layerId: 'layer-1',
+        categoryId: 'cat-1',
+      });
+
+      expect(bin).not.toHaveProperty('clearanceHeight');
+    });
+
+    it('generates unique IDs for each bin', () => {
+      const bin1 = createBin(0, 0, 1, 1, { layerId: 'l', categoryId: 'c' });
+      const bin2 = createBin(1, 0, 1, 1, { layerId: 'l', categoryId: 'c' });
+      const bin3 = createBin(2, 0, 1, 1, { layerId: 'l', categoryId: 'c' });
+
+      expect(bin1.id).not.toBe(bin2.id);
+      expect(bin2.id).not.toBe(bin3.id);
+      expect(bin1.id).not.toBe(bin3.id);
+    });
+  });
+
+  describe('createLayer', () => {
+    it('creates a layer with name and height', () => {
+      const layer = createLayer('Top Layer', 6);
+
+      expect(layer.name).toBe('Top Layer');
+      expect(layer.height).toBe(6);
+      expect(layer.id).toMatch(/^insp-\d+$/);
+    });
+
+    it('generates unique IDs for each layer', () => {
+      const layer1 = createLayer('Layer 1', 3);
+      const layer2 = createLayer('Layer 2', 3);
+
+      expect(layer1.id).not.toBe(layer2.id);
+    });
+  });
+
+  describe('createCategory', () => {
+    it('creates a category with name and color', () => {
+      const category = createCategory('Tools', '#ff0000');
+
+      expect(category.name).toBe('Tools');
+      expect(category.color).toBe('#ff0000');
+      expect(category.id).toMatch(/^insp-\d+$/);
+    });
+
+    it('generates unique IDs for each category', () => {
+      const cat1 = createCategory('Cat 1', '#ff0000');
+      const cat2 = createCategory('Cat 2', '#00ff00');
+
+      expect(cat1.id).not.toBe(cat2.id);
+    });
+  });
+
+  describe('computePreview', () => {
+    it('computes drawer dimensions from layout', () => {
+      const layout = createTestLayout({
+        drawer: { width: 12, depth: 10, height: 15 },
+      });
+
+      const preview = computePreview(layout);
+
+      expect(preview.drawerWidth).toBe(12);
+      expect(preview.drawerDepth).toBe(10);
+      expect(preview.drawerHeight).toBe(15);
+    });
+
+    it('counts bins excluding staging area', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '' },
+          { id: 'b2', x: 1, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '' },
+          { id: 'b3', x: 0, y: 0, width: 1, depth: 1, height: 3, layerId: '__staging__', category: 'cat-1', label: '', notes: '' },
+        ],
+      });
+
+      const preview = computePreview(layout);
+
+      expect(preview.binCount).toBe(2);
+    });
+
+    it('counts layers correctly', () => {
+      const layout = createTestLayout({
+        layers: [
+          { id: 'l1', name: 'Layer 1', height: 3 },
+          { id: 'l2', name: 'Layer 2', height: 3 },
+          { id: 'l3', name: 'Layer 3', height: 6 },
+        ],
+      });
+
+      const preview = computePreview(layout);
+
+      expect(preview.layerCount).toBe(3);
+    });
+
+    it('creates binMap with correct positions and colors', () => {
+      const layout = createTestLayout({
+        categories: [
+          { id: 'tools', name: 'Tools', color: '#ff0000' },
+          { id: 'parts', name: 'Parts', color: '#00ff00' },
+        ],
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 2, depth: 3, height: 3, layerId: 'layer-1', category: 'tools', label: '', notes: '' },
+          { id: 'b2', x: 2, y: 0, width: 1, depth: 2, height: 3, layerId: 'layer-1', category: 'parts', label: '', notes: '' },
+        ],
+      });
+
+      const preview = computePreview(layout);
+
+      expect(preview.binMap).toHaveLength(2);
+      expect(preview.binMap![0]).toEqual({ x: 0, y: 0, w: 2, d: 3, c: '#ff0000' });
+      expect(preview.binMap![1]).toEqual({ x: 2, y: 0, w: 1, d: 2, c: '#00ff00' });
+    });
+
+    it('uses fallback color for unknown category', () => {
+      const layout = createTestLayout({
+        categories: [{ id: 'known', name: 'Known', color: '#ff0000' }],
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'unknown', label: '', notes: '' },
+        ],
+      });
+
+      const preview = computePreview(layout);
+
+      expect(preview.binMap![0].c).toBe('#6b7280'); // fallback gray
+    });
+
+    it('excludes staging bins from binMap', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '' },
+          { id: 'b2', x: 0, y: 0, width: 2, depth: 2, height: 3, layerId: '__staging__', category: 'cat-1', label: '', notes: '' },
+        ],
+      });
+
+      const preview = computePreview(layout);
+
+      expect(preview.binMap).toHaveLength(1);
+      expect(preview.binMap![0]).toEqual({ x: 0, y: 0, w: 1, d: 1, c: '#6b7280' });
+    });
+  });
+
+  describe('detectFeatures', () => {
+    it('detects multiple-layers feature', () => {
+      const layout = createTestLayout({
+        layers: [
+          { id: 'l1', name: 'Layer 1', height: 3 },
+          { id: 'l2', name: 'Layer 2', height: 3 },
+        ],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).toContain('multiple-layers');
+    });
+
+    it('does not detect multiple-layers for single layer', () => {
+      const layout = createTestLayout({
+        layers: [{ id: 'l1', name: 'Layer 1', height: 3 }],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).not.toContain('multiple-layers');
+    });
+
+    it('detects half-bins feature for fractional x', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0.5, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '' },
+        ],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).toContain('half-bins');
+    });
+
+    it('detects half-bins feature for fractional y', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0, y: 1.5, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '' },
+        ],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).toContain('half-bins');
+    });
+
+    it('detects half-bins feature for fractional width', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 1.5, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '' },
+        ],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).toContain('half-bins');
+    });
+
+    it('detects half-bins feature for fractional depth', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 1, depth: 2.5, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '' },
+        ],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).toContain('half-bins');
+    });
+
+    it('does not detect half-bins for whole numbers', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 2, depth: 3, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '' },
+        ],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).not.toContain('half-bins');
+    });
+
+    it('detects labeled-bins feature', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: 'Screws', notes: '' },
+        ],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).toContain('labeled-bins');
+    });
+
+    it('does not detect labeled-bins for empty labels', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '' },
+        ],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).not.toContain('labeled-bins');
+    });
+
+    it('does not detect labeled-bins for whitespace-only labels', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: '   ', notes: '' },
+        ],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).not.toContain('labeled-bins');
+    });
+
+    it('detects clearance-height feature', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '', clearanceHeight: 5 },
+        ],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).toContain('clearance-height');
+    });
+
+    it('does not detect clearance-height for zero value', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '', clearanceHeight: 0 },
+        ],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).not.toContain('clearance-height');
+    });
+
+    it('detects multiple-categories for 3+ categories', () => {
+      const layout = createTestLayout({
+        categories: [
+          { id: 'c1', name: 'Cat 1', color: '#ff0000' },
+          { id: 'c2', name: 'Cat 2', color: '#00ff00' },
+          { id: 'c3', name: 'Cat 3', color: '#0000ff' },
+        ],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).toContain('multiple-categories');
+    });
+
+    it('does not detect multiple-categories for 2 or fewer', () => {
+      const layout = createTestLayout({
+        categories: [
+          { id: 'c1', name: 'Cat 1', color: '#ff0000' },
+          { id: 'c2', name: 'Cat 2', color: '#00ff00' },
+        ],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).not.toContain('multiple-categories');
+    });
+
+    it('detects multiple features at once', () => {
+      const layout = createTestLayout({
+        layers: [
+          { id: 'l1', name: 'Layer 1', height: 3 },
+          { id: 'l2', name: 'Layer 2', height: 3 },
+        ],
+        categories: [
+          { id: 'c1', name: 'Cat 1', color: '#ff0000' },
+          { id: 'c2', name: 'Cat 2', color: '#00ff00' },
+          { id: 'c3', name: 'Cat 3', color: '#0000ff' },
+        ],
+        bins: [
+          { id: 'b1', x: 0.5, y: 0, width: 1, depth: 1, height: 3, layerId: 'l1', category: 'c1', label: 'Test', notes: '', clearanceHeight: 2 },
+        ],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).toContain('multiple-layers');
+      expect(features).toContain('half-bins');
+      expect(features).toContain('labeled-bins');
+      expect(features).toContain('clearance-height');
+      expect(features).toContain('multiple-categories');
+      expect(features).toHaveLength(5);
+    });
+
+    it('returns empty array for layout with no special features', () => {
+      const layout = createTestLayout({
+        layers: [{ id: 'l1', name: 'Layer 1', height: 3 }],
+        categories: [{ id: 'c1', name: 'Cat 1', color: '#ff0000' }],
+        bins: [],
+      });
+
+      const features = detectFeatures(layout);
+
+      expect(features).toHaveLength(0);
+    });
+  });
+
+  describe('calculateMetrics', () => {
+    it('counts bins excluding staging', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '' },
+          { id: 'b2', x: 1, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '' },
+          { id: 'b3', x: 0, y: 0, width: 1, depth: 1, height: 3, layerId: '__staging__', category: 'cat-1', label: '', notes: '' },
+        ],
+      });
+
+      const metrics = calculateMetrics(layout);
+
+      expect(metrics.binCount).toBe(2);
+    });
+
+    it('counts layers', () => {
+      const layout = createTestLayout({
+        layers: [
+          { id: 'l1', name: 'Layer 1', height: 3 },
+          { id: 'l2', name: 'Layer 2', height: 6 },
+        ],
+      });
+
+      const metrics = calculateMetrics(layout);
+
+      expect(metrics.layerCount).toBe(2);
+    });
+
+    it('counts categories', () => {
+      const layout = createTestLayout({
+        categories: [
+          { id: 'c1', name: 'Cat 1', color: '#ff0000' },
+          { id: 'c2', name: 'Cat 2', color: '#00ff00' },
+          { id: 'c3', name: 'Cat 3', color: '#0000ff' },
+        ],
+      });
+
+      const metrics = calculateMetrics(layout);
+
+      expect(metrics.categoryCount).toBe(3);
+    });
+
+    it('counts labeled bins', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: 'Has label', notes: '' },
+          { id: 'b2', x: 1, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '' },
+          { id: 'b3', x: 2, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: 'Another', notes: '' },
+        ],
+      });
+
+      const metrics = calculateMetrics(layout);
+
+      expect(metrics.labeledBinCount).toBe(2);
+    });
+
+    it('does not count whitespace-only labels', () => {
+      const layout = createTestLayout({
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 1, depth: 1, height: 3, layerId: 'layer-1', category: 'cat-1', label: '  ', notes: '' },
+        ],
+      });
+
+      const metrics = calculateMetrics(layout);
+
+      expect(metrics.labeledBinCount).toBe(0);
+    });
+
+    it('includes drawer size', () => {
+      const layout = createTestLayout({
+        drawer: { width: 15, depth: 12, height: 18 },
+      });
+
+      const metrics = calculateMetrics(layout);
+
+      expect(metrics.drawerSize).toEqual({ width: 15, depth: 12, height: 18 });
+    });
+  });
+
+  describe('buildInspirationLayout', () => {
+    it('builds complete InspirationLayout with all fields', () => {
+      const layout = createTestLayout({
+        drawer: { width: 8, depth: 6, height: 10 },
+        layers: [
+          { id: 'l1', name: 'Layer 1', height: 3 },
+          { id: 'l2', name: 'Layer 2', height: 3 },
+        ],
+        categories: [
+          { id: 'c1', name: 'Tools', color: '#ff0000' },
+          { id: 'c2', name: 'Parts', color: '#00ff00' },
+          { id: 'c3', name: 'Other', color: '#0000ff' },
+        ],
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 2, depth: 2, height: 3, layerId: 'l1', category: 'c1', label: 'Screws', notes: '' },
+        ],
+      });
+
+      const result = buildInspirationLayout(layout, {
+        id: 'test-layout',
+        name: 'Test Layout',
+        theme: 'workshop',
+        description: 'A detailed description',
+        shortDescription: 'A short desc',
+        complexity: 'intermediate',
+        tags: ['tools', 'workshop'],
+      });
+
+      expect(result.id).toBe('test-layout');
+      expect(result.name).toBe('Test Layout');
+      expect(result.theme).toBe('workshop');
+      expect(result.description).toBe('A detailed description');
+      expect(result.shortDescription).toBe('A short desc');
+      expect(result.complexity).toBe('intermediate');
+      expect(result.tags).toEqual(['tools', 'workshop']);
+      expect(result.layout).toBe(layout);
+    });
+
+    it('auto-detects features', () => {
+      const layout = createTestLayout({
+        layers: [
+          { id: 'l1', name: 'Layer 1', height: 3 },
+          { id: 'l2', name: 'Layer 2', height: 3 },
+        ],
+        bins: [
+          { id: 'b1', x: 0.5, y: 0, width: 1, depth: 1, height: 3, layerId: 'l1', category: 'cat-1', label: 'Labeled', notes: '' },
+        ],
+      });
+
+      const result = buildInspirationLayout(layout, {
+        id: 'test',
+        name: 'Test',
+        theme: 'hobby',
+        description: 'Desc',
+        shortDescription: 'Short',
+        complexity: 'beginner',
+        tags: [],
+      });
+
+      expect(result.features).toContain('multiple-layers');
+      expect(result.features).toContain('half-bins');
+      expect(result.features).toContain('labeled-bins');
+    });
+
+    it('calculates metrics correctly', () => {
+      const layout = createTestLayout({
+        drawer: { width: 10, depth: 8, height: 12 },
+        layers: [{ id: 'l1', name: 'Layer 1', height: 3 }],
+        categories: [
+          { id: 'c1', name: 'Cat 1', color: '#ff0000' },
+          { id: 'c2', name: 'Cat 2', color: '#00ff00' },
+        ],
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 1, depth: 1, height: 3, layerId: 'l1', category: 'c1', label: 'Test', notes: '' },
+          { id: 'b2', x: 1, y: 0, width: 1, depth: 1, height: 3, layerId: 'l1', category: 'c2', label: '', notes: '' },
+        ],
+      });
+
+      const result = buildInspirationLayout(layout, {
+        id: 'test',
+        name: 'Test',
+        theme: 'kitchen',
+        description: 'Desc',
+        shortDescription: 'Short',
+        complexity: 'beginner',
+        tags: [],
+      });
+
+      expect(result.metrics.binCount).toBe(2);
+      expect(result.metrics.layerCount).toBe(1);
+      expect(result.metrics.categoryCount).toBe(2);
+      expect(result.metrics.labeledBinCount).toBe(1);
+      expect(result.metrics.drawerSize).toEqual({ width: 10, depth: 8, height: 12 });
+    });
+
+    it('computes preview correctly', () => {
+      const layout = createTestLayout({
+        drawer: { width: 5, depth: 4, height: 6 },
+        bins: [
+          { id: 'b1', x: 0, y: 0, width: 2, depth: 2, height: 3, layerId: 'layer-1', category: 'cat-1', label: '', notes: '' },
+        ],
+      });
+
+      const result = buildInspirationLayout(layout, {
+        id: 'test',
+        name: 'Test',
+        theme: 'office',
+        description: 'Desc',
+        shortDescription: 'Short',
+        complexity: 'beginner',
+        tags: [],
+      });
+
+      expect(result.preview.drawerWidth).toBe(5);
+      expect(result.preview.drawerDepth).toBe(4);
+      expect(result.preview.drawerHeight).toBe(6);
+      expect(result.preview.binCount).toBe(1);
+      expect(result.preview.layerCount).toBe(1);
+      expect(result.preview.binMap).toHaveLength(1);
+    });
+  });
+});

--- a/src/features/inspiration-gallery/__tests__/types.test.ts
+++ b/src/features/inspiration-gallery/__tests__/types.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { THEME_CONFIG, FEATURE_CONFIG } from '../types';
+import type { InspirationTheme, LayoutFeature } from '../types';
+
+describe('types', () => {
+  describe('THEME_CONFIG', () => {
+    const expectedThemes: InspirationTheme[] = ['kitchen', 'workshop', 'office', 'hobby', 'personal'];
+
+    it('has all 5 themes', () => {
+      const themes = Object.keys(THEME_CONFIG);
+      expect(themes).toHaveLength(5);
+      expectedThemes.forEach((theme) => {
+        expect(themes).toContain(theme);
+      });
+    });
+
+    it.each(expectedThemes)('theme "%s" has required fields', (theme) => {
+      const config = THEME_CONFIG[theme];
+
+      expect(config).toHaveProperty('label');
+      expect(config).toHaveProperty('icon');
+      expect(config).toHaveProperty('description');
+
+      expect(typeof config.label).toBe('string');
+      expect(typeof config.icon).toBe('string');
+      expect(typeof config.description).toBe('string');
+
+      expect(config.label.length).toBeGreaterThan(0);
+      expect(config.icon.length).toBeGreaterThan(0);
+      expect(config.description.length).toBeGreaterThan(0);
+    });
+
+    it('has correct labels for each theme', () => {
+      expect(THEME_CONFIG.kitchen.label).toBe('Kitchen');
+      expect(THEME_CONFIG.workshop.label).toBe('Workshop');
+      expect(THEME_CONFIG.office.label).toBe('Office');
+      expect(THEME_CONFIG.hobby.label).toBe('Hobby');
+      expect(THEME_CONFIG.personal.label).toBe('Personal');
+    });
+
+    it('has unique labels', () => {
+      const labels = Object.values(THEME_CONFIG).map((c) => c.label);
+      const uniqueLabels = new Set(labels);
+      expect(uniqueLabels.size).toBe(labels.length);
+    });
+
+    it('has unique icons', () => {
+      const icons = Object.values(THEME_CONFIG).map((c) => c.icon);
+      const uniqueIcons = new Set(icons);
+      expect(uniqueIcons.size).toBe(icons.length);
+    });
+  });
+
+  describe('FEATURE_CONFIG', () => {
+    const expectedFeatures: LayoutFeature[] = [
+      'multiple-layers',
+      'half-bins',
+      'labeled-bins',
+      'clearance-height',
+      'multiple-categories',
+    ];
+
+    it('has all 5 features', () => {
+      const features = Object.keys(FEATURE_CONFIG);
+      expect(features).toHaveLength(5);
+      expectedFeatures.forEach((feature) => {
+        expect(features).toContain(feature);
+      });
+    });
+
+    it.each(expectedFeatures)('feature "%s" has required fields', (feature) => {
+      const config = FEATURE_CONFIG[feature];
+
+      expect(config).toHaveProperty('label');
+      expect(config).toHaveProperty('description');
+
+      expect(typeof config.label).toBe('string');
+      expect(typeof config.description).toBe('string');
+
+      expect(config.label.length).toBeGreaterThan(0);
+      expect(config.description.length).toBeGreaterThan(0);
+    });
+
+    it('has user-friendly labels', () => {
+      expect(FEATURE_CONFIG['multiple-layers'].label).toBe('Multi-layer');
+      expect(FEATURE_CONFIG['half-bins'].label).toBe('Half-bins');
+      expect(FEATURE_CONFIG['labeled-bins'].label).toBe('Labeled');
+      expect(FEATURE_CONFIG['clearance-height'].label).toBe('Clearance');
+      expect(FEATURE_CONFIG['multiple-categories'].label).toBe('Categories');
+    });
+
+    it('has unique labels', () => {
+      const labels = Object.values(FEATURE_CONFIG).map((c) => c.label);
+      const uniqueLabels = new Set(labels);
+      expect(uniqueLabels.size).toBe(labels.length);
+    });
+
+    it('has descriptive descriptions', () => {
+      // Each description should be a full sentence (has spaces and reasonable length)
+      Object.values(FEATURE_CONFIG).forEach((config) => {
+        expect(config.description.includes(' ')).toBe(true);
+        expect(config.description.length).toBeGreaterThan(15);
+      });
+    });
+  });
+});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -31,5 +31,5 @@
     "noUncheckedSideEffectImports": true
   },
   "include": ["src"],
-  "exclude": ["src/test"]
+  "exclude": ["src/test", "**/__tests__"]
 }


### PR DESCRIPTION
## Summary
Add 188 tests providing comprehensive test coverage for the inspiration-gallery feature.

### Unit Tests
- `layoutBuilder.test.ts` (44 tests): Tests for `createBin`, `createLayer`, `createCategory`, `computePreview`, `detectFeatures`, `calculateMetrics`, `buildInspirationLayout`
- `types.test.ts` (18 tests): Validates `THEME_CONFIG` and `FEATURE_CONFIG` have all required fields

### Component Tests
- `InspirationGallery.test.tsx` (32 tests): Modal behavior, theme filtering, grid display, keyboard navigation, accessibility, layout import
- `LayoutCard.test.tsx` (21 tests): Rendering, animations, click/keyboard interactions, accessibility
- `LayoutPreviewOverlay.test.tsx` (30 tests): Preview display, drawer comparison, related layouts, interactions, focus management
- `LayoutThumbnailWithLabels.test.tsx` (26 tests): SVG rendering, bin positioning, label display, staging filtering, contrast colors
- `ThemeFilterPills.test.tsx` (17 tests): Rendering, selection state, interactions

### Coverage Results
| File | Statements | Branches | Functions |
|------|------------|----------|-----------|
| layoutBuilder.ts | 100% | 100% | 100% |
| LayoutCard.tsx | 100% | 100% | 100% |
| ThemeFilterPills.tsx | 100% | 100% | 100% |
| LayoutPreviewOverlay.tsx | 100% | 76.47% | 100% |
| LayoutThumbnailWithLabels.tsx | 94.73% | 88.88% | 100% |
| InspirationGallery.tsx | 67.2% | 51.31% | 93.54% |

### Other Changes
- Updates `tsconfig.app.json` to exclude colocated `__tests__` directories from the build (test files handled by vitest's separate config)

## Test Plan
- [x] All 188 new tests pass
- [x] All 3851 existing tests pass
- [x] Coverage thresholds still met
- [x] Build succeeds

Note: The pre-existing flaky performance test in `history.test.ts` occasionally fails due to timing (expects <200ms but sometimes takes ~380ms). This is unrelated to these changes.