### PR TITLE
refactor(print-export): extract layout logic and consolidate aggregates

### DIFF
--- a/src/features/print-export/components/PrintBin.tsx
+++ b/src/features/print-export/components/PrintBin.tsx
@@ -1,6 +1,7 @@
 import type { Bin, Category, Drawer } from '@/core/types';
 import type { PrintViewSettings } from '@/core/store/settings';
 import { DEFAULT_CATEGORY_COLOR } from '@/core/constants';
+import { usePrintBinLayout, getPrintTextColors } from './printBinLayout';
 
 interface PrintBinProps {
   bin: Bin;
@@ -9,30 +10,6 @@ interface PrintBinProps {
   cellSize: number;
   gap: number;
   settings: PrintViewSettings;
-}
-
-/**
- * Calculate print-friendly text colors based on background luminance.
- * Uses hardcoded colors instead of CSS variables for print compatibility.
- */
-function getPrintTextColors(hexColor: string): { primary: string; secondary: string } {
-  const hex = hexColor.replace('#', '');
-  const r = parseInt(hex.substring(0, 2), 16);
-  const g = parseInt(hex.substring(2, 4), 16);
-  const b = parseInt(hex.substring(4, 6), 16);
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-
-  if (luminance > 0.5) {
-    return {
-      primary: 'rgba(0, 0, 0, 0.85)',
-      secondary: 'rgba(0, 0, 0, 0.6)',
-    };
-  } else {
-    return {
-      primary: 'rgba(255, 255, 255, 0.95)',
-      secondary: 'rgba(255, 255, 255, 0.75)',
-    };
-  }
 }
 
 /**
@@ -55,165 +32,19 @@ export function PrintBin({ bin, category, drawer, cellSize, gap, settings }: Pri
     : '#e5e7eb'; // Light gray when color disabled
   const textColors = getPrintTextColors(color);
 
-  // Calculate grid position (CSS Grid is 1-indexed)
-  // Grid y=0 is bottom, but CSS row 1 is top
-  const integerWidth = Math.floor(drawer.width);
-  const integerDepth = Math.floor(drawer.depth);
-  const hasFractionalDrawerWidth = drawer.width % 1 !== 0;
-  const hasFractionalDrawerDepth = drawer.depth % 1 !== 0;
-  const fractionalEdgeX = drawer.fractionalEdgeX ?? 'end';
-  const fractionalEdgeY = drawer.fractionalEdgeY ?? 'end';
-  const fractionalWidthPart = drawer.width - integerWidth;
-  const fractionalDepthPart = drawer.depth - integerDepth;
-  const gridRows = Math.ceil(drawer.depth);
-
-  // Helper: Get CSS column for a grid x coordinate
-  const getCssColForX = (x: number): number => {
-    if (hasFractionalDrawerWidth && fractionalEdgeX === 'start') {
-      if (x < fractionalWidthPart) return 1;
-      return Math.floor(x - fractionalWidthPart) + 2;
-    }
-    return Math.floor(x) + 1;
-  };
-
-  // Helper: Get CSS row for a grid y coordinate (y=0 at bottom, CSS row 1 at top)
-  const getCssRowForY = (y: number): number => {
-    if (hasFractionalDrawerDepth) {
-      if (fractionalEdgeY === 'start') {
-        if (y < fractionalDepthPart) return gridRows;
-        return integerDepth - Math.floor(y - fractionalDepthPart);
-      } else {
-        if (y >= integerDepth) return 1;
-        return integerDepth - Math.floor(y) + 1;
-      }
-    }
-    return integerDepth - Math.floor(y);
-  };
-
-  // Calculate CSS column placement
-  const binEndX = bin.x + bin.width;
-  const startCol = getCssColForX(bin.x);
-  const endCol = getCssColForX(binEndX > 0 ? binEndX - 0.001 : binEndX);
-  const gridCol = startCol;
-  const colSpan = Math.max(1, endCol - startCol + 1);
-
-  // Calculate CSS row placement
-  const binEndY = bin.y + bin.depth;
-  const topRow = getCssRowForY(binEndY > 0 ? binEndY - 0.001 : binEndY);
-  const bottomRow = getCssRowForY(bin.y);
-  const gridRow = topRow;
-  const rowSpan = Math.max(1, bottomRow - topRow + 1);
-
-  // Calculate pixel dimensions accounting for fractional drawer cells
-  const hasFractionalBin =
-    bin.x % 1 !== 0 || bin.y % 1 !== 0 || bin.width % 1 !== 0 || bin.depth % 1 !== 0;
-  const needsCustomSizing =
-    hasFractionalBin || hasFractionalDrawerWidth || hasFractionalDrawerDepth;
-
-  // Calculate fractional cell sizes in pixels
-  const fractionalCellWidth = fractionalWidthPart * (cellSize + gap) - gap;
-  const fractionalCellHeight = fractionalDepthPart * (cellSize + gap) - gap;
-
-  // Calculate pixel width accounting for fractional edge
-  let pixelWidth: number | undefined;
-  if (!needsCustomSizing) {
-    pixelWidth = undefined;
-  } else if (!hasFractionalDrawerWidth) {
-    pixelWidth = bin.width * cellSize + Math.max(0, bin.width - 1) * gap;
-  } else if (fractionalEdgeX === 'start') {
-    const inFractional = Math.max(0, Math.min(binEndX, fractionalWidthPart) - Math.max(bin.x, 0));
-    const inInteger = bin.width - inFractional;
-    let width = 0;
-    if (inFractional > 0) {
-      width += (inFractional / fractionalWidthPart) * fractionalCellWidth;
-    }
-    if (inInteger > 0) {
-      if (inFractional > 0) width += gap;
-      width += inInteger * cellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
-    }
-    pixelWidth = width;
-  } else {
-    const inInteger = Math.max(0, Math.min(binEndX, integerWidth) - bin.x);
-    const inFractional = bin.width - inInteger;
-    let width = 0;
-    if (inInteger > 0) {
-      width += inInteger * cellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
-    }
-    if (inFractional > 0) {
-      if (inInteger > 0) width += gap;
-      width += (inFractional / fractionalWidthPart) * fractionalCellWidth;
-    }
-    pixelWidth = width;
-  }
-
-  // Calculate pixel height accounting for fractional edge
-  let pixelHeight: number | undefined;
-  if (!needsCustomSizing) {
-    pixelHeight = undefined;
-  } else if (!hasFractionalDrawerDepth) {
-    pixelHeight = bin.depth * cellSize + Math.max(0, bin.depth - 1) * gap;
-  } else if (fractionalEdgeY === 'start') {
-    const inFractional = Math.max(0, Math.min(binEndY, fractionalDepthPart) - Math.max(bin.y, 0));
-    const inInteger = bin.depth - inFractional;
-    let height = 0;
-    if (inFractional > 0) {
-      height += (inFractional / fractionalDepthPart) * fractionalCellHeight;
-    }
-    if (inInteger > 0) {
-      if (inFractional > 0) height += gap;
-      height += inInteger * cellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
-    }
-    pixelHeight = height;
-  } else {
-    const inInteger = Math.max(0, Math.min(binEndY, integerDepth) - bin.y);
-    const inFractional = bin.depth - inInteger;
-    let height = 0;
-    if (inInteger > 0) {
-      height += inInteger * cellSize + Math.max(0, Math.floor(inInteger + 0.001) - 1) * gap;
-    }
-    if (inFractional > 0) {
-      if (inInteger > 0) height += gap;
-      height += (inFractional / fractionalDepthPart) * fractionalCellHeight;
-    }
-    pixelHeight = height;
-  }
-
-  // Calculate pixel offsets for fractional positioning within the cell
-  let offsetX = 0;
-  let offsetY = 0;
-  if (needsCustomSizing) {
-    // X offset
-    if (hasFractionalDrawerWidth && fractionalEdgeX === 'start') {
-      if (bin.x < fractionalWidthPart) {
-        offsetX = (bin.x / fractionalWidthPart) * fractionalCellWidth;
-      } else {
-        const integerX = bin.x - fractionalWidthPart;
-        offsetX = (integerX - Math.floor(integerX)) * (cellSize + gap);
-      }
-    } else {
-      offsetX = (bin.x - Math.floor(bin.x)) * (cellSize + gap);
-    }
-
-    // Y offset (from top of cell)
-    if (hasFractionalDrawerDepth && fractionalEdgeY === 'start') {
-      if (binEndY <= fractionalDepthPart) {
-        offsetY = ((fractionalDepthPart - binEndY) / fractionalDepthPart) * fractionalCellHeight;
-      } else {
-        const integerY = binEndY - fractionalDepthPart;
-        offsetY = (Math.ceil(integerY) - integerY) * (cellSize + gap);
-      }
-    } else if (hasFractionalDrawerDepth && fractionalEdgeY === 'end') {
-      if (binEndY > integerDepth) {
-        const fractionalY = binEndY - integerDepth;
-        offsetY =
-          ((fractionalDepthPart - fractionalY) / fractionalDepthPart) * fractionalCellHeight;
-      } else {
-        offsetY = (Math.ceil(binEndY) - binEndY) * (cellSize + gap);
-      }
-    } else {
-      offsetY = (Math.ceil(binEndY) - binEndY) * (cellSize + gap);
-    }
-  }
+  // Use extracted layout calculation
+  const layout = usePrintBinLayout(bin, drawer, cellSize, gap);
+  const {
+    gridCol,
+    colSpan,
+    gridRow,
+    rowSpan,
+    pixelWidth,
+    pixelHeight,
+    offsetX,
+    offsetY,
+    needsCustomSizing,
+  } = layout;
 
   // Determine what text to display based on settings
   const wantsLabel = settings.showLabel && bin.label;

--- a/src/features/print-export/components/PrintModal.tsx
+++ b/src/features/print-export/components/PrintModal.tsx
@@ -169,11 +169,6 @@ export function PrintModal({ isOpen, onClose }: PrintModalProps) {
     setSelectedLayerIds(layout.layers.map((l) => l.id));
   }, [layout.layers]);
 
-  // Handle print
-  const handlePrint = useCallback(() => {
-    window.print();
-  }, []);
-
   const printViewSettings = settings.printViewSettings;
   const allLayersSelected = selectedLayerIds.length === layout.layers.length;
   const noLayersSelected = selectedLayerIds.length === 0;
@@ -421,13 +416,15 @@ export function PrintModal({ isOpen, onClose }: PrintModalProps) {
           {/* Footer */}
           <div className="flex items-center justify-end gap-3 p-4 border-t border-stroke-subtle print-modal-footer">
             {noLayersSelected && (
-              <span className="text-xs text-warning mr-auto">{t('print.selectAtLeastOneLayerToPrint')}</span>
+              <span className="text-xs text-warning mr-auto">
+                {t('print.selectAtLeastOneLayerToPrint')}
+              </span>
             )}
             <button onClick={onClose} className="btn btn-secondary">
               {t('common.cancel')}
             </button>
             <button
