### PR TITLE
refactor: convert failable operations to Result type, surface all errors as toasts

### DIFF
--- a/src/core/storage/SnapshotService.test.ts
+++ b/src/core/storage/SnapshotService.test.ts
@@ -223,12 +223,15 @@ describe('SnapshotService', () => {
       );
     });
 
-    it('throws for non-existent snapshot', async () => {
+    it('returns Err(storageNotFound) for non-existent snapshot', async () => {
       mockIndexedDB.getSnapshot.mockResolvedValue(undefined);
 
-      await expect(updateSnapshotLabel('non-existent', 'Label')).rejects.toThrow(
-        'Snapshot not found'
-      );
+      const result = await updateSnapshotLabel('non-existent', 'Label');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('STORAGE_NOT_FOUND');
+        expect(result.error.key).toBe('non-existent');
+      }
     });
   });
 });

--- a/src/core/storage/SnapshotService.ts
+++ b/src/core/storage/SnapshotService.ts
@@ -19,6 +19,8 @@ import {
 } from './backends/indexedDB';
 import { compressLayout, decompressLayout } from '@/shared/utils';
 import { computePreview } from './preview';
+import { err, ok, storageNotFound } from '@/core/result';
+import type { Result, StorageError } from '@/core/result';
 import type { Layout, Snapshot, CompressedSnapshot } from '@/core/types';
 
 /** Maximum number of unlabeled (auto-created) snapshots per layout */
@@ -117,11 +119,16 @@ export async function deleteSnapshotsForLayout(layoutId: string): Promise<void> 
 
 /**
  * Update the label on an existing snapshot.
+ * Returns Err(storageNotFound) if the snapshot does not exist.
  */
-export async function updateSnapshotLabel(snapshotId: string, label: string): Promise<void> {
+export async function updateSnapshotLabel(
+  snapshotId: string,
+  label: string
+): Promise<Result<void, StorageError>> {
   const existing = await getSnapshot(snapshotId);
   if (!existing) {
-    throw new Error('Snapshot not found');
+    return err(storageNotFound(snapshotId));
   }
   await updateSnapshot({ ...existing, label });
+  return ok(undefined);
 }

--- a/src/core/store/snapshots.test.ts
+++ b/src/core/store/snapshots.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useSnapshotStore } from './snapshots';
 import * as SnapshotService from '@/core/storage/SnapshotService';
+import { ok } from '@/core/result';
 import { createTestLayout } from '@/test/testUtils';
 import type { Snapshot } from '@/core/types';
 
