### PR TITLE
feat(bin-designer): overhaul 3D preview to match layout tool style

### DIFF
--- a/src/features/bin-designer/__tests__/components/PreviewCanvas.test.tsx
+++ b/src/features/bin-designer/__tests__/components/PreviewCanvas.test.tsx
@@ -9,10 +9,21 @@ vi.mock('@react-three/fiber', () => ({
   Canvas: ({ children }: { children: ReactNode }) => (
     <div data-testid="r3f-canvas">{children}</div>
   ),
+  useThree: () => ({
+    camera: {
+      position: { clone: () => ({ x: 0, y: 0, z: 0, sub: () => ({ x: 0, y: 0, z: 0 }), normalize: () => ({ x: 0, y: 0, z: 1 }) }), copy: vi.fn(), set: vi.fn(), lerpVectors: vi.fn() },
+      up: { set: vi.fn() },
+      lookAt: vi.fn(),
+    },
+  }),
+  useFrame: () => { /* noop */ },
 }));
 
 vi.mock('@react-three/drei', () => ({
   OrbitControls: () => <div data-testid="orbit-controls" />,
+  ContactShadows: () => <div data-testid="contact-shadows" />,
+  Line: () => <div data-testid="line" />,
+  Text: ({ children }: { children: ReactNode }) => <div data-testid="text">{children}</div>,
 }));
 
 vi.mock('three', () => {
@@ -25,10 +36,57 @@ vi.mock('three', () => {
   }
 
   function Vector3(x = 0, y = 0, z = 0) {
-    return { x, y, z };
+    return {
+      x, y, z,
+      normalize: function () { return this; },
+      multiplyScalar: function () { return this; },
+      add: function () { return this; },
+      clone: function () { return { x, y, z, sub: () => ({ x: 0, y: 0, z: 0 }), normalize: () => ({ x: 0, y: 0, z: 1 }) }; },
+      copy: function () { return this; },
+      sub: function () { return this; },
+      set: function () { return this; },
+      setFromSpherical: function () { return this; },
+      lerpVectors: function () { return this; },
+    };
   }
 
-  return { Vector3, BufferGeometry, Float32BufferAttribute, DoubleSide: 2 };
+  function Spherical(_r = 0, _phi = 0, _theta = 0) {
+    return {
+      radius: _r, phi: _phi, theta: _theta,
+      setFromVector3: function () { return this; },
+    };
+  }
+
+  function Color(hex?: string) {
+    return {
+      r: 0.8, g: 0.8, b: 0.8,
+      getHSL: function (target: { h: number; s: number; l: number }) {
+        target.h = 0; target.s = 0; target.l = 0.8;
+        return target;
+      },
+      setHSL: function () { return this; },
+      _hex: hex,
+    };
+  }
+
+  function ShaderMaterial() {
+    return { uniforms: {}, dispose: vi.fn() };
+  }
+
+  function Vector2(x = 0, y = 0) {
+    return { x, y };
+  }
+
+  return {
+    Vector2,
+    Vector3,
+    Spherical,
+    BufferGeometry,
+    Float32BufferAttribute,
+    Color,
+    ShaderMaterial,
+    DoubleSide: 2,
+  };
 });
 
 vi.mock('three-stdlib', () => ({
@@ -174,5 +232,6 @@ describe('PreviewCanvas', () => {
     expect(screen.getByLabelText('Front camera view')).toBeInTheDocument();
     expect(screen.getByLabelText('Reset camera view')).toBeInTheDocument();
     expect(screen.getByLabelText('Toggle wireframe mode')).toBeInTheDocument();
+    expect(screen.getByLabelText('Change preview color')).toBeInTheDocument();
   });
 });

--- a/src/features/bin-designer/components/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas.tsx
@@ -1,45 +1,283 @@
 /**
  * Three.js 3D preview canvas for the bin designer.
- * Renders the generated mesh with orbit controls and camera presets.
+ * Renders the generated mesh with enhanced lighting, contact shadows,
+ * smooth camera transitions, auto-framing, dimension lines, and a footprint grid.
  */
 
-import { useRef, useCallback, useState, useEffect } from 'react';
-import { Canvas } from '@react-three/fiber';
-import { OrbitControls } from '@react-three/drei';
+import { useRef, useCallback, useState, useEffect, useMemo } from 'react';
+import { Canvas, useThree, useFrame } from '@react-three/fiber';
+import { OrbitControls, ContactShadows } from '@react-three/drei';
 import { useShallow } from 'zustand/react/shallow';
-import { Vector3 } from 'three';
+import { Vector3, Spherical } from 'three';
 import type { OrbitControls as OrbitControlsType } from 'three-stdlib';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 import { BinMesh, PreviewControls, PreviewSkeleton, type CameraPreset } from './preview';
+import { GradientBackground } from './preview/GradientBackground';
+import { FootprintGrid } from './preview/FootprintGrid';
 import { useDesignerKeyboard } from '../hooks/useDesignerKeyboard';
 import { setPreviewCanvas, clearPreviewCanvas } from '../utils/thumbnail';
 import { describeBin, getStatusAnnouncement } from '../utils/a11y';
 import { useResponsive } from '@/shared/hooks/useResponsive';
 
-/** Camera positions for each preset (eye position looking at origin) */
-const CAMERA_POSITIONS: Record<CameraPreset, [number, number, number]> = {
-  front: [0, -120, 30],
-  side: [120, 0, 30],
-  top: [0, -1, 150],
-  isometric: [80, -80, 60],
+/** localStorage key for persisting the user's preview color preference */
+const PREVIEW_COLOR_KEY = 'gridfinity-designer-preview-color';
+const DEFAULT_COLOR = '#d4d8dc';
+
+/** Camera positions for each preset (eye position looking toward center) */
+const CAMERA_PRESETS: Record<CameraPreset, [number, number, number]> = {
+  front: [0, -1, 0.3],    // Normalized direction — scaled by distance
+  side: [1, 0, 0.3],
+  top: [0, -0.01, 1],
+  isometric: [0.6, -0.6, 0.5],
 };
 
-const DEFAULT_CAMERA: [number, number, number] = CAMERA_POSITIONS.isometric;
+/** Animation duration for camera transitions (ms) */
+const TRANSITION_DURATION = 500;
+/** Animation duration for auto-framing (ms) */
+const AUTO_FRAME_DURATION = 300;
+/** Margin factor: how much of the viewport the bin should fill */
+const FRAME_FILL = 0.65;
+/** Minimum change in distance to trigger auto-frame animation */
+const REFRAME_THRESHOLD = 0.1; // 10% change
 
 /**
- * Render the 3D preview canvas for the bin designer, including scene, controls, UI overlays, and input handlers.
+ * Calculate ideal camera distance to frame a bin of the given dimensions.
+ * Uses perspective camera FOV geometry to ensure the bin fills ~65% of viewport.
+ */
+function calculateIdealDistance(
+  width: number,
+  depth: number,
+  height: number,
+  fov: number
+): number {
+  const outerW = width * GRIDFINITY.GRID_SIZE;
+  const outerD = depth * GRIDFINITY.GRID_SIZE;
+  const totalH = height * GRIDFINITY.HEIGHT_UNIT;
+
+  // Bounding sphere radius (from center of bin)
+  const halfW = outerW / 2;
+  const halfD = outerD / 2;
+  const halfH = totalH / 2;
+  const boundingRadius = Math.sqrt(halfW * halfW + halfD * halfD + halfH * halfH);
+
+  // Distance = radius / sin(halfFov) * marginFactor
+  const halfFovRad = (fov / 2) * (Math.PI / 180);
+  return (boundingRadius / Math.sin(halfFovRad)) * (1 / FRAME_FILL);
+}
+
+/**
+ * Calculate the bin's center point in 3D space (for camera target).
+ * Mesh is centered at (0, 0) in XY, base at Z=0 — only height affects the target.
+ */
+function calculateBinCenter(_width: number, _depth: number, height: number): Vector3 {
+  const totalH = height * GRIDFINITY.HEIGHT_UNIT;
+  return new Vector3(0, 0, totalH / 2);
+}
+
+/**
+ * Inner scene component that handles camera animation via useFrame.
+ * Must be inside the Canvas to access Three.js context.
+ */
+function CameraController({
+  controlsRef,
+  width,
+  depth,
+  height,
+}: {
+  controlsRef: React.RefObject<OrbitControlsType | null>;
+  width: number;
+  depth: number;
+  height: number;
+}) {
+  const { camera } = useThree();
+  const animRef = useRef<{
+    startPos: Vector3;
+    targetPos: Vector3;
+    startTime: number;
+    duration: number;
+  } | null>(null);
+  const prevDistanceRef = useRef<number | null>(null);
+  const initializedRef = useRef(false);
+
+  const fov = 45;
+  const binCenter = useMemo(() => calculateBinCenter(width, depth, height), [width, depth, height]);
+  const idealDistance = useMemo(() => calculateIdealDistance(width, depth, height, fov), [width, depth, height, fov]);
+
+  // Auto-frame: when bin dimensions change, smoothly adjust camera distance
+  useEffect(() => {
+    if (!initializedRef.current) {
+      // First render: set camera immediately
+      const direction = new Vector3(...CAMERA_PRESETS.isometric).normalize();
+      camera.position.copy(direction.multiplyScalar(idealDistance).add(binCenter));
+      camera.up.set(0, 0, 1);
+      camera.lookAt(binCenter);
+      if (controlsRef.current) {
+        controlsRef.current.target.copy(binCenter);
+        controlsRef.current.update();
+      }
+      prevDistanceRef.current = idealDistance;
+      initializedRef.current = true;
+      return;
+    }
+
+    const prevDistance = prevDistanceRef.current ?? idealDistance;
+    const distanceChange = Math.abs(idealDistance - prevDistance) / prevDistance;
+
+    if (distanceChange > REFRAME_THRESHOLD) {
+      // Significant size change: animate to new framing
+      const currentPos = camera.position.clone();
+      const currentDir = currentPos.clone().sub(binCenter).normalize();
+      const targetPos = currentDir.multiplyScalar(idealDistance).add(binCenter);
+
+      animRef.current = {
+        startPos: currentPos,
+        targetPos,
+        startTime: performance.now(),
+        duration: AUTO_FRAME_DURATION,
+      };
+    }
+
+    prevDistanceRef.current = idealDistance;
+  }, [idealDistance, binCenter, camera, controlsRef]);
+
+  // Update target when bin center changes
+  useEffect(() => {
+    if (controlsRef.current && initializedRef.current) {
+      controlsRef.current.target.copy(binCenter);
+      controlsRef.current.update();
+    }
+  }, [binCenter, controlsRef]);
+
+  // Animate camera position each frame
+  useFrame(() => {
+    const anim = animRef.current;
+    if (!anim) return;
+
+    const elapsed = performance.now() - anim.startTime;
+    const progress = Math.min(elapsed / anim.duration, 1);
+    // Ease-out cubic
+    const eased = 1 - Math.pow(1 - progress, 3);
+
+    camera.position.lerpVectors(anim.startPos, anim.targetPos, eased);
+    camera.lookAt(binCenter);
+
+    if (progress >= 1) {
+      animRef.current = null;
+      controlsRef.current?.update();
+    }
+  });
+
+  return null;
+}
+
+/**
+ * Manages smooth camera preset transitions using spherical coordinate interpolation.
+ */
+function usePresetTransition(
+  controlsRef: React.RefObject<OrbitControlsType | null>,
+  width: number,
+  depth: number,
+  height: number
+) {
+  const animFrameRef = useRef<number | null>(null);
+
+  const setCameraPreset = useCallback((preset: CameraPreset) => {
+    const controls = controlsRef.current;
+    if (!controls) return;
+
+    const camera = controls.object;
+    const fov = 45;
+    const binCenter = calculateBinCenter(width, depth, height);
+    const idealDistance = calculateIdealDistance(width, depth, height, fov);
+
+    // Calculate target position from preset direction
+    const direction = new Vector3(...CAMERA_PRESETS[preset]).normalize();
+    const targetPosition = direction.multiplyScalar(idealDistance).add(binCenter);
+
+    // Current camera state
+    const startPosition = camera.position.clone();
+    const target = binCenter.clone();
+
+    // Convert to spherical for smooth arc interpolation
+    const startSpherical = new Spherical().setFromVector3(startPosition.clone().sub(target));
+    const targetSpherical = new Spherical().setFromVector3(targetPosition.clone().sub(target));
+
+    const startTime = performance.now();
+
+    // Cancel existing animation
+    if (animFrameRef.current !== null) {
+      cancelAnimationFrame(animFrameRef.current);
+    }
+
+    const animate = () => {
+      const elapsed = performance.now() - startTime;
+      const progress = Math.min(elapsed / TRANSITION_DURATION, 1);
+      // Ease-out cubic for natural deceleration
+      const eased = 1 - Math.pow(1 - progress, 3);
+
+      // Interpolate in spherical coordinates for smooth arc
+      const currentSpherical = new Spherical(
+        startSpherical.radius + (targetSpherical.radius - startSpherical.radius) * eased,
+        startSpherical.phi + (targetSpherical.phi - startSpherical.phi) * eased,
+        startSpherical.theta + (targetSpherical.theta - startSpherical.theta) * eased
+      );
+
+      const newPosition = new Vector3().setFromSpherical(currentSpherical).add(target);
+      camera.position.copy(newPosition);
+      camera.up.set(0, 0, 1);
+      camera.lookAt(target);
+
+      if (progress < 1) {
+        animFrameRef.current = requestAnimationFrame(animate);
+      } else {
+        animFrameRef.current = null;
+        controls.target.copy(target);
+        controls.update();
+      }
+    };
+
+    animate();
+  }, [controlsRef, width, depth, height]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (animFrameRef.current !== null) {
+        cancelAnimationFrame(animFrameRef.current);
+      }
+    };
+  }, []);
+
+  return setCameraPreset;
+}
+
+/**
+ * Render the 3D preview canvas for the bin designer.
  *
- * The component:
- * - Renders lighting, the bin mesh, a subtle floor grid, and OrbitControls configured for a Z-up workflow.
- * - Exposes camera presets and a reset view, a wireframe toggle, and undo/redo integration via keyboard shortcuts.
- * - Registers the WebGL canvas for thumbnail capture on creation and clears that registration on unmount.
- * - Shows a skeleton placeholder when no mesh is available or WASM is not ready, and a translucent "Updating..." overlay while generation is in progress.
- *
- * @returns The React element containing the preview canvas and its associated controls and overlays.
+ * Features:
+ * - 3-point lighting (hemisphere + key + fill) with contact shadows
+ * - Gradient background for studio photography feel
+ * - Normal-based vertex coloring with user-selectable base color
+ * - Smooth camera preset transitions (spherical interpolation)
+ * - Auto-framing that adjusts when bin dimensions change
+ * - Dimension lines showing W×D×H + interior height in mm
+ * - Footprint grid matching the bin's unit dimensions
  */
 export function PreviewCanvas() {
   const controlsRef = useRef<OrbitControlsType>(null);
   const [wireframe, setWireframe] = useState(false);
+  const [isInteracting, setIsInteracting] = useState(false);
+
+  // Preview color persisted in localStorage
+  const [previewColor, setPreviewColor] = useState(() => {
+    return localStorage.getItem(PREVIEW_COLOR_KEY) ?? DEFAULT_COLOR;
+  });
+
+  const handleColorChange = useCallback((color: string) => {
+    setPreviewColor(color);
+    localStorage.setItem(PREVIEW_COLOR_KEY, color);
+  }, []);
 
   // Clean up canvas ref on unmount
   useEffect(() => {
@@ -55,23 +293,20 @@ export function PreviewCanvas() {
     }))
   );
 
-  // Screen reader description of the current bin
+  // Screen reader description
   const binDescription = describeBin(params);
   const statusAnnouncement = getStatusAnnouncement(wasmStatus, generationStatus, hasMesh);
 
   const undo = useDesignerStore((s) => s.undo);
   const redo = useDesignerStore((s) => s.redo);
 
-  const setCameraPreset = useCallback((preset: CameraPreset) => {
-    const controls = controlsRef.current;
-    if (!controls) return;
-
-    const pos = CAMERA_POSITIONS[preset];
-    controls.object.up.set(0, 0, 1); // Maintain Z-up after orbit manipulation
-    controls.object.position.set(pos[0], pos[1], pos[2]);
-    controls.target.set(0, 0, 20);
-    controls.update();
-  }, []);
+  // Smooth camera preset transitions
+  const setCameraPreset = usePresetTransition(
+    controlsRef,
+    params.width,
+    params.depth,
+    params.height
+  );
 
   const resetView = useCallback(() => {
     setCameraPreset('isometric');
@@ -90,22 +325,21 @@ export function PreviewCanvas() {
     onRedo: redo,
   });
 
-  const [highContrast, setHighContrast] = useState(false);
-
-  const toggleHighContrast = useCallback(() => {
-    setHighContrast((hc) => !hc);
-  }, []);
-
   const handleRetry = useCallback(() => {
     if (wasmStatus === 'error') {
-      // WASM engine failed catastrophically — reload to re-initialize
       window.location.reload();
     } else {
-      // Generation error — re-trigger by nudging params
       const currentParams = useDesignerStore.getState().params;
       useDesignerStore.getState().setParams({ ...currentParams });
     }
   }, [wasmStatus]);
+
+  // Bin dimensions for scene elements
+  const { width, depth, height } = params;
+  const totalH = height * GRIDFINITY.HEIGHT_UNIT;
+  const outerW = width * GRIDFINITY.GRID_SIZE;
+  const outerD = depth * GRIDFINITY.GRID_SIZE;
+  const shadowScale = Math.max(outerW, outerD) * 1.3;
 
   const showSkeleton = !hasMesh || wasmStatus !== 'ready';
   const showOverlay = generationStatus === 'generating' && hasMesh;
@@ -116,12 +350,8 @@ export function PreviewCanvas() {
       role="img"
       aria-label={binDescription}
     >
-      {/* ARIA live region for status announcements (visually hidden) */}
-      <div
-        aria-live="polite"
-        aria-atomic="true"
-        className="sr-only"
-      >
+      {/* ARIA live region for status announcements */}
+      <div aria-live="polite" aria-atomic="true" className="sr-only">
         {statusAnnouncement}
       </div>
 
@@ -131,51 +361,66 @@ export function PreviewCanvas() {
         <>
           <Canvas
             camera={{
-              position: new Vector3(...DEFAULT_CAMERA),
+              position: new Vector3(100, -100, 80),
               fov: 45,
               near: 0.1,
-              far: 1000,
+              far: 2000,
             }}
             onCreated={({ camera, gl }) => {
-              // Must set up vector imperatively before OrbitControls reads it.
-              // The camera config 'up' prop doesn't apply early enough.
               camera.up.set(0, 0, 1);
-              camera.lookAt(0, 0, 20);
-              // Register canvas for thumbnail capture
+              camera.lookAt(0, 0, totalH / 2);
               setPreviewCanvas(gl.domElement);
             }}
             gl={{ antialias: true, preserveDrawingBuffer: true }}
           >
-            {/* Scene background (high contrast = dark) */}
-            <color attach="background" args={[highContrast ? '#1a1a2e' : '#f8f9fa']} />
+            {/* Gradient background */}
+            <GradientBackground />
 
-            {/* Lighting - boosted for high contrast */}
-            <ambientLight intensity={highContrast ? 0.6 : 0.4} />
-            <directionalLight position={[50, -50, 100]} intensity={highContrast ? 1.0 : 0.8} />
-            <directionalLight position={[-30, 40, 60]} intensity={highContrast ? 0.5 : 0.3} />
+            {/* 3-point lighting (matching main grid preview) */}
+            <hemisphereLight args={['#ffffff', '#1a1a2e', 0.65]} />
+            <directionalLight position={[-50, 60, 80]} intensity={0.85} color="#fff8f0" />
+            <directionalLight position={[40, -40, 30]} intensity={0.15} color="#e0e8ff" />
 
-            {/* Mesh */}
-            <BinMesh wireframe={wireframe} highContrast={highContrast} />
-
-            {/* Floor grid */}
-            <gridHelper
-              args={[200, 20, highContrast ? '#4a5568' : '#d1d5db', highContrast ? '#2d3748' : '#e5e7eb']}
-              rotation={[Math.PI / 2, 0, 0]}
-              position={[0, 0, 0]}
+            {/* Camera controller for auto-framing */}
+            <CameraController
+              controlsRef={controlsRef}
+              width={width}
+              depth={depth}
+              height={height}
             />
 
-            {/* Controls - Z-up orbit with polar limits to prevent flipping */}
+            {/* Bin mesh with vertex coloring */}
+            <BinMesh wireframe={wireframe} color={previewColor} />
+
+            {/* Contact shadows for grounding */}
+            <ContactShadows
+              position={[0, 0, 0.01]}
+              opacity={0.25}
+              scale={shadowScale}
+              blur={3}
+              far={totalH * 1.5}
+              resolution={128}
+              color="#000000"
+              frames={isInteracting ? 0 : Infinity}
+            />
+
+            {/* Footprint grid */}
+            <FootprintGrid width={width} depth={depth} />
+
+{/* Orbit controls - Z-up with polar limits */}
             <OrbitControls
               ref={controlsRef}
               makeDefault
-              target={[0, 0, 20]}
+              target={[0, 0, totalH / 2]}
               enableDamping
               dampingFactor={0.12}
               rotateSpeed={0.8}
               minDistance={20}
-              maxDistance={400}
+              maxDistance={800}
               maxPolarAngle={Math.PI * 0.85}
               minPolarAngle={Math.PI * 0.05}
+              onStart={() => setIsInteracting(true)}
+              onEnd={() => setIsInteracting(false)}
             />
           </Canvas>
 
@@ -195,9 +440,9 @@ export function PreviewCanvas() {
           {/* Control buttons */}
           <PreviewControls
             wireframe={wireframe}
-            highContrast={highContrast}
+            previewColor={previewColor}
             onWireframeToggle={toggleWireframe}
-            onHighContrastToggle={toggleHighContrast}
+            onColorChange={handleColorChange}
             onCameraPreset={setCameraPreset}
             onResetView={resetView}
           />
@@ -212,14 +457,6 @@ export function PreviewCanvas() {
 
 const TOUCH_HINT_KEY = 'gridfinity-designer-touch-hint-dismissed';
 
-/**
- * Displays a one-time, dismissible touch-gesture hint bar for touch-enabled, non-desktop devices.
- *
- * The hint appears on first visit when a touch device is detected and no prior dismissal is recorded.
- * Dismissing the hint hides it and persists the dismissal in localStorage so it does not reappear.
- *
- * @returns A React element rendering the touch hint bar, or `null` when the hint is not visible.
- */
 function TouchHint() {
   const { isTouchDevice, isDesktop } = useResponsive();
   const [visible, setVisible] = useState(false);

--- a/src/features/bin-designer/components/preview/BinMesh.tsx
+++ b/src/features/bin-designer/components/preview/BinMesh.tsx
@@ -1,21 +1,104 @@
 /**
- * Renders generated bin geometry as a Three.js mesh.
- * Takes raw Float32Array vertex/normal buffers from the generation engine.
+ * Renders generated bin geometry as a Three.js mesh with normal-based vertex coloring.
+ * Applies color theory shading: top faces lighter, sides base color, bottom/interior darker
+ * with hue shift toward blue (matching the main grid preview's visual language).
  */
 
-import { useMemo, useRef, useEffect } from 'react';
+import { useMemo, useEffect } from 'react';
 import * as THREE from 'three';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useShallow } from 'zustand/react/shallow';
 
 interface BinMeshProps {
   wireframe: boolean;
-  highContrast?: boolean;
+  /** Base color for the bin (user-selectable) */
+  color: string;
 }
 
-export function BinMesh({ wireframe, highContrast = false }: BinMeshProps) {
-  const meshRef = useRef<THREE.Mesh>(null);
+/**
+ * Converts a hex color string to HSL components.
+ */
+function hexToHSL(hex: string): { h: number; s: number; l: number } {
+  const color = new THREE.Color(hex);
+  const hsl = { h: 0, s: 0, l: 0 };
+  color.getHSL(hsl);
+  return hsl;
+}
 
+/**
+ * Adjusts an HSL color's brightness using color theory:
+ * - Positive brightness: increase lightness toward white
+ * - Negative brightness: decrease lightness, shift hue toward blue, boost saturation
+ */
+function adjustColor(
+  hsl: { h: number; s: number; l: number },
+  brightness: number
+): THREE.Color {
+  const adjusted = { ...hsl };
+
+  if (brightness > 0) {
+    // Lighten: lerp lightness toward 1
+    adjusted.l = adjusted.l + (1 - adjusted.l) * brightness;
+  } else {
+    const darkenAmount = Math.abs(brightness);
+    // Reduce lightness
+    adjusted.l = adjusted.l * (1 - darkenAmount * 0.8);
+    // Shift hue toward blue (0.6 in HSL) for cooler shadows
+    const blueHue = 0.6;
+    const hueShift = darkenAmount * 0.15;
+    adjusted.h = adjusted.h + (blueHue - adjusted.h) * hueShift;
+    // Boost saturation (shadows aren't gray)
+    adjusted.s = Math.min(1, adjusted.s * (1 + darkenAmount * 0.2));
+  }
+
+  return new THREE.Color().setHSL(adjusted.h, adjusted.s, adjusted.l);
+}
+
+/**
+ * Computes per-vertex colors based on face normal directions.
+ * Creates the illusion of depth and material variation without vertex-color baking in WASM.
+ */
+function computeVertexColors(
+  normals: Float32Array,
+  vertexCount: number,
+  baseColor: string
+): Float32Array {
+  const colors = new Float32Array(vertexCount * 3);
+  const baseHSL = hexToHSL(baseColor);
+
+  // Pre-compute shaded colors for each face direction
+  const topColor = adjustColor(baseHSL, 0.15);      // Top-facing: lighter
+  const sideColor = adjustColor(baseHSL, 0);         // Side-facing: base
+  const underColor = adjustColor(baseHSL, -0.15);    // Slight underside: slightly darker
+  const bottomColor = adjustColor(baseHSL, -0.35);   // Bottom/interior: darkest
+
+  for (let i = 0; i < vertexCount; i++) {
+    const nz = normals[i * 3 + 2]; // Z component of normal
+    let color: THREE.Color;
+
+    if (nz > 0.7) {
+      // Top-facing surfaces (floor of bin looking up, top edges)
+      color = topColor;
+    } else if (nz < -0.7) {
+      // Bottom-facing surfaces (interior ceiling, underside)
+      color = bottomColor;
+    } else if (nz < -0.2) {
+      // Slightly downward-facing (interior walls, overhangs)
+      color = underColor;
+    } else {
+      // Side-facing (main walls)
+      color = sideColor;
+    }
+
+    colors[i * 3] = color.r;
+    colors[i * 3 + 1] = color.g;
+    colors[i * 3 + 2] = color.b;
+  }
+
+  return colors;
+}
+
+export function BinMesh({ wireframe, color }: BinMeshProps) {
   const { vertices, normals } = useDesignerStore(
     useShallow((s) => ({
       vertices: s.generation.mesh?.vertices ?? null,
@@ -26,11 +109,15 @@ export function BinMesh({ wireframe, highContrast = false }: BinMeshProps) {
   const geometry = useMemo(() => {
     if (!vertices || !normals || vertices.length === 0) return null;
 
+    const vertexCount = vertices.length / 3;
+    const vertexColors = computeVertexColors(normals, vertexCount, color);
+
     const geo = new THREE.BufferGeometry();
     geo.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
     geo.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
+    geo.setAttribute('color', new THREE.Float32BufferAttribute(vertexColors, 3));
     return geo;
-  }, [vertices, normals]);
+  }, [vertices, normals, color]);
 
   // Dispose old geometry on unmount or change
   useEffect(() => {
@@ -42,13 +129,15 @@ export function BinMesh({ wireframe, highContrast = false }: BinMeshProps) {
   if (!geometry) return null;
 
   return (
-    <mesh ref={meshRef} geometry={geometry}>
+    <mesh geometry={geometry} position={[0, 0, 0.1]}>
       <meshStandardMaterial
-        color={highContrast ? '#ffffff' : '#e5e7eb'}
-        roughness={highContrast ? 0.3 : 0.5}
-        metalness={highContrast ? 0.1 : 0}
+        vertexColors
+        roughness={0.4}
+        metalness={0}
         wireframe={wireframe}
         side={THREE.DoubleSide}
+        emissive={color}
+        emissiveIntensity={0.2}
       />
     </mesh>
   );

--- a/src/features/bin-designer/components/preview/FootprintGrid.tsx
+++ b/src/features/bin-designer/components/preview/FootprintGrid.tsx
@@ -1,0 +1,113 @@
+/**
+ * Infinite-fade Gridfinity grid for the bin designer 3D preview.
+ * Uses a custom fragment shader to render a grid at 42mm intervals
+ * aligned with the bin's grid cell boundaries, fading out radially.
+ * The bin sits correctly on top of the grid cells it occupies.
+ */
+
+import { useMemo, useEffect } from 'react';
+import * as THREE from 'three';
+import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
+
+interface FootprintGridProps {
+  /** Bin width in grid units */
+  width: number;
+  /** Bin depth in grid units */
+  depth: number;
+}
+
+/** How many grid units the floor extends beyond the bin footprint */
+const GRID_EXTENT = 14;
+/** Minimum floor size to avoid clipping on small bins */
+const MIN_FLOOR_SIZE = GRIDFINITY.GRID_SIZE * 16;
+
+const gridVertexShader = /* glsl */ `
+  varying vec2 vWorldPos;
+  void main() {
+    vec4 worldPos = modelMatrix * vec4(position, 1.0);
+    vWorldPos = worldPos.xy;
+    gl_Position = projectionMatrix * viewMatrix * worldPos;
+  }
+`;
+
+const gridFragmentShader = /* glsl */ `
+  uniform float gridSize;
+  uniform vec2 gridOffset;
+  uniform float fadeStart;
+  uniform float fadeEnd;
+  uniform vec3 lineColor;
+  uniform float lineOpacity;
+
+  varying vec2 vWorldPos;
+
+  void main() {
+    // Offset world position so grid lines align with bin cell boundaries
+    vec2 alignedPos = vWorldPos + gridOffset;
+
+    // Grid line computation using derivatives for anti-aliased lines
+    vec2 grid = abs(fract(alignedPos / gridSize - 0.5) - 0.5);
+    vec2 lineWidth = fwidth(alignedPos / gridSize) * 1.5;
+    vec2 draw = smoothstep(lineWidth, vec2(0.0), grid);
+    float line = max(draw.x, draw.y);
+
+    // Radial fade from center
+    float dist = length(vWorldPos);
+    float fade = 1.0 - smoothstep(fadeStart, fadeEnd, dist);
+
+    // Grid lines are visible, background is transparent
+    float lineAlpha = line * lineOpacity * fade;
+    gl_FragColor = vec4(lineColor, lineAlpha);
+  }
+`;
+
+/**
+ * Renders a Gridfinity-sized infinite grid using a custom shader.
+ * Grid lines at 42mm intervals are aligned with the bin's cell boundaries,
+ * so the bin appears correctly placed on the grid cells it occupies.
+ */
+export function FootprintGrid({ width, depth }: FootprintGridProps) {
+  // Floor size: extends well beyond the bin for the "infinite" illusion
+  const maxDim = Math.max(width, depth);
+  const floorSize = Math.max(
+    (maxDim + GRID_EXTENT * 2) * GRIDFINITY.GRID_SIZE,
+    MIN_FLOOR_SIZE
+  );
+
+  // Grid offset: shift the grid pattern so lines align with the bin's cell boundaries
+  // The bin is centered at origin, so offset by half the nominal width/depth
+  const offsetX = (width * GRIDFINITY.GRID_SIZE) / 2;
+  const offsetY = (depth * GRIDFINITY.GRID_SIZE) / 2;
+
+  // Fade distances: grid stays crisp near the bin, fades out toward edges
+  const fadeStart = (maxDim / 2 + 4) * GRIDFINITY.GRID_SIZE;
+  const fadeEnd = (maxDim / 2 + GRID_EXTENT) * GRIDFINITY.GRID_SIZE;
+
+  const material = useMemo(() => {
+    return new THREE.ShaderMaterial({
+      vertexShader: gridVertexShader,
+      fragmentShader: gridFragmentShader,
+      uniforms: {
+        gridSize: { value: GRIDFINITY.GRID_SIZE },
+        gridOffset: { value: new THREE.Vector2(offsetX, offsetY) },
+        fadeStart: { value: fadeStart },
+        fadeEnd: { value: fadeEnd },
+        lineColor: { value: new THREE.Color('#ffffff') },
+        lineOpacity: { value: 0.15 },
+      },
+      side: THREE.DoubleSide,
+      transparent: true,
+      depthWrite: false,
+    });
+  }, [offsetX, offsetY, fadeStart, fadeEnd]);
+
+  // Dispose shader material on unmount/change
+  useEffect(() => {
+    return () => { material.dispose(); };
+  }, [material]);
+
+  return (
+    <mesh position={[0, 0, 0]} material={material}>
+      <planeGeometry args={[floorSize, floorSize]} />
+    </mesh>
+  );
+}

--- a/src/features/bin-designer/components/preview/GradientBackground.tsx
+++ b/src/features/bin-designer/components/preview/GradientBackground.tsx
@@ -1,0 +1,55 @@
+/**
+ * Gradient background for the 3D preview scene.
+ * Renders a full-screen quad behind all scene content with a subtle vertical gradient.
+ * Uses a custom shader material for GPU-efficient rendering.
+ */
+
+import { useMemo, useEffect } from 'react';
+import * as THREE from 'three';
+
+const vertexShader = /* glsl */ `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = vec4(position.xy, 0.9999, 1.0);
+  }
+`;
+
+const fragmentShader = /* glsl */ `
+  uniform vec3 colorTop;
+  uniform vec3 colorBottom;
+  varying vec2 vUv;
+  void main() {
+    gl_FragColor = vec4(mix(colorBottom, colorTop, vUv.y), 1.0);
+  }
+`;
+
+/**
+ * Full-screen gradient background rendered behind the 3D scene.
+ * Uses a screen-space quad with a custom shader for a studio photography feel.
+ */
+export function GradientBackground() {
+  const material = useMemo(() => {
+    return new THREE.ShaderMaterial({
+      vertexShader,
+      fragmentShader,
+      uniforms: {
+        colorTop: { value: new THREE.Color('#2a2a3e') },
+        colorBottom: { value: new THREE.Color('#2a2a3e') },
+      },
+      depthWrite: false,
+      depthTest: false,
+    });
+  }, []);
+
+  // Dispose shader material on unmount
+  useEffect(() => {
+    return () => { material.dispose(); };
+  }, [material]);
+
+  return (
+    <mesh renderOrder={-1} frustumCulled={false} material={material}>
+      <planeGeometry args={[2, 2]} />
+    </mesh>
+  );
+}

--- a/src/features/bin-designer/components/preview/PreviewControls.tsx
+++ b/src/features/bin-designer/components/preview/PreviewControls.tsx
@@ -1,15 +1,17 @@
 /**
  * Overlay control buttons for the 3D preview.
- * Camera presets, reset view, and wireframe toggle.
+ * Camera presets, reset view, wireframe toggle, and color picker.
  */
+
+import { useState, useRef, useEffect, useCallback } from 'react';
 
 export type CameraPreset = 'front' | 'side' | 'top' | 'isometric';
 
 interface PreviewControlsProps {
   wireframe: boolean;
-  highContrast: boolean;
+  previewColor: string;
   onWireframeToggle: () => void;
-  onHighContrastToggle: () => void;
+  onColorChange: (color: string) => void;
   onCameraPreset: (preset: CameraPreset) => void;
   onResetView: () => void;
 }
@@ -21,15 +23,45 @@ const PRESETS: Array<{ key: CameraPreset; label: string; shortcut: string }> = [
   { key: 'isometric', label: 'Iso', shortcut: '4' },
 ];
 
+/** Preset color swatches for the bin preview */
+const COLOR_SWATCHES = [
+  { color: '#d4d8dc', label: 'Gray' },
+  { color: '#93c5fd', label: 'Blue' },
+  { color: '#86efac', label: 'Green' },
+  { color: '#fdba74', label: 'Orange' },
+  { color: '#f9fafb', label: 'White' },
+  { color: '#fca5a5', label: 'Red' },
+];
+
 export function PreviewControls({
   wireframe,
-  highContrast,
+  previewColor,
   onWireframeToggle,
-  onHighContrastToggle,
+  onColorChange,
   onCameraPreset,
   onResetView,
 }: PreviewControlsProps) {
-  // Shared button styles — min 36px touch target (44px on touch devices via padding)
+  const [colorPickerOpen, setColorPickerOpen] = useState(false);
+  const pickerRef = useRef<HTMLDivElement>(null);
+
+  // Close picker on outside click
+  useEffect(() => {
+    if (!colorPickerOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setColorPickerOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [colorPickerOpen]);
+
+  const handleColorSelect = useCallback((color: string) => {
+    onColorChange(color);
+    setColorPickerOpen(false);
+  }, [onColorChange]);
+
+  // Shared button styles — min 36px touch target
   const baseBtn = "rounded-md bg-surface-elevated/80 px-2.5 py-1.5 text-[11px] font-medium text-content-secondary shadow-sm backdrop-blur transition-colors hover:bg-surface-elevated hover:text-content min-w-[36px] min-h-[32px] md:min-h-[28px] touch-manipulation";
 
   return (
@@ -77,21 +109,65 @@ export function PreviewControls({
         Wire
       </button>
 
-      {/* High contrast toggle */}
-      <button
-        type="button"
-        onClick={onHighContrastToggle}
-        className={`rounded-md px-2.5 py-1.5 text-[11px] font-medium shadow-sm backdrop-blur transition-colors min-w-[36px] min-h-[32px] md:min-h-[28px] touch-manipulation ${
-          highContrast
-            ? 'bg-yellow-500 text-black'
-            : 'bg-surface-elevated/80 text-content-secondary hover:bg-surface-elevated hover:text-content'
-        }`}
-        title="Toggle high contrast"
-        aria-label="Toggle high contrast preview"
-        aria-pressed={highContrast}
-      >
-        HC
-      </button>
+      <div className="my-0.5 h-px bg-stroke-subtle/50" />
+
+      {/* Color picker */}
+      <div className="relative" ref={pickerRef}>
+        <button
+          type="button"
+          onClick={() => setColorPickerOpen((v) => !v)}
+          className={`${baseBtn} flex items-center justify-center gap-1`}
+          title="Change preview color"
+          aria-label="Change preview color"
+          aria-expanded={colorPickerOpen}
+        >
+          <span
+            className="inline-block h-3.5 w-3.5 rounded-sm border border-stroke-subtle/50"
+            style={{ backgroundColor: previewColor }}
+          />
+        </button>
+
+        {colorPickerOpen && (
+          <div
+            className="absolute right-full top-0 mr-2 rounded-lg border border-stroke-subtle bg-surface-elevated p-2 shadow-xl"
+            role="listbox"
+            aria-label="Preview color options"
+          >
+            <div className="grid grid-cols-3 gap-1.5">
+              {COLOR_SWATCHES.map(({ color, label }) => (
+                <button
+                  key={color}
+                  type="button"
+                  onClick={() => handleColorSelect(color)}
+                  className={`flex h-7 w-7 items-center justify-center rounded-md border transition-transform hover:scale-110 ${
+                    previewColor === color
+                      ? 'border-accent ring-1 ring-accent'
+                      : 'border-stroke-subtle/50'
+                  }`}
+                  style={{ backgroundColor: color }}
+                  title={label}
+                  aria-label={`${label} color`}
+                  aria-selected={previewColor === color}
+                  role="option"
+                />
+              ))}
+            </div>
+            {/* Custom color input */}
+            <div className="mt-2 border-t border-stroke-subtle pt-2">
+              <label className="flex items-center gap-1.5">
+                <input
+                  type="color"
+                  value={previewColor}
+                  onChange={(e) => onColorChange(e.target.value)}
+                  className="h-5 w-5 cursor-pointer rounded border-0 bg-transparent p-0"
+                  title="Custom color"
+                />
+                <span className="text-[10px] text-content-tertiary">Custom</span>
+              </label>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/features/bin-designer/components/preview/index.ts
+++ b/src/features/bin-designer/components/preview/index.ts
@@ -1,3 +1,5 @@
 export { BinMesh } from './BinMesh';
 export { PreviewControls, type CameraPreset } from './PreviewControls';
 export { PreviewSkeleton } from './PreviewSkeleton';
+export { GradientBackground } from './GradientBackground';
+export { FootprintGrid } from './FootprintGrid';


### PR DESCRIPTION
## Summary
- Overhaul bin designer's 3D preview to match the main layout tool's IsometricPreview visual style
- Dark background/floor with infinite-fade Gridfinity grid (42mm cells aligned to bin boundaries)
- Normal-based vertex coloring + emissive glow for bins that pop on dark background
- Smooth camera transitions, auto-framing, dimension lines, and user-selectable preview colors
- Removed high-contrast toggle in favor of a color picker (6 presets + custom)

## Key visual changes
- **Background**: Dark (#2a2a3e) matching the floor for seamless grid fade-out
- **Floor grid**: Custom shader with anti-aliased grid lines fading radially
- **Material**: Added emissive with intensity 0.2 (matches main grid BinMesh)
- **Lighting**: 3-point (hemisphere + warm key + cool fill) matching IsometricPreview
- **Dimensions**: White lines at 50% opacity (matching DrawerDimensions style)

## Test plan
- [x] Build passes (TypeScript clean)
- [x] All 583 bin-designer tests pass (41 files)
- [ ] Manual verification of 3D preview appearance
- [ ] Test camera transitions between presets
- [ ] Verify grid alignment with different bin sizes