### PR TITLE
refactor(cloud-share): remove dead code and simplify state patterns

### DIFF
--- a/src/features/cloud-share/components/CloudShareTab.tsx
+++ b/src/features/cloud-share/components/CloudShareTab.tsx
@@ -34,13 +34,15 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
     reset,
   } = useCloudShare(layoutId);
 
-  // Derive permission from existing share (controlled by parent state)
+  // Derive permission from existing share
   const permission: SharePermission = existingShare?.permission ?? 'view';
-  const setPermission = (newPermission: SharePermission) => {
-    if (existingShare && newPermission !== existingShare.permission) {
-      updatePermission(newPermission);
-    }
-  };
+  // Track local permission for new shares (before first share)
+  const [localPermission, setLocalPermission] = useState<SharePermission>(permission);
+
+  // Sync local permission when existing share changes
+  useEffect(() => {
+    setLocalPermission(permission);
+  }, [permission]);
 
   // Auto-focus URL on success
   useEffect(() => {
@@ -58,11 +60,11 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
   }, [urlCopied]);
 
   const handleShare = async () => {
-    await share(permission);
+    await share(localPermission);
   };
 
   const handlePermissionChange = async (newPermission: SharePermission) => {
-    setPermission(newPermission);
+    setLocalPermission(newPermission);
     if (hasActiveShare) {
       await updatePermission(newPermission);
     }
@@ -84,9 +86,7 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
   if (status === 'idle' && !hasActiveShare) {
     return (
       <div className="space-y-4">
-        <p className="text-sm text-content-secondary">
-          {t('share.cloud.description')}
-        </p>
+        <p className="text-sm text-content-secondary">{t('share.cloud.description')}</p>
 
         <div className="flex items-center gap-3">
           <label htmlFor="permission" className="text-sm text-content-secondary whitespace-nowrap">
@@ -94,8 +94,8 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
           </label>
           <select
             id="permission"
-            value={permission}
-            onChange={(e) => setPermission(e.target.value as SharePermission)}
+            value={localPermission}
+            onChange={(e) => setLocalPermission(e.target.value as SharePermission)}
             className="bg-surface text-content px-3 py-2 rounded border border-stroke focus:outline-none focus:ring-2 focus:ring-accent"
           >
             <option value="view">{t('share.cloud.viewOnly')}</option>
@@ -135,7 +135,7 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
             {urlCopied ? t('share.cloud.linkCopied') : t('share.cloud.copyLink')}
           </button>
           <select
-            value={permission}
+            value={localPermission}
             onChange={(e) => handlePermissionChange(e.target.value as SharePermission)}
             className="btn btn-secondary"
             aria-label={t('share.cloud.permissions')}
@@ -189,7 +189,12 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
     return (
       <div className="flex items-center justify-center py-8" role="status" aria-live="polite">
         <div className="flex items-center gap-3 text-content-secondary">
-          <svg className="w-5 h-5 animate-spin motion-reduce:animate-none" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <svg
+            className="w-5 h-5 animate-spin motion-reduce:animate-none"
+            viewBox="0 0 24 24"
+            fill="none"
+            aria-hidden="true"
+          >
             <circle
               className="opacity-25"
               cx="12"
@@ -239,16 +244,16 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
         </div>
 
         <div className="text-sm text-content-secondary">
-          {result.permission === 'edit'
-            ? t('share.cloud.canEdit')
-            : t('share.cloud.viewOnly')}
+          {result.permission === 'edit' ? t('share.cloud.canEdit') : t('share.cloud.viewOnly')}
         </div>
 
         <div className="flex gap-3 pt-2">
           <button onClick={onClose} className="btn btn-primary">
             {t('common.done')}
           </button>
-          <button onClick={reset} className="btn btn-secondary">{t('share.shareAnother')}</button>
+          <button onClick={reset} className="btn btn-secondary">
+            {t('share.shareAnother')}
+          </button>
         </div>
       </div>
     );
@@ -276,7 +281,9 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
           <button onClick={reset} className="btn btn-primary">
             {t('error.tryAgain')}
           </button>
-          <button onClick={onSwitchToUrlTab} className="btn btn-secondary">{t('share.useShareLinkInstead')}</button>
+          <button onClick={onSwitchToUrlTab} className="btn btn-secondary">
+            {t('share.useShareLinkInstead')}
+          </button>
         </div>
       </div>
     );

--- a/src/features/cloud-share/components/ShareButton.tsx
+++ b/src/features/cloud-share/components/ShareButton.tsx
@@ -196,7 +196,6 @@ function SharePopover({
     // Calculate initial position after mount when ref is available
     const position = calculatePosition();
     if (position) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- DOM ref unavailable during render, must setState after mount
       setPopoverPosition(position);
     }
 
@@ -235,31 +234,18 @@ function SharePopover({
   const [urlCopied, setUrlCopied] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
-  // Determine the effective permission:
-  // - If viewing a shared layout, use that permission
-  // - If we have our own share, use that
-  // - Otherwise default to 'view'
-  const effectivePermission = isViewingSharedLayout
+  // Permission from existing share or shared layout (default to 'view' for new shares)
+  const serverPermission = isViewingSharedLayout
     ? (sharedLayoutPermission ?? 'view')
     : (existingShare?.permission ?? 'view');
 
-  // Track local permission override (only when user changes it before sharing)
-  // Key tracks the "version" of effective permission - when it changes, we reset
-  const effectivePermissionKey = `${isViewingSharedLayout}-${existingShare?.id ?? 'none'}-${effectivePermission}`;
-  const [localPermissionState, setLocalPermissionState] = useState<{
-    key: string;
-    override: SharePermission | null;
-  }>({ key: effectivePermissionKey, override: null });
+  // Local permission state for new shares (before first share)
+  const [localPermission, setLocalPermission] = useState<SharePermission>(serverPermission);
 
-  // Use local override if set and key matches, otherwise use effective permission
-  const localPermission =
-    localPermissionState.key === effectivePermissionKey && localPermissionState.override !== null
-      ? localPermissionState.override
-      : effectivePermission;
-
-  const setLocalPermission = (newPermission: SharePermission) => {
-    setLocalPermissionState({ key: effectivePermissionKey, override: newPermission });
-  };
+  // Sync local permission when server state changes (e.g., after sharing, or switching layouts)
+  useEffect(() => {
+    setLocalPermission(serverPermission);
+  }, [serverPermission]);
 
   // Reset copy state after timeout
   useEffect(() => {

--- a/src/features/cloud-share/hooks/useCloudShare.ts
+++ b/src/features/cloud-share/hooks/useCloudShare.ts
@@ -7,7 +7,7 @@ import { useShallow } from 'zustand/shallow';
 import { useLibraryStore } from '@/core/store/library';
 import { useLayoutStore } from '@/core/store/layout';
 import { useUIStore } from '@/core/store/ui';
-import type { SharePermission, CloudShareInfo, Layout } from '@/core/types';
+import type { SharePermission, CloudShareInfo } from '@/core/types';
 import {
   createShare,
   updateShare,
@@ -51,7 +51,6 @@ interface CloudShareActions {
   updatePermission: (permission: SharePermission) => Promise<boolean>;
   remove: () => Promise<boolean>;
   copyUrl: () => Promise<boolean>;
-  copyDeleteToken: () => Promise<boolean>;
   reset: () => void;
 }
 
@@ -95,10 +94,6 @@ export function useCloudShare(layoutId?: string): CloudShareState & CloudShareAc
 
   // Shares are now permanent, so active share is simply whether one exists
   const hasActiveShare = !!existingShare;
-
-  const getLayoutToShare = useCallback((): Layout => {
-    return layout;
-  }, [layout]);
 
   const handleSuccess = useCallback(
     (response: ShareResponse, isUpdate: boolean) => {
@@ -166,8 +161,7 @@ export function useCloudShare(layoutId?: string): CloudShareState & CloudShareAc
       setStatus('sharing');
       setError(null);
 
-      const layoutToShare = getLayoutToShare();
-      const result = await createShare(targetLayoutId, layoutToShare, permission, authorName);
+      const result = await createShare(targetLayoutId, layout, permission, authorName);
 
       // Prevent state updates if component unmounted during async operation
       if (!mountedRef.current) return false;
@@ -181,7 +175,7 @@ export function useCloudShare(layoutId?: string): CloudShareState & CloudShareAc
         return false;
       }
     },
-    [targetLayoutId, getLayoutToShare, authorName, handleSuccess, handleError]
+    [targetLayoutId, layout, authorName, handleSuccess, handleError]
   );
 
   const update = useCallback(
@@ -207,11 +201,10 @@ export function useCloudShare(layoutId?: string): CloudShareState & CloudShareAc
       setStatus('updating');
       setError(null);
 
-      const layoutToShare = getLayoutToShare();
       const result = await updateShare(
         existingShare.id,
         existingShare.deleteToken,
-        layoutToShare,
+        layout,
         permission
       );
 
@@ -263,7 +256,7 @@ export function useCloudShare(layoutId?: string): CloudShareState & CloudShareAc
     [
       existingShare,
       targetLayoutId,
-      getLayoutToShare,
+      layout,
       setCloudShare,
       handleError,
       clearCloudShare,
@@ -411,17 +404,6 @@ export function useCloudShare(layoutId?: string): CloudShareState & CloudShareAc
     return success;
   }, [result, existingShare, layout.name, announceToScreenReader]);
 
-  const copyDeleteToken = useCallback(async (): Promise<boolean> => {
-    const token = result?.deleteToken || existingShare?.deleteToken;
-    if (!token) return false;
-
-    const success = await copyToClipboard(token);
-    if (success) {
-      announceToScreenReader('Delete token copied to clipboard.');
-    }
-    return success;
-  }, [result, existingShare, announceToScreenReader]);
-
   const reset = useCallback(() => {
     setStatus('idle');
     setResult(null);
@@ -439,7 +421,6 @@ export function useCloudShare(layoutId?: string): CloudShareState & CloudShareAc
     updatePermission: updatePermissionAction,
     remove,
     copyUrl,
-    copyDeleteToken,
     reset,
   };
 }

--- a/src/features/cloud-share/hooks/useCloudShareAutoSync.ts
+++ b/src/features/cloud-share/hooks/useCloudShareAutoSync.ts
@@ -14,7 +14,7 @@ import { useStorage } from '@/liveblocks.config';
 import { useLayoutStore } from '@/core/store/layout';
 import { updateShare } from '@/core/api/share';
 import { isOk } from '@/core/result';
-import { STAGING_ID } from '@/core/constants';
+import { createLayoutFingerprint } from '@/features/cloud-share/utils';
 
 /** Debounce delay for cloud share updates (1 second) */
 const CLOUD_SYNC_DEBOUNCE_MS = 1000;
@@ -45,14 +45,7 @@ export function useCloudShareAutoSync(shareId: string | null, enabled: boolean):
     // Set syncing flag immediately to prevent race conditions
     isSyncingRef.current = true;
 
-    // Create a fingerprint of the current layout for comparison
-    const layoutFingerprint = JSON.stringify({
-      bins: layout.bins.filter((b) => b.layerId !== STAGING_ID),
-      layers: layout.layers,
-      categories: layout.categories,
-      drawer: layout.drawer,
-      name: layout.name,
-    });
+    const layoutFingerprint = createLayoutFingerprint(layout);
 
     // Skip if nothing changed since last sync
     if (layoutFingerprint === lastSyncedRef.current) {

--- a/src/features/cloud-share/hooks/useOwnedShareSync.ts
+++ b/src/features/cloud-share/hooks/useOwnedShareSync.ts
@@ -16,7 +16,7 @@ import { useLayoutStore } from '@/core/store/layout';
 import { useLibraryStore } from '@/core/store/library';
 import { updateShare } from '@/core/api/share';
 import { isOk } from '@/core/result';
-import { STAGING_ID } from '@/core/constants';
+import { createLayoutFingerprint } from '@/features/cloud-share/utils';
 import type { CloudShareInfo } from '@/core/types';
 
 /** Debounce delay for cloud share updates (5 seconds) */
@@ -59,14 +59,7 @@ export function useOwnedShareSync(): void {
     const { id: shareId, deleteToken } = cloudShare;
     if (!shareId || !deleteToken) return;
 
-    // Create a fingerprint of the current layout for comparison
-    const layoutFingerprint = JSON.stringify({
-      bins: layout.bins.filter((b) => b.layerId !== STAGING_ID),
-      layers: layout.layers,
-      categories: layout.categories,
-      drawer: layout.drawer,
-      name: layout.name,
-    });
+    const layoutFingerprint = createLayoutFingerprint(layout);
 
     // Skip if nothing changed since last sync
     if (layoutFingerprint === lastSyncedRef.current) return;

--- a/src/features/cloud-share/utils/cloudShare.ts
+++ b/src/features/cloud-share/utils/cloudShare.ts
@@ -3,6 +3,9 @@
  * Used by both CloudShareTab and MobileCloudSharePanel.
  */
 
+import type { Layout } from '@/core/types';
+import { STAGING_ID } from '@/core/constants';
+
 /**
  * Format a timestamp as a localized date string.
  */
@@ -11,5 +14,19 @@ export function formatShareDate(timestamp: number): string {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+  });
+}
+
+/**
+ * Create a fingerprint string for a layout to detect changes.
+ * Excludes staging bins since they shouldn't be synced.
+ */
+export function createLayoutFingerprint(layout: Layout): string {
+  return JSON.stringify({
+    bins: layout.bins.filter((b) => b.layerId !== STAGING_ID),
+    layers: layout.layers,
+    categories: layout.categories,
+    drawer: layout.drawer,
+    name: layout.name,
   });
 }

--- a/src/features/cloud-share/utils/index.ts
+++ b/src/features/cloud-share/utils/index.ts
@@ -1,1 +1,1 @@
-export { formatShareDate } from './cloudShare';
+export { formatShareDate, createLayoutFingerprint } from './cloudShare';

--- a/src/test/components/MobileLayoutsPanel.test.tsx
+++ b/src/test/components/MobileLayoutsPanel.test.tsx
@@ -503,7 +503,6 @@ describe('MobileLayoutsPanel', () => {
       updatePermission: vi.fn().mockResolvedValue(true),
       remove: mockRemove,
       copyUrl: mockCopyUrl,
-      copyDeleteToken: vi.fn(),
       reset: mockReset,
     };
 

--- a/src/test/hooks/useCloudShare.test.ts
+++ b/src/test/hooks/useCloudShare.test.ts
@@ -460,43 +460,6 @@ describe('useCloudShare', () => {
     });
   });
 
-  describe('copyDeleteToken', () => {
-    it('copies delete token', async () => {
-      const existingShare: CloudShareInfo = {
-        id: 'share-id',
-        deleteToken: 'secret-token-123',
-        sharedAt: Date.now(),
-        permission: 'view',
-      };
-
-      useLibraryStore.setState({
-        library: createTestLibrary(existingShare),
-      });
-
-      const { result } = renderHook(() => useCloudShare());
-
-      let success: boolean | undefined;
-      await act(async () => {
-        success = await result.current.copyDeleteToken();
-      });
-
-      expect(success).toBe(true);
-      expect(storage.copyToClipboard).toHaveBeenCalledWith('secret-token-123');
-      expect(mockAnnounce).toHaveBeenCalledWith(expect.stringContaining('token copied'));
-    });
-
-    it('returns false when no token available', async () => {
-      const { result } = renderHook(() => useCloudShare());
-
-      let success: boolean | undefined;
-      await act(async () => {
-        success = await result.current.copyDeleteToken();
-      });
-
-      expect(success).toBe(false);
-    });
-  });
-
   describe('reset', () => {
     it('resets state to idle', async () => {
       const { apiNetworkError } = await import('@/core/result');


### PR DESCRIPTION
## Summary
- Remove unused `copyDeleteToken` function and its tests
- Remove unnecessary `getLayoutToShare()` abstraction  
- Simplify complex state tracking in `ShareButton` with cleaner permission pattern
- Fix potential double-call bug in `CloudShareTab` `handlePermissionChange`
- Extract shared `createLayoutFingerprint()` utility for sync hooks

## Test plan
- [x] All tests pass (324 related tests)
- [x] Build succeeds
- [x] Pre-commit hooks pass (lint, boundaries, i18n)
- [x] Bundle size reduced ~0.3KB (main chunk: 582.80kB → 582.51kB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)