### PR TITLE
fix: remove build step from pre-commit and fix failing tests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,5 +3,4 @@ npm run check:boundaries:staged
 npm run check:i18n
 npm run check:i18n:interpolation
 npm run check:exhaustiveness
-npm run build
 npm run test:affected

--- a/src/features/grid-editor/components/Grid/Bin.tsx
+++ b/src/features/grid-editor/components/Grid/Bin.tsx
@@ -666,18 +666,6 @@ function BinComponent({
       tabIndex={isGhost ? -1 : 0}
       title={isGhost ? undefined : bin.label ? `${dimensionsText} - ${bin.label}` : undefined}
     >
-      {/* Gradient fade for bins protruding above layer height - subtle top edge indicator */}
-      {isTall && !isGhost && (
-        <div
-          className="absolute inset-0 pointer-events-none rounded-[inherit]"
-          style={{
-            background:
-              'linear-gradient(to top, transparent 50%, color-mix(in srgb, var(--color-warning) 15%, transparent) 85%, color-mix(in srgb, var(--color-warning) 25%, transparent) 100%)',
-          }}
-          aria-hidden="true"
-        />
-      )}
-
       {/* Tall bin indicator badge */}
       {isTall && !isGhost && (
         <div

--- a/src/test/components/Sidebar.test.tsx
+++ b/src/test/components/Sidebar.test.tsx
@@ -441,7 +441,8 @@ describe('Sidebar', () => {
     it('renders Gridfinity attribution', () => {
       render(<Sidebar />);
 
-      expect(screen.getByText(/by Zack Freedman/)).toBeInTheDocument();
+      // "Gridfinity by" is a text node, "Zack Freedman" is in a separate <a> element
+      expect(screen.getByText(/Gridfinity by/)).toBeInTheDocument();
       expect(screen.getByText('Zack Freedman')).toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Summary
- Remove `npm run build` from pre-commit hook for faster commits (build runs in CI anyway)
- Fix Sidebar attribution test that was incorrectly looking for text across DOM element boundaries (`/by Zack Freedman/` → `/Gridfinity by/`)
- Remove gradient overlay on bins taller than layer height (height badge still remains as visual indicator)

## Test plan
- [x] All unit tests pass
- [x] Pre-commit hooks run faster without build step
- [x] Tall bins display height badge without gradient overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)