### PR TITLE
refactor: promote jsx-a11y ESLint rules from warn to error

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,12 +74,12 @@ export default defineConfig([
       '@typescript-eslint/no-base-to-string': 'warn',
       '@typescript-eslint/no-misused-spread': 'warn',
 
-      // Accessibility (warn to fix incrementally)
-      'jsx-a11y/click-events-have-key-events': 'warn',
-      'jsx-a11y/no-static-element-interactions': 'warn',
-      'jsx-a11y/no-noninteractive-element-interactions': 'warn',
-      'jsx-a11y/no-autofocus': 'warn',
-      'jsx-a11y/interactive-supports-focus': 'warn',
+      // Accessibility
+      'jsx-a11y/click-events-have-key-events': 'error',
+      'jsx-a11y/no-static-element-interactions': 'error',
+      'jsx-a11y/no-noninteractive-element-interactions': 'error',
+      'jsx-a11y/no-autofocus': 'error',
+      'jsx-a11y/interactive-supports-focus': 'error',
 
       // React anti-patterns
       'react-hooks/rules-of-hooks': 'error',

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -47,7 +47,11 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <div className="h-screen flex items-center justify-center bg-surface p-8" role="alert">
+        <div
+          className="h-screen flex items-center justify-center bg-surface p-8"
+          role="alert"
+          aria-live="assertive"
+        >
           <div className="max-w-lg text-center">
             <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-error-muted flex items-center justify-center">
               <svg

--- a/src/components/PanelErrorBoundary/PanelErrorBoundary.tsx
+++ b/src/components/PanelErrorBoundary/PanelErrorBoundary.tsx
@@ -52,7 +52,11 @@ export class PanelErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <div className="flex flex-col items-center justify-center p-6 text-center h-full min-h-[200px]">
+        <div
+          className="flex flex-col items-center justify-center p-6 text-center h-full min-h-[200px]"
+          role="alert"
+          aria-live="assertive"
+        >
           <div className="w-12 h-12 mb-3 rounded-full bg-error/20 flex items-center justify-center">
             <svg
               className="w-6 h-6 text-error"


### PR DESCRIPTION
## Summary

- Promotes 5 jsx-a11y ESLint rules from `warn` to `error` severity, enforcing accessibility as a build requirement
- Adds `aria-live="assertive"` to both error boundary fallback UIs for screen reader announcement

### Rules promoted

| Rule | Effect |
|------|--------|
| `click-events-have-key-events` | Clickable elements must have keyboard handlers |
| `no-static-element-interactions` | Non-interactive elements must not have event handlers |
| `no-noninteractive-element-interactions` | Non-interactive HTML elements must not have interaction handlers |
| `no-autofocus` | Prevents jarring autofocus (exceptions via eslint-disable) |
| `interactive-supports-focus` | Interactive elements must be focusable |

### Error boundary improvements

- `ErrorBoundary.tsx`: Added `aria-live="assertive"` (already had `role="alert"`)
- `PanelErrorBoundary.tsx`: Added both `role="alert"` and `aria-live="assertive"`

## Test plan

- [x] ESLint passes with zero a11y warnings or errors
- [x] All existing eslint-disable suppressions justified (modal autofocus, backdrop dismiss)
- [x] TypeScript typecheck clean
- [x] All pre-commit hooks pass