### PR TITLE
feat: add Privacy Policy and Terms of Service pages

### DIFF
--- a/content/privacy.md
+++ b/content/privacy.md
@@ -1,0 +1,95 @@
+---
+title: Privacy Policy
+description: Privacy Policy for Gridfinity Layout Tool. Learn how we collect, use, and protect your data.
+keywords: privacy policy, data collection, analytics, gridfinity layout tool
+schema: Article
+---
+
+# Privacy Policy
+
+**Last updated:** January 2025
+
+Gridfinity Layout Tool is a free, open-source web application maintained by Andy Aragon. This policy explains what data we collect and how we use it.
+
+## Summary
+
+- We collect **anonymous analytics** to improve the app (you can opt out)
+- Layouts you create are stored **locally in your browser** unless you choose to share them
+- When you share a layout, it's stored on our servers with a shareable link
+- We don't sell your data or use it for advertising
+
+## Data We Collect
+
+### Analytics (Optional)
+
+We use [PostHog](https://posthog.com) to understand how people use the app. This helps us prioritize features and fix bugs. Analytics data includes:
+
+- Pages visited and features used
+- Device type (mobile/tablet/desktop)
+- Anonymous usage patterns (drawer sizes, bin counts)
+- Errors and performance metrics
+
+**Analytics is optional.** You can disable it in Settings > Privacy > "Help improve this tool."
+
+When analytics is disabled, no data is sent to PostHog.
+
+### Layout Data
+
+**Local storage:** Your layouts are stored in your browser's localStorage. This data never leaves your device unless you explicitly share a layout.
+
+**Shared layouts:** When you create a shareable link, your layout data is uploaded to [Vercel Blob Storage](https://vercel.com/docs/storage/vercel-blob). Shared layouts include:
+
+- Your drawer configuration (dimensions, grid settings)
+- Bin positions, sizes, labels, and notes
+- Categories and colors you've created
+
+Shared layouts are accessible to anyone with the link. You can delete a shared layout at any time.
+
+### Real-time Collaboration
+
+When you use the collaboration feature, your presence data (cursor position, anonymous display name) is shared with other participants via [Liveblocks](https://liveblocks.io). This data is only transmitted while you're actively collaborating and is not stored permanently.
+
+## Data We Don't Collect
+
+- Personal information (name, email, address)
+- Payment information
+- Precise location
+- Cookies for advertising or tracking across sites
+
+## Third-Party Services
+
+| Service    | Purpose                 | Privacy Policy                                                             |
+| ---------- | ----------------------- | -------------------------------------------------------------------------- |
+| PostHog    | Analytics               | [posthog.com/privacy](https://posthog.com/privacy)                         |
+| Vercel     | Hosting & storage       | [vercel.com/legal/privacy-policy](https://vercel.com/legal/privacy-policy) |
+| Liveblocks | Real-time collaboration | [liveblocks.io/privacy](https://liveblocks.io/privacy)                     |
+
+## Your Rights
+
+You can:
+
+- **Opt out of analytics** in Settings > Privacy
+- **Delete your shared layouts** using the share modal
+- **Clear all local data** by clearing your browser's site data for this domain
+
+## Data Retention
+
+- **Local data:** Stored indefinitely until you clear it
+- **Shared layouts:** Stored until you delete them (or we may remove inactive shares after 12 months)
+- **Analytics:** Retained by PostHog per their data retention policy
+
+## Children's Privacy
+
+This app is not directed at children under 13. We don't knowingly collect data from children.
+
+## Changes to This Policy
+
+We may update this policy occasionally. Significant changes will be noted in the app's changelog.
+
+## Contact
+
+Questions or concerns? Open an issue on our [GitHub repository](https://github.com/andymai/gridfinity-layout-tool/issues).
+
+---
+
+[CTA: Back to the app](/)

--- a/content/terms.md
+++ b/content/terms.md
@@ -1,0 +1,87 @@
+---
+title: Terms of Service
+description: Terms of Service for Gridfinity Layout Tool. Understand your rights and responsibilities when using this app.
+keywords: terms of service, terms and conditions, gridfinity layout tool, user agreement
+schema: Article
+---
+
+# Terms of Service
+
+**Last updated:** January 2025
+
+By using Gridfinity Layout Tool, you agree to these terms.
+
+## What This App Is
+
+Gridfinity Layout Tool is a free, open-source web application for planning storage layouts for 3D-printed Gridfinity drawer organizers. The source code is available under the [AGPL-3.0 license](https://github.com/andymai/gridfinity-layout-tool/blob/main/LICENSE).
+
+## Your Layouts
+
+**You own your content.** Layouts you create belong to you. We don't claim ownership of your drawer designs, bin configurations, labels, or notes.
+
+**Local storage.** Your layouts are stored in your browser by default. We don't have access to them unless you share.
+
+**Shared layouts.** When you share a layout, it becomes accessible via a public link. Anyone with the link can view it. You're responsible for not sharing content that:
+
+- Infringes on others' intellectual property
+- Contains offensive, illegal, or harmful content
+- Impersonates others or misrepresents your identity
+
+We reserve the right to remove shared content that violates these terms.
+
+## Open Source License
+
+This app is licensed under the [GNU Affero General Public License v3.0](https://www.gnu.org/licenses/agpl-3.0.html) (AGPL-3.0).
+
+**What this means for you:**
+
+- You can use the app freely
+- You can view, modify, and distribute the source code
+- If you run a modified version as a web service, you must make your source code available
+
+**Commercial use:** If you want to use this code in a proprietary product without open-sourcing your changes, contact us about a commercial license.
+
+## No Warranty
+
+This app is provided **"as is"** without warranty of any kind. We don't guarantee:
+
+- The app will be available 24/7
+- Layouts will be preserved indefinitely
+- The app is free of bugs or errors
+- Print estimates are accurate for your specific printer
+
+**Back up important work.** Export your layouts regularly. Don't rely solely on browser storage or cloud sharing for critical data.
+
+## Limitation of Liability
+
+To the maximum extent permitted by law, we are not liable for:
+
+- Lost data or layouts
+- Wasted filament from inaccurate print estimates
+- Any damages arising from use of the app
+- Issues with 3D printed items designed using this tool
+
+## Acceptable Use
+
+Don't use this app to:
+
+- Attempt to breach security or access others' data
+- Overload our servers with automated requests
+- Scrape or harvest data from shared layouts
+- Violate any applicable laws
+
+## Changes to Terms
+
+We may update these terms occasionally. Continued use of the app after changes constitutes acceptance of the new terms.
+
+## Governing Law
+
+These terms are governed by the laws of the United States.
+
+## Contact
+
+Questions? Open an issue on our [GitHub repository](https://github.com/andymai/gridfinity-layout-tool/issues).
+
+---
+
+[CTA: Back to the app](/)

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy | Gridfinity Layout Tool</title>
+
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Privacy Policy for Gridfinity Layout Tool. Learn how we collect, use, and protect your data.">
+  <meta name="keywords" content="privacy policy, data collection, analytics, gridfinity layout tool">
+  <meta name="author" content="Andy Aragon">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://gridfinitylayouttool.com/privacy">
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://gridfinitylayouttool.com/privacy">
+  <meta property="og:title" content="Privacy Policy | Gridfinity Layout Tool">
+  <meta property="og:description" content="Privacy Policy for Gridfinity Layout Tool. Learn how we collect, use, and protect your data.">
+  <meta property="og:image" content="https://gridfinitylayouttool.com/og-image.png">
+  <meta property="og:site_name" content="Gridfinity Layout Tool">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://gridfinitylayouttool.com/privacy">
+  <meta name="twitter:title" content="Privacy Policy | Gridfinity Layout Tool">
+  <meta name="twitter:description" content="Privacy Policy for Gridfinity Layout Tool. Learn how we collect, use, and protect your data.">
+  <meta name="twitter:image" content="https://gridfinitylayouttool.com/og-image.png">
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Privacy Policy",
+  "description": "Privacy Policy for Gridfinity Layout Tool. Learn how we collect, use, and protect your data.",
+  "image": "https://gridfinitylayouttool.com/og-image.png",
+  "url": "https://gridfinitylayouttool.com/privacy",
+  "author": {
+    "@type": "Person",
+    "name": "Andy Aragon"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Gridfinity Layout Tool",
+    "url": "https://gridfinitylayouttool.com"
+  }
+}
+  </script>
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
+
+  <!-- Styles -->
+  <link rel="stylesheet" href="/content.9609870d.css">
+
+  <!-- Favicon -->
+  <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">
+  <link rel="icon" type="image/png" sizes="48x48" href="/icons/favicon-48.png">
+
+  <!-- Mobile -->
+  <meta name="theme-color" content="#0f0f12">
+</head>
+<body>
+  <!-- Skip to content link for accessibility -->
+  <a href="#main-content" class="skip-link">Skip to content</a>
+
+  <!-- Navigation -->
+  <nav class="content-nav" aria-label="Main navigation">
+    <a href="/" class="content-nav__logo">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <rect x="3" y="3" width="7" height="7" rx="1"/>
+        <rect x="14" y="3" width="7" height="7" rx="1"/>
+        <rect x="3" y="14" width="7" height="7" rx="1"/>
+        <rect x="14" y="14" width="7" height="7" rx="1"/>
+      </svg>
+      <span>Gridfinity Layout Tool</span>
+    </a>
+    <a href="/" class="content-nav__cta">
+      Open Tool
+    </a>
+  </nav>
+
+  <!-- Main Content -->
+  <main id="main-content" class="content-page content-body">
+<h1 class="content-h1">Privacy Policy</h1>
+<p><strong>Last updated:</strong> January 2025</p>
+<p>Gridfinity Layout Tool is a free, open-source web application maintained by Andy Aragon. This policy explains what data we collect and how we use it.</p>
+<h2 class="content-h2">Summary</h2>
+<ul class="content-list"><li>We collect <strong>anonymous analytics</strong> to improve the app (you can opt out)</li>
+<li>Layouts you create are stored <strong>locally in your browser</strong> unless you choose to share them</li>
+<li>When you share a layout, it&#39;s stored on our servers with a shareable link</li>
+<li>We don&#39;t sell your data or use it for advertising</li>
+</ul>
+<h2 class="content-h2">Data We Collect</h2>
+<h3 class="content-h3">Analytics (Optional)</h3>
+<p>We use <a href="https://posthog.com" target="_blank" rel="noopener">PostHog</a> to understand how people use the app. This helps us prioritize features and fix bugs. Analytics data includes:</p>
+<ul class="content-list"><li>Pages visited and features used</li>
+<li>Device type (mobile/tablet/desktop)</li>
+<li>Anonymous usage patterns (drawer sizes, bin counts)</li>
+<li>Errors and performance metrics</li>
+</ul>
+<p><strong>Analytics is optional.</strong> You can disable it in Settings &gt; Privacy &gt; &quot;Help improve this tool.&quot;</p>
+<p>When analytics is disabled, no data is sent to PostHog.</p>
+<h3 class="content-h3">Layout Data</h3>
+<p><strong>Local storage:</strong> Your layouts are stored in your browser&#39;s localStorage. This data never leaves your device unless you explicitly share a layout.</p>
+<p><strong>Shared layouts:</strong> When you create a shareable link, your layout data is uploaded to <a href="https://vercel.com/docs/storage/vercel-blob" target="_blank" rel="noopener">Vercel Blob Storage</a>. Shared layouts include:</p>
+<ul class="content-list"><li>Your drawer configuration (dimensions, grid settings)</li>
+<li>Bin positions, sizes, labels, and notes</li>
+<li>Categories and colors you&#39;ve created</li>
+</ul>
+<p>Shared layouts are accessible to anyone with the link. You can delete a shared layout at any time.</p>
+<h3 class="content-h3">Real-time Collaboration</h3>
+<p>When you use the collaboration feature, your presence data (cursor position, anonymous display name) is shared with other participants via <a href="https://liveblocks.io" target="_blank" rel="noopener">Liveblocks</a>. This data is only transmitted while you&#39;re actively collaborating and is not stored permanently.</p>
+<h2 class="content-h2">Data We Don&#39;t Collect</h2>
+<ul class="content-list"><li>Personal information (name, email, address)</li>
+<li>Payment information</li>
+<li>Precise location</li>
+<li>Cookies for advertising or tracking across sites</li>
+</ul>
+<h2 class="content-h2">Third-Party Services</h2>
+<table>
+<thead>
+<tr>
+<th>Service</th>
+<th>Purpose</th>
+<th>Privacy Policy</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>PostHog</td>
+<td>Analytics</td>
+<td><a href="https://posthog.com/privacy" target="_blank" rel="noopener">posthog.com/privacy</a></td>
+</tr>
+<tr>
+<td>Vercel</td>
+<td>Hosting &amp; storage</td>
+<td><a href="https://vercel.com/legal/privacy-policy" target="_blank" rel="noopener">vercel.com/legal/privacy-policy</a></td>
+</tr>
+<tr>
+<td>Liveblocks</td>
+<td>Real-time collaboration</td>
+<td><a href="https://liveblocks.io/privacy" target="_blank" rel="noopener">liveblocks.io/privacy</a></td>
+</tr>
+</tbody></table>
+<h2 class="content-h2">Your Rights</h2>
+<p>You can:</p>
+<ul class="content-list"><li><strong>Opt out of analytics</strong> in Settings &gt; Privacy</li>
+<li><strong>Delete your shared layouts</strong> using the share modal</li>
+<li><strong>Clear all local data</strong> by clearing your browser&#39;s site data for this domain</li>
+</ul>
+<h2 class="content-h2">Data Retention</h2>
+<ul class="content-list"><li><strong>Local data:</strong> Stored indefinitely until you clear it</li>
+<li><strong>Shared layouts:</strong> Stored until you delete them (or we may remove inactive shares after 12 months)</li>
+<li><strong>Analytics:</strong> Retained by PostHog per their data retention policy</li>
+</ul>
+<h2 class="content-h2">Children&#39;s Privacy</h2>
+<p>This app is not directed at children under 13. We don&#39;t knowingly collect data from children.</p>
+<h2 class="content-h2">Changes to This Policy</h2>
+<p>We may update this policy occasionally. Significant changes will be noted in the app&#39;s changelog.</p>
+<h2 class="content-h2">Contact</h2>
+<p>Questions or concerns? Open an issue on our <a href="https://github.com/andymai/gridfinity-layout-tool/issues" target="_blank" rel="noopener">GitHub repository</a>.</p>
+<hr>
+<p><a href="/" class="content-cta">Back to the app &rarr;</a></p>
+
+  </main>
+
+  <!-- Footer -->
+  <footer class="content-page">
+    <div class="content-footer">
+      <div class="content-footer__links">
+        <a href="/what-is-gridfinity">What is Gridfinity?</a>
+        <a href="/guide">Planning Guide</a>
+        <a href="/privacy">Privacy</a>
+        <a href="/terms">Terms</a>
+      </div>
+      <p class="content-footer__copyright">
+        © 2026 Gridfinity Layout Tool. Free to use.
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/public/terms/index.html
+++ b/public/terms/index.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Service | Gridfinity Layout Tool</title>
+
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Terms of Service for Gridfinity Layout Tool. Understand your rights and responsibilities when using this app.">
+  <meta name="keywords" content="terms of service, terms and conditions, gridfinity layout tool, user agreement">
+  <meta name="author" content="Andy Aragon">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://gridfinitylayouttool.com/terms">
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://gridfinitylayouttool.com/terms">
+  <meta property="og:title" content="Terms of Service | Gridfinity Layout Tool">
+  <meta property="og:description" content="Terms of Service for Gridfinity Layout Tool. Understand your rights and responsibilities when using this app.">
+  <meta property="og:image" content="https://gridfinitylayouttool.com/og-image.png">
+  <meta property="og:site_name" content="Gridfinity Layout Tool">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://gridfinitylayouttool.com/terms">
+  <meta name="twitter:title" content="Terms of Service | Gridfinity Layout Tool">
+  <meta name="twitter:description" content="Terms of Service for Gridfinity Layout Tool. Understand your rights and responsibilities when using this app.">
+  <meta name="twitter:image" content="https://gridfinitylayouttool.com/og-image.png">
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Terms of Service",
+  "description": "Terms of Service for Gridfinity Layout Tool. Understand your rights and responsibilities when using this app.",
+  "image": "https://gridfinitylayouttool.com/og-image.png",
+  "url": "https://gridfinitylayouttool.com/terms",
+  "author": {
+    "@type": "Person",
+    "name": "Andy Aragon"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Gridfinity Layout Tool",
+    "url": "https://gridfinitylayouttool.com"
+  }
+}
+  </script>
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
+
+  <!-- Styles -->
+  <link rel="stylesheet" href="/content.9609870d.css">
+
+  <!-- Favicon -->
+  <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">
+  <link rel="icon" type="image/png" sizes="48x48" href="/icons/favicon-48.png">
+
+  <!-- Mobile -->
+  <meta name="theme-color" content="#0f0f12">
+</head>
+<body>
+  <!-- Skip to content link for accessibility -->
+  <a href="#main-content" class="skip-link">Skip to content</a>
+
+  <!-- Navigation -->
+  <nav class="content-nav" aria-label="Main navigation">
+    <a href="/" class="content-nav__logo">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <rect x="3" y="3" width="7" height="7" rx="1"/>
+        <rect x="14" y="3" width="7" height="7" rx="1"/>
+        <rect x="3" y="14" width="7" height="7" rx="1"/>
+        <rect x="14" y="14" width="7" height="7" rx="1"/>
+      </svg>
+      <span>Gridfinity Layout Tool</span>
+    </a>
+    <a href="/" class="content-nav__cta">
+      Open Tool
+    </a>
+  </nav>
+
+  <!-- Main Content -->
+  <main id="main-content" class="content-page content-body">
+<h1 class="content-h1">Terms of Service</h1>
+<p><strong>Last updated:</strong> January 2025</p>
+<p>By using Gridfinity Layout Tool, you agree to these terms.</p>
+<h2 class="content-h2">What This App Is</h2>
+<p>Gridfinity Layout Tool is a free, open-source web application for planning storage layouts for 3D-printed Gridfinity drawer organizers. The source code is available under the <a href="https://github.com/andymai/gridfinity-layout-tool/blob/main/LICENSE" target="_blank" rel="noopener">AGPL-3.0 license</a>.</p>
+<h2 class="content-h2">Your Layouts</h2>
+<p><strong>You own your content.</strong> Layouts you create belong to you. We don&#39;t claim ownership of your drawer designs, bin configurations, labels, or notes.</p>
+<p><strong>Local storage.</strong> Your layouts are stored in your browser by default. We don&#39;t have access to them unless you share.</p>
+<p><strong>Shared layouts.</strong> When you share a layout, it becomes accessible via a public link. Anyone with the link can view it. You&#39;re responsible for not sharing content that:</p>
+<ul class="content-list"><li>Infringes on others&#39; intellectual property</li>
+<li>Contains offensive, illegal, or harmful content</li>
+<li>Impersonates others or misrepresents your identity</li>
+</ul>
+<p>We reserve the right to remove shared content that violates these terms.</p>
+<h2 class="content-h2">Open Source License</h2>
+<p>This app is licensed under the <a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank" rel="noopener">GNU Affero General Public License v3.0</a> (AGPL-3.0).</p>
+<p><strong>What this means for you:</strong></p>
+<ul class="content-list"><li>You can use the app freely</li>
+<li>You can view, modify, and distribute the source code</li>
+<li>If you run a modified version as a web service, you must make your source code available</li>
+</ul>
+<p><strong>Commercial use:</strong> If you want to use this code in a proprietary product without open-sourcing your changes, contact us about a commercial license.</p>
+<h2 class="content-h2">No Warranty</h2>
+<p>This app is provided <strong>&quot;as is&quot;</strong> without warranty of any kind. We don&#39;t guarantee:</p>
+<ul class="content-list"><li>The app will be available 24/7</li>
+<li>Layouts will be preserved indefinitely</li>
+<li>The app is free of bugs or errors</li>
+<li>Print estimates are accurate for your specific printer</li>
+</ul>
+<p><strong>Back up important work.</strong> Export your layouts regularly. Don&#39;t rely solely on browser storage or cloud sharing for critical data.</p>
+<h2 class="content-h2">Limitation of Liability</h2>
+<p>To the maximum extent permitted by law, we are not liable for:</p>
+<ul class="content-list"><li>Lost data or layouts</li>
+<li>Wasted filament from inaccurate print estimates</li>
+<li>Any damages arising from use of the app</li>
+<li>Issues with 3D printed items designed using this tool</li>
+</ul>
+<h2 class="content-h2">Acceptable Use</h2>
+<p>Don&#39;t use this app to:</p>
+<ul class="content-list"><li>Attempt to breach security or access others&#39; data</li>
+<li>Overload our servers with automated requests</li>
+<li>Scrape or harvest data from shared layouts</li>
+<li>Violate any applicable laws</li>
+</ul>
+<h2 class="content-h2">Changes to Terms</h2>
+<p>We may update these terms occasionally. Continued use of the app after changes constitutes acceptance of the new terms.</p>
+<h2 class="content-h2">Governing Law</h2>
+<p>These terms are governed by the laws of the United States.</p>
+<h2 class="content-h2">Contact</h2>
+<p>Questions? Open an issue on our <a href="https://github.com/andymai/gridfinity-layout-tool/issues" target="_blank" rel="noopener">GitHub repository</a>.</p>
+<hr>
+<p><a href="/" class="content-cta">Back to the app &rarr;</a></p>
+
+  </main>
+
+  <!-- Footer -->
+  <footer class="content-page">
+    <div class="content-footer">
+      <div class="content-footer__links">
+        <a href="/what-is-gridfinity">What is Gridfinity?</a>
+        <a href="/guide">Planning Guide</a>
+        <a href="/privacy">Privacy</a>
+        <a href="/terms">Terms</a>
+      </div>
+      <p class="content-footer__copyright">
+        © 2026 Gridfinity Layout Tool. Free to use.
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * Build script for static content pages.
  * Converts Markdown files in content/ to HTML in public/.
@@ -29,11 +30,7 @@ interface Frontmatter {
 /**
  * Generate the HTML template for a content page
  */
-function generateHtml(
-  content: string,
-  frontmatter: Frontmatter,
-  slug: string
-): string {
+function generateHtml(content: string, frontmatter: Frontmatter, slug: string): string {
   const { title, description, keywords, ogImage, schema } = frontmatter;
   const canonicalUrl = `${SITE_URL}/${slug}`;
   const image = ogImage || `${SITE_URL}/og-image.png`;
@@ -156,6 +153,8 @@ ${content}
       <div class="content-footer__links">
         <a href="/what-is-gridfinity">What is Gridfinity?</a>
         <a href="/guide">Planning Guide</a>
+        <a href="/privacy">Privacy</a>
+        <a href="/terms">Terms</a>
       </div>
       <p class="content-footer__copyright">
         © ${new Date().getFullYear()} Gridfinity Layout Tool. Free to use.
@@ -183,9 +182,7 @@ function escapeHtml(str: string): string {
  * Escapes < and > to their Unicode equivalents
  */
 function safeJsonLd(data: object): string {
-  return JSON.stringify(data, null, 2)
-    .replace(/</g, '\\u003c')
-    .replace(/>/g, '\\u003e');
+  return JSON.stringify(data, null, 2).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
 }
 
 /**
@@ -203,9 +200,7 @@ function configureMarked(): void {
       // Add classes to lists
       list(token) {
         const type = token.ordered ? 'ol' : 'ul';
-        const body = token.items
-          .map((item) => this.listitem(item))
-          .join('');
+        const body = token.items.map((item) => this.listitem(item)).join('');
         return `<${type} class="content-list">${body}</${type}>\n`;
       },
       // Handle special CTA syntax: [CTA: text](url)

--- a/src/components/Mobile/MobileSettingsPanel.tsx
+++ b/src/components/Mobile/MobileSettingsPanel.tsx
@@ -16,21 +16,29 @@ import { SectionHeader } from '@/shared/components/SectionHeader';
 import { SettingsRow } from '@/shared/components/SettingsRow';
 import type { STLSearchSite } from '@/core/store/settings';
 import { useTranslation } from '@/i18n';
+import { optInAnalytics, optOutAnalytics } from '@/utils/analytics';
 
 /**
  * Privacy settings section for mobile.
  */
 function MobilePrivacySection() {
   const t = useTranslation();
-  const { mlTelemetryEnabled, updateSetting } = useSettingsStore(
+  const { analyticsEnabled, updateSetting } = useSettingsStore(
     useShallow((state) => ({
-      mlTelemetryEnabled: state.settings.mlTelemetryEnabled,
+      analyticsEnabled: state.settings.analyticsEnabled,
       updateSetting: state.updateSetting,
     }))
   );
 
   const handleToggle = () => {
-    updateSetting('mlTelemetryEnabled', !mlTelemetryEnabled);
+    const newValue = !analyticsEnabled;
+    updateSetting('analyticsEnabled', newValue);
+    // Apply the change to PostHog immediately
+    if (newValue) {
+      optInAnalytics();
+    } else {
+      optOutAnalytics();
+    }
   };
 
   return (
@@ -40,7 +48,7 @@ function MobilePrivacySection() {
         className="flex items-center justify-between py-2 cursor-pointer"
         onClick={handleToggle}
         role="checkbox"
-        aria-checked={mlTelemetryEnabled}
+        aria-checked={analyticsEnabled}
         aria-label={t('mobile.settings.toggleUsageDataCollection')}
         tabIndex={0}
         onKeyDown={(e) => {
@@ -52,7 +60,7 @@ function MobilePrivacySection() {
       >
         <div>
           <span
-            className={`text-sm ${mlTelemetryEnabled ? 'text-content' : 'text-content-secondary'}`}
+            className={`text-sm ${analyticsEnabled ? 'text-content' : 'text-content-secondary'}`}
           >
             {t('mobile.settings.helpImproveSuggestions')}
           </span>
@@ -60,7 +68,7 @@ function MobilePrivacySection() {
             {t('mobile.settings.shareBinSizesAndPlacementPatternsNo')}
           </p>
         </div>
-        <Checkbox checked={mlTelemetryEnabled} variant="mobile" />
+        <Checkbox checked={analyticsEnabled} variant="mobile" />
       </div>
     </section>
   );
@@ -384,6 +392,25 @@ export function MobileSettingsPanel() {
             className="hover:underline text-content-tertiary"
           >
             Andy Aragon
+          </a>
+        </div>
+        <div className="text-xs text-content-disabled mt-3 space-x-3">
+          <a
+            href="/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-content-tertiary"
+          >
+            {t('settings.privacyPolicy')}
+          </a>
+          <span>·</span>
+          <a
+            href="/terms"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-content-tertiary"
+          >
+            {t('settings.termsOfService')}
           </a>
         </div>
       </section>

--- a/src/components/Modals/SettingsModal.tsx
+++ b/src/components/Modals/SettingsModal.tsx
@@ -13,6 +13,7 @@ import { useTranslation, useLocale, SUPPORTED_LOCALES, detectBrowserLocale } fro
 import type { Locale } from '@/i18n';
 import type { STLSearchSite } from '@/core/store/settings';
 import { DEFAULT_CATEGORIES } from '@/core/constants';
+import { optInAnalytics, optOutAnalytics } from '@/utils/analytics';
 
 // Style constants
 const STYLES = {
@@ -63,9 +64,9 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     handleSaveCategoriesAsDefaults,
   } = useDrawerSettings();
 
-  const { mlTelemetryEnabled, settingsLocale, updateSetting } = useSettingsStore(
+  const { analyticsEnabled, settingsLocale, updateSetting } = useSettingsStore(
     useShallow((state) => ({
-      mlTelemetryEnabled: state.settings.mlTelemetryEnabled,
+      analyticsEnabled: state.settings.analyticsEnabled,
       settingsLocale: state.settings.locale,
       updateSetting: state.updateSetting,
     }))
@@ -104,7 +105,14 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const graduatedFeatures = getGraduatedFeatures();
 
   const handlePrivacyToggle = () => {
-    updateSetting('mlTelemetryEnabled', !mlTelemetryEnabled);
+    const newValue = !analyticsEnabled;
+    updateSetting('analyticsEnabled', newValue);
+    // Apply the change to PostHog immediately
+    if (newValue) {
+      optInAnalytics();
+    } else {
+      optOutAnalytics();
+    }
   };
 
   // Use portal to escape parent stacking contexts (e.g., BottomSheet with transform)
@@ -397,7 +405,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                 className="flex items-center justify-between text-sm cursor-pointer group rounded-md p-1 -m-1 outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
                 onClick={handlePrivacyToggle}
                 role="checkbox"
-                aria-checked={mlTelemetryEnabled}
+                aria-checked={analyticsEnabled}
                 aria-label={t('settings.toggleUsageData')}
                 tabIndex={0}
                 onKeyDown={(e) => {
@@ -409,7 +417,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
               >
                 <div>
                   <span
-                    className={`${mlTelemetryEnabled ? 'text-content' : 'text-content-tertiary'} group-hover:text-content transition-colors`}
+                    className={`${analyticsEnabled ? 'text-content' : 'text-content-tertiary'} group-hover:text-content transition-colors`}
                   >
                     {t('settings.helpImprove')}
                   </span>
@@ -417,7 +425,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                     {t('settings.helpImproveHint')}
                   </p>
                 </div>
-                <Checkbox checked={mlTelemetryEnabled} variant="desktop" />
+                <Checkbox checked={analyticsEnabled} variant="desktop" />
               </div>
             </section>
 
@@ -453,6 +461,29 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
 
               <GraduatedSection features={graduatedFeatures} />
             </section>
+
+            {/* Legal Links */}
+            <div className="pt-4 border-t border-stroke-subtle text-center">
+              <div className="text-xs text-content-disabled space-x-3">
+                <a
+                  href="/privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-content-tertiary transition-colors"
+                >
+                  {t('settings.privacyPolicy')}
+                </a>
+                <span>·</span>
+                <a
+                  href="/terms"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-content-tertiary transition-colors"
+                >
+                  {t('settings.termsOfService')}
+                </a>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/core/store/settings.ts
+++ b/src/core/store/settings.ts
@@ -185,11 +185,11 @@ export interface UserSettings {
 
   // Privacy settings
   /**
-   * Enable ML telemetry for bin prediction training.
-   * Collects anonymous usage patterns (bin sizes, labels) to improve suggestions.
+   * Enable anonymous analytics and telemetry.
+   * Controls both PostHog analytics and ML telemetry for bin suggestions.
    * Default: true (opt-out model)
    */
-  mlTelemetryEnabled: boolean;
+  analyticsEnabled: boolean;
 
   // Language preference
   /**
@@ -234,7 +234,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   stlSearchSites: [...DEFAULT_STL_SEARCH_SITES],
 
   // Privacy - opt-out by default (enabled)
-  mlTelemetryEnabled: true,
+  analyticsEnabled: true,
 
   // Language - auto-detect from browser by default
   locale: 'auto' as const,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -989,6 +989,8 @@
   "settings.helpImproveHint": "Bin-Größen und Platzierungsmuster teilen (keine persönlichen Daten)",
   "settings.labs": "Labs",
   "settings.labsCheckBack": "Schauen Sie später wieder vorbei!",
+  "settings.privacyPolicy": "Datenschutzrichtlinie",
+  "settings.termsOfService": "Nutzungsbedingungen",
   "settings.labsEmpty": "Derzeit keine experimentellen Funktionen verfügbar.",
   "settings.labsHint": "Probieren Sie neue Funktionen aus, bevor sie veröffentlicht werden. Funktionen können sich basierend auf Feedback ändern.",
   "settings.language": "Sprache",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -638,6 +638,8 @@ const en: Record<string, string> = {
     "Try new features before they're released. Features may change based on feedback.",
   'settings.labsEmpty': 'No experimental features available right now.',
   'settings.labsCheckBack': 'Check back later!',
+  'settings.privacyPolicy': 'Privacy Policy',
+  'settings.termsOfService': 'Terms of Service',
   'settings.experimental': 'Experimental',
   'settings.drawerDimensions': 'Drawer Dimensions',
   'settings.gridSettings': 'Grid Settings',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -989,6 +989,8 @@
   "settings.helpImproveHint": "Compartir tamaños de bins y patrones de ubicación (sin datos personales)",
   "settings.labs": "Labs",
   "settings.labsCheckBack": "¡Vuelve más tarde!",
+  "settings.privacyPolicy": "Política de privacidad",
+  "settings.termsOfService": "Términos de servicio",
   "settings.labsEmpty": "No hay funciones experimentales disponibles en este momento.",
   "settings.labsHint": "Prueba nuevas funciones antes de su lanzamiento. Las funciones pueden cambiar según los comentarios.",
   "settings.language": "Idioma",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -989,6 +989,8 @@
   "settings.helpImproveHint": "Partager les tailles de bins et les motifs de placement (aucune donnée personnelle)",
   "settings.labs": "Laboratoire",
   "settings.labsCheckBack": "Reviens plus tard !",
+  "settings.privacyPolicy": "Politique de confidentialité",
+  "settings.termsOfService": "Conditions d'utilisation",
   "settings.labsEmpty": "Aucune fonctionnalité expérimentale disponible pour le moment.",
   "settings.labsHint": "Essayer de nouvelles fonctionnalités avant leur sortie. Les fonctionnalités peuvent changer selon les retours.",
   "settings.language": "Langue",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -989,6 +989,8 @@
   "settings.helpImproveHint": "Deel bin formaten en plaatsingspatronen (geen persoonlijke gegevens)",
   "settings.labs": "Labs",
   "settings.labsCheckBack": "Kom later terug!",
+  "settings.privacyPolicy": "Privacybeleid",
+  "settings.termsOfService": "Servicevoorwaarden",
   "settings.labsEmpty": "Momenteel geen experimentele functies beschikbaar.",
   "settings.labsHint": "Probeer nieuwe functies voordat ze beschikbaar komen. Functies kunnen wijzigen op basis van feedback.",
   "settings.language": "Taal",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -989,6 +989,8 @@
   "settings.helpImproveHint": "Compartilhar tamanhos de bins e padrões de posicionamento (nenhum dado pessoal)",
   "settings.labs": "Labs",
   "settings.labsCheckBack": "Volte mais tarde!",
+  "settings.privacyPolicy": "Política de Privacidade",
+  "settings.termsOfService": "Termos de Serviço",
   "settings.labsEmpty": "Nenhum recurso experimental disponível no momento.",
   "settings.labsHint": "Experimente novos recursos antes de serem lançados. Os recursos podem mudar com base no feedback.",
   "settings.language": "Idioma",

--- a/src/shared/analytics/mlTelemetry/eventBuffer.ts
+++ b/src/shared/analytics/mlTelemetry/eventBuffer.ts
@@ -110,9 +110,9 @@ export function flush(): void {
 
   if (eventBuffer.length === 0) return;
 
-  // Check if telemetry is still enabled
+  // Check if analytics/telemetry is still enabled
   const settings = useSettingsStore.getState().settings;
-  if (!settings.mlTelemetryEnabled) {
+  if (!settings.analyticsEnabled) {
     eventBuffer = [];
     return;
   }

--- a/src/shared/analytics/mlTelemetry/trackers.ts
+++ b/src/shared/analytics/mlTelemetry/trackers.ts
@@ -81,11 +81,11 @@ import {
 // ============================================
 
 /**
- * Check if ML telemetry is enabled.
+ * Check if analytics/telemetry is enabled.
  */
 export function isEnabled(): boolean {
   const settings = useSettingsStore.getState().settings;
-  return settings.mlTelemetryEnabled ?? true;
+  return settings.analyticsEnabled ?? true;
 }
 
 /**

--- a/src/test/analytics/mlTelemetry.test.ts
+++ b/src/test/analytics/mlTelemetry.test.ts
@@ -36,7 +36,7 @@ vi.mock('@/core/store/settings', () => ({
   useSettingsStore: {
     getState: vi.fn(() => ({
       settings: {
-        mlTelemetryEnabled: true,
+        analyticsEnabled: true,
       },
     })),
   },

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -19,7 +19,7 @@ import {
   hasFractionalDimensions,
   BREAKPOINTS,
 } from '@/core/constants';
-import { useLabsStore, useInteractionStore, useLayoutStore } from '@/core/store';
+import { useLabsStore, useInteractionStore, useLayoutStore, useSettingsStore } from '@/core/store';
 import { getFeature } from '@/core/labs';
 import { generateUUID } from '@/shared/utils';
 
@@ -81,6 +81,10 @@ export function initAnalytics(): void {
   if (typeof window === 'undefined') return;
   if (import.meta.env.DEV) return; // Skip in development
 
+  // Check if analytics is enabled in settings
+  const { analyticsEnabled } = useSettingsStore.getState().settings;
+  if (!analyticsEnabled) return;
+
   const key = import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
 
   if (!key) {
@@ -126,6 +130,30 @@ export function initAnalytics(): void {
     .catch(() => {
       // Fail silently
     });
+}
+
+/**
+ * Opt out of analytics tracking.
+ * Called when user disables analytics in settings.
+ */
+export function optOutAnalytics(): void {
+  if (posthogInstance) {
+    posthogInstance.opt_out_capturing();
+  }
+}
+
+/**
+ * Opt back into analytics tracking.
+ * Called when user re-enables analytics in settings.
+ */
+export function optInAnalytics(): void {
+  if (posthogInstance) {
+    posthogInstance.opt_in_capturing();
+  } else {
+    // If posthog wasn't initialized, try to initialize now
+    initPromise = null;
+    initAnalytics();
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Create `/privacy` and `/terms` content pages with comprehensive legal text
- Add analytics opt-out toggle to Settings (unified control for PostHog + ML telemetry)
- Add Privacy/Terms links to Settings modal and mobile settings footer
- Add translations for legal links in all 6 supported locales

## Changes

### New Pages
- **Privacy Policy** (`/privacy`) - Covers PostHog analytics, Vercel storage, Liveblocks collab, and localStorage
- **Terms of Service** (`/terms`) - Covers AGPL-3.0 license, user content ownership, liability, acceptable use

### Analytics Privacy Control
- Renamed `mlTelemetryEnabled` → `analyticsEnabled` for unified privacy control
- Single toggle now controls both PostHog analytics and ML telemetry
- Added `optInAnalytics()` / `optOutAnalytics()` functions for immediate effect

### UI Updates
- Links to Privacy Policy and Terms in Settings modal footer
- Links in mobile settings footer
- Links in static content page footers

## Test plan
- [x] Privacy page renders at `/privacy`
- [x] Terms page renders at `/terms`
- [x] Analytics toggle works in Settings
- [x] Links open in new tabs
- [x] i18n keys match across all locales
- [x] Build passes
- [ ] Manual verification of opt-out functionality

## Screenshots
N/A - Text content pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)