### PR TITLE
feat: add half-lap wall connectors for thin walls

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.split-connectors.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-connectors.test.ts
@@ -341,4 +341,99 @@ describe('split connector geometry in preview meshes', () => {
     const cols = result.pieces.map((p) => p.col).sort();
     expect(cols).toEqual([1, 2, 3]);
   }, 90000);
+
+  it('half-lap joints at 1.2mm walls produce geometry changes (cuts visible)', () => {
+    const withConnectors = generateSplitPreview(
+      OVERSIZED_PARAMS,
+      CUT_PLANES_X,
+      CUT_PLANES_Y,
+      DEFAULT_SPLIT_CONNECTOR_CONFIG
+    );
+    const withoutConnectors = generateSplitPreview(
+      OVERSIZED_PARAMS,
+      CUT_PLANES_X,
+      CUT_PLANES_Y,
+      DISABLED_CONFIG
+    );
+
+    // Half-lap cuts into walls create additional internal faces → more triangles
+    const trisWithConn = withConnectors.pieces.reduce((s, p) => s + p.indices.length / 3, 0);
+    const trisWithout = withoutConnectors.pieces.reduce((s, p) => s + p.indices.length / 3, 0);
+    expect(trisWithConn).toBeGreaterThan(trisWithout);
+
+    // Both pieces should have valid geometry
+    for (const piece of withConnectors.pieces) {
+      expect(hasNoNaNOrInfinity(piece.vertices)).toBe(true);
+      expect(piece.vertices.length).toBeGreaterThan(100);
+    }
+  }, 60000);
+
+  it('half-lap at 1.2mm walls produces less X-extension than T&G at 1.6mm', () => {
+    // At 1.2mm walls, half-lap is subtractive for walls (only floor tongue protrudes).
+    // At 1.6mm walls, T&G adds both wall AND floor tongues.
+    // The 1.2mm half-lap male piece should extend less than the 1.6mm T&G male piece.
+    const thinResult = generateSplitPreview(
+      OVERSIZED_PARAMS,
+      CUT_PLANES_X,
+      CUT_PLANES_Y,
+      DEFAULT_SPLIT_CONNECTOR_CONFIG
+    );
+    const thickParams: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 8,
+      depth: 2,
+      height: 3,
+      wallThickness: 1.6,
+    };
+    const thickResult = generateSplitPreview(
+      thickParams,
+      CUT_PLANES_X,
+      CUT_PLANES_Y,
+      DEFAULT_SPLIT_CONNECTOR_CONFIG
+    );
+
+    const thinMale = thinResult.pieces.find((p) => p.col === 1);
+    const thickMale = thickResult.pieces.find((p) => p.col === 1);
+    expect(thinMale).toBeDefined();
+    expect(thickMale).toBeDefined();
+
+    const thinMaxX = boundingBox(thinMale!.vertices).maxX;
+    const thickMaxX = boundingBox(thickMale!.vertices).maxX;
+
+    // T&G adds wall tongues that extend further; half-lap only has floor tongue
+    expect(thinMaxX).toBeLessThan(thickMaxX + TESS_TOL);
+  }, 60000);
+
+  it('tongue-and-groove activates at 1.6mm walls (male extends past cut face)', () => {
+    const thickWallParams: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 7,
+      depth: 3,
+      height: 3,
+      wallThickness: 1.6,
+    };
+    const withConnectors = generateSplitPreview(
+      thickWallParams,
+      CUT_PLANES_X,
+      CUT_PLANES_Y,
+      DEFAULT_SPLIT_CONNECTOR_CONFIG
+    );
+    const withoutConnectors = generateSplitPreview(thickWallParams, CUT_PLANES_X, CUT_PLANES_Y, {
+      ...DEFAULT_SPLIT_CONNECTOR_CONFIG,
+      enabled: false,
+    });
+
+    const maleWith = withConnectors.pieces.find((p) => p.col === 1);
+    const maleWithout = withoutConnectors.pieces.find((p) => p.col === 1);
+    expect(maleWith).toBeDefined();
+    expect(maleWithout).toBeDefined();
+
+    const bbWith = boundingBox(maleWith!.vertices);
+    const bbWithout = boundingBox(maleWithout!.vertices);
+
+    // T&G is additive: male piece should extend beyond cut face
+    const protrusion = DEFAULT_SPLIT_CONNECTOR_CONFIG.tongueProtrusion;
+    const extensionX = bbWith.maxX - bbWithout.maxX;
+    expect(extensionX).toBeGreaterThan(protrusion - TESS_TOL - 0.5);
+  }, 60000);
 });

