### PR TITLE
fix(www-migration): handle blank iframe onload before bridge navigates

### DIFF
--- a/src/core/storage/wwwMigration.ts
+++ b/src/core/storage/wwwMigration.ts
@@ -205,7 +205,27 @@ function sendToBridge(data: MigrationData): Promise<BridgeResponse> {
         );
         return;
       }
-      iframe.contentWindow.postMessage(data, CANONICAL_ORIGIN);
+
+      // contentDocument is accessible (non-null) when the iframe is same-origin (about:blank).
+      // This fires either on an initial blank load before the bridge URL navigates in, or when
+      // the navigation was blocked (e.g. CSP). When the bridge loads successfully it is
+      // cross-origin, so contentDocument is null. Wait for the real load in either case.
+      let isBlankPage: boolean;
+      try {
+        isBlankPage = iframe.contentDocument !== null;
+      } catch {
+        isBlankPage = false; // SecurityError → cross-origin → bridge loaded
+      }
+      if (isBlankPage) return;
+
+      try {
+        iframe.contentWindow.postMessage(data, CANONICAL_ORIGIN);
+      } catch (e) {
+        cleanup();
+        reject(
+          new Error(`Failed to send data to bridge: ${e instanceof Error ? e.message : String(e)}`)
+        );
+      }
     };
 
     iframe.onerror = () => {


### PR DESCRIPTION
## Summary

- `iframe.onload` can fire while the frame is at `about:blank` — either as an initial blank state before the bridge URL navigates in, or because navigation was blocked (e.g. CSP)
- Calling `postMessage(data, 'https://gridfinitylayouttool.com')` against an `about:blank` window (origin = `null`) throws a `DOMException`
- This throw happened inside a DOM event handler (not the Promise executor), so it was **uncaught** — console error appeared but the Promise hung for 30 seconds until timeout

## Fix

- Check `iframe.contentDocument !== null` — non-null means same-origin (`about:blank`), bridge hasn't loaded yet; return early and wait for the real load
- Wrap `postMessage` in try/catch so any remaining failure properly rejects the Promise instead of leaking to the console

## Test plan

- [ ] Verify no `postMessage` DOMException in console during www → canonical migration
- [ ] Verify migration still completes successfully