### PR TITLE
fix: use catch-all rewrite for PostHog proxy routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -162,19 +162,9 @@
       "source": "/ph/static/:path(.*)",
       "destination": "https://us-assets.i.posthog.com/static/:path"
     },
-    { "source": "/ph/e", "destination": "https://us.i.posthog.com/e" },
-    { "source": "/ph/e/", "destination": "https://us.i.posthog.com/e/" },
-    { "source": "/ph/decide", "destination": "https://us.i.posthog.com/decide" },
-    { "source": "/ph/decide/", "destination": "https://us.i.posthog.com/decide/" },
-    { "source": "/ph/batch", "destination": "https://us.i.posthog.com/batch" },
-    { "source": "/ph/batch/", "destination": "https://us.i.posthog.com/batch/" },
     {
-      "source": "/ph/ses/:path(.*)",
-      "destination": "https://us.i.posthog.com/ses/:path"
-    },
-    {
-      "source": "/ph/s/:path(.*)",
-      "destination": "https://us.i.posthog.com/s/:path"
+      "source": "/ph/:path(.*)",
+      "destination": "https://us.i.posthog.com/:path"
     },
     { "source": "/what-is-gridfinity", "destination": "/what-is-gridfinity/index.html" },
     { "source": "/guide", "destination": "/guide/index.html" },


### PR DESCRIPTION
## Summary
- PostHog SDK v1.360.2 added new endpoints (`/array/`, `/flags`) not covered by the enumerated rewrite rules, causing 404 console errors in production
- Replaced 8 individual `/ph/*` rewrite rules with a single catch-all `"/ph/:path(.*)"` → `"https://us.i.posthog.com/:path"`
- Static assets rule kept separate to route through `us-assets.i.posthog.com` CDN

## Test plan
- [ ] Verify Vercel preview deployment has no PostHog 404s in browser console
- [ ] Confirm analytics events are being received in PostHog dashboard