### PR TITLE
chore: tighten bundle size limits (Phase 7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,13 +64,13 @@
       "name": "Main bundle (gzip)",
       "path": "dist/assets/main-*.js",
       "gzip": true,
-      "limit": "190 kB"
+      "limit": "165 kB"
     },
     {
       "name": "Total JS (gzip)",
       "path": "dist/assets/*.js",
       "gzip": true,
-      "limit": "1350 kB"
+      "limit": "1300 kB"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
## Summary
- Tighten size-limit budgets to match current actual bundle sizes
- Main bundle: **190 kB → 165 kB** (actual: ~160 kB gzipped, 5 kB headroom)
- Total JS: **1350 kB → 1300 kB** (actual: ~1280 kB gzipped, 20 kB headroom)

## Why no lazy loading changes?
The codebase already has extensive lazy loading (15+ `lazyWithRetry` calls across App.tsx, Header, Sidebar, Grid, MobileLayout). Three.js, react-three-fiber, Liveblocks, brepjs, and most feature pages are already code-split into separate chunks. The remaining bundle composition is the minimum required for initial page load.

## Test plan
- [x] `npm run size` passes with new limits
- [x] `npm run build` succeeds
- [ ] CI: Build, Quality, Unit Tests