### PR TITLE
feat(bin-designer): add configurable wall/magnet/screw parameters

### DIFF
--- a/src/features/bin-designer/__tests__/components/ParameterPanel.test.tsx
+++ b/src/features/bin-designer/__tests__/components/ParameterPanel.test.tsx
@@ -16,6 +16,7 @@ describe('ParameterPanel', () => {
 
     expect(screen.getByText('Dimensions')).toBeInTheDocument();
     expect(screen.getByText('Base')).toBeInTheDocument();
+    expect(screen.getByText('Walls')).toBeInTheDocument();
   });
 
   it('renders dimension sliders', () => {
@@ -96,5 +97,150 @@ describe('ParameterPanel', () => {
     expect(heightSlider).toHaveAttribute('min', '2');
     expect(heightSlider).toHaveAttribute('max', '20');
     expect(heightSlider).toHaveAttribute('step', '1');
+  });
+
+  describe('conditional magnet/screw sliders', () => {
+    it('does not show magnet sliders when magnet is off', () => {
+      render(<ParameterPanel />);
+
+      expect(screen.queryByLabelText('Magnet radius')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Magnet height')).not.toBeInTheDocument();
+    });
+
+    it('shows magnet sliders when magnet is toggled on', () => {
+      render(<ParameterPanel />);
+
+      const magnetToggle = screen.getByText('Magnet holes').closest('label')!.querySelector('button')!;
+      fireEvent.click(magnetToggle);
+
+      expect(screen.getByLabelText('Magnet radius')).toBeInTheDocument();
+      expect(screen.getByLabelText('Magnet height')).toBeInTheDocument();
+    });
+
+    it('does not show screw slider when screw is off', () => {
+      render(<ParameterPanel />);
+
+      expect(screen.queryByLabelText('Screw radius')).not.toBeInTheDocument();
+    });
+
+    it('shows screw slider when screw is toggled on', () => {
+      render(<ParameterPanel />);
+
+      const screwToggle = screen.getByText('Screw holes').closest('label')!.querySelector('button')!;
+      fireEvent.click(screwToggle);
+
+      expect(screen.getByLabelText('Screw radius')).toBeInTheDocument();
+    });
+
+    it('magnet radius slider updates magnetDiameter (radius × 2)', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet' },
+        },
+      });
+
+      render(<ParameterPanel />);
+
+      const radiusSlider = screen.getByLabelText('Magnet radius slider');
+      fireEvent.change(radiusSlider, { target: { value: '4.0' } });
+
+      expect(useDesignerStore.getState().params.base.magnetDiameter).toBe(8.0);
+    });
+
+    it('magnet height slider updates magnetDepth', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet' },
+        },
+      });
+
+      render(<ParameterPanel />);
+
+      const heightSlider = screen.getByLabelText('Magnet height slider');
+      fireEvent.change(heightSlider, { target: { value: '3.0' } });
+
+      expect(useDesignerStore.getState().params.base.magnetDepth).toBe(3.0);
+    });
+
+    it('screw radius slider updates screwDiameter (radius × 2)', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          base: { ...DEFAULT_BIN_PARAMS.base, style: 'screw' },
+        },
+      });
+
+      render(<ParameterPanel />);
+
+      const radiusSlider = screen.getByLabelText('Screw radius slider');
+      fireEvent.change(radiusSlider, { target: { value: '2.0' } });
+
+      expect(useDesignerStore.getState().params.base.screwDiameter).toBe(4.0);
+    });
+  });
+
+  describe('keepFull toggle and wall thickness', () => {
+    it('renders keepFull toggle', () => {
+      render(<ParameterPanel />);
+
+      expect(screen.getByText('Keep full (solid)')).toBeInTheDocument();
+    });
+
+    it('shows wall thickness slider when keepFull is off (default)', () => {
+      render(<ParameterPanel />);
+
+      expect(screen.getByLabelText('Wall thickness')).toBeInTheDocument();
+    });
+
+    it('hides wall thickness slider when keepFull is toggled on', () => {
+      render(<ParameterPanel />);
+
+      const keepFullToggle = screen
+        .getByText('Keep full (solid)')
+        .closest('label')!
+        .querySelector('button')!;
+      fireEvent.click(keepFullToggle);
+
+      expect(screen.queryByLabelText('Wall thickness')).not.toBeInTheDocument();
+    });
+
+    it('toggling keepFull sets style to solid', () => {
+      render(<ParameterPanel />);
+
+      const keepFullToggle = screen
+        .getByText('Keep full (solid)')
+        .closest('label')!
+        .querySelector('button')!;
+      fireEvent.click(keepFullToggle);
+
+      expect(useDesignerStore.getState().params.style).toBe('solid');
+    });
+
+    it('toggling keepFull off sets style back to standard', () => {
+      useDesignerStore.setState({
+        params: { ...DEFAULT_BIN_PARAMS, style: 'solid' },
+      });
+
+      render(<ParameterPanel />);
+
+      const keepFullToggle = screen
+        .getByText('Keep full (solid)')
+        .closest('label')!
+        .querySelector('button')!;
+      fireEvent.click(keepFullToggle);
+
+      expect(useDesignerStore.getState().params.style).toBe('standard');
+    });
+
+    it('wall thickness slider respects constraints', () => {
+      render(<ParameterPanel />);
+
+      const wallSlider = screen.getByLabelText('Wall thickness slider');
+      expect(wallSlider).toHaveAttribute('min', '0.8');
+      expect(wallSlider).toHaveAttribute('max', '2.4');
+      expect(wallSlider).toHaveAttribute('step', '0.1');
+    });
   });
 });

