### PR TITLE
fix: add privacy and terms routes to Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -22,6 +22,24 @@
       ]
     },
     {
+      "source": "/privacy",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
+        }
+      ]
+    },
+    {
+      "source": "/terms",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
+        }
+      ]
+    },
+    {
       "source": "/content.:hash.css",
       "headers": [
         {
@@ -87,6 +105,8 @@
     },
     { "source": "/what-is-gridfinity", "destination": "/what-is-gridfinity/index.html" },
     { "source": "/guide", "destination": "/guide/index.html" },
+    { "source": "/privacy", "destination": "/privacy/index.html" },
+    { "source": "/terms", "destination": "/terms/index.html" },
     { "source": "/s/:id([a-zA-Z0-9]{12})", "destination": "/" },
     { "source": "/l/:id([a-zA-Z0-9]{12})", "destination": "/" },
     { "source": "/l/:id([a-zA-Z0-9]{12})/:slug*", "destination": "/" },


### PR DESCRIPTION
## Summary
Add cache headers and rewrites for `/privacy` and `/terms` pages to match the existing `/guide` and `/what-is-gridfinity` pattern.

Without this, the static HTML pages won't be served correctly on Vercel.

## Test plan
- [x] Build passes
- [ ] `/privacy` loads on Vercel
- [ ] `/terms` loads on Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)