### PR TITLE
docs: link Gridfinity to Zack Freedman's YouTube channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gridfinity Layout Tool
 
-Plan and design [Gridfinity](https://www.printables.com/model/274917-gridfinity-specification) drawer organizer layouts for 3D printing — right in your browser.
+Plan and design [Gridfinity](https://www.youtube.com/c/ZackFreedman) drawer organizer layouts for 3D printing — right in your browser.
 
 **Live:** [gridfinitylayouttool.com](https://gridfinitylayouttool.com)
 


### PR DESCRIPTION
## Summary
- Updates the Gridfinity link in the README from the Printables model page to Zack Freedman's YouTube channel, consistent with the links used throughout the app

## Test plan
- [ ] Verify link in README points to https://www.youtube.com/c/ZackFreedman