### PR TITLE
feat(seo): dynamic meta tags + server-side bot OG injection

### DIFF
--- a/middleware-utils.test.ts
+++ b/middleware-utils.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for middleware utility functions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isBotUserAgent,
+  extractShareId,
+  buildShareMeta,
+  injectMetaTags,
+  escapeHtml,
+} from './middleware-utils';
+
+describe('isBotUserAgent', () => {
+  it.each([
+    ['facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)', 'Facebook'],
+    ['Twitterbot/1.0', 'Twitter'],
+    ['Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)', 'Slack'],
+    ['LinkedInBot/1.0 (compatible; Mozilla/5.0)', 'LinkedIn'],
+    ['Discordbot/2.0', 'Discord'],
+    ['WhatsApp/2.21.4.22 A', 'WhatsApp'],
+    ['TelegramBot (like TwitterBot)', 'Telegram'],
+    ['Googlebot/2.1 (+http://www.google.com/bot.html)', 'Googlebot'],
+    ['Mozilla/5.0 (compatible; bingbot/2.0)', 'Bing'],
+    ['Applebot/0.1', 'Apple'],
+    ['Embedly/0.2', 'Embedly'],
+    ['Pinterest/0.2', 'Pinterest'],
+  ])('returns true for %s (%s)', (ua) => {
+    expect(isBotUserAgent(ua)).toBe(true);
+  });
+
+  it.each([
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Safari/605.1.15',
+    'Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0',
+    '',
+  ])('returns false for regular browser: %s', (ua) => {
+    expect(isBotUserAgent(ua)).toBe(false);
+  });
+});
+
+describe('extractShareId', () => {
+  it('extracts 12-char alphanumeric ID', () => {
+    expect(extractShareId('/l/abc123DEF456')).toBe('abc123DEF456');
+  });
+
+  it('extracts 12-char ID with slug', () => {
+    expect(extractShareId('/l/abc123DEF456/my-layout-name')).toBe('abc123DEF456');
+  });
+
+  it('extracts UUID v4', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(extractShareId(`/l/${uuid}`)).toBe(uuid);
+  });
+
+  it('extracts UUID with slug', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(extractShareId(`/l/${uuid}/my-layout`)).toBe(uuid);
+  });
+
+  it('extracts base36 timestamp ID', () => {
+    expect(extractShareId('/l/lszwz1k7v-8j2kqp1')).toBe('lszwz1k7v-8j2kqp1');
+  });
+
+  it('returns null for non-matching paths', () => {
+    expect(extractShareId('/')).toBeNull();
+    expect(extractShareId('/about')).toBeNull();
+    expect(extractShareId('/l/')).toBeNull();
+  });
+
+  it('returns null for invalid ID format', () => {
+    expect(extractShareId('/l/too-short')).toBeNull();
+    expect(extractShareId('/l/has spaces!')).toBeNull();
+  });
+});
+
+describe('buildShareMeta', () => {
+  it('builds meta from a complete layout', () => {
+    const layout = {
+      name: 'Workshop Drawer',
+      drawer: { width: 10, depth: 8, height: 12 },
+      layers: [{ id: '1', name: 'Bottom', height: 3 }],
+      bins: [
+        { id: 'b1', layerId: 'layer1' },
+        { id: 'b2', layerId: 'layer1' },
+        { id: 'b3', layerId: '__staging__' },
+      ],
+    };
+
+    const result = buildShareMeta(layout);
+
+    expect(result.title).toBe('Workshop Drawer | Gridfinity Layout Tool');
+    expect(result.description).toContain('10\u00D78');
+    expect(result.description).toContain('2 bins');
+    expect(result.description).toContain('1 layers');
+  });
+
+  it('uses default title when name is missing', () => {
+    const layout = {
+      drawer: { width: 5, depth: 5, height: 10 },
+      layers: [],
+      bins: [],
+    };
+
+    const result = buildShareMeta(layout);
+    expect(result.title).toBe('Shared Layout | Gridfinity Layout Tool');
+  });
+
+  it('uses default title when name is empty', () => {
+    const layout = {
+      name: '   ',
+      drawer: { width: 5, depth: 5, height: 10 },
+      layers: [],
+      bins: [],
+    };
+
+    const result = buildShareMeta(layout);
+    expect(result.title).toBe('Shared Layout | Gridfinity Layout Tool');
+  });
+
+  it('uses default description when drawer is missing', () => {
+    const layout = { name: 'Test', layers: [], bins: [] };
+    const result = buildShareMeta(layout);
+    expect(result.description).toContain('View this shared');
+  });
+
+  it('returns defaults for null input', () => {
+    const result = buildShareMeta(null);
+    expect(result.title).toBe('Shared Layout | Gridfinity Layout Tool');
+    expect(result.description).toContain('View this shared');
+  });
+
+  it('returns defaults for non-object input', () => {
+    const result = buildShareMeta('not an object');
+    expect(result.title).toBe('Shared Layout | Gridfinity Layout Tool');
+  });
+
+  it('truncates long names at 60 characters', () => {
+    const layout = {
+      name: 'A'.repeat(80),
+      drawer: { width: 10, depth: 8, height: 12 },
+      layers: [],
+      bins: [],
+    };
+
+    const result = buildShareMeta(layout);
+    expect(result.title).toBe('A'.repeat(60) + ' | Gridfinity Layout Tool');
+  });
+});
+
+describe('injectMetaTags', () => {
+  const sampleHtml = [
+    '<html><head>',
+    '<title>Gridfinity Layout Tool | Plan Your 3D Printed Drawer Organizers</title>',
+    '<meta name="description" content="Original description">',
+    '<meta name="robots" content="index, follow">',
+    '<meta property="og:title" content="Original OG Title">',
+    '<meta property="og:description" content="Original OG Desc">',
+    '<meta property="og:url" content="https://example.com/">',
+    '<meta name="twitter:title" content="Original Twitter Title">',
+    '<meta name="twitter:description" content="Original Twitter Desc">',
+    '</head><body></body></html>',
+  ].join('\n');
+
+  it('replaces all 7 meta tags', () => {
+    const result = injectMetaTags(sampleHtml, {
+      title: 'My Layout | Gridfinity Layout Tool',
+      description: '10×8 layout with 5 bins',
+      url: 'https://example.com/l/abc123DEF456',
+    });
+
+    expect(result).toContain('<title>My Layout | Gridfinity Layout Tool</title>');
+    expect(result).toContain('name="description" content="10×8 layout with 5 bins"');
+    expect(result).toContain('property="og:title" content="My Layout | Gridfinity Layout Tool"');
+    expect(result).toContain('property="og:description" content="10×8 layout with 5 bins"');
+    expect(result).toContain('property="og:url" content="https://example.com/l/abc123DEF456"');
+    expect(result).toContain('name="twitter:title" content="My Layout | Gridfinity Layout Tool"');
+    expect(result).toContain('name="twitter:description" content="10×8 layout with 5 bins"');
+  });
+
+  it('injects noindex for robots meta tag', () => {
+    const result = injectMetaTags(sampleHtml, {
+      title: 'Test',
+      description: 'Test',
+      url: 'https://example.com/l/abc123DEF456',
+    });
+
+    expect(result).toContain('name="robots" content="noindex"');
+    expect(result).not.toContain('content="index, follow"');
+  });
+
+  it('escapes special characters in injected values', () => {
+    const result = injectMetaTags(sampleHtml, {
+      title: 'Layout <script>alert("xss")</script>',
+      description: 'Desc with "quotes" & <angle brackets>',
+      url: 'https://example.com/l/test',
+    });
+
+    expect(result).not.toContain('<script>');
+    expect(result).toContain('&lt;script&gt;');
+    expect(result).toContain('&amp;');
+    expect(result).toContain('&quot;');
+  });
+});
+
+describe('escapeHtml', () => {
+  it('escapes ampersand', () => {
+    expect(escapeHtml('foo & bar')).toBe('foo &amp; bar');
+  });
+
+  it('escapes less-than', () => {
+    expect(escapeHtml('<div>')).toBe('&lt;div&gt;');
+  });
+
+  it('escapes greater-than', () => {
+    expect(escapeHtml('a > b')).toBe('a &gt; b');
+  });
+
+  it('escapes double quotes', () => {
+    expect(escapeHtml('"hello"')).toBe('&quot;hello&quot;');
+  });
+
+  it('escapes single quotes', () => {
+    expect(escapeHtml("it's")).toBe('it&#x27;s');
+  });
+
+  it('handles empty string', () => {
+    expect(escapeHtml('')).toBe('');
+  });
+
+  it('handles string with no special chars', () => {
+    expect(escapeHtml('Hello World')).toBe('Hello World');
+  });
+});

