### PR TITLE
feat(pwa): add tier-1 update smoke gate (CI)

### DIFF
--- a/.github/workflows/smoke-postpromote.yml
+++ b/.github/workflows/smoke-postpromote.yml
@@ -1,0 +1,120 @@
+name: Smoke (Post-Promote)
+
+# Runs the PWA smoke spec against production immediately after a successful
+# production deployment. On failure, rolls the production alias back to the
+# previous deployment and opens a GitHub issue with logs and version metadata.
+#
+# Requires VERCEL_TOKEN secret (and VERCEL_ORG_ID + VERCEL_PROJECT_ID for
+# `vercel rollback`). Add via the repo's Actions secrets.
+
+on:
+  deployment_status:
+
+permissions:
+  contents: read
+  deployments: read
+  issues: write
+
+concurrency:
+  group: smoke-postpromote-${{ github.event.deployment.environment }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: 24
+
+jobs:
+  smoke:
+    name: Production Smoke + Rollback
+    if: >-
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment == 'Production'
+    runs-on: ubuntu-latest
+    # Pin all event-derived inputs as env vars to dodge command-injection vectors
+    # if an attacker manages to influence the deployment payload.
+    env:
+      DEPLOY_URL: ${{ github.event.deployment_status.environment_url }}
+      DEPLOY_TARGET_URL: ${{ github.event.deployment_status.target_url }}
+      DEPLOY_SHA: ${{ github.event.deployment.sha }}
+      DEPLOY_ID: ${{ github.event.deployment.id }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve smoke target URL
+        id: target
+        run: |
+          url="${DEPLOY_URL:-$DEPLOY_TARGET_URL}"
+          if [ -z "$url" ]; then
+            echo "::error::No deployment URL in payload"
+            exit 1
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for CDN warm-up
+        # Vercel marks deploy success before the production alias is fully
+        # propagated through the CDN edge. 30s is empirically enough.
+        run: sleep 30
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run smoke spec against production
+        id: smoke
+        env:
+          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.target.outputs.url }}
+          CI: '1'
+        run: pnpm exec playwright test --config=playwright.smoke.config.ts
+
+      - name: Roll back production
+        if: failure() && steps.smoke.outcome == 'failure'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          # Don't await rollback completion — the alert is the actionable signal.
+          npx --yes vercel@latest rollback \
+            --token "$VERCEL_TOKEN" \
+            --scope "$VERCEL_ORG_ID" \
+            --yes || echo "rollback exited non-zero (continuing — issue will still be filed)"
+
+      - name: Open incident issue
+        if: failure() && steps.smoke.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          short_sha="${DEPLOY_SHA:0:7}"
+          gh issue create \
+            --label incident \
+            --title "Production smoke failed: $short_sha" \
+            --body "$(cat <<EOF
+          Post-promote smoke test failed. Production alias has been rolled back to the previous deployment (verify in Vercel dashboard).
+
+          - Failed deployment URL: ${DEPLOY_URL:-$DEPLOY_TARGET_URL}
+          - Failed deployment SHA: $DEPLOY_SHA
+          - Failed deployment ID: $DEPLOY_ID
+          - CI run: $RUN_URL
+
+          Investigate the smoke trace artifact, fix forward, and re-deploy.
+          EOF
+          )"
+
+      - name: Upload trace on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-postpromote-trace
+          path: test-results/
+          retention-days: 30

--- a/.github/workflows/smoke-postpromote.yml
+++ b/.github/workflows/smoke-postpromote.yml
@@ -82,7 +82,6 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           # Don't await rollback completion — the alert is the actionable signal.
           npx --yes vercel@latest rollback \

--- a/.github/workflows/smoke-postpromote.yml
+++ b/.github/workflows/smoke-postpromote.yml
@@ -74,6 +74,9 @@ jobs:
         id: smoke
         env:
           PLAYWRIGHT_TEST_BASE_URL: ${{ steps.target.outputs.url }}
+          # Production typically isn't protected, but pass the bypass header anyway
+          # in case the project is configured with "All Deployments" protection.
+          VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           CI: '1'
         run: pnpm exec playwright test --config=playwright.smoke.config.ts
 

--- a/.github/workflows/smoke-preview.yml
+++ b/.github/workflows/smoke-preview.yml
@@ -121,6 +121,10 @@ jobs:
         if: steps.preview.outputs.status == 'ready'
         env:
           PLAYWRIGHT_TEST_BASE_URL: ${{ steps.preview.outputs.url }}
+          # Required when Vercel deployment protection is enabled (it is by default
+          # for paid plans). Generate via Vercel project Settings → Deployment
+          # Protection → Protection Bypass for Automation.
+          VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           CI: '1'
         run: pnpm exec playwright test --config=playwright.smoke.config.ts
 

