### PR TITLE
fix(bin-designer): shrink-to-fit long bin names in 3D preview

### DIFF
--- a/src/features/bin-designer/components/preview/BinNameLabel/BinNameLabel.test.tsx
+++ b/src/features/bin-designer/components/preview/BinNameLabel/BinNameLabel.test.tsx
@@ -28,11 +28,7 @@ interface MockTextProps {
 
 vi.mock('@react-three/drei', () => ({
   Text: ({ children, fontSize, maxWidth }: MockTextProps) => (
-    <div
-      data-testid="r3f-text"
-      data-font-size={fontSize}
-      data-max-width={maxWidth === Infinity ? 'Infinity' : maxWidth}
-    >
+    <div data-testid="r3f-text" data-font-size={fontSize} data-max-width={maxWidth ?? 'none'}>
       {children}
     </div>
   ),
@@ -67,7 +63,7 @@ describe('BinNameLabel', () => {
     render(<BinNameLabel width={2} depth={3} name="Bin" />);
     const text = screen.getByTestId('r3f-text');
     expect(text.dataset.fontSize).toBe('7');
-    expect(text.dataset.maxWidth).toBe('Infinity');
+    expect(text.dataset.maxWidth).toBe('none');
   });
 
   it('shrinks font size for medium-long names on a small bin', () => {
@@ -78,7 +74,7 @@ describe('BinNameLabel', () => {
     const fontSize = Number(text.dataset.fontSize);
     expect(fontSize).toBeGreaterThanOrEqual(5);
     expect(fontSize).toBeLessThan(7);
-    expect(text.dataset.maxWidth).toBe('Infinity');
+    expect(text.dataset.maxWidth).toBe('none');
   });
 
   it('falls back to 2-line wrap for very long names on a small bin', () => {
@@ -86,7 +82,7 @@ describe('BinNameLabel', () => {
     render(<BinNameLabel width={1} depth={1} name={veryLongName} />);
     const text = screen.getByTestId('r3f-text');
     expect(text.dataset.fontSize).toBe('7');
-    expect(text.dataset.maxWidth).not.toBe('Infinity');
+    expect(text.dataset.maxWidth).not.toBe('none');
     expect(Number(text.dataset.maxWidth)).toBeGreaterThan(0);
   });
 
@@ -96,6 +92,6 @@ describe('BinNameLabel', () => {
     render(<BinNameLabel width={1} depth={1} name="SCREWS M3 SHORT" />);
     const text = screen.getByTestId('r3f-text');
     expect(text.dataset.fontSize).toBe('7');
-    expect(text.dataset.maxWidth).toBe('Infinity');
+    expect(text.dataset.maxWidth).toBe('none');
   });
 });

--- a/src/features/bin-designer/components/preview/BinNameLabel/BinNameLabel.test.tsx
+++ b/src/features/bin-designer/components/preview/BinNameLabel/BinNameLabel.test.tsx
@@ -20,8 +20,22 @@ vi.mock('@react-three/fiber', () => ({
   extend: vi.fn(),
 }));
 
+interface MockTextProps {
+  children: ReactNode;
+  fontSize?: number;
+  maxWidth?: number;
+}
+
 vi.mock('@react-three/drei', () => ({
-  Text: ({ children }: { children: ReactNode }) => <div data-testid="r3f-text">{children}</div>,
+  Text: ({ children, fontSize, maxWidth }: MockTextProps) => (
+    <div
+      data-testid="r3f-text"
+      data-font-size={fontSize}
+      data-max-width={maxWidth === Infinity ? 'Infinity' : maxWidth}
+    >
+      {children}
+    </div>
+  ),
 }));
 
 describe('BinNameLabel', () => {
@@ -47,5 +61,41 @@ describe('BinNameLabel', () => {
   it('converts name to uppercase', () => {
     render(<BinNameLabel width={2} depth={3} name="lowercase bin" />);
     expect(screen.getByTestId('r3f-text')).toHaveTextContent('LOWERCASE BIN');
+  });
+
+  it('uses default font size (7mm) for short names that fit', () => {
+    render(<BinNameLabel width={2} depth={3} name="Bin" />);
+    const text = screen.getByTestId('r3f-text');
+    expect(text.dataset.fontSize).toBe('7');
+    expect(text.dataset.maxWidth).toBe('Infinity');
+  });
+
+  it('shrinks font size for medium-long names on a small bin', () => {
+    // 25 chars × 7mm × 0.68 ≈ 119mm, exceeds the 100mm floor → shrink.
+    // Ideal: 100 / (25 × 0.68) ≈ 5.88mm, which is above the 5mm minimum.
+    render(<BinNameLabel width={1} depth={1} name="Screws M3 x 12mm Flat Set" />);
+    const text = screen.getByTestId('r3f-text');
+    const fontSize = Number(text.dataset.fontSize);
+    expect(fontSize).toBeGreaterThanOrEqual(5);
+    expect(fontSize).toBeLessThan(7);
+    expect(text.dataset.maxWidth).toBe('Infinity');
+  });
+
+  it('falls back to 2-line wrap for very long names on a small bin', () => {
+    const veryLongName = 'A very long name that exceeds the minimum font size threshold';
+    render(<BinNameLabel width={1} depth={1} name={veryLongName} />);
+    const text = screen.getByTestId('r3f-text');
+    expect(text.dataset.fontSize).toBe('7');
+    expect(text.dataset.maxWidth).not.toBe('Infinity');
+    expect(Number(text.dataset.maxWidth)).toBeGreaterThan(0);
+  });
+
+  it('honors the 100mm minimum available width on tiny bins', () => {
+    // 1x1 bin is 42mm wide → outerW * 1.5 = 63mm, floor raises it to 100mm.
+    // A 15-char name at 7mm ≈ 71mm — fits in 100mm but not in 63mm.
+    render(<BinNameLabel width={1} depth={1} name="SCREWS M3 SHORT" />);
+    const text = screen.getByTestId('r3f-text');
+    expect(text.dataset.fontSize).toBe('7');
+    expect(text.dataset.maxWidth).toBe('Infinity');
   });
 });

--- a/src/features/bin-designer/components/preview/BinNameLabel/BinNameLabel.tsx
+++ b/src/features/bin-designer/components/preview/BinNameLabel/BinNameLabel.tsx
@@ -31,10 +31,12 @@ const CHAR_WIDTH_RATIO = 0.6;
 
 /**
  * Estimate rendered width of uppercase text at a given font size, accounting for letter spacing.
+ * Letter spacing applies between glyphs (charCount - 1 gaps), not after each glyph.
  * Approximation — drei's SDF <Text> only exposes accurate widths via async onSync.
  */
 function estimateTextWidth(charCount: number, fontSize: number): number {
-  return charCount * fontSize * (CHAR_WIDTH_RATIO + LETTER_SPACING);
+  if (charCount <= 0) return 0;
+  return fontSize * (charCount * CHAR_WIDTH_RATIO + (charCount - 1) * LETTER_SPACING);
 }
 
 /**
@@ -57,16 +59,16 @@ export function BinNameLabel({ width, depth, name }: BinNameLabelProps) {
   const defaultWidth = estimateTextWidth(upperName.length, DEFAULT_FONT_SIZE);
 
   let fontSize: number;
-  let maxWidth: number;
+  let maxWidth: number | undefined;
 
   if (defaultWidth <= availableWidth) {
     fontSize = DEFAULT_FONT_SIZE;
-    maxWidth = Infinity;
+    maxWidth = undefined;
   } else {
-    const idealFontSize = availableWidth / (upperName.length * (CHAR_WIDTH_RATIO + LETTER_SPACING));
+    const idealFontSize = availableWidth / estimateTextWidth(upperName.length, 1);
     if (idealFontSize >= MIN_FONT_SIZE) {
       fontSize = idealFontSize;
-      maxWidth = Infinity;
+      maxWidth = undefined;
     } else {
       fontSize = DEFAULT_FONT_SIZE;
       maxWidth = availableWidth;

--- a/src/features/bin-designer/components/preview/BinNameLabel/BinNameLabel.tsx
+++ b/src/features/bin-designer/components/preview/BinNameLabel/BinNameLabel.tsx
@@ -19,36 +19,72 @@ interface BinNameLabelProps {
 }
 
 const TEXT_OPACITY = 0.6;
-const FONT_SIZE = 7; // mm (planner: 0.5 units)
+const DEFAULT_FONT_SIZE = 7; // mm (planner: 0.5 units)
+const MIN_FONT_SIZE = 5; // mm — below this, wrap to 2 lines instead
 const LETTER_SPACING = 0.08;
 /** Distance from bin front edge to label center (mm) */
 const FRONT_OFFSET = 32;
+/** Minimum label width in mm — small bins still get room for reasonable names */
+const MIN_AVAILABLE_WIDTH = 100;
+/** Approximate ratio of uppercase character width to font size for drei's default SDF font */
+const CHAR_WIDTH_RATIO = 0.6;
+
+/**
+ * Estimate rendered width of uppercase text at a given font size, accounting for letter spacing.
+ * Approximation — drei's SDF <Text> only exposes accurate widths via async onSync.
+ */
+function estimateTextWidth(charCount: number, fontSize: number): number {
+  return charCount * fontSize * (CHAR_WIDTH_RATIO + LETTER_SPACING);
+}
 
 /**
  * Bin name label displayed on the floor in front of the bin.
  * Uppercase text centered on the bin's width.
+ *
+ * Long names shrink-to-fit on a single line down to MIN_FONT_SIZE; below that
+ * threshold, font size resets to default and the text wraps to 2 lines.
  */
 export function BinNameLabel({ width, depth, name }: BinNameLabelProps) {
   const colors = useThreeColors();
   if (!name.trim()) return null;
 
+  const upperName = name.toUpperCase();
   const outerW = width * GRIDFINITY.GRID_SIZE;
   const halfD = (depth * GRIDFINITY.GRID_SIZE) / 2;
-
   const textY = -halfD - FRONT_OFFSET;
+
+  const availableWidth = Math.max(outerW * 1.5, MIN_AVAILABLE_WIDTH);
+  const defaultWidth = estimateTextWidth(upperName.length, DEFAULT_FONT_SIZE);
+
+  let fontSize: number;
+  let maxWidth: number;
+
+  if (defaultWidth <= availableWidth) {
+    fontSize = DEFAULT_FONT_SIZE;
+    maxWidth = Infinity;
+  } else {
+    const idealFontSize = availableWidth / (upperName.length * (CHAR_WIDTH_RATIO + LETTER_SPACING));
+    if (idealFontSize >= MIN_FONT_SIZE) {
+      fontSize = idealFontSize;
+      maxWidth = Infinity;
+    } else {
+      fontSize = DEFAULT_FONT_SIZE;
+      maxWidth = availableWidth;
+    }
+  }
 
   return (
     <Text
       position={[0, textY, 0.01]}
-      fontSize={FONT_SIZE}
+      fontSize={fontSize}
       color={colors.labelColor}
       fillOpacity={TEXT_OPACITY}
       anchorX="center"
       anchorY="middle"
       letterSpacing={LETTER_SPACING}
-      maxWidth={outerW * 1.5}
+      maxWidth={maxWidth}
     >
-      {name.toUpperCase()}
+      {upperName}
     </Text>
   );
 }


### PR DESCRIPTION
## Summary

Long design names previously wrapped awkwardly to multiple cramped lines in the 3D preview because `maxWidth` was hard-coded at `outerW * 1.5` — only ~63mm on a 1×1 bin, which fits ~9 chars of 7mm text.

The label now:

- **Shrinks font size** from 7mm down to a 5mm floor to fit on one line
- **Falls back to 2-line wrap** at the default 7mm when text would go below 5mm
- Uses a **100mm absolute minimum** label width so tiny bins still have reasonable room

On a 1×1 bin (42mm, so 100mm floor kicks in):
- ≤21 chars → default 7mm, no wrap
- 22–29 chars → smooth shrink (7mm → 5mm)
- ≥30 chars → wrap to 2 lines at 7mm

Scope is intentionally limited to the bin designer's `BinNameLabel` — the near-duplicate in `src/shared/components/preview/BinNameLabel.tsx` (used by the layout planner) is left for a separate change.

## Test plan

- [x] `pnpm run test:run` — 9769 tests pass, incl. 4 new tests for shrink-to-fit, wrap fallback, and the 100mm floor
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors
- [ ] Visual check in dev: open the bin designer, type a 25-char name on a 1×1 bin → label stays single-line
- [ ] Visual check: type a 60-char name on a 1×1 bin → label wraps to 2 lines at full size