### PR TITLE
fix(bin-designer): correct wall cutout geometry positioning

### DIFF
--- a/src/features/generation/__tests__/replicadBin.integration.test.ts
+++ b/src/features/generation/__tests__/replicadBin.integration.test.ts
@@ -239,5 +239,38 @@ describe('replicad bin generation', () => {
       // If cutout works, the mesh should have MORE triangles
       expect(cutoutResult.triangleCount).toBeGreaterThan(baseResult.triangleCount);
     }, 60000);
+
+    it('wall cutout works on non-square bins (2x3)', () => {
+      // Tests for positioning bug where halfOuter used wrong dimension
+      const baseParams: BinParams = {
+        ...DEFAULT_BIN_PARAMS,
+        width: 2,
+        depth: 3,
+        walls: {
+          front: { width: 0, depth: 0 },
+          back: { width: 0, depth: 0 },
+          left: { width: 0, depth: 0 },
+          right: { width: 0, depth: 0 },
+          interior: { width: 0, depth: 0 },
+        },
+      };
+
+      const withCutoutParams: BinParams = {
+        ...baseParams,
+        walls: {
+          front: { width: 80, depth: 60 },
+          back: { width: 0, depth: 0 },
+          left: { width: 80, depth: 60 },
+          right: { width: 0, depth: 0 },
+          interior: { width: 0, depth: 0 },
+        },
+      };
+
+      const baseResult = generateBin(baseParams);
+      const cutoutResult = generateBin(withCutoutParams);
+
+      // Both front (along X) and left (along Y) cutouts should work
+      expect(cutoutResult.triangleCount).toBeGreaterThan(baseResult.triangleCount);
+    }, 60000);
   });
 });

--- a/src/features/generation/worker/generators/replicadBin.ts
+++ b/src/features/generation/worker/generators/replicadBin.ts
@@ -612,11 +612,12 @@ function buildWallCutouts(
     if (notchWidth <= 0 || notchDepth <= 0) return null;
 
     // Simple rectangle profile extruded through the divider
+    // Center at Z=0 so downstream translate([..., wallHeight]) places cutout at top of wall
     const profile = drawRectangle(notchWidth, notchDepth);
     const solid = (profile.sketchOnPlane('XZ') as unknown as Sketch).extrude(
       extrudeLength
     ) as Shape3D;
-    return solid.translate([0, 0, notchDepth / 2]);
+    return solid.translate([0, 0, -notchDepth / 2]);
   }
 
   // Helper to position cutout on a wall face
@@ -635,7 +636,8 @@ function buildWallCutouts(
     if (notchWidth <= 0 || notchDepth <= 0) return;
 
     // Position: center of the wall face
-    const halfOuter = (isXWall ? innerW : innerD) / 2 + wallThickness;
+    // front/back walls use innerD for Y positioning, left/right use innerW for X positioning
+    const halfOuter = (isXWall ? innerD : innerW) / 2 + wallThickness;
     let positioned: Shape3D;
 
     // Build cutout directly at the wall position using sketchOnPlane with offset


### PR DESCRIPTION
## Summary
- Fix wall cutouts not appearing on generated bins
- Root cause: Cutout shapes were sketched at Y=0 and translated after extrusion, which doesn't work for OpenCascade boolean operations
- Solution: Sketch exterior wall cutout profiles directly at wall position using `sketchOnPlane('XZ', yPos)`

## Changes
- Refactor `addExteriorCutout` to sketch at wall position directly (matches working scoop code pattern)
- Simplify exterior cutout profile from complex arc paths to simple `drawRectangle`
- Keep `buildCutoutSolid` for interior divider cutouts (simpler case that works with translate)
- Add 4 integration tests for wall cutout verification

## Test plan
- [x] All 12 integration tests pass
- [x] Key verification test: bins with cutouts have more triangles (1592) than plain bins (1548)
- [x] Build succeeds
- [ ] Manual verification: enable wall cutout in bin designer, verify notch appears in 3D preview