### PR TITLE
fix(ci): align Node.js version with .nvmrc (v24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: 22
+  NODE_VERSION: 24
 
 jobs:
   # PRs: Just verify the build works (lint/format/tests run via pre-commit hooks)


### PR DESCRIPTION
## Summary
- Update CI Node.js version from 22 to 24 to match `.nvmrc`

This ensures CI uses the same Node version as local development.