### PR TITLE
refactor(bin-designer): remove duplicate logic and unused code

### DIFF
--- a/src/features/bin-designer/components/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor.tsx
@@ -261,142 +261,132 @@ export function CompartmentEditor() {
   const aspectRatio = depth > 0 ? Math.min(2, Math.max(0.5, width / depth)) : 1;
 
   return (
-    <div>
-      <div>
-        <div className="space-y-5">
-          {/* Grid dimensions */}
-          <section>
-            <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-content-tertiary">
-              {t('binDesigner.gridSize')}
-            </h3>
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <span className="mb-1 block text-xs text-content-tertiary">
-                  {t('binDesigner.columns')}
-                </span>
-                <StepperControl
-                  value={cols}
-                  onChange={handleColsChange}
-                  onStep={handleColsStep}
-                  min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID}
-                  max={DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID}
-                  step={1}
-                  variant="compact"
-                  ariaLabel="Columns"
-                />
-              </div>
-              <div>
-                <span className="mb-1 block text-xs text-content-tertiary">
-                  {t('binDesigner.rows')}
-                </span>
-                <StepperControl
-                  value={rows}
-                  onChange={handleRowsChange}
-                  onStep={handleRowsStep}
-                  min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID}
-                  max={DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID}
-                  step={1}
-                  variant="compact"
-                  ariaLabel="Rows"
-                />
-              </div>
-            </div>
-          </section>
-
-          {/* Visual grid editor (hidden for single-cell grids) */}
-          {(cols > 1 || rows > 1) && (
-            <section>
-              <div className="mb-2 flex items-center justify-between">
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-content-tertiary">
-                  {t('binDesigner.layout')}
-                </h3>
-                <div className="flex items-center gap-2">
-                  {hasMergedCompartments && (
-                    <button
-                      type="button"
-                      onClick={handleReset}
-                      className="text-[11px] font-medium text-accent hover:text-accent/80 transition-colors"
-                      aria-label={t('binDesigner.resetCompartmentLayoutToUniformGrid')}
-                    >
-                      {t('common.reset')}
-                    </button>
-                  )}
-                  <span className="text-xs tabular-nums text-content-tertiary">
-                    {t('binDesigner.compartments.count', { count: compartmentCount })}
-                  </span>
-                </div>
-              </div>
-              <p
-                id="compartment-grid-instructions"
-                className={`mb-3 text-xs transition-all ${
-                  isDragging && selectionAction !== 'none'
-                    ? 'text-accent font-medium'
-                    : hoveredIsSplittable
-                      ? 'text-content-secondary'
-                      : 'text-content-tertiary'
-                }`}
-                aria-live={isDragging ? 'off' : 'polite'}
-              >
-                {instructionText}
-              </p>
-              <div
-                ref={gridRef}
-                className="mx-auto max-w-[280px] select-none rounded-lg border border-stroke-subtle bg-surface-elevated p-1.5"
-                style={{ aspectRatio }}
-                role="application"
-                aria-label={`Compartment grid, ${cols} columns by ${rows} rows`}
-                aria-describedby="compartment-grid-instructions"
-                onPointerUp={handlePointerUp}
-                onPointerLeave={() => {
-                  handlePointerUp();
-                  setHoverIdx(null);
-                }}
-              >
-                <div
-                  className="grid h-full w-full"
-                  style={{
-                    gridTemplateColumns: `repeat(${cols}, 1fr)`,
-                    gridTemplateRows: `repeat(${rows}, 1fr)`,
-                    gap: '1px',
-                  }}
-                >
-                  {cells.map((compartmentId, idx) => (
-                    <GridCell
-                      key={idx}
-                      idx={idx}
-                      compartmentId={compartmentId}
-                      isSelected={selection.has(idx)}
-                      isHovered={hoverIdx === idx && !isDragging}
-                      isSplittable={
-                        !isDragging && (compartmentCellCounts.get(compartmentId) ?? 0) > 1
-                      }
-                      isDragging={isDragging}
-                      config={compartments}
-                      onPointerDown={handleCellPointerDown}
-                      onPointerEnter={handleCellPointerEnter}
-                      onPointerLeave={handleCellPointerLeave}
-                    />
-                  ))}
-                </div>
-              </div>
-            </section>
-          )}
-
-          {/* Wall thickness (only when there are dividers) */}
-          {compartmentCount > 1 && (
-            <section>
-              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-content-tertiary">
-                {t('binDesigner.dividerWalls')}
-              </h3>
-              <ThicknessSelector
-                label="Thickness"
-                value={thickness}
-                onChange={handleThicknessChange}
-              />
-            </section>
-          )}
+    <div className="space-y-5">
+      {/* Grid dimensions */}
+      <section>
+        <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-content-tertiary">
+          {t('binDesigner.gridSize')}
+        </h3>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <span className="mb-1 block text-xs text-content-tertiary">
+              {t('binDesigner.columns')}
+            </span>
+            <StepperControl
+              value={cols}
+              onChange={handleColsChange}
+              onStep={handleColsStep}
+              min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID}
+              max={DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID}
+              step={1}
+              variant="compact"
+              ariaLabel="Columns"
+            />
+          </div>
+          <div>
+            <span className="mb-1 block text-xs text-content-tertiary">
+              {t('binDesigner.rows')}
+            </span>
+            <StepperControl
+              value={rows}
+              onChange={handleRowsChange}
+              onStep={handleRowsStep}
+              min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID}
+              max={DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID}
+              step={1}
+              variant="compact"
+              ariaLabel="Rows"
+            />
+          </div>
         </div>
