### PR TITLE
chore(stryker): exclude generator files from mutation set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ Add keys to `en.ts` first, then all locale JSONs. Run `pnpm run check:i18n`. Loc
 
 Complements coverage. Runs nightly via `.github/workflows/mutation-testing.yml`.
 
-**Scope:** `src/core/result`, `src/core/cqrs/{handlers,middleware}`, `src/features/generation/worker/generators`, `src/shared/{utils,generation}` (~148 files). Stores, components, and features outside this list are not yet mutated.
+**Scope:** `src/core/result`, `src/core/cqrs/{handlers,middleware}`, `src/shared/{utils,generation}`. Generators (`src/features/generation/worker/generators`) are excluded — their scenario tests are too slow to multiply across mutants. Stores, components, and features outside this list are not yet mutated.
 
 | Command                                 | Purpose                                         |
 | --------------------------------------- | ----------------------------------------------- |

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -12,15 +12,13 @@
     "src/core/result/**/*.ts",
     "src/core/cqrs/handlers/**/*.ts",
     "src/core/cqrs/middleware/**/*.ts",
-    "src/features/generation/worker/generators/**/*.ts",
     "src/shared/utils/**/*.ts",
     "src/shared/generation/**/*.ts",
     "!**/*.test.ts",
     "!**/*.test.tsx",
     "!**/*.bench.ts",
     "!**/*.d.ts",
-    "!**/types.ts",
-    "!**/__dual-kernel__/**"
+    "!**/types.ts"
   ],
   "timeoutMS": 120000,
   "dryRunTimeoutMinutes": 15,


### PR DESCRIPTION
## Summary

- Drop `src/features/generation/worker/generators/**` from Stryker's `mutate` config. Their BREP/Three.js scenario tests are too slow to multiply across 13k+ mutants — recent runs have churned for hours and timed out.
- Remove the now-redundant `!**/__dual-kernel__/**` exclusion (PR #1488). Its parent directory is no longer in scope.
- Update CLAUDE.md mutation-testing scope to match.

## Why now

The post-merge run after the four PRs landed (#1482-1485) failed at ~30 min with a typescript-checker watcher mismatch on a `__dual-kernel__` file (likely stale incremental baseline). A re-triggered manual run on the same SHA has been running 2+ hours without completing. Pulling generators out of scope makes mutation testing a tight feedback loop on the logic that actually benefits from it (Result, CQRS handlers/middleware, shared utils/generation), and skips the multi-hour scenario suite.

## Test plan

- [ ] CI: nightly Stryker run completes in the typical 5-10 min window
- [ ] Spot-check `pnpm run test:mutation:changed` locally still works
- [ ] No reduction in regular test coverage (this only affects mutation scope)