### PR TITLE
docs: add feature READMEs and optimize CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,507 +1,138 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Gridfinity Layout Tool: React + TypeScript web app for 3D-printed drawer organizer layouts.
 
-Gridfinity Layout Tool: React + TypeScript web app for 3D-printed drawer organizer layouts. Multi-layer support, drag-and-drop, 3D preview (react-three-fiber), print optimization, cloud sharing, real-time collaboration, responsive design.
+**Stack:** React 19, TypeScript 5.9, Vite 7, Zustand 5 + Immer, Tailwind CSS 4, Three.js, Vitest, Playwright, PWA, Vercel Blob + Redis, Liveblocks, PostHog.
 
-**Stack:** React 19, TypeScript 5.9, Vite 7, Zustand 5 + Immer, Tailwind CSS 4, Three.js, Vitest, Playwright, PWA, Vercel Blob + Redis, Liveblocks (real-time), PostHog analytics.
+## Git & Quality
 
-## Git Workflow
-
-**Main branch is protected.** All changes via PRs - never commit directly to `main`.
-
-Pre-commit hooks enforce lint, build, and test coverage. Run `npm run test:coverage` before committing.
-
-**Coverage Thresholds:** Lines: 81%, Branches: 69%, Functions: 81%, Statements: 80%
-
-Focus testing on `src/shared/utils/` (~90%), `src/core/store/` (~87%), `src/hooks/` (~73%).
+- **Main is protected** - all changes via PRs
+- Pre-commit hooks enforce lint, build, test coverage
+- **Coverage:** Lines 81%, Branches 69%, Functions 81%
 
 ## Code Style (Enforced)
 
-**Required:**
-
-- `import type` for type-only imports
-- Explicit types (never `any`, use `unknown`)
-- Prefix unused params with `_`
-- Strict equality (`===` not `==`)
-- `useShallow` when selecting multiple store values
-- Use `@/` path alias for imports (e.g., `@/core/store`)
-
-**Prohibited:** `any`, `console.log`, `var`, `==`, non-null assertions (`!`)
+| Required                      | Prohibited                |
+| ----------------------------- | ------------------------- |
+| `import type` for types       | `any` (use `unknown`)     |
+| Explicit types                | `console.log`             |
+| `useShallow` for multi-select | `var`, `==`               |
+| `@/` path alias               | Non-null assertions (`!`) |
 
 ## Directory Structure
 
 ```
 src/
-├── core/                    # Infrastructure
-│   ├── api/                 # API client (share service)
-│   ├── constants.ts         # App-wide constants
-│   ├── result/              # Result<T,E> type system
-│   ├── storage/             # Storage layer (IndexedDB + localStorage)
-│   ├── store/               # Zustand stores
-│   └── types.ts             # Core data types
-├── features/                # Feature modules (vertical slices)
-│   ├── bin-inspector/       # Bin details panel
-│   ├── categories/          # Category management
-│   ├── cloud-share/         # Cloud sharing UI
-│   ├── grid-editor/         # Main grid canvas & editing
-│   │   ├── components/Grid/ # Grid rendering, overlay, 3D preview
-│   │   ├── hooks/           # Grid-specific hooks
-│   │   └── utils/           # collision.ts, fill.ts
-│   ├── labs/                # Experimental feature flags
-│   ├── layers/              # Layer management
-│   ├── layout-library/      # Multi-layout management
-│   ├── print-export/        # Print list & export
-│   └── staging/             # Staging area (bin stash)
-├── shared/                  # Cross-cutting concerns
-│   ├── components/          # Reusable UI (Toast, ContextMenu, etc.)
-│   ├── contexts/            # React contexts
-│   ├── hooks/               # Shared hooks
-│   └── utils/               # validation.ts, compression, color, etc.
-├── components/              # App-level components
-│   ├── Collab/              # Collaboration cursors/indicators
-│   ├── Mobile/              # Mobile-specific components
-│   ├── Modals/              # Modal dialogs
-│   ├── Sidebar/             # Desktop sidebar panels
-│   └── Tablet/              # Tablet-specific panels
-├── hooks/                   # App-level hooks
-│   └── interactions/        # Interaction state hooks
-├── layouts/                 # Responsive layout shells
-├── utils/                   # App-level utilities
-├── liveblocks.config.ts     # Real-time collaboration config
-└── App.tsx                  # Main app component
+├── core/           # Infrastructure: api/, constants.ts, result/, storage/, store/, types.ts
+├── features/       # Vertical slices (each has README.md): bin-designer, bin-inspector,
+│                   # categories, cloud-share, generation, grid-editor, inspiration-gallery,
+│                   # labs, layers, layout-library, print-export, staging
+├── shared/         # Cross-cutting: components/, contexts/, hooks/, utils/
+├── components/     # App-level: Collab/, Mobile/, Modals/, Sidebar/, Tablet/
+├── hooks/          # App-level hooks + interactions/
+├── i18n/           # Localization (en, de, es, fr, nl, pt-BR)
+└── layouts/        # Responsive layout shells
 ```
 
-## Architecture
+## Core Architecture
 
-### State Management (Zustand + Immer)
+### Stores (`src/core/store/`)
 
-Stores in `src/core/store/`:
+| Store            | Purpose                                                                          |
+| ---------------- | -------------------------------------------------------------------------------- |
+| `layout.ts`      | Layout data (bins, layers, categories, drawer). Returns `Result<T, LayoutError>` |
+| `library.ts`     | Multi-layout library, `activeLayoutId`, thumbnails                               |
+| `settings.ts`    | User preferences (localStorage: `gridfinity-settings-v1`)                        |
+| `history.ts`     | Undo/redo (max 50). Use `useUndoableAction()`                                    |
+| `selection.ts`   | Selected bins, active layer/category                                             |
+| `interaction.ts` | Current mode, drop targets, paint mode                                           |
 
