### PR TITLE
feat: add animated bin transitions in 3D preview

### DIFF
--- a/src/features/grid-editor/components/Grid/IsometricPreview/AnimatedBinMesh/AnimatedBinMesh.test.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/AnimatedBinMesh/AnimatedBinMesh.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { resetAllStores } from '@/test/testUtils';
+import type { ReactNode } from 'react';
+import type { Bin } from '@/core/types';
+import type { BinRenderData } from '@/shared/hooks/useExplodedLayerView';
+import type { BinTransition } from '../useBinTransitions';
+import { AnimatedBinMesh } from './AnimatedBinMesh';
+
+// Mock React Three Fiber
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }: { children: ReactNode }) => <div data-testid="r3f-canvas">{children}</div>,
+  useThree: () => ({
+    camera: { position: { set: vi.fn() }, lookAt: vi.fn(), updateProjectionMatrix: vi.fn() },
+    invalidate: vi.fn(),
+    gl: { domElement: document.createElement('canvas') },
+    size: { width: 800, height: 600 },
+    scene: {},
+  }),
+  useFrame: vi.fn(),
+  extend: vi.fn(),
+}));
+
+// Mock Three.js
+vi.mock('three', () => {
+  const Vector3 = vi.fn(() => ({
+    set: vi.fn().mockReturnThis(),
+    clone: vi.fn().mockReturnThis(),
+  }));
+  const Color = vi.fn(() => ({
+    r: 0.5,
+    g: 0.5,
+    b: 0.5,
+    set: vi.fn().mockReturnThis(),
+  }));
+  return {
+    Vector3,
+    Color,
+    BufferGeometry: vi.fn(() => ({
+      setAttribute: vi.fn(),
+      setIndex: vi.fn(),
+      computeVertexNormals: vi.fn(),
+      dispose: vi.fn(),
+    })),
+    Float32BufferAttribute: vi.fn(),
+    BufferAttribute: vi.fn(),
+    MeshStandardMaterial: vi.fn(() => ({
+      dispose: vi.fn(),
+      color: new Color(),
+      emissiveIntensity: 0,
+    })),
+    DoubleSide: 2,
+  };
+});
+
+// Mock useBinGeometry hook
+vi.mock('@/shared/hooks/useBinGeometry', () => ({
+  useBinGeometry: () => ({ setAttribute: vi.fn(), dispose: vi.fn() }),
+}));
+
+const mockBin: Bin = {
+  id: 'test-bin-1',
+  x: 2,
+  y: 2,
+  width: 2,
+  depth: 2,
+  height: 3,
+  layerId: 'layer-1',
+  category: 'cat-1',
+  label: 'Test Bin',
+  notes: '',
+};
+
+const mockBinData: BinRenderData = {
+  bin: mockBin,
+  x: 2,
+  y: 2,
+  z: 0,
+  height: 0.5,
+  clearanceHeight: 0,
+  color: '#ff0000',
+  opacity: 1,
+};
+
+describe('AnimatedBinMesh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetAllStores();
+  });
+
+  it('renders with entering transition', () => {
+    const transition: BinTransition = {
+      phase: 'entering',
+      springPos: 2.0,
+      springVel: 0,
+      staggerDelay: 0,
+      elapsed: 0,
+    };
+
+    const { container } = render(<AnimatedBinMesh binData={mockBinData} transition={transition} />);
+    expect(container).toBeTruthy();
+  });
+
+  it('renders with exiting transition', () => {
+    const transition: BinTransition = {
+      phase: 'exiting',
+      scale: 0.5,
+      opacity: 0.5,
+      staggerDelay: 0,
+      elapsed: 0.1,
+    };
+
+    const { container } = render(<AnimatedBinMesh binData={mockBinData} transition={transition} />);
+    expect(container).toBeTruthy();
+  });
+});