-      </div>
+      </section>
+
+      {/* Visual grid editor (hidden for single-cell grids) */}
+      {(cols > 1 || rows > 1) && (
+        <section>
+          <div className="mb-2 flex items-center justify-between">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-content-tertiary">
+              {t('binDesigner.layout')}
+            </h3>
+            <div className="flex items-center gap-2">
+              {hasMergedCompartments && (
+                <button
+                  type="button"
+                  onClick={handleReset}
+                  className="text-[11px] font-medium text-accent hover:text-accent/80 transition-colors"
+                  aria-label={t('binDesigner.resetCompartmentLayoutToUniformGrid')}
+                >
+                  {t('common.reset')}
+                </button>
+              )}
+              <span className="text-xs tabular-nums text-content-tertiary">
+                {t('binDesigner.compartments.count', { count: compartmentCount })}
+              </span>
+            </div>
+          </div>
+          <p
+            id="compartment-grid-instructions"
+            className={`mb-3 text-xs transition-all ${
+              isDragging && selectionAction !== 'none'
+                ? 'text-accent font-medium'
+                : hoveredIsSplittable
+                  ? 'text-content-secondary'
+                  : 'text-content-tertiary'
+            }`}
+            aria-live={isDragging ? 'off' : 'polite'}
+          >
+            {instructionText}
+          </p>
+          <div
+            ref={gridRef}
+            className="mx-auto max-w-[280px] select-none rounded-lg border border-stroke-subtle bg-surface-elevated p-1.5"
+            style={{ aspectRatio }}
+            role="application"
+            aria-label={`Compartment grid, ${cols} columns by ${rows} rows`}
+            aria-describedby="compartment-grid-instructions"
+            onPointerUp={handlePointerUp}
+            onPointerLeave={() => {
+              handlePointerUp();
+              setHoverIdx(null);
+            }}
+          >
+            <div
+              className="grid h-full w-full"
+              style={{
+                gridTemplateColumns: `repeat(${cols}, 1fr)`,
+                gridTemplateRows: `repeat(${rows}, 1fr)`,
+                gap: '1px',
+              }}
+            >
+              {cells.map((compartmentId, idx) => (
+                <GridCell
+                  key={idx}
+                  idx={idx}
+                  compartmentId={compartmentId}
+                  isSelected={selection.has(idx)}
+                  isHovered={hoverIdx === idx && !isDragging}
+                  isSplittable={!isDragging && (compartmentCellCounts.get(compartmentId) ?? 0) > 1}
+                  isDragging={isDragging}
+                  config={compartments}
+                  onPointerDown={handleCellPointerDown}
+                  onPointerEnter={handleCellPointerEnter}
+                  onPointerLeave={handleCellPointerLeave}
+                />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Wall thickness (only when there are dividers) */}
+      {compartmentCount > 1 && (
+        <section>
+          <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-content-tertiary">
+            {t('binDesigner.dividerWalls')}
+          </h3>
+          <ThicknessSelector label="Thickness" value={thickness} onChange={handleThicknessChange} />
+        </section>
+      )}
     </div>
   );
 }

--- a/src/features/bin-designer/components/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage.tsx
@@ -31,11 +31,6 @@ import { upsertRegistryEntry } from '@/features/bin-designer/store/customBinRegi
 import type { SaveStatus } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
 
-interface DesignerPageProps {
-  /** Unused - navigation is handled by ToolSwitcher */
-  onNavigateBack?: () => void;
-}
-
 /** CSS class for each save status */
 const SAVE_STATUS_CLASSES: Record<Exclude<SaveStatus, 'idle'>, string> = {
   saving: 'text-content-tertiary',
@@ -127,7 +122,7 @@ function SaveStatusIndicator({ status }: { status: SaveStatus }) {
  * @param onNavigateBack - Callback invoked when the user requests navigation back to the layout planner.
  * @returns The rendered Designer page element.
  */
-export function DesignerPage(_props: DesignerPageProps) {
+export function DesignerPage() {
   // Initialize generation bridge - auto-generates mesh when params change
   useGeneration();
 

--- a/src/features/bin-designer/store/designer.ts
+++ b/src/features/bin-designer/store/designer.ts
@@ -33,7 +33,10 @@ import {
 import { isErr } from '@/core/result';
 import { DEFAULT_EXPORT_FILE_NAME_CONFIG } from '../utils/fileNaming';
 import { isFractional } from '@/core/constants';
-import { isRectangularSelection, normalizeIds } from '../utils/compartments';
+import {
+  mergeCells as mergeCompartmentCells,
+  splitCompartment as splitCompartmentCells,
+} from '../utils/compartments';
 import { validateCompartmentSizes } from '../utils/validation';
 import { createCachedMesh, evictIfNeeded } from './meshCacheManager';
 
@@ -181,7 +184,9 @@ export const useDesignerStore = create<DesignerState>()(
         state.params = migrateParams(design.params);
         state.currentDesignId = design.id;
         state.designName = design.name;
-        state.exportFileNameConfig = design.exportFileNameConfig ?? { ...DEFAULT_EXPORT_FILE_NAME_CONFIG };
+        state.exportFileNameConfig = design.exportFileNameConfig ?? {
+          ...DEFAULT_EXPORT_FILE_NAME_CONFIG,
+        };
         state.history = { past: [], future: [] };
         state.saveStatus = 'saved';
         state.generation.epoch += 1;
@@ -300,23 +305,13 @@ export const useDesignerStore = create<DesignerState>()(
     mergeCells: (cellIndices: readonly number[]) => {
       if (cellIndices.length < 2) return;
       const { params } = get();
-      const { cols } = params.compartments;
 
-      if (!isRectangularSelection(cols, cellIndices)) return;
-
-      const existingIds = cellIndices.map((i) => params.compartments.cells[i]);
-      const targetId = Math.min(...existingIds);
+      const merged = mergeCompartmentCells(params.compartments, cellIndices);
+      if (!merged) return;
 
       set((state) => {
         pushHistoryEntry(state);
-        const newCells = [...state.params.compartments.cells];
-        for (const idx of cellIndices) {
-          newCells[idx] = targetId;
-        }
-        state.params.compartments = {
-          ...state.params.compartments,
-          cells: normalizeIds(newCells),
-        };
+        state.params.compartments = merged;
       });
     },
 
@@ -335,22 +330,7 @@ export const useDesignerStore = create<DesignerState>()(
 
       set((state) => {
         pushHistoryEntry(state);
-        const newCells = [...state.params.compartments.cells];
-        let nextId = Math.max(...newCells) + 1;
-        let first = true;
-        for (let i = 0; i < newCells.length; i++) {
-          if (newCells[i] === compartmentId) {
-            if (first) {
-              first = false;
-            } else {
-              newCells[i] = nextId++;
-            }
-          }
-        }
-        state.params.compartments = {
-          ...state.params.compartments,
-          cells: normalizeIds(newCells),
-        };
+        state.params.compartments = splitCompartmentCells(state.params.compartments, compartmentId);
       });
     },
 


### PR DESCRIPTION
## Summary
- Reuse `mergeCompartmentCells` and `splitCompartmentCells` utility functions in the designer store instead of duplicating the compartment manipulation logic inline
- Remove unnecessary nested wrapper `<div>` elements in CompartmentEditor
- Remove unused `DesignerPageProps` interface and `_props` parameter from DesignerPage

## Test plan
- [x] TypeScript build passes
- [x] All 5,093 tests pass
- [x] Affected bin-designer tests verified (212 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)