### PR TITLE
fix(bin-designer): fix Open in Slicer button downloading instead of opening slicer

### DIFF
--- a/src/features/bin-designer/hooks/useSlicerOpen.test.ts
+++ b/src/features/bin-designer/hooks/useSlicerOpen.test.ts
@@ -66,13 +66,11 @@ const PARSE_OK = { ok: true as const, value: { vertices: MOCK_VERTICES, normals:
 const PARSE_ERR = { ok: false as const, error: 'parse failed' };
 
 const originalURL = globalThis.URL;
-const originalLocation = window.location;
 const mockCreateObjectURL = vi.fn().mockReturnValue('blob:mock-url');
 const mockRevokeObjectURL = vi.fn();
 
 describe('useSlicerOpen', () => {
   let mockFetch: ReturnType<typeof vi.fn>;
-  let mockHref: string;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -97,19 +95,14 @@ describe('useSlicerOpen', () => {
     });
     vi.stubGlobal('fetch', mockFetch);
 
-    // Capture window.location.href writes via a configurable mock
-    mockHref = '';
-    const mockLocation = {} as Location;
-    Object.defineProperty(mockLocation, 'href', {
-      get: () => mockHref,
-      set: (v: string) => {
-        mockHref = v;
-      },
-      configurable: true,
-    });
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: mockLocation,
+    // Stub anchor clicks so protocol URLs don't cause jsdom navigation errors
+    const realCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = realCreateElement(tag);
+      if (tag === 'a') {
+        vi.spyOn(el as HTMLAnchorElement, 'click').mockImplementation(() => {});
+      }
+      return el;
     });
 
     // Set up store state
@@ -137,16 +130,11 @@ describe('useSlicerOpen', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     Object.defineProperty(globalThis, 'URL', {
       value: originalURL,
       writable: true,
       configurable: true,
-    });
-    // Restore original location
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      writable: true,
-      value: originalLocation,
     });
   });
 
@@ -240,22 +228,23 @@ describe('useSlicerOpen', () => {
     expect(result.current.isOpening).toBe(false);
   });
 
