### PR TITLE
fix(bin-designer): improve ARIA attributes for toggle buttons and error displays

### DIFF
--- a/src/features/bin-designer/components/CartDialog.tsx
+++ b/src/features/bin-designer/components/CartDialog.tsx
@@ -203,7 +203,7 @@ export function CartDialog({ open, onClose }: CartDialogProps) {
 
             {/* Error */}
             {error && (
-              <div className="mb-3 rounded-md bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-900/20 dark:text-red-300">
+              <div role="alert" className="mb-3 rounded-md bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-900/20 dark:text-red-300">
                 {error}
               </div>
             )}

--- a/src/features/bin-designer/components/ExportDialog.tsx
+++ b/src/features/bin-designer/components/ExportDialog.tsx
@@ -203,6 +203,7 @@ function NameStyleButton({
   return (
     <button
       onClick={onClick}
+      aria-pressed={active}
       className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
         active
           ? 'bg-accent-muted text-accent'

--- a/src/features/bin-designer/components/ShareDialog.tsx
+++ b/src/features/bin-designer/components/ShareDialog.tsx
@@ -209,7 +209,7 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
 
           {/* Error display */}
           {status === 'error' && error && (
-            <div className="rounded-md bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-900/20 dark:text-red-300">
+            <div role="alert" className="rounded-md bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-900/20 dark:text-red-300">
               {error}
             </div>
           )}


### PR DESCRIPTION
## Summary
- Add `aria-pressed` to `NameStyleButton` in ExportDialog (matching the `FormatOption` toggle pattern)
- Add `role="alert"` to error displays in ShareDialog and CartDialog so screen readers announce errors immediately

## Context
During a systematic accessibility audit of the bin designer, found that:
1. `FormatOption` (STL/3MF/STEP selection) correctly uses `aria-pressed` but `NameStyleButton` (Descriptive/Compact) did not — same toggle pattern, inconsistent ARIA
2. Error messages in ShareDialog and CartDialog used styled `div`s without `role="alert"`, meaning screen readers wouldn't automatically announce errors when they appeared

The `PreviewSkeleton` already correctly uses `role="status"` + `aria-live="polite"` for its status region.

## Test plan
- [x] ExportDialog tests pass (12 tests)
- [x] ShareDialog tests pass (17 tests)
- [x] CartDialog tests pass (12 tests)
- [x] Build succeeds