### PR TITLE
refactor(categories): extract shared color palette and consolidate components

### DIFF
--- a/src/components/Mobile/MobileCategoriesPanel.tsx
+++ b/src/components/Mobile/MobileCategoriesPanel.tsx
@@ -3,25 +3,10 @@ import { useShallow } from 'zustand/shallow';
 import { useLayoutStore } from '@/core/store/layout';
 import { useUIStore, useUndoableAction } from '@/core/store';
 import { useToastStore } from '@/core/store/toast';
-import { CONSTRAINTS, DEFAULT_CATEGORY_COLOR } from '@/core/constants';
+import { CONSTRAINTS, DEFAULT_CATEGORY_COLOR, CATEGORY_COLOR_PALETTE } from '@/core/constants';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { isOk } from '@/core/result';
 import { useTranslation } from '@/i18n';
-
-const COLOR_PALETTE = [
-  { color: '#f87171', name: 'Coral' },
-  { color: '#fb923c', name: 'Orange' },
-  { color: '#fbbf24', name: 'Amber' },
-  { color: '#a3e635', name: 'Lime' },
-  { color: '#4ade80', name: 'Green' },
-  { color: '#2dd4bf', name: 'Teal' },
-  { color: '#38bdf8', name: 'Sky' },
-  { color: '#818cf8', name: 'Indigo' },
-  { color: '#c084fc', name: 'Purple' },
-  { color: '#f472b6', name: 'Pink' },
-  { color: '#e2e8f0', name: 'Cloud' },
-  { color: '#334155', name: 'Charcoal' },
-];
 
 /**
  * Mobile-optimized categories panel with large touch targets.
@@ -109,10 +94,7 @@ export function MobileCategoriesPanel() {
 
     // Show helpful message if category is in use
     if (binCount > 0) {
-      addToast(
-        t('categories.deleteInUse', { count: binCount, name }),
-        'error'
-      );
+      addToast(t('categories.deleteInUse', { count: binCount, name }), 'error');
       return;
     }
 
@@ -178,7 +160,7 @@ export function MobileCategoriesPanel() {
 
                   {/* Color grid */}
                   <div className="grid grid-cols-6 gap-2">
