### PR TITLE
fix: resolve 4 Dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,8 @@
       "eslint-plugin-jsx-a11y>eslint": "^10.0.3",
       "eslint-plugin-jsx-a11y>minimatch": "^3.1.3",
       "@vercel/build-utils>minimatch": "^10.2.3",
+      "@vercel/python-analysis>minimatch": "^10.2.3",
+      "@vercel/static-config>ajv": "^8.18.0",
       "glob>minimatch": "^10.2.3"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,8 @@ overrides:
   eslint-plugin-jsx-a11y>eslint: ^10.0.3
   eslint-plugin-jsx-a11y>minimatch: ^3.1.3
   '@vercel/build-utils>minimatch': ^10.2.3
+  '@vercel/python-analysis>minimatch': ^10.2.3
+  '@vercel/static-config>ajv': ^8.18.0
   glob>minimatch: ^10.2.3
 
 importers:
@@ -2092,20 +2094,6 @@ packages:
         integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==,
       }
 
-  '@isaacs/balanced-match@4.0.1':
-    resolution:
-      {
-        integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==,
-      }
-    engines: { node: 20 || >=22 }
-
-  '@isaacs/brace-expansion@5.0.1':
-    resolution:
-      {
-        integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==,
-      }
-    engines: { node: 20 || >=22 }
-
   '@isaacs/cliui@9.0.0':
     resolution:
       {
@@ -4080,12 +4068,6 @@ packages:
     resolution:
       {
         integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==,
-      }
-
-  ajv@8.6.3:
-    resolution:
-      {
-        integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==,
       }
 
   ansi-escapes@7.3.0:
@@ -6626,13 +6608,6 @@ packages:
         integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==,
       }
     engines: { node: '>=4' }
-
-  minimatch@10.1.1:
-    resolution:
-      {
-        integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==,
-      }
-    engines: { node: 20 || >=22 }
 
   minimatch@10.2.4:
     resolution:
@@ -9946,12 +9921,6 @@ snapshots:
 
   '@ioredis/commands@1.5.1': {}
 
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.1':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
-
   '@isaacs/cliui@9.0.0': {}
 
   '@isaacs/fs-minipass@4.0.1':
@@ -11054,14 +11023,14 @@ snapshots:
       '@renovatebot/pep440': 4.2.1
       fs-extra: 11.1.1
       js-yaml: 4.1.1
-      minimatch: 10.1.1
+      minimatch: 10.2.4
       pip-requirements-js: 1.0.3
       smol-toml: 1.5.2
       zod: 3.22.4
 
   '@vercel/static-config@3.2.0':
     dependencies:
-      ajv: 8.6.3
+      ajv: 8.18.0
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
@@ -11192,13 +11161,6 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-
-  ajv@8.6.3:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-      uri-js: 4.4.1
 
   ansi-escapes@7.3.0:
     dependencies:
@@ -12764,10 +12726,6 @@ snapshots:
   mimic-function@5.0.1: {}
 
   min-indent@1.0.1: {}
-
-  minimatch@10.1.1:
-    dependencies:
-      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@10.2.4:
     dependencies:


### PR DESCRIPTION
## Summary
- Add pnpm override `@vercel/python-analysis>minimatch: ^10.2.3` to fix 3 high-severity ReDoS alerts (#34, #35, #36)
- Add pnpm override `@vercel/static-config>ajv: ^8.18.0` to fix 1 medium-severity ReDoS alert (#33)
- All 4 vulnerabilities are transitive deps of `@vercel/node@5.6.15` (latest available) — scoped overrides will become no-ops once Vercel updates

## Test plan
- [x] `pnpm why minimatch@10.1.1` returns empty (vulnerable version gone)
- [x] `pnpm why ajv@8.6.3` returns empty (vulnerable version gone)
- [x] `pnpm run typecheck` passes
- [ ] CI passes