### PR TITLE
fix(ci): remove duplicate push trigger for release-please branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'release-please--branches--main--components--gridfinity-layout-tool'
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- The release-please branch was listed in both `push.branches` and (implicitly via PR) `pull_request.branches` in the CI workflow
- This caused two CI runs with different concurrency groups (`CI-refs/heads/<branch>` vs `CI-refs/pull/<n>/merge`)
- When the `push`-triggered run got cancelled by `cancel-in-progress`, its "cancelled" check runs blocked auto-merge on the release PR
- Fix: remove the release-please branch from `push.branches` — the `pull_request` trigger already covers it

## Test plan
- [x] Release PR #916 currently shows this exact failure pattern (3 cancelled runs blocking merge)
- [x] After this change, only `pull_request` triggers CI for release-please PRs — one clean run