### PR TITLE
fix(sw): exclude wwwMigration chunk from service worker precache

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -70,7 +70,16 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
         // Exclude manifest icons from glob - they're auto-added via manifest.icons
         // This prevents duplicate precache entries
-        globIgnores: ['icons/icon-192.png', 'icons/icon-512.png', 'storage-bridge.html'],
+        globIgnores: [
+          'icons/icon-192.png',
+          'icons/icon-512.png',
+          'storage-bridge.html',
+          // wwwMigration is a one-shot dynamic import (www → canonical migration).
+          // Precaching it causes SW install failures when the hash changes between
+          // deployments: the new SW's manifest still references the old hash which
+          // 404s, leaving the old SW in control and blocking the fix from reaching users.
+          'assets/wwwMigration-*.js',
+        ],
         // Prefix all cache names to prevent conflicts
         cacheId: 'gridfinity-v1',
         // Prevent accidentally precaching huge assets


### PR DESCRIPTION
## Problem

The `wwwMigration` JS chunk was being included in the SW precache manifest. When a new deployment changes its content hash, the new service worker's manifest still references the old hash — which returns 404. This causes the new SW to **fail installation**, leaving the old SW in control and blocking any fixes from reaching users.

This is why the blank-iframe `postMessage` fix from #864 wasn't having any effect: users' old SWs were still serving the unfixed code.

## Fix

Add `assets/wwwMigration-*.js` to Workbox `globIgnores`. The module is a one-shot dynamic import that only runs on the www subdomain during migration — it doesn't benefit from precaching and should always be fetched fresh from the network.

## Test plan

- [ ] Build and verify `sw.js` precache manifest no longer includes `wwwMigration-*.js`
- [ ] Verify migration still works end-to-end on www subdomain
- [ ] Verify no `bad-precaching-response` errors in console after deploy