### PR TITLE
feat(bin-designer): add bin styles, dividers, scoops, and label geometry

### DIFF
--- a/src/features/bin-designer/__tests__/utils/styleConstraints.test.ts
+++ b/src/features/bin-designer/__tests__/utils/styleConstraints.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { getStyleConstraints, isFeatureDisabled } from '../../utils/styleConstraints';
+import type { BinStyle } from '../../types';
+
+describe('styleConstraints', () => {
+  describe('getStyleConstraints', () => {
+    it('standard style has no disabled features', () => {
+      const constraints = getStyleConstraints('standard');
+      expect(constraints.disabledFeatures).toEqual([]);
+      expect(constraints.hasGussets).toBe(false);
+    });
+
+    it('lite style has no disabled features', () => {
+      const constraints = getStyleConstraints('lite');
+      expect(constraints.disabledFeatures).toEqual([]);
+      expect(constraints.hasGussets).toBe(false);
+    });
+
+    it('solid style enables gussets', () => {
+      const constraints = getStyleConstraints('solid');
+      expect(constraints.disabledFeatures).toEqual([]);
+      expect(constraints.hasGussets).toBe(true);
+    });
+
+    it('vase style disables all interior features', () => {
+      const constraints = getStyleConstraints('vase');
+      expect(constraints.disabledFeatures).toContain('dividers');
+      expect(constraints.disabledFeatures).toContain('scoop');
+      expect(constraints.disabledFeatures).toContain('label');
+      expect(constraints.disabledFeatures).toContain('walls');
+      expect(constraints.hasGussets).toBe(false);
+    });
+
+    it('rugged style enables gussets', () => {
+      const constraints = getStyleConstraints('rugged');
+      expect(constraints.disabledFeatures).toEqual([]);
+      expect(constraints.hasGussets).toBe(true);
+    });
+
+    it('vase has a warning message', () => {
+      const constraints = getStyleConstraints('vase');
+      expect(constraints.warnings.length).toBeGreaterThan(0);
+      expect(constraints.warnings[0]).toContain('Vase');
+    });
+
+    it('lite has a warning about structural integrity', () => {
+      const constraints = getStyleConstraints('lite');
+      expect(constraints.warnings.length).toBeGreaterThan(0);
+      expect(constraints.warnings[0]).toContain('structural');
+    });
+  });
+
+  describe('isFeatureDisabled', () => {
+    it('returns false for standard style features', () => {
+      expect(isFeatureDisabled('standard', 'dividers')).toBe(false);
+      expect(isFeatureDisabled('standard', 'scoop')).toBe(false);
+      expect(isFeatureDisabled('standard', 'label')).toBe(false);
+    });
+
+    it('returns true for vase mode interior features', () => {
+      expect(isFeatureDisabled('vase', 'dividers')).toBe(true);
+      expect(isFeatureDisabled('vase', 'scoop')).toBe(true);
+      expect(isFeatureDisabled('vase', 'label')).toBe(true);
+      expect(isFeatureDisabled('vase', 'walls')).toBe(true);
+    });
+
+    it('returns false for rugged style features', () => {
+      expect(isFeatureDisabled('rugged', 'dividers')).toBe(false);
+      expect(isFeatureDisabled('rugged', 'scoop')).toBe(false);
+    });
+
+    it('covers all style types', () => {
+      const styles: BinStyle[] = ['standard', 'lite', 'solid', 'vase', 'rugged'];
+      for (const style of styles) {
+        // Should not throw for any valid style
+        expect(() => getStyleConstraints(style)).not.toThrow();
+      }
+    });
+  });
+});

--- a/src/features/bin-designer/utils/index.ts
+++ b/src/features/bin-designer/utils/index.ts
@@ -2,3 +2,5 @@ export { validateBinParams } from './validation';
 export type { DesignerValidationError } from './validation';
 export { generateFileName } from './fileNaming';
 export type { FileNameStyle } from './fileNaming';
+export { getStyleConstraints, isFeatureDisabled } from './styleConstraints';
+export type { StyleConstraints, ConstrainedFeature } from './styleConstraints';

