### PR TITLE
fix: redirect Claude hook output to stderr for proper visibility

### DIFF
--- a/.claude/hooks/a11y-check.sh
+++ b/.claude/hooks/a11y-check.sh
@@ -70,12 +70,12 @@ for file in $STAGED; do
 done
 
 if [[ -n "$ISSUES" ]]; then
-  echo ""
-  echo "⚠️  Accessibility issues detected in staged files:"
-  echo "─────────────────────────────────────────────────"
-  echo -e "$ISSUES"
-  echo "─────────────────────────────────────────────────"
-  echo "Fix these issues or use --no-verify to skip (not recommended)"
+  echo "" >&2
+  echo "⚠️  Accessibility issues detected in staged files:" >&2
+  echo "─────────────────────────────────────────────────" >&2
+  echo -e "$ISSUES" >&2
+  echo "─────────────────────────────────────────────────" >&2
+  echo "Fix these issues or use --no-verify to skip (not recommended)" >&2
   exit 2  # Block the commit
 fi
 

--- a/.claude/hooks/coverage-check.sh
+++ b/.claude/hooks/coverage-check.sh
@@ -91,13 +91,13 @@ for file in $MODIFIED; do
 done
 
 if [[ -n "$WARNINGS" ]]; then
-  echo ""
-  echo "📋 Test coverage gaps (warning only):"
-  echo "─────────────────────────────────────"
-  echo -e "$WARNINGS"
-  echo "─────────────────────────────────────"
-  echo "Consider adding tests for new code."
-  echo ""
+  echo "" >&2
+  echo "📋 Test coverage gaps (warning only):" >&2
+  echo "─────────────────────────────────────" >&2
+  echo -e "$WARNINGS" >&2
+  echo "─────────────────────────────────────" >&2
+  echo "Consider adding tests for new code." >&2
+  echo "" >&2
 fi
 
 # Always exit 0 - this is a warning, not a blocker

--- a/.claude/hooks/dangerous-patterns.sh
+++ b/.claude/hooks/dangerous-patterns.sh
@@ -139,12 +139,12 @@ for file in "${TS_FILES[@]}"; do
 done
 
 if [[ -n "$ISSUES" ]]; then
-  echo ""
-  echo "Dangerous patterns detected:"
-  echo "---------------------------------------------"
-  printf '%b' "$ISSUES"
-  echo "---------------------------------------------"
-  echo "Fix these issues or use --no-verify to skip (not recommended)"
+  echo "" >&2
+  echo "Dangerous patterns detected:" >&2
+  echo "---------------------------------------------" >&2
+  printf '%b' "$ISSUES" >&2
+  echo "---------------------------------------------" >&2
+  echo "Fix these issues or use --no-verify to skip (not recommended)" >&2
   exit 2  # Block the commit
 fi
 

--- a/.claude/hooks/effect-cleanup-check.sh
+++ b/.claude/hooks/effect-cleanup-check.sh
@@ -147,18 +147,18 @@ if echo "$CONTENT" | grep -qE 'Ref.*setTimeout|timeoutRef|timerRef'; then
 fi
 
 if [[ -n "$WARNINGS" ]]; then
-  echo ""
-  echo "useEffect cleanup warnings:"
-  echo "---------------------------------------------"
-  echo -e "$WARNINGS"
-  echo "---------------------------------------------"
-  echo "Effects that set up subscriptions/timers should clean up:"
-  echo ""
-  echo "  useEffect(() => {"
-  echo "    const id = setTimeout(fn, delay);"
-  echo "    return () => clearTimeout(id);  // Cleanup!"
-  echo "  }, [deps]);"
-  echo ""
+  echo "" >&2
+  echo "useEffect cleanup warnings:" >&2
+  echo "---------------------------------------------" >&2
+  echo -e "$WARNINGS" >&2
+  echo "---------------------------------------------" >&2
+  echo "Effects that set up subscriptions/timers should clean up:" >&2
+  echo "" >&2
+  echo "  useEffect(() => {" >&2
+  echo "    const id = setTimeout(fn, delay);" >&2
+  echo "    return () => clearTimeout(id);  // Cleanup!" >&2
+  echo "  }, [deps]);" >&2
+  echo "" >&2
 fi
 
 # Informational only - always allow

--- a/.claude/hooks/post-edit-test.sh
+++ b/.claude/hooks/post-edit-test.sh
@@ -65,11 +65,11 @@ EXIT_CODE=$?
 
 # Only show output if tests failed
 if [[ $EXIT_CODE -ne 0 ]]; then
-  echo ""
-  echo "✗ Tests failed for $(basename "$TEST_FILE")"
-  echo "─────────────────────────────────────"
-  echo "$OUTPUT" | tail -30
-  echo "─────────────────────────────────────"
+  echo "" >&2
+  echo "✗ Tests failed for $(basename "$TEST_FILE")" >&2
+  echo "─────────────────────────────────────" >&2
+  echo "$OUTPUT" | tail -30 >&2
+  echo "─────────────────────────────────────" >&2
 fi
 
 # Always exit 0 - PostToolUse hooks are informational

