### PR TITLE
fix(test): increase test timeout to 10s for CI stability

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
     exclude: ['e2e/**', 'node_modules/**'],
+    // Increase timeout for CI environment (slower than local dev)
+    testTimeout: 10000,
     // Optimized for high-core-count CPUs (Ryzen 9 7950X3D: 16c/32t)
     pool: 'threads', // Worker threads are faster than forks for jsdom tests
     maxWorkers: 32, // Use all available threads


### PR DESCRIPTION
## Summary
- Fix 24 flaky test failures in CI caused by 5-second timeout
- Increase default `testTimeout` from 5000ms to 10000ms

## Problem
Tests were passing locally but timing out in CI due to slower GitHub Actions environment. Affected tests included:
- MobileLayoutsPanel.test.tsx (12 failures)
- LayoutManagerModal.test.tsx
- PrintModal.test.tsx
- And 8 other test files

## Solution
Add `testTimeout: 10000` to vitest.config.ts to give tests more time in CI.

## Test plan
- [x] All 5098 tests pass locally
- [ ] CI should now pass with increased timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)