### PR TITLE
fix(generation): restore angled support beneath stacking lip overhang

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -1,168 +1,168 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2556`;
+exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2620`;
 
 exports[`base styles > flat base no lip 1`] = `252`;
 
-exports[`base styles > flat base with lip 1`] = `812`;
+exports[`base styles > flat base with lip 1`] = `892`;
 
 exports[`base styles > magnet base no lip 1`] = `804`;
 
-exports[`base styles > magnet base with lip 1`] = `1820`;
+exports[`base styles > magnet base with lip 1`] = `1900`;
 
 exports[`base styles > magnet+screw base no lip 1`] = `1028`;
 
-exports[`base styles > magnet+screw base with lip 1`] = `2188`;
+exports[`base styles > magnet+screw base with lip 1`] = `2268`;
 
 exports[`base styles > screw base no lip 1`] = `692`;
 
-exports[`base styles > screw base with lip 1`] = `1660`;
+exports[`base styles > screw base with lip 1`] = `1740`;
 
 exports[`base styles > standard base no lip 1`] = `468`;
 
-exports[`base styles > standard base with lip 1`] = `1292`;
+exports[`base styles > standard base with lip 1`] = `1372`;
 
 exports[`base styles > weighted base no lip 1`] = `468`;
 
-exports[`base styles > weighted base with lip 1`] = `1292`;
+exports[`base styles > weighted base with lip 1`] = `1372`;
 
-exports[`bin styles > 2×2 slotted 1`] = `3092`;
+exports[`bin styles > 2×2 slotted 1`] = `3220`;
 
 exports[`bin styles > 2×2 solid 1`] = `2548`;
 
-exports[`bin styles > 2×2 standard 1`] = `2732`;
+exports[`bin styles > 2×2 standard 1`] = `2812`;
 
-exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1172`;
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1300`;
 
-exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3228`;
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3308`;
 
-exports[`combined features > 2×2 label tabs with merged compartments 1`] = `4996`;
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `5308`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `7220`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `7492`;
 
 exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `18048`;
 
-exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2732`;
+exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2812`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `3444`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `3524`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3544`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3624`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5188`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5268`;
 
-exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `2760`;
+exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `2918`;
 
-exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `5160`;
+exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `5318`;
 
-exports[`custom-shape > 2×2 mixed-detail per-cell half sockets 1`] = `4202`;
+exports[`custom-shape > 2×2 mixed-detail per-cell half sockets 1`] = `4360`;
 
 exports[`custom-shape > 3×3 L flat base no lip 1`] = `260`;
 
-exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`] = `5204`;
+exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`] = `5362`;
 
-exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `5568`;
+exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `5762`;
 
-exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `14000`;
+exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `14890`;
 
-exports[`custom-shape > 3×3 L with honeycomb pattern (polygon edge enumeration) 1`] = `14284`;
+exports[`custom-shape > 3×3 L with honeycomb pattern (polygon edge enumeration) 1`] = `15286`;
 
-exports[`custom-shape > 3×3 L with lip 1`] = `5124`;
+exports[`custom-shape > 3×3 L with lip 1`] = `5282`;
 
-exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `5464`;
+exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `5552`;
 
-exports[`custom-shape > 3×3 T with lip 1`] = `4156`;
+exports[`custom-shape > 3×3 T with lip 1`] = `4384`;
 
-exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`] = `5570`;
+exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`] = `5832`;
 
-exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `5206`;
+exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `5432`;
 
-exports[`custom-shape > 3×3 U with honeycomb pattern (multi-side polygon pattern) 1`] = `17286`;
+exports[`custom-shape > 3×3 U with honeycomb pattern (multi-side polygon pattern) 1`] = `18646`;
 
-exports[`custom-shape > 3×3 U with lip 1`] = `5126`;
+exports[`custom-shape > 3×3 U with lip 1`] = `5352`;
 
 exports[`dimensions > 0.5×0.5 no lip 1`] = `468`;
 
-exports[`dimensions > 0.5×0.5 with lip 1`] = `1292`;
+exports[`dimensions > 0.5×0.5 with lip 1`] = `1372`;
 
 exports[`dimensions > 1.5×2 fractional no lip 1`] = `1260`;
 
-exports[`dimensions > 1.5×2 fractional with lip 1`] = `2732`;
+exports[`dimensions > 1.5×2 fractional with lip 1`] = `2812`;
 
 exports[`dimensions > 1×1 no lip 1`] = `468`;
 
