### PR TITLE
feat(export): default export format to STL instead of 3MF

### DIFF
--- a/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
+++ b/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
@@ -93,7 +93,7 @@ export function BaseplatePage() {
 
   const [splitEnabled, setSplitEnabled] = useState(true);
 
-  const activeFormat: ExportFileFormat = exportFileNameConfig.format ?? '3mf';
+  const activeFormat: ExportFileFormat = exportFileNameConfig.format ?? 'stl';
 
   const fullParams = useMemo(
     () =>

--- a/src/features/baseplate/store/baseplatePageStore.ts
+++ b/src/features/baseplate/store/baseplatePageStore.ts
@@ -105,7 +105,7 @@ export const useBaseplatePageStore = create<BaseplatePageState>()(
     hoveredPieceLabel: null,
     selectedPieceLabel: null,
     exportDialogOpen: false,
-    exportFileNameConfig: { style: 'descriptive', customName: '', format: '3mf' },
+    exportFileNameConfig: { style: 'descriptive', customName: '', format: 'stl' },
     exportProgress: null,
 
     setGenerationStatus: (status) => {

--- a/src/features/bin-designer/components/ExportDialog/ExportDialog.test.tsx
+++ b/src/features/bin-designer/components/ExportDialog/ExportDialog.test.tsx
@@ -97,21 +97,21 @@ describe('ExportDialog', () => {
     expect(screen.getByText('Cost')).toBeInTheDocument();
   });
 
-  it('shows Download 3MF button by default', () => {
+  it('shows Download STL button by default', () => {
     render(<ExportDialog />);
-    const button = screen.getByRole('button', { name: /download 3mf/i });
+    const button = screen.getByRole('button', { name: /download stl/i });
     expect(button).toBeInTheDocument();
     expect(button).not.toBeDisabled();
   });
 
-  it('triggers downloadBin with 3mf format on button click', async () => {
+  it('triggers downloadBin with stl format on button click', async () => {
     render(<ExportDialog />);
-    const button = screen.getByRole('button', { name: /download 3mf/i });
+    const button = screen.getByRole('button', { name: /download stl/i });
     await act(async () => {
       fireEvent.click(button);
     });
     expect(mockDownloadBin).toHaveBeenCalledWith(
-      '3mf',
+      'stl',
       expect.objectContaining({ style: 'descriptive' }),
       'Untitled Bin'
     );
@@ -210,7 +210,7 @@ describe('ExportDialog', () => {
 
   it('shows the format extension separately', () => {
     render(<ExportDialog />);
-    expect(screen.getByText('.3mf')).toBeInTheDocument();
+    expect(screen.getByText('.stl')).toBeInTheDocument();
   });
 
   it('shows triangle count', () => {
@@ -272,9 +272,9 @@ describe('ExportDialog', () => {
     const radios = screen.getAllByRole('radio');
     expect(radios).toHaveLength(3);
 
-    // Active radio (3MF, first) has tabIndex 0, others have -1
-    expect(radios[0]).toHaveAttribute('tabindex', '0'); // 3MF (active)
-    expect(radios[1]).toHaveAttribute('tabindex', '-1'); // STL
+    // Active radio (STL, second) has tabIndex 0, others have -1
+    expect(radios[0]).toHaveAttribute('tabindex', '-1'); // 3MF
+    expect(radios[1]).toHaveAttribute('tabindex', '0'); // STL (active)
     expect(radios[2]).toHaveAttribute('tabindex', '-1'); // STEP
   });
 
@@ -282,17 +282,17 @@ describe('ExportDialog', () => {
     render(<ExportDialog />);
     const radios = screen.getAllByRole('radio');
 
-    // Focus 3MF (first) and press ArrowRight → should select STL
-    radios[0].focus();
-    fireEvent.keyDown(radios[0], { key: 'ArrowRight' });
-    expect(useDesignerStore.getState().exportFileNameConfig.format).toBe('stl');
-
-    // Press ArrowRight again → should select STEP
+    // Active format starts as STL (index 1). ArrowRight → STEP
+    radios[1].focus();
     fireEvent.keyDown(radios[1], { key: 'ArrowRight' });
     expect(useDesignerStore.getState().exportFileNameConfig.format).toBe('step');
 
     // Press ArrowRight again → should wrap to 3MF
     fireEvent.keyDown(radios[2], { key: 'ArrowRight' });
     expect(useDesignerStore.getState().exportFileNameConfig.format).toBe('3mf');
+
+    // Press ArrowRight again → should select STL
+    fireEvent.keyDown(radios[0], { key: 'ArrowRight' });
+    expect(useDesignerStore.getState().exportFileNameConfig.format).toBe('stl');
   });
 });

--- a/src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
+++ b/src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
@@ -69,7 +69,7 @@ export function ExportDialog() {
 
   const closeDialog = useCallback(() => setExportDialogOpen(false), [setExportDialogOpen]);
 
-  const activeFormat: ExportFileFormat = exportFileNameConfig.format ?? '3mf';
+  const activeFormat: ExportFileFormat = exportFileNameConfig.format ?? 'stl';
   const showSplitBanner = needsSplit && activeFormat !== 'step';
   const useSplitExport = showSplitBanner && splitEnabled;
 

--- a/src/features/bin-designer/utils/fileNaming.test.ts
+++ b/src/features/bin-designer/utils/fileNaming.test.ts
@@ -264,4 +264,8 @@ describe('DEFAULT_EXPORT_FILE_NAME_CONFIG', () => {
   it('should have empty custom name by default', () => {
     expect(DEFAULT_EXPORT_FILE_NAME_CONFIG.customName).toBe('');
   });
+
+  it('should have stl format by default', () => {
+    expect(DEFAULT_EXPORT_FILE_NAME_CONFIG.format).toBe('stl');
+  });
 });

--- a/src/features/bin-designer/utils/fileNaming.ts
+++ b/src/features/bin-designer/utils/fileNaming.ts
@@ -11,7 +11,7 @@ import type { BinParams, FileNameStyle, ExportFileNameConfig } from '../types';
 export const DEFAULT_EXPORT_FILE_NAME_CONFIG: ExportFileNameConfig = {
   style: 'descriptive',
   customName: '',
-  format: '3mf',
+  format: 'stl',
 };
 
 /** Characters not allowed in filenames (replaced with underscore) */


### PR DESCRIPTION
## Summary

- Change the default selected export format from 3MF to STL in both the bin designer and baseplate generator
- STL is the universal slicer-ready format; 3MF remains one click away for users who want color/material info
- Updates the two seed constants (`DEFAULT_EXPORT_FILE_NAME_CONFIG` and the inline baseplate store initializer) plus the two defensive `?? '3mf'` fallbacks in the dialog parents

## Why

STL is supported by every slicer out of the box and is what most users expect when they click "Export" on a Gridfinity bin. 3MF is a better format for color/multi-material prints, but most Gridfinity prints are single-color so 3MF as the default was friction for the common case.

## Test plan

- [x] `pnpm run test:run -- src/features/bin-designer/components/ExportDialog` passes (665 files / 9764 tests)
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [ ] Open the bin designer → Export dialog → confirm STL is pre-selected and "Download STL" button is shown
- [ ] Open the baseplate generator → Export dialog → confirm STL is pre-selected
- [ ] Switch to 3MF, confirm format and extension update correctly