### PR TITLE
refactor: conservative memoization audit (Phase 4)

### DIFF
--- a/src/components/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
+++ b/src/components/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useSettingsStore } from '@/core/store';
 import { useToastStore } from '@/core/store/toast';
@@ -37,12 +37,9 @@ export function DefaultsTab() {
     hasCustomCategoryDefaults,
   } = useDrawerSettings();
 
-  const updatePrintSetting = useCallback(
-    <K extends keyof PrintSettings>(key: K, value: PrintSettings[K]) => {
-      updateSetting('printSettings', { ...settings.printSettings, [key]: value });
-    },
-    [settings.printSettings, updateSetting]
-  );
+  const updatePrintSetting = <K extends keyof PrintSettings>(key: K, value: PrintSettings[K]) => {
+    updateSetting('printSettings', { ...settings.printSettings, [key]: value });
+  };
 
   const handleCopyFromLayout = () => {
     updateSetting('defaultDrawerWidth', drawer.width);

--- a/src/components/Modals/SettingsModal/tabs/IntegrationsTab/IntegrationsTab.tsx
+++ b/src/components/Modals/SettingsModal/tabs/IntegrationsTab/IntegrationsTab.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useSettingsStore } from '@/core/store';
 import type { STLSearchSite, SlicerSite } from '@/core/store/settings';
@@ -16,29 +15,23 @@ export function IntegrationsTab() {
     }))
   );
 
-  const toggleSite = useCallback(
-    (siteId: string) => {
-      updateSetting(
-        'stlSearchSites',
-        stlSearchSites.map((site) =>
-          site.id === siteId ? { ...site, enabled: !site.enabled } : site
-        )
-      );
-    },
-    [stlSearchSites, updateSetting]
-  );
+  const toggleSite = (siteId: string) => {
+    updateSetting(
+      'stlSearchSites',
+      stlSearchSites.map((site) =>
+        site.id === siteId ? { ...site, enabled: !site.enabled } : site
+      )
+    );
+  };
 
-  const toggleSlicer = useCallback(
-    (slicerId: string) => {
-      updateSetting(
-        'slicerSites',
-        slicerSites.map((slicer) =>
-          slicer.id === slicerId ? { ...slicer, enabled: !slicer.enabled } : slicer
-        )
-      );
-    },
-    [slicerSites, updateSetting]
-  );
+  const toggleSlicer = (slicerId: string) => {
+    updateSetting(
+      'slicerSites',
+      slicerSites.map((slicer) =>
+        slicer.id === slicerId ? { ...slicer, enabled: !slicer.enabled } : slicer
+      )
+    );
+  };
 
   return (
     <div className="space-y-8">


### PR DESCRIPTION
## Summary
- Remove 3 unnecessary `useCallback` wrappers in settings tabs where memoization provides no benefit
- `toggleSite` and `toggleSlicer` in IntegrationsTab: deps include state arrays that change on every invocation, and `ToggleRow` child is not `React.memo`-wrapped
- `updatePrintSetting` in DefaultsTab: deps include `settings.printSettings` that changes on every call, consistent with sibling `handleCopyFromLayout` which is already a plain arrow function

## Why conservative?
Audited all 23 `useMemo`/`useCallback` instances across the 5 target directories (Sidebar, Modals, layers, categories, design-system). Most are justified:
- Design-system primitives (Menu, Dialog, Toast, Stepper): keyboard nav, animation timers, cleanup functions
- Layer/category statistics: legitimate derived-data memoization from arrays  
- Modal callbacks: async operations, debounced handlers

Only removed cases with clear evidence of waste (invalidating deps + no memoized consumers).

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 93 SettingsModal tests pass
- [ ] CI: Build, Quality, Unit Tests
- [ ] Manual: toggle STL search sites and slicer sites in Settings > Integrations
- [ ] Manual: change print settings in Settings > Defaults