### PR TITLE
fix(analytics): disable automatic pageview capture to fix 1000% spike

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -94,7 +94,7 @@ export function initAnalytics(): void {
       posthog.init(key, {
         api_host: '/ph',
         ui_host: 'https://us.posthog.com',
-        capture_pageview: true,
+        capture_pageview: false, // Manual pageview - auto mode fires on every replaceState
         capture_pageleave: true,
         persistence: 'localStorage',
         autocapture: false, // We'll track specific events manually
@@ -106,6 +106,9 @@ export function initAnalytics(): void {
         capture_performance: true,
       });
       posthogInstance = posthog;
+
+      // Fire a single pageview on app load
+      posthog.capture('$pageview');
 
       // Identify user with stable ID for person properties & cohorts
       const userId = getStableUserId();


### PR DESCRIPTION
PostHog's `capture_pageview: true` fires a $pageview event on every
history.pushState() and history.replaceState() call. The layout routing
system uses replaceState extensively (initial URL setup, layout switches,
slug updates, back/forward fallbacks), causing 5-10x phantom pageviews
per session while unique visitors remained flat.

Fix: disable auto-capture and fire a single manual $pageview on app load.

https://claude.ai/code/session_019cJYvUzb8bLYkdHDnVTGXx