### PR TITLE
perf(baseplate): optimize tessellation with adaptive tolerance and skip edge mesh

### DIFF
--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -32,7 +32,6 @@ import {
   translate,
   fuseAll,
   mesh,
-  meshEdges,
   exportSTEP,
 } from 'brepjs';
 import type { Shape3D, Sketch, Drawing } from 'brepjs';
@@ -491,12 +490,16 @@ export function generateBaseplate(
   checkCancelled(signal);
 
   // Tessellate — baseplates are mostly flat slabs, so preview can use coarse settings.
-  // Dovetail connectors are large prismatic features that tessellate fine at 0.5mm.
-  const tolerance = forExport ? 0.01 : 0.5;
+  // For large baseplates (many cells), use even coarser tolerance since the prismatic
+  // geometry (boxes, cylinders) tessellates well at low resolution.
+  const cellCount = Math.ceil(params.width) * Math.ceil(params.depth);
+  const previewTolerance = cellCount > 12 ? 1.0 : 0.5;
+  const tolerance = forExport ? 0.01 : previewTolerance;
   const angularTolerance = forExport ? 5 : 45;
   const meshResult = mesh(baseplate, { tolerance, angularTolerance });
-  const edgeMesh = forExport ? null : meshEdges(baseplate, { tolerance: 0.5 });
-  const edgeVerts = edgeMesh ? new Float32Array(edgeMesh.lines) : new Float32Array(0);
+  // Skip edge mesh computation for preview — the wireframe overlay is cosmetic
+  // and meshEdges() adds significant overhead on complex baseplates.
+  const edgeVerts = new Float32Array(0);
 
   onProgress('base', 1);
 


### PR DESCRIPTION
## Summary

- **Skip `meshEdges()` for preview**: The wireframe overlay on baseplates is cosmetic and `meshEdges()` adds significant overhead on complex baseplates. Now returns an empty `Float32Array` for preview, eliminating this cost entirely.
- **Adaptive preview tolerance**: Large baseplates (>12 cells) now use 1.0mm tessellation tolerance instead of 0.5mm. Prismatic geometry (boxes, cylinders) tessellates well at lower resolution, reducing triangle count without visible quality loss.
- Export quality tessellation is unchanged (0.01mm tolerance, 5° angular tolerance).

This is PR 4/4 in the baseplate performance optimization series:
1. #908 — Batch CSG boolean operations ✅
2. #910 — Intermediate slab-with-pockets cache
3. #911 — Worker pool for parallel split generation
4. **This PR** — Tessellation optimization

## Test plan

- [x] All 23 baseplateGenerator tests pass (18 unit + 5 benchmark)
- [x] TypeScript compiles cleanly
- [x] All 42 affected tests pass (including directMesh cross-check)
- [x] Benchmark times stable/improved vs baseline