### PR TITLE
fix: language selector dropdown rendering behind UI elements

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -114,7 +114,7 @@ export function Header({ onHelpClick, saveStatus }: HeaderProps) {
   const modKey = isMac ? '⌘' : 'Ctrl';
 
   return (
-    <header className="h-12 flex items-center justify-between px-4 bg-surface-secondary border-b border-stroke-subtle overflow-hidden">
+    <header className="h-12 flex items-center justify-between px-4 bg-surface-secondary border-b border-stroke-subtle">
       <div className="flex items-center gap-4 min-w-0">
         <ToolSwitcher />
 
@@ -396,7 +396,9 @@ export function Header({ onHelpClick, saveStatus }: HeaderProps) {
 
       {/* Lazy-loaded modals - only load chunks when modal is opened */}
       {showLayoutManager && (
-        <Suspense fallback={<LoadingFallback variant="overlay" label={t('header.loadingLayouts')} />}>
+        <Suspense
+          fallback={<LoadingFallback variant="overlay" label={t('header.loadingLayouts')} />}
+        >
           <LayoutManagerModal
             isOpen={showLayoutManager}
             onClose={() => setShowLayoutManager(false)}


### PR DESCRIPTION
## Summary
- Remove `overflow-hidden` from header that was clipping the language selector dropdown
- The dropdown's `z-50` can now properly stack above other elements

## Root Cause
The header had `overflow: hidden` which creates a clipping context that physically clips content extending beyond its boundaries, regardless of z-index values.

## Test plan
- [x] Build passes
- [x] Unit tests pass (34 tests)
- [ ] Manual verification: open language selector dropdown, confirm it appears above other UI elements