### PR TITLE
refactor(inspiration-gallery): optimize theme counting and remove dead code

### DIFF
--- a/src/features/inspiration-gallery/__tests__/InspirationGallery.test.tsx
+++ b/src/features/inspiration-gallery/__tests__/InspirationGallery.test.tsx
@@ -138,7 +138,9 @@ vi.mock('../data', () => {
   return {
     INSPIRATION_LAYOUTS: mockLayouts,
     getLayoutsByTheme: (theme: string) =>
-      mockLayouts.filter((l: { theme: string }) => l.theme === theme),
+      theme === 'all'
+        ? mockLayouts
+        : mockLayouts.filter((l: { theme: string }) => l.theme === theme),
   };
 });
 
@@ -336,7 +338,9 @@ describe('InspirationGallery', () => {
       fireEvent.click(screen.getByText('Workshop (2)'));
 
       await waitFor(() => {
-        expect(screen.getByText((content) => content.includes('2 layout(s) in Workshop'))).toBeInTheDocument();
+        expect(
+          screen.getByText((content) => content.includes('2 layout(s) in Workshop'))
+        ).toBeInTheDocument();
       });
     });
 

--- a/src/features/inspiration-gallery/components/InspirationGallery.tsx
+++ b/src/features/inspiration-gallery/components/InspirationGallery.tsx
@@ -58,23 +58,17 @@ function InspirationGalleryContent({ onClose }: { onClose: () => void }) {
   const addToast = useToastStore((state) => state.addToast);
 
   // Filter by theme
-  const filteredLayouts =
-    selectedTheme === 'all'
-      ? INSPIRATION_LAYOUTS
-      : INSPIRATION_LAYOUTS.filter((l) => l.theme === selectedTheme);
+  const filteredLayouts = getLayoutsByTheme(selectedTheme);
 
-  // Count layouts per theme (memoized since INSPIRATION_LAYOUTS is static)
-  const themeCounts = useMemo(
-    () => ({
-      all: INSPIRATION_LAYOUTS.length,
-      kitchen: INSPIRATION_LAYOUTS.filter((l) => l.theme === 'kitchen').length,
-      workshop: INSPIRATION_LAYOUTS.filter((l) => l.theme === 'workshop').length,
-      office: INSPIRATION_LAYOUTS.filter((l) => l.theme === 'office').length,
-      hobby: INSPIRATION_LAYOUTS.filter((l) => l.theme === 'hobby').length,
-      personal: INSPIRATION_LAYOUTS.filter((l) => l.theme === 'personal').length,
-    }),
-    []
-  );
+  // Count layouts per theme in a single pass (memoized since INSPIRATION_LAYOUTS is static)
+  const themeCounts = useMemo(() => {
+    const counts = { all: 0, kitchen: 0, workshop: 0, office: 0, hobby: 0, personal: 0 };
+    for (const layout of INSPIRATION_LAYOUTS) {
+      counts.all++;
+      counts[layout.theme]++;
+    }
+    return counts;
+  }, []);
 
   // Handle escape key
   useEffect(() => {
@@ -136,7 +130,7 @@ function InspirationGalleryContent({ onClose }: { onClose: () => void }) {
   const handleThemeChange = useCallback(
     (theme: InspirationTheme | 'all') => {
       setSelectedTheme(theme);
-      const count = theme === 'all' ? INSPIRATION_LAYOUTS.length : getLayoutsByTheme(theme).length;
+      const count = themeCounts[theme];
       const label = theme === 'all' ? 'all themes' : THEME_CONFIG[theme].label;
       announceToScreenReader(`Showing ${count} ${label} layouts`);
       trackEvent('gallery_filter_changed', {
@@ -144,7 +138,7 @@ function InspirationGalleryContent({ onClose }: { onClose: () => void }) {
         result_count: count,
       });
     },
-    [announceToScreenReader]
+    [announceToScreenReader, themeCounts]
   );
 
   const handleSelectLayout = useCallback((layout: InspirationLayout) => {
@@ -290,7 +284,9 @@ function InspirationGalleryContent({ onClose }: { onClose: () => void }) {
               <h2 id="inspiration-gallery-title" className="text-lg font-semibold text-content">
                 {t('gallery.title')}
               </h2>
-              <p className="text-sm text-content-secondary">{t('gallery.seeWhatSPossibleThenMakeItYours')}</p>
+              <p className="text-sm text-content-secondary">
+                {t('gallery.seeWhatSPossibleThenMakeItYours')}
+              </p>
             </div>
             <div className="flex items-center gap-2">
               {/* Grid size slider (desktop only) */}
@@ -391,7 +387,9 @@ function InspirationGalleryContent({ onClose }: { onClose: () => void }) {
               <button
                 onClick={() => setSelectedTheme('all')}
                 className="text-sm text-accent hover:underline"
-              >{t('gallery.browseAllLayouts')}</button>
+              >
+                {t('gallery.browseAllLayouts')}
+              </button>
             </div>
           )}
         </div>
@@ -399,7 +397,10 @@ function InspirationGalleryContent({ onClose }: { onClose: () => void }) {
         {/* Footer with count */}
         <div className="px-3 py-1.5 border-t border-stroke-subtle text-xs text-content-tertiary shrink-0">
           {selectedTheme !== 'all'
-            ? t('gallery.layoutsInTheme', { count: filteredLayouts.length, theme: THEME_CONFIG[selectedTheme].label })
+            ? t('gallery.layoutsInTheme', {
+                count: filteredLayouts.length,
+                theme: THEME_CONFIG[selectedTheme].label,
+              })
             : t('gallery.layoutCount', { count: filteredLayouts.length })}
         </div>
       </div>

--- a/src/features/inspiration-gallery/components/LayoutPreviewOverlay.tsx
+++ b/src/features/inspiration-gallery/components/LayoutPreviewOverlay.tsx
@@ -150,7 +150,9 @@ export function LayoutPreviewOverlay({
 
             {/* Metrics - streamlined, no redundant drawer size */}
             <div>
-              <h3 className="text-sm font-medium text-content mb-3">{t('gallery.layoutDetails')}</h3>
+              <h3 className="text-sm font-medium text-content mb-3">
+                {t('gallery.layoutDetails')}
+              </h3>
               <div className="grid grid-cols-3 gap-2">
                 <MetricCard label="Bins" value={metrics.binCount.toString()} />
                 <MetricCard label="Layers" value={metrics.layerCount.toString()} />
@@ -161,7 +163,9 @@ export function LayoutPreviewOverlay({
             {/* Example items */}
             {labeledBins.length > 0 && (
               <div>
-                <h3 className="text-sm font-medium text-content mb-2">{t('gallery.exampleItems')}</h3>
+                <h3 className="text-sm font-medium text-content mb-2">
+                  {t('gallery.exampleItems')}
+                </h3>
                 <div className="flex flex-wrap gap-1">
                   {labeledBins.slice(0, 8).map((bin) => (
                     <span
@@ -173,7 +177,8 @@ export function LayoutPreviewOverlay({
                   ))}
                   {labeledBins.length > 8 && (
                     <span className="text-xs px-2 py-1 text-content-tertiary">
-                      {t('gallery.moreCount', { count: labeledBins.length - 8 })}</span>
+                      {t('gallery.moreCount', { count: labeledBins.length - 8 })}
+                    </span>
                   )}
                 </div>
               </div>
@@ -182,7 +187,9 @@ export function LayoutPreviewOverlay({
             {/* Related layouts */}
             {relatedLayouts.length > 0 && onSelectRelated && (
               <div>
-                <h3 className="text-sm font-medium text-content mb-2">{t('gallery.moreInTheme', { theme: THEME_CONFIG[theme].label })}</h3>
+                <h3 className="text-sm font-medium text-content mb-2">
+                  {t('gallery.moreInTheme', { theme: THEME_CONFIG[theme].label })}
+                </h3>
                 <div className="flex gap-2">
                   {relatedLayouts.map((related) => (
                     <button
@@ -204,7 +211,9 @@ export function LayoutPreviewOverlay({
                         {related.name}
                       </div>
                       <div className="text-[10px] text-content-tertiary">
-                        {related.metrics.binCount}{t('gallery.bins')}</div>
+                        {related.metrics.binCount}
+                        {t('gallery.bins')}
+                      </div>
                     </button>
                   ))}
                 </div>
@@ -216,7 +225,9 @@ export function LayoutPreviewOverlay({
         {/* Footer with CTA */}
         <div className="p-4 md:p-6 border-t border-stroke-subtle bg-surface shrink-0">
           <div className="flex items-center justify-between gap-4">
-            <p className="text-sm text-content-secondary">{t('gallery.useAsAStartingPointCustomizeToFitYo')}</p>
+            <p className="text-sm text-content-secondary">
+              {t('gallery.useAsAStartingPointCustomizeToFitYo')}
+            </p>
             <button
               onClick={onUseLayout}
               disabled={isImporting}
@@ -224,7 +235,11 @@ export function LayoutPreviewOverlay({
             >
               {isImporting ? (
                 <>
-                  <svg className="animate-spin motion-reduce:animate-none -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+                  <svg
+                    className="animate-spin motion-reduce:animate-none -ml-1 mr-2 h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
                     <circle
                       className="opacity-25"
                       cx="12"
@@ -294,7 +309,11 @@ function DrawerSizeInfo({
         </svg>
         <div>
           <div className="text-sm font-medium text-success">{t('gallery.matchesYourDrawer')}</div>
-          <div className="text-xs text-success/70">{t('gallery.sameSizeAsYourCurrent', { size: `${currentSize.width}×${currentSize.depth}` })}</div>
+          <div className="text-xs text-success/70">
+            {t('gallery.sameSizeAsYourCurrent', {
+              size: `${currentSize.width}×${currentSize.depth}`,
+            })}
+          </div>
         </div>
       </div>
     );
@@ -318,13 +337,14 @@ function DrawerSizeInfo({
       </svg>
       <div>
         <div className="text-sm font-medium text-content-secondary">
-          {templateSize.width}×{templateSize.depth}{t('gallery.drawer')}</div>
+          {templateSize.width}×{templateSize.depth}
+          {t('gallery.drawer')}
+        </div>
         <div className="text-xs text-content-tertiary">
           {realWidth}×{realDepth}mm
-          {(templateSize.width !== currentSize.width ||
-            templateSize.depth !== currentSize.depth) && (
-            <span className="ml-1 text-content-disabled">{t('gallery.yourSize', { size: `${currentSize.width}×${currentSize.depth}` })}</span>
-          )}
+          <span className="ml-1 text-content-disabled">
+            {t('gallery.yourSize', { size: `${currentSize.width}×${currentSize.depth}` })}
+          </span>
         </div>
       </div>
     </div>

--- a/src/features/inspiration-gallery/data/index.ts
+++ b/src/features/inspiration-gallery/data/index.ts
@@ -88,10 +88,3 @@ export function getLayoutsByTheme(theme: InspirationTheme | 'all'): InspirationL
   if (theme === 'all') return INSPIRATION_LAYOUTS;
   return INSPIRATION_LAYOUTS.filter((l) => l.theme === theme);
 }
-
-/**
- * Get a single layout by ID.
- */
-export function getLayoutById(id: string): InspirationLayout | undefined {
-  return INSPIRATION_LAYOUTS.find((l) => l.id === id);
-}

--- a/src/features/inspiration-gallery/index.ts
+++ b/src/features/inspiration-gallery/index.ts
@@ -6,4 +6,4 @@ export type { InspirationLayout, InspirationTheme, LayoutComplexity, LayoutFeatu
 export { THEME_CONFIG, FEATURE_CONFIG } from './types';
 
 // Data
-export { INSPIRATION_LAYOUTS, getLayoutsByTheme, getLayoutById } from './data';
+export { INSPIRATION_LAYOUTS, getLayoutsByTheme } from './data';


### PR DESCRIPTION
## Summary
- Remove unused `getLayoutById` function (dead code)
- Optimize `themeCounts` from 6 filter iterations to single pass through array
- Reuse `getLayoutsByTheme` instead of duplicating inline filter logic
- Use precomputed `themeCounts` in `handleThemeChange`
- Remove redundant conditional in `DrawerSizeInfo`
- Fix test mock to correctly handle 'all' theme case

## Test plan
- [x] All tests pass (253 related tests)
- [x] Build succeeds
- [x] Pre-commit hooks pass (lint, boundaries, i18n)
- [x] Bundle size reduced ~0.3KB (59.76kB → 59.47kB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)