### PR TITLE
chore(deps): bump brepjs 15.2.11 → 15.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@react-three/fiber": "^9.6.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/blob": "^2.3.3",
-    "brepjs": "15.2.11",
+    "brepjs": "15.6.1",
     "brepjs-opencascade": "0.15.6",
     "brepkit-wasm": "^2.43.10",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: ^2.3.3
         version: 2.3.3
       brepjs:
-        specifier: 15.2.11
-        version: 15.2.11(brepjs-opencascade@0.15.6)(brepkit-wasm@2.43.10)
+        specifier: 15.6.1
+        version: 15.6.1(brepjs-opencascade@0.15.6)(brepkit-wasm@2.43.10)
       brepjs-opencascade:
         specifier: 0.15.6
         version: 0.15.6
@@ -5075,10 +5075,10 @@ packages:
       }
     engines: { node: '>=24 <25' }
 
-  brepjs@15.2.11:
+  brepjs@15.6.1:
     resolution:
       {
-        integrity: sha512-iE61UgdGo/ep9WzpuGapspwrfTOGtj9VAO1IRWOm4RPn+RbL/dP+zhfRM2j235VXUPR4WgNMd875RxnrmEOHbw==,
+        integrity: sha512-OT7SKxqg8R97Gr6XQJdBFZCLBO915tKUuSPJ5hL+0Mk3LJXfWCSa920fz8w8pHAeaORG/UZZNkoV5bb3GgZMeg==,
       }
     engines: { node: '>=24' }
     peerDependencies:
@@ -12724,7 +12724,7 @@ snapshots:
 
   brepjs-opencascade@0.15.6: {}
 
-  brepjs@15.2.11(brepjs-opencascade@0.15.6)(brepkit-wasm@2.43.10):
+  brepjs@15.6.1(brepjs-opencascade@0.15.6)(brepkit-wasm@2.43.10):
     dependencies:
       flatbush: 4.5.1
       opentype.js: 1.3.4


### PR DESCRIPTION
## Summary

Bumps the geometry kernel from 15.2.11 to 15.6.1. All six in-version releases are **occt-wasm-only**:

| Version | Type | Change |
|---|---|---|
| 15.2.12 | fix | direction rotation in occt-wasm `makeCone`/`makeTorus` |
| 15.3.0 | feat | `exportSTEP{Assembly,Configured}` on occt-wasm |
| 15.4.0 | feat | `exportOBJ` on occt-wasm |
| 15.5.0 | feat | `exportPLY` + `exportGLB` on occt-wasm |
| 15.6.0 | feat | `createPoint2d` / `Direction2d` / `Vector2d` on occt-wasm |
| 15.6.1 | fix | per-face evolution in occt-wasm `applyComposedTransformWithHistory` |

This codebase uses **`brepkit-wasm`** as the production runtime kernel — `withKernel('occt', ...)` only appears inside the `__dual-kernel__/` parity test directory, which is excluded from the default test config and runs separately via `vitest.profile.config.ts`. None of these changes touch the production geometry path.

## Test plan

- [x] `pnpm run typecheck` → clean
- [x] `pnpm run lint` → 0 errors / 0 warnings
- [x] `pnpm run build` → succeeds in 1.82s; PWA precache identical (74 entries / 4897.36 KiB)
- [x] `pnpm run test:run` → **10094 / 10094 passing** across 688 files
- [x] `pnpm exec vitest run --config vitest.profile.config.ts __dual-kernel__/{exportParity,visualParity,topologyParity}` → same 22 pre-existing tight-tolerance parity failures (Euler / face-count / volume-within-0.1% asserts). Reproduced identically with this branch's changes stashed against main, so the bump introduces zero new regressions in the parity suite.