### PR TITLE
refactor: consolidate bin filtering utilities

### DIFF
--- a/src/features/print-export/utils/printLayout.ts
+++ b/src/features/print-export/utils/printLayout.ts
@@ -1,15 +1,13 @@
 import type { Bin, Layer, Category, Drawer } from '@/core/types';
 import type { BinListSortOrder, BinSortField } from '@/core/store/settings';
-import { STAGING_ID } from '@/core/constants';
+import { getVisibleBins, getGridBins } from '@/shared/utils';
 
 /**
  * Filter bins to only include those on the specified layers.
  * Excludes staging bins.
  */
 export function getVisibleBinsForPrint(bins: Bin[], layerIds: string[]): Bin[] {
-  return bins.filter(
-    (bin) => bin.layerId !== STAGING_ID && layerIds.includes(bin.layerId)
-  );
+  return getVisibleBins(bins, { layerIds });
 }
 
 /**
@@ -66,11 +64,9 @@ export function getBinCountByLayer(
   }
 
   // Count bins per layer (excluding staging)
-  for (const bin of bins) {
-    if (bin.layerId !== STAGING_ID) {
-      const current = counts.get(bin.layerId) ?? 0;
-      counts.set(bin.layerId, current + 1);
-    }
+  for (const bin of getGridBins(bins)) {
+    const current = counts.get(bin.layerId) ?? 0;
+    counts.set(bin.layerId, current + 1);
   }
 
   return counts;

--- a/src/shared/utils/bins.ts
+++ b/src/shared/utils/bins.ts
@@ -1,0 +1,153 @@
+/**
+ * Bin filtering utilities.
+ * Consolidates common patterns for filtering bins by location (grid/staging)
+ * and layer membership.
+ */
+
+import { STAGING_ID } from '@/core/constants';
+import type { Bin } from '@/core/types';
+
+/**
+ * Options for filtering visible bins.
+ */
+export interface VisibleBinsOptions {
+  /**
+   * If provided, only include bins on these specific layer IDs.
+   * Always excludes staging bins regardless of whether STAGING_ID is in the array.
+   */
+  layerIds?: string[];
+
+  /**
+   * If true, include staging bins in results.
+   * @default false
+   */
+  includeStaging?: boolean;
+}
+
+/**
+ * Get bins that are visible based on layer and staging filters.
+ * This is the consolidated filtering function for all bin visibility logic.
+ *
+ * @param bins - All bins to filter
+ * @param options - Filter options (layer IDs, staging inclusion)
+ * @returns Filtered array of bins
+ *
+ * @example
+ * // Get all bins on the grid (excluding staging)
+ * const gridBins = getVisibleBins(bins);
+ *
+ * @example
+ * // Get bins on specific layers (excluding staging)
+ * const layerBins = getVisibleBins(bins, { layerIds: ['layer-1', 'layer-2'] });
+ *
+ * @example
+ * // Get only staging bins
+ * const stagingBins = getVisibleBins(bins, { includeStaging: true, layerIds: [STAGING_ID] });
+ *
+ * @example
+ * // Get all bins including staging
+ * const allBins = getVisibleBins(bins, { includeStaging: true });
+ */
+export function getVisibleBins(
+  bins: Bin[],
+  options: VisibleBinsOptions = {}
+): Bin[] {
+  const { layerIds, includeStaging = false } = options;
+
+  return bins.filter((bin) => {
+    // Handle staging filter
+    const isStaging = bin.layerId === STAGING_ID;
+
+    if (isStaging) {
+      // If includeStaging is true and no layerIds specified, include all staging
+      // If layerIds specified and includes STAGING_ID, include staging
+      // Otherwise exclude staging
+      if (!includeStaging) return false;
+      if (layerIds && !layerIds.includes(STAGING_ID)) return false;
+      return true;
+    }
+
+    // Non-staging bins: check layer filter if provided
+    if (layerIds !== undefined) {
+      // Empty array means "no layers selected" - return nothing
+      if (layerIds.length === 0) return false;
+      return layerIds.includes(bin.layerId);
+    }
+
+    // No layer filter - include all non-staging bins
+    return true;
+  });
+}
+
+/**
+ * Get all bins that are on the grid (not in staging).
+ * Convenience function for the most common filtering pattern.
+ *
+ * @param bins - All bins to filter
+ * @returns Bins on the grid (layerId !== STAGING_ID)
+ *
+ * @example
+ * const gridBins = getGridBins(layout.bins);
+ */
+export function getGridBins(bins: Bin[]): Bin[] {
+  return bins.filter((bin) => bin.layerId !== STAGING_ID);
+}
+
+/**
+ * Get all bins that are in staging (the stash).
+ * Convenience function for staging-specific filtering.
+ *
+ * @param bins - All bins to filter
+ * @returns Bins in staging (layerId === STAGING_ID)
+ *
+ * @example
+ * const stagingBins = getStagingBins(layout.bins);
+ */
+export function getStagingBins(bins: Bin[]): Bin[] {
+  return bins.filter((bin) => bin.layerId === STAGING_ID);
+}
+
+/**
+ * Get bins on a specific layer (excluding staging).
+ * Convenience function for single-layer filtering.
+ *
+ * @param bins - All bins to filter
+ * @param layerId - The layer ID to filter by
+ * @returns Bins on the specified layer
+ *
+ * @example
+ * const layerBins = getLayerBins(layout.bins, activeLayerId);
+ */
+export function getLayerBins(bins: Bin[], layerId: string): Bin[] {
+  return bins.filter(
+    (bin) => bin.layerId === layerId && bin.layerId !== STAGING_ID
+  );
+}
+
+/**
+ * Split bins into grid and staging groups.
+ * Useful when you need both sets and want to avoid filtering twice.
+ *
+ * @param bins - All bins to split
+ * @returns Object with gridBins and stagingBins arrays
+ *
+ * @example
+ * const { gridBins, stagingBins } = splitBinsByLocation(layout.bins);
+ */
+export function splitBinsByLocation(bins: Bin[]): {
+  gridBins: Bin[];
+  stagingBins: Bin[];
+} {
+  const gridBins: Bin[] = [];
+  const stagingBins: Bin[] = [];
+
+  for (const bin of bins) {
+    if (bin.layerId === STAGING_ID) {
+      stagingBins.push(bin);
+    } else {
+      gridBins.push(bin);
+    }
+  }
+
+  return { gridBins, stagingBins };
+}

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -15,6 +15,15 @@ export { throttleRAF, cancelThrottledRAF, throttle } from './throttle';
 export { scheduleIdleCallback, cancelIdleCallback } from './idle';
 
 export {
+  getVisibleBins,
+  getGridBins,
+  getStagingBins,
+  getLayerBins,
+  splitBinsByLocation,
+} from './bins';
+export type { VisibleBinsOptions } from './bins';
+
+export {
   isValidDrawer,
   isValidLayer,
   isValidBin,

--- a/src/test/bins.test.ts
+++ b/src/test/bins.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getVisibleBins,
+  getGridBins,
+  getStagingBins,
+  getLayerBins,
+  splitBinsByLocation,
+} from '@/shared/utils';
+import { STAGING_ID } from '@/core/constants';
+import type { Bin } from '@/core/types';
+
+// Test data factory
+function createBin(id: string, layerId: string): Bin {
+  return {
+    id,
+    x: 0,
+    y: 0,
+    width: 1,
+    depth: 1,
+    height: 6,
+    layerId,
+    category: 'default',
+  };
+}
+
+describe('bins utilities', () => {
+  const layer1Id = 'layer-1';
+  const layer2Id = 'layer-2';
+
+  const bins: Bin[] = [
+    createBin('bin1', layer1Id),
+    createBin('bin2', layer1Id),
+    createBin('bin3', layer2Id),
+    createBin('bin4', STAGING_ID),
+    createBin('bin5', STAGING_ID),
+  ];
+
+  describe('getGridBins', () => {
+    it('should return only bins on the grid (not staging)', () => {
+      const result = getGridBins(bins);
+      expect(result).toHaveLength(3);
+      expect(result.every((b) => b.layerId !== STAGING_ID)).toBe(true);
+      expect(result.map((b) => b.id)).toEqual(['bin1', 'bin2', 'bin3']);
+    });
+
+    it('should return empty array when all bins are staging', () => {
+      const stagingOnly = [createBin('s1', STAGING_ID), createBin('s2', STAGING_ID)];
+      expect(getGridBins(stagingOnly)).toEqual([]);
+    });
+
+    it('should return all bins when none are staging', () => {
+      const gridOnly = [createBin('g1', layer1Id), createBin('g2', layer2Id)];
+      expect(getGridBins(gridOnly)).toHaveLength(2);
+    });
+  });
+
+  describe('getStagingBins', () => {
+    it('should return only staging bins', () => {
+      const result = getStagingBins(bins);
+      expect(result).toHaveLength(2);
+      expect(result.every((b) => b.layerId === STAGING_ID)).toBe(true);
+      expect(result.map((b) => b.id)).toEqual(['bin4', 'bin5']);
+    });
+
+    it('should return empty array when no staging bins', () => {
+      const gridOnly = [createBin('g1', layer1Id), createBin('g2', layer2Id)];
+      expect(getStagingBins(gridOnly)).toEqual([]);
+    });
+  });
+
+  describe('getLayerBins', () => {
+    it('should return bins on specific layer excluding staging', () => {
+      const result = getLayerBins(bins, layer1Id);
+      expect(result).toHaveLength(2);
+      expect(result.map((b) => b.id)).toEqual(['bin1', 'bin2']);
+    });
+
+    it('should return empty array for STAGING_ID layer', () => {
+      // Even if layerId === STAGING_ID, the function excludes staging
+      const result = getLayerBins(bins, STAGING_ID);
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array for non-existent layer', () => {
+      const result = getLayerBins(bins, 'non-existent');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('splitBinsByLocation', () => {
+    it('should split bins into grid and staging groups', () => {
+      const { gridBins, stagingBins } = splitBinsByLocation(bins);
+      expect(gridBins).toHaveLength(3);
+      expect(stagingBins).toHaveLength(2);
+      expect(gridBins.map((b) => b.id)).toEqual(['bin1', 'bin2', 'bin3']);
+      expect(stagingBins.map((b) => b.id)).toEqual(['bin4', 'bin5']);
+    });
+
+    it('should handle all staging bins', () => {
+      const allStaging = [createBin('s1', STAGING_ID), createBin('s2', STAGING_ID)];
+      const { gridBins, stagingBins } = splitBinsByLocation(allStaging);
+      expect(gridBins).toEqual([]);
+      expect(stagingBins).toHaveLength(2);
+    });
+
+    it('should handle all grid bins', () => {
+      const allGrid = [createBin('g1', layer1Id), createBin('g2', layer2Id)];
+      const { gridBins, stagingBins } = splitBinsByLocation(allGrid);
+      expect(gridBins).toHaveLength(2);
+      expect(stagingBins).toEqual([]);
+    });
+
+    it('should handle empty array', () => {
+      const { gridBins, stagingBins } = splitBinsByLocation([]);
+      expect(gridBins).toEqual([]);
+      expect(stagingBins).toEqual([]);
+    });
+  });
+
+  describe('getVisibleBins', () => {
+    it('should return all grid bins by default', () => {
+      const result = getVisibleBins(bins);
+      expect(result).toHaveLength(3);
+      expect(result.every((b) => b.layerId !== STAGING_ID)).toBe(true);
+    });
+
+    it('should filter by layerIds when provided', () => {
+      const result = getVisibleBins(bins, { layerIds: [layer1Id] });
+      expect(result).toHaveLength(2);
+      expect(result.map((b) => b.id)).toEqual(['bin1', 'bin2']);
+    });
+
+    it('should exclude staging even if STAGING_ID is in layerIds', () => {
+      const result = getVisibleBins(bins, { layerIds: [layer1Id, STAGING_ID] });
+      expect(result).toHaveLength(2);
+      expect(result.map((b) => b.id)).toEqual(['bin1', 'bin2']);
+    });
+
+    it('should include staging with includeStaging option', () => {
+      const result = getVisibleBins(bins, { includeStaging: true });
+      expect(result).toHaveLength(5);
+    });
+
+    it('should return only staging bins when includeStaging and layerIds=[STAGING_ID]', () => {
+      const result = getVisibleBins(bins, {
+        includeStaging: true,
+        layerIds: [STAGING_ID]
+      });
+      expect(result).toHaveLength(2);
+      expect(result.map((b) => b.id)).toEqual(['bin4', 'bin5']);
+    });
+
+    it('should filter by multiple layers', () => {
+      const result = getVisibleBins(bins, { layerIds: [layer1Id, layer2Id] });
+      expect(result).toHaveLength(3);
+      expect(result.map((b) => b.id)).toEqual(['bin1', 'bin2', 'bin3']);
+    });
+
+    it('should return empty array when layerIds is empty', () => {
+      const result = getVisibleBins(bins, { layerIds: [] });
+      expect(result).toEqual([]);
+    });
+
+    it('should include staging when includeStaging and layerIds includes both grid and staging', () => {
+      const result = getVisibleBins(bins, {
+        includeStaging: true,
+        layerIds: [layer1Id, STAGING_ID],
+      });
+      expect(result).toHaveLength(4);
+      expect(result.map((b) => b.id)).toEqual(['bin1', 'bin2', 'bin4', 'bin5']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Consolidates duplicated bin filtering logic into shared utilities in `src/shared/utils/bins.ts`.

## Changes
- **New utilities**:
  - `getVisibleBins()`: Flexible filtering with layer and staging options
  - `getGridBins()`: Get bins on grid (excluding staging)
  - `getStagingBins()`: Get bins in staging/stash
  - `getLayerBins()`: Get bins on specific layer (excluding staging)
  - `splitBinsByLocation()`: Split bins into grid/staging groups

- **Updated consumers**:
  - `src/features/print-export/utils/printLayout.ts`: Uses shared utilities

- **Test coverage**: Added 20 comprehensive tests for all filtering patterns

## Test Plan
- [x] All existing tests pass (4189 tests)
- [x] New utility tests pass (20 tests)
- [x] Build succeeds
- [x] Coverage thresholds maintained

## Notes
This is part of ongoing simplification efforts to reduce code duplication and improve maintainability. Additional consumers can be updated in follow-up PRs.