### PR TITLE
feat(bin-designer): polygon-aware handle cutouts on custom bin shapes

### DIFF
--- a/src/features/bin-designer/components/panel/HandleSection/HandleSection.tsx
+++ b/src/features/bin-designer/components/panel/HandleSection/HandleSection.tsx
@@ -201,25 +201,28 @@ export function HandleSection() {
                     </div>
                   </div>
 
-                  {/* Physical dimensions readout */}
-                  <div className="flex items-center gap-1.5 text-xs text-content-tertiary">
-                    <svg
-                      className="h-3.5 w-3.5 flex-shrink-0"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={1.5}
-                        d="M4 12h16M4 12v-2M8 12v-1M12 12v-2M16 12v-1M20 12v-2"
-                      />
-                    </svg>
-                    <span className="tabular-nums">
-                      {handleWidthMm} × {handles.height} mm
-                    </span>
-                  </div>
+                  {/* Physical dimensions readout — hidden on custom shapes
+                      where the actual span is a polygon edge, not the AABB. */}
+                  {handleWidthMm !== null && (
+                    <div className="flex items-center gap-1.5 text-xs text-content-tertiary">
+                      <svg
+                        className="h-3.5 w-3.5 flex-shrink-0"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={1.5}
+                          d="M4 12h16M4 12v-2M8 12v-1M12 12v-2M16 12v-1M20 12v-2"
+                        />
+                      </svg>
+                      <span className="tabular-nums">
+                        {handleWidthMm} × {handles.height} mm
+                      </span>
+                    </div>
+                  )}
 
                   {/* Corner radius — only for rectangle and u-shape */}
                   {showCornerRadius && (

--- a/src/features/bin-designer/components/panel/HandleSection/useHandleSection.test.ts
+++ b/src/features/bin-designer/components/panel/HandleSection/useHandleSection.test.ts
@@ -195,4 +195,27 @@ describe('useHandleSection', () => {
     const { result } = renderHook(() => useHandleSection());
     expect(result.current.meta.summary).toContain('20');
   });
+
+  it('hides Interior toggle on polygon bins even when compartments exist', () => {
+    // Previously-configured compartments stay on the params when switching to
+    // a custom shape; the generator skips interior handles on polygon bins, so
+    // the toggle must hide to prevent a silent no-op.
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, rows: 2, cells: [0, 1, 2, 3] },
+        cellMask: {
+          cols: 6,
+          rows: 6,
+          cells: [
+            1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1,
+          ],
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useHandleSection());
+    expect(result.current.state.hasCompartments).toBe(false);
+  });
 });

--- a/src/features/bin-designer/components/panel/HandleSection/useHandleSection.test.ts
+++ b/src/features/bin-designer/components/panel/HandleSection/useHandleSection.test.ts
@@ -196,6 +196,28 @@ describe('useHandleSection', () => {
     expect(result.current.meta.summary).toContain('20');
   });
 
