### PR TITLE
fix(grid-editor): reset row/column selection anchor on layer change

### DIFF
--- a/src/features/grid-editor/hooks/useGridRowColumnSelection.ts
+++ b/src/features/grid-editor/hooks/useGridRowColumnSelection.ts
@@ -48,6 +48,15 @@ export function useGridRowColumnSelection(
   const [lastClickedRow, setLastClickedRow] = useState<number | null>(null);
   const [lastClickedCol, setLastClickedCol] = useState<number | null>(null);
 
+  // Reset shift-click anchors when layer changes to avoid cross-layer range artifacts
+  // Uses "adjust state during render" pattern (React-recommended over useEffect for prop-derived resets)
+  const [prevLayerId, setPrevLayerId] = useState(activeLayerId);
+  if (prevLayerId !== activeLayerId) {
+    setPrevLayerId(activeLayerId);
+    setLastClickedRow(null);
+    setLastClickedCol(null);
+  }
+
   // Get all bins that occupy any row in the given range (1-indexed row numbers)
   const getBinsInRowRange = useCallback(
     (startRow: number, endRow: number): Bin[] => {

--- a/src/test/hooks/useGridRowColumnSelection.test.ts
+++ b/src/test/hooks/useGridRowColumnSelection.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useGridRowColumnSelection } from '@/features/grid-editor/hooks/useGridRowColumnSelection';
+import { useSelectionStore } from '@/core/store/selection';
+import { resetAllStores } from '@/test/testUtils';
+import type { Bin } from '@/core/types';
+
+describe('useGridRowColumnSelection', () => {
+  beforeEach(() => {
+    resetAllStores();
+  });
+
+  const createBin = (id: string, x: number, y: number, width = 1, depth = 1): Bin => ({
+    id,
+    layerId: 'layer1',
+    x,
+    y,
+    width,
+    depth,
+    height: 3,
+    category: 'coral',
+    label: '',
+    notes: '',
+  });
+
+  const createMouseEvent = (overrides: Partial<React.MouseEvent> = {}): React.MouseEvent => {
+    return {
+      shiftKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      ...overrides,
+    } as React.MouseEvent;
+  };
+
+  describe('handleRowClick', () => {
+    it('selects bins in the clicked row', () => {
+      const bins = [createBin('bin1', 0, 0), createBin('bin2', 1, 0), createBin('bin3', 0, 1)];
+
+      const { result } = renderHook(() =>
+        useGridRowColumnSelection({ bins, activeLayerId: 'layer1' })
+      );
+
+      act(() => {
+        // Row 1 is y=0 (1-indexed row numbers)
+        result.current.handleRowClick(1, createMouseEvent());
+      });
+
+      expect(useSelectionStore.getState().selectedBinIds).toEqual(['bin1', 'bin2']);
+    });
+
+    it('supports shift-click range selection', () => {
+      const bins = [createBin('bin1', 0, 0), createBin('bin2', 0, 1), createBin('bin3', 0, 2)];
+
+      const { result } = renderHook(() =>
+        useGridRowColumnSelection({ bins, activeLayerId: 'layer1' })
+      );
+
+      // Click row 1 first
+      act(() => {
+        result.current.handleRowClick(1, createMouseEvent());
+      });
+
+      // Shift-click row 3
+      act(() => {
+        result.current.handleRowClick(3, createMouseEvent({ shiftKey: true }));
+      });
+
+      // Should select bins in rows 1-3
+      expect(useSelectionStore.getState().selectedBinIds).toContain('bin1');
+      expect(useSelectionStore.getState().selectedBinIds).toContain('bin2');
+      expect(useSelectionStore.getState().selectedBinIds).toContain('bin3');
+    });
+  });
+
+  describe('handleColumnClick', () => {
+    it('selects bins in the clicked column', () => {
+      const bins = [createBin('bin1', 0, 0), createBin('bin2', 0, 1), createBin('bin3', 1, 0)];
+
+      const { result } = renderHook(() =>
+        useGridRowColumnSelection({ bins, activeLayerId: 'layer1' })
+      );
+
+      act(() => {
+        // Column 1 is x=0 (1-indexed)
+        result.current.handleColumnClick(1, createMouseEvent());
+      });
+
+      expect(useSelectionStore.getState().selectedBinIds).toEqual(['bin1', 'bin2']);
+    });
+  });
+
+  describe('layer change resets shift-click anchor', () => {
+    it('resets row anchor when activeLayerId changes', () => {
+      const layer1Bins = [createBin('bin1', 0, 0, 1, 1), createBin('bin2', 0, 2, 1, 1)];
+      const layer2Bins = [
+        { ...createBin('bin3', 0, 0, 1, 1), layerId: 'layer2' },
+        { ...createBin('bin4', 0, 4, 1, 1), layerId: 'layer2' },
+      ];
+      const allBins = [...layer1Bins, ...layer2Bins];
+
+      const { result, rerender } = renderHook(
+        ({ activeLayerId }) => useGridRowColumnSelection({ bins: allBins, activeLayerId }),
+        { initialProps: { activeLayerId: 'layer1' } }
+      );
+
+      // Click row 1 on layer1 to set anchor
+      act(() => {
+        result.current.handleRowClick(1, createMouseEvent());
+      });
+
+      // Switch to layer2
+      rerender({ activeLayerId: 'layer2' });
+
+      // Shift-click row 5 on layer2 — anchor should have been reset
+      // so this should be a normal click (no shift range from old layer)
+      act(() => {
+        result.current.handleRowClick(5, createMouseEvent({ shiftKey: true }));
+      });
+
+      // With anchor reset, shift-click without prior anchor does normal selection
+      // (only bins in row 5, not a range from row 1)
+      const selected = useSelectionStore.getState().selectedBinIds;
+      expect(selected).toContain('bin4');
+      expect(selected).not.toContain('bin1');
+      expect(selected).not.toContain('bin2');
+    });
+
+    it('resets column anchor when activeLayerId changes', () => {
+      const layer1Bins = [createBin('bin1', 0, 0, 1, 1), createBin('bin2', 2, 0, 1, 1)];
+      const layer2Bins = [
+        { ...createBin('bin3', 0, 0, 1, 1), layerId: 'layer2' },
+        { ...createBin('bin4', 4, 0, 1, 1), layerId: 'layer2' },
+      ];
+      const allBins = [...layer1Bins, ...layer2Bins];
+
+      const { result, rerender } = renderHook(
+        ({ activeLayerId }) => useGridRowColumnSelection({ bins: allBins, activeLayerId }),
+        { initialProps: { activeLayerId: 'layer1' } }
+      );
+
+      // Click column 1 on layer1 to set anchor
+      act(() => {
+        result.current.handleColumnClick(1, createMouseEvent());
+      });
+
+      // Switch to layer2
+      rerender({ activeLayerId: 'layer2' });
+
+      // Shift-click column 5 on layer2 — anchor should have been reset
+      act(() => {
+        result.current.handleColumnClick(5, createMouseEvent({ shiftKey: true }));
+      });
+
+      // With anchor reset, shift-click without prior anchor does normal selection
+      const selected = useSelectionStore.getState().selectedBinIds;
+      expect(selected).toContain('bin4');
+      expect(selected).not.toContain('bin1');
+      expect(selected).not.toContain('bin2');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fix shift-click row/column range selection persisting its anchor across layer changes
- When a user clicks a row on Layer A then switches to Layer B, the shift-click anchor was still pointing to the row on Layer A, causing unexpected range selections
- Uses React's "adjust state during render" pattern to reset anchors when `activeLayerId` changes

## Test plan
- [x] Added `useGridRowColumnSelection.test.ts` with 5 tests covering row/column click, shift-click range, and layer-change anchor reset
- [x] All 4992 existing tests pass
- [x] Coverage thresholds maintained (Lines: 83.67%, Branches: 72.31%, Functions: 84.04%)
- [ ] Manual: Click a row label, switch layers, shift-click another row — should select only that row (not a range from old layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)