### PR TITLE
fix: remove duplicate export button from bin designer

### DIFF
--- a/src/features/bin-designer/components/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage.tsx
@@ -454,44 +454,6 @@ export function DesignerPage(_props: DesignerPageProps) {
             </button>
           </div>
 
-          {/* Divider */}
-          <div className="w-px h-6 bg-stroke-subtle mx-1" />
-
-          {/* Export button (primary, desktop) */}
-          <button
-            onClick={() => setExportDialogOpen(true)}
-            disabled={!canExport}
-            className="hidden items-center gap-1.5 btn btn-primary px-3 py-1.5 text-sm font-medium sm:flex"
-            aria-label={t('binDesigner.exportBinAsStl')}
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
-              />
-            </svg>
-            {t('binDesigner.export')}
-          </button>
-
-          {/* Mobile export icon button */}
-          <button
-            onClick={() => setExportDialogOpen(true)}
-            disabled={!canExport}
-            className="sm:hidden btn btn-ghost btn-icon"
-            title={t('binDesigner.exportBin')}
-            aria-label={t('binDesigner.exportBinAsStl')}
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
-              />
-            </svg>
-          </button>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- Remove the primary export button and mobile export icon button from the top-right of the bin designer header
- The secondary export button in the toolbar area remains as the single export entry point
- Also removes the divider that separated the duplicate button group

## Test plan
- [x] Build succeeds
- [ ] Verify single export button works in bin designer