### PR TITLE
fix: use app token and squash merge for release-please auto-merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Auto-merge Release PR
         if: steps.release.outputs.pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr merge ${{ fromJSON(steps.release.outputs.pr).number }} \
-            --auto --merge --repo ${{ github.repository }}
+            --auto --squash --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Changed `--merge` to `--squash` since repo rulesets only allow squash merges
- Changed `GITHUB_TOKEN` to the GitHub App token for the merge step, since `GITHUB_TOKEN` can't merge PRs it authored

## Test plan
- [ ] Merge this PR, then verify the next release-please PR auto-merges after checks pass