### PR TITLE
feat: single-click bin placement in paint mode

### DIFF
--- a/src/hooks/interactions/useDrawInteraction.test.ts
+++ b/src/hooks/interactions/useDrawInteraction.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDrawInteraction } from '@/hooks/interactions/useDrawInteraction';
+import { useLayoutStore } from '@/core/store/layout';
+import { useSelectionStore } from '@/core/store/selection';
+import { useInteractionStore } from '@/core/store/interaction';
+import { useHalfBinModeStore } from '@/core/store';
+import { resetAllStores } from '@/test/testUtils';
+import { ok } from '@/core/result';
+import type { InteractionContext } from '@/hooks/interactions/types';
+
+// Mock analytics to avoid side effects
+vi.mock('@/shared/analytics/useMLTracking', () => ({
+  mlTracking: {
+    trackPlacement: vi.fn(),
+    trackBulk: vi.fn(),
+    trackRejection: vi.fn(),
+    recordCreation: vi.fn(),
+  },
+}));
+vi.mock('@/shared/analytics/posthog', () => ({
+  trackBinCreated: vi.fn(),
+  trackPaintMode: vi.fn(),
+}));
+
+describe('useDrawInteraction', () => {
+  const mockSetInteraction = vi.fn();
+  const mockSetSelectedBin = vi.fn();
+  const mockSetSelectedBins = vi.fn();
+  const mockAddBin = vi.fn();
+  const mockExecute = vi.fn((fn: () => void) => fn());
+  const mockActivePointerIdRef = { current: null };
+  const mockCapturedPointerRef = { current: null };
+
+  const createContext = (paintSize?: { width: number; depth: number }): InteractionContext => {
+    const { layout } = useLayoutStore.getState();
+    const { activeLayerId, activeCategoryId } = useSelectionStore.getState();
+
+    return {
+      layout,
+      activeLayerId,
+      activeCategoryId,
+      paintSize: paintSize ?? null,
+      setInteraction: mockSetInteraction,
+      setSelectedBin: mockSetSelectedBin,
+      setSelectedBins: mockSetSelectedBins,
+      addBin: mockAddBin,
+      execute: mockExecute,
+      activePointerIdRef: mockActivePointerIdRef,
+      capturedPointerRef: mockCapturedPointerRef,
+    };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetAllStores();
+    const { layout } = useLayoutStore.getState();
+    useSelectionStore.setState({
+      activeLayerId: layout.layers[0].id,
+      activeCategoryId: layout.categories[0].id,
+    });
+    useInteractionStore.setState({ paintSize: null, interaction: null });
+  });
+
+  describe('single-click placement in paint mode', () => {
+    it('places a single bin when clicking without dragging', () => {
+      const paintSize = { width: 2, depth: 3 };
+      mockAddBin.mockReturnValue(ok('new-bin-id'));
+
+      // Set up paint interaction where start === current (single click)
+      useInteractionStore.setState({
+        interaction: {
+          type: 'paint',
+          paintSize,
+          start: { x: 2, y: 2 },
+          current: { x: 2, y: 2 },
+        },
+      });
+
+      const { result } = renderHook(() => useDrawInteraction(createContext(paintSize)));
+
+      act(() => {
+        result.current.handleUp();
+      });
+
+      expect(mockAddBin).toHaveBeenCalledTimes(1);
+      const binData = mockAddBin.mock.calls[0][0];
+      expect(binData.width).toBe(2);
+      expect(binData.depth).toBe(3);
+      expect(mockSetSelectedBin).toHaveBeenCalledWith('new-bin-id');
+    });
+
+    it('centers the bin on the clicked position', () => {
+      const paintSize = { width: 3, depth: 3 };
+      mockAddBin.mockReturnValue(ok('new-bin-id'));
+
+      // Click at position (5, 5) on a 10x8 grid
+      useInteractionStore.setState({
+        interaction: {
+          type: 'paint',
+          paintSize,
+          start: { x: 5, y: 5 },
+          current: { x: 5, y: 5 },
+        },
+      });
+
+      const { result } = renderHook(() => useDrawInteraction(createContext(paintSize)));
+
+      act(() => {
+        result.current.handleUp();
+      });
+
+      expect(mockAddBin).toHaveBeenCalledTimes(1);
+      const binData = mockAddBin.mock.calls[0][0];
+      // 3x3 bin centered on (5,5): x = floor(5 - (3-1)/2) = floor(4) = 4, y = floor(5 - (3-1)/2) = 4
+      expect(binData.x).toBe(4);
+      expect(binData.y).toBe(4);
+    });
+
+    it('clamps bin position to drawer bounds when clicking near edge', () => {
+      const paintSize = { width: 3, depth: 3 };
+      mockAddBin.mockReturnValue(ok('new-bin-id'));
+
+      // Click at position (9, 7) on a 10x8 grid — bin would extend past edge
+      useInteractionStore.setState({
+        interaction: {
+          type: 'paint',
+          paintSize,
+          start: { x: 9, y: 7 },
+          current: { x: 9, y: 7 },
+        },
+      });
+
+      const { result } = renderHook(() => useDrawInteraction(createContext(paintSize)));
+
+      act(() => {
+        result.current.handleUp();
+      });
+
+      expect(mockAddBin).toHaveBeenCalledTimes(1);
+      const binData = mockAddBin.mock.calls[0][0];
+      // Clamped: x = min(centered, drawer.width - 3) = min(8, 7) = 7
+      // Clamped: y = min(centered, drawer.depth - 3) = min(6, 5) = 5
+      expect(binData.x).toBe(7);
+      expect(binData.y).toBe(5);
+    });
+
+    it('clamps bin position to zero when clicking near origin', () => {
+      const paintSize = { width: 4, depth: 4 };
+      mockAddBin.mockReturnValue(ok('new-bin-id'));
+
+      // Click at (0, 0) — centering would go negative
+      useInteractionStore.setState({
+        interaction: {
+          type: 'paint',
+          paintSize,
+          start: { x: 0, y: 0 },
+          current: { x: 0, y: 0 },
+        },
+      });
+
+      const { result } = renderHook(() => useDrawInteraction(createContext(paintSize)));
+
+      act(() => {
+        result.current.handleUp();
+      });
+
+      expect(mockAddBin).toHaveBeenCalledTimes(1);
+      const binData = mockAddBin.mock.calls[0][0];
+      // Centered: floor(0 - (4-1)/2) = floor(-1.5) = -2, clamped to 0
+      expect(binData.x).toBe(0);
+      expect(binData.y).toBe(0);
+    });
+
+    it('places 1x1 bin exactly at clicked position', () => {
+      const paintSize = { width: 1, depth: 1 };
+      mockAddBin.mockReturnValue(ok('new-bin-id'));
+
+      useInteractionStore.setState({
+        interaction: {
+          type: 'paint',
+          paintSize,
+          start: { x: 3, y: 4 },
+          current: { x: 3, y: 4 },
+        },
+      });
+
+      const { result } = renderHook(() => useDrawInteraction(createContext(paintSize)));
+
+      act(() => {
+        result.current.handleUp();
+      });
+
+      expect(mockAddBin).toHaveBeenCalledTimes(1);
+      const binData = mockAddBin.mock.calls[0][0];
+      // 1x1 centered on (3,4): x = floor(3 - 0/2) = 3, y = floor(4 - 0/2) = 4
+      expect(binData.x).toBe(3);
+      expect(binData.y).toBe(4);
+    });
+
+    it('supports half-bin mode with snapping', () => {
+      useHalfBinModeStore.setState({ halfBinMode: true });
+      const paintSize = { width: 1.5, depth: 1 };
+      mockAddBin.mockReturnValue(ok('new-bin-id'));
+
+      useInteractionStore.setState({
+        interaction: {
+          type: 'paint',
+          paintSize,
+          start: { x: 3, y: 3 },
+          current: { x: 3, y: 3 },
+        },
+      });
+
+      const { result } = renderHook(() => useDrawInteraction(createContext(paintSize)));
+
+      act(() => {
+        result.current.handleUp();
+      });
+
+      expect(mockAddBin).toHaveBeenCalledTimes(1);
+      const binData = mockAddBin.mock.calls[0][0];
+      // Half-bin: minSize = 0.5, centered: snapToHalf(3 - (1.5 - 0.5)/2) = snapToHalf(2.5) = 2.5
+      expect(binData.x).toBe(2.5);
+      expect(binData.width).toBe(1.5);
+    });
+
+    it('does not place bin when addBin fails (collision)', () => {
+      const paintSize = { width: 2, depth: 2 };
+      mockAddBin.mockReturnValue({ ok: false, error: { type: 'collision' } });
+
+      useInteractionStore.setState({
+        interaction: {
+          type: 'paint',
+          paintSize,
+          start: { x: 3, y: 3 },
+          current: { x: 3, y: 3 },
+        },
+      });
+
+      const { result } = renderHook(() => useDrawInteraction(createContext(paintSize)));
+
+      act(() => {
+        result.current.handleUp();
+      });
+
+      expect(mockAddBin).toHaveBeenCalledTimes(1);
+      expect(mockSetSelectedBin).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('drag-area paint mode (existing behavior)', () => {
+    it('uses area fill when start differs from current', () => {
+      const paintSize = { width: 2, depth: 2 };
+      mockAddBin.mockReturnValue(ok('new-bin-id'));
+
+      // Drag from (0,0) to (3,3) — selects an area, NOT a single click
+      useInteractionStore.setState({
+        interaction: {
+          type: 'paint',
+          paintSize,
+          start: { x: 0, y: 0 },
+          current: { x: 3, y: 3 },
+        },
+      });
+
+      const { result } = renderHook(() => useDrawInteraction(createContext(paintSize)));
+
+      act(() => {
+        result.current.handleUp();
+      });
+
+      // Area is 4x4, fits 2x2 bins → 4 bins (2 across × 2 down)
+      expect(mockAddBin).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/src/hooks/interactions/useDrawInteraction.ts
+++ b/src/hooks/interactions/useDrawInteraction.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useLayoutStore, useInteractionStore, useHalfBinModeStore } from '@/core/store';
 import { canPlaceBin } from '@/shared/utils/validation';
+import { snapToGrid } from '@/core/constants';
 import { capturePointer } from './interaction';
 import { isOk } from '@/core/result';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
@@ -153,17 +154,60 @@ export function useDrawInteraction(context: InteractionContext): ModeHandlers<Dr
     } else if (interaction.type === 'paint') {
       // Paint mode - fill the selected area with bins of paintSize
       const { start, current, paintSize: ps } = interaction;
+
+      const halfBinModeNow = useHalfBinModeStore.getState().halfBinMode;
+      const minSizeNow = halfBinModeNow ? 0.5 : 1;
+      const layer = layout.layers.find((l) => l.id === activeLayerId);
+
+      // Single-click placement: when user clicks without dragging, place one bin
+      // centered on the clicked position, clamped to drawer bounds
+      const isSingleClick = start.x === current.x && start.y === current.y;
+      if (isSingleClick && layer && ps) {
+        const { drawer } = layout;
+        // Center the bin on the clicked cell, then snap to grid
+        const centeredX = snapToGrid(start.x - (ps.width - minSizeNow) / 2, halfBinModeNow);
+        const centeredY = snapToGrid(start.y - (ps.depth - minSizeNow) / 2, halfBinModeNow);
+        // Clamp to drawer bounds so the bin always fits
+        const clampedX = Math.max(0, Math.min(centeredX, drawer.width - ps.width));
+        const clampedY = Math.max(0, Math.min(centeredY, drawer.depth - ps.depth));
+
+        execute(() => {
+          const binData = {
+            layerId: activeLayerId,
+            x: clampedX,
+            y: clampedY,
+            width: ps.width,
+            depth: ps.depth,
+            height: layer.height,
+            category: activeCategoryId,
+            label: '',
+            notes: '',
+          };
+          const result = addBin(binData);
+          if (isOk(result)) {
+            setSelectedBin(result.value);
+            const placedBin: Bin = { ...binData, id: result.value };
+            mlTracking.trackPlacement(placedBin, 'paint');
+            mlTracking.recordCreation(
+              result.value,
+              'paint',
+              `${ps.width}x${ps.depth}x${layer.height}`
+            );
+            trackBinCreated('paint', 1, { width: ps.width, depth: ps.depth, height: layer.height });
+            trackPaintMode('exited', 1);
+          }
+        });
+        return;
+      }
+
       const x1 = Math.min(start.x, current.x);
       const y1 = Math.min(start.y, current.y);
       const x2 = Math.max(start.x, current.x);
       const y2 = Math.max(start.y, current.y);
 
-      const halfBinModeNow = useHalfBinModeStore.getState().halfBinMode;
-      const minSizeNow = halfBinModeNow ? 0.5 : 1;
       const areaWidth = x2 - x1 + minSizeNow;
       const areaDepth = y2 - y1 + minSizeNow;
 
-      const layer = layout.layers.find((l) => l.id === activeLayerId);
       if (layer && ps) {
         // Calculate how many bins fit in the selected area
         const binsAcross = Math.floor(areaWidth / ps.width);


### PR DESCRIPTION
## Summary
- When a bin size is selected from the palette (paint mode), users can now **single-click** on the grid to instantly place a bin of that size
- The bin is **centered** on the clicked position, then **snapped to grid** and **clamped to drawer bounds** so it always fits
- Paint mode stays active for repeated clicks — no need to re-select from the palette

## Motivation
Session recordings show users frequently selecting a bin size in the palette and then single-clicking on the grid, expecting a bin to appear. Previously, a click-without-drag in paint mode produced a tiny 1×1 selection area that couldn't fit most bin sizes, resulting in nothing happening.

## Implementation
Detects single-click (no drag) in `useDrawInteraction.handleUp()` when `start === current` in paint mode. Places a single bin centered on the clicked cell with:
- Grid snapping via `snapToGrid()` (supports half-bin mode)
- Bounds clamping to prevent out-of-bounds placement
- Full validation through existing `addBin()` (collision detection, blocked zones, etc.)
- All analytics tracking (ML telemetry, PostHog, paint mode exit)

## Test plan
- [x] Unit tests: 8 new tests covering centering, edge clamping (both edges), half-bin mode, 1×1 bins, collision failures, and drag-vs-click differentiation
- [ ] Manual: select 2×3 from palette → single-click grid center → bin appears centered on click
- [ ] Manual: select 4×4 from palette → click near grid corner → bin shifts inward to fit
- [ ] Manual: click-and-drag still fills area with bins as before
- [ ] Manual: half-bin mode works with single-click placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)