### PR TITLE
test: replace manual store resets with resetAllStores() and extract getBinId()

### DIFF
--- a/src/test/hooks/useGridResize.test.ts
+++ b/src/test/hooks/useGridResize.test.ts
@@ -2,37 +2,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useGridResize } from '@/features/grid-editor/hooks/useGridResize';
 import { useLayoutStore } from '@/core/store/layout';
-import { useHistoryStore } from '@/core/store/history';
-import { createDefaultLayout, STAGING_ID } from '@/core/constants';
-import { isOk } from '@/core/result';
-
-// Helper to extract bin ID from Result
-function getBinId(
-  result: ReturnType<typeof useLayoutStore.getState>['addBin'] extends (
-    ...args: unknown[]
-  ) => infer R
-    ? R
-    : never
-): string {
-  if (!isOk(result)) throw new Error('addBin failed');
-  return result.value;
-}
+import { STAGING_ID } from '@/core/constants';
+import { resetAllStores, getBinId } from '@/test/testUtils';
 
 describe('useGridResize', () => {
   const HINT_KEY = 'gridfinity-grid-resize-hint-shown';
 
   beforeEach(() => {
     vi.useFakeTimers();
-    // Reset stores
-    const defaultLayout = createDefaultLayout();
-    useLayoutStore.setState({ layout: defaultLayout });
-    useHistoryStore.setState({
-      past: [],
-      future: [],
-      canUndo: false,
-      canRedo: false,
-    });
-    // Clear localStorage
+    resetAllStores();
     localStorage.removeItem(HINT_KEY);
   });
 

--- a/src/test/hooks/useInteraction.test.ts
+++ b/src/test/hooks/useInteraction.test.ts
@@ -3,26 +3,11 @@ import { renderHook, act } from '@testing-library/react';
 import { useInteraction } from '@/features/grid-editor/hooks/useInteraction';
 import { useUIStore } from '@/core/store/ui';
 import { useLayoutStore } from '@/core/store/layout';
-import { useHistoryStore } from '@/core/store/history';
 import { useSelectionStore } from '@/core/store/selection';
 import { useInteractionStore } from '@/core/store/interaction';
-import { useViewStore } from '@/core/store/view';
-import { useMobileStore } from '@/core/store/mobile';
-import { createDefaultLayout, STAGING_ID } from '@/core/constants';
-import { isOk } from '@/core/result';
+import { STAGING_ID } from '@/core/constants';
+import { resetAllStores, getBinId } from '@/test/testUtils';
 import type { RefObject } from 'react';
-
-// Helper to extract bin ID from Result
-function getBinId(
-  result: ReturnType<typeof useLayoutStore.getState>['addBin'] extends (
-    ...args: unknown[]
-  ) => infer R
-    ? R
-    : never
-): string {
-  if (!isOk(result)) throw new Error('addBin failed');
-  return result.value;
-}
 
 // Mock grid ref that returns consistent coords
 function createMockGridRef(width = 320, height = 256): RefObject<HTMLDivElement> {
@@ -45,49 +30,11 @@ function createMockGridRef(width = 320, height = 256): RefObject<HTMLDivElement>
 
 describe('useInteraction', () => {
   beforeEach(() => {
-    // Reset all stores
-    const defaultLayout = createDefaultLayout();
-    useLayoutStore.setState({ layout: defaultLayout });
+    resetAllStores();
+    const { layout } = useLayoutStore.getState();
     useSelectionStore.setState({
-      activeLayerId: defaultLayout.layers[0].id,
-      selectedBinIds: [],
-      activeCategoryId: defaultLayout.categories[0].id,
-      focusedBinId: null,
-      quickLabelBinId: null,
-    });
-    useInteractionStore.setState({
-      interaction: null,
-      dropTarget: null,
-      paintSize: null,
-      showIsometricPreview: true,
-      isometricRotation: 0,
-      isPreviewExpanded: false,
-      layerViewMode: 'stack',
-      keyboardDragMode: false,
-      keyboardResizeMode: false,
-      liveMessage: null,
-    });
-    useViewStore.setState({
-      zoom: 1,
-      showOtherLayers: true,
-      showLabels: true,
-      leftPanelCollapsed: false,
-      rightPanelCollapsed: false,
-      contextMenu: null,
-      highlightedCategoryId: null,
-      highlightedRowLabel: null,
-      highlightedColLabel: null,
-      printModalOpen: false,
-    });
-    useMobileStore.setState({
-      activeMobilePanel: null,
-      mobileLayersTab: 'layers',
-    });
-    useHistoryStore.setState({
-      past: [],
-      future: [],
-      canUndo: false,
-      canRedo: false,
+      activeLayerId: layout.layers[0].id,
+      activeCategoryId: layout.categories[0].id,
     });
   });
 
@@ -464,48 +411,11 @@ describe('useInteraction', () => {
 // Since it's not exported, we test it indirectly through behavior
 describe('resize rect calculation (integration)', () => {
   beforeEach(() => {
-    const defaultLayout = createDefaultLayout();
-    useLayoutStore.setState({ layout: defaultLayout });
+    resetAllStores();
+    const { layout } = useLayoutStore.getState();
     useSelectionStore.setState({
-      activeLayerId: defaultLayout.layers[0].id,
-      selectedBinIds: [],
-      activeCategoryId: defaultLayout.categories[0].id,
-      focusedBinId: null,
-      quickLabelBinId: null,
-    });
-    useInteractionStore.setState({
-      interaction: null,
-      dropTarget: null,
-      paintSize: null,
-      showIsometricPreview: true,
-      isometricRotation: 0,
-      isPreviewExpanded: false,
-      layerViewMode: 'stack',
-      keyboardDragMode: false,
-      keyboardResizeMode: false,
-      liveMessage: null,
-    });
-    useViewStore.setState({
-      zoom: 1,
-      showOtherLayers: true,
-      showLabels: true,
-      leftPanelCollapsed: false,
-      rightPanelCollapsed: false,
-      contextMenu: null,
-      highlightedCategoryId: null,
-      highlightedRowLabel: null,
-      highlightedColLabel: null,
-      printModalOpen: false,
-    });
-    useMobileStore.setState({
-      activeMobilePanel: null,
-      mobileLayersTab: 'layers',
-    });
-    useHistoryStore.setState({
-      past: [],
-      future: [],
-      canUndo: false,
-      canRedo: false,
+      activeLayerId: layout.layers[0].id,
+      activeCategoryId: layout.categories[0].id,
     });
   });
 
@@ -583,48 +493,11 @@ describe('resize rect calculation (integration)', () => {
 // Test pointer event handlers
 describe('pointer events', () => {
   beforeEach(() => {
-    const defaultLayout = createDefaultLayout();
-    useLayoutStore.setState({ layout: defaultLayout });
+    resetAllStores();
+    const { layout } = useLayoutStore.getState();
     useSelectionStore.setState({
-      activeLayerId: defaultLayout.layers[0].id,
-      selectedBinIds: [],
-      activeCategoryId: defaultLayout.categories[0].id,
-      focusedBinId: null,
-      quickLabelBinId: null,
-    });
-    useInteractionStore.setState({
-      interaction: null,
-      dropTarget: null,
-      paintSize: null,
-      showIsometricPreview: true,
-      isometricRotation: 0,
-      isPreviewExpanded: false,
-      layerViewMode: 'stack',
-      keyboardDragMode: false,
-      keyboardResizeMode: false,
-      liveMessage: null,
-    });
-    useViewStore.setState({
-      zoom: 1,
-      showOtherLayers: true,
-      showLabels: true,
-      leftPanelCollapsed: false,
-      rightPanelCollapsed: false,
-      contextMenu: null,
-      highlightedCategoryId: null,
-      highlightedRowLabel: null,
-      highlightedColLabel: null,
-      printModalOpen: false,
-    });
-    useMobileStore.setState({
-      activeMobilePanel: null,
-      mobileLayersTab: 'layers',
-    });
-    useHistoryStore.setState({
-      past: [],
-      future: [],
-      canUndo: false,
-      canRedo: false,
+      activeLayerId: layout.layers[0].id,
+      activeCategoryId: layout.categories[0].id,
     });
   });
 
@@ -1104,48 +977,11 @@ describe('pointer events', () => {
 // Test stagingDrag interaction
 describe('stagingDrag interaction', () => {
   beforeEach(() => {
-    const defaultLayout = createDefaultLayout();
-    useLayoutStore.setState({ layout: defaultLayout });
+    resetAllStores();
+    const { layout } = useLayoutStore.getState();
     useSelectionStore.setState({
-      activeLayerId: defaultLayout.layers[0].id,
-      selectedBinIds: [],
-      activeCategoryId: defaultLayout.categories[0].id,
-      focusedBinId: null,
-      quickLabelBinId: null,
-    });
-    useInteractionStore.setState({
-      interaction: null,
-      dropTarget: null,
-      paintSize: null,
-      showIsometricPreview: true,
-      isometricRotation: 0,
-      isPreviewExpanded: false,
-      layerViewMode: 'stack',
-      keyboardDragMode: false,
-      keyboardResizeMode: false,
-      liveMessage: null,
-    });
-    useViewStore.setState({
-      zoom: 1,
-      showOtherLayers: true,
-      showLabels: true,
-      leftPanelCollapsed: false,
-      rightPanelCollapsed: false,
-      contextMenu: null,
-      highlightedCategoryId: null,
-      highlightedRowLabel: null,
-      highlightedColLabel: null,
-      printModalOpen: false,
-    });
-    useMobileStore.setState({
-      activeMobilePanel: null,
-      mobileLayersTab: 'layers',
-    });
-    useHistoryStore.setState({
-      past: [],
-      future: [],
-      canUndo: false,
-      canRedo: false,
+      activeLayerId: layout.layers[0].id,
+      activeCategoryId: layout.categories[0].id,
     });
   });
 
@@ -1411,48 +1247,11 @@ describe('stagingDrag interaction', () => {
 // Test Alt+drag duplicate behavior
 describe('duplicate drag (Alt+drag)', () => {
   beforeEach(() => {
-    const defaultLayout = createDefaultLayout();
-    useLayoutStore.setState({ layout: defaultLayout });
+    resetAllStores();
+    const { layout } = useLayoutStore.getState();
     useSelectionStore.setState({
-      activeLayerId: defaultLayout.layers[0].id,
-      selectedBinIds: [],
-      activeCategoryId: defaultLayout.categories[0].id,
-      focusedBinId: null,
-      quickLabelBinId: null,
-    });
-    useInteractionStore.setState({
-      interaction: null,
-      dropTarget: null,
-      paintSize: null,
-      showIsometricPreview: true,
-      isometricRotation: 0,
-      isPreviewExpanded: false,
-      layerViewMode: 'stack',
-      keyboardDragMode: false,
-      keyboardResizeMode: false,
-      liveMessage: null,
-    });
-    useViewStore.setState({
-      zoom: 1,
-      showOtherLayers: true,
-      showLabels: true,
-      leftPanelCollapsed: false,
-      rightPanelCollapsed: false,
-      contextMenu: null,
-      highlightedCategoryId: null,
-      highlightedRowLabel: null,
-      highlightedColLabel: null,
-      printModalOpen: false,
-    });
-    useMobileStore.setState({
-      activeMobilePanel: null,
-      mobileLayersTab: 'layers',
-    });
-    useHistoryStore.setState({
-      past: [],
-      future: [],
-      canUndo: false,
-      canRedo: false,
+      activeLayerId: layout.layers[0].id,
+      activeCategoryId: layout.categories[0].id,
     });
   });
 
@@ -1861,48 +1660,11 @@ describe('duplicate drag (Alt+drag)', () => {
 // Test actual drag completion with movement
 describe('drag completion with movement', () => {
   beforeEach(() => {
-    const defaultLayout = createDefaultLayout();
-    useLayoutStore.setState({ layout: defaultLayout });
+    resetAllStores();
+    const { layout } = useLayoutStore.getState();
     useSelectionStore.setState({
-      activeLayerId: defaultLayout.layers[0].id,
-      selectedBinIds: [],
-      activeCategoryId: defaultLayout.categories[0].id,
-      focusedBinId: null,
-      quickLabelBinId: null,
-    });
-    useInteractionStore.setState({
-      interaction: null,
-      dropTarget: null,
-      paintSize: null,
-      showIsometricPreview: true,
-      isometricRotation: 0,
-      isPreviewExpanded: false,
-      layerViewMode: 'stack',
-      keyboardDragMode: false,
-      keyboardResizeMode: false,
-      liveMessage: null,
-    });
-    useViewStore.setState({
-      zoom: 1,
-      showOtherLayers: true,
-      showLabels: true,
-      leftPanelCollapsed: false,
-      rightPanelCollapsed: false,
-      contextMenu: null,
-      highlightedCategoryId: null,
-      highlightedRowLabel: null,
-      highlightedColLabel: null,
-      printModalOpen: false,
-    });
-    useMobileStore.setState({
-      activeMobilePanel: null,
-      mobileLayersTab: 'layers',
-    });
-    useHistoryStore.setState({
-      past: [],
-      future: [],
-      canUndo: false,
-      canRedo: false,
+      activeLayerId: layout.layers[0].id,
+      activeCategoryId: layout.categories[0].id,
     });
   });
 
@@ -2026,48 +1788,11 @@ describe('drag completion with movement', () => {
 // Test resize completion with actual changes
 describe('resize completion with changes', () => {
   beforeEach(() => {
-    const defaultLayout = createDefaultLayout();
-    useLayoutStore.setState({ layout: defaultLayout });
+    resetAllStores();
+    const { layout } = useLayoutStore.getState();
     useSelectionStore.setState({
-      activeLayerId: defaultLayout.layers[0].id,
-      selectedBinIds: [],
-      activeCategoryId: defaultLayout.categories[0].id,
-      focusedBinId: null,
-      quickLabelBinId: null,
-    });
-    useInteractionStore.setState({
-      interaction: null,
-      dropTarget: null,
-      paintSize: null,
-      showIsometricPreview: true,
-      isometricRotation: 0,
-      isPreviewExpanded: false,
-      layerViewMode: 'stack',
-      keyboardDragMode: false,
-      keyboardResizeMode: false,
-      liveMessage: null,
-    });
-    useViewStore.setState({
-      zoom: 1,
-      showOtherLayers: true,
-      showLabels: true,
-      leftPanelCollapsed: false,
-      rightPanelCollapsed: false,
-      contextMenu: null,
-      highlightedCategoryId: null,
-      highlightedRowLabel: null,
-      highlightedColLabel: null,
-      printModalOpen: false,
-    });
-    useMobileStore.setState({
-      activeMobilePanel: null,
-      mobileLayersTab: 'layers',
-    });
-    useHistoryStore.setState({
-      past: [],
-      future: [],
-      canUndo: false,
-      canRedo: false,
+      activeLayerId: layout.layers[0].id,
+      activeCategoryId: layout.categories[0].id,
     });
   });
 
@@ -2244,48 +1969,11 @@ describe('resize completion with changes', () => {
 // Test stagingDrag behavior
 describe('staging drag', () => {
   beforeEach(() => {
-    const defaultLayout = createDefaultLayout();
-    useLayoutStore.setState({ layout: defaultLayout });
+    resetAllStores();
+    const { layout } = useLayoutStore.getState();
     useSelectionStore.setState({
-      activeLayerId: defaultLayout.layers[0].id,
-      selectedBinIds: [],
-      activeCategoryId: defaultLayout.categories[0].id,
-      focusedBinId: null,
-      quickLabelBinId: null,
-    });
-    useInteractionStore.setState({
-      interaction: null,
-      dropTarget: null,
-      paintSize: null,
-      showIsometricPreview: true,
-      isometricRotation: 0,
-      isPreviewExpanded: false,
-      layerViewMode: 'stack',
-      keyboardDragMode: false,
-      keyboardResizeMode: false,
-      liveMessage: null,
-    });
-    useViewStore.setState({
-      zoom: 1,
-      showOtherLayers: true,
-      showLabels: true,
-      leftPanelCollapsed: false,
-      rightPanelCollapsed: false,
-      contextMenu: null,
-      highlightedCategoryId: null,
-      highlightedRowLabel: null,
-      highlightedColLabel: null,
-      printModalOpen: false,
-    });
-    useMobileStore.setState({
-      activeMobilePanel: null,
-      mobileLayersTab: 'layers',
-    });
-    useHistoryStore.setState({
-      past: [],
-      future: [],
-      canUndo: false,
-      canRedo: false,
+      activeLayerId: layout.layers[0].id,
+      activeCategoryId: layout.categories[0].id,
     });
   });
 
@@ -2317,48 +2005,11 @@ describe('staging drag', () => {
 // Test resize via pointer movement (hits calculateResizeRect)
 describe('resize via pointer movement', () => {
   beforeEach(() => {
-    const defaultLayout = createDefaultLayout();
-    useLayoutStore.setState({ layout: defaultLayout });
+    resetAllStores();
+    const { layout } = useLayoutStore.getState();
     useSelectionStore.setState({
-      activeLayerId: defaultLayout.layers[0].id,
-      selectedBinIds: [],
-      activeCategoryId: defaultLayout.categories[0].id,
-      focusedBinId: null,
-      quickLabelBinId: null,
-    });
-    useInteractionStore.setState({
-      interaction: null,
-      dropTarget: null,
-      paintSize: null,
-      showIsometricPreview: true,
-      isometricRotation: 0,
-      isPreviewExpanded: false,
-      layerViewMode: 'stack',
-      keyboardDragMode: false,
-      keyboardResizeMode: false,
-      liveMessage: null,
-    });
-    useViewStore.setState({
-      zoom: 1,
-      showOtherLayers: true,
-      showLabels: true,
-      leftPanelCollapsed: false,
-      rightPanelCollapsed: false,
-      contextMenu: null,
-      highlightedCategoryId: null,
-      highlightedRowLabel: null,
-      highlightedColLabel: null,
-      printModalOpen: false,
-    });
-    useMobileStore.setState({
-      activeMobilePanel: null,
-      mobileLayersTab: 'layers',
-    });
-    useHistoryStore.setState({
-      past: [],
-      future: [],
-      canUndo: false,
-      canRedo: false,
+      activeLayerId: layout.layers[0].id,
+      activeCategoryId: layout.categories[0].id,
     });
   });
 
@@ -2544,48 +2195,11 @@ describe('resize via pointer movement', () => {
 // Test cleanup on unmount
 describe('cleanup on unmount', () => {
   beforeEach(() => {
-    const defaultLayout = createDefaultLayout();
-    useLayoutStore.setState({ layout: defaultLayout });
+    resetAllStores();
+    const { layout } = useLayoutStore.getState();
     useSelectionStore.setState({
-      activeLayerId: defaultLayout.layers[0].id,
-      selectedBinIds: [],
-      activeCategoryId: defaultLayout.categories[0].id,
-      focusedBinId: null,
-      quickLabelBinId: null,
-    });
-    useInteractionStore.setState({
-      interaction: null,
-      dropTarget: null,
-      paintSize: null,
-      showIsometricPreview: true,
-      isometricRotation: 0,
-      isPreviewExpanded: false,
-      layerViewMode: 'stack',
-      keyboardDragMode: false,
-      keyboardResizeMode: false,
-      liveMessage: null,
-    });
-    useViewStore.setState({
-      zoom: 1,
-      showOtherLayers: true,
-      showLabels: true,
-      leftPanelCollapsed: false,
-      rightPanelCollapsed: false,
-      contextMenu: null,
-      highlightedCategoryId: null,
-      highlightedRowLabel: null,
-      highlightedColLabel: null,
-      printModalOpen: false,
-    });
-    useMobileStore.setState({
-      activeMobilePanel: null,
-      mobileLayersTab: 'layers',
-    });
-    useHistoryStore.setState({
-      past: [],
-      future: [],
-      canUndo: false,
-      canRedo: false,
+      activeLayerId: layout.layers[0].id,
+      activeCategoryId: layout.categories[0].id,
     });
   });
 

--- a/src/test/hooks/useKeyboard.test.ts
+++ b/src/test/hooks/useKeyboard.test.ts
@@ -7,10 +7,9 @@ import { useLibraryStore } from '@/core/store/library';
 import { useSelectionStore } from '@/core/store/selection';
 import { useInteractionStore } from '@/core/store/interaction';
 import { useViewStore } from '@/core/store/view';
-import { useMobileStore } from '@/core/store/mobile';
 import { useHalfBinModeStore } from '@/core/store/halfBinMode';
 import { createDefaultLayout, STAGING_ID } from '@/core/constants';
-import { isOk } from '@/core/result';
+import { resetAllStores, getBinId } from '@/test/testUtils';
 
 // Helper to create keyboard event
 function createKeyboardEvent(key: string, options: Partial<KeyboardEventInit> = {}): KeyboardEvent {
@@ -29,64 +28,14 @@ function pressKey(key: string, options: Partial<KeyboardEventInit> = {}) {
   return event;
 }
 
-// Helper to extract bin ID from Result
-function getBinId(
-  result: ReturnType<typeof useLayoutStore.getState>['addBin'] extends (
-    ...args: unknown[]
-  ) => infer R
-    ? R
-    : never
-): string {
-  if (!isOk(result)) throw new Error('addBin failed');
-  return result.value;
-}
-
 describe('useKeyboard', () => {
   beforeEach(() => {
-    // Reset all stores
-    const defaultLayout = createDefaultLayout();
-    useLayoutStore.setState({ layout: defaultLayout });
+    resetAllStores();
+    // Set activeLayerId/activeCategoryId from the reset layout
+    const { layout } = useLayoutStore.getState();
     useSelectionStore.setState({
-      activeLayerId: defaultLayout.layers[0].id,
-      selectedBinIds: [],
-      activeCategoryId: defaultLayout.categories[0].id,
-      focusedBinId: null,
-      quickLabelBinId: null,
-    });
-    useInteractionStore.setState({
-      interaction: null,
-      dropTarget: null,
-      paintSize: null,
-      showIsometricPreview: true,
-      isometricRotation: 0,
-      isPreviewExpanded: false,
-      layerViewMode: 'stack',
-      keyboardDragMode: false,
-      keyboardResizeMode: false,
-      liveMessage: null,
-    });
-    useViewStore.setState({
-      zoom: 1,
-      showOtherLayers: true,
-      showLabels: true,
-      leftPanelCollapsed: false,
-      rightPanelCollapsed: false,
-      contextMenu: null,
-      highlightedCategoryId: null,
-      highlightedRowLabel: null,
-      highlightedColLabel: null,
-      printModalOpen: false,
-    });
-    useMobileStore.setState({
-      activeMobilePanel: null,
-      mobileLayersTab: 'layers',
-    });
-    useHalfBinModeStore.setState({
-      halfBinMode: false,
-    });
-    useHistoryStore.setState({
-      past: [],
-      future: [],
+      activeLayerId: layout.layers[0].id,
+      activeCategoryId: layout.categories[0].id,
     });
   });
 

--- a/src/test/hooks/useStagingDragInteraction.test.ts
+++ b/src/test/hooks/useStagingDragInteraction.test.ts
@@ -4,9 +4,8 @@ import { useStagingDragInteraction } from '@/hooks/interactions/useStagingDragIn
 import { useLayoutStore } from '@/core/store/layout';
 import { useSelectionStore } from '@/core/store/selection';
 import { useInteractionStore } from '@/core/store/interaction';
-import { useHistoryStore } from '@/core/store/history';
-import { createDefaultLayout, STAGING_ID } from '@/core/constants';
-import { isOk } from '@/core/result';
+import { STAGING_ID } from '@/core/constants';
+import { resetAllStores, getBinId } from '@/test/testUtils';
 import type { InteractionContext } from '@/hooks/interactions/types';
 
 // Mock ML tracking to avoid side effects
@@ -17,15 +16,6 @@ vi.mock('@/shared/analytics/useMLTracking', () => ({
     trackDeletion: vi.fn(),
   },
 }));
-
-// Helper type for addBin result
-type AddBinResult = ReturnType<ReturnType<typeof useLayoutStore.getState>['addBin']>;
-
-// Helper to extract bin ID from Result
-function getBinId(result: AddBinResult): string {
-  if (!isOk(result)) throw new Error('addBin failed');
-  return result.value;
-}
 
 describe('useStagingDragInteraction', () => {
   const mockSetInteraction = vi.fn();
@@ -58,34 +48,11 @@ describe('useStagingDragInteraction', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-
-    // Reset all stores
-    const defaultLayout = createDefaultLayout();
-    useLayoutStore.setState({ layout: defaultLayout });
+    resetAllStores();
+    const { layout } = useLayoutStore.getState();
     useSelectionStore.setState({
-      activeLayerId: defaultLayout.layers[0].id,
-      selectedBinIds: [],
-      activeCategoryId: defaultLayout.categories[0].id,
-      focusedBinId: null,
-      quickLabelBinId: null,
-    });
-    useInteractionStore.setState({
-      interaction: null,
-      dropTarget: null,
-      paintSize: null,
-      showIsometricPreview: true,
-      isometricRotation: 0,
-      isPreviewExpanded: false,
-      layerViewMode: 'stack',
-      keyboardDragMode: false,
-      keyboardResizeMode: false,
-      liveMessage: null,
-    });
-    useHistoryStore.setState({
-      past: [],
-      future: [],
-      canUndo: false,
-      canRedo: false,
+      activeLayerId: layout.layers[0].id,
+      activeCategoryId: layout.categories[0].id,
     });
   });
 

--- a/src/test/mobile-touch.test.tsx
+++ b/src/test/mobile-touch.test.tsx
@@ -3,11 +3,7 @@ import { render, fireEvent, act } from '@testing-library/react';
 import { Bin } from '@/features/grid-editor/components/Grid/Bin';
 import { useUIStore } from '@/core/store/ui';
 import { useLayoutStore } from '@/core/store/layout';
-import { useSelectionStore } from '@/core/store/selection';
-import { useViewStore } from '@/core/store/view';
-import { useInteractionStore } from '@/core/store/interaction';
-import { useMobileStore } from '@/core/store/mobile';
-import { createDefaultLayout } from '@/core/constants';
+import { resetAllStores } from '@/test/testUtils';
 import type { Bin as BinType, Category, Layer } from '@/core/types';
 
 // Mock useResponsive to simulate touch device
@@ -30,7 +26,6 @@ Object.defineProperty(navigator, 'vibrate', {
 });
 
 describe('Mobile Touch Interactions', () => {
-  let defaultLayout: ReturnType<typeof createDefaultLayout>;
   let testBin: BinType;
   let testCategory: Category;
   let testLayer: Layer;
@@ -43,36 +38,11 @@ describe('Mobile Touch Interactions', () => {
     mockStartDrag.mockClear();
     mockStartResize.mockClear();
 
-    defaultLayout = createDefaultLayout();
-    useLayoutStore.setState({ layout: defaultLayout });
-    useSelectionStore.setState({
-      activeLayerId: defaultLayout.layers[0].id,
-      selectedBinIds: [],
-      activeCategoryId: defaultLayout.categories[0].id,
-    });
-    useViewStore.setState({
-      zoom: 1,
-      showOtherLayers: true,
-      showLabels: true,
-      leftPanelCollapsed: false,
-      rightPanelCollapsed: false,
-      contextMenu: null,
-    });
-    useInteractionStore.setState({
-      interaction: null,
-      dropTarget: null,
-      paintSize: null,
-      showIsometricPreview: true,
-      isometricRotation: 0,
-      layerViewMode: 'focus',
-      isPreviewExpanded: false,
-    });
-    useMobileStore.setState({
-      activeMobilePanel: null,
-    });
+    resetAllStores();
+    const { layout } = useLayoutStore.getState();
 
-    testCategory = defaultLayout.categories[0];
-    testLayer = defaultLayout.layers[0];
+    testCategory = layout.categories[0];
+    testLayer = layout.layers[0];
     testBin = {
       id: 'test-bin-1',
       x: 2,

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -125,6 +125,18 @@ export function resetAllStores(): void {
 }
 
 /**
+ * Extract a bin ID from an addBin() Result, throwing if the operation failed.
+ * Replaces the duplicated getBinId() helpers across hook test files.
+ *
+ * @example
+ * const binId = getBinId(addBin({ layerId, x: 0, y: 0, ... }));
+ */
+export function getBinId(result: Result<string, unknown>): string {
+  if (!isOk(result)) throw new Error('addBin failed');
+  return result.value;
+}
+
+/**
  * Factory to create test bins with variations.
  * Prevents inline factory duplication across test files.
  *


### PR DESCRIPTION
## Summary

- Extract duplicated `getBinId()` helper from 4 test files into `testUtils.ts`
- Replace manual multi-store `setState()` boilerplate with `resetAllStores()` in 5 hook test files
- Remove ~510 lines of duplicated test setup code

## Files changed

| File | Change |
|---|---|
| `src/test/testUtils.ts` | Added `getBinId()` export |
| `src/test/hooks/useKeyboard.test.ts` | `resetAllStores()` + imported `getBinId` |
| `src/test/hooks/useInteraction.test.ts` | Replaced 9 identical `beforeEach` blocks |
| `src/test/hooks/useGridResize.test.ts` | `resetAllStores()` + imported `getBinId` |
| `src/test/hooks/useStagingDragInteraction.test.ts` | `resetAllStores()` + imported `getBinId` |
| `src/test/mobile-touch.test.tsx` | `resetAllStores()`, removed 4 unused imports |

## Test plan

- [x] `npx tsc --noEmit` — TypeScript compiles clean
- [x] All 5 modified test files pass (153 tests)
- [x] Full suite passes: 217 files, 5355 tests, 0 failures
- [ ] CI passes