### PR TITLE
feat(bin-designer): auto-enable half-bin mode when fractional dimension is typed

### DIFF
--- a/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.test.ts
+++ b/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.test.ts
@@ -79,4 +79,52 @@ describe('useDimensionsSection', () => {
     // Should stay at 16 (MAX_DIMENSION)
     expect(useDesignerStore.getState().params.width).toBe(16);
   });
+
+  it('auto-enables half-bin mode when width is set to a fractional value', () => {
+    const { result } = renderHook(() => useDimensionsSection());
+
+    act(() => {
+      result.current.handlers.setParam('width', 1.5);
+    });
+
+    expect(useDesignerStore.getState().ui.halfBinMode).toBe(true);
+    expect(useDesignerStore.getState().params.width).toBe(1.5);
+  });
+
+  it('auto-enables half-bin mode when depth is set to a fractional value', () => {
+    const { result } = renderHook(() => useDimensionsSection());
+
+    act(() => {
+      result.current.handlers.setParam('depth', 2.5);
+    });
+
+    expect(useDesignerStore.getState().ui.halfBinMode).toBe(true);
+    expect(useDesignerStore.getState().params.depth).toBe(2.5);
+  });
+
+  it('does not toggle half-bin mode when an integer value is set', () => {
+    const { result } = renderHook(() => useDimensionsSection());
+
+    act(() => {
+      result.current.handlers.setParam('width', 3);
+    });
+
+    expect(useDesignerStore.getState().ui.halfBinMode).toBe(false);
+    expect(useDesignerStore.getState().params.width).toBe(3);
+  });
+
+  it('does not double-toggle half-bin mode when already enabled', () => {
+    useDesignerStore.setState({
+      ui: { ...DEFAULT_UI_STATE, halfBinMode: true },
+    });
+    const { result } = renderHook(() => useDimensionsSection());
+
+    act(() => {
+      result.current.handlers.setParam('width', 1.5);
+    });
+
+    // Should still be enabled (not toggled off)
+    expect(useDesignerStore.getState().ui.halfBinMode).toBe(true);
+    expect(useDesignerStore.getState().params.width).toBe(1.5);
+  });
 });

--- a/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.ts
+++ b/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.ts
@@ -2,6 +2,8 @@ import { useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
+import type { BinParams } from '@/features/bin-designer/types';
+import { isFractional } from '@/core/constants';
 import { useTranslation } from '@/i18n';
 
 export function useDimensionsSection() {
@@ -71,6 +73,16 @@ export function useDimensionsSection() {
     setParams({ width: depth, depth: width });
   }, [width, depth, setParams]);
 
+  const handleSetParam = useCallback(
+    <K extends keyof BinParams>(key: K, value: BinParams[K]) => {
+      if ((key === 'width' || key === 'depth') && isFractional(value as number) && !halfBinMode) {
+        toggleHalfBinMode();
+      }
+      setParam(key, value);
+    },
+    [halfBinMode, toggleHalfBinMode, setParam]
+  );
+
   return {
     state: {
       width,
@@ -84,7 +96,7 @@ export function useDimensionsSection() {
       minDimension,
     },
     handlers: {
-      setParam,
+      setParam: handleSetParam,
       handleWidthStep,
       handleDepthStep,
       handleHeightStep,


### PR DESCRIPTION
## Summary

- Wraps `handlers.setParam` in `useDimensionsSection` to detect fractional width/depth values
- Automatically enables half-bin mode when a value like `1.5` is typed into width or depth, keeping stepper step size and minimum consistent with the entered value
- Guards with `!halfBinMode` so the toggle is never called when already enabled

## Test Plan

- [ ] 10/10 tests pass in `useDimensionsSection.test.ts` (6 existing + 4 new)
- [ ] Type a fractional value (e.g. `1.5`) into width or depth in the bin designer — half-bin mode checkbox enables automatically
- [ ] Type an integer value — half-bin mode is unaffected
- [ ] With half-bin mode already on, type a fractional value — no double-toggle (mode stays on)