### PR TITLE
refactor(storage): replace inline LAYOUT_KEY_PREFIX concatenation with getLayoutStorageKey

### DIFF
--- a/src/core/storage/libraryUtils.ts
+++ b/src/core/storage/libraryUtils.ts
@@ -11,7 +11,7 @@
 import type { LayoutEntry, LayoutLibrary } from '@/core/types';
 import type { Result, StorageError } from '@/core/result';
 import { ok, err, storageNotFound } from '@/core/result';
-import { LAYOUT_KEY_PREFIX } from './storageKeys';
+import { getLayoutStorageKey } from './LayoutService';
 
 /**
  * Find a library entry by layout ID.
@@ -44,7 +44,7 @@ export function findLibraryEntryResult(
 ): Result<{ entry: LayoutEntry; index: number }, StorageError> {
   const found = findLibraryEntry(library, layoutId);
   if (!found) {
-    return err(storageNotFound(`${LAYOUT_KEY_PREFIX}${layoutId}`));
+    return err(storageNotFound(getLayoutStorageKey(layoutId)));
   }
   return ok(found);
 }
@@ -120,7 +120,7 @@ export function updateLibraryEntryById(
 ): Result<LayoutLibrary, StorageError> {
   const found = findLibraryEntry(library, layoutId);
   if (!found) {
-    return err(storageNotFound(`${LAYOUT_KEY_PREFIX}${layoutId}`));
+    return err(storageNotFound(getLayoutStorageKey(layoutId)));
   }
 
   return ok(updateLibraryEntryAtIndex(library, found.index, updates));
@@ -139,7 +139,7 @@ export function removeLibraryEntry(
 ): Result<LayoutLibrary, StorageError> {
   const found = findLibraryEntry(library, layoutId);
   if (!found) {
-    return err(storageNotFound(`${LAYOUT_KEY_PREFIX}${layoutId}`));
+    return err(storageNotFound(getLayoutStorageKey(layoutId)));
   }
 
   return ok({

--- a/src/core/storage/localStorageCleanup.ts
+++ b/src/core/storage/localStorageCleanup.ts
@@ -19,6 +19,7 @@ import * as localStorage from './backends/localStorage';
 import * as indexedDB from './backends/indexedDB';
 import { isIndexedDBAvailable } from './backends/indexedDB';
 import { LAYOUT_KEY_PREFIX, CLEANUP_FLAG_KEY } from './storageKeys';
+import { getLayoutStorageKey } from './LayoutService';
 
 function getCleanupFlag(): boolean {
   try {
@@ -91,7 +92,7 @@ export async function cleanupLocalStorageBackups(): Promise<CleanupStats | null>
   };
 
   for (const layoutId of localStorageIds) {
-    const prefixedKey = `${LAYOUT_KEY_PREFIX}${layoutId}`;
+    const prefixedKey = getLayoutStorageKey(layoutId);
     // Verify the layout actually loads from IndexedDB (not just key exists)
     // to avoid deleting localStorage backup when IndexedDB data is corrupt.
     const loaded = await indexedDB.loadLayout(prefixedKey);

--- a/src/core/storage/migration.ts
+++ b/src/core/storage/migration.ts
@@ -27,6 +27,7 @@ import {
   storageNetworkError,
 } from '@/core/result';
 import { LAYOUT_KEY_PREFIX, MIGRATION_FLAG_KEY } from './storageKeys';
+import { getLayoutStorageKey } from './LayoutService';
 
 // Result types
 interface MigrationResult {
@@ -66,7 +67,7 @@ function getLocalStorageLayoutIds(): string[] {
  * Load a layout from localStorage by ID.
  */
 function loadLayoutFromLocalStorage(layoutId: string): Layout | null {
-  const key = `${LAYOUT_KEY_PREFIX}${layoutId}`;
+  const key = getLayoutStorageKey(layoutId);
   const result = localStorage.loadLayout(key);
   return result.ok ? result.value : null;
 }
@@ -266,7 +267,7 @@ export async function migrateLayoutToIndexedDBResult(
     const layout = loadLayoutFromLocalStorage(layoutId);
 
     if (!layout) {
-      return err(storageNotFound(`${LAYOUT_KEY_PREFIX}${layoutId}`));
+      return err(storageNotFound(getLayoutStorageKey(layoutId)));
     }
 
     // Save to IndexedDB


### PR DESCRIPTION
## Summary
- Replaces 5 instances of inline `${LAYOUT_KEY_PREFIX}${layoutId}` with `getLayoutStorageKey(layoutId)` 
- Affected files: libraryUtils.ts, migration.ts, localStorageCleanup.ts
- `LAYOUT_KEY_PREFIX` is still exported for prefix-scanning operations (getAllLayoutIds, startsWith checks)

## Test plan
- [x] TypeScript build passes
- [x] All 16 libraryUtils tests pass
- [x] Pre-commit hooks pass