-| Store              | Purpose                                                                                |
-| ------------------ | -------------------------------------------------------------------------------------- |
-| `layout.ts`        | Layout data (bins, layers, categories, drawer). Returns `Result<T, LayoutError>`       |
-| `library.ts`       | Multi-layout library. Tracks `activeLayoutId`, CRUD, thumbnails via `computePreview()` |
-| `settings.ts`      | Persisted user preferences (localStorage: `gridfinity-settings-v1`)                    |
-| `history.ts`       | Undo/redo (max 50). Wrap mutations with `useUndoableAction()`                          |
-| `toast.ts`         | Toast notifications (max 3)                                                            |
-| `selection.ts`     | Selected bin IDs, active layer/category                                                |
-| `view.ts`          | Zoom, panels, context menu state                                                       |
-| `interaction.ts`   | Current interaction mode, drop targets, paint mode                                     |
-| `halfBinMode.ts`   | Half-bin mode toggle state                                                             |
-| `mobile.ts`        | Mobile panel state, touch interactions                                                 |
-| `sharedPreview.ts` | Shared layout preview state                                                            |
-
-**Pattern:** Use `useShallow` for multiple selections:
-
-```typescript
-const { drawer, bins } = useLayoutStore(
-  useShallow((state) => ({
-    drawer: state.layout.drawer,
-    bins: state.layout.bins,
-  }))
-);
-```
-
-**Undo pattern:**
-
-```typescript
-const { execute } = useUndoableAction();
-execute(() => addBin({ ... }));
-```
-
-### Core Data Model (`src/core/types.ts`)
+### Data Model (`src/core/types.ts`)
 
 ```
 Layout → Drawer, Categories[], Layers[], Bins[], printBedSize, gridUnitMm, heightUnitMm
-Drawer → width, depth, height (grid units), fractionalEdgeX?, fractionalEdgeY?
-Bin → position (x,y), size (w,d,h), layerId, category, label, notes, clearanceHeight?, customProperties?
-Layer → id, name, height
-Category → id, name, color
-
-LayoutLibrary → activeLayoutId, settings, LayoutEntry[]
-LayoutEntry → id, name, timestamps, preview, cloudShare?
-SharedWithMeEntry → sourceShareId, name, permission, status
+Bin → position (x,y), size (w,d,h), layerId, category, label, notes, customProperties?
 ```
 
-**Critical Gotchas:**
+### Critical Gotchas
 
-1. **Coordinate System**: Grid origin (0,0) is **bottom-left**. `layers[0]` is bottom layer. UI displays layers reversed via `getDisplayLayers()`.
+1. **Coordinate System**: Grid (0,0) is **bottom-left**. `layers[0]` is bottom. UI reverses via `getDisplayLayers()`.
+2. **Staging**: `layerId === '__staging__'` = off-grid stash. Auto-used when bins displaced.
+3. **Half-Bin Mode**: 0.5 increments. Helpers: `snapToHalf()`, `snapToGrid()`, `isFractional()`. `HALF_BIN_SCALE = 2`.
+4. **Multi-Layout**: Each layout stored by UUID (`gridfinity-layout-{uuid}`). Library index tracks metadata only.
 
-2. **Staging Area**: Bins with `layerId === STAGING_ID` (`'__staging__'`) are in stash (off-grid). Bins auto-move here when displaced by drawer resize or when duplication can't find space.
+### Result Type (`src/core/result/`)
 
-3. **Half-Bin Mode**: Supports 0.5 unit increments. Use helpers from `@/core/constants`:
-   - `snapToHalf(value)`, `snapToGrid(value, halfBinMode)`, `isFractional(value)`, `hasFractionalDimensions(rect)`
-   - Validation in `halfBinConstraints.ts` prevents disabling mode when fractional bins exist.
-   - `HALF_BIN_SCALE = 2` - Grid rendered at 2x for 0.5 support
+Use `Result<T, E>` for fallible operations. Import `ok`, `err`, `isOk`, `isErr` from `@/core/result`.
 
-4. **Multi-Layout Storage**: Each layout stored separately by UUID (`gridfinity-layout-{uuid}`). Library index (`gridfinity-library-v1`) tracks metadata without loading full data.
+Error types: `LayoutError`, `ValidationError`, `StorageError`, `ApiError`. Use `getUserMessage()` for display.
 
-5. **Custom Properties**: Bins support arbitrary key-value metadata (max 50 properties, keys max 32 chars, values max 256 chars). Reserved keys (id, layerId, etc.) prohibited.
+### Storage (`src/core/storage/`)
 
-### Result Type System (`src/core/result/`)
+**Atomic ops (preferred):** `saveLayoutWithMetadata()`, `createLayoutEntry()`, `deleteLayoutWithEntry()`, `switchActiveLayout()`
 
-Use `Result<T, E>` for operations that can fail (storage, API, validation):
+Import from `@/core/storage` (public facade).
 
-```typescript
-import { ok, err, isOk, isErr } from '@/core/result';
-import type { Result, StorageError } from '@/core/result';
+### Interaction Modes
 
-function loadData(): Result<Layout, StorageError> {
-  try {
-    const data = localStorage.getItem('key');
-    if (!data) return err(storageError('NOT_FOUND', 'Data not found'));
-    return ok(JSON.parse(data));
-  } catch {
-    return err(storageError('PARSE_ERROR', 'Invalid JSON'));
-  }
-}
+`draw` | `drag` | `resize` | `stagingDrag` | `paint`
 
-const result = loadData();
-if (isOk(result)) {
-  console.log(result.value); // Layout
-} else {
-  console.error(result.error); // StorageError
-}
-```
+## Key Constants (`src/core/constants.ts`)
 
-Error types: `LayoutError`, `ValidationError`, `StorageError`, `ApiError` with structured codes and user-friendly messages via `getUserMessage()`.
+| Constraint        | Value        |
+| ----------------- | ------------ |
+| Grid size         | 0.5-50 units |
+| Layers            | 1-10         |
+| Categories        | 1-20         |
+| Layouts           | 100 max      |
+| Undo states       | 50           |
+| Grid unit         | 42mm         |
+| Height unit       | 7mm          |
+| Print bed default | 256mm        |
 
-**Result Handling Conventions:**
+**Breakpoints:** MD: 768px (mobile/tablet), LG: 900px (tablet/desktop)
 
