### PR TITLE
feat(bin-designer): add STL export, print estimates, and UX polish

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -184,7 +184,8 @@ export default function App() {
   useCrossTabSync();
 
   // URL-based layout routing (bookmarkable URLs)
-  useLayoutRouting();
+  // Skip URL manipulation when on the designer route (it owns its own URL)
+  useLayoutRouting({ skip: isDesignerRoute });
 
   // PWA update detection and auto-reload
   usePWAUpdate();

--- a/src/features/bin-designer/__tests__/components/ExportDialog.test.tsx
+++ b/src/features/bin-designer/__tests__/components/ExportDialog.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ExportDialog } from '@/features/bin-designer/components/ExportDialog';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+
+const mockDownloadSTL = vi.fn();
+
+// Mock useExport hook
+vi.mock('@/features/bin-designer/hooks/useExport', () => ({
+  useExport: () => ({
+    canExport: true,
+    isExporting: false,
+    estimates: {
+      volumeMm3: 15000,
+      gramsFilament: 18.6,
+      metersFilament: 5.02,
+      printTimeMinutes: 34,
+      costUSD: 0.47,
+    },
+    fileName: 'gridfinity_2x2x3.stl',
+    downloadSTL: mockDownloadSTL,
+  }),
+}));
+
+describe('ExportDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS },
+      generation: {
+        status: 'complete',
+        mesh: {
+          vertices: new Float32Array(108), // 12 triangles
+          normals: new Float32Array(108),
+          error: null,
+          timingMs: 10,
+        },
+        progress: 1,
+      },
+      ui: {
+        activeTab: 'dimensions',
+        exportDialogOpen: true,
+        wireframeMode: false,
+      },
+    });
+  });
+
+  it('does not render when dialog is closed', () => {
+    useDesignerStore.setState({
+      ui: { activeTab: 'dimensions', exportDialogOpen: false, wireframeMode: false },
+    });
+    const { container } = render(<ExportDialog />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders when dialog is open', () => {
+    render(<ExportDialog />);
+    expect(screen.getByText('Export Bin')).toBeInTheDocument();
+  });
+
+  it('shows format options with STL active', () => {
+    render(<ExportDialog />);
+    expect(screen.getByText('STL')).toBeInTheDocument();
+    expect(screen.getByText('STEP')).toBeInTheDocument();
+    expect(screen.getByText('3MF')).toBeInTheDocument();
+  });
+
+  it('shows file name preview', () => {
+    render(<ExportDialog />);
+    // The file name from generateFileName with default 2x2x3 params
+    expect(screen.getByText(/gridfinity.*2x2x3/)).toBeInTheDocument();
+  });
+
+  it('shows print estimates', () => {
+    render(<ExportDialog />);
+    expect(screen.getByText('Filament')).toBeInTheDocument();
+    expect(screen.getByText('Weight')).toBeInTheDocument();
+    expect(screen.getByText('Time')).toBeInTheDocument();
+    expect(screen.getByText('Cost')).toBeInTheDocument();
+  });
+
+  it('shows Download STL button', () => {
+    render(<ExportDialog />);
+    const button = screen.getByRole('button', { name: /download stl/i });
+    expect(button).toBeInTheDocument();
+    expect(button).not.toBeDisabled();
+  });
+
+  it('triggers download on button click', () => {
+    render(<ExportDialog />);
+    const button = screen.getByRole('button', { name: /download stl/i });
+    fireEvent.click(button);
+    expect(mockDownloadSTL).toHaveBeenCalled();
+  });
+
+  it('closes on backdrop click', () => {
+    render(<ExportDialog />);
+    const backdrop = screen.getByRole('dialog');
+    fireEvent.click(backdrop);
+
+    // Verify store was updated
+    expect(useDesignerStore.getState().ui.exportDialogOpen).toBe(false);
+  });
+
+  it('closes on close button click', () => {
+    render(<ExportDialog />);
+    const closeButton = screen.getByLabelText('Close export dialog');
+    fireEvent.click(closeButton);
+    expect(useDesignerStore.getState().ui.exportDialogOpen).toBe(false);
+  });
+
+  it('toggles name style between descriptive and compact', () => {
+    render(<ExportDialog />);
+
+    // Initially descriptive
+    expect(screen.getByText(/gridfinity/)).toBeInTheDocument();
+
+    // Click compact
+    fireEvent.click(screen.getByText('Compact'));
+
+    // Should show compact format
+    expect(screen.getByText(/gf_/)).toBeInTheDocument();
+  });
+
+  it('shows triangle count', () => {
+    render(<ExportDialog />);
+    expect(screen.getByText('Triangles')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('has proper aria attributes', () => {
+    render(<ExportDialog />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'export-dialog-title');
+  });
+});

--- a/src/features/bin-designer/__tests__/hooks/useExport.test.ts
+++ b/src/features/bin-designer/__tests__/hooks/useExport.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useExport } from '@/features/bin-designer/hooks/useExport';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+
+// Mock URL.createObjectURL and URL.revokeObjectURL
+const originalURL = globalThis.URL;
+const mockCreateObjectURL = vi.fn().mockReturnValue('blob:mock-url');
+const mockRevokeObjectURL = vi.fn();
+
+describe('useExport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Apply URL mock before each test
+    Object.defineProperty(globalThis, 'URL', {
+      value: {
+        ...originalURL,
+        createObjectURL: mockCreateObjectURL,
+        revokeObjectURL: mockRevokeObjectURL,
+      },
+      writable: true,
+    });
+    // Reset store to defaults
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS },
+      generation: {
+        status: 'idle',
+        mesh: null,
+        progress: 0,
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'URL', { value: originalURL, writable: true });
+    vi.restoreAllMocks();
+  });
+
+  it('canExport is false when no mesh is available', () => {
+    const { result } = renderHook(() => useExport());
+    expect(result.current.canExport).toBe(false);
+  });
+
+  it('canExport is true when mesh with vertices exists', () => {
+    useDesignerStore.setState({
+      generation: {
+        status: 'complete',
+        mesh: {
+          vertices: new Float32Array(9),
+          normals: new Float32Array(9),
+          error: null,
+          timingMs: 10,
+        },
+        progress: 1,
+      },
+    });
+
+    const { result } = renderHook(() => useExport());
+    expect(result.current.canExport).toBe(true);
+  });
+
+  it('canExport is false when mesh has an error', () => {
+    useDesignerStore.setState({
+      generation: {
+        status: 'error',
+        mesh: {
+          vertices: null,
+          normals: null,
+          error: 'Generation failed',
+          timingMs: 0,
+        },
+        progress: 0,
+      },
+    });
+
+    const { result } = renderHook(() => useExport());
+    expect(result.current.canExport).toBe(false);
+  });
+
+  it('provides print estimates', () => {
+    const { result } = renderHook(() => useExport());
+    expect(result.current.estimates.volumeMm3).toBeGreaterThan(0);
+    expect(result.current.estimates.gramsFilament).toBeGreaterThan(0);
+    expect(result.current.estimates.metersFilament).toBeGreaterThan(0);
+  });
+
+  it('provides a file name preview', () => {
+    const { result } = renderHook(() => useExport());
+    expect(result.current.fileName).toContain('gridfinity');
+    expect(result.current.fileName).toContain('.stl');
+  });
+
+  it('isExporting is initially false', () => {
+    const { result } = renderHook(() => useExport());
+    expect(result.current.isExporting).toBe(false);
+  });
+
+  it('downloadSTL does nothing when canExport is false', () => {
+    const { result } = renderHook(() => useExport());
+
+    act(() => {
+      result.current.downloadSTL();
+    });
+
+    expect(mockCreateObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('downloadSTL creates blob URL and triggers download', () => {
+    // Set up valid mesh
+    useDesignerStore.setState({
+      generation: {
+        status: 'complete',
+        mesh: {
+          vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+          normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+          error: null,
+          timingMs: 10,
+        },
+        progress: 1,
+      },
+    });
+
+    // Mock DOM APIs - only intercept 'a' elements to not break renderHook container
+    const mockAnchor = {
+      href: '',
+      download: '',
+      click: vi.fn(),
+    };
+    const originalCreateElement = document.createElement.bind(document);
+    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'a') return mockAnchor as unknown as HTMLAnchorElement;
+      return originalCreateElement(tag);
+    });
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node);
+    const removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation((node) => node);
+
+    const { result } = renderHook(() => useExport());
+
+    act(() => {
+      result.current.downloadSTL();
+    });
+
+    expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(mockAnchor.click).toHaveBeenCalled();
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+
+    createElementSpy.mockRestore();
+    appendChildSpy.mockRestore();
+    removeChildSpy.mockRestore();
+  });
+
+  it('downloadSTL respects name style parameter', () => {
+    useDesignerStore.setState({
+      generation: {
+        status: 'complete',
+        mesh: {
+          vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+          normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+          error: null,
+          timingMs: 10,
+        },
+        progress: 1,
+      },
+    });
+
+    const mockAnchor = { href: '', download: '', click: vi.fn() };
+    const originalCreateElement = document.createElement.bind(document);
+    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'a') return mockAnchor as unknown as HTMLAnchorElement;
+      return originalCreateElement(tag);
+    });
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node);
+    const removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation((node) => node);
+
+    const { result } = renderHook(() => useExport());
+
+    act(() => {
+      result.current.downloadSTL('compact');
+    });
+
+    expect(mockAnchor.download).toContain('gf_');
+
+    createElementSpy.mockRestore();
+    appendChildSpy.mockRestore();
+    removeChildSpy.mockRestore();
+  });
+
+  it('estimates update when params change', () => {
+    const { result, rerender } = renderHook(() => useExport());
+    const initialVolume = result.current.estimates.volumeMm3;
+
+    act(() => {
+      useDesignerStore.getState().setParams({ width: 4, depth: 4 });
+    });
+
+    rerender();
+    expect(result.current.estimates.volumeMm3).toBeGreaterThan(initialVolume);
+  });
+});

