### PR TITLE
fix: add privacy/terms to service worker denylist

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -78,6 +78,8 @@ export default defineConfig({
           /^\/robots\.txt$/,
           /^\/what-is-gridfinity(?:\/|$)/,
           /^\/guide(?:\/|$)/,
+          /^\/privacy(?:\/|$)/,
+          /^\/terms(?:\/|$)/,
         ],
         runtimeCaching: [
           {


### PR DESCRIPTION
## Summary
The PWA service worker was intercepting `/privacy` and `/terms` routes and serving `index.html` instead of the static HTML pages.

## Root Cause
The `navigateFallback` in vite.config.ts serves `/index.html` for all navigation requests except those in `navigateFallbackDenylist`. The denylist had `/guide` and `/what-is-gridfinity` but was missing the new pages.

## Fix
Add `/privacy` and `/terms` to the denylist regex patterns.

## Test plan
- [ ] Clear browser cache/service worker
- [ ] Visit `/privacy` - should show Privacy Policy page
- [ ] Visit `/terms` - should show Terms of Service page

🤖 Generated with [Claude Code](https://claude.com/claude-code)