--- a/src/features/grid-editor/components/Grid/IsometricPreview/AnimatedBinMesh/AnimatedBinMesh.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/AnimatedBinMesh/AnimatedBinMesh.tsx
@@ -1,0 +1,72 @@
+import { useRef } from 'react';
+import * as THREE from 'three';
+import { useFrame } from '@react-three/fiber';
+import type { BinRenderData } from '@/shared/hooks/useExplodedLayerView';
+import { useBinGeometry } from '@/shared/hooks/useBinGeometry';
+import type { BinTransition } from '../useBinTransitions';
+
+interface AnimatedBinMeshProps {
+  binData: BinRenderData;
+  transition: BinTransition;
+}
+
+/**
+ * A bin mesh that drives its own entrance (spring drop) or exit (shrink+fade)
+ * animation via useFrame. Reads transition state directly from the mutable
+ * ref managed by useBinTransitions — no per-frame React state updates.
+ */
+export function AnimatedBinMesh({ binData, transition }: AnimatedBinMeshProps) {
+  const meshRef = useRef<THREE.Mesh>(null);
+  const materialRef = useRef<THREE.MeshStandardMaterial>(null);
+
+  const geometry = useBinGeometry({
+    width: binData.bin.width,
+    depth: binData.bin.depth,
+    height: binData.height,
+    baseColor: binData.color,
+  });
+
+  useFrame(() => {
+    const mesh = meshRef.current;
+    const material = materialRef.current;
+    if (!mesh || !material) return;
+
+    if (transition.phase === 'entering') {
+      // Position: target z + spring offset (spring settles toward 0).
+      mesh.position.set(binData.x, binData.y, binData.z + transition.springPos);
+      mesh.scale.set(1, 1, 1);
+      material.opacity = 1;
+      material.transparent = false;
+      material.depthWrite = true;
+    } else {
+      // Exiting: shrink and fade.
+      mesh.position.set(binData.x, binData.y, binData.z);
+      const s = transition.scale;
+      mesh.scale.set(s, s, s);
+      material.opacity = transition.opacity;
+      material.transparent = transition.opacity < 1;
+      material.depthWrite = transition.opacity === 1;
+    }
+  });
+
+  // Initial position for entering bins (before first useFrame tick).
+  const initialZ = transition.phase === 'entering' ? binData.z + transition.springPos : binData.z;
+
+  return (
+    <mesh ref={meshRef} position={[binData.x, binData.y, initialZ]} geometry={geometry}>
+      <meshStandardMaterial
+        ref={materialRef}
+        vertexColors
+        roughness={0.4}
+        metalness={0}
+        transparent={binData.opacity < 1}
+        opacity={binData.opacity}
+        depthWrite={binData.opacity === 1}
+        flatShading={false}
+        side={THREE.DoubleSide}
+        emissive={binData.color}
+        emissiveIntensity={0.15}
+      />
+    </mesh>
+  );
+}

--- a/src/features/grid-editor/components/Grid/IsometricPreview/AnimatedBinMesh/index.ts
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/AnimatedBinMesh/index.ts
@@ -1,0 +1,1 @@
+export { AnimatedBinMesh } from './AnimatedBinMesh';

--- a/src/features/grid-editor/components/Grid/IsometricPreview/BinTransitionTicker.test.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/BinTransitionTicker.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { BinTransitionTicker } from './BinTransitionTicker';
+
+// Mock React Three Fiber
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  useFrame: vi.fn(),
+  extend: vi.fn(),
+}));
+
+describe('BinTransitionTicker', () => {
+  it('renders without crashing', () => {
+    const tick = vi.fn(() => false);
+    const { container } = render(<BinTransitionTicker tick={tick} />);
+    expect(container).toBeTruthy();
+  });
+
+  it('registers a useFrame callback', async () => {
+    const r3f = await import('@react-three/fiber');
+    const useFrameMock = r3f.useFrame as ReturnType<typeof vi.fn>;
+    const tick = vi.fn(() => false);
+    render(<BinTransitionTicker tick={tick} />);
+    expect(useFrameMock).toHaveBeenCalled();
+  });
+});

--- a/src/features/grid-editor/components/Grid/IsometricPreview/BinTransitionTicker.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/BinTransitionTicker.tsx
@@ -1,0 +1,16 @@
+import { useFrame } from '@react-three/fiber';
+
+interface BinTransitionTickerProps {
+  tick: (delta: number) => boolean;
+}
+
+/**
+ * Invisible R3F component that drives bin transition animations.
+ * Must live inside a <Canvas> so useFrame is available.
+ */
+export function BinTransitionTicker({ tick }: BinTransitionTickerProps) {
+  useFrame((_, delta) => {
+    tick(delta);
+  });
+  return null;
+}

--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
@@ -20,6 +20,10 @@ import { useBinsToRender } from './useBinsToRender';
 import { usePreviewSize } from './usePreviewSize';
 import { IsometricPreviewControls } from './IsometricPreviewControls';
 import { BinOverlayGroup } from './BinOverlayGroup';
+import { usePrefersReducedMotion } from '@/shared/hooks/usePrefersReducedMotion';
+import { useBinTransitions } from './useBinTransitions';
+import { AnimatedBinMesh } from './AnimatedBinMesh';
+import { BinTransitionTicker } from './BinTransitionTicker';
 
 interface IsometricPreviewProps {
   inline?: boolean; // When true, fills container instead of using fixed sizing
@@ -143,20 +147,30 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
     heightToGridScale,
   });
 
