### PR TITLE
refactor(inspiration-gallery): remove unused features and complexity tracking

### DIFF
--- a/src/features/inspiration-gallery/__tests__/layoutBuilder.test.ts
+++ b/src/features/inspiration-gallery/__tests__/layoutBuilder.test.ts
@@ -4,7 +4,6 @@ import {
   createLayer,
   createCategory,
   computePreview,
-  detectFeatures,
   calculateMetrics,
   buildInspirationLayout,
 } from '../utils/layoutBuilder';
@@ -337,340 +336,6 @@ describe('layoutBuilder', () => {
     });
   });
 
-  describe('detectFeatures', () => {
-    it('detects multiple-layers feature', () => {
-      const layout = createTestLayout({
-        layers: [
-          { id: 'l1', name: 'Layer 1', height: 3 },
-          { id: 'l2', name: 'Layer 2', height: 3 },
-        ],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).toContain('multiple-layers');
-    });
-
-    it('does not detect multiple-layers for single layer', () => {
-      const layout = createTestLayout({
-        layers: [{ id: 'l1', name: 'Layer 1', height: 3 }],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).not.toContain('multiple-layers');
-    });
-
-    it('detects half-bins feature for fractional x', () => {
-      const layout = createTestLayout({
-        bins: [
-          {
-            id: 'b1',
-            x: 0.5,
-            y: 0,
-            width: 1,
-            depth: 1,
-            height: 3,
-            layerId: 'layer-1',
-            category: 'cat-1',
-            label: '',
-            notes: '',
-          },
-        ],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).toContain('half-bins');
-    });
-
-    it('detects half-bins feature for fractional y', () => {
-      const layout = createTestLayout({
-        bins: [
-          {
-            id: 'b1',
-            x: 0,
-            y: 1.5,
-            width: 1,
-            depth: 1,
-            height: 3,
-            layerId: 'layer-1',
-            category: 'cat-1',
-            label: '',
-            notes: '',
-          },
-        ],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).toContain('half-bins');
-    });
-
-    it('detects half-bins feature for fractional width', () => {
-      const layout = createTestLayout({
-        bins: [
-          {
-            id: 'b1',
-            x: 0,
-            y: 0,
-            width: 1.5,
-            depth: 1,
-            height: 3,
-            layerId: 'layer-1',
-            category: 'cat-1',
-            label: '',
-            notes: '',
-          },
-        ],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).toContain('half-bins');
-    });
-
-    it('detects half-bins feature for fractional depth', () => {
-      const layout = createTestLayout({
-        bins: [
-          {
-            id: 'b1',
-            x: 0,
-            y: 0,
-            width: 1,
-            depth: 2.5,
-            height: 3,
-            layerId: 'layer-1',
-            category: 'cat-1',
-            label: '',
-            notes: '',
-          },
-        ],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).toContain('half-bins');
-    });
-
-    it('does not detect half-bins for whole numbers', () => {
-      const layout = createTestLayout({
-        bins: [
-          {
-            id: 'b1',
-            x: 0,
-            y: 0,
-            width: 2,
-            depth: 3,
-            height: 3,
-            layerId: 'layer-1',
-            category: 'cat-1',
-            label: '',
-            notes: '',
-          },
-        ],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).not.toContain('half-bins');
-    });
-
-    it('detects labeled-bins feature', () => {
-      const layout = createTestLayout({
-        bins: [
-          {
-            id: 'b1',
-            x: 0,
-            y: 0,
-            width: 1,
-            depth: 1,
-            height: 3,
-            layerId: 'layer-1',
-            category: 'cat-1',
-            label: 'Screws',
-            notes: '',
-          },
-        ],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).toContain('labeled-bins');
-    });
-
-    it('does not detect labeled-bins for empty labels', () => {
-      const layout = createTestLayout({
-        bins: [
-          {
-            id: 'b1',
-            x: 0,
-            y: 0,
-            width: 1,
-            depth: 1,
-            height: 3,
-            layerId: 'layer-1',
-            category: 'cat-1',
-            label: '',
-            notes: '',
-          },
-        ],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).not.toContain('labeled-bins');
-    });
-
-    it('does not detect labeled-bins for whitespace-only labels', () => {
-      const layout = createTestLayout({
-        bins: [
-          {
-            id: 'b1',
-            x: 0,
-            y: 0,
-            width: 1,
-            depth: 1,
-            height: 3,
-            layerId: 'layer-1',
-            category: 'cat-1',
-            label: '   ',
-            notes: '',
-          },
-        ],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).not.toContain('labeled-bins');
-    });
-
-    it('detects clearance-height feature', () => {
-      const layout = createTestLayout({
-        bins: [
-          {
-            id: 'b1',
-            x: 0,
-            y: 0,
-            width: 1,
-            depth: 1,
-            height: 3,
-            layerId: 'layer-1',
-            category: 'cat-1',
-            label: '',
-            notes: '',
-            clearanceHeight: 5,
-          },
-        ],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).toContain('clearance-height');
-    });
-
-    it('does not detect clearance-height for zero value', () => {
-      const layout = createTestLayout({
-        bins: [
-          {
-            id: 'b1',
-            x: 0,
-            y: 0,
-            width: 1,
-            depth: 1,
-            height: 3,
-            layerId: 'layer-1',
-            category: 'cat-1',
-            label: '',
-            notes: '',
-            clearanceHeight: 0,
-          },
-        ],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).not.toContain('clearance-height');
-    });
-
-    it('detects multiple-categories for 3+ categories', () => {
-      const layout = createTestLayout({
-        categories: [
-          { id: 'c1', name: 'Cat 1', color: '#ff0000' },
-          { id: 'c2', name: 'Cat 2', color: '#00ff00' },
-          { id: 'c3', name: 'Cat 3', color: '#0000ff' },
-        ],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).toContain('multiple-categories');
-    });
-
-    it('does not detect multiple-categories for 2 or fewer', () => {
-      const layout = createTestLayout({
-        categories: [
-          { id: 'c1', name: 'Cat 1', color: '#ff0000' },
-          { id: 'c2', name: 'Cat 2', color: '#00ff00' },
-        ],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).not.toContain('multiple-categories');
-    });
-
-    it('detects multiple features at once', () => {
-      const layout = createTestLayout({
-        layers: [
-          { id: 'l1', name: 'Layer 1', height: 3 },
-          { id: 'l2', name: 'Layer 2', height: 3 },
-        ],
-        categories: [
-          { id: 'c1', name: 'Cat 1', color: '#ff0000' },
-          { id: 'c2', name: 'Cat 2', color: '#00ff00' },
-          { id: 'c3', name: 'Cat 3', color: '#0000ff' },
-        ],
-        bins: [
-          {
-            id: 'b1',
-            x: 0.5,
-            y: 0,
-            width: 1,
-            depth: 1,
-            height: 3,
-            layerId: 'l1',
-            category: 'c1',
-            label: 'Test',
-            notes: '',
-            clearanceHeight: 2,
-          },
-        ],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).toContain('multiple-layers');
-      expect(features).toContain('half-bins');
-      expect(features).toContain('labeled-bins');
-      expect(features).toContain('clearance-height');
-      expect(features).toContain('multiple-categories');
-      expect(features).toHaveLength(5);
-    });
-
-    it('returns empty array for layout with no special features', () => {
-      const layout = createTestLayout({
-        layers: [{ id: 'l1', name: 'Layer 1', height: 3 }],
-        categories: [{ id: 'c1', name: 'Cat 1', color: '#ff0000' }],
-        bins: [],
-      });
-
-      const features = detectFeatures(layout);
-
-      expect(features).toHaveLength(0);
-    });
-  });
-
   describe('calculateMetrics', () => {
     it('counts bins excluding staging', () => {
       const layout = createTestLayout({
@@ -862,7 +527,6 @@ describe('layoutBuilder', () => {
         theme: 'workshop',
         description: 'A detailed description',
         shortDescription: 'A short desc',
-        complexity: 'intermediate',
         tags: ['tools', 'workshop'],
       });
 
@@ -871,46 +535,8 @@ describe('layoutBuilder', () => {
       expect(result.theme).toBe('workshop');
       expect(result.description).toBe('A detailed description');
       expect(result.shortDescription).toBe('A short desc');
-      expect(result.complexity).toBe('intermediate');
       expect(result.tags).toEqual(['tools', 'workshop']);
       expect(result.layout).toBe(layout);
-    });
-
-    it('auto-detects features', () => {
-      const layout = createTestLayout({
-        layers: [
-          { id: 'l1', name: 'Layer 1', height: 3 },
-          { id: 'l2', name: 'Layer 2', height: 3 },
-        ],
-        bins: [
-          {
-            id: 'b1',
-            x: 0.5,
-            y: 0,
-            width: 1,
-            depth: 1,
-            height: 3,
-            layerId: 'l1',
-            category: 'cat-1',
-            label: 'Labeled',
-            notes: '',
-          },
-        ],
-      });
-
-      const result = buildInspirationLayout(layout, {
-        id: 'test',
-        name: 'Test',
-        theme: 'hobby',
-        description: 'Desc',
-        shortDescription: 'Short',
-        complexity: 'beginner',
-        tags: [],
-      });
-
-      expect(result.features).toContain('multiple-layers');
-      expect(result.features).toContain('half-bins');
-      expect(result.features).toContain('labeled-bins');
     });
 
     it('calculates metrics correctly', () => {
@@ -955,7 +581,6 @@ describe('layoutBuilder', () => {
         theme: 'kitchen',
         description: 'Desc',
         shortDescription: 'Short',
-        complexity: 'beginner',
         tags: [],
       });
 
@@ -991,7 +616,6 @@ describe('layoutBuilder', () => {
         theme: 'office',
         description: 'Desc',
         shortDescription: 'Short',
-        complexity: 'beginner',
         tags: [],
       });
 

--- a/src/features/inspiration-gallery/__tests__/types.test.ts
+++ b/src/features/inspiration-gallery/__tests__/types.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { THEME_CONFIG, FEATURE_CONFIG } from '../types';
-import type { InspirationTheme, LayoutFeature } from '../types';
+import { THEME_CONFIG } from '../types';
+import type { InspirationTheme } from '../types';
 
 describe('types', () => {
   describe('THEME_CONFIG', () => {
@@ -24,16 +24,8 @@ describe('types', () => {
       const config = THEME_CONFIG[theme];
 
       expect(config).toHaveProperty('label');
-      expect(config).toHaveProperty('icon');
-      expect(config).toHaveProperty('description');
-
       expect(typeof config.label).toBe('string');
-      expect(typeof config.icon).toBe('string');
-      expect(typeof config.description).toBe('string');
-
       expect(config.label.length).toBeGreaterThan(0);
-      expect(config.icon.length).toBeGreaterThan(0);
-      expect(config.description.length).toBeGreaterThan(0);
     });
 
     it('has correct labels for each theme', () => {
@@ -48,65 +40,6 @@ describe('types', () => {
       const labels = Object.values(THEME_CONFIG).map((c) => c.label);
       const uniqueLabels = new Set(labels);
       expect(uniqueLabels.size).toBe(labels.length);
-    });
-
-    it('has unique icons', () => {
-      const icons = Object.values(THEME_CONFIG).map((c) => c.icon);
-      const uniqueIcons = new Set(icons);
-      expect(uniqueIcons.size).toBe(icons.length);
-    });
-  });
-
-  describe('FEATURE_CONFIG', () => {
-    const expectedFeatures: LayoutFeature[] = [
-      'multiple-layers',
-      'half-bins',
-      'labeled-bins',
-      'clearance-height',
-      'multiple-categories',
-    ];
-
-    it('has all 5 features', () => {
-      const features = Object.keys(FEATURE_CONFIG);
-      expect(features).toHaveLength(5);
-      expectedFeatures.forEach((feature) => {
-        expect(features).toContain(feature);
-      });
-    });
-
-    it.each(expectedFeatures)('feature "%s" has required fields', (feature) => {
-      const config = FEATURE_CONFIG[feature];
-
-      expect(config).toHaveProperty('label');
-      expect(config).toHaveProperty('description');
-
-      expect(typeof config.label).toBe('string');
-      expect(typeof config.description).toBe('string');
-
-      expect(config.label.length).toBeGreaterThan(0);
-      expect(config.description.length).toBeGreaterThan(0);
-    });
-
-    it('has user-friendly labels', () => {
-      expect(FEATURE_CONFIG['multiple-layers'].label).toBe('Multi-layer');
-      expect(FEATURE_CONFIG['half-bins'].label).toBe('Half-bins');
-      expect(FEATURE_CONFIG['labeled-bins'].label).toBe('Labeled');
-      expect(FEATURE_CONFIG['clearance-height'].label).toBe('Clearance');
-      expect(FEATURE_CONFIG['multiple-categories'].label).toBe('Categories');
-    });
-
-    it('has unique labels', () => {
-      const labels = Object.values(FEATURE_CONFIG).map((c) => c.label);
-      const uniqueLabels = new Set(labels);
-      expect(uniqueLabels.size).toBe(labels.length);
-    });
-
-    it('has descriptive descriptions', () => {
-      // Each description should be a full sentence (has spaces and reasonable length)
-      Object.values(FEATURE_CONFIG).forEach((config) => {
-        expect(config.description.includes(' ')).toBe(true);
-        expect(config.description.length).toBeGreaterThan(15);
-      });
     });
   });
 });

--- a/src/features/inspiration-gallery/data/themes/hobby.ts
+++ b/src/features/inspiration-gallery/data/themes/hobby.ts
@@ -95,7 +95,6 @@ function create3DPrintingSupplies(): InspirationLayout {
     description:
       'Heat inserts sorted by size (M3-M5), magnets, 608/625 bearings, and filament samples. Includes nozzles and finishing supplies.',
     shortDescription: 'Heat inserts, magnets, bearings, and filament',
-    complexity: 'intermediate',
     tags: ['hobby', '3d-printing', 'filament', 'maker', 'ikea-alex'],
   });
 }
@@ -197,7 +196,6 @@ function createMakerStation(): InspirationLayout {
     description:
       'Arduino, ESP32, Wemos D1, Raspberry Pi, and microcontroller organization. Includes slots for sensors, breadboards, jumper wires, and SD cards.',
     shortDescription: 'Arduino, ESP32, Wemos D1, and maker supplies',
-    complexity: 'intermediate',
     tags: ['hobby', 'arduino', 'electronics', 'maker', 'raspberry-pi', 'ikea-alex'],
   });
 }
@@ -251,7 +249,6 @@ function createCraftSupplies(): InspirationLayout {
     description:
       'Adhesives, cutting tools, and small notions. Dedicated slots sized for scissors, X-Acto knives, and glue bottles.',
     shortDescription: 'Adhesives, cutting tools, and notions',
-    complexity: 'intermediate',
     tags: ['hobby', 'craft', 'sewing', 'diy'],
   });
 }
@@ -333,7 +330,6 @@ function createArtStation(): InspirationLayout {
     description:
       'Tall bins for brushes and markers stored upright. Separate sections for pencils, charcoal, erasers, and sharpeners.',
     shortDescription: 'Brushes, markers, pencils, and art supplies',
-    complexity: 'beginner',
     tags: ['hobby', 'art', 'brushes', 'markers', 'drawing'],
   });
 }
@@ -387,7 +383,6 @@ function createSewingKit(): InspirationLayout {
     description:
       'Half-bin compartments for thread spools organized by color. Includes slots for needles, pins, buttons, and shears.',
     shortDescription: 'Thread, needles, and sewing notions',
-    complexity: 'advanced',
     tags: ['hobby', 'sewing', 'thread', 'half-bins'],
   });
 }

--- a/src/features/inspiration-gallery/data/themes/kitchen.ts
+++ b/src/features/inspiration-gallery/data/themes/kitchen.ts
@@ -52,7 +52,6 @@ function createCutleryDrawer(): InspirationLayout {
     description:
       'Silverware organization with main slots sized for dinner cutlery and smaller slots for teaspoons and dessert pieces.',
     shortDescription: 'Forks, knives, spoons, and dessert cutlery',
-    complexity: 'beginner',
     tags: ['kitchen', 'cutlery', 'silverware', 'simple'],
   });
 }
@@ -111,7 +110,6 @@ function createCookingUtensils(): InspirationLayout {
     description:
       'Long cooking tools stored horizontally, organized by type and size. Fits ladles, spatulas, and tongs.',
     shortDescription: 'Spatulas, ladles, whisks, and tongs',
-    complexity: 'beginner',
     tags: ['kitchen', 'utensils', 'cooking'],
   });
 }
@@ -179,7 +177,6 @@ function createKnifeDrawer(): InspirationLayout {
     description:
       'Horizontal knife storage with dedicated slots for each knife to protect blades and keep them accessible.',
     shortDescription: 'Safe storage for kitchen knives',
-    complexity: 'beginner',
     tags: ['kitchen', 'knives', 'safety', 'labeled'],
   });
 }
@@ -287,7 +284,6 @@ function createSpiceDrawer(): InspirationLayout {
     description:
       'Organize your spices with half-bin precision for standard spice jars. Everyday spices up front, herbs in the middle, specialty blends in the back.',
     shortDescription: 'Spice jars organized by frequency of use',
-    complexity: 'intermediate',
     tags: ['kitchen', 'spices', 'cooking', 'half-bins'],
   });
 }

--- a/src/features/inspiration-gallery/data/themes/office.ts
+++ b/src/features/inspiration-gallery/data/themes/office.ts
@@ -77,7 +77,6 @@ function createDeskDrawer(): InspirationLayout {
     description:
       'Sections for pens, pencils, and markers. Small bins for clips, pins, and rubber bands. Larger slots for scissors and tape.',
     shortDescription: 'Pens, clips, and desk essentials',
-    complexity: 'beginner',
     tags: ['office', 'desk', 'pens', 'supplies', 'ikea-alex'],
   });
 }
@@ -157,7 +156,6 @@ function createCableDrawer(): InspirationLayout {
     description:
       'Charging cables organized by type (USB-C, Lightning, Micro). Separate sections for power cables, adapters, and dongles.',
     shortDescription: 'Charging cables, cords, and adapters',
-    complexity: 'intermediate',
     tags: ['office', 'cables', 'charging', 'tech'],
   });
 }

--- a/src/features/inspiration-gallery/data/themes/personal.ts
+++ b/src/features/inspiration-gallery/data/themes/personal.ts
@@ -68,7 +68,6 @@ function createBathroomMakeup(): InspirationLayout {
     description:
       'Tall slots for makeup brushes, small bins for lipsticks and compacts. Includes spots for hair ties and bobby pins.',
     shortDescription: 'Makeup brushes, cosmetics, and accessories',
-    complexity: 'beginner',
     tags: ['bathroom', 'makeup', 'cosmetics', 'personal'],
   });
 }
@@ -119,7 +118,6 @@ function createNightstandDrawer(): InspirationLayout {
     description:
       'Bedside essentials: phone, earbuds, glasses case, medications, and charger. Shallow layout for typical nightstand drawers.',
     shortDescription: 'Phone, glasses, and bedside essentials',
-    complexity: 'beginner',
     tags: ['bedroom', 'nightstand', 'personal', 'simple'],
   });
 }