-  it('triggers fallback download and info toast after 2s timeout', async () => {
+  it('shows not-detected info toast and resets state after 5s timeout (no download)', async () => {
     const { result } = renderHook(() => useSlicerOpen());
     await act(async () => {
       await result.current.openInSlicer(MOCK_SLICER);
     });
 
     await act(async () => {
-      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(5000);
     });
 
-    expect(mockCreateObjectURL).toHaveBeenCalledWith(MOCK_BLOB);
+    // No automatic download — user can download manually from the export dialog
+    expect(mockCreateObjectURL).not.toHaveBeenCalledWith(MOCK_BLOB);
     expect(result.current.isOpening).toBe(false);
     expect(result.current.openingSlicerId).toBeNull();
   });
 
-  it('does not trigger fallback download when blur fires before the timer', async () => {
+  it('does not show not-detected toast when blur fires before the timer', async () => {
     const { result } = renderHook(() => useSlicerOpen());
     await act(async () => {
       await result.current.openInSlicer(MOCK_SLICER);
@@ -268,7 +257,7 @@ describe('useSlicerOpen', () => {
 
     // Timer fires after — but blur already cancelled it
     await act(async () => {
-      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(5000);
     });
 
     expect(mockCreateObjectURL).not.toHaveBeenCalled();

--- a/src/features/bin-designer/hooks/useSlicerOpen.ts
+++ b/src/features/bin-designer/hooks/useSlicerOpen.ts
@@ -4,9 +4,11 @@
  * Flow:
  * 1. Generate a 3MF file via the generation worker
  * 2. Upload it to a temporary public URL via /api/slicer-upload
- * 3. Fire the slicer's protocol handler: <protocol>://open?file_url=<url>
+ * 3. Fire the slicer's protocol handler via a hidden anchor click:
+ *    <protocol>://open?file_url=<url>
  * 4. Detect whether the slicer opened via a window blur event. If no blur
- *    fires within 2s, fall back to triggering a browser download + toast.
+ *    fires within 5s, show a toast suggesting the slicer may not be installed.
+ *    No automatic download — the user can download manually from the dialog.
  *
  * Note: The blur-detection heuristic may not fire on Firefox/Safari for
  * some protocol handlers. This is an accepted trade-off given Chrome/Edge
@@ -28,8 +30,8 @@ import { useToastStore } from '@/core/store/toast';
 import { useTranslation } from '@/i18n';
 import type { SlicerSite } from '@/core/store/settings';
 
-/** How long to wait for the slicer protocol to respond before falling back to download */
-const SLICER_DETECTION_TIMEOUT_MS = 2000;
+/** How long to wait for the slicer protocol to respond before showing a "not detected" toast */
+const SLICER_DETECTION_TIMEOUT_MS = 5000;
 
 interface UseSlicerOpenReturn {
   /** Whether a slicer upload is currently in progress */
@@ -122,10 +124,8 @@ export function useSlicerOpen(): UseSlicerOpenReturn {
         // Step 3: Set up blur detection (slicer opened = page loses focus)
         // and a fallback timer for when the slicer isn't installed.
         // Both callbacks own the state reset to prevent premature re-enabling.
-        const capturedBlob = threeMFBlob;
-        const fallbackTimer = setTimeout(() => {
+        const notDetectedTimer = setTimeout(() => {
           window.removeEventListener('blur', onSlicerOpened);
-          triggerFallbackDownload(capturedBlob);
           addToast({
             message: t('slicerOpen.notDetected', { slicer: slicer.name }),
             type: 'info',
@@ -135,15 +135,23 @@ export function useSlicerOpen(): UseSlicerOpenReturn {
         }, SLICER_DETECTION_TIMEOUT_MS);
 
         const onSlicerOpened = () => {
-          clearTimeout(fallbackTimer);
+          clearTimeout(notDetectedTimer);
           setOpeningSlicerId(null);
         };
 
         window.addEventListener('blur', onSlicerOpened, { once: true });
 
-        // Step 4: Fire protocol handler (state reset is now owned by the callbacks above)
+        // Step 4: Fire protocol handler via anchor click — more reliable than
+        // window.location.href for custom protocol URLs because it's treated
+        // as a user-gesture-initiated navigation in all major browsers.
+        // State reset is now owned by the callbacks above.
         protocolFired = true;
-        window.location.href = buildSlicerUrl(slicer.protocol, url);
+        const protocolAnchor = document.createElement('a');
+        protocolAnchor.href = buildSlicerUrl(slicer.protocol, url);
+        protocolAnchor.style.display = 'none';
+        document.body.appendChild(protocolAnchor);
+        protocolAnchor.click();
+        protocolAnchor.remove();
       } catch {
         if (threeMFBlob) {
           // Upload failed — 3MF was generated successfully, so fall back to direct download

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1268,7 +1268,7 @@
   "stlSearch.searchFor": "Nach {width}×{depth} Bin suchen",
   "stlSearch.searchForSplit": "Nach Split-Bin-Generatoren suchen",
   "slicerOpen.generationFailed": "Datei für Slicer konnte nicht generiert werden",
-  "slicerOpen.notDetected": "{slicer} nicht gefunden — Datei wurde stattdessen heruntergeladen",
+  "slicerOpen.notDetected": "{slicer} nicht gefunden — ist es installiert?",
   "slicerOpen.opening": "Öffne...",
   "slicerOpen.uploadFailed": "Upload fehlgeschlagen — Datei wurde stattdessen heruntergeladen",
   "tablet.layersCategories": "Layers & Kategorien",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1063,7 +1063,7 @@ const en: Record<string, string> = {
   // ===========================================================================
   // Slicer Open
   // ===========================================================================
-  'slicerOpen.notDetected': '{slicer} not detected — file downloaded instead',
+  'slicerOpen.notDetected': '{slicer} not detected — is it installed?',
   'slicerOpen.uploadFailed': 'Upload failed — file downloaded instead',
   'slicerOpen.generationFailed': 'Failed to generate file for slicer',
   'slicerOpen.opening': 'Opening...',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1268,7 +1268,7 @@
   "stlSearch.searchFor": "Buscar bin {width}×{depth}",
   "stlSearch.searchForSplit": "Buscar generadores de split bin",
   "slicerOpen.generationFailed": "No se pudo generar el archivo para el slicer",
-  "slicerOpen.notDetected": "{slicer} no detectado — archivo descargado en su lugar",
+  "slicerOpen.notDetected": "{slicer} no detectado — ¿está instalado?",
   "slicerOpen.opening": "Abriendo...",
   "slicerOpen.uploadFailed": "Error al subir — archivo descargado en su lugar",
   "tablet.layersCategories": "Layers y Categorías",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1268,7 +1268,7 @@
   "stlSearch.searchFor": "Rechercher un bin {width}×{depth}",
   "stlSearch.searchForSplit": "Rechercher des générateurs de split bin",
   "slicerOpen.generationFailed": "Échec de la génération du fichier pour le slicer",
-  "slicerOpen.notDetected": "{slicer} non détecté — fichier téléchargé à la place",
+  "slicerOpen.notDetected": "{slicer} non détecté — est-il installé ?",
   "slicerOpen.opening": "Ouverture...",
   "slicerOpen.uploadFailed": "Échec de l'envoi — fichier téléchargé à la place",
   "tablet.layersCategories": "Layers et Catégories",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1268,7 +1268,7 @@
   "stlSearch.searchFor": "Søk etter {width}×{depth} bin",
   "stlSearch.searchForSplit": "Søk etter delte bin-generatorer",
   "slicerOpen.generationFailed": "Klarte ikke å generere fil for slicer",
-  "slicerOpen.notDetected": "{slicer} ikke funnet — filen ble lastet ned i stedet",
+  "slicerOpen.notDetected": "{slicer} ikke funnet — er det installert?",
   "slicerOpen.opening": "Åpner...",
   "slicerOpen.uploadFailed": "Opplasting mislyktes — filen ble lastet ned i stedet",
   "tablet.layersCategories": "Lag og kategorier",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1268,7 +1268,7 @@
   "stlSearch.searchFor": "Zoeken naar {width}×{depth} bin",
   "stlSearch.searchForSplit": "Zoeken naar split bin generatoren",
   "slicerOpen.generationFailed": "Bestand aanmaken voor slicer mislukt",
-  "slicerOpen.notDetected": "{slicer} niet gevonden — bestand gedownload als alternatief",
+  "slicerOpen.notDetected": "{slicer} niet gevonden — is het geïnstalleerd?",
   "slicerOpen.opening": "Openen...",
   "slicerOpen.uploadFailed": "Upload mislukt — bestand gedownload als alternatief",
   "tablet.layersCategories": "Layers & categorieën",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1268,7 +1268,7 @@
   "stlSearch.searchFor": "Pesquisar bin {width}×{depth}",
   "stlSearch.searchForSplit": "Pesquisar geradores de split bin",
   "slicerOpen.generationFailed": "Falha ao gerar arquivo para o slicer",
-  "slicerOpen.notDetected": "{slicer} não detectado — arquivo baixado em vez disso",
+  "slicerOpen.notDetected": "{slicer} não detectado — está instalado?",
   "slicerOpen.opening": "Abrindo...",
   "slicerOpen.uploadFailed": "Falha no upload — arquivo baixado em vez disso",
   "tablet.layersCategories": "Layers e Categorias",


### PR DESCRIPTION
## Problem

Clicking "Open in PrusaSlicer" (or any slicer) always triggered a 3MF download instead of opening the slicer application.

## Root Cause

Two issues combined to cause this:

1. **`window.location.href` unreliable for protocol URLs**: Assigning a custom protocol URL (`prusaslicer://...`) to `window.location.href` is less reliable than using an anchor click. Browsers treat anchor clicks as user-gesture-initiated navigation, which is required to reliably invoke OS-level protocol handlers.

2. **2s blur detection timeout too short**: The `window.blur` heuristic fires when the browser loses focus to the slicer. But PrusaSlicer (and others) can take >2s to activate — especially if they're already running and just opening a new model. The 2s timer was reliably firing first, triggering a fallback download every time.

## Fix

- **Anchor click for protocol URL**: Replace `window.location.href = buildSlicerUrl(...)` with a hidden `<a href="protocol://...">` + `.click()`. This is more reliably treated as a user gesture by all major browsers.
- **Remove automatic fallback download from timeout**: The timeout no longer downloads the file. Instead it shows a toast: *"{Slicer} not detected — is it installed?"*. Users can still download manually from the export dialog.
- **Increase timeout from 2s → 5s**: Gives slow-starting slicers more time to steal window focus.

## Changes

- `src/features/bin-designer/hooks/useSlicerOpen.ts`
- `src/features/bin-designer/hooks/useSlicerOpen.test.ts`  
- `src/i18n/locales/en.ts` + all 6 locale JSON files (updated `notDetected` toast copy)

## Test plan

- [ ] Open the bin designer export dialog and click "Open in PrusaSlicer" with PrusaSlicer installed → slicer should open with the model
- [ ] Click with no slicer installed → toast appears after 5s: "PrusaSlicer not detected — is it installed?"
- [ ] Upload failure (network) → 3MF downloads as before (fallback preserved in catch block)
- [ ] All 9 `useSlicerOpen` unit tests pass