-  // Memoize filtered bin arrays to prevent recalculation on every render
+  // Animated bin transitions (spring drop-in, shrink+fade exit).
+  const reducedMotion = usePrefersReducedMotion();
+  const { stableBins, enteringBins, exitingGhosts, tick } = useBinTransitions(
+    binsToRender,
+    reducedMotion
+  );
+
+  // Memoize filtered bin arrays to prevent recalculation on every render.
+  // Uses stableBins (excludes currently-animating bins) instead of binsToRender.
   const { selectedBins, nonSelectedBins, binsWithOverlays } = useMemo(() => {
-    const selected: typeof binsToRender = [];
-    const nonSelected: typeof binsToRender = [];
+    const selected: typeof stableBins = [];
+    const nonSelected: typeof stableBins = [];
     const withOverlays: typeof binsToRender = [];
 
-    for (const binData of binsToRender) {
+    for (const binData of stableBins) {
       if (selectedBinIds.includes(binData.bin.id)) {
         selected.push(binData);
       } else {
         nonSelected.push(binData);
       }
+    }
 
-      // Only include bins that need overlays (clearance or split lines)
+    // Overlays computed from all binsToRender (including animating) — positions are stable.
+    for (const binData of binsToRender) {
       const needsClearance = binData.clearanceHeight > 0;
       const needsSplitLines =
         binData.bin.width > maxGridUnits.width || binData.bin.depth > maxGridUnits.depth;
@@ -170,7 +184,7 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
       nonSelectedBins: nonSelected,
       binsWithOverlays: withOverlays,
     };
-  }, [binsToRender, selectedBinIds, maxGridUnits]);
+  }, [stableBins, binsToRender, selectedBinIds, maxGridUnits]);
 
   // Track exit animation — keep groups mounted with offset=0 so useFrame can lerp back.
   // The cleanup function fires when isExplodedView goes from true→false, starting exit animation.
@@ -300,6 +314,27 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
                   isSelected={true}
                 />
               ))}
+
+              {/* Entering bins: spring drop animation */}
+              {enteringBins.map(({ binData, transition }) => (
+                <AnimatedBinMesh
+                  key={`enter-${binData.bin.id}`}
+                  binData={binData}
+                  transition={transition}
+                />
+              ))}
+
+              {/* Exiting ghosts: shrink + fade animation */}
+              {exitingGhosts.map(({ binData, transition }) => (
+                <AnimatedBinMesh
+                  key={`exit-${binData.bin.id}`}
+                  binData={binData}
+                  transition={transition}
+                />
+              ))}
+
+              {/* Drives transition animations each frame */}
+              <BinTransitionTicker tick={tick} />
             </>
           )}
 

