### PR TITLE
fix(types): accept nullable activeLayoutId in resolveLayout

### DIFF
--- a/src/components/Mobile/MobileLayoutsPanel/MobileLayoutsPanel.tsx
+++ b/src/components/Mobile/MobileLayoutsPanel/MobileLayoutsPanel.tsx
@@ -239,7 +239,7 @@ function findEntry(entries: readonly LayoutEntry[], id: string): LayoutEntry | u
 
 async function resolveLayout(
   id: string,
-  activeLayoutId: string,
+  activeLayoutId: string | null,
   currentLayout: Layout
 ): Promise<Layout | null> {
   if (id === activeLayoutId) return currentLayout;


### PR DESCRIPTION
## Summary
- Widen `resolveLayout` parameter type from `string` to `string | null` to match store's `LayoutId | null`
- Fixes TS2345 build error on Vercel

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Pre-commit hooks pass