### PR TITLE
feat: add quality feedback signals with confidence breakdown (ML PR 5)

### DIFF
--- a/api/ml-telemetry.ts
+++ b/api/ml-telemetry.ts
@@ -29,6 +29,12 @@
  * === Quality Signals ===
  * - ml:quality:{signal}       → Quality signal counts
  * - ml:quality_layouts        → Layouts by quality signal type
+ * - ml:quality_confidence     → Confidence score distribution buckets
+ * - ml:quality_conf_by_signal:{signal} → Confidence by signal type
+ * - ml:quality_score:{score_name} → Individual score distributions (undo, completion, session, correction)
+ * - ml:abandonment            → Abandonment type distribution (incomplete, deleted, dormant, superseded)
+ * - ml:abandonment_age:{type} → Abandonment by layout age
+ * - ml:quality_dormancy       → Time since last edit buckets (active, recent, idle, dormant)
  *
  * === Category Changes ===
  * - ml:cat_sizes:{cat_hash}   → Bin sizes assigned to each category (by name hash)
@@ -175,11 +181,24 @@ interface LayoutSnapshotEvent {
   vocab_version: string;
 }
 
+interface ConfidenceBreakdown {
+  undo_score: number;
+  completion_score: number;
+  session_score: number;
+  correction_score: number;
+  combined: number;
+}
+
+type AbandonmentType = 'incomplete' | 'deleted' | 'dormant' | 'superseded';
+
 interface LayoutQualityEvent {
   type: 'layout_quality';
   layout_hash: string;
-  signal: 'shared' | 'exported' | 'duplicated' | 'deleted' | 'revisited_edited' | 'revisited_kept';
+  signal: 'shared' | 'exported' | 'duplicated' | 'deleted' | 'revisited_edited' | 'revisited_kept' | 'modified';
   days_since_creation: number;
+  confidence_breakdown?: ConfidenceBreakdown;
+  abandonment_type: AbandonmentType | null;
+  time_since_last_edit_ms: number;
 }
 
 interface DrawerPurposeEvent {
@@ -446,7 +465,9 @@ const VALID_QUALITY_SIGNALS = new Set([
   'deleted',
   'revisited_edited',
   'revisited_kept',
+  'modified',
 ]);
+const VALID_ABANDONMENT_TYPES = new Set(['incomplete', 'deleted', 'dormant', 'superseded']);
 const VALID_PURPOSES = new Set([
   'workshop',
   'electronics',
@@ -496,6 +517,24 @@ function validateEdgeUsage(value: unknown): value is EdgeUsage {
     typeof e.right === 'boolean' &&
     typeof e.top === 'boolean' &&
     typeof e.bottom === 'boolean'
+  );
+}
+
+/**
+ * Validate confidence breakdown object.
+ * All scores must be numbers between 0 and 1.
+ */
+function validateConfidenceBreakdown(value: unknown): value is ConfidenceBreakdown {
+  if (!value || typeof value !== 'object') return false;
+  const c = value as Record<string, unknown>;
+  const isValidScore = (v: unknown): boolean =>
+    typeof v === 'number' && v >= 0 && v <= 1;
+  return (
+    isValidScore(c.undo_score) &&
+    isValidScore(c.completion_score) &&
+    isValidScore(c.session_score) &&
+    isValidScore(c.correction_score) &&
+    isValidScore(c.combined)
   );
 }
 
@@ -682,7 +721,14 @@ function validateEvent(event: unknown): event is MLTelemetryEvent {
       VALID_QUALITY_SIGNALS.has(e.signal) &&
       typeof e.days_since_creation === 'number' &&
       e.days_since_creation >= 0 &&
-      e.days_since_creation < 10000
+      e.days_since_creation < 10000 &&
+      // New fields for PR 5
+      (e.confidence_breakdown === undefined || validateConfidenceBreakdown(e.confidence_breakdown)) &&
+      (e.abandonment_type === null ||
+        (typeof e.abandonment_type === 'string' && VALID_ABANDONMENT_TYPES.has(e.abandonment_type))) &&
+      typeof e.time_since_last_edit_ms === 'number' &&
+      e.time_since_last_edit_ms >= 0 &&
+      e.time_since_last_edit_ms < 86400000 // Max 24 hours
     );
   }
 
@@ -1197,7 +1243,7 @@ function aggregateLayoutSnapshot(event: LayoutSnapshotEvent, inc: Increments): v
 }
 
 function aggregateQualitySignal(event: LayoutQualityEvent, inc: Increments): void {
-  const { signal } = event;
+  const { signal, confidence_breakdown, abandonment_type, time_since_last_edit_ms } = event;
 
   // Track quality signal frequency
   inc['ml:quality'] = inc['ml:quality'] || {};
@@ -1218,6 +1264,49 @@ function aggregateQualitySignal(event: LayoutQualityEvent, inc: Increments): voi
   const ageKey = `ml:quality_age:${signal}`;
   inc[ageKey] = inc[ageKey] || {};
   inc[ageKey][ageBucket] = (inc[ageKey][ageBucket] || 0) + 1;
+
+  // Track confidence breakdown distribution (if provided)
+  if (confidence_breakdown) {
+    // Track combined confidence in buckets
+    const confBucket = confidence_breakdown.combined < 0.25 ? 'very_low' :
+      confidence_breakdown.combined < 0.5 ? 'low' :
+      confidence_breakdown.combined < 0.75 ? 'medium' : 'high';
+    inc['ml:quality_confidence'] = inc['ml:quality_confidence'] || {};
+    inc['ml:quality_confidence'][confBucket] = (inc['ml:quality_confidence'][confBucket] || 0) + 1;
+
+    // Track confidence by signal type (export/share with high confidence = good data)
+    const confBySignalKey = `ml:quality_conf_by_signal:${signal}`;
+    inc[confBySignalKey] = inc[confBySignalKey] || {};
+    inc[confBySignalKey][confBucket] = (inc[confBySignalKey][confBucket] || 0) + 1;
+
+    // Track individual score distributions for analysis
+    const scoreNames = ['undo_score', 'completion_score', 'session_score', 'correction_score'] as const;
+    for (const scoreName of scoreNames) {
+      const score = confidence_breakdown[scoreName];
+      const scoreBucket = score < 0.4 ? 'low' : score < 0.7 ? 'medium' : 'high';
+      const scoreKey = `ml:quality_score:${scoreName}`;
+      inc[scoreKey] = inc[scoreKey] || {};
+      inc[scoreKey][scoreBucket] = (inc[scoreKey][scoreBucket] || 0) + 1;
+    }
+  }
+
+  // Track abandonment patterns
+  if (abandonment_type) {
+    inc['ml:abandonment'] = inc['ml:abandonment'] || {};
+    inc['ml:abandonment'][abandonment_type] = (inc['ml:abandonment'][abandonment_type] || 0) + 1;
+
+    // Track abandonment by age (newer layouts abandoned more often = exploration)
+    const abandonAgeKey = `ml:abandonment_age:${abandonment_type}`;
+    inc[abandonAgeKey] = inc[abandonAgeKey] || {};
+    inc[abandonAgeKey][ageBucket] = (inc[abandonAgeKey][ageBucket] || 0) + 1;
+  }
+
+  // Track time since last edit (dormancy detection)
+  const dormancyBucket = time_since_last_edit_ms < 60_000 ? 'active' :
+    time_since_last_edit_ms < 300_000 ? 'recent' :
+    time_since_last_edit_ms < 1800_000 ? 'idle' : 'dormant';
+  inc['ml:quality_dormancy'] = inc['ml:quality_dormancy'] || {};
+  inc['ml:quality_dormancy'][dormancyBucket] = (inc['ml:quality_dormancy'][dormancyBucket] || 0) + 1;
 }
 
 function aggregateDrawerPurpose(event: DrawerPurposeEvent, inc: Increments): void {

--- a/src/shared/analytics/mlTelemetry.ts
+++ b/src/shared/analytics/mlTelemetry.ts
@@ -205,6 +205,33 @@ export interface LayoutSnapshotEvent {
 }
 
 /**
+ * Confidence breakdown - detailed quality scoring components.
+ * Helps ML understand WHY a layout is high/low quality.
+ */
+export interface ConfidenceBreakdown {
+  /** Score based on undo frequency (0-1, fewer undos = higher) */
+  undo_score: number;
+  /** Score based on fill % and labeling rate (0-1) */
+  completion_score: number;
+  /** Score based on session time spent (0-1) */
+  session_score: number;
+  /** Score based on quick correction rate (0-1, fewer = higher) */
+  correction_score: number;
+  /** Combined weighted score (0-1) */
+  combined: number;
+}
+
+/**
+ * Types of layout abandonment.
+ * Helps identify negative training signals.
+ */
+export type AbandonmentType =
+  | 'incomplete'   // User stopped mid-layout (low fill, short session)
+  | 'deleted'      // Layout was explicitly deleted
+  | 'dormant'      // Layout untouched for extended period
+  | 'superseded';  // Layout replaced by a newer version
+
+/**
  * Quality signal event - tracks what happens to layouts after creation.
  * Used to weight training data (shared layouts are higher quality).
  */
@@ -219,6 +246,15 @@ export interface LayoutQualityEvent {
 
   /** Days since layout was created */
   days_since_creation: number;
+
+  /** Detailed confidence breakdown (optional for backward compat) */
+  confidence_breakdown?: ConfidenceBreakdown;
+
+  /** Type of abandonment if applicable */
+  abandonment_type: AbandonmentType | null;
+
+  /** Milliseconds since last edit */
+  time_since_last_edit_ms: number;
 }
 
 /**
@@ -626,7 +662,8 @@ export type QualitySignal =
   | 'duplicated'       // Used as starting point
   | 'deleted'          // Negative signal
   | 'revisited_edited' // Came back and changed
-  | 'revisited_kept';  // Came back, no changes (validation)
+  | 'revisited_kept'   // Came back, no changes (validation)
+  | 'modified';        // Layout modified (for abandonment detection)
 
 // ============================================
 // DRAWER PURPOSE CONSTANTS
@@ -690,6 +727,8 @@ interface LayoutSessionState {
   resizeCount: number;
   /** Number of move operations this session */
   moveCount: number;
+  /** Timestamp of last edit action (placement, resize, move, delete) */
+  lastEditTime: number;
 }
 
 let layoutSession: LayoutSessionState = {
@@ -701,6 +740,7 @@ let layoutSession: LayoutSessionState = {
   deletedCount: 0,
   resizeCount: 0,
   moveCount: 0,
+  lastEditTime: Date.now(),
 };
 
 // Minimum time between snapshots for same layout (60 seconds)
@@ -830,6 +870,7 @@ export function resetMLSession(): void {
     deletedCount: 0,
     resizeCount: 0,
     moveCount: 0,
+    lastEditTime: Date.now(),
   };
 }
 
