### PR TITLE
chore: add i18n-reviewer agent and auto-format hook

### DIFF
--- a/.claude/agents/i18n-reviewer.md
+++ b/.claude/agents/i18n-reviewer.md
@@ -1,0 +1,87 @@
+---
+name: i18n-reviewer
+description: Reviews i18n usage for completeness and correctness across all locales
+model: haiku
+---
+
+You are an i18n specialist reviewing translation usage in a React + TypeScript project with en.ts as the source of truth and JSON files for other locales.
+
+## Project i18n Patterns
+
+**Source of truth**: `src/i18n/locales/en.ts` (TypeScript object)
+**Translations**: `src/i18n/locales/*.json` (6 locales)
+**Key format**: `feature.context.element` (e.g., `toast.binsDeleted`)
+**Interpolation**: `{variableName}` syntax
+
+**Gridfinity terms stay English in all locales**: bin, drawer, layer, staging/stash, grid unit, height unit, print bed, Gridfinity
+
+## Review Checklist
+
+### 1. Run Existing Checks
+
+Execute the project's i18n validation scripts:
+
+```bash
+npm run check:i18n              # Main key consistency check
+npm run check:i18n:interpolation # Verify {variable} patterns match
+npm run check:i18n:unused        # Find unused translation keys
+npm run check:i18n:values        # Check for placeholder/untranslated values
+```
+
+Report any failures with specific details.
+
+### 2. Check for Hardcoded Strings
+
+Search for common hardcoded string patterns in TSX files:
+
+```bash
+# Literal strings in JSX (excluding className, data-*, aria-*, key, id, type, role)
+grep -rn --include="*.tsx" -E ">[A-Z][a-z]+" src/ | grep -v "className" | grep -v ".test." | head -20
+```
+
+Flag any user-visible text that should use `t()`.
+
+### 3. Verify t() Usage
+
+Check that all `t()` calls reference valid keys:
+
+```bash
+# Extract t('key') patterns from TSX/TS files
+grep -rohE "t\(['\"][^'\"]+['\"]" src/ | sort -u | sed "s/t(['\"]//;s/['\"]$//" > /tmp/used-keys.txt
+
+# Compare against en.ts keys
+```
+
+### 4. Check Interpolation Consistency
+
+For any key with `{variable}` in en.ts, verify:
+
+- The same variables exist in all locale JSONs
+- No extra/missing variables in translations
+
+### 5. Report Format
+
+```
+## i18n Review Summary
+
+### Script Results
+- check:i18n: [PASS/FAIL] [details if failed]
+- check:i18n:interpolation: [PASS/FAIL]
+- check:i18n:unused: [PASS/FAIL] [count if any]
+- check:i18n:values: [PASS/FAIL]
+
+### Issues Found
+1. [file:line] Description of issue
+
+### Recommendations
+- Actionable fixes for any issues
+```
+
+## Common Issues to Flag
+
+- Missing translations in non-English locales
+- Interpolation variables don't match between locales
+- Hardcoded user-visible strings in components
+- Keys defined in en.ts but missing from JSON files
+- Unused keys that can be cleaned up
+- Placeholder text like "TODO" or copy of English in translations

--- a/.claude/hooks/auto-format.sh
+++ b/.claude/hooks/auto-format.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Auto-format hook - runs prettier on edited files
+# Trigger: PostToolUse on Edit|Write for ts/tsx/json/md/css files
+# Exit codes: 0 = always (informational only)
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Extract file path from JSON
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+
+# Skip if no file provided
+[[ -z "$FILE" ]] && exit 0
+
+# Only format supported file types
+case "$FILE" in
+  *.ts|*.tsx|*.json|*.md|*.css) ;;
+  *) exit 0 ;;
+esac
+
+# Skip node_modules, dist, coverage
+[[ "$FILE" == *node_modules* || "$FILE" == *dist/* || "$FILE" == *coverage/* ]] && exit 0
+
+# Skip if file doesn't exist (was deleted)
+[[ ! -f "$FILE" ]] && exit 0
+
+# Get project root
+PROJECT_ROOT=$(pwd)
+[[ ! -f "$PROJECT_ROOT/package.json" ]] && exit 0
+
+# Run prettier silently
+cd "$PROJECT_ROOT"
+OUTPUT=$(npx prettier --write "$FILE" 2>&1)
+EXIT_CODE=$?
+
+# Only report errors
+if [[ $EXIT_CODE -ne 0 ]]; then
+  echo "" >&2
+  echo "⚠️  Prettier formatting failed for $(basename "$FILE")" >&2
+  echo "─────────────────────────────────────" >&2
+  echo "$OUTPUT" | tail -10 >&2
+  echo "─────────────────────────────────────" >&2
+fi
+
+# Always exit 0 - PostToolUse hooks are informational
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,11 @@
             "type": "command",
             "command": ".claude/hooks/effect-cleanup-check.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/auto-format.sh",
+            "timeout": 15
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add i18n-reviewer subagent for validating translations across locales
- Add auto-format PostToolUse hook that runs Prettier after Edit/Write
- Register the hook in `.claude/settings.json`

## Test plan
- [x] Hook script is executable
- [x] Settings.json is valid JSON
- [x] Pre-commit hooks pass