@@ -183,7 +181,6 @@ function createFirstAidKit(): InspirationLayout {
     description:
       'Bandages, gauze, and tape up front. Medications organized by type. Tools section for scissors, tweezers, and thermometer.',
     shortDescription: 'Bandages, medications, and medical supplies',
-    complexity: 'beginner',
     tags: ['personal', 'medical', 'first-aid', 'health'],
   });
 }
@@ -237,7 +234,6 @@ function createJewelryDrawer(): InspirationLayout {
     description:
       'Keep jewelry organized and tangle-free. Small compartments for rings, wider bins for earrings, and long trays for necklaces and chains.',
     shortDescription: 'Rings, earrings, necklaces, and watches',
-    complexity: 'beginner',
     tags: ['personal', 'jewelry', 'accessories', 'organization'],
   });
 }
@@ -298,7 +294,6 @@ function createEDCDrawer(): InspirationLayout {
     description:
       'Everyday carry essentials: keys, wallet, watch, flashlight, pocket knife, and glasses. Quick-access layout for items you grab daily.',
     shortDescription: 'Keys, wallet, watch, and daily essentials',
-    complexity: 'beginner',
     tags: ['personal', 'edc', 'keys', 'wallet', 'everyday'],
   });
 }

--- a/src/features/inspiration-gallery/data/themes/workshop.ts
+++ b/src/features/inspiration-gallery/data/themes/workshop.ts
@@ -94,7 +94,6 @@ function createScrewOrganizer(): InspirationLayout {
     description:
       'Metric fastener organization with small bins for M2-M4, medium for M5-M6, and large bins for nuts and washers. Uses half-bin increments.',
     shortDescription: 'Sort screws by size with half-bin divisions',
-    complexity: 'intermediate',
     tags: ['workshop', 'screws', 'fasteners', 'half-bins', 'ikea-alex'],
   });
 }
