### PR TITLE
fix: prevent OOM and WASM leaks in baseplate generator

### DIFF
--- a/src/features/generation/worker/generators/baseplateDirectMesh.ts
+++ b/src/features/generation/worker/generators/baseplateDirectMesh.ts
@@ -773,6 +773,16 @@ export function generateBaseplateDirect(
   onProgress: ProgressFn,
   signal?: AbortSignal
 ): MeshData {
+  // Guard against NaN/negative/infinite values that would produce degenerate geometry
+  if (
+    !Number.isFinite(params.width) ||
+    params.width <= 0 ||
+    !Number.isFinite(params.depth) ||
+    params.depth <= 0
+  ) {
+    throw new Error(`Invalid baseplate dimensions: ${params.width}x${params.depth}`);
+  }
+
   onProgress('base', 0);
   checkCancelled(signal);
 

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -231,25 +231,25 @@ function buildMagnetHoles(
   });
 
   const holes: Shape3D[] = [];
-  forEachCell(
-    gridW,
-    gridD,
-    (cell) => {
-      if (cell.widthUnits < 1 || cell.depthUnits < 1) return;
+  try {
+    forEachCell(
+      gridW,
+      gridD,
+      (cell) => {
+        if (cell.widthUnits < 1 || cell.depthUnits < 1) return;
 
-      for (const [dx, dy] of MAGNET_OFFSETS) {
-        const cloned = unwrap(clone(magnetTemplate));
-        const positioned = translate(cloned, [cell.centerX + dx, cell.centerY + dy, 0]);
-        cloned.delete();
-        holes.push(positioned);
-      }
-    },
-    cellOpts
-  );
-
-  // Template is only used to stamp clones per cell — dispose once the loop
-  // is done so its WASM handle is released.
-  magnetTemplate.delete();
+        for (const [dx, dy] of MAGNET_OFFSETS) {
+          const cloned = unwrap(clone(magnetTemplate));
+          const positioned = translate(cloned, [cell.centerX + dx, cell.centerY + dy, 0]);
+          cloned.delete();
+          holes.push(positioned);
+        }
+      },
+      cellOpts
+    );
+  } finally {
+    magnetTemplate.delete();
+  }
   return holes;
 }
 /**
@@ -885,15 +885,51 @@ function buildSlabProfile(
   return pen.close();
 }
 
+/** Maximum grid dimension for baseplate generation (units). */
+const MAX_BASEPLATE_GRID = 50;
+
+/**
+ * Validate and clamp baseplate params to safe ranges.
+ * Throws on clearly invalid dimensions (NaN, zero, negative) to surface
+ * upstream bugs. Clamps other fields to safe ranges to prevent OOM.
+ */
+function sanitizeParams(params: BaseplateParams): BaseplateParams {
+  if (
+    !Number.isFinite(params.width) ||
+    params.width <= 0 ||
+    !Number.isFinite(params.depth) ||
+    params.depth <= 0
+  ) {
+    throw new Error(`Invalid baseplate dimensions: ${params.width}x${params.depth}`);
+  }
+
+  const clamp = (v: number, min: number, max: number): number =>
+    Number.isFinite(v) ? Math.max(min, Math.min(max, v)) : min;
+
+  return {
+    ...params,
+    width: Math.min(params.width, MAX_BASEPLATE_GRID),
+    depth: Math.min(params.depth, MAX_BASEPLATE_GRID),
+    gridUnitMm: clamp(params.gridUnitMm, 1, 200),
+    magnetDiameter: clamp(params.magnetDiameter, 0.5, 20),
+    magnetDepth: clamp(params.magnetDepth, 0.5, 10),
+    paddingLeft: clamp(params.paddingLeft, 0, 100),
+    paddingRight: clamp(params.paddingRight, 0, 100),
+    paddingFront: clamp(params.paddingFront, 0, 100),
+    paddingBack: clamp(params.paddingBack, 0, 100),
+  };
+}
+
 /**
  * Generate baseplate mesh for preview or export.
  */
 export function generateBaseplate(
-  params: BaseplateParams,
+  rawParams: BaseplateParams,
   onProgress: ProgressFn,
   forExport: boolean,
   signal?: AbortSignal
 ): MeshData {
+  const params = sanitizeParams(rawParams);
   onProgress('base', 0);
   checkCancelled(signal);
 
@@ -934,14 +970,56 @@ export function generateBaseplate(
     tolerance = Math.min(0.4, Math.max(0.15, maxDimension / 600));
     angularTolerance = 12;
   }
-  const meshResult = mesh(baseplate, { tolerance, angularTolerance });
-  // Compute edge lines procedurally from params (avoids expensive meshEdges() on BREP)
-  const edgeVerts = computeBaseplateEdgeLines(params);
 
-  onProgress('base', 1);
+  try {
+    const meshResult = mesh(baseplate, { tolerance, angularTolerance });
+    // Compute edge lines procedurally from params (avoids expensive meshEdges() on BREP)
+    const edgeVerts = computeBaseplateEdgeLines(params);
 
-  const result = toIndexedMeshData(meshResult, edgeVerts);
-  meshResultCache.set(cacheKey, result);
+    onProgress('base', 1);
+
+    const result = toIndexedMeshData(meshResult, edgeVerts);
+    meshResultCache.set(cacheKey, result);
+    return result;
+  } finally {
+    baseplate.delete();
+  }
+}
+
+/**
+ * Maximum number of BREP tool shapes to cut in a single boolean pass.
+ * Keeps WASM heap bounded — larger grids (16x16 = 1024 magnet holes)
+ * would otherwise hold all shapes simultaneously, causing OOM.
+ */
+const BOOLEAN_BATCH_SIZE = 64;
+
+/**
+ * Cut an array of tool shapes from a solid in batches.
+ * Each batch cuts up to BOOLEAN_BATCH_SIZE shapes, then disposes them
+ * before building the next batch. This bounds peak WASM memory usage.
+ */
+function cutInBatches(solid: Shape3D, tools: Shape3D[]): Shape3D {
+  if (tools.length === 0) return solid;
+
+  let result = solid;
+  let processed = 0;
+
+  try {
+    for (let i = 0; i < tools.length; i += BOOLEAN_BATCH_SIZE) {
+      const end = Math.min(i + BOOLEAN_BATCH_SIZE, tools.length);
+      const batch = tools.slice(i, end);
+      const prev = result;
+      result = unwrap(cutAll(result as ValidSolid, batch as ValidSolid[]));
+      prev.delete();
+      for (const t of batch) t.delete();
+      processed = end;
+    }
+  } catch (e) {
+    // Dispose any remaining tool shapes not yet processed to prevent WASM leaks
+    for (let j = processed; j < tools.length; j++) tools[j].delete();
+    throw e;
+  }
+
   return result;
 }
 
