### PR TITLE
chore: remove 13 unused Result utility functions

### DIFF
--- a/src/core/result/index.ts
+++ b/src/core/result/index.ts
@@ -203,28 +203,7 @@ export {
   // Pattern matching
   match,
 
-  // Combining
-  combine,
-  combine3,
-  collect,
-  collectAll,
-
-  // Boolean operations
-  or,
-  and,
-
   // Try-catch wrappers
   tryCatch,
   tryCatchAsync,
-
-  // Unit helpers
-  toUnit,
-  tap,
-  tapErr,
-
-  // Array utilities
-  allOk,
-  anyErr,
-  filterOk,
-  filterErr,
 } from './utils';

--- a/src/core/result/utils.ts
+++ b/src/core/result/utils.ts
@@ -5,17 +5,14 @@
  * - Transformations: map, mapErr, flatMap/andThen
  * - Extraction: unwrap, unwrapOr, unwrapOrElse
  * - Pattern matching: match
- * - Combining: combine, collect, collectAll
- * - Boolean operations: or, and
  * - Try-catch wrappers: tryCatch, tryCatchAsync
- * - Side effects: tap, tapErr
  *
  * These utilities are inspired by Rust's Result type and functional
  * programming patterns, adapted for TypeScript ergonomics.
  */
 
-import type { Result, Unit } from './types';
-import { ok, err, isOk, isErr, OK } from './types';
+import type { Result } from './types';
+import { ok, err, isOk, isErr } from './types';
 
 // =============================================================================
 // Mapping & Transformation
@@ -178,127 +175,6 @@ export function match<T, E, U>(
 }
 
 // =============================================================================
-// Combining Results
-// =============================================================================
-
-/**
- * Combine two Results into a tuple.
- * Returns the first Err if either is Err.
- *
- * @example
- * ```ts
- * const r1 = ok(1);
- * const r2 = ok('hello');
- * const combined = combine(r1, r2);
- * // { ok: true, value: [1, 'hello'] }
- * ```
- */
-export function combine<T1, T2, E>(r1: Result<T1, E>, r2: Result<T2, E>): Result<[T1, T2], E> {
-  if (isErr(r1)) return r1;
-  if (isErr(r2)) return r2;
-  return ok([r1.value, r2.value]);
-}
-
-/**
- * Combine three Results into a tuple.
- */
-export function combine3<T1, T2, T3, E>(
-  r1: Result<T1, E>,
-  r2: Result<T2, E>,
-  r3: Result<T3, E>
-): Result<[T1, T2, T3], E> {
-  if (isErr(r1)) return r1;
-  if (isErr(r2)) return r2;
-  if (isErr(r3)) return r3;
-  return ok([r1.value, r2.value, r3.value]);
-}
-
-/**
- * Collect an array of Results into a Result of array.
- * Returns the first Err if any Result is Err.
- *
- * @example
- * ```ts
- * const results = [ok(1), ok(2), ok(3)];
- * const collected = collect(results);
- * // { ok: true, value: [1, 2, 3] }
- *
- * const mixed = [ok(1), err('failed'), ok(3)];
- * const failed = collect(mixed);
- * // { ok: false, error: 'failed' }
- * ```
- */
-export function collect<T, E>(results: Result<T, E>[]): Result<T[], E> {
-  const values: T[] = [];
-  for (const result of results) {
-    if (isErr(result)) {
-      return result;
-    }
-    values.push(result.value);
-  }
-  return ok(values);
-}
-
-/**
- * Collect an array of Results, accumulating all errors.
- * Returns Ok with all values if all succeed, or Err with all errors.
- *
- * @example
- * ```ts
- * const results = [ok(1), err('a'), ok(2), err('b')];
- * const collected = collectAll(results);
- * // { ok: false, error: ['a', 'b'] }
- * ```
- */
-export function collectAll<T, E>(results: Result<T, E>[]): Result<T[], E[]> {
-  const values: T[] = [];
-  const errors: E[] = [];
-
-  for (const result of results) {
-    if (isOk(result)) {
-      values.push(result.value);
-    } else {
-      errors.push(result.error);
-    }
-  }
-
-  if (errors.length > 0) {
-    return err(errors);
-  }
-  return ok(values);
-}
-
-// =============================================================================
-// Boolean Operations
-// =============================================================================
-
-/**
- * Return the first Ok, or the last Err if all fail.
- * Useful for fallback chains.
- *
- * @example
- * ```ts
- * const result = or(
- *   loadFromCache(id),
- *   loadFromDatabase(id)
- * );
- * ```
- */
-export function or<T, E>(r1: Result<T, E>, r2: Result<T, E>): Result<T, E> {
-  if (isOk(r1)) return r1;
-  return r2;
-}
-
-/**
- * Return r2 if r1 is Ok, otherwise return r1's Err.
- * Useful when you need both operations to succeed but only want the second value.
- */
-export function and<T, U, E>(r1: Result<T, E>, r2: Result<U, E>): Result<U, E> {
-  if (isErr(r1)) return r1;
-  return r2;
-}
-
-// =============================================================================
 // Try-Catch Wrappers
 // =============================================================================
 
