### PR TITLE
refactor: improve Result type consistency and error handling

### DIFF
--- a/src/core/api/share.ts
+++ b/src/core/api/share.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Layout, SharePermission } from '@/core/types';
-import type { Result, ApiError } from '@/core/result';
+import type { Result, ApiError, ValidationError } from '@/core/result';
 import {
   ok,
   err,
@@ -20,7 +20,9 @@ import {
   apiSizeLimit,
   apiBinLimit,
   apiExpired,
+  validationImportFailed,
 } from '@/core/result';
+import { validateImport } from '@/shared/utils/validation';
 
 // API Response types
 export interface ShareResponse {
@@ -80,31 +82,38 @@ function isShareErrorResponse(data: unknown): data is ShareErrorResponse {
 }
 
 function isShareResponse(data: unknown): data is ShareResponse {
+  if (typeof data !== 'object' || data === null) return false;
+  const obj = data as Record<string, unknown>;
   return (
-    typeof data === 'object' &&
-    data !== null &&
     'id' in data &&
     'url' in data &&
     'deleteToken' in data &&
     'permission' in data &&
-    typeof (data as Record<string, unknown>).id === 'string' &&
-    typeof (data as Record<string, unknown>).url === 'string'
+    typeof obj.id === 'string' &&
+    typeof obj.url === 'string' &&
+    typeof obj.deleteToken === 'string' &&
+    (obj.permission === 'view' || obj.permission === 'edit')
   );
 }
 
 function isUpdateShareResponse(data: unknown): data is UpdateShareResponse {
+  if (typeof data !== 'object' || data === null) return false;
+  const obj = data as Record<string, unknown>;
   return (
-    typeof data === 'object' &&
-    data !== null &&
     'id' in data &&
     'url' in data &&
     'permission' in data &&
-    typeof (data as Record<string, unknown>).id === 'string' &&
-    typeof (data as Record<string, unknown>).url === 'string'
+    typeof obj.id === 'string' &&
+    typeof obj.url === 'string' &&
+    (obj.permission === 'view' || obj.permission === 'edit')
   );
 }
 
-function isFetchShareResponse(data: unknown): data is FetchShareResponse {
+/**
+ * Basic structural check for FetchShareResponse.
+ * Does not validate Layout contents - use validateFetchShareResponse for full validation.
+ */
+function isFetchShareResponseStructure(data: unknown): data is FetchShareResponse {
   return (
     typeof data === 'object' &&
     data !== null &&
@@ -113,6 +122,26 @@ function isFetchShareResponse(data: unknown): data is FetchShareResponse {
     typeof (data as Record<string, unknown>).layout === 'object' &&
     typeof (data as Record<string, unknown>).metadata === 'object'
   );
+}
+
+/**
+ * Validate a FetchShareResponse including Layout contents.
+ * Returns validation errors if the layout structure is invalid.
+ */
+function validateFetchShareResponse(
+  data: unknown
+): { valid: true; data: FetchShareResponse } | { valid: false; errors: string[] } {
+  if (!isFetchShareResponseStructure(data)) {
+    return { valid: false, errors: ['Invalid response structure'] };
+  }
+
+  // Validate the Layout using the import validator
+  const layoutValidation = validateImport(data.layout);
+  if (!layoutValidation.valid) {
+    return { valid: false, errors: layoutValidation.errors };
+  }
+
+  return { valid: true, data };
 }
 
 /**
@@ -268,8 +297,11 @@ export async function updatePermission(
 
 /**
  * Fetch a shared layout by ID.
+ * Validates the layout structure after deserialization to ensure data integrity.
  */
-export async function fetchShare(id: string): Promise<Result<FetchShareResponse, ApiError>> {
+export async function fetchShare(
+  id: string
+): Promise<Result<FetchShareResponse, ApiError | ValidationError>> {
   try {
     const response = await fetch(`/api/share/${id}`);
     const data: unknown = await response.json();
@@ -281,10 +313,13 @@ export async function fetchShare(id: string): Promise<Result<FetchShareResponse,
       return err(apiServerError());
     }
 
-    if (isFetchShareResponse(data)) {
-      return ok(data);
+    // Validate both structure and layout contents
+    const validation = validateFetchShareResponse(data);
+    if (!validation.valid) {
+      return err(validationImportFailed(validation.errors));
     }
-    return err(apiServerError());
+
+    return ok(validation.data);
   } catch (error) {
     return err(apiNetworkError(error));
   }

--- a/src/core/storage/migration.ts
+++ b/src/core/storage/migration.ts
@@ -21,6 +21,7 @@ import {
   ok,
   err,
   OK,
+  isOk,
   storageNotFound,
   storageUnavailable,
   storageNetworkError,
@@ -291,7 +292,7 @@ export async function migrateAllLayoutsToIndexedDBResult(): Promise<
 
     const migrationResult = await migrateLayoutToIndexedDBResult(layoutId);
 
-    if (migrationResult.ok) {
+    if (isOk(migrationResult)) {
       stats.migratedCount++;
     }
     // Note: Individual failures are silently skipped - use legacy API for error details

--- a/src/core/store/history.ts
+++ b/src/core/store/history.ts
@@ -97,6 +97,19 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
 /**
  * Hook to wrap layout actions with history tracking.
  * Use this instead of calling layout store directly for undoable actions.
+ *
+ * The execute function returns whatever the action returns, allowing callers
+ * to check Result types from store actions:
+ *
+ * @example
+ * ```ts
+ * const result = execute(() => addBin({ ... }));
+ * if (isOk(result)) {
+ *   // handle success
+ * } else {
+ *   addToast(getUserMessage(result.error), 'error');
+ * }
+ * ```
  */
 export function useUndoableAction() {
   const layout = useLayoutStore((state) => state.layout);
@@ -109,11 +122,12 @@ export function useUndoableAction() {
   }, [layout]);
 
   const execute = useCallback(
-    (action: () => void) => {
+    <T>(action: () => T): T => {
       push(cloneLayout(layoutRef.current));
-      action();
+      const result = action();
       // Record timestamp AFTER action executes for accurate undo timing
       mlTracking.recordAction();
+      return result;
     },
     [push]
   ); // Only depends on push, which is stable from Zustand

--- a/src/features/categories/components/CategoriesPanel.tsx
+++ b/src/features/categories/components/CategoriesPanel.tsx
@@ -6,7 +6,7 @@ import { CONSTRAINTS, DEFAULT_CATEGORY_COLOR } from '@/core/constants';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { useToastStore } from '@/core/store/toast';
 import { CollapsibleSection } from '@/shared/components/CollapsibleSection';
-import { isOk } from '@/core/result';
+import { isOk, isErr, getUserMessage } from '@/core/result';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
 
 // Curated color palette optimized for dark UI backgrounds
@@ -110,11 +110,14 @@ export function CategoriesPanel() {
   };
 
   const handleUpdateCategory = (id: string, field: 'name' | 'color', value: string) => {
-    execute(() => {
+    const result = execute(() =>
       updateCategory(id, {
         [field]: field === 'name' ? value.slice(0, CONSTRAINTS.LABEL_MAX_LENGTH) : value,
-      });
-    });
+      })
+    );
+    if (isErr(result)) {
+      addToast(getUserMessage(result.error), 'error');
+    }
   };
 
   const handleDeleteCategory = (id: string, name: string, e: React.MouseEvent) => {
@@ -142,15 +145,21 @@ export function CategoriesPanel() {
   const confirmDeleteCategory = () => {
     if (!deleteConfirm) return;
     const { id } = deleteConfirm;
-    execute(() => {
-      deleteCategory(id);
-      // Access fresh state to avoid stale closure issues
-      const currentCategories = useLayoutStore.getState().layout.categories;
-      const currentActiveCategoryId = useUIStore.getState().activeCategoryId;
-      if (currentActiveCategoryId === id && currentCategories.length > 0) {
-        setActiveCategory(currentCategories[0].id);
+    const result = execute(() => {
+      const deleteResult = deleteCategory(id);
+      if (isOk(deleteResult)) {
+        // Access fresh state to avoid stale closure issues
+        const currentCategories = useLayoutStore.getState().layout.categories;
+        const currentActiveCategoryId = useUIStore.getState().activeCategoryId;
+        if (currentActiveCategoryId === id && currentCategories.length > 0) {
+          setActiveCategory(currentCategories[0].id);
+        }
       }
+      return deleteResult;
     });
+    if (isErr(result)) {
+      addToast(getUserMessage(result.error), 'error');
+    }
     setEditingId(null);
     setDeleteConfirm(null);
   };

--- a/src/features/layout-library/components/LayoutManagerModal/index.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/index.tsx
@@ -122,14 +122,18 @@ function LayoutManagerModalContent({
 
   const handleDelete = useCallback(
     async (id: string) => {
-      await deleteLayout(id);
+      const result = await deleteLayout(id);
+      // Result error is already shown via toast internally
+      return isOk(result);
     },
     [deleteLayout]
   );
 
   const handleDuplicate = useCallback(
     async (id: string) => {
-      await duplicateLayout(id);
+      const result = await duplicateLayout(id);
+      // Result error is already shown via toast internally
+      return isOk(result);
     },
     [duplicateLayout]
   );

--- a/src/hooks/useBinList.ts
+++ b/src/hooks/useBinList.ts
@@ -5,7 +5,15 @@
 
 import { useMemo, useState, useCallback } from 'react';
 import { useShallow } from 'zustand/shallow';
-import { useLayoutStore, useUndoableAction, useToastStore, useSelectionStore, useInteractionStore } from '@/core/store';
+import {
+  useLayoutStore,
+  useUndoableAction,
+  useToastStore,
+  useSelectionStore,
+  useInteractionStore,
+} from '@/core/store';
+import type { LayoutError } from '@/core/result';
+import { isErr, getUserMessage } from '@/core/result';
 import { usePrintList, type UsePrintListReturn } from '@/features/print-export/hooks/usePrintList';
 import {
   filterBySearch,
@@ -151,17 +159,30 @@ export function useBinList(): UseBinListReturn {
       }
     }
 
-    const count = selectedBinIds.length;
+    let successCount = 0;
+    let lastError: LayoutError | null = null;
+
     execute(() => {
       for (const binId of selectedBinIds) {
-        deleteBin(binId);
+        const result = deleteBin(binId);
+        if (isErr(result)) {
+          lastError = result.error;
+        } else {
+          successCount++;
+        }
       }
     });
 
     clearSelection();
     setSelectedBins([]);
-    addToast(`Deleted ${count} bin${count !== 1 ? 's' : ''}`, 'success');
-    announceToScreenReader(`Deleted ${count} bins`);
+
+    if (successCount > 0) {
+      addToast(`Deleted ${successCount} bin${successCount !== 1 ? 's' : ''}`, 'success');
+      announceToScreenReader(`Deleted ${successCount} bins`);
+    }
+    if (lastError) {
+      addToast(`Some bins could not be deleted: ${getUserMessage(lastError)}`, 'error');
+    }
   }, [
     selectedBinIds,
     layout,
@@ -183,26 +204,38 @@ export function useBinList(): UseBinListReturn {
         .filter((bin): bin is (typeof layout.bins)[number] => !!bin && bin.category !== categoryId);
       if (binsToUpdate.length === 0) return;
 
-      const count = binsToUpdate.length;
       const category = printList.categories.find((c) => c.id === categoryId);
+
+      let successCount = 0;
+      let lastError: LayoutError | null = null;
 
       execute(() => {
         for (const bin of binsToUpdate) {
-          updateBin(bin.id, { category: categoryId });
+          const result = updateBin(bin.id, { category: categoryId });
+          if (isErr(result)) {
+            lastError = result.error;
+          } else {
+            successCount++;
+          }
         }
       });
 
       // Track once per batch (not per bin)
-      if (category && binsToUpdate.length > 0) {
-        mlTracking.trackCategory(binsToUpdate[0], category.name, count);
+      if (category && successCount > 0) {
+        mlTracking.trackCategory(binsToUpdate[0], category.name, successCount);
       }
 
       clearSelection();
-      addToast(
-        `Changed ${count} bin${count !== 1 ? 's' : ''} to ${category?.name || 'category'}`,
-        'success'
-      );
-      announceToScreenReader(`Changed category for ${count} bins`);
+      if (successCount > 0) {
+        addToast(
+          `Changed ${successCount} bin${successCount !== 1 ? 's' : ''} to ${category?.name || 'category'}`,
+          'success'
+        );
+        announceToScreenReader(`Changed category for ${successCount} bins`);
+      }
+      if (lastError) {
+        addToast(`Some bins could not be updated: ${getUserMessage(lastError)}`, 'error');
+      }
     },
     [
       selectedBinIds,
@@ -220,19 +253,34 @@ export function useBinList(): UseBinListReturn {
     (label: string) => {
       if (selectedBinIds.length === 0) return;
 
-      const count = selectedBinIds.length;
+      let successCount = 0;
+      let lastError: LayoutError | null = null;
+
       execute(() => {
         for (const binId of selectedBinIds) {
           const bin = layout.bins.find((b) => b.id === binId);
           if (bin) {
             const oldLabel = bin.label;
-            updateBin(binId, { label });
-            mlTracking.trackLabel(bin, oldLabel, label);
+            const result = updateBin(binId, { label });
+            if (isErr(result)) {
+              lastError = result.error;
+            } else {
+              successCount++;
+              mlTracking.trackLabel(bin, oldLabel, label);
+            }
           }
         }
       });
 
-      addToast(`Updated label for ${count} bin${count !== 1 ? 's' : ''}`, 'success');
+      if (successCount > 0) {
+        addToast(
+          `Updated label for ${successCount} bin${successCount !== 1 ? 's' : ''}`,
+          'success'
+        );
+      }
+      if (lastError) {
+        addToast(`Some bins could not be updated: ${getUserMessage(lastError)}`, 'error');
+      }
     },
     [selectedBinIds, layout.bins, execute, updateBin, addToast]
   );
@@ -241,14 +289,29 @@ export function useBinList(): UseBinListReturn {
     (notes: string) => {
       if (selectedBinIds.length === 0) return;
 
-      const count = selectedBinIds.length;
+      let successCount = 0;
+      let lastError: LayoutError | null = null;
+
       execute(() => {
         for (const binId of selectedBinIds) {
-          updateBin(binId, { notes });
+          const result = updateBin(binId, { notes });
+          if (isErr(result)) {
+            lastError = result.error;
+          } else {
+            successCount++;
+          }
         }
       });
 
-      addToast(`Updated notes for ${count} bin${count !== 1 ? 's' : ''}`, 'success');
+      if (successCount > 0) {
+        addToast(
+          `Updated notes for ${successCount} bin${successCount !== 1 ? 's' : ''}`,
+          'success'
+        );
+      }
+      if (lastError) {
+        addToast(`Some bins could not be updated: ${getUserMessage(lastError)}`, 'error');
+      }
     },
     [selectedBinIds, execute, updateBin, addToast]
   );
@@ -258,19 +321,34 @@ export function useBinList(): UseBinListReturn {
     (binIds: string[], label: string) => {
       if (binIds.length === 0) return;
 
-      const count = binIds.length;
+      let successCount = 0;
+      let lastError: LayoutError | null = null;
+
       execute(() => {
         for (const binId of binIds) {
           const bin = layout.bins.find((b) => b.id === binId);
           if (bin) {
             const oldLabel = bin.label;
-            updateBin(binId, { label });
-            mlTracking.trackLabel(bin, oldLabel, label);
+            const result = updateBin(binId, { label });
+            if (isErr(result)) {
+              lastError = result.error;
+            } else {
+              successCount++;
+              mlTracking.trackLabel(bin, oldLabel, label);
+            }
           }
         }
       });
 
-      addToast(`Updated label for ${count} bin${count !== 1 ? 's' : ''}`, 'success');
+      if (successCount > 0) {
+        addToast(
+          `Updated label for ${successCount} bin${successCount !== 1 ? 's' : ''}`,
+          'success'
+        );
+      }
+      if (lastError) {
+        addToast(`Some bins could not be updated: ${getUserMessage(lastError)}`, 'error');
+      }
     },
     [layout.bins, execute, updateBin, addToast]
   );
@@ -279,14 +357,29 @@ export function useBinList(): UseBinListReturn {
     (binIds: string[], notes: string) => {
       if (binIds.length === 0) return;
 
-      const count = binIds.length;
+      let successCount = 0;
+      let lastError: LayoutError | null = null;
+
       execute(() => {
         for (const binId of binIds) {
-          updateBin(binId, { notes });
+          const result = updateBin(binId, { notes });
+          if (isErr(result)) {
+            lastError = result.error;
+          } else {
+            successCount++;
+          }
         }
       });
 
-      addToast(`Updated notes for ${count} bin${count !== 1 ? 's' : ''}`, 'success');
+      if (successCount > 0) {
+        addToast(
+          `Updated notes for ${successCount} bin${successCount !== 1 ? 's' : ''}`,
+          'success'
+        );
+      }
+      if (lastError) {
+        addToast(`Some bins could not be updated: ${getUserMessage(lastError)}`, 'error');
+      }
     },
     [execute, updateBin, addToast]
   );

--- a/src/shared/utils/collision.ts
+++ b/src/shared/utils/collision.ts
@@ -1,4 +1,6 @@
 import type { Bin, Layer, Rect3D, BlockedZone } from '@/core/types';
+import type { Result, ValidationError } from '@/core/result';
+import { ok, err, isOk, validationInvalidLayer } from '@/core/result';
 import { STAGING_ID } from '@/core/constants';
 
 /**
@@ -10,21 +12,60 @@ export function getDisplayLayers<T>(layers: T[]): T[] {
 }
 
 /**
- * Calculate the Z-axis start position for a layer.
- * Layers stack from bottom (index 0) upward.
+ * Calculate the Z-axis start position for a layer with Result-based error handling.
+ * Use this when layer existence is not guaranteed (e.g., during user interactions).
  */
-export function getLayerZStart(layerId: string, layers: Layer[]): number {
+export function getLayerZStartResult(
+  layerId: string,
+  layers: Layer[]
+): Result<number, ValidationError> {
   let z = 0;
   for (const layer of layers) {
-    if (layer.id === layerId) return z;
+    if (layer.id === layerId) return ok(z);
     z += layer.height;
+  }
+  return err(validationInvalidLayer(layerId));
+}
+
+/**
+ * Calculate the Z-axis start position for a layer.
+ * Layers stack from bottom (index 0) upward.
+ *
+ * @throws Error if layer not found - use getLayerZStartResult for safe error handling
+ */
+export function getLayerZStart(layerId: string, layers: Layer[]): number {
+  const result = getLayerZStartResult(layerId, layers);
+  if (isOk(result)) {
+    return result.value;
   }
   throw new Error(`Layer not found: ${layerId}`);
 }
 
 /**
+ * Get the 3D bounding box for a bin with Result-based error handling.
+ * Use this when layer existence is not guaranteed.
+ */
+export function getBin3DRectResult(bin: Bin, layers: Layer[]): Result<Rect3D, ValidationError> {
+  const zStartResult = getLayerZStartResult(bin.layerId, layers);
+  if (!isOk(zStartResult)) {
+    return zStartResult;
+  }
+  const zStart = zStartResult.value;
+  return ok({
+    x: bin.x,
+    y: bin.y,
+    width: bin.width,
+    depth: bin.depth,
+    zStart,
+    zEnd: zStart + bin.height + (bin.clearanceHeight || 0),
+  });
+}
+
+/**
  * Get the 3D bounding box for a bin.
  * Includes clearanceHeight in the vertical extent for collision detection.
+ *
+ * @throws Error if bin's layer not found - use getBin3DRectResult for safe error handling
  */
 export function getBin3DRect(bin: Bin, layers: Layer[]): Rect3D {
   const zStart = getLayerZStart(bin.layerId, layers);
@@ -59,8 +100,43 @@ export function verticalRangesOverlap(
 }
 
 /**
+ * Check if two bins collide in 3D space with Result-based error handling.
+ * Returns Ok(false) for staging bins or non-overlapping footprints.
+ * Returns Err if either bin's layer is invalid.
+ */
+export function binsCollideResult(
+  binA: Bin,
+  binB: Bin,
+  layers: Layer[]
+): Result<boolean, ValidationError> {
+  // Staging bins don't collide with anything
+  if (binA.layerId === STAGING_ID || binB.layerId === STAGING_ID) {
+    return ok(false);
+  }
+
+  // Check footprint overlap first (cheaper)
+  if (!footprintsOverlap(binA, binB)) {
+    return ok(false);
+  }
+
+  const rectAResult = getBin3DRectResult(binA, layers);
+  if (!isOk(rectAResult)) {
+    return rectAResult;
+  }
+
+  const rectBResult = getBin3DRectResult(binB, layers);
+  if (!isOk(rectBResult)) {
+    return rectBResult;
+  }
+
+  return ok(verticalRangesOverlap(rectAResult.value, rectBResult.value));
+}
+
+/**
  * Check if two bins collide in 3D space.
  * Bins must overlap in both footprint AND vertical range to collide.
+ *
+ * @throws Error if either bin's layer not found - use binsCollideResult for safe error handling
  */
 export function binsCollide(binA: Bin, binB: Bin, layers: Layer[]): boolean {
   // Staging bins don't collide with anything

--- a/src/test/api-client.test.ts
+++ b/src/test/api-client.test.ts
@@ -43,7 +43,7 @@ describe('createShare', () => {
       json: () => Promise.resolve(mockResponse),
     } as Response);
 
-    const result = await createShare(mockLayout, 'view');
+    const result = await createShare('test-layout-id', mockLayout, 'view');
 
     expect(isOk(result)).toBe(true);
     if (isOk(result)) {
@@ -63,7 +63,7 @@ describe('createShare', () => {
         }),
     } as Response);
 
-    const result = await createShare(mockLayout, 'view');
+    const result = await createShare('test-layout-id', mockLayout, 'view');
 
     expect(isErr(result)).toBe(true);
     if (isErr(result)) {
@@ -78,7 +78,7 @@ describe('createShare', () => {
   it('returns Err with ApiNetworkError on fetch failure', async () => {
     vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
 
-    const result = await createShare(mockLayout, 'view');
+    const result = await createShare('test-layout-id', mockLayout, 'view');
 
     expect(isErr(result)).toBe(true);
     if (isErr(result)) {
@@ -97,7 +97,7 @@ describe('createShare', () => {
         }),
     } as Response);
 
-    const result = await createShare(mockLayout, 'view');
+    const result = await createShare('test-layout-id', mockLayout, 'view');
 
     expect(isErr(result)).toBe(true);
     if (isErr(result)) {
@@ -115,7 +115,7 @@ describe('createShare', () => {
         }),
     } as Response);
 
-    const result = await createShare(mockLayout, 'view');
+    const result = await createShare('test-layout-id', mockLayout, 'view');
 
     expect(isErr(result)).toBe(true);
     if (isErr(result)) {
@@ -133,7 +133,7 @@ describe('createShare', () => {
         }),
     } as Response);
 
-    const result = await createShare(mockLayout, 'view');
+    const result = await createShare('test-layout-id', mockLayout, 'view');
 
     expect(isErr(result)).toBe(true);
     if (isErr(result)) {
@@ -384,7 +384,7 @@ describe('API error mapping', () => {
         }),
     } as Response);
 
-    const result = await createShare(mockLayout, 'view');
+    const result = await createShare('test-layout-id', mockLayout, 'view');
 
     expect(isErr(result)).toBe(true);
     if (isErr(result)) {
@@ -402,7 +402,7 @@ describe('API error mapping', () => {
         }),
     } as Response);
 
-    const result = await createShare(mockLayout, 'invalid' as 'view');
+    const result = await createShare('test-layout-id', mockLayout, 'invalid' as 'view');
 
     expect(isErr(result)).toBe(true);
     if (isErr(result)) {
@@ -421,7 +421,7 @@ describe('API error mapping', () => {
         }),
     } as Response);
 
-    const result = await createShare(mockLayout, 'view');
+    const result = await createShare('test-layout-id', mockLayout, 'view');
 
     expect(isErr(result)).toBe(true);
     if (isErr(result)) {
@@ -440,7 +440,7 @@ describe('API error mapping', () => {
     } as Response);
 
     const beforeTime = Date.now();
-    const result = await createShare(mockLayout, 'view');
+    const result = await createShare('test-layout-id', mockLayout, 'view');
     const afterTime = Date.now();
 
     expect(isErr(result)).toBe(true);


### PR DESCRIPTION
This commit addresses several Result type usage issues across the codebase:

**collision.ts:**
- Add Result-based variants: getLayerZStartResult, getBin3DRectResult, binsCollideResult
- Keep original throwing functions but document they should use *Result variants for safe error handling

**history.ts:**
- Update useUndoableAction to return action result, allowing callers to check Result types from store actions

**share.ts (API):**
- Add validateFetchShareResponse to validate Layout structure after deserialization
- Enhance type guards with more comprehensive property validation
- fetchShare now returns Result<T, ApiError | ValidationError>

**migration.ts:**
- Replace migrationResult.ok with isOk(migrationResult) for consistency with Result type system

**Components (CategoriesPanel, useBinList, LayoutManagerModal):**
- Add proper Result checking for store action calls
- Show user-friendly error toasts when operations fail
- Track success counts and display appropriate feedback

**Tests:**
- Fix createShare test signatures (add missing layoutId parameter)

All 4189 tests pass and build succeeds.