### PR TITLE
feat: increase max bin dimensions from 8x8 to 16x16

### DIFF
--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.test.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.test.tsx
@@ -137,7 +137,7 @@ describe('ParameterPanel', () => {
 
     const widthInput = screen.getByLabelText('Width');
     expect(widthInput).toHaveAttribute('min', '1');
-    expect(widthInput).toHaveAttribute('max', '8');
+    expect(widthInput).toHaveAttribute('max', '16');
     expect(widthInput).toHaveAttribute('step', '1');
 
     const heightInput = screen.getByLabelText('Height');

--- a/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.test.ts
+++ b/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.test.ts
@@ -75,7 +75,7 @@ describe('useDimensionsSection', () => {
 
   it('clamps width to max dimension', () => {
     useDesignerStore.setState({
-      params: { ...DEFAULT_BIN_PARAMS, width: 8 },
+      params: { ...DEFAULT_BIN_PARAMS, width: 16 },
     });
 
     const { result } = renderHook(() => useDimensionsSection());
@@ -84,7 +84,7 @@ describe('useDimensionsSection', () => {
       result.current.handlers.handleWidthStep(1);
     });
 
-    // Should stay at 8 (MAX_DIMENSION)
-    expect(useDesignerStore.getState().params.width).toBe(8);
+    // Should stay at 16 (MAX_DIMENSION)
+    expect(useDesignerStore.getState().params.width).toBe(16);
   });
 });

--- a/src/features/bin-designer/constants/gridfinity.ts
+++ b/src/features/bin-designer/constants/gridfinity.ts
@@ -64,7 +64,7 @@ export const STYLE_WALL_THICKNESS: Record<string, number> = {
 /** Dimension constraints for bin parameters */
 export const DESIGNER_CONSTRAINTS = {
   MIN_DIMENSION: 0.5, // grid units
-  MAX_DIMENSION: 8, // grid units (expanded: standard Gridfinity supports large bins)
+  MAX_DIMENSION: 16, // grid units (expanded: standard Gridfinity supports large bins)
   DIMENSION_STEP: 0.5, // grid units
   MIN_HEIGHT: 2, // height units (1U = base only, 2U minimum for usable cavity)
   MAX_HEIGHT: 20, // height units (expanded: tall bins for tools/bottles)

--- a/src/features/bin-designer/utils/validation.test.ts
+++ b/src/features/bin-designer/utils/validation.test.ts
@@ -28,7 +28,7 @@ describe('validateBinParams', () => {
     });
 
     it('should reject width above maximum', () => {
-      const result = validateBinParams(makeParams({ width: 9 }));
+      const result = validateBinParams(makeParams({ width: 17 }));
       const error = expectErr(result);
       expect(error.code).toBe('DIMENSION_OUT_OF_RANGE');
     });
@@ -39,7 +39,7 @@ describe('validateBinParams', () => {
     });
 
     it('should reject depth above maximum', () => {
-      const result = validateBinParams(makeParams({ depth: 9 }));
+      const result = validateBinParams(makeParams({ depth: 17 }));
       expectErr(result);
     });
 
@@ -492,8 +492,8 @@ describe('validateBinParams', () => {
       expectOk(validateBinParams(makeParams({ width: 7 })));
     });
 
-    it('should accept 8-unit width (new maximum)', () => {
-      expectOk(validateBinParams(makeParams({ width: 8 })));
+    it('should accept 16-unit width (maximum)', () => {
+      expectOk(validateBinParams(makeParams({ width: 16 })));
     });
 
     it('should accept height 15', () => {
@@ -508,8 +508,8 @@ describe('validateBinParams', () => {
       expectErr(validateBinParams(makeParams({ height: 21 })));
     });
 
-    it('should reject width 8.5', () => {
-      expectErr(validateBinParams(makeParams({ width: 8.5 })));
+    it('should reject width 16.5', () => {
+      expectErr(validateBinParams(makeParams({ width: 16.5 })));
     });
   });
 });


### PR DESCRIPTION
## Summary
- Increases `DESIGNER_CONSTRAINTS.MAX_DIMENSION` from 8 to 16 grid units
- Updates all boundary-value assertions in validation, ParameterPanel, and DimensionsSection tests

## Test plan
- [x] Validation tests pass (reject at 17, accept at 16)
- [x] ParameterPanel test verifies `max="16"` attribute on width input
- [x] DimensionsSection stepper clamps correctly at 16
- [x] All 93 affected tests green