@@ -1185,6 +1226,9 @@ export function trackBinPlacement(
     sessionState.firstBinTime = Date.now();
   }
 
+  // Update last edit time for quality tracking
+  layoutSession.lastEditTime = Date.now();
+
   // Buffer event
   eventBuffer.push(event);
 
@@ -1507,11 +1551,23 @@ export function trackQualitySignal(
     daysSinceCreation = Math.floor((Date.now() - createdTime) / (1000 * 60 * 60 * 24));
   }
 
+  // Compute confidence breakdown
+  const confidenceBreakdown = computeConfidenceBreakdown(layout);
+
+  // Detect abandonment type
+  const abandonmentType = detectAbandonmentType(layout, signal);
+
+  // Calculate time since last edit
+  const timeSinceLastEditMs = Date.now() - layoutSession.lastEditTime;
+
   const event: LayoutQualityEvent = {
     type: 'layout_quality',
     layout_hash: layoutHash,
     signal,
     days_since_creation: daysSinceCreation,
+    confidence_breakdown: confidenceBreakdown,
+    abandonment_type: abandonmentType,
+    time_since_last_edit_ms: timeSinceLastEditMs,
   };
 
   eventBuffer.push(event);
@@ -1678,8 +1734,9 @@ export function trackBinResize(
     fill_pct: computeFillPercentage(layout),
   };
 