--- a/.github/workflows/smoke-preview.yml
+++ b/.github/workflows/smoke-preview.yml
@@ -1,0 +1,74 @@
+name: Smoke (Preview)
+
+# Runs the PWA smoke spec against the Vercel preview deployment for every PR.
+# Catches deploy-time bugs (broken precache, missing assets, wwwMigration-class
+# hash mismatches) before merge. Mark this as a required status check in branch
+# protection to block merges on smoke failure.
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/CODEOWNERS'
+
+permissions:
+  contents: read
+  pull-requests: read
+  deployments: read
+  statuses: read
+
+concurrency:
+  group: smoke-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: 24
+
+jobs:
+  smoke:
+    name: PWA Smoke Test
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Wait for Vercel preview
+        id: wait
+        # Polls the GitHub deployment_status API for the PR head SHA until a
+        # successful preview deployment appears. Returns its URL.
+        uses: patrickedqvist/wait-for-vercel-preview@v1.3.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 600
+          allow_inactive: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run smoke spec against preview
+        env:
+          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.wait.outputs.url }}
+          CI: '1'
+        run: pnpm exec playwright test --config=playwright.smoke.config.ts
+
+      - name: Upload trace on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-preview-trace
+          path: test-results/
+          retention-days: 7

--- a/.github/workflows/smoke-preview.yml
+++ b/.github/workflows/smoke-preview.yml
@@ -4,6 +4,10 @@ name: Smoke (Preview)
 # Catches deploy-time bugs (broken precache, missing assets, wwwMigration-class
 # hash mismatches) before merge. Mark this as a required status check in branch
 # protection to block merges on smoke failure.
+#
+# When the Vercel deploy is "ignored" by `scripts/vercel-ignore.sh` (e.g. a
+# PR that touches only CI / docs), there is no preview to smoke against.
+# The workflow exits success with a clear warning in that case.
 
 on:
   pull_request:
@@ -31,37 +35,92 @@ jobs:
     name: PWA Smoke Test
     if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
+    env:
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
       - uses: actions/checkout@v6
 
-      - name: Wait for Vercel preview
-        id: wait
-        # Polls the GitHub deployment_status API for the PR head SHA until a
-        # successful preview deployment appears. Returns its URL.
-        uses: patrickedqvist/wait-for-vercel-preview@v1.3.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 600
-          allow_inactive: false
+      - name: Resolve Vercel preview URL
+        id: preview
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Poll GitHub deployments API for up to 5 min looking for a successful
+          # Vercel preview matching this PR's head SHA. We can't use the third-party
+          # wait-for-vercel-preview action because (a) it pins to a tag and (b) it
+          # fails hard when Vercel's ignore step legitimately skips a deploy.
+          deadline=$(( $(date +%s) + 300 ))
+          url=""
+          ignored=""
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            # First: any deployment for this SHA?
+            deployment_id=$(gh api "repos/$GITHUB_REPOSITORY/deployments?sha=$HEAD_SHA&per_page=20" \
+              --jq '[.[] | select(.environment != "Production")] | .[0].id // empty')
+
+            if [ -n "$deployment_id" ]; then
+              status_json=$(gh api "repos/$GITHUB_REPOSITORY/deployments/$deployment_id/statuses?per_page=10")
+              state=$(echo "$status_json" | jq -r '.[0].state // ""')
+              candidate=$(echo "$status_json" | jq -r '.[0].environment_url // ""')
+              if [ "$state" = "success" ] && [[ "$candidate" == *.vercel.app* ]]; then
+                url="$candidate"
+                break
+              fi
+            fi
+
+            # Detect the Vercel "ignored build" case via PR-bot comment so we can
+            # exit cleanly instead of timing out.
+            if gh api "repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/comments" \
+                --jq '.[].body' \
+                | grep -qE 'Skipped Deployment|Ignored Build Step'; then
+              ignored=1
+              break
+            fi
+
+            sleep 10
+          done
+
+          if [ -n "$url" ]; then
+            echo "url=$url" >> "$GITHUB_OUTPUT"
+            echo "status=ready" >> "$GITHUB_OUTPUT"
+            echo "Resolved preview URL: $url"
+          elif [ -n "$ignored" ]; then
+            echo "status=ignored" >> "$GITHUB_OUTPUT"
+            echo "::warning::Vercel build was ignored for this PR — no preview to smoke against."
+          else
+            echo "status=timeout" >> "$GITHUB_OUTPUT"
+            echo "::error::Timed out waiting for Vercel preview after 5 min."
+            exit 1
+          fi
+
+      - name: Skip — no preview deployed
+        if: steps.preview.outputs.status == 'ignored'
+        run: |
+          echo "Vercel ignored this build (likely a CI/infra-only PR). Smoke is N/A."
+          echo "If this PR DOES touch SPA code, check scripts/vercel-ignore.sh."
 
       - name: Install pnpm
+        if: steps.preview.outputs.status == 'ready'
         uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
+        if: steps.preview.outputs.status == 'ready'
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: steps.preview.outputs.status == 'ready'
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Chromium
+        if: steps.preview.outputs.status == 'ready'
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run smoke spec against preview
+        if: steps.preview.outputs.status == 'ready'
         env:
-          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.wait.outputs.url }}
+          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.preview.outputs.url }}
           CI: '1'
         run: pnpm exec playwright test --config=playwright.smoke.config.ts
 

