### PR TITLE
fix(bin-designer): remove fade transition on tool switch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,6 +96,10 @@ const CollabProvider = lazyWithRetry(() =>
   import('./components/Collab/CollabProvider').then(namedExport('CollabProvider'))
 );
 
+// Track whether the initial layout has rendered, so we only play the fade-in
+// animation on first app load (not when switching between tools).
+let hasRenderedInitialLayout = false;
+
 // Initialize layout library once at module level to avoid effect setState issues
 let initialLoadError: Error | null = null;
 try {
@@ -211,6 +215,12 @@ export default function App() {
   // Storage migration (localStorage → IndexedDB)
   useStorageMigration();
 
+  // Only fade in on initial app load, not when switching between tools
+  const entranceClass = hasRenderedInitialLayout ? '' : 'animate-fade-in';
+  useEffect(() => {
+    hasRenderedInitialLayout = true;
+  }, []);
+
   // Help modal keyboard shortcut
   const handleHelpKeyboard = useCallback((e: KeyboardEvent) => {
     if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
@@ -299,7 +309,7 @@ export default function App() {
   // Mobile layout - lazy loaded
   if (isMobile) {
     return wrapWithMutations(
-      <div className="h-screen animate-fade-in">
+      <div className={`h-screen ${entranceClass}`}>
         <Suspense fallback={<LoadingFallback label="Loading mobile layout" />}>
           <MobileLayout
             isMobileHelpOpen={isMobileHelpOpen}
@@ -314,7 +324,9 @@ export default function App() {
   // Tablet layout - full width grid with overlay panels
   if (isTablet) {
     return wrapWithMutations(
-      <div className="h-screen flex flex-col overflow-hidden bg-surface text-content animate-fade-in">
+      <div
+        className={`h-screen flex flex-col overflow-hidden bg-surface text-content ${entranceClass}`}
+      >
         {/* Shared layout banner (shown when viewing unsaved shared layout) */}
         {hasSharedLayoutPreview && (
           <Suspense fallback={null}>
@@ -407,7 +419,9 @@ export default function App() {
 
   // Desktop layout
   return wrapWithMutations(
-    <div className="h-screen flex flex-col overflow-hidden bg-surface text-content animate-fade-in">
+    <div
+      className={`h-screen flex flex-col overflow-hidden bg-surface text-content ${entranceClass}`}
+    >
       {/* Skip to content link for keyboard navigation */}
       <a href="#main-grid" className="skip-to-content">
         Skip to grid editor

--- a/src/features/bin-designer/components/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage.tsx
@@ -174,7 +174,7 @@ export function DesignerPage(_props: DesignerPageProps) {
   }, [setParams, addToast]);
 
   return (
-    <div className="flex h-screen flex-col bg-surface animate-fade-in">
+    <div className="flex h-screen flex-col bg-surface">
       {/* Header */}
       <header className="h-12 flex items-center justify-between border-b border-stroke-subtle bg-surface-secondary px-3 lg:px-4">
         <div className="flex items-center gap-2 lg:gap-3">


### PR DESCRIPTION
## Summary
- Removes the fade-in animation when switching between Layout Planner and Bin Designer via the ToolSwitcher
- The fade now only plays on initial app load (first visit), providing a nice entrance without penalizing subsequent tool switches
- Tool switches are now instant — the stable header with the segmented control provides visual continuity without needing a transition (matching the UX of Figma, VS Code, and other professional tools)

## Test plan
- [ ] First visit / hard refresh: app fades in smoothly as before
- [ ] Enable `bin_designer` flag, switch to Bin Designer via toggle: instant switch, no fade
- [ ] Switch back to Layout Planner: instant switch, no fade
- [ ] Verify no layout shift (header stays perfectly stable at h-12 in both modes)
- [ ] Test on mobile: same instant behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)