### PR TITLE
fix: add explicit permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds explicit `permissions` block to `.github/workflows/release.yml` with `contents: write` and `pull-requests: write`
- Resolves CodeQL alert #8 (`actions/missing-workflow-permissions`)
- Follows the same least-privilege pattern already applied to `ci.yml` and `deploy-partykit.yml`

## Test plan
- [ ] Verify the release workflow still runs correctly on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)