### PR TITLE
test(generation): add honeycomb junction triangle count regression tests

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -82,17 +82,17 @@ exports[`height > 2×2 height minimum (2u) 1`] = `2940`;
 
 exports[`height > 2×2 height tall (10u) 1`] = `2940`;
 
-exports[`honeycomb junction > 2×1 honeycomb + divider + front + interior cutouts 1`] = `7012`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `7012`;
 
-exports[`honeycomb junction > 2×1 honeycomb + divider + front cutout 1`] = `6948`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6948`;
 
-exports[`honeycomb junction > 2×1 honeycomb + divider, cutouts on (sides off) 1`] = `7104`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `7104`;
 
-exports[`honeycomb junction > 2×1 honeycomb + divider, no cutouts 1`] = `7104`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `7104`;
 
-exports[`honeycomb junction > 2×2 honeycomb + 2×2 dividers, no cutouts 1`] = `7232`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `7376`;
 
-exports[`honeycomb junction > 2×2 honeycomb + dividers + interior cutouts 1`] = `7376`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `7232`;
 
 exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `7068`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -1,0 +1,163 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `3036`;
+
+exports[`base styles > flat base no lip 1`] = `252`;
+
+exports[`base styles > flat base with lip 1`] = `1020`;
+
+exports[`base styles > magnet base no lip 1`] = `804`;
+
+exports[`base styles > magnet base with lip 1`] = `2028`;
+
+exports[`base styles > magnet+screw base no lip 1`] = `1028`;
+
+exports[`base styles > magnet+screw base with lip 1`] = `2396`;
+
+exports[`base styles > screw base no lip 1`] = `692`;
+
+exports[`base styles > screw base with lip 1`] = `1868`;
+
+exports[`base styles > standard base no lip 1`] = `468`;
+
+exports[`base styles > standard base with lip 1`] = `1500`;
+
+exports[`base styles > weighted base no lip 1`] = `468`;
+
+exports[`base styles > weighted base with lip 1`] = `1500`;
+
+exports[`bin styles > 2×2 slotted 1`] = `3348`;
+
+exports[`bin styles > 2×2 solid 1`] = `2548`;
+
+exports[`bin styles > 2×2 standard 1`] = `2940`;
+
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1580`;
+
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3436`;
+
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `5428`;
+
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `7636`;
+
+exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `18048`;
+
+exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2940`;
+
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `3652`;
+
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3752`;
+
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5396`;
+
+exports[`dimensions > 0.5×0.5 no lip 1`] = `468`;
+
+exports[`dimensions > 0.5×0.5 with lip 1`] = `1820`;
+
+exports[`dimensions > 1.5×2 fractional no lip 1`] = `1260`;
+
+exports[`dimensions > 1.5×2 fractional with lip 1`] = `3260`;
+
+exports[`dimensions > 1×1 no lip 1`] = `468`;
+
+exports[`dimensions > 1×1 with lip 1`] = `1500`;
+
+exports[`dimensions > 2×2 no lip 1`] = `1260`;
+
+exports[`dimensions > 2×2 with lip 1`] = `2940`;
+
+exports[`dimensions > 4×4 no lip 1`] = `3500`;
+
+exports[`dimensions > 4×4 with lip 1`] = `8092`;
+
+exports[`export mode > 2×2 default params (forExport=true) 1`] = `5668`;
+
+exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5660`;
+
+exports[`half-sockets > 1×1 with half sockets 1`] = `2940`;
+
+exports[`half-sockets > 2×2 with half sockets 1`] = `8700`;
+
+exports[`height > 2×2 height minimum (2u) 1`] = `2940`;
+
+exports[`height > 2×2 height tall (10u) 1`] = `2940`;
+
+exports[`honeycomb junction > 2×1 honeycomb + divider + front + interior cutouts 1`] = `7012`;
+
+exports[`honeycomb junction > 2×1 honeycomb + divider + front cutout 1`] = `6948`;
+
+exports[`honeycomb junction > 2×1 honeycomb + divider, cutouts on (sides off) 1`] = `7104`;
+
+exports[`honeycomb junction > 2×1 honeycomb + divider, no cutouts 1`] = `7104`;
+
+exports[`honeycomb junction > 2×2 honeycomb + 2×2 dividers, no cutouts 1`] = `7232`;
+
+exports[`honeycomb junction > 2×2 honeycomb + dividers + interior cutouts 1`] = `7376`;
+
+exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `7068`;
+
+exports[`inserts > 2×2 with circle insert 1`] = `3208`;
+
+exports[`inserts > 2×2 with hexagon insert 1`] = `3208`;
+
+exports[`inserts > 2×2 with rectangle insert 1`] = `2976`;
+
+exports[`inserts > 2×2 with rounded-rect insert 1`] = `3104`;
+
+exports[`inserts > 2×2 with slot insert 1`] = `3152`;
+
+exports[`label tabs > 2×2 label bracket center 1`] = `3748`;
+
+exports[`label tabs > 2×2 label bracket left 1`] = `3748`;
+
+exports[`label tabs > 2×2 label bracket right 1`] = `3748`;
+
+exports[`label tabs > 2×2 label disabled 1`] = `2940`;
+
+exports[`label tabs > 2×2 label solid left 1`] = `3636`;
+
+exports[`large bin > 8×8 standard 1`] = `23228`;
+
+exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3432`;
+
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4144`;
+
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `5032`;
+
+exports[`scoop > 2×2 scoop auto radius 1`] = `4144`;
+
+exports[`scoop > 2×2 scoop disabled 1`] = `2940`;
+
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `4310`;
+
+exports[`slotted variations > slotted with Y-axis slots 1`] = `3348`;
+
+exports[`slotted variations > slotted with both axes 1`] = `3756`;
+
+exports[`slotted variations > slotted without lip 1`] = `1380`;
+
+exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `2784`;
+
+exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `2700`;
+
+exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `3166`;
+
+exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2578`;
+
+exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `2740`;
+
+exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2568`;
+
+exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `3244`;
+
+exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2580`;
+
+exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `2696`;
+
+exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2560`;
+
+exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2560`;
+
+exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `2700`;
+
+exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `3084`;

