### PR TITLE
fix: resolve TypeScript errors in Vercel API build

### DIFF
--- a/api/lib/contentFilter.test.ts
+++ b/api/lib/contentFilter.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { filterLayoutContent } from '../../api/lib/contentFilter';
+import { filterLayoutContent } from '../../api/lib/contentFilter.js';
 
 describe('filterLayoutContent', () => {
   describe('clean content', () => {

--- a/api/lib/designerValidation.test.ts
+++ b/api/lib/designerValidation.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { validateDesignerShare } from './designerValidation';
+import { validateDesignerShare } from './designerValidation.js';
 
 function validPayload() {
   return {
@@ -28,7 +28,7 @@ function validPayload() {
       compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
       label: { enabled: false, support: 'bracket', depth: 12, width: 100, alignment: 'center' },
       walls: { front: 0, back: 0, left: 0, right: 0 },
-      inserts: [],
+      inserts: [] as Record<string, unknown>[],
     },
   };
 }

--- a/api/lib/validation.test.ts
+++ b/api/lib/validation.test.ts
@@ -4,7 +4,21 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { validateShareLayout, validateExpiration } from '../../api/lib/validation';
+import { validateShareLayout, validateExpiration } from '../../api/lib/validation.js';
+
+interface TestBin {
+  id: string;
+  layerId: string;
+  x: number;
+  y: number;
+  width: number;
+  depth: number;
+  height: number;
+  category: string;
+  label: string;
+  notes: string;
+  customProperties?: Record<string, string>;
+}
 
 // Helper to create a valid layout for testing
 function createValidLayout() {
@@ -30,7 +44,7 @@ function createValidLayout() {
         label: 'Test',
         notes: '',
       },
-    ],
+    ] as TestBin[],
   };
 }
 

--- a/api/liveblocks-auth.test.ts
+++ b/api/liveblocks-auth.test.ts
@@ -33,7 +33,7 @@ function createMockRequest(overrides: Partial<VercelRequest> = {}): VercelReques
 function createMockResponse(): VercelResponse & { _status: number; _body: unknown } {
   const res = {
     _status: 0,
-    _body: null,
+    _body: null as unknown,
     _headers: {} as Record<string, string>,
     status(code: number) {
       res._status = code;
@@ -99,7 +99,7 @@ describe('liveblocks-auth handler', () => {
       getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
     }));
 
-    const mod = await import('./liveblocks-auth');
+    const mod = await import('./liveblocks-auth.js');
     handler = mod.default;
   });
 

--- a/api/share.ts
+++ b/api/share.ts
@@ -70,9 +70,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       const result = validateDesignerShare(designerPayload, payloadJson.length);
 
       if (!result.valid) {
+        const { error } = result;
         return res.status(400).json({
-          error: result.error.message,
-          code: result.error.code,
+          error: error.message,
+          code: error.code,
         });
       }
 

--- a/api/suggest-name.ts
+++ b/api/suggest-name.ts
@@ -129,8 +129,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // Validate request
     const validation = validateRequest(req.body);
     if (!validation.valid) {
+      const { error } = validation;
       return res.status(400).json({
-        error: validation.error,
+        error,
         code: ErrorCode.VALIDATION_ERROR,
       });
     }


### PR DESCRIPTION
## Summary

- Fix TypeScript errors that appear during every Vercel deployment due to `--moduleResolution node16` (stricter than our local `bundler` config)
- Add `.js` extensions to relative imports in 4 API test files
- Fix type inference issues: `never[]` on empty arrays, missing `customProperties` on test bins, narrow `_body` mock type
- Improve discriminated union narrowing in `share.ts` and `suggest-name.ts` via destructuring

## Test plan

- [x] All 4 affected test files pass with `--moduleResolution node16`
- [x] `tsconfig.api.json` typecheck passes
- [x] All 123 API tests pass (`npx vitest run api/`)
- [x] Pre-commit hooks pass (lint, i18n, boundaries, exhaustiveness, affected tests)