### PR TITLE
chore: remove experimental badge from half-bin mode

### DIFF
--- a/src/components/Mobile/MobileSettingsPanel.tsx
+++ b/src/components/Mobile/MobileSettingsPanel.tsx
@@ -53,8 +53,12 @@ function MobilePrivacySection() {
         <div>
           <span
             className={`text-sm ${mlTelemetryEnabled ? 'text-content' : 'text-content-secondary'}`}
-          >{t('mobile.settings.helpImproveSuggestions')}</span>
-          <p className="text-xs text-content-tertiary">{t('mobile.settings.shareBinSizesAndPlacementPatternsNo')}</p>
+          >
+            {t('mobile.settings.helpImproveSuggestions')}
+          </span>
+          <p className="text-xs text-content-tertiary">
+            {t('mobile.settings.shareBinSizesAndPlacementPatternsNo')}
+          </p>
         </div>
         <Checkbox checked={mlTelemetryEnabled} variant="mobile" />
       </div>
@@ -202,13 +206,12 @@ export function MobileSettingsPanel() {
           }}
         >
           <div>
-            <div className="flex items-center gap-1.5">
-              <span
-                className={`text-sm ${halfBinMode ? 'text-content' : 'text-content-secondary'}`}
-              >{t('mobile.settings.halfBinMode')}</span>
-              <span className="text-[9px] text-warning bg-warning-muted px-1 py-0.5 rounded">{t('mobile.settings.experimental')}</span>
-            </div>
-            <p className="text-xs text-content-tertiary">{t('mobile.settings.allow05UnitPrecision')}</p>
+            <span className={`text-sm ${halfBinMode ? 'text-content' : 'text-content-secondary'}`}>
+              {t('mobile.settings.halfBinMode')}
+            </span>
+            <p className="text-xs text-content-tertiary">
+              {t('mobile.settings.allow05UnitPrecision')}
+            </p>
           </div>
           <Checkbox checked={halfBinMode} variant="mobile" />
         </div>
