### PR TITLE
refactor: extract useLayoutActivation hook

### DIFF
--- a/src/features/cloud-share/components/SharedLayoutImporter/SharedLayoutImporter.tsx
+++ b/src/features/cloud-share/components/SharedLayoutImporter/SharedLayoutImporter.tsx
@@ -1,9 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { useLayoutStore } from '@/core/store/layout';
 import { useSharedPreviewStore } from '@/core/store/sharedPreview';
-import { useSelectionStore } from '@/core/store/selection';
-import { useInteractionStore } from '@/core/store/interaction';
-import { useHistoryStore } from '@/core/store/history';
 import { useToastStore } from '@/core/store/toast';
 import { useLibraryStore, computePreview } from '@/core/store/library';
 import { useSharedWithMeStore } from '@/core/store/sharedWithMe';
@@ -17,6 +13,7 @@ import { isOk, getUserMessage } from '@/core/result';
 import type { Layout, SharePermission, LayoutPreview } from '@/core/types';
 import { SHARED_PREVIEW_ID } from '@/core/constants';
 import { useTranslation } from '@/i18n';
+import { useLayoutActivation } from '@/hooks/useLayoutActivation';
 
 // Check for shared layout once at module load time (URL-encoded shares)
 const initialShareResult = getSharedLayoutFromURL();
