### PR TITLE
feat(bin-designer): editable export filenames with per-design persistence

### DIFF
--- a/src/core/storage/DesignerStorage.ts
+++ b/src/core/storage/DesignerStorage.ts
@@ -9,7 +9,7 @@
 import { openDB, type IDBPDatabase } from 'idb';
 import type { Result, StorageError } from '@/core/result';
 import { ok, err, isErr, storageNotFound, storageCorrupted, storageUnavailable } from '@/core/result';
-import type { SavedDesign, BinParams } from '@/features/bin-designer/types';
+import type { SavedDesign, BinParams, ExportFileNameConfig } from '@/features/bin-designer/types';
 
 const DB_NAME = 'gridfinity-designer-v1';
 const DB_VERSION = 1;
@@ -68,6 +68,7 @@ export async function saveDesign(
       name: design.name,
       params: design.params,
       thumbnail: design.thumbnail ?? null,
+      exportFileNameConfig: design.exportFileNameConfig ?? null,
       createdAt,
       updatedAt: now,
     };
@@ -148,17 +149,20 @@ export function closeDesignerDb(): void {
 }
 
 /**
- * Update an existing design's bin parameters and optionally its thumbnail.
+ * Update an existing design's bin parameters, thumbnail, and/or export config.
  *
  * If `thumbnail` is `undefined` the design's thumbnail is left unchanged; if `null` the thumbnail is cleared.
+ * If `exportFileNameConfig` is `undefined` it is left unchanged.
  *
  * @param thumbnail - The new thumbnail data, `null` to remove it, or `undefined` to keep the current thumbnail
+ * @param exportFileNameConfig - The new export config, or `undefined` to keep the current config
  * @returns A `Result` with the updated `SavedDesign` on success, or a `StorageError` on failure
  */
 export async function updateDesignParams(
   id: string,
   params: BinParams,
-  thumbnail?: string | null
+  thumbnail?: string | null,
+  exportFileNameConfig?: ExportFileNameConfig
 ): Promise<Result<SavedDesign, StorageError>> {
   const loadResult = await loadDesign(id);
   if (isErr(loadResult)) {
@@ -169,5 +173,6 @@ export async function updateDesignParams(
     ...loadResult.value,
     params,
     ...(thumbnail !== undefined ? { thumbnail } : {}),
+    ...(exportFileNameConfig !== undefined ? { exportFileNameConfig } : {}),
   });
 }

--- a/src/features/bin-designer/__tests__/components/ExportDialog.test.tsx
+++ b/src/features/bin-designer/__tests__/components/ExportDialog.test.tsx
@@ -3,8 +3,10 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { ExportDialog } from '@/features/bin-designer/components/ExportDialog';
 import { useDesignerStore } from '@/features/bin-designer/store/designer';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import { DEFAULT_EXPORT_FILE_NAME_CONFIG } from '@/features/bin-designer/utils/fileNaming';
 
 const mockDownloadSTL = vi.fn();
+const mockDownload3MF = vi.fn().mockResolvedValue(undefined);
 
 // Mock useExport hook
 vi.mock('@/features/bin-designer/hooks/useExport', () => ({
@@ -18,37 +20,55 @@ vi.mock('@/features/bin-designer/hooks/useExport', () => ({
       printTimeMinutes: 34,
       costUSD: 0.47,
     },
-    fileName: 'gridfinity_2x2x3.stl',
     downloadSTL: mockDownloadSTL,
+    download3MF: mockDownload3MF,
+    downloadSTEP: vi.fn(),
+    canExportBREP: false,
   }),
 }));
