### PR TITLE
fix(ux): help modal accessibility and remaining design tokens

### DIFF
--- a/src/components/Modals/HelpModal.tsx
+++ b/src/components/Modals/HelpModal.tsx
@@ -242,7 +242,7 @@ export function HelpModal({ isOpen, onClose, isTablet = false }: HelpModalProps)
           <div className="flex gap-1">
             <button
               onClick={() => setActiveTab('shortcuts')}
-              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent ${
                 activeTab === 'shortcuts'
                   ? 'bg-accent/20 text-accent'
                   : 'text-content-secondary hover:text-content hover:bg-surface-hover'
@@ -252,7 +252,7 @@ export function HelpModal({ isOpen, onClose, isTablet = false }: HelpModalProps)
             </button>
             <button
               onClick={() => setActiveTab('tips')}
-              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent ${
                 activeTab === 'tips'
                   ? 'bg-accent/20 text-accent'
                   : 'text-content-secondary hover:text-content hover:bg-surface-hover'
@@ -288,7 +288,8 @@ export function HelpModal({ isOpen, onClose, isTablet = false }: HelpModalProps)
                 {searchQuery && (
                   <button
                     onClick={() => setSearchQuery('')}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-content-tertiary hover:text-content"
+                    className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded text-content-tertiary hover:text-content focus-visible:ring-2 focus-visible:ring-accent"
+                    aria-label="Clear search"
                   >
                     <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path

--- a/src/features/labs/components/FeatureCard.tsx
+++ b/src/features/labs/components/FeatureCard.tsx
@@ -91,7 +91,7 @@ export function FeatureCard({ feature, isEnabled, onToggle }: FeatureCardProps) 
             />
           </button>
         ) : isGraduated ? (
-          <div className="flex items-center gap-2 text-xs text-green-400">
+          <div className="flex items-center gap-2 text-xs text-success">
             <CheckIcon className="w-4 h-4" />
             <span>Always on</span>
           </div>

--- a/src/features/labs/components/FeatureStatusBadge.tsx
+++ b/src/features/labs/components/FeatureStatusBadge.tsx
@@ -7,15 +7,15 @@ interface FeatureStatusBadgeProps {
 const STATUS_CONFIG: Record<FeatureStatus, { label: string; className: string }> = {
   experimental: {
     label: 'Experimental',
-    className: 'bg-amber-500/15 text-amber-500',
+    className: 'bg-warning-muted text-warning',
   },
   preview: {
     label: 'Preview',
-    className: 'bg-blue-500/15 text-blue-500',
+    className: 'bg-info-muted text-info',
   },
   graduated: {
     label: 'Graduated',
-    className: 'bg-green-500/15 text-green-500',
+    className: 'bg-success-muted text-success',
   },
   deprecated: {
     label: 'Deprecated',

--- a/src/features/labs/components/GraduatedSection.tsx
+++ b/src/features/labs/components/GraduatedSection.tsx
@@ -30,10 +30,10 @@ export function GraduatedSection({ features }: GraduatedSectionProps) {
               key={feature.id}
               className="flex items-start gap-2 p-3 rounded-lg bg-surface border border-stroke-subtle"
             >
-              <CheckCircleIcon className="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" />
+              <CheckCircleIcon className="w-5 h-5 text-success flex-shrink-0 mt-0.5" />
               <div>
                 <div className="text-sm font-medium text-content">{feature.name}</div>
-                <div className="text-xs text-green-400 mt-0.5">Now available to everyone!</div>
+                <div className="text-xs text-success mt-0.5">Now available to everyone!</div>
               </div>
             </div>
           ))}

--- a/src/features/layout-library/components/LayoutManagerModal/LayoutActions.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutActions.tsx
@@ -245,7 +245,7 @@ export function LayoutActions({
                       {isConfirmingDelete ? 'Click to confirm' : 'Delete'}
                     </span>
                     {isConfirmingDelete && entry.preview.binCount > 0 && (
-                      <span className="text-xs text-red-200 ml-6">
+                      <span className="text-xs text-danger/60 ml-6">
                         {entry.preview.binCount} bin{entry.preview.binCount === 1 ? '' : 's'} will
                         be deleted
                       </span>


### PR DESCRIPTION
## Summary
- Add focus-visible ring indicators to HelpModal tab buttons for keyboard navigation
- Add aria-label and focus indicator to search clear button in HelpModal
- Replace hardcoded color classes in Labs feature components with semantic design tokens:
  - FeatureStatusBadge: amber→warning, blue→info, green→success
  - GraduatedSection: green→success
  - FeatureCard: green→success
  - LayoutActions: red→danger

## Test plan
- [x] All affected tests pass (200 tests across 7 test files)
- [x] Accessibility axe tests pass
- [x] TypeScript type check passes
- [x] Production build succeeds
- [x] Pre-commit hooks pass (lint, boundaries, build, affected tests)
- [ ] Visual: verify Labs feature badges render with correct semantic colors
- [ ] Keyboard: verify HelpModal tabs show focus ring when navigated with Tab key

🤖 Generated with [Claude Code](https://claude.com/claude-code)