### PR TITLE
feat: default bin designer on, Shift+D toggle, shared overlays, UX fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,8 +139,14 @@ export default function App() {
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isMobileHelpOpen, setIsMobileHelpOpen] = useState(false);
 
-  // Command palette state (⌘K / Ctrl+K)
-  const { open: commandPaletteOpen, setOpen: setCommandPaletteOpen } = useCommandPalette();
+  // Bin Designer route detection (behind feature flag)
+  const isDesignerEnabled = useLabsStore((state) => state.isFeatureEnabled('bin_designer'));
+  const { isDesignerRoute, navigateToDesigner } = useDesignerRouting();
+
+  // Command palette state (⌘K / Ctrl+K) — disabled on designer route
+  const { open: commandPaletteOpen, setOpen: setCommandPaletteOpen } = useCommandPalette({
+    disabled: isDesignerRoute,
+  });
   const { isMobile, isTablet } = useResponsive();
   const contextMenu = useViewStore((state) => state.contextMenu);
   const hideContextMenu = useViewStore((state) => state.hideContextMenu);
@@ -160,10 +166,6 @@ export default function App() {
     const pathname = window.location.pathname;
     return hash.includes('share=') || /^\/l\/[a-zA-Z0-9]{12}$/.test(pathname);
   });
-
-  // Bin Designer route detection (behind feature flag)
-  const isDesignerEnabled = useLabsStore((state) => state.isFeatureEnabled('bin_designer'));
-  const { isDesignerRoute } = useDesignerRouting();
 
   // Handle ?placeBin= param from Designer's "Use in Layout" button
   usePlaceBinFromURL();
@@ -263,6 +265,13 @@ export default function App() {
     return () => window.removeEventListener('open-help-modal', handleOpenHelp);
   }, []);
 
