### PR TITLE
chore(lint): clear all non-max-lines warnings via case-by-case audit

### DIFF
--- a/src/core/cqrs/middleware/middlewareConfig.ts
+++ b/src/core/cqrs/middleware/middlewareConfig.ts
@@ -85,5 +85,8 @@ const COMMAND_PROFILES: Readonly<Record<CommandType, MiddlewareProfile>> = {
 
 /** Look up middleware flags for a command type. Defaults to domain profile. */
 export function getMiddlewareFlags(type: CommandType): MiddlewareFlags {
+  // Records are typed exhaustively but the runtime fallback is exercised by
+  // tests that pass unregistered command types — keep it.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   return PROFILES[COMMAND_PROFILES[type]] ?? PROFILES.domain;
 }

--- a/src/core/cqrs/middleware/undoCapture.ts
+++ b/src/core/cqrs/middleware/undoCapture.ts
@@ -81,7 +81,7 @@ export function undoCaptureMiddleware(
 
   if (isOk(result)) {
     useHistoryStore.getState().push(snapshot, command.type, selectionSnapshot);
-    mlTracking.recordAction?.();
+    mlTracking.recordAction();
   }
 
   return result;
@@ -130,8 +130,11 @@ export function batch<T>(fn: () => T): T {
     // Check if layout actually changed (Immer produces new reference on mutation)
     const currentLayout = useLayoutStore.getState().layout;
     if (currentLayout !== layout) {
+      // batchCommandType is mutated by the inner middleware via fn(); TS's flow
+      // analysis can't see across that boundary so it narrows to `null` here.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       useHistoryStore.getState().push(snapshot, batchCommandType ?? 'unknown', selectionSnapshot);
-      mlTracking.recordAction?.();
+      mlTracking.recordAction();
     }
 
     return result;
@@ -139,8 +142,11 @@ export function batch<T>(fn: () => T): T {
     // Push undo snapshot even on error so partial mutations can be reverted
     const currentLayout = useLayoutStore.getState().layout;
     if (currentLayout !== layout) {
+      // batchCommandType is mutated by the inner middleware via fn(); TS's flow
+      // analysis can't see across that boundary so it narrows to `null` here.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       useHistoryStore.getState().push(snapshot, batchCommandType ?? 'unknown', selectionSnapshot);
-      mlTracking.recordAction?.();
+      mlTracking.recordAction();
     }
     throw e;
   } finally {

--- a/src/features/baseplate/hooks/useBaseplateGeneration.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.ts
@@ -229,7 +229,9 @@ export function useBaseplateGeneration(): void {
             }
           }
 
-          // Build mesh entries: original for first piece in group, clone for duplicates
+          // Build mesh entries: original for first piece in group, clone for duplicates.
+          // `new Array(n)` returns `any[]`; we pre-size the typed slot.
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           const meshEntries: PieceMeshEntry[] = new Array(totalCount);
 
           for (let groupIdx = 0; groupIdx < uniqueGroups.length; groupIdx++) {

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
@@ -28,6 +28,9 @@ export function ColorsSection() {
     }))
   );
 
+  // featureColors is typed as required, but legacy persisted configs may
+  // omit it; preserve the runtime fallback.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const featureColors = rawColors ?? DEFAULT_FEATURE_COLOR_CONFIG;
   const updateFeatureColors = useDesignerStore((s) => s.updateFeatureColors);
   const setHoveredColorZone = useDesignerStore((s) => s.setHoveredColorZone);

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgParser.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgParser.ts
@@ -39,6 +39,9 @@ export function parseSvgString(svgString: string): Result<ParsedCutoutSpec[], Sv
   // Check for parse errors
   const parseError = doc.querySelector('parsererror');
   if (parseError) {
+    // textContent is `string | null`; the err `detail` field accepts `string | undefined`,
+    // so coalesce null → undefined.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     return err({ code: 'SVG_PARSE_FAILED', detail: parseError.textContent ?? undefined });
   }
 

--- a/src/features/bin-designer/components/panel/ShapeSection/useShapeSection.ts
+++ b/src/features/bin-designer/components/panel/ShapeSection/useShapeSection.ts
@@ -39,6 +39,8 @@ function subCellIndices(
 function coarsenToGridUnits(hb: CellMask): CellMask {
   const cols = hb.cols / 2;
   const rows = hb.rows / 2;
+  // `new Array(n)` returns `any[]`; we pre-size the typed slot for in-place fill.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const cells: (0 | 1)[] = new Array(cols * rows);
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < cols; c++) {

--- a/src/features/bin-designer/components/preview/BinMesh/BinMesh.tsx
+++ b/src/features/bin-designer/components/preview/BinMesh/BinMesh.tsx
@@ -103,6 +103,8 @@ export function BinMesh({ wireframe, color }: BinMeshProps) {
       edgeVertices: s.generation.mesh?.edgeVertices ?? null,
       faceGroups: s.generation.mesh?.faceGroups ?? null,
       coarseLOD: s.generation.mesh?.coarseLOD ?? null,
+      // featureColors is typed required but legacy persisted configs may omit it
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       featureColors: s.params.featureColors ?? null,
       hasLip: s.params.base.stackingLip,
       hasLabelTabs: s.params.label.enabled,
@@ -120,6 +122,8 @@ export function BinMesh({ wireframe, color }: BinMeshProps) {
 
   // Build multi-color groups when feature is active
   const multiColorData = useMemo(() => {
+    // featureColors is null-coalesced upstream (legacy persisted configs); guard it.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!multiColorEnabled || !faceGroups || !featureColors || !indices) return null;
     return buildMultiColorGroups(faceGroups, featureColors, activeZones, indices.length);
   }, [multiColorEnabled, faceGroups, featureColors, activeZones, indices]);
@@ -140,6 +144,8 @@ export function BinMesh({ wireframe, color }: BinMeshProps) {
 
     // Determine which material index is hovered (if any)
     let hoveredIndex: number | undefined;
+    // featureColors is null-coalesced upstream (legacy persisted configs); guard it.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (hoveredColorZone && featureColors) {
       const hoveredHex = featureColors[hoveredColorZone];
       hoveredIndex = multiColorData.colorToIndex.get(hoveredHex);
@@ -185,6 +191,8 @@ export function BinMesh({ wireframe, color }: BinMeshProps) {
     if (coarseGeometry) invalidate();
   }, [coarseGeometry, invalidate]);
 
+  // featureColors is null-coalesced upstream (legacy persisted configs); guard it.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const baseColor = multiColorEnabled && featureColors ? featureColors.body : color;
 
   // Single-color material props shared between fine mesh and coarse LOD

--- a/src/features/bin-designer/constants/defaults.ts
+++ b/src/features/bin-designer/constants/defaults.ts
@@ -110,6 +110,11 @@ const LEGACY_SLOT_COLORS: Record<string, string> = {
 /** Migrate featureColors from old slot-based format to direct hex colors */
 function migrateFeatureColors(raw: Partial<FeatureColorConfig> | undefined): FeatureColorConfig {
   if (!raw) return DEFAULT_FEATURE_COLOR_CONFIG;
+  // LEGACY_SLOT_COLORS is `Record<string, string>` so TS treats every lookup
+  // as defined; at runtime an unmapped legacy slot returns undefined and we
+  // fall through to the direct color or default. The `??` chain encodes
+  // that fallback ladder.
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
   return {
     body: LEGACY_SLOT_COLORS[raw.body as string] ?? raw.body ?? DEFAULT_FEATURE_COLOR_CONFIG.body,
     lip: LEGACY_SLOT_COLORS[raw.lip as string] ?? raw.lip ?? DEFAULT_FEATURE_COLOR_CONFIG.lip,
@@ -118,6 +123,7 @@ function migrateFeatureColors(raw: Partial<FeatureColorConfig> | undefined): Fea
       raw.labelTab ??
       DEFAULT_FEATURE_COLOR_CONFIG.labelTab,
   };
+  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
 }
 
 /** Default feature color config: all zones use the default bin color (light grey) */

--- a/src/features/bin-designer/hooks/useExport.ts
+++ b/src/features/bin-designer/hooks/useExport.ts
@@ -176,11 +176,16 @@ export function useExport(): UseExportReturn {
 
             // Build multi-color config when Labs flag is enabled
             let colorConfig: ThreeMFColorConfig | undefined;
+            // result.faceGroups & params.featureColors are typed as non-null
+            // here, but the runtime guard is intentional belt-and-suspenders
+            // against shape drift in the generation pipeline.
+            /* eslint-disable @typescript-eslint/no-unnecessary-condition */
             if (
               isFeatureEnabled('multi_color_export') &&
               result.faceGroups &&
               params.featureColors
             ) {
+              /* eslint-enable @typescript-eslint/no-unnecessary-condition */
               const triangleCount = vertices.length / 9;
               colorConfig =
                 buildTriangleMaterialIndices(
@@ -209,12 +214,17 @@ export function useExport(): UseExportReturn {
 
               // Only apply color config to the bin piece (first piece)
               let colorConfig: ThreeMFColorConfig | undefined;
+              // result.faceGroups & params.featureColors are typed as non-null
+              // here, but the runtime guard mirrors the single-piece branch
+              // above as belt-and-suspenders against pipeline shape drift.
+              /* eslint-disable @typescript-eslint/no-unnecessary-condition */
               if (
                 i === 0 &&
                 isFeatureEnabled('multi_color_export') &&
                 result.faceGroups &&
                 params.featureColors
               ) {
+                /* eslint-enable @typescript-eslint/no-unnecessary-condition */
                 const triangleCount = parseResult.value.vertices.length / 9;
                 colorConfig =
                   buildTriangleMaterialIndices(

--- a/src/features/generation/worker/generators/__dual-kernel__/dualKernelInit.ts
+++ b/src/features/generation/worker/generators/__dual-kernel__/dualKernelInit.ts
@@ -118,6 +118,9 @@ export function collectTopologyStatsRaw(
   // (boundary edges from edge splitting, non-shared edges at face junctions).
   // Strict validation would flag these as errors. Relaxed checks only for
   // degenerate faces, matching OCCT's effective validation level.
+  // rawKernel is the WASM module export; its return types aren't fully
+  // declared in the kernel binding shim.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const validationIssues = rawKernel.validateSolidRelaxed(solidId);
   return {
     isValid: validationIssues === 0,

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -423,6 +423,7 @@ function buildTopShapeLoft(
     }
 
     // Fillet the peak edge (only when TOP_FILLET > 0; spec default is 0)
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- TOP_FILLET is a tunable constant; default is 0 but build can override
     if (TOP_FILLET > 0) {
       const lipEdges = edgeFinder()
         .when((e) => {
@@ -505,6 +506,7 @@ function buildTopShapeSweep(
       swept = unwrap(fuse(swept, holeLip));
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- TOP_FILLET is a tunable constant; default is 0 but build can override
     if (TOP_FILLET > 0) {
       const lipEdges = edgeFinder()
         .when((e) => {

--- a/src/features/generation/worker/generators/wallPatternBuilder.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.ts
@@ -234,6 +234,9 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
       params.handles.enabled &&
       !dim.isSlotted &&
       handleWall &&
+      // Record<Side, HandleSide> is exhaustive in the type system, but
+      // legacy persisted configs may have missing keys.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       params.handles[wall.side]?.enabled &&
       !(wall.side === 'back' && params.label.enabled)
     ) {

--- a/src/features/generation/worker/handlers/exportHandler.ts
+++ b/src/features/generation/worker/handlers/exportHandler.ts
@@ -109,6 +109,9 @@ export async function handleExportCombined(message: ExportCombinedMessage): Prom
         const binSolid = getLastSolid();
         if (!binSolid) throw new Error('Failed to get bin solid for compound assembly');
 
+        // gridUnitMm is typed required, but persisted configs predating the
+        // field may not have it; preserve the runtime fallback.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         const gridUnitMm = params.gridUnitMm ?? GRIDFINITY.GRID_SIZE;
         const outerW = params.width * gridUnitMm - GRIDFINITY.TOLERANCE;
         const outerD = params.depth * gridUnitMm - GRIDFINITY.TOLERANCE;

--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreviewControls.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreviewControls.tsx
@@ -252,14 +252,14 @@ export function IsometricPreviewControls({
                   toggleExplodedView();
                 }}
                 className={`flex items-center justify-center transition-colors ${
-                  isPreviewExpanded && !isMobile
+                  isPreviewExpanded
                     ? `btn ${isExplodedView ? 'btn-primary' : 'btn-ghost'} gap-2 px-3 py-2 rounded-md`
                     : `w-7 h-7 ${isExplodedView ? 'bg-accent text-on-dark' : 'hover:bg-surface-elevated'}`
                 }`}
                 title={t('grid.explodedView.toggle')}
               >
                 <svg
-                  className={isPreviewExpanded && !isMobile ? 'w-5 h-5' : 'w-3.5 h-3.5'}
+                  className={isPreviewExpanded ? 'w-5 h-5' : 'w-3.5 h-3.5'}
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -272,7 +272,7 @@ export function IsometricPreviewControls({
                   <path d="M2 14l10 5 10-5" />
                   <path d="M2 20l10 5 10-5" />
                 </svg>
-                {isPreviewExpanded && !isMobile && (
+                {isPreviewExpanded && (
                   <span className="text-xs">{t('grid.explodedView.label')}</span>
                 )}
               </button>

--- a/src/features/onboarding/hooks/useOnboarding.test.ts
+++ b/src/features/onboarding/hooks/useOnboarding.test.ts
@@ -86,7 +86,11 @@ describe('useOnboarding', () => {
       });
 
       function setPathname(path: string) {
+        // Spreading the Location class instance is intentional here — the
+        // test only reads enumerable string properties on the result, never
+        // calls prototype methods (assign/replace/reload).
         Object.defineProperty(window, 'location', {
+          // eslint-disable-next-line @typescript-eslint/no-misused-spread
           value: { ...originalLocation, pathname: path },
           writable: true,
         });

--- a/src/shared/analytics/posthog/events.ts
+++ b/src/shared/analytics/posthog/events.ts
@@ -645,7 +645,8 @@ export function captureUtmParameters(): void {
     for (const key of utmKeys) {
       url.searchParams.delete(key);
     }
-    const currentState = window.history.state ?? null;
+    // window.history.state is typed as `any` by the DOM lib; widen to `unknown`.
+    const currentState: unknown = window.history.state ?? null;
     window.history.replaceState(currentState, '', url.toString());
   } catch {
     // Fail silently


### PR DESCRIPTION
## Summary

Brings `src/` lint to **0 errors / 20 warnings**, all of which are `max-lines` (deferred to the structural extraction PRs). The other ~30 warnings — `no-unnecessary-condition`, `no-unsafe-assignment`, `no-misused-spread` — are addressed here, each on its own merit.

### Removed (genuine dead code)

- `IsometricPreviewControls.tsx`: three `&& !isMobile` guards inside a parent that already gates on `!isMobile`. The inner checks were always-truthy.
- `undoCapture.ts`: three `mlTracking.recordAction?.()` calls; the method is always defined on the exported object literal.
- `events.ts`: typed `currentState` as `unknown` (DOM `History.state` is `any`) — preserves runtime semantics with a clean type, no disable needed.

### Suppressed with `eslint-disable` + reason (defense kept)

The runtime invariants are real even though the types erase them — these aren't blanket suppressions, each has a concrete justification in the comment:

- `middlewareConfig.ts`: `?? PROFILES.domain` fallback. Records typed exhaustively but `validationMiddleware.test.ts` exercises the unregistered-command-type branch — fallback is genuinely needed and tested.
- `undoCapture.ts` (2 sites): `batchCommandType ?? 'unknown'`. The variable IS mutated by inner middleware via `fn()`, but TS's flow analysis can't see across that boundary.
- `defaults.ts` (3 sites): `LEGACY_SLOT_COLORS[raw.body as string]` lookups. `Record<string, string>` is `string` per TS with `noUncheckedIndexedAccess: false`, but the runtime path for unmapped legacy slot names is exactly why the `??` chain exists.
- `ColorsSection` / `BinMesh` (4 sites): `featureColors ?? null` and downstream null-guards. Legacy persisted configs may omit `featureColors`.
- `useExport.ts` (2 blocks): pipeline shape-drift defense.
- `wallPatternBuilder.ts`: `params.handles[wall.side]?.enabled`. `Record<Side, HandleSide>` is exhaustive in types, but legacy configs may have missing keys.
- `exportHandler.ts`: `params.gridUnitMm ?? GRIDFINITY.GRID_SIZE` for older saved designs.
- `boxBuilder.ts` (2 sites): two `if (TOP_FILLET > 0)` blocks. `TOP_FILLET` is a tunable constant (currently 0); removing the dead-block would lose the tuning point.
- `svgParser.ts`: `parseError.textContent ?? undefined` for the `string | null` → `string | undefined` conversion.
- `dualKernelInit.ts`: WASM kernel call returns `any`.
- `useBaseplateGeneration` / `useShapeSection`: `new Array(n)` returns `any[]`; pre-sized typed-slot pattern.
- `useOnboarding.test.ts`: spreading the `Location` class instance is intentional (test only reads enumerable string properties).

## Test plan

- [x] `pnpm exec eslint src` — 0 errors / 20 warnings (all `max-lines`)
- [x] `pnpm exec vitest run src/core/cqrs/validation/validationMiddleware.test.ts` — 15/15 pass (this is the test that gates the `middlewareConfig.ts` fallback)
- [x] All pre-commit hooks pass