-              onClick={handlePrint}
+              onClick={() => window.print()}
               disabled={noLayersSelected}
               className="btn btn-primary flex items-center gap-2"
             >

--- a/src/features/print-export/components/printBinLayout.ts
+++ b/src/features/print-export/components/printBinLayout.ts
@@ -1,0 +1,299 @@
+/**
+ * Print Bin Layout Calculations
+ *
+ * Extracted utility for computing CSS grid positioning and pixel sizing
+ * for bins in the print view. Handles fractional drawer dimensions.
+ */
+
+import { useMemo } from 'react';
+import type { Bin, Drawer } from '@/core/types';
+
+const FLOAT_EPSILON = 0.001;
+
+export interface PrintBinLayoutResult {
+  gridCol: number;
+  colSpan: number;
+  gridRow: number;
+  rowSpan: number;
+  pixelWidth: number | undefined;
+  pixelHeight: number | undefined;
+  offsetX: number;
+  offsetY: number;
+  needsCustomSizing: boolean;
+}
+
+/**
+ * Calculate print-friendly text colors based on background luminance.
+ * Uses hardcoded colors instead of CSS variables for print compatibility.
+ */
+export function getPrintTextColors(hexColor: string): { primary: string; secondary: string } {
+  const hex = hexColor.replace('#', '');
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+
+  return luminance > 0.5
+    ? { primary: 'rgba(0, 0, 0, 0.85)', secondary: 'rgba(0, 0, 0, 0.6)' }
+    : { primary: 'rgba(255, 255, 255, 0.95)', secondary: 'rgba(255, 255, 255, 0.75)' };
+}
+
+/**
+ * Calculate CSS grid column for a grid x coordinate.
+ */
+function getCssCol(
+  x: number,
+  hasFractionalWidth: boolean,
+  fractionalEdgeX: 'start' | 'end',
+  fractionalWidthPart: number
+): number {
+  if (hasFractionalWidth && fractionalEdgeX === 'start') {
+    if (x < fractionalWidthPart) return 1;
+    return Math.floor(x - fractionalWidthPart) + 2;
+  }
+  return Math.floor(x) + 1;
+}
+
+/**
+ * Calculate CSS grid row for a grid y coordinate.
+ * Grid y=0 is bottom, CSS row 1 is top.
+ */
+function getCssRow(
+  y: number,
+  integerDepth: number,
+  gridRows: number,
+  hasFractionalDepth: boolean,
+  fractionalEdgeY: 'start' | 'end',
+  fractionalDepthPart: number
+): number {
+  if (hasFractionalDepth) {
+    if (fractionalEdgeY === 'start') {
+      if (y < fractionalDepthPart) return gridRows;
+      return integerDepth - Math.floor(y - fractionalDepthPart);
+    }
+    if (y >= integerDepth) return 1;
+    return integerDepth - Math.floor(y) + 1;
+  }
+  return integerDepth - Math.floor(y);
+}
+
+/**
+ * Calculate pixel size for a dimension accounting for fractional edges.
+ */
+function calcPixelSize(
+  position: number,
+  size: number,
+  integerDimension: number,
+  fractionalPart: number,
+  hasFractional: boolean,
+  fractionalEdge: 'start' | 'end',
+  cellSize: number,
+  gap: number
+): number | undefined {
+  const hasFractionalPosition = position % 1 !== 0 || size % 1 !== 0;
+  if (!hasFractionalPosition && !hasFractional) {
+    return undefined;
+  }
+
+  const fractionalCellSize = fractionalPart * (cellSize + gap) - gap;
+  const end = position + size;
+
+  if (!hasFractional) {
+    return size * cellSize + Math.max(0, size - 1) * gap;
+  }
+
+  if (fractionalEdge === 'start') {
+    const inFractional = Math.max(0, Math.min(end, fractionalPart) - Math.max(position, 0));
+    const inInteger = size - inFractional;
+    let pixels = 0;
+    if (inFractional > 0) {
+      pixels += (inFractional / fractionalPart) * fractionalCellSize;
+    }
+    if (inInteger > 0) {
+      if (inFractional > 0) pixels += gap;
+      pixels += inInteger * cellSize + Math.max(0, Math.floor(inInteger + FLOAT_EPSILON) - 1) * gap;
+    }
+    return pixels;
+  }
+
+  const inInteger = Math.max(0, Math.min(end, integerDimension) - position);
+  const inFractional = size - inInteger;
+  let pixels = 0;
+  if (inInteger > 0) {
+    pixels += inInteger * cellSize + Math.max(0, Math.floor(inInteger + FLOAT_EPSILON) - 1) * gap;
+  }
+  if (inFractional > 0) {
+    if (inInteger > 0) pixels += gap;
+    pixels += (inFractional / fractionalPart) * fractionalCellSize;
+  }
+  return pixels;
+}
+
+/**
+ * Calculate offset for fractional positioning within a cell.
+ */
+function calcOffset(
+  position: number,
+  size: number,
+  integerDimension: number,
+  fractionalPart: number,
+  hasFractional: boolean,
+  fractionalEdge: 'start' | 'end',
+  cellSize: number,
+  gap: number,
+  isYAxis: boolean
+): number {
+  if (!hasFractional && position % 1 === 0) return 0;
+
+  const fractionalCellSize = fractionalPart * (cellSize + gap) - gap;
+  const end = position + size;
+
+  if (isYAxis) {
+    // Y offset is from top of cell
+    if (hasFractional && fractionalEdge === 'start') {
+      if (end <= fractionalPart) {
+        return ((fractionalPart - end) / fractionalPart) * fractionalCellSize;
+      }
+      const integerY = end - fractionalPart;
+      return (Math.ceil(integerY) - integerY) * (cellSize + gap);
+    }
+    if (hasFractional && fractionalEdge === 'end') {
+      if (end > integerDimension) {
+        const fractionalY = end - integerDimension;
+        return ((fractionalPart - fractionalY) / fractionalPart) * fractionalCellSize;
+      }
+      return (Math.ceil(end) - end) * (cellSize + gap);
+    }
+    return (Math.ceil(end) - end) * (cellSize + gap);
+  }
+
+  // X offset
+  if (hasFractional && fractionalEdge === 'start') {
+    if (position < fractionalPart) {
+      return (position / fractionalPart) * fractionalCellSize;
+    }
+    const integerX = position - fractionalPart;
+    return (integerX - Math.floor(integerX)) * (cellSize + gap);
+  }
+  return (position - Math.floor(position)) * (cellSize + gap);
+}
+
+/**
+ * Hook to calculate print bin layout.
+ * Memoized to prevent recalculation on unrelated rerenders.
+ */
+export function usePrintBinLayout(
+  bin: Bin,
+  drawer: Drawer,
+  cellSize: number,
+  gap: number
+): PrintBinLayoutResult {
+  return useMemo(() => {
+    const integerWidth = Math.floor(drawer.width);
+    const integerDepth = Math.floor(drawer.depth);
+    const hasFractionalWidth = drawer.width % 1 !== 0;
+    const hasFractionalDepth = drawer.depth % 1 !== 0;
+    const fractionalEdgeX = drawer.fractionalEdgeX ?? 'end';
+    const fractionalEdgeY = drawer.fractionalEdgeY ?? 'end';
+    const fractionalWidthPart = drawer.width - integerWidth;
+    const fractionalDepthPart = drawer.depth - integerDepth;
+    const gridRows = Math.ceil(drawer.depth);
+
+    const binEndX = bin.x + bin.width;
+    const binEndY = bin.y + bin.depth;
+
+    // CSS grid positioning
+    const startCol = getCssCol(bin.x, hasFractionalWidth, fractionalEdgeX, fractionalWidthPart);
+    const endCol = getCssCol(
+      binEndX > 0 ? binEndX - 0.001 : binEndX,
+      hasFractionalWidth,
+      fractionalEdgeX,
+      fractionalWidthPart
+    );
+    const topRow = getCssRow(
+      binEndY > 0 ? binEndY - 0.001 : binEndY,
+      integerDepth,
+      gridRows,
+      hasFractionalDepth,
+      fractionalEdgeY,
+      fractionalDepthPart
+    );
+    const bottomRow = getCssRow(
+      bin.y,
+      integerDepth,
+      gridRows,
+      hasFractionalDepth,
+      fractionalEdgeY,
+      fractionalDepthPart
+    );
+
+    const hasFractionalBin =
+      bin.x % 1 !== 0 || bin.y % 1 !== 0 || bin.width % 1 !== 0 || bin.depth % 1 !== 0;
+    const needsCustomSizing = hasFractionalBin || hasFractionalWidth || hasFractionalDepth;
+
+    return {
+      gridCol: startCol,
+      colSpan: Math.max(1, endCol - startCol + 1),
+      gridRow: topRow,
+      rowSpan: Math.max(1, bottomRow - topRow + 1),
+      pixelWidth: calcPixelSize(
+        bin.x,
+        bin.width,
+        integerWidth,
+        fractionalWidthPart,
+        hasFractionalWidth,
+        fractionalEdgeX,
+        cellSize,
+        gap
+      ),
+      pixelHeight: calcPixelSize(
+        bin.y,
+        bin.depth,
+        integerDepth,
+        fractionalDepthPart,
+        hasFractionalDepth,
+        fractionalEdgeY,
+        cellSize,
+        gap
+      ),
+      offsetX: needsCustomSizing
+        ? calcOffset(
+            bin.x,
+            bin.width,
+            integerWidth,
+            fractionalWidthPart,
+            hasFractionalWidth,
+            fractionalEdgeX,
+            cellSize,
+            gap,
+            false
+          )
+        : 0,
+      offsetY: needsCustomSizing
+        ? calcOffset(
+            bin.y,
+            bin.depth,
+            integerDepth,
+            fractionalDepthPart,
+            hasFractionalDepth,
+            fractionalEdgeY,
+            cellSize,
+            gap,
+            true
+          )
+        : 0,
+      needsCustomSizing,
+    };
+  }, [
+    bin.x,
+    bin.y,
+    bin.width,
+    bin.depth,
+    drawer.width,
+    drawer.depth,
+    drawer.fractionalEdgeX,
+    drawer.fractionalEdgeY,
+    cellSize,
+    gap,
+  ]);
+}

