### PR TITLE
fix(baseplate): solid-infill slicing — broken STL winding heuristic (#1472)

### DIFF
--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.dovetail.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.dovetail.test.ts
@@ -218,3 +218,81 @@ describe('baseplateGenerator — dovetail export (issue #1407)', () => {
     TEST_TIMEOUT_MS
   );
 });
+
+/**
+ * Regression tests for issue #1472 — baseplates with fractional half-cells
+ * + dovetails + per-edge padding sliced as a solid block in slicers.
+ *
+ * The user's reproducer was a 19.5×9.5 split into 8 pieces. Several pieces
+ * combine half-cells, asymmetric padding, and dovetails — a configuration
+ * not covered by the #1407 tests. We verify the corner and edge tiles that
+ * carry the fractional column/row produce watertight STLs.
+ */
+describe('baseplateGenerator — fractional + dovetail export (issue #1472)', () => {
+  const TEST_TIMEOUT_MS = 60_000;
+
+  function expectWatertight(stats: StlStats, label: string): void {
+    expect(stats.nonManifoldEdges, `${label}: non-manifold edges`).toBe(0);
+    expect(stats.boundaryEdges, `${label}: boundary edges`).toBe(0);
+  }
+
+  it(
+    'fractional corner tile (4.5×4.5, padding, grooves only)',
+    async () => {
+      // corner-1 from the user's 19.5×9.5 split: front-left, half-cells
+      // on both axes, paddingLeft, only grooves (right + back are joins).
+      const params = defaults({
+        width: 4.5,
+        depth: 4.5,
+        paddingLeft: 7,
+        fractionalEdgeX: 'start',
+        fractionalEdgeY: 'start',
+        connectorNubs: true,
+        edges: { left: 'exterior', right: 'join', front: 'exterior', back: 'join' },
+      });
+
+      const { data } = await exportBaseplate(params, 'stl');
+      expectWatertight(analyzeManifold(data), '4.5×4.5 corner-1');
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    'fractional edge tile (5×4.5, tongue + grooves)',
+    async () => {
+      // edge-y-1: front edge of split, fractional in Y, all three of
+      // left/right/back are joins → tongue on left, grooves on right + back.
+      const params = defaults({
+        width: 5,
+        depth: 4.5,
+        fractionalEdgeY: 'start',
+        connectorNubs: true,
+        edges: { left: 'join', right: 'join', front: 'exterior', back: 'join' },
+      });
+
+      const { data } = await exportBaseplate(params, 'stl');
+      expectWatertight(analyzeManifold(data), '5×4.5 edge-y-1');
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    'fractional corner tile (4.5×5, padding both axes)',
+    async () => {
+      // corner-3: back-left of split, fractional in X, padding on left + back.
+      const params = defaults({
+        width: 4.5,
+        depth: 5,
+        paddingLeft: 7,
+        paddingBack: 6,
+        fractionalEdgeX: 'start',
+        connectorNubs: true,
+        edges: { left: 'exterior', right: 'join', front: 'join', back: 'exterior' },
+      });
+
+      const { data } = await exportBaseplate(params, 'stl');
+      expectWatertight(analyzeManifold(data), '4.5×5 corner-3');
+    },
+    TEST_TIMEOUT_MS
+  );
+});

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.dovetail.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.dovetail.test.ts
@@ -220,13 +220,14 @@ describe('baseplateGenerator — dovetail export (issue #1407)', () => {
 });
 
 /**
- * Regression tests for issue #1472 — baseplates with fractional half-cells
- * + dovetails + per-edge padding sliced as a solid block in slicers.
- *
- * The user's reproducer was a 19.5×9.5 split into 8 pieces. Several pieces
- * combine half-cells, asymmetric padding, and dovetails — a configuration
- * not covered by the #1407 tests. We verify the corner and edge tiles that
- * carry the fractional column/row produce watertight STLs.
+ * Watertight regression for the fractional + padded configurations from
+ * issue #1472. The actual root cause of #1472 (directed-edge winding
+ * collisions from a faulty STL writer heuristic) is covered by
+ * `baseplateGenerator.scenario.winding.test.ts`; this block only asserts
+ * the undirected/2-manifold property — boundary and non-manifold edge
+ * counts — for the half-cell + asymmetric-padding pieces from the user's
+ * 19.5×9.5 split-into-8 reproducer, which the existing #1407 dovetail
+ * tests didn't cover.
  */
 describe('baseplateGenerator — fractional + dovetail export (issue #1472)', () => {
   const TEST_TIMEOUT_MS = 60_000;

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.winding.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.winding.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment node
+/**
+ * Regression test for issue #1472 — Bambu Studio reported ~2138 "non-manifold
+ * edges" on every baseplate export. The root cause was the previous
+ * `buildBaseplateSTL` winding-correction heuristic: it flipped a triangle's
+ * winding whenever (cross · sum-of-vertex-normals) < 0. brepjs already
+ * tessellates faces with winding consistent with each face's BREP
+ * orientation, but along curved/shared edges its vertex normals are
+ * averaged across adjacent faces, so the heuristic mis-fired on ~7% of
+ * triangles and emitted them with reversed winding. Each reversed triangle
+ * shows up in the slicer as a directed-edge collision (a→b appearing twice
+ * in the same direction).
+ *
+ * This test verifies, on a representative slice of the user's exact
+ * 19.5 × 9.5 split-baseplate-with-dovetails reproducer, that every directed
+ * edge in the export appears at most once.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { BaseplateParams } from '@/shared/types/bin';
+import { isOk } from '@/core/result';
+import { parseSTLBinary } from '@/shared/generation/stlParser';
+import { initBrepjs } from './__dual-kernel__/wasmInit';
+
+type ExportFn = (
+  params: BaseplateParams,
+  format: 'stl'
+) => Promise<{ data: ArrayBuffer; fileName: string }>;
+
+let exportBaseplate: ExportFn;
+
+beforeAll(async () => {
+  await initBrepjs();
+  const mod = await import('./baseplateGenerator');
+  exportBaseplate = mod.exportBaseplate;
+}, 30000);
+
+const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+  width: 4.5,
+  depth: 4.5,
+  gridUnitMm: 42,
+  magnetHoles: false,
+  magnetDiameter: 6.5,
+  magnetDepth: 2.4,
+  paddingLeft: 0,
+  paddingRight: 0,
+  paddingFront: 0,
+  paddingBack: 0,
+  fractionalEdgeX: 'end',
+  fractionalEdgeY: 'end',
+  lightweight: true,
+  ...overrides,
+});
+
+/**
+ * Count directed edges (a→b) that appear more than once across all triangles.
+ * In a closed orientable mesh each directed edge appears at most once;
+ * duplicates indicate inconsistent triangle winding — which Bambu/Cura
+ * surface as "non-manifold edges" and repair as solid infill.
+ */
+function countWindingErrors(stl: ArrayBuffer): number {
+  const parsed = parseSTLBinary(stl);
+  if (!isOk(parsed)) throw new Error('STL parse failed');
+  const verts = parsed.value.vertices;
+  const triCount = verts.length / 9;
+
+  const QUANTIZE = 1e4;
+  const vKey = (x: number, y: number, z: number): string =>
+    `${Math.round(x * QUANTIZE)},${Math.round(y * QUANTIZE)},${Math.round(z * QUANTIZE)}`;
+  const seen = new Set<string>();
+  let dupes = 0;
+  for (let t = 0; t < triCount; t++) {
+    const b = t * 9;
+    const a = vKey(verts[b], verts[b + 1], verts[b + 2]);
+    const c = vKey(verts[b + 3], verts[b + 4], verts[b + 5]);
+    const d = vKey(verts[b + 6], verts[b + 7], verts[b + 8]);
+    for (const e of [`${a}->${c}`, `${c}->${d}`, `${d}->${a}`]) {
+      if (seen.has(e)) dupes++;
+      else seen.add(e);
+    }
+  }
+  return dupes;
+}
+
+describe('baseplateGenerator — directed-edge winding (issue #1472)', () => {
+  const TEST_TIMEOUT_MS = 60_000;
+
+  it(
+    'corner-1 (4.5×4.5, paddingLeft=7, no magnets, dovetail grooves) — winding consistent',
+    async () => {
+      const params = defaults({
+        width: 4.5,
+        depth: 4.5,
+        paddingLeft: 7,
+        fractionalEdgeX: 'start',
+        fractionalEdgeY: 'start',
+        connectorNubs: true,
+        edges: { left: 'exterior', right: 'join', front: 'exterior', back: 'join' },
+      });
+
+      const { data } = await exportBaseplate(params, 'stl');
+      expect(countWindingErrors(data)).toBe(0);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    'edge-y-1 (5×4.5, dovetail tongues + grooves) — winding consistent',
+    async () => {
+      const params = defaults({
+        width: 5,
+        depth: 4.5,
+        fractionalEdgeY: 'start',
+        connectorNubs: true,
+        edges: { left: 'join', right: 'join', front: 'exterior', back: 'join' },
+      });
+
+      const { data } = await exportBaseplate(params, 'stl');
+      expect(countWindingErrors(data)).toBe(0);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    'magnet baseplate with lightweight floor — winding consistent',
+    async () => {
+      // Cover the magnet-on path too: lightweight floor cutters introduce
+      // many curved/shared edges where the old heuristic was most fragile.
+      const params = defaults({
+        width: 5,
+        depth: 4,
+        magnetHoles: true,
+        connectorNubs: true,
+        edges: { left: 'exterior', right: 'join', front: 'join', back: 'join' },
+      });
+
+      const { data } = await exportBaseplate(params, 'stl');
+      expect(countWindingErrors(data)).toBe(0);
+    },
+    TEST_TIMEOUT_MS
+  );
+});

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -1294,23 +1294,29 @@ export async function exportBaseplate(
 }
 
 /**
- * Build binary STL from brepjs mesh output, correcting triangle winding.
+ * Build binary STL from brepjs mesh output.
  *
- * brepjs mesh() produces vertex normals that point outward from the solid,
- * but the triangle winding may not match STL's right-hand rule convention.
- * For each triangle we compute the cross-product normal from the winding
- * and flip the vertex order if it disagrees with the BREP normal.
+ * brepjs's `mesh()` already tessellates each face with winding consistent
+ * with that face's BREP orientation, so we trust its triangle order verbatim.
+ * The face normal we emit in the STL record is the cross-product of the
+ * winding edges — the same convention slicers reconstruct anyway.
+ *
+ * An earlier version flipped winding whenever
+ *   (cross · sum-of-vertex-normals) < 0
+ * to "fix" supposedly-bad output. brepjs returns averaged vertex normals at
+ * shared/curved edges (cell-corner gussets, magnet-hole rims, dovetail
+ * groove walls), so along ~7% of triangles the heuristic fired and emitted
+ * the triangle reversed. Bambu Studio + Cura then flagged thousands of
+ * "non-manifold edges" and repaired the result as solid infill (#1472).
  */
 function buildBaseplateSTL(
   meshResult: {
     vertices: ArrayLike<number>;
-    normals: ArrayLike<number>;
     triangles: ArrayLike<number>;
   },
   name: string
 ): ArrayBuffer {
   const verts = meshResult.vertices;
-  const norms = meshResult.normals;
   const tris = meshResult.triangles;
   const triangleCount = tris.length / 3;
 
@@ -1320,7 +1326,6 @@ function buildBaseplateSTL(
   const buffer = new ArrayBuffer(HEADER_SIZE + COUNT_SIZE + triangleCount * TRIANGLE_SIZE);
   const view = new DataView(buffer);
 
-  // Header
   const header = `Exported by Gridfinity Layout Tool - ${name}`;
   const headerBytes = new TextEncoder().encode(header);
   for (let i = 0; i < 80; i++) {
@@ -1331,56 +1336,35 @@ function buildBaseplateSTL(
   let offset = HEADER_SIZE + COUNT_SIZE;
   for (let t = 0; t < triangleCount; t++) {
     const i0 = tris[t * 3];
-    let i1 = tris[t * 3 + 1];
-    let i2 = tris[t * 3 + 2];
+    const i1 = tris[t * 3 + 1];
+    const i2 = tris[t * 3 + 2];
 
-    // Vertex positions
-    const v0x = verts[i0 * 3],
-      v0y = verts[i0 * 3 + 1],
-      v0z = verts[i0 * 3 + 2];
-    const v1x = verts[i1 * 3],
-      v1y = verts[i1 * 3 + 1],
-      v1z = verts[i1 * 3 + 2];
-    const v2x = verts[i2 * 3],
-      v2y = verts[i2 * 3 + 1],
-      v2z = verts[i2 * 3 + 2];
+    const v0x = verts[i0 * 3];
+    const v0y = verts[i0 * 3 + 1];
+    const v0z = verts[i0 * 3 + 2];
+    const v1x = verts[i1 * 3];
+    const v1y = verts[i1 * 3 + 1];
+    const v1z = verts[i1 * 3 + 2];
+    const v2x = verts[i2 * 3];
+    const v2y = verts[i2 * 3 + 1];
+    const v2z = verts[i2 * 3 + 2];
 
-    // Cross-product normal from winding order
-    const ex = v1x - v0x,
-      ey = v1y - v0y,
-      ez = v1z - v0z;
-    const fx = v2x - v0x,
-      fy = v2y - v0y,
-      fz = v2z - v0z;
-    let cx = ey * fz - ez * fy;
-    let cy = ez * fx - ex * fz;
-    let cz = ex * fy - ey * fx;
+    const ex = v1x - v0x;
+    const ey = v1y - v0y;
+    const ez = v1z - v0z;
+    const fx = v2x - v0x;
+    const fy = v2y - v0y;
+    const fz = v2z - v0z;
+    const cx = ey * fz - ez * fy;
+    const cy = ez * fx - ex * fz;
+    const cz = ex * fy - ey * fx;
 
-    // BREP vertex normal (average of triangle's vertex normals for comparison)
-    const bnx = norms[i0 * 3] + norms[i1 * 3] + norms[i2 * 3];
-    const bny = norms[i0 * 3 + 1] + norms[i1 * 3 + 1] + norms[i2 * 3 + 1];
-    const bnz = norms[i0 * 3 + 2] + norms[i1 * 3 + 2] + norms[i2 * 3 + 2];
-
-    // If cross-product disagrees with BREP normal, flip winding
-    const dot = cx * bnx + cy * bny + cz * bnz;
-    if (dot < 0) {
-      // Swap i1 and i2 to reverse winding
-      const tmp = i1;
-      i1 = i2;
-      i2 = tmp;
-      cx = -cx;
-      cy = -cy;
-      cz = -cz;
-    }
-
-    // Normalize for STL face normal
     const len = Math.sqrt(cx * cx + cy * cy + cz * cz) || 1;
     view.setFloat32(offset, cx / len, true);
     view.setFloat32(offset + 4, cy / len, true);
     view.setFloat32(offset + 8, cz / len, true);
     offset += 12;
 
-    // Vertices (using possibly-swapped order)
     for (const vi of [i0, i1, i2]) {
       view.setFloat32(offset, verts[vi * 3], true);
       view.setFloat32(offset + 4, verts[vi * 3 + 1], true);

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -1280,9 +1280,11 @@ export async function exportBaseplate(
       return { data, fileName: `${name}.step` };
     }
 
-    // STL — mesh the BREP and build binary STL with winding correction.
+    // STL — mesh the BREP and pack the triangles into a binary STL.
     // OCCT's StlAPI.Write fails on baseplate geometries, so we tessellate
-    // manually and fix triangle winding to match the STL right-hand rule.
+    // via brepjs `mesh()` and emit the records ourselves; brepjs already
+    // produces face-consistent winding so no per-triangle correction is
+    // applied (see #1472).
     const tol = tolerance ?? 0.01;
     const angTol = angularTolerance ?? 5;
     const meshResult = mesh(baseplate, { tolerance: tol, angularTolerance: angTol });


### PR DESCRIPTION
## Summary

- Removes the broken STL winding-correction heuristic in `buildBaseplateSTL`. brepjs's `mesh()` already tessellates with face-consistent winding, but the old code flipped triangles whenever `(cross_product · sum-of-vertex-normals) < 0` — and brepjs returns averaged vertex normals at curved/shared edges (cell-corner gussets, magnet rims, dovetail groove walls), so ~7% of triangles got reversed.
- Bambu Studio + Cura see each reversed triangle as a directed-edge collision and report the model as non-manifold; their auto-repair then floods it with infill. That's the user's "solid bottom layer" symptom — `2138` non-manifold edges on the 19.5×9.5 corner-1 export, exactly `2 × 1069` of the wrong-winding triangles I measured locally.
- New regression tests count directed edges (`a→b` distinct from `b→a`) on the user's exact piece configs (corner-1 grooves-only, edge-y-1 tongues+grooves) plus a magnet/lightweight-floor case where the old heuristic was most fragile. Watertight coverage from #1407 is preserved and extended to fractional-cell + padded variants.

Closes #1472.

## Test plan

- [x] `pnpm vitest run src/features/generation/worker/generators/baseplateGenerator.scenario.winding.test.ts` — all 3 cases pass
- [x] `pnpm vitest run src/features/generation/worker/generators/baseplateGenerator.scenario.dovetail.test.ts` — all 7 cases pass (4 existing #1407 + 3 new fractional)
- [x] `pnpm vitest run` full suite — 10100 / 10100 pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] Re-export 19.5×9.5 padded+connectors baseplate, slice in Bambu Studio, confirm 0 non-manifold edges and hollow cell pockets through the bottom face