### PR TITLE
feat: add flat floor (no socket) base option

### DIFF
--- a/src/features/bin-designer/components/panel/BaseSection/BaseSection.test.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/BaseSection.test.tsx
@@ -17,5 +17,23 @@ describe('BaseSection', () => {
     expect(screen.getByText('Magnet holes')).toBeInTheDocument();
     expect(screen.getByText('Screw holes')).toBeInTheDocument();
     expect(screen.getByText('Stacking lip')).toBeInTheDocument();
+    expect(screen.getByText('Flat floor (no socket)')).toBeInTheDocument();
+  });
+
+  it('disables magnet and screw toggles when flat floor is active', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' },
+      },
+    });
+
+    render(<BaseSection />);
+
+    const magnetToggle = screen.getByRole('switch', { name: 'Magnet holes' });
+    const screwToggle = screen.getByRole('switch', { name: 'Screw holes' });
+
+    expect(magnetToggle).toBeDisabled();
+    expect(screwToggle).toBeDisabled();
   });
 });

--- a/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
@@ -29,6 +29,7 @@ export function BaseSection() {
           label="Magnet holes"
           checked={state.hasMagnet}
           onChange={handlers.toggleMagnet}
+          disabledReason={handlers.flatDisabledReason}
           valueSummary={`\u00f8${state.base.magnetDiameter}mm \u00d7 ${state.base.magnetDepth}mm deep`}
         >
           <SliderInput
@@ -55,6 +56,7 @@ export function BaseSection() {
           label="Screw holes"
           checked={state.hasScrew}
           onChange={handlers.toggleScrew}
+          disabledReason={handlers.flatDisabledReason}
           valueSummary={`\u00f8${state.base.screwDiameter}mm (M${state.base.screwDiameter})`}
         >
           <SliderInput
@@ -67,6 +69,12 @@ export function BaseSection() {
             unit="mm"
           />
         </FeatureToggle>
+
+        <FeatureToggle
+          label={t('binDesigner.flatFloor')}
+          checked={state.isFlat}
+          onChange={handlers.toggleFlat}
+        />
       </div>
     </CollapsibleSection>
   );

--- a/src/features/bin-designer/components/panel/BaseSection/useBaseSection.test.ts
+++ b/src/features/bin-designer/components/panel/BaseSection/useBaseSection.test.ts
@@ -111,4 +111,112 @@ describe('useBaseSection', () => {
 
     expect(result.current.meta.summary).toBe('Standard (no attachment)');
   });
+
+  describe('flat floor', () => {
+    it('derives isFlat from base style', () => {
+      const { result } = renderHook(() => useBaseSection());
+
+      // Default: standard style, not flat
+      expect(result.current.state.isFlat).toBe(false);
+    });
+
+    it('toggleFlat sets style to flat', () => {
+      const { result } = renderHook(() => useBaseSection());
+
+      act(() => {
+        result.current.handlers.toggleFlat();
+      });
+
+      expect(useDesignerStore.getState().params.base.style).toBe('flat');
+      expect(result.current.state.isFlat).toBe(true);
+    });
+
+    it('toggleFlat off reverts to standard', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' },
+        },
+      });
+
+      const { result } = renderHook(() => useBaseSection());
+
+      act(() => {
+        result.current.handlers.toggleFlat();
+      });
+
+      expect(useDesignerStore.getState().params.base.style).toBe('standard');
+      expect(result.current.state.isFlat).toBe(false);
+    });
+
+    it('flat disables magnet and screw', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' },
+        },
+      });
+
+      const { result } = renderHook(() => useBaseSection());
+
+      expect(result.current.state.hasMagnet).toBe(false);
+      expect(result.current.state.hasScrew).toBe(false);
+      expect(result.current.handlers.flatDisabledReason).toBeDefined();
+    });
+
+    it('toggleMagnet is a no-op when flat', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' },
+        },
+      });
+
+      const { result } = renderHook(() => useBaseSection());
+
+      act(() => {
+        result.current.handlers.toggleMagnet();
+      });
+
+      expect(useDesignerStore.getState().params.base.style).toBe('flat');
+    });
+
+    it('toggleScrew is a no-op when flat', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' },
+        },
+      });
+
+      const { result } = renderHook(() => useBaseSection());
+
+      act(() => {
+        result.current.handlers.toggleScrew();
+      });
+
+      expect(useDesignerStore.getState().params.base.style).toBe('flat');
+    });
+
+    it('flatDisabledReason is undefined when not flat', () => {
+      const { result } = renderHook(() => useBaseSection());
+
+      expect(result.current.handlers.flatDisabledReason).toBeUndefined();
+    });
+
+    it('summary shows flat floor when enabled', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat', stackingLip: true },
+        },
+      });
+
+      const { result } = renderHook(() => useBaseSection());
+
+      expect(result.current.meta.summary).toContain('Flat floor');
+      expect(result.current.meta.summary).toContain('Lip');
+      expect(result.current.meta.summary).not.toContain('magnets');
+    });
+  });
 });

