### PR TITLE
fix: reject 0.5×0.5 bin footprint as invalid

### DIFF
--- a/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
+++ b/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
@@ -28,7 +28,7 @@ export function DimensionsSection() {
             value={state.width}
             onChange={(v) => handlers.setParam('width', v)}
             onStep={handlers.handleWidthStep}
-            min={state.minDimension}
+            min={state.minWidth}
             max={DESIGNER_CONSTRAINTS.MAX_DIMENSION}
             step={state.dimensionStep}
             variant={stepperVariant}
@@ -66,7 +66,7 @@ export function DimensionsSection() {
             value={state.depth}
             onChange={(v) => handlers.setParam('depth', v)}
             onStep={handlers.handleDepthStep}
-            min={state.minDimension}
+            min={state.minDepth}
             max={DESIGNER_CONSTRAINTS.MAX_DIMENSION}
             step={state.dimensionStep}
             variant={stepperVariant}

--- a/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.test.ts
+++ b/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.test.ts
@@ -62,7 +62,22 @@ describe('useDimensionsSection', () => {
     const { result } = renderHook(() => useDimensionsSection());
 
     expect(result.current.state.dimensionStep).toBe(0.5);
-    expect(result.current.state.minDimension).toBe(0.5);
+    // Both dimensions are 2 (≥1), so min can be 0.5 for either
+    expect(result.current.state.minWidth).toBe(0.5);
+    expect(result.current.state.minDepth).toBe(0.5);
+  });
+
+  it('prevents 0.5×0.5 footprint in half-bin mode', () => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, width: 0.5, depth: 2 },
+      ui: { ...DEFAULT_UI_STATE, halfBinMode: true },
+    });
+
+    const { result } = renderHook(() => useDimensionsSection());
+
+    // Width is 0.5, so depth min must be 1
+    expect(result.current.state.minWidth).toBe(0.5);
+    expect(result.current.state.minDepth).toBe(1);
   });
 
   it('clamps width to max dimension', () => {

--- a/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.ts
+++ b/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.ts
@@ -33,7 +33,9 @@ export function useDimensionsSection() {
   const t = useTranslation();
 
   const dimensionStep = halfBinMode ? 0.5 : 1;
-  const minDimension = halfBinMode ? 0.5 : 1;
+  // At least one dimension must be ≥ 1 — if the other is 0.5, this one can't go below 1
+  const minWidth = halfBinMode && depth >= 1 ? 0.5 : 1;
+  const minDepth = halfBinMode && width >= 1 ? 0.5 : 1;
 
   const widthMm = width * gridUnitMm;
   const depthMm = depth * gridUnitMm;
@@ -42,19 +44,19 @@ export function useDimensionsSection() {
   const handleWidthStep = useCallback(
     (delta: number) => {
       const next = width + delta * dimensionStep;
-      const clamped = Math.min(DESIGNER_CONSTRAINTS.MAX_DIMENSION, Math.max(minDimension, next));
+      const clamped = Math.min(DESIGNER_CONSTRAINTS.MAX_DIMENSION, Math.max(minWidth, next));
       setParam('width', clamped);
     },
-    [width, dimensionStep, minDimension, setParam]
+    [width, dimensionStep, minWidth, setParam]
   );
 
   const handleDepthStep = useCallback(
     (delta: number) => {
       const next = depth + delta * dimensionStep;
-      const clamped = Math.min(DESIGNER_CONSTRAINTS.MAX_DIMENSION, Math.max(minDimension, next));
+      const clamped = Math.min(DESIGNER_CONSTRAINTS.MAX_DIMENSION, Math.max(minDepth, next));
       setParam('depth', clamped);
     },
-    [depth, dimensionStep, minDimension, setParam]
+    [depth, dimensionStep, minDepth, setParam]
   );
 
   const handleHeightStep = useCallback(
@@ -93,7 +95,8 @@ export function useDimensionsSection() {
       heightMm,
       halfBinMode,
       dimensionStep,
-      minDimension,
+      minWidth,
+      minDepth,
     },
     handlers: {
       setParam: handleSetParam,

--- a/src/features/bin-designer/utils/validation.test.ts
+++ b/src/features/bin-designer/utils/validation.test.ts
@@ -72,11 +72,23 @@ describe('validateBinParams', () => {
     });
 
     it('should accept boundary values', () => {
-      expectOk(validateBinParams(makeParams({ width: 0.5 })));
+      expectOk(validateBinParams(makeParams({ width: 0.5, depth: 2 })));
+      expectOk(validateBinParams(makeParams({ width: 1, depth: 0.5 })));
       expectOk(validateBinParams(makeParams({ width: 8 })));
       // MIN_HEIGHT is 2 (1U = base only, 2U minimum for usable cavity)
       expectOk(validateBinParams(makeParams({ height: 2 })));
       expectOk(validateBinParams(makeParams({ height: 20 })));
+    });
+
+    it('should reject 0.5×0.5 footprint', () => {
+      const result = validateBinParams(makeParams({ width: 0.5, depth: 0.5 }));
+      const error = expectErr(result);
+      expect(error.code).toBe('FOOTPRINT_TOO_SMALL');
+    });
+
+    it('should accept 0.5×1 and 1×0.5 footprints', () => {
+      expectOk(validateBinParams(makeParams({ width: 0.5, depth: 1 })));
+      expectOk(validateBinParams(makeParams({ width: 1, depth: 0.5 })));
     });
   });
 

--- a/src/features/bin-designer/utils/validation.ts
+++ b/src/features/bin-designer/utils/validation.ts
@@ -60,6 +60,15 @@ export function validateBinParams(params: BinParams): Result<BinParams, Designer
     });
   }
 
+  // At least one dimension must be ≥ 1 unit (0.5×0.5 produces degenerate socket geometry)
+  if (params.width < 1 && params.depth < 1) {
+    return err({
+      code: 'FOOTPRINT_TOO_SMALL',
+      message: 'At least one dimension (width or depth) must be 1 unit or larger',
+      field: 'width',
+    });
+  }
+
   // Dimension step check (0.5 increments for width/depth, tolerance-based for float safety)
   if (!isValidStep(params.width, DESIGNER_CONSTRAINTS.DIMENSION_STEP)) {
     return err({


### PR DESCRIPTION
## Summary
- Adds validation rejecting bins where both width and depth are < 1 unit (e.g. 0.5×0.5), which produces degenerate socket geometry crashing both kernels
- Half-bin combos like 1×0.5 or 0.5×2 remain valid
- UI steppers now dynamically enforce the constraint: if one dimension is 0.5, the other's minimum becomes 1

## Test plan
- [x] `validateBinParams` rejects 0.5×0.5, accepts 0.5×1 and 1×0.5
- [x] `useDimensionsSection` enforces dynamic min per dimension
- [x] All existing validation, dimensions, and parameter panel tests pass
- [x] TypeScript compiles cleanly