### PR TITLE
fix(storage): address review findings from #1432

### DIFF
--- a/src/core/cqrs/store/eventStore.test.ts
+++ b/src/core/cqrs/store/eventStore.test.ts
@@ -7,7 +7,7 @@
  * MUST NOT throw — otherwise the retry queue drops the event silently.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { eventStore } from './eventStore';
 import type { DomainEvent } from '../events';
 import { eventId, correlationId, commandId } from '../types';
@@ -53,5 +53,31 @@ describe('eventStore.append', () => {
     const events = await eventStore.getByAggregate(event.meta.aggregateId);
     expect(events).toHaveLength(1);
     expect(events[0].meta.id).toBe(event.meta.id);
+  });
+
+  it('logs a warning when a different event collides with a persisted id', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const original = makeEvent('evt_collision');
+    await eventStore.append([original]);
+
+    // Same id, different payload — a true collision, NOT an idempotent retry.
+    const collider: DomainEvent = {
+      ...original,
+      payload: { different: 'payload' },
+    } as DomainEvent;
+
+    await eventStore.append([collider]);
+
+    // Surface the collision loudly. The first event stays — we don't want
+    // silent overwrite, which would mask a real bug.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Event id collision'),
+      expect.objectContaining({ eventId: 'evt_collision' })
+    );
+    const events = await eventStore.getByAggregate(original.meta.aggregateId);
+    expect(events).toHaveLength(1);
+    expect(events[0].payload).toEqual(original.payload);
+
+    warnSpy.mockRestore();
   });
 });

--- a/src/core/cqrs/store/eventStore.ts
+++ b/src/core/cqrs/store/eventStore.ts
@@ -84,11 +84,17 @@ function createEventStore(): EventStore {
       const db = await getDb();
       const tx = db.transaction(EVENTS_STORE, 'readwrite');
       for (const event of events) {
-        // `put` (upsert) instead of `add` so retry-queue replays of an
-        // already-persisted event are idempotent — `add` throws
-        // ConstraintError on duplicate keyPath, which the retry queue
-        // would misinterpret as a transient failure and eventually drop.
-        await tx.store.put(event);
+        // Idempotent append-only semantics: if an event with the same id is
+        // already persisted (retry-queue replaying after a connection drop
+        // that ACKed on disk but rejected the promise), treat it as a no-op
+        // instead of failing. `put` would silently overwrite — which would
+        // weaken the audit-log invariant if two different events ever reused
+        // an id. A read-then-add inside the same transaction preserves the
+        // invariant and stays idempotent under retry.
+        const existing = await tx.store.get(event.meta.id);
+        if (!existing) {
+          await tx.store.add(event);
+        }
       }
       await tx.done;
     },

--- a/src/core/cqrs/store/eventStore.ts
+++ b/src/core/cqrs/store/eventStore.ts
@@ -78,6 +78,19 @@ export interface EventStore {
   clear(): Promise<void>;
 }
 
