### PR TITLE
refactor: standardize API layer error handling and reduce duplication

### DIFF
--- a/api/lib/rateLimit.ts
+++ b/api/lib/rateLimit.ts
@@ -2,7 +2,7 @@ import type { RedisOptions } from 'ioredis';
 import Redis from 'ioredis';
 
 export type RateLimitAction =
-  | 'create' | 'update' | 'view' | 'delete' | 'report';
+  | 'create' | 'update' | 'view' | 'delete' | 'report' | 'telemetry';
 
 /**
  * Parse Redis URL using WHATWG URL API to avoid deprecated url.parse().
@@ -31,6 +31,7 @@ const RATE_LIMITS: Record<RateLimitAction, RateLimitConfig> = {
   view: { limit: 100, windowSeconds: 60 },         // 100/minute
   delete: { limit: 100, windowSeconds: 60 },       // 100/minute (dev friendly)
   report: { limit: 10, windowSeconds: 3600 },      // 10/hour
+  telemetry: { limit: 100, windowSeconds: 60 },    // 100/minute (ML telemetry)
 };
 
 interface RateLimitResult {

--- a/api/lib/shared.ts
+++ b/api/lib/shared.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared utilities for API endpoints.
+ *
+ * This module consolidates common functionality used across multiple API routes:
+ * - ID validation (layout/share IDs)
+ * - Token hashing for authentication
+ * - Shared type definitions
+ */
+
+/**
+ * Validate a layout/share ID format.
+ * Supports multiple formats for backwards compatibility:
+ * - Standard UUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (older layouts)
+ * - Base36 timestamp: {timestamp}-{random 7 chars} e.g., "lszwz1k7v-8j2kqp1"
+ * - Legacy 12-char: alphanumeric only
+ */
+export function isValidShareId(id: unknown): id is string {
+  if (typeof id !== 'string') return false;
+  // Standard UUID format (8-4-4-4-12 hex chars)
+  if (/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(id)) return true;
+  // Base36 timestamp format (variable length + hyphen + 7 chars)
+  if (/^[a-z0-9]+-[a-z0-9]{7}$/.test(id)) return true;
+  // Legacy 12-char alphanumeric format
+  if (/^[a-zA-Z0-9]{12}$/.test(id)) return true;
+  return false;
+}
+
+/**
+ * Hash a delete token using SHA-256 with server salt.
+ * Uses Web Crypto API (available in Vercel Edge/Node).
+ *
+ * @throws Error if TOKEN_SALT environment variable is not configured
+ */
+export async function hashToken(token: string): Promise<string> {
+  const salt = process.env.TOKEN_SALT;
+  if (!salt) {
+    throw new Error('TOKEN_SALT environment variable must be configured');
+  }
+  const data = new TextEncoder().encode(salt + token);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Generate a 32-character hex delete token (128-bit entropy).
+ */
+export function generateDeleteToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * Standard error codes used across all API endpoints.
+ * These map to client-side ApiError types.
+ */
+export const ErrorCode = {
+  // Validation errors (4xx)
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  NOT_FOUND: 'NOT_FOUND',
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  RATE_LIMITED: 'RATE_LIMITED',
+  METHOD_NOT_ALLOWED: 'METHOD_NOT_ALLOWED',
+  SIZE_LIMIT: 'SIZE_LIMIT',
+  BIN_LIMIT: 'BIN_LIMIT',
+  CONTENT_BLOCKED: 'CONTENT_BLOCKED',
+  EXPIRED: 'EXPIRED',
+  INVALID_PERMISSION: 'INVALID_PERMISSION',
+
+  // Server errors (5xx)
+  SERVER_ERROR: 'SERVER_ERROR',
+  CONFIGURATION_ERROR: 'CONFIGURATION_ERROR',
+
+  // Network errors (client-side only, not returned by server)
+  // NETWORK_ERROR is reserved for client-side fetch failures
+} as const;
+
+export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+/**
+ * Standard error response shape for all API endpoints.
+ */
+export interface ApiErrorResponse {
+  error: string;
+  code: ErrorCodeType;
+  retryAfter?: number;
+}
+
+/**
+ * Shared metadata structure for stored shares.
+ */
+export interface ShareMetadata {
+  deleteTokenHash: string;
+  createdAt: string;
+  lastUpdatedAt: string;
+  lastAccessedAt: string;
+  permission: 'view' | 'edit';
+  authorName?: string;
+  reportCount: number;
+}
+
+/**
+ * Shared data structure for stored shares.
+ */
+export interface ShareData {
+  layout: unknown;
+  metadata: ShareMetadata;
+}

--- a/api/liveblocks-auth.ts
+++ b/api/liveblocks-auth.ts
@@ -1,6 +1,7 @@
 import { Liveblocks } from '@liveblocks/node';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP } from './lib/rateLimit.js';
