### PR TITLE
fix: patch undici security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5781,9 +5781,9 @@
       }
     },
     "node_modules/@vercel/node/node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,9 @@
     ]
   },
   "overrides": {
+    "@vercel/node": {
+      "undici": "5.29.0"
+    },
     "path-to-regexp": "6.3.0",
     "workbox-build": {
       "@rollup/plugin-replace": {


### PR DESCRIPTION
## Summary
- Add npm override to upgrade `undici` from 5.28.4 to 5.29.0 for `@vercel/node`
- Fixes CVE-2025-47279 (DoS via bad certificate data) and CVE-2025-22150 (insufficiently random values)
- Targeted override preserves newer undici versions in other packages (`@vercel/blob`, `jsdom`)

## Test plan
- [x] Build passes
- [x] All 6594 tests pass
- [x] Verify `npm ls undici` shows 5.29.0 for @vercel/node