### PR TITLE
ci: enforce conventional commits on PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,37 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Conventional Commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            a11y
+            i18n
+            refactor
+            chore
+            test
+            docs
+            style
+            ci
+            build
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" must not start with an uppercase letter.
+            Use lowercase: "{subject}" → e.g. "feat: add dark mode"


### PR DESCRIPTION
## Summary
- Add `action-semantic-pull-request` workflow to validate PR titles follow conventional commit format
- Allowed types align with `release-please-config.json` changelog sections
- Rejects uppercase subjects for consistency

## Context
release-please couldn't parse merge commits because GitHub's default merge message (`Merge pull request #N from...`) isn't a conventional commit. Two fixes applied:
1. Repo setting changed: merge commit title now uses PR title (`PR_TITLE`)
2. This PR: enforces PR titles are valid conventional commits

## Test plan
- [ ] Verify the "Conventional Commit" check runs on this PR
- [ ] After merge, test with a PR using a bad title (e.g., `bad title no type`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)