+import { ErrorCode } from './lib/shared.js';
 
 /**
  * Liveblocks authentication endpoint.
@@ -64,7 +65,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Only allow POST
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
-    return res.status(405).json({ error: 'Method not allowed', code: 'METHOD_NOT_ALLOWED' });
+    return res.status(405).json({ error: 'Method not allowed', code: ErrorCode.METHOD_NOT_ALLOWED });
   }
 
   try {
@@ -73,7 +74,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       console.error('LIVEBLOCKS_SECRET_KEY not configured');
       return res.status(500).json({
         error: 'Collaboration not configured',
-        code: 'CONFIGURATION_ERROR',
+        code: ErrorCode.CONFIGURATION_ERROR,
       });
     }
 
@@ -84,7 +85,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!rateLimit.allowed) {
       return res.status(429).json({
         error: 'Too many requests. Try again later.',
-        code: 'RATE_LIMITED',
+        code: ErrorCode.RATE_LIMITED,
         retryAfter: rateLimit.retryAfterSeconds,
       });
     }
@@ -96,14 +97,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!room || typeof room !== 'string') {
       return res.status(400).json({
         error: 'Missing room ID',
-        code: 'VALIDATION_ERROR',
+        code: ErrorCode.VALIDATION_ERROR,
       });
     }
 
     if (!room.startsWith('gridfinity-')) {
       return res.status(400).json({
         error: 'Invalid room ID format',
-        code: 'VALIDATION_ERROR',
+        code: ErrorCode.VALIDATION_ERROR,
       });
     }
 
@@ -112,7 +113,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (shareId.length !== 12) {
       return res.status(400).json({
         error: 'Invalid share ID',
-        code: 'VALIDATION_ERROR',
+        code: ErrorCode.VALIDATION_ERROR,
       });
     }
 
@@ -120,7 +121,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!userId || typeof userId !== 'string') {
       return res.status(400).json({
         error: 'Missing user ID',
-        code: 'VALIDATION_ERROR',
+        code: ErrorCode.VALIDATION_ERROR,
       });
     }
 
@@ -148,7 +149,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     console.error('Liveblocks auth error:', error);
     return res.status(500).json({
       error: 'Authentication failed',
-      code: 'SERVER_ERROR',
+      code: ErrorCode.SERVER_ERROR,
     });
   }
 }

--- a/api/ml-telemetry.ts
+++ b/api/ml-telemetry.ts
@@ -113,6 +113,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type { RedisOptions } from 'ioredis';
 import Redis from 'ioredis';
+import { getClientIP } from './lib/rateLimit.js';
 
 // ============================================
 // TYPES
@@ -427,10 +428,11 @@ function getRedis(): Redis | null {
 // ============================================
 
 /**
- * Simple rate limiting using IP hash.
+ * Internal rate limiting for ML telemetry endpoint.
+ * Uses the same Redis client as aggregation operations.
  * 100 requests per minute per IP.
  */
