### PR TITLE
fix(staging): rotate button hidden behind other bins in stash

### DIFF
--- a/src/features/staging/components/Staging.tsx
+++ b/src/features/staging/components/Staging.tsx
@@ -800,11 +800,16 @@ export function Staging() {
                 // Letter-spacing for small text
                 const letterSpacing = primaryFontSize < 11 ? '0.02em' : 'normal';
 
+                // Elevate z-index when hovered/selected so rotate button appears above other bins
+                const isElevated = hoveredBinId === bin.id || isSelected;
+
                 return (
                   <div
                     key={bin.id}
                     data-staging-bin-id={bin.id}
-                    className={`relative flex flex-col items-center justify-center transition-all duration-150 cursor-move rounded-sm z-10 touch-none ${
+                    className={`relative flex flex-col items-center justify-center transition-all duration-150 cursor-move rounded-sm touch-none ${
+                      isElevated ? 'z-20' : 'z-10'
+                    } ${
                       isDragging
                         ? 'bg-transparent border-2 border-dashed border-accent pointer-events-none'
                         : isSelected


### PR DESCRIPTION
## Summary
Fix rotate button appearing behind other bins in the stash panel.

## Problem
The rotate button (z-index: 30) could appear behind other bins because all bins shared the same z-index (z-10). Since z-index creates a stacking context, a child's z-index only applies within its parent's context. Bins rendered later in the DOM would stack on top regardless of the rotate button's z-index.

## Solution
Elevate hovered/selected bins from `z-10` to `z-20` so their entire stacking context (including the rotate button) renders above other bins.

## Changes
- `src/features/staging/components/Staging.tsx` - Add `isElevated` check to conditionally apply `z-20` when bin is hovered or selected

## Test plan
- [x] Build passes
- [x] All 48 Staging tests pass
- [ ] Manual: hover over a bin that has another bin to its top-right, verify rotate button appears above