### PR TITLE
fix: retry WASM worker init on failure and fix preload warning

### DIFF
--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -117,6 +117,9 @@ export class GenerationBridge {
   /**
    * Initialize the worker. Resolves when the worker signals INIT_READY.
    * Safe to call multiple times (returns cached promise).
+   *
+   * Retries once on failure to recover from transient network errors,
+   * CDN edge cache misses, and service worker update races.
    */
   init(): Promise<void> {
     if (this.destroyed) {
@@ -127,7 +130,28 @@ export class GenerationBridge {
       return this.initPromise;
     }
 
-    this.initPromise = new Promise<void>((resolve, reject) => {
+    this.initPromise = this.tryInit().catch((firstError: unknown) => {
+      // Tear down the failed worker before retrying
+      this.worker?.terminate();
+      this.worker = null;
+
+      if (this.destroyed) throw firstError;
+
+      return this.tryInit().catch((retryError: unknown) => {
+        // Both attempts failed — throw the retry error (more recent/relevant)
+        // but preserve the first error for diagnostics
+        const message = retryError instanceof Error ? retryError.message : String(retryError);
+        const firstMessage = firstError instanceof Error ? firstError.message : String(firstError);
+        throw new Error(`${message} (first attempt: ${firstMessage})`);
+      });
+    });
+
+    return this.initPromise;
+  }
+
+  /** Single init attempt: create worker, send INIT, wait for INIT_READY. */
+  private tryInit(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
       try {
         this.worker = new Worker(new URL('../worker/generation.worker.ts', import.meta.url), {
           type: 'module',
@@ -147,7 +171,14 @@ export class GenerationBridge {
 
         this.worker.addEventListener('message', onInitMessage);
         this.worker.addEventListener('error', (e) => {
-          reject(new Error(`Worker failed to initialize: ${e.message}`));
+          // When a worker script fails to load (network error, CSP block, missing module),
+          // the ErrorEvent.message is often empty. Build a diagnostic message from whatever
+          // fields are available so the error is actionable in telemetry.
+          const detail =
+            e.message ||
+            (e.filename ? `loading ${e.filename}${e.lineno ? `:${e.lineno}` : ''}` : '') ||
+            'script failed to load (possible network error, CSP restriction, or unsupported browser)';
+          reject(new Error(`Worker failed to initialize: ${detail}`));
         });
 
         this.postMessage({ type: 'INIT' });
@@ -155,8 +186,6 @@ export class GenerationBridge {
         reject(new Error(`Failed to create worker: ${e instanceof Error ? e.message : String(e)}`));
       }
     });
-
-    return this.initPromise;
   }
 
   /**

--- a/src/shared/generation/wasmPreload.test.ts
+++ b/src/shared/generation/wasmPreload.test.ts
@@ -20,12 +20,14 @@ vi.mock('@/shared/generation/wasmCapabilities', () => ({
 import { detectWasmCapabilities } from '@/shared/generation/wasmCapabilities';
 const mockDetectWasmCapabilities = vi.mocked(detectWasmCapabilities);
 
+// Capture fetch calls made by preloadWasmBinary
+const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response());
+
 describe('preloadWasmBinary', () => {
   beforeEach(() => {
     // Reset module registry so `preloaded` flag starts as false each test
     vi.resetModules();
-    // Clear any link elements injected by previous tests
-    document.head.innerHTML = '';
+    fetchSpy.mockClear();
     // Clear call history and reset to threaded default; individual tests override as needed
     mockDetectWasmCapabilities.mockClear();
     mockDetectWasmCapabilities.mockReturnValue({
@@ -35,26 +37,20 @@ describe('preloadWasmBinary', () => {
     });
   });
 
-  it('injects a <link rel="preload" as="fetch"> element into document.head', async () => {
+  it('calls fetch() with the WASM URL and same-origin credentials', async () => {
+    const { preloadWasmBinary } = await import('./wasmPreload');
+    preloadWasmBinary();
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy).toHaveBeenCalledWith('/mock-threaded.wasm', { credentials: 'same-origin' });
+  });
+
+  it('does not inject any <link rel="preload"> elements', async () => {
     const { preloadWasmBinary } = await import('./wasmPreload');
     preloadWasmBinary();
 
     const links = document.head.querySelectorAll('link[rel="preload"]');
-    expect(links).toHaveLength(1);
-
-    const link = links[0] as HTMLLinkElement;
-    expect(link.rel).toBe('preload');
-    // jsdom reflects `as` as a property — getAttribute returns null for non-standard attributes
-    expect(link.as).toBe('fetch');
-  });
-
-  it('sets crossOrigin to "anonymous" on the injected link', async () => {
-    const { preloadWasmBinary } = await import('./wasmPreload');
-    preloadWasmBinary();
-
-    const link = document.head.querySelector('link[rel="preload"]');
-    expect(link).not.toBeNull();
-    expect((link as HTMLLinkElement).crossOrigin).toBe('anonymous');
+    expect(links).toHaveLength(0);
   });
 
   it('uses threaded WASM URL when supportsThreads is true', async () => {
@@ -67,9 +63,7 @@ describe('preloadWasmBinary', () => {
     const { preloadWasmBinary } = await import('./wasmPreload');
     preloadWasmBinary();
 
-    const link = document.head.querySelector('link[rel="preload"]');
-    expect(link).not.toBeNull();
-    expect((link as HTMLLinkElement).href).toContain('mock-threaded.wasm');
+    expect(fetchSpy).toHaveBeenCalledWith('/mock-threaded.wasm', { credentials: 'same-origin' });
   });
 
   it('uses single WASM URL when supportsThreads is false', async () => {
@@ -82,19 +76,16 @@ describe('preloadWasmBinary', () => {
     const { preloadWasmBinary } = await import('./wasmPreload');
     preloadWasmBinary();
 
-    const link = document.head.querySelector('link[rel="preload"]');
-    expect(link).not.toBeNull();
-    expect((link as HTMLLinkElement).href).toContain('mock-single.wasm');
+    expect(fetchSpy).toHaveBeenCalledWith('/mock-single.wasm', { credentials: 'same-origin' });
   });
 
-  it('is idempotent — second call does not inject a second link element', async () => {
+  it('is idempotent — second call does not fetch again', async () => {
     const { preloadWasmBinary } = await import('./wasmPreload');
 
     preloadWasmBinary();
     preloadWasmBinary();
 
-    const links = document.head.querySelectorAll('link[rel="preload"]');
-    expect(links).toHaveLength(1);
+    expect(fetchSpy).toHaveBeenCalledOnce();
   });
 
   it('is idempotent — second call does not call detectWasmCapabilities again', async () => {
@@ -113,12 +104,31 @@ describe('preloadWasmBinary', () => {
 
     const { preloadWasmBinary } = await import('./wasmPreload');
 
-    // First call fails — no link injected
+    // First call fails — no fetch
     preloadWasmBinary();
-    expect(document.head.querySelectorAll('link[rel="preload"]')).toHaveLength(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
 
-    // Second call succeeds — link injected
+    // Second call succeeds — fetch issued
     preloadWasmBinary();
-    expect(document.head.querySelectorAll('link[rel="preload"]')).toHaveLength(1);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it('resets preloaded flag on fetch failure so a later call can retry', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('network error'));
+
+    const { preloadWasmBinary } = await import('./wasmPreload');
+
+    preloadWasmBinary();
+    // Wait for the rejected promise to settle
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledOnce();
+    });
+
+    // Allow microtask for the .catch() handler to reset preloaded
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Second call should retry
+    preloadWasmBinary();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/shared/generation/wasmPreload.ts
+++ b/src/shared/generation/wasmPreload.ts
@@ -1,9 +1,12 @@
 /**
- * Preloads the OpenCascade WASM binary during idle time.
+ * Primes the HTTP cache with the OpenCascade WASM binary during idle time.
  *
- * Injects a `<link rel="preload">` tag so the browser fetches the binary
- * before any worker requests it, eliminating the network waterfall when
- * the user navigates to the bin designer or baseplate generator.
+ * Uses a background fetch() instead of <link rel="preload"> because the WASM
+ * is consumed by a Web Worker, not the document. Preload hints track usage at
+ * the document level and emit "not used within a few seconds" warnings when
+ * the resource is only consumed cross-context (by a worker). A plain fetch
+ * with the same credentials mode Emscripten uses ensures the HTTP cache entry
+ * is reusable by the worker without warnings or CORS-mode mismatches.
  */
 
 import singleWasm from 'brepjs-opencascade/src/brepjs_single.wasm?url';
@@ -14,17 +17,16 @@ let preloaded = false;
 
 export function preloadWasmBinary(): void {
   if (preloaded) return;
-  if (typeof document === 'undefined' || !document.head) return;
 
   try {
     const url = detectWasmCapabilities().supportsThreads ? threadedWasm : singleWasm;
 
-    const link = document.createElement('link');
-    link.rel = 'preload';
-    link.as = 'fetch';
-    link.crossOrigin = 'anonymous';
-    link.href = url;
-    document.head.appendChild(link);
+    // Fire-and-forget fetch that mirrors Emscripten's credentials mode.
+    // The response is discarded — we only care about priming the HTTP cache.
+    void fetch(url, { credentials: 'same-origin' }).catch(() => {
+      // Network failure is non-fatal; the worker will attempt its own fetch.
+      preloaded = false;
+    });
 
     preloaded = true;
   } catch {


### PR DESCRIPTION
## Summary
- **Retry on init failure**: `GenerationBridge.init()` now retries once when the worker fails to initialize, recovering from transient network errors, CDN edge cache misses, and service worker update races
- **Better error diagnostics**: Extracts `filename`/`lineno` from `ErrorEvent` when `message` is empty (the cause of `"Uncaught [object Event]"` in PostHog)
- **Fix WASM preload warning**: Replaces `<link rel="preload">` with a plain `fetch()` for cache priming — the preload was consumed by the worker (not the document), causing browser warnings and potential CORS-mode cache key mismatches

Fixes: `Failed to initialize 3D engine: Worker failed to initialize: Uncaught [object Event]` on `/baseplate`

## Test plan
- [x] `GenerationBridge` tests pass (18 tests)
- [x] `BridgeManager` tests pass (19 tests)
- [x] `wasmPreload` tests updated and pass (8 tests)
- [x] `usePrefetchChunks` tests pass (9 tests)
- [x] TypeScript compiles cleanly
- [x] All pre-commit hooks pass (lint, i18n, boundaries, exhaustiveness, tests)