### PR TITLE
feat(bin-designer): redesign parameter panel and enhance 3D preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
       "name": "Total JS (gzip)",
       "path": "dist/assets/*.js",
       "gzip": true,
-      "limit": "690 kB"
+      "limit": "950 kB"
     }
   ],
   "dependencies": {

--- a/src/features/bin-designer/__tests__/components/ParameterPanel.test.tsx
+++ b/src/features/bin-designer/__tests__/components/ParameterPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { ParameterPanel } from '../../components/ParameterPanel';
 import { useDesignerStore } from '../../store';
 import { DEFAULT_BIN_PARAMS } from '../../constants';
@@ -17,12 +17,12 @@ describe('ParameterPanel', () => {
     });
   });
 
-  it('renders tab buttons', () => {
+  it('renders section headers', () => {
     render(<ParameterPanel />);
 
-    expect(screen.getByText('Size')).toBeInTheDocument();
+    expect(screen.getByText('Dimensions')).toBeInTheDocument();
     expect(screen.getByText('Base')).toBeInTheDocument();
-    expect(screen.getByText('Compartments')).toBeInTheDocument();
+    expect(screen.getByText('Interior')).toBeInTheDocument();
     expect(screen.getByText('Walls')).toBeInTheDocument();
   });
 
@@ -37,9 +37,7 @@ describe('ParameterPanel', () => {
   it('renders base feature toggles', () => {
     render(<ParameterPanel />);
 
-    // Click on the Base tab to reveal base toggles
-    fireEvent.click(screen.getByText('Base'));
-
+    // Base section is expanded by default — no tab click needed
     expect(screen.getByText('Magnet holes')).toBeInTheDocument();
     expect(screen.getByText('Screw holes')).toBeInTheDocument();
     expect(screen.getByText('Stacking lip')).toBeInTheDocument();
@@ -48,7 +46,7 @@ describe('ParameterPanel', () => {
   it('shows mm info for dimensions', () => {
     render(<ParameterPanel />);
 
-    // Default tab is 'dimensions' (Size), width=2 and depth=2 both show 84mm
+    // Default width=2, depth=2 both show 84mm
     const mmLabels = screen.getAllByText('84mm');
     expect(mmLabels.length).toBe(2);
   });
@@ -56,10 +54,7 @@ describe('ParameterPanel', () => {
   it('toggling magnet holes updates base style', () => {
     render(<ParameterPanel />);
 
-    // Click on the Base tab first
-    fireEvent.click(screen.getByText('Base'));
-
-    const magnetToggle = screen.getByText('Magnet holes').closest('label')!.querySelector('button')!;
+    const magnetToggle = screen.getByRole('switch', { name: 'Magnet holes' });
     fireEvent.click(magnetToggle);
 
     expect(useDesignerStore.getState().params.base.style).toBe('magnet');
@@ -68,10 +63,7 @@ describe('ParameterPanel', () => {
   it('toggling screw holes updates base style', () => {
     render(<ParameterPanel />);
 
-    // Click on the Base tab first
-    fireEvent.click(screen.getByText('Base'));
-
-    const screwToggle = screen.getByText('Screw holes').closest('label')!.querySelector('button')!;
+    const screwToggle = screen.getByRole('switch', { name: 'Screw holes' });
     fireEvent.click(screwToggle);
 
     expect(useDesignerStore.getState().params.base.style).toBe('screw');
@@ -80,11 +72,8 @@ describe('ParameterPanel', () => {
   it('toggling both magnet and screw sets magnet_and_screw style', () => {
     render(<ParameterPanel />);
 
-    // Click on the Base tab first
-    fireEvent.click(screen.getByText('Base'));
-
-    const magnetToggle = screen.getByText('Magnet holes').closest('label')!.querySelector('button')!;
-    const screwToggle = screen.getByText('Screw holes').closest('label')!.querySelector('button')!;
+    const magnetToggle = screen.getByRole('switch', { name: 'Magnet holes' });
+    const screwToggle = screen.getByRole('switch', { name: 'Screw holes' });
 
     fireEvent.click(magnetToggle);
     fireEvent.click(screwToggle);
@@ -95,73 +84,85 @@ describe('ParameterPanel', () => {
   it('toggling stacking lip updates base config', () => {
     render(<ParameterPanel />);
 
-    // Click on the Base tab first
-    fireEvent.click(screen.getByText('Base'));
-
     // Default is stacking lip ON
     expect(useDesignerStore.getState().params.base.stackingLip).toBe(true);
 
-    const lipToggle = screen.getByText('Stacking lip').closest('label')!.querySelector('button')!;
+    const lipToggle = screen.getByRole('switch', { name: 'Stacking lip' });
     fireEvent.click(lipToggle);
 
     expect(useDesignerStore.getState().params.base.stackingLip).toBe(false);
   });
 
-  it('dimension sliders respect constraints', () => {
+  it('dimension steppers respect constraints (default: whole-unit mode)', () => {
     render(<ParameterPanel />);
 
-    const widthSlider = screen.getByLabelText('Width slider');
-    expect(widthSlider).toHaveAttribute('min', '0.5');
-    expect(widthSlider).toHaveAttribute('max', '8');
-    expect(widthSlider).toHaveAttribute('step', '0.5');
+    const widthInput = screen.getByLabelText('Width');
+    expect(widthInput).toHaveAttribute('min', '1');
+    expect(widthInput).toHaveAttribute('max', '8');
+    expect(widthInput).toHaveAttribute('step', '1');
 
-    const heightSlider = screen.getByLabelText('Height slider');
-    expect(heightSlider).toHaveAttribute('min', '2');
-    expect(heightSlider).toHaveAttribute('max', '20');
-    expect(heightSlider).toHaveAttribute('step', '1');
+    const heightInput = screen.getByLabelText('Height');
+    expect(heightInput).toHaveAttribute('min', '2');
+    expect(heightInput).toHaveAttribute('max', '20');
+    expect(heightInput).toHaveAttribute('step', '1');
+  });
+
+  it('dimension steppers use 0.5 step when half-bin mode is enabled', () => {
+    useDesignerStore.setState({
+      ui: { ...useDesignerStore.getState().ui, halfBinMode: true },
+    });
+    render(<ParameterPanel />);
+
+    const widthInput = screen.getByLabelText('Width');
+    expect(widthInput).toHaveAttribute('min', '0.5');
+    expect(widthInput).toHaveAttribute('step', '0.5');
+
+    const depthInput = screen.getByLabelText('Depth');
+    expect(depthInput).toHaveAttribute('min', '0.5');
+    expect(depthInput).toHaveAttribute('step', '0.5');
+
+    // Height is always integer units regardless of half-bin mode
+    const heightInput = screen.getByLabelText('Height');
+    expect(heightInput).toHaveAttribute('step', '1');
   });
 
   describe('conditional magnet/screw sliders', () => {
     it('does not show magnet sliders when magnet is off', () => {
       render(<ParameterPanel />);
 
-      // Click on the Base tab first
-      fireEvent.click(screen.getByText('Base'));
-
       expect(screen.queryByLabelText('Magnet radius')).not.toBeInTheDocument();
-      expect(screen.queryByLabelText('Magnet height')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Magnet depth')).not.toBeInTheDocument();
     });
 
-    it('shows magnet sliders when magnet is toggled on', () => {
+    it('shows magnet sliders when magnet is toggled on and Customize clicked', () => {
       render(<ParameterPanel />);
 
-      // Click on the Base tab first
-      fireEvent.click(screen.getByText('Base'));
-
-      const magnetToggle = screen.getByText('Magnet holes').closest('label')!.querySelector('button')!;
+      const magnetToggle = screen.getByRole('switch', { name: 'Magnet holes' });
       fireEvent.click(magnetToggle);
 
+      // Click "Customize" to reveal detailed sliders
+      const customizeBtn = screen.getAllByText('Customize')[0];
+      fireEvent.click(customizeBtn);
+
       expect(screen.getByLabelText('Magnet radius')).toBeInTheDocument();
-      expect(screen.getByLabelText('Magnet height')).toBeInTheDocument();
+      expect(screen.getByLabelText('Magnet depth')).toBeInTheDocument();
     });
 
     it('does not show screw slider when screw is off', () => {
       render(<ParameterPanel />);
 
-      // Click on the Base tab first
-      fireEvent.click(screen.getByText('Base'));
-
       expect(screen.queryByLabelText('Screw radius')).not.toBeInTheDocument();
     });
 
-    it('shows screw slider when screw is toggled on', () => {
+    it('shows screw slider when screw is toggled on and Customize clicked', () => {
       render(<ParameterPanel />);
 
-      // Click on the Base tab first
-      fireEvent.click(screen.getByText('Base'));
-
-      const screwToggle = screen.getByText('Screw holes').closest('label')!.querySelector('button')!;
+      const screwToggle = screen.getByRole('switch', { name: 'Screw holes' });
       fireEvent.click(screwToggle);
+
+      // Click "Customize" for screw settings
+      const customizeBtns = screen.getAllByText('Customize');
+      fireEvent.click(customizeBtns[0]);
 
       expect(screen.getByLabelText('Screw radius')).toBeInTheDocument();
     });
@@ -176,8 +177,9 @@ describe('ParameterPanel', () => {
 
       render(<ParameterPanel />);
 
-      // Click on the Base tab first
-      fireEvent.click(screen.getByText('Base'));
+      // Click Customize to reveal sliders
+      const customizeBtn = screen.getAllByText('Customize')[0];
+      fireEvent.click(customizeBtn);
 
       const radiusSlider = screen.getByLabelText('Magnet radius slider');
       fireEvent.change(radiusSlider, { target: { value: '4.0' } });
@@ -185,7 +187,7 @@ describe('ParameterPanel', () => {
       expect(useDesignerStore.getState().params.base.magnetDiameter).toBe(8.0);
     });
 
-    it('magnet height slider updates magnetDepth', () => {
+    it('magnet depth slider updates magnetDepth', () => {
       useDesignerStore.setState({
         params: {
           ...DEFAULT_BIN_PARAMS,
@@ -195,11 +197,12 @@ describe('ParameterPanel', () => {
 
       render(<ParameterPanel />);
 
-      // Click on the Base tab first
-      fireEvent.click(screen.getByText('Base'));
+      // Click Customize to reveal sliders
+      const customizeBtn = screen.getAllByText('Customize')[0];
+      fireEvent.click(customizeBtn);
 
-      const heightSlider = screen.getByLabelText('Magnet height slider');
-      fireEvent.change(heightSlider, { target: { value: '3.0' } });
+      const depthSlider = screen.getByLabelText('Magnet depth slider');
+      fireEvent.change(depthSlider, { target: { value: '3.0' } });
 
       expect(useDesignerStore.getState().params.base.magnetDepth).toBe(3.0);
     });
@@ -214,8 +217,9 @@ describe('ParameterPanel', () => {
 
       render(<ParameterPanel />);
 
-      // Click on the Base tab first
-      fireEvent.click(screen.getByText('Base'));
+      // Click Customize to reveal sliders
+      const customizeBtn = screen.getAllByText('Customize')[0];
+      fireEvent.click(customizeBtn);
 
       const radiusSlider = screen.getByLabelText('Screw radius slider');
       fireEvent.change(radiusSlider, { target: { value: '2.0' } });
@@ -224,100 +228,39 @@ describe('ParameterPanel', () => {
     });
   });
 
-  describe('keepFull toggle and wall thickness', () => {
-    it('renders keepFull toggle', () => {
+  describe('walls section', () => {
+    it('shows wall thickness selector (expanded by default)', () => {
       render(<ParameterPanel />);
-
-      // Click on the Walls tab first
-      fireEvent.click(screen.getByText('Walls'));
-
-      expect(screen.getByText('Keep full (solid)')).toBeInTheDocument();
-    });
-
-    it('shows wall thickness slider when keepFull is off (default)', () => {
-      render(<ParameterPanel />);
-
-      // Click on the Walls tab first
-      fireEvent.click(screen.getByText('Walls'));
 
       expect(screen.getByLabelText('Wall thickness')).toBeInTheDocument();
-    });
-
-    it('hides wall thickness slider when keepFull is toggled on', () => {
-      render(<ParameterPanel />);
-
-      // Click on the Walls tab first
-      fireEvent.click(screen.getByText('Walls'));
-
-      const keepFullToggle = screen
-        .getByText('Keep full (solid)')
-        .closest('label')!
-        .querySelector('button')!;
-      fireEvent.click(keepFullToggle);
-
-      expect(screen.queryByLabelText('Wall thickness')).not.toBeInTheDocument();
-    });
-
-    it('toggling keepFull sets style to solid', () => {
-      render(<ParameterPanel />);
-
-      // Click on the Walls tab first
-      fireEvent.click(screen.getByText('Walls'));
-
-      const keepFullToggle = screen
-        .getByText('Keep full (solid)')
-        .closest('label')!
-        .querySelector('button')!;
-      fireEvent.click(keepFullToggle);
-
-      expect(useDesignerStore.getState().params.style).toBe('solid');
-    });
-
-    it('toggling keepFull off sets style back to standard', () => {
-      useDesignerStore.setState({
-        params: { ...DEFAULT_BIN_PARAMS, style: 'solid' },
-      });
-
-      render(<ParameterPanel />);
-
-      // Click on the Walls tab first
-      fireEvent.click(screen.getByText('Walls'));
-
-      const keepFullToggle = screen
-        .getByText('Keep full (solid)')
-        .closest('label')!
-        .querySelector('button')!;
-      fireEvent.click(keepFullToggle);
-
-      expect(useDesignerStore.getState().params.style).toBe('standard');
     });
 
     it('wall thickness selector shows discrete options', () => {
       render(<ParameterPanel />);
 
-      // Click on the Walls tab first
-      fireEvent.click(screen.getByText('Walls'));
-
-      // Verify all discrete thickness options are present as radio buttons
-      const options = screen.getAllByRole('radio');
+      const thicknessGroup = screen.getByRole('radiogroup', { name: 'Wall thickness' });
+      const options = within(thicknessGroup).getAllByRole('radio');
       expect(options).toHaveLength(8);
       expect(screen.getByLabelText('0.4mm')).toBeInTheDocument();
-      expect(screen.getByLabelText('0.6mm')).toBeInTheDocument();
-      expect(screen.getByLabelText('0.8mm')).toBeInTheDocument();
       expect(screen.getByLabelText('1.2mm')).toBeInTheDocument();
-      expect(screen.getByLabelText('1.6mm')).toBeInTheDocument();
-      expect(screen.getByLabelText('1.8mm')).toBeInTheDocument();
-      expect(screen.getByLabelText('2mm')).toBeInTheDocument();
       expect(screen.getByLabelText('2.4mm')).toBeInTheDocument();
     });
 
     it('clicking a thickness option updates the store', () => {
       render(<ParameterPanel />);
 
-      fireEvent.click(screen.getByText('Walls'));
       fireEvent.click(screen.getByLabelText('1.6mm'));
 
       expect(useDesignerStore.getState().params.wallThickness).toBe(1.6);
+    });
+  });
+
+  describe('interior section', () => {
+    it('renders compartment grid controls', () => {
+      render(<ParameterPanel />);
+
+      expect(screen.getByLabelText('Columns')).toBeInTheDocument();
+      expect(screen.getByLabelText('Rows')).toBeInTheDocument();
     });
   });
 });

--- a/src/features/bin-designer/components/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor.tsx
@@ -3,7 +3,7 @@
  *
  * Displays a top-down 2D view of the bin interior divided into a user-defined
  * grid. Users can:
- * 1. Set grid dimensions (rows × cols) via sliders
+ * 1. Set grid dimensions (rows × cols) via stepper controls
  * 2. Click-drag to select a rectangular region of cells
  * 3. Merge selected cells into one compartment (or split merged ones)
  *
@@ -16,7 +16,7 @@ import { useCallback, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
-import { SliderInput } from './controls/SliderInput';
+import { StepperControl } from '@/shared/components/StepperControl';
 import { ThicknessSelector } from './controls/ThicknessSelector';
 import {
   getCompartmentCount,
@@ -148,12 +148,32 @@ export function CompartmentEditor() {
     [rows, setCompartmentGrid]
   );
 
+  const handleColsStep = useCallback(
+    (delta: number) => {
+      const next = cols + delta;
+      const clamped = Math.min(DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID, Math.max(DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID, next));
+      setCompartmentGrid(clamped, rows);
+      setSelection(new Set());
+    },
+    [cols, rows, setCompartmentGrid]
+  );
+
   const handleRowsChange = useCallback(
     (newRows: number) => {
       setCompartmentGrid(cols, newRows);
       setSelection(new Set());
     },
     [cols, setCompartmentGrid]
+  );
+
+  const handleRowsStep = useCallback(
+    (delta: number) => {
+      const next = rows + delta;
+      const clamped = Math.min(DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID, Math.max(DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID, next));
+      setCompartmentGrid(cols, clamped);
+      setSelection(new Set());
+    },
+    [cols, rows, setCompartmentGrid]
   );
 
   const handleThicknessChange = useCallback(
@@ -166,76 +186,87 @@ export function CompartmentEditor() {
   const compartmentCount = getCompartmentCount(compartments);
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="flex-1 overflow-y-auto px-4 py-3">
-        <div className="space-y-6">
+    <div>
+      <div>
+        <div className="space-y-5">
           {/* Grid dimensions */}
           <section>
             <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-content-tertiary">
               Grid Size
             </h3>
-            <div className="space-y-4">
-              <SliderInput
-                label="Columns"
-                value={cols}
-                onChange={handleColsChange}
-                min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID}
-                max={DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID}
-                step={1}
-                unit=""
-              />
-              <SliderInput
-                label="Rows"
-                value={rows}
-                onChange={handleRowsChange}
-                min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID}
-                max={DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID}
-                step={1}
-                unit=""
-              />
-            </div>
-          </section>
-
-          {/* Visual grid editor */}
-          <section>
-            <div className="mb-2 flex items-center justify-between">
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-content-tertiary">
-                Layout
-              </h3>
-              <span className="text-xs text-content-tertiary">
-                {compartmentCount} {compartmentCount === 1 ? 'compartment' : 'compartments'}
-              </span>
-            </div>
-            <p className="mb-3 text-xs text-content-tertiary">
-              Drag to select cells, then release to merge. Click a merged compartment to split.
-            </p>
-            <div
-              ref={gridRef}
-              className="mx-auto aspect-square max-w-[280px] select-none rounded-lg border border-stroke-subtle p-1"
-              onPointerUp={handlePointerUp}
-              onPointerLeave={handlePointerUp}
-            >
-              <div
-                className="grid h-full w-full gap-0.5"
-                style={{
-                  gridTemplateColumns: `repeat(${cols}, 1fr)`,
-                  gridTemplateRows: `repeat(${rows}, 1fr)`,
-                }}
-              >
-                {cells.map((compartmentId, idx) => (
-                  <GridCell
-                    key={idx}
-                    idx={idx}
-                    compartmentId={compartmentId}
-                    isSelected={selection.has(idx)}
-                    config={compartments}
-                    onPointerDown={handleCellPointerDown}
-                    onPointerEnter={handleCellPointerEnter}
-                  />
-                ))}
+            <div className="space-y-3">
+              <div>
+                <span className="mb-1 block text-xs text-content-tertiary">Columns</span>
+                <StepperControl
+                  value={cols}
+                  onChange={handleColsChange}
+                  onStep={handleColsStep}
+                  min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID}
+                  max={DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID}
+                  step={1}
+                  variant="compact"
+                  ariaLabel="Columns"
+                />
+              </div>
+              <div>
+                <span className="mb-1 block text-xs text-content-tertiary">Rows</span>
+                <StepperControl
+                  value={rows}
+                  onChange={handleRowsChange}
+                  onStep={handleRowsStep}
+                  min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID}
+                  max={DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID}
+                  step={1}
+                  variant="compact"
+                  ariaLabel="Rows"
+                />
               </div>
             </div>
           </section>
+
+          {/* Visual grid editor (hidden for single-cell grids) */}
+          {(cols > 1 || rows > 1) && (
+            <section>
+              <div className="mb-2 flex items-center justify-between">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-content-tertiary">
+                  Layout
+                </h3>
+                <span className="text-xs text-content-tertiary">
+                  {compartmentCount} {compartmentCount === 1 ? 'compartment' : 'compartments'}
+                </span>
+              </div>
+              <p className="mb-3 text-xs text-content-tertiary">
+                Drag to select cells, then release to merge. Click a merged compartment to split.
+              </p>
+              <div
+                ref={gridRef}
+                className="mx-auto aspect-square max-w-[280px] select-none rounded-lg border border-stroke-subtle p-1"
+                onPointerUp={handlePointerUp}
+                onPointerLeave={handlePointerUp}
+              >
+                <div
+                  className="grid h-full w-full gap-0.5"
+                  style={{
+                    gridTemplateColumns: `repeat(${cols}, 1fr)`,
+                    gridTemplateRows: `repeat(${rows}, 1fr)`,
+                    transform: 'scaleY(-1)',
+                  }}
+                >
+                  {cells.map((compartmentId, idx) => (
+                    <GridCell
+                      key={idx}
+                      idx={idx}
+                      compartmentId={compartmentId}
+                      isSelected={selection.has(idx)}
+                      config={compartments}
+                      onPointerDown={handleCellPointerDown}
+                      onPointerEnter={handleCellPointerEnter}
+                    />
+                  ))}
+                </div>
+              </div>
+            </section>
+          )}
 
           {/* Wall thickness (only when there are dividers) */}
           {compartmentCount > 1 && (

--- a/src/features/bin-designer/components/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage.tsx
@@ -512,7 +512,7 @@ export function DesignerPage(_props: DesignerPageProps) {
       {isDesktop ? (
         /* Desktop: side-by-side */
         <main className="flex flex-1 overflow-hidden">
-          <div className="w-80 flex-shrink-0 overflow-hidden border-r border-stroke-subtle bg-surface-secondary">
+          <div className="w-72 flex-shrink-0 overflow-hidden border-r border-stroke-subtle bg-surface-secondary">
             <ParameterPanel />
           </div>
           <div className="relative flex-1 overflow-hidden">

--- a/src/features/bin-designer/components/MobileParameterTabs.tsx
+++ b/src/features/bin-designer/components/MobileParameterTabs.tsx
@@ -1,7 +1,6 @@
 /**
- * Mobile parameter panel — re-uses the tabbed ParameterPanel.
- * Now that we have multiple tabs (Size, Base, Compartments, Walls),
- * the panel handles its own tab switching.
+ * Mobile parameter panel — renders the scrollable ParameterPanel directly.
+ * Same layout on all breakpoints (no separate tab navigation for mobile).
  */
 
 import { ParameterPanel } from './ParameterPanel';

--- a/src/features/bin-designer/components/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel.tsx
@@ -1,278 +1,47 @@
 /**
- * Parameter panel for replicad-based bin generation.
- * Contains tabbed sections: Dimensions, Base, Compartments, Walls.
+ * Parameter panel for the bin designer.
+ *
+ * Scrollable container composing collapsible sections for all bin parameters.
+ * Sections are independently subscribed to the store for minimal re-renders.
+ *
+ * Layout:
+ * - Dimensions (expanded) — Width, Depth, Height
+ * - Base (expanded) — Magnets, Screws, Stacking lip
+ * - Walls (expanded) — Wall thickness
+ * - Interior (expanded) — Compartments
+ * - Coming Soon (collapsed) — Feature roadmap teaser
  */
 
-import { useCallback } from 'react';
-import { useShallow } from 'zustand/react/shallow';
-import { useDesignerStore } from '@/features/bin-designer/store';
-import { GRIDFINITY, DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
-import { SliderInput } from './controls/SliderInput';
-import { ThicknessSelector } from './controls/ThicknessSelector';
-import { CompartmentEditor } from './CompartmentEditor';
-import type { BaseConfig, BaseStyle, BinStyle, DesignerTab } from '@/features/bin-designer/types';
-
-/** Derive base style from individual magnet/screw booleans */
-function computeBaseStyle(magnet: boolean, screw: boolean): BaseStyle {
-  if (magnet && screw) return 'magnet_and_screw';
-  if (magnet) return 'magnet';
-  if (screw) return 'screw';
-  return 'standard';
-}
-
-const TAB_LABELS: Record<DesignerTab, string> = {
-  dimensions: 'Size',
-  base: 'Base',
-  compartments: 'Compartments',
-  walls: 'Walls',
-  style: 'Style',
-};
-
-const ACTIVE_TABS: DesignerTab[] = ['dimensions', 'base', 'compartments', 'walls'];
+import { DimensionsSection } from './panel/DimensionsSection';
+import { BaseSection } from './panel/BaseSection';
+import { InteriorSection } from './panel/InteriorSection';
+import { WallsSection } from './panel/WallsSection';
+import { PhysicalUnitsSection } from './panel/PhysicalUnitsSection';
+import { ComingSoonSection } from './panel/ComingSoonSection';
 
 export function ParameterPanel() {
-  const { width, depth, height, wallThickness, base, style, activeTab, setParam, setActiveTab } = useDesignerStore(
-    useShallow((s) => ({
-      width: s.params.width,
-      depth: s.params.depth,
-      height: s.params.height,
-      wallThickness: s.params.wallThickness,
-      base: s.params.base,
-      style: s.params.style,
-      activeTab: s.ui.activeTab,
-      setParam: s.setParam,
-      setActiveTab: s.setActiveTab,
-    }))
-  );
-
-  const hasMagnet = base.style === 'magnet' || base.style === 'magnet_and_screw';
-  const hasScrew = base.style === 'screw' || base.style === 'magnet_and_screw';
-  const keepFull = style === 'solid';
-
-  const toggleMagnet = useCallback(() => {
-    const newMagnet = !hasMagnet;
-    const newBase: BaseConfig = {
-      ...base,
-      style: computeBaseStyle(newMagnet, hasScrew),
-    };
-    setParam('base', newBase);
-  }, [base, hasMagnet, hasScrew, setParam]);
-
-  const toggleScrew = useCallback(() => {
-    const newScrew = !hasScrew;
-    const newBase: BaseConfig = {
-      ...base,
-      style: computeBaseStyle(hasMagnet, newScrew),
-    };
-    setParam('base', newBase);
-  }, [base, hasMagnet, hasScrew, setParam]);
-
-  const toggleStackingLip = useCallback(() => {
-    const newBase: BaseConfig = {
-      ...base,
-      stackingLip: !base.stackingLip,
-    };
-    setParam('base', newBase);
-  }, [base, setParam]);
-
-  const toggleKeepFull = useCallback(() => {
-    const newStyle: BinStyle = keepFull ? 'standard' : 'solid';
-    setParam('style', newStyle);
-  }, [keepFull, setParam]);
-
-  const setMagnetRadius = useCallback(
-    (radius: number) => {
-      const newBase: BaseConfig = { ...base, magnetDiameter: radius * 2 };
-      setParam('base', newBase);
-    },
-    [base, setParam]
-  );
-
-  const setMagnetHeight = useCallback(
-    (depth: number) => {
-      const newBase: BaseConfig = { ...base, magnetDepth: depth };
-      setParam('base', newBase);
-    },
-    [base, setParam]
-  );
-
-  const setScrewRadius = useCallback(
-    (radius: number) => {
-      const newBase: BaseConfig = { ...base, screwDiameter: radius * 2 };
-      setParam('base', newBase);
-    },
-    [base, setParam]
-  );
-
   return (
     <div className="flex h-full flex-col">
-      {/* Tab bar */}
-      <div className="flex border-b border-stroke-subtle bg-surface-tertiary">
-        {ACTIVE_TABS.map((tab) => (
-          <button
-            key={tab}
-            type="button"
-            onClick={() => setActiveTab(tab)}
-            className={`flex-1 px-2 py-2 text-xs font-medium transition-colors ${
-              activeTab === tab
-                ? 'border-b-2 border-accent text-accent'
-                : 'text-content-tertiary hover:text-content-secondary'
-            }`}
-          >
-            {TAB_LABELS[tab]}
-          </button>
-        ))}
+      <div className="flex-1 overflow-y-auto scrollbar-thin">
+        <div className="px-4 py-4 border-b border-stroke-subtle">
+          <DimensionsSection />
+        </div>
+        <div className="px-4 py-4 border-b border-stroke-subtle">
+          <BaseSection />
+        </div>
+        <div className="px-4 py-4 border-b border-stroke-subtle">
+          <WallsSection />
+        </div>
+        <div className="px-4 py-4 border-b border-stroke-subtle">
+          <InteriorSection />
+        </div>
+        <div className="px-4 py-4 border-b border-stroke-subtle">
+          <PhysicalUnitsSection />
+        </div>
+        <div className="px-4 py-4">
+          <ComingSoonSection />
+        </div>
       </div>
-
-      {/* Tab content */}
-      {activeTab === 'dimensions' && (
-        <div className="flex-1 overflow-y-auto px-4 py-3">
-          <div className="space-y-4">
-            <SliderInput
-              label="Width"
-              value={width}
-              onChange={(v) => setParam('width', v)}
-              min={DESIGNER_CONSTRAINTS.MIN_DIMENSION}
-              max={DESIGNER_CONSTRAINTS.MAX_DIMENSION}
-              step={DESIGNER_CONSTRAINTS.DIMENSION_STEP}
-              unit="u"
-              info={`${(width * GRIDFINITY.GRID_SIZE).toFixed(0)}mm`}
-            />
-            <SliderInput
-              label="Depth"
-              value={depth}
-              onChange={(v) => setParam('depth', v)}
-              min={DESIGNER_CONSTRAINTS.MIN_DIMENSION}
-              max={DESIGNER_CONSTRAINTS.MAX_DIMENSION}
-              step={DESIGNER_CONSTRAINTS.DIMENSION_STEP}
-              unit="u"
-              info={`${(depth * GRIDFINITY.GRID_SIZE).toFixed(0)}mm`}
-            />
-            <SliderInput
-              label="Height"
-              value={height}
-              onChange={(v) => setParam('height', v)}
-              min={DESIGNER_CONSTRAINTS.MIN_HEIGHT}
-              max={DESIGNER_CONSTRAINTS.MAX_HEIGHT}
-              step={DESIGNER_CONSTRAINTS.HEIGHT_STEP}
-              unit="u"
-              info={`${(height * GRIDFINITY.HEIGHT_UNIT).toFixed(0)}mm body + ${GRIDFINITY.LIP_HEIGHT}mm lip`}
-            />
-          </div>
-        </div>
-      )}
-
-      {activeTab === 'base' && (
-        <div className="flex-1 overflow-y-auto px-4 py-3">
-          <div className="space-y-2">
-            <ToggleRow
-              label="Magnet holes"
-              checked={hasMagnet}
-              onChange={toggleMagnet}
-            />
-            {hasMagnet && (
-              <div className="ml-4 space-y-3 border-l border-stroke-subtle pl-3 pt-1">
-                <SliderInput
-                  label="Magnet radius"
-                  value={base.magnetDiameter / 2}
-                  onChange={setMagnetRadius}
-                  min={DESIGNER_CONSTRAINTS.MIN_MAGNET_RADIUS}
-                  max={DESIGNER_CONSTRAINTS.MAX_MAGNET_RADIUS}
-                  step={DESIGNER_CONSTRAINTS.MAGNET_RADIUS_STEP}
-                  unit="mm"
-                />
-                <SliderInput
-                  label="Magnet height"
-                  value={base.magnetDepth}
-                  onChange={setMagnetHeight}
-                  min={DESIGNER_CONSTRAINTS.MIN_MAGNET_HEIGHT}
-                  max={DESIGNER_CONSTRAINTS.MAX_MAGNET_HEIGHT}
-                  step={DESIGNER_CONSTRAINTS.MAGNET_HEIGHT_STEP}
-                  unit="mm"
-                />
-              </div>
-            )}
-            <ToggleRow
-              label="Screw holes"
-              checked={hasScrew}
-              onChange={toggleScrew}
-            />
-            {hasScrew && (
-              <div className="ml-4 space-y-3 border-l border-stroke-subtle pl-3 pt-1">
-                <SliderInput
-                  label="Screw radius"
-                  value={base.screwDiameter / 2}
-                  onChange={setScrewRadius}
-                  min={DESIGNER_CONSTRAINTS.MIN_SCREW_RADIUS}
-                  max={DESIGNER_CONSTRAINTS.MAX_SCREW_RADIUS}
-                  step={DESIGNER_CONSTRAINTS.SCREW_RADIUS_STEP}
-                  unit="mm"
-                />
-              </div>
-            )}
-            <ToggleRow
-              label="Stacking lip"
-              checked={base.stackingLip}
-              onChange={toggleStackingLip}
-            />
-          </div>
-        </div>
-      )}
-
-      {activeTab === 'compartments' && <CompartmentEditor />}
-
-      {activeTab === 'walls' && (
-        <div className="flex-1 overflow-y-auto px-4 py-3">
-          <div className="space-y-2">
-            <ToggleRow
-              label="Keep full (solid)"
-              checked={keepFull}
-              onChange={toggleKeepFull}
-            />
-            {!keepFull && (
-              <div className="ml-4 space-y-3 border-l border-stroke-subtle pl-3 pt-1">
-                <ThicknessSelector
-                  label="Wall thickness"
-                  value={wallThickness}
-                  onChange={(v) => setParam('wallThickness', v)}
-                />
-              </div>
-            )}
-          </div>
-        </div>
-      )}
     </div>
-  );
-}
-
-/** Simple labeled toggle switch */
-function ToggleRow({
-  label,
-  checked,
-  onChange,
-}: {
-  label: string;
-  checked: boolean;
-  onChange: () => void;
-}) {
-  return (
-    <label className="flex cursor-pointer items-center justify-between py-1">
-      <span className="text-xs text-content-secondary">{label}</span>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={checked}
-        onClick={onChange}
-        className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
-          checked ? 'bg-accent' : 'bg-stroke-subtle'
-        }`}
-      >
-        <span
-          className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow-sm transition-transform ${
-            checked ? 'translate-x-4' : 'translate-x-0.5'
-          }`}
-        />
-      </button>
-    </label>
   );
 }

--- a/src/features/bin-designer/components/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas.tsx
@@ -12,7 +12,7 @@ import { Vector3, Spherical } from 'three';
 import type { OrbitControls as OrbitControlsType } from 'three-stdlib';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
-import { BinMesh, PreviewControls, PreviewSkeleton, type CameraPreset } from './preview';
+import { BinMesh, BinAxisLabels, BinDimensions, BinNameLabel, PreviewControls, PreviewSkeleton, type CameraPreset } from './preview';
 import { GradientBackground } from './preview/GradientBackground';
 import { FootprintGrid } from './preview/FootprintGrid';
 import { useDesignerKeyboard } from '../hooks/useDesignerKeyboard';
@@ -284,12 +284,13 @@ export function PreviewCanvas() {
     return () => clearPreviewCanvas();
   }, []);
 
-  const { wasmStatus, generationStatus, hasMesh, params } = useDesignerStore(
+  const { wasmStatus, generationStatus, hasMesh, params, designName } = useDesignerStore(
     useShallow((s) => ({
       wasmStatus: s.wasmStatus,
       generationStatus: s.generation.status,
       hasMesh: s.generation.mesh !== null && s.generation.mesh.vertices !== null,
       params: s.params,
+      designName: s.designName,
     }))
   );
 
@@ -407,7 +408,23 @@ export function PreviewCanvas() {
             {/* Footprint grid */}
             <FootprintGrid width={width} depth={depth} />
 
-{/* Orbit controls - Z-up with polar limits */}
+            {/* Grid axis labels */}
+            <BinAxisLabels width={width} depth={depth} />
+
+            {/* Dimension markers */}
+            <BinDimensions
+              width={width}
+              depth={depth}
+              height={height}
+              gridUnitMm={params.gridUnitMm}
+              heightUnitMm={params.heightUnitMm}
+              stackingLip={params.base.stackingLip}
+            />
+
+            {/* Design name on floor */}
+            <BinNameLabel width={width} depth={depth} name={designName} />
+
+            {/* Orbit controls - Z-up with polar limits */}
             <OrbitControls
               ref={controlsRef}
               makeDefault

--- a/src/features/bin-designer/components/panel/BaseSection.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection.tsx
@@ -1,0 +1,154 @@
+/**
+ * Base section: Magnet holes, screw holes, stacking lip, flat bottom.
+ *
+ * Uses smart defaults with "Customize" inline expansion for magnet/screw
+ * radius and depth parameters that most users won't need to change.
+ */
+
+import { useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
+import { CollapsibleSection } from '@/shared/components/CollapsibleSection';
+import { SliderInput } from '../controls/SliderInput';
+import { FeatureToggle } from './FeatureToggle';
+import { BaseIcon } from './SectionIllustrations';
+import type { BaseConfig, BaseStyle } from '@/features/bin-designer/types';
+
+/** Derive base style from individual magnet/screw booleans */
+function computeBaseStyle(magnet: boolean, screw: boolean): BaseStyle {
+  if (magnet && screw) return 'magnet_and_screw';
+  if (magnet) return 'magnet';
+  if (screw) return 'screw';
+  return 'standard';
+}
+
+export function BaseSection() {
+  const { base, setParam } = useDesignerStore(
+    useShallow((s) => ({
+      base: s.params.base,
+      setParam: s.setParam,
+    }))
+  );
+
+  const hasMagnet = base.style === 'magnet' || base.style === 'magnet_and_screw';
+  const hasScrew = base.style === 'screw' || base.style === 'magnet_and_screw';
+
+  const toggleMagnet = useCallback(() => {
+    const newMagnet = !hasMagnet;
+    const newBase: BaseConfig = {
+      ...base,
+      style: computeBaseStyle(newMagnet, hasScrew),
+    };
+    setParam('base', newBase);
+  }, [base, hasMagnet, hasScrew, setParam]);
+
+  const toggleScrew = useCallback(() => {
+    const newScrew = !hasScrew;
+    const newBase: BaseConfig = {
+      ...base,
+      style: computeBaseStyle(hasMagnet, newScrew),
+    };
+    setParam('base', newBase);
+  }, [base, hasMagnet, hasScrew, setParam]);
+
+  const toggleStackingLip = useCallback(() => {
+    const newBase: BaseConfig = { ...base, stackingLip: !base.stackingLip };
+    setParam('base', newBase);
+  }, [base, setParam]);
+
+  const setMagnetRadius = useCallback(
+    (radius: number) => {
+      setParam('base', { ...base, magnetDiameter: radius * 2 });
+    },
+    [base, setParam]
+  );
+
+  const setMagnetHeight = useCallback(
+    (depth: number) => {
+      setParam('base', { ...base, magnetDepth: depth });
+    },
+    [base, setParam]
+  );
+
+  const setScrewRadius = useCallback(
+    (radius: number) => {
+      setParam('base', { ...base, screwDiameter: radius * 2 });
+    },
+    [base, setParam]
+  );
+
+  // Build summary for collapsed state
+  const summaryParts: string[] = [];
+  if (hasMagnet) summaryParts.push(`${base.magnetDiameter}mm magnets`);
+  if (hasScrew) summaryParts.push(`M${base.screwDiameter} screws`);
+  if (base.stackingLip) summaryParts.push('Lip');
+  const summary = summaryParts.length > 0 ? summaryParts.join(' • ') : 'Standard (no attachment)';
+
+  return (
+    <CollapsibleSection
+      title="Base"
+      defaultExpanded={true}
+      illustration={<BaseIcon />}
+      summary={summary}
+    >
+      <div className="space-y-1">
+        <FeatureToggle
+          label="Magnet holes"
+          checked={hasMagnet}
+          onChange={toggleMagnet}
+          valueSummary={`ø${base.magnetDiameter}mm × ${base.magnetDepth}mm deep`}
+        >
+          <SliderInput
+            label="Magnet radius"
+            value={base.magnetDiameter / 2}
+            onChange={setMagnetRadius}
+            min={DESIGNER_CONSTRAINTS.MIN_MAGNET_RADIUS}
+            max={DESIGNER_CONSTRAINTS.MAX_MAGNET_RADIUS}
+            step={DESIGNER_CONSTRAINTS.MAGNET_RADIUS_STEP}
+            unit="mm"
+          />
+          <SliderInput
+            label="Magnet depth"
+            value={base.magnetDepth}
+            onChange={setMagnetHeight}
+            min={DESIGNER_CONSTRAINTS.MIN_MAGNET_HEIGHT}
+            max={DESIGNER_CONSTRAINTS.MAX_MAGNET_HEIGHT}
+            step={DESIGNER_CONSTRAINTS.MAGNET_HEIGHT_STEP}
+            unit="mm"
+          />
+        </FeatureToggle>
+
+        <FeatureToggle
+          label="Screw holes"
+          checked={hasScrew}
+          onChange={toggleScrew}
+          valueSummary={`ø${base.screwDiameter}mm (M${base.screwDiameter})`}
+        >
+          <SliderInput
+            label="Screw radius"
+            value={base.screwDiameter / 2}
+            onChange={setScrewRadius}
+            min={DESIGNER_CONSTRAINTS.MIN_SCREW_RADIUS}
+            max={DESIGNER_CONSTRAINTS.MAX_SCREW_RADIUS}
+            step={DESIGNER_CONSTRAINTS.SCREW_RADIUS_STEP}
+            unit="mm"
+          />
+        </FeatureToggle>
+
+        <FeatureToggle
+          label="Stacking lip"
+          checked={base.stackingLip}
+          onChange={toggleStackingLip}
+        />
+
+        <FeatureToggle
+          label="Flat bottom"
+          checked={false}
+          onChange={() => {}}
+          comingSoon
+        />
+      </div>
+    </CollapsibleSection>
+  );
+}

--- a/src/features/bin-designer/components/panel/ComingSoonSection.tsx
+++ b/src/features/bin-designer/components/panel/ComingSoonSection.tsx
@@ -1,0 +1,68 @@
+/**
+ * Coming Soon section: Teaser list of planned features.
+ *
+ * Organized into "Spec Features" (Gridfinity standard enhancements) and
+ * "Power Features" (advanced customization). Non-intrusive discovery
+ * for users who want to know what's next.
+ */
+
+import { CollapsibleSection } from '@/shared/components/CollapsibleSection';
+import { ComingSoonIcon } from './SectionIllustrations';
+
+interface PlannedFeature {
+  name: string;
+  description: string;
+}
+
+const SPEC_FEATURES: PlannedFeature[] = [
+  { name: 'Finger scoops', description: 'Ramp for easy part access per compartment' },
+  { name: 'Label tabs', description: 'Front-face text embossing for organization' },
+  { name: 'Wall cutouts', description: 'Per-side wall removal for access/visibility' },
+  { name: 'Flat bottom', description: 'Remove baseplate grid for flush surfaces' },
+  { name: 'Anti-slide notches', description: 'Lip notches to prevent bin sliding' },
+  { name: 'Magnet hole styles', description: 'Press-fit, glue-in, bridging-friendly' },
+];
+
+const POWER_FEATURES: PlannedFeature[] = [
+  { name: 'Floor inserts', description: 'Cut cavities into bin floor for tool holders' },
+  { name: 'Weighted base', description: 'Heavier base for stability without magnets' },
+  { name: 'Wall cutout shapes', description: 'Custom profiles beyond % removal' },
+  { name: 'Insert templates', description: 'Library of common tool holder shapes' },
+  { name: 'Multi-color export', description: 'Separate lip/body for MMU printing' },
+];
+
+function FeatureList({ title, features }: { title: string; features: PlannedFeature[] }) {
+  return (
+    <div>
+      <h4 className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-content-tertiary">
+        {title}
+      </h4>
+      <ul className="space-y-1.5">
+        {features.map((feature) => (
+          <li key={feature.name} className="flex items-start gap-2">
+            <span className="mt-0.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-accent/40" />
+            <div>
+              <span className="text-xs text-content-secondary">{feature.name}</span>
+              <span className="text-xs text-content-tertiary"> — {feature.description}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function ComingSoonSection() {
+  return (
+    <CollapsibleSection
+      title="Coming Soon"
+      defaultExpanded={false}
+      illustration={<ComingSoonIcon />}
+    >
+      <div className="space-y-4">
+        <FeatureList title="Spec Features" features={SPEC_FEATURES} />
+        <FeatureList title="Power Features" features={POWER_FEATURES} />
+      </div>
+    </CollapsibleSection>
+  );
+}

--- a/src/features/bin-designer/components/panel/DimensionsSection.tsx
+++ b/src/features/bin-designer/components/panel/DimensionsSection.tsx
@@ -1,0 +1,164 @@
+/**
+ * Dimensions section: Width, Depth, Height with stepper controls,
+ * half-bin mode toggle, and physical unit settings.
+ */
+
+import { useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { GRIDFINITY, DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
+import { CollapsibleSection } from '@/shared/components/CollapsibleSection';
+import { StepperControl } from '@/shared/components/StepperControl';
+import { Checkbox } from '@/shared/components/Checkbox';
+import { DimensionsIcon } from './SectionIllustrations';
+
+export function DimensionsSection() {
+  const { width, depth, height, gridUnitMm, heightUnitMm, halfBinMode, setParam, toggleHalfBinMode } =
+    useDesignerStore(
+      useShallow((s) => ({
+        width: s.params.width,
+        depth: s.params.depth,
+        height: s.params.height,
+        gridUnitMm: s.params.gridUnitMm,
+        heightUnitMm: s.params.heightUnitMm,
+        halfBinMode: s.ui.halfBinMode,
+        setParam: s.setParam,
+        toggleHalfBinMode: s.toggleHalfBinMode,
+      }))
+    );
+
+  // Step sizes depend on half-bin mode
+  const dimensionStep = halfBinMode ? 0.5 : 1;
+  const minDimension = halfBinMode ? 0.5 : 1;
+
+  // Physical mm calculations using per-bin unit settings
+  const widthMm = width * gridUnitMm;
+  const depthMm = depth * gridUnitMm;
+  const heightMm = height * heightUnitMm;
+
+  const summary = `${width}×${depth} × ${height}u (${widthMm.toFixed(0)}×${depthMm.toFixed(0)}×${heightMm.toFixed(0)}mm)`;
+
+  const handleWidthStep = useCallback(
+    (delta: number) => {
+      const next = width + delta * dimensionStep;
+      const clamped = Math.min(DESIGNER_CONSTRAINTS.MAX_DIMENSION, Math.max(minDimension, next));
+      setParam('width', clamped);
+    },
+    [width, dimensionStep, minDimension, setParam]
+  );
+
+  const handleDepthStep = useCallback(
+    (delta: number) => {
+      const next = depth + delta * dimensionStep;
+      const clamped = Math.min(DESIGNER_CONSTRAINTS.MAX_DIMENSION, Math.max(minDimension, next));
+      setParam('depth', clamped);
+    },
+    [depth, dimensionStep, minDimension, setParam]
+  );
+
+  const handleHeightStep = useCallback(
+    (delta: number) => {
+      const next = height + delta * DESIGNER_CONSTRAINTS.HEIGHT_STEP;
+      const clamped = Math.min(DESIGNER_CONSTRAINTS.MAX_HEIGHT, Math.max(DESIGNER_CONSTRAINTS.MIN_HEIGHT, next));
+      setParam('height', clamped);
+    },
+    [height, setParam]
+  );
+
+  return (
+    <CollapsibleSection
+      title="Dimensions"
+      defaultExpanded={true}
+      illustration={<DimensionsIcon />}
+      summary={summary}
+    >
+      <div className="space-y-3">
+        {/* Width */}
+        <div>
+          <div className="mb-1 flex items-center justify-between">
+            <span className="text-xs text-content-tertiary">Width</span>
+            <span className="text-[11px] tabular-nums text-content-tertiary">{widthMm.toFixed(0)}mm</span>
+          </div>
+          <StepperControl
+            value={width}
+            onChange={(v) => setParam('width', v)}
+            onStep={handleWidthStep}
+            min={minDimension}
+            max={DESIGNER_CONSTRAINTS.MAX_DIMENSION}
+            step={dimensionStep}
+            variant="compact"
+            ariaLabel="Width"
+          />
+        </div>
+
+        {/* Depth */}
+        <div>
+          <div className="mb-1 flex items-center justify-between">
+            <span className="text-xs text-content-tertiary">Depth</span>
+            <span className="text-[11px] tabular-nums text-content-tertiary">{depthMm.toFixed(0)}mm</span>
+          </div>
+          <StepperControl
+            value={depth}
+            onChange={(v) => setParam('depth', v)}
+            onStep={handleDepthStep}
+            min={minDimension}
+            max={DESIGNER_CONSTRAINTS.MAX_DIMENSION}
+            step={dimensionStep}
+            variant="compact"
+            ariaLabel="Depth"
+          />
+        </div>
+
+        {/* Height */}
+        <div>
+          <div className="mb-1 flex items-center justify-between">
+            <span className="text-xs text-content-tertiary">Height</span>
+            <span className="text-[11px] tabular-nums text-content-tertiary">
+              {heightMm.toFixed(0)}mm body + {GRIDFINITY.LIP_HEIGHT}mm lip
+            </span>
+          </div>
+          <StepperControl
+            value={height}
+            onChange={(v) => setParam('height', v)}
+            onStep={handleHeightStep}
+            min={DESIGNER_CONSTRAINTS.MIN_HEIGHT}
+            max={DESIGNER_CONSTRAINTS.MAX_HEIGHT}
+            step={DESIGNER_CONSTRAINTS.HEIGHT_STEP}
+            variant="compact"
+            ariaLabel="Height"
+          />
+        </div>
+
+        {/* Half-bin mode toggle */}
+        <div
+          className="flex items-center justify-between pt-2 cursor-pointer"
+          onClick={toggleHalfBinMode}
+          role="checkbox"
+          aria-checked={halfBinMode}
+          aria-label="Toggle half-bin mode"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === ' ' || e.key === 'Enter') {
+              e.preventDefault();
+              toggleHalfBinMode();
+            }
+          }}
+        >
+          <div className="flex items-center gap-1.5">
+            <span
+              className={`text-xs leading-none ${halfBinMode ? 'text-content' : 'text-content-tertiary'}`}
+              title="Enable 0.5 grid unit precision for half-size bins"
+            >
+              Half-bin mode
+            </span>
+            <span className="text-[9px] leading-none text-warning bg-warning-muted px-1 py-0.5 rounded">
+              experimental
+            </span>
+          </div>
+          <Checkbox checked={halfBinMode} variant="desktop" />
+        </div>
+
+      </div>
+    </CollapsibleSection>
+  );
+}

--- a/src/features/bin-designer/components/panel/FeatureToggle.tsx
+++ b/src/features/bin-designer/components/panel/FeatureToggle.tsx
@@ -1,0 +1,108 @@
+/**
+ * Feature toggle with "Customize" inline expand pattern.
+ *
+ * Shows a toggle switch with optional default value summary.
+ * When enabled, optionally shows a "Customize" link that reveals
+ * detailed sub-controls inline below the toggle.
+ */
+
+import { useState, useId, type ReactNode } from 'react';
+
+interface FeatureToggleProps {
+  /** Display label for the feature */
+  label: string;
+  /** Whether the feature is enabled */
+  checked: boolean;
+  /** Called when toggle changes */
+  onChange: () => void;
+  /** Brief summary of current value shown when enabled (e.g., "6.5mm × 2mm") */
+  valueSummary?: string;
+  /** Detailed controls shown when "Customize" is clicked */
+  children?: ReactNode;
+  /** Whether this feature is coming soon (shows badge, disables toggle) */
+  comingSoon?: boolean;
+}
+
+export function FeatureToggle({
+  label,
+  checked,
+  onChange,
+  valueSummary,
+  children,
+  comingSoon = false,
+}: FeatureToggleProps) {
+  const [customizeOpen, setCustomizeOpen] = useState(false);
+  const contentId = useId();
+
+  return (
+    <div>
+      {/* Toggle row */}
+      <div className="flex items-center justify-between py-1.5">
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-content-secondary">{label}</span>
+          {comingSoon && (
+            <span className="rounded-full bg-surface-tertiary px-1.5 py-0.5 text-[10px] font-medium text-content-tertiary">
+              Soon
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={checked}
+          aria-label={label}
+          onClick={onChange}
+          disabled={comingSoon}
+          className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+            comingSoon
+              ? 'cursor-not-allowed bg-stroke-subtle opacity-50'
+              : checked
+                ? 'bg-accent'
+                : 'bg-stroke-subtle'
+          }`}
+        >
+          <span
+            className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow-sm transition-transform ${
+              checked ? 'translate-x-4' : 'translate-x-0.5'
+            }`}
+          />
+        </button>
+      </div>
+
+      {/* Value summary + Customize link (shown when enabled and has children) */}
+      {checked && !comingSoon && children && (
+        <div className="ml-1 mt-0.5">
+          <div className="flex items-center gap-2">
+            {valueSummary && !customizeOpen && (
+              <span className="text-[11px] text-content-tertiary">{valueSummary}</span>
+            )}
+            <button
+              type="button"
+              onClick={() => setCustomizeOpen(!customizeOpen)}
+              aria-expanded={customizeOpen}
+              aria-controls={contentId}
+              className="text-[11px] font-medium text-accent hover:text-accent/80 transition-colors"
+            >
+              {customizeOpen ? 'Done' : 'Customize'}
+            </button>
+          </div>
+
+          {/* Inline expand for detailed controls */}
+          <div
+            id={contentId}
+            role="region"
+            aria-label={`${label} settings`}
+            aria-hidden={!customizeOpen}
+            className={`overflow-hidden transition-all duration-200 ${
+              customizeOpen ? 'opacity-100 max-h-[500px] mt-2' : 'opacity-0 max-h-0'
+            }`}
+          >
+            <div className="space-y-3 border-l-2 border-accent/20 pl-3 pb-1">
+              {children}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/panel/InteriorSection.tsx
+++ b/src/features/bin-designer/components/panel/InteriorSection.tsx
@@ -1,0 +1,34 @@
+/**
+ * Interior section: Compartment grid editor.
+ *
+ * Embeds the existing CompartmentEditor for configuring the bin's
+ * internal compartment layout. Scoop and label features are not yet
+ * supported by the generator.
+ */
+
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { CollapsibleSection } from '@/shared/components/CollapsibleSection';
+import { CompartmentEditor } from '../CompartmentEditor';
+import { InteriorIcon } from './SectionIllustrations';
+import { getCompartmentCount } from '../../utils/compartments';
+
+export function InteriorSection() {
+  const compartments = useDesignerStore(
+    useShallow((s) => s.params.compartments)
+  );
+
+  const compartmentCount = getCompartmentCount(compartments);
+  const summary = `${compartmentCount} ${compartmentCount === 1 ? 'compartment' : 'compartments'}`;
+
+  return (
+    <CollapsibleSection
+      title="Interior"
+      defaultExpanded={true}
+      illustration={<InteriorIcon />}
+      summary={summary}
+    >
+      <CompartmentEditor />
+    </CollapsibleSection>
+  );
+}

--- a/src/features/bin-designer/components/panel/PhysicalUnitsSection.tsx
+++ b/src/features/bin-designer/components/panel/PhysicalUnitsSection.tsx
@@ -1,0 +1,70 @@
+/**
+ * Physical Units section: Grid unit (mm) and Height unit (mm) settings.
+ *
+ * These rarely change (standard Gridfinity uses 42mm grid, 7mm height unit)
+ * so this section is collapsed by default, placed near the bottom of the panel.
+ */
+
+import { useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { CollapsibleSection } from '@/shared/components/CollapsibleSection';
+import { SettingsRow } from '@/shared/components/SettingsRow';
+import { DeferredNumberInput } from '@/shared/components/DeferredNumberInput';
+
+export function PhysicalUnitsSection() {
+  const { gridUnitMm, heightUnitMm, setParam } = useDesignerStore(
+    useShallow((s) => ({
+      gridUnitMm: s.params.gridUnitMm,
+      heightUnitMm: s.params.heightUnitMm,
+      setParam: s.setParam,
+    }))
+  );
+
+  const handleGridUnitChange = useCallback(
+    (value: number) => {
+      setParam('gridUnitMm', value);
+    },
+    [setParam]
+  );
+
+  const handleHeightUnitChange = useCallback(
+    (value: number) => {
+      setParam('heightUnitMm', value);
+    },
+    [setParam]
+  );
+
+  const summary = `${gridUnitMm}mm grid, ${heightUnitMm}mm height`;
+
+  return (
+    <CollapsibleSection
+      title="Physical Units"
+      defaultExpanded={false}
+      summary={summary}
+    >
+      <div className="space-y-2">
+        <SettingsRow label="Grid unit" tooltip="Size of one grid unit in mm (standard Gridfinity = 42mm)" unit="mm">
+          <DeferredNumberInput
+            value={gridUnitMm}
+            onChange={handleGridUnitChange}
+            min={1}
+            max={200}
+            className="input w-14 py-0.5 px-1 text-xs text-right"
+            aria-label="Grid unit"
+          />
+        </SettingsRow>
+        <SettingsRow label="Height unit" tooltip="Size of one height unit in mm (standard Gridfinity = 7mm)" unit="mm">
+          <DeferredNumberInput
+            value={heightUnitMm}
+            onChange={handleHeightUnitChange}
+            min={1}
+            max={50}
+            className="input w-14 py-0.5 px-1 text-xs text-right"
+            aria-label="Height unit"
+          />
+        </SettingsRow>
+      </div>
+    </CollapsibleSection>
+  );
+}

--- a/src/features/bin-designer/components/panel/SectionIllustrations.tsx
+++ b/src/features/bin-designer/components/panel/SectionIllustrations.tsx
@@ -1,0 +1,91 @@
+/**
+ * Mini SVG illustrations for panel section headers.
+ *
+ * Each is a 16×16 simplified diagram showing what the section controls
+ * on the bin. Uses currentColor for theme consistency.
+ */
+
+/** 3D cube wireframe representing bin dimensions */
+export function DimensionsIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
+      {/* Front face */}
+      <rect x="3" y="5" width="8" height="8" rx="0.5" />
+      {/* Top face (isometric) */}
+      <path d="M3 5 L6 2 L14 2 L11 5" />
+      {/* Right face (isometric) */}
+      <path d="M11 5 L14 2 L14 10 L11 13" />
+    </svg>
+  );
+}
+
+/** Bottom profile showing magnet holes and baseplate interface */
+export function BaseIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
+      {/* Bin body outline */}
+      <path d="M2 4 L2 12 L14 12 L14 4" />
+      {/* Base profile step */}
+      <path d="M2 12 L3 14 L13 14 L14 12" />
+      {/* Magnet holes */}
+      <circle cx="5.5" cy="13" r="1" />
+      <circle cx="10.5" cy="13" r="1" />
+    </svg>
+  );
+}
+
+/** Cross-section showing compartment dividers */
+export function InteriorIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
+      {/* Outer bin walls */}
+      <rect x="2" y="3" width="12" height="10" rx="0.5" />
+      {/* Vertical divider */}
+      <line x1="8" y1="3" x2="8" y2="13" />
+      {/* Horizontal divider */}
+      <line x1="2" y1="8" x2="8" y2="8" />
+      {/* Scoop curve (front-right compartment) */}
+      <path d="M9 13 Q9 10 12 10" />
+    </svg>
+  );
+}
+
+/** Bin shell outline showing wall thickness */
+export function WallsIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
+      {/* Outer wall */}
+      <rect x="2" y="3" width="12" height="10" rx="0.5" />
+      {/* Inner wall (showing thickness) */}
+      <rect x="4" y="5" width="8" height="6" rx="0.5" strokeDasharray="2 1" />
+      {/* Wall cutout indicator (front) */}
+      <path d="M6 13 L6 11 L10 11 L10 13" strokeWidth="1.5" />
+    </svg>
+  );
+}
+
+/** Circle cut into bin floor representing inserts */
+export function InsertsIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
+      {/* Bin floor (top-down view) */}
+      <rect x="2" y="2" width="12" height="12" rx="1" />
+      {/* Circular insert */}
+      <circle cx="6.5" cy="6.5" r="2.5" />
+      {/* Rectangular insert */}
+      <rect x="10" y="9" width="3" height="4" rx="0.5" />
+    </svg>
+  );
+}
+
+/** Sparkle/star icon for coming soon features */
+export function ComingSoonIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
+      {/* Four-point star */}
+      <path d="M8 2 L9 6 L13 7 L9 8 L8 13 L7 8 L3 7 L7 6 Z" />
+      {/* Small sparkle */}
+      <path d="M12 3 L12.5 4 L13.5 4.5 L12.5 5 L12 6 L11.5 5 L10.5 4.5 L11.5 4 Z" strokeWidth="0.8" />
+    </svg>
+  );
+}

--- a/src/features/bin-designer/components/panel/WallsSection.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection.tsx
@@ -1,0 +1,38 @@
+/**
+ * Walls section: Wall thickness selector.
+ *
+ * Shows discrete wall thickness options (multiples of common FDM nozzle sizes).
+ * Wall cutouts and style variants are not yet supported by the generator.
+ */
+
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { CollapsibleSection } from '@/shared/components/CollapsibleSection';
+import { ThicknessSelector } from '../controls/ThicknessSelector';
+import { WallsIcon } from './SectionIllustrations';
+
+export function WallsSection() {
+  const { wallThickness, setParam } = useDesignerStore(
+    useShallow((s) => ({
+      wallThickness: s.params.wallThickness,
+      setParam: s.setParam,
+    }))
+  );
+
+  const summary = `${wallThickness}mm`;
+
+  return (
+    <CollapsibleSection
+      title="Walls"
+      defaultExpanded={true}
+      illustration={<WallsIcon />}
+      summary={summary}
+    >
+      <ThicknessSelector
+        label="Wall thickness"
+        value={wallThickness}
+        onChange={(v) => setParam('wallThickness', v)}
+      />
+    </CollapsibleSection>
+  );
+}

--- a/src/features/bin-designer/components/preview/BinAxisLabels.tsx
+++ b/src/features/bin-designer/components/preview/BinAxisLabels.tsx
@@ -1,0 +1,165 @@
+/**
+ * Grid axis labels for the bin designer 3D preview.
+ *
+ * Renders numbered column (X) and row (Y) labels along the bin's footprint edges,
+ * with tick marks at cell boundaries. Adapted from the layout planner's AxisLabels
+ * but operating in mm-space with the bin centered at origin.
+ *
+ * X-axis labels: along the front edge (negative Y), numbered left to right
+ * Y-axis labels: along the left edge (negative X), numbered front to back
+ *
+ * Supports half-bin fractional dimensions (shows "+.5" for fractional cells).
+ */
+
+import { useMemo, useEffect } from 'react';
+import { Text } from '@react-three/drei';
+import * as THREE from 'three';
+import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
+
+interface BinAxisLabelsProps {
+  /** Bin width in grid units (can be fractional for half-bin mode) */
+  width: number;
+  /** Bin depth in grid units (can be fractional for half-bin mode) */
+  depth: number;
+}
+
+// Styling constants matched to planner's AxisLabels proportions
+// (planner values × GRID_SIZE, scaled for typical 2–4 unit bins)
+const LABEL_COLOR = '#ffffff';
+const LABEL_OPACITY = 0.45;
+const FRACTIONAL_LABEL_OPACITY = 0.35;
+const FONT_SIZE = 4; // mm (planner: 0.28 units)
+const FRACTIONAL_FONT_SIZE = 3.2; // mm (planner: 0.22 units)
+const TICK_SIZE = 3; // mm — outward from edge (planner: 0.08 units)
+const TICK_OPACITY = 0.3;
+const LABEL_OFFSET = 5; // mm from bin edge to label anchor (planner: 0.28 units)
+const TICK_OFFSET = 0.5; // mm above Z=0 to avoid z-fighting with floor
+
+/**
+ * Grid axis labels showing column/row numbers along bin edges.
+ * Matches the architectural drawing style of the layout planner.
+ */
+export function BinAxisLabels({ width, depth }: BinAxisLabelsProps) {
+  const GS = GRIDFINITY.GRID_SIZE; // 42mm
+
+  const halfW = (width * GS) / 2;
+  const halfD = (depth * GS) / 2;
+
+  const integerWidth = Math.floor(width);
+  const integerDepth = Math.floor(depth);
+  const hasFractionalWidth = width % 1 !== 0;
+  const hasFractionalDepth = depth % 1 !== 0;
+
+  // Build X-axis labels (columns)
+  const xLabels: { value: number; isFractional: boolean }[] = [];
+  for (let i = 1; i <= integerWidth; i++) {
+    xLabels.push({ value: i, isFractional: false });
+  }
+  if (hasFractionalWidth) {
+    xLabels.push({ value: width, isFractional: true });
+  }
+
+  // Build Y-axis labels (rows)
+  const yLabels: { value: number; isFractional: boolean }[] = [];
+  for (let i = 1; i <= integerDepth; i++) {
+    yLabels.push({ value: i, isFractional: false });
+  }
+  if (hasFractionalDepth) {
+    yLabels.push({ value: depth, isFractional: true });
+  }
+
+  // Create tick mark geometry at cell boundaries
+  const tickGeometry = useMemo(() => {
+    const positions: number[] = [];
+
+    // X-axis ticks along the front edge — outward only (matching planner)
+    for (let i = 0; i <= integerWidth; i++) {
+      const x = -halfW + i * GS;
+      positions.push(x, -halfD, TICK_OFFSET);
+      positions.push(x, -halfD - TICK_SIZE, TICK_OFFSET);
+    }
+    if (hasFractionalWidth) {
+      positions.push(halfW, -halfD, TICK_OFFSET);
+      positions.push(halfW, -halfD - TICK_SIZE, TICK_OFFSET);
+    }
+
+    // Y-axis ticks along the left edge — outward only (matching planner)
+    for (let i = 0; i <= integerDepth; i++) {
+      const y = -halfD + i * GS;
+      positions.push(-halfW, y, TICK_OFFSET);
+      positions.push(-halfW - TICK_SIZE, y, TICK_OFFSET);
+    }
+    if (hasFractionalDepth) {
+      positions.push(-halfW, halfD, TICK_OFFSET);
+      positions.push(-halfW - TICK_SIZE, halfD, TICK_OFFSET);
+    }
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    return geo;
+  }, [halfW, halfD, integerWidth, integerDepth, hasFractionalWidth, hasFractionalDepth, GS]);
+
+  // Cleanup geometry on unmount or change
+  useEffect(() => {
+    return () => {
+      tickGeometry.dispose();
+    };
+  }, [tickGeometry]);
+
+  return (
+    <group>
+      {/* Tick marks */}
+      <lineSegments geometry={tickGeometry}>
+        <lineBasicMaterial color={LABEL_COLOR} transparent opacity={TICK_OPACITY} />
+      </lineSegments>
+
+      {/* X-axis labels (columns) — along front edge */}
+      {xLabels.map(({ value, isFractional }, idx) => {
+        // Center label in its grid cell
+        const xPos = isFractional
+          ? -halfW + (integerWidth + (width - integerWidth) / 2) * GS
+          : -halfW + (value - 0.5) * GS;
+        const yPos = -halfD - LABEL_OFFSET;
+        const label = isFractional ? '+.5' : value.toString();
+
+        return (
+          <Text
+            key={`x-${idx}`}
+            position={[xPos, yPos, TICK_OFFSET]}
+            fontSize={isFractional ? FRACTIONAL_FONT_SIZE : FONT_SIZE}
+            color={LABEL_COLOR}
+            fillOpacity={isFractional ? FRACTIONAL_LABEL_OPACITY : LABEL_OPACITY}
+            anchorX="center"
+            anchorY="top"
+          >
+            {label}
+          </Text>
+        );
+      })}
+
+      {/* Y-axis labels (rows) — along left edge */}
+      {yLabels.map(({ value, isFractional }, idx) => {
+        // Center label in its grid cell
+        const yPos = isFractional
+          ? -halfD + (integerDepth + (depth - integerDepth) / 2) * GS
+          : -halfD + (value - 0.5) * GS;
+        const xPos = -halfW - LABEL_OFFSET;
+        const label = isFractional ? '+.5' : value.toString();
+
+        return (
+          <Text
+            key={`y-${idx}`}
+            position={[xPos, yPos, TICK_OFFSET]}
+            fontSize={isFractional ? FRACTIONAL_FONT_SIZE : FONT_SIZE}
+            color={LABEL_COLOR}
+            fillOpacity={isFractional ? FRACTIONAL_LABEL_OPACITY : LABEL_OPACITY}
+            anchorX="right"
+            anchorY="middle"
+          >
+            {label}
+          </Text>
+        );
+      })}
+    </group>
+  );
+}

--- a/src/features/bin-designer/components/preview/BinDimensions.tsx
+++ b/src/features/bin-designer/components/preview/BinDimensions.tsx
@@ -1,0 +1,230 @@
+/**
+ * Architectural dimension lines for the bin designer 3D preview.
+ *
+ * Shows width, depth, and height annotations with end caps and centered labels.
+ * Positioned just outside the bin's bounding box, matching the visual style
+ * of DrawerDimensions in the layout planner's IsometricPreview.
+ *
+ * The bin mesh is centered at origin (0,0) in XY with base at Z≈0.
+ * All coordinates are in millimeters (scene unit = mm).
+ */
+
+import { Line, Text } from '@react-three/drei';
+import { useMemo } from 'react';
+import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
+
+interface BinDimensionsProps {
+  /** Bin width in grid units */
+  width: number;
+  /** Bin depth in grid units */
+  depth: number;
+  /** Bin height in height units */
+  height: number;
+  /** Grid unit size in mm (for label text) */
+  gridUnitMm: number;
+  /** Height unit size in mm (for label text) */
+  heightUnitMm: number;
+  /** Whether stacking lip is enabled (adds LIP_HEIGHT to total height) */
+  stackingLip: boolean;
+}
+
+// Layout constants matched to planner's DrawerDimensions proportions
+// (planner: OFFSET=0.8, END_CAP=0.15, FONT_SIZE=0.32, label_gap=0.3)
+const OFFSET = 14; // Distance from bin edge to dimension line
+const END_CAP = 2; // Length of end cap markers
+const LABEL_GAP = 4; // Additional offset from line to label text
+const LINE_COLOR = '#ffffff';
+const LINE_OPACITY = 0.5;
+const TEXT_OPACITY = 0.7;
+const FONT_SIZE = 4.5;
+
+/**
+ * Dimension lines showing bin width, depth, and height in mm.
+ * Matches the architectural drawing style from the layout planner.
+ */
+export function BinDimensions({
+  width,
+  depth,
+  height,
+  gridUnitMm,
+  heightUnitMm,
+  stackingLip,
+}: BinDimensionsProps) {
+  // Bin extents in mm (mesh is centered at origin)
+  const outerW = width * GRIDFINITY.GRID_SIZE;
+  const outerD = depth * GRIDFINITY.GRID_SIZE;
+  const lipHeight = stackingLip ? GRIDFINITY.LIP_HEIGHT : 0;
+  const totalH = height * GRIDFINITY.HEIGHT_UNIT + lipHeight;
+
+  // Display labels use the user's configured unit sizes
+  const widthMm = Math.round(width * gridUnitMm);
+  const depthMm = Math.round(depth * gridUnitMm);
+  const heightMm = Math.round(height * heightUnitMm + lipHeight);
+
+  const dimensions = useMemo(() => {
+    const halfW = outerW / 2;
+    const halfD = outerD / 2;
+
+    return {
+      // Width: along front edge, offset in -Y direction
+      width: {
+        start: [-halfW, -halfD - OFFSET, 0] as [number, number, number],
+        end: [halfW, -halfD - OFFSET, 0] as [number, number, number],
+        labelPos: [0, -halfD - OFFSET - LABEL_GAP, 0] as [number, number, number],
+        label: `${widthMm}mm`,
+        endCaps: {
+          left: [
+            [-halfW, -halfD - OFFSET - END_CAP, 0],
+            [-halfW, -halfD - OFFSET + END_CAP, 0],
+          ] as [[number, number, number], [number, number, number]],
+          right: [
+            [halfW, -halfD - OFFSET - END_CAP, 0],
+            [halfW, -halfD - OFFSET + END_CAP, 0],
+          ] as [[number, number, number], [number, number, number]],
+        },
+      },
+      // Depth: along left edge, offset in -X direction
+      depth: {
+        start: [-halfW - OFFSET, -halfD, 0] as [number, number, number],
+        end: [-halfW - OFFSET, halfD, 0] as [number, number, number],
+        labelPos: [-halfW - OFFSET - LABEL_GAP, 0, 0] as [number, number, number],
+        label: `${depthMm}mm`,
+        endCaps: {
+          left: [
+            [-halfW - OFFSET - END_CAP, -halfD, 0],
+            [-halfW - OFFSET + END_CAP, -halfD, 0],
+          ] as [[number, number, number], [number, number, number]],
+          right: [
+            [-halfW - OFFSET - END_CAP, halfD, 0],
+            [-halfW - OFFSET + END_CAP, halfD, 0],
+          ] as [[number, number, number], [number, number, number]],
+        },
+      },
+      // Height: vertical at back-left corner, offset from both edges
+      height: {
+        start: [-halfW - OFFSET, halfD + OFFSET, 0] as [number, number, number],
+        end: [-halfW - OFFSET, halfD + OFFSET, totalH] as [number, number, number],
+        labelPos: [-halfW - OFFSET - LABEL_GAP, halfD + OFFSET, totalH / 2] as [
+          number,
+          number,
+          number,
+        ],
+        label: `${heightMm}mm`,
+        endCaps: {
+          bottom: [
+            [-halfW - OFFSET - END_CAP, halfD + OFFSET, 0],
+            [-halfW - OFFSET + END_CAP, halfD + OFFSET, 0],
+          ] as [[number, number, number], [number, number, number]],
+          top: [
+            [-halfW - OFFSET - END_CAP, halfD + OFFSET, totalH],
+            [-halfW - OFFSET + END_CAP, halfD + OFFSET, totalH],
+          ] as [[number, number, number], [number, number, number]],
+        },
+      },
+    };
+  }, [outerW, outerD, totalH, widthMm, depthMm, heightMm]);
+
+  return (
+    <group>
+      {/* Width dimension line */}
+      <Line
+        points={[dimensions.width.start, dimensions.width.end]}
+        color={LINE_COLOR}
+        lineWidth={1}
+        transparent
+        opacity={LINE_OPACITY}
+      />
+      <Line
+        points={dimensions.width.endCaps.left}
+        color={LINE_COLOR}
+        lineWidth={1}
+        transparent
+        opacity={LINE_OPACITY}
+      />
+      <Line
+        points={dimensions.width.endCaps.right}
+        color={LINE_COLOR}
+        lineWidth={1}
+        transparent
+        opacity={LINE_OPACITY}
+      />
+      <Text
+        position={dimensions.width.labelPos}
+        fontSize={FONT_SIZE}
+        color={LINE_COLOR}
+        fillOpacity={TEXT_OPACITY}
+        anchorX="center"
+        anchorY="top"
+      >
+        {dimensions.width.label}
+      </Text>
+
+      {/* Depth dimension line */}
+      <Line
+        points={[dimensions.depth.start, dimensions.depth.end]}
+        color={LINE_COLOR}
+        lineWidth={1}
+        transparent
+        opacity={LINE_OPACITY}
+      />
+      <Line
+        points={dimensions.depth.endCaps.left}
+        color={LINE_COLOR}
+        lineWidth={1}
+        transparent
+        opacity={LINE_OPACITY}
+      />
+      <Line
+        points={dimensions.depth.endCaps.right}
+        color={LINE_COLOR}
+        lineWidth={1}
+        transparent
+        opacity={LINE_OPACITY}
+      />
+      <Text
+        position={dimensions.depth.labelPos}
+        fontSize={FONT_SIZE}
+        color={LINE_COLOR}
+        fillOpacity={TEXT_OPACITY}
+        anchorX="right"
+        anchorY="middle"
+        rotation={[0, 0, Math.PI / 2]}
+      >
+        {dimensions.depth.label}
+      </Text>
+
+      {/* Height dimension line */}
+      <Line
+        points={[dimensions.height.start, dimensions.height.end]}
+        color={LINE_COLOR}
+        lineWidth={1}
+        transparent
+        opacity={LINE_OPACITY}
+      />
+      <Line
+        points={dimensions.height.endCaps.bottom}
+        color={LINE_COLOR}
+        lineWidth={1}
+        transparent
+        opacity={LINE_OPACITY}
+      />
+      <Line
+        points={dimensions.height.endCaps.top}
+        color={LINE_COLOR}
+        lineWidth={1}
+        transparent
+        opacity={LINE_OPACITY}
+      />
+      <Text
+        position={dimensions.height.labelPos}
+        fontSize={FONT_SIZE}
+        color={LINE_COLOR}
+        fillOpacity={TEXT_OPACITY}
+        anchorX="right"
+        anchorY="middle"
+      >
+        {dimensions.height.label}
+      </Text>
+    </group>
+  );
+}

--- a/src/features/bin-designer/components/preview/BinNameLabel.tsx
+++ b/src/features/bin-designer/components/preview/BinNameLabel.tsx
@@ -1,0 +1,53 @@
+/**
+ * Renders the bin design name on the floor in front of the bin,
+ * matching the FrontLabel style from the layout planner's 3D preview.
+ *
+ * Positioned below the width dimension line for a technical drawing aesthetic.
+ */
+
+import { Text } from '@react-three/drei';
+import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
+
+interface BinNameLabelProps {
+  /** Bin width in grid units (for centering) */
+  width: number;
+  /** Bin depth in grid units (for vertical positioning relative to bin edge) */
+  depth: number;
+  /** Design name to display */
+  name: string;
+}
+
+const TEXT_COLOR = '#ffffff';
+const TEXT_OPACITY = 0.6;
+const FONT_SIZE = 7; // mm (planner: 0.5 units)
+const LETTER_SPACING = 0.08;
+/** Distance from bin front edge to label center (mm) */
+const FRONT_OFFSET = 32;
+
+/**
+ * Bin name label displayed on the floor in front of the bin.
+ * Uppercase text centered on the bin's width.
+ */
+export function BinNameLabel({ width, depth, name }: BinNameLabelProps) {
+  if (!name.trim()) return null;
+
+  const outerW = width * GRIDFINITY.GRID_SIZE;
+  const halfD = (depth * GRIDFINITY.GRID_SIZE) / 2;
+
+  const textY = -halfD - FRONT_OFFSET;
+
+  return (
+    <Text
+      position={[0, textY, 0.01]}
+      fontSize={FONT_SIZE}
+      color={TEXT_COLOR}
+      fillOpacity={TEXT_OPACITY}
+      anchorX="center"
+      anchorY="middle"
+      letterSpacing={LETTER_SPACING}
+      maxWidth={outerW * 1.5}
+    >
+      {name.toUpperCase()}
+    </Text>
+  );
+}

--- a/src/features/bin-designer/components/preview/index.ts
+++ b/src/features/bin-designer/components/preview/index.ts
@@ -1,4 +1,7 @@
 export { BinMesh } from './BinMesh';
+export { BinAxisLabels } from './BinAxisLabels';
+export { BinDimensions } from './BinDimensions';
+export { BinNameLabel } from './BinNameLabel';
 export { PreviewControls, type CameraPreset } from './PreviewControls';
 export { PreviewSkeleton } from './PreviewSkeleton';
 export { GradientBackground } from './GradientBackground';

--- a/src/features/bin-designer/constants/defaults.ts
+++ b/src/features/bin-designer/constants/defaults.ts
@@ -9,6 +9,8 @@ export const DEFAULT_BIN_PARAMS: BinParams = {
   width: 2,
   depth: 2,
   height: 3,
+  gridUnitMm: 42,
+  heightUnitMm: 7,
   wallThickness: 1.2,
   base: {
     style: 'standard',
@@ -56,6 +58,7 @@ export const DEFAULT_UI_STATE: DesignerUIState = {
   exportDialogOpen: false,
   designListOpen: false,
   wireframeMode: false,
+  halfBinMode: false,
 } as const;
 
 /** Default empty history */

--- a/src/features/bin-designer/store/designer.ts
+++ b/src/features/bin-designer/store/designer.ts
@@ -334,5 +334,21 @@ export const useDesignerStore = create<DesignerState>()(
         state.ui.wireframeMode = enabled;
       });
     },
+
+    toggleHalfBinMode: () => {
+      set((state) => {
+        const enabling = !state.ui.halfBinMode;
+        if (!enabling) {
+          // Disabling: round fractional dimensions to nearest integer
+          if (state.params.width % 1 !== 0) {
+            state.params.width = Math.ceil(state.params.width);
+          }
+          if (state.params.depth % 1 !== 0) {
+            state.params.depth = Math.ceil(state.params.depth);
+          }
+        }
+        state.ui.halfBinMode = enabling;
+      });
+    },
   }))
 );

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -87,6 +87,10 @@ export interface BinParams {
   readonly width: number;
   readonly depth: number;
   readonly height: number;
+  /** Grid unit size in mm (default 42mm per Gridfinity spec) */
+  readonly gridUnitMm: number;
+  /** Height unit size in mm (default 7mm per Gridfinity spec) */
+  readonly heightUnitMm: number;
   /** Wall thickness in mm (default 1.2). Ignored when style is 'solid'. */
   readonly wallThickness: number;
   readonly base: BaseConfig;
@@ -169,6 +173,8 @@ export interface DesignerUIState {
   readonly exportDialogOpen: boolean;
   readonly designListOpen: boolean;
   readonly wireframeMode: boolean;
+  /** Whether half-bin mode is enabled (0.5 grid unit increments for width/depth) */
+  readonly halfBinMode: boolean;
 }
 
 /** Undo/redo history for bin parameters */
@@ -248,6 +254,7 @@ export interface DesignerState {
   setExportDialogOpen: (open: boolean) => void;
   setDesignListOpen: (open: boolean) => void;
   setWireframeMode: (enabled: boolean) => void;
+  toggleHalfBinMode: () => void;
 }
 
 // =============================================================================

--- a/src/shared/components/CollapsibleSection/CollapsibleSection.tsx
+++ b/src/shared/components/CollapsibleSection/CollapsibleSection.tsx
@@ -13,6 +13,10 @@ interface CollapsibleSectionProps {
   actions?: ReactNode;
   /** Size variant for the header */
   variant?: 'default' | 'small';
+  /** Optional illustration icon shown before the title */
+  illustration?: ReactNode;
+  /** Optional summary shown when section is collapsed (e.g., "2×2×3u") */
+  summary?: ReactNode;
 }
 
 /**
@@ -26,6 +30,8 @@ export function CollapsibleSection({
   badge,
   actions,
   variant = 'default',
+  illustration,
+  summary,
 }: CollapsibleSectionProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   // Track if user has toggled - only animate after first interaction to prevent CLS
@@ -58,11 +64,19 @@ export function CollapsibleSection({
           >
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
           </svg>
+          {illustration && (
+            <span className="flex-shrink-0 text-content-tertiary">{illustration}</span>
+          )}
           <span className={headerClass}>{title}</span>
           {badge}
         </button>
         {actions}
       </div>
+      {summary && !expanded && (
+        <div className="mt-1 ml-[22px] text-xs text-content-tertiary truncate">
+          {summary}
+        </div>
+      )}
       <div
         id={contentId}
         role="region"


### PR DESCRIPTION
## Summary
- Redesign parameter panel from tabbed layout to scrollable collapsible sections with section illustrations
- Add half-bin mode toggle (0.5 grid-unit precision) and configurable physical unit settings
- Add 3D preview enhancements: dimension lines, grid axis labels, and design name on floor
- Match sidebar width and annotation proportions to the layout planner mode
- Fix compartment grid orientation to match the 3D preview's spatial layout

## Changes

### Parameter Panel Redesign
- Replace tabbed ParameterPanel with independently-collapsible sections: Dimensions, Base, Walls, Interior, Physical Units, Coming Soon
- Each section uses `useShallow` store subscription for minimal re-renders
- Add `FeatureToggle` for binary settings with icon/label/description
- Extend `CollapsibleSection` with `summary` and `illustration` props
- Add section illustrations (SVG icons for each panel section)

### Half-Bin Mode & Physical Units
- Add `halfBinMode` UI state and `toggleHalfBinMode` action (auto-rounds fractional dims on disable)
- Add `gridUnitMm` and `heightUnitMm` to `BinParams` (default: 42mm/7mm)
- Create dedicated `PhysicalUnitsSection` (collapsed by default, rarely changed)
- DimensionsSection respects half-bin mode for step sizes and min values

### 3D Preview Enhancements
- `BinDimensions`: Architectural dimension lines (width/depth/height with end caps) accounting for stacking lip
- `BinAxisLabels`: Numbered grid column/row labels with tick marks, supporting fractional dimensions
- `BinNameLabel`: Design name displayed on the floor in front of the bin
- All proportions matched to the layout planner's `DrawerDimensions`/`AxisLabels`/`FrontLabel`

### Other
- Sidebar width: `w-80` (320px) → `w-72` (288px) to match planner
- CompartmentEditor: `scaleY(-1)` on grid to match 3D preview orientation (front = bottom)
- StepperControl for discrete integer inputs (Columns, Rows), sliders kept for continuous values

## Test plan
- [x] Build succeeds (`npm run build`)
- [x] All 557 bin-designer tests pass
- [ ] Manual: verify collapsible sections expand/collapse with summaries
- [ ] Manual: verify half-bin mode toggle enables 0.5 step precision
- [ ] Manual: verify 3D preview shows dimension lines, axis labels, and design name
- [ ] Manual: verify compartment grid orientation matches 3D preview