### PR TITLE
refactor: adopt findBinById/findBinsByIds utilities

### DIFF
--- a/src/components/Mobile/BinContextMenu.tsx
+++ b/src/components/Mobile/BinContextMenu.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/shared/components/ContextMenu';
 import { STLSearchDropdown } from '@/components/STLSearchDropdown';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
+import { findBinById } from '@/utils/entity';
 import { isOk } from '@/core/result';
 import { useTranslation } from '@/i18n';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
@@ -87,7 +88,7 @@ export function BinContextMenu({ bin, position, onClose, source }: BinContextMen
       const result = duplicateBin(bin.id);
       if (isOk(result)) {
         // Track for ML telemetry
-        const newBin = useLayoutStore.getState().layout.bins.find((b) => b.id === result.value);
+        const newBin = findBinById(useLayoutStore.getState().layout, result.value);
         if (newBin) {
           mlTracking.trackPlacement(newBin, 'duplicate');
         }

--- a/src/components/Mobile/MultiBinContextMenu.tsx
+++ b/src/components/Mobile/MultiBinContextMenu.tsx
@@ -9,8 +9,8 @@ import {
 import { useContextMenu } from '@/hooks/useContextMenu';
 import { splitBinsByLocation } from '@/shared/utils';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
+import { findBinsByIds } from '@/utils/entity';
 import { useTranslation } from '@/i18n';
-import type { Bin } from '@/core/types';
 
 interface MultiBinContextMenuProps {
   binIds: string[];
@@ -53,9 +53,7 @@ export function MultiBinContextMenu({
   const [showCategoryPicker, setShowCategoryPicker] = useState(false);
 
   // Get bins and categorize them
-  const bins = binIds
-    .map((id) => layout.bins.find((b) => b.id === id))
-    .filter((b): b is Bin => b !== undefined);
+  const bins = findBinsByIds(layout, binIds);
 
   const { stagingBins, gridBins } = splitBinsByLocation(bins);
 

--- a/src/features/command-palette/components/CommandPalette.tsx
+++ b/src/features/command-palette/components/CommandPalette.tsx
@@ -22,6 +22,7 @@ import { useShallow } from 'zustand/shallow';
 import { useLayoutSwitcher } from '@/hooks';
 import { COMMAND_DEFINITIONS, CATEGORY_LABELS, CATEGORY_ORDER } from '../commands';
 import { getStagingBins } from '@/shared/utils';
+import { findBinById } from '@/utils/entity';
 import type { CommandDefinition } from '../commands';
 import { useRecentCommandsStore } from '../store/recentStore';
 import { ShortcutBadge } from './ShortcutBadge';
@@ -160,7 +161,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             : null;
         case 'rotate-bin': {
           if (selectedBinIds.length !== 1) return null;
-          const bin = layout.bins.find((b) => b.id === selectedBinIds[0]);
+          const bin = findBinById(layout, selectedBinIds[0]);
           if (!bin) return null;
           return () => {
             execute(() => {
@@ -245,7 +246,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 
           if (selectedBinIds.length > 0) {
             // Cycle category of selected bins
-            const firstBin = layout.bins.find((b) => b.id === selectedBinIds[0]);
+            const firstBin = findBinById(layout, selectedBinIds[0]);
             if (!firstBin) return null;
 
             return () => {
@@ -344,7 +345,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         }
         case 'select-by-category': {
           if (selectedBinIds.length === 0) return null;
-          const firstBin = layout.bins.find((b) => b.id === selectedBinIds[0]);
+          const firstBin = findBinById(layout, selectedBinIds[0]);
           if (!firstBin) return null;
           const sameCategoryBins = layout.bins
             .filter((b) => b.layerId === activeLayerId && b.category === firstBin.category)

--- a/src/hooks/useBinList.ts
+++ b/src/hooks/useBinList.ts
@@ -13,6 +13,7 @@ import { useInteractionStore } from '@/core/store/interaction';
 import type { LayoutError } from '@/core/result';
 import { markFeatureUsed } from '@/utils/analytics';
 import { isErr, getUserMessage } from '@/core/result';
+import { findBinsByIds } from '@/utils/entity';
 import { usePrintList, type UsePrintListReturn } from '@/features/print-export';
 import {
   filterBySearch,
@@ -148,9 +149,7 @@ export function useBinList(): UseBinListReturn {
     if (selectedBinIds.length === 0) return;
 
     // Track deletion BEFORE executing (need bin data)
-    const binsToDelete = selectedBinIds
-      .map((id) => layout.bins.find((b) => b.id === id))
-      .filter((bin): bin is (typeof layout.bins)[number] => bin !== undefined);
+    const binsToDelete = findBinsByIds(layout, selectedBinIds);
     if (binsToDelete.length > 0) {
       mlTracking.trackDeletion(binsToDelete[0], 'bulk', binsToDelete.length);
 
@@ -201,9 +200,9 @@ export function useBinList(): UseBinListReturn {
       if (selectedBinIds.length === 0) return;
 
       // Filter to only bins that actually change
-      const binsToUpdate = selectedBinIds
-        .map((id) => layout.bins.find((b) => b.id === id))
-        .filter((bin): bin is (typeof layout.bins)[number] => !!bin && bin.category !== categoryId);
+      const binsToUpdate = findBinsByIds(layout, selectedBinIds).filter(
+        (bin) => bin.category !== categoryId
+      );
       if (binsToUpdate.length === 0) return;
 
       const category = printList.categories.find((c) => c.id === categoryId);

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -21,6 +21,7 @@ import { useLabsStore } from '@/core/store';
 import { useGridNavigation } from '@/features/grid-editor';
 import { isOk } from '@/core/result';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
+import { findBinById, findBinsByIds } from '@/utils/entity';
 import { useTranslation } from '@/i18n';
 
 /**
@@ -149,9 +150,7 @@ export function useKeyboard() {
       if (isShortcut(key, SHORTCUTS.DELETE) && selectedBinIds.length > 0) {
         e.preventDefault();
         // Track deletion BEFORE executing (need bin data)
-        const binsToDelete = selectedBinIds
-          .map((id) => layout.bins.find((b) => b.id === id))
-          .filter((b): b is (typeof layout.bins)[number] => b !== undefined);
+        const binsToDelete = findBinsByIds(layout, selectedBinIds);
         if (binsToDelete.length > 0) {
           mlTracking.trackDeletion(binsToDelete[0], 'key', binsToDelete.length);
           // Check for quick-correction (deleted shortly after creation)
@@ -208,9 +207,7 @@ export function useKeyboard() {
             if (isOk(result)) {
               newIds.push(result.value);
               // Track for ML telemetry
-              const newBin = useLayoutStore
-                .getState()
-                .layout.bins.find((b) => b.id === result.value);
+              const newBin = findBinById(useLayoutStore.getState().layout, result.value);
               if (newBin) {
                 mlTracking.trackPlacement(newBin, 'duplicate');
               }
@@ -228,7 +225,7 @@ export function useKeyboard() {
       // Smart rotation: if rotation doesn't fit in place, finds nearby valid position
       if (key.toLowerCase() === SHORTCUTS.ROTATE && !ctrlOrMeta && selectedBinIds.length === 1) {
         e.preventDefault();
-        const bin = layout.bins.find((b) => b.id === selectedBinIds[0]);
+        const bin = findBinById(layout, selectedBinIds[0]);
         if (!bin) return;
 
         const result = validateBinRotation(bin, layout);
@@ -330,7 +327,7 @@ export function useKeyboard() {
 
         if (selectedBinIds.length > 0) {
           // Change category of selected bins
-          const firstBin = layout.bins.find((b) => b.id === selectedBinIds[0]);
+          const firstBin = findBinById(layout, selectedBinIds[0]);
           if (!firstBin) return;
 
           const currentPos = categories.findIndex((c) => c.id === firstBin.category);
@@ -338,11 +335,9 @@ export function useKeyboard() {
           const newCategoryId = categories[nextPos].id;
 
           // Filter to only bins that actually change
-          const binsToUpdate = selectedBinIds
-            .map((id) => layout.bins.find((b) => b.id === id))
-            .filter(
-              (bin): bin is (typeof layout.bins)[number] => !!bin && bin.category !== newCategoryId
-            );
+          const binsToUpdate = findBinsByIds(layout, selectedBinIds).filter(
+            (bin) => bin.category !== newCategoryId
+          );
           if (binsToUpdate.length === 0) return;
 
           const batchSize = binsToUpdate.length;
@@ -420,9 +415,7 @@ export function useKeyboard() {
         // Otherwise, use existing nudge logic for selected bins
         if (selectedBinIds.length > 0) {
           // Check if any selected bins have fractional dimensions
-          const selectedBins = selectedBinIds
-            .map((id) => layout.bins.find((b) => b.id === id))
-            .filter((b): b is (typeof layout.bins)[number] => b !== undefined);
+          const selectedBins = findBinsByIds(layout, selectedBinIds);
           const increment = selectedBins.some((bin) => hasFractionalDimensions(bin)) ? 0.5 : 1;
 
           let dx = 0,
@@ -437,7 +430,7 @@ export function useKeyboard() {
           let allValid = true;
 
           for (const binId of selectedBinIds) {
-            const bin = layout.bins.find((b) => b.id === binId);
+            const bin = findBinById(layout, binId);
             if (!bin || bin.layerId === STAGING_ID) {
               allValid = false;
               break;
@@ -472,7 +465,7 @@ export function useKeyboard() {
 
             execute(() => {
               for (const binId of selectedBinIds) {
-                const bin = layout.bins.find((b) => b.id === binId);
+                const bin = findBinById(layout, binId);
                 if (!bin) continue;
                 updateBin(binId, { x: bin.x + dx, y: bin.y + dy });
               }


### PR DESCRIPTION
## Summary
- Replace inline `.map().filter()` bin lookup chains with existing `findBinsByIds()` utility (4 sites)
- Replace inline `.bins.find()` calls with `findBinById()` utility (8 sites)
- Consolidates duplicated patterns across 5 files: `useKeyboard.ts`, `useBinList.ts`, `MultiBinContextMenu.tsx`, `BinContextMenu.tsx`, `CommandPalette.tsx`
- Intentionally preserves inline lookups in `useCallback` hooks with `layout.bins` dependencies to avoid widening React Compiler memoization scope

## Test plan
- [x] All pre-commit hooks pass (lint, build, coverage, i18n, module boundaries)
- [x] 313 affected tests pass
- [x] TypeScript compilation clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)