### PR TITLE
fix(mutation-testing): relax vite fs.strict for Stryker sandbox

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,15 @@ const domIncludes = [
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    fs: {
+      // pnpm's symlinked node_modules resolve outside the project root;
+      // Stryker's sandbox copy trips vite's fs.strict when tests import
+      // `?url` WASM assets. Tests don't run a dev server, so relaxing
+      // this is safe.
+      strict: false,
+    },
+  },
   test: {
     globals: true,
     testTimeout: 30000,


### PR DESCRIPTION
## Summary

Follow-up to #1395. Unblocks the nightly mutation run.

Stryker's sandbox copy of the project has pnpm-style symlinked `node_modules` that resolve *outside* the sandbox root. Vitest honours vite's `server.fs.strict` even though tests don't run a dev server, so `?url` imports of WASM binaries (e.g. `brepjs-opencascade/src/brepjs_single.wasm?url`) fail the initial dry run with `Denied ID`.

Disabling `fs.strict` for the vitest config is safe — tests never serve files over HTTP — and lets the full 148-file mutation scope run end-to-end.

## Repro on main (pre-fix)

```
$ pnpm run test:mutation
INFO Instrumenter Instrumented 148 source file(s) with 12332 mutant(s)
ERROR DryRunExecutor One or more tests failed in the initial test run:
	preloadWasmBinary preloads single-threaded WASM
		Denied ID /var/home/andy/Git/gridfinity-layout-tool/node_modules/.pnpm/brepjs-opencascade@0.15.6/node_modules/brepjs-opencascade/src/brepjs_single.wasm?url
ConfigError: There were failed tests in the initial test run.
```

## After fix

Sample run of the previously-failing module:
```
File            |  total | covered | # killed | # timeout | # survived | # no cov
wasmPreload.ts  |  90.00 |  100.00 |       18 |         0 |          0 |        2
Done in 31 seconds.
```

## Test plan

- [ ] CI green
- [ ] Manually trigger `Mutation Testing` workflow → initial dry run passes, full run completes