### PR TITLE
fix(bin-designer): add bottom padding to export dialog

### DIFF
--- a/src/shared/components/ExportDialog/ExportDialog.tsx
+++ b/src/shared/components/ExportDialog/ExportDialog.tsx
@@ -159,7 +159,7 @@ export function ExportDialog({
     <Dialog.Root open={open} onClose={onClose} size="md">
       <Dialog.Header title={t('common.export')} />
       <Dialog.Body>
-        <div>
+        <div className="pb-2">
           {/* Section Title */}
           {sectionTitle && (
             <>


### PR DESCRIPTION
## Summary
- Adds `pb-2` to the export dialog's inner content wrapper in the shared `ExportDialog` component
- The `Dialog.Body` uses `py-0`, so content was flush against the bottom edge

## Test plan
- [x] All 9082 unit tests pass
- [ ] Visual check: open bin designer export dialog, confirm bottom spacing below buttons