### PR TITLE
perf: optimize O(n²) lookups in grid rendering components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useState, useCallback, Suspense } from 'react';
+import { useShallow } from 'zustand/shallow';
 import { useLayoutStore, useUIStore, useLibraryStore } from './core/store';
 import { useLayoutRouting, useAnalytics, useStorageMigration, useTabletPanels, useKeyboard } from './hooks';
 import { useAutoSave, useResponsive, useCrossTabSync, usePWAUpdate } from './shared/hooks';
@@ -95,7 +96,13 @@ export default function App() {
     closeRightPanel,
   } = useTabletPanels(isTablet);
 
-  const layout = useLayoutStore(state => state.layout);
+  // Performance: Only subscribe to the specific arrays we need, not the entire layout object
+  const { layers, categories } = useLayoutStore(
+    useShallow((state) => ({
+      layers: state.layout.layers,
+      categories: state.layout.categories,
+    }))
+  );
   const activeLayerId = useUIStore(state => state.activeLayerId);
   const activeCategoryId = useUIStore(state => state.activeCategoryId);
   const setActiveLayer = useUIStore(state => state.setActiveLayer);
@@ -104,16 +111,16 @@ export default function App() {
   // Initialize activeLayerId and activeCategoryId to valid values (sync before paint)
   useLayoutEffect(() => {
     // Check if current activeLayerId is valid for the current layout
-    const layerExists = layout.layers.some(l => l.id === activeLayerId);
-    if ((!activeLayerId || !layerExists) && layout.layers.length > 0) {
-      setActiveLayer(layout.layers[0].id);
+    const layerExists = layers.some(l => l.id === activeLayerId);
+    if ((!activeLayerId || !layerExists) && layers.length > 0) {
+      setActiveLayer(layers[0].id);
     }
     // Ensure activeCategoryId is valid for current layout
-    const categoryExists = layout.categories.some(c => c.id === activeCategoryId);
-    if (!categoryExists && layout.categories.length > 0) {
-      setActiveCategory(layout.categories[0].id);
+    const categoryExists = categories.some(c => c.id === activeCategoryId);
+    if (!categoryExists && categories.length > 0) {
+      setActiveCategory(categories[0].id);
     }
-  }, [activeLayerId, activeCategoryId, layout.layers, layout.categories, setActiveLayer, setActiveCategory]);
+  }, [activeLayerId, activeCategoryId, layers, categories, setActiveLayer, setActiveCategory]);
 
   // Global keyboard shortcuts
   useKeyboard();

--- a/src/features/grid-editor/components/Grid/GridCanvas.tsx
+++ b/src/features/grid-editor/components/Grid/GridCanvas.tsx
@@ -73,6 +73,20 @@ export function GridCanvas({ gridRef, cellSize, gap, onStartDraw, onStartDrag, o
     [activeLayerId, bins, layers]
   );
 
+  // Performance: Create O(1) lookup maps to avoid O(n²) .find() calls in render loops
+  const categoryMap = useMemo(
+    () => new Map(categories.map((c) => [c.id, c])),
+    [categories]
+  );
+  const layerMap = useMemo(
+    () => new Map(layers.map((l) => [l.id, l])),
+    [layers]
+  );
+  const binMap = useMemo(
+    () => new Map(bins.map((b) => [b.id, b])),
+    [bins]
+  );
+
   // Capture phase handler for paint mode - runs before Bin components can stop propagation
   const handlePointerDownCapture = (e: PointerEvent<HTMLDivElement>) => {
     if (e.button !== 0) return;
@@ -245,34 +259,28 @@ export function GridCanvas({ gridRef, cellSize, gap, onStartDraw, onStartDrag, o
         {fractionalCells}
 
         {/* Ghost bins (other layers) */}
-        {ghostBins.map((bin) => {
-          const category = categories.find((c) => c.id === bin.category);
-          const layer = layers.find((l) => l.id === bin.layerId);
-          return (
-            <Bin
-              key={bin.id}
-              bin={bin}
-              category={category}
-              layer={layer}
-              drawer={drawer}
-              cellSize={cellSize}
-              gap={gap}
-              halfBinMode={halfBinMode}
-              isGhost
-              isSelected={false}
-              onStartDrag={onStartDrag}
-              onStartResize={onStartResize}
-            />
-          );
-        })}
+        {ghostBins.map((bin) => (
+          <Bin
+            key={bin.id}
+            bin={bin}
+            category={categoryMap.get(bin.category)}
+            layer={layerMap.get(bin.layerId)}
+            drawer={drawer}
+            cellSize={cellSize}
+            gap={gap}
+            halfBinMode={halfBinMode}
+            isGhost
+            isSelected={false}
+            onStartDrag={onStartDrag}
+            onStartResize={onStartResize}
+          />
+        ))}
 
         {/* Blocked zones - bins from lower layers extending into this layer */}
         {blockedZones.map((zone) => {
-          const sourceBin = bins.find((b) => b.id === zone.sourceBinId);
-          const category = sourceBin
-            ? categories.find((c) => c.id === sourceBin.category)
-            : undefined;
-          const sourceLayer = sourceBin ? layers.find(l => l.id === sourceBin.layerId) : undefined;
+          const sourceBin = binMap.get(zone.sourceBinId);
+          const category = sourceBin ? categoryMap.get(sourceBin.category) : undefined;
+          const sourceLayer = sourceBin ? layerMap.get(sourceBin.layerId) : undefined;
 
           // Calculate grid position (always use standard grid, no scaling)
           // Apply same fractional edge positioning as bins
@@ -353,26 +361,22 @@ export function GridCanvas({ gridRef, cellSize, gap, onStartDraw, onStartDrag, o
         })}
 
         {/* Active layer bins */}
-        {activeBins.map((bin) => {
-          const category = categories.find((c) => c.id === bin.category);
-          const layer = layers.find((l) => l.id === bin.layerId);
-          return (
-            <Bin
-              key={bin.id}
-              bin={bin}
-              category={category}
-              layer={layer}
-              drawer={drawer}
-              cellSize={cellSize}
-              gap={gap}
-              halfBinMode={halfBinMode}
-              isGhost={false}
-              isSelected={selectedBinIds.includes(bin.id)}
-              onStartDrag={onStartDrag}
-              onStartResize={onStartResize}
-            />
-          );
-        })}
+        {activeBins.map((bin) => (
+          <Bin
+            key={bin.id}
+            bin={bin}
+            category={categoryMap.get(bin.category)}
+            layer={layerMap.get(bin.layerId)}
+            drawer={drawer}
+            cellSize={cellSize}
+            gap={gap}
+            halfBinMode={halfBinMode}
+            isGhost={false}
+            isSelected={selectedBinIds.includes(bin.id)}
+            onStartDrag={onStartDrag}
+            onStartResize={onStartResize}
+          />
+        ))}
       </div>
     </div>
   );

--- a/src/features/grid-editor/components/Grid/IsometricPreview.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview.tsx
@@ -143,6 +143,16 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
     [printBedSize, gridUnitMm]
   )
 
+  // Performance: Create O(1) lookup maps to avoid O(n²) .findIndex()/.find() calls in render loop
+  const layerIndexMap = useMemo(
+    () => new Map(layers.map((l, idx) => [l.id, idx])),
+    [layers]
+  )
+  const categoryMap = useMemo(
+    () => new Map(categories.map((c) => [c.id, c])),
+    [categories]
+  )
+
   // Convert layout bins to renderable format with layer filtering
   // Dependencies are specific properties (bins, layers, categories) not entire layout object
   const binsToRender = useMemo(() => {
@@ -160,11 +170,9 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
     for (const bin of bins) {
       if (bin.layerId === STAGING_ID) continue
 
-      // Filter bins based on layer view mode
+      // Filter bins based on layer view mode (O(1) lookup instead of O(n) findIndex)
       if (activeLayerIndex >= 0) {
-        const binLayerIndex = layers.findIndex(
-          (l) => l.id === bin.layerId
-        )
+        const binLayerIndex = layerIndexMap.get(bin.layerId) ?? -1
 
         switch (layerViewMode) {
           case 'focus':
@@ -183,7 +191,7 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
 
       const zStart =
         getLayerZStart(bin.layerId, layers) * heightToGridScale
-      const category = categories.find((c) => c.id === bin.category)
+      const category = categoryMap.get(bin.category)
       const baseColor = category?.color || DEFAULT_CATEGORY_COLOR
 
       // No dimming needed since focus mode now hides other layers entirely
@@ -233,7 +241,8 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
   }, [
     bins,
     layers,
-    categories,
+    categoryMap,
+    layerIndexMap,
     activeLayerIndex,
     layerViewMode,
     heightToGridScale,


### PR DESCRIPTION
## Summary
- Replace `.find()` calls inside `.map()` loops with memoized Map lookups
- Add `useShallow` to root App component to prevent cascading re-renders
- Reduce render complexity from O(n×m) to O(n+m) for grid components

## Problem
The grid rendering components had O(n²) lookup patterns that degraded performance as bin count increased:

| Location | Issue |
|----------|-------|
| `GridCanvas.tsx:248-375` | `.find()` for category/layer inside `ghostBins.map()`, `blockedZones.map()`, `activeBins.map()` |
| `IsometricPreview.tsx:165-186` | `.findIndex()` and `.find()` for every bin in `binsToRender` computation |
| `App.tsx:98` | Subscribed to entire `layout` object, causing re-renders on any bin change |

## Solution
Created memoized lookup Maps that are computed once per render:

```typescript
// Before (O(n×m) - called for each bin):
{activeBins.map((bin) => {
  const category = categories.find((c) => c.id === bin.category);
  ...
})}

// After (O(n+m) - Map created once, O(1) lookups):
const categoryMap = useMemo(() => new Map(categories.map(c => [c.id, c])), [categories]);
{activeBins.map((bin) => (
  <Bin category={categoryMap.get(bin.category)} ... />
))}
```

## Impact
With 100 bins, 10 categories, 5 layers:
- **Before:** ~1,500 lookups per render
- **After:** ~115 lookups per render (Map creation + direct accesses)

## Test plan
- [x] Build succeeds
- [x] All 4,086 tests pass (7 pre-existing failures in SharedWithMeItem.test.tsx)
- [x] Coverage thresholds met
- [x] Module boundary checker passes
- [ ] Manual testing: verify grid responsiveness with 50+ bins