### PR TITLE
feat(print-export): consolidate bins with same dimensions and labels in TSV/CSV export

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -119,7 +119,9 @@ export function RightPanel() {
         }`}
       >
         {collapseButton}
-        <h2 className="text-xs font-semibold text-content-tertiary uppercase tracking-wider">{t('rightPanel.inspector')}</h2>
+        <h2 className="text-xs font-semibold text-content-tertiary uppercase tracking-wider">
+          {t('rightPanel.inspector')}
+        </h2>
       </div>
 
       {/* Scrollable content area */}
@@ -131,7 +133,13 @@ export function RightPanel() {
         {/* Selection Panel - Collapsible */}
         <div className="px-4 py-3 border-b border-stroke-subtle">
           <CollapsibleSection
-            title={isMultiSelect ? t('rightPanel.multiSelection') : bin ? t('rightPanel.binProperties') : t('rightPanel.selection')}
+            title={
+              isMultiSelect
+                ? t('rightPanel.multiSelection')
+                : bin
+                  ? t('rightPanel.binProperties')
+                  : t('rightPanel.selection')
+            }
             variant="default"
           >
             {isMultiSelect ? (
@@ -201,7 +209,10 @@ export function RightPanel() {
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
-                    const tsv = exportPrintListTSV(printList.rows);
+                    const tsv = exportPrintListTSV(printList.rows, {
+                      gridUnitMm: layout.gridUnitMm,
+                      categories: layout.categories,
+                    });
                     navigator.clipboard.writeText(tsv);
                     setCopyFeedback(true);
                     trackLayoutSnapshot(useLayoutStore.getState().layout, 'export_tsv');
@@ -250,7 +261,9 @@ export function RightPanel() {
                 <table className="w-full text-sm">
                   <thead className="bg-surface-elevated">
                     <tr>
-                      <th className="pl-4 pr-2 py-2 text-left font-medium sticky top-0 text-content-secondary bg-surface-elevated">{t('common.size')}</th>
+                      <th className="pl-4 pr-2 py-2 text-left font-medium sticky top-0 text-content-secondary bg-surface-elevated">
+                        {t('common.size')}
+                      </th>
                       <th
                         className="px-2 py-2 text-left font-medium sticky top-0 text-content-secondary bg-surface-elevated"
                         title={t('common.height')}
@@ -326,7 +339,9 @@ export function RightPanel() {
                                     })}
                                     {(row.categoryIds ?? []).length > 3 && (
                                       <span className="text-[9px] text-content-disabled">
-                                        {t('rightPanel.moreCategories', { count: (row.categoryIds ?? []).length - 3 })}
+                                        {t('rightPanel.moreCategories', {
+                                          count: (row.categoryIds ?? []).length - 3,
+                                        })}
                                       </span>
                                     )}
                                   </span>
@@ -382,7 +397,9 @@ export function RightPanel() {
                                     {row.customProperties &&
                                       Object.keys(row.customProperties).length > 0 && (
                                         <span
-                                          title={t('rightPanel.customPropertiesCount', { count: Object.keys(row.customProperties).length })}
+                                          title={t('rightPanel.customPropertiesCount', {
+                                            count: Object.keys(row.customProperties).length,
+                                          })}
                                         >
                                           <svg
                                             className="w-3 h-3 flex-shrink-0 text-content-disabled"
@@ -424,7 +441,11 @@ export function RightPanel() {
                                 <div className="flex items-start gap-4">
                                   <SplitPreview width={w} depth={d} pieces={row.pieces} />
                                   <div className="text-xs text-content-secondary">
-                                    <div className="font-medium mb-1">{t('rightPanel.splitInto')}{row.totalPieces}{t('rightPanel.pieces')}</div>
+                                    <div className="font-medium mb-1">
+                                      {t('rightPanel.splitInto')}
+                                      {row.totalPieces}
+                                      {t('rightPanel.pieces')}
+                                    </div>
                                     {row.pieces.map((piece) => (
                                       <div
                                         key={`${piece.width}x${piece.depth}`}

--- a/src/core/storage/ShareService.ts
+++ b/src/core/storage/ShareService.ts
@@ -120,21 +120,29 @@ function escapeTSVValue(value: string): string {
  * Metadata for TSV export including layout context.
  */
 export interface PrintListTSVMeta {
-  layoutName?: string;
-  gridSize?: string;
+  gridUnitMm: number;
+  categories: Array<{ id: string; name: string }>;
+}
+
+/**
+ * Calculate size in mm from grid units.
+ */
+function calculateSizeMm(size: string, gridUnitMm: number): string {
+  const [w, d] = size.split('×').map(Number);
+  return `${Math.round(w * gridUnitMm)}×${Math.round(d * gridUnitMm)}`;
 }
 
 /**
  * Export print list as TSV for spreadsheet paste.
+ * Column order: Qty, Size, Size(mm), Height, Category, Label, Notes, [Custom Props]
  * Dynamically adds columns for custom properties that exist in any row.
- * Optionally includes layout name and grid size columns for context.
  */
 export function exportPrintListTSV(
   rows: Array<{
     size: string;
     height: number;
     binCount: number;
-    totalPieces: number;
+    categoryIds?: string[];
     labels?: string[];
     notes?: string;
     customProperties?: Record<string, string>;
@@ -152,21 +160,23 @@ export function exportPrintListTSV(
   }
   const sortedKeys = Array.from(customKeys).sort();
 
-  // Build header with optional metadata and dynamic custom property columns
-  const metaHeader = meta ? 'Layout\tGrid Size\t' : '';
-  const baseHeader = `${metaHeader}Size\tHeight\tBins\tPieces\tLabel\tNotes`;
+  // Build header with new column order: Qty, Size, Size(mm), Height, Category, Label, Notes
+  const baseHeader = 'Qty\tSize\tSize(mm)\tHeight\tCategory\tLabel\tNotes';
   const header = sortedKeys.length > 0 ? `${baseHeader}\t${sortedKeys.join('\t')}` : baseHeader;
 
-  // Pre-compute metadata values if provided (with TSV escaping)
-  const layoutName = meta ? escapeTSVValue(meta.layoutName || '') : '';
-  const gridSize = meta ? escapeTSVValue(meta.gridSize || '') : '';
+  // Build category lookup map
+  const categoryMap = new Map(meta?.categories.map((c) => [c.id, c.name]) ?? []);
 
   // Build data rows
   const lines = rows.map((r) => {
+    const sizeMm = meta ? calculateSizeMm(r.size, meta.gridUnitMm) : '';
+    const categoryName = r.categoryIds?.[0]
+      ? escapeTSVValue(categoryMap.get(r.categoryIds[0]) || 'Uncategorized')
+      : '';
     const label = escapeTSVValue(r.labels?.[0] || '');
     const notes = escapeTSVValue(r.notes || '');
-    const metaValues = meta ? `${layoutName}\t${gridSize}\t` : '';
-    const baseLine = `${metaValues}${r.size}\t${r.height}u\t${r.binCount}\t${r.totalPieces}\t${label}\t${notes}`;
+
+    const baseLine = `${r.binCount}\t${r.size}\t${sizeMm}\t${r.height}u\t${categoryName}\t${label}\t${notes}`;
 
     if (sortedKeys.length === 0) {
       return baseLine;

--- a/src/features/print-export/utils/split.ts
+++ b/src/features/print-export/utils/split.ts
@@ -129,16 +129,57 @@ function mergePieces(pieces: PrintPiece[]): PrintPiece[] {
 }
 
 /**
- * Check if a bin has custom properties (non-empty object).
+ * Merge unique values from an array, filtering empty strings.
+ * Used for consolidating notes and custom property values.
  */
-function hasCustomProperties(bin: Bin): boolean {
-  return bin.customProperties !== undefined && Object.keys(bin.customProperties).length > 0;
+function mergeUniqueValues(values: string[], separator = '; '): string {
+  const unique = new Set<string>();
+  for (const v of values) {
+    const trimmed = v.trim();
+    if (trimmed) {
+      unique.add(trimmed);
+    }
+  }
+  return Array.from(unique).join(separator);
+}
+
+/**
+ * Merge custom properties from multiple bins.
+ * Values for the same key are concatenated with "; " separator (unique only).
+ */
+function mergeCustomProperties(
+  propsList: Array<Record<string, string> | undefined>
+): Record<string, string> | undefined {
+  const merged = new Map<string, Set<string>>();
+
+  for (const props of propsList) {
+    if (!props) continue;
+    for (const [key, value] of Object.entries(props)) {
+      const trimmed = value.trim();
+      if (!trimmed) continue;
+      const existing = merged.get(key);
+      if (existing) {
+        existing.add(trimmed);
+      } else {
+        merged.set(key, new Set([trimmed]));
+      }
+    }
+  }
+
+  if (merged.size === 0) return undefined;
+
+  const result: Record<string, string> = {};
+  for (const [key, values] of merged) {
+    result[key] = Array.from(values).join('; ');
+  }
+  return result;
 }
 
 /**
  * Generate the print list from bins.
- * Groups bins by size×height, calculates split pieces.
- * Bins with labels or custom properties get their own rows.
+ * Groups bins by size×height×label×category, calculates split pieces.
+ * Bins with the same dimensions AND label AND category are consolidated with quantity counts.
+ * Notes and custom properties are merged (unique values joined with "; ").
  */
 export function generatePrintList(
   bins: Bin[],
@@ -147,7 +188,7 @@ export function generatePrintList(
 ): PrintRow[] {
   const placedBins = bins.filter((b) => b.layerId !== STAGING_ID);
 
-  // Group by size, height, category. Labeled bins and bins with custom properties get their own rows.
+  // Group by size, height, label, and category (consolidate same dimensions + label + category)
   const groups = new Map<
     string,
     {
@@ -157,22 +198,21 @@ export function generatePrintList(
       count: number;
       categoryId: string;
       label: string;
-      notes: string;
+      notesList: string[]; // Collect all notes for merging
       binIds: string[];
-      customProperties?: Record<string, string>;
+      customPropertiesList: Array<Record<string, string> | undefined>; // Collect for merging
     }
   >();
 
   for (const bin of placedBins) {
-    // Labeled bins and bins with custom properties get their own row
-    const isIndividual = bin.label || hasCustomProperties(bin);
-    const key = isIndividual
-      ? `${bin.width}×${bin.depth}×${bin.height}:${bin.category}:${bin.id}` // Unique key
-      : `${bin.width}×${bin.depth}×${bin.height}:${bin.category}`;
+    // Consolidate bins with same size + height + label + category
+    const key = `${bin.width}×${bin.depth}×${bin.height}:${bin.category}:${bin.label || ''}`;
     const existing = groups.get(key);
     if (existing) {
       existing.count++;
       existing.binIds.push(bin.id);
+      existing.notesList.push(bin.notes);
+      existing.customPropertiesList.push(bin.customProperties);
     } else {
       groups.set(key, {
         width: bin.width,
@@ -181,9 +221,9 @@ export function generatePrintList(
         count: 1,
         categoryId: bin.category,
         label: bin.label,
-        notes: bin.notes,
+        notesList: [bin.notes],
         binIds: [bin.id],
-        customProperties: bin.customProperties,
+        customPropertiesList: [bin.customProperties],
       });
     }
   }
@@ -204,6 +244,10 @@ export function generatePrintList(
     );
     const filament = Math.round(filamentPerBin * group.count * 10) / 10; // Round to 1 decimal
 
+    // Merge notes and custom properties from all bins in the group
+    const mergedNotes = mergeUniqueValues(group.notesList);
+    const mergedCustomProps = mergeCustomProperties(group.customPropertiesList);
+
     rows.push({
       size: `${group.width}×${group.depth}`,
       height: group.height,
@@ -214,9 +258,9 @@ export function generatePrintList(
       filament,
       categoryIds: [group.categoryId],
       labels: group.label ? [group.label] : [],
-      notes: group.notes,
+      notes: mergedNotes,
       binIds: group.binIds,
-      customProperties: group.customProperties,
+      customProperties: mergedCustomProps,
     });
   }
 

--- a/src/hooks/useBinList.ts
+++ b/src/hooks/useBinList.ts
@@ -393,17 +393,17 @@ export function useBinList(): UseBinListReturn {
   // Export handlers
   const exportToTSV = useCallback(() => {
     return exportPrintListTSV(filteredRows, {
-      layoutName: layout.name,
-      gridSize: `${layout.drawer.width}×${layout.drawer.depth}`,
+      gridUnitMm: layout.gridUnitMm,
+      categories: layout.categories,
     });
-  }, [filteredRows, layout.name, layout.drawer.width, layout.drawer.depth]);
+  }, [filteredRows, layout.gridUnitMm, layout.categories]);
 
   const exportToCSV = useCallback(() => {
     return formatAsCSV(filteredRows, {
-      layoutName: layout.name,
-      gridSize: `${layout.drawer.width}×${layout.drawer.depth}`,
+      gridUnitMm: layout.gridUnitMm,
+      categories: layout.categories,
     });
-  }, [filteredRows, layout.name, layout.drawer.width, layout.drawer.depth]);
+  }, [filteredRows, layout.gridUnitMm, layout.categories]);
 
   const exportToJSON = useCallback(() => {
     return formatAsJSON(filteredRows, layout);

--- a/src/test/binListOperations.test.ts
+++ b/src/test/binListOperations.test.ts
@@ -230,40 +230,46 @@ describe('binListOperations', () => {
   });
 
   describe('formatAsCSV', () => {
-    it('creates valid CSV with header', () => {
+    // Default meta for tests (required for new column format)
+    const defaultMeta = {
+      gridUnitMm: 42,
+      categories: [{ id: 'cat1', name: 'Tools' }],
+    };
+
+    it('creates valid CSV with new column order', () => {
       const rows = [
         createTestRow({
           size: '3×2',
           height: 4,
           binCount: 2,
-          totalPieces: 2,
-          filament: 5.5,
+          categoryIds: ['cat1'],
           labels: ['Test bin'],
           notes: 'Some notes',
         }),
       ];
-      const csv = formatAsCSV(rows);
+      const csv = formatAsCSV(rows, defaultMeta);
       const lines = csv.split('\n');
 
-      expect(lines[0]).toBe('Size,Height,Bins,Pieces,Filament (m),Label,Notes');
-      expect(lines[1]).toBe('3×2,4u,2,2,5.5,Test bin,Some notes');
+      // New column order: Qty, Size, Size(mm), Height, Category, Label, Notes
+      expect(lines[0]).toBe('Qty,Size,Size(mm),Height,Category,Label,Notes');
+      expect(lines[1]).toBe('2,3×2,126×84,4u,Tools,Test bin,Some notes');
     });
 
     it('escapes commas in values', () => {
       const rows = [createTestRow({ labels: ['Label, with comma'] })];
-      const csv = formatAsCSV(rows);
+      const csv = formatAsCSV(rows, defaultMeta);
       expect(csv).toContain('"Label, with comma"');
     });
 
     it('escapes double quotes in values', () => {
       const rows = [createTestRow({ labels: ['Label with "quotes"'] })];
-      const csv = formatAsCSV(rows);
+      const csv = formatAsCSV(rows, defaultMeta);
       expect(csv).toContain('"Label with ""quotes"""');
     });
 
     it('escapes newlines in values', () => {
       const rows = [createTestRow({ notes: 'Line 1\nLine 2' })];
-      const csv = formatAsCSV(rows);
+      const csv = formatAsCSV(rows, defaultMeta);
       expect(csv).toContain('"Line 1\nLine 2"');
     });
 
@@ -274,7 +280,7 @@ describe('binListOperations', () => {
         createTestRow({ labels: ['-NEGATIVE'] }),
         createTestRow({ labels: ['@INDIRECT'] }),
       ];
-      const csv = formatAsCSV(rows);
+      const csv = formatAsCSV(rows, defaultMeta);
       // Values starting with formula chars should be prefixed with '
       expect(csv).toContain("'=SUM");
       expect(csv).toContain("'+1234567890");
@@ -284,14 +290,15 @@ describe('binListOperations', () => {
 
     it('handles empty labels and notes', () => {
       const rows = [createTestRow({ labels: [], notes: '' })];
-      const csv = formatAsCSV(rows);
+      const csv = formatAsCSV(rows, defaultMeta);
       const lines = csv.split('\n');
-      expect(lines[1]).toBe('2×2,3u,1,1,4.5,,');
+      // Qty,Size,Size(mm),Height,Category,Label,Notes
+      expect(lines[1]).toBe('1,2×2,84×84,3u,Tools,,');
     });
 
     it('handles empty rows array', () => {
-      const csv = formatAsCSV([]);
-      expect(csv).toBe('Size,Height,Bins,Pieces,Filament (m),Label,Notes');
+      const csv = formatAsCSV([], defaultMeta);
+      expect(csv).toBe('Qty,Size,Size(mm),Height,Category,Label,Notes');
     });
 
     it('includes custom property columns when present', () => {
@@ -310,11 +317,11 @@ describe('binListOperations', () => {
           },
         }),
       ];
-      const csv = formatAsCSV(rows);
+      const csv = formatAsCSV(rows, defaultMeta);
       const lines = csv.split('\n');
 
       // Header should include custom property columns (sorted alphabetically)
-      expect(lines[0]).toBe('Size,Height,Bins,Pieces,Filament (m),Label,Notes,Color,Material');
+      expect(lines[0]).toBe('Qty,Size,Size(mm),Height,Category,Label,Notes,Color,Material');
 
       // First row has both properties
       expect(lines[1]).toContain('Red,PETG');
@@ -331,7 +338,7 @@ describe('binListOperations', () => {
           },
         }),
       ];
-      const csv = formatAsCSV(rows);
+      const csv = formatAsCSV(rows, defaultMeta);
       expect(csv).toContain('"Value, with comma"');
     });
 
@@ -346,74 +353,38 @@ describe('binListOperations', () => {
           customProperties: {},
         }),
       ];
-      const csv = formatAsCSV(rows);
+      const csv = formatAsCSV(rows, defaultMeta);
       const lines = csv.split('\n');
 
       // No custom property columns
-      expect(lines[0]).toBe('Size,Height,Bins,Pieces,Filament (m),Label,Notes');
+      expect(lines[0]).toBe('Qty,Size,Size(mm),Height,Category,Label,Notes');
     });
 
-    it('includes layout metadata when provided', () => {
-      const rows = [
-        createTestRow({
-          size: '2×2',
-          height: 3,
-          binCount: 1,
-          totalPieces: 1,
-          filament: 4.5,
-          labels: ['Test'],
-        }),
-      ];
+    it('shows Uncategorized for missing category', () => {
+      const rows = [createTestRow({ categoryIds: ['unknown'] })];
+      const csv = formatAsCSV(rows, defaultMeta);
+      expect(csv).toContain('Uncategorized');
+    });
+
+    it('calculates Size(mm) correctly with different gridUnitMm', () => {
+      const rows = [createTestRow({ size: '2×3' })];
       const csv = formatAsCSV(rows, {
-        layoutName: 'My Drawer',
-        gridSize: '10×8',
+        gridUnitMm: 50,
+        categories: [{ id: 'cat1', name: 'Tools' }],
       });
       const lines = csv.split('\n');
-
-      // Header should have Layout and Grid Size columns first
-      expect(lines[0]).toBe('Layout,Grid Size,Size,Height,Bins,Pieces,Filament (m),Label,Notes');
-      // Data row should include metadata values
-      expect(lines[1]).toContain('My Drawer,10×8,');
+      // 2*50 = 100, 3*50 = 150
+      expect(lines[1]).toContain('100×150');
     });
 
-    it('includes layout metadata with custom properties', () => {
-      const rows = [
-        createTestRow({
-          labels: ['Bin 1'],
-          customProperties: { SKU: 'ABC123' },
-        }),
-      ];
+    it('escapes category names with special characters', () => {
+      const rows = [createTestRow({ categoryIds: ['cat1'] })];
       const csv = formatAsCSV(rows, {
-        layoutName: 'Tool Drawer',
-        gridSize: '12×10',
+        gridUnitMm: 42,
+        categories: [{ id: 'cat1', name: 'Tools, Hardware' }],
       });
-      const lines = csv.split('\n');
-
-      // Header should have metadata first, then base columns, then custom properties
-      expect(lines[0]).toBe(
-        'Layout,Grid Size,Size,Height,Bins,Pieces,Filament (m),Label,Notes,SKU'
-      );
-      expect(lines[1].startsWith('Tool Drawer,12×10,')).toBe(true);
-      expect(lines[1]).toContain('ABC123');
-    });
-
-    it('escapes layout metadata values', () => {
-      const rows = [createTestRow()];
-      const csv = formatAsCSV(rows, {
-        layoutName: 'Drawer, with comma',
-        gridSize: '10×8',
-      });
-      expect(csv).toContain('"Drawer, with comma"');
-    });
-
-    it('omits metadata columns when meta is undefined', () => {
-      const rows = [createTestRow()];
-      const csv = formatAsCSV(rows);
-      const lines = csv.split('\n');
-
-      // Should be the original format without Layout/Grid Size
-      expect(lines[0]).toBe('Size,Height,Bins,Pieces,Filament (m),Label,Notes');
-      expect(lines[1]).not.toContain('Layout');
+      // Category name with comma should be quoted
+      expect(csv).toContain('"Tools, Hardware"');
     });
   });
 

--- a/src/test/hooks/useBinList.test.ts
+++ b/src/test/hooks/useBinList.test.ts
@@ -382,7 +382,7 @@ describe('useBinList', () => {
   });
 
   describe('export functionality', () => {
-    it('exports to TSV format', () => {
+    it('exports to TSV format with new column order', () => {
       const layout = createTestLayout([
         createTestBin({ label: 'Test Bin', width: 2, depth: 2, height: 3 }),
       ]);
@@ -391,11 +391,13 @@ describe('useBinList', () => {
       const { result } = renderHook(() => useBinList());
       const tsv = result.current.exportToTSV();
 
-      expect(tsv).toContain('Size\tHeight\tBins');
+      // New column order: Qty, Size, Size(mm), Height, Category, Label, Notes
+      expect(tsv).toContain('Qty\tSize\tSize(mm)\tHeight\tCategory\tLabel\tNotes');
       expect(tsv).toContain('2×2');
+      expect(tsv).toContain('Test Bin');
     });
 
-    it('exports to CSV format', () => {
+    it('exports to CSV format with new column order', () => {
       const layout = createTestLayout([
         createTestBin({ label: 'Test Bin', width: 2, depth: 2, height: 3 }),
       ]);
@@ -404,8 +406,10 @@ describe('useBinList', () => {
       const { result } = renderHook(() => useBinList());
       const csv = result.current.exportToCSV();
 
-      expect(csv).toContain('Size,Height,Bins');
+      // New column order: Qty, Size, Size(mm), Height, Category, Label, Notes
+      expect(csv).toContain('Qty,Size,Size(mm),Height,Category,Label,Notes');
       expect(csv).toContain('2×2');
+      expect(csv).toContain('Test Bin');
     });
 
     it('exports to JSON format', () => {

--- a/src/test/split.test.ts
+++ b/src/test/split.test.ts
@@ -328,7 +328,7 @@ describe('generatePrintList', () => {
     expect(rows[0].pieces[0].count).toBe(4);
   });
 
-  it('keeps labeled bins separate even with same dimensions', () => {
+  it('keeps labeled bins with DIFFERENT labels separate', () => {
     const bins: Bin[] = [
       {
         id: '1',
@@ -356,10 +356,44 @@ describe('generatePrintList', () => {
       },
     ];
     const rows = generatePrintList(bins, 4);
-    // Each labeled bin gets its own row
+    // Bins with different labels get separate rows
     expect(rows).toHaveLength(2);
     expect(rows[0].labels).toContain('Screws');
     expect(rows[1].labels).toContain('Bolts');
+  });
+
+  it('consolidates labeled bins with SAME label', () => {
+    const bins: Bin[] = [
+      {
+        id: '1',
+        layerId: 'l1',
+        x: 0,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: 'c1',
+        label: 'Screws',
+        notes: '',
+      },
+      {
+        id: '2',
+        layerId: 'l1',
+        x: 2,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: 'c1',
+        label: 'Screws',
+        notes: '',
+      },
+    ];
+    const rows = generatePrintList(bins, 4);
+    // Bins with same dimensions + label + category are consolidated
+    expect(rows).toHaveLength(1);
+    expect(rows[0].binCount).toBe(2);
+    expect(rows[0].labels).toContain('Screws');
   });
 
   it('groups unlabeled bins with same dimensions', () => {
@@ -406,7 +440,7 @@ describe('generatePrintList', () => {
     expect(rows).toHaveLength(2);
   });
 
-  it('keeps bins with custom properties separate even with same dimensions', () => {
+  it('consolidates bins with custom properties (merges values)', () => {
     const bins: Bin[] = [
       {
         id: '1',
@@ -436,10 +470,92 @@ describe('generatePrintList', () => {
       },
     ];
     const rows = generatePrintList(bins, 4);
-    // Each bin with custom properties gets its own row
-    expect(rows).toHaveLength(2);
-    expect(rows.some((r) => r.customProperties?.SKU === 'A1')).toBe(true);
-    expect(rows.some((r) => r.customProperties?.SKU === 'B2')).toBe(true);
+    // Bins are consolidated, custom properties are merged with "; " separator
+    expect(rows).toHaveLength(1);
+    expect(rows[0].binCount).toBe(2);
+    expect(rows[0].customProperties?.SKU).toBe('A1; B2');
+  });
+
+  it('consolidates bins with custom properties - same values are deduplicated', () => {
+    const bins: Bin[] = [
+      {
+        id: '1',
+        layerId: 'l1',
+        x: 0,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: 'c1',
+        label: '',
+        notes: '',
+        customProperties: { Color: 'Red' },
+      },
+      {
+        id: '2',
+        layerId: 'l1',
+        x: 2,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: 'c1',
+        label: '',
+        notes: '',
+        customProperties: { Color: 'Red' },
+      },
+    ];
+    const rows = generatePrintList(bins, 4);
+    // Consolidated - duplicate values are deduplicated
+    expect(rows).toHaveLength(1);
+    expect(rows[0].binCount).toBe(2);
+    expect(rows[0].customProperties?.Color).toBe('Red');
+  });
+
+  it('consolidates notes from multiple bins (unique values joined)', () => {
+    const bins: Bin[] = [
+      {
+        id: '1',
+        layerId: 'l1',
+        x: 0,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: 'c1',
+        label: '',
+        notes: 'Note 1',
+      },
+      {
+        id: '2',
+        layerId: 'l1',
+        x: 2,
+        y: 0,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: 'c1',
+        label: '',
+        notes: 'Note 2',
+      },
+      {
+        id: '3',
+        layerId: 'l1',
+        x: 0,
+        y: 2,
+        width: 2,
+        depth: 2,
+        height: 3,
+        category: 'c1',
+        label: '',
+        notes: 'Note 1', // Duplicate
+      },
+    ];
+    const rows = generatePrintList(bins, 4);
+    // All bins consolidated, notes merged (unique only)
+    expect(rows).toHaveLength(1);
+    expect(rows[0].binCount).toBe(3);
+    expect(rows[0].notes).toBe('Note 1; Note 2');
   });
 
   it('groups bins without custom properties together', () => {
@@ -483,14 +599,11 @@ describe('generatePrintList', () => {
       },
     ];
     const rows = generatePrintList(bins, 4);
-    // Two bins without props grouped, one with props separate
-    expect(rows).toHaveLength(2);
-    const groupedRow = rows.find((r) => r.binCount === 2);
-    const individualRow = rows.find((r) => r.binCount === 1);
-    expect(groupedRow).toBeDefined();
-    expect(groupedRow?.customProperties).toBeUndefined();
-    expect(individualRow).toBeDefined();
-    expect(individualRow?.customProperties?.SKU).toBe('C3');
+    // All 3 bins are consolidated (same dimensions + label + category)
+    expect(rows).toHaveLength(1);
+    expect(rows[0].binCount).toBe(3);
+    // Custom property from the one bin that has it
+    expect(rows[0].customProperties?.SKU).toBe('C3');
   });
 
   it('treats empty customProperties object as no custom properties', () => {

--- a/src/test/storage.test.ts
+++ b/src/test/storage.test.ts
@@ -349,42 +349,49 @@ describe('storage', () => {
   });
 
   describe('exportPrintListTSV', () => {
+    // Default meta for tests (required for new column format)
+    const defaultMeta = {
+      gridUnitMm: 42,
+      categories: [{ id: 'cat1', name: 'Tools' }],
+    };
+
     it('exports empty list with header only', () => {
-      const tsv = exportPrintListTSV([]);
-      expect(tsv).toBe('Size\tHeight\tBins\tPieces\tLabel\tNotes');
+      const tsv = exportPrintListTSV([], defaultMeta);
+      expect(tsv).toBe('Qty\tSize\tSize(mm)\tHeight\tCategory\tLabel\tNotes');
     });
 
     it('exports single row correctly', () => {
-      const rows = [{ size: '1x1', height: 3, binCount: 5, totalPieces: 5 }];
-      const tsv = exportPrintListTSV(rows);
+      const rows = [{ size: '1×1', height: 3, binCount: 5, categoryIds: ['cat1'] }];
+      const tsv = exportPrintListTSV(rows, defaultMeta);
       const lines = tsv.split('\n');
       expect(lines).toHaveLength(2);
-      expect(lines[1]).toBe('1x1\t3u\t5\t5\t\t');
+      // Qty, Size, Size(mm), Height, Category, Label, Notes
+      expect(lines[1]).toBe('5\t1×1\t42×42\t3u\tTools\t\t');
     });
 
     it('exports row with labels and notes', () => {
       const rows = [
         {
-          size: '2x3',
+          size: '2×3',
           height: 6,
           binCount: 2,
-          totalPieces: 4,
+          categoryIds: ['cat1'],
           labels: ['Screws', 'Nails'],
           notes: 'Small parts',
         },
       ];
-      const tsv = exportPrintListTSV(rows);
+      const tsv = exportPrintListTSV(rows, defaultMeta);
       const lines = tsv.split('\n');
-      expect(lines[1]).toBe('2x3\t6u\t2\t4\tScrews\tSmall parts');
+      expect(lines[1]).toBe('2\t2×3\t84×126\t6u\tTools\tScrews\tSmall parts');
     });
 
     it('exports multiple rows', () => {
       const rows = [
-        { size: '1x1', height: 3, binCount: 10, totalPieces: 10 },
-        { size: '2x2', height: 6, binCount: 4, totalPieces: 4 },
-        { size: '3x1', height: 3, binCount: 2, totalPieces: 6 },
+        { size: '1×1', height: 3, binCount: 10, categoryIds: ['cat1'] },
+        { size: '2×2', height: 6, binCount: 4, categoryIds: ['cat1'] },
+        { size: '3×1', height: 3, binCount: 2, categoryIds: ['cat1'] },
       ];
-      const tsv = exportPrintListTSV(rows);
+      const tsv = exportPrintListTSV(rows, defaultMeta);
       const lines = tsv.split('\n');
       expect(lines).toHaveLength(4);
     });
@@ -392,116 +399,90 @@ describe('storage', () => {
     it('exports rows with custom properties as additional columns', () => {
       const rows = [
         {
-          size: '1x1',
+          size: '1×1',
           height: 3,
           binCount: 1,
-          totalPieces: 1,
+          categoryIds: ['cat1'],
           customProperties: { SKU: 'ABC123', Location: 'A1' },
         },
         {
-          size: '2x2',
+          size: '2×2',
           height: 6,
           binCount: 1,
-          totalPieces: 1,
+          categoryIds: ['cat1'],
           customProperties: { SKU: 'XYZ789' }, // Missing Location
         },
       ];
-      const tsv = exportPrintListTSV(rows);
+      const tsv = exportPrintListTSV(rows, defaultMeta);
       const lines = tsv.split('\n');
       expect(lines).toHaveLength(3);
       // Header should have custom property columns (sorted alphabetically)
-      expect(lines[0]).toBe('Size\tHeight\tBins\tPieces\tLabel\tNotes\tLocation\tSKU');
+      expect(lines[0]).toBe('Qty\tSize\tSize(mm)\tHeight\tCategory\tLabel\tNotes\tLocation\tSKU');
       // Row with both properties
-      expect(lines[1]).toBe('1x1\t3u\t1\t1\t\t\tA1\tABC123');
+      expect(lines[1]).toBe('1\t1×1\t42×42\t3u\tTools\t\t\tA1\tABC123');
       // Row missing Location should have empty value
-      expect(lines[2]).toBe('2x2\t6u\t1\t1\t\t\t\tXYZ789');
+      expect(lines[2]).toBe('1\t2×2\t84×84\t6u\tTools\t\t\t\tXYZ789');
     });
 
     it('does not add custom property columns when none present', () => {
       const rows = [
-        { size: '1x1', height: 3, binCount: 5, totalPieces: 5 },
-        { size: '2x2', height: 6, binCount: 4, totalPieces: 4 },
+        { size: '1×1', height: 3, binCount: 5, categoryIds: ['cat1'] },
+        { size: '2×2', height: 6, binCount: 4, categoryIds: ['cat1'] },
       ];
-      const tsv = exportPrintListTSV(rows);
+      const tsv = exportPrintListTSV(rows, defaultMeta);
       const lines = tsv.split('\n');
       // Header should not have extra columns
-      expect(lines[0]).toBe('Size\tHeight\tBins\tPieces\tLabel\tNotes');
+      expect(lines[0]).toBe('Qty\tSize\tSize(mm)\tHeight\tCategory\tLabel\tNotes');
     });
 
-    it('exports with layout metadata when provided', () => {
-      const rows = [{ size: '1x1', height: 3, binCount: 5, totalPieces: 5 }];
+    it('shows Uncategorized for missing category', () => {
+      const rows = [{ size: '1×1', height: 3, binCount: 5, categoryIds: ['unknown'] }];
+      const tsv = exportPrintListTSV(rows, defaultMeta);
+      const lines = tsv.split('\n');
+      expect(lines[1]).toContain('Uncategorized');
+    });
+
+    it('calculates Size(mm) correctly with different gridUnitMm', () => {
+      const rows = [{ size: '2×3', height: 3, binCount: 1, categoryIds: ['cat1'] }];
       const tsv = exportPrintListTSV(rows, {
-        layoutName: 'My Drawer',
-        gridSize: '10×8',
+        gridUnitMm: 50,
+        categories: [{ id: 'cat1', name: 'Tools' }],
       });
       const lines = tsv.split('\n');
-      expect(lines).toHaveLength(2);
-      // Header should have Layout and Grid Size columns first
-      expect(lines[0]).toBe('Layout\tGrid Size\tSize\tHeight\tBins\tPieces\tLabel\tNotes');
-      // Data row should include metadata values
-      expect(lines[1]).toBe('My Drawer\t10×8\t1x1\t3u\t5\t5\t\t');
+      // 2*50 = 100, 3*50 = 150
+      expect(lines[1]).toContain('100×150');
     });
 
-    it('exports with layout metadata and custom properties', () => {
-      const rows = [
-        {
-          size: '2x2',
-          height: 6,
-          binCount: 1,
-          totalPieces: 1,
-          labels: ['Screws'],
-          customProperties: { SKU: 'ABC123' },
-        },
-      ];
+    it('escapes tabs and newlines in category name', () => {
+      const rows = [{ size: '1×1', height: 3, binCount: 1, categoryIds: ['cat1'] }];
       const tsv = exportPrintListTSV(rows, {
-        layoutName: 'Tool Drawer',
-        gridSize: '12×10',
-      });
-      const lines = tsv.split('\n');
-      // Header should have metadata first, then base columns, then custom properties
-      expect(lines[0]).toBe('Layout\tGrid Size\tSize\tHeight\tBins\tPieces\tLabel\tNotes\tSKU');
-      expect(lines[1]).toBe('Tool Drawer\t12×10\t2x2\t6u\t1\t1\tScrews\t\tABC123');
-    });
-
-    it('exports without metadata columns when meta is undefined', () => {
-      const rows = [{ size: '1x1', height: 3, binCount: 1, totalPieces: 1 }];
-      const tsv = exportPrintListTSV(rows);
-      const lines = tsv.split('\n');
-      // Should be the original format without Layout/Grid Size
-      expect(lines[0]).toBe('Size\tHeight\tBins\tPieces\tLabel\tNotes');
-      expect(lines[1]).toBe('1x1\t3u\t1\t1\t\t');
-    });
-
-    it('escapes tabs and newlines in metadata values', () => {
-      const rows = [{ size: '1x1', height: 3, binCount: 1, totalPieces: 1 }];
-      const tsv = exportPrintListTSV(rows, {
-        layoutName: 'Drawer\twith\ttabs',
-        gridSize: '10×8',
+        gridUnitMm: 42,
+        categories: [{ id: 'cat1', name: 'Tools\twith\ttabs' }],
       });
       const lines = tsv.split('\n');
       // Tabs should be replaced with spaces
-      expect(lines[1]).toContain('Drawer with tabs');
-      // Should still have correct number of columns (no extra tabs)
-      expect(lines[1].split('\t')).toHaveLength(8);
+      expect(lines[1]).toContain('Tools with tabs');
+      // Should still have correct number of columns (7 base columns)
+      expect(lines[1].split('\t')).toHaveLength(7);
     });
 
     it('escapes tabs and newlines in label and notes', () => {
       const rows = [
         {
-          size: '1x1',
+          size: '1×1',
           height: 3,
           binCount: 1,
-          totalPieces: 1,
+          categoryIds: ['cat1'],
           labels: ['Label\twith\ttab'],
           notes: 'Notes\nwith\nnewlines',
         },
       ];
-      const tsv = exportPrintListTSV(rows);
+      const tsv = exportPrintListTSV(rows, defaultMeta);
       const lines = tsv.split('\n');
       expect(lines[1]).toContain('Label with tab');
       expect(lines[1]).toContain('Notes with newlines');
-      // Should still have correct number of columns
-      expect(lines[1].split('\t')).toHaveLength(6);
+      // Should still have correct number of columns (7 base columns)
+      expect(lines[1].split('\t')).toHaveLength(7);
     });
   });
 

--- a/src/utils/binListOperations.ts
+++ b/src/utils/binListOperations.ts
@@ -141,15 +141,23 @@ function escapeCSVValue(value: string): string {
  * Metadata for CSV export including layout context.
  */
 export interface CSVExportMeta {
-  layoutName?: string;
-  gridSize?: string;
+  gridUnitMm: number;
+  categories: Array<{ id: string; name: string }>;
+}
+
+/**
+ * Calculate size in mm from grid units.
+ */
+function calculateSizeMm(size: string, gridUnitMm: number): string {
+  const [w, d] = size.split('×').map(Number);
+  return `${Math.round(w * gridUnitMm)}×${Math.round(d * gridUnitMm)}`;
 }
 
 /**
  * Format rows as CSV with proper escaping.
+ * Column order: Qty, Size, Size(mm), Height, Category, Label, Notes, [Custom Props]
  * Compatible with Excel, Google Sheets, etc.
  * Dynamically adds columns for custom properties that exist in any row.
- * Optionally includes layout name and grid size columns for context.
  */
 export function formatAsCSV(rows: EnhancedPrintRow[], meta?: CSVExportMeta): string {
   // Collect all unique custom property keys across all rows
@@ -163,21 +171,23 @@ export function formatAsCSV(rows: EnhancedPrintRow[], meta?: CSVExportMeta): str
   }
   const sortedKeys = Array.from(customKeys).sort();
 
-  // Build header with optional metadata and dynamic custom property columns
-  const metaHeader = meta ? 'Layout,Grid Size,' : '';
-  const baseHeader = `${metaHeader}Size,Height,Bins,Pieces,Filament (m),Label,Notes`;
+  // Build header with new column order: Qty, Size, Size(mm), Height, Category, Label, Notes
+  const baseHeader = 'Qty,Size,Size(mm),Height,Category,Label,Notes';
   const header = sortedKeys.length > 0 ? `${baseHeader},${sortedKeys.join(',')}` : baseHeader;
 
-  // Pre-compute metadata values if provided (with CSV escaping)
-  const layoutName = meta ? escapeCSVValue(meta.layoutName || '') : '';
-  const gridSize = meta ? escapeCSVValue(meta.gridSize || '') : '';
+  // Build category lookup map
+  const categoryMap = new Map(meta?.categories.map((c) => [c.id, c.name]) ?? []);
 
   // Build data rows
   const lines = rows.map((row) => {
+    const sizeMm = meta ? calculateSizeMm(row.size, meta.gridUnitMm) : '';
+    const categoryName = row.categoryIds?.[0]
+      ? escapeCSVValue(categoryMap.get(row.categoryIds[0]) || 'Uncategorized')
+      : '';
     const label = escapeCSVValue((row.labels ?? [])[0] || '');
     const notes = escapeCSVValue(row.notes || '');
-    const metaValues = meta ? `${layoutName},${gridSize},` : '';
-    const baseLine = `${metaValues}${row.size},${row.height}u,${row.binCount},${row.totalPieces},${row.filament},${label},${notes}`;
+
+    const baseLine = `${row.binCount},${row.size},${sizeMm},${row.height}u,${categoryName},${label},${notes}`;
 
     if (sortedKeys.length === 0) {
       return baseLine;


### PR DESCRIPTION
## Summary

- **Consolidate bins**: Bins with the same size, height, label, and category are now consolidated with quantity counts (previously, labeled bins got individual rows)
- **Merge notes**: Notes from consolidated bins are merged (unique values joined with "; ")
- **Merge custom properties**: Custom properties are merged per-key (unique values joined with "; ")
- **New column order**: `Qty | Size | Size(mm) | Height | Category | Label | Notes | [Custom Props]`
- **Removed columns**: Pieces and Filament columns removed for cleaner output
- **Consistent format**: Same format used for both sidebar quick-copy and modal export

### Example Output

```
Qty	Size	Size(mm)	Height	Category	Label	Notes
3	2×2	84×84	3u	Tools	Screwdrivers	Phillips; Flathead
2	1×1	42×42	2u	Hardware	Nuts	M3; M4
```

## Test plan

- [x] All 5142 tests pass
- [x] Build succeeds
- [x] i18n check passes
- [ ] Manual test: Copy TSV from sidebar and paste into spreadsheet
- [ ] Manual test: Export TSV from print modal and paste into spreadsheet
- [ ] Verify bins with same dimensions + label are consolidated
- [ ] Verify notes are merged correctly when consolidating
- [ ] Verify custom properties are merged correctly when consolidating

🤖 Generated with [Claude Code](https://claude.com/claude-code)