### PR TITLE
fix(bin-designer): prevent unwanted 'Untitled Bin' entries in My Designs

### DIFF
--- a/src/features/bin-designer/__tests__/hooks/useAutoSave.test.ts
+++ b/src/features/bin-designer/__tests__/hooks/useAutoSave.test.ts
@@ -30,22 +30,9 @@ describe('useAutoSave', () => {
     vi.useRealTimers();
   });
 
-  function mockSaveDesign(id: string = 'new-id-123') {
+  function mockUpdateDesignParams(id: string = 'existing-id') {
     const savedDesign: SavedDesign = {
       id,
-      name: 'Untitled Bin',
-      params: DEFAULT_BIN_PARAMS,
-      thumbnail: null,
-      createdAt: '2026-01-22T00:00:00.000Z',
-      updatedAt: '2026-01-22T00:00:00.000Z',
-    };
-    vi.mocked(DesignerStorage.saveDesign).mockResolvedValue(ok(savedDesign));
-    return savedDesign;
-  }
-
-  function mockUpdateDesignParams() {
-    const savedDesign: SavedDesign = {
-      id: 'existing-id',
       name: 'Existing Bin',
       params: { ...DEFAULT_BIN_PARAMS, width: 3 },
       thumbnail: null,
@@ -57,38 +44,30 @@ describe('useAutoSave', () => {
   }
 
   it('should not save on initial render', async () => {
+    useDesignerStore.setState({ currentDesignId: 'existing-id' });
     renderHook(() => useAutoSave());
 
     await act(async () => {
       vi.advanceTimersByTime(2000);
     });
 
-    expect(DesignerStorage.saveDesign).not.toHaveBeenCalled();
     expect(DesignerStorage.updateDesignParams).not.toHaveBeenCalled();
   });
 
-  it('should create new design when currentDesignId is null', async () => {
-    mockSaveDesign('new-design-id');
+  it('should not save when currentDesignId is null (unsaved design)', async () => {
     renderHook(() => useAutoSave());
 
-    // Change params to trigger save
+    // Change params — should NOT trigger save since design hasn't been explicitly saved
     act(() => {
       useDesignerStore.getState().setParam('width', 3);
     });
 
-    // Wait for debounce
     await act(async () => {
       vi.advanceTimersByTime(1100);
     });
 
-    expect(DesignerStorage.saveDesign).toHaveBeenCalledWith({
-      name: 'Untitled Bin',
-      params: expect.objectContaining({ width: 3 }),
-      thumbnail: null,
-    });
-
-    expect(useDesignerStore.getState().currentDesignId).toBe('new-design-id');
-    expect(useDesignerStore.getState().saveStatus).toBe('saved');
+    expect(DesignerStorage.updateDesignParams).not.toHaveBeenCalled();
+    expect(useDesignerStore.getState().saveStatus).toBe('idle');
   });
 
   it('should update existing design when currentDesignId is set', async () => {
@@ -117,7 +96,9 @@ describe('useAutoSave', () => {
   });
 
   it('should debounce multiple rapid changes', async () => {
-    mockSaveDesign();
+    mockUpdateDesignParams();
+    useDesignerStore.setState({ currentDesignId: 'existing-id' });
+
     renderHook(() => useAutoSave());
 
     // Rapid changes
@@ -142,18 +123,19 @@ describe('useAutoSave', () => {
     });
 
     // Only the last value should be saved
-    expect(DesignerStorage.saveDesign).toHaveBeenCalledTimes(1);
-    expect(DesignerStorage.saveDesign).toHaveBeenCalledWith(
-      expect.objectContaining({
-        params: expect.objectContaining({ width: 4 }),
-      })
+    expect(DesignerStorage.updateDesignParams).toHaveBeenCalledTimes(1);
+    expect(DesignerStorage.updateDesignParams).toHaveBeenCalledWith(
+      'existing-id',
+      expect.objectContaining({ width: 4 }),
+      null
     );
   });
 
   it('should set saveStatus to error on failure', async () => {
-    vi.mocked(DesignerStorage.saveDesign).mockResolvedValue(
+    vi.mocked(DesignerStorage.updateDesignParams).mockResolvedValue(
       err(storageUnavailable('indexedDB', new Error('quota exceeded')))
     );
+    useDesignerStore.setState({ currentDesignId: 'existing-id' });
 
     renderHook(() => useAutoSave());
 
@@ -170,11 +152,12 @@ describe('useAutoSave', () => {
 
   it('should set saveStatus to saving during save operation', async () => {
     let resolvePromise: ((value: unknown) => void) | null = null;
-    vi.mocked(DesignerStorage.saveDesign).mockReturnValue(
+    vi.mocked(DesignerStorage.updateDesignParams).mockReturnValue(
       new Promise((resolve) => {
         resolvePromise = resolve;
-      }) as ReturnType<typeof DesignerStorage.saveDesign>
+      }) as ReturnType<typeof DesignerStorage.updateDesignParams>
     );
+    useDesignerStore.setState({ currentDesignId: 'existing-id' });
 
     renderHook(() => useAutoSave());
 
@@ -192,9 +175,9 @@ describe('useAutoSave', () => {
     expect(resolvePromise).not.toBeNull();
     await act(async () => {
       resolvePromise?.(ok({
-        id: 'test-id',
+        id: 'existing-id',
         name: 'Test',
-        params: DEFAULT_BIN_PARAMS,
+        params: { ...DEFAULT_BIN_PARAMS, width: 3 },
         thumbnail: null,
         createdAt: '2026-01-22T00:00:00.000Z',
         updatedAt: '2026-01-22T00:00:00.000Z',
@@ -202,5 +185,38 @@ describe('useAutoSave', () => {
     });
 
     expect(useDesignerStore.getState().saveStatus).toBe('saved');
+  });
+
+  it('should start auto-saving after currentDesignId is set', async () => {
+    mockUpdateDesignParams();
+    renderHook(() => useAutoSave());
+
+    // Initially null — changes are ignored
+    act(() => {
+      useDesignerStore.getState().setParam('width', 3);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+    });
+    expect(DesignerStorage.updateDesignParams).not.toHaveBeenCalled();
+
+    // Simulate explicit save setting the ID (e.g., user renamed the design)
+    act(() => {
+      useDesignerStore.setState({ currentDesignId: 'new-id' });
+    });
+
+    // Now changes should trigger auto-save
+    act(() => {
+      useDesignerStore.getState().setParam('width', 5);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(DesignerStorage.updateDesignParams).toHaveBeenCalledWith(
+      'new-id',
+      expect.objectContaining({ width: 5 }),
+      null
+    );
   });
 });

--- a/src/features/bin-designer/components/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage.tsx
@@ -26,6 +26,9 @@ import { useResponsive } from '@/shared/hooks/useResponsive';
 import { useToastStore } from '@/core/store/toast';
 import { useShallow } from 'zustand/react/shallow';
 import { isOk } from '@/core/result';
+import { saveDesign } from '@/core/storage/DesignerStorage';
+import { captureThumbnail } from '@/features/bin-designer/utils/thumbnail';
+import { upsertRegistryEntry } from '@/features/bin-designer/store/customBinRegistry';
 import type { SaveStatus } from '@/features/bin-designer/types';
 
 interface DesignerPageProps {
@@ -134,6 +137,10 @@ export function DesignerPage(_props: DesignerPageProps) {
   const saveStatus = useDesignerStore((s) => s.saveStatus);
   const designName = useDesignerStore((s) => s.designName);
   const setDesignName = useDesignerStore((s) => s.setDesignName);
+  const currentDesignId = useDesignerStore((s) => s.currentDesignId);
+  const setCurrentDesignId = useDesignerStore((s) => s.setCurrentDesignId);
+  const setSaveStatus = useDesignerStore((s) => s.setSaveStatus);
+  const params = useDesignerStore((s) => s.params);
   const designListOpen = useDesignerStore((s) => s.ui.designListOpen);
   const setDesignListOpen = useDesignerStore((s) => s.setDesignListOpen);
   const setParams = useDesignerStore((s) => s.setParams);
@@ -182,9 +189,33 @@ export function DesignerPage(_props: DesignerPageProps) {
   }, [designName]);
 
   const handleNameSubmit = useCallback(() => {
-    setDesignName(editNameValue.trim() || 'Untitled Bin');
+    const name = editNameValue.trim() || 'Untitled Bin';
+    setDesignName(name);
     setIsEditingName(false);
-  }, [editNameValue, setDesignName]);
+
+    // First save: when user names an unsaved design, persist it
+    if (!currentDesignId) {
+      setSaveStatus('saving');
+      const thumbnail = captureThumbnail();
+      void saveDesign({ name, params, thumbnail }).then((result) => {
+        if (isOk(result)) {
+          setCurrentDesignId(result.value.id);
+          setSaveStatus('saved');
+          upsertRegistryEntry({
+            id: result.value.id,
+            name: result.value.name,
+            width: params.width,
+            depth: params.depth,
+            height: params.height,
+            thumbnail: result.value.thumbnail,
+            updatedAt: result.value.updatedAt,
+          });
+        } else {
+          setSaveStatus('error');
+        }
+      });
+    }
+  }, [editNameValue, setDesignName, currentDesignId, params, setCurrentDesignId, setSaveStatus]);
 
   const handleNameKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/src/features/bin-designer/hooks/useAutoSave.ts
+++ b/src/features/bin-designer/hooks/useAutoSave.ts
@@ -2,13 +2,14 @@
  * Auto-save hook for the Bin Designer.
  *
  * Watches for parameter changes and saves to IndexedDB after a 1-second
- * debounce. Creates a new design on first save, updates existing on subsequent.
+ * debounce. Only auto-saves existing designs — new designs require an
+ * explicit save (e.g., user renames from "Untitled Bin").
  */
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { isOk } from '@/core/result';
-import { saveDesign, updateDesignParams } from '@/core/storage/DesignerStorage';
+import { updateDesignParams } from '@/core/storage/DesignerStorage';
 import { useDesignerStore } from '../store';
 import { captureThumbnail } from '../utils/thumbnail';
 import { upsertRegistryEntry } from '../store/customBinRegistry';
@@ -19,73 +20,36 @@ const AUTO_SAVE_DELAY_MS = 1000;
 /**
  * Automatically saves designer parameters to IndexedDB after a short debounce when they change.
  *
- * Watches the designer's parameters and, after 1000ms of inactivity, either updates the current design or creates a new one; captures a 3D-preview thumbnail if available, updates a lightweight registry entry with design metadata, and updates save status and current design id as appropriate. Skips saving on initial mount and avoids redundant saves when parameters are unchanged.
+ * Only updates existing designs (where currentDesignId is set). New/unsaved designs are not
+ * auto-persisted — the user must explicitly save by naming the design. This prevents unwanted
+ * "Untitled Bin" entries from appearing in My Designs during exploratory parameter tweaks.
  */
 export function useAutoSave(): void {
-  const { params, currentDesignId, designName } = useDesignerStore(
+  const { params, currentDesignId } = useDesignerStore(
     useShallow((s) => ({
       params: s.params,
       currentDesignId: s.currentDesignId,
-      designName: s.designName,
     }))
   );
 
   const setSaveStatus = useDesignerStore((s) => s.setSaveStatus);
-  const setCurrentDesignId = useDesignerStore((s) => s.setCurrentDesignId);
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isFirstRender = useRef(true);
   const lastSavedParams = useRef<BinParams | null>(null);
   const abortRef = useRef(false);
 
-  useEffect(() => {
-    // Skip first render (initial mount shouldn't trigger save)
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      lastSavedParams.current = params;
-      return;
-    }
+  const performSave = useCallback(
+    async (
+      paramsToSave: BinParams,
+      designId: string,
+      abortToken: { current: boolean }
+    ): Promise<void> => {
+      setSaveStatus('saving');
 
-    // Skip if params haven't actually changed (reference check is fine with Immer)
-    if (lastSavedParams.current === params) {
-      return;
-    }
+      // Capture thumbnail from the 3D preview (null if canvas not ready)
+      const thumbnail = captureThumbnail();
 
-    // Abort any in-flight save and clear pending timer
-    abortRef.current = true;
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-    }
-
-    // Reset abort flag for the new save
-    abortRef.current = false;
-    const abortToken = abortRef;
-
-    timerRef.current = setTimeout(() => {
-      void performSave(params, currentDesignId, designName, abortToken);
-    }, AUTO_SAVE_DELAY_MS);
-
-    return () => {
-      abortRef.current = true;
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-    };
-  }, [params, currentDesignId, designName]);
-
-  async function performSave(
-    paramsToSave: BinParams,
-    designId: string | null,
-    name: string,
-    abortToken: { current: boolean }
-  ): Promise<void> {
-    setSaveStatus('saving');
-
-    // Capture thumbnail from the 3D preview (null if canvas not ready)
-    const thumbnail = captureThumbnail();
-
-    if (designId) {
-      // Update existing design
       const result = await updateDesignParams(designId, paramsToSave, thumbnail);
       if (abortToken.current) return; // Superseded by newer save
       if (isOk(result)) {
@@ -104,31 +68,49 @@ export function useAutoSave(): void {
       } else {
         setSaveStatus('error');
       }
-    } else {
-      // Create new design
-      const result = await saveDesign({
-        name,
-        params: paramsToSave,
-        thumbnail,
-      });
-      if (abortToken.current) return; // Superseded by newer save
-      if (isOk(result)) {
-        lastSavedParams.current = paramsToSave;
-        setCurrentDesignId(result.value.id);
-        setSaveStatus('saved');
-        // Sync lightweight ref to registry for Layout Planner
-        upsertRegistryEntry({
-          id: result.value.id,
-          name: result.value.name,
-          width: paramsToSave.width,
-          depth: paramsToSave.depth,
-          height: paramsToSave.height,
-          thumbnail: result.value.thumbnail,
-          updatedAt: result.value.updatedAt,
-        });
-      } else {
-        setSaveStatus('error');
-      }
+    },
+    [setSaveStatus]
+  );
+
+  useEffect(() => {
+    // Skip first render (initial mount shouldn't trigger save)
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      lastSavedParams.current = params;
+      return;
     }
-  }
+
+    // Only auto-save existing designs — new designs require explicit save
+    // (e.g., user renames from "Untitled Bin") to avoid creating unwanted entries
+    if (!currentDesignId) {
+      return;
+    }
+
+    // Skip if params haven't actually changed (reference check is fine with Immer)
+    if (lastSavedParams.current === params) {
+      return;
+    }
+
+    // Abort any in-flight save and clear pending timer
+    abortRef.current = true;
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    // Reset abort flag for the new save
+    abortRef.current = false;
+    const abortToken = abortRef;
+
+    const designId = currentDesignId; // Narrowed to string by guard above
+    timerRef.current = setTimeout(() => {
+      void performSave(params, designId, abortToken);
+    }, AUTO_SAVE_DELAY_MS);
+
+    return () => {
+      abortRef.current = true;
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [params, currentDesignId, performSave]);
 }


### PR DESCRIPTION
## Summary
- Auto-save no longer creates new design entries for unsaved/exploratory designs
- Only auto-saves existing designs (where `currentDesignId` is already set)
- New designs now require explicit save via naming (clicking the title and renaming)

## Problem
Opening the bin designer and tweaking any slider would create a persistent "Untitled Bin" entry in My Designs after 1 second. This happened because `useAutoSave` treated "create new" and "update existing" as equivalent paths — any parameter change on a fresh designer triggered `saveDesign()`.

## Solution
Separated creation from auto-save:
1. **Auto-save hook** — now only fires for existing designs (`currentDesignId !== null`)
2. **First save** — triggered explicitly when user renames the design in the header

## Test plan
- [x] All 589 bin-designer tests pass (7 auto-save tests updated)
- [x] TypeScript type check passes
- [x] ESLint passes
- [ ] Manual: open bin designer, tweak params → no entry in My Designs
- [ ] Manual: rename design → entry created, subsequent changes auto-save
- [ ] Manual: load existing design → auto-save still works