--- a/src/features/bin-designer/components/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel.tsx
@@ -1,7 +1,7 @@
 /**
- * Simplified parameter panel for replicad-based bin generation.
- * Contains dimension sliders (width, depth, height) and base feature toggles
- * (magnet holes, screw holes, stacking lip).
+ * Parameter panel for replicad-based bin generation.
+ * Contains dimension sliders, base feature toggles with conditional
+ * sub-parameter sliders, and wall/style options.
  */
 
 import { useCallback } from 'react';
@@ -9,7 +9,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { GRIDFINITY, DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
 import { SliderInput } from './controls/SliderInput';
-import type { BaseConfig, BaseStyle } from '@/features/bin-designer/types';
+import type { BaseConfig, BaseStyle, BinStyle } from '@/features/bin-designer/types';
 
 /** Derive base style from individual magnet/screw booleans */
 function computeBaseStyle(magnet: boolean, screw: boolean): BaseStyle {
@@ -20,18 +20,21 @@ function computeBaseStyle(magnet: boolean, screw: boolean): BaseStyle {
 }
 
 export function ParameterPanel() {
-  const { width, depth, height, base, setParam } = useDesignerStore(
+  const { width, depth, height, wallThickness, base, style, setParam } = useDesignerStore(
     useShallow((s) => ({
       width: s.params.width,
       depth: s.params.depth,
       height: s.params.height,
+      wallThickness: s.params.wallThickness,
       base: s.params.base,
+      style: s.params.style,
       setParam: s.setParam,
     }))
   );
 
   const hasMagnet = base.style === 'magnet' || base.style === 'magnet_and_screw';
   const hasScrew = base.style === 'screw' || base.style === 'magnet_and_screw';
+  const keepFull = style === 'solid';
 
   const toggleMagnet = useCallback(() => {
     const newMagnet = !hasMagnet;
@@ -58,6 +61,35 @@ export function ParameterPanel() {
     };
     setParam('base', newBase);
   }, [base, setParam]);
+
+  const toggleKeepFull = useCallback(() => {
+    const newStyle: BinStyle = keepFull ? 'standard' : 'solid';
+    setParam('style', newStyle);
+  }, [keepFull, setParam]);
+
+  const setMagnetRadius = useCallback(
+    (radius: number) => {
+      const newBase: BaseConfig = { ...base, magnetDiameter: radius * 2 };
+      setParam('base', newBase);
+    },
+    [base, setParam]
+  );
+
+  const setMagnetHeight = useCallback(
+    (depth: number) => {
+      const newBase: BaseConfig = { ...base, magnetDepth: depth };
+      setParam('base', newBase);
+    },
+    [base, setParam]
+  );
+
+  const setScrewRadius = useCallback(
+    (radius: number) => {
+      const newBase: BaseConfig = { ...base, screwDiameter: radius * 2 };
+      setParam('base', newBase);
+    },
+    [base, setParam]
+  );
 
   return (
     <div className="flex h-full flex-col">
@@ -113,16 +145,78 @@ export function ParameterPanel() {
                 checked={hasMagnet}
                 onChange={toggleMagnet}
               />
+              {hasMagnet && (
+                <div className="ml-4 space-y-3 border-l border-stroke-subtle pl-3 pt-1">
+                  <SliderInput
+                    label="Magnet radius"
+                    value={base.magnetDiameter / 2}
+                    onChange={setMagnetRadius}
+                    min={DESIGNER_CONSTRAINTS.MIN_MAGNET_RADIUS}
+                    max={DESIGNER_CONSTRAINTS.MAX_MAGNET_RADIUS}
+                    step={DESIGNER_CONSTRAINTS.MAGNET_RADIUS_STEP}
+                    unit="mm"
+                  />
+                  <SliderInput
+                    label="Magnet height"
+                    value={base.magnetDepth}
+                    onChange={setMagnetHeight}
+                    min={DESIGNER_CONSTRAINTS.MIN_MAGNET_HEIGHT}
+                    max={DESIGNER_CONSTRAINTS.MAX_MAGNET_HEIGHT}
+                    step={DESIGNER_CONSTRAINTS.MAGNET_HEIGHT_STEP}
+                    unit="mm"
+                  />
+                </div>
+              )}
               <ToggleRow
                 label="Screw holes"
                 checked={hasScrew}
                 onChange={toggleScrew}
               />
+              {hasScrew && (
+                <div className="ml-4 space-y-3 border-l border-stroke-subtle pl-3 pt-1">
+                  <SliderInput
+                    label="Screw radius"
+                    value={base.screwDiameter / 2}
+                    onChange={setScrewRadius}
+                    min={DESIGNER_CONSTRAINTS.MIN_SCREW_RADIUS}
+                    max={DESIGNER_CONSTRAINTS.MAX_SCREW_RADIUS}
+                    step={DESIGNER_CONSTRAINTS.SCREW_RADIUS_STEP}
+                    unit="mm"
+                  />
+                </div>
+              )}
               <ToggleRow
                 label="Stacking lip"
                 checked={base.stackingLip}
                 onChange={toggleStackingLip}
               />
+            </div>
+          </section>
+
+          {/* Walls */}
+          <section>
+            <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-content-tertiary">
+              Walls
+            </h3>
+            <div className="space-y-2">
+              <ToggleRow
+                label="Keep full (solid)"
+                checked={keepFull}
+                onChange={toggleKeepFull}
+              />
+              {!keepFull && (
+                <div className="ml-4 space-y-3 border-l border-stroke-subtle pl-3 pt-1">
+                  <SliderInput
+                    label="Wall thickness"
+                    value={wallThickness}
+                    onChange={(v) => setParam('wallThickness', v)}
+                    min={DESIGNER_CONSTRAINTS.MIN_WALL_THICKNESS}
+                    max={DESIGNER_CONSTRAINTS.MAX_WALL_THICKNESS}
+                    step={DESIGNER_CONSTRAINTS.WALL_THICKNESS_STEP}
+                    unit="mm"
+                  />
+                </div>
+              )}
             </div>
           </section>
         </div>

--- a/src/features/bin-designer/constants/defaults.ts
+++ b/src/features/bin-designer/constants/defaults.ts
@@ -9,10 +9,11 @@ export const DEFAULT_BIN_PARAMS: BinParams = {
   width: 2,
   depth: 2,
   height: 3,
+  wallThickness: 1.2,
   base: {
     style: 'standard',
-    magnetDiameter: 6,
-    magnetDepth: 2.4,
+    magnetDiameter: 6.5,
+    magnetDepth: 2,
     screwDiameter: 3,
     stackingLip: true,
   },

--- a/src/features/bin-designer/constants/gridfinity.ts
+++ b/src/features/bin-designer/constants/gridfinity.ts
@@ -87,4 +87,19 @@ export const DESIGNER_CONSTRAINTS = {
   MAGNET_MAX_DEPTH: 4.0, // mm
   MIN_SCOOP_RADIUS: 2.0, // mm (minimum useful scoop)
   MAX_SCOOP_RADIUS: 30.0, // mm (large scoops for deep bins)
+  // Wall thickness
+  MIN_WALL_THICKNESS: 0.8, // mm (single-wall FDM minimum)
+  MAX_WALL_THICKNESS: 2.4, // mm (3 standard 0.4mm nozzle lines × 2)
+  WALL_THICKNESS_STEP: 0.1, // mm
+  // Magnet holes (radius in UI, diameter in store)
+  MIN_MAGNET_RADIUS: 2.0, // mm (diameter 4mm)
+  MAX_MAGNET_RADIUS: 5.0, // mm (diameter 10mm)
+  MAGNET_RADIUS_STEP: 0.25, // mm
+  MIN_MAGNET_HEIGHT: 1.0, // mm
+  MAX_MAGNET_HEIGHT: 4.0, // mm
+  MAGNET_HEIGHT_STEP: 0.5, // mm
+  // Screw holes (radius in UI, diameter in store)
+  MIN_SCREW_RADIUS: 1.0, // mm (diameter 2mm)
+  MAX_SCREW_RADIUS: 3.0, // mm (diameter 6mm)
+  SCREW_RADIUS_STEP: 0.25, // mm
 } as const;

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -60,6 +60,8 @@ export interface BinParams {
   readonly width: number;
   readonly depth: number;
   readonly height: number;
+  /** Wall thickness in mm (default 1.2). Ignored when style is 'solid'. */
+  readonly wallThickness: number;
   readonly base: BaseConfig;
   readonly style: BinStyle;
   readonly dividers: DividerConfig;

--- a/src/features/bin-designer/utils/validation.ts
+++ b/src/features/bin-designer/utils/validation.ts
@@ -7,7 +7,7 @@
 import type { Result } from '@/core/result';
 import { ok, err } from '@/core/result';
 import type { BinParams } from '../types';
-import { DESIGNER_CONSTRAINTS, GRIDFINITY, STYLE_WALL_THICKNESS } from '../constants';
+import { DESIGNER_CONSTRAINTS, GRIDFINITY } from '../constants';
 
 /** Tolerance for floating-point step comparisons */
 const EPSILON = 1e-10;
@@ -82,6 +82,58 @@ export function validateBinParams(
     });
   }
 
+  // Wall thickness check
+  if (
+    params.wallThickness < DESIGNER_CONSTRAINTS.MIN_WALL_THICKNESS ||
+    params.wallThickness > DESIGNER_CONSTRAINTS.MAX_WALL_THICKNESS
+  ) {
+    return err({
+      code: 'WALL_THICKNESS_OUT_OF_RANGE',
+      message: `Wall thickness must be between ${DESIGNER_CONSTRAINTS.MIN_WALL_THICKNESS}mm and ${DESIGNER_CONSTRAINTS.MAX_WALL_THICKNESS}mm`,
+      field: 'wallThickness',
+    });
+  }
+
+  // Magnet dimension checks (only when magnet is enabled)
+  if (params.base.style === 'magnet' || params.base.style === 'magnet_and_screw') {
+    const magnetRadius = params.base.magnetDiameter / 2;
+    if (
+      magnetRadius < DESIGNER_CONSTRAINTS.MIN_MAGNET_RADIUS ||
+      magnetRadius > DESIGNER_CONSTRAINTS.MAX_MAGNET_RADIUS
+    ) {
+      return err({
+        code: 'MAGNET_RADIUS_OUT_OF_RANGE',
+        message: `Magnet radius must be between ${DESIGNER_CONSTRAINTS.MIN_MAGNET_RADIUS}mm and ${DESIGNER_CONSTRAINTS.MAX_MAGNET_RADIUS}mm`,
+        field: 'base.magnetDiameter',
+      });
+    }
+    if (
+      params.base.magnetDepth < DESIGNER_CONSTRAINTS.MIN_MAGNET_HEIGHT ||
+      params.base.magnetDepth > DESIGNER_CONSTRAINTS.MAX_MAGNET_HEIGHT
+    ) {
+      return err({
+        code: 'MAGNET_HEIGHT_OUT_OF_RANGE',
+        message: `Magnet height must be between ${DESIGNER_CONSTRAINTS.MIN_MAGNET_HEIGHT}mm and ${DESIGNER_CONSTRAINTS.MAX_MAGNET_HEIGHT}mm`,
+        field: 'base.magnetDepth',
+      });
+    }
+  }
+
+  // Screw dimension check (only when screw is enabled)
+  if (params.base.style === 'screw' || params.base.style === 'magnet_and_screw') {
+    const screwRadius = params.base.screwDiameter / 2;
+    if (
+      screwRadius < DESIGNER_CONSTRAINTS.MIN_SCREW_RADIUS ||
+      screwRadius > DESIGNER_CONSTRAINTS.MAX_SCREW_RADIUS
+    ) {
+      return err({
+        code: 'SCREW_RADIUS_OUT_OF_RANGE',
+        message: `Screw radius must be between ${DESIGNER_CONSTRAINTS.MIN_SCREW_RADIUS}mm and ${DESIGNER_CONSTRAINTS.MAX_SCREW_RADIUS}mm`,
+        field: 'base.screwDiameter',
+      });
+    }
+  }
+
   // Divider checks
   if (params.dividers.x < 0 || params.dividers.x > DESIGNER_CONSTRAINTS.MAX_DIVIDERS) {
     return err({
@@ -153,9 +205,8 @@ export function validateBinParams(
 
   // Compartment size validation (ensures dividers don't create impossibly thin sections)
   if (params.dividers.x > 0 || params.dividers.y > 0) {
-    const wallThickness = STYLE_WALL_THICKNESS[params.style] ?? GRIDFINITY.WALL_THICKNESS;
-    const innerWidth = params.width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE - 2 * wallThickness;
-    const innerDepth = params.depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE - 2 * wallThickness;
+    const innerWidth = params.width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE - 2 * params.wallThickness;
+    const innerDepth = params.depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE - 2 * params.wallThickness;
 
     if (params.dividers.x > 0) {
       const totalDividerWidth = params.dividers.x * params.dividers.thickness;

--- a/src/features/generation/worker/generators/replicadBin.ts
+++ b/src/features/generation/worker/generators/replicadBin.ts
@@ -27,7 +27,7 @@ import {
 import type { Solid, Shape3D, Sketch, Plane, Point, Edge, Wire } from 'replicad';
 import type { BinParams } from '@/features/bin-designer/types';
 import type { MeshData, ExportFormat } from '../../bridge/types';
-import { GRIDFINITY, STYLE_WALL_THICKNESS } from '@/features/bin-designer/constants/gridfinity';
+import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 
 /** Progress callback for reporting generation stages */
 export type ProgressFn = (stage: string, progress: number) => void;
@@ -516,7 +516,7 @@ export function generateBin(
   params: BinParams,
   onProgress?: ProgressFn
 ): MeshData {
-  const wallThickness = STYLE_WALL_THICKNESS[params.style] ?? GRIDFINITY.WALL_THICKNESS;
+  const wallThickness = params.wallThickness;
   const totalHeight = params.height * GRIDFINITY.HEIGHT_UNIT;
   // Wall height = total minus base height (first unit is base)
   // But in our coordinate system, the box floor is at Z=0 and socket is below.
@@ -540,9 +540,9 @@ export function generateBin(
     params.depth,
     withMagnet,
     withScrew,
-    GRIDFINITY.MAGNET_DIAMETER / 2,
-    GRIDFINITY.MAGNET_DEPTH,
-    GRIDFINITY.SCREW_DIAMETER / 2
+    params.base.magnetDiameter / 2,
+    params.base.magnetDepth,
+    params.base.screwDiameter / 2
   );
 
   // Stage 2: Build bin box (walls + floor)


### PR DESCRIPTION
## Summary
- Make bin generation fully parametric — wallThickness, magnetRadius/Height, screwRadius now user-adjustable
- Add conditional sliders in ParameterPanel (magnet/screw params visible only when toggle ON)
- Add "Keep full (solid)" toggle in new Walls section (hides wall thickness slider when ON)
- Add validation constraints for all new parameter ranges
- Remove hardcoded GRIDFINITY constant usage from replicad generator

## Files changed
- `replicadBin.ts` — Use params instead of constants for wall/magnet/screw dimensions
- `ParameterPanel.tsx` — Add conditional sliders + keepFull toggle
- `gridfinity.ts` — Add constraint ranges (wall 0.8–2.4mm, magnet radius 2–5mm, etc.)
- `validation.ts` — Add range validation, use params.wallThickness for compartment checks
- `defaults.ts` — Add wallThickness: 1.2, fix magnetDiameter to 6.5mm
- `types/index.ts` — Already had wallThickness (added in previous session)
- `ParameterPanel.test.tsx` — Expanded 8 → 22 tests

## Test plan
- [x] All 4860 tests pass
- [x] TypeScript compiles cleanly
- [x] Production build succeeds
- [x] ParameterPanel conditional visibility verified (22 tests)
- [ ] Manual: toggle magnet → see radius/height sliders appear
- [ ] Manual: toggle keepFull → wall thickness slider disappears