-async function checkRateLimit(ip: string, client: Redis): Promise<boolean> {
+async function checkRateLimitInternal(ip: string, client: Redis): Promise<boolean> {
   const hashedIP = hashIP(ip);
   const key = `ml_ratelimit:${hashedIP}`;
   const now = Math.floor(Date.now() / 1000);
@@ -2014,11 +2016,9 @@ export default async function handler(
   }
 
   // Rate limiting
-  const ip = (req.headers['x-forwarded-for'] as string)?.split(',')[0] ||
-    req.socket?.remoteAddress ||
-    'unknown';
+  const ip = getClientIP(req);
 
-  const allowed = await checkRateLimit(ip, client);
+  const allowed = await checkRateLimitInternal(ip, client);
   if (!allowed) {
     res.status(429).json({ error: 'Rate limit exceeded' });
     return;

--- a/api/report/[id].ts
+++ b/api/report/[id].ts
@@ -2,43 +2,17 @@ import { put, head } from '@vercel/blob';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP } from '../lib/rateLimit.js';
 import { REPORT_THRESHOLD } from '../lib/contentFilter.js';
-
-interface ShareMetadata {
-  deleteTokenHash: string;
-  expiresAt: string;
-  expiresInDays: number;
-  createdAt: string;
-  authorName?: string;
-  reportCount: number;
-}
-
-interface ShareData {
-  layout: unknown;
-  metadata: ShareMetadata;
-}
-
-/**
- * Validate share ID format.
- * Supports multiple formats for backwards compatibility:
- * - Standard UUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (older layouts)
- * - Base36 timestamp: {timestamp}-{random 7 chars}
- * - Legacy 12-char: alphanumeric only
- */
-function isValidShareId(id: string): boolean {
-  // Standard UUID format (8-4-4-4-12 hex chars)
-  if (/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(id)) return true;
-  // Base36 timestamp format
-  if (/^[a-z0-9]+-[a-z0-9]{7}$/.test(id)) return true;
-  // Legacy 12-char alphanumeric format
-  if (/^[a-zA-Z0-9]{12}$/.test(id)) return true;
-  return false;
-}
+import {
+  isValidShareId,
+  ErrorCode,
+  type ShareData,
+} from '../lib/shared.js';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Only allow POST for reports
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
-    return res.status(405).json({ error: 'Method not allowed', code: 'METHOD_NOT_ALLOWED' });
+    return res.status(405).json({ error: 'Method not allowed', code: ErrorCode.METHOD_NOT_ALLOWED });
   }
 
   const { id } = req.query;
@@ -46,7 +20,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (typeof id !== 'string' || !isValidShareId(id)) {
     return res.status(400).json({
       error: 'Invalid share ID',
-      code: 'VALIDATION_ERROR',
+      code: ErrorCode.VALIDATION_ERROR,
     });
   }
 
@@ -58,7 +32,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!rateLimit.allowed) {
       return res.status(429).json({
         error: 'Too many reports. Try again later.',
-        code: 'RATE_LIMITED',
+        code: ErrorCode.RATE_LIMITED,
         retryAfter: rateLimit.retryAfterSeconds,
       });
     }
@@ -75,7 +49,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!blobInfo) {
       return res.status(404).json({
         error: 'Share not found',
-        code: 'NOT_FOUND',
+        code: ErrorCode.NOT_FOUND,
       });
     }
 
@@ -83,7 +57,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!response.ok) {
       return res.status(404).json({
         error: 'Share not found',
-        code: 'NOT_FOUND',
+        code: ErrorCode.NOT_FOUND,
       });
     }
 
@@ -133,7 +107,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     console.error('Report error:', error);
     return res.status(500).json({
       error: 'Failed to submit report',
-      code: 'NETWORK_ERROR',
+      code: ErrorCode.SERVER_ERROR,
     });
   }
 }

--- a/api/share.ts
+++ b/api/share.ts
@@ -3,70 +3,19 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP } from './lib/rateLimit.js';
 import { validateShareLayout } from './lib/validation.js';
 import { filterLayoutContent } from './lib/contentFilter.js';
-
-/**
- * Validate a layout ID format.
- * Supports multiple formats for backwards compatibility:
- * - Standard UUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (older layouts)
- * - Base36 timestamp: {timestamp}-{random 7 chars} e.g., "lszwz1k7v-8j2kqp1"
- * - Legacy 12-char: alphanumeric only
- */
-function isValidLayoutId(id: unknown): id is string {
-  if (typeof id !== 'string') return false;
-  // Standard UUID format (8-4-4-4-12 hex chars)
-  if (/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(id)) return true;
-  // Base36 timestamp format (variable length + hyphen + 7 chars)
-  if (/^[a-z0-9]+-[a-z0-9]{7}$/.test(id)) return true;
-  // Legacy 12-char alphanumeric format
-  if (/^[a-zA-Z0-9]{12}$/.test(id)) return true;
-  return false;
-}
-
-/**
- * Generate a 32-character hex delete token (128-bit entropy).
- */
-function generateDeleteToken(): string {
-  const bytes = crypto.getRandomValues(new Uint8Array(16));
-  return Array.from(bytes)
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
-}
-
-/**
- * Hash a delete token using SHA-256 with server salt.
- * Uses Web Crypto API (available in Vercel Edge/Node).
- */
-async function hashToken(token: string): Promise<string> {
-  const salt = process.env.TOKEN_SALT;
-  if (!salt) {
-    throw new Error('TOKEN_SALT environment variable must be configured');
-  }
-  const data = new TextEncoder().encode(salt + token);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-}
-
-interface ShareMetadata {
-  deleteTokenHash: string;
-  createdAt: string;
-  lastUpdatedAt: string;
-  lastAccessedAt: string;
-  permission: 'view' | 'edit';
-  authorName?: string;
-  reportCount: number;
-}
-
-interface ShareData {
-  layout: unknown;
-  metadata: ShareMetadata;
-}
+import {
+  isValidShareId,
+  hashToken,
+  generateDeleteToken,
+  ErrorCode,
+  type ShareData,
+} from './lib/shared.js';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Only allow POST for creating shares
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
-    return res.status(405).json({ error: 'Method not allowed', code: 'METHOD_NOT_ALLOWED' });
+    return res.status(405).json({ error: 'Method not allowed', code: ErrorCode.METHOD_NOT_ALLOWED });
   }
 
   try {
@@ -77,7 +26,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!rateLimit.allowed) {
       return res.status(429).json({
         error: 'Too many shares created. Try again later.',
-        code: 'RATE_LIMITED',
+        code: ErrorCode.RATE_LIMITED,
         retryAfter: rateLimit.retryAfterSeconds,
       });
     }
