### PR TITLE
fix(ci): unblock nightly mutation testing — bump dry-run timeout + cache hygiene

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -52,8 +52,12 @@ jobs:
         run: |
           set -eu
           if [ -f "$BASELINE_PATH" ]; then
-            if ! jq empty "$BASELINE_PATH" >/dev/null 2>&1; then
-              echo "::warning::Restored incremental baseline is not valid JSON; deleting so Stryker performs a clean full run."
+            # Validate both that it parses AND that it has the top-level
+            # "files" key Stryker writes — guards against a structurally
+            # valid but schema-wrong baseline (e.g. an empty object) that
+            # would still crash Stryker mid-run.
+            if ! jq -e 'type == "object" and has("files")' "$BASELINE_PATH" >/dev/null 2>&1; then
+              echo "::warning::Restored incremental baseline is missing the expected schema; deleting so Stryker performs a clean full run."
               rm -f "$BASELINE_PATH"
             else
               echo "Incremental baseline restored and validated."
@@ -66,12 +70,17 @@ jobs:
         run: pnpm run test:mutation
 
       - name: Upload incremental baseline
-        if: success()
+        # Upload on both success and failure so partial progress survives a
+        # mid-run timeout — the next run's "Validate incremental baseline"
+        # step will discard a corrupt or schema-wrong baseline. Skip only
+        # on cancellation, where the file is most likely half-written.
+        if: success() || failure()
         uses: actions/upload-artifact@v7
         with:
           name: mutation-incremental
           path: reports/mutation/incremental.json
           retention-days: 90
+          if-no-files-found: warn
 
       - name: Upload mutation report
         if: always()

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -46,6 +46,22 @@ jobs:
           path: reports/mutation/
           if_no_artifact_found: warn
 
+      - name: Validate incremental baseline
+        env:
+          BASELINE_PATH: reports/mutation/incremental.json
+        run: |
+          set -eu
+          if [ -f "$BASELINE_PATH" ]; then
+            if ! jq empty "$BASELINE_PATH" >/dev/null 2>&1; then
+              echo "::warning::Restored incremental baseline is not valid JSON; deleting so Stryker performs a clean full run."
+              rm -f "$BASELINE_PATH"
+            else
+              echo "Incremental baseline restored and validated."
+            fi
+          else
+            echo "No incremental baseline restored; Stryker will perform a full run."
+          fi
+
       - name: Run Stryker
         run: pnpm run test:mutation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,8 +165,6 @@ Reports land in `reports/mutation/mutation.html`. The incremental baseline (`inc
 
 **Surviving mutants** indicate tests whose assertions don't cover the mutated logic. Add assertions rather than deleting mutants. Use `// Stryker disable next-line <mutator>` only for genuinely equivalent mutants (e.g., unobservable optimizations).
 
-**Note:** The TypeScript checker is disabled due to a pre-existing `TS2883` portability warning in `src/liveblocks.config.ts` that only surfaces under composite declaration emit. Re-enable by adding `"@stryker-mutator/typescript-checker"` to `plugins` and `"typescript"` to `checkers` in `stryker.config.json` after annotating the `useEventListener` export type.
-
 Threshold is currently **advisory** — PRs are not blocked by mutation score. Will tighten after baseline stabilizes.
 
 ## Debugging & Bug Fixing

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -19,11 +19,11 @@
     "!**/*.test.tsx",
     "!**/*.bench.ts",
     "!**/*.d.ts",
-    "!**/__mocks__/**",
     "!**/types.ts"
   ],
   "timeoutMS": 120000,
-  "concurrency": 2,
+  "dryRunTimeoutMinutes": 15,
+  "concurrency": 4,
   "incremental": true,
   "incrementalFile": "reports/mutation/incremental.json",
   "reporters": ["html", "json", "progress", "clear-text"],


### PR DESCRIPTION
## Summary

The nightly Stryker workflow has been failing for **7+ consecutive days** ([latest run](https://github.com/andymai/gridfinity-layout-tool/actions/runs/24947013536), all earlier runs in the failure list show the same pattern). All failures share a single root cause:

```
03:13:26 INFO DryRunExecutor Starting initial test run (vitest test runner with "perTest" coverage analysis)…
03:18:29 ERROR DryRunExecutor Initial test run timed out!
03:18:29 ERROR Stryker Unexpected error occurred while running Stryker Error: Something went wrong in the initial test run
```

The dry run hits Stryker's default `dryRunTimeoutMinutes` of **5 minutes** before per-test coverage analysis finishes. Because `Upload incremental baseline` only runs `if: success()`, no baseline has been published since the first failure — so each subsequent night re-runs the full suite from scratch and times out again, perpetuating the broken state.

## Changes

### `stryker.config.json`
- **Add `dryRunTimeoutMinutes: 15`** (3× the default). The dry run is a single full vitest pass, so it scales with suite size, not with parallelism.
- **Raise `concurrency` 2 → 4.** Hosted runners have 4 vCPU; this only affects the post-dry-run mutant phase, not the dry run itself.
- **Drop `!**/__mocks__/**` from `mutate`.** Stryker logs `Glob pattern "!**/__mocks__/**" did not exclude any files` — there are no `__mocks__` directories under any mutated path.

### `.github/workflows/mutation-testing.yml`
- **Add `Validate incremental baseline` step** between artifact restore and Stryker. Uses preinstalled `jq` to verify `incremental.json` parses; if not, deletes it so Stryker performs a clean full run instead of crashing partway through. Defends against future cache corruption.

### `CLAUDE.md`
- **Remove stale doc note** claiming the TypeScript checker is disabled. It was re-enabled in #1457 and the current `stryker.config.json` already lists it under `checkers` and `plugins`.

## Test plan

- [ ] Schedule-only workflow can't run on this PR — verify by triggering `workflow_dispatch` on the branch (`gh workflow run mutation-testing.yml --ref chore/stryker-workflow-fix`) **after merge**, or wait for the next nightly
- [ ] First post-merge run will be a full run (no baseline yet); confirm it completes within the 15-minute dry-run budget
- [ ] Second nightly run should restore the freshly-uploaded baseline and complete in the documented ~5-10 min warm-cache time
- [ ] Once green, monitor for any OOM/concurrency issues from the 2 → 4 bump (unwind to 3 if observed)