@@ -1031,12 +1109,7 @@ function buildBaseplateSolid(
     );
 
     if (pockets.length > 0) {
-      const preCut = baseplate;
-      baseplate = unwrap(cutAll(baseplate as ValidSolid, pockets as ValidSolid[]));
-      // cutAll allocates a fresh handle for the result and does not dispose
-      // its inputs — free the pre-cut slab and every pocket cutter now.
-      preCut.delete();
-      for (const p of pockets) p.delete();
+      baseplate = cutInBatches(baseplate, pockets);
     }
 
     slabWithPocketsCache.set(spKey, baseplate);
@@ -1076,13 +1149,11 @@ function buildBaseplateSolid(
     roundedTranslated.delete();
   }
 
-  // into a single array for one batched cutAll operation.
-  const allCuts: Shape3D[] = [];
-
-  // 2a. Magnet hole cutters
+  // 2a. Magnet hole cutters — built and cut in batches to limit WASM memory.
+  // A 16x16 grid produces 1024 magnet holes; holding all simultaneously can OOM.
   if (magnetHoles) {
     const holes = buildMagnetHoles(width, depth, magnetDiameter / 2, magnetDepth, cellOpts);
-    allCuts.push(...holes);
+    baseplate = cutInBatches(baseplate, holes);
   }
 
   // 2a-ii. Lightweight floor cutters (cross-shaped material removal)
@@ -1094,12 +1165,12 @@ function buildBaseplateSolid(
       magnetDepth,
       cellOpts
     );
-    allCuts.push(...floorCutters);
+    baseplate = cutInBatches(baseplate, floorCutters);
   }
 
   onProgress?.(0.4);
 