--- a/src/features/generation/worker/generators/splitConnectorBuilder.ts
+++ b/src/features/generation/worker/generators/splitConnectorBuilder.ts
@@ -4,7 +4,9 @@
  * Generates tongue-and-groove features on cut faces so split bin pieces
  * can be quickly aligned and glued together:
  *
- * - Wall tongues: vertical tongues at each outer wall edge with 55° chamfers
+ * - Wall connectors: auto-selected by wall thickness:
+ *   - Thin walls (< 1.4mm): half-lap joints (each piece keeps half the wall)
+ *   - Thick walls (≥ 1.4mm): tongue-and-groove with 55° chamfers
  * - Floor tongue: horizontal tongue centered in the floor slab with 55° chamfers.
  *   Top taper is invisible (swallowed by existing floor material on fuse).
  *
@@ -60,6 +62,16 @@ const EPSILON = 1e-9;
  *  cot(max_overhang_angle_from_vertical).
  *  0.7 → 55° overhang (safe on most modern printers with PLA). */
 const CHAMFER_SLOPE = 0.7;
+
+/** Wall thickness threshold (mm) for auto-selecting joint style.
+ *  Below this: half-lap joints (cut-based, works at any wall thickness).
+ *  At or above: tongue-and-groove joints (additive, needs room for tongue). */
+const HALF_LAP_WALL_THRESHOLD = 1.4;
+
+/** Clearance per side (mm) for half-lap joints.
+ *  Tighter than T&G (0.15mm) because the lap surfaces are planar and
+ *  don't need wiggle room for tapered insertion. */
+const HALF_LAP_CLEARANCE = 0.1;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -329,6 +341,61 @@ function addFeature(
   }
 }
 
