### PR TITLE
fix: widen onRemediate prop type to accept sync callbacks

### DIFF
--- a/src/components/Modals/HalfBinModeBlockedModal/HalfBinModeBlockedModal.tsx
+++ b/src/components/Modals/HalfBinModeBlockedModal/HalfBinModeBlockedModal.tsx
@@ -7,7 +7,7 @@ interface HalfBinModeBlockedModalProps {
   isOpen: boolean;
   violation: HalfBinConstraintViolation;
   onClose: () => void;
-  onRemediate: () => Promise<void>;
+  onRemediate: () => void | Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Widen `HalfBinModeBlockedModal`'s `onRemediate` prop from `() => Promise<void>` to `() => void | Promise<void>`
- Fixes TS2322 build errors in `Sidebar.tsx` and `MobileSettingsPanel.tsx` where the sync `handleRemediate` from `useDrawerSettings` was passed to the async-only prop

## Test plan
- [x] `tsc` passes with zero errors
- [x] `HalfBinModeBlockedModal` tests pass (30 tests)
- [x] `useDrawerSettings` tests pass (37 tests)
- [x] Pre-commit hooks pass
- [ ] CI build passes