### PR TITLE
chore: migrate deprecated APIs + fix broken lint-staged from #1453

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "NODE_OPTIONS=--max-old-space-size=8192 eslint --fix",
+      "eslint --fix",
       "prettier --write"
     ],
     "*.{json,md,yml,yaml}": [

--- a/src/core/cqrs/index.ts
+++ b/src/core/cqrs/index.ts
@@ -152,8 +152,7 @@ export { getPendingRetryCount, clearRetryQueue } from './store/retryQueue';
 export { undoCaptureMiddleware, batch, _resetUndoCaptureState } from './middleware/undoCapture';
 export { loggingMiddleware } from './middleware/logging';
 export { analyticsMiddleware } from './middleware/analytics';
-/** @deprecated Use `getDefaultPipeline()` instead */
-export { defaultPipeline, getDefaultPipeline } from './middleware';
+export { getDefaultPipeline } from './middleware';
 
 export { validationMiddleware, COMMAND_SCHEMAS, getCommandSchema } from './validation';
 export { getMiddlewareFlags } from './middleware/middlewareConfig';

--- a/src/core/cqrs/middleware/index.ts
+++ b/src/core/cqrs/middleware/index.ts
@@ -19,16 +19,6 @@ import { analyticsMiddleware } from './analytics';
 import { undoCaptureMiddleware } from './undoCapture';
 
 /**
- * @deprecated Use `getDefaultPipeline()` instead.
- */
-export const defaultPipeline: ReadonlyArray<Middleware<Command, DomainEvent>> = [
-  validationMiddleware,
-  undoCaptureMiddleware,
-  analyticsMiddleware,
-  loggingMiddleware,
-];
-
-/**
  * Build the default middleware pipeline.
  *
  * Order: validation (fail-fast) -> undoCapture -> analytics -> logging.

--- a/src/core/cqrs/validation/librarySchemas.ts
+++ b/src/core/cqrs/validation/librarySchemas.ts
@@ -33,7 +33,7 @@ export const librarySetAuthorNameSchema = z.object({ name: nameStr });
 
 export const librarySetCloudShareSchema = z.object({
   layoutId: layoutIdSchema,
-  shareInfo: z.object({ id: z.string(), url: z.string() }).passthrough(),
+  shareInfo: z.object({ id: z.string(), url: z.string() }).loose(),
 });
 
 export const libraryClearCloudShareSchema = z.object({ layoutId: layoutIdSchema });


### PR DESCRIPTION
## Summary

**Hotfix included:** #1453 added `NODE_OPTIONS=--max-old-space-size=8192` as an inline POSIX env-var prefix to the `lint-staged` command. lint-staged spawns commands without a shell (using cross-spawn directly), so the prefix isn't parsed as an env assignment — it's treated as the executable name and fails with `ENOENT`. **This was blocking pre-commit hooks on main.** Reverted; the heap bump remains on the top-level `lint`/`lint:fix` scripts (pnpm runs those through a shell, so they work). lint-staged operates on small per-file batches during pre-commit and is unlikely to OOM in practice.

**Deprecated APIs (the actual scope of this PR):**

- Drop the deprecated `defaultPipeline` const alias in `src/core/cqrs/middleware/index.ts`. It's been marked `@deprecated Use getDefaultPipeline() instead` and has zero consumers in `src/` — only the public re-export, which I'm also removing. `getDefaultPipeline()` is functionally identical (same middleware, same order).
- Migrate the one Zod 3 `.passthrough()` call to Zod 4's `.loose()` in `src/core/cqrs/validation/librarySchemas.ts`. Functionally identical; clears the `@typescript-eslint/no-deprecated` warning.

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm exec vitest run src/core/cqrs` — 279 / 279 pass
- [x] All pre-commit hooks pass (this commit succeeded — the lint-staged hotfix is verified)
- [x] No remaining `defaultPipeline` or `.passthrough()` references in `src/`