### PR TITLE
fix: hide SEO fallback content flash on page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,9 +365,10 @@
     </script>
   </head>
   <body>
-    <!-- SEO: Initial content visible to crawlers before React mounts. createRoot().render() replaces it. -->
+    <!-- SEO: Content for crawlers/noscript. Hidden by inline script; shown only if JS is disabled. -->
     <div id="root">
-      <div style="max-width: 800px; margin: 40px auto; padding: 20px; font-family: system-ui, sans-serif; line-height: 1.6;">
+      <div id="seo-fallback" style="display:none; max-width: 800px; margin: 40px auto; padding: 20px; font-family: system-ui, sans-serif; line-height: 1.6;">
+    <noscript><style>#seo-fallback{display:block!important}</style></noscript>
         <h1>Gridfinity Layout Tool</h1>
         <p>A free tool for making Gridfinity bins and planning drawer layouts. Runs in your browser — nothing to install.</p>
 


### PR DESCRIPTION
## Summary
- SEO fallback content inside `#root` was flashing briefly before React mounted
- Now hidden with `display:none` by default, shown only via `<noscript><style>` for crawlers/no-JS users

## Test plan
- [ ] Load the page — no flash of static HTML content
- [ ] View page source — SEO content still present for crawlers
- [ ] Disable JS in devtools — fallback content becomes visible