### PR TITLE
fix: prevent floating inspector panel jitter during slider interaction

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/FloatingInspector.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/FloatingInspector.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { FloatingInspector } from './FloatingInspector';
 import type { Cutout } from '@/features/bin-designer/types';
 
@@ -213,5 +213,113 @@ describe('FloatingInspector', () => {
     // Should show preview values, not original
     expect(xInput).toHaveValue('15');
     expect(yInput).toHaveValue('25');
+  });
+
+  describe('position locking during interaction', () => {
+    it('locks panel position on pointerdown and unlocks on pointerup', () => {
+      const cutout = createCutout({ x: 10, y: 10, width: 20, depth: 20 });
+      const { container, rerender } = render(
+        <FloatingInspector {...defaultProps} cutouts={[cutout]} selection={new Set(['cutout1'])} />
+      );
+
+      const panel = container.firstChild as HTMLElement;
+      const initialLeft = panel.style.left;
+      const initialTop = panel.style.top;
+
+      // Simulate pointer down on panel (user starts dragging a slider)
+      fireEvent.pointerDown(panel);
+
+      // Re-render with a cutout that has different bounds (simulating rotation change)
+      const changedCutout = createCutout({ x: 10, y: 5, width: 30, depth: 40 });
+      rerender(
+        <FloatingInspector
+          {...defaultProps}
+          cutouts={[changedCutout]}
+          selection={new Set(['cutout1'])}
+        />
+      );
+
+      // Position should be locked to original values
+      expect(panel.style.left).toBe(initialLeft);
+      expect(panel.style.top).toBe(initialTop);
+
+      // Simulate pointer up (user releases slider)
+      act(() => {
+        fireEvent.pointerUp(window);
+      });
+
+      // Position should now reflect the new bounds
+      expect(panel.style.left).not.toBe(initialLeft);
+    });
+
+    it('keeps position locked when focus moves between controls within the panel', () => {
+      const cutout = createCutout({ x: 10, y: 10, width: 20, depth: 20 });
+      const { container, rerender } = render(
+        <FloatingInspector {...defaultProps} cutouts={[cutout]} selection={new Set(['cutout1'])} />
+      );
+
+      const panel = container.firstChild as HTMLElement;
+      const initialLeft = panel.style.left;
+      const rotationSlider = screen.getByTestId('slider-input-Rotation');
+      const depthSlider = screen.getByTestId('slider-input-Depth');
+
+      // Focus an input (locks position)
+      fireEvent.focusIn(rotationSlider, { relatedTarget: null });
+
+      // Change bounds
+      const changedCutout = createCutout({ x: 10, y: 5, width: 30, depth: 40 });
+      rerender(
+        <FloatingInspector
+          {...defaultProps}
+          cutouts={[changedCutout]}
+          selection={new Set(['cutout1'])}
+        />
+      );
+
+      // Position stays locked
+      expect(panel.style.left).toBe(initialLeft);
+
+      // Move focus within panel (blur one, focus another)
+      // relatedTarget is inside the panel, so it should NOT unlock
+      fireEvent.focusOut(rotationSlider, { relatedTarget: depthSlider });
+      fireEvent.focusIn(depthSlider, { relatedTarget: rotationSlider });
+
+      // Still locked
+      expect(panel.style.left).toBe(initialLeft);
+    });
+
+    it('unlocks position when focus leaves the panel entirely', () => {
+      const cutout = createCutout({ x: 10, y: 10, width: 20, depth: 20 });
+      const { container, rerender } = render(
+        <FloatingInspector {...defaultProps} cutouts={[cutout]} selection={new Set(['cutout1'])} />
+      );
+
+      const panel = container.firstChild as HTMLElement;
+      const initialLeft = panel.style.left;
+      const rotationSlider = screen.getByTestId('slider-input-Rotation');
+
+      // Focus an input (locks position)
+      fireEvent.focusIn(rotationSlider, { relatedTarget: null });
+
+      // Change bounds
+      const changedCutout = createCutout({ x: 10, y: 5, width: 30, depth: 40 });
+      rerender(
+        <FloatingInspector
+          {...defaultProps}
+          cutouts={[changedCutout]}
+          selection={new Set(['cutout1'])}
+        />
+      );
+
+      expect(panel.style.left).toBe(initialLeft);
+
+      // Focus leaves panel entirely (relatedTarget is outside)
+      act(() => {
+        fireEvent.focusOut(rotationSlider, { relatedTarget: document.body });
+      });
+
+      // Position should update
+      expect(panel.style.left).not.toBe(initialLeft);
+    });
   });
 });