@@ -250,7 +253,9 @@ export function MobileSettingsPanel() {
             />
           </SettingsRow>
 
-          <div className="text-sm text-right text-content-disabled">{t('mobile.settings.maxBinSize')}{maxGridUnits}×{maxGridUnits}
+          <div className="text-sm text-right text-content-disabled">
+            {t('mobile.settings.maxBinSize')}
+            {maxGridUnits}×{maxGridUnits}
           </div>
         </div>
       </section>
@@ -291,15 +296,25 @@ export function MobileSettingsPanel() {
         <SectionHeader title={t('settings.defaultPreferences')} />
 
         <div className="bg-surface-elevated rounded-lg p-3 space-y-2">
-          <div className="text-xs text-content-tertiary">{t('mobile.settings.newLayoutsWillUseTheseDefaults')}</div>
-          <div className="text-sm text-content-secondary">{t('mobile.settings.drawer')}{settings.defaultDrawerWidth}×{settings.defaultDrawerDepth}×
+          <div className="text-xs text-content-tertiary">
+            {t('mobile.settings.newLayoutsWillUseTheseDefaults')}
+          </div>
+          <div className="text-sm text-content-secondary">
+            {t('mobile.settings.drawer')}
+            {settings.defaultDrawerWidth}×{settings.defaultDrawerDepth}×
             {settings.defaultDrawerHeight}u
           </div>
-          <div className="text-sm text-content-secondary">{t('mobile.settings.layerHeight')}{settings.defaultLayerHeight}u
+          <div className="text-sm text-content-secondary">
+            {t('mobile.settings.layerHeight')}
+            {settings.defaultLayerHeight}u
           </div>
-          <div className="text-sm text-content-secondary">{t('mobile.settings.printBed')}{settings.defaultPrintBedSize}mm
+          <div className="text-sm text-content-secondary">
+            {t('mobile.settings.printBed')}
+            {settings.defaultPrintBedSize}mm
           </div>
-          <div className="text-sm text-content-secondary">{t('mobile.settings.gridUnit')}{settings.defaultGridUnitMm}mm
+          <div className="text-sm text-content-secondary">
+            {t('mobile.settings.gridUnit')}
+            {settings.defaultGridUnitMm}mm
           </div>
           <button
             onClick={() => setShowSaveDefaultsConfirm(true)}
@@ -312,7 +327,9 @@ export function MobileSettingsPanel() {
                 strokeWidth={2}
                 d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4"
               />
-            </svg>{t('mobile.settings.saveCurrentAsDefaults')}</button>
+            </svg>
+            {t('mobile.settings.saveCurrentAsDefaults')}
+          </button>
         </div>
       </section>
 
@@ -330,7 +347,9 @@ export function MobileSettingsPanel() {
             <SparklesIcon className="w-5 h-5 text-accent" />
             <div className="text-left">
               <div className="text-sm font-medium text-content">{t('mobile.settings.labs')}</div>
-              <div className="text-xs text-content-tertiary">{t('mobile.settings.tryExperimentalFeatures')}</div>
+              <div className="text-xs text-content-tertiary">
+                {t('mobile.settings.tryExperimentalFeatures')}
+              </div>
             </div>
           </div>
           <div className="flex items-center gap-2">
@@ -354,7 +373,10 @@ export function MobileSettingsPanel() {
             className="hover:underline text-content-tertiary"
           >
             Gridfinity
-          </a>{' '}{t('mobile.settings.byZackFreedman')}<br />{t('mobile.settings.toolBy')}{' '}
+          </a>{' '}
+          {t('mobile.settings.byZackFreedman')}
+          <br />
+          {t('mobile.settings.toolBy')}{' '}
           <a
             href="https://www.linkedin.com/in/andyhmai/"
             target="_blank"
@@ -369,7 +391,14 @@ export function MobileSettingsPanel() {
       <ConfirmDialog
         isOpen={showSaveDefaultsConfirm}
         title={t('settings.confirmSaveDefaults.title')}
-        message={t('settings.confirmSaveDefaults.message', { width: drawer.width, depth: drawer.depth, height: drawer.height, layerHeight: activeLayerHeight, printBed: printBedSize, gridUnit: gridUnitMm })}
+        message={t('settings.confirmSaveDefaults.message', {
+          width: drawer.width,
+          depth: drawer.depth,
+          height: drawer.height,
+          layerHeight: activeLayerHeight,
+          printBed: printBedSize,
+          gridUnit: gridUnitMm,
+        })}
         confirmText={t('settings.confirmSaveDefaults.confirm')}
         onConfirm={handleSaveDefaults}
         onCancel={() => setShowSaveDefaultsConfirm(false)}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -192,8 +192,12 @@ export function Sidebar() {
                   </svg>
                 </div>
                 <div className="flex-1 min-w-0">
-                  <div className="text-sm font-medium text-content">{t('sidebar.inspirationGallery')}</div>
-                  <div className="text-xs text-content-tertiary">{t('sidebar.inspirationHint')}</div>
+                  <div className="text-sm font-medium text-content">
+                    {t('sidebar.inspirationGallery')}
+                  </div>
+                  <div className="text-xs text-content-tertiary">
+                    {t('sidebar.inspirationHint')}
+                  </div>
                 </div>
                 <svg
                   className="w-4 h-4 text-content-tertiary group-hover:translate-x-0.5 transition-transform"
@@ -316,9 +320,6 @@ export function Sidebar() {
                       >
                         {t('sidebar.halfBinMode')}
                       </span>
-                      <span className="text-[9px] leading-none text-warning bg-warning-muted px-1 py-0.5 rounded">
-                        {t('settings.experimental')}
-                      </span>
                       <kbd className="text-[9px] leading-none text-content-disabled bg-surface-elevated px-1 py-0.5 rounded border border-stroke-subtle">
                         H
                       </kbd>
@@ -329,7 +330,9 @@ export function Sidebar() {
                   {/* Fractional edge position toggles - only shown when dimensions are fractional */}
                   {(hasFractionalWidth || hasFractionalDepth) && (
                     <div className="pt-2 space-y-1.5">
-                      <div className="text-content-tertiary text-[10px] mb-1">{t('sidebar.halfUnitEdgePosition')}</div>
+                      <div className="text-content-tertiary text-[10px] mb-1">
+                        {t('sidebar.halfUnitEdgePosition')}
+                      </div>
                       {hasFractionalWidth && (
                         <div className="flex items-center justify-between">
                           <span className="text-content-tertiary">{t('sidebar.width5')}</span>
@@ -342,7 +345,9 @@ export function Sidebar() {
                                   : 'bg-surface-elevated text-content-tertiary hover:bg-surface-hover'
                               }`}
                               title={t('sidebar.halfBinLeft')}
-                            >{t('sidebar.left')}</button>
+                            >
+                              {t('sidebar.left')}
+                            </button>
                             <button
                               onClick={() => handleFractionalEdgeChange('x', 'end')}
                               className={`px-2.5 py-1 text-[10px] border-l border-stroke-subtle transition-colors focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent ${
@@ -351,7 +356,9 @@ export function Sidebar() {
                                   : 'bg-surface-elevated text-content-tertiary hover:bg-surface-hover'
                               }`}
                               title={t('sidebar.halfBinRight')}
-                            >{t('sidebar.right')}</button>
+                            >
+                              {t('sidebar.right')}
+                            </button>
                           </div>
                         </div>
                       )}
@@ -367,7 +374,9 @@ export function Sidebar() {
                                   : 'bg-surface-elevated text-content-tertiary hover:bg-surface-hover'
                               }`}
                               title={t('sidebar.halfBinBottom')}
-                            >{t('sidebar.bottom')}</button>
+                            >
+                              {t('sidebar.bottom')}
+                            </button>
                             <button
                               onClick={() => handleFractionalEdgeChange('y', 'end')}
                               className={`px-2.5 py-1 text-[10px] border-l border-stroke-subtle transition-colors focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent ${
@@ -376,7 +385,9 @@ export function Sidebar() {
                                   : 'bg-surface-elevated text-content-tertiary hover:bg-surface-hover'
                               }`}
                               title={t('sidebar.halfBinTop')}
-                            >{t('sidebar.top')}</button>
+                            >
+                              {t('sidebar.top')}
+                            </button>
                           </div>
                         </div>
                       )}
@@ -445,7 +456,8 @@ export function Sidebar() {
             </div>
 
             {/* Attribution */}
-            <div className="px-4 py-4 border-t border-stroke-subtle text-content-disabled text-[10px] leading-relaxed">{t('sidebar.gridfinityBy')}{' '}
+            <div className="px-4 py-4 border-t border-stroke-subtle text-content-disabled text-[10px] leading-relaxed">
+              {t('sidebar.gridfinityBy')}{' '}
               <a
                 href="https://www.youtube.com/c/ZackFreedman"
                 target="_blank"
@@ -454,7 +466,8 @@ export function Sidebar() {
               >
                 Zack Freedman
               </a>
-              <br />{t('sidebar.toolBy')}{' '}
+              <br />
+              {t('sidebar.toolBy')}{' '}
               <a
                 href="https://www.linkedin.com/in/andyhmai/"
                 target="_blank"
@@ -476,7 +489,9 @@ export function Sidebar() {
                   viewBox="0 0 24 24"
                 >
                   <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-                </svg>{t('sidebar.tip')}</a>
+                </svg>
+                {t('sidebar.tip')}
+              </a>
             </div>
           </div>
         </div>

--- a/src/features/bin-designer/components/panel/DimensionsSection.tsx
+++ b/src/features/bin-designer/components/panel/DimensionsSection.tsx
@@ -131,7 +131,9 @@ export function DimensionsSection() {
           <div className="mb-1 flex items-center justify-between">
             <span className="text-xs text-content-tertiary">{t('common.height')}</span>
             <span className="text-[11px] tabular-nums text-content-tertiary">
-              {heightMm.toFixed(0)}{t('binDesigner.mmBody')}</span>
+              {heightMm.toFixed(0)}
+              {t('binDesigner.mmBody')}
+            </span>
           </div>
           <StepperControl
             value={height}
@@ -157,15 +159,14 @@ export function DimensionsSection() {
           }}
           role="checkbox"
           aria-checked={halfBinMode}
-          aria-label={t('binDesigner.halfBinModeExperimentalEnable05Grid')}
+          aria-label={t('binDesigner.halfBinModeEnable05Grid')}
           tabIndex={0}
         >
-          <div className="flex items-center gap-1.5">
-            <span
-              className={`text-xs leading-none ${halfBinMode ? 'text-content' : 'text-content-tertiary'}`}
-            >{t('binDesigner.halfBinMode')}</span>
-            <span className="text-[9px] leading-none text-warning bg-warning-muted px-1 py-0.5 rounded">{t('binDesigner.experimental')}</span>
-          </div>
+          <span
+            className={`text-xs leading-none ${halfBinMode ? 'text-content' : 'text-content-tertiary'}`}
+          >
+            {t('binDesigner.halfBinMode')}
+          </span>
           <Checkbox checked={halfBinMode} variant="desktop" />
         </div>
       </div>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -41,7 +41,7 @@
   "binDesigner.gridSize": "Rastergröße",
   "binDesigner.gridUnit": "Grid unit",
   "binDesigner.halfBinMode": "Half-Bin-Modus",
-  "binDesigner.halfBinModeExperimentalEnable05Grid": "Half-Bin-Modus (experimentell): 0,5 grid unit Präzision aktivieren",
+  "binDesigner.halfBinModeEnable05Grid": "Half-Bin-Modus: 0,5 grid unit Präzision aktivieren",
   "binDesigner.heightUnit": "Height unit",
   "binDesigner.layout": "Layout",
   "binDesigner.load": "Laden",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1082,8 +1082,7 @@ const en: Record<string, string> = {
   'binDesigner.gridSize': 'Grid size',
   'binDesigner.gridUnit': 'Grid unit',
   'binDesigner.halfBinMode': 'Half-bin mode',
-  'binDesigner.halfBinModeExperimentalEnable05Grid':
-    'Half-bin mode (experimental): enable 0.5 grid unit precision',
+  'binDesigner.halfBinModeEnable05Grid': 'Half-bin mode: enable 0.5 grid unit precision',
   'binDesigner.heightUnit': 'Height unit',
   'binDesigner.layout': 'Layout',
   'binDesigner.load': 'Load',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -48,7 +48,7 @@
   "binDesigner.gridSize": "Tamaño de cuadrícula",
   "binDesigner.gridUnit": "Grid unit",
   "binDesigner.halfBinMode": "Modo half-bin",
-  "binDesigner.halfBinModeExperimentalEnable05Grid": "Modo half-bin (experimental): habilita precisión de 0.5 grid unit",
+  "binDesigner.halfBinModeEnable05Grid": "Modo half-bin: habilita precisión de 0.5 grid unit",
   "binDesigner.heightUnit": "Height unit",
   "binDesigner.interior": "Interior",
   "binDesigner.interiorSummary": "{count} compartimento(s)",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -49,7 +49,7 @@
   "binDesigner.gridSize": "Taille de grille",
   "binDesigner.gridUnit": "Grid unit",
   "binDesigner.halfBinMode": "Mode demi-bin",
-  "binDesigner.halfBinModeExperimentalEnable05Grid": "Mode demi-bin (expérimental) : activer la précision 0,5 grid unit",
+  "binDesigner.halfBinModeEnable05Grid": "Mode demi-bin : activer la précision 0,5 grid unit",
   "binDesigner.heightUnit": "Height unit",
   "binDesigner.interior": "Intérieur",
   "binDesigner.interiorSummary": "{count} compartiment(s)",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -47,7 +47,7 @@
   "binDesigner.gridSize": "Grid grootte",
   "binDesigner.gridUnit": "Grid unit",
   "binDesigner.halfBinMode": "Half-bin modus",
-  "binDesigner.halfBinModeExperimentalEnable05Grid": "Half-bin modus (experimenteel): 0,5 grid unit precisie inschakelen",
+  "binDesigner.halfBinModeEnable05Grid": "Half-bin modus: 0,5 grid unit precisie inschakelen",
   "binDesigner.heightUnit": "Height unit",
   "binDesigner.interior": "Interieur",
   "binDesigner.interiorSummary": "{count} compartiment(en)",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -47,7 +47,7 @@
   "binDesigner.gridSize": "Tamanho da grade",
   "binDesigner.gridUnit": "Grid unit",
   "binDesigner.halfBinMode": "Modo half-bin",
-  "binDesigner.halfBinModeExperimentalEnable05Grid": "Modo half-bin (experimental): habilita precisão de 0.5 grid unit",
+  "binDesigner.halfBinModeEnable05Grid": "Modo half-bin: habilita precisão de 0.5 grid unit",
   "binDesigner.heightUnit": "Height unit",
   "binDesigner.interior": "Interior",
   "binDesigner.interiorSummary": "{count} compartimento(s)",


### PR DESCRIPTION
## Summary
- Remove experimental badge/label from half-bin mode in all UI locations
- Update translation key to remove "(experimental)" from aria-label

Half-bin mode has been stable and is ready for general use.

## Changes
- `DimensionsSection.tsx` - Remove experimental badge span
- `Sidebar/index.tsx` - Remove experimental badge span
- `MobileSettingsPanel.tsx` - Remove experimental badge span  
- Rename translation key `halfBinModeExperimentalEnable05Grid` → `halfBinModeEnable05Grid`
- Update all 6 locale files (en, de, es, fr, nl, pt-BR)

## Test plan
- [x] Build succeeds
- [x] All 5032 tests pass
- [ ] Manual verification that experimental badge is removed from all locations