### PR TITLE
fix: make half-lap connectors work with stacking lip

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.split-connectors.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-connectors.test.ts
@@ -21,13 +21,21 @@ const CLEARANCE = GRIDFINITY.TOLERANCE;
 /** Tessellation tolerance — geometry vertices may deviate from exact CAD by this amount. */
 const TESS_TOL = 0.3;
 
-/** 8×2×3 bin with default 1.2mm walls. At this thickness (< 1.4mm),
- *  half-lap wall connectors are used; at ≥ 1.4mm, tongue-and-groove. */
+/** 8×2×3 bin with default 1.2mm walls and stacking lip.
+ *  Half-lap wall connectors are skipped when stacking lip is present
+ *  (lip flange prevents interlocking assembly). */
 const OVERSIZED_PARAMS: BinParams = {
   ...DEFAULT_BIN_PARAMS,
   width: 8,
   depth: 2,
   height: 3,
+};
+
+/** Same dimensions but WITHOUT stacking lip — half-lap wall connectors
+ *  are used at < 1.4mm wall thickness. */
+const OVERSIZED_NO_LIP: BinParams = {
+  ...OVERSIZED_PARAMS,
+  base: { ...OVERSIZED_PARAMS.base, stackingLip: false },
 };
 
 const CUT_PLANES_X = [0];
@@ -289,7 +297,7 @@ describe('split connector geometry in preview meshes', () => {
     expect(cols).toEqual([1, 2, 3]);
   }, 90000);
 