--- a/src/features/bin-designer/__tests__/utils/printEstimates.test.ts
+++ b/src/features/bin-designer/__tests__/utils/printEstimates.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import { estimatePrint, formatPrintTime, formatFilament } from '@/features/bin-designer/utils/printEstimates';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import type { BinParams } from '@/features/bin-designer/types';
+
+describe('printEstimates', () => {
+  describe('estimatePrint', () => {
+    it('returns positive values for default params', () => {
+      const est = estimatePrint(DEFAULT_BIN_PARAMS);
+      expect(est.volumeMm3).toBeGreaterThan(0);
+      expect(est.gramsFilament).toBeGreaterThan(0);
+      expect(est.metersFilament).toBeGreaterThan(0);
+      expect(est.printTimeMinutes).toBeGreaterThan(0);
+      expect(est.costUSD).toBeGreaterThan(0);
+    });
+
+    it('larger bins have more volume', () => {
+      const small = estimatePrint({ ...DEFAULT_BIN_PARAMS, width: 1, depth: 1 });
+      const large = estimatePrint({ ...DEFAULT_BIN_PARAMS, width: 4, depth: 4 });
+      expect(large.volumeMm3).toBeGreaterThan(small.volumeMm3);
+    });
+
+    it('taller bins have more material', () => {
+      const short = estimatePrint({ ...DEFAULT_BIN_PARAMS, height: 2 });
+      const tall = estimatePrint({ ...DEFAULT_BIN_PARAMS, height: 8 });
+      expect(tall.gramsFilament).toBeGreaterThan(short.gramsFilament);
+    });
+
+    it('vase mode uses less material than standard', () => {
+      const standard = estimatePrint({ ...DEFAULT_BIN_PARAMS, style: 'standard' });
+      const vase = estimatePrint({ ...DEFAULT_BIN_PARAMS, style: 'vase' });
+      expect(vase.volumeMm3).toBeLessThan(standard.volumeMm3);
+    });
+
+    it('solid style uses more material (thicker walls)', () => {
+      const standard = estimatePrint({ ...DEFAULT_BIN_PARAMS, style: 'standard' });
+      const solid = estimatePrint({ ...DEFAULT_BIN_PARAMS, style: 'solid' });
+      expect(solid.volumeMm3).toBeGreaterThan(standard.volumeMm3);
+    });
+
+    it('rugged style uses more material (thick walls + gussets)', () => {
+      const standard = estimatePrint({ ...DEFAULT_BIN_PARAMS, style: 'standard' });
+      const rugged = estimatePrint({ ...DEFAULT_BIN_PARAMS, style: 'rugged' });
+      expect(rugged.volumeMm3).toBeGreaterThan(standard.volumeMm3);
+    });
+
+    it('dividers add volume', () => {
+      const noDividers = estimatePrint(DEFAULT_BIN_PARAMS);
+      const withDividers = estimatePrint({
+        ...DEFAULT_BIN_PARAMS,
+        dividers: { x: 2, y: 2, thickness: 1.2 },
+      });
+      expect(withDividers.volumeMm3).toBeGreaterThan(noDividers.volumeMm3);
+    });
+
+    it('thicker dividers use more material', () => {
+      const thin = estimatePrint({
+        ...DEFAULT_BIN_PARAMS,
+        dividers: { x: 1, y: 1, thickness: 0.8 },
+      });
+      const thick = estimatePrint({
+        ...DEFAULT_BIN_PARAMS,
+        dividers: { x: 1, y: 1, thickness: 2.0 },
+      });
+      expect(thick.volumeMm3).toBeGreaterThan(thin.volumeMm3);
+    });
+
+    it('filament grams is derived from volume', () => {
+      const est = estimatePrint(DEFAULT_BIN_PARAMS);
+      // PLA density: 1.24 g/cm³, volume in mm³ → cm³ / 1000
+      const expectedGrams = (est.volumeMm3 / 1000) * 1.24;
+      expect(est.gramsFilament).toBeCloseTo(expectedGrams, 0);
+    });
+
+    it('cost scales with filament usage', () => {
+      const cheapCost = estimatePrint(DEFAULT_BIN_PARAMS, 10);
+      const expensiveCost = estimatePrint(DEFAULT_BIN_PARAMS, 50);
+      expect(expensiveCost.costUSD).toBeGreaterThan(cheapCost.costUSD);
+      // Cost should scale linearly
+      expect(expensiveCost.costUSD / cheapCost.costUSD).toBeCloseTo(5, 0);
+    });
+
+    it('print time increases with filament length', () => {
+      const small = estimatePrint({ ...DEFAULT_BIN_PARAMS, width: 1, depth: 1, height: 1 });
+      const large = estimatePrint({ ...DEFAULT_BIN_PARAMS, width: 4, depth: 4, height: 8 });
+      expect(large.printTimeMinutes).toBeGreaterThan(small.printTimeMinutes);
+    });
+
+    it('vase mode ignores dividers', () => {
+      const vaseNoDividers = estimatePrint({
+        ...DEFAULT_BIN_PARAMS,
+        style: 'vase',
+        dividers: { x: 0, y: 0, thickness: 1.2 },
+      });
+      const vaseWithDividers = estimatePrint({
+        ...DEFAULT_BIN_PARAMS,
+        style: 'vase',
+        dividers: { x: 3, y: 3, thickness: 1.2 },
+      });
+      // Vase ignores dividers, so volumes should be equal
+      expect(vaseWithDividers.volumeMm3).toBe(vaseNoDividers.volumeMm3);
+    });
+
+    it('volume is reasonable for a 2x2x3 standard bin', () => {
+      const est = estimatePrint(DEFAULT_BIN_PARAMS);
+      // A 2x2x3 bin is about 83.5 × 83.5 × 26 mm
+      // Shell volume should be between 10,000 and 100,000 mm³
+      expect(est.volumeMm3).toBeGreaterThan(10000);
+      expect(est.volumeMm3).toBeLessThan(100000);
+    });
+
+    it('returns rounded values', () => {
+      const est = estimatePrint(DEFAULT_BIN_PARAMS);
+      // Volume should be integer
+      expect(est.volumeMm3).toBe(Math.round(est.volumeMm3));
+      // Time should be integer
+      expect(est.printTimeMinutes).toBe(Math.round(est.printTimeMinutes));
+      // Cost should have at most 2 decimals
+      expect(est.costUSD * 100).toBeCloseTo(Math.round(est.costUSD * 100), 5);
+    });
+
+    it('handles half-unit dimensions', () => {
+      const params: BinParams = { ...DEFAULT_BIN_PARAMS, width: 0.5, depth: 0.5 };
+      const est = estimatePrint(params);
+      expect(est.volumeMm3).toBeGreaterThan(0);
+      expect(est.gramsFilament).toBeGreaterThan(0);
+    });
+  });
+
+  describe('formatPrintTime', () => {
+    it('formats minutes under 60 as Xm', () => {
+      expect(formatPrintTime(30)).toBe('30m');
+      expect(formatPrintTime(59)).toBe('59m');
+    });
+
+    it('formats exactly 60 minutes as 1h', () => {
+      expect(formatPrintTime(60)).toBe('1h');
+    });
+
+    it('formats hours + minutes as XhYm', () => {
+      expect(formatPrintTime(90)).toBe('1h 30m');
+      expect(formatPrintTime(135)).toBe('2h 15m');
+    });
+
+    it('formats exact hours without minutes', () => {
+      expect(formatPrintTime(120)).toBe('2h');
+      expect(formatPrintTime(180)).toBe('3h');
+    });
+  });
+
+  describe('formatFilament', () => {
+    it('formats sub-meter values as cm', () => {
+      expect(formatFilament(0.5)).toBe('50cm');
+      expect(formatFilament(0.12)).toBe('12cm');
+    });
+
+    it('formats values >= 1m with one decimal', () => {
+      expect(formatFilament(1.5)).toBe('1.5m');
+      expect(formatFilament(3.25)).toBe('3.3m'); // Rounded to 1 decimal
+    });
+
+    it('formats exactly 1m', () => {
+      expect(formatFilament(1.0)).toBe('1.0m');
+    });
+  });
+});