--- a/src/features/grid-editor/components/Grid/IsometricPreview/useBinTransitions.test.ts
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/useBinTransitions.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import {
+  stepSpring,
+  useBinTransitions,
+  SPRING_STIFFNESS,
+  SPRING_DAMPING,
+  DROP_HEIGHT,
+  EXIT_DURATION_S,
+  EXIT_MIN_SCALE,
+  STAGGER_DELAY_S,
+} from './useBinTransitions';
+import type { BinRenderData } from '@/shared/hooks/useExplodedLayerView';
+import type { Bin } from '@/core/types';
+
+function createBinRenderData(id: string, overrides: Partial<BinRenderData> = {}): BinRenderData {
+  return {
+    bin: {
+      id,
+      x: 0,
+      y: 0,
+      width: 1,
+      depth: 1,
+      height: 3,
+      layerId: 'layer-1',
+      category: 'cat-1',
+      clearanceHeight: 0,
+    } as Bin,
+    x: 0,
+    y: 0,
+    z: 0,
+    height: 0.5,
+    clearanceHeight: 0,
+    color: '#ff0000',
+    opacity: 1,
+    ...overrides,
+  };
+}
+
+// ── stepSpring ────────────────────────────────────────────────────────
+
+describe('stepSpring', () => {
+  it('moves position toward zero from positive offset', () => {
+    const { pos } = stepSpring(DROP_HEIGHT, 0, 1 / 60);
+    expect(pos).toBeLessThan(DROP_HEIGHT);
+    expect(pos).toBeGreaterThan(0);
+  });
+
+  it('produces negative velocity (moving downward) from rest at positive pos', () => {
+    const { vel } = stepSpring(DROP_HEIGHT, 0, 1 / 60);
+    expect(vel).toBeLessThan(0);
+  });
+
+  it('overshoots past zero (underdamped) when given enough steps', () => {
+    let pos = DROP_HEIGHT;
+    let vel = 0;
+    const dt = 1 / 60;
+    let wentNegative = false;
+
+    for (let i = 0; i < 300; i++) {
+      const step = stepSpring(pos, vel, dt);
+      pos = step.pos;
+      vel = step.vel;
+      if (pos < 0) {
+        wentNegative = true;
+        break;
+      }
+    }
+
+    expect(wentNegative).toBe(true);
+  });
+
+  it('settles close to zero after many frames', () => {
+    let pos = DROP_HEIGHT;
+    let vel = 0;
+    const dt = 1 / 60;
+
+    for (let i = 0; i < 600; i++) {
+      const step = stepSpring(pos, vel, dt);
+      pos = step.pos;
+      vel = step.vel;
+    }
+
+    expect(Math.abs(pos)).toBeLessThan(0.001);
+    expect(Math.abs(vel)).toBeLessThan(0.01);
+  });
+
+  it('is stable at large dt (e.g. lag spikes)', () => {
+    const { pos, vel } = stepSpring(DROP_HEIGHT, 0, 0.1);
+    expect(Number.isFinite(pos)).toBe(true);
+    expect(Number.isFinite(vel)).toBe(true);
+  });
+});
+
+// ── useBinTransitions ─────────────────────────────────────────────────
+
+describe('useBinTransitions', () => {
+  it('returns all bins as stable on initial mount (no animations)', () => {
+    const bins = [createBinRenderData('a'), createBinRenderData('b')];
+
+    const { result } = renderHook(() => useBinTransitions(bins, false));
+
+    expect(result.current.stableBins).toHaveLength(2);
+    expect(result.current.enteringBins).toHaveLength(0);
+    expect(result.current.exitingGhosts).toHaveLength(0);
+  });
+
+  it('detects new bins as entering on subsequent render', () => {
+    const bins1 = [createBinRenderData('a')];
+    const bins2 = [createBinRenderData('a'), createBinRenderData('b')];
+
+    const { result, rerender } = renderHook(({ bins }) => useBinTransitions(bins, false), {
+      initialProps: { bins: bins1 },
+    });
+
+    rerender({ bins: bins2 });
+
+    expect(result.current.enteringBins).toHaveLength(1);
+    expect(result.current.enteringBins[0].binData.bin.id).toBe('b');
+    expect(result.current.enteringBins[0].transition.phase).toBe('entering');
+    // 'b' should be excluded from stableBins
+    expect(result.current.stableBins.map((b) => b.bin.id)).toEqual(['a']);
+  });
+
+  it('detects removed bins as exiting ghosts', () => {
+    const bins1 = [createBinRenderData('a'), createBinRenderData('b')];
+    const bins2 = [createBinRenderData('a')];
+
+    const { result, rerender } = renderHook(({ bins }) => useBinTransitions(bins, false), {
+      initialProps: { bins: bins1 },
+    });
+
+    rerender({ bins: bins2 });
+
+    expect(result.current.exitingGhosts).toHaveLength(1);
+    expect(result.current.exitingGhosts[0].binData.bin.id).toBe('b');
+    expect(result.current.exitingGhosts[0].transition.phase).toBe('exiting');
+  });
+
+  it('skips all animations when reducedMotion is true', () => {
+    const bins1 = [createBinRenderData('a')];
+    const bins2 = [createBinRenderData('a'), createBinRenderData('b')];
+
+    const { result, rerender } = renderHook(({ bins }) => useBinTransitions(bins, true), {
+      initialProps: { bins: bins1 },
+    });
+
+    rerender({ bins: bins2 });
+
+    expect(result.current.stableBins).toHaveLength(2);
+    expect(result.current.enteringBins).toHaveLength(0);
+    expect(result.current.exitingGhosts).toHaveLength(0);
+  });
+
+  it('applies stagger delay for bulk additions', () => {
+    const bins1 = [createBinRenderData('a')];
+    const bins2 = [
+      createBinRenderData('a'),
+      createBinRenderData('b'),
+      createBinRenderData('c'),
+      createBinRenderData('d'),
+    ];
+
+    const { result, rerender } = renderHook(({ bins }) => useBinTransitions(bins, false), {
+      initialProps: { bins: bins1 },
+    });
+
+    rerender({ bins: bins2 });
+
+    expect(result.current.enteringBins).toHaveLength(3);
+    const delays = result.current.enteringBins.map((b) => b.transition.staggerDelay);
+    expect(delays[0]).toBeCloseTo(0);
+    expect(delays[1]).toBeCloseTo(STAGGER_DELAY_S);
+    expect(delays[2]).toBeCloseTo(STAGGER_DELAY_S * 2);
+  });
+
+  it('skips animations on layout switch (low overlap)', () => {
+    // Simulate switching from one layout to a completely different one
+    const bins1 = [createBinRenderData('a'), createBinRenderData('b'), createBinRenderData('c')];
+    const bins2 = [createBinRenderData('x'), createBinRenderData('y'), createBinRenderData('z')];
+
+    const { result, rerender } = renderHook(({ bins }) => useBinTransitions(bins, false), {
+      initialProps: { bins: bins1 },
+    });
+
+    rerender({ bins: bins2 });
+
+    // Should detect layout switch (0% overlap) and skip animations
+    expect(result.current.stableBins).toHaveLength(3);
+    expect(result.current.enteringBins).toHaveLength(0);
+    expect(result.current.exitingGhosts).toHaveLength(0);
+  });
+
+  it('tick advances entering spring animation', () => {
+    const bins1 = [createBinRenderData('a')];
+    const bins2 = [createBinRenderData('a'), createBinRenderData('b')];
+
+    const { result, rerender } = renderHook(({ bins }) => useBinTransitions(bins, false), {
+      initialProps: { bins: bins1 },
+    });
+
+    rerender({ bins: bins2 });
+
+    const initialSpringPos = result.current.enteringBins[0].transition;
+    expect(initialSpringPos.phase).toBe('entering');
+    if (initialSpringPos.phase === 'entering') {
+      expect(initialSpringPos.springPos).toBe(DROP_HEIGHT);
+    }
+
+    // Tick forward
+    result.current.tick(1 / 60);
+
+    // Spring should have moved
+    const afterTick = result.current.enteringBins[0]?.transition;
+    if (afterTick && afterTick.phase === 'entering') {
+      expect(afterTick.springPos).toBeLessThan(DROP_HEIGHT);
+    }
+  });
+});
+
+// ── Constants validation ──────────────────────────────────────────────
+
+describe('animation constants', () => {
+  it('spring is underdamped (damping ratio < 1)', () => {
+    const dampingRatio = SPRING_DAMPING / (2 * Math.sqrt(SPRING_STIFFNESS));
+    expect(dampingRatio).toBeLessThan(1);
+    expect(dampingRatio).toBeGreaterThan(0.3); // Not too bouncy
+  });
+
+  it('drop height is reasonable', () => {
+    expect(DROP_HEIGHT).toBeGreaterThan(0);
+    expect(DROP_HEIGHT).toBeLessThanOrEqual(5);
+  });
+
+  it('exit duration is reasonable', () => {
+    expect(EXIT_DURATION_S).toBeGreaterThan(0.05);
+    expect(EXIT_DURATION_S).toBeLessThanOrEqual(1);
+  });
+
+  it('exit min scale is between 0 and 1', () => {
+    expect(EXIT_MIN_SCALE).toBeGreaterThan(0);
+    expect(EXIT_MIN_SCALE).toBeLessThan(1);
+  });
+
+  it('stagger delay is reasonable', () => {
+    expect(STAGGER_DELAY_S).toBeGreaterThan(0);
+    expect(STAGGER_DELAY_S).toBeLessThanOrEqual(0.1);
+  });
+});

