### PR TITLE
fix: reset floating inspector position lock on hide/selection change

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/FloatingInspector.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/FloatingInspector.test.tsx
@@ -321,5 +321,79 @@ describe('FloatingInspector', () => {
       // Position should update
       expect(panel.style.left).not.toBe(initialLeft);
     });
+
+    it('resets position lock when panel is hidden and re-shown', () => {
+      const cutout = createCutout({ x: 10, y: 10, width: 20, depth: 20 });
+      const { container, rerender } = render(
+        <FloatingInspector {...defaultProps} cutouts={[cutout]} selection={new Set(['cutout1'])} />
+      );
+
+      const panel = container.firstChild as HTMLElement;
+
+      // Interact with panel to engage position lock
+      fireEvent.pointerDown(panel);
+      fireEvent.focusIn(screen.getByTestId('slider-input-Rotation'), { relatedTarget: null });
+
+      const lockedLeft = panel.style.left;
+
+      // Panel hidden (simulating canvas drag) — DOM removed, onBlurCapture can't fire
+      rerender(
+        <FloatingInspector
+          {...defaultProps}
+          cutouts={[cutout]}
+          selection={new Set(['cutout1'])}
+          hidden={true}
+        />
+      );
+      expect(container.firstChild).toBeNull();
+
+      // Panel re-shown with different cutout position
+      const movedCutout = createCutout({ x: 50, y: 50, width: 20, depth: 20 });
+      rerender(
+        <FloatingInspector
+          {...defaultProps}
+          cutouts={[movedCutout]}
+          selection={new Set(['cutout1'])}
+          hidden={false}
+        />
+      );
+
+      // Panel should reposition to the new cutout location, not stay at locked pos
+      const newPanel = container.firstChild as HTMLElement;
+      expect(newPanel).not.toBeNull();
+      expect(newPanel.style.left).not.toBe(lockedLeft);
+    });
+
+    it('resets position lock when selection changes', () => {
+      const cutout1 = createCutout({ id: 'c1', x: 10, y: 10, width: 20, depth: 20 });
+      const cutout2 = createCutout({ id: 'c2', x: 70, y: 70, width: 15, depth: 15 });
+      const { container, rerender } = render(
+        <FloatingInspector
+          {...defaultProps}
+          cutouts={[cutout1, cutout2]}
+          selection={new Set(['c1'])}
+        />
+      );
+
+      const panel = container.firstChild as HTMLElement;
+
+      // Interact with panel to engage position lock
+      fireEvent.pointerDown(panel);
+      fireEvent.focusIn(screen.getByTestId('slider-input-Rotation'), { relatedTarget: null });
+
+      const lockedLeft = panel.style.left;
+
+      // Switch selection to a different cutout at a different position
+      rerender(
+        <FloatingInspector
+          {...defaultProps}
+          cutouts={[cutout1, cutout2]}
+          selection={new Set(['c2'])}
+        />
+      );
+
+      // Panel should reposition for the new cutout
+      expect(panel.style.left).not.toBe(lockedLeft);
+    });
   });
 });

--- a/src/features/bin-designer/components/CutoutWorkspace/FloatingInspector.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/FloatingInspector.tsx
@@ -141,6 +141,20 @@ export function FloatingInspector({
     };
   }, [tryUnlock]);
 
+  // Reset position lock when the panel is hidden or the selection changes.
+  // When hidden, the panel DOM is removed so onBlurCapture never fires,
+  // leaving hasFocusRef stuck true and lockedPos stale. The setState call
+  // here is safe: it only triggers when hidden/selectionKey change (infrequent
+  // prop updates), and is a no-op when the lock was never engaged.
+  const selectionKey = [...selection].sort().join(',');
+
+  useEffect(() => {
+    pointerIsDownRef.current = false;
+    hasFocusRef.current = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- clearing stale lock; DOM removal prevents blur events from firing
+    setLockedPos(null);
+  }, [hidden, selectionKey]);
+
   if (selection.size === 0 || hidden || !selectionBounds) return null;
 
   // Convert world bounds to screen coords


### PR DESCRIPTION
## Summary

- Fixes floating inspector panel never repositioning after #689's position-lock feature
- When the panel was hidden (during canvas drag) or the selection changed, the DOM was removed so `onBlurCapture` never fired — leaving `hasFocusRef` stuck at `true` and `lockedPos` permanently stale
- Adds a `useEffect` that resets the lock refs and clears `lockedPos` whenever the `hidden` prop or selection identity changes

## Test plan

- [x] Existing 12 tests continue to pass
- [x] New test: position lock resets when panel is hidden and re-shown
- [x] New test: position lock resets when selection changes to a different cutout
- [ ] Manual: select a cutout, adjust rotation slider, then drag the cutout on canvas — panel should follow to the new position
- [ ] Manual: select cutout A, interact with panel, then click cutout B — panel should snap to cutout B's position