-exports[`dimensions > 1×1 with lip 1`] = `1292`;
+exports[`dimensions > 1×1 with lip 1`] = `1372`;
 
 exports[`dimensions > 2×2 no lip 1`] = `1260`;
 
-exports[`dimensions > 2×2 with lip 1`] = `2732`;
+exports[`dimensions > 2×2 with lip 1`] = `2812`;
 
 exports[`dimensions > 4×4 no lip 1`] = `3500`;
 
-exports[`dimensions > 4×4 with lip 1`] = `7932`;
+exports[`dimensions > 4×4 with lip 1`] = `7996`;
 
-exports[`export mode > 2×2 default params (forExport=true) 1`] = `5148`;
+exports[`export mode > 2×2 default params (forExport=true) 1`] = `5276`;
 
-exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5132`;
+exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5212`;
 
-exports[`half-sockets > 1×1 with half sockets 1`] = `2732`;
+exports[`half-sockets > 1×1 with half sockets 1`] = `2812`;
 
-exports[`half-sockets > 2×2 with half sockets 1`] = `8492`;
+exports[`half-sockets > 2×2 with half sockets 1`] = `8572`;
 
-exports[`height > 2×2 height minimum (2u) 1`] = `2732`;
+exports[`height > 2×2 height minimum (2u) 1`] = `2812`;
 
-exports[`height > 2×2 height tall (10u) 1`] = `2732`;
+exports[`height > 2×2 height tall (10u) 1`] = `2812`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6556`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6876`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6492`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6812`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6592`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6960`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6592`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6960`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `6880`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `7216`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `6736`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `7072`;
 
-exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `6540`;
+exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `6940`;
 
-exports[`inserts > 2×2 with circle insert 1`] = `3000`;
+exports[`inserts > 2×2 with circle insert 1`] = `3080`;
 
-exports[`inserts > 2×2 with hexagon insert 1`] = `3000`;
+exports[`inserts > 2×2 with hexagon insert 1`] = `3080`;
 
-exports[`inserts > 2×2 with rectangle insert 1`] = `2768`;
+exports[`inserts > 2×2 with rectangle insert 1`] = `2848`;
 
-exports[`inserts > 2×2 with rounded-rect insert 1`] = `2896`;
+exports[`inserts > 2×2 with rounded-rect insert 1`] = `2976`;
 
-exports[`inserts > 2×2 with slot insert 1`] = `2944`;
+exports[`inserts > 2×2 with slot insert 1`] = `3024`;
 
-exports[`label tabs > 2×2 label bracket center 1`] = `3340`;
+exports[`label tabs > 2×2 label bracket center 1`] = `3628`;
 
-exports[`label tabs > 2×2 label bracket left 1`] = `3340`;
+exports[`label tabs > 2×2 label bracket left 1`] = `3628`;
 
-exports[`label tabs > 2×2 label bracket right 1`] = `3340`;
+exports[`label tabs > 2×2 label bracket right 1`] = `3628`;
 
-exports[`label tabs > 2×2 label disabled 1`] = `2732`;
+exports[`label tabs > 2×2 label disabled 1`] = `2812`;
 
-exports[`label tabs > 2×2 label solid left 1`] = `3232`;
+exports[`label tabs > 2×2 label solid left 1`] = `3380`;
 
-exports[`large bin > 8×8 standard 1`] = `23156`;
+exports[`large bin > 8×8 standard 1`] = `23180`;
 
-exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3224`;
+exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3304`;
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `3816`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4000`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4616`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4888`;
 
-exports[`scoop > 2×2 scoop auto radius 1`] = `3816`;
+exports[`scoop > 2×2 scoop auto radius 1`] = `4000`;
 
-exports[`scoop > 2×2 scoop disabled 1`] = `2732`;
+exports[`scoop > 2×2 scoop disabled 1`] = `2812`;
 
-exports[`scoop > 2×2 scoop radius 10mm 1`] = `3820`;
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `4032`;
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `3092`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `3220`;
 
-exports[`slotted variations > slotted with both axes 1`] = `3452`;
+exports[`slotted variations > slotted with both axes 1`] = `3628`;
 
 exports[`slotted variations > slotted without lip 1`] = `1380`;
 
@@ -190,4 +190,4 @@ exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2560`;
 
 exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `2700`;
 
-exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `2748`;
+exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `2900`;

--- a/src/features/generation/worker/generators/boxBuilder.test.ts
+++ b/src/features/generation/worker/generators/boxBuilder.test.ts
@@ -142,4 +142,30 @@ describe('buildTopShape', () => {
     expect(lipBounds.xMax - lipBounds.xMin).toBeGreaterThan(outerW - TOL);
     expect(lipBounds.yMax - lipBounds.yMin).toBeGreaterThan(outerD - TOL);
   }, 30000);
