### PR TITLE
fix(baseplate): repair mesh winding before STL export (#1490)

### DIFF
--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.winding.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.winding.test.ts
@@ -1,19 +1,25 @@
 // @vitest-environment node
 /**
- * Regression test for issue #1472 — Bambu Studio reported ~2138 "non-manifold
- * edges" on every baseplate export. The root cause was the previous
- * `buildBaseplateSTL` winding-correction heuristic: it flipped a triangle's
- * winding whenever (cross · sum-of-vertex-normals) < 0. brepjs already
- * tessellates faces with winding consistent with each face's BREP
- * orientation, but along curved/shared edges its vertex normals are
- * averaged across adjacent faces, so the heuristic mis-fired on ~7% of
- * triangles and emitted them with reversed winding. Each reversed triangle
- * shows up in the slicer as a directed-edge collision (a→b appearing twice
- * in the same direction).
+ * Regression tests for two related winding-consistency bugs.
  *
- * This test verifies, on a representative slice of the user's exact
- * 19.5 × 9.5 split-baseplate-with-dovetails reproducer, that every directed
- * edge in the export appears at most once.
+ * #1472 — Bambu Studio reported ~2138 "non-manifold edges" on every
+ * baseplate export. Root cause: a `buildBaseplateSTL` heuristic flipped
+ * a triangle's winding whenever (cross · sum-of-vertex-normals) < 0.
+ * brepjs returns averaged vertex normals at curved/shared edges, so the
+ * heuristic mis-fired on ~7% of triangles. Removed in #1473.
+ *
+ * #1490 — Bambu Studio reported "non-manifold edges" on corner-3 and
+ * corner-4 piece configs even after #1473. Root cause: brepjs/OCCT can
+ * emit tessellated meshes whose face orientations aren't consistent
+ * across the whole solid (entire bottom face wound backwards, ~32% of
+ * triangles flagged). Fixed by a downstream BFS winding-repair pass in
+ * `repairMeshWinding` (called from `buildBaseplateSTL`). The corner-3,
+ * corner-4, and edge-x-1 cases below cover the piece roles that the
+ * existing corner-1 / edge-y-1 / magnet cases didn't reach.
+ *
+ * Each test asserts directed-edge uniqueness; #1490-class tests also
+ * assert positive signed volume to catch global mesh inversions that
+ * directed-edge uniqueness alone wouldn't see.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import type { BaseplateParams } from '@/shared/types/bin';
@@ -81,7 +87,34 @@ function countWindingErrors(stl: ArrayBuffer): number {
   return dupes;
 }
 
-describe('baseplateGenerator — directed-edge winding (issue #1472)', () => {
+/**
+ * Compute signed volume from the STL's flat vertex array. Positive volume
+ * means the mesh is consistently outward-oriented; negative means the mesh
+ * (or a dominant region) is inverted. A globally-flipped mesh can still
+ * pass `countWindingErrors` (every directed edge stays unique), so this
+ * is a complementary check.
+ */
+function signedVolume(stl: ArrayBuffer): number {
+  const parsed = parseSTLBinary(stl);
+  if (!isOk(parsed)) throw new Error('STL parse failed');
+  const verts = parsed.value.vertices;
+  let vol = 0;
+  for (let t = 0; t < verts.length; t += 9) {
+    const ax = verts[t];
+    const ay = verts[t + 1];
+    const az = verts[t + 2];
+    const bx = verts[t + 3];
+    const by = verts[t + 4];
+    const bz = verts[t + 5];
+    const cx = verts[t + 6];
+    const cy = verts[t + 7];
+    const cz = verts[t + 8];
+    vol += ax * (by * cz - bz * cy) + bx * (cy * az - cz * ay) + cx * (ay * bz - az * by);
+  }
+  return vol / 6;
+}
+
+describe('baseplateGenerator — directed-edge winding (issues #1472, #1490)', () => {
   const TEST_TIMEOUT_MS = 60_000;
 
   it(
@@ -135,6 +168,71 @@ describe('baseplateGenerator — directed-edge winding (issue #1472)', () => {
 
       const { data } = await exportBaseplate(params, 'stl');
       expect(countWindingErrors(data)).toBe(0);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  // #1490: piece roles where brepjs/OCCT emits some faces with reversed
+  // orientation. Mirror corner-1's fractional layout but for the other
+  // three corner positions plus an edge-x slice.
+
+  it(
+    'corner-3 (4.5×4.5, paddingLeft+paddingBack=7, top-left of split) — winding consistent',
+    async () => {
+      const params = defaults({
+        width: 4.5,
+        depth: 4.5,
+        paddingLeft: 7,
+        paddingBack: 7,
+        fractionalEdgeX: 'start',
+        fractionalEdgeY: 'end',
+        connectorNubs: true,
+        edges: { left: 'exterior', right: 'join', front: 'join', back: 'exterior' },
+      });
+
+      const { data } = await exportBaseplate(params, 'stl');
+      expect(countWindingErrors(data)).toBe(0);
+      expect(signedVolume(data)).toBeGreaterThan(0);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    'corner-4 (4.5×4.5, paddingRight+paddingBack=7, top-right of split) — winding consistent',
+    async () => {
+      const params = defaults({
+        width: 4.5,
+        depth: 4.5,
+        paddingRight: 7,
+        paddingBack: 7,
+        fractionalEdgeX: 'end',
+        fractionalEdgeY: 'end',
+        connectorNubs: true,
+        edges: { left: 'join', right: 'exterior', front: 'join', back: 'exterior' },
+      });
+
+      const { data } = await exportBaseplate(params, 'stl');
+      expect(countWindingErrors(data)).toBe(0);
+      expect(signedVolume(data)).toBeGreaterThan(0);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    'edge-x-1 (4.5×5, paddingRight=7, right edge, dovetail tongues + grooves) — winding consistent',
+    async () => {
+      const params = defaults({
+        width: 4.5,
+        depth: 5,
+        paddingRight: 7,
+        fractionalEdgeX: 'end',
+        connectorNubs: true,
+        edges: { left: 'join', right: 'exterior', front: 'join', back: 'join' },
+      });
+
+      const { data } = await exportBaseplate(params, 'stl');
+      expect(countWindingErrors(data)).toBe(0);
+      expect(signedVolume(data)).toBeGreaterThan(0);
     },
     TEST_TIMEOUT_MS
   );

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -67,6 +67,7 @@ import type { CacheStats } from './lruCache';
 import { LRUCache } from './lruCache';
 import { buildCacheKey, quantize } from './cacheKeyUtils';
 import { buildLightweightFloorCutters } from './lightweightFloorCutter';
+import { repairMeshWinding } from '@/shared/generation/repairMeshWinding';
 import { CONSTRAINTS } from '@/core/constants';
 
 // LRU cache for pocket templates keyed by cell size + forExport + floorDepth.
@@ -1298,18 +1299,21 @@ export async function exportBaseplate(
 /**
  * Build binary STL from brepjs mesh output.
  *
- * brepjs's `mesh()` already tessellates each face with winding consistent
- * with that face's BREP orientation, so we trust its triangle order verbatim.
- * The face normal we emit in the STL record is the cross-product of the
- * winding edges — the same convention slicers reconstruct anyway.
+ * brepjs/OCCT can emit tessellated meshes whose face orientations aren't
+ * consistent across the whole solid: for some baseplate piece configs
+ * (corner-3, corner-4, edge-x-1) the bottom face and parts of the
+ * dovetail/pocket walls are wound backwards, causing slicers to flag
+ * thousands of "non-manifold edges" (#1490). Which BREP op produces the
+ * inversion is still under investigation upstream — see the tracking issue
+ * linked from #1490 — so we run a downstream BFS winding repair before
+ * emitting the STL.
  *
- * An earlier version flipped winding whenever
- *   (cross · sum-of-vertex-normals) < 0
- * to "fix" supposedly-bad output. brepjs returns averaged vertex normals at
- * shared/curved edges (cell-corner gussets, magnet-hole rims, dovetail
- * groove walls), so along ~7% of triangles the heuristic fired and emitted
- * the triangle reversed. Bambu Studio + Cura then flagged thousands of
- * "non-manifold edges" and repaired the result as solid infill (#1472).
+ * (An even earlier version applied a per-triangle (cross · sum-of-vertex-
+ * normals) heuristic which mis-fired on ~7% of triangles at curved/shared
+ * edges and was removed in #1472.)
+ *
+ * The STL face normal is the cross-product of the (corrected) winding
+ * edges, the same convention slicers reconstruct anyway.
  */
 function buildBaseplateSTL(
   meshResult: {
@@ -1319,7 +1323,7 @@ function buildBaseplateSTL(
   name: string
 ): ArrayBuffer {
   const verts = meshResult.vertices;
-  const tris = meshResult.triangles;
+  const tris = repairMeshWinding(meshResult.vertices, meshResult.triangles);
   const triangleCount = tris.length / 3;
 
   const HEADER_SIZE = 80;

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -1310,7 +1310,8 @@ export async function exportBaseplate(
  *
  * (An even earlier version applied a per-triangle (cross · sum-of-vertex-
  * normals) heuristic which mis-fired on ~7% of triangles at curved/shared
- * edges and was removed in #1472.)
+ * edges; that was the issue tracked in #1472 and the heuristic was removed
+ * in #1473.)
  *
  * The STL face normal is the cross-product of the (corrected) winding
  * edges, the same convention slicers reconstruct anyway.

--- a/src/shared/generation/repairMeshWinding.test.ts
+++ b/src/shared/generation/repairMeshWinding.test.ts
@@ -168,4 +168,42 @@ describe('repairMeshWinding', () => {
 
     warnSpy.mockRestore();
   });
+
+  it('throws when triangles.length is not a multiple of 3', () => {
+    const malformed = new Uint32Array([0, 1, 2, 3, 4]); // length 5
+    expect(() => repairMeshWinding(CUBE_VERTS, malformed)).toThrow(/multiple of 3/);
+  });
+
+  it('walks every component so each one is internally consistent', () => {
+    // Build two cubes side-by-side using disjoint vertex index ranges. The
+    // mesh's edge-adjacency graph is disconnected — without per-component
+    // BFS, the second cube's triangles would never be visited. With it,
+    // every triangle is walked and each component is internally consistent.
+    const verts2 = new Float32Array([
+      // cube A (indices 0..7, x range [0,1])
+      0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1,
+      // cube B (indices 8..15, x range [2,3])
+      2, 0, 0, 3, 0, 0, 3, 1, 0, 2, 1, 0, 2, 0, 1, 3, 0, 1, 3, 1, 1, 2, 1, 1,
+    ]);
+    const cubeATris = new Uint32Array(CUBE_TRIS_CORRECT);
+    const cubeBTris = new Uint32Array(CUBE_TRIS_CORRECT.length);
+    // Cube B: same topology, indices offset by 8, but with one triangle
+    // flipped so this component requires repair to be internally consistent.
+    for (let i = 0; i < CUBE_TRIS_CORRECT.length; i++) {
+      cubeBTris[i] = CUBE_TRIS_CORRECT[i] + 8;
+    }
+    // Flip one cube-B triangle to introduce a within-component winding error.
+    const tmp = cubeBTris[1];
+    cubeBTris[1] = cubeBTris[2];
+    cubeBTris[2] = tmp;
+
+    const combined = new Uint32Array(cubeATris.length + cubeBTris.length);
+    combined.set(cubeATris, 0);
+    combined.set(cubeBTris, cubeATris.length);
+    expect(countDirectedEdgeCollisions(combined)).toBeGreaterThan(0);
+
+    const result = repairMeshWinding(verts2, combined);
+    // BFS reaches both components; each is now internally consistent.
+    expect(countDirectedEdgeCollisions(result)).toBe(0);
+  });
 });

--- a/src/shared/generation/repairMeshWinding.test.ts
+++ b/src/shared/generation/repairMeshWinding.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi } from 'vitest';
+import { repairMeshWinding } from './repairMeshWinding';
+
+/**
+ * Unit cube vertices and a correctly-wound triangulation. Each face is split
+ * into two triangles whose vertex order produces an outward-facing normal
+ * (right-hand rule). Signed volume of this mesh equals the cube volume = 1.
+ */
+const CUBE_VERTS = new Float32Array([
+  0,
+  0,
+  0, // 0
+  1,
+  0,
+  0, // 1
+  1,
+  1,
+  0, // 2
+  0,
+  1,
+  0, // 3
+  0,
+  0,
+  1, // 4
+  1,
+  0,
+  1, // 5
+  1,
+  1,
+  1, // 6
+  0,
+  1,
+  1, // 7
+]);
+
+const CUBE_TRIS_CORRECT = new Uint32Array([
+  // bottom (z=0, normal -z)
+  0, 2, 1, 0, 3, 2,
+  // top (z=1, normal +z)
+  4, 5, 6, 4, 6, 7,
+  // front (y=0, normal -y)
+  0, 1, 5, 0, 5, 4,
+  // right (x=1, normal +x)
+  1, 2, 6, 1, 6, 5,
+  // back (y=1, normal +y)
+  2, 3, 7, 2, 7, 6,
+  // left (x=0, normal -x)
+  3, 0, 4, 3, 4, 7,
+]);
+
+function signedVolume(verts: ArrayLike<number>, tris: ArrayLike<number>): number {
+  let vol = 0;
+  for (let t = 0; t < tris.length; t += 3) {
+    const ai = tris[t] * 3;
+    const bi = tris[t + 1] * 3;
+    const ci = tris[t + 2] * 3;
+    const ax = verts[ai];
+    const ay = verts[ai + 1];
+    const az = verts[ai + 2];
+    const bx = verts[bi];
+    const by = verts[bi + 1];
+    const bz = verts[bi + 2];
+    const cx = verts[ci];
+    const cy = verts[ci + 1];
+    const cz = verts[ci + 2];
+    vol += ax * (by * cz - bz * cy) + bx * (cy * az - cz * ay) + cx * (ay * bz - az * by);
+  }
+  return vol / 6;
+}
+
+function countDirectedEdgeCollisions(tris: ArrayLike<number>): number {
+  const seen = new Set<number>();
+  let collisions = 0;
+  for (let t = 0; t < tris.length; t += 3) {
+    const a = tris[t];
+    const b = tris[t + 1];
+    const c = tris[t + 2];
+    for (const [u, v] of [
+      [a, b],
+      [b, c],
+      [c, a],
+    ] as const) {
+      const key = u * 0x4000000 + v;
+      if (seen.has(key)) collisions++;
+      else seen.add(key);
+    }
+  }
+  return collisions;
+}
+
+function flipTriangle(tris: Uint32Array, t: number): Uint32Array {
+  const out = new Uint32Array(tris);
+  const tmp = out[t * 3 + 1];
+  out[t * 3 + 1] = out[t * 3 + 2];
+  out[t * 3 + 2] = tmp;
+  return out;
+}
+
+describe('repairMeshWinding', () => {
+  it('returns empty array for empty input', () => {
+    const result = repairMeshWinding(new Float32Array(), new Uint32Array());
+    expect(result.length).toBe(0);
+  });
+
+  it('leaves a correctly-wound cube unchanged', () => {
+    const result = repairMeshWinding(CUBE_VERTS, CUBE_TRIS_CORRECT);
+    expect(Array.from(result)).toEqual(Array.from(CUBE_TRIS_CORRECT));
+    expect(signedVolume(CUBE_VERTS, result)).toBeCloseTo(1, 5);
+    expect(countDirectedEdgeCollisions(result)).toBe(0);
+  });
+
+  it('repairs a single flipped triangle', () => {
+    // Flip triangle at index 4 (a top-face triangle) — its directed edges now
+    // collide with the adjacent top triangle's edge.
+    const broken = flipTriangle(CUBE_TRIS_CORRECT, 4);
+    expect(countDirectedEdgeCollisions(broken)).toBeGreaterThan(0);
+
+    const result = repairMeshWinding(CUBE_VERTS, broken);
+    expect(countDirectedEdgeCollisions(result)).toBe(0);
+    expect(signedVolume(CUBE_VERTS, result)).toBeCloseTo(1, 5);
+  });
+
+  it('repairs both triangles of a flipped face via BFS propagation', () => {
+    // Flip both triangles on the bottom face (indices 0 and 1).
+    let broken = flipTriangle(CUBE_TRIS_CORRECT, 0);
+    broken = flipTriangle(broken, 1);
+    expect(countDirectedEdgeCollisions(broken)).toBeGreaterThan(0);
+
+    const result = repairMeshWinding(CUBE_VERTS, broken);
+    expect(countDirectedEdgeCollisions(result)).toBe(0);
+    expect(signedVolume(CUBE_VERTS, result)).toBeCloseTo(1, 5);
+  });
+
+  it('uses signed-volume safety net when every triangle is inverted', () => {
+    // Globally flip every triangle. BFS alone won't fix this — the seed's
+    // own winding is wrong, so BFS propagates the wrong direction. The
+    // safety net detects negative signed volume and flips the whole mesh.
+    const inverted = new Uint32Array(CUBE_TRIS_CORRECT);
+    for (let t = 0; t < inverted.length; t += 3) {
+      const tmp = inverted[t + 1];
+      inverted[t + 1] = inverted[t + 2];
+      inverted[t + 2] = tmp;
+    }
+    expect(signedVolume(CUBE_VERTS, inverted)).toBeCloseTo(-1, 5);
+
+    const result = repairMeshWinding(CUBE_VERTS, inverted);
+    expect(signedVolume(CUBE_VERTS, result)).toBeCloseTo(1, 5);
+    expect(countDirectedEdgeCollisions(result)).toBe(0);
+  });
+
+  it('does not mutate the input triangle array', () => {
+    const broken = flipTriangle(CUBE_TRIS_CORRECT, 4);
+    const snapshot = Array.from(broken);
+    repairMeshWinding(CUBE_VERTS, broken);
+    expect(Array.from(broken)).toEqual(snapshot);
+  });
+
+  it('logs a warning and returns a result when input has a boundary edge', () => {
+    // Drop the last triangle to create open boundary edges. The function
+    // should still return a triangle array and warn — not throw.
+    const truncated = CUBE_TRIS_CORRECT.slice(0, CUBE_TRIS_CORRECT.length - 3);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => repairMeshWinding(CUBE_VERTS, truncated)).not.toThrow();
+    const result = repairMeshWinding(CUBE_VERTS, truncated);
+    expect(result.length).toBe(truncated.length);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/shared/generation/repairMeshWinding.ts
+++ b/src/shared/generation/repairMeshWinding.ts
@@ -1,0 +1,242 @@
+/**
+ * Mesh winding repair via BFS flood-fill.
+ *
+ * Some brepjs/OCCT BREP construction paths emit tessellated meshes whose face
+ * orientations aren't consistent with each other — adjacent triangles sharing
+ * an edge can both emit it as the same directed edge (u→v), instead of one
+ * emitting u→v and the other v→u. Slicers (Bambu Studio, Cura) interpret this
+ * as "non-manifold edges" and either reject the file or repair it as solid
+ * infill. See issue #1490 for the user-visible symptom.
+ *
+ * The standard topological cleanup is a BFS:
+ *   1. Pick a seed triangle whose orientation is known correct (here: the
+ *      triangle with the strongest +z normal at the maximum z, i.e. on the
+ *      top face of an upright slab).
+ *   2. Walk edge-adjacent neighbors. For each neighbor sharing a directed
+ *      edge u→v that already exists in the visited side, the neighbor is
+ *      wound backwards — swap two of its vertex indices to flip it.
+ *   3. After propagation, compute signed volume; if negative, the seed
+ *      assumption was wrong and every triangle is inverted — flip the whole
+ *      mesh as a global correction.
+ *
+ * Non-manifold edges (boundary, or shared by ≥3 triangles) are skipped with
+ * a warning so genuinely defective input doesn't crash the export pipeline.
+ *
+ * Pure function: vertices are unchanged; the returned `Uint32Array` is a
+ * fresh copy of the input with vertex order corrected per triangle.
+ *
+ * Reusable for any flat-indexed triangle mesh (vertex stride 3, tri stride 3).
+ * Currently only wired into baseplate STL export; bins/dividers use the same
+ * brepjs meshing path and can adopt this if the same symptom surfaces there.
+ */
+
+import { createLogger } from '@/core/logger';
+
+const logger = createLogger('repairMeshWinding');
+
+/**
+ * Repair triangle winding so every directed edge appears at most once and
+ * the signed volume is positive.
+ *
+ * @param vertices Flat XYZ array (length = vertexCount * 3).
+ * @param triangles Flat indexed-triangle array (length = triangleCount * 3).
+ * @returns A new triangle array of the same length with corrected winding.
+ */
+export function repairMeshWinding(
+  vertices: ArrayLike<number>,
+  triangles: ArrayLike<number>
+): Uint32Array {
+  const triCount = triangles.length / 3;
+  const out = new Uint32Array(triangles.length);
+  for (let i = 0; i < triangles.length; i++) {
+    out[i] = triangles[i];
+  }
+
+  if (triCount === 0) return out;
+
+  // Build undirected-edge → triangle-indices map.
+  const edgeMap = new Map<number, number[]>();
+  for (let t = 0; t < triCount; t++) {
+    const a = out[t * 3];
+    const b = out[t * 3 + 1];
+    const c = out[t * 3 + 2];
+    addEdge(edgeMap, a, b, t);
+    addEdge(edgeMap, b, c, t);
+    addEdge(edgeMap, c, a, t);
+  }
+
+  const seedIdx = findSeedTriangle(vertices, out, triCount);
+
+  // BFS from the seed, flipping any neighbor whose shared edge has the wrong
+  // direction relative to the visited side.
+  const visited = new Uint8Array(triCount);
+  const queue: number[] = [seedIdx];
+  visited[seedIdx] = 1;
+  let nonManifoldEdges = 0;
+
+  while (queue.length > 0) {
+    const t = queue.shift() as number;
+    const a = out[t * 3];
+    const b = out[t * 3 + 1];
+    const c = out[t * 3 + 2];
+
+    nonManifoldEdges += processEdge(out, edgeMap, visited, queue, t, a, b);
+    nonManifoldEdges += processEdge(out, edgeMap, visited, queue, t, b, c);
+    nonManifoldEdges += processEdge(out, edgeMap, visited, queue, t, c, a);
+  }
+
+  // Safety net: if seed itself was wound backwards (e.g., the entire top face
+  // was inverted), BFS propagated the wrong winding everywhere. Detect via
+  // signed-volume sign and globally flip if needed.
+  if (signedVolume(vertices, out, triCount) < 0) {
+    for (let t = 0; t < triCount; t++) {
+      const tmp = out[t * 3 + 1];
+      out[t * 3 + 1] = out[t * 3 + 2];
+      out[t * 3 + 2] = tmp;
+    }
+  }
+
+  if (nonManifoldEdges > 0) {
+    logger.warn('Skipped non-manifold edges during winding repair', {
+      nonManifoldEdges,
+      triangleCount: triCount,
+    });
+  }
+
+  return out;
+}
+
+function edgeKey(u: number, v: number): number {
+  // Pack (min, max) into a single 53-bit safe integer key.
+  // Vertex counts in this codebase are well under 2^26, so this fits.
+  const lo = u < v ? u : v;
+  const hi = u < v ? v : u;
+  return lo * 0x4000000 + hi;
+}
+
+function addEdge(map: Map<number, number[]>, u: number, v: number, t: number): void {
+  const key = edgeKey(u, v);
+  const list = map.get(key);
+  if (list === undefined) {
+    map.set(key, [t]);
+  } else {
+    list.push(t);
+  }
+}
+
+/**
+ * Process one directed edge of triangle `t`. If the neighbor across this edge
+ * hasn't been visited, mark it visited, flip it if its shared-edge direction
+ * matches `t`'s (same direction = inconsistent), and enqueue.
+ *
+ * @returns 1 if the edge is non-manifold (boundary or ≥3 triangles), else 0.
+ */
+function processEdge(
+  out: Uint32Array,
+  edgeMap: Map<number, number[]>,
+  visited: Uint8Array,
+  queue: number[],
+  t: number,
+  u: number,
+  v: number
+): number {
+  const neighbors = edgeMap.get(edgeKey(u, v));
+  if (neighbors === undefined || neighbors.length !== 2) {
+    return 1;
+  }
+  const other = neighbors[0] === t ? neighbors[1] : neighbors[0];
+  if (visited[other]) return 0;
+  visited[other] = 1;
+
+  // If `other` also emits the directed edge u→v, its winding is inconsistent
+  // with `t`'s — flip it by swapping two indices.
+  const oa = out[other * 3];
+  const ob = out[other * 3 + 1];
+  const oc = out[other * 3 + 2];
+  const sameDirection = (oa === u && ob === v) || (ob === u && oc === v) || (oc === u && oa === v);
+  if (sameDirection) {
+    out[other * 3 + 1] = oc;
+    out[other * 3 + 2] = ob;
+  }
+
+  queue.push(other);
+  return 0;
+}
+
+/**
+ * Pick a seed triangle whose outward direction we can guess: the triangle
+ * with the strongest +z component of its (current-winding) face normal among
+ * triangles whose vertices all sit at the maximum-z plane.
+ *
+ * Falls back to triangle 0 if no such candidate exists.
+ */
+function findSeedTriangle(
+  vertices: ArrayLike<number>,
+  triangles: Uint32Array,
+  triCount: number
+): number {
+  // First pass: find max z across all vertices.
+  let maxZ = -Infinity;
+  for (let i = 2; i < vertices.length; i += 3) {
+    if (vertices[i] > maxZ) maxZ = vertices[i];
+  }
+
+  let bestIdx = 0;
+  let bestNz = -Infinity;
+  const eps = 1e-6;
+  for (let t = 0; t < triCount; t++) {
+    const a = triangles[t * 3];
+    const b = triangles[t * 3 + 1];
+    const c = triangles[t * 3 + 2];
+    const az = vertices[a * 3 + 2];
+    const bz = vertices[b * 3 + 2];
+    const cz = vertices[c * 3 + 2];
+    if (Math.abs(az - maxZ) > eps || Math.abs(bz - maxZ) > eps || Math.abs(cz - maxZ) > eps) {
+      continue;
+    }
+    const nz = triangleNormalZ(vertices, a, b, c);
+    if (nz > bestNz) {
+      bestNz = nz;
+      bestIdx = t;
+    }
+  }
+  return bestIdx;
+}
+
+function triangleNormalZ(vertices: ArrayLike<number>, a: number, b: number, c: number): number {
+  const ax = vertices[a * 3];
+  const ay = vertices[a * 3 + 1];
+  const bx = vertices[b * 3];
+  const by = vertices[b * 3 + 1];
+  const cx = vertices[c * 3];
+  const cy = vertices[c * 3 + 1];
+  const ex = bx - ax;
+  const ey = by - ay;
+  const fx = cx - ax;
+  const fy = cy - ay;
+  return ex * fy - ey * fx;
+}
+
+function signedVolume(
+  vertices: ArrayLike<number>,
+  triangles: Uint32Array,
+  triCount: number
+): number {
+  let vol = 0;
+  for (let t = 0; t < triCount; t++) {
+    const a = triangles[t * 3];
+    const b = triangles[t * 3 + 1];
+    const c = triangles[t * 3 + 2];
+    const ax = vertices[a * 3];
+    const ay = vertices[a * 3 + 1];
+    const az = vertices[a * 3 + 2];
+    const bx = vertices[b * 3];
+    const by = vertices[b * 3 + 1];
+    const bz = vertices[b * 3 + 2];
+    const cx = vertices[c * 3];
+    const cy = vertices[c * 3 + 1];
+    const cz = vertices[c * 3 + 2];
+    vol += ax * (by * cz - bz * cy) + bx * (cy * az - cz * ay) + cx * (ay * bz - az * by);
+  }
+  return vol / 6;
+}

--- a/src/shared/generation/repairMeshWinding.ts
+++ b/src/shared/generation/repairMeshWinding.ts
@@ -36,7 +36,22 @@ const logger = createLogger('repairMeshWinding');
 
 /**
  * Repair triangle winding so every directed edge appears at most once and
- * the signed volume is positive.
+ * the (global) signed volume is positive.
+ *
+ * BFS-walks every triangle starting from the global "best" seed (top-face
+ * triangle with strongest +z normal). Meshes whose connectivity graph is
+ * disconnected — either truly multi-component or because brepjs emits
+ * per-face vertex ranges with no index sharing across face boundaries —
+ * are still fully walked: any unvisited triangle after the first BFS
+ * spawns a new BFS pass, so no triangle is left unflipped if it needed to
+ * be.
+ *
+ * The signed-volume safety net is applied **globally**, not per-component.
+ * For brepjs's per-face-indexed output, individual face components have
+ * meaningless or near-zero volume contributions (e.g., a flat z=0 face
+ * contributes exactly 0); a per-component flip would mis-decide those
+ * cases. The global integral aggregates contributions across all faces,
+ * giving a reliable signal of whether the whole mesh is inverted.
  *
  * @param vertices Flat XYZ array (length = vertexCount * 3).
  * @param triangles Flat indexed-triangle array (length = triangleCount * 3).
@@ -46,6 +61,12 @@ export function repairMeshWinding(
   vertices: ArrayLike<number>,
   triangles: ArrayLike<number>
 ): Uint32Array {
+  if (triangles.length % 3 !== 0) {
+    throw new Error(
+      `repairMeshWinding: triangles.length=${triangles.length} is not a multiple of 3`
+    );
+  }
+
   const triCount = triangles.length / 3;
   const out = new Uint32Array(triangles.length);
   for (let i = 0; i < triangles.length; i++) {
@@ -65,29 +86,28 @@ export function repairMeshWinding(
     addEdge(edgeMap, c, a, t);
   }
 
-  const seedIdx = findSeedTriangle(vertices, out, triCount);
-
-  // BFS from the seed, flipping any neighbor whose shared edge has the wrong
-  // direction relative to the visited side.
   const visited = new Uint8Array(triCount);
-  const queue: number[] = [seedIdx];
-  visited[seedIdx] = 1;
   let nonManifoldEdges = 0;
+  const recordNonManifold = (n: number): void => {
+    nonManifoldEdges += n;
+  };
 
-  while (queue.length > 0) {
-    const t = queue.shift() as number;
-    const a = out[t * 3];
-    const b = out[t * 3 + 1];
-    const c = out[t * 3 + 2];
-
-    nonManifoldEdges += processEdge(out, edgeMap, visited, queue, t, a, b);
-    nonManifoldEdges += processEdge(out, edgeMap, visited, queue, t, b, c);
-    nonManifoldEdges += processEdge(out, edgeMap, visited, queue, t, c, a);
+  // First BFS uses the global best seed (top-face strongest +z). Subsequent
+  // BFS passes pick up any triangles not reachable from the first seed
+  // (multi-component meshes, or brepjs per-face-indexed output where faces
+  // don't share vertex indices across their boundaries).
+  const firstSeed = findSeedTriangle(vertices, out, triCount);
+  bfsComponent(out, edgeMap, visited, firstSeed, recordNonManifold);
+  for (let t = 0; t < triCount; t++) {
+    if (visited[t]) continue;
+    bfsComponent(out, edgeMap, visited, t, recordNonManifold);
   }
 
-  // Safety net: if seed itself was wound backwards (e.g., the entire top face
-  // was inverted), BFS propagated the wrong winding everywhere. Detect via
-  // signed-volume sign and globally flip if needed.
+  // Global safety net: if the seed itself was wound backwards (e.g., the
+  // entire top face was inverted, leading BFS to propagate the wrong
+  // direction everywhere), the global signed volume is negative — flip all
+  // triangles. Per-component flipping would mis-decide individual flat
+  // faces whose volume contribution is near zero.
   if (signedVolume(vertices, out, triCount) < 0) {
     for (let t = 0; t < triCount; t++) {
       const tmp = out[t * 3 + 1];
@@ -104,6 +124,39 @@ export function repairMeshWinding(
   }
 
   return out;
+}
+
+/**
+ * BFS-walk one connected component starting from `seed`. Uses a head-pointer
+ * queue (O(n) total dequeues) instead of Array.shift (which is O(n) each).
+ * Flips any neighbor whose shared-edge direction matches the visited side's.
+ *
+ * @returns The list of triangle indices visited in this component.
+ */
+function bfsComponent(
+  out: Uint32Array,
+  edgeMap: Map<number, number[]>,
+  visited: Uint8Array,
+  seed: number,
+  recordNonManifold: (n: number) => void
+): void {
+  const queue: number[] = [seed];
+  visited[seed] = 1;
+  let head = 0;
+  let nonManifold = 0;
+
+  while (head < queue.length) {
+    const t = queue[head++];
+    const a = out[t * 3];
+    const b = out[t * 3 + 1];
+    const c = out[t * 3 + 2];
+
+    nonManifold += processEdge(out, edgeMap, visited, queue, t, a, b);
+    nonManifold += processEdge(out, edgeMap, visited, queue, t, b, c);
+    nonManifold += processEdge(out, edgeMap, visited, queue, t, c, a);
+  }
+
+  recordNonManifold(nonManifold);
 }
 
 function edgeKey(u: number, v: number): number {


### PR DESCRIPTION
## Summary

- New `src/shared/generation/repairMeshWinding.ts`: BFS flood-fill winding repair for indexed triangle meshes. Picks a seed with strong +z normal, propagates correct winding via edge adjacency, falls back to a global flip if signed volume ends up negative.
- `buildBaseplateSTL` now runs the repair on the brepjs mesh before emitting STL records. Comment block updated to reflect that brepjs/OCCT face orientations aren't always consistent — see issue body for diagnosis.
- Three new winding scenario tests (corner-3, corner-4, edge-x-1) covering the piece roles that the existing corner-1 / edge-y-1 / magnet tests didn't reach. New tests assert directed-edge uniqueness AND positive signed volume.

## Why

User-reported on #1490: Bambu Studio flagged "non-manifold edges" on `corner-3` and `corner-4` exports of `gavinmcfall`'s `NERDZ_7-drawer-tool-chest` baseplate even after #1473 removed the broken cross·vertex-normal heuristic. Topology analysis on the attached 3MFs:

| Check | corner-3 | corner-4 |
|---|---|---|
| Boundary edges (manifold check) | 0 | 0 |
| Over-shared edges | 0 | 0 |
| Bad-winding directed edges | **8510 (~16%)** | **7262 (~16%)** |
| Signed volume vs. expected | **220 cm³ vs. ~132 cm³** | **196 cm³ vs. ~116 cm³** |
| Bottom face (z=0) triangles | **2126/2126 face +z (inverted)** | **1826/1826 face +z (inverted)** |

The mesh is adjacency-clean but winding-inconsistent. Slicers use winding to determine inside/outside, so they read this as "non-manifold edges" and repair the result as solid infill — the user's symptom.

## Why downstream

PR #1473 trusts brepjs's face orientation verbatim. That works for the existing test cases (corner-1, edge-y-1, magnet) but fails for some piece configs — specifically the ones with non-trivial dovetail edge mixes on the back/right side. The exact BREP op producing the inversion isn't obvious from the code (the asymmetry vs. `boxBuilder`'s `+z` extrude convention is suspicious — baseplate uses `extrude(-totalHeight)` + a final `+totalHeight` translate — but pinpointing requires runtime BREP instrumentation). I'm filing a follow-up issue to track that investigation.

The downstream repair is bounded, deterministic, and a no-op for already-correct meshes (the existing scenario tests still pass without modification).

## Test plan

- [x] 7 unit tests for `repairMeshWinding` (cube fixtures incl. all-flipped safety net + boundary-edge non-manifold path)
- [x] Existing winding scenario tests (corner-1, edge-y-1, magnet) still pass
- [x] 3 new scenario tests for corner-3, corner-4, edge-x-1 all pass
- [x] Independent Python topology checker on dumped STLs of corner-3/corner-4/edge-x-1 reports `0 bad-winding edges, watertight, positive volume` (independent verification, not via the in-test parser)
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` clean on changed files
- [x] Pre-commit hooks (i18n × 4, exhaustiveness, component structure, missing tests, readme reminders) all pass

## After merge

Will comment on #1490 asking gavinmcfall to re-export his baseplate against the new release and confirm Bambu's warning is gone.