### PR TITLE
feat(bin-designer): add 3D preview canvas with orbit controls

### DIFF
--- a/src/features/bin-designer/__tests__/components/PreviewCanvas.test.tsx
+++ b/src/features/bin-designer/__tests__/components/PreviewCanvas.test.tsx
@@ -1,0 +1,178 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useDesignerStore } from '../../store';
+import { DEFAULT_BIN_PARAMS } from '../../constants';
+
+// Mock Three.js rendering (jsdom has no WebGL)
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }: { children: ReactNode }) => (
+    <div data-testid="r3f-canvas">{children}</div>
+  ),
+}));
+
+vi.mock('@react-three/drei', () => ({
+  OrbitControls: () => <div data-testid="orbit-controls" />,
+}));
+
+vi.mock('three', () => {
+  function BufferGeometry() { /* mock */ }
+  BufferGeometry.prototype.setAttribute = function () { return this; };
+  BufferGeometry.prototype.dispose = function () { /* noop */ };
+
+  function Float32BufferAttribute(array: Float32Array, _itemSize: number) {
+    return { array };
+  }
+
+  function Vector3(x = 0, y = 0, z = 0) {
+    return { x, y, z };
+  }
+
+  return { Vector3, BufferGeometry, Float32BufferAttribute, DoubleSide: 2 };
+});
+
+vi.mock('three-stdlib', () => ({
+  OrbitControls: vi.fn(),
+}));
+
+// Mock the generation hook to avoid worker initialization
+vi.mock('../../hooks/useGeneration', () => ({
+  useGeneration: vi.fn(),
+}));
+
+import { PreviewCanvas } from '../../components/PreviewCanvas';
+
+describe('PreviewCanvas', () => {
+  beforeEach(() => {
+    useDesignerStore.setState({
+      params: DEFAULT_BIN_PARAMS,
+      wasmStatus: 'idle',
+      generation: {
+        status: 'idle',
+        mesh: null,
+        error: null,
+        timingMs: 0,
+      },
+    });
+  });
+
+  it('shows skeleton when WASM is loading', () => {
+    useDesignerStore.setState({ wasmStatus: 'loading' });
+    render(<PreviewCanvas />);
+
+    expect(screen.getByText('Initializing engine...')).toBeInTheDocument();
+  });
+
+  it('shows skeleton when WASM has error', () => {
+    useDesignerStore.setState({ wasmStatus: 'error' });
+    render(<PreviewCanvas />);
+
+    expect(screen.getByText('Engine failed to load')).toBeInTheDocument();
+  });
+
+  it('shows skeleton when no mesh is available', () => {
+    useDesignerStore.setState({
+      wasmStatus: 'ready',
+      generation: { status: 'idle', mesh: null, error: null, timingMs: 0 },
+    });
+    render(<PreviewCanvas />);
+
+    expect(screen.getByText('Loading preview...')).toBeInTheDocument();
+  });
+
+  it('shows skeleton when generating with no prior mesh', () => {
+    useDesignerStore.setState({
+      wasmStatus: 'ready',
+      generation: { status: 'generating', mesh: null, error: null, timingMs: 0 },
+    });
+    render(<PreviewCanvas />);
+
+    expect(screen.getByText('Generating mesh...')).toBeInTheDocument();
+  });
+
+  it('shows skeleton when generation has error with no mesh', () => {
+    useDesignerStore.setState({
+      wasmStatus: 'ready',
+      generation: { status: 'error', mesh: null, error: 'Failed', timingMs: 0 },
+    });
+    render(<PreviewCanvas />);
+
+    expect(screen.getByText('Generation failed')).toBeInTheDocument();
+  });
+
+  it('renders canvas when mesh is available', () => {
+    useDesignerStore.setState({
+      wasmStatus: 'ready',
+      generation: {
+        status: 'complete',
+        mesh: {
+          vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+          normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+        },
+        error: null,
+        timingMs: 50,
+      },
+    });
+    render(<PreviewCanvas />);
+
+    expect(screen.getByTestId('r3f-canvas')).toBeInTheDocument();
+    expect(screen.queryByText('Loading preview...')).not.toBeInTheDocument();
+  });
+
+  it('shows updating overlay when regenerating with existing mesh', () => {
+    useDesignerStore.setState({
+      wasmStatus: 'ready',
+      generation: {
+        status: 'generating',
+        mesh: {
+          vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+          normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+        },
+        error: null,
+        timingMs: 50,
+      },
+    });
+    render(<PreviewCanvas />);
+
+    expect(screen.getByTestId('r3f-canvas')).toBeInTheDocument();
+    expect(screen.getByText('Updating...')).toBeInTheDocument();
+  });
+
+  it('does not show updating overlay when generation is complete', () => {
+    useDesignerStore.setState({
+      wasmStatus: 'ready',
+      generation: {
+        status: 'complete',
+        mesh: {
+          vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+          normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+        },
+        error: null,
+        timingMs: 50,
+      },
+    });
+    render(<PreviewCanvas />);
+
+    expect(screen.queryByText('Updating...')).not.toBeInTheDocument();
+  });
+
+  it('renders preview control buttons when mesh is available', () => {
+    useDesignerStore.setState({
+      wasmStatus: 'ready',
+      generation: {
+        status: 'complete',
+        mesh: {
+          vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+          normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+        },
+        error: null,
+        timingMs: 50,
+      },
+    });
+    render(<PreviewCanvas />);
+
+    expect(screen.getByLabelText('Front camera view')).toBeInTheDocument();
+    expect(screen.getByLabelText('Reset camera view')).toBeInTheDocument();
+    expect(screen.getByLabelText('Toggle wireframe mode')).toBeInTheDocument();
+  });
+});

