### PR TITLE
chore(build): increase main bundle size limit to 165KB

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       "name": "Main bundle (gzip)",
       "path": "dist/assets/main-*.js",
       "gzip": true,
-      "limit": "140 kB"
+      "limit": "165 kB"
     },
     {
       "name": "Total JS (gzip)",


### PR DESCRIPTION
## Summary
Increase main bundle size limit from 140KB to 165KB to accommodate the command palette feature (#385).

## Details
- Current size: 163KB gzipped
- New limit: 165KB (2KB headroom)
- The command palette added ~23KB to the main bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)