### PR TITLE
fix(ci): use -- separator for pnpm shard arg forwarding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
             pnpm run test:coverage
           else
             echo "Running without coverage (PR, shard $SHARD)"
-            pnpm run test:run --shard="$SHARD"
+            pnpm run test:run -- --shard="$SHARD"
           fi
 
       - name: Upload coverage report


### PR DESCRIPTION
## Summary
- Add `--` separator before `--shard` flag when calling `pnpm run test:run` to ensure explicit arg forwarding to vitest
- Addresses review comment from PR #1191

## Test plan
- [ ] Verify both shard jobs still pass with the `--` separator