### PR TITLE
feat(bin-designer): polygon-aware wall patterns on custom bin shapes

### DIFF
--- a/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
@@ -15,8 +15,10 @@ import { HandleSection } from '../HandleSection';
 
 export function WallsSection() {
   const { state, handlers, t } = useWallsSection();
-  // Wall cutouts, handles, and pattern are all polygon-aware (each auto-snaps
-  // to the outermost matching external edge on custom shapes).
+  // Wall cutouts and handles auto-snap to the outermost matching polygon
+  // edge on custom shapes. Wall patterns tile across *every* axis-aligned
+  // outer edge; outermost-per-cardinal matching is used only for border
+  // clipping around cutouts/handles, not to limit tiling itself.
 
   return (
     <div className="space-y-4">

--- a/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
@@ -7,22 +7,16 @@
  * Also allows selection of wall patterns (honeycomb, etc.) via dropdown.
  */
 
-import { useDesignerStore } from '@/features/bin-designer/store';
-import { isPartialMask } from '@/shared/utils/cellMask';
 import { SnappingSlider } from '../../controls/SnappingSlider';
 import { useWallsSection } from './useWallsSection';
 import { PatternSelector } from './PatternSelector';
 import { WallCutoutsSection } from '../WallCutoutsSection';
 import { HandleSection } from '../HandleSection';
-import { FeatureGate } from '../FeatureGate';
 
 export function WallsSection() {
   const { state, handlers, t } = useWallsSection();
-  // Wall pattern still tiles across rectangular walls only. Wall cutouts and
-  // handles are polygon-aware (auto-snap to the outermost matching polygon
-  // edge) and stay interactive on custom shapes.
-  const isCustomShape = useDesignerStore((s) => isPartialMask(s.params.cellMask));
-  const customShapeReason = t('binDesigner.shape.custom.hint');
+  // Wall cutouts, handles, and pattern are all polygon-aware (each auto-snaps
+  // to the outermost matching external edge on custom shapes).
 
   return (
     <div className="space-y-4">
@@ -36,17 +30,15 @@ export function WallsSection() {
       />
       <div className="space-y-4">
         <div className="pt-3 border-t border-stroke-subtle/50">
-          <FeatureGate disabled={isCustomShape} reason={customShapeReason}>
-            <PatternSelector
-              selectedPattern={state.patternEnabled ? state.pattern : null}
-              onChange={handlers.handlePatternChange}
-              disabled={state.patternDisabled}
-              disabledReason={state.patternDisabledReason}
-            />
-            {state.patternPartialNote && state.patternEnabled && (
-              <p className="text-[11px] text-content-tertiary mt-1">{state.patternPartialNote}</p>
-            )}
-          </FeatureGate>
+          <PatternSelector
+            selectedPattern={state.patternEnabled ? state.pattern : null}
+            onChange={handlers.handlePatternChange}
+            disabled={state.patternDisabled}
+            disabledReason={state.patternDisabledReason}
+          />
+          {state.patternPartialNote && state.patternEnabled && (
+            <p className="text-[11px] text-content-tertiary mt-1">{state.patternPartialNote}</p>
+          )}
         </div>
         <div className="pt-3 border-t border-stroke-subtle/50">
           <WallCutoutsSection />

--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -45,7 +45,7 @@ graph TB
 - `worker/generators/scoopRampBuilder.ts` — scoop ramp geometry
 - `worker/generators/wallCutoutBuilder.ts` — wall U-notch cutouts
 - `worker/generators/handleBuilder.ts` — handle hole through-cuts in bin walls
-- `worker/generators/wallPatternBuilder.ts` — per-wall hex pattern compounds with two-layer caching (uncut base + clipped result) and optional cutout/handle/ramp clipping
+- `worker/generators/wallPatternBuilder.ts` — per-wall hex pattern compounds with two-layer caching (uncut base + clipped result) and optional cutout/handle/ramp clipping. Polygon bins consume per-edge descriptors from `wallPatterns.collectPolygonWallSegments`: one descriptor per axis-aligned outer edge, with an `allowClip` flag that binds cutout/handle clipping only to the outermost edge per cardinal (matching `findPolygonEdgeForSide`). Divider ramp/junction zones are unconditionally empty on polygon bins — dividers are filtered out at `featuresStage`.
 - `bridge/generationTimeout.ts` — complexity-aware per-request timeout (30-90 s based on pattern, cutouts, height)
 - `worker/generators/featureBuilder.ts` — barrel re-export of all builder modules
 - `worker/generators/dividerBuilder.ts` — divider piece generation

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -62,6 +62,10 @@ exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`
 
 exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `5568`;
 
+exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `14000`;
+
+exports[`custom-shape > 3×3 L with honeycomb pattern (polygon edge enumeration) 1`] = `14284`;
+
 exports[`custom-shape > 3×3 L with lip 1`] = `5124`;
 
 exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `5464`;
@@ -71,6 +75,8 @@ exports[`custom-shape > 3×3 T with lip 1`] = `4156`;
 exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`] = `5570`;
 
 exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `5206`;
+
+exports[`custom-shape > 3×3 U with honeycomb pattern (multi-side polygon pattern) 1`] = `17286`;
 
 exports[`custom-shape > 3×3 U with lip 1`] = `5126`;
 

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -67,8 +67,10 @@ export const featuresStage: PipelineStage = {
     const targets = runFeatureBuilders(builders, ctx);
 
     // Wall patterns: special case with per-wall caching + cutout clipping.
-    // Polygon support for wall patterns is tracked separately in issue #1416.
-    if (params.wallPattern.enabled && !isPolygon) {
+    // Polygon bins enumerate outer polygon edges (see wallPatterns.ts) and
+    // only bind clipping to the outermost edge per cardinal — non-outermost
+    // step walls get pure pattern.
+    if (params.wallPattern.enabled) {
       const patternShapes = buildWallPatterns(ctx);
       targets.patternCutTargets.push(...patternShapes);
     }

--- a/src/features/generation/worker/generators/scenarios/customShape.ts
+++ b/src/features/generation/worker/generators/scenarios/customShape.ts
@@ -257,4 +257,46 @@ export const customShapes: ScenarioCase[] = [
       },
     },
   }),
+  defineScenario('custom-shape', '3×3 L with honeycomb pattern (polygon edge enumeration)', {
+    // L-shape produces six outer edges (back/left full, front/right each split
+    // into a long and short segment by the notch). Every edge gets pattern;
+    // only the outermost per cardinal participates in cutout/handle clipping.
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: L_SHAPE_MASK,
+      wallPattern: { enabled: true, pattern: 'honeycomb' as const },
+    },
+  }),
+  defineScenario('custom-shape', '3×3 L with honeycomb + front cutout (outermost-edge clip)', {
+    // Validates that the cutout border clip lands on the L's short front arm
+    // (the outermost front edge) and not on the inner step wall.
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: L_SHAPE_MASK,
+      wallPattern: { enabled: true, pattern: 'honeycomb' as const },
+      walls: {
+        enabled: true,
+        shape: 'u-shape',
+        width: 0,
+        depth: 0,
+        front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
+        back: DISABLED_WALL_CUTOUT,
+        left: DISABLED_WALL_CUTOUT,
+        right: DISABLED_WALL_CUTOUT,
+        interior: DISABLED_WALL_CUTOUT,
+      },
+    },
+  }),
+  defineScenario('custom-shape', '3×3 U with honeycomb pattern (multi-side polygon pattern)', {
+    // U-shape produces more edges (two front extensions + inner step walls);
+    // validates that all axis-aligned outer edges are tiled independently.
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: U_SHAPE_MASK,
+      wallPattern: { enabled: true, pattern: 'honeycomb' as const },
+    },
+  }),
 ];

