### PR TITLE
fix: UX audit — dynamic modal title and seed changelog entries

### DIFF
--- a/src/components/Modals/HelpModal/HelpModal.tsx
+++ b/src/components/Modals/HelpModal/HelpModal.tsx
@@ -258,7 +258,7 @@ export function HelpModal({ isOpen, onClose, isTablet = false }: HelpModalProps)
           {/* Header */}
           <div className="flex justify-between items-center p-6 pb-4 border-b border-stroke-subtle">
             <h2 id="help-title" style={STYLES.title}>
-              {t('help.title')}
+              {activeTab === 'changelog' ? t('changelog.whatsNew') : t('help.title')}
             </h2>
             <button
               onClick={onClose}

--- a/src/features/engagement/changelog.ts
+++ b/src/features/engagement/changelog.ts
@@ -25,6 +25,20 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     titleKey: 'changelog.v20260308.title',
     itemKeys: ['changelog.v20260308.item1', 'changelog.v20260308.item2'],
   },
+  {
+    version: '2026-02-15',
+    titleKey: 'changelog.v20260215.title',
+    itemKeys: [
+      'changelog.v20260215.item1',
+      'changelog.v20260215.item2',
+      'changelog.v20260215.item3',
+    ],
+  },
+  {
+    version: '2026-01-20',
+    titleKey: 'changelog.v20260120.title',
+    itemKeys: ['changelog.v20260120.item1', 'changelog.v20260120.item2'],
+  },
 ];
 
 const CHANGELOG_STORAGE_KEY = 'gridfinity-changelog-seen';

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1473,5 +1473,12 @@
   "changelog.noEntries": "Noch keine Updates.",
   "changelog.v20260308.title": "Community-Engagement",
   "changelog.v20260308.item1": "Engagement-Hinweise hinzugef\u00fcgt \u2014 Feedback- und Unterst\u00fctzungsaufforderungen f\u00fcr aktive Nutzer.",
-  "changelog.v20260308.item2": "Neuigkeiten-\u00c4nderungsprotokoll hinzugef\u00fcgt \u2014 sieh die neuesten \u00c4nderungen direkt hier."
+  "changelog.v20260308.item2": "Neuigkeiten-\u00c4nderungsprotokoll hinzugef\u00fcgt \u2014 sieh die neuesten \u00c4nderungen direkt hier.",
+  "changelog.v20260215.title": "Bin Designer-Verbesserungen",
+  "changelog.v20260215.item1": "Cutouts im Bin Designer horizontal und vertikal spiegeln.",
+  "changelog.v20260215.item2": "Half-lap-Wandverbinder f\u00fcr d\u00fcnne W\u00e4nde \u2014 st\u00e4rkere Drucke mit weniger Material.",
+  "changelog.v20260215.item3": "Ausrichtungsverbinder beim Export geteilter Bins f\u00fcr einfacheren Zusammenbau.",
+  "changelog.v20260120.title": "Speicher & Zuverl\u00e4ssigkeit",
+  "changelog.v20260120.item1": "Snapshot-Verlauf mit automatischem Speichern \u2014 fr\u00fchere Versionen deiner Layouts wiederherstellen.",
+  "changelog.v20260120.item2": "Alle Layouts auf einmal exportieren und importieren f\u00fcr einfaches Backup."
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1820,6 +1820,15 @@ const en: Record<string, string> = {
   'changelog.v20260308.item1':
     'Added engagement nudges — feedback and support prompts for active users.',
   'changelog.v20260308.item2': "Added What's New changelog — see the latest changes right here.",
+  'changelog.v20260215.title': 'Bin Designer Improvements',
+  'changelog.v20260215.item1': 'Flip cutouts horizontally and vertically in the bin designer.',
+  'changelog.v20260215.item2':
+    'Half-lap wall connectors for thin walls — stronger prints with less material.',
+  'changelog.v20260215.item3': 'Alignment connectors on split bin exports for easier assembly.',
+  'changelog.v20260120.title': 'Storage & Reliability',
+  'changelog.v20260120.item1':
+    'Snapshot history with auto-save — restore previous versions of your layouts.',
+  'changelog.v20260120.item2': 'Bulk export and import all layouts at once for easy backup.',
 };
 
 export default en;

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1473,5 +1473,12 @@
   "changelog.noEntries": "A\u00fan no hay actualizaciones.",
   "changelog.v20260308.title": "Participaci\u00f3n comunitaria",
   "changelog.v20260308.item1": "Se a\u00f1adieron avisos de participaci\u00f3n \u2014 solicitudes de feedback y apoyo para usuarios activos.",