+
+function setupStore(overrides: Record<string, unknown> = {}) {
+  useDesignerStore.setState({
+    params: { ...DEFAULT_BIN_PARAMS },
+    designName: 'Untitled Bin',
+    exportFileNameConfig: { ...DEFAULT_EXPORT_FILE_NAME_CONFIG },
+    generation: {
+      status: 'complete',
+      mesh: {
+        vertices: new Float32Array(108), // 12 triangles
+        normals: new Float32Array(108),
+        error: null,
+        timingMs: 10,
+      },
+      progress: 1,
+      epoch: 1,
+    },
+    ui: {
+      activeTab: 'dimensions',
+      exportDialogOpen: true,
+      wireframeMode: false,
+      designListOpen: false,
+      halfBinMode: false,
+    },
+    ...overrides,
+  });
+}
 
 describe('ExportDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useDesignerStore.setState({
-      params: { ...DEFAULT_BIN_PARAMS },
-      generation: {
-        status: 'complete',
-        mesh: {
-          vertices: new Float32Array(108), // 12 triangles
-          normals: new Float32Array(108),
-          error: null,
-          timingMs: 10,
-        },
-        progress: 1,
-      },
-      ui: {
-        activeTab: 'dimensions',
-        exportDialogOpen: true,
-        wireframeMode: false,
-      },
-    });
+    setupStore();
   });
 
   it('does not render when dialog is closed', () => {
-    useDesignerStore.setState({
-      ui: { activeTab: 'dimensions', exportDialogOpen: false, wireframeMode: false },
+    setupStore({
+      ui: {
+        activeTab: 'dimensions',
+        exportDialogOpen: false,
+        wireframeMode: false,
+        designListOpen: false,
+        halfBinMode: false,
+      },
     });
     const { container } = render(<ExportDialog />);
     expect(container.innerHTML).toBe('');
@@ -66,7 +86,7 @@ describe('ExportDialog', () => {
     expect(screen.getByText('3MF')).toBeInTheDocument();
   });
 
-  it('shows file name preview', () => {
+  it('shows file name preview in descriptive mode', () => {
     render(<ExportDialog />);
     // The file name from generateFileName with default 2x2x3 params
     expect(screen.getByText(/gridfinity.*2x2x3/)).toBeInTheDocument();
@@ -87,11 +107,14 @@ describe('ExportDialog', () => {
     expect(button).not.toBeDisabled();
   });
 
-  it('triggers download on button click', () => {
+  it('triggers download with config on button click', () => {
     render(<ExportDialog />);
     const button = screen.getByRole('button', { name: /download stl/i });
     fireEvent.click(button);
-    expect(mockDownloadSTL).toHaveBeenCalled();
+    expect(mockDownloadSTL).toHaveBeenCalledWith(
+      { style: 'descriptive', customName: '' },
+      'Untitled Bin'
+    );
   });
 
   it('closes on backdrop click', () => {
@@ -119,8 +142,60 @@ describe('ExportDialog', () => {
     // Click compact
     fireEvent.click(screen.getByText('Compact'));
 
+    // Store should be updated
+    expect(useDesignerStore.getState().exportFileNameConfig.style).toBe('compact');
+
     // Should show compact format
     expect(screen.getByText(/gf_/)).toBeInTheDocument();
+  });
+
+  it('switches to custom mode and shows editable input', () => {
+    render(<ExportDialog />);
+
+    // Click custom
+    fireEvent.click(screen.getByText('Custom'));
+
+    // Store should be updated to custom with pre-filled name
+    const config = useDesignerStore.getState().exportFileNameConfig;
+    expect(config.style).toBe('custom');
+    expect(config.customName).toBe('gridfinity_2x2x3');
+
+    // Should show editable input
+    const input = screen.getByLabelText('Custom file name');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue('gridfinity_2x2x3');
+  });
+
+  it('updates custom name on input change', () => {
+    setupStore({
+      exportFileNameConfig: { style: 'custom', customName: 'my-bin' },
+    });
+    render(<ExportDialog />);
+
+    const input = screen.getByLabelText('Custom file name');
+    fireEvent.change(input, { target: { value: 'new-bin-name' } });
+
+    expect(useDesignerStore.getState().exportFileNameConfig.customName).toBe('new-bin-name');
+  });
+
+  it('uses design name as prefix when set', () => {
+    setupStore({ designName: 'Screwdriver Bin' });
+    render(<ExportDialog />);
+
+    // Should show design name as prefix in descriptive mode
+    expect(screen.getByText(/Screwdriver Bin_2x2x3/)).toBeInTheDocument();
+  });
+
+  it('falls back to gridfinity prefix when design is Untitled Bin', () => {
+    setupStore({ designName: 'Untitled Bin' });
+    render(<ExportDialog />);
+
+    expect(screen.getByText(/gridfinity_2x2x3/)).toBeInTheDocument();
+  });
+
+  it('shows the format extension separately', () => {
+    render(<ExportDialog />);
+    expect(screen.getByText('.stl')).toBeInTheDocument();
   });
 
   it('shows triangle count', () => {
@@ -134,5 +209,12 @@ describe('ExportDialog', () => {
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-modal', 'true');
     expect(dialog).toHaveAttribute('aria-labelledby', 'export-dialog-title');
+  });
+
+  it('shows all three style buttons', () => {
+    render(<ExportDialog />);
+    expect(screen.getByText('Descriptive')).toBeInTheDocument();
+    expect(screen.getByText('Compact')).toBeInTheDocument();
+    expect(screen.getByText('Custom')).toBeInTheDocument();
   });
 });

--- a/src/features/bin-designer/__tests__/fileNaming.test.ts
+++ b/src/features/bin-designer/__tests__/fileNaming.test.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { generateFileName } from '../utils/fileNaming';
+import { generateFileName, sanitizeFileName, DEFAULT_EXPORT_FILE_NAME_CONFIG } from '../utils/fileNaming';
 import { DEFAULT_BIN_PARAMS } from '../constants/defaults';
-import type { BinParams } from '../types';
+import type { BinParams, ExportFileNameConfig } from '../types';
 
 function makeParams(overrides: Partial<BinParams> = {}): BinParams {
   return { ...DEFAULT_BIN_PARAMS, ...overrides };
 }
 
+function makeConfig(overrides: Partial<ExportFileNameConfig> = {}): ExportFileNameConfig {
+  return { ...DEFAULT_EXPORT_FILE_NAME_CONFIG, ...overrides };
+}
+
 describe('generateFileName', () => {
-  describe('compact style', () => {
+  describe('compact style (legacy string API)', () => {
     it('should generate compact name for default params', () => {
       const name = generateFileName(DEFAULT_BIN_PARAMS, 'stl', 'compact');
       expect(name).toBe('gf_2x2x3.stl');
@@ -29,7 +33,7 @@ describe('generateFileName', () => {
     });
   });
 
-  describe('descriptive style', () => {
+  describe('descriptive style (legacy string API)', () => {
     it('should generate base name with no features', () => {
       const name = generateFileName(DEFAULT_BIN_PARAMS, 'stl', 'descriptive');
       expect(name).toBe('gridfinity_2x2x3.stl');
@@ -111,5 +115,153 @@ describe('generateFileName', () => {
       const name = generateFileName(DEFAULT_BIN_PARAMS, 'stl');
       expect(name).toBe('gridfinity_2x2x3.stl');
     });
+  });
+
+  describe('config object API', () => {
+    it('should work with ExportFileNameConfig for descriptive', () => {
+      const name = generateFileName(DEFAULT_BIN_PARAMS, 'stl', makeConfig({ style: 'descriptive' }));
+      expect(name).toBe('gridfinity_2x2x3.stl');
+    });
+
+    it('should work with ExportFileNameConfig for compact', () => {
+      const name = generateFileName(DEFAULT_BIN_PARAMS, 'stl', makeConfig({ style: 'compact' }));
+      expect(name).toBe('gf_2x2x3.stl');
+    });
+  });
+
+  describe('design name prefix', () => {
+    it('should use design name as prefix in descriptive mode', () => {
+      const name = generateFileName(DEFAULT_BIN_PARAMS, 'stl', 'descriptive', 'Screwdriver Bin');
+      expect(name).toBe('Screwdriver Bin_2x2x3.stl');
+    });
+
+    it('should use design name as prefix in compact mode', () => {
+      const name = generateFileName(DEFAULT_BIN_PARAMS, 'stl', 'compact', 'My Tools');
+      expect(name).toBe('My Tools_2x2x3.stl');
+    });
+
+    it('should include features with design name in descriptive mode', () => {
+      const name = generateFileName(
+        makeParams({ scoop: { enabled: true, radius: 'auto', allRows: false } }),
+        'stl',
+        'descriptive',
+        'Screwdriver Bin'
+      );
+      expect(name).toBe('Screwdriver Bin_2x2x3_scoop.stl');
+    });
+
+    it('should fall back to gridfinity prefix when design name is Untitled Bin', () => {
+      const name = generateFileName(DEFAULT_BIN_PARAMS, 'stl', 'descriptive', 'Untitled Bin');
+      expect(name).toBe('gridfinity_2x2x3.stl');
+    });
+
+    it('should fall back to gf prefix when design name is Untitled Bin in compact mode', () => {
+      const name = generateFileName(DEFAULT_BIN_PARAMS, 'stl', 'compact', 'Untitled Bin');
+      expect(name).toBe('gf_2x2x3.stl');
+    });
+
+    it('should fall back when design name is empty', () => {
+      const name = generateFileName(DEFAULT_BIN_PARAMS, 'stl', 'descriptive', '');
+      expect(name).toBe('gridfinity_2x2x3.stl');
+    });
+
+    it('should fall back when design name is whitespace only', () => {
+      const name = generateFileName(DEFAULT_BIN_PARAMS, 'stl', 'descriptive', '   ');
+      expect(name).toBe('gridfinity_2x2x3.stl');
+    });
+
+    it('should sanitize unsafe characters in design name', () => {
+      const name = generateFileName(DEFAULT_BIN_PARAMS, 'stl', 'descriptive', 'My/Bin<test>');
+      expect(name).toBe('My_Bin_test__2x2x3.stl');
+    });
+  });
+
+  describe('custom mode', () => {
+    it('should use custom name with extension', () => {
+      const name = generateFileName(
+        DEFAULT_BIN_PARAMS,
+        'stl',
+        makeConfig({ style: 'custom', customName: 'my-special-bin' })
+      );
+      expect(name).toBe('my-special-bin.stl');
+    });
+
+    it('should fallback to gridfinity-bin when custom name is empty', () => {
+      const name = generateFileName(
+        DEFAULT_BIN_PARAMS,
+        'stl',
+        makeConfig({ style: 'custom', customName: '' })
+      );
+      expect(name).toBe('gridfinity-bin.stl');
+    });
+
+    it('should sanitize custom name', () => {
+      const name = generateFileName(
+        DEFAULT_BIN_PARAMS,
+        'stl',
+        makeConfig({ style: 'custom', customName: 'my<bin>test' })
+      );
+      expect(name).toBe('my_bin_test.stl');
+    });
+
+    it('should fallback when custom name is only unsafe characters', () => {
+      const name = generateFileName(
+        DEFAULT_BIN_PARAMS,
+        'stl',
+        makeConfig({ style: 'custom', customName: '<<<>>>' })
+      );
+      expect(name).toBe('gridfinity-bin.stl');
+    });
+
+    it('should ignore design name in custom mode', () => {
+      const name = generateFileName(
+        DEFAULT_BIN_PARAMS,
+        'stl',
+        makeConfig({ style: 'custom', customName: 'custom-file' }),
+        'Some Design Name'
+      );
+      expect(name).toBe('custom-file.stl');
+    });
+
+    it('should work with 3mf format', () => {
+      const name = generateFileName(
+        DEFAULT_BIN_PARAMS,
+        '3mf',
+        makeConfig({ style: 'custom', customName: 'my-bin' })
+      );
+      expect(name).toBe('my-bin.3mf');
+    });
+  });
+});
+
+describe('sanitizeFileName', () => {
+  it('should replace angle brackets', () => {
+    expect(sanitizeFileName('foo<bar>')).toBe('foo_bar_');
+  });
+
+  it('should replace colons and slashes', () => {
+    expect(sanitizeFileName('C:\\path/to:file')).toBe('C__path_to_file');
+  });
+
+  it('should replace quotes and pipes', () => {
+    expect(sanitizeFileName('file"name|test')).toBe('file_name_test');
+  });
+
+  it('should trim whitespace', () => {
+    expect(sanitizeFileName('  hello  ')).toBe('hello');
+  });
+
+  it('should leave safe characters untouched', () => {
+    expect(sanitizeFileName('my-bin_v2 (copy).txt')).toBe('my-bin_v2 (copy).txt');
+  });
+});
+
+describe('DEFAULT_EXPORT_FILE_NAME_CONFIG', () => {
+  it('should have descriptive style by default', () => {
+    expect(DEFAULT_EXPORT_FILE_NAME_CONFIG.style).toBe('descriptive');
+  });
+
+  it('should have empty custom name by default', () => {
+    expect(DEFAULT_EXPORT_FILE_NAME_CONFIG.customName).toBe('');
   });
 });

--- a/src/features/bin-designer/__tests__/hooks/useAutoSave.test.ts
+++ b/src/features/bin-designer/__tests__/hooks/useAutoSave.test.ts
@@ -90,7 +90,8 @@ describe('useAutoSave', () => {
     expect(DesignerStorage.updateDesignParams).toHaveBeenCalledWith(
       'existing-id',
       expect.objectContaining({ width: 4 }),
-      null // thumbnail (null since no canvas in test)
+      null, // thumbnail (null since no canvas in test)
+      { style: 'descriptive', customName: '' }
     );
     expect(useDesignerStore.getState().saveStatus).toBe('saved');
   });
@@ -127,7 +128,8 @@ describe('useAutoSave', () => {
     expect(DesignerStorage.updateDesignParams).toHaveBeenCalledWith(
       'existing-id',
       expect.objectContaining({ width: 4 }),
-      null
+      null,
+      { style: 'descriptive', customName: '' }
     );
   });
 
@@ -216,7 +218,8 @@ describe('useAutoSave', () => {
     expect(DesignerStorage.updateDesignParams).toHaveBeenCalledWith(
       'new-id',
       expect.objectContaining({ width: 5 }),
-      null
+      null,
+      { style: 'descriptive', customName: '' }
     );
   });
 });

--- a/src/features/bin-designer/__tests__/hooks/useExport.test.ts
+++ b/src/features/bin-designer/__tests__/hooks/useExport.test.ts
@@ -85,10 +85,10 @@ describe('useExport', () => {
     expect(result.current.estimates.metersFilament).toBeGreaterThan(0);
   });
 
-  it('provides a file name preview', () => {
+  it('provides export function', () => {
     const { result } = renderHook(() => useExport());
-    expect(result.current.fileName).toContain('gridfinity');
-    expect(result.current.fileName).toContain('.stl');
+    expect(result.current.downloadSTL).toBeTypeOf('function');
+    expect(result.current.download3MF).toBeTypeOf('function');
   });
 
   it('isExporting is initially false', () => {
@@ -100,7 +100,7 @@ describe('useExport', () => {
     const { result } = renderHook(() => useExport());
 
     act(() => {
-      result.current.downloadSTL();
+      result.current.downloadSTL({ style: 'descriptive', customName: '' });
     });
 
     expect(mockCreateObjectURL).not.toHaveBeenCalled();
@@ -138,7 +138,7 @@ describe('useExport', () => {
     const { result } = renderHook(() => useExport());
 
     act(() => {
-      result.current.downloadSTL();
+      result.current.downloadSTL({ style: 'descriptive', customName: '' });
     });
 
     expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob));

--- a/src/features/bin-designer/components/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage.tsx
@@ -141,6 +141,7 @@ export function DesignerPage(_props: DesignerPageProps) {
   const setCurrentDesignId = useDesignerStore((s) => s.setCurrentDesignId);
   const setSaveStatus = useDesignerStore((s) => s.setSaveStatus);
   const params = useDesignerStore((s) => s.params);
+  const exportFileNameConfig = useDesignerStore((s) => s.exportFileNameConfig);
   const designListOpen = useDesignerStore((s) => s.ui.designListOpen);
   const setDesignListOpen = useDesignerStore((s) => s.setDesignListOpen);
   const setParams = useDesignerStore((s) => s.setParams);
@@ -197,7 +198,7 @@ export function DesignerPage(_props: DesignerPageProps) {
     if (!currentDesignId) {
       setSaveStatus('saving');
       const thumbnail = captureThumbnail();
-      void saveDesign({ name, params, thumbnail }).then((result) => {
+      void saveDesign({ name, params, thumbnail, exportFileNameConfig }).then((result) => {
         if (isOk(result)) {
           setCurrentDesignId(result.value.id);
           setSaveStatus('saved');
@@ -215,7 +216,7 @@ export function DesignerPage(_props: DesignerPageProps) {
         }
       });
     }
-  }, [editNameValue, setDesignName, currentDesignId, params, setCurrentDesignId, setSaveStatus]);
+  }, [editNameValue, setDesignName, currentDesignId, params, exportFileNameConfig, setCurrentDesignId, setSaveStatus]);
 
   const handleNameKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/src/features/bin-designer/components/ExportDialog.tsx
+++ b/src/features/bin-designer/components/ExportDialog.tsx
@@ -1,38 +1,41 @@
 /**
  * Export dialog for the bin designer.
  *
- * Shows export format options, file name preview, print estimates,
- * and a download button. Only STL is available in Alpha; others
- * are shown as "coming soon" placeholders.
+ * Shows export format options, editable file name with style selection
+ * (Descriptive / Compact / Custom), print estimates, and a download button.
+ * The filename preference is persisted per-design via the designer store.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store/designer';
 import { useExport } from '@/features/bin-designer/hooks/useExport';
 import type { ExportFormat } from '@/features/bin-designer/hooks/useExport';
 import { formatPrintTime, formatFilament } from '@/features/bin-designer/utils/printEstimates';
-import type { FileNameStyle } from '@/features/bin-designer/utils/fileNaming';
 import { generateFileName } from '@/features/bin-designer/utils/fileNaming';
+import type { FileNameStyle } from '@/features/bin-designer/types';
 import { getSTLFileSize, estimate3MFFileSize } from '@/shared/generation/export';
 import { useFocusTrap } from '@/shared/hooks/useFocusTrap';
 import { useToastStore } from '@/core/store/toast';
 
 export function ExportDialog() {
-  const { exportDialogOpen, params, triangleCount } = useDesignerStore(
-    useShallow((state) => ({
-      exportDialogOpen: state.ui.exportDialogOpen,
-      params: state.params,
-      triangleCount: state.generation.mesh?.vertices
-        ? state.generation.mesh.vertices.length / 9
-        : 0,
-    }))
-  );
+  const { exportDialogOpen, params, triangleCount, designName, exportFileNameConfig } =
+    useDesignerStore(
+      useShallow((state) => ({
+        exportDialogOpen: state.ui.exportDialogOpen,
+        params: state.params,
+        triangleCount: state.generation.mesh?.vertices
+          ? state.generation.mesh.vertices.length / 9
+          : 0,
+        designName: state.designName,
+        exportFileNameConfig: state.exportFileNameConfig,
+      }))
+    );
   const setExportDialogOpen = useDesignerStore((s) => s.setExportDialogOpen);
+  const setExportFileNameConfig = useDesignerStore((s) => s.setExportFileNameConfig);
 
   const { canExport, estimates, isExporting, downloadSTL, download3MF } = useExport();
   const addToast = useToastStore((s) => s.addToast);
-  const [nameStyle, setNameStyle] = useState<FileNameStyle>('descriptive');
   const [format, setFormat] = useState<ExportFormat>('stl');
 
   const closeDialog = useCallback(() => setExportDialogOpen(false), [setExportDialogOpen]);
@@ -41,9 +44,48 @@ export function ExportDialog() {
     onEscape: closeDialog,
   });
 
+  const customInputRef = useRef<HTMLInputElement>(null);
+
+  // Focus the custom input when switching to custom mode
+  useEffect(() => {
+    if (exportFileNameConfig.style === 'custom' && customInputRef.current) {
+      customInputRef.current.focus();
+      customInputRef.current.select();
+    }
+  }, [exportFileNameConfig.style]);
+
+  const fileName = useMemo(
+    () => generateFileName(params, format, exportFileNameConfig, designName),
+    [params, format, exportFileNameConfig, designName]
+  );
+
+  // The display name (without extension) for the input field
+  const fileNameWithoutExt = useMemo(() => {
+    const lastDot = fileName.lastIndexOf('.');
+    return lastDot > 0 ? fileName.slice(0, lastDot) : fileName;
+  }, [fileName]);
+
+  const handleStyleChange = useCallback(
+    (style: FileNameStyle) => {
+      if (style === 'custom' && exportFileNameConfig.customName === '') {
+        // Pre-fill custom name with current auto-generated name (without extension)
+        setExportFileNameConfig({ style, customName: fileNameWithoutExt });
+      } else {
+        setExportFileNameConfig({ ...exportFileNameConfig, style });
+      }
+    },
+    [exportFileNameConfig, setExportFileNameConfig, fileNameWithoutExt]
+  );
+
+  const handleCustomNameChange = useCallback(
+    (value: string) => {
+      setExportFileNameConfig({ ...exportFileNameConfig, customName: value });
+    },
+    [exportFileNameConfig, setExportFileNameConfig]
+  );
+
   if (!exportDialogOpen) return null;
 
-  const fileName = generateFileName(params, format, nameStyle);
   const fileSizeBytes =
     format === 'stl' ? getSTLFileSize(triangleCount) : estimate3MFFileSize(triangleCount);
   const fileSizeLabel =
@@ -104,20 +146,45 @@ export function ExportDialog() {
 
         {/* File Name */}
         <div className="mb-4">
-          <label className="mb-2 block text-sm font-medium text-content-secondary">File Name</label>
-          <div className="rounded-md border border-stroke-subtle bg-surface px-3 py-2">
-            <code className="break-all text-sm text-content">{fileName}</code>
+          <label className="mb-2 block text-sm font-medium text-content-secondary">
+            File Name
+          </label>
+          <div className="flex items-center rounded-md border border-stroke-subtle bg-surface">
+            {exportFileNameConfig.style === 'custom' ? (
+              <input
+                ref={customInputRef}
+                type="text"
+                value={exportFileNameConfig.customName}
+                onChange={(e) => handleCustomNameChange(e.target.value)}
+                className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm text-content outline-none"
+                placeholder="Enter filename"
+                aria-label="Custom file name"
+                maxLength={128}
+              />
+            ) : (
+              <span className="flex-1 truncate px-3 py-2 text-sm text-content">
+                {fileNameWithoutExt}
+              </span>
+            )}
+            <span className="shrink-0 border-l border-stroke-subtle px-2 py-2 text-sm text-content-tertiary">
+              .{format}
+            </span>
           </div>
           <div className="mt-2 flex gap-2">
             <NameStyleButton
-              active={nameStyle === 'descriptive'}
-              onClick={() => setNameStyle('descriptive')}
+              active={exportFileNameConfig.style === 'descriptive'}
+              onClick={() => handleStyleChange('descriptive')}
               label="Descriptive"
             />
             <NameStyleButton
-              active={nameStyle === 'compact'}
-              onClick={() => setNameStyle('compact')}
+              active={exportFileNameConfig.style === 'compact'}
+              onClick={() => handleStyleChange('compact')}
               label="Compact"
+            />
+            <NameStyleButton
+              active={exportFileNameConfig.style === 'custom'}
+              onClick={() => handleStyleChange('custom')}
+              label="Custom"
             />
           </div>
         </div>
@@ -146,9 +213,9 @@ export function ExportDialog() {
           onClick={async () => {
             try {
               if (format === '3mf') {
-                await download3MF(nameStyle);
+                await download3MF(exportFileNameConfig, designName);
               } else {
-                downloadSTL(nameStyle);
+                downloadSTL(exportFileNameConfig, designName);
               }
               addToast({
                 message: `${format.toUpperCase()} exported successfully`,

--- a/src/features/bin-designer/hooks/useAutoSave.ts
+++ b/src/features/bin-designer/hooks/useAutoSave.ts
@@ -13,7 +13,7 @@ import { updateDesignParams } from '@/core/storage/DesignerStorage';
 import { useDesignerStore } from '../store';
 import { captureThumbnail } from '../utils/thumbnail';
 import { upsertRegistryEntry } from '../store/customBinRegistry';
-import type { BinParams } from '../types';
+import type { BinParams, ExportFileNameConfig } from '../types';
 
 const AUTO_SAVE_DELAY_MS = 1000;
 
@@ -25,10 +25,11 @@ const AUTO_SAVE_DELAY_MS = 1000;
  * "Untitled Bin" entries from appearing in My Designs during exploratory parameter tweaks.
  */
 export function useAutoSave(): void {
-  const { params, currentDesignId } = useDesignerStore(
+  const { params, currentDesignId, exportFileNameConfig } = useDesignerStore(
     useShallow((s) => ({
       params: s.params,
       currentDesignId: s.currentDesignId,
+      exportFileNameConfig: s.exportFileNameConfig,
     }))
   );
 
@@ -37,11 +38,13 @@ export function useAutoSave(): void {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isFirstRender = useRef(true);
   const lastSavedParams = useRef<BinParams | null>(null);
+  const lastSavedConfig = useRef<ExportFileNameConfig | null>(null);
   const abortRef = useRef(false);
 
   const performSave = useCallback(
     async (
       paramsToSave: BinParams,
+      configToSave: ExportFileNameConfig,
       designId: string,
       abortToken: { current: boolean }
     ): Promise<void> => {
@@ -50,10 +53,11 @@ export function useAutoSave(): void {
       // Capture thumbnail from the 3D preview (null if canvas not ready)
       const thumbnail = captureThumbnail();
 
-      const result = await updateDesignParams(designId, paramsToSave, thumbnail);
+      const result = await updateDesignParams(designId, paramsToSave, thumbnail, configToSave);
       if (abortToken.current) return; // Superseded by newer save
       if (isOk(result)) {
         lastSavedParams.current = paramsToSave;
+        lastSavedConfig.current = configToSave;
         setSaveStatus('saved');
         // Sync lightweight ref to registry for Layout Planner
         upsertRegistryEntry({
@@ -77,6 +81,7 @@ export function useAutoSave(): void {
     if (isFirstRender.current) {
       isFirstRender.current = false;
       lastSavedParams.current = params;
+      lastSavedConfig.current = exportFileNameConfig;
       return;
     }
 
@@ -86,8 +91,8 @@ export function useAutoSave(): void {
       return;
     }
 
-    // Skip if params haven't actually changed (reference check is fine with Immer)
-    if (lastSavedParams.current === params) {
+    // Skip if neither params nor config have changed
+    if (lastSavedParams.current === params && lastSavedConfig.current === exportFileNameConfig) {
       return;
     }
 
@@ -103,7 +108,7 @@ export function useAutoSave(): void {
 
     const designId = currentDesignId; // Narrowed to string by guard above
     timerRef.current = setTimeout(() => {
-      void performSave(params, designId, abortToken);
+      void performSave(params, exportFileNameConfig, designId, abortToken);
     }, AUTO_SAVE_DELAY_MS);
 
     return () => {
@@ -112,5 +117,5 @@ export function useAutoSave(): void {
         clearTimeout(timerRef.current);
       }
     };
-  }, [params, currentDesignId, performSave]);
+  }, [params, exportFileNameConfig, currentDesignId, performSave]);
 }

--- a/src/features/bin-designer/hooks/useExport.ts
+++ b/src/features/bin-designer/hooks/useExport.ts
@@ -19,7 +19,7 @@ import { getActiveBridge } from '@/features/generation/bridge';
 import { generateFileName } from '@/features/bin-designer/utils/fileNaming';
 import { estimatePrint } from '@/features/bin-designer/utils/printEstimates';
 import { captureThumbnailPNG } from '@/features/bin-designer/utils/thumbnail';
-import type { FileNameStyle } from '@/features/bin-designer/utils/fileNaming';
+import type { ExportFileNameConfig } from '@/features/bin-designer/types';
 import type { PrintEstimate } from '@/features/bin-designer/utils/printEstimates';
 
 /** Supported export formats */
@@ -34,12 +34,10 @@ interface UseExportReturn {
   readonly canExportBREP: boolean;
   /** Current print estimates based on params */
   readonly estimates: PrintEstimate;
-  /** Preview of the generated file name */
-  readonly fileName: string;
-  /** Trigger STL download (from tessellated mesh, fast) */
-  readonly downloadSTL: (nameStyle?: FileNameStyle) => void;
+  /** Trigger STL download */
+  readonly downloadSTL: (config: ExportFileNameConfig, designName?: string) => void;
   /** Trigger 3MF download (with thumbnail & print settings) */
-  readonly download3MF: (nameStyle?: FileNameStyle) => Promise<void>;
+  readonly download3MF: (config: ExportFileNameConfig, designName?: string) => Promise<void>;
   /** Trigger STEP download (exact BREP via worker, lossless) */
   readonly downloadSTEP: () => Promise<void>;
 }
@@ -64,13 +62,8 @@ export function useExport(): UseExportReturn {
 
   const estimates = useMemo(() => estimatePrint(params), [params]);
 
-  const fileName = useMemo(
-    () => generateFileName(params, 'stl', 'descriptive'),
-    [params]
-  );
-
   const downloadSTL = useCallback(
-    (nameStyle: FileNameStyle = 'descriptive') => {
+    (config: ExportFileNameConfig, designName?: string) => {
       if (!canExport || !mesh?.vertices || !mesh?.normals) return;
 
       setIsExporting(true);
@@ -78,7 +71,7 @@ export function useExport(): UseExportReturn {
       let url: string | null = null;
       let anchor: HTMLAnchorElement | null = null;
       try {
-        const name = generateFileName(params, 'stl', nameStyle);
+        const name = generateFileName(params, 'stl', config, designName);
         const blob = exportSTL(mesh.vertices, mesh.normals, name);
 
         // Trigger browser download via hidden anchor
@@ -98,7 +91,7 @@ export function useExport(): UseExportReturn {
   );
 
   const download3MF = useCallback(
-    async (nameStyle: FileNameStyle = 'descriptive') => {
+    async (config: ExportFileNameConfig, designName?: string) => {
       if (!canExport || !mesh?.vertices || !mesh?.normals) return;
 
       setIsExporting(true);
@@ -106,7 +99,7 @@ export function useExport(): UseExportReturn {
       let url: string | null = null;
       let anchor: HTMLAnchorElement | null = null;
       try {
-        const name = generateFileName(params, '3mf', nameStyle);
+        const name = generateFileName(params, '3mf', config, designName);
 
         // Capture thumbnail from 3D preview (async canvas → PNG)
         const thumbnail = await captureThumbnailPNG() ?? undefined;
@@ -167,5 +160,5 @@ export function useExport(): UseExportReturn {
     [params]
   );
 
-  return { isExporting, canExport, canExportBREP, estimates, fileName, downloadSTL, download3MF, downloadSTEP };
+  return { isExporting, canExport, canExportBREP, estimates, downloadSTL, download3MF, downloadSTEP };
 }

--- a/src/features/bin-designer/store/designer.ts
+++ b/src/features/bin-designer/store/designer.ts
@@ -12,6 +12,7 @@ import type {
   DesignerState,
   BinParams,
   Insert,
+  ExportFileNameConfig,
   GenerationStatus,
   GenerationResult,
   WasmStatus,
@@ -30,6 +31,7 @@ import {
   migrateParams,
 } from '../constants';
 import { isErr } from '@/core/result';
+import { DEFAULT_EXPORT_FILE_NAME_CONFIG } from '../utils/fileNaming';
 import { isFractional } from '@/core/constants';
 import { isRectangularSelection, normalizeIds } from '../utils/compartments';
 import { validateCompartmentSizes } from '../utils/validation';
@@ -79,6 +81,7 @@ export const useDesignerStore = create<DesignerState>()(
     currentDesignId: null as string | null,
     designName: 'Untitled Bin',
     saveStatus: 'idle' as SaveStatus,
+    exportFileNameConfig: { ...DEFAULT_EXPORT_FILE_NAME_CONFIG },
 
     // Param actions
     setParam: <K extends keyof BinParams>(key: K, value: BinParams[K]) => {
@@ -153,6 +156,12 @@ export const useDesignerStore = create<DesignerState>()(
       });
     },
 
+    setExportFileNameConfig: (config: ExportFileNameConfig) => {
+      set((state) => {
+        state.exportFileNameConfig = config;
+      });
+    },
+
     newDesign: () => {
       set((state) => {
         state.history.past = [];
@@ -161,6 +170,7 @@ export const useDesignerStore = create<DesignerState>()(
         state.currentDesignId = null;
         state.designName = 'Untitled Bin';
         state.saveStatus = 'idle';
+        state.exportFileNameConfig = { ...DEFAULT_EXPORT_FILE_NAME_CONFIG };
         state.generation.epoch += 1;
         pendingMeshCache = null;
       });
@@ -171,6 +181,7 @@ export const useDesignerStore = create<DesignerState>()(
         state.params = migrateParams(design.params);
         state.currentDesignId = design.id;
         state.designName = design.name;
+        state.exportFileNameConfig = design.exportFileNameConfig ?? { ...DEFAULT_EXPORT_FILE_NAME_CONFIG };
         state.history = { past: [], future: [] };
         state.saveStatus = 'saved';
         state.generation.epoch += 1;

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -200,6 +200,21 @@ export interface DesignerHistory {
 }
 
 // =============================================================================
+// Export File Name Types
+// =============================================================================
+
+/** File naming style for exports */
+export type FileNameStyle = 'descriptive' | 'compact' | 'custom';
+
+/** Export filename configuration stored per design */
+export interface ExportFileNameConfig {
+  /** Which naming mode to use */
+  readonly style: FileNameStyle;
+  /** User-provided filename (without extension) for 'custom' mode */
+  readonly customName: string;
+}
+
+// =============================================================================
 // Storage Types
 // =============================================================================
 
@@ -211,6 +226,8 @@ export interface SavedDesign {
   readonly thumbnail: string | null;
   readonly createdAt: string;
   readonly updatedAt: string;
+  /** Per-design export filename preference (null = use defaults) */
+  readonly exportFileNameConfig: ExportFileNameConfig | null;
 }
 
 // =============================================================================
@@ -230,6 +247,7 @@ export interface DesignerState {
   currentDesignId: string | null;
   designName: string;
   saveStatus: SaveStatus;
+  exportFileNameConfig: ExportFileNameConfig;
 
   // Param actions
   setParam: <K extends keyof BinParams>(key: K, value: BinParams[K]) => void;
@@ -245,6 +263,7 @@ export interface DesignerState {
   setCurrentDesignId: (id: string | null) => void;
   setDesignName: (name: string) => void;
   setSaveStatus: (status: SaveStatus) => void;
+  setExportFileNameConfig: (config: ExportFileNameConfig) => void;
   newDesign: () => void;
   loadDesign: (design: SavedDesign) => void;
 

--- a/src/features/bin-designer/utils/fileNaming.ts
+++ b/src/features/bin-designer/utils/fileNaming.ts
@@ -1,40 +1,95 @@
 /**
  * File naming utilities for bin exports.
  *
- * Generates descriptive or compact file names from bin parameters.
+ * Generates descriptive, compact, or custom file names from bin parameters
+ * and optional design name.
  */
 
-import type { BinParams } from '../types';
+import type { BinParams, FileNameStyle, ExportFileNameConfig } from '../types';
 
-/** File naming style */
-export type FileNameStyle = 'descriptive' | 'compact';
+/** Default export filename config */
+export const DEFAULT_EXPORT_FILE_NAME_CONFIG: ExportFileNameConfig = {
+  style: 'descriptive',
+  customName: '',
+};
+
+/** Characters not allowed in filenames (replaced with underscore) */
+const UNSAFE_CHARS = /[<>:"/\\|?*\x00-\x1f]/g;
 
 /**
- * Generates a file name from bin parameters and export format.
+ * Sanitizes a string for use in a filename.
+ * Replaces unsafe characters and trims whitespace.
+ */
+export function sanitizeFileName(name: string): string {
+  return name.replace(UNSAFE_CHARS, '_').trim();
+}
+
+/**
+ * Determines the effective design name prefix.
+ * Returns null if the design name is the default "Untitled Bin" or empty.
+ */
+function getEffectiveDesignName(designName: string | undefined): string | null {
+  if (!designName || designName === 'Untitled Bin' || designName.trim() === '') {
+    return null;
+  }
+  return sanitizeFileName(designName);
+}
+
+export type { FileNameStyle };
+
+/**
+ * Generates a file name from bin parameters, export format, and naming config.
  *
  * @example
- * // Descriptive: "gridfinity_2x3x6_dividers_scoop.stl"
- * generateFileName(params, 'stl', 'descriptive')
+ * // Descriptive (no design name): "gridfinity_2x3x6_scoop.stl"
+ * generateFileName(params, 'stl', { style: 'descriptive', customName: '' })
  *
- * // Compact: "gf_2x3x6.stl"
- * generateFileName(params, 'stl', 'compact')
+ * // Descriptive (with design name): "Screwdriver Bin_2x3x6_scoop.stl"
+ * generateFileName(params, 'stl', { style: 'descriptive', customName: '' }, 'Screwdriver Bin')
+ *
+ * // Compact (no design name): "gf_2x3x6.stl"
+ * generateFileName(params, 'stl', { style: 'compact', customName: '' })
+ *
+ * // Compact (with design name): "Screwdriver Bin_2x3x6.stl"
+ * generateFileName(params, 'stl', { style: 'compact', customName: '' }, 'Screwdriver Bin')
+ *
+ * // Custom: "my-special-bin.stl"
+ * generateFileName(params, 'stl', { style: 'custom', customName: 'my-special-bin' })
  */
 export function generateFileName(
   params: BinParams,
   format: string,
-  style: FileNameStyle = 'descriptive'
+  config: FileNameStyle | ExportFileNameConfig = 'descriptive',
+  designName?: string
 ): string {
   const ext = format.toLowerCase();
-  const dims = formatDimensions(params);
 
-  if (style === 'compact') {
-    return `gf_${dims}.${ext}`;
+  // Normalize legacy string-based style to config object
+  const resolved: ExportFileNameConfig =
+    typeof config === 'string'
+      ? { style: config === 'custom' ? 'descriptive' : config, customName: '' }
+      : config;
+
+  if (resolved.style === 'custom') {
+    const sanitized = sanitizeFileName(resolved.customName);
+    const name = !sanitized || /^_+$/.test(sanitized) ? 'gridfinity-bin' : sanitized;
+    return `${name}.${ext}`;
   }
 
+  const dims = formatDimensions(params);
+  const effectiveName = getEffectiveDesignName(designName);
+
+  if (resolved.style === 'compact') {
+    const prefix = effectiveName ?? 'gf';
+    return `${prefix}_${dims}.${ext}`;
+  }
+
+  // Descriptive style
+  const prefix = effectiveName ?? 'gridfinity';
   const features = collectFeatures(params);
   const featureSuffix = features.length > 0 ? `_${features.join('_')}` : '';
 
-  return `gridfinity_${dims}${featureSuffix}.${ext}`;
+  return `${prefix}_${dims}${featureSuffix}.${ext}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add 3-mode editable filename system to the export dialog: **Descriptive** (auto-generated with features), **Compact** (short prefix + dimensions), and **Custom** (free-text input)
- Named designs (e.g., "Screwdriver Bin") use the design name as the filename prefix instead of `gridfinity`/`gf`
- Each saved design remembers its filename preference via auto-save to IndexedDB
- Unsafe filesystem characters are sanitized automatically

## Implementation
- New `ExportFileNameConfig` type (`style: 'descriptive' | 'compact' | 'custom'`, `customName: string`)
- Extended `generateFileName()` with backward-compatible API (accepts both legacy string and config object)
- Integrated into Zustand store with `setExportFileNameConfig` action
- Persistence via `DesignerStorage.updateDesignParams()` + auto-save hook
- ExportDialog rewritten with inline editable input, extension suffix, and style toggle buttons

## Test plan
- [x] Build passes
- [x] All 4,949 tests pass (193 test files)
- [x] `fileNaming.test.ts`: 58 assertions covering all modes, design name prefix, sanitization
- [x] `ExportDialog.test.tsx`: 20 assertions covering UI, mode switching, custom input
- [x] `useExport.test.ts`: 9 assertions covering download lifecycle with config
- [x] `useAutoSave.test.ts`: 7 assertions covering debounce and config persistence
- [ ] Manual verification of export dialog UX