### PR TITLE
fix(designer,baseplate): unclip language dropdown in page headers

### DIFF
--- a/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
+++ b/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
@@ -145,7 +145,7 @@ export function BaseplatePage() {
   return (
     <div className="flex h-screen flex-col bg-surface">
       {/* Header */}
-      <header className="h-12 flex items-center justify-between px-4 bg-surface-secondary border-b border-stroke-subtle overflow-hidden">
+      <header className="h-12 flex items-center justify-between px-4 bg-surface-secondary border-b border-stroke-subtle">
         <div className="flex items-center gap-3 min-w-0">
           <ToolSwitcher compact={isMobile} iconOnly={isMobile || isTablet} />
 

--- a/src/features/bin-designer/components/DesignerPage/DesignerHeader.tsx
+++ b/src/features/bin-designer/components/DesignerPage/DesignerHeader.tsx
@@ -58,7 +58,7 @@ export function DesignerHeader({ isDesktop, nameEditor }: DesignerHeaderProps) {
   } = nameEditor;
 
   return (
-    <header className="h-12 flex items-center justify-between px-4 bg-surface-secondary border-b border-stroke-subtle overflow-hidden">
+    <header className="h-12 flex items-center justify-between px-4 bg-surface-secondary border-b border-stroke-subtle">
       {isDesktop ? (
         /* ---- Desktop action bar ---- */
         <>


### PR DESCRIPTION
## Summary

- The bin designer and baseplate page headers used `overflow-hidden`, which clipped the absolutely-positioned `LanguageSelector` dropdown that opens below the header
- Removing the class aligns these headers with the main app `Header` (`src/shell/Header/Header.tsx:100`), which already omits `overflow-hidden` — that's why the language menu works on the home page but not on the designer/baseplate pages
- `min-w-0` on the left cluster and `flex-shrink-0` on the right cluster already prevent horizontal overflow, so the class was redundant

Fixes #1399

## Test plan

- [x] \`pnpm run typecheck\` — clean
- [x] \`pnpm run lint\` — no new issues
- [x] \`pnpm run test:run\` on affected components (DesignerPage, BaseplatePage, LanguageSelector) — all pass
- [ ] Manual: open Designer page, click language globe, confirm dropdown is visible
- [ ] Manual: open Baseplate page, click language globe, confirm dropdown is visible