-  "changelog.v20260308.item2": "Se a\u00f1adi\u00f3 el registro de novedades \u2014 consulta los \u00faltimos cambios aqu\u00ed mismo."
+  "changelog.v20260308.item2": "Se a\u00f1adi\u00f3 el registro de novedades \u2014 consulta los \u00faltimos cambios aqu\u00ed mismo.",
+  "changelog.v20260215.title": "Mejoras del Bin Designer",
+  "changelog.v20260215.item1": "Voltear cutouts horizontal y verticalmente en el Bin Designer.",
+  "changelog.v20260215.item2": "Conectores de pared half-lap para paredes delgadas \u2014 impresiones m\u00e1s fuertes con menos material.",
+  "changelog.v20260215.item3": "Conectores de alineaci\u00f3n en exportaciones de bins divididos para un ensamblaje m\u00e1s f\u00e1cil.",
+  "changelog.v20260120.title": "Almacenamiento y fiabilidad",
+  "changelog.v20260120.item1": "Historial de snapshots con guardado autom\u00e1tico \u2014 restaura versiones anteriores de tus layouts.",
+  "changelog.v20260120.item2": "Exportar e importar todos los layouts a la vez para una copia de seguridad f\u00e1cil."
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1473,5 +1473,12 @@
   "changelog.noEntries": "Aucune mise \u00e0 jour pour le moment.",
   "changelog.v20260308.title": "Engagement communautaire",
   "changelog.v20260308.item1": "Ajout de rappels d'engagement \u2014 invitations \u00e0 donner son avis et \u00e0 soutenir le projet pour les utilisateurs actifs.",
-  "changelog.v20260308.item2": "Ajout du journal des nouveaut\u00e9s \u2014 consultez les derniers changements ici m\u00eame."
+  "changelog.v20260308.item2": "Ajout du journal des nouveaut\u00e9s \u2014 consultez les derniers changements ici m\u00eame.",
+  "changelog.v20260215.title": "Am\u00e9liorations du Bin Designer",
+  "changelog.v20260215.item1": "Retourner les cutouts horizontalement et verticalement dans le Bin Designer.",
+  "changelog.v20260215.item2": "Connecteurs de paroi half-lap pour les parois fines \u2014 des impressions plus solides avec moins de mat\u00e9riau.",
+  "changelog.v20260215.item3": "Connecteurs d'alignement sur les exports de bins divis\u00e9s pour un assemblage plus facile.",
+  "changelog.v20260120.title": "Stockage et fiabilit\u00e9",
+  "changelog.v20260120.item1": "Historique de snapshots avec sauvegarde automatique \u2014 restaurez les versions pr\u00e9c\u00e9dentes de vos layouts.",
+  "changelog.v20260120.item2": "Exporter et importer tous les layouts en une fois pour une sauvegarde facile."
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1473,5 +1473,12 @@
   "changelog.noEntries": "Ingen oppdateringer enn\u00e5.",
   "changelog.v20260308.title": "Samfunnsengasjement",
   "changelog.v20260308.item1": "Lagt til engasjementsp\u00e5minnelser \u2014 tilbakemeldings- og st\u00f8tteoppfordringer for aktive brukere.",
