### PR TITLE
ci(release): add concurrency group to dedupe push events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- GitHub occasionally delivers two push events for the same release-please bot merge commit, causing the `Release` workflow to race with itself.
- The first run creates the tag and clears `autorelease: pending`; the second crashes on `Duplicate release tag` / `Label does not exist`, turning the commit red even though the release shipped.
- A workflow-level `concurrency` group with `cancel-in-progress: true` ensures only one Release run executes per branch at a time.

Concrete example: commit `06ac9fffe` (v4.47.4 release merge) — two push events at 12:49:26 and 12:49:27 UTC fired runs `24779173740` (success) and `24779174195` (failure on duplicate tag).

## Test plan

- [ ] CI passes on this PR
- [ ] Next release-please merge to main produces exactly one `Release` workflow run, even if GitHub double-delivers