--- a/src/features/bin-designer/utils/styleConstraints.ts
+++ b/src/features/bin-designer/utils/styleConstraints.ts
@@ -1,0 +1,65 @@
+/**
+ * Style constraint logic for the bin designer.
+ *
+ * Different bin styles disable certain interior features.
+ * For example, vase mode (thin single wall) cannot support
+ * dividers, scoops, or labels.
+ */
+
+import type { BinStyle } from '../types';
+
+/** Features that can be constrained by a style */
+export type ConstrainedFeature = 'dividers' | 'scoop' | 'label' | 'walls';
+
+/** Constraint information for a bin style */
+export interface StyleConstraints {
+  /** Features disabled by this style */
+  readonly disabledFeatures: readonly ConstrainedFeature[];
+  /** Warning messages to show in the UI */
+  readonly warnings: readonly string[];
+  /** Extra gusset reinforcement available */
+  readonly hasGussets: boolean;
+}
+
+const STYLE_CONSTRAINTS: Record<BinStyle, StyleConstraints> = {
+  standard: {
+    disabledFeatures: [],
+    warnings: [],
+    hasGussets: false,
+  },
+  lite: {
+    disabledFeatures: [],
+    warnings: ['Thinner walls may reduce structural integrity with heavy items'],
+    hasGussets: false,
+  },
+  solid: {
+    disabledFeatures: [],
+    warnings: [],
+    hasGussets: true,
+  },
+  vase: {
+    disabledFeatures: ['dividers', 'scoop', 'label', 'walls'],
+    warnings: ['Vase mode: single thin wall with no interior features'],
+    hasGussets: false,
+  },
+  rugged: {
+    disabledFeatures: [],
+    warnings: [],
+    hasGussets: true,
+  },
+};
+
+/**
+ * Returns constraint information for the given style.
+ * Used by UI to disable/warn about incompatible features.
+ */
+export function getStyleConstraints(style: BinStyle): StyleConstraints {
+  return STYLE_CONSTRAINTS[style];
+}
+
+/**
+ * Checks if a specific feature is disabled for a given style.
+ */
+export function isFeatureDisabled(style: BinStyle, feature: ConstrainedFeature): boolean {
+  return STYLE_CONSTRAINTS[style].disabledFeatures.includes(feature);
+}

--- a/src/features/generation/__tests__/binGenerator.test.ts
+++ b/src/features/generation/__tests__/binGenerator.test.ts
@@ -159,5 +159,133 @@ describe('binGenerator', () => {
       expect(mesh.vertices.length % 9).toBe(0);
       expect(mesh.vertices.length / 9).toBe(mesh.triangleCount);
     });
+
+    it('scoop adds geometry when enabled', () => {
+      const noScoop = generateBinGeometry({ ...DEFAULT_BIN_PARAMS, scoop: false });
+      const withScoop = generateBinGeometry({ ...DEFAULT_BIN_PARAMS, scoop: true });
+
+      expect(withScoop.triangleCount).toBeGreaterThan(noScoop.triangleCount);
+    });
+
+    it('scoop geometry stays within bin bounds', () => {
+      const params: BinParams = { ...DEFAULT_BIN_PARAMS, scoop: true };
+      const mesh = generateBinGeometry(params);
+      const bounds = getBounds(mesh.vertices);
+
+      const expectedWidth = 2 * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+      const expectedDepth = 2 * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+      const expectedHeight = 3 * GRIDFINITY.HEIGHT_UNIT + GRIDFINITY.BASE_HEIGHT;
+
+      expect(bounds.maxX - bounds.minX).toBeCloseTo(expectedWidth, 0);
+      expect(bounds.maxY - bounds.minY).toBeCloseTo(expectedDepth, 0);
+      // Scoop may add slight height due to arc, but within bounds
+      expect(bounds.maxZ).toBeLessThanOrEqual(expectedHeight + 1);
+    });
+
+    it('scoop respects divider compartments', () => {
+      const noDividers = generateBinGeometry({
+        ...DEFAULT_BIN_PARAMS,
+        scoop: true,
+        dividers: { x: 0, y: 0, thickness: 1.2 },
+      });
+      const withDividers = generateBinGeometry({
+        ...DEFAULT_BIN_PARAMS,
+        scoop: true,
+        dividers: { x: 2, y: 0, thickness: 1.2 },
+      });
+
+      // More compartments = more scoops = more triangles
+      expect(withDividers.triangleCount).toBeGreaterThan(noDividers.triangleCount);
+    });
+
+    it('label tab adds geometry when enabled', () => {
+      const noLabel = generateBinGeometry({
+        ...DEFAULT_BIN_PARAMS,
+        label: { enabled: false, text: '', fontSize: 'auto' },
+      });
+      const withLabel = generateBinGeometry({
+        ...DEFAULT_BIN_PARAMS,
+        label: { enabled: true, text: 'Test', fontSize: 'auto' },
+      });
+
+      expect(withLabel.triangleCount).toBeGreaterThan(noLabel.triangleCount);
+    });
+
+    it('rugged style adds corner gussets', () => {
+      const standard = generateBinGeometry({ ...DEFAULT_BIN_PARAMS, style: 'standard' });
+      const rugged = generateBinGeometry({ ...DEFAULT_BIN_PARAMS, style: 'rugged' });
+
+      expect(rugged.triangleCount).toBeGreaterThan(standard.triangleCount);
+    });
+
+    it('solid style adds corner gussets', () => {
+      const standard = generateBinGeometry({ ...DEFAULT_BIN_PARAMS, style: 'standard' });
+      const solid = generateBinGeometry({ ...DEFAULT_BIN_PARAMS, style: 'solid' });
+
+      expect(solid.triangleCount).toBeGreaterThan(standard.triangleCount);
+    });
+
+    it('vase mode ignores scoop even when enabled', () => {
+      const vaseNoScoop = generateBinGeometry({
+        ...DEFAULT_BIN_PARAMS,
+        style: 'vase',
+        scoop: false,
+      });
+      const vaseWithScoop = generateBinGeometry({
+        ...DEFAULT_BIN_PARAMS,
+        style: 'vase',
+        scoop: true,
+      });
+
+      expect(vaseWithScoop.triangleCount).toBe(vaseNoScoop.triangleCount);
+    });
+
+    it('vase mode ignores label even when enabled', () => {
+      const vaseNoLabel = generateBinGeometry({
+        ...DEFAULT_BIN_PARAMS,
+        style: 'vase',
+        label: { enabled: false, text: '', fontSize: 'auto' },
+      });
+      const vaseWithLabel = generateBinGeometry({
+        ...DEFAULT_BIN_PARAMS,
+        style: 'vase',
+        label: { enabled: true, text: 'Test', fontSize: 'auto' },
+      });
+
+      expect(vaseWithLabel.triangleCount).toBe(vaseNoLabel.triangleCount);
+    });
+
+    it('vase mode ignores dividers even when specified', () => {
+      const vaseNoDividers = generateBinGeometry({
+        ...DEFAULT_BIN_PARAMS,
+        style: 'vase',
+        dividers: { x: 0, y: 0, thickness: 1.2 },
+      });
+      const vaseWithDividers = generateBinGeometry({
+        ...DEFAULT_BIN_PARAMS,
+        style: 'vase',
+        dividers: { x: 2, y: 2, thickness: 1.2 },
+      });
+
+      expect(vaseWithDividers.triangleCount).toBe(vaseNoDividers.triangleCount);
+    });
+
+    it('lite style produces same features as standard but thinner walls', () => {
+      const lite = generateBinGeometry({
+        ...DEFAULT_BIN_PARAMS,
+        style: 'lite',
+        scoop: true,
+        label: { enabled: true, text: 'Test', fontSize: 'auto' },
+      });
+      const standard = generateBinGeometry({
+        ...DEFAULT_BIN_PARAMS,
+        style: 'standard',
+        scoop: true,
+        label: { enabled: true, text: 'Test', fontSize: 'auto' },
+      });
+
+      // Same feature set (same triangle count), different geometry positions
+      expect(lite.triangleCount).toBe(standard.triangleCount);
+    });
   });
 });

