### PR TITLE
fix(bin-designer): respect prefers-reduced-motion for animations

### DIFF
--- a/src/features/bin-designer/components/DesignListDialog.tsx
+++ b/src/features/bin-designer/components/DesignListDialog.tsx
@@ -158,7 +158,7 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
           {loading ? (
             <div className="space-y-2 py-2">
               {[1, 2, 3].map((i) => (
-                <div key={i} className="flex animate-pulse items-center gap-3 rounded-lg border border-stroke-subtle px-3 py-2.5">
+                <div key={i} className="flex animate-pulse motion-reduce:animate-none items-center gap-3 rounded-lg border border-stroke-subtle px-3 py-2.5">
                   <div className="h-10 w-10 flex-shrink-0 rounded-md bg-surface-elevated" />
                   <div className="flex-1 space-y-1.5">
                     <div className="h-3.5 w-24 rounded bg-surface-elevated" />

--- a/src/features/bin-designer/components/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage.tsx
@@ -357,7 +357,7 @@ export function DesignerPage({ onNavigateBack }: DesignerPageProps) {
       {/* Share loading banner */}
       {shareLoading && (
         <div className="flex items-center justify-center gap-2 bg-accent-muted px-3 py-1.5 text-xs font-medium text-accent">
-          <svg className="h-3.5 w-3.5 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+          <svg className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none" fill="none" viewBox="0 0 24 24" aria-hidden="true">
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
           </svg>

--- a/src/features/bin-designer/components/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas.tsx
@@ -183,7 +183,7 @@ export function PreviewCanvas() {
           {showOverlay && (
             <div className="absolute inset-0 flex items-center justify-center bg-black/5 backdrop-blur-[2px] transition-opacity">
               <span className="flex items-center gap-2 rounded-full bg-surface-elevated/95 px-3.5 py-1.5 text-xs font-medium text-content-secondary shadow-md">
-                <svg className="h-3.5 w-3.5 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                <svg className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                 </svg>

--- a/src/features/bin-designer/components/ShareDialog.tsx
+++ b/src/features/bin-designer/components/ShareDialog.tsx
@@ -129,7 +129,7 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
 
             {status === 'sharing' && (
               <div className="flex items-center justify-center gap-2 rounded-md bg-surface-secondary py-2 text-sm text-content-secondary">
-                <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                <svg className="h-4 w-4 animate-spin motion-reduce:animate-none" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                 </svg>

--- a/src/features/bin-designer/components/preview/PreviewSkeleton.tsx
+++ b/src/features/bin-designer/components/preview/PreviewSkeleton.tsx
@@ -33,7 +33,7 @@ export function PreviewSkeleton({ wasmStatus, generationStatus, onRetry }: Previ
   return (
     <div className="flex h-full w-full items-center justify-center bg-surface" role="status" aria-live="polite" aria-label={getMessage()}>
       <div className="text-center max-w-[240px]">
-        <div className={`mx-auto mb-3 h-16 w-16 rounded-xl ${isError ? 'bg-red-500/10' : 'bg-surface-elevated animate-pulse'} flex items-center justify-center`}>
+        <div className={`mx-auto mb-3 h-16 w-16 rounded-xl ${isError ? 'bg-red-500/10' : 'bg-surface-elevated animate-pulse motion-reduce:animate-none'} flex items-center justify-center`}>
           {isError ? (
             <svg className="h-8 w-8 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />


### PR DESCRIPTION
## Summary
- Add `motion-reduce:animate-none` to all `animate-pulse` and `animate-spin` usages in the bin designer
- Users with `prefers-reduced-motion: reduce` will see static loading indicators instead of repetitive motion

## Details

WCAG 2.1 guideline [2.3.3 Animation from Interactions](https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions.html) recommends respecting the user's motion preferences. Tailwind v4 doesn't auto-disable animations for reduced-motion — the `motion-reduce:` variant must be applied explicitly.

All affected spinners are accompanied by text labels ("Updating…", "Loading shared design…", "Creating link…") so the loading state remains clear without the motion.

## Affected components
| Component | Animation | Purpose |
|-----------|-----------|---------|
| DesignListDialog | pulse | Skeleton loading |
| PreviewSkeleton | pulse | Loading placeholder |
| PreviewCanvas | spin | Generation overlay |
| ShareDialog | spin | Share creation |
| DesignerPage | spin | Share loading banner |

## Test plan
- [x] 38 affected tests pass
- [x] Build succeeds
- [x] Transitions (hover, focus) intentionally left alone — one-shot transitions don't constitute "animation from interactions"