-  it('half-lap joints at 1.2mm walls produce geometry changes (cuts visible)', () => {
+  it('half-lap joints at 1.2mm walls produce geometry changes', () => {
     const generateSplitPreview = getGenerateSplitPreview();
     const withConnectors = generateSplitPreview(
       OVERSIZED_PARAMS,
@@ -304,7 +312,7 @@ describe('split connector geometry in preview meshes', () => {
       DISABLED_CONFIG
     );
 
-    // Half-lap cuts into walls create additional internal faces → more triangles
+    // Half-lap cuts into walls + lip create additional internal faces → more triangles
     const trisWithConn = withConnectors.pieces.reduce((s, p) => s + p.indices.length / 3, 0);
     const trisWithout = withoutConnectors.pieces.reduce((s, p) => s + p.indices.length / 3, 0);
     expect(trisWithConn).toBeGreaterThan(trisWithout);
@@ -354,6 +362,55 @@ describe('split connector geometry in preview meshes', () => {
     // T&G adds wall tongues that extend further; half-lap only has floor tongue
     expect(thinMaxX).toBeLessThan(thickMaxX + TESS_TOL);
   }, 60000);
+
+  it('half-lap wall cuts extend through stacking lip (lip + thin walls)', () => {
+    const generateSplitPreview = getGenerateSplitPreview();
+    // With lip + thin walls + connectors: half-lap cuts extend through the lip
+    // so both halves interlock when assembled.
+    const withConn = generateSplitPreview(
+      OVERSIZED_PARAMS,
+      CUT_PLANES_X,
+      CUT_PLANES_Y,
+      DEFAULT_SPLIT_CONNECTOR_CONFIG
+    );
+    const withoutConn = generateSplitPreview(
+      OVERSIZED_PARAMS,
+      CUT_PLANES_X,
+      CUT_PLANES_Y,
+      DISABLED_CONFIG
+    );
+
+    for (const piece of withConn.pieces) {
+      expect(hasNoNaNOrInfinity(piece.vertices)).toBe(true);
+      expect(piece.vertices.length).toBeGreaterThan(100);
+    }
+
+    // Half-lap cuts through wall + lip produce more triangles than no connectors
+    const trisConn = withConn.pieces.reduce((s, p) => s + p.indices.length / 3, 0);
+    const trisNoConn = withoutConn.pieces.reduce((s, p) => s + p.indices.length / 3, 0);
+    expect(trisConn).toBeGreaterThan(trisNoConn);
+
+    // The lip-extended cuts should produce MORE geometry delta than no-lip cuts,
+    // because the cut prism is taller (wall + 4.4mm lip vs wall only).
+    const noLipConn = generateSplitPreview(
+      OVERSIZED_NO_LIP,
+      CUT_PLANES_X,
+      CUT_PLANES_Y,
+      DEFAULT_SPLIT_CONNECTOR_CONFIG
+    );
+    const noLipNoConn = generateSplitPreview(
+      OVERSIZED_NO_LIP,
+      CUT_PLANES_X,
+      CUT_PLANES_Y,
+      DISABLED_CONFIG
+    );
+
+    const lipDelta = trisConn - trisNoConn;
+    const noLipDelta =
+      noLipConn.pieces.reduce((s, p) => s + p.indices.length / 3, 0) -
+      noLipNoConn.pieces.reduce((s, p) => s + p.indices.length / 3, 0);
+    expect(lipDelta).toBeGreaterThan(noLipDelta);
+  }, 90000);
 
   it('tongue-and-groove activates at 1.6mm walls (male extends past cut face)', () => {
     const generateSplitPreview = getGenerateSplitPreview();

--- a/src/features/generation/worker/generators/binGenerator.ts
+++ b/src/features/generation/worker/generators/binGenerator.ts
@@ -742,6 +742,8 @@ function splitSolidIntoPieces(
           wallTopZ,
           wallThickness: params.wallThickness,
           floorThickness: params.wallThickness,
+          lipHeight: hasLip ? GRIDFINITY.LIP_HEIGHT : 0,
+          lipTaperWidth: hasLip ? LIP_TAPER_WIDTH : 0,
         };
         piece = applySplitConnectors(piece, cutFaces, geometryContext, connectorConfig);
       }

--- a/src/features/generation/worker/generators/splitConnectorBuilder.ts
+++ b/src/features/generation/worker/generators/splitConnectorBuilder.ts
@@ -96,6 +96,14 @@ export interface BinGeometryContext {
   /** Floor slab thickness (mm). Equal to wallThickness from the shell operation,
    *  but decoupled so floor tongue sizing is independent of wall changes. */
   readonly floorThickness: number;
+  /** Stacking lip height (mm). 0 when no lip is present, 4.4mm with a lip.
+   *  Half-lap wall cuts extend through the lip so both halves interlock
+   *  when the split pieces are assembled. */
+  readonly lipHeight: number;
+  /** Stacking lip inward taper width (mm). 0 when no lip is present, 2.6mm with a lip.
+   *  The lip extends this far inward from the outer bin edge. On the male side,
+   *  the half-lap cut must be widened to remove the full inner lip overhang. */
+  readonly lipTaperWidth: number;
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────
@@ -344,47 +352,99 @@ function addFeature(
 // ─── Half-Lap Wall Joint ────────────────────────────────────────────────────
 
 /**
- * Build a half-lap cut for a wall at the cut face.
+ * Build an overlapping half-lap joint for a wall at the cut face.
  *
- * Instead of adding a protruding tongue (which needs room inside the wall),
- * half-lap joints cut away half the wall thickness near the cut face:
- * - Male piece: inner half removed → outer tab remains, overlaps female
- * - Female piece: outer half removed → inner surface remains, receives male tab
+ * Each piece gets two features:
+ * 1. A **cut** (subtractive) removing the opposing half of wall+lip for lapDepth
+ *    from the cut face, creating a recess for the other piece's tab.
+ * 2. A **tab** (additive) extending its own half of the wall past the cut face
+ *    by lapDepth, filling the opposing piece's recess.
  *
- * Both sides are subtractive (push to cutTargets only). The overlap zone
- * is `lapDepth` deep from the cut face on each piece.
+ * Male piece: outer tab extends past cut face, inner half is cut away.
+ * Female piece: inner tab extends past cut face, outer half is cut away.
+ *
+ * When a stacking lip is present, the cut extends through the lip height
+ * (and is widened on the male side to cover the lip's inner overhang).
+ * The tab covers only the wall zone — the lip's tapered profile can't be
+ * approximated by a rectangular prism, so the lip zone has just the step
+ * for glue surface area.
  */
 function addHalfLapWallFeature(
   face: CutFace,
+  fuseTargets: Shape3D[],
   cutTargets: Shape3D[],
   lapDepth: number,
   wallHeight: number,
+  lipHeight: number,
   bottomZ: number,
   edgePos: number,
-  wallThickness: number
+  wallThickness: number,
+  lipTaperWidth: number
 ): void {
   if (edgePos === 0) return; // Wall coincides with bin center — no meaningful lap joint
   const sign = Math.sign(edgePos);
   const halfWt = wallThickness / 2;
-  const cutWidth = halfWt + 2 * HALF_LAP_CLEARANCE;
-  // Male: cut INNER half (toward bin center) — outer tab remains for overlap
-  // Female: cut OUTER half (toward bin edge) — inner surface receives male tab
-  const quarterShift = (sign * halfWt) / 2;
   const isMale = face.isMale;
-  const sketchPos = isMale ? face.position - lapDepth - OVERLAP : face.position - OVERLAP;
-  const depthExtra = isMale ? 0 : HALF_LAP_CLEARANCE;
+
+  // ── Subtractive: remove opposing half of wall + lip ─────────────────────
+  // Male cut must be wide enough for the lip's inner overhang.
+  // Female cut covers the outer half — halfWt from centerline suffices.
+  const totalHeight = wallHeight + lipHeight;
+  const cutExtent = isMale && lipTaperWidth > 0 ? lipTaperWidth - halfWt : halfWt;
+  const cutWidth = cutExtent + 2 * HALF_LAP_CLEARANCE;
+  const cutShift = (sign * cutExtent) / 2;
+
+  // Both sides need depthExtra so the opposing tab doesn't bottom out.
+  const cutSketchPos = isMale
+    ? face.position - lapDepth - HALF_LAP_CLEARANCE - OVERLAP
+    : face.position - OVERLAP;
+  const cutDepth = lapDepth + HALF_LAP_CLEARANCE + 2 * OVERLAP;
 
   cutTargets.push(
     buildPrism(
       face.axis,
-      sketchPos,
-      lapDepth + depthExtra + 2 * OVERLAP,
+      cutSketchPos,
+      cutDepth,
       cutWidth,
-      wallHeight,
+      totalHeight,
       bottomZ,
-      edgePos + (isMale ? -quarterShift : quarterShift)
+      edgePos + (isMale ? -cutShift : cutShift)
     )
   );
+
+  // ── Additive: extend own half of the wall past the cut face ─────────────
+  // Tab covers only the wall zone (rectangular prism matches the wall).
+  // The lip zone gets the subtractive step above for glue surface.
+  const tabWidth = halfWt;
+  const tabShift = (sign * halfWt) / 2;
+
+  if (isMale) {
+    // Male tab: outer half of wall extending into female territory
+    fuseTargets.push(
+      buildPrism(
+        face.axis,
+        face.position - OVERLAP,
+        lapDepth + OVERLAP,
+        tabWidth,
+        wallHeight,
+        bottomZ,
+        edgePos + tabShift
+      )
+    );
+  } else {
+    // Female tab: inner half of wall extending into male territory
+    fuseTargets.push(
+      buildPrism(
+        face.axis,
+        face.position - lapDepth,
+        lapDepth + OVERLAP,
+        tabWidth,
+        wallHeight,
+        bottomZ,
+        edgePos - tabShift
+      )
+    );
+  }
 }
 
 // ─── Tongue & Groove Features ────────────────────────────────────────────────
@@ -425,12 +485,15 @@ function addTongueAndGroove(
       if (useHalfLap) {
         addHalfLapWallFeature(
           face,
+          fuseTargets,
           cutTargets,
           config.tongueProtrusion,
           wallHeight,
+          context.lipHeight,
           context.floorZ,
           edgePos,
-          wt
+          wt,
+          context.lipTaperWidth
         );
       } else {
         addFeature(


### PR DESCRIPTION
## Summary
- Half-lap wall connectors (for thin walls <1.4mm) were purely subtractive, so split pieces just butted at the cut face with no overlap. With a stacking lip, the 2.6mm taper also blocked physical assembly.
- Changed half-lap joints to true interlocking: each piece now gets both a recess (cut) and a tab (fuse) extending past the cut face. Cuts extend through the full wall+lip height; male-side cut is widened to clear the lip overhang.
- Added `lipHeight` and `lipTaperWidth` to `BinGeometryContext` so the connector builder knows lip dimensions.

## Test plan
- [x] All 210 scenario tests pass (split-connectors, split-robustness, core scenarios, split-connectors lip test)
- [x] New test: "half-lap wall cuts extend through stacking lip" verifies lip-aware cuts produce more geometry delta than no-lip cuts
- [x] TypeScript compiles cleanly (`npm run build`)
- [x] Visual confirmation via Playwright: assembled/exploded/wireframe views show correct interlocking geometry