### PR TITLE
feat(i18n): add SEO meta tag localization

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,13 @@
     <link rel="canonical" href="https://gridfinitylayouttool.com/">
 
     <!-- International targeting: hreflang for multilingual/multiregional SEO -->
+    <!-- All locales point to same URL since language is auto-detected client-side -->
     <link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/">
+    <link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/">
+    <link rel="alternate" hreflang="nl" href="https://gridfinitylayouttool.com/">
+    <link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/">
+    <link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/">
+    <link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/">
     <link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/">
 
     <!-- Open Graph / Facebook -->

--- a/src/i18n/context.tsx
+++ b/src/i18n/context.tsx
@@ -34,6 +34,19 @@ import type { ReactNode } from 'react';
 import type { Locale, Translations, TranslationVars } from './types';
 import en from './locales/en';
 
+/**
+ * Map of locale codes to Open Graph locale format.
+ * OG uses underscore format (e.g., en_US, de_DE).
+ */
+const OG_LOCALE_MAP: Record<Locale, string> = {
+  en: 'en_US',
+  de: 'de_DE',
+  nl: 'nl_NL',
+  es: 'es_ES',
+  fr: 'fr_FR',
+  'pt-BR': 'pt_BR',
+};
+
 /** Translation function signature */
 export type TFunction = (key: string, vars?: TranslationVars) => string;
 
@@ -157,14 +170,35 @@ export function LocaleProvider({ children, initialLocale, onLocaleChange }: Loca
       setLocaleState(newLocale);
       loadLocale(newLocale);
       onLocaleChange?.(newLocale);
-
-      // Update document lang attribute
-      if (typeof document !== 'undefined') {
-        document.documentElement.lang = newLocale === 'pt-BR' ? 'pt' : newLocale;
-      }
     },
     [loadLocale, onLocaleChange]
   );
