### PR TITLE
feat(bin-designer): polygon-aware wall cutouts on custom bin shapes

### DIFF
--- a/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
@@ -18,9 +18,9 @@ import { FeatureGate } from '../FeatureGate';
 
 export function WallsSection() {
   const { state, handlers, t } = useWallsSection();
-  // Pattern/cutouts/handle position from the axis-aligned bounding box, so
-  // they don't align with custom polygons. Wall thickness, by contrast, is
-  // a single mm value and works for any footprint.
+  // Pattern and handles still position from the axis-aligned bounding box, so
+  // they don't align with custom polygons. Wall cutouts are now polygon-aware
+  // (auto-snap to the outermost matching polygon edge) and stay interactive.
   const isCustomShape = useDesignerStore((s) => isPartialMask(s.params.cellMask));
   const customShapeReason = t('binDesigner.shape.custom.hint');
 
@@ -34,9 +34,9 @@ export function WallsSection() {
         unit="mm"
         tip={t('binDesigner.wallThickness.nozzleTip')}
       />
-      <FeatureGate disabled={isCustomShape} reason={customShapeReason}>
-        <div className="space-y-4">
-          <div className="pt-3 border-t border-stroke-subtle/50">
+      <div className="space-y-4">
+        <div className="pt-3 border-t border-stroke-subtle/50">
+          <FeatureGate disabled={isCustomShape} reason={customShapeReason}>
             <PatternSelector
               selectedPattern={state.patternEnabled ? state.pattern : null}
               onChange={handlers.handlePatternChange}
@@ -46,15 +46,17 @@ export function WallsSection() {
             {state.patternPartialNote && state.patternEnabled && (
               <p className="text-[11px] text-content-tertiary mt-1">{state.patternPartialNote}</p>
             )}
-          </div>
-          <div className="pt-3 border-t border-stroke-subtle/50">
-            <WallCutoutsSection />
-          </div>
-          <div className="pt-3 border-t border-stroke-subtle/50">
-            <HandleSection />
-          </div>
+          </FeatureGate>
         </div>
-      </FeatureGate>
+        <div className="pt-3 border-t border-stroke-subtle/50">
+          <WallCutoutsSection />
+        </div>
+        <div className="pt-3 border-t border-stroke-subtle/50">
+          <FeatureGate disabled={isCustomShape} reason={customShapeReason}>
+            <HandleSection />
+          </FeatureGate>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -58,11 +58,15 @@ exports[`custom-shape > 2×2 mixed-detail per-cell half sockets 1`] = `4202`;
 
 exports[`custom-shape > 3×3 L flat base no lip 1`] = `260`;
 
+exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`] = `5204`;
+
 exports[`custom-shape > 3×3 L with lip 1`] = `5124`;
 
 exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `5464`;
 
 exports[`custom-shape > 3×3 T with lip 1`] = `4156`;
+
+exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `5206`;
 
 exports[`custom-shape > 3×3 U with lip 1`] = `5126`;
 

--- a/src/features/generation/worker/generators/maskPolygonEdges.test.ts
+++ b/src/features/generation/worker/generators/maskPolygonEdges.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import type { CellMask } from '@/shared/utils/cellMask';
+import { findPolygonEdgeForSide, resolvePolygonSideGeometry } from './maskPolygonEdges';
+
+/**
+ * Build a CellMask from a top-down 2D array of 0/1.
+ * Rows are visual (top-to-bottom); cellMask rows run bottom-to-top, so flip.
+ */
+function makeMask(rows: ReadonlyArray<ReadonlyArray<0 | 1>>): CellMask {
+  const rowCount = rows.length;
+  const colCount = rows[0].length;
+  const cells: Array<0 | 1> = new Array<0 | 1>(rowCount * colCount).fill(0);
+  for (let r = 0; r < rowCount; r++) {
+    const sourceRow = rows[rowCount - 1 - r];
+    for (let c = 0; c < colCount; c++) {
+      cells[r * colCount + c] = sourceRow[c];
+    }
+  }
+  return { cols: colCount, rows: rowCount, cells };
+}
+
+describe('findPolygonEdgeForSide', () => {
+  describe('fully filled rectangle', () => {
+    // 2x2 unit mask = 4x4 cells
+    const rectMask = makeMask([
+      [1, 1, 1, 1],
+      [1, 1, 1, 1],
+      [1, 1, 1, 1],
+      [1, 1, 1, 1],
+    ]);
+
+    it('picks the bottom edge for front', () => {
+      const edge = findPolygonEdgeForSide(rectMask, 'front');
+      expect(edge).not.toBeNull();
+      expect(edge!.perpU).toBe(0);
+      expect(edge!.spanU).toBe(2); // 2 grid units wide
+      expect(edge!.midU).toEqual({ x: 1, y: 0 });
+    });
+
+    it('picks the top edge for back', () => {
+      const edge = findPolygonEdgeForSide(rectMask, 'back');
+      expect(edge).not.toBeNull();
+      expect(edge!.perpU).toBe(2);
+      expect(edge!.spanU).toBe(2);
+      expect(edge!.midU).toEqual({ x: 1, y: 2 });
+    });
+
+    it('picks the left edge for left', () => {
+      const edge = findPolygonEdgeForSide(rectMask, 'left');
+      expect(edge).not.toBeNull();
+      expect(edge!.perpU).toBe(0);
+      expect(edge!.spanU).toBe(2);
+      expect(edge!.midU).toEqual({ x: 0, y: 1 });
+    });
+
+    it('picks the right edge for right', () => {
+      const edge = findPolygonEdgeForSide(rectMask, 'right');
+      expect(edge).not.toBeNull();
+      expect(edge!.perpU).toBe(2);
+      expect(edge!.spanU).toBe(2);
+      expect(edge!.midU).toEqual({ x: 2, y: 1 });
+    });
+  });
+
+  describe('L-shape (notch top-right)', () => {
+    // 2x2 unit mask with top-right unit (cols 2-3, rows 2-3) empty
+    const lMask = makeMask([
+      [1, 1, 0, 0],
+      [1, 1, 0, 0],
+      [1, 1, 1, 1],
+      [1, 1, 1, 1],
+    ]);
+
+    it('picks the full bottom for front (single candidate)', () => {
+      const edge = findPolygonEdgeForSide(lMask, 'front');
+      expect(edge!.perpU).toBe(0);
+      expect(edge!.spanU).toBe(2);
+    });
+
+    it('picks the outermost top edge for back (extremum over notch-shelf)', () => {
+      // Two candidates: the shelf at y=1 (over the notch) and the outer top at y=2
+      const edge = findPolygonEdgeForSide(lMask, 'back');
+      expect(edge!.perpU).toBe(2); // outermost
+      expect(edge!.spanU).toBe(1); // only left column spans 1 unit at y=2
+    });
+
+    it('picks the outermost right edge', () => {
+      // Two candidates: right edge of bottom row at x=2 (span 1) and right of column at x=1 (span 1)
+      const edge = findPolygonEdgeForSide(lMask, 'right');
+      expect(edge!.perpU).toBe(2);
+      expect(edge!.spanU).toBe(1);
+    });
+
+    it('picks the left edge spanning the full height', () => {
+      const edge = findPolygonEdgeForSide(lMask, 'left');
+      expect(edge!.perpU).toBe(0);
+      expect(edge!.spanU).toBe(2);
+    });
+  });
+
+  describe('U-shape (channel through middle)', () => {
+    // 3 cols × 2 units tall with top-middle cells empty (U open at top)
+    // Cells layout (top→bottom visual):
+    //   [1,0,1] × 2 rows (top half has empty middle column)
+    //   [1,1,1] × 2 rows (bottom half fully filled)
+    // Width 3u = 6 cols, depth 2u = 4 rows
+    const uMask = makeMask([
+      [1, 1, 0, 0, 1, 1],
+      [1, 1, 0, 0, 1, 1],
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1],
+    ]);
+
+    it('picks the full bottom for front', () => {
+      const edge = findPolygonEdgeForSide(uMask, 'front');
+      expect(edge!.perpU).toBe(0);
+      expect(edge!.spanU).toBe(3);
+    });
+
+    it('picks the tallest back edge (tiebreak on length, equal extremum)', () => {
+      // Back edges at y=2 (left arm and right arm, each span 1u) — both outermost.
+      // Tiebreak on length: both are 1u, so the one found first wins (order depends
+      // on polygon traversal). Either is acceptable — both are symmetrically valid.
+      const edge = findPolygonEdgeForSide(uMask, 'back');
+      expect(edge!.perpU).toBe(2);
+      expect(edge!.spanU).toBe(1);
+    });
+
+    it('picks the outermost left edge', () => {
+      const edge = findPolygonEdgeForSide(uMask, 'left');
+      expect(edge!.perpU).toBe(0);
+      expect(edge!.spanU).toBe(2); // full height
+    });
+
+    it('picks the outermost right edge', () => {
+      const edge = findPolygonEdgeForSide(uMask, 'right');
+      expect(edge!.perpU).toBe(3);
+      expect(edge!.spanU).toBe(2); // full height
+    });
+  });
+});
+
+describe('resolvePolygonSideGeometry', () => {
+  const GRID_UNIT = 42;
+  const WALL = 0.95;
+  // CLEARANCE / 2 = 0.25 → inset = 1.2 mm
+  const INSET = WALL + 0.25;
+
+  it('matches rect-bin placement for a fully filled 2u×2u mask', () => {
+    const mask = makeMask([
+      [1, 1, 1, 1],
+      [1, 1, 1, 1],
+      [1, 1, 1, 1],
+      [1, 1, 1, 1],
+    ]);
+    const outerW = 2 * GRID_UNIT - 0.5; // 83.5
+    const innerW = outerW - 2 * WALL; // 81.6
+    const innerHalf = innerW / 2; // 40.8
+
+    const front = resolvePolygonSideGeometry(mask, GRID_UNIT, WALL, 'front');
+    expect(front).not.toBeNull();
+    expect(front!.rotateZ).toBe(0);
+    expect(front!.x).toBeCloseTo(0, 5);
+    expect(front!.y).toBeCloseTo(-innerHalf, 5);
+    expect(front!.wallSpan).toBeCloseTo(innerW, 5);
+
+    const right = resolvePolygonSideGeometry(mask, GRID_UNIT, WALL, 'right');
+    expect(right!.rotateZ).toBe(90);
+    expect(right!.x).toBeCloseTo(innerHalf, 5);
+    expect(right!.y).toBeCloseTo(0, 5);
+    expect(right!.wallSpan).toBeCloseTo(innerW, 5);
+  });
+
+  it('places cutout on the outer L-shape back wall, not the notch shelf', () => {
+    const lMask = makeMask([
+      [1, 1, 0, 0],
+      [1, 1, 0, 0],
+      [1, 1, 1, 1],
+      [1, 1, 1, 1],
+    ]);
+    const back = resolvePolygonSideGeometry(lMask, GRID_UNIT, WALL, 'back');
+    expect(back).not.toBeNull();
+    expect(back!.rotateZ).toBe(0);
+    // Outer edge at polygon y=2 → mm y = 2*42 - halfDepth(42) = 42, inset back by 1.2
+    expect(back!.y).toBeCloseTo(42 - INSET, 5);
+    // Midpoint of [0,2]→[1,2] at polygon x = 0.5 → mm x = 0.5*42 - 42 = -21
+    expect(back!.x).toBeCloseTo(-21, 5);
+    // Inner span = raw - CLEARANCE - 2*wallThickness (mirrors rect-bin formula)
+    expect(back!.wallSpan).toBeCloseTo(42 - 0.5 - 2 * WALL, 5);
+  });
+
+  it('returns null for a side with no matching edge (pathological)', () => {
+    // Single-cell mask: has all four sides, so not pathological. We can't easily
+    // construct a polygon with no edge facing a side via the mask API, so test
+    // the null path via the underlying edge finder directly instead.
+    const mask = makeMask([[1]]);
+    // All four sides should have an edge on a trivial mask.
+    expect(findPolygonEdgeForSide(mask, 'front')).not.toBeNull();
+    expect(findPolygonEdgeForSide(mask, 'back')).not.toBeNull();
+    expect(findPolygonEdgeForSide(mask, 'left')).not.toBeNull();
+    expect(findPolygonEdgeForSide(mask, 'right')).not.toBeNull();
+  });
+});

--- a/src/features/generation/worker/generators/maskPolygonEdges.test.ts
+++ b/src/features/generation/worker/generators/maskPolygonEdges.test.ts
@@ -117,13 +117,15 @@ describe('findPolygonEdgeForSide', () => {
       expect(edge!.spanU).toBe(3);
     });
 
-    it('picks the tallest back edge (tiebreak on length, equal extremum)', () => {
+    it('picks the left arm for back on a symmetric U (deterministic tiebreak)', () => {
       // Back edges at y=2 (left arm and right arm, each span 1u) — both outermost.
-      // Tiebreak on length: both are 1u, so the one found first wins (order depends
-      // on polygon traversal). Either is acceptable — both are symmetrically valid.
+      // Length ties, so the deterministic midpoint-X tiebreak wins: the LEFT arm
+      // (smaller midpoint X) is selected consistently, regardless of polygon
+      // traversal order. Users get reproducible results on symmetric shapes.
       const edge = findPolygonEdgeForSide(uMask, 'back');
       expect(edge!.perpU).toBe(2);
       expect(edge!.spanU).toBe(1);
+      expect(edge!.midU.x).toBe(0.5); // left arm midpoint, not 2.5 (right arm)
     });
 
     it('picks the outermost left edge', () => {
@@ -189,12 +191,13 @@ describe('resolvePolygonSideGeometry', () => {
     expect(back!.wallSpan).toBeCloseTo(42 - 0.5 - 2 * WALL, 5);
   });
 
-  it('returns null for a side with no matching edge (pathological)', () => {
-    // Single-cell mask: has all four sides, so not pathological. We can't easily
-    // construct a polygon with no edge facing a side via the mask API, so test
-    // the null path via the underlying edge finder directly instead.
+  it('resolves all four sides for a trivial single-cell mask', () => {
+    // Sanity check that even the smallest valid mask has matching edges on
+    // every side — any axis-aligned CCW polygon traversal must include all
+    // four cardinal directions to close, so the null-return path is only
+    // reachable for invalid (<3-vertex) polygons, which `maskToPolygon`
+    // rejects upstream. We keep the null guard defensively.
     const mask = makeMask([[1]]);
-    // All four sides should have an edge on a trivial mask.
     expect(findPolygonEdgeForSide(mask, 'front')).not.toBeNull();
     expect(findPolygonEdgeForSide(mask, 'back')).not.toBeNull();
     expect(findPolygonEdgeForSide(mask, 'left')).not.toBeNull();

--- a/src/features/generation/worker/generators/maskPolygonEdges.ts
+++ b/src/features/generation/worker/generators/maskPolygonEdges.ts
@@ -1,0 +1,180 @@
+/**
+ * Map a rectangular bin side (front/back/left/right) to a polygon edge for
+ * non-rectangular bin footprints.
+ *
+ * Used by feature builders (wall cutouts, eventually handles) that position
+ * their geometry by side on the bounding box. For a custom shape, each side
+ * may correspond to one or more external polygon edges; this module picks the
+ * outermost one (extreme perpendicular coordinate), tiebreaking by length.
+ *
+ * Coordinate conventions match `maskPolygon.ts`: the input loop comes from
+ * `maskToPolygon` in grid-unit coordinates (origin at mask bottom-left, CCW).
+ * The resolver returns centered-mm coordinates (matching the existing wall
+ * cutout builder's "bin centered at origin" frame).
+ */
+
+import { MASK_CELL_SIZE, maskToPolygon, type CellMask } from '@/shared/utils/cellMask';
+import { CLEARANCE } from './generatorConstants';
+
+export type WallSideKey = 'front' | 'back' | 'left' | 'right';
+
+/**
+ * Resolved placement geometry for a wall-sided feature on a polygon footprint.
+ *
+ * Matches the shape of the rect-bin entries in wallCutoutBuilder's `sides`
+ * array so the two code paths can share the downstream loop.
+ */
+export interface PolygonSideGeometry {
+  readonly key: WallSideKey;
+  /** Effective inner wall span in mm — the basis for percentage widths. */
+  readonly wallSpan: number;
+  /** Cutout anchor X in centered mm (bin origin at 0,0). */
+  readonly x: number;
+  /** Cutout anchor Y in centered mm. */
+  readonly y: number;
+  /** Rotation in degrees: 0 for horizontal walls (front/back), 90 for vertical. */
+  readonly rotateZ: number;
+}
+
+interface SideConfig {
+  readonly dxMatch: -1 | 0 | 1;
+  readonly dyMatch: -1 | 0 | 1;
+  readonly perpAxis: 'x' | 'y';
+  /** +1 means prefer higher perpendicular coord, -1 means lower. */
+  readonly extremeSign: -1 | 1;
+  readonly rotateZ: number;
+}
+
+/**
+ * CCW polygon edge directions that face each side (outward normal points "out"
+ * the named side). For a CCW outer loop, interior is on the LEFT of each edge
+ * direction, so an edge going +X has its interior above (normal -Y = front face),
+ * meaning the edge itself IS the front wall.
+ */
+const SIDE_CONFIG: Record<WallSideKey, SideConfig> = {
+  front: { dxMatch: 1, dyMatch: 0, perpAxis: 'y', extremeSign: -1, rotateZ: 0 },
+  back: { dxMatch: -1, dyMatch: 0, perpAxis: 'y', extremeSign: 1, rotateZ: 0 },
+  left: { dxMatch: 0, dyMatch: -1, perpAxis: 'x', extremeSign: -1, rotateZ: 90 },
+  right: { dxMatch: 0, dyMatch: 1, perpAxis: 'x', extremeSign: 1, rotateZ: 90 },
+};
+
+interface PolygonEdgeRaw {
+  /** Edge midpoint in grid units. */
+  readonly midU: { readonly x: number; readonly y: number };
+  /** Edge length in grid units. */
+  readonly spanU: number;
+  /** Fixed perpendicular coordinate (constant along the edge). */
+  readonly perpU: number;
+}
+
+/**
+ * Find the polygon edge that best represents `side` on a custom mask.
+ *
+ * Returns null when no polygon edge faces the requested direction — which
+ * can happen for pathological shapes where the mask has no axis-aligned wall
+ * facing that side. Callers are expected to silently skip placement in that
+ * case (matching the generator's existing out-of-polygon clip semantics).
+ *
+ * Exported for unit testing; production code should prefer `resolvePolygonSideGeometry`.
+ */
+export function findPolygonEdgeForSide(mask: CellMask, side: WallSideKey): PolygonEdgeRaw | null {
+  const loops = maskToPolygon(mask);
+  const outer = loops[0];
+  if (outer.length < 3) return null;
+
+  const config = SIDE_CONFIG[side];
+  let best: PolygonEdgeRaw | null = null;
+
+  for (let i = 0; i < outer.length; i++) {
+    const a = outer[i];
+    const b = outer[(i + 1) % outer.length];
+    const dx = Math.sign(b.x - a.x);
+    const dy = Math.sign(b.y - a.y);
+    if (dx !== config.dxMatch || dy !== config.dyMatch) continue;
+
+    const spanU = Math.abs(b.x - a.x) + Math.abs(b.y - a.y);
+    const perpU = config.perpAxis === 'y' ? a.y : a.x;
+    const midU = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+    const candidate: PolygonEdgeRaw = { midU, spanU, perpU };
+
+    if (!best) {
+      best = candidate;
+      continue;
+    }
+    // Prefer more extreme perpendicular coord; tie-break on longer span.
+    const extremeDelta = (perpU - best.perpU) * config.extremeSign;
+    if (extremeDelta > 1e-9) {
+      best = candidate;
+    } else if (extremeDelta > -1e-9 && spanU > best.spanU) {
+      best = candidate;
+    }
+  }
+
+  return best;
+}
+
+/**
+ * Resolve the placement geometry for a wall-sided feature on a polygon bin.
+ *
+ * Mirrors the rect-bin entries in wallCutoutBuilder: the returned {x, y}
+ * coordinates are in centered mm (bin origin at 0,0), and `wallSpan` is the
+ * inner-face span (the basis for percentage cutout widths). Both derivations
+ * match the rect-bin case when the mask is fully filled.
+ *
+ * Returns null when no edge faces the requested side — caller silently skips.
+ */
+export function resolvePolygonSideGeometry(
+  mask: CellMask,
+  gridUnitMm: number,
+  wallThickness: number,
+  side: WallSideKey
+): PolygonSideGeometry | null {
+  const edge = findPolygonEdgeForSide(mask, side);
+  if (!edge) return null;
+
+  // halfWidthMm / halfDepthMm match maskPolygon.ts loopToMm — the mask spans
+  // the FULL grid-unit extent (outer body plus CLEARANCE/2 on each side).
+  const halfWidthMm = (mask.cols * MASK_CELL_SIZE * gridUnitMm) / 2;
+  const halfDepthMm = (mask.rows * MASK_CELL_SIZE * gridUnitMm) / 2;
+
+  // Edge midpoint in centered mm space.
+  const outerX = edge.midU.x * gridUnitMm - halfWidthMm;
+  const outerY = edge.midU.y * gridUnitMm - halfDepthMm;
+
+  // Inset inward by (wallThickness + CLEARANCE/2) so cutout lands at the
+  // inner wall face — same as rect-bin case where y = -innerD/2.
+  const inset = wallThickness + CLEARANCE / 2;
+  let x = outerX;
+  let y = outerY;
+  switch (side) {
+    case 'front':
+      y += inset;
+      break;
+    case 'back':
+      y -= inset;
+      break;
+    case 'left':
+      x += inset;
+      break;
+    case 'right':
+      x -= inset;
+      break;
+  }
+
+  // Inner span derivation: the raw polygon edge spans `spanU * gridUnitMm`
+  // mm (mask extent). The bin body is inset by CLEARANCE/2 on each side, and
+  // the wall further by wallThickness. So inner span = raw - CLEARANCE - 2*wall.
+  // Matches rect-bin's innerW = outerW - 2*wall exactly when the mask is a
+  // full rectangle. For non-convex neighbors the inner face is technically
+  // longer; we approximate uniformly here (error bounded by wallThickness,
+  // generator clips against the real bin body at the 3D stage).
+  const wallSpan = edge.spanU * gridUnitMm - CLEARANCE - 2 * wallThickness;
+
+  return {
+    key: side,
+    wallSpan,
+    x,
+    y,
+    rotateZ: SIDE_CONFIG[side].rotateZ,
+  };
+}

--- a/src/features/generation/worker/generators/maskPolygonEdges.ts
+++ b/src/features/generation/worker/generators/maskPolygonEdges.ts
@@ -101,12 +101,21 @@ export function findPolygonEdgeForSide(mask: CellMask, side: WallSideKey): Polyg
       best = candidate;
       continue;
     }
-    // Prefer more extreme perpendicular coord; tie-break on longer span.
+    // Ranking: (1) more extreme perpendicular coord, (2) longer span, (3) lower
+    // midpoint along the edge direction. (3) makes the result deterministic for
+    // symmetric shapes (e.g. U-shape back = left arm, not traversal-dependent).
     const extremeDelta = (perpU - best.perpU) * config.extremeSign;
     if (extremeDelta > 1e-9) {
       best = candidate;
-    } else if (extremeDelta > -1e-9 && spanU > best.spanU) {
-      best = candidate;
+    } else if (extremeDelta > -1e-9) {
+      if (spanU > best.spanU + 1e-9) {
+        best = candidate;
+      } else if (spanU > best.spanU - 1e-9) {
+        // Deterministic tiebreak on midpoint coordinate along the edge axis.
+        const edgeAxisCoord = config.perpAxis === 'y' ? midU.x : midU.y;
+        const bestAxisCoord = config.perpAxis === 'y' ? best.midU.x : best.midU.y;
+        if (edgeAxisCoord < bestAxisCoord) best = candidate;
+      }
     }
   }
 

--- a/src/features/generation/worker/generators/pipeline/featureBuilder.ts
+++ b/src/features/generation/worker/generators/pipeline/featureBuilder.ts
@@ -46,6 +46,12 @@ export interface FeatureBuilder {
   readonly tag: FeatureTag;
   /** Which boolean pass this feature's shapes participate in. */
   readonly target: FeatureTarget;
+  /**
+   * Whether this builder handles non-rectangular (cellMask) footprints.
+   * Defaults to false — unsupported builders are filtered out before running.
+   * Opt in per feature as polygon-awareness is added.
+   */
+  readonly supportsCellMask?: boolean;
   /** Fast check — return false to skip cache lookup and build entirely. */
   shouldBuild(ctx: PipelineContext): boolean;
   /** Deterministic cache key for this feature's current parameters. */

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -28,11 +28,6 @@ export const featuresStage: PipelineStage = {
 
   shouldRun(ctx: PipelineContext): boolean {
     const { innerW, innerD } = ctx.dimensions;
-    // Non-rectangular footprints skip all interior features in v1.
-    // The shape-model refactor does not yet teach compartments, cutouts,
-    // walls, handles, inserts, scoops, or label tabs how to operate on a
-    // non-rectangular bounding region. Follow-up PRs will lift this.
-    if (isPartialMask(ctx.params.cellMask)) return false;
     return innerW > 0 && innerD > 0;
   },
 
@@ -60,11 +55,20 @@ export const featuresStage: PipelineStage = {
       return ctx;
     }
 
-    // Standard mode: run all feature builders via composition root
-    const targets = runFeatureBuilders(BIN_FEATURE_BUILDERS, ctx);
+    // For non-rectangular (cellMask) bins, run only builders that have
+    // opted in. Most interior features still assume a rectangular interior
+    // (compartments, inserts, slots, label tabs, handles, scoops); each gets
+    // polygon support in its own follow-up PR.
+    const isPolygon = isPartialMask(params.cellMask);
+    const builders = isPolygon
+      ? BIN_FEATURE_BUILDERS.filter((b) => b.supportsCellMask === true)
+      : BIN_FEATURE_BUILDERS;
 
-    // Wall patterns: special case with per-wall caching + cutout clipping
-    if (params.wallPattern.enabled) {
+    const targets = runFeatureBuilders(builders, ctx);
+
+    // Wall patterns: special case with per-wall caching + cutout clipping.
+    // Polygon support for wall patterns is tracked separately in issue #1416.
+    if (params.wallPattern.enabled && !isPolygon) {
       const patternShapes = buildWallPatterns(ctx);
       targets.patternCutTargets.push(...patternShapes);
     }

--- a/src/features/generation/worker/generators/scenarios/customShape.ts
+++ b/src/features/generation/worker/generators/scenarios/customShape.ts
@@ -11,7 +11,7 @@
  * verified visually correct, update with:
  *   pnpm run test:run -- -u src/features/generation/worker/generators/binGenerator.scenario.test
  */
-import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
 import type { CellMask } from '@/shared/utils/cellMask';
 import { defineScenario } from '../__dual-kernel__/scenarioTypes';
 import type { ScenarioCase } from '../__dual-kernel__/scenarioTypes';
@@ -182,6 +182,46 @@ export const customShapes: ScenarioCase[] = [
       depth: 3,
       cellMask: O_SHAPE_MASK,
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+  }),
+  defineScenario('custom-shape', '3×3 L with front cutout (polygon-aware side mapping)', {
+    // Exercises polygon-aware wallCutoutBuilder for the front edge, which
+    // spans only 2u of a 3u bin (notch bottom-right truncates the front wall).
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: L_SHAPE_MASK,
+      walls: {
+        enabled: true,
+        shape: 'u-shape',
+        width: 0,
+        depth: 0,
+        front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
+        back: DISABLED_WALL_CUTOUT,
+        left: DISABLED_WALL_CUTOUT,
+        right: DISABLED_WALL_CUTOUT,
+        interior: DISABLED_WALL_CUTOUT,
+      },
+    },
+  }),
+  defineScenario('custom-shape', '3×3 U with front cutout (single candidate edge)', {
+    // U-shape front edge spans the full bottom; polygon resolver picks it
+    // cleanly regardless of the multiple back/side candidates.
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: U_SHAPE_MASK,
+      walls: {
+        enabled: true,
+        shape: 'u-shape',
+        width: 0,
+        depth: 0,
+        front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
+        back: DISABLED_WALL_CUTOUT,
+        left: DISABLED_WALL_CUTOUT,
+        right: DISABLED_WALL_CUTOUT,
+        interior: DISABLED_WALL_CUTOUT,
+      },
     },
   }),
 ];

--- a/src/features/generation/worker/generators/wallCutoutBuilder.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.ts
@@ -280,8 +280,12 @@ function buildWallCutoutCutsInScope(
     );
   }
 
-  // Interior divider walls
-  if (params.walls.interior.enabled) {
+  // Interior divider walls — skip entirely on polygon bins, since
+  // compartmentWallsFeature is filtered out for custom shapes and the
+  // corresponding divider walls won't exist. Cutting where there's no
+  // material would be wasted boolean work (and risks carving the shell
+  // if a cut crosses it).
+  if (params.walls.interior.enabled && !isPartialMask(params.cellMask)) {
     const { effectiveWidth, effectiveDepth } = resolveEffective('interior');
     if (effectiveWidth > 0 && effectiveDepth > 0) {
       const { cols, rows, cells } = params.compartments;

--- a/src/features/generation/worker/generators/wallCutoutBuilder.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.ts
@@ -21,6 +21,8 @@ import type { BinParams, WallCutoutShape } from '@/shared/types/bin';
 import { sketch } from './meshUtils';
 import { LIP_HEIGHT, LIP_TAPER_WIDTH } from './generatorConstants';
 import { findWallSegments } from './compartmentBuilder';
+import { resolvePolygonSideGeometry, type PolygonSideGeometry } from './maskPolygonEdges';
+import { isPartialMask } from '@/shared/utils/cellMask';
 import { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
 
 // Re-export for consumers that were importing from this module
@@ -221,18 +223,20 @@ function buildWallCutoutCutsInScope(
   const extrudeDepth = (maxThickness + lipOverhang) * 2 + 1;
   const overshoot = (hasLip ? LIP_HEIGHT : 0) + 2;
 
-  const sides: Array<{
-    key: 'front' | 'back' | 'left' | 'right';
-    wallSpan: number;
-    x: number;
-    y: number;
-    rotateZ: number;
-  }> = [
-    { key: 'front', wallSpan: innerW, x: 0, y: -innerD / 2, rotateZ: 0 },
-    { key: 'back', wallSpan: innerW, x: 0, y: innerD / 2, rotateZ: 0 },
-    { key: 'left', wallSpan: innerD, x: -innerW / 2, y: 0, rotateZ: 90 },
-    { key: 'right', wallSpan: innerD, x: innerW / 2, y: 0, rotateZ: 90 },
-  ];
+  // For non-rectangular bins, map each side to the outermost polygon edge
+  // facing that direction (silently skipping sides with no matching edge).
+  // Rectangular fallback uses the bin AABB.
+  const cellMask = params.cellMask;
+  const sides: PolygonSideGeometry[] = isPartialMask(cellMask)
+    ? (['front', 'back', 'left', 'right'] as const)
+        .map((key) => resolvePolygonSideGeometry(cellMask, params.gridUnitMm, wallThickness, key))
+        .filter((g): g is PolygonSideGeometry => g !== null)
+    : [
+        { key: 'front', wallSpan: innerW, x: 0, y: -innerD / 2, rotateZ: 0 },
+        { key: 'back', wallSpan: innerW, x: 0, y: innerD / 2, rotateZ: 0 },
+        { key: 'left', wallSpan: innerD, x: -innerW / 2, y: 0, rotateZ: 90 },
+        { key: 'right', wallSpan: innerD, x: innerW / 2, y: 0, rotateZ: 90 },
+      ];
 
   for (const side of sides) {
     const cfg = params.walls[side.key];
@@ -372,9 +376,13 @@ export const wallCutoutsFeature: FeatureBuilder = {
   name: 'wallCutoutCuts',
   tag: FeatureTag.WALL_CUTOUT,
   target: 'cut',
+  supportsCellMask: true,
   shouldBuild: (ctx) => ctx.params.walls.enabled,
   cacheKey: (ctx) => {
     const { dimensions: dim, params } = ctx;
+    // cellMask presence + shape affect the polygon-edge resolution, so
+    // include the mask hash (via context's derived maskKey) to prevent
+    // rect-bin cache bleed into polygon bins with identical wall config.
     return compactKey(
       buildCacheKey(
         'v1',

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Behälterform-Editor. Klicke auf eine Zelle, um sie umzuschalten.",
   "binDesigner.shape.grid.cellLabel.filled": "Zelle {col}, {row}: gefüllt",
   "binDesigner.shape.grid.cellLabel.empty": "Zelle {col}, {row}: leer",
-  "binDesigner.shape.custom.hint": "Benutzerdefinierte Form. Wandmuster, Wandaussparungen, Griffe, Fächer, Trennwände, Etikettenlaschen und Schaufel sind für nicht-rechteckige Behälter nicht verfügbar.",
+  "binDesigner.shape.custom.hint": "Benutzerdefinierte Form. Wandmuster, Griffe, Fächer, Trennwände, Etikettenlaschen und Schaufel sind für nicht-rechteckige Behälter nicht verfügbar.",
   "binDesigner.colors.labelTab": "Beschriftungslasche",
   "binDesigner.colors.lip": "Stapellippe",
   "binDesigner.colors.presets": "Voreinstellungen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1072,7 +1072,7 @@
   "binDesigner.shape.grid.ariaLabel": "Bin shape editor. Click a cell to toggle it.",
   "binDesigner.shape.grid.cellLabel.filled": "Cell {col}, {row}: filled",
   "binDesigner.shape.grid.cellLabel.empty": "Cell {col}, {row}: empty",
-  "binDesigner.shape.custom.hint": "Custom shape. Wall patterns, wall cutouts, handles, compartments, dividers, label tabs, and scoop are unavailable for non-rectangular bins.",
+  "binDesigner.shape.custom.hint": "Custom shape. Wall patterns, handles, compartments, dividers, label tabs, and scoop are unavailable for non-rectangular bins.",
   "binDesigner.splitAxisInfo": "Split along {axis} into {count} pieces",
   "binDesigner.splitAxisWidth": "width",
   "binDesigner.splitAxisDepth": "depth",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1220,7 +1220,7 @@ const en: Record<string, string> = {
   'binDesigner.shape.grid.cellLabel.filled': 'Cell {col}, {row}: filled',
   'binDesigner.shape.grid.cellLabel.empty': 'Cell {col}, {row}: empty',
   'binDesigner.shape.custom.hint':
-    'Custom shape. Wall patterns, wall cutouts, handles, compartments, dividers, label tabs, and scoop are unavailable for non-rectangular bins.',
+    'Custom shape. Wall patterns, handles, compartments, dividers, label tabs, and scoop are unavailable for non-rectangular bins.',
 
   'binDesigner.splitAxisInfo': 'Split along {axis} into {count} pieces',
 

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Editor de forma del contenedor. Haz clic en una celda para alternarla.",
   "binDesigner.shape.grid.cellLabel.filled": "Celda {col}, {row}: rellena",
   "binDesigner.shape.grid.cellLabel.empty": "Celda {col}, {row}: vacía",
-  "binDesigner.shape.custom.hint": "Forma personalizada. Los patrones de pared, los recortes de pared, las asas, los compartimentos, los divisores, las pestañas de etiqueta y la pala no están disponibles para los contenedores no rectangulares.",
+  "binDesigner.shape.custom.hint": "Forma personalizada. Los patrones de pared, las asas, los compartimentos, los divisores, las pestañas de etiqueta y la pala no están disponibles para los contenedores no rectangulares.",
   "binDesigner.colors.labelTab": "Pestaña de etiqueta",
   "binDesigner.colors.lip": "Labio de apilamiento",
   "binDesigner.colors.presets": "Preajustes",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Éditeur de forme du bac. Cliquez sur une cellule pour la basculer.",
   "binDesigner.shape.grid.cellLabel.filled": "Cellule {col}, {row} : remplie",
   "binDesigner.shape.grid.cellLabel.empty": "Cellule {col}, {row} : vide",
-  "binDesigner.shape.custom.hint": "Forme personnalisée. Motifs de paroi, découpes de paroi, poignées, compartiments, séparateurs, onglets d'étiquette et pelle sont indisponibles pour les bacs non rectangulaires.",
+  "binDesigner.shape.custom.hint": "Forme personnalisée. Motifs de paroi, poignées, compartiments, séparateurs, onglets d'étiquette et pelle sont indisponibles pour les bacs non rectangulaires.",
   "binDesigner.colors.labelTab": "Languette d'étiquette",
   "binDesigner.colors.lip": "Lèvre d'empilage",
   "binDesigner.colors.presets": "Préréglages",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Redigerer for beholderform. Klikk på en celle for å veksle den.",
   "binDesigner.shape.grid.cellLabel.filled": "Celle {col}, {row}: fylt",
   "binDesigner.shape.grid.cellLabel.empty": "Celle {col}, {row}: tom",
-  "binDesigner.shape.custom.hint": "Egendefinert form. Veggmønstre, veggutskjæringer, håndtak, rom, skillevegger, etikettfaner og skje er ikke tilgjengelige for ikke-rektangulære beholdere.",
+  "binDesigner.shape.custom.hint": "Egendefinert form. Veggmønstre, håndtak, rom, skillevegger, etikettfaner og skje er ikke tilgjengelige for ikke-rektangulære beholdere.",
   "binDesigner.colors.labelTab": "Etikett-fane",
   "binDesigner.colors.lip": "Stablelippe",
   "binDesigner.colors.presets": "Forhåndsvalg",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Vakvorm-editor. Klik op een cel om deze te wisselen.",
   "binDesigner.shape.grid.cellLabel.filled": "Cel {col}, {row}: gevuld",
   "binDesigner.shape.grid.cellLabel.empty": "Cel {col}, {row}: leeg",
-  "binDesigner.shape.custom.hint": "Aangepaste vorm. Wandpatronen, wanduitsparingen, handgrepen, compartimenten, scheidingen, labeltabs en scheppen zijn niet beschikbaar voor niet-rechthoekige bakken.",
+  "binDesigner.shape.custom.hint": "Aangepaste vorm. Wandpatronen, handgrepen, compartimenten, scheidingen, labeltabs en scheppen zijn niet beschikbaar voor niet-rechthoekige bakken.",
   "binDesigner.colors.labelTab": "Labeltab",
   "binDesigner.colors.lip": "Stapelrand",
   "binDesigner.colors.presets": "Voorinstellingen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Editor de forma do compartimento. Clique em uma célula para alterná-la.",
   "binDesigner.shape.grid.cellLabel.filled": "Célula {col}, {row}: preenchida",
   "binDesigner.shape.grid.cellLabel.empty": "Célula {col}, {row}: vazia",
-  "binDesigner.shape.custom.hint": "Forma personalizada. Padrões de parede, recortes de parede, alças, compartimentos, divisores, abas de etiqueta e concha não estão disponíveis para caixas não retangulares.",
+  "binDesigner.shape.custom.hint": "Forma personalizada. Padrões de parede, alças, compartimentos, divisores, abas de etiqueta e concha não estão disponíveis para caixas não retangulares.",
   "binDesigner.colors.labelTab": "Aba de etiqueta",
   "binDesigner.colors.lip": "Lábio de empilhamento",
   "binDesigner.colors.presets": "Predefinidos",


### PR DESCRIPTION
## Summary

Addresses the **Wall Cutouts** item from #1416: wall cutouts now work on non-rectangular (L/T/U/custom) bin footprints.

- New `maskPolygonEdges.ts` utility: `findPolygonEdgeForSide` picks the outermost polygon edge facing a requested side, tie-breaking by length. `resolvePolygonSideGeometry` wraps that into the same `{ wallSpan, x, y, rotateZ }` shape the rect-bin code path already uses.
- `wallCutoutBuilder` now switches between AABB-sided geometry (rect bins) and polygon-edge geometry (custom shapes) transparently. Sides with no matching polygon edge are silently skipped.
- `FeatureBuilder` gets a new optional `supportsCellMask` flag. Only `wallCutoutsFeature` opts in for now. `featuresStage` filters the builder list instead of blanket-skipping the whole stage on polygon bins — paves the way for Handles / Label Tabs / Scoop follow-up PRs.
- `WallsSection` splits its `FeatureGate` so only Pattern + Handle stay gated on custom shapes; wall cutouts stay interactive.
- `binDesigner.shape.custom.hint` updated across all 7 locales to drop "wall cutouts" from the gated list.

## UX notes

- Alignment (left/center/right) and offset snap within the chosen polygon segment, not the AABB — so "center" really means centered on the segment the cutout lands on. For an L-shape's short-front edge, that's the midpoint of just the filled 2u portion.
- Shape config (U-shape / scoop / funnel) and width/depth sliders behave unchanged.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` no new warnings on touched files
- [x] `pnpm test:run` — 9983 tests pass (+9 new unit tests + 2 new scenario snapshots for L and U with front cutouts)
- [x] Generator scenario triangle counts show the expected delta (plain L: 5124 → L + front cutout: 5204; plain U: 5126 → U + front cutout: 5206)
- [ ] Manual: enable a front/back/left/right cutout on each of L/T/U shapes in the bin designer and inspect the 3D preview
- [ ] Manual: confirm rect bins unchanged (regression guard)