### PR TITLE
fix: exempt instructional animations from app-level reduce motion

### DIFF
--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -264,7 +264,7 @@ html[data-reduce-motion='true'] *::after {
 }
 
 /* Instructional animations — teach interaction, exempt from blanket kill.
-   Class specificity (0,1,0) beats * (0,0,0) when both use !important. */
+   html[attr] .class (0,2,0) beats html[attr] * (0,1,0) when both use !important. */
 html[data-reduce-motion='true'] .animate-draw-hint-click {
   animation: draw-hint-click 4s ease-out infinite !important;
 }


### PR DESCRIPTION
## Summary
- The app-level "Reduce motion" toggle (`data-reduce-motion` attribute set via settings store) was killing **all** animations, including the grid empty state draw tutorial
- The OS-level `@media (prefers-reduced-motion: reduce)` in `index.css` already correctly exempted these instructional animations — this mirrors those exemptions for the app-level setting in `themes.css`
- Covers both grid editor (`infinite` loop) and cutout editor (`1` iteration) draw tutorial variants

## Test plan
- [ ] Enable "Reduce motion" in Settings > Appearance
- [ ] Navigate to an empty grid (first layer with no bins) — draw tutorial animation should still play
- [ ] Verify other animations (toasts, scale-in, pulse) are still suppressed
- [ ] Disable "Reduce motion" — all animations should work normally
- [ ] Test with OS-level prefers-reduced-motion enabled — same behavior as app toggle