@@ -114,7 +115,7 @@ describe('useSnapshotStore', () => {
 
   describe('updateLabel', () => {
     it('updates label in service and local state', async () => {
-      mockService.updateSnapshotLabel.mockResolvedValue(undefined);
+      mockService.updateSnapshotLabel.mockResolvedValue(ok(undefined));
       useSnapshotStore.setState({
         snapshots: [makeSnapshot({ id: 'layout-1-1000' })],
       });

--- a/src/core/store/snapshots.ts
+++ b/src/core/store/snapshots.ts
@@ -12,6 +12,8 @@ import {
   deleteSnapshot as deleteSnapshotService,
   updateSnapshotLabel as updateSnapshotLabelService,
 } from '@/core/storage/SnapshotService';
+import { isErr, getUserMessage } from '@/core/result';
+import { useToastStore } from '@/core/store/toast';
 import type { Layout, Snapshot } from '@/core/types';
 
 export interface SnapshotState {
@@ -75,7 +77,11 @@ export const useSnapshotStore = create<SnapshotState>((set) => ({
   },
 
   updateLabel: async (snapshotId: string, label: string) => {
-    await updateSnapshotLabelService(snapshotId, label);
+    const result = await updateSnapshotLabelService(snapshotId, label);
+    if (isErr(result)) {
+      useToastStore.getState().addToast(getUserMessage(result.error), 'error');
+      return;
+    }
     set((state) => ({
       snapshots: state.snapshots.map((s) => (s.id === snapshotId ? { ...s, label } : s)),
     }));

--- a/src/features/bin-designer/hooks/useCreateFromBin.test.ts
+++ b/src/features/bin-designer/hooks/useCreateFromBin.test.ts
@@ -133,7 +133,7 @@ describe('useCreateFromBin', () => {
     await waitFor(() => {
       const toasts = useToastStore.getState().toasts;
       expect(toasts.length).toBeGreaterThan(0);
-      expect(toasts[0].type).toBe('info');
+      expect(toasts[0].type).toBe('error');
     });
   });
 

--- a/src/features/bin-designer/hooks/useCreateFromBin.ts
+++ b/src/features/bin-designer/hooks/useCreateFromBin.ts
@@ -193,7 +193,7 @@ export function useCreateFromBin(): void {
           // Design saved but linking failed
           addToast({
             message: t('binDesigner.designCreatedLinkFailed'),
-            type: 'info',
+            type: 'error',
             duration: 5000,
           });
         }

--- a/src/features/bin-designer/hooks/useDesignerUrlSync.ts
+++ b/src/features/bin-designer/hooks/useDesignerUrlSync.ts
@@ -13,7 +13,7 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { isOk } from '@/core/result';
+import { isOk, getUserMessage } from '@/core/result';
 import { loadDesign } from '@/features/bin-designer/storage/DesignerStorage';
 import { useDesignerStore } from '../store';
 import { useDesignerRouting } from '@/hooks/useDesignerRouting';
@@ -59,8 +59,7 @@ export function useDesignerUrlSync(): void {
       if (isOk(result)) {
         storeLoadDesign(result.value);
       } else {
-        // Design not found — notify user and clean URL
-        addToast({ message: 'Design not found — starting fresh', type: 'info', duration: 4000 });
+        addToast({ message: getUserMessage(result.error), type: 'error', duration: 4000 });
         syncUrlToDesign(null);
       }
       loadingFromUrlRef.current = false;

--- a/src/features/bin-designer/hooks/useExport.ts
+++ b/src/features/bin-designer/hooks/useExport.ts
@@ -28,6 +28,8 @@ import {
 import { packageSplitPiecesAsZip } from '@/features/bin-designer/utils/splitExport';
 import { export3MF } from '@/shared/generation/export';
 import { parseSTLBinary } from '@/features/bin-designer/utils/stlParser';
+import { isErr, getUserMessage } from '@/core/result';
+import { useToastStore } from '@/core/store/toast';
 import type { ExportFileNameConfig, ExportFileFormat } from '@/features/bin-designer/types';
 import type { PrintEstimate } from '@/features/bin-designer/utils/printEstimates';
 
@@ -141,7 +143,12 @@ export function useExport(): UseExportReturn {
         if (format === '3mf') {
           // 3MF: get high-quality STL from worker, parse, then package as 3MF
           const stlResult = await bridge.exportBin(params, 'stl');
-          const { vertices, normals } = parseSTLBinary(stlResult.data);
+          const parseResult = parseSTLBinary(stlResult.data);
+          if (isErr(parseResult)) {
+            useToastStore.getState().addToast(getUserMessage(parseResult.error), 'error');
+            return;
+          }
+          const { vertices, normals } = parseResult.value;
 
           // Read print settings at call time to avoid capturing reactive values
           const currentPrintSettings = useSettingsStore.getState().settings.printSettings;

--- a/src/features/bin-designer/utils/stlParser.test.ts
+++ b/src/features/bin-designer/utils/stlParser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseSTLBinary } from './stlParser';
+import { isOk, isErr } from '@/core/result';
 import { buildSTLBuffer } from '@/features/generation/export/stlExporter';
 
 describe('parseSTLBinary', () => {
@@ -13,7 +14,10 @@ describe('parseSTLBinary', () => {
     const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
 
     const buffer = makeSTL(vertices, normals);
-    const parsed = parseSTLBinary(buffer);
+    const result = parseSTLBinary(buffer);
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    const parsed = result.value;
 
     // Vertices should match exactly
     expect(parsed.vertices).toHaveLength(9);
@@ -45,7 +49,10 @@ describe('parseSTLBinary', () => {
     const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, -1, 0, 0, -1, 0, 0, -1]);
 
     const buffer = makeSTL(vertices, normals);
-    const parsed = parseSTLBinary(buffer);
+    const result = parseSTLBinary(buffer);
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    const parsed = result.value;
 
     expect(parsed.vertices).toHaveLength(18);
     expect(parsed.normals).toHaveLength(18);
@@ -59,24 +66,34 @@ describe('parseSTLBinary', () => {
     expect(parsed.normals[11]).toBeCloseTo(-1);
   });
 
-  it('throws on buffer too small', () => {
-    expect(() => parseSTLBinary(new ArrayBuffer(10))).toThrow(/too small/);
+  it('returns Err on buffer too small', () => {
+    const result = parseSTLBinary(new ArrayBuffer(10));
+    expect(isErr(result)).toBe(true);
+    if (!isErr(result)) return;
+    expect(result.error.code).toBe('VALIDATION_IMPORT_FAILED');
+    expect(result.error.errors[0]).toMatch(/too small/);
   });
 
-  it('throws on triangle count mismatch', () => {
+  it('returns Err on triangle count mismatch', () => {
     // Build a buffer with header claiming 100 triangles but only 84 bytes total (0 payload)
     const buffer = new ArrayBuffer(84);
     const view = new DataView(buffer);
     view.setUint32(80, 100, true); // claim 100 triangles
-    expect(() => parseSTLBinary(buffer)).toThrow(/does not match/);
+    const result = parseSTLBinary(buffer);
+    expect(isErr(result)).toBe(true);
+    if (!isErr(result)) return;
+    expect(result.error.errors[0]).toMatch(/does not match/);
   });
 
-  it('throws on misaligned payload size', () => {
+  it('returns Err on misaligned payload size', () => {
     // 84-byte header + 30 bytes of junk (not a multiple of 50-byte triangle records)
     const buffer = new ArrayBuffer(84 + 30);
     const view = new DataView(buffer);
     view.setUint32(80, 0, true);
-    expect(() => parseSTLBinary(buffer)).toThrow(/not a multiple/);
+    const result = parseSTLBinary(buffer);
+    expect(isErr(result)).toBe(true);
+    if (!isErr(result)) return;
+    expect(result.error.errors[0]).toMatch(/not a multiple/);
   });
 
   it('handles empty mesh (0 triangles)', () => {
@@ -84,8 +101,10 @@ describe('parseSTLBinary', () => {
     const view = new DataView(buffer);
     view.setUint32(80, 0, true);
 
-    const parsed = parseSTLBinary(buffer);
-    expect(parsed.vertices).toHaveLength(0);
-    expect(parsed.normals).toHaveLength(0);
+    const result = parseSTLBinary(buffer);
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.vertices).toHaveLength(0);
+    expect(result.value.normals).toHaveLength(0);
   });
 });

--- a/src/features/bin-designer/utils/stlParser.ts
+++ b/src/features/bin-designer/utils/stlParser.ts
@@ -10,6 +10,9 @@
  *   Per tri: 50 bytes (normal 3×f32 + 3 vertices × 3×f32 + attr uint16)
  */
 
+import { err, ok, validationImportFailed } from '@/core/result';
+import type { Result, ValidationError } from '@/core/result';
+
 /** Parsed mesh arrays from binary STL */
 export interface ParsedSTLMesh {
   /** Flat vertex array (every 9 floats = 1 triangle, 3 vertices × XYZ) */
@@ -30,11 +33,13 @@ const MIN_FILE_SIZE = HEADER_SIZE + COUNT_SIZE;
  * Each triangle's face normal is replicated to all three vertices
  * (flat shading), matching the layout expected by threemfExporter.
  *
- * @throws If the buffer is too small or triangle count doesn't match buffer size
+ * Returns Err(validationImportFailed) if the buffer is malformed.
  */
-export function parseSTLBinary(buffer: ArrayBuffer): ParsedSTLMesh {
+export function parseSTLBinary(buffer: ArrayBuffer): Result<ParsedSTLMesh, ValidationError> {
   if (buffer.byteLength < MIN_FILE_SIZE) {
-    throw new Error(`Invalid STL: buffer too small (${buffer.byteLength} bytes)`);
+    return err(
+      validationImportFailed([`Invalid STL: buffer too small (${buffer.byteLength} bytes)`])
+    );
   }
 
   const view = new DataView(buffer);
@@ -44,16 +49,20 @@ export function parseSTLBinary(buffer: ArrayBuffer): ParsedSTLMesh {
 
   // Ensure payload length aligns with fixed per-triangle record size
   if (payloadBytes % TRIANGLE_SIZE !== 0) {
-    throw new Error(
-      `Invalid STL: payload size (${payloadBytes} bytes) is not a multiple of triangle record size (${TRIANGLE_SIZE} bytes)`
+    return err(
+      validationImportFailed([
+        `Invalid STL: payload size (${payloadBytes} bytes) is not a multiple of triangle record size (${TRIANGLE_SIZE} bytes)`,
+      ])
     );
   }
 
   const expectedSize = MIN_FILE_SIZE + triangleCount * TRIANGLE_SIZE;
   if (buffer.byteLength !== expectedSize) {
     const actualTriangleCount = payloadBytes / TRIANGLE_SIZE;
-    throw new Error(
-      `Invalid STL: triangle count header (${triangleCount}) does not match payload (${actualTriangleCount} triangles)`
+    return err(
+      validationImportFailed([
+        `Invalid STL: triangle count header (${triangleCount}) does not match payload (${actualTriangleCount} triangles)`,
+      ])
     );
   }
 
@@ -87,5 +96,5 @@ export function parseSTLBinary(buffer: ArrayBuffer): ParsedSTLMesh {
     offset += 2;
   }
 
-  return { vertices, normals };
+  return ok({ vertices, normals });
 }

--- a/src/features/design-linking/hooks/useQuickExport.ts
+++ b/src/features/design-linking/hooks/useQuickExport.ts
@@ -40,7 +40,12 @@ export function useQuickExport(): UseQuickExportReturn {
         // Load full design from IndexedDB
         const designResult = await loadDesign(designId);
         if (!isOk(designResult)) {
-          throw new Error('Failed to load design');
+          addToast({
+            message: t('designLinking.toast.exportFailed'),
+            type: 'error',
+            duration: 4000,
+          });
+          return;
         }
         const design = designResult.value;
 

--- a/src/hooks/useLayoutSwitcher.ts
+++ b/src/hooks/useLayoutSwitcher.ts
@@ -94,12 +94,12 @@ export function useLayoutSwitcher() {
 
     const result = await saveLayoutWithMetadata(currentActiveId, currentLayout, currentLibrary);
     if (isErr(result)) {
-      console.error('Failed to save current layout:', result.error);
+      addToast(t('toast.layoutSaveFailed'), 'error');
       return;
     }
 
     setLibrary(result.value.library);
-  }, [setLibrary]);
+  }, [setLibrary, addToast, t]);
 
   /**
    * Switch to a different layout.
@@ -366,9 +366,11 @@ export function useLayoutSwitcher() {
         }
 
         trackLayoutAction('renamed');
+      } else {
+        addToast(t('toast.layoutRenameFailed'), 'error');
       }
     },
-    [setLibrary]
+    [setLibrary, addToast, t]
   );
 
   /**

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1477,6 +1477,8 @@
   "toast.layoutDuplicateFailed": "Layout-Duplizierung fehlgeschlagen",
   "toast.layoutDuplicated": "Layout dupliziert",
   "toast.layoutImportFailed": "Layout-Import fehlgeschlagen",
+  "toast.layoutSaveFailed": "Layout konnte nicht gespeichert werden",
+  "toast.layoutRenameFailed": "Layout konnte nicht umbenannt werden",
   "toast.layoutImported": "\"{name}\" importiert",
   "toast.layoutNotFound": "Layout nicht gefunden",
   "toast.layoutRecovered": "Layout aus Sicherungsspeicher wiederhergestellt",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1053,6 +1053,8 @@ const en: Record<string, string> = {
   'toast.layoutDeleteFailed': 'Failed to delete layout',
   'toast.layoutDuplicateFailed': 'Failed to duplicate layout',
   'toast.layoutImportFailed': 'Failed to import layout',
+  'toast.layoutSaveFailed': 'Failed to save layout',
+  'toast.layoutRenameFailed': 'Failed to rename layout',
   'toast.binsDeleted': 'Deleted {count} bin(s)',
   'toast.binRotated': 'Bin rotated',
   'toast.clearComplete': 'Cleared {count} bin(s) from layer',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1477,6 +1477,8 @@
   "toast.layoutDuplicateFailed": "Error al duplicar diseño",
   "toast.layoutDuplicated": "Diseño duplicado",
   "toast.layoutImportFailed": "Error al importar diseño",
+  "toast.layoutSaveFailed": "Error al guardar el diseño",
+  "toast.layoutRenameFailed": "Error al renombrar el diseño",
   "toast.layoutImported": "\"{name}\" importado",
   "toast.layoutNotFound": "Diseño no encontrado",
   "toast.layoutRecovered": "Diseño recuperado del almacenamiento de respaldo",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1477,6 +1477,8 @@
   "toast.layoutDuplicateFailed": "Échec de la duplication du layout",
   "toast.layoutDuplicated": "Layout dupliqué",
   "toast.layoutImportFailed": "Échec de l'importation du layout",
+  "toast.layoutSaveFailed": "Échec de la sauvegarde du layout",
+  "toast.layoutRenameFailed": "Échec du renommage du layout",
   "toast.layoutImported": "« {name} » importé",
   "toast.layoutNotFound": "Layout introuvable",
   "toast.layoutRecovered": "Disposition récupérée depuis le stockage de secours",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1477,6 +1477,8 @@
   "toast.layoutDuplicateFailed": "Kunne ikke duplisere layout",
   "toast.layoutDuplicated": "Layout duplisert",
   "toast.layoutImportFailed": "Kunne ikke importere layout",
+  "toast.layoutSaveFailed": "Kunne ikke lagre layout",
+  "toast.layoutRenameFailed": "Kunne ikke gi nytt navn til layout",
   "toast.layoutImported": "Importert \"{name}\"",
   "toast.layoutNotFound": "Layout ikke funnet",
   "toast.layoutRecovered": "Layout gjenopprettet fra sikkerhetskopi",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1477,6 +1477,8 @@
   "toast.layoutDuplicateFailed": "Dupliceren van layout mislukt",
   "toast.layoutDuplicated": "Layout gedupliceerd",
   "toast.layoutImportFailed": "Importeren van layout mislukt",
+  "toast.layoutSaveFailed": "Opslaan van layout mislukt",
+  "toast.layoutRenameFailed": "Hernoemen van layout mislukt",
   "toast.layoutImported": "\"{name}\" geïmporteerd",
   "toast.layoutNotFound": "Layout niet gevonden",
   "toast.layoutRecovered": "Layout hersteld uit back-upopslag",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1477,6 +1477,8 @@
   "toast.layoutDuplicateFailed": "Falha ao duplicar layout",
   "toast.layoutDuplicated": "Layout duplicado",
   "toast.layoutImportFailed": "Falha ao importar layout",
+  "toast.layoutSaveFailed": "Falha ao salvar layout",
+  "toast.layoutRenameFailed": "Falha ao renomear layout",
   "toast.layoutImported": "\"{name}\" importado",
   "toast.layoutNotFound": "Layout não encontrado",
   "toast.layoutRecovered": "Layout recuperado do armazenamento de backup",


### PR DESCRIPTION
## Summary

- **`SnapshotService.updateSnapshotLabel`**: changed from throwing `new Error('Snapshot not found')` to returning `Result<void, StorageError>` — store now handles the error with a user-facing toast
- **`stlParser.parseSTLBinary`**: changed from throwing on malformed binary to returning `Result<ParsedSTLMesh, ValidationError>` — callers in `useExport` and `useQuickExport` handle gracefully
- **Silent failure fixes**: `saveCurrentLayout` was swallowing errors with `console.error`; `renameLayout` was silently ignoring failures — both now show toasts
- **Severity upgrade**: `designCreatedLinkFailed` toast changed from `'info'` to `'error'`
- **Specific error messages**: `useDesignerUrlSync` now shows `getUserMessage(result.error)` instead of a generic hardcoded string

## Test plan

- [ ] All existing tests pass (pre-commit hook verified)
- [ ] Snapshot label update on non-existent snapshot shows toast error instead of unhandled throw
- [ ] 3MF export with corrupted STL data shows toast instead of crashing
- [ ] Switching layouts when save fails shows a toast
- [ ] Renaming a layout when the operation fails shows a toast
- [ ] Loading a designer URL with an invalid design ID shows the specific storage error message