### PR TITLE
refactor(grid-editor): extract shared toPixels utility and simplify code

### DIFF
--- a/src/features/grid-editor/components/Grid/Bin.tsx
+++ b/src/features/grid-editor/components/Grid/Bin.tsx
@@ -851,13 +851,14 @@ function BinComponent({
  * Only re-render if props that affect visual appearance change.
  */
 function binPropsAreEqual(prevProps: BinProps, nextProps: BinProps): boolean {
-  // Always re-render if selection state changes
+  const { bin: prevBin, category: prevCat, layer: prevLayer, drawer: prevDrawer } = prevProps;
+  const { bin: nextBin, category: nextCat, layer: nextLayer, drawer: nextDrawer } = nextProps;
+
+  // Selection/ghost state
   if (prevProps.isSelected !== nextProps.isSelected) return false;
   if (prevProps.isGhost !== nextProps.isGhost) return false;
 
-  // Re-render if bin data changes
-  const prevBin = prevProps.bin;
-  const nextBin = nextProps.bin;
+  // Bin visual properties
   if (
     prevBin.id !== nextBin.id ||
     prevBin.x !== nextBin.x ||
@@ -872,55 +873,35 @@ function binPropsAreEqual(prevProps: BinProps, nextProps: BinProps): boolean {
     return false;
   }
 
-  // Re-render if customProperties change (compare keys and values)
-  const prevCustomProps = prevBin.customProperties;
-  const nextCustomProps = nextBin.customProperties;
-  const prevHasProps = prevCustomProps && Object.keys(prevCustomProps).length > 0;
-  const nextHasProps = nextCustomProps && Object.keys(nextCustomProps).length > 0;
-  if (prevHasProps !== nextHasProps) {
-    return false;
-  }
-  if (prevHasProps && nextHasProps) {
-    const prevKeys = Object.keys(prevCustomProps);
-    const nextKeys = Object.keys(nextCustomProps);
+  // Custom properties - shallow object comparison
+  const prevCustom = prevBin.customProperties;
+  const nextCustom = nextBin.customProperties;
+  if (prevCustom !== nextCustom) {
+    const prevKeys = prevCustom ? Object.keys(prevCustom) : [];
+    const nextKeys = nextCustom ? Object.keys(nextCustom) : [];
     if (prevKeys.length !== nextKeys.length) return false;
-    for (const key of prevKeys) {
-      if (prevCustomProps[key] !== nextCustomProps[key]) return false;
+    if (prevCustom && nextCustom) {
+      for (const key of prevKeys) {
+        if (prevCustom[key] !== nextCustom[key]) return false;
+      }
     }
   }
 
-  // Re-render if category changes
+  // Category/layer/drawer - only compare visual-affecting properties
+  if (prevCat?.id !== nextCat?.id || prevCat?.color !== nextCat?.color) return false;
+  if (prevLayer?.id !== nextLayer?.id || prevLayer?.height !== nextLayer?.height) return false;
   if (
-    prevProps.category?.id !== nextProps.category?.id ||
-    prevProps.category?.color !== nextProps.category?.color
+    prevDrawer.width !== nextDrawer.width ||
+    prevDrawer.depth !== nextDrawer.depth ||
+    prevDrawer.fractionalEdgeX !== nextDrawer.fractionalEdgeX ||
+    prevDrawer.fractionalEdgeY !== nextDrawer.fractionalEdgeY
   ) {
     return false;
   }
 
-  // Re-render if layer changes
-  if (
-    prevProps.layer?.id !== nextProps.layer?.id ||
-    prevProps.layer?.height !== nextProps.layer?.height
-  ) {
-    return false;
-  }
+  // Cell sizing
+  if (prevProps.cellSize !== nextProps.cellSize || prevProps.gap !== nextProps.gap) return false;
 
-  // Re-render if drawer dimensions or edge configuration changes
-  if (
-    prevProps.drawer.width !== nextProps.drawer.width ||
-    prevProps.drawer.depth !== nextProps.drawer.depth ||
-    prevProps.drawer.fractionalEdgeX !== nextProps.drawer.fractionalEdgeX ||
-    prevProps.drawer.fractionalEdgeY !== nextProps.drawer.fractionalEdgeY
-  ) {
-    return false;
-  }
-
-  // Re-render if cellSize or gap changes (affects sizing)
-  if (prevProps.cellSize !== nextProps.cellSize || prevProps.gap !== nextProps.gap) {
-    return false;
-  }
-
-  // Callbacks are stable (from useCallback), so we don't compare them
   return true;
 }
 

--- a/src/features/grid-editor/components/Grid/GridCanvas.tsx
+++ b/src/features/grid-editor/components/Grid/GridCanvas.tsx
@@ -3,8 +3,8 @@ import { useMemo } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { useUIStore, useLayoutStore } from '@/core/store';
 import { useGridCoords, useGridTemplate } from '@/features/grid-editor/hooks';
+import { toPixels } from '@/features/grid-editor/utils/fractionalPixels';
 import { Bin } from './Bin';
-
 import { getBlockedZones } from '@/shared/utils/collision';
 import { DEFAULT_CATEGORY_COLOR } from '@/core/constants';
 import type { Coord, ResizeHandle } from '@/core/types';
@@ -301,9 +301,12 @@ export function GridCanvas({
           const hasFractionalDims =
             zone.x % 1 !== 0 || zone.y % 1 !== 0 || zone.width % 1 !== 0 || zone.depth % 1 !== 0;
           // Calculate true pixel size for fractional zones
-          const toPixels = (units: number) => units * cellSize + Math.max(0, units - 1) * gap;
-          const zonePixelWidth = hasFractionalDims ? toPixels(zone.width) : undefined;
-          const zonePixelHeight = hasFractionalDims ? toPixels(zone.depth) : undefined;
+          const zonePixelWidth = hasFractionalDims
+            ? toPixels(zone.width, cellSize, gap)
+            : undefined;
+          const zonePixelHeight = hasFractionalDims
+            ? toPixels(zone.depth, cellSize, gap)
+            : undefined;
           // Calculate pixel offset for fractional positions
           const fractionalX = zone.x - Math.floor(zone.x);
           const fractionalYFromTop = Math.ceil(zone.y + zone.depth) - (zone.y + zone.depth);

--- a/src/features/grid-editor/components/Grid/IsometricPreview.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview.tsx
@@ -185,14 +185,8 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
 
       const zStart = getLayerZStart(bin.layerId, layers) * heightToGridScale;
       const category = categoryMap.get(bin.category);
-      const baseColor = category?.color || DEFAULT_CATEGORY_COLOR;
+      const color = category?.color || DEFAULT_CATEGORY_COLOR;
 
-      // No dimming needed since focus mode now hides other layers entirely
-      const color = baseColor;
-
-      // Y-axis: In grid, y=0 is front (bottom), y increases toward back (top)
-      // In 3D: Y=0 is front (toward camera), Y increases away (toward back)
-      // Direct mapping - no flip needed
       result.push({
         bin,
         x: bin.x,

--- a/src/features/grid-editor/components/Grid/Overlay.tsx
+++ b/src/features/grid-editor/components/Grid/Overlay.tsx
@@ -3,6 +3,7 @@ import { useShallow } from 'zustand/shallow';
 import { useLayoutStore, useInteractionStore, useHalfBinModeStore } from '@/core/store';
 import {
   calcFractionalPixelSize,
+  toPixels,
   type FractionalGridContext,
 } from '@/features/grid-editor/utils/fractionalPixels';
 import { useTranslation } from '@/i18n';
@@ -13,11 +14,6 @@ interface OverlayProps {
   gap: number;
 }
 
-/**
- * Draw/drag/resize preview overlay.
- * Shows amber dashed border for draw, green/red for drag/resize.
- * Supports multi-bin drag and resize previews.
- */
 /**
  * Floating indicator component that shows why placement is invalid.
  * Positioned relative to the preview rectangle.
@@ -78,6 +74,11 @@ function PlacementIndicator({
   );
 }
 
+/**
+ * Draw/drag/resize preview overlay.
+ * Shows amber dashed border for draw, green/red for drag/resize.
+ * Supports multi-bin drag and resize previews.
+ */
 export function Overlay({ cellSize, gap }: OverlayProps) {
   // Performance: Use focused stores directly instead of facade
   const interaction = useInteractionStore((state) => state.interaction);
@@ -121,7 +122,7 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
   };
 
   // Helper to calculate pixel dimension for grid elements (standard calculation)
-  const toPixels = (units: number) => units * visualCellSize + Math.max(0, units - 1) * gap;
+  const calcPixels = (units: number) => toPixels(units, visualCellSize, gap);
 
   // Calculate pixel width/height accounting for fractional edges
   const calcPixelWidth = (x: number, width: number) => calcFractionalPixelSize(x, width, widthCtx);
@@ -381,8 +382,8 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
 
       const left = calcLeft(currentRect.x);
       const top = calcTop(currentRect.y, currentRect.depth);
-      const rectWidth = toPixels(currentRect.width);
-      const rectHeight = toPixels(currentRect.depth);
+      const rectWidth = calcPixels(currentRect.width);
+      const rectHeight = calcPixels(currentRect.depth);
 
       // Track first preview position for indicator
       if (isFirstBin) {
@@ -401,8 +402,8 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
       if (sizeChanged) {
         const origLeft = calcLeft(originalBin.x);
         const origTop = calcTop(originalBin.y, originalBin.depth);
-        const origWidth = toPixels(originalBin.width);
-        const origHeight = toPixels(originalBin.depth);
+        const origWidth = calcPixels(originalBin.width);
+        const origHeight = calcPixels(originalBin.depth);
 
         previews.push(
           <div
@@ -465,8 +466,8 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
 
       const left = calcLeft(currentCoord.x);
       const top = calcTop(currentCoord.y, bin.depth);
-      const rectWidth = toPixels(bin.width);
-      const rectHeight = toPixels(bin.depth);
+      const rectWidth = calcPixels(bin.width);
+      const rectHeight = calcPixels(bin.depth);
 
       previews.push(
         <div
@@ -522,8 +523,8 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
     // Outer selection area (amber dashed like draw)
     const areaLeft = calcLeft(x1);
     const areaTop = calcTop(y1, areaDepth);
-    const areaPixelWidth = toPixels(areaWidth);
-    const areaPixelHeight = toPixels(areaDepth);
+    const areaPixelWidth = calcPixels(areaWidth);
+    const areaPixelHeight = calcPixels(areaDepth);
 
     previews.push(
       <div
@@ -550,8 +551,8 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
 
           const left = calcLeft(binX);
           const top = calcTop(binY, paintSize.depth);
-          const rectWidth = toPixels(paintSize.width);
-          const rectHeight = toPixels(paintSize.depth);
+          const rectWidth = calcPixels(paintSize.width);
+          const rectHeight = calcPixels(paintSize.depth);
 
           previews.push(
             <div
@@ -580,8 +581,8 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
 
         const stripLeft = calcLeft(stripX);
         const stripTop = calcTop(y1, usedDepth);
-        const stripWidth = toPixels(remainderWidth);
-        const stripHeight = toPixels(usedDepth);
+        const stripWidth = calcPixels(remainderWidth);
+        const stripHeight = calcPixels(usedDepth);
 
         previews.push(
           <div
@@ -605,8 +606,8 @@ export function Overlay({ cellSize, gap }: OverlayProps) {
 
         const stripLeft = calcLeft(x1);
         const stripTop = calcTop(stripY, remainderDepth);
-        const stripWidth = toPixels(areaWidth);
-        const stripHeight = toPixels(remainderDepth);
+        const stripWidth = calcPixels(areaWidth);
+        const stripHeight = calcPixels(remainderDepth);
 
         previews.push(
           <div

--- a/src/features/grid-editor/hooks/useGridCoords.ts
+++ b/src/features/grid-editor/hooks/useGridCoords.ts
@@ -44,7 +44,6 @@ import { useResponsive } from '@/shared/hooks';
  *   - `isInBounds(coord)` - Check if coordinates are within grid bounds
  *   - `cellSize` - Current cell size in pixels (accounts for zoom)
  *   - `halfBinMode` - Whether half-bin mode is active
- *   - `visualCellSize` - Size of each visual cell (half of cellSize when halfBinMode active)
  *
  * @example
  * ```tsx
@@ -72,9 +71,6 @@ export function useGridCoords(gridRef: RefObject<HTMLDivElement | null>) {
   // Base cell size at current zoom (represents 1 grid unit)
   const cellSize = Math.round(getBaseCellSize(viewportWidth) * zoom);
   const gap = 1; // 1px gap between cells
-
-  // Visual cell size (same as cellSize since grid is always standard)
-  const visualCellSize = cellSize;
 
   const getGridCoords = useCallback(
     (clientX: number, clientY: number): Coord | null => {
@@ -271,6 +267,5 @@ export function useGridCoords(gridRef: RefObject<HTMLDivElement | null>) {
     isInBounds,
     cellSize,
     halfBinMode,
-    visualCellSize,
   };
 }

--- a/src/features/grid-editor/utils/fractionalPixels.ts
+++ b/src/features/grid-editor/utils/fractionalPixels.ts
@@ -11,6 +11,19 @@
  */
 
 /**
+ * Convert grid units to pixels, accounting for gaps between cells.
+ * Standard calculation used throughout grid rendering.
+ *
+ * @param units - Size in grid units
+ * @param cellSize - Cell size in pixels
+ * @param gap - Gap between cells in pixels
+ * @returns Pixel size
+ */
+export function toPixels(units: number, cellSize: number, gap: number): number {
+  return units * cellSize + Math.max(0, units - 1) * gap;
+}
+
+/**
  * Epsilon for floating-point gap count calculation.
  * Prevents Math.floor from under-counting due to values like 1.9999999999.
  */

--- a/src/features/grid-editor/utils/index.ts
+++ b/src/features/grid-editor/utils/index.ts
@@ -1,4 +1,4 @@
-export { calcFractionalPixelSize, type FractionalGridContext } from './fractionalPixels';
+export { calcFractionalPixelSize, toPixels, type FractionalGridContext } from './fractionalPixels';
 
 export {
   isCornerHandle,


### PR DESCRIPTION
## Summary
- Extract shared `toPixels(units, cellSize, gap)` helper to `fractionalPixels.ts` to eliminate duplication across Overlay.tsx and GridCanvas.tsx
- Simplify `binPropsAreEqual` memo comparison function in Bin.tsx using destructuring (75→53 lines)
- Remove unused `visualCellSize` variable from useGridCoords hook
- Remove redundant variable assignment in IsometricPreview.tsx

## Test plan
- [x] TypeScript build passes
- [x] All 5,093 tests pass
- [x] Affected tests verified (394 tests in related files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)