### PR TITLE
fix(lint): resolve all ESLint no-unnecessary-condition warnings

### DIFF
--- a/api/feedback.ts
+++ b/api/feedback.ts
@@ -127,7 +127,7 @@ function buildEnrichmentPrompt(
     general: 'Format structuredBody as: ## Details\\n\\n[organized feedback details]',
   };
 
-  const enrichedCategory = CATEGORY_CONFIG[userCategory]?.enriched ?? 'general';
+  const enrichedCategory = CATEGORY_CONFIG[userCategory].enriched;
 
   let prompt = `Analyze this user feedback and produce structured output.
 
@@ -216,7 +216,7 @@ async function enrichFeedback(
     let body = sanitizeLlmBody(enrichment.structuredBody);
 
     const enrichedCategory = enrichment.category;
-    const userEnrichedCategory = CATEGORY_CONFIG[userCategory]?.enriched ?? 'general';
+    const userEnrichedCategory = CATEGORY_CONFIG[userCategory].enriched;
     if (enrichedCategory !== userEnrichedCategory) {
       body += `\n\n> **Note:** User selected "${userCategory}" but LLM classified as "${enrichedCategory}".`;
     }
@@ -244,7 +244,7 @@ async function enrichFeedback(
 
     // Fallback: first sentence as title, raw body
     const fallbackTitle = description.split(/[.\n]/)[0].slice(0, 80) || 'User Feedback';
-    const categoryLabel = CATEGORY_CONFIG[userCategory]?.label ?? 'feedback: general';
+    const categoryLabel = CATEGORY_CONFIG[userCategory].label;
 
     const body = appendMetadataSections(sanitizeLlmBody(description), context, email);
 

--- a/src/components/Mobile/BottomSheet/BottomSheet.tsx
+++ b/src/components/Mobile/BottomSheet/BottomSheet.tsx
@@ -106,6 +106,7 @@ export function BottomSheet({ children, title }: BottomSheetProps) {
 
     if (shouldDismiss) {
       // Haptic feedback on dismiss
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- not available in all environments (e.g. jsdom)
       if (navigator.vibrate) {
         navigator.vibrate(15);
       }

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/PathEditOverlay3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/PathEditOverlay3D.tsx
@@ -132,7 +132,7 @@ export function PathEditOverlay3D({
       })}
 
       {/* Segment hover: highlighted segment + ghost dot */}
-      {segmentHover && path && (
+      {segmentHover && (
         <SegmentHoverPreview
           path={path}
           hover={segmentHover}

--- a/src/features/command-palette/components/CommandPalette/CommandPalette.tsx
+++ b/src/features/command-palette/components/CommandPalette/CommandPalette.tsx
@@ -777,7 +777,6 @@ const CATEGORY_ICON_MAP: Record<string, IconName> = {
 
 function CategoryIcon({ category }: { category: string }) {
   const iconName = CATEGORY_ICON_MAP[category];
-  if (!iconName) return null;
   const paths = ICON_PATHS[iconName];
 
   return (

--- a/src/shared/constraints/engine.ts
+++ b/src/shared/constraints/engine.ts
@@ -24,6 +24,7 @@ function mergeParams(base: BinParams, partial: Partial<BinParams>): BinParams {
   const result = { ...base };
 
   for (const [key, value] of Object.entries(partial)) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Object.entries can yield undefined at runtime for Partial<T>
     if (value === undefined) continue;
 
     const k = key as keyof BinParams;


### PR DESCRIPTION
## Summary
- Remove redundant optional chains, nullish coalescing, and dead guards where TypeScript proves conditions are always truthy/falsy
- Add targeted `eslint-disable` comments for 2 cases where runtime behavior diverges from types (`navigator.vibrate` in jsdom, `Object.entries` of `Partial<T>`)
- Resolves all 10 `@typescript-eslint/no-unnecessary-condition` warnings on main

## Test plan
- [x] `npm run lint` — zero warnings
- [x] `npm run typecheck` — passes
- [x] Affected test suites pass (BottomSheet, CommandPalette, constraints engine, feedback API, bin designer)