### PR TITLE
test: fix CI coverage threshold failures on main

### DIFF
--- a/src/core/storage/LayoutManager.test.ts
+++ b/src/core/storage/LayoutManager.test.ts
@@ -655,6 +655,38 @@ describe('switchActiveLayout', () => {
 
     expect(expectErr(result).code).toBe('STORAGE_NOT_FOUND');
   });
+
+  it('returns error when saving current layout fails during switch', async () => {
+    vi.mocked(backend.saveAsync).mockRejectedValueOnce(new Error('quota exceeded'));
+    const fromLayout = createTestLayout();
+    const library = createTestLibrary([
+      createTestEntry('from-id', 'From'),
+      createTestEntry('to-id', 'To'),
+    ]);
+
+    const result = await switchActiveLayout('from-id', fromLayout, 'to-id', library);
+
+    expect(expectErr(result).code).toBe('STORAGE_QUOTA_EXCEEDED');
+  });
+
+  it('returns error when library save fails after loading target', async () => {
+    // First saveSyncGeneric call (from saveLayoutWithMetadata) succeeds,
+    // second call (switchActiveLayout's own library save) fails
+    vi.mocked(backend.saveSyncGeneric)
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {
+        throw new Error('Storage full');
+      });
+    const fromLayout = createTestLayout();
+    const library = createTestLibrary([
+      createTestEntry('from-id', 'From'),
+      createTestEntry('to-id', 'To'),
+    ]);
+
+    const result = await switchActiveLayout('from-id', fromLayout, 'to-id', library);
+
+    expectErr(result);
+  });
 });
 
 // === updateCloudShare Tests ===
@@ -720,6 +752,21 @@ describe('updateCloudShare', () => {
       })
     );
   });
+
+  it('returns error when library save fails', () => {
+    vi.mocked(backend.saveSyncGeneric).mockImplementationOnce(() => {
+      throw new Error('Storage full');
+    });
+    const library = createTestLibrary([createTestEntry('layout-1', 'Layout 1')]);
+
+    const result = updateCloudShare(
+      'layout-1',
+      { id: 'share', deleteToken: 'token', sharedAt: Date.now(), permission: 'view' },
+      library
+    );
+
+    expectErr(result);
+  });
 });
 
 // === renameLayoutEntry Tests ===
@@ -780,5 +827,16 @@ describe('renameLayoutEntry', () => {
         entries: expect.arrayContaining([expect.objectContaining({ name: 'New' })]),
       })
     );
+  });
+
+  it('returns error when library save fails', () => {
+    vi.mocked(backend.saveSyncGeneric).mockImplementationOnce(() => {
+      throw new Error('Storage full');
+    });
+    const library = createTestLibrary([createTestEntry('layout-1', 'Old')]);
+
+    const result = renameLayoutEntry('layout-1', 'New', library);
+
+    expectErr(result);
   });
 });

--- a/src/core/store/library.test.ts
+++ b/src/core/store/library.test.ts
@@ -492,6 +492,59 @@ describe('library store', () => {
     });
   });
 
