### PR TITLE
refactor: eliminate cross-feature imports and complete barrel exports

### DIFF
--- a/src/features/bin-designer/__tests__/hooks/useGeneration.test.ts
+++ b/src/features/bin-designer/__tests__/hooks/useGeneration.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useGeneration } from '../../hooks/useGeneration';
 import { useDesignerStore } from '../../store';
-import type { WorkerResponse } from '@/features/generation/bridge/types';
+import type { WorkerResponse } from '@/shared/generation/bridge';
 
 /**
  * Mock Worker for testing the useGeneration hook.
@@ -145,9 +145,9 @@ describe('useGeneration', () => {
 
     // Complete initial generation
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1);   // init
+      await vi.advanceTimersByTimeAsync(1); // init
       await vi.advanceTimersByTimeAsync(201); // debounce
-      await vi.advanceTimersByTimeAsync(1);   // worker response
+      await vi.advanceTimersByTimeAsync(1); // worker response
     });
 
     expect(useDesignerStore.getState().generation.status).toBe('complete');
@@ -160,7 +160,7 @@ describe('useGeneration', () => {
     // Wait for re-generation: debounce (200ms) + worker response
     await act(async () => {
       await vi.advanceTimersByTimeAsync(201); // debounce
-      await vi.advanceTimersByTimeAsync(1);   // worker response
+      await vi.advanceTimersByTimeAsync(1); // worker response
     });
 
     expect(useDesignerStore.getState().generation.status).toBe('complete');
@@ -208,9 +208,9 @@ describe('useGeneration', () => {
 
     // Init + debounce + error response
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1);   // init
+      await vi.advanceTimersByTimeAsync(1); // init
       await vi.advanceTimersByTimeAsync(201); // debounce
-      await vi.advanceTimersByTimeAsync(1);   // worker error response
+      await vi.advanceTimersByTimeAsync(1); // worker error response
     });
 
     const state = useDesignerStore.getState();

--- a/src/features/bin-designer/hooks/useExport.ts
+++ b/src/features/bin-designer/hooks/useExport.ts
@@ -13,9 +13,8 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store/designer';
-import { exportSTL } from '@/features/generation/export/stlExporter';
-import { export3MF } from '@/features/generation/export/threemfExporter';
-import { getActiveBridge } from '@/features/generation/bridge';
+import { exportSTL, export3MF } from '@/shared/generation/export';
+import { getActiveBridge } from '@/shared/generation/bridge';
 import { generateFileName } from '@/features/bin-designer/utils/fileNaming';
 import { estimatePrint } from '@/features/bin-designer/utils/printEstimates';
 import { captureThumbnailPNG } from '@/features/bin-designer/utils/thumbnail';
@@ -52,10 +51,8 @@ export function useExport(): UseExportReturn {
 
   const [isExporting, setIsExporting] = useState(false);
 
-  const canExport = mesh !== null &&
-    mesh.vertices !== null &&
-    mesh.normals !== null &&
-    mesh.error === null;
+  const canExport =
+    mesh !== null && mesh.vertices !== null && mesh.normals !== null && mesh.error === null;
 
   // BREP export requires the generation worker to be active
   const canExportBREP = canExport && getActiveBridge() !== null;
@@ -102,7 +99,7 @@ export function useExport(): UseExportReturn {
         const name = generateFileName(params, '3mf', config, designName);
 
         // Capture thumbnail from 3D preview (async canvas → PNG)
-        const thumbnail = await captureThumbnailPNG() ?? undefined;
+        const thumbnail = (await captureThumbnailPNG()) ?? undefined;
 
         const blob = export3MF(mesh.vertices, mesh.normals, {
           name: name.replace(/\.3mf$/, ''),
@@ -132,33 +129,38 @@ export function useExport(): UseExportReturn {
     [canExport, mesh, params, estimates]
   );
 
-  const downloadSTEP = useCallback(
-    async () => {
-      const bridge = getActiveBridge();
-      if (!bridge) return;
+  const downloadSTEP = useCallback(async () => {
+    const bridge = getActiveBridge();
+    if (!bridge) return;
 
-      setIsExporting(true);
+    setIsExporting(true);
 
-      let url: string | null = null;
-      let anchor: HTMLAnchorElement | null = null;
-      try {
-        const result = await bridge.exportBin(params, 'step');
+    let url: string | null = null;
+    let anchor: HTMLAnchorElement | null = null;
+    try {
+      const result = await bridge.exportBin(params, 'step');
 
-        const blob = new Blob([result.data], { type: 'application/step' });
-        url = URL.createObjectURL(blob);
-        anchor = document.createElement('a');
-        anchor.href = url;
-        anchor.download = result.fileName;
-        document.body.appendChild(anchor);
-        anchor.click();
-      } finally {
-        if (anchor?.parentNode) anchor.parentNode.removeChild(anchor);
-        if (url) URL.revokeObjectURL(url);
-        setIsExporting(false);
-      }
-    },
-    [params]
-  );
+      const blob = new Blob([result.data], { type: 'application/step' });
+      url = URL.createObjectURL(blob);
+      anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = result.fileName;
+      document.body.appendChild(anchor);
+      anchor.click();
+    } finally {
+      if (anchor?.parentNode) anchor.parentNode.removeChild(anchor);
+      if (url) URL.revokeObjectURL(url);
+      setIsExporting(false);
+    }
+  }, [params]);
 
-  return { isExporting, canExport, canExportBREP, estimates, downloadSTL, download3MF, downloadSTEP };
+  return {
+    isExporting,
+    canExport,
+    canExportBREP,
+    estimates,
+    downloadSTL,
+    download3MF,
+    downloadSTEP,
+  };
 }

--- a/src/features/bin-designer/utils/batchExport.ts
+++ b/src/features/bin-designer/utils/batchExport.ts
@@ -6,8 +6,8 @@
  */
 
 import { zipSync, strToU8 } from 'fflate';