-1. **When to use throwing vs Result-based functions:**
-   - Use `Result<T, E>` for operations where failure is expected (storage, API, validation)
-   - Use throwing functions for internal errors that indicate programmer mistakes
-   - Provide both versions where appropriate (e.g., `getLayerZStart` throws, `getLayerZStartResult` returns Result)
-
-2. **Handling Results in UI components:**
-
-   ```typescript
-   // For operations that return values (use the returned value)
-   const result = addLayer();
-   if (isOk(result)) {
-     setActiveLayer(result.value);
-   }
-
-   // For operations that may fail (show error to user)
-   const result = updateLayer(id, updates);
-   if (isErr(result)) {
-     addToast(getUserMessage(result.error), 'error');
-   }
-   ```
-
-3. **Batch operations with `execute()` (undo wrapper):**
-   - Mutations inside `execute()` callbacks are batched for undo/redo
-   - Individual Result checking is optional since store validates inputs
-   - Check Results when the outcome affects subsequent logic (e.g., getting new IDs)
-
-   ```typescript
-   // Simple batch - no individual checks needed
-   execute(() => {
-     for (const binId of selectedBinIds) {
-       updateBin(binId, { category: newCategoryId });
-     }
-   });
-
-   // When you need the result value
-   execute(() => {
-     const result = addBin(binData);
-     if (isOk(result)) {
-       setSelectedBin(result.value); // Need the new bin ID
-     }
-   });
-   ```
-
-4. **Fire-and-forget async patterns (background sync):**
-   - Used in `useAutoSave`, `useOwnedShareSync`, `useCloudShareAutoSync`
-   - Check Results but silently ignore failures for non-critical background operations
-   - Track failure counts for escalating error display
-   ```typescript
-   const result = await saveLayoutWithMetadata(id, layout, library);
-   if (isErr(result)) {
-     handleSaveError(result.error); // Escalating toasts after 3 failures
-     return;
-   }
-   // Success path...
-   ```
-
-### Component Architecture
-
-**Grid rendering:** CSS Grid-based (NOT HTML Canvas), despite `GridCanvas.tsx` naming. DOM overlay (`Overlay.tsx`) handles interactive bins with drag/resize handles.
-
-**Responsive:** Three layout modes detected via `useResponsive.ts`:
-
-- Mobile (<768px): `Mobile/` components, lazy-loaded `MobileLayout.tsx`
-- Tablet (768-900px): `Tablet/` overlay panels
-- Desktop (>=900px): Standard sidebar layout
-
-**3D Preview:** `features/grid-editor/components/Grid/IsometricPreview/` - Three.js scene (lazy loaded). Camera controlled via `use3DPreviewKeyboard.ts` (keys 1-4 for presets, Space to expand).
-
-### Storage Layer (`src/core/storage/`)
-
-Service-layer architecture with dual-write backend (IndexedDB + localStorage):
-
-**Atomic Operations (Preferred):**
-
-- `saveLayoutWithMetadata()` - Atomic layout + library save
-- `createLayoutEntry()` - Create new layout with entry
-- `deleteLayoutWithEntry()` - Delete layout and entry atomically
-- `switchActiveLayout()` - Switch and update library
-
-**Legacy CRUD:**
-
-- Async (runtime): `saveLayoutAsync()`, `loadLayoutAsync()`, `deleteLayoutAsync()`
-- Sync (init only): `saveLayoutSync()`, `loadLayoutSync()`, `deleteLayoutSync()`
-- Result-based: `saveLayoutResult()`, `loadLayoutResult()`, `deleteLayoutResult()`
-
-**Other:**
-
-- Library: `saveLibrary()`, `loadLibrary()`, `initializeLayoutLibrary()`
-- Share: `exportLayoutJSON()`, `importLayoutJSON()`, `encodeLayoutForURL()`, `decodeLayoutResult()`
-- SharedWithMe: `saveSharedWithMe()`, `loadSharedWithMe()` - Track layouts shared by others
-- Migration: `isMigrationNeeded()`, `migrateAllLayoutsToIndexedDB()`
-
-Import from `@/core/storage` (public API facade).
-
-### Interaction System (`src/hooks/interactions/`)
-
-Five interaction modes (union type):
-
-- **draw** - Drag-select to create bin
-- **drag** - Move selected bins
-- **resize** - Corner/edge handles
-- **stagingDrag** - Drag from stash to grid
-- **paint** - Fill mode: drag area to fill with uniform bins
-
-### Real-Time Collaboration (`src/liveblocks.config.ts`)
-
-Experimental feature using Liveblocks. Enable via Labs settings.
-
-**Presence data:**
-
-- Cursor position (normalized 0-1 coords)
-- User name and color
-- Interaction hints (drawing, dragging, resizing)
-- Selected bin IDs (for Figma-style selection rings)
-
-**Storage sync:**
-
-- Layout data synchronized in real-time
-- Owner permissions (view/edit) enforced
-- Schema versioning for migrations
-
-**Key hooks:**
-
-- `useCollabMode()` - Check/enable collab mode
-- `useCollabSync()` - Sync local <-> Liveblocks state
-- `useCollabPresence()` - Update presence data
-- `useInterpolatedPresence()` - Smooth cursor animations
-
-### Internationalization (`src/i18n/`)
-
-Multi-language support with lazy-loaded locales.
-
-**Supported locales:** English (inline), German, Spanish, French, Dutch, Portuguese (BR)
-
-**Key hooks:**
+## i18n (`src/i18n/`)
 
 ```typescript
-import { useTranslation, useFormatting } from '@/i18n';
-
 const t = useTranslation();
-const { formatDate, formatRelativeDate, formatNumber } = useFormatting();
-
-// Translation with interpolation
-t('toast.binsDeleted', { count: 5 }); // "Deleted 5 bin(s)"
-
-// Locale-aware date formatting
-formatRelativeDate(timestamp); // "Today", "2d ago", etc.
-formatRelativeDate(ts, false); // Long format: "2 days ago"
-formatRelativeDate(ts, { includeTime: true }); // "5m ago", "2h ago"
+t('toast.binsDeleted', { count: 5 }); // Interpolation with {variable}
 ```
 
-**For class components** (like ErrorBoundary):
+Add keys to `en.ts` first, then all locale JSONs. Run `npm run check:i18n`.
 
-```typescript
-import { getStaticTranslation } from '@/i18n';
-getStaticTranslation('errorBoundary.heading');
-```
+## API (`api/`)
 
