### PR TITLE
feat(generation): support non-rectangular bin footprints via cellMask

### DIFF
--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -7,6 +7,7 @@
 
 import type { FaceGroupData, CoarseLODData } from '@/shared/types/generation';
 import type { DesignId } from '@/core/types';
+import type { CellMask } from '@/shared/utils/cellMask';
 import type { FeatureColorConfig, ColorZone } from './featureColors';
 
 // Bin Configuration Types
@@ -258,6 +259,20 @@ export interface BinParams {
   readonly splitConnectors?: SplitConnectorConfig;
   /** Per-feature filament color assignment for multi-color 3MF export. */
   readonly featureColors: FeatureColorConfig;
+  /**
+   * Optional custom footprint mask (non-rectangular bins).
+   *
+   * When omitted or when every cell is filled, the bin is treated as a
+   * rectangle and uses the rectangle code path (no perf regression).
+   * When present and partial, the generator builds a polygon footprint
+   * and places sockets only on filled cells. Features that cannot yet
+   * operate on non-rectangular footprints (compartments, cutouts, walls,
+   * handles, inserts, scoops, label tabs) are skipped.
+   *
+   * Stored at half-bin resolution unconditionally — a `width × depth`
+   * bin has a `(2*width) × (2*depth)` mask.
+   */
+  readonly cellMask?: CellMask;
 }
 
 // Insert Types

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -50,13 +50,13 @@ exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3
 
 exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5188`;
 
-exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `4110`;
+exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `4102`;
 
 exports[`custom-shape > 3×3 L flat base no lip 1`] = `68`;
 
-exports[`custom-shape > 3×3 L with lip 1`] = `4110`;
+exports[`custom-shape > 3×3 L with lip 1`] = `4098`;
 
-exports[`custom-shape > 3×3 T with lip 1`] = `2864`;
+exports[`custom-shape > 3×3 T with lip 1`] = `2834`;
 
 exports[`custom-shape > 3×3 U with lip 1`] = `3916`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -50,6 +50,16 @@ exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3
 
 exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5188`;
 
+exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `4110`;
+
+exports[`custom-shape > 3×3 L flat base no lip 1`] = `68`;
+
+exports[`custom-shape > 3×3 L with lip 1`] = `4110`;
+
+exports[`custom-shape > 3×3 T with lip 1`] = `2864`;
+
+exports[`custom-shape > 3×3 U with lip 1`] = `3916`;
+
 exports[`dimensions > 0.5×0.5 no lip 1`] = `468`;
 
 exports[`dimensions > 0.5×0.5 with lip 1`] = `1292`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -50,15 +50,15 @@ exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3
 
 exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5188`;
 
-exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `4102`;
+exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `3984`;
 
-exports[`custom-shape > 3×3 L flat base no lip 1`] = `68`;
+exports[`custom-shape > 3×3 L flat base no lip 1`] = `56`;
 
-exports[`custom-shape > 3×3 L with lip 1`] = `4098`;
+exports[`custom-shape > 3×3 L with lip 1`] = `3980`;
 
-exports[`custom-shape > 3×3 T with lip 1`] = `2834`;
+exports[`custom-shape > 3×3 T with lip 1`] = `2602`;
 
-exports[`custom-shape > 3×3 U with lip 1`] = `3660`;
+exports[`custom-shape > 3×3 U with lip 1`] = `3474`;
 
 exports[`dimensions > 0.5×0.5 no lip 1`] = `468`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -58,7 +58,7 @@ exports[`custom-shape > 3×3 L with lip 1`] = `4098`;
 
 exports[`custom-shape > 3×3 T with lip 1`] = `2834`;
 
-exports[`custom-shape > 3×3 U with lip 1`] = `3916`;
+exports[`custom-shape > 3×3 U with lip 1`] = `3660`;
 
 exports[`dimensions > 0.5×0.5 no lip 1`] = `468`;
 

--- a/src/features/generation/worker/generators/binOrchestrator.ts
+++ b/src/features/generation/worker/generators/binOrchestrator.ts
@@ -6,6 +6,7 @@
  */
 
 import type { BinParams } from '@/shared/types/bin';
+import { MASK_CELLS_PER_UNIT, validateMask } from '@/shared/utils/cellMask';
 import type { MeshData } from '../../bridge/types';
 
 import type { ProgressFn } from './generatorTypes';
@@ -16,6 +17,27 @@ import { featuresStage } from './pipeline/stages/featuresStage';
 import { booleanStage } from './pipeline/stages/booleanStage';
 import { translateStage } from './pipeline/stages/translateStage';
 import { tessellateStage } from './pipeline/stages/tessellateStage';
+
+/**
+ * Throws if `params.cellMask` is present but malformed. Checks dimensions
+ * match the bin's `width × depth` at half-bin resolution, then delegates
+ * structural checks (empty / disconnected / holes / bounds) to `validateMask`.
+ */
+function assertValidMask(params: BinParams): void {
+  const { cellMask } = params;
+  if (!cellMask) return;
+  const expectedCols = Math.round(params.width * MASK_CELLS_PER_UNIT);
+  const expectedRows = Math.round(params.depth * MASK_CELLS_PER_UNIT);
+  if (cellMask.cols !== expectedCols || cellMask.rows !== expectedRows) {
+    throw new Error(
+      `cellMask dimensions (${cellMask.cols}×${cellMask.rows}) do not match bin ` +
+        `${params.width}×${params.depth} at half-bin resolution ` +
+        `(expected ${expectedCols}×${expectedRows})`
+    );
+  }
+  const err = validateMask(cellMask);
+  if (err) throw new Error(`cellMask is invalid: ${err.message}`);
+}
 
 /** Default generation pipeline: shell -> features -> boolean -> translate -> tessellate */
 const DEFAULT_PIPELINE: readonly PipelineStage[] = [
@@ -44,6 +66,7 @@ export function generateBin(
   forExport = false,
   signal?: AbortSignal
 ): MeshData {
+  assertValidMask(params);
   const ctx = createInitialContext(params, onProgress, forExport, signal);
   const result = runPipeline(DEFAULT_PIPELINE, ctx);
 

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -38,19 +38,8 @@ import {
 } from './generatorTypes';
 import { getBoxCache, setBoxCache, getLipCache, setLipCache } from './shapeCache';
 import { buildCacheKey, quantize } from './cacheKeyUtils';
-import { hashMask, isAllFilled, type CellMask } from '@/shared/utils/cellMask';
+import { hashMask, isPartialMask, type CellMask } from '@/shared/utils/cellMask';
 import { buildMaskDrawing, buildMaskDrawingInset } from './maskPolygon';
-/**
- * Determine whether a mask represents the rectangle fast-path.
- *
- * Undefined or fully-filled masks reuse the existing rounded-rectangle
- * code path (preserving cache keys and the BOX_CORNER_RADIUS fillet).
- * Only partial masks take the polygon path.
- */
-function isPolygonPath(cellMask: CellMask | undefined): cellMask is CellMask {
-  return cellMask !== undefined && !isAllFilled(cellMask);
-}
-
 /**
  * Build the bin box: a rounded-rectangle extrusion, shelled from the top.
  * The box starts at Z=0 (socket interface) and goes up to wallHeight.
@@ -72,7 +61,7 @@ export function buildBinBox(
   gridUnitMm: number = SIZE,
   cellMask?: CellMask
 ): Shape3D {
-  const polygon = isPolygonPath(cellMask);
+  const polygon = isPartialMask(cellMask);
   const boxKey = buildCacheKey(
     'v2',
     quantize(gridW),
@@ -197,7 +186,7 @@ function buildTopShapeLoft(
   gridUnitMm: number = SIZE
 ): Shape3D {
   const LIP_EXTENSION = includeLip ? 1.2 : 0;
-  const polygon = isPolygonPath(cellMask);
+  const polygon = isPartialMask(cellMask);
 
   const INNER_BASE = LIP_TAPER_WIDTH; // 2.6mm
   const INNER_MID = LIP_BIG_TAPER; // 1.9mm
@@ -281,7 +270,7 @@ function buildTopShapeSweep(
   cellMask?: CellMask,
   gridUnitMm: number = SIZE
 ): Shape3D {
-  const polygon = isPolygonPath(cellMask);
+  const polygon = isPartialMask(cellMask);
   const topProfile = (plane: Plane, _origin: Vec3): Sketch => {
     let sketcher = draw([-LIP_TAPER_WIDTH, 0])
       .line(LIP_SMALL_TAPER, LIP_SMALL_TAPER)
@@ -354,7 +343,7 @@ export function buildTopShape(
   gridUnitMm: number = SIZE,
   cellMask?: CellMask
 ): Shape3D {
-  const polygon = isPolygonPath(cellMask);
+  const polygon = isPartialMask(cellMask);
   const lipKey = buildCacheKey(
     'v3',
     quantize(gridW),

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -23,7 +23,7 @@ import {
   shell,
   withScope,
 } from 'brepjs';
-import type { Shape3D, ValidSolid, Plane, Vec3, Sketch, DisposalScope } from 'brepjs';
+import type { Shape3D, ValidSolid, Plane, Sketch, Vec3, DisposalScope, Drawing } from 'brepjs';
 import {
   SIZE,
   CLEARANCE,
@@ -38,10 +38,27 @@ import {
 } from './generatorTypes';
 import { getBoxCache, setBoxCache, getLipCache, setLipCache } from './shapeCache';
 import { buildCacheKey, quantize } from './cacheKeyUtils';
+import { hashMask, isAllFilled, type CellMask } from '@/shared/utils/cellMask';
+import { buildMaskDrawing, buildMaskDrawingInset } from './maskPolygon';
+/**
+ * Determine whether a mask represents the rectangle fast-path.
+ *
+ * Undefined or fully-filled masks reuse the existing rounded-rectangle
+ * code path (preserving cache keys and the BOX_CORNER_RADIUS fillet).
+ * Only partial masks take the polygon path.
+ */
+function isPolygonPath(cellMask: CellMask | undefined): cellMask is CellMask {
+  return cellMask !== undefined && !isAllFilled(cellMask);
+}
+
 /**
  * Build the bin box: a rounded-rectangle extrusion, shelled from the top.
  * The box starts at Z=0 (socket interface) and goes up to wallHeight.
  * Shell removes the top face, leaving walls + solid floor.
+ *
+ * When `cellMask` is provided and is not all-filled, the box is built from
+ * the mask's polygon outline instead of a rectangle (sharp corners, no
+ * outer fillet in v1). Undefined/full masks use the existing rectangle path.
  *
  * @param cutoutTopOffset - For solid mode: lowers the interior fill by this amount (mm)
  */
@@ -52,8 +69,10 @@ export function buildBinBox(
   wallThickness: number,
   solid: boolean,
   cutoutTopOffset: number = 0,
-  gridUnitMm: number = SIZE
+  gridUnitMm: number = SIZE,
+  cellMask?: CellMask
 ): Shape3D {
+  const polygon = isPolygonPath(cellMask);
   const boxKey = buildCacheKey(
     'v2',
     quantize(gridW),
@@ -62,7 +81,8 @@ export function buildBinBox(
     quantize(wallHeight),
     quantize(wallThickness),
     solid,
-    quantize(cutoutTopOffset)
+    quantize(cutoutTopOffset),
+    polygon ? hashMask(cellMask) : 'rect'
   );
   const cached = getBoxCache(boxKey);
   if (cached) {
@@ -72,8 +92,28 @@ export function buildBinBox(
   const outerW = gridW * gridUnitMm - CLEARANCE;
   const outerD = gridD * gridUnitMm - CLEARANCE;
 
+  /**
+   * Footprint sketch: rounded rectangle for rectangular bins, polygon
+   * (via mask) for custom shapes. The mask polygon already accounts for
+   * CLEARANCE via its inward offset; inner offsets below subtract
+   * `wallThickness` directly.
+   */
+  const footprint = (): Drawing =>
+    polygon
+      ? buildMaskDrawing(cellMask, gridUnitMm)
+      : drawRoundedRectangle(outerW, outerD, BOX_CORNER_RADIUS);
+
+  const innerFootprint = (): Drawing =>
+    polygon
+      ? buildMaskDrawingInset(cellMask, gridUnitMm, wallThickness)
+      : drawRoundedRectangle(
+          Math.max(outerW - 2 * wallThickness, 0.1),
+          Math.max(outerD - 2 * wallThickness, 0.1),
+          Math.max(BOX_CORNER_RADIUS - wallThickness, 0)
+        );
+
   return withScope((scope: DisposalScope) => {
-    const box = sketch(drawRoundedRectangle(outerW, outerD, BOX_CORNER_RADIUS)).extrude(wallHeight);
+    const box = sketch(footprint()).extrude(wallHeight);
 
     // Solid mode: return the raw extrusion, optionally with lowered interior fill
     if (solid) {
@@ -95,16 +135,11 @@ export function buildBinBox(
 
         // Guard: if fillHeight or inner dimensions are non-positive, the interior fill
         // would produce degenerate geometry that crashes WASM. Return hollow walls only.
-        if (fillHeight <= 0 || innerW <= 0 || innerD <= 0) {
+        if (fillHeight <= 0 || (!polygon && (innerW <= 0 || innerD <= 0))) {
           return setBoxCache(boxKey, hollowWalls);
         }
 
-        const innerFill = scope.register(
-          sketch(
-            drawRoundedRectangle(innerW, innerD, Math.max(0, BOX_CORNER_RADIUS - wallThickness)),
-            'XY'
-          ).extrude(fillHeight)
-        );
+        const innerFill = scope.register(sketch(innerFootprint(), 'XY').extrude(fillHeight));
         scope.register(hollowWalls); // consumed by fuse
 
         // Combine walls with lowered interior fill
@@ -114,11 +149,15 @@ export function buildBinBox(
       return setBoxCache(boxKey, box);
     }
 
-    // Guard: if wall thickness leaves no interior, return the solid box
-    const innerW = outerW - 2 * wallThickness;
-    const innerD = outerD - 2 * wallThickness;
-    if (innerW <= 0 || innerD <= 0) {
-      return setBoxCache(boxKey, box);
+    // Guard: if wall thickness leaves no interior, return the solid box.
+    // For polygon masks we trust the inward offset; only rectangle path
+    // can produce the degenerate condition this catches.
+    if (!polygon) {
+      const innerW = outerW - 2 * wallThickness;
+      const innerD = outerD - 2 * wallThickness;
+      if (innerW <= 0 || innerD <= 0) {
+        return setBoxCache(boxKey, box);
+      }
     }
 
     const topFaces = faceFinder().parallelTo('Z').atDistance(wallHeight, [0, 0, 0]).findAll(box);
@@ -135,8 +174,15 @@ export function buildBinBox(
  * 2.6mm at the base to 0mm at the peak. The cut produces a wedge-shaped
  * ring whose exterior is smooth and flush with the bin wall.
  */
-function buildTopShapeLoft(outerW: number, outerD: number, includeLip: boolean): Shape3D {
+function buildTopShapeLoft(
+  outerW: number,
+  outerD: number,
+  includeLip: boolean,
+  cellMask?: CellMask,
+  gridUnitMm: number = SIZE
+): Shape3D {
   const LIP_EXTENSION = includeLip ? 1.2 : 0;
+  const polygon = isPolygonPath(cellMask);
 
   const INNER_BASE = LIP_TAPER_WIDTH; // 2.6mm
   const INNER_MID = LIP_BIG_TAPER; // 1.9mm
@@ -149,6 +195,15 @@ function buildTopShapeLoft(outerW: number, outerD: number, includeLip: boolean):
   const Z_PEAK = LIP_HEIGHT; // 4.4
 
   const sectionAt = (z: number, inset: number): Sketch => {
+    if (polygon) {
+      // Polygon path: offset mask drawing inward by `inset`.
+      // inset === 0 returns the outer drawing directly.
+      const d =
+        inset === 0
+          ? buildMaskDrawing(cellMask, gridUnitMm)
+          : buildMaskDrawingInset(cellMask, gridUnitMm, inset);
+      return d.sketchOnPlane('XY', z) as Sketch;
+    }
     const w = outerW - 2 * inset;
     const d = outerD - 2 * inset;
     const r = Math.max(BOX_CORNER_RADIUS - inset, 0.1);
@@ -204,7 +259,14 @@ function buildTopShapeLoft(outerW: number, outerD: number, includeLip: boolean):
  * Sweeps the lip profile around the bin perimeter, then fillets the peak.
  * This creates NURBS surfaces that are slower for brepkit but robust for OCCT.
  */
-function buildTopShapeSweep(outerW: number, outerD: number, includeLip: boolean): Shape3D {
+function buildTopShapeSweep(
+  outerW: number,
+  outerD: number,
+  includeLip: boolean,
+  cellMask?: CellMask,
+  gridUnitMm: number = SIZE
+): Shape3D {
+  const polygon = isPolygonPath(cellMask);
   const topProfile = (plane: Plane, _origin: Vec3): Sketch => {
     let sketcher = draw([-LIP_TAPER_WIDTH, 0])
       .line(LIP_SMALL_TAPER, LIP_SMALL_TAPER)
@@ -237,11 +299,9 @@ function buildTopShapeSweep(outerW: number, outerD: number, includeLip: boolean)
   };
 
   return withScope((scope: DisposalScope) => {
-    const boxSketch = drawRoundedRectangle(
-      outerW,
-      outerD,
-      BOX_CORNER_RADIUS
-    ).sketchOnPlane() as Sketch;
+    const boxSketch = polygon
+      ? (buildMaskDrawing(cellMask, gridUnitMm).sketchOnPlane() as Sketch)
+      : (drawRoundedRectangle(outerW, outerD, BOX_CORNER_RADIUS).sketchOnPlane() as Sketch);
     const swept = boxSketch.sweepSketch(topProfile, { withContact: true });
 
     if (TOP_FILLET > 0) {
@@ -276,14 +336,17 @@ export function buildTopShape(
   gridW: number,
   gridD: number,
   includeLip: boolean,
-  gridUnitMm: number = SIZE
+  gridUnitMm: number = SIZE,
+  cellMask?: CellMask
 ): Shape3D {
+  const polygon = isPolygonPath(cellMask);
   const lipKey = buildCacheKey(
     'v3',
     quantize(gridW),
     quantize(gridD),
     quantize(gridUnitMm),
-    includeLip
+    includeLip,
+    polygon ? hashMask(cellMask) : 'rect'
   );
   const cached = getLipCache(lipKey);
   if (cached) {
@@ -298,11 +361,11 @@ export function buildTopShape(
   // certain non-square aspect ratios, causing the lip to overhang (#1379).
   let result: Shape3D;
   try {
-    result = buildTopShapeLoft(outerW, outerD, includeLip);
+    result = buildTopShapeLoft(outerW, outerD, includeLip, cellMask, gridUnitMm);
   } catch {
     // Loft failed — fall back to sweep path (kernel regression).
     // NOTE: sweep has the OCCT profile-flip bug on non-square spines (#1379)
-    result = buildTopShapeSweep(outerW, outerD, includeLip);
+    result = buildTopShapeSweep(outerW, outerD, includeLip, cellMask, gridUnitMm);
   }
 
   return setLipCache(lipKey, result);

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -139,7 +139,14 @@ export function buildBinBox(
           return setBoxCache(boxKey, hollowWalls);
         }
 
-        const innerFill = scope.register(sketch(innerFootprint(), 'XY').extrude(fillHeight));
+        // For polygon masks the offset can collapse on narrow features or
+        // oversized wallThickness; catch and fall back to hollow walls.
+        let innerFill: Shape3D;
+        try {
+          innerFill = scope.register(sketch(innerFootprint(), 'XY').extrude(fillHeight));
+        } catch {
+          return setBoxCache(boxKey, hollowWalls);
+        }
         scope.register(hollowWalls); // consumed by fuse
 
         // Combine walls with lowered interior fill
@@ -161,7 +168,15 @@ export function buildBinBox(
     }
 
     const topFaces = faceFinder().parallelTo('Z').atDistance(wallHeight, [0, 0, 0]).findAll(box);
-    const result = unwrap(shell(box as ValidSolid, topFaces, wallThickness));
+    // For polygon masks the shell operation can fail on narrow features
+    // where wallThickness consumes the interior; fall back to the solid
+    // extrusion in that case.
+    let result: Shape3D;
+    try {
+      result = unwrap(shell(box as ValidSolid, topFaces, wallThickness));
+    } catch {
+      return setBoxCache(boxKey, box);
+    }
     scope.register(box); // consumed by shell
     return setBoxCache(boxKey, result);
   });

--- a/src/features/generation/worker/generators/maskPolygon.test.ts
+++ b/src/features/generation/worker/generators/maskPolygon.test.ts
@@ -2,11 +2,10 @@
 /**
  * Tests for the mask → brepjs Drawing converter.
  *
- * These tests require a live brepjs kernel because `Drawing.offset(...)`
- * must succeed to produce the inward-inset polygon. The spike test already
- * confirmed offset works for concave shapes; here we verify the helper
- * wires gridUnit → mm correctly and preserves the rectangle/L/T bbox after
- * offset inset.
+ * Verifies the helper wires gridUnit → mm correctly and preserves the
+ * rectangle/L/T bbox after inset. Requires a live brepjs kernel because
+ * the output is a brepjs Drawing; the inset itself is computed
+ * geometrically (see `insetAxisAlignedPolygon` in `maskPolygon.ts`).
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs } from './__dual-kernel__/wasmInit';

--- a/src/features/generation/worker/generators/maskPolygon.test.ts
+++ b/src/features/generation/worker/generators/maskPolygon.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+/**
+ * Tests for the mask → brepjs Drawing converter.
+ *
+ * These tests require a live brepjs kernel because `Drawing.offset(...)`
+ * must succeed to produce the inward-inset polygon. The spike test already
+ * confirmed offset works for concave shapes; here we verify the helper
+ * wires gridUnit → mm correctly and preserves the rectangle/L/T bbox after
+ * offset inset.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs } from './__dual-kernel__/wasmInit';
+import { buildFullMask, type CellMask } from '@/shared/utils/cellMask';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30_000);
+
+/** Build a mask from a visually top-first 2D array. */
+function mask(rows: (0 | 1)[][]): CellMask {
+  const bottomFirst = rows.slice().reverse();
+  const cols = bottomFirst[0]?.length ?? 0;
+  return { cols, rows: bottomFirst.length, cells: bottomFirst.flat() };
+}
+
+describe('buildMaskDrawing', () => {
+  it('builds a centered polygon with bbox matching a 2×2 full-mask footprint', async () => {
+    const { buildMaskDrawing } = await import('./maskPolygon');
+    const full = buildFullMask(2, 2); // 4×4 mask, 2 grid units per side = 84mm
+    const drawing = buildMaskDrawing(full, 42);
+    const bb = drawing.boundingBox;
+    // 2 grid units = 84mm, minus CLEARANCE (0.5mm total from offset -0.25 each side) → 83.5mm
+    expect(bb.bounds[1][0] - bb.bounds[0][0]).toBeCloseTo(83.5, 2);
+    expect(bb.bounds[1][1] - bb.bounds[0][1]).toBeCloseTo(83.5, 2);
+    // Centered on origin
+    expect((bb.bounds[0][0] + bb.bounds[1][0]) / 2).toBeCloseTo(0, 3);
+    expect((bb.bounds[0][1] + bb.bounds[1][1]) / 2).toBeCloseTo(0, 3);
+  });
+
+  it('preserves L-shape bbox dimensions (3×3 with BR corner missing)', async () => {
+    const { buildMaskDrawing } = await import('./maskPolygon');
+    const lMask = mask([
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 0, 0],
+      [1, 1, 1, 1, 0, 0],
+    ]);
+    const drawing = buildMaskDrawing(lMask, 42);
+    const bb = drawing.boundingBox;
+    // 3 grid units = 126mm minus CLEARANCE → 125.5mm
+    expect(bb.bounds[1][0] - bb.bounds[0][0]).toBeCloseTo(125.5, 2);
+    expect(bb.bounds[1][1] - bb.bounds[0][1]).toBeCloseTo(125.5, 2);
+  });
+
+  it('scales with gridUnitMm', async () => {
+    const { buildMaskDrawing } = await import('./maskPolygon');
+    const full = buildFullMask(1, 1);
+    const drawing50 = buildMaskDrawing(full, 50);
+    const bb = drawing50.boundingBox;
+    // 1 grid unit at 50mm/unit = 50mm minus CLEARANCE → 49.5mm
+    expect(bb.bounds[1][0] - bb.bounds[0][0]).toBeCloseTo(49.5, 2);
+  });
+
+  it('throws for a single-cell (degenerate) polygon', async () => {
+    const { buildMaskDrawing } = await import('./maskPolygon');
+    // 1×1 mask with a single filled cell is still 4 corners → valid.
+    // To force a degenerate polygon we'd need <3 corners, which mask->polygon
+    // never produces. The throw path is a defensive guard — assert it by
+    // constructing an impossible mask directly.
+    const impossible: CellMask = { cols: 1, rows: 1, cells: [1] };
+    // This succeeds because any non-empty mask has ≥4 corners.
+    const d = buildMaskDrawing(impossible, 42);
+    expect(d).toBeDefined();
+  });
+});
+
+describe('buildMaskDrawingInset', () => {
+  it('produces a smaller polygon than the outer drawing', async () => {
+    const { buildMaskDrawing, buildMaskDrawingInset } = await import('./maskPolygon');
+    const lMask = mask([
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 0, 0],
+      [1, 1, 1, 1, 0, 0],
+    ]);
+    const outer = buildMaskDrawing(lMask, 42).boundingBox;
+    const inner = buildMaskDrawingInset(lMask, 42, 2.6).boundingBox;
+    // Inset by 2.6mm per side → outer bbox shrinks by ~5.2mm in each dim
+    expect(inner.bounds[1][0] - inner.bounds[0][0]).toBeLessThan(
+      outer.bounds[1][0] - outer.bounds[0][0] - 5
+    );
+    expect(inner.bounds[1][1] - inner.bounds[0][1]).toBeLessThan(
+      outer.bounds[1][1] - outer.bounds[0][1] - 5
+    );
+  });
+});

--- a/src/features/generation/worker/generators/maskPolygon.ts
+++ b/src/features/generation/worker/generators/maskPolygon.ts
@@ -10,6 +10,11 @@
  * Adding outer-corner fillets so L-shapes match rectangular `BOX_CORNER_RADIUS`
  * is a follow-up — brepjs's `Drawing.fillet(radius, filter)` needs a
  * convex-vs-concave corner finder, which we leave for a separate PR.
+ *
+ * All insets are applied in a SINGLE `offset()` call on the raw sharp
+ * polygon. Chaining two `.offset(...)` calls on the same concave polygon
+ * triggers brepjs's `POINT_NOT_ON_CURVE` error (rounded corners from the
+ * first offset split edge curves, making subsequent offsets degenerate).
  */
 import { draw } from 'brepjs';
 import type { Drawing } from 'brepjs';
@@ -17,16 +22,10 @@ import { CLEARANCE } from './generatorConstants';
 import { MASK_CELL_SIZE, maskToPolygon, type CellMask } from '@/shared/utils/cellMask';
 
 /**
- * Build a Drawing of the mask's outer polygon, centered on the origin,
- * inset by `CLEARANCE / 2` on each side (matching the rectangle path).
- *
- * The returned Drawing is closed (first vertex == last vertex logically)
- * and suitable for `.sketchOnPlane(...)` + `.extrude(...)` or `.loftWith(...)`.
- *
- * @throws if the polygon has fewer than 3 vertices (caller should
- *   validate the mask first).
+ * Build the raw sharp-cornered polygon for the mask, centered on origin.
+ * Internal helper; callers choose the total inset applied via `.offset()`.
  */
-export function buildMaskDrawing(mask: CellMask, gridUnitMm: number): Drawing {
+function buildRawMaskPolygon(mask: CellMask, gridUnitMm: number): Drawing {
   const vertices = maskToPolygon(mask);
   if (vertices.length < 3) {
     throw new Error(`mask polygon has only ${vertices.length} vertices (need 3+)`);
@@ -45,19 +44,25 @@ export function buildMaskDrawing(mask: CellMask, gridUnitMm: number): Drawing {
   for (let i = 1; i < vertices.length; i++) {
     pen = pen.lineTo(toMm(vertices[i]));
   }
-  const polygon = pen.close();
-
-  // Inset by CLEARANCE/2 so the polygon's nominal dimensions match what
-  // `drawRoundedRectangle(w - CLEARANCE, d - CLEARANCE)` produces for the
-  // rectangle path. The spike confirmed brepjs handles concave offsets.
-  return polygon.offset(-CLEARANCE / 2);
+  return pen.close();
 }
 
 /**
- * Build an inner polygon Drawing offset inward by `inset` mm.
- * Used by the lip builder for inner frustum sections.
+ * Outer polygon: sharp perimeter inset by `CLEARANCE / 2` to match the
+ * tolerance gap used by the rectangle path (`w - CLEARANCE`).
+ *
+ * @throws if the polygon has fewer than 3 vertices (caller should
+ *   validate the mask first).
+ */
+export function buildMaskDrawing(mask: CellMask, gridUnitMm: number): Drawing {
+  return buildRawMaskPolygon(mask, gridUnitMm).offset(-CLEARANCE / 2);
+}
+
+/**
+ * Inner polygon: sharp perimeter inset by `CLEARANCE / 2 + inset` in a
+ * single `offset()` call. Used by the lip builder for inner frustum
+ * sections where each Z level insets a different amount.
  */
 export function buildMaskDrawingInset(mask: CellMask, gridUnitMm: number, inset: number): Drawing {
-  const outer = buildMaskDrawing(mask, gridUnitMm);
-  return outer.offset(-inset);
+  return buildRawMaskPolygon(mask, gridUnitMm).offset(-(CLEARANCE / 2 + inset));
 }

--- a/src/features/generation/worker/generators/maskPolygon.ts
+++ b/src/features/generation/worker/generators/maskPolygon.ts
@@ -11,38 +11,76 @@
  * is a follow-up — brepjs's `Drawing.fillet(radius, filter)` needs a
  * convex-vs-concave corner finder, which we leave for a separate PR.
  *
- * All insets are applied in a SINGLE `offset()` call on the raw sharp
- * polygon. Chaining two `.offset(...)` calls on the same concave polygon
- * triggers brepjs's `POINT_NOT_ON_CURVE` error (rounded corners from the
- * first offset split edge curves, making subsequent offsets degenerate).
+ * Insets are computed geometrically on the polygon vertices rather than via
+ * `Drawing.offset()`. brepjs 15.x returns a silently-empty Drawing when
+ * `offset()` runs on a concave polygon, which later crashes `sketchOnPlane`
+ * with "empty drawing". Since every mask polygon is axis-aligned with 90°
+ * turns, we can shift each edge perpendicular-inward by the inset distance
+ * and recompute vertex intersections in closed form.
  */
 import { draw } from 'brepjs';
 import type { Drawing } from 'brepjs';
 import { CLEARANCE } from './generatorConstants';
 import { MASK_CELL_SIZE, maskToPolygon, type CellMask } from '@/shared/utils/cellMask';
 
+interface Point2Mm {
+  readonly x: number;
+  readonly y: number;
+}
+
 /**
- * Build the raw sharp-cornered polygon for the mask, centered on origin.
- * Internal helper; callers choose the total inset applied via `.offset()`.
+ * Inset an axis-aligned CCW polygon by `inset` mm, moving every edge
+ * perpendicular-inward. Every edge is horizontal or vertical and every
+ * turn is 90° (mask polygons are produced by `maskToPolygon`), so the new
+ * vertex is the intersection of the two inset-shifted edges.
+ *
+ * For a CCW polygon the interior lies on the LEFT of each edge direction.
+ * The interior-pointing normal at a 90° corner is the sum of the two
+ * adjacent edges' left-normals; shifting the vertex by `inset *` that sum
+ * places it at the intersection of the two shifted edges.
  */
-function buildRawMaskPolygon(mask: CellMask, gridUnitMm: number): Drawing {
-  const vertices = maskToPolygon(mask);
-  if (vertices.length < 3) {
-    throw new Error(`mask polygon has only ${vertices.length} vertices (need 3+)`);
+function insetAxisAlignedPolygon(vertices: readonly Point2Mm[], inset: number): Point2Mm[] {
+  const n = vertices.length;
+  const result: Point2Mm[] = [];
+  for (let i = 0; i < n; i++) {
+    const prev = vertices[(i - 1 + n) % n];
+    const cur = vertices[i];
+    const next = vertices[(i + 1) % n];
+
+    const dxIn = Math.sign(cur.x - prev.x);
+    const dyIn = Math.sign(cur.y - prev.y);
+    const dxOut = Math.sign(next.x - cur.x);
+    const dyOut = Math.sign(next.y - cur.y);
+
+    // Left-normal of direction (dx, dy) is (-dy, dx).
+    const nx = -dyIn + -dyOut;
+    const ny = dxIn + dxOut;
+
+    result.push({ x: cur.x + inset * nx, y: cur.y + inset * ny });
+  }
+  return result;
+}
+
+/** Build a closed Drawing from mask vertices at given total inset (mm, non-negative). */
+function buildMaskDrawingAtInset(mask: CellMask, gridUnitMm: number, insetMm: number): Drawing {
+  const gridVertices = maskToPolygon(mask);
+  if (gridVertices.length < 3) {
+    throw new Error(`mask polygon has only ${gridVertices.length} vertices (need 3+)`);
   }
 
   const halfWidthMm = (mask.cols * MASK_CELL_SIZE * gridUnitMm) / 2;
   const halfDepthMm = (mask.rows * MASK_CELL_SIZE * gridUnitMm) / 2;
 
-  const toMm = (p: { x: number; y: number }): [number, number] => [
-    p.x * gridUnitMm - halfWidthMm,
-    p.y * gridUnitMm - halfDepthMm,
-  ];
+  const mmVertices: Point2Mm[] = gridVertices.map((p) => ({
+    x: p.x * gridUnitMm - halfWidthMm,
+    y: p.y * gridUnitMm - halfDepthMm,
+  }));
 
-  const first = toMm(vertices[0]);
-  let pen = draw(first);
-  for (let i = 1; i < vertices.length; i++) {
-    pen = pen.lineTo(toMm(vertices[i]));
+  const shrunk = insetMm > 0 ? insetAxisAlignedPolygon(mmVertices, insetMm) : mmVertices;
+
+  let pen = draw([shrunk[0].x, shrunk[0].y]);
+  for (let i = 1; i < shrunk.length; i++) {
+    pen = pen.lineTo([shrunk[i].x, shrunk[i].y]);
   }
   return pen.close();
 }
@@ -55,14 +93,14 @@ function buildRawMaskPolygon(mask: CellMask, gridUnitMm: number): Drawing {
  *   validate the mask first).
  */
 export function buildMaskDrawing(mask: CellMask, gridUnitMm: number): Drawing {
-  return buildRawMaskPolygon(mask, gridUnitMm).offset(-CLEARANCE / 2);
+  return buildMaskDrawingAtInset(mask, gridUnitMm, CLEARANCE / 2);
 }
 
 /**
- * Inner polygon: sharp perimeter inset by `CLEARANCE / 2 + inset` in a
- * single `offset()` call. Used by the lip builder for inner frustum
- * sections where each Z level insets a different amount.
+ * Inner polygon: sharp perimeter inset by `CLEARANCE / 2 + inset`. Used by
+ * the lip builder and inner-fill paths where each Z level insets a different
+ * amount.
  */
 export function buildMaskDrawingInset(mask: CellMask, gridUnitMm: number, inset: number): Drawing {
-  return buildRawMaskPolygon(mask, gridUnitMm).offset(-(CLEARANCE / 2 + inset));
+  return buildMaskDrawingAtInset(mask, gridUnitMm, CLEARANCE / 2 + inset);
 }

--- a/src/features/generation/worker/generators/maskPolygon.ts
+++ b/src/features/generation/worker/generators/maskPolygon.ts
@@ -1,0 +1,63 @@
+/**
+ * Mask → brepjs Drawing converter for non-rectangular bin footprints.
+ *
+ * Converts a {@link CellMask} into a closed Drawing suitable for extrusion
+ * or lofting. The polygon is centered on the origin (like the rectangular
+ * `drawRoundedRectangle` path) and shrunk by `CLEARANCE / 2` on each side
+ * to match the tolerance gap used by standard Gridfinity bins.
+ *
+ * v1 uses sharp corners at every vertex (convex and concave alike).
+ * Adding outer-corner fillets so L-shapes match rectangular `BOX_CORNER_RADIUS`
+ * is a follow-up — brepjs's `Drawing.fillet(radius, filter)` needs a
+ * convex-vs-concave corner finder, which we leave for a separate PR.
+ */
+import { draw } from 'brepjs';
+import type { Drawing } from 'brepjs';
+import { CLEARANCE } from './generatorConstants';
+import { MASK_CELL_SIZE, maskToPolygon, type CellMask } from '@/shared/utils/cellMask';
+
+/**
+ * Build a Drawing of the mask's outer polygon, centered on the origin,
+ * inset by `CLEARANCE / 2` on each side (matching the rectangle path).
+ *
+ * The returned Drawing is closed (first vertex == last vertex logically)
+ * and suitable for `.sketchOnPlane(...)` + `.extrude(...)` or `.loftWith(...)`.
+ *
+ * @throws if the polygon has fewer than 3 vertices (caller should
+ *   validate the mask first).
+ */
+export function buildMaskDrawing(mask: CellMask, gridUnitMm: number): Drawing {
+  const vertices = maskToPolygon(mask);
+  if (vertices.length < 3) {
+    throw new Error(`mask polygon has only ${vertices.length} vertices (need 3+)`);
+  }
+
+  const halfWidthMm = (mask.cols * MASK_CELL_SIZE * gridUnitMm) / 2;
+  const halfDepthMm = (mask.rows * MASK_CELL_SIZE * gridUnitMm) / 2;
+
+  const toMm = (p: { x: number; y: number }): [number, number] => [
+    p.x * gridUnitMm - halfWidthMm,
+    p.y * gridUnitMm - halfDepthMm,
+  ];
+
+  const first = toMm(vertices[0]);
+  let pen = draw(first);
+  for (let i = 1; i < vertices.length; i++) {
+    pen = pen.lineTo(toMm(vertices[i]));
+  }
+  const polygon = pen.close();
+
+  // Inset by CLEARANCE/2 so the polygon's nominal dimensions match what
+  // `drawRoundedRectangle(w - CLEARANCE, d - CLEARANCE)` produces for the
+  // rectangle path. The spike confirmed brepjs handles concave offsets.
+  return polygon.offset(-CLEARANCE / 2);
+}
+
+/**
+ * Build an inner polygon Drawing offset inward by `inset` mm.
+ * Used by the lip builder for inner frustum sections.
+ */
+export function buildMaskDrawingInset(mask: CellMask, gridUnitMm: number, inset: number): Drawing {
+  const outer = buildMaskDrawing(mask, gridUnitMm);
+  return outer.offset(-inset);
+}

--- a/src/features/generation/worker/generators/pipeline/context.test.ts
+++ b/src/features/generation/worker/generators/pipeline/context.test.ts
@@ -108,7 +108,8 @@ describe('createInitialContext', () => {
     const ctx = createInitialContext(createTestParams());
 
     // shellKey uses buildCacheKey with v5 prefix, gridUnitMm, and quantized floats
-    // forExport is no longer in the key since shell geometry is identical for preview/export
+    // forExport is no longer in the key since shell geometry is identical for preview/export.
+    // Final segment is 'rect' when no cellMask is in use; mask hash otherwise.
     const expected = [
       'v5',
       2,
@@ -125,6 +126,7 @@ describe('createInitialContext', () => {
       1.2,
       false,
       false,
+      'rect',
     ].join('|');
 
     expect(ctx.dimensions.shellKey).toBe(expected);

--- a/src/features/generation/worker/generators/pipeline/context.test.ts
+++ b/src/features/generation/worker/generators/pipeline/context.test.ts
@@ -1,70 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { createInitialContext } from './context';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import type { BinParams } from '@/shared/types/bin';
 
-function createTestParams(overrides?: Record<string, unknown>): BinParams {
+// Source from DEFAULT_BIN_PARAMS so the fixture tracks the real BinParams
+// shape automatically. Tests below expect a no-lip baseline, so override
+// base.stackingLip off; all other fields flow through the defaults.
+function createTestParams(overrides?: Partial<BinParams>): BinParams {
   return {
-    width: 2,
-    depth: 2,
-    height: 3,
-    wallThickness: 1.2,
-    style: 'standard',
-    base: {
-      style: 'plain',
-      stackingLip: false,
-      halfSockets: false,
-      solid: false,
-      magnetDiameter: 6,
-      magnetDepth: 2,
-      screwDiameter: 3,
-    },
-    compartments: {
-      cols: 1,
-      rows: 1,
-      thickness: 1.2,
-      cells: [0],
-    },
-    label: {
-      enabled: false,
-      depth: 12,
-      width: 100,
-      alignment: 'center',
-      support: 'bracket',
-    },
-    scoop: { enabled: false, radius: 21 },
-    inserts: [],
-    cutoutConfig: {
-      topOffset: 0,
-      shape: 'roundedRect',
-      cornerRadius: 3.75,
-      enabled: false,
-      widthPercent: 100,
-      depthPercent: 100,
-      isGrouped: false,
-    },
-    walls: {
-      enabled: false,
-      height: 50,
-      cornerRadius: 2,
-      sides: { front: true, back: true, left: true, right: true },
-    },
-    wallPattern: {
-      enabled: false,
-      pattern: 'honeycomb',
-      size: 5,
-      spacing: 1.5,
-      sides: { front: true, back: true, left: true, right: true },
-    },
-    slotConfig: {
-      width: 5,
-      depth: 10,
-      spacing: 10,
-      sides: { front: false, back: false, left: false, right: false },
-    },
-    gridUnitMm: 42,
-    heightUnitMm: 7,
+    ...DEFAULT_BIN_PARAMS,
+    base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
     ...overrides,
-  } as BinParams;
+  };
 }
 
 describe('createInitialContext', () => {
@@ -119,7 +66,7 @@ describe('createInitialContext', () => {
       false,
       false,
       false,
-      6,
+      6.5,
       2,
       3,
       16,

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -7,6 +7,7 @@
 
 import type { BinParams } from '@/shared/types/bin';
 import { GRIDFINITY } from '@/shared/constants/bin';
+import { hashMask, isAllFilled } from '@/shared/utils/cellMask';
 import { SIZE, CLEARANCE, SOCKET_HEIGHT, LIP_SMALL_TAPER } from '../generatorConstants';
 // SIZE is kept as a fallback default for backwards compatibility with callers
 // that construct BinParams without gridUnitMm.
@@ -42,7 +43,12 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
   // already clears the actual lip base at wallHeight - LIP_OVERLAP.
   const interiorHeight = hasLip ? wallHeight - LIP_SMALL_TAPER : wallHeight;
 
-  // Shell cache key — versioned + quantized for deterministic matching
+  // Shell cache key — versioned + quantized for deterministic matching.
+  // Mask hash is included only when the mask triggers the polygon path so
+  // rectangular bins continue to share the existing cache bucket.
+  const { cellMask } = params;
+  const maskKeySegment =
+    cellMask !== undefined && !isAllFilled(cellMask) ? hashMask(cellMask) : 'rect';
   const shellKey = compactKey(
     buildCacheKey(
       'v5',
@@ -59,7 +65,8 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
       quantize(wallHeight),
       quantize(params.wallThickness),
       params.base.stackingLip,
-      solid
+      solid,
+      maskKeySegment
     )
   );
 

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -7,7 +7,7 @@
 
 import type { BinParams } from '@/shared/types/bin';
 import { GRIDFINITY } from '@/shared/constants/bin';
-import { hashMask, isAllFilled } from '@/shared/utils/cellMask';
+import { hashMask, isPartialMask } from '@/shared/utils/cellMask';
 import { SIZE, CLEARANCE, SOCKET_HEIGHT, LIP_SMALL_TAPER } from '../generatorConstants';
 // SIZE is kept as a fallback default for backwards compatibility with callers
 // that construct BinParams without gridUnitMm.
@@ -47,8 +47,7 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
   // Mask hash is included only when the mask triggers the polygon path so
   // rectangular bins continue to share the existing cache bucket.
   const { cellMask } = params;
-  const maskKeySegment =
-    cellMask !== undefined && !isAllFilled(cellMask) ? hashMask(cellMask) : 'rect';
+  const maskKeySegment = isPartialMask(cellMask) ? hashMask(cellMask) : 'rect';
   const shellKey = compactKey(
     buildCacheKey(
       'v5',

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -13,7 +13,7 @@
  */
 
 import { unwrap, cut } from 'brepjs';
-import { isAllFilled } from '@/shared/utils/cellMask';
+import { isPartialMask } from '@/shared/utils/cellMask';
 import type { PipelineContext, PipelineStage } from '../types';
 import { buildCutoutCuts } from '../../featureBuilder';
 import { FeatureTag } from '../../featureTags';
@@ -32,8 +32,7 @@ export const featuresStage: PipelineStage = {
     // The shape-model refactor does not yet teach compartments, cutouts,
     // walls, handles, inserts, scoops, or label tabs how to operate on a
     // non-rectangular bounding region. Follow-up PRs will lift this.
-    const usingMask = ctx.params.cellMask !== undefined && !isAllFilled(ctx.params.cellMask);
-    if (usingMask) return false;
+    if (isPartialMask(ctx.params.cellMask)) return false;
     return innerW > 0 && innerD > 0;
   },
 

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -13,6 +13,7 @@
  */
 
 import { unwrap, cut } from 'brepjs';
+import { isAllFilled } from '@/shared/utils/cellMask';
 import type { PipelineContext, PipelineStage } from '../types';
 import { buildCutoutCuts } from '../../featureBuilder';
 import { FeatureTag } from '../../featureTags';
@@ -27,6 +28,12 @@ export const featuresStage: PipelineStage = {
 
   shouldRun(ctx: PipelineContext): boolean {
     const { innerW, innerD } = ctx.dimensions;
+    // Non-rectangular footprints skip all interior features in v1.
+    // The shape-model refactor does not yet teach compartments, cutouts,
+    // walls, handles, inserts, scoops, or label tabs how to operate on a
+    // non-rectangular bounding region. Follow-up PRs will lift this.
+    const usingMask = ctx.params.cellMask !== undefined && !isAllFilled(ctx.params.cellMask);
+    if (usingMask) return false;
     return innerW > 0 && innerD > 0;
   },
 

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -49,7 +49,8 @@ export const shellStage: PipelineStage = {
         params.wallThickness,
         dim.solid,
         cutoutTopOffset,
-        params.gridUnitMm
+        params.gridUnitMm,
+        params.cellMask
       );
       collectOrigins(binBody, FeatureTag.BASE, originToTag);
 
@@ -62,7 +63,7 @@ export const shellStage: PipelineStage = {
             // the scope disposes that intermediate after translate produces
             // the positioned copy.
             const lipBase = scope.register(
-              buildTopShape(params.width, params.depth, true, params.gridUnitMm)
+              buildTopShape(params.width, params.depth, true, params.gridUnitMm, params.cellMask)
             );
             const top = scope.register(translate(lipBase, [0, 0, dim.wallHeight - LIP_OVERLAP]));
             collectOrigins(top, FeatureTag.LIP, originToTag);
@@ -97,7 +98,8 @@ export const shellStage: PipelineStage = {
           params.base.screwDiameter / 2,
           true, // Always use full 5-section socket profile (OCCT v8 is fast enough)
           dim.halfSockets,
-          params.gridUnitMm
+          params.gridUnitMm,
+          params.cellMask
         )
       );
       collectOrigins(base, FeatureTag.SOCKET, originToTag);
@@ -110,7 +112,7 @@ export const shellStage: PipelineStage = {
           // the scope disposes that intermediate after translate produces
           // the positioned copy.
           const lipBase = scope.register(
-            buildTopShape(params.width, params.depth, true, params.gridUnitMm)
+            buildTopShape(params.width, params.depth, true, params.gridUnitMm, params.cellMask)
           );
           const top = scope.register(translate(lipBase, [0, 0, dim.wallHeight - LIP_OVERLAP]));
           collectOrigins(top, FeatureTag.LIP, originToTag);

--- a/src/features/generation/worker/generators/scenarios/customShape.ts
+++ b/src/features/generation/worker/generators/scenarios/customShape.ts
@@ -1,0 +1,126 @@
+/**
+ * Scenarios for non-rectangular (cellMask) bin footprints.
+ *
+ * Each fixture tests a different boundary of the polygon code path:
+ *   - L: one concave corner, asymmetric perimeter
+ *   - T: two concave corners + a thin middle arm
+ *   - U: two concave corners + U-shaped interior (longest perimeter)
+ *   - half-bin L: half-cell resolution, validates mask granularity end-to-end
+ *
+ * All fixtures produce meshes; triangle counts are snapshotted. When
+ * verified visually correct, update with:
+ *   pnpm run test:run -- -u src/features/generation/worker/generators/binGenerator.scenario.test
+ */
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { CellMask } from '@/shared/utils/cellMask';
+import { defineScenario } from '../__dual-kernel__/scenarioTypes';
+import type { ScenarioCase } from '../__dual-kernel__/scenarioTypes';
+
+/**
+ * Build a cellMask at half-bin resolution from a 2D array where row 0 is
+ * the top (reader-friendly). Returned mask uses bottom-first row ordering.
+ */
+function buildMask(rows: (0 | 1)[][]): CellMask {
+  const bottomFirst = rows.slice().reverse();
+  const cols = bottomFirst[0]?.length ?? 0;
+  return { cols, rows: bottomFirst.length, cells: bottomFirst.flat() };
+}
+
+/**
+ * 3×3 L-shape with the bottom-right corner (a full 1×1 grid cell) removed.
+ * Half-bin resolution: 6×6 mask with bottom-right 2×2 sub-cells empty.
+ */
+const L_SHAPE_MASK: CellMask = buildMask([
+  [1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 0, 0],
+  [1, 1, 1, 1, 0, 0],
+]);
+
+/**
+ * 3×3 T-shape: top row full, bottom two rows have only the center 1×1 cell.
+ *   [ 1 1 1 ]
+ *   [ 0 1 0 ]
+ *   [ 0 1 0 ]
+ */
+const T_SHAPE_MASK: CellMask = buildMask([
+  [1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1],
+  [0, 0, 1, 1, 0, 0],
+  [0, 0, 1, 1, 0, 0],
+  [0, 0, 1, 1, 0, 0],
+  [0, 0, 1, 1, 0, 0],
+]);
+
+/**
+ * 3×3 U-shape: outer frame filled, center middle cell empty.
+ *   [ 1 1 1 ]
+ *   [ 1 0 1 ]
+ *   [ 1 1 1 ]
+ */
+const U_SHAPE_MASK: CellMask = buildMask([
+  [1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1],
+  [1, 1, 0, 0, 1, 1],
+  [1, 1, 0, 0, 1, 1],
+  [1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1],
+]);
+
+/**
+ * Half-bin L: 1.5×1.5 bin where the bottom-right half-cell is empty.
+ * Mask is 3×3 at half-bin resolution.
+ *   [ 1 1 1 ]
+ *   [ 1 1 1 ]
+ *   [ 1 1 0 ]
+ */
+const HALF_L_MASK: CellMask = buildMask([
+  [1, 1, 1],
+  [1, 1, 1],
+  [1, 1, 0],
+]);
+
+export const customShapes: ScenarioCase[] = [
+  defineScenario('custom-shape', '3×3 L with lip', {
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: L_SHAPE_MASK,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+  }),
+  defineScenario('custom-shape', '3×3 L flat base no lip', {
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: L_SHAPE_MASK,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat', stackingLip: false },
+    },
+  }),
+  defineScenario('custom-shape', '3×3 T with lip', {
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: T_SHAPE_MASK,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+  }),
+  defineScenario('custom-shape', '3×3 U with lip', {
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: U_SHAPE_MASK,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+  }),
+  defineScenario('custom-shape', '1.5×1.5 half-bin L with lip', {
+    params: {
+      width: 1.5,
+      depth: 1.5,
+      cellMask: HALF_L_MASK,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true, halfSockets: true },
+    },
+  }),
+];

--- a/src/features/generation/worker/generators/scenarios/customShape.ts
+++ b/src/features/generation/worker/generators/scenarios/customShape.ts
@@ -55,14 +55,14 @@ const T_SHAPE_MASK: CellMask = buildMask([
 ]);
 
 /**
- * 3×3 U-shape: outer frame filled, center middle cell empty.
- *   [ 1 1 1 ]
+ * 3×3 U-shape: left/right columns + bottom row filled, open at the top.
+ *   [ 1 0 1 ]
  *   [ 1 0 1 ]
  *   [ 1 1 1 ]
  */
 const U_SHAPE_MASK: CellMask = buildMask([
-  [1, 1, 1, 1, 1, 1],
-  [1, 1, 1, 1, 1, 1],
+  [1, 1, 0, 0, 1, 1],
+  [1, 1, 0, 0, 1, 1],
   [1, 1, 0, 0, 1, 1],
   [1, 1, 0, 0, 1, 1],
   [1, 1, 1, 1, 1, 1],

--- a/src/features/generation/worker/generators/scenarios/index.ts
+++ b/src/features/generation/worker/generators/scenarios/index.ts
@@ -30,6 +30,7 @@ import { groupedScoop } from './groupedScoop';
 import { lipWall } from './lipWall';
 import { handles } from './handles';
 import { honeycombJunction } from './honeycombJunction';
+import { customShapes } from './customShape';
 
 export type { ScenarioCase } from '../__dual-kernel__/scenarioTypes';
 
@@ -61,4 +62,5 @@ export const ALL_SCENARIOS: readonly ScenarioCase[] = [
   ...lipWall,
   ...handles,
   ...honeycombJunction,
+  ...customShapes,
 ];

--- a/src/features/generation/worker/generators/shapeCache.test.ts
+++ b/src/features/generation/worker/generators/shapeCache.test.ts
@@ -20,7 +20,7 @@ function mockShape(): Shape3D & { delete: ReturnType<typeof vi.fn> } {
 describe('socketCacheKey', () => {
   it('produces deterministic versioned key from parameters', () => {
     const key = socketCacheKey(2, 2, true, false, 3.1, 2.0, 1.5, false, false);
-    expect(key).toBe('v2|2|2|42|true|false|3.1|2|1.5|false|false');
+    expect(key).toBe('v2|2|2|42|true|false|3.1|2|1.5|false|false|rect');
   });
 
   it('differs when magnet flag changes', () => {

--- a/src/features/generation/worker/generators/shapeCache.ts
+++ b/src/features/generation/worker/generators/shapeCache.ts
@@ -103,7 +103,8 @@ export function socketCacheKey(
   screwRadius: number,
   forExport: boolean,
   halfSockets: boolean,
-  gridUnitMm: number = GRIDFINITY.GRID_SIZE
+  gridUnitMm: number = GRIDFINITY.GRID_SIZE,
+  maskHash?: string
 ): string {
   return compactKey(
     buildCacheKey(
@@ -117,7 +118,8 @@ export function socketCacheKey(
       quantize(magnetDepth),
       quantize(screwRadius),
       forExport,
-      halfSockets
+      halfSockets,
+      maskHash ?? 'rect'
     )
   );
 }

--- a/src/features/generation/worker/generators/socketBuilder.ts
+++ b/src/features/generation/worker/generators/socketBuilder.ts
@@ -34,6 +34,7 @@ import {
   forEachCell,
 } from './generatorTypes';
 import { socketCacheKey, getSocketCache, setSocketCache } from './shapeCache';
+import { hashMask, isAllFilled, isRegionFilled, type CellMask } from '@/shared/utils/cellMask';
 /**
  * Build a single socket cell solid at the origin using multi-section loft.
  *
@@ -154,8 +155,13 @@ export function buildBaseSocket(
   screwRadius: number,
   forExport = false,
   halfSockets = false,
-  gridUnitMm: number = SIZE
+  gridUnitMm: number = SIZE,
+  cellMask?: CellMask
 ): Shape3D {
+  // Treat a fully-filled mask as a rectangle so the cache key and iteration
+  // path match the existing rectangular code.
+  const usingMask = cellMask !== undefined && !isAllFilled(cellMask);
+
   // Check socket cache -- skip entire build if params haven't changed
   const key = socketCacheKey(
     gridW,
@@ -167,12 +173,32 @@ export function buildBaseSocket(
     screwRadius,
     forExport,
     halfSockets,
-    gridUnitMm
+    gridUnitMm,
+    usingMask ? hashMask(cellMask) : undefined
   );
   const cached = getSocketCache(key);
   if (cached) {
     return cached;
   }
+
+  /**
+   * True when the cell with center `(centerX, centerY)` in bin-centered mm
+   * coordinates and size `wUnits × dUnits` lies entirely inside the filled
+   * region of the mask. Returns true when no mask is in use.
+   */
+  const cellInMask = (
+    centerX: number,
+    centerY: number,
+    wUnits: number,
+    dUnits: number
+  ): boolean => {
+    if (!usingMask) return true;
+    const totalW_mm = gridW * gridUnitMm;
+    const totalD_mm = gridD * gridUnitMm;
+    const leftUnit = (centerX + totalW_mm / 2 - (wUnits * gridUnitMm) / 2) / gridUnitMm;
+    const bottomUnit = (centerY + totalD_mm / 2 - (dUnits * gridUnitMm) / 2) / gridUnitMm;
+    return isRegionFilled(cellMask, leftUnit, bottomUnit, wUnits, dUnits);
+  };
 
   return withScope((scope: DisposalScope) => {
     // Build and position each cell socket
@@ -182,6 +208,7 @@ export function buildBaseSocket(
       gridW,
       gridD,
       (cell) => {
+        if (!cellInMask(cell.centerX, cell.centerY, cell.widthUnits, cell.depthUnits)) return;
         const cellW_mm = cell.widthUnits * gridUnitMm - CLEARANCE;
         const cellD_mm = cell.depthUnits * gridUnitMm - CLEARANCE;
         // Use simplified 3-section socket for preview, full 5-section for export
@@ -231,6 +258,7 @@ export function buildBaseSocket(
         gridD,
         (cell) => {
           if (cell.widthUnits < 1 || cell.depthUnits < 1) return;
+          if (!cellInMask(cell.centerX, cell.centerY, cell.widthUnits, cell.depthUnits)) return;
           for (const [dx, dy] of holeOffsets) {
             holeTools.push(
               translate(scope.register(unwrap(clone(cutout))), [

--- a/src/features/generation/worker/generators/socketBuilder.ts
+++ b/src/features/generation/worker/generators/socketBuilder.ts
@@ -34,7 +34,7 @@ import {
   forEachCell,
 } from './generatorTypes';
 import { socketCacheKey, getSocketCache, setSocketCache } from './shapeCache';
-import { hashMask, isAllFilled, isRegionFilled, type CellMask } from '@/shared/utils/cellMask';
+import { hashMask, isPartialMask, isRegionFilled, type CellMask } from '@/shared/utils/cellMask';
 /**
  * Build a single socket cell solid at the origin using multi-section loft.
  *
@@ -160,7 +160,7 @@ export function buildBaseSocket(
 ): Shape3D {
   // Treat a fully-filled mask as a rectangle so the cache key and iteration
   // path match the existing rectangular code.
-  const usingMask = cellMask !== undefined && !isAllFilled(cellMask);
+  const usingMask = isPartialMask(cellMask);
 
   // Check socket cache -- skip entire build if params haven't changed
   const key = socketCacheKey(

--- a/src/shared/utils/cellMask.test.ts
+++ b/src/shared/utils/cellMask.test.ts
@@ -104,6 +104,33 @@ describe('validateMask', () => {
     expect(err?.kind).toBe('disconnected');
   });
 
+  it('rejects masks with interior holes (donut / ring)', () => {
+    // 3×3 ring: outer frame filled, center empty — the center cell is
+    // enclosed by filled cells on all four sides.
+    const err = validateMask(
+      mask([
+        [1, 1, 1],
+        [1, 0, 1],
+        [1, 1, 1],
+      ])
+    );
+    expect(err?.kind).toBe('has_holes');
+  });
+
+  it('accepts a true U-shape (empty region reaches the boundary)', () => {
+    // 3×3 U: open at the top. The center cell is empty but reaches
+    // the top edge via the empty cell above it.
+    expect(
+      validateMask(
+        mask([
+          [1, 0, 1],
+          [1, 0, 1],
+          [1, 1, 1],
+        ])
+      )
+    ).toBeNull();
+  });
+
   it('rejects masks exceeding MAX_MASK_DIMENSION', () => {
     const tooBig = MAX_MASK_DIMENSION + 1;
     const err = validateMask({ cols: tooBig, rows: 1, cells: new Array(tooBig).fill(1) });

--- a/src/shared/utils/cellMask.test.ts
+++ b/src/shared/utils/cellMask.test.ts
@@ -5,6 +5,7 @@ import {
   countFilled,
   hashMask,
   isAllFilled,
+  isPartialMask,
   isRegionFilled,
   MASK_CELL_SIZE,
   MASK_CELLS_PER_UNIT,
@@ -53,6 +54,24 @@ describe('isAllFilled / countFilled', () => {
     ]);
     expect(isAllFilled(m)).toBe(false);
     expect(countFilled(m)).toBe(8);
+  });
+});
+
+describe('isPartialMask', () => {
+  it('returns false for undefined', () => {
+    expect(isPartialMask(undefined)).toBe(false);
+  });
+
+  it('returns false for a fully-filled mask', () => {
+    expect(isPartialMask(buildFullMask(2, 2))).toBe(false);
+  });
+
+  it('returns true for a mask with at least one empty cell', () => {
+    const m = mask([
+      [1, 1],
+      [1, 0],
+    ]);
+    expect(isPartialMask(m)).toBe(true);
   });
 });
 

--- a/src/shared/utils/cellMask.test.ts
+++ b/src/shared/utils/cellMask.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildFullMask,
+  classifyShape,
+  countFilled,
+  hashMask,
+  isAllFilled,
+  isRegionFilled,
+  MASK_CELL_SIZE,
+  MASK_CELLS_PER_UNIT,
+  MAX_MASK_DIMENSION,
+  maskToPolygon,
+  resizeMask,
+  validateMask,
+  type CellMask,
+} from './cellMask';
+
+/** Build a mask from a 2D boolean array (row 0 = bottom). */
+function mask(rows: (0 | 1)[][]): CellMask {
+  const r = rows.slice().reverse(); // input comes visually top-first; flip to bottom-first
+  const cols = r[0]?.length ?? 0;
+  return { cols, rows: r.length, cells: r.flat() };
+}
+
+describe('buildFullMask', () => {
+  it('builds an all-filled mask at half-bin resolution', () => {
+    const m = buildFullMask(2, 3);
+    expect(m.cols).toBe(4); // 2 * MASK_CELLS_PER_UNIT
+    expect(m.rows).toBe(6); // 3 * MASK_CELLS_PER_UNIT
+    expect(m.cells.length).toBe(24);
+    expect(m.cells.every((c) => c === 1)).toBe(true);
+  });
+
+  it('handles half-bin widths', () => {
+    const m = buildFullMask(1.5, 1.5);
+    expect(m.cols).toBe(3);
+    expect(m.rows).toBe(3);
+  });
+});
+
+describe('isAllFilled / countFilled', () => {
+  it('detects a full mask', () => {
+    const m = buildFullMask(2, 2);
+    expect(isAllFilled(m)).toBe(true);
+    expect(countFilled(m)).toBe(16);
+  });
+
+  it('detects a partial mask', () => {
+    const m = mask([
+      [1, 1, 1],
+      [1, 1, 1],
+      [1, 1, 0],
+    ]);
+    expect(isAllFilled(m)).toBe(false);
+    expect(countFilled(m)).toBe(8);
+  });
+});
+
+describe('validateMask', () => {
+  it('accepts a full rectangle', () => {
+    expect(validateMask(buildFullMask(2, 2))).toBeNull();
+  });
+
+  it('accepts a 4-connected L-shape', () => {
+    expect(
+      validateMask(
+        mask([
+          [1, 1, 1],
+          [1, 1, 1],
+          [1, 1, 0],
+        ])
+      )
+    ).toBeNull();
+  });
+
+  it('rejects an empty mask', () => {
+    const err = validateMask(mask([[0]]));
+    expect(err?.kind).toBe('empty');
+  });
+
+  it('rejects dimension mismatch', () => {
+    const err = validateMask({ cols: 2, rows: 2, cells: [1, 1, 1] });
+    expect(err?.kind).toBe('dimension_mismatch');
+  });
+
+  it('rejects invalid cell values', () => {
+    const err = validateMask({ cols: 2, rows: 1, cells: [1, 2 as unknown as 1] });
+    expect(err?.kind).toBe('invalid_cell_value');
+  });
+
+  it('rejects disconnected components', () => {
+    // Two 1×1 cells separated by an empty one
+    const err = validateMask(mask([[1, 0, 1]]));
+    expect(err?.kind).toBe('disconnected');
+  });
+
+  it('rejects diagonal-only touching (4-connected, not 8-connected)', () => {
+    const err = validateMask(
+      mask([
+        [1, 0],
+        [0, 1],
+      ])
+    );
+    expect(err?.kind).toBe('disconnected');
+  });
+
+  it('rejects masks exceeding MAX_MASK_DIMENSION', () => {
+    const tooBig = MAX_MASK_DIMENSION + 1;
+    const err = validateMask({ cols: tooBig, rows: 1, cells: new Array(tooBig).fill(1) });
+    expect(err?.kind).toBe('out_of_bounds');
+  });
+
+  it('rejects zero or negative dimensions', () => {
+    expect(validateMask({ cols: 0, rows: 1, cells: [] })?.kind).toBe('dimension_mismatch');
+    expect(validateMask({ cols: 1, rows: -1, cells: [] })?.kind).toBe('dimension_mismatch');
+  });
+});
+
+describe('resizeMask', () => {
+  it('preserves overlap when growing', () => {
+    const m = mask([
+      [1, 0],
+      [1, 1],
+    ]);
+    const bigger = resizeMask(m, 3, 3);
+    // Old 2×2 region preserved at (cols 0-1, rows 0-1); new cells default to filled.
+    expect(bigger.cols).toBe(3);
+    expect(bigger.rows).toBe(3);
+    // row 0 = bottom (was [1,1]) + new col 2 filled
+    expect(bigger.cells.slice(0, 3)).toEqual([1, 1, 1]);
+    // row 1 = (was [1,0]) + new col 2 filled
+    expect(bigger.cells.slice(3, 6)).toEqual([1, 0, 1]);
+    // row 2 = all new, filled
+    expect(bigger.cells.slice(6, 9)).toEqual([1, 1, 1]);
+  });
+
+  it('drops cells when shrinking', () => {
+    const m = mask([
+      [1, 1, 1],
+      [1, 1, 0],
+      [1, 1, 1],
+    ]);
+    const smaller = resizeMask(m, 2, 2);
+    // Keeps bottom-left 2×2 of the original
+    expect(smaller.cols).toBe(2);
+    expect(smaller.rows).toBe(2);
+    // row 0 = bottom (was [1,1,1]) → first 2 = [1,1]
+    // row 1 = (was [1,1,0]) → first 2 = [1,1]
+    expect(smaller.cells).toEqual([1, 1, 1, 1]);
+  });
+});
+
+describe('maskToPolygon', () => {
+  it('returns 4 corners for a 1×1 rectangle', () => {
+    const m = buildFullMask(0.5, 0.5); // exactly one half-cell
+    const poly = maskToPolygon(m);
+    expect(poly).toHaveLength(4);
+    // CCW from bottom-left
+    expect(poly[0]).toEqual({ x: 0, y: 0 });
+    // Bounding box check
+    const xs = poly.map((p) => p.x);
+    const ys = poly.map((p) => p.y);
+    expect(Math.min(...xs)).toBe(0);
+    expect(Math.max(...xs)).toBeCloseTo(MASK_CELL_SIZE);
+    expect(Math.min(...ys)).toBe(0);
+    expect(Math.max(...ys)).toBeCloseTo(MASK_CELL_SIZE);
+  });
+
+  it('collapses collinear cells into 4 corners for a larger rectangle', () => {
+    const m = buildFullMask(2, 1); // 4×2 mask cells = one rectangle
+    const poly = maskToPolygon(m);
+    expect(poly).toHaveLength(4);
+    const xs = poly.map((p) => p.x);
+    const ys = poly.map((p) => p.y);
+    expect(Math.max(...xs)).toBeCloseTo(2);
+    expect(Math.max(...ys)).toBeCloseTo(1);
+  });
+
+  it('produces 6 corners for an L-shape (3×3 with BR corner missing)', () => {
+    // One full grid cell = 2 mask cells. 3×3 L with bottom-right 1×1 grid cell empty
+    // = 6×6 mask with bottom-right 2×2 cells empty.
+    const m = mask([
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 0, 0],
+      [1, 1, 1, 1, 0, 0],
+    ]);
+    const poly = maskToPolygon(m);
+    expect(poly).toHaveLength(6);
+
+    // Bounds: 3 grid units wide, 3 grid units tall
+    const xs = poly.map((p) => p.x);
+    const ys = poly.map((p) => p.y);
+    expect(Math.min(...xs)).toBe(0);
+    expect(Math.max(...xs)).toBeCloseTo(3);
+    expect(Math.min(...ys)).toBe(0);
+    expect(Math.max(...ys)).toBeCloseTo(3);
+
+    // Concave corner at (2, 1) (grid units)
+    const hasConcave = poly.some((p) => Math.abs(p.x - 2) < 1e-6 && Math.abs(p.y - 1) < 1e-6);
+    expect(hasConcave).toBe(true);
+  });
+
+  it('produces 8 corners for a T-shape', () => {
+    // 3×3 T: top row full, middle row: only center, bottom row: only center
+    //   [ 1 1 1 ]
+    //   [ 0 1 0 ]
+    //   [ 0 1 0 ]
+    // At half-bin resolution (6×6):
+    const m = mask([
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1],
+      [0, 0, 1, 1, 0, 0],
+      [0, 0, 1, 1, 0, 0],
+      [0, 0, 1, 1, 0, 0],
+      [0, 0, 1, 1, 0, 0],
+    ]);
+    const poly = maskToPolygon(m);
+    expect(poly).toHaveLength(8);
+  });
+});
+
+describe('classifyShape', () => {
+  it('returns rectangle for a full mask', () => {
+    expect(classifyShape(buildFullMask(2, 2))).toBe('rectangle');
+  });
+
+  it('returns custom for a non-full mask', () => {
+    expect(
+      classifyShape(
+        mask([
+          [1, 1, 1],
+          [1, 1, 0],
+        ])
+      )
+    ).toBe('custom');
+  });
+});
+
+describe('hashMask', () => {
+  it('is deterministic', () => {
+    const m = buildFullMask(2, 2);
+    expect(hashMask(m)).toBe(hashMask(m));
+  });
+
+  it('differs for different masks', () => {
+    const a = buildFullMask(2, 2);
+    const b = mask([
+      [1, 1, 1, 1],
+      [1, 1, 1, 1],
+      [1, 1, 1, 1],
+      [1, 1, 1, 0],
+    ]);
+    expect(hashMask(a)).not.toBe(hashMask(b));
+  });
+});
+
+describe('MASK_CELLS_PER_UNIT', () => {
+  it('matches HALF_BIN_SCALE semantics (2 sub-cells per grid unit)', () => {
+    expect(MASK_CELLS_PER_UNIT).toBe(2);
+    expect(MASK_CELL_SIZE).toBe(0.5);
+  });
+});
+
+describe('isRegionFilled', () => {
+  // 3x3 L-shape (BR corner removed), at half-bin resolution (6x6 mask)
+  const lMask = mask([
+    [1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 0, 0],
+    [1, 1, 1, 1, 0, 0],
+  ]);
+
+  it('returns true for a 1x1 region fully inside the filled area', () => {
+    // cell (0, 0) — bottom-left full grid unit of the L
+    expect(isRegionFilled(lMask, 0, 0, 1, 1)).toBe(true);
+  });
+
+  it('returns false for a 1x1 region on the missing corner', () => {
+    // cell (2, 0) — the removed bottom-right corner of the L
+    expect(isRegionFilled(lMask, 2, 0, 1, 1)).toBe(false);
+  });
+
+  it('returns false for a 1x1 region overlapping the concave boundary', () => {
+    // cell (1.5, 0) — half in, half out (right half of row 0 overlaps the missing corner)
+    expect(isRegionFilled(lMask, 1.5, 0, 1, 1)).toBe(false);
+  });
+
+  it('returns true for a half-cell inside the filled area', () => {
+    expect(isRegionFilled(lMask, 0, 0, 0.5, 0.5)).toBe(true);
+  });
+
+  it('returns false when region extends outside the mask', () => {
+    expect(isRegionFilled(lMask, 3, 0, 1, 1)).toBe(false);
+  });
+});

--- a/src/shared/utils/cellMask.ts
+++ b/src/shared/utils/cellMask.ts
@@ -65,6 +65,16 @@ export function isAllFilled(mask: CellMask): boolean {
   return true;
 }
 
+/**
+ * Type guard: `true` when the mask is defined AND has at least one empty
+ * cell — i.e., the generator should take the polygon path rather than the
+ * rectangle fast-path. An undefined mask or a fully-filled one both
+ * produce rectangles and share the existing cache bucket.
+ */
+export function isPartialMask(mask: CellMask | undefined): mask is CellMask {
+  return mask !== undefined && !isAllFilled(mask);
+}
+
 /** Count filled cells in the mask. */
 export function countFilled(mask: CellMask): number {
   let n = 0;

--- a/src/shared/utils/cellMask.ts
+++ b/src/shared/utils/cellMask.ts
@@ -1,0 +1,339 @@
+/**
+ * Cell mask utilities for non-rectangular bin footprints.
+ *
+ * A `CellMask` defines which half-bin-sized cells are filled. It uses
+ * half-bin resolution unconditionally: a `width` × `depth` bin in grid
+ * units has a `(2*width) × (2*depth)` mask. Each full grid cell is
+ * represented by a 2×2 block of mask cells.
+ *
+ * Storage invariant: mask cells are row-major with row 0 = bottom.
+ *   cells[row * cols + col] = 1 if filled, 0 if empty.
+ *
+ * A mask is "equivalent to a rectangle" when every cell is filled.
+ * The generator detects this via `isAllFilled` and falls through to
+ * the existing rectangle code path (no perf regression for the 99%
+ * case of rectangular bins).
+ */
+
+/** Always-half-bin-resolution cell mask. `cells` is row-major, origin bottom-left. */
+export interface CellMask {
+  readonly cols: number;
+  readonly rows: number;
+  /** Row-major occupancy. Length must equal `cols * rows`. Values are 0 or 1. */
+  readonly cells: (0 | 1)[];
+}
+
+/** Half-bin cells per grid unit (matches `HALF_BIN_SCALE` in core). */
+export const MASK_CELLS_PER_UNIT = 2;
+
+/** Cell size in grid units. */
+export const MASK_CELL_SIZE = 1 / MASK_CELLS_PER_UNIT;
+
+/** Hard cap: a 10×10 grid-unit bin → 20×20 mask cells = 400 cells. */
+export const MAX_MASK_DIMENSION = 10 * MASK_CELLS_PER_UNIT;
+
+/** Validation error kinds for mask checks. */
+export type MaskValidationErrorKind =
+  | 'dimension_mismatch'
+  | 'empty'
+  | 'disconnected'
+  | 'out_of_bounds'
+  | 'invalid_cell_value';
+
+export interface MaskValidationError {
+  readonly kind: MaskValidationErrorKind;
+  readonly message: string;
+}
+
+/**
+ * Build a fully-filled mask for a `width × depth` bin (in grid units).
+ * Convenience for the "all cells filled" case.
+ */
+export function buildFullMask(widthUnits: number, depthUnits: number): CellMask {
+  const cols = Math.round(widthUnits * MASK_CELLS_PER_UNIT);
+  const rows = Math.round(depthUnits * MASK_CELLS_PER_UNIT);
+  return { cols, rows, cells: new Array<0 | 1>(cols * rows).fill(1) };
+}
+
+/** True when every cell in the mask is filled (equivalent to a rectangle). */
+export function isAllFilled(mask: CellMask): boolean {
+  const { cells } = mask;
+  for (let i = 0; i < cells.length; i++) {
+    if (cells[i] !== 1) return false;
+  }
+  return true;
+}
+
+/** Count filled cells in the mask. */
+export function countFilled(mask: CellMask): number {
+  let n = 0;
+  for (const c of mask.cells) {
+    if (c === 1) n++;
+  }
+  return n;
+}
+
+/**
+ * Validate a mask. Returns `null` on success, or the first error found.
+ *
+ * Checks:
+ * - Dimensions match cells.length
+ * - Cell values are 0 or 1
+ * - At least one filled cell
+ * - Within MAX_MASK_DIMENSION bounds
+ * - All filled cells form one 4-connected component
+ */
+export function validateMask(mask: CellMask): MaskValidationError | null {
+  const { cols, rows, cells } = mask;
+
+  if (cols <= 0 || rows <= 0) {
+    return {
+      kind: 'dimension_mismatch',
+      message: `cols/rows must be positive (got ${cols}×${rows})`,
+    };
+  }
+  if (cols > MAX_MASK_DIMENSION || rows > MAX_MASK_DIMENSION) {
+    return {
+      kind: 'out_of_bounds',
+      message: `mask exceeds ${MAX_MASK_DIMENSION}×${MAX_MASK_DIMENSION} half-cells (got ${cols}×${rows})`,
+    };
+  }
+  if (cells.length !== cols * rows) {
+    return {
+      kind: 'dimension_mismatch',
+      message: `cells.length (${cells.length}) does not match cols×rows (${cols * rows})`,
+    };
+  }
+
+  let filledCount = 0;
+  let firstFilled = -1;
+  for (let i = 0; i < cells.length; i++) {
+    // Cast to number to silence TS's literal narrowing — runtime values from
+    // JSON loads or hand-built arrays may violate the 0 | 1 type.
+    const v = cells[i] as number;
+    if (v !== 0 && v !== 1) {
+      return {
+        kind: 'invalid_cell_value',
+        message: `cell ${i} has invalid value ${String(v)} (must be 0 or 1)`,
+      };
+    }
+    if (v === 1) {
+      filledCount++;
+      if (firstFilled === -1) firstFilled = i;
+    }
+  }
+
+  if (filledCount === 0) {
+    return { kind: 'empty', message: 'mask has no filled cells' };
+  }
+
+  // 4-connected single-component check via BFS from first filled cell.
+  const visited = new Uint8Array(cells.length);
+  const queue: number[] = [firstFilled];
+  visited[firstFilled] = 1;
+  let visitedCount = 1;
+
+  while (queue.length > 0) {
+    const idx = queue.pop();
+    if (idx === undefined) break;
+    const col = idx % cols;
+    const row = Math.floor(idx / cols);
+    const neighbors: Array<[number, number]> = [
+      [col - 1, row],
+      [col + 1, row],
+      [col, row - 1],
+      [col, row + 1],
+    ];
+    for (const [nc, nr] of neighbors) {
+      if (nc < 0 || nc >= cols || nr < 0 || nr >= rows) continue;
+      const nIdx = nr * cols + nc;
+      if (visited[nIdx]) continue;
+      if (cells[nIdx] !== 1) continue;
+      visited[nIdx] = 1;
+      visitedCount++;
+      queue.push(nIdx);
+    }
+  }
+
+  if (visitedCount !== filledCount) {
+    return {
+      kind: 'disconnected',
+      message: `mask has ${filledCount - visitedCount} disconnected filled cell(s); must form a single 4-connected region`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Resize a mask, preserving overlapping cells and filling new ones.
+ *
+ * - If new dims are smaller, cells outside the new bounds are dropped.
+ * - If new dims are larger, new cells default to filled (1).
+ * - If this would leave zero filled cells (e.g. all-empty mask shrunk to
+ *   exclude its filled region), the result is still returned — validation
+ *   is the caller's responsibility.
+ */
+export function resizeMask(prev: CellMask, newCols: number, newRows: number): CellMask {
+  const cells = new Array<0 | 1>(newCols * newRows);
+  for (let row = 0; row < newRows; row++) {
+    for (let col = 0; col < newCols; col++) {
+      const inPrev = col < prev.cols && row < prev.rows;
+      cells[row * newCols + col] = inPrev ? prev.cells[row * prev.cols + col] : 1;
+    }
+  }
+  return { cols: newCols, rows: newRows, cells };
+}
+
+/** Point in grid units — origin bottom-left of the bin bounding box. */
+export interface Point2 {
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * Convert a cell mask to the outer polygon of its filled region.
+ *
+ * Returns vertices in counter-clockwise order, origin at (0, 0) in grid
+ * units (NOT mm — caller multiplies by `gridUnitMm`). Vertices land only at
+ * corners where the perimeter direction changes; collinear points are
+ * elided so downstream sketch APIs see minimum-complexity polygons.
+ *
+ * Algorithm: collect every boundary edge (between filled and empty or
+ * filled and out-of-bounds), connect them head-to-tail starting from the
+ * first boundary edge at the bottom-left, and drop collinear midpoints.
+ *
+ * Preconditions: `validateMask(mask)` must return null. Passing an
+ * invalid mask yields undefined results.
+ */
+export function maskToPolygon(mask: CellMask): readonly Point2[] {
+  const { cols, rows, cells } = mask;
+  const s = MASK_CELL_SIZE;
+  const filled = (c: number, r: number): boolean =>
+    c >= 0 && c < cols && r >= 0 && r < rows && cells[r * cols + c] === 1;
+
+  // Edge: directed segment on the perimeter. Stored as {from: Point2, to: Point2}.
+  // Boundary edges are emitted with the filled region on the LEFT (so CCW ordering).
+  type Edge = {
+    readonly fx: number;
+    readonly fy: number;
+    readonly tx: number;
+    readonly ty: number;
+  };
+  const edges: Edge[] = [];
+
+  // For each filled cell, emit boundary edges (sides adjacent to empty/outside).
+  // Directions chosen so filled is on the LEFT of the edge direction (CCW hull).
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      if (cells[r * cols + c] !== 1) continue;
+      const x0 = c * s;
+      const y0 = r * s;
+      const x1 = x0 + s;
+      const y1 = y0 + s;
+      // South edge (empty below): goes +X (filled above = left of direction)
+      if (!filled(c, r - 1)) edges.push({ fx: x0, fy: y0, tx: x1, ty: y0 });
+      // East edge (empty to right): goes +Y (filled to left)
+      if (!filled(c + 1, r)) edges.push({ fx: x1, fy: y0, tx: x1, ty: y1 });
+      // North edge (empty above): goes -X (filled below = left of direction)
+      if (!filled(c, r + 1)) edges.push({ fx: x1, fy: y1, tx: x0, ty: y1 });
+      // West edge (empty to left): goes -Y (filled to right = left of direction)
+      if (!filled(c - 1, r)) edges.push({ fx: x0, fy: y1, tx: x0, ty: y0 });
+    }
+  }
+
+  // Index edges by start point for chaining.
+  const key = (x: number, y: number): string => `${x},${y}`;
+  const byStart = new Map<string, Edge>();
+  for (const e of edges) byStart.set(key(e.fx, e.fy), e);
+
+  // Start at the bottom-most, then left-most edge endpoint (canonical start).
+  edges.sort((a, b) => a.fy - b.fy || a.fx - b.fx);
+  const start = edges[0];
+
+  // Walk the chain.
+  const ordered: Edge[] = [];
+  let cur: Edge | undefined = start;
+  const seen = new Set<string>();
+  while (cur) {
+    const k = key(cur.fx, cur.fy);
+    if (seen.has(k)) break;
+    seen.add(k);
+    ordered.push(cur);
+    cur = byStart.get(key(cur.tx, cur.ty));
+  }
+
+  // Collapse collinear runs: keep only points where direction changes.
+  const result: Point2[] = [];
+  for (let i = 0; i < ordered.length; i++) {
+    const prev = ordered[(i - 1 + ordered.length) % ordered.length];
+    const e = ordered[i];
+    const prevDx = Math.sign(prev.tx - prev.fx);
+    const prevDy = Math.sign(prev.ty - prev.fy);
+    const curDx = Math.sign(e.tx - e.fx);
+    const curDy = Math.sign(e.ty - e.fy);
+    if (prevDx !== curDx || prevDy !== curDy) {
+      result.push({ x: e.fx, y: e.fy });
+    }
+  }
+  return result;
+}
+
+/**
+ * Classify a mask for filename / UI labelling.
+ *
+ * v1 returns only `'rectangle'` or `'custom'`. Classifying L/T/U/plus
+ * reliably needs care (orientations, aspect ratios, mixed-resolution
+ * half-cells) — deferred to a follow-up once real users produce shapes
+ * we can eyeball.
+ */
+export function classifyShape(mask: CellMask): 'rectangle' | 'custom' {
+  return isAllFilled(mask) ? 'rectangle' : 'custom';
+}
+
+/**
+ * True if every mask cell overlapping the rectangle `[leftUnit, leftUnit+wUnits) ×
+ * [bottomUnit, bottomUnit+dUnits)` (in grid units, origin bottom-left of the bin)
+ * is filled. Used by the generator to decide whether a per-cell socket / feature
+ * should be placed.
+ *
+ * Coordinates use a tolerance so floating-point arithmetic from
+ * `gridUnitMm` conversions round to the nearest mask cell.
+ */
+export function isRegionFilled(
+  mask: CellMask,
+  leftUnit: number,
+  bottomUnit: number,
+  wUnits: number,
+  dUnits: number
+): boolean {
+  const colStart = Math.round(leftUnit * MASK_CELLS_PER_UNIT);
+  const rowStart = Math.round(bottomUnit * MASK_CELLS_PER_UNIT);
+  const colEnd = Math.round((leftUnit + wUnits) * MASK_CELLS_PER_UNIT);
+  const rowEnd = Math.round((bottomUnit + dUnits) * MASK_CELLS_PER_UNIT);
+  if (colStart < 0 || rowStart < 0 || colEnd > mask.cols || rowEnd > mask.rows) {
+    return false;
+  }
+  for (let r = rowStart; r < rowEnd; r++) {
+    for (let c = colStart; c < colEnd; c++) {
+      if (mask.cells[r * mask.cols + c] !== 1) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Stable, short hash for a mask — suitable for inclusion in cache keys.
+ * Uses a 32-bit FNV-1a over the canonicalized `cols|rows|cells`.
+ */
+export function hashMask(mask: CellMask): string {
+  const { cols, rows, cells } = mask;
+  let h = 2166136261;
+  h = Math.imul(h ^ cols, 16777619);
+  h = Math.imul(h ^ rows, 16777619);
+  for (let i = 0; i < cells.length; i++) {
+    h = Math.imul(h ^ cells[i], 16777619);
+  }
+  // Convert to unsigned + base36 for compactness.
+  return (h >>> 0).toString(36);
+}

--- a/src/shared/utils/cellMask.ts
+++ b/src/shared/utils/cellMask.ts
@@ -37,6 +37,7 @@ export type MaskValidationErrorKind =
   | 'dimension_mismatch'
   | 'empty'
   | 'disconnected'
+  | 'has_holes'
   | 'out_of_bounds'
   | 'invalid_cell_value';
 
@@ -162,6 +163,62 @@ export function validateMask(mask: CellMask): MaskValidationError | null {
     };
   }
 
+  // Hole check: flood-fill empty cells from the outside (conceptually adding
+  // an empty border around the mask, then BFS). Any empty cell not reached is
+  // enclosed by filled cells, which would produce an invalid polygon since
+  // `maskToPolygon` only walks the outer boundary.
+  const emptyCount = cells.length - filledCount;
+  if (emptyCount > 0) {
+    const emptyVisited = new Uint8Array(cells.length);
+    const emptyQueue: number[] = [];
+    for (let c = 0; c < cols; c++) {
+      for (const r of [0, rows - 1]) {
+        const idx = r * cols + c;
+        if (cells[idx] !== 1 && !emptyVisited[idx]) {
+          emptyVisited[idx] = 1;
+          emptyQueue.push(idx);
+        }
+      }
+    }
+    for (let r = 0; r < rows; r++) {
+      for (const c of [0, cols - 1]) {
+        const idx = r * cols + c;
+        if (cells[idx] !== 1 && !emptyVisited[idx]) {
+          emptyVisited[idx] = 1;
+          emptyQueue.push(idx);
+        }
+      }
+    }
+    let emptyReached = emptyQueue.length;
+    while (emptyQueue.length > 0) {
+      const idx = emptyQueue.pop();
+      if (idx === undefined) break;
+      const col = idx % cols;
+      const row = Math.floor(idx / cols);
+      const neighbors: Array<[number, number]> = [
+        [col - 1, row],
+        [col + 1, row],
+        [col, row - 1],
+        [col, row + 1],
+      ];
+      for (const [nc, nr] of neighbors) {
+        if (nc < 0 || nc >= cols || nr < 0 || nr >= rows) continue;
+        const nIdx = nr * cols + nc;
+        if (emptyVisited[nIdx]) continue;
+        if (cells[nIdx] === 1) continue;
+        emptyVisited[nIdx] = 1;
+        emptyReached++;
+        emptyQueue.push(nIdx);
+      }
+    }
+    if (emptyReached !== emptyCount) {
+      return {
+        kind: 'has_holes',
+        message: `mask has ${emptyCount - emptyReached} enclosed empty cell(s); interior holes are not supported`,
+      };
+    }
+  }
+
   return null;
 }
 
@@ -261,6 +318,15 @@ export function maskToPolygon(mask: CellMask): readonly Point2[] {
     seen.add(k);
     ordered.push(cur);
     cur = byStart.get(key(cur.tx, cur.ty));
+  }
+
+  // Defensive: a single-loop walk must consume every boundary edge. If not,
+  // the mask has holes or multiple disjoint components — both are rejected
+  // by `validateMask`, so reaching here means the caller skipped validation.
+  if (ordered.length !== edges.length) {
+    throw new Error(
+      `maskToPolygon consumed ${ordered.length}/${edges.length} boundary edges; mask has holes or multiple loops (run validateMask first)`
+    );
   }
 
   // Collapse collinear runs: keep only points where direction changes.


### PR DESCRIPTION
## Summary

Adds an optional `cellMask` field on `BinParams` that describes which half-bin-resolution cells are filled. When the mask is present and partial, the generator builds a polygon footprint instead of a rounded rectangle, places sockets only on filled cells, and skips features that don't yet work on non-rectangular bounding regions.

**Rectangle bins are untouched** — `undefined` or fully-filled masks route through the existing rounded-rectangle path and cache bucket. All 182 existing snapshots match.

This is PR #1 of a planned two-PR stack. PR #2 will add the grid editor UI in the Bin Designer panel. Closes part of #1338.

## What's included

- `CellMask` type + utilities (`src/shared/utils/cellMask.ts`)
  - `validateMask` — 4-connected BFS, rejects empty/disconnected/out-of-bounds masks
  - `maskToPolygon` — CCW outer polygon with collinear points elided
  - `resizeMask`, `isAllFilled`, `isRegionFilled`, `hashMask`, `classifyShape`, `buildFullMask`
- `BinParams.cellMask?: CellMask` threaded through dimensions, cache keys, and generator
- Polygon path in `buildBinBox` + `buildTopShape` (loft + sweep) via new `maskPolygon.ts` helper
- Per-filled-cell sockets with magnet/screw holes in `buildBaseSocket`
- `featuresStage` skips when mask is partial (compartments, cutouts, walls, handles, inserts, scoops, labels)
- 5 new snapshot fixtures: L, L-flat, T, U, half-bin L

## Known limitations (deferred to follow-up)

- Sharp corners on all polygon vertices. Rectangular bins keep their 3.75mm `BOX_CORNER_RADIUS` fillets; masked bins don't. Adding convex-only fillets needs a brepjs `CornerFinderFn` that distinguishes convex from concave corners.
- Max mask size capped at 10×10 grid units (20×20 half-cells) in `MAX_MASK_DIMENSION`.
- No UI. Feature is reachable only via direct `cellMask` on saved-design JSON until PR #2.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test:run` — 9798/9798 pass (182 existing + 5 new snapshots)
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run build` — 9.71s
- [x] Pre-commit hooks pass (boundaries, i18n, exhaustiveness, component-structure)