### PR TITLE
fix: auto-approve release-please PRs via GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,22 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: Generate App Token
+        if: steps.release.outputs.pr
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Auto-approve Release PR
+        if: steps.release.outputs.pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr review ${{ fromJSON(steps.release.outputs.pr).number }} \
+            --approve --repo ${{ github.repository }}
+
       - name: Auto-merge Release PR
         if: steps.release.outputs.pr
         env:


### PR DESCRIPTION
## Summary
- Release-please PRs were requiring manual approval because `GITHUB_TOKEN` cannot approve its own PR (GitHub prevents the same identity from both authoring and approving)
- Added a GitHub App token generation step (`actions/create-github-app-token@v2`) that provides a separate identity to auto-approve the PR before enabling auto-merge

## Setup required
After merging, add these repo secrets (Settings → Secrets → Actions):
- `APP_ID` — from the GitHub App settings page
- `APP_PRIVATE_KEY` — the `.pem` private key file contents

## Test plan
- [ ] Create GitHub App with Pull Requests read/write permission
- [ ] Install app on this repo
- [ ] Add `APP_ID` and `APP_PRIVATE_KEY` secrets
- [ ] Verify next release-please PR is auto-approved and auto-merged