### PR TITLE
fix: widen return types to include LayoutLibraryLimitError

### DIFF
--- a/src/hooks/useLayoutSwitcher.ts
+++ b/src/hooks/useLayoutSwitcher.ts
@@ -24,7 +24,14 @@ import { setLayoutURL } from '@/utils/url';
 import { createLayoutWithSettings } from '@/core/constants';
 import { trackLayoutAction } from '@/shared/analytics/posthog';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
-import type { Result, Unit, LayoutError, StorageError, UnknownError } from '@/core/result';
+import type {
+  Result,
+  Unit,
+  LayoutError,
+  StorageError,
+  UnknownError,
+  LayoutLibraryLimitError,
+} from '@/core/result';
 import { ok, err, OK, layoutLastEntity, layoutInvalidOperation, fromUnknown } from '@/core/result';
 import { useTranslation } from '@/i18n';
 
@@ -189,7 +196,9 @@ export function useLayoutSwitcher() {
    * Create a new layout and switch to it.
    */
   const createNewLayout = useCallback(
-    async (name?: string): Promise<Result<string, StorageError | UnknownError>> => {
+    async (
+      name?: string
+    ): Promise<Result<string, StorageError | UnknownError | LayoutLibraryLimitError>> => {
       // Save current layout first
       await saveCurrentLayout();
 
@@ -369,7 +378,7 @@ export function useLayoutSwitcher() {
     async (
       importedLayout: Layout,
       forkedFrom?: { name: string; author?: string }
-    ): Promise<Result<string, StorageError | UnknownError>> => {
+    ): Promise<Result<string, StorageError | UnknownError | LayoutLibraryLimitError>> => {
       try {
         // Get fresh library state to avoid stale closure
         const currentLibrary = useLibraryStore.getState().library;


### PR DESCRIPTION
## Summary
- Fixes the TypeScript build failure on main caused by a type mismatch in `useLayoutSwitcher`
- `createNewLayout` and `importLayoutFromJSON` declared `Result<string, StorageError | UnknownError>` but call `createLayoutEntry` which can return `LayoutLibraryLimitError` — TypeScript rejects the implicit narrowing since their discriminant `kind` fields differ
- Adds `LayoutLibraryLimitError` to both function return types

## Test plan
- [x] `npx tsc -b --noEmit` no longer reports errors in `useLayoutSwitcher.ts`
- [x] All pre-commit hooks pass (lint, i18n, boundaries, exhaustiveness, tests)
- [ ] CI passes on this PR