--- a/src/features/bin-designer/components/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage.tsx
@@ -6,9 +6,11 @@
  * The useGeneration hook auto-generates mesh when parameters change.
  */
 
-import { ParameterPanel } from './ParameterPanel';
-import { PreviewCanvas } from './PreviewCanvas';
-import { useGeneration } from '../hooks/useGeneration';
+import { ParameterPanel } from '@/features/bin-designer/components/ParameterPanel';
+import { PreviewCanvas } from '@/features/bin-designer/components/PreviewCanvas';
+import { ExportDialog } from '@/features/bin-designer/components/ExportDialog';
+import { useGeneration } from '@/features/bin-designer/hooks/useGeneration';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
 
 interface DesignerPageProps {
   onNavigateBack: () => void;
@@ -18,14 +20,22 @@ export function DesignerPage({ onNavigateBack }: DesignerPageProps) {
   // Initialize generation bridge - auto-generates mesh when params change
   useGeneration();
 
+  const canExport = useDesignerStore(
+    (s) => s.generation.mesh !== null &&
+      s.generation.mesh.error === null &&
+      s.generation.mesh.vertices !== null &&
+      s.generation.mesh.normals !== null
+  );
+  const setExportDialogOpen = useDesignerStore((s) => s.setExportDialogOpen);
+
   return (
-    <div className="flex h-screen flex-col bg-gray-50">
+    <div className="flex h-screen flex-col bg-surface">
       {/* Header */}
-      <header className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-3">
+      <header className="flex items-center justify-between border-b border-stroke-subtle bg-surface-secondary px-4 py-3">
         <div className="flex items-center gap-3">
           <button
             onClick={onNavigateBack}
-            className="flex items-center gap-1 rounded-md px-2 py-1 text-sm text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+            className="flex items-center gap-1 rounded-md px-2 py-1 text-sm text-content-secondary hover:bg-surface-hover hover:text-content"
             aria-label="Back to Layout Planner"
           >
             <svg
@@ -44,18 +54,29 @@ export function DesignerPage({ onNavigateBack }: DesignerPageProps) {
             </svg>
             Back
           </button>
-          <div className="h-5 w-px bg-gray-300" />
-          <h1 className="text-lg font-semibold text-gray-900">Bin Designer</h1>
-          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
+          <div className="h-5 w-px bg-stroke-subtle" />
+          <h1 className="text-lg font-semibold text-content">Bin Designer</h1>
+          <span className="rounded-full bg-accent-muted px-2 py-0.5 text-xs font-medium text-accent">
             Experimental
           </span>
         </div>
+        <button
+          onClick={() => setExportDialogOpen(true)}
+          disabled={!canExport}
+          className="flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-surface-elevated disabled:text-content-disabled"
+          aria-label="Export bin as STL"
+        >
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+          </svg>
+          Export
+        </button>
       </header>
 
       {/* Main content area */}
       <main className="flex flex-1 overflow-hidden">
         {/* Left panel: Parameter controls (hidden on mobile, shown on md+) */}
-        <div className="hidden w-80 flex-shrink-0 border-r border-gray-200 bg-white md:block">
+        <div className="hidden w-80 flex-shrink-0 overflow-hidden border-r border-stroke-subtle bg-surface-secondary md:block">
           <ParameterPanel />
         </div>
 
@@ -66,12 +87,16 @@ export function DesignerPage({ onNavigateBack }: DesignerPageProps) {
 
         {/* Mobile: Bottom parameter panel (shown on mobile, hidden on md+) */}
         <div
-          className="fixed inset-x-0 bottom-0 max-h-[70vh] overflow-y-auto border-t border-gray-200 bg-white md:hidden"
+          className="fixed inset-x-0 bottom-0 max-h-[70vh] overflow-y-auto border-t border-stroke-subtle bg-surface-secondary md:hidden"
           style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
         >
           <ParameterPanel />
         </div>
       </main>
+
+      {/* Export modal */}
+      <ExportDialog />
     </div>
   );
 }
+

--- a/src/features/bin-designer/components/ExportDialog.tsx
+++ b/src/features/bin-designer/components/ExportDialog.tsx
@@ -1,0 +1,191 @@
+/**
+ * Export dialog for the bin designer.
+ *
+ * Shows export format options, file name preview, print estimates,
+ * and a download button. Only STL is available in Alpha; others
+ * are shown as "coming soon" placeholders.
+ */
+
+import { useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+import { useExport } from '@/features/bin-designer/hooks/useExport';
+import { formatPrintTime, formatFilament } from '@/features/bin-designer/utils/printEstimates';
+import type { FileNameStyle } from '@/features/bin-designer/utils/fileNaming';
+import { generateFileName } from '@/features/bin-designer/utils/fileNaming';
+import { getSTLFileSize } from '@/features/generation/export/stlExporter';
+
+export function ExportDialog() {
+  const { exportDialogOpen, params, triangleCount } = useDesignerStore(
+    useShallow((state) => ({
+      exportDialogOpen: state.ui.exportDialogOpen,
+      params: state.params,
+      triangleCount: state.generation.mesh?.vertices
+        ? state.generation.mesh.vertices.length / 9
+        : 0,
+    }))
+  );
+  const setExportDialogOpen = useDesignerStore((s) => s.setExportDialogOpen);
+
+  const { canExport, estimates, isExporting, downloadSTL } = useExport();
+  const [nameStyle, setNameStyle] = useState<FileNameStyle>('descriptive');
+
+  if (!exportDialogOpen) return null;
+
+  const fileName = generateFileName(params, 'stl', nameStyle);
+  const fileSizeBytes = getSTLFileSize(triangleCount);
+  const fileSizeLabel = fileSizeBytes < 1024
+    ? `${fileSizeBytes} B`
+    : `${Math.round(fileSizeBytes / 1024)} KB`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) setExportDialogOpen(false);
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="export-dialog-title"
+    >
+      <div className="mx-4 w-full max-w-md rounded-xl bg-surface-elevated p-6 shadow-2xl">
+        {/* Header */}
+        <div className="mb-5 flex items-center justify-between">
+          <h2 id="export-dialog-title" className="text-lg font-semibold text-content">
+            Export Bin
+          </h2>
+          <button
+            onClick={() => setExportDialogOpen(false)}
+            className="rounded-md p-1 text-content-tertiary hover:bg-surface-hover hover:text-content-secondary"
+            aria-label="Close export dialog"
+          >
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Format Selection */}
+        <div className="mb-4">
+          <label className="mb-2 block text-sm font-medium text-content-secondary">Format</label>
+          <div className="grid grid-cols-3 gap-2">
+            <FormatOption label="STL" active description="Binary STL mesh" />
+            <FormatOption label="STEP" disabled description="Coming soon" />
+            <FormatOption label="3MF" disabled description="Coming soon" />
+          </div>
+        </div>
+
+        {/* File Name */}
+        <div className="mb-4">
+          <label className="mb-2 block text-sm font-medium text-content-secondary">File Name</label>
+          <div className="rounded-md border border-stroke-subtle bg-surface px-3 py-2">
+            <code className="break-all text-sm text-content">{fileName}</code>
+          </div>
+          <div className="mt-2 flex gap-2">
+            <NameStyleButton
+              active={nameStyle === 'descriptive'}
+              onClick={() => setNameStyle('descriptive')}
+              label="Descriptive"
+            />
+            <NameStyleButton
+              active={nameStyle === 'compact'}
+              onClick={() => setNameStyle('compact')}
+              label="Compact"
+            />
+          </div>
+        </div>
+
+        {/* Print Estimates */}
+        <div className="mb-5 rounded-lg border border-stroke-subtle bg-surface p-3">
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-content-tertiary">
+            Print Estimates (PLA)
+          </h3>
+          <div className="grid grid-cols-2 gap-y-1.5 text-sm">
+            <EstimateRow label="Filament" value={formatFilament(estimates.metersFilament)} />
+            <EstimateRow label="Weight" value={`${estimates.gramsFilament}g`} />
+            <EstimateRow label="Time" value={formatPrintTime(estimates.printTimeMinutes)} />
+            <EstimateRow label="Cost" value={`$${estimates.costUSD.toFixed(2)}`} />
+            <EstimateRow label="Triangles" value={triangleCount.toLocaleString()} />
+            <EstimateRow label="File Size" value={fileSizeLabel} />
+          </div>
+        </div>
+
+        {/* Download Button */}
+        <button
+          onClick={() => downloadSTL(nameStyle)}
+          disabled={!canExport || isExporting}
+          className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-surface-elevated disabled:text-content-disabled"
+        >
+          {isExporting ? 'Exporting…' : 'Download STL'}
+        </button>
+
+        {!canExport && (
+          <p className="mt-2 text-center text-xs text-warning">
+            Generate a mesh first to enable export
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+function FormatOption({
+  label,
+  active,
+  disabled,
+  description,
+}: {
+  label: string;
+  active?: boolean;
+  disabled?: boolean;
+  description: string;
+}) {
+  return (
+    <div
+      className={`rounded-lg border px-3 py-2 text-center ${
+        active
+          ? 'border-accent bg-accent-muted text-accent'
+          : disabled
+            ? 'cursor-not-allowed border-stroke-subtle bg-surface text-content-disabled'
+            : 'border-stroke-subtle text-content-secondary'
+      }`}
+    >
+      <div className="text-sm font-medium">{label}</div>
+      <div className="text-xs">{description}</div>
+    </div>
+  );
+}
+
+function NameStyleButton({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+        active
+          ? 'bg-accent-muted text-accent'
+          : 'bg-surface text-content-secondary hover:bg-surface-hover'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+function EstimateRow({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <span className="text-content-tertiary">{label}</span>
+      <span className="font-medium text-content">{value}</span>
+    </>
+  );
+}

--- a/src/features/bin-designer/components/parameters/BaseSection.tsx
+++ b/src/features/bin-designer/components/parameters/BaseSection.tsx
@@ -44,7 +44,7 @@ export function BaseSection() {
               onClick={() => updateBase({ style: value })}
               className={`rounded-md border px-2 py-1.5 text-left transition-colors ${
                 base.style === value
-                  ? 'border-accent bg-accent/5 text-content'
+                  ? 'border-accent bg-surface text-content ring-1 ring-accent/30'
                   : 'border-stroke-subtle bg-surface text-content-secondary hover:border-stroke hover:bg-surface-hover'
               }`}
               aria-pressed={base.style === value}

--- a/src/features/bin-designer/components/parameters/StyleSection.tsx
+++ b/src/features/bin-designer/components/parameters/StyleSection.tsx
@@ -38,7 +38,7 @@ export function StyleSection() {
           onClick={() => setParam('style', value)}
           className={`w-full rounded-md border px-3 py-2 text-left transition-colors ${
             style === value
-              ? 'border-accent bg-accent/5'
+              ? 'border-accent bg-surface ring-1 ring-accent/30'
               : 'border-stroke-subtle bg-surface hover:border-stroke hover:bg-surface-hover'
           }`}
           aria-pressed={style === value}

--- a/src/features/bin-designer/components/preview/PreviewControls.tsx
+++ b/src/features/bin-designer/components/preview/PreviewControls.tsx
@@ -33,7 +33,7 @@ export function PreviewControls({
           key={key}
           type="button"
           onClick={() => onCameraPreset(key)}
-          className="rounded bg-white/80 px-2 py-1 text-[10px] font-medium text-gray-700 shadow-sm backdrop-blur hover:bg-white"
+          className="rounded bg-surface-elevated/80 px-2 py-1 text-[10px] font-medium text-content-secondary shadow-sm backdrop-blur hover:bg-surface-elevated hover:text-content"
           title={`${label} view (${shortcut})`}
           aria-label={`${label} camera view`}
         >
@@ -41,13 +41,13 @@ export function PreviewControls({
         </button>
       ))}
 
-      <div className="my-1 h-px bg-gray-300" />
+      <div className="my-1 h-px bg-stroke-subtle" />
 
       {/* Reset view */}
       <button
         type="button"
         onClick={onResetView}
-        className="rounded bg-white/80 px-2 py-1 text-[10px] font-medium text-gray-700 shadow-sm backdrop-blur hover:bg-white"
+        className="rounded bg-surface-elevated/80 px-2 py-1 text-[10px] font-medium text-content-secondary shadow-sm backdrop-blur hover:bg-surface-elevated hover:text-content"
         title="Reset view (R)"
         aria-label="Reset camera view"
       >
@@ -61,7 +61,7 @@ export function PreviewControls({
         className={`rounded px-2 py-1 text-[10px] font-medium shadow-sm backdrop-blur ${
           wireframe
             ? 'bg-accent text-white'
-            : 'bg-white/80 text-gray-700 hover:bg-white'
+            : 'bg-surface-elevated/80 text-content-secondary hover:bg-surface-elevated hover:text-content'
         }`}
         title="Toggle wireframe (W)"
         aria-label="Toggle wireframe mode"

--- a/src/features/bin-designer/components/preview/PreviewSkeleton.tsx
+++ b/src/features/bin-designer/components/preview/PreviewSkeleton.tsx
@@ -22,20 +22,20 @@ export function PreviewSkeleton({ wasmStatus, generationStatus }: PreviewSkeleto
   const isError = wasmStatus === 'error' || generationStatus === 'error';
 
   return (
-    <div className="flex h-full w-full items-center justify-center bg-gray-100">
+    <div className="flex h-full w-full items-center justify-center bg-surface">
       <div className="text-center">
-        <div className={`mx-auto mb-3 h-16 w-16 rounded-xl ${isError ? 'bg-red-100' : 'bg-gray-200 animate-pulse'} flex items-center justify-center`}>
+        <div className={`mx-auto mb-3 h-16 w-16 rounded-xl ${isError ? 'bg-red-500/10' : 'bg-surface-elevated animate-pulse'} flex items-center justify-center`}>
           {isError ? (
             <svg className="h-8 w-8 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           ) : (
-            <svg className="h-8 w-8 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="h-8 w-8 text-content-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
             </svg>
           )}
         </div>
-        <p className={`text-sm ${isError ? 'text-red-600' : 'text-gray-500'}`}>
+        <p className={`text-sm ${isError ? 'text-red-400' : 'text-content-tertiary'}`}>
           {getMessage()}
         </p>
       </div>

--- a/src/features/bin-designer/hooks/index.ts
+++ b/src/features/bin-designer/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useDesignerKeyboard } from './useDesignerKeyboard';
 export { useDesignerRouting } from './useDesignerRouting';
+export { useExport } from './useExport';
 export { useGeneration } from './useGeneration';

--- a/src/features/bin-designer/hooks/useExport.ts
+++ b/src/features/bin-designer/hooks/useExport.ts
@@ -1,0 +1,81 @@
+/**
+ * Export hook for the bin designer.
+ *
+ * Manages the STL export lifecycle: generates blob from mesh data,
+ * triggers browser download, and computes live print estimates.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+import { exportSTL } from '@/features/generation/export/stlExporter';
+import { generateFileName } from '@/features/bin-designer/utils/fileNaming';
+import { estimatePrint } from '@/features/bin-designer/utils/printEstimates';
+import type { FileNameStyle } from '@/features/bin-designer/utils/fileNaming';
+import type { PrintEstimate } from '@/features/bin-designer/utils/printEstimates';
+
+interface UseExportReturn {
+  /** Whether an export is currently being generated */
+  readonly isExporting: boolean;
+  /** Whether mesh data is available for export */
+  readonly canExport: boolean;
+  /** Current print estimates based on params */
+  readonly estimates: PrintEstimate;
+  /** Preview of the generated file name */
+  readonly fileName: string;
+  /** Trigger STL download */
+  readonly downloadSTL: (nameStyle?: FileNameStyle) => void;
+}
+
+export function useExport(): UseExportReturn {
+  const { params, mesh } = useDesignerStore(
+    useShallow((state) => ({
+      params: state.params,
+      mesh: state.generation.mesh,
+    }))
+  );
+
+  const [isExporting, setIsExporting] = useState(false);
+
+  const canExport = mesh !== null &&
+    mesh.vertices !== null &&
+    mesh.normals !== null &&
+    mesh.error === null;
+
+  const estimates = useMemo(() => estimatePrint(params), [params]);
+
+  const fileName = useMemo(
+    () => generateFileName(params, 'stl', 'descriptive'),
+    [params]
+  );
+
+  const downloadSTL = useCallback(
+    (nameStyle: FileNameStyle = 'descriptive') => {
+      if (!canExport || !mesh?.vertices || !mesh?.normals) return;
+
+      setIsExporting(true);
+
+      let url: string | null = null;
+      let anchor: HTMLAnchorElement | null = null;
+      try {
+        const name = generateFileName(params, 'stl', nameStyle);
+        const blob = exportSTL(mesh.vertices, mesh.normals, name);
+
+        // Trigger browser download via hidden anchor
+        url = URL.createObjectURL(blob);
+        anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = name;
+        document.body.appendChild(anchor);
+        anchor.click();
+      } finally {
+        if (anchor?.parentNode) anchor.parentNode.removeChild(anchor);
+        if (url) URL.revokeObjectURL(url);
+        setIsExporting(false);
+      }
+    },
+    [canExport, mesh, params]
+  );
+
+  return { isExporting, canExport, estimates, fileName, downloadSTL };
+}

--- a/src/features/bin-designer/utils/index.ts
+++ b/src/features/bin-designer/utils/index.ts
@@ -2,5 +2,7 @@ export { validateBinParams } from './validation';
 export type { DesignerValidationError } from './validation';
 export { generateFileName } from './fileNaming';
 export type { FileNameStyle } from './fileNaming';
+export { estimatePrint, formatPrintTime, formatFilament } from './printEstimates';
+export type { PrintEstimate } from './printEstimates';
 export { getStyleConstraints, isFeatureDisabled } from './styleConstraints';
 export type { StyleConstraints, ConstrainedFeature } from './styleConstraints';

--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -1,0 +1,193 @@
+/**
+ * Print estimate calculations for the bin designer.
+ *
+ * Analytically computes material volume from bin parameters,
+ * then derives filament usage and print time estimates.
+ *
+ * Volume is computed as: outer shell + dividers + gussets (minus cavity).
+ * This avoids expensive mesh-based volume integration.
+ */
+
+import type { BinParams } from '@/features/bin-designer/types';
+import { GRIDFINITY, STYLE_WALL_THICKNESS } from '@/features/bin-designer/constants/gridfinity';
+import { getStyleConstraints } from '@/features/bin-designer/utils/styleConstraints';
+
+// ─── Material Constants ──────────────────────────────────────────────────────
+
+/** PLA density in g/cm³ */
+const PLA_DENSITY = 1.24;
+
+/** 1.75mm filament cross-section area in mm² */
+const FILAMENT_AREA_MM2 = Math.PI * (1.75 / 2) ** 2;
+
+/** Default cost per kg of filament (USD) */
+const DEFAULT_COST_PER_KG = 25;
+
+/** Print speed constants (calibrated for 0.4mm nozzle, 0.2mm layer, 15% infill) */
+const OVERHEAD_MINUTES = 16; // Bed heat, first layer
+const MINUTES_PER_METER = 3.6; // Extrusion + travel
+
+// ─── Result Type ─────────────────────────────────────────────────────────────
+
+export interface PrintEstimate {
+  /** Estimated material volume in mm³ */
+  readonly volumeMm3: number;
+  /** Estimated filament mass in grams */
+  readonly gramsFilament: number;
+  /** Estimated filament length in meters */
+  readonly metersFilament: number;
+  /** Estimated print time in minutes */
+  readonly printTimeMinutes: number;
+  /** Estimated cost in USD */
+  readonly costUSD: number;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Computes print estimates from bin parameters.
+ *
+ * @param params - Complete bin parameter set
+ * @param costPerKg - Filament cost in USD/kg (default $25)
+ * @returns Print estimates including volume, mass, filament length, time, and cost
+ */
+export function estimatePrint(
+  params: BinParams,
+  costPerKg: number = DEFAULT_COST_PER_KG
+): PrintEstimate {
+  const volumeMm3 = computeBinVolume(params);
+  const volumeCm3 = volumeMm3 / 1000; // mm³ → cm³
+  const gramsFilament = volumeCm3 * PLA_DENSITY;
+  const metersFilament = volumeMm3 / FILAMENT_AREA_MM2 / 1000; // mm³ → mm length → m
+  const printTimeMinutes = OVERHEAD_MINUTES + metersFilament * MINUTES_PER_METER;
+  const costUSD = (gramsFilament / 1000) * costPerKg; // g → kg × $/kg
+
+  return {
+    volumeMm3: Math.round(volumeMm3),
+    gramsFilament: Math.round(gramsFilament * 10) / 10,
+    metersFilament: Math.round(metersFilament * 100) / 100,
+    printTimeMinutes: Math.round(printTimeMinutes),
+    costUSD: Math.round(costUSD * 100) / 100,
+  };
+}
+
+/**
+ * Formats print time as human-readable string.
+ */
+export function formatPrintTime(minutes: number): string {
+  if (minutes < 60) return `${minutes}m`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+/**
+ * Formats filament length for display.
+ */
+export function formatFilament(meters: number): string {
+  if (meters < 1) return `${Math.round(meters * 100)}cm`;
+  return `${meters.toFixed(1)}m`;
+}
+
+// ─── Volume Calculation ──────────────────────────────────────────────────────
+
+/**
+ * Computes total material volume analytically from bin parameters.
+ *
+ * Components:
+ * 1. Outer shell (walls + bottom)
+ * 2. Divider walls
+ * 3. Corner gussets (solid/rugged styles)
+ *
+ * Scoops and label tabs are small relative to the bin volume
+ * and are included as minor additions rather than subtractions.
+ */
+function computeBinVolume(params: BinParams): number {
+  const wallThickness = STYLE_WALL_THICKNESS[params.style] ?? GRIDFINITY.WALL_THICKNESS;
+  const constraints = getStyleConstraints(params.style);
+
+  // Outer dimensions in mm
+  const outerW = params.width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+  const outerD = params.depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+  const totalH = params.height * GRIDFINITY.HEIGHT_UNIT + GRIDFINITY.BASE_HEIGHT;
+
+  // Bottom thickness
+  const bottomH = GRIDFINITY.BASE_HEIGHT + GRIDFINITY.BOTTOM_THICKNESS;
+
+  // For vase mode: thin outer shell only
+  if (params.style === 'vase') {
+    return computeHollowBoxVolume(outerW, outerD, totalH, wallThickness, bottomH);
+  }
+
+  let volume = 0;
+
+  // Shell volume (outer walls + bottom)
+  volume += computeHollowBoxVolume(outerW, outerD, totalH, wallThickness, bottomH);
+
+  // Divider volumes
+  if (!constraints.disabledFeatures.includes('dividers')) {
+    volume += computeDividerVolume(params, outerW, outerD, totalH, wallThickness, bottomH);
+  }
+
+  // Corner gussets
+  if (constraints.hasGussets) {
+    const gussetSize = wallThickness * 2;
+    const gussetHeight = totalH - bottomH;
+    // 4 triangular prisms: volume = 0.5 * size * size * height each
+    volume += 4 * 0.5 * gussetSize * gussetSize * gussetHeight;
+  }
+
+  return volume;
+}
+
+/**
+ * Volume of a hollow box (outer - inner cavity).
+ */
+function computeHollowBoxVolume(
+  w: number, d: number, h: number,
+  wall: number, bottomH: number
+): number {
+  const outerVol = w * d * h;
+  const innerW = w - 2 * wall;
+  const innerD = d - 2 * wall;
+  const innerH = h - bottomH;
+
+  if (innerW <= 0 || innerD <= 0 || innerH <= 0) {
+    return outerVol; // Solid block (walls too thick)
+  }
+
+  return outerVol - innerW * innerD * innerH;
+}
+
+/**
+ * Volume of all divider walls inside the cavity.
+ */
+function computeDividerVolume(
+  params: BinParams,
+  outerW: number, outerD: number, totalH: number,
+  wallThickness: number, bottomH: number
+): number {
+  const innerW = outerW - 2 * wallThickness;
+  const innerD = outerD - 2 * wallThickness;
+  const dividerH = totalH - bottomH;
+  const { x: divX, y: divY, thickness } = params.dividers;
+
+  let volume = 0;
+
+  // Y dividers (walls parallel to Y axis, splitting width)
+  if (divX > 0) {
+    volume += divX * thickness * innerD * dividerH;
+  }
+
+  // X dividers (walls parallel to X axis, splitting depth)
+  if (divY > 0) {
+    volume += divY * thickness * innerW * dividerH;
+  }
+
+  // Subtract double-counted intersections where X and Y dividers cross
+  if (divX > 0 && divY > 0) {
+    volume -= divX * divY * thickness * thickness * dividerH;
+  }
+
+  return volume;
+}

--- a/src/features/generation/__tests__/stlExporter.test.ts
+++ b/src/features/generation/__tests__/stlExporter.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import { exportSTL, buildSTLBuffer, getSTLFileSize } from '@/features/generation/export/stlExporter';
+
+describe('stlExporter', () => {
+  // Helper: create a simple 1-triangle mesh (3 vertices, 9 floats)
+  function createSingleTriangle() {
+    const vertices = new Float32Array([
+      0, 0, 0, // v1
+      1, 0, 0, // v2
+      0, 1, 0, // v3
+    ]);
+    const normals = new Float32Array([
+      0, 0, 1, // n1
+      0, 0, 1, // n2
+      0, 0, 1, // n3
+    ]);
+    return { vertices, normals };
+  }
+
+  // Helper: create a 2-triangle mesh
+  function createTwoTriangles() {
+    const vertices = new Float32Array([
+      0, 0, 0, 1, 0, 0, 0, 1, 0, // tri 1
+      1, 0, 0, 1, 1, 0, 0, 1, 0, // tri 2
+    ]);
+    const normals = new Float32Array([
+      0, 0, 1, 0, 0, 1, 0, 0, 1, // tri 1
+      0, 0, 1, 0, 0, 1, 0, 0, 1, // tri 2
+    ]);
+    return { vertices, normals };
+  }
+
+  describe('exportSTL', () => {
+    it('produces a Blob with correct MIME type', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const blob = exportSTL(vertices, normals, 'test');
+      expect(blob).toBeInstanceOf(Blob);
+      expect(blob.type).toBe('application/sla');
+    });
+
+    it('produces correct file size for 1 triangle', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const blob = exportSTL(vertices, normals, 'test');
+      // 80 header + 4 count + 1 * 50 = 134 bytes
+      expect(blob.size).toBe(134);
+    });
+
+    it('produces correct file size for 2 triangles', () => {
+      const { vertices, normals } = createTwoTriangles();
+      const blob = exportSTL(vertices, normals, 'test');
+      // 80 header + 4 count + 2 * 50 = 184 bytes
+      expect(blob.size).toBe(184);
+    });
+
+    it('writes correct header text', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const buffer = buildSTLBuffer(vertices, normals, 'my-bin');
+      const header = new Uint8Array(buffer, 0, 80);
+
+      // Decode ASCII header
+      const headerText = String.fromCharCode(...header).replace(/\0+$/, '');
+      expect(headerText).toContain('Gridfinity Layout Tool');
+      expect(headerText).toContain('my-bin');
+    });
+
+    it('writes correct triangle count in header', () => {
+      const { vertices, normals } = createTwoTriangles();
+      const buffer = buildSTLBuffer(vertices, normals, 'test');
+      const view = new DataView(buffer);
+
+      const count = view.getUint32(80, true); // LE at offset 80
+      expect(count).toBe(2);
+    });
+
+    it('writes correct normal vector for each triangle', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const buffer = buildSTLBuffer(vertices, normals, 'test');
+      const view = new DataView(buffer);
+
+      // Normal starts at offset 84 (80 header + 4 count)
+      const nx = view.getFloat32(84, true);
+      const ny = view.getFloat32(88, true);
+      const nz = view.getFloat32(92, true);
+
+      expect(nx).toBeCloseTo(0);
+      expect(ny).toBeCloseTo(0);
+      expect(nz).toBeCloseTo(1);
+    });
+
+    it('writes correct vertex coordinates', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const buffer = buildSTLBuffer(vertices, normals, 'test');
+      const view = new DataView(buffer);
+
+      // First vertex starts at offset 96 (84 normal + 12 bytes)
+      const v1x = view.getFloat32(96, true);
+      const v1y = view.getFloat32(100, true);
+      const v1z = view.getFloat32(104, true);
+      expect(v1x).toBeCloseTo(0);
+      expect(v1y).toBeCloseTo(0);
+      expect(v1z).toBeCloseTo(0);
+
+      // Second vertex
+      const v2x = view.getFloat32(108, true);
+      const v2y = view.getFloat32(112, true);
+      const v2z = view.getFloat32(116, true);
+      expect(v2x).toBeCloseTo(1);
+      expect(v2y).toBeCloseTo(0);
+      expect(v2z).toBeCloseTo(0);
+
+      // Third vertex
+      const v3x = view.getFloat32(120, true);
+      const v3y = view.getFloat32(124, true);
+      const v3z = view.getFloat32(128, true);
+      expect(v3x).toBeCloseTo(0);
+      expect(v3y).toBeCloseTo(1);
+      expect(v3z).toBeCloseTo(0);
+    });
+
+    it('sets attribute byte count to 0', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const buffer = buildSTLBuffer(vertices, normals, 'test');
+      const view = new DataView(buffer);
+
+      // Attribute at offset 132 (84 + 12 normal + 36 vertices)
+      const attr = view.getUint16(132, true);
+      expect(attr).toBe(0);
+    });
+
+    it('truncates long header names to 80 bytes', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const longName = 'a'.repeat(200);
+      const buffer = buildSTLBuffer(vertices, normals, longName);
+
+      // File should still have correct size
+      expect(buffer.byteLength).toBe(134);
+    });
+
+    it('throws for non-divisible-by-9 vertex count', () => {
+      const vertices = new Float32Array(10); // Not divisible by 9
+      const normals = new Float32Array(10);
+      expect(() => exportSTL(vertices, normals)).toThrow('not divisible by 9');
+    });
+
+    it('throws for mismatched normal/vertex lengths', () => {
+      const vertices = new Float32Array(9);
+      const normals = new Float32Array(18);
+      expect(() => exportSTL(vertices, normals)).toThrow('length mismatch');
+    });
+
+    it('handles empty mesh (0 triangles)', () => {
+      const vertices = new Float32Array(0);
+      const normals = new Float32Array(0);
+      const blob = exportSTL(vertices, normals, 'empty');
+      expect(blob.size).toBe(84); // 80 header + 4 count (0)
+    });
+
+    it('uses default name when none provided', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const buffer = buildSTLBuffer(vertices, normals);
+      const header = new Uint8Array(buffer, 0, 80);
+      const headerText = String.fromCharCode(...header).replace(/\0+$/, '');
+      expect(headerText).toContain('gridfinity-bin');
+    });
+  });
+
+  describe('getSTLFileSize', () => {
+    it('returns 84 for 0 triangles', () => {
+      expect(getSTLFileSize(0)).toBe(84);
+    });
+
+    it('returns 134 for 1 triangle', () => {
+      expect(getSTLFileSize(1)).toBe(134);
+    });
+
+    it('returns correct size for large mesh', () => {
+      expect(getSTLFileSize(1000)).toBe(80 + 4 + 1000 * 50);
+    });
+
+    it('matches actual blob size', () => {
+      const { vertices, normals } = createTwoTriangles();
+      const blob = exportSTL(vertices, normals, 'test');
+      expect(blob.size).toBe(getSTLFileSize(2));
+    });
+  });
+});

--- a/src/features/generation/export/index.ts
+++ b/src/features/generation/export/index.ts
@@ -1,0 +1,1 @@
+export { exportSTL, buildSTLBuffer, getSTLFileSize } from '@/features/generation/export/stlExporter';

--- a/src/features/generation/export/stlExporter.ts
+++ b/src/features/generation/export/stlExporter.ts
@@ -1,0 +1,115 @@
+/**
+ * Binary STL file exporter.
+ *
+ * Produces valid binary STL from mesh vertex/normal arrays.
+ * Binary format is preferred over ASCII for smaller file sizes (~50 bytes/tri vs ~200).
+ *
+ * Format spec:
+ *   Header:  80 bytes (any text, zero-padded)
+ *   Count:   4 bytes (uint32 LE triangle count)
+ *   Per tri: 50 bytes (normal 3×f32 + 3 vertices × 3×f32 + attr uint16)
+ */
+
+/**
+ * Generates a binary STL Blob from mesh data.
+ *
+ * @param vertices - Flat vertex array (every 9 floats = 1 triangle, 3 vertices × XYZ)
+ * @param normals - Flat normal array (matching vertices layout; uses first vertex normal per triangle)
+ * @param name - Model name for the STL header (truncated to 80 chars)
+ * @returns Binary STL as a Blob with correct MIME type
+ *
+ * @throws If vertex count is not divisible by 9 (incomplete triangles)
+ * @throws If normals length doesn't match vertices length
+ */
+export function exportSTL(
+  vertices: Float32Array,
+  normals: Float32Array,
+  name: string = 'gridfinity-bin'
+): Blob {
+  const buffer = buildSTLBuffer(vertices, normals, name);
+  return new Blob([buffer], { type: 'application/sla' });
+}
+
+/**
+ * Builds the raw binary STL ArrayBuffer.
+ * Exposed separately for direct testing without Blob API limitations.
+ */
+export function buildSTLBuffer(
+  vertices: Float32Array,
+  normals: Float32Array,
+  name: string = 'gridfinity-bin'
+): ArrayBuffer {
+  if (vertices.length % 9 !== 0) {
+    throw new Error(
+      `Invalid vertex count: ${vertices.length} is not divisible by 9`
+    );
+  }
+  if (normals.length !== vertices.length) {
+    throw new Error(
+      `Normal/vertex length mismatch: ${normals.length} vs ${vertices.length}`
+    );
+  }
+
+  const triangleCount = vertices.length / 9;
+  const HEADER_SIZE = 80;
+  const COUNT_SIZE = 4;
+  const TRIANGLE_SIZE = 50; // 12 (normal) + 36 (3 vertices) + 2 (attr)
+  const fileSize = HEADER_SIZE + COUNT_SIZE + triangleCount * TRIANGLE_SIZE;
+
+  const buffer = new ArrayBuffer(fileSize);
+  const view = new DataView(buffer);
+
+  // Write header (80 bytes, zero-padded ASCII)
+  writeHeader(view, name);
+
+  // Write triangle count (uint32 LE at offset 80)
+  view.setUint32(HEADER_SIZE, triangleCount, true);
+
+  // Write triangles
+  let offset = HEADER_SIZE + COUNT_SIZE;
+  for (let tri = 0; tri < triangleCount; tri++) {
+    const vBase = tri * 9;
+
+    // Normal (use first vertex normal of triangle — flat shading)
+    view.setFloat32(offset, normals[vBase], true);
+    view.setFloat32(offset + 4, normals[vBase + 1], true);
+    view.setFloat32(offset + 8, normals[vBase + 2], true);
+    offset += 12;
+
+    // 3 vertices (9 floats)
+    for (let v = 0; v < 3; v++) {
+      const idx = vBase + v * 3;
+      view.setFloat32(offset, vertices[idx], true);
+      view.setFloat32(offset + 4, vertices[idx + 1], true);
+      view.setFloat32(offset + 8, vertices[idx + 2], true);
+      offset += 12;
+    }
+
+    // Attribute byte count (always 0 for standard STL)
+    view.setUint16(offset, 0, true);
+    offset += 2;
+  }
+
+  return buffer;
+}
+
+/**
+ * Writes a zero-padded ASCII header into the DataView.
+ */
+function writeHeader(view: DataView, name: string): void {
+  const header = `Exported by Gridfinity Layout Tool - ${name}`;
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(header);
+
+  for (let i = 0; i < 80; i++) {
+    view.setUint8(i, i < bytes.length ? bytes[i] : 0);
+  }
+}
+
+/**
+ * Computes the file size in bytes for a given triangle count.
+ * Useful for pre-flight checks or progress reporting.
+ */
+export function getSTLFileSize(triangleCount: number): number {
+  return 80 + 4 + triangleCount * 50;
+}

--- a/src/features/generation/index.ts
+++ b/src/features/generation/index.ts
@@ -8,3 +8,4 @@ export type {
   MeshData,
   GenerationStage,
 } from './bridge';
+export { exportSTL, buildSTLBuffer, getSTLFileSize } from './export';

--- a/src/features/layout-library/hooks/useLayoutRouting.ts
+++ b/src/features/layout-library/hooks/useLayoutRouting.ts
@@ -34,7 +34,7 @@ import {
  * - Invalid/missing layout IDs show friendly error
  * - Shared preview mode skips URL updates
  */
-export function useLayoutRouting() {
+export function useLayoutRouting(options: { skip?: boolean } = {}) {
   const hasInitialized = useRef(false);
 
   const { layout, activeLayoutId, importLayout } = useLayoutStore(
@@ -125,6 +125,9 @@ export function useLayoutRouting() {
     // Skip during shared preview - keep the share URL visible
     if (sharedLayoutPreview) return;
 
+    // Skip when another route (e.g. /designer) owns the URL
+    if (options.skip) return;
+
     const urlInfo = parseLayoutFromURL();
     if (!urlInfo) {
       // No layout in URL - set URL to current active layout
@@ -188,6 +191,9 @@ export function useLayoutRouting() {
       // Don't handle during shared preview
       if (sharedLayoutPreview) return;
 
+      // Skip when another route (e.g. /designer) owns the URL
+      if (options.skip) return;
+
       // Try to get layout ID from history state first
       let layoutId = getLayoutIdFromHistoryState(event.state);
 
@@ -230,6 +236,9 @@ export function useLayoutRouting() {
 
   // Update URL when active layout changes (from UI interactions)
   useEffect(() => {
+    // Skip when another route (e.g. /designer) owns the URL
+    if (options.skip) return;
+
     // Skip during shared preview - keep the share URL visible
     if (sharedLayoutPreview) {
       return;
@@ -261,6 +270,9 @@ export function useLayoutRouting() {
 
   // Handle layout name changes (update slug in URL)
   useEffect(() => {
+    // Skip when another route (e.g. /designer) owns the URL
+    if (options.skip) return;
+
     if (sharedLayoutPreview || !activeLayoutId || activeLayoutId === '__shared_preview__') {
       return;
     }


### PR DESCRIPTION
## Summary
- Binary STL exporter with proper 80-byte header, triangle count, and per-triangle normals/vertices
- Print estimates: filament meters, weight (g), time, cost ($25/kg PLA default)
- Export dialog with format selection (STL active; STEP/3MF coming soon), file naming styles (descriptive/compact), and live print estimates
- `useExport` hook managing download lifecycle (blob creation → object URL → anchor click)
- **Fix:** `/designer` URL no longer overwritten by `useLayoutRouting` (added `skip` parameter)
- **Fix:** All designer components now use the app's dark theme semantic tokens instead of Tailwind light colors
- **Fix:** Removed duplicate old light-theme code blocks from DesignerPage, ExportDialog, PreviewControls

## Test plan
- [x] Build succeeds (`npm run build`)
- [x] All 199 bin-designer tests pass
- [x] STL exporter tests verify binary format correctness
- [x] Print estimates tests verify calculations
- [x] Export dialog tests verify UI interactions
- [x] Playwright screenshot confirms dark theme matches app
- [x] Playwright confirms `/designer` URL stays stable
- [ ] Manual: Enable bin_designer flag → navigate to /designer → adjust params → export STL → open in 3D viewer