### PR TITLE
fix(settings): stabilize modal height and add mobile fullscreen

### DIFF
--- a/src/components/Modals/SettingsModal/SettingsModal.tsx
+++ b/src/components/Modals/SettingsModal/SettingsModal.tsx
@@ -92,7 +92,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
         <div
           ref={modalRef}
           className={`flex flex-col animate-scale-in ${
-            isMobile ? 'w-full h-full' : 'w-full mx-4 h-[85vh] max-w-2xl'
+            isMobile ? 'w-full h-full' : 'w-[48rem] h-[85vh]'
           }`}
           style={{
             backgroundColor: 'var(--bg-secondary)',


### PR DESCRIPTION
## Summary
- Fix settings modal changing size when switching between tabs by using fixed `h-[85vh]` instead of `max-h-[85vh]`
- Make settings modal fullscreen on mobile for a native sheet experience
- Remove border/radius/shadow on mobile for clean edge-to-edge layout

## Test plan
- [ ] Open settings modal on desktop — verify height stays constant when switching tabs
- [ ] Open settings modal on mobile viewport — verify it goes fullscreen
- [ ] Verify tab content scrolls properly within the fixed-height container
- [ ] Verify close button and escape key still work on both desktop and mobile