### PR TITLE
fix(a11y): respect prefers-reduced-motion across all animations

### DIFF
--- a/src/components/Collab/CollabGhosts.tsx
+++ b/src/components/Collab/CollabGhosts.tsx
@@ -312,7 +312,7 @@ export function CollabGhosts({ className }: CollabGhostsProps) {
           aria-hidden="true"
         >
           <span
-            className="animate-pulse"
+            className="animate-pulse motion-reduce:animate-none"
             style={{
               fontSize: 18,
               color,

--- a/src/components/Collab/ConnectionIndicator.tsx
+++ b/src/components/Collab/ConnectionIndicator.tsx
@@ -66,7 +66,7 @@ export function ConnectionIndicator({
         inline-block rounded-full
         ${sizeClass}
         ${bg}
-        ${animate ? 'animate-pulse' : ''}
+        ${animate ? 'animate-pulse motion-reduce:animate-none' : ''}
         ${className}
       `.trim()}
       role="status"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -246,7 +246,7 @@ export function Header({ onHelpClick, saveStatus }: HeaderProps) {
             role="status"
           >
             <svg
-              className="w-3 h-3 animate-spin"
+              className="w-3 h-3 animate-spin motion-reduce:animate-none"
               viewBox="0 0 24 24"
               fill="none"
               aria-hidden="true"

--- a/src/components/Mobile/MobileLayoutsPanel.tsx
+++ b/src/components/Mobile/MobileLayoutsPanel.tsx
@@ -845,7 +845,7 @@ function MobileCloudSharePanel({ layoutId, onClose }: { layoutId: string; onClos
           <div className="flex items-center justify-center py-8" role="status" aria-live="polite">
             <div className="flex items-center gap-3 text-content-secondary">
               <svg
-                className="w-5 h-5 animate-spin"
+                className="w-5 h-5 animate-spin motion-reduce:animate-none"
                 viewBox="0 0 24 24"
                 fill="none"
                 aria-hidden="true"

--- a/src/components/Modals/HalfBinModeBlockedModal.tsx
+++ b/src/components/Modals/HalfBinModeBlockedModal.tsx
@@ -210,7 +210,7 @@ export function HalfBinModeBlockedModal({
             {isRemediating ? (
               <>
                 <svg
-                  className="animate-spin h-4 w-4"
+                  className="animate-spin motion-reduce:animate-none h-4 w-4"
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"
                   viewBox="0 0 24 24"

--- a/src/features/cloud-share/components/CloudShareTab.tsx
+++ b/src/features/cloud-share/components/CloudShareTab.tsx
@@ -187,7 +187,7 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
     return (
       <div className="flex items-center justify-center py-8">
         <div className="flex items-center gap-3 text-content-secondary">
-          <svg className="w-5 h-5 animate-spin" viewBox="0 0 24 24" fill="none">
+          <svg className="w-5 h-5 animate-spin motion-reduce:animate-none" viewBox="0 0 24 24" fill="none">
             <circle
               className="opacity-25"
               cx="12"

--- a/src/features/cloud-share/components/ShareButton.tsx
+++ b/src/features/cloud-share/components/ShareButton.tsx
@@ -56,7 +56,7 @@ export function ShareButton() {
       >
         {/* Loading spinner */}
         {isLoading ? (
-          <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+          <svg className="w-4 h-4 animate-spin motion-reduce:animate-none" viewBox="0 0 24 24" fill="none">
             <circle
               className="opacity-25"
               cx="12"
@@ -412,7 +412,7 @@ function SharePopover({
       {(status === 'sharing' || status === 'updating') && (
         <div className="flex items-center justify-center py-4">
           <div className="flex items-center gap-2 text-content-secondary">
-            <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+            <svg className="w-4 h-4 animate-spin motion-reduce:animate-none" viewBox="0 0 24 24" fill="none">
               <circle
                 className="opacity-25"
                 cx="12"
@@ -549,7 +549,7 @@ function SharePopover({
                     >
                       {status === 'deleting' ? (
                         <span className="flex items-center gap-2">
-                          <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
+                          <svg className="w-3 h-3 animate-spin motion-reduce:animate-none" viewBox="0 0 24 24" fill="none">
                             <circle
                               className="opacity-25"
                               cx="12"

--- a/src/features/cloud-share/components/SharedLayoutImporter.tsx
+++ b/src/features/cloud-share/components/SharedLayoutImporter.tsx
@@ -283,7 +283,7 @@ export function SharedLayoutImporter() {
     return (
       <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
         <div className="bg-surface-elevated rounded-lg p-6 flex items-center gap-3">
-          <svg className="w-5 h-5 animate-spin text-accent" viewBox="0 0 24 24" fill="none">
+          <svg className="w-5 h-5 animate-spin motion-reduce:animate-none text-accent" viewBox="0 0 24 24" fill="none">
             <circle
               className="opacity-25"
               cx="12"

--- a/src/features/grid-editor/components/Grid/DrawerResizeHandles.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerResizeHandles.tsx
@@ -35,7 +35,7 @@ export const DrawerResizeHandles = memo(function DrawerResizeHandles({
   shouldPulse,
   onResizeStart,
 }: DrawerResizeHandlesProps) {
-  const pulseClass = shouldPulse ? 'animate-pulse' : '';
+  const pulseClass = shouldPulse ? 'animate-pulse motion-reduce:animate-none' : '';
 
   return (
     <>

--- a/src/features/grid-editor/components/Grid/GridToolbar.tsx
+++ b/src/features/grid-editor/components/Grid/GridToolbar.tsx
@@ -148,7 +148,7 @@ export const GridToolbar = memo(function GridToolbar({
         {paintSize && (
           <button
             onClick={() => setPaintSize(null)}
-            className={`flex items-center gap-2 px-3 py-1.5 rounded-md bg-primary-muted border border-accent hover:bg-accent/20 transition-colors cursor-pointer ${shouldPulsePaintHint ? 'animate-pulse' : ''}`}
+            className={`flex items-center gap-2 px-3 py-1.5 rounded-md bg-primary-muted border border-accent hover:bg-accent/20 transition-colors cursor-pointer ${shouldPulsePaintHint ? 'animate-pulse motion-reduce:animate-none' : ''}`}
             aria-label="Exit paint mode"
             title="Click to exit paint mode"
           >

--- a/src/features/grid-editor/components/Grid/index.tsx
+++ b/src/features/grid-editor/components/Grid/index.tsx
@@ -241,7 +241,7 @@ export function Grid() {
                 fallback={
                   // Reserve minimum height to prevent CLS while loading
                   <div className="w-full h-full min-h-[200px] flex items-center justify-center bg-surface-secondary">
-                    <div className="animate-pulse text-content-tertiary text-sm">
+                    <div className="animate-pulse motion-reduce:animate-none text-content-tertiary text-sm">
                       Loading 3D preview...
                     </div>
                   </div>
@@ -445,7 +445,7 @@ export function Grid() {
                 fallback={
                   // Reserve full space to prevent CLS while loading
                   <div className="w-full h-full min-h-[300px] flex items-center justify-center bg-surface-secondary">
-                    <div className="animate-pulse text-content-tertiary text-sm">
+                    <div className="animate-pulse motion-reduce:animate-none text-content-tertiary text-sm">
                       Loading 3D preview...
                     </div>
                   </div>

--- a/src/features/inspiration-gallery/components/LayoutPreviewOverlay.tsx
+++ b/src/features/inspiration-gallery/components/LayoutPreviewOverlay.tsx
@@ -228,7 +228,7 @@ export function LayoutPreviewOverlay({
             >
               {isImporting ? (
                 <>
-                  <svg className="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+                  <svg className="animate-spin motion-reduce:animate-none -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
                     <circle
                       className="opacity-25"
                       cx="12"

--- a/src/features/layout-library/components/LayoutManagerModal/SharedWithMeItem.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/SharedWithMeItem.tsx
@@ -163,7 +163,7 @@ export function SharedWithMeItem({
             aria-label={isDeleted ? 'Layout has been deleted' : 'Open layout'}
           >
             {isLoading ? (
-              <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+              <svg className="w-4 h-4 animate-spin motion-reduce:animate-none" viewBox="0 0 24 24" fill="none">
                 <circle
                   className="opacity-25"
                   cx="12"

--- a/src/features/layout-library/components/LayoutManagerModal/SharedWithMeList.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/SharedWithMeList.tsx
@@ -84,7 +84,7 @@ export function SharedWithMeList({ onOpenLayout }: SharedWithMeListProps) {
     return (
       <div className="flex items-center justify-center py-12">
         <div className="flex items-center gap-2 text-content-secondary">
-          <svg className="w-5 h-5 animate-spin" viewBox="0 0 24 24" fill="none">
+          <svg className="w-5 h-5 animate-spin motion-reduce:animate-none" viewBox="0 0 24 24" fill="none">
             <circle
               className="opacity-25"
               cx="12"

--- a/src/shared/components/LoadingFallback/LoadingFallback.tsx
+++ b/src/shared/components/LoadingFallback/LoadingFallback.tsx
@@ -16,7 +16,7 @@ export function LoadingFallback({
   const spinner = (
     <div className="flex flex-col items-center gap-3" role="status" aria-label={label}>
       <svg
-        className="w-6 h-6 text-accent animate-spin"
+        className="w-6 h-6 text-accent animate-spin motion-reduce:animate-none"
         viewBox="0 0 24 24"
         fill="none"
         aria-hidden="true"


### PR DESCRIPTION
## Summary
- Add `motion-reduce:animate-none` to every `animate-spin` and `animate-pulse` usage across the entire app
- Users with `prefers-reduced-motion: reduce` will see static indicators instead of repetitive motion
- Follows the bin-designer-specific fix in PR #326, extending coverage to all features

## Background

WCAG 2.1 SC 2.3.3 (Animation from Interactions) and SC 2.2.2 (Pause, Stop, Hide) recommend giving users control over non-essential motion. The `prefers-reduced-motion` media query lets users opt out of animations OS-wide.

Tailwind v4 doesn't auto-disable animations — the `motion-reduce:animate-none` variant must be applied explicitly. All spinners are paired with text labels ("Loading...", "Creating...", etc.) so loading state remains clear without motion.

## Files changed (15)

| Feature | File | Animation |
|---------|------|-----------|
| Core | Header.tsx | spin |
| Core | LoadingFallback.tsx | spin |
| Grid Editor | Grid/index.tsx | pulse (×2) |
| Grid Editor | GridToolbar.tsx | pulse (conditional) |
| Grid Editor | DrawerResizeHandles.tsx | pulse (conditional) |
| Modals | HalfBinModeBlockedModal.tsx | spin |
| Collab | ConnectionIndicator.tsx | pulse (conditional) |
| Collab | CollabGhosts.tsx | pulse |
| Inspiration | LayoutPreviewOverlay.tsx | spin |
| Mobile | MobileLayoutsPanel.tsx | spin |
| Cloud Share | CloudShareTab.tsx | spin |
| Cloud Share | SharedLayoutImporter.tsx | spin |
| Cloud Share | ShareButton.tsx | spin (×3) |
| Layout Library | SharedWithMeItem.tsx | spin |
| Layout Library | SharedWithMeList.tsx | spin |

## Test plan
- [x] Build succeeds
- [x] All 80 affected tests pass (CloudShareTab + SharedWithMeItem use `.animate-spin` selectors)
- [x] `motion-reduce:animate-none` only adds a CSS class — doesn't affect test selectors
- [x] No remaining `animate-spin` or `animate-pulse` without `motion-reduce:` in codebase