### PR TITLE
fix(generation): use loft for stacking lip on all kernels

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -1,163 +1,163 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `3292`;
+exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2872`;
 
 exports[`base styles > flat base no lip 1`] = `300`;
 
-exports[`base styles > flat base with lip 1`] = `1596`;
+exports[`base styles > flat base with lip 1`] = `1156`;
 
 exports[`base styles > magnet base no lip 1`] = `804`;
 
-exports[`base styles > magnet base with lip 1`] = `2604`;
+exports[`base styles > magnet base with lip 1`] = `2164`;
 
 exports[`base styles > magnet+screw base no lip 1`] = `1028`;
 
-exports[`base styles > magnet+screw base with lip 1`] = `2972`;
+exports[`base styles > magnet+screw base with lip 1`] = `2532`;
 
 exports[`base styles > screw base no lip 1`] = `692`;
 
-exports[`base styles > screw base with lip 1`] = `2444`;
+exports[`base styles > screw base with lip 1`] = `2004`;
 
 exports[`base styles > standard base no lip 1`] = `468`;
 
-exports[`base styles > standard base with lip 1`] = `2076`;
+exports[`base styles > standard base with lip 1`] = `1636`;
 
 exports[`base styles > weighted base no lip 1`] = `468`;
 
-exports[`base styles > weighted base with lip 1`] = `2076`;
+exports[`base styles > weighted base with lip 1`] = `1636`;
 
-exports[`bin styles > 2×2 slotted 1`] = `4072`;
+exports[`bin styles > 2×2 slotted 1`] = `3500`;
 
-exports[`bin styles > 2×2 solid 1`] = `2924`;
+exports[`bin styles > 2×2 solid 1`] = `2844`;
 
-exports[`bin styles > 2×2 standard 1`] = `3500`;
+exports[`bin styles > 2×2 standard 1`] = `3068`;
 
-exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `2140`;
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1564`;
 
-exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `4044`;
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3588`;
 
-exports[`combined features > 2×2 label tabs with merged compartments 1`] = `6494`;
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `5604`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `8446`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `7700`;
 
 exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `18048`;
 
-exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `3500`;
+exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `3068`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `4324`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `3828`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `4454`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3940`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `6292`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5668`;
 
 exports[`dimensions > 0.5×0.5 no lip 1`] = `468`;
 
-exports[`dimensions > 0.5×0.5 with lip 1`] = `2156`;
+exports[`dimensions > 0.5×0.5 with lip 1`] = `1644`;
 
 exports[`dimensions > 1.5×2 fractional no lip 1`] = `1260`;
 
-exports[`dimensions > 1.5×2 fractional with lip 1`] = `3488`;
+exports[`dimensions > 1.5×2 fractional with lip 1`] = `3052`;
 
 exports[`dimensions > 1×1 no lip 1`] = `468`;
 
-exports[`dimensions > 1×1 with lip 1`] = `2076`;
+exports[`dimensions > 1×1 with lip 1`] = `1636`;
 
 exports[`dimensions > 2×2 no lip 1`] = `1260`;
 
-exports[`dimensions > 2×2 with lip 1`] = `3500`;
+exports[`dimensions > 2×2 with lip 1`] = `3068`;
 
 exports[`dimensions > 4×4 no lip 1`] = `3500`;
 
-exports[`dimensions > 4×4 with lip 1`] = `8620`;
+exports[`dimensions > 4×4 with lip 1`] = `8244`;
 
-exports[`export mode > 2×2 default params (forExport=true) 1`] = `7580`;
+exports[`export mode > 2×2 default params (forExport=true) 1`] = `6182`;
 
-exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5908`;
+exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5468`;
 
-exports[`half-sockets > 1×1 with half sockets 1`] = `3516`;
+exports[`half-sockets > 1×1 with half sockets 1`] = `3076`;
 
-exports[`half-sockets > 2×2 with half sockets 1`] = `9260`;
+exports[`half-sockets > 2×2 with half sockets 1`] = `8828`;
 
-exports[`height > 2×2 height minimum (2u) 1`] = `3500`;
+exports[`height > 2×2 height minimum (2u) 1`] = `3068`;
 
-exports[`height > 2×2 height tall (10u) 1`] = `3490`;
+exports[`height > 2×2 height tall (10u) 1`] = `3058`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `7380`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6924`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `7316`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6860`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `7408`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6952`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `7408`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6952`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `7744`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `7264`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `7600`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `7120`;
 
-exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `7308`;
+exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `6876`;
 
-exports[`inserts > 2×2 with circle insert 1`] = `3768`;
+exports[`inserts > 2×2 with circle insert 1`] = `3336`;
 
-exports[`inserts > 2×2 with hexagon insert 1`] = `3768`;
+exports[`inserts > 2×2 with hexagon insert 1`] = `3336`;
 
-exports[`inserts > 2×2 with rectangle insert 1`] = `3536`;
+exports[`inserts > 2×2 with rectangle insert 1`] = `3104`;
 
-exports[`inserts > 2×2 with rounded-rect insert 1`] = `3664`;
+exports[`inserts > 2×2 with rounded-rect insert 1`] = `3232`;
 
-exports[`inserts > 2×2 with slot insert 1`] = `3712`;
+exports[`inserts > 2×2 with slot insert 1`] = `3280`;
 
-exports[`label tabs > 2×2 label bracket center 1`] = `4568`;
+exports[`label tabs > 2×2 label bracket center 1`] = `3832`;
 
-exports[`label tabs > 2×2 label bracket left 1`] = `4568`;
+exports[`label tabs > 2×2 label bracket left 1`] = `3832`;
 
-exports[`label tabs > 2×2 label bracket right 1`] = `4568`;
+exports[`label tabs > 2×2 label bracket right 1`] = `3832`;
 
-exports[`label tabs > 2×2 label disabled 1`] = `3500`;
+exports[`label tabs > 2×2 label disabled 1`] = `3068`;
 
-exports[`label tabs > 2×2 label solid left 1`] = `4460`;
+exports[`label tabs > 2×2 label solid left 1`] = `3724`;
 
-exports[`large bin > 8×8 standard 1`] = `23636`;
+exports[`large bin > 8×8 standard 1`] = `23380`;
 
-exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3992`;
+exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3560`;
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4802`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4184`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `5658`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `5008`;
 
-exports[`scoop > 2×2 scoop auto radius 1`] = `4802`;
+exports[`scoop > 2×2 scoop auto radius 1`] = `4184`;
 
-exports[`scoop > 2×2 scoop disabled 1`] = `3500`;
+exports[`scoop > 2×2 scoop disabled 1`] = `3068`;
 
-exports[`scoop > 2×2 scoop radius 10mm 1`] = `4848`;
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `4136`;
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `4072`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `3500`;
 
-exports[`slotted variations > slotted with both axes 1`] = `4644`;
+exports[`slotted variations > slotted with both axes 1`] = `3932`;
 
 exports[`slotted variations > slotted without lip 1`] = `1380`;
 
-exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `3170`;
+exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `3090`;
 
-exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `3084`;
+exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `3004`;
 
-exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `3208`;
+exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `3128`;
 
-exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2964`;
+exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2884`;
 
-exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `3116`;
+exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `3036`;
 
-exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2952`;
+exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2872`;
 
-exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `3628`;
+exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `3548`;
 
-exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2968`;
+exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2888`;
 
-exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `3080`;
+exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `3000`;
 
-exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2936`;
+exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2856`;
 
-exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2936`;
+exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2856`;
 
-exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `3396`;
+exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `3036`;
 
-exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `3572`;
+exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `3084`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -1,163 +1,163 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2796`;
+exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2556`;
 
 exports[`base styles > flat base no lip 1`] = `252`;
 
-exports[`base styles > flat base with lip 1`] = `1052`;
+exports[`base styles > flat base with lip 1`] = `812`;
 
 exports[`base styles > magnet base no lip 1`] = `804`;
 
-exports[`base styles > magnet base with lip 1`] = `2060`;
+exports[`base styles > magnet base with lip 1`] = `1820`;
 
 exports[`base styles > magnet+screw base no lip 1`] = `1028`;
 
-exports[`base styles > magnet+screw base with lip 1`] = `2428`;
+exports[`base styles > magnet+screw base with lip 1`] = `2188`;
 
 exports[`base styles > screw base no lip 1`] = `692`;
 
-exports[`base styles > screw base with lip 1`] = `1900`;
+exports[`base styles > screw base with lip 1`] = `1660`;
 
 exports[`base styles > standard base no lip 1`] = `468`;
 
-exports[`base styles > standard base with lip 1`] = `1532`;
+exports[`base styles > standard base with lip 1`] = `1292`;
 
 exports[`base styles > weighted base no lip 1`] = `468`;
 
-exports[`base styles > weighted base with lip 1`] = `1532`;
+exports[`base styles > weighted base with lip 1`] = `1292`;
 
-exports[`bin styles > 2×2 slotted 1`] = `3332`;
+exports[`bin styles > 2×2 slotted 1`] = `3092`;
 
-exports[`bin styles > 2×2 solid 1`] = `2788`;
+exports[`bin styles > 2×2 solid 1`] = `2548`;
 
-exports[`bin styles > 2×2 standard 1`] = `2972`;
+exports[`bin styles > 2×2 standard 1`] = `2732`;
 
-exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1412`;
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1172`;
 
-exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3468`;
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3228`;
 
-exports[`combined features > 2×2 label tabs with merged compartments 1`] = `5236`;
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `4996`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `7460`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `7220`;
 
 exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `18048`;
 
-exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2972`;
+exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2732`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `3684`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `3444`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3784`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3544`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5428`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5188`;
 
 exports[`dimensions > 0.5×0.5 no lip 1`] = `468`;
 
-exports[`dimensions > 0.5×0.5 with lip 1`] = `1532`;
+exports[`dimensions > 0.5×0.5 with lip 1`] = `1292`;
 
 exports[`dimensions > 1.5×2 fractional no lip 1`] = `1260`;
 
-exports[`dimensions > 1.5×2 fractional with lip 1`] = `2972`;
+exports[`dimensions > 1.5×2 fractional with lip 1`] = `2732`;
 
 exports[`dimensions > 1×1 no lip 1`] = `468`;
 
-exports[`dimensions > 1×1 with lip 1`] = `1532`;
+exports[`dimensions > 1×1 with lip 1`] = `1292`;
 
 exports[`dimensions > 2×2 no lip 1`] = `1260`;
 
-exports[`dimensions > 2×2 with lip 1`] = `2972`;
+exports[`dimensions > 2×2 with lip 1`] = `2732`;
 
 exports[`dimensions > 4×4 no lip 1`] = `3500`;
 
-exports[`dimensions > 4×4 with lip 1`] = `8172`;
+exports[`dimensions > 4×4 with lip 1`] = `7932`;
 
-exports[`export mode > 2×2 default params (forExport=true) 1`] = `5556`;
+exports[`export mode > 2×2 default params (forExport=true) 1`] = `5148`;
 
-exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5372`;
+exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5132`;
 
-exports[`half-sockets > 1×1 with half sockets 1`] = `2972`;
+exports[`half-sockets > 1×1 with half sockets 1`] = `2732`;
 
-exports[`half-sockets > 2×2 with half sockets 1`] = `8732`;
+exports[`half-sockets > 2×2 with half sockets 1`] = `8492`;
 
-exports[`height > 2×2 height minimum (2u) 1`] = `2972`;
+exports[`height > 2×2 height minimum (2u) 1`] = `2732`;
 
-exports[`height > 2×2 height tall (10u) 1`] = `2972`;
+exports[`height > 2×2 height tall (10u) 1`] = `2732`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6808`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6556`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6744`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6492`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6832`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6592`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6832`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6592`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `7120`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `6880`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `6976`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `6736`;
 
-exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `6780`;
+exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `6540`;
 
-exports[`inserts > 2×2 with circle insert 1`] = `3240`;
+exports[`inserts > 2×2 with circle insert 1`] = `3000`;
 
-exports[`inserts > 2×2 with hexagon insert 1`] = `3240`;
+exports[`inserts > 2×2 with hexagon insert 1`] = `3000`;
 
-exports[`inserts > 2×2 with rectangle insert 1`] = `3008`;
+exports[`inserts > 2×2 with rectangle insert 1`] = `2768`;
 
-exports[`inserts > 2×2 with rounded-rect insert 1`] = `3136`;
+exports[`inserts > 2×2 with rounded-rect insert 1`] = `2896`;
 
-exports[`inserts > 2×2 with slot insert 1`] = `3184`;
+exports[`inserts > 2×2 with slot insert 1`] = `2944`;
 
-exports[`label tabs > 2×2 label bracket center 1`] = `3580`;
+exports[`label tabs > 2×2 label bracket center 1`] = `3340`;
 
-exports[`label tabs > 2×2 label bracket left 1`] = `3580`;
+exports[`label tabs > 2×2 label bracket left 1`] = `3340`;
 
-exports[`label tabs > 2×2 label bracket right 1`] = `3580`;
+exports[`label tabs > 2×2 label bracket right 1`] = `3340`;
 
-exports[`label tabs > 2×2 label disabled 1`] = `2972`;
+exports[`label tabs > 2×2 label disabled 1`] = `2732`;
 
-exports[`label tabs > 2×2 label solid left 1`] = `3472`;
+exports[`label tabs > 2×2 label solid left 1`] = `3232`;
 
-exports[`large bin > 8×8 standard 1`] = `23348`;
+exports[`large bin > 8×8 standard 1`] = `23156`;
 
-exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3464`;
+exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3224`;
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4056`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `3816`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4856`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4616`;
 
