### PR TITLE
fix(cqrs): undo restoration, event replay, and migration fidelity

### DIFF
--- a/src/core/cqrs/handlers/binHandlers.test.ts
+++ b/src/core/cqrs/handlers/binHandlers.test.ts
@@ -146,18 +146,19 @@ describe('Bin Handlers', () => {
       }
     });
 
-    it('returns error when bin not found', () => {
-      mockStore.updateBin.mockReturnValueOnce({
-        ok: false,
-        error: { code: 'LAYOUT_INVALID_OPERATION' },
-      });
+    it('returns error when bin not found without touching the store', () => {
       const cmd = createCommand('bin.update', {
         id: binId('nonexistent'),
         updates: { x: 1 },
       });
 
       const result = handleUpdateBin(cmd);
+
       expect(isErr(result)).toBe(true);
+      // Must not call updateBin when the bin is missing — previously the
+      // handler fell through, mutated on the assumption of success, and
+      // returned ok with an empty events array (silent audit gap).
+      expect(mockStore.updateBin).not.toHaveBeenCalled();
     });
   });
 

--- a/src/core/cqrs/handlers/binHandlers.ts
+++ b/src/core/cqrs/handlers/binHandlers.ts
@@ -7,7 +7,7 @@
  */
 
 import { useLayoutStore } from '@/core/store/layout';
-import { ok, err, isErr } from '@/core/result';
+import { ok, err, isErr, layoutInvalidOperation } from '@/core/result';
 import type { CommandResult } from '../types';
 import type {
   AddBinCommand,
@@ -51,11 +51,12 @@ export function handleUpdateBin(command: UpdateBinCommand): CommandResult<void, 
   const store = useLayoutStore.getState();
   const { id, updates } = command.payload;
 
+  // Fail fast if the bin is gone. Previously the handler fell through to
+  // `store.updateBin` with no `previous` capture and would have emitted no
+  // event even on a hypothetical success — a silent audit gap.
   const existingBin = store.layout.bins.find((b) => b.id === id);
   if (!existingBin) {
-    const storeResult = store.updateBin(id, updates);
-    if (isErr(storeResult)) return err(storeResult.error);
-    return ok({ value: undefined, events: [] });
+    return err(layoutInvalidOperation('updateBin', `Bin ${id} not found`));
   }
 
   const previous = capturePrevious(existingBin, updates);

--- a/src/core/cqrs/handlers/layerHandlers.test.ts
+++ b/src/core/cqrs/handlers/layerHandlers.test.ts
@@ -96,6 +96,18 @@ describe('Layer Handlers', () => {
         }
       }
     });