+// ─── Half-Lap Wall Joint ────────────────────────────────────────────────────
+
+/**
+ * Build a half-lap cut for a wall at the cut face.
+ *
+ * Instead of adding a protruding tongue (which needs room inside the wall),
+ * half-lap joints cut away half the wall thickness near the cut face:
+ * - Male piece: inner half removed → outer tab remains, overlaps female
+ * - Female piece: outer half removed → inner surface remains, receives male tab
+ *
+ * Both sides are subtractive (push to cutTargets only). The overlap zone
+ * is `lapDepth` deep from the cut face on each piece.
+ */
+function addHalfLapWallFeature(
+  face: CutFace,
+  cutTargets: Shape3D[],
+  lapDepth: number,
+  wallHeight: number,
+  bottomZ: number,
+  edgePos: number,
+  wallThickness: number
+): void {
+  const sign = Math.sign(edgePos);
+  const halfWt = wallThickness / 2;
+  const cutWidth = halfWt + HALF_LAP_CLEARANCE;
+
+  if (face.isMale) {
+    // Cut INNER half of wall: keeps outer tab exposed for overlap
+    cutTargets.push(
+      buildPrism(
+        face.axis,
+        face.position - lapDepth - OVERLAP,
+        lapDepth + 2 * OVERLAP,
+        cutWidth,
+        wallHeight,
+        bottomZ,
+        edgePos - (sign * halfWt) / 2
+      )
+    );
+  } else {
+    // Cut OUTER half of wall: keeps inner surface as mating face
+    cutTargets.push(
+      buildPrism(
+        face.axis,
+        face.position - OVERLAP,
+        lapDepth + 2 * OVERLAP,
+        cutWidth,
+        wallHeight,
+        bottomZ,
+        edgePos + (sign * halfWt) / 2
+      )
+    );
+  }
+}
+
 // ─── Tongue & Groove Features ────────────────────────────────────────────────
 
 function addTongueAndGroove(
@@ -347,29 +414,51 @@ function addTongueAndGroove(
   const pieceMin = face.pieceCenterOffset - face.pieceEdgeLength / 2;
   const pieceMax = face.pieceCenterOffset + face.pieceEdgeLength / 2;
 
-  // ── Wall tongues (at outer bin walls only) ─────────────────────────────
-  // Tongue width is capped at tongueThickness but reduced to fit within
-  // the wall groove. Skip if the reduced size is below MIN_FEATURE_WIDTH.
-  const maxGrooveWidth = wt - 2 * MIN_SHELL;
-  const tongueWidth = Math.min(config.tongueThickness, maxGrooveWidth - 2 * config.clearance);
+  // ── Wall connectors (at outer bin walls only) ──────────────────────────
+  // Auto-select joint style based on wall thickness:
+  // - Thin walls (< 1.4mm): half-lap joints (subtractive, always viable)
+  // - Thick walls (≥ 1.4mm): tongue-and-groove (additive, needs room)
+  const useHalfLap = wt < HALF_LAP_WALL_THRESHOLD;
 
-  if (tongueWidth >= MIN_FEATURE_WIDTH - EPSILON) {
+  if (useHalfLap) {
+    // Half-lap: cut away half the wall thickness near the cut face
     for (const edgePos of [-wallOffset, wallOffset]) {
       if (edgePos < pieceMin || edgePos > pieceMax) continue;
       const nearCut = face.perpendicularCuts.some((cp) => Math.abs(edgePos - cp) < wt * 2);
       if (nearCut) continue;
-      addFeature(
+      addHalfLapWallFeature(
         face,
-        config.clearance,
-        fuseTargets,
         cutTargets,
         config.tongueProtrusion,
-        tongueWidth,
         wallHeight,
         context.floorZ,
         edgePos,
-        true
+        wt
       );
+    }
+  } else {
+    // Tongue-and-groove: additive tongue with matching groove
+    const maxGrooveWidth = wt - 2 * MIN_SHELL;
+    const tongueWidth = Math.min(config.tongueThickness, maxGrooveWidth - 2 * config.clearance);
+
+    if (tongueWidth >= MIN_FEATURE_WIDTH - EPSILON) {
+      for (const edgePos of [-wallOffset, wallOffset]) {
+        if (edgePos < pieceMin || edgePos > pieceMax) continue;
+        const nearCut = face.perpendicularCuts.some((cp) => Math.abs(edgePos - cp) < wt * 2);
+        if (nearCut) continue;
+        addFeature(
+          face,
+          config.clearance,
+          fuseTargets,
+          cutTargets,
+          config.tongueProtrusion,
+          tongueWidth,
+          wallHeight,
+          context.floorZ,
+          edgePos,
+          true
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds half-lap wall joints that auto-activate when wall thickness < 1.4mm, solving the problem where tongue-and-groove connectors were skipped at the default 1.2mm wall thickness (tongue too thin for OCCT booleans)
- Half-lap cuts away half the wall thickness near the cut face — male keeps outer half, female keeps inner half — providing wall alignment without requiring additive features
- Floor tongue remains unchanged and supplements the wall joint at all thicknesses

## Design

- **Threshold:** `wt < 1.4mm` → half-lap; `wt >= 1.4mm` → tongue-and-groove (existing)
- **Geometry:** 50/50 split, `config.tongueProtrusion` depth (3mm), 0.10mm clearance per side
- **Scope:** Wall edges only, full wall height, lip left intact
- **Visibility:** Fully automatic — no UI changes or new config fields

## Test plan

- [x] 3 new scenario tests: half-lap geometry changes at 1.2mm, less extension than T&G, T&G activates at 1.6mm
- [x] All 209 existing scenario tests pass
- [x] Typecheck clean
- [x] Build succeeds