### PR TITLE
chore: disable test:affected in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,7 +9,7 @@ if git diff --cached --name-only | grep -qE '^src/i18n/'; then
   pnpm run check:i18n:unused
 fi
 pnpm run check:exhaustiveness
-pnpm run test:affected
+# pnpm run test:affected  # disabled — too slow for pre-commit, run manually or in CI
 pnpm run check:component-structure
 pnpm run check:missing-tests
 pnpm run check:readme-reminders


### PR DESCRIPTION
## Summary
- Comment out `pnpm run test:affected` from pre-commit hook — too slow for iterative development
- Tests still run in CI via the Unit Tests workflow