--- a/src/features/generation/__tests__/geometry.test.ts
+++ b/src/features/generation/__tests__/geometry.test.ts
@@ -4,6 +4,9 @@ import {
   createHollowBox,
   createCylinder,
   createDividerWall,
+  createScoop,
+  createLabelTab,
+  createCornerGusset,
   mergeMeshes,
 } from '../worker/generators/geometry';
 import type { MeshData } from '../bridge/types';
@@ -172,6 +175,171 @@ describe('geometry utilities', () => {
       for (let i = 0; i < meshes[1].vertices.length; i++) {
         expect(result.vertices[offset + i]).toBe(meshes[1].vertices[i]);
       }
+    });
+  });
+
+  describe('createScoop', () => {
+    it('produces non-empty mesh', () => {
+      const mesh = createScoop(0, -30, 5, 40, 15);
+      expect(mesh.vertices.length).toBeGreaterThan(0);
+      expect(mesh.normals.length).toBe(mesh.vertices.length);
+      expect(mesh.triangleCount).toBeGreaterThan(0);
+    });
+
+    it('spans the correct width', () => {
+      const width = 40;
+      const mesh = createScoop(0, -30, 5, width, 15);
+
+      let minX = Infinity, maxX = -Infinity;
+      for (let i = 0; i < mesh.vertices.length; i += 3) {
+        minX = Math.min(minX, mesh.vertices[i]);
+        maxX = Math.max(maxX, mesh.vertices[i]);
+      }
+      expect(maxX - minX).toBeCloseTo(width, 1);
+    });
+
+    it('starts at the given Z coordinate', () => {
+      const floorZ = 5.7;
+      const mesh = createScoop(0, -30, floorZ, 40, 15);
+
+      let minZ = Infinity;
+      for (let i = 2; i < mesh.vertices.length; i += 3) {
+        minZ = Math.min(minZ, mesh.vertices[i]);
+      }
+      expect(minZ).toBeCloseTo(floorZ, 3);
+    });
+
+    it('scoop height equals radius', () => {
+      const radius = 15;
+      const floorZ = 5;
+      const mesh = createScoop(0, -30, floorZ, 40, radius);
+
+      let minZ = Infinity, maxZ = -Infinity;
+      for (let i = 2; i < mesh.vertices.length; i += 3) {
+        minZ = Math.min(minZ, mesh.vertices[i]);
+        maxZ = Math.max(maxZ, mesh.vertices[i]);
+      }
+      expect(maxZ - minZ).toBeCloseTo(radius, 1);
+    });
+
+    it('more segments produce more triangles', () => {
+      const mesh4 = createScoop(0, 0, 5, 40, 15, 4);
+      const mesh16 = createScoop(0, 0, 5, 40, 15, 16);
+      expect(mesh16.triangleCount).toBeGreaterThan(mesh4.triangleCount);
+    });
+
+    it('vertex count matches triangle count * 9', () => {
+      const mesh = createScoop(0, 0, 5, 40, 15);
+      expect(mesh.vertices.length).toBe(mesh.triangleCount * 9);
+    });
+  });
+
+  describe('createLabelTab', () => {
+    it('produces 4 triangles for valid dimensions', () => {
+      const mesh = createLabelTab(84, 1.2, 42, 26);
+      expect(mesh.triangleCount).toBe(4);
+      expect(mesh.vertices.length).toBe(36); // 4 * 9
+    });
+
+    it('returns empty mesh when tab width is zero or negative', () => {
+      const mesh = createLabelTab(4, 3, 2, 26);
+      expect(mesh.vertices.length).toBe(0);
+      expect(mesh.triangleCount).toBe(0);
+    });
+
+    it('tab top edge is at total height', () => {
+      const totalHeight = 26;
+      const mesh = createLabelTab(84, 1.2, 42, totalHeight);
+
+      let maxZ = -Infinity;
+      for (let i = 2; i < mesh.vertices.length; i += 3) {
+        maxZ = Math.max(maxZ, mesh.vertices[i]);
+      }
+      expect(maxZ).toBeCloseTo(totalHeight, 1);
+    });
+
+    it('tab height span matches tabHeight parameter', () => {
+      const totalHeight = 26;
+      const tabHeight = 10;
+      const mesh = createLabelTab(84, 1.2, 42, totalHeight, tabHeight);
+
+      let minZ = Infinity, maxZ = -Infinity;
+      for (let i = 2; i < mesh.vertices.length; i += 3) {
+        minZ = Math.min(minZ, mesh.vertices[i]);
+        maxZ = Math.max(maxZ, mesh.vertices[i]);
+      }
+      expect(maxZ - minZ).toBeCloseTo(tabHeight, 1);
+    });
+
+    it('normals have non-zero Y and Z components (angled surface)', () => {
+      const mesh = createLabelTab(84, 1.2, 42, 26);
+      // Front face normals should have negative Y and positive Z (angled 45°)
+      const ny = mesh.normals[1];
+      const nz = mesh.normals[2];
+      expect(ny).toBeLessThan(0);
+      expect(nz).toBeGreaterThan(0);
+    });
+  });
+
+  describe('createCornerGusset', () => {
+    it('produces 8 triangles', () => {
+      const mesh = createCornerGusset(0, 0, 5, 3, 20, 1, 1);
+      expect(mesh.triangleCount).toBe(8);
+      expect(mesh.vertices.length).toBe(72); // 8 * 9
+    });
+
+    it('gusset Z range matches z + height', () => {
+      const z = 5.7;
+      const height = 20;
+      const mesh = createCornerGusset(0, 0, z, 3, height, 1, 1);
+
+      let minZ = Infinity, maxZ = -Infinity;
+      for (let i = 2; i < mesh.vertices.length; i += 3) {
+        minZ = Math.min(minZ, mesh.vertices[i]);
+        maxZ = Math.max(maxZ, mesh.vertices[i]);
+      }
+      expect(minZ).toBeCloseTo(z, 3);
+      expect(maxZ).toBeCloseTo(z + height, 3);
+    });
+
+    it('positive signs extend in +X +Y from corner', () => {
+      const mesh = createCornerGusset(10, 10, 0, 5, 10, 1, 1);
+
+      let minX = Infinity, maxX = -Infinity;
+      let minY = Infinity, maxY = -Infinity;
+      for (let i = 0; i < mesh.vertices.length; i += 3) {
+        minX = Math.min(minX, mesh.vertices[i]);
+        maxX = Math.max(maxX, mesh.vertices[i]);
+        minY = Math.min(minY, mesh.vertices[i + 1]);
+        maxY = Math.max(maxY, mesh.vertices[i + 1]);
+      }
+      expect(minX).toBeCloseTo(10, 3);
+      expect(maxX).toBeCloseTo(15, 3);
+      expect(minY).toBeCloseTo(10, 3);
+      expect(maxY).toBeCloseTo(15, 3);
+    });
+
+    it('negative signs extend in -X -Y from corner', () => {
+      const mesh = createCornerGusset(10, 10, 0, 5, 10, -1, -1);
+
+      let minX = Infinity, maxX = -Infinity;
+      let minY = Infinity, maxY = -Infinity;
+      for (let i = 0; i < mesh.vertices.length; i += 3) {
+        minX = Math.min(minX, mesh.vertices[i]);
+        maxX = Math.max(maxX, mesh.vertices[i]);
+        minY = Math.min(minY, mesh.vertices[i + 1]);
+        maxY = Math.max(maxY, mesh.vertices[i + 1]);
+      }
+      expect(minX).toBeCloseTo(5, 3);
+      expect(maxX).toBeCloseTo(10, 3);
+      expect(minY).toBeCloseTo(5, 3);
+      expect(maxY).toBeCloseTo(10, 3);
+    });
+
+    it('vertex count is consistent', () => {
+      const mesh = createCornerGusset(0, 0, 0, 3, 20, 1, 1);
+      expect(mesh.vertices.length).toBe(mesh.triangleCount * 9);
+      expect(mesh.normals.length).toBe(mesh.vertices.length);
     });
   });
 });