--- a/src/features/bin-designer/components/panel/BaseSection/useBaseSection.ts
+++ b/src/features/bin-designer/components/panel/BaseSection/useBaseSection.ts
@@ -2,10 +2,17 @@ import { useCallback, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import type { BaseStyle } from '@/features/bin-designer/types';
+import { useTranslation } from '@/i18n';
 import type { SectionMeta } from '../types';
 
-/** Derive base style from individual magnet/screw booleans */
-function computeBaseStyle(magnet: boolean, screw: boolean, currentStyle: BaseStyle): BaseStyle {
+/** Derive base style from individual magnet/screw/flat booleans */
+function computeBaseStyle(
+  magnet: boolean,
+  screw: boolean,
+  flat: boolean,
+  currentStyle: BaseStyle
+): BaseStyle {
+  if (flat) return 'flat';
   if (!magnet && !screw && currentStyle === 'weighted') return 'weighted';
   if (magnet && screw) return 'magnet_and_screw';
   if (magnet) return 'magnet';
@@ -14,6 +21,7 @@ function computeBaseStyle(magnet: boolean, screw: boolean, currentStyle: BaseSty
 }
 
 export function useBaseSection() {
+  const t = useTranslation();
   const { base, updateBase } = useDesignerStore(
     useShallow((s) => ({
       base: s.params.base,
@@ -23,20 +31,30 @@ export function useBaseSection() {
 
   const hasMagnet = base.style === 'magnet' || base.style === 'magnet_and_screw';
   const hasScrew = base.style === 'screw' || base.style === 'magnet_and_screw';
+  const isFlat = base.style === 'flat';
+
+  const flatDisabledReason = isFlat ? t('binDesigner.flatFloorDisablesAttachment') : undefined;
 
   const toggleMagnet = useCallback(() => {
+    if (isFlat) return;
     const newMagnet = !hasMagnet;
-    updateBase({ style: computeBaseStyle(newMagnet, hasScrew, base.style) });
-  }, [base.style, hasMagnet, hasScrew, updateBase]);
+    updateBase({ style: computeBaseStyle(newMagnet, hasScrew, false, base.style) });
+  }, [base.style, hasMagnet, hasScrew, isFlat, updateBase]);
 
   const toggleScrew = useCallback(() => {
+    if (isFlat) return;
     const newScrew = !hasScrew;
-    updateBase({ style: computeBaseStyle(hasMagnet, newScrew, base.style) });
-  }, [base.style, hasMagnet, hasScrew, updateBase]);
+    updateBase({ style: computeBaseStyle(hasMagnet, newScrew, false, base.style) });
+  }, [base.style, hasMagnet, hasScrew, isFlat, updateBase]);
 
   const toggleStackingLip = useCallback(() => {
     updateBase({ stackingLip: !base.stackingLip });
   }, [base.stackingLip, updateBase]);
+
+  const toggleFlat = useCallback(() => {
+    const newFlat = !isFlat;
+    updateBase({ style: computeBaseStyle(false, false, newFlat, base.style) });
+  }, [base.style, isFlat, updateBase]);
 
   const setMagnetRadius = useCallback(
     (radius: number) => {
@@ -61,23 +79,29 @@ export function useBaseSection() {
 
   const meta: SectionMeta = useMemo(() => {
     const summaryParts: string[] = [];
-    if (hasMagnet) summaryParts.push(`${base.magnetDiameter}mm magnets`);
-    if (hasScrew) summaryParts.push(`M${base.screwDiameter} screws`);
+    if (isFlat) {
+      summaryParts.push(t('binDesigner.flatFloor'));
+    } else {
+      if (hasMagnet) summaryParts.push(`${base.magnetDiameter}mm magnets`);
+      if (hasScrew) summaryParts.push(`M${base.screwDiameter} screws`);
+    }
     if (base.stackingLip) summaryParts.push('Lip');
     const summary =
       summaryParts.length > 0 ? summaryParts.join(' \u2022 ') : 'Standard (no attachment)';
     return { summary };
-  }, [hasMagnet, hasScrew, base.magnetDiameter, base.screwDiameter, base.stackingLip]);
+  }, [hasMagnet, hasScrew, isFlat, base.magnetDiameter, base.screwDiameter, base.stackingLip, t]);
 
   return {
-    state: { base, hasMagnet, hasScrew },
+    state: { base, hasMagnet, hasScrew, isFlat },
     handlers: {
       toggleMagnet,
       toggleScrew,
       toggleStackingLip,
+      toggleFlat,
       setMagnetRadius,
       setMagnetHeight,
       setScrewRadius,
+      flatDisabledReason,
     },
     meta,
   };

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -10,7 +10,7 @@
 // =============================================================================
 
 /** Base attachment style for bin-to-baseplate connection */
-export type BaseStyle = 'standard' | 'magnet' | 'screw' | 'magnet_and_screw' | 'weighted';
+export type BaseStyle = 'standard' | 'magnet' | 'screw' | 'magnet_and_screw' | 'weighted' | 'flat';
 
 /** Bin wall/style variant */
 export type BinStyle = 'standard' | 'slotted';

--- a/src/features/generation/worker/generators/binGenerator.scenario.edge-cases.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.edge-cases.test.ts
@@ -139,6 +139,34 @@ describe('edge case generation', () => {
     });
   });
 
+  describe('flat floor (no socket)', () => {
+    testParams('2x2x3 flat floor', {
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' },
+    });
+    testParams('1x1x2 flat floor', {
+      width: 1,
+      depth: 1,
+      height: 2,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' },
+    });
+    testParams('2x2x3 flat floor with stacking lip', {
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat', stackingLip: true },
+    });
+    testParams('2x2x3 flat floor without stacking lip', {
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat', stackingLip: false },
+    });
+    testParams('2x2x3 flat floor with compartments', {
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' },
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
+    });
+    testParams('0.5x0.5x2 flat floor (half-bin)', {
+      width: 0.5,
+      depth: 0.5,
+      height: 2,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' },
+    });
+  });
+
   describe('stress tests - all features combined', () => {
     testParams(
       '4x4 with everything enabled',

--- a/src/features/generation/worker/generators/binGenerator.ts
+++ b/src/features/generation/worker/generators/binGenerator.ts
@@ -902,10 +902,12 @@ export function generateBin(
 ): MeshData {
   const wallThickness = params.wallThickness;
   const totalHeight = params.height * GRIDFINITY.HEIGHT_UNIT;
+  const isFlat = params.base.style === 'flat';
   // Wall extends from socket top to bin top. Per Gridfinity spec, base is 1u (7mm),
   // but the physical socket structure is 5mm deep. Wall = total - socket depth.
+  // Flat floor: no socket, so the full height is available for the box body.
   // Total height: e.g., 3u + lip = 21 + 4.4 = 25.4mm
-  const wallHeight = totalHeight - SOCKET_HEIGHT;
+  const wallHeight = isFlat ? totalHeight : totalHeight - SOCKET_HEIGHT;
 
   const outerW = params.width * SIZE - CLEARANCE;
   const outerD = params.depth * SIZE - CLEARANCE;
@@ -913,8 +915,10 @@ export function generateBin(
   const innerD = outerD - 2 * wallThickness;
   const isSlotted = params.style === 'slotted';
 
-  const withMagnet = params.base.style === 'magnet' || params.base.style === 'magnet_and_screw';
-  const withScrew = params.base.style === 'screw' || params.base.style === 'magnet_and_screw';
+  const withMagnet =
+    !isFlat && (params.base.style === 'magnet' || params.base.style === 'magnet_and_screw');
+  const withScrew =
+    !isFlat && (params.base.style === 'screw' || params.base.style === 'magnet_and_screw');
 
   // Dynamic quality: small bins (< 4x4) get higher fidelity preview
   const cellCount = params.width * params.depth;
@@ -928,6 +932,7 @@ export function generateBin(
   const shellKey = [
     params.width,
     params.depth,
+    isFlat,
     withMagnet,
     withScrew,
     params.base.magnetDiameter,
@@ -943,41 +948,60 @@ export function generateBin(
   if (shellCache?.key === shellKey) {
     bin = shellCache.shape.clone();
   } else {
-    const base = buildBaseSocket(
-      params.width,
-      params.depth,
-      withMagnet,
-      withScrew,
-      params.base.magnetDiameter / 2,
-      params.base.magnetDepth,
-      params.base.screwDiameter / 2,
-      useHighQuality
-    );
-
     onProgress?.('shell', 0.3);
     const box = buildBinBox(params.width, params.depth, wallHeight, wallThickness);
 
-    onProgress?.('features', 0.4);
-    if (params.base.stackingLip) {
-      try {
-        const top = buildTopShape(params.width, params.depth, true).translateZ(wallHeight);
-        bin = unwrap(
-          unwrap(base.fuse(box, { optimisation: 'commonFace' })).fuse(top, {
-            optimisation: 'commonFace',
-          })
-        );
-      } catch (e) {
-        console.warn(
-          '[BinGen] Stacking lip failed, skipping:',
-          e instanceof Error ? e.message : e,
-          {
-            wallThickness,
-          }
-        );
-        bin = unwrap(base.fuse(box, { optimisation: 'commonFace' }));
+    if (isFlat) {
+      // Flat floor: no socket, box body is the entire base
+      onProgress?.('features', 0.4);
+      if (params.base.stackingLip) {
+        try {
+          const top = buildTopShape(params.width, params.depth, true).translateZ(wallHeight);
+          bin = unwrap(box.fuse(top, { optimisation: 'commonFace' }));
+        } catch (e) {
+          console.warn(
+            '[BinGen] Stacking lip failed, skipping:',
+            e instanceof Error ? e.message : e,
+            { wallThickness }
+          );
+          bin = box;
+        }
+      } else {
+        bin = box;
       }
     } else {
-      bin = unwrap(base.fuse(box, { optimisation: 'commonFace' }));
+      // Socket style: build base socket and fuse with box
+      const base = buildBaseSocket(
+        params.width,
+        params.depth,
+        withMagnet,
+        withScrew,
+        params.base.magnetDiameter / 2,
+        params.base.magnetDepth,
+        params.base.screwDiameter / 2,
+        useHighQuality
+      );
+
+      onProgress?.('features', 0.4);
+      if (params.base.stackingLip) {
+        try {
+          const top = buildTopShape(params.width, params.depth, true).translateZ(wallHeight);
+          bin = unwrap(
+            unwrap(base.fuse(box, { optimisation: 'commonFace' })).fuse(top, {
+              optimisation: 'commonFace',
+            })
+          );
+        } catch (e) {
+          console.warn(
+            '[BinGen] Stacking lip failed, skipping:',
+            e instanceof Error ? e.message : e,
+            { wallThickness }
+          );
+          bin = unwrap(base.fuse(box, { optimisation: 'commonFace' }));
+        }
+      } else {
+        bin = unwrap(base.fuse(box, { optimisation: 'commonFace' }));
+      }
     }
 
     shellCache = { key: shellKey, shape: bin };
@@ -1111,9 +1135,12 @@ export function generateBin(
     }
   }
 
-  // Stage 5: Translate so Z=0 = absolute bottom (socket bottom)
+  // Stage 5: Translate so Z=0 = absolute bottom (socket bottom).
+  // Flat floor bins are already at Z=0 — no translation needed.
   onProgress?.('merge', 0.8);
-  bin = bin.translateZ(SOCKET_HEIGHT);
+  if (!isFlat) {
+    bin = bin.translateZ(SOCKET_HEIGHT);
+  }
 
   // Stage 6: Tessellate to triangle mesh
   onProgress?.('merge', 0.9);

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -8,6 +8,8 @@
   "binDesigner.alignment.left": "Links",
   "binDesigner.alignment.right": "Rechts",
   "binDesigner.base": "Montage",
+  "binDesigner.flatFloor": "Flacher Boden (ohne Sockel)",
+  "binDesigner.flatFloorDisablesAttachment": "Nicht verfügbar mit flachem Boden",
   "binDesigner.group.shape": "Form",
   "binDesigner.group.interior": "Innenraum",
   "binDesigner.group.base": "Sockel",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1214,6 +1214,8 @@ const en: Record<string, string> = {
   'binDesigner.wallThickness.nozzleTip':
     'For best results, use a multiple of your nozzle size (e.g., 1.2mm = 3× 0.4mm nozzle)',
   'binDesigner.base': 'Mounting',
+  'binDesigner.flatFloor': 'Flat floor (no socket)',
+  'binDesigner.flatFloorDisablesAttachment': 'Not available with flat floor',
   'binDesigner.physicalUnits': 'Physical Units',
   'binDesigner.group.shape': 'Shape',
   'binDesigner.group.interior': 'Interior',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -8,6 +8,8 @@
   "binDesigner.alignment.left": "Izquierda",
   "binDesigner.alignment.right": "Derecha",
   "binDesigner.base": "Montaje",
+  "binDesigner.flatFloor": "Fondo plano (sin encaje)",
+  "binDesigner.flatFloorDisablesAttachment": "No disponible con fondo plano",
   "binDesigner.group.shape": "Forma",
   "binDesigner.group.interior": "Interior",
   "binDesigner.group.base": "Base",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -8,6 +8,8 @@
   "binDesigner.alignment.left": "Gauche",
   "binDesigner.alignment.right": "Droite",
   "binDesigner.base": "Montage",
+  "binDesigner.flatFloor": "Fond plat (sans socle)",
+  "binDesigner.flatFloorDisablesAttachment": "Non disponible avec le fond plat",
   "binDesigner.group.shape": "Forme",
   "binDesigner.group.interior": "Intérieur",
   "binDesigner.group.base": "Base",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -8,6 +8,8 @@
   "binDesigner.alignment.left": "Venstre",
   "binDesigner.alignment.right": "Høyre",
   "binDesigner.base": "Montering",
+  "binDesigner.flatFloor": "Flat bunn (uten sokkel)",
+  "binDesigner.flatFloorDisablesAttachment": "Ikke tilgjengelig med flat bunn",
   "binDesigner.group.shape": "Form",
   "binDesigner.group.interior": "Interiør",
   "binDesigner.group.base": "Base",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -8,6 +8,8 @@
   "binDesigner.alignment.left": "Links",
   "binDesigner.alignment.right": "Rechts",
   "binDesigner.base": "Montage",
+  "binDesigner.flatFloor": "Platte bodem (zonder socket)",
+  "binDesigner.flatFloorDisablesAttachment": "Niet beschikbaar met platte bodem",
   "binDesigner.group.shape": "Vorm",
   "binDesigner.group.interior": "Interieur",
   "binDesigner.group.base": "Basis",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -8,6 +8,8 @@
   "binDesigner.alignment.left": "Esquerda",
   "binDesigner.alignment.right": "Direita",
   "binDesigner.base": "Montagem",
+  "binDesigner.flatFloor": "Fundo plano (sem encaixe)",
+  "binDesigner.flatFloorDisablesAttachment": "Não disponível com fundo plano",
   "binDesigner.group.shape": "Forma",
   "binDesigner.group.interior": "Interior",
   "binDesigner.group.base": "Base",


### PR DESCRIPTION
## Summary
- Adds a new **"Flat floor (no socket)"** toggle to the bin designer's Base/Mounting section
- When enabled, the Gridfinity socket is removed entirely, producing a bin with a plain flat bottom — useful for shelves, drawers, or anywhere a baseplate isn't used
- Flat floor bins gain ~5mm of interior cavity depth since the socket no longer consumes base height

## Changes
- **Type system**: Added `'flat'` to the `BaseStyle` union type
- **UI**: New toggle (last in Base section), magnet/screw toggles disabled with explanation when flat is active
- **3D generator**: Conditional socket generation — skips `buildBaseSocket()` for flat floor, adjusts wall height and Z translation
- **i18n**: Translations added for all 7 locales (en, de, es, fr, nl, nb, pt-BR)

## Test plan
- [x] 19 unit tests pass (hook + component): toggle behavior, disabled states, guard clauses, summary text
- [x] 6 generator edge-case test scenarios added for flat floor variants
- [x] TypeScript compilation passes
- [x] i18n key parity verified (`npm run check:i18n`)
- [x] All pre-commit hooks pass (lint, boundaries, coverage, build)
- [ ] Manual: toggle flat floor on/off, verify 3D preview updates
- [ ] Manual: export flat floor bin STL, verify no socket geometry in slicer
- [ ] Manual: verify undo/redo works with flat floor toggle