### PR TITLE
feat(bin-designer): auto-save designs without explicit first save

### DIFF
--- a/src/features/bin-designer/__tests__/hooks/useDesignerInit.test.ts
+++ b/src/features/bin-designer/__tests__/hooks/useDesignerInit.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useDesignerInit } from '../../hooks/useDesignerInit';
+import { useDesignerStore } from '../../store/designer';
+import * as DesignerStorage from '@/features/bin-designer/storage/DesignerStorage';
+import { ok, err, storageUnavailable } from '@/core/result';
+import { DEFAULT_BIN_PARAMS } from '../../constants/defaults';
+import type { SavedDesign } from '../../types';
+
+vi.mock('@/features/bin-designer/storage/DesignerStorage');
+vi.mock('@/hooks/useDesignerRouting', () => ({
+  useDesignerRouting: () => ({
+    designIdFromUrl: null,
+    syncUrlToDesign: vi.fn(),
+  }),
+}));
+
+describe('useDesignerInit', () => {
+  const mockDesign: SavedDesign = {
+    id: 'init-design-123',
+    name: 'Untitled Bin',
+    params: { ...DEFAULT_BIN_PARAMS },
+    thumbnail: null,
+    createdAt: '2026-01-27T00:00:00.000Z',
+    updatedAt: '2026-01-27T00:00:00.000Z',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Reset store to clean state
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS },
+      currentDesignId: null,
+      designName: 'Untitled Bin',
+      saveStatus: 'idle',
+      history: { past: [], future: [] },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should create a new design on first load when no design exists', async () => {
+    vi.mocked(DesignerStorage.initializeDesigner).mockResolvedValue(ok(mockDesign));
+    vi.mocked(DesignerStorage.setActiveDesignId).mockImplementation(() => {});
+
+    renderHook(() => useDesignerInit());
+
+    await waitFor(() => {
+      expect(DesignerStorage.initializeDesigner).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(useDesignerStore.getState().currentDesignId).toBe('init-design-123');
+    });
+
+    expect(DesignerStorage.setActiveDesignId).toHaveBeenCalledWith('init-design-123');
+  });
+
+  it('should not initialize when currentDesignId is already set', async () => {
+    useDesignerStore.setState({ currentDesignId: 'existing-design' });
+
+    renderHook(() => useDesignerInit());
+
+    // Give it time to potentially call initializeDesigner
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(DesignerStorage.initializeDesigner).not.toHaveBeenCalled();
+  });
+
+  it('should create a new design after newDesign() is called', async () => {
+    // Start with an existing design
+    useDesignerStore.setState({ currentDesignId: 'existing-design' });
+
+    vi.mocked(DesignerStorage.createNewDesign).mockResolvedValue(ok(mockDesign));
+    vi.mocked(DesignerStorage.setActiveDesignId).mockImplementation(() => {});
+
+    const { rerender } = renderHook(() => useDesignerInit());
+
+    // Simulate user clicking "New Design" which sets currentDesignId to null
+    act(() => {
+      useDesignerStore.getState().newDesign();
+    });
+
+    rerender();
+
+    await waitFor(() => {
+      expect(DesignerStorage.createNewDesign).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(useDesignerStore.getState().currentDesignId).toBe('init-design-123');
+    });
+  });
+
+  it('should handle initialization error gracefully', async () => {
+    vi.mocked(DesignerStorage.initializeDesigner).mockResolvedValue(
+      err(storageUnavailable('indexedDB', new Error('storage error')))
+    );
+
+    renderHook(() => useDesignerInit());
+
+    await waitFor(() => {
+      expect(DesignerStorage.initializeDesigner).toHaveBeenCalled();
+    });
+
+    // Should not crash, currentDesignId stays null
+    expect(useDesignerStore.getState().currentDesignId).toBeNull();
+  });
+});

