### PR TITLE
fix(generation): fix honeycomb pattern at divider-wall junctions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Bin → position (x,y), size (w,d,h), layerId, category, label, notes, customPro
 2. **Staging**: `layerId === '__staging__'` = off-grid stash. Auto-used when bins displaced.
 3. **Half-Bin Mode**: 0.5 increments. Helpers: `snapToHalf()`, `snapToGrid()`, `isFractional()`. `HALF_BIN_SCALE = 2`.
 4. **Multi-Layout**: Each layout stored by UUID (`gridfinity-layout-{uuid}`). Library index tracks metadata only.
-5. **Wall Pattern Border Rule**: Any feature that cuts through a wall (cutouts, handles, etc.) MUST have corresponding border clipping in `wallPatternBuilder.ts` using `CUTOUT_BORDER_WIDTH` (1.5mm). Without it, hex prisms overlap the cut region producing jagged edges.
+5. **Wall Pattern Border Rule**: Any feature that cuts through a wall (cutouts, handles, etc.) MUST have corresponding border clipping in `wallPatternBuilder.ts`. Cutout/handle clips use `CUTOUT_BORDER_WIDTH` (1.5mm); divider junction clips use `max(CUTOUT_BORDER_WIDTH, shapeRadius)` so larger hex prisms (4u+ bins) can't bleed into divider walls. Without border clipping, hex prisms overlap the cut region producing jagged edges.
 
 ### Result Type (`src/core/result/`)
 

--- a/src/features/generation/worker/generators/dividerBlendBuilder.test.ts
+++ b/src/features/generation/worker/generators/dividerBlendBuilder.test.ts
@@ -313,4 +313,18 @@ describe('computeDividerJunctionZones (#1345)', () => {
     );
     expect(zonesNoCutout).toEqual(zonesWithCutout);
   });
+
+  it('works when wall cutouts feature is entirely disabled (#1350)', () => {
+    // walls.enabled = false (cutout feature off) should still produce junction zones
+    const params = makeParams({
+      walls: {
+        ...BASE_PARAMS.walls,
+        enabled: false,
+        front: DISABLED_WALL_CUTOUT,
+      },
+    });
+    const zones = computeDividerJunctionZones('front', params, INNER_W, INNER_D, WALL_HEIGHT);
+    expect(zones).toHaveLength(1);
+    expect(zones[0].height).toBe(WALL_HEIGHT);
+  });
 });

--- a/src/features/generation/worker/generators/dividerBlendBuilder.ts
+++ b/src/features/generation/worker/generators/dividerBlendBuilder.ts
@@ -577,7 +577,6 @@ export function computeDividerJunctionZones(
 ): RampZone[] {
   // 'solid' intentionally included — junction blocking applies to any fused-wall style
   if (params.style === 'slotted') return [];
-  if (!params.walls.enabled) return [];
 
   const dividers = collectDividers(params, innerW, innerD);
   if (dividers.length === 0) return [];

--- a/src/features/generation/worker/generators/wallPatternBuilder.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.ts
@@ -293,9 +293,16 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
       (z) => !junctionOffsets.has(quantize(z.offsetAlongWall))
     );
     const combinedZones = [...uniqueRampZones, ...junctionZones];
+    // Ensure border is at least shapeRadius so hex prisms can't bleed into divider walls (#1350).
+    const zoneBorder = Math.max(CUTOUT_BORDER_WIDTH, shapeRadius);
     const rampClip: RampZoneClipParams | null =
       combinedZones.length > 0
-        ? { zones: combinedZones, clipExtrudeDepth: clipExtrudeDepth, wallHeight: dim.wallHeight }
+        ? {
+            zones: combinedZones,
+            clipExtrudeDepth,
+            wallHeight: dim.wallHeight,
+            border: zoneBorder,
+          }
         : null;
 
     const rampKeyPart = rampClip
@@ -309,7 +316,7 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
 
     const wallKey = compactKey(
       buildCacheKey(
-        'v6', // bumped: divider junction zone clipping (#1345)
+        'v7', // bumped: shape-radius-aware junction border (#1350)
         patternType,
         quantize(shapeRadius),
         quantize(cutDepth),
@@ -388,6 +395,9 @@ interface RampZoneClipParams {
   readonly zones: readonly RampZone[];
   readonly clipExtrudeDepth: number;
   readonly wallHeight: number;
+  /** Border width for clip boxes — max(CUTOUT_BORDER_WIDTH, shapeRadius)
+   *  so hex prisms don't extend into divider walls at junctions. */
+  readonly border: number;
 }
 
 /** Build a single wall's pattern compound with optional cutout/handle/ramp clipping. */
@@ -520,22 +530,18 @@ function buildWallPatternShape(
 
   // --- Ramp zone border clipping ---
   if (rampClip && rampClip.zones.length > 0) {
-    const border = CUTOUT_BORDER_WIDTH;
+    const { border, clipExtrudeDepth: rampExtrudeDepth, wallHeight, zones } = rampClip;
     const rampBoxes: Shape3D[] = [];
 
     try {
-      for (const zone of rampClip.zones) {
+      for (const zone of zones) {
         const rboxW = zone.width + 2 * border;
         const rboxH = zone.height + 2 * border;
         const profile = drawRectangle(rboxW, rboxH);
         // Dispose intermediates from each transform.
-        const extruded = sketch(profile, 'XZ').extrude(rampClip.clipExtrudeDepth);
-        const centerZ = rampClip.wallHeight - zone.height / 2;
-        const centered = translate(extruded, [
-          zone.offsetAlongWall,
-          rampClip.clipExtrudeDepth / 2,
-          centerZ,
-        ]);
+        const extruded = sketch(profile, 'XZ').extrude(rampExtrudeDepth);
+        const centerZ = wallHeight - zone.height / 2;
+        const centered = translate(extruded, [zone.offsetAlongWall, rampExtrudeDepth / 2, centerZ]);
         extruded.delete();
         let rbox = centered;
         if (wall.zRotation !== undefined) {


### PR DESCRIPTION
## Summary

Fixes #1350 — two honeycomb wall pattern bugs at divider-wall junctions:

- **Junction blocking gated on wall cutouts:** `computeDividerJunctionZones()` had an incorrect `params.walls.enabled` guard (added during #1348 review) that prevented junction blocking when wall cutouts were disabled. Removed the guard — junction blocking now works for all non-slotted bins with dividers.
- **Partial hex prisms cutting into dividers:** The junction clip border used `CUTOUT_BORDER_WIDTH` (1.5mm), which is too small for larger hex radii (e.g., 3.6mm on 4u+ bins). Clip border now uses `max(CUTOUT_BORDER_WIDTH, shapeRadius)` to fully prevent hex prism bleed-through.

## Test plan

- [x] Added test: junction zones computed when `walls.enabled = false`
- [x] All 9683 existing tests pass including scenario tests
- [x] TypeScript compiles cleanly
- [x] Visual verification: create a 4u bin with 2×1 compartments + honeycomb pattern, confirm no holes at divider-wall junctions with and without wall cutouts enabled