-  "changelog.v20260308.item2": "Lagt til endringslogg for nyheter \u2014 se de siste endringene her."
+  "changelog.v20260308.item2": "Lagt til endringslogg for nyheter \u2014 se de siste endringene her.",
+  "changelog.v20260215.title": "Forbedringer i Bin Designer",
+  "changelog.v20260215.item1": "Speilvend cutouts horisontalt og vertikalt i Bin Designer.",
+  "changelog.v20260215.item2": "Half-lap-veggkoblinger for tynne vegger \u2014 sterkere utskrifter med mindre materiale.",
+  "changelog.v20260215.item3": "Justeringskoblinger p\u00e5 delte bin-eksporter for enklere montering.",
+  "changelog.v20260120.title": "Lagring og p\u00e5litelighet",
+  "changelog.v20260120.item1": "Snapshot-historikk med automatisk lagring \u2014 gjenopprett tidligere versjoner av layoutene dine.",
+  "changelog.v20260120.item2": "Eksporter og importer alle layouts p\u00e5 en gang for enkel sikkerhetskopiering."
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1473,5 +1473,12 @@
   "changelog.noEntries": "Nog geen updates.",
   "changelog.v20260308.title": "Communitybetrokkenheid",
   "changelog.v20260308.item1": "Betrokkenheidsherinneringen toegevoegd \u2014 feedback- en steunverzoeken voor actieve gebruikers.",
-  "changelog.v20260308.item2": "Nieuw-wijzigingslogboek toegevoegd \u2014 bekijk de laatste wijzigingen hier."
+  "changelog.v20260308.item2": "Nieuw-wijzigingslogboek toegevoegd \u2014 bekijk de laatste wijzigingen hier.",
+  "changelog.v20260215.title": "Verbeteringen aan Bin Designer",
+  "changelog.v20260215.item1": "Cutouts horizontaal en verticaal spiegelen in de Bin Designer.",
+  "changelog.v20260215.item2": "Half-lap-wandconnectoren voor dunne wanden \u2014 sterkere prints met minder materiaal.",
+  "changelog.v20260215.item3": "Uitlijnconnectoren bij gesplitste bin-exports voor eenvoudigere montage.",
+  "changelog.v20260120.title": "Opslag en betrouwbaarheid",
+  "changelog.v20260120.item1": "Snapshot-geschiedenis met automatisch opslaan \u2014 herstel eerdere versies van je layouts.",
+  "changelog.v20260120.item2": "Alle layouts tegelijk exporteren en importeren voor eenvoudige back-up."
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1473,5 +1473,12 @@
   "changelog.noEntries": "Nenhuma atualiza\u00e7\u00e3o ainda.",
   "changelog.v20260308.title": "Engajamento da comunidade",
   "changelog.v20260308.item1": "Adicionados lembretes de engajamento \u2014 solicita\u00e7\u00f5es de feedback e apoio para usu\u00e1rios ativos.",
-  "changelog.v20260308.item2": "Adicionado registro de novidades \u2014 veja as \u00faltimas mudan\u00e7as aqui mesmo."
+  "changelog.v20260308.item2": "Adicionado registro de novidades \u2014 veja as \u00faltimas mudan\u00e7as aqui mesmo.",
+  "changelog.v20260215.title": "Melhorias no Bin Designer",
+  "changelog.v20260215.item1": "Espelhar cutouts horizontal e verticalmente no Bin Designer.",
+  "changelog.v20260215.item2": "Conectores de parede half-lap para paredes finas \u2014 impress\u00f5es mais fortes com menos material.",
+  "changelog.v20260215.item3": "Conectores de alinhamento em exporta\u00e7\u00f5es de bins divididos para montagem mais f\u00e1cil.",
+  "changelog.v20260120.title": "Armazenamento e confiabilidade",
+  "changelog.v20260120.item1": "Hist\u00f3rico de snapshots com salvamento autom\u00e1tico \u2014 restaure vers\u00f5es anteriores dos seus layouts.",
+  "changelog.v20260120.item2": "Exportar e importar todos os layouts de uma vez para backup f\u00e1cil."
 }


### PR DESCRIPTION
## Summary

Addresses findings from the UX/UI audit of the engagement feature (#1065):

- **Dynamic modal title** — Help modal heading now shows "What's New" when the changelog tab is active instead of always showing "Keyboard Shortcuts"
- **Seed changelog entries** — Added two historical entries (Bin Designer Improvements, Storage & Reliability) so the changelog tab feels substantive rather than sparse with a single entry

## Test plan
- [x] 17 unit tests passing
- [x] TypeScript clean
- [x] i18n keys synced and translated (1482 keys across 7 locales)
- [ ] Manual: open help modal → title shows "Keyboard Shortcuts"
- [ ] Manual: switch to What's New tab → title changes to "What's New"
- [ ] Manual: changelog shows 3 entries with dates