### PR TITLE
fix: bin designer UI fixes and remove JSON export from export modal

### DIFF
--- a/src/features/bin-designer/components/DesignListDialog/DesignListDialog.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListDialog.tsx
@@ -390,10 +390,7 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
         {/* Design list or import view */}
         <div className="flex-1 min-h-0 overflow-hidden px-5 py-3" aria-busy={loading}>
           {showImport ? (
-            <DesignImportView
-              onImport={handleImportDesign}
-              onCancel={() => setShowImport(false)}
-            />
+            <DesignImportView onImport={handleImportDesign} onCancel={() => setShowImport(false)} />
           ) : loading ? (
             <div className="space-y-2 py-2">
               {[1, 2, 3].map((i) => (
@@ -482,7 +479,7 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
                   ref={gridRef}
                   role="listbox"
                   aria-label={t('binDesigner.savedDesigns')}
-                  className="grid grid-cols-[repeat(auto-fit,minmax(140px,1fr))] gap-3 content-start"
+                  className="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3 content-start"
                 >
                   {items.map((design, index) => (
                     <DesignGridItem

--- a/src/features/bin-designer/components/ExportDialog/ExportDialog.test.tsx
+++ b/src/features/bin-designer/components/ExportDialog/ExportDialog.test.tsx
@@ -207,50 +207,17 @@ describe('ExportDialog', () => {
     expect(screen.getByText('Custom')).toBeInTheDocument();
   });
 
-  describe('JSON export section', () => {
-    it('shows Design File section with Download JSON button', () => {
-      render(<ExportDialog />);
+  it('shows 3D Model section with STL export', () => {
+    render(<ExportDialog />);
 
-      // Check for section heading
-      expect(screen.getByText(/Design File.*\.json/i)).toBeInTheDocument();
+    // Check for section heading
+    expect(screen.getByText(/3D Model.*\.stl/i)).toBeInTheDocument();
 
-      // Check for description
-      expect(
-        screen.getByText(/Save your bin configuration for editing later or sharing with others/i)
-      ).toBeInTheDocument();
+    // Check for description
+    expect(screen.getByText(/Export a printable 3D model file/i)).toBeInTheDocument();
 
-      // Check for Download JSON button
-      const jsonButton = screen.getByRole('button', { name: /download json/i });
-      expect(jsonButton).toBeInTheDocument();
-    });
-
-    it('JSON download button is always enabled (no mesh required)', () => {
-      setupStore({
-        generation: {
-          status: 'idle',
-          mesh: null, // No mesh generated
-          progress: 0,
-          epoch: 0,
-        },
-      });
-      render(<ExportDialog />);
-
-      const jsonButton = screen.getByRole('button', { name: /download json/i });
-      expect(jsonButton).not.toBeDisabled();
-    });
-
-    it('shows 3D Model section with STL export', () => {
-      render(<ExportDialog />);
-
-      // Check for section heading
-      expect(screen.getByText(/3D Model.*\.stl/i)).toBeInTheDocument();
-
-      // Check for description
-      expect(screen.getByText(/Export a printable 3D model file/i)).toBeInTheDocument();
-
-      // Check for Download STL button
-      const stlButton = screen.getByRole('button', { name: /download stl/i });
-      expect(stlButton).toBeInTheDocument();
-    });
+    // Check for Download STL button
+    const stlButton = screen.getByRole('button', { name: /download stl/i });
+    expect(stlButton).toBeInTheDocument();
   });
 });

--- a/src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
+++ b/src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
@@ -12,7 +12,6 @@ import { useDesignerStore } from '@/features/bin-designer/store/designer';
 import { useExport } from '@/features/bin-designer/hooks/useExport';
 import { formatPrintTime, formatFilament } from '@/features/bin-designer/utils/printEstimates';
 import { generateFileName } from '@/features/bin-designer/utils/fileNaming';
-import { downloadDesignAsFile } from '@/features/bin-designer/utils/designJson';
 import type { FileNameStyle } from '@/features/bin-designer/types';
 import { getSTLFileSize } from '@/shared/generation/export';
 import { useFocusTrap } from '@/shared/hooks/useFocusTrap';
@@ -125,49 +124,7 @@ export function ExportDialog() {
           </button>
         </div>
 
-        {/* Section 1: Design File (.json) */}
-        <div className="mb-5">
-          {/* eslint-disable i18next/no-literal-string */}
-          <h3 className="mb-1 text-sm font-semibold text-content">
-            {t('binDesigner.designFile')} (.json)
-          </h3>
-          {/* eslint-enable i18next/no-literal-string */}
-          <p className="mb-3 text-xs text-content-secondary">
-            {t('binDesigner.designFileDescription')}
-          </p>
-          <button
-            onClick={() => {
-              downloadDesignAsFile(designName, params);
-              addToast({
-                message: t('binDesigner.downloadDesignJson') + ' ✓',
-                type: 'success',
-                duration: 2000,
-              });
-            }}
-            className="flex w-full items-center justify-center gap-2 rounded-lg border border-stroke-subtle bg-surface px-4 py-2.5 text-sm font-medium text-content transition-colors hover:bg-surface-hover"
-          >
-            <svg
-              className="h-4 w-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-              />
-            </svg>
-            {t('binDesigner.downloadJSON')}
-          </button>
-        </div>
-
-        {/* Visual Divider */}
-        <div className="mb-5 border-t border-stroke-subtle" />
-
-        {/* Section 2: 3D Model (.stl) */}
+        {/* 3D Model (.stl) */}
         <div>
           {/* eslint-disable i18next/no-literal-string */}
           <h3 className="mb-1 text-sm font-semibold text-content">

--- a/src/features/bin-designer/store/designer.ts
+++ b/src/features/bin-designer/store/designer.ts
@@ -202,8 +202,7 @@ export const useDesignerStore = create<DesignerState>()(
     loadDesign: (design: SavedDesign) => {
       // Check if thumbnail needs regeneration (missing or outdated version)
       const needsNewThumbnail =
-        design.thumbnail !== null &&
-        (design.thumbnailVersion === undefined || design.thumbnailVersion < THUMBNAIL_VERSION);
+        !design.thumbnail || (design.thumbnailVersion ?? 0) < THUMBNAIL_VERSION;
 
       set((state) => {
         state.params = migrateParams(design.params);


### PR DESCRIPTION
## Summary
- **Fix oversized design card**: Single saved design card stretched to full container width due to `auto-fit` grid behavior — changed to `auto-fill` so empty tracks retain their size
- **Fix thumbnail regeneration bug**: `loadDesign()` incorrectly skipped thumbnail capture for designs with `null` thumbnails (inverted condition: `!== null` instead of `=== null`)
- **Remove JSON export from export modal**: JSON download is already available in the saved designs modal — removes redundant section, divider, and related tests

## Test plan
- [x] All 239 affected tests pass
- [x] Open bin designer, save a single design, verify the card stays a reasonable size in the design list
- [ ] Create a design from a bin in the layout planner, close and reopen — verify thumbnail generates
- [x] Open export modal and verify only the STL section is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)