### PR TITLE
fix(bin-designer): use Override in 3MF content types for slicer compatibility

### DIFF
--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -404,14 +404,17 @@ describe('threemfExporter', () => {
       expect(rels).toContain('3dmanufacturing');
     });
 
-    it('declares model content type', () => {
+    it('declares model content type using Override (not Default Extension)', () => {
       const { vertices, normals } = createSingleTriangle();
       const buffer = build3MFBuffer(vertices, normals, { name: 'test' });
       const files = unzipSync(buffer);
       const contentTypes = strFromU8(files['[Content_Types].xml']);
 
-      expect(contentTypes).toContain('Extension="model"');
+      // Override element is required for PrusaSlicer/OrcaSlicer compatibility;
+      // Default Extension="model" is valid per spec but not all parsers support it.
+      expect(contentTypes).toContain('Override PartName="/3D/3dmodel.model"');
       expect(contentTypes).toContain('3dmanufacturing-3dmodel+xml');
+      expect(contentTypes).not.toContain('Extension="model"');
     });
 
     it('declares rels content type', () => {

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -147,8 +147,10 @@ function buildContentTypes(hasThumbnail: boolean): string {
   xml += '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">\n';
   xml +=
     '  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />\n';
+  // Use Override (specific path) rather than Default (extension) for the model file.
+  // PrusaSlicer and other slicers generate Override elements; some parsers only handle Override.
   xml +=
-    '  <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml" />\n';
+    '  <Override PartName="/3D/3dmodel.model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml" />\n';
   if (hasThumbnail) {
     xml += '  <Default Extension="png" ContentType="image/png" />\n';
   }


### PR DESCRIPTION
## Summary

- Fixes **Open in Slicer** — PrusaSlicer (and other slicers) opened but no model was loaded
- In `[Content_Types].xml`, switches the model file declaration from `Default Extension="model"` to `Override PartName="/3D/3dmodel.model"`, matching what PrusaSlicer, OrcaSlicer, and Bambu Studio generate natively
- Updates the test assertion to verify the `Override` format

## Root cause

The OPC spec allows both `Default` (extension-based) and `Override` (exact path-based) content type declarations. However, PrusaSlicer's parser appears to only resolve content types via `Override` elements — when only a `Default` is present, the parser may not identify the model file's type correctly, causing it to silently skip loading the model.

## Test plan

- [x] All 60 slicer-related tests pass (`threemfExporter`, `useSlicerOpen`, `slicer-upload`)
- [x] TypeScript compiles cleanly
- [x] Manual: Open in PrusaSlicer/OrcaSlicer — model should load on the plater