### PR TITLE
refactor(bin-designer): remove redundant entry points and fix header height

### DIFF
--- a/src/components/Mobile/MobileLayoutsPanel.tsx
+++ b/src/components/Mobile/MobileLayoutsPanel.tsx
@@ -8,8 +8,6 @@ import { useCloudShare } from '@/features/cloud-share/hooks/useCloudShare';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { LayoutThumbnail } from '@/components/LayoutThumbnail';
 import { InspirationGallery } from '@/features/inspiration-gallery';
-import { useDesignerRouting } from '@/features/bin-designer/hooks/useDesignerRouting';
-import { useLabsStore } from '@/core/store';
 import {
   loadLayoutAsync,
   generateShareableURL,
@@ -33,8 +31,6 @@ export function MobileLayoutsPanel() {
   const [renameLayoutId, setRenameLayoutId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const [showInspirationGallery, setShowInspirationGallery] = useState(false);
-  const isDesignerEnabled = useLabsStore((state) => state.isFeatureEnabled('bin_designer'));
-  const { navigateToDesigner } = useDesignerRouting();
   const renameInputRef = useRef<HTMLInputElement>(null);
 
   // Scroll rename input into view when keyboard appears on mobile
@@ -498,43 +494,6 @@ export function MobileLayoutsPanel() {
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
         </svg>
       </button>
-
-      {/* Bin Designer button - behind feature flag */}
-      {isDesignerEnabled && (
-        <button
-          onClick={navigateToDesigner}
-          className="w-full flex items-center gap-3 mt-3 p-3 rounded-xl bg-gradient-to-r from-blue-500/10 to-cyan-500/10 border border-blue-500/20 active:scale-[0.98] transition-transform"
-          aria-label="Open Bin Designer"
-        >
-          <div className="w-10 h-10 rounded-lg bg-blue-500/20 flex items-center justify-center shrink-0">
-            <svg
-              className="w-5 h-5 text-blue-400"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
-              />
-            </svg>
-          </div>
-          <div className="flex-1 text-left">
-            <div className="text-sm font-medium text-content">Bin Designer</div>
-            <div className="text-xs text-content-tertiary">Create custom bins for 3D printing</div>
-          </div>
-          <svg
-            className="w-4 h-4 text-content-tertiary"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-          </svg>
-        </button>
-      )}
 
       {/* Create new button */}
       <button onClick={handleCreateNew} className="btn btn-secondary w-full mt-3 h-12">

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, Suspense } from 'react';
 import { useShallow } from 'zustand/shallow';
-import { useUIStore, useLabsStore } from '@/core/store';
+import { useUIStore } from '@/core/store';
 import { useDrawerSettings } from '@/hooks/useDrawerSettings';
 import { CONSTRAINTS } from '@/core/constants';
 import { ActiveLayerPanel } from '@/features/layers/components/ActiveLayerPanel';
@@ -14,7 +14,6 @@ import { LoadingFallback } from '@/shared/components/LoadingFallback';
 import { useResponsive } from '@/shared/hooks';
 import { Checkbox } from '@/shared/components/Checkbox';
 import { SettingsRow } from '@/shared/components/SettingsRow';
-import { useDesignerRouting } from '@/features/bin-designer/hooks/useDesignerRouting';
 import { lazyWithRetry, namedExport } from '@/utils/lazyWithRetry';
 
 // Lazy load modals/galleries - only loaded when opened (using lazyWithRetry for PWA resilience)
@@ -28,7 +27,7 @@ const SettingsModal = lazyWithRetry(() =>
 /**
  * Renders the left-hand Tools sidebar with collapsed and expanded states, user controls for drawer/grid settings, and access to auxiliary panels.
  *
- * The component displays panels for active layer, layers, categories, an Inspiration Gallery entry, and physical/grid unit settings. It shows a Bin Designer entry when the bin_designer feature flag is enabled, supports a half-bin mode and fractional-edge controls when applicable, and conditionally mounts lazy-loaded modals for the Inspiration Gallery and Settings.
+ * The component displays panels for active layer, layers, categories, an Inspiration Gallery entry, and physical/grid unit settings. It supports a half-bin mode and fractional-edge controls when applicable, and conditionally mounts lazy-loaded modals for the Inspiration Gallery and Settings.
  *
  * @returns The sidebar element as JSX to be mounted in the application layout.
  */
@@ -38,8 +37,6 @@ export function Sidebar() {
   const [showSettingsModal, setShowSettingsModal] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const { isDesktop } = useResponsive();
-  const isDesignerEnabled = useLabsStore((state) => state.isFeatureEnabled('bin_designer'));
-  const { navigateToDesigner } = useDesignerRouting();
 
   const handleScroll = useCallback(() => {
     if (scrollRef.current) {
@@ -211,52 +208,6 @@ export function Sidebar() {
                 </svg>
               </button>
             </div>
-
-            {/* Bin Designer - behind feature flag */}
-            {isDesignerEnabled && (
-              <div className="px-4 py-4 border-b border-stroke-subtle">
-                <button
-                  onClick={navigateToDesigner}
-                  className="w-full flex items-center gap-3 text-left p-3 rounded-lg bg-gradient-to-r from-blue-500/10 to-cyan-500/10 hover:from-blue-500/20 hover:to-cyan-500/20 border border-blue-500/20 transition-all group"
-                  aria-label="Open Bin Designer"
-                >
-                  <div className="w-10 h-10 rounded-lg bg-blue-500/20 flex items-center justify-center group-hover:scale-105 transition-transform">
-                    <svg
-                      className="w-5 h-5 text-blue-400"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
-                      />
-                    </svg>
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="text-sm font-medium text-content">Bin Designer</div>
-                    <div className="text-xs text-content-tertiary">
-                      Create custom bins for 3D printing
-                    </div>
-                  </div>
-                  <svg
-                    className="w-4 h-4 text-content-tertiary group-hover:translate-x-0.5 transition-transform"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 5l7 7-7 7"
-                    />
-                  </svg>
-                </button>
-              </div>
-            )}
 
             {/* Grid Size */}
             <div data-grid-size-panel className="mt-auto px-4 py-4">

--- a/src/features/bin-designer/components/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage.tsx
@@ -176,7 +176,7 @@ export function DesignerPage(_props: DesignerPageProps) {
   return (
     <div className="flex h-screen flex-col bg-surface animate-fade-in">
       {/* Header */}
-      <header className="flex items-center justify-between border-b border-stroke-subtle bg-surface-secondary px-3 py-2 lg:px-4 lg:py-3">
+      <header className="h-12 flex items-center justify-between border-b border-stroke-subtle bg-surface-secondary px-3 lg:px-4">
         <div className="flex items-center gap-2 lg:gap-3">
           <ToolSwitcher compact={!isDesktop} />
           <div className="hidden h-5 w-px bg-stroke-subtle sm:block" />


### PR DESCRIPTION
## Summary
- Removes the "Bin Designer" button from the sidebar (desktop/tablet) and mobile layouts panel, since the ToolSwitcher in the header now handles navigation
- Sets the Designer page header to a fixed `h-12` height matching the Layout Planner header, eliminating layout shift when switching between tools
- Cleans up unused imports (`useLabsStore`, `useDesignerRouting`) from both Sidebar and MobileLayoutsPanel

## Test plan
- [ ] Enable `bin_designer` feature flag in Labs
- [ ] Verify the sidebar no longer shows the gradient "Bin Designer" card
- [ ] Verify the mobile layouts panel no longer shows the "Bin Designer" button
- [ ] Switch between Layout Planner and Bin Designer via the header toggle — confirm no vertical layout shift (both headers are 48px)
- [ ] Verify the ToolSwitcher still works correctly in desktop, tablet, and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)