### PR TITLE
fix(seo): shorten meta descriptions to 100-130 characters

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Gridfinity Layout Tool | Plan Your 3D Printed Drawer Organizers</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Design Gridfinity drawer layouts for 3D printing. Plan custom organizers with drag-and-drop bins, multi-layer support, 3D preview, and automatic print optimization. Works offline, no signup required.">
+    <meta name="description" content="Plan and visualize Gridfinity drawer layouts for 3D printing. Custom bins, multi-layer support, and 3D preview.">
     <meta name="keywords" content="gridfinity, drawer organizer, 3D printing, layout tool, bin organizer, drawer layout, storage bins, gridfinity bins, drawer dividers, 3D print planner, modular storage, desk organizer, tool organizer">
     <meta name="author" content="Andy Aragon">
     <meta name="robots" content="index, follow">
@@ -32,7 +32,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://gridfinitylayouttool.com/">
     <meta property="og:title" content="Gridfinity Layout Tool | Plan Your 3D Printed Drawer Organizers">
-    <meta property="og:description" content="Design Gridfinity drawer layouts for 3D printing. Plan custom organizers with drag-and-drop bins, multi-layer support, 3D preview, and automatic print optimization.">
+    <meta property="og:description" content="Plan and visualize Gridfinity drawer layouts for 3D printing. Custom bins, multi-layer support, and 3D preview.">
     <meta property="og:image" content="https://gridfinitylayouttool.com/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -44,7 +44,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://gridfinitylayouttool.com/">
     <meta name="twitter:title" content="Gridfinity Layout Tool | Plan Your 3D Printed Drawer Organizers">
-    <meta name="twitter:description" content="Design Gridfinity drawer layouts for 3D printing. Plan custom organizers with drag-and-drop bins, multi-layer support, 3D preview, and automatic print optimization.">
+    <meta name="twitter:description" content="Plan and visualize Gridfinity drawer layouts for 3D printing. Custom bins, multi-layer support, and 3D preview.">
     <meta name="twitter:image" content="https://gridfinitylayouttool.com/og-image.png">
     <meta name="twitter:image:alt" content="Gridfinity Layout Tool interface showing a grid-based drawer layout editor with colorful storage bins">
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1138,7 +1138,7 @@
   "rightPanel.selection": "Auswahl",
   "rightPanel.splitInto": "Teilen in",
   "rightPanel.unknownCategory": "Unbekannte Kategorie",
