### PR TITLE
fix(bin-designer): use dimension-based tessellation with tight lip tolerance

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.snapshots.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.snapshots.test.ts.snap
@@ -1,149 +1,149 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `1018`;
+exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2246`;
 
-exports[`base styles > 'flat' base > 'no lip' 1`] = `172`;
+exports[`base styles > 'flat' base > 'no lip' 1`] = `212`;
 
-exports[`base styles > 'flat' base > 'with lip' 1`] = `540`;
+exports[`base styles > 'flat' base > 'with lip' 1`] = `1478`;
 
 exports[`base styles > 'magnet' base > 'no lip' 1`] = `572`;
 
-exports[`base styles > 'magnet' base > 'with lip' 1`] = `940`;
+exports[`base styles > 'magnet' base > 'with lip' 1`] = `2158`;
 
 exports[`base styles > 'magnet+screw' base > 'no lip' 1`] = `732`;
 
-exports[`base styles > 'magnet+screw' base > 'with lip' 1`] = `1100`;
+exports[`base styles > 'magnet+screw' base > 'with lip' 1`] = `2446`;
 
 exports[`base styles > 'screw' base > 'no lip' 1`] = `476`;
 
-exports[`base styles > 'screw' base > 'with lip' 1`] = `844`;
+exports[`base styles > 'screw' base > 'with lip' 1`] = `2030`;
 
 exports[`base styles > 'standard' base > 'no lip' 1`] = `316`;
 
-exports[`base styles > 'standard' base > 'with lip' 1`] = `684`;
+exports[`base styles > 'standard' base > 'with lip' 1`] = `1742`;
 
 exports[`base styles > 'weighted' base > 'no lip' 1`] = `316`;
 
-exports[`base styles > 'weighted' base > 'with lip' 1`] = `684`;
+exports[`base styles > 'weighted' base > 'with lip' 1`] = `1742`;
 
-exports[`bin styles > 2×2 'slotted' 1`] = `1500`;
+exports[`bin styles > 2×2 'slotted' 1`] = `2990`;
 
-exports[`bin styles > 2×2 'solid' 1`] = `1148`;
+exports[`bin styles > 2×2 'solid' 1`] = `2558`;
 
-exports[`bin styles > 2×2 'standard' 1`] = `1260`;
+exports[`bin styles > 2×2 'standard' 1`] = `2750`;
 
-exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `780`;
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1718`;
 
-exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `1676`;
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3214`;
 
-exports[`combined features > 2×2 label tabs with merged compartments 1`] = `3648`;
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `5202`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `5396`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `6974`;
 
-exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `4636`;
+exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `10788`;
 
-exports[`compartments > 2×2 bin with '1×1 (none)' compartments 1`] = `1260`;
+exports[`compartments > 2×2 bin with '1×1 (none)' compartments 1`] = `2750`;
 
-exports[`compartments > 2×2 bin with '2×2' compartments 1`] = `2004`;
+exports[`compartments > 2×2 bin with '2×2' compartments 1`] = `3470`;
 
-exports[`compartments > 2×2 bin with '3×2 merged top-left' compartments 1`] = `2088`;
+exports[`compartments > 2×2 bin with '3×2 merged top-left' compartments 1`] = `3562`;
 
-exports[`compartments > 2×2 bin with '4×4 dense grid' compartments 1`] = `3748`;
+exports[`compartments > 2×2 bin with '4×4 dense grid' compartments 1`] = `5214`;
 
 exports[`dimensions > '0.5×0.5' > 'no lip' 1`] = `316`;
 
-exports[`dimensions > '0.5×0.5' > 'with lip' 1`] = `684`;
+exports[`dimensions > '0.5×0.5' > 'with lip' 1`] = `1742`;
 
 exports[`dimensions > '1.5×2 fractional' > 'no lip' 1`] = `892`;
 
-exports[`dimensions > '1.5×2 fractional' > 'with lip' 1`] = `1260`;
+exports[`dimensions > '1.5×2 fractional' > 'with lip' 1`] = `2750`;
 
 exports[`dimensions > '1×1' > 'no lip' 1`] = `316`;
 
-exports[`dimensions > '1×1' > 'with lip' 1`] = `684`;
+exports[`dimensions > '1×1' > 'with lip' 1`] = `1742`;
 
 exports[`dimensions > '2×2' > 'no lip' 1`] = `892`;
 
-exports[`dimensions > '2×2' > 'with lip' 1`] = `1260`;
+exports[`dimensions > '2×2' > 'with lip' 1`] = `2750`;
 
-exports[`dimensions > '4×4' > 'no lip' 1`] = `1116`;
+exports[`dimensions > '4×4' > 'no lip' 1`] = `2652`;
 
-exports[`dimensions > '4×4' > 'with lip' 1`] = `1334`;
+exports[`dimensions > '4×4' > 'with lip' 1`] = `5798`;
 
 exports[`export mode > 2×2 default params (forExport=true) 1`] = `10292`;
 
-exports[`half-sockets > '1.5×1.5' with half sockets 1`] = `2220`;
+exports[`half-sockets > '1.5×1.5' with half sockets 1`] = `4430`;
 
-exports[`half-sockets > '1×1' with half sockets 1`] = `1260`;
+exports[`half-sockets > '1×1' with half sockets 1`] = `2750`;
 
-exports[`half-sockets > '2×2' with half sockets 1`] = `3564`;
+exports[`half-sockets > '2×2' with half sockets 1`] = `6782`;
 
-exports[`height > 2×2 height 'minimum (2u)' 1`] = `1260`;
+exports[`height > 2×2 height 'minimum (2u)' 1`] = `2750`;
 
-exports[`height > 2×2 height 'tall (10u)' 1`] = `1260`;
+exports[`height > 2×2 height 'tall (10u)' 1`] = `2750`;
 
-exports[`inserts > 2×2 with 'circle' insert 1`] = `1408`;
+exports[`inserts > 2×2 with 'circle' insert 1`] = `2970`;
 
-exports[`inserts > 2×2 with 'hexagon' insert 1`] = `1408`;
+exports[`inserts > 2×2 with 'hexagon' insert 1`] = `2970`;
 
-exports[`inserts > 2×2 with 'rectangle' insert 1`] = `1296`;
+exports[`inserts > 2×2 with 'rectangle' insert 1`] = `2786`;
 
-exports[`inserts > 2×2 with 'rounded-rect' insert 1`] = `1360`;
+exports[`inserts > 2×2 with 'rounded-rect' insert 1`] = `2898`;
 
-exports[`inserts > 2×2 with 'slot' insert 1`] = `1384`;
+exports[`inserts > 2×2 with 'slot' insert 1`] = `2922`;
 
-exports[`label tabs > 2×2 label 'bracket center' 1`] = `1952`;
+exports[`label tabs > 2×2 label 'bracket center' 1`] = `3522`;
 
-exports[`label tabs > 2×2 label 'bracket left' 1`] = `1952`;
+exports[`label tabs > 2×2 label 'bracket left' 1`] = `3522`;
 
-exports[`label tabs > 2×2 label 'bracket right' 1`] = `1952`;
+exports[`label tabs > 2×2 label 'bracket right' 1`] = `3522`;
 
-exports[`label tabs > 2×2 label 'disabled' 1`] = `1260`;
+exports[`label tabs > 2×2 label 'disabled' 1`] = `2750`;
 
-exports[`label tabs > 2×2 label 'solid left' 1`] = `1624`;
+exports[`label tabs > 2×2 label 'solid left' 1`] = `3258`;
 
-exports[`large bin > 8×8 standard 1`] = `4406`;
+exports[`large bin > 8×8 standard 1`] = `15532`;
 
-exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `1520`;
+exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3146`;
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `1884`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `3482`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `2764`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4358`;
 
-exports[`scoop > 2×2 scoop 'auto radius' 1`] = `1884`;
+exports[`scoop > 2×2 scoop 'auto radius' 1`] = `3482`;
 
-exports[`scoop > 2×2 scoop 'disabled' 1`] = `1260`;
+exports[`scoop > 2×2 scoop 'disabled' 1`] = `2750`;
 
-exports[`scoop > 2×2 scoop 'radius 10mm' 1`] = `1952`;
+exports[`scoop > 2×2 scoop 'radius 10mm' 1`] = `3514`;
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `1500`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `2990`;
 
-exports[`slotted variations > slotted with both axes 1`] = `1740`;
+exports[`slotted variations > slotted with both axes 1`] = `3230`;
 
 exports[`slotted variations > slotted without lip 1`] = `988`;
 
-exports[`solid cutouts > 2×2 solid with 'circle' cutout 1`] = `1264`;
+exports[`solid cutouts > 2×2 solid with 'circle' cutout 1`] = `2746`;
 
-exports[`solid cutouts > 2×2 solid with 'ellipse' cutout 1`] = `1278`;
+exports[`solid cutouts > 2×2 solid with 'ellipse' cutout 1`] = `2772`;
 
-exports[`solid cutouts > 2×2 solid with 'rectangle with scoop' cutout 1`] = `1384`;
+exports[`solid cutouts > 2×2 solid with 'rectangle with scoop' cutout 1`] = `3106`;
 
-exports[`solid cutouts > 2×2 solid with 'rectangle' cutout 1`] = `1168`;
+exports[`solid cutouts > 2×2 solid with 'rectangle' cutout 1`] = `2578`;
 
-exports[`solid cutouts > 2×2 solid with 'rotated 45°' cutout 1`] = `1180`;
+exports[`solid cutouts > 2×2 solid with 'rotated 45°' cutout 1`] = `2590`;
 
-exports[`solid cutouts > 2×2 solid with 'rounded-rectangle' cutout 1`] = `1236`;
+exports[`solid cutouts > 2×2 solid with 'rounded-rectangle' cutout 1`] = `2686`;
 
-exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `1300`;
+exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `2710`;
 
-exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `1178`;
+exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2588`;
 
-exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `1340`;
+exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `2750`;
 
-exports[`solid cutouts > 2×2 solid with topOffset 1`] = `1160`;
+exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2570`;
 
-exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `1160`;
+exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2570`;
 
-exports[`wall thickness > 2×2 'thick (2.4mm)' walls 1`] = `1356`;
+exports[`wall thickness > 2×2 'thick (2.4mm)' walls 1`] = `2878`;
 
-exports[`wall thickness > 2×2 'thin (0.4mm)' walls 1`] = `1340`;
+exports[`wall thickness > 2×2 'thin (0.4mm)' walls 1`] = `2878`;

--- a/src/features/generation/worker/generators/binGenerator.ts
+++ b/src/features/generation/worker/generators/binGenerator.ts
@@ -206,10 +206,13 @@ export function generateBin(
     !halfSockets &&
     (params.base.style === 'screw' || params.base.style === 'magnet_and_screw');
 
-  // Dynamic quality: small bins (< 4x4) get higher fidelity preview
-  const cellCount = params.width * params.depth;
-  const isSmallBin = cellCount < 16; // 4x4 = 16 cells threshold
-  const useHighQuality = forExport || isSmallBin;
+  // Dynamic quality based on physical dimension (not cell count).
+  // Cell count correlates poorly with needed tessellation quality — a 6×2 bin
+  // has only 12 cells but a 252mm footprint with thin features that need care.
+  const maxDimension = Math.max(params.width, params.depth) * SIZE;
+  const isSmallBin = maxDimension <= 200; // ~4.7 units — small enough for full-quality preview
+  // Lip bins always need precomputed normals for smooth chamfer shading
+  const useHighQuality = forExport || isSmallBin || params.base.stackingLip;
 
   // Stages 1-3: Build base socket + box + lip, then assemble.
   // The assembled shell is cached -- only features (compartments, inserts, tabs)
@@ -556,32 +559,36 @@ export function generateBin(
   onProgress?.('merge', 0.9);
   setLastSolid(bin);
 
-  // Dynamic tessellation: export gets fine quality, preview adapts to bin size
-  const maxDimension = Math.max(params.width, params.depth) * SIZE;
+  // Dynamic tessellation: export gets fine quality, preview scales with dimension.
+  //
+  // The stacking lip has a 0.7mm chamfer and 1.9mm chamfer that intersect with
+  // corner fillets — these curved junctions need tight tolerance to avoid chunky
+  // faceting. For bins with lips, tolerance is capped at 0.1mm so the chamfer
+  // profile stays smooth. Bins without lips can use coarser tessellation since
+  // their surfaces are mostly planar.
   let tolerance: number;
   let angularTolerance: number;
 
-  // The stacking lip wall extension is only 1.2mm thick. Tessellation tolerance
-  // must be well under this to preserve the thin wall geometry in the mesh.
-  // Tolerance values above ~0.7mm cause the lip extension faces to collapse.
   const hasLipFeature = params.base.stackingLip;
 
   if (forExport) {
     // Export: fine tessellation for smooth curves
     tolerance = 0.01;
     angularTolerance = 5;
+  } else if (hasLipFeature) {
+    // Any bin with stacking lip: tight tolerance to preserve chamfer profile.
+    // The lip's 0.7mm small chamfer at corner fillet intersections needs ≤0.1mm
+    // tolerance to render smoothly. Scale slightly with dimension but hard-cap.
+    tolerance = Math.min(0.1, Math.max(0.05, maxDimension / 2500));
+    angularTolerance = 10;
   } else if (isSmallBin) {
-    // Small bin preview: moderate quality (fast but still smooth)
+    // Small bin without lip: moderate quality
     tolerance = Math.min(0.4, Math.max(0.15, maxDimension / 600));
     angularTolerance = 12;
-  } else if (hasLipFeature) {
-    // Large bin with lip: tighter tolerance to preserve the thin lip extension wall
-    tolerance = Math.min(0.6, Math.max(0.3, maxDimension / 400));
-    angularTolerance = 20;
   } else {
-    // Large bin without lip: coarse tessellation for speed
-    tolerance = Math.min(3, Math.max(1, maxDimension / 100));
-    angularTolerance = 30;
+    // Large bin without lip: coarser tessellation for speed
+    tolerance = Math.min(1.0, Math.max(0.3, maxDimension / 300));
+    angularTolerance = 25;
   }
 
   const shapeMesh = mesh(bin, { tolerance, angularTolerance });


### PR DESCRIPTION
## Summary
- Replaced cell-count threshold (`cellCount < 16`) with physical dimension threshold (`maxDimension ≤ 200mm`) for preview quality tiers — elongated bins like 6×2 (12 cells, 252mm footprint) were misclassified as "small"
- Bins with stacking lip now get ≤0.1mm tolerance / 10° angular tolerance regardless of size, preserving smooth chamfer profiles at corner-fillet intersections
- Bins without lip retain coarser tessellation for speed; large lipless bins get a modest quality bump (tolerance capped at 1.0mm instead of 3.0mm)

Fixes chunky/faceted stacking lip rendering on bins ≥5 units in any dimension. Follow-up to #782.

## Test plan
- [x] All 147 scenario snapshot tests pass (63 snapshots updated for higher triangle counts)
- [x] All 4 lip-wall regression tests pass (6×2, 4×4, 5×4, 8×2)
- [x] Visually verified smooth lip profile on 6×2 and 8×2 bins in Bin Designer preview
- [ ] Verify no noticeable performance regression on mobile for large lip bins