--- a/src/features/generation/worker/generators/wallPatternBuilder.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.ts
@@ -55,6 +55,8 @@ import {
 } from '@/shared/utils/handleCutoutClip';
 import type { HandleSegment, HandleWallDef } from '@/shared/utils/handleCutoutClip';
 import { computeMultiHandleOffsets } from '@/shared/utils/handleLayout';
+import { isPartialMask } from '@/shared/utils/cellMask';
+import { resolvePolygonSideGeometry } from './maskPolygonEdges';
 
 /**
  * Build a compound of positioned hex prisms for a single wall.
@@ -141,13 +143,6 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
     setPatternTemplateCache(templateKey, shapeTemplate);
   }
 
-  const wallSpanForSide: Record<string, number> = {
-    front: innerW,
-    back: innerW,
-    left: innerD,
-    right: innerD,
-  };
-
   const lipOverhang = hasLip ? LIP_TAPER_WIDTH : 0;
   const maxThickness = Math.max(params.wallThickness, params.compartments.thickness);
   // Clip boxes must be at least as deep as the hex prism extrusion (cutDepth)
@@ -155,15 +150,44 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
   const clipExtrudeDepth = Math.max((maxThickness + lipOverhang) * 2 + 1, cutDepth + 1);
   const clipOvershoot = (hasLip ? LIP_HEIGHT : 0) + 2;
 
-  // Build handle wall defs for clip positioning (uses handleBuilder coordinate convention)
-  const handleWallDefs = params.handles.enabled ? buildHandleWallDefs(innerW, innerD) : [];
+  // Build handle wall defs for clip positioning. Polygon bins use the
+  // outermost edge per cardinal (matches handleBuilder), so clip boxes land
+  // on the actual handle cutout location rather than the AABB wall center.
+  const cellMask = params.cellMask;
+  const isPolygon = isPartialMask(cellMask);
+  const handleWallDefs: readonly HandleWallDef[] = !params.handles.enabled
+    ? []
+    : isPolygon
+      ? (['front', 'back', 'left', 'right'] as const)
+          .map((side) => {
+            const geom = resolvePolygonSideGeometry(
+              cellMask,
+              params.gridUnitMm,
+              params.wallThickness,
+              side
+            );
+            return geom
+              ? ({
+                  side,
+                  wallSpan: geom.wallSpan,
+                  x: geom.x,
+                  y: geom.y,
+                  rotateZ: geom.rotateZ,
+                } satisfies HandleWallDef)
+              : null;
+          })
+          .filter((w): w is HandleWallDef => w !== null)
+      : buildHandleWallDefs(innerW, innerD);
   const handleWallDefForSide = new Map(handleWallDefs.map((d) => [d.side, d]));
 
   for (const wall of wallDescriptors) {
     checkCancelled(signal);
 
-    const cutoutCfg = params.walls.enabled ? params.walls[wall.side] : undefined;
-    const wallSpan = wallSpanForSide[wall.side];
+    // Polygon non-outermost edges: no cutout/handle/ramp lives there, so
+    // emit pure pattern without any clip lookup. Prevents a cardinal-side
+    // cutout/handle config from being projected onto an inner step wall.
+    const cutoutCfg = wall.allowClip && params.walls.enabled ? params.walls[wall.side] : undefined;
+    const wallSpan = wall.wallSpan;
 
     let cutWidth = 0;
     let userCutHeight = 0;
@@ -206,6 +230,7 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
     let handleClip: HandleClipParams | null = null;
     const handleWall = handleWallDefForSide.get(wall.side);
     if (
+      wall.allowClip &&
       params.handles.enabled &&
       !dim.isSlotted &&
       handleWall &&
@@ -290,15 +315,15 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
         )
       : 'nohdl';
 
-    // Ramp zone clipping for divider-cutout blends + divider junction blocking (#1345)
-    const rampZones = computeRampZones(wall.side, params, innerW, innerD, dim.wallHeight);
-    const junctionZones = computeDividerJunctionZones(
-      wall.side,
-      params,
-      innerW,
-      innerD,
-      dim.wallHeight
-    );
+    // Ramp zone clipping for divider-cutout blends + divider junction blocking (#1345).
+    // Polygon bins skip both: dividers are filtered out of the feature pipeline
+    // on custom shapes so there's nothing to blend against or block.
+    const rampZones = isPolygon
+      ? []
+      : computeRampZones(wall.side, params, innerW, innerD, dim.wallHeight);
+    const junctionZones = isPolygon
+      ? []
+      : computeDividerJunctionZones(wall.side, params, innerW, innerD, dim.wallHeight);
     // Deduplicate: junction zones (full height) subsume ramp zones at the same offset
     const junctionOffsets = new Set(junctionZones.map((z) => quantize(z.offsetAlongWall)));
     const uniqueRampZones = rampZones.filter(

--- a/src/features/generation/worker/generators/wallPatterns.test.ts
+++ b/src/features/generation/worker/generators/wallPatterns.test.ts
@@ -7,6 +7,7 @@ import {
 } from './wallPatterns';
 import { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
 import type { BinParams } from '@/shared/types/bin';
+import type { CellMask } from '@/shared/utils/cellMask';
 import { DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
 
 /** Minimal BinParams stub for testing wallPatterns functions. */
