### PR TITLE
refactor(name-suggestions): remove unused fields and unreachable code

### DIFF
--- a/src/features/name-suggestions/utils/generateSuggestions.ts
+++ b/src/features/name-suggestions/utils/generateSuggestions.ts
@@ -152,6 +152,7 @@ const DOMAIN_NAMING: Record<LabelDomain, DomainNaming> = {
 
 /**
  * Purpose display names for suggestion formatting.
+ * Maps purpose values from inferDrawerPurpose to display names.
  */
 const PURPOSE_NAMES: Record<string, string> = {
   workshop: 'Workshop',
@@ -159,8 +160,6 @@ const PURPOSE_NAMES: Record<string, string> = {
   office: 'Office',
   craft: 'Craft',
   bathroom: 'Bathroom',
-  kitchen: 'Kitchen',
-  garage: 'Garage',
   general: 'Storage',
 };
 
@@ -1027,8 +1026,6 @@ interface SubcategoryMatch {
   names: string[];
   /** Confidence boost */
   confidenceBoost: number;
-  /** Number of matches */
-  matchCount: number;
 }
 
 /**
@@ -1108,7 +1105,6 @@ function detectSubcategories(labels: string[]): SubcategoryMatch | null {
       return {
         names: subcategory.names,
         confidenceBoost: subcategory.confidenceBoost,
-        matchCount: matchedIndices.size,
       };
     }
   }
@@ -1183,21 +1179,16 @@ function detectLocation(labels: string[]): string | null {
  * Analyze categories to find dominant theme.
  */
 function analyzeCategories(categories: CategoryCount[]): {
-  primaryCategory: string | null;
-  secondaryCategory: string | null;
   concentration: number;
   categoryNames: string[];
 } {
   if (categories.length === 0) {
-    return { primaryCategory: null, secondaryCategory: null, concentration: 0, categoryNames: [] };
+    return { concentration: 0, categoryNames: [] };
   }
 
   const sorted = [...categories].sort((a, b) => b.count - a.count);
   const totalBins = categories.reduce((sum, c) => sum + c.count, 0);
-
-  const primaryCategory = sorted[0]?.name ?? null;
   const primaryCount = sorted[0]?.count ?? 0;
-  const secondaryCategory = sorted[1]?.name ?? null;
   const concentration = totalBins > 0 ? primaryCount / totalBins : 0;
 
   // Collect all meaningful category names (excluding default color names)
@@ -1206,7 +1197,7 @@ function analyzeCategories(categories: CategoryCount[]): {
     .filter((c) => !defaultColors.includes(c.name))
     .map((c) => c.name);
 
-  return { primaryCategory, secondaryCategory, concentration, categoryNames };
+  return { concentration, categoryNames };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove unused `matchCount` field from `SubcategoryMatch` interface (defined but never read)
- Simplify `analyzeCategories` return type by removing unused `primaryCategory`/`secondaryCategory`
- Remove unused `PURPOSE_NAMES` entries ('kitchen'/'garage' never returned by `inferDrawerPurpose`)

**Note:** This feature is mostly data structures (76 subcategory patterns, name lists) which are intentional. The code structure is clean with well-sized helper functions.

**Impact:** 12 lines removed

## Test plan
- [x] TypeScript build passes
- [x] All tests pass (66 affected tests verified)
- [x] Bundle size reduced slightly (29.24KB → 29.07KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)