### PR TITLE
feat(bin-designer): mask-aware cutouts for non-rectangular footprints

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
@@ -91,6 +91,8 @@ export function CutoutWorkspace() {
   const outerD = params.depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
   const binWidth = outerW - 2 * params.wallThickness;
   const binDepth = outerD - 2 * params.wallThickness;
+  // See CutoutEditor for rationale — keeps validator and polygon rendering aligned.
+  const editorGridUnitMm = binWidth / params.width;
   const totalHeight = params.height * GRIDFINITY.HEIGHT_UNIT;
   const isFlat = params.base.style === 'flat';
   const wallHeight = isFlat ? totalHeight : totalHeight - GRIDFINITY.BASE_HEIGHT;
@@ -238,6 +240,8 @@ export function CutoutWorkspace() {
     binWidth,
     binDepth,
     gridSize,
+    cellMask: params.cellMask,
+    gridUnitMm: editorGridUnitMm,
   });
 
   // Marquee state — now in mm world coordinates (no SVG pixel conversion needed)
@@ -692,6 +696,7 @@ export function CutoutWorkspace() {
                 cutouts={cutouts}
                 binWidth={binWidth}
                 binDepth={binDepth}
+                cellMask={params.cellMask}
                 canvasWidth={canvasWidth}
                 canvasHeight={canvasHeight}
                 selection={selection}

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
@@ -91,8 +91,11 @@ export function CutoutWorkspace() {
   const outerD = params.depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
   const binWidth = outerW - 2 * params.wallThickness;
   const binDepth = outerD - 2 * params.wallThickness;
-  // See CutoutEditor for rationale — keeps validator and polygon rendering aligned.
-  const editorGridUnitMm = binWidth / params.width;
+  // See CutoutEditor for rationale — separate X/Y cell sizes keep validator and
+  // polygon rendering aligned for non-square bins.
+  const maskCellSize = params.cellMask
+    ? { cellMmX: binWidth / params.cellMask.cols, cellMmY: binDepth / params.cellMask.rows }
+    : undefined;
   const totalHeight = params.height * GRIDFINITY.HEIGHT_UNIT;
   const isFlat = params.base.style === 'flat';
   const wallHeight = isFlat ? totalHeight : totalHeight - GRIDFINITY.BASE_HEIGHT;
@@ -241,7 +244,7 @@ export function CutoutWorkspace() {
     binDepth,
     gridSize,
     cellMask: params.cellMask,
-    gridUnitMm: editorGridUnitMm,
+    maskCellSize,
   });
 
   // Marquee state — now in mm world coordinates (no SVG pixel conversion needed)

--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
@@ -93,9 +93,9 @@ export function ParameterPanel() {
           summary={interiorSummary}
         >
           <div className="px-4 py-4">
-            <FeatureGate disabled={isCustomShape} reason={customShapeReason}>
-              <InteriorSection />
-            </FeatureGate>
+            {/* Per-mode gating lives inside InteriorSection: Solid (cutouts) stays
+                interactive on custom shapes; Standard/Slotted remain gated. */}
+            <InteriorSection />
           </div>
           {showLabelTabs && (
             <div className="px-4 py-4 border-t border-stroke-subtle/50">

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.tsx
@@ -73,11 +73,14 @@ export function CutoutEditor() {
   const outerD = params.depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
   const binWidth = outerW - 2 * params.wallThickness;
   const binDepth = outerD - 2 * params.wallThickness;
-  // Mm-per-grid-unit in the editor's interior coordinate system. Differs
-  // slightly from `params.gridUnitMm` (42) because interior space excludes the
-  // wall shell + baseplate clearance. Keeping this in sync between validator
-  // and renderer ensures the polygon outline matches the rejection region.
-  const editorGridUnitMm = binWidth / params.width;
+  // Mm-per-mask-cell in the editor's interior coordinate system. X and Y differ
+  // on non-square bins because the interior is shrunk by wall + tolerance (an
+  // absolute mm amount) independently on each axis. Keeping validator and
+  // polygon renderer tied to the same derivation ensures the visible outline
+  // traces the exact rejection boundary.
+  const maskCellSize = params.cellMask
+    ? { cellMmX: binWidth / params.cellMask.cols, cellMmY: binDepth / params.cellMask.rows }
+    : undefined;
   const totalHeight = params.height * GRIDFINITY.HEIGHT_UNIT;
   const isFlat = params.base.style === 'flat';
   const wallHeight = isFlat ? totalHeight : totalHeight - GRIDFINITY.BASE_HEIGHT;
@@ -145,7 +148,7 @@ export function CutoutEditor() {
     binDepth,
     gridSize,
     cellMask: params.cellMask,
-    gridUnitMm: editorGridUnitMm,
+    maskCellSize,
   });
 
   const t = useTranslation();

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.tsx
@@ -73,6 +73,11 @@ export function CutoutEditor() {
   const outerD = params.depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
   const binWidth = outerW - 2 * params.wallThickness;
   const binDepth = outerD - 2 * params.wallThickness;
+  // Mm-per-grid-unit in the editor's interior coordinate system. Differs
+  // slightly from `params.gridUnitMm` (42) because interior space excludes the
+  // wall shell + baseplate clearance. Keeping this in sync between validator
+  // and renderer ensures the polygon outline matches the rejection region.
+  const editorGridUnitMm = binWidth / params.width;
   const totalHeight = params.height * GRIDFINITY.HEIGHT_UNIT;
   const isFlat = params.base.style === 'flat';
   const wallHeight = isFlat ? totalHeight : totalHeight - GRIDFINITY.BASE_HEIGHT;
@@ -139,6 +144,8 @@ export function CutoutEditor() {
     binWidth,
     binDepth,
     gridSize,
+    cellMask: params.cellMask,
+    gridUnitMm: editorGridUnitMm,
   });
 
   const t = useTranslation();
@@ -461,6 +468,7 @@ export function CutoutEditor() {
           cutouts={cutouts}
           binWidth={binWidth}
           binDepth={binDepth}
+          cellMask={params.cellMask}
           canvasWidth={CANVAS_WIDTH}
           canvasHeight={canvasHeight}
           selection={selection}

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
@@ -25,6 +25,8 @@ import {
   flipSelectionHorizontal,
   flipSelectionVertical,
 } from './geometry';
+import { rectFitsInMask, cutoutFitsInMask } from './maskFit';
+import type { CellMask } from '@/shared/utils/cellMask';
 
 const createCutout = (overrides: Partial<Cutout> = {}): Cutout => ({
   id: 'test',
@@ -925,6 +927,185 @@ describe('geometry', () => {
       const pathAPoints = patchA.path as PathPoint[];
       expect(pathAPoints[0].y).toBeCloseTo(40);
       expect(pathAPoints[1].y).toBeCloseTo(30);
+    });
+  });
+
+  describe('rectFitsInMask', () => {
+    const GRID_UNIT = 42;
+    // Mask helper: fill from a 2D array of 0/1 rows, read top-to-bottom so tests
+    // read naturally. cellMask rows run bottom→top (grid origin), so flip on build.
+    const makeMask = (rows: ReadonlyArray<ReadonlyArray<0 | 1>>): CellMask => {
+      const rowCount = rows.length;
+      const colCount = rows[0].length;
+      const cells = new Uint8Array(rowCount * colCount);
+      for (let r = 0; r < rowCount; r++) {
+        const sourceRow = rows[rowCount - 1 - r];
+        for (let c = 0; c < colCount; c++) {
+          cells[r * colCount + c] = sourceRow[c];
+        }
+      }
+      return { cols: colCount, rows: rowCount, cells };
+    };
+
+    it('accepts a rect entirely inside a fully filled mask', () => {
+      // 2x2 grid unit bin = 4x4 mask cells
+      const fullMask = makeMask([
+        [1, 1, 1, 1],
+        [1, 1, 1, 1],
+        [1, 1, 1, 1],
+        [1, 1, 1, 1],
+      ]);
+      expect(rectFitsInMask(fullMask, 20, 20, 30, 30, GRID_UNIT)).toBe(true);
+    });
+
+    it('rejects a rect that extends beyond the mask bounds', () => {
+      const fullMask = makeMask([
+        [1, 1],
+        [1, 1],
+      ]);
+      // 1x1 bin = 2x2 cells = 42mm. A rect at 40mm spanning 10mm exits the mask.
+      expect(rectFitsInMask(fullMask, 40, 0, 10, 10, GRID_UNIT)).toBe(false);
+    });
+
+    it('rejects a rect straddling an unfilled notch in an L-shape', () => {
+      // L-shape: top-right cell empty (3x3 grid units = 6x6 cells with 1u notch)
+      // Actually simpler: 2x2 units, top-right unit (2 cells wide) empty.
+      // Rows (top→bottom): [[1,1,0,0],[1,1,0,0],[1,1,1,1],[1,1,1,1]]
+      const lMask = makeMask([
+        [1, 1, 0, 0],
+        [1, 1, 0, 0],
+        [1, 1, 1, 1],
+        [1, 1, 1, 1],
+      ]);
+      // Rect in the notch area: top-right 1u × 1u region = x=42-84, y=42-84
+      expect(rectFitsInMask(lMask, 42, 42, 42, 42, GRID_UNIT)).toBe(false);
+    });
+
+    it('accepts a rect flush against a filled region in an L-shape', () => {
+      const lMask = makeMask([
+        [1, 1, 0, 0],
+        [1, 1, 0, 0],
+        [1, 1, 1, 1],
+        [1, 1, 1, 1],
+      ]);
+      // Bottom-left 2u × 2u is fully filled → rect inside it should fit
+      expect(rectFitsInMask(lMask, 5, 5, 30, 30, GRID_UNIT)).toBe(true);
+    });
+
+    it('accepts a rect exactly spanning a filled region edge-to-edge', () => {
+      const lMask = makeMask([
+        [1, 1, 0, 0],
+        [1, 1, 0, 0],
+        [1, 1, 1, 1],
+        [1, 1, 1, 1],
+      ]);
+      // Bottom 2 rows span full 4 cells wide × 2 cells tall (= 84 × 42 mm)
+      expect(rectFitsInMask(lMask, 0, 0, 84, 42, GRID_UNIT)).toBe(true);
+    });
+
+    it('tolerates sub-epsilon floating-point slack at cell boundaries', () => {
+      // 2x2 cells = 42x42 mm. A rect snapped to the exact right edge with tiny
+      // overshoot (42 + sub-epsilon) is accepted; normal float noise won't trip it.
+      const fullMask = makeMask([
+        [1, 1],
+        [1, 1],
+      ]);
+      expect(rectFitsInMask(fullMask, 0, 0, 42 + 0.005, 21, GRID_UNIT)).toBe(true);
+    });
+
+    it('honours a non-default gridUnitMm', () => {
+      const fullMask = makeMask([
+        [1, 1, 1, 1],
+        [1, 1, 1, 1],
+      ]);
+      // gridUnit = 30 → cell = 15 mm. Mask is 2x4 cells = 60x30 mm.
+      expect(rectFitsInMask(fullMask, 0, 0, 60, 30, 30)).toBe(true);
+      expect(rectFitsInMask(fullMask, 0, 0, 65, 30, 30)).toBe(false);
+    });
+
+    it('rejects a rect with negative origin', () => {
+      const fullMask = makeMask([[1]]);
+      expect(rectFitsInMask(fullMask, -5, 0, 10, 10, GRID_UNIT)).toBe(false);
+    });
+  });
+
+  describe('cutoutFitsInMask', () => {
+    const GRID_UNIT = 42;
+    const lMask: CellMask = {
+      cols: 4,
+      rows: 4,
+      // Rows bottom→top. Top two rows have right half empty (L-shape notch).
+      cells: new Uint8Array([
+        1,
+        1,
+        1,
+        1, // row 0 (bottom)
+        1,
+        1,
+        1,
+        1, // row 1
+        1,
+        1,
+        0,
+        0, // row 2
+        1,
+        1,
+        0,
+        0, // row 3 (top)
+      ]),
+    };
+
+    it('accepts a rectangle cutout in the filled region', () => {
+      const cutout = createCutout({ x: 10, y: 10, width: 30, depth: 30 });
+      expect(cutoutFitsInMask(cutout, lMask, GRID_UNIT)).toBe(true);
+    });
+
+    it('rejects a rectangle cutout in the notch', () => {
+      const cutout = createCutout({ x: 50, y: 50, width: 30, depth: 30 });
+      expect(cutoutFitsInMask(cutout, lMask, GRID_UNIT)).toBe(false);
+    });
+
+    it('uses rotated AABB for rotated cutouts', () => {
+      // A 30x30 square rotated 45° has an AABB ~42x42 mm (30*sqrt(2)).
+      // Centered at (42, 42), so the AABB extends to ~63, reaching into the notch.
+      const cutout = createCutout({ x: 27, y: 27, width: 30, depth: 30, rotation: 45 });
+      expect(cutoutFitsInMask(cutout, lMask, GRID_UNIT)).toBe(false);
+    });
+
+    it('uses path bounds for path cutouts', () => {
+      const path: PathPoint[] = [
+        { x: 10, y: 10, handleIn: null, handleOut: null, symmetric: false },
+        { x: 40, y: 10, handleIn: null, handleOut: null, symmetric: false },
+        { x: 40, y: 40, handleIn: null, handleOut: null, symmetric: false },
+        { x: 10, y: 40, handleIn: null, handleOut: null, symmetric: false },
+      ];
+      const cutout = createCutout({
+        shape: 'path',
+        x: 10,
+        y: 10,
+        width: 30,
+        depth: 30,
+        path,
+      });
+      expect(cutoutFitsInMask(cutout, lMask, GRID_UNIT)).toBe(true);
+    });
+
+    it('rejects a path cutout whose bounds overhang the notch', () => {
+      const path: PathPoint[] = [
+        { x: 50, y: 50, handleIn: null, handleOut: null, symmetric: false },
+        { x: 80, y: 50, handleIn: null, handleOut: null, symmetric: false },
+        { x: 80, y: 80, handleIn: null, handleOut: null, symmetric: false },
+        { x: 50, y: 80, handleIn: null, handleOut: null, symmetric: false },
+      ];
+      const cutout = createCutout({
+        shape: 'path',
+        x: 50,
+        y: 50,
+        width: 30,
+        depth: 30,
+        path,
+      });
+      expect(cutoutFitsInMask(cutout, lMask, GRID_UNIT)).toBe(false);
     });
   });
 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
@@ -931,13 +931,14 @@ describe('geometry', () => {
   });
 
   describe('rectFitsInMask', () => {
-    const GRID_UNIT = 42;
+    // Default cell size: square 21mm cells (matches 42mm grid unit, 2 cells/unit)
+    const CELL = { cellMmX: 21, cellMmY: 21 };
     // Mask helper: fill from a 2D array of 0/1 rows, read top-to-bottom so tests
     // read naturally. cellMask rows run bottom→top (grid origin), so flip on build.
     const makeMask = (rows: ReadonlyArray<ReadonlyArray<0 | 1>>): CellMask => {
       const rowCount = rows.length;
       const colCount = rows[0].length;
-      const cells = new Uint8Array(rowCount * colCount);
+      const cells: Array<0 | 1> = new Array<0 | 1>(rowCount * colCount).fill(0);
       for (let r = 0; r < rowCount; r++) {
         const sourceRow = rows[rowCount - 1 - r];
         for (let c = 0; c < colCount; c++) {
@@ -955,7 +956,7 @@ describe('geometry', () => {
         [1, 1, 1, 1],
         [1, 1, 1, 1],
       ]);
-      expect(rectFitsInMask(fullMask, 20, 20, 30, 30, GRID_UNIT)).toBe(true);
+      expect(rectFitsInMask(fullMask, 20, 20, 30, 30, CELL)).toBe(true);
     });
 
     it('rejects a rect that extends beyond the mask bounds', () => {
@@ -964,13 +965,11 @@ describe('geometry', () => {
         [1, 1],
       ]);
       // 1x1 bin = 2x2 cells = 42mm. A rect at 40mm spanning 10mm exits the mask.
-      expect(rectFitsInMask(fullMask, 40, 0, 10, 10, GRID_UNIT)).toBe(false);
+      expect(rectFitsInMask(fullMask, 40, 0, 10, 10, CELL)).toBe(false);
     });
 
     it('rejects a rect straddling an unfilled notch in an L-shape', () => {
-      // L-shape: top-right cell empty (3x3 grid units = 6x6 cells with 1u notch)
-      // Actually simpler: 2x2 units, top-right unit (2 cells wide) empty.
-      // Rows (top→bottom): [[1,1,0,0],[1,1,0,0],[1,1,1,1],[1,1,1,1]]
+      // L-shape: 2x2 units, top-right unit (2 cells wide) empty.
       const lMask = makeMask([
         [1, 1, 0, 0],
         [1, 1, 0, 0],
@@ -978,7 +977,7 @@ describe('geometry', () => {
         [1, 1, 1, 1],
       ]);
       // Rect in the notch area: top-right 1u × 1u region = x=42-84, y=42-84
-      expect(rectFitsInMask(lMask, 42, 42, 42, 42, GRID_UNIT)).toBe(false);
+      expect(rectFitsInMask(lMask, 42, 42, 42, 42, CELL)).toBe(false);
     });
 
     it('accepts a rect flush against a filled region in an L-shape', () => {
@@ -989,7 +988,7 @@ describe('geometry', () => {
         [1, 1, 1, 1],
       ]);
       // Bottom-left 2u × 2u is fully filled → rect inside it should fit
-      expect(rectFitsInMask(lMask, 5, 5, 30, 30, GRID_UNIT)).toBe(true);
+      expect(rectFitsInMask(lMask, 5, 5, 30, 30, CELL)).toBe(true);
     });
 
     it('accepts a rect exactly spanning a filled region edge-to-edge', () => {
@@ -1000,7 +999,7 @@ describe('geometry', () => {
         [1, 1, 1, 1],
       ]);
       // Bottom 2 rows span full 4 cells wide × 2 cells tall (= 84 × 42 mm)
-      expect(rectFitsInMask(lMask, 0, 0, 84, 42, GRID_UNIT)).toBe(true);
+      expect(rectFitsInMask(lMask, 0, 0, 84, 42, CELL)).toBe(true);
     });
 
     it('tolerates sub-epsilon floating-point slack at cell boundaries', () => {
@@ -1010,32 +1009,49 @@ describe('geometry', () => {
         [1, 1],
         [1, 1],
       ]);
-      expect(rectFitsInMask(fullMask, 0, 0, 42 + 0.005, 21, GRID_UNIT)).toBe(true);
+      expect(rectFitsInMask(fullMask, 0, 0, 42 + 0.005, 21, CELL)).toBe(true);
     });
 
-    it('honours a non-default gridUnitMm', () => {
+    it('honours a non-default cell size', () => {
       const fullMask = makeMask([
         [1, 1, 1, 1],
         [1, 1, 1, 1],
       ]);
-      // gridUnit = 30 → cell = 15 mm. Mask is 2x4 cells = 60x30 mm.
-      expect(rectFitsInMask(fullMask, 0, 0, 60, 30, 30)).toBe(true);
-      expect(rectFitsInMask(fullMask, 0, 0, 65, 30, 30)).toBe(false);
+      // 15 mm cells → mask is 2x4 cells = 60x30 mm.
+      const smallCell = { cellMmX: 15, cellMmY: 15 };
+      expect(rectFitsInMask(fullMask, 0, 0, 60, 30, smallCell)).toBe(true);
+      expect(rectFitsInMask(fullMask, 0, 0, 65, 30, smallCell)).toBe(false);
+    });
+
+    it('handles non-square cells (X and Y differ on non-square bins)', () => {
+      // 2-wide × 4-deep bin with a notch on the right half of the top row.
+      const mask = makeMask([
+        [1, 1, 0, 0],
+        [1, 1, 1, 1],
+        [1, 1, 1, 1],
+        [1, 1, 1, 1],
+      ]);
+      // Imagine binWidth=84, binDepth=168 → cellMmX=21, cellMmY=42.
+      // A 40×40 mm rect at (48, 130) overlaps col 2..3 × row 3 (notch) — reject.
+      const asymmetric = { cellMmX: 21, cellMmY: 42 };
+      expect(rectFitsInMask(mask, 48, 130, 40, 30, asymmetric)).toBe(false);
+      // Same rect moved into the filled left half (x=0) fits.
+      expect(rectFitsInMask(mask, 0, 130, 40, 30, asymmetric)).toBe(true);
     });
 
     it('rejects a rect with negative origin', () => {
       const fullMask = makeMask([[1]]);
-      expect(rectFitsInMask(fullMask, -5, 0, 10, 10, GRID_UNIT)).toBe(false);
+      expect(rectFitsInMask(fullMask, -5, 0, 10, 10, CELL)).toBe(false);
     });
   });
 
   describe('cutoutFitsInMask', () => {
-    const GRID_UNIT = 42;
+    const CELL = { cellMmX: 21, cellMmY: 21 };
     const lMask: CellMask = {
       cols: 4,
       rows: 4,
       // Rows bottom→top. Top two rows have right half empty (L-shape notch).
-      cells: new Uint8Array([
+      cells: [
         1,
         1,
         1,
@@ -1052,24 +1068,24 @@ describe('geometry', () => {
         1,
         0,
         0, // row 3 (top)
-      ]),
+      ],
     };
 
     it('accepts a rectangle cutout in the filled region', () => {
       const cutout = createCutout({ x: 10, y: 10, width: 30, depth: 30 });
-      expect(cutoutFitsInMask(cutout, lMask, GRID_UNIT)).toBe(true);
+      expect(cutoutFitsInMask(cutout, lMask, CELL)).toBe(true);
     });
 
     it('rejects a rectangle cutout in the notch', () => {
       const cutout = createCutout({ x: 50, y: 50, width: 30, depth: 30 });
-      expect(cutoutFitsInMask(cutout, lMask, GRID_UNIT)).toBe(false);
+      expect(cutoutFitsInMask(cutout, lMask, CELL)).toBe(false);
     });
 
     it('uses rotated AABB for rotated cutouts', () => {
       // A 30x30 square rotated 45° has an AABB ~42x42 mm (30*sqrt(2)).
       // Centered at (42, 42), so the AABB extends to ~63, reaching into the notch.
       const cutout = createCutout({ x: 27, y: 27, width: 30, depth: 30, rotation: 45 });
-      expect(cutoutFitsInMask(cutout, lMask, GRID_UNIT)).toBe(false);
+      expect(cutoutFitsInMask(cutout, lMask, CELL)).toBe(false);
     });
 
     it('uses path bounds for path cutouts', () => {
@@ -1087,7 +1103,7 @@ describe('geometry', () => {
         depth: 30,
         path,
       });
-      expect(cutoutFitsInMask(cutout, lMask, GRID_UNIT)).toBe(true);
+      expect(cutoutFitsInMask(cutout, lMask, CELL)).toBe(true);
     });
 
     it('rejects a path cutout whose bounds overhang the notch', () => {
@@ -1105,7 +1121,7 @@ describe('geometry', () => {
         depth: 30,
         path,
       });
-      expect(cutoutFitsInMask(cutout, lMask, GRID_UNIT)).toBe(false);
+      expect(cutoutFitsInMask(cutout, lMask, CELL)).toBe(false);
     });
   });
 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.ts
@@ -7,6 +7,7 @@
 
 import type { Cutout } from '@/features/bin-designer/types';
 import { constrainGroupDrag, computeBounds, findAlignmentGuides } from '../geometry';
+import { cutoutFitsInMask } from '../maskFit';
 import type { InteractionMode } from '../useCutoutInteraction';
 import type { PointerMoveEvent, BinBounds, SnapFn, PreviewSetters, DeadZoneRef } from './types';
 
@@ -70,6 +71,20 @@ export function handleDragMove(
       y: Math.max(0, Math.min(snap(mode.startY + dy + offset.dy), bounds.binDepth - cutout.depth)),
     });
   }
+
+  // Polygon mask: hard-reject moves that would overhang the polygon — preview
+  // stays at its last valid state so the drag "sticks" like the bin-bounds clamp.
+  if (bounds.cellMask && bounds.gridUnitMm !== undefined) {
+    for (const [id, updates] of nextPreview) {
+      const orig = cutouts.find((c) => c.id === id);
+      if (!orig) continue;
+      const candidate = { ...orig, ...updates } as Cutout;
+      if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.gridUnitMm)) {
+        return;
+      }
+    }
+  }
+
   setters.setPreview(nextPreview);
 
   // Compute alignment guides

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.ts
@@ -74,12 +74,12 @@ export function handleDragMove(
 
   // Polygon mask: hard-reject moves that would overhang the polygon — preview
   // stays at its last valid state so the drag "sticks" like the bin-bounds clamp.
-  if (bounds.cellMask && bounds.gridUnitMm !== undefined) {
+  if (bounds.cellMask && bounds.maskCellSize) {
     for (const [id, updates] of nextPreview) {
       const orig = cutouts.find((c) => c.id === id);
       if (!orig) continue;
       const candidate = { ...orig, ...updates } as Cutout;
-      if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.gridUnitMm)) {
+      if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize)) {
         return;
       }
     }

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/drawHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/drawHandler.ts
@@ -59,14 +59,14 @@ export function handleDrawMove(
   // Polygon mask: hard-reject draw preview that overhangs the polygon.
   if (
     bounds.cellMask &&
-    bounds.gridUnitMm !== undefined &&
+    bounds.maskCellSize &&
     !rectFitsInMask(
       bounds.cellMask,
       preview.x,
       preview.y,
       preview.width,
       preview.depth,
-      bounds.gridUnitMm
+      bounds.maskCellSize
     )
   ) {
     return;

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/drawHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/drawHandler.ts
@@ -6,6 +6,7 @@
  */
 
 import { MIN_CUTOUT_SIZE } from '../geometry';
+import { rectFitsInMask } from '../maskFit';
 import type { InteractionMode } from '../useCutoutInteraction';
 import type { PointerMoveEvent, BinBounds, SnapFn, PreviewSetters } from './types';
 
@@ -47,11 +48,29 @@ export function handleDrawMove(
     d = Math.min(d, bounds.binDepth - y);
   }
 
-  setters.setDrawingPreview({
+  const preview = {
     x: snap(x),
     y: snap(y),
     width: Math.max(MIN_CUTOUT_SIZE, snap(w)),
     depth: Math.max(MIN_CUTOUT_SIZE, snap(d)),
     shape: mode.shape,
-  });
+  };
+
+  // Polygon mask: hard-reject draw preview that overhangs the polygon.
+  if (
+    bounds.cellMask &&
+    bounds.gridUnitMm !== undefined &&
+    !rectFitsInMask(
+      bounds.cellMask,
+      preview.x,
+      preview.y,
+      preview.width,
+      preview.depth,
+      bounds.gridUnitMm
+    )
+  ) {
+    return;
+  }
+
+  setters.setDrawingPreview(preview);
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/groupRotateHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/groupRotateHandler.ts
@@ -7,8 +7,9 @@
 
 import type { Cutout } from '@/features/bin-designer/types';
 import { rotatePoint } from '../geometry';
+import { cutoutFitsInMask } from '../maskFit';
 import type { InteractionMode } from '../useCutoutInteraction';
-import type { PointerMoveEvent, PreviewSetters, DeadZoneRef } from './types';
+import type { PointerMoveEvent, BinBounds, PreviewSetters, DeadZoneRef } from './types';
 
 /** Mode state for group rotation, derived from the global InteractionMode union. */
 type GroupRotatingMode = Extract<InteractionMode, { type: 'group-rotating' }>;
@@ -20,6 +21,7 @@ export function handleGroupRotateMove(
   mode: GroupRotatingMode,
   event: PointerMoveEvent,
   cutouts: readonly Cutout[],
+  bounds: BinBounds,
   deadZoneRef: DeadZoneRef,
   setters: Pick<PreviewSetters, 'setPreview'>
 ): void {
@@ -51,5 +53,16 @@ export function handleGroupRotateMove(
       rotation: (((initial.rotation + delta) % 360) + 360) % 360,
     });
   }
+
+  // Polygon mask: reject the rotation if any member would overhang the polygon.
+  if (bounds.cellMask && bounds.maskCellSize) {
+    for (const [id, patch] of nextPreview) {
+      const orig = cutouts.find((c) => c.id === id);
+      if (!orig) continue;
+      const candidate = { ...orig, ...patch } as Cutout;
+      if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize)) return;
+    }
+  }
+
   setters.setPreview(nextPreview);
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/groupScaleHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/groupScaleHandler.ts
@@ -7,8 +7,9 @@
 
 import type { Cutout } from '@/features/bin-designer/types';
 import { MIN_CUTOUT_SIZE } from '../geometry';
+import { cutoutFitsInMask } from '../maskFit';
 import type { InteractionMode } from '../useCutoutInteraction';
-import type { PointerMoveEvent, PreviewSetters, DeadZoneRef } from './types';
+import type { PointerMoveEvent, BinBounds, PreviewSetters, DeadZoneRef } from './types';
 
 /** Dead zone in mm before scale starts updating preview. */
 const DEAD_ZONE_MM = 0.5;
@@ -22,6 +23,8 @@ type GroupScalingMode = Extract<InteractionMode, { type: 'group-scaling' }>;
 export function handleGroupScaleMove(
   mode: GroupScalingMode,
   event: PointerMoveEvent,
+  cutouts: readonly Cutout[],
+  bounds: BinBounds,
   deadZoneRef: DeadZoneRef,
   setters: Pick<PreviewSetters, 'setPreview'>
 ): void {
@@ -51,5 +54,16 @@ export function handleGroupScaleMove(
       depth: newD,
     });
   }
+
+  // Polygon mask: reject the scale step if any member would overhang the polygon.
+  if (bounds.cellMask && bounds.maskCellSize) {
+    for (const [id, patch] of nextPreview) {
+      const orig = cutouts.find((c) => c.id === id);
+      if (!orig) continue;
+      const candidate = { ...orig, ...patch } as Cutout;
+      if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize)) return;
+    }
+  }
+
   setters.setPreview(nextPreview);
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.ts
@@ -72,9 +72,9 @@ export function handleResizeMove(
   };
 
   // Polygon mask: hard-reject resizes that would overhang the polygon.
-  if (bounds.cellMask && bounds.gridUnitMm !== undefined) {
+  if (bounds.cellMask && bounds.maskCellSize) {
     const candidate = { ...cutout, ...nextPatch } as Cutout;
-    if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.gridUnitMm)) {
+    if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize)) {
       return;
     }
   }

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.ts
@@ -7,6 +7,7 @@
 
 import type { Cutout } from '@/features/bin-designer/types';
 import { calculateCutoutResize, MIN_CUTOUT_SIZE } from '../geometry';
+import { cutoutFitsInMask } from '../maskFit';
 import type { InteractionMode } from '../useCutoutInteraction';
 import type { PointerMoveEvent, BinBounds, SnapFn, PreviewSetters, DeadZoneRef } from './types';
 
@@ -63,17 +64,20 @@ export function handleResizeMove(
   // Snap, then clamp to bin bounds (snap can round past non-integer edges)
   const snappedW = Math.max(MIN_CUTOUT_SIZE, snap(resized.width));
   const snappedD = Math.max(MIN_CUTOUT_SIZE, snap(resized.depth));
-  setters.setPreview(
-    new Map([
-      [
-        mode.cutoutId,
-        {
-          x: Math.max(0, Math.min(snap(resized.x), bounds.binWidth - snappedW)),
-          y: Math.max(0, Math.min(snap(resized.y), bounds.binDepth - snappedD)),
-          width: snappedW,
-          depth: snappedD,
-        },
-      ],
-    ])
-  );
+  const nextPatch = {
+    x: Math.max(0, Math.min(snap(resized.x), bounds.binWidth - snappedW)),
+    y: Math.max(0, Math.min(snap(resized.y), bounds.binDepth - snappedD)),
+    width: snappedW,
+    depth: snappedD,
+  };
+
+  // Polygon mask: hard-reject resizes that would overhang the polygon.
+  if (bounds.cellMask && bounds.gridUnitMm !== undefined) {
+    const candidate = { ...cutout, ...nextPatch } as Cutout;
+    if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.gridUnitMm)) {
+      return;
+    }
+  }
+
+  setters.setPreview(new Map([[mode.cutoutId, nextPatch]]));
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/rotateHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/rotateHandler.ts
@@ -7,6 +7,7 @@
 
 import type { Cutout } from '@/features/bin-designer/types';
 import { clampRotationToBounds } from '../geometry';
+import { cutoutFitsInMask } from '../maskFit';
 import type { InteractionMode } from '../useCutoutInteraction';
 import type { PointerMoveEvent, BinBounds, PreviewSetters, DeadZoneRef } from './types';
 
@@ -52,6 +53,14 @@ export function handleRotateMove(
 
   // Clamp rotation to keep within bin bounds
   newRotation = clampRotationToBounds(cutout, newRotation, bounds.binWidth, bounds.binDepth);
+
+  // Polygon mask: hard-reject rotations whose rotated AABB overhangs the polygon.
+  if (bounds.cellMask && bounds.gridUnitMm !== undefined) {
+    const candidate = { ...cutout, rotation: newRotation } as Cutout;
+    if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.gridUnitMm)) {
+      return;
+    }
+  }
 
   setters.setPreview(new Map([[mode.cutoutId, { rotation: newRotation }]]));
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/rotateHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/rotateHandler.ts
@@ -55,9 +55,9 @@ export function handleRotateMove(
   newRotation = clampRotationToBounds(cutout, newRotation, bounds.binWidth, bounds.binDepth);
 
   // Polygon mask: hard-reject rotations whose rotated AABB overhangs the polygon.
-  if (bounds.cellMask && bounds.gridUnitMm !== undefined) {
+  if (bounds.cellMask && bounds.maskCellSize) {
     const candidate = { ...cutout, rotation: newRotation } as Cutout;
-    if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.gridUnitMm)) {
+    if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize)) {
       return;
     }
   }

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/types.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/types.ts
@@ -9,6 +9,7 @@
 import type { Cutout, CutoutShape } from '@/features/bin-designer/types';
 import type { CellMask } from '@/shared/utils/cellMask';
 import type { AlignmentGuide } from '../geometry';