@@ -174,7 +173,6 @@ function createToolDrawer(): InspirationLayout {
     description:
       'Tool chest layout with dedicated sections for pliers, screwdrivers, wrenches, and allen keys. Bins sized for real tool dimensions.',
     shortDescription: 'Pliers, screwdrivers, and wrenches organized',
-    complexity: 'beginner',
     tags: ['workshop', 'tools', 'pliers', 'screwdrivers', 'tool-chest'],
   });
 }
@@ -251,7 +249,6 @@ function createElectronicsBench(): InspirationLayout {
     description:
       'Small bins for resistors, capacitors, and LEDs. Tool slots for tweezers and cutters. Larger bins for wire and solder.',
     shortDescription: 'Components, tools, and supplies',
-    complexity: 'intermediate',
     tags: ['workshop', 'electronics', 'soldering', 'components', 'ikea-alex'],
   });
 }
@@ -331,7 +328,6 @@ function createSocketOrganizer(): InspirationLayout {
     description:
       'Metric sockets grouped by drive size (1/4", 3/8", 1/2") with dedicated slots for ratchets and extensions.',
     shortDescription: 'Socket sets with ratchets and extensions',
-    complexity: 'beginner',
     tags: ['workshop', 'sockets', 'automotive', 'mechanic'],
   });
 }