+  // Switch to designer command palette action
+  useEffect(() => {
+    const handleSwitchToDesigner = () => navigateToDesigner();
+    window.addEventListener('switch-to-designer', handleSwitchToDesigner);
+    return () => window.removeEventListener('switch-to-designer', handleSwitchToDesigner);
+  }, [navigateToDesigner]);
+
   // Download layout command palette action
   useEffect(() => {
     const handleDownloadLayout = async () => {
@@ -348,9 +357,11 @@ export default function App() {
     );
   }
 
-  // Bin Designer route - lazy loaded, behind feature flag
-  if (isDesignerRoute && isDesignerEnabled) {
-    return (
+  // Route-specific content (shared overlays rendered once below)
+  const routeContent = (() => {
+    // Bin Designer route - lazy loaded, behind feature flag
+    if (isDesignerRoute && isDesignerEnabled) {
+      return (
       <Suspense fallback={<LoadingFallback label={t('loading.designer')} />}>
         <DesignerPage />
       </Suspense>
@@ -431,9 +442,6 @@ export default function App() {
           </Suspense>
         )}
 
-        {/* Command Palette (⌘K / Ctrl+K) */}
-        <CommandPalette open={commandPaletteOpen} onOpenChange={setCommandPaletteOpen} />
-
         {/* Context menu (long-press on bin) */}
         {(() => {
           if (contextMenu) {
@@ -451,20 +459,10 @@ export default function App() {
           return null;
         })()}
 
-        {/* Toast notifications */}
-        <ToastContainer />
-
         {/* Shared layout URL importer - only load when URL has share params */}
         {hasShareUrl && (
           <Suspense fallback={null}>
             <SharedLayoutImporter />
-          </Suspense>
-        )}
-
-        {/* Labs drawer - only load when drawer is open */}
-        {isLabsDrawerOpen && (
-          <Suspense fallback={null}>
-            <LabsDrawer />
           </Suspense>
         )}
       </div>
@@ -527,9 +525,6 @@ export default function App() {
         </Suspense>
       )}
 
-      {/* Command Palette (⌘K / Ctrl+K) */}
-      <CommandPalette open={commandPaletteOpen} onOpenChange={setCommandPaletteOpen} />
-
       {/* Context menu (right-click on bin) */}
       {(() => {
         if (contextMenu) {
@@ -547,9 +542,6 @@ export default function App() {
         return null;
       })()}
 
-      {/* Toast notifications */}
-      <ToastContainer />
-
       {/* ARIA live region for screen reader announcements */}
       <LiveRegion />
 
@@ -559,13 +551,23 @@ export default function App() {
           <SharedLayoutImporter />
         </Suspense>
       )}
+    </div>
+  );
+  })();
 
-      {/* Labs drawer - only load when drawer is open */}
+  // Shared overlays — rendered once for all routes (designer, mobile, tablet, desktop)
+  return (
+    <>
+      {routeContent}
+      <ToastContainer />
+      {!isMobile && (
+        <CommandPalette open={commandPaletteOpen} onOpenChange={setCommandPaletteOpen} />
+      )}
       {isLabsDrawerOpen && (
         <Suspense fallback={null}>
           <LabsDrawer />
         </Suspense>
       )}
-    </div>
+    </>
   );
 }

--- a/src/components/Modals/HelpModal.tsx
+++ b/src/components/Modals/HelpModal.tsx
@@ -63,6 +63,7 @@ interface ShortcutItem {
   keys: string | readonly string[];
   descriptionKey: string; // Translation key
   modifier?: boolean; // Whether to show Ctrl/⌘ prefix
+  shift?: boolean; // Whether to show Shift prefix
 }
 
 interface ShortcutCategory {
@@ -99,6 +100,7 @@ const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
       { keys: formatKey(SHORTCUTS.REDO), descriptionKey: 'help.shortcut.redo', modifier: true },
       { keys: formatKey(SHORTCUTS.HELP), descriptionKey: 'help.shortcut.showHelp' },
       { keys: formatKey(SHORTCUTS.ESCAPE), descriptionKey: 'help.shortcut.cancelDeselect' },
+      { keys: SHORTCUTS.TOOL_SWITCH, descriptionKey: 'help.shortcut.toolSwitch', shift: true },
     ],
   },
   {
@@ -108,10 +110,12 @@ const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
     shortcuts: [
       { keys: 'D', descriptionKey: 'help.shortcut.duplicate', modifier: true },
       { keys: formatKey(SHORTCUTS.DELETE), descriptionKey: 'help.shortcut.delete' },
+      { keys: formatKey(SHORTCUTS.ROTATE).toUpperCase(), descriptionKey: 'help.shortcut.rotate' },
       {
         keys: formatKey(SHORTCUTS.QUICK_LABEL).toUpperCase(),
         descriptionKey: 'help.shortcut.quickLabel',
       },
+      { keys: 'A', descriptionKey: 'help.shortcut.selectAll', modifier: true },
       { keys: 'Arrow keys', descriptionKey: 'help.shortcut.nudge' },
     ],
   },
@@ -162,9 +166,6 @@ const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
         descriptionKey: 'help.shortcut.togglePreview',
       },
       { keys: 'Space', descriptionKey: 'help.shortcut.expandPreview' },
-      { keys: '1', descriptionKey: 'help.shortcut.isometricView' },
-      { keys: '2', descriptionKey: 'help.shortcut.frontView' },
-      { keys: '3', descriptionKey: 'help.shortcut.sideView' },
     ],
   },
   {
@@ -176,6 +177,7 @@ const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
         keys: formatKey(SHORTCUTS.HALF_BIN_TOGGLE).toUpperCase(),
         descriptionKey: 'help.shortcut.toggleHalfBin',
       },
+      { keys: 'P', descriptionKey: 'help.shortcut.togglePaintMode' },
     ],
   },
 ];
@@ -424,6 +426,7 @@ function ShortcutCategorySection({
             keys={shortcut.keys}
             description={t(shortcut.descriptionKey)}
             modifier={shortcut.modifier}
+            shift={shortcut.shift}
             modifierKey={modifierKey}
           />
         ))}
