### PR TITLE
chore: quality and perf improvements (schema gap, hook fix, ghost preview perf)

### DIFF
--- a/src/core/cqrs/validation/schemas.test.ts
+++ b/src/core/cqrs/validation/schemas.test.ts
@@ -490,4 +490,54 @@ describe('layout.setBaseplateParams schema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('accepts lightweight, cornerRadius, and cornerRadii', () => {
+    const result = z.safeParse(schema, {
+      params: {
+        magnetHoles: true,
+        magnetDiameter: 6.5,
+        magnetDepth: 2,
+        paddingLeft: 0,
+        paddingRight: 0,
+        paddingFront: 0,
+        paddingBack: 0,
+        lightweight: true,
+        cornerRadius: 2.5,
+        cornerRadii: { tl: 2.5, tr: 2.5, bl: 2.5, br: 2.5 },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects negative cornerRadius', () => {
+    const result = z.safeParse(schema, {
+      params: {
+        magnetHoles: true,
+        magnetDiameter: 6.5,
+        magnetDepth: 2,
+        paddingLeft: 0,
+        paddingRight: 0,
+        paddingFront: 0,
+        paddingBack: 0,
+        cornerRadius: -1,
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects cornerRadii missing a corner', () => {
+    const result = z.safeParse(schema, {
+      params: {
+        magnetHoles: true,
+        magnetDiameter: 6.5,
+        magnetDepth: 2,
+        paddingLeft: 0,
+        paddingRight: 0,
+        paddingFront: 0,
+        paddingBack: 0,
+        cornerRadii: { tl: 2, tr: 2, bl: 2 },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/src/core/cqrs/validation/schemas.ts
+++ b/src/core/cqrs/validation/schemas.ts
@@ -209,7 +209,8 @@ const layoutSetGridUnitMmSchema = z.object({ mm: positiveMm });
 const layoutSetHeightUnitMmSchema = z.object({ mm: positiveMm });
 
 /** Baseplate params schema */
-const cornerRadiusMm = z.number().min(0).max(100);
+// Max = gridUnitMm/2 (capped at 200mm) + max padding (100mm). UI derives a tighter bound per-layout.
+const cornerRadiusMm = z.number().min(0).max(200);
 const baseplateParamsSchema = z.object({
   magnetHoles: z.boolean(),
   magnetDiameter: z.number().min(0.5).max(20),

--- a/src/core/cqrs/validation/schemas.ts
+++ b/src/core/cqrs/validation/schemas.ts
@@ -209,6 +209,7 @@ const layoutSetGridUnitMmSchema = z.object({ mm: positiveMm });
 const layoutSetHeightUnitMmSchema = z.object({ mm: positiveMm });
 
 /** Baseplate params schema */
+const cornerRadiusMm = z.number().min(0).max(100);
 const baseplateParamsSchema = z.object({
   magnetHoles: z.boolean(),
   magnetDiameter: z.number().min(0.5).max(20),
@@ -219,9 +220,19 @@ const baseplateParamsSchema = z.object({
   paddingBack: z.number().min(0).max(100),
   connectorNubs: z.boolean().optional(),
   invertDovetails: z.boolean().optional(),
+  lightweight: z.boolean().optional(),
   syncWithLayout: z.boolean().optional(),
   baseplateWidth: z.number().min(CONSTRAINTS.GRID_MIN).max(CONSTRAINTS.GRID_MAX).optional(),
   baseplateDepth: z.number().min(CONSTRAINTS.GRID_MIN).max(CONSTRAINTS.GRID_MAX).optional(),
+  cornerRadius: cornerRadiusMm.optional(),
+  cornerRadii: z
+    .object({
+      tl: cornerRadiusMm,
+      tr: cornerRadiusMm,
+      bl: cornerRadiusMm,
+      br: cornerRadiusMm,
+    })
+    .optional(),
 });
 
 /** layout.setBaseplateParams */

--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.test.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.test.tsx
@@ -187,6 +187,7 @@ vi.mock('three/examples/jsm/lines/LineSegments2.js', () => ({
 
 vi.mock('three/examples/jsm/lines/LineMaterial.js', () => ({
   LineMaterial: class MockLineMaterial {
+    resolution = { set: vi.fn() };
     dispose = vi.fn();
   },
 }));

--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -619,12 +619,11 @@ function TouchHint() {
   const t = useTranslation();
   const { isTouchDevice, isDesktop } = useResponsive();
   const [dismissed, setDismissed] = useState(false);
+  const alreadyDismissed = useSettingsStore((s) =>
+    s.settings.dismissedHints.includes('designer-touch')
+  );
 
-  const visible =
-    !dismissed &&
-    isTouchDevice &&
-    !isDesktop &&
-    !useSettingsStore.getState().settings.dismissedHints.includes('designer-touch');
+  const visible = !dismissed && isTouchDevice && !isDesktop && !alreadyDismissed;
 
   const dismiss = useCallback(() => {
     setDismissed(true);

--- a/src/features/bin-designer/components/preview/BinNameLabel/BinNameLabel.test.tsx
+++ b/src/features/bin-designer/components/preview/BinNameLabel/BinNameLabel.test.tsx
@@ -67,8 +67,8 @@ describe('BinNameLabel', () => {
   });
 
   it('shrinks font size for medium-long names on a small bin', () => {
-    // 25 chars × 7mm × 0.68 ≈ 119mm, exceeds the 100mm floor → shrink.
-    // Ideal: 100 / (25 × 0.68) ≈ 5.88mm, which is above the 5mm minimum.
+    // 25 chars → estimateTextWidth(25, 7) ≈ 118mm (char ratio 0.6 + letter-spacing 0.08),
+    // exceeds the 100mm floor → shrink. Shrunk font ≈ 5.9mm, above the 5mm minimum.
     render(<BinNameLabel width={1} depth={1} name="Screws M3 x 12mm Flat Set" />);
     const text = screen.getByTestId('r3f-text');
     const fontSize = Number(text.dataset.fontSize);

--- a/src/features/bin-designer/components/preview/GhostCompartmentPreview/GhostCompartmentPreview.tsx
+++ b/src/features/bin-designer/components/preview/GhostCompartmentPreview/GhostCompartmentPreview.tsx
@@ -7,12 +7,13 @@
 
 import { useMemo, useEffect, useRef } from 'react';
 import * as THREE from 'three';
-import { useThree, useFrame } from '@react-three/fiber';
+import { useThree } from '@react-three/fiber';
 import { useShallow } from 'zustand/react/shallow';
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { useLineMaterialResolution } from '../useLineMaterialResolution';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 import { cellIndex } from '@/features/bin-designer/utils/compartments';
 
@@ -26,23 +27,22 @@ const SPLIT_OPACITY = 0.85;
 const LINE_WIDTH = 3;
 
 export function GhostCompartmentPreview() {
-  const { invalidate, size } = useThree();
+  const { invalidate } = useThree();
   const lineRef = useRef<LineSegments2 | null>(null);
-  const materialRef = useRef<LineMaterial | null>(null);
 
-  const canvasWidth = size.width;
-  const canvasHeight = size.height;
-
-  const { params, previewCompartments, previewSelection } = useDesignerStore(
-    useShallow((s) => ({
-      params: s.params,
-      previewCompartments: s.ui.previewCompartments,
-      previewSelection: s.ui.previewSelection,
-    }))
-  );
-
-  const { width, depth, height, wallThickness } = params;
-  const { cols, rows } = params.compartments;
+  const { width, depth, height, wallThickness, cols, rows, previewCompartments, previewSelection } =
+    useDesignerStore(
+      useShallow((s) => ({
+        width: s.params.width,
+        depth: s.params.depth,
+        height: s.params.height,
+        wallThickness: s.params.wallThickness,
+        cols: s.params.compartments.cols,
+        rows: s.params.compartments.rows,
+        previewCompartments: s.ui.previewCompartments,
+        previewSelection: s.ui.previewSelection,
+      }))
+    );
 
   // Calculate bin dimensions
   const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
@@ -149,21 +149,11 @@ export function GhostCompartmentPreview() {
       transparent: true,
       opacity: SPLIT_OPACITY,
       depthTest: true,
-      resolution: new THREE.Vector2(canvasWidth, canvasHeight),
+      resolution: new THREE.Vector2(),
     });
-  }, [shouldShow, isMerge, canvasWidth, canvasHeight]);
+  }, [shouldShow, isMerge]);
 
-  // Store material ref for resolution updates
-  useEffect(() => {
-    materialRef.current = splitMaterial;
-  }, [splitMaterial]);
-
-  // Update resolution on resize
-  useFrame(() => {
-    if (materialRef.current) {
-      materialRef.current.resolution.set(canvasWidth, canvasHeight);
-    }
-  });
+  useLineMaterialResolution(splitMaterial);
 
   // Dispose resources
   useEffect(() => {

--- a/src/features/bin-designer/components/preview/GhostCompartmentPreview/GhostCompartmentPreview.tsx
+++ b/src/features/bin-designer/components/preview/GhostCompartmentPreview/GhostCompartmentPreview.tsx
@@ -172,6 +172,11 @@ export function GhostCompartmentPreview() {
     }
   }, [mergePlane, mergeMaterial, splitGeometry, splitMaterial, invalidate]);
 
+  const splitLineSegments = useMemo(
+    () => (splitGeometry && splitMaterial ? new LineSegments2(splitGeometry, splitMaterial) : null),
+    [splitGeometry, splitMaterial]
+  );
+
   if (!shouldShow) return null;
 
   // Render merge preview (flat amber plane)
@@ -187,14 +192,9 @@ export function GhostCompartmentPreview() {
   }
 
   // Render split preview (cyan divider lines)
-  if (!isMerge && splitGeometry && splitMaterial) {
+  if (!isMerge && splitLineSegments) {
     return (
-      <primitive
-        ref={lineRef}
-        object={new LineSegments2(splitGeometry, splitMaterial)}
-        position={[0, 0, 0.2]}
-        renderOrder={3}
-      />
+      <primitive ref={lineRef} object={splitLineSegments} position={[0, 0, 0.2]} renderOrder={3} />
     );
   }
 

--- a/src/features/bin-designer/components/preview/GhostCutouts/GhostCutouts.tsx
+++ b/src/features/bin-designer/components/preview/GhostCutouts/GhostCutouts.tsx
@@ -243,14 +243,12 @@ export function GhostCutouts() {
     if (geometry && material) invalidate();
   }, [geometry, material, invalidate]);
 
-  if (!geometry || !material) return null;
-
-  return (
-    <primitive
-      ref={lineRef}
-      object={new LineSegments2(geometry, material)}
-      position={[0, 0, 0.1]}
-      renderOrder={3}
-    />
+  const lineSegments = useMemo(
+    () => (geometry && material ? new LineSegments2(geometry, material) : null),
+    [geometry, material]
   );
+
+  if (!lineSegments) return null;
+
+  return <primitive ref={lineRef} object={lineSegments} position={[0, 0, 0.1]} renderOrder={3} />;
 }

--- a/src/features/bin-designer/components/preview/GhostCutouts/GhostCutouts.tsx
+++ b/src/features/bin-designer/components/preview/GhostCutouts/GhostCutouts.tsx
@@ -12,12 +12,13 @@
 
 import { useMemo, useEffect, useRef } from 'react';
 import * as THREE from 'three';
-import { useThree, useFrame } from '@react-three/fiber';
+import { useThree } from '@react-three/fiber';
 import { useShallow } from 'zustand/react/shallow';
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
 import { useDesignerStore, useCutoutSelection } from '@/features/bin-designer/store';
+import { useLineMaterialResolution } from '../useLineMaterialResolution';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 import type { Cutout } from '@/features/bin-designer/types';
 import {
@@ -151,16 +152,17 @@ function buildCutoutGeometry(
 }
 
 export function GhostCutouts() {
-  const { invalidate, size } = useThree();
+  const { invalidate } = useThree();
   const lineRef = useRef<LineSegments2 | null>(null);
-  const materialRef = useRef<LineMaterial | null>(null);
 
-  const canvasWidth = size.width;
-  const canvasHeight = size.height;
-
-  const { params, generationStatus } = useDesignerStore(
+  const { width, depth, height, wallThickness, cutouts, base, generationStatus } = useDesignerStore(
     useShallow((s) => ({
-      params: s.params,
+      width: s.params.width,
+      depth: s.params.depth,
+      height: s.params.height,
+      wallThickness: s.params.wallThickness,
+      cutouts: s.params.cutouts,
+      base: s.params.base,
       generationStatus: s.generation.status,
     }))
   );
@@ -168,17 +170,16 @@ export function GhostCutouts() {
   const selectedIds = useCutoutSelection((s) => s.selectedIds);
   const previewOverrides = useCutoutSelection((s) => s.previewOverrides);
 
-  const { cutouts, base } = params;
   const isSolid = base.solid;
-  const totalH = params.height * GRIDFINITY.HEIGHT_UNIT;
+  const totalH = height * GRIDFINITY.HEIGHT_UNIT;
   const isFlat = base.style === 'flat';
   const wallHeight = isFlat ? totalH : totalH - GRIDFINITY.BASE_HEIGHT;
   const floorZ = isFlat ? 0 : GRIDFINITY.BASE_HEIGHT;
 
-  const outerW = params.width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
-  const outerD = params.depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
-  const innerW = outerW - 2 * params.wallThickness;
-  const innerD = outerD - 2 * params.wallThickness;
+  const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+  const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+  const innerW = outerW - 2 * wallThickness;
+  const innerD = outerD - 2 * wallThickness;
   const originX = -innerW / 2;
   const originY = -innerD / 2;
 
@@ -225,19 +226,11 @@ export function GhostCutouts() {
       // making cutout depth clearly visible from any angle.
       depthTest: false,
       depthWrite: false,
-      resolution: new THREE.Vector2(canvasWidth, canvasHeight),
+      resolution: new THREE.Vector2(),
     });
-  }, [shouldShow, canvasWidth, canvasHeight]);
+  }, [shouldShow]);
 
-  useEffect(() => {
-    materialRef.current = material;
-  }, [material]);
-
-  useFrame(() => {
-    if (materialRef.current) {
-      materialRef.current.resolution.set(canvasWidth, canvasHeight);
-    }
-  });
+  useLineMaterialResolution(material);
 
   useEffect(() => {
     return () => {

--- a/src/features/bin-designer/components/preview/GhostDividerPieces/GhostDividerPieces.tsx
+++ b/src/features/bin-designer/components/preview/GhostDividerPieces/GhostDividerPieces.tsx
@@ -40,13 +40,19 @@ const DEFAULT_COLOR = '#d4d8dc';
 export function GhostDividerPieces() {
   const { invalidate } = useThree();
 
-  const { params } = useDesignerStore(
-    useShallow((s) => ({
-      params: s.params,
-    }))
-  );
-
-  const { width, depth, height, wallThickness, style, slotConfig, dividerPieces } = params;
+  const { width, depth, height, wallThickness, style, slotConfig, dividerPieces, hasLip } =
+    useDesignerStore(
+      useShallow((s) => ({
+        width: s.params.width,
+        depth: s.params.depth,
+        height: s.params.height,
+        wallThickness: s.params.wallThickness,
+        style: s.params.style,
+        slotConfig: s.params.slotConfig,
+        dividerPieces: s.params.dividerPieces,
+        hasLip: s.params.base.stackingLip,
+      }))
+    );
 
   const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
   const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
@@ -57,7 +63,6 @@ export function GhostDividerPieces() {
   // In preview space, the bin is translated up by SOCKET_HEIGHT, so the
   // cavity floor (inner surface after shelling) is at SOCKET_HEIGHT + wallThickness.
   const floorZ = GRIDFINITY.SOCKET_HEIGHT + wallThickness;
-  const hasLip = params.base.stackingLip;
 
   const lipTaperWidth = GRIDFINITY.LIP_SMALL_TAPER + GRIDFINITY.LIP_BIG_TAPER;
   const lipOverhang = hasLip ? Math.max(0, lipTaperWidth - wallThickness) : 0;

--- a/src/features/bin-designer/components/preview/GhostDividers/GhostDividers.tsx
+++ b/src/features/bin-designer/components/preview/GhostDividers/GhostDividers.tsx
@@ -112,14 +112,12 @@ export function GhostDividers() {
     if (geometry && material) invalidate();
   }, [geometry, material, invalidate]);
 
-  if (!geometry || !material) return null;
-
-  return (
-    <primitive
-      ref={lineRef}
-      object={new LineSegments2(geometry, material)}
-      position={[0, 0, 0.1]}
-      renderOrder={2}
-    />
+  const lineSegments = useMemo(
+    () => (geometry && material ? new LineSegments2(geometry, material) : null),
+    [geometry, material]
   );
+
+  if (!lineSegments) return null;
+
+  return <primitive ref={lineRef} object={lineSegments} position={[0, 0, 0.1]} renderOrder={2} />;
 }

--- a/src/features/bin-designer/components/preview/GhostDividers/GhostDividers.tsx
+++ b/src/features/bin-designer/components/preview/GhostDividers/GhostDividers.tsx
@@ -10,12 +10,13 @@
 
 import { useMemo, useEffect, useRef } from 'react';
 import * as THREE from 'three';
-import { useThree, useFrame } from '@react-three/fiber';
+import { useThree } from '@react-three/fiber';
 import { useShallow } from 'zustand/react/shallow';
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { useLineMaterialResolution } from '../useLineMaterialResolution';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 
 /** Ghost line color (matches selection ring yellow used in 2D grid editor) */
@@ -25,22 +26,20 @@ const GHOST_OPACITY = 0.75;
 const LINE_WIDTH = 2;
 
 export function GhostDividers() {
-  const { invalidate, size } = useThree();
+  const { invalidate } = useThree();
   const lineRef = useRef<LineSegments2 | null>(null);
-  const materialRef = useRef<LineMaterial | null>(null);
 
-  const canvasWidth = size.width;
-  const canvasHeight = size.height;
-
-  const { params, generationStatus } = useDesignerStore(
+  const { width, depth, height, wallThickness, cols, rows, generationStatus } = useDesignerStore(
     useShallow((s) => ({
-      params: s.params,
+      width: s.params.width,
+      depth: s.params.depth,
+      height: s.params.height,
+      wallThickness: s.params.wallThickness,
+      cols: s.params.compartments.cols,
+      rows: s.params.compartments.rows,
       generationStatus: s.generation.status,
     }))
   );
-
-  const { width, depth, height, wallThickness, compartments } = params;
-  const { cols, rows } = compartments;
 
   // Calculate bin dimensions
   const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
@@ -84,7 +83,7 @@ export function GhostDividers() {
     return geo;
   }, [shouldShow, cols, rows, innerW, innerD, topZ]);
 
-  // Create material
+  // Create material (resolution set via effect — avoids recreating on resize)
   const material = useMemo(() => {
     if (!shouldShow || (cols <= 1 && rows <= 1)) return null;
 
@@ -94,21 +93,11 @@ export function GhostDividers() {
       transparent: true,
       opacity: GHOST_OPACITY,
       depthTest: true,
-      resolution: new THREE.Vector2(canvasWidth, canvasHeight),
+      resolution: new THREE.Vector2(),
     });
-  }, [shouldShow, cols, rows, canvasWidth, canvasHeight]);
+  }, [shouldShow, cols, rows]);
 
-  // Sync material ref after render (not during render)
-  useEffect(() => {
-    materialRef.current = material;
-  }, [material]);
-
-  // Update resolution on resize
-  useFrame(() => {
-    if (materialRef.current) {
-      materialRef.current.resolution.set(canvasWidth, canvasHeight);
-    }
-  });
+  useLineMaterialResolution(material);
 
   // Dispose resources on unmount or change
   useEffect(() => {

--- a/src/features/bin-designer/components/preview/GhostHandles/GhostHandles.tsx
+++ b/src/features/bin-designer/components/preview/GhostHandles/GhostHandles.tsx
@@ -25,13 +25,6 @@ const GHOST_OPACITY = 0.4;
 
 export function GhostHandles() {
   const { invalidate } = useThree();
-  const { params, generationStatus } = useDesignerStore(
-    useShallow((s) => ({
-      params: s.params,
-      generationStatus: s.generation.status,
-    }))
-  );
-
   const {
     width,
     depth,
@@ -41,8 +34,22 @@ export function GhostHandles() {
     handles,
     label,
     base,
-    walls: wallConfig,
-  } = params;
+    wallConfig,
+    generationStatus,
+  } = useDesignerStore(
+    useShallow((s) => ({
+      width: s.params.width,
+      depth: s.params.depth,
+      height: s.params.height,
+      wallThickness: s.params.wallThickness,
+      style: s.params.style,
+      handles: s.params.handles,
+      label: s.params.label,
+      base: s.params.base,
+      wallConfig: s.params.walls,
+      generationStatus: s.generation.status,
+    }))
+  );
 
   const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
   const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;

--- a/src/features/bin-designer/components/preview/GhostLabelTabs/GhostLabelTabs.tsx
+++ b/src/features/bin-designer/components/preview/GhostLabelTabs/GhostLabelTabs.tsx
@@ -21,14 +21,19 @@ const GHOST_OPACITY = 0.45;
 export function GhostLabelTabs() {
   const { invalidate } = useThree();
 
-  const { params, generationStatus } = useDesignerStore(
-    useShallow((s) => ({
-      params: s.params,
-      generationStatus: s.generation.status,
-    }))
-  );
-
-  const { width, depth, height, wallThickness, style, compartments, label } = params;
+  const { width, depth, height, wallThickness, style, compartments, label, generationStatus } =
+    useDesignerStore(
+      useShallow((s) => ({
+        width: s.params.width,
+        depth: s.params.depth,
+        height: s.params.height,
+        wallThickness: s.params.wallThickness,
+        style: s.params.style,
+        compartments: s.params.compartments,
+        label: s.params.label,
+        generationStatus: s.generation.status,
+      }))
+    );
   const { cols, rows, thickness, cells } = compartments;
 
   const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;

--- a/src/features/bin-designer/components/preview/GhostScoops/GhostScoops.tsx
+++ b/src/features/bin-designer/components/preview/GhostScoops/GhostScoops.tsx
@@ -28,14 +28,29 @@ const ARC_SEGMENTS = 16;
 export function GhostScoops() {
   const { invalidate } = useThree();
 
-  const { params, generationStatus } = useDesignerStore(
+  const {
+    width,
+    depth,
+    height,
+    wallThickness,
+    style,
+    compartments,
+    scoop,
+    base,
+    generationStatus,
+  } = useDesignerStore(
     useShallow((s) => ({
-      params: s.params,
+      width: s.params.width,
+      depth: s.params.depth,
+      height: s.params.height,
+      wallThickness: s.params.wallThickness,
+      style: s.params.style,
+      compartments: s.params.compartments,
+      scoop: s.params.scoop,
+      base: s.params.base,
       generationStatus: s.generation.status,
     }))
   );
-
-  const { width, depth, height, wallThickness, style, compartments, scoop, base } = params;
   const { cols, rows, cells } = compartments;
 
   const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;

--- a/src/features/bin-designer/components/preview/GhostSlotLines/GhostSlotLines.tsx
+++ b/src/features/bin-designer/components/preview/GhostSlotLines/GhostSlotLines.tsx
@@ -9,12 +9,13 @@
 
 import { useMemo, useEffect, useRef } from 'react';
 import * as THREE from 'three';
-import { useThree, useFrame } from '@react-three/fiber';
+import { useThree } from '@react-three/fiber';
 import { useShallow } from 'zustand/react/shallow';
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { useLineMaterialResolution } from '../useLineMaterialResolution';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 import {
   calculateSlotPositions,
@@ -27,21 +28,32 @@ const GHOST_OPACITY = 0.75;
 const LINE_WIDTH = 2;
 
 export function GhostSlotLines() {
-  const { invalidate, size } = useThree();
+  const { invalidate } = useThree();
   const lineRef = useRef<LineSegments2 | null>(null);
-  const materialRef = useRef<LineMaterial | null>(null);
 
-  const canvasWidth = size.width;
-  const canvasHeight = size.height;
-
-  const { params, generationStatus } = useDesignerStore(
+  const {
+    width,
+    depth,
+    height,
+    wallThickness,
+    style,
+    slotConfig,
+    dividerPieces,
+    hasLip,
+    generationStatus,
+  } = useDesignerStore(
     useShallow((s) => ({
-      params: s.params,
+      width: s.params.width,
+      depth: s.params.depth,
+      height: s.params.height,
+      wallThickness: s.params.wallThickness,
+      style: s.params.style,
+      slotConfig: s.params.slotConfig,
+      dividerPieces: s.params.dividerPieces,
+      hasLip: s.params.base.stackingLip,
       generationStatus: s.generation.status,
     }))
   );
-
-  const { width, depth, height, wallThickness, style, slotConfig, dividerPieces } = params;
 
   const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
   const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
@@ -49,8 +61,6 @@ export function GhostSlotLines() {
   const innerD = outerD - 2 * wallThickness;
   const totalH = height * GRIDFINITY.HEIGHT_UNIT;
   const topZ = totalH;
-
-  const hasLip = params.base.stackingLip;
   const lipTaperWidth = GRIDFINITY.LIP_SMALL_TAPER + GRIDFINITY.LIP_BIG_TAPER;
   const lipOverhang = hasLip ? Math.max(0, lipTaperWidth - wallThickness) : 0;
 
@@ -118,20 +128,11 @@ export function GhostSlotLines() {
       transparent: true,
       opacity: GHOST_OPACITY,
       depthTest: true,
-      resolution: new THREE.Vector2(canvasWidth, canvasHeight),
+      resolution: new THREE.Vector2(),
     });
-  }, [shouldShow, canvasWidth, canvasHeight]);
+  }, [shouldShow]);
 
-  // Keep materialRef in sync via effect (not during render)
-  useEffect(() => {
-    materialRef.current = material;
-  }, [material]);
-
-  useFrame(() => {
-    if (materialRef.current) {
-      materialRef.current.resolution.set(canvasWidth, canvasHeight);
-    }
-  });
+  useLineMaterialResolution(material);
 
   useEffect(() => {
     return () => {

--- a/src/features/bin-designer/components/preview/GhostSlotLines/GhostSlotLines.tsx
+++ b/src/features/bin-designer/components/preview/GhostSlotLines/GhostSlotLines.tsx
@@ -145,14 +145,12 @@ export function GhostSlotLines() {
     if (geometry && material) invalidate();
   }, [geometry, material, invalidate]);
 
-  if (!geometry || !material) return null;
-
-  return (
-    <primitive
-      ref={lineRef}
-      object={new LineSegments2(geometry, material)}
-      position={[0, 0, 0.1]}
-      renderOrder={2}
-    />
+  const lineSegments = useMemo(
+    () => (geometry && material ? new LineSegments2(geometry, material) : null),
+    [geometry, material]
   );
+
+  if (!lineSegments) return null;
+
+  return <primitive ref={lineRef} object={lineSegments} position={[0, 0, 0.1]} renderOrder={2} />;
 }

--- a/src/features/bin-designer/components/preview/GhostWallCutouts/GhostWallCutouts.tsx
+++ b/src/features/bin-designer/components/preview/GhostWallCutouts/GhostWallCutouts.tsx
@@ -9,12 +9,13 @@
 
 import { useMemo, useEffect, useRef } from 'react';
 import * as THREE from 'three';
-import { useThree, useFrame } from '@react-three/fiber';
+import { useThree } from '@react-three/fiber';
 import { useShallow } from 'zustand/react/shallow';
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { useLineMaterialResolution } from '../useLineMaterialResolution';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 import { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
 
@@ -23,28 +24,28 @@ const GHOST_OPACITY = 0.75;
 const LINE_WIDTH = 2;
 
 export function GhostWallCutouts() {
-  const { invalidate, size } = useThree();
+  const { invalidate } = useThree();
   const lineRef = useRef<LineSegments2 | null>(null);
-  const materialRef = useRef<LineMaterial | null>(null);
 
-  const canvasWidth = size.width;
-  const canvasHeight = size.height;
-
-  const { params, generationStatus } = useDesignerStore(
-    useShallow((s) => ({
-      params: s.params,
-      generationStatus: s.generation.status,
-    }))
-  );
-
-  const { width, depth, height, wallThickness, walls } = params;
+  const { width, depth, height, wallThickness, walls, baseStyle, generationStatus } =
+    useDesignerStore(
+      useShallow((s) => ({
+        width: s.params.width,
+        depth: s.params.depth,
+        height: s.params.height,
+        wallThickness: s.params.wallThickness,
+        walls: s.params.walls,
+        baseStyle: s.params.base.style,
+        generationStatus: s.generation.status,
+      }))
+    );
 
   const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
   const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
   const innerW = outerW - 2 * wallThickness;
   const innerD = outerD - 2 * wallThickness;
   const totalH = height * GRIDFINITY.HEIGHT_UNIT;
-  const isFlat = params.base.style === 'flat';
+  const isFlat = baseStyle === 'flat';
   const wallHeight = isFlat ? totalH : totalH - GRIDFINITY.SOCKET_HEIGHT;
 
   const shouldShow = walls.enabled && generationStatus === 'generating';
@@ -218,19 +219,11 @@ export function GhostWallCutouts() {
       transparent: true,
       opacity: GHOST_OPACITY,
       depthTest: true,
-      resolution: new THREE.Vector2(canvasWidth, canvasHeight),
+      resolution: new THREE.Vector2(),
     });
-  }, [shouldShow, canvasWidth, canvasHeight]);
+  }, [shouldShow]);
 
-  useEffect(() => {
-    materialRef.current = material;
-  }, [material]);
-
-  useFrame(() => {
-    if (materialRef.current) {
-      materialRef.current.resolution.set(canvasWidth, canvasHeight);
-    }
-  });
+  useLineMaterialResolution(material);
 
   useEffect(() => {
     return () => {

--- a/src/features/bin-designer/components/preview/GhostWallCutouts/GhostWallCutouts.tsx
+++ b/src/features/bin-designer/components/preview/GhostWallCutouts/GhostWallCutouts.tsx
@@ -236,14 +236,12 @@ export function GhostWallCutouts() {
     if (geometry && material) invalidate();
   }, [geometry, material, invalidate]);
 
-  if (!geometry || !material) return null;
-
-  return (
-    <primitive
-      ref={lineRef}
-      object={new LineSegments2(geometry, material)}
-      position={[0, 0, 0.1]}
-      renderOrder={2}
-    />
+  const lineSegments = useMemo(
+    () => (geometry && material ? new LineSegments2(geometry, material) : null),
+    [geometry, material]
   );
+
+  if (!lineSegments) return null;
+
+  return <primitive ref={lineRef} object={lineSegments} position={[0, 0, 0.1]} renderOrder={2} />;
 }

--- a/src/features/bin-designer/components/preview/GhostWireframe/GhostWireframe.tsx
+++ b/src/features/bin-designer/components/preview/GhostWireframe/GhostWireframe.tsx
@@ -10,13 +10,14 @@
 
 import { useMemo, useEffect, useRef } from 'react';
 import * as THREE from 'three';
-import { useThree, useFrame } from '@react-three/fiber';
+import { useThree } from '@react-three/fiber';
 import { useShallow } from 'zustand/react/shallow';
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
+import { useLineMaterialResolution } from '../useLineMaterialResolution';
 
 /** Ghost line color (matches selection ring yellow used in 2D grid editor) */
 const GHOST_COLOR = '#fbbf24';
@@ -25,21 +26,17 @@ const GHOST_OPACITY = 0.85;
 const LINE_WIDTH = 2;
 
 export function GhostWireframe() {
-  const { invalidate, size } = useThree();
+  const { invalidate } = useThree();
   const lineRef = useRef<LineSegments2 | null>(null);
-  const materialRef = useRef<LineMaterial | null>(null);
 
-  const canvasWidth = size.width;
-  const canvasHeight = size.height;
-
-  const { params, generationStatus } = useDesignerStore(
+  const { width, depth, height, generationStatus } = useDesignerStore(
     useShallow((s) => ({
-      params: s.params,
+      width: s.params.width,
+      depth: s.params.depth,
+      height: s.params.height,
       generationStatus: s.generation.status,
     }))
   );
-
-  const { width, depth, height } = params;
 
   // Calculate bin dimensions
   const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
@@ -146,7 +143,7 @@ export function GhostWireframe() {
     return geo;
   }, [shouldShow, outerW, outerD, totalH]);
 
-  // Create material
+  // Create material (resolution set via effect — avoids recreating on resize)
   const material = useMemo(() => {
     if (!shouldShow) return null;
 
@@ -156,21 +153,11 @@ export function GhostWireframe() {
       transparent: true,
       opacity: GHOST_OPACITY,
       depthTest: true,
-      resolution: new THREE.Vector2(canvasWidth, canvasHeight),
+      resolution: new THREE.Vector2(),
     });
-  }, [shouldShow, canvasWidth, canvasHeight]);
+  }, [shouldShow]);
 
-  // Sync material ref after render (not during render)
-  useEffect(() => {
-    materialRef.current = material;
-  }, [material]);
-
-  // Update resolution on resize
-  useFrame(() => {
-    if (materialRef.current) {
-      materialRef.current.resolution.set(canvasWidth, canvasHeight);
-    }
-  });
+  useLineMaterialResolution(material);
 
   // Dispose resources on unmount or change
   useEffect(() => {

--- a/src/features/bin-designer/components/preview/GhostWireframe/GhostWireframe.tsx
+++ b/src/features/bin-designer/components/preview/GhostWireframe/GhostWireframe.tsx
@@ -172,14 +172,12 @@ export function GhostWireframe() {
     if (geometry && material) invalidate();
   }, [geometry, material, invalidate]);
 
-  if (!geometry || !material) return null;
-
-  return (
-    <primitive
-      ref={lineRef}
-      object={new LineSegments2(geometry, material)}
-      position={[0, 0, 0.1]}
-      renderOrder={3}
-    />
+  const lineSegments = useMemo(
+    () => (geometry && material ? new LineSegments2(geometry, material) : null),
+    [geometry, material]
   );
+
+  if (!lineSegments) return null;
+
+  return <primitive ref={lineRef} object={lineSegments} position={[0, 0, 0.1]} renderOrder={3} />;
 }

--- a/src/features/bin-designer/components/preview/useLineMaterialResolution.test.ts
+++ b/src/features/bin-designer/components/preview/useLineMaterialResolution.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
+import { useLineMaterialResolution } from './useLineMaterialResolution';
+
+const sizeMock = { width: 0, height: 0 };
+
+vi.mock('@react-three/fiber', () => ({
+  useThree: () => ({ size: sizeMock }),
+}));
+
+function makeMaterial() {
+  return { resolution: { set: vi.fn() } } as unknown as LineMaterial;
+}
+
+describe('useLineMaterialResolution', () => {
+  beforeEach(() => {
+    sizeMock.width = 800;
+    sizeMock.height = 600;
+  });
+
+  it('sets resolution on mount when material is non-null', () => {
+    const material = makeMaterial();
+    renderHook(() => useLineMaterialResolution(material));
+    expect(material.resolution.set).toHaveBeenCalledWith(800, 600);
+  });
+
+  it('is a no-op when material is null', () => {
+    expect(() => renderHook(() => useLineMaterialResolution(null))).not.toThrow();
+  });
+
+  it('updates resolution when canvas size changes', () => {
+    const material = makeMaterial();
+    const { rerender } = renderHook(() => useLineMaterialResolution(material));
+    vi.mocked(material.resolution.set).mockClear();
+
+    sizeMock.width = 1200;
+    sizeMock.height = 900;
+    rerender();
+
+    expect(material.resolution.set).toHaveBeenCalledWith(1200, 900);
+  });
+
+  it('updates resolution when material reference changes', () => {
+    const first = makeMaterial();
+    const { rerender } = renderHook(
+      ({ material }: { material: LineMaterial | null }) => useLineMaterialResolution(material),
+      { initialProps: { material: first } }
+    );
+    expect(first.resolution.set).toHaveBeenCalledWith(800, 600);
+
+    const second = makeMaterial();
+    rerender({ material: second });
+    expect(second.resolution.set).toHaveBeenCalledWith(800, 600);
+  });
+});

--- a/src/features/bin-designer/components/preview/useLineMaterialResolution.test.ts
+++ b/src/features/bin-designer/components/preview/useLineMaterialResolution.test.ts
@@ -4,9 +4,10 @@ import type { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { useLineMaterialResolution } from './useLineMaterialResolution';
 
 const sizeMock = { width: 0, height: 0 };
+const invalidateMock = vi.fn();
 
 vi.mock('@react-three/fiber', () => ({
-  useThree: () => ({ size: sizeMock }),
+  useThree: () => ({ size: sizeMock, invalidate: invalidateMock }),
 }));
 
 function makeMaterial() {
@@ -17,12 +18,14 @@ describe('useLineMaterialResolution', () => {
   beforeEach(() => {
     sizeMock.width = 800;
     sizeMock.height = 600;
+    invalidateMock.mockClear();
   });
 
   it('sets resolution on mount when material is non-null', () => {
     const material = makeMaterial();
     renderHook(() => useLineMaterialResolution(material));
     expect(material.resolution.set).toHaveBeenCalledWith(800, 600);
+    expect(invalidateMock).toHaveBeenCalled();
   });
 
   it('is a no-op when material is null', () => {

--- a/src/features/bin-designer/components/preview/useLineMaterialResolution.ts
+++ b/src/features/bin-designer/components/preview/useLineMaterialResolution.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useThree } from '@react-three/fiber';
+import type { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
+
+/**
+ * Sync a LineMaterial's resolution to the canvas size whenever it changes.
+ * LineMaterial needs accurate resolution for correct pixel-space line widths.
+ * Pass null when the material isn't ready — the effect is a no-op then.
+ */
+export function useLineMaterialResolution(material: LineMaterial | null): void {
+  const { size } = useThree();
+  useEffect(() => {
+    if (material) material.resolution.set(size.width, size.height);
+  }, [material, size.width, size.height]);
+}

--- a/src/features/bin-designer/components/preview/useLineMaterialResolution.ts
+++ b/src/features/bin-designer/components/preview/useLineMaterialResolution.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import { useThree } from '@react-three/fiber';
 import type { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 
@@ -6,10 +6,15 @@ import type { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
  * Sync a LineMaterial's resolution to the canvas size whenever it changes.
  * LineMaterial needs accurate resolution for correct pixel-space line widths.
  * Pass null when the material isn't ready — the effect is a no-op then.
+ *
+ * Uses useLayoutEffect + invalidate() so the resolution is correct before the
+ * first paint and a new frame is scheduled under frameloop="demand".
  */
 export function useLineMaterialResolution(material: LineMaterial | null): void {
-  const { size } = useThree();
-  useEffect(() => {
-    if (material) material.resolution.set(size.width, size.height);
-  }, [material, size.width, size.height]);
+  const { size, invalidate } = useThree();
+  useLayoutEffect(() => {
+    if (!material) return;
+    material.resolution.set(size.width, size.height);
+    invalidate();
+  }, [material, size.width, size.height, invalidate]);
 }

--- a/src/features/generation/worker/generators/baseplateDirectMesh.test.ts
+++ b/src/features/generation/worker/generators/baseplateDirectMesh.test.ts
@@ -373,6 +373,21 @@ describe('baseplateDirectMesh', () => {
     expect(bbWith.maxX).toBeCloseTo(bbWithout.maxX, 1);
   });
 
+  // ─── Validation ────────────────────────────────────────────────────────
+  it('throws for zero or negative dimensions', () => {
+    expect(() => generateDirect(defaults({ width: 0 }), noop)).toThrow(
+      /Invalid baseplate dimensions/
+    );
+    expect(() => generateDirect(defaults({ depth: -1 }), noop)).toThrow(
+      /Invalid baseplate dimensions/
+    );
+  });
+
+  it('throws when dimensions exceed MAX_BASEPLATE_GRID', () => {
+    expect(() => generateDirect(defaults({ width: 51 }), noop)).toThrow(/exceed maximum/);
+    expect(() => generateDirect(defaults({ depth: 999 }), noop)).toThrow(/exceed maximum/);
+  });
+
   // ─── Speed comparison ──────────────────────────────────────────────────
   it('4×4 with magnets: direct is at least 10x faster than BREP', () => {
     const params = defaults({ width: 4, depth: 4, magnetHoles: true });

--- a/src/features/generation/worker/generators/baseplateDirectMesh.ts
+++ b/src/features/generation/worker/generators/baseplateDirectMesh.ts
@@ -768,6 +768,8 @@ function tangentVectors(nx: number, ny: number): [number, number, number, number
  * Produces a waffle-grid slab with tapered pockets, optional magnet holes in a
  * solid floor, and a rounded outer perimeter. Targets <50ms for any grid size.
  */
+const MAX_BASEPLATE_GRID_DIRECT = 50;
+
 export function generateBaseplateDirect(
   params: BaseplateParams,
   onProgress: ProgressFn,
@@ -781,6 +783,11 @@ export function generateBaseplateDirect(
     params.depth <= 0
   ) {
     throw new Error(`Invalid baseplate dimensions: ${params.width}x${params.depth}`);
+  }
+  if (params.width > MAX_BASEPLATE_GRID_DIRECT || params.depth > MAX_BASEPLATE_GRID_DIRECT) {
+    throw new Error(
+      `Baseplate dimensions ${params.width}x${params.depth} exceed maximum ${MAX_BASEPLATE_GRID_DIRECT}`
+    );
   }
 
   onProgress('base', 0);

--- a/src/features/generation/worker/generators/baseplateDirectMesh.ts
+++ b/src/features/generation/worker/generators/baseplateDirectMesh.ts
@@ -22,6 +22,7 @@
  */
 
 import type { BaseplateParams } from '@/shared/types/bin';
+import { CONSTRAINTS } from '@/core/constants';
 import { resolveCornerRadii } from './generatorConstants';
 import type { MeshData } from '../../bridge/types';
 import {
@@ -768,8 +769,6 @@ function tangentVectors(nx: number, ny: number): [number, number, number, number
  * Produces a waffle-grid slab with tapered pockets, optional magnet holes in a
  * solid floor, and a rounded outer perimeter. Targets <50ms for any grid size.
  */
-const MAX_BASEPLATE_GRID_DIRECT = 50;
-
 export function generateBaseplateDirect(
   params: BaseplateParams,
   onProgress: ProgressFn,
@@ -784,9 +783,9 @@ export function generateBaseplateDirect(
   ) {
     throw new Error(`Invalid baseplate dimensions: ${params.width}x${params.depth}`);
   }
-  if (params.width > MAX_BASEPLATE_GRID_DIRECT || params.depth > MAX_BASEPLATE_GRID_DIRECT) {
+  if (params.width > CONSTRAINTS.GRID_MAX || params.depth > CONSTRAINTS.GRID_MAX) {
     throw new Error(
-      `Baseplate dimensions ${params.width}x${params.depth} exceed maximum ${MAX_BASEPLATE_GRID_DIRECT}`
+      `Baseplate dimensions ${params.width}x${params.depth} exceed maximum ${CONSTRAINTS.GRID_MAX}`
     );
   }
 


### PR DESCRIPTION
## Summary

Two focused commits addressing gap-finder, review, and perf findings across the recent bin-designer / baseplate / generation churn.

### Commit 1: bug/correctness fixes
- **Schema gap**: `baseplateParamsSchema` now validates `lightweight`, `cornerRadius`, `cornerRadii`. These three optional fields of `BaseplateParams` were missing from the Zod schema, so the CQRS validation middleware let them through unvalidated.
- **Rules-of-Hooks**: `TouchHint` (in `PreviewCanvas`) now subscribes to `dismissedHints` via a `useSettingsStore` selector instead of calling `getState()` during render. The hint was previously a stale snapshot.
- **OOM guard**: `generateBaseplateDirect` now enforces `MAX_BASEPLATE_GRID` like the BREP path. #1373 only guarded the BREP path; the direct-mesh path had no upper cap.
- **Stale test comment**: `BinNameLabel.test.tsx` cited `CHAR_WIDTH_RATIO ≈ 0.68`, actual is `0.6` (with `+0.08` letter-spacing in `estimateTextWidth`).

### Commit 2: Ghost preview perf
- **Narrow Zustand selectors** in 10 `Ghost*` components. They were pulling `params: s.params` (the entire `BinParams` object) via `useShallow` then destructuring a handful of fields. `useShallow` does one-level shallow compare, so unrelated param edits (walls, handles, scoops, etc.) would invalidate the selector result and re-render every ghost component. Now each selects only the scalar/object fields it uses.
- **Replace per-frame `useFrame` resolution sync** with `useEffect` keyed on canvas size in 6 files. Materials are no longer recreated on resize either — `LineMaterial` is built once per `shouldShow` change with a default `Vector2()`, and its `resolution` is updated via effect only when size actually changes.
- **Extract `useLineMaterialResolution` hook** — the sync pattern appeared at 7 call sites. New hook encapsulates the `useThree().size` + `useEffect` combo; one-line adoption at each site.

## Test plan
- [x] `pnpm run test:run` — 9778 tests pass (added 2 baseplate validation tests, 3 schema validation tests, 4 hook tests)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — no new errors (64 pre-existing warnings unchanged)
- [ ] Manual smoke test of ghost preview interactions in dev after reviewer feedback
- [ ] Verify baseplate generation at edge sizes (1, 50) in dev after reviewer feedback

## Not addressed (investigated, skipped as false positives)
- `fitToPage` math ignoring `showBinList`/`showLegend` — PR #1378 commit explicitly documents "Fit grid to page" constrains the grid only.
- `connectorUtils` half-bin placement — `Math.ceil(depth) - 1` correctly places connectors at integer grid boundaries for fractional pieces.
- `cornerRadii` reference instability in `useBaseplateGeneration` — Immer structural sharing already preserves the reference.