### PR TITLE
fix: remove mobile ToolSwitcher and prevent 3D toggle zoom reset

### DIFF
--- a/src/components/Mobile/MobileHeader/MobileHeader.tsx
+++ b/src/components/Mobile/MobileHeader/MobileHeader.tsx
@@ -3,7 +3,6 @@ import { useLayoutStore } from '@/core/store/layout';
 import { useHistoryStore, useUIStore } from '@/core/store';
 import { useCollabMode } from '@/hooks/useCollabMode';
 import { CONSTRAINTS } from '@/core/constants';
-import { ToolSwitcher } from '@/shared/components/ToolSwitcher';
 import { PresenceAvatars } from '@/components/Collab';
 import type { MobilePanel } from '@/core/store/ui';
 import type { SaveStatus } from '@/shared/hooks';
@@ -73,7 +72,9 @@ export function MobileHeader({ onMenuClick, onHelpClick, saveStatus }: MobileHea
     <div className="flex-shrink-0">
       {/* App title bar */}
       <div className="h-7 flex items-center justify-between px-3 bg-surface border-b border-stroke-subtle">
-        <ToolSwitcher compact />
+        <span className="text-xs font-medium text-content-secondary">
+          {t('toolSwitcher.gridfinityLayoutTool')}
+        </span>
         <div className="flex items-center gap-3">
           <a
             href="https://ko-fi.com/andyaragon"

--- a/src/features/grid-editor/components/Grid/Grid.tsx
+++ b/src/features/grid-editor/components/Grid/Grid.tsx
@@ -174,7 +174,6 @@ export function Grid({ shouldShowDrawTutorial = false }: GridProps) {
     gap,
     isMobile,
     isResizing: !!resizeDirection,
-    showIsometricPreview,
   });
 
   // Listen for fit-to-screen command from command palette

--- a/src/features/grid-editor/hooks/useGridZoom.test.ts
+++ b/src/features/grid-editor/hooks/useGridZoom.test.ts
@@ -426,32 +426,29 @@ describe('useGridZoom', () => {
     });
   });
 
-  describe('auto-fit on preview toggle', () => {
-    it('refits when showIsometricPreview changes', () => {
+  describe('preview toggle does not auto-fit', () => {
+    it('keeps zoom stable when showIsometricPreview changes', () => {
       const scrollContainerRef = createMockScrollContainerRef(800, 600);
 
       const { result, rerender } = renderHook(
-        ({ showPreview }) =>
+        ({ _showPreview }) =>
           useGridZoom({
             scrollContainerRef,
             drawerWidth: 10,
             drawerDepth: 8,
             gap: 2,
             isMobile: false,
-            showIsometricPreview: showPreview,
           }),
-        { initialProps: { showPreview: false } }
+        { initialProps: { _showPreview: false } }
       );
 
-      // Record initial state
-      const _initialZoom = result.current.zoom;
+      // Record initial zoom set by mount auto-fit
+      const initialZoom = result.current.zoom;
 
-      // Toggle preview
-      rerender({ showPreview: true });
+      // Toggle preview — zoom should NOT change
+      rerender({ _showPreview: true });
 
-      // fitToScreen should have been called
-      // (zoom might be same or different depending on calculation)
-      expect(result.current.zoom).toBeDefined();
+      expect(result.current.zoom).toBe(initialZoom);
     });
   });
 

--- a/src/features/grid-editor/hooks/useGridZoom.ts
+++ b/src/features/grid-editor/hooks/useGridZoom.ts
@@ -23,8 +23,6 @@ export interface UseGridZoomOptions {
   isMobile: boolean;
   /** Whether user is actively resizing the grid (skip auto-fit during resize) */
   isResizing?: boolean;
-  /** Whether 3D preview is shown (affects available space) */
-  showIsometricPreview?: boolean;
 }
 
 export interface GridZoomState {
@@ -52,7 +50,6 @@ export function useGridZoom(options: UseGridZoomOptions): GridZoomState {
     gap,
     isMobile,
     isResizing = false,
-    showIsometricPreview = false,
   } = options;
 
   const { zoom, setZoom, zoomIn, zoomOut } = useViewStore(
@@ -100,13 +97,16 @@ export function useGridZoom(options: UseGridZoomOptions): GridZoomState {
     setZoom(clampedZoom);
   }, [drawerWidth, drawerDepth, gap, setZoom, isMobile, scrollContainerRef]);
 
-  // Fit to screen on initial mount, drawer size changes, or 3D preview toggle.
+  // Fit to screen on initial mount and drawer size changes.
   // Uses useLayoutEffect to calculate zoom synchronously before paint, preventing CLS.
   // Skips during active resize drag to avoid fighting the user's intent.
+  // Note: showIsometricPreview is intentionally excluded — toggling the 3D preview
+  // on mobile halves the container, causing fitToScreen to zoom out to the minimum.
+  // Users expect their zoom to stay stable when toggling the preview.
   useLayoutEffect(() => {
     if (isResizing) return;
     fitToScreen();
-  }, [fitToScreen, drawerWidth, drawerDepth, isResizing, showIsometricPreview]);
+  }, [fitToScreen, drawerWidth, drawerDepth, isResizing]);
 
   return {
     zoom,


### PR DESCRIPTION
## Summary
- Replace `ToolSwitcher` in mobile header with static app title — the bin designer UI isn't ready for mobile yet
- Fix bug where toggling 3D preview on mobile caused the 2D grid to zoom out to 25% by removing `showIsometricPreview` from `useGridZoom`'s auto-fit effect dependencies

## Test plan
- [x] All 271 affected tests pass
- [ ] Verify mobile header shows "Gridfinity Layout Tool" text instead of segmented control
- [ ] Toggle 3D preview on mobile and confirm zoom level stays stable