-  "seo.description": "Gestalte Gridfinity Schubladen-Layouts für den 3D-Druck. Plane individuelle Organizer mit Drag-and-Drop-Bins, Multi-Layer-Unterstützung, 3D-Vorschau und automatischer Druck-Optimierung.",
+  "seo.description": "Plane und visualisiere Gridfinity Schubladen-Layouts für den 3D-Druck. Individuelle Bins, Multi-Layer und 3D-Vorschau.",
   "seo.title": "Gridfinity Layout Tool | Plane deine 3D-gedruckten Schubladen-Organizer",
   "settings.autoDetect": "Auto (Browser-Standard)",
   "settings.confirmCopyFromLayout.confirm": "Kopieren",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -19,7 +19,7 @@ const en: Record<string, string> = {
   // ===========================================================================
   'seo.title': 'Gridfinity Layout Tool | Plan Your 3D Printed Drawer Organizers',
   'seo.description':
-    'Design Gridfinity drawer layouts for 3D printing. Plan custom organizers with drag-and-drop bins, multi-layer support, 3D preview, and automatic print optimization.',
+    'Plan and visualize Gridfinity drawer layouts for 3D printing. Custom bins, multi-layer support, and 3D preview.',
 
   // ===========================================================================
   // Common / Shared

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1138,7 +1138,7 @@
   "rightPanel.selection": "Selección",
   "rightPanel.splitInto": "Dividir en",
   "rightPanel.unknownCategory": "Categoría desconocida",
-  "seo.description": "Diseña layouts de cajones Gridfinity para impresión 3D. Planifica organizadores personalizados con bins arrastrables, soporte multicapa, vista previa 3D y optimización automática de impresión.",
+  "seo.description": "Planifica y visualiza layouts de cajones Gridfinity para impresión 3D. Bins personalizados, soporte multicapa y vista previa 3D.",
   "seo.title": "Gridfinity Layout Tool | Planifica tus organizadores de cajones para impresión 3D",
   "settings.autoDetect": "Auto (predeterminado del navegador)",
   "settings.confirmCopyFromLayout.confirm": "Copiar",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1138,7 +1138,7 @@
   "rightPanel.selection": "Sélection",
   "rightPanel.splitInto": "Diviser en",
   "rightPanel.unknownCategory": "Catégorie inconnue",
-  "seo.description": "Concevez des agencements de tiroirs Gridfinity pour l'impression 3D. Planifiez des organisateurs personnalisés avec des bins glisser-déposer, support multicouche, aperçu 3D et optimisation automatique d'impression.",
+  "seo.description": "Planifiez et visualisez des agencements de tiroirs Gridfinity pour l'impression 3D. Bins personnalisés, multicouche et aperçu 3D.",
   "seo.title": "Gridfinity Layout Tool | Planifiez vos organisateurs de tiroirs imprimés en 3D",
   "settings.autoDetect": "Auto (langue du navigateur)",
   "settings.confirmCopyFromLayout.confirm": "Copier",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1138,7 +1138,7 @@
   "rightPanel.selection": "Utvalg",
   "rightPanel.splitInto": "Del i",
   "rightPanel.unknownCategory": "Ukjent kategori",
-  "seo.description": "Design Gridfinity skuffeoppsett for 3D-printing. Planlegg tilpassede organisatorer med dra-og-slipp bins, flerlags støtte, 3D-forhåndsvisning og automatisk utskriftsoptimalisering.",
+  "seo.description": "Planlegg og visualiser Gridfinity skuffeoppsett for 3D-printing. Tilpassede bins, flerlags støtte og 3D-forhåndsvisning.",
   "seo.title": "Gridfinity Layout Tool | Planlegg dine 3D-printede skufforganisatorer",
   "settings.autoDetect": "Auto (nettleserstandard)",
   "settings.confirmCopyFromLayout.confirm": "Kopier",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1138,7 +1138,7 @@
   "rightPanel.selection": "Selectie",
   "rightPanel.splitInto": "Splitsen in",
   "rightPanel.unknownCategory": "Onbekende categorie",
-  "seo.description": "Ontwerp Gridfinity lade-indelingen voor 3D-printen. Plan aangepaste organizers met drag-and-drop bins, multi-layer ondersteuning, 3D-preview en automatische printoptimalisatie.",
+  "seo.description": "Plan en visualiseer Gridfinity lade-indelingen voor 3D-printen. Aangepaste bins, multi-layer ondersteuning en 3D-preview.",
   "seo.title": "Gridfinity Layout Tool | Plan je 3D-geprinte lade-organizers",
   "settings.autoDetect": "Automatisch (browserstandaard)",
   "settings.confirmCopyFromLayout.confirm": "Kopiëren",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1138,7 +1138,7 @@
   "rightPanel.selection": "Seleção",
   "rightPanel.splitInto": "Dividir em",
   "rightPanel.unknownCategory": "Categoria desconhecida",
-  "seo.description": "Projete layouts de gavetas Gridfinity para impressão 3D. Planeje organizadores personalizados com bins arrastar e soltar, suporte multicamadas, prévia 3D e otimização automática de impressão.",
+  "seo.description": "Planeje e visualize layouts de gavetas Gridfinity para impressão 3D. Bins personalizados, suporte multicamadas e prévia 3D.",
   "seo.title": "Gridfinity Layout Tool | Planeje seus organizadores de gavetas impressos em 3D",
   "settings.autoDetect": "Automático (padrão do navegador)",
   "settings.confirmCopyFromLayout.confirm": "Copiar",


### PR DESCRIPTION
## Summary
- Shorten all meta descriptions (`description`, `og:description`, `twitter:description`) in `index.html` to ~112 characters to prevent truncation on mobile SERPs
- Update `seo.description` in English source (`en.ts`) and all 6 locale JSON files (de, es, fr, nb, nl, pt-BR) to match
- JSON-LD structured data descriptions left unchanged (different purpose, no char limit)

## Test plan
- [x] `npm run build` — passes
- [x] `npm run check:i18n` — all 6 locales have matching keys
- [x] `npm run test:coverage` — passes (1 pre-existing failure unrelated to this change)
- [ ] Verify SERP preview shows full description without truncation