### PR TITLE
fix(bin-designer): feedback, accessibility, and empty states (batch 2)

### DIFF
--- a/src/features/bin-designer/__tests__/components/InsertFloorPlan.test.tsx
+++ b/src/features/bin-designer/__tests__/components/InsertFloorPlan.test.tsx
@@ -29,9 +29,11 @@ describe('InsertFloorPlan', () => {
     });
   });
 
-  it('renders nothing when no inserts exist', () => {
-    const { container } = render(<InsertFloorPlan />);
-    expect(container.querySelector('svg')).toBeNull();
+  it('shows empty state when no inserts exist', () => {
+    render(<InsertFloorPlan />);
+    expect(screen.getByText(/add a template below/i)).toBeInTheDocument();
+    // Should not render the interactive floor plan SVG
+    expect(screen.queryByRole('img', { name: /floor plan/i })).not.toBeInTheDocument();
   });
 
   it('renders SVG floor plan when inserts exist', () => {

--- a/src/features/bin-designer/components/ExportDialog.tsx
+++ b/src/features/bin-designer/components/ExportDialog.tsx
@@ -176,6 +176,7 @@ function FormatOption({
       type="button"
       onClick={disabled ? undefined : onClick}
       disabled={disabled}
+      aria-pressed={active}
       className={`rounded-lg border px-3 py-2 text-center transition-colors ${
         active
           ? 'border-accent bg-accent-muted text-accent'

--- a/src/features/bin-designer/components/ShareDialog.tsx
+++ b/src/features/bin-designer/components/ShareDialog.tsx
@@ -11,6 +11,7 @@ import { useDesignerStore } from '@/features/bin-designer/store/designer';
 import { useDesignerSharing } from '@/features/bin-designer/hooks/useDesignerSharing';
 import { migrateParams } from '@/features/bin-designer/constants/defaults';
 import { useFocusTrap } from '@/shared/hooks/useFocusTrap';
+import { useToastStore } from '@/core/store/toast';
 
 interface ShareDialogProps {
   open: boolean;
@@ -47,6 +48,8 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
     }
   }, [open, reset]);
 
+  const addToast = useToastStore((s) => s.addToast);
+
   const handleShare = useCallback(() => {
     share(params);
   }, [share, params]);
@@ -56,12 +59,13 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
     try {
       await navigator.clipboard.writeText(shareUrl);
       setCopied(true);
+      addToast({ message: 'Share link copied to clipboard', type: 'success', duration: 2000 });
       setTimeout(() => setCopied(false), 2000);
     } catch {
       // Fallback: select the input text
       inputRef.current?.select();
     }
-  }, [shareUrl]);
+  }, [shareUrl, addToast]);
 
   const handleLoad = useCallback(async () => {
     const input = loadInput.trim();
@@ -74,9 +78,10 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
     const loadedParams = await loadShared(id);
     if (loadedParams) {
       setParams(migrateParams(loadedParams));
+      addToast({ message: 'Shared design loaded', type: 'success', duration: 3000 });
       onClose();
     }
-  }, [loadInput, loadShared, setParams, onClose]);
+  }, [loadInput, loadShared, setParams, onClose, addToast]);
 
   if (!open) return null;
 

--- a/src/features/bin-designer/components/parameters/InsertFloorPlan.tsx
+++ b/src/features/bin-designer/components/parameters/InsertFloorPlan.tsx
@@ -463,7 +463,22 @@ export function InsertFloorPlan() {
     });
   }, [inserts]);
 
-  if (inserts.length === 0) return null;
+  if (inserts.length === 0) {
+    return (
+      <div className="space-y-1.5">
+        <span className="text-xs font-medium text-content-secondary">Floor Plan</span>
+        <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-stroke-subtle bg-surface-tertiary px-4 py-5">
+          <svg className="mb-1.5 h-5 w-5 text-content-tertiary" viewBox="0 0 20 20" fill="none" stroke="currentColor" aria-hidden="true">
+            <rect x="3" y="3" width="14" height="14" strokeWidth="1.5" rx="2" strokeDasharray="3 2" />
+            <path d="M10 7v6M7 10h6" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+          <p className="text-center text-[10px] text-content-tertiary">
+            Add a template below to see inserts here
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/features/bin-designer/components/parameters/PresetSelector.tsx
+++ b/src/features/bin-designer/components/parameters/PresetSelector.tsx
@@ -8,6 +8,7 @@
 
 import { useState, useCallback, type JSX } from 'react';
 import { useDesignerStore } from '@/features/bin-designer/store/designer';
+import { useToastStore } from '@/core/store/toast';
 import { BUILT_IN_PRESETS, type DesignPreset } from '@/features/bin-designer/constants/presets';
 import {
   loadUserPresets,
@@ -70,6 +71,7 @@ const USER_PRESET_ICON = (
 export function PresetSelector() {
   const setParams = useDesignerStore((s) => s.setParams);
   const params = useDesignerStore((s) => s.params);
+  const addToast = useToastStore((s) => s.addToast);
 
   const [userPresets, setUserPresets] = useState<UserPreset[]>(() => loadUserPresets());
   const [showSaveForm, setShowSaveForm] = useState(false);
@@ -82,10 +84,12 @@ export function PresetSelector() {
 
   const handleApplyBuiltIn = (preset: DesignPreset) => {
     setParams(preset.overrides);
+    addToast({ message: `Applied "${preset.name}" preset`, type: 'success', duration: 2000 });
   };
 
   const handleApplyUser = (preset: UserPreset) => {
     setParams(preset.overrides as Partial<BinParams>);
+    addToast({ message: `Applied "${preset.name}" preset`, type: 'success', duration: 2000 });
   };
 
   const handleSave = () => {
@@ -93,11 +97,15 @@ export function PresetSelector() {
     if (!trimmedName) return;
 
     const result = createUserPreset(trimmedName, presetDescription, params);
-    if (!result) return; // Limit reached
+    if (!result) {
+      addToast({ message: `Maximum ${MAX_USER_PRESETS} presets reached`, type: 'error', duration: 3000 });
+      return;
+    }
     refreshPresets();
     setShowSaveForm(false);
     setPresetName('');
     setPresetDescription('');
+    addToast({ message: `Saved "${trimmedName}" preset`, type: 'success', duration: 2000 });
   };
 
   const handleDelete = (id: string) => {
@@ -166,11 +174,13 @@ export function PresetSelector() {
                 </button>
                 <button
                   onClick={() => handleDelete(preset.id)}
-                  className="absolute -right-1 -top-1 h-4 w-4 items-center justify-center rounded-full bg-surface-error text-[10px] text-content-on-error opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100 flex"
+                  className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-surface-error text-[10px] text-content-on-error transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 sm:focus:opacity-100"
                   aria-label={`Delete ${preset.name} preset`}
                   title="Delete preset"
                 >
-                  &times;
+                  <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 12 12" aria-hidden="true">
+                    <path d="M3 3l6 6M9 3l-6 6" strokeWidth="2" strokeLinecap="round" />
+                  </svg>
                 </button>
               </div>
             ))}

--- a/src/features/bin-designer/components/parameters/TemplateBrowser.tsx
+++ b/src/features/bin-designer/components/parameters/TemplateBrowser.tsx
@@ -5,9 +5,10 @@
  * Clicking a template adds an insert at the next available position.
  */
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback, useRef } from 'react';
 import { useDesignerStore } from '@/features/bin-designer/store/designer';
 import { useShallow } from 'zustand/react/shallow';
+import { useToastStore } from '@/core/store/toast';
 import { ALL_TEMPLATES, AVAILABLE_CATEGORIES, searchTemplates } from '@/features/bin-designer/templates';
 import { GRIDFINITY, STYLE_WALL_THICKNESS } from '@/features/bin-designer/constants/gridfinity';
 import type { InsertTemplate, TemplateCategory, Insert, BinStyle } from '@/features/bin-designer/types';
@@ -74,6 +75,7 @@ function getInnerWidth(widthUnits: number, style: BinStyle): number {
 export function TemplateBrowser() {
   const [activeCategory, setActiveCategory] = useState<TemplateCategory | 'all'>('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const tablistRef = useRef<HTMLDivElement>(null);
   const { inserts, addInsert, binWidth, style } = useDesignerStore(
     useShallow((s) => ({
       inserts: s.params.inserts,
@@ -92,7 +94,9 @@ export function TemplateBrowser() {
     return searched.filter((t) => t.category === activeCategory);
   }, [searchQuery, activeCategory]);
 
-  const handleAddTemplate = (template: InsertTemplate) => {
+  const addToast = useToastStore((s) => s.addToast);
+
+  const handleAddTemplate = useCallback((template: InsertTemplate) => {
     const pos = getNextPosition(inserts, template.defaults.width, template.defaults.depth, innerWidth);
     const insert: Insert = {
       id: generateInsertId(),
@@ -108,7 +112,8 @@ export function TemplateBrowser() {
       label: template.defaults.label,
     };
     addInsert(insert);
-  };
+    addToast({ message: `Added "${template.name}" insert`, type: 'success', duration: 2000 });
+  }, [inserts, innerWidth, addInsert, addToast]);
 
   return (
     <div className="space-y-2">
@@ -136,7 +141,37 @@ export function TemplateBrowser() {
       </div>
 
       {/* Category tabs */}
-      <div className="flex gap-1" role="tablist" aria-label="Template categories">
+      <div
+        ref={tablistRef}
+        className="flex gap-1"
+        role="tablist"
+        aria-label="Template categories"
+        onKeyDown={(e) => {
+          const allCategories: (TemplateCategory | 'all')[] = ['all', ...AVAILABLE_CATEGORIES];
+          const currentIdx = allCategories.indexOf(activeCategory);
+          let nextIdx: number | null = null;
+
+          if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+            e.preventDefault();
+            nextIdx = (currentIdx + 1) % allCategories.length;
+          } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+            e.preventDefault();
+            nextIdx = (currentIdx - 1 + allCategories.length) % allCategories.length;
+          } else if (e.key === 'Home') {
+            e.preventDefault();
+            nextIdx = 0;
+          } else if (e.key === 'End') {
+            e.preventDefault();
+            nextIdx = allCategories.length - 1;
+          }
+
+          if (nextIdx !== null) {
+            setActiveCategory(allCategories[nextIdx]);
+            const buttons = tablistRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+            buttons?.[nextIdx]?.focus();
+          }
+        }}
+      >
         <CategoryTab
           label="All"
           isActive={activeCategory === 'all'}
@@ -206,6 +241,7 @@ function CategoryTab({
     <button
       role="tab"
       aria-selected={isActive}
+      tabIndex={isActive ? 0 : -1}
       onClick={onClick}
       className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
         isActive


### PR DESCRIPTION
## Summary

Second pass of UX polish on the bin designer, focusing on interaction feedback (toasts), keyboard accessibility gaps, and empty/null states.

### Feedback
- **Template insert toast**: Confirmation when a template insert is added
- **Preset toast**: Confirmation when a preset is applied, saved, or at max limit
- **Share link copy toast**: Feedback when URL is copied to clipboard
- **Share load toast**: Confirmation when a shared design is loaded

### Accessibility
- **PresetSelector delete button**: Always visible on mobile (sm:opacity-0), larger 20px tap target, SVG icon
- **TemplateBrowser tabs**: Arrow key navigation, Home/End, roving tabIndex
- **ExportDialog format options**: Added `aria-pressed` for screen reader state

### Empty States
- **InsertFloorPlan**: Shows instructional placeholder with icon when no inserts exist (previously rendered nothing)

## Test plan
- [x] All 559 bin-designer tests pass
- [x] TypeScript build clean
- [ ] Manual: add a template, verify toast appears
- [ ] Manual: apply a preset, verify toast
- [ ] Manual: navigate template category tabs with arrow keys
- [ ] Manual: view inserts section with no inserts, verify empty state