### PR TITLE
fix(api): add missing allowOverwrite to report endpoint

### DIFF
--- a/api/report/[id].ts
+++ b/api/report/[id].ts
@@ -78,6 +78,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       access: 'public',
       contentType: 'application/json',
       addRandomSuffix: false,
+      allowOverwrite: true,
     });
 
     // Log report for manual review


### PR DESCRIPTION
## Summary
- Report endpoint `put()` was missing `allowOverwrite: true`, causing report count updates to write to a new blob path instead of updating the existing one
- Matches the pattern already used in `share/[id].ts`

## Test plan
- [x] Typecheck passes
- [ ] Manual: report a shared layout, verify blob is updated in-place (not duplicated)