### PR TITLE
fix(generation): use loft for stacking lip on all kernels

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -1,149 +1,149 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2540`;
+exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2848`;
 
-exports[`base styles > flat base no lip 1`] = `252`;
+exports[`base styles > flat base no lip 1`] = `300`;
 
-exports[`base styles > flat base with lip 1`] = `812`;
+exports[`base styles > flat base with lip 1`] = `1124`;
 
 exports[`base styles > magnet base no lip 1`] = `804`;
 
-exports[`base styles > magnet base with lip 1`] = `1820`;
+exports[`base styles > magnet base with lip 1`] = `2132`;
 
 exports[`base styles > magnet+screw base no lip 1`] = `1028`;
 
-exports[`base styles > magnet+screw base with lip 1`] = `2188`;
+exports[`base styles > magnet+screw base with lip 1`] = `2500`;
 
 exports[`base styles > screw base no lip 1`] = `692`;
 
-exports[`base styles > screw base with lip 1`] = `1660`;
+exports[`base styles > screw base with lip 1`] = `1972`;
 
 exports[`base styles > standard base no lip 1`] = `468`;
 
-exports[`base styles > standard base with lip 1`] = `1292`;
+exports[`base styles > standard base with lip 1`] = `1604`;
 
 exports[`base styles > weighted base no lip 1`] = `468`;
 
-exports[`base styles > weighted base with lip 1`] = `1292`;
+exports[`base styles > weighted base with lip 1`] = `1604`;
 
-exports[`bin styles > 2×2 slotted 1`] = `3068`;
+exports[`bin styles > 2×2 slotted 1`] = `3468`;
 
-exports[`bin styles > 2×2 solid 1`] = `2460`;
+exports[`bin styles > 2×2 solid 1`] = `2812`;
 
-exports[`bin styles > 2×2 standard 1`] = `2732`;
+exports[`bin styles > 2×2 standard 1`] = `3036`;
 
-exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1148`;
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1548`;
 
-exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3228`;
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3556`;
 
-exports[`combined features > 2×2 label tabs with merged compartments 1`] = `5244`;
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `5572`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `7240`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `7482`;
 
 exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `18048`;
 
-exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2732`;
+exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `3036`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `3444`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `3796`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3544`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3908`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5188`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5636`;
 
 exports[`dimensions > 0.5×0.5 no lip 1`] = `468`;
 
-exports[`dimensions > 0.5×0.5 with lip 1`] = `1292`;
+exports[`dimensions > 0.5×0.5 with lip 1`] = `1604`;
 
 exports[`dimensions > 1.5×2 fractional no lip 1`] = `1260`;
 
-exports[`dimensions > 1.5×2 fractional with lip 1`] = `2732`;
+exports[`dimensions > 1.5×2 fractional with lip 1`] = `3036`;
 
 exports[`dimensions > 1×1 no lip 1`] = `468`;
 
-exports[`dimensions > 1×1 with lip 1`] = `1292`;
+exports[`dimensions > 1×1 with lip 1`] = `1604`;
 
 exports[`dimensions > 2×2 no lip 1`] = `1260`;
 
-exports[`dimensions > 2×2 with lip 1`] = `2732`;
+exports[`dimensions > 2×2 with lip 1`] = `3036`;
 
 exports[`dimensions > 4×4 no lip 1`] = `3500`;
 
-exports[`dimensions > 4×4 with lip 1`] = `7916`;
+exports[`dimensions > 4×4 with lip 1`] = `8220`;
 
-exports[`export mode > 2×2 default params (forExport=true) 1`] = `5140`;
+exports[`export mode > 2×2 default params (forExport=true) 1`] = `6172`;
 
-exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5132`;
+exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5436`;
 
-exports[`half-sockets > 1×1 with half sockets 1`] = `2732`;
+exports[`half-sockets > 1×1 with half sockets 1`] = `3044`;
 
-exports[`half-sockets > 2×2 with half sockets 1`] = `8492`;
+exports[`half-sockets > 2×2 with half sockets 1`] = `8796`;
 
-exports[`height > 2×2 height minimum (2u) 1`] = `2732`;
+exports[`height > 2×2 height minimum (2u) 1`] = `3036`;
 
-exports[`height > 2×2 height tall (10u) 1`] = `2732`;
+exports[`height > 2×2 height tall (10u) 1`] = `3036`;
 
-exports[`inserts > 2×2 with circle insert 1`] = `3000`;
+exports[`inserts > 2×2 with circle insert 1`] = `3304`;
 
-exports[`inserts > 2×2 with hexagon insert 1`] = `3000`;
+exports[`inserts > 2×2 with hexagon insert 1`] = `3304`;
 
-exports[`inserts > 2×2 with rectangle insert 1`] = `2768`;
+exports[`inserts > 2×2 with rectangle insert 1`] = `3072`;
 
-exports[`inserts > 2×2 with rounded-rect insert 1`] = `2896`;
+exports[`inserts > 2×2 with rounded-rect insert 1`] = `3200`;
 
-exports[`inserts > 2×2 with slot insert 1`] = `2944`;
+exports[`inserts > 2×2 with slot insert 1`] = `3248`;
 
-exports[`label tabs > 2×2 label bracket center 1`] = `3564`;
+exports[`label tabs > 2×2 label bracket center 1`] = `3800`;
 
-exports[`label tabs > 2×2 label bracket left 1`] = `3564`;
+exports[`label tabs > 2×2 label bracket left 1`] = `3800`;
 
-exports[`label tabs > 2×2 label bracket right 1`] = `3564`;
+exports[`label tabs > 2×2 label bracket right 1`] = `3800`;
 
-exports[`label tabs > 2×2 label disabled 1`] = `2732`;
+exports[`label tabs > 2×2 label disabled 1`] = `3036`;
 
-exports[`label tabs > 2×2 label solid left 1`] = `3300`;
+exports[`label tabs > 2×2 label solid left 1`] = `3692`;
 
-exports[`large bin > 8×8 standard 1`] = `23116`;
+exports[`large bin > 8×8 standard 1`] = `23380`;
 
-exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3224`;
+exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3528`;
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `3764`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `3988`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4652`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4812`;
 
-exports[`scoop > 2×2 scoop auto radius 1`] = `3764`;
+exports[`scoop > 2×2 scoop auto radius 1`] = `3988`;
 
-exports[`scoop > 2×2 scoop disabled 1`] = `2732`;
+exports[`scoop > 2×2 scoop disabled 1`] = `3036`;
 
-exports[`scoop > 2×2 scoop radius 10mm 1`] = `3840`;
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `3992`;
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `3068`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `3468`;
 
-exports[`slotted variations > slotted with both axes 1`] = `3404`;
+exports[`slotted variations > slotted with both axes 1`] = `3900`;
 
 exports[`slotted variations > slotted without lip 1`] = `1380`;
 
-exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `2696`;
+exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `3058`;
 
-exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `2612`;
+exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `2972`;
 
-exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `2736`;
+exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `3444`;
 
-exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2490`;
+exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2852`;
 
-exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `2652`;
+exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `3004`;
 
-exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2480`;
+exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2840`;
 
-exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `3156`;
+exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `3516`;
 
-exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2492`;
+exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2856`;
 
-exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `2608`;
+exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `2968`;
 
-exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2472`;
+exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2824`;
 
-exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2472`;
+exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2824`;
 
-exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `2620`;
+exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `3004`;
 
-exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `2892`;
+exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `3052`;

--- a/src/features/generation/worker/generators/boxBuilder.test.ts
+++ b/src/features/generation/worker/generators/boxBuilder.test.ts
@@ -93,4 +93,25 @@ describe('buildTopShape', () => {
     const withoutLip = meshShape(buildTopShape(2, 2, false));
     expect(withLip.triangles.length).toBeGreaterThan(withoutLip.triangles.length);
   }, 60000);
+
+  it('rectangular lip does not exceed box bounds', async () => {
+    const { getBounds } = await import('brepjs');
+    const TOLERANCE = 0.02;
+
+    for (const [gw, gd] of [
+      [1, 2],
+      [1, 4],
+      [2, 3],
+    ] as const) {
+      const lip = buildTopShape(gw, gd, true);
+      const box = buildBinBox(gw, gd, 16, 1.2, false);
+      const lb = getBounds(lip as never);
+      const bb = getBounds(box as never);
+
+      expect(lb.xMax - bb.xMax).toBeLessThanOrEqual(TOLERANCE);
+      expect(lb.yMax - bb.yMax).toBeLessThanOrEqual(TOLERANCE);
+      expect(bb.xMin - lb.xMin).toBeLessThanOrEqual(TOLERANCE);
+      expect(bb.yMin - lb.yMin).toBeLessThanOrEqual(TOLERANCE);
+    }
+  }, 60000);
 });

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -21,7 +21,6 @@ import {
   edgeFinder,
   getBounds,
   shell,
-  getKernel,
   withScope,
 } from 'brepjs';
 import type { Shape3D, ValidSolid, Plane, Vec3, Sketch, DisposalScope } from 'brepjs';
@@ -265,9 +264,10 @@ function buildTopShapeSweep(outerW: number, outerD: number, includeLip: boolean)
 /**
  * Build the stacking lip at the top of the bin.
  *
- * Uses kernel-optimized construction:
- * - brepkit: loft + boolean cut (analytic surfaces, avoids slow shell)
- * - OCCT: sweep + fillet (robust, avoids loft-shell failures)
+ * Uses loft-cut for all kernels: constructs explicit cross-sections at each
+ * profile breakpoint so the lip matches the box outer bounds exactly.
+ * Falls back to sweep if the loft fails (produces oversized lip on non-square
+ * bins due to OCCT profile orientation issues — logged as a warning).
  *
  * Profile per Gridfinity spec v5: 0.7mm + 1.8mm + 1.9mm = 4.4mm total height.
  * Built at Z=0 locally, caller translates to wallHeight.
@@ -279,7 +279,7 @@ export function buildTopShape(
   gridUnitMm: number = SIZE
 ): Shape3D {
   const lipKey = buildCacheKey(
-    'v2',
+    'v3',
     quantize(gridW),
     quantize(gridD),
     quantize(gridUnitMm),
@@ -293,20 +293,14 @@ export function buildTopShape(
   const outerW = gridW * gridUnitMm - CLEARANCE;
   const outerD = gridD * gridUnitMm - CLEARANCE;
 
+  // Loft-cut for all kernels — explicit cross-sections keep the lip within box
+  // bounds. Sweep fallback may overshoot on non-square bins (OCCT profile bug).
   let result: Shape3D;
-  if (getKernel().kernelId === 'brepkit') {
-    // brepkit: loft-cut is ~5-50x faster than sweep (analytic surfaces)
-    try {
-      result = buildTopShapeLoft(outerW, outerD, includeLip);
-    } catch (e: unknown) {
-      // Loft failed — fall back to sweep path. Log for diagnostics since this
-      // indicates a kernel regression (loft should always succeed).
-      const msg = e instanceof Error ? e.message : String(e);
-      console.warn(`[boxBuilder] brepkit loft failed, falling back to sweep: ${msg}`);
-      result = buildTopShapeSweep(outerW, outerD, includeLip);
-    }
-  } else {
-    // OCCT: sweep is faster and more robust (loft-shell fails, loft-cut is slow)
+  try {
+    result = buildTopShapeLoft(outerW, outerD, includeLip);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.warn(`[boxBuilder] loft failed, falling back to sweep: ${msg}`);
     result = buildTopShapeSweep(outerW, outerD, includeLip);
   }
 


### PR DESCRIPTION
## Summary
- Re-applies the fix from #1306 (reverted in #1309): use `buildTopShapeLoft` for all kernels instead of only brepkit
- The OCCT sweep path produces a lip profile that converges to a point at its base, creating a visible vertical gap between the wall top and the stacking lip — especially on non-square bins and thin walls (0.4mm)
- Loft constructs explicit cross-sections at each profile breakpoint, ensuring the lip matches the box outer bounds exactly
- Sweep retained as fallback if loft fails
- Restores the rectangular lip bounds regression test (1x2, 1x4, 2x3)
- Cache key bumped v2 → v3 to flush stale cached shapes

Closes #1310

## Context
The issue only affected users on the default OCCT kernel (non-Labs). Users with the brepkit Labs flag already used the loft path and were unaffected.

## Test plan
- [x] Scenario tests: 169 pass (62 snapshots updated — expected triangle count changes from loft tessellation)
- [x] boxBuilder tests: 10 pass including restored rectangular lip bounds test
- [ ] Manual: Create 1x1x8u bin, wall 0.4mm, stacking lip → verify no gap
- [ ] Manual: Create 1x2 and 2x3 bins → verify lip doesn't overshoot