### PR TITLE
chore: update brepjs-opencascade to 0.7.2, remove WASM type casts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "@vercel/analytics": "^1.6.1",
         "@vercel/blob": "^2.0.0",
         "ai": "^6.0.49",
-        "brepjs": "8.1.0",
-        "brepjs-opencascade": "^0.7.1",
+        "brepjs": "^8.1.0",
+        "brepjs-opencascade": "^0.7.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -7346,9 +7346,9 @@
       }
     },
     "node_modules/brepjs-opencascade": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/brepjs-opencascade/-/brepjs-opencascade-0.7.1.tgz",
-      "integrity": "sha512-L5o1lKjkXI1rjLwszknABptOqoOZsdVF87hpwe+PpGKXTBWfS6/eM1R1mvrc/kPJu/Fhww2X4dY4dfq66SW/eA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/brepjs-opencascade/-/brepjs-opencascade-0.7.2.tgz",
+      "integrity": "sha512-UoHieILsJRzosUd4bU1UKRzWndFU0Y7V5gC8wf2TcgE2jtBp7bmKCVaEKFYljNA85aigi8sHd6jaIE/9P7+BDA==",
       "license": "MIT",
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@vercel/blob": "^2.0.0",
     "ai": "^6.0.49",
     "brepjs": "^8.1.0",
-    "brepjs-opencascade": "^0.7.1",
+    "brepjs-opencascade": "^0.7.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/features/generation/worker/generation.worker.ts
+++ b/src/features/generation/worker/generation.worker.ts
@@ -29,20 +29,6 @@ import opencascadeThreadedWasm from 'brepjs-opencascade/src/brepjs_threaded.wasm
 import opencascadeThreadedWorker from 'brepjs-opencascade/src/brepjs_threaded.worker.js?url';
 import opencascadeThreadedJs from 'brepjs-opencascade/src/brepjs_threaded.js?url';
 
-// Emscripten module factory options (not reflected in the .d.ts)
-interface EmscriptenModuleConfig {
-  locateFile?: (path: string) => string;
-  mainScriptUrlOrBlob?: string;
-}
-
-// Type assertion for Emscripten factory functions that accept config
-const opencascadeSingle = opencascadeSingleInit as unknown as (
-  config?: EmscriptenModuleConfig
-) => ReturnType<typeof opencascadeSingleInit>;
-const opencascadeThreaded = opencascadeThreadedInit as unknown as (
-  config?: EmscriptenModuleConfig
-) => ReturnType<typeof opencascadeThreadedInit>;
-
 /** Currently active generation request ID (for cancellation) */
 let activeRequestId: string | null = null;
 
@@ -111,7 +97,7 @@ async function initOpenCascade(): Promise<void> {
 
   let OC: Awaited<ReturnType<typeof opencascadeSingleInit>>;
   if (isThreaded) {
-    OC = await opencascadeThreaded({
+    OC = await opencascadeThreadedInit({
       mainScriptUrlOrBlob: opencascadeThreadedJs,
       locateFile: (fileName: string) => {
         if (fileName.endsWith('.wasm')) {
@@ -125,7 +111,7 @@ async function initOpenCascade(): Promise<void> {
     });
   } else {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Emscripten WASM factory returns untyped module (see vite-env.d.ts TECH-DEBT)
-    OC = await opencascadeSingle({
+    OC = await opencascadeSingleInit({
       locateFile: (fileName: string) => {
         if (fileName.endsWith('.wasm')) {
           return opencascadeSingleWasm;


### PR DESCRIPTION
## Summary
- Updates `brepjs-opencascade` from 0.7.1 to 0.7.2, which adds proper `EmscriptenModuleConfig` type declarations to the init functions
- Removes the local `EmscriptenModuleConfig` interface and two `as unknown as` type casts from the generation worker that are no longer needed

## Test plan
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Dev server loads and generates bins correctly
- [ ] Production build succeeds