### PR TITLE
refactor: move useStagingDragInteraction to interactions layer

### DIFF
--- a/src/features/grid-editor/hooks/useInteraction.ts
+++ b/src/features/grid-editor/hooks/useInteraction.ts
@@ -10,7 +10,7 @@ import { mapInteractionToHint } from '@/utils/interaction';
 import { useDrawInteraction } from '@/hooks/interactions/useDrawInteraction';
 import { useDragInteraction } from '@/hooks/interactions/useDragInteraction';
 import { useResizeInteraction } from '@/hooks/interactions/useResizeInteraction';
-import { useStagingDragInteraction } from '@/features/staging/hooks/useStagingDragInteraction';
+import { useStagingDragInteraction } from '@/hooks/interactions/useStagingDragInteraction';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
 import type { InteractionContext, ModeHandlers, DrawStartArgs, DragStartArgs, ResizeStartArgs, StagingDragStartArgs } from '@/hooks/interactions/types';
 

--- a/src/features/staging/hooks/index.ts
+++ b/src/features/staging/hooks/index.ts
@@ -1,2 +1,0 @@
-// Barrel export for staging hooks
-export { useStagingDragInteraction } from './useStagingDragInteraction';

--- a/src/features/staging/index.ts
+++ b/src/features/staging/index.ts
@@ -1,3 +1,2 @@
 // Barrel export for staging feature
 export * from './components';
-export * from './hooks';

--- a/src/hooks/interactions/index.ts
+++ b/src/hooks/interactions/index.ts
@@ -31,4 +31,4 @@ export type {
 export { useDrawInteraction } from './useDrawInteraction';
 export { useDragInteraction } from './useDragInteraction';
 export { useResizeInteraction } from './useResizeInteraction';
-export { useStagingDragInteraction } from '@/features/staging/hooks/useStagingDragInteraction';
+export { useStagingDragInteraction } from './useStagingDragInteraction';

--- a/src/hooks/interactions/useStagingDragInteraction.ts
+++ b/src/hooks/interactions/useStagingDragInteraction.ts
@@ -4,7 +4,7 @@ import { canPlaceBin, clamp } from '@/shared/utils/validation';
 import { capturePointer } from '@/utils/interaction';
 import { findBinById } from '@/utils/entity';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
-import type { InteractionContext, ModeHandlers, StagingDragStartArgs } from '@/hooks/interactions/types';
+import type { InteractionContext, ModeHandlers, StagingDragStartArgs } from './types';
 import type { Coord } from '@/core/types';
 
 /**


### PR DESCRIPTION
Move useStagingDragInteraction hook from feature-specific location
(src/features/staging/hooks/) to the app-level interactions layer
(src/hooks/interactions/) where it belongs with other interaction
mode handlers (draw, drag, resize).

This fixes a cross-feature import violation where grid-editor was
importing from the staging feature. The interaction system is
app-level infrastructure, and all mode handlers should be colocated.

Changes:
- Move useStagingDragInteraction.ts to src/hooks/interactions/
- Update barrel export to use local import instead of re-export
- Remove empty staging/hooks directory
- Update consuming imports in useInteraction.ts