+
+  // Regression: #1487 — the lip extension must include an angled support
+  // face below the overhang so it can be FDM-printed without strings. The
+  // sweep version produced this naturally; the original loft (#1380) only
+  // built sections at Z_EXT (-1.2) and above, leaving the underside of the
+  // overhang as a flat horizontal shelf with nothing below it. Verify that
+  // when stacking is enabled the lip reaches down to Z = -LIP_TAPER_WIDTH
+  // (-2.6mm) — at least 1mm deeper than the previous loft, which stopped
+  // at -1.2 (LIP_EXTENSION) and would not pass the lower bound below.
+  it('lip extends below Z_EXT with angled support (no flat overhang)', () => {
+    const lipNoStack = buildTopShape(2, 2, false);
+    const lipWithStack = buildTopShape(2, 2, true);
+    const noStackBounds = shapeBounds(lipNoStack);
+    const withStackBounds = shapeBounds(lipWithStack);
+
+    // The added depth of the stacking lip below Z = 0 is the lip
+    // extension PLUS the angled support, which spans LIP_TAPER_WIDTH
+    // (2.6mm). The pre-fix loft only built the extension flange and
+    // produced a delta of LIP_EXTENSION (1.2mm), which would fail the
+    // lower bound below. Comparing the delta cancels out the small
+    // BREP getBounds tolerance epsilon (~0.3mm) that's present in
+    // both the with-stack and no-stack cases.
+    const lipDepthDelta = noStackBounds.zMin - withStackBounds.zMin;
+    expect(lipDepthDelta).toBeGreaterThan(2.5); // ≈ LIP_TAPER_WIDTH (2.6)
+    expect(lipDepthDelta).toBeLessThan(2.7);
+  }, 60000);
 });

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -313,9 +313,15 @@ export function buildBinBox(
  * Build the stacking lip using a ruled loft + boolean cut.
  *
  * Outer frustum is a rectangular tube flush with the bin wall (inset=0).
- * Inner frustum traces the lip profile's inner contour, tapering from
- * 2.6mm at the base to 0mm at the peak. The cut produces a wedge-shaped
- * ring whose exterior is smooth and flush with the bin wall.
+ * Inner frustum traces the lip profile's inner contour, including the
+ * angled support face that the sweep version produces by sweeping the
+ * lip-extension polygon: from INNER_BASE (2.6mm) at Z_EXT down to a
+ * narrower inset (LIP_EXTENSION, 1.2mm) at Z_ANGLE_BOTTOM (-2.6mm).
+ * After the loft is cut from the outer and fused with the bin wall, the
+ * portion of the ring that overlaps the wall thickness is absorbed; what
+ * remains is the visible lip overhang plus an angled support that goes
+ * from zero overhang at Z_ANGLE_BOTTOM up to (LIP_TAPER_WIDTH −
+ * wallThickness) overhang at Z_EXT — printable without supports. (#1487)
  */
 function buildTopShapeLoft(
   outerW: number,
@@ -330,7 +336,13 @@ function buildTopShapeLoft(
   const INNER_BASE = LIP_TAPER_WIDTH; // 2.6mm
   const INNER_MID = LIP_BIG_TAPER; // 1.9mm
   const INNER_TOP = 0;
+  // Inset at the bottom of the angled support: matches the sweep profile,
+  // where the support's inner edge sits at X = -LIP_EXTENSION (1.2mm).
+  const INNER_ANGLE = LIP_EXTENSION;
 
+  // Z_ANGLE_BOTTOM matches the sweep profile's deepest Y (-LIP_TAPER_WIDTH);
+  // the angled support spans Z = [Z_ANGLE_BOTTOM, Z_EXT] = [-2.6, -1.2].
+  const Z_ANGLE_BOTTOM = includeLip ? -LIP_TAPER_WIDTH : 0;
   const Z_EXT = -LIP_EXTENSION;
   const Z_BASE = 0;
   const Z_TAPER1 = LIP_SMALL_TAPER; // 0.7
@@ -354,15 +366,17 @@ function buildTopShapeLoft(
   };
 
   // Outer: rectangular tube at bin outer edge (2 sections → no extra edges)
-  const zBottom = includeLip ? Z_EXT : Z_BASE;
+  const zBottom = includeLip ? Z_ANGLE_BOTTOM : Z_BASE;
   const outerSections: Sketch[] = [sectionAt(zBottom, 0), sectionAt(Z_PEAK, 0)];
 
-  // For O-shape footprints, pre-compute three sets of hole drawings at
-  // different inset levels so each Z-section of the hole lip can reach
-  // directly for the right one. holesCavity matches the cavity boundary
-  // (bin's outer face); holesInnerBase/Mid are the same boundary grown
-  // further into the filled material by the standard lip offsets.
+  // For O-shape footprints, pre-compute the hole drawings at every inset
+  // level the loft sections need. holesCavity matches the cavity boundary
+  // (bin's outer face); holesInnerAngle/Base/Mid are the same boundary grown
+  // further into the filled material by the corresponding lip offsets.
   const holesCavity = polygon ? buildMaskHoleDrawings(cellMask, gridUnitMm) : [];
+  const holesInnerAngle = polygon
+    ? buildMaskHoleDrawings(cellMask, gridUnitMm, CLEARANCE / 2 + INNER_ANGLE)
+    : [];
   const holesInnerBase = polygon
     ? buildMaskHoleDrawings(cellMask, gridUnitMm, CLEARANCE / 2 + INNER_BASE)
     : [];
@@ -374,9 +388,11 @@ function buildTopShapeLoft(
     const [outerFirst, ...outerRest] = outerSections;
     const outerFrustum = scope.register(outerFirst.loftWith(outerRest, { ruled: true }));
 
-    // Inner: tapered frustum tracing the lip profile
+    // Inner: tapered frustum tracing the lip profile, including the angled
+    // support face below Z_EXT.
     const innerSections: Sketch[] = [];
     if (includeLip) {
+      innerSections.push(sectionAt(Z_ANGLE_BOTTOM, INNER_ANGLE));
       innerSections.push(sectionAt(Z_EXT, INNER_BASE));
     }
     innerSections.push(sectionAt(Z_BASE, INNER_BASE));
@@ -391,18 +407,23 @@ function buildTopShapeLoft(
     let result = unwrap(cut(outerFrustum, innerFrustum));
 
     // Add a lip ring around each interior hole. Mirrors the outer lip's
-    // profile: the lip's "outer" face (facing the filled material) grows
-    // from INNER_BASE at Z_BASE to 0 at Z_PEAK; its "inner" face (facing
-    // the cavity) stays at the cavity boundary.  cut(outerFrustum,
+    // profile, including the angled support: the lip's "outer" face (facing
+    // the filled material) grows from INNER_ANGLE at Z_ANGLE_BOTTOM, through
+    // INNER_BASE at Z_EXT/Z_BASE, to 0 at Z_PEAK; its "inner" face (facing
+    // the cavity) stays at the cavity boundary. cut(outerFrustum,
     // innerFrustum) is then fused onto the outer lip so a bin stacked on
     // top sits flush over both the outer perimeter and the hole.
     for (let h = 0; h < holesCavity.length; h++) {
       const cavity = holesCavity[h];
+      const atAngle = holesInnerAngle[h];
       const atBase = holesInnerBase[h];
       const atMid = holesInnerMid[h];
 
       const bigSections: Sketch[] = [];
-      if (includeLip) bigSections.push(atBase.sketchOnPlane('XY', Z_EXT) as Sketch);
+      if (includeLip) {
+        bigSections.push(atAngle.sketchOnPlane('XY', Z_ANGLE_BOTTOM) as Sketch);
+        bigSections.push(atBase.sketchOnPlane('XY', Z_EXT) as Sketch);
+      }
       bigSections.push(atBase.sketchOnPlane('XY', Z_BASE) as Sketch);
       bigSections.push(atMid.sketchOnPlane('XY', Z_TAPER1) as Sketch);
       bigSections.push(atMid.sketchOnPlane('XY', Z_VERT) as Sketch);
@@ -544,7 +565,7 @@ export function buildTopShape(
 ): Shape3D {
   const polygon = isPartialMask(cellMask);
   const lipKey = buildCacheKey(
-    'v3',
+    'v4',
     quantize(gridW),
     quantize(gridD),
     quantize(gridUnitMm),

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -373,10 +373,14 @@ function buildTopShapeLoft(
   // level the loft sections need. holesCavity matches the cavity boundary
   // (bin's outer face); holesInnerAngle/Base/Mid are the same boundary grown
   // further into the filled material by the corresponding lip offsets.
+  // holesInnerAngle is only needed when stacking is included (its only
+  // consumer is inside `if (includeLip)`), so skip the offset-and-tessellate
+  // work for non-stacking bins.
   const holesCavity = polygon ? buildMaskHoleDrawings(cellMask, gridUnitMm) : [];
-  const holesInnerAngle = polygon
-    ? buildMaskHoleDrawings(cellMask, gridUnitMm, CLEARANCE / 2 + INNER_ANGLE)
-    : [];
+  const holesInnerAngle =
+    polygon && includeLip
+      ? buildMaskHoleDrawings(cellMask, gridUnitMm, CLEARANCE / 2 + INNER_ANGLE)
+      : [];
   const holesInnerBase = polygon
     ? buildMaskHoleDrawings(cellMask, gridUnitMm, CLEARANCE / 2 + INNER_BASE)
     : [];


### PR DESCRIPTION
Closes #1487.

## Summary

The stacking lip's overhang has been printing as a flat horizontal shelf since #1380, which switched lip construction from a sweep-based profile to a ruled loft (to dodge an OCCT `BRepOffsetAPI_MakePipeShell` direction-flip bug on non-square spines, #1379). The old sweep profile included an angled support face below the overhang — a 45° chamfer from the wall's inner edge up to the lip-extension flange — that lets FDM printers lay each layer over an angled, supported underside instead of trying to print a flat shelf in mid-air.

The replacement loft only constructed cross-sections at `Z_EXT` (-1.2) and above, so the wedge of material that had been the angled support disappeared. Result: stringing under the overhang, exactly as reported.

## Diagnosis

The user's report ("regression ~10 days ago") matches the loft commit date almost exactly:
- `a6a5218d6` "use loft for stacking lip on all kernels (#1380)" — Apr 16 (today is Apr 26)
- `be37a8f1a` brepjs 14 → 15 upgrade — Apr 18 (also a candidate, but the missing-geometry pattern is structural to the loft sections regardless of brepjs version)

Reading the sweep profile that #1380 replaced, the polygon includes vertices `(-1.2, -2.6)` and `(-2.6, -1.2)` connected by a diagonal — that diagonal **is** the angled support face. The loft built sections at `Z = -1.2` and above only, so that diagonal had nothing to interpolate from.

## Fix

In `buildTopShapeLoft`, add a new bottom section at `Z_ANGLE_BOTTOM = -LIP_TAPER_WIDTH` (-2.6mm) with inset `LIP_EXTENSION` (1.2mm), and extend the outer frustum down to match:

| Inner section | Before | After |
|---|---|---|
| Z_ANGLE_BOTTOM (-2.6) | — | inset 1.2 ← new |
| Z_EXT (-1.2) | inset 2.6 | inset 2.6 |
| Z_BASE (0.0) | inset 2.6 | inset 2.6 |
| Z_TAPER1 (0.7) | inset 1.9 | inset 1.9 |
| Z_VERT (2.5) | inset 1.9 | inset 1.9 |
| Z_PEAK (4.4) | inset 0 | inset 0 |

The outer frustum still has only 2 sections (no extra edges, per the existing `// 2 sections → no extra edges` comment); `zBottom` extends from `Z_EXT` to `Z_ANGLE_BOTTOM`.

After the lip is fused with the bin wall, the new inner inset of `LIP_EXTENSION` (1.2mm) is exactly the wall thickness for a default-spec bin — so the bottom of the angled support is absorbed into the wall and the visible chamfer matches the sweep version's overhang grow-in.

Hole lips on O-shape footprints get the matching `holesInnerAngle` treatment (uses `buildMaskHoleDrawings(..., CLEARANCE/2 + LIP_EXTENSION)`) so interior cavities print with the same support profile.

Cache key bumped `v3 → v4` (geometry changed; must invalidate persisted caches).

## Test plan

- [x] **New regression test in `boxBuilder.test.ts`** — `lip extends below Z_EXT with angled support (no flat overhang)`: with-stack lip's bottom Z is ≈ `LIP_TAPER_WIDTH` (2.6mm) deeper than no-stack's. The pre-fix loft produced a delta of `LIP_EXTENSION` (1.2mm) and would fail this assertion. Asserts the delta rather than absolute Z to cancel a small BREP `getBounds` tolerance epsilon (~0.3mm) present in both readings.
- [x] All 15 `boxBuilder.test.ts` tests pass.
- [x] All 197 `binGenerator.scenario.test.ts` tests pass — 69 triangle-count snapshots updated for the extra angled-support faces.
- [x] All 63 split-bin scenario tests pass (`split-robustness`, `split-lip-trim`, `split-large-bin`, `split-connectors`).
- [x] `tsc -b --noEmit` clean. ESLint clean on touched files.
- [ ] **Manual print verification recommended** — generate a 2x2 bin, check that the bottom face of the lip overhang is angled (not flat) when sliced.