--- a/.claude/hooks/pre-pr-review.sh
+++ b/.claude/hooks/pre-pr-review.sh
@@ -12,9 +12,9 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 # Only run for gh pr create commands
 [[ "$COMMAND" != *"gh pr create"* ]] && exit 0
 
-echo ""
-echo "🔍 Running pre-PR review..."
-echo "═══════════════════════════════════════════════════════════════"
+echo "" >&2
+echo "🔍 Running pre-PR review..." >&2
+echo "═══════════════════════════════════════════════════════════════" >&2
 
 # Detect base branch
 BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
@@ -30,13 +30,13 @@ STATS=$(git diff --stat "$BASE_BRANCH"..."$CURRENT_BRANCH" 2>/dev/null | tail -1
 NUM_FILES=$(echo "$FILES_CHANGED" | grep -c . || echo "0")
 NUM_COMMITS=$(echo "$COMMITS" | grep -c . || echo "0")
 
-echo ""
-echo "Branch: $CURRENT_BRANCH → $BASE_BRANCH"
-echo "Files changed: $NUM_FILES"
-echo "Commits: $NUM_COMMITS"
-echo "Stats: $STATS"
-echo ""
-echo "───────────────────────────────────────────────────────────────"
+echo "" >&2
+echo "Branch: $CURRENT_BRANCH → $BASE_BRANCH" >&2
+echo "Files changed: $NUM_FILES" >&2
+echo "Commits: $NUM_COMMITS" >&2
+echo "Stats: $STATS" >&2
+echo "" >&2
+echo "───────────────────────────────────────────────────────────────" >&2
 
 ISSUES=""
 
@@ -119,22 +119,22 @@ fi
 
 # Display findings
 if [[ -n "$ISSUES" ]]; then
-  echo ""
-  echo "Issues found:"
-  echo "───────────────────────────────────────────────────────────────"
-  echo -e "$ISSUES"
-  echo "───────────────────────────────────────────────────────────────"
+  echo "" >&2
+  echo "Issues found:" >&2
+  echo "───────────────────────────────────────────────────────────────" >&2
+  echo -e "$ISSUES" >&2
+  echo "───────────────────────────────────────────────────────────────" >&2
 else
-  echo ""
-  echo "✅ No obvious issues found in quick checks."
+  echo "" >&2
+  echo "✅ No obvious issues found in quick checks." >&2
 fi
 
-echo ""
-echo "Files in this PR:"
-echo "$FILES_CHANGED" | head -15
-[[ $NUM_FILES -gt 15 ]] && echo "... and $((NUM_FILES - 15)) more"
-echo ""
-echo "═══════════════════════════════════════════════════════════════"
+echo "" >&2
+echo "Files in this PR:" >&2
+echo "$FILES_CHANGED" | head -15 >&2
+[[ $NUM_FILES -gt 15 ]] && echo "... and $((NUM_FILES - 15)) more" >&2
+echo "" >&2
+echo "═══════════════════════════════════════════════════════════════" >&2
 
 # Informational only - always allow PR creation
 exit 0

--- a/.claude/hooks/result-exhaustion-check.sh
+++ b/.claude/hooks/result-exhaustion-check.sh
@@ -93,26 +93,26 @@ for file in "${TS_FILES[@]}"; do
 done
 
 if [[ -n "$ISSUES" ]]; then
-  echo ""
-  echo "Result type exhaustion issues:"
-  echo "---------------------------------------------"
-  printf '%b' "$ISSUES"
-  echo "---------------------------------------------"
-  echo "Result<T,E> values must be checked with isOk()/isErr()"
-  echo ""
-  echo "Correct patterns:"
-  echo "  const result = addBin(...);"
-  echo "  if (isOk(result)) { /* use result.value */ }"
-  echo "  if (isErr(result)) { /* handle result.error */ }"
-  echo ""
-  echo "For bulk operations:"
-  echo "  const errors: Error[] = [];"
-  echo "  for (const item of items) {"
-  echo "    const result = process(item);"
-  echo "    if (isErr(result)) errors.push(result.error);"
-  echo "  }"
-  echo ""
-  echo "Use --no-verify to skip (not recommended)"
+  echo "" >&2
+  echo "Result type exhaustion issues:" >&2
+  echo "---------------------------------------------" >&2
+  printf '%b' "$ISSUES" >&2
+  echo "---------------------------------------------" >&2
+  echo "Result<T,E> values must be checked with isOk()/isErr()" >&2
+  echo "" >&2
+  echo "Correct patterns:" >&2
+  echo "  const result = addBin(...);" >&2
+  echo "  if (isOk(result)) { /* use result.value */ }" >&2
+  echo "  if (isErr(result)) { /* handle result.error */ }" >&2
+  echo "" >&2
+  echo "For bulk operations:" >&2
+  echo "  const errors: Error[] = [];" >&2
+  echo "  for (const item of items) {" >&2
+  echo "    const result = process(item);" >&2
+  echo "    if (isErr(result)) errors.push(result.error);" >&2
+  echo "  }" >&2
+  echo "" >&2
+  echo "Use --no-verify to skip (not recommended)" >&2
   exit 2
 fi
 

--- a/.claude/hooks/suppression-guard.sh
+++ b/.claude/hooks/suppression-guard.sh
@@ -76,18 +76,18 @@ for file in "${TS_FILES[@]}"; do
 done
 
 if [[ -n "$ISSUES" ]]; then
-  echo ""
-  echo "Suppression comments require justification:"
-  echo "---------------------------------------------"
-  printf '%b' "$ISSUES"
-  echo "---------------------------------------------"
-  echo "Valid formats:"
-  echo "  // @ts-expect-error TECH-DEBT: description"
-  echo "  // @ts-expect-error #123"
-  echo "  // eslint-disable-next-line rule -- explanation"
-  echo "  // eslint-disable-next-line rule -- TECH-DEBT: reason"
-  echo ""
-  echo "Use --no-verify to skip (not recommended)"
+  echo "" >&2
+  echo "Suppression comments require justification:" >&2
+  echo "---------------------------------------------" >&2
+  printf '%b' "$ISSUES" >&2
+  echo "---------------------------------------------" >&2
+  echo "Valid formats:" >&2
+  echo "  // @ts-expect-error TECH-DEBT: description" >&2
+  echo "  // @ts-expect-error #123" >&2
+  echo "  // eslint-disable-next-line rule -- explanation" >&2
+  echo "  // eslint-disable-next-line rule -- TECH-DEBT: reason" >&2
+  echo "" >&2
+  echo "Use --no-verify to skip (not recommended)" >&2
   exit 2  # Block the commit
 fi
 

--- a/.claude/hooks/union-exhaustiveness-check.sh
+++ b/.claude/hooks/union-exhaustiveness-check.sh
@@ -178,21 +178,21 @@ for file in "${TS_FILES[@]}"; do
 done
 
 if [[ -n "$ISSUES" ]]; then
-  echo ""
-  echo "Union type exhaustiveness issues:"
-  echo "---------------------------------------------"
-  printf '%b' "$ISSUES"
-  echo "---------------------------------------------"
-  echo "Switch statements on union types should handle all cases."
-  echo ""
-  echo "Options:"
-  echo "  1. Add missing case statements"
-  echo "  2. Add default with exhaustive check:"
-  echo "     default:"
-  echo "       const _exhaustive: never = value;"
-  echo "       throw new Error('Unhandled case');"
-  echo ""
-  echo "Use --no-verify to skip (not recommended)"
+  echo "" >&2
+  echo "Union type exhaustiveness issues:" >&2
+  echo "---------------------------------------------" >&2
+  printf '%b' "$ISSUES" >&2
+  echo "---------------------------------------------" >&2
+  echo "Switch statements on union types should handle all cases." >&2
+  echo "" >&2
+  echo "Options:" >&2
+  echo "  1. Add missing case statements" >&2
+  echo "  2. Add default with exhaustive check:" >&2
+  echo "     default:" >&2
+  echo "       const _exhaustive: never = value;" >&2
+  echo "       throw new Error('Unhandled case');" >&2
+  echo "" >&2
+  echo "Use --no-verify to skip (not recommended)" >&2
   exit 2
 fi
 

--- a/.claude/hooks/use-shallow-check.sh
+++ b/.claude/hooks/use-shallow-check.sh
@@ -79,14 +79,14 @@ if [[ -n "$DESTRUCTURE_SELECTOR" ]] && ! echo "$CONTENT" | grep -q "useShallow";
 fi
 
 if [[ -n "$WARNINGS" ]]; then
-  echo ""
-  echo "Zustand selector optimization (useShallow):"
-  echo "---------------------------------------------"
-  echo -e "$WARNINGS"
-  echo "---------------------------------------------"
-  echo "Import: import { useShallow } from 'zustand/react/shallow'"
-  echo "Usage:  useStore(useShallow(state => ({ a: state.a, b: state.b })))"
-  echo ""
+  echo "" >&2
+  echo "Zustand selector optimization (useShallow):" >&2
+  echo "---------------------------------------------" >&2
+  echo -e "$WARNINGS" >&2
+  echo "---------------------------------------------" >&2
+  echo "Import: import { useShallow } from 'zustand/react/shallow'" >&2
+  echo "Usage:  useStore(useShallow(state => ({ a: state.a, b: state.b })))" >&2
+  echo "" >&2
 fi
 
 # Informational only - always allow


### PR DESCRIPTION
## Summary
- Fix all 10 Claude Code hooks to write output to stderr instead of stdout
- When hooks block (exit code 2), only stderr is shown to Claude - stdout was being ignored
- This ensures Claude actually sees the feedback messages explaining why commits were blocked

## Hooks updated
- `a11y-check.sh`, `coverage-check.sh`, `post-edit-test.sh`
- `pre-pr-review.sh`, `dangerous-patterns.sh`, `suppression-guard.sh`
- `effect-cleanup-check.sh`, `result-exhaustion-check.sh`
- `union-exhaustiveness-check.sh`, `use-shallow-check.sh`

## Test plan
- [x] All echo/printf statements now use `>&2` redirection
- [ ] Verify blocking hooks show messages to Claude when triggered