+import type { MaskCellSize } from '../maskFit';
 import type { InteractionMode } from '../useCutoutInteraction';
 
 // ── Pointer event context shared by all move handlers ────────────────────────
@@ -29,8 +30,8 @@ export interface BinBounds {
   readonly binDepth: number;
   /** Present only when the bin has a non-rectangular (custom) footprint. */
   readonly cellMask?: CellMask;
-  /** mm per grid unit — required when cellMask is present (mm ↔ mask conversion). */
-  readonly gridUnitMm?: number;
+  /** Mm per mask cell. Required alongside cellMask; separate X/Y for non-square bins. */
+  readonly maskCellSize?: MaskCellSize;
 }
 
 /** Snap function that respects the current snap-enabled state. */

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/types.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Cutout, CutoutShape } from '@/features/bin-designer/types';
+import type { CellMask } from '@/shared/utils/cellMask';
 import type { AlignmentGuide } from '../geometry';
 import type { InteractionMode } from '../useCutoutInteraction';
 
@@ -26,6 +27,10 @@ export interface PointerMoveEvent {
 export interface BinBounds {
   readonly binWidth: number;
   readonly binDepth: number;
+  /** Present only when the bin has a non-rectangular (custom) footprint. */
+  readonly cellMask?: CellMask;
+  /** mm per grid unit — required when cellMask is present (mm ↔ mask conversion). */
+  readonly gridUnitMm?: number;
 }
 
 /** Snap function that respects the current snap-enabled state. */

--- a/src/features/bin-designer/components/panel/CutoutsSection/maskFit.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/maskFit.ts
@@ -1,0 +1,75 @@
+/**
+ * Polygon-mask containment checks for cutouts.
+ *
+ * The cutout editor accepts placements only where every mask cell the cutout
+ * covers is filled. Wall-thickness offset between interior and outer grid
+ * coords is ignored — it's <5% of a mask cell and this check is purely UX
+ * (the generator silently clips out-of-polygon geometry regardless).
+ */
+
+import type { Cutout } from '@/features/bin-designer/types';
+import { MASK_CELLS_PER_UNIT, type CellMask } from '@/shared/utils/cellMask';
+import { getRotatedBounds } from './geometry';
+import { getPathBounds } from './pathGeometry';
+
+/** Tolerance for mask-cell boundary rounding (mm). */
+const MASK_FIT_EPSILON = 0.01;
+
+/**
+ * Check whether an axis-aligned rectangle (in bin-interior mm) lies entirely
+ * within the filled region of a cellMask polygon.
+ *
+ * Every mask cell the rect overlaps must be filled — straddling an unfilled
+ * cell (a concave notch) is rejected.
+ */
+export function rectFitsInMask(
+  mask: CellMask,
+  xMm: number,
+  yMm: number,
+  widthMm: number,
+  depthMm: number,
+  gridUnitMm: number
+): boolean {
+  const cellMm = gridUnitMm / MASK_CELLS_PER_UNIT;
+  const colStart = Math.floor((xMm + MASK_FIT_EPSILON) / cellMm);
+  const rowStart = Math.floor((yMm + MASK_FIT_EPSILON) / cellMm);
+  const colEnd = Math.ceil((xMm + widthMm - MASK_FIT_EPSILON) / cellMm);
+  const rowEnd = Math.ceil((yMm + depthMm - MASK_FIT_EPSILON) / cellMm);
+  if (colStart < 0 || rowStart < 0 || colEnd > mask.cols || rowEnd > mask.rows) {
+    return false;
+  }
+  for (let r = rowStart; r < rowEnd; r++) {
+    for (let c = colStart; c < colEnd; c++) {
+      if (mask.cells[r * mask.cols + c] !== 1) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Check whether a cutout's effective AABB fits within the mask polygon.
+ *
+ * Uses `getRotatedBounds()` for rectangles/ellipses and `getPathBounds()` for
+ * path cutouts — all shapes are validated via their axis-aligned bounding box
+ * for consistency with the existing bin-bound clamping.
+ */
+export function cutoutFitsInMask(cutout: Cutout, mask: CellMask, gridUnitMm: number): boolean {
+  let minX: number;
+  let minY: number;
+  let maxX: number;
+  let maxY: number;
+  if (cutout.shape === 'path' && cutout.path) {
+    const b = getPathBounds(cutout.path);
+    minX = b.minX;
+    minY = b.minY;
+    maxX = b.maxX;
+    maxY = b.maxY;
+  } else {
+    const b = getRotatedBounds(cutout);
+    minX = b.minX;
+    minY = b.minY;
+    maxX = b.maxX;
+    maxY = b.maxY;
+  }
+  return rectFitsInMask(mask, minX, minY, maxX - minX, maxY - minY, gridUnitMm);
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/maskFit.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/maskFit.ts
@@ -8,12 +8,25 @@
  */
 
 import type { Cutout } from '@/features/bin-designer/types';
-import { MASK_CELLS_PER_UNIT, type CellMask } from '@/shared/utils/cellMask';
+import type { CellMask } from '@/shared/utils/cellMask';
 import { getRotatedBounds } from './geometry';
 import { getPathBounds } from './pathGeometry';
 
 /** Tolerance for mask-cell boundary rounding (mm). */
 const MASK_FIT_EPSILON = 0.01;
+
+/**
+ * Mm-per-mask-cell in the editor's interior coordinate system. X and Y scales
+ * differ whenever `params.width !== params.depth` (non-square bins), since the
+ * interior is shrunk by wall thickness + baseplate tolerance — an absolute mm
+ * amount — on both axes. Callers derive from `binWidth/mask.cols` (= editor mm
+ * per mask column) and `binDepth/mask.rows` to keep validator and polygon
+ * rendering aligned.
+ */
+export interface MaskCellSize {
+  readonly cellMmX: number;
+  readonly cellMmY: number;
+}
 
 /**
  * Check whether an axis-aligned rectangle (in bin-interior mm) lies entirely
@@ -28,13 +41,13 @@ export function rectFitsInMask(
   yMm: number,
   widthMm: number,
   depthMm: number,
-  gridUnitMm: number
+  cellSize: MaskCellSize
 ): boolean {
-  const cellMm = gridUnitMm / MASK_CELLS_PER_UNIT;
-  const colStart = Math.floor((xMm + MASK_FIT_EPSILON) / cellMm);
-  const rowStart = Math.floor((yMm + MASK_FIT_EPSILON) / cellMm);
-  const colEnd = Math.ceil((xMm + widthMm - MASK_FIT_EPSILON) / cellMm);
-  const rowEnd = Math.ceil((yMm + depthMm - MASK_FIT_EPSILON) / cellMm);
+  const { cellMmX, cellMmY } = cellSize;
+  const colStart = Math.floor((xMm + MASK_FIT_EPSILON) / cellMmX);
+  const rowStart = Math.floor((yMm + MASK_FIT_EPSILON) / cellMmY);
+  const colEnd = Math.ceil((xMm + widthMm - MASK_FIT_EPSILON) / cellMmX);
+  const rowEnd = Math.ceil((yMm + depthMm - MASK_FIT_EPSILON) / cellMmY);
   if (colStart < 0 || rowStart < 0 || colEnd > mask.cols || rowEnd > mask.rows) {
     return false;
   }
@@ -53,7 +66,7 @@ export function rectFitsInMask(
  * path cutouts — all shapes are validated via their axis-aligned bounding box
  * for consistency with the existing bin-bound clamping.
  */
-export function cutoutFitsInMask(cutout: Cutout, mask: CellMask, gridUnitMm: number): boolean {
+export function cutoutFitsInMask(cutout: Cutout, mask: CellMask, cellSize: MaskCellSize): boolean {
   let minX: number;
   let minY: number;
   let maxX: number;
@@ -71,5 +84,5 @@ export function cutoutFitsInMask(cutout: Cutout, mask: CellMask, gridUnitMm: num
     maxX = b.maxX;
     maxY = b.maxY;
   }
-  return rectFitsInMask(mask, minX, minY, maxX - minX, maxY - minY, gridUnitMm);
+  return rectFitsInMask(mask, minX, minY, maxX - minX, maxY - minY, cellSize);
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutCanvas3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutCanvas3D.tsx
@@ -15,6 +15,7 @@ import type {
   CutoutShape as CutoutShapeType,
   PathPoint,
 } from '@/features/bin-designer/types';
+import type { CellMask } from '@/shared/utils/cellMask';
 import type { ResizeHandle, InteractionMode, PreviewMap } from '../useCutoutInteraction';
 import type { SegmentHoverInfo } from '../handlers';
 import type { RulerMeasurement } from '../handlers/rulerHandler';
@@ -56,6 +57,8 @@ export interface CutoutCanvas3DProps {
   readonly cutouts: readonly Cutout[];
   readonly binWidth: number;
   readonly binDepth: number;
+  /** Non-rectangular footprint mask — when present the background renders the polygon shape. */
+  readonly cellMask?: CellMask;
   readonly canvasWidth: number;
   readonly canvasHeight: number;
   readonly selection: ReadonlySet<string>;
@@ -109,6 +112,7 @@ export function CutoutCanvas3D({
   cutouts,
   binWidth,
   binDepth,
+  cellMask,
   canvasWidth,
   canvasHeight,
   selection,
@@ -283,6 +287,7 @@ export function CutoutCanvas3D({
         cutouts={cutouts}
         binWidth={binWidth}
         binDepth={binDepth}
+        cellMask={cellMask}
         binColor={binColor}
         selection={selection}
         preview={preview}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/EditorBackground3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/EditorBackground3D.tsx
@@ -12,11 +12,14 @@
 
 import { useMemo } from 'react';
 import * as THREE from 'three';
+import { isPartialMask, maskToPolygon, type CellMask } from '@/shared/utils/cellMask';
 import { RENDER_ORDER, LARGE_BIN_THRESHOLD, DOT_RADIUS_PX } from './constants';
 
 interface EditorBackground3DProps {
   readonly binWidth: number;
   readonly binDepth: number;
+  /** Non-rectangular footprint mask. When present, bin fill/outline follow the polygon. */
+  readonly cellMask?: CellMask;
   readonly zoom: number;
   readonly binColor: string;
 }
@@ -34,9 +37,11 @@ function getDotInterval(binWidth: number, binDepth: number, zoom: number): numbe
 export function EditorBackground3D({
   binWidth,
   binDepth,
+  cellMask,
   zoom,
   binColor,
 }: EditorBackground3DProps) {
+  const hasPolygon = isPartialMask(cellMask);
   const dotInterval = getDotInterval(binWidth, binDepth, zoom);
 
   // Constant screen-size dot radius (convert screen px to world mm)
@@ -53,30 +58,77 @@ export function EditorBackground3D({
   // Dot geometry recreated when zoom changes (screen-space sizing)
   const dotGeometry = useMemo(() => new THREE.CircleGeometry(dotRadius, 6), [dotRadius]);
 
-  // Build instanced mesh matrices for grid dots
+  // Build instanced mesh matrices for grid dots. For custom shapes, skip dots
+  // whose sample cell is outside the polygon — keeps the "inside" region visible.
   const { matrices, count } = useMemo(() => {
     const mats: THREE.Matrix4[] = [];
     const tempMatrix = new THREE.Matrix4();
+    const cellMmX = cellMask ? binWidth / cellMask.cols : 0;
+    const cellMmY = cellMask ? binDepth / cellMask.rows : 0;
     for (let x = 0; x <= binWidth; x += dotInterval) {
       for (let y = 0; y <= binDepth; y += dotInterval) {
+        if (cellMask && hasPolygon) {
+          // Find containing cell. Clamp to valid range; dots on the far edge
+          // belong to the last cell, not a phantom cell past the end.
+          const c = Math.min(cellMask.cols - 1, Math.max(0, Math.floor(x / cellMmX)));
+          const r = Math.min(cellMask.rows - 1, Math.max(0, Math.floor(y / cellMmY)));
+          if (cellMask.cells[r * cellMask.cols + c] !== 1) continue;
+        }
         tempMatrix.makeTranslation(x, y, 0.01);
         mats.push(tempMatrix.clone());
       }
     }
     return { matrices: mats, count: mats.length };
-  }, [binWidth, binDepth, dotInterval]);
+  }, [binWidth, binDepth, dotInterval, cellMask, hasPolygon]);
 
-  // Bin boundary line
+  // Polygon loops scaled from mask grid units to editor interior mm.
+  // Using binWidth/binDepth (vs gridUnitMm) keeps validator and visuals aligned:
+  // the polygon outline traces exactly the region where cutouts are accepted.
+  const polygonLoops = useMemo(() => {
+    if (!cellMask || !hasPolygon) return null;
+    const loops = maskToPolygon(cellMask);
+    const scaleX = binWidth / (cellMask.cols * 0.5);
+    const scaleY = binDepth / (cellMask.rows * 0.5);
+    return loops.map((loop) => loop.map((pt) => ({ x: pt.x * scaleX, y: pt.y * scaleY })));
+  }, [cellMask, hasPolygon, binWidth, binDepth]);
+
+  // THREE.Shape for filled polygon area (outer loop + holes)
+  const polygonShape = useMemo(() => {
+    if (!polygonLoops || polygonLoops.length === 0) return null;
+    const [outer, ...holes] = polygonLoops;
+    const shape = new THREE.Shape(outer.map((p) => new THREE.Vector2(p.x, p.y)));
+    for (const hole of holes) {
+      shape.holes.push(new THREE.Path(hole.map((p) => new THREE.Vector2(p.x, p.y))));
+    }
+    return shape;
+  }, [polygonLoops]);
+
+  // Bin boundary line — rectangular AABB or polygon loops
   const boundaryGeometry = useMemo(() => {
-    const points = [
-      new THREE.Vector3(0, 0, 0.005),
-      new THREE.Vector3(binWidth, 0, 0.005),
-      new THREE.Vector3(binWidth, binDepth, 0.005),
-      new THREE.Vector3(0, binDepth, 0.005),
-      new THREE.Vector3(0, 0, 0.005),
-    ];
-    return new THREE.BufferGeometry().setFromPoints(points);
-  }, [binWidth, binDepth]);
+    if (!polygonLoops) {
+      const points = [
+        new THREE.Vector3(0, 0, 0.005),
+        new THREE.Vector3(binWidth, 0, 0.005),
+        new THREE.Vector3(binWidth, binDepth, 0.005),
+        new THREE.Vector3(0, binDepth, 0.005),
+        new THREE.Vector3(0, 0, 0.005),
+      ];
+      return new THREE.BufferGeometry().setFromPoints(points);
+    }
+    // Concatenate all loops as discontinuous line segments — use a dummy break
+    // between loops by emitting each as its own closed polyline.
+    const segments: number[] = [];
+    for (const loop of polygonLoops) {
+      for (let i = 0; i < loop.length; i++) {
+        const a = loop[i];
+        const b = loop[(i + 1) % loop.length];
+        segments.push(a.x, a.y, 0.005, b.x, b.y, 0.005);
+      }
+    }
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(segments), 3));
+    return geo;
+  }, [binWidth, binDepth, polygonLoops]);
 
   // Center crosshair lines
   const crosshairGeometry = useMemo(() => {
@@ -105,11 +157,18 @@ export function EditorBackground3D({
 
   return (
     <group renderOrder={RENDER_ORDER.BACKGROUND}>
-      {/* Bin area fill — uses user's selected preview color */}
-      <mesh position={[binWidth / 2, binDepth / 2, 0]}>
-        <planeGeometry args={[binWidth, binDepth]} />
-        <meshBasicMaterial color={binColor} depthTest={false} />
-      </mesh>
+      {/* Bin area fill — polygon footprint for custom shapes, rectangle otherwise */}
+      {polygonShape ? (
+        <mesh position={[0, 0, 0]}>
+          <shapeGeometry args={[polygonShape]} />
+          <meshBasicMaterial color={binColor} depthTest={false} />
+        </mesh>
+      ) : (
+        <mesh position={[binWidth / 2, binDepth / 2, 0]}>
+          <planeGeometry args={[binWidth, binDepth]} />
+          <meshBasicMaterial color={binColor} depthTest={false} />
+        </mesh>
+      )}
 
       {/* Dot grid via InstancedMesh */}
       {count > 0 && (
@@ -127,10 +186,16 @@ export function EditorBackground3D({
         </instancedMesh>
       )}
 
-      {/* Bin boundary */}
-      <lineLoop geometry={boundaryGeometry}>
-        <lineBasicMaterial color={dotColor} transparent opacity={0.25} depthTest={false} />
-      </lineLoop>
+      {/* Bin boundary — lineLoop (closed) for rectangle, lineSegments for polygon loops */}
+      {polygonLoops ? (
+        <lineSegments geometry={boundaryGeometry}>
+          <lineBasicMaterial color={dotColor} transparent opacity={0.35} depthTest={false} />
+        </lineSegments>
+      ) : (
+        <lineLoop geometry={boundaryGeometry}>
+          <lineBasicMaterial color={dotColor} transparent opacity={0.25} depthTest={false} />
+        </lineLoop>
+      )}
 
       {/* Center crosshair — very subtle */}
       <lineSegments geometry={crosshairGeometry}>

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/SceneContent.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/SceneContent.tsx
@@ -13,6 +13,7 @@ import type {
   CutoutShape as CutoutShapeType,
   PathPoint,
 } from '@/features/bin-designer/types';
+import type { CellMask } from '@/shared/utils/cellMask';
 import type { ResizeHandle, InteractionMode, PreviewMap } from '../useCutoutInteraction';
 import type { SegmentHoverInfo } from '../handlers';
 import type { AlignmentGuide } from '../geometry';
@@ -71,6 +72,8 @@ export interface SceneContentProps {
   readonly cutouts: readonly Cutout[];
   readonly binWidth: number;
   readonly binDepth: number;
+  /** Non-rectangular footprint mask — when present background renders the polygon. */
+  readonly cellMask?: CellMask;
   readonly binColor: string;
   readonly selection: ReadonlySet<string>;
   readonly preview: PreviewMap;
@@ -126,6 +129,7 @@ export function SceneContent({
   cutouts,
   binWidth,
   binDepth,
+  cellMask,
   binColor,
   selection,
   preview,
@@ -201,6 +205,7 @@ export function SceneContent({
       <EditorBackground3D
         binWidth={binWidth}
         binDepth={binDepth}
+        cellMask={cellMask}
         zoom={camera.zoom}
         binColor={binColor}
       />

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.ts
@@ -11,6 +11,7 @@
 
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import type { Cutout, CutoutShape, PathPoint } from '@/features/bin-designer/types';
+import type { CellMask } from '@/shared/utils/cellMask';
 import { useCutoutSelection } from '@/features/bin-designer/store';
 import { useToastStore } from '@/core/store/toast';
 import { useTranslation } from '@/i18n';
@@ -21,6 +22,7 @@ import {
   getRotatedBounds,
   type AlignmentGuide,
 } from './geometry';
+import { rectFitsInMask } from './maskFit';
 import {
   getPathBounds,
   CLOSE_SNAP_THRESHOLD,
@@ -152,6 +154,10 @@ interface UseCutoutInteractionOptions {
   readonly binWidth: number;
   readonly binDepth: number;
   readonly gridSize?: number;
+  /** Non-rectangular footprint mask — when present, rejects placements outside the polygon. */
+  readonly cellMask?: CellMask;
+  /** mm per grid unit. Required alongside cellMask for mm ↔ mask conversion. */
+  readonly gridUnitMm?: number;
 }
 
 /** Paste offset in mm — each successive paste shifts by this amount */
@@ -262,6 +268,8 @@ export function useCutoutInteraction({
   binWidth,
   binDepth,
   gridSize = 0.5,
+  cellMask,
+  gridUnitMm,
 }: UseCutoutInteractionOptions) {
   const addToast = useToastStore((s) => s.addToast);
   const t = useTranslation();
@@ -481,7 +489,7 @@ export function useCutoutInteraction({
   /** Handle path background click (first click or subsequent). */
   const handlePathBackgroundDown = useCallback(
     (mmX: number, mmY: number, shiftKey: boolean) => {
-      const bounds = { binWidth, binDepth };
+      const bounds = { binWidth, binDepth, cellMask, gridUnitMm };
       const pathMode = mode.type === 'path-drawing' ? mode : null;
       handlePathDrawingPointerDown(pathMode, mmX, mmY, shiftKey, bounds, snap, {
         setMode,
@@ -489,7 +497,7 @@ export function useCutoutInteraction({
         commitPath,
       });
     },
-    [mode, binWidth, binDepth, snap, commitPath]
+    [mode, binWidth, binDepth, cellMask, gridUnitMm, snap, commitPath]
   );
 
   /** Handle clicking an existing vertex while drawing (to reposition or close). */
@@ -738,7 +746,7 @@ export function useCutoutInteraction({
   const handlePointerMove = useCallback(
     (mmX: number, mmY: number, shiftKey?: boolean, altKey?: boolean) => {
       const event = { mmX, mmY, shiftKey, altKey };
-      const bounds = { binWidth, binDepth };
+      const bounds = { binWidth, binDepth, cellMask, gridUnitMm };
 
       switch (mode.type) {
         case 'pending-place':
@@ -808,7 +816,7 @@ export function useCutoutInteraction({
         }
       }
     },
-    [mode, cutouts, binWidth, binDepth, snap, commitPath, rulerSnapTargets]
+    [mode, cutouts, binWidth, binDepth, cellMask, gridUnitMm, snap, commitPath, rulerSnapTargets]
   );
 
   // ── Pointer up (commit) ────────────────────────────────────────────
@@ -825,12 +833,23 @@ export function useCutoutInteraction({
         0,
         Math.min(snap(placeMode.startMmY - defaultSize / 2), binDepth - defaultSize)
       );
+
+      // Polygon mask: reject click-to-place inside an unfilled notch.
+      if (
+        cellMask &&
+        gridUnitMm !== undefined &&
+        !rectFitsInMask(cellMask, x, y, defaultSize, defaultSize, gridUnitMm)
+      ) {
+        setMode({ type: 'idle' });
+        return;
+      }
+
       const newId = crypto.randomUUID();
       onAdd(createDefaultCutout(newId, placeMode.shape, x, y, defaultSize, defaultSize));
       setSelection(new Set([newId]));
       setMode({ type: 'idle' });
     },
-    [snap, binWidth, binDepth, onAdd]
+    [snap, binWidth, binDepth, cellMask, gridUnitMm, onAdd]
   );
 
   /**

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.ts
@@ -22,7 +22,7 @@ import {
   getRotatedBounds,
   type AlignmentGuide,
 } from './geometry';
-import { rectFitsInMask } from './maskFit';
+import { cutoutFitsInMask, rectFitsInMask, type MaskCellSize } from './maskFit';
 import {
   getPathBounds,
   CLOSE_SNAP_THRESHOLD,
@@ -156,8 +156,8 @@ interface UseCutoutInteractionOptions {
   readonly gridSize?: number;
   /** Non-rectangular footprint mask — when present, rejects placements outside the polygon. */
   readonly cellMask?: CellMask;
-  /** mm per grid unit. Required alongside cellMask for mm ↔ mask conversion. */
-  readonly gridUnitMm?: number;
+  /** Mm per mask cell. Required alongside cellMask; X/Y differ on non-square bins. */
+  readonly maskCellSize?: MaskCellSize;
 }
 
 /** Paste offset in mm — each successive paste shifts by this amount */
@@ -269,7 +269,7 @@ export function useCutoutInteraction({
   binDepth,
   gridSize = 0.5,
   cellMask,
-  gridUnitMm,
+  maskCellSize,
 }: UseCutoutInteractionOptions) {
   const addToast = useToastStore((s) => s.addToast);
   const t = useTranslation();
@@ -413,6 +413,18 @@ export function useCutoutInteraction({
           y: Math.max(minY, Math.min(cutout.y + dy, maxY)),
         });
       }
+
+      // Polygon mask: reject the whole nudge if any cutout would overhang,
+      // matching the "stuck" semantics of drag against the polygon edge.
+      if (cellMask && maskCellSize) {
+        for (const [id, patch] of updates) {
+          const orig = cutouts.find((c) => c.id === id);
+          if (!orig) continue;
+          const candidate = { ...orig, ...patch } as Cutout;
+          if (!cutoutFitsInMask(candidate, cellMask, maskCellSize)) return;
+        }
+      }
+
       if (onUpdateBatch) {
         onUpdateBatch(updates);
       } else {
@@ -421,7 +433,7 @@ export function useCutoutInteraction({
         }
       }
     },
-    [selection, cutouts, onUpdate, onUpdateBatch, binWidth, binDepth]
+    [selection, cutouts, onUpdate, onUpdateBatch, binWidth, binDepth, cellMask, maskCellSize]
   );
 
   // ── Clipboard ──────────────────────────────────────────────────────
@@ -444,19 +456,39 @@ export function useCutoutInteraction({
     pasteCountRef.current += 1;
     const offset = PASTE_OFFSET * pasteCountRef.current;
 
-    addClonedCutouts(clipboard, onAdd, setSelection, (original) =>
+    // Polygon bins: drop originals whose offset clone would overhang the mask.
+    // User can re-paste at a different location rather than losing the clipboard.
+    const placeable =
+      cellMask && maskCellSize
+        ? clipboard.filter((orig) => {
+            const pos = clampedOffset(orig, offset, binWidth, binDepth);
+            return cutoutFitsInMask({ ...orig, ...pos } as Cutout, cellMask, maskCellSize);
+          })
+        : clipboard;
+    if (placeable.length === 0) return;
+
+    addClonedCutouts(placeable, onAdd, setSelection, (original) =>
       clampedOffset(original, offset, binWidth, binDepth)
     );
-  }, [clipboard, onAdd, binWidth, binDepth]);
+  }, [clipboard, onAdd, binWidth, binDepth, cellMask, maskCellSize]);
 
   const duplicateSelected = useCallback(() => {
     const selected = cutouts.filter((c) => selection.has(c.id));
     if (selected.length === 0) return;
 
-    addClonedCutouts(selected, onAdd, setSelection, (original) =>
+    const placeable =
+      cellMask && maskCellSize
+        ? selected.filter((orig) => {
+            const pos = clampedOffset(orig, PASTE_OFFSET, binWidth, binDepth);
+            return cutoutFitsInMask({ ...orig, ...pos } as Cutout, cellMask, maskCellSize);
+          })
+        : selected;
+    if (placeable.length === 0) return;
+
+    addClonedCutouts(placeable, onAdd, setSelection, (original) =>
       clampedOffset(original, PASTE_OFFSET, binWidth, binDepth)
     );
-  }, [cutouts, selection, onAdd, binWidth, binDepth]);
+  }, [cutouts, selection, onAdd, binWidth, binDepth, cellMask, maskCellSize]);
 
   // ── Path tool ────────────────────────────────────────────────────
 
@@ -474,6 +506,18 @@ export function useCutoutInteraction({
       }
 
       const { minX, minY, maxX, maxY } = getPathBounds(clamped);
+
+      // Polygon bins: reject paths whose bounds overhang the mask.
+      if (
+        cellMask &&
+        maskCellSize &&
+        !rectFitsInMask(cellMask, minX, minY, maxX - minX, maxY - minY, maskCellSize)
+      ) {
+        setPathDrawingPreview(null);
+        setMode({ type: 'idle' });
+        return;
+      }
+
       const newId = crypto.randomUUID();
       onAdd({
         ...createDefaultCutout(newId, 'path', minX, minY, maxX - minX, maxY - minY),
@@ -483,13 +527,13 @@ export function useCutoutInteraction({
       setMode({ type: 'idle' });
       setPathDrawingPreview(null);
     },
-    [onAdd, binWidth, binDepth]
+    [onAdd, binWidth, binDepth, cellMask, maskCellSize]
   );
 
   /** Handle path background click (first click or subsequent). */
   const handlePathBackgroundDown = useCallback(
     (mmX: number, mmY: number, shiftKey: boolean) => {
-      const bounds = { binWidth, binDepth, cellMask, gridUnitMm };
+      const bounds = { binWidth, binDepth, cellMask, maskCellSize };
       const pathMode = mode.type === 'path-drawing' ? mode : null;
       handlePathDrawingPointerDown(pathMode, mmX, mmY, shiftKey, bounds, snap, {
         setMode,
@@ -497,7 +541,7 @@ export function useCutoutInteraction({
         commitPath,
       });
     },
-    [mode, binWidth, binDepth, cellMask, gridUnitMm, snap, commitPath]
+    [mode, binWidth, binDepth, cellMask, maskCellSize, snap, commitPath]
   );
 
   /** Handle clicking an existing vertex while drawing (to reposition or close). */
@@ -746,7 +790,7 @@ export function useCutoutInteraction({
   const handlePointerMove = useCallback(
     (mmX: number, mmY: number, shiftKey?: boolean, altKey?: boolean) => {
       const event = { mmX, mmY, shiftKey, altKey };
-      const bounds = { binWidth, binDepth, cellMask, gridUnitMm };
+      const bounds = { binWidth, binDepth, cellMask, maskCellSize };
 
       switch (mode.type) {
         case 'pending-place':
@@ -773,13 +817,13 @@ export function useCutoutInteraction({
           break;
 
         case 'group-rotating':
-          handleGroupRotateMove(mode, event, cutouts, pastDeadZoneRef, {
+          handleGroupRotateMove(mode, event, cutouts, bounds, pastDeadZoneRef, {
             setPreview,
           });
           break;
 
         case 'group-scaling':
-          handleGroupScaleMove(mode, event, pastDeadZoneRef, {
+          handleGroupScaleMove(mode, event, cutouts, bounds, pastDeadZoneRef, {
             setPreview,
           });
           break;
@@ -816,7 +860,7 @@ export function useCutoutInteraction({
         }
       }
     },
-    [mode, cutouts, binWidth, binDepth, cellMask, gridUnitMm, snap, commitPath, rulerSnapTargets]
+    [mode, cutouts, binWidth, binDepth, cellMask, maskCellSize, snap, commitPath, rulerSnapTargets]
   );
 
   // ── Pointer up (commit) ────────────────────────────────────────────
@@ -837,8 +881,8 @@ export function useCutoutInteraction({
       // Polygon mask: reject click-to-place inside an unfilled notch.
       if (
         cellMask &&
-        gridUnitMm !== undefined &&
-        !rectFitsInMask(cellMask, x, y, defaultSize, defaultSize, gridUnitMm)
+        maskCellSize &&
+        !rectFitsInMask(cellMask, x, y, defaultSize, defaultSize, maskCellSize)
       ) {
         setMode({ type: 'idle' });
         return;
@@ -849,7 +893,7 @@ export function useCutoutInteraction({
       setSelection(new Set([newId]));
       setMode({ type: 'idle' });
     },
-    [snap, binWidth, binDepth, cellMask, gridUnitMm, onAdd]
+    [snap, binWidth, binDepth, cellMask, maskCellSize, onAdd]
   );
 
   /**

--- a/src/features/bin-designer/components/panel/InteriorSection/InteriorSection.tsx
+++ b/src/features/bin-designer/components/panel/InteriorSection/InteriorSection.tsx
@@ -6,25 +6,48 @@
  * Each card shows icon, title, description, and expands inline with controls.
  */
 
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { isPartialMask } from '@/shared/utils/cellMask';
+import { useTranslation } from '@/i18n';
 import { InteriorModeCard } from './InteriorModeCard';
 import { useInteriorSection } from './useInteriorSection';
+import { FeatureGate } from '../FeatureGate';
 import type { BinStyle } from '../../../types';
 
 const MODES: BinStyle[] = ['standard', 'slotted', 'solid'];
 
+/**
+ * Standard (compartment grid) and Slotted (divider slots) assume a rectangular
+ * interior; Solid (cutouts) is polygon-aware and stays interactive on custom shapes.
+ */
+const MODES_REQUIRING_RECTANGULAR_SHAPE: ReadonlySet<BinStyle> = new Set(['standard', 'slotted']);
+
 export function InteriorSection() {
   const { state, handlers } = useInteriorSection();
+  const t = useTranslation();
+  const isCustomShape = useDesignerStore((s) => isPartialMask(s.params.cellMask));
+  const customShapeReason = t('binDesigner.shape.custom.hint');
 
   return (
     <div className="space-y-2">
-      {MODES.map((mode) => (
-        <InteriorModeCard
-          key={mode}
-          mode={mode}
-          isExpanded={state.style === mode}
-          onSelect={() => handlers.setStyle(mode)}
-        />
-      ))}
+      {MODES.map((mode) => {
+        const card = (
+          <InteriorModeCard
+            key={mode}
+            mode={mode}
+            isExpanded={state.style === mode}
+            onSelect={() => handlers.setStyle(mode)}
+          />
+        );
+        if (isCustomShape && MODES_REQUIRING_RECTANGULAR_SHAPE.has(mode)) {
+          return (
+            <FeatureGate key={mode} disabled reason={customShapeReason}>
+              {card}
+            </FeatureGate>
+          );
+        }
+        return card;
+      })}
     </div>
   );
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Behälterform-Editor. Klicke auf eine Zelle, um sie umzuschalten.",
   "binDesigner.shape.grid.cellLabel.filled": "Zelle {col}, {row}: gefüllt",
   "binDesigner.shape.grid.cellLabel.empty": "Zelle {col}, {row}: leer",
-  "binDesigner.shape.custom.hint": "Benutzerdefinierte Form. Wandmuster, Aussparungen, Griffe, Fächer, Etikettenlaschen und Schaufel sind für nicht-rechteckige Behälter nicht verfügbar.",
+  "binDesigner.shape.custom.hint": "Benutzerdefinierte Form. Wandmuster, Wandaussparungen, Griffe, Fächer, Trennwände, Etikettenlaschen und Schaufel sind für nicht-rechteckige Behälter nicht verfügbar.",
   "binDesigner.colors.labelTab": "Beschriftungslasche",
   "binDesigner.colors.lip": "Stapellippe",
   "binDesigner.colors.presets": "Voreinstellungen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1072,7 +1072,7 @@
   "binDesigner.shape.grid.ariaLabel": "Bin shape editor. Click a cell to toggle it.",
   "binDesigner.shape.grid.cellLabel.filled": "Cell {col}, {row}: filled",
   "binDesigner.shape.grid.cellLabel.empty": "Cell {col}, {row}: empty",
-  "binDesigner.shape.custom.hint": "Custom shape. Wall patterns, cutouts, handles, compartments, label tabs, and scoop are unavailable for non-rectangular bins.",
+  "binDesigner.shape.custom.hint": "Custom shape. Wall patterns, wall cutouts, handles, compartments, dividers, label tabs, and scoop are unavailable for non-rectangular bins.",
   "binDesigner.splitAxisInfo": "Split along {axis} into {count} pieces",
   "binDesigner.splitAxisWidth": "width",
   "binDesigner.splitAxisDepth": "depth",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1220,7 +1220,7 @@ const en: Record<string, string> = {
   'binDesigner.shape.grid.cellLabel.filled': 'Cell {col}, {row}: filled',
   'binDesigner.shape.grid.cellLabel.empty': 'Cell {col}, {row}: empty',
   'binDesigner.shape.custom.hint':
-    'Custom shape. Wall patterns, cutouts, handles, compartments, label tabs, and scoop are unavailable for non-rectangular bins.',
+    'Custom shape. Wall patterns, wall cutouts, handles, compartments, dividers, label tabs, and scoop are unavailable for non-rectangular bins.',
 
   'binDesigner.splitAxisInfo': 'Split along {axis} into {count} pieces',
 

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Editor de forma del contenedor. Haz clic en una celda para alternarla.",
   "binDesigner.shape.grid.cellLabel.filled": "Celda {col}, {row}: rellena",
   "binDesigner.shape.grid.cellLabel.empty": "Celda {col}, {row}: vacía",
-  "binDesigner.shape.custom.hint": "Forma personalizada. Los patrones de pared, los recortes, las asas, los compartimentos, las pestañas de etiqueta y la pala no están disponibles para los contenedores no rectangulares.",
+  "binDesigner.shape.custom.hint": "Forma personalizada. Los patrones de pared, los recortes de pared, las asas, los compartimentos, los divisores, las pestañas de etiqueta y la pala no están disponibles para los contenedores no rectangulares.",
   "binDesigner.colors.labelTab": "Pestaña de etiqueta",
   "binDesigner.colors.lip": "Labio de apilamiento",
   "binDesigner.colors.presets": "Preajustes",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Éditeur de forme du bac. Cliquez sur une cellule pour la basculer.",
   "binDesigner.shape.grid.cellLabel.filled": "Cellule {col}, {row} : remplie",
   "binDesigner.shape.grid.cellLabel.empty": "Cellule {col}, {row} : vide",
-  "binDesigner.shape.custom.hint": "Forme personnalisée. Motifs de paroi, découpes, poignées, compartiments, onglets d'étiquette et pelle sont indisponibles pour les bacs non rectangulaires.",
+  "binDesigner.shape.custom.hint": "Forme personnalisée. Motifs de paroi, découpes de paroi, poignées, compartiments, séparateurs, onglets d'étiquette et pelle sont indisponibles pour les bacs non rectangulaires.",
   "binDesigner.colors.labelTab": "Languette d'étiquette",
   "binDesigner.colors.lip": "Lèvre d'empilage",
   "binDesigner.colors.presets": "Préréglages",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Redigerer for beholderform. Klikk på en celle for å veksle den.",
   "binDesigner.shape.grid.cellLabel.filled": "Celle {col}, {row}: fylt",
   "binDesigner.shape.grid.cellLabel.empty": "Celle {col}, {row}: tom",
-  "binDesigner.shape.custom.hint": "Egendefinert form. Veggmønstre, utskjæringer, håndtak, rom, etikettfaner og skje er ikke tilgjengelige for ikke-rektangulære beholdere.",
+  "binDesigner.shape.custom.hint": "Egendefinert form. Veggmønstre, veggutskjæringer, håndtak, rom, skillevegger, etikettfaner og skje er ikke tilgjengelige for ikke-rektangulære beholdere.",
   "binDesigner.colors.labelTab": "Etikett-fane",
   "binDesigner.colors.lip": "Stablelippe",
   "binDesigner.colors.presets": "Forhåndsvalg",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Vakvorm-editor. Klik op een cel om deze te wisselen.",
   "binDesigner.shape.grid.cellLabel.filled": "Cel {col}, {row}: gevuld",
   "binDesigner.shape.grid.cellLabel.empty": "Cel {col}, {row}: leeg",
-  "binDesigner.shape.custom.hint": "Aangepaste vorm. Wandpatronen, uitsparingen, handgrepen, compartimenten, labeltabs en scheppen zijn niet beschikbaar voor niet-rechthoekige bakken.",
+  "binDesigner.shape.custom.hint": "Aangepaste vorm. Wandpatronen, wanduitsparingen, handgrepen, compartimenten, scheidingen, labeltabs en scheppen zijn niet beschikbaar voor niet-rechthoekige bakken.",
   "binDesigner.colors.labelTab": "Labeltab",
   "binDesigner.colors.lip": "Stapelrand",
   "binDesigner.colors.presets": "Voorinstellingen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Editor de forma do compartimento. Clique em uma célula para alterná-la.",
   "binDesigner.shape.grid.cellLabel.filled": "Célula {col}, {row}: preenchida",
   "binDesigner.shape.grid.cellLabel.empty": "Célula {col}, {row}: vazia",
-  "binDesigner.shape.custom.hint": "Forma personalizada. Padrões de parede, recortes, alças, compartimentos, abas de etiqueta e concha não estão disponíveis para caixas não retangulares.",
+  "binDesigner.shape.custom.hint": "Forma personalizada. Padrões de parede, recortes de parede, alças, compartimentos, divisores, abas de etiqueta e concha não estão disponíveis para caixas não retangulares.",
   "binDesigner.colors.labelTab": "Aba de etiqueta",
   "binDesigner.colors.lip": "Lábio de empilhamento",
   "binDesigner.colors.presets": "Predefinidos",


### PR DESCRIPTION
## Summary

Addresses the **Custom Cutouts** (Easy) item from #1416: extends `cellMask` awareness to the Solid cutout interior mode so L/T/U/custom footprints accept cutouts.

- Drag, resize, rotate, draw, and click-to-place hard-reject placements whose AABB overhangs the polygon (matches the dimension-overflow rejection style already in place for out-of-bounds transforms).
- New `maskFit.ts` with `rectFitsInMask(mask, x, y, w, d, gridUnit)` + `cutoutFitsInMask(cutout, mask, gridUnit)` helpers.
- `useCutoutInteraction` threads the mask through `BinBounds` to drag/resize/rotate/draw handlers.
- Ungates the Solid mode card when the shape is custom. Standard/Slotted stay gated (rectangular-only, tracked as "defer indefinitely" in #1416).
- `EditorBackground3D` renders the polygon footprint (fill + outline) instead of the AABB; grid dots outside the polygon are skipped so the valid placement region is visible at a glance.
- Validator and renderer share `editorGridUnitMm = binWidth / params.width` so the polygon outline traces the exact rejection boundary — no "looks inside but gets rejected" edge cases.

Other #1416 checklist items (wall cutouts, handles, label tabs, scoop, wall pattern) remain follow-up PRs per the issue.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` no new warnings on touched files
- [x] `pnpm test:run` — 9965 tests pass (+15 new unit tests in `geometry.test.ts`)
- [x] Generator scenario tests still pass
- [ ] Manual: draw / drag / resize / rotate a cutout on an L-shape; confirm rejection at the notch and visible polygon outline
- [ ] Manual: click-to-place inside notch is rejected
- [ ] Manual: rectangular bins unchanged (regression guard)