+
+    it('returns error when layer not found without touching the store', () => {
+      const cmd = createCommand('layer.update', {
+        id: layerId('nonexistent'),
+        updates: { name: 'X' },
+      });
+
+      const result = handleUpdateLayer(cmd);
+
+      expect(isErr(result)).toBe(true);
+      expect(mockStore.updateLayer).not.toHaveBeenCalled();
+    });
   });
 
   describe('handleDeleteLayer', () => {

--- a/src/core/cqrs/handlers/layerHandlers.ts
+++ b/src/core/cqrs/handlers/layerHandlers.ts
@@ -3,7 +3,7 @@
  */
 
 import { useLayoutStore } from '@/core/store/layout';
-import { ok, err, isErr } from '@/core/result';
+import { ok, err, isErr, layoutInvalidOperation } from '@/core/result';
 import { STAGING_ID } from '@/core/constants';
 import type { CommandResult } from '../types';
 import type {
@@ -42,11 +42,10 @@ export function handleUpdateLayer(command: UpdateLayerCommand): CommandResult<vo
   const store = useLayoutStore.getState();
   const { id, updates } = command.payload;
 
+  // Fail fast if the layer is missing (symmetry with handleUpdateBin).
   const existing = store.layout.layers.find((l) => l.id === id);
   if (!existing) {
-    const result = store.updateLayer(id, updates);
-    if (isErr(result)) return err(result.error);
-    return ok({ value: undefined, events: [] });
+    return err(layoutInvalidOperation('updateLayer', `Layer ${id} not found`));
   }
 
   const previous = capturePrevious(existing, updates);

--- a/src/core/cqrs/middleware/undoCapture.ts
+++ b/src/core/cqrs/middleware/undoCapture.ts
@@ -10,7 +10,7 @@
  */
 
 import { useLayoutStore } from '@/core/store/layout';
-import { useHistoryStore } from '@/core/store/history';
+import { useHistoryStore, captureSelectionSnapshot } from '@/core/store/history';
 import { isOk } from '@/core/result';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
 import type { Command } from '../commands';
@@ -51,13 +51,17 @@ export function undoCaptureMiddleware(
   // Clone BEFORE next() — Immer produces a new state object on mutation,
   // so the pre-mutation reference stays immutable, but we need a deep copy
   // for the undo stack (the snapshot must survive future mutations).
+  // Selection is captured at the same moment so undo restores the user's
+  // activeLayerId/activeCategoryId/focus rather than silently resetting to
+  // `layers[0]` via post-hoc pruning.
   const layout = useLayoutStore.getState().layout;
   const snapshot = structuredClone(layout);
+  const selectionSnapshot = captureSelectionSnapshot();
 
   const result = next(command);
 
   if (isOk(result)) {
-    useHistoryStore.getState().push(snapshot, command.type);
+    useHistoryStore.getState().push(snapshot, command.type, selectionSnapshot);
     mlTracking.recordAction?.();
   }
 
@@ -97,6 +101,7 @@ export function batch<T>(fn: () => T): T {
 
   const layout = useLayoutStore.getState().layout;
   const snapshot = structuredClone(layout);
+  const selectionSnapshot = captureSelectionSnapshot();
 
   isBatching = true;
   batchCommandType = null;
@@ -106,7 +111,7 @@ export function batch<T>(fn: () => T): T {
     // Check if layout actually changed (Immer produces new reference on mutation)
     const currentLayout = useLayoutStore.getState().layout;
     if (currentLayout !== layout) {
-      useHistoryStore.getState().push(snapshot, batchCommandType ?? 'unknown');
+      useHistoryStore.getState().push(snapshot, batchCommandType ?? 'unknown', selectionSnapshot);
       mlTracking.recordAction?.();
     }
 
@@ -115,7 +120,7 @@ export function batch<T>(fn: () => T): T {
     // Push undo snapshot even on error so partial mutations can be reverted
     const currentLayout = useLayoutStore.getState().layout;
     if (currentLayout !== layout) {
-      useHistoryStore.getState().push(snapshot, batchCommandType ?? 'unknown');
+      useHistoryStore.getState().push(snapshot, batchCommandType ?? 'unknown', selectionSnapshot);
       mlTracking.recordAction?.();
     }
     throw e;

--- a/src/core/cqrs/projection/replay.test.ts
+++ b/src/core/cqrs/projection/replay.test.ts
@@ -4,6 +4,7 @@ import type { Layout, Bin } from '@/core/types';
 import { binId, layerId, categoryId, layoutId } from '@/core/types';
 import { eventId, correlationId, commandId } from '../types';
 import type { DomainEvent } from '../events';
+import { STAGING_ID } from '@/core/constants';
 
 const baseMeta = {
   id: eventId('evt_1'),
@@ -103,7 +104,7 @@ describe('applyEvent', () => {
     expect(result.layers).toHaveLength(2);
   });
 
-  it('applies layer.deleted — removes layer and its bins', () => {
+  it('applies layer.deleted — removes layer and moves its bins to staging', () => {
     const bin1 = makeBin({ id: binId('bin_1'), layerId: layerId('layer_1') });
     const bin2 = makeBin({ id: binId('bin_2'), layerId: layerId('layer_2') });
     const layout = makeLayout([bin1, bin2]);
@@ -113,7 +114,7 @@ describe('applyEvent', () => {
       type: 'layer.deleted',
       payload: {
         layer: { id: layerId('layer_1'), name: 'Layer 1', height: 1 },
-        deletedBinCount: 0,
+        deletedBinCount: 1,
       },
       meta: baseMeta,
     };
@@ -121,9 +122,14 @@ describe('applyEvent', () => {
     const result = applyEvent(layout, event);
     expect(result.layers).toHaveLength(1);
     expect(result.layers[0].id).toBe('layer_2');
-    // Bins on deleted layer are removed, not displaced to staging
-    expect(result.bins).toHaveLength(1);
-    expect(result.bins[0].id).toBe('bin_2');
+    // Match the live store (layerActions.ts): bins on the deleted layer are
+    // displaced to staging, not deleted. Replay must preserve this or users
+    // debugging via event replay silently lose bins that the real user still has.
+    expect(result.bins).toHaveLength(2);
+    const displaced = result.bins.find((b) => b.id === 'bin_1');
+    expect(displaced?.layerId).toBe(STAGING_ID);
+    const untouched = result.bins.find((b) => b.id === 'bin_2');
+    expect(untouched?.layerId).toBe('layer_2');
   });
 
   it('applies category.deleted — removes category only', () => {

--- a/src/core/cqrs/projection/replay.ts
+++ b/src/core/cqrs/projection/replay.ts
@@ -81,8 +81,12 @@ export function applyEvent(layout: Layout, event: DomainEvent): Layout {
     case 'layer.deleted': {
       const deletedLayerId = event.payload.layer.id;
       next.layers = next.layers.filter((l) => l.id !== deletedLayerId);
-      // Store deletes bins on the layer (not staging displacement)
-      next.bins = next.bins.filter((b) => b.layerId !== deletedLayerId);
+      // Match store behavior (layerActions.ts): bins on the deleted layer are
+      // displaced to staging, not removed. Prior versions of this case filtered
+      // the bins out, which silently lost data during replay-based debugging.
+      next.bins = next.bins.map((b) =>
+        b.layerId === deletedLayerId ? { ...b, layerId: STAGING_ID } : b
+      );
       break;
     }
 

--- a/src/core/cqrs/versioning/migrations.test.ts
+++ b/src/core/cqrs/versioning/migrations.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import type { DomainEvent, DomainEventType } from '../events';
 import type { EventMeta } from '../types';
 import { eventId, commandId, correlationId } from '../types';
@@ -124,7 +124,8 @@ describe('migrateEvent', () => {
     CURRENT_EVENT_VERSIONS['category.added'] = original;
   });
 
-  it('stops at a gap in the migration chain and stamps the version actually reached', () => {
+  it('logs and returns the event unmigrated when the chain has a gap', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const original = CURRENT_EVENT_VERSIONS['drawer.updated'];
     CURRENT_EVENT_VERSIONS['drawer.updated'] = 3;
 
@@ -142,11 +143,21 @@ describe('migrateEvent', () => {
     });
     const result = migrateEvent(event);
 
-    // v1->v2 step is missing — migration stops at v1, v2->v3 never runs
+    // Gap at v1→v2: no migration runs, the event is returned AS-IS so the
+    // stored schemaVersion still reflects reality (v1). Previously the code
+    // stamped a partial version (v1) AND the event later re-entered the same
+    // broken migration on every read, silently looping.
     expect((result.payload as Record<string, unknown>)['addedInV3']).toBeUndefined();
     expect(result.meta.schemaVersion).toBe(1);
+    expect(result).toBe(event); // returned unchanged
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Missing migration'));
 
     CURRENT_EVENT_VERSIONS['drawer.updated'] = original;
+    errorSpy.mockRestore();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 });
 

--- a/src/core/cqrs/versioning/migrations.ts
+++ b/src/core/cqrs/versioning/migrations.ts
@@ -72,11 +72,14 @@ export function migrateEvent(event: DomainEvent): DomainEvent {
       // Gap in the migration chain. Previously this silently stopped at the
       // last successful step AND stamped the partial version, which meant the
       // same event looped through a broken migration on every read. Instead,
-      // log loudly and return the event with its original version untouched
-      // so callers can still detect `schemaVersion !== currentVersion` and
-      // handle or surface the inconsistency.
+      // log loudly and return the ORIGINAL event with its original version
+      // untouched — any earlier v→v+1 steps that succeeded in this call are
+      // also discarded, because persisting a partially-migrated event at a
+      // bogus intermediate version is worse than a fresh retry next time.
+      // Callers can detect `schemaVersion !== currentVersion` to handle the
+      // inconsistency.
       console.error(
-        `[migrations] Missing migration ${eventType} v${String(v)}→v${String(v + 1)}; event returned unmigrated at v${String(eventVersion)}.`
+        `[migrations] Missing migration ${eventType} v${String(v)}→v${String(v + 1)}; event returned unmigrated at v${String(eventVersion)} (any earlier migration steps completed in this call were also discarded).`
       );
       return event;
     }

--- a/src/core/cqrs/versioning/migrations.ts
+++ b/src/core/cqrs/versioning/migrations.ts
@@ -51,9 +51,9 @@ export function registerMigration(
  */
 export function migrateEvent(event: DomainEvent): DomainEvent {
   const eventType = event.type;
-  const currentVersion = (
-    CURRENT_EVENT_VERSIONS as Readonly<Record<string, number | undefined>>
-  )[eventType];
+  const currentVersion = (CURRENT_EVENT_VERSIONS as Readonly<Record<string, number | undefined>>)[
+    eventType
+  ];
 
   // Unknown event type (e.g., removed from the codebase) — return as-is
   if (currentVersion === undefined) return event;
@@ -65,24 +65,28 @@ export function migrateEvent(event: DomainEvent): DomainEvent {
   if (eventVersion >= currentVersion) return event;
 
   let migrated: unknown = event;
-  let reachedVersion = eventVersion;
   for (let v = eventVersion; v < currentVersion; v++) {
     const key = migrationKey(eventType, v, v + 1);
     const fn = migrationRegistry.get(key);
-    if (fn) {
-      migrated = fn(migrated);
-      reachedVersion = v + 1;
-    } else {
-      // Gap in migration chain — stop at the last successfully migrated version
-      break;
+    if (!fn) {
+      // Gap in the migration chain. Previously this silently stopped at the
+      // last successful step AND stamped the partial version, which meant the
+      // same event looped through a broken migration on every read. Instead,
+      // log loudly and return the event with its original version untouched
+      // so callers can still detect `schemaVersion !== currentVersion` and
+      // handle or surface the inconsistency.
+      console.error(
+        `[migrations] Missing migration ${eventType} v${String(v)}→v${String(v + 1)}; event returned unmigrated at v${String(eventVersion)}.`
+      );
+      return event;
     }
+    migrated = fn(migrated);
   }
 
-  // Only stamp schemaVersion if migrations actually ran or we're already current
   const result = migrated as DomainEvent;
   return {
     ...result,
-    meta: { ...result.meta, schemaVersion: reachedVersion },
+    meta: { ...result.meta, schemaVersion: currentVersion },
   };
 }
 

--- a/src/core/store/history.test.ts
+++ b/src/core/store/history.test.ts
@@ -622,4 +622,50 @@ describe('history store', () => {
       expect(useSelectionStore.getState().selectedBinIds).not.toContain(binId);
     });
   });
+
+  describe('selection snapshot restoration', () => {
+    it('undo restores the captured activeLayerId, not layers[0]', () => {
+      const { push, undo } = useHistoryStore.getState();
+      const layout = useLayoutStore.getState().layout;
+      const addLayerResult = useLayoutStore.getState().addLayer();
+      if (!isOk(addLayerResult)) throw new Error('addLayer failed');
+      const topLayerId = addLayerResult.value;
+
+      // User has the top layer active.
+      useSelectionStore.getState().setActiveLayer(topLayerId);
+
+      // Snapshot at this moment: layout has both layers, active = topLayerId.
+      push(JSON.parse(JSON.stringify(useLayoutStore.getState().layout)), 'bin.add', {
+        activeLayerId: topLayerId,
+        activeCategoryId: useSelectionStore.getState().activeCategoryId,
+        selectedBinIds: [],
+        focusedBinId: null,
+        quickLabelBinId: null,
+      });
+
+      // User performs some other action that would reset active layer via pruning
+      // (simulate by directly changing active layer first)
+      useSelectionStore.getState().setActiveLayer(layout.layers[0].id);
+
+      undo();
+
+      // Previously undo fell back to layers[0] because it used pruning on the
+      // current selection. With the snapshot, the user's prior active layer is
+      // restored faithfully.
+      expect(useSelectionStore.getState().activeLayerId).toBe(topLayerId);
+    });
+
+    it('falls back to pruning when a history entry has no selection snapshot', () => {
+      const { push, undo } = useHistoryStore.getState();
+      const layout = useLayoutStore.getState().layout;
+
+      // Legacy-style push (no selection snapshot) — should still work.
+      push(JSON.parse(JSON.stringify(layout)), 'bin.add');
+
+      useLayoutStore.getState().setName('Modified');
+      undo();
+
+      expect(useLayoutStore.getState().layout.name).toBe(layout.name);
+    });
+  });
 });

--- a/src/core/store/history.ts
+++ b/src/core/store/history.ts
@@ -38,6 +38,17 @@ export function captureSelectionSnapshot(): SelectionSnapshot {
  * A snapshotted ID that no longer exists in the restored layout falls back to
  * the same pruning logic used before snapshots were captured.
  */
+/**
+ * Fallback active-layer id when the snapshotted/current id is no longer in
+ * the restored layout. Matches `handleRestoreLayout` in restoreHandlers.ts:
+ * use the last layer in data order (= top layer in the UI, since the UI
+ * reverses via `getDisplayLayers()`). New bins typically land on the top
+ * layer, so this is the least-surprising fallback.
+ */
+function fallbackActiveLayerId(restoredLayout: Layout): LayerId {
+  return restoredLayout.layers[restoredLayout.layers.length - 1].id;
+}
+
 function restoreSelectionFromSnapshot(restoredLayout: Layout, snapshot: SelectionSnapshot): void {
   const binIds = new Set(restoredLayout.bins.map((b) => b.id));
   const layerIds = new Set(restoredLayout.layers.map((l) => l.id));
@@ -46,7 +57,7 @@ function restoreSelectionFromSnapshot(restoredLayout: Layout, snapshot: Selectio
   const activeLayerId =
     layerIds.has(snapshot.activeLayerId) || restoredLayout.layers.length === 0
       ? snapshot.activeLayerId
-      : restoredLayout.layers[0].id;
+      : fallbackActiveLayerId(restoredLayout);
 
   const activeCategoryId =
     categoryIds.has(snapshot.activeCategoryId) || restoredLayout.categories.length === 0
@@ -98,7 +109,7 @@ function pruneStaleSelections(restoredLayout: Layout): void {
   }
 
   if (!layerIds.has(selectionState.activeLayerId) && restoredLayout.layers.length > 0) {
-    updates.activeLayerId = restoredLayout.layers[0].id;
+    updates.activeLayerId = fallbackActiveLayerId(restoredLayout);
   }
 
   if (!categoryIds.has(selectionState.activeCategoryId) && restoredLayout.categories.length > 0) {

--- a/src/core/store/history.ts
+++ b/src/core/store/history.ts
@@ -10,12 +10,65 @@ import { getCommandDescriptionKey } from '@/core/cqrs/commandDescriptions';
 import { getStaticTranslation } from '@/i18n';
 
 /**
- * Remove stale bin references from the selection store after layout restoration.
- * Called after undo/redo to prevent selectedBinIds, focusedBinId, etc. from
- * referencing bins that no longer exist in the restored layout.
- *
- * Uses the selection store's restoreSelection() action instead of raw setState()
- * to maintain store encapsulation.
+ * Subset of the selection store captured alongside the layout snapshot.
+ * Reverting these on undo restores the user's active layer/category/focus
+ * rather than silently resetting them to `layers[0]` via pruning.
+ */
+export interface SelectionSnapshot {
+  readonly activeLayerId: LayerId;
+  readonly activeCategoryId: CategoryId;
+  readonly selectedBinIds: ReadonlyArray<BinId>;
+  readonly focusedBinId: BinId | null;
+  readonly quickLabelBinId: BinId | null;
+}
+
+export function captureSelectionSnapshot(): SelectionSnapshot {
+  const s = useSelectionStore.getState();
+  return {
+    activeLayerId: s.activeLayerId,
+    activeCategoryId: s.activeCategoryId,
+    selectedBinIds: [...s.selectedBinIds],
+    focusedBinId: s.focusedBinId,
+    quickLabelBinId: s.quickLabelBinId,
+  };
+}
+
+/**
+ * Restore selection from a snapshot, reconciling against the restored layout.
+ * A snapshotted ID that no longer exists in the restored layout falls back to
+ * the same pruning logic used before snapshots were captured.
+ */
+function restoreSelectionFromSnapshot(restoredLayout: Layout, snapshot: SelectionSnapshot): void {
+  const binIds = new Set(restoredLayout.bins.map((b) => b.id));
+  const layerIds = new Set(restoredLayout.layers.map((l) => l.id));
+  const categoryIds = new Set(restoredLayout.categories.map((c) => c.id));
+
+  const activeLayerId =
+    layerIds.has(snapshot.activeLayerId) || restoredLayout.layers.length === 0
+      ? snapshot.activeLayerId
+      : restoredLayout.layers[0].id;
+
+  const activeCategoryId =
+    categoryIds.has(snapshot.activeCategoryId) || restoredLayout.categories.length === 0
+      ? snapshot.activeCategoryId
+      : restoredLayout.categories[0].id;
+
+  useSelectionStore.getState().restoreSelection({
+    activeLayerId,
+    activeCategoryId,
+    selectedBinIds: snapshot.selectedBinIds.filter((id) => binIds.has(id)),
+    focusedBinId:
+      snapshot.focusedBinId && binIds.has(snapshot.focusedBinId) ? snapshot.focusedBinId : null,
+    quickLabelBinId:
+      snapshot.quickLabelBinId && binIds.has(snapshot.quickLabelBinId)
+        ? snapshot.quickLabelBinId
+        : null,
+  });
+}
+
+/**
+ * Legacy pruning — used when a history entry has no captured selection
+ * (pre-fix entries, or direct push() calls from outside the middleware).
  */
 function pruneStaleSelections(restoredLayout: Layout): void {
   const binIds = new Set(restoredLayout.bins.map((b) => b.id));
@@ -44,12 +97,10 @@ function pruneStaleSelections(restoredLayout: Layout): void {
     updates.quickLabelBinId = null;
   }
 
-  // Reset active layer if it no longer exists in the restored layout
   if (!layerIds.has(selectionState.activeLayerId) && restoredLayout.layers.length > 0) {
     updates.activeLayerId = restoredLayout.layers[0].id;
   }
 
-  // Reset active category if it no longer exists in the restored layout
   if (!categoryIds.has(selectionState.activeCategoryId) && restoredLayout.categories.length > 0) {
     updates.activeCategoryId = restoredLayout.categories[0].id;
   }
@@ -62,6 +113,8 @@ function pruneStaleSelections(restoredLayout: Layout): void {
 export interface HistoryEntry {
   layout: Layout;
   commandType: CommandType | 'unknown';
+  /** Selection captured at the same moment as `layout`. */
+  selection?: SelectionSnapshot;
 }
 
 interface HistoryState {
@@ -71,10 +124,22 @@ interface HistoryState {
   canUndo: boolean;
   canRedo: boolean;
 
-  push: (layout: Layout, commandType?: CommandType | 'unknown') => void;
+  push: (
+    layout: Layout,
+    commandType?: CommandType | 'unknown',
+    selection?: SelectionSnapshot
+  ) => void;
   undo: () => void;
   redo: () => void;
   clear: () => void;
+}
+
+function applySelection(restoredLayout: Layout, snapshot: SelectionSnapshot | undefined): void {
+  if (snapshot) {
+    restoreSelectionFromSnapshot(restoredLayout, snapshot);
+  } else {
+    pruneStaleSelections(restoredLayout);
+  }
 }
 
 /**
@@ -88,9 +153,9 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
   canUndo: false,
   canRedo: false,
 
-  push: (layout, commandType = 'unknown') => {
+  push: (layout, commandType = 'unknown', selection) => {
     set((state) => {
-      const entry: HistoryEntry = { layout, commandType };
+      const entry: HistoryEntry = { layout, commandType, selection };
       const newPast = [...state.past, entry];
       if (newPast.length > CONSTRAINTS.UNDO_LIMIT) {
         newPast.shift();
@@ -109,18 +174,19 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
     if (past.length === 0) return;
 
     const current = useLayoutStore.getState().layout;
+    const currentSelection = captureSelectionSnapshot();
     const previousEntry = past[past.length - 1];
-    const { layout: previous, commandType } = previousEntry;
+    const { layout: previous, commandType, selection: previousSelection } = previousEntry;
 
     set((state) => ({
       past: state.past.slice(0, -1),
-      future: [{ layout: current, commandType }, ...state.future],
+      future: [{ layout: current, commandType, selection: currentSelection }, ...state.future],
       canUndo: state.past.length > 1,
       canRedo: true,
     }));
 
     useLayoutStore.getState().restoreLayout(previous);
-    pruneStaleSelections(previous);
+    applySelection(previous, previousSelection);
 
     // Show undo toast with action description
     // NOTE: getStaticTranslation uses English only. Full locale support
@@ -143,18 +209,19 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
     if (future.length === 0) return;
 
     const current = useLayoutStore.getState().layout;
+    const currentSelection = captureSelectionSnapshot();
     const nextEntry = future[0];
-    const { layout: next, commandType } = nextEntry;
+    const { layout: next, commandType, selection: nextSelection } = nextEntry;
 
     set((state) => ({
-      past: [...state.past, { layout: current, commandType }],
+      past: [...state.past, { layout: current, commandType, selection: currentSelection }],
       future: state.future.slice(1),
       canUndo: true,
       canRedo: state.future.length > 1,
     }));
 
     useLayoutStore.getState().restoreLayout(next);
-    pruneStaleSelections(next);
+    applySelection(next, nextSelection);
 
     // Show redo toast with action description
     const descKey = getCommandDescriptionKey(commandType);


### PR DESCRIPTION
## Summary

Four divergence bugs between the command, handler, replay, and undo paths that produced silently-wrong state. All four come from the systematic bug hunt (see #1432 for the sibling storage PR). Each fix includes a regression test.

### 1. `layer.deleted` replay deleted bins that the store stages
`src/core/cqrs/projection/replay.ts`

The live store's \`layerActions.ts\` displaces bins on a deleted layer to staging (`layerId = STAGING_ID`). Replay was filtering them out entirely, so any replay-based debugging/reconstruction silently lost bins the real user still had.

Fixed: match the store — map bins on the deleted layer to staging. No event-schema change needed because replay operates over events in order, so those bins are already present in the replayed state.

### 2. Gap in migration chain stamped a partial version and silently looped
\`src/core/cqrs/versioning/migrations.ts\`

When a migration step was missing mid-chain, the loop broke early AND stamped the partial \`reachedVersion\` onto the event. The same event then re-entered the same broken migration on every read, never reaching the current version.

Fixed: log loudly (\`console.error\`) and return the event AS-IS with its original \`schemaVersion\` intact so callers can still detect \`schemaVersion !== currentVersion\` and handle the inconsistency.

### 3. Undo silently reset activeLayerId to \`layers[0]\`
\`src/core/store/history.ts\` + \`src/core/cqrs/middleware/undoCapture.ts\`

Undo snapshots only captured the layout, not selection state. After undo, \`pruneStaleSelections\` fell back to \`layers[0]\` whenever the previously-active layer was missing (or the user had moved off it), silently resetting the UI's active layer on every layer-related undo.

Fixed: capture \`activeLayerId\`, \`activeCategoryId\`, \`selectedBinIds\`, \`focusedBinId\`, \`quickLabelBinId\` alongside the layout snapshot in both \`undoCaptureMiddleware\` and \`batch()\`. On undo/redo, the snapshot is reconciled against the restored layout (still prunes IDs that no longer exist) and applied. Legacy history entries without a snapshot fall back to the old pruning behavior.

### 4. \`handleUpdateBin\` / \`handleUpdateLayer\` could mutate without emitting an event
\`src/core/cqrs/handlers/binHandlers.ts\` + \`layerHandlers.ts\`

When the target bin/layer wasn't found, the handlers fell through to the store anyway, with no \`previous\` capture. If the store somehow succeeded on a missing entity, the result would be \`ok\` with an empty events array — a silent audit gap.

Fixed: fail fast with \`layoutInvalidOperation\` before touching the store.

## Test plan

- [x] \`pnpm run typecheck\`
- [x] \`pnpm run test:run -- src/core/store/history src/core/cqrs/middleware src/core/cqrs/projection src/core/cqrs/versioning src/core/cqrs/handlers\` — 10017 tests pass (3 new)
- [x] Pre-commit hooks (module boundaries, i18n, exhaustiveness, component structure, missing tests) pass
- [ ] CI green
- [ ] Manual: undo a \`layer.delete\` command and confirm \`activeLayerId\` returns to the previously-active layer, not \`layers[0]\`

Sibling PRs: #1432 (storage atomicity), #1434 (review follow-up).