@@ -345,95 +221,4 @@ export async function tryCatchAsync<T, E = unknown>(
   } catch (error) {
     return err(mapError ? mapError(error) : (error as E));
   }
-}
-
-// =============================================================================
-// Void/Unit Helpers
-// =============================================================================
-
-/**
- * Convert any Ok result to Ok<Unit>.
- * Useful when you don't care about the value, only success/failure.
- *
- * @example
- * ```ts
- * const result = saveFile(data); // Result<FileInfo, Error>
- * const voidResult = toUnit(result); // Result<void, Error>
- * ```
- */
-export function toUnit<T, E>(result: Result<T, E>): Result<Unit, E> {
-  if (isOk(result)) {
-    return OK;
-  }
-  return result;
-}
-
-/**
- * Perform a side effect if Result is Ok, then return the original result.
- * Useful for logging or other side effects without changing the result.
- *
- * @example
- * ```ts
- * const result = tap(loadUser(id), (user) => {
- *   console.log('Loaded user:', user.name);
- * });
- * ```
- */
-export function tap<T, E>(result: Result<T, E>, fn: (value: T) => void): Result<T, E> {
-  if (isOk(result)) {
-    fn(result.value);
-  }
-  return result;
-}
-
-/**
- * Perform a side effect if Result is Err, then return the original result.
- * Useful for logging errors without changing the result.
- *
- * @example
- * ```ts
- * const result = tapErr(loadUser(id), (error) => {
- *   console.error('Failed to load user:', error.message);
- * });
- * ```
- */
-export function tapErr<T, E>(result: Result<T, E>, fn: (error: E) => void): Result<T, E> {
-  if (isErr(result)) {
-    fn(result.error);
-  }
-  return result;
-}
-
-// =============================================================================
-// Utility Functions
-// =============================================================================
-
-/**
- * Check if all Results in an array are Ok.
- */
-export function allOk<T, E>(results: Result<T, E>[]): boolean {
-  return results.every(isOk);
-}
-
-/**
- * Check if any Result in an array is Err.
- */
-export function anyErr<T, E>(results: Result<T, E>[]): boolean {
-  return results.some(isErr);
-}
-
-/**
- * Get all Ok values from an array of Results.
- * Filters out Err results and returns only the Ok values.
- */
-export function filterOk<T, E>(results: Result<T, E>[]): T[] {
-  return results.filter(isOk).map((r) => r.value);
-}
-
-/**
- * Get all Err values from an array of Results.
- * Filters out Ok results and returns only the errors.
- */
-export function filterErr<T, E>(results: Result<T, E>[]): E[] {
-  return results.filter(isErr).map((r) => r.error);
 }