-**Adding new keys:**
-
-1. Add to `src/i18n/locales/en.ts` (source of truth)
-2. Add translations to all JSON locale files
-3. Run `npm run check:i18n` to verify sync
-
-**Conventions:**
-
-- Use `{variable}` for interpolation (not `{{variable}}`)
-- Keep brand names ("Gridfinity") in English
-- Use `(s)` suffix for simple plurals (e.g., `{count} bin(s)`)
-- Aria-labels should be localized using `t()` function
-
-### Labs / Feature Flags (`src/features/labs/`)
-
-Experimental features can be toggled in settings:
-
-```typescript
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
-
-const isEnabled = useFeatureFlag('collaborative_editing');
-```
-
-Current flags:
-
-- `collaborative_editing` - Real-time collaboration (experimental)
-- `layout_to_print` - STL export (coming soon)
-
-### Key Utilities
-
-**Validation & Collision (`src/shared/utils/`, `src/features/grid-editor/utils/`):**
-
-- `validation.ts` - `canPlaceBin()` checks bounds, height, collisions; `validateImport()` for imports
-- `collision.ts` - Collision detection, blocked zones, layer Z calculations, `getDisplayLayers()`
-- `halfBinConstraints.ts` - Validates half-bin mode toggle
-
-**Bulk Operations:**
-
-- `fill.ts` - `fillAllWithSize()`, `fillGaps()`
-- `split.ts` - `splitBinSize()` recursively splits oversized bins, `generatePrintList()` creates manifest with filament estimates
-- `printEstimates.ts` - Filament cost/spool calculations
-- **Print Bed Constraints:** `calcMaxGridUnits(printBedSizeMm, gridUnitMm)` computes max bin dimensions for printer.
-
-**Other utilities:**
-
-- `compression.ts` - LZ-string compression for URL sharing
-- `guestNames.ts` - Random guest name generation for collab
-- `throttle.ts` - Throttle/debounce for presence updates
-- `stlSearch.ts` - Gridfinity STL file search helpers
-
-### API (Vercel Serverless)
-
-**Backend** (`api/`):
-
-- `share.ts` - POST: Create share (Vercel Blob)
-- `share/[id].ts` - GET/PUT/DELETE share
-- `report/[id].ts` - POST: Report content
-- `liveblocks-auth.ts` - Liveblocks authentication
-- `lib/rateLimit.ts` - Redis rate limiting (10 shares/hour, 100 reads/hour)
-- `lib/validation.ts` - 500KB max, 2500 bins max
-
-**Client** (`src/core/api/share.ts`):
-
-- `createShare()`, `updateShare()`, `fetchShare()`, `deleteShare()`, `reportShare()`
-- Types: `ShareResponse`, `ShareErrorResponse`, `ShareResult<T>`
-
-### ML Telemetry (`src/shared/analytics/`, `api/ml-telemetry.ts`)
-
-Privacy-preserving telemetry for training bin size prediction models. No PII stored - only aggregate counts in Redis.
-
-**Event Types:**
-
-- `bin_placed` - Size, position, label hash, drawer context, placement method
-- `layout_snapshot` - Triggered on save/export/share with size distributions
-- `bin_resized`, `bin_deleted`, `bin_moved` - User corrections (negative signals)
-- `placement_rejected`, `undo`, `quick_correction` - Strong negative signals
-
-**Client** (`src/shared/analytics/useMLTracking.ts`):
-
-```typescript
-import { mlTracking } from '@/shared/analytics/useMLTracking';
-
-mlTracking.trackPlacement(bin, 'draw');
-mlTracking.trackDeletion(bin, 'key', batchSize);
-mlTracking.recordCreation(binId, 'draw', '2x3x6'); // For quick-correction detection
-```
-
-Events are batched (20 events or 30s) and sent to `/api/ml-telemetry`. Redis keys prefixed with `ml:` for positive signals, `ml:neg:` for negative signals.
-
-**Auditing Production Data:**
-
-```bash
-# Run the audit script
-./scripts/audit-ml-telemetry.sh
-
-# Or query directly
-source .env.local
-redis-cli -u "$REDIS_URL" HGETALL "ml:sizes"
-```
-
-See `docs/ml-telemetry-audit.md` for full audit guide, key structure documentation, and troubleshooting.
-
-## Constants (`src/core/constants.ts`)
-
-**Constraints:**
-
-- Grid: 0.5-50 units (half-unit increments supported)
-- Layers: 1-10, Categories: 1-20, Layouts: 100 max (warn at 80)
-- Undo: 50 states, Zoom: 0.25-4.0
-- Quick fill max: 2500 bins (confirm at 100+)
-- Print gap: 10mm, Custom properties: max 50/bin
-
-**Defaults:**
-
-- Cell: 32px (`BASE_CELL_SIZE`), Drawer: 10x8x12 units
-- Grid unit: 42mm, Height unit: 7mm, Print bed: 256mm
-
-**Breakpoints:** TINY_PHONE: 375px, SM: 640px, MD: 768px (mobile/tablet), LG: 900px (tablet/desktop), XL: 1280px
-
-**Keyboard Shortcuts:** See `SHORTCUTS` object - includes navigation (WASD/arrows), 3D preview (1-4, Space, V), undo/redo (Ctrl+Z/Y), duplicate (Ctrl+D), rotate (R), half-bin (H), layout manager (Ctrl+O).
+| Endpoint            | Purpose                    |
+| ------------------- | -------------------------- |
+| `share.ts`          | POST: Create share         |
+| `share/[id].ts`     | GET/PUT/DELETE share       |
+| `lib/rateLimit.ts`  | 10 shares/hr, 100 reads/hr |
+| `lib/validation.ts` | 500KB max, 2500 bins max   |
 
 ## Testing
 
-**Unit tests** (`src/test/`): Vitest + jsdom. Focus on utils/store/hooks. Use `createTestLayout()` factory from `testUtils.ts`. Run `npm run test:coverage` before commit.
-
-**E2E tests** (`e2e/`): Playwright. Full user flows. Run `npm run test:e2e` (headless) or `npm run test:e2e:ui` (interactive).
-
-**Test setup** (`src/test/setup.ts`):
-
-- fake-indexeddb for storage tests
-- Mocked pointer capture, matchMedia
-- Auto-cleanup after each test
-
-## Build Config
-
-**Vite** (`vite.config.ts`):
-
-- Code splitting: `three` (lazy), `react-three`, `react-vendor`, `state` (Zustand + Immer)
-- Bundle limits: Main 126 kB gzip, Total 690 kB gzip
-- Path alias: `@/` -> `src/`
-
-**ESLint:** Strict TypeScript + React hooks rules. Relaxed for test files (allow `any`, non-null assertions).
+- **Unit:** Vitest + jsdom. Use `createTestLayout()` from `testUtils.ts`
+- **E2E:** Playwright. `npm run test:e2e`
+- Run `npm run test:coverage` before commit
 
 ## Scripts
 
 ```bash
-npm run dev          # Start dev server
-npm run build        # TypeScript check + production build
-npm run lint         # ESLint check
-npm run test         # Run tests in watch mode
-npm run test:run     # Run tests once
-npm run test:coverage # Run tests with coverage
-npm run test:e2e     # Run Playwright E2E tests
-npm run test:e2e:ui  # Run E2E with interactive UI
-npm run size         # Check bundle sizes
+npm run dev           # Dev server
+npm run build         # TypeScript + production build
+npm run test:coverage # Tests with coverage
+npm run test:e2e      # Playwright E2E
+npm run size          # Bundle size check
 ```
 
 ## Environment Variables
 
-Vercel backend (set in Vercel dashboard):
+**Vercel (required):** `BLOB_READ_WRITE_TOKEN`, `KV_REST_API_URL`, `KV_REST_API_TOKEN`, `TOKEN_SALT`
 
-- `BLOB_READ_WRITE_TOKEN` - Vercel Blob access
-- `KV_REST_API_URL`, `KV_REST_API_TOKEN` - Vercel KV (Redis)
-- `TOKEN_SALT` - Delete token hashing
+**Optional:** `VITE_LIVEBLOCKS_PUBLIC_KEY`, `LIVEBLOCKS_SECRET_KEY`
 
-Optional (for Liveblocks):
+## Claude Code Hooks
 
