### PR TITLE
test: add 40 interaction tests for settings modal and bin designer

### DIFF
--- a/src/components/Modals/SettingsModal/SettingsModal.test.tsx
+++ b/src/components/Modals/SettingsModal/SettingsModal.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SettingsModal } from './SettingsModal';
+
+const mockOnClose = vi.hoisted(() => vi.fn());
 
 vi.mock('@/shared/hooks', () => ({
   useResponsive: () => ({ isMobile: false, isTablet: false, isDesktop: true }),
@@ -63,6 +65,7 @@ vi.mock('@/features/onboarding/hooks/useOnboarding', () => ({
 describe('SettingsModal', () => {
   beforeEach(() => {
     sessionStorage.clear();
+    mockOnClose.mockClear();
   });
 
   it('renders nothing when closed', () => {
@@ -104,5 +107,26 @@ describe('SettingsModal', () => {
   it('renders reset onboarding button in footer', () => {
     render(<SettingsModal isOpen={true} onClose={vi.fn()} />);
     expect(screen.getByText('settings.resetOnboarding')).toBeInTheDocument();
+  });
+
+  it('Escape key calls onClose', () => {
+    render(<SettingsModal isOpen={true} onClose={mockOnClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('clicking overlay calls onClose', () => {
+    render(<SettingsModal isOpen={true} onClose={mockOnClose} />);
+    // The overlay is the outermost div with the fixed class
+    const overlay = screen.getByRole('dialog').parentElement!;
+    fireEvent.click(overlay);
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('clicking modal content does NOT call onClose', () => {
+    render(<SettingsModal isOpen={true} onClose={mockOnClose} />);
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(dialog);
+    expect(mockOnClose).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Modals/SettingsModal/tabDefinitions.test.ts
+++ b/src/components/Modals/SettingsModal/tabDefinitions.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { TAB_DEFINITIONS } from './tabDefinitions';
+
+describe('TAB_DEFINITIONS', () => {
+  it('has exactly 5 tab definitions', () => {
+    expect(TAB_DEFINITIONS).toHaveLength(5);
+  });
+
+  it('every tab has id, labelKey, and icon', () => {
+    for (const tab of TAB_DEFINITIONS) {
+      expect(tab).toHaveProperty('id');
+      expect(tab).toHaveProperty('labelKey');
+      expect(tab).toHaveProperty('icon');
+      expect(typeof tab.id).toBe('string');
+      expect(typeof tab.labelKey).toBe('string');
+      expect(typeof tab.icon).toBe('function');
+    }
+  });
+
+  it('tab ids match expected set', () => {
+    const ids = TAB_DEFINITIONS.map((t) => t.id);
+    expect(ids).toEqual(['general', 'defaults', 'integrations', 'privacy', 'labs']);
+  });
+
+  it('all labelKeys follow settings.tabs.* pattern', () => {
+    for (const tab of TAB_DEFINITIONS) {
+      expect(tab.labelKey).toMatch(/^settings\.tabs\.\w+$/);
+    }
+  });
+});

--- a/src/components/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.test.tsx
+++ b/src/components/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.test.tsx
@@ -1,6 +1,14 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DefaultsTab } from './DefaultsTab';
+
+const mockUpdateSetting = vi.hoisted(() => vi.fn());
+const mockAddToast = vi.hoisted(() => vi.fn());
+const mockSetShowSaveCategoriesConfirm = vi.hoisted(() => vi.fn());
+const mockHandleSaveCategoriesAsDefaults = vi.hoisted(() => vi.fn());
+const mockDrawerState = vi.hoisted(() => ({
+  hasCustomCategoryDefaults: false,
+}));
 
 vi.mock('@/i18n', () => ({
   useTranslation: () => (key: string) => key,
@@ -22,13 +30,13 @@ vi.mock('@/core/store', () => ({
         defaultGridUnitMm: 42,
         defaultCategories: null,
       },
-      updateSetting: vi.fn(),
+      updateSetting: mockUpdateSetting,
     }),
 }));
 
 vi.mock('@/core/store/toast', () => ({
   useToastStore: (selector: (state: Record<string, unknown>) => unknown) =>
-    selector({ addToast: vi.fn() }),
+    selector({ addToast: mockAddToast }),
 }));
 
 vi.mock('@/hooks/useDrawerSettings', () => ({
@@ -37,11 +45,14 @@ vi.mock('@/hooks/useDrawerSettings', () => ({
     gridUnitMm: 42,
     printBedSize: 256,
     activeLayerHeight: 3,
-    currentCategories: [],
+    currentCategories: [
+      { id: 'coral', name: 'Coral', color: '#f87171' },
+      { id: 'sky', name: 'Sky', color: '#38bdf8' },
+    ],
     showSaveCategoriesConfirm: false,
-    setShowSaveCategoriesConfirm: vi.fn(),
-    handleSaveCategoriesAsDefaults: vi.fn(),
-    hasCustomCategoryDefaults: false,
+    setShowSaveCategoriesConfirm: mockSetShowSaveCategoriesConfirm,
+    handleSaveCategoriesAsDefaults: mockHandleSaveCategoriesAsDefaults,
+    hasCustomCategoryDefaults: mockDrawerState.hasCustomCategoryDefaults,
   }),
 }));
 
@@ -51,11 +62,48 @@ vi.mock('@/shared/components/StepperControl', () => ({
   ),
 }));
 
+vi.mock('@/shared/components/DeferredNumberInput', () => ({
+  DeferredNumberInput: ({ id }: { id: string }) => <input data-testid={`input-${id}`} />,
+}));
+
+vi.mock('@/shared/components/SettingsRow', () => ({
+  SettingsRow: ({ label, children }: { label: string; children: React.ReactNode }) => (
+    <div data-testid={`settings-row-${label}`}>{children}</div>
+  ),
+}));
+
 vi.mock('@/shared/components/ConfirmDialog', () => ({
-  ConfirmDialog: () => null,
+  ConfirmDialog: ({
+    isOpen,
+    onConfirm,
+    onCancel,
+    title,
+  }: {
+    isOpen: boolean;
+    onConfirm: () => void;
+    onCancel: () => void;
+    title: string;
+  }) =>
+    isOpen ? (
+      <div data-testid="confirm-dialog">
+        <span>{title}</span>
+        <button data-testid="confirm-btn" onClick={onConfirm}>
+          Confirm
+        </button>
+        <button data-testid="cancel-btn" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    ) : null,
 }));
 
 describe('DefaultsTab', () => {
+  beforeEach(() => {
+    mockUpdateSetting.mockClear();
+    mockAddToast.mockClear();
+    mockDrawerState.hasCustomCategoryDefaults = false;
+  });
+
   it('renders default preferences heading', () => {
     render(<DefaultsTab />);
     expect(screen.getByText('settings.defaultPreferences')).toBeInTheDocument();
@@ -70,5 +118,30 @@ describe('DefaultsTab', () => {
   it('renders copy from layout button', () => {
     render(<DefaultsTab />);
     expect(screen.getByText('settings.copyFromCurrentLayout')).toBeInTheDocument();
+  });
+
+  it('renders default categories section', () => {
+    render(<DefaultsTab />);
+    expect(screen.getByText('settings.defaultCategories')).toBeInTheDocument();
+  });
+
+  it('clicking copy-from-layout button shows confirm dialog', () => {
+    render(<DefaultsTab />);
+    const copyBtn = screen.getByText('settings.copyFromCurrentLayout');
+    fireEvent.click(copyBtn);
+    expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+  });
+
+  it('renders category color chips from defaults', () => {
+    render(<DefaultsTab />);
+    // With defaultCategories: null, it falls back to DEFAULT_CATEGORIES from constants
+    // The component renders (settings.defaultCategories ?? DEFAULT_CATEGORIES)
+    expect(screen.getByText('settings.usingBuiltInCategories')).toBeInTheDocument();
+  });
+
+  it('shows reset-to-built-in button when hasCustomCategoryDefaults is true', () => {
+    mockDrawerState.hasCustomCategoryDefaults = true;
+    render(<DefaultsTab />);
+    expect(screen.getByText('settings.resetToBuiltIn')).toBeInTheDocument();
   });
 });

--- a/src/components/Modals/SettingsModal/tabs/GeneralTab/GeneralTab.test.tsx
+++ b/src/components/Modals/SettingsModal/tabs/GeneralTab/GeneralTab.test.tsx
@@ -1,12 +1,19 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { GeneralTab } from './GeneralTab';
 
+const mockUpdateSetting = vi.hoisted(() => vi.fn());
+const mockSetLocale = vi.hoisted(() => vi.fn());
+const mockDetectBrowserLocale = vi.hoisted(() => vi.fn(() => 'en'));
+
 vi.mock('@/i18n', () => ({
   useTranslation: () => (key: string) => key,
-  useLocale: () => ({ locale: 'en', setLocale: vi.fn() }),
-  SUPPORTED_LOCALES: [{ code: 'en', nativeName: 'English', englishName: 'English' }],
-  detectBrowserLocale: () => 'en',
+  useLocale: () => ({ locale: 'en', setLocale: mockSetLocale }),
+  SUPPORTED_LOCALES: [
+    { code: 'en', nativeName: 'English', englishName: 'English' },
+    { code: 'nb', nativeName: 'Norsk bokmål', englishName: 'Norwegian Bokmål' },
+  ],
+  detectBrowserLocale: mockDetectBrowserLocale,
 }));
 
 vi.mock('zustand/shallow', () => ({
@@ -17,7 +24,7 @@ vi.mock('@/core/store', () => ({
   useSettingsStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
       settings: { locale: 'auto' },
-      updateSetting: vi.fn(),
+      updateSetting: mockUpdateSetting,
     }),
 }));
 
@@ -25,5 +32,44 @@ describe('GeneralTab', () => {
   it('renders language section', () => {
     render(<GeneralTab />);
     expect(screen.getByText('settings.language')).toBeInTheDocument();
+  });
+
+  it('renders auto-detect radio option', () => {
+    render(<GeneralTab />);
+    expect(screen.getByText('settings.autoDetect')).toBeInTheDocument();
+    const autoRadio = screen.getByText('settings.autoDetect').closest('[role="radio"]');
+    expect(autoRadio).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('renders all supported locale options with native names', () => {
+    render(<GeneralTab />);
+    expect(screen.getByText('English')).toBeInTheDocument();
+    expect(screen.getByText('Norsk bokmål')).toBeInTheDocument();
+  });
+
+  it('clicking auto-detect calls updateSetting and setLocale', () => {
+    render(<GeneralTab />);
+    const autoOption = screen.getByText('settings.autoDetect').closest('[role="radio"]')!;
+    fireEvent.click(autoOption);
+    expect(mockUpdateSetting).toHaveBeenCalledWith('locale', 'auto');
+    expect(mockSetLocale).toHaveBeenCalledWith('en');
+  });
+
+  it('clicking a specific locale calls updateSetting and setLocale', () => {
+    render(<GeneralTab />);
+    const nbOption = screen.getByText('Norsk bokmål').closest('[role="radio"]')!;
+    fireEvent.click(nbOption);
+    expect(mockUpdateSetting).toHaveBeenCalledWith('locale', 'nb');
+    expect(mockSetLocale).toHaveBeenCalledWith('nb');
+  });
+
+  it('keyboard Enter/Space on locale triggers selection', () => {
+    render(<GeneralTab />);
+    const nbOption = screen.getByText('Norsk bokmål').closest('[role="radio"]')!;
+    fireEvent.keyDown(nbOption, { key: 'Enter' });
+    expect(mockUpdateSetting).toHaveBeenCalledWith('locale', 'nb');
+    mockUpdateSetting.mockClear();
+    fireEvent.keyDown(nbOption, { key: ' ' });
+    expect(mockUpdateSetting).toHaveBeenCalledWith('locale', 'nb');
   });
 });

--- a/src/components/Modals/SettingsModal/tabs/IntegrationsTab/IntegrationsTab.test.tsx
+++ b/src/components/Modals/SettingsModal/tabs/IntegrationsTab/IntegrationsTab.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { IntegrationsTab } from './IntegrationsTab';
+
+const mockUpdateSetting = vi.hoisted(() => vi.fn());
 
 vi.mock('@/i18n', () => ({
   useTranslation: () => (key: string) => key,
@@ -16,10 +18,10 @@ vi.mock('@/core/store', () => ({
       settings: {
         stlSearchSites: [
           { id: 'thangs', name: 'Thangs', enabled: true, urlTemplate: '' },
-          { id: 'printables', name: 'Printables', enabled: true, urlTemplate: '' },
+          { id: 'printables', name: 'Printables', enabled: false, urlTemplate: '' },
         ],
       },
-      updateSetting: vi.fn(),
+      updateSetting: mockUpdateSetting,
     }),
 }));
 
@@ -30,6 +32,10 @@ vi.mock('@/shared/components/Checkbox', () => ({
 }));
 
 describe('IntegrationsTab', () => {
+  beforeEach(() => {
+    mockUpdateSetting.mockClear();
+  });
+
   it('renders STL search heading', () => {
     render(<IntegrationsTab />);
     expect(screen.getByText('settings.stlSearch')).toBeInTheDocument();
@@ -39,5 +45,40 @@ describe('IntegrationsTab', () => {
     render(<IntegrationsTab />);
     expect(screen.getByText('Thangs')).toBeInTheDocument();
     expect(screen.getByText('Printables')).toBeInTheDocument();
+  });
+
+  it('renders checkboxes with correct aria-checked state', () => {
+    render(<IntegrationsTab />);
+    const thangsRow = screen.getByText('Thangs').closest('[role="checkbox"]');
+    const printablesRow = screen.getByText('Printables').closest('[role="checkbox"]');
+    expect(thangsRow).toHaveAttribute('aria-checked', 'true');
+    expect(printablesRow).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('clicking enabled site calls updateSetting with site toggled off', () => {
+    render(<IntegrationsTab />);
+    const thangsRow = screen.getByText('Thangs').closest('[role="checkbox"]')!;
+    fireEvent.click(thangsRow);
+    expect(mockUpdateSetting).toHaveBeenCalledWith('stlSearchSites', [
+      { id: 'thangs', name: 'Thangs', enabled: false, urlTemplate: '' },
+      { id: 'printables', name: 'Printables', enabled: false, urlTemplate: '' },
+    ]);
+  });
+
+  it('clicking disabled site calls updateSetting with site toggled on', () => {
+    render(<IntegrationsTab />);
+    const printablesRow = screen.getByText('Printables').closest('[role="checkbox"]')!;
+    fireEvent.click(printablesRow);
+    expect(mockUpdateSetting).toHaveBeenCalledWith('stlSearchSites', [
+      { id: 'thangs', name: 'Thangs', enabled: true, urlTemplate: '' },
+      { id: 'printables', name: 'Printables', enabled: true, urlTemplate: '' },
+    ]);
+  });
+
+  it('keyboard Space triggers toggle', () => {
+    render(<IntegrationsTab />);
+    const thangsRow = screen.getByText('Thangs').closest('[role="checkbox"]')!;
+    fireEvent.keyDown(thangsRow, { key: ' ' });
+    expect(mockUpdateSetting).toHaveBeenCalledWith('stlSearchSites', expect.any(Array));
   });
 });

--- a/src/components/Modals/SettingsModal/tabs/LabsTab/LabsTab.test.tsx
+++ b/src/components/Modals/SettingsModal/tabs/LabsTab/LabsTab.test.tsx
@@ -2,6 +2,18 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { LabsTab } from './LabsTab';
 
+const mockToggleFeature = vi.hoisted(() => vi.fn());
+const mockIsFeatureEnabled = vi.hoisted(() => vi.fn(() => true));
+const mockFeatures = vi.hoisted(() => ({
+  toggleable: [
+    {
+      id: 'binDesigner',
+      titleKey: 'labs.binDesigner.title',
+      descriptionKey: 'labs.binDesigner.desc',
+    },
+  ] as Array<{ id: string; titleKey: string; descriptionKey: string }>,
+}));
+
 vi.mock('@/i18n', () => ({
   useTranslation: () => (key: string) => key,
 }));
@@ -13,25 +25,29 @@ vi.mock('zustand/shallow', () => ({
 vi.mock('@/core/store', () => ({
   useLabsStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
-      toggleFeature: vi.fn(),
-      isFeatureEnabled: () => false,
+      toggleFeature: mockToggleFeature,
+      isFeatureEnabled: mockIsFeatureEnabled,
     }),
 }));
 
 vi.mock('@/core/labs', () => ({
-  getToggleableFeatures: () => [
-    {
-      id: 'binDesigner',
-      titleKey: 'labs.binDesigner.title',
-      descriptionKey: 'labs.binDesigner.desc',
-    },
-  ],
+  getToggleableFeatures: () => mockFeatures.toggleable,
   getGraduatedFeatures: () => [],
 }));
 
 vi.mock('@/features/labs/components/FeatureCard', () => ({
-  FeatureCard: ({ feature }: { feature: { titleKey: string } }) => (
-    <div data-testid="feature-card">{feature.titleKey}</div>
+  FeatureCard: ({
+    feature,
+    isEnabled,
+    onToggle,
+  }: {
+    feature: { titleKey: string };
+    isEnabled: boolean;
+    onToggle: () => void;
+  }) => (
+    <div data-testid="feature-card" data-enabled={isEnabled} onClick={onToggle}>
+      {feature.titleKey}
+    </div>
   ),
 }));
 
@@ -54,5 +70,31 @@ describe('LabsTab', () => {
   it('renders feature cards', () => {
     render(<LabsTab />);
     expect(screen.getByTestId('feature-card')).toBeInTheDocument();
+  });
+
+  it('FeatureCard receives correct isEnabled and onToggle props', () => {
+    mockIsFeatureEnabled.mockReturnValue(true);
+    render(<LabsTab />);
+    const card = screen.getByTestId('feature-card');
+    expect(card).toHaveAttribute('data-enabled', 'true');
+  });
+
+  it('renders empty state when no toggleable features', () => {
+    mockFeatures.toggleable = [];
+    render(<LabsTab />);
+    expect(screen.getByText('settings.labsEmpty')).toBeInTheDocument();
+    // Restore for other tests
+    mockFeatures.toggleable = [
+      {
+        id: 'binDesigner',
+        titleKey: 'labs.binDesigner.title',
+        descriptionKey: 'labs.binDesigner.desc',
+      },
+    ];
+  });
+
+  it('renders GraduatedSection component', () => {
+    render(<LabsTab />);
+    expect(screen.getByTestId('graduated-section')).toBeInTheDocument();
   });
 });

--- a/src/components/Modals/SettingsModal/tabs/PrivacyTab/PrivacyTab.test.tsx
+++ b/src/components/Modals/SettingsModal/tabs/PrivacyTab/PrivacyTab.test.tsx
@@ -1,6 +1,11 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PrivacyTab } from './PrivacyTab';
+
+const mockUpdateSetting = vi.hoisted(() => vi.fn());
+const mockOptIn = vi.hoisted(() => vi.fn());
+const mockOptOut = vi.hoisted(() => vi.fn());
+const mockState = vi.hoisted(() => ({ analyticsEnabled: true }));
 
 vi.mock('@/i18n', () => ({
   useTranslation: () => (key: string) => key,
@@ -13,8 +18,8 @@ vi.mock('zustand/shallow', () => ({
 vi.mock('@/core/store', () => ({
   useSettingsStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
-      settings: { analyticsEnabled: true },
-      updateSetting: vi.fn(),
+      settings: mockState,
+      updateSetting: mockUpdateSetting,
     }),
 }));
 
@@ -25,11 +30,18 @@ vi.mock('@/shared/components/Checkbox', () => ({
 }));
 
 vi.mock('@/shared/analytics/posthog', () => ({
-  optInAnalytics: vi.fn(),
-  optOutAnalytics: vi.fn(),
+  optInAnalytics: mockOptIn,
+  optOutAnalytics: mockOptOut,
 }));
 
 describe('PrivacyTab', () => {
+  beforeEach(() => {
+    mockUpdateSetting.mockClear();
+    mockOptIn.mockClear();
+    mockOptOut.mockClear();
+    mockState.analyticsEnabled = true;
+  });
+
   it('renders privacy heading', () => {
     render(<PrivacyTab />);
     expect(screen.getByText('settings.privacy')).toBeInTheDocument();
@@ -38,5 +50,38 @@ describe('PrivacyTab', () => {
   it('renders analytics toggle', () => {
     render(<PrivacyTab />);
     expect(screen.getByText('settings.helpImprove')).toBeInTheDocument();
+  });
+
+  it('checkbox reflects aria-checked state', () => {
+    render(<PrivacyTab />);
+    const toggle = screen.getByRole('checkbox', { name: 'settings.toggleUsageData' });
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('clicking when enabled calls updateSetting(false) and optOutAnalytics', () => {
+    mockState.analyticsEnabled = true;
+    render(<PrivacyTab />);
+    const toggle = screen.getByRole('checkbox', { name: 'settings.toggleUsageData' });
+    fireEvent.click(toggle);
+    expect(mockUpdateSetting).toHaveBeenCalledWith('analyticsEnabled', false);
+    expect(mockOptOut).toHaveBeenCalled();
+    expect(mockOptIn).not.toHaveBeenCalled();
+  });
+
+  it('clicking when disabled calls updateSetting(true) and optInAnalytics', () => {
+    mockState.analyticsEnabled = false;
+    render(<PrivacyTab />);
+    const toggle = screen.getByRole('checkbox', { name: 'settings.toggleUsageData' });
+    fireEvent.click(toggle);
+    expect(mockUpdateSetting).toHaveBeenCalledWith('analyticsEnabled', true);
+    expect(mockOptIn).toHaveBeenCalled();
+    expect(mockOptOut).not.toHaveBeenCalled();
+  });
+
+  it('keyboard Enter triggers toggle', () => {
+    render(<PrivacyTab />);
+    const toggle = screen.getByRole('checkbox', { name: 'settings.toggleUsageData' });
+    fireEvent.keyDown(toggle, { key: 'Enter' });
+    expect(mockUpdateSetting).toHaveBeenCalledWith('analyticsEnabled', false);
   });
 });

--- a/src/features/bin-designer/components/panel/FeatureToggle/FeatureToggle.test.tsx
+++ b/src/features/bin-designer/components/panel/FeatureToggle/FeatureToggle.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { FeatureToggle } from './FeatureToggle';
+
+vi.mock('@/i18n', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+describe('FeatureToggle', () => {
+  it('renders label text', () => {
+    render(<FeatureToggle label="Test Feature" checked={false} onChange={vi.fn()} />);
+    expect(screen.getByText('Test Feature')).toBeInTheDocument();
+  });
+
+  it('switch shows aria-checked="true" when checked', () => {
+    render(<FeatureToggle label="Test Feature" checked={true} onChange={vi.fn()} />);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('switch shows aria-checked="false" when unchecked', () => {
+    render(<FeatureToggle label="Test Feature" checked={false} onChange={vi.fn()} />);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('clicking switch calls onChange', () => {
+    const onChange = vi.fn();
+    render(<FeatureToggle label="Test Feature" checked={false} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('switch'));
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  it('does not render customize section when unchecked', () => {
+    render(
+      <FeatureToggle label="Test Feature" checked={false} onChange={vi.fn()}>
+        <div data-testid="child-controls">Controls</div>
+      </FeatureToggle>
+    );
+    expect(screen.queryByText('binDesigner.customize')).not.toBeInTheDocument();
+  });
+
+  it('shows Customize button when checked and children provided', () => {
+    render(
+      <FeatureToggle label="Test Feature" checked={true} onChange={vi.fn()}>
+        <div data-testid="child-controls">Controls</div>
+      </FeatureToggle>
+    );
+    expect(screen.getByText('binDesigner.customize')).toBeInTheDocument();
+  });
+
+  it('clicking Customize reveals children, clicking Done hides them', () => {
+    render(
+      <FeatureToggle label="Test Feature" checked={true} onChange={vi.fn()}>
+        <div data-testid="child-controls">Controls</div>
+      </FeatureToggle>
+    );
+    // Initially the customize region exists but is aria-hidden
+    const customizeBtn = screen.getByText('binDesigner.customize');
+    const region = screen.getByRole('region', { hidden: true });
+    expect(region).toHaveAttribute('aria-hidden', 'true');
+
+    // Click Customize — reveals children
+    fireEvent.click(customizeBtn);
+    expect(region).toHaveAttribute('aria-hidden', 'false');
+    expect(screen.getByText('common.done')).toBeInTheDocument();
+
+    // Click Done — hides children again
+    fireEvent.click(screen.getByText('common.done'));
+    expect(region).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('shows coming soon badge and disables switch when comingSoon', () => {
+    render(
+      <FeatureToggle label="Test Feature" checked={false} onChange={vi.fn()} comingSoon={true} />
+    );
+    expect(screen.getByText('binDesigner.soon')).toBeInTheDocument();
+    expect(screen.getByRole('switch')).toBeDisabled();
+  });
+
+  it('shows valueSummary when checked and customize is closed', () => {
+    render(
+      <FeatureToggle
+        label="Test Feature"
+        checked={true}
+        onChange={vi.fn()}
+        valueSummary="6.5mm × 2mm"
+      >
+        <div>Controls</div>
+      </FeatureToggle>
+    );
+    expect(screen.getByText('6.5mm × 2mm')).toBeInTheDocument();
+
+    // Open customize — summary should be hidden
+    fireEvent.click(screen.getByText('binDesigner.customize'));
+    expect(screen.queryByText('6.5mm × 2mm')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/bin-designer/utils/validation.test.ts
+++ b/src/features/bin-designer/utils/validation.test.ts
@@ -226,6 +226,98 @@ describe('validateBinParams', () => {
       );
       expectOk(result);
     });
+
+    it('should accept label tab at boundary depth values', () => {
+      expectOk(
+        validateBinParams(
+          makeParams({
+            label: {
+              enabled: true,
+              support: 'bracket',
+              depth: DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_DEPTH,
+              width: 100,
+              alignment: 'left',
+            },
+          })
+        )
+      );
+      expectOk(
+        validateBinParams(
+          makeParams({
+            label: {
+              enabled: true,
+              support: 'bracket',
+              depth: DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_DEPTH,
+              width: 100,
+              alignment: 'left',
+            },
+          })
+        )
+      );
+    });
+
+    it('should accept label tab at boundary width values', () => {
+      expectOk(
+        validateBinParams(
+          makeParams({
+            label: {
+              enabled: true,
+              support: 'bracket',
+              depth: 12,
+              width: DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_WIDTH,
+              alignment: 'center',
+            },
+          })
+        )
+      );
+      expectOk(
+        validateBinParams(
+          makeParams({
+            label: {
+              enabled: true,
+              support: 'bracket',
+              depth: 12,
+              width: DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH,
+              alignment: 'right',
+            },
+          })
+        )
+      );
+    });
+
+    it('should reject depth just beyond boundary', () => {
+      const result = validateBinParams(
+        makeParams({
+          label: {
+            enabled: true,
+            support: 'bracket',
+            depth: DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_DEPTH + 1,
+            width: 100,
+            alignment: 'left',
+          },
+        })
+      );
+      const error = expectErr(result);
+      expect(error.code).toBe('LABEL_TAB_DEPTH_OUT_OF_RANGE');
+      expect(error.field).toBe('label.depth');
+    });
+
+    it('should reject width just beyond boundary', () => {
+      const result = validateBinParams(
+        makeParams({
+          label: {
+            enabled: true,
+            support: 'bracket',
+            depth: 12,
+            width: DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH + 1,
+            alignment: 'left',
+          },
+        })
+      );
+      const error = expectErr(result);
+      expect(error.code).toBe('LABEL_TAB_WIDTH_OUT_OF_RANGE');
+      expect(error.field).toBe('label.width');
+    });
   });
 
   describe('magnet depth constraints', () => {


### PR DESCRIPTION
## Summary
- Add **40 new tests** across 9 files covering testing gaps from PRs #530, #531, and #525
- Upgrade test pattern from render-only assertions to **behavioral/interaction tests** using `vi.hoisted()` for assertable mocks
- Create 2 new test files: `tabDefinitions.test.ts` (pure data validation) and `FeatureToggle.test.tsx` (full component lifecycle)

## Test plan
- [x] All 129 tests pass across 11 test files (`npx vitest run`)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Pre-commit hooks pass (lint, boundaries, i18n, affected tests)
- [x] No source code changes — test files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)