@@ -391,7 +387,6 @@ function createBatteryDrawer(): InspirationLayout {
     description:
       'Batteries organized by type: AA, AAA, 9V, rechargeable 18650s, and coin cells (CR2032, LR44).',
     shortDescription: 'AA, AAA, 18650, and coin cell batteries',
-    complexity: 'beginner',
     tags: ['workshop', 'batteries', 'electronics', 'storage'],
   });
 }
@@ -536,7 +531,6 @@ function createGarageDrawer(): InspirationLayout {
     description:
       'Automotive consumables for a tool chest drawer (13×11 units). Small spray cans, thread lockers, tapes, gloves, and electrical supplies.',
     shortDescription: 'Spray cans, tapes, gloves, and hardware',
-    complexity: 'beginner',
     tags: ['workshop', 'garage', 'automotive', 'car', 'tool-chest'],
   });
 }
@@ -630,7 +624,6 @@ function createDrillBitOrganizer(): InspirationLayout {
     description:
       'Twist drill bits sorted by size (1-13mm), spade bits, forstner bits, hole saws, and countersinks. Long bins for laying bits flat.',
     shortDescription: 'Twist, spade, forstner, and hole saws',
-    complexity: 'intermediate',
     tags: ['workshop', 'drill', 'bits', 'woodworking', 'ikea-alex'],
   });
 }

