### PR TITLE
chore(mutation-testing): tune timeouts from baseline-run learnings

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -20,7 +20,7 @@ jobs:
   mutation:
     name: Stryker
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@v6
 

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -21,7 +21,7 @@
     "!**/__mocks__/**",
     "!**/types.ts"
   ],
-  "timeoutMS": 60000,
+  "timeoutMS": 120000,
   "concurrency": 2,
   "incremental": true,
   "incrementalFile": "reports/mutation/incremental.json",


### PR DESCRIPTION
## Summary

Follow-up to #1395 / #1396. Applies what multiple local baseline attempts taught us about Stryker runtime cost on this codebase.

## What we learned

Across several runs at concurrency 2/6/12 on a 16-core / 64 GB local machine:

| Attempt            | Concurrency | Observed         | Takeaway                              |
| ------------------ | ----------- | ---------------- | ------------------------------------- |
| Full scope, local  | 12          | Swap exhausted (8 GB/8 GB) @ ~87 mutants/min | 12 workers blow past 16 GB on 64 GB, let alone 16 GB CI |
| Full scope, local  | 6           | ~118/min start, dropping to ~34/min in generators tail | Generators are 10-30× slower per mutant than utils/result |
| Narrow (no gens)   | 6           | 93% in 32 min, then ~5/min tail | Even non-generator tail has slow mutants |
| Per-attempt        | —           | 20-55 false `TimedOut` | 60 s per-mutant timeout is too tight for geometry tests |

## Changes

1. **`timeout-minutes`: 90 → 360** on the nightly workflow. 90 min wasn't survivable for any cold-cache full-scope run we attempted. 6 h is realistic for nightly on 4-vCPU GH runners.
2. **`timeoutMS`: 60 000 → 120 000** in `stryker.config.json`. Halves false-timeout noise on slow generator mutants. Stryker still counts TimedOut as killed, but scores are more meaningful without the noise.

## What we're deliberately NOT changing

- **`concurrency: 2`** stays in the committed config. GH-hosted `ubuntu-latest` has 16 GB RAM; our local 64 GB machine was already swap-thrashing at higher values. Local users can override with `--concurrency 6` (documented follow-up: add to CLAUDE.md if useful).
- **Scope** stays full (148 files). Generators are the bug-prone area; excluding them defeats the purpose.

## Test plan

- [ ] CI green
- [ ] After merge, trigger `Mutation Testing` workflow manually → confirm run completes within 6 h and uploads artifacts