### PR TITLE
feat(bin-designer): add parameter panel UI with all bin controls

### DIFF
--- a/src/features/bin-designer/__tests__/components/DimensionsSection.test.tsx
+++ b/src/features/bin-designer/__tests__/components/DimensionsSection.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DimensionsSection } from '../../components/parameters/DimensionsSection';
+import { useDesignerStore } from '../../store';
+import { DEFAULT_BIN_PARAMS } from '../../constants';
+
+describe('DimensionsSection', () => {
+  beforeEach(() => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS },
+    });
+  });
+
+  it('renders width, depth, and height sliders', () => {
+    render(<DimensionsSection />);
+
+    expect(screen.getByLabelText('Width')).toBeInTheDocument();
+    expect(screen.getByLabelText('Depth')).toBeInTheDocument();
+    expect(screen.getByLabelText('Height')).toBeInTheDocument();
+  });
+
+  it('displays mm dimensions for width and depth', () => {
+    render(<DimensionsSection />);
+
+    // Default width & depth are both 2 units = 84mm each
+    const mmLabels = screen.getAllByText('84mm');
+    expect(mmLabels.length).toBe(2);
+  });
+
+  it('displays total mm for height (including base)', () => {
+    render(<DimensionsSection />);
+
+    // Default height is 3 units = 3*7 + 5 = 26mm total
+    expect(screen.getByText('26mm total')).toBeInTheDocument();
+  });
+
+  it('renders quick-select buttons for width', () => {
+    render(<DimensionsSection />);
+
+    const widthPresets = screen.getByRole('group', { name: 'Width presets' });
+    expect(widthPresets).toBeInTheDocument();
+
+    // Should have buttons 1, 2, 3, 4
+    const buttons = widthPresets.querySelectorAll('button');
+    expect(buttons).toHaveLength(4);
+  });
+
+  it('clicking a quick-select button updates the store', () => {
+    render(<DimensionsSection />);
+
+    const widthPresets = screen.getByRole('group', { name: 'Width presets' });
+    const button3 = widthPresets.querySelector('button:nth-child(3)');
+    fireEvent.click(button3!);
+
+    expect(useDesignerStore.getState().params.width).toBe(3);
+  });
+
+  it('changing the width slider updates the store', () => {
+    render(<DimensionsSection />);
+
+    const slider = screen.getByLabelText('Width slider');
+    fireEvent.change(slider, { target: { value: '4' } });
+
+    expect(useDesignerStore.getState().params.width).toBe(4);
+  });
+
+  it('changing the number input updates the store', () => {
+    render(<DimensionsSection />);
+
+    const input = screen.getByLabelText('Width');
+    fireEvent.change(input, { target: { value: '5' } });
+
+    expect(useDesignerStore.getState().params.width).toBe(5);
+  });
+
+  it('clamps input value to valid range', () => {
+    render(<DimensionsSection />);
+
+    const input = screen.getByLabelText('Width');
+    fireEvent.change(input, { target: { value: '10' } });
+
+    // Max is 6
+    expect(useDesignerStore.getState().params.width).toBe(6);
+  });
+
+  it('snaps width to 0.5 step increments', () => {
+    render(<DimensionsSection />);
+
+    const input = screen.getByLabelText('Width');
+    fireEvent.change(input, { target: { value: '2.7' } });
+
+    // Should snap to 2.5
+    expect(useDesignerStore.getState().params.width).toBe(2.5);
+  });
+
+  it('height slider uses integer steps', () => {
+    render(<DimensionsSection />);
+
+    const slider = screen.getByLabelText('Height slider');
+    expect(slider).toHaveAttribute('step', '1');
+    expect(slider).toHaveAttribute('min', '1');
+    expect(slider).toHaveAttribute('max', '12');
+  });
+
+  it('height quick-select buttons are 3, 6, 9, 12', () => {
+    render(<DimensionsSection />);
+
+    const heightPresets = screen.getByRole('group', { name: 'Height presets' });
+    const buttons = heightPresets.querySelectorAll('button');
+    expect(buttons[0]).toHaveTextContent('3');
+    expect(buttons[1]).toHaveTextContent('6');
+    expect(buttons[2]).toHaveTextContent('9');
+    expect(buttons[3]).toHaveTextContent('12');
+  });
+});

