### PR TITLE
feat(baseplate): add custom grid size with sync toggle

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -183,6 +183,13 @@ export function migrateBaseplateParams(stored: unknown): BaseplateParams {
     paddingFront: clampNumber(obj.paddingFront, 0, 100, 0),
     paddingBack: clampNumber(obj.paddingBack, 0, 100, 0),
     ...(typeof obj.connectorNubs === 'boolean' ? { connectorNubs: obj.connectorNubs } : {}),
+    ...(typeof obj.syncWithLayout === 'boolean' ? { syncWithLayout: obj.syncWithLayout } : {}),
+    ...(typeof obj.baseplateWidth === 'number'
+      ? { baseplateWidth: Math.min(50, Math.max(0.5, obj.baseplateWidth)) }
+      : {}),
+    ...(typeof obj.baseplateDepth === 'number'
+      ? { baseplateDepth: Math.min(50, Math.max(0.5, obj.baseplateDepth)) }
+      : {}),
   };
 }
 

--- a/src/core/store/layout.ts
+++ b/src/core/store/layout.ts
@@ -618,6 +618,12 @@ export const useLayoutStore = create<LayoutState>()(
             paddingBack: Math.max(0, params.paddingBack),
             magnetDiameter: clamp(params.magnetDiameter, 0.5, 20),
             magnetDepth: clamp(params.magnetDepth, 0.5, 10),
+            ...(params.baseplateWidth !== undefined
+              ? { baseplateWidth: clamp(params.baseplateWidth, 0.5, 50) }
+              : {}),
+            ...(params.baseplateDepth !== undefined
+              ? { baseplateDepth: clamp(params.baseplateDepth, 0.5, 50) }
+              : {}),
           };
         });
       },

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -33,7 +33,8 @@ export interface Layout {
 }
 
 /** Baseplate generation parameters stored per-layout.
- * Width/depth/gridUnitMm are derived from the layout's drawer at generation time, not stored here.
+ * Width/depth/gridUnitMm are derived from the layout's drawer at generation time unless
+ * syncWithLayout is false, in which case baseplateWidth/baseplateDepth override drawer dims.
  * Per-side padding in mm — user enters directly, total drawer = grid + padding. */
 export interface BaseplateParams {
   readonly magnetHoles: boolean;
@@ -45,6 +46,12 @@ export interface BaseplateParams {
   readonly paddingBack: number;
   /** Enable registration nubs/holes on split piece join edges (default false). */
   readonly connectorNubs?: boolean;
+  /** When true (or undefined), grid dims are derived from the drawer. */
+  readonly syncWithLayout?: boolean;
+  /** Custom grid width in units, only used when syncWithLayout is false. */
+  readonly baseplateWidth?: number;
+  /** Custom grid depth in units, only used when syncWithLayout is false. */
+  readonly baseplateDepth?: number;
 }
 
 /** Position of fractional edge when drawer has half-unit dimensions */

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
@@ -41,6 +41,13 @@ const { useLayoutStore } = await import('@/core/store/layout');
 (useLayoutStore as unknown as { getState: () => typeof mockLayoutState }).getState = () =>
   mockLayoutState;
 
+// Mock half-bin mode store
+let mockHalfBinMode = false;
+vi.mock('@/core/store/halfBinMode', () => ({
+  useHalfBinModeStore: (selector: (state: { halfBinMode: boolean }) => unknown) =>
+    selector({ halfBinMode: mockHalfBinMode }),
+}));
+
 // Mock page store
 let mockTiling: unknown = null;
 let mockSplitViewMode = 'assembled';
@@ -92,6 +99,7 @@ describe('BaseplatePanel', () => {
       setBaseplateParams: mockSetBaseplateParams,
       setPrintBedSize: mockSetPrintBedSize,
     };
+    mockHalfBinMode = false;
     mockTiling = null;
     mockSplitViewMode = 'assembled';
     mockHoveredPieceLabel = null;
@@ -202,6 +210,78 @@ describe('BaseplatePanel', () => {
       const a1Button = screen.getByText('A1');
       fireEvent.click(a1Button);
       expect(mockSetSelectedPieceLabel).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('grid size sync toggle', () => {
+    it('renders grid size section with sync checkbox checked by default', () => {
+      render(<BaseplatePanel />);
+      expect(screen.getByText('baseplate.sectionGridSize')).toBeInTheDocument();
+      expect(screen.getByText('baseplate.syncWithLayout')).toBeInTheDocument();
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toBeChecked();
+    });
+
+    it('renders width/depth steppers disabled when synced', () => {
+      render(<BaseplatePanel />);
+      const widthStepper = screen.getByRole('textbox', { name: 'baseplate.gridWidth' });
+      const depthStepper = screen.getByRole('textbox', { name: 'baseplate.gridDepth' });
+      expect(widthStepper).toBeDisabled();
+      expect(depthStepper).toBeDisabled();
+    });
+
+    it('shows drawer values in steppers when synced', () => {
+      render(<BaseplatePanel />);
+      const widthStepper = screen.getByRole('textbox', { name: 'baseplate.gridWidth' });
+      const depthStepper = screen.getByRole('textbox', { name: 'baseplate.gridDepth' });
+      expect(widthStepper).toHaveValue('4');
+      expect(depthStepper).toHaveValue('6');
+    });
+
+    it('enables steppers when sync is unchecked', () => {
+      mockLayoutState.layout.baseplateParams = {
+        ...DEFAULT_BASEPLATE_PARAMS,
+        syncWithLayout: false,
+        baseplateWidth: 8,
+        baseplateDepth: 10,
+      };
+      render(<BaseplatePanel />);
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).not.toBeChecked();
+      const widthStepper = screen.getByRole('textbox', { name: 'baseplate.gridWidth' });
+      const depthStepper = screen.getByRole('textbox', { name: 'baseplate.gridDepth' });
+      expect(widthStepper).not.toBeDisabled();
+      expect(depthStepper).not.toBeDisabled();
+      expect(widthStepper).toHaveValue('8');
+      expect(depthStepper).toHaveValue('10');
+    });
+
+    it('initializes custom dims from drawer when unchecking sync', () => {
+      render(<BaseplatePanel />);
+      const checkbox = screen.getByRole('checkbox');
+      fireEvent.click(checkbox);
+      expect(mockSetBaseplateParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          syncWithLayout: false,
+          baseplateWidth: 4,
+          baseplateDepth: 6,
+        })
+      );
+    });
+
+    it('sets syncWithLayout true when re-checking sync', () => {
+      mockLayoutState.layout.baseplateParams = {
+        ...DEFAULT_BASEPLATE_PARAMS,
+        syncWithLayout: false,
+        baseplateWidth: 8,
+        baseplateDepth: 10,
+      };
+      render(<BaseplatePanel />);
+      const checkbox = screen.getByRole('checkbox');
+      fireEvent.click(checkbox);
+      expect(mockSetBaseplateParams).toHaveBeenCalledWith(
+        expect.objectContaining({ syncWithLayout: true })
+      );
     });
   });
 });

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -15,7 +15,9 @@
 import { useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
-import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
+import { DEFAULT_BASEPLATE_PARAMS, CONSTRAINTS } from '@/core/constants';
+import { useHalfBinModeStore } from '@/core/store/halfBinMode';
+import { Checkbox } from '@/design-system/Checkbox/Checkbox';
 import { Stepper } from '@/design-system/Stepper';
 import { useTranslation } from '@/i18n';
 import { StickyGroupHeader } from '@/shared/components/StickyGroupHeader';
@@ -67,16 +69,30 @@ export function BaseplatePanel() {
     []
   );
 
-  const handleGridUnitChange = useCallback((mm: number) => {
-    useLayoutStore.getState().setGridUnitMm(mm);
-  }, []);
+  const halfBinMode = useHalfBinModeStore((s) => s.halfBinMode);
+  const synced = baseplateParams.syncWithLayout !== false;
+  const effectiveWidth = synced ? drawerWidth : (baseplateParams.baseplateWidth ?? drawerWidth);
+  const effectiveDepth = synced ? drawerDepth : (baseplateParams.baseplateDepth ?? drawerDepth);
 
-  const handlePrintBedChange = useCallback((size: number) => {
-    useLayoutStore.getState().setPrintBedSize(size);
-  }, []);
+  const handleSyncToggle = useCallback(
+    (checked: boolean) => {
+      const current = useLayoutStore.getState().layout.baseplateParams ?? DEFAULT_BASEPLATE_PARAMS;
+      if (checked) {
+        useLayoutStore.getState().setBaseplateParams({ ...current, syncWithLayout: true });
+      } else {
+        useLayoutStore.getState().setBaseplateParams({
+          ...current,
+          syncWithLayout: false,
+          baseplateWidth: drawerWidth,
+          baseplateDepth: drawerDepth,
+        });
+      }
+    },
+    [drawerWidth, drawerDepth]
+  );
 
-  const gridWidthMm = drawerWidth * gridUnitMm;
-  const gridDepthMm = drawerDepth * gridUnitMm;
+  const gridWidthMm = effectiveWidth * gridUnitMm;
+  const gridDepthMm = effectiveDepth * gridUnitMm;
 
   const totalWidthMm = gridWidthMm + baseplateParams.paddingLeft + baseplateParams.paddingRight;
   const totalDepthMm = gridDepthMm + baseplateParams.paddingFront + baseplateParams.paddingBack;
@@ -86,7 +102,6 @@ export function BaseplatePanel() {
     baseplateParams.paddingFront > 0 ||
     baseplateParams.paddingBack > 0;
 
-  // Padding section summary
   const paddingSummary = hasPadding
     ? `L:${baseplateParams.paddingLeft} R:${baseplateParams.paddingRight} F:${baseplateParams.paddingFront} B:${baseplateParams.paddingBack}`
     : undefined;
@@ -106,8 +121,8 @@ export function BaseplatePanel() {
               </div>
               <div className="text-xs tabular-nums text-content-tertiary">
                 {t('baseplate.gridPlusPadding', {
-                  width: drawerWidth,
-                  depth: drawerDepth,
+                  width: effectiveWidth,
+                  depth: effectiveDepth,
                 })}
               </div>
             </>
@@ -115,8 +130,8 @@ export function BaseplatePanel() {
             <div className="flex items-baseline justify-between">
               <span className="text-xs tabular-nums text-content-secondary">
                 {t('baseplate.dimensionsUnits', {
-                  width: drawerWidth,
-                  depth: drawerDepth,
+                  width: effectiveWidth,
+                  depth: effectiveDepth,
                 })}
               </span>
               <span className="text-sm font-semibold tabular-nums text-content">
@@ -126,7 +141,37 @@ export function BaseplatePanel() {
           )}
         </div>
 
-        {/* 2. Drawer Fit — primary configuration */}
+        {/* 2. Grid Size — sync toggle + optional custom width/depth */}
+        <StickyGroupHeader
+          title={t('baseplate.sectionGridSize')}
+          summary={`${effectiveWidth}×${effectiveDepth}`}
+        >
+          <div className="space-y-3 px-4 py-3">
+            <Checkbox
+              checked={synced}
+              onChange={handleSyncToggle}
+              label={t('baseplate.syncWithLayout')}
+            />
+            <div className={`grid grid-cols-2 gap-x-3 gap-y-2${synced ? ' opacity-50' : ''}`}>
+              <GridDimensionStepper
+                label={t('baseplate.gridWidth')}
+                value={effectiveWidth}
+                onChange={(v) => updateParam('baseplateWidth', v)}
+                halfBinMode={halfBinMode}
+                disabled={synced}
+              />
+              <GridDimensionStepper
+                label={t('baseplate.gridDepth')}
+                value={effectiveDepth}
+                onChange={(v) => updateParam('baseplateDepth', v)}
+                halfBinMode={halfBinMode}
+                disabled={synced}
+              />
+            </div>
+          </div>
+        </StickyGroupHeader>
+
+        {/* 3. Drawer Fit — primary configuration */}
         <StickyGroupHeader title={t('baseplate.sectionFitToDrawer')} summary={paddingSummary}>
           <div className="space-y-3 px-4 py-3">
             <p className="text-xs text-content-tertiary">{t('baseplate.paddingHelp')}</p>
@@ -222,7 +267,7 @@ export function BaseplatePanel() {
                 <DeferredNumberInput
                   id="bp-gridUnit"
                   value={gridUnitMm}
-                  onChange={handleGridUnitChange}
+                  onChange={(mm) => useLayoutStore.getState().setGridUnitMm(mm)}
                   min={1}
                   max={200}
                   className="input w-14 py-0.5 px-1 text-xs text-right"
@@ -237,7 +282,7 @@ export function BaseplatePanel() {
                 <DeferredNumberInput
                   id="bp-printBedSize"
                   value={printBedSize}
-                  onChange={handlePrintBedChange}
+                  onChange={(size) => useLayoutStore.getState().setPrintBedSize(size)}
                   min={42}
                   max={500}
                   step={10}
@@ -373,6 +418,45 @@ function PaddingStepper({ label, value, onChange }: PaddingStepperProps) {
         min={0}
         max={100}
         step={0.1}
+        aria-label={label}
+      />
+    </div>
+  );
+}
+
+interface GridDimensionStepperProps {
+  readonly label: string;
+  readonly value: number;
+  readonly onChange: (value: number) => void;
+  readonly halfBinMode: boolean;
+  readonly disabled: boolean;
+}
+
+/** Compact stepper for a custom grid width or depth dimension (grid units). */
+function GridDimensionStepper({
+  label,
+  value,
+  onChange,
+  halfBinMode,
+  disabled,
+}: GridDimensionStepperProps) {
+  const step = halfBinMode ? 0.5 : 1;
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-xs text-content-tertiary">{label}</span>
+      <Stepper
+        size="sm"
+        value={value}
+        onChange={onChange}
+        onStep={(delta) =>
+          onChange(
+            Math.min(CONSTRAINTS.GRID_MAX, Math.max(CONSTRAINTS.GRID_MIN, value + delta * step))
+          )
+        }
+        disabled={disabled}
+        min={CONSTRAINTS.GRID_MIN}
+        max={CONSTRAINTS.GRID_MAX}
+        step={step}
         aria-label={label}
       />
     </div>

--- a/src/features/baseplate/hooks/useBaseplateGeneration.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.ts
@@ -63,6 +63,9 @@ export function useBaseplateGeneration(): void {
     paddingFront,
     paddingBack,
     connectorNubs,
+    syncWithLayout,
+    baseplateWidth,
+    baseplateDepth,
   } = useLayoutStore(
     useShallow((state) => {
       const bp = state.layout.baseplateParams ?? DEFAULT_BASEPLATE_PARAMS;
@@ -81,6 +84,9 @@ export function useBaseplateGeneration(): void {
         paddingFront: bp.paddingFront,
         paddingBack: bp.paddingBack,
         connectorNubs: bp.connectorNubs,
+        syncWithLayout: bp.syncWithLayout,
+        baseplateWidth: bp.baseplateWidth,
+        baseplateDepth: bp.baseplateDepth,
       };
     })
   );
@@ -323,6 +329,9 @@ export function useBaseplateGeneration(): void {
     paddingFront,
     paddingBack,
     connectorNubs,
+    syncWithLayout,
+    baseplateWidth,
+    baseplateDepth,
     runGeneration,
   ]);
 }

--- a/src/features/baseplate/utils/buildFullParams.test.ts
+++ b/src/features/baseplate/utils/buildFullParams.test.ts
@@ -83,4 +83,43 @@ describe('buildFullParams', () => {
       fractionalEdgeY: 'start',
     });
   });
+
+  describe('syncWithLayout', () => {
+    it('uses drawer dims when syncWithLayout is undefined', () => {
+      const result = buildFullParams(storedBase, 10, 8, 42, 'end', 'end');
+      expect(result.width).toBe(10);
+      expect(result.depth).toBe(8);
+    });
+
+    it('uses drawer dims when syncWithLayout is true', () => {
+      const stored = {
+        ...storedBase,
+        syncWithLayout: true,
+        baseplateWidth: 20,
+        baseplateDepth: 16,
+      };
+      const result = buildFullParams(stored, 10, 8, 42, 'end', 'end');
+      expect(result.width).toBe(10);
+      expect(result.depth).toBe(8);
+    });
+
+    it('uses custom dims when syncWithLayout is false', () => {
+      const stored = {
+        ...storedBase,
+        syncWithLayout: false,
+        baseplateWidth: 20,
+        baseplateDepth: 16,
+      };
+      const result = buildFullParams(stored, 10, 8, 42, 'end', 'end');
+      expect(result.width).toBe(20);
+      expect(result.depth).toBe(16);
+    });
+
+    it('falls back to drawer dims when syncWithLayout is false but custom dims missing', () => {
+      const stored = { ...storedBase, syncWithLayout: false };
+      const result = buildFullParams(stored, 10, 8, 42, 'end', 'end');
+      expect(result.width).toBe(10);
+      expect(result.depth).toBe(8);
+    });
+  });
 });

