### PR TITLE
feat: improve auto scoop radius with height-aware formula

### DIFF
--- a/scripts/i18n-values-allowlist.json
+++ b/scripts/i18n-values-allowlist.json
@@ -21,6 +21,8 @@
     "binDesigner.layout",
     "binDesigner.radius",
     "binDesigner.scoopRadius",
+    "binDesigner.scoopRadiusAutoRange",
+    "binDesigner.scoopRadiusAutoValue",
     "binDesigner.slotDirection",
     "binDesigner.slotHorizontal",
     "binDesigner.slotVertical",

--- a/src/features/bin-designer/components/panel/ScoopSection/ScoopSection.tsx
+++ b/src/features/bin-designer/components/panel/ScoopSection/ScoopSection.tsx
@@ -60,9 +60,7 @@ export function ScoopSection() {
                 />
               )}
               {state.isAutoRadius && (
-                <p className="text-[11px] text-content-tertiary">
-                  {t('binDesigner.scoopRadiusAuto')}
-                </p>
+                <p className="text-[11px] text-content-tertiary">{state.autoDisplayText}</p>
               )}
             </div>
           </>

--- a/src/features/bin-designer/components/panel/ScoopSection/useScoopSection.test.ts
+++ b/src/features/bin-designer/components/panel/ScoopSection/useScoopSection.test.ts
@@ -55,7 +55,7 @@ describe('useScoopSection', () => {
     expect(result.current.meta.summary).toBeUndefined();
   });
 
-  it('summary shows Auto when scoops enabled with auto radius', () => {
+  it('summary shows Auto with resolved value when scoops enabled with auto radius', () => {
     useDesignerStore.setState({
       params: {
         ...DEFAULT_BIN_PARAMS,
@@ -66,6 +66,8 @@ describe('useScoopSection', () => {
     const { result } = renderHook(() => useScoopSection());
 
     expect(result.current.meta.summary).toContain('Auto');
+    // Should include resolved radius value in mm
+    expect(result.current.meta.summary).toMatch(/\d+mm/);
   });
 
   it('summary shows radius in mm when manual', () => {
@@ -121,5 +123,55 @@ describe('useScoopSection', () => {
     });
 
     expect(useDesignerStore.getState().params.scoop.radius).toBe(15);
+  });
+
+  it('autoDisplayText shows resolved value for single compartment', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        scoop: { enabled: true, radius: 'auto' },
+      },
+    });
+
+    const { result } = renderHook(() => useScoopSection());
+
+    expect(result.current.state.autoDisplayText).toMatch(/Auto \(\d+mm\)/);
+  });
+
+  it('autoDisplayText is empty string when manual radius', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        scoop: { enabled: true, radius: 10 },
+      },
+    });
+
+    const { result } = renderHook(() => useScoopSection());
+
+    expect(result.current.state.autoDisplayText).toBe('');
+  });
+
+  it('autoDisplayText shows range for non-uniform compartments', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        width: 4,
+        depth: 2,
+        scoop: { enabled: true, radius: 'auto' },
+        compartments: {
+          cols: 2,
+          rows: 2,
+          thickness: 1.2,
+          // Row 0: one wide merged compartment (ID 0)
+          // Row 1: two narrow compartments (IDs 1 and 2)
+          cells: [0, 0, 1, 2],
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useScoopSection());
+
+    // Merged compartment is wider → may produce different radius
+    expect(result.current.state.autoDisplayText).toMatch(/Auto/);
   });
 });