-import { GenerationBridge } from '@/features/generation/bridge';
-import { buildSTLBuffer } from '@/features/generation/export/stlExporter';
+import { GenerationBridge } from '@/shared/generation/bridge';
+import { buildSTLBuffer } from '@/shared/generation/export';
 import { generateFileName } from '@/features/bin-designer/utils/fileNaming';
 import { estimatePrint } from '@/features/bin-designer/utils/printEstimates';
 import type { CartItem } from '../types';
@@ -95,11 +95,7 @@ export async function batchExport(
         const result = await bridge.generateImmediate(item.params);
 
         // Build binary STL
-        const stlBuffer = buildSTLBuffer(
-          result.mesh.vertices,
-          result.mesh.normals,
-          item.name
-        );
+        const stlBuffer = buildSTLBuffer(result.mesh.vertices, result.mesh.normals, item.name);
 
         files[fileName] = new Uint8Array(stlBuffer);
 
@@ -133,15 +129,19 @@ export async function batchExport(
     });
 
     // Add manifest.json
-    const manifestJson = JSON.stringify({
-      version: 1,
-      generatedAt: new Date().toISOString(),
-      files: manifest,
-      totalEstimates: {
-        filamentG: manifest.reduce((sum, m) => sum + m.estimates.filamentG, 0),
-        printTimeMin: manifest.reduce((sum, m) => sum + m.estimates.printTimeMin, 0),
+    const manifestJson = JSON.stringify(
+      {
+        version: 1,
+        generatedAt: new Date().toISOString(),
+        files: manifest,
+        totalEstimates: {
+          filamentG: manifest.reduce((sum, m) => sum + m.estimates.filamentG, 0),
+          printTimeMin: manifest.reduce((sum, m) => sum + m.estimates.printTimeMin, 0),
+        },
       },
-    }, null, 2);
+      null,
+      2
+    );
     files['manifest.json'] = strToU8(manifestJson);
 
     // Create ZIP

--- a/src/features/bin-designer/utils/index.ts
+++ b/src/features/bin-designer/utils/index.ts
@@ -1,9 +1,34 @@
-export { validateBinParams, computeMinCellSize, validateCompartmentSizes } from './validation';
-export type { DesignerValidationError, MinCellSize } from './validation';
+export { describeBin, getStatusAnnouncement } from './a11y';
+export { batchExport, type BatchProgress, type BatchExportResult } from './batchExport';
+export {
+  createUniformGrid,
+  createSingleCell,
+  getCellId,
+  cellIndex,
+  getCompartmentIds,
+  getCellsForCompartment,
+  getCompartmentBounds,
+  getCompartmentCount,
+  isRectangularSelection,
+  validateCompartmentGrid,
+  mergeCells,
+  splitCompartment,
+  normalizeIds,
+  deriveWallSegments,
+  fromDividerConfig,
+  type WallSegment,
+} from './compartments';
 export { generateFileName } from './fileNaming';
 export type { FileNameStyle } from './fileNaming';
 export { estimatePrint, formatPrintTime, formatFilament } from './printEstimates';
 export type { PrintEstimate } from './printEstimates';
 export { getStyleConstraints, isFeatureDisabled } from './styleConstraints';
 export type { StyleConstraints, ConstrainedFeature } from './styleConstraints';
-export { captureThumbnail, setPreviewCanvas, clearPreviewCanvas } from './thumbnail';
+export {
+  captureThumbnail,
+  captureThumbnailPNG,
+  setPreviewCanvas,
+  clearPreviewCanvas,
+} from './thumbnail';
+export { validateBinParams, computeMinCellSize, validateCompartmentSizes } from './validation';
+export type { DesignerValidationError, MinCellSize } from './validation';

--- a/src/features/generation/__tests__/bridge.test.ts
+++ b/src/features/generation/__tests__/bridge.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GenerationBridge } from '../bridge/GenerationBridge';
-import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import type { WorkerResponse } from '../bridge/types';
 
 /**

--- a/src/features/generation/__tests__/replicadBin.integration.test.ts
+++ b/src/features/generation/__tests__/replicadBin.integration.test.ts
@@ -1,10 +1,13 @@
 // @vitest-environment node
 import { describe, it, expect, beforeAll } from 'vitest';
-import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
-import type { BinParams } from '@/features/bin-designer/types';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { BinParams } from '@/shared/types/bin';
 import type { MeshData } from '@/features/generation/bridge/types';
 
-type GenerateFn = (params: BinParams, onProgress?: (stage: string, progress: number) => void) => MeshData;
+type GenerateFn = (
+  params: BinParams,
+  onProgress?: (stage: string, progress: number) => void
+) => MeshData;
 let generateBin: GenerateFn;
 
 beforeAll(async () => {
@@ -13,7 +16,10 @@ beforeAll(async () => {
   const { readFileSync } = await import('fs');
   const { join } = await import('path');
 
-  const wasmPath = join(process.cwd(), 'node_modules/replicad-opencascadejs/src/replicad_single.wasm');
+  const wasmPath = join(
+    process.cwd(),
+    'node_modules/replicad-opencascadejs/src/replicad_single.wasm'
+  );
   const wasmBinary = readFileSync(wasmPath);
   const OC = await opencascade({ wasmBinary });
   setOC(OC);

--- a/src/features/generation/bridge/types.ts
+++ b/src/features/generation/bridge/types.ts
@@ -5,7 +5,7 @@
  * (GenerationBridge) and the Web Worker (generation.worker.ts).
  */
 