-- `VITE_LIVEBLOCKS_PUBLIC_KEY` - Client-side Liveblocks key
-- `LIVEBLOCKS_SECRET_KEY` - Server-side auth (if using auth endpoint)
-
-## Claude Code Hooks (`.claude/hooks/`)
-
-Pre-configured hooks for quality checks:
-
-- `pre-pr-review.sh` - Runs before PR creation (lint, build, test coverage)
-- `post-edit-test.sh` - Runs affected tests after file edits
-- `coverage-check.sh` - Validates coverage thresholds
-- `a11y-check.sh` - Accessibility audit for component changes
+- `pre-pr-review.sh` - Lint, build, coverage before PR
+- `post-edit-test.sh` - Affected tests after edits

--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -1,0 +1,51 @@
+# Bin Designer
+
+Parametric 3D Gridfinity bin generator with WASM-based geometry engine.
+
+## Key Files
+
+| File                               | Purpose                                                             |
+| ---------------------------------- | ------------------------------------------------------------------- |
+| `store/designer.ts`                | Zustand store: params, generation state, undo/redo history (max 50) |
+| `store/meshCacheManager.ts`        | Memory budget (100MB) for cached meshes in history                  |
+| `store/customBinRegistry.ts`       | Lightweight localStorage index for Layout Planner palette           |
+| `hooks/useGeneration.ts`           | Bridge lifecycle, epoch-based auto-regeneration                     |
+| `hooks/useAutoSave.ts`             | 1s debounced save for existing designs                              |
+| `hooks/useExport.ts`               | STL/3MF/STEP export lifecycle                                       |
+| `components/DesignerPage.tsx`      | Main layout, responsive (desktop/tablet/mobile)                     |
+| `components/CompartmentEditor.tsx` | Visual grid for merge/split cells                                   |
+
+## Data Flow
+
+```
+User edits params → store.setParam() → epoch++ → useGeneration detects
+→ GenerationBridge.generate(params) → Worker tessellates mesh
+→ setGenerationResult() → PreviewCanvas renders Three.js mesh
+```
+
+## Architecture
+
+- **Generation runs in Web Worker** (can't access DOM)
+- **OpenCascade WASM** is ~11MB, lazy-loaded on first use
+- **Epoch pattern**: Increment signals regeneration; unchanged = cache hit (instant undo)
+- **Pending mesh cache**: Module-level variable, attached to history on next edit
+
+## Gotchas
+
+1. **Compartment cells must form rectangles** - `isRectangularSelection()` validates
+2. **Min compartment size is 5mm** - smaller cells silently skip wall generation
+3. **Auto-save only for saved designs** - unsaved "Untitled" bins don't persist
+4. **Half-cells get no magnet holes** - only full 1×1 unit cells
+5. **Solid style ignores wallThickness** - hardcoded to 1.6mm
+
+## Integration Points
+
+- **Layout Planner**: `?placeBin=WxDxH` URL param places custom bin at (0,0)
+- **Custom bin registry**: localStorage sync for planner's "Custom Bins" palette
+- **Export**: Uses shared `exportSTL()`, `export3MF()` from generation feature
+
+## Constants
+
+- Grid: 42mm/unit, Height: 7mm/unit, Socket: 5mm deep
+- Dimensions: 0.5-8 units (0.5 increments)
+- History: 50 states, Cache: 100MB budget

--- a/src/features/bin-inspector/README.md
+++ b/src/features/bin-inspector/README.md
@@ -1,0 +1,47 @@
+# Bin Inspector
+
+Details panel for viewing and editing selected bin properties.
+
+## Key Files
+
+| File                          | Purpose                             |
+| ----------------------------- | ----------------------------------- |
+| `components/BinInspector.tsx` | Main panel showing bin details      |
+| `hooks/useBinInspector.ts`    | Selected bin data and edit handlers |
+
+## Features
+
+- View/edit bin dimensions (width, depth, height)
+- View/edit label and notes
+- Category assignment dropdown
+- Custom properties editor (key-value pairs)
+- Delete button with confirmation
+
+## Data Flow
+
+```
+Selection store → selectedBinIds → useBinInspector
+  → derives bin data from layout store
+  → edit handlers call layout store mutations
+```
+
+## Editable Fields
+
+| Field        | Constraint                              |
+| ------------ | --------------------------------------- |
+| Label        | Max 64 chars                            |
+| Notes        | Max 256 chars                           |
+| Category     | From available categories               |
+| Custom props | Max 50, key: 32 chars, value: 256 chars |
+
+## Gotchas
+
+1. **Multi-select shows summary** - can't edit dimensions of multiple bins
+2. **Custom properties have reserved keys** - id, layerId, category blocked
+3. **Height changes validate** - must fit in layer + drawer height
+
+## Integration
+
+- **selection store**: Reads `selectedBinIds`
+- **layout store**: Calls `updateBin()` for edits
+- **undo**: Edits wrapped in `useUndoableAction`

--- a/src/features/categories/README.md
+++ b/src/features/categories/README.md
@@ -1,0 +1,42 @@
+# Categories
+
+Bin color-coding system for visual organization.
+
+## Key Files
+
+| File                             | Purpose                               |
+| -------------------------------- | ------------------------------------- |
+| `components/CategoriesPanel.tsx` | Category list with CRUD, color picker |
+
+## Core Concepts
+
+- Each bin has a `category` field (category ID)
+- Categories have `id`, `name`, and `color` (hex)
+- Default category created on layout init
+- Colors rendered on bins and in print list
+
+## Data Flow
+
+```
+addCategory({ name, color }) → new category with generated ID
+updateCategory(id, { color }) → all bins with that category update visually
+deleteCategory(id) → bins reassigned to first remaining category
+```
+
+## Constraints
+
+- **Min 1 category** - can't delete the last one
+- **Max 20 categories** - CONSTRAINTS.MAX_CATEGORIES
+- **Color format** - hex string (e.g., `#3B82F6`)
+
+## Gotchas
+
+1. **Deleting category reassigns bins** - not orphaned
+2. **Category ID used in bin.category** - not name
+3. **Print list groups by category** - affects export organization
+
+## Integration
+
+- **grid-editor**: Bin colors derived from category
+- **print-export**: Groups bins by category in print list
+- **layout store**: Category CRUD with Result types

--- a/src/features/cloud-share/README.md
+++ b/src/features/cloud-share/README.md
@@ -1,0 +1,57 @@
+# Cloud Share
+
+Persistent cloud sharing via Vercel Blob with permission control.
+
+## Key Files
+
+| File                                  | Purpose                                        |
+| ------------------------------------- | ---------------------------------------------- |
+| `hooks/useCloudShare.ts`              | Main hook: share/update/delete/permission CRUD |
+| `hooks/useOwnedShareSync.ts`          | 5s debounced auto-sync for owners              |
+| `hooks/useCloudShareAutoSync.ts`      | 1s debounced sync in collab mode               |
+| `components/CloudShareTab.tsx`        | Full UI in ShareModal                          |
+| `components/ShareButton.tsx`          | Compact header button (collab mode)            |
+| `components/SharedLayoutImporter.tsx` | Detects/loads shared layouts from URL          |
+| `components/SharedLayoutBanner.tsx`   | View-only banner with save/discard             |
+
+## Data Flow
+
+```
+Create: share(permission) → POST /api/share → Blob storage
+        → setCloudShare() saves CloudShareInfo to library entry
+
+Auto-sync: Owner edits → useOwnedShareSync (5s debounce)
+           → PUT /api/share/{id} with fingerprint check
+
+Import: /l/{shareId} → SharedLayoutImporter → fetchShare()
+        → Add to "Shared with me" list
+```
+
+## Permission Model
+
+- **`view`**: Read-only, anyone with link can see
+- **`edit`**: Collaborative editing (requires Liveblocks flag)
+- **Delete token**: Random secret, hashed server-side, required for mutations
+
+## Gotchas
+
+1. **Share ID = Layout UUID** - URL uses layout's own ID
+2. **Shares are permanent** - no expiration, only explicit delete
+3. **Staging bins never sync** - filtered from fingerprint
+4. **Owner can't see own share in "Shared with me"**
+5. **Delete while in collab disconnects all users**
+
+## Auto-Sync Behavior
+
+| Hook                    | Who           | Debounce | Trigger              |
+| ----------------------- | ------------- | -------- | -------------------- |
+| `useOwnedShareSync`     | Owner         | 5s       | Local edits, unmount |
+| `useCloudShareAutoSync` | Collaborators | 1s       | Liveblocks mutations |
+
+Both use fingerprint comparison to skip redundant syncs.
+
+## API Layer
+
+Uses Result types: `createShare()`, `updateShare()`, `fetchShare()`, `deleteShare()`
+
+Error codes: `RATE_LIMITED`, `SIZE_LIMIT` (500KB), `BIN_LIMIT` (2500), `CONTENT_BLOCKED`

--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -1,0 +1,64 @@
+# Generation
+
+BREP-based 3D geometry engine running in Web Worker with OpenCascade WASM.
+
+## Key Files
+
+| File                               | Purpose                                              |
+| ---------------------------------- | ---------------------------------------------------- |
+| `bridge/GenerationBridge.ts`       | Main-thread API: lifecycle, debouncing, cancellation |
+| `bridge/adaptiveDebounce.ts`       | 50-300ms delay based on recent timings               |
+| `worker/generation.worker.ts`      | Entry: WASM init, message dispatch                   |
+| `worker/generators/replicadBin.ts` | Core geometry (1000+ lines)                          |
+| `worker/stageCache.ts`             | Intermediate BREP shape caching                      |
+| `export/stlExporter.ts`            | Binary STL (50 bytes/triangle)                       |
+| `export/threemfExporter.ts`        | 3MF ZIP with XML mesh + metadata                     |
+
+## Generation Pipeline
+
+```
+Stage 1: Base Socket → [cached: baseShape]
+Stage 2: Shell Box   → [cached: shellShape]
+Stage 3: Assembly    → [cached: assemblyShape]
+Stage 4: Features (dividers, scoops, cutouts, inserts) → always rebuilt
+Stage 5: Translate Z by SOCKET_HEIGHT
+Stage 6: Tessellate → MeshData {vertices, normals}
+```
+
+## Worker Protocol
+
+```
+INIT → worker loads WASM (2-4s, 11MB)
+GENERATE → tessellation + progress callbacks
+EXPORT → STL/3MF (main-thread) or STEP (worker)
+CANCEL → silently aborts current request
+```
+
+Each request tagged with `requestId`; cancelled requests ignored.
+
+## Export Formats
+
+| Format | Size                       | Use Case                       |
+| ------ | -------------------------- | ------------------------------ |
+| STL    | ~50 bytes/tri              | Fast, portable 3D printing     |
+| 3MF    | ~30 bytes/tri (compressed) | Rich metadata, slicer settings |
+| STEP   | ~500KB+                    | Lossless CAD interchange       |
+
+## Gotchas
+
+1. **Half-cells decompose separately** - 1.5 width = [1.0, 0.5] cells
+2. **Magnet holes only in full (1×1) cells** - half cells remain solid
+3. **Features fail silently** - tiny cells → scoop skipped with warning
+4. **Stacking lip fusion can fail** - falls back to base+shell only
+5. **WASM heap refs can't transfer threads** - cache only valid in worker
+
+## Performance
+
+| Stage           | Typical (2×2 bin) |
+| --------------- | ----------------- |
+| WASM init       | 2-4s (first load) |
+| Full generation | 1-3s (warm cache) |
+| Features only   | 0.2-0.5s          |
+| Tessellation    | 0.5-1s            |
+
+Adaptive debounce: fast gens → 50ms delay, slow gens → 300ms delay

--- a/src/features/grid-editor/README.md
+++ b/src/features/grid-editor/README.md
@@ -1,0 +1,57 @@
+# Grid Editor
+
+Core interactive layout editor using CSS Grid rendering (not Canvas).
+
+## Key Files
+
+| File                             | Purpose                                            |
+| -------------------------------- | -------------------------------------------------- |
+| `components/Grid/index.tsx`      | Main container, responsive breakpoints             |
+| `components/Grid/GridCanvas.tsx` | CSS Grid cells, bin containers, event handling     |
+| `components/Grid/Overlay.tsx`    | Real-time interaction previews                     |
+| `components/Grid/Bin.tsx`        | Individual bin with selection ring, resize handles |
+| `hooks/useInteraction.ts`        | Master dispatcher for 5 interaction modes          |
+| `hooks/useGridCoords.ts`         | Pixel ↔ grid coordinate conversion                 |
+| `utils/collision.ts`             | 3D collision detection, blocked zones              |
+
+## Coordinate System (CRITICAL)
+
+```
+Grid origin (0,0) is BOTTOM-LEFT
+Screen Y is inverted: gridY = drawer.depth - screenY - 1
+layers[0] is BOTTOM layer (UI displays reversed)
+```
+
+## Interaction Modes
+
+| Mode          | Trigger               | Throttled | Purpose                          |
+| ------------- | --------------------- | --------- | -------------------------------- |
+| `draw`        | Drag empty space      | No        | Create bin by dragging rectangle |
+| `drag`        | Drag bin(s)           | RAF       | Move selected bins               |
+| `resize`      | Drag handle           | RAF       | Resize with corner/edge handles  |
+| `paint`       | Paint size set + drag | No        | Fill area with uniform bins      |
+| `stagingDrag` | Drag from stash       | RAF       | Place bin from staging area      |
+
+## Validation Flow
+
+All modes call `canPlaceBin()` which checks:
+
+1. **Bounds** - within drawer dimensions
+2. **Height** - fits remaining drawer height
+3. **Blocked zones** - no overlap with lower-layer protrusions
+4. **Collisions** - 3D overlap (footprint + vertical range)
+
+## Gotchas
+
+1. **Y-axis inversion** - forget this and bins appear upside down
+2. **Half-bin mode** - doubles visual grid (`HALF_BIN_SCALE = 2`)
+3. **Fractional edges** - drawer 10.5 width = one narrow column
+4. **Multi-select drag** - entire group stops if one bin blocked
+5. **Ghost bins** - lower-layer bins shown semi-transparent
+
+## Integration Points
+
+- **Staging**: Bins with `layerId === STAGING_ID` are off-grid
+- **Layers**: `getBlockedZones()` calculates protrusions from lower layers
+- **Selection store**: `setSelectedBins()` for multi-select
+- **Collab**: Cursor tracking via `updateCursor({ x, y })`

--- a/src/features/inspiration-gallery/README.md
+++ b/src/features/inspiration-gallery/README.md
@@ -1,0 +1,59 @@
+# Inspiration Gallery
+
+Curated example layouts organized by theme for user onboarding.
+
+## Key Files
+
+| File                                | Purpose                                 |
+| ----------------------------------- | --------------------------------------- |
+| `components/InspirationGallery.tsx` | Modal with theme filtering              |
+| `components/LayoutCard.tsx`         | Individual layout preview card          |
+| `components/ThemeFilterPills.tsx`   | Theme category filter buttons           |
+| `data/themes/*.ts`                  | Layout definitions by theme             |
+| `utils/layoutBuilder.ts`            | Converts InspirationLayout → Layout     |
+| `types.ts`                          | InspirationLayout, InspirationBin types |
+
+## Themes
+
+| Theme    | Examples                        |
+| -------- | ------------------------------- |
+| Workshop | Tool drawer, hardware organizer |
+| Office   | Desk drawer, supplies           |
+| Kitchen  | Utensil drawer, spice rack      |
+| Hobby    | Craft supplies, sewing          |
+| Personal | Bathroom drawer, jewelry        |
+
+## Data Structure
+
+```typescript
+interface InspirationLayout {
+  id: string;
+  name: string;
+  description: string;
+  theme: Theme;
+  drawer: { width; depth; height };
+  bins: InspirationBin[]; // Simplified bin format
+  tags: string[];
+}
+```
+
+## Data Flow
+
+```
+User selects layout → buildLayoutFromInspiration(inspiration)
+  → generates full Layout with IDs, layers, categories
+  → importLayout() loads into editor
+```
+
+## Gotchas
+
+1. **Layouts are templates** - importing creates copy, not reference
+2. **Simplified bin format** - no layerId (defaults to first layer)
+3. **Categories auto-generated** - from bin category names in template
+4. **Lazy-loaded modal** - chunk split for bundle size
+
+## Integration
+
+- **layout store**: `importLayout()` loads generated layout
+- **layout-library**: Creates new entry on import
+- **MobileLayoutsPanel**: Links to gallery for mobile users

--- a/src/features/labs/README.md
+++ b/src/features/labs/README.md
@@ -1,0 +1,47 @@
+# Labs
+
+Experimental feature flags for opt-in preview features.
+
+## Key Files
+
+| File                           | Purpose                             |
+| ------------------------------ | ----------------------------------- |
+| `components/LabsPanel.tsx`     | Settings UI with feature toggles    |
+| `components/WhatsNewBadge.tsx` | "New" indicator for recent features |
+
+## Infrastructure Location
+
+Core labs infrastructure lives elsewhere:
+
+- **Types & definitions**: `@/core/labs` (LabFeature, FEATURES array)
+- **Store**: `@/core/store/labs` (useLabsStore)
+- **Hook**: `@/hooks/useFeatureFlag`
+
+## Current Flags
+
+| Flag                    | Purpose                     | Status       |
+| ----------------------- | --------------------------- | ------------ |
+| `collaborative_editing` | Real-time Liveblocks collab | Experimental |
+| `layout_to_print`       | STL export from layout      | Coming soon  |
+
+## Usage Pattern
+
+```typescript
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+
+const isEnabled = useFeatureFlag('collaborative_editing');
+if (isEnabled) {
+  // Show collab-specific UI
+}
+```
+
+## Gotchas
+
+1. **Flags persisted in localStorage** - survives refresh
+2. **Some flags require page reload** - noted in UI
+3. **Feature definitions in core/labs** - not in this feature module
+
+## Integration
+
+- **cloud-share**: `collaborative_editing` enables edit permission
+- **settings**: Labs section links to this panel

--- a/src/features/layers/README.md
+++ b/src/features/layers/README.md
@@ -1,0 +1,49 @@
+# Layers
+
+Vertical stacking system for multi-height drawer organization.
+
+## Key Files
+
+| File                              | Purpose                                 |
+| --------------------------------- | --------------------------------------- |
+| `components/LayerPanel.tsx`       | Full layer list with add/delete/reorder |
+| `components/ActiveLayerPanel.tsx` | Compact current layer indicator         |
+| `hooks/useLayerHeight.ts`         | Z-axis calculations for layer stacking  |
+
+## Core Concepts
+
+- **layers[0] is BOTTOM** - array order = physical stack order
+- **UI displays reversed** - via `getDisplayLayers()` for top-to-bottom visual
+- **Z-start calculated** - cumulative height of layers below
+
+## Data Flow
+
+```
+addLayer() → new layer at top of stack
+setActiveLayer(id) → selection store updates
+reorderLayers(from, to) → validates no collision conflicts
+deleteLayer(id) → bins move to staging, can't delete last layer
+```
+
+## Layer Z Calculations
+
+```typescript
+getLayerZStart(layerId, layers):
+  sum of heights of all layers with index < targetIndex
+
+getLayerZEnd(layerId, layers):
+  zStart + layer.height
+```
+
+## Gotchas
+
+1. **Bottom-left coordinate system** - Y=0 is bottom, layers[0] is bottom
+2. **Blocked zones** - bins from lower layers protrude into higher layers
+3. **Reorder validation** - checks for vertical collisions before allowing
+4. **Can't delete last layer** - minimum 1 layer required
+
+## Integration
+
+- **grid-editor**: Ghost bins show lower layers, blocked zones hatched
+- **collision.ts**: `checkLayerReorderCollisions()` validates moves
+- **layout store**: Layer CRUD operations with Result types

--- a/src/features/layout-library/README.md
+++ b/src/features/layout-library/README.md
@@ -1,0 +1,48 @@
+# Layout Library
+
+Multi-layout management with thumbnails and metadata.
+
+## Key Files
+
+| File                                | Purpose                    |
+| ----------------------------------- | -------------------------- |
+| `components/LayoutManagerModal.tsx` | Full layout browser dialog |
+| `hooks/useLayoutRouting.ts`         | URL-based layout loading   |
+
+## Note on useLayoutSwitcher
+
+Main switching logic moved to `@/hooks/useLayoutSwitcher` (re-exported here for backward compatibility).
+
+## Core Concepts
+
+- **Library**: Index of `LayoutEntry` objects (metadata only)
+- **Layouts**: Stored separately by UUID in IndexedDB
+- **Active layout**: Currently loaded in editor
+- **Preview**: Thumbnail + stats (binCount, layerCount, dimensions)
+
+## Data Flow
+
+```
+createNewLayout() → generates UUID, saves empty layout, adds entry
+switchLayout(id) → saves current, loads target, updates activeLayoutId
+duplicateLayout(id) → copies layout data, new UUID, "(copy)" suffix
+deleteLayout(id) → removes from IndexedDB + library entry
+```
+
+## Storage Keys
+
+- Library index: `gridfinity-library-v1` (localStorage)
+- Individual layouts: `gridfinity-layout-{uuid}` (IndexedDB)
+
+## Gotchas
+
+1. **Can't delete last layout** - minimum 1 required
+2. **Max 100 layouts** - warning at 80
+3. **Preview computed on save** - `computePreview()` generates thumbnail data
+4. **Switching saves current first** - prevents data loss
+
+## Integration
+
+- **storage**: Atomic operations (saveLayoutWithMetadata, switchActiveLayout)
+- **library store**: Entry CRUD, activeLayoutId tracking
+- **layout store**: setActiveLayoutId syncs with library

--- a/src/features/print-export/README.md
+++ b/src/features/print-export/README.md
@@ -1,0 +1,61 @@
+# Print Export
+
+Print list generation with bin splitting and filament estimates.
+
+## Key Files
+
+| File                              | Purpose                                                  |
+| --------------------------------- | -------------------------------------------------------- |
+| `hooks/usePrintList.ts`           | Core hook: generates split print list from layout        |
+| `components/PrintModal.tsx`       | Full-screen print list view                              |
+| `components/PrintListSummary.tsx` | Aggregated stats (total bins, filament, time)            |
+| `utils/split.ts`                  | `splitBinSize()` - recursive bin splitting for print bed |
+| `utils/printEstimates.ts`         | Filament weight, time, cost calculations                 |
+| `utils/printLayout.ts`            | Print bed arrangement visualization                      |
+
+## Core Concepts
+
+- **Print list**: Bins split to fit print bed, grouped by size
+- **Split algorithm**: Recursively halves oversized bins until they fit
+- **Estimates**: PLA density (1.24 g/cm3), configurable cost/gram
+
+## Data Flow
+
+```
+Layout bins → splitBinSize(maxSize) → PrintListRow[]
+  → group by (width, depth, height)
+  → calculate filament per unique size
+  → sum totals for summary
+```
+
+## Split Algorithm
+
+```typescript
+splitBinSize(w, d, h, maxUnits):
+  if (w <= max && d <= max) return [{ w, d, h, count: 1 }]
+  if (w > d) split width in half
+  else split depth in half
+  recurse and combine results
+```
+
+## Print Estimates
+
+| Metric       | Formula                              |
+| ------------ | ------------------------------------ |
+| Filament (g) | shell volume × density + base weight |
+| Time (min)   | proportional to filament weight      |
+| Cost         | filament × $/gram setting            |
+| Spool %      | total filament / spool size          |
+
+## Gotchas
+
+1. **Max print size in mm** - converted from `printBedSize` setting
+2. **Dividers not counted** - estimate may undercount filament
+3. **Staging bins excluded** - only placed bins in print list
+4. **Category grouping optional** - toggle in UI
+
+## Integration
+
+- **settings**: `printBedSize`, `filamentCostPerGram`, `spoolSize`
+- **bin-list modal**: Uses same `usePrintList` data
+- **export**: TSV/CSV/JSON download via `useBinList`

--- a/src/features/staging/README.md
+++ b/src/features/staging/README.md
@@ -1,0 +1,36 @@
+# Staging
+
+Off-grid bin stash (holding area) for bins not placed on the layout grid.
+
+## Key Files
+
+| File                     | Purpose                                         |
+| ------------------------ | ----------------------------------------------- |
+| `components/Staging.tsx` | Stash panel UI with bin thumbnails, drag source |
+
+## Purpose
+
+Bins with `layerId === STAGING_ID` (`'__staging__'`) are stored here:
+
+- Displaced bins (drawer resize clips them)
+- Duplicated bins when no grid space available
+- User-moved bins (drag to stash icon)
+
+## Data Flow
+
+```
+Bin displaced → moveBinToStaging(id) → layerId = STAGING_ID
+Drag from stash → stagingDrag interaction → moveBinFromStaging(id, layerId, x, y)
+```
+
+## Integration
+
+- **grid-editor**: `stagingDrag` interaction mode handles placement
+- **layout store**: `moveBinToStaging()`, `moveBinFromStaging()` mutations
+- **cloud-share**: Staging bins excluded from sync fingerprint
+
+## Gotchas
+
+1. **STAGING_ID is magic string** - `'__staging__'`, not a real layer
+2. **Bins here don't count** toward print list until placed
+3. **Drag preview** uses `stagingDrag` mode in grid-editor


### PR DESCRIPTION
## Summary

- Add AI-optimized README documentation to each of the 12 feature modules
- Optimize CLAUDE.md for token efficiency (73% reduction)

## Feature READMEs Added

| Feature | Lines | Key Documentation |
|---------|-------|-------------------|
| bin-designer | 51 | Parametric 3D generation, WASM pipeline |
| bin-inspector | 47 | Property editing, validation constraints |
| categories | 42 | Color-coding, max 20 limit |
| cloud-share | 57 | Vercel Blob, permission model, auto-sync |
| generation | 64 | BREP geometry engine, 6-stage pipeline |
| grid-editor | 56 | CSS Grid rendering, coordinate system |
| inspiration-gallery | 59 | Template layouts, theme filtering |
| labs | 46 | Feature flags infrastructure |
| layers | 49 | Vertical stacking, Z-axis calculations |
| layout-library | 48 | Multi-layout IndexedDB storage |
| print-export | 61 | Bin splitting algorithm, estimates |
| staging | 35 | Off-grid bin stash |

## CLAUDE.md Optimization

| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| Lines | 507 | 138 | 73% |
| Words | 2,298 | 621 | 73% |
| Est. Tokens | ~3,000 | ~800 | 73% |

Creates hierarchical documentation: CLAUDE.md provides essential patterns (~800 tokens), feature READMEs provide deep context when working within specific features (~200-400 tokens each).

## Test plan

- [x] Lint passes (0 errors)
- [x] Build succeeds
- [x] No code changes, documentation only