--- a/src/features/bin-designer/__tests__/components/ParameterPanel.test.tsx
+++ b/src/features/bin-designer/__tests__/components/ParameterPanel.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ParameterPanel } from '../../components/ParameterPanel';
+import { useDesignerStore } from '../../store';
+import { DEFAULT_BIN_PARAMS } from '../../constants';
+
+describe('ParameterPanel', () => {
+  beforeEach(() => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS },
+    });
+  });
+
+  it('renders all section headings', () => {
+    render(<ParameterPanel />);
+
+    expect(screen.getByText('Dimensions')).toBeInTheDocument();
+    expect(screen.getByText('Style')).toBeInTheDocument();
+    expect(screen.getByText('Base')).toBeInTheDocument();
+    expect(screen.getByText('Features')).toBeInTheDocument();
+    expect(screen.getByText('Walls')).toBeInTheDocument();
+  });
+
+  it('renders dimension sliders', () => {
+    render(<ParameterPanel />);
+
+    expect(screen.getByLabelText('Width')).toBeInTheDocument();
+    expect(screen.getByLabelText('Depth')).toBeInTheDocument();
+    expect(screen.getByLabelText('Height')).toBeInTheDocument();
+  });
+
+  it('renders base style options', () => {
+    render(<ParameterPanel />);
+
+    // 'Standard' appears in both Style and Base sections
+    expect(screen.getAllByText('Standard').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText('Magnet')).toBeInTheDocument();
+    expect(screen.getByText('Screw')).toBeInTheDocument();
+    expect(screen.getByText('Weighted')).toBeInTheDocument();
+  });
+
+  it('renders feature controls', () => {
+    render(<ParameterPanel />);
+
+    expect(screen.getByLabelText('Dividers X')).toBeInTheDocument();
+    expect(screen.getByLabelText('Dividers Y')).toBeInTheDocument();
+    expect(screen.getByLabelText('Enable finger scoop')).toBeInTheDocument();
+    expect(screen.getByLabelText('Enable label tab')).toBeInTheDocument();
+  });
+
+  it('shows vase mode warning in Features section when vase selected', () => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, style: 'vase' },
+    });
+
+    render(<ParameterPanel />);
+
+    expect(screen.getByText(/interior features are disabled/i)).toBeInTheDocument();
+  });
+
+  it('shows vase mode warning in Walls section when vase selected', () => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, style: 'vase' },
+    });
+
+    render(<ParameterPanel />);
+
+    expect(screen.getByText(/wall cutouts are not available/i)).toBeInTheDocument();
+  });
+
+  it('selecting magnet base style shows magnet depth slider', () => {
+    render(<ParameterPanel />);
+
+    // Click magnet button (unique text in base section)
+    const magnetButtons = screen.getAllByText('Magnet');
+    fireEvent.click(magnetButtons[0].closest('button')!);
+
+    expect(screen.getByLabelText('Magnet Depth')).toBeInTheDocument();
+  });
+
+  it('selecting screw base style shows screw info', () => {
+    render(<ParameterPanel />);
+
+    const screwButtons = screen.getAllByText('Screw');
+    fireEvent.click(screwButtons[0].closest('button')!);
+
+    expect(screen.getByText(/M3 screw holes/)).toBeInTheDocument();
+  });
+
+  it('enabling label shows text input', () => {
+    render(<ParameterPanel />);
+
+    const labelCheckbox = screen.getByLabelText('Enable label tab');
+    fireEvent.click(labelCheckbox);
+
+    expect(screen.getByLabelText('Label text')).toBeInTheDocument();
+  });
+
+  it('adding dividers shows thickness slider', () => {
+    render(<ParameterPanel />);
+
+    // Increase dividers X
+    const divXInput = screen.getByLabelText('Dividers X');
+    fireEvent.change(divXInput, { target: { value: '2' } });
+
+    expect(screen.getByLabelText('Divider Thickness')).toBeInTheDocument();
+  });
+
+  it('wall sliders update the store', () => {
+    render(<ParameterPanel />);
+
+    // Walls section is collapsed by default, expand it
+    fireEvent.click(screen.getByText('Walls'));
+
+    const frontSlider = screen.getByLabelText('Front slider');
+    fireEvent.change(frontSlider, { target: { value: '50' } });
+
+    expect(useDesignerStore.getState().params.walls.front).toBe(50);
+  });
+
+  it('wall values snap to minimum 20% when between 1-19%', () => {
+    render(<ParameterPanel />);
+
+    // Expand walls section
+    fireEvent.click(screen.getByText('Walls'));
+
+    const frontSlider = screen.getByLabelText('Front slider');
+    fireEvent.change(frontSlider, { target: { value: '15' } });
+
+    // Should snap to 20%
+    expect(useDesignerStore.getState().params.walls.front).toBe(20);
+  });
+});

