### PR TITLE
fix(bin-designer): use diameter instead of radius for magnet/screw UI

### DIFF
--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.test.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.test.tsx
@@ -195,7 +195,7 @@ describe('ParameterPanel', () => {
     it('does not show magnet sliders when magnet is off', () => {
       render(<ParameterPanel />);
 
-      expect(screen.queryByLabelText('Magnet radius')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Magnet diameter')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('Magnet depth')).not.toBeInTheDocument();
     });
 
@@ -209,14 +209,14 @@ describe('ParameterPanel', () => {
       const customizeBtn = screen.getAllByText('Customize')[0];
       fireEvent.click(customizeBtn);
 
-      expect(screen.getByRole('slider', { name: 'Magnet radius' })).toBeInTheDocument();
+      expect(screen.getByRole('slider', { name: 'Magnet diameter' })).toBeInTheDocument();
       expect(screen.getByRole('slider', { name: 'Magnet depth' })).toBeInTheDocument();
     });
 
     it('does not show screw slider when screw is off', () => {
       render(<ParameterPanel />);
 
-      expect(screen.queryByLabelText('Screw radius')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Screw diameter')).not.toBeInTheDocument();
     });
 
     it('shows screw slider when screw is toggled on and Customize clicked', () => {
@@ -229,10 +229,10 @@ describe('ParameterPanel', () => {
       const customizeBtns = screen.getAllByText('Customize');
       fireEvent.click(customizeBtns[0]);
 
-      expect(screen.getByRole('slider', { name: 'Screw radius' })).toBeInTheDocument();
+      expect(screen.getByRole('slider', { name: 'Screw diameter' })).toBeInTheDocument();
     });
 
-    it('magnet radius slider updates magnetDiameter (radius × 2)', () => {
+    it('magnet diameter slider updates magnetDiameter directly', () => {
       useDesignerStore.setState({
         params: {
           ...DEFAULT_BIN_PARAMS,
@@ -246,10 +246,10 @@ describe('ParameterPanel', () => {
       const customizeBtn = screen.getAllByText('Customize')[0];
       fireEvent.click(customizeBtn);
 
-      const radiusSlider = screen.getByRole('slider', { name: 'Magnet radius' });
-      fireEvent.change(radiusSlider, { target: { value: '4.0' } });
+      const diameterSlider = screen.getByRole('slider', { name: 'Magnet diameter' });
+      fireEvent.change(diameterSlider, { target: { value: '6.5' } });
 
-      expect(useDesignerStore.getState().params.base.magnetDiameter).toBe(8.0);
+      expect(useDesignerStore.getState().params.base.magnetDiameter).toBe(6.5);
     });
 
     it('magnet depth slider updates magnetDepth', () => {
@@ -272,7 +272,7 @@ describe('ParameterPanel', () => {
       expect(useDesignerStore.getState().params.base.magnetDepth).toBe(3.0);
     });
 
-    it('screw radius slider updates screwDiameter (radius × 2)', () => {
+    it('screw diameter slider updates screwDiameter directly', () => {
       useDesignerStore.setState({
         params: {
           ...DEFAULT_BIN_PARAMS,
@@ -286,8 +286,8 @@ describe('ParameterPanel', () => {
       const customizeBtn = screen.getAllByText('Customize')[0];
       fireEvent.click(customizeBtn);
 
-      const radiusSlider = screen.getByRole('slider', { name: 'Screw radius' });
-      fireEvent.change(radiusSlider, { target: { value: '2.0' } });
+      const diameterSlider = screen.getByRole('slider', { name: 'Screw diameter' });
+      fireEvent.change(diameterSlider, { target: { value: '4.0' } });
 
       expect(useDesignerStore.getState().params.base.screwDiameter).toBe(4.0);
     });

--- a/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
@@ -57,7 +57,7 @@ export function BaseSection() {
         checked={state.hasScrew}
         onChange={handlers.toggleScrew}
         disabledReason={handlers.screwDisabledReason}
-        valueSummary={`\u00f8${state.base.screwDiameter}mm (M${state.base.screwDiameter})`}
+        valueSummary={`\u00f8${state.base.screwDiameter}mm`}
       >
         <SliderInput
           label="Screw diameter"

--- a/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
@@ -33,12 +33,12 @@ export function BaseSection() {
         valueSummary={`\u00f8${state.base.magnetDiameter}mm \u00d7 ${state.base.magnetDepth}mm deep`}
       >
         <SliderInput
-          label="Magnet radius"
-          value={state.base.magnetDiameter / 2}
-          onChange={handlers.setMagnetRadius}
-          min={DESIGNER_CONSTRAINTS.MIN_MAGNET_RADIUS}
-          max={DESIGNER_CONSTRAINTS.MAX_MAGNET_RADIUS}
-          step={DESIGNER_CONSTRAINTS.MAGNET_RADIUS_STEP}
+          label="Magnet diameter"
+          value={state.base.magnetDiameter}
+          onChange={handlers.setMagnetDiameter}
+          min={DESIGNER_CONSTRAINTS.MIN_MAGNET_DIAMETER}
+          max={DESIGNER_CONSTRAINTS.MAX_MAGNET_DIAMETER}
+          step={DESIGNER_CONSTRAINTS.MAGNET_DIAMETER_STEP}
           unit="mm"
         />
         <SliderInput
@@ -60,12 +60,12 @@ export function BaseSection() {
         valueSummary={`\u00f8${state.base.screwDiameter}mm (M${state.base.screwDiameter})`}
       >
         <SliderInput
-          label="Screw radius"
-          value={state.base.screwDiameter / 2}
-          onChange={handlers.setScrewRadius}
-          min={DESIGNER_CONSTRAINTS.MIN_SCREW_RADIUS}
-          max={DESIGNER_CONSTRAINTS.MAX_SCREW_RADIUS}
-          step={DESIGNER_CONSTRAINTS.SCREW_RADIUS_STEP}
+          label="Screw diameter"
+          value={state.base.screwDiameter}
+          onChange={handlers.setScrewDiameter}
+          min={DESIGNER_CONSTRAINTS.MIN_SCREW_DIAMETER}
+          max={DESIGNER_CONSTRAINTS.MAX_SCREW_DIAMETER}
+          step={DESIGNER_CONSTRAINTS.SCREW_DIAMETER_STEP}
           unit="mm"
         />
       </FeatureToggle>

--- a/src/features/bin-designer/components/panel/BaseSection/useBaseSection.test.ts
+++ b/src/features/bin-designer/components/panel/BaseSection/useBaseSection.test.ts
@@ -65,21 +65,21 @@ describe('useBaseSection', () => {
     expect(useDesignerStore.getState().params.base.stackingLip).toBe(false);
   });
 
-  it('setMagnetRadius updates magnetDiameter (radius × 2)', () => {
+  it('setMagnetDiameter updates magnetDiameter directly', () => {
     const { result } = renderHook(() => useBaseSection());
 
     act(() => {
-      result.current.handlers.setMagnetRadius(4.0);
+      result.current.handlers.setMagnetDiameter(6.5);
     });
 
-    expect(useDesignerStore.getState().params.base.magnetDiameter).toBe(8.0);
+    expect(useDesignerStore.getState().params.base.magnetDiameter).toBe(6.5);
   });
 
-  it('setScrewRadius updates screwDiameter (radius × 2)', () => {
+  it('setScrewDiameter updates screwDiameter directly', () => {
     const { result } = renderHook(() => useBaseSection());
 
     act(() => {
-      result.current.handlers.setScrewRadius(2.0);
+      result.current.handlers.setScrewDiameter(4.0);
     });
 
     expect(useDesignerStore.getState().params.base.screwDiameter).toBe(4.0);

--- a/src/features/bin-designer/components/panel/BaseSection/useBaseSection.ts
+++ b/src/features/bin-designer/components/panel/BaseSection/useBaseSection.ts
@@ -73,9 +73,9 @@ export function useBaseSection() {
     setParams(resolved);
   }, [params, isFlat, setParams]);
 
-  const setMagnetRadius = useCallback(
-    (radius: number) => {
-      updateBase({ magnetDiameter: radius * 2 });
+  const setMagnetDiameter = useCallback(
+    (diameter: number) => {
+      updateBase({ magnetDiameter: diameter });
     },
     [updateBase]
   );
@@ -87,9 +87,9 @@ export function useBaseSection() {
     [updateBase]
   );
 
-  const setScrewRadius = useCallback(
-    (radius: number) => {
-      updateBase({ screwDiameter: radius * 2 });
+  const setScrewDiameter = useCallback(
+    (diameter: number) => {
+      updateBase({ screwDiameter: diameter });
     },
     [updateBase]
   );
@@ -102,9 +102,9 @@ export function useBaseSection() {
       toggleStackingLip,
       toggleHalfSockets,
       toggleFlat,
-      setMagnetRadius,
+      setMagnetDiameter,
       setMagnetHeight,
-      setScrewRadius,
+      setScrewDiameter,
       magnetDisabledReason,
       screwDisabledReason,
       flatDisabledReason,

--- a/src/features/bin-designer/constants/gridfinity.ts
+++ b/src/features/bin-designer/constants/gridfinity.ts
@@ -43,17 +43,17 @@ export const DESIGNER_CONSTRAINTS = {
   MIN_WALL_THICKNESS: 0.4, // mm (1-wall for 0.4mm nozzle)
   MAX_WALL_THICKNESS: 2.4, // mm (3-wall for 0.8mm nozzle)
   WALL_THICKNESS_STEP: 0.1, // mm (legacy — use WALL_THICKNESS_OPTIONS)
-  // Magnet holes (radius in UI, diameter in store)
-  MIN_MAGNET_RADIUS: 2.0, // mm (diameter 4mm)
-  MAX_MAGNET_RADIUS: 5.0, // mm (diameter 10mm)
-  MAGNET_RADIUS_STEP: 0.25, // mm
+  // Magnet holes (diameter in UI and store)
+  MIN_MAGNET_DIAMETER: 4.0, // mm
+  MAX_MAGNET_DIAMETER: 10.0, // mm
+  MAGNET_DIAMETER_STEP: 0.1, // mm
   MIN_MAGNET_HEIGHT: 1.0, // mm
   MAX_MAGNET_HEIGHT: 4.0, // mm
   MAGNET_HEIGHT_STEP: 0.5, // mm
-  // Screw holes (radius in UI, diameter in store)
-  MIN_SCREW_RADIUS: 1.0, // mm (diameter 2mm)
-  MAX_SCREW_RADIUS: 3.0, // mm (diameter 6mm)
-  SCREW_RADIUS_STEP: 0.25, // mm
+  // Screw holes (diameter in UI and store)
+  MIN_SCREW_DIAMETER: 2.0, // mm
+  MAX_SCREW_DIAMETER: 6.0, // mm
+  SCREW_DIAMETER_STEP: 0.1, // mm
   // Slot configuration (slotted style)
   MIN_SLOT_PITCH: 10, // mm between slot centers
   MAX_SLOT_PITCH: 50, // mm

--- a/src/features/bin-designer/utils/validation.ts
+++ b/src/features/bin-designer/utils/validation.ts
@@ -105,14 +105,13 @@ export function validateBinParams(params: BinParams): Result<BinParams, Designer
 
   // Magnet dimension checks (only when magnet is enabled)
   if (params.base.style === 'magnet' || params.base.style === 'magnet_and_screw') {
-    const magnetRadius = params.base.magnetDiameter / 2;
     if (
-      magnetRadius < DESIGNER_CONSTRAINTS.MIN_MAGNET_RADIUS ||
-      magnetRadius > DESIGNER_CONSTRAINTS.MAX_MAGNET_RADIUS
+      params.base.magnetDiameter < DESIGNER_CONSTRAINTS.MIN_MAGNET_DIAMETER ||
+      params.base.magnetDiameter > DESIGNER_CONSTRAINTS.MAX_MAGNET_DIAMETER
     ) {
       return err({
-        code: 'MAGNET_RADIUS_OUT_OF_RANGE',
-        message: `Magnet radius must be between ${DESIGNER_CONSTRAINTS.MIN_MAGNET_RADIUS}mm and ${DESIGNER_CONSTRAINTS.MAX_MAGNET_RADIUS}mm`,
+        code: 'MAGNET_DIAMETER_OUT_OF_RANGE',
+        message: `Magnet diameter must be between ${DESIGNER_CONSTRAINTS.MIN_MAGNET_DIAMETER}mm and ${DESIGNER_CONSTRAINTS.MAX_MAGNET_DIAMETER}mm`,
         field: 'base.magnetDiameter',
       });
     }
@@ -130,14 +129,13 @@ export function validateBinParams(params: BinParams): Result<BinParams, Designer
 
   // Screw dimension check (only when screw is enabled)
   if (params.base.style === 'screw' || params.base.style === 'magnet_and_screw') {
-    const screwRadius = params.base.screwDiameter / 2;
     if (
-      screwRadius < DESIGNER_CONSTRAINTS.MIN_SCREW_RADIUS ||
-      screwRadius > DESIGNER_CONSTRAINTS.MAX_SCREW_RADIUS
+      params.base.screwDiameter < DESIGNER_CONSTRAINTS.MIN_SCREW_DIAMETER ||
+      params.base.screwDiameter > DESIGNER_CONSTRAINTS.MAX_SCREW_DIAMETER
     ) {
       return err({
-        code: 'SCREW_RADIUS_OUT_OF_RANGE',
-        message: `Screw radius must be between ${DESIGNER_CONSTRAINTS.MIN_SCREW_RADIUS}mm and ${DESIGNER_CONSTRAINTS.MAX_SCREW_RADIUS}mm`,
+        code: 'SCREW_DIAMETER_OUT_OF_RANGE',
+        message: `Screw diameter must be between ${DESIGNER_CONSTRAINTS.MIN_SCREW_DIAMETER}mm and ${DESIGNER_CONSTRAINTS.MAX_SCREW_DIAMETER}mm`,
         field: 'base.screwDiameter',
       });
     }


### PR DESCRIPTION
## Summary
- Magnet and screw hole sliders in the bin designer now display **diameter** (0.1mm steps) instead of radius (0.25mm steps), matching the baseplate UI
- Eliminates the radius↔diameter conversion layer — values pass through directly to the store
- Validation error codes updated from `*_RADIUS_OUT_OF_RANGE` to `*_DIAMETER_OUT_OF_RANGE`

Closes #1344

## Test plan
- [x] Unit tests updated and passing (9674 tests, 659 files)
- [x] TypeScript type check clean
- [ ] Verify magnet diameter slider in bin designer shows ø with 0.1mm precision
- [ ] Verify screw diameter slider shows 0.1mm precision
- [ ] Verify baseplate and bin designer now use consistent magnet/screw controls
- [ ] Verify existing saved layouts with magnet/screw settings load correctly (store format unchanged)