### PR TITLE
fix: prevent WASM memory access crashes from degenerate geometry

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.edge-cases.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.edge-cases.test.ts
@@ -374,4 +374,233 @@ describe('edge case generation', () => {
       base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true, stackingLip: true },
     });
   });
+
+  describe('WASM degenerate geometry guards', () => {
+    // Solid mode: cutoutTopOffset >= wallHeight → fillHeight <= 0
+    testParams('solid mode with cutoutTopOffset >= wallHeight (zero fillHeight)', {
+      width: 2,
+      depth: 2,
+      height: 3,
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true, stackingLip: false },
+      cutoutConfig: { topOffset: 100 }, // Exceeds wallHeight (~16mm)
+    });
+
+    // Solid mode: solidSurfaceZ <= 0 with cutouts present (exercises the guard in buildCutoutCuts)
+    testParams('solid mode with solidSurfaceZ <= 0 and cutouts present', {
+      width: 2,
+      depth: 2,
+      height: 3,
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true, stackingLip: false },
+      cutoutConfig: { topOffset: 100 },
+      cutouts: [
+        {
+          id: 'unreachable',
+          shape: 'rectangle',
+          width: 20,
+          depth: 20,
+          cutDepth: 5,
+          x: 0,
+          y: 0,
+          rotation: 0,
+          cornerRadius: 0,
+          label: '',
+          groupId: null,
+          scoopRadius: 0,
+        },
+      ],
+    });
+
+    // Solid mode: cutout cutDepth exceeds solidSurfaceZ (extends below floor)
+    testParams('solid mode with cutout cutDepth > solidSurfaceZ', {
+      width: 2,
+      depth: 2,
+      height: 3,
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true, stackingLip: false },
+      cutoutConfig: { topOffset: 10 },
+      cutouts: [
+        {
+          id: 'deep',
+          shape: 'rectangle',
+          width: 20,
+          depth: 20,
+          cutDepth: 50, // Much deeper than solidSurfaceZ
+          x: 0,
+          y: 0,
+          rotation: 0,
+          cornerRadius: 0,
+          label: '',
+          groupId: null,
+          scoopRadius: 0,
+        },
+      ],
+    });
+
+    // Insert with corner radius exceeding half min dimension (clamped to valid range)
+    testParams('insert with excessive cornerRadius (clamped gracefully)', {
+      width: 2,
+      depth: 2,
+      inserts: [
+        {
+          shape: 'rounded-rect',
+          width: 5,
+          depth: 5,
+          cutDepth: 3,
+          x: 0,
+          y: 0,
+          cornerRadius: 100, // Far exceeds min(5,5)/2 = 2.5
+        },
+      ],
+    });
+
+    // Insert with zero cutDepth
+    testParams('insert with zero cutDepth (skipped gracefully)', {
+      width: 2,
+      depth: 2,
+      inserts: [
+        { shape: 'circle', width: 20, depth: 20, cutDepth: 0, x: 0, y: 0, cornerRadius: 0 },
+      ],
+    });
+
+    // Cutout with zero width
+    testParams('solid mode with zero-width cutout (skipped gracefully)', {
+      width: 2,
+      depth: 2,
+      height: 3,
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true, stackingLip: false },
+      cutouts: [
+        {
+          id: 'zero-w',
+          shape: 'rectangle',
+          width: 0,
+          depth: 20,
+          cutDepth: 5,
+          x: 0,
+          y: 0,
+          rotation: 0,
+          cornerRadius: 0,
+          label: '',
+          groupId: null,
+          scoopRadius: 0,
+        },
+      ],
+    });
+
+    // Cutout with zero depth
+    testParams('solid mode with zero-depth cutout (skipped gracefully)', {
+      width: 2,
+      depth: 2,
+      height: 3,
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true, stackingLip: false },
+      cutouts: [
+        {
+          id: 'zero-d',
+          shape: 'rectangle',
+          width: 20,
+          depth: 0,
+          cutDepth: 5,
+          x: 0,
+          y: 0,
+          rotation: 0,
+          cornerRadius: 0,
+          label: '',
+          groupId: null,
+          scoopRadius: 0,
+        },
+      ],
+    });
+
+    // Small bin with thick walls → near-zero inner dimensions
+    testParams('0.5x0.5 with thick walls (near-zero inner dimensions)', {
+      width: 0.5,
+      depth: 0.5,
+      height: 2,
+      wallThickness: 2.4,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat', stackingLip: false },
+    });
+
+    // Label tab where tabDepth >= wallHeight (hits pre-existing early return)
+    testParams('label tab with tabDepth >= wallHeight', {
+      width: 2,
+      depth: 2,
+      height: 2, // wallHeight ~9mm
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+      label: {
+        enabled: true,
+        support: 'bracket',
+        depth: 20, // Exceeds wallHeight
+        width: 100,
+        alignment: 'left',
+      },
+    });
+
+    // Label tab where tabDepth <= wallThickness → gussetLeg <= 0 (exercises bracket guard)
+    testParams('label tab bracket with gussetLeg <= 0 (tabDepth <= wallThickness)', {
+      width: 2,
+      depth: 2,
+      height: 4, // wallHeight ~23mm, plenty of room
+      wallThickness: 2.4,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+      label: {
+        enabled: true,
+        support: 'bracket',
+        depth: 2, // tabHeight = 2 < wt = 2.4, so gussetLeg = -0.4
+        width: 100,
+        alignment: 'left',
+      },
+    });
+
+    // Label tab solid support where tabDepth <= wallThickness → gussetLeg <= 0
+    testParams('label tab solid with gussetLeg <= 0 (tabDepth <= wallThickness)', {
+      width: 2,
+      depth: 2,
+      height: 4,
+      wallThickness: 2.4,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+      label: {
+        enabled: true,
+        support: 'solid',
+        depth: 2, // tabHeight = 2 < wt = 2.4
+        width: 100,
+        alignment: 'left',
+      },
+    });
+
+    // Grouped cutouts with some zero-dimension members
+    testParams('solid mode with grouped cutouts including zero-width member', {
+      width: 2,
+      depth: 2,
+      height: 4,
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true, stackingLip: false },
+      cutouts: [
+        {
+          id: 'good',
+          shape: 'rectangle',
+          width: 15,
+          depth: 15,
+          cutDepth: 5,
+          x: 0,
+          y: 0,
+          rotation: 0,
+          cornerRadius: 0,
+          label: '',
+          groupId: 'g1',
+          scoopRadius: 0,
+        },
+        {
+          id: 'bad',
+          shape: 'rectangle',
+          width: 0,
+          depth: 15,
+          cutDepth: 5,
+          x: 20,
+          y: 0,
+          rotation: 0,
+          cornerRadius: 0,
+          label: '',
+          groupId: 'g1',
+          scoopRadius: 0,
+        },
+      ],
+    });
+  });
 });