-exports[`scoop > 2×2 scoop auto radius 1`] = `4056`;
+exports[`scoop > 2×2 scoop auto radius 1`] = `3816`;
 
-exports[`scoop > 2×2 scoop disabled 1`] = `2972`;
+exports[`scoop > 2×2 scoop disabled 1`] = `2732`;
 
-exports[`scoop > 2×2 scoop radius 10mm 1`] = `4060`;
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `3820`;
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `3332`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `3092`;
 
-exports[`slotted variations > slotted with both axes 1`] = `3692`;
+exports[`slotted variations > slotted with both axes 1`] = `3452`;
 
 exports[`slotted variations > slotted without lip 1`] = `1380`;
 
-exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `3024`;
+exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `2784`;
 
-exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `2940`;
+exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `2700`;
 
-exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `3062`;
+exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `2822`;
 
-exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2818`;
+exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2578`;
 
-exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `2980`;
+exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `2740`;
 
-exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2808`;
+exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2568`;
 
-exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `3484`;
+exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `3244`;
 
-exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2820`;
+exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2580`;
 
-exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `2936`;
+exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `2696`;
 
-exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2800`;
+exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2560`;
 
-exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2800`;
+exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2560`;
 
-exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `2940`;
+exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `2700`;
 
-exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `2988`;
+exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `2748`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -1,163 +1,163 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2620`;
+exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `3292`;
 
-exports[`base styles > flat base no lip 1`] = `252`;
+exports[`base styles > flat base no lip 1`] = `300`;
 
-exports[`base styles > flat base with lip 1`] = `892`;
+exports[`base styles > flat base with lip 1`] = `1596`;
 
 exports[`base styles > magnet base no lip 1`] = `804`;
 
-exports[`base styles > magnet base with lip 1`] = `1900`;
+exports[`base styles > magnet base with lip 1`] = `2604`;
 
 exports[`base styles > magnet+screw base no lip 1`] = `1028`;
 
-exports[`base styles > magnet+screw base with lip 1`] = `2268`;
+exports[`base styles > magnet+screw base with lip 1`] = `2972`;
 
 exports[`base styles > screw base no lip 1`] = `692`;
 
-exports[`base styles > screw base with lip 1`] = `1740`;
+exports[`base styles > screw base with lip 1`] = `2444`;
 
 exports[`base styles > standard base no lip 1`] = `468`;
 
-exports[`base styles > standard base with lip 1`] = `1372`;
+exports[`base styles > standard base with lip 1`] = `2076`;
 
 exports[`base styles > weighted base no lip 1`] = `468`;
 
-exports[`base styles > weighted base with lip 1`] = `1372`;
+exports[`base styles > weighted base with lip 1`] = `2076`;
 
-exports[`bin styles > 2×2 slotted 1`] = `3220`;
+exports[`bin styles > 2×2 slotted 1`] = `4072`;
 
-exports[`bin styles > 2×2 solid 1`] = `2548`;
+exports[`bin styles > 2×2 solid 1`] = `2924`;
 
-exports[`bin styles > 2×2 standard 1`] = `2812`;
+exports[`bin styles > 2×2 standard 1`] = `3500`;
 
-exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1300`;
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `2140`;
 
-exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3308`;
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `4044`;
 
-exports[`combined features > 2×2 label tabs with merged compartments 1`] = `5308`;
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `6494`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `7492`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `8446`;
 
 exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `18048`;
 
-exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2812`;
+exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `3500`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `3524`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `4324`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3624`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `4454`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5268`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `6292`;
 
 exports[`dimensions > 0.5×0.5 no lip 1`] = `468`;
 
-exports[`dimensions > 0.5×0.5 with lip 1`] = `1372`;
+exports[`dimensions > 0.5×0.5 with lip 1`] = `2156`;
 
 exports[`dimensions > 1.5×2 fractional no lip 1`] = `1260`;
 
-exports[`dimensions > 1.5×2 fractional with lip 1`] = `2812`;
+exports[`dimensions > 1.5×2 fractional with lip 1`] = `3488`;
 
 exports[`dimensions > 1×1 no lip 1`] = `468`;
 
-exports[`dimensions > 1×1 with lip 1`] = `1372`;
+exports[`dimensions > 1×1 with lip 1`] = `2076`;
 
 exports[`dimensions > 2×2 no lip 1`] = `1260`;
 
-exports[`dimensions > 2×2 with lip 1`] = `2812`;
+exports[`dimensions > 2×2 with lip 1`] = `3500`;
 
 exports[`dimensions > 4×4 no lip 1`] = `3500`;
 
-exports[`dimensions > 4×4 with lip 1`] = `7996`;
+exports[`dimensions > 4×4 with lip 1`] = `8620`;
 
-exports[`export mode > 2×2 default params (forExport=true) 1`] = `5276`;
+exports[`export mode > 2×2 default params (forExport=true) 1`] = `7580`;
 
-exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5212`;
+exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5908`;
 
-exports[`half-sockets > 1×1 with half sockets 1`] = `2812`;
+exports[`half-sockets > 1×1 with half sockets 1`] = `3516`;
 
-exports[`half-sockets > 2×2 with half sockets 1`] = `8572`;
+exports[`half-sockets > 2×2 with half sockets 1`] = `9260`;
 
-exports[`height > 2×2 height minimum (2u) 1`] = `2812`;
+exports[`height > 2×2 height minimum (2u) 1`] = `3500`;
 
-exports[`height > 2×2 height tall (10u) 1`] = `2812`;
+exports[`height > 2×2 height tall (10u) 1`] = `3490`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6756`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `7380`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6692`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `7316`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6816`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `7408`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6816`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `7408`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `7088`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `7744`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `6944`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `7600`;
 
-exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `6780`;
+exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `7308`;
 
-exports[`inserts > 2×2 with circle insert 1`] = `3080`;
+exports[`inserts > 2×2 with circle insert 1`] = `3768`;
 
-exports[`inserts > 2×2 with hexagon insert 1`] = `3080`;
+exports[`inserts > 2×2 with hexagon insert 1`] = `3768`;
 
-exports[`inserts > 2×2 with rectangle insert 1`] = `2848`;
+exports[`inserts > 2×2 with rectangle insert 1`] = `3536`;
 
-exports[`inserts > 2×2 with rounded-rect insert 1`] = `2976`;
+exports[`inserts > 2×2 with rounded-rect insert 1`] = `3664`;
 
-exports[`inserts > 2×2 with slot insert 1`] = `3024`;
+exports[`inserts > 2×2 with slot insert 1`] = `3712`;
 
-exports[`label tabs > 2×2 label bracket center 1`] = `3628`;
+exports[`label tabs > 2×2 label bracket center 1`] = `4568`;
 
-exports[`label tabs > 2×2 label bracket left 1`] = `3628`;
+exports[`label tabs > 2×2 label bracket left 1`] = `4568`;
 
-exports[`label tabs > 2×2 label bracket right 1`] = `3628`;
+exports[`label tabs > 2×2 label bracket right 1`] = `4568`;
 
-exports[`label tabs > 2×2 label disabled 1`] = `2812`;
+exports[`label tabs > 2×2 label disabled 1`] = `3500`;
 
-exports[`label tabs > 2×2 label solid left 1`] = `3380`;
+exports[`label tabs > 2×2 label solid left 1`] = `4460`;
 
-exports[`large bin > 8×8 standard 1`] = `23180`;
+exports[`large bin > 8×8 standard 1`] = `23636`;
 
-exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3304`;
+exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3992`;
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4000`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4802`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4888`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `5658`;
 
-exports[`scoop > 2×2 scoop auto radius 1`] = `4000`;
+exports[`scoop > 2×2 scoop auto radius 1`] = `4802`;
 
-exports[`scoop > 2×2 scoop disabled 1`] = `2812`;
+exports[`scoop > 2×2 scoop disabled 1`] = `3500`;
 
-exports[`scoop > 2×2 scoop radius 10mm 1`] = `4032`;
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `4848`;
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `3220`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `4072`;
 
-exports[`slotted variations > slotted with both axes 1`] = `3628`;
+exports[`slotted variations > slotted with both axes 1`] = `4644`;
 
 exports[`slotted variations > slotted without lip 1`] = `1380`;
 
-exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `2784`;
+exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `3170`;
 
-exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `2700`;
+exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `3084`;
 
-exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `2822`;
+exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `3208`;
 
-exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2578`;
+exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2964`;
 
-exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `2740`;
+exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `3116`;
 
-exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2568`;
+exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2952`;
 
-exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `3244`;
+exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `3628`;
 
-exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2580`;
+exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2968`;
 
-exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `2696`;
+exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `3080`;
 
-exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2560`;
+exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2936`;
 
-exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2560`;
+exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2936`;
 
-exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `2700`;
+exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `3396`;
 
-exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `2972`;
+exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `3572`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -1,163 +1,163 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2872`;
+exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2796`;
 
-exports[`base styles > flat base no lip 1`] = `300`;
+exports[`base styles > flat base no lip 1`] = `252`;
 
-exports[`base styles > flat base with lip 1`] = `1156`;
+exports[`base styles > flat base with lip 1`] = `1052`;
 
 exports[`base styles > magnet base no lip 1`] = `804`;
 
-exports[`base styles > magnet base with lip 1`] = `2164`;
+exports[`base styles > magnet base with lip 1`] = `2060`;
 
 exports[`base styles > magnet+screw base no lip 1`] = `1028`;
 
-exports[`base styles > magnet+screw base with lip 1`] = `2532`;
+exports[`base styles > magnet+screw base with lip 1`] = `2428`;
 
 exports[`base styles > screw base no lip 1`] = `692`;
 
-exports[`base styles > screw base with lip 1`] = `2004`;
+exports[`base styles > screw base with lip 1`] = `1900`;
 
 exports[`base styles > standard base no lip 1`] = `468`;
 
-exports[`base styles > standard base with lip 1`] = `1636`;
+exports[`base styles > standard base with lip 1`] = `1532`;
 
 exports[`base styles > weighted base no lip 1`] = `468`;
 
-exports[`base styles > weighted base with lip 1`] = `1636`;
+exports[`base styles > weighted base with lip 1`] = `1532`;
 
-exports[`bin styles > 2×2 slotted 1`] = `3500`;
+exports[`bin styles > 2×2 slotted 1`] = `3332`;
 
-exports[`bin styles > 2×2 solid 1`] = `2844`;
+exports[`bin styles > 2×2 solid 1`] = `2788`;
 
-exports[`bin styles > 2×2 standard 1`] = `3068`;
+exports[`bin styles > 2×2 standard 1`] = `2972`;
 
-exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1564`;
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1412`;
 
-exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3588`;
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3468`;
 
-exports[`combined features > 2×2 label tabs with merged compartments 1`] = `5604`;
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `5236`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `7700`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `7460`;
 
 exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `18048`;
 
-exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `3068`;
+exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2972`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `3828`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `3684`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3940`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3784`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5668`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5428`;
 
 exports[`dimensions > 0.5×0.5 no lip 1`] = `468`;
 
-exports[`dimensions > 0.5×0.5 with lip 1`] = `1644`;
+exports[`dimensions > 0.5×0.5 with lip 1`] = `1532`;
 
 exports[`dimensions > 1.5×2 fractional no lip 1`] = `1260`;
 
-exports[`dimensions > 1.5×2 fractional with lip 1`] = `3052`;
+exports[`dimensions > 1.5×2 fractional with lip 1`] = `2972`;
 
 exports[`dimensions > 1×1 no lip 1`] = `468`;
 
-exports[`dimensions > 1×1 with lip 1`] = `1636`;
+exports[`dimensions > 1×1 with lip 1`] = `1532`;
 
 exports[`dimensions > 2×2 no lip 1`] = `1260`;
 
