### PR TITLE
fix(bin-designer): complete flex chain fix for saved designs dialog scrolling

### DIFF
--- a/src/features/bin-designer/components/DesignListDialog/DesignListDialog.test.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListDialog.test.tsx
@@ -306,10 +306,11 @@ describe('DesignListDialog', () => {
       expect(screen.getByText(`Design ${i}`)).toBeInTheDocument();
     }
 
-    // The content wrapper must be a flex column to ensure the scroll chain works
+    // The content wrapper must be a flex column (not overflow-hidden) to ensure the scroll chain works
     const dialog = screen.getByRole('dialog');
     const contentWrapper = dialog.querySelector('[aria-busy]');
     expect(contentWrapper).toHaveClass('flex', 'flex-col');
+    expect(contentWrapper).not.toHaveClass('overflow-hidden');
   });
 
   describe('Import flow', () => {

--- a/src/features/bin-designer/components/DesignListDialog/DesignListDialog.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListDialog.tsx
@@ -398,7 +398,7 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
         </div>
 
         {/* Design list or import view */}
-        <div className="flex-1 min-h-0 overflow-hidden flex flex-col px-5 py-3" aria-busy={loading}>
+        <div className="flex-1 min-h-0 flex flex-col px-5 py-3" aria-busy={loading}>
           {showImport ? (
             <DesignImportView onImport={handleImportDesign} onCancel={() => setShowImport(false)} />
           ) : loading ? (

--- a/src/shared/components/ItemListShell/ItemListShell.tsx
+++ b/src/shared/components/ItemListShell/ItemListShell.tsx
@@ -81,7 +81,7 @@ export function ItemListShell<T>({
   };
 
   return (
-    <div className="h-full flex flex-col">
+    <div className="flex-1 min-h-0 flex flex-col">
       {/* Optional Header Content (e.g., Create Button) */}
       {headerContent && <div className="pb-3">{headerContent}</div>}
 


### PR DESCRIPTION
## Summary

Follow-up to #790 which didn't fully resolve the scrolling issue.

- Removes `overflow-hidden` from the content wrapper — the dialog panel already clips overflow, and this was preventing scroll propagation
- Replaces `h-full` with `flex-1 min-h-0` on `ItemListShell`'s root — `height: 100%` cannot resolve to a definite height when the ancestor only has `max-height` (not `height`), breaking the scroll chain
- Updates regression test to assert no `overflow-hidden` on the content wrapper

The complete flex chain is now:
```
Dialog (max-h-[80vh] flex-col overflow-hidden)
  → Content wrapper (flex-1 min-h-0 flex-col)
    → ItemListShell (flex-1 min-h-0 flex-col)
      → Scroll area (flex-1 min-h-0 overflow-y-auto) ← scrolls here
```

## Test plan

- [ ] Open the bin designer and save 10+ designs
- [ ] Open the saved designs modal — verify the list scrolls when designs overflow
- [ ] Verify search, sort, grid/list toggle, and import still work correctly
- [ ] Test on mobile viewport to confirm list view scrolls properly