### PR TITLE
fix(stryker): exclude __dual-kernel__ from mutation set

### DIFF
--- a/stryker.config.json
+++ b/stryker.config.json
@@ -19,7 +19,8 @@
     "!**/*.test.tsx",
     "!**/*.bench.ts",
     "!**/*.d.ts",
-    "!**/types.ts"
+    "!**/types.ts",
+    "!**/__dual-kernel__/**"
   ],
   "timeoutMS": 120000,
   "dryRunTimeoutMinutes": 15,


### PR DESCRIPTION
## Summary

Follow-on fix to #1482. The Stryker `workflow_dispatch` verification run on freshly-merged main ([run 24966536564](https://github.com/andymai/gridfinity-layout-tool/actions/runs/24966536564)) cleared the dry-run-timeout failure mode (good news: the timeout bump worked, the run got 30 minutes in) but uncovered a follow-on configuration drift:

```
StrykerError: Tried to check file
  ".../src/features/generation/worker/generators/__dual-kernel__/kernelInit.ts"
  (which is part of your typescript project), but no watcher is registered
  for it. Changes would go unnoticed. This probably means that you need to
  expand the files that are included in your project.
```

The `__dual-kernel__` directory is excluded from `tsconfig.app.json` (line 33: `"**/__dual-kernel__"` in the `exclude` list), so its 8 non-test files aren't part of the compiled TypeScript project. Stryker's mutate glob `src/features/generation/worker/generators/**/*.ts` was still pulling them in, and the typescript-checker hit the tsconfig boundary mid-run.

`disableTypeChecks` doesn't help here — that flag only suppresses per-mutant type checking on instrumented code; the project-level watcher still wants to track every mutate target. The fix has to be on the input side: don't mutate files that aren't in the project.

## Change

Add `!**/__dual-kernel__/**` to the mutate excludes, mirroring the tsconfig exclusion. Drops the mutate file count from 152 → ~144; all excluded files are dual-kernel scaffolding:

- `kernelInit.ts`, `dualKernelInit.ts`, `wasmInit.ts`
- `meshAssertions.ts`, `reportTable.ts`, `scenarioTypes.ts`, `testCases.ts`, `topologyHelpers.ts`

Their `.test.ts` siblings were already excluded by the existing `!**/*.test.ts` rule.

## Test plan

- [x] `jq empty stryker.config.json` valid
- [ ] `gh workflow run mutation-testing.yml --ref main` after merge — expect first full run to complete (no incremental cache yet)
- [ ] Subsequent nightly runs return to documented ~5-10 min warm-cache time