### PR TITLE
chore: prepare repo for open source release

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: andyaragon

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,205 +1,55 @@
 # Contributing to Gridfinity Layout Tool
 
-Thank you for your interest in contributing! This guide will help you get set up and productive quickly.
+Thanks for your interest in Gridfinity Layout Tool! This project is **open source but not open contribution** — code changes are handled by the maintainer to keep development focused and maintainable. That said, community input is valuable and there are several ways to help.
 
-## Quick Start
+## Ways to Contribute
+
+### Bug Reports
+
+Found something broken? [Open a bug report](https://github.com/andymai/gridfinity-layout-tool/issues/new?template=bug_report.md). Good bug reports include:
+
+- Steps to reproduce the issue
+- What you expected vs. what happened
+- Browser and device info
+- Screenshots or screen recordings if applicable
+
+### Feature Requests
+
+Have an idea? [Open a feature request](https://github.com/andymai/gridfinity-layout-tool/issues/new?template=feature_request.md). Describe the problem you're trying to solve — that context helps more than a specific solution.
+
+### Discussions
+
+Use [GitHub Discussions](https://github.com/andymai/gridfinity-layout-tool/discussions) for questions, ideas, and general conversation about the project.
+
+### Security Vulnerabilities
+
+See [SECURITY.md](./SECURITY.md) for how to privately report security issues.
+
+## Pull Requests
+
+This project does not accept unsolicited pull requests. PRs opened without prior discussion will be closed — not because the idea is bad, but because features require design consideration and carry a long-term maintenance burden.
+
+If you have a code change you'd like to suggest, please open an issue describing the problem and your proposed approach. If it aligns with the project direction, the maintainer will implement it.
+
+## Running Locally
+
+To run the project locally for testing or verifying a bug report:
 
 ```bash
-# Clone the repository
 git clone https://github.com/andymai/gridfinity-layout-tool.git
 cd gridfinity-layout-tool
-
-# Use the correct Node version (requires nvm)
 nvm use
-
-# Install dependencies
 npm install
-
-# Start development server
 npm run dev
 ```
 
 The app will be available at `http://localhost:5173`.
 
-## Development Environment
-
 ### Prerequisites
 
-- **Node.js 20+** (see `.nvmrc` - use `nvm use` to switch)
+- **Node.js 20+** (see `.nvmrc` — use `nvm use` to switch)
 - **npm 10+** (comes with Node 20)
-- A modern browser (Chrome, Firefox, or Safari)
-
-### Recommended VS Code Extensions
-
-- [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) - Linting
-- [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) - Formatting
-- [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) - Consistent settings
-- [Tailwind CSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) - CSS autocomplete
-
-### Editor Setup
-
-The project includes `.editorconfig` and `.prettierrc.json` for consistent formatting. Configure your editor to:
-
-1. Format on save using Prettier
-2. Use 2-space indentation
-3. Use single quotes for strings
-4. Trim trailing whitespace
-
-## Available Scripts
-
-### Development
-
-| Command           | Description                         |
-| ----------------- | ----------------------------------- |
-| `npm run dev`     | Start dev server at localhost:5173  |
-| `npm run build`   | Production build with type checking |
-| `npm run preview` | Preview production build locally    |
-
-### Code Quality
-
-| Command                    | Description                      |
-| -------------------------- | -------------------------------- |
-| `npm run lint`             | Run ESLint                       |
-| `npm run lint:fix`         | Run ESLint with auto-fix         |
-| `npm run format`           | Format all files with Prettier   |
-| `npm run format:check`     | Check formatting without writing |
-| `npm run check:boundaries` | Validate module boundary rules   |
-
-### Testing
-
-| Command                 | Description                         |
-| ----------------------- | ----------------------------------- |
-| `npm run test`          | Run unit tests in watch mode        |
-| `npm run test:run`      | Run unit tests once                 |
-| `npm run test:coverage` | Run tests with coverage report      |
-| `npm run test:e2e`      | Run Playwright E2E tests (headless) |
-| `npm run test:e2e:ui`   | Run Playwright with interactive UI  |
-
-### Bundle Analysis
-
-| Command              | Description                |
-| -------------------- | -------------------------- |
-| `npm run size`       | Report bundle sizes        |
-| `npm run size:check` | Enforce bundle size limits |
-
-## Pre-commit Hooks
-
-This project uses Husky to run quality checks before each commit:
-
-1. **lint-staged** - ESLint + Prettier on changed files
-2. **Module boundaries** - Validates import rules
-3. **Build** - Full TypeScript check
-4. **Test coverage** - Enforces 83%+ line coverage
-
-If a commit fails, check the error output. Common issues:
-
-- **ESLint errors**: Run `npm run lint:fix` and review remaining issues
-- **Type errors**: Run `npm run build` to see full error output
-- **Coverage failures**: Add tests for new code
-
-### Bypassing Hooks (Emergency Only)
-
-```bash
-git commit --no-verify -m "WIP: emergency fix"
-```
-
-Use sparingly - CI will still catch issues.
-
-## Code Style
-
-See [CLAUDE.md](./CLAUDE.md) for comprehensive code style rules. Key points:
-
-### Required
-
-- Use `import type` for type-only imports
-- Use explicit types (never `any`, use `unknown`)
-- Prefix unused parameters with `_`
-- Use strict equality (`===`)
-- Use `@/` path alias for imports
-
-### Prohibited
-
-- `any` type
-- `console.log` (use `console.warn` or `console.error`)
-- `var` keyword
-- `==` comparison
-- Non-null assertions (`!`)
-
-## Testing Guidelines
-
-### Unit Tests
-
-- Located in `src/test/` or co-located with source files
-- Use Testing Library and Vitest
-- Focus on behavior, not implementation
-- Use `createTestLayout()` factory for test data
-
-```typescript
-import { describe, it, expect } from 'vitest';
-import { createTestLayout } from '@/test/testUtils';
-
-describe('myFunction', () => {
-  it('should handle valid input', () => {
-    const layout = createTestLayout({ bins: [...] });
-    expect(myFunction(layout)).toBe(expected);
-  });
-});
-```
-
-### E2E Tests
-
-- Located in `e2e/`
-- Use Playwright
-- Test critical user journeys
-- Run against all browsers in CI (Chromium, Firefox, WebKit)
-
-```typescript
-import { test, expect } from '@playwright/test';
-
-test('user can create a bin', async ({ page }) => {
-  await page.goto('/');
-  // ... test steps
-});
-```
-
-## Pull Request Process
-
-1. Create a feature branch from `main`
-2. Make your changes with clear commits
-3. Ensure all checks pass locally:
-   ```bash
-   npm run lint && npm run build && npm run test:coverage
-   ```
-4. Push and open a PR
-5. CI will run lint, build, tests, bundle size, and E2E across browsers
-6. Address review feedback
-7. Merge once approved
-
-### PR Guidelines
-
-- Keep PRs focused and reasonably sized
-- Write descriptive commit messages
-- Add tests for new functionality
-- Update documentation if needed
-- Don't include unrelated changes
-
-## Architecture Overview
-
-See [CLAUDE.md](./CLAUDE.md) for detailed architecture documentation, including:
-
-- Directory structure
-- State management (Zustand + Immer)
-- Core data model
-- Component patterns
-- Storage layer
-- API endpoints
-
-## Getting Help
-
-- Check existing [issues](https://github.com/andymai/gridfinity-layout-tool/issues)
-- Read [CLAUDE.md](./CLAUDE.md) for technical details
-- Open a new issue for bugs or feature requests
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the project's license.
+This project is licensed under [AGPL-3.0](./LICENSE). By interacting with this project, you agree to abide by the [Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability, please report it by emailing the maintainer directly rather than opening a public issue.
+If you discover a security vulnerability, please **do not** open a public issue. Instead, use [GitHub's private vulnerability reporting](https://github.com/andymai/gridfinity-layout-tool/security/advisories/new) to submit your report.
 
 **Please include:**
 


### PR DESCRIPTION
## Summary
- Add `.github/FUNDING.yml` with Ko-fi link (`andyaragon`)
- Update `SECURITY.md` to direct vulnerability reports to GitHub private vulnerability reporting instead of vague "email the maintainer"

Part of a broader open-source readiness effort that also included (already applied via API):
- Branch ruleset: 1 required approval, stale review dismissal, admin bypass
- Actions: restricted to GitHub + verified creators, default token set to read-only
- Repo settings: squash-only merges, discussions enabled, wiki disabled, topics added

## Test plan
- [ ] Verify FUNDING.yml renders the "Sponsor" button on the repo page
- [ ] Verify SECURITY.md link points to the correct advisory form