### PR TITLE
chore(deps): bump brepkit-wasm from 1.0.4 to 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ai": "^6.0.116",
         "brepjs": "^12.2.12",
         "brepjs-opencascade": "^0.9.0",
-        "brepkit-wasm": "^1.0.4",
+        "brepkit-wasm": "^1.0.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -7272,9 +7272,9 @@
       }
     },
     "node_modules/brepkit-wasm": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-1.0.4.tgz",
-      "integrity": "sha512-6KcPX0W+K4z6xhm3y7wK5pSkyBdV5tuwQQ1iiHHmYGd/lPs0O0Mom8QyzLdMEEgJEGnoOdwp8U5ce5Z56FupJw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-1.0.5.tgz",
+      "integrity": "sha512-ai9U9ag9Bg9Y9iOzz1i0hYz2n38AUdP0NOkggbMlNnHf5V2ehNeESh5a3gF0UZxYvI0RhsNx9AbhUndjwummYA==",
       "license": "AGPL-3.0-only",
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ai": "^6.0.116",
     "brepjs": "^12.2.12",
     "brepjs-opencascade": "^0.9.0",
-    "brepkit-wasm": "^1.0.4",
+    "brepkit-wasm": "^1.0.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
## Summary
- Bumps `brepkit-wasm` from 1.0.4 to 1.0.5
- Internal perf improvements: CDT batch `split_face` (10-50x honeycomb), BVH buffer reuse, HashMap pre-sizing, shared-boundary fuse

## Benchmarks (brepkit 1.0.5 vs OCCT)

| Scenario | OCCT | brepkit | Speedup |
|---|---:|---:|---:|
| 1×1 std lip | 512ms | 17ms | **30×** |
| bp 6×4 magnets | 1271ms | 44ms | **29×** |
| bp 4×4 plain | 816ms | 29ms | **28×** |
| 2×2 circle insert | 272ms | 13ms | **21×** |
| 1×1 std no-lip | 170ms | 11ms | **15×** |
| 2×2 full-featured | 2166ms | 2170ms | **1.0× (was 1.7× slower)** |
| **Total** | **14.3s** | **3.9s** | **3.7× (was 1.7×)** |

## Test plan
- [x] All 22 profiling scenarios pass with brepkit kernel
- [x] All 22 profiling scenarios pass with OCCT kernel
- [ ] CI passes