### PR TITLE
chore: fix Claude hooks and clean up CLAUDE.md

### DIFF
--- a/.claude/hooks/dangerous-patterns.sh
+++ b/.claude/hooks/dangerous-patterns.sh
@@ -45,7 +45,7 @@ for file in "${TS_FILES[@]}"; do
   [[ -z "$ADDED_LINES" ]] && continue
 
   # Get the actual diff with context once per file (for checks that need it)
-  DIFF_CONTEXT=$(git diff --cached -U10 "$file" 2>/dev/null)
+  DIFF_CONTEXT=$(git diff --cached -U30 "$file" 2>/dev/null)
 
   # Check 1: innerHTML assignment (XSS risk)
   if echo "$ADDED_LINES" | grep -qE '\.innerHTML\s*='; then

--- a/.claude/hooks/pre-pr-review.sh
+++ b/.claude/hooks/pre-pr-review.sh
@@ -72,16 +72,7 @@ if [[ -n "$ANY_TYPES" ]]; then
   done <<< "$ANY_TYPES"
 fi
 
-# Check 5: Non-null assertions
-NON_NULL=$(git diff "$BASE_BRANCH"..."$CURRENT_BRANCH" -- '*.ts' '*.tsx' 2>/dev/null | grep '^+' | grep -v '^+++' | grep -E '\w+!' | grep -v '!==' | grep -v '!=' | grep -v '<!--' | head -3)
-if [[ -n "$NON_NULL" ]]; then
-  ISSUES+="⚠️  Non-null assertions (!) - consider null checks:\n"
-  while IFS= read -r line; do
-    ISSUES+="    ${line:0:80}\n"
-  done <<< "$NON_NULL"
-fi
-
-# Check 6: Accessibility issues in changed TSX files
+# Check 5: Accessibility issues in changed TSX files
 A11Y_ISSUES=""
 for file in $FILES_CHANGED; do
   [[ "$file" != *.tsx ]] && continue

--- a/.claude/hooks/result-exhaustion-check.sh
+++ b/.claude/hooks/result-exhaustion-check.sh
@@ -47,7 +47,7 @@ for file in "${TS_FILES[@]}"; do
   # Pattern 1: Result-returning function called but result not stored or checked
   # e.g., addBin({ ... }); // Result ignored
   # This is tricky - look for function calls not assigned to anything
-  IGNORED_RESULTS=$(echo "$ADDED_LINES" | grep -E "^\+\s*(${RESULT_FUNCTIONS})\s*\(" | grep -v '=' | grep -v 'isOk' | grep -v 'isErr' | head -3)
+  IGNORED_RESULTS=$(echo "$ADDED_LINES" | grep -E "^\+.*\b(${RESULT_FUNCTIONS})\s*\(" | grep -v '=' | grep -v 'isOk' | grep -v 'isErr' | head -3)
 
   if [[ -n "$IGNORED_RESULTS" ]]; then
     ISSUES+="  $file: Result-returning function called but result ignored\n"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,12 +55,7 @@
             "type": "command",
             "command": ".claude/hooks/union-exhaustiveness-check.sh",
             "timeout": 30
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
+          },
           {
             "type": "command",
             "command": ".claude/hooks/pre-pr-review.sh",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,6 @@ Gridfinity Layout Tool: React + TypeScript web app for 3D-printed drawer organiz
 
 - **Main is protected** - all changes via PRs
 - Pre-commit hooks enforce lint, build, test coverage
-- **Coverage:** Lines 81%, Branches 69%, Functions 81%
 
 ## Code Style (Enforced)
 
@@ -131,8 +130,3 @@ npm run size          # Bundle size check
 **Vercel (required):** `BLOB_READ_WRITE_TOKEN`, `KV_REST_API_URL`, `KV_REST_API_TOKEN`, `TOKEN_SALT`
 
 **Optional:** `VITE_LIVEBLOCKS_PUBLIC_KEY`, `LIVEBLOCKS_SECRET_KEY`
-
-## Claude Code Hooks
-
-- `pre-pr-review.sh` - Lint, build, coverage before PR
-- `post-edit-test.sh` - Affected tests after edits


### PR DESCRIPTION
## Summary
- Remove stale coverage numbers and redundant hooks section from CLAUDE.md
- Remove false-positive-prone non-null assertion check from `pre-pr-review.sh` (ESLint already enforces `@typescript-eslint/no-non-null-assertion`)
- Increase diff context (`-U10` → `-U30`) in `dangerous-patterns.sh` for better JSON.parse try-catch detection
- Fix `result-exhaustion-check.sh` regex to catch Result-returning calls inside callbacks (e.g., `execute(() => deleteBin(id))`)
- Merge duplicate Bash PreToolUse matcher groups in `settings.json`
- Enable "Allow GitHub Actions to create and approve pull requests" repo setting (for release-please)

## Test plan
- [ ] Verify hooks still trigger on `git commit` and `gh pr create`
- [ ] Confirm `result-exhaustion-check.sh` catches `execute(() => deleteBin(id))` pattern
- [ ] Confirm release-please action can create PRs on next push to main