### PR TITLE
refactor(grid-editor): address code review findings

### DIFF
--- a/src/features/grid-editor/components/Grid/Bin.tsx
+++ b/src/features/grid-editor/components/Grid/Bin.tsx
@@ -13,6 +13,7 @@ import { useToastStore } from '@/core/store/toast';
 import { useResponsive } from '@/shared/hooks';
 import { calcMaxGridUnits, DEFAULT_CATEGORY_COLOR } from '@/core/constants';
 import { getBinTextColors } from '@/shared/utils';
+import { calcFractionalPixelSize } from '@/features/grid-editor/utils/fractionalPixels';
 import { ResizeHandles } from './ResizeHandles';
 
 /** Clamp a value between min and max */
@@ -30,7 +31,6 @@ interface BinProps {
   drawer: Drawer;
   cellSize: number;
   gap?: number;
-  halfBinMode?: boolean;
   isGhost: boolean;
   isSelected: boolean;
   onStartDrag: (
@@ -54,7 +54,6 @@ function BinComponent({
   drawer,
   cellSize,
   gap = 1,
-  halfBinMode: _halfBinMode = false,
   isGhost,
   isSelected,
   onStartDrag,
@@ -225,69 +224,23 @@ function BinComponent({
     const gridRowStart = topRow;
     const gridRowSpan = Math.max(1, bottomRow - topRow + 1);
 
-    // Calculate actual pixel dimensions of bin
+    // Calculate actual pixel dimensions using shared fractional pixel utility
     const fractionalCellWidth = fractionalWidthPart * (cellSize + gap) - gap;
     const fractionalCellHeight = fractionalDepthPart * (cellSize + gap) - gap;
 
-    // Calculate pixel width accounting for fractional edge
-    let binPixelWidth: number;
-    if (!hasFractionalDrawerWidth) {
-      binPixelWidth = bin.width * cellSize + Math.max(0, bin.width - 1) * gap;
-    } else if (fractionalEdgeX === 'start') {
-      const inFractional = Math.max(0, Math.min(binEndX, fractionalWidthPart) - Math.max(bin.x, 0));
-      const inInteger = bin.width - inFractional;
-      let width = 0;
-      if (inFractional > 0) {
-        width += (inFractional / fractionalWidthPart) * fractionalCellWidth;
-      }
-      if (inInteger > 0) {
-        if (inFractional > 0) width += gap;
-        width += inInteger * cellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
-      }
-      binPixelWidth = width;
-    } else {
-      const inInteger = Math.max(0, Math.min(binEndX, integerWidth) - bin.x);
-      const inFractional = bin.width - inInteger;
-      let width = 0;
-      if (inInteger > 0) {
-        width += inInteger * cellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
-      }
-      if (inFractional > 0) {
-        if (inInteger > 0) width += gap;
-        width += (inFractional / fractionalWidthPart) * fractionalCellWidth;
-      }
-      binPixelWidth = width;
-    }
+    const binPixelWidth = calcFractionalPixelSize(bin.x, bin.width, {
+      drawerDimension: drawer.width,
+      fractionalEdge: fractionalEdgeX,
+      cellSize,
+      gap,
+    });
 
-    // Calculate pixel height accounting for fractional edge
-    let binPixelHeight: number;
-    if (!hasFractionalDrawerDepth) {
-      binPixelHeight = bin.depth * cellSize + Math.max(0, bin.depth - 1) * gap;
-    } else if (fractionalEdgeY === 'start') {
-      const inFractional = Math.max(0, Math.min(binEndY, fractionalDepthPart) - Math.max(bin.y, 0));
-      const inInteger = bin.depth - inFractional;
-      let height = 0;
-      if (inFractional > 0) {
-        height += (inFractional / fractionalDepthPart) * fractionalCellHeight;
-      }
-      if (inInteger > 0) {
-        if (inFractional > 0) height += gap;
-        height += inInteger * cellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
-      }
-      binPixelHeight = height;
-    } else {
-      const inInteger = Math.max(0, Math.min(binEndY, integerDepth) - bin.y);
-      const inFractional = bin.depth - inInteger;
-      let height = 0;
-      if (inInteger > 0) {
-        height += inInteger * cellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
-      }
-      if (inFractional > 0) {
-        if (inInteger > 0) height += gap;
-        height += (inFractional / fractionalDepthPart) * fractionalCellHeight;
-      }
-      binPixelHeight = height;
-    }
+    const binPixelHeight = calcFractionalPixelSize(bin.y, bin.depth, {
+      drawerDimension: drawer.depth,
+      fractionalEdge: fractionalEdgeY,
+      cellSize,
+      gap,
+    });
 
     // Need custom sizing when drawer has fractional dimensions or bin has fractional coords
     const needsCustomSizing =
@@ -911,7 +864,7 @@ function binPropsAreEqual(prevProps: BinProps, nextProps: BinProps): boolean {
     return false;
   }
 
-  // Re-render if customProperties change (compare by key count and values)
+  // Re-render if customProperties change (compare keys and values)
   const prevCustomProps = prevBin.customProperties;
   const nextCustomProps = nextBin.customProperties;
   const prevHasProps = prevCustomProps && Object.keys(prevCustomProps).length > 0;
@@ -923,6 +876,9 @@ function binPropsAreEqual(prevProps: BinProps, nextProps: BinProps): boolean {
     const prevKeys = Object.keys(prevCustomProps);
     const nextKeys = Object.keys(nextCustomProps);
     if (prevKeys.length !== nextKeys.length) return false;
+    for (const key of prevKeys) {
+      if (prevCustomProps[key] !== nextCustomProps[key]) return false;
+    }
   }
 
   // Re-render if category changes
@@ -953,11 +909,6 @@ function binPropsAreEqual(prevProps: BinProps, nextProps: BinProps): boolean {
 
   // Re-render if cellSize or gap changes (affects sizing)
   if (prevProps.cellSize !== nextProps.cellSize || prevProps.gap !== nextProps.gap) {
-    return false;
-  }
-
-  // Re-render if halfBinMode changes (affects grid positioning)
-  if (prevProps.halfBinMode !== nextProps.halfBinMode) {
     return false;
   }
 

--- a/src/features/grid-editor/components/Grid/DrawerResizeHandles.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerResizeHandles.tsx
@@ -23,7 +23,7 @@ export interface DrawerResizeHandlesProps {
   /** Whether resize handles should pulse (first-use hint) */
   shouldPulse: boolean;
   /** Start resize operation */
-  onResizeStart: (direction: ResizeDirection, e: React.MouseEvent) => void;
+  onResizeStart: (direction: ResizeDirection, e: React.PointerEvent) => void;
 }
 
 export const DrawerResizeHandles = memo(function DrawerResizeHandles({
@@ -48,7 +48,7 @@ export const DrawerResizeHandles = memo(function DrawerResizeHandles({
           width: 24,
           cursor: 'ew-resize',
         }}
-        onMouseDown={(e) => onResizeStart('width', e)}
+        onPointerDown={(e) => onResizeStart('width', e)}
         title="Drag to add/remove columns"
       >
         <div
@@ -71,7 +71,7 @@ export const DrawerResizeHandles = memo(function DrawerResizeHandles({
           height: 24,
           cursor: 'ns-resize',
         }}
-        onMouseDown={(e) => onResizeStart('depth', e)}
+        onPointerDown={(e) => onResizeStart('depth', e)}
         title="Drag to add/remove rows"
       >
         <div
@@ -95,7 +95,7 @@ export const DrawerResizeHandles = memo(function DrawerResizeHandles({
           height: 24,
           cursor: 'nwse-resize',
         }}
-        onMouseDown={(e) => onResizeStart('both', e)}
+        onPointerDown={(e) => onResizeStart('both', e)}
         title="Drag to add/remove rows and columns"
       >
         <div

--- a/src/features/grid-editor/components/Grid/GridCanvas.tsx
+++ b/src/features/grid-editor/components/Grid/GridCanvas.tsx
@@ -4,6 +4,7 @@ import { useShallow } from 'zustand/shallow';
 import { useUIStore, useLayoutStore } from '@/core/store';
 import { useGridCoords, useGridTemplate } from '@/features/grid-editor/hooks';
 import { Bin } from './Bin';
+
 import { getBlockedZones } from '@/shared/utils/collision';
 import { DEFAULT_CATEGORY_COLOR } from '@/core/constants';
 import type { Coord, ResizeHandle } from '@/core/types';
@@ -58,7 +59,7 @@ export function GridCanvas({
     }))
   );
 
-  const { getGridCoords, halfBinMode } = useGridCoords(gridRef);
+  const { getGridCoords } = useGridCoords(gridRef);
 
   // Memoized: Filter bins for current layer
   const activeBins = useMemo(
@@ -84,6 +85,7 @@ export function GridCanvas({
   const categoryMap = useMemo(() => new Map(categories.map((c) => [c.id, c])), [categories]);
   const layerMap = useMemo(() => new Map(layers.map((l) => [l.id, l])), [layers]);
   const binMap = useMemo(() => new Map(bins.map((b) => [b.id, b])), [bins]);
+  const selectedBinIdSet = useMemo(() => new Set(selectedBinIds), [selectedBinIds]);
 
   // Capture phase handler for paint mode - runs before Bin components can stop propagation
   const handlePointerDownCapture = (e: PointerEvent<HTMLDivElement>) => {
@@ -266,7 +268,6 @@ export function GridCanvas({
             drawer={drawer}
             cellSize={cellSize}
             gap={gap}
-            halfBinMode={halfBinMode}
             isGhost
             isSelected={false}
             onStartDrag={onStartDrag}
@@ -376,9 +377,8 @@ export function GridCanvas({
             drawer={drawer}
             cellSize={cellSize}
             gap={gap}
-            halfBinMode={halfBinMode}
             isGhost={false}
-            isSelected={selectedBinIds.includes(bin.id)}
+            isSelected={selectedBinIdSet.has(bin.id)}
             onStartDrag={onStartDrag}
             onStartResize={onStartResize}
           />

--- a/src/features/grid-editor/components/Grid/IsometricPreview/BinMesh.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/BinMesh.tsx
@@ -39,10 +39,11 @@ export const BinMesh = memo(function BinMesh({
     baseColor: color,
   });
 
-  // Animate emissive intensity for selected bins (slow pulse)
+  // Animate emissive intensity for selected bins (slow pulse).
+  // This component is only mounted for selected bins (non-selected use MergedBinMeshes),
+  // so this callback only runs for the small number of actively selected bins.
   useFrame(({ clock }) => {
     if (materialRef.current && isSelected) {
-      // Slow sine wave: 0.3 to 0.5 intensity over ~2 seconds
       const pulse = 0.4 + Math.sin(clock.elapsedTime * Math.PI) * 0.1;
       materialRef.current.emissiveIntensity = pulse;
     }

--- a/src/features/grid-editor/components/Grid/IsometricPreview/MergedBinMeshes.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/MergedBinMeshes.tsx
@@ -65,7 +65,9 @@ export function MergedBinMeshes({ bins }: MergedBinMeshesProps) {
   // Build merged geometry for all bins
   const geometry = useMemo(() => buildMergedGeometry(bins), [bins]);
 
-  // Cleanup geometry on change or unmount
+  // Cleanup geometry on change or unmount.
+  // When `geometry` changes: cleanup disposes the previous value, new effect captures the new one.
+  // On unmount: cleanup disposes the current geometry.
   useEffect(() => {
     return () => {
       geometry?.dispose();

--- a/src/features/grid-editor/components/Grid/Overlay.tsx
+++ b/src/features/grid-editor/components/Grid/Overlay.tsx
@@ -1,5 +1,10 @@
+import { useMemo } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { useLayoutStore, useInteractionStore, useHalfBinModeStore } from '@/core/store';
+import {
+  calcFractionalPixelSize,
+  type FractionalGridContext,
+} from '@/features/grid-editor/utils/fractionalPixels';
 
 interface OverlayProps {
   cellSize: number;
@@ -22,112 +27,45 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
     }))
   );
 
-  // Always use standard cell size (grid renders at normal dimensions)
-  // Half-bin mode only affects snapping, not visual grid size
   const visualCellSize = cellSize;
-  // No scaling needed - grid is always standard dimensions
-  const scale = 1;
-  // Visual grid dimensions (standard)
   const visualDepth = drawer.depth;
   const integerDepth = Math.floor(drawer.depth);
+
+  // O(1) lookup map for bins (avoids O(n) .find() calls in render loops)
+  const binMap = useMemo(() => new Map(bins.map((b) => [b.id, b])), [bins]);
 
   // Fractional edge settings affect visual positioning
   const hasFractionalWidth = drawer.width % 1 !== 0;
   const hasFractionalDepth = drawer.depth % 1 !== 0;
   const fractionalEdgeX = drawer.fractionalEdgeX ?? 'end';
   const fractionalEdgeY = drawer.fractionalEdgeY ?? 'end';
-
-  // Calculate fractional cell dimensions
   const fractionalWidthPart = drawer.width - Math.floor(drawer.width);
   const fractionalDepthPart = drawer.depth - Math.floor(drawer.depth);
   const fractionalCellWidth = fractionalWidthPart * (cellSize + gap) - gap;
   const fractionalCellHeight = fractionalDepthPart * (cellSize + gap) - gap;
 
+  // Shared fractional grid contexts for width and depth calculations
+  const widthCtx: FractionalGridContext = {
+    drawerDimension: drawer.width,
+    fractionalEdge: fractionalEdgeX,
+    cellSize: visualCellSize,
+    gap,
+  };
+  const depthCtx: FractionalGridContext = {
+    drawerDimension: drawer.depth,
+    fractionalEdge: fractionalEdgeY,
+    cellSize: visualCellSize,
+    gap,
+  };
+
   // Helper to calculate pixel dimension for grid elements (standard calculation)
   const toPixels = (units: number) => units * visualCellSize + Math.max(0, units - 1) * gap;
 
-  // Calculate pixel width accounting for fractional edges
-  const calcPixelWidth = (x: number, width: number): number => {
-    if (!hasFractionalWidth) {
-      return width * visualCellSize + Math.max(0, width - 1) * gap;
-    }
-
-    const binEndX = x + width;
-
-    if (fractionalEdgeX === 'start') {
-      // Fractional column at left [0, fractionalWidthPart)
-      const inFractional = Math.max(0, Math.min(binEndX, fractionalWidthPart) - Math.max(x, 0));
-      const inInteger = width - inFractional;
-
-      let pixelWidth = 0;
-      if (inFractional > 0) {
-        pixelWidth += (inFractional / fractionalWidthPart) * fractionalCellWidth;
-      }
-      if (inInteger > 0) {
-        if (inFractional > 0) pixelWidth += gap;
-        pixelWidth +=
-          inInteger * visualCellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
-      }
-      return pixelWidth;
-    } else {
-      // Fractional column at right
-      const integerWidth = Math.floor(drawer.width);
-      const inInteger = Math.max(0, Math.min(binEndX, integerWidth) - x);
-      const inFractional = width - inInteger;
-
-      let pixelWidth = 0;
-      if (inInteger > 0) {
-        pixelWidth +=
-          inInteger * visualCellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
-      }
-      if (inFractional > 0) {
-        if (inInteger > 0) pixelWidth += gap;
-        pixelWidth += (inFractional / fractionalWidthPart) * fractionalCellWidth;
-      }
-      return pixelWidth;
-    }
-  };
-
-  // Calculate pixel height accounting for fractional edges
-  const calcPixelHeight = (y: number, depth: number): number => {
-    if (!hasFractionalDepth) {
-      return depth * visualCellSize + Math.max(0, depth - 1) * gap;
-    }
-
-    const binEndY = y + depth;
-
-    if (fractionalEdgeY === 'start') {
-      // Fractional row at bottom [0, fractionalDepthPart)
-      const inFractional = Math.max(0, Math.min(binEndY, fractionalDepthPart) - Math.max(y, 0));
-      const inInteger = depth - inFractional;
-
-      let pixelHeight = 0;
-      if (inFractional > 0) {
-        pixelHeight += (inFractional / fractionalDepthPart) * fractionalCellHeight;
-      }
-      if (inInteger > 0) {
-        if (inFractional > 0) pixelHeight += gap;
-        pixelHeight +=
-          inInteger * visualCellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
-      }
-      return pixelHeight;
-    } else {
-      // Fractional row at top [integerDepth, drawer.depth)
-      const inInteger = Math.max(0, Math.min(binEndY, integerDepth) - y);
-      const inFractional = depth - inInteger;
-
-      let pixelHeight = 0;
-      if (inInteger > 0) {
-        pixelHeight +=
-          inInteger * visualCellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
-      }
-      if (inFractional > 0) {
-        if (inInteger > 0) pixelHeight += gap;
-        pixelHeight += (inFractional / fractionalDepthPart) * fractionalCellHeight;
-      }
-      return pixelHeight;
-    }
-  };
+  // Calculate pixel width/height accounting for fractional edges
+  const calcPixelWidth = (x: number, width: number) =>
+    calcFractionalPixelSize(x, width, widthCtx);
+  const calcPixelHeight = (y: number, depth: number) =>
+    calcFractionalPixelSize(y, depth, depthCtx);
 
   // Helper to calculate left position accounting for fractional edge
   // When fractionalEdgeX='start', the first column is narrower
@@ -207,15 +145,10 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
     const width = x2 - x1 + minUnit;
     const depth = y2 - y1 + minUnit;
 
-    // Scale coordinates for half-bin mode
-    const vx1 = x1 * scale;
-    const vWidth = width * scale;
-    const vDepth = depth * scale;
-
-    const left = calcLeft(vx1);
-    const top = calcTop(y1 * scale, vDepth);
-    const rectWidth = calcPixelWidth(vx1, vWidth);
-    const rectHeight = calcPixelHeight(y1 * scale, vDepth);
+    const left = calcLeft(x1);
+    const top = calcTop(y1, depth);
+    const rectWidth = calcPixelWidth(x1, width);
+    const rectHeight = calcPixelHeight(y1, depth);
 
     previews.push(
       <div
@@ -239,7 +172,7 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
     if (!isOverGrid) {
       // Don't render any preview when dragging outside grid
     } else {
-      const primaryBin = bins.find((b) => b.id === binIds[0]);
+      const primaryBin = binMap.get(binIds[0]);
       if (!primaryBin) return null;
 
       const borderColor = valid ? 'var(--color-success)' : 'var(--color-error)';
@@ -251,23 +184,17 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
 
       // Draw preview for each bin being dragged with uniform delta applied
       for (const binId of binIds) {
-        const bin = bins.find((b) => b.id === binId);
+        const bin = binMap.get(binId);
         if (!bin) continue;
 
         // Apply uniform delta - NO individual clamping (preserves arrangement)
         const newX = bin.x + deltaX;
         const newY = bin.y + deltaY;
 
-        // Scale for half-bin mode
-        const vNewX = newX * scale;
-        const vNewY = newY * scale;
-        const vBinWidth = bin.width * scale;
-        const vBinDepth = bin.depth * scale;
-
-        const left = calcLeft(vNewX);
-        const top = calcTop(vNewY, vBinDepth);
-        const rectWidth = calcPixelWidth(vNewX, vBinWidth);
-        const rectHeight = calcPixelHeight(vNewY, vBinDepth);
+        const left = calcLeft(newX);
+        const top = calcTop(newY, bin.depth);
+        const rectWidth = calcPixelWidth(newX, bin.width);
+        const rectHeight = calcPixelHeight(newY, bin.depth);
 
         previews.push(
           <div
@@ -294,18 +221,13 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
     // Draw preview for each bin being resized
     for (const binId of binIds) {
       const currentRect = currentRects.get(binId);
-      const originalBin = bins.find((b) => b.id === binId);
+      const originalBin = binMap.get(binId);
       if (!currentRect || !originalBin) continue;
 
-      // Scale for half-bin mode
-      const vRectX = currentRect.x * scale;
-      const vRectWidth = currentRect.width * scale;
-      const vRectDepth = currentRect.depth * scale;
-
-      const left = calcLeft(vRectX);
-      const top = calcTop(currentRect.y * scale, vRectDepth);
-      const rectWidth = toPixels(vRectWidth);
-      const rectHeight = toPixels(vRectDepth);
+      const left = calcLeft(currentRect.x);
+      const top = calcTop(currentRect.y, currentRect.depth);
+      const rectWidth = toPixels(currentRect.width);
+      const rectHeight = toPixels(currentRect.depth);
 
       // Ghost outline of original size (dashed gray border)
       const sizeChanged =
@@ -315,15 +237,10 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
         currentRect.depth !== originalBin.depth;
 
       if (sizeChanged) {
-        // Scale original bin dimensions
-        const vOrigX = originalBin.x * scale;
-        const vOrigWidth = originalBin.width * scale;
-        const vOrigDepth = originalBin.depth * scale;
-
-        const origLeft = calcLeft(vOrigX);
-        const origTop = calcTop(originalBin.y * scale, vOrigDepth);
-        const origWidth = toPixels(vOrigWidth);
-        const origHeight = toPixels(vOrigDepth);
+        const origLeft = calcLeft(originalBin.x);
+        const origTop = calcTop(originalBin.y, originalBin.depth);
+        const origWidth = toPixels(originalBin.width);
+        const origHeight = toPixels(originalBin.depth);
 
         previews.push(
           <div
@@ -364,22 +281,17 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
     }
   } else if (interaction.type === 'stagingDrag') {
     const { binId, currentCoord, valid } = interaction;
-    const bin = bins.find((b) => b.id === binId);
+    const bin = binMap.get(binId);
 
     // Only show preview if we have a valid coordinate (mouse is over grid)
     if (bin && currentCoord) {
       const borderColor = valid ? 'var(--color-success)' : 'var(--color-error)';
       const bgColor = valid ? 'var(--color-success-muted)' : 'var(--color-error-muted)';
 
-      // Scale for half-bin mode
-      const vCoordX = currentCoord.x * scale;
-      const vBinWidth = bin.width * scale;
-      const vBinDepth = bin.depth * scale;
-
-      const left = calcLeft(vCoordX);
-      const top = calcTop(currentCoord.y * scale, vBinDepth);
-      const rectWidth = toPixels(vBinWidth);
-      const rectHeight = toPixels(vBinDepth);
+      const left = calcLeft(currentCoord.x);
+      const top = calcTop(currentCoord.y, bin.depth);
+      const rectWidth = toPixels(bin.width);
+      const rectHeight = toPixels(bin.depth);
 
       previews.push(
         <div
@@ -419,16 +331,11 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
     const remainderDepth = areaDepth - usedDepth;
     const hasRemainder = remainderWidth > 0 || remainderDepth > 0;
 
-    // Scale for half-bin mode
-    const vx1 = x1 * scale;
-    const vAreaWidth = areaWidth * scale;
-    const vAreaDepth = areaDepth * scale;
-
     // Outer selection area (amber dashed like draw)
-    const areaLeft = calcLeft(vx1);
-    const areaTop = calcTop(y1 * scale, vAreaDepth);
-    const areaPixelWidth = toPixels(vAreaWidth);
-    const areaPixelHeight = toPixels(vAreaDepth);
+    const areaLeft = calcLeft(x1);
+    const areaTop = calcTop(y1, areaDepth);
+    const areaPixelWidth = toPixels(areaWidth);
+    const areaPixelHeight = toPixels(areaDepth);
 
     previews.push(
       <div
@@ -448,22 +355,15 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
 
     // Draw grid of bin previews
     if (binsAcross > 0 && binsDown > 0) {
-      // Scale paint size for visual display
-      const vPaintWidth = paintSize.width * scale;
-      const vPaintDepth = paintSize.depth * scale;
-
       for (let row = 0; row < binsDown; row++) {
         for (let col = 0; col < binsAcross; col++) {
           const binX = x1 + col * paintSize.width;
           const binY = y1 + row * paintSize.depth;
 
-          // Scale coordinates
-          const vBinX = binX * scale;
-
-          const left = calcLeft(vBinX);
-          const top = calcTop(binY * scale, vPaintDepth);
-          const rectWidth = toPixels(vPaintWidth);
-          const rectHeight = toPixels(vPaintDepth);
+          const left = calcLeft(binX);
+          const top = calcTop(binY, paintSize.depth);
+          const rectWidth = toPixels(paintSize.width);
+          const rectHeight = toPixels(paintSize.depth);
 
           previews.push(
             <div
@@ -486,20 +386,14 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
 
     // Show remainder area as red/warning if it exists
     if (hasRemainder) {
-      // Scale remainder dimensions
-      const vRemainderWidth = remainderWidth * scale;
-      const vRemainderDepth = remainderDepth * scale;
-      const vUsedDepth = usedDepth * scale;
-
       // Right remainder strip
       if (remainderWidth > 0 && binsDown > 0) {
         const stripX = x1 + usedWidth;
-        const vStripX = stripX * scale;
 
-        const stripLeft = calcLeft(vStripX);
-        const stripTop = calcTop(y1 * scale, vUsedDepth);
-        const stripWidth = toPixels(vRemainderWidth);
-        const stripHeight = toPixels(vUsedDepth);
+        const stripLeft = calcLeft(stripX);
+        const stripTop = calcTop(y1, usedDepth);
+        const stripWidth = toPixels(remainderWidth);
+        const stripHeight = toPixels(usedDepth);
 
         previews.push(
           <div
@@ -521,10 +415,10 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
       if (remainderDepth > 0) {
         const stripY = y1 + usedDepth;
 
-        const stripLeft = calcLeft(vx1);
-        const stripTop = calcTop(stripY * scale, vRemainderDepth);
-        const stripWidth = toPixels(vAreaWidth);
-        const stripHeight = toPixels(vRemainderDepth);
+        const stripLeft = calcLeft(x1);
+        const stripTop = calcTop(stripY, remainderDepth);
+        const stripWidth = toPixels(areaWidth);
+        const stripHeight = toPixels(remainderDepth);
 
         previews.push(
           <div

--- a/src/features/grid-editor/components/Grid/QuickLabelPopover.tsx
+++ b/src/features/grid-editor/components/Grid/QuickLabelPopover.tsx
@@ -91,7 +91,7 @@ function QuickLabelPopoverInner({ binId }: { binId: string }) {
   if (!bin) return null;
 
   // Find the bin element to position the popover
-  const binElement = document.querySelector(`[data-bin-id="${binId}"]`);
+  const binElement = document.querySelector(`[data-bin-id="${CSS.escape(binId)}"]`);
   if (!binElement) return null;
 
   const binRect = binElement.getBoundingClientRect();

--- a/src/features/grid-editor/hooks/useGridNavigation.ts
+++ b/src/features/grid-editor/hooks/useGridNavigation.ts
@@ -69,7 +69,7 @@ export function useGridNavigation() {
     if (!focusedBinId) return;
 
     // Find bin element by data attribute
-    const binElement = document.querySelector(`[data-bin-id="${focusedBinId}"]`);
+    const binElement = document.querySelector(`[data-bin-id="${CSS.escape(focusedBinId)}"]`);
     if (binElement instanceof HTMLElement) {
       binElement.focus();
     }

--- a/src/features/grid-editor/hooks/useGridResize.ts
+++ b/src/features/grid-editor/hooks/useGridResize.ts
@@ -33,8 +33,8 @@ export interface GridResizeState {
   pendingResize: PendingResize | null;
   /** Whether resize handles should pulse (first-use hint) */
   shouldPulseResizeHandles: boolean;
-  /** Start resize operation from mouse event */
-  handleResizeStart: (direction: ResizeDirection, e: React.MouseEvent) => void;
+  /** Start resize operation from pointer event */
+  handleResizeStart: (direction: ResizeDirection, e: React.PointerEvent) => void;
   /** Confirm pending resize - moves clipped bins to staging */
   confirmResize: () => void;
   /** Cancel pending resize - reverts to original size */
@@ -80,6 +80,9 @@ export function useGridResize(options: UseGridResizeOptions): GridResizeState {
   const pulseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const stopPulseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Track captured pointer for explicit release on cleanup (matches useInteraction pattern)
+  const capturedPointerRef = useRef<{ element: HTMLElement; pointerId: number } | null>(null);
+
   // Use ref to track current drawer dimensions without causing effect re-runs
   const drawerRef = useRef(drawer);
   useEffect(() => {
@@ -106,8 +109,11 @@ export function useGridResize(options: UseGridResizeOptions): GridResizeState {
     };
   }, []);
 
-  const handleResizeStart = useCallback((direction: ResizeDirection, e: React.MouseEvent) => {
+  const handleResizeStart = useCallback((direction: ResizeDirection, e: React.PointerEvent) => {
     e.preventDefault();
+    const target = e.target as HTMLElement;
+    target.setPointerCapture(e.pointerId);
+    capturedPointerRef.current = { element: target, pointerId: e.pointerId };
     setResizeDirection(direction);
     setResizeStart({
       x: e.clientX,
@@ -120,7 +126,7 @@ export function useGridResize(options: UseGridResizeOptions): GridResizeState {
   useEffect(() => {
     if (!resizeDirection || !resizeStart) return;
 
-    const handleMouseMove = (e: MouseEvent) => {
+    const handlePointerMove = (e: PointerEvent) => {
       const dx = e.clientX - resizeStart.x;
       const dy = e.clientY - resizeStart.y;
       const cellStep = cellSize + gap;
@@ -146,7 +152,21 @@ export function useGridResize(options: UseGridResizeOptions): GridResizeState {
       }
     };
 
-    const handleMouseUp = () => {
+    const releaseCapture = () => {
+      if (capturedPointerRef.current) {
+        try {
+          capturedPointerRef.current.element.releasePointerCapture(
+            capturedPointerRef.current.pointerId
+          );
+        } catch {
+          // Element may have been removed from DOM
+        }
+        capturedPointerRef.current = null;
+      }
+    };
+
+    const handlePointerUp = () => {
+      releaseCapture();
       // Read current state directly from store to ensure we have the latest values
       const currentState = useLayoutStore.getState().layout;
       const currentDrawer = currentState.drawer;
@@ -183,11 +203,12 @@ export function useGridResize(options: UseGridResizeOptions): GridResizeState {
       setResizeStart(null);
     };
 
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
+    document.addEventListener('pointermove', handlePointerMove);
+    document.addEventListener('pointerup', handlePointerUp);
     return () => {
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
+      document.removeEventListener('pointermove', handlePointerMove);
+      document.removeEventListener('pointerup', handlePointerUp);
+      releaseCapture();
     };
   }, [resizeDirection, resizeStart, cellSize, gap, updateDrawer]);
 

--- a/src/features/grid-editor/hooks/useGridZoom.ts
+++ b/src/features/grid-editor/hooks/useGridZoom.ts
@@ -100,19 +100,13 @@ export function useGridZoom(options: UseGridZoomOptions): GridZoomState {
     setZoom(clampedZoom);
   }, [drawerWidth, drawerDepth, gap, setZoom, isMobile, scrollContainerRef]);
 
-  // Fit to screen on initial mount and when drawer size changes (but not during resize drag)
-  // Uses useLayoutEffect to calculate zoom synchronously before paint, preventing CLS
+  // Fit to screen on initial mount, drawer size changes, or 3D preview toggle.
+  // Uses useLayoutEffect to calculate zoom synchronously before paint, preventing CLS.
+  // Skips during active resize drag to avoid fighting the user's intent.
   useLayoutEffect(() => {
-    // Skip while user is actively resizing via handles
     if (isResizing) return;
     fitToScreen();
-  }, [fitToScreen, drawerWidth, drawerDepth, isResizing]);
-
-  // Refit when 3D preview is toggled (changes available width on desktop, height on mobile)
-  // Uses useLayoutEffect for immediate response to user interaction
-  useLayoutEffect(() => {
-    fitToScreen();
-  }, [showIsometricPreview, fitToScreen]);
+  }, [fitToScreen, drawerWidth, drawerDepth, isResizing, showIsometricPreview]);
 
   return {
     zoom,

--- a/src/features/grid-editor/utils/fractionalPixels.ts
+++ b/src/features/grid-editor/utils/fractionalPixels.ts
@@ -1,0 +1,80 @@
+/**
+ * Fractional Pixel Calculations
+ *
+ * Shared utility for computing pixel dimensions of grid elements that may
+ * span both fractional and integer columns/rows. Used by Overlay.tsx (for
+ * interaction previews) and Bin.tsx (for bin sizing).
+ *
+ * When a drawer has non-integer dimensions (e.g., 10.5 units wide), one
+ * column/row is narrower than the others. Bins spanning the fractional
+ * boundary need proportional pixel sizing.
+ */
+
+export interface FractionalGridContext {
+  /** Full drawer dimension in grid units (e.g., 10.5) */
+  drawerDimension: number;
+  /** Which edge the fractional column/row is on */
+  fractionalEdge: 'start' | 'end';
+  /** Cell size in pixels */
+  cellSize: number;
+  /** Gap between cells in pixels */
+  gap: number;
+}
+
+/**
+ * Calculate the pixel size of a region along one axis, accounting for
+ * fractional edge columns/rows.
+ *
+ * @param position - Start position in grid units (x or y)
+ * @param size - Size in grid units (width or depth)
+ * @param ctx - Grid context (drawer dimension, edge, cell size, gap)
+ * @returns Pixel size of the region
+ */
+export function calcFractionalPixelSize(
+  position: number,
+  size: number,
+  ctx: FractionalGridContext
+): number {
+  const { drawerDimension, fractionalEdge, cellSize, gap } = ctx;
+  const integerDimension = Math.floor(drawerDimension);
+  const fractionalPart = drawerDimension - integerDimension;
+  const hasFractional = fractionalPart > 0;
+
+  // Standard case: no fractional dimension
+  if (!hasFractional) {
+    return size * cellSize + Math.max(0, size - 1) * gap;
+  }
+
+  const fractionalCellSize = fractionalPart * (cellSize + gap) - gap;
+  const regionEnd = position + size;
+
+  if (fractionalEdge === 'start') {
+    // Fractional region at [0, fractionalPart)
+    const inFractional = Math.max(0, Math.min(regionEnd, fractionalPart) - Math.max(position, 0));
+    const inInteger = size - inFractional;
+
+    let pixels = 0;
+    if (inFractional > 0) {
+      pixels += (inFractional / fractionalPart) * fractionalCellSize;
+    }
+    if (inInteger > 0) {
+      if (inFractional > 0) pixels += gap;
+      pixels += inInteger * cellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
+    }
+    return pixels;
+  } else {
+    // Fractional region at [integerDimension, drawerDimension)
+    const inInteger = Math.max(0, Math.min(regionEnd, integerDimension) - position);
+    const inFractional = size - inInteger;
+
+    let pixels = 0;
+    if (inInteger > 0) {
+      pixels += inInteger * cellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
+    }
+    if (inFractional > 0) {
+      if (inInteger > 0) pixels += gap;
+      pixels += (inFractional / fractionalPart) * fractionalCellSize;
+    }
+    return pixels;
+  }
+}

--- a/src/test/hooks/useGridResize.test.ts
+++ b/src/test/hooks/useGridResize.test.ts
@@ -115,7 +115,9 @@ describe('useGridResize', () => {
         preventDefault: vi.fn(),
         clientX: 100,
         clientY: 100,
-      } as unknown as React.MouseEvent;
+        pointerId: 1,
+        target: { setPointerCapture: vi.fn() },
+      } as unknown as React.PointerEvent;
 
       act(() => {
         result.current.handleResizeStart('width', mockEvent);
@@ -132,7 +134,9 @@ describe('useGridResize', () => {
         preventDefault: vi.fn(),
         clientX: 100,
         clientY: 100,
-      } as unknown as React.MouseEvent;
+        pointerId: 1,
+        target: { setPointerCapture: vi.fn() },
+      } as unknown as React.PointerEvent;
 
       act(() => {
         result.current.handleResizeStart('depth', mockEvent);
@@ -148,7 +152,9 @@ describe('useGridResize', () => {
         preventDefault: vi.fn(),
         clientX: 100,
         clientY: 100,
-      } as unknown as React.MouseEvent;
+        pointerId: 1,
+        target: { setPointerCapture: vi.fn() },
+      } as unknown as React.PointerEvent;
 
       act(() => {
         result.current.handleResizeStart('both', mockEvent);
@@ -158,7 +164,7 @@ describe('useGridResize', () => {
     });
   });
 
-  describe('mouse move during resize', () => {
+  describe('pointer move during resize', () => {
     it('updates drawer width on horizontal drag', () => {
       const cellSize = 32;
       const gap = 2;
@@ -174,12 +180,14 @@ describe('useGridResize', () => {
           preventDefault: vi.fn(),
           clientX: 0,
           clientY: 0,
-        } as unknown as React.MouseEvent);
+          pointerId: 1,
+          target: { setPointerCapture: vi.fn() },
+        } as unknown as React.PointerEvent);
       });
 
-      // Simulate mouse move (2 cells to the right)
+      // Simulate pointer move (2 cells to the right)
       act(() => {
-        const moveEvent = new MouseEvent('mousemove', {
+        const moveEvent = new PointerEvent('pointermove', {
           clientX: cellStep * 2,
           clientY: 0,
         });
@@ -205,12 +213,14 @@ describe('useGridResize', () => {
           preventDefault: vi.fn(),
           clientX: 0,
           clientY: 0,
-        } as unknown as React.MouseEvent);
+          pointerId: 1,
+          target: { setPointerCapture: vi.fn() },
+        } as unknown as React.PointerEvent);
       });
 
-      // Simulate mouse move (3 cells down)
+      // Simulate pointer move (3 cells down)
       act(() => {
-        const moveEvent = new MouseEvent('mousemove', {
+        const moveEvent = new PointerEvent('pointermove', {
           clientX: 0,
           clientY: cellStep * 3,
         });
@@ -238,12 +248,14 @@ describe('useGridResize', () => {
           preventDefault: vi.fn(),
           clientX: 0,
           clientY: 0,
-        } as unknown as React.MouseEvent);
+          pointerId: 1,
+          target: { setPointerCapture: vi.fn() },
+        } as unknown as React.PointerEvent);
       });
 
-      // Simulate diagonal mouse move
+      // Simulate diagonal pointer move
       act(() => {
-        const moveEvent = new MouseEvent('mousemove', {
+        const moveEvent = new PointerEvent('pointermove', {
           clientX: cellStep * 2,
           clientY: cellStep * 3,
         });
@@ -268,12 +280,14 @@ describe('useGridResize', () => {
           preventDefault: vi.fn(),
           clientX: 0,
           clientY: 0,
-        } as unknown as React.MouseEvent);
+          pointerId: 1,
+          target: { setPointerCapture: vi.fn() },
+        } as unknown as React.PointerEvent);
       });
 
       // Simulate large negative move
       act(() => {
-        const moveEvent = new MouseEvent('mousemove', {
+        const moveEvent = new PointerEvent('pointermove', {
           clientX: -cellStep * 100,
           clientY: 0,
         });
@@ -297,12 +311,14 @@ describe('useGridResize', () => {
           preventDefault: vi.fn(),
           clientX: 0,
           clientY: 0,
-        } as unknown as React.MouseEvent);
+          pointerId: 1,
+          target: { setPointerCapture: vi.fn() },
+        } as unknown as React.PointerEvent);
       });
 
       // Simulate large positive move
       act(() => {
-        const moveEvent = new MouseEvent('mousemove', {
+        const moveEvent = new PointerEvent('pointermove', {
           clientX: cellStep * 100,
           clientY: 0,
         });
@@ -314,8 +330,8 @@ describe('useGridResize', () => {
     });
   });
 
-  describe('mouse up completes resize', () => {
-    it('clears resize direction on mouse up', () => {
+  describe('pointer up completes resize', () => {
+    it('clears resize direction on pointer up', () => {
       const { result } = renderHook(() => useGridResize({ cellSize: 32, gap: 2 }));
 
       // Start resize
@@ -324,14 +340,16 @@ describe('useGridResize', () => {
           preventDefault: vi.fn(),
           clientX: 0,
           clientY: 0,
-        } as unknown as React.MouseEvent);
+          pointerId: 1,
+          target: { setPointerCapture: vi.fn() },
+        } as unknown as React.PointerEvent);
       });
 
       expect(result.current.resizeDirection).toBe('width');
 
-      // Mouse up
+      // Pointer up
       act(() => {
-        const upEvent = new MouseEvent('mouseup');
+        const upEvent = new PointerEvent('pointerup');
         document.dispatchEvent(upEvent);
       });
 
@@ -353,12 +371,14 @@ describe('useGridResize', () => {
           preventDefault: vi.fn(),
           clientX: 0,
           clientY: 0,
-        } as unknown as React.MouseEvent);
+          pointerId: 1,
+          target: { setPointerCapture: vi.fn() },
+        } as unknown as React.PointerEvent);
       });
 
       // Increase size (no clipping possible)
       act(() => {
-        const moveEvent = new MouseEvent('mousemove', {
+        const moveEvent = new PointerEvent('pointermove', {
           clientX: cellStep * 2,
           clientY: 0,
         });
@@ -367,7 +387,7 @@ describe('useGridResize', () => {
 
       // Complete resize
       act(() => {
-        const upEvent = new MouseEvent('mouseup');
+        const upEvent = new PointerEvent('pointerup');
         document.dispatchEvent(upEvent);
       });
 
@@ -406,11 +426,13 @@ describe('useGridResize', () => {
           preventDefault: vi.fn(),
           clientX: 0,
           clientY: 0,
-        } as unknown as React.MouseEvent);
+          pointerId: 1,
+          target: { setPointerCapture: vi.fn() },
+        } as unknown as React.PointerEvent);
       });
 
       act(() => {
-        const moveEvent = new MouseEvent('mousemove', {
+        const moveEvent = new PointerEvent('pointermove', {
           clientX: -cellStep * 5,
           clientY: 0,
         });
@@ -418,7 +440,7 @@ describe('useGridResize', () => {
       });
 
       act(() => {
-        const upEvent = new MouseEvent('mouseup');
+        const upEvent = new PointerEvent('pointerup');
         document.dispatchEvent(upEvent);
       });
 
@@ -469,7 +491,9 @@ describe('useGridResize', () => {
           preventDefault: vi.fn(),
           clientX: 0,
           clientY: 0,
-        } as unknown as React.MouseEvent);
+          pointerId: 1,
+          target: { setPointerCapture: vi.fn() },
+        } as unknown as React.PointerEvent);
       });
 
       // Unmount should not throw


### PR DESCRIPTION
## Summary
Address all findings from comprehensive code review of the `grid-editor` feature module.

### Important Fixes
- **Performance**: Add memoized `binMap` to `Overlay.tsx` for O(1) bin lookups during drag/resize (was O(n×m))
- **Performance**: Use `Set` for `selectedBinIds` in `GridCanvas.tsx` for O(1) selection checks (was O(n))
- **Security**: Add `CSS.escape()` to `querySelector` calls that interpolate bin IDs
- **Maintainability**: Extract shared fractional pixel calculation into `utils/fractionalPixels.ts` (was duplicated in Overlay + Bin)
- **Consistency**: Convert drawer resize from mouse events to pointer events (matches rest of interaction system)

### Advisory Fixes
- Remove dead `scale = 1` variable from Overlay.tsx (all `* scale` no-ops removed)
- Remove unused `halfBinMode` prop from Bin component
- Fix incomplete `customProperties` memo comparison (was checking key count only, now checks values)
- Consolidate duplicate `useLayoutEffect` hooks in `useGridZoom`
- Clarify geometry lifecycle in `MergedBinMeshes` with explanatory comment

### Not Addressed (out of scope)
- **A6**: Breaking up `IsometricPreview.tsx` (757 lines) — too risky for a fixes PR, deferred

## Files Changed
- `Overlay.tsx` — Remove dead code, add binMap, use shared pixel utility
- `Bin.tsx` — Remove unused prop, fix memo comparison, use shared pixel utility
- `GridCanvas.tsx` — Use Set for selection, remove halfBinMode prop
- `QuickLabelPopover.tsx` — CSS.escape() for querySelector
- `useGridNavigation.ts` — CSS.escape() for querySelector
- `DrawerResizeHandles.tsx` — pointer events
- `useGridResize.ts` — pointer events
- `useGridZoom.ts` — consolidate layout effects
- `BinMesh.tsx` — clarifying comment
- `MergedBinMeshes.tsx` — clarifying comment
- `utils/fractionalPixels.ts` — new shared utility
- `useGridResize.test.ts` — update mocks for pointer events

## Test plan
- [x] `npm run build` passes (TypeScript + Vite)
- [x] All 4974 tests pass
- [x] No new lint errors introduced
- [ ] Manual testing of grid interactions (draw, drag, resize, paint)
- [ ] Manual testing of drawer resize handles
- [ ] Manual testing with fractional drawer dimensions