### PR TITLE
refactor(store): export INITIAL_STATE constants and simplify resetAllStores

### DIFF
--- a/src/components/Modals/SettingsModal/SettingsModal.test.tsx
+++ b/src/components/Modals/SettingsModal/SettingsModal.test.tsx
@@ -52,6 +52,7 @@ vi.mock('@/core/store', () => ({
 vi.mock('@/core/store/toast', () => ({
   useToastStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({ addToast: vi.fn() }),
+  INITIAL_TOAST_STATE: {},
 }));
 
 vi.mock('@/shared/components/ConfirmDialog', () => ({

--- a/src/components/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.test.tsx
+++ b/src/components/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.test.tsx
@@ -42,6 +42,7 @@ vi.mock('@/core/store', () => ({
 vi.mock('@/core/store/toast', () => ({
   useToastStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({ addToast: mockAddToast }),
+  INITIAL_TOAST_STATE: {},
 }));
 
 vi.mock('@/hooks/useDrawerSettings', () => ({

--- a/src/core/store/halfBinMode.ts
+++ b/src/core/store/halfBinMode.ts
@@ -64,6 +64,10 @@ interface HalfBinModeActions {
 
 export type HalfBinModeStore = HalfBinModeState & HalfBinModeActions;
 
+export const INITIAL_HALF_BIN_MODE_STATE = {
+  halfBinMode: false,
+} as const;
+
 export const useHalfBinModeStore = create<HalfBinModeStore>((set) => ({
   halfBinMode: loadFromStorage(),
 

--- a/src/core/store/index.ts
+++ b/src/core/store/index.ts
@@ -1,28 +1,28 @@
 export { useLayoutStore } from './layout';
 export { useHistoryStore, useUndoableAction } from './history';
-export { useToastStore } from './toast';
+export { useToastStore, INITIAL_TOAST_STATE } from './toast';
 export { useLibraryStore, computePreview, createDefaultLibrary } from './library';
 export { useSettingsStore, DEFAULT_SETTINGS } from './settings';
 export type { UserSettings } from './settings';
 export { useLabsStore, LABS_STORAGE_KEY } from './labs';
 
-export { useSelectionStore } from './selection';
+export { useSelectionStore, INITIAL_SELECTION_STATE } from './selection';
 export type { SelectionStore } from './selection';
 
-export { useViewStore } from './view';
+export { useViewStore, INITIAL_VIEW_STATE } from './view';
 export type { ViewStore, ContextMenuState, LayerViewMode } from './view';
 
-export { useInteractionStore } from './interaction';
+export { useInteractionStore, INITIAL_INTERACTION_STATE } from './interaction';
 export type { InteractionStore, DropTarget, PaintSize } from './interaction';
 
-export { useMobileStore } from './mobile';
+export { useMobileStore, INITIAL_MOBILE_STATE } from './mobile';
 export type { MobileStore, MobilePanel, MobileLayersTab } from './mobile';
 
-export { useHalfBinModeStore } from './halfBinMode';
+export { useHalfBinModeStore, INITIAL_HALF_BIN_MODE_STATE } from './halfBinMode';
 export type { HalfBinModeStore } from './halfBinMode';
 
-export { useSharedPreviewStore } from './sharedPreview';
+export { useSharedPreviewStore, INITIAL_SHARED_PREVIEW_STATE } from './sharedPreview';
 export type { SharedPreviewStore } from './sharedPreview';
 
-export { useSnapshotStore } from './snapshots';
+export { useSnapshotStore, INITIAL_SNAPSHOT_STATE } from './snapshots';
 export type { SnapshotState } from './snapshots';

--- a/src/core/store/interaction.ts
+++ b/src/core/store/interaction.ts
@@ -60,14 +60,18 @@ interface InteractionActions {
 
 export type InteractionStore = InteractionState & InteractionActions;
 
-export const useInteractionStore = create<InteractionStore>((set) => ({
-  // Initial state
-  interaction: null,
-  dropTarget: null,
-  paintSize: null,
+export const INITIAL_INTERACTION_STATE = {
+  interaction: null as Interaction | null,
+  dropTarget: null as DropTarget,
+  paintSize: null as PaintSize | null,
   keyboardDragMode: false,
   keyboardResizeMode: false,
-  liveMessage: null,
+  liveMessage: null as string | null,
+} as const;
+
+export const useInteractionStore = create<InteractionStore>((set) => ({
+  // Initial state
+  ...INITIAL_INTERACTION_STATE,
 
   // Interaction actions
   setInteraction: (interaction) => set({ interaction }),

--- a/src/core/store/mobile.ts
+++ b/src/core/store/mobile.ts
@@ -36,10 +36,14 @@ interface MobileActions {
 
 export type MobileStore = MobileState & MobileActions;
 
+export const INITIAL_MOBILE_STATE = {
+  activeMobilePanel: null as MobilePanel,
+  mobileLayersTab: 'layers' as MobileLayersTab,
+} as const;
+
 export const useMobileStore = create<MobileStore>((set) => ({
   // Initial state
-  activeMobilePanel: null,
-  mobileLayersTab: 'layers',
+  ...INITIAL_MOBILE_STATE,
 
   // Actions
   setActiveMobilePanel: (panel) => set({ activeMobilePanel: panel }),

--- a/src/core/store/selection.ts
+++ b/src/core/store/selection.ts
@@ -53,13 +53,17 @@ interface SelectionActions {
 
 export type SelectionStore = SelectionState & SelectionActions;
 
-export const useSelectionStore = create<SelectionStore>((set) => ({
-  // Initial state
-  selectedBinIds: [],
+export const INITIAL_SELECTION_STATE = {
+  selectedBinIds: [] as BinId[],
   activeLayerId: layerId(''),
   activeCategoryId: categoryId('coral'),
-  focusedBinId: null,
-  quickLabelBinId: null,
+  focusedBinId: null as BinId | null,
+  quickLabelBinId: null as BinId | null,
+} as const;
+
+export const useSelectionStore = create<SelectionStore>((set) => ({
+  // Initial state
+  ...INITIAL_SELECTION_STATE,
 
   // Bin selection actions
   setSelectedBin: (id) => set({ selectedBinIds: id ? [id] : [] }),

--- a/src/core/store/sharedPreview.ts
+++ b/src/core/store/sharedPreview.ts
@@ -52,8 +52,12 @@ interface SharedPreviewActions {
 
 export type SharedPreviewStore = SharedPreviewState & SharedPreviewActions;
 
+export const INITIAL_SHARED_PREVIEW_STATE = {
+  sharedPreview: null as SharedPreviewData | null,
+} as const;
+
 export const useSharedPreviewStore = create<SharedPreviewStore>((set) => ({
-  sharedPreview: null,
+  ...INITIAL_SHARED_PREVIEW_STATE,
 
   setSharedLayoutPreview: (layout, originalName, authorName, cloudShareId, permission) => {
     if (layout) {

--- a/src/core/store/snapshots.ts
+++ b/src/core/store/snapshots.ts
@@ -35,9 +35,13 @@ export interface SnapshotState {
   updateLabel: (snapshotId: string, label: string) => Promise<void>;
 }
 
-export const useSnapshotStore = create<SnapshotState>((set) => ({
-  snapshots: [],
+export const INITIAL_SNAPSHOT_STATE = {
+  snapshots: [] as Snapshot[],
   isLoading: false,
+} as const;
+
+export const useSnapshotStore = create<SnapshotState>((set) => ({
+  ...INITIAL_SNAPSHOT_STATE,
 
   loadForLayout: async (layoutId: string) => {
     set({ isLoading: true });

--- a/src/core/store/toast.ts
+++ b/src/core/store/toast.ts
@@ -37,8 +37,12 @@ interface ToastState {
 const DEFAULT_DURATION = 5000;
 const MAX_TOASTS = 3;
 
+export const INITIAL_TOAST_STATE = {
+  toasts: [] as Toast[],
+} as const;
+
 export const useToastStore = create<ToastState>((set) => ({
-  toasts: [],
+  ...INITIAL_TOAST_STATE,
 
   addToast: (
     messageOrOptions: string | AddToastOptions,

--- a/src/core/store/view.ts
+++ b/src/core/store/view.ts
@@ -97,22 +97,26 @@ interface ViewActions {
 
 export type ViewStore = ViewState & ViewActions;
 
-export const useViewStore = create<ViewStore>((set) => ({
-  // Initial state
+export const INITIAL_VIEW_STATE = {
   zoom: 1,
   showOtherLayers: true,
   leftPanelCollapsed: false,
   rightPanelCollapsed: false,
-  contextMenu: null,
-  highlightedCategoryId: null,
-  highlightedRowLabel: null,
-  highlightedColLabel: null,
+  contextMenu: null as ContextMenuState | null,
+  highlightedCategoryId: null as CategoryId | null,
+  highlightedRowLabel: null as number | null,
+  highlightedColLabel: null as number | null,
   printModalOpen: false,
   showLayoutManager: false,
   showIsometricPreview: false,
   isometricRotation: 0,
-  layerViewMode: 'stack',
+  layerViewMode: 'stack' as LayerViewMode,
   isPreviewExpanded: false,
+} as const;
+
+export const useViewStore = create<ViewStore>((set) => ({
+  // Initial state
+  ...INITIAL_VIEW_STATE,
 
   // Zoom actions
   setZoom: (zoom) =>

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
@@ -56,6 +56,7 @@ let mockHalfBinMode = false;
 vi.mock('@/core/store/halfBinMode', () => ({
   useHalfBinModeStore: (selector: (state: { halfBinMode: boolean }) => unknown) =>
     selector({ halfBinMode: mockHalfBinMode }),
+  INITIAL_HALF_BIN_MODE_STATE: {},
 }));
 
 // Mock page store

--- a/src/features/grid-editor/components/Grid/GridAxisLabels/GridAxisLabels.test.tsx
+++ b/src/features/grid-editor/components/Grid/GridAxisLabels/GridAxisLabels.test.tsx
@@ -31,6 +31,7 @@ vi.mock('@/core/store/view', () => {
         subscribe: vi.fn(),
       }
     ),
+    INITIAL_VIEW_STATE: mockStoreState,
   };
 });
 

--- a/src/hooks/useIndexedDBRecovery.test.ts
+++ b/src/hooks/useIndexedDBRecovery.test.ts
@@ -30,6 +30,7 @@ vi.mock('@/core/store/toast', () => ({
       addToast: vi.fn(),
     })),
   },
+  INITIAL_TOAST_STATE: {},
 }));
 
 vi.mock('@/i18n', () => ({

--- a/src/hooks/useTabletPanels.test.ts
+++ b/src/hooks/useTabletPanels.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/core/store/view', () => {
 
       return selector(state);
     }),
+    INITIAL_VIEW_STATE: {},
   };
 });
 

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -9,18 +9,18 @@ import { createDefaultLayout } from '@/core/constants';
 import { useLayoutStore } from '@/core/store/layout';
 import { useHistoryStore } from '@/core/store/history';
 import { useToastStore } from '@/core/store/toast';
+import { INITIAL_TOAST_STATE } from '@/core/store/toast';
 import { useSettingsStore, DEFAULT_SETTINGS } from '@/core/store/settings';
 import { useLibraryStore } from '@/core/store/library';
 import { useLabsStore } from '@/core/store';
 import { createDefaultLabsPreferences } from '@/core/labs';
-// New stores extracted from ui.ts
-import { useSelectionStore } from '@/core/store/selection';
-import { useViewStore } from '@/core/store/view';
-import { useInteractionStore } from '@/core/store/interaction';
-import { useMobileStore } from '@/core/store/mobile';
-import { useHalfBinModeStore } from '@/core/store/halfBinMode';
-import { useSharedPreviewStore } from '@/core/store/sharedPreview';
-import { useSnapshotStore } from '@/core/store/snapshots';
+import { useSelectionStore, INITIAL_SELECTION_STATE } from '@/core/store/selection';
+import { useViewStore, INITIAL_VIEW_STATE } from '@/core/store/view';
+import { useInteractionStore, INITIAL_INTERACTION_STATE } from '@/core/store/interaction';
+import { useMobileStore, INITIAL_MOBILE_STATE } from '@/core/store/mobile';
+import { useHalfBinModeStore, INITIAL_HALF_BIN_MODE_STATE } from '@/core/store/halfBinMode';
+import { useSharedPreviewStore, INITIAL_SHARED_PREVIEW_STATE } from '@/core/store/sharedPreview';
+import { useSnapshotStore, INITIAL_SNAPSHOT_STATE } from '@/core/store/snapshots';
 
 /**
  * Reset individual stores for tests that only need partial isolation.
@@ -36,28 +36,11 @@ export function resetLayoutStore(): void {
 }
 
 export function resetSelectionStore(): void {
-  useSelectionStore.setState({
-    selectedBinIds: [],
-    activeLayerId: layerId(''),
-    activeCategoryId: categoryId('coral'),
-    focusedBinId: null,
-    quickLabelBinId: null,
-  });
+  useSelectionStore.setState(INITIAL_SELECTION_STATE);
 }
 
 export function resetInteractionStore(): void {
-  useInteractionStore.setState({
-    interaction: null,
-    dropTarget: null,
-    paintSize: null,
-    keyboardDragMode: false,
-    keyboardResizeMode: false,
-    liveMessage: null,
-    showIsometricPreview: false,
-    isometricRotation: 0,
-    layerViewMode: 'stack',
-    isPreviewExpanded: false,
-  });
+  useInteractionStore.setState(INITIAL_INTERACTION_STATE);
 }
 
 export function resetHistoryStore(): void {
@@ -70,17 +53,7 @@ export function resetHistoryStore(): void {
 }
 
 export function resetViewStore(): void {
-  useViewStore.setState({
-    zoom: 1,
-    showOtherLayers: true,
-    leftPanelCollapsed: false,
-    rightPanelCollapsed: false,
-    contextMenu: null,
-    highlightedCategoryId: null,
-    highlightedRowLabel: null,
-    highlightedColLabel: null,
-    printModalOpen: false,
-  });
+  useViewStore.setState(INITIAL_VIEW_STATE);
 }
 
 export function resetLibraryStore(): void {
@@ -107,56 +80,22 @@ export function resetAllStores(): void {
   });
 
   // Selection store
-  useSelectionStore.setState({
-    selectedBinIds: [],
-    activeLayerId: layerId(''),
-    activeCategoryId: categoryId('coral'),
-    focusedBinId: null,
-    quickLabelBinId: null,
-  });
+  useSelectionStore.setState(INITIAL_SELECTION_STATE);
 
   // View store
-  useViewStore.setState({
-    zoom: 1,
-    showOtherLayers: true,
-    leftPanelCollapsed: false,
-    rightPanelCollapsed: false,
-    contextMenu: null,
-    highlightedCategoryId: null,
-    highlightedRowLabel: null,
-    highlightedColLabel: null,
-    printModalOpen: false,
-  });
+  useViewStore.setState(INITIAL_VIEW_STATE);
 
   // Interaction store
-  useInteractionStore.setState({
-    interaction: null,
-    dropTarget: null,
-    paintSize: null,
-    keyboardDragMode: false,
-    keyboardResizeMode: false,
-    liveMessage: null,
-    showIsometricPreview: false, // Match InteractionStore default
-    isometricRotation: 0,
-    layerViewMode: 'stack', // Match InteractionStore default
-    isPreviewExpanded: false,
-  });
+  useInteractionStore.setState(INITIAL_INTERACTION_STATE);
 
   // Mobile store
-  useMobileStore.setState({
-    activeMobilePanel: null,
-    mobileLayersTab: 'layers',
-  });
+  useMobileStore.setState(INITIAL_MOBILE_STATE);
 
   // Half-bin mode store
-  useHalfBinModeStore.setState({
-    halfBinMode: false,
-  });
+  useHalfBinModeStore.setState(INITIAL_HALF_BIN_MODE_STATE);
 
   // Shared preview store
-  useSharedPreviewStore.setState({
-    sharedPreview: null,
-  });
+  useSharedPreviewStore.setState(INITIAL_SHARED_PREVIEW_STATE);
 
   // History store
   useHistoryStore.setState({
@@ -167,7 +106,7 @@ export function resetAllStores(): void {
   });
 
   // Toast store
-  useToastStore.setState({ toasts: [] });
+  useToastStore.setState(INITIAL_TOAST_STATE);
 
   // Settings store
   useSettingsStore.setState({ settings: { ...DEFAULT_SETTINGS } });
@@ -188,10 +127,7 @@ export function resetAllStores(): void {
   });
 
   // Snapshot store
-  useSnapshotStore.setState({
-    snapshots: [],
-    isLoading: false,
-  });
+  useSnapshotStore.setState(INITIAL_SNAPSHOT_STATE);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extracted initial state from 8 store `create()` calls into exported `INITIAL_*_STATE` constants
- Refactored `resetAllStores()` in `testUtils.ts` to use these constants instead of hard-coded duplicates
- Updated 5 test files with `vi.mock` to include the new exports

## Motivation
`resetAllStores()` manually duplicated ~90 lines of initial state across 12 stores. When a store adds a new field, this function silently goes stale. Now each store is the single source of truth for its own initial state.

## Test plan
- [x] Full test suite: 8,493 tests pass (536 files)
- [x] TypeScript typecheck passes
- [x] No runtime behavior changes