--- a/src/features/bin-designer/__tests__/components/StyleSection.test.tsx
+++ b/src/features/bin-designer/__tests__/components/StyleSection.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StyleSection } from '../../components/parameters/StyleSection';
+import { useDesignerStore } from '../../store';
+import { DEFAULT_BIN_PARAMS } from '../../constants';
+
+describe('StyleSection', () => {
+  beforeEach(() => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, style: 'standard' },
+    });
+  });
+
+  it('renders all 5 style options', () => {
+    render(<StyleSection />);
+
+    expect(screen.getByText('Standard')).toBeInTheDocument();
+    expect(screen.getByText('Lite')).toBeInTheDocument();
+    expect(screen.getByText('Solid')).toBeInTheDocument();
+    expect(screen.getByText('Vase')).toBeInTheDocument();
+    expect(screen.getByText('Rugged')).toBeInTheDocument();
+  });
+
+  it('shows wall thickness for each style', () => {
+    render(<StyleSection />);
+
+    expect(screen.getByText('1.2mm wall')).toBeInTheDocument();
+    expect(screen.getByText('0.8mm wall')).toBeInTheDocument();
+    expect(screen.getByText('1.6mm wall')).toBeInTheDocument();
+    expect(screen.getByText('0.4mm wall')).toBeInTheDocument();
+    expect(screen.getByText('2mm wall')).toBeInTheDocument();
+  });
+
+  it('highlights the currently selected style', () => {
+    render(<StyleSection />);
+
+    const standardBtn = screen.getByText('Standard').closest('button');
+    expect(standardBtn).toHaveAttribute('aria-pressed', 'true');
+
+    const liteBtn = screen.getByText('Lite').closest('button');
+    expect(liteBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('clicking a style updates the store', () => {
+    render(<StyleSection />);
+
+    fireEvent.click(screen.getByText('Rugged').closest('button')!);
+
+    expect(useDesignerStore.getState().params.style).toBe('rugged');
+  });
+
+  it('shows description for each style', () => {
+    render(<StyleSection />);
+
+    expect(screen.getByText('Default balance of strength and material')).toBeInTheDocument();
+    expect(screen.getByText('Single wall, no interior features')).toBeInTheDocument();
+  });
+});

--- a/src/features/bin-designer/components/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage.tsx
@@ -1,11 +1,11 @@
 /**
- * Bin Designer page shell.
+ * Bin Designer page layout.
  *
- * Top-level component for the /designer route. Displays a placeholder
- * layout that will be populated with parameter panel and 3D preview
- * in subsequent PRs.
+ * Two-column layout: left panel (parameter controls, 320px) + main area (3D preview placeholder).
+ * On mobile (<768px), the parameter panel is shown as a full-width bottom area.
  */
 
+import { ParameterPanel } from './ParameterPanel';
 
 interface DesignerPageProps {
   onNavigateBack: () => void;
@@ -46,14 +46,14 @@ export function DesignerPage({ onNavigateBack }: DesignerPageProps) {
         </div>
       </header>
 
-      {/* Main content area - to be populated in subsequent PRs */}
+      {/* Main content area */}
       <main className="flex flex-1 overflow-hidden">
-        {/* Left panel placeholder (parameter panel) */}
-        <div className="hidden w-80 flex-shrink-0 border-r border-gray-200 bg-white p-4 md:block">
-          <p className="text-sm text-gray-500">Parameter panel coming soon...</p>
+        {/* Left panel: Parameter controls (hidden on mobile, shown on md+) */}
+        <div className="hidden w-80 flex-shrink-0 border-r border-gray-200 bg-white md:block">
+          <ParameterPanel />
         </div>
 
-        {/* Center area (3D preview) */}
+        {/* Center area: 3D preview placeholder */}
         <div className="flex flex-1 items-center justify-center bg-gray-100">
           <div className="text-center">
             <div className="mx-auto mb-4 h-24 w-24 rounded-xl bg-gray-200 p-6">
@@ -77,6 +77,14 @@ export function DesignerPage({ onNavigateBack }: DesignerPageProps) {
               Parametric bin preview will appear here
             </p>
           </div>
+        </div>
+
+        {/* Mobile: Bottom parameter panel (shown on mobile, hidden on md+) */}
+        <div
+          className="fixed inset-x-0 bottom-0 max-h-[70vh] overflow-y-auto border-t border-gray-200 bg-white md:hidden"
+          style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+        >
+          <ParameterPanel />
         </div>
       </main>
     </div>

--- a/src/features/bin-designer/components/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel.tsx
@@ -1,0 +1,43 @@
+/**
+ * Scrollable parameter panel containing all bin configuration sections.
+ * Each section uses CollapsibleSection for expand/collapse.
+ */
+
+import { CollapsibleSection } from '@/shared/components/CollapsibleSection';
+import {
+  DimensionsSection,
+  BaseSection,
+  FeaturesSection,
+  WallsSection,
+  StyleSection,
+} from './parameters';
+
+export function ParameterPanel() {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 overflow-y-auto px-4 py-3">
+        <div className="space-y-5">
+          <CollapsibleSection title="Dimensions" defaultExpanded>
+            <DimensionsSection />
+          </CollapsibleSection>
+
+          <CollapsibleSection title="Style" defaultExpanded>
+            <StyleSection />
+          </CollapsibleSection>
+
+          <CollapsibleSection title="Base">
+            <BaseSection />
+          </CollapsibleSection>
+
+          <CollapsibleSection title="Features">
+            <FeaturesSection />
+          </CollapsibleSection>
+
+          <CollapsibleSection title="Walls" defaultExpanded={false}>
+            <WallsSection />
+          </CollapsibleSection>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/controls/QuickSelect.tsx
+++ b/src/features/bin-designer/components/controls/QuickSelect.tsx
@@ -1,0 +1,52 @@
+/**
+ * Row of quick-select preset buttons.
+ * Allows one-click selection of common values.
+ */
+
+interface QuickSelectProps<T extends number | string> {
+  /** The currently selected value */
+  value: T;
+  /** Available preset options */
+  options: T[];
+  /** Called when an option is selected */
+  onChange: (value: T) => void;
+  /** Format function for display (default: String) */
+  format?: (value: T) => string;
+  /** Whether the control is disabled */
+  disabled?: boolean;
+  /** Accessible group label */
+  ariaLabel: string;
+}
+
+export function QuickSelect<T extends number | string>({
+  value,
+  options,
+  onChange,
+  format = String,
+  disabled = false,
+  ariaLabel,
+}: QuickSelectProps<T>) {
+  return (
+    <div className="flex gap-1" role="group" aria-label={ariaLabel}>
+      {options.map((option) => {
+        const isActive = option === value;
+        return (
+          <button
+            key={String(option)}
+            type="button"
+            onClick={() => onChange(option)}
+            disabled={disabled}
+            className={`flex-1 rounded px-1.5 py-0.5 text-xs font-medium transition-colors ${
+              isActive
+                ? 'bg-accent text-white'
+                : 'bg-surface-elevated text-content-secondary hover:bg-surface-hover'
+            } disabled:opacity-50 disabled:cursor-not-allowed`}
+            aria-pressed={isActive}
+          >
+            {format(option)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/controls/SliderInput.tsx
+++ b/src/features/bin-designer/components/controls/SliderInput.tsx
@@ -1,0 +1,96 @@
+/**
+ * Combined slider + number input control for the bin designer.
+ * Provides both coarse (slider drag) and fine (type a value) input.
+ */
+
+import { useId } from 'react';
+
+interface SliderInputProps {
+  /** Display label */
+  label: string;
+  /** Current value */
+  value: number;
+  /** Called when value changes */
+  onChange: (value: number) => void;
+  /** Minimum value */
+  min: number;
+  /** Maximum value */
+  max: number;
+  /** Step increment (default: 1) */
+  step?: number;
+  /** Unit suffix shown after the input (e.g., 'mm', 'u', '%') */
+  unit?: string;
+  /** Secondary info shown below the label */
+  info?: string;
+  /** Whether the control is disabled */
+  disabled?: boolean;
+}
+
+export function SliderInput({
+  label,
+  value,
+  onChange,
+  min,
+  max,
+  step = 1,
+  unit,
+  info,
+  disabled = false,
+}: SliderInputProps) {
+  const id = useId();
+
+  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(Number(e.target.value));
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = Number(e.target.value);
+    if (!isNaN(raw)) {
+      const clamped = Math.min(max, Math.max(min, raw));
+      // Round to step precision
+      const snapped = Math.round(clamped / step) * step;
+      onChange(Number(snapped.toFixed(3)));
+    }
+  };
+
+  return (
+    <div className={disabled ? 'opacity-50' : ''}>
+      <div className="flex items-center justify-between mb-1">
+        <label htmlFor={id} className="text-xs font-medium text-content-secondary">
+          {label}
+        </label>
+        <div className="flex items-center gap-1">
+          <input
+            id={id}
+            type="number"
+            value={value}
+            onChange={handleInputChange}
+            min={min}
+            max={max}
+            step={step}
+            disabled={disabled}
+            className="w-14 rounded border border-stroke-subtle bg-surface px-1.5 py-0.5 text-right text-xs tabular-nums text-content focus:outline-none focus:ring-1 focus:ring-accent disabled:cursor-not-allowed"
+            aria-label={label}
+          />
+          {unit && (
+            <span className="text-xs text-content-tertiary">{unit}</span>
+          )}
+        </div>
+      </div>
+      {info && (
+        <p className="mb-1 text-[10px] text-content-tertiary">{info}</p>
+      )}
+      <input
+        type="range"
+        value={value}
+        onChange={handleSliderChange}
+        min={min}
+        max={max}
+        step={step}
+        disabled={disabled}
+        className="w-full h-1.5 rounded-full appearance-none bg-stroke-subtle accent-accent cursor-pointer disabled:cursor-not-allowed"
+        aria-label={`${label} slider`}
+      />
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/controls/index.ts
+++ b/src/features/bin-designer/components/controls/index.ts
@@ -1,0 +1,2 @@
+export { SliderInput } from './SliderInput';
+export { QuickSelect } from './QuickSelect';

--- a/src/features/bin-designer/components/parameters/BaseSection.tsx
+++ b/src/features/bin-designer/components/parameters/BaseSection.tsx
@@ -1,0 +1,90 @@
+/**
+ * Base options section: base style selector, magnet depth, stacking lip toggle.
+ * Conditionally shows magnet/screw-specific controls based on selected style.
+ */
+
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
+import { Checkbox } from '@/shared/components/Checkbox';
+import { SliderInput } from '../controls/SliderInput';
+import type { BaseStyle, BaseConfig } from '@/features/bin-designer/types';
+
+const BASE_STYLES: Array<{ value: BaseStyle; label: string; description: string }> = [
+  { value: 'standard', label: 'Standard', description: 'Flat bottom' },
+  { value: 'magnet', label: 'Magnet', description: '6mm holes' },
+  { value: 'screw', label: 'Screw', description: 'M3 holes' },
+  { value: 'weighted', label: 'Weighted', description: 'Thick base' },
+];
+
+export function BaseSection() {
+  const { base, setParam } = useDesignerStore(
+    useShallow((s) => ({
+      base: s.params.base,
+      setParam: s.setParam,
+    }))
+  );
+
+  const updateBase = (partial: Partial<BaseConfig>) => {
+    setParam('base', { ...base, ...partial });
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Style selector */}
+      <div>
+        <label className="mb-2 block text-xs font-medium text-content-secondary">
+          Attachment Style
+        </label>
+        <div className="grid grid-cols-2 gap-1.5">
+          {BASE_STYLES.map(({ value, label, description }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => updateBase({ style: value })}
+              className={`rounded-md border px-2 py-1.5 text-left transition-colors ${
+                base.style === value
+                  ? 'border-accent bg-accent/5 text-content'
+                  : 'border-stroke-subtle bg-surface text-content-secondary hover:border-stroke hover:bg-surface-hover'
+              }`}
+              aria-pressed={base.style === value}
+            >
+              <span className="block text-xs font-medium">{label}</span>
+              <span className="block text-[10px] text-content-tertiary">{description}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Magnet depth (only for magnet style) */}
+      {base.style === 'magnet' && (
+        <SliderInput
+          label="Magnet Depth"
+          value={base.magnetDepth}
+          onChange={(v) => updateBase({ magnetDepth: v })}
+          min={DESIGNER_CONSTRAINTS.MAGNET_MIN_DEPTH}
+          max={DESIGNER_CONSTRAINTS.MAGNET_MAX_DEPTH}
+          step={0.1}
+          unit="mm"
+        />
+      )}
+
+      {/* Screw info (only for screw style) */}
+      {base.style === 'screw' && (
+        <div className="rounded-md bg-surface-elevated px-3 py-2">
+          <span className="text-xs text-content-secondary">
+            M3 screw holes ({base.screwDiameter}mm diameter)
+          </span>
+        </div>
+      )}
+
+      {/* Stacking lip toggle */}
+      <Checkbox
+        checked={base.stackingLip}
+        onChange={(checked) => updateBase({ stackingLip: checked })}
+        label="Stacking lip"
+        ariaLabel="Enable stacking lip"
+      />
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/parameters/DimensionsSection.tsx
+++ b/src/features/bin-designer/components/parameters/DimensionsSection.tsx
@@ -1,0 +1,88 @@
+/**
+ * Dimensions section: Width, Depth, and Height sliders with quick-select presets.
+ * Shows computed mm values below each slider.
+ */
+
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { GRIDFINITY, DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
+import { SliderInput } from '../controls/SliderInput';
+import { QuickSelect } from '../controls/QuickSelect';
+
+const DIMENSION_PRESETS = [1, 2, 3, 4];
+const HEIGHT_PRESETS = [3, 6, 9, 12];
+
+export function DimensionsSection() {
+  const { width, depth, height, setParam } = useDesignerStore(
+    useShallow((s) => ({
+      width: s.params.width,
+      depth: s.params.depth,
+      height: s.params.height,
+      setParam: s.setParam,
+    }))
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* Width */}
+      <div className="space-y-1.5">
+        <SliderInput
+          label="Width"
+          value={width}
+          onChange={(v) => setParam('width', v)}
+          min={DESIGNER_CONSTRAINTS.MIN_DIMENSION}
+          max={DESIGNER_CONSTRAINTS.MAX_DIMENSION}
+          step={DESIGNER_CONSTRAINTS.DIMENSION_STEP}
+          unit="u"
+          info={`${(width * GRIDFINITY.GRID_SIZE).toFixed(0)}mm`}
+        />
+        <QuickSelect
+          value={width}
+          options={DIMENSION_PRESETS}
+          onChange={(v) => setParam('width', v)}
+          ariaLabel="Width presets"
+        />
+      </div>
+
+      {/* Depth */}
+      <div className="space-y-1.5">
+        <SliderInput
+          label="Depth"
+          value={depth}
+          onChange={(v) => setParam('depth', v)}
+          min={DESIGNER_CONSTRAINTS.MIN_DIMENSION}
+          max={DESIGNER_CONSTRAINTS.MAX_DIMENSION}
+          step={DESIGNER_CONSTRAINTS.DIMENSION_STEP}
+          unit="u"
+          info={`${(depth * GRIDFINITY.GRID_SIZE).toFixed(0)}mm`}
+        />
+        <QuickSelect
+          value={depth}
+          options={DIMENSION_PRESETS}
+          onChange={(v) => setParam('depth', v)}
+          ariaLabel="Depth presets"
+        />
+      </div>
+
+      {/* Height */}
+      <div className="space-y-1.5">
+        <SliderInput
+          label="Height"
+          value={height}
+          onChange={(v) => setParam('height', v)}
+          min={DESIGNER_CONSTRAINTS.MIN_HEIGHT}
+          max={DESIGNER_CONSTRAINTS.MAX_HEIGHT}
+          step={DESIGNER_CONSTRAINTS.HEIGHT_STEP}
+          unit="u"
+          info={`${(height * GRIDFINITY.HEIGHT_UNIT + GRIDFINITY.BASE_HEIGHT).toFixed(0)}mm total`}
+        />
+        <QuickSelect
+          value={height}
+          options={HEIGHT_PRESETS}
+          onChange={(v) => setParam('height', v)}
+          ariaLabel="Height presets"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/parameters/FeaturesSection.tsx
+++ b/src/features/bin-designer/components/parameters/FeaturesSection.tsx
@@ -1,0 +1,111 @@
+/**
+ * Interior features section: dividers, scoop, and label controls.
+ * Vase mode disables all features with an explanation.
+ */
+
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
+import { Checkbox } from '@/shared/components/Checkbox';
+import { SliderInput } from '../controls/SliderInput';
+import type { DividerConfig, LabelConfig } from '@/features/bin-designer/types';
+
+export function FeaturesSection() {
+  const { dividers, scoop, label, style, setParam } = useDesignerStore(
+    useShallow((s) => ({
+      dividers: s.params.dividers,
+      scoop: s.params.scoop,
+      label: s.params.label,
+      style: s.params.style,
+      setParam: s.setParam,
+    }))
+  );
+
+  const isVase = style === 'vase';
+
+  const updateDividers = (partial: Partial<DividerConfig>) => {
+    setParam('dividers', { ...dividers, ...partial });
+  };
+
+  const updateLabel = (partial: Partial<LabelConfig>) => {
+    setParam('label', { ...label, ...partial });
+  };
+
+  if (isVase) {
+    return (
+      <div className="rounded-md bg-amber-50 px-3 py-2">
+        <p className="text-xs text-amber-800">
+          Interior features are disabled for vase mode bins (single-wall construction).
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Dividers X */}
+      <SliderInput
+        label="Dividers X"
+        value={dividers.x}
+        onChange={(v) => updateDividers({ x: v })}
+        min={0}
+        max={DESIGNER_CONSTRAINTS.MAX_DIVIDERS}
+        step={1}
+        info={dividers.x > 0 ? `${dividers.x + 1} columns` : undefined}
+      />
+
+      {/* Dividers Y */}
+      <SliderInput
+        label="Dividers Y"
+        value={dividers.y}
+        onChange={(v) => updateDividers({ y: v })}
+        min={0}
+        max={DESIGNER_CONSTRAINTS.MAX_DIVIDERS}
+        step={1}
+        info={dividers.y > 0 ? `${dividers.y + 1} rows` : undefined}
+      />
+
+      {/* Divider thickness (only if dividers enabled) */}
+      {(dividers.x > 0 || dividers.y > 0) && (
+        <SliderInput
+          label="Divider Thickness"
+          value={dividers.thickness}
+          onChange={(v) => updateDividers({ thickness: v })}
+          min={DESIGNER_CONSTRAINTS.MIN_DIVIDER_THICKNESS}
+          max={DESIGNER_CONSTRAINTS.MAX_DIVIDER_THICKNESS}
+          step={0.1}
+          unit="mm"
+        />
+      )}
+
+      {/* Scoop */}
+      <Checkbox
+        checked={scoop}
+        onChange={(checked) => setParam('scoop', checked)}
+        label="Finger scoop"
+        ariaLabel="Enable finger scoop"
+      />
+
+      {/* Label */}
+      <div className="space-y-2">
+        <Checkbox
+          checked={label.enabled}
+          onChange={(checked) => updateLabel({ enabled: checked })}
+          label="Label tab"
+          ariaLabel="Enable label tab"
+        />
+        {label.enabled && (
+          <input
+            type="text"
+            value={label.text}
+            onChange={(e) => updateLabel({ text: e.target.value.slice(0, DESIGNER_CONSTRAINTS.MAX_LABEL_LENGTH) })}
+            placeholder="Label text (optional)"
+            maxLength={DESIGNER_CONSTRAINTS.MAX_LABEL_LENGTH}
+            className="w-full rounded border border-stroke-subtle bg-surface px-2 py-1 text-xs text-content placeholder:text-content-tertiary focus:outline-none focus:ring-1 focus:ring-accent"
+            aria-label="Label text"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/parameters/StyleSection.tsx
+++ b/src/features/bin-designer/components/parameters/StyleSection.tsx
@@ -1,0 +1,59 @@
+/**
+ * Style section: visual cards for selecting one of 5 bin style variants.
+ * Each style affects wall thickness and available features.
+ */
+
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { STYLE_WALL_THICKNESS } from '@/features/bin-designer/constants';
+import type { BinStyle } from '@/features/bin-designer/types';
+
+const STYLES: Array<{
+  value: BinStyle;
+  label: string;
+  description: string;
+  wallMm: number;
+}> = [
+  { value: 'standard', label: 'Standard', description: 'Default balance of strength and material', wallMm: STYLE_WALL_THICKNESS.standard },
+  { value: 'lite', label: 'Lite', description: 'Thin walls, less material', wallMm: STYLE_WALL_THICKNESS.lite },
+  { value: 'solid', label: 'Solid', description: 'Thick walls, maximum strength', wallMm: STYLE_WALL_THICKNESS.solid },
+  { value: 'vase', label: 'Vase', description: 'Single wall, no interior features', wallMm: STYLE_WALL_THICKNESS.vase },
+  { value: 'rugged', label: 'Rugged', description: 'Extra thick with corner reinforcement', wallMm: STYLE_WALL_THICKNESS.rugged },
+];
+
+export function StyleSection() {
+  const { style, setParam } = useDesignerStore(
+    useShallow((s) => ({
+      style: s.params.style,
+      setParam: s.setParam,
+    }))
+  );
+
+  return (
+    <div className="space-y-1.5">
+      {STYLES.map(({ value, label, description, wallMm }) => (
+        <button
+          key={value}
+          type="button"
+          onClick={() => setParam('style', value)}
+          className={`w-full rounded-md border px-3 py-2 text-left transition-colors ${
+            style === value
+              ? 'border-accent bg-accent/5'
+              : 'border-stroke-subtle bg-surface hover:border-stroke hover:bg-surface-hover'
+          }`}
+          aria-pressed={style === value}
+        >
+          <div className="flex items-center justify-between">
+            <span className={`text-xs font-medium ${style === value ? 'text-content' : 'text-content-secondary'}`}>
+              {label}
+            </span>
+            <span className="text-[10px] tabular-nums text-content-tertiary">
+              {wallMm}mm wall
+            </span>
+          </div>
+          <p className="mt-0.5 text-[10px] text-content-tertiary">{description}</p>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/parameters/WallsSection.tsx
+++ b/src/features/bin-designer/components/parameters/WallsSection.tsx
@@ -1,0 +1,68 @@
+/**
+ * Walls section: percentage sliders for wall cutouts on each side.
+ * When a wall cutout is between 1-19%, it snaps to 20% minimum.
+ */
+
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
+import { SliderInput } from '../controls/SliderInput';
+import type { WallConfig } from '@/features/bin-designer/types';
+
+const WALL_SIDES: Array<{ key: keyof WallConfig; label: string }> = [
+  { key: 'front', label: 'Front' },
+  { key: 'back', label: 'Back' },
+  { key: 'left', label: 'Left' },
+  { key: 'right', label: 'Right' },
+];
+
+export function WallsSection() {
+  const { walls, style, setParam } = useDesignerStore(
+    useShallow((s) => ({
+      walls: s.params.walls,
+      style: s.params.style,
+      setParam: s.setParam,
+    }))
+  );
+
+  const isVase = style === 'vase';
+
+  const updateWall = (side: keyof WallConfig, rawValue: number) => {
+    // Snap: if between 1-19%, snap to minimum 20%
+    let value = rawValue;
+    if (value > 0 && value < DESIGNER_CONSTRAINTS.MIN_WALL_CUTOUT) {
+      value = DESIGNER_CONSTRAINTS.MIN_WALL_CUTOUT;
+    }
+    setParam('walls', { ...walls, [side]: value });
+  };
+
+  if (isVase) {
+    return (
+      <div className="rounded-md bg-amber-50 px-3 py-2">
+        <p className="text-xs text-amber-800">
+          Wall cutouts are not available for vase mode bins.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-[10px] text-content-tertiary">
+        Set wall height as percentage (0 = full wall, 100 = removed)
+      </p>
+      {WALL_SIDES.map(({ key, label }) => (
+        <SliderInput
+          key={key}
+          label={label}
+          value={walls[key]}
+          onChange={(v) => updateWall(key, v)}
+          min={0}
+          max={DESIGNER_CONSTRAINTS.MAX_WALL_CUTOUT}
+          step={5}
+          unit="%"
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/parameters/index.ts
+++ b/src/features/bin-designer/components/parameters/index.ts
@@ -1,0 +1,5 @@
+export { DimensionsSection } from './DimensionsSection';
+export { BaseSection } from './BaseSection';
+export { FeaturesSection } from './FeaturesSection';
+export { WallsSection } from './WallsSection';
+export { StyleSection } from './StyleSection';


### PR DESCRIPTION
## Summary
- Add `ParameterPanel` component with 5 collapsible sections: Dimensions, Style, Base, Features, Walls
- Create designer-specific controls: `SliderInput` (slider + number input combo) and `QuickSelect` (preset buttons)
- Update `DesignerPage` with two-column layout (320px panel + preview area)
- Responsive: desktop shows side panel, mobile shows bottom sheet
- All controls update the Zustand designer store with proper undo history
- Vase mode auto-disables incompatible Features and Walls sections
- Wall cutout values snap to 20% minimum when between 1-19%
- Dimension sliders show mm conversion (grid×42mm, height×7mm+5mm base)

## Files Added
- `components/controls/SliderInput.tsx` - Combined slider + number input
- `components/controls/QuickSelect.tsx` - Row of preset value buttons
- `components/parameters/DimensionsSection.tsx` - Width/Depth/Height with quick-select
- `components/parameters/BaseSection.tsx` - Base style, magnet depth, stacking lip
- `components/parameters/FeaturesSection.tsx` - Dividers, scoop, label
- `components/parameters/WallsSection.tsx` - 4 wall percentage sliders
- `components/parameters/StyleSection.tsx` - 5 style variant cards
- `components/ParameterPanel.tsx` - Assembled panel with CollapsibleSections

## Reused Shared Components
- `CollapsibleSection` from `shared/components/`
- `Checkbox` from `shared/components/`

## Test plan
- [x] 28 new component tests pass (DimensionsSection, StyleSection, ParameterPanel)
- [x] All 4382 tests pass
- [x] Lint: 0 errors
- [x] Build: main chunk 120.58 kB gzip (within 126 kB limit)
- [x] TypeScript: no type errors
- [ ] Manual: verify parameter panel renders on /designer route
- [ ] Manual: verify controls update store values correctly