### PR TITLE
fix(bin-designer): use scrollbar-thin style in saved designs dialog

### DIFF
--- a/src/shared/components/ItemListShell/ItemListShell.tsx
+++ b/src/shared/components/ItemListShell/ItemListShell.tsx
@@ -101,7 +101,7 @@ export function ItemListShell<T>({
 
       {/* Content Area */}
       <div
-        className="flex-1 min-h-0 overflow-y-auto [scrollbar-gutter:stable]"
+        className="flex-1 min-h-0 overflow-y-auto scrollbar-thin"
         role="presentation"
         onKeyDown={onKeyboardNav}
       >


### PR DESCRIPTION
## Summary

- Replaces `[scrollbar-gutter:stable]` with `scrollbar-thin` on the ItemListShell scroll area to match the sidebar, right panel, settings modal, and all other scrollable areas in the app

## Test plan

- [ ] Open saved designs dialog with enough designs to scroll
- [ ] Verify scrollbar matches the thin style used in the sidebar