### PR TITLE
feat(pwa): add tier-2 client-side update smoke gate

### DIFF
--- a/e2e/smoke/pwa-smoke.spec.ts
+++ b/e2e/smoke/pwa-smoke.spec.ts
@@ -37,10 +37,18 @@ test('boots ?smoke=1 fixture and exposes a fresh /version.json', async ({ page, 
   });
   page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
 
+  // Build the per-request bypass header for direct API calls — same-origin only.
+  // We avoid Playwright's `extraHTTPHeaders` because that would pollute every
+  // outgoing request, including third-party (fonts.gstatic.com), where CORS
+  // preflight rejects unknown headers and breaks asset loading.
+  const bypass = process.env.VERCEL_BYPASS_SECRET ?? '';
+  const apiHeaders: Record<string, string> = { 'Cache-Control': 'no-store' };
+  if (bypass) apiHeaders['x-vercel-protection-bypass'] = bypass;
+
   // /version.json must be reachable and parseable. Bypass any service worker by
   // requesting from the API context.
   const versionRes = await page.request.get(`${baseURL ?? ''}/version.json`, {
-    headers: { 'Cache-Control': 'no-store' },
+    headers: apiHeaders,
   });
   expect(versionRes.status()).toBe(200);
   const versionJson = (await versionRes.json()) as VersionJson;
@@ -48,8 +56,17 @@ test('boots ?smoke=1 fixture and exposes a fresh /version.json', async ({ page, 
   expect(versionJson.gitSha).toBeTruthy();
   expect(versionJson.buildTime).toBeTruthy();
 
-  // Boot the smoke fixture.
-  await page.goto('/?smoke=1', { waitUntil: 'domcontentloaded' });
+  // Boot the smoke fixture. When the preview is gated by Vercel deployment
+  // protection, attach the bypass secret as a query string with
+  // `x-vercel-set-bypass-cookie=true` — Vercel responds with a same-origin
+  // cookie that grants access for the rest of the session WITHOUT polluting
+  // third-party requests with a bypass header.
+  // https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation
+  const sep = '?smoke=1';
+  const bootUrl = bypass
+    ? `${sep}&x-vercel-protection-bypass=${encodeURIComponent(bypass)}&x-vercel-set-bypass-cookie=true`
+    : sep;
+  await page.goto(bootUrl, { waitUntil: 'domcontentloaded' });
 
   // Mirror waitForAppReady from e2e/fixtures.ts but tighter — the smoke harness
   // mounts the same App tree, so the same selectors apply.

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -23,13 +23,12 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     actionTimeout: 10_000,
     navigationTimeout: 10_000,
-    // Vercel preview deployments are gated behind deployment protection by default.
-    // Pass the bypass secret on every request (page navigation + APIRequestContext)
-    // when running against a protected preview. See:
-    // https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation
-    extraHTTPHeaders: process.env.VERCEL_BYPASS_SECRET
-      ? { 'x-vercel-protection-bypass': process.env.VERCEL_BYPASS_SECRET }
-      : undefined,
+    // NOTE: don't set extraHTTPHeaders for the Vercel bypass token here.
+    // Playwright sends `extraHTTPHeaders` on EVERY outgoing request including
+    // third-party (fonts.gstatic.com etc.), and those origins reject unknown
+    // headers via CORS preflight, breaking asset loading. The smoke spec sets
+    // a same-origin bypass cookie via the navigation query string instead, and
+    // includes the header explicitly only on direct same-origin API calls.
   },
   projects: [
     {

--- a/src/shared/hooks/usePWAUpdate.test.ts
+++ b/src/shared/hooks/usePWAUpdate.test.ts
@@ -23,6 +23,19 @@ let mockOnRegisteredSW:
   | undefined;
 let mockOnRegisterError: ((error: Error) => void) | undefined;
 
+// Mock the new PWA-gate modules so existing tests exercise the original
+// flag-disabled flow with the same timing they were written for. The gate
+// itself is covered by src/shared/pwa/smokeGate.test.ts.
+vi.mock('@/shared/pwa/featureFlag', () => ({
+  getSmokeGateFlag: vi.fn().mockResolvedValue(false),
+}));
+vi.mock('@/shared/pwa/iosBypass', () => ({
+  isIosStandalonePwa: vi.fn().mockReturnValue(false),
+}));
+vi.mock('@/shared/pwa/smokeGate', () => ({
+  runUpdateSmokeTest: vi.fn(),
+}));
+
 // Mock the virtual:pwa-register/react module
 vi.mock('virtual:pwa-register/react', () => ({
   useRegisterSW: (options?: {
@@ -254,15 +267,18 @@ describe('usePWAUpdate', () => {
         mockOnRegisteredSW?.('/sw.js', mockRegistration);
       });
 
-      // Flush pending promises and advance through idle check + toast duration
+      // Flush pending promises and advance through idle check + toast duration.
+      // The first microtask flush resolves the awaited getSmokeGateFlag() promise
+      // (mocked to resolve `false`); subsequent flushes drive the rest of the chain.
       await act(async () => {
-        // Advance time for idle check
-        timerUtils.advanceTime(IDLE_CHECK_INTERVAL_MS);
-        await Promise.resolve(); // Flush microtasks
+        await Promise.resolve(); // Flush getSmokeGateFlag()
+        await Promise.resolve(); // Flush waitForSafeReload's initial resolve
 
-        // Advance time for toast duration
+        timerUtils.advanceTime(IDLE_CHECK_INTERVAL_MS);
+        await Promise.resolve();
+
         timerUtils.advanceTime(UPDATE_TOAST_MS);
-        await Promise.resolve(); // Flush microtasks
+        await Promise.resolve();
       });
 
       expect(mockUpdateServiceWorker).toHaveBeenCalledWith(true);
@@ -595,6 +611,9 @@ describe('usePWAUpdate', () => {
       // Advance through all the idle checks until timeout
       // The check runs every 1 second, so we need to advance in steps
       await act(async () => {
+        // Flush gate-flag + initial isSafeToReload check before driving the loop.
+        await Promise.resolve();
+        await Promise.resolve();
         for (let elapsed = 0; elapsed <= MAX_IDLE_WAIT_MS; elapsed += IDLE_CHECK_INTERVAL_MS) {
           timerUtils.advanceTime(IDLE_CHECK_INTERVAL_MS);
           await Promise.resolve();
@@ -629,8 +648,12 @@ describe('usePWAUpdate', () => {
         mockOnRegisteredSW?.('/sw.js', mockRegistration);
       });
 
-      // Complete the update flow
+      // Complete the update flow. Extra flushes account for the awaited
+      // getSmokeGateFlag() and waitForSafeReload() promises in the gatedUpdate
+      // chain (gate is mocked to disabled, so it falls straight through).
       await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
         timerUtils.advanceTime(IDLE_CHECK_INTERVAL_MS);
         await Promise.resolve();
         timerUtils.advanceTime(UPDATE_TOAST_MS);

--- a/src/shared/hooks/usePWAUpdate.ts
+++ b/src/shared/hooks/usePWAUpdate.ts
@@ -465,7 +465,11 @@ export function usePWAUpdate(): void {
             duration_ms: result.durationMs,
             retries: result.retries,
             ua: navigator.userAgent,
-            is_pwa_installed: window.matchMedia('(display-mode: standalone)').matches,
+            // matchMedia is virtually always available in real browsers, but
+            // guard so a missing implementation can't take out the cleanup.
+            is_pwa_installed:
+              typeof window.matchMedia === 'function' &&
+              window.matchMedia('(display-mode: standalone)').matches,
             is_offline: !navigator.onLine,
             has_active_interaction: useInteractionStore.getState().interaction !== null,
           });
@@ -493,6 +497,10 @@ export function usePWAUpdate(): void {
 
       // Common reload path — used by both the gated-success branch and the
       // flag-disabled / iOS-bypass / no-waiting-worker fall-through.
+      // Re-check abort: getSmokeGateFlag can take up to 2s, plenty of time
+      // for the component to unmount.
+      if (abortController.signal.aborted) return;
+
       try {
         sessionStorage.setItem(RELOAD_FLAG_KEY, Date.now().toString());
       } catch {
@@ -500,6 +508,7 @@ export function usePWAUpdate(): void {
       }
 
       const wasSafe = await waitForSafeReload(MAX_IDLE_WAIT_MS, abortController.signal);
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- signal can flip between awaits
       if (abortController.signal.aborted) return;
       if (!wasSafe) {
         console.warn('Timed out waiting for idle, proceeding with update');

--- a/src/shared/hooks/usePWAUpdate.ts
+++ b/src/shared/hooks/usePWAUpdate.ts
@@ -15,6 +15,38 @@ import { binId, layerId, categoryId } from '@/core/types';
 import type { BinId } from '@/core/types';
 import { useTranslation } from '@/i18n';
 import { isSmokeMode } from '@/shared/utils/smokeMode';
+import { runUpdateSmokeTest, type SmokeGateResult } from '@/shared/pwa/smokeGate';
+import { getSmokeGateFlag } from '@/shared/pwa/featureFlag';
+import { isIosStandalonePwa } from '@/shared/pwa/iosBypass';
+import { getPosthogInstance } from '@/shared/analytics/posthog/init';
+
+/**
+ * Module-level flag so the periodic checkForUpdate() doesn't fire a second
+ * smoke run while one is already in flight. Reset by `gatedUpdate()` on exit.
+ */
+let smokeInProgress = false;
+
+/** Cache name prefix used by Workbox precache (matches `cacheId: 'gridfinity-v1'`). */
+const PRECACHE_PREFIX = 'gridfinity-v1-precache-';
+
+async function clearPrecaches(): Promise<void> {
+  try {
+    const keys = await caches.keys();
+    await Promise.all(
+      keys.filter((k) => k.startsWith(PRECACHE_PREFIX)).map((k) => caches.delete(k))
+    );
+  } catch {
+    // best-effort
+  }
+}
+
+function captureSmokeEvent(name: string, props: Record<string, unknown>): void {
+  try {
+    getPosthogInstance()?.capture(name, props);
+  } catch {
+    // never let telemetry crash the gate
+  }
+}
 
 // Toast duration for update notification
 const UPDATE_TOAST_MS = 5000;
@@ -274,6 +306,10 @@ export function usePWAUpdate(): void {
     // Skip if SW is currently installing
     if (registration.installing) return;
 
+    // Skip if a smoke gate run is in flight — racing a second update detection
+    // could SKIP_WAITING a different worker mid-iframe and corrupt the gate.
+    if (smokeInProgress) return;
+
     // Skip if offline
     if (!navigator.onLine) return;
 
@@ -381,7 +417,10 @@ export function usePWAUpdate(): void {
     };
   }, [checkForUpdate, skipRegistration]);
 
-  // Handle update notification and auto-reload when idle
+  // Handle update notification and auto-reload when idle.
+  // The smoke gate (when enabled via PostHog flag) runs first: it activates the
+  // new SW manually, spawns a hidden iframe to verify the new bundle boots,
+  // and either green-lights the reload or rolls back the precache.
   useEffect(() => {
     if (!needRefresh || hasTriggeredReload.current) return;
 
@@ -397,32 +436,78 @@ export function usePWAUpdate(): void {
 
     hasTriggeredReload.current = true;
 
-    // Set flag before attempting reload
-    try {
-      sessionStorage.setItem(RELOAD_FLAG_KEY, Date.now().toString());
-    } catch {
-      // best-effort
-    }
-
     // Use AbortController for cleanup on unmount
     const abortController = new AbortController();
     let toastTimeoutId: number | undefined;
 
-    // Wait for safe state before reloading
-    const performUpdate = async () => {
+    const gatedUpdate = async (): Promise<void> => {
+      const registration = registrationRef.current;
+      const flagEnabled = await getSmokeGateFlag();
+      const useGate = flagEnabled && !isIosStandalonePwa() && Boolean(registration?.waiting);
+
+      if (useGate && registration) {
+        smokeInProgress = true;
+        let result: SmokeGateResult;
+        try {
+          result = await runUpdateSmokeTest(registration);
+        } finally {
+          smokeInProgress = false;
+        }
+
+        if (abortController.signal.aborted) return;
+
+        if (!result.ok) {
+          captureSmokeEvent('pwa_smoke_failed', {
+            reason: result.reason,
+            from_version: __APP_VERSION__,
+            to_version: result.version,
+            expected_version: result.expectedVersion,
+            duration_ms: result.durationMs,
+            retries: result.retries,
+            ua: navigator.userAgent,
+            is_pwa_installed: window.matchMedia('(display-mode: standalone)').matches,
+            is_offline: !navigator.onLine,
+            has_active_interaction: useInteractionStore.getState().interaction !== null,
+          });
+          // Drop the new SW + its precache. Existing tab keeps its in-memory bundle;
+          // next reload will fetch from network without a SW until a fix re-deploys.
+          await clearPrecaches();
+          try {
+            await registration.unregister();
+          } catch {
+            // best-effort
+          }
+          // Allow a future update attempt (don't leave RELOAD_FLAG_KEY set since
+          // we never actually reloaded).
+          hasTriggeredReload.current = false;
+          return;
+        }
+
+        captureSmokeEvent('pwa_smoke_passed', {
+          from_version: __APP_VERSION__,
+          to_version: result.version,
+          duration_ms: result.durationMs,
+          retries: result.retries,
+        });
+      }
+
+      // Common reload path — used by both the gated-success branch and the
+      // flag-disabled / iOS-bypass / no-waiting-worker fall-through.
+      try {
+        sessionStorage.setItem(RELOAD_FLAG_KEY, Date.now().toString());
+      } catch {
+        // best-effort
+      }
+
       const wasSafe = await waitForSafeReload(MAX_IDLE_WAIT_MS, abortController.signal);
-
-      // Don't proceed if aborted during wait
       if (abortController.signal.aborted) return;
-
       if (!wasSafe) {
         console.warn('Timed out waiting for idle, proceeding with update');
       }
 
-      // Show toast notification
       addToast(t('toast.updating'), 'info', UPDATE_TOAST_MS);
 
-      // Brief delay to let user see the toast (cancellable)
+      // Brief delay so the user actually sees the toast (cancellable).
       await new Promise<void>((resolve) => {
         if (abortController.signal.aborted) {
           resolve();
@@ -435,14 +520,17 @@ export function usePWAUpdate(): void {
         });
       });
 
-      // Save current UI state before reload so we can restore it
+      // Save UI state right before reload (after smoke success in the gated path,
+      // so we never leave stale ephemeral state behind a failed gate run).
       saveEphemeralState(gatherEphemeralState());
 
-      // Trigger the update (reloads the page)
+      // updateServiceWorker(true) sends SKIP_WAITING + reloads. In the gated
+      // path the new SW is already 'activated', so SKIP_WAITING is a no-op
+      // and only the reload runs.
       void updateServiceWorker(true);
     };
 
-    void performUpdate();
+    void gatedUpdate();
 
     return () => {
       abortController.abort();

--- a/src/shared/pwa/featureFlag.test.ts
+++ b/src/shared/pwa/featureFlag.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('@/shared/analytics/posthog/init', () => ({
+  getPosthogInstance: vi.fn(),
+}));
+
+import { getSmokeGateFlag } from './featureFlag';
+import { getPosthogInstance } from '@/shared/analytics/posthog/init';
+
+const FLAG_KEY = 'pwa-smoke-gate-enabled';
+
+describe('getSmokeGateFlag', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('returns false when PostHog is not initialized', async () => {
+    vi.mocked(getPosthogInstance).mockReturnValue(null);
+    await expect(getSmokeGateFlag()).resolves.toBe(false);
+  });
+
+  it('returns true when PostHog reports the flag enabled', async () => {
+    const onFeatureFlags = vi.fn((cb: () => void) => {
+      cb();
+    });
+    const getFeatureFlag = vi.fn().mockReturnValue(true);
+    vi.mocked(getPosthogInstance).mockReturnValue({
+      onFeatureFlags,
+      getFeatureFlag,
+    } as unknown as ReturnType<typeof getPosthogInstance>);
+
+    await expect(getSmokeGateFlag()).resolves.toBe(true);
+    expect(getFeatureFlag).toHaveBeenCalledWith(FLAG_KEY);
+  });
+
+  it('returns false when PostHog reports the flag explicitly false', async () => {
+    vi.mocked(getPosthogInstance).mockReturnValue({
+      onFeatureFlags: (cb: () => void) => cb(),
+      getFeatureFlag: () => false,
+    } as unknown as ReturnType<typeof getPosthogInstance>);
+
+    await expect(getSmokeGateFlag()).resolves.toBe(false);
+  });
+
+  it('returns false when PostHog returns undefined (flag not yet loaded)', async () => {
+    vi.mocked(getPosthogInstance).mockReturnValue({
+      onFeatureFlags: (cb: () => void) => cb(),
+      getFeatureFlag: () => undefined,
+    } as unknown as ReturnType<typeof getPosthogInstance>);
+
+    await expect(getSmokeGateFlag()).resolves.toBe(false);
+  });
+
+  it('returns false when PostHog returns a string variant (only boolean true counts)', async () => {
+    vi.mocked(getPosthogInstance).mockReturnValue({
+      onFeatureFlags: (cb: () => void) => cb(),
+      getFeatureFlag: () => 'control',
+    } as unknown as ReturnType<typeof getPosthogInstance>);
+
+    await expect(getSmokeGateFlag()).resolves.toBe(false);
+  });
+
+  it('returns false after 2s when onFeatureFlags never fires', async () => {
+    vi.mocked(getPosthogInstance).mockReturnValue({
+      onFeatureFlags: vi.fn(),
+      getFeatureFlag: vi.fn(),
+    } as unknown as ReturnType<typeof getPosthogInstance>);
+
+    const promise = getSmokeGateFlag();
+    await vi.advanceTimersByTimeAsync(2000);
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it('returns false when onFeatureFlags throws synchronously', async () => {
+    vi.mocked(getPosthogInstance).mockReturnValue({
+      onFeatureFlags: () => {
+        throw new Error('PostHog blocked');
+      },
+      getFeatureFlag: vi.fn(),
+    } as unknown as ReturnType<typeof getPosthogInstance>);
+
+    await expect(getSmokeGateFlag()).resolves.toBe(false);
+  });
+});

--- a/src/shared/pwa/featureFlag.test.ts
+++ b/src/shared/pwa/featureFlag.test.ts
@@ -5,7 +5,7 @@ vi.mock('@/shared/analytics/posthog/init', () => ({
   getPosthogInstance: vi.fn(),
 }));
 
-import { getSmokeGateFlag } from './featureFlag';
+import { getSmokeGateFlag, _resetSmokeGateFlagCache } from './featureFlag';
 import { getPosthogInstance } from '@/shared/analytics/posthog/init';
 
 const FLAG_KEY = 'pwa-smoke-gate-enabled';
@@ -13,11 +13,13 @@ const FLAG_KEY = 'pwa-smoke-gate-enabled';
 describe('getSmokeGateFlag', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    _resetSmokeGateFlagCache();
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+    _resetSmokeGateFlagCache();
   });
 
   it('returns false when PostHog is not initialized', async () => {

--- a/src/shared/pwa/featureFlag.ts
+++ b/src/shared/pwa/featureFlag.ts
@@ -1,0 +1,44 @@
+import { getPosthogInstance } from '@/shared/analytics/posthog/init';
+
+/** PostHog flag that gates the client-side smoke harness. */
+const FLAG_KEY = 'pwa-smoke-gate-enabled';
+
+/** Hard cap on how long we'll wait for PostHog to deliver flag values. */
+const FLAG_RESOLVE_TIMEOUT_MS = 2000;
+
+/**
+ * Resolve the smoke-gate feature flag. Returns `false` on any failure path —
+ * PostHog blocked by an adblocker, EU consent denied, dev mode, init failure,
+ * or just slow flag delivery. Failure-mode parity with "flag disabled" is
+ * deliberate: a misbehaving flag plumbing must never leave the user stuck on
+ * an unverified bundle.
+ */
+export async function getSmokeGateFlag(): Promise<boolean> {
+  const posthog = getPosthogInstance();
+  if (!posthog) return false;
+
+  // posthog-js fires `onFeatureFlags` once flags are available (either from
+  // localStorage cache or after the first network round-trip). Use it instead
+  // of polling getFeatureFlag, which can return undefined indefinitely.
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (value: boolean): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+
+    const timeoutId = window.setTimeout(() => finish(false), FLAG_RESOLVE_TIMEOUT_MS);
+
+    try {
+      posthog.onFeatureFlags(() => {
+        window.clearTimeout(timeoutId);
+        const value = posthog.getFeatureFlag(FLAG_KEY);
+        finish(value === true);
+      });
+    } catch {
+      window.clearTimeout(timeoutId);
+      finish(false);
+    }
+  });
+}

--- a/src/shared/pwa/featureFlag.ts
+++ b/src/shared/pwa/featureFlag.ts
@@ -7,20 +7,30 @@ const FLAG_KEY = 'pwa-smoke-gate-enabled';
 const FLAG_RESOLVE_TIMEOUT_MS = 2000;
 
 /**
+ * Module-level cache. The flag value doesn't change within a session (PostHog
+ * delivers it once), so memoize the in-flight promise and its result so
+ * repeated callers don't each register a new `onFeatureFlags` callback —
+ * those accumulate in posthog-js and are never cleaned up.
+ */
+let cached: Promise<boolean> | null = null;
+
+/**
  * Resolve the smoke-gate feature flag. Returns `false` on any failure path —
  * PostHog blocked by an adblocker, EU consent denied, dev mode, init failure,
  * or just slow flag delivery. Failure-mode parity with "flag disabled" is
  * deliberate: a misbehaving flag plumbing must never leave the user stuck on
  * an unverified bundle.
  */
-export async function getSmokeGateFlag(): Promise<boolean> {
-  const posthog = getPosthogInstance();
-  if (!posthog) return false;
+export function getSmokeGateFlag(): Promise<boolean> {
+  if (cached) return cached;
 
-  // posthog-js fires `onFeatureFlags` once flags are available (either from
-  // localStorage cache or after the first network round-trip). Use it instead
-  // of polling getFeatureFlag, which can return undefined indefinitely.
-  return new Promise<boolean>((resolve) => {
+  cached = new Promise<boolean>((resolve) => {
+    const posthog = getPosthogInstance();
+    if (!posthog) {
+      resolve(false);
+      return;
+    }
+
     let settled = false;
     const finish = (value: boolean): void => {
       if (settled) return;
@@ -30,6 +40,9 @@ export async function getSmokeGateFlag(): Promise<boolean> {
 
     const timeoutId = window.setTimeout(() => finish(false), FLAG_RESOLVE_TIMEOUT_MS);
 
+    // posthog-js fires `onFeatureFlags` once flags are available (either from
+    // localStorage cache or after the first network round-trip). Use it
+    // instead of polling getFeatureFlag, which can return undefined indefinitely.
     try {
       posthog.onFeatureFlags(() => {
         window.clearTimeout(timeoutId);
@@ -41,4 +54,11 @@ export async function getSmokeGateFlag(): Promise<boolean> {
       finish(false);
     }
   });
+
+  return cached;
+}
+
+/** Test-only — reset the module-level memo between tests. */
+export function _resetSmokeGateFlagCache(): void {
+  cached = null;
 }

--- a/src/shared/pwa/iosBypass.test.ts
+++ b/src/shared/pwa/iosBypass.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { isIosStandalonePwa } from './iosBypass';
+
+describe('isIosStandalonePwa', () => {
+  const originalUserAgent = navigator.userAgent;
+  const originalPlatform = navigator.platform;
+  const originalMaxTouchPoints = navigator.maxTouchPoints;
+  const originalMatchMedia = window.matchMedia;
+
+  function setNavigator(overrides: {
+    userAgent?: string;
+    platform?: string;
+    maxTouchPoints?: number;
+    standalone?: boolean;
+  }): void {
+    if (overrides.userAgent !== undefined) {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: overrides.userAgent,
+        configurable: true,
+      });
+    }
+    if (overrides.platform !== undefined) {
+      Object.defineProperty(navigator, 'platform', {
+        value: overrides.platform,
+        configurable: true,
+      });
+    }
+    if (overrides.maxTouchPoints !== undefined) {
+      Object.defineProperty(navigator, 'maxTouchPoints', {
+        value: overrides.maxTouchPoints,
+        configurable: true,
+      });
+    }
+    if (overrides.standalone !== undefined) {
+      Object.defineProperty(navigator, 'standalone', {
+        value: overrides.standalone,
+        configurable: true,
+      });
+    }
+  }
+
+  function setStandaloneMatch(matches: boolean): void {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches,
+      media: '(display-mode: standalone)',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+  }
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'userAgent', { value: originalUserAgent, configurable: true });
+    Object.defineProperty(navigator, 'platform', { value: originalPlatform, configurable: true });
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      value: originalMaxTouchPoints,
+      configurable: true,
+    });
+    window.matchMedia = originalMatchMedia;
+  });
+
+  beforeEach(() => {
+    setStandaloneMatch(false);
+  });
+
+  it('returns false on a desktop browser', () => {
+    setNavigator({
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/605.1.15 Chrome/124.0',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      standalone: false,
+    });
+    expect(isIosStandalonePwa()).toBe(false);
+  });
+
+  it('returns false on iOS Safari (browser, not installed)', () => {
+    setNavigator({
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
+      platform: 'iPhone',
+      standalone: false,
+    });
+    setStandaloneMatch(false);
+    expect(isIosStandalonePwa()).toBe(false);
+  });
+
+  it('returns true on iPhone home-screen install via navigator.standalone', () => {
+    setNavigator({
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
+      platform: 'iPhone',
+      standalone: true,
+    });
+    expect(isIosStandalonePwa()).toBe(true);
+  });
+
+  it('returns true on iPhone home-screen install via display-mode media query', () => {
+    setNavigator({
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
+      platform: 'iPhone',
+      standalone: false,
+    });
+    setStandaloneMatch(true);
+    expect(isIosStandalonePwa()).toBe(true);
+  });
+
+  it('returns true on iPadOS 13+ (MacIntel + multi-touch) installed PWA', () => {
+    setNavigator({
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15',
+      platform: 'MacIntel',
+      maxTouchPoints: 5,
+      standalone: true,
+    });
+    expect(isIosStandalonePwa()).toBe(true);
+  });
+
+  it('returns false on macOS desktop Safari standalone PWA — not iOS', () => {
+    setNavigator({
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      standalone: true,
+    });
+    expect(isIosStandalonePwa()).toBe(false);
+  });
+});

--- a/src/shared/pwa/iosBypass.ts
+++ b/src/shared/pwa/iosBypass.ts
@@ -1,0 +1,32 @@
+/**
+ * Detect iOS Safari running as an installed home-screen PWA. SW lifecycle on
+ * this surface is unreliable in well-known ways: `controllerchange` doesn't
+ * always fire, `registration.waiting` is sometimes null when an update exists,
+ * and iOS aggressively kills offscreen iframes when the PWA backgrounds.
+ *
+ * Treating this surface as "smoke gate disabled" trades the gate's safety net
+ * for the user's app actually working. Logged via PostHog so we can measure
+ * exposure if the gate ever becomes a hard requirement.
+ */
+export function isIosStandalonePwa(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  // iOS Safari historically sets `navigator.standalone` for home-screen apps.
+  // Modern iOS versions also honor the standard `display-mode: standalone`.
+  const navStandalone = (navigator as unknown as { standalone?: boolean }).standalone === true;
+  const matchesStandalone =
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(display-mode: standalone)').matches;
+
+  // UA sniffing for iOS — `iPad` UA on iPadOS 13+ reports as "MacIntel" with
+  // touch points >0. Both checks together cover iPhone/iPad PWAs.
+  const ua = navigator.userAgent;
+  const isIphoneOrIpod = /iPhone|iPod/.test(ua);
+  const isIpadOs13Plus =
+    navigator.platform === 'MacIntel' &&
+    typeof navigator.maxTouchPoints === 'number' &&
+    navigator.maxTouchPoints > 1;
+  const isIos = isIphoneOrIpod || isIpadOs13Plus;
+
+  return isIos && (navStandalone || matchesStandalone);
+}

--- a/src/shared/pwa/smokeGate.test.ts
+++ b/src/shared/pwa/smokeGate.test.ts
@@ -1,0 +1,304 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { runUpdateSmokeTest } from './smokeGate';
+import { SMOKE_MESSAGE_TYPE } from '@/shared/utils/smokeMode';
+
+interface MockWorker {
+  state: ServiceWorkerState;
+  postMessage: ReturnType<typeof vi.fn>;
+  addEventListener: (type: string, listener: () => void) => void;
+  removeEventListener: (type: string, listener: () => void) => void;
+  fireStateChange: (newState: ServiceWorkerState) => void;
+}
+
+function makeWorker(initialState: ServiceWorkerState = 'installed'): MockWorker {
+  let state: ServiceWorkerState = initialState;
+  const listeners = new Set<() => void>();
+  return {
+    get state() {
+      return state;
+    },
+    set state(s: ServiceWorkerState) {
+      state = s;
+    },
+    postMessage: vi.fn(),
+    addEventListener: (type: string, listener: () => void) => {
+      if (type === 'statechange') listeners.add(listener);
+    },
+    removeEventListener: (type: string, listener: () => void) => {
+      if (type === 'statechange') listeners.delete(listener);
+    },
+    fireStateChange(newState: ServiceWorkerState) {
+      state = newState;
+      for (const l of listeners) l();
+    },
+  };
+}
+
+function makeRegistration(waiting: MockWorker | null): ServiceWorkerRegistration {
+  return {
+    waiting,
+    unregister: vi.fn().mockResolvedValue(true),
+  } as unknown as ServiceWorkerRegistration;
+}
+
+const FRESH_VERSION = {
+  version: '4.48.0',
+  gitSha: 'abc1234',
+  buildTime: '2026-04-26T18:00:00.000Z',
+};
+
+function mockFetchVersion(payload: typeof FRESH_VERSION | { ok: false; status?: number }): void {
+  // Build a minimal duck-typed Response to avoid the jsdom Response constructor's
+  // internal stream timers, which clash with vi.useFakeTimers().
+  global.fetch = vi.fn().mockImplementation(() => {
+    if ('ok' in payload && !payload.ok) {
+      return Promise.resolve({
+        ok: false,
+        status: payload.status ?? 500,
+        json: () => Promise.resolve({}),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(payload),
+    });
+  });
+}
+
+/**
+ * Drain microtasks so the gate's awaits (fetch, JSON parse, etc.) resolve before
+ * the test drives the next event. 10 ticks is overkill for our flow, but cheap.
+ */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+}
+
+/**
+ * Find the iframe the gate just appended and dispatch a postMessage from it.
+ * Source must match contentWindow for the gate's strict check to pass.
+ */
+function postFromIframe(data: unknown, originOverride?: string): void {
+  const iframe = document.querySelector<HTMLIFrameElement>('iframe[src="/?smoke=1"]');
+  if (!iframe) throw new Error('iframe not found');
+  const event = new MessageEvent('message', {
+    data,
+    origin: originOverride ?? window.location.origin,
+    source: iframe.contentWindow,
+  });
+  window.dispatchEvent(event);
+}
+
+describe('runUpdateSmokeTest', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.replaceChildren();
+    mockFetchVersion(FRESH_VERSION);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.body.replaceChildren();
+  });
+
+  it('returns ok when SW activates, iframe boots, and versions match', async () => {
+    const worker = makeWorker('installed');
+    const registration = makeRegistration(worker);
+
+    const promise = runUpdateSmokeTest(registration);
+
+    // Let the gate fetch /version.json and post SKIP_WAITING.
+    await flush();
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+
+    // Activate the worker — gate proceeds to spawn the iframe.
+    worker.fireStateChange('activating');
+    worker.fireStateChange('activated');
+    await flush();
+
+    postFromIframe({
+      type: SMOKE_MESSAGE_TYPE,
+      smokeOk: true,
+      version: FRESH_VERSION.version,
+      gitSha: FRESH_VERSION.gitSha,
+      buildTime: FRESH_VERSION.buildTime,
+    });
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+    expect(result.version).toBe(FRESH_VERSION.version);
+    expect(result.expectedVersion).toBe(FRESH_VERSION.version);
+    expect(document.querySelector('iframe[src="/?smoke=1"]')).toBeNull();
+  });
+
+  it('reports version_mismatch when iframe gitSha differs from /version.json', async () => {
+    const worker = makeWorker('installed');
+    const registration = makeRegistration(worker);
+
+    const promise = runUpdateSmokeTest(registration);
+    await flush();
+
+    worker.fireStateChange('activated');
+    await flush();
+
+    postFromIframe({
+      type: SMOKE_MESSAGE_TYPE,
+      smokeOk: true,
+      version: '4.48.0',
+      gitSha: 'staleeee',
+      buildTime: FRESH_VERSION.buildTime,
+    });
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('version_mismatch');
+    expect(result.expectedVersion).toBe(FRESH_VERSION.version);
+  });
+
+  it('returns version_fetch_failed when /version.json is non-200', async () => {
+    mockFetchVersion({ ok: false, status: 502 });
+    const worker = makeWorker('installed');
+    const registration = makeRegistration(worker);
+
+    const result = await runUpdateSmokeTest(registration);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('version_fetch_failed');
+    expect(worker.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('returns no_waiting_worker when registration.waiting is null', async () => {
+    const registration = makeRegistration(null);
+    const result = await runUpdateSmokeTest(registration);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('no_waiting_worker');
+  });
+
+  it('returns activate_failed when the worker becomes redundant', async () => {
+    const worker = makeWorker('installed');
+    const registration = makeRegistration(worker);
+
+    const promise = runUpdateSmokeTest(registration);
+    await flush();
+
+    worker.fireStateChange('redundant');
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('activate_failed');
+    expect(result.reason).toContain('activate_redundant');
+  });
+
+  it('reports activate_timeout when the worker never activates', async () => {
+    const worker = makeWorker('installed');
+    const registration = makeRegistration(worker);
+
+    const promise = runUpdateSmokeTest(registration);
+    await flush();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('activate_timeout');
+  });
+
+  it('retries iframe smoke once on timeout, then gives up', async () => {
+    const worker = makeWorker('installed');
+    const registration = makeRegistration(worker);
+
+    const promise = runUpdateSmokeTest(registration);
+    await flush();
+    worker.fireStateChange('activated');
+    await flush();
+
+    // First attempt — drive its 10s timeout without posting.
+    await vi.advanceTimersByTimeAsync(10_000);
+    await flush();
+    // Retry — drive that timeout too.
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('timeout');
+    expect(result.retries).toBe(1);
+  });
+
+  it('rejects messages from a wrong origin (anti-spoof)', async () => {
+    const worker = makeWorker('installed');
+    const registration = makeRegistration(worker);
+
+    const promise = runUpdateSmokeTest(registration);
+    await flush();
+    worker.fireStateChange('activated');
+    await flush();
+
+    // Wrong origin — must be ignored, not treated as a pass.
+    postFromIframe(
+      {
+        type: SMOKE_MESSAGE_TYPE,
+        smokeOk: true,
+        version: FRESH_VERSION.version,
+        gitSha: FRESH_VERSION.gitSha,
+        buildTime: FRESH_VERSION.buildTime,
+      },
+      'https://evil.example.com'
+    );
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await flush();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('timeout');
+  });
+
+  it('reports iframe_reported when the iframe self-reports a failure', async () => {
+    const worker = makeWorker('installed');
+    const registration = makeRegistration(worker);
+
+    const promise = runUpdateSmokeTest(registration);
+    await flush();
+    worker.fireStateChange('activated');
+    await flush();
+
+    postFromIframe({
+      type: SMOKE_MESSAGE_TYPE,
+      smokeOk: false,
+      reason: 'error:boom',
+      version: FRESH_VERSION.version,
+      gitSha: FRESH_VERSION.gitSha,
+      buildTime: FRESH_VERSION.buildTime,
+    });
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('iframe_reported:error:boom');
+    // iframe_reported is non-transient — must NOT retry.
+    expect(result.retries).toBe(0);
+  });
+
+  it('skips SKIP_WAITING if the worker is already activated', async () => {
+    const worker = makeWorker('activated');
+    const registration = makeRegistration(worker);
+
+    const promise = runUpdateSmokeTest(registration);
+    await flush();
+
+    // Already-activated worker: no SKIP_WAITING needed, gate proceeds straight to iframe.
+    expect(worker.postMessage).not.toHaveBeenCalled();
+
+    postFromIframe({
+      type: SMOKE_MESSAGE_TYPE,
+      smokeOk: true,
+      version: FRESH_VERSION.version,
+      gitSha: FRESH_VERSION.gitSha,
+      buildTime: FRESH_VERSION.buildTime,
+    });
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/shared/pwa/smokeGate.test.ts
+++ b/src/shared/pwa/smokeGate.test.ts
@@ -50,21 +50,26 @@ const FRESH_VERSION = {
 
 function mockFetchVersion(payload: typeof FRESH_VERSION | { ok: false; status?: number }): void {
   // Build a minimal duck-typed Response to avoid the jsdom Response constructor's
-  // internal stream timers, which clash with vi.useFakeTimers().
-  global.fetch = vi.fn().mockImplementation(() => {
-    if ('ok' in payload && !payload.ok) {
+  // internal stream timers, which clash with vi.useFakeTimers(). vi.stubGlobal
+  // is restored automatically by vi.unstubAllGlobals() in afterEach so the
+  // fetch override doesn't leak into other test files.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation(() => {
+      if ('ok' in payload && !payload.ok) {
+        return Promise.resolve({
+          ok: false,
+          status: payload.status ?? 500,
+          json: () => Promise.resolve({}),
+        });
+      }
       return Promise.resolve({
-        ok: false,
-        status: payload.status ?? 500,
-        json: () => Promise.resolve({}),
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(payload),
       });
-    }
-    return Promise.resolve({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve(payload),
-    });
-  });
+    })
+  );
 }
 
 /**
@@ -100,6 +105,7 @@ describe('runUpdateSmokeTest', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     document.body.replaceChildren();
   });
 

--- a/src/shared/pwa/smokeGate.ts
+++ b/src/shared/pwa/smokeGate.ts
@@ -1,0 +1,232 @@
+import { SMOKE_MESSAGE_TYPE, type SmokeResultMessage } from '@/shared/utils/smokeMode';
+
+/**
+ * One smoke attempt has 10s to complete: SW activation + iframe boot + fixture
+ * render + postMessage. Realistic in normal conditions; longer than that almost
+ * always means a real problem.
+ */
+const SMOKE_ATTEMPT_TIMEOUT_MS = 10_000;
+
+/** Activation alone (SKIP_WAITING → state=activated) shouldn't take more than this. */
+const ACTIVATE_TIMEOUT_MS = 5_000;
+
+/** Number of retries on iframe boot failure. Total budget = (1 + retries) * ATTEMPT_TIMEOUT. */
+const SMOKE_RETRIES = 1;
+
+export interface SmokeGateResult {
+  ok: boolean;
+  reason?: string;
+  /** Version reported by the iframe (i.e., the new bundle), if it got far enough. */
+  version?: string;
+  /** /version.json's reported version (i.e., what the deploy says is live). */
+  expectedVersion?: string;
+  durationMs: number;
+  retries: number;
+}
+
+interface VersionPayload {
+  version: string;
+  gitSha: string;
+  buildTime: string;
+}
+
+/**
+ * Run the client-side update smoke test. Caller is responsible for checking the
+ * PostHog flag + iOS bypass first; this function assumes those gates have passed.
+ *
+ * Sequence:
+ *   1. Fetch /version.json from the parent context (the deploy's source of truth).
+ *      Because `version.json` is globIgnored from the SW precache, this hits
+ *      network/CDN and reflects the just-deployed asset graph.
+ *   2. Send SKIP_WAITING to the waiting worker, then wait for `statechange` →
+ *      `activated`. Do NOT use `controllerchange`: with `clientsClaim:false`
+ *      the parent tab is never claimed and that event would never fire.
+ *   3. Open a hidden iframe at `/?smoke=1`. With the new SW now active, the
+ *      iframe's initial navigation is served by the new SW = new bundle.
+ *   4. Listen for a postMessage from the iframe (with strict origin + source
+ *      validation). Compare the iframe's compile-time gitSha to /version.json.
+ *      Any mismatch is a stale-SW or asset-graph-mismatch failure.
+ *
+ * On failure the caller should `caches.delete()` the precache + `unregister()`.
+ */
+export async function runUpdateSmokeTest(
+  registration: ServiceWorkerRegistration
+): Promise<SmokeGateResult> {
+  const start = performance.now();
+
+  let expected: VersionPayload;
+  try {
+    const res = await fetch('/version.json', { cache: 'reload' });
+    if (!res.ok) {
+      return failure('version_fetch_failed', start, 0);
+    }
+    expected = (await res.json()) as VersionPayload;
+  } catch {
+    return failure('version_fetch_threw', start, 0);
+  }
+
+  const waiting = registration.waiting;
+  if (!waiting) return failure('no_waiting_worker', start, 0, undefined, expected);
+
+  try {
+    await activateWaitingWorker(waiting);
+  } catch (err) {
+    return failure(`activate_failed:${asReason(err)}`, start, 0, undefined, expected);
+  }
+
+  for (let attempt = 0; attempt <= SMOKE_RETRIES; attempt++) {
+    let result: IframeSmokeOutcome;
+    try {
+      result = await runIframeSmoke();
+    } catch (err) {
+      result = { ok: false, reason: `iframe_threw:${asReason(err)}` };
+    }
+
+    if (!result.ok) {
+      // Retry only transient failures: iframe never reported (timeout) or the
+      // iframe element failed to load (network/CSP). Do NOT retry
+      // `iframe_reported:*` — the iframe loaded fine and deterministically said
+      // smoke failed; another attempt will say the same thing.
+      const isTransient = result.reason === 'timeout' || result.reason === 'iframe_load_error';
+      if (isTransient && attempt < SMOKE_RETRIES) continue;
+      return failure(result.reason, start, attempt, undefined, expected);
+    }
+
+    // Iframe booted and reported. Verify version matches the deployed source of truth.
+    if (result.payload.gitSha !== expected.gitSha) {
+      return failure('version_mismatch', start, attempt, result.payload.version, expected);
+    }
+
+    return {
+      ok: true,
+      version: result.payload.version,
+      expectedVersion: expected.version,
+      durationMs: performance.now() - start,
+      retries: attempt,
+    };
+  }
+
+  return failure('exhausted_retries', start, SMOKE_RETRIES, undefined, expected);
+}
+
+function failure(
+  reason: string,
+  start: number,
+  retries: number,
+  version?: string,
+  expected?: VersionPayload | null
+): SmokeGateResult {
+  return {
+    ok: false,
+    reason,
+    version,
+    expectedVersion: expected?.version,
+    durationMs: performance.now() - start,
+    retries,
+  };
+}
+
+function asReason(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Send SKIP_WAITING and wait for the worker to reach 'activated'. Times out so
+ * a SW stuck in installing/activating can't hang the gate forever.
+ */
+function activateWaitingWorker(waiting: ServiceWorker): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (waiting.state === 'activated') {
+      resolve();
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      waiting.removeEventListener('statechange', onStateChange);
+      reject(new Error(`activate_timeout:${waiting.state}`));
+    }, ACTIVATE_TIMEOUT_MS);
+
+    const onStateChange = (): void => {
+      if (waiting.state === 'activated') {
+        window.clearTimeout(timeoutId);
+        waiting.removeEventListener('statechange', onStateChange);
+        resolve();
+      } else if (waiting.state === 'redundant') {
+        window.clearTimeout(timeoutId);
+        waiting.removeEventListener('statechange', onStateChange);
+        reject(new Error('activate_redundant'));
+      }
+    };
+    waiting.addEventListener('statechange', onStateChange);
+
+    try {
+      waiting.postMessage({ type: 'SKIP_WAITING' });
+    } catch (err) {
+      window.clearTimeout(timeoutId);
+      waiting.removeEventListener('statechange', onStateChange);
+      reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  });
+}
+
+type IframeSmokeOutcome = { ok: true; payload: VersionPayload } | { ok: false; reason: string };
+
+/**
+ * Spawn an offscreen iframe at `/?smoke=1` and wait for a structured smoke
+ * result message back. Validates origin + source so a same-origin opener can't
+ * spoof a pass. Cleans up the iframe and listener regardless of outcome.
+ */
+function runIframeSmoke(): Promise<IframeSmokeOutcome> {
+  return new Promise((resolve) => {
+    const iframe = document.createElement('iframe');
+    iframe.setAttribute('aria-hidden', 'true');
+    iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+    iframe.style.position = 'absolute';
+    iframe.style.width = '1280px';
+    iframe.style.height = '720px';
+    iframe.style.left = '-10000px';
+    iframe.style.top = '-10000px';
+    iframe.style.border = '0';
+    iframe.src = '/?smoke=1';
+
+    let settled = false;
+    const finish = (outcome: IframeSmokeOutcome): void => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeoutId);
+      window.removeEventListener('message', onMessage);
+      iframe.remove();
+      resolve(outcome);
+    };
+
+    const timeoutId = window.setTimeout(
+      () => finish({ ok: false, reason: 'timeout' }),
+      SMOKE_ATTEMPT_TIMEOUT_MS
+    );
+
+    const onMessage = (event: MessageEvent): void => {
+      // Strict source/origin gating — without these any same-origin window could spoof.
+      if (event.origin !== window.location.origin) return;
+      if (event.source !== iframe.contentWindow) return;
+
+      const data = event.data as Partial<SmokeResultMessage> | undefined;
+      if (!data || data.type !== SMOKE_MESSAGE_TYPE) return;
+
+      if (data.smokeOk === true && data.version && data.gitSha && data.buildTime) {
+        finish({
+          ok: true,
+          payload: { version: data.version, gitSha: data.gitSha, buildTime: data.buildTime },
+        });
+      } else {
+        finish({ ok: false, reason: `iframe_reported:${data.reason ?? 'unknown'}` });
+      }
+    };
+    window.addEventListener('message', onMessage);
+
+    iframe.addEventListener('error', () => finish({ ok: false, reason: 'iframe_load_error' }), {
+      once: true,
+    });
+
+    document.body.appendChild(iframe);
+  });
+}

--- a/src/shared/pwa/smokeGate.ts
+++ b/src/shared/pwa/smokeGate.ts
@@ -1,16 +1,16 @@
 import { SMOKE_MESSAGE_TYPE, type SmokeResultMessage } from '@/shared/utils/smokeMode';
 
 /**
- * One smoke attempt has 10s to complete: SW activation + iframe boot + fixture
- * render + postMessage. Realistic in normal conditions; longer than that almost
- * always means a real problem.
+ * Per-attempt budget for the iframe phase only (load + fixture render +
+ * postMessage). Activation runs once before the retry loop with its own budget.
+ * Total worst-case wall time: ACTIVATE_TIMEOUT_MS + (1 + SMOKE_RETRIES) * SMOKE_ATTEMPT_TIMEOUT_MS.
  */
 const SMOKE_ATTEMPT_TIMEOUT_MS = 10_000;
 
 /** Activation alone (SKIP_WAITING → state=activated) shouldn't take more than this. */
 const ACTIVATE_TIMEOUT_MS = 5_000;
 
-/** Number of retries on iframe boot failure. Total budget = (1 + retries) * ATTEMPT_TIMEOUT. */
+/** Number of retries on transient iframe failures. Activation is not retried. */
 const SMOKE_RETRIES = 1;
 
 export interface SmokeGateResult {
@@ -180,7 +180,14 @@ function runIframeSmoke(): Promise<IframeSmokeOutcome> {
   return new Promise((resolve) => {
     const iframe = document.createElement('iframe');
     iframe.setAttribute('aria-hidden', 'true');
-    iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+    // No sandbox attribute set on purpose. We considered
+    // `sandbox="allow-scripts allow-same-origin"`, but per the HTML spec that
+    // combination is equivalent to no sandbox at all (the same-origin script
+    // can call out to its parent and remove the sandbox via document mutation).
+    // The iframe loads our own bundle from our own origin under our own SW,
+    // so there's no security boundary a stricter sandbox could enforce. A
+    // sandbox that omitted `allow-same-origin` would also break the smoke
+    // boot, which uses localStorage for locale.
     iframe.style.position = 'absolute';
     iframe.style.width = '1280px';
     iframe.style.height = '720px';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,7 +43,9 @@ export default defineConfig({
     tailwindcss(),
     versionPlugin(),
     VitePWA({
-      registerType: 'autoUpdate',
+      // 'prompt' so the smoke gate (src/shared/pwa/smokeGate.ts) controls activation.
+      // With 'autoUpdate' the new SW would auto-skip-waiting on install, defeating the gate.
+      registerType: 'prompt',
       // Note: Don't use includeAssets here - icons are precached via globPatterns,
       // except manifest icons (icon-192, icon-512) which are excluded via globIgnores
       // since they're auto-added by vite-plugin-pwa from manifest.icons below.
@@ -98,10 +100,13 @@ export default defineConfig({
         cacheId: 'gridfinity-v1',
         // Prevent accidentally precaching huge assets
         maximumFileSizeToCacheInBytes: 3 * 1024 * 1024, // 3MB per file
-        // Force the new service worker to activate immediately
-        skipWaiting: true,
-        // Take control of pages that were controlled by an old SW
-        clientsClaim: true,
+        // Don't auto-skip-waiting — the smoke gate sends SKIP_WAITING manually
+        // after a hidden-iframe smoke against the new bundle passes.
+        skipWaiting: false,
+        // Don't claim existing tabs on activation — keep them on the old SW until they
+        // reload, so an in-flight session is unaffected by a brand-new (potentially
+        // broken) bundle's runtime caching strategy.
+        clientsClaim: false,
         // Clean up old caches from previous versions
         cleanupOutdatedCaches: true,
         // SPA navigation fallback - serve index.html for all navigation requests


### PR DESCRIPTION
## Summary

Tier 2 of the PWA update smoke gate (#1475 was tier 1). Before reloading an existing user into a new bundle, activate the new SW manually, verify it serves the new bundle to a hidden iframe, then either green-light the reload or roll back the precache. Catches user-environment bugs that CI smoke can't (Safari WASM quirks, real-device network conditions, broken precache hashes).

**Behavior is gated behind PostHog flag `pwa-smoke-gate-enabled`.** Default off → existing auto-reload behavior preserved. iOS standalone PWAs are also bypassed (SW lifecycle there is too quirky to gate on safely).

## Lifecycle changes (vite.config.ts)

- `registerType: 'autoUpdate' → 'prompt'`
- `skipWaiting: true → false`
- `clientsClaim: true → false`

The gate sends `SKIP_WAITING` manually after smoke passes. Workbox still injects the message handler at `skipWaiting: false` — verified by checking `grep -c SKIP_WAITING dist/sw.js` after build.

## What it catches

- New bundle serves but won't boot in real-world conditions
- SW precache hash mismatch (compares iframe's `__GIT_SHA__` to `/version.json`)
- Asset graph drift between SW manifest and CDN

## What it deliberately doesn't do

- It does NOT roll back to the previous bundle. On failure: clear `gridfinity-v1-precache-*`, `unregister()` the new SW, log to PostHog, **leave the user on their currently-loaded in-memory bundle.** Their next reload fetches from network without a SW until a fix re-deploys. Fix-forward is the recovery model — tier 1 (the post-promote check on main) is the prevention model.

## Critical correctness notes

- Uses `statechange → activated` to detect activation, NOT `controllerchange`. With `clientsClaim:false` the parent tab is never claimed and `controllerchange` would never fire.
- `saveEphemeralState` moved to AFTER smoke success — never leave stale state behind a failed gate run.
- `smokeGate` is statically imported from `usePWAUpdate.ts` — dynamic import would emit a separately-hashed chunk, the exact failure pattern that bit `wwwMigration`.
- Strict origin + source validation on the iframe's postMessage so a same-origin opener can't spoof a pass.
- `iframe_reported:*` failures are deterministic — gate does NOT retry them. Only `timeout` and `iframe_load_error` retry.

## Test plan

- [x] 23 unit tests: happy path, version mismatch, version_fetch_failed, no_waiting_worker, redundant worker, activate timeout, iframe timeout retry, origin spoof, iframe self-reported failure, already-activated worker, all featureFlag + iosBypass edge cases
- [x] Bundle size unchanged at the limit (gate code is small + main is well under 190 kB)
- [x] `dist/sw.js` still emits SKIP_WAITING handler with skipWaiting:false
- [ ] CI green
- [ ] After merge, leave PostHog flag `pwa-smoke-gate-enabled` OFF for ~1 release cycle. Then turn on for 5–10% of users via PostHog and watch `pwa_smoke_passed` / `pwa_smoke_failed` events to validate rollout

## Operator notes (NOT for the README — internal only)

The first deploy of this PR will reach existing users via the OLD SW's `skipWaiting:true, clientsClaim:true` config — they'll auto-update one last time. From the next deploy onward, the gate engages. This one-shot bootstrap transition is unavoidable.

To turn on the gate after merge: create the `pwa-smoke-gate-enabled` boolean feature flag in PostHog, default false, then ramp via rollout.