### PR TITLE
fix: correct ML telemetry validation for user_hash and edit_to_done_ratio

### DIFF
--- a/api/ml-telemetry.ts
+++ b/api/ml-telemetry.ts
@@ -1023,7 +1023,7 @@ function validateEvent(event: unknown): event is MLTelemetryEvent {
       validateSizeSequenceArray(e.size_sequence) &&
       typeof e.edit_to_done_ratio === 'number' &&
       e.edit_to_done_ratio >= 0 &&
-      e.edit_to_done_ratio <= 1 && // Ratio is 0-1, not percentage
+      e.edit_to_done_ratio <= 100 && // Ratio can exceed 1.0 when edits > bins (e.g., heavy editing then deleting)
       typeof e.undo_count === 'number' &&
       e.undo_count >= 0 &&
       e.undo_count < 10000 &&
@@ -1043,8 +1043,10 @@ function validateEvent(event: unknown): event is MLTelemetryEvent {
   // ============================================
 
   if (e.type === 'cross_layout_pattern') {
-    // Validate user_hash (should be a simple alphanumeric string)
-    if (typeof e.user_hash !== 'string' || !/^[a-z0-9]{8,20}$/.test(e.user_hash)) {
+    // Validate user_hash (UUID format from crypto.randomUUID() or simple alphanumeric)
+    // UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (36 chars with hyphens)
+    // Simple format: 8-20 lowercase alphanumeric chars
+    if (typeof e.user_hash !== 'string' || !/^[a-z0-9-]{8,36}$/.test(e.user_hash)) {
       // Allow 'anonymous' as fallback
       if (e.user_hash !== 'anonymous') return false;
     }


### PR DESCRIPTION
## Summary

Fixes 20% validation failure rate in ML telemetry events by correcting two validation bugs identified via production data analysis.

### Changes

1. **user_hash validation** (cross_layout_pattern events - 415 failures)
   - Old: `/^[a-z0-9]{8,20}$/` - rejected UUIDs from `crypto.randomUUID()`
   - New: `/^[a-z0-9-]{8,36}$/` - accepts both UUID format and simple alphanumeric

2. **edit_to_done_ratio validation** (session_summary events - 114 failures)  
   - Old: `<= 1` - incorrectly assumed ratio can't exceed 1.0
   - New: `<= 100` - allows ratios > 1.0 when edits exceed final bin count (e.g., heavy editing then deleting)

### Production Impact

Before: 893 failed events / 4399 total = **20.3% failure rate**
After: Should reduce to near 0% for these event types

### Test Plan

- [x] Build passes
- [x] All 4054 tests pass
- [ ] Monitor ml:meta:validation:failed after deployment