--- a/middleware-utils.ts
+++ b/middleware-utils.ts
@@ -1,0 +1,178 @@
+/**
+ * Pure utility functions for Vercel Edge Middleware.
+ *
+ * Extracted from middleware.ts for testability. All functions are
+ * synchronous and have no external dependencies.
+ */
+
+/** Bot User-Agent patterns for social media crawlers and search engines. */
+const BOT_PATTERNS = [
+  'facebookexternalhit',
+  'Twitterbot',
+  'Slackbot',
+  'LinkedInBot',
+  'Discordbot',
+  'WhatsApp',
+  'TelegramBot',
+  'Googlebot',
+  'bingbot',
+  'Applebot',
+  'Embedly',
+  'Pinterest',
+  'Pinterestbot',
+  'Rocket.Chat',
+  'Iframely',
+  'Mastodon',
+];
+
+/**
+ * Check if a User-Agent string belongs to a known bot/crawler.
+ */
+export function isBotUserAgent(ua: string): boolean {
+  const lower = ua.toLowerCase();
+  return BOT_PATTERNS.some((pattern) => lower.includes(pattern.toLowerCase()));
+}
+
+/**
+ * Extract the share ID from a `/l/{id}` or `/l/{id}/{slug}` pathname.
+ *
+ * Supports:
+ * - 12-char alphanumeric IDs: `/l/abc123DEF456`
+ * - Base36 timestamp IDs: `/l/lszwz1k7v-8j2kqp1`
+ * - UUIDs: `/l/xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`
+ * - Any of the above with an optional trailing slug: `/l/{id}/my-layout-name`
+ *
+ * @returns The share ID, or null if the path doesn't match.
+ */
+export function extractShareId(pathname: string): string | null {
+  // Match /l/{id} with optional /{slug}
+  const match = pathname.match(/^\/l\/([^/]+)/);
+  if (!match) return null;
+
+  const id = match[1];
+
+  // Validate: 12-char alphanumeric
+  if (/^[a-zA-Z0-9]{12}$/.test(id)) return id;
+
+  // Validate: UUID v4
+  if (/^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i.test(id)) {
+    return id;
+  }
+
+  // Validate: Base36 timestamp format
+  if (/^[a-z0-9]+-[a-z0-9]{7}$/.test(id)) return id;
+
+  return null;
+}
+
+/**
+ * Safely extract meta information from an untyped layout blob.
+ *
+ * Handles missing or malformed data gracefully, returning sensible
+ * defaults for any field that can't be read.
+ */
+export function buildShareMeta(layout: unknown): { title: string; description: string } {
+  const DEFAULT_TITLE = 'Shared Layout | Gridfinity Layout Tool';
+  const DEFAULT_DESC =
+    'View this shared Gridfinity drawer layout. Plan and visualize 3D printed drawer organizers.';
+
+  if (typeof layout !== 'object' || layout === null) {
+    return { title: DEFAULT_TITLE, description: DEFAULT_DESC };
+  }
+
+  const obj = layout as Record<string, unknown>;
+
+  // Extract name
+  const name = typeof obj.name === 'string' && obj.name.trim().length > 0 ? obj.name.trim() : '';
+  const title = name.length > 0 ? `${name.slice(0, 60)} | Gridfinity Layout Tool` : DEFAULT_TITLE;
+
+  // Extract drawer dimensions
+  const drawer =
+    typeof obj.drawer === 'object' && obj.drawer !== null
+      ? (obj.drawer as Record<string, unknown>)
+      : null;
+  const width = drawer && typeof drawer.width === 'number' ? drawer.width : 0;
+  const depth = drawer && typeof drawer.depth === 'number' ? drawer.depth : 0;
+
+  // Count bins (excluding staging)
+  const bins = Array.isArray(obj.bins) ? obj.bins : [];
+  const gridBinCount = bins.filter(
+    (b: unknown) =>
+      typeof b === 'object' &&
+      b !== null &&
+      (b as Record<string, unknown>).layerId !== '__staging__'
+  ).length;
+
+  // Count layers
+  const layers = Array.isArray(obj.layers) ? obj.layers : [];
+  const layerCount = layers.length;
+
+  // Build description
+  const description =
+    width > 0 && depth > 0
+      ? `${width}\u00D7${depth} Gridfinity drawer layout with ${gridBinCount} bins across ${layerCount} layers.`
+      : DEFAULT_DESC;
+
+  return { title, description };
+}
+
+/**
+ * Inject layout-specific meta tags into an HTML string.
+ *
+ * Performs targeted replacements on title, description, og:*, and twitter:* tags.
+ * Also injects a noindex meta tag for shared layouts (they should not be indexed).
+ */
+export function injectMetaTags(
+  html: string,
+  meta: { title: string; description: string; url: string }
+): string {
+  const safeTitle = escapeHtml(meta.title);
+  const safeDesc = escapeHtml(meta.description);
+  const safeUrl = escapeHtml(meta.url);
+
+  let result = html;
+
+  // Replace <title>...</title>
+  result = result.replace(/<title>[^<]*<\/title>/, `<title>${safeTitle}</title>`);
+
+  // Replace meta description
+  result = result.replace(/(<meta\s+name="description"\s+content=")[^"]*(")/, `$1${safeDesc}$2`);
+
+  // Replace og:title
+  result = result.replace(/(<meta\s+property="og:title"\s+content=")[^"]*(")/, `$1${safeTitle}$2`);
+
+  // Replace og:description
+  result = result.replace(
+    /(<meta\s+property="og:description"\s+content=")[^"]*(")/,
+    `$1${safeDesc}$2`
+  );
+
+  // Replace og:url
+  result = result.replace(/(<meta\s+property="og:url"\s+content=")[^"]*(")/, `$1${safeUrl}$2`);
+
+  // Replace twitter:title
+  result = result.replace(/(<meta\s+name="twitter:title"\s+content=")[^"]*(")/, `$1${safeTitle}$2`);
+
+  // Replace twitter:description
+  result = result.replace(
+    /(<meta\s+name="twitter:description"\s+content=")[^"]*(")/,
+    `$1${safeDesc}$2`
+  );
+
+  // Inject noindex for shared layouts (before closing </head>)
+  result = result.replace(/(<meta\s+name="robots"\s+content=")[^"]*(")/, '$1noindex$2');
+
+  return result;
+}
+
+/**
+ * Escape special HTML characters to prevent XSS in injected meta content.
+ */
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Integration tests for Vercel Edge Middleware.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock @vercel/blob before importing middleware
+vi.mock('@vercel/blob', () => ({
+  head: vi.fn(),
+}));
+
+// Mock global fetch for blob content and index.html fetches
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import middleware from './middleware';
+import { head } from '@vercel/blob';
+
+const SAMPLE_INDEX_HTML = [
+  '<!doctype html><html><head>',
+  '<title>Gridfinity Layout Tool | Plan Your 3D Printed Drawer Organizers</title>',
+  '<meta name="description" content="Default desc">',
+  '<meta name="robots" content="index, follow">',
+  '<meta property="og:title" content="Default OG">',
+  '<meta property="og:description" content="Default OG Desc">',
+  '<meta property="og:url" content="https://gridfinitylayouttool.com/">',
+  '<meta name="twitter:title" content="Default Twitter">',
+  '<meta name="twitter:description" content="Default Twitter Desc">',
+  '</head><body><div id="root"></div></body></html>',
+].join('\n');
+
+const SAMPLE_SHARE_DATA = {
+  layout: {
+    name: 'My Workshop',
+    drawer: { width: 10, depth: 8, height: 12 },
+    layers: [
+      { id: 'l1', name: 'Bottom', height: 3 },
+      { id: 'l2', name: 'Top', height: 3 },
+    ],
+    bins: [
+      { id: 'b1', layerId: 'l1' },
+      { id: 'b2', layerId: 'l1' },
+      { id: 'b3', layerId: 'l2' },
+      { id: 'b4', layerId: '__staging__' },
+    ],
+  },
+  deleteTokenHash: 'abc',
+  createdAt: Date.now(),
+};
+
+function createRequest(path: string, userAgent = 'Mozilla/5.0 Chrome/120.0'): Request {
+  return new Request(`https://gridfinitylayouttool.com${path}`, {
+    headers: { 'user-agent': userAgent },
+  });
+}
+
+describe('middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes through non-bot requests', async () => {
+    const request = createRequest('/l/abc123DEF456');
+    const result = await middleware(request);
+
+    // undefined means pass through (no interception)
+    expect(result).toBeUndefined();
+    expect(head).not.toHaveBeenCalled();
+  });
+
+  it('returns layout-specific HTML for bot with valid share', async () => {
+    vi.mocked(head).mockResolvedValue({
+      url: 'https://blob.vercel-storage.com/shares/abc123DEF456.json',
+      downloadUrl: 'https://blob.vercel-storage.com/shares/abc123DEF456.json',
+      pathname: 'shares/abc123DEF456.json',
+      contentType: 'application/json',
+      contentDisposition: 'inline',
+      size: 1234,
+      uploadedAt: new Date(),
+    });
+
+    mockFetch
+      // First call: blob content
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(SAMPLE_SHARE_DATA),
+      })
+      // Second call: index.html
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_INDEX_HTML),
+      });
+
+    const request = createRequest('/l/abc123DEF456', 'Twitterbot/1.0');
+    const result = await middleware(request);
+
+    expect(result).toBeInstanceOf(Response);
+    const html = await result!.text();
+
+    // Layout-specific meta tags
+    expect(html).toContain('<title>My Workshop | Gridfinity Layout Tool</title>');
+    expect(html).toContain('10×8 Gridfinity drawer layout');
+    expect(html).toContain('3 bins'); // 4 total minus 1 staging
+    expect(html).toContain('2 layers');
+
+    // noindex for shared layouts
+    expect(html).toContain('name="robots" content="noindex"');
+
+    // Correct content type
+    expect(result!.headers.get('content-type')).toBe('text/html; charset=utf-8');
+  });
+
+  it('returns fallback HTML when share not found', async () => {
+    vi.mocked(head).mockRejectedValue(new Error('Not found'));
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(SAMPLE_INDEX_HTML),
+    });
+
+    const request = createRequest('/l/abc123DEF456', 'facebookexternalhit/1.1');
+    const result = await middleware(request);
+
+    expect(result).toBeInstanceOf(Response);
+    const html = await result!.text();
+
+    // Fallback with noindex
+    expect(html).toContain('Shared Layout | Gridfinity Layout Tool');
+    expect(html).toContain('name="robots" content="noindex"');
+  });
+
+  it('returns undefined for bot with invalid path', async () => {
+    const request = createRequest('/l/', 'Twitterbot/1.0');
+    const result = await middleware(request);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('handles blob fetch failure gracefully', async () => {
+    vi.mocked(head).mockResolvedValue({
+      url: 'https://blob.vercel-storage.com/shares/abc123DEF456.json',
+      downloadUrl: 'https://blob.vercel-storage.com/shares/abc123DEF456.json',
+      pathname: 'shares/abc123DEF456.json',
+      contentType: 'application/json',
+      contentDisposition: 'inline',
+      size: 1234,
+      uploadedAt: new Date(),
+    });
+
+    mockFetch
+      // Blob fetch fails
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      // Fallback index.html
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_INDEX_HTML),
+      });
+
+    const request = createRequest('/l/abc123DEF456', 'Slackbot-LinkExpanding 1.0');
+    const result = await middleware(request);
+
+    // Should still return something (fallback HTML)
+    expect(result).toBeInstanceOf(Response);
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,115 @@
+/**
+ * Vercel Edge Middleware for shared layout OG tag injection.
+ *
+ * Intercepts `/l/*` requests from social media bots and search engine crawlers,
+ * fetches the shared layout from Vercel Blob, and injects layout-specific
+ * Open Graph and Twitter Card meta tags into the HTML response.
+ *
+ * Non-bot requests pass through untouched to the SPA.
+ */
+
+import { head } from '@vercel/blob';
+import { isBotUserAgent, extractShareId, buildShareMeta, injectMetaTags } from './middleware-utils';
+
+export const config = {
+  matcher: ['/l/:path*'],
+};
+
+export default async function middleware(request: Request): Promise<Response | undefined> {
+  const userAgent = request.headers.get('user-agent') ?? '';
+
+  // Non-bot requests: pass through to SPA (Vercel rewrites handle this)
+  if (!isBotUserAgent(userAgent)) {
+    return undefined;
+  }
+
+  const url = new URL(request.url);
+  const shareId = extractShareId(url.pathname);
+
+  if (!shareId) {
+    return undefined;
+  }
+
+  try {
+    // Fetch share blob metadata
+    const blobPath = `shares/${shareId}.json`;
+    const blobInfo = await head(blobPath).catch(() => null);
+
+    if (!blobInfo?.url) {
+      // Share not found — fall through to default HTML
+      return serveFallbackHtml(url);
+    }
+
+    // Fetch the actual layout data
+    const blobResponse = await fetch(blobInfo.url);
+    if (!blobResponse.ok) {
+      return serveFallbackHtml(url);
+    }
+
+    const shareData: unknown = await blobResponse.json();
+
+    // Extract layout from share wrapper (ShareData has { layout, ... })
+    const layout =
+      typeof shareData === 'object' && shareData !== null && 'layout' in shareData
+        ? (shareData as Record<string, unknown>).layout
+        : shareData;
+
+    const meta = buildShareMeta(layout);
+
+    // Fetch the origin index.html
+    const originUrl = `${url.origin}/index.html`;
+    const htmlResponse = await fetch(originUrl);
+
+    if (!htmlResponse.ok) {
+      return undefined;
+    }
+
+    const html = await htmlResponse.text();
+    const injectedHtml = injectMetaTags(html, {
+      title: meta.title,
+      description: meta.description,
+      url: url.href,
+    });
+
+    return new Response(injectedHtml, {
+      status: 200,
+      headers: {
+        'content-type': 'text/html; charset=utf-8',
+        'cache-control': 'public, max-age=300, s-maxage=600',
+      },
+    });
+  } catch {
+    // On any error, fall through to unmodified SPA
+    return undefined;
+  }
+}
+
+/**
+ * Serve fallback HTML with noindex injected for shared layout URLs.
+ * Even if the share doesn't exist, bots should see noindex.
+ */
+async function serveFallbackHtml(url: URL): Promise<Response | undefined> {
+  try {
+    const originUrl = `${url.origin}/index.html`;
+    const htmlResponse = await fetch(originUrl);
+    if (!htmlResponse.ok) return undefined;
+
+    const html = await htmlResponse.text();
+    const injectedHtml = injectMetaTags(html, {
+      title: 'Shared Layout | Gridfinity Layout Tool',
+      description:
+        'View this shared Gridfinity drawer layout. Plan and visualize 3D printed drawer organizers.',
+      url: url.href,
+    });
+
+    return new Response(injectedHtml, {
+      status: 200,
+      headers: {
+        'content-type': 'text/html; charset=utf-8',
+        'cache-control': 'public, max-age=60',
+      },
+    });
+  } catch {
+    return undefined;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
   useCrossTabSync,
   usePWAUpdate,
   usePrefetchChunks,
+  useDocumentMeta,
 } from './shared/hooks';
 import { useCollabMode } from './hooks/useCollabMode';
 import { useOwnedShareSync } from './features/cloud-share/hooks/useOwnedShareSync';
@@ -254,6 +255,9 @@ export default function App() {
 
   // Prefetch lazy-loaded chunks during idle time (desktop only)
   usePrefetchChunks();
+
+  // Dynamic document meta tags (title, description, OG, Twitter)
+  useDocumentMeta();
 
   // Only fade in on initial app load, not when switching between tools
   const entranceClass = hasRenderedInitialLayout ? '' : 'animate-fade-in';

--- a/src/i18n/context.test.tsx
+++ b/src/i18n/context.test.tsx
@@ -12,7 +12,6 @@ import {
   useFormatting,
   getStaticTranslation,
 } from '@/i18n/context';
-import en from '@/i18n/locales/en';
 
 describe('getStaticTranslation', () => {
   it('returns translated string for valid key', () => {
@@ -549,33 +548,14 @@ describe('LocaleProvider document updates', () => {
   beforeEach(() => {
     // Mock document structure for testing
     document.documentElement.lang = 'en';
-    document.title = '';
 
-    const metaTags = [
-      { name: 'description' },
-      { property: 'og:locale' },
-      { property: 'og:title' },
-      { property: 'og:description' },
-      { name: 'twitter:title' },
-      { name: 'twitter:description' },
-    ];
-
-    metaTags.forEach((tag) => {
-      const existing = tag.name
-        ? document.querySelector(`meta[name="${tag.name}"]`)
-        : document.querySelector(`meta[property="${tag.property}"]`);
-
-      if (!existing) {
-        const meta = document.createElement('meta');
-        if (tag.name) {
-          meta.setAttribute('name', tag.name);
-        } else if (tag.property) {
-          meta.setAttribute('property', tag.property);
-        }
-        meta.setAttribute('content', '');
-        document.head.appendChild(meta);
-      }
-    });
+    // Ensure og:locale meta tag exists
+    if (!document.querySelector('meta[property="og:locale"]')) {
+      const meta = document.createElement('meta');
+      meta.setAttribute('property', 'og:locale');
+      meta.setAttribute('content', '');
+      document.head.appendChild(meta);
+    }
   });
 
   it('updates document lang attribute', () => {
@@ -588,27 +568,6 @@ describe('LocaleProvider document updates', () => {
     expect(document.documentElement.lang).toBe('en');
   });
 
-  it('updates document title with SEO title', () => {
-    render(
-      <LocaleProvider initialLocale="en">
-        <div>Content</div>
-      </LocaleProvider>
-    );
-
-    expect(document.title).toBe(en['seo.title']);
-  });
-
-  it('updates meta description', () => {
-    render(
-      <LocaleProvider initialLocale="en">
-        <div>Content</div>
-      </LocaleProvider>
-    );
-
-    const meta = document.querySelector('meta[name="description"]');
-    expect(meta?.getAttribute('content')).toBe(en['seo.description']);
-  });
-
   it('updates OG locale meta tag', () => {
     render(
       <LocaleProvider initialLocale="en">
@@ -618,49 +577,5 @@ describe('LocaleProvider document updates', () => {
 
     const meta = document.querySelector('meta[property="og:locale"]');
     expect(meta?.getAttribute('content')).toBe('en_US');
-  });
-
-  it('updates OG title meta tag', () => {
-    render(
-      <LocaleProvider initialLocale="en">
-        <div>Content</div>
-      </LocaleProvider>
-    );
-
-    const meta = document.querySelector('meta[property="og:title"]');
-    expect(meta?.getAttribute('content')).toBe(en['seo.title']);
-  });
-
-  it('updates OG description meta tag', () => {
-    render(
-      <LocaleProvider initialLocale="en">
-        <div>Content</div>
-      </LocaleProvider>
-    );
-
-    const meta = document.querySelector('meta[property="og:description"]');
-    expect(meta?.getAttribute('content')).toBe(en['seo.description']);
-  });
-
-  it('updates Twitter title meta tag', () => {
-    render(
-      <LocaleProvider initialLocale="en">
-        <div>Content</div>
-      </LocaleProvider>
-    );
-
-    const meta = document.querySelector('meta[name="twitter:title"]');
-    expect(meta?.getAttribute('content')).toBe(en['seo.title']);
-  });
-
-  it('updates Twitter description meta tag', () => {
-    render(
-      <LocaleProvider initialLocale="en">
-        <div>Content</div>
-      </LocaleProvider>
-    );
-
-    const meta = document.querySelector('meta[name="twitter:description"]');
-    expect(meta?.getAttribute('content')).toBe(en['seo.description']);
   });
 });

--- a/src/i18n/context.tsx
+++ b/src/i18n/context.tsx
@@ -176,31 +176,16 @@ export function LocaleProvider({ children, initialLocale, onLocaleChange }: Loca
     [loadLocale, onLocaleChange]
   );
 
-  // Sync SEO meta tags when locale/translations change
+  // Sync locale-dependent document attributes (lang + OG locale).
+  // Title, description, OG, and Twitter tags are managed by useDocumentMeta.
   useEffect(() => {
     if (isLoading || typeof document === 'undefined') return;
 
-    // HTML lang attribute (screen readers, SEO)
     document.documentElement.lang = locale;
-
-    // Page title and meta description
-    const seoTitle = translations['seo.title'] ?? en['seo.title'];
-    const seoDesc = translations['seo.description'] ?? en['seo.description'];
-
-    document.title = seoTitle;
-    document.querySelector('meta[name="description"]')?.setAttribute('content', seoDesc);
-
-    // Open Graph tags
     document
       .querySelector('meta[property="og:locale"]')
       ?.setAttribute('content', OG_LOCALE_MAP[locale]);
-    document.querySelector('meta[property="og:title"]')?.setAttribute('content', seoTitle);
-    document.querySelector('meta[property="og:description"]')?.setAttribute('content', seoDesc);
-
-    // Twitter Card tags
-    document.querySelector('meta[name="twitter:title"]')?.setAttribute('content', seoTitle);
-    document.querySelector('meta[name="twitter:description"]')?.setAttribute('content', seoDesc);
-  }, [locale, translations, isLoading]);
+  }, [locale, isLoading]);
 
   const t: TFunction = useCallback(
     (key: string, vars?: TranslationVars): string => {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1139,6 +1139,8 @@
   "rightPanel.splitInto": "Teilen in",
   "rightPanel.unknownCategory": "Unbekannte Kategorie",
   "seo.description": "Plane und visualisiere Gridfinity Schubladen-Layouts für den 3D-Druck. Individuelle Bins, Multi-Layer und 3D-Vorschau.",
+  "seo.layoutDescription": "{width}×{depth} Gridfinity Schubladen-Layout mit {binCount} Bins auf {layerCount} Layern.",
+  "seo.layoutTitle": "{name} | Gridfinity Layout Tool",
   "seo.title": "Gridfinity Layout Tool | Plane deine 3D-gedruckten Schubladen-Organizer",
   "settings.autoDetect": "Auto (Browser-Standard)",
   "settings.confirmCopyFromLayout.confirm": "Kopieren",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -20,6 +20,9 @@ const en: Record<string, string> = {
   'seo.title': 'Gridfinity Layout Tool | Plan Your 3D Printed Drawer Organizers',
   'seo.description':
     'Plan and visualize Gridfinity drawer layouts for 3D printing. Custom bins, multi-layer support, and 3D preview.',
+  'seo.layoutTitle': '{name} | Gridfinity Layout Tool',
+  'seo.layoutDescription':
+    '{width}×{depth} Gridfinity drawer layout with {binCount} bins across {layerCount} layers.',
 
   // ===========================================================================
   // Common / Shared

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1139,6 +1139,8 @@
   "rightPanel.splitInto": "Dividir en",
   "rightPanel.unknownCategory": "Categoría desconocida",
   "seo.description": "Planifica y visualiza layouts de cajones Gridfinity para impresión 3D. Bins personalizados, soporte multicapa y vista previa 3D.",
+  "seo.layoutDescription": "{width}×{depth} layout de cajón Gridfinity con {binCount} bins en {layerCount} capas.",
+  "seo.layoutTitle": "{name} | Gridfinity Layout Tool",
   "seo.title": "Gridfinity Layout Tool | Planifica tus organizadores de cajones para impresión 3D",
   "settings.autoDetect": "Auto (predeterminado del navegador)",
   "settings.confirmCopyFromLayout.confirm": "Copiar",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1139,6 +1139,8 @@
   "rightPanel.splitInto": "Diviser en",
   "rightPanel.unknownCategory": "Catégorie inconnue",
   "seo.description": "Planifiez et visualisez des agencements de tiroirs Gridfinity pour l'impression 3D. Bins personnalisés, multicouche et aperçu 3D.",
+  "seo.layoutDescription": "{width}×{depth} agencement de tiroir Gridfinity avec {binCount} bins sur {layerCount} couches.",
+  "seo.layoutTitle": "{name} | Gridfinity Layout Tool",
   "seo.title": "Gridfinity Layout Tool | Planifiez vos organisateurs de tiroirs imprimés en 3D",
   "settings.autoDetect": "Auto (langue du navigateur)",
   "settings.confirmCopyFromLayout.confirm": "Copier",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1139,6 +1139,8 @@
   "rightPanel.splitInto": "Del i",
   "rightPanel.unknownCategory": "Ukjent kategori",
   "seo.description": "Planlegg og visualiser Gridfinity skuffeoppsett for 3D-printing. Tilpassede bins, flerlags støtte og 3D-forhåndsvisning.",
+  "seo.layoutDescription": "{width}×{depth} Gridfinity skuffeoppsett med {binCount} bins over {layerCount} lag.",
+  "seo.layoutTitle": "{name} | Gridfinity Layout Tool",
   "seo.title": "Gridfinity Layout Tool | Planlegg dine 3D-printede skufforganisatorer",
   "settings.autoDetect": "Auto (nettleserstandard)",
   "settings.confirmCopyFromLayout.confirm": "Kopier",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1139,6 +1139,8 @@
   "rightPanel.splitInto": "Splitsen in",
   "rightPanel.unknownCategory": "Onbekende categorie",
   "seo.description": "Plan en visualiseer Gridfinity lade-indelingen voor 3D-printen. Aangepaste bins, multi-layer ondersteuning en 3D-preview.",
+  "seo.layoutDescription": "{width}×{depth} Gridfinity lade-indeling met {binCount} bins over {layerCount} lagen.",
+  "seo.layoutTitle": "{name} | Gridfinity Layout Tool",
   "seo.title": "Gridfinity Layout Tool | Plan je 3D-geprinte lade-organizers",
   "settings.autoDetect": "Automatisch (browserstandaard)",
   "settings.confirmCopyFromLayout.confirm": "Kopiëren",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1139,6 +1139,8 @@
   "rightPanel.splitInto": "Dividir em",
   "rightPanel.unknownCategory": "Categoria desconhecida",
   "seo.description": "Planeje e visualize layouts de gavetas Gridfinity para impressão 3D. Bins personalizados, suporte multicamadas e prévia 3D.",
+  "seo.layoutDescription": "{width}×{depth} layout de gaveta Gridfinity com {binCount} bins em {layerCount} camadas.",
+  "seo.layoutTitle": "{name} | Gridfinity Layout Tool",
   "seo.title": "Gridfinity Layout Tool | Planeje seus organizadores de gavetas impressos em 3D",
   "settings.autoDetect": "Automático (padrão do navegador)",
   "settings.confirmCopyFromLayout.confirm": "Copiar",

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -19,3 +19,5 @@ export type { SharedWithMeStatus } from './useSharedWithMe';
 export { useInlineEdit } from './useInlineEdit';
 
 export { usePrefetchChunks } from './usePrefetchChunks';
+
+export { useDocumentMeta, buildLayoutDescription } from './useDocumentMeta';

--- a/src/shared/hooks/useDocumentMeta.test.ts
+++ b/src/shared/hooks/useDocumentMeta.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for useDocumentMeta hook and buildLayoutDescription helper.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { LocaleProvider } from '@/i18n/context';
+import { useLayoutStore, useLibraryStore } from '@/core/store';
+import { resetAllStores, createTestBin } from '@/test/testUtils';
+import { STAGING_ID } from '@/core/constants';
+import { buildLayoutDescription, useDocumentMeta } from './useDocumentMeta';
+
+// Helper: wrap hook in LocaleProvider
+function createWrapper({ children }: { children: ReactNode }) {
+  return createElement(LocaleProvider, { initialLocale: 'en' }, children);
+}
+
+/** Ensure all required meta tags exist in the test DOM */
+function ensureMetaTags(): void {
+  const tags = [
+    { attr: 'name', value: 'description' },
+    { attr: 'property', value: 'og:title' },
+    { attr: 'property', value: 'og:description' },
+    { attr: 'property', value: 'og:url' },
+    { attr: 'name', value: 'twitter:title' },
+    { attr: 'name', value: 'twitter:description' },
+  ];
+
+  for (const tag of tags) {
+    const selector = `meta[${tag.attr}="${tag.value}"]`;
+    if (!document.querySelector(selector)) {
+      const meta = document.createElement('meta');
+      meta.setAttribute(tag.attr, tag.value);
+      meta.setAttribute('content', '');
+      document.head.appendChild(meta);
+    }
+  }
+}
+
+describe('buildLayoutDescription', () => {
+  it('builds description with layout data', () => {
+    const t = (key: string, vars?: Record<string, string | number>) => {
+      if (key === 'seo.layoutDescription' && vars) {
+        return `${vars.width}×${vars.depth} Gridfinity drawer layout with ${vars.binCount} bins across ${vars.layerCount} layers.`;
+      }
+      return key;
+    };
+
+    const result = buildLayoutDescription(t, 10, 8, 15, 2);
+    expect(result).toBe('10×8 Gridfinity drawer layout with 15 bins across 2 layers.');
+  });
+
+  it('handles zero bins and single layer', () => {
+    const t = (key: string, vars?: Record<string, string | number>) => {
+      if (key === 'seo.layoutDescription' && vars) {
+        return `${vars.width}×${vars.depth} Gridfinity drawer layout with ${vars.binCount} bins across ${vars.layerCount} layers.`;
+      }
+      return key;
+    };
+
+    const result = buildLayoutDescription(t, 5, 5, 0, 1);
+    expect(result).toBe('5×5 Gridfinity drawer layout with 0 bins across 1 layers.');
+  });
+
+  it('passes values as strings to translation function', () => {
+    const receivedVars: Record<string, string | number> = {};
+    const t = (key: string, vars?: Record<string, string | number>) => {
+      if (vars) Object.assign(receivedVars, vars);
+      return key;
+    };
+
+    buildLayoutDescription(t, 10, 8, 15, 2);
+    expect(receivedVars.width).toBe('10');
+    expect(receivedVars.depth).toBe('8');
+    expect(receivedVars.binCount).toBe('15');
+    expect(receivedVars.layerCount).toBe('2');
+  });
+});
+
+describe('useDocumentMeta', () => {
+  beforeEach(() => {
+    resetAllStores();
+    ensureMetaTags();
+    document.title = '';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sets layout-specific meta tags when layout has a name', () => {
+    // Set up store with a named layout
+    useLayoutStore.setState({
+      layout: {
+        version: '1.0',
+        name: 'My Workshop',
+        drawer: { width: 10, depth: 8, height: 12 },
+        printBedSize: 256,
+        gridUnitMm: 42,
+        heightUnitMm: 7,
+        categories: [{ id: 'cat1', name: 'General', color: '#3b82f6' }],
+        layers: [
+          { id: 'layer1', name: 'Layer 1', height: 3 },
+          { id: 'layer2', name: 'Layer 2', height: 3 },
+        ],
+        bins: [
+          createTestBin({ id: 'b1', layerId: 'layer1' }),
+          createTestBin({ id: 'b2', layerId: 'layer1' }),
+          createTestBin({ id: 'b3', layerId: 'layer2', x: 3 }),
+        ],
+      },
+    });
+    useLibraryStore.setState({
+      library: {
+        version: '1.0',
+        activeLayoutId: 'test-layout-123',
+        settings: {},
+        entries: [],
+      },
+    });
+
+    renderHook(() => useDocumentMeta(), { wrapper: createWrapper });
+
+    expect(document.title).toBe('My Workshop | Gridfinity Layout Tool');
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toContain(
+      '10×8'
+    );
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toContain(
+      '3 bins'
+    );
+    expect(document.querySelector('meta[property="og:title"]')?.getAttribute('content')).toBe(
+      'My Workshop | Gridfinity Layout Tool'
+    );
+    expect(document.querySelector('meta[name="twitter:title"]')?.getAttribute('content')).toBe(
+      'My Workshop | Gridfinity Layout Tool'
+    );
+  });
+
+  it('excludes staging bins from count', () => {
+    useLayoutStore.setState({
+      layout: {
+        version: '1.0',
+        name: 'With Staging',
+        drawer: { width: 5, depth: 5, height: 10 },
+        printBedSize: 256,
+        gridUnitMm: 42,
+        heightUnitMm: 7,
+        categories: [{ id: 'cat1', name: 'General', color: '#3b82f6' }],
+        layers: [{ id: 'layer1', name: 'Layer 1', height: 3 }],
+        bins: [
+          createTestBin({ id: 'b1', layerId: 'layer1' }),
+          createTestBin({ id: 'staged1', layerId: STAGING_ID }),
+          createTestBin({ id: 'staged2', layerId: STAGING_ID }),
+        ],
+      },
+    });
+    useLibraryStore.setState({
+      library: {
+        version: '1.0',
+        activeLayoutId: 'test-layout-123',
+        settings: {},
+        entries: [],
+      },
+    });
+
+    renderHook(() => useDocumentMeta(), { wrapper: createWrapper });
+
+    const desc = document.querySelector('meta[name="description"]')?.getAttribute('content');
+    expect(desc).toContain('1 bins');
+  });
+
+  it('restores default meta tags when layout name is empty', () => {
+    useLayoutStore.setState({
+      layout: {
+        version: '1.0',
+        name: '',
+        drawer: { width: 10, depth: 8, height: 12 },
+        printBedSize: 256,
+        gridUnitMm: 42,
+        heightUnitMm: 7,
+        categories: [{ id: 'cat1', name: 'General', color: '#3b82f6' }],
+        layers: [{ id: 'layer1', name: 'Layer 1', height: 3 }],
+        bins: [],
+      },
+    });
+    useLibraryStore.setState({
+      library: {
+        version: '1.0',
+        activeLayoutId: 'test-layout-123',
+        settings: {},
+        entries: [],
+      },
+    });
+
+    renderHook(() => useDocumentMeta(), { wrapper: createWrapper });
+
+    expect(document.title).toContain('Gridfinity Layout Tool | Plan Your');
+  });
+
+  it('truncates long layout names at 60 characters', () => {
+    const longName = 'A'.repeat(80);
+    useLayoutStore.setState({
+      layout: {
+        version: '1.0',
+        name: longName,
+        drawer: { width: 10, depth: 8, height: 12 },
+        printBedSize: 256,
+        gridUnitMm: 42,
+        heightUnitMm: 7,
+        categories: [{ id: 'cat1', name: 'General', color: '#3b82f6' }],
+        layers: [{ id: 'layer1', name: 'Layer 1', height: 3 }],
+        bins: [],
+      },
+    });
+    useLibraryStore.setState({
+      library: {
+        version: '1.0',
+        activeLayoutId: 'test-layout-123',
+        settings: {},
+        entries: [],
+      },
+    });
+
+    renderHook(() => useDocumentMeta(), { wrapper: createWrapper });
+
+    // Title should contain truncated name (60 chars) not full 80
+    expect(document.title).toBe('A'.repeat(60) + ' | Gridfinity Layout Tool');
+  });
+
+  it('restores defaults on unmount', () => {
+    useLayoutStore.setState({
+      layout: {
+        version: '1.0',
+        name: 'My Layout',
+        drawer: { width: 10, depth: 8, height: 12 },
+        printBedSize: 256,
+        gridUnitMm: 42,
+        heightUnitMm: 7,
+        categories: [{ id: 'cat1', name: 'General', color: '#3b82f6' }],
+        layers: [{ id: 'layer1', name: 'Layer 1', height: 3 }],
+        bins: [],
+      },
+    });
+    useLibraryStore.setState({
+      library: {
+        version: '1.0',
+        activeLayoutId: 'test-layout-123',
+        settings: {},
+        entries: [],
+      },
+    });
+
+    const { unmount } = renderHook(() => useDocumentMeta(), { wrapper: createWrapper });
+
+    expect(document.title).toBe('My Layout | Gridfinity Layout Tool');
+
+    unmount();
+
+    // After unmount, defaults should be restored
+    expect(document.title).toContain('Gridfinity Layout Tool | Plan Your');
+  });
+});

--- a/src/shared/hooks/useDocumentMeta.ts
+++ b/src/shared/hooks/useDocumentMeta.ts
@@ -1,0 +1,117 @@
+/**
+ * Hook that dynamically updates document meta tags based on the active layout.
+ *
+ * Updates `document.title`, `meta[name="description"]`, Open Graph, and Twitter Card
+ * tags to reflect the current layout's name and dimensions. Falls back to generic
+ * defaults when no layout is active or the layout has no name.
+ *
+ * Should be mounted once at the App root level.
+ */
+
+import { useEffect } from 'react';
+import { useShallow } from 'zustand/shallow';
+import { useLayoutStore, useLibraryStore } from '@/core/store';
+import { getGridBins } from '@/shared/utils';
+import { useTranslation } from '@/i18n';
+import type { TFunction } from '@/i18n/context';
+
+/** Maximum length for layout name in the page title */
+const MAX_TITLE_NAME_LENGTH = 60;
+
+/**
+ * Build a layout-specific meta description string.
+ *
+ * Extracted as a pure function for testability.
+ *
+ * @param t - Translation function
+ * @param width - Drawer width in grid units
+ * @param depth - Drawer depth in grid units
+ * @param binCount - Number of bins on the grid (excluding staging)
+ * @param layerCount - Number of layers
+ */
+export function buildLayoutDescription(
+  t: TFunction,
+  width: number,
+  depth: number,
+  binCount: number,
+  layerCount: number
+): string {
+  return t('seo.layoutDescription', {
+    width: String(width),
+    depth: String(depth),
+    binCount: String(binCount),
+    layerCount: String(layerCount),
+  });
+}
+
+/** Set a meta tag's content attribute by selector. */
+function setMetaContent(selector: string, content: string): void {
+  document.querySelector(selector)?.setAttribute('content', content);
+}
+
+/** Check if the current URL is a shared layout route (/l/*). */
+function isSharedLayoutRoute(): boolean {
+  return /^\/l\//.test(window.location.pathname);
+}
+
+/** Apply title, description, and OG/Twitter meta tags to the document. */
+function applyMeta(title: string, description: string): void {
+  document.title = title;
+  setMetaContent('meta[name="description"]', description);
+  setMetaContent('meta[property="og:title"]', title);
+  setMetaContent('meta[property="og:description"]', description);
+  setMetaContent('meta[property="og:url"]', window.location.href);
+  setMetaContent('meta[name="twitter:title"]', title);
+  setMetaContent('meta[name="twitter:description"]', description);
+
+  // Shared layouts should not be indexed by search engines
+  setMetaContent('meta[name="robots"]', isSharedLayoutRoute() ? 'noindex' : 'index, follow');
+}
+
+export function useDocumentMeta(): void {
+  const t = useTranslation();
+
+  const { name, width, depth, bins, layerCount } = useLayoutStore(
+    useShallow((state) => ({
+      name: state.layout.name,
+      width: state.layout.drawer.width,
+      depth: state.layout.drawer.depth,
+      bins: state.layout.bins,
+      layerCount: state.layout.layers.length,
+    }))
+  );
+
+  const activeLayoutId = useLibraryStore((state) => state.library.activeLayoutId);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    const trimmedName = name.trim();
+
+    if (activeLayoutId && trimmedName.length > 0) {
+      const truncatedName =
+        trimmedName.length > MAX_TITLE_NAME_LENGTH
+          ? trimmedName.slice(0, MAX_TITLE_NAME_LENGTH)
+          : trimmedName;
+
+      const title = t('seo.layoutTitle', { name: truncatedName });
+      const gridBins = getGridBins(bins);
+      const description = buildLayoutDescription(t, width, depth, gridBins.length, layerCount);
+
+      applyMeta(title, description);
+    } else {
+      // Restore defaults
+      const defaultTitle = t('seo.title');
+      const defaultDescription = t('seo.description');
+      applyMeta(defaultTitle, defaultDescription);
+    }
+
+    // Cleanup: restore defaults on unmount
+    return () => {
+      if (typeof document === 'undefined') return;
+      const defaultTitle = t('seo.title');
+      const defaultDescription = t('seo.description');
+      applyMeta(defaultTitle, defaultDescription);
+    };
+  }, [t, name, width, depth, bins, layerCount, activeLayoutId]);
+}

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -24,6 +24,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "include": ["api/**/*.ts"],
+  "include": ["api/**/*.ts", "middleware.ts", "middleware-utils.ts"],
   "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- **Client-side**: New `useDocumentMeta` hook dynamically updates browser tab title, description, OG, and Twitter meta tags based on the active layout's name and dimensions. Shared layout routes (`/l/*`) get `noindex`.
- **Server-side**: Vercel Edge Middleware intercepts `/l/*` bot requests, fetches layout from Blob, and injects layout-specific OG tags into HTML so social media previews show the actual layout name and dimensions.
- Adds `seo.layoutTitle` and `seo.layoutDescription` i18n keys across all 7 locales.

## Test plan
- [x] `npm run build` passes
- [x] `npm run check:i18n` — all 1411 keys match across 7 locales
- [x] 97 new/modified tests pass across 4 test files
- [ ] Manual: open a layout → verify browser tab shows layout name
- [ ] Manual: navigate to root → verify title restores to default
- [ ] Deploy to preview, `curl -A "Twitterbot" /l/{shareId}` → verify layout-specific OG tags
- [ ] Deploy to preview, `curl -A "Mozilla/5.0" /l/{shareId}` → verify normal SPA HTML