### PR TITLE
fix: floor max grid units to 0.5 increments for half-bin mode

### DIFF
--- a/src/core/constants.test.ts
+++ b/src/core/constants.test.ts
@@ -34,14 +34,14 @@ describe('calcMaxGridUnits', () => {
   it('handles exact fit scenarios', () => {
     // 126mm bed fits exactly 3 units: 3 * 42 = 126mm
     expect(calcMaxGridUnits(126, 42)).toEqual({ width: 3, depth: 3 });
-    // 125mm bed fits only 2 units: floor(125 / 42) = 2
-    expect(calcMaxGridUnits(125, 42)).toEqual({ width: 2, depth: 2 });
+    // 125mm bed: floor(125/42 * 2) / 2 = 2.5 (2.5 * 42 = 105mm fits on 125mm bed)
+    expect(calcMaxGridUnits(125, 42)).toEqual({ width: 2.5, depth: 2.5 });
   });
 
   it('handles small grid units', () => {
     // 256mm bed, 20mm grid
-    // N ≤ 256 / 20 = 12.8 → 12 (bin size = 240mm fits on 256mm bed)
-    expect(calcMaxGridUnits(256, 20)).toEqual({ width: 12, depth: 12 });
+    // N ≤ 256 / 20 = 12.8 → 12.5 (bin size = 250mm fits on 256mm bed)
+    expect(calcMaxGridUnits(256, 20)).toEqual({ width: 12.5, depth: 12.5 });
   });
 
   it('never returns less than 1', () => {
@@ -57,6 +57,25 @@ describe('calcMaxGridUnits', () => {
   it('uses width for depth when depth is omitted', () => {
     expect(calcMaxGridUnits(300, 42)).toEqual({ width: 7, depth: 7 });
     expect(calcMaxGridUnits(300, 42, undefined)).toEqual({ width: 7, depth: 7 });
+  });
+
+  it('floors to half-unit increments for half-bin mode support', () => {
+    // 280mm bed, 42mm grid: 280/42 = 6.667 → 6.5
+    // A 6.5-unit bin = 273mm fits on 280mm bed
+    expect(calcMaxGridUnits(280, 42)).toEqual({ width: 6.5, depth: 6.5 });
+  });
+
+  it('handles non-standard grid unit (25mm) with 300mm bed', () => {
+    // 300mm bed, 25mm grid: 300/25 = 12 exactly
+    expect(calcMaxGridUnits(300, 25)).toEqual({ width: 12, depth: 12 });
+  });
+
+  it('allows half-unit bins that fit in mm but not in whole units', () => {
+    // 313mm bed, 25mm grid: 313/25 = 12.52 → 12.5
+    // A 12.5-unit bin = 312.5mm fits on 313mm bed
+    expect(calcMaxGridUnits(313, 25)).toEqual({ width: 12.5, depth: 12.5 });
+    // A 13-unit bin = 325mm does NOT fit, so max should be 12.5
+    expect(calcMaxGridUnits(313, 25).width).toBeLessThan(13);
   });
 });
 

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -61,9 +61,14 @@ export const RESERVED_PROPERTY_KEYS = [
 /**
  * Max grid units for a single axis.
  * N * gridUnitMm ≤ bedMm → N ≤ bedMm / gridUnitMm
+ *
+ * Floors to the nearest 0.5 so that half-bin sizes (e.g. 6.5 units)
+ * are correctly recognized as fitting when their mm footprint is within
+ * the bed. Integer-only layouts are unaffected because ⌊x⌋ === ⌊2x⌋/2
+ * whenever x is already an integer.
  */
 function calcMaxGridUnitsForAxis(bedMm: number, gridUnitMm: number): number {
-  return Math.max(1, Math.floor(bedMm / gridUnitMm));
+  return Math.max(1, Math.floor((bedMm / gridUnitMm) * 2) / 2);
 }
 
 /**

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -62,10 +62,10 @@ export const RESERVED_PROPERTY_KEYS = [
  * Max grid units for a single axis.
  * N * gridUnitMm ≤ bedMm → N ≤ bedMm / gridUnitMm
  *
- * Floors to the nearest 0.5 so that half-bin sizes (e.g. 6.5 units)
- * are correctly recognized as fitting when their mm footprint is within
- * the bed. Integer-only layouts are unaffected because ⌊x⌋ === ⌊2x⌋/2
- * whenever x is already an integer.
+ * Floors down to the next lower 0.5 increment so that half-bin sizes
+ * (e.g. 6.5 units) are correctly recognized as fitting when their mm
+ * footprint is within the bed. Integer-only layouts are unaffected
+ * because ⌊x⌋ === ⌊2x⌋/2 whenever x is already an integer.
  */
 function calcMaxGridUnitsForAxis(bedMm: number, gridUnitMm: number): number {
   return Math.max(1, Math.floor((bedMm / gridUnitMm) * 2) / 2);

--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -368,20 +368,15 @@ export function PreviewCanvas() {
     }))
   );
 
-  const {
-    defaultPrintBedSize: bedSize,
-    defaultPrintBedDepth: bedDepth,
-    defaultGridUnitMm: gridUnit,
-  } = useSettingsStore(
+  const { defaultPrintBedSize: bedSize, defaultPrintBedDepth: bedDepth } = useSettingsStore(
     useShallow((s) => ({
       defaultPrintBedSize: s.settings.defaultPrintBedSize,
       defaultPrintBedDepth: s.settings.defaultPrintBedDepth,
-      defaultGridUnitMm: s.settings.defaultGridUnitMm,
     }))
   );
   const maxGrid = useMemo(
-    () => calcMaxGridUnits(bedSize, gridUnit, bedDepth),
-    [bedSize, bedDepth, gridUnit]
+    () => calcMaxGridUnits(bedSize, params.gridUnitMm, bedDepth),
+    [bedSize, bedDepth, params.gridUnitMm]
   );
   const needsSplit = params.width > maxGrid.width || params.depth > maxGrid.depth;
 

--- a/src/features/bin-designer/components/panel/SplitOptionsSection/useSplitOptionsSection.ts
+++ b/src/features/bin-designer/components/panel/SplitOptionsSection/useSplitOptionsSection.ts
@@ -9,11 +9,12 @@ import { getSplitPieceCount } from '@/features/bin-designer/utils/splitPositions
 export type SplitAxis = 'width' | 'depth' | 'both';
 
 export function useSplitOptionsSection() {
-  const { width, depth, splitConnectors, splitViewMode, setParam, setSplitViewMode } =
+  const { width, depth, gridUnitMm, splitConnectors, splitViewMode, setParam, setSplitViewMode } =
     useDesignerStore(
       useShallow((s) => ({
         width: s.params.width,
         depth: s.params.depth,
+        gridUnitMm: s.params.gridUnitMm,
         splitConnectors: s.params.splitConnectors,
         splitViewMode: s.ui.splitViewMode,
         setParam: s.setParam,
@@ -21,17 +22,17 @@ export function useSplitOptionsSection() {
       }))
     );
 
-  const { defaultPrintBedSize, defaultPrintBedDepth, defaultGridUnitMm } = useSettingsStore(
+  const { defaultPrintBedSize, defaultPrintBedDepth } = useSettingsStore(
     useShallow((s) => ({
       defaultPrintBedSize: s.settings.defaultPrintBedSize,
       defaultPrintBedDepth: s.settings.defaultPrintBedDepth,
-      defaultGridUnitMm: s.settings.defaultGridUnitMm,
     }))
   );
 
+  // Use the bin's actual grid unit rather than defaultGridUnitMm from settings
   const maxGrid = useMemo(
-    () => calcMaxGridUnits(defaultPrintBedSize, defaultGridUnitMm, defaultPrintBedDepth),
-    [defaultPrintBedSize, defaultPrintBedDepth, defaultGridUnitMm]
+    () => calcMaxGridUnits(defaultPrintBedSize, gridUnitMm, defaultPrintBedDepth),
+    [defaultPrintBedSize, defaultPrintBedDepth, gridUnitMm]
   );
 
   const needsSplit = width > maxGrid.width || depth > maxGrid.depth;

--- a/src/features/bin-designer/components/preview/BinSplitLines/BinSplitLines.tsx
+++ b/src/features/bin-designer/components/preview/BinSplitLines/BinSplitLines.tsx
@@ -39,17 +39,16 @@ export const BinSplitLines = memo(function BinSplitLines() {
     }))
   );
 
-  const { defaultPrintBedSize, defaultPrintBedDepth, defaultGridUnitMm } = useSettingsStore(
+  const { defaultPrintBedSize, defaultPrintBedDepth } = useSettingsStore(
     useShallow((s) => ({
       defaultPrintBedSize: s.settings.defaultPrintBedSize,
       defaultPrintBedDepth: s.settings.defaultPrintBedDepth,
-      defaultGridUnitMm: s.settings.defaultGridUnitMm,
     }))
   );
 
   const maxGrid = useMemo(
-    () => calcMaxGridUnits(defaultPrintBedSize, defaultGridUnitMm, defaultPrintBedDepth),
-    [defaultPrintBedSize, defaultPrintBedDepth, defaultGridUnitMm]
+    () => calcMaxGridUnits(defaultPrintBedSize, gridUnitMm, defaultPrintBedDepth),
+    [defaultPrintBedSize, defaultPrintBedDepth, gridUnitMm]
   );
 
   const needsSplit = width > maxGrid.width || depth > maxGrid.depth;

--- a/src/features/bin-designer/hooks/useExport.ts
+++ b/src/features/bin-designer/hooks/useExport.ts
@@ -94,15 +94,13 @@ export function useExport(): UseExportReturn {
     }))
   );
 
-  const { printSettings, defaultPrintBedSize, defaultPrintBedDepth, defaultGridUnitMm } =
-    useSettingsStore(
-      useShallow((s) => ({
-        printSettings: s.settings.printSettings,
-        defaultPrintBedSize: s.settings.defaultPrintBedSize,
-        defaultPrintBedDepth: s.settings.defaultPrintBedDepth,
-        defaultGridUnitMm: s.settings.defaultGridUnitMm,
-      }))
-    );
+  const { printSettings, defaultPrintBedSize, defaultPrintBedDepth } = useSettingsStore(
+    useShallow((s) => ({
+      printSettings: s.settings.printSettings,
+      defaultPrintBedSize: s.settings.defaultPrintBedSize,
+      defaultPrintBedDepth: s.settings.defaultPrintBedDepth,
+    }))
+  );
 
   const [isExportingBin, setIsExportingBin] = useState(false);
   const isExporting = isExportingBin;
@@ -116,10 +114,11 @@ export function useExport(): UseExportReturn {
 
   const estimates = useMemo(() => estimatePrint(params, printSettings), [params, printSettings]);
 
-  // Split detection
+  // Split detection — use params.gridUnitMm (the bin's actual grid unit)
+  // rather than defaultGridUnitMm from settings, which may be stale
   const maxGrid = useMemo(
-    () => calcMaxGridUnits(defaultPrintBedSize, defaultGridUnitMm, defaultPrintBedDepth),
-    [defaultPrintBedSize, defaultPrintBedDepth, defaultGridUnitMm]
+    () => calcMaxGridUnits(defaultPrintBedSize, params.gridUnitMm, defaultPrintBedDepth),
+    [defaultPrintBedSize, defaultPrintBedDepth, params.gridUnitMm]
   );
 
   const needsSplit = params.width > maxGrid.width || params.depth > maxGrid.depth;

--- a/src/features/bin-designer/hooks/useSplitPreview.ts
+++ b/src/features/bin-designer/hooks/useSplitPreview.ts
@@ -34,15 +34,16 @@ export function useSplitPreview(): void {
     }))
   );
 
-  const { defaultPrintBedSize, defaultPrintBedDepth, defaultGridUnitMm } = useSettingsStore(
+  const { defaultPrintBedSize, defaultPrintBedDepth } = useSettingsStore(
     useShallow((s) => ({
       defaultPrintBedSize: s.settings.defaultPrintBedSize,
       defaultPrintBedDepth: s.settings.defaultPrintBedDepth,
-      defaultGridUnitMm: s.settings.defaultGridUnitMm,
     }))
   );
 
-  const maxGrid = calcMaxGridUnits(defaultPrintBedSize, defaultGridUnitMm, defaultPrintBedDepth);
+  // Use params.gridUnitMm (the bin's actual grid unit) rather than
+  // defaultGridUnitMm from settings, which may be stale
+  const maxGrid = calcMaxGridUnits(defaultPrintBedSize, params.gridUnitMm, defaultPrintBedDepth);
   const needsSplit = params.width > maxGrid.width || params.depth > maxGrid.depth;
 
   const requestIdRef = useRef(0);

--- a/src/features/print-export/utils/split.test.ts
+++ b/src/features/print-export/utils/split.test.ts
@@ -150,6 +150,19 @@ describe('splitBinSize with fractional dimensions (half-bin mode)', () => {
     expect(pieces.some((p) => p.width === 1.5 || p.width === 1)).toBe(true);
     expect(pieces.every((p) => p.width <= 2 && p.depth <= 2)).toBe(true);
   });
+
+  it('does not split when bin fits with half-unit max (6.5 max)', () => {
+    // A 6.5-unit bin should not split when maxWidth is 6.5
+    const pieces = splitBinSize(6.5, 3, 6.5);
+    expect(pieces).toEqual([{ width: 6.5, depth: 3, count: 1 }]);
+  });
+
+  it('splits correctly when exceeding half-unit max', () => {
+    // A 7-unit bin with max 6.5 should split
+    const pieces = splitBinSize(7, 3, 6.5);
+    expect(pieces).toHaveLength(2);
+    expect(pieces.every((p) => p.width <= 6.5 && p.depth <= 6.5)).toBe(true);
+  });
 });
 
 describe('generatePrintList', () => {

--- a/src/shared/utils/fill.ts
+++ b/src/shared/utils/fill.ts
@@ -173,10 +173,11 @@ export function fillGaps(
   const newBins: Bin[] = [];
 
   // Generate sizes sorted by area (largest first)
-  // Clamp to drawer dimensions since bins can't exceed the drawer
-  // In half-bin mode, include 0.5 increment sizes
-  const effectiveMaxW = Math.min(maxPrintSize, layout.drawer.width);
-  const effectiveMaxD = Math.min(maxPrintSize, layout.drawer.depth);
+  // Clamp to drawer dimensions since bins can't exceed the drawer.
+  // Floor to step so we never generate fractional sizes in integer-only mode
+  // (maxPrintSize may be a 0.5-increment from calcMaxGridUnits).
+  const effectiveMaxW = Math.floor(Math.min(maxPrintSize, layout.drawer.width) / step) * step;
+  const effectiveMaxD = Math.floor(Math.min(maxPrintSize, layout.drawer.depth) / step) * step;
   const sizes: Array<{ w: number; d: number }> = [];
   for (let w = effectiveMaxW; w >= minSize; w -= step) {
     for (let d = effectiveMaxD; d >= minSize; d -= step) {


### PR DESCRIPTION
## Summary

Closes #1359

**Root cause (commit 3):** The bin designer's split detection used `defaultGridUnitMm` from the settings store (e.g. 42mm default) instead of the bin's actual `params.gridUnitMm` (e.g. 25mm). This caused false splits when the user had a non-default grid unit — the max grid units calculation used the wrong grid size.

**Additional fix (commit 1):** `calcMaxGridUnitsForAxis` previously floored to whole integers, which could falsely flag half-bin sizes as needing a split even when their mm footprint fits on the print bed. Now floors to the nearest 0.5 increment.

**Guard fix (commit 2):** `fillGaps` now normalizes the max to the step size so integer-only mode never generates fractional bin sizes from a 0.5-increment max.

### Changes
- **5 bin designer files** (`useExport`, `useSplitPreview`, `useSplitOptionsSection`, `BinSplitLines`, `PreviewCanvas`): use `params.gridUnitMm` instead of `defaultGridUnitMm` from settings
- **`calcMaxGridUnitsForAxis`**: floor to 0.5 increments for half-bin mode
- **`fillGaps`**: normalize max to step size

## Test plan

- [x] All 9708 unit tests pass
- [x] Updated `calcMaxGridUnits` tests for 0.5-increment behavior
- [x] Added half-bin mode split tests
- [x] Reporter's exact scenario (25mm grid, 200mm bed, 4×7.5 bin) now correctly uses params grid unit