### PR TITLE
refactor: centralize SHARED_PREVIEW_ID constant and isRealLayoutId helper

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,4 +1,12 @@
-import type { Layout, Category, BaseplateParams, BinId, LayerId, CategoryId } from './types';
+import type {
+  Layout,
+  Category,
+  BaseplateParams,
+  BinId,
+  LayoutId,
+  LayerId,
+  CategoryId,
+} from './types';
 import { binId, layerId, categoryId } from './types';
 
 // === Constraints (from PRD) ===
@@ -65,6 +73,16 @@ export function calcMaxGridUnits(printBedSizeMm: number, gridUnitMm: number): nu
 // === Staging ===
 
 export const STAGING_ID = '__staging__' as LayerId;
+
+// === Shared Preview ===
+
+/** Sentinel layout ID used when viewing a shared layout in preview mode. */
+export const SHARED_PREVIEW_ID = '__shared_preview__' as LayoutId;
+
+/** Returns true if the ID represents a real persisted layout (not a preview sentinel). */
+export function isRealLayoutId(id: LayoutId | null): id is LayoutId {
+  return id !== null && id !== SHARED_PREVIEW_ID;
+}
 
 // === Half-bin Mode ===
 

--- a/src/core/storage/LayoutManager.test.ts
+++ b/src/core/storage/LayoutManager.test.ts
@@ -17,7 +17,7 @@ import {
 } from '@/core/storage/LayoutManager';
 import { expectOk, expectErr } from '@/test/testUtils';
 import { ok, err, storageQuotaExceeded, storageUnavailable } from '@/core/result';
-import { createDefaultLayout, STAGING_ID, CONSTRAINTS } from '@/core/constants';
+import { createDefaultLayout, STAGING_ID, CONSTRAINTS, SHARED_PREVIEW_ID } from '@/core/constants';
 import type { Layout, LayoutLibrary, LayoutEntry, Bin } from '@/core/types';
 
 // Mock the backend module
@@ -669,14 +669,14 @@ describe('switchActiveLayout', () => {
     const fromLayout = createTestLayout();
     const library = createTestLibrary([createTestEntry('to-id', 'To')]);
 
-    await switchActiveLayout('__shared_preview__', fromLayout, 'to-id', library);
+    await switchActiveLayout(SHARED_PREVIEW_ID, fromLayout, 'to-id', library);
 
     // saveAsync should only be called once (for loading target, not saving from)
     // Actually, saveAsync is for saving, loadAsync is for loading
     // So saveAsync should NOT have been called at all for the "from" layout
     const saveAsyncCalls = vi.mocked(backend.saveAsync).mock.calls;
     const savingFromId = saveAsyncCalls.some(
-      (call) => call[0] === 'gridfinity-layout-__shared_preview__'
+      (call) => call[0] === `gridfinity-layout-${SHARED_PREVIEW_ID}`
     );
     expect(savingFromId).toBe(false);
   });

--- a/src/core/storage/LayoutManager.ts
+++ b/src/core/storage/LayoutManager.ts
@@ -25,7 +25,7 @@ import { deleteSnapshotsForLayout } from './SnapshotService';
 import * as indexedDB from './backends/indexedDB';
 import { salvageImport } from '@/shared/utils/validation';
 import { generateLayoutId } from '@/shared/utils';
