### PR TITLE
fix(ci): use GITHUB_TOKEN for release PR auto-approve

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Auto-approve Release PR
         if: steps.release.outputs.pr
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr review ${{ fromJSON(steps.release.outputs.pr).number }} \
             --approve --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary

- Switches the auto-approve step in the release workflow from the App token to `GITHUB_TOKEN`
- The App token that creates the release PR cannot approve it (GitHub prevents self-approval)
- `GITHUB_TOKEN` is a different identity, so it can approve the App-authored PR

## Context

All release workflow runs since v2.0.4 have failed at the auto-approve step with:
```
Review Can not approve your own pull request
```

The release PR (v2.1.0, #514) was created successfully but could not be auto-approved or auto-merged.

## Test plan

- [ ] Merge this PR, then re-run the release workflow to verify #514 gets approved and merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)