### PR TITLE
fix(bin-designer): add ARIA progressbar to batch export progress

### DIFF
--- a/src/features/bin-designer/components/CartDialog.tsx
+++ b/src/features/bin-designer/components/CartDialog.tsx
@@ -184,7 +184,7 @@ export function CartDialog({ open, onClose }: CartDialogProps) {
             {/* Progress bar */}
             {exporting && progress && (
               <div className="mb-3 space-y-1">
-                <div className="flex justify-between text-xs text-content-secondary">
+                <div className="flex justify-between text-xs text-content-secondary" aria-live="polite">
                   <span>
                     {progress.phase === 'generating'
                       ? `Generating: ${progress.currentName}`
@@ -192,7 +192,14 @@ export function CartDialog({ open, onClose }: CartDialogProps) {
                   </span>
                   <span>{progress.current + 1}/{progress.total}</span>
                 </div>
-                <div className="h-1.5 overflow-hidden rounded-full bg-surface-secondary">
+                <div
+                  className="h-1.5 overflow-hidden rounded-full bg-surface-secondary"
+                  role="progressbar"
+                  aria-valuenow={progress.current + 1}
+                  aria-valuemin={0}
+                  aria-valuemax={progress.total}
+                  aria-label="Export progress"
+                >
                   <div
                     className="h-full rounded-full bg-blue-500 transition-all"
                     style={{ width: `${((progress.current + 1) / progress.total) * 100}%` }}


### PR DESCRIPTION
## Summary
- Add `role="progressbar"` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax` to the batch export progress bar
- Add `aria-live="polite"` to the progress status text so screen readers announce phase changes
- Add `aria-label="Export progress"` for identification

## Context
The batch export in CartDialog shows a visual progress bar during ZIP export, but screen readers couldn't convey the progress. With proper ARIA progressbar attributes, assistive technology can now announce "Export progress: 3 of 5" style updates.

## Test plan
- [x] CartDialog tests pass (12 tests)
- [x] Build succeeds
- [ ] Manual: VoiceOver/NVDA announces progress during batch export