### PR TITLE
chore: quality fixes (migration loss, BREP drift, opacity, a11y, timers)

### DIFF
--- a/src/core/constants.test.ts
+++ b/src/core/constants.test.ts
@@ -324,6 +324,59 @@ describe('migrateBaseplateParams', () => {
     expect(result.paddingLeft).toBe(0);
     expect(result.connectorNubs).toBeUndefined();
   });
+
+  it('preserves invertDovetails, lightweight, cornerRadius, and cornerRadii', () => {
+    const stored = {
+      magnetHoles: false,
+      magnetDiameter: 6.5,
+      magnetDepth: 2,
+      paddingLeft: 0,
+      paddingRight: 0,
+      paddingFront: 0,
+      paddingBack: 0,
+      invertDovetails: true,
+      lightweight: false,
+      cornerRadius: 3.5,
+      cornerRadii: { tl: 1, tr: 2, bl: 3, br: 4 },
+    };
+    const result = migrateBaseplateParams(stored);
+    expect(result.invertDovetails).toBe(true);
+    expect(result.lightweight).toBe(false);
+    expect(result.cornerRadius).toBe(3.5);
+    expect(result.cornerRadii).toEqual({ tl: 1, tr: 2, bl: 3, br: 4 });
+  });
+
+  it('clamps cornerRadius and cornerRadii to [0, 200] mm', () => {
+    const stored = {
+      magnetHoles: false,
+      magnetDiameter: 6.5,
+      magnetDepth: 2,
+      paddingLeft: 0,
+      paddingRight: 0,
+      paddingFront: 0,
+      paddingBack: 0,
+      cornerRadius: 9999,
+      cornerRadii: { tl: -5, tr: 500, bl: 10, br: 10 },
+    };
+    const result = migrateBaseplateParams(stored);
+    expect(result.cornerRadius).toBe(200);
+    expect(result.cornerRadii).toEqual({ tl: 0, tr: 200, bl: 10, br: 10 });
+  });
+
+  it('ignores invalid cornerRadii shape', () => {
+    const stored = {
+      magnetHoles: false,
+      magnetDiameter: 6.5,
+      magnetDepth: 2,
+      paddingLeft: 0,
+      paddingRight: 0,
+      paddingFront: 0,
+      paddingBack: 0,
+      cornerRadii: { tl: 'oops' },
+    };
+    const result = migrateBaseplateParams(stored);
+    expect(result.cornerRadii).toBeUndefined();
+  });
 });
 
 describe('getDefaultDrawerSize', () => {

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -243,6 +243,14 @@ export function migrateBaseplateParams(stored: unknown): BaseplateParams {
     };
   }
   // Validate and clamp all fields from persisted/imported data
+  const radii = obj.cornerRadii;
+  const hasRadii =
+    radii !== null &&
+    typeof radii === 'object' &&
+    typeof (radii as Record<string, unknown>).tl === 'number' &&
+    typeof (radii as Record<string, unknown>).tr === 'number' &&
+    typeof (radii as Record<string, unknown>).bl === 'number' &&
+    typeof (radii as Record<string, unknown>).br === 'number';
   return {
     magnetHoles: typeof obj.magnetHoles === 'boolean' ? obj.magnetHoles : false,
     magnetDiameter: mm(clampNumber(obj.magnetDiameter, 0.5, 20, 6.5)),
@@ -252,12 +260,35 @@ export function migrateBaseplateParams(stored: unknown): BaseplateParams {
     paddingFront: mm(clampNumber(obj.paddingFront, 0, 100, 0)),
     paddingBack: mm(clampNumber(obj.paddingBack, 0, 100, 0)),
     ...(typeof obj.connectorNubs === 'boolean' ? { connectorNubs: obj.connectorNubs } : {}),
+    ...(typeof obj.invertDovetails === 'boolean' ? { invertDovetails: obj.invertDovetails } : {}),
+    ...(typeof obj.lightweight === 'boolean' ? { lightweight: obj.lightweight } : {}),
     ...(typeof obj.syncWithLayout === 'boolean' ? { syncWithLayout: obj.syncWithLayout } : {}),
     ...(typeof obj.baseplateWidth === 'number'
-      ? { baseplateWidth: gridUnits(Math.min(50, Math.max(0.5, obj.baseplateWidth))) }
+      ? {
+          baseplateWidth: gridUnits(
+            Math.min(CONSTRAINTS.GRID_MAX, Math.max(CONSTRAINTS.GRID_MIN, obj.baseplateWidth))
+          ),
+        }
       : {}),
     ...(typeof obj.baseplateDepth === 'number'
-      ? { baseplateDepth: gridUnits(Math.min(50, Math.max(0.5, obj.baseplateDepth))) }
+      ? {
+          baseplateDepth: gridUnits(
+            Math.min(CONSTRAINTS.GRID_MAX, Math.max(CONSTRAINTS.GRID_MIN, obj.baseplateDepth))
+          ),
+        }
+      : {}),
+    ...(typeof obj.cornerRadius === 'number'
+      ? { cornerRadius: mm(clampNumber(obj.cornerRadius, 0, 200, 0)) }
+      : {}),
+    ...(hasRadii
+      ? {
+          cornerRadii: {
+            tl: mm(clampNumber((radii as Record<string, unknown>).tl, 0, 200, 0)),
+            tr: mm(clampNumber((radii as Record<string, unknown>).tr, 0, 200, 0)),
+            bl: mm(clampNumber((radii as Record<string, unknown>).bl, 0, 200, 0)),
+            br: mm(clampNumber((radii as Record<string, unknown>).br, 0, 200, 0)),
+          },
+        }
       : {}),
   };
 }

--- a/src/core/cqrs/validation/schemas.test.ts
+++ b/src/core/cqrs/validation/schemas.test.ts
@@ -19,6 +19,7 @@ describe('COMMAND_SCHEMAS', () => {
     'bin.moveToStaging',
     'bin.moveFromStaging',
     'bin.fillLayer',
+    'bin.fillGaps',
     'bin.clearLayer',
     'layer.add',
     'layer.update',

--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -46,6 +46,7 @@ import { setPreviewCanvas, setPreviewContext, clearPreviewCanvas } from '../../u
 import { describeBin, getStatusAnnouncement } from '../../utils/a11y';
 import { useResponsive } from '@/shared/hooks/useResponsive';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
+import { usePrefersReducedMotion } from '@/shared/hooks/usePrefersReducedMotion';
 import { useTranslation } from '@/i18n';
 import { useToastStore } from '@/core/store/toast';
 import { useSettingsStore } from '@/core/store/settings';
@@ -674,6 +675,9 @@ const LOADING_MESSAGE_COUNT = 12;
  */
 function GeneratingIndicator() {
   const t = useTranslation();
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const reduceMotionSetting = useSettingsStore((s) => s.settings.reduceMotion);
+  const reduceMotion = prefersReducedMotion || reduceMotionSetting;
 
   const loadingMessages = useMemo(
     () =>
@@ -685,13 +689,14 @@ function GeneratingIndicator() {
     Math.floor(Math.random() * LOADING_MESSAGE_COUNT)
   );
 
-  // Cycle through messages every 1.5 seconds
+  // Cycle through messages every 1.5 seconds; skip when motion is reduced.
   useEffect(() => {
+    if (reduceMotion) return;
     const interval = setInterval(() => {
       setMessageIndex((prev) => (prev + 1) % LOADING_MESSAGE_COUNT);
     }, 1500);
     return () => clearInterval(interval);
-  }, []);
+  }, [reduceMotion]);
 
   return (
     <div

--- a/src/features/bin-designer/components/preview/useLineMaterialResolution.test.ts
+++ b/src/features/bin-designer/components/preview/useLineMaterialResolution.test.ts
@@ -56,4 +56,26 @@ describe('useLineMaterialResolution', () => {
     rerender({ material: second });
     expect(second.resolution.set).toHaveBeenCalledWith(800, 600);
   });
+
+  it('skips setting resolution when canvas size is 0×0 (pre-measurement)', () => {
+    sizeMock.width = 0;
+    sizeMock.height = 0;
+    const material = makeMaterial();
+    renderHook(() => useLineMaterialResolution(material));
+    expect(material.resolution.set).not.toHaveBeenCalled();
+    expect(invalidateMock).not.toHaveBeenCalled();
+  });
+
+  it('applies resolution once size becomes non-zero after a 0×0 pre-measurement', () => {
+    sizeMock.width = 0;
+    sizeMock.height = 0;
+    const material = makeMaterial();
+    const { rerender } = renderHook(() => useLineMaterialResolution(material));
+    expect(material.resolution.set).not.toHaveBeenCalled();
+
+    sizeMock.width = 800;
+    sizeMock.height = 600;
+    rerender();
+    expect(material.resolution.set).toHaveBeenCalledWith(800, 600);
+  });
 });

--- a/src/features/bin-designer/components/preview/useLineMaterialResolution.ts
+++ b/src/features/bin-designer/components/preview/useLineMaterialResolution.ts
@@ -14,6 +14,9 @@ export function useLineMaterialResolution(material: LineMaterial | null): void {
   const { size, invalidate } = useThree();
   useLayoutEffect(() => {
     if (!material) return;
+    // Skip pre-measurement frames (0×0) — some drivers render NaN line widths
+    // when resolution is zero. r3f will fire a second effect once size is real.
+    if (size.width === 0 || size.height === 0) return;
     material.resolution.set(size.width, size.height);
     invalidate();
   }, [material, size.width, size.height, invalidate]);

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -66,6 +66,7 @@ import type { CacheStats } from './lruCache';
 import { LRUCache } from './lruCache';
 import { buildCacheKey, quantize } from './cacheKeyUtils';
 import { buildLightweightFloorCutters } from './lightweightFloorCutter';
+import { CONSTRAINTS } from '@/core/constants';
 
 // LRU cache for pocket templates keyed by cell size + forExport + floorDepth.
 // Build one loft per unique cell size, then clone+translate for each grid position.
@@ -894,9 +895,6 @@ function buildSlabProfile(
   return pen.close();
 }
 
-/** Maximum grid dimension for baseplate generation (units). */
-const MAX_BASEPLATE_GRID = 50;
-
 /**
  * Validate and clamp baseplate params to safe ranges.
  * Throws on clearly invalid dimensions (NaN, zero, negative) to surface
@@ -911,9 +909,9 @@ function sanitizeParams(params: BaseplateParams): BaseplateParams {
   ) {
     throw new Error(`Invalid baseplate dimensions: ${params.width}x${params.depth}`);
   }
-  if (params.width > MAX_BASEPLATE_GRID || params.depth > MAX_BASEPLATE_GRID) {
+  if (params.width > CONSTRAINTS.GRID_MAX || params.depth > CONSTRAINTS.GRID_MAX) {
     throw new Error(
-      `Baseplate dimensions ${params.width}x${params.depth} exceed maximum ${MAX_BASEPLATE_GRID}`
+      `Baseplate dimensions ${params.width}x${params.depth} exceed maximum ${CONSTRAINTS.GRID_MAX}`
     );
   }
 

--- a/src/features/grid-editor/components/Grid/IsometricPreview/AnimatedBinMesh/AnimatedBinMesh.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/AnimatedBinMesh/AnimatedBinMesh.tsx
@@ -31,22 +31,26 @@ export function AnimatedBinMesh({ binData, transition }: AnimatedBinMeshProps) {
     const material = materialRef.current;
     if (!mesh || !material) return;
 
+    let z: number;
+    let scale: number;
+    let opacity: number;
     if (transition.phase === 'entering') {
-      // Position: target z + spring offset (spring settles toward 0).
-      mesh.position.set(binData.x, binData.y, binData.z + transition.springPos);
-      mesh.scale.set(1, 1, 1);
-      material.opacity = 1;
-      material.transparent = false;
-      material.depthWrite = true;
+      // Spring settles toward 0 above target z.
+      z = binData.z + transition.springPos;
+      scale = 1;
+      opacity = binData.opacity;
     } else {
-      // Exiting: shrink and fade.
-      mesh.position.set(binData.x, binData.y, binData.z);
-      const s = transition.scale;
-      mesh.scale.set(s, s, s);
-      material.opacity = transition.opacity;
-      material.transparent = transition.opacity < 1;
-      material.depthWrite = transition.opacity === 1;
+      // Exiting: shrink and fade; compose with any dimming in binData.opacity.
+      z = binData.z;
+      scale = transition.scale;
+      opacity = transition.opacity * binData.opacity;
     }
+
+    mesh.position.set(binData.x, binData.y, z);
+    mesh.scale.set(scale, scale, scale);
+    material.opacity = opacity;
+    material.transparent = opacity < 1;
+    material.depthWrite = opacity === 1;
   });
 
   // Initial position for entering bins (before first useFrame tick).

--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
@@ -189,13 +189,29 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
   // Track exit animation — keep groups mounted with offset=0 so useFrame can lerp back.
   // The cleanup function fires when isExplodedView goes from true→false, starting exit animation.
   const [isExplodeExiting, setIsExplodeExiting] = useState(false);
+  const exitTimerRef = useRef<number | null>(null);
   useEffect(() => {
     if (!isExplodedView) return;
     return () => {
       setIsExplodeExiting(true);
-      setTimeout(() => setIsExplodeExiting(false), 600);
+      if (exitTimerRef.current !== null) {
+        window.clearTimeout(exitTimerRef.current);
+      }
+      exitTimerRef.current = window.setTimeout(() => {
+        setIsExplodeExiting(false);
+        exitTimerRef.current = null;
+      }, 600);
     };
   }, [isExplodedView]);
+  useEffect(() => {
+    // Clear pending exit-animation timer on unmount to avoid setState-after-unmount.
+    return () => {
+      if (exitTimerRef.current !== null) {
+        window.clearTimeout(exitTimerRef.current);
+        exitTimerRef.current = null;
+      }
+    };
+  }, []);
 
   // Exploded layer view: per-layer bin groups with Z offsets and opacity
   const explodedLayerGroups = useExplodedLayerView({


### PR DESCRIPTION
## Summary

Seven high-confidence fixes from a gap-finder + reviewer sweep of the last week's changes. No behavior changes for valid inputs — these repair silent failure modes (data loss, invariant violations, leaked timers) and close a dual-path drift.

- **BREP path drift** — `baseplateGenerator.sanitizeParams` used a local `MAX_BASEPLATE_GRID = 50`; the direct-mesh path already uses `CONSTRAINTS.GRID_MAX`. Same source of truth now.
- **Silent migration loss** — `migrateBaseplateParams` was dropping `cornerRadius`, `cornerRadii`, `invertDovetails`, and `lightweight` from persisted layouts even though the Zod schema validates them. Users lost those settings on reload. Fixed; magic number `50` replaced with `CONSTRAINTS.GRID_MIN/MAX`.
- **Missing command in test guard** — `ALL_COMMAND_TYPES` in `schemas.test.ts` was missing `bin.fillGaps`, so new domain commands without schemas could slip past the "missing schema" check.
- **AnimatedBinMesh opacity invariant** — `useFrame` was overwriting `material.opacity`, ignoring `binData.opacity`. Latent today (bin opacity is always 1 in flat view) but would surface the moment `AnimatedBinMesh` is used in exploded view. Now composes multiplicatively.
- **Reduce-motion gap** — `GeneratingIndicator` message cycling (1.5s `setInterval`) didn't honor `prefers-reduced-motion` or `settings.reduceMotion`. Now skipped when either is set.
- **Untracked `setTimeout`** — `IsometricPreview` explode-exit timer wasn't tracked; rapid toggles stacked timers and unmount during the 600 ms window would `setState` on an unmounted component. Timer now held in a ref, cleared on re-toggle and unmount.
- **0×0 LineMaterial resolution** — `useLineMaterialResolution` unconditionally wrote `size.width`/`size.height`; when r3f hasn't measured yet (first paint under `frameloop="demand"` or Suspense), those are 0 and some drivers render NaN line widths. Now guarded.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors, pre-existing warnings unchanged
- [x] `pnpm run test:run` — all 9783 tests pass (added 5 new: 3 for `migrateBaseplateParams` field preservation + clamping, 2 for `useLineMaterialResolution` zero-size guard)
- [x] `pnpm run check:i18n` + `check:i18n:values` + `check:i18n:interpolation` — all green
- [x] Pre-commit hooks passed (module boundaries, exhaustiveness, component structure, missing tests)
- [ ] Manually verify: open a layout saved with custom `cornerRadius` / `invertDovetails` and confirm they survive reload
- [ ] Manually verify: toggle exploded-view rapidly, confirm no console warnings about setState on unmounted components
- [ ] Manually verify with `prefers-reduced-motion: reduce`, confirm loading indicator shows a static message