--- a/src/features/bin-designer/components/panel/ScoopSection/useScoopSection.ts
+++ b/src/features/bin-designer/components/panel/ScoopSection/useScoopSection.ts
@@ -2,21 +2,96 @@ import { useCallback, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useTranslation } from '@/i18n';
+import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
+import { getCompartmentBounds } from '@/features/bin-designer/utils/compartments';
+import {
+  resolveScoopRadius,
+  computeLipOffset,
+  computeInteriorHeight,
+} from '@/shared/utils/scoopCalculations';
 import type { SectionMeta } from '../types';
 
 export function useScoopSection() {
-  const { scoop, style, updateScoop } = useDesignerStore(
-    useShallow((s) => ({
-      scoop: s.params.scoop,
-      style: s.params.style,
-      updateScoop: s.updateScoop,
-    }))
-  );
+  const { scoop, style, updateScoop, width, depth, height, wallThickness, base, compartments } =
+    useDesignerStore(
+      useShallow((s) => ({
+        scoop: s.params.scoop,
+        style: s.params.style,
+        updateScoop: s.updateScoop,
+        width: s.params.width,
+        depth: s.params.depth,
+        height: s.params.height,
+        wallThickness: s.params.wallThickness,
+        base: s.params.base,
+        compartments: s.params.compartments,
+      }))
+    );
   const t = useTranslation();
 
   const isUnavailable = style !== 'standard';
   const isAutoRadius = scoop.radius === 'auto';
   const manualRadius = typeof scoop.radius === 'number' ? scoop.radius : 10;
+
+  const autoDisplayText = useMemo(() => {
+    if (!isAutoRadius) return '';
+
+    const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+    const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+    const innerW = outerW - 2 * wallThickness;
+    const innerD = outerD - 2 * wallThickness;
+    const cellW = innerW / compartments.cols;
+    const cellD = innerD / compartments.rows;
+
+    const isFlat = base.style === 'flat';
+    const totalH = height * GRIDFINITY.HEIGHT_UNIT;
+    const wallHeight = isFlat ? totalH : totalH - GRIDFINITY.SOCKET_HEIGHT;
+    const hasLip = base.stackingLip;
+    const interiorHeight = computeInteriorHeight(wallHeight, hasLip, GRIDFINITY.LIP_SMALL_TAPER);
+    const lipTaperWidth = GRIDFINITY.LIP_SMALL_TAPER + GRIDFINITY.LIP_BIG_TAPER;
+
+    const processedCompartments = new Set<number>();
+    const radii: number[] = [];
+
+    for (let row = 0; row < compartments.rows; row++) {
+      for (let col = 0; col < compartments.cols; col++) {
+        const compId = compartments.cells[row * compartments.cols + col];
+        if (processedCompartments.has(compId)) continue;
+        processedCompartments.add(compId);
+
+        const bounds = getCompartmentBounds(compartments, compId);
+        if (!bounds) continue;
+
+        const { minCol, maxCol, minRow, maxRow } = bounds;
+        const compW = (maxCol - minCol + 1) * cellW;
+        const compD = (maxRow - minRow + 1) * cellD;
+        const isMinRow = minRow === 0;
+        const lipOffset = computeLipOffset(hasLip, isMinRow, lipTaperWidth, wallThickness);
+
+        const radius = resolveScoopRadius(
+          'auto',
+          compW,
+          compD,
+          isMinRow,
+          hasLip,
+          wallHeight,
+          interiorHeight,
+          lipOffset
+        );
+        if (radius > 0) radii.push(radius);
+      }
+    }
+
+    if (radii.length === 0) return t('binDesigner.scoopRadiusAuto');
+
+    const rounded = radii.map((r) => Math.round(r));
+    const min = Math.min(...rounded);
+    const max = Math.max(...rounded);
+
+    if (min === max) {
+      return t('binDesigner.scoopRadiusAutoValue', { value: String(min) });
+    }
+    return t('binDesigner.scoopRadiusAutoRange', { min: String(min), max: String(max) });
+  }, [isAutoRadius, width, depth, height, wallThickness, base, compartments, t]);
 
   const toggleScoop = useCallback(() => {
     updateScoop({ enabled: !scoop.enabled });
@@ -35,8 +110,8 @@ export function useScoopSection() {
 
   const sectionSummary = useMemo(() => {
     if (!scoop.enabled) return undefined;
-    return isAutoRadius ? 'Auto' : `${manualRadius}mm`;
-  }, [scoop.enabled, isAutoRadius, manualRadius]);
+    return isAutoRadius ? autoDisplayText : `${manualRadius}mm`;
+  }, [scoop.enabled, isAutoRadius, autoDisplayText, manualRadius]);
 
   const disabledReason = isUnavailable ? t('binDesigner.fingerScoopUnavailableSlotted') : undefined;
 
@@ -49,7 +124,7 @@ export function useScoopSection() {
   );
 
   return {
-    state: { scoop, isAutoRadius, manualRadius },
+    state: { scoop, isAutoRadius, manualRadius, autoDisplayText },
     handlers: { toggleScoop, toggleAutoRadius, setRadius },
     meta,
     t,

--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -22,6 +22,11 @@ import {
   scalePrintTime,
   type PrintSettings,
 } from '@/shared/printSettings';
+import {
+  resolveScoopRadius,
+  computeLipOffset,
+  computeInteriorHeight,
+} from '@/shared/utils/scoopCalculations';
 
 // ─── Result Type ─────────────────────────────────────────────────────────────
 
@@ -324,11 +329,26 @@ function computeScoopVolume(
   const colWidth = innerW / cols;
   const rowDepth = innerD / rows;
 
-  // Resolve 'auto' radius
-  const scoopRadius =
-    params.scoop.radius === 'auto'
-      ? Math.min(Math.min(colWidth, rowDepth) / 3, 15)
-      : params.scoop.radius;
+  const hasLip = params.base.stackingLip;
+  const isFlat = params.base.style === 'flat';
+  const totalH = params.height * GRIDFINITY.HEIGHT_UNIT;
+  const wallHeight = isFlat ? totalH : totalH - GRIDFINITY.SOCKET_HEIGHT;
+  const interiorHeight = computeInteriorHeight(wallHeight, hasLip, GRIDFINITY.LIP_SMALL_TAPER);
+  const lipTaperWidth = GRIDFINITY.LIP_SMALL_TAPER + GRIDFINITY.LIP_BIG_TAPER;
+
+  // Use representative compartment (single-row bins are front row, multi-row are not)
+  const isRepresentativeMinRow = rows === 1;
+  const lipOffset = computeLipOffset(hasLip, isRepresentativeMinRow, lipTaperWidth, wallThickness);
+  const scoopRadius = resolveScoopRadius(
+    params.scoop.radius,
+    colWidth,
+    rowDepth,
+    isRepresentativeMinRow,
+    hasLip,
+    wallHeight,
+    interiorHeight,
+    lipOffset
+  );
 
   const numScoops = cols * rows;
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -235,6 +235,8 @@
   "binDesigner.saving": "Speichere...",
   "binDesigner.scoopRadius": "Radius",
   "binDesigner.scoopRadiusAuto": "Automatisch (passt sich an Fachgröße an)",
+  "binDesigner.scoopRadiusAutoValue": "Auto ({value}mm)",
+  "binDesigner.scoopRadiusAutoRange": "Auto ({min}–{max}mm)",
   "binDesigner.searchDesigns": "Designs suchen…",
   "binDesigner.searchDesignsAriaLabel": "Designs suchen",
   "binDesigner.shareDesign": "Design teilen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1205,6 +1205,8 @@ const en: Record<string, string> = {
   'binDesigner.fingerScoopUnavailableSlotted': 'Not available for slotted or solid bins',
   'binDesigner.scoopRadius': 'Radius',
   'binDesigner.scoopRadiusAuto': 'Auto (adapts to compartment size)',
+  'binDesigner.scoopRadiusAutoValue': 'Auto ({value}mm)',
+  'binDesigner.scoopRadiusAutoRange': 'Auto ({min}–{max}mm)',
   'binDesigner.walls': 'Walls',
   'binDesigner.wallThickness': 'Wall thickness',
   'binDesigner.wallThickness.0.4': 'Ultra-thin, fragile—light contents only',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -235,6 +235,8 @@
   "binDesigner.saving": "Guardando...",
   "binDesigner.scoopRadius": "Radio",
   "binDesigner.scoopRadiusAuto": "Automático (se adapta al tamaño del compartimento)",
+  "binDesigner.scoopRadiusAutoValue": "Auto ({value}mm)",
+  "binDesigner.scoopRadiusAutoRange": "Auto ({min}–{max}mm)",
   "binDesigner.searchDesigns": "Buscar diseños...",
   "binDesigner.searchDesignsAriaLabel": "Buscar diseños",
   "binDesigner.shareDesign": "Compartir Diseño",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -235,6 +235,8 @@
   "binDesigner.saving": "Enregistrement...",
   "binDesigner.scoopRadius": "Rayon",
   "binDesigner.scoopRadiusAuto": "Automatique (s'adapte à la taille du compartiment)",
+  "binDesigner.scoopRadiusAutoValue": "Auto ({value}mm)",
+  "binDesigner.scoopRadiusAutoRange": "Auto ({min}–{max}mm)",
   "binDesigner.searchDesigns": "Rechercher des designs…",
   "binDesigner.searchDesignsAriaLabel": "Rechercher des designs",
   "binDesigner.shareDesign": "Partager le Design",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -235,6 +235,8 @@
   "binDesigner.saving": "Lagrer...",
   "binDesigner.scoopRadius": "Radius",
   "binDesigner.scoopRadiusAuto": "Automatisk (tilpasser seg romstørrelse)",
+  "binDesigner.scoopRadiusAutoValue": "Auto ({value}mm)",
+  "binDesigner.scoopRadiusAutoRange": "Auto ({min}–{max}mm)",
   "binDesigner.searchDesigns": "Søk etter design…",
   "binDesigner.searchDesignsAriaLabel": "Søk etter design",
   "binDesigner.shareDesign": "Del design",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -235,6 +235,8 @@
   "binDesigner.saving": "Opslaan...",
   "binDesigner.scoopRadius": "Radius",
   "binDesigner.scoopRadiusAuto": "Automatisch (past zich aan aan vakmaat)",
+  "binDesigner.scoopRadiusAutoValue": "Auto ({value}mm)",
+  "binDesigner.scoopRadiusAutoRange": "Auto ({min}–{max}mm)",
   "binDesigner.searchDesigns": "Ontwerpen zoeken…",
   "binDesigner.searchDesignsAriaLabel": "Ontwerpen zoeken",
   "binDesigner.shareDesign": "Design delen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -235,6 +235,8 @@
   "binDesigner.saving": "Salvando...",
   "binDesigner.scoopRadius": "Raio",
   "binDesigner.scoopRadiusAuto": "Automático (adapta-se ao tamanho do compartimento)",
+  "binDesigner.scoopRadiusAutoValue": "Auto ({value}mm)",
+  "binDesigner.scoopRadiusAutoRange": "Auto ({min}–{max}mm)",
   "binDesigner.searchDesigns": "Buscar designs…",
   "binDesigner.searchDesignsAriaLabel": "Buscar designs",
   "binDesigner.shareDesign": "Compartilhar Design",

--- a/src/shared/utils/scoopCalculations.test.ts
+++ b/src/shared/utils/scoopCalculations.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import { resolveScoopRadius, computeLipOffset, computeInteriorHeight } from './scoopCalculations';
+
+describe('resolveScoopRadius', () => {
+  // Common test parameters
+  const wallHeight = 16; // 3U bin (3*7 - 5 socket)
+  const interiorHeight = 15.3; // wallHeight - LIP_SMALL_TAPER (0.7)
+  const lipOffset = 0;
+
+  describe('auto mode', () => {
+    it('uses min(minDim/3, ...) for typical compartments', () => {
+      // 1x1 bin: compW ≈ 39mm, compD ≈ 39mm → minDim/3 = 13
+      const radius = resolveScoopRadius('auto', 39, 39, true, false, wallHeight, interiorHeight, 0);
+      expect(radius).toBeCloseTo(13, 0);
+    });
+
+    it('caps at 15mm when wallHeight * 0.5 < 15', () => {
+      // Large compartment (4x4 single) but short bin (3U, wallHeight=16)
+      // minDim/3 = 164/3 = 54.7, max(15, 16*0.5) = max(15, 8) = 15
+      const radius = resolveScoopRadius(
+        'auto',
+        164,
+        164,
+        true,
+        false,
+        wallHeight,
+        interiorHeight,
+        0
+      );
+      expect(radius).toBe(15);
+    });
+
+    it('allows larger radius for tall bins via height-aware cap', () => {
+      // 4x4 single compartment, 10U bin (wallHeight ≈ 65mm)
+      // minDim/3 = 54.7, max(15, 65*0.5) = 32.5
+      const tallWallHeight = 65;
+      const tallInteriorHeight = 64.3;
+      const radius = resolveScoopRadius(
+        'auto',
+        164,
+        164,
+        true,
+        false,
+        tallWallHeight,
+        tallInteriorHeight,
+        0
+      );
+      expect(radius).toBeCloseTo(32.5, 0);
+    });
+
+    it('preserves at least 2/3 of depth (compD/3 constraint)', () => {
+      // compD/3 acts alongside minDim/3. When compD < compW, minDim = compD.
+      // 20mm depth, 100mm width → minDim/3 = 6.7, compD/3 = 6.7 (same)
+      const radius = resolveScoopRadius(
+        'auto',
+        100,
+        20,
+        true,
+        false,
+        wallHeight,
+        interiorHeight,
+        0
+      );
+      expect(radius).toBeCloseTo(6.67, 1);
+    });
+
+    it('returns 0 for compartments too small for a scoop', () => {
+      // Very small compartment: minDim/3 = 0.5 < 1mm threshold
+      const radius = resolveScoopRadius(
+        'auto',
+        1.5,
+        1.5,
+        true,
+        false,
+        wallHeight,
+        interiorHeight,
+        0
+      );
+      expect(radius).toBe(0);
+    });
+
+    it('increases auto radius to wallHeight for front-row scoops with lip', () => {
+      // Front row (isMinRow=true) with lip: max(base, wallHeight)
+      const radius = resolveScoopRadius(
+        'auto',
+        39,
+        39,
+        true,
+        true,
+        wallHeight,
+        interiorHeight,
+        1.4
+      );
+      // Base = min(13, 15, 13) = 13, but with lip: max(13, 16) = 16
+      // Clamped by min(16, 39-0.5-1.4, 16) = 16
+      expect(radius).toBe(wallHeight);
+    });
+
+    it('does not increase radius for interior rows even with lip', () => {
+      // Interior row: lip alignment does not apply
+      const radius = resolveScoopRadius('auto', 39, 39, false, true, wallHeight, interiorHeight, 0);
+      // min(13, 15, 13) = 13, no lip boost for interior rows
+      expect(radius).toBeCloseTo(13, 0);
+    });
+  });
+
+  describe('manual mode', () => {
+    it('uses the provided radius value', () => {
+      const radius = resolveScoopRadius(10, 39, 39, true, false, wallHeight, interiorHeight, 0);
+      expect(radius).toBe(10);
+    });
+
+    it('clamps to compartment depth', () => {
+      // Radius 20mm but compartment only 15mm deep
+      const radius = resolveScoopRadius(
+        20,
+        39,
+        15,
+        true,
+        false,
+        wallHeight,
+        interiorHeight,
+        lipOffset
+      );
+      expect(radius).toBe(14.5); // 15 - 0.5
+    });
+
+    it('clamps to wall height for front row', () => {
+      const radius = resolveScoopRadius(25, 100, 100, true, false, wallHeight, interiorHeight, 0);
+      expect(radius).toBe(wallHeight);
+    });
+
+    it('clamps to interior height for non-front rows', () => {
+      const radius = resolveScoopRadius(25, 100, 100, false, true, wallHeight, interiorHeight, 0);
+      expect(radius).toBe(interiorHeight);
+    });
+
+    it('returns 0 when clamped below 1mm', () => {
+      // compD - 0.5 = 1 - 0.5 = 0.5 < 1mm threshold → returns 0
+      const radius = resolveScoopRadius(5, 2, 1, true, false, wallHeight, interiorHeight, 0);
+      expect(radius).toBe(0);
+    });
+  });
+});
+
+describe('computeLipOffset', () => {
+  it('returns offset for front row with lip', () => {
+    const offset = computeLipOffset(true, true, 2.6, 1.2);
+    expect(offset).toBeCloseTo(1.4, 1);
+  });
+
+  it('returns 0 for interior rows', () => {
+    expect(computeLipOffset(true, false, 2.6, 1.2)).toBe(0);
+  });
+
+  it('returns 0 when no lip', () => {
+    expect(computeLipOffset(false, true, 2.6, 1.2)).toBe(0);
+  });
+
+  it('returns 0 when wall is thicker than lip taper', () => {
+    expect(computeLipOffset(true, true, 2.0, 3.0)).toBe(0);
+  });
+});
+
+describe('computeInteriorHeight', () => {
+  it('subtracts lip taper when lip is present', () => {
+    expect(computeInteriorHeight(16, true, 0.7)).toBeCloseTo(15.3, 1);
+  });
+
+  it('returns full wall height without lip', () => {
+    expect(computeInteriorHeight(16, false, 0.7)).toBe(16);
+  });
+});

--- a/src/shared/utils/scoopCalculations.ts
+++ b/src/shared/utils/scoopCalculations.ts
@@ -9,7 +9,8 @@
 /**
  * Resolve scoop radius for a compartment.
  *
- * Auto mode: min(smallerDim/3, 15mm), clamped to fit compartment and height.
+ * Auto mode: min(smallerDim/3, max(15, wallHeight*0.5), compD/3),
+ * clamped to fit compartment depth and wall height.
  * Manual mode: clamped to fit compartment and height.
  *
  * For front-row scoops with a stacking lip, auto radius is increased to reach
@@ -38,7 +39,11 @@ export function resolveScoopRadius(
   const minDim = Math.min(compW, compD);
   let radius: number;
   if (scoopRadius === 'auto') {
-    radius = Math.min(minDim / 3, 15);
+    // Three-factor balance: curvature, usability, volume
+    //  - minDim/3: radius proportional to compartment size (curvature)
+    //  - max(15, wallHeight*0.5): height-aware cap for tall bins (usability)
+    //  - compD/3: preserve ≥2/3 of depth for storage (volume)
+    radius = Math.min(minDim / 3, Math.max(15, wallHeight * 0.5), compD / 3);
   } else {
     radius = scoopRadius;
   }


### PR DESCRIPTION
## Summary

- **Smarter auto formula**: Replace fixed 15mm cap with three-factor balance — `min(minDim/3, max(15, wallHeight*0.5), compD/3)` — so taller bins get proportionally larger scoops while preserving ≥2/3 of compartment depth for storage
- **Show resolved radius in UI**: Auto mode now displays the computed value ("Auto (12mm)" or "Auto (8–15mm)" for non-uniform compartments) instead of generic text
- **Fix print estimate drift**: Replace inline simplified formula in `computeScoopVolume()` with shared `resolveScoopRadius()` so estimates match actual generated geometry

### Formula behavior

| Bin Config | Previous Auto | New Auto | Change |
|---|---|---|---|
| 1×1×3 (typical) | 13mm | 13mm | Same |
| 2×2 single, 6U | 15mm (capped) | 18.5mm | +3.5mm |
| 4×4 single, 10U | 15mm (capped) | 32.5mm | +17.5mm |
| 0.5×0.5, 2U (tiny) | 6.3mm | 6.3mm | Same |

## Test plan

- [x] 18 new unit tests for `scoopCalculations.ts` (auto formula, manual mode, clamping, lip alignment)
- [x] 3 new tests for `useScoopSection` hook (auto display text, range format, manual fallback)
- [x] All 1334 bin-designer tests passing, zero regressions
- [x] TypeScript, ESLint, i18n checks clean
- [ ] Visual verification: auto display text renders correctly in scoop section
- [ ] Visual verification: tall bin (10U) generates larger scoop than before