--- a/src/features/bin-designer/__tests__/storage.test.ts
+++ b/src/features/bin-designer/__tests__/storage.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { isOk, isErr } from '@/core/result';
 import {
   saveDesign,
@@ -7,6 +7,10 @@ import {
   deleteDesign,
   updateDesignParams,
   closeDesignerDb,
+  getActiveDesignId,
+  setActiveDesignId,
+  createNewDesign,
+  initializeDesigner,
 } from '@/features/bin-designer/storage/DesignerStorage';
 import { DEFAULT_BIN_PARAMS } from '../constants/defaults';
 import type { BinParams } from '../types';
@@ -186,6 +190,110 @@ describe('DesignerStorage', () => {
     it('should return error for non-existent design', async () => {
       const result = await updateDesignParams('nonexistent', DEFAULT_BIN_PARAMS);
       expect(isErr(result)).toBe(true);
+    });
+  });
+
+  describe('activeDesignId', () => {
+    const ACTIVE_DESIGN_KEY = 'gridfinity-designer-active-v1';
+
+    afterEach(() => {
+      localStorage.removeItem(ACTIVE_DESIGN_KEY);
+    });
+
+    it('should return null when no active design is set', () => {
+      expect(getActiveDesignId()).toBeNull();
+    });
+
+    it('should set and get active design ID', () => {
+      setActiveDesignId('test-design-123');
+      expect(getActiveDesignId()).toBe('test-design-123');
+    });
+
+    it('should clear active design ID when set to null', () => {
+      setActiveDesignId('test-design-123');
+      setActiveDesignId(null);
+      expect(getActiveDesignId()).toBeNull();
+    });
+  });
+
+  describe('createNewDesign', () => {
+    it('should create a new design with default params', async () => {
+      const result = await createNewDesign();
+
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        expect(result.value.id).toMatch(/^design_/);
+        expect(result.value.name).toBe('Untitled Bin');
+        expect(result.value.params).toEqual(DEFAULT_BIN_PARAMS);
+      }
+    });
+
+    it('should create a new design with custom name', async () => {
+      const result = await createNewDesign('My Custom Bin');
+
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        expect(result.value.name).toBe('My Custom Bin');
+      }
+    });
+  });
+
+  describe('initializeDesigner', () => {
+    const ACTIVE_DESIGN_KEY = 'gridfinity-designer-active-v1';
+
+    afterEach(() => {
+      localStorage.removeItem(ACTIVE_DESIGN_KEY);
+    });
+
+    it('should create a new design when no active design exists', async () => {
+      const result = await initializeDesigner();
+
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        expect(result.value.name).toBe('Untitled Bin');
+        expect(result.value.params).toEqual(DEFAULT_BIN_PARAMS);
+      }
+    });
+
+    it('should load existing active design', async () => {
+      // Create a design first
+      const createResult = await saveDesign({
+        id: 'existing-design',
+        name: 'Existing Design',
+        params: { ...DEFAULT_BIN_PARAMS, width: 5 },
+        thumbnail: null,
+      });
+      expect(isOk(createResult)).toBe(true);
+
+      // Set it as active
+      setActiveDesignId('existing-design');
+
+      // Initialize should load it
+      const result = await initializeDesigner();
+
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        expect(result.value.id).toBe('existing-design');
+        expect(result.value.name).toBe('Existing Design');
+        expect(result.value.params.width).toBe(5);
+      }
+    });
+
+    it('should create new design if active design was deleted', async () => {
+      // Set a non-existent design as active
+      setActiveDesignId('deleted-design');
+
+      const result = await initializeDesigner();
+
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        // Should create a new design, not the deleted one
+        expect(result.value.id).not.toBe('deleted-design');
+        expect(result.value.name).toBe('Untitled Bin');
+      }
+
+      // Should have cleared the stale reference
+      expect(getActiveDesignId()).not.toBe('deleted-design');
     });
   });
 });

