### PR TITLE
refactor: remove deprecated labs re-exports

### DIFF
--- a/src/features/labs/definitions/index.ts
+++ b/src/features/labs/definitions/index.ts
@@ -1,5 +1,0 @@
-/**
- * @deprecated Import from '@/core/labs' instead.
- * This re-export exists for backward compatibility during migration.
- */
-export * from '@/core/labs';

--- a/src/features/labs/index.ts
+++ b/src/features/labs/index.ts
@@ -1,18 +1,11 @@
 /**
  * Labs feature module.
  *
- * Note: The labs store and type definitions have been moved to core/
- * as they are infrastructure used throughout the application.
+ * This module exports the UI components for the Labs feature.
  *
- * - Types and feature definitions: import from '@/core/labs'
- * - Store (useLabsStore): import from '@/core/store'
- *
- * This module now only exports the UI components for the Labs feature.
+ * For labs infrastructure, import directly from:
+ * - Types and feature definitions: '@/core/labs'
+ * - Store (useLabsStore): '@/core/store'
  */
 
-// UI Components (remain in features)
 export * from './components';
-
-// Re-exports for backward compatibility (deprecated)
-export * from './store';
-export * from './definitions';

--- a/src/features/labs/store/index.ts
+++ b/src/features/labs/store/index.ts
@@ -1,5 +1,0 @@
-/**
- * @deprecated Import from '@/core/store' instead.
- * This re-export exists for backward compatibility during migration.
- */
-export { useLabsStore, LABS_STORAGE_KEY } from '@/core/store';


### PR DESCRIPTION
## Summary

Removes deprecated backward-compatibility re-export files that were left behind after PR #274 merged empty (due to jj/git sync issues).

## Changes

**Deleted files:**
- `src/features/labs/store/index.ts` - was re-exporting from `@/core/store`
- `src/features/labs/definitions/index.ts` - was re-exporting from `@/core/labs`

**Updated:**
- `src/features/labs/index.ts` - now only exports UI components

## Proper Import Paths (now enforced)

| Type | Import From |
|------|-------------|
| Labs store (`useLabsStore`) | `@/core/store` |
| Labs types/definitions | `@/core/labs` |
| Labs UI components | `@/features/labs` |

## Test Plan

- [x] Build passes
- [x] All 4189 tests pass
- [x] Coverage thresholds maintained
- [x] No imports from deprecated paths (verified with grep)

## Note

This is a redo of PR #274, which was accidentally merged with no changes due to jj/git synchronization issues during parallel agent work.