### PR TITLE
fix(ci): skip Vercel preview builds for release-please branches

### DIFF
--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -11,6 +11,13 @@
 
 set -e
 
+# Skip release-please branches — they only bump version/changelog and
+# frequently force-push, causing Vercel to build stale commits that no longer exist.
+if [[ "$VERCEL_GIT_COMMIT_REF" == release-please--* ]]; then
+  echo "Release-please branch. Skipping build."
+  exit 0
+fi
+
 # Always build on main branch, but check if SPA source changed
 if [ "$VERCEL_GIT_COMMIT_REF" = "main" ]; then
   echo "Main branch: checking for SPA changes..."


### PR DESCRIPTION
## Summary
- Skip Vercel preview builds for `release-please--*` branches in `vercel-ignore.sh`
- Release-please force-pushes its branch on every main commit, causing Vercel to build stale commits that no longer exist — resulting in instant failures with empty logs

## Test plan
- [ ] Verify next release-please branch push does not trigger a Vercel preview build
- [ ] Verify regular PR preview builds still work
- [ ] Verify main branch production builds still work