### PR TITLE
fix(generation): add mainScriptUrlOrBlob for threaded WASM module resolution

### DIFF
--- a/src/features/generation/worker/generation.worker.ts
+++ b/src/features/generation/worker/generation.worker.ts
@@ -27,10 +27,12 @@ import opencascadeSingleWasm from 'brepjs-opencascade/src/brepjs_single.wasm?url
 import opencascadeThreadedInit from 'brepjs-opencascade/src/brepjs_threaded.js';
 import opencascadeThreadedWasm from 'brepjs-opencascade/src/brepjs_threaded.wasm?url';
 import opencascadeThreadedWorker from 'brepjs-opencascade/src/brepjs_threaded.worker.js?url';
+import opencascadeThreadedJs from 'brepjs-opencascade/src/brepjs_threaded.js?url';
 
 // Emscripten module factory options (not reflected in the .d.ts)
 interface EmscriptenModuleConfig {
   locateFile?: (path: string) => string;
+  mainScriptUrlOrBlob?: string;
 }
 
 // Type assertion for Emscripten factory functions that accept config
@@ -107,6 +109,7 @@ async function initOpenCascade(): Promise<void> {
   let OC: Awaited<ReturnType<typeof opencascadeSingleInit>>;
   if (isThreaded) {
     OC = await opencascadeThreaded({
+      mainScriptUrlOrBlob: opencascadeThreadedJs,
       locateFile: (fileName: string) => {
         if (fileName.endsWith('.wasm')) {
           return opencascadeThreadedWasm;


### PR DESCRIPTION
## Summary
- Fix "Failed to fetch dynamically imported module" error for threaded WASM

## Problem
Emscripten's pthread workers need to dynamically import the main script. Without `mainScriptUrlOrBlob`, it tries to use a path that doesn't exist in the bundled output.

## Solution
- Import `brepjs_threaded.js` as URL for Emscripten to locate itself
- Add `mainScriptUrlOrBlob` to `EmscriptenModuleConfig` interface
- Pass `mainScriptUrlOrBlob` when initializing threaded OpenCascade

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run test` passes (6602 tests)
- [x] Preview server loads `/designer` without errors
- [x] Manual test: verify 3D preview generates in bin designer