--- a/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
+++ b/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
@@ -7,6 +7,7 @@
  * triangle count because extra cut faces appear or solid wall geometry is
  * removed.
  */
+import { expect } from 'vitest';
 import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
 import { defineScenario } from '../__dual-kernel__/scenarioTypes';
 import type { ScenarioCase } from '../__dual-kernel__/scenarioTypes';

--- a/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
+++ b/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
@@ -12,6 +12,17 @@ import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin
 import { defineScenario } from '../__dual-kernel__/scenarioTypes';
 import type { ScenarioCase } from '../__dual-kernel__/scenarioTypes';
 
+/** All cutout sides explicitly disabled — used as the canonical "no cutouts" walls config. */
+const ALL_SIDES_OFF = {
+  ...DEFAULT_BIN_PARAMS.walls,
+  enabled: false,
+  front: DISABLED_WALL_CUTOUT,
+  back: DISABLED_WALL_CUTOUT,
+  left: DISABLED_WALL_CUTOUT,
+  right: DISABLED_WALL_CUTOUT,
+  interior: DISABLED_WALL_CUTOUT,
+} as const;
+
 export const honeycombJunction: ScenarioCase[] = [
   // ── Baseline: honeycomb without dividers ─────────────────────────────────
 
@@ -21,61 +32,54 @@ export const honeycombJunction: ScenarioCase[] = [
       depth: 2,
       height: 4,
       wallPattern: { enabled: true, pattern: 'honeycomb' },
-      walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: false },
+      walls: ALL_SIDES_OFF,
     },
     timeout: 60_000,
   }),
 
   // ── Bug 1: junction blocking must work without wall cutouts ──────────────
 