@@ -88,15 +37,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!layout) {
       return res.status(400).json({
         error: 'Missing layout data',
-        code: 'VALIDATION_ERROR',
+        code: ErrorCode.VALIDATION_ERROR,
       });
     }
 
     // Validate layoutId - must be provided by client
-    if (!isValidLayoutId(layoutId)) {
+    if (!isValidShareId(layoutId)) {
       return res.status(400).json({
         error: 'Invalid or missing layoutId. Must be a 12-character alphanumeric string.',
-        code: 'VALIDATION_ERROR',
+        code: ErrorCode.VALIDATION_ERROR,
       });
     }
 
@@ -104,7 +53,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (permission !== 'view' && permission !== 'edit') {
       return res.status(400).json({
         error: 'Invalid permission. Must be "view" or "edit".',
-        code: 'VALIDATION_ERROR',
+        code: ErrorCode.VALIDATION_ERROR,
       });
     }
 
@@ -171,7 +120,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     console.error('Share creation error:', error);
     return res.status(500).json({
       error: 'Failed to create share',
-      code: 'NETWORK_ERROR',
+      code: ErrorCode.SERVER_ERROR,
     });
   }
 }

--- a/api/share/[id].ts
+++ b/api/share/[id].ts
@@ -3,52 +3,12 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP } from '../lib/rateLimit.js';
 import { validateShareLayout } from '../lib/validation.js';
 import { filterLayoutContent } from '../lib/contentFilter.js';
-
-interface ShareMetadata {
-  deleteTokenHash: string;
-  createdAt: string;
-  lastUpdatedAt: string;
-  lastAccessedAt: string;
-  permission: 'view' | 'edit';
-  authorName?: string;
-  reportCount: number;
-}
-
-interface ShareData {
-  layout: unknown;
-  metadata: ShareMetadata;
-}
-
-/**
- * Hash a delete token using SHA-256 with server salt.
- */
-async function hashToken(token: string): Promise<string> {
-  const salt = process.env.TOKEN_SALT;
-  if (!salt) {
-    throw new Error('TOKEN_SALT environment variable must be configured');
-  }
-  const data = new TextEncoder().encode(salt + token);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-}
-
-/**
- * Validate share ID format.
- * Supports multiple formats for backwards compatibility:
- * - Standard UUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (older layouts)
- * - Base36 timestamp: {timestamp}-{random 7 chars}
- * - Legacy 12-char: alphanumeric only
- */
-function isValidShareId(id: string): boolean {
-  // Standard UUID format (8-4-4-4-12 hex chars)
-  if (/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(id)) return true;
-  // Base36 timestamp format
-  if (/^[a-z0-9]+-[a-z0-9]{7}$/.test(id)) return true;
-  // Legacy 12-char alphanumeric format
-  if (/^[a-zA-Z0-9]{12}$/.test(id)) return true;
-  return false;
-}
+import {
+  isValidShareId,
+  hashToken,
+  ErrorCode,
+  type ShareData,
+} from '../lib/shared.js';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { id } = req.query;
@@ -56,7 +16,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (typeof id !== 'string' || !isValidShareId(id)) {
     return res.status(400).json({
       error: 'Invalid share ID',
-      code: 'VALIDATION_ERROR',
+      code: ErrorCode.VALIDATION_ERROR,
     });
   }
 
