### PR TITLE
fix: resolve API TypeScript errors for Vercel build

### DIFF
--- a/api/lib/rateLimit.ts
+++ b/api/lib/rateLimit.ts
@@ -1,8 +1,7 @@
-import type { RedisOptions } from 'ioredis';
+import type { RedisOptions, Redis as RedisInstance } from 'ioredis';
 import Redis from 'ioredis';
 
-export type RateLimitAction =
-  | 'create' | 'update' | 'view' | 'delete' | 'report' | 'telemetry';
+export type RateLimitAction = 'create' | 'update' | 'view' | 'delete' | 'report' | 'telemetry';
 
 /**
  * Parse Redis URL using WHATWG URL API to avoid deprecated url.parse().
@@ -26,12 +25,12 @@ interface RateLimitConfig {
 }
 
 const RATE_LIMITS: Record<RateLimitAction, RateLimitConfig> = {
-  create: { limit: 100, windowSeconds: 60 },       // 100/minute (dev friendly)
-  update: { limit: 100, windowSeconds: 60 },       // 100/minute (dev friendly)
-  view: { limit: 100, windowSeconds: 60 },         // 100/minute
-  delete: { limit: 100, windowSeconds: 60 },       // 100/minute (dev friendly)
-  report: { limit: 10, windowSeconds: 3600 },      // 10/hour
-  telemetry: { limit: 100, windowSeconds: 60 },    // 100/minute (ML telemetry)
+  create: { limit: 100, windowSeconds: 60 }, // 100/minute (dev friendly)
+  update: { limit: 100, windowSeconds: 60 }, // 100/minute (dev friendly)
+  view: { limit: 100, windowSeconds: 60 }, // 100/minute
+  delete: { limit: 100, windowSeconds: 60 }, // 100/minute (dev friendly)
+  report: { limit: 10, windowSeconds: 3600 }, // 10/hour
+  telemetry: { limit: 100, windowSeconds: 60 }, // 100/minute (ML telemetry)
 };
 
 interface RateLimitResult {
@@ -42,9 +41,9 @@ interface RateLimitResult {
 }
 
 // Lazy-initialize Redis connection
-let redis: Redis | null = null;
+let redis: RedisInstance | null = null;
 
-function getRedis(): Redis | null {
+function getRedis(): RedisInstance | null {
   if (!process.env.REDIS_URL) {
     return null;
   }
@@ -91,9 +90,10 @@ export async function checkRateLimit(
     if (count >= config.limit) {
       // Get oldest entry to calculate reset time
       const oldest = await client.zrange(key, 0, 0, 'WITHSCORES');
-      const resetAt = oldest.length > 1
-        ? Math.ceil(Number(oldest[1]) + config.windowSeconds)
-        : now + config.windowSeconds;
+      const resetAt =
+        oldest.length > 1
+          ? Math.ceil(Number(oldest[1]) + config.windowSeconds)
+          : now + config.windowSeconds;
 
       return {
         allowed: false,
@@ -135,7 +135,7 @@ function hashIP(ip: string): string {
   let hash = 0;
   for (let i = 0; i < ip.length; i++) {
     const char = ip.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
+    hash = (hash << 5) - hash + char;
     hash = hash & hash; // Convert to 32-bit int
   }
   return Math.abs(hash).toString(36);
@@ -146,7 +146,9 @@ function hashIP(ip: string): string {
  * Vercel sets x-forwarded-for header.
  * Supports both Fetch API Request and Node.js IncomingHttpHeaders.
  */
