### PR TITLE
fix: default cutout editor to rectangle tool on open

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.test.ts
@@ -37,9 +37,9 @@ describe('useCutoutInteraction', () => {
     vi.clearAllMocks();
   });
 
-  it('starts in idle mode with empty selection', () => {
+  it('starts in rectangle placing mode with empty selection', () => {
     const { result } = renderHook(() => useCutoutInteraction(defaultOpts));
-    expect(result.current.mode).toEqual({ type: 'idle' });
+    expect(result.current.mode).toEqual({ type: 'placing', shape: 'rectangle' });
     expect(result.current.selection.size).toBe(0);
   });
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.ts
@@ -266,7 +266,7 @@ export function useCutoutInteraction({
   const addToast = useToastStore((s) => s.addToast);
   const t = useTranslation();
 
-  const [mode, setMode] = useState<InteractionMode>({ type: 'idle' });
+  const [mode, setMode] = useState<InteractionMode>({ type: 'placing', shape: 'rectangle' });
   const [selection, setSelection] = useState<ReadonlySet<string>>(new Set());
   const [preview, setPreview] = useState<PreviewMap>(new Map());
   const [snapEnabled, setSnapEnabled] = useState(true);


### PR DESCRIPTION
## Summary
- Default the cutout editor to the rectangle drawing tool instead of the pointer/idle mode when opening
- Reduces friction since rectangle is the most common cutout shape — users can start drawing immediately

## Test plan
- [x] Unit tests updated and passing (43/43)
- [ ] Open cutout editor and verify rectangle tool is highlighted/active
- [ ] Verify click-and-drag immediately creates a rectangle cutout
- [ ] Verify switching to other tools (circle, pen, pointer) still works