+  it('returns null handleWidthMm on polygon bins to avoid misleading mm preview', () => {
+    // AABB-based mm preview would misrepresent the actual polygon-edge span
+    // (e.g. 61mm shown vs 40mm generated on a 3×3 L front).
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        cellMask: {
+          cols: 6,
+          rows: 6,
+          cells: [
+            1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1,
+          ],
+        },
+        handles: { ...DEFAULT_BIN_PARAMS.handles, enabled: true, front: { enabled: true } },
+      },
+    });
+
+    const { result } = renderHook(() => useHandleSection());
+    expect(result.current.state.handleWidthMm).toBeNull();
+  });
+
   it('hides Interior toggle on polygon bins even when compartments exist', () => {
     // Previously-configured compartments stay on the params when switching to
     // a custom shape; the generator skips interior handles on polygon bins, so

--- a/src/features/bin-designer/components/panel/HandleSection/useHandleSection.ts
+++ b/src/features/bin-designer/components/panel/HandleSection/useHandleSection.ts
@@ -4,6 +4,7 @@ import { useDesignerStore } from '@/features/bin-designer/store';
 import { GRIDFINITY } from '../../../constants';
 import { useTranslation } from '@/i18n';
 import { getFeatureStatus } from '@/shared/constraints';
+import { isPartialMask } from '@/shared/utils/cellMask';
 import { DEFAULT_HANDLE_SIDE } from '../../../constants/defaults';
 import type { HandleWallSide, HandleCutoutShape, HandleSide } from '@/features/bin-designer/types';
 import type { SectionMeta } from '../types';
@@ -152,7 +153,11 @@ export function useHandleSection() {
 
   const isUShape = handles.shape === 'u-shape';
   const showCornerRadius = handles.shape === 'rectangle' || handles.shape === 'u-shape';
-  const hasCompartments = params.compartments.cols > 1 || params.compartments.rows > 1;
+  const isCustomShape = isPartialMask(params.cellMask);
+  // Interior handles are skipped on polygon bins (no compartment walls exist
+  // for custom shapes), so hide the toggle there to prevent a silent no-op.
+  const hasCompartments =
+    !isCustomShape && (params.compartments.cols > 1 || params.compartments.rows > 1);
 
   return {
     state: {

--- a/src/features/bin-designer/components/panel/HandleSection/useHandleSection.ts
+++ b/src/features/bin-designer/components/panel/HandleSection/useHandleSection.ts
@@ -111,7 +111,13 @@ export function useHandleSection() {
     [applySideUpdate]
   );
 
+  const isCustomShape = isPartialMask(params.cellMask);
+
+  // On polygon bins the actual handle spans a polygon-edge wallSpan (computed
+  // by the generator), not the AABB — so the AABB-derived preview would lie.
+  // Returning null here lets the UI suppress the mm readout for custom shapes.
   const handleWidthMm = useMemo(() => {
+    if (isCustomShape) return null;
     const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
     const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
     const innerW = outerW - 2 * wallThickness;
@@ -125,7 +131,7 @@ export function useHandleSection() {
       span = innerD;
     }
     return Math.round(span * (handles.width / 100) * 10) / 10;
-  }, [width, depth, wallThickness, handles, isBackDisabled]);
+  }, [width, depth, wallThickness, handles, isBackDisabled, isCustomShape]);
 
   const summary = useMemo(() => {
     if (!handles.enabled || activeSides.length === 0) return undefined;
@@ -153,7 +159,6 @@ export function useHandleSection() {
 
   const isUShape = handles.shape === 'u-shape';
   const showCornerRadius = handles.shape === 'rectangle' || handles.shape === 'u-shape';
-  const isCustomShape = isPartialMask(params.cellMask);
   // Interior handles are skipped on polygon bins (no compartment walls exist
   // for custom shapes), so hide the toggle there to prevent a silent no-op.
   const hasCompartments =

--- a/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
@@ -18,9 +18,9 @@ import { FeatureGate } from '../FeatureGate';
 
 export function WallsSection() {
   const { state, handlers, t } = useWallsSection();
-  // Pattern and handles still position from the axis-aligned bounding box, so
-  // they don't align with custom polygons. Wall cutouts are now polygon-aware
-  // (auto-snap to the outermost matching polygon edge) and stay interactive.
+  // Wall pattern still tiles across rectangular walls only. Wall cutouts and
+  // handles are polygon-aware (auto-snap to the outermost matching polygon
+  // edge) and stay interactive on custom shapes.
   const isCustomShape = useDesignerStore((s) => isPartialMask(s.params.cellMask));
   const customShapeReason = t('binDesigner.shape.custom.hint');
 
@@ -52,9 +52,7 @@ export function WallsSection() {
           <WallCutoutsSection />
         </div>
         <div className="pt-3 border-t border-stroke-subtle/50">
-          <FeatureGate disabled={isCustomShape} reason={customShapeReason}>
-            <HandleSection />
-          </FeatureGate>
+          <HandleSection />
         </div>
       </div>
     </div>

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -60,11 +60,15 @@ exports[`custom-shape > 3×3 L flat base no lip 1`] = `260`;
 
 exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`] = `5204`;
 
+exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `5568`;
+
 exports[`custom-shape > 3×3 L with lip 1`] = `5124`;
 
 exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `5464`;
 
 exports[`custom-shape > 3×3 T with lip 1`] = `4156`;
+
+exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`] = `5570`;
 
 exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `5206`;
 

--- a/src/features/generation/worker/generators/handleBuilder.test.ts
+++ b/src/features/generation/worker/generators/handleBuilder.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs } from './__dual-kernel__/wasmInit';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import type { BinParams, HandleConfig } from '@/shared/types/bin';
+import type { CellMask } from '@/shared/utils/cellMask';
 
 function makeParams(handles: Partial<HandleConfig>, label?: { enabled: boolean }): BinParams {
   return {
@@ -142,5 +143,64 @@ describe('buildHandleHoles', () => {
     });
     const result = buildHandleHoles(params, 40, 40, 20, 1.2, false);
     expect(result).not.toBeNull();
+  });
+
+  describe('polygon (cellMask) footprints', () => {
+    // 3×3 L-shape at half-bin resolution: bottom-right 1u removed.
+    const L_MASK: CellMask = {
+      cols: 6,
+      rows: 6,
+      cells: [
+        // bottom row first (grid origin is bottom-left)
+        1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1,
+      ],
+    };
+
+    it('produces front-handle geometry on a 3×3 L footprint', async () => {
+      const { buildHandleHoles } = await import('./handleBuilder');
+      const params: BinParams = {
+        ...makeParams({
+          enabled: true,
+          front: { enabled: true },
+          back: { enabled: false },
+          left: { enabled: false },
+          right: { enabled: false },
+        }),
+        width: 3,
+        depth: 3,
+        cellMask: L_MASK,
+      };
+      // innerW/D reflect the bin AABB (3u × 3u minus walls/clearance).
+      const result = buildHandleHoles(params, 120, 120, 30, 1.2, false);
+      expect(result).not.toBeNull();
+    });
+
+    it('skips interior handles on polygon bins even when interior=true', async () => {
+      const { buildHandleHoles } = await import('./handleBuilder');
+      const params: BinParams = {
+        ...makeParams({
+          enabled: true,
+          interior: true,
+          front: { enabled: false },
+          back: { enabled: false },
+          left: { enabled: false },
+          right: { enabled: false },
+        }),
+        width: 3,
+        depth: 3,
+        cellMask: L_MASK,
+        compartments: {
+          ...DEFAULT_BIN_PARAMS.compartments,
+          cols: 2,
+          rows: 2,
+          cells: [0, 1, 2, 3],
+        },
+      };
+      // With all outer sides off and only `interior` requested, polygon bins
+      // must return null (compartments don't exist for custom shapes).
+      const result = buildHandleHoles(params, 120, 120, 30, 1.2, false);
+      expect(result).toBeNull();
+    });
   });
 });

--- a/src/features/generation/worker/generators/handleBuilder.ts
+++ b/src/features/generation/worker/generators/handleBuilder.ts
@@ -25,6 +25,8 @@ import type { HandleWallDef } from '@/shared/utils/handleCutoutClip';
 import { computeMultiHandleOffsets } from '@/shared/utils/handleLayout';
 import { buildHandleProfile } from './handleProfiles';
 import { LIP_TAPER_WIDTH } from './generatorConstants';
+import { resolvePolygonSideGeometry } from './maskPolygonEdges';
+import { isPartialMask } from '@/shared/utils/cellMask';
 
 /**
  * Build a single hole cut solid from a profile.
@@ -149,7 +151,28 @@ function buildHandleHolesInScope(
   const extrudeDepth = (wallThickness + lipOverhang) * 2 + 1;
   const isUShape = shape === 'u-shape';
 
-  const walls = buildHandleWallDefs(innerW, innerD);
+  // Non-rectangular footprints map each outer side to its outermost matching
+  // polygon edge (silently skipping sides with no edge). Rect bins use the
+  // AABB-derived defs. Interior handles are skipped on polygon bins since
+  // compartment walls are filtered out for custom shapes (see featuresStage).
+  const cellMask = params.cellMask;
+  const isPolygon = isPartialMask(cellMask);
+  const walls: readonly HandleWallDef[] = isPolygon
+    ? (['front', 'back', 'left', 'right'] as const)
+        .map((side) => {
+          const geom = resolvePolygonSideGeometry(cellMask, params.gridUnitMm, wallThickness, side);
+          return geom
+            ? ({
+                side,
+                wallSpan: geom.wallSpan,
+                x: geom.x,
+                y: geom.y,
+                rotateZ: geom.rotateZ,
+              } satisfies HandleWallDef)
+            : null;
+        })
+        .filter((w): w is HandleWallDef => w !== null)
+    : buildHandleWallDefs(innerW, innerD);
   const allHoles: Shape3D[] = [];
 
   for (const wall of walls) {
@@ -217,8 +240,9 @@ function buildHandleHolesInScope(
     }
   }
 
-  // Interior wall handles
-  if (interior && !isUShape) {
+  // Interior wall handles — skipped on polygon bins (compartment walls are
+  // filtered out for custom shapes, so there's nothing to cut through).
+  if (interior && !isUShape && !isPolygon) {
     const { cols, rows, cells } = params.compartments;
     if (cols > 1 || rows > 1) {
       const cellW = innerW / cols;
@@ -312,6 +336,7 @@ export const handlesFeature: FeatureBuilder = {
   name: 'handles',
   tag: FeatureTag.HANDLE,
   target: 'cut',
+  supportsCellMask: true,
   shouldBuild: (ctx) => ctx.params.handles.enabled && !ctx.dimensions.isSlotted,
   cacheKey: (ctx) => {
     const { dimensions: dim, params } = ctx;

--- a/src/features/generation/worker/generators/scenarios/customShape.ts
+++ b/src/features/generation/worker/generators/scenarios/customShape.ts
@@ -11,7 +11,11 @@
  * verified visually correct, update with:
  *   pnpm run test:run -- -u src/features/generation/worker/generators/binGenerator.scenario.test
  */
-import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
+import {
+  DEFAULT_BIN_PARAMS,
+  DEFAULT_HANDLE_SIDE,
+  DISABLED_WALL_CUTOUT,
+} from '@/shared/constants/bin';
 import type { CellMask } from '@/shared/utils/cellMask';
 import { defineScenario } from '../__dual-kernel__/scenarioTypes';
 import type { ScenarioCase } from '../__dual-kernel__/scenarioTypes';
@@ -221,6 +225,35 @@ export const customShapes: ScenarioCase[] = [
         left: DISABLED_WALL_CUTOUT,
         right: DISABLED_WALL_CUTOUT,
         interior: DISABLED_WALL_CUTOUT,
+      },
+    },
+  }),
+  defineScenario('custom-shape', '3×3 L with front handle (polygon-aware side mapping)', {
+    // Exercises polygon-aware handleBuilder: the front edge spans only 2u of
+    // the 3u bin, so the handle must be centered on the L's short front arm.
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: L_SHAPE_MASK,
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        front: { ...DEFAULT_HANDLE_SIDE, enabled: true },
+      },
+    },
+  }),
+  defineScenario('custom-shape', '3×3 U with front + left handles (multi-side polygon)', {
+    // U-shape exposes distinct front/left/right outer edges; validates that
+    // each side resolves to its outermost matching polygon segment.
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: U_SHAPE_MASK,
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        front: { ...DEFAULT_HANDLE_SIDE, enabled: true },
+        left: { ...DEFAULT_HANDLE_SIDE, enabled: true },
       },
     },
   }),

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Behälterform-Editor. Klicke auf eine Zelle, um sie umzuschalten.",
   "binDesigner.shape.grid.cellLabel.filled": "Zelle {col}, {row}: gefüllt",
   "binDesigner.shape.grid.cellLabel.empty": "Zelle {col}, {row}: leer",