-export function getClientIP(request: Request | { headers: Record<string, string | string[] | undefined> }): string {
+export function getClientIP(
+  request: Request | { headers: Record<string, string | string[] | undefined> }
+): string {
   // Handle Fetch API Request
   if ('get' in request.headers && typeof request.headers.get === 'function') {
     const forwarded = request.headers.get('x-forwarded-for');

--- a/api/ml-telemetry.ts
+++ b/api/ml-telemetry.ts
@@ -111,7 +111,7 @@
  */
 
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import type { RedisOptions } from 'ioredis';
+import type { RedisOptions, Redis as RedisInstance } from 'ioredis';
 import Redis from 'ioredis';
 import { getClientIP } from './lib/rateLimit.js';
 
@@ -161,7 +161,12 @@ interface LabelUpdateEvent {
 }
 
 type LayoutArchetype = 'uniform' | 'mixed' | 'border_fill' | 'compartmentalized' | 'layered';
-type SpatialPattern = 'corner_start' | 'large_first' | 'category_grouped' | 'edge_aligned' | 'center_out';
+type SpatialPattern =
+  | 'corner_start'
+  | 'large_first'
+  | 'category_grouped'
+  | 'edge_aligned'
+  | 'center_out';
 
 interface EdgeUsage {
   left: boolean;
@@ -172,7 +177,16 @@ interface EdgeUsage {
 
 interface LayoutSnapshotEvent {
   type: 'layout_snapshot';
-  trigger: 'save' | 'export_json' | 'export_tsv' | 'share' | 'print' | 'session_end' | 'layout_switch' | 'idle' | 'print_preview';
+  trigger:
+    | 'save'
+    | 'export_json'
+    | 'export_tsv'
+    | 'share'
+    | 'print'
+    | 'session_end'
+    | 'layout_switch'
+    | 'idle'
+    | 'print_preview';
   layout_hash: string;
   snapshot_index: number;
   drawer_size: string;
@@ -212,7 +226,14 @@ type AbandonmentType = 'incomplete' | 'deleted' | 'dormant' | 'superseded';
 interface LayoutQualityEvent {
   type: 'layout_quality';
   layout_hash: string;
-  signal: 'shared' | 'exported' | 'duplicated' | 'deleted' | 'revisited_edited' | 'revisited_kept' | 'modified';
+  signal:
+    | 'shared'
+    | 'exported'
+    | 'duplicated'
+    | 'deleted'
+    | 'revisited_edited'
+    | 'revisited_kept'
+    | 'modified';
   days_since_creation: number;
   confidence_breakdown?: ConfidenceBreakdown;
   abandonment_type: AbandonmentType | null;
@@ -260,7 +281,6 @@ interface BinDeletedEvent {
   fill_pct: number;
   method: 'key' | 'context_menu' | 'bulk' | 'inspector';
 }
-
 
 interface AbandonedBinEvent {
   type: 'bin_abandoned';
@@ -336,7 +356,15 @@ interface PlacementRejectedEvent {
 
 interface UndoEvent {
   type: 'undo';
-  action_undone: 'placement' | 'deletion' | 'move' | 'resize' | 'fill' | 'layer_change' | 'drawer_resize' | 'other';
+  action_undone:
+    | 'placement'
+    | 'deletion'
+    | 'move'
+    | 'resize'
+    | 'fill'
+    | 'layer_change'
+    | 'drawer_resize'
+    | 'other';
   bins_affected: number;
   time_since_action_ms: number;
   drawer_size: string;
@@ -429,9 +457,9 @@ function parseRedisUrl(redisUrl: string): RedisOptions {
   };
 }
 
-let redis: Redis | null = null;
+let redis: RedisInstance | null = null;
 
-function getRedis(): Redis | null {
+function getRedis(): RedisInstance | null {
   if (!process.env.REDIS_URL) {
     return null;
   }
@@ -456,7 +484,7 @@ function getRedis(): Redis | null {
  * Uses the same Redis client as aggregation operations.
  * 100 requests per minute per IP.
  */
-async function checkRateLimitInternal(ip: string, client: Redis): Promise<boolean> {
+async function checkRateLimitInternal(ip: string, client: RedisInstance): Promise<boolean> {
   const hashedIP = hashIP(ip);
   const key = `ml_ratelimit:${hashedIP}`;
   const now = Math.floor(Date.now() / 1000);
@@ -485,7 +513,7 @@ function hashIP(ip: string): string {
   let hash = 0;
   for (let i = 0; i < ip.length; i++) {
     const char = ip.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
+    hash = (hash << 5) - hash + char;
     hash = hash & hash;
   }
   return Math.abs(hash).toString(16).slice(0, 8);
@@ -559,15 +587,41 @@ const VALID_LAYER_MOVE_METHODS = new Set(['inspector', 'drag', 'keyboard', 'cont
 const VALID_FILL_SIZE_REGEX = /^\d+(\.\d+)?x\d+(\.\d+)?$/; // WxD (no height)
 
 // Negative signal validation
-const VALID_REJECTION_REASONS = new Set(['cancelled', 'second_touch', 'outside_bounds', 'too_small']);
+const VALID_REJECTION_REASONS = new Set([
+  'cancelled',
+  'second_touch',
+  'outside_bounds',
+  'too_small',
+]);
 const VALID_DRAW_MODES = new Set(['draw', 'paint']);
-const VALID_UNDO_ACTIONS = new Set(['placement', 'deletion', 'move', 'resize', 'fill', 'layer_change', 'drawer_resize', 'other']);
+const VALID_UNDO_ACTIONS = new Set([
+  'placement',
+  'deletion',
+  'move',
+  'resize',
+  'fill',
+  'layer_change',
+  'drawer_resize',
+  'other',
+]);
 const VALID_CORRECTION_TYPES = new Set(['delete', 'resize', 'move']);
 const VALID_RESIZE_DIRECTIONS = new Set(['grow', 'shrink', 'mixed']);
 
 // Pattern detection validation
-const VALID_ARCHETYPES = new Set(['uniform', 'mixed', 'border_fill', 'compartmentalized', 'layered']);
-const VALID_SPATIAL_PATTERNS = new Set(['corner_start', 'large_first', 'category_grouped', 'edge_aligned', 'center_out']);
+const VALID_ARCHETYPES = new Set([
+  'uniform',
+  'mixed',
+  'border_fill',
+  'compartmentalized',
+  'layered',
+]);
+const VALID_SPATIAL_PATTERNS = new Set([
+  'corner_start',
+  'large_first',
+  'category_grouped',
+  'edge_aligned',
+  'center_out',
+]);
 
 /**
  * Validate spatial patterns array.
@@ -599,8 +653,7 @@ function validateEdgeUsage(value: unknown): value is EdgeUsage {
 function validateConfidenceBreakdown(value: unknown): value is ConfidenceBreakdown {
   if (!value || typeof value !== 'object') return false;
   const c = value as Record<string, unknown>;
-  const isValidScore = (v: unknown): boolean =>
-    typeof v === 'number' && v >= 0 && v <= 1;
+  const isValidScore = (v: unknown): boolean => typeof v === 'number' && v >= 0 && v <= 1;
   return (
     isValidScore(c.undo_score) &&
     isValidScore(c.completion_score) &&
@@ -614,10 +667,7 @@ function validateConfidenceBreakdown(value: unknown): value is ConfidenceBreakdo
  * Validate nullable string field used in Redis keys.
  * Returns true if null or matches the pattern.
  */
-function validateNullableField(
-  value: unknown,
-  pattern: RegExp
-): value is string | null {
+function validateNullableField(value: unknown, pattern: RegExp): value is string | null {
   if (value === null) return true;
   return typeof value === 'string' && pattern.test(value);
 }
@@ -647,10 +697,7 @@ function validateSizeDistribution(value: unknown): value is Record<string, numbe
 /**
  * Validate category/domain distribution object (keys are valid IDs, values are positive numbers).
  */
-function validateDistribution(
-  value: unknown,
-  keyPattern: RegExp
-): value is Record<string, number> {
+function validateDistribution(value: unknown, keyPattern: RegExp): value is Record<string, number> {
   if (!value || typeof value !== 'object') return false;
   const obj = value as Record<string, unknown>;
   for (const [key, val] of Object.entries(obj)) {
@@ -694,8 +741,7 @@ function validateEvent(event: unknown): event is MLTelemetryEvent {
       typeof e.bin_size === 'string' &&
       VALID_BIN_SIZE_REGEX.test(e.bin_size) &&
       (e.prev_bin_size === null ||
-        (typeof e.prev_bin_size === 'string' &&
-          VALID_BIN_SIZE_REGEX.test(e.prev_bin_size))) &&
+        (typeof e.prev_bin_size === 'string' && VALID_BIN_SIZE_REGEX.test(e.prev_bin_size))) &&
       typeof e.drawer_size === 'string' &&
       VALID_DRAWER_SIZE_REGEX.test(e.drawer_size) &&
       typeof e.gap_fit === 'string' &&
@@ -715,10 +761,14 @@ function validateEvent(event: unknown): event is MLTelemetryEvent {
       // Adjacent context validation (Priority 3)
       Array.isArray(e.adjacent_label_hashes) &&
       e.adjacent_label_hashes.length <= 8 &&
-      e.adjacent_label_hashes.every((h: unknown) => typeof h === 'string' && VALID_LABEL_HASH_REGEX.test(h)) &&
+      e.adjacent_label_hashes.every(
+        (h: unknown) => typeof h === 'string' && VALID_LABEL_HASH_REGEX.test(h)
+      ) &&
       Array.isArray(e.adjacent_sizes) &&
       e.adjacent_sizes.length <= 8 &&
-      e.adjacent_sizes.every((s: unknown) => typeof s === 'string' && VALID_BIN_SIZE_REGEX.test(s)) &&
+      e.adjacent_sizes.every(
+        (s: unknown) => typeof s === 'string' && VALID_BIN_SIZE_REGEX.test(s)
+      ) &&
       typeof e.adjacent_count === 'number' &&
       e.adjacent_count >= 0 &&
       e.adjacent_count <= 8 &&
@@ -816,9 +866,11 @@ function validateEvent(event: unknown): event is MLTelemetryEvent {
       e.days_since_creation >= 0 &&
       e.days_since_creation < 10000 &&
       // New fields for PR 5
-      (e.confidence_breakdown === undefined || validateConfidenceBreakdown(e.confidence_breakdown)) &&
+      (e.confidence_breakdown === undefined ||
+        validateConfidenceBreakdown(e.confidence_breakdown)) &&
       (e.abandonment_type === null ||
-        (typeof e.abandonment_type === 'string' && VALID_ABANDONMENT_TYPES.has(e.abandonment_type))) &&
+        (typeof e.abandonment_type === 'string' &&
+          VALID_ABANDONMENT_TYPES.has(e.abandonment_type))) &&
       typeof e.time_since_last_edit_ms === 'number' &&
       e.time_since_last_edit_ms >= 0 &&
       e.time_since_last_edit_ms < 86400000 // Max 24 hours
@@ -851,7 +903,8 @@ function validateEvent(event: unknown): event is MLTelemetryEvent {
   }
 
   if (e.type === 'bin_resized') {
-    const validDimensions = Array.isArray(e.dimensions_changed) &&
+    const validDimensions =
+      Array.isArray(e.dimensions_changed) &&
       e.dimensions_changed.length > 0 &&
       e.dimensions_changed.every((d: unknown) => d === 'width' || d === 'depth');
     return (
@@ -920,7 +973,8 @@ function validateEvent(event: unknown): event is MLTelemetryEvent {
   }
 
   if (e.type === 'drawer_resized') {
-    const validDimensions = Array.isArray(e.dimensions_changed) &&
+    const validDimensions =
+      Array.isArray(e.dimensions_changed) &&
       e.dimensions_changed.length > 0 &&
       e.dimensions_changed.every((d: unknown) => d === 'width' || d === 'depth' || d === 'height');
     return (
@@ -1000,7 +1054,8 @@ function validateEvent(event: unknown): event is MLTelemetryEvent {
       (e.intended_size === null ||
         (typeof e.intended_size === 'string' && VALID_FILL_SIZE_REGEX.test(e.intended_size))) &&
       (e.intended_position === null ||
-        (typeof e.intended_position === 'string' && VALID_POSITION_REGEX.test(e.intended_position))) &&
+        (typeof e.intended_position === 'string' &&
+          VALID_POSITION_REGEX.test(e.intended_position))) &&
       typeof e.layer_index === 'number' &&
       e.layer_index >= 0 &&
       e.layer_index <= 20 &&
@@ -1128,16 +1183,20 @@ function validateEvent(event: unknown): event is MLTelemetryEvent {
     }
 
     // Validate inferred_purpose
-    if (e.inferred_purpose !== null &&
-        (typeof e.inferred_purpose !== 'string' ||
-         (!VALID_PURPOSES.has(e.inferred_purpose) && !VALID_PURPOSE_REGEX.test(e.inferred_purpose)))) {
+    if (
+      e.inferred_purpose !== null &&
+      (typeof e.inferred_purpose !== 'string' ||
+        (!VALID_PURPOSES.has(e.inferred_purpose) && !VALID_PURPOSE_REGEX.test(e.inferred_purpose)))
+    ) {
       return false;
     }
 
     // Validate confidence
-    if (typeof e.inferred_purpose_confidence !== 'number' ||
-        e.inferred_purpose_confidence < 0 ||
-        e.inferred_purpose_confidence > 1) {
+    if (
+      typeof e.inferred_purpose_confidence !== 'number' ||
+      e.inferred_purpose_confidence < 0 ||
+      e.inferred_purpose_confidence > 1
+    ) {
       return false;
     }
 
@@ -1151,7 +1210,11 @@ function validateEvent(event: unknown): event is MLTelemetryEvent {
       if (typeof item.label_hash !== 'string' || !VALID_LABEL_HASH_REGEX.test(item.label_hash)) {
         return false;
       }
-      if (!Array.isArray(item.sizes_used) || item.sizes_used.length === 0 || item.sizes_used.length > 10) {
+      if (
+        !Array.isArray(item.sizes_used) ||
+        item.sizes_used.length === 0 ||
+        item.sizes_used.length > 10
+      ) {
         return false;
       }
       for (const size of item.sizes_used) {
@@ -1262,8 +1325,7 @@ function aggregateBinPlacement(event: BinPlacementEvent, inc: Increments): void 
   // Track adjacent bin count distribution
   inc['ml:adjacent_counts'] = inc['ml:adjacent_counts'] || {};
   const adjBucket = event.adjacent_count >= 4 ? '4+' : String(event.adjacent_count);
-  inc['ml:adjacent_counts'][adjBucket] =
-    (inc['ml:adjacent_counts'][adjBucket] || 0) + 1;
+  inc['ml:adjacent_counts'][adjBucket] = (inc['ml:adjacent_counts'][adjBucket] || 0) + 1;
 
   // 11. First-of-label tracking (Priority 5)
   // Track initial size choices for new item types - strong learning signal
@@ -1417,15 +1479,21 @@ function aggregateLayoutSnapshot(event: LayoutSnapshotEvent, inc: Increments): v
   // 12. Track uniformity score buckets (0-0.25, 0.25-0.5, 0.5-0.75, 0.75-1.0)
   const uniformityBucket = Math.min(Math.floor(uniformity_score * 4), 3);
   inc['ml:uniformity'] = inc['ml:uniformity'] || {};
-  inc['ml:uniformity'][`bucket_${uniformityBucket}`] = (inc['ml:uniformity'][`bucket_${uniformityBucket}`] || 0) + 1;
+  inc['ml:uniformity'][`bucket_${uniformityBucket}`] =
+    (inc['ml:uniformity'][`bucket_${uniformityBucket}`] || 0) + 1;
 
   // 13. Track edge usage patterns
-  const edgeCount = [edge_usage.left, edge_usage.right, edge_usage.top, edge_usage.bottom].filter(Boolean).length;
+  const edgeCount = [edge_usage.left, edge_usage.right, edge_usage.top, edge_usage.bottom].filter(
+    Boolean
+  ).length;
   inc['ml:edge_count'] = inc['ml:edge_count'] || {};
-  inc['ml:edge_count'][`edges_${edgeCount}`] = (inc['ml:edge_count'][`edges_${edgeCount}`] || 0) + 1;
+  inc['ml:edge_count'][`edges_${edgeCount}`] =
+    (inc['ml:edge_count'][`edges_${edgeCount}`] || 0) + 1;
 
   // Track specific edge combinations
-  const edgeKey = `${edge_usage.left ? 'L' : ''}${edge_usage.right ? 'R' : ''}${edge_usage.top ? 'T' : ''}${edge_usage.bottom ? 'B' : ''}` || 'none';
+  const edgeKey =
+    `${edge_usage.left ? 'L' : ''}${edge_usage.right ? 'R' : ''}${edge_usage.top ? 'T' : ''}${edge_usage.bottom ? 'B' : ''}` ||
+    'none';
   inc['ml:edge_combo'] = inc['ml:edge_combo'] || {};
   inc['ml:edge_combo'][edgeKey] = (inc['ml:edge_combo'][edgeKey] || 0) + 1;
 
@@ -1464,7 +1532,8 @@ function aggregateLayoutSnapshot(event: LayoutSnapshotEvent, inc: Increments): v
 
   // Track cluster distribution (how common each structure hash is)
   inc['ml:cluster_distribution'] = inc['ml:cluster_distribution'] || {};
-  inc['ml:cluster_distribution'][structure_hash] = (inc['ml:cluster_distribution'][structure_hash] || 0) + 1;
+  inc['ml:cluster_distribution'][structure_hash] =
+    (inc['ml:cluster_distribution'][structure_hash] || 0) + 1;
 }
 
 function aggregateQualitySignal(event: LayoutQualityEvent, inc: Increments): void {
@@ -1493,9 +1562,14 @@ function aggregateQualitySignal(event: LayoutQualityEvent, inc: Increments): voi
   // Track confidence breakdown distribution (if provided)
   if (confidence_breakdown) {
     // Track combined confidence in buckets
-    const confBucket = confidence_breakdown.combined < 0.25 ? 'very_low' :
-      confidence_breakdown.combined < 0.5 ? 'low' :
-      confidence_breakdown.combined < 0.75 ? 'medium' : 'high';
+    const confBucket =
+      confidence_breakdown.combined < 0.25
+        ? 'very_low'
+        : confidence_breakdown.combined < 0.5
+          ? 'low'
+          : confidence_breakdown.combined < 0.75
+            ? 'medium'
+            : 'high';
     inc['ml:quality_confidence'] = inc['ml:quality_confidence'] || {};
     inc['ml:quality_confidence'][confBucket] = (inc['ml:quality_confidence'][confBucket] || 0) + 1;
 
@@ -1505,7 +1579,12 @@ function aggregateQualitySignal(event: LayoutQualityEvent, inc: Increments): voi
     inc[confBySignalKey][confBucket] = (inc[confBySignalKey][confBucket] || 0) + 1;
 
     // Track individual score distributions for analysis
-    const scoreNames = ['undo_score', 'completion_score', 'session_score', 'correction_score'] as const;
+    const scoreNames = [
+      'undo_score',
+      'completion_score',
+      'session_score',
+      'correction_score',
+    ] as const;
     for (const scoreName of scoreNames) {
       const score = confidence_breakdown[scoreName];
       const scoreBucket = score < 0.4 ? 'low' : score < 0.7 ? 'medium' : 'high';
@@ -1527,11 +1606,17 @@ function aggregateQualitySignal(event: LayoutQualityEvent, inc: Increments): voi
   }
 
   // Track time since last edit (dormancy detection)
-  const dormancyBucket = time_since_last_edit_ms < 60_000 ? 'active' :
-    time_since_last_edit_ms < 300_000 ? 'recent' :
-    time_since_last_edit_ms < 1800_000 ? 'idle' : 'dormant';
+  const dormancyBucket =
+    time_since_last_edit_ms < 60_000
+      ? 'active'
+      : time_since_last_edit_ms < 300_000
+        ? 'recent'
+        : time_since_last_edit_ms < 1800_000
+          ? 'idle'
+          : 'dormant';
   inc['ml:quality_dormancy'] = inc['ml:quality_dormancy'] || {};
-  inc['ml:quality_dormancy'][dormancyBucket] = (inc['ml:quality_dormancy'][dormancyBucket] || 0) + 1;
+  inc['ml:quality_dormancy'][dormancyBucket] =
+    (inc['ml:quality_dormancy'][dormancyBucket] || 0) + 1;
 }
 
 function aggregateDrawerPurpose(event: DrawerPurposeEvent, inc: Increments): void {
@@ -1716,10 +1801,12 @@ function aggregateDrawerResize(event: DrawerResizedEvent, inc: Increments): void
   // Track how often bins are staged due to resize
   if (bins_staged > 0) {
     inc['ml:drawer_resize_staged'] = inc['ml:drawer_resize_staged'] || {};
-    inc['ml:drawer_resize_staged']['with_bins'] = (inc['ml:drawer_resize_staged']['with_bins'] || 0) + 1;
+    inc['ml:drawer_resize_staged']['with_bins'] =
+      (inc['ml:drawer_resize_staged']['with_bins'] || 0) + 1;
   } else {
     inc['ml:drawer_resize_staged'] = inc['ml:drawer_resize_staged'] || {};
-    inc['ml:drawer_resize_staged']['no_bins'] = (inc['ml:drawer_resize_staged']['no_bins'] || 0) + 1;
+    inc['ml:drawer_resize_staged']['no_bins'] =
+      (inc['ml:drawer_resize_staged']['no_bins'] || 0) + 1;
   }
 
   // Track total drawer resizes
@@ -1750,9 +1837,14 @@ function aggregateFillOperation(event: FillOperationEvent, inc: Increments): voi
   }
 
   // Track bins created per fill (helps understand fill efficiency)
-  const binsBucket = bins_created <= 10 ? 'small' :
-    bins_created <= 50 ? 'medium' :
-    bins_created <= 100 ? 'large' : 'xlarge';
+  const binsBucket =
+    bins_created <= 10
+      ? 'small'
+      : bins_created <= 50
+        ? 'medium'
+        : bins_created <= 100
+          ? 'large'
+          : 'xlarge';
   inc['ml:fill_bins'] = inc['ml:fill_bins'] || {};
   inc['ml:fill_bins'][binsBucket] = (inc['ml:fill_bins'][binsBucket] || 0) + 1;
 
@@ -1889,12 +1981,18 @@ function aggregateUndo(event: UndoEvent, inc: Increments): void {
   // Track by action + timing (e.g., "placement_immediate" indicates bad auto-suggestion)
   const actionTimingKey = `${action_undone}_${timingBucket}`;
   inc['ml:neg:undo_action_timing'] = inc['ml:neg:undo_action_timing'] || {};
-  inc['ml:neg:undo_action_timing'][actionTimingKey] = (inc['ml:neg:undo_action_timing'][actionTimingKey] || 0) + 1;
+  inc['ml:neg:undo_action_timing'][actionTimingKey] =
+    (inc['ml:neg:undo_action_timing'][actionTimingKey] || 0) + 1;
 
   // Track bins affected (bulk undos vs single-bin undos)
-  const binsBucket = bins_affected <= 1 ? 'single' :
-    bins_affected <= 5 ? 'few' :
-    bins_affected <= 20 ? 'many' : 'bulk';
+  const binsBucket =
+    bins_affected <= 1
+      ? 'single'
+      : bins_affected <= 5
+        ? 'few'
+        : bins_affected <= 20
+          ? 'many'
+          : 'bulk';
   inc['ml:neg:undo_scale'] = inc['ml:neg:undo_scale'] || {};
   inc['ml:neg:undo_scale'][binsBucket] = (inc['ml:neg:undo_scale'][binsBucket] || 0) + 1;
 
@@ -1915,16 +2013,19 @@ function aggregateUndo(event: UndoEvent, inc: Increments): void {
  * - ml:neg:resize_correct:{size}         → What users resize corrected bins to
  */
 function aggregateQuickCorrection(event: QuickCorrectionEvent, inc: Increments): void {
-  const { correction_type, original_size, new_size, placement_method, time_to_correction_ms } = event;
+  const { correction_type, original_size, new_size, placement_method, time_to_correction_ms } =
+    event;
 
   // Track correction type (delete, resize, move)
   inc['ml:neg:quick_corrections'] = inc['ml:neg:quick_corrections'] || {};
-  inc['ml:neg:quick_corrections'][correction_type] = (inc['ml:neg:quick_corrections'][correction_type] || 0) + 1;
+  inc['ml:neg:quick_corrections'][correction_type] =
+    (inc['ml:neg:quick_corrections'][correction_type] || 0) + 1;
 
   // STRONG NEGATIVE SIGNAL: Track which sizes get quickly corrected
   // These are sizes the model should NOT suggest
   inc['ml:neg:corrected_sizes'] = inc['ml:neg:corrected_sizes'] || {};
-  inc['ml:neg:corrected_sizes'][original_size] = (inc['ml:neg:corrected_sizes'][original_size] || 0) + 1;
+  inc['ml:neg:corrected_sizes'][original_size] =
+    (inc['ml:neg:corrected_sizes'][original_size] || 0) + 1;
 
   // Track which placement methods produce quick corrections
   // High correction rate for a method = that method needs improvement
@@ -1943,7 +2044,8 @@ function aggregateQuickCorrection(event: QuickCorrectionEvent, inc: Increments):
     timingBucket = 'considered';
   }
   inc['ml:neg:correction_timing'] = inc['ml:neg:correction_timing'] || {};
-  inc['ml:neg:correction_timing'][timingBucket] = (inc['ml:neg:correction_timing'][timingBucket] || 0) + 1;
+  inc['ml:neg:correction_timing'][timingBucket] =
+    (inc['ml:neg:correction_timing'][timingBucket] || 0) + 1;
 
   // For resize corrections, track the size transition (what user ACTUALLY wanted)
   if (correction_type === 'resize' && new_size) {
@@ -1972,8 +2074,7 @@ function aggregateBinAbandonment(event: AbandonedBinEvent, inc: Increments): voi
   // STRONG NEGATIVE SIGNAL: Track which sizes get abandoned
   // These are sizes the model should be cautious about suggesting
   inc['ml:neg:abandoned_sizes'] = inc['ml:neg:abandoned_sizes'] || {};
-  inc['ml:neg:abandoned_sizes'][bin_size] =
-    (inc['ml:neg:abandoned_sizes'][bin_size] || 0) + 1;
+  inc['ml:neg:abandoned_sizes'][bin_size] = (inc['ml:neg:abandoned_sizes'][bin_size] || 0) + 1;
 
   // Track abandonment by creation method
   // High abandonment for a method = that method produces regrettable placements
@@ -2004,8 +2105,7 @@ function aggregateBinAbandonment(event: AbandonedBinEvent, inc: Increments): voi
 
   // Track total
   inc['ml:neg:abandonment_total'] = inc['ml:neg:abandonment_total'] || {};
-  inc['ml:neg:abandonment_total']['total'] =
-    (inc['ml:neg:abandonment_total']['total'] || 0) + 1;
+  inc['ml:neg:abandonment_total']['total'] = (inc['ml:neg:abandonment_total']['total'] || 0) + 1;
 }
 
 /**
@@ -2020,7 +2120,8 @@ function aggregateBinAbandonment(event: AbandonedBinEvent, inc: Increments): voi
  * - ml:cross_layout_total             → Total cross-layout events
  */
 function aggregateCrossLayoutPattern(event: CrossLayoutPatternEvent, inc: Increments): void {
-  const { drawer_size, inferred_purpose, inferred_purpose_confidence, label_size_consistency } = event;
+  const { drawer_size, inferred_purpose, inferred_purpose_confidence, label_size_consistency } =
+    event;
 
   // Track inferred purpose by drawer size
   if (inferred_purpose) {
@@ -2030,10 +2131,15 @@ function aggregateCrossLayoutPattern(event: CrossLayoutPatternEvent, inc: Increm
   }
 
   // Track confidence distribution (bucketed)
-  const confidenceBucket = inferred_purpose_confidence < 0.4 ? 'low' :
-    inferred_purpose_confidence < 0.7 ? 'medium' : 'high';
+  const confidenceBucket =
+    inferred_purpose_confidence < 0.4
+      ? 'low'
+      : inferred_purpose_confidence < 0.7
+        ? 'medium'
+        : 'high';
   inc['ml:purpose_confidence'] = inc['ml:purpose_confidence'] || {};
-  inc['ml:purpose_confidence'][confidenceBucket] = (inc['ml:purpose_confidence'][confidenceBucket] || 0) + 1;
+  inc['ml:purpose_confidence'][confidenceBucket] =
+    (inc['ml:purpose_confidence'][confidenceBucket] || 0) + 1;
 
   // Track label-size consistency
   let consistentCount = 0;
@@ -2052,8 +2158,10 @@ function aggregateCrossLayoutPattern(event: CrossLayoutPatternEvent, inc: Increm
   }
 
   inc['ml:label_consistency'] = inc['ml:label_consistency'] || {};
-  inc['ml:label_consistency']['consistent'] = (inc['ml:label_consistency']['consistent'] || 0) + consistentCount;
-  inc['ml:label_consistency']['inconsistent'] = (inc['ml:label_consistency']['inconsistent'] || 0) + inconsistentCount;
+  inc['ml:label_consistency']['consistent'] =
+    (inc['ml:label_consistency']['consistent'] || 0) + consistentCount;
+  inc['ml:label_consistency']['inconsistent'] =
+    (inc['ml:label_consistency']['inconsistent'] || 0) + inconsistentCount;
 
   // Track total cross-layout events
   inc['ml:cross_layout_total'] = inc['ml:cross_layout_total'] || {};
@@ -2090,45 +2198,78 @@ function aggregateSessionSummary(event: SessionSummaryEvent, inc: Increments): v
   } = event;
 
   // 1. Track bins placed per session (histogram buckets)
-  const binsBucket = bins_placed === 0 ? '0' :
-    bins_placed <= 5 ? '1-5' :
-    bins_placed <= 10 ? '6-10' :
-    bins_placed <= 20 ? '11-20' :
-    bins_placed <= 50 ? '21-50' : '51+';
+  const binsBucket =
+    bins_placed === 0
+      ? '0'
+      : bins_placed <= 5
+        ? '1-5'
+        : bins_placed <= 10
+          ? '6-10'
+          : bins_placed <= 20
+            ? '11-20'
+            : bins_placed <= 50
+              ? '21-50'
+              : '51+';
   inc['ml:session:bins_placed'] = inc['ml:session:bins_placed'] || {};
   inc['ml:session:bins_placed'][binsBucket] = (inc['ml:session:bins_placed'][binsBucket] || 0) + 1;
 
   // 2. Track edit-to-done ratio buckets
-  const editRatioBucket = edit_to_done_ratio === 0 ? 'zero' :
-    edit_to_done_ratio < 0.3 ? 'low' :
-    edit_to_done_ratio < 0.6 ? 'medium' : 'high';
+  const editRatioBucket =
+    edit_to_done_ratio === 0
+      ? 'zero'
+      : edit_to_done_ratio < 0.3
+        ? 'low'
+        : edit_to_done_ratio < 0.6
+          ? 'medium'
+          : 'high';
   inc['ml:session:edit_ratio'] = inc['ml:session:edit_ratio'] || {};
-  inc['ml:session:edit_ratio'][editRatioBucket] = (inc['ml:session:edit_ratio'][editRatioBucket] || 0) + 1;
+  inc['ml:session:edit_ratio'][editRatioBucket] =
+    (inc['ml:session:edit_ratio'][editRatioBucket] || 0) + 1;
 
   // 3. Track time to first bin buckets
   if (time_to_first_bin_ms !== null) {
-    const ttfbBucket = time_to_first_bin_ms < 10_000 ? 'quick' :      // <10s
-      time_to_first_bin_ms < 30_000 ? 'normal' :                        // 10-30s
-      time_to_first_bin_ms < 120_000 ? 'slow' : 'very_slow';            // 30-120s, >120s
+    const ttfbBucket =
+      time_to_first_bin_ms < 10_000
+        ? 'quick' // <10s
+        : time_to_first_bin_ms < 30_000
+          ? 'normal' // 10-30s
+          : time_to_first_bin_ms < 120_000
+            ? 'slow'
+            : 'very_slow'; // 30-120s, >120s
     inc['ml:session:time_to_first'] = inc['ml:session:time_to_first'] || {};
-    inc['ml:session:time_to_first'][ttfbBucket] = (inc['ml:session:time_to_first'][ttfbBucket] || 0) + 1;
+    inc['ml:session:time_to_first'][ttfbBucket] =
+      (inc['ml:session:time_to_first'][ttfbBucket] || 0) + 1;
   }
 
   // 4. Track confidence score distribution (buckets of 0.2)
-  const confidenceBucket = confidence_score < 0.2 ? 'very_low' :
-    confidence_score < 0.4 ? 'low' :
-    confidence_score < 0.6 ? 'medium' :
-    confidence_score < 0.8 ? 'high' : 'very_high';
+  const confidenceBucket =
+    confidence_score < 0.2
+      ? 'very_low'
+      : confidence_score < 0.4
+        ? 'low'
+        : confidence_score < 0.6
+          ? 'medium'
+          : confidence_score < 0.8
+            ? 'high'
+            : 'very_high';
   inc['ml:session:confidence'] = inc['ml:session:confidence'] || {};
-  inc['ml:session:confidence'][confidenceBucket] = (inc['ml:session:confidence'][confidenceBucket] || 0) + 1;
+  inc['ml:session:confidence'][confidenceBucket] =
+    (inc['ml:session:confidence'][confidenceBucket] || 0) + 1;
 
   // 5. Track session duration buckets
-  const durationBucket = session_duration_ms < 60_000 ? '<1min' :
-    session_duration_ms < 300_000 ? '1-5min' :
-    session_duration_ms < 900_000 ? '5-15min' :
-    session_duration_ms < 1800_000 ? '15-30min' : '30min+';
+  const durationBucket =
+    session_duration_ms < 60_000
+      ? '<1min'
+      : session_duration_ms < 300_000
+        ? '1-5min'
+        : session_duration_ms < 900_000
+          ? '5-15min'
+          : session_duration_ms < 1800_000
+            ? '15-30min'
+            : '30min+';
   inc['ml:session:duration'] = inc['ml:session:duration'] || {};
-  inc['ml:session:duration'][durationBucket] = (inc['ml:session:duration'][durationBucket] || 0) + 1;
+  inc['ml:session:duration'][durationBucket] =
+    (inc['ml:session:duration'][durationBucket] || 0) + 1;
 
   // 6. Track size sequences by drawer (first 5 sizes as pattern)
   if (size_sequence.length >= 2) {
@@ -2139,9 +2280,8 @@ function aggregateSessionSummary(event: SessionSummaryEvent, inc: Increments): v
   }
 
   // 7. Track undo count distribution
-  const undoBucket = undo_count === 0 ? '0' :
-    undo_count <= 2 ? '1-2' :
-    undo_count <= 5 ? '3-5' : '6+';
+  const undoBucket =
+    undo_count === 0 ? '0' : undo_count <= 2 ? '1-2' : undo_count <= 5 ? '3-5' : '6+';
   inc['ml:session:undo_count'] = inc['ml:session:undo_count'] || {};
   inc['ml:session:undo_count'][undoBucket] = (inc['ml:session:undo_count'][undoBucket] || 0) + 1;
 
@@ -2176,10 +2316,7 @@ function aggregateSessionSummary(event: SessionSummaryEvent, inc: Increments): v
  * @param res - VercelResponse used to send the JSON response
  */
 
-export default async function handler(
-  req: VercelRequest,
-  res: VercelResponse
-): Promise<void> {
+export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
   // Only accept POST
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
@@ -2322,9 +2459,11 @@ export default async function handler(
       // Add TTLs for keys that can grow unbounded (90 days)
       // These are lower-value or temporary data
       // Use NX flag to only set TTL on first creation, not reset on every write
-      if (hash === 'ml:unknown_hashes' ||
-          hash.startsWith('ml:size_seq:') ||
-          hash.startsWith('ml:cooccur:')) {
+      if (
+        hash === 'ml:unknown_hashes' ||
+        hash.startsWith('ml:size_seq:') ||
+        hash.startsWith('ml:cooccur:')
+      ) {
         pipe.expire(hash, 90 * 24 * 60 * 60, 'NX'); // 90 days, only if no TTL exists
       }
     }

--- a/api/report/[id].ts
+++ b/api/report/[id].ts
@@ -2,17 +2,15 @@ import { put, head } from '@vercel/blob';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP } from '../lib/rateLimit.js';
 import { REPORT_THRESHOLD } from '../lib/contentFilter.js';
-import {
-  isValidShareId,
-  ErrorCode,
-  type ShareData,
-} from '../lib/shared.js';
+import { isValidShareId, ErrorCode, type ShareData } from '../lib/shared.js';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Only allow POST for reports
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
-    return res.status(405).json({ error: 'Method not allowed', code: ErrorCode.METHOD_NOT_ALLOWED });
+    return res
+      .status(405)
+      .json({ error: 'Method not allowed', code: ErrorCode.METHOD_NOT_ALLOWED });
   }
 
   const { id } = req.query;
@@ -61,7 +59,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       });
     }
 
-    const shareData: ShareData = await response.json();
+    const shareData = (await response.json()) as ShareData;
 
     // Increment report count
     const newReportCount = shareData.metadata.reportCount + 1;

--- a/api/share.ts
+++ b/api/share.ts
@@ -15,7 +15,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Only allow POST for creating shares
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
-    return res.status(405).json({ error: 'Method not allowed', code: ErrorCode.METHOD_NOT_ALLOWED });
+    return res
+      .status(405)
+      .json({ error: 'Method not allowed', code: ErrorCode.METHOD_NOT_ALLOWED });
   }
 
   try {
@@ -62,9 +64,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const validationResult = validateShareLayout(layout, layoutJson.length);
 
     if (!validationResult.valid) {
+      const { error } = validationResult;
       return res.status(400).json({
-        error: validationResult.error.message,
-        code: validationResult.error.code,
+        error: error.message,
+        code: error.code,
       });
     }
 

--- a/api/share/[id].ts
+++ b/api/share/[id].ts
@@ -3,12 +3,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP } from '../lib/rateLimit.js';
 import { validateShareLayout } from '../lib/validation.js';
 import { filterLayoutContent } from '../lib/contentFilter.js';
-import {
-  isValidShareId,
-  hashToken,
-  ErrorCode,
-  type ShareData,
-} from '../lib/shared.js';
+import { isValidShareId, hashToken, ErrorCode, type ShareData } from '../lib/shared.js';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { id } = req.query;
@@ -31,19 +26,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return handleDelete(req, res, id, blobPath);
     default:
       res.setHeader('Allow', 'GET, PUT, DELETE');
-      return res.status(405).json({ error: 'Method not allowed', code: ErrorCode.METHOD_NOT_ALLOWED });
+      return res
+        .status(405)
+        .json({ error: 'Method not allowed', code: ErrorCode.METHOD_NOT_ALLOWED });
   }
 }
 
 /**
  * GET /api/share/[id] - Fetch a shared layout
  */
-async function handleGet(
-  req: VercelRequest,
-  res: VercelResponse,
-  id: string,
-  blobPath: string
-) {
+async function handleGet(req: VercelRequest, res: VercelResponse, _id: string, blobPath: string) {
   try {
     // Rate limiting
     const clientIP = getClientIP(req);
@@ -75,7 +67,7 @@ async function handleGet(
       });
     }
 
-    const shareData: ShareData = await response.json();
+    const shareData = (await response.json()) as ShareData;
 
     // Update lastAccessedAt timestamp (fire-and-forget, don't block response)
     const now = new Date().toISOString();
@@ -114,12 +106,7 @@ async function handleGet(
 /**
  * PUT /api/share/[id] - Update an existing share
  */
-async function handlePut(
-  req: VercelRequest,
-  res: VercelResponse,
-  id: string,
-  blobPath: string
-) {
+async function handlePut(req: VercelRequest, res: VercelResponse, id: string, blobPath: string) {
   try {
     // Rate limiting
     const clientIP = getClientIP(req);
@@ -159,7 +146,7 @@ async function handlePut(
       });
     }
 
-    const existingData: ShareData = await response.json();
+    const existingData = (await response.json()) as ShareData;
 
     // Verify delete token
     const tokenHash = await hashToken(deleteToken);
@@ -213,9 +200,10 @@ async function handlePut(
     const validationResult = validateShareLayout(layout, layoutJson.length);
 
     if (!validationResult.valid) {
+      const { error } = validationResult;
       return res.status(400).json({
-        error: validationResult.error.message,
-        code: validationResult.error.code,
+        error: error.message,
+        code: error.code,
       });
     }
 
@@ -267,7 +255,7 @@ async function handlePut(
 async function handleDelete(
   req: VercelRequest,
   res: VercelResponse,
-  id: string,
+  _id: string,
   blobPath: string
 ) {
   try {
@@ -284,8 +272,8 @@ async function handleDelete(
     }
 
     // Get delete token from header or body
-    const deleteToken = req.headers['x-delete-token'] as string ||
-      (req.body && req.body.deleteToken);
+    const deleteToken =
+      (req.headers['x-delete-token'] as string) || (req.body && req.body.deleteToken);
 
     if (!deleteToken) {
       return res.status(401).json({
@@ -311,7 +299,7 @@ async function handleDelete(
       });
     }
 
-    const existingData: ShareData = await response.json();
+    const existingData = (await response.json()) as ShareData;
 
     // Verify delete token
     const tokenHash = await hashToken(deleteToken);

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@types/react": "^19.2.8",
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.182.0",
+        "@vercel/node": "^5.5.26",
         "@vitejs/plugin-react": "^5.1.1",
         "@vitest/coverage-v8": "^4.0.17",
         "@vitest/ui": "^4.0.16",
@@ -181,6 +182,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1715,6 +1717,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -1803,6 +1829,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1846,6 +1873,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1855,6 +1883,60 @@
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@edge-runtime/format": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/format/-/format-2.2.1.tgz",
+      "integrity": "sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/node-utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/node-utils/-/node-utils-2.3.0.tgz",
+      "integrity": "sha512-uUtx8BFoO1hNxtHjp3eqVPC/mWImGb2exOfGjMLUoipuWgjej+f4o/VP4bUI8U40gu7Teogd5VTeZUkGvJSPOQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/ponyfill": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/ponyfill/-/ponyfill-2.4.2.tgz",
+      "integrity": "sha512-oN17GjFr69chu6sDLvXxdhg0Qe8EZviGSuqzR9qOiKh4MhFYGdBBcqRNzdmYeAdeRzOW2mM9yil4RftUQ7sUOA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/primitives": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-4.1.0.tgz",
+      "integrity": "sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/vm": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.2.0.tgz",
+      "integrity": "sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "@edge-runtime/primitives": "4.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.2",
@@ -2637,6 +2719,19 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2751,6 +2846,41 @@
         }
       }
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
+      "integrity": "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "consola": "^3.2.3",
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^7.0.5",
+        "node-fetch": "^2.6.7",
+        "nopt": "^8.0.0",
+        "semver": "^7.5.3",
+        "tar": "^7.4.0"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@mediapipe/tasks-vision": {
       "version": "0.10.17",
       "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
@@ -2769,11 +2899,50 @@
         "three": ">= 0.159.0"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3162,6 +3331,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.5.0.tgz",
       "integrity": "sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -4040,6 +4210,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4108,6 +4279,60 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.11.1.tgz",
+      "integrity": "sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.2.7",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
@@ -4202,7 +4427,8 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/lz-string": {
       "version": "1.5.0",
@@ -4220,6 +4446,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
       "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4235,6 +4462,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4245,6 +4473,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4276,6 +4505,7 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.182.0.tgz",
       "integrity": "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -4344,6 +4574,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -4640,6 +4871,724 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@vercel/build-utils": {
+      "version": "13.2.14",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.2.14.tgz",
+      "integrity": "sha512-+URzjZtGWyuvhIhVs2fb+O3nRLNo3y4g0pIJRcBym1FmLoONH10abNDmvzebGDKrKk45G+zQpmKbyE4ow/gL8Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vercel/error-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@vercel/error-utils/-/error-utils-2.0.3.tgz",
+      "integrity": "sha512-CqC01WZxbLUxoiVdh9B/poPbNpY9U+tO1N9oWHwTl5YAZxcqXmmWJ8KNMFItJCUUWdY3J3xv8LvAuQv2KZ5YdQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vercel/nft": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.1.1.tgz",
+      "integrity": "sha512-mKMGa7CEUcXU75474kOeqHbtvK1kAcu4wiahhmlUenB5JbTQB8wVlDI8CyHR3rpGo0qlzoRWqcDzI41FUoBJCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^2.0.0",
+        "@rollup/pluginutils": "^5.1.3",
+        "acorn": "^8.6.0",
+        "acorn-import-attributes": "^1.9.5",
+        "async-sema": "^3.1.1",
+        "bindings": "^1.4.0",
+        "estree-walker": "2.0.2",
+        "glob": "^13.0.0",
+        "graceful-fs": "^4.2.9",
+        "node-gyp-build": "^4.2.2",
+        "picomatch": "^4.0.2",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "nft": "out/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vercel/nft/node_modules/glob": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@vercel/node": {
+      "version": "5.5.26",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.5.26.tgz",
+      "integrity": "sha512-Rm/UcQlXmAIbIwJtLrle6xGgVm7VVO0fNsoNOHCxhNb3TqBIaQ+f2WgPBqHW947yCGYa8hPgTRmhaPtuB2/OJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@edge-runtime/node-utils": "2.3.0",
+        "@edge-runtime/primitives": "4.1.0",
+        "@edge-runtime/vm": "3.2.0",
+        "@types/node": "20.11.0",
+        "@vercel/build-utils": "13.2.14",
+        "@vercel/error-utils": "2.0.3",
+        "@vercel/nft": "1.1.1",
+        "@vercel/static-config": "3.1.2",
+        "async-listen": "3.0.0",
+        "cjs-module-lexer": "1.2.3",
+        "edge-runtime": "2.5.9",
+        "es-module-lexer": "1.4.1",
+        "esbuild": "0.27.0",
+        "etag": "1.8.1",
+        "mime-types": "2.1.35",
+        "node-fetch": "2.6.9",
+        "path-to-regexp": "6.1.0",
+        "path-to-regexp-updated": "npm:path-to-regexp@6.3.0",
+        "ts-morph": "12.0.0",
+        "ts-node": "10.9.1",
+        "typescript": "4.9.5",
+        "typescript5": "npm:typescript@5.9.3",
+        "undici": "5.28.4"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/android-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/android-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@types/node": {
+      "version": "20.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
+      "integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/es-module-lexer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
+      "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vercel/node/node_modules/esbuild": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.0",
+        "@esbuild/android-arm": "0.27.0",
+        "@esbuild/android-arm64": "0.27.0",
+        "@esbuild/android-x64": "0.27.0",
+        "@esbuild/darwin-arm64": "0.27.0",
+        "@esbuild/darwin-x64": "0.27.0",
+        "@esbuild/freebsd-arm64": "0.27.0",
+        "@esbuild/freebsd-x64": "0.27.0",
+        "@esbuild/linux-arm": "0.27.0",
+        "@esbuild/linux-arm64": "0.27.0",
+        "@esbuild/linux-ia32": "0.27.0",
+        "@esbuild/linux-loong64": "0.27.0",
+        "@esbuild/linux-mips64el": "0.27.0",
+        "@esbuild/linux-ppc64": "0.27.0",
+        "@esbuild/linux-riscv64": "0.27.0",
+        "@esbuild/linux-s390x": "0.27.0",
+        "@esbuild/linux-x64": "0.27.0",
+        "@esbuild/netbsd-arm64": "0.27.0",
+        "@esbuild/netbsd-x64": "0.27.0",
+        "@esbuild/openbsd-arm64": "0.27.0",
+        "@esbuild/openbsd-x64": "0.27.0",
+        "@esbuild/openharmony-arm64": "0.27.0",
+        "@esbuild/sunos-x64": "0.27.0",
+        "@esbuild/win32-arm64": "0.27.0",
+        "@esbuild/win32-ia32": "0.27.0",
+        "@esbuild/win32-x64": "0.27.0"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/node/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vercel/node/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/undici": {
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vercel/node/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@vercel/node/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/@vercel/speed-insights": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.3.1.tgz",
@@ -4673,6 +5622,42 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@vercel/static-config": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.1.2.tgz",
+      "integrity": "sha512-2d+TXr6K30w86a+WbMbGm2W91O0UzO5VeemZYBBUJbCjk/5FLLGIi8aV6RS2+WmaRvtcqNTn2pUA7nCOK3bGcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "8.6.3",
+        "json-schema-to-ts": "1.6.4",
+        "ts-morph": "12.0.0"
+      }
+    },
+    "node_modules/@vercel/static-config/node_modules/ajv": {
+      "version": "8.6.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@vercel/static-config/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.2",
@@ -4829,6 +5814,7 @@
       "integrity": "sha512-hRDjg6dlDz7JlZAvjbiCdAJ3SDG+NH8tjZe21vjxfvT2ssYAn72SRXMge3dKKABm3bIJ3C+3wdunIdur8PHEAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.17",
         "fflate": "^0.8.2",
@@ -4865,17 +5851,38 @@
       "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/abbrev": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -4886,6 +5893,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -4956,6 +5976,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5059,6 +6086,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/async-listen": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.0.tgz",
+      "integrity": "sha512-V+SsTpDqkrWTimiotsyl33ePSjA5/KrithwupuvJ6ztsqPvGv6ge4OredFhPffVXiLN/QUWvE0XcqJaYgt6fOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -5067,6 +6104,13 @@
       "dependencies": {
         "retry": "0.13.1"
       }
+    },
+    "node_modules/async-sema": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
+      "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -5192,6 +6236,16 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -5236,6 +6290,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5425,6 +6480,23 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -5535,6 +6607,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/code-block-writer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
+      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5589,6 +6668,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/convert-hrtime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-3.0.0.tgz",
+      "integrity": "sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -5620,6 +6719,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -5909,6 +7015,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -5959,6 +7075,60 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/edge-runtime": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.5.9.tgz",
+      "integrity": "sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@edge-runtime/format": "2.2.1",
+        "@edge-runtime/ponyfill": "2.4.2",
+        "@edge-runtime/vm": "3.2.0",
+        "async-listen": "3.0.1",
+        "mri": "1.2.0",
+        "picocolors": "1.0.0",
+        "pretty-ms": "7.0.1",
+        "signal-exit": "4.0.2",
+        "time-span": "4.0.0"
+      },
+      "bin": {
+        "edge-runtime": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/edge-runtime/node_modules/async-listen": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.1.tgz",
+      "integrity": "sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/edge-runtime/node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/edge-runtime/node_modules/signal-exit": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -6251,6 +7421,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6453,6 +7624,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -6500,6 +7681,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -6537,6 +7748,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -6555,6 +7776,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -7265,6 +8493,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.3.tgz",
       "integrity": "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -8028,6 +9257,7 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -8088,6 +9318,17 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-1.6.4.tgz",
+      "integrity": "sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.6",
+        "ts-toolbelt": "^6.15.5"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -8678,6 +9919,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/marked": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
@@ -8708,6 +9956,16 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/meshline": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
@@ -8735,6 +9993,29 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-function": {
@@ -8793,6 +10074,19 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -8804,6 +10098,16 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mrmime": {
@@ -8913,12 +10217,40 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^3.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -9106,6 +10438,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -9118,6 +10460,13 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -9181,6 +10530,21 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
+      "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp-updated": {
+      "name": "path-to-regexp",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -9247,6 +10611,7 @@
       "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -9403,6 +10768,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
@@ -9453,6 +10834,27 @@
       "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
       "license": "MIT"
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -9468,6 +10870,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9477,6 +10880,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9739,6 +11143,17 @@
         "node": ">= 4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -9788,6 +11203,7 @@
       "integrity": "sha512-y9yUpfQvetAjiDLtNMf1hL9NXchIJgWt6zIKeoB+tCd3npX08Eqfzg60V9DhIGVMtQ0AlMkFw5xa+AQ37zxnAA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9825,6 +11241,30 @@
         "@rollup/rollup-win32-x64-gnu": "4.55.3",
         "@rollup/rollup-win32-x64-msvc": "4.55.3",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-array-concat": {
@@ -10143,6 +11583,7 @@
       "integrity": "sha512-JBG8dioIs0m2kHOhs9jD6E/tZKD08vmbf2bfqj/rJyNWqJxk/ZcakixjhYtsqdbi+AKVbfPkt3g2RRZiKaizYA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "lilconfig": "^3.1.3",
@@ -10738,6 +12179,33 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
+      "integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/temp": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
@@ -10811,7 +12279,8 @@
       "version": "0.182.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
       "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -10852,6 +12321,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/time-span": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-4.0.0.tgz",
+      "integrity": "sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-hrtime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10915,6 +12400,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11043,6 +12529,68 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-morph": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-12.0.0.tgz",
+      "integrity": "sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.11.0",
+        "code-block-writer": "^10.1.1"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -11226,6 +12774,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11256,6 +12805,21 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/typescript5": {
+      "name": "typescript",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -11432,12 +12996,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vite": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11577,6 +13149,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11590,6 +13163,7 @@
       "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.17",
         "@vitest/mocker": "4.0.17",
@@ -12065,6 +13639,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12119,6 +13694,7 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -12532,6 +14108,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -12551,6 +14137,7 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@types/react": "^19.2.8",
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.182.0",
+    "@vercel/node": "^5.5.26",
     "@vitejs/plugin-react": "^5.1.1",
     "@vitest/coverage-v8": "^4.0.17",
     "@vitest/ui": "^4.0.16",

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.api.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "skipLibCheck": true,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./node_modules/.tmp/api-types",
+
+    /* Strict type checking */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+
+    /* Interop */
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["api/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "files": [],
-  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.api.json" }
+  ]
 }


### PR DESCRIPTION
## Summary
- Install `@vercel/node` for serverless function types
- Fix TypeScript errors that were causing Vercel builds to fail
- Add `tsconfig.api.json` to catch API type errors locally

## Problem
Vercel builds were failing with 15+ TypeScript errors in the `api/` directory:
- `@vercel/node` module not found
- Redis namespace errors (TS2709, TS2351)
- ValidationResult discriminated union narrowing issues (TS2339)
- Untyped `response.json()` returns (TS2322)

These errors weren't caught locally because the `api/` directory wasn't included in any tsconfig.

## Changes

### Dependencies
- Added `@vercel/node` as dev dependency for `VercelRequest`/`VercelResponse` types

### Type Fixes
| File | Fix |
|------|-----|
| `api/lib/rateLimit.ts` | Import `Redis as RedisInstance` type alias |
| `api/ml-telemetry.ts` | Import `Redis as RedisInstance` type alias |
| `api/share.ts` | Explicit destructuring for ValidationResult narrowing |
| `api/share/[id].ts` | Type assertions for `response.json()`, prefix unused params |
| `api/report/[id].ts` | Type assertion for `response.json()` |

### Configuration
- Added `tsconfig.api.json` for API-specific type checking
- Updated `tsconfig.json` to include API config in project references

## Test plan
- [x] `npx tsc -p tsconfig.api.json` passes with no errors
- [x] Client build succeeds (`npm run build`)
- [x] Pre-commit hooks pass (lint, build, tests)
- [ ] Vercel build should now succeed