### PR TITLE
fix(analytics): defer DEFAULT_CATEGORIES read — fix blank-page on boot (#1466)

### DIFF
--- a/src/shared/analytics/posthog/metrics.ts
+++ b/src/shared/analytics/posthog/metrics.ts
@@ -96,7 +96,19 @@ export interface LayoutMetrics {
 
 export const DEFAULT_DRAWER = { width: 10, depth: 8, height: 12 };
 export const DEFAULT_PRINT_BED = 256;
-export const DEFAULT_CATEGORY_NAMES = new Set(DEFAULT_CATEGORIES.map((c) => c.name.toLowerCase()));
+
+// Lazily computed to avoid a top-level read of the imported DEFAULT_CATEGORIES
+// binding. In production, this module and src/core/constants land in chunks
+// that participate in a static-import cycle; reading the binding at module-init
+// time can resolve to undefined and crash app boot with a TypeError on .map.
+// See issue #1466.
+let defaultCategoryNamesCache: ReadonlySet<string> | null = null;
+export function getDefaultCategoryNames(): ReadonlySet<string> {
+  if (defaultCategoryNamesCache === null) {
+    defaultCategoryNamesCache = new Set(DEFAULT_CATEGORIES.map((c) => c.name.toLowerCase()));
+  }
+  return defaultCategoryNamesCache;
+}
 
 export function computeLayoutMetrics(layout: Layout): LayoutMetrics {
   const { gridBins, stagingBins } = splitBinsByLocation(layout.bins);
@@ -159,8 +171,9 @@ export function computeLayoutMetrics(layout: Layout): LayoutMetrics {
     .map(([id, count]) => ({ name: categoryIdToName.get(id as CategoryId) || 'Unknown', count }));
 
   // Custom categories (not matching default names)
+  const defaultCategoryNames = getDefaultCategoryNames();
   const customCategoryCount = layout.categories.filter(
-    (c) => !DEFAULT_CATEGORY_NAMES.has(c.name.toLowerCase())
+    (c) => !defaultCategoryNames.has(c.name.toLowerCase())
   ).length;
 
   // Print bed check


### PR DESCRIPTION
## Summary

Fixes #1466 — site renders a blank dark page with `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'map')` thrown from the `layout-*` chunk during initial mount.

## Root cause

`src/shared/analytics/posthog/metrics.ts` exported

```ts
export const DEFAULT_CATEGORY_NAMES = new Set(DEFAULT_CATEGORIES.map((c) => c.name.toLowerCase()));
```

at module top level. In production, this module and `src/core/constants` end up in chunks (`layout-*` and `main-*`) that **statically import each other** — i.e. they form a chunk-level ESM cycle.

When `main` starts evaluating and hits the static import of the layout chunk, the layout chunk's top-level statements run *before* `main` has finished initializing its exports. The imported `DEFAULT_CATEGORIES` binding therefore resolves to `undefined`, and `.map(...)` throws — aborting initial render. With cleared storage the error reproduces 100% of the time on first paint.

The cycle exists because `metrics.ts` imports `useLabsStore` from `@/core/store/labs`, while `labs.ts` imports `trackEvent` from `@/shared/analytics/posthog`, which re-exports `metrics.ts`. Vite 7 → 8 (#1464) likely rebalanced the chunking, creating this static cycle.

## Fix

Replace the eager top-level `new Set(...)` with a lazily-initialized helper. The binding is now read at first call (after both modules have finished evaluating), so there's nothing to crash at boot:

```ts
let defaultCategoryNamesCache: ReadonlySet<string> | null = null;
export function getDefaultCategoryNames(): ReadonlySet<string> {
  if (defaultCategoryNamesCache === null) {
    defaultCategoryNamesCache = new Set(DEFAULT_CATEGORIES.map((c) => c.name.toLowerCase()));
  }
  return defaultCategoryNamesCache;
}
```

Single call site updated. No behavior change at runtime — same Set, same membership semantics, same one-time computation.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` succeeds
- [x] `pnpm vitest run src/shared/analytics/posthog/posthog.test.ts` — 63/63 pass (existing `custom_category_count` test still asserts correctly)
- [x] Verify on Vercel preview that the deployed site renders (this is the actual repro path — vitest can't reproduce the bundled cycle)
- [ ] Confirm console no longer shows the `Cannot read properties of undefined (reading 'map')` error

## Follow-up (not in this PR)

The deeper cycle (`metrics.ts` ↔ `labs.ts` ↔ `posthog/index.ts`) should be broken — likely by extracting `trackEvent` into a leaf module that the labs store can import without dragging in the metrics layer. Worth doing in a separate PR; this fix unblocks production.