### PR TITLE
fix: move baseplate export button next to tool switcher

### DIFF
--- a/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
+++ b/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
@@ -148,51 +148,49 @@ export function BaseplatePage() {
   return (
     <div className="flex h-screen flex-col bg-surface">
       {/* Header */}
-      <header className="h-12 flex items-center justify-between px-4 bg-surface-secondary border-b border-stroke-subtle overflow-hidden">
+      <header className="h-12 flex items-center gap-3 px-4 bg-surface-secondary border-b border-stroke-subtle overflow-hidden">
         <ToolSwitcher compact={isMobile} iconOnly={isMobile || isTablet} />
 
-        <div className="flex items-center flex-shrink-0">
-          <button
-            onClick={() => setExportDialogOpen(true)}
-            disabled={!canExport || isExporting}
-            className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-content-secondary transition-all bg-transparent hover:bg-surface-hover hover:text-content disabled:opacity-50 disabled:pointer-events-none"
-            title={t('common.export')}
-            aria-label={t('common.export')}
-          >
-            {isExporting ? (
-              <svg
-                className="h-4 w-4 animate-spin motion-reduce:animate-none"
-                fill="none"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                />
-              </svg>
-            ) : (
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
-                />
-              </svg>
-            )}
-            <span className="hidden lg:inline">{t('common.export')}</span>
-          </button>
-        </div>
+        <button
+          onClick={() => setExportDialogOpen(true)}
+          disabled={!canExport || isExporting}
+          className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-content-secondary transition-all bg-transparent hover:bg-surface-hover hover:text-content disabled:opacity-50 disabled:pointer-events-none"
+          title={t('common.export')}
+          aria-label={t('common.export')}
+        >
+          {isExporting ? (
+            <svg
+              className="h-4 w-4 animate-spin motion-reduce:animate-none"
+              fill="none"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+              />
+            </svg>
+          ) : (
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+              />
+            </svg>
+          )}
+          <span className="hidden lg:inline">{t('common.export')}</span>
+        </button>
       </header>
 
       {/* Main content — 4 responsive states */}


### PR DESCRIPTION
## Summary
- Moves the export button from the far-right of the header to directly beside the tool switcher for better discoverability
- Removes unnecessary wrapper div and replaces `justify-between` with `gap-3` spacing

## Test plan
- [x] Existing BaseplatePage tests pass (5/5)
- [ ] Verify export button renders next to tool switcher on desktop, tablet, and mobile