-import { CONSTRAINTS } from '@/core/constants';
+import { CONSTRAINTS, SHARED_PREVIEW_ID } from '@/core/constants';
 import { computePreview } from './preview';
 import { layoutId } from '@/core/types';
 import type {
@@ -540,7 +540,7 @@ export async function switchActiveLayout(
   // 2. Save current layout (skip if it's a shared preview or was deleted)
   let updatedLibrary = library;
   const fromEntry = library.entries.find((e) => e.id === fromId);
-  if (fromId !== '__shared_preview__' && fromEntry) {
+  if (fromId !== SHARED_PREVIEW_ID && fromEntry) {
     const saveResult = await saveLayoutWithMetadata(fromId, fromLayout, library);
     if (isErr(saveResult)) {
       // Current layout save failed - don't proceed with switch

--- a/src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.test.tsx
+++ b/src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.test.tsx
@@ -6,6 +6,7 @@ import { useLayoutStore } from '@/core/store/layout';
 import { useLibraryStore } from '@/core/store/library';
 import { useToastStore } from '@/core/store/toast';
 import type { Layout } from '@/core/types';
+import { SHARED_PREVIEW_ID } from '@/core/constants';
 
 // Hoisted mock for computePreview - used by both storage and library store re-export
 const { mockComputePreview } = vi.hoisted(() => ({
@@ -155,7 +156,7 @@ describe('SharedLayoutBanner', () => {
     // Reset layout store
     useLayoutStore.setState({
       layout: mockLayout,
-      activeLayoutId: '__shared_preview__',
+      activeLayoutId: SHARED_PREVIEW_ID,
     });
 
     // Reset library store

--- a/src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.tsx
+++ b/src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.tsx
@@ -93,7 +93,7 @@ export function SharedLayoutBanner() {
     const { layoutId: rawLayoutId, library: updatedLibrary } = result.value;
     const brandedLayoutId = toLayoutId(rawLayoutId);
 
-    // Update the layout store with the proper ID (not __shared_preview__)
+    // Update the layout store with the proper ID (not SHARED_PREVIEW_ID)
     importLayout(savedLayout, brandedLayoutId, 'init');
     setActiveLayoutId(brandedLayoutId);
 

--- a/src/features/cloud-share/components/SharedLayoutImporter/SharedLayoutImporter.tsx
+++ b/src/features/cloud-share/components/SharedLayoutImporter/SharedLayoutImporter.tsx
@@ -15,7 +15,7 @@ import {
 import { fetchShare } from '@/core/api/share';
 import { isOk, getUserMessage } from '@/core/result';
 import type { Layout, SharePermission, LayoutPreview } from '@/core/types';
-import { layoutId } from '@/core/types';
+import { SHARED_PREVIEW_ID } from '@/core/constants';
 import { useTranslation } from '@/i18n';
 
 // Check for shared layout once at module load time (URL-encoded shares)
@@ -123,7 +123,7 @@ export function SharedLayoutImporter() {
     (layout: Layout, authorName?: string, cloudShareId?: string, permission?: 'view' | 'edit') => {
       // Load the shared layout directly into the view
       // Use a temporary ID since it's not saved yet
-      importLayout(layout, layoutId('__shared_preview__'), 'init');
+      importLayout(layout, SHARED_PREVIEW_ID, 'init');
 
       // Set the preview state so the banner knows to show
       setSharedLayoutPreview(layout, layout.name, authorName, cloudShareId, permission);

--- a/src/features/cloud-share/hooks/useOwnedShareSync.test.ts
+++ b/src/features/cloud-share/hooks/useOwnedShareSync.test.ts
@@ -3,7 +3,7 @@ import { renderHook, act } from '@testing-library/react';
 import { useOwnedShareSync } from './useOwnedShareSync';
 import { useLayoutStore } from '@/core/store/layout';
 import { useLibraryStore } from '@/core/store/library';
-import { createDefaultLayout } from '@/core/constants';
+import { createDefaultLayout, SHARED_PREVIEW_ID } from '@/core/constants';
 import * as shareApi from '@/core/api/share';
 import { ok, err, apiServerError } from '@/core/result';
 import type { LayoutLibrary, CloudShareInfo, Layout } from '@/core/types';
@@ -141,7 +141,7 @@ describe('useOwnedShareSync', () => {
       });
 
       useLayoutStore.setState({
-        activeLayoutId: layoutId('__shared_preview__'),
+        activeLayoutId: SHARED_PREVIEW_ID,
         lastEditSource: 'local',
       });
 

--- a/src/features/cloud-share/hooks/useOwnedShareSync.ts
+++ b/src/features/cloud-share/hooks/useOwnedShareSync.ts
@@ -16,6 +16,7 @@ import { useLayoutStore } from '@/core/store/layout';
 import { useLibraryStore } from '@/core/store/library';
 import { updateShare } from '@/core/api/share';
 import { isOk } from '@/core/result';
+import { SHARED_PREVIEW_ID } from '@/core/constants';
 import { createLayoutFingerprint } from '@/features/cloud-share/utils';
 import type { CloudShareInfo } from '@/core/types';
 
@@ -91,7 +92,7 @@ export function useOwnedShareSync(): void {
     // 3. Not viewing a shared preview
     if (!cloudShare) return;
     if (lastEditSource !== 'local') return;
-    if (activeLayoutId === '__shared_preview__') return;
+    if (activeLayoutId === SHARED_PREVIEW_ID) return;
 
     // Clear existing timer
     if (debounceTimerRef.current) {

--- a/src/features/layout-library/hooks/useLayoutRouting.test.ts
+++ b/src/features/layout-library/hooks/useLayoutRouting.test.ts
@@ -8,6 +8,7 @@ import { resetAllStores } from '@/test/testUtils';
 import * as storage from '@/core/storage';
 import * as url from '@/utils/url';
 import * as validation from '@/shared/utils/validation';
+import { SHARED_PREVIEW_ID } from '@/core/constants';
 
 // Mock storage module
 vi.mock('@/core/storage', () => ({
@@ -352,7 +353,7 @@ describe('useLayoutRouting', () => {
     });
 
     it('skips URL update for __shared_preview__ layout', () => {
-      useLayoutStore.setState({ activeLayoutId: '__shared_preview__' });
+      useLayoutStore.setState({ activeLayoutId: SHARED_PREVIEW_ID });
 
       renderHook(() => useLayoutRouting());
 

--- a/src/features/layout-library/hooks/useLayoutRouting.ts
+++ b/src/features/layout-library/hooks/useLayoutRouting.ts
@@ -19,8 +19,7 @@ import {
   categoryId as toCategoryId,
 } from '@/core/types';
 import type { LayoutId } from '@/core/types';
-
-const SHARED_PREVIEW_ID = '__shared_preview__';
+import { SHARED_PREVIEW_ID } from '@/core/constants';
 
 /**
  * Hook that synchronizes the URL with the active layout.

--- a/src/features/snapshots/components/SnapshotHistory/SnapshotHistory.tsx
+++ b/src/features/snapshots/components/SnapshotHistory/SnapshotHistory.tsx
@@ -6,6 +6,7 @@ import { useHistoryStore } from '@/core/store/history';
 import { useSnapshotStore } from '@/core/store/snapshots';
 import { useToastStore } from '@/core/store/toast';
 import { restoreSnapshot, createLayoutEntry, deleteSnapshotById } from '@/core/storage';
+import { SHARED_PREVIEW_ID } from '@/core/constants';
 import { useTranslation } from '@/i18n';
 import { isOk } from '@/core/result';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
@@ -50,7 +51,7 @@ export function SnapshotHistory() {
 
   // Deferred delete: remove from UI immediately, delay IndexedDB deletion for undo window
   const pendingDeleteTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
-  const isEditable = activeLayoutId !== null && activeLayoutId !== '__shared_preview__';
+  const isEditable = activeLayoutId !== null && activeLayoutId !== SHARED_PREVIEW_ID;
 
   useEffect(() => {
     if (isEditable && activeLayoutId) {

--- a/src/hooks/useLayoutSwitcher.test.ts
+++ b/src/hooks/useLayoutSwitcher.test.ts
@@ -7,7 +7,7 @@ import { useSelectionStore } from '@/core/store/selection';
 import { useHistoryStore } from '@/core/store/history';
 import { useToastStore } from '@/core/store/toast';
 import { useSharedPreviewStore } from '@/core/store/sharedPreview';
-import { createDefaultLayout } from '@/core/constants';
+import { createDefaultLayout, SHARED_PREVIEW_ID } from '@/core/constants';
 import { resetAllStores, expectOk, expectErr } from '@/test/testUtils';
 import * as storage from '@/core/storage';
 import type { LayoutLibrary, LayoutEntry, Layout } from '@/core/types';
@@ -424,7 +424,7 @@ describe('useLayoutSwitcher', () => {
 
     it('skips saving when current layout is __shared_preview__', async () => {
       // Set current layout ID to shared preview
-      useLayoutStore.setState({ activeLayoutId: '__shared_preview__' });
+      useLayoutStore.setState({ activeLayoutId: SHARED_PREVIEW_ID });
 
       const { result } = renderHook(() => useLayoutSwitcher());
 

--- a/src/hooks/useLayoutSwitcher.ts
+++ b/src/hooks/useLayoutSwitcher.ts
@@ -21,7 +21,7 @@ import {
   renameLayoutEntry,
 } from '@/core/storage';
 import { setLayoutURL } from '@/utils/url';
-import { createLayoutWithSettings } from '@/core/constants';
+import { createLayoutWithSettings, SHARED_PREVIEW_ID, isRealLayoutId } from '@/core/constants';
 import { trackLayoutAction } from '@/shared/analytics/posthog';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
 import type {
@@ -90,7 +90,7 @@ export function useLayoutSwitcher() {
     const currentLayout = useLayoutStore.getState().layout;
     const currentLibrary = useLibraryStore.getState().library;
 
-    if (!currentActiveId || currentActiveId === '__shared_preview__') return;
+    if (!isRealLayoutId(currentActiveId)) return;
 
     const result = await saveLayoutWithMetadata(currentActiveId, currentLayout, currentLibrary);
     if (isErr(result)) {
@@ -131,7 +131,7 @@ export function useLayoutSwitcher() {
         const currentActiveId = useLayoutStore.getState().activeLayoutId;
         const currentLayout = useLayoutStore.getState().layout;
         const result = await switchActiveLayout(
-          currentActiveId || '__shared_preview__',
+          currentActiveId || SHARED_PREVIEW_ID,
           currentLayout,
           targetId,
           currentLibrary

--- a/src/hooks/useSnapshotAutoSave.test.ts
+++ b/src/hooks/useSnapshotAutoSave.test.ts
@@ -5,6 +5,7 @@ import { useLayoutStore } from '@/core/store/layout';
 import { useLibraryStore } from '@/core/store/library';
 import { useSnapshotStore } from '@/core/store/snapshots';
 import { createTestLayout, createTestLibrary } from '@/test/testUtils';
+import { SHARED_PREVIEW_ID } from '@/core/constants';
 import { layoutId } from '@/core/types';
 import type { Snapshot } from '@/core/types';
 
@@ -120,7 +121,7 @@ describe('useSnapshotAutoSave', () => {
     it('skips bootstrap for shared preview layouts', async () => {
       useLayoutStore.setState({
         layout: layoutWithBins,
-        activeLayoutId: layoutId('__shared_preview__'),
+        activeLayoutId: SHARED_PREVIEW_ID,
       });
 
       renderHook(() => useSnapshotAutoSave());
@@ -198,7 +199,7 @@ describe('useSnapshotAutoSave', () => {
 
     it('skips snapshot when activeLayoutId is __shared_preview__', async () => {
       useLayoutStore.setState({
-        activeLayoutId: layoutId('__shared_preview__'),
+        activeLayoutId: SHARED_PREVIEW_ID,
       });
 
       renderHook(() => useSnapshotAutoSave());

--- a/src/hooks/useSnapshotAutoSave.ts
+++ b/src/hooks/useSnapshotAutoSave.ts
@@ -12,6 +12,7 @@ import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
 import { useSnapshotStore } from '@/core/store/snapshots';
+import { isRealLayoutId } from '@/core/constants';
 import { scheduleIdleCallback, cancelIdleCallback } from '@/shared/utils';
 
 const SNAPSHOT_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
@@ -67,7 +68,7 @@ export function useSnapshotAutoSave(): void {
   // Bootstrap: create initial snapshot if none exist for this layout
   useEffect(() => {
     if (initialSnapshotCreatedRef.current) return;
-    if (!activeLayoutId || activeLayoutId === '__shared_preview__') return;
+    if (!isRealLayoutId(activeLayoutId)) return;
     if (layout.bins.length === 0) return;
 
     initialSnapshotCreatedRef.current = true;
@@ -98,7 +99,7 @@ export function useSnapshotAutoSave(): void {
       const currentLayoutId = activeLayoutIdRef.current;
 
       // Skip shared preview
-      if (!currentLayoutId || currentLayoutId === '__shared_preview__') {
+      if (!isRealLayoutId(currentLayoutId)) {
         return;
       }
 

--- a/src/shared/hooks/useAutoSave.test.ts
+++ b/src/shared/hooks/useAutoSave.test.ts
@@ -7,6 +7,7 @@ import { useToastStore } from '@/core/store/toast';
 import { resetAllStores, setupFakeTimers } from '@/test/testUtils';
 import * as storage from '@/core/storage';
 import { err, storageQuotaExceeded, storageUnavailable } from '@/core/result';
+import { SHARED_PREVIEW_ID } from '@/core/constants';
 
 // Mock the storage module with atomic API functions
 // Note: vi.mock is hoisted, so we must define the factory inline
@@ -304,7 +305,7 @@ describe('useAutoSave', () => {
 
     it('does not save when activeLayoutId is __shared_preview__', async () => {
       // Set activeLayoutId to shared preview (temporary layout)
-      useLayoutStore.setState({ activeLayoutId: '__shared_preview__' });
+      useLayoutStore.setState({ activeLayoutId: SHARED_PREVIEW_ID });
 
       renderHook(() => useAutoSave());
 

--- a/src/shared/hooks/useAutoSave.ts
+++ b/src/shared/hooks/useAutoSave.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore, useLibraryStore, useToastStore } from '@/core/store';
 import { saveLayoutWithMetadata } from '@/core/storage';
+import { SHARED_PREVIEW_ID } from '@/core/constants';
 import { scheduleIdleCallback, cancelIdleCallback } from '@/shared/utils';
 import { isErr, getUserMessage, isRetryable } from '@/core/result';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
@@ -69,7 +70,7 @@ export function useAutoSave(): SaveStatus {
     if (!activeLayoutId) return;
 
     // Don't save temporary shared preview layouts
-    if (activeLayoutId === '__shared_preview__') return;
+    if (activeLayoutId === SHARED_PREVIEW_ID) return;
 
     // Capture the layout ID we're saving for race condition detection
     const savingLayoutId = activeLayoutId;

--- a/src/shared/hooks/useSharedWithMe.ts
+++ b/src/shared/hooks/useSharedWithMe.ts
@@ -14,7 +14,7 @@ import { useSharedPreviewStore } from '@/core/store/sharedPreview';
 import { useHistoryStore } from '@/core/store/history';
 import { useToastStore } from '@/core/store/toast';
 import type { SharedWithMeEntry } from '@/core/types';
-import { layoutId as toLayoutId } from '@/core/types';
+import { SHARED_PREVIEW_ID } from '@/core/constants';
 import { fetchShare } from '@/core/api/share';
 import { isOk, getUserMessage } from '@/core/result';
 
@@ -137,7 +137,7 @@ export function useSharedWithMe(): SharedWithMeState & SharedWithMeActions {
       });
 
       // Load the layout into preview mode
-      importLayout(layout, toLayoutId('__shared_preview__'), 'init');
+      importLayout(layout, SHARED_PREVIEW_ID, 'init');
 
       // Set preview state so the banner shows
       setSharedLayoutPreview(


### PR DESCRIPTION
## Summary
- Extracts magic string `'__shared_preview__'` into `SHARED_PREVIEW_ID` constant in `core/constants.ts`, matching the existing `STAGING_ID` pattern
- Adds `isRealLayoutId()` type guard for simplified guard clauses
- Replaces all 17 occurrences across production and test files
- Removes the local duplicate constant from `useLayoutRouting.ts`

## Test plan
- [x] 151 affected tests pass
- [x] TypeScript build clean
- [x] All pre-commit hooks pass