### PR TITLE
docs: add brepjs link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Web app for designing storage layouts for 3D-printed Gridfinity drawer organizer
 - **Responsive Design** - Desktop, tablet, and mobile support
 - **PWA** - Installable, works offline
 
+## Built With
+
+3D geometry generation is powered by [brepjs](https://github.com/andymai/brepjs) — a Web CAD library built on OpenCascade WASM for solid modeling, boolean operations, and mesh export.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a "Built With" section to the root README linking to the [brepjs](https://github.com/andymai/brepjs) repository
- Credits brepjs as the CAD engine powering 3D geometry generation

## Test plan
- [ ] Verify the link resolves to the correct GitHub repository
- [ ] Confirm README renders correctly on GitHub