### PR TITLE
chore(knip): move root entry/project config into workspaces map

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,17 +1,21 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
-  "entry": ["api/**/*.ts", "scripts/**/*.ts"],
-  "project": ["src/**/*.{ts,tsx}", "api/**/*.ts", "scripts/**/*.ts"],
-  "ignore": ["src/test/**", "**/*.test.{ts,tsx}", "**/index.ts"],
   "ignoreDependencies": ["axe-core", "postcss"],
   "exclude": ["exports", "types", "duplicates"],
-  "vite": {
-    "config": ["vite.config.ts"]
-  },
-  "vitest": {
-    "config": ["vite.config.ts", "vitest.config.ts"]
-  },
-  "playwright": {
-    "config": ["playwright.config.ts"]
+  "workspaces": {
+    ".": {
+      "entry": ["api/**/*.ts", "scripts/**/*.ts"],
+      "project": ["src/**/*.{ts,tsx}", "api/**/*.ts", "scripts/**/*.ts"],
+      "ignore": ["src/test/**", "**/*.test.{ts,tsx}", "**/index.ts"],
+      "vite": {
+        "config": ["vite.config.ts"]
+      },
+      "vitest": {
+        "config": ["vite.config.ts", "vitest.config.ts"]
+      },
+      "playwright": {
+        "config": ["playwright.config.ts"]
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Resolves the two configuration hints that knip emits on every run:

```
Configuration hints (2)
[api/**/*.ts, …]          knip.json  Remove, or move unused top-level entry to one of "workspaces"
[src/**/*.{ts,tsx}, …]    knip.json  Remove, or move unused top-level project to one of "workspaces"
```

Knip 6 prefers monorepos to declare per-workspace configuration via the `workspaces` map so each pattern is attributed to a concrete package. The repo is a pnpm monorepo with the root project plus `packages/branded-types`. The `src/**`, `api/**`, `scripts/**`, and `vite`/`vitest`/`playwright` patterns only apply to the root, so they all move under `workspaces["."]`.

`ignoreDependencies` and `exclude` stay at the top level — those legitimately apply repo-wide.

## Test plan

- [x] `pnpm exec knip` exits 0 with no output
- [x] `pnpm exec knip --treat-config-hints-as-errors` exits 0
- [x] No newly-detected issues introduced (output unchanged from before)