-import type { BinParams } from '@/features/bin-designer/types';
+import type { BinParams } from '@/shared/types/bin';
 
 // ─── Main → Worker Messages ──────────────────────────────────────────────────
 

--- a/src/features/grid-editor/utils/index.ts
+++ b/src/features/grid-editor/utils/index.ts
@@ -1,0 +1,11 @@
+export { calcFractionalPixelSize, type FractionalGridContext } from './fractionalPixels';
+
+export {
+  isCornerHandle,
+  shouldUseExternalHandles,
+  getHandlePosition,
+  getHandleVisual,
+  getAllHandles,
+} from './handlePositioning';
+
+export { findNearestBinInDirection, type Direction } from './navigation';

--- a/src/features/layout-library/hooks/index.ts
+++ b/src/features/layout-library/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useLayoutRouting } from './useLayoutRouting';

--- a/src/shared/generation/bridge.ts
+++ b/src/shared/generation/bridge.ts
@@ -7,3 +7,4 @@
  */
 export { GenerationBridge } from '@/features/generation/bridge';
 export { setActiveBridge, getActiveBridge } from '@/features/generation/bridge';
+export type { WorkerResponse } from '@/features/generation/bridge/types';

--- a/src/shared/generation/export.ts
+++ b/src/shared/generation/export.ts
@@ -3,7 +3,11 @@
  *
  * The canonical implementations live in features/generation/export.
  * This barrel allows other features (e.g., bin-designer) to use
- * file size estimation functions without a cross-feature import violation.
+ * export and file size estimation functions without a cross-feature import violation.
  */
-export { getSTLFileSize } from '@/features/generation/export/stlExporter';
-export { estimate3MFFileSize } from '@/features/generation/export/threemfExporter';
+export {
+  exportSTL,
+  buildSTLBuffer,
+  getSTLFileSize,
+} from '@/features/generation/export/stlExporter';
+export { export3MF, estimate3MFFileSize } from '@/features/generation/export/threemfExporter';


### PR DESCRIPTION
## Summary
- Route bin-designer ↔ generation imports through existing shared facades (`shared/generation/bridge`, `shared/generation/export`, `shared/types/bin`, `shared/constants/bin`) instead of direct cross-feature paths
- Add missing barrel files for `grid-editor/utils/` and `layout-library/hooks/`
- Complete `bin-designer/utils/` barrel with exports for `a11y.ts`, `batchExport.ts`, and `compartments.ts`
- Expand shared generation facades to export `exportSTL`, `buildSTLBuffer`, `export3MF`, and `WorkerResponse` type

## Test plan
- [x] All 5000 unit tests pass
- [x] TypeScript compiles cleanly
- [x] ESLint passes with zero warnings
- [x] Module boundary check passes (no cross-feature violations)
- [x] Production build succeeds within bundle limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)