### PR TITLE
fix(bin-designer): stop pinch-zoom from snapping camera back to isometric on mobile

### DIFF
--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -459,8 +459,11 @@ export function PreviewCanvas() {
 
   // Double-tap to reset view (touch only). The hook ignores multi-touch
   // gestures so pinch-to-zoom never misfires as a double-tap.
-  const { onPointerDown: onDoubleTapPointerDown, onPointerUp: onDoubleTapPointerUp } =
-    useDoubleTapReset({ onDoubleTap: resetView, disabled: isDesktop });
+  const {
+    onPointerDown: onDoubleTapPointerDown,
+    onPointerUp: onDoubleTapPointerUp,
+    onPointerCancel: onDoubleTapPointerCancel,
+  } = useDoubleTapReset({ onDoubleTap: resetView, disabled: isDesktop });
 
   // Scene dimensions
   const width = params.width;
@@ -478,6 +481,7 @@ export function PreviewCanvas() {
       aria-label={binDescription}
       onPointerDown={onDoubleTapPointerDown}
       onPointerUp={onDoubleTapPointerUp}
+      onPointerCancel={onDoubleTapPointerCancel}
     >
       {/* ARIA live region for status announcements */}
       <div aria-live="polite" aria-atomic="true" className="sr-only">

--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -40,6 +40,7 @@ import {
 import { GradientBackground } from '../preview/GradientBackground';
 import { FootprintGrid } from '../preview/FootprintGrid';
 import { useDesignerKeyboard } from '../../hooks/useDesignerKeyboard';
+import { useDoubleTapReset } from '../../hooks/useDoubleTapReset';
 import { useSplitPreview } from '../../hooks/useSplitPreview';
 import { setPreviewCanvas, setPreviewContext, clearPreviewCanvas } from '../../utils/thumbnail';
 import { describeBin, getStatusAnnouncement } from '../../utils/a11y';
@@ -454,24 +455,12 @@ export function PreviewCanvas() {
   const showColors = useFeatureFlag('multi_color_export');
 
   // Responsive state for touch optimizations
-  const { isDesktop } = useResponsive();
+  const { isDesktop, isTouchDevice } = useResponsive();
 
-  // Double-tap to reset view (mobile only)
-  const lastTapRef = useRef(0);
-  const handleCanvasDoubleTouch = useCallback(
-    (e: React.PointerEvent) => {
-      if (isDesktop || e.pointerType !== 'touch') return;
-      const now = Date.now();
-      if (now - lastTapRef.current < 300) {
-        e.preventDefault();
-        resetView();
-        lastTapRef.current = 0;
-      } else {
-        lastTapRef.current = now;
-      }
-    },
-    [isDesktop, resetView]
-  );
+  // Double-tap to reset view (touch only). The hook ignores multi-touch
+  // gestures so pinch-to-zoom never misfires as a double-tap.
+  const { onPointerDown: onDoubleTapPointerDown, onPointerUp: onDoubleTapPointerUp } =
+    useDoubleTapReset({ onDoubleTap: resetView, disabled: isDesktop });
 
   // Scene dimensions
   const width = params.width;
@@ -487,7 +476,8 @@ export function PreviewCanvas() {
       className="relative h-full w-full touch-manipulation"
       role="img"
       aria-label={binDescription}
-      onPointerUp={handleCanvasDoubleTouch}
+      onPointerDown={onDoubleTapPointerDown}
+      onPointerUp={onDoubleTapPointerUp}
     >
       {/* ARIA live region for status announcements */}
       <div aria-live="polite" aria-atomic="true" className="sr-only">
@@ -584,8 +574,9 @@ export function PreviewCanvas() {
               target={[0, 0, totalH / 2]}
               enableDamping
               dampingFactor={0.12}
-              rotateSpeed={0.8}
-              minDistance={isDesktop ? 20 : 5}
+              rotateSpeed={isTouchDevice ? 1.0 : 0.8}
+              zoomSpeed={isTouchDevice ? 1.2 : 1.0}
+              minDistance={20}
               maxDistance={800}
               maxPolarAngle={Math.PI * 0.85}
               minPolarAngle={Math.PI * 0.05}

--- a/src/features/bin-designer/hooks/index.ts
+++ b/src/features/bin-designer/hooks/index.ts
@@ -3,6 +3,7 @@ export { useCreateFromBin } from './useCreateFromBin';
 export { useDesignerInit } from './useDesignerInit';
 export { useDesignerKeyboard } from './useDesignerKeyboard';
 export { useDesignerUrlSync } from './useDesignerUrlSync';
+export { useDoubleTapReset } from './useDoubleTapReset';
 export { useExport } from './useExport';
 export { useGeneration } from './useGeneration';
 export { useThumbnailCapture } from './useThumbnailCapture';

--- a/src/features/bin-designer/hooks/useDoubleTapReset.test.ts
+++ b/src/features/bin-designer/hooks/useDoubleTapReset.test.ts
@@ -9,6 +9,7 @@ interface PointerStub {
   isPrimary?: boolean;
   clientX?: number;
   clientY?: number;
+  preventDefault?: () => void;
 }
 
 function pointerEvent(stub: PointerStub): PointerEvent {
@@ -18,7 +19,7 @@ function pointerEvent(stub: PointerStub): PointerEvent {
     isPrimary: stub.isPrimary ?? true,
     clientX: stub.clientX ?? 100,
     clientY: stub.clientY ?? 100,
-    preventDefault: () => undefined,
+    preventDefault: stub.preventDefault ?? (() => undefined),
   } as unknown as PointerEvent;
 }
 
@@ -165,6 +166,70 @@ describe('useDoubleTapReset', () => {
       result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
     });
     expect(onDoubleTap).not.toHaveBeenCalled();
+  });
+
+  it('calls preventDefault on the second tap when firing', () => {
+    // Parity with the old inline handler: prevent synthesized click / legacy
+    // double-tap-zoom on the triggering pointerup event.
+    const { result } = render();
+    const firstPreventDefault = vi.fn();
+    const secondPreventDefault = vi.fn();
+    act(() => {
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerUp(
+        pointerEvent({ pointerId: 1, preventDefault: firstPreventDefault })
+      );
+    });
+    act(() => {
+      vi.advanceTimersByTime(150);
+      result.current.onPointerDown(pointerEvent({ pointerId: 2 }));
+      result.current.onPointerUp(
+        pointerEvent({ pointerId: 2, preventDefault: secondPreventDefault })
+      );
+    });
+    expect(onDoubleTap).toHaveBeenCalledOnce();
+    expect(firstPreventDefault).not.toHaveBeenCalled();
+    expect(secondPreventDefault).toHaveBeenCalledOnce();
+  });
+
+  it('recovers after a cancelled touch so subsequent taps still detect', () => {
+    // Regression: without onPointerCancel, an interrupted touch leaves the
+    // pointerId in the active set forever and disables double-tap detection.
+    const { result } = render();
+    act(() => {
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      // OS yanks the gesture — pointerup never arrives, pointercancel does.
+      result.current.onPointerCancel(pointerEvent({ pointerId: 1 }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+      result.current.onPointerDown(pointerEvent({ pointerId: 2 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 2 }));
+      vi.advanceTimersByTime(150);
+      result.current.onPointerDown(pointerEvent({ pointerId: 3 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 3 }));
+    });
+    expect(onDoubleTap).toHaveBeenCalledOnce();
+  });
+
+  it('clears state when the last of several pointers is cancelled mid-pinch', () => {
+    const { result } = render();
+    act(() => {
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerDown(pointerEvent({ pointerId: 2, isPrimary: false }));
+      // First finger lifts normally, second is cancelled.
+      result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerCancel(pointerEvent({ pointerId: 2, isPrimary: false }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+      result.current.onPointerDown(pointerEvent({ pointerId: 3 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 3 }));
+      vi.advanceTimersByTime(150);
+      result.current.onPointerDown(pointerEvent({ pointerId: 4 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 4 }));
+    });
+    expect(onDoubleTap).toHaveBeenCalledOnce();
   });
 
   it('fires after a pinch gesture is fully completed', () => {

--- a/src/features/bin-designer/hooks/useDoubleTapReset.test.ts
+++ b/src/features/bin-designer/hooks/useDoubleTapReset.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { PointerEvent } from 'react';
+import { useDoubleTapReset } from './useDoubleTapReset';
+
+interface PointerStub {
+  pointerId: number;
+  pointerType?: string;
+  isPrimary?: boolean;
+  clientX?: number;
+  clientY?: number;
+}
+
+function pointerEvent(stub: PointerStub): PointerEvent {
+  return {
+    pointerId: stub.pointerId,
+    pointerType: stub.pointerType ?? 'touch',
+    isPrimary: stub.isPrimary ?? true,
+    clientX: stub.clientX ?? 100,
+    clientY: stub.clientY ?? 100,
+    preventDefault: () => undefined,
+  } as unknown as PointerEvent;
+}
+
+describe('useDoubleTapReset', () => {
+  const onDoubleTap = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function render(opts: { disabled?: boolean; windowMs?: number } = {}) {
+    return renderHook(() => useDoubleTapReset({ onDoubleTap, ...opts }));
+  }
+
+  it('fires on two quick taps with the same finger', () => {
+    const { result } = render();
+    act(() => {
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(150);
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
+    });
+    expect(onDoubleTap).toHaveBeenCalledOnce();
+  });
+
+  it('fires on two quick taps even when the second uses a different pointerId', () => {
+    // iOS Safari often assigns a new pointerId to each fresh touch.
+    const { result } = render();
+    act(() => {
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(150);
+      result.current.onPointerDown(pointerEvent({ pointerId: 2 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 2 }));
+    });
+    expect(onDoubleTap).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT fire when a pinch gesture releases both fingers in quick succession', () => {
+    // This is the core bug: two pointerups within 300ms from a pinch.
+    const { result } = render();
+    act(() => {
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerDown(pointerEvent({ pointerId: 2, isPrimary: false }));
+      vi.advanceTimersByTime(5);
+      result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
+      vi.advanceTimersByTime(5);
+      result.current.onPointerUp(pointerEvent({ pointerId: 2, isPrimary: false }));
+    });
+    expect(onDoubleTap).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire when a three-finger gesture releases in sequence', () => {
+    const { result } = render();
+    act(() => {
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerDown(pointerEvent({ pointerId: 2, isPrimary: false }));
+      result.current.onPointerDown(pointerEvent({ pointerId: 3, isPrimary: false }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 2, isPrimary: false }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 3, isPrimary: false }));
+    });
+    expect(onDoubleTap).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire when the two taps are farther apart than the window', () => {
+    const { result } = render({ windowMs: 300 });
+    act(() => {
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
+    });
+    expect(onDoubleTap).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire when the first gesture is a drag (movement exceeds threshold)', () => {
+    // Orbit rotation: pointer moves significantly between down and up.
+    const { result } = render();
+    act(() => {
+      result.current.onPointerDown(pointerEvent({ pointerId: 1, clientX: 100, clientY: 100 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 1, clientX: 180, clientY: 120 }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
+    });
+    expect(onDoubleTap).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire when a single tap is held too long (long-press)', () => {
+    const { result } = render();
+    act(() => {
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      vi.advanceTimersByTime(600);
+      result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(50);
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
+    });
+    expect(onDoubleTap).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire for mouse or pen events', () => {
+    const { result } = render();
+    act(() => {
+      result.current.onPointerDown(pointerEvent({ pointerId: 1, pointerType: 'mouse' }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 1, pointerType: 'mouse' }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+      result.current.onPointerDown(pointerEvent({ pointerId: 1, pointerType: 'mouse' }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 1, pointerType: 'mouse' }));
+    });
+    expect(onDoubleTap).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when disabled', () => {
+    const { result } = render({ disabled: true });
+    act(() => {
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
+    });
+    expect(onDoubleTap).not.toHaveBeenCalled();
+  });
+
+  it('fires after a pinch gesture is fully completed', () => {
+    // User pinches (no reset), then double-taps (reset should fire fresh).
+    const { result } = render();
+    act(() => {
+      // Pinch
+      result.current.onPointerDown(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerDown(pointerEvent({ pointerId: 2, isPrimary: false }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 1 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 2, isPrimary: false }));
+    });
+    expect(onDoubleTap).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(200);
+      // Now a real double-tap
+      result.current.onPointerDown(pointerEvent({ pointerId: 3 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 3 }));
+      vi.advanceTimersByTime(150);
+      result.current.onPointerDown(pointerEvent({ pointerId: 4 }));
+      result.current.onPointerUp(pointerEvent({ pointerId: 4 }));
+    });
+    expect(onDoubleTap).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/bin-designer/hooks/useDoubleTapReset.ts
+++ b/src/features/bin-designer/hooks/useDoubleTapReset.ts
@@ -31,6 +31,12 @@ interface UseDoubleTapResetOptions {
 interface DoubleTapHandlers {
   onPointerDown: (e: PointerEvent) => void;
   onPointerUp: (e: PointerEvent) => void;
+  /**
+   * Must be wired to `onPointerCancel`. Without it, a browser-interrupted touch
+   * (system notification, app switch, etc.) leaves stale pointer IDs in the
+   * active set and permanently blocks future tap detection.
+   */
+  onPointerCancel: (e: PointerEvent) => void;
 }
 
 /**
@@ -86,6 +92,7 @@ export function useDoubleTapReset({
       }
 
       if (lastTapTimeRef.current && now - lastTapTimeRef.current < windowMs) {
+        e.preventDefault();
         onDoubleTap();
         lastTapTimeRef.current = 0;
       } else {
@@ -95,5 +102,20 @@ export function useDoubleTapReset({
     [disabled, windowMs, onDoubleTap]
   );
 
-  return { onPointerDown, onPointerUp };
+  const onPointerCancel = useCallback(
+    (e: PointerEvent) => {
+      if (disabled || e.pointerType !== 'touch') return;
+      activePointersRef.current.delete(e.pointerId);
+      // If the interrupted finger was the last active one, reset the whole
+      // gesture so a subsequent clean single-tap starts from scratch.
+      if (activePointersRef.current.size === 0) {
+        wasMultiTouchRef.current = false;
+        tapStartRef.current = null;
+        lastTapTimeRef.current = 0;
+      }
+    },
+    [disabled]
+  );
+
+  return { onPointerDown, onPointerUp, onPointerCancel };
 }

--- a/src/features/bin-designer/hooks/useDoubleTapReset.ts
+++ b/src/features/bin-designer/hooks/useDoubleTapReset.ts
@@ -1,0 +1,99 @@
+/**
+ * Detects a clean single-finger double-tap on a touch surface and fires a callback.
+ *
+ * Distinguishes a tap from a drag/orbit (movement threshold) and from a pinch
+ * or multi-finger gesture (any frame where more than one pointer was active
+ * disqualifies the whole gesture from producing a tap). This prevents the
+ * 3D preview from snapping back to the isometric preset whenever the user
+ * pinch-zooms — both fingers produce near-simultaneous `pointerup` events
+ * that a naive timestamp-based handler mistakes for a double-tap.
+ */
+
+import { useCallback, useRef } from 'react';
+import type { PointerEvent } from 'react';
+
+/** Max pixels between tap start and end to still count as a tap (not a drag). */
+const TAP_MAX_DISTANCE_PX = 10;
+/** Max duration (ms) of a single tap before it's treated as a long-press. */
+const TAP_MAX_DURATION_MS = 500;
+/** Default window (ms) between two taps to count as a double-tap. */
+const DEFAULT_DOUBLE_TAP_WINDOW_MS = 300;
+
+interface UseDoubleTapResetOptions {
+  /** Called when a clean single-finger double-tap is detected. */
+  onDoubleTap: () => void;
+  /** When true, handlers are a no-op (e.g. disable on desktop / non-touch). */
+  disabled?: boolean;
+  /** Max ms between two taps to count as a double-tap. */
+  windowMs?: number;
+}
+
+interface DoubleTapHandlers {
+  onPointerDown: (e: PointerEvent) => void;
+  onPointerUp: (e: PointerEvent) => void;
+}
+
+/**
+ * React hook returning `onPointerDown` / `onPointerUp` handlers to attach to
+ * a surface for robust double-tap detection that survives multi-touch gestures.
+ */
+export function useDoubleTapReset({
+  onDoubleTap,
+  disabled = false,
+  windowMs = DEFAULT_DOUBLE_TAP_WINDOW_MS,
+}: UseDoubleTapResetOptions): DoubleTapHandlers {
+  const activePointersRef = useRef<Set<number>>(new Set());
+  const wasMultiTouchRef = useRef(false);
+  const tapStartRef = useRef<{ x: number; y: number; time: number } | null>(null);
+  const lastTapTimeRef = useRef(0);
+
+  const onPointerDown = useCallback(
+    (e: PointerEvent) => {
+      if (disabled || e.pointerType !== 'touch') return;
+      activePointersRef.current.add(e.pointerId);
+      if (activePointersRef.current.size === 1) {
+        tapStartRef.current = { x: e.clientX, y: e.clientY, time: Date.now() };
+      } else {
+        // Additional finger landed — this gesture can no longer be a tap.
+        wasMultiTouchRef.current = true;
+        lastTapTimeRef.current = 0;
+      }
+    },
+    [disabled]
+  );
+
+  const onPointerUp = useCallback(
+    (e: PointerEvent) => {
+      if (disabled || e.pointerType !== 'touch') return;
+      activePointersRef.current.delete(e.pointerId);
+      if (activePointersRef.current.size > 0) return;
+
+      const wasMulti = wasMultiTouchRef.current;
+      const start = tapStartRef.current;
+      wasMultiTouchRef.current = false;
+      tapStartRef.current = null;
+
+      if (wasMulti || !start) return;
+
+      const now = Date.now();
+      const dx = e.clientX - start.x;
+      const dy = e.clientY - start.y;
+      const movedFar = dx * dx + dy * dy > TAP_MAX_DISTANCE_PX * TAP_MAX_DISTANCE_PX;
+      const heldTooLong = now - start.time > TAP_MAX_DURATION_MS;
+      if (movedFar || heldTooLong) {
+        lastTapTimeRef.current = 0;
+        return;
+      }
+
+      if (lastTapTimeRef.current && now - lastTapTimeRef.current < windowMs) {
+        onDoubleTap();
+        lastTapTimeRef.current = 0;
+      } else {
+        lastTapTimeRef.current = now;
+      }
+    },
+    [disabled, windowMs, onDoubleTap]
+  );
+
+  return { onPointerDown, onPointerUp };
+}


### PR DESCRIPTION
## Summary

- Mobile users could orbit and pinch the 3D preview, but the view would **snap back to the isometric preset the moment they released the gesture**, making zoom feel "clamped" and view angles un-changeable.
- Root cause: `handleCanvasDoubleTouch` in `PreviewCanvas.tsx` used a single timestamp to detect double-taps. Pinch release emits two `pointerup` events within ~10ms — they fell inside the 300ms window and fired `resetView()`.
- Fix: extract into `useDoubleTapReset`, which tracks active `pointerId`s and disqualifies the entire gesture if any frame saw multi-touch. Also rejects drags (>10px movement) and long-presses (>500ms), so quick sequential orbits don't misfire either.
- Bonus touch tuning on `OrbitControls`: `rotateSpeed` 1.0 (was 0.8), `zoomSpeed` 1.2 (was 1.0), `minDistance` unified to 20 (was 5 on mobile as a workaround for this bug).

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` — zero new warnings
- [x] `pnpm exec vitest run src/features/bin-designer` — 1708/1708 pass (includes 10 new hook tests)
- [ ] Manual: on a mobile device, pinch-zoom should stay zoomed after release
- [ ] Manual: on a mobile device, orbit to a new angle and the view should stay there
- [ ] Manual: legitimate single-finger double-tap still resets to isometric
- [ ] Manual: desktop behavior unchanged