### PR TITLE
fix(mobile): make settings modal responsive on mobile

### DIFF
--- a/src/components/Modals/SettingsModal/SettingsModal.tsx
+++ b/src/components/Modals/SettingsModal/SettingsModal.tsx
@@ -91,7 +91,11 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
       onClick={onClose}
       role="presentation"
     >
-      <div role="presentation" onClick={(e) => e.stopPropagation()}>
+      <div
+        role="presentation"
+        className={isMobile ? 'w-full h-full' : ''}
+        onClick={(e) => e.stopPropagation()}
+      >
         <div
           ref={modalRef}
           className={`flex flex-col animate-scale-in ${


### PR DESCRIPTION
## Summary
- The nested settings modal (opened from the mobile settings bottom sheet) was not rendering full-screen on mobile viewports
- Root cause: an intermediate `<div role="presentation">` wrapper (for click propagation stopping) had no dimensions, breaking CSS percentage-based sizing (`w-full h-full`) in the flex overlay
- Fix: add `w-full h-full` to the wrapper on mobile so the modal properly fills the screen

## Test plan
- [x] Verified mobile settings modal renders full-screen (390x844 viewport via Playwright)
- [x] Verified tab navigation and content scrolling work correctly
- [x] Verified close button returns to bottom sheet cleanly
- [x] Verified desktop settings modal is unaffected (1280x800)
- [x] All 527 component tests pass
- [x] TypeScript compiles cleanly