--- a/src/test/result.test.ts
+++ b/src/test/result.test.ts
@@ -17,21 +17,8 @@ import {
   unwrapOrElse,
   unwrapErr,
   match,
-  combine,
-  combine3,
-  collect,
-  collectAll,
-  or,
-  and,
   tryCatch,
   tryCatchAsync,
-  toUnit,
-  tap,
-  tapErr,
-  allOk,
-  anyErr,
-  filterOk,
-  filterErr,
 
   // Error constructors
   storageNotFound,
@@ -276,107 +263,6 @@ describe('Result utilities', () => {
     });
   });
 
-  describe('combine()', () => {
-    it('combines two ok results into tuple', () => {
-      const result = combine(ok(1), ok('hello'));
-      expect(result).toEqual({ ok: true, value: [1, 'hello'] });
-    });
-
-    it('returns first error if first is err', () => {
-      const result = combine(err('first'), ok('hello'));
-      expect(result).toEqual({ ok: false, error: 'first' });
-    });
-
-    it('returns second error if second is err', () => {
-      const result = combine(ok(1), err('second'));
-      expect(result).toEqual({ ok: false, error: 'second' });
-    });
-  });
-
-  describe('combine3()', () => {
-    it('combines three ok results into tuple', () => {
-      const result = combine3(ok(1), ok('hello'), ok(true));
-      expect(result).toEqual({ ok: true, value: [1, 'hello', true] });
-    });
-
-    it('returns first error when first is err', () => {
-      const result = combine3(err('first'), ok('hello'), ok(true));
-      expect(result).toEqual({ ok: false, error: 'first' });
-    });
-
-    it('returns second error when first is ok and second is err', () => {
-      const result = combine3(ok(1), err('second'), err('third'));
-      expect(result).toEqual({ ok: false, error: 'second' });
-    });
-
-    it('returns third error when first two are ok', () => {
-      const result = combine3(ok(1), ok('hello'), err('third'));
-      expect(result).toEqual({ ok: false, error: 'third' });
-    });
-  });
-
-  describe('collect()', () => {
-    it('collects all ok values into array', () => {
-      const results = [ok(1), ok(2), ok(3)];
-      const collected = collect(results);
-      expect(collected).toEqual({ ok: true, value: [1, 2, 3] });
-    });
-
-    it('returns first error', () => {
-      const results = [ok(1), err('error'), ok(3)];
-      const collected = collect(results);
-      expect(collected).toEqual({ ok: false, error: 'error' });
-    });
-
-    it('handles empty array', () => {
-      const collected = collect([]);
-      expect(collected).toEqual({ ok: true, value: [] });
-    });
-  });
-
-  describe('collectAll()', () => {
-    it('collects all ok values when no errors', () => {
-      const results = [ok(1), ok(2), ok(3)];
-      const collected = collectAll(results);
-      expect(collected).toEqual({ ok: true, value: [1, 2, 3] });
-    });
-
-    it('collects all errors when some fail', () => {
-      const results = [ok(1), err('a'), ok(2), err('b')];
-      const collected = collectAll(results);
-      expect(collected).toEqual({ ok: false, error: ['a', 'b'] });
-    });
-  });
-
-  describe('or()', () => {
-    it('returns first ok', () => {
-      const result = or(ok(1), ok(2));
-      expect(result).toEqual({ ok: true, value: 1 });
-    });
-
-    it('returns second if first is err', () => {
-      const result = or(err('first') as Result<number, string>, ok(2));
-      expect(result).toEqual({ ok: true, value: 2 });
-    });
-
-    it('returns last err if both fail', () => {
-      const result = or(err('first'), err('second'));
-      expect(result).toEqual({ ok: false, error: 'second' });
-    });
-  });
-
-  describe('and()', () => {
-    it('returns second if first is ok', () => {
-      const result = and(ok(1), ok('hello'));
-      expect(result).toEqual({ ok: true, value: 'hello' });
-    });
-
-    it('returns first error if first is err', () => {
-      const result = and(err('first'), ok('hello'));
-      expect(result).toEqual({ ok: false, error: 'first' });
-    });
-  });
-
   describe('tryCatch()', () => {
     it('returns ok for successful function', () => {
       const result = tryCatch(() => JSON.parse('{"a": 1}'));
@@ -420,88 +306,6 @@ describe('Result utilities', () => {
         throw originalError;
       });
       expect(result).toEqual({ ok: false, error: originalError });
-    });
-  });
-
-  describe('toUnit()', () => {
-    it('converts ok to ok<void>', () => {
-      const result = toUnit(ok(42));
-      expect(result).toEqual({ ok: true, value: undefined });
-    });
-
-    it('preserves err', () => {
-      const result = toUnit(err('error'));
-      expect(result).toEqual({ ok: false, error: 'error' });
-    });
-  });
-
-  describe('tap()', () => {
-    it('calls function for ok and returns original', () => {
-      let captured = 0;
-      const original = ok(42);
-      const result = tap(original, (v) => {
-        captured = v;
-      });
-      expect(captured).toBe(42);
-      expect(result).toBe(original);
-    });
-
-    it('does not call function for err', () => {
-      let called = false;
-      const result = tap(err('error'), () => {
-        called = true;
-      });
-      expect(called).toBe(false);
-      expect(isErr(result)).toBe(true);
-    });
-  });
-
-  describe('tapErr()', () => {
-    it('calls function for err and returns original', () => {
-      let captured = '';
-      const original = err('error');
-      const result = tapErr(original, (e) => {
-        captured = e;
-      });
-      expect(captured).toBe('error');
-      expect(result).toBe(original);
-    });
-
-    it('does not call function for ok', () => {
-      let called = false;
-      const result = tapErr(ok(42), () => {
-        called = true;
-      });
-      expect(called).toBe(false);
-      expect(isOk(result)).toBe(true);
-    });
-  });
-
-  describe('array utilities', () => {
-    it('allOk returns true when all ok', () => {
-      expect(allOk([ok(1), ok(2), ok(3)])).toBe(true);
-    });
-
-    it('allOk returns false when any err', () => {
-      expect(allOk([ok(1), err('e'), ok(3)])).toBe(false);
-    });
-
-    it('anyErr returns true when any err', () => {
-      expect(anyErr([ok(1), err('e'), ok(3)])).toBe(true);
-    });
-
-    it('anyErr returns false when all ok', () => {
-      expect(anyErr([ok(1), ok(2), ok(3)])).toBe(false);
-    });
-
-    it('filterOk extracts ok values', () => {
-      const results = [ok(1), err('e'), ok(3)];
-      expect(filterOk(results)).toEqual([1, 3]);
-    });
-
-    it('filterErr extracts err values', () => {
-      const results = [ok(1), err('a'), ok(3), err('b')];
-      expect(filterErr(results)).toEqual(['a', 'b']);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Remove 13 unused Result utility functions that were never imported in production code: `combine`, `combine3`, `collect`, `collectAll`, `or`, `and`, `toUnit`, `tap`, `tapErr`, `allOk`, `anyErr`, `filterOk`, `filterErr`
- Remove corresponding 29 dead tests and barrel file re-exports
- Clean up unused `Unit` and `OK` imports from utils.ts
- Keeps core primitives (`map`, `flatMap`, `match`, `unwrap`, `tryCatch`, `tryCatchAsync`) that form the standard Result API

**Net: -434 lines deleted**

## Test plan
- [x] All 5326 tests pass (29 dead tests removed alongside dead functions)
- [x] TypeScript compilation clean
- [x] Pre-commit hooks pass (lint, build, coverage, i18n, module boundaries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)