### PR TITLE
chore: gitignore claude agent-memory-local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Git worktrees
 .worktrees/
 
+# Claude Code local agent memory
+.claude/agent-memory-local/
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
## Summary

- Remove `.claude/agent-memory-local/` from git tracking
- Add to `.gitignore`

Subagent memory files are user-specific session context that shouldn't be shared across contributors or cause merge conflicts.

## Test plan

- [ ] Verify `.claude/agent-memory-local/` files still exist locally but are no longer tracked