### PR TITLE
refactor: graduate bin designer out of labs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ import { useTranslation } from '@/i18n';
 import { CommandPalette, useCommandPalette } from '@/features/command-palette';
 import { useOnboarding } from '@/features/onboarding/hooks/useOnboarding';
 
-// Lazy load design-linking dialogs - only needed when bin_designer feature is enabled
+// Lazy load design-linking dialogs - loaded when mutations provider wraps content
 const DesignLinkingDialogs = lazyWithRetry(() =>
   import('./features/design-linking/components/DesignLinkingDialogs').then(
     namedExport('DesignLinkingDialogs')
@@ -151,8 +151,7 @@ export default function App() {
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isMobileHelpOpen, setIsMobileHelpOpen] = useState(false);
 
-  // Bin Designer route detection (behind feature flag)
-  const isDesignerEnabled = useLabsStore((state) => state.isFeatureEnabled('bin_designer'));
+  // Bin Designer route detection
   const { isDesignerRoute, navigateToDesigner } = useDesignerRouting();
 
   // Command palette state (⌘K / Ctrl+K) — disabled on designer route
@@ -293,10 +292,10 @@ export default function App() {
 
   // Download layout command palette action
   useEffect(() => {
-    const handleDownloadLayout = async () => {
+    const handleDownloadLayout = () => {
       const layout = useLayoutStore.getState().layout;
       const filename = `${layout.name.replace(/[^a-z0-9]/gi, '-').toLowerCase()}.json`;
-      await downloadLayoutAsFile(layout, filename);
+      void downloadLayoutAsFile(layout, filename);
     };
     window.addEventListener('download-layout', handleDownloadLayout);
     return () => window.removeEventListener('download-layout', handleDownloadLayout);
@@ -307,11 +306,11 @@ export default function App() {
   // - Local mode: LocalMutationsProvider
   // Also renders DesignLinkingDialogs once (uses portal, so placement doesn't matter)
   const wrapWithMutations = (content: React.ReactNode) => {
-    const dialogs = isDesignerEnabled ? (
+    const dialogs = (
       <Suspense fallback={null}>
         <DesignLinkingDialogs />
       </Suspense>
-    ) : null;
+    );
     if (isCollaborative && shareId) {
       return (
         <Suspense fallback={<LoadingFallback label={t('loading.collaboration')} />}>
@@ -378,8 +377,8 @@ export default function App() {
 
   // Route-specific content (shared overlays rendered once below)
   const routeContent = (() => {
-    // Bin Designer route - lazy loaded, behind feature flag
-    if (isDesignerRoute && isDesignerEnabled) {
+    // Bin Designer route - lazy loaded
+    if (isDesignerRoute) {
       return (
         <Suspense fallback={<LoadingFallback label={t('loading.designer')} />}>
           <DesignerPage />

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -78,10 +78,10 @@ describe('Header', () => {
   });
 
   describe('rendering', () => {
-    it('renders app title', () => {
+    it('renders tool switcher', () => {
       render(<Header {...defaultProps} />);
 
-      expect(screen.getByText('Gridfinity Layout Tool')).toBeInTheDocument();
+      expect(screen.getByRole('tablist')).toBeInTheDocument();
     });
 
     it('renders layout name', () => {

--- a/src/components/Mobile/BinContextMenu/BinContextMenu.test.tsx
+++ b/src/components/Mobile/BinContextMenu/BinContextMenu.test.tsx
@@ -29,10 +29,6 @@ vi.mock('@/hooks/useContextMenu', () => ({
   useContextMenu: () => ({ menuRef: { current: null } }),
 }));
 
-vi.mock('@/hooks/useFeatureFlag', () => ({
-  useFeatureFlag: () => false,
-}));
-
 vi.mock('@/shared/hooks', () => ({
   useResponsive: () => ({ isDesktop: false, isMobile: true }),
 }));

--- a/src/components/Mobile/BinContextMenu/BinContextMenu.tsx
+++ b/src/components/Mobile/BinContextMenu/BinContextMenu.tsx
@@ -15,10 +15,9 @@ import { mlTracking } from '@/shared/analytics/useMLTracking';
 import { findBinById } from '@/utils/entity';
 import { isOk } from '@/core/result';
 import { useTranslation } from '@/i18n';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import type { Bin } from '@/core/types';
 
-// Lazy load design-linking section - only needed when bin_designer feature is enabled
+// Lazy load design-linking section
 const BinContextMenuDesignSection = lazy(() =>
   import('../BinContextMenuDesignSection').then((m) => ({
     default: m.BinContextMenuDesignSection,
@@ -62,9 +61,6 @@ export function BinContextMenu({ bin, position, onClose, source }: BinContextMen
 
   const { execute } = useUndoableAction();
   const { isDesktop } = useResponsive();
-
-  // Design linking - requires Bin Designer feature flag
-  const isDesignerEnabled = useFeatureFlag('bin_designer');
 
   const handleDelete = () => {
     // Track deletion BEFORE executing (need bin data)
@@ -245,12 +241,10 @@ export function BinContextMenu({ bin, position, onClose, source }: BinContextMen
 
         <ContextMenuDivider />
 
-        {/* Design Linking Actions - requires Bin Designer feature flag */}
-        {isDesignerEnabled && (
-          <Suspense fallback={null}>
-            <BinContextMenuDesignSection bin={bin} onClose={onClose} />
-          </Suspense>
-        )}
+        {/* Design Linking Actions */}
+        <Suspense fallback={null}>
+          <BinContextMenuDesignSection bin={bin} onClose={onClose} />
+        </Suspense>
 
         <ContextMenuItem
           icon={

--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -13,14 +13,11 @@ export const FEATURE_FLAGS = [
     name: 'Bin Designer',
     description:
       'Create custom parametric Gridfinity bins with a visual designer. Configure dimensions, compartments, magnet/screw holes, and export STL or 3MF files for 3D printing.',
-    status: 'experimental',
+    status: 'graduated',
     risk: 'medium',
-    warning:
-      'This feature is experimental. The CAD engine runs in a Web Worker and may use significant memory.',
     addedAt: '2026-01',
+    graduatedAt: '2026-02',
     requiresRefresh: false,
-    comingSoon: false,
-    defaultEnabled: true,
   },
   {
     id: 'collaborative_editing',

--- a/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
+++ b/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
@@ -8,10 +8,9 @@ import { StepperControl } from '@/shared/components/StepperControl';
 import { SelectDropdown } from '@/shared/components/SelectDropdown';
 import { CustomPropertiesEditor } from '../CustomPropertiesEditor';
 import { STLSearchDropdown } from '@/components/STLSearchDropdown';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useTranslation } from '@/i18n';
 
-// Lazy load LinkedDesignSection - only needed when bin_designer feature is enabled
+// Lazy load LinkedDesignSection
 const LinkedDesignSection = lazy(() =>
   import('@/features/design-linking/components/LinkedDesignSection').then((m) => ({
     default: m.LinkedDesignSection,
@@ -49,7 +48,6 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
   } = inspector;
 
   const halfBinMode = useUIStore((state) => state.halfBinMode);
-  const isDesignerEnabled = useFeatureFlag('bin_designer');
   const t = useTranslation();
 
   if (!bin) return null;
@@ -308,12 +306,10 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
           className="w-full justify-center py-2 rounded-lg bg-surface-elevated/50 hover:bg-surface-hover border border-stroke-subtle"
         />
 
-        {/* Linked Design - requires Bin Designer feature flag */}
-        {isDesignerEnabled && (
-          <Suspense fallback={null}>
-            <LinkedDesignSection bin={bin} variant={variant} />
-          </Suspense>
-        )}
+        {/* Linked Design */}
+        <Suspense fallback={null}>
+          <LinkedDesignSection bin={bin} variant={variant} />
+        </Suspense>
 
         {/* Notes */}
         <div>

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -18,7 +18,6 @@ import { validateHalfBinModeToggle } from '@/utils/halfBinConstraints';
 import type { BinId } from '@/core/types';
 import { SHORTCUTS, STAGING_ID, hasFractionalDimensions } from '@/core/constants';
 import { useDesignerRouting } from '@/hooks/useDesignerRouting';
-import { useLabsStore } from '@/core/store';
 import { useGridNavigation } from '@/features/grid-editor';
 import { isOk, isErr } from '@/core/result';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
@@ -117,7 +116,6 @@ export function useKeyboard() {
   const addToast = useToastStore((state) => state.addToast);
 
   // Tool switching (Shift+D)
-  const isDesignerEnabled = useLabsStore((state) => state.isFeatureEnabled('bin_designer'));
   const { navigateToDesigner } = useDesignerRouting();
 
   // Grid navigation hook for spatial arrow key navigation
@@ -283,7 +281,7 @@ export function useKeyboard() {
       }
 
       // Tool switch (Shift+D) — toggle to Bin Designer
-      if (key === SHORTCUTS.TOOL_SWITCH && e.shiftKey && !ctrlOrMeta && isDesignerEnabled) {
+      if (key === SHORTCUTS.TOOL_SWITCH && e.shiftKey && !ctrlOrMeta) {
         e.preventDefault();
         navigateToDesigner();
         return;
@@ -502,7 +500,6 @@ export function useKeyboard() {
       toggleHalfBinMode,
       setShowLayoutManager,
       addToast,
-      isDesignerEnabled,
       navigateToDesigner,
       t,
     ]

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/components/Mobile';
 import { PresenceAvatarList } from '@/components/Collab';
 
-// Lazy load design-linking dialogs - only needed when bin_designer feature is enabled
+// Lazy load design-linking dialogs
 const DesignLinkingDialogs = lazyWithRetry(() =>
   import('@/features/design-linking/components/DesignLinkingDialogs').then(
     namedExport('DesignLinkingDialogs')
@@ -31,7 +31,6 @@ const DesignLinkingDialogs = lazyWithRetry(() =>
 );
 import { usePresence } from '@/hooks/usePresence';
 import { useCollabMode } from '@/hooks/useCollabMode';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import type { SaveStatus } from '@/shared/hooks';
 import { useTranslation } from '@/i18n';
 import { useOnboarding } from '@/features/onboarding/hooks/useOnboarding';
@@ -75,7 +74,6 @@ export function MobileLayout({
   const setActiveMobilePanel = useMobileStore((state) => state.setActiveMobilePanel);
   const contextMenu = useViewStore((state) => state.contextMenu);
   const hideContextMenu = useViewStore((state) => state.hideContextMenu);
-  const isDesignerEnabled = useFeatureFlag('bin_designer');
   const { shouldShowDrawTutorial } = useOnboarding();
 
   return (
@@ -123,12 +121,10 @@ export function MobileLayout({
         />
       )}
 
-      {/* Design linking dialogs - requires Bin Designer feature flag */}
-      {isDesignerEnabled && (
-        <Suspense fallback={null}>
-          <DesignLinkingDialogs />
-        </Suspense>
-      )}
+      {/* Design linking dialogs */}
+      <Suspense fallback={null}>
+        <DesignLinkingDialogs />
+      </Suspense>
 
       {/* Mobile help modal (touch gestures guide) */}
       {isMobileHelpOpen && (

--- a/src/shared/components/ToolSwitcher/ToolSwitcher.test.tsx
+++ b/src/shared/components/ToolSwitcher/ToolSwitcher.test.tsx
@@ -7,10 +7,6 @@ const mockNavigateToDesigner = vi.fn();
 const mockNavigateToPlanner = vi.fn();
 let mockIsDesignerRoute = false;
 
-vi.mock('@/hooks/useFeatureFlag', () => ({
-  useFeatureFlag: vi.fn(() => false),
-}));
-
 vi.mock('@/hooks/useDesignerRouting', () => ({
   useDesignerRouting: () => ({
     isDesignerRoute: mockIsDesignerRoute,
@@ -19,131 +15,105 @@ vi.mock('@/hooks/useDesignerRouting', () => ({
   }),
 }));
 
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
-
 describe('ToolSwitcher', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsDesignerRoute = false;
   });
 
-  describe('when feature flag is disabled', () => {
-    beforeEach(() => {
-      vi.mocked(useFeatureFlag).mockReturnValue(false);
-    });
-
-    it('shows static title when feature flag disabled', () => {
-      render(<ToolSwitcher />);
-      expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Gridfinity Layout Tool');
-    });
-
-    it('shows compact title when feature flag disabled and compact', () => {
-      render(<ToolSwitcher compact />);
-      expect(screen.queryByRole('heading')).not.toBeInTheDocument();
-      expect(screen.getByText('Gridfinity Layout Tool')).toBeInTheDocument();
-    });
+  it('shows tablist', () => {
+    render(<ToolSwitcher />);
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+    expect(screen.getAllByRole('tab')).toHaveLength(2);
   });
 
-  describe('when feature flag is enabled', () => {
-    beforeEach(() => {
-      vi.mocked(useFeatureFlag).mockReturnValue(true);
-    });
+  it('has planner tab selected by default', () => {
+    render(<ToolSwitcher />);
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+  });
 
-    it('shows tablist when feature flag enabled', () => {
-      render(<ToolSwitcher />);
-      expect(screen.getByRole('tablist')).toBeInTheDocument();
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
-    });
+  it('has designer tab selected when on designer route', () => {
+    mockIsDesignerRoute = true;
+    render(<ToolSwitcher />);
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+  });
 
-    it('has planner tab selected by default', () => {
-      render(<ToolSwitcher />);
-      const tabs = screen.getAllByRole('tab');
-      expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
-      expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
-    });
+  it('navigates to designer when clicking designer tab', async () => {
+    const user = userEvent.setup();
+    render(<ToolSwitcher />);
 
-    it('has designer tab selected when on designer route', () => {
-      mockIsDesignerRoute = true;
-      render(<ToolSwitcher />);
-      const tabs = screen.getAllByRole('tab');
-      expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
-      expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
-    });
+    const tabs = screen.getAllByRole('tab');
+    await user.click(tabs[1]); // Click designer tab
 
-    it('navigates to designer when clicking designer tab', async () => {
-      const user = userEvent.setup();
-      render(<ToolSwitcher />);
+    expect(mockNavigateToDesigner).toHaveBeenCalledTimes(1);
+  });
 
-      const tabs = screen.getAllByRole('tab');
-      await user.click(tabs[1]); // Click designer tab
+  it('navigates to planner when clicking planner tab', async () => {
+    const user = userEvent.setup();
+    mockIsDesignerRoute = true;
+    render(<ToolSwitcher />);
 
-      expect(mockNavigateToDesigner).toHaveBeenCalledTimes(1);
-    });
+    const tabs = screen.getAllByRole('tab');
+    await user.click(tabs[0]); // Click planner tab
 
-    it('navigates to planner when clicking planner tab', async () => {
-      const user = userEvent.setup();
-      mockIsDesignerRoute = true;
-      render(<ToolSwitcher />);
+    expect(mockNavigateToPlanner).toHaveBeenCalledTimes(1);
+  });
 
-      const tabs = screen.getAllByRole('tab');
-      await user.click(tabs[0]); // Click planner tab
+  it('does not navigate when clicking already active tab', async () => {
+    const user = userEvent.setup();
+    render(<ToolSwitcher />);
 
-      expect(mockNavigateToPlanner).toHaveBeenCalledTimes(1);
-    });
+    const tabs = screen.getAllByRole('tab');
+    await user.click(tabs[0]); // Click already active planner tab
 
-    it('does not navigate when clicking already active tab', async () => {
-      const user = userEvent.setup();
-      render(<ToolSwitcher />);
+    expect(mockNavigateToPlanner).not.toHaveBeenCalled();
+    expect(mockNavigateToDesigner).not.toHaveBeenCalled();
+  });
 
-      const tabs = screen.getAllByRole('tab');
-      await user.click(tabs[0]); // Click already active planner tab
+  it('renders GridfinityIcon', () => {
+    render(<ToolSwitcher />);
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
 
-      expect(mockNavigateToPlanner).not.toHaveBeenCalled();
-      expect(mockNavigateToDesigner).not.toHaveBeenCalled();
-    });
+  it('applies compact styles when compact prop is true', () => {
+    render(<ToolSwitcher compact />);
+    const navigation = screen.getByRole('navigation');
+    expect(navigation).toHaveClass('gap-1.5');
+  });
 
-    it('renders GridfinityIcon', () => {
-      render(<ToolSwitcher />);
-      const svg = document.querySelector('svg');
-      expect(svg).toBeInTheDocument();
-    });
+  it('applies regular styles when compact prop is false', () => {
+    render(<ToolSwitcher />);
+    const navigation = screen.getByRole('navigation');
+    expect(navigation).toHaveClass('gap-2');
+  });
 
-    it('applies compact styles when compact prop is true', () => {
-      render(<ToolSwitcher compact />);
-      const navigation = screen.getByRole('navigation');
-      expect(navigation).toHaveClass('gap-1.5');
-    });
+  it('has accessible labels', () => {
+    render(<ToolSwitcher />);
+    expect(screen.getByRole('navigation')).toHaveAttribute('aria-label', 'Tool Switcher');
+    expect(screen.getByRole('tablist')).toHaveAttribute('aria-label', 'Active tool');
+  });
 
-    it('applies regular styles when compact prop is false', () => {
-      render(<ToolSwitcher />);
-      const navigation = screen.getByRole('navigation');
-      expect(navigation).toHaveClass('gap-2');
-    });
+  it('shows title attribute on inactive tabs', () => {
+    render(<ToolSwitcher />);
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs[0]).not.toHaveAttribute('title'); // Active tab
+    // Title includes keyboard shortcut
+    const title = tabs[1].getAttribute('title');
+    expect(title).toContain('Switch to Bin Designer');
+  });
 
-    it('has accessible labels', () => {
-      render(<ToolSwitcher />);
-      expect(screen.getByRole('navigation')).toHaveAttribute('aria-label', 'Tool Switcher');
-      expect(screen.getByRole('tablist')).toHaveAttribute('aria-label', 'Active tool');
-    });
-
-    it('shows title attribute on inactive tabs', () => {
-      render(<ToolSwitcher />);
-      const tabs = screen.getAllByRole('tab');
-      expect(tabs[0]).not.toHaveAttribute('title'); // Active tab
-      // Title includes keyboard shortcut
-      const title = tabs[1].getAttribute('title');
-      expect(title).toContain('Switch to Bin Designer');
-    });
-
-    it('shows correct title attribute when designer is active', () => {
-      mockIsDesignerRoute = true;
-      render(<ToolSwitcher />);
-      const tabs = screen.getAllByRole('tab');
-      // Title includes keyboard shortcut
-      const title = tabs[0].getAttribute('title');
-      expect(title).toContain('Switch to');
-      expect(tabs[1]).not.toHaveAttribute('title'); // Active tab
-    });
+  it('shows correct title attribute when designer is active', () => {
+    mockIsDesignerRoute = true;
+    render(<ToolSwitcher />);
+    const tabs = screen.getAllByRole('tab');
+    // Title includes keyboard shortcut
+    const title = tabs[0].getAttribute('title');
+    expect(title).toContain('Switch to');
+    expect(tabs[1]).not.toHaveAttribute('title'); // Active tab
   });
 });

--- a/src/shared/components/ToolSwitcher/ToolSwitcher.tsx
+++ b/src/shared/components/ToolSwitcher/ToolSwitcher.tsx
@@ -1,14 +1,9 @@
 /**
  * Tool switcher segmented control.
  *
- * When the bin_designer feature flag is enabled, replaces the static
- * "Gridfinity Layout Tool" title with a segmented control to switch
- * between Layout Planner and Bin Designer.
- *
- * When the flag is off, renders the original static title.
+ * Renders a segmented control to switch between Layout Planner and Bin Designer.
  */
 
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useDesignerRouting } from '@/hooks/useDesignerRouting';
 import { useTranslation } from '@/i18n';
 
@@ -42,24 +37,11 @@ function GridfinityIcon({ className }: { className?: string }) {
 type Tool = 'planner' | 'designer';
 
 /**
- * Renders a segmented control for switching between Layout Planner and Bin Designer,
- * or falls back to a static "Gridfinity Layout Tool" title when the bin_designer
- * feature flag is disabled.
+ * Renders a segmented control for switching between Layout Planner and Bin Designer.
  */
 export function ToolSwitcher({ compact = false }: ToolSwitcherProps) {
   const t = useTranslation();
-  const isDesignerEnabled = useFeatureFlag('bin_designer');
   const { isDesignerRoute, navigateToDesigner, navigateToPlanner } = useDesignerRouting();
-
-  // When feature flag is off, show original static title
-  if (!isDesignerEnabled) {
-    if (compact) {
-      return (
-        <span className="text-xs font-medium text-content-secondary">{t('toolSwitcher.gridfinityLayoutTool')}</span>
-      );
-    }
-    return <h1 className="text-lg font-semibold text-content">{t('toolSwitcher.gridfinityLayoutTool')}</h1>;
-  }
 
   const activeTool: Tool = isDesignerRoute ? 'designer' : 'planner';
 
@@ -78,7 +60,11 @@ export function ToolSwitcher({ compact = false }: ToolSwitcherProps) {
   const gap = compact ? 'gap-1.5' : 'gap-2';
 
   return (
-    <div className={`flex items-center ${gap}`} role="navigation" aria-label={t('toolSwitcher.toolSwitcher')}>
+    <div
+      className={`flex items-center ${gap}`}
+      role="navigation"
+      aria-label={t('toolSwitcher.toolSwitcher')}
+    >
       <GridfinityIcon className={`${iconSize} text-content-secondary flex-shrink-0`} />
       <div
         className="flex rounded-md bg-surface p-0.5 border border-stroke-subtle"


### PR DESCRIPTION
## Summary

- Graduate the `bin_designer` feature flag from `experimental` to `graduated` status, making it permanently enabled for all users
- Remove 7 conditional feature flag guards across 6 source files that are now dead code
- Fix pre-existing `no-misused-promises` lint error in App.tsx download handler

## Changes

**Feature flag (`src/core/labs/features.ts`):**
- Status: `experimental` → `graduated`
- Added `graduatedAt: '2026-02'`
- Removed `warning`, `defaultEnabled`, `comingSoon` (no longer relevant)

**Dead code removed (6 files):**
- `App.tsx` — removed `isDesignerEnabled`; `DesignLinkingDialogs` always renders; route guard simplified
- `MobileLayout.tsx` — removed `isDesignerEnabled`; `DesignLinkingDialogs` always renders
- `ToolSwitcher.tsx` — removed static title fallback; always renders segmented control
- `SingleBinInspector.tsx` — removed guard; `LinkedDesignSection` always renders
- `useKeyboard.ts` — removed guard on Shift+D shortcut; removed unused `useLabsStore` import
- `BinContextMenu.tsx` — removed guard; `BinContextMenuDesignSection` always renders

**Tests updated (3 files):**
- `ToolSwitcher.test.tsx` — deleted "feature flag disabled" block; removed mock
- `BinContextMenu.test.tsx` — removed `useFeatureFlag` mock
- `Header.test.tsx` — updated assertion for tool switcher (tablist instead of static title)

## Test plan

- [x] `npm run typecheck` — no type errors
- [x] `npm run lint` — no new lint issues (pre-existing warnings only)
- [x] `npm run test:coverage` — 440 test files, 7174 tests pass
- [x] `npm run build` — production build succeeds
- [x] Verify bin designer is accessible at `/designer` route
- [x] Verify Shift+D shortcut navigates to designer
- [ ] Verify graduated feature appears in Labs drawer "What's New" section