-  // 2b. Connector groove cutters
+  // 2b. Connector groove cutters (small count — no batching needed)
   const { nubs, holes: connHoles } = buildConnectors(
     params,
     totalHeight,
@@ -1108,14 +1179,11 @@ function buildBaseplateSolid(
     slabOffsetX,
     slabOffsetY
   );
-  allCuts.push(...connHoles);
 
-  // Primary path: single-call pipeline fuses nubs then cuts holes,
-  // skipping intermediate UnifySameDomain between the fuse and cut passes.
-  if (nubs.length > 0 || allCuts.length > 0) {
+  if (nubs.length > 0 || connHoles.length > 0) {
     const steps: BooleanPipelineStep[] = [
       ...nubs.map((n): BooleanPipelineStep => ({ op: 'fuse', tool: n })),
-      ...allCuts.map((c): BooleanPipelineStep => ({ op: 'cut', tool: c })),
+      ...connHoles.map((c): BooleanPipelineStep => ({ op: 'cut', tool: c })),
     ];
     const preBoolean = baseplate;
     const pipelineResult = booleanPipeline(baseplate, steps);
@@ -1126,17 +1194,15 @@ function buildBaseplateSolid(
       if (nubs.length > 0) {
         baseplate = unwrap(fuseAll([baseplate, ...nubs] as ValidSolid[]));
       }
-      if (allCuts.length > 0) {
+      if (connHoles.length > 0) {
         const preCut = baseplate;
-        baseplate = unwrap(cutAll(baseplate as ValidSolid, allCuts as ValidSolid[]));
+        baseplate = unwrap(cutAll(baseplate as ValidSolid, connHoles as ValidSolid[]));
         if (preCut !== preBoolean) preCut.delete();
       }
     }
-    // Dispose the pre-boolean baseplate (replaced by the pipeline result)
-    // and every tool shape consumed by the boolean pass.
     if (baseplate !== preBoolean) preBoolean.delete();
     for (const n of nubs) n.delete();
-    for (const c of allCuts) c.delete();
+    for (const c of connHoles) c.delete();
   }
 
   onProgress?.(0.6);
@@ -1152,34 +1218,39 @@ function buildBaseplateSolid(
  * Export baseplate as STL or STEP file.
  */
 export async function exportBaseplate(
-  params: BaseplateParams,
+  rawParams: BaseplateParams,
   format: ExportFormat,
   tolerance?: number,
   angularTolerance?: number
 ): Promise<{ data: ArrayBuffer; fileName: string }> {
+  const params = sanitizeParams(rawParams);
   // Use simplified pocket cutter (forExport=false) — the full-detail
   // multi-section loft creates BREP topologies that OCCT can't reliably
   // tessellate or export. The simplified version is geometrically equivalent
   // for 3D printing (same outer profile, slightly simplified taper).
   const baseplate = buildBaseplateSolid(params, false);
-  const totalW = params.width * params.gridUnitMm + params.paddingLeft + params.paddingRight;
-  const totalD = params.depth * params.gridUnitMm + params.paddingFront + params.paddingBack;
-  const name = `baseplate_${params.width}x${params.depth}_${Math.round(totalW)}x${Math.round(totalD)}mm`;
+  try {
+    const totalW = params.width * params.gridUnitMm + params.paddingLeft + params.paddingRight;
+    const totalD = params.depth * params.gridUnitMm + params.paddingFront + params.paddingBack;
+    const name = `baseplate_${params.width}x${params.depth}_${Math.round(totalW)}x${Math.round(totalD)}mm`;
 
-  if (format === 'step') {
-    const blob = unwrap(exportSTEP(baseplate));
-    const data = await blob.arrayBuffer();
-    return { data, fileName: `${name}.step` };
+    if (format === 'step') {
+      const blob = unwrap(exportSTEP(baseplate));
+      const data = await blob.arrayBuffer();
+      return { data, fileName: `${name}.step` };
+    }
+
+    // STL — mesh the BREP and build binary STL with winding correction.
+    // OCCT's StlAPI.Write fails on baseplate geometries, so we tessellate
+    // manually and fix triangle winding to match the STL right-hand rule.
+    const tol = tolerance ?? 0.01;
+    const angTol = angularTolerance ?? 5;
+    const meshResult = mesh(baseplate, { tolerance: tol, angularTolerance: angTol });
+    const data = buildBaseplateSTL(meshResult, name);
+    return { data, fileName: `${name}.stl` };
+  } finally {
+    baseplate.delete();
   }
-
-  // STL — mesh the BREP and build binary STL with winding correction.
-  // OCCT's StlAPI.Write fails on baseplate geometries, so we tessellate
-  // manually and fix triangle winding to match the STL right-hand rule.
-  const tol = tolerance ?? 0.01;
-  const angTol = angularTolerance ?? 5;
-  const meshResult = mesh(baseplate, { tolerance: tol, angularTolerance: angTol });
-  const data = buildBaseplateSTL(meshResult, name);
-  return { data, fileName: `${name}.stl` };
 }
 
 /**

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -240,13 +240,19 @@ function buildMagnetHoles(
 
         for (const [dx, dy] of MAGNET_OFFSETS) {
           const cloned = unwrap(clone(magnetTemplate));
-          const positioned = translate(cloned, [cell.centerX + dx, cell.centerY + dy, 0]);
-          cloned.delete();
-          holes.push(positioned);
+          try {
+            const positioned = translate(cloned, [cell.centerX + dx, cell.centerY + dy, 0]);
+            holes.push(positioned);
+          } finally {
+            cloned.delete();
+          }
         }
       },
       cellOpts
     );
+  } catch (e) {
+    for (const h of holes) h.delete();
+    throw e;
   } finally {
     magnetTemplate.delete();
   }
@@ -902,14 +908,17 @@ function sanitizeParams(params: BaseplateParams): BaseplateParams {
   ) {
     throw new Error(`Invalid baseplate dimensions: ${params.width}x${params.depth}`);
   }
+  if (params.width > MAX_BASEPLATE_GRID || params.depth > MAX_BASEPLATE_GRID) {
+    throw new Error(
+      `Baseplate dimensions ${params.width}x${params.depth} exceed maximum ${MAX_BASEPLATE_GRID}`
+    );
+  }
 
   const clamp = (v: number, min: number, max: number): number =>
     Number.isFinite(v) ? Math.max(min, Math.min(max, v)) : min;
 
   return {
     ...params,
-    width: Math.min(params.width, MAX_BASEPLATE_GRID),
-    depth: Math.min(params.depth, MAX_BASEPLATE_GRID),
     gridUnitMm: clamp(params.gridUnitMm, 1, 200),
     magnetDiameter: clamp(params.magnetDiameter, 0.5, 20),
     magnetDepth: clamp(params.magnetDepth, 0.5, 10),
@@ -997,6 +1006,10 @@ const BOOLEAN_BATCH_SIZE = 64;
  * Cut an array of tool shapes from a solid in batches.
  * Each batch cuts up to BOOLEAN_BATCH_SIZE shapes, then disposes them
  * before building the next batch. This bounds peak WASM memory usage.
+ *
+ * Consumes `solid` on both success and failure — callers must not
+ * reference it after this call. On error, disposes `result` and all
+ * remaining unprocessed tools before rethrowing.
  */
 function cutInBatches(solid: Shape3D, tools: Shape3D[]): Shape3D {
   if (tools.length === 0) return solid;
@@ -1015,8 +1028,9 @@ function cutInBatches(solid: Shape3D, tools: Shape3D[]): Shape3D {
       processed = end;
     }
   } catch (e) {
-    // Dispose any remaining tool shapes not yet processed to prevent WASM leaks
+    // Dispose remaining unprocessed tools and the current result solid
     for (let j = processed; j < tools.length; j++) tools[j].delete();
+    result.delete();
     throw e;
   }
 

--- a/src/features/generation/worker/generators/lightweightFloorCutter.ts
+++ b/src/features/generation/worker/generators/lightweightFloorCutter.ts
@@ -84,9 +84,12 @@ export function buildLightweightFloorCutters(
             templates.set(fractionalKey, fractionalTemplate);
           }
           const cloned = unwrap(clone(fractionalTemplate));
-          const positioned = translate(cloned, [cell.centerX, cell.centerY, 0]);
-          cloned.delete();
-          cutters.push(positioned);
+          try {
+            const positioned = translate(cloned, [cell.centerX, cell.centerY, 0]);
+            cutters.push(positioned);
+          } finally {
+            cloned.delete();
+          }
           return;
         }
 
@@ -131,12 +134,18 @@ export function buildLightweightFloorCutters(
         }
 
         const cloned = unwrap(clone(template));
-        const positioned = translate(cloned, [cell.centerX, cell.centerY, 0]);
-        cloned.delete();
-        cutters.push(positioned);
+        try {
+          const positioned = translate(cloned, [cell.centerX, cell.centerY, 0]);
+          cutters.push(positioned);
+        } finally {
+          cloned.delete();
+        }
       },
       cellOpts
     );
+  } catch (e) {
+    for (const c of cutters) c.delete();
+    throw e;
   } finally {
     // Dispose template shapes — they were allocated for this build only.
     // In a finally block so WASM handles are freed even if a BREP op throws.

--- a/src/features/generation/worker/generators/lightweightFloorCutter.ts
+++ b/src/features/generation/worker/generators/lightweightFloorCutter.ts
@@ -62,83 +62,86 @@ export function buildLightweightFloorCutters(
   const cutters: Shape3D[] = [];
   const templates = new Map<string, Shape3D>();
 
-  forEachCell(
-    gridW,
-    gridD,
-    (cell) => {
-      const cellW_mm = cell.widthUnits * gridUnitMm;
-      const cellD_mm = cell.depthUnits * gridUnitMm;
+  try {
+    forEachCell(
+      gridW,
+      gridD,
+      (cell) => {
+        const cellW_mm = cell.widthUnits * gridUnitMm;
+        const cellD_mm = cell.depthUnits * gridUnitMm;
 
-      // Fractional cells (half-unit) have no magnets — cut through their
-      // entire floor since the solid material serves no purpose.
-      if (cell.widthUnits < 1 || cell.depthUnits < 1) {
-        const fhw = cellW_mm / 2 - INSET_BOT;
-        const fhd = cellD_mm / 2 - INSET_BOT;
-        if (fhw <= 0 || fhd <= 0) return;
-        const fractionalKey = `frac-${cell.widthUnits}x${cell.depthUnits}`;
-        let fractionalTemplate = templates.get(fractionalKey);
-        if (!fractionalTemplate) {
-          const rectProfile = drawRectangle(fhw * 2, fhd * 2);
-          fractionalTemplate = sketch(rectProfile, 'XY', cutterZ).extrude(-cutterDepth);
-          templates.set(fractionalKey, fractionalTemplate);
+        // Fractional cells (half-unit) have no magnets — cut through their
+        // entire floor since the solid material serves no purpose.
+        if (cell.widthUnits < 1 || cell.depthUnits < 1) {
+          const fhw = cellW_mm / 2 - INSET_BOT;
+          const fhd = cellD_mm / 2 - INSET_BOT;
+          if (fhw <= 0 || fhd <= 0) return;
+          const fractionalKey = `frac-${cell.widthUnits}x${cell.depthUnits}`;
+          let fractionalTemplate = templates.get(fractionalKey);
+          if (!fractionalTemplate) {
+            const rectProfile = drawRectangle(fhw * 2, fhd * 2);
+            fractionalTemplate = sketch(rectProfile, 'XY', cutterZ).extrude(-cutterDepth);
+            templates.set(fractionalKey, fractionalTemplate);
+          }
+          const cloned = unwrap(clone(fractionalTemplate));
+          const positioned = translate(cloned, [cell.centerX, cell.centerY, 0]);
+          cloned.delete();
+          cutters.push(positioned);
+          return;
         }
-        const cloned = unwrap(clone(fractionalTemplate));
+
+        // Inset by INSET_BOT so the cutout stays within the flat pocket floor
+        // and doesn't undercut the tapered pocket walls (which would create overhangs).
+        const hw = cellW_mm / 2 - INSET_BOT;
+        const hd = cellD_mm / 2 - INSET_BOT;
+
+        // Guard: skip if cross arms would be too narrow
+        const armW = hw - padHalf;
+        const armD = hd - padHalf;
+        if (armW < MIN_ARM_WIDTH || armD < MIN_ARM_WIDTH) return;
+
+        const cacheKey = `${cell.widthUnits}x${cell.depthUnits}`;
+        let template = templates.get(cacheKey);
+
+        if (!template) {
+          const r = Math.min(magnetRadius, Math.min(armW, armD));
+
+          // Cross-shaped profile (CCW), 12 segments + 4 inner corner fillets.
+          // Walking CCW from top-right of vertical arm:
+          const profile = draw([padHalf, hd])
+            .lineTo([-padHalf, hd])
+            .lineTo([-padHalf, padHalf])
+            .customCorner(r)
+            .lineTo([-hw, padHalf])
+            .lineTo([-hw, -padHalf])
+            .lineTo([-padHalf, -padHalf])
+            .customCorner(r)
+            .lineTo([-padHalf, -hd])
+            .lineTo([padHalf, -hd])
+            .lineTo([padHalf, -padHalf])
+            .customCorner(r)
+            .lineTo([hw, -padHalf])
+            .lineTo([hw, padHalf])
+            .lineTo([padHalf, padHalf])
+            .customCorner(r)
+            .close();
+
+          template = sketch(profile, 'XY', cutterZ).extrude(-cutterDepth);
+          templates.set(cacheKey, template);
+        }
+
+        const cloned = unwrap(clone(template));
         const positioned = translate(cloned, [cell.centerX, cell.centerY, 0]);
         cloned.delete();
         cutters.push(positioned);
-        return;
-      }
-
-      // Inset by INSET_BOT so the cutout stays within the flat pocket floor
-      // and doesn't undercut the tapered pocket walls (which would create overhangs).
-      const hw = cellW_mm / 2 - INSET_BOT;
-      const hd = cellD_mm / 2 - INSET_BOT;
-
-      // Guard: skip if cross arms would be too narrow
-      const armW = hw - padHalf;
-      const armD = hd - padHalf;
-      if (armW < MIN_ARM_WIDTH || armD < MIN_ARM_WIDTH) return;
-
-      const cacheKey = `${cell.widthUnits}x${cell.depthUnits}`;
-      let template = templates.get(cacheKey);
-
-      if (!template) {
-        const r = Math.min(magnetRadius, Math.min(armW, armD));
-
-        // Cross-shaped profile (CCW), 12 segments + 4 inner corner fillets.
-        // Walking CCW from top-right of vertical arm:
-        const profile = draw([padHalf, hd])
-          .lineTo([-padHalf, hd])
-          .lineTo([-padHalf, padHalf])
-          .customCorner(r)
-          .lineTo([-hw, padHalf])
-          .lineTo([-hw, -padHalf])
-          .lineTo([-padHalf, -padHalf])
-          .customCorner(r)
-          .lineTo([-padHalf, -hd])
-          .lineTo([padHalf, -hd])
-          .lineTo([padHalf, -padHalf])
-          .customCorner(r)
-          .lineTo([hw, -padHalf])
-          .lineTo([hw, padHalf])
-          .lineTo([padHalf, padHalf])
-          .customCorner(r)
-          .close();
-
-        template = sketch(profile, 'XY', cutterZ).extrude(-cutterDepth);
-        templates.set(cacheKey, template);
-      }
-
-      const cloned = unwrap(clone(template));
-      const positioned = translate(cloned, [cell.centerX, cell.centerY, 0]);
-      cloned.delete();
-      cutters.push(positioned);
-    },
-    cellOpts
-  );
-
-  // Dispose template shapes — they were allocated for this build only.
-  for (const t of templates.values()) t.delete();
+      },
+      cellOpts
+    );
+  } finally {
+    // Dispose template shapes — they were allocated for this build only.
+    // In a finally block so WASM handles are freed even if a BREP op throws.
+    for (const t of templates.values()) t.delete();
+  }
 
   return cutters;
 }


### PR DESCRIPTION
## Summary

Users are experiencing OOM errors and generation failures in the baseplate generator, especially on larger grids with magnets enabled. Root cause analysis identified several issues:

- **BREP shape explosion**: A 16x16 grid with magnets creates 1,024 magnet hole shapes + 256 floor cutters, all held simultaneously in WASM memory before boolean processing begins
- **WASM handle leaks**: `generateBaseplate`, `exportBaseplate`, `buildMagnetHoles`, and `buildLightweightFloorCutters` all lacked cleanup on error paths — if any BREP operation threw, WASM handles leaked permanently
- **No input validation**: NaN, zero, or negative dimensions from corrupted state could reach the BREP kernel, causing cryptic crashes

### Changes

- **Batch boolean operations** via `cutInBatches()` — processes BREP cuts in chunks of 64 shapes, disposing each batch before the next. Bounds peak WASM memory for pockets, magnet holes, and floor cutters
- **Try/finally for BREP disposal** in `generateBaseplate` (tessellation), `exportBaseplate` (mesh/STEP), `buildMagnetHoles` (template cylinder), and `buildLightweightFloorCutters` (template shapes)
- **`cutInBatches` error cleanup** — on mid-batch failure, disposes all remaining unprocessed tool shapes before rethrowing
- **`sanitizeParams`** — throws on invalid dimensions (NaN, zero, negative) to surface upstream bugs; clamps other fields (gridUnitMm, magnetDiameter, padding, etc.) to safe ranges
- **Direct mesh guard** — `generateBaseplateDirect` also validates dimensions for consistency

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `baseplateGenerator.test.ts` — 52 tests pass
- [x] `baseplateDirectMesh.test.ts` — 4 tests pass
- [x] `lightweightFloorCutter.test.ts` — 5 tests pass
- [x] `buildFullParams.test.ts` — 2 tests pass
- [x] Pre-commit hooks pass (lint, boundaries, i18n, exhaustiveness)
- [ ] CI checks