### PR TITLE
fix(generation): ensure clip depth covers hex prism extrusion at thick walls

### DIFF
--- a/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
+++ b/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
@@ -132,6 +132,84 @@ export const honeycombJunction: ScenarioCase[] = [
     timeout: 60_000,
   }),
 
+  // ── Bug 3: clip depth must cover hex prism extrusion at thick walls (#1354) ─
+  // When wallThickness > 0.85mm (especially without lip), cutDepth = wallThickness*4
+  // can exceed clipExtrudeDepth, letting hex prisms escape junction clip boxes.
+
+  defineScenario('honeycomb junction', 'thick walls (1.6mm) no lip — junction blocking holds', {
+    assert: 'structural',
+    params: {
+      width: 2,
+      depth: 2,
+      height: 4,
+      wallThickness: 1.6,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      walls: ALL_SIDES_OFF,
+    },
+    compareWith: {
+      params: {
+        width: 2,
+        depth: 2,
+        height: 4,
+        wallThickness: 1.6,
+        base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+        wallPattern: { enabled: true, pattern: 'honeycomb' },
+        compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
+        walls: ALL_SIDES_OFF,
+      },
+      assert: (noDivider, withDivider) => {
+        expect(withDivider.triangleCount, 'divider should add triangles').toBeGreaterThan(
+          noDivider.triangleCount
+        );
+        const increase = withDivider.triangleCount - noDivider.triangleCount;
+        const maxIncrease = noDivider.triangleCount * 0.05;
+        expect(
+          increase,
+          `divider added ${increase} tris (max ${Math.round(maxIncrease)}); junction clip depth may be too shallow`
+        ).toBeLessThanOrEqual(maxIncrease);
+      },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('honeycomb junction', 'thick walls (2.4mm) no lip — junction blocking holds', {
+    assert: 'structural',
+    params: {
+      width: 2,
+      depth: 2,
+      height: 4,
+      wallThickness: 2.4,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      walls: ALL_SIDES_OFF,
+    },
+    compareWith: {
+      params: {
+        width: 2,
+        depth: 2,
+        height: 4,
+        wallThickness: 2.4,
+        base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+        wallPattern: { enabled: true, pattern: 'honeycomb' },
+        compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
+        walls: ALL_SIDES_OFF,
+      },
+      assert: (noDivider, withDivider) => {
+        expect(withDivider.triangleCount, 'divider should add triangles').toBeGreaterThan(
+          noDivider.triangleCount
+        );
+        const increase = withDivider.triangleCount - noDivider.triangleCount;
+        const maxIncrease = noDivider.triangleCount * 0.05;
+        expect(
+          increase,
+          `divider added ${increase} tris (max ${Math.round(maxIncrease)}); junction clip depth may be too shallow`
+        ).toBeLessThanOrEqual(maxIncrease);
+      },
+    },
+    timeout: 60_000,
+  }),
+
   // ── Dividers add geometry but junction blocking limits the increase ─────
   // Adding a divider adds wall geometry but removes hex prisms at the
   // junction. Net result: slightly more triangles, not dramatically more.

--- a/src/features/generation/worker/generators/wallPatternBuilder.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.ts
@@ -140,7 +140,9 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
 
   const lipOverhang = hasLip ? LIP_TAPER_WIDTH : 0;
   const maxThickness = Math.max(params.wallThickness, params.compartments.thickness);
-  const clipExtrudeDepth = (maxThickness + lipOverhang) * 2 + 1;
+  // Clip boxes must be at least as deep as the hex prism extrusion (cutDepth)
+  // so they fully envelop hex prisms at junction/cutout boundaries (#1354).
+  const clipExtrudeDepth = Math.max((maxThickness + lipOverhang) * 2 + 1, cutDepth + 1);
   const clipOvershoot = (hasLip ? LIP_HEIGHT : 0) + 2;
 
   // Build handle wall defs for clip positioning (uses handleBuilder coordinate convention)
@@ -316,7 +318,7 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
 
     const wallKey = compactKey(
       buildCacheKey(
-        'v7', // bumped: shape-radius-aware junction border (#1350)
+        'v8', // bumped: clip depth covers hex prism extrusion (#1354)
         patternType,
         quantize(shapeRadius),
         quantize(cutDepth),


### PR DESCRIPTION
## Summary
- Fixes #1354: honeycomb pattern leaving holes in dividers when wall thickness > 0.8mm
- **Root cause**: `clipExtrudeDepth` (junction clip box depth) was calculated as `(maxThickness + lipOverhang) * 2 + 1`, but hex prisms extrude `wallThickness * 4`. When wall thickness exceeds ~0.85mm (especially without a stacking lip), hex prisms extend deeper than the clip boxes, escaping at junction boundaries and cutting holes in divider walls
- **Fix**: `clipExtrudeDepth` now uses `Math.max(original, cutDepth + 1)` so clip boxes always fully envelop hex prisms
- Adds 2 regression tests for thick walls (1.6mm, 2.4mm) without stacking lip

## Test plan
- [x] All 9694 existing tests pass
- [x] New thick-wall structural tests verify junction blocking holds at 1.6mm and 2.4mm
- [x] TypeScript type check passes
- [x] Visual verification: generate a bin with honeycomb walls, dividers, wall thickness > 0.8mm — no holes in dividers