### PR TITLE
chore(deps): bump brepkit-wasm from 1.0.6 to 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ai": "^6.0.116",
         "brepjs": "^12.2.12",
         "brepjs-opencascade": "^0.9.0",
-        "brepkit-wasm": "^1.0.6",
+        "brepkit-wasm": "^1.0.7",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -7272,9 +7272,9 @@
       }
     },
     "node_modules/brepkit-wasm": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-1.0.6.tgz",
-      "integrity": "sha512-SdNdVukoCH7pw6a2rCzWlo+k0mcK2dOMgdfqnoZcJYU0RLtc3AFpDgjVNxFu18By3RTcckuMH6mEZQJUBJscLQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-1.0.7.tgz",
+      "integrity": "sha512-b2/S6YaFC3yxuCkicswTWo9a6mG4oN22ZuNL1/uloT8ais6l8edcznuQZmim6OFnTgyla0c8oN7mejfhVsSQuQ==",
       "license": "AGPL-3.0-only",
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ai": "^6.0.116",
     "brepjs": "^12.2.12",
     "brepjs-opencascade": "^0.9.0",
-    "brepkit-wasm": "^1.0.6",
+    "brepkit-wasm": "^1.0.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/features/generation/worker/generators/__test-infra__/visualParity.test.ts
+++ b/src/features/generation/worker/generators/__test-infra__/visualParity.test.ts
@@ -110,9 +110,11 @@ describe('visual parity: brepkit vs OCCT (3×3 scoop+label+lip)', () => {
   });
 
   // Issue #2: Edge-to-triangle ratio should be similar
-  it('edge-to-triangle ratios are comparable (within 2×)', () => {
+  // brepkit produces fewer triangles per edge than OCCT (coarser tessellation),
+  // so the ratio can reach ~2.4× on complex bins with many B-Rep edges
+  it('edge-to-triangle ratios are comparable (within 3×)', () => {
     const ratio = brepkitMetrics.edgeToTriangleRatio / occtMetrics.edgeToTriangleRatio;
-    expect(ratio).toBeLessThan(2.0);
+    expect(ratio).toBeLessThan(3.0);
   });
 
   it('prints comparison summary', () => {


### PR DESCRIPTION
## Summary
- Bump brepkit-wasm from 1.0.6 to 1.0.7
- v1.0.7 brings coarser tessellation (73% fewer triangles on 3×3 reference bin) while keeping volume within 5% of OCCT
- Widen edge-to-triangle ratio threshold from 2× to 3× (actual ratio ~2.4× with new tessellation)

## Test plan
- [x] All 191 `__test-infra__` tests pass (visual parity, export parity, stress test, profile)
- [x] brepkit faster in 32/34 stress scenarios (only 0.5-unit loft regression remains)