### PR TITLE
feat(baseplate): add edge lines, improve tessellation, and polish 3D preview

### DIFF
--- a/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
+++ b/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
@@ -144,11 +144,14 @@ export function BaseplatePage() {
   }, [navigateBack]);
 
   const { paddingLeft, paddingRight, paddingFront, paddingBack } = baseplateParams;
+  const synced = baseplateParams.syncWithLayout !== false;
+  const effectiveWidth = synced ? drawerWidth : (baseplateParams.baseplateWidth ?? drawerWidth);
+  const effectiveDepth = synced ? drawerDepth : (baseplateParams.baseplateDepth ?? drawerDepth);
 
   const preview = (
     <BaseplatePreview
-      width={drawerWidth}
-      depth={drawerDepth}
+      width={effectiveWidth}
+      depth={effectiveDepth}
       gridUnitMm={gridUnitMm}
       paddingLeft={paddingLeft}
       paddingRight={paddingRight}

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -211,7 +211,6 @@ export function BaseplatePanel() {
           }
         >
           <div className="space-y-3 px-4 py-3">
-            <p className="text-xs text-content-tertiary">{t('baseplate.magnetHelp')}</p>
             <FeatureToggle
               label={t('baseplate.magnetHoles')}
               checked={baseplateParams.magnetHoles}
@@ -240,16 +239,13 @@ export function BaseplatePanel() {
               />
             </FeatureToggle>
             {tiling?.isSplit && (
-              <>
-                <p className="text-xs text-content-tertiary">{t('baseplate.connectorNubsHelp')}</p>
-                <FeatureToggle
-                  label={t('baseplate.connectorNubs')}
-                  checked={baseplateParams.connectorNubs === true}
-                  onChange={() =>
-                    updateParam('connectorNubs', baseplateParams.connectorNubs !== true)
-                  }
-                />
-              </>
+              <FeatureToggle
+                label={t('baseplate.connectorNubs')}
+                checked={baseplateParams.connectorNubs === true}
+                onChange={() =>
+                  updateParam('connectorNubs', baseplateParams.connectorNubs !== true)
+                }
+              />
             )}
           </div>
         </StickyGroupHeader>

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
@@ -219,13 +219,19 @@ function BaseplateMesh({ color }: { color: string }) {
           emissiveIntensity={0.08}
           flatShading={!hasPrecomputedNormals}
           polygonOffset
-          polygonOffsetFactor={1}
-          polygonOffsetUnits={1}
+          polygonOffsetFactor={4}
+          polygonOffsetUnits={8}
         />
       </mesh>
       {edgesGeometry && (
         <lineSegments geometry={edgesGeometry} position={[0, 0, 0.1]} renderOrder={1}>
-          <lineBasicMaterial color="#000000" />
+          <lineBasicMaterial
+            color="#000000"
+            depthTest
+            polygonOffset
+            polygonOffsetFactor={-4}
+            polygonOffsetUnits={-8}
+          />
         </lineSegments>
       )}
     </>

--- a/src/features/baseplate/components/BaseplatePreview/SplitBaseplateMeshes.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/SplitBaseplateMeshes.tsx
@@ -77,8 +77,8 @@ function PieceMesh({
 
   const activePiece = hoveredPieceLabel ?? selectedPieceLabel;
   const isActive = entry.label === activePiece;
-  // Only dim non-active pieces during hover -- when no pointer is over any
-  // piece, the full baseplate should render at normal brightness.
+  // Dim non-active pieces only while hovering — when no pointer is over any
+  // piece, every piece renders at full brightness.
   const isDimmed = hoveredPieceLabel !== null && !isActive;
 
   useEffect(() => {
@@ -144,18 +144,24 @@ function PieceMesh({
           metalness={0}
           side={THREE.DoubleSide}
           emissive={PIECE_COLOR}
-          emissiveIntensity={isActive ? 0.25 : 0.08}
+          emissiveIntensity={0.08}
           flatShading={!hasPrecomputedNormals}
           transparent={isDimmed}
           opacity={isDimmed ? 0.55 : 1}
           polygonOffset
-          polygonOffsetFactor={1}
-          polygonOffsetUnits={1}
+          polygonOffsetFactor={4}
+          polygonOffsetUnits={8}
         />
       </mesh>
       {edgesGeometry && (
         <lineSegments geometry={edgesGeometry} renderOrder={1}>
-          <lineBasicMaterial color="#000000" />
+          <lineBasicMaterial
+            color="#000000"
+            depthTest
+            polygonOffset
+            polygonOffsetFactor={-4}
+            polygonOffsetUnits={-8}
+          />
         </lineSegments>
       )}
       {splitViewMode === 'exploded' && (

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -383,6 +383,381 @@ function buildConnectors(
   return { nubs: tongues, holes: grooves };
 }
 
+// ─── Edge Line Computation ──────────────────────────────────────────────────
+
+/** Segments per rounded corner arc for edge lines */
+const EDGE_CORNER_SEGMENTS = 4;
+
+/** Segments per magnet hole circle for edge lines (matches 10° angular tolerance) */
+const EDGE_CIRCLE_SEGMENTS = 36;
+
+/**
+ * Generate points for a rounded rectangle centered at origin (CCW from +Z).
+ * Used for computing edge line contours — matches the same profile as the BREP
+ * slab and pocket geometry without requiring BREP edge extraction.
+ */
+function edgeRoundedRect(
+  w: number,
+  d: number,
+  r: number,
+  segments: number
+): ReadonlyArray<readonly [number, number]> {
+  const hw = w / 2;
+  const hd = d / 2;
+  const effectiveR = Math.max(Math.min(r, hw - 0.01, hd - 0.01), 0);
+
+  if (effectiveR < 0.01) {
+    return [
+      [-hw, -hd],
+      [hw, -hd],
+      [hw, hd],
+      [-hw, hd],
+    ];
+  }
+
+  const pts: Array<[number, number]> = [];
+  const corners: ReadonlyArray<readonly [number, number, number]> = [
+    [-hw + effectiveR, -hd + effectiveR, Math.PI],
+    [hw - effectiveR, -hd + effectiveR, (3 * Math.PI) / 2],
+    [hw - effectiveR, hd - effectiveR, 0],
+    [-hw + effectiveR, hd - effectiveR, Math.PI / 2],
+  ];
+
+  for (const [cx, cy, startAngle] of corners) {
+    for (let i = 0; i <= segments; i++) {
+      const angle = startAngle + (i / segments) * (Math.PI / 2);
+      pts.push([cx + effectiveR * Math.cos(angle), cy + effectiveR * Math.sin(angle)]);
+    }
+  }
+  return pts;
+}
+
+/**
+ * Generate a rounded rectangle with selective corner rounding.
+ * Only rounds corners where both adjacent edges are exterior.
+ */
+function edgeRoundedRectSelective(
+  w: number,
+  d: number,
+  r: number,
+  segments: number,
+  edges?: BaseplateParams['edges']
+): ReadonlyArray<readonly [number, number]> {
+  if (
+    !edges ||
+    (edges.left === 'exterior' &&
+      edges.right === 'exterior' &&
+      edges.front === 'exterior' &&
+      edges.back === 'exterior')
+  ) {
+    return edgeRoundedRect(w, d, r, segments);
+  }
+
+  const hw = w / 2;
+  const hd = d / 2;
+  const effectiveR = Math.max(Math.min(r, hw - 0.01, hd - 0.01), 0);
+
+  const roundFL = edges.left === 'exterior' && edges.front === 'exterior' && effectiveR > 0.01;
+  const roundFR = edges.right === 'exterior' && edges.front === 'exterior' && effectiveR > 0.01;
+  const roundBR = edges.right === 'exterior' && edges.back === 'exterior' && effectiveR > 0.01;
+  const roundBL = edges.left === 'exterior' && edges.back === 'exterior' && effectiveR > 0.01;
+
+  const pts: Array<[number, number]> = [];
+  const cornerDefs: ReadonlyArray<readonly [number, number, number, boolean]> = [
+    [-hw + effectiveR, -hd + effectiveR, Math.PI, roundFL],
+    [hw - effectiveR, -hd + effectiveR, (3 * Math.PI) / 2, roundFR],
+    [hw - effectiveR, hd - effectiveR, 0, roundBR],
+    [-hw + effectiveR, hd - effectiveR, Math.PI / 2, roundBL],
+  ];
+  const sharp: ReadonlyArray<readonly [number, number]> = [
+    [-hw, -hd],
+    [hw, -hd],
+    [hw, hd],
+    [-hw, hd],
+  ];
+
+  for (let c = 0; c < 4; c++) {
+    const [cx, cy, startAngle, shouldRound] = cornerDefs[c];
+    if (shouldRound) {
+      for (let i = 0; i <= segments; i++) {
+        const angle = startAngle + (i / segments) * (Math.PI / 2);
+        pts.push([cx + effectiveR * Math.cos(angle), cy + effectiveR * Math.sin(angle)]);
+      }
+    } else {
+      pts.push([sharp[c][0], sharp[c][1]]);
+    }
+  }
+  return pts;
+}
+
+/** Push a closed polygon as line segments into an edge buffer. */
+function pushEdgeLoop(
+  buf: number[],
+  pts: ReadonlyArray<readonly [number, number]>,
+  z: number,
+  ox: number,
+  oy: number
+): void {
+  const n = pts.length;
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    buf.push(pts[i][0] + ox, pts[i][1] + oy, z, pts[j][0] + ox, pts[j][1] + oy, z);
+  }
+}
+
+/**
+ * Compute the arc–straight transition points of a rounded rectangle.
+ *
+ * These are the 8 points (2 per corner) where arc segments meet straight
+ * segments — exactly where BREP topology would place vertical edges because
+ * the adjacent flat-wall and curved-corner faces meet at a sharp angle.
+ *
+ * For a sharp (unrounded) corner, only 1 point is returned for that corner.
+ */
+function roundedRectTransitionPts(w: number, d: number, r: number): Array<[number, number]> {
+  const hw = w / 2;
+  const hd = d / 2;
+  const effectiveR = Math.max(Math.min(r, hw - 0.01, hd - 0.01), 0);
+
+  if (effectiveR < 0.01) {
+    // Sharp rectangle — 4 corner points
+    return [
+      [-hw, -hd],
+      [hw, -hd],
+      [hw, hd],
+      [-hw, hd],
+    ];
+  }
+
+  // 8 transition points: arc-start and arc-end for each corner.
+  // Listed in CCW order matching edgeRoundedRect traversal.
+  return [
+    // Bottom-left corner (arc from π to 3π/2)
+    [-hw, -hd + effectiveR], // arc start: left wall → arc
+    [-hw + effectiveR, -hd], // arc end:   arc → bottom wall
+    // Bottom-right corner (arc from 3π/2 to 2π)
+    [hw - effectiveR, -hd], // arc start: bottom wall → arc
+    [hw, -hd + effectiveR], // arc end:   arc → right wall
+    // Top-right corner (arc from 0 to π/2)
+    [hw, hd - effectiveR], // arc start: right wall → arc
+    [hw - effectiveR, hd], // arc end:   arc → top wall
+    // Top-left corner (arc from π/2 to π)
+    [-hw + effectiveR, hd], // arc start: top wall → arc
+    [-hw, hd - effectiveR], // arc end:   arc → left wall
+  ];
+}
+
+/**
+ * Transition points for a rounded rectangle with selective corner rounding.
+ * Returns 1 point per sharp corner, 2 per rounded corner.
+ */
+function roundedRectTransitionPtsSelective(
+  w: number,
+  d: number,
+  r: number,
+  edges?: BaseplateParams['edges']
+): Array<[number, number]> {
+  if (
+    !edges ||
+    (edges.left === 'exterior' &&
+      edges.right === 'exterior' &&
+      edges.front === 'exterior' &&
+      edges.back === 'exterior')
+  ) {
+    return roundedRectTransitionPts(w, d, r);
+  }
+
+  const hw = w / 2;
+  const hd = d / 2;
+  const effectiveR = Math.max(Math.min(r, hw - 0.01, hd - 0.01), 0);
+
+  const roundFL = edges.left === 'exterior' && edges.front === 'exterior' && effectiveR > 0.01;
+  const roundFR = edges.right === 'exterior' && edges.front === 'exterior' && effectiveR > 0.01;
+  const roundBR = edges.right === 'exterior' && edges.back === 'exterior' && effectiveR > 0.01;
+  const roundBL = edges.left === 'exterior' && edges.back === 'exterior' && effectiveR > 0.01;
+
+  const pts: Array<[number, number]> = [];
+
+  if (roundFL) {
+    pts.push([-hw, -hd + effectiveR], [-hw + effectiveR, -hd]);
+  } else {
+    pts.push([-hw, -hd]);
+  }
+  if (roundFR) {
+    pts.push([hw - effectiveR, -hd], [hw, -hd + effectiveR]);
+  } else {
+    pts.push([hw, -hd]);
+  }
+  if (roundBR) {
+    pts.push([hw, hd - effectiveR], [hw - effectiveR, hd]);
+  } else {
+    pts.push([hw, hd]);
+  }
+  if (roundBL) {
+    pts.push([-hw + effectiveR, hd], [-hw, hd - effectiveR]);
+  } else {
+    pts.push([-hw, hd]);
+  }
+
+  return pts;
+}
+
+/**
+ * Push vertical edge lines connecting transition points between two Z levels.
+ * Each pair of corresponding top/bottom points gets a vertical line segment.
+ */
+function pushVerticalEdges(
+  buf: number[],
+  topPts: ReadonlyArray<readonly [number, number]>,
+  botPts: ReadonlyArray<readonly [number, number]>,
+  zTop: number,
+  zBot: number,
+  ox: number,
+  oy: number
+): void {
+  // When contours have the same number of points, connect them 1:1
+  const n = Math.min(topPts.length, botPts.length);
+  for (let i = 0; i < n; i++) {
+    buf.push(
+      topPts[i][0] + ox,
+      topPts[i][1] + oy,
+      zTop,
+      botPts[i][0] + ox,
+      botPts[i][1] + oy,
+      zBot
+    );
+  }
+}
+
+/**
+ * Compute edge line vertices procedurally from baseplate params.
+ *
+ * Generates contour loops at face boundaries (outer perimeter, pocket openings,
+ * pocket floors, magnet holes) to produce the same visual "sketch look" as BREP
+ * topology edges — without the cost of meshEdges().
+ */
+function computeBaseplateEdgeLines(params: BaseplateParams): Float32Array {
+  const {
+    width,
+    depth,
+    gridUnitMm,
+    magnetHoles,
+    magnetDiameter,
+    magnetDepth,
+    paddingLeft,
+    paddingRight,
+    paddingFront,
+    paddingBack,
+    fractionalEdgeX,
+    fractionalEdgeY,
+    edges,
+  } = params;
+
+  const floorDepth = magnetHoles ? MAGNET_FLOOR + magnetDepth : 0;
+  const totalHeight = SOCKET_HEIGHT + floorDepth;
+  const totalW = width * gridUnitMm + paddingLeft + paddingRight;
+  const totalD = depth * gridUnitMm + paddingFront + paddingBack;
+  const maxRadius = Math.min(totalW, totalD) / 2 - 0.1;
+  const cornerR = Math.min(PLATE_CORNER_RADIUS, maxRadius);
+  const slabOffsetX = (paddingRight - paddingLeft) / 2;
+  const slabOffsetY = (paddingBack - paddingFront) / 2;
+
+  const buf: number[] = [];
+
+  // ── Outer perimeter: horizontal contours + vertical corner edges ──
+  const outerPts = edgeRoundedRectSelective(totalW, totalD, cornerR, EDGE_CORNER_SEGMENTS, edges);
+  pushEdgeLoop(buf, outerPts, totalHeight, slabOffsetX, slabOffsetY);
+  pushEdgeLoop(buf, outerPts, 0, slabOffsetX, slabOffsetY);
+
+  // Vertical edges at outer perimeter corners (wall is not tapered, same XY at top and bottom)
+  const outerTransition = roundedRectTransitionPtsSelective(totalW, totalD, cornerR, edges);
+  pushVerticalEdges(
+    buf,
+    outerTransition,
+    outerTransition,
+    totalHeight,
+    0,
+    slabOffsetX,
+    slabOffsetY
+  );
+
+  // ── Pocket openings, floors, and vertical wall edges for each cell ──
+  const cellOpts: ForEachCellOptions = { fractionalEdgeX, fractionalEdgeY, gridUnitMm };
+  forEachCell(
+    width,
+    depth,
+    (cell) => {
+      const cellW = cell.widthUnits * gridUnitMm;
+      const cellD = cell.depthUnits * gridUnitMm;
+      const cr = pocketCornerRadius(cellW, cellD);
+
+      // Pocket opening at top
+      pushEdgeLoop(
+        buf,
+        edgeRoundedRect(cellW, cellD, cr, EDGE_CORNER_SEGMENTS),
+        totalHeight,
+        cell.centerX,
+        cell.centerY
+      );
+
+      // Pocket floor + vertical wall edges
+      const botW = cellW - 2 * INSET_BOT;
+      const botD = cellD - 2 * INSET_BOT;
+      const botR = Math.max(cr - INSET_BOT, 0.1);
+      const pocketFloorZ = floorDepth > 0 ? floorDepth : 0;
+
+      if (floorDepth > 0) {
+        pushEdgeLoop(
+          buf,
+          edgeRoundedRect(botW, botD, botR, EDGE_CORNER_SEGMENTS),
+          floorDepth,
+          cell.centerX,
+          cell.centerY
+        );
+      }
+
+      // Vertical edges along the tapered pocket walls
+      const topTransition = roundedRectTransitionPts(cellW, cellD, cr);
+      const botTransition = roundedRectTransitionPts(botW, botD, botR);
+      pushVerticalEdges(
+        buf,
+        topTransition,
+        botTransition,
+        totalHeight,
+        pocketFloorZ,
+        cell.centerX,
+        cell.centerY
+      );
+    },
+    cellOpts
+  );
+
+  // Magnet hole circles
+  if (magnetHoles) {
+    const magnetRadius = magnetDiameter / 2;
+    const circlePts: Array<[number, number]> = [];
+    for (let i = 0; i < EDGE_CIRCLE_SEGMENTS; i++) {
+      const angle = (i / EDGE_CIRCLE_SEGMENTS) * Math.PI * 2;
+      circlePts.push([magnetRadius * Math.cos(angle), magnetRadius * Math.sin(angle)]);
+    }
+
+    forEachCell(
+      width,
+      depth,
+      (cell) => {
+        if (cell.widthUnits < 1 || cell.depthUnits < 1) return;
+        for (const [dx, dy] of MAGNET_OFFSETS) {
+          pushEdgeLoop(buf, circlePts, floorDepth, cell.centerX + dx, cell.centerY + dy);
+          pushEdgeLoop(buf, circlePts, MAGNET_FLOOR, cell.centerX + dx, cell.centerY + dy);
+        }
+      },
+      cellOpts
+    );
+  }
+
+  return new Float32Array(buf);
+}
+
 // ─── Public API ─────────────────────────────────────────────────────────────
 
 function meshCacheKey(params: BaseplateParams, forExport: boolean): string {
@@ -522,17 +897,30 @@ export function generateBaseplate(
   onProgress('base', 0.9);
   checkCancelled(signal);
 
-  // Tessellate — baseplates are mostly flat slabs, so preview can use coarse settings.
-  // For large baseplates (many cells), use even coarser tolerance since the prismatic
-  // geometry (boxes, cylinders) tessellates well at low resolution.
-  const cellCount = Math.ceil(params.width) * Math.ceil(params.depth);
-  const previewTolerance = cellCount > 12 ? 1.0 : 0.5;
-  const tolerance = forExport ? 0.01 : previewTolerance;
-  const angularTolerance = forExport ? 5 : 45;
+  // Tessellate — match the bin designer's tolerance strategy.
+  // Baseplates have magnet hole cylinders that need tight angular tolerance
+  // and mostly flat surfaces where linear tolerance can be coarser.
+  const totalW = params.width * params.gridUnitMm + params.paddingLeft + params.paddingRight;
+  const totalD = params.depth * params.gridUnitMm + params.paddingFront + params.paddingBack;
+  const maxDimension = Math.max(totalW, totalD);
+  let tolerance: number;
+  let angularTolerance: number;
+
+  if (forExport) {
+    tolerance = 0.01;
+    angularTolerance = 5;
+  } else if (params.magnetHoles) {
+    // Magnet holes have small cylinders — match bin designer's "with lip" tier
+    tolerance = Math.min(0.1, Math.max(0.05, maxDimension / 2500));
+    angularTolerance = 10;
+  } else {
+    // No magnets — mostly planar, match bin designer's "simple" tier
+    tolerance = Math.min(0.4, Math.max(0.15, maxDimension / 600));
+    angularTolerance = 12;
+  }
   const meshResult = mesh(baseplate, { tolerance, angularTolerance });
-  // Skip edge mesh computation for preview — the wireframe overlay is cosmetic
-  // and meshEdges() adds significant overhead on complex baseplates.
-  const edgeVerts = new Float32Array(0);
+  // Compute edge lines procedurally from params (avoids expensive meshEdges() on BREP)
+  const edgeVerts = computeBaseplateEdgeLines(params);
 
   onProgress('base', 1);
 


### PR DESCRIPTION
## Summary
- **Edge lines**: Procedural edge line computation matching bin designer topology edges — includes vertical edges at rounded-rectangle corners and tapered pocket walls, avoiding expensive `meshEdges()` on BREP
- **Tessellation**: Match bin designer tolerance tiers (export 0.01/5°, magnets 0.05-0.1/10°, flat 0.15-0.4/12°) — magnet holes now render as smooth circles instead of hexagons
- **Z-fighting fix**: Dual polygon offset strategy (mesh +4/+8, lines -4/-8) eliminates edge line flickering at all camera angles
- **Uniform brightness**: Constant emissive intensity (0.08) for all pieces — dimming only via opacity on hover
- **Dimension markings**: Fix for unsynced custom grid sizes passing correct width/depth to preview
- **Panel cleanup**: Remove redundant help text paragraphs

## Test plan
- [x] 144 baseplate tests pass
- [x] 413 generation tests pass
- [x] TypeScript compiles cleanly
- [x] Visual verification via Playwright: isometric and top-down views show clean edge lines with no z-fighting