### PR TITLE
fix(validation): reject zero/negative dimensions in type guards

### DIFF
--- a/api/lib/validation.ts
+++ b/api/lib/validation.ts
@@ -410,7 +410,8 @@ function isValidLayer(value: unknown): value is LayerShape {
     typeof obj.id === 'string' &&
     typeof obj.name === 'string' &&
     typeof obj.height === 'number' &&
-    Number.isFinite(obj.height)
+    Number.isFinite(obj.height) &&
+    obj.height > 0
   );
 }
 
@@ -429,7 +430,10 @@ function isValidBin(value: unknown): value is BinShape {
     Number.isFinite(obj.y) &&
     Number.isFinite(obj.width) &&
     Number.isFinite(obj.depth) &&
-    Number.isFinite(obj.height)
+    Number.isFinite(obj.height) &&
+    obj.width > 0 &&
+    obj.depth > 0 &&
+    obj.height > 0
   );
 }
 

--- a/src/shared/utils/validation.ts
+++ b/src/shared/utils/validation.ts
@@ -61,7 +61,10 @@ export function isValidDrawer(value: unknown): value is DrawerShape {
     typeof obj.height === 'number' &&
     Number.isFinite(obj.width) &&
     Number.isFinite(obj.depth) &&
-    Number.isFinite(obj.height)
+    Number.isFinite(obj.height) &&
+    obj.width > 0 &&
+    obj.depth > 0 &&
+    obj.height > 0
   );
 }
 
@@ -77,7 +80,8 @@ export function isValidLayer(value: unknown): value is LayerShape {
     typeof obj.id === 'string' &&
     typeof obj.name === 'string' &&
     typeof obj.height === 'number' &&
-    Number.isFinite(obj.height)
+    Number.isFinite(obj.height) &&
+    obj.height > 0
   );
 }
 
@@ -101,7 +105,10 @@ export function isValidBin(value: unknown): value is BinShape {
     Number.isFinite(obj.y) &&
     Number.isFinite(obj.width) &&
     Number.isFinite(obj.depth) &&
-    Number.isFinite(obj.height)
+    Number.isFinite(obj.height) &&
+    obj.width > 0 &&
+    obj.depth > 0 &&
+    obj.height > 0
   );
 }
 


### PR DESCRIPTION
## Summary
- Client-side `isValidDrawer`, `isValidLayer`, `isValidBin` were missing `> 0` checks on dimensions, allowing degenerate data through JSON import/paste
- Server-side `isValidLayer` and `isValidBin` had the same gap
- Aligns all type guards with server `isValidDrawer` which already enforced `> 0`

## Test plan
- [x] All 112 validation tests pass (client + server)