### PR TITLE
chore(uuid): drop misleading @deprecated tag, clarify intended use

### DIFF
--- a/src/shared/analytics/posthog/identity.ts
+++ b/src/shared/analytics/posthog/identity.ts
@@ -70,7 +70,6 @@ export function getStableUserId(): string {
   try {
     const data = loadAnalyticsData();
     if (!data.userId) {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- user IDs must remain UUIDs for PostHog identity stability
       data.userId = generateUUID();
       if (!data.firstSeen) {
         data.firstSeen = new Date().toISOString();
@@ -81,7 +80,6 @@ export function getStableUserId(): string {
   } catch {
     // localStorage unavailable (private browsing, storage full, etc.)
     // Fall back to a session-only ID
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- user IDs must remain UUIDs for PostHog identity stability
     return generateUUID();
   }
 }

--- a/src/shared/utils/uuid.ts
+++ b/src/shared/utils/uuid.ts
@@ -1,11 +1,15 @@
 import type { LayoutId } from '@/core/types';
 
 /**
- * Generate a UUID v4 for layout identification.
- * Uses crypto.randomUUID() when available, falls back to manual generation.
+ * Generate a UUID v4 (RFC 4122) for contexts that need a globally unique
+ * 122-bit identifier — e.g. PostHog analytics user IDs, where stability and
+ * standard format matter more than URL-friendliness.
  *
- * @deprecated Use generateLayoutId() for new layouts. UUIDs are kept for
- * backward compatibility with existing layouts.
+ * For layout IDs, prefer `generateLayoutId()` instead: it produces a shorter
+ * 12-char alphanumeric ID better suited to share URLs.
+ *
+ * Uses crypto.randomUUID() when available, falls back to manual generation
+ * via crypto.getRandomValues for older environments.
  */
 export function generateUUID(): string {
   const c = globalThis.crypto;


### PR DESCRIPTION
## Summary

`generateUUID()` was tagged `@deprecated` with the message:

> Use `generateLayoutId()` for new layouts. UUIDs are kept for backward compatibility with existing layouts.

That framing is inaccurate. The function is **not** deprecated — it's still actively (and correctly) used by `posthog/identity.ts` to mint PostHog analytics user IDs, which need to be RFC 4122 v4 UUIDs (~122 bits) for identity stability with the PostHog SDK. The two ID generators serve different domains rather than being old vs new:

| Function | Output | Use case |
|---|---|---|
| `generateLayoutId()` | 12-char alphanumeric (~70 bits) | Layout IDs, share URLs |
| `generateUUID()` | RFC 4122 v4 (~122 bits) | Analytics identity, anything needing standard UUID format |

Because of the misleading `@deprecated` tag, `identity.ts` had to suppress the lint rule at every call site:

```ts
// eslint-disable-next-line @typescript-eslint/no-deprecated --
// user IDs must remain UUIDs for PostHog identity stability
data.userId = generateUUID();
```

Removing the tag eliminates two such suppressions and replaces them with the genuine guard rail in JSDoc itself: callers tempted to mint *layout* IDs are now steered toward `generateLayoutId()` by the docstring, but no longer pay an artificial deprecation cost.

## Changes

- **`src/shared/utils/uuid.ts`** — replace the `@deprecated` block on `generateUUID()` with a JSDoc that documents both intended uses and points layout generators at `generateLayoutId()`.
- **`src/shared/analytics/posthog/identity.ts`** — remove the two now-unneeded `eslint-disable @typescript-eslint/no-deprecated` lines.

## Test plan

- [x] `pnpm exec eslint` clean on both files
- [x] `pnpm exec vitest run` for `uuid.test.ts` + `posthog/` — 77 tests pass
- [x] No runtime behavior change — only JSDoc + comment removals