### PR TITLE
chore(utils): consolidate split-position helpers into shared/utils

### DIFF
--- a/src/features/bin-designer/components/panel/SplitOptionsSection/useSplitOptionsSection.ts
+++ b/src/features/bin-designer/components/panel/SplitOptionsSection/useSplitOptionsSection.ts
@@ -4,7 +4,7 @@ import { useDesignerStore } from '@/features/bin-designer/store';
 import { useSettingsStore } from '@/core/store';
 import { calcMaxGridUnits } from '@/core/constants';
 import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
-import { getSplitPieceCount } from '@/features/bin-designer/utils/splitPositions';
+import { getSplitPieceCount } from '@/shared/utils/splitPositions';
 
 export type SplitAxis = 'width' | 'depth' | 'both';
 

--- a/src/features/bin-designer/components/preview/BinSplitLines/BinSplitLines.tsx
+++ b/src/features/bin-designer/components/preview/BinSplitLines/BinSplitLines.tsx
@@ -15,7 +15,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useSettingsStore } from '@/core/store';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { calcMaxGridUnits } from '@/core/constants';
-import { getSplitPlanePositionsMm } from '@/features/bin-designer/utils/splitPositions';
+import { getSplitPlanePositionsMm } from '@/shared/utils/splitPositions';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 
 const AMBER_COLOR = new Color(0xfbbf24);

--- a/src/features/bin-designer/hooks/useExport.ts
+++ b/src/features/bin-designer/hooks/useExport.ts
@@ -19,10 +19,7 @@ import { calcMaxGridUnits } from '@/core/constants';
 import { getActiveBridge, workerPoolManager } from '@/shared/generation/bridge';
 import { generateFileName } from '@/features/bin-designer/utils/fileNaming';
 import { estimatePrint } from '@/features/bin-designer/utils/printEstimates';
-import {
-  getSplitPieceCount,
-  getSplitPlanePositionsMm,
-} from '@/features/bin-designer/utils/splitPositions';
+import { getSplitPieceCount, getSplitPlanePositionsMm } from '@/shared/utils/splitPositions';
 import { packagePiecesAsZip } from '@/shared/generation/zipExport';
 import { export3MF, export3MFMultiObject } from '@/shared/generation/export';
 import { parseSTLBinary } from '@/features/bin-designer/utils/stlParser';

--- a/src/features/bin-designer/hooks/useSplitPreview.ts
+++ b/src/features/bin-designer/hooks/useSplitPreview.ts
@@ -19,10 +19,7 @@ import { useDesignerStore } from '@/features/bin-designer/store';
 import { useSettingsStore } from '@/core/store/settings';
 import { calcMaxGridUnits } from '@/core/constants';
 import { getActiveBridge, workerPoolManager } from '@/shared/generation/bridge';
-import {
-  getSplitPieceCount,
-  getSplitPlanePositionsMm,
-} from '@/features/bin-designer/utils/splitPositions';
+import { getSplitPieceCount, getSplitPlanePositionsMm } from '@/shared/utils/splitPositions';
 import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
 import type { SplitPieceMeshEntry } from '../types';
 

--- a/src/features/bin-designer/utils/index.ts
+++ b/src/features/bin-designer/utils/index.ts
@@ -27,7 +27,6 @@ export {
   setPreviewCanvas,
   clearPreviewCanvas,
 } from './thumbnail';
-export { getSplitPositions, getSplitPieceCount, getSplitPlanePositionsMm } from './splitPositions';
 export { packageSplitPiecesAsZip } from './splitExport';
 export { validateBinParams, computeMinCellSize, validateCompartmentSizes } from './validation';
 export type { DesignerValidationError, MinCellSize } from './validation';

--- a/src/features/grid-editor/components/Grid/IsometricPreview/SplitLineOverlay/SplitLineOverlay.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/SplitLineOverlay/SplitLineOverlay.tsx
@@ -1,26 +1,10 @@
 import { memo } from 'react';
 import { Line } from '@react-three/drei';
 import * as THREE from 'three';
+import { getSplitPositions } from '@/shared/utils/splitPositions';
 
 // Hoisted constant to avoid allocation on every render
 const AMBER_COLOR = new THREE.Color(0xfbbf24); // rgb(251, 191, 36)
