### PR TITLE
fix: allow clicking export file name to edit it directly

### DIFF
--- a/src/features/bin-designer/components/ExportDialog/ExportDialog.test.tsx
+++ b/src/features/bin-designer/components/ExportDialog/ExportDialog.test.tsx
@@ -207,6 +207,26 @@ describe('ExportDialog', () => {
     expect(screen.getByText('Custom')).toBeInTheDocument();
   });
 
+  it('switches to custom mode when clicking the file name display', () => {
+    render(<ExportDialog />);
+
+    // In descriptive mode, the file name display should be clickable
+    const nameDisplay = screen.getByRole('textbox', { name: 'Custom file name' });
+    expect(nameDisplay.tagName).toBe('SPAN');
+
+    // Click the display name
+    fireEvent.click(nameDisplay);
+
+    // Should switch to custom mode with pre-filled name
+    const config = useDesignerStore.getState().exportFileNameConfig;
+    expect(config.style).toBe('custom');
+    expect(config.customName).toBe('gridfinity_2x2x3');
+
+    // Should now show editable input
+    const input = screen.getByLabelText('Custom file name');
+    expect(input.tagName).toBe('INPUT');
+  });
+
   it('shows 3D Model section with STL export', () => {
     render(<ExportDialog />);
 

--- a/src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
+++ b/src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
@@ -169,7 +169,15 @@ export function ExportDialog() {
                   maxLength={128}
                 />
               ) : (
-                <span className="flex-1 truncate px-3 py-2 text-sm text-content">
+                <span
+                  className="flex-1 cursor-text truncate px-3 py-2 text-sm text-content"
+                  onClick={() => handleStyleChange('custom')}
+                  onFocus={() => handleStyleChange('custom')}
+                  role="textbox"
+                  tabIndex={0}
+                  aria-readonly="true"
+                  aria-label={t('binDesigner.customFileName')}
+                >
                   {fileNameWithoutExt}
                 </span>
               )}


### PR DESCRIPTION
## Summary
- Makes the file name display in the export dialog clickable — clicking or focusing it auto-switches to Custom mode with the current name pre-filled and selected
- Adds proper accessibility attributes (`role="textbox"`, `tabIndex`, `aria-readonly`) and `cursor-text` visual hint
- Custom name is preserved when switching between naming modes

## Context
Users were trying to click on the displayed file name to rename it, but nothing happened because the field was read-only in Descriptive/Compact mode. They had to explicitly find and click the "Custom" button first — a non-obvious step.

## Test plan
- [x] New unit test: clicking the file name display switches to custom mode
- [x] All 1222 existing tests pass
- [x] Build passes with no TypeScript errors
- [ ] Manual: open export dialog, click the file name text, verify it becomes editable with text selected
- [ ] Manual: type a custom name, switch to Descriptive, switch back to Custom — verify the custom name is preserved
- [ ] Manual: verify keyboard accessibility (Tab to the name, it switches to Custom mode)