### PR TITLE
fix: resolve remaining Vercel API TypeScript errors

### DIFF
--- a/api/lib/rateLimit.ts
+++ b/api/lib/rateLimit.ts
@@ -1,5 +1,5 @@
-import type { RedisOptions, Redis as RedisInstance } from 'ioredis';
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
+import type { RedisOptions } from 'ioredis';
 
 export type RateLimitAction = 'create' | 'update' | 'view' | 'delete' | 'report' | 'telemetry';
 
@@ -41,9 +41,9 @@ interface RateLimitResult {
 }
 
 // Lazy-initialize Redis connection
-let redis: RedisInstance | null = null;
+let redis: Redis | null = null;
 
-function getRedis(): RedisInstance | null {
+function getRedis(): Redis | null {
   if (!process.env.REDIS_URL) {
     return null;
   }

--- a/api/lib/validation.ts
+++ b/api/lib/validation.ts
@@ -25,8 +25,18 @@ const SHARE_CONSTRAINTS = {
 
 /** Reserved keys that cannot be used as custom property names */
 const RESERVED_PROPERTY_KEYS = [
-  'id', 'layerId', 'x', 'y', 'width', 'depth', 'height',
-  'clearanceHeight', 'category', 'label', 'notes', 'customProperties',
+  'id',
+  'layerId',
+  'x',
+  'y',
+  'width',
+  'depth',
+  'height',
+  'clearanceHeight',
+  'category',
+  'label',
+  'notes',
+  'customProperties',
 ];
 
 export type ValidExpiration = (typeof SHARE_CONSTRAINTS.VALID_EXPIRATIONS)[number];
@@ -85,13 +95,20 @@ export type ValidationResult =
   | { valid: false; error: ValidationError };
 
 /**
+ * Type guard for validation failure.
+ * Helps TypeScript narrow the type in environments where control flow analysis is limited.
+ */
+export function isValidationError(
+  result: ValidationResult
+): result is { valid: false; error: ValidationError } {
+  return !result.valid;
+}
+
+/**
  * Validate a layout for cloud sharing.
  * Returns sanitized layout on success.
  */
-export function validateShareLayout(
-  data: unknown,
-  jsonSize: number
-): ValidationResult {
+export function validateShareLayout(data: unknown, jsonSize: number): ValidationResult {
   // Size check first
   if (jsonSize > SHARE_CONSTRAINTS.MAX_SIZE_BYTES) {
     return {
@@ -163,8 +180,10 @@ export function validateShareLayout(
   }
 
   // Validate drawer dimensions
-  if (!isInRange(drawer.width, SHARE_CONSTRAINTS.GRID_MIN, SHARE_CONSTRAINTS.GRID_MAX) ||
-      !isInRange(drawer.depth, SHARE_CONSTRAINTS.GRID_MIN, SHARE_CONSTRAINTS.GRID_MAX)) {
+  if (
+    !isInRange(drawer.width, SHARE_CONSTRAINTS.GRID_MIN, SHARE_CONSTRAINTS.GRID_MAX) ||
+    !isInRange(drawer.depth, SHARE_CONSTRAINTS.GRID_MIN, SHARE_CONSTRAINTS.GRID_MAX)
+  ) {
     return {
       valid: false,
       error: {
@@ -230,7 +249,11 @@ export function validateShareLayout(
 
     // Validate and sanitize custom properties if present
     let validatedCustomProperties: Record<string, string> | undefined;
-    if (bin.customProperties && typeof bin.customProperties === 'object' && !Array.isArray(bin.customProperties)) {
+    if (
+      bin.customProperties &&
+      typeof bin.customProperties === 'object' &&
+      !Array.isArray(bin.customProperties)
+    ) {
       const props = bin.customProperties as Record<string, unknown>;
       const keys = Object.keys(props);
 
@@ -256,8 +279,14 @@ export function validateShareLayout(
         if (typeof value !== 'string') continue;
 
         // Sanitize key and value
-        const cleanKey = sanitizeString(String(key), SHARE_CONSTRAINTS.CUSTOM_PROPERTY_KEY_MAX_LENGTH);
-        const cleanValue = sanitizeString(value, SHARE_CONSTRAINTS.CUSTOM_PROPERTY_VALUE_MAX_LENGTH);
+        const cleanKey = sanitizeString(
+          String(key),
+          SHARE_CONSTRAINTS.CUSTOM_PROPERTY_KEY_MAX_LENGTH
+        );
+        const cleanValue = sanitizeString(
+          value,
+          SHARE_CONSTRAINTS.CUSTOM_PROPERTY_VALUE_MAX_LENGTH
+        );
 
         // Skip empty keys
         if (!cleanKey) continue;
@@ -355,7 +384,9 @@ function isValidDrawer(value: unknown): value is DrawerShape {
     typeof obj.width === 'number' &&
     typeof obj.depth === 'number' &&
     typeof obj.height === 'number' &&
-    obj.width > 0 && obj.depth > 0 && obj.height > 0
+    obj.width > 0 &&
+    obj.depth > 0 &&
+    obj.height > 0
   );
 }
 
@@ -363,9 +394,7 @@ function isValidLayer(value: unknown): value is LayerShape {
   if (!value || typeof value !== 'object') return false;
   const obj = value as Record<string, unknown>;
   return (
-    typeof obj.id === 'string' &&
-    typeof obj.name === 'string' &&
-    typeof obj.height === 'number'
+    typeof obj.id === 'string' && typeof obj.name === 'string' && typeof obj.height === 'number'
   );
 }
 
@@ -387,9 +416,7 @@ function isValidCategory(value: unknown): value is CategoryShape {
   if (!value || typeof value !== 'object') return false;
   const obj = value as Record<string, unknown>;
   return (
-    typeof obj.id === 'string' &&
-    typeof obj.name === 'string' &&
-    typeof obj.color === 'string'
+    typeof obj.id === 'string' && typeof obj.name === 'string' && typeof obj.color === 'string'
   );
 }
 
@@ -416,7 +443,10 @@ function sanitizeColor(color: string): string {
     let hex = match[1].toLowerCase();
     // Expand 3-char to 6-char (#abc -> #aabbcc)
     if (hex.length === 3) {
-      hex = hex.split('').map((c) => c + c).join('');
+      hex = hex
+        .split('')
+        .map((c) => c + c)
+        .join('');
     }
     return '#' + hex;
   }

--- a/api/ml-telemetry.ts
+++ b/api/ml-telemetry.ts
@@ -111,8 +111,8 @@
  */
 
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import type { RedisOptions, Redis as RedisInstance } from 'ioredis';
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
+import type { RedisOptions } from 'ioredis';
 import { getClientIP } from './lib/rateLimit.js';
 
 // ============================================
@@ -457,9 +457,9 @@ function parseRedisUrl(redisUrl: string): RedisOptions {
   };
 }
 
-let redis: RedisInstance | null = null;
+let redis: Redis | null = null;
 
-function getRedis(): RedisInstance | null {
+function getRedis(): Redis | null {
   if (!process.env.REDIS_URL) {
     return null;
   }
@@ -484,7 +484,7 @@ function getRedis(): RedisInstance | null {
  * Uses the same Redis client as aggregation operations.
  * 100 requests per minute per IP.
  */
-async function checkRateLimitInternal(ip: string, client: RedisInstance): Promise<boolean> {
+async function checkRateLimitInternal(ip: string, client: Redis): Promise<boolean> {
   const hashedIP = hashIP(ip);
   const key = `ml_ratelimit:${hashedIP}`;
   const now = Math.floor(Date.now() / 1000);

--- a/api/share.ts
+++ b/api/share.ts
@@ -1,7 +1,7 @@
 import { put } from '@vercel/blob';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP } from './lib/rateLimit.js';
-import { validateShareLayout } from './lib/validation.js';
+import { validateShareLayout, isValidationError } from './lib/validation.js';
 import { filterLayoutContent } from './lib/contentFilter.js';
 import {
   isValidShareId,
@@ -63,11 +63,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const layoutJson = JSON.stringify(layout);
     const validationResult = validateShareLayout(layout, layoutJson.length);
 
-    if (!validationResult.valid) {
-      const { error } = validationResult;
+    if (isValidationError(validationResult)) {
       return res.status(400).json({
-        error: error.message,
-        code: error.code,
+        error: validationResult.error.message,
+        code: validationResult.error.code,
       });
     }
 

--- a/api/share/[id].ts
+++ b/api/share/[id].ts
@@ -1,7 +1,7 @@
 import { put, del, head } from '@vercel/blob';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP } from '../lib/rateLimit.js';
-import { validateShareLayout } from '../lib/validation.js';
+import { validateShareLayout, isValidationError } from '../lib/validation.js';
 import { filterLayoutContent } from '../lib/contentFilter.js';
 import { isValidShareId, hashToken, ErrorCode, type ShareData } from '../lib/shared.js';
 
@@ -199,11 +199,10 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string, bl
     const layoutJson = JSON.stringify(layout);
     const validationResult = validateShareLayout(layout, layoutJson.length);
 
-    if (!validationResult.valid) {
-      const { error } = validationResult;
+    if (isValidationError(validationResult)) {
       return res.status(400).json({
-        error: error.message,
-        code: error.code,
+        error: validationResult.error.message,
+        code: validationResult.error.code,
       });
     }
 


### PR DESCRIPTION
## Summary
Fix the remaining TypeScript errors that were still causing Vercel builds to fail after PR #299.

## Problem
Vercel's TypeScript compiler handles certain patterns differently than the local build:

1. **Redis constructor (TS2351)**: Default import `import Redis from 'ioredis'` was seen as a module namespace, not a class
2. **ValidationResult narrowing (TS2339)**: Control flow analysis wasn't narrowing the discriminated union type

## Solution

### Redis Import Fix
```diff
- import Redis from 'ioredis';
+ import { Redis } from 'ioredis';
```
Named imports work consistently across both local and Vercel builds.

### ValidationResult Type Guard
```typescript
// Added explicit type guard function
export function isValidationError(result: ValidationResult): result is { valid: false; error: ValidationError } {
  return !result.valid;
}

// Usage
if (isValidationError(validationResult)) {
  // TypeScript now knows validationResult.error exists
}
```

## Files Changed
- `api/lib/rateLimit.ts` - Named Redis import
- `api/ml-telemetry.ts` - Named Redis import  
- `api/lib/validation.ts` - Added `isValidationError()` type guard
- `api/share.ts` - Use type guard
- `api/share/[id].ts` - Use type guard

## Test plan
- [x] `npx tsc -p tsconfig.api.json` passes
- [x] `npm run build` succeeds
- [x] API validation tests pass (41 tests)
- [ ] Vercel build should now succeed