@@ -38,13 +35,8 @@ export function SharedLayoutImporter() {
   // (not when there's just a URL ID - it might be a local layout)
   const [isLoading, setIsLoading] = useState(false);
 
-  const importLayout = useLayoutStore((state) => state.importLayout);
+  const { activateLayout } = useLayoutActivation();
   const setSharedLayoutPreview = useSharedPreviewStore((state) => state.setSharedLayoutPreview);
-  const setActiveLayer = useSelectionStore((state) => state.setActiveLayer);
-  const setActiveCategory = useSelectionStore((state) => state.setActiveCategory);
-  const clearSelection = useSelectionStore((state) => state.clearSelection);
-  const clearHistory = useHistoryStore((state) => state.clear);
-  const announceToScreenReader = useInteractionStore((state) => state.announceToScreenReader);
   const addToast = useToastStore((state) => state.addToast);
 
   // Library store
@@ -121,37 +113,10 @@ export function SharedLayoutImporter() {
   // Helper function to load a layout into preview
   const loadLayoutPreview = useCallback(
     (layout: Layout, authorName?: string, cloudShareId?: string, permission?: 'view' | 'edit') => {
-      // Load the shared layout directly into the view
-      // Use a temporary ID since it's not saved yet
-      importLayout(layout, SHARED_PREVIEW_ID, 'init');
-
-      // Set the preview state so the banner knows to show
+      activateLayout(layout, SHARED_PREVIEW_ID, `Viewing shared layout: ${layout.name}`);
       setSharedLayoutPreview(layout, layout.name, authorName, cloudShareId, permission);
-
-      // Reset UI state for the new layout
-      clearSelection();
-      if (layout.layers[0]) {
-        setActiveLayer(layout.layers[0].id);
-      }
-      if (layout.categories[0]) {
-        setActiveCategory(layout.categories[0].id);
-      }
-
-      // Clear undo history (can't undo into previous layout)
-      clearHistory();
-
-      // Announce for accessibility
-      announceToScreenReader(`Viewing shared layout: ${layout.name}`);
     },
-    [
-      importLayout,
-      setSharedLayoutPreview,
-      clearSelection,
-      setActiveLayer,
-      setActiveCategory,
-      clearHistory,
-      announceToScreenReader,
-    ]
+    [activateLayout, setSharedLayoutPreview]
   );
 
   // Track whether we've processed the URL share (persists through Strict Mode remounts)

--- a/src/hooks/useLayoutActivation.ts
+++ b/src/hooks/useLayoutActivation.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared hook for the "activate a layout" orchestration pattern.
+ *
+ * Four call-sites (SharedLayoutImporter, useSharedWithMe, useLayoutSwitcher)
+ * independently duplicated the same 5-step sequence:
+ *   importLayout → clearSelection → setActiveLayer → setActiveCategory → clearHistory
+ *
+ * This hook centralises that sequence so callers only need one function call.
+ */
+
+import { useCallback } from 'react';
+import { useLayoutStore } from '@/core/store/layout';
+import { useSelectionStore } from '@/core/store/selection';
+import { useHistoryStore } from '@/core/store/history';
+import { useInteractionStore } from '@/core/store/interaction';
+import { useShallow } from 'zustand/react/shallow';
+import type { Layout, LayoutId } from '@/core/types';
+
+/**
+ * Load a layout into the editor and reset all dependent UI state.
+ *
+ * @returns `activateLayout` — call with a layout, its ID, and an optional
+ *   accessibility announcement string.
+ */
+export function useLayoutActivation() {
+  const importLayout = useLayoutStore((s) => s.importLayout);
+
+  const { clearSelection, setActiveLayer, setActiveCategory } = useSelectionStore(
+    useShallow((s) => ({
+      clearSelection: s.clearSelection,
+      setActiveLayer: s.setActiveLayer,
+      setActiveCategory: s.setActiveCategory,
+    }))
+  );
+
+  const clearHistory = useHistoryStore((s) => s.clear);
+  const announceToScreenReader = useInteractionStore((s) => s.announceToScreenReader);
+
+  const activateLayout = useCallback(
+    (layout: Layout, layoutId: LayoutId, announcement?: string) => {
+      importLayout(layout, layoutId, 'init');
+
+      clearSelection();
+      if (layout.layers[0]) {
+        setActiveLayer(layout.layers[0].id);
+      }
+      if (layout.categories[0]) {
+        setActiveCategory(layout.categories[0].id);
+      }
+
+      clearHistory();
+
+      if (announcement) {
+        announceToScreenReader(announcement);
+      }
+    },
+    [
+      importLayout,
+      clearSelection,
+      setActiveLayer,
+      setActiveCategory,
+      clearHistory,
+      announceToScreenReader,
+    ]
+  );
+
+  return { activateLayout };
+}

--- a/src/hooks/useLayoutSwitcher.ts
+++ b/src/hooks/useLayoutSwitcher.ts
@@ -1,16 +1,11 @@
 import { useCallback, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
-import {
-  useLibraryStore,
-  useHistoryStore,
-  useToastStore,
-  useSettingsStore,
-  useSelectionStore,
-} from '@/core/store';
+import { useLibraryStore, useToastStore, useSettingsStore } from '@/core/store';
 import { useSharedPreviewStore } from '@/core/store/sharedPreview';
 import type { Layout, LayoutId } from '@/core/types';
-import { layoutId, layerId, categoryId } from '@/core/types';
+import { layoutId } from '@/core/types';
+import { useLayoutActivation } from '@/hooks/useLayoutActivation';
 import { isErr, isOk } from '@/core/result';
 import {
   saveLayoutWithMetadata,
@@ -43,14 +38,11 @@ export function useLayoutSwitcher() {
   const t = useTranslation();
   const pendingSaveRef = useRef<number | null>(null);
 
-  // Layout store
-  // Note: layout is accessed via getState() in callbacks to avoid stale closures
-  const { activeLayoutId, importLayout } = useLayoutStore(
-    useShallow((state) => ({
-      activeLayoutId: state.activeLayoutId,
-      importLayout: state.importLayout,
-    }))
-  );
+  // Layout activation hook (importLayout + UI reset + history clear)
+  const { activateLayout } = useLayoutActivation();
+
+  // Layout store (activeLayoutId for return value; getState() used in callbacks)
+  const activeLayoutId = useLayoutStore((state) => state.activeLayoutId);
 
   // Library store
   const { library, getEntry, setLibrary } = useLibraryStore(
@@ -58,18 +50,6 @@ export function useLayoutSwitcher() {
       library: state.library,
       getEntry: state.getEntry,
       setLibrary: state.setLibrary,
-    }))
-  );
-
-  // History store
-  const clearHistory = useHistoryStore((state) => state.clear);
-
-  // Selection store
-  const { clearSelection, setActiveLayer, setActiveCategory } = useSelectionStore(
-    useShallow((state) => ({
-      clearSelection: state.clearSelection,
-      setActiveLayer: state.setActiveLayer,
-      setActiveCategory: state.setActiveCategory,
     }))
   );
 
@@ -142,19 +122,11 @@ export function useLayoutSwitcher() {
           return result;
         }
 
-        // 5. Update stores with result
+        // 5. Update stores and activate layout
         setLibrary(result.value.library);
-        importLayout(result.value.targetLayout, targetId, 'init');
+        activateLayout(result.value.targetLayout, targetId);
 
-        // 6. Reset UI state
-        clearSelection();
-        setActiveLayer(result.value.targetLayout.layers[0]?.id ?? layerId(''));
-        setActiveCategory(result.value.targetLayout.categories[0]?.id ?? categoryId(''));
-
-        // 7. Clear undo history
-        clearHistory();
-
-        // 8. Update URL with slug
+        // 6. Update URL with slug
         setLayoutURL(targetId, result.value.targetLayout.name, true);
 
         // 9. Track analytics
@@ -178,11 +150,7 @@ export function useLayoutSwitcher() {
       // Note: activeLayoutId, layout, library removed - we use fresh state via getState()
       getEntry,
       setLibrary,
-      importLayout,
-      clearSelection,
-      setActiveLayer,
-      setActiveCategory,
-      clearHistory,
+      activateLayout,
       clearSharedLayoutPreview,
       addToast,
       t,
@@ -221,17 +189,10 @@ export function useLayoutSwitcher() {
           return result;
         }
 
-        // Update stores
+        // Update stores and activate layout
         setLibrary(result.value.library);
         const newLayoutId = layoutId(result.value.layoutId);
-        importLayout(result.value.layout, newLayoutId, 'init');
-
-        // Reset UI state
-        clearSelection();
-        setActiveLayer(result.value.layout.layers[0]?.id ?? layerId(''));
-        setActiveCategory(result.value.layout.categories[0]?.id ?? categoryId(''));
-
-        clearHistory();
+        activateLayout(result.value.layout, newLayoutId);
 
         setLayoutURL(newLayoutId, result.value.layout.name, true);
 
@@ -248,11 +209,7 @@ export function useLayoutSwitcher() {
       saveCurrentLayout,
       // Note: library removed - we use fresh state via getState()
       setLibrary,
-      importLayout,
-      clearSelection,
-      setActiveLayer,
-      setActiveCategory,
-      clearHistory,
+      activateLayout,
       addToast,
       settings,
       t,

--- a/src/shared/hooks/useSharedWithMe.ts
+++ b/src/shared/hooks/useSharedWithMe.ts
@@ -7,16 +7,14 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { computePreview } from '@/core/store/library';
 import { useSharedWithMeStore } from '@/core/store/sharedWithMe';
-import { useLayoutStore } from '@/core/store/layout';
-import { useSelectionStore } from '@/core/store/selection';
 import { useInteractionStore } from '@/core/store/interaction';
 import { useSharedPreviewStore } from '@/core/store/sharedPreview';
-import { useHistoryStore } from '@/core/store/history';
 import { useToastStore } from '@/core/store/toast';
 import type { SharedWithMeEntry } from '@/core/types';
 import { SHARED_PREVIEW_ID } from '@/core/constants';
 import { fetchShare } from '@/core/api/share';
 import { isOk, getUserMessage } from '@/core/result';
+import { useLayoutActivation } from '@/hooks/useLayoutActivation';
 
 export type SharedWithMeStatus = 'idle' | 'loading' | 'error';
 
@@ -63,26 +61,14 @@ export function useSharedWithMe(): SharedWithMeState & SharedWithMeActions {
     }))
   );
 
-  // Layout store
-  const importLayout = useLayoutStore((state) => state.importLayout);
+  // Layout activation hook (importLayout + UI reset + history clear)
+  const { activateLayout } = useLayoutActivation();
 
-  // Selection store
-  const { setActiveLayer, setActiveCategory, clearSelection } = useSelectionStore(
-    useShallow((state) => ({
-      setActiveLayer: state.setActiveLayer,
-      setActiveCategory: state.setActiveCategory,
-      clearSelection: state.clearSelection,
-    }))
-  );
-
-  // Interaction store
+  // Interaction store (still needed for removeLayout announcement)
   const announceToScreenReader = useInteractionStore((state) => state.announceToScreenReader);
 
   // Shared preview store
   const setSharedLayoutPreview = useSharedPreviewStore((state) => state.setSharedLayoutPreview);
-
-  // History store
-  const clearHistory = useHistoryStore((state) => state.clear);
 
   // Toast store
   const addToast = useToastStore((state) => state.addToast);
@@ -136,8 +122,8 @@ export function useSharedWithMe(): SharedWithMeState & SharedWithMeActions {
         status: 'available',
       });
 
-      // Load the layout into preview mode
-      importLayout(layout, SHARED_PREVIEW_ID, 'init');
+      // Load layout and reset UI state
+      activateLayout(layout, SHARED_PREVIEW_ID, `Opened shared layout: ${layout.name}`);
 
       // Set preview state so the banner shows
       setSharedLayoutPreview(
@@ -148,35 +134,10 @@ export function useSharedWithMe(): SharedWithMeState & SharedWithMeActions {
         permission
       );
 
-      // Reset UI state
-      clearSelection();
-      if (layout.layers[0]) {
-        setActiveLayer(layout.layers[0].id);
-      }
-      if (layout.categories[0]) {
-        setActiveCategory(layout.categories[0].id);
-      }
-
-      // Clear undo history
-      clearHistory();
-
-      // Announce for accessibility
-      announceToScreenReader(`Opened shared layout: ${layout.name}`);
-
       setStatus('idle');
       return true;
     },
-    [
-      updateSharedWithMe,
-      importLayout,
-      setSharedLayoutPreview,
-      clearSelection,
-      setActiveLayer,
-      setActiveCategory,
-      clearHistory,
-      announceToScreenReader,
-      addToast,
-    ]
+    [updateSharedWithMe, activateLayout, setSharedLayoutPreview, addToast]
   );
 
   /**


### PR DESCRIPTION
## Summary

- Extracts the duplicated 5-step layout activation pattern (`importLayout → clearSelection → setActiveLayer → setActiveCategory → clearHistory`) into a shared `useLayoutActivation` hook
- Consolidates 4 call-sites across 3 files into single `activateLayout()` calls
- Each consumer drops 4-5 individual store subscriptions, reducing coupling and boilerplate

### Files changed

| File | Change |
|------|--------|
| `src/hooks/useLayoutActivation.ts` | **New** — shared hook with `activateLayout(layout, layoutId, announcement?)` |
| `SharedLayoutImporter.tsx` | `loadLayoutPreview` reduced from 30 → 2 lines; removed 5 store imports |
| `useSharedWithMe.ts` | Removed `useLayoutStore`, `useSelectionStore`, `useHistoryStore` imports |
| `useLayoutSwitcher.ts` | Simplified `switchLayout` and `createNewLayout` activation sequences |

## Test plan

- [x] TypeScript builds cleanly
- [x] All 8614 tests pass
- [x] ESLint clean on all changed files
- [ ] CI passes