### PR TITLE
chore: use percentage-based maxWorkers in vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     // Use threads pool for faster jsdom tests
     pool: 'threads',
     // CI runners have limited cores, local dev can use more
-    maxWorkers: process.env.CI ? 4 : 32,
+    maxWorkers: process.env.CI ? '50%' : '75%',
     coverage: {
       provider: 'v8',
       reporter: ['text', 'text-summary', 'html'],


### PR DESCRIPTION
## Summary
- Replace hardcoded worker counts (`4` on CI / `32` local) with percentage-based values (`50%` on CI / `75%` local)
- Makes the config portable across machines with different core counts

## Test plan
- [x] Pre-commit hooks pass (lint, i18n, boundary checks)
- [ ] CI tests pass with `50%` workers