--- a/src/features/bin-designer/components/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage.tsx
@@ -16,6 +16,7 @@ import { ExportDialog } from '@/features/bin-designer/components/ExportDialog';
 import { DesignListDialog } from '@/features/bin-designer/components/DesignListDialog';
 import { ToolSwitcher } from '@/shared/components/ToolSwitcher';
 import { useGeneration } from '@/features/bin-designer/hooks/useGeneration';
+import { useDesignerInit } from '@/features/bin-designer/hooks/useDesignerInit';
 import { useAutoSave } from '@/features/bin-designer/hooks/useAutoSave';
 import { useDesignerUrlSync } from '@/features/bin-designer/hooks/useDesignerUrlSync';
 import { fetchDesignerShare } from '@/features/bin-designer/hooks/useDesignerSharing';
@@ -128,6 +129,10 @@ function SaveStatusIndicator({ status }: { status: SaveStatus }) {
  * @returns The rendered Designer page element.
  */
 export function DesignerPage(_props: DesignerPageProps) {
+  // Initialize designer - ensures we always have an active design
+  // Must be called before useAutoSave to set currentDesignId
+  useDesignerInit();
+
   // Initialize generation bridge - auto-generates mesh when params change
   useGeneration();
 

--- a/src/features/bin-designer/hooks/index.ts
+++ b/src/features/bin-designer/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useAutoSave } from './useAutoSave';
+export { useDesignerInit } from './useDesignerInit';
 export { useDesignerKeyboard } from './useDesignerKeyboard';
 export { useDesignerUrlSync } from './useDesignerUrlSync';
 export { useExport } from './useExport';

--- a/src/features/bin-designer/hooks/useAutoSave.ts
+++ b/src/features/bin-designer/hooks/useAutoSave.ts
@@ -9,7 +9,10 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { isOk } from '@/core/result';
-import { updateDesignParams } from '@/features/bin-designer/storage/DesignerStorage';
+import {
+  updateDesignParams,
+  setActiveDesignId,
+} from '@/features/bin-designer/storage/DesignerStorage';
 import { useDesignerStore } from '../store';
 import { captureThumbnail } from '../utils/thumbnail';
 import { upsertRegistryEntry } from '../store/customBinRegistry';
@@ -39,7 +42,8 @@ export function useAutoSave(): void {
   const isFirstRender = useRef(true);
   const lastSavedParams = useRef<BinParams | null>(null);
   const lastSavedConfig = useRef<ExportFileNameConfig | null>(null);
-  const abortRef = useRef(false);
+  // Abort token for the current pending save (new object per effect run)
+  const abortTokenRef = useRef<{ current: boolean }>({ current: false });
 
   const performSave = useCallback(
     async (
@@ -59,6 +63,8 @@ export function useAutoSave(): void {
         lastSavedParams.current = paramsToSave;
         lastSavedConfig.current = configToSave;
         setSaveStatus('saved');
+        // Track active design for session restoration
+        setActiveDesignId(result.value.id);
         // Sync lightweight ref to registry for Layout Planner
         upsertRegistryEntry({
           id: result.value.id,
@@ -97,14 +103,14 @@ export function useAutoSave(): void {
     }
 
     // Abort any in-flight save and clear pending timer
-    abortRef.current = true;
+    abortTokenRef.current.current = true;
     if (timerRef.current) {
       clearTimeout(timerRef.current);
     }
 
-    // Reset abort flag for the new save
-    abortRef.current = false;
-    const abortToken = abortRef;
+    // Create a new abort token for this save (separate object per timeout)
+    const abortToken = { current: false };
+    abortTokenRef.current = abortToken;
 
     const designId = currentDesignId; // Narrowed to string by guard above
     timerRef.current = setTimeout(() => {
@@ -112,7 +118,7 @@ export function useAutoSave(): void {
     }, AUTO_SAVE_DELAY_MS);
 
     return () => {
-      abortRef.current = true;
+      abortToken.current = true;
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }

--- a/src/features/bin-designer/hooks/useDesignerInit.ts
+++ b/src/features/bin-designer/hooks/useDesignerInit.ts
@@ -1,0 +1,109 @@
+/**
+ * Designer initialization hook.
+ *
+ * Ensures the designer always has an active design.
+ * Similar to how the grid editor's initializeLayoutLibrary() works,
+ * but async since we use IndexedDB.
+ *
+ * Flow:
+ * 1. If URL has ?id=, let useDesignerUrlSync handle loading
+ * 2. If no URL param and no currentDesignId, initialize:
+ *    - Try to load previously active design from storage
+ *    - If not found, create a new "Untitled Bin" design
+ * 3. Set currentDesignId so auto-save works immediately
+ *
+ * Also handles when newDesign() is called (sets currentDesignId to null):
+ * - Creates a new design immediately to keep auto-save working
+ */
+
+import { useEffect, useRef } from 'react';
+import { isOk } from '@/core/result';
+import {
+  initializeDesigner,
+  createNewDesign,
+  setActiveDesignId,
+} from '@/features/bin-designer/storage/DesignerStorage';
+import { useDesignerStore } from '../store';
+import { useDesignerRouting } from '@/hooks/useDesignerRouting';
+import { upsertRegistryEntry } from '../store/customBinRegistry';
+
+/**
+ * Initialize the designer with an active design.
+ *
+ * Must be called before useAutoSave to ensure currentDesignId is set.
+ * Skips initialization if URL contains a design ID (defers to useDesignerUrlSync).
+ */
+export function useDesignerInit(): void {
+  const { designIdFromUrl } = useDesignerRouting();
+  const currentDesignId = useDesignerStore((s) => s.currentDesignId);
+  const loadDesign = useDesignerStore((s) => s.loadDesign);
+  const setCurrentDesignId = useDesignerStore((s) => s.setCurrentDesignId);
+
+  // Track if this is the first time currentDesignId became null
+  // (vs. being null on mount which needs full initialization)
+  const hasInitialized = useRef(false);
+  const initInProgress = useRef(false);
+
+  useEffect(() => {
+    // Skip if URL has a design ID - useDesignerUrlSync will handle it
+    if (designIdFromUrl) {
+      hasInitialized.current = true;
+      return;
+    }
+
+    // Skip if we already have a design loaded
+    if (currentDesignId) {
+      hasInitialized.current = true;
+      return;
+    }
+
+    // Prevent concurrent initialization
+    if (initInProgress.current) return;
+    initInProgress.current = true;
+
+    const doInit = async () => {
+      if (!hasInitialized.current) {
+        // First load - try to restore previous session or create new
+        const result = await initializeDesigner();
+        if (isOk(result)) {
+          const design = result.value;
+          loadDesign(design);
+          setActiveDesignId(design.id);
+          syncToRegistry(design);
+        }
+      } else {
+        // newDesign() was called - create a fresh design
+        const result = await createNewDesign();
+        if (isOk(result)) {
+          const design = result.value;
+          // Only set the ID, params are already reset by newDesign()
+          setCurrentDesignId(design.id);
+          setActiveDesignId(design.id);
+          syncToRegistry(design);
+        }
+      }
+      hasInitialized.current = true;
+      initInProgress.current = false;
+    };
+
+    void doInit();
+  }, [designIdFromUrl, currentDesignId, loadDesign, setCurrentDesignId]);
+}
+
+function syncToRegistry(design: {
+  id: string;
+  name: string;
+  params: { width: number; depth: number; height: number };
+  thumbnail: string | null;
+  updatedAt: string;
+}): void {
+  upsertRegistryEntry({
+    id: design.id,
+    name: design.name,
+    width: design.params.width,
+    depth: design.params.depth,
+    height: design.params.height,
+    thumbnail: design.thumbnail,
+    updatedAt: design.updatedAt,
+  });
+}

--- a/src/features/bin-designer/storage/DesignerStorage.ts
+++ b/src/features/bin-designer/storage/DesignerStorage.ts
@@ -17,10 +17,15 @@ import {
   storageUnavailable,
 } from '@/core/result';
 import type { SavedDesign, BinParams, ExportFileNameConfig } from '@/features/bin-designer/types';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import { DEFAULT_EXPORT_FILE_NAME_CONFIG } from '@/features/bin-designer/utils/fileNaming';
 
 const DB_NAME = 'gridfinity-designer-v1';
 const DB_VERSION = 1;
 const DESIGNS_STORE = 'designs';
+
+/** localStorage key for tracking the active design ID across sessions */
+const ACTIVE_DESIGN_KEY = 'gridfinity-designer-active-v1';
 
 let dbInstance: IDBPDatabase | null = null;
 
@@ -182,4 +187,79 @@ export async function updateDesignParams(
     ...(thumbnail !== undefined ? { thumbnail } : {}),
     ...(exportFileNameConfig !== undefined ? { exportFileNameConfig } : {}),
   });
+}
+
+// === Active Design Tracking ===
+
+/**
+ * Get the active design ID from localStorage.
+ * Returns null if no active design is set.
+ */
+export function getActiveDesignId(): string | null {
+  try {
+    return localStorage.getItem(ACTIVE_DESIGN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save the active design ID to localStorage.
+ * Pass null to clear the active design.
+ */
+export function setActiveDesignId(id: string | null): void {
+  try {
+    if (id === null) {
+      localStorage.removeItem(ACTIVE_DESIGN_KEY);
+    } else {
+      localStorage.setItem(ACTIVE_DESIGN_KEY, id);
+    }
+  } catch {
+    // Storage unavailable - silently fail
+  }
+}
+
+/**
+ * Create a new design with default parameters and save it to IndexedDB.
+ * Returns the saved design.
+ */
+export async function createNewDesign(
+  name: string = 'Untitled Bin'
+): Promise<Result<SavedDesign, StorageError>> {
+  return saveDesign({
+    name,
+    params: { ...DEFAULT_BIN_PARAMS },
+    thumbnail: null,
+    exportFileNameConfig: { ...DEFAULT_EXPORT_FILE_NAME_CONFIG },
+  });
+}
+
+/**
+ * Initialize the designer storage system.
+ *
+ * Similar to how the grid editor's initializeLayoutLibrary() works:
+ * - If there's an active design ID saved, try to load it
+ * - If loading fails or no active design, create a new one
+ * - Always returns a valid SavedDesign
+ *
+ * @returns The active design (loaded or newly created)
+ */
+export async function initializeDesigner(): Promise<Result<SavedDesign, StorageError>> {
+  // Try to load the previously active design
+  const activeId = getActiveDesignId();
+  if (activeId) {
+    const loadResult = await loadDesign(activeId);
+    if (!isErr(loadResult)) {
+      return loadResult;
+    }
+    // Active design not found - clear the stale reference
+    setActiveDesignId(null);
+  }
+
+  // No active design or failed to load - create a new one
+  const createResult = await createNewDesign();
+  if (!isErr(createResult)) {
+    setActiveDesignId(createResult.value.id);
+  }
+  return createResult;
 }


### PR DESCRIPTION
## Summary
- Make bin designer auto-save work like grid editor
- Designs are created and persisted immediately on first load
- Auto-save works without requiring users to rename/save first
- Refreshing page now restores your design instead of resetting to 2×2 defaults

## Changes
- Add `initializeDesigner()` to create design on first load
- Add `useDesignerInit` hook to ensure active design exists
- Track active design ID in localStorage for session restoration
- Fix abort token race condition in `useAutoSave`

## Test plan
- [x] Build succeeds
- [x] All 49 affected tests pass
- [ ] Manual test: Open designer, change params, refresh - design persists
- [ ] Manual test: Click "New Design" in My Designs - new design created and auto-saves