--- a/src/features/grid-editor/components/Grid/IsometricPreview/useBinTransitions.ts
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/useBinTransitions.ts
@@ -1,0 +1,363 @@
+import { useCallback, useState, useLayoutEffect, useSyncExternalStore } from 'react';
+import type { BinRenderData } from '@/shared/hooks/useExplodedLayerView';
+
+// ── Spring constants ──────────────────────────────────────────────────
+/** Spring stiffness — higher = faster snap. */
+export const SPRING_STIFFNESS = 180;
+/** Spring damping — lower = bouncier. Damping ratio ~0.45 (underdamped). */
+export const SPRING_DAMPING = 12;
+/** Height (grid units) from which entering bins drop. */
+export const DROP_HEIGHT = 2.0;
+/** Duration of exit animation in seconds. */
+export const EXIT_DURATION_S = 0.2;
+/** Final scale of exiting bins (before removal). */
+export const EXIT_MIN_SCALE = 0.3;
+/** Per-bin stagger delay for bulk operations (seconds). */
+export const STAGGER_DELAY_S = 0.04;
+/** Threshold to consider entering spring settled. */
+const POS_SNAP = 0.001;
+/** Velocity threshold to consider entering spring settled. */
+const VEL_SNAP = 0.01;
+
+// ── Types ────────────────────────────────────────────────────────────��
+
+interface EnterTransition {
+  phase: 'entering';
+  /** Current spring offset above target z (starts at DROP_HEIGHT, settles to 0). */
+  springPos: number;
+  /** Current spring velocity. */
+  springVel: number;
+  /** Seconds to wait before animation starts (stagger). */
+  staggerDelay: number;
+  /** Elapsed time since transition was created (seconds). */
+  elapsed: number;
+}
+
+interface ExitTransition {
+  phase: 'exiting';
+  /** Current scale factor (1 → EXIT_MIN_SCALE). */
+  scale: number;
+  /** Current opacity (1 → 0). */
+  opacity: number;
+  /** Seconds to wait before animation starts (stagger). */
+  staggerDelay: number;
+  /** Elapsed time since transition was created (seconds). */
+  elapsed: number;
+}
+
+export type BinTransition = EnterTransition | ExitTransition;
+
+interface TransitionEntry {
+  binData: BinRenderData;
+  transition: BinTransition;
+}
+
+export interface TransitioningBin {
+  binData: BinRenderData;
+  transition: BinTransition;
+}
+
+interface TransitionSnapshot {
+  stableBins: BinRenderData[];
+  enteringBins: TransitioningBin[];
+  exitingGhosts: TransitioningBin[];
+}
+
+export interface BinTransitionResult extends TransitionSnapshot {
+  /** Call from useFrame to advance all animations by `delta` seconds. */
+  tick: (delta: number) => boolean;
+}
+
+// ── Spring step (exported for testing) ────────────────────────────────
+
+export function stepSpring(pos: number, vel: number, dt: number): { pos: number; vel: number } {
+  const accel = -SPRING_STIFFNESS * pos - SPRING_DAMPING * vel;
+  const newVel = vel + accel * dt;
+  const newPos = pos + newVel * dt;
+  return { pos: newPos, vel: newVel };
+}
+
+// ── Transition Store ───────────────────────────────��──────────────────
+
+interface TransitionStore {
+  subscribe: (listener: () => void) => () => void;
+  getSnapshot: () => TransitionSnapshot;
+  updateBins: (bins: BinRenderData[], reducedMotion: boolean) => void;
+  tick: (delta: number) => boolean;
+}
+
+const EMPTY_SNAPSHOT: TransitionSnapshot = {
+  stableBins: [],
+  enteringBins: [],
+  exitingGhosts: [],
+};
+
+function computeSnapshot(
+  binsToRender: BinRenderData[],
+  transitions: Map<string, TransitionEntry>
+): TransitionSnapshot {
+  const currentBinMap = new Map<string, BinRenderData>();
+  for (const bd of binsToRender) {
+    currentBinMap.set(bd.bin.id, bd);
+  }
+
+  const stableBins: BinRenderData[] = [];
+  for (const bd of binsToRender) {
+    if (!transitions.has(bd.bin.id)) {
+      stableBins.push(bd);
+    }
+  }
+
+  const enteringBins: TransitioningBin[] = [];
+  const exitingGhosts: TransitioningBin[] = [];
+  for (const entry of transitions.values()) {
+    if (entry.transition.phase === 'entering') {
+      const freshData = currentBinMap.get(entry.binData.bin.id);
+      enteringBins.push({
+        binData: freshData ?? entry.binData,
+        transition: entry.transition,
+      });
+    } else {
+      exitingGhosts.push(entry);
+    }
+  }
+
+  return { stableBins, enteringBins, exitingGhosts };
+}
+
+function createTransitionStore(): TransitionStore {
+  let prevBinIds = new Set<string>();
+  let currentBins: BinRenderData[] = [];
+  const transitions = new Map<string, TransitionEntry>();
+  let snapshot: TransitionSnapshot = EMPTY_SNAPSHOT;
+  const listeners = new Set<() => void>();
+
+  function notify(): void {
+    for (const listener of listeners) {
+      listener();
+    }
+  }
+
+  function rebuildSnapshot(): void {
+    snapshot = computeSnapshot(currentBins, transitions);
+  }
+
+  return {
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    getSnapshot() {
+      return snapshot;
+    },
+
+    updateBins(bins: BinRenderData[], reducedMotion: boolean) {
+      currentBins = bins;
+
+      const currentIds = new Set<string>();
+      const currentMap = new Map<string, BinRenderData>();
+      for (const bd of bins) {
+        currentIds.add(bd.bin.id);
+        currentMap.set(bd.bin.id, bd);
+      }
+
+      const isInitialMount = prevBinIds.size === 0 && currentIds.size > 0;
+
+      // Detect layout switch: overlap < 20% of total → skip animations.
+      let isLayoutSwitch = false;
+      if (!isInitialMount && prevBinIds.size > 0 && currentIds.size > 0) {
+        let overlap = 0;
+        for (const id of currentIds) {
+          if (prevBinIds.has(id)) overlap++;
+        }
+        const total = Math.max(prevBinIds.size, currentIds.size);
+        isLayoutSwitch = overlap / total < 0.2;
+      }
+
+      const shouldAnimate = !reducedMotion && !isInitialMount && !isLayoutSwitch;
+
+      if (shouldAnimate) {
+        // Find new bins (in current but not in previous).
+        let enterIndex = 0;
+        for (const [id, bd] of currentMap) {
+          if (!prevBinIds.has(id) && !transitions.has(id)) {
+            transitions.set(id, {
+              binData: bd,
+              transition: {
+                phase: 'entering',
+                springPos: DROP_HEIGHT,
+                springVel: 0,
+                staggerDelay: enterIndex * STAGGER_DELAY_S,
+                elapsed: 0,
+              },
+            });
+            enterIndex++;
+          }
+        }
+
+        // Find removed bins (in previous but not in current).
+        let exitIndex = 0;
+        for (const id of prevBinIds) {
+          if (!currentIds.has(id)) {
+            const existing = transitions.get(id);
+            if (existing && existing.transition.phase === 'entering') {
+              // Was entering — flip to exiting.
+              transitions.set(id, {
+                binData: existing.binData,
+                transition: {
+                  phase: 'exiting',
+                  scale: 1,
+                  opacity: 1,
+                  staggerDelay: exitIndex * STAGGER_DELAY_S,
+                  elapsed: 0,
+                },
+              });
+            } else if (!existing) {
+              // Need the previous bin data for the ghost. Look it up from
+              // the snapshot's entering/exiting arrays or from a stored copy.
+              // Since prevBinIds doesn't store BinRenderData, we need to find
+              // the bin data from the old snapshot or transitions.
+              const prevBinData =
+                snapshot.stableBins.find((b) => b.bin.id === id) ??
+                snapshot.enteringBins.find((b) => b.binData.bin.id === id)?.binData;
+              if (prevBinData) {
+                transitions.set(id, {
+                  binData: prevBinData,
+                  transition: {
+                    phase: 'exiting',
+                    scale: 1,
+                    opacity: 1,
+                    staggerDelay: exitIndex * STAGGER_DELAY_S,
+                    elapsed: 0,
+                  },
+                });
+              }
+            }
+            exitIndex++;
+          }
+        }
+
+        // Handle re-added bins (currently exiting but now present again).
+        for (const [id, bd] of currentMap) {
+          const existing = transitions.get(id);
+          if (existing && existing.transition.phase === 'exiting') {
+            transitions.set(id, {
+              binData: bd,
+              transition: {
+                phase: 'entering',
+                springPos: DROP_HEIGHT,
+                springVel: 0,
+                staggerDelay: 0,
+                elapsed: 0,
+              },
+            });
+          }
+        }
+      } else {
+        // No animation — clear any lingering transitions.
+        transitions.clear();
+      }
+
+      prevBinIds = currentIds;
+      rebuildSnapshot();
+      notify();
+    },
+
+    tick(delta: number): boolean {
+      if (transitions.size === 0) return false;
+
+      let anyActive = false;
+      const toRemove: string[] = [];
+
+      for (const [id, entry] of transitions) {
+        const t = entry.transition;
+        t.elapsed += delta;
+
+        if (t.phase === 'entering') {
+          if (t.elapsed < t.staggerDelay) {
+            anyActive = true;
+            continue;
+          }
+          const activeDt = Math.min(delta, t.elapsed - t.staggerDelay);
+          const step = stepSpring(t.springPos, t.springVel, activeDt);
+          t.springPos = step.pos;
+          t.springVel = step.vel;
+
+          if (Math.abs(t.springPos) < POS_SNAP && Math.abs(t.springVel) < VEL_SNAP) {
+            t.springPos = 0;
+            t.springVel = 0;
+            toRemove.push(id);
+          } else {
+            anyActive = true;
+          }
+        } else {
+          // Exiting
+          if (t.elapsed < t.staggerDelay) {
+            anyActive = true;
+            continue;
+          }
+          const activeElapsed = t.elapsed - t.staggerDelay;
+          const progress = Math.min(activeElapsed / EXIT_DURATION_S, 1);
+          t.scale = 1 - progress * (1 - EXIT_MIN_SCALE);
+          t.opacity = 1 - progress;
+
+          if (progress >= 1) {
+            toRemove.push(id);
+          } else {
+            anyActive = true;
+          }
+        }
+      }
+
+      for (const id of toRemove) {
+        transitions.delete(id);
+      }
+
+      // Re-render only when transitions complete (bins move to stableBins).
+      // During animation, AnimatedBinMesh reads mutated props directly in useFrame.
+      if (toRemove.length > 0) {
+        rebuildSnapshot();
+        notify();
+      }
+
+      return anyActive || toRemove.length > 0;
+    },
+  };
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────
+
+/**
+ * Tracks bin additions and removals across renders, producing three lists:
+ * stable bins (for MergedBinMeshes), entering bins (spring drop), and
+ * exiting ghosts (shrink+fade). Call `tick(delta)` inside useFrame to
+ * advance all animations.
+ *
+ * Transition state lives in an external store (plain closure) to satisfy
+ * the React Compiler's ref-access and immutability rules. React subscribes
+ * to snapshot changes via `useSyncExternalStore`.
+ */
+export function useBinTransitions(
+  binsToRender: BinRenderData[],
+  reducedMotion: boolean
+): BinTransitionResult {
+  const [store] = useState(createTransitionStore);
+
+  // Update store when bins change (synchronous, before paint).
+  useLayoutEffect(() => {
+    store.updateBins(binsToRender, reducedMotion);
+  }, [store, binsToRender, reducedMotion]);
+
+  const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
+
+  // Stable tick reference — delegates to the store's tick method.
+  const tick = useCallback((delta: number): boolean => store.tick(delta), [store]);
+
+  return {
+    ...snapshot,
+    tick,
+  };
+}

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -9,6 +9,7 @@ export { usePrefetchChunks } from './usePrefetchChunks';
 export { useFocusTrap } from './useFocusTrap';
 export { useInlineEdit } from './useInlineEdit';
 export { useKeyboard } from './useKeyboard';
+export { usePrefersReducedMotion } from './usePrefersReducedMotion';
 
 // Grid & layout hooks
 export { useGridTemplate } from './useGridTemplate';

--- a/src/shared/hooks/usePrefersReducedMotion.test.ts
+++ b/src/shared/hooks/usePrefersReducedMotion.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+
+describe('usePrefersReducedMotion', () => {
+  let listeners: Array<(event: MediaQueryListEvent) => void>;
+  let matches: boolean;
+
+  beforeEach(() => {
+    listeners = [];
+    matches = false;
+
+    vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: (_event: string, handler: (event: MediaQueryListEvent) => void) => {
+        listeners.push(handler);
+      },
+      removeEventListener: (_event: string, handler: (event: MediaQueryListEvent) => void) => {
+        listeners = listeners.filter((l) => l !== handler);
+      },
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  it('returns false when motion is not reduced', () => {
+    matches = false;
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when motion is reduced', () => {
+    matches = true;
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(true);
+  });
+
+  it('reacts to runtime changes', () => {
+    matches = false;
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      for (const listener of listeners) {
+        listener({ matches: true } as MediaQueryListEvent);
+      }
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('cleans up listener on unmount', () => {
+    const { unmount } = renderHook(() => usePrefersReducedMotion());
+    expect(listeners).toHaveLength(1);
+    unmount();
+    expect(listeners).toHaveLength(0);
+  });
+});

--- a/src/shared/hooks/usePrefersReducedMotion.ts
+++ b/src/shared/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+/**
+ * Detects the user's OS-level `prefers-reduced-motion` setting.
+ * Returns `true` when the user prefers reduced motion.
+ * Reacts to runtime changes (e.g., toggling the setting while the app is open).
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia(QUERY).matches;
+  });
+
+  useEffect(() => {
+    const mql = window.matchMedia(QUERY);
+    const handler = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return prefersReducedMotion;
+}


### PR DESCRIPTION
## Summary

- Adds spring-physics **drop-in animations** for bin placement and **shrink+fade animations** for bin removal in the isometric 3D preview
- Makes the tool feel alive and helps new users understand spatial relationships between the grid editor and 3D preview
- Respects OS `prefers-reduced-motion` setting — animations disabled automatically for accessibility
- Zero new dependencies — manual spring physics in R3F's `useFrame` loop

### Architecture

Non-selected bins are merged into a single geometry (`MergedBinMeshes`) for performance. Animating bins are temporarily pulled out as individual `AnimatedBinMesh` components during their transition, then released back to the merged mesh.

Transition state lives in an external store (plain closure) subscribed via `useSyncExternalStore`, satisfying the React Compiler's ref-access and immutability rules while enabling imperative animation mutations from `useFrame`.

### New files
| File | Purpose |
|------|---------|
| `useBinTransitions.ts` | Core hook — diffs bins across renders, manages enter/exit transitions with staggered cascades |
| `AnimatedBinMesh/` | R3F component — spring drop-in and linear fade-out via `useFrame` |
| `BinTransitionTicker.tsx` | Drives animation ticks inside the Canvas |
| `usePrefersReducedMotion.ts` | OS-level reduced motion detection |

### Edge cases handled
- Initial mount & layout switch: animations skipped to avoid cascade
- Bin removed while entering: flips to exit animation
- Bin re-added while exiting: cancels ghost, starts fresh entrance
- Bulk operations: staggered 40ms cascade per bin

## Test plan

- [ ] `pnpm run dev` — draw a bin, verify it drops from above with spring bounce
- [ ] Delete a bin, verify it shrinks and fades out
- [ ] Fill a row with draw tool, observe staggered cascade
- [ ] Clear layer — observe staggered exit cascade
- [ ] Undo/redo — verify bins animate correctly
- [ ] Enable OS reduced motion — verify bins appear/disappear instantly
- [ ] Exploded view — verify no regressions (animations don't play there)
- [ ] Verify 3D preview performance with many bins (50+)