--- a/src/features/bin-designer/__tests__/hooks/useDesignerKeyboard.test.ts
+++ b/src/features/bin-designer/__tests__/hooks/useDesignerKeyboard.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDesignerKeyboard } from '../../hooks/useDesignerKeyboard';
+
+describe('useDesignerKeyboard', () => {
+  const onCameraPreset = vi.fn();
+  const onResetView = vi.fn();
+  const onToggleWireframe = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function renderKeyboardHook() {
+    return renderHook(() =>
+      useDesignerKeyboard({ onCameraPreset, onResetView, onToggleWireframe })
+    );
+  }
+
+  function pressKey(key: string, options: Partial<KeyboardEventInit> = {}) {
+    const event = new KeyboardEvent('keydown', { key, bubbles: true, ...options });
+    window.dispatchEvent(event);
+  }
+
+  it('maps key 1 to front preset', () => {
+    renderKeyboardHook();
+    pressKey('1');
+    expect(onCameraPreset).toHaveBeenCalledWith('front');
+  });
+
+  it('maps key 2 to side preset', () => {
+    renderKeyboardHook();
+    pressKey('2');
+    expect(onCameraPreset).toHaveBeenCalledWith('side');
+  });
+
+  it('maps key 3 to top preset', () => {
+    renderKeyboardHook();
+    pressKey('3');
+    expect(onCameraPreset).toHaveBeenCalledWith('top');
+  });
+
+  it('maps key 4 to isometric preset', () => {
+    renderKeyboardHook();
+    pressKey('4');
+    expect(onCameraPreset).toHaveBeenCalledWith('isometric');
+  });
+
+  it('maps R key to reset view', () => {
+    renderKeyboardHook();
+    pressKey('r');
+    expect(onResetView).toHaveBeenCalledOnce();
+  });
+
+  it('maps uppercase R key to reset view', () => {
+    renderKeyboardHook();
+    pressKey('R');
+    expect(onResetView).toHaveBeenCalledOnce();
+  });
+
+  it('maps W key to wireframe toggle', () => {
+    renderKeyboardHook();
+    pressKey('w');
+    expect(onToggleWireframe).toHaveBeenCalledOnce();
+  });
+
+  it('maps uppercase W key to wireframe toggle', () => {
+    renderKeyboardHook();
+    pressKey('W');
+    expect(onToggleWireframe).toHaveBeenCalledOnce();
+  });
+
+  it('ignores keys with Ctrl modifier', () => {
+    renderKeyboardHook();
+    pressKey('1', { ctrlKey: true });
+    expect(onCameraPreset).not.toHaveBeenCalled();
+  });
+
+  it('ignores keys with Meta modifier', () => {
+    renderKeyboardHook();
+    pressKey('r', { metaKey: true });
+    expect(onResetView).not.toHaveBeenCalled();
+  });
+
+  it('ignores keys with Alt modifier', () => {
+    renderKeyboardHook();
+    pressKey('w', { altKey: true });
+    expect(onToggleWireframe).not.toHaveBeenCalled();
+  });
+
+  it('ignores keys when target is an input element', () => {
+    renderKeyboardHook();
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    const event = new KeyboardEvent('keydown', { key: '1', bubbles: true });
+    Object.defineProperty(event, 'target', { value: input });
+    window.dispatchEvent(event);
+
+    expect(onCameraPreset).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+
+  it('ignores keys when target is a textarea', () => {
+    renderKeyboardHook();
+
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    const event = new KeyboardEvent('keydown', { key: 'r', bubbles: true });
+    Object.defineProperty(event, 'target', { value: textarea });
+    window.dispatchEvent(event);
+
+    expect(onResetView).not.toHaveBeenCalled();
+    document.body.removeChild(textarea);
+  });
+
+  it('ignores keys when target is contenteditable', () => {
+    renderKeyboardHook();
+
+    const div = document.createElement('div');
+    div.contentEditable = 'true';
+    // jsdom may not compute isContentEditable properly, so set it explicitly
+    Object.defineProperty(div, 'isContentEditable', { value: true, configurable: true });
+    document.body.appendChild(div);
+    const event = new KeyboardEvent('keydown', { key: 'w', bubbles: true });
+    Object.defineProperty(event, 'target', { value: div });
+    window.dispatchEvent(event);
+
+    expect(onToggleWireframe).not.toHaveBeenCalled();
+    document.body.removeChild(div);
+  });
+
+  it('ignores unrecognized keys', () => {
+    renderKeyboardHook();
+    pressKey('x');
+    pressKey('5');
+    pressKey('Escape');
+
+    expect(onCameraPreset).not.toHaveBeenCalled();
+    expect(onResetView).not.toHaveBeenCalled();
+    expect(onToggleWireframe).not.toHaveBeenCalled();
+  });
+
+  it('removes event listener on unmount', () => {
+    const { unmount } = renderKeyboardHook();
+    unmount();
+
+    pressKey('1');
+    expect(onCameraPreset).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/bin-designer/components/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage.tsx
@@ -1,17 +1,23 @@
 /**
  * Bin Designer page layout.
  *
- * Two-column layout: left panel (parameter controls, 320px) + main area (3D preview placeholder).
+ * Two-column layout: left panel (parameter controls, 320px) + main area (3D preview).
  * On mobile (<768px), the parameter panel is shown as a full-width bottom area.
+ * The useGeneration hook auto-generates mesh when parameters change.
  */
 
 import { ParameterPanel } from './ParameterPanel';
+import { PreviewCanvas } from './PreviewCanvas';
+import { useGeneration } from '../hooks/useGeneration';
 
 interface DesignerPageProps {
   onNavigateBack: () => void;
 }
 
 export function DesignerPage({ onNavigateBack }: DesignerPageProps) {
+  // Initialize generation bridge - auto-generates mesh when params change
+  useGeneration();
+
   return (
     <div className="flex h-screen flex-col bg-gray-50">
       {/* Header */}
@@ -53,30 +59,9 @@ export function DesignerPage({ onNavigateBack }: DesignerPageProps) {
           <ParameterPanel />
         </div>
 
-        {/* Center area: 3D preview placeholder */}
-        <div className="flex flex-1 items-center justify-center bg-gray-100">
-          <div className="text-center">
-            <div className="mx-auto mb-4 h-24 w-24 rounded-xl bg-gray-200 p-6">
-              <svg
-                className="h-full w-full text-gray-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={1.5}
-                  d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"
-                />
-              </svg>
-            </div>
-            <h2 className="text-lg font-medium text-gray-700">3D Preview</h2>
-            <p className="mt-1 text-sm text-gray-500">
-              Parametric bin preview will appear here
-            </p>
-          </div>
+        {/* Center area: 3D preview */}
+        <div className="relative flex-1 overflow-hidden">
+          <PreviewCanvas />
         </div>
 
         {/* Mobile: Bottom parameter panel (shown on mobile, hidden on md+) */}

--- a/src/features/bin-designer/components/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas.tsx
@@ -1,0 +1,127 @@
+/**
+ * Three.js 3D preview canvas for the bin designer.
+ * Renders the generated mesh with orbit controls and camera presets.
+ */
+
+import { useRef, useCallback, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import { useShallow } from 'zustand/react/shallow';
+import { Vector3 } from 'three';
+import type { OrbitControls as OrbitControlsType } from 'three-stdlib';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { BinMesh, PreviewControls, PreviewSkeleton, type CameraPreset } from './preview';
+import { useDesignerKeyboard } from '../hooks/useDesignerKeyboard';
+
+/** Camera positions for each preset (eye position looking at origin) */
+const CAMERA_POSITIONS: Record<CameraPreset, [number, number, number]> = {
+  front: [0, -120, 30],
+  side: [120, 0, 30],
+  top: [0, -1, 150],
+  isometric: [80, -80, 60],
+};
+
+const DEFAULT_CAMERA: [number, number, number] = CAMERA_POSITIONS.isometric;
+
+export function PreviewCanvas() {
+  const controlsRef = useRef<OrbitControlsType>(null);
+  const [wireframe, setWireframe] = useState(false);
+
+  const { wasmStatus, generationStatus, hasMesh } = useDesignerStore(
+    useShallow((s) => ({
+      wasmStatus: s.wasmStatus,
+      generationStatus: s.generation.status,
+      hasMesh: s.generation.mesh !== null && s.generation.mesh.vertices !== null,
+    }))
+  );
+
+  const setCameraPreset = useCallback((preset: CameraPreset) => {
+    const controls = controlsRef.current;
+    if (!controls) return;
+
+    const pos = CAMERA_POSITIONS[preset];
+    controls.object.position.set(pos[0], pos[1], pos[2]);
+    controls.target.set(0, 0, 20);
+    controls.update();
+  }, []);
+
+  const resetView = useCallback(() => {
+    setCameraPreset('isometric');
+  }, [setCameraPreset]);
+
+  const toggleWireframe = useCallback(() => {
+    setWireframe((w) => !w);
+  }, []);
+
+  // Keyboard shortcuts
+  useDesignerKeyboard({
+    onCameraPreset: setCameraPreset,
+    onResetView: resetView,
+    onToggleWireframe: toggleWireframe,
+  });
+
+  const showSkeleton = !hasMesh || wasmStatus !== 'ready';
+  const showOverlay = generationStatus === 'generating' && hasMesh;
+
+  return (
+    <div className="relative h-full w-full">
+      {showSkeleton ? (
+        <PreviewSkeleton wasmStatus={wasmStatus} generationStatus={generationStatus} />
+      ) : (
+        <>
+          <Canvas
+            camera={{
+              position: new Vector3(...DEFAULT_CAMERA),
+              fov: 45,
+              near: 0.1,
+              far: 1000,
+            }}
+            gl={{ antialias: true }}
+          >
+            {/* Lighting */}
+            <ambientLight intensity={0.4} />
+            <directionalLight position={[50, -50, 100]} intensity={0.8} />
+            <directionalLight position={[-30, 40, 60]} intensity={0.3} />
+
+            {/* Mesh */}
+            <BinMesh wireframe={wireframe} />
+
+            {/* Floor grid (subtle) */}
+            <gridHelper
+              args={[200, 20, '#d1d5db', '#e5e7eb']}
+              rotation={[Math.PI / 2, 0, 0]}
+              position={[0, 0, 0]}
+            />
+
+            {/* Controls */}
+            <OrbitControls
+              ref={controlsRef}
+              target={[0, 0, 20]}
+              enableDamping
+              dampingFactor={0.1}
+              minDistance={20}
+              maxDistance={400}
+            />
+          </Canvas>
+
+          {/* Generating overlay */}
+          {showOverlay && (
+            <div className="absolute inset-0 flex items-center justify-center bg-white/30 backdrop-blur-[1px]">
+              <span className="rounded-full bg-white/90 px-3 py-1 text-xs font-medium text-gray-600 shadow-sm">
+                Updating...
+              </span>
+            </div>
+          )}
+
+          {/* Control buttons */}
+          <PreviewControls
+            wireframe={wireframe}
+            onWireframeToggle={toggleWireframe}
+            onCameraPreset={setCameraPreset}
+            onResetView={resetView}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/preview/BinMesh.tsx
+++ b/src/features/bin-designer/components/preview/BinMesh.tsx
@@ -1,0 +1,54 @@
+/**
+ * Renders generated bin geometry as a Three.js mesh.
+ * Takes raw Float32Array vertex/normal buffers from the generation engine.
+ */
+
+import { useMemo, useRef, useEffect } from 'react';
+import * as THREE from 'three';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { useShallow } from 'zustand/react/shallow';
+
+interface BinMeshProps {
+  wireframe: boolean;
+}
+
+export function BinMesh({ wireframe }: BinMeshProps) {
+  const meshRef = useRef<THREE.Mesh>(null);
+
+  const { vertices, normals } = useDesignerStore(
+    useShallow((s) => ({
+      vertices: s.generation.mesh?.vertices ?? null,
+      normals: s.generation.mesh?.normals ?? null,
+    }))
+  );
+
+  const geometry = useMemo(() => {
+    if (!vertices || !normals || vertices.length === 0) return null;
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+    geo.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
+    return geo;
+  }, [vertices, normals]);
+
+  // Dispose old geometry on unmount or change
+  useEffect(() => {
+    return () => {
+      geometry?.dispose();
+    };
+  }, [geometry]);
+
+  if (!geometry) return null;
+
+  return (
+    <mesh ref={meshRef} geometry={geometry}>
+      <meshStandardMaterial
+        color="#e5e7eb"
+        roughness={0.5}
+        metalness={0}
+        wireframe={wireframe}
+        side={THREE.DoubleSide}
+      />
+    </mesh>
+  );
+}

--- a/src/features/bin-designer/components/preview/PreviewControls.tsx
+++ b/src/features/bin-designer/components/preview/PreviewControls.tsx
@@ -1,0 +1,74 @@
+/**
+ * Overlay control buttons for the 3D preview.
+ * Camera presets, reset view, and wireframe toggle.
+ */
+
+export type CameraPreset = 'front' | 'side' | 'top' | 'isometric';
+
+interface PreviewControlsProps {
+  wireframe: boolean;
+  onWireframeToggle: () => void;
+  onCameraPreset: (preset: CameraPreset) => void;
+  onResetView: () => void;
+}
+
+const PRESETS: Array<{ key: CameraPreset; label: string; shortcut: string }> = [
+  { key: 'front', label: 'Front', shortcut: '1' },
+  { key: 'side', label: 'Side', shortcut: '2' },
+  { key: 'top', label: 'Top', shortcut: '3' },
+  { key: 'isometric', label: 'Iso', shortcut: '4' },
+];
+
+export function PreviewControls({
+  wireframe,
+  onWireframeToggle,
+  onCameraPreset,
+  onResetView,
+}: PreviewControlsProps) {
+  return (
+    <div className="absolute right-2 top-2 flex flex-col gap-1">
+      {/* Camera presets */}
+      {PRESETS.map(({ key, label, shortcut }) => (
+        <button
+          key={key}
+          type="button"
+          onClick={() => onCameraPreset(key)}
+          className="rounded bg-white/80 px-2 py-1 text-[10px] font-medium text-gray-700 shadow-sm backdrop-blur hover:bg-white"
+          title={`${label} view (${shortcut})`}
+          aria-label={`${label} camera view`}
+        >
+          {label}
+        </button>
+      ))}
+
+      <div className="my-1 h-px bg-gray-300" />
+
+      {/* Reset view */}
+      <button
+        type="button"
+        onClick={onResetView}
+        className="rounded bg-white/80 px-2 py-1 text-[10px] font-medium text-gray-700 shadow-sm backdrop-blur hover:bg-white"
+        title="Reset view (R)"
+        aria-label="Reset camera view"
+      >
+        Reset
+      </button>
+
+      {/* Wireframe toggle */}
+      <button
+        type="button"
+        onClick={onWireframeToggle}
+        className={`rounded px-2 py-1 text-[10px] font-medium shadow-sm backdrop-blur ${
+          wireframe
+            ? 'bg-accent text-white'
+            : 'bg-white/80 text-gray-700 hover:bg-white'
+        }`}
+        title="Toggle wireframe (W)"
+        aria-label="Toggle wireframe mode"
+        aria-pressed={wireframe}
+      >
+        Wire
+      </button>
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/preview/PreviewSkeleton.tsx
+++ b/src/features/bin-designer/components/preview/PreviewSkeleton.tsx
@@ -1,0 +1,44 @@
+/**
+ * Loading skeleton for the 3D preview.
+ * Shows a pulsing placeholder while WASM initializes or mesh generates.
+ */
+
+import type { WasmStatus, GenerationStatus } from '@/features/bin-designer/types';
+
+interface PreviewSkeletonProps {
+  wasmStatus: WasmStatus;
+  generationStatus: GenerationStatus;
+}
+
+export function PreviewSkeleton({ wasmStatus, generationStatus }: PreviewSkeletonProps) {
+  const getMessage = () => {
+    if (wasmStatus === 'loading') return 'Initializing engine...';
+    if (wasmStatus === 'error') return 'Engine failed to load';
+    if (generationStatus === 'generating') return 'Generating mesh...';
+    if (generationStatus === 'error') return 'Generation failed';
+    return 'Loading preview...';
+  };
+
+  const isError = wasmStatus === 'error' || generationStatus === 'error';
+
+  return (
+    <div className="flex h-full w-full items-center justify-center bg-gray-100">
+      <div className="text-center">
+        <div className={`mx-auto mb-3 h-16 w-16 rounded-xl ${isError ? 'bg-red-100' : 'bg-gray-200 animate-pulse'} flex items-center justify-center`}>
+          {isError ? (
+            <svg className="h-8 w-8 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          ) : (
+            <svg className="h-8 w-8 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
+            </svg>
+          )}
+        </div>
+        <p className={`text-sm ${isError ? 'text-red-600' : 'text-gray-500'}`}>
+          {getMessage()}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/preview/index.ts
+++ b/src/features/bin-designer/components/preview/index.ts
@@ -1,0 +1,3 @@
+export { BinMesh } from './BinMesh';
+export { PreviewControls, type CameraPreset } from './PreviewControls';
+export { PreviewSkeleton } from './PreviewSkeleton';

--- a/src/features/bin-designer/hooks/index.ts
+++ b/src/features/bin-designer/hooks/index.ts
@@ -1,2 +1,3 @@
+export { useDesignerKeyboard } from './useDesignerKeyboard';
 export { useDesignerRouting } from './useDesignerRouting';
 export { useGeneration } from './useGeneration';

--- a/src/features/bin-designer/hooks/useDesignerKeyboard.ts
+++ b/src/features/bin-designer/hooks/useDesignerKeyboard.ts
@@ -1,0 +1,60 @@
+/**
+ * Keyboard shortcuts for the bin designer preview.
+ * Keys 1-4: Camera presets, R: Reset, W: Wireframe toggle.
+ */
+
+import { useEffect } from 'react';
+import type { CameraPreset } from '../components/preview';
+
+interface UseDesignerKeyboardOptions {
+  onCameraPreset: (preset: CameraPreset) => void;
+  onResetView: () => void;
+  onToggleWireframe: () => void;
+}
+
+const PRESET_KEYS: Record<string, CameraPreset> = {
+  '1': 'front',
+  '2': 'side',
+  '3': 'top',
+  '4': 'isometric',
+};
+
+export function useDesignerKeyboard({
+  onCameraPreset,
+  onResetView,
+  onToggleWireframe,
+}: UseDesignerKeyboardOptions): void {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Ignore when typing in inputs
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+        return;
+      }
+
+      // Ignore with modifiers (except for undo/redo which are handled elsewhere)
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+      const preset = PRESET_KEYS[e.key];
+      if (preset) {
+        e.preventDefault();
+        onCameraPreset(preset);
+        return;
+      }
+
+      if (e.key === 'r' || e.key === 'R') {
+        e.preventDefault();
+        onResetView();
+        return;
+      }
+
+      if (e.key === 'w' || e.key === 'W') {
+        e.preventDefault();
+        onToggleWireframe();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onCameraPreset, onResetView, onToggleWireframe]);
+}


### PR DESCRIPTION
## Summary
- Add Three.js 3D preview canvas that renders generated bin mesh geometry from the Zustand store
- Camera presets (Front, Side, Top, Isometric) via overlay buttons and keyboard shortcuts (1-4)
- OrbitControls for free rotation/zoom/pan with damping
- Wireframe toggle (W key) for mesh inspection
- Reset view (R key) to isometric default
- Loading skeleton during WASM init/generation, "Updating..." overlay during re-generation
- Integration: `useGeneration` hook now auto-generates mesh on parameter changes

## Components Added
- `PreviewCanvas` - Main canvas with lighting, controls, conditional rendering
- `preview/BinMesh` - Renders Float32Array vertex/normal buffers as BufferGeometry
- `preview/PreviewControls` - Overlay buttons for camera presets + wireframe
- `preview/PreviewSkeleton` - Loading/error state display
- `hooks/useDesignerKeyboard` - Keyboard shortcut handler (1-4, R, W)

## Architecture
- `PreviewCanvas` subscribes to store via `useShallow` for `wasmStatus`, `generationStatus`, `hasMesh`
- `BinMesh` subscribes separately for `vertices`/`normals` to avoid re-rendering on unrelated state changes
- Camera presets use direct `OrbitControls` manipulation (not state-driven re-renders)
- Keyboard hook ignores events when typing in inputs/textareas/contenteditable

## Test plan
- [x] 16 keyboard hook tests (all presets, modifiers, input/textarea/contenteditable filtering, cleanup)
- [x] 9 PreviewCanvas tests (skeleton states, canvas rendering, overlay, control buttons)
- [x] Full suite: 4407 tests pass
- [x] Lint: 0 errors
- [x] Build: 120.58 kB gzip (under 126 kB limit)
- [ ] Manual: orbit controls, camera presets, wireframe toggle