### PR TITLE
perf(ci): shard PR unit tests across 2 parallel runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,15 @@ jobs:
           project-id: ${{ secrets.POSTHOG_PROJECT_ID }}
           api-key: ${{ secrets.POSTHOG_API_KEY }}
 
-  # PRs: Full test suite without coverage (fast feedback)
-  # Main: Full test suite with coverage thresholds (regression guard)
+  # PRs: Sharded test suite without coverage (fast feedback, 2 parallel runners)
+  # Main: Full test suite with coverage thresholds (regression guard, single runner)
   test:
-    name: Unit Tests
+    name: Unit Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ github.event_name == 'pull_request' && fromJSON('["1/2", "2/2"]') || fromJSON('["1/1"]') }}
     steps:
       - uses: actions/checkout@v6
 
@@ -82,13 +86,14 @@ jobs:
       - name: Run tests
         env:
           GIT_REF: ${{ github.ref }}
+          SHARD: ${{ matrix.shard }}
         run: |
           if [ "$GIT_REF" = "refs/heads/main" ]; then
             echo "Running with coverage (main branch)"
             pnpm run test:coverage
           else
-            echo "Running without coverage (PR)"
-            pnpm run test:run
+            echo "Running without coverage (PR, shard $SHARD)"
+            pnpm run test:run --shard="$SHARD"
           fi
 
       - name: Upload coverage report


### PR DESCRIPTION
## Summary
- Split the CI test job into 2 parallel shards on PRs using vitest's `--shard` flag
- Main branch keeps a single unsharded runner with coverage thresholds (unchanged)
- `fail-fast: false` ensures both shards report all failures

## Test plan
- [ ] Verify both shard jobs appear in the PR checks UI (`Unit Tests (1/2)` and `Unit Tests (2/2)`)
- [ ] Verify both shards pass and the full test suite is covered across them
- [ ] Verify main branch CI still runs a single `Unit Tests (1/1)` job with coverage
- [ ] Update branch protection rules if they reference the old `Unit Tests` check name