### PR TITLE
fix(bin-designer): fix Open in Slicer 403 in production

### DIFF
--- a/api/slicer-upload.ts
+++ b/api/slicer-upload.ts
@@ -13,7 +13,7 @@
 import { put } from '@vercel/blob';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP } from './lib/rateLimit.js';
-import { getBaseUrl, methodNotAllowed } from './lib/shared.js';
+import { methodNotAllowed } from './lib/shared.js';
 
 /** Maximum accepted file size: 2MB (well above any realistic 3MF bin file) */
 const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024;
@@ -26,18 +26,35 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Enforce same-origin requests to prevent third-party file hosting abuse.
   // Requests without an Origin header (e.g. curl, server-side scripts) are also
   // rejected — this endpoint is intentionally browser-only.
-  // Comparison is hostname-based (not full URL) to handle http/https and port
-  // differences across dev (localhost:5173) and production environments.
+  //
+  // VERCEL_URL is always the unique per-deployment hash URL (e.g. proj-abc123.vercel.app),
+  // even in production — it differs from the canonical production URL that users
+  // actually visit. We therefore check against all three Vercel URL variables so
+  // that both the canonical domain and the deployment-hash URL are accepted.
   const originHeader = req.headers['origin'];
   const origin = Array.isArray(originHeader) ? originHeader[0] : originHeader;
-  const appBaseUrl = getBaseUrl();
+
+  const allowedHosts = new Set<string>();
+  for (const raw of [
+    process.env.VERCEL_PROJECT_PRODUCTION_URL,
+    process.env.VERCEL_URL,
+    process.env.VERCEL_BRANCH_URL,
+  ]) {
+    if (raw) {
+      try {
+        allowedHosts.add(new URL(`https://${raw}`).hostname);
+      } catch {
+        /* skip malformed */
+      }
+    }
+  }
+
   let originAllowed = false;
   if (origin) {
     try {
       const originHost = new URL(origin).hostname;
-      const appHost = new URL(appBaseUrl).hostname;
       const isProduction = process.env.VERCEL_ENV === 'production';
-      originAllowed = (!isProduction && originHost === 'localhost') || originHost === appHost;
+      originAllowed = (!isProduction && originHost === 'localhost') || allowedHosts.has(originHost);
     } catch {
       /* malformed Origin — denied */
     }


### PR DESCRIPTION
## Summary

- `VERCEL_URL` is always the unique per-deployment hash URL (e.g. `proj-abc123.vercel.app`), not the canonical production URL users visit
- The old origin check compared the browser `Origin` against a single URL from `getBaseUrl()`, causing a 403 whenever they didn't match (e.g. canonical URL vs. deployment hash URL)
- Fix: build an `allowedHosts` set from all three Vercel URL env vars (`VERCEL_PROJECT_PRODUCTION_URL`, `VERCEL_URL`, `VERCEL_BRANCH_URL`) and check membership

## Test plan

- [x] Deploy to Vercel and verify "Open in Slicer" no longer returns 403 in the Network tab
- [x] Confirm fallback download no longer triggers on click
- [x] Verify third-party curl requests to `/api/slicer-upload` are still rejected with 403