### PR TITLE
fix: use app token for release-please to trigger CI on release PRs

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -2,7 +2,7 @@ name: PR Title
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize]
+    types: [opened, reopened, edited, synchronize]
 
 permissions:
   pull-requests: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,27 +3,23 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
-        id: release
-        with:
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
-
       - name: Generate App Token
-        if: steps.release.outputs.pr
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Auto-approve Release PR
         if: steps.release.outputs.pr


### PR DESCRIPTION
## Summary
- Move app token generation **before** `release-please-action` and pass it via `token` input, so the release PR is created by the GitHub App instead of `GITHUB_TOKEN`
- This ensures `pull_request` events fire and CI/PR-title checks run on release PRs (GitHub suppresses events from `GITHUB_TOKEN` to prevent infinite loops)
- Add `reopened` event type to PR Title workflow so it triggers on reopened PRs
- Remove workflow-level `permissions` block (no longer needed since all operations use the app token)

## Context
PR #505 (release 2.0.4) was stuck because "Build" and "Conventional Commit" checks never ran — the branch ruleset requires both. The auto-merge step also failed due to missing app permissions (fixed separately by updating the GitHub App's Contents permission to read-write).

## Test plan
- [x] Verified PR #505 unblocked and merged after manually triggering checks
- [ ] Next release PR should auto-create, trigger CI, get approved, and auto-merge without intervention