### PR TITLE
chore: shorten interior type descriptions to single line

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -92,7 +92,7 @@
   "binDesigner.walls.pattern.someSlotted": "Wände mit Trennschlitzen bleiben massiv",
   "binDesigner.walls.pattern.cutoutsEnabled": "Wandmuster sind im Ausschnittmodus nicht verfügbar",
   "binDesigner.interior.standard.title": "Rastereinteilung",
-  "binDesigner.interior.standard.description": "Fächer mit festen Wänden",
+  "binDesigner.interior.standard.description": "Fächer mit Wänden",
   "binDesigner.interior.slotted.title": "Herausnehmbare Trennwände",
   "binDesigner.interior.slotted.description": "Schlitze für einsetzbare Trennwände",
   "binDesigner.interior.solid.title": "Individuelle Ausschnitte",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1307,7 +1307,7 @@ const en: Record<string, string> = {
   'binDesigner.walls.pattern.someSlotted': 'Walls with divider slots will keep solid walls',
   'binDesigner.walls.pattern.cutoutsEnabled': 'Wall patterns are not available in cutout mode',
   'binDesigner.interior.standard.title': 'Grid Dividers',
-  'binDesigner.interior.standard.description': 'Compartments with permanent walls',
+  'binDesigner.interior.standard.description': 'Compartments with walls',
   'binDesigner.interior.slotted.title': 'Removable Dividers',
   'binDesigner.interior.slotted.description': 'Slots for insertable dividers',
   'binDesigner.interior.solid.title': 'Custom Cutouts',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -92,7 +92,7 @@
   "binDesigner.walls.pattern.someSlotted": "Las paredes con ranuras mantendrán paredes sólidas",
   "binDesigner.walls.pattern.cutoutsEnabled": "Los patrones de pared no están disponibles en modo recorte",
   "binDesigner.interior.standard.title": "Divisores de cuadrícula",
-  "binDesigner.interior.standard.description": "Compartimentos con paredes fijas",
+  "binDesigner.interior.standard.description": "Compartimentos con paredes",
   "binDesigner.interior.slotted.title": "Divisores removibles",
   "binDesigner.interior.slotted.description": "Ranuras para divisores extraíbles",
   "binDesigner.interior.solid.title": "Recortes personalizados",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -92,7 +92,7 @@
   "binDesigner.walls.pattern.someSlotted": "Les murs avec des fentes garderont des murs pleins",
   "binDesigner.walls.pattern.cutoutsEnabled": "Les motifs de mur ne sont pas disponibles en mode découpe",
   "binDesigner.interior.standard.title": "Séparateurs en grille",
-  "binDesigner.interior.standard.description": "Compartiments à parois fixes",
+  "binDesigner.interior.standard.description": "Compartiments avec parois",
   "binDesigner.interior.slotted.title": "Séparateurs amovibles",
   "binDesigner.interior.slotted.description": "Fentes pour cloisons amovibles",
   "binDesigner.interior.solid.title": "Découpes personnalisées",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -92,7 +92,7 @@
   "binDesigner.walls.pattern.someSlotted": "Vegger med skillespor beholder solide vegger",
   "binDesigner.walls.pattern.cutoutsEnabled": "Veggmønstre er ikke tilgjengelige i utskjæringsmodus",
   "binDesigner.interior.standard.title": "Rutenettvegger",
-  "binDesigner.interior.standard.description": "Rom med faste vegger",
+  "binDesigner.interior.standard.description": "Rom med vegger",
   "binDesigner.interior.slotted.title": "Avtakbare skillevegger",
   "binDesigner.interior.slotted.description": "Spor for innsettbare skillevegger",
   "binDesigner.interior.solid.title": "Egendefinerte utskjæringer",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -92,7 +92,7 @@
   "binDesigner.walls.pattern.someSlotted": "Wanden met verdeelsleuven blijven massief",
   "binDesigner.walls.pattern.cutoutsEnabled": "Wandpatronen zijn niet beschikbaar in uitsparingsmodus",
   "binDesigner.interior.standard.title": "Rasterverdeling",
-  "binDesigner.interior.standard.description": "Compartimenten met vaste wanden",
+  "binDesigner.interior.standard.description": "Compartimenten met wanden",
   "binDesigner.interior.slotted.title": "Verwijderbare scheidingswanden",
   "binDesigner.interior.slotted.description": "Sleuven voor inzetbare scheidingen",
   "binDesigner.interior.solid.title": "Aangepaste uitsparingen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -92,7 +92,7 @@
   "binDesigner.walls.pattern.someSlotted": "Paredes com ranhuras manterão paredes sólidas",
   "binDesigner.walls.pattern.cutoutsEnabled": "Padrões de parede não estão disponíveis no modo recorte",
   "binDesigner.interior.standard.title": "Divisores em grade",
-  "binDesigner.interior.standard.description": "Compartimentos com paredes fixas",
+  "binDesigner.interior.standard.description": "Compartimentos com paredes",
   "binDesigner.interior.slotted.title": "Divisores removíveis",
   "binDesigner.interior.slotted.description": "Ranhuras para divisores inseríveis",
   "binDesigner.interior.solid.title": "Recortes personalizados",


### PR DESCRIPTION
## Summary
- Shortened the 3 bin designer interior type descriptions (Grid Dividers, Removable Dividers, Custom Cutouts) so they fit on one line in the UI
- Updated all 7 locales (en, de, es, fr, nb, nl, pt-BR)

## Test plan
- [ ] Verify descriptions display on a single line in the interior type selector panel