### PR TITLE
fix(lint): resolve ESLint errors and warnings

### DIFF
--- a/src/features/bin-designer/__tests__/hooks/useCustomBins.test.ts
+++ b/src/features/bin-designer/__tests__/hooks/useCustomBins.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import { useCustomBins } from '../../hooks/useCustomBins';
+import { useCustomBins, resetCustomBinsCache } from '../../hooks/useCustomBins';
 import { upsertRegistryEntry, type CustomBinRef } from '../../store/customBinRegistry';
 
 function makeRef(id: string, name: string = 'Test Bin'): CustomBinRef {
@@ -18,6 +18,7 @@ function makeRef(id: string, name: string = 'Test Bin'): CustomBinRef {
 describe('useCustomBins', () => {
   beforeEach(() => {
     localStorage.clear();
+    resetCustomBinsCache(); // Reset module-level cache after clearing storage
   });
 
   it('returns empty array when no custom bins saved', () => {

--- a/src/features/bin-designer/hooks/useCustomBins.ts
+++ b/src/features/bin-designer/hooks/useCustomBins.ts
@@ -6,23 +6,77 @@
  * for fast synchronous access.
  */
 
-import { useState, useEffect } from 'react';
-import { loadRegistry, type CustomBinRef } from '../store/customBinRegistry';
+import { useSyncExternalStore } from 'react';
+import { loadRegistry, subscribeToRegistry, type CustomBinRef } from '../store/customBinRegistry';
+
+// Cache the registry result to prevent useSyncExternalStore infinite loops
+let cachedRegistry: CustomBinRef[] = loadRegistry();
+
+// Track subscribers for storage event notifications
+const storageSubscribers = new Set<() => void>();
+
+function subscribe(callback: () => void): () => void {
+  // Refresh cache on subscribe to catch any updates that happened
+  // before this hook instance mounted (e.g., upsertRegistryEntry called
+  // while no hooks were active)
+  cachedRegistry = loadRegistry();
+
+  // Subscribe to registry changes (same-tab updates)
+  const unsubscribeRegistry = subscribeToRegistry(() => {
+    cachedRegistry = loadRegistry();
+    callback();
+  });
+
+  // Also track for storage events (cross-tab updates)
+  storageSubscribers.add(callback);
+
+  return () => {
+    unsubscribeRegistry();
+    storageSubscribers.delete(callback);
+  };
+}
+
+function getSnapshot(): CustomBinRef[] {
+  // Return cached value - useSyncExternalStore expects referential stability
+  return cachedRegistry;
+}
+
+// Listen for storage events from other tabs
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (e) => {
+    if (e.key === 'gridfinity-custom-bins-v1' || e.key === null) {
+      cachedRegistry = loadRegistry();
+      storageSubscribers.forEach((cb) => cb());
+    }
+  });
+}
 
 /**
  * Provide the current list of available custom bin designs from the registry.
  *
- * The list is seeded from the registry and refreshed once when the component mounts.
+ * Uses useSyncExternalStore for safe external data access. Automatically
+ * updates when the registry changes via upsertRegistryEntry, removeRegistryEntry,
+ * or rebuildRegistry.
  *
  * @returns An array of `CustomBinRef` representing available custom bin designs.
  */
 export function useCustomBins(): CustomBinRef[] {
-  const [bins, setBins] = useState<CustomBinRef[]>(() => loadRegistry());
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
 
-  useEffect(() => {
-    // Re-read on mount (covers navigation from designer back to planner)
-    setBins(loadRegistry());
-  }, []);
+/**
+ * Refresh the cached registry. Call this when you know the registry
+ * may have changed externally (e.g., from another tab).
+ */
+export function refreshCustomBinsCache(): void {
+  cachedRegistry = loadRegistry();
+}
 
-  return bins;
+/**
+ * Reset the cache to current localStorage state. Used by tests after
+ * localStorage.clear() to ensure clean state.
+ * @internal
+ */
+export function resetCustomBinsCache(): void {
+  cachedRegistry = loadRegistry();
 }

--- a/src/features/bin-designer/store/customBinRegistry.ts
+++ b/src/features/bin-designer/store/customBinRegistry.ts
@@ -9,6 +9,20 @@
 
 const REGISTRY_KEY = 'gridfinity-custom-bins-v1';
 
+/** Subscribers notified when the registry changes */
+const subscribers = new Set<() => void>();
+
+/** Subscribe to registry changes. Returns unsubscribe function. */
+export function subscribeToRegistry(callback: () => void): () => void {
+  subscribers.add(callback);
+  return () => subscribers.delete(callback);
+}
+
+/** Notify all subscribers that registry has changed */
+function notifySubscribers(): void {
+  subscribers.forEach((cb) => cb());
+}
+
 /** Lightweight reference to a saved bin design (for planner palette) */
 export interface CustomBinRef {
   readonly id: string;
@@ -71,6 +85,7 @@ export function upsertRegistryEntry(ref: CustomBinRef): void {
     refs.push(ref);
   }
   saveRegistry(refs);
+  notifySubscribers();
 }
 
 /**
@@ -83,6 +98,7 @@ export function upsertRegistryEntry(ref: CustomBinRef): void {
 export function removeRegistryEntry(id: string): void {
   const refs = loadRegistry().filter((r) => r.id !== id);
   saveRegistry(refs);
+  notifySubscribers();
 }
 
 /**
@@ -92,4 +108,5 @@ export function removeRegistryEntry(id: string): void {
  */
 export function rebuildRegistry(refs: CustomBinRef[]): void {
   saveRegistry(refs);
+  notifySubscribers();
 }

--- a/src/features/bin-designer/utils/fileNaming.ts
+++ b/src/features/bin-designer/utils/fileNaming.ts
@@ -14,6 +14,7 @@ export const DEFAULT_EXPORT_FILE_NAME_CONFIG: ExportFileNameConfig = {
 };
 
 /** Characters not allowed in filenames (replaced with underscore) */
+// eslint-disable-next-line no-control-regex -- Intentionally matching control chars for filename sanitization
 const UNSAFE_CHARS = /[<>:"/\\|?*\x00-\x1f]/g;
 
 /**

--- a/src/shared/hooks/useFocusTrap.ts
+++ b/src/shared/hooks/useFocusTrap.ts
@@ -27,11 +27,12 @@ interface UseFocusTrapOptions {
 export function useFocusTrap<T extends HTMLElement = HTMLDivElement>(
   options: UseFocusTrapOptions
 ): RefObject<T | null> {
+  const { active, onEscape } = options;
   const containerRef = useRef<T | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
-    if (!options.active) return;
+    if (!active) return;
 
     // Store the currently focused element to restore later
     previousFocusRef.current = document.activeElement as HTMLElement | null;
@@ -53,7 +54,7 @@ export function useFocusTrap<T extends HTMLElement = HTMLDivElement>(
 
       if (e.key === 'Escape') {
         e.preventDefault();
-        options.onEscape?.();
+        onEscape?.();
         return;
       }
 
@@ -91,7 +92,7 @@ export function useFocusTrap<T extends HTMLElement = HTMLDivElement>(
         previousFocusRef.current.focus();
       }
     };
-  }, [options.active, options.onEscape]);
+  }, [active, onEscape]);
 
   return containerRef;
 }


### PR DESCRIPTION
## Summary
- Fix ESLint `no-control-regex` error in `fileNaming.ts` by adding intentional disable comment
- Fix `react-hooks/exhaustive-deps` warning in `useFocusTrap.ts` by destructuring options
- Fix `react-hooks/set-state-in-effect` warning in `useCustomBins.ts` by replacing useState+useEffect with `useSyncExternalStore`
- Add pub/sub pattern to `customBinRegistry.ts` for reactive updates

## Details
The `useCustomBins` refactor properly handles:
- Same-tab updates via `subscribeToRegistry()` 
- Cross-tab updates via storage events
- Cache refresh on subscribe for data added before hook mounts
- Referential stability to prevent infinite render loops

## Test plan
- [x] All 5028 tests pass
- [x] Lint check passes
- [x] Build succeeds