--- a/src/features/baseplate/utils/buildFullParams.ts
+++ b/src/features/baseplate/utils/buildFullParams.ts
@@ -18,9 +18,13 @@ export function buildFullParams(
   fractionalEdgeX: 'start' | 'end',
   fractionalEdgeY: 'start' | 'end'
 ): FullBaseplateParams {
+  const synced = stored.syncWithLayout !== false;
+  const width = synced ? drawerWidth : (stored.baseplateWidth ?? drawerWidth);
+  const depth = synced ? drawerDepth : (stored.baseplateDepth ?? drawerDepth);
+
   return {
-    width: drawerWidth,
-    depth: drawerDepth,
+    width,
+    depth,
     gridUnitMm,
     magnetHoles: stored.magnetHoles,
     magnetDiameter: stored.magnetDiameter,
@@ -31,6 +35,6 @@ export function buildFullParams(
     paddingBack: stored.paddingBack,
     fractionalEdgeX,
     fractionalEdgeY,
-    ...(stored.connectorNubs !== undefined ? { connectorNubs: stored.connectorNubs } : {}),
+    connectorNubs: stored.connectorNubs,
   };
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1419,5 +1419,9 @@
   "baseplate.topView": "Oben",
   "baseplate.isoView": "Iso",
   "baseplate.connectorNubs": "Dovetail connectors",
-  "baseplate.connectorNubsHelp": "Dovetail joints on split edges so pieces lock together when assembled."
+  "baseplate.connectorNubsHelp": "Dovetail joints on split edges so pieces lock together when assembled.",
+  "baseplate.sectionGridSize": "Rastergröße",
+  "baseplate.syncWithLayout": "Mit Layout synchronisiert",
+  "baseplate.gridWidth": "Breite",
+  "baseplate.gridDepth": "Tiefe"
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1453,6 +1453,10 @@ const en: Record<string, string> = {
   'baseplate.connectorNubs': 'Dovetail connectors',
   'baseplate.connectorNubsHelp':
     'Dovetail joints on split edges so pieces lock together when assembled.',
+  'baseplate.sectionGridSize': 'Grid Size',
+  'baseplate.syncWithLayout': 'Synced with layout',
+  'baseplate.gridWidth': 'Width',
+  'baseplate.gridDepth': 'Depth',
 
   // ===========================================================================
   // Collaboration

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1419,5 +1419,9 @@
   "baseplate.topView": "Arriba",
   "baseplate.isoView": "Iso",
   "baseplate.connectorNubs": "Dovetail connectors",
-  "baseplate.connectorNubsHelp": "Dovetail joints on split edges so pieces lock together when assembled."
+  "baseplate.connectorNubsHelp": "Dovetail joints on split edges so pieces lock together when assembled.",
+  "baseplate.sectionGridSize": "Tamaño de rejilla",
+  "baseplate.syncWithLayout": "Sincronizado con diseño",
+  "baseplate.gridWidth": "Ancho",
+  "baseplate.gridDepth": "Profundidad"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1419,5 +1419,9 @@
   "baseplate.topView": "Dessus",
   "baseplate.isoView": "Iso",
   "baseplate.connectorNubs": "Dovetail connectors",
-  "baseplate.connectorNubsHelp": "Dovetail joints on split edges so pieces lock together when assembled."
+  "baseplate.connectorNubsHelp": "Dovetail joints on split edges so pieces lock together when assembled.",
+  "baseplate.sectionGridSize": "Taille de la grille",
+  "baseplate.syncWithLayout": "Synchronisé avec le plan",
+  "baseplate.gridWidth": "Largeur",
+  "baseplate.gridDepth": "Profondeur"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1419,5 +1419,9 @@
   "baseplate.topView": "Topp",
   "baseplate.isoView": "Iso",
   "baseplate.connectorNubs": "Dovetail connectors",
-  "baseplate.connectorNubsHelp": "Dovetail joints on split edges so pieces lock together when assembled."
+  "baseplate.connectorNubsHelp": "Dovetail joints on split edges so pieces lock together when assembled.",
+  "baseplate.sectionGridSize": "Rutenettstørrelse",
+  "baseplate.syncWithLayout": "Synkronisert med layout",
+  "baseplate.gridWidth": "Bredde",
+  "baseplate.gridDepth": "Dybde"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1419,5 +1419,9 @@
   "baseplate.topView": "Boven",
   "baseplate.isoView": "Iso",
   "baseplate.connectorNubs": "Dovetail connectors",
-  "baseplate.connectorNubsHelp": "Dovetail joints on split edges so pieces lock together when assembled."
+  "baseplate.connectorNubsHelp": "Dovetail joints on split edges so pieces lock together when assembled.",
+  "baseplate.sectionGridSize": "Rastergrootte",
+  "baseplate.syncWithLayout": "Gesynchroniseerd met layout",
+  "baseplate.gridWidth": "Breedte",
+  "baseplate.gridDepth": "Diepte"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1419,5 +1419,9 @@
   "baseplate.topView": "Topo",
   "baseplate.isoView": "Iso",
   "baseplate.connectorNubs": "Dovetail connectors",
-  "baseplate.connectorNubsHelp": "Dovetail joints on split edges so pieces lock together when assembled."
+  "baseplate.connectorNubsHelp": "Dovetail joints on split edges so pieces lock together when assembled.",
+  "baseplate.sectionGridSize": "Tamanho da grade",
+  "baseplate.syncWithLayout": "Sincronizado com layout",
+  "baseplate.gridWidth": "Largura",
+  "baseplate.gridDepth": "Profundidade"
 }


### PR DESCRIPTION
## Summary
- Add "Synced with layout" checkbox and width/depth steppers to the baseplate panel's new **Grid Size** section
- When checked (default), steppers are disabled and show drawer dimensions
- When unchecked, steppers become editable, initialized from current drawer dims, and drive baseplate generation independently
- Custom dimensions persist per-layout via optional `BaseplateParams` fields (`syncWithLayout`, `baseplateWidth`, `baseplateDepth`)

## Changes
| File | Change |
|---|---|
| `src/core/types.ts` | Added 3 optional fields to `BaseplateParams` |
| `src/core/constants.ts` | Migration carry-forward for new fields |
| `src/core/store/layout.ts` | Clamping (0.5–50) for custom dims in `setBaseplateParams` |
| `buildFullParams.ts` | Conditional width/depth based on sync flag |
| `useBaseplateGeneration.ts` | New fields in reactivity deps |
| `BaseplatePanel.tsx` | New Grid Size section with `Checkbox` + `GridDimensionStepper` sub-component |
| `en.ts` + 7 locale JSONs | 4 new i18n keys per locale |
| `buildFullParams.test.ts` | 4 new sync behavior tests |
| `BaseplatePanel.test.tsx` | 6 new sync toggle UI tests |

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test:run -- src/features/baseplate` — 143/143 pass
- [x] `npm run check:i18n` — all 7 locales match (1425 keys)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — successful production build
- [x] All pre-commit hooks pass (module boundaries, i18n, exhaustiveness, affected tests, component structure)
- [ ] Manual: navigate to baseplate page, verify checkbox checked + steppers disabled
- [ ] Manual: uncheck → steppers activate with drawer values → change dims → preview updates
- [ ] Manual: re-check → steppers disable, show drawer values
- [ ] Manual: reload → custom dims persist when previously set