### PR TITLE
fix(bin-designer): normalize toast API and add aria-busy to design list

### DIFF
--- a/src/features/bin-designer/components/DesignListDialog.tsx
+++ b/src/features/bin-designer/components/DesignListDialog.tsx
@@ -154,7 +154,7 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
         </div>
 
         {/* Design list */}
-        <div className="max-h-[50vh] overflow-y-auto px-5 py-3">
+        <div className="max-h-[50vh] overflow-y-auto px-5 py-3" aria-busy={loading} aria-label="Saved designs">
           {loading ? (
             <div className="space-y-2 py-2">
               {[1, 2, 3].map((i) => (

--- a/src/features/bin-designer/hooks/usePlaceBinInLayout.ts
+++ b/src/features/bin-designer/hooks/usePlaceBinInLayout.ts
@@ -93,10 +93,11 @@ export function usePlaceBinFromURL(): void {
 
         if (isOk(result)) {
           useSelectionStore.getState().setSelectedBins([result.value]);
-          addToast(
-            `Placed "${binName ?? 'custom bin'}" (${w}×${d}×${h}) — drag to reposition`,
-            'success'
-          );
+          addToast({
+            message: `Placed "${binName ?? 'custom bin'}" (${w}×${d}×${h}) — drag to reposition`,
+            type: 'success',
+            duration: 3000,
+          });
           placed = true;
         }
       }
@@ -118,10 +119,11 @@ export function usePlaceBinFromURL(): void {
 
       if (isOk(stagingResult)) {
         useSelectionStore.getState().setSelectedBins([stagingResult.value]);
-        addToast(
-          `"${binName ?? 'custom bin'}" added to staging — drag it to the grid`,
-          'info'
-        );
+        addToast({
+          message: `"${binName ?? 'custom bin'}" added to staging — drag it to the grid`,
+          type: 'info',
+          duration: 4000,
+        });
       }
     }
   }, []);


### PR DESCRIPTION
## Summary
- Convert `usePlaceBinInLayout` toast calls from legacy positional API to object API for consistency with all other bin-designer components
- Add `aria-busy={loading}` and `aria-label` to DesignListDialog's content container for screen reader loading announcements

## Details

**Toast API normalization:**
The toast store supports both positional `addToast(message, type)` and object `addToast({ message, type, duration })` APIs. All bin-designer components use the object form except `usePlaceBinInLayout.ts`. This normalizes it and adds explicit durations (3s for success, 4s for staging fallback which includes guidance text).

**aria-busy:**
When the design list dialog loads saved designs from IndexedDB, it shows skeleton loading indicators. Adding `aria-busy="true"` during this phase tells screen readers to wait for content, preventing premature announcement of empty/loading state.

## Test plan
- [x] 13 `usePlaceBinInLayout` tests pass
- [x] 12 `DesignListDialog` tests pass
- [x] Build succeeds