@@ -217,5 +218,92 @@ describe('getPatternDescriptors — cutout-aware walls', () => {
     // (clipping happens in featuresStage, not here)
     const sides = result!.descriptors.map((d) => d.side);
     expect(sides).toContain('front');
+  });
+});
+
+describe('getPatternDescriptors — polygon (cellMask) bins', () => {
+  // 3×3 L-shape at half-bin resolution (6×6 mask): bottom-right 1u cell empty.
+  // Outer loop has 6 axis-aligned edges: 1 back, 1 left, 2 front (notch + long
+  // arm), 2 right (long arm + notch).
+  function buildMask(rows: (0 | 1)[][]): CellMask {
+    const bottomFirst = rows.slice().reverse();
+    const cols = bottomFirst[0]?.length ?? 0;
+    return { cols, rows: bottomFirst.length, cells: bottomFirst.flat() };
+  }
+  const L_SHAPE: CellMask = buildMask([
+    [1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 0, 0],
+    [1, 1, 1, 1, 0, 0],
+  ]);
+
+  const innerW = 42 * 3 - 2 * 1.2; // 3u AABB inner
+  const innerD = 42 * 3 - 2 * 1.2;
+  const wallHeight = 5 * 7;
+
+  const POLYGON_PARAMS = (extra: Partial<BinParams> = {}): BinParams =>
+    makeParams({
+      width: 3,
+      depth: 3,
+      height: 5,
+      cellMask: L_SHAPE,
+      wallPattern: { enabled: true, pattern: 'honeycomb' as const },
+      ...extra,
+    });
+
+  it('emits one descriptor per axis-aligned outer edge', () => {
+    const result = getPatternDescriptors(POLYGON_PARAMS(), innerW, innerD, wallHeight);
+    expect(result).not.toBeNull();
+    // L-shape outer loop has 6 edges; each produces a descriptor provided the
+    // wall span is wide enough for at least one pattern element.
+    const { descriptors } = result!;
+    expect(descriptors.length).toBeGreaterThanOrEqual(4);
+    expect(descriptors.length).toBeLessThanOrEqual(6);
+  });
+
+  it('flags exactly one descriptor per cardinal as outermost (allowClip)', () => {
+    const result = getPatternDescriptors(POLYGON_PARAMS(), innerW, innerD, wallHeight);
+    expect(result).not.toBeNull();
+    const { descriptors } = result!;
+    const outermostBySide = new Map<string, number>();
+    for (const d of descriptors) {
+      if (d.allowClip) {
+        outermostBySide.set(d.side, (outermostBySide.get(d.side) ?? 0) + 1);
+      }
+    }
+    // Each cardinal with at least one descriptor has exactly one outermost.
+    for (const count of outermostBySide.values()) {
+      expect(count).toBe(1);
+    }
+  });
+
+  it('each descriptor carries its own wallSpan (not a single-side lookup)', () => {
+    const result = getPatternDescriptors(POLYGON_PARAMS(), innerW, innerD, wallHeight);
+    expect(result).not.toBeNull();
+    const { descriptors } = result!;
+    // L-shape: front cardinal has two edges of different spans (long arm vs notch step).
+    const frontSpans = descriptors
+      .filter((d) => d.side === 'front')
+      .map((d) => d.wallSpan)
+      .sort((a, b) => a - b);
+    if (frontSpans.length === 2) {
+      expect(frontSpans[1]).toBeGreaterThan(frontSpans[0]);
+    }
+    // Every wallSpan must be positive.
+    for (const d of descriptors) expect(d.wallSpan).toBeGreaterThan(0);
+  });
+
+  it('rect bins mark every descriptor as allowClip: true', () => {
+    const rectParams = makeParams({
+      wallPattern: { enabled: true, pattern: 'honeycomb' as const },
+      height: 5,
+    });
+    const result = getPatternDescriptors(rectParams, 42 - 2 * 1.2, 42 - 2 * 1.2, wallHeight);
+    expect(result).not.toBeNull();
+    for (const d of result!.descriptors) {
+      expect(d.allowClip).toBe(true);
+    }
   });
 });

