### PR TITLE
refactor: improve Result type system with ErrorCode union and createError helper

### DIFF
--- a/src/core/result/catalog.ts
+++ b/src/core/result/catalog.ts
@@ -11,12 +11,14 @@
  * with translation keys in the future without changing error handling code.
  */
 
+import type { ErrorCode } from './errors';
+
 /**
  * Entry in the error catalog.
  */
 export interface ErrorCatalogEntry {
   /** Unique error code */
-  code: string;
+  code: ErrorCode;
   /** Default message for logging/debugging */
   defaultMessage: string;
   /** User-friendly message (if different from default) */
@@ -39,7 +41,7 @@ export interface ErrorCatalogEntry {
  * - API_*: Cloud API errors
  * - UNKNOWN_*: Fallback errors
  */
-export const ERROR_CATALOG: Record<string, ErrorCatalogEntry> = {
+export const ERROR_CATALOG: Record<ErrorCode, ErrorCatalogEntry> = {
   // ===========================================================================
   // Storage Errors
   // ===========================================================================
@@ -154,7 +156,7 @@ export const ERROR_CATALOG: Record<string, ErrorCatalogEntry> = {
   LAYOUT_LAYER_LIMIT: {
     code: 'LAYOUT_LAYER_LIMIT',
     defaultMessage: 'Maximum layer count reached',
-    userMessage: 'Cannot add more layers (max 10)',
+    userMessage: 'Cannot add more layers ({currentCount}/{maxCount})',
     recoveryHint: 'Remove unused layers',
     retryable: false,
     severity: 'warning',
@@ -163,7 +165,7 @@ export const ERROR_CATALOG: Record<string, ErrorCatalogEntry> = {
   LAYOUT_CATEGORY_LIMIT: {
     code: 'LAYOUT_CATEGORY_LIMIT',
     defaultMessage: 'Maximum category count reached',
-    userMessage: 'Cannot add more categories (max 20)',
+    userMessage: 'Cannot add more categories ({currentCount}/{maxCount})',
     recoveryHint: 'Remove unused categories',
     retryable: false,
     severity: 'warning',
@@ -172,7 +174,7 @@ export const ERROR_CATALOG: Record<string, ErrorCatalogEntry> = {
   LAYOUT_LIBRARY_LIMIT: {
     code: 'LAYOUT_LIBRARY_LIMIT',
     defaultMessage: 'Maximum layout count reached',
-    userMessage: 'Cannot add more layouts (max 100)',
+    userMessage: 'Cannot add more layouts ({currentCount}/{maxCount})',
     recoveryHint: 'Delete unused layouts',
     retryable: false,
     severity: 'warning',
@@ -329,8 +331,8 @@ export const ERROR_CATALOG: Record<string, ErrorCatalogEntry> = {
  * @param code - The error code to look up
  * @returns The catalog entry for this error
  */
-export function getErrorInfo(code: string): ErrorCatalogEntry {
-  return ERROR_CATALOG[code] || ERROR_CATALOG.UNKNOWN_ERROR;
+export function getErrorInfo(code: ErrorCode): ErrorCatalogEntry {
+  return ERROR_CATALOG[code];
 }
 
 /**
@@ -373,7 +375,7 @@ export function formatErrorMessage(
  * ```
  */
 export function getUserMessage(error: {
-  code: string;
+  code: ErrorCode;
   metadata?: Record<string, unknown>;
 }): string {
   const info = getErrorInfo(error.code);
@@ -400,7 +402,7 @@ export function getUserMessage(error: {
  * ```
  */
 export function getRecoveryHint(error: {
-  code: string;
+  code: ErrorCode;
   metadata?: Record<string, unknown>;
 }): string | undefined {
   const info = getErrorInfo(error.code);
@@ -420,7 +422,7 @@ export function getRecoveryHint(error: {
  * @param code - The error code to check
  * @returns Whether the operation can be retried
  */
-export function isRetryable(code: string): boolean {
+export function isRetryable(code: ErrorCode): boolean {
   return getErrorInfo(code).retryable;
 }
 
@@ -430,6 +432,6 @@ export function isRetryable(code: string): boolean {
  * @param code - The error code to check
  * @returns Severity level ('error', 'warning', or 'info')
  */
-export function getSeverity(code: string): 'error' | 'warning' | 'info' {
+export function getSeverity(code: ErrorCode): 'error' | 'warning' | 'info' {
   return getErrorInfo(code).severity;
 }

--- a/src/core/result/constructors.ts
+++ b/src/core/result/constructors.ts
@@ -21,6 +21,8 @@
  */
 
 import type {
+  AppError,
+  ErrorCode,
   StorageQuotaExceededError,
   StorageNotFoundError,
   StorageCorruptedError,
@@ -55,529 +57,270 @@ import type {
 import { getErrorInfo } from './catalog';
 
 // =============================================================================
-// Storage Error Constructors
+// Internal Helpers
 // =============================================================================
 
 /**
- * Create a storage quota exceeded error.
- *
- * @param usageBytes - Current storage usage in bytes
- * @param limitBytes - Storage limit in bytes
- * @param cause - Original error that caused this
+ * Build a metadata object from the given fields, filtering out undefined values.
+ * Returns undefined if no fields have values (keeps error objects clean).
  */
+function buildMetadata(fields: Record<string, unknown>): Record<string, unknown> | undefined {
+  const filtered = Object.fromEntries(Object.entries(fields).filter(([, v]) => v !== undefined));
+  return Object.keys(filtered).length > 0 ? filtered : undefined;
+}
+
+/**
+ * Generic factory for creating domain errors with auto-populated base fields.
+ * Sets kind, code, message (from catalog), and timestamp automatically.
+ */
+function createError<T extends AppError>(
+  kind: T['kind'],
+  code: ErrorCode,
+  fields?: Omit<T, 'kind' | 'code' | 'message' | 'timestamp'>
+): T {
+  return {
+    kind,
+    code,
+    message: getErrorInfo(code).defaultMessage,
+    timestamp: Date.now(),
+    ...fields,
+  } as T;
+}
+
+// =============================================================================
+// Storage Error Constructors
+// =============================================================================
+
+/** Create a storage quota exceeded error. */
 export function storageQuotaExceeded(
   usageBytes?: number,
   limitBytes?: number,
   cause?: unknown
 ): StorageQuotaExceededError {
-  return {
-    kind: 'StorageError',
-    code: 'STORAGE_QUOTA_EXCEEDED',
-    message: getErrorInfo('STORAGE_QUOTA_EXCEEDED').defaultMessage,
-    timestamp: Date.now(),
-    usageBytes,
-    limitBytes,
-    cause,
-  };
+  return createError('StorageError', 'STORAGE_QUOTA_EXCEEDED', { usageBytes, limitBytes, cause });
 }
 
-/**
- * Create a storage not found error.
- *
- * @param key - The storage key that was not found
- * @param cause - Original error that caused this
- */
+/** Create a storage not found error. */
 export function storageNotFound(key: string, cause?: unknown): StorageNotFoundError {
-  return {
-    kind: 'StorageError',
-    code: 'STORAGE_NOT_FOUND',
-    message: getErrorInfo('STORAGE_NOT_FOUND').defaultMessage,
-    timestamp: Date.now(),
+  return createError('StorageError', 'STORAGE_NOT_FOUND', {
     key,
     cause,
-  };
+    metadata: buildMetadata({ key }),
+  });
 }
 
-/**
- * Create a storage corrupted error.
- *
- * @param key - The storage key with corrupted data
- * @param validationErrors - List of validation errors
- * @param cause - Original error that caused this
- */
+/** Create a storage corrupted error. */
 export function storageCorrupted(
   key: string,
   validationErrors?: string[],
   cause?: unknown
 ): StorageCorruptedError {
-  return {
-    kind: 'StorageError',
-    code: 'STORAGE_CORRUPTED',
-    message: getErrorInfo('STORAGE_CORRUPTED').defaultMessage,
-    timestamp: Date.now(),
-    key,
-    validationErrors,
-    cause,
-  };
+  return createError('StorageError', 'STORAGE_CORRUPTED', { key, validationErrors, cause });
 }
 
-/**
- * Create a storage unavailable error.
- *
- * @param backend - Which storage backend is unavailable
- * @param cause - Original error that caused this
- */
+/** Create a storage unavailable error. */
 export function storageUnavailable(
   backend: 'localStorage' | 'indexedDB',
   cause?: unknown
 ): StorageUnavailableError {
-  return {
-    kind: 'StorageError',
-    code: 'STORAGE_UNAVAILABLE',
-    message: getErrorInfo('STORAGE_UNAVAILABLE').defaultMessage,
-    timestamp: Date.now(),
+  return createError('StorageError', 'STORAGE_UNAVAILABLE', {
     backend,
     cause,
-  };
+    metadata: buildMetadata({ backend }),
+  });
 }
 
-/**
- * Create a storage network error.
- *
- * @param cause - Original error that caused this
- */
+/** Create a storage network error. */
 export function storageNetworkError(cause?: unknown): StorageNetworkError {
-  return {
-    kind: 'StorageError',
-    code: 'STORAGE_NETWORK_ERROR',
-    message: getErrorInfo('STORAGE_NETWORK_ERROR').defaultMessage,
-    timestamp: Date.now(),
-    cause,
-  };
+  return createError('StorageError', 'STORAGE_NETWORK_ERROR', { cause });
 }
 
 // =============================================================================
 // Validation Error Constructors
 // =============================================================================
 
-/**
- * Create a validation out of bounds error.
- *
- * @param reason - Specific reason for the bounds violation
- * @param binData - The bin data that failed validation
- */
+/** Create a validation out of bounds error. */
 export function validationOutOfBounds(
   reason: ValidationFailureReason,
   binData?: { x: number; y: number; width: number; depth: number }
 ): ValidationOutOfBoundsError {
-  return {
-    kind: 'ValidationError',
-    code: 'VALIDATION_OUT_OF_BOUNDS',
-    message: getErrorInfo('VALIDATION_OUT_OF_BOUNDS').defaultMessage,
-    timestamp: Date.now(),
-    reason,
-    binData,
-  };
+  return createError('ValidationError', 'VALIDATION_OUT_OF_BOUNDS', { reason, binData });
 }
 
-/**
- * Create a validation collision error.
- *
- * @param collidingBinIds - IDs of bins that would collide
- */
+/** Create a validation collision error. */
 export function validationCollision(collidingBinIds?: string[]): ValidationCollisionError {
-  return {
-    kind: 'ValidationError',
-    code: 'VALIDATION_COLLISION',
-    message: getErrorInfo('VALIDATION_COLLISION').defaultMessage,
-    timestamp: Date.now(),
-    collidingBinIds,
-  };
+  return createError('ValidationError', 'VALIDATION_COLLISION', { collidingBinIds });
 }
 
-/**
- * Create a validation invalid layer error.
- *
- * @param layerId - The invalid layer ID
- */
+/** Create a validation invalid layer error. */
 export function validationInvalidLayer(layerId: string): ValidationInvalidLayerError {
-  return {
-    kind: 'ValidationError',
-    code: 'VALIDATION_INVALID_LAYER',
-    message: getErrorInfo('VALIDATION_INVALID_LAYER').defaultMessage,
-    timestamp: Date.now(),
-    layerId,
-  };
+  return createError('ValidationError', 'VALIDATION_INVALID_LAYER', { layerId });
 }
 
-/**
- * Create a validation height exceeded error.
- *
- * @param requested - Requested height
- * @param max - Maximum allowed height
- */
+/** Create a validation height exceeded error. */
 export function validationHeightExceeded(
   requested: number,
   max: number
 ): ValidationHeightExceededError {
-  return {
-    kind: 'ValidationError',
-    code: 'VALIDATION_HEIGHT_EXCEEDED',
-    message: getErrorInfo('VALIDATION_HEIGHT_EXCEEDED').defaultMessage,
-    timestamp: Date.now(),
+  return createError('ValidationError', 'VALIDATION_HEIGHT_EXCEEDED', {
     requested,
     max,
-  };
+    metadata: buildMetadata({ requested, max }),
+  });
 }
 
-/**
- * Create a validation blocked zone error.
- *
- * @param blockingBinIds - IDs of bins creating the blocked zone
- */
+/** Create a validation blocked zone error. */
 export function validationBlockedZone(blockingBinIds?: string[]): ValidationBlockedZoneError {
-  return {
-    kind: 'ValidationError',
-    code: 'VALIDATION_BLOCKED_ZONE',
-    message: getErrorInfo('VALIDATION_BLOCKED_ZONE').defaultMessage,
-    timestamp: Date.now(),
-    blockingBinIds,
-  };
+  return createError('ValidationError', 'VALIDATION_BLOCKED_ZONE', { blockingBinIds });
 }
 
-/**
- * Create a validation import failed error.
- *
- * @param errors - List of validation errors
- */
+/** Create a validation import failed error. */
 export function validationImportFailed(errors: string[]): ValidationImportError {
-  return {
-    kind: 'ValidationError',
-    code: 'VALIDATION_IMPORT_FAILED',
-    message: getErrorInfo('VALIDATION_IMPORT_FAILED').defaultMessage,
-    timestamp: Date.now(),
-    errors,
-  };
+  return createError('ValidationError', 'VALIDATION_IMPORT_FAILED', { errors });
 }
 
 // =============================================================================
 // Layout Error Constructors
 // =============================================================================
 
-/**
- * Create a layout layer limit error.
- *
- * @param currentCount - Current number of layers
- * @param maxCount - Maximum allowed layers
- */
+/** Create a layout layer limit error. */
 export function layoutLayerLimit(currentCount: number, maxCount: number): LayoutLayerLimitError {
-  return {
-    kind: 'LayoutError',
-    code: 'LAYOUT_LAYER_LIMIT',
-    message: getErrorInfo('LAYOUT_LAYER_LIMIT').defaultMessage,
-    timestamp: Date.now(),
+  return createError('LayoutError', 'LAYOUT_LAYER_LIMIT', {
     currentCount,
     maxCount,
-  };
+    metadata: buildMetadata({ currentCount, maxCount }),
+  });
 }
 
-/**
- * Create a layout category limit error.
- *
- * @param currentCount - Current number of categories
- * @param maxCount - Maximum allowed categories
- */
+/** Create a layout category limit error. */
 export function layoutCategoryLimit(
   currentCount: number,
   maxCount: number
 ): LayoutCategoryLimitError {
-  return {
-    kind: 'LayoutError',
-    code: 'LAYOUT_CATEGORY_LIMIT',
-    message: getErrorInfo('LAYOUT_CATEGORY_LIMIT').defaultMessage,
-    timestamp: Date.now(),
+  return createError('LayoutError', 'LAYOUT_CATEGORY_LIMIT', {
     currentCount,
     maxCount,
-  };
+    metadata: buildMetadata({ currentCount, maxCount }),
+  });
 }
 
-/**
- * Create a layout library limit error.
- *
- * @param currentCount - Current number of layouts
- * @param maxCount - Maximum allowed layouts
- */
+/** Create a layout library limit error. */
 export function layoutLibraryLimit(
   currentCount: number,
   maxCount: number
 ): LayoutLibraryLimitError {
-  return {
-    kind: 'LayoutError',
-    code: 'LAYOUT_LIBRARY_LIMIT',
-    message: getErrorInfo('LAYOUT_LIBRARY_LIMIT').defaultMessage,
-    timestamp: Date.now(),
+  return createError('LayoutError', 'LAYOUT_LIBRARY_LIMIT', {
     currentCount,
     maxCount,
-  };
+    metadata: buildMetadata({ currentCount, maxCount }),
+  });
 }
 
-/**
- * Create a layout last entity error.
- *
- * @param entityType - Type of entity that cannot be deleted
- */
+/** Create a layout last entity error. */
 export function layoutLastEntity(
   entityType: 'layer' | 'category' | 'layout'
 ): LayoutLastEntityError {
-  return {
-    kind: 'LayoutError',
-    code: 'LAYOUT_LAST_ENTITY',
-    message: getErrorInfo('LAYOUT_LAST_ENTITY').defaultMessage,
-    timestamp: Date.now(),
+  return createError('LayoutError', 'LAYOUT_LAST_ENTITY', {
     entityType,
     metadata: { entityType },
-  };
+  });
 }
 
-/**
- * Create a layout invalid operation error.
- *
- * @param operation - Name of the operation that failed
- * @param reason - Additional reason for failure
- */
+/** Create a layout invalid operation error. */
 export function layoutInvalidOperation(
   operation: string,
   reason?: string
 ): LayoutInvalidOperationError {
-  return {
-    kind: 'LayoutError',
-    code: 'LAYOUT_INVALID_OPERATION',
-    message: getErrorInfo('LAYOUT_INVALID_OPERATION').defaultMessage,
-    timestamp: Date.now(),
-    operation,
-    reason,
-  };
+  return createError('LayoutError', 'LAYOUT_INVALID_OPERATION', { operation, reason });
 }
 
 // =============================================================================
 // API Error Constructors
 // =============================================================================
 
-/**
- * Create an API rate limited error.
- *
- * @param retryAfter - Seconds until rate limit resets
- */
+/** Create an API rate limited error. */
 export function apiRateLimited(retryAfter?: number): ApiRateLimitedError {
-  return {
-    kind: 'ApiError',
-    code: 'API_RATE_LIMITED',
-    message: getErrorInfo('API_RATE_LIMITED').defaultMessage,
-    timestamp: Date.now(),
+  return createError('ApiError', 'API_RATE_LIMITED', {
     retryAfter,
-    metadata: retryAfter !== undefined ? { retryAfter } : undefined,
-  };
+    metadata: buildMetadata({ retryAfter }),
+  });
 }
 
-/**
- * Create an API unauthorized error.
- *
- * @param cause - Original error that caused this
- */
+/** Create an API unauthorized error. */
 export function apiUnauthorized(cause?: unknown): ApiUnauthorizedError {
-  return {
-    kind: 'ApiError',
-    code: 'API_UNAUTHORIZED',
-    message: getErrorInfo('API_UNAUTHORIZED').defaultMessage,
-    timestamp: Date.now(),
-    cause,
-  };
+  return createError('ApiError', 'API_UNAUTHORIZED', { cause });
 }
 
-/**
- * Create an API not found error.
- *
- * @param resourceId - ID of the resource that was not found
- */
+/** Create an API not found error. */
 export function apiNotFound(resourceId?: string): ApiNotFoundError {
-  return {
-    kind: 'ApiError',
-    code: 'API_NOT_FOUND',
-    message: getErrorInfo('API_NOT_FOUND').defaultMessage,
-    timestamp: Date.now(),
-    resourceId,
-  };
+  return createError('ApiError', 'API_NOT_FOUND', { resourceId });
 }
 
-/**
- * Create an API server error.
- *
- * @param status - HTTP status code
- * @param cause - Original error that caused this
- */
+/** Create an API server error. */
 export function apiServerError(status?: number, cause?: unknown): ApiServerError {
-  return {
-    kind: 'ApiError',
-    code: 'API_SERVER_ERROR',
-    message: getErrorInfo('API_SERVER_ERROR').defaultMessage,
-    timestamp: Date.now(),
-    status,
-    cause,
-  };
+  return createError('ApiError', 'API_SERVER_ERROR', { status, cause });
 }
 
-/**
- * Create an API network error.
- *
- * @param cause - Original error that caused this
- */
+/** Create an API network error. */
 export function apiNetworkError(cause?: unknown): ApiNetworkError {
-  return {
-    kind: 'ApiError',
-    code: 'API_NETWORK_ERROR',
-    message: getErrorInfo('API_NETWORK_ERROR').defaultMessage,
-    timestamp: Date.now(),
-    cause,
-  };
+  return createError('ApiError', 'API_NETWORK_ERROR', { cause });
 }
 
-/**
- * Create an API timeout error.
- *
- * @param cause - Original error that caused this
- */
+/** Create an API timeout error. */
 export function apiTimeout(cause?: unknown): ApiTimeoutError {
-  return {
-    kind: 'ApiError',
-    code: 'API_TIMEOUT',
-    message: getErrorInfo('API_TIMEOUT').defaultMessage,
-    timestamp: Date.now(),
-    cause,
-  };
+  return createError('ApiError', 'API_TIMEOUT', { cause });
 }
 
-/**
- * Create an API validation error.
- *
- * @param fields - Fields that failed validation
- * @param cause - Original error that caused this
- */
+/** Create an API validation error. */
 export function apiValidationError(fields?: string[], cause?: unknown): ApiValidationError {
-  return {
-    kind: 'ApiError',
-    code: 'API_VALIDATION_ERROR',
-    message: getErrorInfo('API_VALIDATION_ERROR').defaultMessage,
-    timestamp: Date.now(),
-    fields,
-    cause,
-  };
+  return createError('ApiError', 'API_VALIDATION_ERROR', { fields, cause });
 }
 
-/**
- * Create an API content blocked error.
- *
- * @param blockedFields - Fields that were blocked
- */
+/** Create an API content blocked error. */
 export function apiContentBlocked(blockedFields?: string[]): ApiContentBlockedError {
-  return {
-    kind: 'ApiError',
-    code: 'API_CONTENT_BLOCKED',
-    message: getErrorInfo('API_CONTENT_BLOCKED').defaultMessage,
-    timestamp: Date.now(),
-    blockedFields,
-  };
+  return createError('ApiError', 'API_CONTENT_BLOCKED', { blockedFields });
 }
 
-/**
- * Create an API size limit error.
- *
- * @param sizeBytes - Current size in bytes
- * @param maxBytes - Maximum allowed size in bytes
- */
+/** Create an API size limit error. */
 export function apiSizeLimit(sizeBytes?: number, maxBytes?: number): ApiSizeLimitError {
-  return {
-    kind: 'ApiError',
-    code: 'API_SIZE_LIMIT',
-    message: getErrorInfo('API_SIZE_LIMIT').defaultMessage,
-    timestamp: Date.now(),
+  return createError('ApiError', 'API_SIZE_LIMIT', {
     sizeBytes,
     maxBytes,
-  };
+    metadata: buildMetadata({ sizeBytes, maxBytes }),
+  });
 }
 
-/**
- * Create an API bin limit error.
- *
- * @param binCount - Current bin count
- * @param maxBins - Maximum allowed bins
- */
+/** Create an API bin limit error. */
 export function apiBinLimit(binCount?: number, maxBins?: number): ApiBinLimitError {
-  return {
-    kind: 'ApiError',
-    code: 'API_BIN_LIMIT',
-    message: getErrorInfo('API_BIN_LIMIT').defaultMessage,
-    timestamp: Date.now(),
+  return createError('ApiError', 'API_BIN_LIMIT', {
     binCount,
     maxBins,
-  };
+    metadata: buildMetadata({ binCount, maxBins }),
+  });
 }
 
-/**
- * Create an API expired error.
- *
- * @param shareId - ID of the expired share
- */
+/** Create an API expired error. */
 export function apiExpired(shareId?: string): ApiExpiredError {
-  return {
-    kind: 'ApiError',
-    code: 'API_EXPIRED',
-    message: getErrorInfo('API_EXPIRED').defaultMessage,
-    timestamp: Date.now(),
-    shareId,
-  };
+  return createError('ApiError', 'API_EXPIRED', { shareId });
 }
 
-/**
- * Create an API invalid expiration error.
- *
- * @param providedValue - The invalid value that was provided
- */
+/** Create an API invalid expiration error. */
 export function apiInvalidExpiration(providedValue?: number): ApiInvalidExpirationError {
-  return {
-    kind: 'ApiError',
-    code: 'API_INVALID_EXPIRATION',
-    message: getErrorInfo('API_INVALID_EXPIRATION').defaultMessage,
-    timestamp: Date.now(),
-    providedValue,
-  };
+  return createError('ApiError', 'API_INVALID_EXPIRATION', { providedValue });
 }
 
 // =============================================================================
 // Unknown Error Constructor
 // =============================================================================
 
-/**
- * Create an unknown error.
- * Use this as a fallback when wrapping unknown exceptions.
- *
- * @param cause - Original error that caused this
- */
+/** Create an unknown error. Use this as a fallback when wrapping unknown exceptions. */
 export function unknownError(cause?: unknown): UnknownError {
-  return {
-    kind: 'UnknownError',
-    code: 'UNKNOWN_ERROR',
-    message: getErrorInfo('UNKNOWN_ERROR').defaultMessage,
-    timestamp: Date.now(),
-    cause,
-  };
+  return createError('UnknownError', 'UNKNOWN_ERROR', { cause });
 }
 
 /**
  * Wrap any unknown error into a domain error.
  * Useful in try-catch blocks where the error type is unknown.
- *
- * @param error - The unknown error to wrap
- * @returns An UnknownError with the original error as cause
  *
  * @example
  * ```ts

--- a/src/core/result/errors.ts
+++ b/src/core/result/errors.ts
@@ -20,6 +20,50 @@
  * Reason codes for validation failures.
  * Matches the existing ValidationResult.reason type.
  */
+/**
+ * Union of all error codes used across domain error types.
+ * Derived from the `code` field of each error interface.
+ */
+export type ErrorCode =
+  // Storage
+  | 'STORAGE_QUOTA_EXCEEDED'
+  | 'STORAGE_NOT_FOUND'
+  | 'STORAGE_CORRUPTED'
+  | 'STORAGE_UNAVAILABLE'
+  | 'STORAGE_NETWORK_ERROR'
+  // Validation
+  | 'VALIDATION_OUT_OF_BOUNDS'
+  | 'VALIDATION_COLLISION'
+  | 'VALIDATION_INVALID_LAYER'
+  | 'VALIDATION_HEIGHT_EXCEEDED'
+  | 'VALIDATION_BLOCKED_ZONE'
+  | 'VALIDATION_IMPORT_FAILED'
+  // Layout
+  | 'LAYOUT_LAYER_LIMIT'
+  | 'LAYOUT_CATEGORY_LIMIT'
+  | 'LAYOUT_LIBRARY_LIMIT'
+  | 'LAYOUT_LAST_ENTITY'
+  | 'LAYOUT_INVALID_OPERATION'
+  // API
+  | 'API_RATE_LIMITED'
+  | 'API_UNAUTHORIZED'
+  | 'API_NOT_FOUND'
+  | 'API_SERVER_ERROR'
+  | 'API_NETWORK_ERROR'
+  | 'API_TIMEOUT'
+  | 'API_VALIDATION_ERROR'
+  | 'API_CONTENT_BLOCKED'
+  | 'API_SIZE_LIMIT'
+  | 'API_BIN_LIMIT'
+  | 'API_EXPIRED'
+  | 'API_INVALID_EXPIRATION'
+  // Generic
+  | 'UNKNOWN_ERROR';
+
+/**
+ * Reason codes for validation failures.
+ * Matches the existing ValidationResult.reason type.
+ */
 export type ValidationFailureReason =
   | 'out_of_bounds'
   | 'exceeds_width'
@@ -37,7 +81,7 @@ export interface AppError {
   /** Discriminant for the error domain (StorageError, ValidationError, etc.) */
   readonly kind: string;
   /** Unique error code from the error catalog */
-  readonly code: string;
+  readonly code: ErrorCode;
   /** Default message for logging/debugging */
   readonly message: string;
   /** Unix timestamp when the error occurred */

--- a/src/core/result/index.ts
+++ b/src/core/result/index.ts
@@ -62,19 +62,42 @@
  */
 
 // =============================================================================
-// Core Types
+// Primary API (used in production)
 // =============================================================================
 
 export type { Result, Ok, Err, Unit } from './types';
 export { ok, err, isOk, isErr, OK } from './types';
+
+export { getUserMessage, isRetryable, getErrorInfo, formatErrorMessage } from './catalog';
+
+export { tryCatchAsync, unwrapOr } from './utils';
+
+// =============================================================================
+// Extended API (available, not currently used in production)
+// =============================================================================
+
+export {
+  map,
+  mapErr,
+  flatMap,
+  andThen,
+  match,
+  unwrap,
+  unwrapErr,
+  unwrapOrElse,
+  tryCatch,
+} from './utils';
+
+export { getRecoveryHint, getSeverity, ERROR_CATALOG } from './catalog';
 
 // =============================================================================
 // Domain Error Types
 // =============================================================================
 
 export type {
-  // Base type
+  // Base type + error code union
   AppError,
+  ErrorCode,
   ValidationFailureReason,
 
   // Storage errors
@@ -122,6 +145,8 @@ export type {
   DomainError,
 } from './errors';
 
+export type { ErrorCatalogEntry } from './catalog';
+
 // =============================================================================
 // Error Constructors
 // =============================================================================
@@ -167,43 +192,3 @@ export {
   unknownError,
   fromUnknown,
 } from './constructors';
-
-// =============================================================================
-// Error Catalog
-// =============================================================================
-
-export type { ErrorCatalogEntry } from './catalog';
-export {
-  ERROR_CATALOG,
-  getErrorInfo,
-  formatErrorMessage,
-  getUserMessage,
-  getRecoveryHint,
-  isRetryable,
-  getSeverity,
-} from './catalog';
-
-// =============================================================================
-// Utility Functions
-// =============================================================================
-
-export {
-  // Transformations
-  map,
-  mapErr,
-  flatMap,
-  andThen,
-
-  // Extraction
-  unwrap,
-  unwrapOr,
-  unwrapOrElse,
-  unwrapErr,
-
-  // Pattern matching
-  match,
-
-  // Try-catch wrappers
-  tryCatch,
-  tryCatchAsync,
-} from './utils';

--- a/src/core/result/result.test.ts
+++ b/src/core/result/result.test.ts
@@ -24,14 +24,19 @@ import {
   storageNotFound,
   storageQuotaExceeded,
   storageCorrupted,
+  storageUnavailable,
   validationCollision,
   validationOutOfBounds,
+  validationHeightExceeded,
   layoutLayerLimit,
+  layoutCategoryLimit,
   layoutLibraryLimit,
   layoutLastEntity,
   apiRateLimited,
   apiNetworkError,
   apiServerError,
+  apiSizeLimit,
+  apiBinLimit,
   apiInvalidExpiration,
   unknownError,
   fromUnknown,
@@ -316,12 +321,13 @@ describe('Result utilities', () => {
 
 describe('Error constructors', () => {
   describe('Storage errors', () => {
-    it('creates storageNotFound with key', () => {
+    it('creates storageNotFound with key and metadata', () => {
       const error = storageNotFound('test-key');
       expect(error.kind).toBe('StorageError');
       expect(error.code).toBe('STORAGE_NOT_FOUND');
       expect(error.key).toBe('test-key');
       expect(error.timestamp).toBeGreaterThan(0);
+      expect(error.metadata).toEqual({ key: 'test-key' });
     });
 
     it('creates storageQuotaExceeded with usage info', () => {
@@ -335,6 +341,13 @@ describe('Error constructors', () => {
       const error = storageCorrupted('key', ['invalid field', 'missing data']);
       expect(error.code).toBe('STORAGE_CORRUPTED');
       expect(error.validationErrors).toEqual(['invalid field', 'missing data']);
+    });
+
+    it('creates storageUnavailable with backend metadata', () => {
+      const error = storageUnavailable('localStorage');
+      expect(error.code).toBe('STORAGE_UNAVAILABLE');
+      expect(error.backend).toBe('localStorage');
+      expect(error.metadata).toEqual({ backend: 'localStorage' });
     });
   });
 
@@ -352,15 +365,32 @@ describe('Error constructors', () => {
       expect(error.reason).toBe('exceeds_width');
       expect(error.binData).toEqual({ x: 5, y: 0, width: 10, depth: 2 });
     });
+
+    it('creates validationHeightExceeded with metadata', () => {
+      const error = validationHeightExceeded(15, 10);
+      expect(error.code).toBe('VALIDATION_HEIGHT_EXCEEDED');
+      expect(error.requested).toBe(15);
+      expect(error.max).toBe(10);
+      expect(error.metadata).toEqual({ requested: 15, max: 10 });
+    });
   });
 
   describe('Layout errors', () => {
-    it('creates layoutLayerLimit with counts', () => {
+    it('creates layoutLayerLimit with counts and metadata', () => {
       const error = layoutLayerLimit(10, 10);
       expect(error.kind).toBe('LayoutError');
       expect(error.code).toBe('LAYOUT_LAYER_LIMIT');
       expect(error.currentCount).toBe(10);
       expect(error.maxCount).toBe(10);
+      expect(error.metadata).toEqual({ currentCount: 10, maxCount: 10 });
+    });
+
+    it('creates layoutCategoryLimit with counts and metadata', () => {
+      const error = layoutCategoryLimit(20, 20);
+      expect(error.code).toBe('LAYOUT_CATEGORY_LIMIT');
+      expect(error.currentCount).toBe(20);
+      expect(error.maxCount).toBe(20);
+      expect(error.metadata).toEqual({ currentCount: 20, maxCount: 20 });
     });
 
     it('creates layoutLastEntity with entity type and metadata', () => {
@@ -370,23 +400,30 @@ describe('Error constructors', () => {
       expect(error.metadata).toEqual({ entityType: 'layer' });
     });
 
-    it('creates layoutLibraryLimit with counts', () => {
+    it('creates layoutLibraryLimit with counts and metadata', () => {
       const error = layoutLibraryLimit(100, 100);
       expect(error.kind).toBe('LayoutError');
       expect(error.code).toBe('LAYOUT_LIBRARY_LIMIT');
       expect(error.currentCount).toBe(100);
       expect(error.maxCount).toBe(100);
       expect(error.timestamp).toBeGreaterThan(0);
+      expect(error.metadata).toEqual({ currentCount: 100, maxCount: 100 });
     });
   });
 
   describe('API errors', () => {
-    it('creates apiRateLimited with retry info', () => {
+    it('creates apiRateLimited with retry info and metadata', () => {
       const error = apiRateLimited(60);
       expect(error.kind).toBe('ApiError');
       expect(error.code).toBe('API_RATE_LIMITED');
       expect(error.retryAfter).toBe(60);
       expect(error.metadata).toEqual({ retryAfter: 60 });
+    });
+
+    it('creates apiRateLimited without retryAfter omits metadata', () => {
+      const error = apiRateLimited();
+      expect(error.code).toBe('API_RATE_LIMITED');
+      expect(error.metadata).toBeUndefined();
     });
 
     it('creates apiNetworkError with cause', () => {
@@ -411,6 +448,22 @@ describe('Error constructors', () => {
       expect(error.code).toBe('API_SERVER_ERROR');
       expect(error.status).toBeUndefined();
       expect(error.cause).toBeUndefined();
+    });
+
+    it('creates apiSizeLimit with metadata', () => {
+      const error = apiSizeLimit(600000, 500000);
+      expect(error.code).toBe('API_SIZE_LIMIT');
+      expect(error.sizeBytes).toBe(600000);
+      expect(error.maxBytes).toBe(500000);
+      expect(error.metadata).toEqual({ sizeBytes: 600000, maxBytes: 500000 });
+    });
+
+    it('creates apiBinLimit with metadata', () => {
+      const error = apiBinLimit(3000, 2500);
+      expect(error.code).toBe('API_BIN_LIMIT');
+      expect(error.binCount).toBe(3000);
+      expect(error.maxBins).toBe(2500);
+      expect(error.metadata).toEqual({ binCount: 3000, maxBins: 2500 });
     });
 
     it('creates apiInvalidExpiration with provided value', () => {
@@ -443,6 +496,22 @@ describe('Error constructors', () => {
       expect(error.cause).toBe('string error');
     });
   });
+
+  describe('createError helper (via constructors)', () => {
+    it('auto-populates kind, code, message, and timestamp', () => {
+      const error = storageNotFound('test-key');
+      expect(error.kind).toBe('StorageError');
+      expect(error.code).toBe('STORAGE_NOT_FOUND');
+      expect(error.message).toBe('Layout not found in storage');
+      expect(error.timestamp).toBeGreaterThan(0);
+      expect(error.timestamp).toBeLessThanOrEqual(Date.now());
+    });
+
+    it('message comes from the error catalog', () => {
+      const error = layoutLayerLimit(10, 10);
+      expect(error.message).toBe('Maximum layer count reached');
+    });
+  });
 });
 
 // =============================================================================
@@ -457,9 +526,10 @@ describe('Error catalog', () => {
       expect(info.userMessage).toBe('Layout not found');
     });
 
-    it('returns UNKNOWN_ERROR for unknown code', () => {
-      const info = getErrorInfo('TOTALLY_FAKE_CODE');
+    it('returns entry for every ErrorCode', () => {
+      const info = getErrorInfo('UNKNOWN_ERROR');
       expect(info.code).toBe('UNKNOWN_ERROR');
+      expect(info.userMessage).toBe('Something went wrong');
     });
   });
 
@@ -474,6 +544,24 @@ describe('Error catalog', () => {
       const error = layoutLastEntity('layer');
       const message = getUserMessage(error);
       expect(message).toBe('Cannot delete the only layer');
+    });
+
+    it('interpolates limit metadata for layer limit', () => {
+      const error = layoutLayerLimit(10, 10);
+      const message = getUserMessage(error);
+      expect(message).toBe('Cannot add more layers (10/10)');
+    });
+
+    it('interpolates limit metadata for category limit', () => {
+      const error = layoutCategoryLimit(20, 20);
+      const message = getUserMessage(error);
+      expect(message).toBe('Cannot add more categories (20/20)');
+    });
+
+    it('interpolates limit metadata for library limit', () => {
+      const error = layoutLibraryLimit(100, 100);
+      const message = getUserMessage(error);
+      expect(message).toBe('Cannot add more layouts (100/100)');
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `ErrorCode` string literal union (28 codes) narrowing `AppError.code` from `string` for compile-time safety
- Add `createError()` factory + `buildMetadata()` helper, reducing `constructors.ts` from 595 → ~270 lines (~345 line reduction)
- Auto-populate `metadata` on 10 constructors enabling message interpolation (e.g. `"Cannot add more layers (10/10)"`)
- Narrow all catalog function signatures (`getErrorInfo`, `isRetryable`, `getSeverity`, etc.) to accept `ErrorCode`
- Reorganize `index.ts` exports into Primary API / Extended API sections

## Test plan
- [x] All 81 result module tests pass (including new tests for metadata, interpolation, createError)
- [x] All 4337 tests pass across the full suite
- [x] TypeScript compilation succeeds with narrowed types
- [x] Production build succeeds