### PR TITLE
fix: polyfill Symbol.dispose for brepjs compat with Safari/older browsers

### DIFF
--- a/src/features/generation/worker/generation.worker.ts
+++ b/src/features/generation/worker/generation.worker.ts
@@ -11,6 +11,9 @@
  * - CANCEL -> (silently aborts current generation)
  */
 
+// Must be first import — polyfills Symbol.dispose before brepjs loads
+import './symbolDisposePolyfill';
+
 import type { WorkerMessage, WorkerResponse, MeshData } from '../bridge/types';
 import { generateBin, exportBin, exportSplitBin } from './generators/binGenerator';
 import { exportDividers } from './generators/dividerExport';

--- a/src/features/generation/worker/symbolDisposePolyfill.ts
+++ b/src/features/generation/worker/symbolDisposePolyfill.ts
@@ -1,0 +1,19 @@
+/**
+ * Polyfill for Symbol.dispose / Symbol.asyncDispose.
+ *
+ * brepjs 8.x uses TC39 Explicit Resource Management (`using` keyword).
+ * esbuild compiles this with a `__using` helper that falls back to
+ * `Symbol.for("Symbol.dispose")` when the native well-known symbol is absent.
+ * However, class definitions in *other* chunks use raw `Symbol.dispose` directly,
+ * which is `undefined` in unsupported browsers (Safari, older Firefox/Chrome).
+ * This causes "Object not disposable" errors at runtime.
+ *
+ * This polyfill bridges the gap by assigning the same fallback symbol that
+ * esbuild's `__knownSymbol` helper uses, so both paths agree.
+ *
+ * MUST be imported before any brepjs code (including transitive imports).
+ */
+
+const S = Symbol as unknown as Record<string, symbol | undefined>;
+S.dispose ??= Symbol.for('Symbol.dispose');
+S.asyncDispose ??= Symbol.for('Symbol.asyncDispose');


### PR DESCRIPTION
## Summary

- Fixes "Object not disposable" error during mesh generation after the brepjs 8.x upgrade (#992)
- brepjs uses TC39 Explicit Resource Management (`using` keyword), compiled by esbuild with a polyfill that falls back to `Symbol.for("Symbol.dispose")`. But class definitions in separate chunks use raw `Symbol.dispose` — `undefined` in Safari and older browsers — causing a key mismatch
- Adds a one-liner polyfill imported before any brepjs code in the Web Worker

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] All 435 generation tests pass
- [ ] Dev server: bin designer generates meshes without "Object not disposable" error
- [ ] Safari: generation works (previously broken with any brepjs 8.x)