### PR TITLE
fix(bin-designer): enable scrolling in saved designs dialog with many designs

### DIFF
--- a/src/features/bin-designer/components/DesignListDialog/DesignListDialog.test.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListDialog.test.tsx
@@ -281,6 +281,37 @@ describe('DesignListDialog', () => {
     expect(screen.getByText(/1×1×6u/)).toBeInTheDocument();
   });
 
+  it('renders all designs when there are more than 9 saved', async () => {
+    const manyDesigns: SavedDesign[] = Array.from({ length: 12 }, (_, i) => ({
+      id: `design-${i + 1}`,
+      name: `Design ${i + 1}`,
+      params: { ...DEFAULT_BIN_PARAMS, width: i + 1 },
+      thumbnail: null,
+      createdAt: '2026-01-20T10:00:00.000Z',
+      updatedAt: new Date(2026, 0, 20 + i).toISOString(),
+      exportFileNameConfig: null,
+    }));
+
+    const DesignerStorage = await import('@/features/bin-designer/storage/DesignerStorage');
+    vi.mocked(DesignerStorage.listDesigns).mockResolvedValue(ok(manyDesigns));
+
+    render(<DesignListDialog open={true} onClose={onClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Design 1')).toBeInTheDocument();
+    });
+
+    // All 12 designs should be in the DOM (scrollable, not clipped)
+    for (let i = 1; i <= 12; i++) {
+      expect(screen.getByText(`Design ${i}`)).toBeInTheDocument();
+    }
+
+    // The content wrapper must be a flex column to ensure the scroll chain works
+    const dialog = screen.getByRole('dialog');
+    const contentWrapper = dialog.querySelector('[aria-busy]');
+    expect(contentWrapper).toHaveClass('flex', 'flex-col');
+  });
+
   describe('Import flow', () => {
     it('shows Import button in header', async () => {
       render(<DesignListDialog open={true} onClose={onClose} />);

--- a/src/features/bin-designer/components/DesignListDialog/DesignListDialog.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListDialog.tsx
@@ -398,7 +398,7 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
         </div>
 
         {/* Design list or import view */}
-        <div className="flex-1 min-h-0 overflow-hidden px-5 py-3" aria-busy={loading}>
+        <div className="flex-1 min-h-0 overflow-hidden flex flex-col px-5 py-3" aria-busy={loading}>
           {showImport ? (
             <DesignImportView onImport={handleImportDesign} onCancel={() => setShowImport(false)} />
           ) : loading ? (


### PR DESCRIPTION
## Summary

- Fixes a bug where users with 9+ saved bin designs could not scroll in the saved designs modal
- The content wrapper div was missing `flex flex-col`, breaking the CSS flex layout chain needed for `overflow-y-auto` to activate on the inner scroll area
- Adds regression test with 12 designs verifying all items render and the content wrapper has the correct flex classes

## Test plan

- [x] Open the bin designer and save 10+ designs
- [x] Open the saved designs modal — verify the list scrolls when designs overflow
- [x] Verify search, sort, grid/list toggle, and import still work correctly
- [x] Test on mobile viewport to confirm list view scrolls properly