### PR TITLE
fix(bin-designer): UX polish across form behavior, accessibility, and feedback

### DIFF
--- a/src/features/bin-designer/__tests__/components/CartDialog.test.tsx
+++ b/src/features/bin-designer/__tests__/components/CartDialog.test.tsx
@@ -42,7 +42,7 @@ describe('CartDialog', () => {
 
   it('shows empty state when no items', () => {
     render(<CartDialog open={true} onClose={onClose} />);
-    expect(screen.getByText(/no designs in cart/i)).toBeInTheDocument();
+    expect(screen.getByText(/cart is empty/i)).toBeInTheDocument();
   });
 
   it('shows item count badge', () => {

--- a/src/features/bin-designer/__tests__/components/DimensionsSection.test.tsx
+++ b/src/features/bin-designer/__tests__/components/DimensionsSection.test.tsx
@@ -64,30 +64,36 @@ describe('DimensionsSection', () => {
     expect(useDesignerStore.getState().params.width).toBe(4);
   });
 
-  it('changing the number input updates the store', () => {
+  it('changing the number input updates the store on blur', () => {
     render(<DimensionsSection />);
 
     const input = screen.getByLabelText('Width');
+    fireEvent.focus(input);
     fireEvent.change(input, { target: { value: '5' } });
+    fireEvent.blur(input);
 
     expect(useDesignerStore.getState().params.width).toBe(5);
   });
 
-  it('clamps input value to valid range', () => {
+  it('clamps input value to valid range on blur', () => {
     render(<DimensionsSection />);
 
     const input = screen.getByLabelText('Width');
+    fireEvent.focus(input);
     fireEvent.change(input, { target: { value: '10' } });
+    fireEvent.blur(input);
 
     // Max is 6
     expect(useDesignerStore.getState().params.width).toBe(6);
   });
 
-  it('snaps width to 0.5 step increments', () => {
+  it('snaps width to 0.5 step increments on blur', () => {
     render(<DimensionsSection />);
 
     const input = screen.getByLabelText('Width');
+    fireEvent.focus(input);
     fireEvent.change(input, { target: { value: '2.7' } });
+    fireEvent.blur(input);
 
     // Should snap to 2.5
     expect(useDesignerStore.getState().params.width).toBe(2.5);

--- a/src/features/bin-designer/__tests__/components/ParameterPanel.test.tsx
+++ b/src/features/bin-designer/__tests__/components/ParameterPanel.test.tsx
@@ -99,9 +99,11 @@ describe('ParameterPanel', () => {
   it('adding dividers shows thickness slider', () => {
     render(<ParameterPanel />);
 
-    // Increase dividers X
+    // Increase dividers X (commit-on-blur pattern)
     const divXInput = screen.getByLabelText('Dividers X');
+    fireEvent.focus(divXInput);
     fireEvent.change(divXInput, { target: { value: '2' } });
+    fireEvent.blur(divXInput);
 
     expect(screen.getByLabelText('Divider Thickness')).toBeInTheDocument();
   });

--- a/src/features/bin-designer/__tests__/components/PreviewCanvas.test.tsx
+++ b/src/features/bin-designer/__tests__/components/PreviewCanvas.test.tsx
@@ -135,7 +135,7 @@ describe('PreviewCanvas', () => {
     render(<PreviewCanvas />);
 
     expect(screen.getByTestId('r3f-canvas')).toBeInTheDocument();
-    expect(screen.getByText('Updating...')).toBeInTheDocument();
+    expect(screen.getByText('Updating…')).toBeInTheDocument();
   });
 
   it('does not show updating overlay when generation is complete', () => {

--- a/src/features/bin-designer/components/CartDialog.tsx
+++ b/src/features/bin-designer/components/CartDialog.tsx
@@ -138,11 +138,14 @@ export function CartDialog({ open, onClose }: CartDialogProps) {
         {/* Cart items */}
         <div className="flex-1 overflow-y-auto px-5 py-3">
           {items.length === 0 ? (
-            <div className="py-8 text-center text-sm text-content-secondary">
-              <svg className="mx-auto mb-2 h-10 w-10 text-content-tertiary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <div className="py-8 text-center">
+              <svg className="mx-auto mb-3 h-12 w-12 text-content-disabled" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
               </svg>
-              No designs in cart. Add designs from the design list.
+              <p className="text-sm font-medium text-content-secondary">Cart is empty</p>
+              <p className="mt-1 text-xs text-content-tertiary">
+                Use the &ldquo;Add to Cart&rdquo; button to queue designs for batch export.
+              </p>
             </div>
           ) : (
             <ul className="space-y-2" aria-label="Cart items">
@@ -275,11 +278,11 @@ function CartItemRow({
         </div>
       </div>
 
-      {/* Remove button */}
+      {/* Remove button — always visible on touch, hover/focus on desktop */}
       <button
         onClick={onRemove}
         disabled={disabled}
-        className="rounded p-1 text-content-tertiary opacity-0 transition-opacity hover:bg-surface-hover hover:text-content group-hover:opacity-100 disabled:opacity-50"
+        className="rounded p-1.5 text-content-tertiary transition-opacity hover:bg-surface-hover hover:text-content sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 disabled:opacity-50"
         aria-label={`Remove ${item.name} from cart`}
       >
         <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/src/features/bin-designer/components/DesignListDialog.tsx
+++ b/src/features/bin-designer/components/DesignListDialog.tsx
@@ -149,7 +149,17 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
         {/* Design list */}
         <div className="max-h-[50vh] overflow-y-auto px-5 py-3">
           {loading ? (
-            <div className="py-8 text-center text-sm text-content-secondary">Loading designs…</div>
+            <div className="space-y-2 py-2">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="flex animate-pulse items-center gap-3 rounded-lg border border-stroke-subtle px-3 py-2.5">
+                  <div className="h-10 w-10 flex-shrink-0 rounded-md bg-surface-elevated" />
+                  <div className="flex-1 space-y-1.5">
+                    <div className="h-3.5 w-24 rounded bg-surface-elevated" />
+                    <div className="h-3 w-16 rounded bg-surface-elevated" />
+                  </div>
+                </div>
+              ))}
+            </div>
           ) : designs.length === 0 ? (
             <div className="py-8 text-center">
               <p className="text-sm text-content-secondary">No saved designs yet</p>
@@ -206,8 +216,8 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
                     </p>
                   </div>
 
-                  {/* Actions */}
-                  <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                  {/* Actions — always visible on touch, hover/focus on desktop */}
+                  <div className="flex items-center gap-1 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100">
                     {design.id !== currentDesignId && (
                       <button
                         onClick={() => handleLoad(design)}

--- a/src/features/bin-designer/components/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage.tsx
@@ -9,7 +9,7 @@
  * The useGeneration hook auto-generates mesh when parameters change.
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { ParameterPanel } from '@/features/bin-designer/components/ParameterPanel';
 import { MobileParameterTabs } from '@/features/bin-designer/components/MobileParameterTabs';
 import { PreviewCanvas } from '@/features/bin-designer/components/PreviewCanvas';
@@ -26,6 +26,7 @@ import { fetchDesignerShare } from '@/features/bin-designer/hooks/useDesignerSha
 import { migrateParams } from '@/features/bin-designer/constants/defaults';
 import { useDesignerStore } from '@/features/bin-designer/store/designer';
 import { useResponsive } from '@/shared/hooks/useResponsive';
+import { useToastStore } from '@/core/store/toast';
 import { isOk } from '@/core/result';
 import type { SaveStatus } from '@/features/bin-designer/types';
 
@@ -98,11 +99,38 @@ export function DesignerPage({ onNavigateBack }: DesignerPageProps) {
   const setExportDialogOpen = useDesignerStore((s) => s.setExportDialogOpen);
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const [cartDialogOpen, setCartDialogOpen] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const mobileMenuRef = useRef<HTMLDivElement>(null);
   const cartItemCount = useCartStore((s) => s.items.length);
   const addToCart = useCartStore((s) => s.addToCart);
+  const addToast = useToastStore((s) => s.addToast);
+
+  // Close mobile menu on outside click
+  useEffect(() => {
+    if (!mobileMenuOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (mobileMenuRef.current && !mobileMenuRef.current.contains(e.target as Node)) {
+        setMobileMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [mobileMenuOpen]);
+
+  const handleAddToCart = useCallback(() => {
+    addToCart({
+      id: currentDesignId ?? `unsaved-${Date.now()}`,
+      name: designName,
+      params,
+      thumbnail: null,
+    });
+    addToast({ message: `"${designName}" added to cart`, type: 'success', duration: 2500 });
+    setMobileMenuOpen(false);
+  }, [addToCart, addToast, currentDesignId, designName, params]);
 
   // Handle ?share= URL parameter on mount
   const shareHandled = useRef(false);
+  const [shareLoading, setShareLoading] = useState(false);
   useEffect(() => {
     if (shareHandled.current) return;
     shareHandled.current = true;
@@ -116,13 +144,18 @@ export function DesignerPage({ onNavigateBack }: DesignerPageProps) {
     url.searchParams.delete('share');
     window.history.replaceState({}, '', url.pathname + url.search);
 
-    // Load shared design
+    // Load shared design with loading indicator
+    setShareLoading(true);
     void fetchDesignerShare(shareId).then((result) => {
       if (isOk(result)) {
         setParams(migrateParams(result.value));
+        addToast({ message: 'Shared design loaded', type: 'success', duration: 3000 });
+      } else {
+        addToast({ message: 'Failed to load shared design', type: 'error', duration: 5000 });
       }
+      setShareLoading(false);
     });
-  }, [setParams]);
+  }, [setParams, addToast]);
 
   return (
     <div className="flex h-screen flex-col bg-surface">
@@ -193,12 +226,7 @@ export function DesignerPage({ onNavigateBack }: DesignerPageProps) {
           </button>
           {/* Add to Cart button */}
           <button
-            onClick={() => addToCart({
-              id: currentDesignId ?? `unsaved-${Date.now()}`,
-              name: designName,
-              params,
-              thumbnail: null,
-            })}
+            onClick={handleAddToCart}
             className="hidden items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content sm:flex"
             aria-label="Add to export cart"
           >
@@ -234,8 +262,95 @@ export function DesignerPage({ onNavigateBack }: DesignerPageProps) {
             </svg>
             Export
           </button>
+
+          {/* Mobile overflow menu (visible only on small screens) */}
+          <div className="relative sm:hidden" ref={mobileMenuRef}>
+            <button
+              onClick={() => setMobileMenuOpen((v) => !v)}
+              className="flex h-9 w-9 items-center justify-center rounded-md text-content-secondary hover:bg-surface-hover hover:text-content"
+              aria-label="More actions"
+              aria-expanded={mobileMenuOpen}
+              aria-haspopup="menu"
+            >
+              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v.01M12 12v.01M12 19v.01" />
+              </svg>
+            </button>
+            {mobileMenuOpen && (
+              <div
+                className="absolute right-0 top-full z-40 mt-1 w-48 rounded-lg border border-stroke-subtle bg-surface-elevated py-1 shadow-xl"
+                role="menu"
+                aria-label="Actions"
+              >
+                <button
+                  onClick={() => { setDesignListOpen(true); setMobileMenuOpen(false); }}
+                  className="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-content hover:bg-surface-hover"
+                  role="menuitem"
+                >
+                  <svg className="h-4 w-4 text-content-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                  </svg>
+                  My Designs
+                </button>
+                <button
+                  onClick={() => { setShareDialogOpen(true); setMobileMenuOpen(false); }}
+                  className="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-content hover:bg-surface-hover"
+                  role="menuitem"
+                >
+                  <svg className="h-4 w-4 text-content-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
+                  </svg>
+                  Share
+                </button>
+                <button
+                  onClick={() => { navigateToPlaceInLayout(params.width, params.depth, params.height, designName); setMobileMenuOpen(false); }}
+                  className="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-content hover:bg-surface-hover"
+                  role="menuitem"
+                >
+                  <svg className="h-4 w-4 text-content-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
+                  </svg>
+                  Use in Layout
+                </button>
+                <div className="my-1 border-t border-stroke-subtle" />
+                <button
+                  onClick={handleAddToCart}
+                  className="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-content hover:bg-surface-hover"
+                  role="menuitem"
+                >
+                  <svg className="h-4 w-4 text-content-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                  </svg>
+                  Add to Cart
+                </button>
+                {cartItemCount > 0 && (
+                  <button
+                    onClick={() => { setCartDialogOpen(true); setMobileMenuOpen(false); }}
+                    className="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-content hover:bg-surface-hover"
+                    role="menuitem"
+                  >
+                    <svg className="h-4 w-4 text-content-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+                    </svg>
+                    View Cart ({cartItemCount})
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
         </div>
       </header>
+
+      {/* Share loading banner */}
+      {shareLoading && (
+        <div className="flex items-center justify-center gap-2 bg-accent-muted px-3 py-1.5 text-xs font-medium text-accent">
+          <svg className="h-3.5 w-3.5 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+          Loading shared design…
+        </div>
+      )}
 
       {/* Main content - responsive layout */}
       {isDesktop ? (

--- a/src/features/bin-designer/components/ExportDialog.tsx
+++ b/src/features/bin-designer/components/ExportDialog.tsx
@@ -17,6 +17,7 @@ import { generateFileName } from '@/features/bin-designer/utils/fileNaming';
 import { getSTLFileSize } from '@/features/generation/export/stlExporter';
 import { estimate3MFFileSize } from '@/features/generation/export/threemfExporter';
 import { useFocusTrap } from '@/shared/hooks/useFocusTrap';
+import { useToastStore } from '@/core/store/toast';
 
 export function ExportDialog() {
   const { exportDialogOpen, params, triangleCount } = useDesignerStore(
@@ -31,6 +32,7 @@ export function ExportDialog() {
   const setExportDialogOpen = useDesignerStore((s) => s.setExportDialogOpen);
 
   const { canExport, estimates, isExporting, downloadSTL, download3MF } = useExport();
+  const addToast = useToastStore((s) => s.addToast);
   const [nameStyle, setNameStyle] = useState<FileNameStyle>('descriptive');
   const [format, setFormat] = useState<ExportFormat>('stl');
 
@@ -125,7 +127,19 @@ export function ExportDialog() {
 
         {/* Download Button */}
         <button
-          onClick={() => format === '3mf' ? download3MF(nameStyle) : downloadSTL(nameStyle)}
+          onClick={async () => {
+            try {
+              if (format === '3mf') {
+                await download3MF(nameStyle);
+              } else {
+                downloadSTL(nameStyle);
+              }
+              addToast({ message: `${format.toUpperCase()} exported successfully`, type: 'success', duration: 3000 });
+              closeDialog();
+            } catch {
+              addToast({ message: 'Export failed — please try again', type: 'error', duration: 5000 });
+            }
+          }}
           disabled={!canExport || isExporting}
           className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-surface-elevated disabled:text-content-disabled"
         >

--- a/src/features/bin-designer/components/MobileParameterTabs.tsx
+++ b/src/features/bin-designer/components/MobileParameterTabs.tsx
@@ -5,7 +5,7 @@
  * Touch-friendly with 44px minimum tap targets.
  */
 
-import { useState, type JSX } from 'react';
+import { useState, useCallback, useRef, type JSX } from 'react';
 import {
   DimensionsSection,
   BaseSection,
@@ -74,23 +74,54 @@ const TABS: readonly TabConfig[] = [
  */
 export function MobileParameterTabs() {
   const [activeTab, setActiveTab] = useState<DesignerTab>('shape');
+  const tablistRef = useRef<HTMLDivElement>(null);
+
+  // ARIA tab pattern: arrow keys navigate between tabs
+  const handleTabKeyDown = useCallback((e: React.KeyboardEvent, currentIndex: number) => {
+    let nextIndex: number | null = null;
+
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      nextIndex = (currentIndex + 1) % TABS.length;
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      nextIndex = (currentIndex - 1 + TABS.length) % TABS.length;
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      nextIndex = 0;
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      nextIndex = TABS.length - 1;
+    }
+
+    if (nextIndex !== null) {
+      const nextTab = TABS[nextIndex];
+      setActiveTab(nextTab.id);
+      // Move focus to the newly activated tab
+      const tabEl = tablistRef.current?.querySelector<HTMLButtonElement>(`#tab-${nextTab.id}`);
+      tabEl?.focus();
+    }
+  }, []);
 
   return (
     <div className="flex h-full flex-col">
       {/* Tab bar */}
       <div
+        ref={tablistRef}
         className="flex border-b border-stroke-subtle bg-surface-secondary"
         role="tablist"
         aria-label="Parameter sections"
       >
-        {TABS.map((tab) => (
+        {TABS.map((tab, index) => (
           <button
             key={tab.id}
             id={`tab-${tab.id}`}
             role="tab"
             aria-selected={activeTab === tab.id}
             aria-controls={`panel-${tab.id}`}
+            tabIndex={activeTab === tab.id ? 0 : -1}
             onClick={() => setActiveTab(tab.id)}
+            onKeyDown={(e) => handleTabKeyDown(e, index)}
             className={`flex flex-1 flex-col items-center gap-0.5 py-2.5 text-[10px] font-medium transition-colors ${
               activeTab === tab.id
                 ? 'border-b-2 border-accent text-accent'

--- a/src/features/bin-designer/components/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas.tsx
@@ -96,6 +96,17 @@ export function PreviewCanvas() {
     setHighContrast((hc) => !hc);
   }, []);
 
+  const handleRetry = useCallback(() => {
+    if (wasmStatus === 'error') {
+      // WASM engine failed catastrophically — reload to re-initialize
+      window.location.reload();
+    } else {
+      // Generation error — re-trigger by nudging params
+      const currentParams = useDesignerStore.getState().params;
+      useDesignerStore.getState().setParams({ ...currentParams });
+    }
+  }, [wasmStatus]);
+
   const showSkeleton = !hasMesh || wasmStatus !== 'ready';
   const showOverlay = generationStatus === 'generating' && hasMesh;
 
@@ -115,7 +126,7 @@ export function PreviewCanvas() {
       </div>
 
       {showSkeleton ? (
-        <PreviewSkeleton wasmStatus={wasmStatus} generationStatus={generationStatus} />
+        <PreviewSkeleton wasmStatus={wasmStatus} generationStatus={generationStatus} onRetry={handleRetry} />
       ) : (
         <>
           <Canvas
@@ -170,9 +181,13 @@ export function PreviewCanvas() {
 
           {/* Generating overlay */}
           {showOverlay && (
-            <div className="absolute inset-0 flex items-center justify-center bg-white/30 backdrop-blur-[1px]">
-              <span className="rounded-full bg-white/90 px-3 py-1 text-xs font-medium text-gray-600 shadow-sm">
-                Updating...
+            <div className="absolute inset-0 flex items-center justify-center bg-black/5 backdrop-blur-[2px] transition-opacity">
+              <span className="flex items-center gap-2 rounded-full bg-surface-elevated/95 px-3.5 py-1.5 text-xs font-medium text-content-secondary shadow-md">
+                <svg className="h-3.5 w-3.5 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                Updating…
               </span>
             </div>
           )}

--- a/src/features/bin-designer/components/controls/SliderInput.tsx
+++ b/src/features/bin-designer/components/controls/SliderInput.tsx
@@ -1,9 +1,13 @@
 /**
  * Combined slider + number input control for the bin designer.
  * Provides both coarse (slider drag) and fine (type a value) input.
+ *
+ * The number input uses "commit-on-blur" semantics: the user can freely
+ * type without triggering intermediate state changes. The value is only
+ * committed (clamped + snapped) on blur or Enter.
  */
 
-import { useId } from 'react';
+import { useId, useState, useEffect, useCallback } from 'react';
 
 interface SliderInputProps {
   /** Display label */
@@ -39,17 +43,60 @@ export function SliderInput({
 }: SliderInputProps) {
   const id = useId();
 
+  // Local draft for the number input — allows free typing without
+  // triggering intermediate onChange calls (e.g. typing "12" won't
+  // flash through "1" first).
+  const [draft, setDraft] = useState(String(value));
+  const [isEditing, setIsEditing] = useState(false);
+
+  // Sync draft from external value changes (slider, undo, preset clicks)
+  useEffect(() => {
+    if (!isEditing) {
+      setDraft(String(value));
+    }
+  }, [value, isEditing]);
+
+  const commitValue = useCallback(() => {
+    setIsEditing(false);
+    const raw = Number(draft);
+    if (isNaN(raw) || draft.trim() === '') {
+      // Revert to current value on invalid input
+      setDraft(String(value));
+      return;
+    }
+    const clamped = Math.min(max, Math.max(min, raw));
+    const snapped = Math.round(clamped / step) * step;
+    const final = Number(snapped.toFixed(3));
+    setDraft(String(final));
+    if (final !== value) {
+      onChange(final);
+    }
+  }, [draft, value, min, max, step, onChange]);
+
   const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange(Number(e.target.value));
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const raw = Number(e.target.value);
-    if (!isNaN(raw)) {
-      const clamped = Math.min(max, Math.max(min, raw));
-      // Round to step precision
-      const snapped = Math.round(clamped / step) * step;
-      onChange(Number(snapped.toFixed(3)));
+    setDraft(e.target.value);
+  };
+
+  const handleInputFocus = () => {
+    setIsEditing(true);
+  };
+
+  const handleInputBlur = () => {
+    commitValue();
+  };
+
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      commitValue();
+      (e.target as HTMLInputElement).blur();
+    } else if (e.key === 'Escape') {
+      setIsEditing(false);
+      setDraft(String(value));
+      (e.target as HTMLInputElement).blur();
     }
   };
 
@@ -63,8 +110,11 @@ export function SliderInput({
           <input
             id={id}
             type="number"
-            value={value}
+            value={draft}
             onChange={handleInputChange}
+            onFocus={handleInputFocus}
+            onBlur={handleInputBlur}
+            onKeyDown={handleInputKeyDown}
             min={min}
             max={max}
             step={step}

--- a/src/features/bin-designer/components/preview/PreviewControls.tsx
+++ b/src/features/bin-designer/components/preview/PreviewControls.tsx
@@ -29,15 +29,18 @@ export function PreviewControls({
   onCameraPreset,
   onResetView,
 }: PreviewControlsProps) {
+  // Shared button styles — min 36px touch target (44px on touch devices via padding)
+  const baseBtn = "rounded-md bg-surface-elevated/80 px-2.5 py-1.5 text-[11px] font-medium text-content-secondary shadow-sm backdrop-blur transition-colors hover:bg-surface-elevated hover:text-content min-w-[36px] min-h-[32px] md:min-h-[28px] touch-manipulation";
+
   return (
-    <div className="absolute right-2 top-2 flex flex-col gap-1">
+    <div className="absolute right-2 top-2 flex flex-col gap-1.5">
       {/* Camera presets */}
       {PRESETS.map(({ key, label, shortcut }) => (
         <button
           key={key}
           type="button"
           onClick={() => onCameraPreset(key)}
-          className="rounded bg-surface-elevated/80 px-2 py-1 text-[10px] font-medium text-content-secondary shadow-sm backdrop-blur hover:bg-surface-elevated hover:text-content"
+          className={baseBtn}
           title={`${label} view (${shortcut})`}
           aria-label={`${label} camera view`}
         >
@@ -45,13 +48,13 @@ export function PreviewControls({
         </button>
       ))}
 
-      <div className="my-1 h-px bg-stroke-subtle" />
+      <div className="my-0.5 h-px bg-stroke-subtle/50" />
 
       {/* Reset view */}
       <button
         type="button"
         onClick={onResetView}
-        className="rounded bg-surface-elevated/80 px-2 py-1 text-[10px] font-medium text-content-secondary shadow-sm backdrop-blur hover:bg-surface-elevated hover:text-content"
+        className={baseBtn}
         title="Reset view (R)"
         aria-label="Reset camera view"
       >
@@ -62,7 +65,7 @@ export function PreviewControls({
       <button
         type="button"
         onClick={onWireframeToggle}
-        className={`rounded px-2 py-1 text-[10px] font-medium shadow-sm backdrop-blur ${
+        className={`rounded-md px-2.5 py-1.5 text-[11px] font-medium shadow-sm backdrop-blur transition-colors min-w-[36px] min-h-[32px] md:min-h-[28px] touch-manipulation ${
           wireframe
             ? 'bg-accent text-white'
             : 'bg-surface-elevated/80 text-content-secondary hover:bg-surface-elevated hover:text-content'
@@ -78,7 +81,7 @@ export function PreviewControls({
       <button
         type="button"
         onClick={onHighContrastToggle}
-        className={`rounded px-2 py-1 text-[10px] font-medium shadow-sm backdrop-blur ${
+        className={`rounded-md px-2.5 py-1.5 text-[11px] font-medium shadow-sm backdrop-blur transition-colors min-w-[36px] min-h-[32px] md:min-h-[28px] touch-manipulation ${
           highContrast
             ? 'bg-yellow-500 text-black'
             : 'bg-surface-elevated/80 text-content-secondary hover:bg-surface-elevated hover:text-content'

--- a/src/features/bin-designer/components/preview/PreviewSkeleton.tsx
+++ b/src/features/bin-designer/components/preview/PreviewSkeleton.tsx
@@ -1,6 +1,7 @@
 /**
  * Loading skeleton for the 3D preview.
  * Shows a pulsing placeholder while WASM initializes or mesh generates.
+ * Error states include a retry button to recover from transient failures.
  */
 
 import type { WasmStatus, GenerationStatus } from '@/features/bin-designer/types';
@@ -8,9 +9,10 @@ import type { WasmStatus, GenerationStatus } from '@/features/bin-designer/types
 interface PreviewSkeletonProps {
   wasmStatus: WasmStatus;
   generationStatus: GenerationStatus;
+  onRetry?: () => void;
 }
 
-export function PreviewSkeleton({ wasmStatus, generationStatus }: PreviewSkeletonProps) {
+export function PreviewSkeleton({ wasmStatus, generationStatus, onRetry }: PreviewSkeletonProps) {
   const getMessage = () => {
     if (wasmStatus === 'loading') return 'Initializing engine...';
     if (wasmStatus === 'error') return 'Engine failed to load';
@@ -19,25 +21,49 @@ export function PreviewSkeleton({ wasmStatus, generationStatus }: PreviewSkeleto
     return 'Loading preview...';
   };
 
+  const getHelpText = () => {
+    if (wasmStatus === 'error') return 'The WebAssembly engine could not be loaded. Check your connection and try again.';
+    if (generationStatus === 'error') return 'Mesh generation encountered an error. Try adjusting parameters or retry.';
+    return null;
+  };
+
   const isError = wasmStatus === 'error' || generationStatus === 'error';
+  const helpText = getHelpText();
 
   return (
     <div className="flex h-full w-full items-center justify-center bg-surface" role="status" aria-live="polite" aria-label={getMessage()}>
-      <div className="text-center">
+      <div className="text-center max-w-[240px]">
         <div className={`mx-auto mb-3 h-16 w-16 rounded-xl ${isError ? 'bg-red-500/10' : 'bg-surface-elevated animate-pulse'} flex items-center justify-center`}>
           {isError ? (
-            <svg className="h-8 w-8 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="h-8 w-8 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           ) : (
-            <svg className="h-8 w-8 text-content-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="h-8 w-8 text-content-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
             </svg>
           )}
         </div>
-        <p className={`text-sm ${isError ? 'text-red-400' : 'text-content-tertiary'}`}>
+        <p className={`text-sm font-medium ${isError ? 'text-red-400' : 'text-content-tertiary'}`}>
           {getMessage()}
         </p>
+        {helpText && (
+          <p className="mt-1 text-xs text-content-tertiary">
+            {helpText}
+          </p>
+        )}
+        {isError && onRetry && (
+          <button
+            onClick={onRetry}
+            className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-surface-elevated px-3 py-1.5 text-xs font-medium text-content-secondary shadow-sm transition-colors hover:bg-surface-hover hover:text-content"
+            aria-label="Retry loading"
+          >
+            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            Retry
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Comprehensive UX polish pass on the bin designer feature addressing 12 issues across form behavior, mobile accessibility, feedback loops, and error states.

### Form Behavior
- **SliderInput commit-on-blur**: Number inputs now commit on blur/Enter and revert on Escape, preventing intermediate value dispatches (typing "12" no longer fires onChange with "1" first)

### Mobile & Touch
- **Overflow action menu**: Mobile users can now access Share, Cart, Use in Layout, and My Designs via a 3-dot menu (previously `hidden sm:flex`)
- **Hover-only visibility fix**: Action buttons in DesignListDialog and CartDialog now visible on mobile, accessible via focus-within for keyboard
- **Touch targets**: PreviewControls increased to 36×32px with `touch-manipulation` CSS

### Accessibility
- **Tab keyboard navigation**: MobileParameterTabs supports Arrow keys and Home/End with roving tabIndex
- **Error retry**: PreviewSkeleton shows retry button with help text for WASM/generation failures

### Feedback & States
- **Cart toast**: Confirmation toast when adding items to cart
- **Export feedback**: Success/failure toast on export, auto-close dialog on success
- **Share loading**: Loading banner while shared layout resolves from URL
- **Design list skeleton**: Animated skeleton placeholders instead of plain "Loading..."
- **Generating overlay**: Improved with spinner, backdrop blur, elevated surface styling
- **Cart empty state**: Clear heading + instructional subtext hierarchy

## Test plan
- [x] All 559 bin-designer tests pass
- [x] TypeScript build clean (no type errors)
- [ ] Manual: test commit-on-blur in dimension inputs (type, blur, verify)
- [ ] Manual: resize to mobile, verify 3-dot menu shows all actions
- [ ] Manual: Tab through DesignListDialog actions with keyboard
- [ ] Manual: trigger WASM error, verify retry button works
- [ ] Manual: export STL, verify success toast appears