-  // Increment session resize count
+  // Increment session resize count and update last edit time
   layoutSession.resizeCount += batchSize;
+  layoutSession.lastEditTime = Date.now();
 
   eventBuffer.push(event);
 
@@ -1748,8 +1805,9 @@ export function trackBinDeletion(
     method,
   };
 
-  // Increment session deleted count
+  // Increment session deleted count and update last edit time
   layoutSession.deletedCount += batchSize;
+  layoutSession.lastEditTime = Date.now();
 
   eventBuffer.push(event);
 
@@ -1805,8 +1863,9 @@ export function trackBinMove(
     method,
   };
 
-  // Increment session move count
+  // Increment session move count and update last edit time
   layoutSession.moveCount += batchSize;
+  layoutSession.lastEditTime = Date.now();
 
   eventBuffer.push(event);
 
@@ -2286,6 +2345,131 @@ function computeSessionConfidence(
 
   // Round to 2 decimal places
   return Math.round(weighted * 100) / 100;
+}
+
+/**
+ * Compute detailed confidence breakdown for quality events.
+ * Provides per-component scores rather than just a combined value.
+ *
+ * @param layout - Current layout state
+ * @returns Confidence breakdown with individual component scores
+ */
+export function computeConfidenceBreakdown(layout: Layout): ConfidenceBreakdown {
+  const binsPlaced = layout.bins.filter((b) => b.layerId !== STAGING_ID).length;
+
+  // No bins = all scores at minimum
+  if (binsPlaced === 0) {
+    return {
+      undo_score: 0,
+      completion_score: 0,
+      session_score: 0,
+      correction_score: 0,
+      combined: 0,
+    };
+  }
+
+  // Undo score: fewer undos = higher score
+  // 0 undos = 1.0, 1-2 undos = 0.8, 3-5 undos = 0.6, 6+ undos = 0.4
+  const undoScore =
+    layoutSession.undoCount === 0
+      ? 1.0
+      : layoutSession.undoCount <= 2
+        ? 0.8
+        : layoutSession.undoCount <= 5
+          ? 0.6
+          : 0.4;
+
+  // Completion score: fill percentage + labeling rate
+  const fillPct = computeFillPercentage(layout);
+  const labeledBins = layout.bins.filter(
+    (b) => b.layerId !== STAGING_ID && b.label?.trim()
+  ).length;
+  const labelRate = binsPlaced > 0 ? labeledBins / binsPlaced : 0;
+
+  // Weight fill at 70%, labels at 30%
+  const completionScore = Math.round((fillPct * 0.7 + labelRate * 100 * 0.3)) / 100;
+
+  // Session score: time spent indicates deliberate work
+  const sessionDurationMs = Date.now() - layoutSession.startTime;
+  const binsPerMinute = binsPlaced / (sessionDurationMs / 60_000);
+  const sessionScore =
+    binsPerMinute > 2
+      ? 1.0 // >2 bins/min = efficient
+      : binsPerMinute > 0.5
+        ? 0.8 // 0.5-2 bins/min = normal
+        : binsPerMinute > 0.1
+          ? 0.6
+          : 0.4; // <0.1 = very slow/exploratory
+
+  // Correction score: ratio of corrections to bins placed
+  const totalCorrections =
+    layoutSession.deletedCount + layoutSession.resizeCount + layoutSession.moveCount;
+  const correctionRatio = totalCorrections / binsPlaced;
+  // 0 corrections = 1.0, <0.3 ratio = 0.8, <0.6 = 0.6, >=0.6 = 0.4
+  const correctionScore =
+    correctionRatio === 0
+      ? 1.0
+      : correctionRatio < 0.3
+        ? 0.8
+        : correctionRatio < 0.6
+          ? 0.6
+          : 0.4;
+
+  // Combined: weighted average (corrections matter most)
+  const weights = { undo: 0.2, completion: 0.25, session: 0.25, correction: 0.3 };
+  const combined =
+    undoScore * weights.undo +
+    completionScore * weights.completion +
+    sessionScore * weights.session +
+    correctionScore * weights.correction;
+
+  return {
+    undo_score: Math.round(undoScore * 100) / 100,
+    completion_score: Math.round(completionScore * 100) / 100,
+    session_score: Math.round(sessionScore * 100) / 100,
+    correction_score: Math.round(correctionScore * 100) / 100,
+    combined: Math.round(combined * 100) / 100,
+  };
+}
+
+/**
+ * Detect abandonment type based on layout state and session context.
+ *
+ * @param layout - Current layout state
+ * @param signal - Quality signal being tracked
+ * @returns Abandonment type or null if not abandoned
+ */
+export function detectAbandonmentType(
+  layout: Layout,
+  signal: QualitySignal
+): AbandonmentType | null {
+  const binsOnGrid = layout.bins.filter((b) => b.layerId !== STAGING_ID);
+  const fillPct = computeFillPercentage(layout);
+  const timeSinceLastEdit = Date.now() - layoutSession.lastEditTime;
+
+  // Dormant: no edits in last 30 minutes but session still active
+  const DORMANT_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
+  if (timeSinceLastEdit > DORMANT_THRESHOLD_MS && binsOnGrid.length > 0) {
+    return 'dormant';
+  }
+
+  // Incomplete: has bins but very low fill rate (<20%) and not saved/exported
+  if (signal === 'modified' && fillPct < 20 && binsOnGrid.length >= 2) {
+    return 'incomplete';
+  }
+
+  // Deleted: layout being cleared (delete signal with bins present)
+  if (signal === 'modified' && binsOnGrid.length === 0 && layoutSession.deletedCount > 0) {
+    return 'deleted';
+  }
+
+  // Superseded: layout switch without save (detected elsewhere)
+  // This would be set by the caller when switching layouts without saving
+  if (signal === 'modified' && layoutSession.editCount > 0 && fillPct < 10) {
+    return 'superseded';
+  }
+
+  return null;
 }
 
 /**

--- a/src/test/analytics/mlTelemetry.test.ts
+++ b/src/test/analytics/mlTelemetry.test.ts
@@ -24,6 +24,8 @@ import {
   trackPlacementRejection,
   trackQuickCorrection,
   recordBinCreation,
+  computeConfidenceBreakdown,
+  detectAbandonmentType,
 } from '@/shared/analytics/mlTelemetry';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
 import type { Layout } from '@/core/types';
@@ -157,6 +159,133 @@ describe('mlTelemetry', () => {
       const createdAt = Date.now() - (7 * 24 * 60 * 60 * 1000); // 7 days ago
       trackQualitySignal(layout, 'exported', createdAt);
       expect(getBufferSize()).toBeGreaterThan(0);
+    });
+
+    it('tracks modified signal for abandonment detection', () => {
+      const layout = createTestLayoutWithBins(3);
+      trackQualitySignal(layout, 'modified');
+      expect(getBufferSize()).toBeGreaterThan(0);
+    });
+  });
+
+  describe('computeConfidenceBreakdown', () => {
+    it('returns zero scores for empty layout', () => {
+      const layout = createDefaultLayout();
+      layout.bins = [];
+      const breakdown = computeConfidenceBreakdown(layout);
+      expect(breakdown.undo_score).toBe(0);
+      expect(breakdown.completion_score).toBe(0);
+      expect(breakdown.session_score).toBe(0);
+      expect(breakdown.correction_score).toBe(0);
+      expect(breakdown.combined).toBe(0);
+    });
+
+    it('returns high scores for layout with bins and no corrections', () => {
+      const layout = createTestLayoutWithBins(5);
+      resetMLSession(); // Fresh session with no corrections
+      const breakdown = computeConfidenceBreakdown(layout);
+      expect(breakdown.undo_score).toBe(1); // No undos
+      expect(breakdown.correction_score).toBe(1); // No corrections
+      expect(breakdown.combined).toBeGreaterThan(0.5);
+    });
+
+    it('returns scores between 0 and 1', () => {
+      const layout = createTestLayoutWithBins(10);
+      const breakdown = computeConfidenceBreakdown(layout);
+      expect(breakdown.undo_score).toBeGreaterThanOrEqual(0);
+      expect(breakdown.undo_score).toBeLessThanOrEqual(1);
+      expect(breakdown.completion_score).toBeGreaterThanOrEqual(0);
+      expect(breakdown.completion_score).toBeLessThanOrEqual(1);
+      expect(breakdown.session_score).toBeGreaterThanOrEqual(0);
+      expect(breakdown.session_score).toBeLessThanOrEqual(1);
+      expect(breakdown.correction_score).toBeGreaterThanOrEqual(0);
+      expect(breakdown.correction_score).toBeLessThanOrEqual(1);
+      expect(breakdown.combined).toBeGreaterThanOrEqual(0);
+      expect(breakdown.combined).toBeLessThanOrEqual(1);
+    });
+
+    it('includes fill percentage in completion score', () => {
+      // Layout with bins should have higher completion than empty
+      const layoutWithBins = createTestLayoutWithBins(20);
+      const emptyLayout = createDefaultLayout();
+      emptyLayout.bins = [];
+
+      const withBinsBreakdown = computeConfidenceBreakdown(layoutWithBins);
+      const emptyBreakdown = computeConfidenceBreakdown(emptyLayout);
+
+      // Empty layout has 0 for all
+      expect(emptyBreakdown.completion_score).toBe(0);
+      // Layout with bins should have positive completion score
+      expect(withBinsBreakdown.completion_score).toBeGreaterThan(0);
+    });
+  });
+
+  describe('detectAbandonmentType', () => {
+    it('returns null for active layouts with good fill', () => {
+      const layout = createTestLayoutWithBins(20);
+      resetMLSession();
+      const abandonmentType = detectAbandonmentType(layout, 'shared');
+      expect(abandonmentType).toBeNull();
+    });
+
+    it('detects deleted abandonment when bins cleared', () => {
+      // Start with bins, then clear them
+      resetMLSession();
+      // Simulate deletions
+      const layout = createDefaultLayout();
+      layout.bins = [];
+      // Track some deletions first
+      const testBin = {
+        id: 'test-bin',
+        x: 0,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        layerId: layout.layers[0].id,
+        category: layout.categories[0].id,
+      };
+      trackBinDeletion(testBin, layout, 'key', 1);
+
+      const abandonmentType = detectAbandonmentType(layout, 'modified');
+      expect(abandonmentType).toBe('deleted');
+    });
+
+    it('detects incomplete abandonment for low fill layouts', () => {
+      const layout = createDefaultLayout();
+      // Add just 2 bins for very low fill
+      layout.bins = [
+        {
+          id: 'bin-1',
+          x: 0,
+          y: 0,
+          width: 1,
+          depth: 1,
+          height: 1,
+          layerId: layout.layers[0].id,
+          category: layout.categories[0].id,
+        },
+        {
+          id: 'bin-2',
+          x: 1,
+          y: 0,
+          width: 1,
+          depth: 1,
+          height: 1,
+          layerId: layout.layers[0].id,
+          category: layout.categories[0].id,
+        },
+      ];
+      resetMLSession();
+      const abandonmentType = detectAbandonmentType(layout, 'modified');
+      expect(abandonmentType).toBe('incomplete');
+    });
+
+    it('returns null for shared signals (positive intent)', () => {
+      const layout = createTestLayoutWithBins(5);
+      resetMLSession();
+      const abandonmentType = detectAbandonmentType(layout, 'shared');
+      expect(abandonmentType).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- Add confidence breakdown scoring system with individual component scores (undo, completion, session, correction)
- Add abandonment type detection (incomplete, deleted, dormant, superseded)
- Add 'modified' quality signal for abandonment tracking
- Track lastEditTime for dormancy detection
- Enhance backend aggregation with new Redis keys for confidence and abandonment patterns

## New Redis Keys
- `ml:quality_confidence` - combined confidence distribution buckets
- `ml:quality_conf_by_signal:{signal}` - confidence by signal type
- `ml:quality_score:{score_name}` - individual score distributions (undo, completion, session, correction)
- `ml:abandonment` - abandonment type distribution
- `ml:abandonment_age:{type}` - abandonment by layout age
- `ml:quality_dormancy` - time since last edit buckets (active, recent, idle, dormant)

## Test plan
- [x] Build succeeds
- [x] All 3356 tests pass
- [x] Coverage thresholds met (83%+ lines)
- [x] New unit tests for computeConfidenceBreakdown() and detectAbandonmentType()

## Dependencies
- Depends on PR 1: Session Workflow Metrics (merged)
- Depends on PR 2: Layout Pattern Detection (merged)