### PR TITLE
fix: align design system sizing to match production components

### DIFF
--- a/src/design-system/Button/Button.test.tsx
+++ b/src/design-system/Button/Button.test.tsx
@@ -95,6 +95,41 @@ describe('Button', () => {
     });
   });
 
+  describe('touchTarget', () => {
+    it('applies touch target class by default on iconOnly', () => {
+      render(
+        <Button iconOnly aria-label="Close">
+          X
+        </Button>
+      );
+      const button = screen.getByRole('button');
+      expect(button.className).toContain('min-h-[44px]');
+      expect(button.className).toContain('min-w-[44px]');
+    });
+
+    it('does not apply touch target on regular buttons', () => {
+      render(<Button>Click</Button>);
+      const button = screen.getByRole('button');
+      expect(button.className).not.toContain('min-h-[44px]');
+    });
+
+    it('can disable touch target on iconOnly', () => {
+      render(
+        <Button iconOnly touchTarget={false} aria-label="Close">
+          X
+        </Button>
+      );
+      const button = screen.getByRole('button');
+      expect(button.className).not.toContain('min-h-[44px]');
+    });
+
+    it('can enable touch target on regular buttons', () => {
+      render(<Button touchTarget>Click</Button>);
+      const button = screen.getByRole('button');
+      expect(button.className).toContain('min-h-[44px]');
+    });
+  });
+
   describe('ref forwarding', () => {
     it('forwards ref to button element', () => {
       const ref = vi.fn();

--- a/src/design-system/Button/Button.tsx
+++ b/src/design-system/Button/Button.tsx
@@ -6,9 +6,7 @@ import {
   focusRing,
   disabledStyles,
   interactiveTransition,
-  sizeHeights,
-  sizePaddings,
-  sizeText,
+  touchTarget,
   sizeGaps,
   variantColors,
 } from '../variants';
@@ -30,9 +28,9 @@ const buttonVariants = cva(
         danger: variantColors.danger,
       },
       size: {
-        sm: [sizeHeights.sm, sizePaddings.sm, sizeText.sm, sizeGaps.sm],
-        md: [sizeHeights.md, sizePaddings.md, sizeText.md, sizeGaps.md],
-        lg: [sizeHeights.lg, sizePaddings.lg, sizeText.lg, sizeGaps.lg],
+        sm: ['h-6', 'px-1.5', 'text-xs', sizeGaps.sm],
+        md: ['py-2', 'px-4', 'text-sm', sizeGaps.md],
+        lg: ['h-12', 'px-5', 'text-base', sizeGaps.lg],
       },
       iconOnly: {
         true: 'aspect-square !px-0 justify-center',
@@ -43,7 +41,7 @@ const buttonVariants = cva(
     },
     compoundVariants: [
       { size: 'sm', iconOnly: true, class: 'w-6' },
-      { size: 'md', iconOnly: true, class: 'w-8' },
+      { size: 'md', iconOnly: true, class: 'w-9' },
       { size: 'lg', iconOnly: true, class: 'w-12' },
     ],
     defaultVariants: {
@@ -77,6 +75,12 @@ export interface ButtonProps
    * Icon displayed after children.
    */
   rightIcon?: React.ReactNode;
+
+  /**
+   * Enforce 44px minimum touch target (Apple HIG).
+   * Defaults to `true` for iconOnly buttons, `false` otherwise.
+   */
+  touchTarget?: boolean;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -128,6 +132,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       loading,
       leftIcon,
       rightIcon,
+      touchTarget: touchTargetProp,
       className,
       children,
       disabled,
@@ -136,12 +141,17 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ref
   ) => {
     const isDisabled = disabled || loading;
+    const hasTouchTarget = touchTargetProp ?? iconOnly === true;
 
     return (
       <button
         ref={ref}
         disabled={isDisabled}
-        className={cn(buttonVariants({ variant, size, iconOnly, fullWidth }), className)}
+        className={cn(
+          buttonVariants({ variant, size, iconOnly, fullWidth }),
+          hasTouchTarget && touchTarget,
+          className
+        )}
         aria-busy={loading || undefined}
         {...props}
       >

--- a/src/design-system/Checkbox/Checkbox.tsx
+++ b/src/design-system/Checkbox/Checkbox.tsx
@@ -40,8 +40,8 @@ const labelVariants = cva(['select-none', 'transition-colors duration-100'], {
   variants: {
     size: {
       sm: 'text-xs',
-      md: 'text-sm',
-      lg: 'text-base',
+      md: 'text-xs',
+      lg: 'text-sm',
     },
     checked: {
       true: 'text-content',

--- a/src/design-system/Dialog/Dialog.tsx
+++ b/src/design-system/Dialog/Dialog.tsx
@@ -44,7 +44,7 @@ const contentVariants = cva(
   [
     'fixed z-50',
     'bg-surface-secondary',
-    'border border-stroke-subtle',
+    'border border-stroke',
     'rounded-[var(--radius-xl)]',
     'shadow-[var(--shadow-xl)]',
     'animate-scale-in',
@@ -485,7 +485,7 @@ export function ConfirmDialog({
   onCancel,
 }: ConfirmDialogProps) {
   return (
-    <DialogRoot open={isOpen} onClose={onCancel} size="sm">
+    <DialogRoot open={isOpen} onClose={onCancel} size="md">
       <DialogHeader title={title} />
       <DialogBody>
         <p className="text-sm text-content-secondary">{message}</p>

--- a/src/design-system/Input/Input.tsx
+++ b/src/design-system/Input/Input.tsx
@@ -18,8 +18,8 @@ const inputWrapperVariants = cva(
   {
     variants: {
       size: {
-        sm: 'h-8',
-        md: 'h-10',
+        sm: 'h-7',
+        md: 'py-2',
         lg: 'h-12',
       },
       error: {
@@ -48,9 +48,9 @@ const inputVariants = cva(
   {
     variants: {
       size: {
-        sm: 'px-3 text-xs',
-        md: 'px-4 text-sm',
-        lg: 'px-5 text-base',
+        sm: 'px-2 text-xs',
+        md: 'px-3 text-sm',
+        lg: 'px-4 text-base',
       },
     },
     defaultVariants: {
@@ -62,13 +62,13 @@ const inputVariants = cva(
 const iconWrapperVariants = cva(['flex-shrink-0', 'text-content-tertiary'], {
   variants: {
     size: {
-      sm: 'w-4 h-4',
-      md: 'w-5 h-5',
-      lg: 'w-6 h-6',
+      sm: 'w-3.5 h-3.5',
+      md: 'w-4 h-4',
+      lg: 'w-5 h-5',
     },
     position: {
-      left: 'ml-3',
-      right: 'mr-3',
+      left: 'ml-2',
+      right: 'mr-2',
     },
   },
   defaultVariants: {

--- a/src/design-system/Toast/Toast.tsx
+++ b/src/design-system/Toast/Toast.tsx
@@ -42,7 +42,7 @@ const toastVariants = cva(
       type: {
         success: 'bg-toast-success text-white border border-success',
         error: 'bg-toast-error text-white border border-error',
-        info: 'bg-toast-default text-content border border-stroke',
+        info: 'bg-toast-default text-on-dark border border-stroke',
       },
     },
     defaultVariants: {
@@ -165,7 +165,7 @@ function ToastItem({ toast, onDismiss, position }: ToastItemProps) {
       <Icon size="md" className="flex-shrink-0 mt-0.5" aria-hidden="true" />
 
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium">{toast.message}</p>
+        <p className="text-sm leading-relaxed whitespace-pre-wrap">{toast.message}</p>
 
         {toast.action && (
           <button
@@ -175,7 +175,7 @@ function ToastItem({ toast, onDismiss, position }: ToastItemProps) {
               handleDismiss();
             }}
             className={cn(
-              'mt-1 text-sm font-medium underline underline-offset-2',
+              'mt-2 text-sm font-medium underline underline-offset-2',
               'hover:opacity-80',
               interactiveTransition,
               ...focusRing
@@ -192,9 +192,9 @@ function ToastItem({ toast, onDismiss, position }: ToastItemProps) {
         onClick={handleDismiss}
         aria-label="Dismiss notification"
         className={cn(
-          'absolute top-2 right-2',
+          'absolute top-1/2 -translate-y-1/2 right-1 p-2',
           'flex items-center justify-center',
-          'w-6 h-6 rounded',
+          'rounded',
           'text-current opacity-60',
           'hover:opacity-100',
           interactiveTransition,

--- a/src/design-system/docs/COMPONENTS.md
+++ b/src/design-system/docs/COMPONENTS.md
@@ -10,16 +10,17 @@ Interactive element for triggering actions.
 
 ### Props
 
-| Prop        | Type                                              | Default       | Description                         |
-| ----------- | ------------------------------------------------- | ------------- | ----------------------------------- |
-| `variant`   | `'primary' \| 'secondary' \| 'ghost' \| 'danger'` | `'secondary'` | Visual style                        |
-| `size`      | `'sm' \| 'md' \| 'lg'`                            | `'md'`        | Size variant                        |
-| `loading`   | `boolean`                                         | `false`       | Shows spinner, disables interaction |
-| `leftIcon`  | `ReactNode`                                       | -             | Icon before children                |
-| `rightIcon` | `ReactNode`                                       | -             | Icon after children                 |
-| `iconOnly`  | `boolean`                                         | `false`       | Square button for icon-only use     |
-| `fullWidth` | `boolean`                                         | `false`       | Expand to full container width      |
-| `disabled`  | `boolean`                                         | `false`       | Disable interaction                 |
+| Prop          | Type                                              | Default       | Description                         |
+| ------------- | ------------------------------------------------- | ------------- | ----------------------------------- |
+| `variant`     | `'primary' \| 'secondary' \| 'ghost' \| 'danger'` | `'secondary'` | Visual style                        |
+| `size`        | `'sm' \| 'md' \| 'lg'`                            | `'md'`        | Size variant                        |
+| `loading`     | `boolean`                                         | `false`       | Shows spinner, disables interaction |
+| `leftIcon`    | `ReactNode`                                       | -             | Icon before children                |
+| `rightIcon`   | `ReactNode`                                       | -             | Icon after children                 |
+| `iconOnly`    | `boolean`                                         | `false`       | Square button for icon-only use     |
+| `fullWidth`   | `boolean`                                         | `false`       | Expand to full container width      |
+| `touchTarget` | `boolean`                                         | `iconOnly`    | 44px min touch target (Apple HIG)   |
+| `disabled`    | `boolean`                                         | `false`       | Disable interaction                 |
 
 ### Examples
 

--- a/src/design-system/docs/TOKENS.md
+++ b/src/design-system/docs/TOKENS.md
@@ -78,13 +78,36 @@ CSS variables and design tokens used throughout the design system.
 
 ## Component Size Scale
 
+### Shared scale (Select, Stepper, Collapsible, etc.)
+
 | Size | Height | Padding  | Icon  | Gap       | Maps to |
 | ---- | ------ | -------- | ----- | --------- | ------- |
 | `sm` | 24px   | `px-1.5` | 12×12 | `gap-1`   | Compact |
 | `md` | 32px   | `px-3`   | 16×16 | `gap-1.5` | Desktop |
 | `lg` | 48px   | `px-5`   | 20×20 | `gap-2.5` | Mobile  |
 
-These are defined in `variants.ts` and shared across Button, Select, Stepper, and other interactive components.
+These are defined in `variants.ts` and shared across Select, Stepper, and other interactive components.
+
+### Button (intrinsic height at md)
+
+| Size | Height   | Padding     | Icon-only | Touch target |
+| ---- | -------- | ----------- | --------- | ------------ |
+| `sm` | 24px     | `px-1.5`    | 24×24     | -            |
+| `md` | ~36px \* | `py-2 px-4` | 36×36     | 44px (icon)  |
+| `lg` | 48px     | `px-5`      | 48×48     | -            |
+
+\* `md` uses intrinsic height from `py-2` padding (~36px with `text-sm`), matching production `.btn`.
+Icon-only buttons get a 44px `touchTarget` by default (per Apple HIG).
+
+### Input (intrinsic height at md)
+
+| Size | Height   | Padding     | Icon  |
+| ---- | -------- | ----------- | ----- |
+| `sm` | 28px     | `px-2`      | 14×14 |
+| `md` | ~36px \* | `py-2 px-3` | 16×16 |
+| `lg` | 48px     | `px-4`      | 20×20 |
+
+\* `md` uses intrinsic height from `py-2` padding (~36px with `text-sm`), matching production `.input`.
 
 ## Size Tokens
 


### PR DESCRIPTION
## Summary

- **Button**: Uses intrinsic height from padding at `md` (~36px via `py-2 px-4`) instead of fixed `h-8` (32px), matching production `.btn`. Adds `touchTarget` prop (44px min per Apple HIG, defaults `true` for `iconOnly`). Icon-only `md` width updated to `w-9` (36px).
- **Input**: Wrapper `sm` → `h-7` (28px), `md` → intrinsic via `py-2` (~36px), matching production `.input`. Inner padding and icon sizes scaled down to match.
- **Checkbox**: Label text `md` → `text-xs` (was `text-sm`), `lg` → `text-sm` (was `text-base`) to match production desktop/mobile sizing.
- **Toast**: Close button vertically centered, text uses `leading-relaxed whitespace-pre-wrap`, action margin `mt-2`, info variant uses `text-on-dark`.
- **Dialog**: Border uses `border-stroke` (was `border-stroke-subtle`), ConfirmDialog uses `size="md"` (was `size="sm"`).
- **Tests**: 4 new tests for `touchTarget` prop behavior. All 139 DS tests pass.
- **Docs**: Updated TOKENS.md and COMPONENTS.md with new Button/Input size tables and `touchTarget` prop.

## Test plan

- [x] TypeScript compiles (`npm run typecheck`)
- [x] All 139 design system tests pass (`vitest run src/design-system/`)
- [x] Pre-commit hooks pass (lint, i18n, boundaries, exhaustiveness, affected tests, component structure)
- [x] Production build succeeds (`npm run build`)
- [ ] Visual review: Button md renders at ~36px (matching `.btn`)
- [ ] Visual review: Input md renders at ~36px (matching `.input`)
- [ ] Visual review: Icon-only buttons have 44px touch target
- [ ] Visual review: Toast close button is vertically centered
- [ ] Visual review: ConfirmDialog is wider (max-w-md vs max-w-sm)