### PR TITLE
fix: resolve all test failures after ESLint lint fix PR

### DIFF
--- a/src/components/DragPreview/DragPreview.test.tsx
+++ b/src/components/DragPreview/DragPreview.test.tsx
@@ -4,12 +4,16 @@ import { DragPreview } from './DragPreview';
 import type { Bin, Category } from '@/core/types';
 
 // Mock state - use explicit type instead of importing Interaction
-let mockUIState: { interaction: { type: string; [key: string]: unknown } | null; zoom: number };
+let mockInteractionState: { interaction: { type: string; [key: string]: unknown } | null };
+let mockViewState: { zoom: number };
 let mockLayoutState: { layout: { bins: Bin[]; categories: Category[] } };
 
 vi.mock('@/core/store', () => ({
-  useUIStore: vi.fn((selector: unknown) => {
-    return (selector as (s: typeof mockUIState) => unknown)(mockUIState);
+  useInteractionStore: vi.fn((selector: unknown) => {
+    return (selector as (s: typeof mockInteractionState) => unknown)(mockInteractionState);
+  }),
+  useViewStore: vi.fn((selector: unknown) => {
+    return (selector as (s: typeof mockViewState) => unknown)(mockViewState);
   }),
   useLayoutStore: vi.fn((selector: unknown) => {
     return (selector as (s: typeof mockLayoutState) => unknown)(mockLayoutState);
@@ -68,7 +72,8 @@ function dispatchPointerMove(x: number, y: number) {
 
 describe('DragPreview', () => {
   beforeEach(() => {
-    mockUIState = { interaction: null, zoom: 1 };
+    mockInteractionState = { interaction: null };
+    mockViewState = { zoom: 1 };
     mockLayoutState = { layout: { bins: [], categories: [] } };
   });
 
@@ -83,7 +88,7 @@ describe('DragPreview', () => {
     });
 
     it('renders nothing when interaction is not drag type', () => {
-      mockUIState.interaction = { type: 'draw', startX: 0, startY: 0 };
+      mockInteractionState.interaction = { type: 'draw', startX: 0, startY: 0 };
       const { container } = render(<DragPreview />);
       expect(container.firstChild).toBeNull();
     });
@@ -98,13 +103,13 @@ describe('DragPreview', () => {
     });
 
     it('renders nothing when mouse position not set yet', () => {
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1'] };
       const { container } = render(<DragPreview />);
       expect(container.firstChild).toBeNull();
     });
 
     it('renders preview after pointer move', () => {
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1'] };
       const { container, rerender } = render(<DragPreview />);
 
       act(() => {
@@ -116,7 +121,7 @@ describe('DragPreview', () => {
     });
 
     it('positions preview at mouse cursor', () => {
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1'] };
       const { container, rerender } = render(<DragPreview />);
 
       act(() => {
@@ -130,7 +135,7 @@ describe('DragPreview', () => {
     });
 
     it('uses click offset when provided', () => {
-      mockUIState.interaction = {
+      mockInteractionState.interaction = {
         type: 'drag',
         binIds: ['bin-1'],
         clickOffset: { x: 30, y: 40 },
@@ -148,7 +153,7 @@ describe('DragPreview', () => {
     });
 
     it('renders bin with correct color', () => {
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1'] };
       const { container, rerender } = render(<DragPreview />);
 
       act(() => {
@@ -162,7 +167,7 @@ describe('DragPreview', () => {
 
     it('uses default color when category not found', () => {
       mockLayoutState.layout.bins = [makeBin({ id: 'bin-1', category: 'nonexistent-category' })];
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1'] };
       const { container, rerender } = render(<DragPreview />);
 
       act(() => {
@@ -176,7 +181,7 @@ describe('DragPreview', () => {
 
     it('renders bin label when present', () => {
       mockLayoutState.layout.bins = [makeBin({ id: 'bin-1', label: 'Test Label' })];
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1'] };
       const { getByText, rerender } = render(<DragPreview />);
 
       act(() => {
@@ -189,7 +194,7 @@ describe('DragPreview', () => {
 
     it('does not render label when bin has no label', () => {
       mockLayoutState.layout.bins = [makeBin({ id: 'bin-1', label: '' })];
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1'] };
       const { container, rerender } = render(<DragPreview />);
 
       act(() => {
@@ -203,7 +208,7 @@ describe('DragPreview', () => {
 
     it('rotates label for tall bins', () => {
       mockLayoutState.layout.bins = [makeBin({ id: 'bin-1', width: 1, depth: 3, label: 'Tall' })];
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1'] };
       const { container, rerender } = render(<DragPreview />);
 
       act(() => {
@@ -217,7 +222,7 @@ describe('DragPreview', () => {
 
     it('does not rotate label for wide bins', () => {
       mockLayoutState.layout.bins = [makeBin({ id: 'bin-1', width: 3, depth: 1, label: 'Wide' })];
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1'] };
       const { container, rerender } = render(<DragPreview />);
 
       act(() => {
@@ -240,7 +245,7 @@ describe('DragPreview', () => {
     });
 
     it('renders all dragged bins', () => {
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1', 'bin-2'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1', 'bin-2'] };
       const { container, rerender } = render(<DragPreview />);
 
       act(() => {
@@ -253,7 +258,7 @@ describe('DragPreview', () => {
     });
 
     it('positions bins relative to each other', () => {
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1', 'bin-2'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1', 'bin-2'] };
       const { container, rerender } = render(<DragPreview />);
 
       act(() => {
@@ -266,7 +271,7 @@ describe('DragPreview', () => {
     });
 
     it('handles bins not in binIds list', () => {
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1'] };
       const { container, rerender } = render(<DragPreview />);
 
       act(() => {
@@ -286,7 +291,7 @@ describe('DragPreview', () => {
     });
 
     it('renders preview for staging drag', () => {
-      mockUIState.interaction = { type: 'stagingDrag', binId: 'bin-1' };
+      mockInteractionState.interaction = { type: 'stagingDrag', binId: 'bin-1' };
       const { container, rerender } = render(<DragPreview />);
 
       act(() => {
@@ -298,7 +303,7 @@ describe('DragPreview', () => {
     });
 
     it('renders nothing if staging bin not found', () => {
-      mockUIState.interaction = { type: 'stagingDrag', binId: 'nonexistent' };
+      mockInteractionState.interaction = { type: 'stagingDrag', binId: 'nonexistent' };
       const { container, rerender } = render(<DragPreview />);
 
       act(() => {
@@ -314,11 +319,11 @@ describe('DragPreview', () => {
     beforeEach(() => {
       mockLayoutState.layout.bins = [makeBin({ id: 'bin-1', width: 2, depth: 2 })];
       mockLayoutState.layout.categories = [makeCategory()];
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1'] };
     });
 
     it('scales preview with zoom', () => {
-      mockUIState.zoom = 1.5;
+      mockViewState.zoom = 1.5;
       const { container, rerender } = render(<DragPreview />);
 
       act(() => {
@@ -335,7 +340,7 @@ describe('DragPreview', () => {
   describe('event cleanup', () => {
     it('cleans up pointer event listener on unmount', () => {
       const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener');
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1'] };
       mockLayoutState.layout.bins = [makeBin({ id: 'bin-1' })];
 
       const { unmount } = render(<DragPreview />);
@@ -346,7 +351,7 @@ describe('DragPreview', () => {
 
     it('resets mouse position when drag ends', () => {
       mockLayoutState.layout.bins = [makeBin({ id: 'bin-1' })];
-      mockUIState.interaction = { type: 'drag', binIds: ['bin-1'] };
+      mockInteractionState.interaction = { type: 'drag', binIds: ['bin-1'] };
 
       const { container, rerender } = render(<DragPreview />);
 
@@ -358,7 +363,7 @@ describe('DragPreview', () => {
       expect(container.firstChild).not.toBeNull();
 
       // End drag
-      mockUIState.interaction = null;
+      mockInteractionState.interaction = null;
       rerender(<DragPreview />);
       expect(container.firstChild).toBeNull();
     });

--- a/src/components/DropZones/DropZones.test.tsx
+++ b/src/components/DropZones/DropZones.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import { DropZones } from './DropZones';
 
 vi.mock('@/core/store', () => ({
-  useUIStore: vi.fn((selector: unknown) => {
+  useInteractionStore: vi.fn((selector: unknown) => {
     const state = {
       interaction: null,
       dropTarget: null,
@@ -11,6 +11,10 @@ vi.mock('@/core/store', () => ({
     };
     return (selector as (s: typeof state) => unknown)(state);
   }),
+}));
+
+vi.mock('@/i18n', () => ({
+  useTranslation: () => (key: string) => key,
 }));
 
 describe('DropZones', () => {

--- a/src/components/LiveRegion/LiveRegion.test.tsx
+++ b/src/components/LiveRegion/LiveRegion.test.tsx
@@ -1,16 +1,16 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { LiveRegion } from './LiveRegion';
-import { useUIStore } from '@/core/store';
+import { useInteractionStore } from '@/core/store';
 
 // Mock the store module
 vi.mock('@/core/store', () => ({
-  useUIStore: vi.fn(),
+  useInteractionStore: vi.fn(),
 }));
 
 describe('LiveRegion', () => {
   it('renders nothing when no message', () => {
-    vi.mocked(useUIStore).mockImplementation((selector: unknown) => {
+    vi.mocked(useInteractionStore).mockImplementation((selector: unknown) => {
       const state = { liveMessage: '' };
       return (selector as (s: typeof state) => unknown)(state);
     });
@@ -20,7 +20,7 @@ describe('LiveRegion', () => {
   });
 
   it('renders message in aria-live region', () => {
-    vi.mocked(useUIStore).mockImplementation((selector: unknown) => {
+    vi.mocked(useInteractionStore).mockImplementation((selector: unknown) => {
       const state = { liveMessage: 'Bin deleted' };
       return (selector as (s: typeof state) => unknown)(state);
     });
@@ -33,7 +33,7 @@ describe('LiveRegion', () => {
   });
 
   it('is visually hidden with sr-only class', () => {
-    vi.mocked(useUIStore).mockImplementation((selector: unknown) => {
+    vi.mocked(useInteractionStore).mockImplementation((selector: unknown) => {
       const state = { liveMessage: 'Test message' };
       return (selector as (s: typeof state) => unknown)(state);
     });

--- a/src/components/Mobile/BottomNavBar/BottomNavBar.test.tsx
+++ b/src/components/Mobile/BottomNavBar/BottomNavBar.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BottomNavBar } from './BottomNavBar';
 import { resetAllStores } from '@/test/testUtils';
-import { useUIStore } from '@/core/store/ui';
+import { useMobileStore } from '@/core/store/mobile';
 
 vi.mock('@/i18n', () => ({
   useTranslation: () => (key: string) => {
@@ -39,12 +39,12 @@ describe('BottomNavBar', () => {
     const layersButton = screen.getByText('Layers').closest('button');
     if (layersButton) {
       fireEvent.click(layersButton);
-      expect(useUIStore.getState().activeMobilePanel).toBe('layers');
+      expect(useMobileStore.getState().activeMobilePanel).toBe('layers');
     }
   });
 
   it('marks active panel with aria-pressed', () => {
-    useUIStore.setState({ activeMobilePanel: 'layers' });
+    useMobileStore.setState({ activeMobilePanel: 'layers' });
     render(<BottomNavBar />);
     const layersButton = screen.getByText('Layers').closest('button');
     expect(layersButton).toHaveAttribute('aria-pressed', 'true');

--- a/src/components/Mobile/BottomSheet/BottomSheet.test.tsx
+++ b/src/components/Mobile/BottomSheet/BottomSheet.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, fireEvent, act } from '@testing-library/react';
 import { BottomSheet } from '@/components/Mobile/BottomSheet';
-import { useUIStore } from '@/core/store/ui';
+import { useMobileStore } from '@/core/store/mobile';
 
 // Mock matchMedia for useResponsive hook
 Object.defineProperty(window, 'matchMedia', {
@@ -21,13 +21,13 @@ Object.defineProperty(window, 'matchMedia', {
 describe('BottomSheet', () => {
   beforeEach(() => {
     // Set up an active mobile panel so the sheet renders
-    useUIStore.setState({
+    useMobileStore.setState({
       activeMobilePanel: 'layers',
     });
   });
 
   afterEach(() => {
-    useUIStore.setState({
+    useMobileStore.setState({
       activeMobilePanel: null,
     });
     document.body.style.overflow = '';
@@ -45,7 +45,7 @@ describe('BottomSheet', () => {
   });
 
   it('does not render when activeMobilePanel is null', () => {
-    useUIStore.setState({ activeMobilePanel: null });
+    useMobileStore.setState({ activeMobilePanel: null });
 
     const { container } = render(
       <BottomSheet title="Test Panel">
@@ -71,7 +71,7 @@ describe('BottomSheet', () => {
       fireEvent.click(backdrop!);
     });
 
-    expect(useUIStore.getState().activeMobilePanel).toBeNull();
+    expect(useMobileStore.getState().activeMobilePanel).toBeNull();
   });
 
   it('closes on close button click', () => {
@@ -88,7 +88,7 @@ describe('BottomSheet', () => {
       fireEvent.click(closeButton!);
     });
 
-    expect(useUIStore.getState().activeMobilePanel).toBeNull();
+    expect(useMobileStore.getState().activeMobilePanel).toBeNull();
   });
 
   it('closes on Escape key', () => {
@@ -102,7 +102,7 @@ describe('BottomSheet', () => {
       fireEvent.keyDown(window, { key: 'Escape' });
     });
 
-    expect(useUIStore.getState().activeMobilePanel).toBeNull();
+    expect(useMobileStore.getState().activeMobilePanel).toBeNull();
   });
 
   describe('Swipe to dismiss', () => {
@@ -125,7 +125,7 @@ describe('BottomSheet', () => {
       });
 
       // The sheet should still be open
-      expect(useUIStore.getState().activeMobilePanel).toBe('layers');
+      expect(useMobileStore.getState().activeMobilePanel).toBe('layers');
     });
 
     it('closes when swiped down more than 80px', () => {
@@ -161,7 +161,7 @@ describe('BottomSheet', () => {
         });
       });
 
-      expect(useUIStore.getState().activeMobilePanel).toBeNull();
+      expect(useMobileStore.getState().activeMobilePanel).toBeNull();
     });
 
     it('stays open when swiped down less than 80px', () => {
@@ -198,7 +198,7 @@ describe('BottomSheet', () => {
       });
 
       // Should still be open
-      expect(useUIStore.getState().activeMobilePanel).toBe('layers');
+      expect(useMobileStore.getState().activeMobilePanel).toBe('layers');
     });
 
     it('does not allow swiping up (negative drag)', () => {
@@ -229,7 +229,7 @@ describe('BottomSheet', () => {
 
       // The sheet transform should be 0 (clamped to non-negative)
       // We can't easily test CSS values, but the panel should stay open
-      expect(useUIStore.getState().activeMobilePanel).toBe('layers');
+      expect(useMobileStore.getState().activeMobilePanel).toBe('layers');
     });
   });
 
@@ -253,7 +253,7 @@ describe('BottomSheet', () => {
     expect(document.body.style.overflow).toBe('hidden');
 
     // Close the panel
-    useUIStore.setState({ activeMobilePanel: null });
+    useMobileStore.setState({ activeMobilePanel: null });
 
     rerender(
       <BottomSheet title="Test Panel">

--- a/src/components/Mobile/MobileHeader/MobileHeader.test.tsx
+++ b/src/components/Mobile/MobileHeader/MobileHeader.test.tsx
@@ -22,7 +22,7 @@ vi.mock('@/core/store', () => ({
       undo: vi.fn(),
       redo: vi.fn(),
     }),
-  useUIStore: (selector: (state: Record<string, unknown>) => unknown) =>
+  useMobileStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
       toggleMobilePanel: vi.fn(),
     }),

--- a/src/components/Modals/HalfBinModeBlockedModal/HalfBinModeBlockedModal.test.tsx
+++ b/src/components/Modals/HalfBinModeBlockedModal/HalfBinModeBlockedModal.test.tsx
@@ -156,8 +156,8 @@ describe('HalfBinModeBlockedModal', () => {
     it('calls onClose when backdrop clicked', () => {
       render(<HalfBinModeBlockedModal {...defaultProps} />);
 
-      // Click on backdrop (role="presentation")
-      const backdrop = screen.getByRole('presentation');
+      // Click on backdrop (outermost role="presentation")
+      const backdrop = screen.getAllByRole('presentation')[0];
       fireEvent.click(backdrop);
 
       expect(mockOnClose).toHaveBeenCalledOnce();
@@ -220,7 +220,7 @@ describe('HalfBinModeBlockedModal', () => {
         expect(screen.getByText('Loading...')).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole('presentation'));
+      fireEvent.click(screen.getAllByRole('presentation')[0]);
 
       expect(mockOnClose).not.toHaveBeenCalled();
     });

--- a/src/components/Modals/SettingsModal/SettingsModal.test.tsx
+++ b/src/components/Modals/SettingsModal/SettingsModal.test.tsx
@@ -117,8 +117,8 @@ describe('SettingsModal', () => {
 
   it('clicking overlay calls onClose', () => {
     render(<SettingsModal isOpen={true} onClose={mockOnClose} />);
-    // The overlay is the outermost div with the fixed class
-    const overlay = screen.getByRole('dialog').parentElement!;
+    // The overlay is the outermost presentation div (backdrop with onClick={onClose})
+    const overlay = screen.getAllByRole('presentation')[0];
     fireEvent.click(overlay);
     expect(mockOnClose).toHaveBeenCalled();
   });

--- a/src/core/storage/LayoutService.ts
+++ b/src/core/storage/LayoutService.ts
@@ -309,6 +309,12 @@ export function saveLibraryResult(library: LayoutLibrary): Result<void, StorageE
  * Returns null if the library is structurally invalid or has no surviving entries.
  */
 function validateAndCleanLibrary(parsed: LayoutLibrary): LayoutLibrary | null {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- validate structure from localStorage
+  if (!parsed.version || !parsed.activeLayoutId || !Array.isArray(parsed.entries)) {
+    console.warn('Invalid library format');
+    return null;
+  }
+
   // Validate each entry exists in storage (clean up orphaned entries)
   const validEntries = parsed.entries.filter((entry: LayoutEntry) => {
     const key = getLayoutStorageKey(entry.id);

--- a/src/core/storage/SharedWithMeService.ts
+++ b/src/core/storage/SharedWithMeService.ts
@@ -49,6 +49,11 @@ export function loadSharedWithMe(): SharedWithMeEntry[] {
 
     const data = JSON.parse(raw) as SharedWithMeIndex;
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- validate structure from localStorage
+    if (!data.entries || !Array.isArray(data.entries)) {
+      return [];
+    }
+
     return data.entries;
   } catch (error) {
     console.error('Failed to load shared-with-me entries:', error);
@@ -119,6 +124,13 @@ export function loadSharedWithMeResult(): Result<SharedWithMeEntry[], StorageErr
     if (!raw) return ok([]);
 
     const data = JSON.parse(raw) as SharedWithMeIndex;
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- validate structure from localStorage
+    if (!data.entries || !Array.isArray(data.entries)) {
+      return err(
+        storageCorrupted(SHARED_WITH_ME_KEY, ['Invalid data structure: missing entries array'])
+      );
+    }
 
     return ok(data.entries);
   } catch (error) {

--- a/src/core/store/labs.ts
+++ b/src/core/store/labs.ts
@@ -166,7 +166,8 @@ export const useLabsStore = create<LabsState>()((set, get) => ({
     // Coming Soon features are always disabled
     if (feature?.comingSoon) return false;
 
-    return preferences.enabledFeatures[featureId];
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureId may not exist in enabledFeatures
+    return preferences.enabledFeatures[featureId] ?? feature?.defaultEnabled ?? false;
   },
 
   getEnabledCount: () => {

--- a/src/features/bin-designer/components/DesignListDialog/DesignListDialog.test.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListDialog.test.tsx
@@ -241,7 +241,8 @@ describe('DesignListDialog', () => {
   it('closes on backdrop click', async () => {
     render(<DesignListDialog open={true} onClose={onClose} />);
 
-    fireEvent.click(screen.getByRole('dialog'));
+    // Click the backdrop (role="presentation") directly, not the dialog
+    fireEvent.click(screen.getByRole('presentation'));
 
     expect(onClose).toHaveBeenCalled();
   });

--- a/src/features/bin-designer/components/ExportDialog/ExportDialog.test.tsx
+++ b/src/features/bin-designer/components/ExportDialog/ExportDialog.test.tsx
@@ -143,7 +143,8 @@ describe('ExportDialog', () => {
 
   it('closes on backdrop click', () => {
     render(<ExportDialog />);
-    const backdrop = screen.getByRole('dialog');
+    // Click the backdrop (role="presentation"), not the dialog itself
+    const backdrop = screen.getByRole('presentation');
     fireEvent.click(backdrop);
 
     // Verify store was updated

--- a/src/features/bin-designer/storage/DesignerStorage.ts
+++ b/src/features/bin-designer/storage/DesignerStorage.ts
@@ -8,7 +8,14 @@
 
 import { openDB, type IDBPDatabase } from 'idb';
 import type { Result, StorageError } from '@/core/result';
-import { ok, err, isErr, storageNotFound, storageUnavailable } from '@/core/result';
+import {
+  ok,
+  err,
+  isErr,
+  storageNotFound,
+  storageUnavailable,
+  storageCorrupted,
+} from '@/core/result';
 import type { SavedDesign, BinParams, ExportFileNameConfig } from '@/features/bin-designer/types';
 import { THUMBNAIL_VERSION } from '@/features/bin-designer/types';
 import { DEFAULT_BIN_PARAMS, migrateParams } from '@/features/bin-designer/constants/defaults';
@@ -100,6 +107,13 @@ export async function loadDesign(id: string): Promise<Result<SavedDesign, Storag
       return err(storageNotFound(`Design '${id}' not found`));
     }
 
+    // Validate that params is a valid object before migration
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- params can be corrupted in IndexedDB
+    if (!design.params || typeof design.params !== 'object' || Array.isArray(design.params)) {
+      const paramsType = String(design.params) === 'null' ? 'null' : typeof design.params;
+      return err(storageCorrupted(id, [`Invalid params type: ${paramsType}`]));
+    }
+
     // Apply migration for backward compatibility with old designs
     const migratedParams = migrateParams(design.params as Partial<BinParams>);
 
@@ -121,10 +135,17 @@ export async function listDesigns(): Promise<Result<SavedDesign[], StorageError>
     const designs = (await db.getAll(DESIGNS_STORE)) as SavedDesign[];
 
     // Apply migration for backward compatibility with old designs
-    const migratedDesigns = designs.map((design) => ({
-      ...design,
-      params: migrateParams(design.params as Partial<BinParams>),
-    }));
+    // Filter out corrupted entries (invalid params) to avoid breaking the entire list
+    const migratedDesigns = designs
+      .filter((design) => {
+        // Skip entries with invalid params (null, undefined, or primitives)
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime data from IndexedDB
+        return design.params && typeof design.params === 'object' && !Array.isArray(design.params);
+      })
+      .map((design) => ({
+        ...design,
+        params: migrateParams(design.params as Partial<BinParams>),
+      }));
 
     // Sort by updatedAt descending
     migratedDesigns.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));

--- a/src/features/bin-inspector/hooks/useBinInspector.test.ts
+++ b/src/features/bin-inspector/hooks/useBinInspector.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useBinInspector } from '@/features/bin-inspector';
 import { useLayoutStore } from '@/core/store/layout';
-import { useUIStore } from '@/core/store/ui';
+import { useSelectionStore } from '@/core/store/selection';
 import { resetAllStores } from '@/test/testUtils';
 import type { Bin } from '@/core/types';
 
@@ -33,7 +33,7 @@ describe('useBinInspector', () => {
     useLayoutStore.setState({ layout });
 
     // Set default UI state
-    useUIStore.setState({ activeLayerId: 'layer1', selectedBinIds: [] });
+    useSelectionStore.setState({ activeLayerId: 'layer1', selectedBinIds: [] });
   });
 
   afterEach(() => {
@@ -56,7 +56,7 @@ describe('useBinInspector', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = [bin];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -72,7 +72,7 @@ describe('useBinInspector', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = bins;
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -102,7 +102,7 @@ describe('useBinInspector', () => {
       layout.bins = [bin];
       layout.drawer.height = 12;
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -118,7 +118,7 @@ describe('useBinInspector', () => {
       layout.printBedSize = 100; // Small print bed
       layout.gridUnitMm = 42;
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -133,7 +133,7 @@ describe('useBinInspector', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = [bin];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -149,7 +149,7 @@ describe('useBinInspector', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = [bin];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -165,7 +165,7 @@ describe('useBinInspector', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = [bin];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -181,7 +181,7 @@ describe('useBinInspector', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = [bin];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -198,7 +198,7 @@ describe('useBinInspector', () => {
       layout.bins = [bin];
       layout.drawer.height = 12;
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -215,7 +215,7 @@ describe('useBinInspector', () => {
       layout.bins = [bin];
       layout.drawer.height = 12;
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -246,7 +246,7 @@ describe('useBinInspector', () => {
       layout.categories.push({ id: 'green', name: 'Green', color: '#00ff00' });
       layout.bins = [createBin('bin1', 'layer1', 0, 0), createBin('bin2', 'layer1', 3, 0)];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -279,7 +279,7 @@ describe('useBinInspector', () => {
         { ...createBin('bin2', 'layer1', 3, 0), height: 4 },
       ];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -297,7 +297,7 @@ describe('useBinInspector', () => {
       layout.drawer.height = 6;
       layout.bins = [{ ...createBin('bin1', 'layer1'), height: 5 }];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -318,7 +318,7 @@ describe('useBinInspector', () => {
         { ...createBin('bin2', 'layer1', 3, 0), height: 4, clearanceHeight: 1 },
       ];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -337,7 +337,7 @@ describe('useBinInspector', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = [createBin('bin1', 'layer1')];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -355,7 +355,7 @@ describe('useBinInspector', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = [createBin('bin1', 'layer1', 0, 0), createBin('bin2', 'layer1', 3, 0)];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -370,7 +370,7 @@ describe('useBinInspector', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = [createBin('bin1', 'layer1')];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -383,14 +383,14 @@ describe('useBinInspector', () => {
       });
 
       expect(useLayoutStore.getState().layout.bins).toHaveLength(0);
-      expect(useUIStore.getState().selectedBinIds).toHaveLength(0);
+      expect(useSelectionStore.getState().selectedBinIds).toHaveLength(0);
     });
 
     it('cancelDelete clears confirmation state', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = [createBin('bin1', 'layer1')];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -415,7 +415,7 @@ describe('useBinInspector', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = [createBin('bin1', 'layer1', 0, 0), createBin('bin2', 'layer1', 3, 0)];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -434,17 +434,17 @@ describe('useBinInspector', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = [createBin('bin1', 'layer1')];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
-      expect(useUIStore.getState().selectedBinIds).toHaveLength(1);
+      expect(useSelectionStore.getState().selectedBinIds).toHaveLength(1);
 
       act(() => {
         result.current.clearSelection();
       });
 
-      expect(useUIStore.getState().selectedBinIds).toHaveLength(0);
+      expect(useSelectionStore.getState().selectedBinIds).toHaveLength(0);
     });
   });
 
@@ -453,7 +453,7 @@ describe('useBinInspector', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = [{ ...createBin('bin1', 'layer1'), width: 2, depth: 3 }];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -470,7 +470,7 @@ describe('useBinInspector', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = [{ ...createBin('bin1', 'layer1'), width: 2, depth: 3 }];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -503,7 +503,7 @@ describe('useBinInspector', () => {
       ];
       layout.bins = [createBin('bin1', 'layer1')];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -518,7 +518,7 @@ describe('useBinInspector', () => {
       const layout = useLayoutStore.getState().layout;
       layout.bins = [createBin('bin1', 'layer1')];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -540,7 +540,7 @@ describe('useBinInspector', () => {
       ];
       layout.bins = [createBin('bin1', 'layer1', 0, 0), createBin('bin2', 'layer1', 3, 0)];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
 
       const { result } = renderHook(() => useBinInspector());
 
@@ -560,7 +560,7 @@ describe('useBinInspector', () => {
         { id: 'layer2', name: 'Layer 2', height: 3 },
       ];
       useLayoutStore.setState({ layout });
-      useUIStore.setState({ selectedBinIds: [] });
+      useSelectionStore.setState({ selectedBinIds: [] });
 
       const { result } = renderHook(() => useBinInspector());
 

--- a/src/features/categories/components/CategoriesPanel/CategoriesPanel.test.tsx
+++ b/src/features/categories/components/CategoriesPanel/CategoriesPanel.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { CategoriesPanel } from '@/features/categories/components/CategoriesPanel';
-import { useLayoutStore, useUIStore } from '@/core/store';
+import { useLayoutStore } from '@/core/store';
+import { useSelectionStore } from '@/core/store/selection';
 import { resetAllStores } from '@/test/testUtils';
 
 // Mock ConfirmDialog to simplify testing
@@ -69,7 +70,7 @@ describe('CategoriesPanel', () => {
       },
     });
 
-    useUIStore.setState({
+    useSelectionStore.setState({
       activeCategoryId: 'coral',
       selectedBinIds: [],
     });
@@ -110,7 +111,7 @@ describe('CategoriesPanel', () => {
 
       fireEvent.click(screen.getByText('Sky'));
 
-      expect(useUIStore.getState().activeCategoryId).toBe('sky');
+      expect(useSelectionStore.getState().activeCategoryId).toBe('sky');
     });
 
     it('updates selected bins when bins are selected', () => {
@@ -128,7 +129,7 @@ describe('CategoriesPanel', () => {
         notes: '',
       });
       const binId = useLayoutStore.getState().layout.bins[0].id;
-      useUIStore.setState({ selectedBinIds: [binId] });
+      useSelectionStore.setState({ selectedBinIds: [binId] });
 
       render(<CategoriesPanel />);
       fireEvent.click(screen.getByText('Sky'));

--- a/src/features/categories/components/CategoriesPanel/CategoriesPanel.tsx
+++ b/src/features/categories/components/CategoriesPanel/CategoriesPanel.tsx
@@ -273,18 +273,11 @@ export function CategoriesPanel() {
             const isHovered = hoveredCategoryId === category.id;
 
             return (
+              // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- keyboard users interact with inner buttons
               <div
                 key={category.id}
-                role="button"
-                tabIndex={0}
                 className={`group flex items-center gap-2 p-2 rounded-md cursor-pointer min-w-0 transition-colors duration-150 ${isActive ? 'bg-[var(--bg-active)]' : 'hover:bg-surface-hover'}`}
                 onClick={() => handleCategorySelect(category.id, category.name)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    handleCategorySelect(category.id, category.name);
-                  }
-                }}
                 onMouseEnter={() => {
                   setHoveredCategoryId(category.id);
                   setHighlightedCategoryId(category.id);

--- a/src/features/cloud-share/components/ShareModal/ShareModal.test.tsx
+++ b/src/features/cloud-share/components/ShareModal/ShareModal.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ShareModal } from '@/features/cloud-share/components/ShareModal';
-import { useLayoutStore, useLibraryStore, useUIStore, useLabsStore } from '@/core/store';
+import { useLayoutStore, useLibraryStore, useLabsStore } from '@/core/store';
+import { useInteractionStore } from '@/core/store/interaction';
 import { resetAllStores } from '@/test/testUtils';
 import * as storage from '@/core/storage';
 import * as analytics from '@/shared/analytics/posthog';
@@ -283,7 +284,7 @@ describe('ShareModal', () => {
   describe('screen reader announcements', () => {
     it('announces copy to screen reader', async () => {
       const announceSpy = vi.fn();
-      useUIStore.setState({ announceToScreenReader: announceSpy });
+      useInteractionStore.setState({ announceToScreenReader: announceSpy });
 
       render(<ShareModal isOpen={true} onClose={mockOnClose} />);
       fireEvent.click(screen.getByRole('tab', { name: 'Link' }));
@@ -296,7 +297,7 @@ describe('ShareModal', () => {
 
     it('announces download to screen reader', async () => {
       const announceSpy = vi.fn();
-      useUIStore.setState({ announceToScreenReader: announceSpy });
+      useInteractionStore.setState({ announceToScreenReader: announceSpy });
 
       render(<ShareModal isOpen={true} onClose={mockOnClose} />);
       fireEvent.click(screen.getByRole('tab', { name: 'File' }));
@@ -309,7 +310,7 @@ describe('ShareModal', () => {
 
     it('announces JSON copy to screen reader', async () => {
       const announceSpy = vi.fn();
-      useUIStore.setState({ announceToScreenReader: announceSpy });
+      useInteractionStore.setState({ announceToScreenReader: announceSpy });
 
       render(<ShareModal isOpen={true} onClose={mockOnClose} />);
       fireEvent.click(screen.getByRole('tab', { name: 'JSON' }));
@@ -333,8 +334,8 @@ describe('ShareModal', () => {
     it('calls onClose when backdrop clicked', () => {
       render(<ShareModal isOpen={true} onClose={mockOnClose} />);
 
-      // The dialog role is on the backdrop div itself
-      const backdrop = screen.getByRole('dialog');
+      // The backdrop div has role="presentation"; the inner content has role="dialog"
+      const backdrop = screen.getByRole('presentation');
       fireEvent.click(backdrop);
 
       expect(mockOnClose).toHaveBeenCalledTimes(1);

--- a/src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.test.tsx
+++ b/src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { SharedLayoutBanner } from '@/features/cloud-share/components/SharedLayoutBanner';
-import { useUIStore } from '@/core/store/ui';
+import { useSharedPreviewStore } from '@/core/store/sharedPreview';
 import { useLayoutStore } from '@/core/store/layout';
 import { useLibraryStore } from '@/core/store/library';
 import { useToastStore } from '@/core/store/toast';
@@ -145,11 +145,8 @@ describe('SharedLayoutBanner', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Reset UI store
-    useUIStore.setState({
-      sharedLayoutPreview: null,
-      sharedLayoutOriginalName: null,
-    });
+    // Reset shared preview store
+    useSharedPreviewStore.getState().clearSharedLayoutPreview();
 
     // Reset layout store
     useLayoutStore.setState({
@@ -196,7 +193,7 @@ describe('SharedLayoutBanner', () => {
 
   describe('visibility', () => {
     it('does not render when sharedLayoutPreview is null', () => {
-      useUIStore.setState({ sharedLayoutPreview: null });
+      useSharedPreviewStore.getState().clearSharedLayoutPreview();
 
       const { container } = render(<SharedLayoutBanner />);
 
@@ -204,10 +201,7 @@ describe('SharedLayoutBanner', () => {
     });
 
     it('renders when sharedLayoutPreview is set', () => {
-      useUIStore.setState({
-        sharedLayoutPreview: mockLayout,
-        sharedLayoutOriginalName: 'Shared Layout',
-      });
+      useSharedPreviewStore.getState().setSharedLayoutPreview(mockLayout, 'Shared Layout');
 
       render(<SharedLayoutBanner />);
 
@@ -217,10 +211,7 @@ describe('SharedLayoutBanner', () => {
 
   describe('content', () => {
     beforeEach(() => {
-      useUIStore.setState({
-        sharedLayoutPreview: mockLayout,
-        sharedLayoutOriginalName: 'Original Name',
-      });
+      useSharedPreviewStore.getState().setSharedLayoutPreview(mockLayout, 'Original Name');
     });
 
     it('displays the original layout name', () => {
@@ -244,10 +235,7 @@ describe('SharedLayoutBanner', () => {
 
   describe('accessibility', () => {
     beforeEach(() => {
-      useUIStore.setState({
-        sharedLayoutPreview: mockLayout,
-        sharedLayoutOriginalName: 'Shared Layout',
-      });
+      useSharedPreviewStore.getState().setSharedLayoutPreview(mockLayout, 'Shared Layout');
     });
 
     it('has role="alert" for screen readers', () => {
@@ -266,10 +254,7 @@ describe('SharedLayoutBanner', () => {
 
   describe('save action', () => {
     beforeEach(() => {
-      useUIStore.setState({
-        sharedLayoutPreview: mockLayout,
-        sharedLayoutOriginalName: 'Original Name',
-      });
+      useSharedPreviewStore.getState().setSharedLayoutPreview(mockLayout, 'Original Name');
     });
 
     it('clears shared preview state after saving', async () => {
@@ -278,7 +263,7 @@ describe('SharedLayoutBanner', () => {
       fireEvent.click(screen.getByRole('button', { name: /Save to My Layouts/i }));
 
       await waitFor(() => {
-        const state = useUIStore.getState();
+        const state = useSharedPreviewStore.getState();
         expect(state.sharedLayoutPreview).toBeNull();
         expect(state.sharedLayoutOriginalName).toBeNull();
       });
@@ -325,10 +310,7 @@ describe('SharedLayoutBanner', () => {
 
   describe('discard action', () => {
     beforeEach(() => {
-      useUIStore.setState({
-        sharedLayoutPreview: mockLayout,
-        sharedLayoutOriginalName: 'Shared Layout',
-      });
+      useSharedPreviewStore.getState().setSharedLayoutPreview(mockLayout, 'Shared Layout');
     });
 
     it('shows confirmation dialog when clicking Discard', () => {
@@ -351,7 +333,7 @@ describe('SharedLayoutBanner', () => {
       const confirmButton = dialog.querySelector('.btn-danger') as HTMLElement;
       fireEvent.click(confirmButton);
 
-      const state = useUIStore.getState();
+      const state = useSharedPreviewStore.getState();
       expect(state.sharedLayoutPreview).toBeNull();
       expect(state.sharedLayoutOriginalName).toBeNull();
     });
@@ -395,7 +377,7 @@ describe('SharedLayoutBanner', () => {
       fireEvent.click(screen.getByRole('button', { name: /Keep viewing/i }));
 
       // State should remain unchanged
-      const state = useUIStore.getState();
+      const state = useSharedPreviewStore.getState();
       expect(state.sharedLayoutPreview).not.toBeNull();
       expect(state.sharedLayoutOriginalName).toBe('Shared Layout');
     });
@@ -403,10 +385,7 @@ describe('SharedLayoutBanner', () => {
 
   describe('edge cases', () => {
     it('handles missing sharedLayoutOriginalName gracefully', () => {
-      useUIStore.setState({
-        sharedLayoutPreview: mockLayout,
-        sharedLayoutOriginalName: null,
-      });
+      useSharedPreviewStore.getState().setSharedLayoutPreview(mockLayout);
 
       render(<SharedLayoutBanner />);
 
@@ -416,10 +395,7 @@ describe('SharedLayoutBanner', () => {
 
     it('handles empty layout name', () => {
       const emptyNameLayout = { ...mockLayout, name: '' };
-      useUIStore.setState({
-        sharedLayoutPreview: emptyNameLayout,
-        sharedLayoutOriginalName: '',
-      });
+      useSharedPreviewStore.getState().setSharedLayoutPreview(emptyNameLayout, '');
       useLayoutStore.setState({ layout: emptyNameLayout });
 
       render(<SharedLayoutBanner />);

--- a/src/features/cloud-share/hooks/useCloudShare.test.ts
+++ b/src/features/cloud-share/hooks/useCloudShare.test.ts
@@ -3,7 +3,7 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { useCloudShare } from '@/features/cloud-share/hooks/useCloudShare';
 import { useLibraryStore } from '@/core/store/library';
 import { useLayoutStore } from '@/core/store/layout';
-import { useUIStore } from '@/core/store/ui';
+import { useInteractionStore } from '@/core/store/interaction';
 import { createDefaultLayout } from '@/core/constants';
 import * as shareApi from '@/core/api/share';
 import * as storage from '@/core/storage';
@@ -80,7 +80,7 @@ describe('useCloudShare', () => {
       showLayoutManager: false,
     });
 
-    useUIStore.setState({
+    useInteractionStore.setState({
       announceToScreenReader: mockAnnounce,
     });
   });

--- a/src/features/command-palette/store/recentStore.ts
+++ b/src/features/command-palette/store/recentStore.ts
@@ -181,7 +181,7 @@ export const useRecentCommandsStore = create<FrecencyState>()((set, get) => {
         ...usage,
         [commandId]: {
           commandId,
-          useCount: existing.useCount + 1,
+          useCount: (existing?.useCount ?? 0) + 1, // eslint-disable-line @typescript-eslint/no-unnecessary-condition -- existing is undefined for new commands
           lastUsedAt: now,
         },
       };

--- a/src/features/grid-editor/components/Grid/GridCanvas/GridCanvas.test.tsx
+++ b/src/features/grid-editor/components/Grid/GridCanvas/GridCanvas.test.tsx
@@ -3,7 +3,9 @@ import { render, fireEvent, cleanup } from '@testing-library/react';
 import { createRef } from 'react';
 import { GridCanvas } from '@/features/grid-editor/components/Grid/GridCanvas';
 import { useLayoutStore } from '@/core/store/layout';
-import { useUIStore } from '@/core/store/ui';
+import { useSelectionStore } from '@/core/store/selection';
+import { useViewStore } from '@/core/store/view';
+import { useInteractionStore } from '@/core/store/interaction';
 import { createDefaultLayout } from '@/core/constants';
 import { resetAllStores } from '@/test/testUtils';
 import type { Bin } from '@/core/types';
@@ -48,7 +50,7 @@ describe('GridCanvas', () => {
     // Set test-specific state
     defaultLayout = createDefaultLayout();
     useLayoutStore.setState({ layout: defaultLayout });
-    useUIStore.setState({
+    useSelectionStore.setState({
       activeLayerId: defaultLayout.layers[0].id,
       activeCategoryId: defaultLayout.categories[0].id,
     });
@@ -162,8 +164,10 @@ describe('GridCanvas', () => {
       });
 
       // Active layer is still the first layer
-      useUIStore.setState({
+      useSelectionStore.setState({
         activeLayerId: defaultLayout.layers[0].id,
+      });
+      useViewStore.setState({
         showOtherLayers: false, // Don't show ghost bins
       });
 
@@ -201,8 +205,10 @@ describe('GridCanvas', () => {
       });
 
       // Set active layer to second layer, show other layers
-      useUIStore.setState({
+      useSelectionStore.setState({
         activeLayerId: 'layer-2',
+      });
+      useViewStore.setState({
         showOtherLayers: true,
       });
 
@@ -234,7 +240,7 @@ describe('GridCanvas', () => {
         },
       });
 
-      useUIStore.setState({
+      useSelectionStore.setState({
         activeLayerId: defaultLayout.layers[0].id,
         selectedBinIds: ['selected-bin'],
       });
@@ -310,7 +316,7 @@ describe('GridCanvas', () => {
     });
 
     it('shows cell cursor in paint mode', () => {
-      useUIStore.setState({
+      useInteractionStore.setState({
         paintSize: { width: 2, depth: 2 },
       });
 
@@ -330,7 +336,7 @@ describe('GridCanvas', () => {
     });
 
     it('disables touch actions during interaction', () => {
-      useUIStore.setState({
+      useInteractionStore.setState({
         interaction: {
           type: 'draw',
           start: { x: 0, y: 0 },
@@ -452,7 +458,7 @@ describe('GridCanvas', () => {
       });
 
       // Set active layer to layer 2 to see blocked zones
-      useUIStore.setState({
+      useSelectionStore.setState({
         activeLayerId: 'layer-2',
       });
 
@@ -492,7 +498,7 @@ describe('GridCanvas', () => {
         },
       });
 
-      useUIStore.setState({
+      useSelectionStore.setState({
         activeLayerId: 'layer-2',
         selectedBinIds: [],
       });
@@ -503,8 +509,8 @@ describe('GridCanvas', () => {
       fireEvent.click(blockedZone!);
 
       // Should switch to layer 1 and select the bin
-      expect(useUIStore.getState().activeLayerId).toBe('layer-1');
-      expect(useUIStore.getState().selectedBinIds).toContain('tall-bin');
+      expect(useSelectionStore.getState().activeLayerId).toBe('layer-1');
+      expect(useSelectionStore.getState().selectedBinIds).toContain('tall-bin');
     });
   });
 
@@ -616,7 +622,7 @@ describe('GridCanvas', () => {
   describe('Paint mode bin click behavior', () => {
     it('allows bin clicks to pass through in paint mode (does not intercept)', () => {
       // Set up paint mode
-      useUIStore.setState({
+      useInteractionStore.setState({
         paintSize: { width: 2, depth: 2 },
       });
 
@@ -644,7 +650,7 @@ describe('GridCanvas', () => {
       const { container } = renderGridCanvas();
 
       // Verify paint mode is active
-      expect(useUIStore.getState().paintSize).toEqual({ width: 2, depth: 2 });
+      expect(useInteractionStore.getState().paintSize).toEqual({ width: 2, depth: 2 });
 
       // Verify bin is rendered and can receive clicks
       const binElement = container.querySelector('[data-bin-id="test-bin-paint"]');
@@ -657,7 +663,7 @@ describe('GridCanvas', () => {
 
     it('clears paint mode when clicking on a bin', () => {
       // Set up paint mode
-      useUIStore.setState({
+      useInteractionStore.setState({
         paintSize: { width: 2, depth: 2 },
       });
 
@@ -685,7 +691,7 @@ describe('GridCanvas', () => {
       const { container } = renderGridCanvas();
 
       // Verify paint mode is active
-      expect(useUIStore.getState().paintSize).toEqual({ width: 2, depth: 2 });
+      expect(useInteractionStore.getState().paintSize).toEqual({ width: 2, depth: 2 });
 
       // Click on the bin
       const binElement = container.querySelector('[data-bin-id="test-bin-click"]');
@@ -695,13 +701,15 @@ describe('GridCanvas', () => {
       fireEvent.pointerDown(binElement!, { button: 0, isPrimary: true });
 
       // Paint mode should be cleared
-      expect(useUIStore.getState().paintSize).toBeNull();
+      expect(useInteractionStore.getState().paintSize).toBeNull();
     });
 
     it('selects the bin when clicking in paint mode', () => {
       // Set up paint mode
-      useUIStore.setState({
+      useInteractionStore.setState({
         paintSize: { width: 2, depth: 2 },
+      });
+      useSelectionStore.setState({
         selectedBinIds: [],
       });
 
@@ -733,7 +741,7 @@ describe('GridCanvas', () => {
       fireEvent.pointerDown(binElement!, { button: 0, isPrimary: true });
 
       // Bin should be selected
-      expect(useUIStore.getState().selectedBinIds).toContain('test-bin-select');
+      expect(useSelectionStore.getState().selectedBinIds).toContain('test-bin-select');
     });
   });
 });

--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.test.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import { resetAllStores } from '@/test/testUtils';
 import type { ReactNode } from 'react';
 import { IsometricPreview } from './IsometricPreview';
-import { useUIStore } from '@/core/store/ui';
+import { useInteractionStore } from '@/core/store/interaction';
 import { useLayoutStore } from '@/core/store/layout';
 import { createDefaultLayout } from '@/core/constants';
 
@@ -200,7 +200,7 @@ describe('IsometricPreview', () => {
     resetAllStores();
     const defaultLayout = createDefaultLayout();
     useLayoutStore.setState({ layout: defaultLayout });
-    useUIStore.setState({ showIsometricPreview: true });
+    useInteractionStore.setState({ showIsometricPreview: true });
   });
 
   it('renders when showIsometricPreview is true', () => {
@@ -209,7 +209,7 @@ describe('IsometricPreview', () => {
   });
 
   it('returns null when showIsometricPreview is false', () => {
-    useUIStore.setState({ showIsometricPreview: false });
+    useInteractionStore.setState({ showIsometricPreview: false });
     const { container } = render(<IsometricPreview />);
     expect(container.textContent).toBe('');
   });
@@ -225,7 +225,7 @@ describe('IsometricPreview', () => {
   });
 
   it('renders with isPreviewExpanded true', () => {
-    useUIStore.setState({ isPreviewExpanded: true });
+    useInteractionStore.setState({ isPreviewExpanded: true });
     const { getByTestId } = render(<IsometricPreview />);
     expect(getByTestId('r3f-canvas')).toBeTruthy();
   });

--- a/src/features/grid-editor/components/Grid/QuickLabelPopover/QuickLabelPopover.test.tsx
+++ b/src/features/grid-editor/components/Grid/QuickLabelPopover/QuickLabelPopover.test.tsx
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { resetAllStores } from '@/test/testUtils';
 import { QuickLabelPopover } from './QuickLabelPopover';
-import { useUIStore, useLayoutStore } from '@/core/store';
+import { useLayoutStore } from '@/core/store';
+import { useSelectionStore } from '@/core/store/selection';
 import { createDefaultLayout } from '@/core/constants';
 
 // Mock i18n
@@ -35,7 +36,7 @@ describe('QuickLabelPopover', () => {
   });
 
   it('renders nothing when quickLabelBinId is null', () => {
-    useUIStore.setState({ quickLabelBinId: null });
+    useSelectionStore.setState({ quickLabelBinId: null });
     const { container } = render(<QuickLabelPopover />);
     expect(container.textContent).toBe('');
   });
@@ -79,7 +80,7 @@ describe('QuickLabelPopover', () => {
         ],
       },
     });
-    useUIStore.setState({ quickLabelBinId: binId });
+    useSelectionStore.setState({ quickLabelBinId: binId });
 
     const { getByRole } = render(<QuickLabelPopover />);
     const input = getByRole('textbox');
@@ -127,7 +128,7 @@ describe('QuickLabelPopover', () => {
         ],
       },
     });
-    useUIStore.setState({ quickLabelBinId: binId });
+    useSelectionStore.setState({ quickLabelBinId: binId });
 
     const { getByRole } = render(<QuickLabelPopover />);
     const input = getByRole('textbox');
@@ -177,7 +178,7 @@ describe('QuickLabelPopover', () => {
         ],
       },
     });
-    useUIStore.setState({ quickLabelBinId: binId });
+    useSelectionStore.setState({ quickLabelBinId: binId });
 
     const { getByRole } = render(<QuickLabelPopover />);
     const input = getByRole('textbox') as HTMLInputElement;
@@ -211,7 +212,7 @@ describe('QuickLabelPopover', () => {
         ],
       },
     });
-    useUIStore.setState({ quickLabelBinId: binId });
+    useSelectionStore.setState({ quickLabelBinId: binId });
 
     const { container } = render(<QuickLabelPopover />);
     expect(container.textContent).toBe('');

--- a/src/features/grid-editor/hooks/useGridCoords.test.ts
+++ b/src/features/grid-editor/hooks/useGridCoords.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useGridCoords } from '@/features/grid-editor/hooks/useGridCoords';
-import { useUIStore } from '@/core/store/ui';
+import { useViewStore } from '@/core/store/view';
+import { useHalfBinModeStore } from '@/core/store/halfBinMode';
 import { useLayoutStore } from '@/core/store/layout';
 import { resetAllStores } from '@/test/testUtils';
 import type { RefObject } from 'react';
@@ -50,7 +51,8 @@ describe('useGridCoords', () => {
     useLayoutStore.setState({ layout });
 
     // Default UI state
-    useUIStore.setState({ zoom: 1, halfBinMode: false });
+    useViewStore.setState({ zoom: 1 });
+    useHalfBinModeStore.setState({ halfBinMode: false });
   });
 
   afterEach(() => {
@@ -97,7 +99,7 @@ describe('useGridCoords', () => {
       const gridRef = createMockGridRef(0, 0);
 
       // Test at zoom 2 (double size cells)
-      useUIStore.setState({ zoom: 2 });
+      useViewStore.setState({ zoom: 2 });
 
       const { result } = renderHook(() => useGridCoords(gridRef));
 
@@ -112,7 +114,7 @@ describe('useGridCoords', () => {
   describe('half-bin mode', () => {
     it('snaps to half-unit increments when enabled', () => {
       const gridRef = createMockGridRef(0, 0);
-      useUIStore.setState({ halfBinMode: true });
+      useHalfBinModeStore.setState({ halfBinMode: true });
 
       const { result } = renderHook(() => useGridCoords(gridRef));
 
@@ -126,11 +128,11 @@ describe('useGridCoords', () => {
     it('returns halfBinMode status', () => {
       const gridRef = createMockGridRef(0, 0);
 
-      useUIStore.setState({ halfBinMode: false });
+      useHalfBinModeStore.setState({ halfBinMode: false });
       const { result: result1 } = renderHook(() => useGridCoords(gridRef));
       expect(result1.current.halfBinMode).toBe(false);
 
-      useUIStore.setState({ halfBinMode: true });
+      useHalfBinModeStore.setState({ halfBinMode: true });
       const { result: result2 } = renderHook(() => useGridCoords(gridRef));
       expect(result2.current.halfBinMode).toBe(true);
     });
@@ -157,7 +159,7 @@ describe('useGridCoords', () => {
 
     it('clamps to half-unit bounds when halfBinMode is enabled', () => {
       const gridRef = createMockGridRef(0, 0);
-      useUIStore.setState({ halfBinMode: true });
+      useHalfBinModeStore.setState({ halfBinMode: true });
 
       const { result } = renderHook(() => useGridCoords(gridRef));
 
@@ -169,7 +171,7 @@ describe('useGridCoords', () => {
 
     it('snaps to half-unit increments in halfBinMode', () => {
       const gridRef = createMockGridRef(0, 0);
-      useUIStore.setState({ halfBinMode: true });
+      useHalfBinModeStore.setState({ halfBinMode: true });
 
       const { result } = renderHook(() => useGridCoords(gridRef));
 
@@ -215,11 +217,11 @@ describe('useGridCoords', () => {
     it('returns cell size based on zoom', () => {
       const gridRef = createMockGridRef(0, 0);
 
-      useUIStore.setState({ zoom: 1 });
+      useViewStore.setState({ zoom: 1 });
       const { result: result1 } = renderHook(() => useGridCoords(gridRef));
       const size1 = result1.current.cellSize;
 
-      useUIStore.setState({ zoom: 2 });
+      useViewStore.setState({ zoom: 2 });
       const { result: result2 } = renderHook(() => useGridCoords(gridRef));
       const size2 = result2.current.cellSize;
 
@@ -267,7 +269,7 @@ describe('useGridCoords', () => {
       layout.drawer = { width: 10.5, depth: 8, height: 12, fractionalEdgeX: 'start' };
       useLayoutStore.setState({ layout });
 
-      useUIStore.setState({ halfBinMode: false });
+      useHalfBinModeStore.setState({ halfBinMode: false });
 
       const { result } = renderHook(() => useGridCoords(gridRef));
 
@@ -287,7 +289,7 @@ describe('useGridCoords', () => {
       layout.drawer = { width: 10, depth: 8.5, height: 12, fractionalEdgeY: 'end' };
       useLayoutStore.setState({ layout });
 
-      useUIStore.setState({ halfBinMode: false });
+      useHalfBinModeStore.setState({ halfBinMode: false });
 
       const { result } = renderHook(() => useGridCoords(gridRef));
 
@@ -308,7 +310,7 @@ describe('useGridCoords', () => {
       layout.drawer = { width: 10, depth: 8.5, height: 12, fractionalEdgeY: 'end' };
       useLayoutStore.setState({ layout });
 
-      useUIStore.setState({ halfBinMode: true });
+      useHalfBinModeStore.setState({ halfBinMode: true });
 
       const { result } = renderHook(() => useGridCoords(gridRef));
 

--- a/src/features/grid-editor/hooks/useGridNavigation.test.ts
+++ b/src/features/grid-editor/hooks/useGridNavigation.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useGridNavigation } from '@/features/grid-editor/hooks/useGridNavigation';
 import { useLayoutStore } from '@/core/store/layout';
-import { useUIStore } from '@/core/store/ui';
+import { useSelectionStore } from '@/core/store/selection';
+import { useInteractionStore } from '@/core/store/interaction';
 import { resetAllStores } from '@/test/testUtils';
 import type { Bin } from '@/core/types';
 
@@ -32,10 +33,10 @@ describe('useGridNavigation', () => {
 
   describe('handleNavigationKey', () => {
     it('does nothing when no bin is focused', () => {
-      const setFocusedBinSpy = vi.spyOn(useUIStore.getState(), 'setFocusedBin');
+      const setFocusedBinSpy = vi.spyOn(useSelectionStore.getState(), 'setFocusedBin');
 
       // No focused bin
-      useUIStore.setState({ focusedBinId: null });
+      useSelectionStore.setState({ focusedBinId: null });
 
       const { result } = renderHook(() => useGridNavigation());
 
@@ -47,10 +48,10 @@ describe('useGridNavigation', () => {
     });
 
     it('does nothing when focused bin does not exist', () => {
-      const setFocusedBinSpy = vi.spyOn(useUIStore.getState(), 'setFocusedBin');
+      const setFocusedBinSpy = vi.spyOn(useSelectionStore.getState(), 'setFocusedBin');
 
       // Focused bin ID that doesn't exist in layout
-      useUIStore.setState({ focusedBinId: 'nonexistent', activeLayerId: 'layer1' });
+      useSelectionStore.setState({ focusedBinId: 'nonexistent', activeLayerId: 'layer1' });
       useLayoutStore.setState({
         layout: {
           ...useLayoutStore.getState().layout,
@@ -77,7 +78,7 @@ describe('useGridNavigation', () => {
           layers: [{ id: 'layer1', name: 'Layer 1', height: 3 }],
         },
       });
-      useUIStore.setState({ focusedBinId: 'bin1', activeLayerId: 'layer1' });
+      useSelectionStore.setState({ focusedBinId: 'bin1', activeLayerId: 'layer1' });
 
       const { result } = renderHook(() => useGridNavigation());
 
@@ -85,7 +86,7 @@ describe('useGridNavigation', () => {
         result.current.handleNavigationKey('ArrowRight');
       });
 
-      expect(useUIStore.getState().focusedBinId).toBe('bin2');
+      expect(useSelectionStore.getState().focusedBinId).toBe('bin2');
     });
 
     it('navigates left to nearest bin', () => {
@@ -98,7 +99,7 @@ describe('useGridNavigation', () => {
           layers: [{ id: 'layer1', name: 'Layer 1', height: 3 }],
         },
       });
-      useUIStore.setState({ focusedBinId: 'bin3', activeLayerId: 'layer1' });
+      useSelectionStore.setState({ focusedBinId: 'bin3', activeLayerId: 'layer1' });
 
       const { result } = renderHook(() => useGridNavigation());
 
@@ -106,7 +107,7 @@ describe('useGridNavigation', () => {
         result.current.handleNavigationKey('ArrowLeft');
       });
 
-      expect(useUIStore.getState().focusedBinId).toBe('bin2');
+      expect(useSelectionStore.getState().focusedBinId).toBe('bin2');
     });
 
     it('navigates down to nearest bin', () => {
@@ -126,7 +127,7 @@ describe('useGridNavigation', () => {
         },
       });
       // Start from top bin, navigate down
-      useUIStore.setState({ focusedBinId: 'bin3', activeLayerId: 'layer1' });
+      useSelectionStore.setState({ focusedBinId: 'bin3', activeLayerId: 'layer1' });
 
       const { result } = renderHook(() => useGridNavigation());
 
@@ -135,7 +136,7 @@ describe('useGridNavigation', () => {
       });
 
       // Should move to bin2 (lower Y value)
-      expect(useUIStore.getState().focusedBinId).toBe('bin2');
+      expect(useSelectionStore.getState().focusedBinId).toBe('bin2');
     });
 
     it('navigates up to nearest bin', () => {
@@ -155,7 +156,7 @@ describe('useGridNavigation', () => {
         },
       });
       // Start from bottom bin, navigate up
-      useUIStore.setState({ focusedBinId: 'bin1', activeLayerId: 'layer1' });
+      useSelectionStore.setState({ focusedBinId: 'bin1', activeLayerId: 'layer1' });
 
       const { result } = renderHook(() => useGridNavigation());
 
@@ -164,7 +165,7 @@ describe('useGridNavigation', () => {
       });
 
       // Should move to bin2 (higher Y value)
-      expect(useUIStore.getState().focusedBinId).toBe('bin2');
+      expect(useSelectionStore.getState().focusedBinId).toBe('bin2');
     });
 
     it('ignores non-arrow keys', () => {
@@ -177,7 +178,7 @@ describe('useGridNavigation', () => {
           layers: [{ id: 'layer1', name: 'Layer 1', height: 3 }],
         },
       });
-      useUIStore.setState({ focusedBinId: 'bin1', activeLayerId: 'layer1' });
+      useSelectionStore.setState({ focusedBinId: 'bin1', activeLayerId: 'layer1' });
 
       const { result } = renderHook(() => useGridNavigation());
 
@@ -188,7 +189,7 @@ describe('useGridNavigation', () => {
       });
 
       // Should still be on bin1
-      expect(useUIStore.getState().focusedBinId).toBe('bin1');
+      expect(useSelectionStore.getState().focusedBinId).toBe('bin1');
     });
 
     it('does nothing when no bin in direction', () => {
@@ -201,7 +202,7 @@ describe('useGridNavigation', () => {
           layers: [{ id: 'layer1', name: 'Layer 1', height: 3 }],
         },
       });
-      useUIStore.setState({ focusedBinId: 'bin1', activeLayerId: 'layer1' });
+      useSelectionStore.setState({ focusedBinId: 'bin1', activeLayerId: 'layer1' });
 
       const { result } = renderHook(() => useGridNavigation());
 
@@ -210,7 +211,7 @@ describe('useGridNavigation', () => {
       });
 
       // Should still be on bin1 (no bin to the right)
-      expect(useUIStore.getState().focusedBinId).toBe('bin1');
+      expect(useSelectionStore.getState().focusedBinId).toBe('bin1');
     });
 
     it('announces navigation to screen reader', () => {
@@ -223,7 +224,7 @@ describe('useGridNavigation', () => {
           layers: [{ id: 'layer1', name: 'Layer 1', height: 3 }],
         },
       });
-      useUIStore.setState({ focusedBinId: 'bin1', activeLayerId: 'layer1' });
+      useSelectionStore.setState({ focusedBinId: 'bin1', activeLayerId: 'layer1' });
 
       const { result } = renderHook(() => useGridNavigation());
 
@@ -232,7 +233,7 @@ describe('useGridNavigation', () => {
       });
 
       // Check that announcement was made (liveMessage is set)
-      expect(useUIStore.getState().liveMessage).toContain('Screws');
+      expect(useInteractionStore.getState().liveMessage).toContain('Screws');
     });
 
     it('navigates only within active layer', () => {
@@ -252,7 +253,7 @@ describe('useGridNavigation', () => {
           ],
         },
       });
-      useUIStore.setState({ focusedBinId: 'bin1', activeLayerId: 'layer1' });
+      useSelectionStore.setState({ focusedBinId: 'bin1', activeLayerId: 'layer1' });
 
       const { result } = renderHook(() => useGridNavigation());
 
@@ -261,7 +262,7 @@ describe('useGridNavigation', () => {
       });
 
       // Should skip bin2 (different layer) and go to bin3
-      expect(useUIStore.getState().focusedBinId).toBe('bin3');
+      expect(useSelectionStore.getState().focusedBinId).toBe('bin3');
     });
   });
 
@@ -284,13 +285,13 @@ describe('useGridNavigation', () => {
       });
 
       // Initially no focus
-      useUIStore.setState({ focusedBinId: null, activeLayerId: 'layer1' });
+      useSelectionStore.setState({ focusedBinId: null, activeLayerId: 'layer1' });
 
       renderHook(() => useGridNavigation());
 
       // Set focused bin
       act(() => {
-        useUIStore.getState().setFocusedBin('bin1');
+        useSelectionStore.getState().setFocusedBin('bin1');
       });
 
       // Element should be focused
@@ -301,14 +302,14 @@ describe('useGridNavigation', () => {
     });
 
     it('does nothing when no focusedBinId', () => {
-      useUIStore.setState({ focusedBinId: null });
+      useSelectionStore.setState({ focusedBinId: null });
 
       // Should not throw
       expect(() => renderHook(() => useGridNavigation())).not.toThrow();
     });
 
     it('does nothing when element not found', () => {
-      useUIStore.setState({ focusedBinId: 'nonexistent', activeLayerId: 'layer1' });
+      useSelectionStore.setState({ focusedBinId: 'nonexistent', activeLayerId: 'layer1' });
 
       // Should not throw even if element doesn't exist
       expect(() => renderHook(() => useGridNavigation())).not.toThrow();

--- a/src/features/inspiration-gallery/components/InspirationGallery/InspirationGallery.test.tsx
+++ b/src/features/inspiration-gallery/components/InspirationGallery/InspirationGallery.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { InspirationGallery } from '.';
-import { useUIStore } from '@/core/store/ui';
+import { useInteractionStore } from '@/core/store/interaction';
+import { useMobileStore } from '@/core/store/mobile';
 import { useToastStore } from '@/core/store/toast';
 import type { InspirationLayout } from '../../types';
 
@@ -244,10 +245,12 @@ describe('InspirationGallery', () => {
     document.body.style.overflow = '';
 
     // Spy on store methods
-    vi.spyOn(useUIStore.getState(), 'announceToScreenReader').mockImplementation(
+    vi.spyOn(useInteractionStore.getState(), 'announceToScreenReader').mockImplementation(
       mockAnnounceToScreenReader
     );
-    vi.spyOn(useUIStore.getState(), 'closeMobilePanel').mockImplementation(mockCloseMobilePanel);
+    vi.spyOn(useMobileStore.getState(), 'closeMobilePanel').mockImplementation(
+      mockCloseMobilePanel
+    );
     vi.spyOn(useToastStore.getState(), 'addToast').mockImplementation(mockAddToast);
   });
 

--- a/src/features/layers/components/LayerPanel/LayerPanel.test.tsx
+++ b/src/features/layers/components/LayerPanel/LayerPanel.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { LayerPanel } from '@/features/layers/components/LayerPanel';
-import { useLayoutStore, useUIStore } from '@/core/store';
+import { useLayoutStore } from '@/core/store';
+import { useSelectionStore } from '@/core/store/selection';
 import { resetAllStores } from '@/test/testUtils';
 import type { Layer } from '@/core/types';
 
@@ -62,7 +63,7 @@ describe('LayerPanel', () => {
     // Set activeLayerId to match the default layer
     const defaultLayerId = useLayoutStore.getState().layout.layers[0]?.id;
     if (defaultLayerId) {
-      useUIStore.setState({ activeLayerId: defaultLayerId });
+      useSelectionStore.setState({ activeLayerId: defaultLayerId });
     }
   });
 
@@ -106,7 +107,7 @@ describe('LayerPanel', () => {
       useLayoutStore.setState({
         layout: { ...layout, layers: [] },
       });
-      useUIStore.setState({ activeLayerId: null });
+      useSelectionStore.setState({ activeLayerId: null });
 
       const { container } = render(<LayerPanel />);
 
@@ -134,7 +135,7 @@ describe('LayerPanel', () => {
       useLayoutStore.setState({
         layout: { ...layout, layers },
       });
-      useUIStore.setState({ activeLayerId: 'layer-0' });
+      useSelectionStore.setState({ activeLayerId: 'layer-0' });
 
       render(<LayerPanel />);
 
@@ -151,7 +152,7 @@ describe('LayerPanel', () => {
           layers: [{ id: 'layer-1', name: 'Layer 1', height: 3 }],
         },
       });
-      useUIStore.setState({ activeLayerId: 'layer-1' });
+      useSelectionStore.setState({ activeLayerId: 'layer-1' });
 
       render(<LayerPanel />);
 
@@ -161,10 +162,10 @@ describe('LayerPanel', () => {
     it('sets new layer as active', () => {
       render(<LayerPanel />);
 
-      const initialActiveId = useUIStore.getState().activeLayerId;
+      const initialActiveId = useSelectionStore.getState().activeLayerId;
       fireEvent.click(screen.getByLabelText('Add new layer'));
 
-      expect(useUIStore.getState().activeLayerId).not.toBe(initialActiveId);
+      expect(useSelectionStore.getState().activeLayerId).not.toBe(initialActiveId);
     });
   });
 
@@ -181,7 +182,7 @@ describe('LayerPanel', () => {
           ],
         },
       });
-      useUIStore.setState({ activeLayerId: 'layer-2' });
+      useSelectionStore.setState({ activeLayerId: 'layer-2' });
     });
 
     it('shows delete button for active layer when multiple layers exist', () => {
@@ -232,7 +233,7 @@ describe('LayerPanel', () => {
       fireEvent.click(screen.getByLabelText('Delete Layer 2 layer'));
       fireEvent.click(screen.getByTestId('confirm-button'));
 
-      expect(useUIStore.getState().activeLayerId).toBe('layer-1');
+      expect(useSelectionStore.getState().activeLayerId).toBe('layer-1');
     });
 
     it('does not show delete button for single layer', () => {
@@ -244,7 +245,7 @@ describe('LayerPanel', () => {
           layers: [{ id: 'layer-1', name: 'Layer 1', height: 3 }],
         },
       });
-      useUIStore.setState({ activeLayerId: 'layer-1' });
+      useSelectionStore.setState({ activeLayerId: 'layer-1' });
 
       render(<LayerPanel />);
 
@@ -265,17 +266,20 @@ describe('LayerPanel', () => {
           ],
         },
       });
-      useUIStore.setState({ activeLayerId: 'layer-1' });
+      useSelectionStore.setState({ activeLayerId: 'layer-1' });
     });
 
     it('clicking layer name sets it as active', () => {
       render(<LayerPanel />);
 
-      // Click on the layer button for Layer 2
-      const layer2Button = screen.getByRole('button', { name: /Layer 2/ });
-      fireEvent.click(layer2Button);
+      // Click on the inner name button for Layer 2 (filter by aria-pressed to
+      // distinguish from the outer draggable div which also has role="button")
+      const layer2Buttons = screen.getAllByRole('button', { name: /Layer 2/ });
+      const layer2NameButton = layer2Buttons.find((btn) => btn.hasAttribute('aria-pressed'));
+      expect(layer2NameButton).toBeTruthy();
+      fireEvent.click(layer2NameButton!);
 
-      expect(useUIStore.getState().activeLayerId).toBe('layer-2');
+      expect(useSelectionStore.getState().activeLayerId).toBe('layer-2');
     });
   });
 
@@ -356,7 +360,7 @@ describe('LayerPanel', () => {
           layers: [{ id: 'layer-1', name: 'Layer 1', height: 5 }],
         },
       });
-      useUIStore.setState({ activeLayerId: 'layer-1' });
+      useSelectionStore.setState({ activeLayerId: 'layer-1' });
 
       render(<LayerPanel />);
 
@@ -373,7 +377,7 @@ describe('LayerPanel', () => {
           layers: [{ id: 'layer-1', name: 'Layer 1', height: 1 }],
         },
       });
-      useUIStore.setState({ activeLayerId: 'layer-1' });
+      useSelectionStore.setState({ activeLayerId: 'layer-1' });
 
       render(<LayerPanel />);
 
@@ -393,7 +397,7 @@ describe('LayerPanel', () => {
           ],
         },
       });
-      useUIStore.setState({ activeLayerId: 'layer-1' });
+      useSelectionStore.setState({ activeLayerId: 'layer-1' });
     });
 
     it('shows height capacity indicator for multiple layers', () => {
@@ -430,7 +434,7 @@ describe('LayerPanel', () => {
           ],
         },
       });
-      useUIStore.setState({ activeLayerId: 'layer-1' });
+      useSelectionStore.setState({ activeLayerId: 'layer-1' });
     });
 
     it('layers are draggable when multiple exist', () => {

--- a/src/features/layers/components/LayerPanel/LayerPanel.tsx
+++ b/src/features/layers/components/LayerPanel/LayerPanel.tsx
@@ -341,9 +341,8 @@ export function LayerPanel() {
                   <div className="absolute -top-0.5 left-0 right-0 h-1 bg-accent z-10 pointer-events-none" />
                 )}
 
+                {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- keyboard users interact with inner buttons */}
                 <div
-                  role="button"
-                  tabIndex={0}
                   draggable={hasMultipleLayers && !editingLayerId}
                   onDragStart={(e) => handleDragStart(e, displayIndex)}
                   onDragOver={(e) => handleDragOver(e, displayIndex)}
@@ -351,12 +350,6 @@ export function LayerPanel() {
                   onDrop={handleDrop}
                   onDragEnd={handleDragEnd}
                   onClick={() => !isEditing && setActiveLayer(layer.id)}
-                  onKeyDown={(e) => {
-                    if ((e.key === 'Enter' || e.key === ' ') && !isEditing) {
-                      e.preventDefault();
-                      setActiveLayer(layer.id);
-                    }
-                  }}
                   className={`group flex items-center gap-2 px-2 py-1.5 text-xs transition-all border-l-2 ${
                     isActive
                       ? 'bg-accent/15 border-l-accent text-content font-medium'

--- a/src/features/layout-library/components/LayoutManagerModal/LayoutList/LayoutList.test.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutList/LayoutList.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { LayoutList } from '@/features/layout-library/components/LayoutManagerModal/LayoutList';
-import { useLayoutStore, useUIStore } from '@/core/store';
+import { useLayoutStore } from '@/core/store';
+import { useInteractionStore } from '@/core/store/interaction';
 import { resetAllStores } from '@/test/testUtils';
 import type { LayoutEntry } from '@/core/types';
 
@@ -303,7 +304,7 @@ describe('LayoutList', () => {
 
     it('calls onRename and announces to screen reader', () => {
       const announceToScreenReader = vi.fn();
-      useUIStore.setState({ announceToScreenReader });
+      useInteractionStore.setState({ announceToScreenReader });
 
       render(<LayoutList {...defaultProps} />);
 
@@ -317,7 +318,7 @@ describe('LayoutList', () => {
 
     it('calls onDuplicate and announces to screen reader', () => {
       const announceToScreenReader = vi.fn();
-      useUIStore.setState({ announceToScreenReader });
+      useInteractionStore.setState({ announceToScreenReader });
 
       render(<LayoutList {...defaultProps} />);
 
@@ -330,7 +331,7 @@ describe('LayoutList', () => {
 
     it('calls onDelete and announces to screen reader', () => {
       const announceToScreenReader = vi.fn();
-      useUIStore.setState({ announceToScreenReader });
+      useInteractionStore.setState({ announceToScreenReader });
 
       render(<LayoutList {...defaultProps} />);
 
@@ -390,7 +391,7 @@ describe('LayoutList', () => {
     it('calls download with layout data', async () => {
       const { downloadLayoutAsFile } = await import('@/core/storage');
       const announceToScreenReader = vi.fn();
-      useUIStore.setState({ announceToScreenReader });
+      useInteractionStore.setState({ announceToScreenReader });
 
       // Setup current layout in store
       useLayoutStore.setState({

--- a/src/features/layout-library/components/LayoutManagerModal/LayoutManagerModal.test.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutManagerModal.test.tsx
@@ -689,7 +689,8 @@ describe('LayoutManagerModal Accessibility', () => {
     it('closes when clicking backdrop', () => {
       render(<LayoutManagerModal isOpen={true} onClose={mockOnClose} />);
 
-      const backdrop = screen.getByRole('presentation');
+      // Multiple elements may have role="presentation"; the backdrop is the first (outermost) one
+      const backdrop = screen.getAllByRole('presentation')[0];
       act(() => {
         fireEvent.click(backdrop);
       });

--- a/src/features/layout-library/hooks/useLayoutRouting.scenario.cloudShare.test.ts
+++ b/src/features/layout-library/hooks/useLayoutRouting.scenario.cloudShare.test.ts
@@ -11,7 +11,7 @@ import { renderHook, act } from '@testing-library/react';
 import { useLayoutRouting } from '@/features/layout-library/hooks/useLayoutRouting';
 import { useLayoutStore } from '@/core/store/layout';
 import { useLibraryStore } from '@/core/store/library';
-import { useUIStore } from '@/core/store/ui';
+import { useSharedPreviewStore } from '@/core/store/sharedPreview';
 import * as url from '@/utils/url';
 
 // Mock the url utilities
@@ -79,7 +79,8 @@ describe('useLayoutRouting with cloud share URLs', () => {
       },
     });
 
-    useUIStore.setState({
+    useSharedPreviewStore.setState({
+      sharedPreview: null,
       sharedLayoutPreview: null,
     });
 
@@ -200,10 +201,13 @@ describe('useLayoutRouting with cloud share URLs', () => {
   describe('shared preview mode', () => {
     it('should preserve URL when in shared preview mode', () => {
       // During shared preview, keep the share URL visible for better UX
-      useUIStore.setState({
-        sharedLayoutPreview: {
+      useSharedPreviewStore.setState({
+        sharedPreview: {
           layout: {} as any,
-          layoutName: 'Shared Layout',
+          originalName: 'Shared Layout',
+          authorName: null,
+          cloudShareId: null,
+          permission: null,
         },
       });
 

--- a/src/features/layout-library/hooks/useLayoutRouting.test.ts
+++ b/src/features/layout-library/hooks/useLayoutRouting.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useLayoutRouting } from '@/features/layout-library/hooks/useLayoutRouting';
-import { useLayoutStore, useLibraryStore, useUIStore, useToastStore } from '@/core/store';
+import { useLayoutStore, useLibraryStore, useToastStore } from '@/core/store';
+import { useSelectionStore } from '@/core/store/selection';
+import { useSharedPreviewStore } from '@/core/store/sharedPreview';
 import { resetAllStores } from '@/test/testUtils';
 import * as storage from '@/core/storage';
 import * as url from '@/utils/url';
@@ -49,6 +51,9 @@ describe('useLayoutRouting', () => {
 
   beforeEach(() => {
     resetAllStores();
+    // resetAllStores clears legacy fields but not the consolidated sharedPreview
+    // field, so explicitly clear it to prevent cross-test contamination.
+    useSharedPreviewStore.setState({ sharedPreview: null });
     vi.clearAllMocks();
 
     // Set up default mocks
@@ -74,8 +79,8 @@ describe('useLayoutRouting', () => {
       activeLayoutId: 'layout123test',
     });
 
-    // Set up UI store
-    useUIStore.setState({
+    // Set up selection store
+    useSelectionStore.setState({
       activeLayerId: 'layer1',
       activeCategoryId: 'coral',
     });
@@ -133,26 +138,26 @@ describe('useLayoutRouting', () => {
     });
 
     it('clears selection when navigating', async () => {
-      useUIStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
+      useSelectionStore.setState({ selectedBinIds: ['bin1', 'bin2'] });
 
       const { result } = renderHook(() => useLayoutRouting());
       await result.current.navigateToLayout('layout123test');
 
-      expect(useUIStore.getState().selectedBinIds).toEqual([]);
+      expect(useSelectionStore.getState().selectedBinIds).toEqual([]);
     });
 
     it('sets active layer to first layer', async () => {
       const { result } = renderHook(() => useLayoutRouting());
       await result.current.navigateToLayout('layout123test');
 
-      expect(useUIStore.getState().activeLayerId).toBe('layer1');
+      expect(useSelectionStore.getState().activeLayerId).toBe('layer1');
     });
 
     it('sets active category to first category', async () => {
       const { result } = renderHook(() => useLayoutRouting());
       await result.current.navigateToLayout('layout123test');
 
-      expect(useUIStore.getState().activeCategoryId).toBe('coral');
+      expect(useSelectionStore.getState().activeCategoryId).toBe('coral');
     });
 
     it('clears undo history', async () => {
@@ -278,7 +283,15 @@ describe('useLayoutRouting', () => {
     });
 
     it('skips popstate during shared preview', () => {
-      useUIStore.setState({ sharedLayoutPreview: mockLayout });
+      useSharedPreviewStore.setState({
+        sharedPreview: {
+          layout: mockLayout,
+          originalName: mockLayout.name,
+          authorName: null,
+          cloudShareId: null,
+          permission: null,
+        },
+      });
 
       renderHook(() => useLayoutRouting());
 
@@ -321,7 +334,15 @@ describe('useLayoutRouting', () => {
 
     it('preserves URL during shared preview', () => {
       // During shared preview, keep the share URL visible for better UX
-      useUIStore.setState({ sharedLayoutPreview: mockLayout });
+      useSharedPreviewStore.setState({
+        sharedPreview: {
+          layout: mockLayout,
+          originalName: mockLayout.name,
+          authorName: null,
+          cloudShareId: null,
+          permission: null,
+        },
+      });
 
       renderHook(() => useLayoutRouting());
 

--- a/src/features/print-export/hooks/usePrintList.test.ts
+++ b/src/features/print-export/hooks/usePrintList.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { usePrintList } from '@/features/print-export/hooks/usePrintList';
 import { useLayoutStore } from '@/core/store/layout';
-import { useUIStore } from '@/core/store/ui';
+import { useSelectionStore } from '@/core/store/selection';
 import { createDefaultLayout, generateId } from '@/core/constants';
 import type { Layout, Bin } from '@/core/types';
 
@@ -47,7 +47,7 @@ describe('usePrintList', () => {
       layout,
       activeLayoutId: 'test-layout',
     });
-    useUIStore.setState({
+    useSelectionStore.setState({
       selectedBinIds: [],
     });
   });
@@ -320,7 +320,7 @@ describe('usePrintList', () => {
       useLayoutStore.setState({ layout });
 
       const setSelectedBinsMock = vi.fn();
-      useUIStore.setState({ setSelectedBins: setSelectedBinsMock });
+      useSelectionStore.setState({ setSelectedBins: setSelectedBinsMock });
 
       const { result } = renderHook(() => usePrintList());
 

--- a/src/features/staging/components/Staging/Staging.test.tsx
+++ b/src/features/staging/components/Staging/Staging.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Staging } from '@/features/staging/components/Staging';
-import { useLayoutStore, useUIStore } from '@/core/store';
+import { useLayoutStore } from '@/core/store';
+import { useSelectionStore } from '@/core/store/selection';
+import { useViewStore } from '@/core/store/view';
+import { useInteractionStore } from '@/core/store/interaction';
 import { resetAllStores } from '@/test/testUtils';
 import { STAGING_ID } from '@/core/constants';
 import type { Bin } from '@/core/types';
@@ -157,12 +160,12 @@ describe('Staging', () => {
       const binElement = document.querySelector(`[data-staging-bin-id="${bins[0].id}"]`);
       fireEvent.click(binElement!);
 
-      expect(useUIStore.getState().selectedBinIds).toContain(bins[0].id);
+      expect(useSelectionStore.getState().selectedBinIds).toContain(bins[0].id);
     });
 
     it('toggles selection with ctrl+click', () => {
       const bins = addStagedBins([{}, {}]);
-      useUIStore.getState().setSelectedBin(bins[0].id);
+      useSelectionStore.getState().setSelectedBin(bins[0].id);
 
       render(<Staging />);
 
@@ -170,38 +173,38 @@ describe('Staging', () => {
       fireEvent.click(binElement!, { ctrlKey: true });
 
       // Both bins should now be selected
-      expect(useUIStore.getState().selectedBinIds).toContain(bins[0].id);
-      expect(useUIStore.getState().selectedBinIds).toContain(bins[1].id);
+      expect(useSelectionStore.getState().selectedBinIds).toContain(bins[0].id);
+      expect(useSelectionStore.getState().selectedBinIds).toContain(bins[1].id);
     });
 
     it('toggles selection with meta+click (Mac)', () => {
       const bins = addStagedBins([{}, {}]);
-      useUIStore.getState().setSelectedBin(bins[0].id);
+      useSelectionStore.getState().setSelectedBin(bins[0].id);
 
       render(<Staging />);
 
       const binElement = document.querySelector(`[data-staging-bin-id="${bins[1].id}"]`);
       fireEvent.click(binElement!, { metaKey: true });
 
-      expect(useUIStore.getState().selectedBinIds).toContain(bins[0].id);
-      expect(useUIStore.getState().selectedBinIds).toContain(bins[1].id);
+      expect(useSelectionStore.getState().selectedBinIds).toContain(bins[0].id);
+      expect(useSelectionStore.getState().selectedBinIds).toContain(bins[1].id);
     });
 
     it('replaces selection on regular click', () => {
       const bins = addStagedBins([{}, {}]);
-      useUIStore.getState().setSelectedBin(bins[0].id);
+      useSelectionStore.getState().setSelectedBin(bins[0].id);
 
       render(<Staging />);
 
       const binElement = document.querySelector(`[data-staging-bin-id="${bins[1].id}"]`);
       fireEvent.click(binElement!);
 
-      expect(useUIStore.getState().selectedBinIds).toEqual([bins[1].id]);
+      expect(useSelectionStore.getState().selectedBinIds).toEqual([bins[1].id]);
     });
 
     it('shows selection ring on selected bins', () => {
       const bins = addStagedBins([{}]);
-      useUIStore.getState().setSelectedBin(bins[0].id);
+      useSelectionStore.getState().setSelectedBin(bins[0].id);
 
       render(<Staging />);
 
@@ -213,7 +216,7 @@ describe('Staging', () => {
   describe('context menu', () => {
     it('shows context menu on right-click', () => {
       const bins = addStagedBins([{}]);
-      const showContextMenuSpy = vi.spyOn(useUIStore.getState(), 'showContextMenu');
+      const showContextMenuSpy = vi.spyOn(useViewStore.getState(), 'showContextMenu');
 
       render(<Staging />);
 
@@ -226,7 +229,7 @@ describe('Staging', () => {
     it('selects bin if not already selected on right-click', () => {
       const bins = addStagedBins([{}, {}]);
       // Select first bin
-      useUIStore.getState().setSelectedBin(bins[0].id);
+      useSelectionStore.getState().setSelectedBin(bins[0].id);
 
       render(<Staging />);
 
@@ -235,7 +238,7 @@ describe('Staging', () => {
       fireEvent.contextMenu(binElement!, { clientX: 100, clientY: 100 });
 
       // Second bin should now be selected
-      expect(useUIStore.getState().selectedBinIds).toContain(bins[1].id);
+      expect(useSelectionStore.getState().selectedBinIds).toContain(bins[1].id);
     });
   });
 
@@ -314,8 +317,10 @@ describe('Staging', () => {
       const binElement = document.querySelector(`[data-staging-bin-id="${bins[0].id}"]`);
       fireEvent.pointerDown(binElement!, { button: 0 });
 
-      expect(useUIStore.getState().interaction?.type).toBe('stagingDrag');
-      expect((useUIStore.getState().interaction as { binId: string })?.binId).toBe(bins[0].id);
+      expect(useInteractionStore.getState().interaction?.type).toBe('stagingDrag');
+      expect((useInteractionStore.getState().interaction as { binId: string })?.binId).toBe(
+        bins[0].id
+      );
     });
 
     it('ignores non-primary button pointer down', () => {
@@ -326,12 +331,12 @@ describe('Staging', () => {
       const binElement = document.querySelector(`[data-staging-bin-id="${bins[0].id}"]`);
       fireEvent.pointerDown(binElement!, { button: 2 }); // Right click
 
-      expect(useUIStore.getState().interaction).toBeNull();
+      expect(useInteractionStore.getState().interaction).toBeNull();
     });
 
     it('shows bin as dragging during staging drag', () => {
       const bins = addStagedBins([{}]);
-      useUIStore.setState({
+      useInteractionStore.setState({
         interaction: {
           type: 'stagingDrag',
           binId: bins[0].id,
@@ -348,7 +353,7 @@ describe('Staging', () => {
 
     it('does not select bin during drag', () => {
       const bins = addStagedBins([{}]);
-      useUIStore.setState({
+      useInteractionStore.setState({
         interaction: {
           type: 'stagingDrag',
           binId: bins[0].id,
@@ -363,7 +368,7 @@ describe('Staging', () => {
       fireEvent.click(binElement!);
 
       // Selection should not change during drag
-      expect(useUIStore.getState().selectedBinIds).toEqual([]);
+      expect(useSelectionStore.getState().selectedBinIds).toEqual([]);
     });
   });
 
@@ -810,7 +815,7 @@ describe('Staging as drop target', () => {
 
   it('shows drop zone when dragging from grid with movement', () => {
     // Set up drag interaction
-    useUIStore.setState({
+    useInteractionStore.setState({
       interaction: {
         type: 'drag',
         binIds: ['some-bin'],

--- a/src/hooks/useCollabMode.test.ts
+++ b/src/hooks/useCollabMode.test.ts
@@ -3,7 +3,7 @@ import { renderHook } from '@testing-library/react';
 import { useCollabMode, getCollabMode } from '@/hooks/useCollabMode';
 import { useLabsStore, useLibraryStore } from '@/core/store';
 import { useSharedPreviewStore } from '@/core/store/sharedPreview';
-import type { CloudShareInfo, LayoutLibrary, LayoutEntry } from '@/core/types';
+import type { CloudShareInfo, LayoutLibrary, LayoutEntry, Layout } from '@/core/types';
 
 const TEST_LAYOUT_ID = 'test-layout-123';
 const TEST_SHARE_ID = 'share-abc-123';
@@ -61,9 +61,7 @@ describe('useCollabMode', () => {
     });
 
     useSharedPreviewStore.setState({
-      sharedLayoutCloudShareId: null,
-      sharedLayoutPermission: undefined,
-      sharedLayoutPreview: null,
+      sharedPreview: null,
     });
   });
 
@@ -114,8 +112,13 @@ describe('useCollabMode', () => {
 
     it('returns collaborative mode when viewing shared layout with edit permission', () => {
       useSharedPreviewStore.setState({
-        sharedLayoutCloudShareId: TEST_SHARE_ID,
-        sharedLayoutPermission: 'edit',
+        sharedPreview: {
+          layout: {} as Layout,
+          originalName: 'Test',
+          authorName: null,
+          cloudShareId: TEST_SHARE_ID,
+          permission: 'edit',
+        },
       });
 
       const { result } = renderHook(() => useCollabMode());
@@ -129,8 +132,13 @@ describe('useCollabMode', () => {
 
     it('returns non-collaborative mode when viewing shared layout with view permission', () => {
       useSharedPreviewStore.setState({
-        sharedLayoutCloudShareId: TEST_SHARE_ID,
-        sharedLayoutPermission: 'view',
+        sharedPreview: {
+          layout: {} as Layout,
+          originalName: 'Test',
+          authorName: null,
+          cloudShareId: TEST_SHARE_ID,
+          permission: 'view',
+        },
       });
 
       const { result } = renderHook(() => useCollabMode());
@@ -150,8 +158,13 @@ describe('useCollabMode', () => {
 
       // But shared preview has edit permission
       useSharedPreviewStore.setState({
-        sharedLayoutCloudShareId: 'different-share-id',
-        sharedLayoutPermission: 'edit',
+        sharedPreview: {
+          layout: {} as Layout,
+          originalName: 'Test',
+          authorName: null,
+          cloudShareId: 'different-share-id',
+          permission: 'edit',
+        },
       });
 
       const { result } = renderHook(() => useCollabMode());
@@ -245,8 +258,13 @@ describe('useCollabMode', () => {
 
       // Enter shared preview mode
       useSharedPreviewStore.setState({
-        sharedLayoutCloudShareId: TEST_SHARE_ID,
-        sharedLayoutPermission: 'edit',
+        sharedPreview: {
+          layout: {} as Layout,
+          originalName: 'Test',
+          authorName: null,
+          cloudShareId: TEST_SHARE_ID,
+          permission: 'edit',
+        },
       });
 
       rerender();
@@ -270,8 +288,7 @@ describe('getCollabMode', () => {
     });
 
     useSharedPreviewStore.setState({
-      sharedLayoutCloudShareId: null,
-      sharedLayoutPermission: undefined,
+      sharedPreview: null,
     });
   });
 
@@ -309,8 +326,13 @@ describe('getCollabMode', () => {
     });
 
     useSharedPreviewStore.setState({
-      sharedLayoutCloudShareId: 'preview-share-id',
-      sharedLayoutPermission: 'edit',
+      sharedPreview: {
+        layout: {} as Layout,
+        originalName: 'Test',
+        authorName: null,
+        cloudShareId: 'preview-share-id',
+        permission: 'edit',
+      },
     });
 
     const result = getCollabMode();

--- a/src/hooks/useCollabSync.test.ts
+++ b/src/hooks/useCollabSync.test.ts
@@ -11,8 +11,7 @@ const mockUseMutation = vi.fn();
 const mockUpdateRemoteLayout = vi.fn();
 
 vi.mock('@/liveblocks.config', () => ({
-  useStorage: (selector: (root: { layout: Layout } | null) => Layout | null) =>
-    mockUseStorage(selector),
+  useStorage: (selector: (root: { layout: Layout }) => Layout) => mockUseStorage(selector),
   useMutation: (callback: unknown) => {
     mockUseMutation(callback);
     return mockUpdateRemoteLayout;
@@ -69,10 +68,8 @@ describe('useCollabSync', () => {
       lastEditSource: 'init',
     });
 
-    // Default mock: no remote layout
-    mockUseStorage.mockImplementation((selector) => {
-      return selector(null);
-    });
+    // Default mock: no remote layout (Liveblocks returns undefined when storage not loaded)
+    mockUseStorage.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -134,9 +131,7 @@ describe('useCollabSync', () => {
     });
 
     it('does not sync when remote layout is null', () => {
-      mockUseStorage.mockImplementation((selector) => {
-        return selector(null);
-      });
+      mockUseStorage.mockReturnValue(undefined);
 
       renderHook(() => useCollabSync());
 
@@ -200,9 +195,8 @@ describe('useCollabSync', () => {
 
     it('does not push when sync state is not ready', () => {
       // Remote is null, so sync state stays pending
-      mockUseStorage.mockImplementation((selector) => {
-        return selector(null);
-      });
+      // The selector receives a null root, so return undefined to simulate unloaded storage
+      mockUseStorage.mockReturnValue(undefined);
 
       renderHook(() => useCollabSync());
 

--- a/src/i18n/detection.ts
+++ b/src/i18n/detection.ts
@@ -59,7 +59,8 @@ const LANGUAGE_MAP: Partial<Record<string, Locale>> = {
  */
 export function detectBrowserLocale(): Locale {
   // Check all preferred languages in order
-  const languages = navigator.languages;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- navigator.languages can be undefined in some environments
+  const languages = navigator.languages ?? [navigator.language];
 
   for (const lang of languages) {
     // Try exact match first (e.g., "pt-BR")

--- a/src/shared/analytics/mlTelemetry/computations.ts
+++ b/src/shared/analytics/mlTelemetry/computations.ts
@@ -122,7 +122,8 @@ export function computeDomainDistribution(
 ): Record<string, number> {
   const distribution: Record<string, number> = {};
   for (const bin of getGridBins(bins)) {
-    if (!bin.label.trim()) continue;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- label can be undefined at runtime despite types
+    if (!bin.label?.trim()) continue;
 
     const labelData = processLabel(bin.label);
     const domain = labelData.domain ?? 'unknown';
@@ -142,7 +143,8 @@ export function computeTopLabelHashes(
   const hashCounts: Record<string, number> = {};
 
   for (const bin of getGridBins(bins)) {
-    if (!bin.label.trim()) continue;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- label can be undefined at runtime despite types
+    if (!bin.label?.trim()) continue;
 
     const labelData = processLabel(bin.label);
     hashCounts[labelData.hash] = (hashCounts[labelData.hash] || 0) + 1;

--- a/src/shared/analytics/mlTelemetry/trackers.ts
+++ b/src/shared/analytics/mlTelemetry/trackers.ts
@@ -103,7 +103,8 @@ function getAdjacentBinContext(
 
   for (const other of sameLevelBins) {
     if (areBinsAdjacent(bin, other)) {
-      if (other.label.trim()) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- label can be undefined at runtime despite types
+      if (other.label?.trim()) {
         const labelData = processLabel(other.label);
         adjacentLabelHashes.push(labelData.hash);
       }
@@ -131,7 +132,8 @@ export function trackBinPlacement(bin: Bin, layout: Layout, method: PlacementMet
   // Apply sampling for high-volume sessions
   const shouldSample =
     sessionState.sessionIndex >= SAMPLING_THRESHOLD &&
-    !bin.label.trim() &&
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- label can be undefined at runtime despite types
+    !bin.label?.trim() &&
     Math.random() > SAMPLING_RATE;
 
   if (shouldSample) {
@@ -160,7 +162,8 @@ export function trackBinPlacement(bin: Bin, layout: Layout, method: PlacementMet
   let labelDomain: string | null = null;
   let labelEmbeddingBucket: string | null = null;
 
-  if (bin.label.trim()) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- label can be undefined at runtime despite types
+  if (bin.label?.trim()) {
     const labelData = processLabel(bin.label);
     labelHash = labelData.hash;
     labelNormalized = labelData.normalized;
@@ -441,7 +444,8 @@ export function trackCategoryChange(bin: Bin, categoryName: string, batchSize: n
 
   let labelHash: string | null = null;
   let labelDomain: string | null = null;
-  if (bin.label.trim()) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- label can be undefined at runtime despite types
+  if (bin.label?.trim()) {
     const labelData = processLabel(bin.label);
     labelHash = labelData.hash;
     labelDomain = labelData.domain;
@@ -535,7 +539,8 @@ export function trackBinDeletion(
   const layerIndex = layout.layers.findIndex((l) => l.id === bin.layerId);
 
   let labelDomain: string | null = null;
-  if (bin.label.trim()) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- label can be undefined at runtime despite types
+  if (bin.label?.trim()) {
     const labelData = processLabel(bin.label);
     labelDomain = labelData.domain;
   }
@@ -560,7 +565,8 @@ export function trackBinDeletion(
     creationRecord &&
     ageMs !== null &&
     ageMs < ABANDONED_THRESHOLD_MS &&
-    !bin.label.trim() &&
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- label can be undefined at runtime despite types
+    !bin.label?.trim() &&
     batchSize === 1
   ) {
     const abandonedEvent: AbandonedBinEvent = {
@@ -581,7 +587,8 @@ export function trackBinDeletion(
     bin_size: `${bin.width}x${bin.depth}x${bin.height}`,
     position: `${bin.x},${bin.y}`,
     layer_index: layerIndex >= 0 ? layerIndex : 0,
-    had_label: Boolean(bin.label.trim()),
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- label can be undefined at runtime despite types
+    had_label: Boolean(bin.label?.trim()),
     label_domain: labelDomain,
     age_ms: ageMs,
     batch_size: batchSize,

--- a/src/shared/analytics/purposeInference.ts
+++ b/src/shared/analytics/purposeInference.ts
@@ -89,7 +89,8 @@ function getDomainDistribution(bins: Bin[]): Map<LabelDomain | 'unknown', number
   const distribution = new Map<LabelDomain | 'unknown', number>();
 
   for (const bin of getGridBins(bins)) {
-    if (!bin.label.trim()) continue;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- label can be undefined at runtime despite types
+    if (!bin.label?.trim()) continue;
 
     const labelData = processLabel(bin.label);
     const domain = labelData.domain || 'unknown';
@@ -353,6 +354,11 @@ function saveLabelSizes(data: Record<string, string[]>): void {
 export function recordLabelSize(labelHash: string, size: string): void {
   const data = loadLabelSizes();
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- labelHash may not exist in data from localStorage
+  if (!data[labelHash]) {
+    data[labelHash] = [];
+  }
+
   // Add size if not already tracked
   if (!data[labelHash].includes(size)) {
     data[labelHash].push(size);
@@ -387,6 +393,11 @@ export function recordLayoutLabelSizes(layout: Layout): void {
     const labelData = processLabel(label);
     const size = `${bin.width}x${bin.depth}x${bin.height}`;
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- labelData.hash may not exist in data from localStorage
+    if (!data[labelData.hash]) {
+      data[labelData.hash] = [];
+    }
+
     // Add size if not already tracked
     if (!data[labelData.hash].includes(size)) {
       data[labelData.hash].push(size);
@@ -418,14 +429,16 @@ export function getLabelSizeConsistency(
   const gridBins = getGridBins(layout.bins);
 
   for (const bin of gridBins) {
-    if (!bin.label.trim()) continue;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- label can be undefined at runtime despite types
+    if (!bin.label?.trim()) continue;
 
     const labelData = processLabel(bin.label);
     if (processedHashes.has(labelData.hash)) continue;
     processedHashes.add(labelData.hash);
 
     const currentSize = `${bin.width}x${bin.depth}x${bin.height}`;
-    const historicalSizes = stored[labelData.hash];
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- stored[hash] can be undefined for new labels
+    const historicalSizes = stored[labelData.hash] || [];
 
     // Combine current with historical (deduplicated)
     const allSizes = [...new Set([...historicalSizes, currentSize])];

--- a/src/shared/hooks/useCrossTabSync.test.ts
+++ b/src/shared/hooks/useCrossTabSync.test.ts
@@ -5,6 +5,7 @@ import { useLayoutStore } from '@/core/store/layout';
 import { useLibraryStore } from '@/core/store/library';
 import { useHistoryStore } from '@/core/store/history';
 import { useUIStore } from '@/core/store/ui';
+import { useSelectionStore } from '@/core/store/selection';
 import { useLabsStore, LABS_STORAGE_KEY } from '@/core/store/labs';
 import { resetAllStores, createTestLayout } from '@/test/testUtils';
 import * as storage from '@/core/storage';
@@ -193,8 +194,8 @@ describe('useCrossTabSync', () => {
     vi.mocked(storage.loadLayoutAsync).mockResolvedValue(mockLayout);
     vi.mocked(validation.validateLayoutIntegrity).mockReturnValue({ valid: true });
 
-    useUIStore.setState({ selectedBinIds: ['bin-1', 'bin-2'] });
-    const clearSelectionSpy = vi.spyOn(useUIStore.getState(), 'clearSelection');
+    useSelectionStore.setState({ selectedBinIds: ['bin-1', 'bin-2'] });
+    const clearSelectionSpy = vi.spyOn(useSelectionStore.getState(), 'clearSelection');
 
     renderHook(() => useCrossTabSync());
 
@@ -222,8 +223,8 @@ describe('useCrossTabSync', () => {
     vi.mocked(storage.loadLayoutAsync).mockResolvedValue(mockLayout);
     vi.mocked(validation.validateLayoutIntegrity).mockReturnValue({ valid: true });
 
-    useUIStore.setState({ activeLayerId: 'old-layer' });
-    const setActiveLayerSpy = vi.spyOn(useUIStore.getState(), 'setActiveLayer');
+    useSelectionStore.setState({ activeLayerId: 'old-layer' });
+    const setActiveLayerSpy = vi.spyOn(useSelectionStore.getState(), 'setActiveLayer');
 
     renderHook(() => useCrossTabSync());
 
@@ -379,8 +380,8 @@ describe('useCrossTabSync', () => {
     vi.mocked(storage.loadLayoutAsync).mockResolvedValue(mockLayout);
     vi.mocked(validation.validateLayoutIntegrity).mockReturnValue({ valid: true });
 
-    useUIStore.setState({ activeCategoryId: 'old-cat' });
-    const setActiveCategorySpy = vi.spyOn(useUIStore.getState(), 'setActiveCategory');
+    useSelectionStore.setState({ activeCategoryId: 'old-cat' });
+    const setActiveCategorySpy = vi.spyOn(useSelectionStore.getState(), 'setActiveCategory');
 
     renderHook(() => useCrossTabSync());
 

--- a/src/shared/hooks/usePWAUpdate.test.ts
+++ b/src/shared/hooks/usePWAUpdate.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 import { renderHook, act, cleanup } from '@testing-library/react';
 import { usePWAUpdate } from '@/shared/hooks';
-import { useUIStore } from '@/core/store/ui';
+import { useInteractionStore } from '@/core/store/interaction';
+import { useSelectionStore } from '@/core/store/selection';
+import { useViewStore } from '@/core/store/view';
 import { useLayoutStore } from '@/core/store/layout';
 import { useToastStore } from '@/core/store/toast';
 import { resetAllStores, setupFakeTimers } from '@/test/testUtils';
@@ -92,7 +94,7 @@ describe('usePWAUpdate', () => {
       mockNeedRefresh = true;
 
       // Set up an active interaction
-      useUIStore.setState({
+      useInteractionStore.setState({
         interaction: {
           type: 'drag',
           binIds: ['bin1'],
@@ -163,7 +165,7 @@ describe('usePWAUpdate', () => {
       mockNeedRefresh = true;
 
       // Set expanded preview state
-      useUIStore.setState({ isPreviewExpanded: true });
+      useInteractionStore.setState({ isPreviewExpanded: true });
 
       renderHook(() => usePWAUpdate());
 
@@ -181,7 +183,7 @@ describe('usePWAUpdate', () => {
     it('blocks reload with context menu open', async () => {
       mockNeedRefresh = true;
 
-      useUIStore.setState({
+      useViewStore.setState({
         contextMenu: { binIds: ['bin1'], position: { x: 100, y: 100 }, source: 'grid' },
       });
 
@@ -201,7 +203,7 @@ describe('usePWAUpdate', () => {
     it('blocks reload with quick label popover open', async () => {
       mockNeedRefresh = true;
 
-      useUIStore.setState({ quickLabelBinId: 'bin1' });
+      useSelectionStore.setState({ quickLabelBinId: 'bin1' });
 
       renderHook(() => usePWAUpdate());
 
@@ -219,7 +221,7 @@ describe('usePWAUpdate', () => {
     it('blocks reload during keyboard drag mode', async () => {
       mockNeedRefresh = true;
 
-      useUIStore.setState({ keyboardDragMode: true });
+      useInteractionStore.setState({ keyboardDragMode: true });
 
       renderHook(() => usePWAUpdate());
 
@@ -238,14 +240,14 @@ describe('usePWAUpdate', () => {
       mockNeedRefresh = true;
 
       // Ensure we're in a safe state (default after resetAllStores)
-      useUIStore.setState({
+      useInteractionStore.setState({
         interaction: null,
         isPreviewExpanded: false,
-        contextMenu: null,
-        quickLabelBinId: null,
         keyboardDragMode: false,
         keyboardResizeMode: false,
       });
+      useViewStore.setState({ contextMenu: null });
+      useSelectionStore.setState({ quickLabelBinId: null });
 
       renderHook(() => usePWAUpdate());
 
@@ -572,7 +574,7 @@ describe('usePWAUpdate', () => {
       mockNeedRefresh = true;
 
       // Keep interaction active
-      useUIStore.setState({
+      useInteractionStore.setState({
         interaction: {
           type: 'drag',
           binIds: ['bin1'],
@@ -619,11 +621,9 @@ describe('usePWAUpdate', () => {
       mockNeedRefresh = true;
 
       // Set up some UI state to be saved
-      useUIStore.setState({
-        selectedBinIds: ['bin-1', 'bin-2'],
-        zoom: 2.0,
-        showIsometricPreview: true,
-      });
+      useSelectionStore.setState({ selectedBinIds: ['bin-1', 'bin-2'] });
+      useViewStore.setState({ zoom: 2.0 });
+      useInteractionStore.setState({ showIsometricPreview: true });
 
       renderHook(() => usePWAUpdate());
 
@@ -701,14 +701,13 @@ describe('usePWAUpdate', () => {
       });
 
       // Check that state was restored
-      const ui = useUIStore.getState();
-      expect(ui.zoom).toBe(1.5);
-      expect(ui.showIsometricPreview).toBe(true);
-      expect(ui.isometricRotation).toBe(90);
-      expect(ui.layerViewMode).toBe('all');
-      expect(ui.rightPanelCollapsed).toBe(true);
-      expect(ui.paintSize).toEqual({ width: 2, depth: 2 });
-      expect(ui.selectedBinIds).toEqual(['bin-1']);
+      expect(useViewStore.getState().zoom).toBe(1.5);
+      expect(useInteractionStore.getState().showIsometricPreview).toBe(true);
+      expect(useInteractionStore.getState().isometricRotation).toBe(90);
+      expect(useInteractionStore.getState().layerViewMode).toBe('all');
+      expect(useViewStore.getState().rightPanelCollapsed).toBe(true);
+      expect(useInteractionStore.getState().paintSize).toEqual({ width: 2, depth: 2 });
+      expect(useSelectionStore.getState().selectedBinIds).toEqual(['bin-1']);
 
       // Check toast was shown
       const toasts = useToastStore.getState().toasts;
@@ -767,9 +766,9 @@ describe('usePWAUpdate', () => {
       });
 
       // Selection should be empty (bins don't exist)
-      const ui = useUIStore.getState();
-      expect(ui.selectedBinIds).toEqual([]);
-      expect(ui.focusedBinId).toBeNull();
+      const selection = useSelectionStore.getState();
+      expect(selection.selectedBinIds).toEqual([]);
+      expect(selection.focusedBinId).toBeNull();
     });
   });
 });

--- a/src/shared/utils/bins.ts
+++ b/src/shared/utils/bins.ts
@@ -130,7 +130,8 @@ export function getLayerBins(bins: Bin[], layerId: LayerId): Bin[] {
  * const labeled = getLabeledBins(getGridBins(layout.bins));
  */
 export function getLabeledBins(bins: Bin[]): Bin[] {
-  return bins.filter((bin) => bin.label.trim());
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- label can be undefined at runtime despite types
+  return bins.filter((bin) => bin.label?.trim());
 }
 
 /**

--- a/src/shared/utils/compression.ts
+++ b/src/shared/utils/compression.ts
@@ -19,7 +19,8 @@ export function compressString(input: string): string {
  */
 export function decompressString(compressed: string): string {
   const result = LZString.decompressFromUTF16(compressed);
-  return result;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- LZString can return null for invalid input
+  return result ?? '';
 }
 
 /**

--- a/src/shared/utils/uuid.ts
+++ b/src/shared/utils/uuid.ts
@@ -8,7 +8,20 @@ import type { LayoutId } from '@/core/types';
  * backward compatibility with existing layouts.
  */
 export function generateUUID(): string {
-  return crypto.randomUUID();
+  const c = globalThis.crypto;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- randomUUID may not exist in test/older environments
+  if (c?.randomUUID) {
+    return c.randomUUID();
+  }
+
+  // Fallback for environments without crypto.randomUUID
+  const bytes = new Uint8Array(16);
+  c.getRandomValues(bytes);
+  // Set version (4) and variant (RFC 4122)
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
 /** Character set for short IDs: a-z, A-Z, 0-9 (62 chars) */

--- a/src/shared/utils/validation.ts
+++ b/src/shared/utils/validation.ts
@@ -417,6 +417,11 @@ export function validateLayoutIntegrity(layout: Layout): { valid: boolean; error
 export function validateCustomProperties(
   props: Record<string, string>
 ): Result<void, ValidationError> {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- props may be null/undefined at runtime
+  if (!props) {
+    return ok(undefined); // undefined/null is valid (no custom properties)
+  }
+
   if (typeof props !== 'object' || Array.isArray(props)) {
     return err(validationImportFailed(['Custom properties must be provided as a plain object']));
   }


### PR DESCRIPTION
## Summary

- Fixes all **266 test failures** (across 48 files) caused by the ESLint lint fix PR (#695)
- The lint PR migrated source components from the monolithic `useUIStore` to granular Zustand stores, but test files still referenced `useUIStore.setState()`/`getState()` — meaning test state never reached the components
- Also restores runtime safety guards that were incorrectly removed by `no-unnecessary-condition` fixes (e.g., IndexedDB/localStorage null checks)

### Changes (47 files)

**Test store migrations (28 test files):**
- Replace `useUIStore.setState()` / `getState()` with correct granular stores: `useSelectionStore`, `useInteractionStore`, `useViewStore`, `useMobileStore`, `useSharedPreviewStore`

**Runtime guard restoration (10 source files):**
- Restore null/type checks on external data (IndexedDB, localStorage, API responses) with `eslint-disable` comments explaining why the guards are necessary despite TypeScript types

**Pre-existing test fixes (6 files):**
- Fix `nested-interactive` a11y violations in `LayerPanel` and `CategoriesPanel` (remove `role="button"` from wrapper divs that contain child buttons)
- Fix ambiguous DOM queries (`getByRole` → `getAllByRole` + filtering) in LayerPanel, LayoutManagerModal, ShareModal tests
- Fix cross-test contamination in `useLayoutRouting` tests (sharedPreview store not reset between tests)

**Lint cleanup (3 files):**
- Fix eslint-disable directive targets, remove unused imports, fix type annotations

## Test plan

- [x] `npm run lint` — 0 errors, 1 pre-existing warning
- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — **443/443 test files pass, 7234/7234 tests pass**
- [x] All pre-commit hooks pass (module boundaries, i18n, exhaustiveness, affected tests, component structure)