-exports[`dimensions > 2×2 with lip 1`] = `3068`;
+exports[`dimensions > 2×2 with lip 1`] = `2972`;
 
 exports[`dimensions > 4×4 no lip 1`] = `3500`;
 
-exports[`dimensions > 4×4 with lip 1`] = `8244`;
+exports[`dimensions > 4×4 with lip 1`] = `8172`;
 
-exports[`export mode > 2×2 default params (forExport=true) 1`] = `6182`;
+exports[`export mode > 2×2 default params (forExport=true) 1`] = `5556`;
 
-exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5468`;
+exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5372`;
 
-exports[`half-sockets > 1×1 with half sockets 1`] = `3076`;
+exports[`half-sockets > 1×1 with half sockets 1`] = `2972`;
 
-exports[`half-sockets > 2×2 with half sockets 1`] = `8828`;
+exports[`half-sockets > 2×2 with half sockets 1`] = `8732`;
 
-exports[`height > 2×2 height minimum (2u) 1`] = `3068`;
+exports[`height > 2×2 height minimum (2u) 1`] = `2972`;
 
-exports[`height > 2×2 height tall (10u) 1`] = `3058`;
+exports[`height > 2×2 height tall (10u) 1`] = `2972`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6924`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6808`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6860`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6744`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6952`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6832`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6952`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6832`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `7264`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `7120`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `7120`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `6976`;
 
-exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `6876`;
+exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `6780`;
 
-exports[`inserts > 2×2 with circle insert 1`] = `3336`;
+exports[`inserts > 2×2 with circle insert 1`] = `3240`;
 
-exports[`inserts > 2×2 with hexagon insert 1`] = `3336`;
+exports[`inserts > 2×2 with hexagon insert 1`] = `3240`;
 
-exports[`inserts > 2×2 with rectangle insert 1`] = `3104`;
+exports[`inserts > 2×2 with rectangle insert 1`] = `3008`;
 
-exports[`inserts > 2×2 with rounded-rect insert 1`] = `3232`;
+exports[`inserts > 2×2 with rounded-rect insert 1`] = `3136`;
 
-exports[`inserts > 2×2 with slot insert 1`] = `3280`;
+exports[`inserts > 2×2 with slot insert 1`] = `3184`;
 
-exports[`label tabs > 2×2 label bracket center 1`] = `3832`;
+exports[`label tabs > 2×2 label bracket center 1`] = `3580`;
 
-exports[`label tabs > 2×2 label bracket left 1`] = `3832`;
+exports[`label tabs > 2×2 label bracket left 1`] = `3580`;
 
-exports[`label tabs > 2×2 label bracket right 1`] = `3832`;
+exports[`label tabs > 2×2 label bracket right 1`] = `3580`;
 
-exports[`label tabs > 2×2 label disabled 1`] = `3068`;
+exports[`label tabs > 2×2 label disabled 1`] = `2972`;
 
-exports[`label tabs > 2×2 label solid left 1`] = `3724`;
+exports[`label tabs > 2×2 label solid left 1`] = `3472`;
 
-exports[`large bin > 8×8 standard 1`] = `23380`;
+exports[`large bin > 8×8 standard 1`] = `23348`;
 
-exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3560`;
+exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3464`;
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4184`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4056`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `5008`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4856`;
 
-exports[`scoop > 2×2 scoop auto radius 1`] = `4184`;
+exports[`scoop > 2×2 scoop auto radius 1`] = `4056`;
 
-exports[`scoop > 2×2 scoop disabled 1`] = `3068`;
+exports[`scoop > 2×2 scoop disabled 1`] = `2972`;
 
-exports[`scoop > 2×2 scoop radius 10mm 1`] = `4136`;
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `4060`;
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `3500`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `3332`;
 
-exports[`slotted variations > slotted with both axes 1`] = `3932`;
+exports[`slotted variations > slotted with both axes 1`] = `3692`;
 
 exports[`slotted variations > slotted without lip 1`] = `1380`;
 
-exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `3090`;
+exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `3024`;
 
-exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `3004`;
+exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `2940`;
 
-exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `3128`;
+exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `3062`;
 
-exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2884`;
+exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2818`;
 
-exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `3036`;
+exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `2980`;
 
-exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2872`;
+exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2808`;
 
-exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `3548`;
+exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `3484`;
 
-exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2888`;
+exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2820`;
 
-exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `3000`;
+exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `2936`;
 
-exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2856`;
+exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2800`;
 
-exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2856`;
+exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2800`;
 
-exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `3036`;
+exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `2940`;
 
-exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `3084`;
+exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `2988`;

--- a/src/features/generation/worker/generators/boxBuilder.test.ts
+++ b/src/features/generation/worker/generators/boxBuilder.test.ts
@@ -16,9 +16,17 @@ let buildBinBox: BuildBinBoxFn;
 let buildTopShape: BuildTopShapeFn;
 
 let meshShape: (shape: unknown) => { vertices: ArrayLike<number>; triangles: ArrayLike<number> };
+let shapeBounds: (shape: unknown) => {
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+  zMin: number;
+  zMax: number;
+};
 
 beforeAll(async () => {
-  const { initFromOC, mesh: meshFn } = await import('brepjs');
+  const { initFromOC, mesh: meshFn, getBounds } = await import('brepjs');
   const opencascade = (await import('brepjs-opencascade/src/brepjs_single.js')).default;
   const { readFileSync } = await import('fs');
   const { join } = await import('path');
@@ -33,6 +41,7 @@ beforeAll(async () => {
   buildTopShape = mod.buildTopShape;
 
   meshShape = (shape) => meshFn(shape as never, { tolerance: 1, angularTolerance: 30 });
+  shapeBounds = (shape) => getBounds(shape as never);
 }, 30000);
 
 describe('buildBinBox', () => {
@@ -93,4 +102,44 @@ describe('buildTopShape', () => {
     const withoutLip = meshShape(buildTopShape(2, 2, false));
     expect(withLip.triangles.length).toBeGreaterThan(withoutLip.triangles.length);
   }, 60000);
+
+  // Regression: #1379 — lip must not overhang the box boundary on non-square bins
+  it.each([
+    [4, 3, '4x3'],
+    [3, 4, '3x4'],
+    [1, 4, '1x4'],
+    [2, 3, '2x3'],
+  ])(
+    'rectangular %sx%s lip does not exceed box bounds',
+    (gridW, gridD, _label) => {
+      const SIZE = 42;
+      const CLEARANCE = 0.5;
+      const outerW = gridW * SIZE - CLEARANCE;
+      const outerD = gridD * SIZE - CLEARANCE;
+
+      const shape = buildTopShape(gridW, gridD, true);
+      const bounds = shapeBounds(shape);
+      const TOL = 0.5;
+
+      expect(bounds.xMax - bounds.xMin).toBeLessThanOrEqual(outerW + TOL);
+      expect(bounds.yMax - bounds.yMin).toBeLessThanOrEqual(outerD + TOL);
+    },
+    30000
+  );
+
+  // Regression: lip outer face should be flush with bin outer edge
+  it('lip outer face is flush with bin wall (not tapered)', () => {
+    const SIZE = 42;
+    const CLEARANCE = 0.5;
+    const outerW = 4 * SIZE - CLEARANCE;
+    const outerD = 3 * SIZE - CLEARANCE;
+
+    const lip = buildTopShape(4, 3, true);
+    const lipBounds = shapeBounds(lip);
+
+    // Lip X/Y extent should match outerW/outerD (flush with bin wall)
+    const TOL = 0.5;
+    expect(lipBounds.xMax - lipBounds.xMin).toBeGreaterThan(outerW - TOL);
+    expect(lipBounds.yMax - lipBounds.yMin).toBeGreaterThan(outerD - TOL);
+  }, 30000);
 });

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -21,7 +21,6 @@ import {
   edgeFinder,
   getBounds,
   shell,
-  getKernel,
   withScope,
 } from 'brepjs';
 import type { Shape3D, ValidSolid, Plane, Vec3, Sketch, DisposalScope } from 'brepjs';
@@ -146,6 +145,10 @@ function buildTopShapeLoft(outerW: number, outerD: number, includeLip: boolean):
   const INSET_MID = LIP_BIG_TAPER; // 1.9mm
   const INSET_TOP = 0; // 0mm (peak at outer edge)
 
+  // Extension flange: no inset so it spans the full outer edge,
+  // guaranteeing overlap with the box walls at the fuse junction.
+  const INSET_EXT = 0;
+
   const Z_EXT = -LIP_EXTENSION;
   const Z_BASE = 0;
   const Z_TAPER1 = LIP_SMALL_TAPER; // 0.7
@@ -162,7 +165,7 @@ function buildTopShapeLoft(outerW: number, outerD: number, includeLip: boolean):
   // Build outer frustum
   const outerSections: Sketch[] = [];
   if (includeLip) {
-    outerSections.push(sectionAt(Z_EXT, INSET_BOTTOM));
+    outerSections.push(sectionAt(Z_EXT, INSET_EXT));
   }
   outerSections.push(sectionAt(Z_BASE, INSET_BOTTOM));
   outerSections.push(sectionAt(Z_TAPER1, INSET_MID));
@@ -176,7 +179,7 @@ function buildTopShapeLoft(outerW: number, outerD: number, includeLip: boolean):
     // Build inner frustum (offset inward by wall thickness)
     const innerSections: Sketch[] = [];
     if (includeLip) {
-      innerSections.push(sectionAt(Z_EXT, INSET_BOTTOM + WALL));
+      innerSections.push(sectionAt(Z_EXT, INSET_EXT + WALL));
     }
     innerSections.push(sectionAt(Z_BASE, INSET_BOTTOM + WALL));
     innerSections.push(sectionAt(Z_TAPER1, INSET_MID + WALL));
@@ -274,9 +277,10 @@ function buildTopShapeSweep(outerW: number, outerD: number, includeLip: boolean)
 /**
  * Build the stacking lip at the top of the bin.
  *
- * Uses kernel-optimized construction:
- * - brepkit: loft + boolean cut (analytic surfaces, avoids slow shell)
- * - OCCT: sweep + fillet (robust, avoids loft-shell failures)
+ * Uses loft-cut for all kernels: constructs explicit rounded-rectangle
+ * cross-sections at each profile breakpoint, avoiding an OCCT sweep bug
+ * that flips the profile on non-square spines (#1379). Sweep retained as
+ * fallback if loft throws.
  *
  * Profile per Gridfinity spec v5: 0.7mm + 1.8mm + 1.9mm = 4.4mm total height.
  * Built at Z=0 locally, caller translates to wallHeight.
@@ -288,7 +292,7 @@ export function buildTopShape(
   gridUnitMm: number = SIZE
 ): Shape3D {
   const lipKey = buildCacheKey(
-    'v2',
+    'v3',
     quantize(gridW),
     quantize(gridD),
     quantize(gridUnitMm),
@@ -302,17 +306,14 @@ export function buildTopShape(
   const outerW = gridW * gridUnitMm - CLEARANCE;
   const outerD = gridD * gridUnitMm - CLEARANCE;
 
+  // Loft-cut for all kernels: produces analytic surfaces and avoids an OCCT
+  // BRepOffsetAPI_MakePipeShell bug where the profile direction flips on
+  // certain non-square aspect ratios, causing the lip to overhang (#1379).
   let result: Shape3D;
-  if (getKernel().kernelId === 'brepkit') {
-    // brepkit: loft-cut is ~5-50x faster than sweep (analytic surfaces)
-    try {
-      result = buildTopShapeLoft(outerW, outerD, includeLip);
-    } catch {
-      // Loft failed — fall back to sweep path (kernel regression)
-      result = buildTopShapeSweep(outerW, outerD, includeLip);
-    }
-  } else {
-    // OCCT: sweep is faster and more robust (loft-shell fails, loft-cut is slow)
+  try {
+    result = buildTopShapeLoft(outerW, outerD, includeLip);
+  } catch {
+    // Loft failed — fall back to sweep path (kernel regression)
     result = buildTopShapeSweep(outerW, outerD, includeLip);
   }
 

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -138,12 +138,14 @@ export function buildBinBox(
  */
 function buildTopShapeLoft(outerW: number, outerD: number, includeLip: boolean): Shape3D {
   const LIP_EXTENSION = includeLip ? 1.2 : 0;
-  const WALL = LIP_TAPER_WIDTH; // 2.6mm wall thickness
 
-  // Insets from outer edge at each profile breakpoint
-  const INSET_BOTTOM = LIP_TAPER_WIDTH; // 2.6mm
-  const INSET_MID = LIP_BIG_TAPER; // 1.9mm
-  const INSET_TOP = 0; // 0mm (peak at outer edge)
+  // Inner contour insets — trace the lip profile's inner face.
+  // The lip profile tapers from INSET_BOTTOM at the base inward toward
+  // the outer edge at the peak. The outer face is flush with the bin
+  // wall (inset=0) at all Z levels.
+  const INNER_BASE = LIP_TAPER_WIDTH; // 2.6mm
+  const INNER_MID = LIP_BIG_TAPER; // 1.9mm
+  const INNER_TOP = 0; // 0mm (inner meets outer at peak)
 
   const Z_EXT = -LIP_EXTENSION;
   const Z_BASE = 0;
@@ -158,29 +160,29 @@ function buildTopShapeLoft(outerW: number, outerD: number, includeLip: boolean):
     return drawRoundedRectangle(w, d, r).sketchOnPlane('XY', z) as Sketch;
   };
 
-  // Build outer frustum
+  // Build outer frustum — flush with bin wall (inset=0) at all Z levels
   const outerSections: Sketch[] = [];
   if (includeLip) {
-    outerSections.push(sectionAt(Z_EXT, INSET_BOTTOM));
+    outerSections.push(sectionAt(Z_EXT, 0));
   }
-  outerSections.push(sectionAt(Z_BASE, INSET_BOTTOM));
-  outerSections.push(sectionAt(Z_TAPER1, INSET_MID));
-  outerSections.push(sectionAt(Z_VERT, INSET_MID));
-  outerSections.push(sectionAt(Z_PEAK, INSET_TOP));
+  outerSections.push(sectionAt(Z_BASE, 0));
+  outerSections.push(sectionAt(Z_TAPER1, 0));
+  outerSections.push(sectionAt(Z_VERT, 0));
+  outerSections.push(sectionAt(Z_PEAK, 0));
 
   return withScope((scope: DisposalScope) => {
     const [outerFirst, ...outerRest] = outerSections;
     const outerFrustum = scope.register(outerFirst.loftWith(outerRest, { ruled: true }));
 
-    // Build inner frustum (offset inward by wall thickness)
+    // Build inner frustum — traces the lip profile's inner contour
     const innerSections: Sketch[] = [];
     if (includeLip) {
-      innerSections.push(sectionAt(Z_EXT, INSET_BOTTOM + WALL));
+      innerSections.push(sectionAt(Z_EXT, INNER_BASE));
     }
-    innerSections.push(sectionAt(Z_BASE, INSET_BOTTOM + WALL));
-    innerSections.push(sectionAt(Z_TAPER1, INSET_MID + WALL));
-    innerSections.push(sectionAt(Z_VERT, INSET_MID + WALL));
-    innerSections.push(sectionAt(Z_PEAK, INSET_TOP + WALL));
+    innerSections.push(sectionAt(Z_BASE, INNER_BASE));
+    innerSections.push(sectionAt(Z_TAPER1, INNER_MID));
+    innerSections.push(sectionAt(Z_VERT, INNER_MID));
+    innerSections.push(sectionAt(Z_PEAK, INNER_TOP));
 
     const [innerFirst, ...innerRest] = innerSections;
     const innerFrustum = scope.register(innerFirst.loftWith(innerRest, { ruled: true }));

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -145,10 +145,6 @@ function buildTopShapeLoft(outerW: number, outerD: number, includeLip: boolean):
   const INSET_MID = LIP_BIG_TAPER; // 1.9mm
   const INSET_TOP = 0; // 0mm (peak at outer edge)
 
-  // Extension flange: no inset so it spans the full outer edge,
-  // guaranteeing overlap with the box walls at the fuse junction.
-  const INSET_EXT = 0;
-
   const Z_EXT = -LIP_EXTENSION;
   const Z_BASE = 0;
   const Z_TAPER1 = LIP_SMALL_TAPER; // 0.7
@@ -165,7 +161,7 @@ function buildTopShapeLoft(outerW: number, outerD: number, includeLip: boolean):
   // Build outer frustum
   const outerSections: Sketch[] = [];
   if (includeLip) {
-    outerSections.push(sectionAt(Z_EXT, INSET_EXT));
+    outerSections.push(sectionAt(Z_EXT, INSET_BOTTOM));
   }
   outerSections.push(sectionAt(Z_BASE, INSET_BOTTOM));
   outerSections.push(sectionAt(Z_TAPER1, INSET_MID));
@@ -179,7 +175,7 @@ function buildTopShapeLoft(outerW: number, outerD: number, includeLip: boolean):
     // Build inner frustum (offset inward by wall thickness)
     const innerSections: Sketch[] = [];
     if (includeLip) {
-      innerSections.push(sectionAt(Z_EXT, INSET_EXT + WALL));
+      innerSections.push(sectionAt(Z_EXT, INSET_BOTTOM + WALL));
     }
     innerSections.push(sectionAt(Z_BASE, INSET_BOTTOM + WALL));
     innerSections.push(sectionAt(Z_TAPER1, INSET_MID + WALL));

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -128,24 +128,19 @@ export function buildBinBox(
   });
 }
 /**
- * Build the stacking lip using a ruled loft + boolean cut (fast path).
+ * Build the stacking lip using a ruled loft + boolean cut.
  *
- * Constructs the lip taper as a ruled loft through rounded-rectangle sections
- * at each profile breakpoint, then boolean-subtracts an inner frustum to create
- * a hollow ring. This produces analytic surfaces (planar + conical) instead of
- * the NURBS surfaces from sweepSketch, making it dramatically faster for boolean
- * and tessellation — especially with the brepkit kernel.
+ * Outer frustum is a rectangular tube flush with the bin wall (inset=0).
+ * Inner frustum traces the lip profile's inner contour, tapering from
+ * 2.6mm at the base to 0mm at the peak. The cut produces a wedge-shaped
+ * ring whose exterior is smooth and flush with the bin wall.
  */
 function buildTopShapeLoft(outerW: number, outerD: number, includeLip: boolean): Shape3D {
   const LIP_EXTENSION = includeLip ? 1.2 : 0;
 
-  // Inner contour insets — trace the lip profile's inner face.
-  // The lip profile tapers from INSET_BOTTOM at the base inward toward
-  // the outer edge at the peak. The outer face is flush with the bin
-  // wall (inset=0) at all Z levels.
   const INNER_BASE = LIP_TAPER_WIDTH; // 2.6mm
   const INNER_MID = LIP_BIG_TAPER; // 1.9mm
-  const INNER_TOP = 0; // 0mm (inner meets outer at peak)
+  const INNER_TOP = 0;
 
   const Z_EXT = -LIP_EXTENSION;
   const Z_BASE = 0;
@@ -160,21 +155,15 @@ function buildTopShapeLoft(outerW: number, outerD: number, includeLip: boolean):
     return drawRoundedRectangle(w, d, r).sketchOnPlane('XY', z) as Sketch;
   };
 
-  // Build outer frustum — flush with bin wall (inset=0) at all Z levels
-  const outerSections: Sketch[] = [];
-  if (includeLip) {
-    outerSections.push(sectionAt(Z_EXT, 0));
-  }
-  outerSections.push(sectionAt(Z_BASE, 0));
-  outerSections.push(sectionAt(Z_TAPER1, 0));
-  outerSections.push(sectionAt(Z_VERT, 0));
-  outerSections.push(sectionAt(Z_PEAK, 0));
+  // Outer: rectangular tube at bin outer edge (2 sections → no extra edges)
+  const zBottom = includeLip ? Z_EXT : Z_BASE;
+  const outerSections: Sketch[] = [sectionAt(zBottom, 0), sectionAt(Z_PEAK, 0)];
 
   return withScope((scope: DisposalScope) => {
     const [outerFirst, ...outerRest] = outerSections;
     const outerFrustum = scope.register(outerFirst.loftWith(outerRest, { ruled: true }));
 
-    // Build inner frustum — traces the lip profile's inner contour
+    // Inner: tapered frustum tracing the lip profile
     const innerSections: Sketch[] = [];
     if (includeLip) {
       innerSections.push(sectionAt(Z_EXT, INNER_BASE));

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -313,7 +313,8 @@ export function buildTopShape(
   try {
     result = buildTopShapeLoft(outerW, outerD, includeLip);
   } catch {
-    // Loft failed — fall back to sweep path (kernel regression)
+    // Loft failed — fall back to sweep path (kernel regression).
+    // NOTE: sweep has the OCCT profile-flip bug on non-square spines (#1379)
     result = buildTopShapeSweep(outerW, outerD, includeLip);
   }
 

--- a/src/features/generation/worker/generators/scenarios/lipWall.ts
+++ b/src/features/generation/worker/generators/scenarios/lipWall.ts
@@ -1,6 +1,6 @@
 import { expect } from 'vitest';
 import { DEFAULT_BIN_PARAMS, GRIDFINITY } from '@/shared/constants/bin';
-import { countWallVerticesInZone } from '../__dual-kernel__/meshAssertions';
+import { boundingBox, countWallVerticesInZone } from '../__dual-kernel__/meshAssertions';
 import { defineScenario } from '../__dual-kernel__/scenarioTypes';
 import type { ScenarioCase } from '../__dual-kernel__/scenarioTypes';
 
@@ -13,6 +13,8 @@ const lipWallCases = [
   { width: 4, depth: 4, label: '4x4 (threshold)' },
   { width: 5, depth: 4, label: '5x4 (above threshold)' },
   { width: 8, depth: 2, label: '8x2 (large, elongated)' },
+  { width: 4, depth: 3, label: '4x3 (reported in #1379)' },
+  { width: 3, depth: 4, label: '3x4 (inverse of #1379)' },
 ];
 
 export const lipWall: ScenarioCase[] = lipWallCases.map(({ width, depth, label }) => {
@@ -42,6 +44,12 @@ export const lipWall: ScenarioCase[] = lipWallCases.map(({ width, depth, label }
       expect(stats.right).toBeGreaterThanOrEqual(2);
       expect(stats.front).toBeGreaterThanOrEqual(2);
       expect(stats.back).toBeGreaterThanOrEqual(2);
+
+      // #1379: lip must not overhang the box outer boundary
+      const bb = boundingBox(result.vertices);
+      const TOL = 1.0; // tessellation tolerance
+      expect(bb.maxX - bb.minX, 'lip X extent must not exceed outerW').toBeLessThan(outerW + TOL);
+      expect(bb.maxY - bb.minY, 'lip Y extent must not exceed outerD').toBeLessThan(outerD + TOL);
     },
   });
 });

--- a/src/features/generation/worker/generators/scenarios/lipWall.ts
+++ b/src/features/generation/worker/generators/scenarios/lipWall.ts
@@ -48,8 +48,12 @@ export const lipWall: ScenarioCase[] = lipWallCases.map(({ width, depth, label }
       // #1379: lip must not overhang the box outer boundary
       const bb = boundingBox(result.vertices);
       const TOL = 1.0; // tessellation tolerance
-      expect(bb.maxX - bb.minX, 'lip X extent must not exceed outerW').toBeLessThan(outerW + TOL);
-      expect(bb.maxY - bb.minY, 'lip Y extent must not exceed outerD').toBeLessThan(outerD + TOL);
+      expect(bb.maxX - bb.minX, 'lip X extent must not exceed outerW').toBeLessThanOrEqual(
+        outerW + TOL
+      );
+      expect(bb.maxY - bb.minY, 'lip Y extent must not exceed outerD').toBeLessThanOrEqual(
+        outerD + TOL
+      );
     },
   });
 });


### PR DESCRIPTION
## Summary

Fixes the stacking lip hanging over the outer wall on non-square bins (e.g. 4x3). The root cause is an OCCT `BRepOffsetAPI_MakePipeShell` bug where the sweep profile direction flips for certain rounded-rectangle spine aspect ratios, producing 2.6mm of outward overhang.

This is a re-attempt of #1306 (reverted in #1309 due to #1310). The prior attempt left the extension flange at `INSET_BOTTOM` (2.6mm inset), which floated inside the box cavity without contacting the walls — `fuse()` produced a disconnected compound. This fix sets `INSET_EXT = 0` so the extension reaches the full outer edge, guaranteeing volumetric overlap with the box walls for any `wallThickness`.

## Changes

- Use `buildTopShapeLoft` for all kernels — constructs explicit rounded-rectangle cross-sections at each profile breakpoint, avoiding the OCCT sweep framing bug. Sweep retained as catch fallback.
- Set extension flange `INSET_EXT = 0` so the lip extension reaches the box outer edge, ensuring the boolean fuse produces a single connected solid (fixes the #1310 gap).
- Bump lip cache key `v2` → `v3` (geometry changed).
- Add 4x3 and 3x4 lip-wall scenario cases with bounding-box overhang assertions.
- Update 69 triangle count snapshots (loft produces analytic surfaces vs sweep's NURBS).

## Test plan

- [ ] 9746 generation tests pass including new lip-wall scenarios
- [ ] Typecheck clean
- [ ] Verify 4x3 bin in bin designer — lip should be flush with outer wall
- [ ] Verify thin wall (0.4mm) + stacking lip — no visible gap between lip and walls (#1310)

Closes #1379
Closes #1310