### PR TITLE
fix: adjust banana Z position to align with grid floor

### DIFF
--- a/src/features/grid-editor/components/Grid/IsometricPreview/BananaScale.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/BananaScale.tsx
@@ -39,16 +39,12 @@ export function BananaScale({ drawerDepth, gridUnitMm }: BananaScaleProps) {
   const rawCenterY = 7;
   const yOffset = -rawCenterY * scaleFactor;
 
-  // Raw model Z min is ~21 units. Offset so the bottom sits on the floor (z=0).
-  const rawZMin = 21;
-  const zOffset = -rawZMin * scaleFactor;
-
   // Position to the left of the grid, centered along the depth axis.
   const x = -3;
 
   return (
-    <group position={[x, drawerDepth / 2, 0]}>
-      <Clone object={scene} scale={scaleFactor} position={[0, yOffset, zOffset]} />
+    <group position={[x, drawerDepth / 2, 0.34]}>
+      <Clone object={scene} scale={scaleFactor} position={[0, yOffset, 0]} />
       {/* Label running alongside the banana's length (offset in X, centered in Y) */}
       <Text
         position={[1.2, 0, 0]}


### PR DESCRIPTION
## Summary

- Nudge the banana model's Z position so it visually sits on the grid floor plane rather than appearing slightly below it

## Test plan

- [ ] Toggle banana on in 3D preview — verify it sits flush with the grid floor