@@ -445,11 +448,13 @@ function ShortcutRow({
   keys,
   description,
   modifier,
+  shift,
   modifierKey,
 }: {
   keys: string | readonly string[];
   description: string;
   modifier?: boolean;
+  shift?: boolean;
   modifierKey: string;
 }) {
   const keyArray = typeof keys === 'string' ? keys.split(' / ') : [...keys];
@@ -461,6 +466,12 @@ function ShortcutRow({
         {modifier && (
           <>
             <KeyboardKey>{modifierKey}</KeyboardKey>
+            <span className="text-content-tertiary text-xs">{KEY_SEPARATOR}</span>
+          </>
+        )}
+        {shift && (
+          <>
+            <KeyboardKey>Shift</KeyboardKey>
             <span className="text-content-tertiary text-xs">{KEY_SEPARATOR}</span>
           </>
         )}

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -291,4 +291,6 @@ export const SHORTCUTS = {
   HALF_BIN_TOGGLE: 'h',
   // Layout management
   LAYOUT_MANAGER: 'o', // with Ctrl/Cmd - "Open" layouts
+  // Tool switching
+  TOOL_SWITCH: 'D', // Shift+D — toggle between Grid Editor and Bin Designer
 } as const;

--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -20,6 +20,7 @@ export const FEATURE_FLAGS = [
     addedAt: '2026-01',
     requiresRefresh: false,
     comingSoon: false,
+    defaultEnabled: true,
   },
   {
     id: 'collaborative_editing',

--- a/src/core/labs/types.ts
+++ b/src/core/labs/types.ts
@@ -26,6 +26,7 @@ export interface FeatureFlag {
   requiresRefresh: boolean;
   dependencies?: string[];
   comingSoon?: boolean;
+  defaultEnabled?: boolean;
 }
 
 export interface LabsPreferences {

--- a/src/core/store/labs.ts
+++ b/src/core/store/labs.ts
@@ -166,7 +166,7 @@ export const useLabsStore = create<LabsState>()((set, get) => ({
     // Coming Soon features are always disabled
     if (feature?.comingSoon) return false;
 
-    return preferences.enabledFeatures[featureId] ?? false;
+    return preferences.enabledFeatures[featureId] ?? (feature?.defaultEnabled ?? false);
   },
 
   getEnabledCount: () => {

--- a/src/features/bin-designer/__tests__/hooks/useUnsavedWarning.test.ts
+++ b/src/features/bin-designer/__tests__/hooks/useUnsavedWarning.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useUnsavedWarning } from '../../hooks/useUnsavedWarning';
+import { useDesignerStore } from '../../store/designer';
+import { DEFAULT_BIN_PARAMS } from '../../constants/defaults';
+
+describe('useUnsavedWarning', () => {
+  let addSpy: ReturnType<typeof vi.spyOn>;
+  let removeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    addSpy = vi.spyOn(window, 'addEventListener');
+    removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    // Reset to clean state
+    useDesignerStore.setState({
+      currentDesignId: null,
+      params: { ...DEFAULT_BIN_PARAMS },
+      history: { past: [], future: [] },
+    });
+  });
+
+  it('should not register listener when no unsaved changes', () => {
+    renderHook(() => useUnsavedWarning());
+
+    const beforeunloadCalls = addSpy.mock.calls.filter(
+      ([event]) => event === 'beforeunload'
+    );
+    expect(beforeunloadCalls).toHaveLength(0);
+  });
+
+  it('should not register listener when design is saved (has ID)', () => {
+    useDesignerStore.setState({
+      currentDesignId: 'saved-id',
+      history: { past: [{ params: DEFAULT_BIN_PARAMS }], future: [] },
+    });
+
+    renderHook(() => useUnsavedWarning());
+
+    const beforeunloadCalls = addSpy.mock.calls.filter(
+      ([event]) => event === 'beforeunload'
+    );
+    expect(beforeunloadCalls).toHaveLength(0);
+  });
+
+  it('should register listener when untitled design has history', () => {
+    useDesignerStore.setState({
+      currentDesignId: null,
+      history: { past: [{ params: DEFAULT_BIN_PARAMS }], future: [] },
+    });
+
+    renderHook(() => useUnsavedWarning());
+
+    const beforeunloadCalls = addSpy.mock.calls.filter(
+      ([event]) => event === 'beforeunload'
+    );
+    expect(beforeunloadCalls).toHaveLength(1);
+  });
+
+  it('should remove listener on unmount', () => {
+    useDesignerStore.setState({
+      currentDesignId: null,
+      history: { past: [{ params: DEFAULT_BIN_PARAMS }], future: [] },
+    });
+
+    const { unmount } = renderHook(() => useUnsavedWarning());
+    unmount();
+
+    const removeCalls = removeSpy.mock.calls.filter(
+      ([event]) => event === 'beforeunload'
+    );
+    expect(removeCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should call preventDefault on beforeunload event', () => {
+    useDesignerStore.setState({
+      currentDesignId: null,
+      history: { past: [{ params: DEFAULT_BIN_PARAMS }], future: [] },
+    });
+
+    renderHook(() => useUnsavedWarning());
+
+    const handler = addSpy.mock.calls.find(
+      ([event]) => event === 'beforeunload'
+    )?.[1] as EventListener;
+
+    const event = new Event('beforeunload') as BeforeUnloadEvent;
+    const preventSpy = vi.spyOn(event, 'preventDefault');
+
+    handler(event);
+
+    expect(preventSpy).toHaveBeenCalled();
+  });
+});

--- a/src/features/bin-designer/components/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage.tsx
@@ -21,6 +21,7 @@ import { useCreateFromBin } from '@/features/bin-designer/hooks/useCreateFromBin
 import { useAutoSave } from '@/features/bin-designer/hooks/useAutoSave';
 import { useThumbnailCapture } from '@/features/bin-designer/hooks/useThumbnailCapture';
 import { useDesignerUrlSync } from '@/features/bin-designer/hooks/useDesignerUrlSync';
+import { useUnsavedWarning } from '@/features/bin-designer/hooks/useUnsavedWarning';
 import { fetchDesignerShare } from '@/features/bin-designer/hooks/useDesignerSharing';
 import { migrateParams } from '@/features/bin-designer/constants/defaults';
 import { useDesignerStore } from '@/features/bin-designer/store/designer';
@@ -150,6 +151,9 @@ export function DesignerPage(_props: DesignerPageProps) {
 
   // Sync URL ↔ store (deep linking, back/forward navigation)
   useDesignerUrlSync();
+
+  // Warn before closing tab with unsaved changes
+  useUnsavedWarning();
 
   const { isDesktop, isMobile } = useResponsive();
   const t = useTranslation();
@@ -344,7 +348,7 @@ export function DesignerPage(_props: DesignerPageProps) {
               onKeyDown={handleNameKeyDown}
               maxLength={50}
               aria-label={t('binDesigner.designName')}
-              className="px-3 py-1.5 rounded-md text-sm transition-all bg-surface-elevated border border-accent text-content"
+              className="px-3 py-1.5 rounded-md text-sm transition-all bg-surface-elevated border border-accent text-content max-w-[120px] sm:max-w-[200px]"
               style={{
                 boxShadow: '0 0 0 3px var(--color-primary-muted)',
               }}
@@ -352,7 +356,7 @@ export function DesignerPage(_props: DesignerPageProps) {
           ) : (
             <button
               onClick={handleNameClick}
-              className="hidden px-3 py-1.5 text-sm rounded-md transition-all hover:scale-[1.02] text-content-secondary bg-transparent hover:bg-surface-hover hover:text-content truncate max-w-[200px] sm:inline-block"
+              className="inline-block px-3 py-1.5 text-sm rounded-md transition-all hover:scale-[1.02] text-content-secondary bg-transparent hover:bg-surface-hover hover:text-content truncate max-w-[120px] sm:max-w-[200px]"
               title={t('binDesigner.clickToRename')}
             >
               {designName}

--- a/src/features/bin-designer/components/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas.tsx
@@ -12,6 +12,7 @@ import { Vector3, Spherical } from 'three';
 import type { PerspectiveCamera } from 'three';
 import type { OrbitControls as OrbitControlsType } from 'three-stdlib';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { useDesignerRouting } from '@/hooks/useDesignerRouting';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 import {
   BinMesh,
@@ -334,6 +335,7 @@ export function PreviewCanvas() {
   const undo = useDesignerStore((s) => s.undo);
   const redo = useDesignerStore((s) => s.redo);
   const addToast = useToastStore((s) => s.addToast);
+  const { navigateToPlanner } = useDesignerRouting();
 
   // Revert to last working configuration on generation error
   const handleRevert = useCallback(() => {
@@ -378,6 +380,7 @@ export function PreviewCanvas() {
     onToggleWireframe: toggleWireframe,
     onUndo: undo,
     onRedo: redo,
+    onToolSwitch: navigateToPlanner,
   });
 
   const handleRetry = useCallback(() => {

--- a/src/features/bin-designer/hooks/index.ts
+++ b/src/features/bin-designer/hooks/index.ts
@@ -6,3 +6,4 @@ export { useDesignerUrlSync } from './useDesignerUrlSync';
 export { useExport } from './useExport';
 export { useGeneration } from './useGeneration';
 export { useThumbnailCapture } from './useThumbnailCapture';
+export { useUnsavedWarning } from './useUnsavedWarning';

--- a/src/features/bin-designer/hooks/useDesignerKeyboard.ts
+++ b/src/features/bin-designer/hooks/useDesignerKeyboard.ts
@@ -4,6 +4,7 @@
  */
 
 import { useEffect } from 'react';
+import { SHORTCUTS } from '@/core/constants';
 import type { CameraPreset } from '../components/preview';
 
 interface UseDesignerKeyboardOptions {
@@ -12,6 +13,7 @@ interface UseDesignerKeyboardOptions {
   onToggleWireframe: () => void;
   onUndo: () => void;
   onRedo: () => void;
+  onToolSwitch?: () => void;
 }
 
 const PRESET_KEYS: Record<string, CameraPreset> = {
@@ -43,6 +45,7 @@ export function useDesignerKeyboard({
   onToggleWireframe,
   onUndo,
   onRedo,
+  onToolSwitch,
 }: UseDesignerKeyboardOptions): void {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -69,6 +72,13 @@ export function useDesignerKeyboard({
 
       if (e.altKey) return;
 
+      // Tool switch (Shift+D) — toggle to Grid Editor
+      if (e.key === SHORTCUTS.TOOL_SWITCH && e.shiftKey && onToolSwitch) {
+        e.preventDefault();
+        onToolSwitch();
+        return;
+      }
+
       const preset = PRESET_KEYS[e.key];
       if (preset) {
         e.preventDefault();
@@ -90,5 +100,5 @@ export function useDesignerKeyboard({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onCameraPreset, onResetView, onToggleWireframe, onUndo, onRedo]);
+  }, [onCameraPreset, onResetView, onToggleWireframe, onUndo, onRedo, onToolSwitch]);
 }

--- a/src/features/bin-designer/hooks/useUnsavedWarning.ts
+++ b/src/features/bin-designer/hooks/useUnsavedWarning.ts
@@ -1,0 +1,30 @@
+/**
+ * Warns users before closing the tab when they have unsaved designer changes.
+ *
+ * Registers a `beforeunload` handler when the current design has no saved ID
+ * (i.e. untitled) and the user has made at least one change (undo history exists).
+ */
+
+import { useEffect } from 'react';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+import { useShallow } from 'zustand/react/shallow';
+
+export function useUnsavedWarning(): void {
+  const { hasUnsavedChanges } = useDesignerStore(
+    useShallow((s) => ({
+      hasUnsavedChanges: s.currentDesignId === null && s.history.past.length > 0,
+    }))
+  );
+
+  useEffect(() => {
+    if (!hasUnsavedChanges) return;
+
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [hasUnsavedChanges]);
+}

--- a/src/features/command-palette/commands.ts
+++ b/src/features/command-palette/commands.ts
@@ -54,6 +54,7 @@ export interface CommandDefinition {
   shortcut?: {
     keys: string | string[];
     modifier?: boolean;
+    shift?: boolean;
   };
   keywords?: string[];
 }
@@ -76,6 +77,13 @@ export const COMMAND_DEFINITIONS: CommandDefinition[] = [
     labelKey: 'commandPalette.openSettings',
     category: 'navigation',
     keywords: ['preferences', 'options', 'configure'],
+  },
+  {
+    id: 'switch-to-designer',
+    labelKey: 'commandPalette.switchToDesigner',
+    category: 'navigation',
+    shortcut: { keys: SHORTCUTS.TOOL_SWITCH, shift: true },
+    keywords: ['designer', 'bin', 'cad', 'stl', '3d'],
   },
   {
     id: 'open-help',

--- a/src/features/command-palette/components/CommandPalette.tsx
+++ b/src/features/command-palette/components/CommandPalette.tsx
@@ -122,6 +122,8 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           return () => window.dispatchEvent(new CustomEvent('open-help-modal'));
         case 'open-print':
           return () => setPrintModalOpen(true);
+        case 'switch-to-designer':
+          return () => window.dispatchEvent(new CustomEvent('switch-to-designer'));
 
         // Edit
         case 'undo':
@@ -881,6 +883,7 @@ function CommandItem({ command, onSelect, t }: CommandItemProps) {
         <ShortcutBadge
           keys={command.shortcut.keys}
           modifier={command.shortcut.modifier}
+          shift={command.shortcut.shift}
           className="opacity-50 group-data-[selected=true]:opacity-90 transition-opacity shrink-0"
         />
       )}

--- a/src/features/command-palette/components/ShortcutBadge.tsx
+++ b/src/features/command-palette/components/ShortcutBadge.tsx
@@ -9,6 +9,7 @@ import { useMemo } from 'react';
 interface ShortcutBadgeProps {
   keys: string | string[];
   modifier?: boolean;
+  shift?: boolean;
   className?: string;
 }
 
@@ -19,7 +20,7 @@ const modKey = isMac ? '⌘' : 'Ctrl';
 const keyClasses =
   'inline-flex items-center justify-center min-w-[22px] h-[22px] px-1.5 text-[11px] font-mono font-medium rounded border border-stroke bg-gradient-to-b from-surface-elevated to-surface text-content-secondary shadow-[0_1px_0_1px_rgba(0,0,0,0.15),inset_0_1px_0_rgba(255,255,255,0.1)]';
 
-export function ShortcutBadge({ keys, modifier, className = '' }: ShortcutBadgeProps) {
+export function ShortcutBadge({ keys, modifier, shift, className = '' }: ShortcutBadgeProps) {
   const keyArray = useMemo(() => {
     if (Array.isArray(keys)) return keys;
     return [keys];
@@ -30,6 +31,13 @@ export function ShortcutBadge({ keys, modifier, className = '' }: ShortcutBadgeP
       {modifier && (
         <>
           <kbd className={keyClasses}>{modKey}</kbd>
+          {/* eslint-disable-next-line i18next/no-literal-string */}
+          <span className="text-content-tertiary text-[10px]">+</span>
+        </>
+      )}
+      {shift && (
+        <>
+          <kbd className={keyClasses}>Shift</kbd>
           {/* eslint-disable-next-line i18next/no-literal-string */}
           <span className="text-content-tertiary text-[10px]">+</span>
         </>

--- a/src/features/command-palette/hooks/useCommandPalette.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.ts
@@ -5,10 +5,12 @@
 
 import { useState, useEffect, useCallback } from 'react';
 
-export function useCommandPalette() {
+export function useCommandPalette({ disabled = false }: { disabled?: boolean } = {}) {
   const [open, setOpen] = useState(false);
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (disabled) return;
+
     // Ignore if in input/textarea or contenteditable
     if (
       e.target instanceof HTMLInputElement ||
@@ -23,7 +25,7 @@ export function useCommandPalette() {
       e.preventDefault();
       setOpen(true);
     }
-  }, []);
+  }, [disabled]);
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -16,6 +16,8 @@ import { canPlaceBin } from '@/shared/utils/validation';
 import { validateBinRotation } from '@/utils/binLocation';
 import { validateHalfBinModeToggle } from '@/utils/halfBinConstraints';
 import { SHORTCUTS, STAGING_ID, hasFractionalDimensions } from '@/core/constants';
+import { useDesignerRouting } from '@/hooks/useDesignerRouting';
+import { useLabsStore } from '@/core/store';
 import { useGridNavigation } from '@/features/grid-editor';
 import { isOk } from '@/core/result';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
@@ -111,6 +113,10 @@ export function useKeyboard() {
 
   const setShowLayoutManager = useLibraryStore((state) => state.setShowLayoutManager);
   const addToast = useToastStore((state) => state.addToast);
+
+  // Tool switching (Shift+D)
+  const isDesignerEnabled = useLabsStore((state) => state.isFeatureEnabled('bin_designer'));
+  const { navigateToDesigner } = useDesignerRouting();
 
   // Grid navigation hook for spatial arrow key navigation
   const { handleNavigationKey } = useGridNavigation();
@@ -275,6 +281,13 @@ export function useKeyboard() {
         if (currentIndex > 0) {
           setActiveLayer(layout.layers[currentIndex - 1].id);
         }
+        return;
+      }
+
+      // Tool switch (Shift+D) — toggle to Bin Designer
+      if (key === SHORTCUTS.TOOL_SWITCH && e.shiftKey && !ctrlOrMeta && isDesignerEnabled) {
+        e.preventDefault();
+        navigateToDesigner();
         return;
       }
 
@@ -495,6 +508,8 @@ export function useKeyboard() {
       toggleHalfBinMode,
       setShowLayoutManager,
       addToast,
+      isDesignerEnabled,
+      navigateToDesigner,
       t,
     ]
   );

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -710,6 +710,10 @@ const en: Record<string, string> = {
   'help.shortcut.isometricView': 'Isometric view',
   'help.shortcut.frontView': 'Front view',
   'help.shortcut.sideView': 'Side view',
+  'help.shortcut.rotate': 'Rotate selected bin',
+  'help.shortcut.selectAll': 'Select all bins on layer',
+  'help.shortcut.togglePaintMode': 'Toggle paint mode',
+  'help.shortcut.toolSwitch': 'Switch Grid Editor / Bin Designer',
   'help.shortcut.toggleHalfBin': 'Toggle half-bin mode',
 
   // Mouse interactions
@@ -1087,6 +1091,8 @@ const en: Record<string, string> = {
   'toolSwitcher.activeTool': 'Active tool',
   'toolSwitcher.gridfinityLayoutTool': 'Gridfinity Layout Tool',
   'toolSwitcher.toolSwitcher': 'Tool Switcher',
+  'toolSwitcher.switchToPlanner': 'Switch to Grid Editor (Shift+D)',
+  'toolSwitcher.switchToDesigner': 'Switch to Bin Designer (Shift+D)',
 
   // ===========================================================================
   // Bin Designer
@@ -1493,6 +1499,7 @@ const en: Record<string, string> = {
   // Layout management commands
   'commandPalette.newLayout': 'New Layout',
   'commandPalette.duplicateLayout': 'Duplicate Layout',
+  'commandPalette.switchToDesigner': 'Switch to Bin Designer',
 
   // Tools commands (extended)
   'commandPalette.togglePaintMode': 'Toggle Paint Mode',

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -6,7 +6,6 @@ import { Grid } from '@/features/grid-editor';
 import { Staging } from '@/features/staging/components/Staging';
 import { DropZones } from '@/components/DropZones';
 import { DragPreview } from '@/components/DragPreview';
-import { ToastContainer } from '@/shared/components/Toast';
 import { PanelErrorBoundary } from '@/components/PanelErrorBoundary';
 import { SharedLayoutImporter, SharedLayoutBanner } from '@/features/cloud-share/components';
 import {
@@ -23,11 +22,6 @@ import {
   BinContextMenuWrapper,
 } from '@/components/Mobile';
 import { PresenceAvatarList } from '@/components/Collab';
-
-// Lazy load LabsDrawer - experimental feature most users won't use
-const LabsDrawer = lazyWithRetry(() =>
-  import('@/features/labs/components/LabsDrawer').then(namedExport('LabsDrawer'))
-);
 
 // Lazy load design-linking dialogs - only needed when bin_designer feature is enabled
 const DesignLinkingDialogs = lazyWithRetry(() =>
@@ -127,9 +121,6 @@ export function MobileLayout({
         />
       )}
 
-      {/* Toast notifications */}
-      <ToastContainer />
-
       {/* Design linking dialogs - requires Bin Designer feature flag */}
       {isDesignerEnabled && (
         <Suspense fallback={null}>
@@ -146,11 +137,6 @@ export function MobileLayout({
 
       {/* Shared layout URL importer */}
       <SharedLayoutImporter />
-
-      {/* Labs drawer */}
-      <Suspense fallback={null}>
-        <LabsDrawer />
-      </Suspense>
     </div>
   );
 }

--- a/src/shared/components/ToolSwitcher.tsx
+++ b/src/shared/components/ToolSwitcher.tsx
@@ -89,6 +89,7 @@ export function ToolSwitcher({ compact = false }: ToolSwitcherProps) {
           role="tab"
           aria-selected={activeTool === 'planner'}
           onClick={() => handleSwitch('planner')}
+          title={activeTool !== 'planner' ? t('toolSwitcher.switchToPlanner') : undefined}
           className={`${segmentPadding} ${fontSize} font-medium rounded transition-all ${
             activeTool === 'planner'
               ? 'bg-surface-elevated text-content shadow-sm'
@@ -101,6 +102,7 @@ export function ToolSwitcher({ compact = false }: ToolSwitcherProps) {
           role="tab"
           aria-selected={activeTool === 'designer'}
           onClick={() => handleSwitch('designer')}
+          title={activeTool !== 'designer' ? t('toolSwitcher.switchToDesigner') : undefined}
           className={`${segmentPadding} ${fontSize} font-medium rounded transition-all ${
             activeTool === 'designer'
               ? 'bg-surface-elevated text-content shadow-sm'


### PR DESCRIPTION
## Summary
- **Default bin designer to on**: Added `defaultEnabled` field to `FeatureFlag` type, set `bin_designer` to default-enabled. Existing explicit toggles preserved.
- **Shift+D keyboard shortcut**: Toggle between Grid Editor and Bin Designer, matching Figma's mode-switching convention. Works from both planner (`useKeyboard`) and designer (`useDesignerKeyboard`). Added as command palette entry with shift badge support.
- **Suppress command palette in designer**: `Ctrl+K` disabled on `/designer` route until contextual commands are added. Passed `disabled` flag to `useCommandPalette` hook.
- **Shared overlays refactor**: Lifted `ToastContainer`, `CommandPalette`, and `LabsDrawer` out of individual layout branches into a single render point in `App.tsx`. Removed duplicated instances from tablet, desktop, and `MobileLayout.tsx`. Fixes toasts/command palette not appearing in designer mode.
- **beforeunload warning**: New `useUnsavedWarning` hook warns before closing the tab when an untitled design has unsaved changes.
- **Mobile design name**: Design name button always visible with responsive truncation (`max-w-[120px]` mobile, `max-w-[200px]` sm+).
- **ToolSwitcher tooltips**: Tab buttons show shortcut hint on hover (e.g. "Switch to Bin Designer (Shift+D)").

## Test plan
- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npm run test:coverage` — 5350 tests pass, coverage maintained
- [ ] Open app fresh (clear localStorage) → ToolSwitcher shows Planner/Designer segmented control
- [ ] Press Shift+D in planner → navigates to designer; press Shift+D in designer → returns to planner
- [ ] Open command palette (Ctrl+K) in planner → "Switch to Bin Designer" command visible with Shift+D badge
- [ ] In designer mode, Ctrl+K does nothing (command palette suppressed)
- [ ] Navigate to /designer → modify params → close tab → browser warns
- [ ] Resize to mobile width → design name visible and clickable
- [ ] Hover ToolSwitcher inactive tab → tooltip shows shortcut hint
- [ ] Toasts fire correctly in designer mode (e.g. share load, save status)