### PR TITLE
refactor: move share button into layout modal overflow menu

### DIFF
--- a/src/features/layout-library/components/LayoutManagerModal/LayoutActions.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutActions.tsx
@@ -18,7 +18,7 @@ interface LayoutActionsProps {
 
 /**
  * Action buttons for a layout list item.
- * Shows copy link and download as icon buttons, with overflow menu for rename/duplicate/delete.
+ * Shows download as icon button, with overflow menu for rename/duplicate/copy link/delete.
  */
 export function LayoutActions({
   entry,
@@ -100,29 +100,6 @@ export function LayoutActions({
 
   return (
     <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
-      {/* Copy Link Button */}
-      <button
-        onClick={handleAction(onCopyLink)}
-        className="p-1.5 rounded text-content-tertiary hover:text-content hover:bg-surface transition-colors"
-        title={t('common.copy')}
-        aria-label={`${t('common.copy')} ${entry.name}`}
-      >
-        <svg
-          className="w-4 h-4"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-          />
-        </svg>
-      </button>
-
       {/* Download Button */}
       <button
         onClick={handleAction(onDownload)}
@@ -242,6 +219,28 @@ export function LayoutActions({
                   />
                 </svg>
                 {t('common.duplicate')}
+              </button>
+              {/* Copy Link */}
+              <button
+                role="menuitem"
+                onClick={handleAction(onCopyLink)}
+                className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface flex items-center gap-2"
+              >
+                <svg
+                  className="w-4 h-4 text-content-secondary"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+                  />
+                </svg>
+                {t('share.copyLink')}
               </button>
               {!isOnlyLayout && (
                 <>

--- a/src/test/components/LayoutActions.test.tsx
+++ b/src/test/components/LayoutActions.test.tsx
@@ -46,12 +46,6 @@ describe('LayoutActions', () => {
   });
 
   describe('rendering', () => {
-    it('renders copy link button', () => {
-      render(<LayoutActions {...defaultProps} />);
-
-      expect(screen.getByLabelText('Copy Test Layout')).toBeInTheDocument();
-    });
-
     it('renders download button', () => {
       render(<LayoutActions {...defaultProps} />);
 
@@ -66,35 +60,12 @@ describe('LayoutActions', () => {
   });
 
   describe('icon button actions', () => {
-    it('calls onCopyLink when copy button clicked', () => {
-      render(<LayoutActions {...defaultProps} />);
-
-      fireEvent.click(screen.getByLabelText('Copy Test Layout'));
-
-      expect(mockOnCopyLink).toHaveBeenCalledOnce();
-    });
-
     it('calls onDownload when download button clicked', () => {
       render(<LayoutActions {...defaultProps} />);
 
       fireEvent.click(screen.getByLabelText('Download Test Layout'));
 
       expect(mockOnDownload).toHaveBeenCalledOnce();
-    });
-
-    it('stops propagation on icon button click', () => {
-      const parentClickHandler = vi.fn();
-
-      render(
-        <div onClick={parentClickHandler}>
-          <LayoutActions {...defaultProps} />
-        </div>
-      );
-
-      fireEvent.click(screen.getByLabelText('Copy Test Layout'));
-
-      // The parent should not receive the click
-      expect(parentClickHandler).not.toHaveBeenCalled();
     });
   });
 
@@ -105,6 +76,23 @@ describe('LayoutActions', () => {
       fireEvent.click(screen.getByLabelText('More actions for Test Layout'));
 
       expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('shows copy link option', () => {
+      render(<LayoutActions {...defaultProps} />);
+
+      fireEvent.click(screen.getByLabelText('More actions for Test Layout'));
+
+      expect(screen.getByRole('menuitem', { name: /Copy Link/ })).toBeInTheDocument();
+    });
+
+    it('calls onCopyLink when copy link clicked', () => {
+      render(<LayoutActions {...defaultProps} />);
+
+      fireEvent.click(screen.getByLabelText('More actions for Test Layout'));
+      fireEvent.click(screen.getByRole('menuitem', { name: /Copy Link/ }));
+
+      expect(mockOnCopyLink).toHaveBeenCalledOnce();
     });
 
     it('shows rename option', () => {


### PR DESCRIPTION
## Summary
- Move the Copy Link (share) button from a standalone icon button into the overflow menu in the layout manager modal
- Placed at the bottom of the menu, just before Delete
- Updated tests to reflect the new menu location

## Test plan
- [x] Build succeeds
- [x] All 24 LayoutActions tests pass
- [ ] Manual verification that Copy Link appears in overflow menu