--- a/README.md
+++ b/README.md
@@ -61,11 +61,15 @@ Both rely on `?smoke=1`, which boots a synthetic fixture while skipping
 layout/library hydration, www-migration recovery, PostHog, and ML telemetry.
 See `src/shell/smokeBoot.tsx` and `e2e/smoke/`.
 
-**One-time setup required for `smoke-postpromote.yml`:**
+**One-time setup required for the smoke workflows:**
 
-- Add `VERCEL_TOKEN` and `VERCEL_ORG_ID` secrets so `vercel rollback` can run
-  on smoke failure (`vercel rollback` reads the linked project from the
-  deployment URL — no separate project ID needed).
+- `VERCEL_AUTOMATION_BYPASS_SECRET` — required by **both** smoke workflows when
+  the Vercel project has Deployment Protection enabled (default on paid plans).
+  Generate via Vercel project Settings → Deployment Protection → Protection
+  Bypass for Automation, then add as a GitHub Actions secret.
+- `VERCEL_TOKEN` and `VERCEL_ORG_ID` — required by `smoke-postpromote.yml` so
+  `vercel rollback` can run on smoke failure (`vercel rollback` reads the
+  linked project from the deployment URL — no separate project ID needed).
 - Add `smoke-preview` to branch protection's required status checks (Settings
   → Branches → main → Require status checks).
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,26 @@ pnpm run test:coverage # Unit tests with coverage
 pnpm run test:e2e      # Playwright end-to-end tests
 ```
 
+### PWA Update Smoke Gate
+
+A two-tier smoke harness verifies that a deploy is healthy before users see it:
+
+1. **CI smoke** — `.github/workflows/smoke-preview.yml` runs Playwright against
+   the Vercel PR preview (required check for merge); `smoke-postpromote.yml`
+   runs against production and auto-rolls-back on failure.
+2. **Client smoke** (PR #2 — pending) — gates an existing user's reload into
+   the new bundle behind a hidden-iframe boot test.
+
+Both rely on `?smoke=1`, which boots a synthetic fixture without touching
+storage. See `src/shell/smokeBoot.tsx` and `e2e/smoke/`.
+
+**One-time setup required for `smoke-postpromote.yml`:**
+
+- Add `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` secrets so
+  `vercel rollback` can run on smoke failure.
+- Add `smoke-preview` to branch protection's required status checks (Settings
+  → Branches → main → Require status checks).
+
 ## Contributing
 
 This project is open source but not open contribution — see [CONTRIBUTING.md](./CONTRIBUTING.md) for details on bug reports, feature requests, and the pull request policy.

--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ A two-tier smoke harness verifies that a deploy is healthy before users see it:
 2. **Client smoke** (PR #2 — pending) — gates an existing user's reload into
    the new bundle behind a hidden-iframe boot test.
 
-Both rely on `?smoke=1`, which boots a synthetic fixture without touching
-storage. See `src/shell/smokeBoot.tsx` and `e2e/smoke/`.
+Both rely on `?smoke=1`, which boots a synthetic fixture while skipping
+layout/library hydration, www-migration recovery, PostHog, and ML telemetry.
+See `src/shell/smokeBoot.tsx` and `e2e/smoke/`.
 
 **One-time setup required for `smoke-postpromote.yml`:**
 
-- Add `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` secrets so
-  `vercel rollback` can run on smoke failure.
+- Add `VERCEL_TOKEN` and `VERCEL_ORG_ID` secrets so `vercel rollback` can run
+  on smoke failure (`vercel rollback` reads the linked project from the
+  deployment URL — no separate project ID needed).
 - Add `smoke-preview` to branch protection's required status checks (Settings
   → Branches → main → Require status checks).
 

--- a/e2e/smoke/pwa-smoke.spec.ts
+++ b/e2e/smoke/pwa-smoke.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, type ConsoleMessage } from '@playwright/test';
+
+/**
+ * PWA update smoke test. Asserts a deployed bundle:
+ * - Boots the `?smoke=1` fixture path without console errors.
+ * - Renders the grid (proves the React tree mounted).
+ * - Serves a parseable `/version.json` whose hash matches the one the runtime
+ *   reports — catches the wwwMigration-class bug where the SW precache and the
+ *   deployed asset graph disagree.
+ *
+ * Runs under `playwright.smoke.config.ts`, single chromium project, against
+ * `PLAYWRIGHT_TEST_BASE_URL`. Used by both PR-preview and post-promote workflows.
+ */
+
+interface VersionJson {
+  version: string;
+  gitSha: string;
+  buildTime: string;
+}
+
+const IGNORED_CONSOLE_PATTERNS: RegExp[] = [
+  // Vercel Analytics in dev/preview
+  /vercel.*analytics/i,
+  // PostHog blocked or not configured (smoke mode skips init)
+  /posthog/i,
+  // React DevTools nag
+  /Download the React DevTools/i,
+];
+
+test('boots ?smoke=1 fixture and exposes a fresh /version.json', async ({ page, baseURL }) => {
+  const errors: string[] = [];
+  page.on('console', (msg: ConsoleMessage) => {
+    if (msg.type() !== 'error') return;
+    const text = msg.text();
+    if (IGNORED_CONSOLE_PATTERNS.some((re) => re.test(text))) return;
+    errors.push(text);
+  });
+  page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+
+  // /version.json must be reachable and parseable. Bypass any service worker by
+  // requesting from the API context.
+  const versionRes = await page.request.get(`${baseURL ?? ''}/version.json`, {
+    headers: { 'Cache-Control': 'no-store' },
+  });
+  expect(versionRes.status()).toBe(200);
+  const versionJson = (await versionRes.json()) as VersionJson;
+  expect(versionJson.version).toBeTruthy();
+  expect(versionJson.gitSha).toBeTruthy();
+  expect(versionJson.buildTime).toBeTruthy();
+
+  // Boot the smoke fixture.
+  await page.goto('/?smoke=1', { waitUntil: 'domcontentloaded' });
+
+  // Mirror waitForAppReady from e2e/fixtures.ts but tighter — the smoke harness
+  // mounts the same App tree, so the same selectors apply.
+  await page.waitForSelector('header', { timeout: 10_000 });
+  await page.waitForSelector('[role="application"]', { timeout: 10_000 });
+
+  // smokeBoot.tsx sets window.__SMOKE_BUILD_INFO__ from the compile-time defines.
+  // If the runtime hash differs from /version.json, the SW is serving stale assets.
+  const runtimeVersion = await page.evaluate(() => {
+    const w = window as unknown as {
+      __SMOKE_BUILD_INFO__?: { version: string; gitSha: string; buildTime: string };
+    };
+    return w.__SMOKE_BUILD_INFO__;
+  });
+  expect(runtimeVersion, 'smoke harness did not expose __SMOKE_BUILD_INFO__').toBeTruthy();
+  expect(runtimeVersion?.version).toBe(versionJson.version);
+  expect(runtimeVersion?.gitSha).toBe(versionJson.gitSha);
+
+  // Console must be clean (excluding ignored patterns).
+  expect(errors, `unexpected console errors: ${errors.join('\n')}`).toHaveLength(0);
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'coverage', 'e2e', 'scripts', 'benchmarks', '.stryker-tmp', 'playwright.config.ts', 'playwright-ct.config.ts', 'playwright', '**/*.visual.tsx']),
+  globalIgnores(['dist', 'coverage', 'e2e', 'scripts', 'benchmarks', '.stryker-tmp', 'playwright.config.ts', 'playwright.smoke.config.ts', 'playwright-ct.config.ts', 'playwright', '**/*.visual.tsx']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Smoke-only Playwright config — runs against a deployed URL (Vercel preview or
+ * production). Used by `.github/workflows/smoke-preview.yml` and
+ * `smoke-postpromote.yml`. The broader suite still uses `playwright.config.ts`.
+ *
+ * No webServer block: the target URL must already be reachable. Set
+ * `PLAYWRIGHT_TEST_BASE_URL` to point at the deployment.
+ */
+export default defineConfig({
+  testDir: './e2e/smoke',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 1,
+  workers: 1,
+  timeout: 30_000, // total per-test budget
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'http://localhost:4173',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    actionTimeout: 10_000,
+    navigationTimeout: 10_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 720 } },
+    },
+  ],
+});

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -23,6 +23,13 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     actionTimeout: 10_000,
     navigationTimeout: 10_000,
+    // Vercel preview deployments are gated behind deployment protection by default.
+    // Pass the bypass secret on every request (page navigation + APIRequestContext)
+    // when running against a protected preview. See:
+    // https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation
+    extraHTTPHeaders: process.env.VERCEL_BYPASS_SECRET
+      ? { 'x-vercel-protection-bypass': process.env.VERCEL_BYPASS_SECRET }
+      : undefined,
   },
   projects: [
     {

--- a/scripts/vite-plugin-version.ts
+++ b/scripts/vite-plugin-version.ts
@@ -1,0 +1,60 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import type { Plugin } from 'vite';
+
+interface VersionInfo {
+  version: string;
+  gitSha: string;
+  buildTime: string;
+}
+
+function readVersionInfo(): VersionInfo {
+  const pkgPath = fileURLToPath(new URL('../package.json', import.meta.url));
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version: string };
+
+  // git may be unavailable in tarball builds or detached environments — fall back gracefully.
+  // execFileSync (not execSync) bypasses the shell, so no injection surface despite fixed args.
+  let gitSha = 'unknown';
+  try {
+    gitSha = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf-8' }).trim();
+  } catch {
+    // ignore
+  }
+
+  return {
+    version: pkg.version,
+    gitSha,
+    buildTime: new Date().toISOString(),
+  };
+}
+
+/**
+ * Emits dist/version.json at build time and exposes __APP_VERSION__ / __GIT_SHA__ /
+ * __BUILD_TIME__ as compile-time defines. Used by the PWA update smoke gate to
+ * identify deployed versions and verify post-promote freshness.
+ */
+export function versionPlugin(): Plugin {
+  let info: VersionInfo;
+
+  return {
+    name: 'gridfinity:version',
+    config() {
+      info = readVersionInfo();
+      return {
+        define: {
+          __APP_VERSION__: JSON.stringify(info.version),
+          __GIT_SHA__: JSON.stringify(info.gitSha),
+          __BUILD_TIME__: JSON.stringify(info.buildTime),
+        },
+      };
+    },
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'version.json',
+        source: JSON.stringify(info, null, 2) + '\n',
+      });
+    },
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,13 +19,13 @@ import { connectEventStoreToBus, connectSelectionPruning, eventBus } from '@/cor
 import { connectDesignLinking } from '@/features/design-linking/subscribers';
 import { InitErrorFallback } from '@/shell/InitErrorFallback';
 import { isSmokeMode } from '@/shared/utils/smokeMode';
-import { runSmokeBoot } from '@/shell/smokeBoot';
 
 // Smoke mode (?smoke=1) boots a synthetic fixture and reports back to a parent listener.
 // Must short-circuit ahead of www-migration paths, which would otherwise reload/redirect
-// during a smoke harness run.
+// during a smoke harness run. The boot module is dynamically imported so it doesn't
+// bloat the main bundle (smoke runs only in CI / iframe gate, never in user browsers).
 if (isSmokeMode()) {
-  runSmokeBoot();
+  void import('./shell/smokeBoot').then(({ runSmokeBoot }) => runSmokeBoot());
 } else if (recoverFromBadWwwMigration()) {
   // Reload triggered — stop all further initialization.
 } else if ((window as unknown as { __wwwMigrationPending?: boolean }).__wwwMigrationPending) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,12 +18,15 @@ import { recoverFromBadWwwMigration } from '@/core/storage/wwwMigrationRecovery'
 import { connectEventStoreToBus, connectSelectionPruning, eventBus } from '@/core/cqrs';
 import { connectDesignLinking } from '@/features/design-linking/subscribers';
 import { InitErrorFallback } from '@/shell/InitErrorFallback';
+import { isSmokeMode } from '@/shared/utils/smokeMode';
+import { runSmokeBoot } from '@/shell/smokeBoot';
 
-// Recovery for canonical users who went through a broken www→canonical migration
-// (before the fix that excluded migration-state flags from bridge LS copy).
-// Must run before React boots so corrected flags take effect during store hydration.
-// Returns true and triggers a page reload if stranded LS layouts are detected.
-if (recoverFromBadWwwMigration()) {
+// Smoke mode (?smoke=1) boots a synthetic fixture and reports back to a parent listener.
+// Must short-circuit ahead of www-migration paths, which would otherwise reload/redirect
+// during a smoke harness run.
+if (isSmokeMode()) {
+  runSmokeBoot();
+} else if (recoverFromBadWwwMigration()) {
   // Reload triggered — stop all further initialization.
 } else if ((window as unknown as { __wwwMigrationPending?: boolean }).__wwwMigrationPending) {
   void import('./core/storage/wwwMigration')

--- a/src/shared/hooks/usePWAUpdate.ts
+++ b/src/shared/hooks/usePWAUpdate.ts
@@ -14,6 +14,7 @@ import {
 import { binId, layerId, categoryId } from '@/core/types';
 import type { BinId } from '@/core/types';
 import { useTranslation } from '@/i18n';
+import { isSmokeMode } from '@/shared/utils/smokeMode';
 
 // Toast duration for update notification
 const UPDATE_TOAST_MS = 5000;
@@ -289,11 +290,18 @@ export function usePWAUpdate(): void {
     }
   }, []);
 
+  // Smoke mode runs inside a hidden iframe and must NOT register a service worker —
+  // doing so would re-trigger the update gate from inside the gate, and any SW the
+  // iframe registered would persist beyond the smoke run.
+  const skipRegistration = isSmokeMode();
+
   const {
     needRefresh: [needRefresh],
     updateServiceWorker,
   } = useRegisterSW({
+    immediate: !skipRegistration,
     onRegisteredSW(_swUrl, registration) {
+      if (skipRegistration) return;
       // Store reference for update checks
       registrationRef.current = registration;
 
@@ -313,6 +321,7 @@ export function usePWAUpdate(): void {
       }, UPDATE_CHECK_INTERVAL_MS);
     },
     onRegisterError(error) {
+      if (skipRegistration) return;
       console.error('SW registration failed:', error);
 
       // App still works without SW, but offline features won't be available
@@ -325,6 +334,8 @@ export function usePWAUpdate(): void {
 
   // Listen for online/offline transitions
   useEffect(() => {
+    if (skipRegistration) return;
+
     const handleOnline = () => {
       if (wasOfflineRef.current) {
         wasOfflineRef.current = false;
@@ -348,10 +359,12 @@ export function usePWAUpdate(): void {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
     };
-  }, [addToast, checkForUpdate, t]);
+  }, [addToast, checkForUpdate, t, skipRegistration]);
 
   // Set up visibility listener for update checks (not focus - fires too often)
   useEffect(() => {
+    if (skipRegistration) return;
+
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
         void checkForUpdate();
@@ -366,7 +379,7 @@ export function usePWAUpdate(): void {
         clearInterval(intervalRef.current);
       }
     };
-  }, [checkForUpdate]);
+  }, [checkForUpdate, skipRegistration]);
 
   // Handle update notification and auto-reload when idle
   useEffect(() => {
@@ -441,6 +454,7 @@ export function usePWAUpdate(): void {
 
   // Restore ephemeral state on mount (after PWA update reload)
   useEffect(() => {
+    if (skipRegistration) return;
     // Small delay to ensure layout store is initialized
     const timeoutId = setTimeout(() => {
       const restored = restoreEphemeralState();
@@ -450,5 +464,5 @@ export function usePWAUpdate(): void {
     }, 100);
 
     return () => clearTimeout(timeoutId);
-  }, [addToast, t]);
+  }, [addToast, t, skipRegistration]);
 }

--- a/src/shared/utils/smokeMode.ts
+++ b/src/shared/utils/smokeMode.ts
@@ -1,0 +1,21 @@
+/**
+ * Smoke mode is triggered by `?smoke=1` in the URL. It boots the app with a synthetic
+ * fixture (no storage reads) so a Playwright/iframe harness can verify a deploy without
+ * touching real user state. See `src/shell/smokeBoot.ts` for the boot sequence and
+ * `.github/workflows/smoke-*.yml` / `src/shared/pwa/smokeGate.ts` (PR #2) for callers.
+ */
+export function isSmokeMode(): boolean {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).get('smoke') === '1';
+}
+
+export const SMOKE_MESSAGE_TYPE = 'pwa-smoke-result' as const;
+
+export interface SmokeResultMessage {
+  type: typeof SMOKE_MESSAGE_TYPE;
+  smokeOk: boolean;
+  version: string;
+  gitSha: string;
+  buildTime: string;
+  reason?: string;
+}

--- a/src/shared/utils/smokeMode.ts
+++ b/src/shared/utils/smokeMode.ts
@@ -1,7 +1,11 @@
 /**
- * Smoke mode is triggered by `?smoke=1` in the URL. It boots the app with a synthetic
- * fixture (no storage reads) so a Playwright/iframe harness can verify a deploy without
- * touching real user state. See `src/shell/smokeBoot.ts` for the boot sequence and
+ * Smoke mode is triggered by `?smoke=1` in the URL. It enables a stripped-down boot
+ * path used by the Playwright/iframe harness to verify a deploy: skips IndexedDB
+ * layout/library hydration, the wwwMigration recovery + redirect paths, PostHog
+ * init, and ML telemetry. Settings-store reads of `localStorage` (locale prefs)
+ * still happen — that's fine for a smoke target.
+ *
+ * See `src/shell/smokeBoot.tsx` for the boot sequence and
  * `.github/workflows/smoke-*.yml` / `src/shared/pwa/smokeGate.ts` (PR #2) for callers.
  */
 export function isSmokeMode(): boolean {

--- a/src/shell/SmokeReporter.tsx
+++ b/src/shell/SmokeReporter.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { SMOKE_MESSAGE_TYPE, type SmokeResultMessage } from '@/shared/utils/smokeMode';
+
+interface SmokeBuildInfo {
+  version: string;
+  gitSha: string;
+  buildTime: string;
+}
+
+/**
+ * One-shot reporter mounted inside the smoke React tree. Fires postMessage once
+ * the app's effects have run (which means React mounted without throwing). Also
+ * exposes build info on `window.__SMOKE_BUILD_INFO__` so Playwright can compare
+ * it against `/version.json` — vite `define` constants are inlined as literals
+ * and not addressable from outside the bundle.
+ */
+export function SmokeReporter(): null {
+  useEffect(() => {
+    const info: SmokeBuildInfo = {
+      version: __APP_VERSION__,
+      gitSha: __GIT_SHA__,
+      buildTime: __BUILD_TIME__,
+    };
+    (window as unknown as { __SMOKE_BUILD_INFO__: SmokeBuildInfo }).__SMOKE_BUILD_INFO__ = info;
+
+    if (window.parent === window) return;
+    const payload: SmokeResultMessage = {
+      type: SMOKE_MESSAGE_TYPE,
+      smokeOk: true,
+      ...info,
+    };
+    try {
+      window.parent.postMessage(payload, window.location.origin);
+    } catch {
+      // best-effort
+    }
+  }, []);
+  return null;
+}

--- a/src/shell/smokeBoot.tsx
+++ b/src/shell/smokeBoot.tsx
@@ -1,0 +1,143 @@
+import { createRoot } from 'react-dom/client';
+import { Analytics } from '@vercel/analytics/react';
+import App from '@/App';
+import { ErrorBoundary } from '@/shell/ErrorBoundary';
+import { SmokeReporter } from '@/shell/SmokeReporter';
+import { LocaleProvider } from '@/i18n/context';
+import { detectBrowserLocale } from '@/i18n/detection';
+import { isLocale } from '@/i18n/types';
+import type { Locale } from '@/i18n/types';
+import { useSettingsStore } from '@/core/store/settings';
+import { useLayoutStore } from '@/core/store/layout';
+import { useLibraryStore } from '@/core/store/library';
+import { useSharedWithMeStore } from '@/core/store/sharedWithMe';
+import { connectEventStoreToBus, connectSelectionPruning, eventBus } from '@/core/cqrs';
+import { connectDesignLinking } from '@/features/design-linking/subscribers';
+import {
+  layoutId,
+  layerId,
+  categoryId,
+  gridUnits,
+  heightUnits,
+  mm,
+  type Layout,
+  type LayoutLibrary,
+  type LayoutId,
+} from '@/core/types';
+import { SMOKE_MESSAGE_TYPE, type SmokeResultMessage } from '@/shared/utils/smokeMode';
+
+/**
+ * Deterministic synthetic layout for smoke boots. Mirrors the shape of
+ * `createTestLayout()` in `src/test/testUtils.ts` but lives outside the test
+ * directory so it can be imported into production code without dragging in vitest.
+ */
+function buildSmokeLayout(): { layout: Layout; library: LayoutLibrary; id: LayoutId } {
+  const id = layoutId('00000000-0000-4000-8000-000000000001');
+  const layout: Layout = {
+    version: '1.0',
+    name: 'Smoke Layout',
+    drawer: { width: gridUnits(10), depth: gridUnits(8), height: heightUnits(12) },
+    printBedSize: mm(256),
+    gridUnitMm: mm(42),
+    heightUnitMm: mm(7),
+    categories: [{ id: categoryId('cat1'), name: 'General', color: '#3b82f6' }],
+    layers: [{ id: layerId('layer1'), name: 'Layer 1', height: heightUnits(3) }],
+    bins: [],
+  };
+  const library: LayoutLibrary = {
+    version: '1.0',
+    activeLayoutId: id,
+    settings: {},
+    entries: [
+      {
+        id,
+        name: layout.name,
+        createdAt: 0,
+        modifiedAt: 0,
+        preview: {
+          drawerWidth: layout.drawer.width,
+          drawerDepth: layout.drawer.depth,
+          drawerHeight: layout.drawer.height,
+          binCount: 0,
+          layerCount: 1,
+        },
+      },
+    ],
+  };
+  return { layout, library, id };
+}
+
+function postSmokeResult(message: Omit<SmokeResultMessage, 'type'>): void {
+  if (window.parent === window) return; // No parent listener — Playwright reads the DOM directly.
+  const payload: SmokeResultMessage = { type: SMOKE_MESSAGE_TYPE, ...message };
+  try {
+    window.parent.postMessage(payload, window.location.origin);
+  } catch {
+    // best-effort
+  }
+}
+
+function resolveInitialLocale(): Locale {
+  const savedLocale = useSettingsStore.getState().settings.locale;
+  if (savedLocale !== 'auto' && isLocale(savedLocale)) {
+    return savedLocale;
+  }
+  return detectBrowserLocale();
+}
+
+export function runSmokeBoot(): void {
+  const rootElement = document.getElementById('root');
+  if (!rootElement) {
+    postSmokeResult({
+      smokeOk: false,
+      version: __APP_VERSION__,
+      gitSha: __GIT_SHA__,
+      buildTime: __BUILD_TIME__,
+      reason: 'root_missing',
+    });
+    return;
+  }
+
+  // Surface unexpected boot errors to the parent before the React error boundary catches them.
+  window.addEventListener('error', (event) => {
+    postSmokeResult({
+      smokeOk: false,
+      version: __APP_VERSION__,
+      gitSha: __GIT_SHA__,
+      buildTime: __BUILD_TIME__,
+      reason: `error:${event.message}`,
+    });
+  });
+  window.addEventListener('unhandledrejection', (event) => {
+    postSmokeResult({
+      smokeOk: false,
+      version: __APP_VERSION__,
+      gitSha: __GIT_SHA__,
+      buildTime: __BUILD_TIME__,
+      reason: `rejection:${String(event.reason)}`,
+    });
+  });
+
+  const { layout, library, id } = buildSmokeLayout();
+  useLibraryStore.getState().initLibrary(library);
+  useLayoutStore.getState().importLayout(layout, id, 'init');
+  useSharedWithMeStore.getState().init([]);
+
+  // Connect CQRS bus — App components subscribe to it; leaving it unconnected can throw.
+  connectEventStoreToBus();
+  connectSelectionPruning(eventBus);
+  connectDesignLinking(eventBus);
+
+  const initialLocale = resolveInitialLocale();
+  document.documentElement.lang = initialLocale === 'pt-BR' ? 'pt' : initialLocale;
+
+  createRoot(rootElement).render(
+    <ErrorBoundary>
+      <LocaleProvider initialLocale={initialLocale} onLocaleChange={() => {}}>
+        <App />
+        <SmokeReporter />
+      </LocaleProvider>
+      <Analytics />
+    </ErrorBoundary>
+  );
+}

--- a/src/shell/smokeBoot.tsx
+++ b/src/shell/smokeBoot.tsx
@@ -99,24 +99,33 @@ export function runSmokeBoot(): void {
   }
 
   // Surface unexpected boot errors to the parent before the React error boundary catches them.
-  window.addEventListener('error', (event) => {
-    postSmokeResult({
-      smokeOk: false,
-      version: __APP_VERSION__,
-      gitSha: __GIT_SHA__,
-      buildTime: __BUILD_TIME__,
-      reason: `error:${event.message}`,
-    });
-  });
-  window.addEventListener('unhandledrejection', (event) => {
-    postSmokeResult({
-      smokeOk: false,
-      version: __APP_VERSION__,
-      gitSha: __GIT_SHA__,
-      buildTime: __BUILD_TIME__,
-      reason: `rejection:${String(event.reason)}`,
-    });
-  });
+  // `once: true` so a single fixture that emits multiple errors doesn't spam the parent.
+  window.addEventListener(
+    'error',
+    (event) => {
+      postSmokeResult({
+        smokeOk: false,
+        version: __APP_VERSION__,
+        gitSha: __GIT_SHA__,
+        buildTime: __BUILD_TIME__,
+        reason: `error:${event.message}`,
+      });
+    },
+    { once: true }
+  );
+  window.addEventListener(
+    'unhandledrejection',
+    (event) => {
+      postSmokeResult({
+        smokeOk: false,
+        version: __APP_VERSION__,
+        gitSha: __GIT_SHA__,
+        buildTime: __BUILD_TIME__,
+        reason: `rejection:${String(event.reason)}`,
+      });
+    },
+    { once: true }
+  );
 
   const { layout, library, id } = buildSmokeLayout();
   useLibraryStore.getState().initLibrary(library);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -28,3 +28,8 @@ declare module 'virtual:pwa-register/react' {
 interface Navigator {
   readonly globalPrivacyControl?: boolean;
 }
+
+// Build-time defines injected by scripts/vite-plugin-version.ts.
+declare const __APP_VERSION__: string;
+declare const __GIT_SHA__: string;
+declare const __BUILD_TIME__: string;

--- a/vercel.json
+++ b/vercel.json
@@ -139,6 +139,15 @@
       ]
     },
     {
+      "source": "/version.json",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, max-age=0"
+        }
+      ]
+    },
+    {
       "source": "/index.html",
       "headers": [
         {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -87,6 +87,9 @@ export default defineConfig({
           // deployments: the new SW's manifest still references the old hash which
           // 404s, leaving the old SW in control and blocking the fix from reaching users.
           'assets/wwwMigration-*.js',
+          // smokeBoot is loaded only via `?smoke=1`. Real users never need it, and
+          // precaching it adds the same hash-mismatch risk that bit wwwMigration.
+          'assets/smokeBoot-*.js',
           // version.json is fetched by the PWA smoke gate to verify a fresh deploy is
           // reachable. Must always hit the network — precaching would mask stale CDN.
           'version.json',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { VitePWA } from 'vite-plugin-pwa';
 import wasm from 'vite-plugin-wasm';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { fileURLToPath, URL } from 'node:url';
+import { versionPlugin } from './scripts/vite-plugin-version';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -40,6 +41,7 @@ export default defineConfig({
     wasm(),
     react(),
     tailwindcss(),
+    versionPlugin(),
     VitePWA({
       registerType: 'autoUpdate',
       // Note: Don't use includeAssets here - icons are precached via globPatterns,
@@ -85,6 +87,9 @@ export default defineConfig({
           // deployments: the new SW's manifest still references the old hash which
           // 404s, leaving the old SW in control and blocking the fix from reaching users.
           'assets/wwwMigration-*.js',
+          // version.json is fetched by the PWA smoke gate to verify a fresh deploy is
+          // reachable. Must always hit the network — precaching would mask stale CDN.
+          'version.json',
         ],
         // Prefix all cache names to prevent conflicts
         cacheId: 'gridfinity-v1',


### PR DESCRIPTION
## Summary

Two-tier PWA update smoke gate, **tier 1 only** (CI). Catches deploy-time bugs (broken precache, missing assets, wwwMigration-class hash mismatches) before any user sees them.

- New `dist/version.json` + `__APP_VERSION__`/`__GIT_SHA__` defines for runtime / SW / CDN consistency checks.
- `?smoke=1` boot path (`src/shell/smokeBoot.tsx`) hydrates a synthetic fixture, bypasses storage/migration, and posts a result to a parent listener — used by both the Playwright smoke and the upcoming client-side gate.
- `usePWAUpdate` skips SW registration in smoke mode so the iframe doesn't re-trigger the gate or leave a registered SW behind.
- Two new workflows:
  - `smoke-preview.yml` runs against the Vercel PR preview (intended as a required check).
  - `smoke-postpromote.yml` runs against production after promote, on failure runs `vercel rollback` + opens a labeled incident issue.

Tier 2 (the client-side reload gate) lands in a follow-up PR — this one is intentionally low-risk: no SW lifecycle changes, no runtime UX changes outside `?smoke=1`.

## Test plan

- [ ] CI green (`smoke-preview` workflow runs against the Vercel preview and passes)
- [ ] Visit `https://<preview>/version.json` — confirm `{ version, gitSha, buildTime }` payload + `Cache-Control: no-store` header
- [ ] Visit `https://<preview>/?smoke=1` — confirm app boots a synthetic 10×8×12 fixture with no console errors
- [ ] Confirm `dist/sw.js` does **not** precache `version.json` (globIgnored)
- [ ] After merge: add `smoke-preview` to branch protection required checks; add `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` secrets so `smoke-postpromote` can run rollback
- [ ] After production deploy: confirm `smoke-postpromote` fires once and goes green