-  "binDesigner.shape.custom.hint": "Benutzerdefinierte Form. Wandmuster, Griffe, Fächer, Trennwände, Etikettenlaschen und Schaufel sind für nicht-rechteckige Behälter nicht verfügbar.",
+  "binDesigner.shape.custom.hint": "Benutzerdefinierte Form. Wandmuster, Fächer, Trennwände, Etikettenlaschen und Schaufel sind für nicht-rechteckige Behälter nicht verfügbar.",
   "binDesigner.colors.labelTab": "Beschriftungslasche",
   "binDesigner.colors.lip": "Stapellippe",
   "binDesigner.colors.presets": "Voreinstellungen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1072,7 +1072,7 @@
   "binDesigner.shape.grid.ariaLabel": "Bin shape editor. Click a cell to toggle it.",
   "binDesigner.shape.grid.cellLabel.filled": "Cell {col}, {row}: filled",
   "binDesigner.shape.grid.cellLabel.empty": "Cell {col}, {row}: empty",
-  "binDesigner.shape.custom.hint": "Custom shape. Wall patterns, handles, compartments, dividers, label tabs, and scoop are unavailable for non-rectangular bins.",
+  "binDesigner.shape.custom.hint": "Custom shape. Wall patterns, compartments, dividers, label tabs, and scoop are unavailable for non-rectangular bins.",
   "binDesigner.splitAxisInfo": "Split along {axis} into {count} pieces",
   "binDesigner.splitAxisWidth": "width",
   "binDesigner.splitAxisDepth": "depth",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1220,7 +1220,7 @@ const en: Record<string, string> = {
   'binDesigner.shape.grid.cellLabel.filled': 'Cell {col}, {row}: filled',
   'binDesigner.shape.grid.cellLabel.empty': 'Cell {col}, {row}: empty',
   'binDesigner.shape.custom.hint':
-    'Custom shape. Wall patterns, handles, compartments, dividers, label tabs, and scoop are unavailable for non-rectangular bins.',
+    'Custom shape. Wall patterns, compartments, dividers, label tabs, and scoop are unavailable for non-rectangular bins.',
 
   'binDesigner.splitAxisInfo': 'Split along {axis} into {count} pieces',
 

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Editor de forma del contenedor. Haz clic en una celda para alternarla.",
   "binDesigner.shape.grid.cellLabel.filled": "Celda {col}, {row}: rellena",
   "binDesigner.shape.grid.cellLabel.empty": "Celda {col}, {row}: vacía",
-  "binDesigner.shape.custom.hint": "Forma personalizada. Los patrones de pared, las asas, los compartimentos, los divisores, las pestañas de etiqueta y la pala no están disponibles para los contenedores no rectangulares.",
+  "binDesigner.shape.custom.hint": "Forma personalizada. Los patrones de pared, los compartimentos, los divisores, las pestañas de etiqueta y la pala no están disponibles para los contenedores no rectangulares.",
   "binDesigner.colors.labelTab": "Pestaña de etiqueta",
   "binDesigner.colors.lip": "Labio de apilamiento",
   "binDesigner.colors.presets": "Preajustes",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Éditeur de forme du bac. Cliquez sur une cellule pour la basculer.",
   "binDesigner.shape.grid.cellLabel.filled": "Cellule {col}, {row} : remplie",
   "binDesigner.shape.grid.cellLabel.empty": "Cellule {col}, {row} : vide",
-  "binDesigner.shape.custom.hint": "Forme personnalisée. Motifs de paroi, poignées, compartiments, séparateurs, onglets d'étiquette et pelle sont indisponibles pour les bacs non rectangulaires.",
+  "binDesigner.shape.custom.hint": "Forme personnalisée. Motifs de paroi, compartiments, séparateurs, onglets d'étiquette et pelle sont indisponibles pour les bacs non rectangulaires.",
   "binDesigner.colors.labelTab": "Languette d'étiquette",
   "binDesigner.colors.lip": "Lèvre d'empilage",
   "binDesigner.colors.presets": "Préréglages",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Redigerer for beholderform. Klikk på en celle for å veksle den.",
   "binDesigner.shape.grid.cellLabel.filled": "Celle {col}, {row}: fylt",
   "binDesigner.shape.grid.cellLabel.empty": "Celle {col}, {row}: tom",
-  "binDesigner.shape.custom.hint": "Egendefinert form. Veggmønstre, håndtak, rom, skillevegger, etikettfaner og skje er ikke tilgjengelige for ikke-rektangulære beholdere.",
+  "binDesigner.shape.custom.hint": "Egendefinert form. Veggmønstre, rom, skillevegger, etikettfaner og skje er ikke tilgjengelige for ikke-rektangulære beholdere.",
   "binDesigner.colors.labelTab": "Etikett-fane",
   "binDesigner.colors.lip": "Stablelippe",
   "binDesigner.colors.presets": "Forhåndsvalg",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Vakvorm-editor. Klik op een cel om deze te wisselen.",
   "binDesigner.shape.grid.cellLabel.filled": "Cel {col}, {row}: gevuld",
   "binDesigner.shape.grid.cellLabel.empty": "Cel {col}, {row}: leeg",
-  "binDesigner.shape.custom.hint": "Aangepaste vorm. Wandpatronen, handgrepen, compartimenten, scheidingen, labeltabs en scheppen zijn niet beschikbaar voor niet-rechthoekige bakken.",
+  "binDesigner.shape.custom.hint": "Aangepaste vorm. Wandpatronen, compartimenten, scheidingen, labeltabs en scheppen zijn niet beschikbaar voor niet-rechthoekige bakken.",
   "binDesigner.colors.labelTab": "Labeltab",
   "binDesigner.colors.lip": "Stapelrand",
   "binDesigner.colors.presets": "Voorinstellingen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Editor de forma do compartimento. Clique em uma célula para alterná-la.",
   "binDesigner.shape.grid.cellLabel.filled": "Célula {col}, {row}: preenchida",
   "binDesigner.shape.grid.cellLabel.empty": "Célula {col}, {row}: vazia",
-  "binDesigner.shape.custom.hint": "Forma personalizada. Padrões de parede, alças, compartimentos, divisores, abas de etiqueta e concha não estão disponíveis para caixas não retangulares.",
+  "binDesigner.shape.custom.hint": "Forma personalizada. Padrões de parede, compartimentos, divisores, abas de etiqueta e concha não estão disponíveis para caixas não retangulares.",
   "binDesigner.colors.labelTab": "Aba de etiqueta",
   "binDesigner.colors.lip": "Lábio de empilhamento",
   "binDesigner.colors.presets": "Predefinidos",


### PR DESCRIPTION
## Summary

Addresses the **Handles** item from #1416: handle holes now work on non-rectangular (L/T/U/custom) bin footprints.

- `handleBuilder` switches between AABB-based wall defs (rect bins) and `resolvePolygonSideGeometry` (polygon bins) — same primitive introduced for wall cutouts in #1420. Sides with no matching polygon edge are silently skipped.
- `handlesFeature.supportsCellMask = true` so `featuresStage` actually runs it on custom shapes.
- Interior wall handles (`params.handles.interior`) are skipped on polygon bins — compartment walls are filtered out for custom shapes, so there's no material to cut through.
- `WallsSection` ungates `HandleSection` on custom shapes; only the Pattern card remains gated.
- `binDesigner.shape.custom.hint` updated across all 7 locales to drop "handles" from the gated list.

## UX notes

- Alignment + offset (where configurable per-side) still snap within the resolved polygon edge, not the AABB — matches wall cutouts behavior. For an L-shape front, that means the handle centers on the 2u short edge, not the missing-notch midpoint.
- Multi-handle counts and chamfer behave unchanged.
- Back-handle suppression when label tabs are enabled still applies.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` no new warnings on touched files
- [x] `pnpm test:run` — 9987 tests pass (+2 new unit tests + 2 new scenario snapshots for L front-handle and U front+left handles)
- [x] `pnpm check:i18n` + `check:i18n:values` pass across all locales
- [ ] Manual: enable front/left/right handles on each of L/T/U shapes in the bin designer and inspect the 3D preview
- [ ] Manual: toggle interior handles on a polygon bin with compartments and confirm no crash and no spurious geometry
- [ ] Manual: confirm rect bins unchanged (regression guard)

## Follow-up (#1416)

Remaining gated features: Label Tabs, Scoop, Wall Pattern. Each stays a separate PR.