@@ -71,7 +31,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return handleDelete(req, res, id, blobPath);
     default:
       res.setHeader('Allow', 'GET, PUT, DELETE');
-      return res.status(405).json({ error: 'Method not allowed', code: 'METHOD_NOT_ALLOWED' });
+      return res.status(405).json({ error: 'Method not allowed', code: ErrorCode.METHOD_NOT_ALLOWED });
   }
 }
 
@@ -92,7 +52,7 @@ async function handleGet(
     if (!rateLimit.allowed) {
       return res.status(429).json({
         error: 'Too many requests. Try again later.',
-        code: 'RATE_LIMITED',
+        code: ErrorCode.RATE_LIMITED,
         retryAfter: rateLimit.retryAfterSeconds,
       });
     }
@@ -102,7 +62,7 @@ async function handleGet(
     if (!blobInfo) {
       return res.status(404).json({
         error: 'Share not found',
-        code: 'NOT_FOUND',
+        code: ErrorCode.NOT_FOUND,
       });
     }
 
@@ -111,7 +71,7 @@ async function handleGet(
     if (!response.ok) {
       return res.status(404).json({
         error: 'Share not found',
-        code: 'NOT_FOUND',
+        code: ErrorCode.NOT_FOUND,
       });
     }
 
@@ -146,7 +106,7 @@ async function handleGet(
     console.error('Share fetch error:', error);
     return res.status(500).json({
       error: 'Failed to fetch share',
-      code: 'NETWORK_ERROR',
+      code: ErrorCode.SERVER_ERROR,
     });
   }
 }
@@ -168,7 +128,7 @@ async function handlePut(
     if (!rateLimit.allowed) {
       return res.status(429).json({
         error: 'Too many updates. Try again later.',
-        code: 'RATE_LIMITED',
+        code: ErrorCode.RATE_LIMITED,
         retryAfter: rateLimit.retryAfterSeconds,
       });
     }
@@ -178,7 +138,7 @@ async function handlePut(
     if (!deleteToken) {
       return res.status(401).json({
         error: 'Delete token required for updates',
-        code: 'UNAUTHORIZED',
+        code: ErrorCode.UNAUTHORIZED,
       });
     }
 
@@ -187,7 +147,7 @@ async function handlePut(
     if (!blobInfo) {
       return res.status(404).json({
         error: 'Share not found',
-        code: 'NOT_FOUND',
+        code: ErrorCode.NOT_FOUND,
       });
     }
 
@@ -195,7 +155,7 @@ async function handlePut(
     if (!response.ok) {
       return res.status(404).json({
         error: 'Share not found',
-        code: 'NOT_FOUND',
+        code: ErrorCode.NOT_FOUND,
       });
     }
 
@@ -206,7 +166,7 @@ async function handlePut(
     if (tokenHash !== existingData.metadata.deleteTokenHash) {
       return res.status(401).json({
         error: 'Invalid delete token',
-        code: 'UNAUTHORIZED',
+        code: ErrorCode.UNAUTHORIZED,
       });
     }
 
@@ -215,7 +175,7 @@ async function handlePut(
     if (newPermission !== 'view' && newPermission !== 'edit') {
       return res.status(400).json({
         error: 'Invalid permission. Must be "view" or "edit".',
-        code: 'VALIDATION_ERROR',
+        code: ErrorCode.VALIDATION_ERROR,
       });
     }
 
@@ -264,7 +224,7 @@ async function handlePut(
     if (!contentResult.passed) {
       return res.status(400).json({
         error: `Content blocked: ${contentResult.reason}`,
-        code: 'CONTENT_BLOCKED',
+        code: ErrorCode.CONTENT_BLOCKED,
       });
     }
 
@@ -296,7 +256,7 @@ async function handlePut(
     console.error('Share update error:', error);
     return res.status(500).json({
       error: 'Failed to update share',
-      code: 'NETWORK_ERROR',
+      code: ErrorCode.SERVER_ERROR,
     });
   }
 }
@@ -318,7 +278,7 @@ async function handleDelete(
     if (!rateLimit.allowed) {
       return res.status(429).json({
         error: 'Too many delete attempts. Try again later.',
-        code: 'RATE_LIMITED',
+        code: ErrorCode.RATE_LIMITED,
         retryAfter: rateLimit.retryAfterSeconds,
       });
     }
@@ -330,7 +290,7 @@ async function handleDelete(
     if (!deleteToken) {
       return res.status(401).json({
         error: 'Delete token required',
-        code: 'UNAUTHORIZED',
+        code: ErrorCode.UNAUTHORIZED,
       });
     }
 
@@ -339,7 +299,7 @@ async function handleDelete(
     if (!blobInfo) {
       return res.status(404).json({
         error: 'Share not found',
-        code: 'NOT_FOUND',
+        code: ErrorCode.NOT_FOUND,
       });
     }
 
@@ -347,7 +307,7 @@ async function handleDelete(
     if (!response.ok) {
       return res.status(404).json({
         error: 'Share not found',
-        code: 'NOT_FOUND',
+        code: ErrorCode.NOT_FOUND,
       });
     }
 
@@ -358,7 +318,7 @@ async function handleDelete(
     if (tokenHash !== existingData.metadata.deleteTokenHash) {
       return res.status(401).json({
         error: 'Invalid delete token',
-        code: 'UNAUTHORIZED',
+        code: ErrorCode.UNAUTHORIZED,
       });
     }
 
@@ -373,7 +333,7 @@ async function handleDelete(
     console.error('Share delete error:', error);
     return res.status(500).json({
       error: 'Failed to delete share',
-      code: 'NETWORK_ERROR',
+      code: ErrorCode.SERVER_ERROR,
     });
   }
 }

--- a/src/core/api/share.ts
+++ b/src/core/api/share.ts
@@ -50,9 +50,19 @@ export interface UpdateShareResponse {
 
 export interface ShareErrorResponse {
   error: string;
-  code: 'VALIDATION_ERROR' | 'SIZE_LIMIT' | 'BIN_LIMIT' | 'RATE_LIMITED' |
-        'CONTENT_BLOCKED' | 'NETWORK_ERROR' | 'NOT_FOUND' | 'UNAUTHORIZED' |
-        'EXPIRED' | 'INVALID_PERMISSION';
+  code:
+    | 'VALIDATION_ERROR'
+    | 'SIZE_LIMIT'
+    | 'BIN_LIMIT'
+    | 'RATE_LIMITED'
+    | 'CONTENT_BLOCKED'
+    | 'NOT_FOUND'
+    | 'UNAUTHORIZED'
+    | 'EXPIRED'
+    | 'INVALID_PERMISSION'
+    | 'SERVER_ERROR'
+    | 'CONFIGURATION_ERROR'
+    | 'METHOD_NOT_ALLOWED';
   retryAfter?: number;
 }
 
@@ -74,8 +84,6 @@ function mapShareErrorToApiError(error: ShareErrorResponse): ApiError {
       return apiNotFound();
     case 'UNAUTHORIZED':
       return apiUnauthorized();
-    case 'NETWORK_ERROR':
-      return apiNetworkError();
     case 'VALIDATION_ERROR':
       return apiValidationError();
     case 'EXPIRED':
@@ -83,6 +91,11 @@ function mapShareErrorToApiError(error: ShareErrorResponse): ApiError {
     case 'INVALID_PERMISSION':
       // Invalid permission errors are treated as validation errors
       return apiValidationError();
+    case 'SERVER_ERROR':
+    case 'CONFIGURATION_ERROR':
+    case 'METHOD_NOT_ALLOWED':
+      // Server-side errors
+      return apiServerError();
     default:
       return apiServerError();
   }


### PR DESCRIPTION
- Extract shared utilities to api/lib/shared.ts:
  - isValidShareId() for ID validation
  - hashToken() for delete token hashing
  - generateDeleteToken() for token generation
  - ErrorCode constants for consistent error codes
  - ShareData and ShareMetadata types

- Standardize error codes across all API endpoints:
  - Change 500 errors from NETWORK_ERROR to SERVER_ERROR
  - Add CONFIGURATION_ERROR for config issues
  - Use ErrorCode constants instead of string literals

- Fix ShareMetadata type mismatch in report/[id].ts:
  - Was using outdated fields (expiresAt, expiresInDays)
  - Now imports shared ShareData type

- Update ml-telemetry.ts to use shared getClientIP()

- Update client ShareErrorResponse to include:
  - SERVER_ERROR, CONFIGURATION_ERROR, METHOD_NOT_ALLOWED
  - Remove NETWORK_ERROR (only for client-side fetch failures)