### PR TITLE
fix(a11y): add focus-visible rings to collapsible toggle buttons

### DIFF
--- a/src/features/staging/components/Staging.tsx
+++ b/src/features/staging/components/Staging.tsx
@@ -509,7 +509,7 @@ export function Staging() {
       <div className="flex items-center justify-between mb-2">
         <button
           type="button"
-          className="flex items-center gap-2 bg-transparent hover:opacity-80 transition-opacity"
+          className="flex items-center gap-2 bg-transparent rounded hover:opacity-80 transition-opacity focus-visible:ring-2 focus-visible:ring-accent"
           onClick={handleToggleExpand}
           aria-expanded={isExpanded}
           aria-controls="staging-stash-panel"

--- a/src/shared/components/CollapsibleSection/CollapsibleSection.tsx
+++ b/src/shared/components/CollapsibleSection/CollapsibleSection.tsx
@@ -42,7 +42,7 @@ export function CollapsibleSection({
       <div className="flex items-center justify-between">
         <button
           type="button"
-          className="flex items-center gap-2 bg-transparent hover:opacity-80 transition-opacity"
+          className="flex items-center gap-2 bg-transparent rounded hover:opacity-80 transition-opacity focus-visible:ring-2 focus-visible:ring-accent"
           onClick={() => {
             setHasToggled(true);
             setExpanded(!expanded);


### PR DESCRIPTION
## Summary
- Added `focus-visible:ring-2 focus-visible:ring-accent` and `rounded` to CollapsibleSection and Staging toggle buttons
- These buttons use `bg-transparent hover:opacity-80` pattern without the `.btn` class, so they don't get the global `:focus-visible` outline style
- Ensures keyboard users can see focus indicators on collapsible section headers

## Test plan
- [x] All 261 affected tests pass
- [x] Pre-commit hooks pass (lint, boundaries, build, coverage)
- [ ] Verify focus ring appears when tabbing to collapsible section headers
- [ ] Verify ring uses accent color from design system

🤖 Generated with [Claude Code](https://claude.com/claude-code)