### PR TITLE
fix(bin-designer): correct stacking lip height and improve dimension controls

### DIFF
--- a/src/features/bin-designer/__tests__/components/ParameterPanel.test.tsx
+++ b/src/features/bin-designer/__tests__/components/ParameterPanel.test.tsx
@@ -46,9 +46,30 @@ describe('ParameterPanel', () => {
   it('shows mm info for dimensions', () => {
     render(<ParameterPanel />);
 
-    // Default width=2, depth=2 both show 84mm
-    const mmLabels = screen.getAllByText('84mm');
-    expect(mmLabels.length).toBe(2);
+    // Default width=2, depth=2, height=3 shows combined dimensions
+    // Format: "84 × 84 × 21 mm" (using gridUnitMm=42, heightUnitMm=7)
+    expect(screen.getByText(/84\s*×\s*84\s*×\s*21\s*mm/)).toBeInTheDocument();
+  });
+
+  it('swap button swaps width and depth values', () => {
+    // Set different width and depth so swap is visible
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, width: 2, depth: 4 },
+    });
+    render(<ParameterPanel />);
+
+    const widthInput = screen.getByLabelText('Width') as HTMLInputElement;
+    const depthInput = screen.getByLabelText('Depth') as HTMLInputElement;
+    expect(widthInput.value).toBe('2');
+    expect(depthInput.value).toBe('4');
+
+    // Click swap button
+    const swapBtn = screen.getByLabelText('Swap width and depth');
+    fireEvent.click(swapBtn);
+
+    // Values should be swapped
+    expect(useDesignerStore.getState().params.width).toBe(4);
+    expect(useDesignerStore.getState().params.depth).toBe(2);
   });
 
   it('toggling magnet holes updates base style', () => {

--- a/src/features/bin-designer/__tests__/validation.test.ts
+++ b/src/features/bin-designer/__tests__/validation.test.ts
@@ -82,7 +82,7 @@ describe('validateBinParams', () => {
     it('should accept boundary values', () => {
       expect(isOk(validateBinParams(makeParams({ width: 0.5 })))).toBe(true);
       expect(isOk(validateBinParams(makeParams({ width: 8 })))).toBe(true);
-      // MIN_HEIGHT is 2 (1U = base only, no usable cavity)
+      // MIN_HEIGHT is 2 (1U = base only, 2U minimum for usable cavity)
       expect(isOk(validateBinParams(makeParams({ height: 2 })))).toBe(true);
       expect(isOk(validateBinParams(makeParams({ height: 20 })))).toBe(true);
     });

--- a/src/features/bin-designer/components/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel.tsx
@@ -6,9 +6,9 @@
  *
  * Layout:
  * - Dimensions (expanded) — Width, Depth, Height
- * - Base (expanded) — Magnets, Screws, Stacking lip
  * - Walls (expanded) — Wall thickness
  * - Interior (expanded) — Compartments
+ * - Base (expanded) — Magnets, Screws, Stacking lip
  * - Physical Units — Grid unit size (mm)
  */
 
@@ -26,13 +26,13 @@ export function ParameterPanel() {
           <DimensionsSection />
         </div>
         <div className="px-4 py-4 border-b border-stroke-subtle">
-          <BaseSection />
-        </div>
-        <div className="px-4 py-4 border-b border-stroke-subtle">
           <WallsSection />
         </div>
         <div className="px-4 py-4 border-b border-stroke-subtle">
           <InteriorSection />
+        </div>
+        <div className="px-4 py-4 border-b border-stroke-subtle">
+          <BaseSection />
         </div>
         <div className="px-4 py-4">
           <PhysicalUnitsSection />

--- a/src/features/bin-designer/components/panel/DimensionsSection.tsx
+++ b/src/features/bin-designer/components/panel/DimensionsSection.tsx
@@ -1,6 +1,9 @@
 /**
  * Dimensions section: Width, Depth, Height with stepper controls,
  * half-bin mode toggle, and physical unit settings.
+ *
+ * Layout matches the bin inspector: width/depth on same row with swap button,
+ * height on its own row.
  */
 
 import { useCallback } from 'react';
@@ -22,6 +25,7 @@ export function DimensionsSection() {
     heightUnitMm,
     halfBinMode,
     setParam,
+    setParams,
     toggleHalfBinMode,
   } = useDesignerStore(
     useShallow((s) => ({
@@ -32,6 +36,7 @@ export function DimensionsSection() {
       heightUnitMm: s.params.heightUnitMm,
       halfBinMode: s.ui.halfBinMode,
       setParam: s.setParam,
+      setParams: s.setParams,
       toggleHalfBinMode: s.toggleHalfBinMode,
     }))
   );
@@ -78,6 +83,10 @@ export function DimensionsSection() {
     [height, setParam]
   );
 
+  const handleSwapDimensions = useCallback(() => {
+    setParams({ width: depth, depth: width });
+  }, [width, depth, setParams]);
+
   return (
     <CollapsibleSection
       title={t('binDesigner.dimensions')}
@@ -86,54 +95,87 @@ export function DimensionsSection() {
       summary={summary}
     >
       <div className="space-y-3">
-        {/* Width */}
-        <div>
-          <div className="mb-1 flex items-center justify-between">
-            <span className="text-xs text-content-tertiary">{t('common.width')}</span>
-            <span className="text-[11px] tabular-nums text-content-tertiary">
-              {widthMm.toFixed(0)}mm
-            </span>
+        {/* Width and Depth on same row with swap button */}
+        <div className="flex items-end gap-2">
+          {/* Width */}
+          <div className="flex-1 min-w-0">
+            <span className="mb-1 block text-xs text-content-tertiary">{t('common.width')}</span>
+            <StepperControl
+              value={width}
+              onChange={(v) => setParam('width', v)}
+              onStep={handleWidthStep}
+              min={minDimension}
+              max={DESIGNER_CONSTRAINTS.MAX_DIMENSION}
+              step={dimensionStep}
+              variant="desktop"
+              ariaLabel="Width"
+            />
           </div>
-          <StepperControl
-            value={width}
-            onChange={(v) => setParam('width', v)}
-            onStep={handleWidthStep}
-            min={minDimension}
-            max={DESIGNER_CONSTRAINTS.MAX_DIMENSION}
-            step={dimensionStep}
-            variant="compact"
-            ariaLabel="Width"
-          />
+
+          {/* Swap button */}
+          <button
+            type="button"
+            onClick={handleSwapDimensions}
+            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded border border-stroke-subtle bg-surface-elevated text-content-tertiary transition-colors hover:bg-surface-hover hover:text-content"
+            title={t('inspector.swapDimensions')}
+            aria-label={t('inspector.swapWidthAndDepth')}
+          >
+            <svg
+              className="h-3 w-3"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2.5}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
+              />
+            </svg>
+          </button>
+
+          {/* Depth */}
+          <div className="flex-1 min-w-0">
+            <span className="mb-1 block text-xs text-content-tertiary">{t('common.depth')}</span>
+            <StepperControl
+              value={depth}
+              onChange={(v) => setParam('depth', v)}
+              onStep={handleDepthStep}
+              min={minDimension}
+              max={DESIGNER_CONSTRAINTS.MAX_DIMENSION}
+              step={dimensionStep}
+              variant="desktop"
+              ariaLabel="Depth"
+            />
+          </div>
         </div>
 
-        {/* Depth */}
-        <div>
-          <div className="mb-1 flex items-center justify-between">
-            <span className="text-xs text-content-tertiary">{t('common.depth')}</span>
-            <span className="text-[11px] tabular-nums text-content-tertiary">
-              {depthMm.toFixed(0)}mm
-            </span>
-          </div>
-          <StepperControl
-            value={depth}
-            onChange={(v) => setParam('depth', v)}
-            onStep={handleDepthStep}
-            min={minDimension}
-            max={DESIGNER_CONSTRAINTS.MAX_DIMENSION}
-            step={dimensionStep}
-            variant="compact"
-            ariaLabel="Depth"
-          />
+        {/* Physical dimensions display */}
+        <div className="flex items-center gap-1.5 text-xs text-content-tertiary">
+          <svg
+            className="h-3.5 w-3.5 flex-shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M4 12h16M4 12v-2M8 12v-1M12 12v-2M16 12v-1M20 12v-2"
+            />
+          </svg>
+          <span className="tabular-nums">
+            {widthMm.toFixed(0)} × {depthMm.toFixed(0)} × {heightMm.toFixed(0)} mm
+          </span>
         </div>
 
         {/* Height */}
         <div>
           <div className="mb-1 flex items-center justify-between">
             <span className="text-xs text-content-tertiary">{t('common.height')}</span>
-            <span className="text-[11px] tabular-nums text-content-tertiary">
-              {heightMm.toFixed(0)}
-              {t('binDesigner.mmBody')}
-            </span>
+            <span className="text-[11px] tabular-nums text-content-tertiary">{height}u</span>
           </div>
           <StepperControl
             value={height}
@@ -142,7 +184,7 @@ export function DimensionsSection() {
             min={DESIGNER_CONSTRAINTS.MIN_HEIGHT}
             max={DESIGNER_CONSTRAINTS.MAX_HEIGHT}
             step={DESIGNER_CONSTRAINTS.HEIGHT_STEP}
-            variant="compact"
+            variant="desktop"
             ariaLabel="Height"
           />
         </div>

--- a/src/features/bin-designer/components/preview/BinDimensions.tsx
+++ b/src/features/bin-designer/components/preview/BinDimensions.tsx
@@ -31,7 +31,7 @@ interface BinDimensionsProps {
 // Layout constants matched to planner's DrawerDimensions proportions
 // (planner: OFFSET=0.8, END_CAP=0.15, FONT_SIZE=0.32, label_gap=0.3)
 const OFFSET = 14; // Distance from bin edge to dimension line
-const END_CAP = 2; // Length of end cap markers
+const END_CAP = 1; // Length of end cap markers (half-length, extends both directions)
 const LABEL_GAP = 4; // Additional offset from line to label text
 const LINE_COLOR = '#ffffff';
 const LINE_OPACITY = 0.5;
@@ -54,12 +54,16 @@ export function BinDimensions({
   const outerW = width * GRIDFINITY.GRID_SIZE;
   const outerD = depth * GRIDFINITY.GRID_SIZE;
   const lipHeight = stackingLip ? GRIDFINITY.LIP_HEIGHT : 0;
+  // Total height per Gridfinity spec: height units + lip
+  // e.g., 3u + lip = 21 + 4.4 = 25.4mm
   const totalH = height * GRIDFINITY.HEIGHT_UNIT + lipHeight;
 
   // Display labels use the user's configured unit sizes
   const widthMm = Math.round(width * gridUnitMm);
   const depthMm = Math.round(depth * gridUnitMm);
-  const heightMm = Math.round(height * heightUnitMm + lipHeight);
+  // Height uses user's heightUnitMm setting + lip
+  const heightMmRaw = height * heightUnitMm + lipHeight;
+  const heightMm = Number.isInteger(heightMmRaw) ? heightMmRaw : heightMmRaw.toFixed(1);
 
   const dimensions = useMemo(() => {
     const halfW = outerW / 2;

--- a/src/features/bin-designer/constants/gridfinity.ts
+++ b/src/features/bin-designer/constants/gridfinity.ts
@@ -25,8 +25,11 @@ export const GRIDFINITY = {
   // Base profile (total dead space from bottom to cavity floor)
   BASE_HEIGHT: 7, // mm total (profile + bridge structure per spec)
 
-  // Stacking lip (sits on top of bin body)
-  LIP_HEIGHT: 4.4, // mm nominal (actual ~3.55mm with fillet)
+  // Stacking lip (sits on top of bin body) - per spec v5
+  LIP_HEIGHT: 4.4, // mm total (0.7 + 1.8 + 1.9)
+  LIP_SMALL_TAPER: 0.7, // mm bottom 45° chamfer
+  LIP_VERTICAL_PART: 1.8, // mm vertical section
+  LIP_BIG_TAPER: 1.9, // mm top 45° chamfer
 
   // Magnet holes (spec defaults; configurable via BinParams.base)
   MAGNET_DIAMETER: 6.5, // mm (6mm magnet + tolerance)
@@ -64,7 +67,7 @@ export const DESIGNER_CONSTRAINTS = {
   MIN_DIMENSION: 0.5, // grid units
   MAX_DIMENSION: 8, // grid units (expanded: standard Gridfinity supports large bins)
   DIMENSION_STEP: 0.5, // grid units
-  MIN_HEIGHT: 2, // height units (1U = base only, no cavity)
+  MIN_HEIGHT: 2, // height units (1U = base only, 2U minimum for usable cavity)
   MAX_HEIGHT: 20, // height units (expanded: tall bins for tools/bottles)
   HEIGHT_STEP: 1, // height units
   // Compartment grid

--- a/src/features/generation/worker/generators/replicadBin.ts
+++ b/src/features/generation/worker/generators/replicadBin.ts
@@ -36,6 +36,14 @@ const SOCKET_TAPER_WIDTH = SOCKET_SMALL_TAPER + SOCKET_BIG_TAPER;
 const AXIS_CLEARANCE = (CLEARANCE * Math.sqrt(2)) / 4;
 const TOP_FILLET = GRIDFINITY.TOP_FILLET;
 
+// ─── Stacking Lip Constants (per spec v5) ─────────────────────────────────────
+
+const LIP_SMALL_TAPER = GRIDFINITY.LIP_SMALL_TAPER; // 0.7mm bottom chamfer
+const LIP_VERTICAL_PART = GRIDFINITY.LIP_VERTICAL_PART; // 1.8mm vertical
+const LIP_BIG_TAPER = GRIDFINITY.LIP_BIG_TAPER; // 1.9mm top chamfer
+const LIP_HEIGHT = LIP_SMALL_TAPER + LIP_VERTICAL_PART + LIP_BIG_TAPER; // 4.4mm total
+const LIP_TAPER_WIDTH = LIP_SMALL_TAPER + LIP_BIG_TAPER; // 2.6mm horizontal inset
+
 // ─── Socket Builder ───────────────────────────────────────────────────────────
 
 /**
@@ -301,12 +309,12 @@ function buildBinBox(
 /**
  * Build the stacking lip at the top of the bin.
  *
- * The lip is the inverse of the socket profile — it provides the mating
- * interface that allows bins to stack. The profile sweeps around the bin
- * perimeter, then gets filleted at the peak for a smooth junction.
+ * The lip provides the mating interface that allows bins to stack.
+ * Profile per Gridfinity spec v5: 0.7mm + 1.8mm + 1.9mm = 4.4mm total height.
+ * The profile sweeps around the bin perimeter, then gets filleted at the peak.
  *
  * Profile traces (in XZ plane, X=outward, Z=up):
- *   Socket taper shape upward (matching socket cavity when stacked)
+ *   Lip taper shape upward (mates with socket cavity when stacked)
  *   + wall extension downward (if includeLip, replaces top wall section)
  *
  * Built at Z=0 locally, caller translates to wallHeight.
@@ -321,17 +329,18 @@ function buildTopShape(
   const outerD = gridD * SIZE - CLEARANCE;
 
   const topProfile = (_plane: Plane, _startPoint: Point): Sketch => {
-    // Draw the socket profile inverted (going upward from the sweep path)
-    let sketcher = draw([-SOCKET_TAPER_WIDTH, 0])
-      .line(SOCKET_SMALL_TAPER, SOCKET_SMALL_TAPER)
-      .vLine(SOCKET_VERTICAL_PART)
-      .line(SOCKET_BIG_TAPER, SOCKET_BIG_TAPER);
+    // Draw the lip profile (going upward from the sweep path)
+    // Per spec: 0.7mm bottom chamfer, 1.8mm vertical, 1.9mm top chamfer
+    let sketcher = draw([-LIP_TAPER_WIDTH, 0])
+      .line(LIP_SMALL_TAPER, LIP_SMALL_TAPER)
+      .vLine(LIP_VERTICAL_PART)
+      .line(LIP_BIG_TAPER, LIP_BIG_TAPER);
 
     if (includeLip) {
       // Extend wall downward to replace top wall section
       sketcher = sketcher
-        .vLineTo(-(SOCKET_TAPER_WIDTH + wallThickness))
-        .lineTo([-SOCKET_TAPER_WIDTH, -wallThickness]);
+        .vLineTo(-(LIP_TAPER_WIDTH + wallThickness))
+        .lineTo([-LIP_TAPER_WIDTH, -wallThickness]);
     } else {
       sketcher = sketcher.vLineTo(0);
     }
@@ -369,8 +378,8 @@ function buildTopShape(
     .sweepSketch(topProfile, { withContact: true })
     .fillet(TOP_FILLET, (e) =>
       e.inBox(
-        [-gridW * SIZE, -gridD * SIZE, SOCKET_HEIGHT],
-        [gridW * SIZE, gridD * SIZE, SOCKET_HEIGHT - 1]
+        [-gridW * SIZE, -gridD * SIZE, LIP_HEIGHT],
+        [gridW * SIZE, gridD * SIZE, LIP_HEIGHT - 1]
       )
     );
 }
@@ -662,7 +671,10 @@ export function generateBin(
 ): MeshData {
   const wallThickness = params.wallThickness;
   const totalHeight = params.height * GRIDFINITY.HEIGHT_UNIT;
-  const wallHeight = totalHeight - GRIDFINITY.BASE_HEIGHT;
+  // Wall extends from socket top to bin top. Per Gridfinity spec, base is 1u (7mm),
+  // but the physical socket structure is 5mm deep. Wall = total - socket depth.
+  // Total height: e.g., 3u + lip = 21 + 4.4 = 25.4mm
+  const wallHeight = totalHeight - SOCKET_HEIGHT;
 
   const outerW = params.width * SIZE - CLEARANCE;
   const outerD = params.depth * SIZE - CLEARANCE;


### PR DESCRIPTION
## Summary
- Update dimension controls to match bin inspector layout (width/depth on same row with swap button, height on its own row)
- Reorder parameter panels: Dimensions → Walls → Interior → Base → Physical Units
- Fix stacking lip to add 4.4mm height per Gridfinity spec v5 (was incorrectly using 5mm socket dimensions)
- Add lip-specific constants: `LIP_HEIGHT`, `LIP_SMALL_TAPER`, `LIP_VERTICAL_PART`, `LIP_BIG_TAPER`
- Fix mesh height calculation: `wallHeight = totalHeight - SOCKET_HEIGHT`
- Fix height dimension line to match actual bin mesh (3u + lip = 25.4mm)
- Respect user's custom `heightUnitMm`/`gridUnitMm` in dimension labels
- Reduce dimension line end cap size from 2 to 1

## Test plan
- [x] Build passes
- [x] All 351 affected tests pass
- [ ] Visual verification of dimension controls layout
- [ ] Verify 3u bin with lip displays as 25.4mm height
- [ ] Verify dimension lines match mesh geometry