### PR TITLE
fix: restore locateFile override for WASM loading in ES module workers

### DIFF
--- a/src/features/generation/worker/wasmInstantiator.test.ts
+++ b/src/features/generation/worker/wasmInstantiator.test.ts
@@ -17,6 +17,14 @@ vi.mock('brepjs-opencascade/src/brepjs_threaded.js', () => ({
   default: (...args: unknown[]) => mockThreadedInit(...args),
 }));
 
+// Mock WASM URL imports
+vi.mock('brepjs-opencascade/src/brepjs_single.wasm?url', () => ({
+  default: '/mocked/brepjs_single.wasm',
+}));
+vi.mock('brepjs-opencascade/src/brepjs_threaded.wasm?url', () => ({
+  default: '/mocked/brepjs_threaded.wasm',
+}));
+
 // Mock wasmCapabilities (always single-threaded in tests/dev)
 vi.mock('@/shared/generation/wasmCapabilities', () => ({
   detectWasmCapabilities: () => ({ supportsThreads: false }),
@@ -35,7 +43,17 @@ describe('wasmInstantiator', () => {
     const result = await loadOpenCascade();
 
     expect(mockSingleInit).toHaveBeenCalledTimes(1);
-    expect(mockSingleInit).toHaveBeenCalledWith();
+    expect(mockSingleInit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        locateFile: expect.any(Function),
+      })
+    );
+
+    // Verify locateFile returns the resolved WASM URL for .wasm paths
+    const { locateFile } = mockSingleInit.mock.calls[0][0] as { locateFile: (p: string) => string };
+    expect(locateFile('brepjs_single.wasm')).toBe('/mocked/brepjs_single.wasm');
+    expect(locateFile('other.js')).toBe('other.js');
+
     expect(result.isThreaded).toBe(false);
     expect(result.hardwareConcurrency).toBeGreaterThan(0);
   });

--- a/src/features/generation/worker/wasmInstantiator.ts
+++ b/src/features/generation/worker/wasmInstantiator.ts
@@ -3,6 +3,11 @@
  *
  * Selects threaded vs single-threaded WASM based on browser capabilities
  * and initialises the brepjs kernel.
+ *
+ * The Emscripten-generated JS uses environment detection (window, importScripts)
+ * to locate the .wasm file. In Vite's ES module workers, neither exists, so the
+ * WASM path resolves incorrectly. We provide an explicit locateFile override using
+ * Vite's ?url imports to ensure the correct path in all environments.
  */
 
 import { initFromOC } from 'brepjs';
@@ -13,6 +18,10 @@ import opencascadeSingleInit from 'brepjs-opencascade/src/brepjs_single.js';
 
 // Multi-threaded WASM (conditionally loaded)
 import opencascadeThreadedInit from 'brepjs-opencascade/src/brepjs_threaded.js';
+
+// Resolved WASM binary URLs (Vite handles asset path resolution)
+import singleWasmUrl from 'brepjs-opencascade/src/brepjs_single.wasm?url';
+import threadedWasmUrl from 'brepjs-opencascade/src/brepjs_threaded.wasm?url';
 
 export interface WasmLoadResult {
   /** Whether multi-threaded WASM is being used */
@@ -51,7 +60,16 @@ export async function loadOpenCascade(): Promise<WasmLoadResult> {
   const isThreaded = detectThreadingSupport();
   const hardwareConcurrency = getHardwareConcurrency();
 
-  const OC = isThreaded ? await opencascadeThreadedInit() : await opencascadeSingleInit();
+  // Pass locateFile to override Emscripten's broken path resolution in ES module workers.
+  // The init functions are typed as () => Promise but the underlying Emscripten factory
+  // still accepts a Module config object.
+  const wasmUrl = isThreaded ? threadedWasmUrl : singleWasmUrl;
+  const moduleConfig = {
+    locateFile: (path: string) => (path.endsWith('.wasm') ? wasmUrl : path),
+  };
+
+  const initFn = isThreaded ? opencascadeThreadedInit : opencascadeSingleInit;
+  const OC = await (initFn as (config: typeof moduleConfig) => Promise<unknown>)(moduleConfig);
 
   initFromOC(OC);
 


### PR DESCRIPTION
## Summary

- Fixes 3D engine init failure (`module doesn't start with '\0asm'`) introduced by the brepjs upgrade in #992
- The Emscripten-generated JS fails to locate `.wasm` files in Vite's ES module workers (no `window` or `importScripts` → empty `scriptDirectory` → fetch hits server root → HTML returned instead of WASM binary)
- Restores a `locateFile` override using Vite's `?url` imports to provide correct WASM paths in all environments

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds (WASM files emitted with content hashes)
- [x] Unit tests pass with locateFile verification
- [ ] Dev server: bin designer / baseplate generator loads without "doesn't start with '\0asm'" error