### PR TITLE
style: add header underline to layout manager modal

### DIFF
--- a/src/features/layout-library/components/LayoutManagerModal/index.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/index.tsx
@@ -202,11 +202,11 @@ function LayoutManagerModalContent({
         role="dialog"
         aria-modal="true"
         aria-labelledby="layout-manager-title"
-        className="bg-surface-elevated rounded-lg p-6 max-w-4xl w-full mx-4 max-h-[80vh] grid grid-rows-[auto_1fr] animate-scale-in"
+        className="bg-surface-elevated rounded-lg max-w-4xl w-full mx-4 max-h-[80vh] grid grid-rows-[auto_1fr] animate-scale-in"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex justify-between items-center mb-4">
+        <div className="flex justify-between items-center border-b border-stroke-subtle px-6 py-4">
           <div className="flex items-center gap-3">
             {activeTab === 'import' && (
               <button
@@ -269,7 +269,7 @@ function LayoutManagerModalContent({
         </div>
 
         {/* Content */}
-        <div className="min-h-0 overflow-hidden flex flex-col">
+        <div className="min-h-0 overflow-hidden flex flex-col px-6 pb-6">
           {activeTab === 'layouts' && (
             <div className="flex-1 min-h-0 overflow-auto">
               <LayoutList


### PR DESCRIPTION
## Summary
- Add edge-to-edge header underline (`border-b border-stroke-subtle`) to layout manager modal, matching the design list dialog styling
- Move container padding to header/content sections so the border spans the full width

## Test plan
- [ ] Visual check that layout manager modal header has underline separator
- [ ] Verify border spans edge to edge