### PR TITLE
perf: optimize pre-commit test execution for high-core CPUs

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 npx lint-staged
 npm run check:boundaries:staged
 npm run build
-npm run test:coverage
+npm run test:affected

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:affected": "./scripts/test-affected.sh",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "prepare": "husky",

--- a/scripts/test-affected.sh
+++ b/scripts/test-affected.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# test-affected.sh - Run tests only for files affected by staged changes
+# Optimized for pre-commit hooks on high-core-count systems (e.g., Ryzen 9 7950X3D)
+#
+# Strategy:
+# - Pre-commit: Run affected tests WITHOUT coverage (fast feedback)
+# - CI: Run full test suite WITH coverage thresholds
+#
+# This avoids the issue where partial test runs can't meet global coverage thresholds.
+
+set -e
+
+# Get staged TypeScript/TSX files
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(ts|tsx)$' || true)
+
+if [ -z "$STAGED_FILES" ]; then
+  echo "✓ No staged TypeScript files, skipping tests"
+  exit 0
+fi
+
+# Count changed files
+FILE_COUNT=$(echo "$STAGED_FILES" | wc -l)
+
+# Threshold for switching to full test suite
+# `vitest related` analyzes import graphs, which can be slow with many files
+MAX_FILES_FOR_RELATED=15
+
+echo "📁 Staged TypeScript files: $FILE_COUNT"
+
+if [ "$FILE_COUNT" -gt "$MAX_FILES_FOR_RELATED" ]; then
+  echo "🔄 Many files changed ($FILE_COUNT > $MAX_FILES_FOR_RELATED), running full test suite..."
+  npx vitest run
+else
+  echo "🎯 Running tests related to changed files..."
+  # Convert newlines to spaces for vitest related command
+  FILES_ARGS=$(echo "$STAGED_FILES" | tr '\n' ' ')
+
+  # Run related tests (no coverage - thresholds checked in CI)
+  # shellcheck disable=SC2086
+  npx vitest related $FILES_ARGS --run
+fi
+
+echo "✓ Tests passed"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vitest/config'
-import react from '@vitejs/plugin-react'
-import path from 'path'
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
@@ -9,6 +9,9 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
     exclude: ['e2e/**', 'node_modules/**'],
+    // Optimized for high-core-count CPUs (Ryzen 9 7950X3D: 16c/32t)
+    pool: 'threads', // Worker threads are faster than forks for jsdom tests
+    maxWorkers: 32, // Use all available threads
     coverage: {
       provider: 'v8',
       reporter: ['text', 'text-summary', 'html'],
@@ -42,4 +45,4 @@ export default defineConfig({
       'virtual:pwa-register/react': path.resolve(__dirname, 'src/test/mocks/pwa-register.ts'),
     },
   },
-})
+});


### PR DESCRIPTION
## Summary
Speed up pre-commit hook by running only affected tests instead of the full test suite with coverage.

- Configure Vitest to use threads pool with 32 workers (optimized for Ryzen 9 7950X3D)
- Add `test-affected.sh` script that uses `vitest related` to run only tests that import changed files
- Replace `npm run test:coverage` with `npm run test:affected` in pre-commit hook

## Performance improvement

| Scenario | Before | After | Speedup |
|----------|--------|-------|---------|
| Full test suite (no coverage) | 7.2s | **6.7s** | ~10% |
| Full test suite (with coverage) | 9.5s | **8.5s** | ~10% |
| Typical commit (1-5 files) | 9.5s | **3-5s** | ~50-70% |

## How it works

The `test-affected.sh` script:
1. Detects staged `.ts`/`.tsx` files
2. Uses `vitest related` to trace imports and find affected test files
3. Runs only those tests (without coverage - thresholds checked in CI)
4. Falls back to full suite if >15 files changed

## Test plan
- [x] `npm run test:run` passes with new pool config
- [x] `npm run test:affected` correctly detects staged files
- [x] Pre-commit hook completes successfully
- [x] CI will verify full coverage thresholds