+  describe('name suggestion state', () => {
+    beforeEach(() => {
+      useLibraryStore.setState({
+        library: createTestLibraryWithEntries(2),
+        isLoaded: true,
+        showLayoutManager: false,
+      });
+    });
+
+    it('setNameSuggestionDismissed sets dismissed state', () => {
+      useLibraryStore.getState().setNameSuggestionDismissed('layout-0', true);
+
+      const state = useLibraryStore.getState().getNameSuggestionState('layout-0');
+      expect(state?.dismissed).toBe(true);
+      expect(state?.dismissCount).toBe(1);
+      expect(state?.dismissedAt).toBeGreaterThan(0);
+    });
+
+    it('setNameSuggestionDismissed increments dismiss count', () => {
+      useLibraryStore.getState().setNameSuggestionDismissed('layout-0', true);
+      useLibraryStore.getState().setNameSuggestionDismissed('layout-0', true);
+
+      const state = useLibraryStore.getState().getNameSuggestionState('layout-0');
+      expect(state?.dismissCount).toBe(2);
+    });
+
+    it('setNameSuggestionDismissed clears state when false', () => {
+      useLibraryStore.getState().setNameSuggestionDismissed('layout-0', true);
+      useLibraryStore.getState().setNameSuggestionDismissed('layout-0', false);
+
+      const state = useLibraryStore.getState().getNameSuggestionState('layout-0');
+      expect(state).toBeUndefined();
+    });
+
+    it('clearNameSuggestionState clears the state', () => {
+      useLibraryStore.getState().setNameSuggestionDismissed('layout-0', true);
+      useLibraryStore.getState().clearNameSuggestionState('layout-0');
+
+      const state = useLibraryStore.getState().getNameSuggestionState('layout-0');
+      expect(state).toBeUndefined();
+    });
+
+    it('getNameSuggestionState returns undefined for entry without state', () => {
+      const state = useLibraryStore.getState().getNameSuggestionState('layout-1');
+      expect(state).toBeUndefined();
+    });
+
+    it('getNameSuggestionState returns undefined for non-existent entry', () => {
+      const state = useLibraryStore.getState().getNameSuggestionState('non-existent');
+      expect(state).toBeUndefined();
+    });
+  });
+
   describe('setShowLayoutManager', () => {
     it('sets showLayoutManager to true', () => {
       useLibraryStore.getState().setShowLayoutManager(true);

--- a/src/core/store/settings.test.ts
+++ b/src/core/store/settings.test.ts
@@ -512,6 +512,44 @@ describe('settings store', () => {
     });
   });
 
+  describe('saveCategoriesAsDefaults', () => {
+    it('saves categories as default categories', () => {
+      const { saveCategoriesAsDefaults } = useSettingsStore.getState();
+      const categories = [
+        { id: 'cat-1', name: 'Tools', color: '#FF0000' },
+        { id: 'cat-2', name: 'Parts', color: '#00FF00' },
+      ];
+
+      saveCategoriesAsDefaults(categories);
+
+      const settings = useSettingsStore.getState().settings;
+      expect(settings.defaultCategories).toEqual(categories);
+    });
+
+    it('deep copies categories to avoid reference issues', () => {
+      const { saveCategoriesAsDefaults } = useSettingsStore.getState();
+      const categories = [{ id: 'cat-1', name: 'Tools', color: '#FF0000' }];
+
+      saveCategoriesAsDefaults(categories);
+
+      const settings = useSettingsStore.getState().settings;
+      expect(settings.defaultCategories).not.toBe(categories);
+      expect(settings.defaultCategories![0]).not.toBe(categories[0]);
+    });
+
+    it('sets null when given empty array', () => {
+      const { saveCategoriesAsDefaults, updateSetting } = useSettingsStore.getState();
+      // First set some categories
+      updateSetting('defaultCategories', [{ id: 'cat-1', name: 'Tools', color: '#FF0000' }]);
+
+      // Then clear with empty array
+      saveCategoriesAsDefaults([]);
+
+      const settings = useSettingsStore.getState().settings;
+      expect(settings.defaultCategories).toBeNull();
+    });
+  });
+
   // Note: Tests for loadSettings() initialization behavior are not feasible in unit tests
   // because Zustand stores initialize their state once at module load time.
   // The localStorage loading and normalization logic is tested via e2e tests instead.

--- a/src/features/bin-designer/constants/defaults.test.ts
+++ b/src/features/bin-designer/constants/defaults.test.ts
@@ -210,6 +210,47 @@ describe('migrateParams', () => {
     expect(result1.wallPattern).not.toBe(result2.wallPattern);
   });
 
+  it('should handle mixed legacy walls with partial WallCutout objects alongside numbers', () => {
+    // Legacy format: at least one side is a number, another is a partial WallCutout object
+    const result = migrateParams({
+      walls: { front: 80, back: { width: 50, depth: 75 }, left: 0, right: undefined },
+    } as any);
+    // Number value: front=80 → enabled with depth 100
+    expect(result.walls.front).toEqual({ enabled: true, width: 80, depth: 100 });
+    // Object value: back gets merged with defaults and inferred enabled
+    expect(result.walls.back.width).toBe(50);
+    expect(result.walls.back.depth).toBe(75);
+    expect(result.walls.back.enabled).toBe(true);
+    // Number zero: left=0 → disabled
+    expect(result.walls.left).toEqual({ enabled: false, width: 0, depth: 0 });
+    // Undefined: right → defaults
+    expect(result.walls.right).toEqual(DEFAULT_BIN_PARAMS.walls.front);
+  });
+
+  it('should migrate legacy base.solid=true to style="solid"', () => {
+    const result = migrateParams({
+      style: 'standard',
+      base: { solid: true } as any,
+    });
+    expect(result.style).toBe('solid');
+  });
+
+  it('should not change style when base.solid is false', () => {
+    const result = migrateParams({
+      style: 'standard',
+      base: { solid: false } as any,
+    });
+    expect(result.style).toBe('standard');
+  });
+
+  it('should not change style when already solid', () => {
+    const result = migrateParams({
+      style: 'solid',
+      base: { solid: true } as any,
+    });
+    expect(result.style).toBe('solid');
+  });
+
   it('should default walls.shape to u-shape when shape is missing', () => {
     const result = migrateParams({
       walls: {


### PR DESCRIPTION
## Summary

- CI on main was failing because line coverage (77.99%) and function coverage (76.97%) fell below thresholds (78% / 77%) after #717 and #718 refactored type casts without adding corresponding tests
- Adds 16 targeted tests across 4 files to cover previously untested error paths and store actions, bringing coverage safely above thresholds

## Changes

| File | Tests added | What's covered |
|------|------------|----------------|
| `defaults.test.ts` | 4 | Mixed legacy wall format (numbers + WallCutout objects), `base.solid` migration |
| `LayoutManager.test.ts` | 3 | `saveLibraryInternal` error paths in `switchActiveLayout`, `updateCloudShare`, `renameLayoutEntry` |
| `library.test.ts` | 6 | `setNameSuggestionDismissed`, `clearNameSuggestionState`, `getNameSuggestionState` |
| `settings.test.ts` | 3 | `saveCategoriesAsDefaults` (save, deep copy, empty → null) |

## Coverage improvement (local)

| Metric | Before | After | Threshold |
|--------|--------|-------|-----------|
| Lines | 78.05% | 78.17% | 78% |
| Functions | 77.19% | 77.38% | 77% |
| Statements | 77.28% | 77.39% | 77% |
| Branches | 69.37% | 69.49% | 66.5% |

## Test plan

- [x] All 7,436 tests pass locally
- [x] All pre-commit hooks pass (lint, i18n, boundaries, affected tests)
- [ ] CI coverage thresholds pass on this branch