### PR TITLE
test: add parametric snapshot tests for bin generation

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.snapshots.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.snapshots.test.ts.snap
@@ -28,7 +28,7 @@ exports[`base styles > 'weighted' base > 'with lip' 1`] = `612`;
 
 exports[`bin styles > 2×2 'slotted' 1`] = `1380`;
 
-exports[`bin styles > 2×2 'solid' 1`] = `1140`;
+exports[`bin styles > 2×2 'solid' 1`] = `1044`;
 
 exports[`bin styles > 2×2 'standard' 1`] = `1140`;
 

--- a/src/features/generation/worker/generators/binGenerator.scenario.snapshots.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.snapshots.test.ts
@@ -149,14 +149,14 @@ describe('base styles', () => {
 // ---------------------------------------------------------------------------
 
 describe('bin styles', () => {
-  it.each<{ style: BinStyle; label: string }>([
+  it.each<{ style: BinStyle; base?: Partial<BinParams['base']>; label: string }>([
     { style: 'standard', label: 'standard' },
     { style: 'slotted', label: 'slotted' },
-    { style: 'solid', label: 'solid' },
+    { style: 'solid', base: { solid: true }, label: 'solid' },
   ])(
     '2×2 $label',
-    ({ style }) => {
-      snapshotBin(buildParams({ style }));
+    ({ style, base }) => {
+      snapshotBin(buildParams({ style, base: { ...DEFAULT_BIN_PARAMS.base, ...base } }));
     },
     30000
   );
@@ -355,7 +355,7 @@ describe('multiple inserts', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 12. Solid bin cutouts — 7 tests (added cornerRadius, rotation, ellipse,
+// 12. Solid bin cutouts — 8 tests (added cornerRadius, rotation, ellipse,
 //     grouped, topOffset) [P1 gaps]
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds **71 triangle-count snapshot tests** covering the full parametric space of `generateBin()` to catch geometry regressions
- Uses Vitest file snapshots on `triangleCount` — deterministic, fast to diff, catches topology changes (added/removed faces)
- Lean matrix design: dimensions and base styles tested independently (not cross-product) since they don't interact architecturally
- Total runtime: ~22s with real BRep.js WASM

## Coverage matrix

| Section | Tests | What it covers |
|---------|-------|----------------|
| Dimensions | 10 | 0.5×0.5 → 4×4, fractional, ±lip |
| Base styles | 12 | standard, magnet, screw, magnet_and_screw, weighted, flat, ±lip |
| Bin styles | 3 | standard, slotted, solid |
| Height | 2 | minimum (2u), tall (10u) |
| Wall thickness | 2 | thin (0.4mm), thick (2.4mm) |
| Compartments | 4 | none, 2×2, 3×2 merged, 4×4 dense |
| Scoop | 3 | disabled, auto, fixed radius |
| Scoop + lip | 2 | single row (lip offset), multi-row (front vs interior) |
| Label tabs | 5 | disabled, bracket/solid support, left/center/right alignment |
| Inserts | 5 | all 5 shapes: circle, rounded-rect, hexagon, rectangle, slot |
| Multiple inserts | 1 | fuseAll code path |
| Solid cutouts | 8 | rectangle, circle, scoop, cornerRadius, rotation, ellipse, grouped, topOffset |
| Half-sockets | 3 | 1×1, 1.5×1.5, 2×2 |
| Slotted variations | 3 | Y-axis slots, both axes, no lip |
| Export mode | 1 | forExport=true (finer tessellation, 5-section lofts) |
| Large/asymmetric | 2 | 8×8, 0.5×4 |
| Combined features | 5 | multi-feature real-world configurations |

## Usage
```bash
# Run snapshot tests
npm run test:run -- src/features/generation/worker/generators/binGenerator.scenario.snapshots

# Update after verified geometry changes
npm run test:run -- -u src/features/generation/worker/generators/binGenerator.scenario.snapshots
```

## Test plan
- [x] All 71 snapshot tests pass
- [x] All 120 scenario tests pass (no interference with existing 4 files)
- [x] Pre-commit hooks pass (lint, i18n, boundary checks, affected tests)
- [x] TypeScript compiles without errors