### PR TITLE
fix(pwa): repair post-promote smoke + revert README smoke section

### DIFF
--- a/.github/workflows/smoke-postpromote.yml
+++ b/.github/workflows/smoke-postpromote.yml
@@ -42,13 +42,19 @@ jobs:
 
       - name: Resolve smoke target URL
         id: target
+        # We deliberately smoke the canonical production domain, not the
+        # deployment-specific URL from the payload. The deployment URL
+        # (gridfinity-layout-tool-<hash>-collective-context.vercel.app) is gated
+        # by Vercel deployment protection (returns 401 to unauthenticated
+        # automation), whereas the canonical alias is public and is what users
+        # actually visit. Smoking that gives us the most realistic post-promote
+        # signal.
+        env:
+          PRODUCTION_URL: 'https://gridfinitylayouttool.com'
         run: |
-          url="${DEPLOY_URL:-$DEPLOY_TARGET_URL}"
-          if [ -z "$url" ]; then
-            echo "::error::No deployment URL in payload"
-            exit 1
-          fi
-          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "url=$PRODUCTION_URL" >> "$GITHUB_OUTPUT"
+          echo "Smoke target: $PRODUCTION_URL"
+          echo "Deployment URL (informational): ${DEPLOY_URL:-$DEPLOY_TARGET_URL}"
 
       - name: Wait for CDN warm-up
         # Vercel marks deploy success before the production alias is fully
@@ -99,7 +105,8 @@ jobs:
         run: |
           short_sha="${DEPLOY_SHA:0:7}"
           gh issue create \
-            --label incident \
+            --label "bug" \
+            --label "priority: critical" \
             --title "Production smoke failed: $short_sha" \
             --body "$(cat <<EOF
           Post-promote smoke test failed. Production alias has been rolled back to the previous deployment (verify in Vercel dashboard).

--- a/README.md
+++ b/README.md
@@ -47,32 +47,6 @@ pnpm run test:coverage # Unit tests with coverage
 pnpm run test:e2e      # Playwright end-to-end tests
 ```
 
-### PWA Update Smoke Gate
-
-A two-tier smoke harness verifies that a deploy is healthy before users see it:
-
-1. **CI smoke** — `.github/workflows/smoke-preview.yml` runs Playwright against
-   the Vercel PR preview (required check for merge); `smoke-postpromote.yml`
-   runs against production and auto-rolls-back on failure.
-2. **Client smoke** (PR #2 — pending) — gates an existing user's reload into
-   the new bundle behind a hidden-iframe boot test.
-
-Both rely on `?smoke=1`, which boots a synthetic fixture while skipping
-layout/library hydration, www-migration recovery, PostHog, and ML telemetry.
-See `src/shell/smokeBoot.tsx` and `e2e/smoke/`.
-
-**One-time setup required for the smoke workflows:**
-
-- `VERCEL_AUTOMATION_BYPASS_SECRET` — required by **both** smoke workflows when
-  the Vercel project has Deployment Protection enabled (default on paid plans).
-  Generate via Vercel project Settings → Deployment Protection → Protection
-  Bypass for Automation, then add as a GitHub Actions secret.
-- `VERCEL_TOKEN` and `VERCEL_ORG_ID` — required by `smoke-postpromote.yml` so
-  `vercel rollback` can run on smoke failure (`vercel rollback` reads the
-  linked project from the deployment URL — no separate project ID needed).
-- Add `smoke-preview` to branch protection's required status checks (Settings
-  → Branches → main → Require status checks).
-
 ## Contributing
 
 This project is open source but not open contribution — see [CONTRIBUTING.md](./CONTRIBUTING.md) for details on bug reports, feature requests, and the pull request policy.


### PR DESCRIPTION
## Summary

Two bugs introduced in #1475 that broke main's post-promote smoke + a README revert.

- **Post-promote target was the deployment-specific Vercel URL** (`gridfinity-layout-tool-<hash>-collective-context.vercel.app`), which is gated by Vercel deployment protection — runner got 401. Switched to the canonical `gridfinitylayouttool.com`. That's public, stable, and what users actually visit.
- **`gh issue create --label incident` failed** because the repo doesn't have that label. Switched to `bug` + `priority: critical`, both of which exist.
- **Reverted the "PWA Update Smoke Gate" README section** I added on #1475 — internal-flavored content that doesn't belong in the public README.

## Test plan

- [ ] CI green
- [ ] Once merged, the next production deploy's post-promote workflow should reach the smoke step against `gridfinitylayouttool.com` and succeed (or fail loudly + open a `bug`/`priority: critical` issue if the deploy is genuinely broken)