--- a/src/features/bin-designer/components/CutoutWorkspace/FloatingInspector.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/FloatingInspector.tsx
@@ -7,7 +7,7 @@
  * Auto-repositions to stay within viewport bounds.
  */
 
-import { useMemo } from 'react';
+import { useMemo, useRef, useState, useCallback, useEffect } from 'react';
 import type { Cutout } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
 import { SliderInput } from '@/features/bin-designer/components/controls/SliderInput';
@@ -109,6 +109,32 @@ export function FloatingInspector({
     return { minX, minY, maxX, maxY };
   }, [selectedCutouts, preview]);
 
+  // --- Position lock: prevent panel jitter during input interaction ---
+  // When the user interacts with any control inside the panel (e.g. dragging
+  // the rotation slider), the cutout bounds change on every frame which causes
+  // the panel's computed position to jitter. We "lock" the position at the
+  // moment interaction starts, then release it on pointer-up / focus-out so
+  // the panel snaps to its new optimal placement.
+  const panelRef = useRef<HTMLDivElement>(null);
+  const pointerIsDownRef = useRef(false);
+  const hasFocusRef = useRef(false);
+  const [lockedPos, setLockedPos] = useState<{ x: number; y: number } | null>(null);
+
+  const tryUnlock = useCallback(() => {
+    if (!pointerIsDownRef.current && !hasFocusRef.current) {
+      setLockedPos(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handlePointerUp = () => {
+      pointerIsDownRef.current = false;
+      tryUnlock();
+    };
+    window.addEventListener('pointerup', handlePointerUp);
+    return () => window.removeEventListener('pointerup', handlePointerUp);
+  }, [tryUnlock]);
+
   if (selection.size === 0 || hidden || !selectionBounds) return null;
 
   // Convert world bounds to screen coords
@@ -160,6 +186,10 @@ export function FloatingInspector({
   // Clamp Y within canvas bounds
   panelY = Math.max(EDGE_MARGIN, Math.min(panelY, canvasHeight - PANEL_HEIGHT_EST - EDGE_MARGIN));
 
+  // Apply position lock: use locked position during interaction, computed otherwise
+  const finalX = lockedPos?.x ?? panelX;
+  const finalY = lockedPos?.y ?? panelY;
+
   const isSingle = selectedCutouts.length === 1;
   const singleCutout = isSingle ? selectedCutouts[0] : null;
 
@@ -180,11 +210,27 @@ export function FloatingInspector({
 
   return (
     <div
+      ref={panelRef}
       className="absolute z-50 w-[220px] rounded-lg border border-stroke-subtle bg-surface-elevated shadow-lg p-2 space-y-1.5 transition-opacity duration-150"
       style={{
-        left: panelX,
-        top: panelY,
+        left: finalX,
+        top: finalY,
         pointerEvents: 'auto',
+      }}
+      onPointerDown={() => {
+        pointerIsDownRef.current = true;
+        setLockedPos((prev) => prev ?? { x: panelX, y: panelY });
+      }}
+      onFocusCapture={() => {
+        hasFocusRef.current = true;
+        setLockedPos((prev) => prev ?? { x: panelX, y: panelY });
+      }}
+      onBlurCapture={(e) => {
+        const related = e.relatedTarget instanceof Node ? e.relatedTarget : null;
+        if (!panelRef.current?.contains(related)) {
+          hasFocusRef.current = false;
+          tryUnlock();
+        }
       }}
     >
       {/* Single selection: compact inputs for position/size, sliders for rotation/depth */}


### PR DESCRIPTION
## Summary
- The FloatingInspector recomputed its screen position from `getRotatedBounds()` on every render. During slider drag (especially rotation on elongated cutouts), each `onChange` tick produced a slightly different axis-aligned bounding box, shifting the panel by a few pixels each frame — causing visible jitter.
- Added a position-lock mechanism that snapshots the panel's `(left, top)` when the user starts interacting with any control (pointerdown or focus), holds it stable during the interaction, then snaps to the new optimal placement on release (pointerup + focus-out).
- Uses `useState` for the locked position (render-safe) and `useRef` for interaction tracking flags (event-handler-only), respecting the `react-hooks/refs` ESLint rule.

## Test plan
- [x] Added test: panel position locks on pointerdown and unlocks on pointerup
- [x] Added test: position stays locked when focus moves between controls within the panel
- [x] Added test: position unlocks when focus leaves the panel entirely
- [x] All 1349 bin-designer tests pass
- [x] TypeScript compiles cleanly
- [x] All pre-commit hooks pass (lint, i18n, boundaries, exhaustiveness, affected tests)