### PR TITLE
refactor(storage): remove saveLayoutResult alias

### DIFF
--- a/src/core/storage/LayoutManager.ts
+++ b/src/core/storage/LayoutManager.ts
@@ -8,7 +8,7 @@
  * - Return Result<T, E> for explicit error handling
  *
  * This module consolidates the previously scattered pattern of:
- *   saveLayoutResult() → updateEntry() → saveLibraryResult()
+ *   saveLayoutAsync() → updateEntry() → saveLibrary()
  * into single atomic operations that are easier to use correctly.
  *
  * @example Save current layout:

--- a/src/core/storage/LayoutService.scenario.result.test.ts
+++ b/src/core/storage/LayoutService.scenario.result.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
-  saveLayoutResult,
+  saveLayoutAsync,
   loadLayoutResult,
   deleteLayoutResult,
   migrateFromLegacyStorageResult,
@@ -75,11 +75,11 @@ describe('Result-based storage functions', () => {
     vi.restoreAllMocks();
   });
 
-  describe('saveLayoutResult', () => {
+  describe('saveLayoutAsync', () => {
     it('returns Ok on successful save', async () => {
       vi.mocked(backend.saveAsync).mockResolvedValue(ok(undefined));
 
-      const result = await saveLayoutResult('test-id', defaultLayout);
+      const result = await saveLayoutAsync('test-id', defaultLayout);
 
       expectOk(result);
       expect(backend.saveAsync).toHaveBeenCalledWith(getLayoutStorageKey('test-id'), defaultLayout);
@@ -88,7 +88,7 @@ describe('Result-based storage functions', () => {
     it('returns Err with quota exceeded error', async () => {
       vi.mocked(backend.saveAsync).mockResolvedValue(err(storageQuotaExceeded()));
 
-      const result = await saveLayoutResult('test-id', defaultLayout);
+      const result = await saveLayoutAsync('test-id', defaultLayout);
 
       const error = expectErr(result);
       expect(error.code).toBe('STORAGE_QUOTA_EXCEEDED');
@@ -101,7 +101,7 @@ describe('Result-based storage functions', () => {
       const storageErr = storageQuotaExceeded(undefined, undefined, new Error('Disk full'));
       vi.mocked(backend.saveAsync).mockResolvedValue(err(storageErr));
 
-      const result = await saveLayoutResult('test-id', defaultLayout);
+      const result = await saveLayoutAsync('test-id', defaultLayout);
 
       const error = expectErr(result);
       expect(error.code).toBe('STORAGE_QUOTA_EXCEEDED');

--- a/src/core/storage/LayoutService.ts
+++ b/src/core/storage/LayoutService.ts
@@ -166,25 +166,6 @@ export async function deleteLayoutAsync(layoutId: string): Promise<void> {
 // Use these when you need detailed error information for user feedback.
 
 /**
- * Save a layout asynchronously with Result-based error handling.
- * Returns Ok on success, or Err with specific StorageError on failure.
- *
- * @example
- * ```ts
- * const result = await saveLayoutResult(id, layout);
- * if (isErr(result)) {
- *   addToast(getUserMessage(result.error), 'error');
- * }
- * ```
- */
-export async function saveLayoutResult(
-  layoutId: string,
-  layout: Layout
-): Promise<Result<void, StorageError>> {
-  return saveLayoutAsync(layoutId, layout);
-}
-
-/**
  * Load a layout asynchronously with Result-based error handling.
  * Returns Ok with the layout, or Err with specific StorageError.
  *

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -43,7 +43,7 @@ export { saveLayoutAsync, loadLayoutAsync, deleteLayoutAsync } from './LayoutSer
 
 // === Layout CRUD (Async - Result-Based) ===
 // Use these when you need explicit error handling with Result types
-export { saveLayoutResult, loadLayoutResult, deleteLayoutResult } from './LayoutService';
+export { loadLayoutResult, deleteLayoutResult } from './LayoutService';
 
 // === Layout CRUD (Sync - Initialization Only) ===
 // Use only during app startup when async is not available

--- a/src/shared/hooks/useAutoSave.test.ts
+++ b/src/shared/hooks/useAutoSave.test.ts
@@ -31,7 +31,6 @@ vi.mock('../../core/storage', () => {
     saveLibrary: vi.fn(),
     computeLayoutPreview: vi.fn(() => mockPreview),
     getLayoutStorageKey: vi.fn((id: string) => `gridfinity-layout-${id}`),
-    saveLayoutResult: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
     saveLibraryResult: vi.fn(() => ({ ok: true, value: undefined })),
     saveLayout: vi.fn(),
     loadLayout: vi.fn(),

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -434,7 +434,6 @@ export function createStorageMock() {
     deleteLayoutAsync: vi.fn().mockResolvedValue(undefined),
     saveLibrary: vi.fn(),
     getLayoutStorageKey: vi.fn((id: string) => `gridfinity-layout-${id}`),
-    saveLayoutResult: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
     exportLayout: vi.fn(),
     importLayout: vi.fn(),
     downloadLayoutAsFile: vi.fn(),


### PR DESCRIPTION
## Summary
- Removes `saveLayoutResult()` which was a pure pass-through to `saveLayoutAsync()` with identical signature
- Updates test file to call `saveLayoutAsync` directly
- Removes mock from test utilities
- Updates doc comment in LayoutManager.ts

## Test plan
- [x] TypeScript build passes
- [x] All 47 affected tests pass (LayoutService.scenario.result + useAutoSave)
- [x] Pre-commit hooks pass