-
-/**
- * Calculate split line positions along an axis using greedy halving.
- * Returns positions relative to 0 (start of bin).
- */
-function getSplitPositions(size: number, maxSize: number, offset: number = 0): number[] {
-  if (size <= maxSize) return [];
-
-  const splitAt = Math.ceil(size / 2);
-  const positions: number[] = [offset + splitAt];
-
-  // Recursively get splits for left and right halves
-  positions.push(...getSplitPositions(splitAt, maxSize, offset));
-  positions.push(...getSplitPositions(size - splitAt, maxSize, offset + splitAt));
-
-  return positions;
-}
 
 interface SplitLineOverlayProps {
   x: number;
@@ -34,8 +18,8 @@ interface SplitLineOverlayProps {
 }
 
 /**
- * Renders dashed amber split lines on the top face of oversized bins.
- * Uses the same greedy halving algorithm as the original Canvas implementation.
+ * Renders dashed amber split lines on the top face of oversized bins,
+ * matching the pieces `getSplitPositions` will produce at export time.
  */
 export const SplitLineOverlay = memo(function SplitLineOverlay({
   x,

--- a/src/shared/generation/splitUtils.test.ts
+++ b/src/shared/generation/splitUtils.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { computePinPositions } from './splitUtils';
+
+describe('computePinPositions', () => {
+  it('returns at least 2 pins for any valid edge', () => {
+    const positions = computePinPositions(20, 35);
+    expect(positions.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('returns positions centered around zero', () => {
+    const positions = computePinPositions(100, 35);
+    // 100mm / 35mm ≈ 3 pins
+    expect(positions).toHaveLength(3);
+    // Sum of centered positions should be ~0
+    const sum = positions.reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(0, 5);
+  });
+
+  it('returns 2 pins for short edge', () => {
+    const positions = computePinPositions(30, 35);
+    expect(positions).toHaveLength(2);
+  });
+
+  it('distributes pins evenly', () => {
+    const positions = computePinPositions(120, 35);
+    // 120/35 ≈ 3.4 → rounds to 3 pins
+    expect(positions).toHaveLength(3);
+    // Check even spacing
+    const spacing = positions[1] - positions[0];
+    expect(positions[2] - positions[1]).toBeCloseTo(spacing, 5);
+  });
+
+  it('returns empty for zero or negative edge', () => {
+    expect(computePinPositions(0, 35)).toEqual([]);
+    expect(computePinPositions(-10, 35)).toEqual([]);
+  });
+
+  it('returns empty for zero spacing', () => {
+    expect(computePinPositions(100, 0)).toEqual([]);
+  });
+
+  it('scales pin count with edge length', () => {
+    const short = computePinPositions(50, 35);
+    const long = computePinPositions(200, 35);
+    expect(long.length).toBeGreaterThan(short.length);
+  });
+});

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -25,6 +25,8 @@ export {
 
 export { throttleRAF, cancelThrottledRAF, throttle } from './throttle';
 
+export { getSplitPositions, getSplitPieceCount, getSplitPlanePositionsMm } from './splitPositions';
+
 export { scheduleIdleCallback, cancelIdleCallback } from './idle';
 
 export {

--- a/src/shared/utils/splitPositions.test.ts
+++ b/src/shared/utils/splitPositions.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import { getSplitPositions, getSplitPieceCount, getSplitPlanePositionsMm } from './splitPositions';
-import { computePinPositions } from '@/shared/generation/splitUtils';
 
 describe('getSplitPositions', () => {
   it('returns empty for bin that fits', () => {
@@ -94,50 +93,5 @@ describe('getSplitPlanePositionsMm', () => {
     for (let i = 1; i < positions.length; i++) {
       expect(positions[i]).toBeGreaterThan(positions[i - 1]);
     }
-  });
-});
-
-describe('computePinPositions', () => {
-  it('returns at least 2 pins for any valid edge', () => {
-    const positions = computePinPositions(20, 35);
-    expect(positions.length).toBeGreaterThanOrEqual(2);
-  });
-
-  it('returns positions centered around zero', () => {
-    const positions = computePinPositions(100, 35);
-    // 100mm / 35mm ≈ 3 pins
-    expect(positions).toHaveLength(3);
-    // Sum of centered positions should be ~0
-    const sum = positions.reduce((a, b) => a + b, 0);
-    expect(sum).toBeCloseTo(0, 5);
-  });
-
-  it('returns 2 pins for short edge', () => {
-    const positions = computePinPositions(30, 35);
-    expect(positions).toHaveLength(2);
-  });
-
-  it('distributes pins evenly', () => {
-    const positions = computePinPositions(120, 35);
-    // 120/35 ≈ 3.4 → rounds to 3 pins
-    expect(positions).toHaveLength(3);
-    // Check even spacing
-    const spacing = positions[1] - positions[0];
-    expect(positions[2] - positions[1]).toBeCloseTo(spacing, 5);
-  });
-
-  it('returns empty for zero or negative edge', () => {
-    expect(computePinPositions(0, 35)).toEqual([]);
-    expect(computePinPositions(-10, 35)).toEqual([]);
-  });
-
-  it('returns empty for zero spacing', () => {
-    expect(computePinPositions(100, 0)).toEqual([]);
-  });
-
-  it('scales pin count with edge length', () => {
-    const short = computePinPositions(50, 35);
-    const long = computePinPositions(200, 35);
-    expect(long.length).toBeGreaterThan(short.length);
   });
 });

--- a/src/shared/utils/splitPositions.ts
+++ b/src/shared/utils/splitPositions.ts
@@ -7,6 +7,9 @@
  *
  * Equal pieces guarantee the minimum split count and a symmetric result,
  * which prints and glues together more predictably than uneven halves.
+ *
+ * Shared between bin-designer (split export/preview) and grid-editor
+ * (split line overlay on the isometric preview).
  */
 
 /** Split line positions along an axis (grid units, relative to 0). */


### PR DESCRIPTION
## Summary

- Moves the split-position helpers (\`getSplitPositions\`, \`getSplitPieceCount\`, \`getSplitPlanePositionsMm\`) from \`src/features/bin-designer/utils/\` to \`src/shared/utils/\`
- Replaces the parallel greedy-halving copy in \`grid-editor/.../SplitLineOverlay.tsx\` with an import from the shared helper — this removes a latent bug (the grid-editor copy never got the #1400 fix since it only ever sees integer grid inputs)
- Relocates the orphaned \`computePinPositions\` tests from \`bin-designer/utils/splitPositions.test.ts\` to a new \`src/shared/generation/splitUtils.test.ts\` sibling file, matching the repo's colocation convention

## Why

The bin-designer split-logic fix in #1404 left a near-duplicate of the buggy algorithm alive in \`grid-editor\`. Consolidating into \`src/shared/utils/\` means future fixes only need to happen once, and the module-boundary checker is happy with both features importing from \`shared\`.

## Test plan

- [x] \`pnpm run typecheck\` — clean
- [x] \`pnpm run test:run\` — all 9784 tests pass across 667 files
- [x] Module-boundary check passes (no cross-feature imports)
- [x] Behavior unchanged for grid-editor: its callers always pass integer sizes where the old and new algorithms produce the same split count