### PR TITLE
fix(generation): block honeycomb pattern at divider-wall junctions

### DIFF
--- a/src/features/generation/worker/generators/dividerBlendBuilder.test.ts
+++ b/src/features/generation/worker/generators/dividerBlendBuilder.test.ts
@@ -4,6 +4,7 @@ import {
   collectDividers,
   buildDividerBlends,
   computeRampZones,
+  computeDividerJunctionZones,
 } from './dividerBlendBuilder';
 import type { BinParams } from '@/shared/types/bin';
 import { DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
@@ -199,7 +200,7 @@ describe('computeRampZones', () => {
     expect(computeRampZones('back', BASE_PARAMS, INNER_W, INNER_D, WALL_HEIGHT)).toEqual([]);
   });
 
-  it('returns ramp zones for adjacent dividers', () => {
+  it('returns ramp zones for adjacent dividers (#1345 note: junction zones handle non-cutout case)', () => {
     // 3×1 grid: dividers at ±INNER_W/3 (~±13.6mm).
     // Narrow cutout (15% width = 12.24mm): edges at ±6.12mm.
     // Distance from cutout edge to divider1: 13.6 - 6.12 = 7.48mm.
@@ -222,5 +223,94 @@ describe('computeRampZones', () => {
         })
       );
     }
+  });
+});
+
+describe('computeDividerJunctionZones (#1345)', () => {
+  it('returns empty for slotted bins', () => {
+    const params = makeParams({ style: 'slotted' });
+    expect(computeDividerJunctionZones('front', params, INNER_W, INNER_D, WALL_HEIGHT)).toEqual([]);
+  });
+
+  it('returns empty when no dividers exist', () => {
+    const params = makeParams({
+      compartments: { enabled: true, rows: 1, cols: 1, thickness: 1.2, cells: [0] },
+    });
+    expect(computeDividerJunctionZones('front', params, INNER_W, INNER_D, WALL_HEIGHT)).toEqual([]);
+  });
+
+  it('returns zones for perpendicular dividers touching the wall', () => {
+    // 2×1 grid: one vertical divider at x=0, spanning full depth.
+    // Vertical dividers are perpendicular to front/back walls.
+    const params = makeParams({
+      walls: { ...BASE_PARAMS.walls, front: DISABLED_WALL_CUTOUT },
+    });
+    const zones = computeDividerJunctionZones('front', params, INNER_W, INNER_D, WALL_HEIGHT);
+    expect(zones).toHaveLength(1);
+    expect(zones[0].offsetAlongWall).toBeCloseTo(0, 1); // centered divider
+    expect(zones[0].height).toBe(WALL_HEIGHT);
+    expect(zones[0].width).toBeGreaterThan(BASE_PARAMS.wallThickness);
+  });
+
+  it('returns zones for back wall too', () => {
+    const params = makeParams({
+      walls: { ...BASE_PARAMS.walls, front: DISABLED_WALL_CUTOUT },
+    });
+    const zones = computeDividerJunctionZones('back', params, INNER_W, INNER_D, WALL_HEIGHT);
+    expect(zones).toHaveLength(1);
+    expect(zones[0].offsetAlongWall).toBeCloseTo(0, 1);
+  });
+
+  it('returns empty for walls parallel to the divider', () => {
+    // 2×1 grid: vertical divider is parallel to left/right walls.
+    const zones = computeDividerJunctionZones('left', BASE_PARAMS, INNER_W, INNER_D, WALL_HEIGHT);
+    expect(zones).toEqual([]);
+  });
+
+  it('returns zones for horizontal dividers touching left/right walls', () => {
+    const params = makeParams({
+      compartments: { enabled: true, rows: 2, cols: 1, thickness: 1.2, cells: [0, 1] },
+      walls: { ...BASE_PARAMS.walls, front: DISABLED_WALL_CUTOUT },
+    });
+    const leftZones = computeDividerJunctionZones('left', params, INNER_W, INNER_D, WALL_HEIGHT);
+    expect(leftZones).toHaveLength(1);
+    expect(leftZones[0].offsetAlongWall).toBeCloseTo(0, 1);
+
+    const rightZones = computeDividerJunctionZones('right', params, INNER_W, INNER_D, WALL_HEIGHT);
+    expect(rightZones).toHaveLength(1);
+  });
+
+  it('returns multiple zones for multi-column grids', () => {
+    const params = makeParams({
+      compartments: { enabled: true, rows: 1, cols: 3, thickness: 1.2, cells: [0, 1, 2] },
+      walls: { ...BASE_PARAMS.walls, front: DISABLED_WALL_CUTOUT },
+    });
+    const zones = computeDividerJunctionZones('front', params, INNER_W, INNER_D, WALL_HEIGHT);
+    expect(zones).toHaveLength(2); // two vertical dividers
+    // Dividers at -INNER_W/6 and +INNER_W/6 from center
+    expect(zones[0].offsetAlongWall).not.toBeCloseTo(zones[1].offsetAlongWall, 1);
+  });
+
+  it('works independently of wall cutout configuration', () => {
+    // Same compartments, different cutout configs → same junction zones
+    const paramsNoCutout = makeParams({
+      walls: { ...BASE_PARAMS.walls, front: DISABLED_WALL_CUTOUT },
+    });
+    const paramsWithCutout = makeParams(); // front cutout enabled
+    const zonesNoCutout = computeDividerJunctionZones(
+      'front',
+      paramsNoCutout,
+      INNER_W,
+      INNER_D,
+      WALL_HEIGHT
+    );
+    const zonesWithCutout = computeDividerJunctionZones(
+      'front',
+      paramsWithCutout,
+      INNER_W,
+      INNER_D,
+      WALL_HEIGHT
+    );
+    expect(zonesNoCutout).toEqual(zonesWithCutout);
   });
 });

