### PR TITLE
feat(bin-designer): add revert button for mesh generation errors

### DIFF
--- a/src/features/bin-designer/__tests__/components/PreviewCanvas.test.tsx
+++ b/src/features/bin-designer/__tests__/components/PreviewCanvas.test.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { useDesignerStore } from '../../store';
+import { useToastStore } from '@/core/store/toast';
 import { DEFAULT_BIN_PARAMS } from '../../constants';
 
 // Mock Three.js rendering (jsdom has no WebGL)
@@ -303,5 +304,97 @@ describe('PreviewCanvas', () => {
       screen.getAllByLabelText('Toggle wireframe mode, keyboard shortcut W').length
     ).toBeGreaterThan(0);
     expect(screen.getAllByLabelText('Change preview color').length).toBeGreaterThan(0);
+  });
+
+  describe('error recovery', () => {
+    it('shows revert button when generation error and history exists', () => {
+      useDesignerStore.setState({
+        wasmStatus: 'ready',
+        generation: {
+          status: 'error',
+          mesh: { vertices: null, normals: null, error: 'Test error', timingMs: 0 },
+          progress: 0,
+          epoch: 1,
+        },
+        history: {
+          past: [{ params: DEFAULT_BIN_PARAMS, mesh: null }],
+          future: [],
+        },
+      });
+      render(<PreviewCanvas />);
+
+      expect(screen.getByText('Generation failed')).toBeInTheDocument();
+      expect(screen.getByLabelText('Revert')).toBeInTheDocument();
+    });
+
+    it('does not show revert button when no history exists', () => {
+      useDesignerStore.setState({
+        wasmStatus: 'ready',
+        generation: {
+          status: 'error',
+          mesh: { vertices: null, normals: null, error: 'Test error', timingMs: 0 },
+          progress: 0,
+          epoch: 1,
+        },
+        history: {
+          past: [],
+          future: [],
+        },
+      });
+      render(<PreviewCanvas />);
+
+      expect(screen.getByText('Generation failed')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Revert')).not.toBeInTheDocument();
+    });
+
+    it('calls undo and shows toast when revert button clicked', () => {
+      const undoSpy = vi.spyOn(useDesignerStore.getState(), 'undo');
+      const addToastSpy = vi.spyOn(useToastStore.getState(), 'addToast');
+
+      useDesignerStore.setState({
+        wasmStatus: 'ready',
+        generation: {
+          status: 'error',
+          mesh: { vertices: null, normals: null, error: 'Test error', timingMs: 0 },
+          progress: 0,
+          epoch: 1,
+        },
+        history: {
+          past: [{ params: DEFAULT_BIN_PARAMS, mesh: null }],
+          future: [],
+        },
+      });
+      render(<PreviewCanvas />);
+
+      const revertButton = screen.getByLabelText('Revert');
+      fireEvent.click(revertButton);
+
+      expect(undoSpy).toHaveBeenCalled();
+      expect(addToastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Reverted to last working configuration',
+          type: 'info',
+        })
+      );
+
+      undoSpy.mockRestore();
+      addToastSpy.mockRestore();
+    });
+
+    it('does not show revert button for WASM errors (only retry)', () => {
+      useDesignerStore.setState({
+        wasmStatus: 'error',
+        generation: { status: 'idle', mesh: null, progress: 0, epoch: 0 },
+        history: {
+          past: [{ params: DEFAULT_BIN_PARAMS, mesh: null }],
+          future: [],
+        },
+      });
+      render(<PreviewCanvas />);
+
+      expect(screen.getByText('Engine failed to load')).toBeInTheDocument();
+      expect(screen.getByLabelText('Retry loading')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Revert')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/features/bin-designer/components/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas.tsx
@@ -28,6 +28,7 @@ import { setPreviewCanvas, clearPreviewCanvas } from '../utils/thumbnail';
 import { describeBin, getStatusAnnouncement } from '../utils/a11y';
 import { useResponsive } from '@/shared/hooks/useResponsive';
 import { useTranslation } from '@/i18n';
+import { useToastStore } from '@/core/store/toast';
 
 /** localStorage key for persisting the user's preview color preference */
 const PREVIEW_COLOR_KEY = 'gridfinity-designer-preview-color';
@@ -308,16 +309,18 @@ export function PreviewCanvas() {
     return () => clearPreviewCanvas();
   }, []);
 
-  const { wasmStatus, generationStatus, hasMesh, meshError, params, designName } = useDesignerStore(
-    useShallow((s) => ({
-      wasmStatus: s.wasmStatus,
-      generationStatus: s.generation.status,
-      hasMesh: s.generation.mesh !== null && s.generation.mesh.vertices !== null,
-      meshError: s.generation.mesh?.error ?? null,
-      params: s.params,
-      designName: s.designName,
-    }))
-  );
+  const { wasmStatus, generationStatus, hasMesh, meshError, params, designName, canRevert } =
+    useDesignerStore(
+      useShallow((s) => ({
+        wasmStatus: s.wasmStatus,
+        generationStatus: s.generation.status,
+        hasMesh: s.generation.mesh !== null && s.generation.mesh.vertices !== null,
+        meshError: s.generation.mesh?.error ?? null,
+        params: s.params,
+        designName: s.designName,
+        canRevert: s.history.past.length > 0,
+      }))
+    );
 
   // Screen reader description
   const binDescription = describeBin(params);
@@ -325,6 +328,13 @@ export function PreviewCanvas() {
 
   const undo = useDesignerStore((s) => s.undo);
   const redo = useDesignerStore((s) => s.redo);
+  const addToast = useToastStore((s) => s.addToast);
+
+  // Revert to last working configuration on generation error
+  const handleRevert = useCallback(() => {
+    undo();
+    addToast({ message: t('binDesigner.revertedToWorking'), type: 'info', duration: 3000 });
+  }, [undo, addToast, t]);
 
   // Smooth camera preset transitions
   const setCameraPresetRaw = usePresetTransition(
@@ -398,6 +408,8 @@ export function PreviewCanvas() {
           generationStatus={generationStatus}
           errorMessage={meshError}
           onRetry={handleRetry}
+          onRevert={handleRevert}
+          canRevert={canRevert}
         />
       ) : (
         <>
@@ -510,7 +522,9 @@ export function PreviewCanvas() {
                   fill="currentColor"
                   d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
                 />
-              </svg>{t('binDesigner.updating')}</div>
+              </svg>
+              {t('binDesigner.updating')}
+            </div>
           )}
 
           {/* Control buttons */}

--- a/src/features/bin-designer/components/preview/PreviewSkeleton.tsx
+++ b/src/features/bin-designer/components/preview/PreviewSkeleton.tsx
@@ -12,6 +12,10 @@ interface PreviewSkeletonProps {
   generationStatus: GenerationStatus;
   errorMessage?: string | null;
   onRetry?: () => void;
+  /** Callback to revert to last known working state (undo) */
+  onRevert?: () => void;
+  /** Whether there's history to revert to */
+  canRevert?: boolean;
 }
 
 export function PreviewSkeleton({
@@ -19,6 +23,8 @@ export function PreviewSkeleton({
   generationStatus,
   errorMessage,
   onRetry,
+  onRevert,
+  canRevert = false,
 }: PreviewSkeletonProps) {
   const t = useTranslation();
   const getMessage = () => {
@@ -91,26 +97,55 @@ export function PreviewSkeleton({
           {getMessage()}
         </p>
         {helpText && <p className="mt-1 text-xs text-content-tertiary">{helpText}</p>}
-        {isError && onRetry && (
-          <button
-            onClick={onRetry}
-            className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-surface-elevated px-3 py-1.5 text-xs font-medium text-content-secondary shadow-sm transition-colors hover:bg-surface-hover hover:text-content"
-            aria-label={t('binDesigner.retryLoading')}
-          >
-            <svg
-              className="h-3.5 w-3.5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-              />
-            </svg>{t('binDesigner.retry')}</button>
+        {isError && (onRetry || (onRevert && canRevert)) && (
+          <div className="mt-3 flex items-center justify-center gap-2">
+            {onRetry && (
+              <button
+                onClick={onRetry}
+                className="inline-flex items-center gap-1.5 rounded-md bg-surface-elevated px-3 py-1.5 text-xs font-medium text-content-secondary shadow-sm transition-colors hover:bg-surface-hover hover:text-content"
+                aria-label={t('binDesigner.retryLoading')}
+              >
+                <svg
+                  className="h-3.5 w-3.5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                  />
+                </svg>
+                {t('binDesigner.retry')}
+              </button>
+            )}
+            {onRevert && canRevert && generationStatus === 'error' && (
+              <button
+                onClick={onRevert}
+                className="inline-flex items-center gap-1.5 rounded-md bg-surface-elevated px-3 py-1.5 text-xs font-medium text-content-secondary shadow-sm transition-colors hover:bg-surface-hover hover:text-content"
+                aria-label={t('binDesigner.revertToWorking')}
+              >
+                <svg
+                  className="h-3.5 w-3.5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"
+                  />
+                </svg>
+                {t('binDesigner.revertToWorking')}
+              </button>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -62,6 +62,8 @@
   "binDesigner.resetToAuto": "Auf Auto zurücksetzen",
   "binDesigner.retry": "Erneut versuchen",
   "binDesigner.retryLoading": "Erneut laden",
+  "binDesigner.revertToWorking": "Zurücksetzen",
+  "binDesigner.revertedToWorking": "Zur letzten funktionierenden Konfiguration zurückgesetzt",
   "binDesigner.rows": "Reihen",
   "binDesigner.saved": "Gespeichert",
   "binDesigner.savedDesigns": "Gespeicherte Designs",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1104,6 +1104,8 @@ const en: Record<string, string> = {
   'binDesigner.resetToAuto': 'Reset to auto',
   'binDesigner.retry': 'Retry',
   'binDesigner.retryLoading': 'Retry loading',
+  'binDesigner.revertToWorking': 'Revert',
+  'binDesigner.revertedToWorking': 'Reverted to last working configuration',
   'binDesigner.rows': 'Rows',
   'binDesigner.saved': 'Saved',
   'binDesigner.savedDesigns': 'Saved Designs',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -77,6 +77,8 @@
   "binDesigner.resetView": "Restablecer vista (R)",
   "binDesigner.retry": "Reintentar",
   "binDesigner.retryLoading": "Reintentar carga",
+  "binDesigner.revertToWorking": "Revertir",
+  "binDesigner.revertedToWorking": "Revertido a la última configuración funcional",
   "binDesigner.rows": "Filas",
   "binDesigner.saved": "Guardado",
   "binDesigner.savedDesigns": "Diseños Guardados",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -78,6 +78,8 @@
   "binDesigner.resetView": "Réinitialiser la vue (R)",
   "binDesigner.retry": "Réessayer",
   "binDesigner.retryLoading": "Réessayer le chargement",
+  "binDesigner.revertToWorking": "Annuler",
+  "binDesigner.revertedToWorking": "Retour à la dernière configuration fonctionnelle",
   "binDesigner.rows": "Rangées",
   "binDesigner.saved": "Enregistré",
   "binDesigner.savedDesigns": "Designs enregistrés",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -76,6 +76,8 @@
   "binDesigner.resetView": "Weergave resetten (R)",
   "binDesigner.retry": "Opnieuw proberen",
   "binDesigner.retryLoading": "Opnieuw laden",
+  "binDesigner.revertToWorking": "Ongedaan maken",
+  "binDesigner.revertedToWorking": "Teruggezet naar laatst werkende configuratie",
   "binDesigner.rows": "Rijen",
   "binDesigner.saved": "Opgeslagen",
   "binDesigner.savedDesigns": "Opgeslagen designs",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -76,6 +76,8 @@
   "binDesigner.resetView": "Redefinir vista (R)",
   "binDesigner.retry": "Tentar Novamente",
   "binDesigner.retryLoading": "Tentar carregar novamente",
+  "binDesigner.revertToWorking": "Reverter",
+  "binDesigner.revertedToWorking": "Revertido para última configuração funcional",
   "binDesigner.rows": "Linhas",
   "binDesigner.saved": "Salvo",
   "binDesigner.savedDesigns": "Designs Salvos",


### PR DESCRIPTION
## Summary
When mesh generation fails due to invalid parameters, users now see a "Revert" button alongside "Retry" that restores the last working configuration via undo.

**Before:** On generation error, users could only retry (which fails again with same params) or manually adjust params.

**After:** Users can click "Revert" to instantly restore the last working state with cached mesh.

## Changes
- Add `onRevert`/`canRevert` props to `PreviewSkeleton` component
- Wire up `handleRevert` in `PreviewCanvas` that calls `undo()` + shows toast notification
- Only show Revert button when there's history to revert to (not for fresh designs)
- Revert button only appears for generation errors (not WASM loading errors)
- Add i18n translations for all 6 locales

## Test plan
- [x] All 5032 tests pass
- [x] Build succeeds
- [x] Added 4 new tests for error recovery scenarios:
  - Shows revert button when generation error and history exists
  - Hides revert button when no history exists
  - Calls undo and shows toast when revert clicked
  - Hides revert button for WASM errors (only retry)
- [ ] Manual: Trigger generation error, verify Revert button appears and works