### PR TITLE
fix(grid-editor): clamp fractional coords to valid half-bin positions

### DIFF
--- a/src/features/grid-editor/hooks/useGridCoords.ts
+++ b/src/features/grid-editor/hooks/useGridCoords.ts
@@ -145,8 +145,9 @@ export function useGridCoords(gridRef: RefObject<HTMLDivElement | null>) {
 
         let x: number;
         if (cellX === -1) {
-          // In fractional column - x is 0 to fractionalWidthPart
-          x = isLeftHalf ? 0 : fractionalWidthPart / 2;
+          // In fractional column - clamp to valid half-bin positions within the strip
+          const xHalfOffset = isLeftHalf ? 0 : snapToHalf(fractionalWidthPart / 2);
+          x = Math.min(xHalfOffset, fractionalWidthPart - 0.5);
         } else {
           // In integer column - offset by fractional width if edge is at start
           const baseX =
@@ -157,8 +158,9 @@ export function useGridCoords(gridRef: RefObject<HTMLDivElement | null>) {
         let y: number;
         if (cellY === -1) {
           // In fractional row (at top when edge='end')
-          const fractionalY = integerDepth + (isTopHalf ? fractionalDepthPart / 2 : 0);
-          y = fractionalY;
+          // Clamp to last valid half-bin position within the fractional strip
+          const halfOffset = isTopHalf ? snapToHalf(fractionalDepthPart / 2) : 0;
+          y = integerDepth + Math.min(halfOffset, fractionalDepthPart - 0.5);
         } else {
           // In integer row
           const baseY =


### PR DESCRIPTION
## Summary
- Clicking the top half of a 0.5-unit fractional row in half-bin mode produced an out-of-bounds y coordinate (e.g. `y=7.5` in a `depth=7.5` drawer), causing interactions to silently fail near the drawer edge
- Applied the same defensive clamping to fractional columns on the X axis

## Test plan
- [x] Existing `useGridCoords.test.ts` passes (19 tests)
- [ ] Manual: enable half-bin mode, set fractional drawer depth (e.g. 7.5), click near the top edge of the fractional row — bin should place correctly