### PR TITLE
fix: wire up engagement milestone tracking for PostHog funnel

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -475,6 +475,34 @@ export function trackBinCreated(
     count,
     ...(size ? { size: `${size.width}x${size.depth}x${size.height}` } : {}),
   });
+  checkEngagementMilestones();
+}
+
+const MILESTONE_THRESHOLDS: Array<{ key: 'first_bin' | 'engaged' | 'substantial'; min: number }> = [
+  { key: 'first_bin', min: 1 },
+  { key: 'engaged', min: 5 },
+  { key: 'substantial', min: 15 },
+];
+
+/**
+ * Check if the current bin count crosses any engagement milestone thresholds.
+ * Uses localStorage to ensure each milestone fires only once per user.
+ */
+function checkEngagementMilestones(): void {
+  try {
+    const bins = useLayoutStore.getState().layout.bins;
+    const binsOnGrid = bins.filter((b) => b.layerId !== STAGING_ID).length;
+
+    for (const { key, min } of MILESTONE_THRESHOLDS) {
+      const storageKey = `gridfinity_milestone_${key}`;
+      if (binsOnGrid >= min && !localStorage.getItem(storageKey)) {
+        localStorage.setItem(storageKey, new Date().toISOString());
+        trackEngagementMilestone(key);
+      }
+    }
+  } catch {
+    // Silently ignore - analytics should never break the app
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- `trackEngagementMilestone()` was defined but never called, causing the engagement funnel in PostHog to show 0 conversions at steps 3-4
- Add `checkEngagementMilestones()` that fires after each `bin_created` event, checking if on-grid bin count crosses thresholds (1, 5, 15 bins)
- Uses localStorage dedup (`gridfinity_milestone_*` keys) to ensure each milestone fires only once per user

## Test plan
- [x] Build succeeds
- [x] All 4,210 tests pass
- [x] Lint passes
- [x] PostHog funnel refreshed — step 2 (`bin_created`) now shows 4 users converting
- [ ] After deploy: verify `engagement_milestone` events appear when users cross 5+ and 15+ bin thresholds