### PR TITLE
chore: migrate from @vercel/kv to ioredis

### DIFF
--- a/api/lib/rateLimit.ts
+++ b/api/lib/rateLimit.ts
@@ -45,7 +45,7 @@ interface RateLimitResult {
 // Lazy-initialize Redis connection
 let redis: Redis | null = null;
 
-function getRedis(): Redis | null {
+export function getRedis(): Redis | null {
   if (!process.env.REDIS_URL) {
     return null;
   }

--- a/api/suggest-name.ts
+++ b/api/suggest-name.ts
@@ -8,9 +8,8 @@
  */
 
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { kv } from '@vercel/kv';
 import { APICallError } from 'ai';
-import { checkRateLimit, getClientIP } from './lib/rateLimit.js';
+import { checkRateLimit, getClientIP, getRedis } from './lib/rateLimit.js';
 import { generateNameSuggestions, createCacheKey, type NameSuggestionRequest } from './lib/llm.js';
 import { ErrorCode } from './lib/shared.js';
 
@@ -140,16 +139,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const cacheKey = createCacheKey(request);
 
     // Check cache first
+    const redis = getRedis();
     try {
-      const cached = await kv.get<{ names: string[] }>(cacheKey);
-      if (cached && cached.names && cached.names.length > 0) {
-        return res.status(200).json({
-          suggestions: cached.names.map((name: string) => ({
-            name,
-            source: 'server_ml' as const,
-          })),
-          cached: true,
-        });
+      if (redis) {
+        const raw = await redis.get(cacheKey);
+        if (raw) {
+          const cached = JSON.parse(raw) as { names: string[] };
+          if (cached.names && cached.names.length > 0) {
+            return res.status(200).json({
+              suggestions: cached.names.map((name: string) => ({
+                name,
+                source: 'server_ml' as const,
+              })),
+              cached: true,
+            });
+          }
+        }
       }
     } catch {
       // Cache read failed, continue without cache
@@ -160,7 +165,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     // Cache the result
     try {
-      await kv.set(cacheKey, { names: result.names }, { ex: CACHE_TTL_SECONDS });
+      if (redis) {
+        await redis.set(cacheKey, JSON.stringify({ names: result.names }), 'EX', CACHE_TTL_SECONDS);
+      }
     } catch {
       // Cache write failed, continue without caching
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@react-three/fiber": "^9.5.0",
         "@vercel/analytics": "^1.6.1",
         "@vercel/blob": "^2.0.0",
-        "@vercel/kv": "^3.0.0",
         "@vercel/speed-insights": "^1.3.1",
         "ai": "^6.0.49",
         "cmdk": "^1.1.1",
@@ -5312,15 +5311,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@upstash/redis": {
-      "version": "1.36.1",
-      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.36.1.tgz",
-      "integrity": "sha512-N6SjDcgXdOcTAF+7uNoY69o7hCspe9BcA7YjQdxVu5d25avljTwyLaHBW3krWjrP0FfocgMk94qyVtQbeDp39A==",
-      "license": "MIT",
-      "dependencies": {
-        "uncrypto": "^0.1.3"
-      }
-    },
     "node_modules/@use-gesture/core": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
@@ -5406,19 +5396,6 @@
       "integrity": "sha512-CqC01WZxbLUxoiVdh9B/poPbNpY9U+tO1N9oWHwTl5YAZxcqXmmWJ8KNMFItJCUUWdY3J3xv8LvAuQv2KZ5YdQ==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@vercel/kv": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-3.0.0.tgz",
-      "integrity": "sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==",
-      "deprecated": "Vercel KV is deprecated. If you had an existing KV store, it should have moved to Upstash Redis which you will see under Vercel Integrations. For new projects, install a Redis integration from Vercel Marketplace: https://vercel.com/marketplace?category=storage&search=redis",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@upstash/redis": "^1.34.0"
-      },
-      "engines": {
-        "node": ">=14.6"
-      }
     },
     "node_modules/@vercel/nft": {
       "version": "1.1.1",
@@ -12844,12 +12821,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/uncrypto": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
-      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
-      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "6.23.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@react-three/fiber": "^9.5.0",
     "@vercel/analytics": "^1.6.1",
     "@vercel/blob": "^2.0.0",
-    "@vercel/kv": "^3.0.0",
     "@vercel/speed-insights": "^1.3.1",
     "ai": "^6.0.49",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
## Summary
- Migrates `api/suggest-name.ts` from deprecated `@vercel/kv` to `ioredis`
- Reuses the existing `getRedis()` helper from `api/lib/rateLimit.ts` (now exported)
- Removes `@vercel/kv` dependency entirely
- No env var changes needed — both use `REDIS_URL`

## Test plan
- [x] No remaining `@vercel/kv` imports in codebase
- [x] TypeScript compiles cleanly
- [x] Cache get/set logic preserved with explicit JSON serialization
- [x] Graceful fallback when Redis is unavailable (same as before)