--- a/src/features/generation/worker/generators/wallPatterns.test.ts
+++ b/src/features/generation/worker/generators/wallPatterns.test.ts
@@ -267,15 +267,20 @@ describe('getPatternDescriptors — polygon (cellMask) bins', () => {
     const result = getPatternDescriptors(POLYGON_PARAMS(), innerW, innerD, wallHeight);
     expect(result).not.toBeNull();
     const { descriptors } = result!;
-    const outermostBySide = new Map<string, number>();
+    // Group by side so we catch the case where a cardinal has descriptors
+    // but *zero* allowClip (would mean cutout/handle clipping has no edge
+    // to bind to on that side — a real bug, silent without this assert).
+    const bySide = new Map<string, { total: number; clip: number }>();
     for (const d of descriptors) {
-      if (d.allowClip) {
-        outermostBySide.set(d.side, (outermostBySide.get(d.side) ?? 0) + 1);
-      }
+      const counts = bySide.get(d.side) ?? { total: 0, clip: 0 };
+      counts.total += 1;
+      if (d.allowClip) counts.clip += 1;
+      bySide.set(d.side, counts);
     }
-    // Each cardinal with at least one descriptor has exactly one outermost.
-    for (const count of outermostBySide.values()) {
-      expect(count).toBe(1);
+    expect(bySide.size).toBeGreaterThan(0);
+    for (const { total, clip } of bySide.values()) {
+      expect(total).toBeGreaterThan(0);
+      expect(clip).toBe(1);
     }
   });
 

--- a/src/features/generation/worker/generators/wallPatterns.ts
+++ b/src/features/generation/worker/generators/wallPatterns.ts
@@ -10,6 +10,7 @@ import type { BinParams } from '@/shared/types/bin';
 import type { CellMask } from '@/shared/utils/cellMask';
 import { MASK_CELL_SIZE, isPartialMask, maskToPolygon } from '@/shared/utils/cellMask';
 import { CLEARANCE } from './generatorConstants';
+import { findPolygonEdgeForSide } from './maskPolygonEdges';
 import type { PatternCenter, PatternCalculator } from './patterns';
 import { getPatternCalculator, PATTERN_REGISTRY } from './patterns';
 
@@ -249,20 +250,24 @@ function collectPolygonWallSegments(
     }
   }
 
