### PR TITLE
fix(i18n): clarify bin palette instruction to avoid click confusion

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -532,7 +532,7 @@
   "layers.addNewLayer": "Neuen Layer hinzufügen",
   "layers.binPalette": "Bin-Palette",
   "layers.binPaletteHint": "Shift+Klick zum Hinzufügen zum Stash.",
-  "layers.binPaletteInstruction": "Wähle eine Größe, dann klicke oder ziehe auf dem Raster.",
+  "layers.binPaletteInstruction": "Wähle eine Größe, dann ziehe um den Bereich mit Bins zu füllen.",
   "layers.clearBins": "Bins löschen",
   "layers.clearBinsTitle": "Alle Bins von diesem Layer entfernen",
   "layers.clearLayer.confirm": "Leeren",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -304,7 +304,7 @@ const en: Record<string, string> = {
   'layers.clearLayer.confirm': 'Clear',
   'layers.layerNamePlaceholder': 'Layer name',
   'layers.binPalette': 'Bin Palette',
-  'layers.binPaletteInstruction': 'Select a size, then click or drag on grid.',
+  'layers.binPaletteInstruction': 'Select a size, then drag to fill area with bins.',
   'layers.binPaletteHint': 'Shift+click to add to stash.',
   'layers.decreaseHeight': 'Decrease {name} height',
   'layers.increaseHeight': 'Increase {name} height',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -540,7 +540,7 @@
   "layers.addNewLayer": "Agregar nuevo layer",
   "layers.binPalette": "Paleta de Bins",
   "layers.binPaletteHint": "Shift+clic para agregar al stash.",
-  "layers.binPaletteInstruction": "Selecciona un tamaño, luego haz clic o arrastra en la cuadrícula.",
+  "layers.binPaletteInstruction": "Selecciona un tamaño, luego arrastra para llenar el área con bins.",
   "layers.clearBins": "Borrar bins",
   "layers.clearBinsTitle": "Borrar todos los bins de este layer",
   "layers.clearLayer.confirm": "Limpiar",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -540,7 +540,7 @@
   "layers.addNewLayer": "Ajouter un nouveau layer",
   "layers.binPalette": "Palette de Bins",
   "layers.binPaletteHint": "Maj+clic pour ajouter au stash.",
-  "layers.binPaletteInstruction": "Sélectionnez une taille, puis cliquez ou faites glisser sur la grille.",
+  "layers.binPaletteInstruction": "Sélectionnez une taille, puis glissez pour remplir la zone avec des bacs.",
   "layers.clearBins": "Effacer les bins",
   "layers.clearBinsTitle": "Effacer tous les bins de ce layer",
   "layers.clearLayer.confirm": "Vider",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -602,7 +602,7 @@
   "layers.addNewLayer": "Nieuwe layer toevoegen",
   "layers.binPalette": "Bin palet",
   "layers.binPaletteHint": "Shift+klik om toe te voegen aan stash.",
-  "layers.binPaletteInstruction": "Selecteer een grootte en klik of sleep op het raster.",
+  "layers.binPaletteInstruction": "Selecteer een grootte en sleep om het gebied te vullen met bins.",
   "layers.clearBins": "Bins wissen",
   "layers.clearBinsTitle": "Alle bins van deze layer wissen",
   "layers.clearLayer.confirm": "Wissen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -540,7 +540,7 @@
   "layers.addNewLayer": "Adicionar novo layer",
   "layers.binPalette": "Paleta de Bins",
   "layers.binPaletteHint": "Shift+clique para adicionar ao stash.",
-  "layers.binPaletteInstruction": "Selecione um tamanho, depois clique ou arraste na grade.",
+  "layers.binPaletteInstruction": "Selecione um tamanho, depois arraste para preencher a área com bins.",
   "layers.clearBins": "Limpar bins",
   "layers.clearBinsTitle": "Limpar todos os bins deste layer",
   "layers.clearLayer.confirm": "Limpar",

--- a/src/test/components/ActiveLayerPanel.test.tsx
+++ b/src/test/components/ActiveLayerPanel.test.tsx
@@ -79,7 +79,7 @@ describe('ActiveLayerPanel', () => {
     it('displays instruction text', () => {
       render(<ActiveLayerPanel />);
 
-      expect(screen.getByText(/Select a size, then click or drag/)).toBeInTheDocument();
+      expect(screen.getByText(/Select a size, then drag to fill/)).toBeInTheDocument();
     });
 
     it('displays squares section', () => {


### PR DESCRIPTION
## Summary
- Change "Select a size, then click or drag on grid" to "Select a size, then drag to fill area with bins"
- Updated all 6 locale files (en, de, es, fr, nl, pt-BR)

## Problem
Users were selecting a size (e.g., 2x3) then clicking once expecting a single bin to appear. Paint mode actually requires dragging an area which gets filled with bins of the selected size.

Technically, a single click creates a 1x1 area - when `Math.floor(1 / 2) = 0`, larger bins don't fit, so nothing happens.

## Test plan
- [x] Build passes
- [x] i18n key sync check passes
- [x] Unit tests pass (1813 tests)
- [ ] Manual: verify instruction text is clear in bin palette