### PR TITLE
chore: upgrade brepjs from v7 to v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@vercel/analytics": "^1.6.1",
         "@vercel/blob": "^2.0.0",
         "ai": "^6.0.49",
-        "brepjs": "^7.2.0",
+        "brepjs": "^8.0.0",
         "brepjs-opencascade": "^0.7.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -7326,9 +7326,9 @@
       }
     },
     "node_modules/brepjs": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/brepjs/-/brepjs-7.2.0.tgz",
-      "integrity": "sha512-EPmAKMSO+ma1xPxuGFuNLL0bWTQ7vs06F+GT+pias7Hs0P8NkBh2nEispEc0L1aQR6h9TJksa6yq+/QPUm6HHg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/brepjs/-/brepjs-8.0.0.tgz",
+      "integrity": "sha512-JolocWTKhSxS4Nm80EUymD3B4FPmEghi9S0BRE2YpOQ0R2HnFJjqglYHhyvZ8qMFJvGpnJRj7Iq3E76iNeSyAg==",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -10467,6 +10467,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -10790,6 +10791,7 @@
       "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -12704,7 +12706,6 @@
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -13741,6 +13742,7 @@
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -15545,6 +15547,7 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@vercel/analytics": "^1.6.1",
     "@vercel/blob": "^2.0.0",
     "ai": "^6.0.49",
-    "brepjs": "^7.2.0",
+    "brepjs": "^8.0.0",
     "brepjs-opencascade": "^0.7.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- Upgrades `brepjs` from `^7.2.0` to `^8.0.0`
- v8 removes deprecated legacy type aliases (`*Config` → `*Options`), legacy blueprint function aliases, and the `around` revolve option — none of which were used in this codebase
- No code changes required; clean version bump

## Test plan
- [x] TypeScript typecheck passes
- [x] All 230 generation tests pass
- [x] Production build succeeds
- [x] Pre-commit hooks pass (lint-staged, i18n, boundaries, exhaustiveness)