-  // Outermost per cardinal: most extreme perpendicular coord (front = lowest y,
-  // back = highest y, left = lowest x, right = highest x). Tiebreak on longest
-  // span so the cutout/handle binding lands on the widest wall.
-  const extremeSign = { front: -1, back: 1, left: -1, right: 1 } as const;
-  const outermostKey = new Map<string, RawSegment>();
-  for (const seg of segments) {
-    const cur = outermostKey.get(seg.side);
-    if (!cur) {
-      outermostKey.set(seg.side, seg);
-      continue;
-    }
-    const delta = (seg.perpU - cur.perpU) * extremeSign[seg.side];
-    if (delta > 1e-9 || (delta > -1e-9 && seg.spanU > cur.spanU + 1e-9)) {
-      outermostKey.set(seg.side, seg);
+  // Outermost per cardinal: reuse findPolygonEdgeForSide so the edge flagged
+  // allowClip is the same one wallCutoutBuilder and handleBuilder place their
+  // geometry on. Matching on our own ranking would risk diverging on symmetric
+  // shapes (e.g. the two candidate back edges on a U-shape) where that function
+  // applies a midpoint tiebreak — if the two paths disagreed, clip would land
+  // on the wrong segment.
+  const outermostKey = new Map<'front' | 'back' | 'left' | 'right', RawSegment>();
+  for (const side of ['front', 'back', 'left', 'right'] as const) {
+    const canonical = findPolygonEdgeForSide(mask, side);
+    if (!canonical) continue;
+    for (const seg of segments) {
+      if (seg.side !== side) continue;
+      if (Math.abs(seg.perpU - canonical.perpU) > 1e-9) continue;
+      if (Math.abs(seg.spanU - canonical.spanU) > 1e-9) continue;
+      if (Math.abs(seg.midU.x - canonical.midU.x) > 1e-9) continue;
+      if (Math.abs(seg.midU.y - canonical.midU.y) > 1e-9) continue;
+      outermostKey.set(side, seg);
+      break;
     }
   }
 

--- a/src/features/generation/worker/generators/wallPatterns.ts
+++ b/src/features/generation/worker/generators/wallPatterns.ts
@@ -7,6 +7,9 @@
  */
 
 import type { BinParams } from '@/shared/types/bin';
+import type { CellMask } from '@/shared/utils/cellMask';
+import { MASK_CELL_SIZE, isPartialMask, maskToPolygon } from '@/shared/utils/cellMask';
+import { CLEARANCE } from './generatorConstants';
 import type { PatternCenter, PatternCalculator } from './patterns';
 import { getPatternCalculator, PATTERN_REGISTRY } from './patterns';
 
@@ -23,7 +26,13 @@ export interface SlotFreeWalls {
 
 /** Descriptor for a single wall's pattern element positions + transform. */
 export interface WallPatternDescriptor {
-  /** Which outer wall this descriptor belongs to. */
+  /**
+   * Cardinal wall direction. For rect bins this is the literal side of the
+   * AABB. For polygon bins, multiple external edges may share a cardinal
+   * (e.g. the L-shape step produces two "front" edges); the outermost one
+   * per cardinal is flagged by `allowClip` so cutout/handle clipping only
+   * binds to the edge where the cutout/handle actually lives.
+   */
   readonly side: 'front' | 'back' | 'left' | 'right';
   /** Element center positions on the flat XY grid (before wall rotation). Non-empty — walls with zero centers are filtered out by getWallPatternDescriptors. */
   readonly centers: readonly [PatternCenter, ...PatternCenter[]];
@@ -33,6 +42,15 @@ export interface WallPatternDescriptor {
   readonly translateZ: number;
   /** Optional Z-axis rotation (degrees) for wall orientation */
   readonly zRotation?: number;
+  /** Inner span of this wall in mm — basis for cutout-width percentages. */
+  readonly wallSpan: number;
+  /**
+   * Whether this descriptor should bind to cutout / handle / ramp-zone
+   * clipping. False for polygon non-outermost edges where no cutout/handle
+   * lives, so the pure pattern doesn't try to subtract a clip at the wrong
+   * location.
+   */
+  readonly allowClip: boolean;
 }
 
 /**
@@ -112,7 +130,8 @@ function getWallPatternDescriptors(
     fillW: number,
     translateX: number,
     translateY: number,
-    zRotation?: number
+    zRotation?: number,
+    allowClip = true
   ): void => {
     const centers = calculator.calculateCenters({ fillW, fillH: patternHeight });
     if (centers.length === 0) return;
@@ -124,8 +143,35 @@ function getWallPatternDescriptors(
       translateY,
       translateZ: patternCenterZ,
       zRotation,
+      wallSpan: fillW,
+      allowClip,
     });
   };
+
+  // Polygon footprint: emit one descriptor per axis-aligned outer edge.
+  // Cutouts/handles only land on the outermost edge per cardinal (matching
+  // resolvePolygonSideGeometry in maskPolygonEdges), so only that edge is
+  // flagged allowClip; non-outermost edges get pure pattern.
+  const cellMask = params.cellMask;
+  if (isPartialMask(cellMask)) {
+    const polygonWalls = collectPolygonWallSegments(
+      cellMask,
+      params.gridUnitMm,
+      params.wallThickness
+    );
+    for (const seg of polygonWalls) {
+      if (!slotFree[seg.side]) continue;
+      addWall(
+        seg.side,
+        seg.wallSpan,
+        seg.translateX,
+        seg.translateY,
+        seg.zRotation,
+        seg.isOutermost
+      );
+    }
+    return descriptors.length > 0 ? descriptors : null;
+  }
 
   if (slotFree.front) addWall('front', innerW, 0, -innerD / 2);
   if (slotFree.back) addWall('back', innerW, 0, innerD / 2, 180);
@@ -133,6 +179,125 @@ function getWallPatternDescriptors(
   if (slotFree.right) addWall('right', innerD, innerW / 2, 0, -90);
 
   return descriptors.length > 0 ? descriptors : null;
+}
+
+/**
+ * Polygon outer-edge segment mapped to a cardinal wall for pattern tiling.
+ * `translateX/Y` points at the edge's inner face midpoint in centered mm
+ * (matching the rect-case anchor convention of wall pattern descriptors).
+ */
+interface PolygonWallSegment {
+  readonly side: 'front' | 'back' | 'left' | 'right';
+  readonly wallSpan: number;
+  readonly translateX: number;
+  readonly translateY: number;
+  readonly zRotation?: number;
+  readonly isOutermost: boolean;
+}
+
+/**
+ * Enumerate outer-perimeter edges of a polygon mask and map each to a
+ * cardinal wall. For a CCW outer loop, an edge going +X has its interior
+ * above (so the edge IS a front wall); +Y → right; -X → back; -Y → left.
+ *
+ * Each cardinal may have multiple external edges (L/T/U shapes); the edge
+ * with the most extreme perpendicular coordinate is flagged as outermost,
+ * matching wallCutoutBuilder/handleBuilder's single-edge binding for
+ * cutouts and handles on polygon bins.
+ */
+function collectPolygonWallSegments(
+  mask: CellMask,
+  gridUnitMm: number,
+  wallThickness: number
+): PolygonWallSegment[] {
+  const loops = maskToPolygon(mask);
+  const outer = loops[0];
+  if (outer.length < 3) return [];
+
+  const halfWidthMm = (mask.cols * MASK_CELL_SIZE * gridUnitMm) / 2;
+  const halfDepthMm = (mask.rows * MASK_CELL_SIZE * gridUnitMm) / 2;
+  const inset = wallThickness + CLEARANCE / 2;
+
+  interface RawSegment {
+    readonly side: 'front' | 'back' | 'left' | 'right';
+    readonly spanU: number;
+    readonly midU: { readonly x: number; readonly y: number };
+    readonly perpU: number;
+    readonly zRotation?: number;
+  }
+
+  const segments: RawSegment[] = [];
+  for (let i = 0; i < outer.length; i++) {
+    const a = outer[i];
+    const b = outer[(i + 1) % outer.length];
+    const dx = Math.sign(b.x - a.x);
+    const dy = Math.sign(b.y - a.y);
+    const spanU = Math.abs(b.x - a.x) + Math.abs(b.y - a.y);
+    if (spanU === 0) continue;
+    const midU = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+
+    // CCW outer: interior sits on the LEFT of edge direction. Identify the
+    // wall this edge faces (which outer-normal side looks "out" the wall).
+    if (dx === 1 && dy === 0) {
+      segments.push({ side: 'front', spanU, midU, perpU: a.y });
+    } else if (dx === -1 && dy === 0) {
+      segments.push({ side: 'back', spanU, midU, perpU: a.y, zRotation: 180 });
+    } else if (dx === 0 && dy === -1) {
+      segments.push({ side: 'left', spanU, midU, perpU: a.x, zRotation: 90 });
+    } else if (dx === 0 && dy === 1) {
+      segments.push({ side: 'right', spanU, midU, perpU: a.x, zRotation: -90 });
+    }
+  }
+
+  // Outermost per cardinal: most extreme perpendicular coord (front = lowest y,
+  // back = highest y, left = lowest x, right = highest x). Tiebreak on longest
+  // span so the cutout/handle binding lands on the widest wall.
+  const extremeSign = { front: -1, back: 1, left: -1, right: 1 } as const;
+  const outermostKey = new Map<string, RawSegment>();
+  for (const seg of segments) {
+    const cur = outermostKey.get(seg.side);
+    if (!cur) {
+      outermostKey.set(seg.side, seg);
+      continue;
+    }
+    const delta = (seg.perpU - cur.perpU) * extremeSign[seg.side];
+    if (delta > 1e-9 || (delta > -1e-9 && seg.spanU > cur.spanU + 1e-9)) {
+      outermostKey.set(seg.side, seg);
+    }
+  }
+
+  const result: PolygonWallSegment[] = [];
+  for (const seg of segments) {
+    const outerX = seg.midU.x * gridUnitMm - halfWidthMm;
+    const outerY = seg.midU.y * gridUnitMm - halfDepthMm;
+    let translateX = outerX;
+    let translateY = outerY;
+    switch (seg.side) {
+      case 'front':
+        translateY += inset;
+        break;
+      case 'back':
+        translateY -= inset;
+        break;
+      case 'left':
+        translateX += inset;
+        break;
+      case 'right':
+        translateX -= inset;
+        break;
+    }
+    const wallSpan = seg.spanU * gridUnitMm - CLEARANCE - 2 * wallThickness;
+    if (wallSpan <= 0) continue;
+    result.push({
+      side: seg.side,
+      wallSpan,
+      translateX,
+      translateY,
+      zRotation: seg.zRotation,
+      isOutermost: outermostKey.get(seg.side) === seg,
+    });
+  }
+  return result;
 }
 
 /**

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Behälterform-Editor. Klicke auf eine Zelle, um sie umzuschalten.",
   "binDesigner.shape.grid.cellLabel.filled": "Zelle {col}, {row}: gefüllt",
   "binDesigner.shape.grid.cellLabel.empty": "Zelle {col}, {row}: leer",
-  "binDesigner.shape.custom.hint": "Benutzerdefinierte Form. Wandmuster, Fächer, Trennwände, Etikettenlaschen und Schaufel sind für nicht-rechteckige Behälter nicht verfügbar.",
+  "binDesigner.shape.custom.hint": "Benutzerdefinierte Form. Fächer, Trennwände, Etikettenlaschen und Schaufel sind für nicht-rechteckige Behälter nicht verfügbar.",
   "binDesigner.colors.labelTab": "Beschriftungslasche",
   "binDesigner.colors.lip": "Stapellippe",
   "binDesigner.colors.presets": "Voreinstellungen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1072,7 +1072,7 @@
   "binDesigner.shape.grid.ariaLabel": "Bin shape editor. Click a cell to toggle it.",
   "binDesigner.shape.grid.cellLabel.filled": "Cell {col}, {row}: filled",
   "binDesigner.shape.grid.cellLabel.empty": "Cell {col}, {row}: empty",
-  "binDesigner.shape.custom.hint": "Custom shape. Wall patterns, compartments, dividers, label tabs, and scoop are unavailable for non-rectangular bins.",
+  "binDesigner.shape.custom.hint": "Custom shape. Compartments, dividers, label tabs, and scoop are unavailable for non-rectangular bins.",
   "binDesigner.splitAxisInfo": "Split along {axis} into {count} pieces",
   "binDesigner.splitAxisWidth": "width",
   "binDesigner.splitAxisDepth": "depth",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1220,7 +1220,7 @@ const en: Record<string, string> = {
   'binDesigner.shape.grid.cellLabel.filled': 'Cell {col}, {row}: filled',
   'binDesigner.shape.grid.cellLabel.empty': 'Cell {col}, {row}: empty',
   'binDesigner.shape.custom.hint':
-    'Custom shape. Wall patterns, compartments, dividers, label tabs, and scoop are unavailable for non-rectangular bins.',
+    'Custom shape. Compartments, dividers, label tabs, and scoop are unavailable for non-rectangular bins.',
 
   'binDesigner.splitAxisInfo': 'Split along {axis} into {count} pieces',
 

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Editor de forma del contenedor. Haz clic en una celda para alternarla.",
   "binDesigner.shape.grid.cellLabel.filled": "Celda {col}, {row}: rellena",
   "binDesigner.shape.grid.cellLabel.empty": "Celda {col}, {row}: vacía",
-  "binDesigner.shape.custom.hint": "Forma personalizada. Los patrones de pared, los compartimentos, los divisores, las pestañas de etiqueta y la pala no están disponibles para los contenedores no rectangulares.",
+  "binDesigner.shape.custom.hint": "Forma personalizada. Los compartimentos, los divisores, las pestañas de etiqueta y la pala no están disponibles para los contenedores no rectangulares.",
   "binDesigner.colors.labelTab": "Pestaña de etiqueta",
   "binDesigner.colors.lip": "Labio de apilamiento",
   "binDesigner.colors.presets": "Preajustes",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Éditeur de forme du bac. Cliquez sur une cellule pour la basculer.",
   "binDesigner.shape.grid.cellLabel.filled": "Cellule {col}, {row} : remplie",
   "binDesigner.shape.grid.cellLabel.empty": "Cellule {col}, {row} : vide",
-  "binDesigner.shape.custom.hint": "Forme personnalisée. Motifs de paroi, compartiments, séparateurs, onglets d'étiquette et pelle sont indisponibles pour les bacs non rectangulaires.",
+  "binDesigner.shape.custom.hint": "Forme personnalisée. Compartiments, séparateurs, onglets d'étiquette et pelle sont indisponibles pour les bacs non rectangulaires.",
   "binDesigner.colors.labelTab": "Languette d'étiquette",
   "binDesigner.colors.lip": "Lèvre d'empilage",
   "binDesigner.colors.presets": "Préréglages",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Redigerer for beholderform. Klikk på en celle for å veksle den.",
   "binDesigner.shape.grid.cellLabel.filled": "Celle {col}, {row}: fylt",
   "binDesigner.shape.grid.cellLabel.empty": "Celle {col}, {row}: tom",
-  "binDesigner.shape.custom.hint": "Egendefinert form. Veggmønstre, rom, skillevegger, etikettfaner og skje er ikke tilgjengelige for ikke-rektangulære beholdere.",
+  "binDesigner.shape.custom.hint": "Egendefinert form. Rom, skillevegger, etikettfaner og skje er ikke tilgjengelige for ikke-rektangulære beholdere.",
   "binDesigner.colors.labelTab": "Etikett-fane",
   "binDesigner.colors.lip": "Stablelippe",
   "binDesigner.colors.presets": "Forhåndsvalg",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Vakvorm-editor. Klik op een cel om deze te wisselen.",
   "binDesigner.shape.grid.cellLabel.filled": "Cel {col}, {row}: gevuld",
   "binDesigner.shape.grid.cellLabel.empty": "Cel {col}, {row}: leeg",
-  "binDesigner.shape.custom.hint": "Aangepaste vorm. Wandpatronen, compartimenten, scheidingen, labeltabs en scheppen zijn niet beschikbaar voor niet-rechthoekige bakken.",
+  "binDesigner.shape.custom.hint": "Aangepaste vorm. Compartimenten, scheidingen, labeltabs en scheppen zijn niet beschikbaar voor niet-rechthoekige bakken.",
   "binDesigner.colors.labelTab": "Labeltab",
   "binDesigner.colors.lip": "Stapelrand",
   "binDesigner.colors.presets": "Voorinstellingen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -90,7 +90,7 @@
   "binDesigner.shape.grid.ariaLabel": "Editor de forma do compartimento. Clique em uma célula para alterná-la.",
   "binDesigner.shape.grid.cellLabel.filled": "Célula {col}, {row}: preenchida",
   "binDesigner.shape.grid.cellLabel.empty": "Célula {col}, {row}: vazia",
-  "binDesigner.shape.custom.hint": "Forma personalizada. Padrões de parede, compartimentos, divisores, abas de etiqueta e concha não estão disponíveis para caixas não retangulares.",
+  "binDesigner.shape.custom.hint": "Forma personalizada. Compartimentos, divisores, abas de etiqueta e concha não estão disponíveis para caixas não retangulares.",
   "binDesigner.colors.labelTab": "Aba de etiqueta",
   "binDesigner.colors.lip": "Lábio de empilhamento",
   "binDesigner.colors.presets": "Predefinidos",


### PR DESCRIPTION
## Summary

Closes the last "harder" item from #1416. Wall patterns (honeycomb, etc.) now tile across every axis-aligned outer edge of a polygon footprint, matching the polygon-aware treatment shipped for wall cutouts (#1420) and handles (#1422). With this, the cellMask-awareness tracker is effectively complete — the remaining items (Grid Dividers, Label Tabs, Scoop) all share the compartment-grid coupling and are deferred.

## What changed

- **`wallPatterns.ts`** — `WallPatternDescriptor` gains `wallSpan` and `allowClip`. `getWallPatternDescriptors` branches on `isPartialMask(cellMask)`; the polygon branch walks the CCW outer loop via `maskToPolygon`, emits one descriptor per external segment, and flags the outermost edge per cardinal as `allowClip` so cutout/handle clipping binds only to the edge where those features actually land.
- **`wallPatternBuilder.ts`** — reads span from each descriptor (drops the `wallSpanForSide` map); builds polygon-aware `handleWallDefs` via `resolvePolygonSideGeometry` so clip boxes land on the actual handle position; gates cutout/handle clipping on `wall.allowClip` and skips ramp/junction zones on polygon bins (dividers are already filtered out at featuresStage for custom shapes).
- **`featuresStage.ts`** — drops the `!isPolygon` exclusion on `buildWallPatterns`.
- **`WallsSection.tsx`** — removes the `FeatureGate` around `PatternSelector`.
- **i18n** — updates `binDesigner.shape.custom.hint` across all 7 locales to drop "wall patterns" from the gated list.

## Test plan

- [x] New scenarios: L with honeycomb, L with honeycomb + front cutout (outermost-edge clip), U with honeycomb. Triangle counts: 14284 / 14000 / 17286 (vs. 5124 baseline L — hex adds thousands of tris as expected).
- [x] Unit tests: polygon path emits ≥4 descriptors on L-shape, exactly one outermost per cardinal, per-descriptor `wallSpan`, rect path unchanged.
- [x] Full suite: **10008/10008 pass** (+7 new tests).
- [x] `typecheck`, `lint`, `check:i18n`, `check:i18n:values`, `check:i18n:interpolation`, module boundaries, exhaustiveness — all clean.
- [ ] Manual browser check on an L-shape with honeycomb pattern + front cutout to confirm the border clip lands on the short front arm.

## Notes

- Non-outermost polygon edges get pure pattern (no clip). This is correct: cutouts/handles on polygon bins only land on the outermost edge per cardinal (via `resolvePolygonSideGeometry` in maskPolygonEdges), so inner step walls have nothing to clip against.
- Polygon bins skip ramp/junction zones unconditionally — dividers aren't built on custom shapes (see `featuresStage.ts:62-65`), so there's no divider-cutout blend to produce.