### PR TITLE
feat(bin-designer): add corrugated wall pattern

### DIFF
--- a/src/features/bin-designer/components/panel/WallsSection/PatternSelector.test.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/PatternSelector.test.tsx
@@ -9,6 +9,7 @@ vi.mock('@/i18n', () => ({
       'binDesigner.walls.pattern.label': 'Wall pattern',
       'binDesigner.walls.pattern.none': 'Solid walls',
       'binDesigner.walls.pattern.honeycomb': 'Honeycomb',
+      'binDesigner.walls.pattern.corrugated': 'Corrugated',
     };
     return translations[key] ?? key;
   },
@@ -28,9 +29,10 @@ describe('PatternSelector', () => {
     const select = screen.getByRole('combobox');
     const options = select.querySelectorAll('option');
 
-    expect(options).toHaveLength(2);
+    expect(options).toHaveLength(3);
     expect(options[0]).toHaveTextContent('Solid walls');
     expect(options[1]).toHaveTextContent('Honeycomb');
+    expect(options[2]).toHaveTextContent('Corrugated');
   });
 
   it('shows "none" as selected when pattern is null', () => {
@@ -85,6 +87,23 @@ describe('PatternSelector', () => {
     );
 
     expect(screen.getByText('All walls have slots')).toBeInTheDocument();
+  });
+
+  it('disables individual pattern options via disabledPatterns', () => {
+    const disabledPatterns = new Set<'honeycomb' | 'corrugated'>(['corrugated']);
+    render(
+      <PatternSelector
+        selectedPattern={null}
+        onChange={() => {}}
+        disabledPatterns={disabledPatterns}
+      />
+    );
+
+    const select = screen.getByRole('combobox');
+    const options = select.querySelectorAll('option');
+    expect(options[0]).not.toBeDisabled(); // Solid
+    expect(options[1]).not.toBeDisabled(); // Honeycomb
+    expect(options[2]).toBeDisabled(); // Corrugated
   });
 
   it('does not show disabled reason when enabled', () => {

--- a/src/features/bin-designer/components/panel/WallsSection/PatternSelector.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/PatternSelector.tsx
@@ -26,6 +26,22 @@ function HoneycombIcon({ className }: { className?: string }) {
   );
 }
 
+/** SVG icon for corrugated pattern (sine wave) */
+function CorrugatedIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <path d="M3 12 C6 6, 9 6, 12 12 S18 18, 21 12" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 /** Pattern option configuration */
 interface PatternOption {
   value: WallPatternType | null;
@@ -37,6 +53,7 @@ interface PatternOption {
 const PATTERN_OPTIONS: PatternOption[] = [
   { value: null, labelKey: 'binDesigner.walls.pattern.none', icon: SolidIcon },
   { value: 'honeycomb', labelKey: 'binDesigner.walls.pattern.honeycomb', icon: HoneycombIcon },
+  { value: 'corrugated', labelKey: 'binDesigner.walls.pattern.corrugated', icon: CorrugatedIcon },
 ];
 
 interface PatternSelectorProps {
@@ -48,6 +65,8 @@ interface PatternSelectorProps {
   disabled?: boolean;
   /** Reason why the selector is disabled */
   disabledReason?: string;
+  /** Set of pattern types that are individually disabled (e.g., corrugated needs thick walls) */
+  disabledPatterns?: ReadonlySet<WallPatternType>;
 }
 
 export function PatternSelector({
@@ -55,6 +74,7 @@ export function PatternSelector({
   onChange,
   disabled = false,
   disabledReason,
+  disabledPatterns,
 }: PatternSelectorProps) {
   const t = useTranslation();
 
@@ -84,7 +104,11 @@ export function PatternSelector({
           className="w-full appearance-none rounded-md bg-surface-secondary text-content-primary text-sm py-2 pl-9 pr-8 border border-stroke-subtle disabled:cursor-not-allowed"
         >
           {PATTERN_OPTIONS.map(({ value, labelKey }) => (
-            <option key={value ?? 'none'} value={value ?? 'none'}>
+            <option
+              key={value ?? 'none'}
+              value={value ?? 'none'}
+              disabled={value !== null && disabledPatterns?.has(value)}
+            >
               {t(labelKey)}
             </option>
           ))}
@@ -106,6 +130,11 @@ export function PatternSelector({
       </div>
       {disabled && disabledReason && (
         <p className="text-[11px] text-content-tertiary mt-1.5">{disabledReason}</p>
+      )}
+      {!disabled && disabledPatterns && disabledPatterns.size > 0 && (
+        <p className="text-[11px] text-content-tertiary mt-1.5">
+          {t('binDesigner.walls.pattern.corrugatedThinWall')}
+        </p>
       )}
     </div>
   );

--- a/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
@@ -32,6 +32,7 @@ export function WallsSection() {
           onChange={handlers.handlePatternChange}
           disabled={state.patternDisabled}
           disabledReason={state.patternDisabledReason}
+          disabledPatterns={state.disabledPatterns}
         />
         {state.patternPartialNote && state.patternEnabled && (
           <p className="text-[11px] text-content-tertiary mt-1">{state.patternPartialNote}</p>

--- a/src/features/bin-designer/components/panel/WallsSection/useWallsSection.ts
+++ b/src/features/bin-designer/components/panel/WallsSection/useWallsSection.ts
@@ -6,8 +6,7 @@ import { useTranslation } from '@/i18n';
 import { getFeatureStatus } from '@/shared/constraints';
 import type { WallPatternType } from '@/features/bin-designer/types';
 import type { SnappingSliderOption } from '../../controls/SnappingSlider';
-/** Minimum wall thickness for corrugated pattern (mm). Must match corrugatedPattern.ts. */
-const CORRUGATED_MIN_WALL_THICKNESS = 1.6;
+import { CORRUGATED_MIN_WALL_THICKNESS } from '@/shared/constants/bin';
 
 export function useWallsSection() {
   const { wallThickness, wallPattern, params, setParam, updateWallPattern } = useDesignerStore(

--- a/src/features/bin-designer/components/panel/WallsSection/useWallsSection.ts
+++ b/src/features/bin-designer/components/panel/WallsSection/useWallsSection.ts
@@ -6,6 +6,8 @@ import { useTranslation } from '@/i18n';
 import { getFeatureStatus } from '@/shared/constraints';
 import type { WallPatternType } from '@/features/bin-designer/types';
 import type { SnappingSliderOption } from '../../controls/SnappingSlider';
+/** Minimum wall thickness for corrugated pattern (mm). Must match corrugatedPattern.ts. */
+const CORRUGATED_MIN_WALL_THICKNESS = 1.6;
 
 export function useWallsSection() {
   const { wallThickness, wallPattern, params, setParam, updateWallPattern } = useDesignerStore(
@@ -28,7 +30,20 @@ export function useWallsSection() {
     [t]
   );
 
-  const handleChange = useCallback((v: number) => setParam('wallThickness', v), [setParam]);
+  const handleChange = useCallback(
+    (v: number) => {
+      setParam('wallThickness', v);
+      // Auto-disable corrugated pattern if wall becomes too thin
+      if (
+        v < CORRUGATED_MIN_WALL_THICKNESS &&
+        wallPattern.enabled &&
+        wallPattern.pattern === 'corrugated'
+      ) {
+        updateWallPattern({ enabled: false });
+      }
+    },
+    [setParam, wallPattern, updateWallPattern]
+  );
 
   // Pattern selection handler
   const handlePatternChange = useCallback(
@@ -45,6 +60,15 @@ export function useWallsSection() {
   // Constraint-driven pattern availability
   const patternStatus = getFeatureStatus(params, 'wallPattern');
   const patternDisabledReason = patternStatus.reason ? t(patternStatus.reason) : undefined;
+
+  // Patterns that are unavailable due to parameter constraints
+  const disabledPatterns = useMemo(() => {
+    const disabled = new Set<WallPatternType>();
+    if (wallThickness < CORRUGATED_MIN_WALL_THICKNESS) {
+      disabled.add('corrugated');
+    }
+    return disabled;
+  }, [wallThickness]);
 
   // Partial note for UI hint when some (but not all) walls are slotted
   const someWallsSlotted = useMemo(() => {
@@ -67,6 +91,7 @@ export function useWallsSection() {
       patternDisabled: !patternStatus.available,
       patternDisabledReason,
       patternPartialNote,
+      disabledPatterns,
     },
     handlers: { handleChange, handlePatternChange },
     t,

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -206,7 +206,7 @@ export interface WallConfig {
 // Wall Pattern Types
 
 /** Supported wall pattern types. Extensible via pattern registry. */
-export type WallPatternType = 'honeycomb';
+export type WallPatternType = 'honeycomb' | 'corrugated';
 
 /** Wall pattern configuration — stored per design in BinParams */
 export interface WallPatternConfig {

--- a/src/features/generation/worker/generators/corrugatedWallBuilder.test.ts
+++ b/src/features/generation/worker/generators/corrugatedWallBuilder.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { createCorrugatedSpec, CORRUGATED_MIN_WALL_THICKNESS } from './patterns/corrugatedPattern';
+
+describe('corrugatedWallBuilder', () => {
+  describe('spec generation', () => {
+    it('creates valid spec for standard bin parameters', () => {
+      // 2×2 bin at 4u height, 1.6mm walls
+      const spec = createCorrugatedSpec(1.6, 28, 80.8, 4);
+      expect(spec).not.toBeNull();
+      expect(spec!.amplitude).toBeCloseTo(0.64);
+      expect(spec!.waveCount).toBeGreaterThanOrEqual(1);
+      expect(spec!.patternH).toBeGreaterThan(0);
+    });
+
+    it('rejects thin walls', () => {
+      const spec = createCorrugatedSpec(0.8, 28, 80.8, 4);
+      expect(spec).toBeNull();
+    });
+
+    it('rejects very short walls', () => {
+      // Wall height of 5mm with 1.6mm bottom keepout and 1.5mm top = 1.9mm patternH
+      // Wavelength for height=4 is ~12mm, half = 6mm > 1.9mm → null
+      const spec = createCorrugatedSpec(1.6, 5, 80.8, 4);
+      expect(spec).toBeNull();
+    });
+
+    it('adapts wavelength to bin height', () => {
+      const shortSpec = createCorrugatedSpec(1.6, 21, 40, 3);
+      const tallSpec = createCorrugatedSpec(1.6, 56, 40, 8);
+      expect(shortSpec).not.toBeNull();
+      expect(tallSpec).not.toBeNull();
+      // Tall bins use longer wavelength
+      expect(tallSpec!.wavelength).toBeGreaterThan(shortSpec!.wavelength);
+    });
+
+    it('exports minimum wall thickness constant', () => {
+      expect(CORRUGATED_MIN_WALL_THICKNESS).toBe(1.6);
+    });
+  });
+});

--- a/src/features/generation/worker/generators/corrugatedWallBuilder.ts
+++ b/src/features/generation/worker/generators/corrugatedWallBuilder.ts
@@ -69,27 +69,26 @@ function buildCorrugatedProfile(spec: CorrugatedWallSpec): Drawing {
   const innerPoints = generateInnerFacePoints(spec);
   const halfSpan = spec.wallSpan / 2;
 
-  // In the bin's coordinate system, walls extend outward (negative Y from
-  // the inner face for the front wall). The profile Y axis is negated so
-  // the geometry occupies the wall region, not the bin cavity.
+  // Outer face is at Y=0 (flat, at the existing shell boundary).
+  // Inner face follows the sine wave inward (positive Y = towards bin interior).
   //
-  // Y=0 = inner face (wall anchor point)
-  // Y=-wallThickness = outer face (flat, at grid boundary)
-  // Y=-wallThickness-amplitude = deepest corrugation point
+  // Y=0 = outer face (grid boundary, flat)
+  // Y=wallThickness = nominal inner face (at wave troughs)
+  // Y=wallThickness+amplitude = deepest corrugation point (at wave crests)
 
-  // Start at bottom-left of inner face
+  // Start at left of outer face
   let pen = draw([-halfSpan, 0]);
 
-  // Inner face: left to right (flat line at Y=0, the inner face boundary)
+  // Outer face: left to right (flat line at Y=0)
   pen = pen.lineTo([halfSpan, 0]);
 
-  // Right edge: step outward to outer sinusoidal face
+  // Right edge: step inward to inner sinusoidal face
   const lastInner = innerPoints[innerPoints.length - 1];
-  pen = pen.lineTo([lastInner[0], -lastInner[1]]);
+  pen = pen.lineTo([lastInner[0], lastInner[1]]);
 
-  // Outer face: right to left (sinusoidal wave, negated Y)
+  // Inner face: right to left (sinusoidal wave, depth from outer face)
   for (let i = innerPoints.length - 2; i >= 0; i--) {
-    pen = pen.lineTo([innerPoints[i][0], -innerPoints[i][1]]);
+    pen = pen.lineTo([innerPoints[i][0], innerPoints[i][1]]);
   }
 
   // Close: left edge back to start
@@ -109,10 +108,11 @@ function buildCorrugatedSolid(spec: CorrugatedWallSpec, wallPos: WallPosition): 
   // Sketch in XY plane at Z=bottomZ, extrude upward by patternH
   let solid = sketch(profile, 'XY', spec.bottomZ).extrude(spec.patternH);
 
-  // The profile is centered on the wall span. The Y axis in the profile
-  // maps to the wall's perpendicular direction. For the front wall,
-  // the outer face (Y=0) should be at -innerD/2 (the wall position).
-  // We need to shift so outer face aligns with the wall's inner surface.
+  // Profile has outer face at Y=0, inner face at positive Y.
+  // Wall anchors (translateX/Y) are at the INNER face position.
+  // Shift so the inner face (Y≈wallThickness) aligns with the anchor,
+  // meaning outer face (Y=0) ends up at anchor - wallThickness (the shell boundary).
+  solid = translate(solid, [0, -spec.wallThickness, 0]);
 
   // Rotate and translate to wall position
   if (wallPos.zRotation !== undefined) {
@@ -139,9 +139,9 @@ function buildFlatWallSlab(spec: CorrugatedWallSpec, wallPos: WallPosition): Sha
   const profile = drawRectangle(spec.wallSpan, slabDepth);
   let slab = sketch(profile, 'XY', spec.bottomZ - COPLANAR_MARGIN).extrude(slabHeight);
 
-  // Position slab to cover the wall region in negative Y direction.
-  // Y=0 = inner face, slab extends to -(wallThickness + amplitude + margin)
-  slab = translate(slab, [0, -slabDepth / 2, 0]);
+  // Match corrugated profile coordinate system: shift so slab is centered
+  // on the wall thickness region (same -wallThickness offset as the solid).
+  slab = translate(slab, [0, -spec.wallThickness, 0]);
 
   if (wallPos.zRotation !== undefined) {
     slab = rotate(slab, wallPos.zRotation, { axis: [0, 0, 1] });
@@ -449,7 +449,50 @@ export function buildCorrugatedWalls(ctx: PipelineContext): { cuts: Shape3D[]; f
     );
     if (!spec) continue;
 
-    // Cache key
+    // Cache key — must include all inputs that affect final clipped geometry
+    const cutoutCfg = params.walls.enabled ? params.walls[wallPos.side] : undefined;
+    const rampZones = computeRampZones(wallPos.side, params, innerW, innerD, wallHeight);
+
+    const cutoutKeyPart = cutoutCfg?.enabled
+      ? buildCacheKey(
+          'clip',
+          params.walls.shape,
+          cutoutCfg.widthMm !== null ? 'mm' : 'pct',
+          cutoutCfg.widthMm !== null ? quantize(cutoutCfg.widthMm) : quantize(cutoutCfg.width),
+          quantize(cutoutCfg.depth),
+          cutoutCfg.alignment,
+          quantize(cutoutCfg.offset),
+          dim.hasLip,
+          quantize(params.compartments.thickness)
+        )
+      : 'noclip';
+
+    const handleKeyPart =
+      params.handles.enabled &&
+      params.handles[wallPos.side]?.enabled &&
+      !(wallPos.side === 'back' && params.label.enabled)
+        ? buildCacheKey(
+            'hdl',
+            params.handles.shape,
+            params.handles.count,
+            quantize(params.handles[wallPos.side].width ?? params.handles.width),
+            quantize(params.handles[wallPos.side].height ?? params.handles.height),
+            quantize(params.handles.verticalPosition ?? 0)
+          )
+        : 'nohdl';
+
+    const rampKeyPart =
+      rampZones.length > 0
+        ? buildCacheKey(
+            'ramp',
+            rampZones
+              .map(
+                (z) => `${quantize(z.offsetAlongWall)}:${quantize(z.width)}:${quantize(z.height)}`
+              )
+              .join(',')
+          )
+        : 'noramp';
+
     const wallKey = compactKey(
       buildCacheKey(
         'v1',
@@ -464,27 +507,9 @@ export function buildCorrugatedWalls(ctx: PipelineContext): { cuts: Shape3D[]; f
         quantize(wallPos.translateX),
         quantize(wallPos.translateY),
         wallPos.zRotation ?? 0,
-        // Include cutout/handle config in cache key for clear zones
-        params.walls.enabled && params.walls[wallPos.side]?.enabled
-          ? buildCacheKey(
-              'clip',
-              params.walls.shape,
-              quantize(params.walls[wallPos.side].width),
-              quantize(params.walls[wallPos.side].depth),
-              params.walls[wallPos.side].alignment,
-              quantize(params.walls[wallPos.side].offset)
-            )
-          : 'noclip',
-        params.handles.enabled && params.handles[wallPos.side]?.enabled
-          ? buildCacheKey(
-              'hdl',
-              params.handles.shape,
-              params.handles.count,
-              quantize(params.handles[wallPos.side].width ?? params.handles.width),
-              quantize(params.handles[wallPos.side].height ?? params.handles.height),
-              quantize(params.handles.verticalPosition ?? 0)
-            )
-          : 'nohdl'
+        cutoutKeyPart,
+        handleKeyPart,
+        rampKeyPart
       )
     );
 

--- a/src/features/generation/worker/generators/corrugatedWallBuilder.ts
+++ b/src/features/generation/worker/generators/corrugatedWallBuilder.ts
@@ -1,0 +1,526 @@
+/**
+ * Corrugated wall geometry builder for Gridfinity bins.
+ *
+ * Replaces flat wall sections with sinusoidal corrugated profiles.
+ * The wave folds inward (outer face stays at grid boundary), maintaining
+ * uniform wall thickness along the sine curve.
+ *
+ * Returns { cut, fuse } pairs per wall:
+ *   - cut: flat wall slab to remove from the shell
+ *   - fuse: corrugated wall solid to add back
+ *
+ * Per-wall caching and cutout/handle/ramp clear-zone clipping are handled
+ * similarly to wallPatternBuilder.ts.
+ */
+
+import { draw, drawRectangle, unwrap, cut, clone, translate, rotate } from 'brepjs';
+import type { Shape3D, Drawing } from 'brepjs';
+import type { PipelineContext } from './pipeline/types';
+import { getSlotFreeWalls, CUTOUT_BORDER_WIDTH, getExpandedCutoutDimensions } from './wallPatterns';
+import { LIP_HEIGHT, LIP_TAPER_WIDTH, COPLANAR_MARGIN } from './generatorConstants';
+import { sketch } from './meshUtils';
+import { buildCacheKey, quantize, compactKey } from './cacheKeyUtils';
+import { checkCancelled, isAbortError } from './utils/abort';
+import { getFeatureCache, setFeatureCache } from './shapeCache';
+import { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
+import { computeRampZones } from './dividerBlendBuilder';
+import { buildSingleCutout } from './featureBuilder';
+import { FeatureTag } from './featureTags';
+import { collectOrigins } from './pipeline/collectOrigins';
+import {
+  buildHandleWallDefs,
+  computeHandleHoleGeometry,
+  computeWallHandleSegments,
+  U_SHAPE_OVERSHOOT,
+} from '@/shared/utils/handleCutoutClip';
+import { computeMultiHandleOffsets } from '@/shared/utils/handleLayout';
+import { createCorrugatedSpec, generateInnerFacePoints } from './patterns/corrugatedPattern';
+import type { CorrugatedWallSpec } from './patterns/corrugatedPattern';
+
+/** Wall side identifier. */
+type WallSide = 'front' | 'back' | 'left' | 'right';
+
+/** Positioning data for a single wall face. */
+interface WallPosition {
+  readonly side: WallSide;
+  readonly wallSpan: number;
+  readonly translateX: number;
+  readonly translateY: number;
+  readonly zRotation?: number;
+}
+
+/** A cut/fuse pair for one wall replacement. */
+interface WallReplacePair {
+  readonly cut: Shape3D;
+  readonly fuse: Shape3D;
+}
+
+/**
+ * Build a corrugated wall profile as a closed 2D drawing in the XZ plane.
+ *
+ * The profile represents the wall cross-section looking along the wall's
+ * depth (perpendicular) axis:
+ * - X axis = span position along the wall
+ * - Z (mapped to Y in the drawing) = depth into wall from outer face
+ *
+ * Outer face is at Y=0 (flat line), inner face follows the sine wave.
+ */
+function buildCorrugatedProfile(spec: CorrugatedWallSpec): Drawing {
+  const innerPoints = generateInnerFacePoints(spec);
+  const halfSpan = spec.wallSpan / 2;
+
+  // In the bin's coordinate system, walls extend outward (negative Y from
+  // the inner face for the front wall). The profile Y axis is negated so
+  // the geometry occupies the wall region, not the bin cavity.
+  //
+  // Y=0 = inner face (wall anchor point)
+  // Y=-wallThickness = outer face (flat, at grid boundary)
+  // Y=-wallThickness-amplitude = deepest corrugation point
+
+  // Start at bottom-left of inner face
+  let pen = draw([-halfSpan, 0]);
+
+  // Inner face: left to right (flat line at Y=0, the inner face boundary)
+  pen = pen.lineTo([halfSpan, 0]);
+
+  // Right edge: step outward to outer sinusoidal face
+  const lastInner = innerPoints[innerPoints.length - 1];
+  pen = pen.lineTo([lastInner[0], -lastInner[1]]);
+
+  // Outer face: right to left (sinusoidal wave, negated Y)
+  for (let i = innerPoints.length - 2; i >= 0; i--) {
+    pen = pen.lineTo([innerPoints[i][0], -innerPoints[i][1]]);
+  }
+
+  // Close: left edge back to start
+  return pen.close();
+}
+
+/**
+ * Build the corrugated wall solid for a single wall.
+ *
+ * Profile is sketched in XY plane at the bottom of the pattern zone,
+ * then extruded upward by patternH. The profile's Y axis maps to the
+ * wall's depth (perpendicular) direction.
+ */
+function buildCorrugatedSolid(spec: CorrugatedWallSpec, wallPos: WallPosition): Shape3D {
+  const profile = buildCorrugatedProfile(spec);
+
+  // Sketch in XY plane at Z=bottomZ, extrude upward by patternH
+  let solid = sketch(profile, 'XY', spec.bottomZ).extrude(spec.patternH);
+
+  // The profile is centered on the wall span. The Y axis in the profile
+  // maps to the wall's perpendicular direction. For the front wall,
+  // the outer face (Y=0) should be at -innerD/2 (the wall position).
+  // We need to shift so outer face aligns with the wall's inner surface.
+
+  // Rotate and translate to wall position
+  if (wallPos.zRotation !== undefined) {
+    solid = rotate(solid, wallPos.zRotation, { axis: [0, 0, 1] });
+  }
+  solid = translate(solid, [wallPos.translateX, wallPos.translateY, 0]);
+
+  return solid;
+}
+
+/**
+ * Build a flat wall slab that covers the corrugated zone.
+ *
+ * This slab is cut from the bin shell to remove the flat wall section
+ * before the corrugated replacement is fused in.
+ */
+function buildFlatWallSlab(spec: CorrugatedWallSpec, wallPos: WallPosition): Shape3D {
+  // The slab must be slightly oversized in depth to ensure a clean cut
+  // through the entire wall thickness, and slightly oversized in Z
+  // to avoid coplanar faces at the keep-out boundaries.
+  const slabDepth = spec.wallThickness + spec.amplitude + COPLANAR_MARGIN;
+  const slabHeight = spec.patternH + 2 * COPLANAR_MARGIN;
+
+  const profile = drawRectangle(spec.wallSpan, slabDepth);
+  let slab = sketch(profile, 'XY', spec.bottomZ - COPLANAR_MARGIN).extrude(slabHeight);
+
+  // Position slab to cover the wall region in negative Y direction.
+  // Y=0 = inner face, slab extends to -(wallThickness + amplitude + margin)
+  slab = translate(slab, [0, -slabDepth / 2, 0]);
+
+  if (wallPos.zRotation !== undefined) {
+    slab = rotate(slab, wallPos.zRotation, { axis: [0, 0, 1] });
+  }
+  slab = translate(slab, [wallPos.translateX, wallPos.translateY, 0]);
+
+  return slab;
+}
+
+/**
+ * Apply clear-zone clipping to both corrugated and cut-slab shapes.
+ *
+ * Uses the same CUTOUT_BORDER_WIDTH clipping approach as wallPatternBuilder:
+ * builds expanded clip solids around cutouts/handles/ramps and removes
+ * those regions from both shapes (preserving flat wall at those locations).
+ */
+function applyClipZones(
+  corrugated: Shape3D,
+  cutSlab: Shape3D,
+  wallPos: WallPosition,
+  ctx: PipelineContext
+): WallReplacePair | null {
+  const { params, dimensions: dim } = ctx;
+  let corrResult = corrugated;
+  let cutResult = cutSlab;
+
+  const cutoutCfg = params.walls.enabled ? params.walls[wallPos.side] : undefined;
+  const { hasLip } = dim;
+  const lipOverhang = hasLip ? LIP_TAPER_WIDTH : 0;
+  const maxThickness = Math.max(params.wallThickness, params.compartments.thickness);
+  const clipExtrudeDepth = (maxThickness + lipOverhang) * 2 + 1;
+  const clipOvershoot = (hasLip ? LIP_HEIGHT : 0) + 2;
+
+  // --- Cutout clear zone ---
+  if (cutoutCfg?.enabled) {
+    const cutWidth =
+      cutoutCfg.widthMm !== null
+        ? Math.min(cutoutCfg.widthMm, wallPos.wallSpan)
+        : wallPos.wallSpan * (cutoutCfg.width / 100);
+    const interiorWallHeight = dim.wallHeight - params.wallThickness;
+    const userCutHeight = interiorWallHeight * (cutoutCfg.depth / 100);
+
+    if (cutWidth >= 0.1 && userCutHeight >= 0.1) {
+      const { expandedWidth, expandedHeight } = getExpandedCutoutDimensions(
+        cutWidth,
+        userCutHeight,
+        CUTOUT_BORDER_WIDTH
+      );
+
+      // If expanded cutout covers the entire span, skip this wall entirely
+      if (expandedWidth >= wallPos.wallSpan) {
+        corrResult.delete();
+        cutResult.delete();
+        return null;
+      }
+
+      const rotateZ = wallPos.side === 'left' || wallPos.side === 'right' ? 90 : 0;
+      const centerOffset = computeCutoutCenter(
+        wallPos.wallSpan,
+        cutWidth,
+        params.wallThickness,
+        cutoutCfg.alignment,
+        cutoutCfg.offset
+      );
+
+      const clipSolid = buildSingleCutout(
+        params.walls.shape,
+        expandedWidth,
+        expandedHeight,
+        clipOvershoot,
+        clipExtrudeDepth,
+        dim.wallHeight,
+        {
+          x: rotateZ === 0 ? wallPos.translateX + centerOffset : wallPos.translateX,
+          y: rotateZ !== 0 ? wallPos.translateY + centerOffset : wallPos.translateY,
+          rotateZ,
+        }
+      );
+
+      const clipClone = unwrap(clone(clipSolid));
+      try {
+        const clippedCorr = unwrap(cut(corrResult, clipSolid));
+        corrResult.delete();
+        corrResult = clippedCorr;
+        const clippedCut = unwrap(cut(cutResult, clipClone));
+        cutResult.delete();
+        cutResult = clippedCut;
+      } catch (err: unknown) {
+        if (isAbortError(err)) {
+          corrResult.delete();
+          cutResult.delete();
+          throw err;
+        }
+      } finally {
+        try {
+          clipSolid.delete();
+        } catch {
+          /* already consumed or disposed */
+        }
+        try {
+          clipClone.delete();
+        } catch {
+          /* already consumed or disposed */
+        }
+      }
+    }
+  }
+
+  // --- Handle clear zone ---
+  const { innerW, innerD, interiorHeight, isSlotted } = dim;
+  const handleWallDefs = params.handles.enabled ? buildHandleWallDefs(innerW, innerD) : [];
+  const handleWall = handleWallDefs.find((d) => d.side === wallPos.side);
+
+  if (
+    params.handles.enabled &&
+    !isSlotted &&
+    handleWall &&
+    params.handles[wallPos.side]?.enabled &&
+    !(wallPos.side === 'back' && params.label.enabled)
+  ) {
+    const isUShape = params.handles.shape === 'u-shape';
+    const side = params.handles[wallPos.side];
+    const sideHeight = side.height ?? params.handles.height;
+    const sideWidth = side.width ?? params.handles.width;
+
+    let handleCenterZ: number;
+    let handleEffHeight: number;
+    if (isUShape) {
+      const clampedHeight = Math.min(sideHeight, interiorHeight);
+      handleEffHeight = clampedHeight + U_SHAPE_OVERSHOOT;
+      handleCenterZ = (clampedHeight - U_SHAPE_OVERSHOOT) / 2;
+    } else {
+      const geom = computeHandleHoleGeometry(
+        interiorHeight,
+        sideHeight,
+        params.handles.verticalPosition
+      );
+      handleCenterZ = geom.centerZ;
+      handleEffHeight = geom.effectiveHeight;
+    }
+
+    if (handleEffHeight >= 1) {
+      const handleCutoutCfg = params.walls.enabled ? params.walls[wallPos.side] : undefined;
+      const baseSegments = computeWallHandleSegments(
+        wallPos.wallSpan,
+        sideWidth,
+        params.wallThickness,
+        handleCutoutCfg
+      );
+
+      if (baseSegments && baseSegments.length > 0) {
+        const handleWidthMm = wallPos.wallSpan * (sideWidth / 100);
+        const offsets = computeMultiHandleOffsets(
+          params.handles.count,
+          wallPos.wallSpan,
+          handleWidthMm
+        );
+
+        const border = CUTOUT_BORDER_WIDTH;
+        for (const handleOffset of offsets) {
+          for (const seg of baseSegments) {
+            const boxW = seg.width + 2 * border;
+            const boxH = handleEffHeight + 2 * border;
+            const profile = drawRectangle(boxW, boxH);
+            let hbox = sketch(profile, 'XZ').extrude(clipExtrudeDepth);
+            hbox = translate(hbox, [
+              seg.offset + handleOffset,
+              clipExtrudeDepth / 2,
+              handleCenterZ,
+            ]);
+            if (handleWall.rotateZ !== 0) {
+              hbox = rotate(hbox, handleWall.rotateZ, { axis: [0, 0, 1] });
+            }
+            hbox = translate(hbox, [handleWall.x, handleWall.y, 0]);
+
+            const hboxClone = unwrap(clone(hbox));
+            try {
+              const clippedCorr = unwrap(cut(corrResult, hbox));
+              corrResult.delete();
+              corrResult = clippedCorr;
+              const clippedCut = unwrap(cut(cutResult, hboxClone));
+              cutResult.delete();
+              cutResult = clippedCut;
+            } catch (err: unknown) {
+              if (isAbortError(err)) {
+                corrResult.delete();
+                cutResult.delete();
+                throw err;
+              }
+            } finally {
+              try {
+                hbox.delete();
+              } catch {
+                /* already consumed or disposed */
+              }
+              try {
+                hboxClone.delete();
+              } catch {
+                /* already consumed or disposed */
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // --- Ramp zone clear zone ---
+  const rampZones = computeRampZones(wallPos.side, params, innerW, innerD, dim.wallHeight);
+  if (rampZones.length > 0) {
+    const border = CUTOUT_BORDER_WIDTH;
+    for (const zone of rampZones) {
+      const rboxW = zone.width + 2 * border;
+      const rboxH = zone.height + 2 * border;
+      const profile = drawRectangle(rboxW, rboxH);
+      let rbox = sketch(profile, 'XZ').extrude(clipExtrudeDepth);
+      const centerZ = dim.wallHeight - zone.height / 2;
+      rbox = translate(rbox, [zone.offsetAlongWall, clipExtrudeDepth / 2, centerZ]);
+      if (wallPos.zRotation !== undefined) {
+        rbox = rotate(rbox, wallPos.zRotation, { axis: [0, 0, 1] });
+      }
+      rbox = translate(rbox, [wallPos.translateX, wallPos.translateY, 0]);
+
+      const rboxClone = unwrap(clone(rbox));
+      try {
+        const clippedCorr = unwrap(cut(corrResult, rbox));
+        corrResult.delete();
+        corrResult = clippedCorr;
+        const clippedCut = unwrap(cut(cutResult, rboxClone));
+        cutResult.delete();
+        cutResult = clippedCut;
+      } catch (err: unknown) {
+        if (isAbortError(err)) {
+          corrResult.delete();
+          cutResult.delete();
+          throw err;
+        }
+      } finally {
+        try {
+          rbox.delete();
+        } catch {
+          /* already consumed or disposed */
+        }
+        try {
+          rboxClone.delete();
+        } catch {
+          /* already consumed or disposed */
+        }
+      }
+    }
+  }
+
+  return { cut: cutResult, fuse: corrResult };
+}
+
+/**
+ * Build corrugated wall replacements for all eligible walls.
+ *
+ * Returns arrays of cut/fuse shape pairs to be applied in the boolean stage.
+ */
+export function buildCorrugatedWalls(ctx: PipelineContext): { cuts: Shape3D[]; fuses: Shape3D[] } {
+  const { params, dimensions: dim, signal, originToTag } = ctx;
+  const { innerW, innerD, wallHeight } = dim;
+  const cuts: Shape3D[] = [];
+  const fuses: Shape3D[] = [];
+
+  const slotFree = getSlotFreeWalls(params);
+
+  const wallPositions: WallPosition[] = [];
+  if (slotFree.front)
+    wallPositions.push({ side: 'front', wallSpan: innerW, translateX: 0, translateY: -innerD / 2 });
+  if (slotFree.back)
+    wallPositions.push({
+      side: 'back',
+      wallSpan: innerW,
+      translateX: 0,
+      translateY: innerD / 2,
+      zRotation: 180,
+    });
+  if (slotFree.left)
+    wallPositions.push({
+      side: 'left',
+      wallSpan: innerD,
+      translateX: -innerW / 2,
+      translateY: 0,
+      zRotation: 90,
+    });
+  if (slotFree.right)
+    wallPositions.push({
+      side: 'right',
+      wallSpan: innerD,
+      translateX: innerW / 2,
+      translateY: 0,
+      zRotation: -90,
+    });
+
+  for (const wallPos of wallPositions) {
+    checkCancelled(signal);
+
+    const spec = createCorrugatedSpec(
+      params.wallThickness,
+      wallHeight,
+      wallPos.wallSpan,
+      params.height
+    );
+    if (!spec) continue;
+
+    // Cache key
+    const wallKey = compactKey(
+      buildCacheKey(
+        'v1',
+        'corrugated',
+        quantize(spec.amplitude),
+        quantize(spec.wavelength),
+        quantize(spec.patternH),
+        quantize(spec.bottomZ),
+        quantize(spec.wallSpan),
+        quantize(spec.wallThickness),
+        spec.waveCount,
+        quantize(wallPos.translateX),
+        quantize(wallPos.translateY),
+        wallPos.zRotation ?? 0,
+        // Include cutout/handle config in cache key for clear zones
+        params.walls.enabled && params.walls[wallPos.side]?.enabled
+          ? buildCacheKey(
+              'clip',
+              params.walls.shape,
+              quantize(params.walls[wallPos.side].width),
+              quantize(params.walls[wallPos.side].depth),
+              params.walls[wallPos.side].alignment,
+              quantize(params.walls[wallPos.side].offset)
+            )
+          : 'noclip',
+        params.handles.enabled && params.handles[wallPos.side]?.enabled
+          ? buildCacheKey(
+              'hdl',
+              params.handles.shape,
+              params.handles.count,
+              quantize(params.handles[wallPos.side].width ?? params.handles.width),
+              quantize(params.handles[wallPos.side].height ?? params.handles.height),
+              quantize(params.handles.verticalPosition ?? 0)
+            )
+          : 'nohdl'
+      )
+    );
+
+    // Check cache — cache stores [cutShape, fuseShape] as a compound
+    const cachedFuse = getFeatureCache('corrugatedWall', wallKey);
+    const cachedCut = getFeatureCache('corrugatedCut', wallKey);
+    if (cachedFuse && cachedCut) {
+      const fuseClone = unwrap(clone(cachedFuse));
+      const cutClone = unwrap(clone(cachedCut));
+      collectOrigins(fuseClone, FeatureTag.WALL_PATTERN, originToTag);
+      fuses.push(fuseClone);
+      cuts.push(cutClone);
+      continue;
+    }
+
+    // Build fresh
+    try {
+      const corrugated = buildCorrugatedSolid(spec, wallPos);
+      const cutSlab = buildFlatWallSlab(spec, wallPos);
+      const pair = applyClipZones(corrugated, cutSlab, wallPos, ctx);
+
+      if (pair) {
+        // Cache the originals, return clones
+        setFeatureCache('corrugatedWall', wallKey, pair.fuse);
+        setFeatureCache('corrugatedCut', wallKey, pair.cut);
+        const fuseClone = unwrap(clone(pair.fuse));
+        const cutClone = unwrap(clone(pair.cut));
+        collectOrigins(fuseClone, FeatureTag.WALL_PATTERN, originToTag);
+        fuses.push(fuseClone);
+        cuts.push(cutClone);
+      }
+    } catch (err: unknown) {
+      if (isAbortError(err)) throw err;
+      // On geometry failure, skip this wall silently
+    }
+  }
+
+  return { cuts, fuses };
+}

--- a/src/features/generation/worker/generators/patterns/corrugatedPattern.test.ts
+++ b/src/features/generation/worker/generators/patterns/corrugatedPattern.test.ts
@@ -40,8 +40,8 @@ describe('createCorrugatedSpec', () => {
     expect(spec?.wavelength).toBeCloseTo(40 / 3);
   });
 
-  it('returns null when pattern height is too short for half a wavelength', () => {
-    // Very short wall: wallHeight=4, bottomKeepOut=1.6, topKeepOut=1.5 → patternH=0.9
+  it('returns null when pattern height is too short', () => {
+    // Very short wall: wallHeight=4, bottomKeepOut=1.6, topKeepOut=1.5 → patternH=0.9 < 2mm min
     const spec = createCorrugatedSpec(1.6, 4, 40, 4);
     expect(spec).toBeNull();
   });

--- a/src/features/generation/worker/generators/patterns/corrugatedPattern.test.ts
+++ b/src/features/generation/worker/generators/patterns/corrugatedPattern.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createCorrugatedSpec,
+  getBaseWavelength,
+  generateInnerFacePoints,
+  SEGMENTS_PER_HALF_WAVE,
+} from './corrugatedPattern';
+
+describe('createCorrugatedSpec', () => {
+  it('returns null when wall thickness is below minimum', () => {
+    expect(createCorrugatedSpec(0.8, 30, 40, 4)).toBeNull();
+    expect(createCorrugatedSpec(1.2, 30, 40, 4)).toBeNull();
+  });
+
+  it('returns a spec when wall thickness meets minimum', () => {
+    const spec = createCorrugatedSpec(1.6, 30, 40, 4);
+    expect(spec).not.toBeNull();
+  });
+
+  it('computes amplitude as wallThickness × 0.4', () => {
+    const spec = createCorrugatedSpec(1.6, 30, 40, 4);
+    expect(spec?.amplitude).toBeCloseTo(0.64);
+
+    const spec2 = createCorrugatedSpec(2.4, 30, 40, 4);
+    expect(spec2?.amplitude).toBeCloseTo(0.96);
+  });
+
+  it('computes bottomZ as max(1.0, wallThickness)', () => {
+    const spec = createCorrugatedSpec(1.6, 30, 40, 4);
+    expect(spec?.bottomZ).toBe(1.6);
+
+    const spec2 = createCorrugatedSpec(2.4, 30, 40, 4);
+    expect(spec2?.bottomZ).toBe(2.4);
+  });
+
+  it('phase-aligns wavelength to fit integer waves in span', () => {
+    // Base wavelength for height=4 is 12mm. Span=40 → round(40/12)=3 → λ=40/3≈13.33
+    const spec = createCorrugatedSpec(1.6, 30, 40, 4);
+    expect(spec?.waveCount).toBe(3);
+    expect(spec?.wavelength).toBeCloseTo(40 / 3);
+  });
+
+  it('returns null when pattern height is too short for half a wavelength', () => {
+    // Very short wall: wallHeight=4, bottomKeepOut=1.6, topKeepOut=1.5 → patternH=0.9
+    const spec = createCorrugatedSpec(1.6, 4, 40, 4);
+    expect(spec).toBeNull();
+  });
+
+  it('returns null when wall span is too narrow for corrugation', () => {
+    // Span=3mm with base wavelength 12mm → 3 < 12/2 = too narrow
+    const spec = createCorrugatedSpec(1.6, 30, 3, 4);
+    expect(spec).toBeNull();
+  });
+});
+
+describe('getBaseWavelength', () => {
+  it('returns 8mm for short bins (≤3u)', () => {
+    expect(getBaseWavelength(1)).toBe(8);
+    expect(getBaseWavelength(3)).toBe(8);
+  });
+
+  it('returns 12mm for medium bins (4-6u)', () => {
+    expect(getBaseWavelength(4)).toBe(12);
+    expect(getBaseWavelength(6)).toBe(12);
+  });
+
+  it('returns 16mm for tall bins (>6u)', () => {
+    expect(getBaseWavelength(7)).toBe(16);
+    expect(getBaseWavelength(10)).toBe(16);
+  });
+});
+
+describe('generateInnerFacePoints', () => {
+  it('generates correct number of points', () => {
+    const spec = createCorrugatedSpec(1.6, 30, 40, 4);
+    expect(spec).not.toBeNull();
+    const points = generateInnerFacePoints(spec!);
+    // waveCount * segmentsPerHalfWave * 2 + 1 (fence-post)
+    expect(points.length).toBe(spec!.waveCount * SEGMENTS_PER_HALF_WAVE * 2 + 1);
+  });
+
+  it('starts and ends at span edges', () => {
+    const spec = createCorrugatedSpec(1.6, 30, 40, 4);
+    expect(spec).not.toBeNull();
+    const points = generateInnerFacePoints(spec!);
+    expect(points[0][0]).toBeCloseTo(-20); // -halfSpan
+    expect(points[points.length - 1][0]).toBeCloseTo(20); // +halfSpan
+  });
+
+  it('has Y values within expected range', () => {
+    const spec = createCorrugatedSpec(1.6, 30, 40, 4);
+    expect(spec).not.toBeNull();
+    const points = generateInnerFacePoints(spec!);
+    const minY = spec!.wallThickness;
+    const maxY = spec!.wallThickness + spec!.amplitude;
+    for (const [, y] of points) {
+      expect(y).toBeGreaterThanOrEqual(minY - 0.001);
+      expect(y).toBeLessThanOrEqual(maxY + 0.001);
+    }
+  });
+
+  it('has crests (maximum thickness) at span edges', () => {
+    const spec = createCorrugatedSpec(1.6, 30, 40, 4);
+    expect(spec).not.toBeNull();
+    const points = generateInnerFacePoints(spec!);
+    const maxY = spec!.wallThickness + spec!.amplitude;
+    // First and last points should be at wave crests (cosine=1 at x=0 offset)
+    expect(points[0][1]).toBeCloseTo(maxY);
+    expect(points[points.length - 1][1]).toBeCloseTo(maxY);
+  });
+});

--- a/src/features/generation/worker/generators/patterns/corrugatedPattern.ts
+++ b/src/features/generation/worker/generators/patterns/corrugatedPattern.ts
@@ -1,0 +1,141 @@
+/**
+ * Corrugated wall pattern calculator.
+ *
+ * Computes wave parameters for a sinusoidal corrugated wall profile.
+ * Pure math module — no brepjs imports.
+ *
+ * The corrugated wall replaces the flat wall with a uniform-thickness
+ * sinusoidal profile. The wave folds inward from the outer face (which
+ * stays at the standard gridfinity boundary). Arc segments approximate
+ * the sine curve.
+ *
+ * Cross-section (top-down, looking at one wall):
+ *
+ *   outer face (flat, at grid boundary)
+ *   │                              │
+ *   │─╮    ╭───╮    ╭───╮    ╭──│
+ *   │ ╰───╯   ╰───╯   ╰───╯   │
+ *   │                              │
+ *     interior (wavy surface)
+ */
+
+import { TOP_KEEP_OUT, MIN_BOTTOM_KEEP_OUT } from '../wallPatterns';
+
+/** Minimum wall thickness required for corrugation (mm). */
+export const CORRUGATED_MIN_WALL_THICKNESS = 1.6;
+
+/** Amplitude multiplier: amplitude = wallThickness × this factor. */
+const AMPLITUDE_RATIO = 0.4;
+
+/** Base wavelengths by bin height tier (mm). Adaptive sizing like honeycomb. */
+const WAVELENGTH_SHORT = 8; // binHeight ≤ 3u
+const WAVELENGTH_MEDIUM = 12; // binHeight ≤ 6u
+const WAVELENGTH_TALL = 16; // binHeight > 6u
+
+/** Number of line segments per half-wavelength for profile approximation. */
+export const SEGMENTS_PER_HALF_WAVE = 8;
+
+/** Specification for building a corrugated wall solid. */
+export interface CorrugatedWallSpec {
+  /** Wave amplitude (mm) — max inward displacement from outer face */
+  readonly amplitude: number;
+  /** Wave wavelength (mm) — phase-aligned to fit integer waves in wall span */
+  readonly wavelength: number;
+  /** Total span this wall covers (mm) */
+  readonly wallSpan: number;
+  /** Usable height for corrugation after keep-outs (mm) */
+  readonly patternH: number;
+  /** Z coordinate of the bottom of the corrugated zone (mm) */
+  readonly bottomZ: number;
+  /** Nominal wall thickness (mm) */
+  readonly wallThickness: number;
+  /** Number of complete waves fitting in the wall span */
+  readonly waveCount: number;
+}
+
+/**
+ * Get the base wavelength for a given bin height (in grid height units).
+ */
+export function getBaseWavelength(binHeight: number): number {
+  if (binHeight <= 3) return WAVELENGTH_SHORT;
+  if (binHeight <= 6) return WAVELENGTH_MEDIUM;
+  return WAVELENGTH_TALL;
+}
+
+/**
+ * Create a corrugated wall specification.
+ *
+ * Returns null if the wall is too thin, too short, or too narrow
+ * for meaningful corrugation.
+ *
+ * @param wallThickness - Nominal wall thickness (mm)
+ * @param wallHeight - Total wall height available (mm)
+ * @param wallSpan - Wall span along the face (mm)
+ * @param binHeight - Bin height in grid units (for wavelength selection)
+ */
+export function createCorrugatedSpec(
+  wallThickness: number,
+  wallHeight: number,
+  wallSpan: number,
+  binHeight: number
+): CorrugatedWallSpec | null {
+  if (wallThickness < CORRUGATED_MIN_WALL_THICKNESS) return null;
+
+  const bottomKeepOut = Math.max(MIN_BOTTOM_KEEP_OUT, wallThickness);
+  const patternH = wallHeight - TOP_KEEP_OUT - bottomKeepOut;
+
+  const amplitude = wallThickness * AMPLITUDE_RATIO;
+  const baseWavelength = getBaseWavelength(binHeight);
+
+  // Phase-align: snap to integer number of complete waves
+  const waveCount = Math.max(1, Math.round(wallSpan / baseWavelength));
+  const wavelength = wallSpan / waveCount;
+
+  // Must fit at least one half-wave vertically
+  if (patternH < wavelength / 2) return null;
+
+  // Wall span must be meaningful (need at least one full wave)
+  if (wallSpan < baseWavelength / 2) return null;
+
+  return {
+    amplitude,
+    wavelength,
+    wallSpan,
+    patternH,
+    bottomZ: bottomKeepOut,
+    wallThickness,
+    waveCount,
+  };
+}
+
+/**
+ * Generate 2D profile points for the corrugated inner face.
+ *
+ * Returns points along the sinusoidal inner surface from left to right
+ * (negative X to positive X). The outer face is a straight line at Y=0.
+ *
+ * The Y coordinate represents depth into the wall (inward from outer face).
+ * At wave troughs: Y = wallThickness (minimum depth, wall is thinnest).
+ * At wave crests: Y = wallThickness + amplitude (maximum depth, wall is thickest).
+ *
+ * @returns Array of [x, y] points for the inner face profile
+ */
+export function generateInnerFacePoints(spec: CorrugatedWallSpec): readonly [number, number][] {
+  const { amplitude, wallSpan, wallThickness } = spec;
+  const halfSpan = wallSpan / 2;
+  const totalSegments = spec.waveCount * SEGMENTS_PER_HALF_WAVE * 2;
+  const points: [number, number][] = [];
+
+  for (let i = 0; i <= totalSegments; i++) {
+    const x = -halfSpan + (i / totalSegments) * wallSpan;
+    // Cosine wave using waveCount to guarantee integer cycles across span.
+    // cos(2π × waveCount × normalized_x) has crests at both span edges
+    // because normalized_x goes from 0 to 1, and waveCount is an integer.
+    const normalized = (x + halfSpan) / wallSpan;
+    const y =
+      wallThickness + (amplitude * (1 + Math.cos(2 * Math.PI * spec.waveCount * normalized))) / 2;
+    points.push([x, y]);
+  }
+
+  return points;
+}

--- a/src/features/generation/worker/generators/patterns/corrugatedPattern.ts
+++ b/src/features/generation/worker/generators/patterns/corrugatedPattern.ts
@@ -20,9 +20,9 @@
  */
 
 import { TOP_KEEP_OUT, MIN_BOTTOM_KEEP_OUT } from '../wallPatterns';
+import { CORRUGATED_MIN_WALL_THICKNESS } from '@/shared/constants/bin';
 
-/** Minimum wall thickness required for corrugation (mm). */
-export const CORRUGATED_MIN_WALL_THICKNESS = 1.6;
+export { CORRUGATED_MIN_WALL_THICKNESS };
 
 /** Amplitude multiplier: amplitude = wallThickness × this factor. */
 const AMPLITUDE_RATIO = 0.4;
@@ -91,8 +91,8 @@ export function createCorrugatedSpec(
   const waveCount = Math.max(1, Math.round(wallSpan / baseWavelength));
   const wavelength = wallSpan / waveCount;
 
-  // Must fit at least one half-wave vertically
-  if (patternH < wavelength / 2) return null;
+  // Must have enough height for a visible corrugated band (at least 2mm)
+  if (patternH < 2) return null;
 
   // Wall span must be meaningful (need at least one full wave)
   if (wallSpan < baseWavelength / 2) return null;

--- a/src/features/generation/worker/generators/patterns/index.ts
+++ b/src/features/generation/worker/generators/patterns/index.ts
@@ -19,10 +19,20 @@ export {
   DEFAULT_HEX_WEB_THICKNESS,
 } from './honeycombPattern';
 
+// Corrugated pattern
+export {
+  createCorrugatedSpec,
+  generateInnerFacePoints,
+  CORRUGATED_MIN_WALL_THICKNESS,
+} from './corrugatedPattern';
+export type { CorrugatedWallSpec } from './corrugatedPattern';
+
 // Registry
 export {
   PATTERN_REGISTRY,
   getPatternCalculator,
+  getPatternMode,
   isHoneycombCalculator,
   getAvailablePatterns,
 } from './registry';
+export type { CutPatternEntry, ReplacePatternEntry, PatternRegistryEntry } from './registry';

--- a/src/features/generation/worker/generators/patterns/registry.ts
+++ b/src/features/generation/worker/generators/patterns/registry.ts
@@ -16,22 +16,40 @@ import type { HoneycombPatternCalculator } from './honeycombPattern';
 import { createHoneycombCalculator } from './honeycombPattern';
 
 /**
- * Registry entry for a pattern type.
+ * Registry entry for a cut-through pattern (repeating elements subtracted from walls).
  */
-export interface PatternRegistryEntry {
+export interface CutPatternEntry {
+  readonly mode: 'cut';
   /** Factory function to create calculator with size-adaptive parameters */
-  createCalculator: (binHeight: number) => PatternCalculator;
+  readonly createCalculator: (binHeight: number) => PatternCalculator;
   /** Human-readable display name (for debugging) */
-  displayName: string;
+  readonly displayName: string;
 }
+
+/**
+ * Registry entry for a wall-replacement pattern (wall geometry is rebuilt).
+ */
+export interface ReplacePatternEntry {
+  readonly mode: 'replace';
+  /** Human-readable display name (for debugging) */
+  readonly displayName: string;
+}
+
+/** Discriminated union for pattern registry entries. */
+export type PatternRegistryEntry = CutPatternEntry | ReplacePatternEntry;
 
 /**
  * Pattern registry mapping pattern types to their calculator factories.
  */
 export const PATTERN_REGISTRY: Record<WallPatternType, PatternRegistryEntry> = {
   honeycomb: {
+    mode: 'cut',
     createCalculator: createHoneycombCalculator,
     displayName: 'Honeycomb',
+  },
+  corrugated: {
+    mode: 'replace',
+    displayName: 'Corrugated',
   },
 };
 
@@ -52,6 +70,9 @@ export function getPatternCalculator(
     const available = Object.keys(PATTERN_REGISTRY).join(', ');
     throw new Error(`Unknown wall pattern type: "${pattern}". Available patterns: ${available}`);
   }
+  if (entry.mode !== 'cut') {
+    throw new Error(`Pattern "${pattern}" is a replacement pattern, not a cut pattern`);
+  }
   return entry.createCalculator(binHeight);
 }
 
@@ -62,6 +83,14 @@ export function isHoneycombCalculator(
   calculator: PatternCalculator
 ): calculator is HoneycombPatternCalculator {
   return calculator.getPatternType() === 'honeycomb';
+}
+
+/**
+ * Get the pattern mode for a given pattern type.
+ */
+export function getPatternMode(pattern: WallPatternType): 'cut' | 'replace' {
+  const entry = (PATTERN_REGISTRY as Record<string, PatternRegistryEntry | undefined>)[pattern];
+  return entry?.mode ?? 'cut';
 }
 
 /**

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -99,6 +99,7 @@ export function createInitialContext(
     fuseTargets: [],
     cutTargets: [],
     patternCutTargets: [],
+    wallReplaceTargets: [],
     mesh: null,
     coarseMesh: null,
   };

--- a/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
@@ -110,29 +110,45 @@ export const booleanStage: PipelineStage = {
       bin = applyCutPass(bin, originalSolid, ctx.patternCutTargets, cutOpts);
     }
 
-    // Wall replacement pass: cut away flat wall, then fuse corrugated replacement.
-    // Sequential per-wall (max 4 walls) — pairwise is safe here.
+    // Wall replacement pass: cut flat wall, then fuse corrugated replacement.
+    // Atomic per-wall: only update bin if BOTH cut and fuse succeed,
+    // otherwise keep the original bin intact (no holes from partial ops).
     if (ctx.wallReplaceTargets.length > 0) {
       checkCancelled(signal);
       for (const { cut: cutShape, fuse: fuseShape } of ctx.wallReplaceTargets) {
+        let cutResult: Shape3D;
         try {
-          const prev = bin;
-          bin = unwrap(cut(bin as ValidSolid, cutShape as ValidSolid));
-          if (prev !== originalSolid) prev.delete();
+          cutResult = unwrap(cut(bin as ValidSolid, cutShape as ValidSolid));
         } catch (e: unknown) {
           if (isAbortError(e)) throw e;
-          // If cut fails, skip this wall replacement
-          fuseShape.delete();
-          cutShape.delete();
           continue;
         }
         try {
-          const prev = bin;
-          bin = unwrap(fuse(bin as ValidSolid, fuseShape as ValidSolid));
-          if (prev !== originalSolid) prev.delete();
+          const fused: Shape3D = unwrap(fuse(cutResult as ValidSolid, fuseShape as ValidSolid));
+          // Both succeeded — atomically update bin
+          if (bin !== originalSolid && bin) {
+            try {
+              bin.delete();
+            } catch {
+              /* already disposed */
+            }
+          }
+          try {
+            cutResult.delete();
+          } catch {
+            /* already disposed */
+          }
+          bin = fused;
         } catch (e: unknown) {
           if (isAbortError(e)) throw e;
-          // If fuse fails, keep the cut result (flat wall is removed, no corrugated added)
+          // Fuse failed — discard cut result, keep original bin intact
+          if (cutResult) {
+            try {
+              cutResult.delete();
+            } catch {
+              /* already disposed */
+            }
+          }
         }
       }
     }

--- a/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
@@ -70,7 +70,10 @@ export const booleanStage: PipelineStage = {
 
   shouldRun(ctx: PipelineContext): boolean {
     return (
-      ctx.fuseTargets.length > 0 || ctx.cutTargets.length > 0 || ctx.patternCutTargets.length > 0
+      ctx.fuseTargets.length > 0 ||
+      ctx.cutTargets.length > 0 ||
+      ctx.patternCutTargets.length > 0 ||
+      ctx.wallReplaceTargets.length > 0
     );
   },
 
@@ -107,10 +110,56 @@ export const booleanStage: PipelineStage = {
       bin = applyCutPass(bin, originalSolid, ctx.patternCutTargets, cutOpts);
     }
 
+    // Wall replacement pass: cut away flat wall, then fuse corrugated replacement.
+    // Sequential per-wall (max 4 walls) — pairwise is safe here.
+    if (ctx.wallReplaceTargets.length > 0) {
+      checkCancelled(signal);
+      for (const { cut: cutShape, fuse: fuseShape } of ctx.wallReplaceTargets) {
+        try {
+          const prev = bin;
+          bin = unwrap(cut(bin as ValidSolid, cutShape as ValidSolid));
+          if (prev !== originalSolid) prev.delete();
+        } catch (e: unknown) {
+          if (isAbortError(e)) throw e;
+          // If cut fails, skip this wall replacement
+          fuseShape.delete();
+          cutShape.delete();
+          continue;
+        }
+        try {
+          const prev = bin;
+          bin = unwrap(fuse(bin as ValidSolid, fuseShape as ValidSolid));
+          if (prev !== originalSolid) prev.delete();
+        } catch (e: unknown) {
+          if (isAbortError(e)) throw e;
+          // If fuse fails, keep the cut result (flat wall is removed, no corrugated added)
+        }
+      }
+    }
+
     if (bin !== originalSolid) originalSolid.delete();
     const allTargets = [...ctx.fuseTargets, ...ctx.cutTargets, ...ctx.patternCutTargets];
     for (const t of allTargets) t.delete();
+    for (const { cut: c, fuse: f } of ctx.wallReplaceTargets) {
+      try {
+        c.delete();
+      } catch {
+        /* already disposed */
+      }
+      try {
+        f.delete();
+      } catch {
+        /* already disposed */
+      }
+    }
 
-    return { ...ctx, solid: bin, fuseTargets: [], cutTargets: [], patternCutTargets: [] };
+    return {
+      ...ctx,
+      solid: bin,
+      fuseTargets: [],
+      cutTargets: [],
+      patternCutTargets: [],
+      wallReplaceTargets: [],
+    };
   },
 };

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -13,6 +13,7 @@
  */
 
 import { unwrap, cut } from 'brepjs';
+import type { Shape3D } from 'brepjs';
 import type { PipelineContext, PipelineStage } from '../types';
 import { buildCutoutCuts } from '../../featureBuilder';
 import { FeatureTag } from '../../featureTags';
@@ -20,6 +21,8 @@ import { collectOrigins } from '../collectOrigins';
 import { runFeatureBuilders } from '../featureRunner';
 import { BIN_FEATURE_BUILDERS } from '../featureComposition';
 import { buildWallPatterns } from '../../wallPatternBuilder';
+import { buildCorrugatedWalls } from '../../corrugatedWallBuilder';
+import { getPatternMode } from '../../patterns/registry';
 
 export const featuresStage: PipelineStage = {
   name: 'features',
@@ -58,9 +61,18 @@ export const featuresStage: PipelineStage = {
     const targets = runFeatureBuilders(BIN_FEATURE_BUILDERS, ctx);
 
     // Wall patterns: special case with per-wall caching + cutout clipping
+    const wallReplaceTargets: { cut: Shape3D; fuse: Shape3D }[] = [];
     if (params.wallPattern.enabled) {
-      const patternShapes = buildWallPatterns(ctx);
-      targets.patternCutTargets.push(...patternShapes);
+      const mode = getPatternMode(params.wallPattern.pattern);
+      if (mode === 'cut') {
+        const patternShapes = buildWallPatterns(ctx);
+        targets.patternCutTargets.push(...patternShapes);
+      } else {
+        const { cuts, fuses } = buildCorrugatedWalls(ctx);
+        for (let i = 0; i < cuts.length; i++) {
+          wallReplaceTargets.push({ cut: cuts[i], fuse: fuses[i] });
+        }
+      }
     }
 
     return {
@@ -68,6 +80,7 @@ export const featuresStage: PipelineStage = {
       fuseTargets: targets.fuseTargets,
       cutTargets: targets.cutTargets,
       patternCutTargets: targets.patternCutTargets,
+      wallReplaceTargets,
     };
   },
 };

--- a/src/features/generation/worker/generators/pipeline/types.ts
+++ b/src/features/generation/worker/generators/pipeline/types.ts
@@ -51,6 +51,8 @@ export interface PipelineContext {
   readonly cutTargets: readonly Shape3D[];
   /** Pattern cut targets — applied in a separate boolean pass after cutTargets */
   readonly patternCutTargets: readonly Shape3D[];
+  /** Wall replacement targets — flat wall section cut + corrugated fuse pairs */
+  readonly wallReplaceTargets: readonly { readonly cut: Shape3D; readonly fuse: Shape3D }[];
   /** Final mesh output (set by tessellate stage) */
   readonly mesh: MeshData | null;
   /** Coarse LOD mesh for distance-based rendering (preview only) */

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -366,6 +366,8 @@
   "binDesigner.wallThickness.2.6": "Maximale Steifigkeit für große Bins",
   "binDesigner.wallThickness.nozzleTip": "Für beste Ergebnisse ein Vielfaches der Düsengröße verwenden (z.B. 1,2mm = 3× 0,4mm Düse)",
   "binDesigner.walls.pattern.allSlotted": "Alle Wände haben Trennschlitze",
+  "binDesigner.walls.pattern.corrugated": "Wellblech",
+  "binDesigner.walls.pattern.corrugatedThinWall": "Wellblech-Muster erfordert Wandstärke ≥ 1,6mm",
   "binDesigner.walls.pattern.honeycomb": "Waben",
   "binDesigner.walls.pattern.label": "Wandmuster",
   "binDesigner.walls.pattern.none": "Massiv",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -367,6 +367,8 @@
   "binDesigner.wallThickness.2.6": "Maximum rigidity for large bins",
   "binDesigner.wallThickness.nozzleTip": "For best results, use a multiple of your nozzle size (e.g., 1.2mm = 3× 0.4mm nozzle)",
   "binDesigner.walls.pattern.allSlotted": "All walls have divider slots",
+  "binDesigner.walls.pattern.corrugated": "Corrugated",
+  "binDesigner.walls.pattern.corrugatedThinWall": "Corrugated pattern requires wall thickness ≥ 1.6mm",
   "binDesigner.walls.pattern.honeycomb": "Honeycomb",
   "binDesigner.walls.pattern.label": "Wall pattern",
   "binDesigner.walls.pattern.none": "Solid",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1293,6 +1293,9 @@ const en: Record<string, string> = {
   'binDesigner.walls.pattern.label': 'Wall pattern',
   'binDesigner.walls.pattern.none': 'Solid',
   'binDesigner.walls.pattern.honeycomb': 'Honeycomb',
+  'binDesigner.walls.pattern.corrugated': 'Corrugated',
+  'binDesigner.walls.pattern.corrugatedThinWall':
+    'Corrugated pattern requires wall thickness ≥ 1.6mm',
   'binDesigner.walls.pattern.allSlotted': 'All walls have divider slots',
   'binDesigner.walls.pattern.someSlotted': 'Walls with divider slots will keep solid walls',
   'binDesigner.wallCutouts': 'Wall Cutouts',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -366,6 +366,8 @@
   "binDesigner.wallThickness.2.6": "Máxima rigidez para bins grandes",
   "binDesigner.wallThickness.nozzleTip": "Para mejores resultados, usa un múltiplo del tamaño de boquilla (ej: 1,2mm = 3× boquilla 0,4mm)",
   "binDesigner.walls.pattern.allSlotted": "Todas las paredes tienen ranuras divisoras",
+  "binDesigner.walls.pattern.corrugated": "Corrugado",
+  "binDesigner.walls.pattern.corrugatedThinWall": "El patrón corrugado requiere un grosor de pared ≥ 1,6mm",
   "binDesigner.walls.pattern.honeycomb": "Panal",
   "binDesigner.walls.pattern.label": "Patrón de pared",
   "binDesigner.walls.pattern.none": "Sólido",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -366,6 +366,8 @@
   "binDesigner.wallThickness.2.6": "Rigidité maximale pour grands bins",
   "binDesigner.wallThickness.nozzleTip": "Pour de meilleurs résultats, utilisez un multiple de la taille de buse (ex: 1,2mm = 3× buse 0,4mm)",
   "binDesigner.walls.pattern.allSlotted": "Tous les murs ont des fentes de séparation",
+  "binDesigner.walls.pattern.corrugated": "Ondulé",
+  "binDesigner.walls.pattern.corrugatedThinWall": "Le motif ondulé nécessite une épaisseur de paroi ≥ 1,6mm",
   "binDesigner.walls.pattern.honeycomb": "Alvéoles",
   "binDesigner.walls.pattern.label": "Motif de mur",
   "binDesigner.walls.pattern.none": "Plein",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -366,6 +366,8 @@
   "binDesigner.wallThickness.2.6": "Maksimal stivhet for store bins",
   "binDesigner.wallThickness.nozzleTip": "For beste resultater, bruk et multiplum av dysestørrelsen din (f.eks. 1.2mm = 3× 0.4mm dyse)",
   "binDesigner.walls.pattern.allSlotted": "Alle vegger har skillesporene",
+  "binDesigner.walls.pattern.corrugated": "Bølget",
+  "binDesigner.walls.pattern.corrugatedThinWall": "Bølget mønster krever veggtykkelse ≥ 1,6mm",
   "binDesigner.walls.pattern.honeycomb": "Bikube",
   "binDesigner.walls.pattern.label": "Veggmønster",
   "binDesigner.walls.pattern.none": "Solid",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -366,6 +366,8 @@
   "binDesigner.wallThickness.2.6": "Maximale stijfheid voor grote bins",
   "binDesigner.wallThickness.nozzleTip": "Voor beste resultaten, gebruik een veelvoud van je nozzle grootte (bijv. 1,2mm = 3× 0,4mm nozzle)",
   "binDesigner.walls.pattern.allSlotted": "Alle wanden hebben verdeelsleuven",
+  "binDesigner.walls.pattern.corrugated": "Gegolfd",
+  "binDesigner.walls.pattern.corrugatedThinWall": "Gegolfd patroon vereist wanddikte ≥ 1,6mm",
   "binDesigner.walls.pattern.honeycomb": "Honingraat",
   "binDesigner.walls.pattern.label": "Wandpatroon",
   "binDesigner.walls.pattern.none": "Massief",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -366,6 +366,8 @@
   "binDesigner.wallThickness.2.6": "Rigidez máxima para bins grandes",
   "binDesigner.wallThickness.nozzleTip": "Para melhores resultados, use um múltiplo do tamanho do bico (ex: 1,2mm = 3× bico 0,4mm)",
   "binDesigner.walls.pattern.allSlotted": "Todas as paredes têm ranhuras divisórias",
+  "binDesigner.walls.pattern.corrugated": "Corrugado",
+  "binDesigner.walls.pattern.corrugatedThinWall": "O padrão corrugado requer espessura de parede ≥ 1,6mm",
   "binDesigner.walls.pattern.honeycomb": "Colmeia",
   "binDesigner.walls.pattern.label": "Padrão de parede",
   "binDesigner.walls.pattern.none": "Sólido",

--- a/src/shared/constants/bin.ts
+++ b/src/shared/constants/bin.ts
@@ -11,3 +11,6 @@ export {
   DISABLED_WALL_CUTOUT,
 } from '@/features/bin-designer/constants/defaults';
 export { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
+
+/** Minimum wall thickness for corrugated pattern (mm). Used by both UI and generation. */
+export const CORRUGATED_MIN_WALL_THICKNESS = 1.6;


### PR DESCRIPTION
## Summary

- Adds a **corrugated wall pattern** — sinusoidal wave profiles that replace flat walls for added structural strength
- New `wallReplaceTargets` pipeline concept: cut flat wall section, then fuse corrugated replacement (unlike honeycomb which is purely subtractive)
- Pattern registry widened to a discriminated union (`cut` vs `replace` modes) for clean extensibility
- Phase-aligned wavelength ensures wave crests at wall corners for clean geometry
- Size-adaptive parameters: amplitude = wallThickness × 0.4, wavelength scales with bin height (8/12/16mm tiers)
- Minimum 1.6mm wall thickness enforced via per-option disable in the pattern selector UI
- Clear zones around cutouts/handles/ramps match honeycomb's CUTOUT_BORDER_WIDTH clipping behavior
- i18n: all 7 locales updated (de, en, es, fr, nb, nl, pt-BR)

## Files

**Created (4):**
- `patterns/corrugatedPattern.ts` — pure math: spec computation, wave profile points
- `patterns/corrugatedPattern.test.ts` — 14 unit tests
- `corrugatedWallBuilder.ts` — geometry: profile → solid, slab, clip zones, per-wall caching
- `corrugatedWallBuilder.test.ts` — 5 spec integration tests

**Modified (13):** types, registry, pipeline context/stages, constraints, UI selector, i18n

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run check:i18n` — all 4 checks pass
- [x] All 721 generation tests pass (47 files)
- [x] All 109 affected tests pass (patterns, constraints, WallsSection)
- [ ] Manual: verify corrugated wall renders correctly in 3D preview
- [ ] Manual: verify corrugated + cutout/handle clear zones
- [ ] Manual: verify thickness slider auto-disables corrugated below 1.6mm