--- a/src/features/generation/worker/generators/binGenerator.ts
+++ b/src/features/generation/worker/generators/binGenerator.ts
@@ -11,7 +11,8 @@
 import type { BinParams } from '@/features/bin-designer/types';
 import type { MeshData } from '../../bridge/types';
 import { GRIDFINITY, STYLE_WALL_THICKNESS } from '@/features/bin-designer/constants/gridfinity';
-import { createHollowBox, createDividerWall, mergeMeshes } from './geometry';
+import { createHollowBox, createDividerWall, createScoop, createLabelTab, createCornerGusset, mergeMeshes } from './geometry';
+import { getStyleConstraints } from '@/features/bin-designer/utils/styleConstraints';
 
 /** Converts grid units to mm (width/depth) */
 function gridToMm(units: number): number {
@@ -32,10 +33,11 @@ function getWallThickness(style: string): number {
  * Generates complete bin geometry from parameters.
  *
  * Geometry is centered on X/Y axes, with Z=0 at the bottom of the bin.
- * Includes outer shell, inner cavity, and optional dividers.
+ * Includes outer shell, inner cavity, dividers, scoops, label tab, and style reinforcements.
  */
 export function generateBinGeometry(params: BinParams): MeshData {
   const wallThickness = getWallThickness(params.style);
+  const constraints = getStyleConstraints(params.style);
 
   // Outer dimensions in mm (subtract tolerance for baseplate fit)
   const outerWidth = gridToMm(params.width) - GRIDFINITY.TOLERANCE;
@@ -55,10 +57,34 @@ export function generateBinGeometry(params: BinParams): MeshData {
   // Main shell (outer walls + bottom)
   meshes.push(createHollowBox(outerWidth, outerDepth, totalHeight, wallThickness, bottomThickness));
 
-  // Dividers (if any)
-  if (params.dividers.x > 0 || params.dividers.y > 0) {
+  // Inner cavity dimensions (used by multiple features)
+  const innerWidth = outerWidth - 2 * wallThickness;
+  const innerDepth = outerDepth - 2 * wallThickness;
+  const halfDepth = outerDepth / 2;
+
+  // Dividers (if any and not constrained)
+  const hasDividers = !constraints.disabledFeatures.includes('dividers') &&
+    (params.dividers.x > 0 || params.dividers.y > 0);
+  if (hasDividers) {
     const dividerMesh = generateDividers(params, outerWidth, outerDepth, totalHeight, wallThickness, bottomThickness);
     meshes.push(dividerMesh);
+  }
+
+  // Scoops (if enabled and not constrained)
+  if (params.scoop && !constraints.disabledFeatures.includes('scoop')) {
+    const scoopMesh = generateScoops(params, innerWidth, innerDepth, wallThickness, bottomThickness);
+    meshes.push(scoopMesh);
+  }
+
+  // Label tab (if enabled and not constrained)
+  if (params.label.enabled && !constraints.disabledFeatures.includes('label')) {
+    meshes.push(createLabelTab(outerWidth, wallThickness, halfDepth, totalHeight));
+  }
+
+  // Corner gussets for reinforced styles (solid, rugged)
+  if (constraints.hasGussets) {
+    const gussetMesh = generateCornerGussets(outerWidth, outerDepth, wallThickness, bottomThickness, totalHeight);
+    meshes.push(gussetMesh);
   }
 
   return mergeMeshes(meshes);
@@ -104,6 +130,83 @@ function generateDividers(
       meshes.push(createDividerWall(x, startY, bottomThickness, thickness, innerDepth, dividerHeight));
     }
   }
+
+  return mergeMeshes(meshes);
+}
+
+/**
+ * Generates scoop ramps at the front of each compartment.
+ * Scoop radius is proportional to the compartment size, capped at 20mm.
+ */
+function generateScoops(
+  params: BinParams,
+  innerWidth: number,
+  innerDepth: number,
+  wallThickness: number,
+  bottomThickness: number
+): MeshData {
+  const meshes: MeshData[] = [];
+  const divX = params.dividers.x;
+
+  // Number of compartments along X axis
+  const compCountX = divX + 1;
+  const compCountY = params.dividers.y + 1;
+
+  const compWidth = innerWidth / compCountX;
+  const compDepth = innerDepth / compCountY;
+
+  // Scoop radius: 40% of smaller compartment dimension, max 20mm
+  const radius = Math.min(compWidth * 0.4, compDepth * 0.4, 20);
+
+  // Front row inner Y coordinate
+  const frontInnerY = -innerDepth / 2;
+
+  // Add scoops to the front row of compartments
+  for (let ix = 0; ix < compCountX; ix++) {
+    const cx = -innerWidth / 2 + (ix + 0.5) * compWidth;
+
+    meshes.push(createScoop(
+      cx,
+      frontInnerY,
+      bottomThickness,
+      compWidth - wallThickness,
+      radius
+    ));
+  }
+
+  return mergeMeshes(meshes);
+}
+
+/**
+ * Generates corner gussets at all 4 inner corners of the bin.
+ * Gusset size is proportional to wall thickness.
+ */
+function generateCornerGussets(
+  outerWidth: number,
+  outerDepth: number,
+  wallThickness: number,
+  bottomThickness: number,
+  totalHeight: number
+): MeshData {
+  const meshes: MeshData[] = [];
+  const halfW = outerWidth / 2;
+  const halfD = outerDepth / 2;
+
+  // Gusset size: 2x wall thickness
+  const gussetSize = wallThickness * 2;
+  const gussetHeight = totalHeight - bottomThickness;
+
+  // Inner corner positions
+  const innerLeft = -halfW + wallThickness;
+  const innerRight = halfW - wallThickness;
+  const innerFront = -halfD + wallThickness;
+  const innerBack = halfD - wallThickness;
+
+  // 4 corners with appropriate directions
+  meshes.push(createCornerGusset(innerLeft, innerFront, bottomThickness, gussetSize, gussetHeight, 1, 1));
+  meshes.push(createCornerGusset(innerRight, innerFront, bottomThickness, gussetSize, gussetHeight, -1, 1));
+  meshes.push(createCornerGusset(innerLeft, innerBack, bottomThickness, gussetSize, gussetHeight, 1, -1));
+  meshes.push(createCornerGusset(innerRight, innerBack, bottomThickness, gussetSize, gussetHeight, -1, -1));
 
   return mergeMeshes(meshes);
 }

--- a/src/features/generation/worker/generators/geometry.ts
+++ b/src/features/generation/worker/generators/geometry.ts
@@ -207,6 +207,243 @@ export function createCylinder(
 }
 
 /**
+ * Creates a scoop ramp (quarter-circle approximation) for a compartment.
+ *
+ * The scoop is a concave curve at the front (min Y side) of a compartment,
+ * spanning the full width of the compartment. It makes items easier to pick up.
+ *
+ * @param cx - Center X of the compartment
+ * @param frontY - Y coordinate of the compartment front wall (inner edge)
+ * @param z - Z coordinate of the compartment floor (top of bottom plate)
+ * @param compartmentWidth - Width of the compartment
+ * @param radius - Scoop radius (quarter-circle)
+ * @param segments - Number of arc segments (default 8)
+ */
+export function createScoop(
+  cx: number,
+  frontY: number,
+  z: number,
+  compartmentWidth: number,
+  radius: number,
+  segments: number = 8
+): MeshData {
+  // Scoop is a quarter-circle arc from floor going up, starting at front wall
+  // Profile: from (frontY, z) curving up to (frontY + radius, z + radius)
+  // The arc sweeps the full compartment width along X
+
+  const halfWidth = compartmentWidth / 2;
+  const x1 = cx - halfWidth;
+  const x2 = cx + halfWidth;
+
+  // Each segment produces 2 triangles (quad), total segments * 2 triangles
+  const triangleCount = segments * 2;
+  const vertices = new Float32Array(triangleCount * 9);
+  const normals = new Float32Array(triangleCount * 9);
+  let vi = 0;
+
+  const setVertex = (vx: number, vy: number, vz: number, nx: number, ny: number, nz: number) => {
+    vertices[vi] = vx; vertices[vi + 1] = vy; vertices[vi + 2] = vz;
+    normals[vi] = nx; normals[vi + 1] = ny; normals[vi + 2] = nz;
+    vi += 3;
+  };
+
+  for (let i = 0; i < segments; i++) {
+    // Angle goes from 0 (horizontal) to PI/2 (vertical)
+    const angle1 = (i / segments) * (Math.PI / 2);
+    const angle2 = ((i + 1) / segments) * (Math.PI / 2);
+
+    // Points on the quarter circle (Y offset from front, Z offset from floor)
+    const y1 = frontY + radius * (1 - Math.cos(angle1));
+    const z1 = z + radius * Math.sin(angle1);
+    const y2 = frontY + radius * (1 - Math.cos(angle2));
+    const z2 = z + radius * Math.sin(angle2);
+
+    // Normal points inward (toward center of curvature)
+    const ny1 = -Math.cos(angle1);
+    const nz1 = Math.sin(angle1);
+    const ny2 = -Math.cos(angle2);
+    const nz2 = Math.sin(angle2);
+
+    // Quad as 2 triangles (left edge to right edge)
+    // Triangle 1
+    setVertex(x1, y1, z1, 0, ny1, nz1);
+    setVertex(x2, y1, z1, 0, ny1, nz1);
+    setVertex(x2, y2, z2, 0, ny2, nz2);
+
+    // Triangle 2
+    setVertex(x1, y1, z1, 0, ny1, nz1);
+    setVertex(x2, y2, z2, 0, ny2, nz2);
+    setVertex(x1, y2, z2, 0, ny2, nz2);
+  }
+
+  return { vertices, normals, triangleCount };
+}
+
+/**
+ * Creates a label tab at the top of the front wall.
+ *
+ * Gridfinity label tabs are angled ~45° inward from the top of the front wall.
+ * Modeled as a thin angled plate (two triangles forming a quad).
+ *
+ * @param outerWidth - Full bin outer width
+ * @param wallThickness - Wall thickness
+ * @param totalHeight - Total bin height
+ * @param tabHeight - Height of the label tab (default 12mm)
+ * @param tabDepth - How far the tab extends inward (default 12mm for 45°)
+ */
+export function createLabelTab(
+  outerWidth: number,
+  wallThickness: number,
+  halfDepth: number,
+  totalHeight: number,
+  tabHeight: number = 12,
+  tabDepth: number = 12
+): MeshData {
+  // Tab spans most of the front face width (minus wall insets)
+  const tabWidth = outerWidth - 2 * wallThickness - 2; // 1mm inset on each side
+  if (tabWidth <= 0 || tabHeight <= 0) {
+    return { vertices: new Float32Array(0), normals: new Float32Array(0), triangleCount: 0 };
+  }
+
+  const halfTabW = tabWidth / 2;
+
+  // Tab top edge: at the top of the front wall, on the inner surface
+  const topZ = totalHeight;
+  const topY = -halfDepth + wallThickness;
+
+  // Tab bottom edge: angled inward and downward
+  const bottomZ = topZ - tabHeight;
+  const bottomY = topY + tabDepth;
+
+  // Normal for the angled surface (points up-and-forward at 45°)
+  const nLen = Math.sqrt(tabDepth * tabDepth + tabHeight * tabHeight);
+  const ny = -tabHeight / nLen;
+  const nz = tabDepth / nLen;
+
+  // 2 triangles for the tab face, 2 for thickness (back side)
+  const triangleCount = 4;
+  const vertices = new Float32Array(triangleCount * 9);
+  const normals = new Float32Array(triangleCount * 9);
+  let vi = 0;
+
+  const setVertex = (vx: number, vy: number, vz: number, vnx: number, vny: number, vnz: number) => {
+    vertices[vi] = vx; vertices[vi + 1] = vy; vertices[vi + 2] = vz;
+    normals[vi] = vnx; normals[vi + 1] = vny; normals[vi + 2] = vnz;
+    vi += 3;
+  };
+
+  // Front face (visible)
+  setVertex(-halfTabW, topY, topZ, 0, ny, nz);
+  setVertex(halfTabW, topY, topZ, 0, ny, nz);
+  setVertex(halfTabW, bottomY, bottomZ, 0, ny, nz);
+
+  setVertex(-halfTabW, topY, topZ, 0, ny, nz);
+  setVertex(halfTabW, bottomY, bottomZ, 0, ny, nz);
+  setVertex(-halfTabW, bottomY, bottomZ, 0, ny, nz);
+
+  // Back face (inside, reversed normal)
+  setVertex(halfTabW, topY, topZ, 0, -ny, -nz);
+  setVertex(-halfTabW, topY, topZ, 0, -ny, -nz);
+  setVertex(-halfTabW, bottomY, bottomZ, 0, -ny, -nz);
+
+  setVertex(halfTabW, topY, topZ, 0, -ny, -nz);
+  setVertex(-halfTabW, bottomY, bottomZ, 0, -ny, -nz);
+  setVertex(halfTabW, bottomY, bottomZ, 0, -ny, -nz);
+
+  return { vertices, normals, triangleCount };
+}
+
+/**
+ * Creates a triangular corner gusset for structural reinforcement.
+ *
+ * A gusset is a right-triangle prism at the inner corner of the bin,
+ * providing extra material at stress points.
+ *
+ * @param cornerX - X position of the corner
+ * @param cornerY - Y position of the corner
+ * @param z - Z start (bottom of gusset)
+ * @param size - Size of the gusset triangle legs
+ * @param height - Height of the gusset
+ * @param xSign - Direction on X axis (+1 or -1)
+ * @param ySign - Direction on Y axis (+1 or -1)
+ */
+export function createCornerGusset(
+  cornerX: number,
+  cornerY: number,
+  z: number,
+  size: number,
+  height: number,
+  xSign: number,
+  ySign: number
+): MeshData {
+  // Triangle prism: right triangle in XY plane, extruded along Z
+  // Vertices of the triangle base (at z)
+  const ax = cornerX;
+  const ay = cornerY;
+  const bx = cornerX + xSign * size;
+  const by = cornerY;
+  const cx = cornerX;
+  const cy = cornerY + ySign * size;
+
+  const z2 = z + height;
+
+  // 8 triangles: 2 triangle caps + 3 rectangular sides (2 tris each)
+  const triangleCount = 8;
+  const vertices = new Float32Array(triangleCount * 9);
+  const normals = new Float32Array(triangleCount * 9);
+  let vi = 0;
+
+  const setVertex = (vx: number, vy: number, vz: number, nx: number, ny: number, nz: number) => {
+    vertices[vi] = vx; vertices[vi + 1] = vy; vertices[vi + 2] = vz;
+    normals[vi] = nx; normals[vi + 1] = ny; normals[vi + 2] = nz;
+    vi += 3;
+  };
+
+  // Bottom cap (normal -Z)
+  setVertex(ax, ay, z, 0, 0, -1);
+  setVertex(cx, cy, z, 0, 0, -1);
+  setVertex(bx, by, z, 0, 0, -1);
+
+  // Top cap (normal +Z)
+  setVertex(ax, ay, z2, 0, 0, 1);
+  setVertex(bx, by, z2, 0, 0, 1);
+  setVertex(cx, cy, z2, 0, 0, 1);
+
+  // Side 1: edge A-B (wall along Y direction, normal = -ySign on Y)
+  setVertex(ax, ay, z, 0, -ySign, 0);
+  setVertex(bx, by, z, 0, -ySign, 0);
+  setVertex(bx, by, z2, 0, -ySign, 0);
+  setVertex(ax, ay, z, 0, -ySign, 0);
+  setVertex(bx, by, z2, 0, -ySign, 0);
+  setVertex(ax, ay, z2, 0, -ySign, 0);
+
+  // Side 2: edge A-C (wall along X direction, normal = -xSign on X)
+  setVertex(cx, cy, z, -xSign, 0, 0);
+  setVertex(ax, ay, z, -xSign, 0, 0);
+  setVertex(ax, ay, z2, -xSign, 0, 0);
+  setVertex(cx, cy, z, -xSign, 0, 0);
+  setVertex(ax, ay, z2, -xSign, 0, 0);
+  setVertex(cx, cy, z2, -xSign, 0, 0);
+
+  // Side 3: hypotenuse B-C (diagonal face)
+  // Normal of hypotenuse: perpendicular to B-C in XY plane
+  const hx = cx - bx;
+  const hy = cy - by;
+  const hLen = Math.sqrt(hx * hx + hy * hy);
+  const hnx = -hy / hLen; // perpendicular
+  const hny = hx / hLen;
+
+  setVertex(bx, by, z, hnx, hny, 0);
+  setVertex(cx, cy, z, hnx, hny, 0);
+  setVertex(cx, cy, z2, hnx, hny, 0);
+  setVertex(bx, by, z, hnx, hny, 0);
+  setVertex(cx, cy, z2, hnx, hny, 0);
+  setVertex(bx, by, z2, hnx, hny, 0);
+
+  return { vertices, normals, triangleCount };
+}
+
+/**
  * Merges multiple meshes into a single buffer.
  * Simple concatenation of vertex/normal arrays.
  */


### PR DESCRIPTION
## Summary
- Add scoop ramp geometry at the front of each compartment (quarter-circle approximation)
- Add label tab geometry (45° angled tab at top of front wall, standard Gridfinity feature)
- Add corner gusset reinforcement for solid/rugged styles (triangular prisms at inner corners)
- Add style constraints utility (`getStyleConstraints`, `isFeatureDisabled`) for UI integration
- Integrate all features into the bin generator with proper style-based gating

## How It Works

The bin generator now follows this pipeline:
1. **Outer shell** (hollow box) - all styles
2. **Dividers** (if x > 0 or y > 0 and style allows) - thin walls splitting the cavity
3. **Scoops** (if enabled and style allows) - quarter-circle ramp at front row of compartments
4. **Label tab** (if enabled and style allows) - angled flat tab at top of front wall
5. **Corner gussets** (if style is solid or rugged) - triangular corner reinforcements

Vase mode skips steps 2-5 entirely (single thin wall, no interior features).

## Architecture
- Geometry primitives added to `geometry.ts`: `createScoop`, `createLabelTab`, `createCornerGusset`
- Style constraints in `utils/styleConstraints.ts` with typed feature names
- Generator integration uses `getStyleConstraints()` to check `disabledFeatures` and `hasGussets`

## Test plan
- [x] 11 style constraints tests (all styles, disabled features, gusset flags)
- [x] 13 new bin generator integration tests (scoop, label, gussets, vase mode gating)
- [x] 13 new geometry primitive tests (scoop, label tab, corner gusset dimensions/normals)
- [x] Full suite: 4444 tests pass (37 new)
- [x] Lint: 0 errors
- [x] Build: 120.58 kB gzip (no regression)
- [ ] Manual: verify 3D preview shows scoops/labels/gussets when toggled