### PR TITLE
refactor: simplify duplicateBin and binsCollide

### DIFF
--- a/src/core/store/layout.ts
+++ b/src/core/store/layout.ts
@@ -200,20 +200,20 @@ export const useLayoutStore = create<LayoutState>()(
         return err(layoutInvalidOperation('duplicateBin', `Bin ${id} not found`));
       }
 
+      const copyProps = (overrides: { layerId: string; x: number; y: number }) => ({
+        width: bin.width,
+        depth: bin.depth,
+        height: bin.height,
+        clearanceHeight: bin.clearanceHeight,
+        category: bin.category,
+        label: bin.label,
+        notes: bin.notes,
+        customProperties: bin.customProperties,
+        ...overrides,
+      });
+
       if (bin.layerId === STAGING_ID) {
-        return addBin({
-          layerId: STAGING_ID,
-          x: 0,
-          y: 0,
-          width: bin.width,
-          depth: bin.depth,
-          height: bin.height,
-          clearanceHeight: bin.clearanceHeight,
-          category: bin.category,
-          label: bin.label,
-          notes: bin.notes,
-          customProperties: bin.customProperties,
-        });
+        return addBin(copyProps({ layerId: STAGING_ID, x: 0, y: 0 }));
       }
 
       const offsets = [
@@ -234,36 +234,12 @@ export const useLayoutStore = create<LayoutState>()(
         );
 
         if (result.valid) {
-          return addBin({
-            layerId: bin.layerId,
-            x: newX,
-            y: newY,
-            width: bin.width,
-            depth: bin.depth,
-            height: bin.height,
-            clearanceHeight: bin.clearanceHeight,
-            category: bin.category,
-            label: bin.label,
-            notes: bin.notes,
-            customProperties: bin.customProperties,
-          });
+          return addBin(copyProps({ layerId: bin.layerId, x: newX, y: newY }));
         }
       }
 
       // Fallback to staging if no adjacent space available
-      return addBin({
-        layerId: STAGING_ID,
-        x: 0,
-        y: 0,
-        width: bin.width,
-        depth: bin.depth,
-        height: bin.height,
-        clearanceHeight: bin.clearanceHeight,
-        category: bin.category,
-        label: bin.label,
-        notes: bin.notes,
-        customProperties: bin.customProperties,
-      });
+      return addBin(copyProps({ layerId: STAGING_ID, x: 0, y: 0 }));
     },
 
     moveBinToStaging: (id) => {

--- a/src/shared/utils/collision.ts
+++ b/src/shared/utils/collision.ts
@@ -139,20 +139,11 @@ export function binsCollideResult(
  * @throws Error if either bin's layer not found - use binsCollideResult for safe error handling
  */
 export function binsCollide(binA: Bin, binB: Bin, layers: Layer[]): boolean {
-  // Staging bins don't collide with anything
-  if (binA.layerId === STAGING_ID || binB.layerId === STAGING_ID) {
-    return false;
+  const result = binsCollideResult(binA, binB, layers);
+  if (isOk(result)) {
+    return result.value;
   }
-
-  // Check footprint overlap first (cheaper)
-  if (!footprintsOverlap(binA, binB)) {
-    return false;
-  }
-
-  const rectA = getBin3DRect(binA, layers);
-  const rectB = getBin3DRect(binB, layers);
-
-  return verticalRangesOverlap(rectA, rectB);
+  throw new Error(result.error.message);
 }
 
 // Simple cache for getBlockedZones - avoids recomputation when called repeatedly


### PR DESCRIPTION
## Summary

- **`duplicateBin` (layout.ts):** Extracted a `copyProps` helper to eliminate 3× repeated bin property spreads (`width`, `depth`, `height`, `clearanceHeight`, `category`, `label`, `notes`, `customProperties`). Adding a new `Bin` field now requires updating only one place instead of three.
- **`binsCollide` (collision.ts):** Delegated to `binsCollideResult` instead of re-implementing the same staging check → footprint check → 3D rect logic. The throwing variant now unwraps the Result-based variant.

Net: **-33 lines**, no behavior change.

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 5,355 unit tests pass
- [x] Pre-commit hooks pass (lint, build, coverage, i18n, boundaries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)