--- a/src/features/inspiration-gallery/index.ts
+++ b/src/features/inspiration-gallery/index.ts
@@ -2,8 +2,8 @@
 export { InspirationGallery } from './components/InspirationGallery';
 
 // Types
-export type { InspirationLayout, InspirationTheme, LayoutComplexity, LayoutFeature } from './types';
-export { THEME_CONFIG, FEATURE_CONFIG } from './types';
+export type { InspirationLayout, InspirationTheme } from './types';
+export { THEME_CONFIG } from './types';
 
 // Data
 export { INSPIRATION_LAYOUTS, getLayoutsByTheme } from './data';

--- a/src/features/inspiration-gallery/types.ts
+++ b/src/features/inspiration-gallery/types.ts
@@ -7,23 +7,6 @@ import type { Layout, LayoutPreview } from '@/core/types';
 export type InspirationTheme = 'kitchen' | 'workshop' | 'office' | 'hobby' | 'personal';
 
 /**
- * Features that a layout can showcase.
- * Used to indicate complexity and highlight advanced features.
- */
-export type LayoutFeature =
-  | 'multiple-layers'
-  | 'half-bins'
-  | 'labeled-bins'
-  | 'clearance-height'
-  | 'multiple-categories';
-
-/**
- * Complexity level for progressive discovery.
- * Beginners see simple layouts first, advanced users can explore complex ones.
- */
-export type LayoutComplexity = 'beginner' | 'intermediate' | 'advanced';
-
-/**
  * An inspiration layout with metadata for the gallery.
  */
 export interface InspirationLayout {
@@ -37,10 +20,6 @@ export interface InspirationLayout {
   description: string;
   /** Short description for card (max 80 chars) */
   shortDescription: string;
-  /** Complexity level */
-  complexity: LayoutComplexity;
-  /** Features showcased */
-  features: LayoutFeature[];
   /** Pre-calculated metrics for display */
   metrics: {
     binCount: number;
@@ -60,59 +39,10 @@ export interface InspirationLayout {
 /**
  * Theme metadata for display.
  */
-export const THEME_CONFIG: Record<
-  InspirationTheme,
-  { label: string; icon: string; description: string }
-> = {
-  kitchen: {
-    label: 'Kitchen',
-    icon: 'utensils',
-    description: 'Organize cooking tools, utensils, and drawer essentials',
-  },
-  workshop: {
-    label: 'Workshop',
-    icon: 'wrench',
-    description: 'Tools, fasteners, and maker supplies',
-  },
-  office: {
-    label: 'Office',
-    icon: 'briefcase',
-    description: 'Desk supplies, stationery, and organization',
-  },
-  hobby: {
-    label: 'Hobby',
-    icon: 'palette',
-    description: 'Craft supplies, 3D printing, and creative projects',
-  },
-  personal: {
-    label: 'Personal',
-    icon: 'sparkles',
-    description: 'Bathroom, bedroom, and personal care organization',
-  },
-};
-
-/**
- * Feature metadata for badges.
- */
-export const FEATURE_CONFIG: Record<LayoutFeature, { label: string; description: string }> = {
-  'multiple-layers': {
-    label: 'Multi-layer',
-    description: 'Uses multiple vertical layers for stacking',
-  },
-  'half-bins': {
-    label: 'Half-bins',
-    description: 'Uses 0.5 unit increments for fine divisions',
-  },
-  'labeled-bins': {
-    label: 'Labeled',
-    description: 'Bins have descriptive labels',
-  },
-  'clearance-height': {
-    label: 'Clearance',
-    description: 'Some bins have clearance height for tall items',
-  },
-  'multiple-categories': {
-    label: 'Categories',
-    description: 'Uses multiple color categories for organization',
-  },
+export const THEME_CONFIG: Record<InspirationTheme, { label: string }> = {
+  kitchen: { label: 'Kitchen' },
+  workshop: { label: 'Workshop' },
+  office: { label: 'Office' },
+  hobby: { label: 'Hobby' },
+  personal: { label: 'Personal' },
 };

--- a/src/features/inspiration-gallery/utils/layoutBuilder.ts
+++ b/src/features/inspiration-gallery/utils/layoutBuilder.ts
@@ -1,10 +1,5 @@
 import type { Layout, Bin, Layer, Category } from '@/core/types';
-import type {
-  InspirationLayout,
-  InspirationTheme,
-  LayoutComplexity,
-  LayoutFeature,
-} from '../types';
+import type { InspirationLayout, InspirationTheme } from '../types';
 import { computePreview } from '@/core/storage';
 
 let idCounter = 0;
@@ -70,40 +65,6 @@ export function createCategory(name: string, color: string): Category {
 export { computePreview };
 
 /**
- * Detect features from a layout.
- */
-export function detectFeatures(layout: Layout): LayoutFeature[] {
-  const features: LayoutFeature[] = [];
-
-  if (layout.layers.length > 1) {
-    features.push('multiple-layers');
-  }
-
-  const hasHalfBins = layout.bins.some(
-    (b) => b.x % 1 !== 0 || b.y % 1 !== 0 || b.width % 1 !== 0 || b.depth % 1 !== 0
-  );
-  if (hasHalfBins) {
-    features.push('half-bins');
-  }
-
-  const labeledCount = layout.bins.filter((b) => b.label.trim() !== '').length;
-  if (labeledCount > 0) {
-    features.push('labeled-bins');
-  }
-
-  const hasClearance = layout.bins.some((b) => b.clearanceHeight && b.clearanceHeight > 0);
-  if (hasClearance) {
-    features.push('clearance-height');
-  }
-
-  if (layout.categories.length > 2) {
-    features.push('multiple-categories');
-  }
-
-  return features;
-}
-
-/**
  * Calculate metrics from a layout.
  */
 export function calculateMetrics(layout: Layout): InspirationLayout['metrics'] {
@@ -126,7 +87,6 @@ interface BuilderOptions {
   theme: InspirationTheme;
   description: string;
   shortDescription: string;
-  complexity: LayoutComplexity;
   tags: string[];
 }
 
@@ -140,8 +100,6 @@ export function buildInspirationLayout(layout: Layout, options: BuilderOptions):
     theme: options.theme,
     description: options.description,
     shortDescription: options.shortDescription,
-    complexity: options.complexity,
-    features: detectFeatures(layout),
     metrics: calculateMetrics(layout),
     preview: computePreview(layout),
     layout,


### PR DESCRIPTION
## Summary
- Remove unused `LayoutFeature` and `LayoutComplexity` types
- Remove unused `features` and `complexity` fields from `InspirationLayout` interface
- Remove `FEATURE_CONFIG` constant (defined but never used in production)
- Remove `detectFeatures()` function (computed features that were never displayed)
- Remove unused `icon` and `description` fields from `THEME_CONFIG`
- Remove `complexity` field from all 23 theme layout definitions
- Clean up related tests for removed dead code

**Impact:** 578 lines removed (9% reduction in feature size)

## Test plan
- [x] TypeScript build passes
- [x] All 5,066 tests pass
- [x] Bundle size reduced (inspiration-gallery chunk: 59.47KB → 57.63KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)