--- a/src/features/generation/worker/generators/binGenerator.ts
+++ b/src/features/generation/worker/generators/binGenerator.ts
@@ -296,9 +296,13 @@ export function generateBin(
   checkCancelled(signal);
   onProgress?.('features', 0.5);
 
+  // Guard: if inner dimensions are non-positive (small bin with thick walls),
+  // skip all interior features — there's no room for dividers, inserts, etc.
+  const hasValidInterior = innerW > 0 && innerD > 0;
+
   // Solid mode: skip all interior features -- the bin is a solid block.
   // Cutouts will later carve into this solid to create shaped cavities.
-  if (!solid) {
+  if (!solid && hasValidInterior) {
     // Interior features (dividers, tabs) must clear the stacking lip zone.
     // The lip's bottom taper extends LIP_SMALL_TAPER (0.7mm) inward from the
     // outer wall at wallHeight. Dividers and tabs stop short to avoid interference.
@@ -458,7 +462,7 @@ export function generateBin(
         }
       }
     }
-  } else {
+  } else if (hasValidInterior) {
     // Solid mode: apply cutouts (top-down cavity cuts into the solid block)
     const cutoutCuts = buildCutoutCuts(params, innerW, innerD, wallHeight);
     if (cutoutCuts) {

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -75,6 +75,13 @@ export function buildBinBox(
       const innerW = outerW - 2 * wallThickness;
       const innerD = outerD - 2 * wallThickness;
       const fillHeight = wallHeight - cutoutTopOffset;
+
+      // Guard: if fillHeight or inner dimensions are non-positive, the interior fill
+      // would produce degenerate geometry that crashes WASM. Return hollow walls only.
+      if (fillHeight <= 0 || innerW <= 0 || innerD <= 0) {
+        return setBoxCache(boxKey, hollowWalls);
+      }
+
       const innerFill = sketch(
         drawRoundedRectangle(innerW, innerD, Math.max(0, CORNER_RADIUS - wallThickness)),
         'XY'

--- a/src/features/generation/worker/generators/featureBuilder.ts
+++ b/src/features/generation/worker/generators/featureBuilder.ts
@@ -156,6 +156,9 @@ export function buildInsertCuts(params: BinParams): Shape3D | null {
   const insertShapes: Shape3D[] = [];
 
   for (const insert of params.inserts) {
+    // Guard: skip inserts with degenerate dimensions that would crash WASM
+    if (insert.cutDepth <= 0 || insert.width <= 0 || insert.depth <= 0) continue;
+
     let solid: Shape3D;
 
     switch (insert.shape) {
@@ -197,12 +200,15 @@ export function buildInsertCuts(params: BinParams): Shape3D | null {
     insertShapes.push(translate(solid, [insert.x, insert.y, 0]));
   }
 
+  if (insertShapes.length === 0) return null;
   return unwrap(fuseAll(insertShapes));
 }
 
 // ─── Cutout Builder (Solid Mode Only) ────────────────────────────────────────
 
-/** Create an extruded + rotated cutout shape centered at origin (no translation). */
+/** Create an extruded + rotated cutout shape centered at origin (no translation).
+ *  Returns null if dimensions are degenerate (would crash WASM).
+ */
 function buildCutoutShape(cutout: {
   readonly shape: string;
   readonly x: number;
@@ -213,7 +219,10 @@ function buildCutoutShape(cutout: {
   readonly rotation: number;
   readonly cornerRadius: number;
   readonly path?: readonly PathPoint[];
-}): Shape3D {
+}): Shape3D | null {
+  // Guard: skip cutouts with degenerate dimensions that would crash WASM
+  if (cutout.cutDepth <= 0 || cutout.width <= 0 || cutout.depth <= 0) return null;
+
   let shape: Shape3D;
 
   switch (cutout.shape) {
@@ -522,6 +531,10 @@ export function buildCutoutCuts(
   const topOffset = params.cutoutConfig.topOffset;
   const solidSurfaceZ = wallHeight - topOffset;
 
+  // Guard: if solidSurfaceZ is non-positive, there's no valid cutting surface
+  // (the solid fill is at or below floor level). Skip all cutouts.
+  if (solidSurfaceZ <= 0) return null;
+
   const cutoutShapes: Shape3D[] = [];
 
   // Partition cutouts by groupId: null -> ungrouped, same groupId -> collected
@@ -542,10 +555,15 @@ export function buildCutoutCuts(
 
   // --- Process ungrouped cutouts (individual scoop, same as before) ---
   for (const cutout of ungrouped) {
-    let shape = buildCutoutShape(cutout);
+    // Clamp effective cutDepth so the cutout doesn't extend below Z=0
+    const effectiveDepth = Math.min(cutout.cutDepth, solidSurfaceZ);
+    if (effectiveDepth <= 0) continue;
+
+    let shape = buildCutoutShape({ ...cutout, cutDepth: effectiveDepth });
+    if (!shape) continue;
 
     // Apply scoop radius fillet to bottom edges (before translation, at Z ~ 0)
-    const maxScoop = Math.min(cutout.cutDepth, Math.min(cutout.width, cutout.depth) / 2) - 0.01;
+    const maxScoop = Math.min(effectiveDepth, Math.min(cutout.width, cutout.depth) / 2) - 0.01;
     const scoopR = Math.min(cutout.scoopRadius ?? 0, Math.max(0, maxScoop));
     if (scoopR > 0) {
       const halfW = cutout.width / 2 + 1;
@@ -570,32 +588,45 @@ export function buildCutoutCuts(
       translate(shape, [
         originX + cutout.x + cutout.width / 2,
         originY + cutout.y + cutout.depth / 2,
-        solidSurfaceZ - cutout.cutDepth,
+        solidSurfaceZ - effectiveDepth,
       ])
     );
   }
 
   // --- Process grouped cutouts (fuse first, then single scoop fillet) ---
   for (const [, groupMembers] of groups) {
-    // Create and translate each member shape (no individual scoop)
+    // Create and translate each member shape (no individual scoop).
+    // Track which members actually produced shapes so scoop aggregates
+    // use clamped depths and exclude filtered-out zero-dimension members.
     const memberShapes: Shape3D[] = [];
+    const builtMembers: typeof groupMembers = [];
+    const builtDepths: number[] = [];
     for (const cutout of groupMembers) {
-      const shape = buildCutoutShape(cutout);
+      // Clamp effective cutDepth so the cutout doesn't extend below Z=0
+      const effectiveDepth = Math.min(cutout.cutDepth, solidSurfaceZ);
+      if (effectiveDepth <= 0) continue;
+
+      const shape = buildCutoutShape({ ...cutout, cutDepth: effectiveDepth });
+      if (!shape) continue;
+
+      builtMembers.push(cutout);
+      builtDepths.push(effectiveDepth);
       memberShapes.push(
         translate(shape, [
           originX + cutout.x + cutout.width / 2,
           originY + cutout.y + cutout.depth / 2,
-          solidSurfaceZ - cutout.cutDepth,
+          solidSurfaceZ - effectiveDepth,
         ])
       );
     }
+    if (memberShapes.length === 0) continue;
 
     let fused = memberShapes.length === 1 ? memberShapes[0] : unwrap(fuseAll(memberShapes));
 
-    // Determine group scoop radius and cut depth
-    const groupScoopRadius = Math.max(...groupMembers.map((c) => c.scoopRadius ?? 0));
-    const groupCutDepth = Math.min(...groupMembers.map((c) => c.cutDepth));
-    const minDim = Math.min(...groupMembers.map((c) => Math.min(c.width, c.depth)));
+    // Determine group scoop radius and cut depth from built members only
+    const groupScoopRadius = Math.max(...builtMembers.map((c) => c.scoopRadius ?? 0));
+    const groupCutDepth = Math.min(...builtDepths);
+    const minDim = Math.min(...builtMembers.map((c) => Math.min(c.width, c.depth)));
     const maxScoop = Math.min(groupCutDepth, minDim / 2) - 0.01;
     const scoopR = Math.min(groupScoopRadius, Math.max(0, maxScoop));
 
@@ -607,7 +638,7 @@ export function buildCutoutCuts(
         maxX: -Infinity,
         maxY: -Infinity,
       };
-      for (const cutout of groupMembers) {
+      for (const cutout of builtMembers) {
         const cx = originX + cutout.x + cutout.width / 2;
         const cy = originY + cutout.y + cutout.depth / 2;
         // Account for rotation: use diagonal as safe half-extent
@@ -636,12 +667,14 @@ export function buildCutoutCuts(
         .findAll(fused);
       // Only apply fillet if we found edges (avoid empty edge list error)
       if (groupScoopEdges.length > 0) {
-        fused = applyAdaptiveScoop(fused, groupScoopEdges, scoopR, groupMembers, originX, originY);
+        fused = applyAdaptiveScoop(fused, groupScoopEdges, scoopR, builtMembers, originX, originY);
       }
     }
 
     cutoutShapes.push(fused);
   }
+
+  if (cutoutShapes.length === 0) return null;
 
   const fusedResult = unwrap(fuseAll(cutoutShapes));
 
@@ -799,53 +832,54 @@ export function buildLabelTabs(
       const gussetLeg = tabHeight - wt;
       const maxSpan = 10; // mm
 
-      // Collect all gusset X positions (left edge of each gusset)
-      const gussetPositions: number[] = [];
-
-      // Edge gussets at free ends
-      if (!touchesLeft) gussetPositions.push(0);
-      if (!touchesRight) gussetPositions.push(tabWidth - gt);
-
-      // Interior gussets between the outermost supports
-      const leftSupport = touchesLeft ? 0 : gt;
-      const rightSupport = touchesRight ? tabWidth : tabWidth - gt;
-      const interiorSpan = rightSupport - leftSupport;
-      const numInterior = Math.max(0, Math.ceil(interiorSpan / maxSpan) - 1);
-      for (let g = 0; g < numInterior; g++) {
-        const center = leftSupport + (interiorSpan * (g + 1)) / (numInterior + 1);
-        gussetPositions.push(center - gt / 2);
-      }
-
       let tabSolid: Shape3D = shelf;
 
-      const labelSupport = params.label.support;
+      // Guard: if gussetLeg <= 0 (tabHeight <= wallThickness), there's no room
+      // for support structure. Skip gusset/solid generation to avoid degenerate geometry.
+      if (gussetLeg > 0) {
+        // Collect all gusset X positions (left edge of each gusset)
+        const gussetPositions: number[] = [];
 
-      if (labelSupport === 'solid') {
-        // Solid style: single continuous 45deg right-triangle prism under the shelf
-        const gussetLegSolid = tabHeight - wt;
-        if (gussetLegSolid > 0) {
-          const solidProfile = draw([0, gussetLegSolid])
-            .lineTo([-gussetLegSolid, gussetLegSolid])
+        // Edge gussets at free ends
+        if (!touchesLeft) gussetPositions.push(0);
+        if (!touchesRight) gussetPositions.push(tabWidth - gt);
+
+        // Interior gussets between the outermost supports
+        const leftSupport = touchesLeft ? 0 : gt;
+        const rightSupport = touchesRight ? tabWidth : tabWidth - gt;
+        const interiorSpan = rightSupport - leftSupport;
+        const numInterior = Math.max(0, Math.ceil(interiorSpan / maxSpan) - 1);
+        for (let g = 0; g < numInterior; g++) {
+          const center = leftSupport + (interiorSpan * (g + 1)) / (numInterior + 1);
+          gussetPositions.push(center - gt / 2);
+        }
+
+        const labelSupport = params.label.support;
+
+        if (labelSupport === 'solid') {
+          // Solid style: single continuous 45deg right-triangle prism under the shelf
+          const solidProfile = draw([0, gussetLeg])
+            .lineTo([-gussetLeg, gussetLeg])
             .lineTo([0, 0])
             .close();
           const solidSupport = sketch(solidProfile, 'YZ', 0).extrude(tabWidth);
           tabSolid = unwrap(fuse(tabSolid, solidSupport));
-        }
-      } else {
-        // Bracket style: discrete triangular gussets at edges + every <=10mm
-        if (gussetPositions.length > 0) {
-          const gussetProfile = draw([0, gussetLeg])
-            .lineTo([-gussetLeg, gussetLeg])
-            .lineTo([0, 0])
-            .close();
+        } else {
+          // Bracket style: discrete triangular gussets at edges + every <=10mm
+          if (gussetPositions.length > 0) {
+            const gussetProfile = draw([0, gussetLeg])
+              .lineTo([-gussetLeg, gussetLeg])
+              .lineTo([0, 0])
+              .close();
 
-          const gussetShapes: Shape3D[] = [];
-          for (const gx of gussetPositions) {
-            const gusset = sketch(gussetProfile, 'YZ', 0).extrude(gt);
-            gussetShapes.push(translate(gusset, [gx, 0, 0]));
+            const gussetShapes: Shape3D[] = [];
+            for (const gx of gussetPositions) {
+              const gusset = sketch(gussetProfile, 'YZ', 0).extrude(gt);
+              gussetShapes.push(translate(gusset, [gx, 0, 0]));
+            }
+
+            tabSolid = unwrap(fuse(tabSolid, unwrap(fuseAll(gussetShapes))));
           }
-
-          tabSolid = unwrap(fuse(tabSolid, unwrap(fuseAll(gussetShapes))));
         }
       }
 


### PR DESCRIPTION
## Summary

- Add pre-WASM guards to prevent six categories of degenerate geometry from crashing OpenCascade with `RuntimeError: memory access out of bounds`
- Fix grouped cutout scoop fillet bug where unclamped `cutDepth` and zero-dimension members poisoned edge-finder Z-level and `minDim` aggregates
- Add 12 new edge-case scenario tests exercising all guard paths

## Problem

When invalid parameters reach the WASM kernel — zero-length edges, degenerate shapes, zero/negative extrusion heights — it crashes with an unrecoverable `RuntimeError: memory access out of bounds` that kills the Web Worker. This can happen via:

1. **Zero/negative extrusion heights** — `extrude(0)` or `extrude(-N)`
2. **Zero/negative shape dimensions** — `drawCircle(0)`, `drawRectangle(0, d)`
3. **Degenerate corner radii** — `drawRoundedRectangle(w, d, r)` where `r <= 0`
4. **Solid mode fillHeight** — `wallHeight - cutoutTopOffset` can be zero/negative
5. **Cutout solidSurfaceZ** — `wallHeight - topOffset` can be zero/negative
6. **Inner dimensions** — `outerW - 2*wallThickness` can be zero/negative

## Changes

| File | Change |
|------|--------|
| `boxBuilder.ts` | Guard `fillHeight <= 0` and `innerW/innerD <= 0` in solid mode — return hollow walls only |
| `featureBuilder.ts` | Guard `buildInsertCuts` (skip degenerate inserts, empty-array before `fuseAll`), `buildCutoutShape` returns `null` for degenerate dims, `buildCutoutCuts` guards `solidSurfaceZ <= 0` and clamps `effectiveDepth`, `buildLabelTabs` wraps gusset generation in `gussetLeg > 0` |
| `featureBuilder.ts` | Fix grouped cutout scoop: compute aggregates from `builtMembers`/`builtDepths` only (not the unfiltered group) |
| `binGenerator.ts` | Add `hasValidInterior` check — skip all interior features when `innerW <= 0 \|\| innerD <= 0` |
| `edge-cases.test.ts` | 12 new test cases covering all guard paths |

## Test plan

- [x] All 140 scenario tests pass (42 edge-case + 98 existing)
- [x] All 165 affected tests pass (pre-commit hook)
- [x] TypeScript compiles cleanly
- [x] No regressions in snapshot tests