### PR TITLE
feat(split): replace connectors with FDM-friendly scarf lap floor joint

### DIFF
--- a/src/features/bin-designer/constants/defaults.ts
+++ b/src/features/bin-designer/constants/defaults.ts
@@ -66,8 +66,10 @@ const DEFAULT_CUTOUT_CONFIG: CutoutConfig = {
 export const DEFAULT_SPLIT_CONNECTOR_CONFIG: SplitConnectorConfig = {
   enabled: true,
   clearance: 0.15,
-  tongueThickness: 2.4,
+  tongueThickness: 2.4, // legacy — unused by scarf lap, kept for saved design compat
   tongueProtrusion: 3.0,
+  ridgeWidthFraction: 0.35,
+  ridgeHeightFraction: 0.8,
 } as const;
 
 /** Default handle configuration: disabled, front + sides enabled when toggled on */

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -198,12 +198,16 @@ export interface WallPatternConfig {
 export interface SplitConnectorConfig {
   /** Whether to add alignment connectors (default: true when split needed) */
   readonly enabled: boolean;
-  /** FDM fit clearance applied to all groove dimensions per side (mm, 0.05–0.3) */
+  /** FDM fit clearance applied to groove/channel dimensions per side, normal to surface (mm, 0.05–0.3) */
   readonly clearance: number;
-  /** Tongue cross-section thickness (mm) */
-  readonly tongueThickness: number;
-  /** Tongue protrusion depth from cut face (mm) */
+  /** Legacy tongue protrusion depth; kept for backward compat, unused by current scarf lap (mm) */
   readonly tongueProtrusion: number;
+  /** Tongue cross-section thickness — kept for backward compat, unused by scarf lap (mm) */
+  readonly tongueThickness: number;
+  /** Reserved for future wall ridge feature — ridge width as fraction of wall thickness */
+  readonly ridgeWidthFraction?: number;
+  /** Reserved for future wall ridge feature — ridge height as fraction of wall height */
+  readonly ridgeHeightFraction?: number;
 }
 
 /** Complete bin parameter set for generation */

--- a/src/features/generation/worker/generators/binGenerator.scenario.split-connectors.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-connectors.test.ts
@@ -8,7 +8,6 @@ import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constant
 import type { BinParams, SplitConnectorConfig } from '@/shared/types/bin';
 import { initBrepjs, getGenerateSplitPreview } from './__dual-kernel__/wasmInit';
 import { boundingBox, hasNoNaNOrInfinity } from './__dual-kernel__/meshAssertions';
-import { OVERLAP } from './splitConnectorBuilder';
 
 beforeAll(async () => {
   await initBrepjs();
@@ -22,8 +21,7 @@ const CLEARANCE = GRIDFINITY.TOLERANCE;
 /** Tessellation tolerance — geometry vertices may deviate from exact CAD by this amount. */
 const TESS_TOL = 0.3;
 
-/** 8×2×3 bin with default 1.2mm walls and stacking lip.
- *  Half-lap wall connectors interlock in the wall zone; lip is preserved intact. */
+/** 8×2×3 bin with default 1.2mm walls and stacking lip. */
 const OVERSIZED_PARAMS: BinParams = {
   ...DEFAULT_BIN_PARAMS,
   width: 8,
@@ -31,44 +29,11 @@ const OVERSIZED_PARAMS: BinParams = {
   height: 3,
 };
 
-/** Same dimensions but WITHOUT stacking lip — half-lap wall connectors
- *  are used at < 1.4mm wall thickness. */
-const OVERSIZED_NO_LIP: BinParams = {
-  ...OVERSIZED_PARAMS,
-  base: { ...OVERSIZED_PARAMS.base, stackingLip: false },
-};
-
-/** 7x3x3 bin with 1.6mm walls — thicker half-lap tabs than the default 1.2mm. */
-const THICK_WALL_PARAMS: BinParams = {
-  ...DEFAULT_BIN_PARAMS,
-  width: 7,
-  depth: 3,
-  height: 3,
-  wallThickness: 1.6,
-};
-
 const CUT_PLANES_X = [0];
 const CUT_PLANES_Y: number[] = [];
 const DISABLED_CONFIG: SplitConnectorConfig = { ...DEFAULT_SPLIT_CONNECTOR_CONFIG, enabled: false };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/** Find the extreme X coordinate among vertices near a given Y position. */
-function extremeXNearY(
-  vertices: Float32Array,
-  targetY: number,
-  yTolerance: number,
-  mode: 'max' | 'min'
-): number {
-  let result = mode === 'max' ? -Infinity : Infinity;
-  const compare = mode === 'max' ? Math.max : Math.min;
-  for (let i = 0; i < vertices.length; i += 3) {
-    if (Math.abs(vertices[i + 1] - targetY) < yTolerance) {
-      result = compare(result, vertices[i]);
-    }
-  }
-  return result;
-}
 
 /** Sum triangle counts across all pieces. */
 function totalTriCount(pieces: { indices: { length: number } }[]): number {
@@ -140,7 +105,7 @@ describe('split connector geometry in preview meshes', () => {
     }
   }, 60000);
 
-  it('male piece extends beyond nominal boundary with connectors (tongue protrusion)', () => {
+  it('male piece extends beyond nominal boundary with scarf lap', () => {
     const generateSplitPreview = getGenerateSplitPreview();
     const withConnectors = generateSplitPreview(
       OVERSIZED_PARAMS,
@@ -165,15 +130,13 @@ describe('split connector geometry in preview meshes', () => {
     const bbWith = boundingBox(maleWith.vertices);
     const bbWithout = boundingBox(maleWithout.vertices);
 
-    // Wall half-lap tabs extend lapDepth + OVERLAP past the cut face to
-    // fill the opposing groove completely (no gap at the bottom of the recess).
-    const protrusion = DEFAULT_SPLIT_CONNECTOR_CONFIG.tongueProtrusion + OVERLAP;
+    // Scarf lap extends floorThickness past the cut face (at 45°, overlap = floor thickness)
     const extensionX = bbWith.maxX - bbWithout.maxX;
-    expect(extensionX).toBeGreaterThan(protrusion - TESS_TOL - 0.5);
-    expect(extensionX).toBeLessThan(protrusion + TESS_TOL + 0.5);
+    expect(extensionX).toBeGreaterThan(0);
+    expect(extensionX).toBeLessThan(OVERSIZED_PARAMS.wallThickness + TESS_TOL + 1.0);
   }, 60000);
 
-  it('female piece has groove (vertices recessed inside piece boundary)', () => {
+  it('female piece has scarf ramp (more triangles than without connectors)', () => {
     const generateSplitPreview = getGenerateSplitPreview();
     const withConnectors = generateSplitPreview(
       OVERSIZED_PARAMS,
@@ -198,32 +161,6 @@ describe('split connector geometry in preview meshes', () => {
     const trisWith = femaleWith.indices.length / 3;
     const trisWithout = femaleWithout.indices.length / 3;
     expect(trisWith).toBeGreaterThan(trisWithout);
-  }, 60000);
-
-  it('connector clearance widens groove relative to tongue', () => {
-    const generateSplitPreview = getGenerateSplitPreview();
-    const tightConfig: SplitConnectorConfig = {
-      ...DEFAULT_SPLIT_CONNECTOR_CONFIG,
-      clearance: 0.0,
-    };
-    const looseConfig: SplitConnectorConfig = {
-      ...DEFAULT_SPLIT_CONNECTOR_CONFIG,
-      clearance: 0.3,
-    };
-
-    const tight = generateSplitPreview(OVERSIZED_PARAMS, CUT_PLANES_X, CUT_PLANES_Y, tightConfig);
-    const loose = generateSplitPreview(OVERSIZED_PARAMS, CUT_PLANES_X, CUT_PLANES_Y, looseConfig);
-
-    const femaleTight = tight.pieces.find((p) => p.col === 2);
-    const femaleLoose = loose.pieces.find((p) => p.col === 2);
-
-    if (!femaleTight || !femaleLoose) {
-      expect.fail('Expected to find female pieces (col === 2) in both results');
-    }
-
-    const trisTight = femaleTight.indices.length / 3;
-    const trisLoose = femaleLoose.indices.length / 3;
-    expect(trisTight).not.toBe(trisLoose);
   }, 60000);
 
   it('undefined splitConnectorConfig skips connectors (same as disabled)', () => {
@@ -265,46 +202,6 @@ describe('split connector geometry in preview meshes', () => {
     expect(trisResult - trisWithout).toBeGreaterThan(5);
   }, 60000);
 
-  it('wall tongues at 1.6mm wall thickness do not destroy bin geometry', () => {
-    const generateSplitPreview = getGenerateSplitPreview();
-
-    const withoutConnectors = generateSplitPreview(
-      THICK_WALL_PARAMS,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DISABLED_CONFIG
-    );
-    expect(withoutConnectors.pieces).toHaveLength(2);
-    const baseVertCount = withoutConnectors.pieces[0].vertices.length;
-    expect(baseVertCount).toBeGreaterThan(100);
-
-    const result = generateSplitPreview(
-      THICK_WALL_PARAMS,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DEFAULT_SPLIT_CONNECTOR_CONFIG
-    );
-
-    expect(result.pieces).toHaveLength(2);
-
-    const outerW = THICK_WALL_PARAMS.width * SIZE - CLEARANCE;
-    const halfW = outerW / 2;
-    const outerD = THICK_WALL_PARAMS.depth * SIZE - CLEARANCE;
-
-    for (const piece of result.pieces) {
-      expect(hasNoNaNOrInfinity(piece.vertices)).toBe(true);
-      expect(piece.vertices.length).toBeGreaterThan(100);
-
-      const bb = boundingBox(piece.vertices);
-      const pieceW = bb.maxX - bb.minX;
-      const pieceD = bb.maxY - bb.minY;
-
-      // Each piece should be approximately half the bin width
-      expect(pieceW).toBeGreaterThan(halfW - 5);
-      expect(pieceD).toBeGreaterThan(outerD - 2);
-    }
-  }, 60000);
-
   it('asymmetric multi-split produces correct piece count and labels', () => {
     const generateSplitPreview = getGenerateSplitPreview();
     const wideParams: BinParams = { ...DEFAULT_BIN_PARAMS, width: 13, depth: 2, height: 3 };
@@ -322,276 +219,6 @@ describe('split connector geometry in preview meshes', () => {
     const cols = result.pieces.map((p) => p.col).sort();
     expect(cols).toEqual([1, 2, 3]);
   }, 90000);
-
-  it('half-lap joints at 1.2mm walls produce geometry changes', () => {
-    const generateSplitPreview = getGenerateSplitPreview();
-    const withConnectors = generateSplitPreview(
-      OVERSIZED_PARAMS,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DEFAULT_SPLIT_CONNECTOR_CONFIG
-    );
-    const withoutConnectors = generateSplitPreview(
-      OVERSIZED_PARAMS,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DISABLED_CONFIG
-    );
-
-    // Half-lap cuts into walls create additional internal faces → more triangles
-    const trisWithConn = totalTriCount(withConnectors.pieces);
-    const trisWithout = totalTriCount(withoutConnectors.pieces);
-    expect(trisWithConn).toBeGreaterThan(trisWithout);
-
-    for (const piece of withConnectors.pieces) {
-      expect(hasNoNaNOrInfinity(piece.vertices)).toBe(true);
-      expect(piece.vertices.length).toBeGreaterThan(100);
-    }
-  }, 60000);
-
-  it('half-lap at 1.2mm walls produces similar X-extension to 1.6mm walls', () => {
-    const generateSplitPreview = getGenerateSplitPreview();
-    // Both use half-lap joints. The 1.2mm wall has 0.6mm half-width tabs,
-    // the 1.6mm wall has 0.8mm half-width tabs. Both extend lapDepth + OVERLAP
-    // past the cut face, so X-extension is approximately equal.
-    const thinResult = generateSplitPreview(
-      OVERSIZED_PARAMS,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DEFAULT_SPLIT_CONNECTOR_CONFIG
-    );
-    const thickParams: BinParams = {
-      ...DEFAULT_BIN_PARAMS,
-      width: 8,
-      depth: 2,
-      height: 3,
-      wallThickness: 1.6,
-    };
-    const thickResult = generateSplitPreview(
-      thickParams,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DEFAULT_SPLIT_CONNECTOR_CONFIG
-    );
-
-    const thinMale = thinResult.pieces.find((p) => p.col === 1);
-    const thickMale = thickResult.pieces.find((p) => p.col === 1);
-
-    if (!thinMale || !thickMale) {
-      expect.fail('Expected to find male pieces (col === 1) in both results');
-    }
-
-    const thinMaxX = boundingBox(thinMale.vertices).maxX;
-    const thickMaxX = boundingBox(thickMale.vertices).maxX;
-
-    // Both half-lap tabs extend the same depth; thicker walls may add slightly
-    // more due to wider tab geometry
-    expect(thinMaxX).toBeLessThan(thickMaxX + TESS_TOL);
-  }, 60000);
-
-  it('half-lap wall cuts preserve stacking lip intact (lip + thin walls)', () => {
-    const generateSplitPreview = getGenerateSplitPreview();
-    // Half-lap cuts only affect the wall zone. The lip was already intersected
-    // with the cutting box, so each piece's lip terminates at the cut face.
-    // When assembled, both pieces' lips meet edge-to-edge with no gap.
-    const withConn = generateSplitPreview(
-      OVERSIZED_PARAMS,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DEFAULT_SPLIT_CONNECTOR_CONFIG
-    );
-    const withoutConn = generateSplitPreview(
-      OVERSIZED_PARAMS,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DISABLED_CONFIG
-    );
-
-    for (const piece of withConn.pieces) {
-      expect(hasNoNaNOrInfinity(piece.vertices)).toBe(true);
-      expect(piece.vertices.length).toBeGreaterThan(100);
-    }
-
-    // Half-lap cuts in the wall zone still produce more triangles than no connectors
-    const trisConn = totalTriCount(withConn.pieces);
-    const trisNoConn = totalTriCount(withoutConn.pieces);
-    expect(trisConn).toBeGreaterThan(trisNoConn);
-
-    // Lip max Z should be identical with and without connectors — the lip
-    // is untouched by the half-lap (no material removed from lip zone).
-    const wallTopZ = OVERSIZED_PARAMS.height * GRIDFINITY.HEIGHT_UNIT;
-    for (const connPiece of withConn.pieces) {
-      const noConnPiece = withoutConn.pieces.find((p) => p.col === connPiece.col);
-      expect(noConnPiece).toBeDefined();
-      if (!noConnPiece) continue;
-
-      const connBb = boundingBox(connPiece.vertices);
-      const noConnBb = boundingBox(noConnPiece.vertices);
-
-      // Both should reach the same lip height (within tessellation tolerance)
-      expect(connBb.maxZ).toBeGreaterThan(wallTopZ);
-      expect(Math.abs(connBb.maxZ - noConnBb.maxZ)).toBeLessThan(0.5);
-    }
-  }, 90000);
-
-  it('male wall tabs protrude past cut face at wall Y positions (no lip)', () => {
-    const generateSplitPreview = getGenerateSplitPreview();
-    const outerD = OVERSIZED_NO_LIP.depth * SIZE - CLEARANCE;
-    const wt = OVERSIZED_NO_LIP.wallThickness;
-    const wallOffset = outerD / 2 - wt / 2;
-
-    const withConn = generateSplitPreview(
-      OVERSIZED_NO_LIP,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DEFAULT_SPLIT_CONNECTOR_CONFIG
-    );
-    const withoutConn = generateSplitPreview(
-      OVERSIZED_NO_LIP,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DISABLED_CONFIG
-    );
-
-    const maleWith = withConn.pieces.find((p) => p.col === 1);
-    const maleWithout = withoutConn.pieces.find((p) => p.col === 1);
-    expect(maleWith).toBeDefined();
-    expect(maleWithout).toBeDefined();
-    if (!maleWith || !maleWithout) return;
-
-    const wallMaxXWith = extremeXNearY(maleWith.vertices, wallOffset, wt, 'max');
-    const wallMaxXWithout = extremeXNearY(maleWithout.vertices, wallOffset, wt, 'max');
-    const wallProtrusion = wallMaxXWith - wallMaxXWithout;
-    const expectedProtrusion = DEFAULT_SPLIT_CONNECTOR_CONFIG.tongueProtrusion;
-
-    expect(wallProtrusion).toBeGreaterThan(expectedProtrusion - TESS_TOL - 0.5);
-  }, 60000);
-
-  it('male wall tabs protrude past cut face at wall Y positions (with lip)', () => {
-    const generateSplitPreview = getGenerateSplitPreview();
-    const outerD = OVERSIZED_PARAMS.depth * SIZE - CLEARANCE;
-    const wt = OVERSIZED_PARAMS.wallThickness;
-    const wallOffset = outerD / 2 - wt / 2;
-
-    const withConn = generateSplitPreview(
-      OVERSIZED_PARAMS,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DEFAULT_SPLIT_CONNECTOR_CONFIG
-    );
-    const withoutConn = generateSplitPreview(
-      OVERSIZED_PARAMS,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DISABLED_CONFIG
-    );
-
-    const maleWith = withConn.pieces.find((p) => p.col === 1);
-    const maleWithout = withoutConn.pieces.find((p) => p.col === 1);
-    expect(maleWith).toBeDefined();
-    expect(maleWithout).toBeDefined();
-    if (!maleWith || !maleWithout) return;
-
-    const wallMaxXWith = extremeXNearY(maleWith.vertices, wallOffset, wt, 'max');
-    const wallMaxXWithout = extremeXNearY(maleWithout.vertices, wallOffset, wt, 'max');
-    const wallProtrusion = wallMaxXWith - wallMaxXWithout;
-    const expectedProtrusion = DEFAULT_SPLIT_CONNECTOR_CONFIG.tongueProtrusion;
-
-    expect(wallProtrusion).toBeGreaterThan(expectedProtrusion - TESS_TOL - 0.5);
-  }, 60000);
-
-  it('female wall tab protrudes into male territory at wall Y positions (with lip)', () => {
-    const generateSplitPreview = getGenerateSplitPreview();
-    const outerD = OVERSIZED_PARAMS.depth * SIZE - CLEARANCE;
-    const wt = OVERSIZED_PARAMS.wallThickness;
-    const wallOffset = outerD / 2 - wt / 2;
-
-    const withConn = generateSplitPreview(
-      OVERSIZED_PARAMS,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DEFAULT_SPLIT_CONNECTOR_CONFIG
-    );
-    const withoutConn = generateSplitPreview(
-      OVERSIZED_PARAMS,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DISABLED_CONFIG
-    );
-
-    const femaleWith = withConn.pieces.find((p) => p.col === 2);
-    const femaleWithout = withoutConn.pieces.find((p) => p.col === 2);
-    expect(femaleWith).toBeDefined();
-    expect(femaleWithout).toBeDefined();
-    if (!femaleWith || !femaleWithout) return;
-
-    const femaleMinXWith = extremeXNearY(femaleWith.vertices, wallOffset, wt, 'min');
-    const femaleMinXWithout = extremeXNearY(femaleWithout.vertices, wallOffset, wt, 'min');
-    const femaleProtrusion = femaleMinXWithout - femaleMinXWith;
-    const expectedProtrusion = DEFAULT_SPLIT_CONNECTOR_CONFIG.tongueProtrusion;
-
-    expect(femaleProtrusion).toBeGreaterThan(expectedProtrusion - TESS_TOL - 0.5);
-  }, 60000);
-
-  it('half-lap at 1.6mm walls extends male piece past cut face', () => {
-    const generateSplitPreview = getGenerateSplitPreview();
-    const withConnectors = generateSplitPreview(
-      THICK_WALL_PARAMS,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DEFAULT_SPLIT_CONNECTOR_CONFIG
-    );
-    const withoutConnectors = generateSplitPreview(
-      THICK_WALL_PARAMS,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DISABLED_CONFIG
-    );
-
-    const maleWith = withConnectors.pieces.find((p) => p.col === 1);
-    const maleWithout = withoutConnectors.pieces.find((p) => p.col === 1);
-
-    if (!maleWith || !maleWithout) {
-      expect.fail('Expected to find male pieces (col === 1) in both results');
-    }
-
-    const bbWith = boundingBox(maleWith.vertices);
-    const bbWithout = boundingBox(maleWithout.vertices);
-
-    const protrusion = DEFAULT_SPLIT_CONNECTOR_CONFIG.tongueProtrusion;
-    const extensionX = bbWith.maxX - bbWithout.maxX;
-    expect(extensionX).toBeGreaterThan(protrusion - TESS_TOL - 0.5);
-  }, 60000);
-
-  it('lip max Z at wall positions is preserved with half-lap connectors', () => {
-    const generateSplitPreview = getGenerateSplitPreview();
-    const outerD = OVERSIZED_PARAMS.depth * SIZE - CLEARANCE;
-    const wt = OVERSIZED_PARAMS.wallThickness;
-    const wallOffset = outerD / 2 - wt / 2;
-    const wallTopZ = OVERSIZED_PARAMS.height * GRIDFINITY.HEIGHT_UNIT;
-    const expectedLipTop = wallTopZ + GRIDFINITY.LIP_HEIGHT;
-
-    const withConn = generateSplitPreview(
-      OVERSIZED_PARAMS,
-      CUT_PLANES_X,
-      CUT_PLANES_Y,
-      DEFAULT_SPLIT_CONNECTOR_CONFIG
-    );
-
-    // At each wall Y position, the lip should reach full height even with connectors.
-    // This catches the regression where half-lap cuts removed lip material.
-    for (const piece of withConn.pieces) {
-      let maxZAtWall = -Infinity;
-      for (let i = 0; i < piece.vertices.length; i += 3) {
-        if (Math.abs(Math.abs(piece.vertices[i + 1]) - wallOffset) < wt) {
-          maxZAtWall = Math.max(maxZAtWall, piece.vertices[i + 2]);
-        }
-      }
-      expect(maxZAtWall, `piece ${piece.label} lip truncated at wall`).toBeGreaterThan(
-        expectedLipTop - 1.0
-      );
-    }
-  }, 60000);
 
   // Regression: sketchOnPlane('XZ', pos) negated Y origin, causing Y-axis
   // prisms to land 40+ mm off instead of the expected ~3 mm protrusion.
@@ -611,6 +238,9 @@ describe('split connector geometry in preview meshes', () => {
       const conn = generateSplitPreview(params, cutsX, cutsY, DEFAULT_SPLIT_CONNECTOR_CONFIG);
       const base = generateSplitPreview(params, cutsX, cutsY, DISABLED_CONFIG);
 
+      // Male piece extends past cut face with scarf lap fuse.
+      // Female piece only gets ramp cut — no bounding box growth.
+      let totalGrowth = 0;
       for (let i = 0; i < conn.pieces.length; i++) {
         const connBB = boundingBox(conn.pieces[i].vertices);
         const baseBB = boundingBox(base.pieces[i].vertices);
@@ -623,11 +253,20 @@ describe('split connector geometry in preview meshes', () => {
           growth,
           `${axis}-split piece ${i} growth ${growth.toFixed(1)}mm exceeds max`
         ).toBeLessThan(maxAllowedGrowth);
+
         expect(
           growth,
-          `${axis}-split piece ${i} growth ${growth.toFixed(1)}mm — connector missing`
-        ).toBeGreaterThan(0);
+          `${axis}-split piece ${i} growth ${growth.toFixed(1)}mm — piece shrank`
+        ).toBeGreaterThanOrEqual(0);
+
+        totalGrowth += growth;
       }
+
+      // At least one piece must have positive growth (the male side)
+      expect(
+        totalGrowth,
+        `${axis}-split total growth ${totalGrowth.toFixed(1)}mm — no connectors applied`
+      ).toBeGreaterThan(0);
     }
   }, 120000);
 });

--- a/src/features/generation/worker/generators/binGenerator.scenario.split-robustness.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-robustness.test.ts
@@ -42,9 +42,8 @@ const NO_CONNECTORS: SplitConnectorConfig = { ...DEFAULT_SPLIT_CONNECTOR_CONFIG,
 // ─── Wall Thickness Permutations ────────────────────────────────────────────
 
 describe('split robustness: wall thickness permutations', () => {
-  // Test every discrete wall thickness option. The original crash was at 1.6mm
-  // where wall tongues first activate. Thicker walls produce wider tongues with
-  // different loft geometry. Thinner walls skip tongue features entirely.
+  // Test every discrete wall thickness option to ensure the floor scarf lap
+  // works correctly across all wall thicknesses without crashing.
   const wallThicknesses = [0.4, 0.8, 1.2, 1.6, 2.0, 2.4];
 
   for (const wt of wallThicknesses) {
@@ -108,8 +107,8 @@ describe('split robustness: base style permutations', () => {
 // ─── Lip + Thick Wall Combinations ──────────────────────────────────────────
 
 describe('split robustness: lip + wall thickness combinations', () => {
-  // The original crash was lip + 1.6mm. Test lip with all wall thicknesses
-  // that activate wall tongues (≥1.4mm where tongueWidth ≥ MIN_FEATURE_WIDTH).
+  // The original crash was lip + 1.6mm. Test lip with thicker wall options
+  // to ensure floor scarf lap works alongside the stacking lip.
   const thickWalls = [1.6, 1.8, 2.0, 2.4];
 
   for (const wt of thickWalls) {
@@ -394,7 +393,7 @@ describe('split robustness: connector configuration', () => {
     assertValidSplit(result, 2, params, 'zero clearance');
   }, 60000);
 
-  it('thick tongue (3.0mm) connectors at 2.0mm walls', () => {
+  it('deep protrusion (4.0mm) connectors at 2.0mm walls', () => {
     const generateSplitPreview = getGenerateSplitPreview();
     const params: BinParams = {
       ...DEFAULT_BIN_PARAMS,
@@ -411,7 +410,7 @@ describe('split robustness: connector configuration', () => {
     };
 
     const result = generateSplitPreview(params, [0], [], config);
-    assertValidSplit(result, 2, params, 'thick tongue');
+    assertValidSplit(result, 2, params, 'deep protrusion');
   }, 60000);
 
   it('disabled connectors still produce valid split at 2.4mm walls', () => {
@@ -449,7 +448,7 @@ describe('split robustness: regression tests', () => {
     const withoutConn = generateSplitPreview(params, [0], [], NO_CONNECTORS);
     assertValidSplit(withoutConn, 2, params, '7×3 1.6mm no connectors');
 
-    // With connectors should have more geometry (tongue protrusions)
+    // With connectors should have more geometry (ridge/scarf protrusions)
     const vertsWith = withConn.pieces.reduce((s, p) => s + p.vertices.length, 0);
     const vertsWithout = withoutConn.pieces.reduce((s, p) => s + p.vertices.length, 0);
     expect(vertsWith).toBeGreaterThan(vertsWithout);

--- a/src/features/generation/worker/generators/binGenerator.ts
+++ b/src/features/generation/worker/generators/binGenerator.ts
@@ -318,30 +318,11 @@ function splitSolidIntoPieces(
           centerX,
           centerY
         );
-        // Compute max cutout depth fraction across outer walls for tab clipping.
-        // Uses the global max across all 4 sides (conservative — tabs on walls with
-        // shallower cutouts will be shorter than necessary, but never protrude).
-        // Per-axis precision would require CutFace to carry wall side info.
-        const wallHeight = wallTopZ - floorZ;
-        let wallCutoutDepthFraction: number | undefined;
-        if (params.walls.enabled && wallHeight > 0) {
-          const interiorH = wallHeight - params.wallThickness;
-          for (const wallSide of ['front', 'back', 'left', 'right'] as const) {
-            const wallCfg = params.walls[wallSide];
-            const hasWidth = wallCfg.widthMm !== null ? wallCfg.widthMm > 0 : wallCfg.width > 0;
-            if (wallCfg.enabled && wallCfg.depth > 0 && hasWidth) {
-              // depth% is relative to interiorHeight, convert to fraction of total wallHeight
-              const fraction = (interiorH * wallCfg.depth) / (100 * wallHeight);
-              wallCutoutDepthFraction = Math.max(wallCutoutDepthFraction ?? 0, fraction);
-            }
-          }
-        }
         const geometryContext: BinGeometryContext = {
           floorZ,
           wallTopZ,
           wallThickness: params.wallThickness,
           floorThickness: params.wallThickness,
-          wallCutoutDepthFraction,
         };
         piece = applySplitConnectors(piece, cutFaces, geometryContext, connectorConfig);
       }

--- a/src/features/generation/worker/generators/splitConnectorBuilder.test.ts
+++ b/src/features/generation/worker/generators/splitConnectorBuilder.test.ts
@@ -9,6 +9,7 @@ vi.mock('brepjs', () => ({
       loftWith: vi.fn(() => 'lofted-shape'),
     })),
   })),
+  translateDrawing: vi.fn((drawing) => drawing),
   unwrap: vi.fn((v) => v),
   fuse: vi.fn((_a, b) => b),
   cut: vi.fn((a) => a),
@@ -16,11 +17,31 @@ vi.mock('brepjs', () => ({
   getBounds: vi.fn(() => ({ xMin: 0, xMax: 10, yMin: 0, yMax: 10, zMin: 0, zMax: 10 })),
 }));
 
-vi.mock('./generatorTypes', () => ({
-  sketch: vi.fn(() => ({ extrude: vi.fn(() => 'extruded-shape') })),
-}));
+const baseFace: CutFace = {
+  axis: 'x',
+  position: 0,
+  isMale: true,
+  binEdgeLength: 84,
+  pieceEdgeLength: 42,
+  pieceCenterOffset: 0,
+  perpendicularCuts: [],
+};
 
-describe('splitConnectorBuilder tab clipping', () => {
+const baseConfig = {
+  enabled: true,
+  clearance: 0.15,
+  tongueThickness: 2.4,
+  tongueProtrusion: 3.0,
+};
+
+const baseContext: BinGeometryContext = {
+  floorZ: 3.8,
+  wallTopZ: 24.8,
+  wallThickness: 1.2,
+  floorThickness: 1.2,
+};
+
+describe('splitConnectorBuilder', () => {
   let applySplitConnectors: typeof ApplySplitConnectorsFn;
 
   beforeEach(async () => {
@@ -29,73 +50,39 @@ describe('splitConnectorBuilder tab clipping', () => {
     applySplitConnectors = mod.applySplitConnectors;
   });
 
-  const baseFace: CutFace = {
-    axis: 'x',
-    position: 0,
-    isMale: true,
-    binEdgeLength: 84, // 2-unit bin width in mm
-    pieceEdgeLength: 42,
-    pieceCenterOffset: 0,
-    perpendicularCuts: [],
-  };
-
-  const baseConfig = {
-    enabled: true,
-    clearance: 0.15,
-    tongueThickness: 2.4,
-    tongueProtrusion: 3.0,
-  };
-
-  it('generates tabs at full wall height when no cutout fraction', () => {
-    const context: BinGeometryContext = {
-      floorZ: 3.8,
-      wallTopZ: 24.8,
-      wallThickness: 1.2,
-      floorThickness: 1.2,
-    };
-
-    // Should not throw and should return a result
-    const result = applySplitConnectors('piece' as any, [baseFace], context, baseConfig);
-    expect(result).toBeDefined();
-  });
-
-  it('generates tabs with clipped height when cutout fraction is set', () => {
-    const context: BinGeometryContext = {
-      floorZ: 3.8,
-      wallTopZ: 24.8,
-      wallThickness: 1.2,
-      floorThickness: 1.2,
-      wallCutoutDepthFraction: 0.5, // 50% cutout
-    };
-
-    const result = applySplitConnectors('piece' as any, [baseFace], context, baseConfig);
-    expect(result).toBeDefined();
-  });
-
-  it('skips wall tabs when cutout removes nearly all wall (fraction ≈ 1)', () => {
-    const context: BinGeometryContext = {
-      floorZ: 3.8,
-      wallTopZ: 24.8,
-      wallThickness: 1.2,
-      floorThickness: 1.2,
-      wallCutoutDepthFraction: 0.99, // 99% cutout → effective height < MIN_FEATURE_HEIGHT
-    };
-
-    // Should still return without error (tabs skipped, floor tongue may still apply)
-    const result = applySplitConnectors('piece' as any, [baseFace], context, baseConfig);
-    expect(result).toBeDefined();
-  });
-
   it('returns piece unchanged when no cut faces', () => {
-    const context: BinGeometryContext = {
-      floorZ: 3.8,
-      wallTopZ: 24.8,
-      wallThickness: 1.2,
-      floorThickness: 1.2,
-    };
-
-    const piece = 'unchanged-piece' as any;
-    const result = applySplitConnectors(piece, [], context, baseConfig);
+    const piece = 'unchanged-piece' as never;
+    const result = applySplitConnectors(piece, [], baseContext, baseConfig);
     expect(result).toBe(piece);
+  });
+
+  it('generates fuse target for male scarf lap', () => {
+    const face: CutFace = { ...baseFace, isMale: true };
+    const result = applySplitConnectors('piece' as never, [face], baseContext, baseConfig);
+    expect(result).toBeDefined();
+  });
+
+  it('generates cut target for female scarf ramp', () => {
+    const face: CutFace = { ...baseFace, isMale: false };
+    const result = applySplitConnectors('piece' as never, [face], baseContext, baseConfig);
+    expect(result).toBeDefined();
+  });
+
+  it('handles zero wall height gracefully', () => {
+    const context: BinGeometryContext = {
+      ...baseContext,
+      wallTopZ: baseContext.floorZ, // zero wall height
+    };
+    const result = applySplitConnectors('piece' as never, [baseFace], context, baseConfig);
+    expect(result).toBeDefined();
+  });
+
+  it('handles very thin floor gracefully', () => {
+    const context: BinGeometryContext = {
+      ...baseContext,
+      floorThickness: 0.1, // below MIN_FEATURE_HEIGHT
+    };
+    const result = applySplitConnectors('piece' as never, [baseFace], context, baseConfig);
+    expect(result).toBeDefined();
   });
 });

--- a/src/features/generation/worker/generators/splitConnectorBuilder.ts
+++ b/src/features/generation/worker/generators/splitConnectorBuilder.ts
@@ -1,52 +1,55 @@
 /**
  * Alignment connector builder for split bin pieces.
  *
- * Generates half-lap wall joints and tongue-and-groove floor features on cut
- * faces so split bin pieces can be aligned and glued together seamlessly.
+ * Generates FDM-friendly zero-overhang connectors on cut faces so split
+ * bin pieces can be aligned and glued together without print supports.
  *
- * - Wall connectors: half-lap joints with zero clearance for seamless
- *   exterior/interior surfaces. Each piece keeps half the wall thickness
- *   and extends it past the cut face to fill the opposing piece's recess.
- * - Floor tongue: horizontal tongue centered in the floor slab with 55°
- *   chamfers and configurable clearance for alignment during assembly.
+ * - Wall connectors: simple butt joints. Walls meet at the cut face with
+ *   no interlock features. The floor scarf lap provides alignment.
+ * - Floor connectors: 45° scarf lap joint. The male piece extends past
+ *   the cut face with a 45° underside slope; the female piece has a
+ *   matching 45° ramp cut into its floor. Both surfaces are at the FDM
+ *   self-supporting limit. Overlap distance = floor thickness.
  *
- * All features respect FDM printing constraints:
+ * FDM printing constraints:
  * - Minimum feature width: 0.7mm (~2x 0.4mm nozzle)
  * - Minimum feature height: 0.5mm (reliable OCCT boolean threshold)
- * - Minimum shell around grooves: 0.2mm (~1 print layer)
- * - 55° max overhang angle on floor tongue surfaces
+ * - All overhangs ≤ 45° (self-supporting on FDM without supports)
  * - Features shortened near corner intersections of perpendicular cuts
+ * - Width tapers 45° at scarf lap ends for self-supporting termination
  *
  * Direction convention (both male and female extrude in +axis):
- * - Male (tongue): sketch OVERLAP inside piece body, extrudes outward
- *   through the cut face. Fused onto the left/front piece.
- * - Female (groove): sketch OVERLAP outside piece body (past cut face),
- *   extrudes inward. Boolean subtraction clips the overhang, producing
- *   a groove that opens cleanly at the mating face.
+ * - Male (ridge/scarf overhang): sketch OVERLAP inside piece body,
+ *   extrudes outward through the cut face. Fused onto the left/front piece.
+ * - Female (channel/scarf ramp): sketch OVERLAP outside piece body
+ *   (past cut face), extrudes inward. Boolean subtraction clips the
+ *   overhang, producing a channel/ramp that opens cleanly at the mating face.
  */
 
-import { drawRectangle, unwrap, fuse, cut, translate, getBounds } from 'brepjs';
+import { drawRectangle, unwrap, fuse, cut, translate, getBounds, translateDrawing } from 'brepjs';
 import type { Shape3D, Sketch } from 'brepjs';
 import type { SplitConnectorConfig } from '@/shared/types/bin';
-import { sketch } from './generatorTypes';
 
 /** Overlap into the piece body so booleans have shared volume (mm). */
 export const OVERLAP = 1.0;
 
-/** Minimum printable feature width (mm). */
+/** Minimum printable feature width for horizontal features (mm, ~2× nozzle). */
 const MIN_FEATURE_WIDTH = 0.7;
 
 /** Minimum feature height (mm) for reliable OCCT boolean operations. */
 const MIN_FEATURE_HEIGHT = 0.5;
 
-/** Minimum shell thickness (mm) around a groove to remain printable. */
-const MIN_SHELL = 0.2;
-
 /** Tolerance for floating-point mm comparisons. */
 const EPSILON = 1e-9;
 
-/** Chamfer slope ratio (cot of max overhang angle). 0.7 = 55° overhang. */
-const CHAMFER_SLOPE = 0.7;
+/** Scarf lap angle in radians (45° = π/4). tan(45°) = 1.0 → overlap = floorThickness. */
+const SCARF_ANGLE = Math.PI / 4;
+
+/** Scarf lap slope ratio: overlap distance per unit of floor thickness. tan(45°) = 1.0 */
+const SCARF_SLOPE = Math.tan(SCARF_ANGLE);
+
+/** Width taper slope: 45° taper at each end of the scarf lap for self-supporting FDM. */
+const WIDTH_TAPER_SLOPE = 1.0;
 
 type Extent = [number, number, number];
 
@@ -65,8 +68,6 @@ export interface BinGeometryContext {
   readonly wallTopZ: number;
   readonly wallThickness: number;
   readonly floorThickness: number;
-  /** Fraction of wall height removed by the deepest wall cutout (0-1). Undefined = no cutout. */
-  readonly wallCutoutDepthFraction?: number;
 }
 
 export function applySplitConnectors(
@@ -182,180 +183,126 @@ export function computeCutFaces(
   return faces;
 }
 
-/** Rectangular prism. */
-function buildPrism(
+// ── Geometry Primitives ─────────────────────────────────────────────────────
+
+/**
+ * Build a wedge for scarf lap joint (floor connector).
+ *
+ * Ruled loft between two cross-sections at different positions along the
+ * cut axis, with the tip section shifted upward so top edges are
+ * coplanar. This creates a flat top + sloped bottom surface (the 45° ramp).
+ *
+ * - Base face: full rectangle (baseWidth × baseHeight) at the body side
+ * - Tip face: thin rectangle (tipWidth × tipHeight) shifted up so its
+ *   top edge aligns with the base's top edge
+ */
+function buildScarfWedge(
   cutAxis: 'x' | 'y',
   sketchPos: number,
   extrudeLen: number,
-  width: number,
-  height: number,
+  baseWidth: number,
+  tipWidth: number,
+  baseHeight: number,
+  tipHeight: number,
   bottomZ: number,
   edgeOffset: number
 ): Shape3D {
-  const rect = drawRectangle(width, height);
-  const sketchPlane = cutAxis === 'x' ? 'YZ' : 'XZ';
-  const prism = sketch(rect, sketchPlane, 0).extrude(extrudeLen);
-
-  const xOffset = cutAxis === 'x' ? sketchPos : edgeOffset;
-  const yOffset = cutAxis === 'x' ? edgeOffset : sketchPos + extrudeLen;
-
-  return translate(prism, [xOffset, yOffset, bottomZ + height / 2]);
-}
-
-/** Tapered prism via ruled loft with 55° chamfers. */
-function buildTaperedPrism(
-  cutAxis: 'x' | 'y',
-  sketchPos: number,
-  extrudeLen: number,
-  width: number,
-  height: number,
-  bottomZ: number,
-  edgeOffset: number
-): Shape3D {
-  const maxHeightChamfer = Math.max(0, (height - MIN_FEATURE_HEIGHT) / 2);
-  const maxWidthChamfer = Math.max(0, (width - MIN_FEATURE_WIDTH) / 2);
-  const heightChamfer = Math.min(extrudeLen * CHAMFER_SLOPE, maxHeightChamfer);
-  const widthChamfer = Math.min(extrudeLen * CHAMFER_SLOPE, maxWidthChamfer);
-
-  if ((heightChamfer < 0.1 && widthChamfer < 0.1) || height < 1.0 || width < 2.0) {
-    return buildPrism(cutAxis, sketchPos, extrudeLen, width, height, bottomZ, edgeOffset);
-  }
-
-  const tipWidth = width - 2 * widthChamfer;
-  const tipHeight = height - 2 * heightChamfer;
-
   const plane = cutAxis === 'x' ? 'YZ' : 'XZ';
   const [basePos, tipPos] = cutAxis === 'x' ? [0, extrudeLen] : [extrudeLen, 0];
 
-  const baseSection = drawRectangle(width, height).sketchOnPlane(plane, basePos) as Sketch;
-  const tipSection = drawRectangle(tipWidth, tipHeight).sketchOnPlane(plane, tipPos) as Sketch;
+  // Base section: centered at sketch origin
+  const baseSection = drawRectangle(baseWidth, baseHeight).sketchOnPlane(plane, basePos) as Sketch;
+
+  // Tip section: shifted upward in drawing-Y (maps to world-Z on YZ/XZ planes)
+  // so top edges align with base. The loft creates a flat top + sloped bottom.
+  // Shift = (baseHeight - tipHeight) / 2 because drawRectangle centers at origin.
+  const tipZShift = (baseHeight - tipHeight) / 2;
+  const tipDrawing = translateDrawing(drawRectangle(tipWidth, tipHeight), [0, tipZShift]);
+  const tipSection = tipDrawing.sketchOnPlane(plane, tipPos) as Sketch;
+
   const lofted = baseSection.loftWith([tipSection], { ruled: true });
 
   const xOffset = cutAxis === 'x' ? sketchPos : edgeOffset;
   const yOffset = cutAxis === 'x' ? edgeOffset : sketchPos + extrudeLen;
 
-  return translate(lofted, [xOffset, yOffset, bottomZ + height / 2]);
+  return translate(lofted, [xOffset, yOffset, bottomZ + baseHeight / 2]);
 }
 
+// ── Floor Scarf Lap ─────────────────────────────────────────────────────────
+
 /**
- * Build a tongue or groove and push to the appropriate target array.
- * Male = tapered tongue (fused). Female = rectangular groove (cut).
+ * Add a 45° scarf lap floor joint at a cut face.
+ *
+ * Male: wedge fused onto piece, extending past cut face with 45° underside.
+ * Female: wedge cut from piece, creating 45° ramp into floor (reversed slope).
+ *
+ * The scarf overlap distance = floorThickness × SCARF_SLOPE (= floorThickness at 45°).
+ * Width tapers 45° at each end for self-supporting FDM geometry.
  */
-function addFeature(
+function addScarfLapFeature(
   face: CutFace,
   clearance: number,
   fuseTargets: Shape3D[],
   cutTargets: Shape3D[],
-  extrudeLen: number,
-  width: number,
-  height: number,
-  bottomZ: number,
-  edgeOffset: number,
-  tapered: boolean
+  floorThickness: number,
+  floorZ: number,
+  effectiveWidth: number,
+  edgeOffset: number
 ): void {
-  if (face.isMale) {
-    const builder = tapered ? buildTaperedPrism : buildPrism;
-    fuseTargets.push(
-      builder(
-        face.axis,
-        face.position - OVERLAP,
-        extrudeLen + OVERLAP,
-        width,
-        height,
-        bottomZ,
-        edgeOffset
-      )
-    );
-  } else {
-    cutTargets.push(
-      buildPrism(
-        face.axis,
-        face.position - OVERLAP,
-        extrudeLen + clearance + OVERLAP,
-        width + clearance * 2,
-        height + clearance * 2,
-        bottomZ - clearance,
-        edgeOffset
-      )
-    );
-  }
-}
+  const overlapLen = floorThickness * SCARF_SLOPE;
 
-/**
- * Half-lap wall joint for seamless exterior/interior surfaces.
- *
- * Each piece gets a cut (removing the opposing half of wall) and a tab
- * (extending its own half past the cut face to fill the opposing recess).
- * Male = outer tab + inner cut. Female = inner tab + outer cut.
- *
- * Zero clearance on wall half-laps produces perfectly flush inner and
- * outer surfaces when assembled. The tab depth matches the groove depth
- * exactly, eliminating gaps at the bottom of the recess.
- */
-function addHalfLapWallFeature(
-  face: CutFace,
-  fuseTargets: Shape3D[],
-  cutTargets: Shape3D[],
-  lapDepth: number,
-  wallHeight: number,
-  bottomZ: number,
-  edgePos: number,
-  wallThickness: number
-): void {
-  if (edgePos === 0) return;
-  const sign = Math.sign(edgePos);
-  const halfWt = wallThickness / 2;
-  const isMale = face.isMale;
-  const halfShift = (sign * halfWt) / 2;
-
-  // Subtractive: remove opposing half of wall
-  const cutSketchPos = isMale ? face.position - lapDepth - OVERLAP : face.position - OVERLAP;
-  const cutDepth = lapDepth + 2 * OVERLAP;
-
-  cutTargets.push(
-    buildPrism(
-      face.axis,
-      cutSketchPos,
-      cutDepth,
-      halfWt,
-      wallHeight,
-      bottomZ,
-      edgePos + (isMale ? -halfShift : halfShift)
-    )
+  // Width taper: 45° at each end reduces effective width at the tip
+  const taperEach = Math.min(
+    overlapLen * WIDTH_TAPER_SLOPE,
+    effectiveWidth / 2 - MIN_FEATURE_WIDTH / 2
   );
+  const tipWidth = Math.max(MIN_FEATURE_WIDTH, effectiveWidth - 2 * Math.max(0, taperEach));
 
-  // Additive: extend own half past cut face, filling the opposing groove
-  const tabDepth = lapDepth + OVERLAP;
-
-  if (isMale) {
+  if (face.isMale) {
+    // Male: wedge extends past cut face. Base (full height) is inside piece,
+    // tip (near-zero height) is at the far end of the overhang.
     fuseTargets.push(
-      buildPrism(
+      buildScarfWedge(
         face.axis,
         face.position - OVERLAP,
-        tabDepth + OVERLAP,
-        halfWt,
-        wallHeight,
-        bottomZ,
-        edgePos + halfShift
+        overlapLen + OVERLAP,
+        effectiveWidth,
+        tipWidth,
+        floorThickness,
+        MIN_FEATURE_HEIGHT,
+        floorZ,
+        edgeOffset
       )
     );
   } else {
-    fuseTargets.push(
-      buildPrism(
+    // Female: ramp cut into floor — SAME wedge shape as male (flat top,
+    // sloped bottom), positioned at the cut face extending into the piece body.
+    // Thick end (full floor height) at the cut face, thin end deeper inside.
+    // The boolean cut removes this volume, creating the ramp channel.
+    const axisClearance = clearance / Math.cos(SCARF_ANGLE);
+    const widthClearance = clearance * 2;
+
+    cutTargets.push(
+      buildScarfWedge(
         face.axis,
-        face.position - tabDepth,
-        tabDepth + OVERLAP,
-        halfWt,
-        wallHeight,
-        bottomZ,
-        edgePos - halfShift
+        face.position - OVERLAP,
+        overlapLen + axisClearance + OVERLAP,
+        effectiveWidth + widthClearance,
+        tipWidth + widthClearance,
+        floorThickness + axisClearance,
+        MIN_FEATURE_HEIGHT,
+        floorZ - axisClearance / 2,
+        edgeOffset
       )
     );
   }
 }
 
+// ── Connector Orchestration ─────────────────────────────────────────────────
+
 /**
- * Add wall half-laps and floor tongue for a cut face.
+ * Add floor scarf lap connectors for a cut face.
+ * Walls use simple butt joints (no interlock features).
  */
 function addConnectors(
   face: CutFace,
@@ -368,45 +315,13 @@ function addConnectors(
   if (wallHeight <= 0) return;
 
   const wt = context.wallThickness;
-  const binHalfEdge = face.binEdgeLength / 2;
-  const wallOffset = binHalfEdge - wt / 2;
   const pieceMin = face.pieceCenterOffset - face.pieceEdgeLength / 2;
   const pieceMax = face.pieceCenterOffset + face.pieceEdgeLength / 2;
 
-  // ── Wall half-laps (seamless exterior/interior surfaces) ───────────────
-  // Clip tab height so it doesn't extend into the wall cutout region
-  const effectiveWallHeight =
-    context.wallCutoutDepthFraction !== undefined
-      ? wallHeight * (1 - context.wallCutoutDepthFraction)
-      : wallHeight;
-
-  for (const edgePos of [-wallOffset, wallOffset]) {
-    if (edgePos < pieceMin || edgePos > pieceMax) continue;
-    const nearCut = face.perpendicularCuts.some((cp) => Math.abs(edgePos - cp) < wt * 2);
-    if (nearCut) continue;
-    if (effectiveWallHeight < MIN_FEATURE_HEIGHT) continue;
-
-    addHalfLapWallFeature(
-      face,
-      fuseTargets,
-      cutTargets,
-      config.tongueProtrusion,
-      effectiveWallHeight,
-      context.floorZ,
-      edgePos,
-      wt
-    );
-  }
-
-  // ── Floor tongue (centered on piece, shortened near corners) ──────────
+  // ── Floor scarf lap (45° self-supporting joint, centered on piece) ──────
   const ft = context.floorThickness;
-  const maxGrooveHeight = ft - 2 * MIN_SHELL;
-  const floorHeight = Math.min(config.tongueThickness, maxGrooveHeight - 2 * config.clearance);
-  if (floorHeight >= MIN_FEATURE_HEIGHT - EPSILON) {
-    const floorCenterZ = context.floorZ + ft / 2;
-    const floorBottomZ = floorCenterZ - floorHeight / 2;
-    const margin = wt + config.tongueProtrusion;
-
+  if (ft >= MIN_FEATURE_HEIGHT) {
+    const margin = wt + ft * SCARF_SLOPE;
     const effectiveWidth = shortenForCorners(
       face.pieceEdgeLength * 0.7,
       face.pieceCenterOffset,
@@ -417,17 +332,15 @@ function addConnectors(
     );
 
     if (effectiveWidth >= MIN_FEATURE_WIDTH - EPSILON) {
-      addFeature(
+      addScarfLapFeature(
         face,
         config.clearance,
         fuseTargets,
         cutTargets,
-        config.tongueProtrusion,
+        ft,
+        context.floorZ,
         effectiveWidth,
-        floorHeight,
-        floorBottomZ,
-        face.pieceCenterOffset,
-        true
+        face.pieceCenterOffset
       );
     }
   }


### PR DESCRIPTION
## Summary

- Replace floor tongue-and-groove with 45° scarf lap joint — eliminates thin-roof overhang that caused stringing at 0.20mm layer height
- Replace wall half-lap joints with simple butt joints — eliminates horizontal overhang sagging, floor scarf provides alignment
- Add `ridgeWidthFraction` and `ridgeHeightFraction` optional fields to `SplitConnectorConfig` (backward-compatible, reserved for future wall features)

## Design

**Floor scarf lap:** Male piece extends past the cut face with a 45° sloped underside (self-supporting on FDM). Female piece has a matching 45° ramp cut into the floor. Overlap distance = floor thickness (1.2mm at 45°). Width tapers 45° at each end for fully self-supporting termination. Clearance is 0.15mm normal-to-surface.

**Wall butt joints:** Walls meet cleanly at the cut face with no interlock features. Alignment comes from the floor scarf lap; walls are glued.

## Test plan

- [x] Unit tests pass (splitConnectorBuilder.test.ts — 5 tests)
- [x] Scenario tests pass (split-connectors — 9 tests, split-robustness — all passing)
- [x] Full test suite passes (357 files, 5525 tests)
- [x] Typecheck, lint, boundary checks, i18n checks all pass
- [ ] Visual inspection of split preview in exploded view
- [ ] Test print of split bin with scarf lap connectors