### PR TITLE
fix(categories): resolve color picker overlap and empty badge spacing

### DIFF
--- a/src/features/categories/components/CategoriesPanel.tsx
+++ b/src/features/categories/components/CategoriesPanel.tsx
@@ -271,7 +271,7 @@ export function CategoriesPanel() {
                       placeholder={t('categories.categoryNamePlaceholder')}
                     />
                     {/* Color palette - 7 columns for better fit with 14 colors */}
-                    <div className="grid grid-cols-7 gap-1">
+                    <div className="grid grid-cols-7 gap-1.5">
                       {COLOR_PALETTE.map(({ color, name }) => (
                         <button
                           key={color}
@@ -346,7 +346,7 @@ export function CategoriesPanel() {
                           className="absolute left-0 top-full mt-1.5 z-50 p-2 bg-surface-elevated border border-stroke-subtle rounded-lg shadow-lg animate-scale-in"
                           onClick={(e) => e.stopPropagation()}
                         >
-                          <div className="grid grid-cols-7 gap-1">
+                          <div className="grid grid-cols-7 gap-1.5">
                             {COLOR_PALETTE.map(({ color, name }) => (
                               <button
                                 key={color}
@@ -450,21 +450,17 @@ export function CategoriesPanel() {
                         </svg>
                       </button>
                     )}
-                    {/* Bin count badge */}
-                    <span
-                      className={`text-[10px] min-w-[20px] text-center px-1.5 py-0.5 rounded-full flex-shrink-0 transition-colors ${
-                        isHovered && binCount > 0
-                          ? 'bg-accent/20 text-accent'
-                          : 'text-content-tertiary'
-                      }`}
-                      title={
-                        binCount > 0
-                          ? t('categories.binsUseCategory', { count: binCount })
-                          : t('categories.noBinsUseCategory')
-                      }
-                    >
-                      {binCount > 0 ? binCount : ''}
-                    </span>
+                    {/* Bin count badge - only rendered when category has bins */}
+                    {binCount > 0 && (
+                      <span
+                        className={`text-[10px] min-w-[20px] text-center px-1.5 py-0.5 rounded-full flex-shrink-0 transition-colors ${
+                          isHovered ? 'bg-accent/20 text-accent' : 'text-content-tertiary'
+                        }`}
+                        title={t('categories.binsUseCategory', { count: binCount })}
+                      >
+                        {binCount}
+                      </span>
+                    )}
                   </>
                 )}
               </div>

--- a/src/test/components/CategoriesPanel.test.tsx
+++ b/src/test/components/CategoriesPanel.test.tsx
@@ -347,15 +347,13 @@ describe('CategoriesPanel', () => {
       expect(screen.getByTitle('2 bin(s) use this category')).toBeInTheDocument();
     });
 
-    it('shows empty for categories without bins', () => {
+    it('does not render badges for categories without bins', () => {
       render(<CategoriesPanel />);
 
-      // Both categories have no bins, badges should be empty
-      const emptyBadges = screen.getAllByTitle('No bins use this category');
-      expect(emptyBadges).toHaveLength(2);
-      emptyBadges.forEach((badge) => {
-        expect(badge).toHaveTextContent('');
-      });
+      // Both categories have no bins, no badges should be rendered
+      expect(screen.queryByTitle('No bins use this category')).not.toBeInTheDocument();
+      // Also verify no bin count badges exist at all (they only render when binCount > 0)
+      expect(screen.queryByTitle(/bin\(s\) use this category/)).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Increase color palette grid gap from `gap-1` to `gap-1.5` to prevent swatch overlap when hovering (both inline and popover pickers)
- Only render bin count badge when category has bins, eliminating empty space from `min-w-[20px]` on unused categories

## Test plan
- [x] Hover over color swatches in edit mode - no overlap
- [x] Hover over color swatches in quick picker popover - no overlap
- [x] Empty categories show no badge/empty space on the right
- [x] Categories with bins still show count badge correctly
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)