+
+  // Sync SEO meta tags when locale/translations change
+  useEffect(() => {
+    if (isLoading || typeof document === 'undefined') return;
+
+    // HTML lang attribute (screen readers, SEO)
+    document.documentElement.lang = locale;
+
+    // Page title and meta description
+    const seoTitle = translations['seo.title'] ?? en['seo.title'];
+    const seoDesc = translations['seo.description'] ?? en['seo.description'];
+
+    document.title = seoTitle;
+    document.querySelector('meta[name="description"]')?.setAttribute('content', seoDesc);
+
+    // Open Graph tags
+    document
+      .querySelector('meta[property="og:locale"]')
+      ?.setAttribute('content', OG_LOCALE_MAP[locale]);
+    document.querySelector('meta[property="og:title"]')?.setAttribute('content', seoTitle);
+    document.querySelector('meta[property="og:description"]')?.setAttribute('content', seoDesc);
+
+    // Twitter Card tags
+    document.querySelector('meta[name="twitter:title"]')?.setAttribute('content', seoTitle);
+    document.querySelector('meta[name="twitter:description"]')?.setAttribute('content', seoDesc);
+  }, [locale, translations, isLoading]);
 
   const t: TFunction = useCallback(
     (key: string, vars?: TranslationVars): string => {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -857,6 +857,8 @@
   "rightPanel.selection": "Auswahl",
   "rightPanel.splitInto": "Teilen in",
   "rightPanel.unknownCategory": "Unbekannte Kategorie",
+  "seo.title": "Gridfinity Layout Tool | Plane deine 3D-gedruckten Schubladen-Organizer",
+  "seo.description": "Gestalte Gridfinity Schubladen-Layouts für den 3D-Druck. Plane individuelle Organizer mit Drag-and-Drop-Bins, Multi-Layer-Unterstützung, 3D-Vorschau und automatischer Druck-Optimierung.",
   "settings.autoDetect": "Auto (Browser-Standard)",
   "settings.confirmSaveDefaults.confirm": "Speichern",
   "settings.confirmSaveDefaults.message": "Aktuelle Einstellungen als Standard für neue Layouts speichern?\n\nDrawer: {width}×{depth}×{height}u\nLayer-Höhe: {layerHeight}u\nPrint bed: {printBed}mm\nGrid unit: {gridUnit}mm",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -15,6 +15,13 @@
 
 const en: Record<string, string> = {
   // ===========================================================================
+  // SEO Meta Tags (dynamically injected into document head)
+  // ===========================================================================
+  'seo.title': 'Gridfinity Layout Tool | Plan Your 3D Printed Drawer Organizers',
+  'seo.description':
+    'Design Gridfinity drawer layouts for 3D printing. Plan custom organizers with drag-and-drop bins, multi-layer support, 3D preview, and automatic print optimization.',
+
+  // ===========================================================================
   // Common / Shared
   // ===========================================================================
   'common.save': 'Save',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -865,6 +865,8 @@
   "rightPanel.selection": "Selección",
   "rightPanel.splitInto": "Dividir en",
   "rightPanel.unknownCategory": "Categoría desconocida",
+  "seo.title": "Gridfinity Layout Tool | Planifica tus organizadores de cajones para impresión 3D",
+  "seo.description": "Diseña layouts de cajones Gridfinity para impresión 3D. Planifica organizadores personalizados con bins arrastrables, soporte multicapa, vista previa 3D y optimización automática de impresión.",
   "settings.autoDetect": "Auto (predeterminado del navegador)",
   "settings.confirmSaveDefaults.confirm": "Guardar",
   "settings.confirmSaveDefaults.message": "¿Guardar la configuración actual como predeterminada para nuevos diseños?\n\nDrawer: {width}×{depth}×{height}u\nAltura de layer: {layerHeight}u\nPrint bed: {printBed}mm\nGrid unit: {gridUnit}mm",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -865,6 +865,8 @@
   "rightPanel.selection": "Sélection",
   "rightPanel.splitInto": "Diviser en",
   "rightPanel.unknownCategory": "Catégorie inconnue",
+  "seo.title": "Gridfinity Layout Tool | Planifiez vos organisateurs de tiroirs imprimés en 3D",
+  "seo.description": "Concevez des agencements de tiroirs Gridfinity pour l'impression 3D. Planifiez des organisateurs personnalisés avec des bins glisser-déposer, support multicouche, aperçu 3D et optimisation automatique d'impression.",
   "settings.autoDetect": "Auto (langue du navigateur)",
   "settings.confirmSaveDefaults.confirm": "Enregistrer",
   "settings.confirmSaveDefaults.message": "Enregistrer les paramètres actuels comme valeurs par défaut pour les nouveaux layouts ?\n\nDrawer : {width}×{depth}×{height}u\nHauteur de layer : {layerHeight}u\nPrint bed : {printBed}mm\nGrid unit : {gridUnit}mm",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -865,6 +865,8 @@
   "rightPanel.selection": "Selectie",
   "rightPanel.splitInto": "Splitsen in",
   "rightPanel.unknownCategory": "Onbekende categorie",
+  "seo.title": "Gridfinity Layout Tool | Plan je 3D-geprinte lade-organizers",
+  "seo.description": "Ontwerp Gridfinity lade-indelingen voor 3D-printen. Plan aangepaste organizers met drag-and-drop bins, multi-layer ondersteuning, 3D-preview en automatische printoptimalisatie.",
   "settings.autoDetect": "Automatisch (browserstandaard)",
   "settings.confirmSaveDefaults.confirm": "Opslaan",
   "settings.confirmSaveDefaults.message": "Huidige instellingen opslaan als standaard voor nieuwe layouts?\n\nDrawer: {width}×{depth}×{height}u\nLayer hoogte: {layerHeight}u\nPrint bed: {printBed}mm\nGrid unit: {gridUnit}mm",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -865,6 +865,8 @@
   "rightPanel.selection": "Seleção",
   "rightPanel.splitInto": "Dividir em",
   "rightPanel.unknownCategory": "Categoria desconhecida",
+  "seo.title": "Gridfinity Layout Tool | Planeje seus organizadores de gavetas impressos em 3D",
+  "seo.description": "Projete layouts de gavetas Gridfinity para impressão 3D. Planeje organizadores personalizados com bins arrastar e soltar, suporte multicamadas, prévia 3D e otimização automática de impressão.",
   "settings.autoDetect": "Automático (padrão do navegador)",
   "settings.confirmSaveDefaults.confirm": "Salvar",
   "settings.confirmSaveDefaults.message": "Salvar configurações atuais como padrão para novos layouts?\n\nDrawer: {width}×{depth}×{height}u\nAltura do layer: {layerHeight}u\nPrint bed: {printBed}mm\nGrid unit: {gridUnit}mm",


### PR DESCRIPTION
## Summary
Improve international SEO by dynamically localizing meta tags based on user's detected/selected language.

## Changes
- Add complete hreflang tags for all 6 supported locales (en, de, nl, es, fr, pt-BR)
- Add `seo.title` and `seo.description` translation keys to all locale files
- Dynamically sync `<html lang>` attribute on locale change
- Dynamically update meta tags when translations load:
  - `<title>`
  - `<meta name="description">`
  - `<meta property="og:locale/title/description">`
  - `<meta name="twitter:title/description">`

## Why this matters
- **Search engines**: hreflang tags tell Google the page supports multiple languages
- **Screen readers**: `<html lang>` enables correct pronunciation
- **Social sharing**: Localized OG/Twitter cards for non-English users
- **CTR**: Users see meta descriptions in their language in search results

## Test plan
- [x] Build succeeds
- [x] All i18n keys sync (1087 keys)
- [x] All tests pass
- [ ] Manual: Change browser language, verify title/meta update
- [ ] Manual: Share link on social media, verify localized preview