### PR TITLE
fix(baseplate): pin fractional half-units to edge positions in split tiling

### DIFF
--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -277,6 +277,42 @@ describe('computeBaseplateTiling', () => {
     expect(totalWidth).toBe(10.5);
   });
 
+  it('fractional edge at end with 3+ splits pins fraction at last column', () => {
+    // 13.5 → needs 3 cols. Fraction should be pinned at the last col, not the middle.
+    const params = makeParams({ width: 13.5, depth: 4, fractionalEdgeX: 'end' });
+    const tiling = computeBaseplateTiling(params, 256);
+
+    expect(tiling.cols).toBeGreaterThanOrEqual(3);
+    const widths = tiling.pieces
+      .filter((p) => p.row === 0)
+      .sort((a, b) => a.col - b.col)
+      .map((p) => p.widthUnits);
+    // Fractional piece pinned at last col
+    expect(widths[widths.length - 1] % 1).not.toBe(0);
+    // Middle pieces should be integer
+    for (let i = 1; i < widths.length - 1; i++) {
+      expect(widths[i] % 1).toBe(0);
+    }
+  });
+
+  it('fractional edge at end on Y-axis pins fraction at last row', () => {
+    // 13.5 depth → needs 3 rows. Fraction should be at last row, not middle.
+    const params = makeParams({ width: 4, depth: 13.5, fractionalEdgeY: 'end' });
+    const tiling = computeBaseplateTiling(params, 256);
+
+    expect(tiling.rows).toBeGreaterThanOrEqual(3);
+    const depths = tiling.pieces
+      .filter((p) => p.col === 0)
+      .sort((a, b) => a.row - b.row)
+      .map((p) => p.depthUnits);
+    // Fractional piece pinned at last row
+    expect(depths[depths.length - 1] % 1).not.toBe(0);
+    // Middle pieces should be integer
+    for (let i = 1; i < depths.length - 1; i++) {
+      expect(depths[i] % 1).toBe(0);
+    }
+  });
+
   it('fractional edge at start with 3+ splits pins fraction and sorts rest', () => {
     // 13.5 → needs 3 cols. Fraction pinned at col 0
     const params = makeParams({ width: 13.5, depth: 4, fractionalEdgeX: 'start' });

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -506,16 +506,26 @@ function reorderForDisplay(
   const maxAtFirst = Math.floor((printBedMm - paddingFirst) / gridUnitMm);
   const maxAtLast = Math.floor((printBedMm - paddingLast) / gridUnitMm);
 
+  const fracIdx = sizes.findIndex(isFractional);
+
   // When fractionAtStart, pin the fractional piece to position 0 —
   // but only if it actually fits with paddingFirst at that position.
   if (fractionAtStart) {
-    const fracIdx = sizes.findIndex(isFractional);
     if (fracIdx >= 0 && sizes[fracIdx] <= maxAtFirst) {
       const maxMiddle = Math.floor(printBedMm / gridUnitMm);
       const rest = sizes.filter((_, i) => i !== fracIdx);
       const sortedRest = sortDescWithEdges(rest, maxMiddle, maxAtLast);
       return [sizes[fracIdx], ...sortedRest];
     }
+  }
+
+  // When fraction exists and belongs at the end, pin it to the last position
+  // to prevent sortDescWithEdges from placing it in the middle.
+  if (!fractionAtStart && fracIdx >= 0 && sizes[fracIdx] <= maxAtLast) {
+    const maxMiddle = Math.floor(printBedMm / gridUnitMm);
+    const rest = sizes.filter((_, i) => i !== fracIdx);
+    const sortedRest = sortDescWithEdges(rest, maxAtFirst, maxMiddle);
+    return [...sortedRest, sizes[fracIdx]];
   }
 
   return sortDescWithEdges(sizes, maxAtFirst, maxAtLast);


### PR DESCRIPTION
## Summary
- **Bug:** PR #898's 2D tiling optimizer could place fractional half-unit pieces (e.g. 4.5u) in the middle of a 3+ piece baseplate split instead of at the edge, because `reorderForDisplay` only had pinning logic for `fractionAtStart=true` but not for `fractionAtStart=false`
- **Fix:** Added symmetric pinning in `reorderForDisplay` — when the fraction belongs at the end, extract it from the sort pool and append it to the last position
- **Tests:** Added 2 regression tests (X-axis and Y-axis) verifying fractional pieces stay at edge positions in 3+ splits

## Test plan
- [x] New unit tests for fractional-edge-at-end on both axes
- [x] All 45 splitPlanner tests pass
- [x] All 64 affected tests pass (including BaseplatePanel, useBaseplateGeneration, useBaseplateExport)