### PR TITLE
chore(baseplate): remove superfluous Options section header

### DIFF
--- a/scripts/i18n-values-allowlist.json
+++ b/scripts/i18n-values-allowlist.json
@@ -153,7 +153,6 @@
     "baseplate.sectionBase",
     "baseplate.sideView",
     "baseplate.connectorNubs",
-    "baseplate.sectionOptions",
     "baseplate.connectorNubsHelp",
     "export.format",
     "export.nameStyle.compact"

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -241,15 +241,6 @@ export function BaseplatePanel() {
           </div>
         </StickyGroupHeader>
 
-        {/* Options divider — separates primary controls from rarely-changed settings */}
-        <div className="flex items-center gap-3 px-4 py-2">
-          <div className="h-px flex-1 bg-stroke-subtle" />
-          <span className="text-[10px] font-semibold uppercase tracking-widest text-content-tertiary">
-            {t('baseplate.sectionOptions')}
-          </span>
-          <div className="h-px flex-1 bg-stroke-subtle" />
-        </div>
-
         {/* 3. Base — magnet holes toggle */}
         <StickyGroupHeader
           title={t('baseplate.sectionBase')}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -51,7 +51,6 @@
   "baseplate.sectionBase": "Basis",
   "baseplate.sectionFitToDrawer": "Randpolsterung",
   "baseplate.sectionGridSize": "Rastergröße",
-  "baseplate.sectionOptions": "Optionen",
   "baseplate.sectionPrintSettings": "Druckeinstellungen",
   "baseplate.sectionView": "Ansicht",
   "baseplate.sideView": "Seite",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1477,7 +1477,6 @@ const en: Record<string, string> = {
   'baseplate.gridWidth': 'Width',
   'baseplate.gridDepth': 'Depth',
   'baseplate.filamentColor': 'Filament color',
-  'baseplate.sectionOptions': 'Options',
   'baseplate.initializingEngine': 'Initializing 3D engine...',
   'baseplate.elapsed': '{seconds}s',
 

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -51,7 +51,6 @@
   "baseplate.sectionBase": "Base",
   "baseplate.sectionFitToDrawer": "Relleno de bordes",
   "baseplate.sectionGridSize": "Tamaño de rejilla",
-  "baseplate.sectionOptions": "Opciones",
   "baseplate.sectionPrintSettings": "Ajustes de impresión",
   "baseplate.sectionView": "Vista",
   "baseplate.sideView": "Lado",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -51,7 +51,6 @@
   "baseplate.sectionBase": "Base",
   "baseplate.sectionFitToDrawer": "Marge de bord",
   "baseplate.sectionGridSize": "Taille de la grille",
-  "baseplate.sectionOptions": "Options",
   "baseplate.sectionPrintSettings": "Paramètres d'impression",
   "baseplate.sectionView": "Vue",
   "baseplate.sideView": "Côté",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -51,7 +51,6 @@
   "baseplate.sectionBase": "Base",
   "baseplate.sectionFitToDrawer": "Kantpolstring",
   "baseplate.sectionGridSize": "Rutenettstørrelse",
-  "baseplate.sectionOptions": "Alternativer",
   "baseplate.sectionPrintSettings": "Utskriftsinnstillinger",
   "baseplate.sectionView": "Visning",
   "baseplate.sideView": "Side",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -51,7 +51,6 @@
   "baseplate.sectionBase": "Basis",
   "baseplate.sectionFitToDrawer": "Randvulling",
   "baseplate.sectionGridSize": "Rastergrootte",
-  "baseplate.sectionOptions": "Opties",
   "baseplate.sectionPrintSettings": "Printinstellingen",
   "baseplate.sectionView": "Weergave",
   "baseplate.sideView": "Zij",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -51,7 +51,6 @@
   "baseplate.sectionBase": "Base",
   "baseplate.sectionFitToDrawer": "Preenchimento de borda",
   "baseplate.sectionGridSize": "Tamanho da grade",
-  "baseplate.sectionOptions": "Opções",
   "baseplate.sectionPrintSettings": "Configurações de impressão",
   "baseplate.sectionView": "Visualização",
   "baseplate.sideView": "Lado",


### PR DESCRIPTION
## Summary
- Removes the "Options" divider between Fit to Drawer and Base sections in the baseplate designer panel
- The `StickyGroupHeader` components already provide their own titles, making the extra divider redundant
- Cleans up `baseplate.sectionOptions` i18n key from all 7 locales and the allowlist

## Test plan
- [ ] Visual: baseplate panel flows directly from Fit to Drawer → Base → Print Settings without an extra "Options" label