### PR TITLE
refactor(bin-designer): remove TECH-DEBT marker on CutoutShapeMesh material

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutShapeMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutShapeMesh.tsx
@@ -117,28 +117,30 @@ const SDFShapeMesh = memo(function SDFShapeMesh({
   const strokeWidth = strokeWidthPx / zoom; // Convert screen px to world mm
   const shapeType = effective.shape === 'circle' ? 1 : 0;
 
-  // Select fragment shader based on render mode
-  const fragmentShader =
-    renderMode === 'fill'
-      ? sdfFragmentShaderFillOnly
-      : renderMode === 'stroke'
-        ? sdfFragmentShaderStrokeOnly
-        : sdfFragmentShader;
-
-  // SDF material with uniforms
+  // SDF material — recreated only when renderMode changes (which picks both
+  // the fragment shader and the stencil config). All numeric/color uniforms
+  // start at neutral defaults; the reactive useEffect below populates them
+  // and keeps them in sync on every render. This keeps material identity
+  // stable for the common case (renderMode is fixed per mesh in current
+  // callers), without leaking the rest of the prop set into the dep array.
   const material = useMemo(() => {
+    const fragmentShader =
+      renderMode === 'fill'
+        ? sdfFragmentShaderFillOnly
+        : renderMode === 'stroke'
+          ? sdfFragmentShaderStrokeOnly
+          : sdfFragmentShader;
+
     const mat = new THREE.ShaderMaterial({
       vertexShader: sdfVertexShader,
       fragmentShader,
       uniforms: {
-        u_size: { value: new THREE.Vector2(effective.width, effective.depth) },
-        u_cornerRadius: { value: effective.cornerRadius },
-        u_fillColor: {
-          value: new THREE.Vector4(cutFillColor.r, cutFillColor.g, cutFillColor.b, fillOpacity),
-        },
-        u_strokeColor: { value: new THREE.Vector4(strokeColor.r, strokeColor.g, strokeColor.b, 1) },
-        u_strokeWidth: { value: isGrouped ? 0.8 : 0.5 },
-        u_shapeType: { value: shapeType },
+        u_size: { value: new THREE.Vector2() },
+        u_cornerRadius: { value: 0 },
+        u_fillColor: { value: new THREE.Vector4() },
+        u_strokeColor: { value: new THREE.Vector4() },
+        u_strokeWidth: { value: 0 },
+        u_shapeType: { value: 0 },
       },
       transparent: true,
       depthTest: false,
@@ -158,9 +160,11 @@ const SDFShapeMesh = memo(function SDFShapeMesh({
     }
 
     return mat;
-    // renderMode is stable per instance — grouped cutouts always have fixed modes
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TECH-DEBT: intentional empty deps for stable material identity
-  }, []);
+  }, [renderMode]);
+
+  // r3f's <primitive> tag does not auto-dispose attached objects, so release
+  // the GPU resources when the material is replaced or the component unmounts.
+  useEffect(() => () => material.dispose(), [material]);
 
   // Update uniforms reactively without recreating material
   useEffect(() => {

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutShapeMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutShapeMesh.tsx
@@ -166,10 +166,12 @@ const SDFShapeMesh = memo(function SDFShapeMesh({
   // the GPU resources when the material is replaced or the component unmounts.
   useEffect(() => () => material.dispose(), [material]);
 
-  // Update uniforms reactively without recreating material
+  // Populate (and re-populate) the material's uniforms whenever any of them
+  // change OR when the material itself is replaced — without `material` in
+  // the deps, a renderMode change would yield a fresh material with the
+  // zero-value placeholder uniforms, leaving the cutout invisible.
   useEffect(() => {
-    if (!materialRef.current) return;
-    const u = materialRef.current.uniforms;
+    const u = material.uniforms;
     (u.u_size.value as THREE.Vector2).set(effective.width, effective.depth);
     u.u_cornerRadius.value = effective.cornerRadius;
     (u.u_fillColor.value as THREE.Vector4).set(
@@ -181,7 +183,7 @@ const SDFShapeMesh = memo(function SDFShapeMesh({
     (u.u_strokeColor.value as THREE.Vector4).set(strokeColor.r, strokeColor.g, strokeColor.b, 1);
     u.u_strokeWidth.value = strokeWidth;
     u.u_shapeType.value = shapeType;
-  }, [effective, fillOpacity, cutFillColor, strokeColor, strokeWidth, shapeType]);
+  }, [material, effective, fillOpacity, cutFillColor, strokeColor, strokeWidth, shapeType]);
 
   // Geometry sized to the shape
   const geometry = useMemo(() => {


### PR DESCRIPTION
## Summary

The SDF `ShaderMaterial` in `CutoutShapeMesh` was created inside a `useMemo` with empty deps and a literal `TECH-DEBT` annotation:

```ts
return mat;
// renderMode is stable per instance — grouped cutouts always have fixed modes
// eslint-disable-next-line react-hooks/exhaustive-deps -- TECH-DEBT:
//   intentional empty deps for stable material identity
}, []);
```

Two real issues hide under that label:

1. **Oversized dep set, not an irreducible one.** The `useMemo` body referenced ~9 reactive props (`effective.{width, depth, cornerRadius}`, `cutFillColor`, `fillOpacity`, `strokeColor`, `isGrouped`, `shapeType`, `renderMode`), but only `renderMode` actually mattered for material identity. Every other reference fed a placeholder uniform that's overwritten by the existing reactive `useEffect` on the next render.

2. **r3f's `<primitive>` doesn't auto-dispose.** Per the docs ("primitives don't get disposed by default since you might still want to use it elsewhere"), `material.dispose()` is the application's responsibility. Today this is benign because `renderMode` is hardcoded by the only caller (`SceneContent.tsx:264, :284`), but a future caller passing a dynamic `renderMode` would silently leak GPU resources on every change.

## Changes

- **Inline `fragmentShader` selection** (which is itself derived from `renderMode`) into the `useMemo` body, then replace the placeholder uniform values with neutral defaults (`new THREE.Vector2()`, `0`, `new THREE.Vector4()`). The body's only remaining external reference is `renderMode`, so `[renderMode]` is the exhaustive dep set — the eslint-disable + TECH-DEBT comment disappear naturally.
- **Add disposal cleanup**: `useEffect(() => () => material.dispose(), [material])` releases GPU resources when the material is replaced or the component unmounts.

## Runtime impact

For current callers: **identical**. `renderMode` is hardcoded at all known call sites, so the memo never invalidates and the material is created once per mount — same as before. The added disposal only matters when the material is replaced (theoretical for current usage, defensive for future usage).

## Test plan

- [x] `pnpm exec eslint` clean on the file
- [x] `pnpm exec tsc -b --noEmit` clean
- [x] `pnpm exec vitest run src/features/bin-designer/components/panel/CutoutsSection/renderer/` — 22 test files, 40 tests, all pass