--- a/src/features/generation/worker/generators/dividerBlendBuilder.ts
+++ b/src/features/generation/worker/generators/dividerBlendBuilder.ts
@@ -575,7 +575,9 @@ export function computeDividerJunctionZones(
   innerD: number,
   wallHeight: number
 ): RampZone[] {
+  // 'solid' intentionally included — junction blocking applies to any fused-wall style
   if (params.style === 'slotted') return [];
+  if (!params.walls.enabled) return [];
 
   const dividers = collectDividers(params, innerW, innerD);
   if (dividers.length === 0) return [];

--- a/src/features/generation/worker/generators/dividerBlendBuilder.ts
+++ b/src/features/generation/worker/generators/dividerBlendBuilder.ts
@@ -532,6 +532,66 @@ export function computeRampZones(
   return zones;
 }
 
+/**
+ * Compute zones where perpendicular dividers meet a specific outer wall,
+ * for blocking honeycomb pattern at the junction (full wall height).
+ *
+ * Unlike computeRampZones (which only produces zones near cutout edges),
+ * this returns a zone for every perpendicular divider touching the wall,
+ * regardless of whether a cutout exists. This ensures the hex pattern is
+ * cleared where divider walls connect to the outer wall for structural
+ * integrity (see issue #1345).
+ */
+export function computeDividerJunctionZones(
+  wallSide: 'front' | 'back' | 'left' | 'right',
+  params: BinParams,
+  innerW: number,
+  innerD: number,
+  wallHeight: number
+): RampZone[] {
+  if (params.style === 'slotted') return [];
+
+  const dividers = collectDividers(params, innerW, innerD);
+  if (dividers.length === 0) return [];
+
+  const wallMeta: Record<
+    string,
+    { wallFaceCoord: number; inwardSign: number; spanAxis: 'x' | 'y' }
+  > = {
+    front: { wallFaceCoord: -innerD / 2, inwardSign: 1, spanAxis: 'x' },
+    back: { wallFaceCoord: innerD / 2, inwardSign: -1, spanAxis: 'x' },
+    left: { wallFaceCoord: -innerW / 2, inwardSign: 1, spanAxis: 'y' },
+    right: { wallFaceCoord: innerW / 2, inwardSign: -1, spanAxis: 'y' },
+  };
+
+  const meta = wallMeta[wallSide];
+  const zones: RampZone[] = [];
+  const tol = 0.01;
+
+  for (const divider of dividers) {
+    // Only perpendicular dividers (vertical dividers ⊥ front/back, horizontal ⊥ left/right)
+    const perp =
+      (divider.axis === 'vertical' && meta.spanAxis === 'x') ||
+      (divider.axis === 'horizontal' && meta.spanAxis === 'y');
+    if (!perp) continue;
+
+    // Check if divider end touches this wall face
+    const touches =
+      meta.inwardSign > 0
+        ? Math.abs(divider.spanStart - meta.wallFaceCoord) < tol
+        : Math.abs(divider.spanEnd - meta.wallFaceCoord) < tol;
+    if (!touches) continue;
+
+    zones.push({
+      offsetAlongWall: divider.posAlongPerp,
+      width: divider.thickness + 2 * COPLANAR_MARGIN,
+      height: wallHeight,
+    });
+  }
+
+  return zones;
+}
+
 // --- FeatureBuilder protocol ---
 
 import type { FeatureBuilder } from './pipeline/featureBuilder';

--- a/src/features/generation/worker/generators/dividerBlendBuilder.ts
+++ b/src/features/generation/worker/generators/dividerBlendBuilder.ts
@@ -63,6 +63,31 @@ interface DividerInfo {
 /** Minimum geometry dimension to avoid degenerate shapes (mm). */
 const MIN_DIM = 0.5;
 
+/** Tolerance for matching divider endpoints to wall face coordinates (mm). */
+const WALL_TOUCH_TOL = 0.01;
+
+/** Minimal wall face descriptor shared by cutout info and junction detection. */
+interface WallFaceInfo {
+  readonly wallFaceCoord: number;
+  readonly inwardSign: number;
+  readonly spanAxis: 'x' | 'y';
+}
+
+/** Build a WallFaceInfo for a given side from bin inner dimensions. */
+function getWallFaceInfo(
+  side: 'front' | 'back' | 'left' | 'right',
+  innerW: number,
+  innerD: number
+): WallFaceInfo {
+  const info: Record<string, WallFaceInfo> = {
+    front: { wallFaceCoord: -innerD / 2, inwardSign: 1, spanAxis: 'x' },
+    back: { wallFaceCoord: innerD / 2, inwardSign: -1, spanAxis: 'x' },
+    left: { wallFaceCoord: -innerW / 2, inwardSign: 1, spanAxis: 'y' },
+    right: { wallFaceCoord: innerW / 2, inwardSign: -1, spanAxis: 'y' },
+  };
+  return info[side];
+}
+
 /**
  * Resolve outer-wall cutout geometry for all enabled sides.
  * Pure function — no brepjs dependency.
@@ -194,29 +219,30 @@ export function collectDividers(params: BinParams, innerW: number, innerD: numbe
 }
 
 /**
- * Check if a divider is perpendicular to a given wall cutout.
+ * Check if a divider is perpendicular to a given wall face.
  * Vertical dividers (run along Y) are perpendicular to front/back walls.
  * Horizontal dividers (run along X) are perpendicular to left/right walls.
  */
-function isPerpendicular(divider: DividerInfo, cutout: OuterWallCutoutInfo): boolean {
-  if (divider.axis === 'vertical') return cutout.spanAxis === 'x'; // front/back
-  return cutout.spanAxis === 'y'; // left/right
+function isPerpendicular(divider: DividerInfo, wall: WallFaceInfo): boolean {
+  if (divider.axis === 'vertical') return wall.spanAxis === 'x'; // front/back
+  return wall.spanAxis === 'y'; // left/right
 }
 
 /**
  * Check if a divider's end touches a specific wall face.
  */
-function dividerTouchesWall(divider: DividerInfo, cutout: OuterWallCutoutInfo): boolean {
-  const tol = 0.01;
-  if (divider.axis === 'vertical' && cutout.spanAxis === 'x') {
+function dividerTouchesWall(divider: DividerInfo, wall: WallFaceInfo): boolean {
+  if (divider.axis === 'vertical' && wall.spanAxis === 'x') {
     // Vertical divider, front/back wall
-    if (cutout.inwardSign > 0) return Math.abs(divider.spanStart - cutout.wallFaceCoord) < tol;
-    return Math.abs(divider.spanEnd - cutout.wallFaceCoord) < tol;
+    if (wall.inwardSign > 0)
+      return Math.abs(divider.spanStart - wall.wallFaceCoord) < WALL_TOUCH_TOL;
+    return Math.abs(divider.spanEnd - wall.wallFaceCoord) < WALL_TOUCH_TOL;
   }
-  if (divider.axis === 'horizontal' && cutout.spanAxis === 'y') {
+  if (divider.axis === 'horizontal' && wall.spanAxis === 'y') {
     // Horizontal divider, left/right wall
-    if (cutout.inwardSign > 0) return Math.abs(divider.spanStart - cutout.wallFaceCoord) < tol;
-    return Math.abs(divider.spanEnd - cutout.wallFaceCoord) < tol;
+    if (wall.inwardSign > 0)
+      return Math.abs(divider.spanStart - wall.wallFaceCoord) < WALL_TOUCH_TOL;
+    return Math.abs(divider.spanEnd - wall.wallFaceCoord) < WALL_TOUCH_TOL;
   }
   return false;
 }
@@ -554,33 +580,12 @@ export function computeDividerJunctionZones(
   const dividers = collectDividers(params, innerW, innerD);
   if (dividers.length === 0) return [];
 
-  const wallMeta: Record<
-    string,
-    { wallFaceCoord: number; inwardSign: number; spanAxis: 'x' | 'y' }
-  > = {
-    front: { wallFaceCoord: -innerD / 2, inwardSign: 1, spanAxis: 'x' },
-    back: { wallFaceCoord: innerD / 2, inwardSign: -1, spanAxis: 'x' },
-    left: { wallFaceCoord: -innerW / 2, inwardSign: 1, spanAxis: 'y' },
-    right: { wallFaceCoord: innerW / 2, inwardSign: -1, spanAxis: 'y' },
-  };
-
-  const meta = wallMeta[wallSide];
+  const wall = getWallFaceInfo(wallSide, innerW, innerD);
   const zones: RampZone[] = [];
-  const tol = 0.01;
 
   for (const divider of dividers) {
-    // Only perpendicular dividers (vertical dividers ⊥ front/back, horizontal ⊥ left/right)
-    const perp =
-      (divider.axis === 'vertical' && meta.spanAxis === 'x') ||
-      (divider.axis === 'horizontal' && meta.spanAxis === 'y');
-    if (!perp) continue;
-
-    // Check if divider end touches this wall face
-    const touches =
-      meta.inwardSign > 0
-        ? Math.abs(divider.spanStart - meta.wallFaceCoord) < tol
-        : Math.abs(divider.spanEnd - meta.wallFaceCoord) < tol;
-    if (!touches) continue;
+    if (!isPerpendicular(divider, wall)) continue;
+    if (!dividerTouchesWall(divider, wall)) continue;
 
     zones.push({
       offsetAlongWall: divider.posAlongPerp,

--- a/src/features/generation/worker/generators/wallPatternBuilder.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.ts
@@ -287,7 +287,12 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
       innerD,
       dim.wallHeight
     );
-    const combinedZones = [...rampZones, ...junctionZones];
+    // Deduplicate: junction zones (full height) subsume ramp zones at the same offset
+    const junctionOffsets = new Set(junctionZones.map((z) => quantize(z.offsetAlongWall)));
+    const uniqueRampZones = rampZones.filter(
+      (z) => !junctionOffsets.has(quantize(z.offsetAlongWall))
+    );
+    const combinedZones = [...uniqueRampZones, ...junctionZones];
     const rampClip: RampZoneClipParams | null =
       combinedZones.length > 0
         ? { zones: combinedZones, clipExtrudeDepth: clipExtrudeDepth, wallHeight: dim.wallHeight }

--- a/src/features/generation/worker/generators/wallPatternBuilder.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.ts
@@ -41,7 +41,7 @@ import {
   getExpandedCutoutDimensions,
 } from './wallPatterns';
 import { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
-import { computeRampZones } from './dividerBlendBuilder';
+import { computeRampZones, computeDividerJunctionZones } from './dividerBlendBuilder';
 import type { RampZone } from './dividerBlendBuilder';
 import type { WallCutoutShape } from '@/shared/types/bin';
 import { buildSingleCutout } from './featureBuilder';
@@ -278,11 +278,19 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
         )
       : 'nohdl';
 
-    // Ramp zone clipping for divider-cutout blends
+    // Ramp zone clipping for divider-cutout blends + divider junction blocking (#1345)
     const rampZones = computeRampZones(wall.side, params, innerW, innerD, dim.wallHeight);
+    const junctionZones = computeDividerJunctionZones(
+      wall.side,
+      params,
+      innerW,
+      innerD,
+      dim.wallHeight
+    );
+    const combinedZones = [...rampZones, ...junctionZones];
     const rampClip: RampZoneClipParams | null =
-      rampZones.length > 0
-        ? { zones: rampZones, clipExtrudeDepth: clipExtrudeDepth, wallHeight: dim.wallHeight }
+      combinedZones.length > 0
+        ? { zones: combinedZones, clipExtrudeDepth: clipExtrudeDepth, wallHeight: dim.wallHeight }
         : null;
 
     const rampKeyPart = rampClip
@@ -296,7 +304,7 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
 
     const wallKey = compactKey(
       buildCacheKey(
-        'v5', // bumped: ramp zone clipping added
+        'v6', // bumped: divider junction zone clipping (#1345)
         patternType,
         quantize(shapeRadius),
         quantize(cutDepth),


### PR DESCRIPTION
## Summary
Closes #1345

- Adds `computeDividerJunctionZones()` to detect where interior dividers connect to outer walls
- Clips honeycomb wall pattern at those junctions for structural integrity
- Works independently of wall cutout configuration — every divider-wall connection gets a solid zone

## How it works
The new function finds perpendicular dividers that touch each outer wall and returns full-height clip zones (reusing the existing `RampZone` type). These are merged with the existing cutout ramp zones in `wallPatternBuilder.ts`, so the hex pattern is cleared at every junction with zero new clipping code.

## Test plan
- [x] 8 new unit tests for `computeDividerJunctionZones` (slotted skip, no-divider, front/back/left/right walls, parallel exclusion, multi-column, cutout-independence)
- [x] All 27 `dividerBlendBuilder` tests pass
- [x] TypeScript compiles clean
- [ ] Visual verification: bin with honeycomb + compartment dividers shows solid wall at divider junction