### PR TITLE
fix: resolve circular dependency warnings in build

### DIFF
--- a/src/components/Mobile/MobileCategoriesPanel.tsx
+++ b/src/components/Mobile/MobileCategoriesPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useShallow } from 'zustand/shallow';
-import { useLayoutStore, useUIStore, useUndoableAction } from '@/core/store';
+import { useLayoutStore } from '@/core/store/layout';
+import { useUIStore, useUndoableAction } from '@/core/store';
 import { useToastStore } from '@/core/store/toast';
 import { CONSTRAINTS, DEFAULT_CATEGORY_COLOR } from '@/core/constants';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';

--- a/src/components/Mobile/MobileGridToolbar.tsx
+++ b/src/components/Mobile/MobileGridToolbar.tsx
@@ -1,5 +1,6 @@
 import { useShallow } from 'zustand/shallow';
-import { useUIStore, useLayoutStore } from '@/core/store';
+import { useLayoutStore } from '@/core/store/layout';
+import { useUIStore } from '@/core/store';
 import { CONSTRAINTS } from '@/core/constants';
 
 interface MobileGridToolbarProps {

--- a/src/components/Mobile/MobileHeader.tsx
+++ b/src/components/Mobile/MobileHeader.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
-import { useLayoutStore, useHistoryStore, useUIStore } from '@/core/store';
+import { useLayoutStore } from '@/core/store/layout';
+import { useHistoryStore, useUIStore } from '@/core/store';
 import { useCollabMode } from '@/hooks/useCollabMode';
 import { CONSTRAINTS } from '@/core/constants';
 import { PresenceAvatars } from '@/components/Collab';

--- a/src/components/Mobile/MobileLayersPanel/LayersTab.tsx
+++ b/src/components/Mobile/MobileLayersPanel/LayersTab.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useShallow } from 'zustand/shallow';
-import { useLayoutStore, useUIStore, useUndoableAction } from '@/core/store';
+import { useLayoutStore } from '@/core/store/layout';
+import { useUIStore, useUndoableAction } from '@/core/store';
 import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
 import { getDisplayLayers } from '@/shared/utils/collision';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';

--- a/src/components/Mobile/MobileLayersPanel/ToolsTab.tsx
+++ b/src/components/Mobile/MobileLayersPanel/ToolsTab.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useShallow } from 'zustand/shallow';
-import { useLayoutStore, useUIStore, useUndoableAction } from '@/core/store';
+import { useLayoutStore } from '@/core/store/layout';
+import { useUIStore, useUndoableAction } from '@/core/store';
 import { useToastStore } from '@/core/store/toast';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 

--- a/src/features/grid-editor/components/Grid/IsometricPreview.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useCallback, useRef, useState, useEffect } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { useShallow } from 'zustand/shallow';
-import { useLayoutStore, useUIStore } from '@/core/store';
+import { useLayoutStore } from '@/core/store/layout';
+import { useUIStore } from '@/core/store';
 import { STAGING_ID, DEFAULT_CATEGORY_COLOR, calcMaxGridUnits } from '@/core/constants';
 import { useResponsive } from '@/shared/hooks';
 import { use3DPreviewKeyboard } from '@/hooks/use3DPreviewKeyboard';

--- a/src/features/print-export/components/PrintModal.tsx
+++ b/src/features/print-export/components/PrintModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo, useCallback, useRef, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import { useShallow } from 'zustand/shallow';
-import { useLayoutStore } from '@/core/store';
+import { useLayoutStore } from '@/core/store/layout';
 import {
   useSettingsStore,
   type PrintViewSettings,

--- a/src/hooks/useLayoutSwitcher.ts
+++ b/src/hooks/useLayoutSwitcher.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from 'react';
 import { useShallow } from 'zustand/shallow';
+import { useLayoutStore } from '@/core/store/layout';
 import {
-  useLayoutStore,
   useLibraryStore,
   useHistoryStore,
   useToastStore,


### PR DESCRIPTION
## Summary
- Import `useLayoutStore` directly from `@/core/store/layout` instead of through the barrel file `@/core/store` in lazy-loaded chunks
- Eliminates 8 Rollup circular dependency warnings during production builds

## Problem
Lazy-loaded chunks (Mobile components, IsometricPreview, PrintModal) were importing `useLayoutStore` through the barrel file, creating cross-chunk circular dependencies:

```
Lazy Chunk → @/core/store (barrel) → @/core/store/layout (main chunk)
                    ↑___________________________________|
```

This could cause broken execution order at runtime.

## Solution
Changed imports from:
```typescript
import { useLayoutStore, useUIStore } from '@/core/store';
```
To:
```typescript
import { useLayoutStore } from '@/core/store/layout';
import { useUIStore } from '@/core/store';
```

## Files Updated
- `src/components/Mobile/MobileGridToolbar.tsx`
- `src/components/Mobile/MobileHeader.tsx`
- `src/components/Mobile/MobileCategoriesPanel.tsx`
- `src/components/Mobile/MobileLayersPanel/LayersTab.tsx`
- `src/components/Mobile/MobileLayersPanel/ToolsTab.tsx`
- `src/hooks/useLayoutSwitcher.ts`
- `src/features/print-export/components/PrintModal.tsx`
- `src/features/grid-editor/components/Grid/IsometricPreview.tsx`

## Test plan
- [x] Build completes with zero warnings
- [x] All 3356 tests pass
- [x] Coverage thresholds met