### PR TITLE
fix(lint): resolve additional ESLint errors

### DIFF
--- a/src/components/STLSearchDropdown.tsx
+++ b/src/components/STLSearchDropdown.tsx
@@ -121,7 +121,6 @@ export function STLSearchDropdown({
     hide();
   }, [hide]);
 
-  const sizeLabel = `${formatDimension(width)}x${formatDimension(depth)}`;
   const isDisabled = enabledSites.length === 0;
 
   // Build descriptive tooltip for icon variant (memoized to avoid array ops on every render)
@@ -129,8 +128,11 @@ export function STLSearchDropdown({
     () =>
       isSingleSite
         ? t('stlSearch.findOnSite', { site: enabledSites[0].name })
-        : t('stlSearch.searchFor', { width: formatDimension(width), depth: formatDimension(depth) }),
-    [isSingleSite, enabledSites, sizeLabel, t, width, depth]
+        : t('stlSearch.searchFor', {
+            width: formatDimension(width),
+            depth: formatDimension(depth),
+          }),
+    [isSingleSite, enabledSites, t, width, depth]
   );
 
   // Don't render anything if no sites are enabled
@@ -147,12 +149,17 @@ export function STLSearchDropdown({
           type="button"
           onClick={handleClick}
           className={`btn btn-ghost gap-1.5 text-content-secondary hover:text-content ${className}`}
-          aria-label={t('stlSearch.searchFor', { width: formatDimension(width), depth: formatDimension(depth) })}
+          aria-label={t('stlSearch.searchFor', {
+            width: formatDimension(width),
+            depth: formatDimension(depth),
+          })}
           aria-expanded={isSingleSite ? undefined : isOpen}
           aria-haspopup={isSingleSite ? undefined : 'menu'}
         >
           <SearchIcon className="w-4 h-4" />
-          {isSingleSite ? t('stlSearch.findOnSite', { site: enabledSites[0].name }) : t('stlSearch.findSTL')}
+          {isSingleSite
+            ? t('stlSearch.findOnSite', { site: enabledSites[0].name })
+            : t('stlSearch.findSTL')}
           {!isSingleSite && <ChevronIcon className="w-3 h-3" isOpen={isOpen} />}
         </button>
       )}
@@ -178,13 +185,18 @@ export function STLSearchDropdown({
           type="button"
           onClick={handleClick}
           className={`w-full px-4 py-3 flex items-center gap-3 text-content hover:bg-surface-hover ${className}`}
-          aria-label={t('stlSearch.searchFor', { width: formatDimension(width), depth: formatDimension(depth) })}
+          aria-label={t('stlSearch.searchFor', {
+            width: formatDimension(width),
+            depth: formatDimension(depth),
+          })}
           aria-expanded={isSingleSite ? undefined : isOpen}
           aria-haspopup={isSingleSite ? undefined : 'menu'}
         >
           <SearchIcon className="w-5 h-5 text-content-tertiary flex-shrink-0" />
           <span className="flex-1 text-left">
-            {isSingleSite ? t('stlSearch.findOnSite', { site: enabledSites[0].name }) : t('stlSearch.findSTL')}
+            {isSingleSite
+              ? t('stlSearch.findOnSite', { site: enabledSites[0].name })
+              : t('stlSearch.findSTL')}
           </span>
           {!isSingleSite && (
             <ChevronRightIcon className="w-4 h-4 text-content-tertiary flex-shrink-0" />
@@ -204,7 +216,12 @@ export function STLSearchDropdown({
             {/* Header */}
             <div className="px-4 py-2 border-b border-stroke-subtle">
               <div className="text-xs text-content-tertiary">
-                {needsSplit ? t('stlSearch.searchForSplit') : t('stlSearch.searchFor', { width: formatDimension(width), depth: formatDimension(depth) })}
+                {needsSplit
+                  ? t('stlSearch.searchForSplit')
+                  : t('stlSearch.searchFor', {
+                      width: formatDimension(width),
+                      depth: formatDimension(depth),
+                    })}
               </div>
             </div>
 

--- a/src/features/bin-designer/__tests__/components/ShareDialog.test.tsx
+++ b/src/features/bin-designer/__tests__/components/ShareDialog.test.tsx
@@ -21,7 +21,7 @@ vi.mock('../../hooks/useDesignerSharing', () => ({
 }));
 
 vi.mock('../../constants/defaults', async (importOriginal) => {
-  const orig = await importOriginal<typeof import('../../constants/defaults')>();
+  const orig = (await importOriginal()) as { DEFAULT_BIN_PARAMS: typeof DEFAULT_BIN_PARAMS };
   return {
     ...orig,
     migrateParams: (params: unknown) => ({ ...orig.DEFAULT_BIN_PARAMS, ...(params as object) }),

--- a/src/features/bin-designer/__tests__/utils/compartments.test.ts
+++ b/src/features/bin-designer/__tests__/utils/compartments.test.ts
@@ -15,7 +15,6 @@ import {
   normalizeIds,
   deriveWallSegments,
   fromDividerConfig,
-  type WallSegment,
 } from '@/features/bin-designer/utils/compartments';
 import type { CompartmentConfig } from '@/features/bin-designer/types';
 

--- a/src/features/bin-designer/components/CartDialog.tsx
+++ b/src/features/bin-designer/components/CartDialog.tsx
@@ -60,11 +60,7 @@ export function CartDialog({ open, onClose }: CartDialogProps) {
     abortRef.current = controller;
 
     try {
-      const result = await batchExport(
-        items,
-        (p) => setProgress(p),
-        controller.signal
-      );
+      const result = await batchExport(items, (p) => setProgress(p), controller.signal);
 
       // Trigger download
       const url = URL.createObjectURL(result.blob);
@@ -79,7 +75,11 @@ export function CartDialog({ open, onClose }: CartDialogProps) {
       if (result.failed.length > 0) {
         setError(`${result.failed.length} design(s) failed to generate and were skipped.`);
       } else {
-        addToast({ message: `Exported ${items.length} design(s) as ZIP`, type: 'success', duration: 3000 });
+        addToast({
+          message: `Exported ${items.length} design(s) as ZIP`,
+          type: 'success',
+          duration: 3000,
+        });
       }
     } catch (e) {
       if (e instanceof Error && e.message === 'Export cancelled') {
@@ -92,7 +92,7 @@ export function CartDialog({ open, onClose }: CartDialogProps) {
       setProgress(null);
       abortRef.current = null;
     }
-  }, [items]);
+  }, [items, addToast]);
 
   const handleClearCart = useCallback(() => {
     if (!window.confirm(`Remove all ${items.length} items from cart?`)) return;
@@ -119,7 +119,10 @@ export function CartDialog({ open, onClose }: CartDialogProps) {
   );
 
   return (
-    <div ref={dialogRef} className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+    >
       <div
         className="mx-4 flex w-full max-w-lg flex-col rounded-lg border border-stroke-subtle bg-surface shadow-xl"
         style={{ maxHeight: '80vh' }}
@@ -141,8 +144,19 @@ export function CartDialog({ open, onClose }: CartDialogProps) {
             aria-label={t('common.close')}
             disabled={exporting}
           >
-            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
             </svg>
           </button>
         </div>
@@ -151,13 +165,24 @@ export function CartDialog({ open, onClose }: CartDialogProps) {
         <div className="flex-1 overflow-y-auto px-5 py-3">
           {items.length === 0 ? (
             <div className="py-8 text-center">
-              <svg className="mx-auto mb-3 h-12 w-12 text-content-disabled" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+              <svg
+                className="mx-auto mb-3 h-12 w-12 text-content-disabled"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+                />
               </svg>
-              <p className="text-sm font-medium text-content-secondary">{t('binDesigner.cartEmpty')}</p>
-              <p className="mt-1 text-xs text-content-tertiary">
-                {t('binDesigner.cartEmptyHint')}
+              <p className="text-sm font-medium text-content-secondary">
+                {t('binDesigner.cartEmpty')}
               </p>
+              <p className="mt-1 text-xs text-content-tertiary">{t('binDesigner.cartEmptyHint')}</p>
             </div>
           ) : (
             <ul className="space-y-2" aria-label={t('binDesigner.cartItems')}>
@@ -186,13 +211,18 @@ export function CartDialog({ open, onClose }: CartDialogProps) {
             {/* Progress bar */}
             {exporting && progress && (
               <div className="mb-3 space-y-1">
-                <div className="flex justify-between text-xs text-content-secondary" aria-live="polite">
+                <div
+                  className="flex justify-between text-xs text-content-secondary"
+                  aria-live="polite"
+                >
                   <span>
                     {progress.phase === 'generating'
                       ? `Generating: ${progress.currentName}`
                       : 'Packaging ZIP...'}
                   </span>
-                  <span>{progress.current + 1}/{progress.total}</span>
+                  <span>
+                    {progress.current + 1}/{progress.total}
+                  </span>
                 </div>
                 <div
                   className="h-1.5 overflow-hidden rounded-full bg-surface-secondary"
@@ -212,7 +242,10 @@ export function CartDialog({ open, onClose }: CartDialogProps) {
 
             {/* Error */}
             {error && (
-              <div role="alert" className="mb-3 rounded-md bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-900/20 dark:text-red-300">
+              <div
+                role="alert"
+                className="mb-3 rounded-md bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-900/20 dark:text-red-300"
+              >
                 {error}
               </div>
             )}
@@ -223,21 +256,38 @@ export function CartDialog({ open, onClose }: CartDialogProps) {
                 onClick={handleClearCart}
                 disabled={exporting}
                 className="text-xs text-content-secondary hover:text-content disabled:opacity-50"
-              >{t('binDesigner.clearCart')}</button>
+              >
+                {t('binDesigner.clearCart')}
+              </button>
               <div className="flex gap-2">
                 {exporting ? (
                   <button
                     onClick={handleCancel}
                     className="rounded-md px-4 py-2 text-sm font-medium text-content-secondary hover:bg-surface-hover"
-                  >{t('common.cancel')}</button>
+                  >
+                    {t('common.cancel')}
+                  </button>
                 ) : (
                   <button
                     onClick={handleExport}
                     className="flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
                   >
-                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                    </svg>{t('binDesigner.downloadZip')}</button>
+                    <svg
+                      className="h-4 w-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                      />
+                    </svg>
+                    {t('binDesigner.downloadZip')}
+                  </button>
                 )}
               </div>
             </div>
@@ -276,8 +326,19 @@ function CartItemRow({
         {item.thumbnail ? (
           <img src={item.thumbnail} alt="" className="h-full w-full object-cover" />
         ) : (
-          <svg className="h-5 w-5 text-content-tertiary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+          <svg
+            className="h-5 w-5 text-content-tertiary"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+            />
           </svg>
         )}
       </div>
@@ -299,8 +360,19 @@ function CartItemRow({
         className="rounded p-1.5 text-content-tertiary transition-opacity hover:bg-surface-hover hover:text-content sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 disabled:opacity-50"
         aria-label={`Remove ${item.name} from cart`}
       >
-        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M6 18L18 6M6 6l12 12"
+          />
         </svg>
       </button>
     </li>

--- a/src/features/bin-designer/components/ShareDialog.tsx
+++ b/src/features/bin-designer/components/ShareDialog.tsx
@@ -6,7 +6,7 @@
  * - Load: Loads a shared design from a URL or ID
  */
 
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useLayoutEffect, useRef } from 'react';
 import { useDesignerStore } from '@/features/bin-designer/store/designer';
 import { useDesignerSharing } from '@/features/bin-designer/hooks/useDesignerSharing';
 import { migrateParams } from '@/features/bin-designer/constants/defaults';
@@ -41,14 +41,16 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
     onEscape: onClose,
   });
 
-  // Reset state when dialog opens
-  useEffect(() => {
+  // Reset state when dialog opens (useLayoutEffect to run synchronously before paint)
+  /* eslint-disable react-hooks/set-state-in-effect -- Intentional: reset local state when modal opens */
+  useLayoutEffect(() => {
     if (open) {
       reset();
       setLoadInput('');
       setCopied(false);
     }
   }, [open, reset]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const addToast = useToastStore((s) => s.addToast);
 
@@ -88,7 +90,10 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
   if (!open) return null;
 
   return (
-    <div ref={dialogRef} className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+    >
       <div
         className="mx-4 w-full max-w-md rounded-lg border border-stroke-subtle bg-surface p-6 shadow-xl"
         role="dialog"
@@ -103,8 +108,19 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
             className="rounded-md p-1 text-content-secondary hover:bg-surface-hover hover:text-content"
             aria-label={t('common.close')}
           >
-            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
             </svg>
           </button>
         </div>
@@ -122,16 +138,45 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
                 onClick={handleShare}
                 className="flex w-full items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
               >
-                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
-                </svg>{t('binDesigner.createShareLink')}</button>
+                <svg
+                  className="h-4 w-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+                  />
+                </svg>
+                {t('binDesigner.createShareLink')}
+              </button>
             )}
 
             {status === 'sharing' && (
               <div className="flex items-center justify-center gap-2 rounded-md bg-surface-secondary py-2 text-sm text-content-secondary">
-                <svg className="h-4 w-4 animate-spin motion-reduce:animate-none" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                <svg
+                  className="h-4 w-4 animate-spin motion-reduce:animate-none"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
                 </svg>
                 Creating link...
               </div>
@@ -155,14 +200,40 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
                   >
                     {copied ? (
                       <>
-                        <svg className="h-4 w-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                        </svg>{t('binDesigner.copied')}</>
+                        <svg
+                          className="h-4 w-4 text-green-500"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                          aria-hidden="true"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M5 13l4 4L19 7"
+                          />
+                        </svg>
+                        {t('binDesigner.copied')}
+                      </>
                     ) : (
                       <>
-                        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                        </svg>{t('common.copy')}</>
+                        <svg
+                          className="h-4 w-4"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                          aria-hidden="true"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                          />
+                        </svg>
+                        {t('common.copy')}
+                      </>
                     )}
                   </button>
                 </div>
@@ -182,7 +253,9 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
 
           {/* Load section */}
           <div className="space-y-2">
-            <h3 className="text-sm font-medium text-content">{t('binDesigner.loadSharedDesign')}</h3>
+            <h3 className="text-sm font-medium text-content">
+              {t('binDesigner.loadSharedDesign')}
+            </h3>
             <div className="flex gap-2">
               <input
                 type="text"
@@ -191,7 +264,9 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
                 placeholder={t('binDesigner.pasteShareUrl')}
                 className="flex-1 rounded-md border border-stroke-subtle bg-surface-secondary px-3 py-2 text-xs text-content placeholder:text-content-tertiary focus:border-accent focus:outline-none"
                 aria-label={t('binDesigner.shareUrlOrId')}
-                onKeyDown={(e) => { if (e.key === 'Enter') handleLoad(); }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleLoad();
+                }}
               />
               <button
                 onClick={handleLoad}
@@ -205,7 +280,10 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
 
           {/* Error display */}
           {status === 'error' && error && (
-            <div role="alert" className="rounded-md bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-900/20 dark:text-red-300">
+            <div
+              role="alert"
+              className="rounded-md bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-900/20 dark:text-red-300"
+            >
               {error}
             </div>
           )}
@@ -240,7 +318,8 @@ function extractShareId(input: string): string | null {
 
   // Validate as a raw share ID (UUID or base36)
   const trimmed = input.trim();
-  if (/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(trimmed)) return trimmed;
+  if (/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(trimmed))
+    return trimmed;
   if (/^[a-z0-9]+-[a-z0-9]{7}$/.test(trimmed)) return trimmed;
   if (/^[a-zA-Z0-9]{12}$/.test(trimmed)) return trimmed;
 


### PR DESCRIPTION
## Summary
- Fix `@typescript-eslint/consistent-type-imports` error in ShareDialog.test.tsx
- Remove unused `WallSegment` import in compartments.test.ts
- Fix `react-hooks/set-state-in-effect` warning in ShareDialog.tsx by using useLayoutEffect with eslint-disable
- Fix unnecessary useMemo dependency in STLSearchDropdown.tsx
- Add missing `addToast` dependency in CartDialog.tsx useCallback

## Test plan
- [x] All 5028 tests pass
- [x] `npm run lint` shows 0 errors
- [x] Build succeeds