### PR TITLE
chore(lint): drive lint to zero warnings + remove dead deprecated alias

### DIFF
--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -143,12 +143,13 @@ function validateCellMask(mask: unknown): string | null {
     return `cellMask.rows must be integer 1-${CONSTRAINTS.MAX_MASK_DIMENSION}`;
   }
   if (!Array.isArray(mask.cells)) return 'cellMask.cells must be an array';
+  const cells = mask.cells as unknown[];
   const expected = mask.cols * mask.rows;
-  if (mask.cells.length !== expected) {
+  if (cells.length !== expected) {
     return `cellMask.cells length must be cols × rows (${expected})`;
   }
-  for (let i = 0; i < mask.cells.length; i++) {
-    const v = mask.cells[i];
+  for (let i = 0; i < cells.length; i++) {
+    const v = cells[i];
     if (v !== 0 && v !== 1) return `cellMask.cells[${i}] must be 0 or 1`;
   }
   return null;

--- a/api/lib/logger.test.ts
+++ b/api/lib/logger.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console -- this file tests the logger by mocking and
+ * asserting against console.log/warn/error; references are intentional. */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { logger } from './logger';
 

--- a/api/lib/mlTelemetry/validators.constants.ts
+++ b/api/lib/mlTelemetry/validators.constants.ts
@@ -1,19 +1,29 @@
 /**
  * Validation constants for ML telemetry events.
  *
- * Regex patterns and `Set`s of allowed enum values used across event-shape
- * validators. Kept in a dedicated module so `validators.ts` stays focused on
- * the validation dispatch logic.
+ * Regex patterns and `ReadonlySet`s of allowed enum values used across
+ * event-shape validators. Kept in a dedicated module so `validators.ts` stays
+ * focused on the validation dispatch logic.
  *
- * Security note: the regex constants prefixed with `VALID_*_REGEX` are
+ * Security note 1: the regex constants prefixed with `VALID_*_REGEX` are
  * deliberately strict because the matched values are interpolated into
  * Redis keys downstream — anything more permissive risks key injection.
+ *
+ * Security note 2: the allowed-value sets are exported as `ReadonlySet<string>`
+ * to prevent importers from calling `.add()` / `.delete()` and silently
+ * weakening these security-sensitive validators at runtime.
  */
 
 export const VALID_BIN_SIZE_REGEX = /^\d+(\.\d+)?x\d+(\.\d+)?x\d+(\.\d+)?$/;
 export const VALID_DRAWER_SIZE_REGEX = /^\d+(\.\d+)?x\d+(\.\d+)?x\d+(\.\d+)?$/;
-export const VALID_GAP_FIT = new Set(['exact', 'partial', 'none']);
-export const VALID_METHODS = new Set(['draw', 'fill', 'duplicate', 'staging', 'paint']);
+export const VALID_GAP_FIT: ReadonlySet<string> = new Set(['exact', 'partial', 'none']);
+export const VALID_METHODS: ReadonlySet<string> = new Set([
+  'draw',
+  'fill',
+  'duplicate',
+  'staging',
+  'paint',
+]);
 
 // Security: Strict validation for fields used in Redis keys to prevent injection
 export const VALID_LABEL_HASH_REGEX = /^[a-f0-9]{8}$/; // 8-char hex hash
@@ -21,7 +31,7 @@ export const VALID_LAYOUT_HASH_REGEX = /^[a-f0-9]{8}$/; // 8-char hex hash
 export const VALID_NORMALIZED_LABEL_REGEX = /^[a-z][a-z0-9_]{0,31}$/; // lowercase, alphanumeric + underscore
 export const VALID_CATEGORY_ID_REGEX = /^[a-zA-Z0-9_-]{1,36}$/; // UUID-like or simple ID
 export const VALID_EMBEDDING_BUCKET_REGEX = /^[a-f0-9]{4}$/; // 4-char hex embedding bucket
-export const VALID_DOMAINS = new Set([
+export const VALID_DOMAINS: ReadonlySet<string> = new Set([
   'tools',
   'fasteners',
   'electronics',
@@ -33,7 +43,7 @@ export const VALID_DOMAINS = new Set([
 ]);
 
 // Layout snapshot validation
-export const VALID_TRIGGERS = new Set([
+export const VALID_TRIGGERS: ReadonlySet<string> = new Set([
   'save',
   'export_json',
   'export_tsv',
@@ -44,7 +54,7 @@ export const VALID_TRIGGERS = new Set([
   'idle',
   'print_preview',
 ]);
-export const VALID_QUALITY_SIGNALS = new Set([
+export const VALID_QUALITY_SIGNALS: ReadonlySet<string> = new Set([
   'shared',
   'exported',
   'duplicated',
@@ -53,8 +63,13 @@ export const VALID_QUALITY_SIGNALS = new Set([
   'revisited_kept',
   'modified',
 ]);
-export const VALID_ABANDONMENT_TYPES = new Set(['incomplete', 'deleted', 'dormant', 'superseded']);
-export const VALID_PURPOSES = new Set([
+export const VALID_ABANDONMENT_TYPES: ReadonlySet<string> = new Set([
+  'incomplete',
+  'deleted',
+  'dormant',
+  'superseded',
+]);
+export const VALID_PURPOSES: ReadonlySet<string> = new Set([
   'workshop',
   'electronics',
   'office',
@@ -65,23 +80,33 @@ export const VALID_PURPOSES = new Set([
   'other',
 ]);
 export const VALID_PURPOSE_REGEX = /^[a-z][a-z0-9_-]{0,31}$/; // For custom purposes
-export const VALID_QUALITY_TIERS = new Set(['high', 'medium', 'low', 'skip']);
-export const VALID_DELETE_METHODS = new Set(['key', 'context_menu', 'bulk', 'inspector']);
-export const VALID_MOVE_METHODS = new Set(['drag', 'nudge']);
+export const VALID_QUALITY_TIERS: ReadonlySet<string> = new Set(['high', 'medium', 'low', 'skip']);
+export const VALID_DELETE_METHODS: ReadonlySet<string> = new Set([
+  'key',
+  'context_menu',
+  'bulk',
+  'inspector',
+]);
+export const VALID_MOVE_METHODS: ReadonlySet<string> = new Set(['drag', 'nudge']);
 export const VALID_POSITION_REGEX = /^\d+(\.\d+)?,\d+(\.\d+)?$/; // e.g., "3,5" or "3.5,2.5"
-export const VALID_FILL_METHODS = new Set(['uniform', 'gaps']);
-export const VALID_LAYER_MOVE_METHODS = new Set(['inspector', 'drag', 'keyboard', 'context_menu']);
+export const VALID_FILL_METHODS: ReadonlySet<string> = new Set(['uniform', 'gaps']);
+export const VALID_LAYER_MOVE_METHODS: ReadonlySet<string> = new Set([
+  'inspector',
+  'drag',
+  'keyboard',
+  'context_menu',
+]);
 export const VALID_FILL_SIZE_REGEX = /^\d+(\.\d+)?x\d+(\.\d+)?$/; // WxD (no height)
 
 // Negative signal validation
-export const VALID_REJECTION_REASONS = new Set([
+export const VALID_REJECTION_REASONS: ReadonlySet<string> = new Set([
   'cancelled',
   'second_touch',
   'outside_bounds',
   'too_small',
 ]);
-export const VALID_DRAW_MODES = new Set(['draw', 'paint']);
-export const VALID_UNDO_ACTIONS = new Set([
+export const VALID_DRAW_MODES: ReadonlySet<string> = new Set(['draw', 'paint']);
+export const VALID_UNDO_ACTIONS: ReadonlySet<string> = new Set([
   'placement',
   'deletion',
   'move',
@@ -91,18 +116,18 @@ export const VALID_UNDO_ACTIONS = new Set([
   'drawer_resize',
   'other',
 ]);
-export const VALID_CORRECTION_TYPES = new Set(['delete', 'resize', 'move']);
-export const VALID_RESIZE_DIRECTIONS = new Set(['grow', 'shrink', 'mixed']);
+export const VALID_CORRECTION_TYPES: ReadonlySet<string> = new Set(['delete', 'resize', 'move']);
+export const VALID_RESIZE_DIRECTIONS: ReadonlySet<string> = new Set(['grow', 'shrink', 'mixed']);
 
 // Pattern detection validation
-export const VALID_ARCHETYPES = new Set([
+export const VALID_ARCHETYPES: ReadonlySet<string> = new Set([
   'uniform',
   'mixed',
   'border_fill',
   'compartmentalized',
   'layered',
 ]);
-export const VALID_SPATIAL_PATTERNS = new Set([
+export const VALID_SPATIAL_PATTERNS: ReadonlySet<string> = new Set([
   'corner_start',
   'large_first',
   'category_grouped',

--- a/api/lib/mlTelemetry/validators.constants.ts
+++ b/api/lib/mlTelemetry/validators.constants.ts
@@ -1,0 +1,111 @@
+/**
+ * Validation constants for ML telemetry events.
+ *
+ * Regex patterns and `Set`s of allowed enum values used across event-shape
+ * validators. Kept in a dedicated module so `validators.ts` stays focused on
+ * the validation dispatch logic.
+ *
+ * Security note: the regex constants prefixed with `VALID_*_REGEX` are
+ * deliberately strict because the matched values are interpolated into
+ * Redis keys downstream — anything more permissive risks key injection.
+ */
+
+export const VALID_BIN_SIZE_REGEX = /^\d+(\.\d+)?x\d+(\.\d+)?x\d+(\.\d+)?$/;
+export const VALID_DRAWER_SIZE_REGEX = /^\d+(\.\d+)?x\d+(\.\d+)?x\d+(\.\d+)?$/;
+export const VALID_GAP_FIT = new Set(['exact', 'partial', 'none']);
+export const VALID_METHODS = new Set(['draw', 'fill', 'duplicate', 'staging', 'paint']);
+
+// Security: Strict validation for fields used in Redis keys to prevent injection
+export const VALID_LABEL_HASH_REGEX = /^[a-f0-9]{8}$/; // 8-char hex hash
+export const VALID_LAYOUT_HASH_REGEX = /^[a-f0-9]{8}$/; // 8-char hex hash
+export const VALID_NORMALIZED_LABEL_REGEX = /^[a-z][a-z0-9_]{0,31}$/; // lowercase, alphanumeric + underscore
+export const VALID_CATEGORY_ID_REGEX = /^[a-zA-Z0-9_-]{1,36}$/; // UUID-like or simple ID
+export const VALID_EMBEDDING_BUCKET_REGEX = /^[a-f0-9]{4}$/; // 4-char hex embedding bucket
+export const VALID_DOMAINS = new Set([
+  'tools',
+  'fasteners',
+  'electronics',
+  'office',
+  'craft',
+  'printing_3d',
+  'cosmetics',
+  'misc',
+]);
+
+// Layout snapshot validation
+export const VALID_TRIGGERS = new Set([
+  'save',
+  'export_json',
+  'export_tsv',
+  'share',
+  'print',
+  'session_end',
+  'layout_switch',
+  'idle',
+  'print_preview',
+]);
+export const VALID_QUALITY_SIGNALS = new Set([
+  'shared',
+  'exported',
+  'duplicated',
+  'deleted',
+  'revisited_edited',
+  'revisited_kept',
+  'modified',
+]);
+export const VALID_ABANDONMENT_TYPES = new Set(['incomplete', 'deleted', 'dormant', 'superseded']);
+export const VALID_PURPOSES = new Set([
+  'workshop',
+  'electronics',
+  'office',
+  'craft',
+  'kitchen',
+  'bathroom',
+  'garage',
+  'other',
+]);
+export const VALID_PURPOSE_REGEX = /^[a-z][a-z0-9_-]{0,31}$/; // For custom purposes
+export const VALID_QUALITY_TIERS = new Set(['high', 'medium', 'low', 'skip']);
+export const VALID_DELETE_METHODS = new Set(['key', 'context_menu', 'bulk', 'inspector']);
+export const VALID_MOVE_METHODS = new Set(['drag', 'nudge']);
+export const VALID_POSITION_REGEX = /^\d+(\.\d+)?,\d+(\.\d+)?$/; // e.g., "3,5" or "3.5,2.5"
+export const VALID_FILL_METHODS = new Set(['uniform', 'gaps']);
+export const VALID_LAYER_MOVE_METHODS = new Set(['inspector', 'drag', 'keyboard', 'context_menu']);
+export const VALID_FILL_SIZE_REGEX = /^\d+(\.\d+)?x\d+(\.\d+)?$/; // WxD (no height)
+
+// Negative signal validation
+export const VALID_REJECTION_REASONS = new Set([
+  'cancelled',
+  'second_touch',
+  'outside_bounds',
+  'too_small',
+]);
+export const VALID_DRAW_MODES = new Set(['draw', 'paint']);
+export const VALID_UNDO_ACTIONS = new Set([
+  'placement',
+  'deletion',
+  'move',
+  'resize',
+  'fill',
+  'layer_change',
+  'drawer_resize',
+  'other',
+]);
+export const VALID_CORRECTION_TYPES = new Set(['delete', 'resize', 'move']);
+export const VALID_RESIZE_DIRECTIONS = new Set(['grow', 'shrink', 'mixed']);
+
+// Pattern detection validation
+export const VALID_ARCHETYPES = new Set([
+  'uniform',
+  'mixed',
+  'border_fill',
+  'compartmentalized',
+  'layered',
+]);
+export const VALID_SPATIAL_PATTERNS = new Set([
+  'corner_start',
+  'large_first',
+  'category_grouped',
+  'edge_aligned',
+  'center_out',
+]);

--- a/api/lib/mlTelemetry/validators.ts
+++ b/api/lib/mlTelemetry/validators.ts
@@ -1,108 +1,35 @@
 import type { ConfidenceBreakdown, EdgeUsage, MLTelemetryEvent, SpatialPattern } from './types.js';
-
-// ============================================
-// VALIDATION
-// ============================================
-
-const VALID_BIN_SIZE_REGEX = /^\d+(\.\d+)?x\d+(\.\d+)?x\d+(\.\d+)?$/;
-const VALID_DRAWER_SIZE_REGEX = /^\d+(\.\d+)?x\d+(\.\d+)?x\d+(\.\d+)?$/;
-const VALID_GAP_FIT = new Set(['exact', 'partial', 'none']);
-const VALID_METHODS = new Set(['draw', 'fill', 'duplicate', 'staging', 'paint']);
-
-// Security: Strict validation for fields used in Redis keys to prevent injection
-const VALID_LABEL_HASH_REGEX = /^[a-f0-9]{8}$/; // 8-char hex hash
-const VALID_LAYOUT_HASH_REGEX = /^[a-f0-9]{8}$/; // 8-char hex hash
-const VALID_NORMALIZED_LABEL_REGEX = /^[a-z][a-z0-9_]{0,31}$/; // lowercase, alphanumeric + underscore
-const VALID_CATEGORY_ID_REGEX = /^[a-zA-Z0-9_-]{1,36}$/; // UUID-like or simple ID
-const VALID_EMBEDDING_BUCKET_REGEX = /^[a-f0-9]{4}$/; // 4-char hex embedding bucket
-const VALID_DOMAINS = new Set([
-  'tools',
-  'fasteners',
-  'electronics',
-  'office',
-  'craft',
-  'printing_3d',
-  'cosmetics',
-  'misc',
-]);
-
-// Layout snapshot validation
-const VALID_TRIGGERS = new Set([
-  'save',
-  'export_json',
-  'export_tsv',
-  'share',
-  'print',
-  'session_end',
-  'layout_switch',
-  'idle',
-  'print_preview',
-]);
-const VALID_QUALITY_SIGNALS = new Set([
-  'shared',
-  'exported',
-  'duplicated',
-  'deleted',
-  'revisited_edited',
-  'revisited_kept',
-  'modified',
-]);
-const VALID_ABANDONMENT_TYPES = new Set(['incomplete', 'deleted', 'dormant', 'superseded']);
-const VALID_PURPOSES = new Set([
-  'workshop',
-  'electronics',
-  'office',
-  'craft',
-  'kitchen',
-  'bathroom',
-  'garage',
-  'other',
-]);
-const VALID_PURPOSE_REGEX = /^[a-z][a-z0-9_-]{0,31}$/; // For custom purposes
-const VALID_QUALITY_TIERS = new Set(['high', 'medium', 'low', 'skip']);
-const VALID_DELETE_METHODS = new Set(['key', 'context_menu', 'bulk', 'inspector']);
-const VALID_MOVE_METHODS = new Set(['drag', 'nudge']);
-const VALID_POSITION_REGEX = /^\d+(\.\d+)?,\d+(\.\d+)?$/; // e.g., "3,5" or "3.5,2.5"
-const VALID_FILL_METHODS = new Set(['uniform', 'gaps']);
-const VALID_LAYER_MOVE_METHODS = new Set(['inspector', 'drag', 'keyboard', 'context_menu']);
-const VALID_FILL_SIZE_REGEX = /^\d+(\.\d+)?x\d+(\.\d+)?$/; // WxD (no height)
-
-// Negative signal validation
-const VALID_REJECTION_REASONS = new Set([
-  'cancelled',
-  'second_touch',
-  'outside_bounds',
-  'too_small',
-]);
-const VALID_DRAW_MODES = new Set(['draw', 'paint']);
-const VALID_UNDO_ACTIONS = new Set([
-  'placement',
-  'deletion',
-  'move',
-  'resize',
-  'fill',
-  'layer_change',
-  'drawer_resize',
-  'other',
-]);
-const VALID_CORRECTION_TYPES = new Set(['delete', 'resize', 'move']);
-const VALID_RESIZE_DIRECTIONS = new Set(['grow', 'shrink', 'mixed']);
-
-// Pattern detection validation
-const VALID_ARCHETYPES = new Set([
-  'uniform',
-  'mixed',
-  'border_fill',
-  'compartmentalized',
-  'layered',
-]);
-const VALID_SPATIAL_PATTERNS = new Set([
-  'corner_start',
-  'large_first',
-  'category_grouped',
-  'edge_aligned',
-  'center_out',
-]);
+import {
+  VALID_ABANDONMENT_TYPES,
+  VALID_ARCHETYPES,
+  VALID_BIN_SIZE_REGEX,
+  VALID_CATEGORY_ID_REGEX,
+  VALID_CORRECTION_TYPES,
+  VALID_DELETE_METHODS,
+  VALID_DOMAINS,
+  VALID_DRAW_MODES,
+  VALID_DRAWER_SIZE_REGEX,
+  VALID_EMBEDDING_BUCKET_REGEX,
+  VALID_FILL_METHODS,
+  VALID_FILL_SIZE_REGEX,
+  VALID_GAP_FIT,
+  VALID_LABEL_HASH_REGEX,
+  VALID_LAYER_MOVE_METHODS,
+  VALID_LAYOUT_HASH_REGEX,
+  VALID_METHODS,
+  VALID_MOVE_METHODS,
+  VALID_NORMALIZED_LABEL_REGEX,
+  VALID_POSITION_REGEX,
+  VALID_PURPOSE_REGEX,
+  VALID_PURPOSES,
+  VALID_QUALITY_SIGNALS,
+  VALID_QUALITY_TIERS,
+  VALID_REJECTION_REASONS,
+  VALID_RESIZE_DIRECTIONS,
+  VALID_SPATIAL_PATTERNS,
+  VALID_TRIGGERS,
+  VALID_UNDO_ACTIONS,
+} from './validators.constants.js';
 
 /**
  * Validate spatial patterns array.

--- a/src/features/layout-library/components/LayoutManagerModal/LayoutManagerModal.test.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutManagerModal.test.tsx
@@ -195,6 +195,7 @@ vi.mock('@/shared/analytics/useMLTracking', () => ({
     trackSession: vi.fn(),
     incrementEdit: vi.fn(),
     markActivity: vi.fn(),
+    recordAction: vi.fn(),
   },
 }));
 

--- a/src/shared/hooks/useLayoutSwitcher.test.ts
+++ b/src/shared/hooks/useLayoutSwitcher.test.ts
@@ -189,6 +189,7 @@ vi.mock('@/shared/analytics/useMLTracking', () => ({
     trackSession: vi.fn(),
     incrementEdit: vi.fn(),
     markActivity: vi.fn(),
+    recordAction: vi.fn(),
   },
 }));
 

--- a/src/shared/utils/handleCutoutClip.ts
+++ b/src/shared/utils/handleCutoutClip.ts
@@ -37,8 +37,6 @@ export interface HandleWallDef {
 export const DEFAULT_VERTICAL_POSITION = 0.7;
 /** U-shape floor overshoot for clean boolean cut (mm). */
 export const U_SHAPE_OVERSHOOT = 5;
-/** @deprecated Use DEFAULT_VERTICAL_POSITION instead */
-export const HOLE_VERTICAL_CENTER = DEFAULT_VERTICAL_POSITION;
 /** Clearance gap between handle edge and cutout edge (mm). */
 export const CUTOUT_CLEARANCE = 1.0;
 /** Minimum handle segment width to generate (mm). */


### PR DESCRIPTION
## Summary

Continues the case-by-case audit from #1459/#1460 — clears the last 9 ESLint warnings without touching the `max-lines` allowlist. After this PR the repo lints with **0 errors, 0 warnings**.

- **`designerValidation.ts`** — narrow `Array.isArray` result via an `unknown[]` local; fixes `no-unsafe-assignment` caused by TS widening `isArray`-checked unknowns to `any[]`.
- **`logger.test.ts`** — file-scoped `eslint-disable no-console` with justification: this is the logger's own test, and references to `console.log/warn/error` are intentional (mocking + assertions).
- **`mlTelemetry/validators.ts`** — extract regex/Set constants to a sibling `validators.constants.ts` (mirrors the split pattern from #1460). Brings effective LOC from 518 → ~418, well under the 500 `max-lines` threshold, without needing an allowlist entry.
- **`handleCutoutClip.ts`** — drop unused `@deprecated HOLE_VERTICAL_CENTER` alias (zero call sites repo-wide), per the no-backwards-compat-shims rule in `CLAUDE.md`.

## Test plan

- [x] `pnpm run lint` → 0 errors, 0 warnings
- [x] `pnpm run typecheck` → clean
- [x] `pnpm run test:run api/lib src/shared/utils/handleCutoutClip` → 114/114 passing
- [x] Pre-commit hooks (lint-staged, module boundaries, i18n × 4, exhaustiveness, component structure, missing tests) all green