--- a/src/features/print-export/hooks/usePrintList.ts
+++ b/src/features/print-export/hooks/usePrintList.ts
@@ -7,12 +7,7 @@ import { useMemo, useState, useCallback } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { useLayoutStore, useUIStore } from '@/core/store';
 import { calcMaxGridUnits } from '@/core/constants';
-import {
-  generateEnhancedPrintList,
-  getTotalBins,
-  getTotalPieces,
-  getSpoolEstimate,
-} from '@/features/print-export/utils/split';
+import { generateEnhancedPrintList } from '@/features/print-export/utils/split';
 import {
   applyFiltersAndSort,
   groupByCategory,
@@ -115,27 +110,24 @@ export function usePrintList(): UsePrintListReturn {
     return groupByCategory(rows, layout.categories);
   }, [rows, filters.groupByCategory, layout.categories]);
 
-  // Aggregates (computed from filtered rows)
-  const totalBins = useMemo(() => getTotalBins(rows), [rows]);
-  const totalPieces = useMemo(() => getTotalPieces(rows), [rows]);
-  const totalFilament = useMemo(
-    () => Math.round(rows.reduce((sum, r) => sum + r.filament, 0) * 10) / 10,
-    [rows]
-  );
-  const totalCost = useMemo(
-    () => calcFilamentCost(totalFilament, config.filamentCostPerKg, config.metersPerKg),
-    [totalFilament, config]
-  );
-  const totalPrintTimeHours = useMemo(
-    () => calcPrintTimeHours(totalFilament, rows.length),
-    [totalFilament, rows.length]
-  );
-  const spoolEstimate = useMemo(() => getSpoolEstimate(totalFilament), [totalFilament]);
-  const spoolPercentage = useMemo(
-    () => calcSpoolPercentage(totalFilament, config.metersPerKg),
-    [totalFilament, config.metersPerKg]
-  );
-  const hasAnySplits = useMemo(() => rows.some((r) => r.needsSplit), [rows]);
+  // Compute all aggregates in a single memo to reduce memoization overhead
+  const aggregates = useMemo(() => {
+    const totalBins = rows.reduce((sum, r) => sum + r.binCount, 0);
+    const totalPieces = rows.reduce((sum, r) => sum + r.totalPieces, 0);
+    const totalFilament = Math.round(rows.reduce((sum, r) => sum + r.filament, 0) * 10) / 10;
+    const hasAnySplits = rows.some((r) => r.needsSplit);
+
+    return {
+      totalBins,
+      totalPieces,
+      totalFilament,
+      totalCost: calcFilamentCost(totalFilament, config.filamentCostPerKg, config.metersPerKg),
+      totalPrintTimeHours: calcPrintTimeHours(totalFilament, rows.length),
+      spoolEstimate: Math.ceil((totalFilament / config.metersPerKg) * 10) / 10,
+      spoolPercentage: calcSpoolPercentage(totalFilament, config.metersPerKg),
+      hasAnySplits,
+    };
+  }, [rows, config.filamentCostPerKg, config.metersPerKg]);
 
   // Actions
   const setSort = useCallback((key: PrintListSortKey) => {
@@ -185,14 +177,7 @@ export function usePrintList(): UsePrintListReturn {
   return {
     rows,
     groupedRows,
-    totalBins,
-    totalPieces,
-    totalFilament,
-    totalCost,
-    totalPrintTimeHours,
-    spoolEstimate,
-    spoolPercentage,
-    hasAnySplits,
+    ...aggregates,
     filters,
     setSort,
     toggleSortOrder,


### PR DESCRIPTION
## Summary
- Extract complex layout calculations into `usePrintBinLayout` hook (169 lines saved from PrintBin.tsx)
- Consolidate 8 separate `useMemo` calls into single aggregate computation in usePrintList
- Remove unnecessary `handlePrint` callback wrapper
- New `printBinLayout.ts` contains reusable layout logic and `getPrintTextColors`

## Test plan
- [x] All tests pass (440 related tests)
- [x] Build succeeds
- [x] Pre-commit hooks pass (lint, boundaries, i18n)

🤖 Generated with [Claude Code](https://claude.com/claude-code)