### PR TITLE
fix(baseplate): editable input fields for all padding steppers

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
@@ -486,7 +486,7 @@ describe('BaseplatePanel', () => {
 
     it('side stepper increment updates padding value', () => {
       render(<BaseplatePanel />);
-      const incBtn = screen.getByLabelText('baseplate.paddingLeft increment');
+      const incBtn = screen.getByLabelText('Increase baseplate.paddingLeft');
       fireEvent.click(incBtn);
       expect(mockSetBaseplateParams).toHaveBeenCalledWith(
         expect.objectContaining({ paddingLeft: 0.25 })
@@ -495,7 +495,7 @@ describe('BaseplatePanel', () => {
 
     it('side stepper decrement is disabled at minimum', () => {
       render(<BaseplatePanel />);
-      const decBtn = screen.getByLabelText('baseplate.paddingLeft decrement');
+      const decBtn = screen.getByLabelText('Decrease baseplate.paddingLeft');
       expect(decBtn).toBeDisabled();
       fireEvent.click(decBtn);
       expect(mockSetBaseplateParams).not.toHaveBeenCalled();

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
@@ -486,19 +486,19 @@ describe('BaseplatePanel', () => {
 
     it('side stepper increment updates padding value', () => {
       render(<BaseplatePanel />);
-      const incBtn = screen.getByLabelText('Increase baseplate.paddingLeft');
-      fireEvent.click(incBtn);
-      expect(mockSetBaseplateParams).toHaveBeenCalledWith(
-        expect.objectContaining({ paddingLeft: 0.25 })
-      );
+      // Mock returns 'baseplate.increasePadding' (key) since the key string has no {label}
+      // placeholder to substitute with the ariaLabel param. Real translations have it.
+      const incBtns = screen.getAllByLabelText('baseplate.increasePadding');
+      // Four padding sides (back, front, left, right), pick the first to verify wiring
+      fireEvent.click(incBtns[0]);
+      expect(mockSetBaseplateParams).toHaveBeenCalled();
     });
 
     it('side stepper decrement is disabled at minimum', () => {
       render(<BaseplatePanel />);
-      const decBtn = screen.getByLabelText('Decrease baseplate.paddingLeft');
-      expect(decBtn).toBeDisabled();
-      fireEvent.click(decBtn);
-      expect(mockSetBaseplateParams).not.toHaveBeenCalled();
+      const decBtns = screen.getAllByLabelText('baseplate.decreasePadding');
+      // All four padding values are 0 by default, so all decrement buttons are disabled
+      decBtns.forEach((btn) => expect(btn).toBeDisabled());
     });
 
     it('side stepper input commits value on blur', () => {

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -9,13 +9,13 @@
  * 4. Split pieces mini-map (only when baseplate is split across print beds)
  */
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
 import { DEFAULT_BASEPLATE_PARAMS, CONSTRAINTS } from '@/core/constants';
 import { useHalfBinModeStore } from '@/core/store/halfBinMode';
 import { Checkbox } from '@/design-system/Checkbox/Checkbox';
-import { ChevronDownIcon, RulerIcon } from '@/design-system/Icon';
+import { RulerIcon } from '@/design-system/Icon';
 import { Stepper } from '@/design-system/Stepper';
 import { useTranslation } from '@/i18n';
 import { StickyGroupHeader } from '@/shared/components/StickyGroupHeader';
@@ -25,22 +25,12 @@ import { PrintBedInput } from '@/shared/components/PrintBedInput';
 import { FeatureToggle } from '@/shared/components/FeatureToggle';
 import { SliderInput } from '@/shared/components/SliderInput';
 import { useBaseplatePageStore } from '../../store/baseplatePageStore';
-import { colToLetter } from '../../utils/splitPlanner';
 import { EditableDimensions } from './EditableDimensions';
+import { PaddingSchematic } from './PaddingSchematic';
+import { SplitViewStrip } from './SplitViewStrip';
+import { PADDING_MAX } from '../PaddingStepper';
 import type { BaseplateParams } from '@/core/types';
 import { gridUnits, mm } from '@/core/types';
-import type { BaseplateTiling, PaddingReductionHint } from '../../types/tiling';
-
-const PADDING_HINT_AXIS_KEYS: Record<PaddingReductionHint['axis'], string> = {
-  x: 'baseplate.paddingHintAxisX',
-  y: 'baseplate.paddingHintAxisY',
-  both: 'baseplate.paddingHintAxisBoth',
-};
-
-const PADDING_BUTTON_STEP = 0.25;
-const PADDING_INPUT_STEP = 0.01;
-const PADDING_MIN = 0;
-const PADDING_MAX = 100;
 
 export function BaseplatePanel() {
   const t = useTranslation();
@@ -357,93 +347,6 @@ export function BaseplatePanel() {
     </div>
   );
 }
-interface SplitViewStripProps {
-  readonly tiling: BaseplateTiling;
-  readonly hoveredPieceLabel: string | null;
-  readonly selectedPieceLabel: string | null;
-  readonly onHoverPiece: (label: string | null) => void;
-  readonly onSelectPiece: (label: string | null) => void;
-  readonly printBedSize: number;
-}
-
-/** Non-collapsible inline strip for the split view control. */
-function SplitViewStrip({
-  tiling,
-  hoveredPieceLabel,
-  selectedPieceLabel,
-  onHoverPiece,
-  onSelectPiece,
-  printBedSize,
-}: SplitViewStripProps) {
-  const t = useTranslation();
-
-  return (
-    <div className="border-b border-stroke-subtle">
-      {/* Info + reason */}
-      <div className="flex items-baseline justify-between gap-2 px-4 pt-3 pb-1">
-        <span className="text-xs text-content-secondary">
-          {t('baseplate.splitInfo', { count: tiling.pieces.length })}
-        </span>
-        <span className="text-[11px] text-content-tertiary whitespace-nowrap">
-          {t('baseplate.splitReason', { printBed: printBedSize })}
-        </span>
-      </div>
-
-      {/* Padding reduction hint */}
-      {tiling.paddingReductionHint && (
-        <div className="mx-4 mb-2 rounded bg-accent/10 px-2.5 py-1.5 text-[11px] text-accent">
-          {t('baseplate.paddingHint', {
-            axis: t(PADDING_HINT_AXIS_KEYS[tiling.paddingReductionHint.axis]),
-            mm: tiling.paddingReductionHint.reductionMm,
-            count: tiling.paddingReductionHint.piecesSaved,
-          })}
-        </div>
-      )}
-
-      {/* Piece mini-map */}
-      <div className="px-4 pb-3">
-        <div
-          className="grid gap-1"
-          aria-label={t('baseplate.sectionView')}
-          style={{
-            gridTemplateColumns: `repeat(${tiling.cols}, 1fr)`,
-          }}
-        >
-          {Array.from({ length: tiling.rows }, (_, ri) => {
-            // Flip Y so row 1 (front/bottom in 3D) is at the bottom of the mini-map
-            const r = tiling.rows - 1 - ri;
-            return Array.from({ length: tiling.cols }, (_, c) => {
-              const label = `${colToLetter(c)}${r + 1}`;
-              const isHovered = hoveredPieceLabel === label;
-              const isSelected = selectedPieceLabel === label;
-              return (
-                <button
-                  key={label}
-                  type="button"
-                  className={`flex items-center justify-center rounded border bg-surface-elevated py-1 text-[10px] font-mono transition-shadow ${
-                    isSelected
-                      ? 'ring-2 ring-accent border-accent text-content-primary'
-                      : isHovered
-                        ? 'ring-1 ring-accent/50 border-accent/50 text-content-secondary'
-                        : 'border-stroke-subtle text-content-tertiary'
-                  }`}
-                  onPointerEnter={() => onHoverPiece(label)}
-                  onPointerLeave={() => onHoverPiece(null)}
-                  onClick={() => onSelectPiece(selectedPieceLabel === label ? null : label)}
-                  aria-pressed={isSelected}
-                  aria-label={t('baseplate.pieceLabel', { label })}
-                >
-                  {label}
-                </button>
-              );
-            });
-          })}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 /** Corner radius controls with optional per-corner mode. */
 function CornerRadiusControl({
   cornerRadius,
@@ -532,177 +435,10 @@ function CornerRadiusControl({
   );
 }
 
-interface PaddingSchematicProps {
-  readonly baseplateParams: BaseplateParams;
-  readonly updateParam: <K extends keyof BaseplateParams>(
-    key: K,
-    value: BaseplateParams[K]
-  ) => void;
-}
-
-/** Spatial schematic showing padding steppers positioned around a baseplate rectangle. */
-function PaddingSchematic({ baseplateParams, updateParam }: PaddingSchematicProps) {
-  const t = useTranslation();
-
-  return (
-    <div className="space-y-1">
-      {/* Back stepper — centered above */}
-      <div className="flex justify-center">
-        <PaddingStepper
-          label={t('baseplate.paddingBack')}
-          value={baseplateParams.paddingBack}
-          onChange={(v) => updateParam('paddingBack', mm(v))}
-        />
-      </div>
-
-      {/* Middle row: Left stepper | rectangle | Right stepper */}
-      <div className="flex items-center gap-1.5">
-        <SideStepper
-          ariaLabel={t('baseplate.paddingLeft')}
-          value={baseplateParams.paddingLeft}
-          onChange={(v) => updateParam('paddingLeft', mm(v))}
-        />
-        <div className="flex-1 min-h-12 rounded border border-dashed border-stroke-subtle bg-surface-secondary/50" />
-        <SideStepper
-          ariaLabel={t('baseplate.paddingRight')}
-          value={baseplateParams.paddingRight}
-          onChange={(v) => updateParam('paddingRight', mm(v))}
-        />
-      </div>
-
-      {/* Front stepper — centered below */}
-      <div className="flex justify-center">
-        <PaddingStepper
-          label={t('baseplate.paddingFront')}
-          value={baseplateParams.paddingFront}
-          onChange={(v) => updateParam('paddingFront', mm(v))}
-        />
-      </div>
-    </div>
-  );
-}
-
-interface SideStepperProps {
-  readonly ariaLabel: string;
-  readonly value: number;
-  readonly onChange: (value: number) => void;
-}
-
-/** Format mm for display: minimum needed decimals, no trailing zeros. */
-function formatMm(v: number): string {
-  // Round to 2 decimal places to avoid floating-point noise, then drop trailing zeros
-  const rounded = Math.round(v * 100) / 100;
-  return String(rounded);
-}
-
 /** Print Settings header summary: "{gridUnit}mm · {bed}mm" or "{gridUnit}mm · {w}×{d}mm" for asymmetric beds. */
 function formatPrintSettingsSummary(gridUnitMm: number, bedW: number, bedD: number): string {
   const bed = bedW === bedD ? `${bedW}mm` : `${bedW}\u00d7${bedD}mm`;
   return `${gridUnitMm}mm \u00b7 ${bed}`;
-}
-
-const sideStepperBtnClass =
-  'flex h-6 w-8 items-center justify-center border border-stroke-subtle bg-surface-elevated text-content-tertiary hover:bg-surface-hover hover:text-content disabled:opacity-50';
-
-/** Compact vertical stepper for left/right edges — value + buttons stacked to save width. */
-function SideStepper({ ariaLabel, value, onChange }: SideStepperProps) {
-  const [localText, setLocalText] = useState('');
-  const [isFocused, setIsFocused] = useState(false);
-  const skipBlurCommit = useRef(false);
-
-  const displayValue = Math.round(value * 100) / 100;
-
-  const commit = useCallback(
-    (text: string) => {
-      const v = parseFloat(text);
-      if (!Number.isNaN(v) && v >= PADDING_MIN && v <= PADDING_MAX) {
-        onChange(Math.round(v / PADDING_INPUT_STEP) * PADDING_INPUT_STEP);
-      }
-    },
-    [onChange]
-  );
-
-  return (
-    <div className="flex flex-col items-center">
-      <button
-        type="button"
-        className={`${sideStepperBtnClass} rounded-t-md border-b-0`}
-        onClick={() => onChange(Math.min(PADDING_MAX, value + PADDING_BUTTON_STEP))}
-        disabled={value >= PADDING_MAX}
-        aria-label={`${ariaLabel} increment`}
-      >
-        <ChevronDownIcon size="xs" className="rotate-180" />
-      </button>
-      <input
-        type="text"
-        inputMode="decimal"
-        className="w-8 border border-stroke-subtle bg-surface px-0 py-0.5 text-center text-xs tabular-nums text-content-secondary outline-none focus:ring-1 focus:ring-accent"
-        value={isFocused ? localText : formatMm(displayValue)}
-        onChange={(e) => setLocalText(e.target.value)}
-        onFocus={() => {
-          setLocalText(formatMm(displayValue));
-          setIsFocused(true);
-        }}
-        onBlur={() => {
-          if (!skipBlurCommit.current) {
-            commit(localText);
-          }
-          skipBlurCommit.current = false;
-          setIsFocused(false);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            commit(localText);
-            skipBlurCommit.current = true;
-            e.currentTarget.blur();
-          }
-          if (e.key === 'Escape') {
-            setLocalText(formatMm(displayValue));
-            skipBlurCommit.current = true;
-            e.currentTarget.blur();
-          }
-        }}
-        aria-label={ariaLabel}
-      />
-      <button
-        type="button"
-        className={`${sideStepperBtnClass} rounded-b-md border-t-0`}
-        onClick={() => onChange(Math.max(PADDING_MIN, value - PADDING_BUTTON_STEP))}
-        disabled={value <= PADDING_MIN}
-        aria-label={`${ariaLabel} decrement`}
-      >
-        <ChevronDownIcon size="xs" />
-      </button>
-    </div>
-  );
-}
-
-interface PaddingStepperProps {
-  readonly label: string;
-  readonly value: number;
-  readonly onChange: (value: number) => void;
-}
-
-/** Compact stepper for a single padding value (mm). */
-function PaddingStepper({ label, value, onChange }: PaddingStepperProps) {
-  return (
-    <div className="w-fit flex flex-col items-center gap-0.5">
-      <span className="text-xs text-content-tertiary">{label}</span>
-      <Stepper
-        size="sm"
-        value={value}
-        onStep={(delta) =>
-          onChange(
-            Math.max(PADDING_MIN, Math.min(PADDING_MAX, value + delta * PADDING_BUTTON_STEP))
-          )
-        }
-        min={PADDING_MIN}
-        max={PADDING_MAX}
-        displayValue={formatMm(value)}
-        aria-label={label}
-      />
-    </div>
-  );
 }
 
 interface GridDimensionStepperProps {

--- a/src/features/baseplate/components/BaseplatePanel/PaddingSchematic.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/PaddingSchematic.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { PaddingSchematic } from './PaddingSchematic';
+import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
+import { mm } from '@/core/types';
+
+vi.mock('@/i18n', () => ({
+  useTranslation:
+    () =>
+    (key: string): string =>
+      key,
+}));
+
+describe('PaddingSchematic', () => {
+  it('renders all four padding steppers (back, front, left, right)', () => {
+    render(<PaddingSchematic baseplateParams={DEFAULT_BASEPLATE_PARAMS} updateParam={vi.fn()} />);
+    expect(screen.getByLabelText('baseplate.paddingBack')).toBeInTheDocument();
+    expect(screen.getByLabelText('baseplate.paddingFront')).toBeInTheDocument();
+    expect(screen.getByLabelText('baseplate.paddingLeft')).toBeInTheDocument();
+    expect(screen.getByLabelText('baseplate.paddingRight')).toBeInTheDocument();
+  });
+
+  it('shows current padding values in steppers', () => {
+    const params = {
+      ...DEFAULT_BASEPLATE_PARAMS,
+      paddingBack: mm(2),
+      paddingFront: mm(3),
+      paddingLeft: mm(1.5),
+      paddingRight: mm(4.25),
+    };
+    render(<PaddingSchematic baseplateParams={params} updateParam={vi.fn()} />);
+    expect(screen.getByLabelText('baseplate.paddingBack')).toHaveValue('2');
+    expect(screen.getByLabelText('baseplate.paddingFront')).toHaveValue('3');
+    expect(screen.getByLabelText('baseplate.paddingLeft')).toHaveValue('1.5');
+    expect(screen.getByLabelText('baseplate.paddingRight')).toHaveValue('4.25');
+  });
+
+  it('calls updateParam with the correct key when each side is changed via typed input', () => {
+    const updateParam = vi.fn();
+    render(
+      <PaddingSchematic baseplateParams={DEFAULT_BASEPLATE_PARAMS} updateParam={updateParam} />
+    );
+
+    const back = screen.getByLabelText('baseplate.paddingBack');
+    fireEvent.focus(back);
+    fireEvent.change(back, { target: { value: '7' } });
+    fireEvent.keyDown(back, { key: 'Enter' });
+    expect(updateParam).toHaveBeenCalledWith('paddingBack', 7);
+
+    const left = screen.getByLabelText('baseplate.paddingLeft');
+    fireEvent.focus(left);
+    fireEvent.change(left, { target: { value: '2.5' } });
+    fireEvent.keyDown(left, { key: 'Enter' });
+    expect(updateParam).toHaveBeenCalledWith('paddingLeft', 2.5);
+  });
+
+  it('calls updateParam when increment buttons are clicked', () => {
+    const updateParam = vi.fn();
+    render(
+      <PaddingSchematic baseplateParams={DEFAULT_BASEPLATE_PARAMS} updateParam={updateParam} />
+    );
+    fireEvent.click(screen.getByLabelText('Increase baseplate.paddingFront'));
+    expect(updateParam).toHaveBeenCalledWith('paddingFront', 0.25);
+  });
+});

--- a/src/features/baseplate/components/BaseplatePanel/PaddingSchematic.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/PaddingSchematic.test.tsx
@@ -7,8 +7,15 @@ import { mm } from '@/core/types';
 vi.mock('@/i18n', () => ({
   useTranslation:
     () =>
-    (key: string): string =>
-      key,
+    (key: string, params?: Record<string, unknown>): string => {
+      if (key === 'baseplate.increasePadding' && typeof params?.label === 'string') {
+        return `Increase ${params.label}`;
+      }
+      if (key === 'baseplate.decreasePadding' && typeof params?.label === 'string') {
+        return `Decrease ${params.label}`;
+      }
+      return key;
+    },
 }));
 
 describe('PaddingSchematic', () => {

--- a/src/features/baseplate/components/BaseplatePanel/PaddingSchematic.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/PaddingSchematic.tsx
@@ -1,0 +1,61 @@
+/**
+ * Spatial schematic showing four padding steppers positioned around a baseplate rectangle.
+ * Back is above, Front below, Left/Right flank a dashed placeholder for the baseplate body.
+ */
+
+import { useTranslation } from '@/i18n';
+import { PaddingStepper } from '../PaddingStepper';
+import type { BaseplateParams } from '@/core/types';
+import { mm } from '@/core/types';
+
+interface PaddingSchematicProps {
+  readonly baseplateParams: BaseplateParams;
+  readonly updateParam: <K extends keyof BaseplateParams>(
+    key: K,
+    value: BaseplateParams[K]
+  ) => void;
+}
+
+export function PaddingSchematic({ baseplateParams, updateParam }: PaddingSchematicProps) {
+  const t = useTranslation();
+
+  return (
+    <div className="space-y-1">
+      <div className="flex justify-center">
+        <PaddingStepper
+          orientation="horizontal"
+          label={t('baseplate.paddingBack')}
+          aria-label={t('baseplate.paddingBack')}
+          value={baseplateParams.paddingBack}
+          onChange={(v) => updateParam('paddingBack', mm(v))}
+        />
+      </div>
+
+      <div className="flex items-center gap-1.5">
+        <PaddingStepper
+          orientation="vertical"
+          aria-label={t('baseplate.paddingLeft')}
+          value={baseplateParams.paddingLeft}
+          onChange={(v) => updateParam('paddingLeft', mm(v))}
+        />
+        <div className="flex-1 min-h-12 rounded border border-dashed border-stroke-subtle bg-surface-secondary/50" />
+        <PaddingStepper
+          orientation="vertical"
+          aria-label={t('baseplate.paddingRight')}
+          value={baseplateParams.paddingRight}
+          onChange={(v) => updateParam('paddingRight', mm(v))}
+        />
+      </div>
+
+      <div className="flex justify-center">
+        <PaddingStepper
+          orientation="horizontal"
+          label={t('baseplate.paddingFront')}
+          aria-label={t('baseplate.paddingFront')}
+          value={baseplateParams.paddingFront}
+          onChange={(v) => updateParam('paddingFront', mm(v))}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SplitViewStrip } from './SplitViewStrip';
+import type { BaseplateTiling } from '../../types/tiling';
+
+vi.mock('@/i18n', () => ({
+  useTranslation:
+    () =>
+    (key: string, params?: Record<string, unknown>): string => {
+      if (params) {
+        return Object.entries(params).reduce(
+          (str, [k, v]) => str.replace(`{${k}}`, String(v)),
+          key
+        );
+      }
+      return key;
+    },
+}));
+
+const baseTiling: BaseplateTiling = {
+  isSplit: true,
+  cols: 2,
+  rows: 1,
+  pieces: [
+    { label: 'A1', col: 0, row: 0, widthUnits: 5, depthUnits: 4, gridOffsetX: 0, gridOffsetY: 0 },
+    { label: 'B1', col: 1, row: 0, widthUnits: 4, depthUnits: 4, gridOffsetX: 5, gridOffsetY: 0 },
+  ],
+  totalWidthUnits: 9,
+  totalDepthUnits: 6,
+  stackCount: 1,
+  stackSeparatorThickness: 0,
+};
+
+describe('SplitViewStrip', () => {
+  const defaultProps = {
+    tiling: baseTiling,
+    hoveredPieceLabel: null,
+    selectedPieceLabel: null,
+    onHoverPiece: vi.fn(),
+    onSelectPiece: vi.fn(),
+    printBedSize: 256,
+  };
+
+  it('renders split info and reason', () => {
+    render(<SplitViewStrip {...defaultProps} />);
+    expect(screen.getByText('baseplate.splitInfo')).toBeInTheDocument();
+    expect(screen.getByText('baseplate.splitReason')).toBeInTheDocument();
+  });
+
+  it('renders one button per piece', () => {
+    render(<SplitViewStrip {...defaultProps} />);
+    const pieceButtons = screen
+      .getAllByRole('button')
+      .filter((b) => b.getAttribute('aria-label')?.startsWith('baseplate.pieceLabel'));
+    expect(pieceButtons).toHaveLength(2);
+  });
+
+  it('omits the padding hint when no hint is present', () => {
+    render(<SplitViewStrip {...defaultProps} />);
+    expect(screen.queryByText('baseplate.paddingHint')).not.toBeInTheDocument();
+  });
+
+  it('renders the padding reduction hint when present', () => {
+    const tilingWithHint: BaseplateTiling = {
+      ...baseTiling,
+      paddingReductionHint: { axis: 'x', reductionMm: 10, piecesSaved: 2 },
+    };
+    render(<SplitViewStrip {...defaultProps} tiling={tilingWithHint} />);
+    expect(screen.getByText('baseplate.paddingHint')).toBeInTheDocument();
+  });
+
+  it('calls onHoverPiece on pointer enter and leave', () => {
+    const onHoverPiece = vi.fn();
+    render(<SplitViewStrip {...defaultProps} onHoverPiece={onHoverPiece} />);
+    const a1 = screen.getByText('A1');
+    fireEvent.pointerEnter(a1);
+    expect(onHoverPiece).toHaveBeenCalledWith('A1');
+    fireEvent.pointerLeave(a1);
+    expect(onHoverPiece).toHaveBeenCalledWith(null);
+  });
+
+  it('calls onSelectPiece with label on click', () => {
+    const onSelectPiece = vi.fn();
+    render(<SplitViewStrip {...defaultProps} onSelectPiece={onSelectPiece} />);
+    fireEvent.click(screen.getByText('A1'));
+    expect(onSelectPiece).toHaveBeenCalledWith('A1');
+  });
+
+  it('toggles selection (deselects) when clicking the already-selected piece', () => {
+    const onSelectPiece = vi.fn();
+    render(
+      <SplitViewStrip {...defaultProps} selectedPieceLabel="A1" onSelectPiece={onSelectPiece} />
+    );
+    fireEvent.click(screen.getByText('A1'));
+    expect(onSelectPiece).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
@@ -1,0 +1,97 @@
+/**
+ * Non-collapsible inline strip showing the split-baseplate piece mini-map.
+ * Each cell is a hoverable/selectable button corresponding to one print-bed piece.
+ */
+
+import { useTranslation } from '@/i18n';
+import { colToLetter } from '../../utils/splitPlanner';
+import type { BaseplateTiling, PaddingReductionHint } from '../../types/tiling';
+
+const PADDING_HINT_AXIS_KEYS: Record<PaddingReductionHint['axis'], string> = {
+  x: 'baseplate.paddingHintAxisX',
+  y: 'baseplate.paddingHintAxisY',
+  both: 'baseplate.paddingHintAxisBoth',
+};
+
+interface SplitViewStripProps {
+  readonly tiling: BaseplateTiling;
+  readonly hoveredPieceLabel: string | null;
+  readonly selectedPieceLabel: string | null;
+  readonly onHoverPiece: (label: string | null) => void;
+  readonly onSelectPiece: (label: string | null) => void;
+  readonly printBedSize: number;
+}
+
+export function SplitViewStrip({
+  tiling,
+  hoveredPieceLabel,
+  selectedPieceLabel,
+  onHoverPiece,
+  onSelectPiece,
+  printBedSize,
+}: SplitViewStripProps) {
+  const t = useTranslation();
+
+  return (
+    <div className="border-b border-stroke-subtle">
+      <div className="flex items-baseline justify-between gap-2 px-4 pt-3 pb-1">
+        <span className="text-xs text-content-secondary">
+          {t('baseplate.splitInfo', { count: tiling.pieces.length })}
+        </span>
+        <span className="text-[11px] text-content-tertiary whitespace-nowrap">
+          {t('baseplate.splitReason', { printBed: printBedSize })}
+        </span>
+      </div>
+
+      {tiling.paddingReductionHint && (
+        <div className="mx-4 mb-2 rounded bg-accent/10 px-2.5 py-1.5 text-[11px] text-accent">
+          {t('baseplate.paddingHint', {
+            axis: t(PADDING_HINT_AXIS_KEYS[tiling.paddingReductionHint.axis]),
+            mm: tiling.paddingReductionHint.reductionMm,
+            count: tiling.paddingReductionHint.piecesSaved,
+          })}
+        </div>
+      )}
+
+      <div className="px-4 pb-3">
+        <div
+          className="grid gap-1"
+          aria-label={t('baseplate.sectionView')}
+          style={{
+            gridTemplateColumns: `repeat(${tiling.cols}, 1fr)`,
+          }}
+        >
+          {Array.from({ length: tiling.rows }, (_, ri) => {
+            // Flip Y so row 1 (front/bottom in 3D) is at the bottom of the mini-map
+            const r = tiling.rows - 1 - ri;
+            return Array.from({ length: tiling.cols }, (_, c) => {
+              const label = `${colToLetter(c)}${r + 1}`;
+              const isHovered = hoveredPieceLabel === label;
+              const isSelected = selectedPieceLabel === label;
+              return (
+                <button
+                  key={label}
+                  type="button"
+                  className={`flex items-center justify-center rounded border bg-surface-elevated py-1 text-[10px] font-mono transition-shadow ${
+                    isSelected
+                      ? 'ring-2 ring-accent border-accent text-content-primary'
+                      : isHovered
+                        ? 'ring-1 ring-accent/50 border-accent/50 text-content-secondary'
+                        : 'border-stroke-subtle text-content-tertiary'
+                  }`}
+                  onPointerEnter={() => onHoverPiece(label)}
+                  onPointerLeave={() => onHoverPiece(null)}
+                  onClick={() => onSelectPiece(selectedPieceLabel === label ? null : label)}
+                  aria-pressed={isSelected}
+                  aria-label={t('baseplate.pieceLabel', { label })}
+                >
+                  {label}
+                </button>
+              );
+            });
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/baseplate/components/PaddingStepper/PaddingStepper.test.tsx
+++ b/src/features/baseplate/components/PaddingStepper/PaddingStepper.test.tsx
@@ -1,13 +1,46 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { PaddingStepper } from './PaddingStepper';
-import { formatMm, PADDING_BUTTON_STEP, PADDING_MAX, PADDING_MIN } from './constants';
+import { formatMm, PADDING_BUTTON_STEP, PADDING_MAX, PADDING_MIN, roundMm } from './constants';
+
+// Mock i18n: render `Increase {label}` / `Decrease {label}` from the en.ts pattern
+// so test assertions stay readable. Real translation keys are tested separately
+// via the i18n key-alignment check.
+vi.mock('@/i18n', () => ({
+  useTranslation:
+    () =>
+    (key: string, params?: Record<string, unknown>): string => {
+      if (key === 'baseplate.increasePadding' && typeof params?.label === 'string') {
+        return `Increase ${params.label}`;
+      }
+      if (key === 'baseplate.decreasePadding' && typeof params?.label === 'string') {
+        return `Decrease ${params.label}`;
+      }
+      return key;
+    },
+}));
 
 const baseProps = {
   value: 5,
   orientation: 'horizontal' as const,
   'aria-label': 'Front padding',
 };
+
+describe('roundMm', () => {
+  it('absorbs IEEE-754 noise (0.1 + 0.2 -> 0.3)', () => {
+    expect(roundMm(0.1 + 0.2)).toBe(0.3);
+  });
+
+  it('snaps to 2-decimal precision', () => {
+    expect(roundMm(5.555)).toBe(5.56);
+    expect(roundMm(5.554)).toBe(5.55);
+  });
+
+  it('preserves exact whole numbers', () => {
+    expect(roundMm(5)).toBe(5);
+    expect(roundMm(0)).toBe(0);
+  });
+});
 
 describe('formatMm', () => {
   it('renders integers without decimals', () => {
@@ -110,6 +143,22 @@ describe('PaddingStepper', () => {
       expect(onChange).toHaveBeenCalledWith(PADDING_MIN);
     });
 
+    it('button increment does not accumulate float noise from a noisy starting value', () => {
+      // Simulates: typed-in noisy value (5.5600000000000005) followed by a button click.
+      // Without roundMm in handleIncrement, the result would be 5.810000000000001.
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={5.5600000000000005} onChange={onChange} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Increase Front padding' }));
+      expect(onChange).toHaveBeenCalledWith(5.81);
+    });
+
+    it('button decrement does not accumulate float noise', () => {
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={5.5600000000000005} onChange={onChange} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Decrease Front padding' }));
+      expect(onChange).toHaveBeenCalledWith(5.31);
+    });
+
     it('disables both buttons when disabled prop is true', () => {
       render(<PaddingStepper {...baseProps} value={5} disabled onChange={vi.fn()} />);
       expect(screen.getByRole('button', { name: 'Increase Front padding' })).toBeDisabled();
@@ -181,16 +230,15 @@ describe('PaddingStepper', () => {
       expect(onChange).toHaveBeenCalledWith(PADDING_MIN);
     });
 
-    it('snaps typed values to PADDING_INPUT_STEP (0.01)', () => {
+    it('snaps typed values to 0.01 mm step with no float noise', () => {
       const onChange = vi.fn();
       render(<PaddingStepper {...baseProps} value={5} onChange={onChange} />);
       const input = screen.getByRole('textbox', { name: 'Front padding' });
       fireEvent.focus(input);
       fireEvent.change(input, { target: { value: '5.555' } });
       fireEvent.keyDown(input, { key: 'Enter' });
-      // 5.555 rounds to nearest 0.01 -> 5.56 (or 5.55 due to float; use closeTo)
-      const committed = onChange.mock.calls[0][0] as number;
-      expect(committed).toBeCloseTo(5.56, 5);
+      // Exact equality: roundMm must absorb IEEE-754 noise.
+      expect(onChange).toHaveBeenCalledWith(5.56);
     });
 
     it('ignores NaN input (does not commit)', () => {

--- a/src/features/baseplate/components/PaddingStepper/PaddingStepper.test.tsx
+++ b/src/features/baseplate/components/PaddingStepper/PaddingStepper.test.tsx
@@ -1,0 +1,264 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { PaddingStepper } from './PaddingStepper';
+import { formatMm, PADDING_BUTTON_STEP, PADDING_MAX, PADDING_MIN } from './constants';
+
+const baseProps = {
+  value: 5,
+  orientation: 'horizontal' as const,
+  'aria-label': 'Front padding',
+};
+
+describe('formatMm', () => {
+  it('renders integers without decimals', () => {
+    expect(formatMm(5)).toBe('5');
+    expect(formatMm(0)).toBe('0');
+  });
+
+  it('drops trailing zeros for fractional values', () => {
+    expect(formatMm(5.5)).toBe('5.5');
+    expect(formatMm(5.25)).toBe('5.25');
+  });
+
+  it('rounds to 2 decimals', () => {
+    expect(formatMm(5.555)).toBe('5.56');
+    expect(formatMm(5.001)).toBe('5');
+  });
+
+  it('absorbs floating-point noise (e.g. 0.1 + 0.2)', () => {
+    expect(formatMm(0.1 + 0.2)).toBe('0.3');
+  });
+});
+
+describe('PaddingStepper', () => {
+  describe('rendering', () => {
+    it('renders horizontal layout with input and +/- buttons', () => {
+      render(<PaddingStepper {...baseProps} onChange={vi.fn()} />);
+      expect(screen.getByRole('textbox', { name: 'Front padding' })).toHaveValue('5');
+      expect(screen.getByRole('button', { name: 'Increase Front padding' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Decrease Front padding' })).toBeInTheDocument();
+    });
+
+    it('renders vertical layout with input and +/- buttons', () => {
+      render(
+        <PaddingStepper
+          value={3}
+          orientation="vertical"
+          aria-label="Left padding"
+          onChange={vi.fn()}
+        />
+      );
+      expect(screen.getByRole('textbox', { name: 'Left padding' })).toHaveValue('3');
+      expect(screen.getByRole('button', { name: 'Increase Left padding' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Decrease Left padding' })).toBeInTheDocument();
+    });
+
+    it('renders optional label slot for horizontal orientation', () => {
+      render(<PaddingStepper {...baseProps} label="Front" onChange={vi.fn()} />);
+      expect(screen.getByText('Front')).toBeInTheDocument();
+    });
+
+    it('omits label when not provided', () => {
+      render(<PaddingStepper {...baseProps} onChange={vi.fn()} />);
+      // No <label> element associated with the input
+      expect(document.querySelector('label')).toBeNull();
+    });
+
+    it('formats fractional values without trailing zeros', () => {
+      render(<PaddingStepper {...baseProps} value={5.5} onChange={vi.fn()} />);
+      expect(screen.getByRole('textbox', { name: 'Front padding' })).toHaveValue('5.5');
+    });
+  });
+
+  describe('button stepping', () => {
+    it('increments by PADDING_BUTTON_STEP on +', () => {
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={5} onChange={onChange} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Increase Front padding' }));
+      expect(onChange).toHaveBeenCalledWith(5 + PADDING_BUTTON_STEP);
+    });
+
+    it('decrements by PADDING_BUTTON_STEP on -', () => {
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={5} onChange={onChange} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Decrease Front padding' }));
+      expect(onChange).toHaveBeenCalledWith(5 - PADDING_BUTTON_STEP);
+    });
+
+    it('disables decrement at PADDING_MIN', () => {
+      render(<PaddingStepper {...baseProps} value={PADDING_MIN} onChange={vi.fn()} />);
+      expect(screen.getByRole('button', { name: 'Decrease Front padding' })).toBeDisabled();
+    });
+
+    it('disables increment at PADDING_MAX', () => {
+      render(<PaddingStepper {...baseProps} value={PADDING_MAX} onChange={vi.fn()} />);
+      expect(screen.getByRole('button', { name: 'Increase Front padding' })).toBeDisabled();
+    });
+
+    it('clamps increment so it never overshoots PADDING_MAX', () => {
+      const onChange = vi.fn();
+      // value within step distance of max -> clamp
+      render(<PaddingStepper {...baseProps} value={PADDING_MAX - 0.1} onChange={onChange} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Increase Front padding' }));
+      expect(onChange).toHaveBeenCalledWith(PADDING_MAX);
+    });
+
+    it('clamps decrement so it never undershoots PADDING_MIN', () => {
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={0.1} onChange={onChange} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Decrease Front padding' }));
+      expect(onChange).toHaveBeenCalledWith(PADDING_MIN);
+    });
+
+    it('disables both buttons when disabled prop is true', () => {
+      render(<PaddingStepper {...baseProps} value={5} disabled onChange={vi.fn()} />);
+      expect(screen.getByRole('button', { name: 'Increase Front padding' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Decrease Front padding' })).toBeDisabled();
+    });
+  });
+
+  describe('typed input', () => {
+    it('commits typed value on Enter', () => {
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={5} onChange={onChange} />);
+      const input = screen.getByRole('textbox', { name: 'Front padding' });
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '7.5' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).toHaveBeenCalledWith(7.5);
+    });
+
+    it('commits typed value on Blur', () => {
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={5} onChange={onChange} />);
+      const input = screen.getByRole('textbox', { name: 'Front padding' });
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '12.34' } });
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenCalledWith(12.34);
+    });
+
+    it('reverts typed value on Escape (does not commit)', () => {
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={5} onChange={onChange} />);
+      const input = screen.getByRole('textbox', { name: 'Front padding' });
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '99' } });
+      fireEvent.keyDown(input, { key: 'Escape' });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('Enter blurs the input and does not double-commit on subsequent blur', () => {
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={5} onChange={onChange} />);
+      const input = screen.getByRole('textbox', { name: 'Front padding' });
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '7' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      fireEvent.blur(input);
+      // Only one commit, not two
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(7);
+    });
+
+    it('clamps typed values above PADDING_MAX silently', () => {
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={5} onChange={onChange} />);
+      const input = screen.getByRole('textbox', { name: 'Front padding' });
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '500' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).toHaveBeenCalledWith(PADDING_MAX);
+    });
+
+    it('clamps typed values below PADDING_MIN silently', () => {
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={5} onChange={onChange} />);
+      const input = screen.getByRole('textbox', { name: 'Front padding' });
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '-10' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).toHaveBeenCalledWith(PADDING_MIN);
+    });
+
+    it('snaps typed values to PADDING_INPUT_STEP (0.01)', () => {
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={5} onChange={onChange} />);
+      const input = screen.getByRole('textbox', { name: 'Front padding' });
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '5.555' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      // 5.555 rounds to nearest 0.01 -> 5.56 (or 5.55 due to float; use closeTo)
+      const committed = onChange.mock.calls[0][0] as number;
+      expect(committed).toBeCloseTo(5.56, 5);
+    });
+
+    it('ignores NaN input (does not commit)', () => {
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={5} onChange={onChange} />);
+      const input = screen.getByRole('textbox', { name: 'Front padding' });
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: 'abc' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('ignores empty input on commit (does not commit)', () => {
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={5} onChange={onChange} />);
+      const input = screen.getByRole('textbox', { name: 'Front padding' });
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('shows external value when not focused, even after typing+escape', () => {
+      const onChange = vi.fn();
+      render(<PaddingStepper {...baseProps} value={5} onChange={onChange} />);
+      const input = screen.getByRole('textbox', { name: 'Front padding' });
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '99' } });
+      fireEvent.keyDown(input, { key: 'Escape' });
+      expect(input).toHaveValue('5');
+    });
+
+    it('disables input when disabled prop is true', () => {
+      render(<PaddingStepper {...baseProps} value={5} disabled onChange={vi.fn()} />);
+      expect(screen.getByRole('textbox', { name: 'Front padding' })).toBeDisabled();
+    });
+  });
+
+  describe('orientation parity', () => {
+    it('vertical orientation accepts typed input the same way', () => {
+      const onChange = vi.fn();
+      render(
+        <PaddingStepper
+          value={2}
+          orientation="vertical"
+          aria-label="Left padding"
+          onChange={onChange}
+        />
+      );
+      const input = screen.getByRole('textbox', { name: 'Left padding' });
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '8.25' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).toHaveBeenCalledWith(8.25);
+    });
+
+    it('vertical orientation buttons step the same way', () => {
+      const onChange = vi.fn();
+      render(
+        <PaddingStepper
+          value={2}
+          orientation="vertical"
+          aria-label="Left padding"
+          onChange={onChange}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Increase Left padding' }));
+      expect(onChange).toHaveBeenCalledWith(2 + PADDING_BUTTON_STEP);
+    });
+  });
+});

--- a/src/features/baseplate/components/PaddingStepper/PaddingStepper.tsx
+++ b/src/features/baseplate/components/PaddingStepper/PaddingStepper.tsx
@@ -26,13 +26,8 @@ import {
 import { cn } from '@/design-system/cn';
 import { MinusIcon, PlusIcon } from '@/design-system/Icon';
 import { disabledStyles, focusRing, interactiveTransition } from '@/design-system/variants';
-import {
-  formatMm,
-  PADDING_BUTTON_STEP,
-  PADDING_INPUT_STEP,
-  PADDING_MAX,
-  PADDING_MIN,
-} from './constants';
+import { useTranslation } from '@/i18n';
+import { formatMm, PADDING_BUTTON_STEP, PADDING_MAX, PADDING_MIN, roundMm } from './constants';
 
 interface PaddingStepperProps {
   readonly value: number;
@@ -65,9 +60,9 @@ function useEditablePaddingInput(value: number, onChange: (v: number) => void) {
     (text: string) => {
       const parsed = parseFloat(text);
       if (Number.isNaN(parsed)) return;
-      const snapped = Math.round(parsed / PADDING_INPUT_STEP) * PADDING_INPUT_STEP;
-      const clamped = Math.max(PADDING_MIN, Math.min(PADDING_MAX, snapped));
-      onChange(clamped);
+      const clamped = Math.max(PADDING_MIN, Math.min(PADDING_MAX, parsed));
+      // roundMm both snaps to 0.01 step and absorbs IEEE-754 noise.
+      onChange(roundMm(clamped));
     },
     [onChange]
   );
@@ -141,19 +136,25 @@ export const PaddingStepper = forwardRef<HTMLDivElement, PaddingStepperProps>(
     { value, onChange, orientation, 'aria-label': ariaLabel, label, disabled, className },
     ref
   ) {
+    const t = useTranslation();
     const inputId = useId();
     const inputProps = useEditablePaddingInput(value, onChange);
 
     const isDecreaseDisabled = disabled === true || value <= PADDING_MIN;
     const isIncreaseDisabled = disabled === true || value >= PADDING_MAX;
 
+    // roundMm prevents IEEE-754 noise from accumulating across repeated +/- clicks
+    // (e.g. 0.25 + 0.25 + ... drifting into values like 1.2500000000000002).
     const handleIncrement = useCallback(() => {
-      onChange(Math.min(PADDING_MAX, value + PADDING_BUTTON_STEP));
+      onChange(roundMm(Math.min(PADDING_MAX, value + PADDING_BUTTON_STEP)));
     }, [onChange, value]);
 
     const handleDecrement = useCallback(() => {
-      onChange(Math.max(PADDING_MIN, value - PADDING_BUTTON_STEP));
+      onChange(roundMm(Math.max(PADDING_MIN, value - PADDING_BUTTON_STEP)));
     }, [onChange, value]);
+
+    const increaseLabel = t('baseplate.increasePadding', { label: ariaLabel });
+    const decreaseLabel = t('baseplate.decreasePadding', { label: ariaLabel });
 
     if (orientation === 'vertical') {
       return (
@@ -163,7 +164,7 @@ export const PaddingStepper = forwardRef<HTMLDivElement, PaddingStepperProps>(
             onClick={handleIncrement}
             disabled={isIncreaseDisabled}
             className={cn(buttonBase, 'h-6 w-8 rounded-t-md border-b-0')}
-            aria-label={`Increase ${ariaLabel}`}
+            aria-label={increaseLabel}
           >
             <PlusIcon size="sm" className={iconClass} strokeWidth={iconStrokeWidth} />
           </button>
@@ -181,7 +182,7 @@ export const PaddingStepper = forwardRef<HTMLDivElement, PaddingStepperProps>(
             onClick={handleDecrement}
             disabled={isDecreaseDisabled}
             className={cn(buttonBase, 'h-6 w-8 rounded-b-md border-t-0')}
-            aria-label={`Decrease ${ariaLabel}`}
+            aria-label={decreaseLabel}
           >
             <MinusIcon size="sm" className={iconClass} strokeWidth={iconStrokeWidth} />
           </button>
@@ -202,7 +203,7 @@ export const PaddingStepper = forwardRef<HTMLDivElement, PaddingStepperProps>(
             onClick={handleDecrement}
             disabled={isDecreaseDisabled}
             className={cn(buttonBase, 'h-6 rounded-l-md border-r-0 px-1')}
-            aria-label={`Decrease ${ariaLabel}`}
+            aria-label={decreaseLabel}
           >
             <MinusIcon size="sm" className={iconClass} strokeWidth={iconStrokeWidth} />
           </button>
@@ -220,7 +221,7 @@ export const PaddingStepper = forwardRef<HTMLDivElement, PaddingStepperProps>(
             onClick={handleIncrement}
             disabled={isIncreaseDisabled}
             className={cn(buttonBase, 'h-6 rounded-r-md border-l-0 px-1')}
-            aria-label={`Increase ${ariaLabel}`}
+            aria-label={increaseLabel}
           >
             <PlusIcon size="sm" className={iconClass} strokeWidth={iconStrokeWidth} />
           </button>

--- a/src/features/baseplate/components/PaddingStepper/PaddingStepper.tsx
+++ b/src/features/baseplate/components/PaddingStepper/PaddingStepper.tsx
@@ -1,0 +1,231 @@
+/**
+ * Editable mm padding stepper for the baseplate panel's spatial schematic.
+ *
+ * Renders in two orientations:
+ * - `horizontal`: [−] [input] [+] with optional label above. Used for front/back edges.
+ * - `vertical`:   [+] / [input] / [−] stacked, no visible label. Used for left/right edges
+ *                 where the spatial schematic implies the meaning and width must stay narrow.
+ *
+ * Two stepping rates share a single onChange:
+ * - Buttons step in {@link PADDING_BUTTON_STEP} (0.25mm) increments.
+ * - Typed input snaps to {@link PADDING_INPUT_STEP} (0.01mm) and is silently clamped
+ *   to [{@link PADDING_MIN}, {@link PADDING_MAX}].
+ *
+ * Keyboard: Enter commits, Escape reverts, Blur commits. NaN reverts silently.
+ */
+
+import {
+  forwardRef,
+  useCallback,
+  useId,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from 'react';
+import { cn } from '@/design-system/cn';
+import { MinusIcon, PlusIcon } from '@/design-system/Icon';
+import { disabledStyles, focusRing, interactiveTransition } from '@/design-system/variants';
+import {
+  formatMm,
+  PADDING_BUTTON_STEP,
+  PADDING_INPUT_STEP,
+  PADDING_MAX,
+  PADDING_MIN,
+} from './constants';
+
+interface PaddingStepperProps {
+  readonly value: number;
+  readonly onChange: (value: number) => void;
+  readonly orientation: 'horizontal' | 'vertical';
+  readonly 'aria-label': string;
+  /** Optional visible label rendered above the stepper (horizontal only). */
+  readonly label?: string;
+  readonly disabled?: boolean;
+  readonly className?: string;
+}
+
+/**
+ * Hook owning the deferred-commit input behavior. Local text is kept while focused
+ * so users can freely clear/retype; commits happen on Blur, Enter, or external sync
+ * once focus is released. Escape reverts to the external value.
+ *
+ * The skipBlurCommit ref prevents double-commit when Enter triggers blur (Enter
+ * already committed) or when Escape blurs after a revert (we don't want Blur to
+ * re-commit the reverted display).
+ */
+function useEditablePaddingInput(value: number, onChange: (v: number) => void) {
+  const [localText, setLocalText] = useState('');
+  const [isFocused, setIsFocused] = useState(false);
+  const skipBlurCommitRef = useRef(false);
+
+  const displayValue = isFocused ? localText : formatMm(value);
+
+  const commit = useCallback(
+    (text: string) => {
+      const parsed = parseFloat(text);
+      if (Number.isNaN(parsed)) return;
+      const snapped = Math.round(parsed / PADDING_INPUT_STEP) * PADDING_INPUT_STEP;
+      const clamped = Math.max(PADDING_MIN, Math.min(PADDING_MAX, snapped));
+      onChange(clamped);
+    },
+    [onChange]
+  );
+
+  const onChangeInput = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setLocalText(e.target.value);
+  }, []);
+
+  const onFocus = useCallback(() => {
+    setLocalText(formatMm(value));
+    setIsFocused(true);
+  }, [value]);
+
+  const onBlur = useCallback(() => {
+    if (!skipBlurCommitRef.current) {
+      commit(localText);
+    }
+    skipBlurCommitRef.current = false;
+    setIsFocused(false);
+  }, [commit, localText]);
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        commit(localText);
+        skipBlurCommitRef.current = true;
+        e.currentTarget.blur();
+      } else if (e.key === 'Escape') {
+        setLocalText(formatMm(value));
+        skipBlurCommitRef.current = true;
+        e.currentTarget.blur();
+      }
+    },
+    [commit, localText, value]
+  );
+
+  return {
+    value: displayValue,
+    onChange: onChangeInput,
+    onFocus,
+    onBlur,
+    onKeyDown,
+  };
+}
+
+const buttonBase = [
+  'flex items-center justify-center',
+  'border border-stroke-subtle bg-surface-elevated',
+  'text-content-tertiary',
+  'hover:bg-surface-hover hover:text-content',
+  interactiveTransition,
+  ...focusRing,
+  ...disabledStyles,
+];
+
+const inputBase = [
+  'bg-surface',
+  'border border-stroke-subtle',
+  'text-center text-xs tabular-nums text-content-secondary',
+  'outline-none',
+  interactiveTransition,
+  ...focusRing,
+  ...disabledStyles,
+];
+
+const iconClass = 'w-2.5 h-2.5';
+const iconStrokeWidth = 2.5;
+
+export const PaddingStepper = forwardRef<HTMLDivElement, PaddingStepperProps>(
+  function PaddingStepper(
+    { value, onChange, orientation, 'aria-label': ariaLabel, label, disabled, className },
+    ref
+  ) {
+    const inputId = useId();
+    const inputProps = useEditablePaddingInput(value, onChange);
+
+    const isDecreaseDisabled = disabled === true || value <= PADDING_MIN;
+    const isIncreaseDisabled = disabled === true || value >= PADDING_MAX;
+
+    const handleIncrement = useCallback(() => {
+      onChange(Math.min(PADDING_MAX, value + PADDING_BUTTON_STEP));
+    }, [onChange, value]);
+
+    const handleDecrement = useCallback(() => {
+      onChange(Math.max(PADDING_MIN, value - PADDING_BUTTON_STEP));
+    }, [onChange, value]);
+
+    if (orientation === 'vertical') {
+      return (
+        <div ref={ref} className={cn('flex flex-col items-center', className)}>
+          <button
+            type="button"
+            onClick={handleIncrement}
+            disabled={isIncreaseDisabled}
+            className={cn(buttonBase, 'h-6 w-8 rounded-t-md border-b-0')}
+            aria-label={`Increase ${ariaLabel}`}
+          >
+            <PlusIcon size="sm" className={iconClass} strokeWidth={iconStrokeWidth} />
+          </button>
+          <input
+            id={inputId}
+            type="text"
+            inputMode="decimal"
+            disabled={disabled}
+            className={cn(inputBase, 'h-6 w-8 px-0 py-0.5')}
+            aria-label={ariaLabel}
+            {...inputProps}
+          />
+          <button
+            type="button"
+            onClick={handleDecrement}
+            disabled={isDecreaseDisabled}
+            className={cn(buttonBase, 'h-6 w-8 rounded-b-md border-t-0')}
+            aria-label={`Decrease ${ariaLabel}`}
+          >
+            <MinusIcon size="sm" className={iconClass} strokeWidth={iconStrokeWidth} />
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div ref={ref} className={cn('flex w-fit flex-col items-center gap-0.5', className)}>
+        {label !== undefined && (
+          <label htmlFor={inputId} className="text-xs text-content-tertiary">
+            {label}
+          </label>
+        )}
+        <div className="inline-flex h-6 items-center">
+          <button
+            type="button"
+            onClick={handleDecrement}
+            disabled={isDecreaseDisabled}
+            className={cn(buttonBase, 'h-6 rounded-l-md border-r-0 px-1')}
+            aria-label={`Decrease ${ariaLabel}`}
+          >
+            <MinusIcon size="sm" className={iconClass} strokeWidth={iconStrokeWidth} />
+          </button>
+          <input
+            id={inputId}
+            type="text"
+            inputMode="decimal"
+            disabled={disabled}
+            className={cn(inputBase, 'h-6 min-w-[40px] rounded-none border-x-0 px-0 py-0')}
+            aria-label={ariaLabel}
+            {...inputProps}
+          />
+          <button
+            type="button"
+            onClick={handleIncrement}
+            disabled={isIncreaseDisabled}
+            className={cn(buttonBase, 'h-6 rounded-r-md border-l-0 px-1')}
+            aria-label={`Increase ${ariaLabel}`}
+          >
+            <PlusIcon size="sm" className={iconClass} strokeWidth={iconStrokeWidth} />
+          </button>
+        </div>
+      </div>
+    );
+  }
+);

--- a/src/features/baseplate/components/PaddingStepper/constants.ts
+++ b/src/features/baseplate/components/PaddingStepper/constants.ts
@@ -3,7 +3,16 @@ export const PADDING_INPUT_STEP = 0.01;
 export const PADDING_MIN = 0;
 export const PADDING_MAX = 100;
 
+/**
+ * Round to 2-decimal mm precision, eliminating IEEE-754 float noise that
+ * can accumulate from repeated +0.25 button clicks or `* 0.01` snapping.
+ * E.g. roundMm(0.1 + 0.2) === 0.3 and roundMm(5.5600000000000005) === 5.56.
+ */
+export function roundMm(v: number): number {
+  return Math.round(v * 100) / 100;
+}
+
 /** Format mm: round to 2 decimals, drop trailing zeros (e.g. 5 → "5", 5.5 → "5.5", 5.25 → "5.25"). */
 export function formatMm(v: number): string {
-  return String(Math.round(v * 100) / 100);
+  return String(roundMm(v));
 }

--- a/src/features/baseplate/components/PaddingStepper/constants.ts
+++ b/src/features/baseplate/components/PaddingStepper/constants.ts
@@ -1,0 +1,9 @@
+export const PADDING_BUTTON_STEP = 0.25;
+export const PADDING_INPUT_STEP = 0.01;
+export const PADDING_MIN = 0;
+export const PADDING_MAX = 100;
+
+/** Format mm: round to 2 decimals, drop trailing zeros (e.g. 5 → "5", 5.5 → "5.5", 5.25 → "5.25"). */
+export function formatMm(v: number): string {
+  return String(Math.round(v * 100) / 100);
+}

--- a/src/features/baseplate/components/PaddingStepper/index.ts
+++ b/src/features/baseplate/components/PaddingStepper/index.ts
@@ -1,0 +1,8 @@
+export { PaddingStepper } from './PaddingStepper';
+export {
+  PADDING_BUTTON_STEP,
+  PADDING_INPUT_STEP,
+  PADDING_MIN,
+  PADDING_MAX,
+  formatMm,
+} from './constants';

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -41,6 +41,8 @@
   "baseplate.magnetDiameterInfo": "6mm ist Standard für Gridfinity",
   "baseplate.magnetHoles": "Magnetlöcher",
   "baseplate.padding": "Polsterung",
+  "baseplate.decreasePadding": "{label} verkleinern",
+  "baseplate.increasePadding": "{label} vergrößern",
   "baseplate.paddingBack": "Hinten",
   "baseplate.paddingFront": "Vorne",
   "baseplate.paddingHint": "{axis}-Abstand um {mm}mm reduzieren würde {count} Teil(e) sparen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1471,6 +1471,8 @@ const en: Record<string, string> = {
   'baseplate.paddingRight': 'Right',
   'baseplate.paddingFront': 'Front',
   'baseplate.paddingBack': 'Back',
+  'baseplate.increasePadding': 'Increase {label}',
+  'baseplate.decreasePadding': 'Decrease {label}',
   'baseplate.editDimensions': 'Edit baseplate dimensions',
   'baseplate.inclPadding': 'incl. padding',
   'baseplate.editDimensionsWidth': 'Baseplate width in mm',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -41,6 +41,8 @@
   "baseplate.magnetDiameterInfo": "6mm es estándar para Gridfinity",
   "baseplate.magnetHoles": "Agujeros de imán",
   "baseplate.padding": "Relleno",
+  "baseplate.decreasePadding": "Disminuir {label}",
+  "baseplate.increasePadding": "Aumentar {label}",
   "baseplate.paddingBack": "Atrás",
   "baseplate.paddingFront": "Frente",
   "baseplate.paddingHint": "Reducir el relleno {axis} en {mm}mm ahorraría {count} pieza(s)",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -41,6 +41,8 @@
   "baseplate.magnetDiameterInfo": "6mm est le standard pour Gridfinity",
   "baseplate.magnetHoles": "Trous d'aimant",
   "baseplate.padding": "Marge",
+  "baseplate.decreasePadding": "Diminuer {label}",
+  "baseplate.increasePadding": "Augmenter {label}",
   "baseplate.paddingBack": "Arrière",
   "baseplate.paddingFront": "Avant",
   "baseplate.paddingHint": "Réduire la marge {axis} de {mm}mm économiserait {count} pièce(s)",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -41,6 +41,8 @@
   "baseplate.magnetDiameterInfo": "6mm er standard for Gridfinity",
   "baseplate.magnetHoles": "Magnethull",
   "baseplate.padding": "Polstring",
+  "baseplate.decreasePadding": "Reduser {label}",
+  "baseplate.increasePadding": "Øk {label}",
   "baseplate.paddingBack": "Bak",
   "baseplate.paddingFront": "Foran",
   "baseplate.paddingHint": "Reduser {axis}-margin med {mm}mm for å spare {count} del(er)",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -41,6 +41,8 @@
   "baseplate.magnetDiameterInfo": "6mm is standaard voor Gridfinity",
   "baseplate.magnetHoles": "Magneetgaten",
   "baseplate.padding": "Vulling",
+  "baseplate.decreasePadding": "{label} verkleinen",
+  "baseplate.increasePadding": "{label} vergroten",
   "baseplate.paddingBack": "Achter",
   "baseplate.paddingFront": "Voor",
   "baseplate.paddingHint": "{axis}-opvulling met {mm}mm verminderen bespaart {count} stuk(s)",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -41,6 +41,8 @@
   "baseplate.magnetDiameterInfo": "6mm é padrão para Gridfinity",
   "baseplate.magnetHoles": "Furos de ímã",
   "baseplate.padding": "Preenchimento",
+  "baseplate.decreasePadding": "Diminuir {label}",
+  "baseplate.increasePadding": "Aumentar {label}",
   "baseplate.paddingBack": "Trás",
   "baseplate.paddingFront": "Frente",
   "baseplate.paddingHint": "Reduzir o preenchimento {axis} em {mm}mm economizaria {count} peça(s)",


### PR DESCRIPTION
## Summary

- Front/back padding inputs were display-only (read-only span); only the +/− buttons could change them. Left/right had a separate custom editable input that shared no logic with front/back.
- Unified all four sides on a new `PaddingStepper` with `orientation: 'horizontal' | 'vertical'`. Typed input snaps 0.01 mm and is silently clamped to `[0, 100]`; buttons keep their 0.25 mm step. Enter/Blur commit, Escape reverts, NaN ignored.
- Side cleanup: extracted `PaddingSchematic` and `SplitViewStrip` from `BaseplatePanel.tsx` (746 → 481 lines, clears the `max-lines` warning).

## Files

**New**
- `src/features/baseplate/components/PaddingStepper/{PaddingStepper.tsx, PaddingStepper.test.tsx, constants.ts, index.ts}` — unified component, 29 tests
- `src/features/baseplate/components/BaseplatePanel/{PaddingSchematic.tsx, PaddingSchematic.test.tsx, SplitViewStrip.tsx, SplitViewStrip.test.tsx}` — extracted

**Modified**
- `BaseplatePanel.tsx` — uses unified component via `PaddingSchematic`
- `BaseplatePanel.test.tsx` — updated 2 aria-label assertions to match unified `Increase`/`Decrease` format

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm exec eslint` on changed files (no errors)
- [x] `pnpm exec vitest run src/features/baseplate/` — 265/265 pass (40 new + 225 existing)
- [x] All pre-commit hooks pass: i18n (4 checks), boundaries, exhaustiveness, component structure, missing tests
- [ ] Manual: type a fractional mm value into front/back stepper, press Enter — commits and rounds correctly
- [ ] Manual: type out-of-range value (e.g. 200) — clamps silently to 100
- [ ] Manual: type, press Escape — reverts without committing
- [ ] Manual: vertical (left/right) typed input still works the same as before