### PR TITLE
fix(ci): update PostHog source map upload inputs for v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,15 +40,15 @@ jobs:
         run: npm run size:check
 
       # Upload source maps to PostHog for error tracking (main branch only)
-      # Requires POSTHOG_CLI_TOKEN and POSTHOG_ENV_ID secrets
+      # Requires POSTHOG_API_KEY and POSTHOG_PROJECT_ID secrets
       # Get these from PostHog: Settings > Environment > Source Maps
       - name: Upload source maps to PostHog
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: PostHog/upload-source-maps@v2.0.0
         with:
           directory: dist
-          env-id: ${{ secrets.POSTHOG_ENV_ID }}
-          cli-token: ${{ secrets.POSTHOG_CLI_TOKEN }}
+          project-id: ${{ secrets.POSTHOG_PROJECT_ID }}
+          api-key: ${{ secrets.POSTHOG_API_KEY }}
 
   # Main branch only: Full test suite with coverage (safety net)
   test:


### PR DESCRIPTION
## Summary
- Fixes the CI Build failure on main caused by `PostHog/upload-source-maps@v2.0.0` changing its input names
- `env-id` → `project-id` (secret: `POSTHOG_PROJECT_ID`)
- `cli-token` → `api-key` (secret: `POSTHOG_API_KEY`)

## Action required
You'll need to add two new GitHub repository secrets:
- **`POSTHOG_PROJECT_ID`** — your PostHog project ID (Settings > Project > Project ID)
- **`POSTHOG_API_KEY`** — a personal API key with error tracking write scope

The old secrets (`POSTHOG_ENV_ID`, `POSTHOG_CLI_TOKEN`) can be removed afterward.

## Test plan
- [ ] CI Build job passes after secrets are configured