-  defineScenario('honeycomb junction', '2×1 honeycomb + divider, no cutouts', {
+  defineScenario('honeycomb junction', '2×2 bin, 2×1 compartments, no cutouts', {
     params: {
       width: 2,
       depth: 2,
       height: 4,
       wallPattern: { enabled: true, pattern: 'honeycomb' },
       compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
-      walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: false },
+      walls: ALL_SIDES_OFF,
     },
     timeout: 60_000,
   }),
 
-  defineScenario('honeycomb junction', '2×2 honeycomb + 2×2 dividers, no cutouts', {
+  defineScenario('honeycomb junction', '2×2 bin, 2×2 compartments, no cutouts', {
     params: {
       width: 2,
       depth: 2,
       height: 4,
       wallPattern: { enabled: true, pattern: 'honeycomb' },
       compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 1.2 },
-      walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: false },
+      walls: ALL_SIDES_OFF,
     },
     timeout: 60_000,
   }),
 
   // ── Bug 2: no mesh holes when cutouts enabled but all sides off ──────────
 
-  defineScenario('honeycomb junction', '2×1 honeycomb + divider, cutouts on (sides off)', {
+  defineScenario('honeycomb junction', '2×2 bin, 2×1 compartments, cutouts on (sides off)', {
     params: {
       width: 2,
       depth: 2,
       height: 4,
       wallPattern: { enabled: true, pattern: 'honeycomb' },
       compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
-      walls: {
-        ...DEFAULT_BIN_PARAMS.walls,
-        enabled: true,
-        front: DISABLED_WALL_CUTOUT,
-        back: DISABLED_WALL_CUTOUT,
-        left: DISABLED_WALL_CUTOUT,
-        right: DISABLED_WALL_CUTOUT,
-      },
+      walls: { ...ALL_SIDES_OFF, enabled: true },
     },
     timeout: 60_000,
   }),
 
   // ── Junction + active cutout on one side ─────────────────────────────────
 
-  defineScenario('honeycomb junction', '2×1 honeycomb + divider + front cutout', {
+  defineScenario('honeycomb junction', '2×2 bin, 2×1 compartments + front cutout', {
     params: {
       width: 2,
       depth: 2,
@@ -83,12 +87,9 @@ export const honeycombJunction: ScenarioCase[] = [
       wallPattern: { enabled: true, pattern: 'honeycomb' },
       compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
       walls: {
-        ...DEFAULT_BIN_PARAMS.walls,
+        ...ALL_SIDES_OFF,
         enabled: true,
         front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
-        back: DISABLED_WALL_CUTOUT,
-        left: DISABLED_WALL_CUTOUT,
-        right: DISABLED_WALL_CUTOUT,
       },
     },
     timeout: 60_000,
@@ -96,7 +97,7 @@ export const honeycombJunction: ScenarioCase[] = [
 
   // ── Honeycomb + dividers + interior wall cutouts ──────────────────────────
 
-  defineScenario('honeycomb junction', '2×2 honeycomb + dividers + interior cutouts', {
+  defineScenario('honeycomb junction', '2×2 bin, 2×2 compartments + interior cutouts', {
     params: {
       width: 2,
       depth: 2,
@@ -104,12 +105,8 @@ export const honeycombJunction: ScenarioCase[] = [
       wallPattern: { enabled: true, pattern: 'honeycomb' },
       compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 1.2 },
       walls: {
-        ...DEFAULT_BIN_PARAMS.walls,
+        ...ALL_SIDES_OFF,
         enabled: true,
-        front: DISABLED_WALL_CUTOUT,
-        back: DISABLED_WALL_CUTOUT,
-        left: DISABLED_WALL_CUTOUT,
-        right: DISABLED_WALL_CUTOUT,
         interior: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
       },
     },
@@ -118,7 +115,7 @@ export const honeycombJunction: ScenarioCase[] = [
 
   // ── Honeycomb + dividers + outer + interior cutouts ──────────────────────
 
-  defineScenario('honeycomb junction', '2×1 honeycomb + divider + front + interior cutouts', {
+  defineScenario('honeycomb junction', '2×2 bin, 2×1 compartments + front + interior cutouts', {
     params: {
       width: 2,
       depth: 2,
@@ -126,12 +123,9 @@ export const honeycombJunction: ScenarioCase[] = [
       wallPattern: { enabled: true, pattern: 'honeycomb' },
       compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
       walls: {
-        ...DEFAULT_BIN_PARAMS.walls,
+        ...ALL_SIDES_OFF,
         enabled: true,
         front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
-        back: DISABLED_WALL_CUTOUT,
-        left: DISABLED_WALL_CUTOUT,
-        right: DISABLED_WALL_CUTOUT,
         interior: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
       },
     },
@@ -152,7 +146,7 @@ export const honeycombJunction: ScenarioCase[] = [
         depth: 2,
         height: 4,
         wallPattern: { enabled: true, pattern: 'honeycomb' },
-        walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: false },
+        walls: ALL_SIDES_OFF,
       },
       compareWith: {
         params: {
@@ -161,7 +155,7 @@ export const honeycombJunction: ScenarioCase[] = [
           height: 4,
           wallPattern: { enabled: true, pattern: 'honeycomb' },
           compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
-          walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: false },
+          walls: ALL_SIDES_OFF,
         },
         assert: (noDivider, withDivider) => {
           // Divider adds geometry, so withDivider > noDivider
@@ -184,8 +178,8 @@ export const honeycombJunction: ScenarioCase[] = [
   ),
 
   // ── Triangle count must match regardless of cutout toggle ────────────────
-  // The junction zone geometry is identical whether walls.enabled is true or
-  // false (with all sides off), so the triangle counts must be equal.
+  // Both configs have all sides explicitly DISABLED_WALL_CUTOUT; the only
+  // difference is walls.enabled (false vs true). Triangle counts must match.
 
   defineScenario(
     'honeycomb junction',
@@ -198,7 +192,7 @@ export const honeycombJunction: ScenarioCase[] = [
         height: 4,
         wallPattern: { enabled: true, pattern: 'honeycomb' },
         compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
-        walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: false },
+        walls: ALL_SIDES_OFF,
       },
       compareWith: {
         params: {
@@ -207,14 +201,7 @@ export const honeycombJunction: ScenarioCase[] = [
           height: 4,
           wallPattern: { enabled: true, pattern: 'honeycomb' },
           compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
-          walls: {
-            ...DEFAULT_BIN_PARAMS.walls,
-            enabled: true,
-            front: DISABLED_WALL_CUTOUT,
-            back: DISABLED_WALL_CUTOUT,
-            left: DISABLED_WALL_CUTOUT,
-            right: DISABLED_WALL_CUTOUT,
-          },
+          walls: { ...ALL_SIDES_OFF, enabled: true },
         },
         assert: (cutoutsOff, cutoutsOnSidesOff) => {
           expect(

--- a/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
+++ b/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
@@ -1,0 +1,228 @@
+/**
+ * Honeycomb wall pattern + divider junction regression scenarios (#1350).
+ *
+ * These pin triangle counts for configurations where the honeycomb pattern
+ * interacts with divider walls at the outer-wall junction. Regressions in
+ * junction blocking (e.g. hex prisms cutting through dividers) change the
+ * triangle count because extra cut faces appear or solid wall geometry is
+ * removed.
+ */
+import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
+import { defineScenario } from '../__dual-kernel__/scenarioTypes';
+import type { ScenarioCase } from '../__dual-kernel__/scenarioTypes';
+
+export const honeycombJunction: ScenarioCase[] = [
+  // ── Baseline: honeycomb without dividers ─────────────────────────────────
+
+  defineScenario('honeycomb junction', '2×2×4 honeycomb baseline (no dividers)', {
+    params: {
+      width: 2,
+      depth: 2,
+      height: 4,
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: false },
+    },
+    timeout: 60_000,
+  }),
+
+  // ── Bug 1: junction blocking must work without wall cutouts ──────────────
+
+  defineScenario('honeycomb junction', '2×1 honeycomb + divider, no cutouts', {
+    params: {
+      width: 2,
+      depth: 2,
+      height: 4,
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
+      walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: false },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('honeycomb junction', '2×2 honeycomb + 2×2 dividers, no cutouts', {
+    params: {
+      width: 2,
+      depth: 2,
+      height: 4,
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 1.2 },
+      walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: false },
+    },
+    timeout: 60_000,
+  }),
+
+  // ── Bug 2: no mesh holes when cutouts enabled but all sides off ──────────
+
+  defineScenario('honeycomb junction', '2×1 honeycomb + divider, cutouts on (sides off)', {
+    params: {
+      width: 2,
+      depth: 2,
+      height: 4,
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
+      walls: {
+        ...DEFAULT_BIN_PARAMS.walls,
+        enabled: true,
+        front: DISABLED_WALL_CUTOUT,
+        back: DISABLED_WALL_CUTOUT,
+        left: DISABLED_WALL_CUTOUT,
+        right: DISABLED_WALL_CUTOUT,
+      },
+    },
+    timeout: 60_000,
+  }),
+
+  // ── Junction + active cutout on one side ─────────────────────────────────
+
+  defineScenario('honeycomb junction', '2×1 honeycomb + divider + front cutout', {
+    params: {
+      width: 2,
+      depth: 2,
+      height: 4,
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
+      walls: {
+        ...DEFAULT_BIN_PARAMS.walls,
+        enabled: true,
+        front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
+        back: DISABLED_WALL_CUTOUT,
+        left: DISABLED_WALL_CUTOUT,
+        right: DISABLED_WALL_CUTOUT,
+      },
+    },
+    timeout: 60_000,
+  }),
+
+  // ── Honeycomb + dividers + interior wall cutouts ──────────────────────────
+
+  defineScenario('honeycomb junction', '2×2 honeycomb + dividers + interior cutouts', {
+    params: {
+      width: 2,
+      depth: 2,
+      height: 4,
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 1.2 },
+      walls: {
+        ...DEFAULT_BIN_PARAMS.walls,
+        enabled: true,
+        front: DISABLED_WALL_CUTOUT,
+        back: DISABLED_WALL_CUTOUT,
+        left: DISABLED_WALL_CUTOUT,
+        right: DISABLED_WALL_CUTOUT,
+        interior: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
+      },
+    },
+    timeout: 60_000,
+  }),
+
+  // ── Honeycomb + dividers + outer + interior cutouts ──────────────────────
+
+  defineScenario('honeycomb junction', '2×1 honeycomb + divider + front + interior cutouts', {
+    params: {
+      width: 2,
+      depth: 2,
+      height: 4,
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
+      walls: {
+        ...DEFAULT_BIN_PARAMS.walls,
+        enabled: true,
+        front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
+        back: DISABLED_WALL_CUTOUT,
+        left: DISABLED_WALL_CUTOUT,
+        right: DISABLED_WALL_CUTOUT,
+        interior: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
+      },
+    },
+    timeout: 60_000,
+  }),
+
+  // ── Dividers add geometry but junction blocking limits the increase ─────
+  // Adding a divider adds wall geometry but removes hex prisms at the
+  // junction. Net result: slightly more triangles, not dramatically more.
+
+  defineScenario(
+    'honeycomb junction',
+    'adding divider increases triangles modestly (junction blocking works)',
+    {
+      assert: 'structural',
+      params: {
+        width: 2,
+        depth: 2,
+        height: 4,
+        wallPattern: { enabled: true, pattern: 'honeycomb' },
+        walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: false },
+      },
+      compareWith: {
+        params: {
+          width: 2,
+          depth: 2,
+          height: 4,
+          wallPattern: { enabled: true, pattern: 'honeycomb' },
+          compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
+          walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: false },
+        },
+        assert: (noDivider, withDivider) => {
+          // Divider adds geometry, so withDivider > noDivider
+          expect(withDivider.triangleCount, 'divider should add triangles').toBeGreaterThan(
+            noDivider.triangleCount
+          );
+          // But junction blocking removes hex prisms, so the increase is small.
+          // Without blocking, hex cuts through the junction would add hundreds
+          // of extra triangles. Cap the increase at 5% to catch regressions.
+          const increase = withDivider.triangleCount - noDivider.triangleCount;
+          const maxIncrease = noDivider.triangleCount * 0.05;
+          expect(
+            increase,
+            `divider added ${increase} triangles (max ${Math.round(maxIncrease)}); junction blocking may be broken`
+          ).toBeLessThanOrEqual(maxIncrease);
+        },
+      },
+      timeout: 60_000,
+    }
+  ),
+
+  // ── Triangle count must match regardless of cutout toggle ────────────────
+  // The junction zone geometry is identical whether walls.enabled is true or
+  // false (with all sides off), so the triangle counts must be equal.
+
+  defineScenario(
+    'honeycomb junction',
+    'cutout toggle off vs on (sides off) produces same triangle count',
+    {
+      assert: 'structural',
+      params: {
+        width: 2,
+        depth: 2,
+        height: 4,
+        wallPattern: { enabled: true, pattern: 'honeycomb' },
+        compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
+        walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: false },
+      },
+      compareWith: {
+        params: {
+          width: 2,
+          depth: 2,
+          height: 4,
+          wallPattern: { enabled: true, pattern: 'honeycomb' },
+          compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
+          walls: {
+            ...DEFAULT_BIN_PARAMS.walls,
+            enabled: true,
+            front: DISABLED_WALL_CUTOUT,
+            back: DISABLED_WALL_CUTOUT,
+            left: DISABLED_WALL_CUTOUT,
+            right: DISABLED_WALL_CUTOUT,
+          },
+        },
+        assert: (cutoutsOff, cutoutsOnSidesOff) => {
+          expect(
+            cutoutsOff.triangleCount,
+            'triangle count must match regardless of walls.enabled when no sides are active'
+          ).toBe(cutoutsOnSidesOff.triangleCount);
+        },
+      },
+      timeout: 60_000,
+    }
+  ),
+];

--- a/src/features/generation/worker/generators/scenarios/index.ts
+++ b/src/features/generation/worker/generators/scenarios/index.ts
@@ -29,6 +29,7 @@ import { cutoutOffset } from './cutoutOffset';
 import { groupedScoop } from './groupedScoop';
 import { lipWall } from './lipWall';
 import { handles } from './handles';
+import { honeycombJunction } from './honeycombJunction';
 
 export type { ScenarioCase } from '../__dual-kernel__/scenarioTypes';
 
@@ -59,4 +60,5 @@ export const ALL_SCENARIOS: readonly ScenarioCase[] = [
   ...groupedScoop,
   ...lipWall,
   ...handles,
+  ...honeycombJunction,
 ];


### PR DESCRIPTION
## Summary

Adds 7 scenario tests that pin triangle counts for honeycomb + divider configurations from #1350:

- **4 snapshot tests** pinning triangle counts for: no cutouts, cutouts on/sides off, front cutout, 2×2 dividers
- **2 snapshot tests** covering interior wall cutouts on dividers (honeycomb + dividers + interior cutouts, and combined with front outer cutout)
- **1 comparison test** asserting `walls.enabled` toggle doesn't change geometry when no sides are active

Any future regression in junction blocking will change the triangle count and fail the snapshot.

## Test plan

- [x] All 9690 tests pass
- [x] Snapshots generated and verified
- [x] Pre-commit hooks pass