### PR TITLE
refactor: replace inline bin layer filters with getLayerBins utility

### DIFF
--- a/src/components/Mobile/MobileLayersPanel/ToolsTab/ToolsTab.tsx
+++ b/src/components/Mobile/MobileLayersPanel/ToolsTab/ToolsTab.tsx
@@ -91,9 +91,7 @@ export function ToolsTab() {
     });
     closeMobilePanel();
     setTimeout(() => {
-      const afterCount = useLayoutStore
-        .getState()
-        .layout.bins.filter((b) => b.layerId === activeLayerId).length;
+      const afterCount = getLayerBins(useLayoutStore.getState().layout.bins, activeLayerId).length;
       const added = afterCount - beforeCount;
       if (added > 0) {
         addToast(t('toast.fillComplete', { count: added }), 'success');
@@ -123,9 +121,7 @@ export function ToolsTab() {
     setPaintSize(null);
     closeMobilePanel();
     setTimeout(() => {
-      const afterCount = useLayoutStore
-        .getState()
-        .layout.bins.filter((b) => b.layerId === activeLayerId).length;
+      const afterCount = getLayerBins(useLayoutStore.getState().layout.bins, activeLayerId).length;
       const added = afterCount - beforeCount;
       if (added > 0) {
         addToast(t('toast.fillWithSize', { count: added, width, depth }), 'success');

--- a/src/core/store/selectors.ts
+++ b/src/core/store/selectors.ts
@@ -12,6 +12,7 @@ import { useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { STAGING_ID } from '@/core/constants';
 import type { Bin, Layer, LayerId } from '@/core/types';
+import { getLayerBins } from '@/shared/utils/bins';
 import { useLayoutStore } from './layout';
 import { useSelectionStore } from './selection';
 
@@ -41,10 +42,7 @@ export function useActiveLayerBins(): Bin[] {
   const bins = useLayoutStore(selectBins);
   const activeLayerId = useSelectionStore((s) => s.activeLayerId);
 
-  return useMemo(() => {
-    if (activeLayerId === STAGING_ID) return [];
-    return bins.filter((b) => b.layerId === activeLayerId);
-  }, [bins, activeLayerId]);
+  return useMemo(() => getLayerBins(bins, activeLayerId), [bins, activeLayerId]);
 }
 
 /**

--- a/src/features/command-palette/components/CommandPalette/CommandPalette.tsx
+++ b/src/features/command-palette/components/CommandPalette/CommandPalette.tsx
@@ -20,7 +20,7 @@ import { useMutations } from '@/shared/contexts';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutSwitcher } from '@/hooks';
 import { COMMAND_DEFINITIONS, CATEGORY_LABELS, CATEGORY_ORDER } from '../../commands';
-import { getStagingBins } from '@/shared/utils';
+import { getStagingBins, getLayerBins } from '@/shared/utils';
 import { findBinById } from '@/utils/entity';
 import { STAGING_ID } from '@/core/constants';
 import { isOk, isErr } from '@/core/result';
@@ -119,7 +119,7 @@ function useActionHandlers(): Record<string, ActionHandler> {
   return useMemo(() => {
     const hasBinsSelected = selectedBinIds.length > 0;
     const hasSingleBin = selectedBinIds.length === 1;
-    const layerBins = layout.bins.filter((b) => b.layerId === activeLayerId);
+    const layerBins = getLayerBins(layout.bins, activeLayerId);
     const stagingBins = getStagingBins(layout.bins);
     const categories = layout.categories;
 

--- a/src/features/grid-editor/components/Grid/GridCanvas/GridCanvas.tsx
+++ b/src/features/grid-editor/components/Grid/GridCanvas/GridCanvas.tsx
@@ -6,6 +6,7 @@ import { useGridCoords, useGridTemplate } from '@/features/grid-editor/hooks';
 import { toPixels } from '@/features/grid-editor/utils/fractionalPixels';
 import { Bin } from '../Bin';
 import { getBlockedZones } from '@/shared/utils/collision';
+import { getLayerBins } from '@/shared/utils/bins';
 import { DEFAULT_CATEGORY_COLOR } from '@/core/constants';
 import type { Coord, ResizeHandle, BinId, LayerId } from '@/core/types';
 import { useTranslation } from '@/i18n';
@@ -64,10 +65,7 @@ export function GridCanvas({
   const { getGridCoords } = useGridCoords(gridRef);
 
   // Memoized: Filter bins for current layer
-  const activeBins = useMemo(
-    () => bins.filter((b) => b.layerId === activeLayerId),
-    [bins, activeLayerId]
-  );
+  const activeBins = useMemo(() => getLayerBins(bins, activeLayerId), [bins, activeLayerId]);
 
   // Memoized: Filter ghost bins (bins from layers below)
   const ghostBins = useMemo(() => {

--- a/src/features/layers/components/ActiveLayerPanel/ActiveLayerPanel.tsx
+++ b/src/features/layers/components/ActiveLayerPanel/ActiveLayerPanel.tsx
@@ -63,9 +63,7 @@ export function ActiveLayerPanel() {
       fillLayerGaps(activeLayerId, activeCategoryId, halfBinMode);
     });
     setTimeout(() => {
-      const afterCount = useLayoutStore
-        .getState()
-        .layout.bins.filter((b) => b.layerId === activeLayerId).length;
+      const afterCount = getLayerBins(useLayoutStore.getState().layout.bins, activeLayerId).length;
       const added = afterCount - beforeCount;
       if (added > 0) {
         addToast(t('toast.fillComplete', { count: added }), 'success');
@@ -94,9 +92,7 @@ export function ActiveLayerPanel() {
     // Exit paint mode after filling
     setPaintSize(null);
     setTimeout(() => {
-      const afterCount = useLayoutStore
-        .getState()
-        .layout.bins.filter((b) => b.layerId === activeLayerId).length;
+      const afterCount = getLayerBins(useLayoutStore.getState().layout.bins, activeLayerId).length;
       const added = afterCount - beforeCount;
       if (added > 0) {
         addToast(t('toast.fillWithSize', { count: added, width, depth }), 'success');

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -12,6 +12,7 @@ import {
 } from '@/core/store';
 import { useMutations } from '@/shared/contexts';
 import { canPlaceBin } from '@/shared/utils/validation';
+import { getLayerBins } from '@/shared/utils/bins';
 import { validateBinRotation } from '@/utils/binLocation';
 import { validateHalfBinModeToggle } from '@/utils/halfBinConstraints';
 import type { BinId } from '@/core/types';
@@ -288,9 +289,9 @@ export function useKeyboard() {
       // Bin selection cycling (A/D) - cycles through bins on current layer
       if (key.toLowerCase() === SHORTCUTS.SELECT_PREV_BIN && !ctrlOrMeta) {
         e.preventDefault();
-        const layerBins = layout.bins
-          .filter((b) => b.layerId === activeLayerId && b.layerId !== STAGING_ID)
-          .sort((a, b) => (a.y === b.y ? a.x - b.x : a.y - b.y)); // Sort by row then column
+        const layerBins = getLayerBins(layout.bins, activeLayerId).sort((a, b) =>
+          a.y === b.y ? a.x - b.x : a.y - b.y
+        ); // Sort by row then column
         if (layerBins.length === 0) return;
 
         const currentId = selectedBinIds[0];
@@ -301,9 +302,9 @@ export function useKeyboard() {
       }
       if (key.toLowerCase() === SHORTCUTS.SELECT_NEXT_BIN && !ctrlOrMeta) {
         e.preventDefault();
-        const layerBins = layout.bins
-          .filter((b) => b.layerId === activeLayerId && b.layerId !== STAGING_ID)
-          .sort((a, b) => (a.y === b.y ? a.x - b.x : a.y - b.y)); // Sort by row then column
+        const layerBins = getLayerBins(layout.bins, activeLayerId).sort((a, b) =>
+          a.y === b.y ? a.x - b.x : a.y - b.y
+        ); // Sort by row then column
         if (layerBins.length === 0) return;
 
         const currentId = selectedBinIds[0];


### PR DESCRIPTION
## Summary
- Replaces 8 instances of inline `.filter(b => b.layerId === activeLayerId)` with the existing `getLayerBins()` utility
- Affected files: selectors.ts, GridCanvas.tsx, CommandPalette.tsx, ToolsTab.tsx, ActiveLayerPanel.tsx, useKeyboard.ts
- No behavior change — `getLayerBins()` applies the same layer + staging filter

## Test plan
- [x] TypeScript build passes
- [x] 63 affected tests pass (selectors, GridCanvas, ActiveLayerPanel)
- [x] Pre-commit hooks pass