### PR TITLE
test: add BREP topology parity tests (OCCT vs brepkit-wasm)

### DIFF
--- a/src/features/generation/worker/generators/__test-infra__/dualKernelInit.ts
+++ b/src/features/generation/worker/generators/__test-infra__/dualKernelInit.ts
@@ -20,7 +20,8 @@ export interface TopologyStats {
   readonly volume: number;
   readonly eulerCharacteristic: number;
   readonly stepByteSize: number;
-  readonly stepHeaderValid: boolean;
+  /** Size-only heuristic; actual header validation requires async `validateStepBlob()`. */
+  readonly stepNonEmpty: boolean;
 }
 
 export type GenerateBinFn = (
@@ -90,19 +91,13 @@ export function computeSignedVolume(mesh: MeshData): number {
 export function collectTopologyStats(solid: Shape3D): TopologyStats {
   const desc = describeSolid(solid);
 
-  // STEP export
+  // STEP export — synchronous size check only; header validation is async via validateStepBlob()
   let stepByteSize = 0;
-  let stepHeaderValid = false;
   try {
     const blob: Blob = unwrap(exportSTEP(solid));
-    // In Node, Blob.size gives byte length synchronously
     stepByteSize = blob.size;
-    // We can't synchronously read the blob text in all envs,
-    // so check size > 0 as the primary validation.
-    // Header validation is done via arrayBuffer in the async variant below.
-    stepHeaderValid = stepByteSize > 100;
   } catch {
-    // exportSTEP may fail on some kernel/shape combos — record as invalid
+    // exportSTEP may fail on some kernel/shape combos — record as zero
   }
 
   return {
@@ -113,23 +108,35 @@ export function collectTopologyStats(solid: Shape3D): TopologyStats {
     volume: measureVolume(solid),
     eulerCharacteristic: desc.vertexCount - desc.edgeCount + desc.faceCount,
     stepByteSize,
-    stepHeaderValid,
+    stepNonEmpty: stepByteSize > 0,
   };
 }
 
 /**
- * Validate STEP export buffer asynchronously (reads blob to check header).
- * Returns byte size and whether the header starts with "ISO-10303-21".
+ * Export a STEP blob synchronously (kernel-sensitive).
+ * Call inside `withKernel()`, then pass the blob to `validateStepBlob()` for async header check.
  */
-export async function validateStepBuffer(
-  solid: Shape3D
-): Promise<{ byteSize: number; headerValid: boolean }> {
+export function exportStepBlob(solid: Shape3D): Blob | null {
   try {
-    const blob: Blob = unwrap(exportSTEP(solid));
+    return unwrap(exportSTEP(solid));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate a STEP blob asynchronously (reads content to check header).
+ * Not kernel-sensitive — safe to call outside `withKernel()`.
+ */
+export async function validateStepBlob(
+  blob: Blob | null
+): Promise<{ byteSize: number; headerValid: boolean }> {
+  if (!blob) return { byteSize: 0, headerValid: false };
+  try {
     const buffer = await blob.arrayBuffer();
     const byteSize = buffer.byteLength;
     const header = new TextDecoder().decode(new Uint8Array(buffer, 0, Math.min(50, byteSize)));
-    return { byteSize, headerValid: header.includes('ISO-10303-21') };
+    return { byteSize, headerValid: header.trimStart().startsWith('ISO-10303-21') };
   } catch {
     return { byteSize: 0, headerValid: false };
   }

--- a/src/features/generation/worker/generators/__test-infra__/topologyParity.test.ts
+++ b/src/features/generation/worker/generators/__test-infra__/topologyParity.test.ts
@@ -13,8 +13,7 @@
 // @vitest-environment node
 import { describe, it, expect, beforeAll } from 'vitest';
 import { withKernel } from 'brepjs';
-import { clearAllCaches } from '@/features/generation/worker/generators/shapeCache';
-import { getLastSolid } from '@/features/generation/worker/generators/shapeCache';
+import { clearAllCaches, getLastSolid } from '@/features/generation/worker/generators/shapeCache';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import type { BinParams } from '@/shared/types/bin';
 import type { Shape3D } from 'brepjs';
@@ -23,7 +22,8 @@ import {
   initBrepkitKernel,
   loadGenerateBin,
   collectTopologyStats,
-  validateStepBuffer,
+  exportStepBlob,
+  validateStepBlob,
 } from './dualKernelInit';
 import type { GenerateBinFn, TopologyStats } from './dualKernelInit';
 
@@ -192,34 +192,40 @@ describe('topology parity: brepkit vs OCCT', () => {
         expect(pctDiff).toBeLessThan(0.3);
       });
 
-      it('STEP export produces non-empty valid output', () => {
+      it('STEP export produces non-empty output', () => {
         const occt = occtStats.get(tc.name);
         const bk = brepkitStats.get(tc.name);
         expect(occt).toBeDefined();
         expect(bk).toBeDefined();
 
         expect(occt?.stepByteSize, 'OCCT STEP should be non-empty').toBeGreaterThan(0);
-        expect(occt?.stepHeaderValid, 'OCCT STEP header should be valid').toBe(true);
         expect(bk?.stepByteSize, 'brepkit STEP should be non-empty').toBeGreaterThan(0);
-        expect(bk?.stepHeaderValid, 'brepkit STEP header should be valid').toBe(true);
       });
     });
   }
 
   it('validates STEP headers asynchronously', async () => {
+    let validated = 0;
     for (const tc of TEST_CASES) {
       const occtSolid = occtSolids.get(tc.name);
       const bkSolid = brepkitSolids.get(tc.name);
       if (!occtSolid || !bkSolid) continue;
 
+      // exportSTEP is the kernel-sensitive call and completes synchronously;
+      // extracting blobs here avoids relying on withKernel wrapping async fns.
+      const occtBlob = withKernel('occt', () => exportStepBlob(occtSolid));
+      const bkBlob = withKernel('brepkit', () => exportStepBlob(bkSolid));
+
       const [occtStep, bkStep] = await Promise.all([
-        withKernel('occt', () => validateStepBuffer(occtSolid)),
-        withKernel('brepkit', () => validateStepBuffer(bkSolid)),
+        validateStepBlob(occtBlob),
+        validateStepBlob(bkBlob),
       ]);
 
       expect(occtStep.headerValid, `${tc.name}: OCCT STEP header`).toBe(true);
       expect(bkStep.headerValid, `${tc.name}: brepkit STEP header`).toBe(true);
+      validated++;
     }
+    expect(validated, 'at least one case must have been validated').toBeGreaterThan(0);
   });
 
   it('prints topology comparison summary', () => {


### PR DESCRIPTION
## Summary

- Add `topologyParity.test.ts` alongside existing parity tests in `__test-infra__/` — compares BREP-level topology between OCCT and brepkit-wasm kernels
- Add `collectTopologyStats()` and `validateStepBuffer()` helpers to `dualKernelInit.ts` using brepjs `describe()`, `measureVolume()`, and `exportSTEP()` APIs
- Tests 7 bin configurations (5 existing + 1.5×2 half-bin + 3×3 scoop+label+lip), checking: solid validity, Euler characteristic (V-E+F), exact BREP volume (±10%), face counts (±30%), and STEP export

### Current findings (brepkit v1.0.7)

| Check | Status | Notes |
|-------|--------|-------|
| Solid validity | Pass | Both kernels report valid |
| Euler χ | Fail | brepkit χ=-52 vs OCCT χ=2 (edge count divergence) |
| BREP volume | Fail | 16-56% difference (polygon arc approximation) |
| Face counts | Fail | 37-50% more faces in brepkit |
| 3×3 scoop+label+lip | Crash | Both kernels crash (OCCT: WASM ptr, brepkit: non-finite matrix) |

Manual run only — excluded from CI via `__test-infra__/`.

## Test plan

- [x] Typecheck passes (`npx tsc --noEmit`)
- [x] Pre-commit hooks pass (lint, boundaries, i18n, exhaustiveness)
- [x] Test runs and produces expected failures for brepkit topology divergence
- [x] Existing `exportParity.test.ts` unaffected (no shared code broken)