-                    {COLOR_PALETTE.map(({ color, name }) => (
+                    {CATEGORY_COLOR_PALETTE.map(({ color, name }) => (
                       <button
                         key={color}
                         onClick={() => handleUpdateColor(category.id, color)}
@@ -200,9 +182,13 @@ export function MobileCategoriesPanel() {
                     <button
                       onClick={() => handleDelete(category.id, category.name)}
                       className={`btn flex-1 ${canDelete ? 'btn-danger' : 'btn-secondary opacity-50'}`}
-                    >{t('common.delete')}{binCount > 0 ? ` (${binCount} bins)` : ''}
+                    >
+                      {t('common.delete')}
+                      {binCount > 0 ? ` (${binCount} bins)` : ''}
                     </button>
-                    <button onClick={() => setEditingId(null)} className="btn btn-secondary flex-1">{t('common.done')}</button>
+                    <button onClick={() => setEditingId(null)} className="btn btn-secondary flex-1">
+                      {t('common.done')}
+                    </button>
                   </div>
                 </div>
               ) : (
@@ -211,7 +197,10 @@ export function MobileCategoriesPanel() {
                   onClick={() => handleSelectCategory(category.id, category.name)}
                   aria-label={
                     selectedBinIds.length > 0
-                      ? t('mobile.categories.applyToSelected', { count: selectedBinIds.length, name: category.name })
+                      ? t('mobile.categories.applyToSelected', {
+                          count: selectedBinIds.length,
+                          name: category.name,
+                        })
                       : t('mobile.categories.selectForNew', { name: category.name })
                   }
                 >
@@ -228,7 +217,9 @@ export function MobileCategoriesPanel() {
                     </span>
                   )}
                   {isActive && (
-                    <span className="px-2 py-1 rounded text-xs font-medium bg-accent text-black">{t('mobile.categories.active')}</span>
+                    <span className="px-2 py-1 rounded text-xs font-medium bg-accent text-black">
+                      {t('mobile.categories.active')}
+                    </span>
                   )}
                   <button
                     onClick={(e) => {
@@ -262,7 +253,9 @@ export function MobileCategoriesPanel() {
       >
         <svg className="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-        </svg>{t('mobile.categories.addCategory')}</button>
+        </svg>
+        {t('mobile.categories.addCategory')}
+      </button>
 
       <ConfirmDialog
         isOpen={deleteConfirm !== null}

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -124,6 +124,24 @@ export function hasFractionalDimensions(rect: {
 /** Default category color (slate gray) - used as fallback when category is undefined */
 export const DEFAULT_CATEGORY_COLOR = '#6b7280';
 
+/** Curated color palette for categories, optimized for dark UI backgrounds */
+export const CATEGORY_COLOR_PALETTE = [
+  { color: '#f87171', name: 'Coral' },
+  { color: '#fb923c', name: 'Orange' },
+  { color: '#fbbf24', name: 'Amber' },
+  { color: '#a3e635', name: 'Lime' },
+  { color: '#4ade80', name: 'Green' },
+  { color: '#2dd4bf', name: 'Teal' },
+  { color: '#38bdf8', name: 'Sky' },
+  { color: '#818cf8', name: 'Indigo' },
+  { color: '#c084fc', name: 'Purple' },
+  { color: '#f472b6', name: 'Pink' },
+  { color: '#e2e8f0', name: 'Cloud' },
+  { color: '#334155', name: 'Charcoal' },
+  { color: '#94a3b8', name: 'Slate' },
+  { color: '#a8a29e', name: 'Stone' },
+] as const;
+
 /** Default layout name for new layouts */
 export const DEFAULT_LAYOUT_NAME = 'Untitled layout';
 

--- a/src/features/categories/components/CategoriesPanel.tsx
+++ b/src/features/categories/components/CategoriesPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { useLayoutStore, useUIStore, useUndoableAction, useSettingsStore } from '@/core/store';
 import { useMutations } from '@/shared/contexts';
-import { CONSTRAINTS, DEFAULT_CATEGORY_COLOR } from '@/core/constants';
+import { CONSTRAINTS, DEFAULT_CATEGORY_COLOR, CATEGORY_COLOR_PALETTE } from '@/core/constants';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { useToastStore } from '@/core/store/toast';
 import { CollapsibleSection } from '@/shared/components/CollapsibleSection';
@@ -10,24 +10,33 @@ import { isOk, isErr, getUserMessage } from '@/core/result';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
 import { useTranslation } from '@/i18n';
 
-// Curated color palette optimized for dark UI backgrounds
-// Colors chosen for: visual distinction, balanced saturation, good contrast
-const COLOR_PALETTE = [
-  { color: '#f87171', name: 'Coral' }, // Warm red, softer than pure red
-  { color: '#fb923c', name: 'Orange' }, // Vibrant orange
-  { color: '#fbbf24', name: 'Amber' }, // Golden yellow
-  { color: '#a3e635', name: 'Lime' }, // Yellow-green, high visibility
-  { color: '#4ade80', name: 'Green' }, // Fresh green
-  { color: '#2dd4bf', name: 'Teal' }, // Blue-green
-  { color: '#38bdf8', name: 'Sky' }, // Light blue
-  { color: '#818cf8', name: 'Indigo' }, // Purple-blue
-  { color: '#c084fc', name: 'Purple' }, // Vibrant purple
-  { color: '#f472b6', name: 'Pink' }, // Warm pink
-  { color: '#e2e8f0', name: 'Cloud' }, // Soft off-white
-  { color: '#334155', name: 'Charcoal' }, // Near-black
-  { color: '#94a3b8', name: 'Slate' }, // Cool neutral
-  { color: '#a8a29e', name: 'Stone' }, // Warm neutral
-];
+interface ColorPaletteGridProps {
+  selectedColor: string;
+  onColorSelect: (color: string) => void;
+  t: ReturnType<typeof useTranslation>;
+}
+
+function ColorPaletteGrid({ selectedColor, onColorSelect, t }: ColorPaletteGridProps) {
+  return (
+    <div className="grid grid-cols-7 gap-1.5">
+      {CATEGORY_COLOR_PALETTE.map(({ color, name }) => (
+        <button
+          key={color}
+          onClick={() => onColorSelect(color)}
+          className="w-6 h-6 rounded transition-all duration-150 hover:scale-110 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-accent"
+          style={{
+            backgroundColor: color,
+            boxShadow:
+              selectedColor === color ? '0 0 0 2px var(--color-primary)' : 'var(--shadow-sm)',
+          }}
+          title={name}
+          aria-label={t('categories.setColorTo', { name })}
+          aria-pressed={selectedColor === color}
+        />
+      ))}
+    </div>
+  );
+}
 
 export function CategoriesPanel() {
   const t = useTranslation();
@@ -137,11 +146,7 @@ export function CategoriesPanel() {
         }
       });
 
-      // Track once per batch (not per bin)
-      if (binsToUpdate.length > 0) {
-        mlTracking.trackCategory(binsToUpdate[0], categoryName, binCount);
-      }
-
+      mlTracking.trackCategory(binsToUpdate[0], categoryName, binCount);
       addToast(t('toast.categoryChanged', { count: binCount, name: categoryName }), 'success');
     }
   };
@@ -293,26 +298,11 @@ export function CategoriesPanel() {
                       autoFocus
                       placeholder={t('categories.categoryNamePlaceholder')}
                     />
-                    {/* Color palette - 7 columns for better fit with 14 colors */}
-                    <div className="grid grid-cols-7 gap-1.5">
-                      {COLOR_PALETTE.map(({ color, name }) => (
-                        <button
-                          key={color}
-                          onClick={() => handleUpdateCategory(category.id, 'color', color)}
-                          className="w-6 h-6 rounded transition-all duration-150 hover:scale-110 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-accent"
-                          style={{
-                            backgroundColor: color,
-                            boxShadow:
-                              category.color === color
-                                ? '0 0 0 2px var(--color-primary)'
-                                : 'var(--shadow-sm)',
-                          }}
-                          title={name}
-                          aria-label={t('categories.setColorTo', { name })}
-                          aria-pressed={category.color === color}
-                        />
-                      ))}
-                    </div>
+                    <ColorPaletteGrid
+                      selectedColor={category.color}
+                      onColorSelect={(color) => handleUpdateCategory(category.id, 'color', color)}
+                      t={t}
+                    />
                     {/* Footer row: hint + delete link */}
                     <div className="flex items-center justify-between text-xs text-content-tertiary mt-0.5">
                       <span>{t('categories.clickOutsideToClose')}</span>
@@ -362,35 +352,20 @@ export function CategoriesPanel() {
                         )}
                       </button>
 
-                      {/* Quick color picker popover */}
                       {colorPickerId === category.id && (
                         <div
                           ref={colorPickerRef}
                           className="absolute left-0 top-full mt-1.5 z-50 p-2 bg-surface-elevated border border-stroke-subtle rounded-lg shadow-lg animate-scale-in"
                           onClick={(e) => e.stopPropagation()}
                         >
-                          <div className="grid grid-cols-7 gap-1.5">
-                            {COLOR_PALETTE.map(({ color, name }) => (
-                              <button
-                                key={color}
-                                onClick={() => {
-                                  handleUpdateCategory(category.id, 'color', color);
-                                  setColorPickerId(null);
-                                }}
-                                className="w-6 h-6 rounded transition-all duration-150 hover:scale-110 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-accent"
-                                style={{
-                                  backgroundColor: color,
-                                  boxShadow:
-                                    category.color === color
-                                      ? '0 0 0 2px var(--color-primary)'
-                                      : 'var(--shadow-sm)',
-                                }}
-                                title={name}
-                                aria-label={t('categories.setColorTo', { name })}
-                                aria-pressed={category.color === color}
-                              />
-                            ))}
-                          </div>
+                          <ColorPaletteGrid
+                            selectedColor={category.color}
+                            onColorSelect={(color) => {
+                              handleUpdateCategory(category.id, 'color', color);
+                              setColorPickerId(null);
+                            }}
+                            t={t}
+                          />
                         </div>
                       )}
                     </div>


### PR DESCRIPTION
## Summary
- Extract `CATEGORY_COLOR_PALETTE` constant to `core/constants.ts` for reuse across components
- Create `ColorPaletteGrid` component to eliminate duplicate inline color grid implementations
- Update `MobileCategoriesPanel` to use shared constant (also gains 2 additional colors for consistency)
- Remove redundant conditional check (early return already handles the case)

**Impact:** 14 lines removed, code duplication eliminated, single source of truth for color palette

## Test plan
- [x] TypeScript build passes
- [x] All 5,093 tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)