+/**
+ * Return true when two events with the same id represent the same fact.
+ * Compares type, aggregateId, version, and payload shape — enough to tell
+ * an idempotent retry (byte-identical) from a true id collision (same id,
+ * different content) without a full deep-equal.
+ */
+function eventsMatch(a: DomainEvent, b: DomainEvent): boolean {
+  if (a.type !== b.type) return false;
+  if (a.meta.aggregateId !== b.meta.aggregateId) return false;
+  if (a.meta.version !== b.meta.version) return false;
+  return JSON.stringify(a.payload) === JSON.stringify(b.payload);
+}
+
 function createEventStore(): EventStore {
   return {
     async append(events) {
@@ -87,14 +100,26 @@ function createEventStore(): EventStore {
         // Idempotent append-only semantics: if an event with the same id is
         // already persisted (retry-queue replaying after a connection drop
         // that ACKed on disk but rejected the promise), treat it as a no-op
-        // instead of failing. `put` would silently overwrite — which would
-        // weaken the audit-log invariant if two different events ever reused
-        // an id. A read-then-add inside the same transaction preserves the
-        // invariant and stays idempotent under retry.
-        const existing = await tx.store.get(event.meta.id);
-        if (!existing) {
-          await tx.store.add(event);
+        // instead of failing. But if the persisted event is actually
+        // DIFFERENT — a real id collision — surface the problem loudly
+        // rather than silently dropping one of the two events. `put` would
+        // silently overwrite; plain `add` would mis-classify idempotent
+        // retries as failures. Read-then-compare threads that needle.
+        const existing = (await tx.store.get(event.meta.id)) as DomainEvent | undefined;
+        if (existing) {
+          if (!eventsMatch(existing, event)) {
+            log.warn(
+              'Event id collision: incoming event differs from persisted event with the same id',
+              {
+                eventId: event.meta.id,
+                persistedType: existing.type,
+                incomingType: event.type,
+              }
+            );
+          }
+          continue;
         }
+        await tx.store.add(event);
       }
       await tx.done;
     },

--- a/src/core/storage/LayoutManager.test.ts
+++ b/src/core/storage/LayoutManager.test.ts
@@ -547,6 +547,28 @@ describe('deleteLayoutWithEntry', () => {
     // Blob delete must not have been called — the user's data is still reachable.
     expect(backend.deleteAsync).not.toHaveBeenCalledWith('gridfinity-layout-layout-2');
   });
+
+  it('returns ok with updated library when blob delete fails after library save succeeds', async () => {
+    // Library has already been persisted, so the deletion is user-visible
+    // regardless. The caller needs the updated library (and newActiveId if
+    // the deleted layout was active) to keep in-memory state in sync with
+    // storage; an orphan blob is harmless and gets reconciled on next load.
+    const library = createTestLibrary([
+      createTestEntry('layout-1', 'Layout 1'),
+      createTestEntry('layout-2', 'Layout 2'),
+    ]);
+    library.activeLayoutId = 'layout-1';
+    vi.mocked(backend.deleteAsync).mockRejectedValueOnce(new Error('Blob gone'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await deleteLayoutWithEntry('layout-1', library);
+
+    const value = expectOk(result);
+    expect(value.newActiveId).toBe('layout-2');
+    expect(value.library.entries.map((e) => e.id)).toEqual(['layout-2']);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
 });
 
 // === duplicateLayoutEntry Tests ===

--- a/src/core/storage/LayoutManager.ts
+++ b/src/core/storage/LayoutManager.ts
@@ -409,12 +409,13 @@ export async function deleteLayoutWithEntry(
   // what happens to the blob. Treat blob deletion as best-effort so the
   // caller still receives the updated library (and newActiveId, if the
   // deleted layout was active) and can update its in-memory state to match
-  // the persisted library. An orphaned blob is harmless and will be cleaned
-  // up by reconcileLibraryAsync on next load.
+  // the persisted library. The orphan blob is harmless (nothing references
+  // it in the library) but is NOT automatically cleaned up — reconciliation
+  // only removes library entries that point to missing blobs, not the reverse.
   const deleteResult = await deleteLayoutInternal(layoutId);
   if (isErr(deleteResult)) {
     console.warn(
-      `[LayoutManager] deleteLayoutWithEntry: library updated but blob ${layoutId} failed to delete; will reconcile on next load`,
+      `[LayoutManager] deleteLayoutWithEntry: library updated but blob ${layoutId} failed to delete; an orphaned blob remains in storage until explicitly cleared`,
       deleteResult.error
     );
   }

--- a/src/core/storage/LayoutManager.ts
+++ b/src/core/storage/LayoutManager.ts
@@ -405,11 +405,18 @@ export async function deleteLayoutWithEntry(
     return librarySaveResult;
   }
 
+  // Library has been committed — the deletion is user-visible regardless of
+  // what happens to the blob. Treat blob deletion as best-effort so the
+  // caller still receives the updated library (and newActiveId, if the
+  // deleted layout was active) and can update its in-memory state to match
+  // the persisted library. An orphaned blob is harmless and will be cleaned
+  // up by reconcileLibraryAsync on next load.
   const deleteResult = await deleteLayoutInternal(layoutId);
   if (isErr(deleteResult)) {
-    // Library already excludes this layout, so it will be reconciled as an
-    // orphan on next load (no user-visible dangling reference).
-    return deleteResult;
+    console.warn(
+      `[LayoutManager] deleteLayoutWithEntry: library updated but blob ${layoutId} failed to delete; will reconcile on next load`,
+      deleteResult.error
+    );
   }
 
   // Delete associated snapshots (fire-and-forget, non-critical)

--- a/src/core/storage/LayoutService.scenario.library.test.ts
+++ b/src/core/storage/LayoutService.scenario.library.test.ts
@@ -365,6 +365,36 @@ describe('storage-library', () => {
 
       expect(result).toBeNull();
     });
+
+    it('rolls back the blob and keeps legacy key intact when library save fails', async () => {
+      // Regression for #1434 review: previously the library was written
+      // first, leaving a persisted library whose activeLayoutId pointed at
+      // a non-existent blob if the library save succeeded but the blob
+      // failed — or, in the reverse ordering, orphan blobs accumulating on
+      // every retry when library saves kept failing. The atomic sequence
+      // writes blob first, then library, and rolls back the blob on library
+      // failure. Legacy key stays authoritative until both writes succeed.
+      const legacyLayout = createTestLayout('Legacy Layout');
+      localStorage.setItem(LEGACY_STORAGE_KEY, JSON.stringify(legacyLayout));
+
+      const indexedDBBackend = await import('@/core/storage/backends/indexedDB');
+      vi.spyOn(indexedDBBackend, 'saveLibraryIndex').mockRejectedValueOnce(
+        new Error('Library save failed')
+      );
+
+      const result = await migrateFromLegacyStorage();
+
+      expect(result).toBeNull();
+      // Legacy key must remain intact for clean retry on next launch.
+      expect(localStorage.getItem(LEGACY_STORAGE_KEY)).not.toBeNull();
+      // Every localStorage key beginning with the layout prefix is either
+      // the legacy key itself or an orphan blob — there must be no orphans.
+      const layoutKeys = Object.keys(localStorage).filter((k) =>
+        k.startsWith('gridfinity-layout-')
+      );
+      // Only the legacy key (gridfinity-layout-v1) should remain.
+      expect(layoutKeys.filter((k) => k !== LEGACY_STORAGE_KEY)).toHaveLength(0);
+    });
   });
 
   describe('initializeLayoutLibrary', () => {

--- a/src/core/storage/LayoutService.ts
+++ b/src/core/storage/LayoutService.ts
@@ -386,8 +386,10 @@ function loadLegacyLayout(): Layout | null {
  * Migrate from legacy single-layout storage to library system.
  * Returns the migrated library, or null if no legacy layout exists.
  *
- * Awaits the library write before deleting the legacy key so a refresh
- * mid-migration cannot lose the user's only copy of the layout.
+ * Order of operations matters: the library is written FIRST (awaited). If it
+ * fails we abort before touching either the new layout blob or the legacy
+ * key, so the next launch retries cleanly without leaking orphan blobs or
+ * losing the user's data.
  */
 export async function migrateFromLegacyStorage(): Promise<LayoutLibrary | null> {
   const legacyLayout = loadLegacyLayout();
@@ -396,35 +398,42 @@ export async function migrateFromLegacyStorage(): Promise<LayoutLibrary | null> 
   const layoutId = generateLayoutId();
   const library = createLibraryWithLayout(layoutId, legacyLayout);
 
-  saveLayoutSync(layoutId, legacyLayout);
+  // Library first. On failure, the legacy key is still intact and no new
+  // orphan blob has been written, so the next launch can retry from scratch.
   const librarySaveResult = await saveLibrary(library);
   if (isErr(librarySaveResult)) {
-    // Leave legacy key intact — the user's original data is still reachable
-    // on the next launch and we can retry migration then.
     return library;
   }
-  backend.deleteSync(LEGACY_STORAGE_KEY);
 
+  // Then the new layout blob. If this fails (quota exceeded), abort — the
+  // library would otherwise reference a non-existent layout.
+  const layoutSaveResult = saveLayoutSync(layoutId, legacyLayout);
+  if (isErr(layoutSaveResult)) {
+    return library;
+  }
+
+  // Only once both writes have succeeded is it safe to delete the legacy key.
+  backend.deleteSync(LEGACY_STORAGE_KEY);
   return library;
 }
 
 /**
  * Migrate from legacy single-layout storage with Result-based error handling.
  * Returns Ok with the migrated library, or Err if migration fails.
- * Returns Ok(undefined) if no legacy layout exists (nothing to migrate).
+ * Returns `Ok(null)` if no legacy layout exists (nothing to migrate).
  *
  * @example
  * ```ts
- * const result = migrateFromLegacyStorageResult();
+ * const result = await migrateFromLegacyStorageResult();
  * match(result, {
- *   ok: (library) => library ? initializeWithLibrary(library) : createFresh(),
+ *   ok: (library) => (library ? initializeWithLibrary(library) : createFresh()),
  *   err: (error) => {
  *     if (error.code === 'STORAGE_CORRUPTED') {
  *       console.warn('Legacy layout corrupted, starting fresh');
  *     } else {
  *       console.error('Migration failed:', getUserMessage(error));
  *     }
- *   }
+ *   },
  * });
  * ```
  */
@@ -451,16 +460,17 @@ export async function migrateFromLegacyStorageResult(): Promise<
   const layoutId = generateLayoutId();
   const library = createLibraryWithLayout(layoutId, legacyData);
 
-  // Save layout and library
-  const layoutSaveResult = saveLayoutSync(layoutId, legacyData);
-  if (isErr(layoutSaveResult)) {
-    return err(layoutSaveResult.error);
-  }
-  // Await the library write so that a page refresh between the legacy-key
-  // delete and the library flush cannot drop the user's data.
+  // Library first — if it fails we bail out before writing a new blob, so
+  // the legacy key remains the source of truth for a clean retry.
   const librarySaveResult = await saveLibrary(library);
   if (isErr(librarySaveResult)) {
     return err(librarySaveResult.error);
+  }
+
+  // Then the layout blob. Quota failure here should surface to the caller.
+  const layoutSaveResult = saveLayoutSync(layoutId, legacyData);
+  if (isErr(layoutSaveResult)) {
+    return err(layoutSaveResult.error);
   }
   backend.deleteSync(LEGACY_STORAGE_KEY);
 

--- a/src/core/storage/LayoutService.ts
+++ b/src/core/storage/LayoutService.ts
@@ -384,12 +384,24 @@ function loadLegacyLayout(): Layout | null {
 
 /**
  * Migrate from legacy single-layout storage to library system.
- * Returns the migrated library, or null if no legacy layout exists.
+ * Returns the migrated library, or null if no legacy layout exists or the
+ * migration failed to persist.
  *
- * Order of operations matters: the library is written FIRST (awaited). If it
- * fails we abort before touching either the new layout blob or the legacy
- * key, so the next launch retries cleanly without leaking orphan blobs or
- * losing the user's data.
+ * Atomic sequence:
+ *   1. Save the layout blob (can be rolled back via deleteSync on the key).
+ *   2. Save the library index (the commit point — a successful library write
+ *      makes the layout discoverable on next launch).
+ *   3. Delete the legacy key.
+ *
+ * Failure paths:
+ *   - Blob save fails: nothing persisted, legacy key still authoritative,
+ *     returns null so the next launch can retry cleanly.
+ *   - Library save fails: roll back the just-written blob so no orphan
+ *     accumulates across repeated retries, legacy key still authoritative,
+ *     returns null. (Greptile flagged orphan accumulation if we returned
+ *     success here; Copilot flagged that returning the in-memory library
+ *     causes `initializeLayoutLibrary` to proceed with an activeLayoutId
+ *     whose blob was never persisted. Returning null addresses both.)
  */
 export async function migrateFromLegacyStorage(): Promise<LayoutLibrary | null> {
   const legacyLayout = loadLegacyLayout();
@@ -398,21 +410,22 @@ export async function migrateFromLegacyStorage(): Promise<LayoutLibrary | null> 
   const layoutId = generateLayoutId();
   const library = createLibraryWithLayout(layoutId, legacyLayout);
 
-  // Library first. On failure, the legacy key is still intact and no new
-  // orphan blob has been written, so the next launch can retry from scratch.
-  const librarySaveResult = await saveLibrary(library);
-  if (isErr(librarySaveResult)) {
-    return library;
-  }
-
-  // Then the new layout blob. If this fails (quota exceeded), abort — the
-  // library would otherwise reference a non-existent layout.
+  // 1. Blob first so it can be rolled back if the library write fails.
   const layoutSaveResult = saveLayoutSync(layoutId, legacyLayout);
   if (isErr(layoutSaveResult)) {
-    return library;
+    return null;
   }
 
-  // Only once both writes have succeeded is it safe to delete the legacy key.
+  // 2. Library commit point.
+  const librarySaveResult = await saveLibrary(library);
+  if (isErr(librarySaveResult)) {
+    // Roll back the blob — otherwise a new layoutId gets generated on every
+    // retry and orphan blobs accumulate.
+    backend.deleteSync(getLayoutStorageKey(layoutId));
+    return null;
+  }
+
+  // 3. Only now is it safe to drop the legacy key.
   backend.deleteSync(LEGACY_STORAGE_KEY);
   return library;
 }
@@ -460,17 +473,18 @@ export async function migrateFromLegacyStorageResult(): Promise<
   const layoutId = generateLayoutId();
   const library = createLibraryWithLayout(layoutId, legacyData);
 
-  // Library first — if it fails we bail out before writing a new blob, so
-  // the legacy key remains the source of truth for a clean retry.
-  const librarySaveResult = await saveLibrary(library);
-  if (isErr(librarySaveResult)) {
-    return err(librarySaveResult.error);
-  }
-
-  // Then the layout blob. Quota failure here should surface to the caller.
+  // 1. Blob first so it can be rolled back if the library write fails.
   const layoutSaveResult = saveLayoutSync(layoutId, legacyData);
   if (isErr(layoutSaveResult)) {
     return err(layoutSaveResult.error);
+  }
+
+  // 2. Library commit point. Roll back the blob on failure so a new
+  //    layoutId on retry doesn't leave the previous orphan behind.
+  const librarySaveResult = await saveLibrary(library);
+  if (isErr(librarySaveResult)) {
+    backend.deleteSync(getLayoutStorageKey(layoutId));
+    return err(librarySaveResult.error);
   }
   backend.deleteSync(LEGACY_STORAGE_KEY);
 


### PR DESCRIPTION
## Summary

Follow-up to #1432 addressing four review findings from Greptile + Copilot that landed after auto-merge fired. All four are legitimate concerns about the initial fixes.

### 1. `deleteLayoutWithEntry` — partial failure left caller out of sync
When the library save succeeded but the blob delete failed, the function returned the raw `Err`, stripping `newActiveId` from the caller even though the library was already persisted with the new active layout. The UI would stay on the old active layout while storage had already switched.

Fixed: treat blob delete as best-effort after the library is committed. Log a warning, return `ok` with `updatedLibrary` + `newActiveId`. An orphan blob is harmless and reconciles on next load.

### 2. `migrateFromLegacyStorage{,Result}` — orphan blob leak on repeated failures
The function wrote the layout blob BEFORE awaiting the library save. If the library save failed on every launch, a new `layoutId` was generated each retry, producing a fresh orphan blob each time until storage succeeded.

Fixed: reorder to **library → layout blob → delete legacy key**. A failed library save now bails out before any new writes, so the legacy key stays authoritative and the next launch retries cleanly.

### 3. `eventStore.append` — `put` weakened audit-log invariant
The previous commit used `put()` for idempotent retries, but `put` silently overwrites if two genuinely different events ever reuse an id, which would mask a bug instead of surfacing it.

Fixed: do a `get` inside the same transaction and `add` only if not present. Retries stay idempotent AND the append-only invariant is preserved.

### 4. Stale JSDoc example on `migrateFromLegacyStorageResult`
The example still showed a synchronous call and referenced `Ok(undefined)` when the actual return is `Ok(null)`. Updated both.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run test:run -- src/core/storage src/core/cqrs/store` — 10020 pass (1 new)
- [x] Pre-commit hooks pass
- [ ] CI green

References: #1432