### PR TITLE
chore(baseplate): document winding-repair as no-op on brepjs 15.6.1 (#1494)

### DIFF
--- a/src/features/generation/worker/generators/__dual-kernel__/diagnoseBaseplateWinding.test.ts
+++ b/src/features/generation/worker/generators/__dual-kernel__/diagnoseBaseplateWinding.test.ts
@@ -52,8 +52,9 @@ interface StepMetrics {
 }
 
 const QUANTIZE = 1e4;
-const vKey = (x: number, y: number, z: number): string =>
-  `${Math.round(x * QUANTIZE)},${Math.round(y * QUANTIZE)},${Math.round(z * QUANTIZE)}`;
+function vKey(x: number, y: number, z: number): string {
+  return `${Math.round(x * QUANTIZE)},${Math.round(y * QUANTIZE)},${Math.round(z * QUANTIZE)}`;
+}
 
 /**
  * Count directed-edge collisions and divergence-theorem volume on a flat
@@ -85,10 +86,15 @@ function metricsFromMesh(
     const a = vKey(ax, ay, az);
     const b = vKey(bx, by, bz);
     const c = vKey(cx, cy, cz);
-    for (const e of [`${a}->${b}`, `${b}->${c}`, `${c}->${a}`]) {
-      if (seen.has(e)) collisions++;
-      else seen.add(e);
-    }
+    const ab = `${a}->${b}`;
+    const bc = `${b}->${c}`;
+    const ca = `${c}->${a}`;
+    if (seen.has(ab)) collisions++;
+    else seen.add(ab);
+    if (seen.has(bc)) collisions++;
+    else seen.add(bc);
+    if (seen.has(ca)) collisions++;
+    else seen.add(ca);
     volume += ax * (by * cz - bz * cy) + bx * (cy * az - cz * ay) + cx * (ay * bz - az * by);
   }
   return { collisions, volume: volume / 6 };
@@ -106,22 +112,24 @@ function measureStep(label: string, shape: Shape3D): StepMetrics {
   };
 }
 
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
-  width: 4.5,
-  depth: 4.5,
-  gridUnitMm: 42,
-  magnetHoles: false,
-  magnetDiameter: 6.5,
-  magnetDepth: 2.4,
-  paddingLeft: 0,
-  paddingRight: 0,
-  paddingFront: 0,
-  paddingBack: 0,
-  fractionalEdgeX: 'end',
-  fractionalEdgeY: 'end',
-  lightweight: true,
-  ...overrides,
-});
+function defaults(overrides: Partial<BaseplateParams> = {}): BaseplateParams {
+  return {
+    width: 4.5,
+    depth: 4.5,
+    gridUnitMm: 42,
+    magnetHoles: false,
+    magnetDiameter: 6.5,
+    magnetDepth: 2.4,
+    paddingLeft: 0,
+    paddingRight: 0,
+    paddingFront: 0,
+    paddingBack: 0,
+    fractionalEdgeX: 'end',
+    fractionalEdgeY: 'end',
+    lightweight: true,
+    ...overrides,
+  };
+}
 
 interface NamedConfig {
   readonly name: string;
@@ -195,11 +203,13 @@ const CONFIGS: readonly NamedConfig[] = [
 ];
 
 function formatStepRow(m: StepMetrics): string {
-  const tris = m.triangleCount.toString().padStart(6);
-  const groups = m.faceGroupCount.toString().padStart(5);
-  const collisions = m.directedEdgeCollisions.toString().padStart(6);
-  const vol = m.signedVolume.toFixed(0).padStart(10);
-  return `  ${m.label.padEnd(22)}  tris=${tris}  faces=${groups}  edge-dupes=${collisions}  vol=${vol}`;
+  return (
+    `  ${m.label.padEnd(22)}` +
+    `  tris=${m.triangleCount.toString().padStart(6)}` +
+    `  faces=${m.faceGroupCount.toString().padStart(5)}` +
+    `  edge-dupes=${m.directedEdgeCollisions.toString().padStart(6)}` +
+    `  vol=${m.signedVolume.toFixed(0).padStart(10)}`
+  );
 }
 
 beforeAll(async () => {
@@ -271,7 +281,13 @@ test('diagnose buildBaseplateSolid winding step-by-step', () => {
   console.log('                  (>0 means inconsistent triangle winding)');
   console.log('    vol         = signed mesh volume (negative => mesh is globally inverted)');
 
+  const failures: string[] = [];
   for (const cfg of CONFIGS) {
+    // `slabExtruded` only fires on the cache-miss path; clearing between
+    // configs guarantees every config walks every milestone, even if two
+    // ever shared a `slabWithPocketsCache` key.
+    clearBaseplateCaches();
+
     console.log('\n------------------------------------------------------------------------');
     console.log(`  ${cfg.name}`);
     console.log('------------------------------------------------------------------------');
@@ -286,9 +302,16 @@ test('diagnose buildBaseplateSolid winding step-by-step', () => {
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       console.log(`  ! buildBaseplateSolid threw: ${msg}`);
+      failures.push(`${cfg.name}: ${msg}`);
     }
     for (const m of steps) console.log(formatStepRow(m));
   }
   console.log('\n========================================================================\n');
   /* eslint-enable no-console */
+
+  // Surface any per-config throws as a real test failure rather than only
+  // a console line — silence is success-shaped in CI.
+  if (failures.length > 0) {
+    throw new Error(`buildBaseplateSolid threw for: ${failures.join('; ')}`);
+  }
 }, 300_000);

--- a/src/features/generation/worker/generators/__dual-kernel__/diagnoseBaseplateWinding.test.ts
+++ b/src/features/generation/worker/generators/__dual-kernel__/diagnoseBaseplateWinding.test.ts
@@ -1,0 +1,283 @@
+// @vitest-environment node
+/**
+ * Step-by-step winding diagnosis for `buildBaseplateSolid` (issue #1494).
+ *
+ * Walks construction one BREP op at a time using the `BaseplateProbe` hook,
+ * meshes each intermediate solid with the same tessellation parameters as
+ * the production STL export path, and reports per-step winding metrics:
+ *
+ *   - directedEdgeCollisions — directed edges (a→b) appearing more than
+ *     once across all triangles. In a closed orientable mesh each
+ *     directed edge appears at most once; duplicates indicate triangles
+ *     wound inconsistently relative to their neighbours.
+ *   - signedVolume — divergence-theorem volume from the mesh. Positive
+ *     means the mesh is consistently outward-oriented; negative means
+ *     a dominant region is inverted.
+ *
+ * The test also runs a second pass that diffs raw `mesh()` output against
+ * `repairMeshWinding(...)` output to report how many triangles the repair
+ * actually flips. With brepjs 15.6.1 and the OCCT kernel, the repair flips
+ * zero triangles for every known piece config including the user-reported
+ * 13×9 magnet+lightweight+connector reproducer — i.e. the bug described in
+ * #1490 is no longer observable downstream of `mesh()`. The repair remains
+ * as a defensive net for any future regression in brepjs/OCCT tessellation.
+ *
+ * Run:
+ *   pnpm exec vitest run --config vitest.profile.config.ts \
+ *     src/features/generation/worker/generators/__dual-kernel__/diagnoseBaseplateWinding
+ *
+ * The test is **diagnostic** — it always passes. Inspect the printed
+ * tables to identify the first construction step at which a failing
+ * config (corner-3 / corner-4 / edge-x-1) diverges from a passing one
+ * (corner-1).
+ */
+import { test, beforeAll } from 'vitest';
+import { mesh } from 'brepjs';
+import type { Shape3D } from 'brepjs';
+import type { BaseplateParams } from '@/shared/types/bin';
+import { initBrepjs } from './wasmInit';
+import {
+  buildBaseplateSolid,
+  type BaseplateProbe,
+} from '@/features/generation/worker/generators/baseplateGenerator';
+import { repairMeshWinding } from '@/shared/generation/repairMeshWinding';
+
+interface StepMetrics {
+  readonly label: string;
+  readonly triangleCount: number;
+  readonly faceGroupCount: number;
+  readonly directedEdgeCollisions: number;
+  readonly signedVolume: number;
+}
+
+const QUANTIZE = 1e4;
+const vKey = (x: number, y: number, z: number): string =>
+  `${Math.round(x * QUANTIZE)},${Math.round(y * QUANTIZE)},${Math.round(z * QUANTIZE)}`;
+
+/**
+ * Count directed-edge collisions and divergence-theorem volume on a flat
+ * (vertices, triangles) pair. Mirrors the metrics in
+ * `baseplateGenerator.scenario.winding.test.ts` so this diagnosis can be
+ * cross-checked against the existing regression assertions.
+ */
+function metricsFromMesh(
+  vertices: ArrayLike<number>,
+  triangles: ArrayLike<number>
+): { collisions: number; volume: number } {
+  const triCount = triangles.length / 3;
+  const seen = new Set<string>();
+  let collisions = 0;
+  let volume = 0;
+  for (let t = 0; t < triCount; t++) {
+    const i0 = triangles[t * 3] * 3;
+    const i1 = triangles[t * 3 + 1] * 3;
+    const i2 = triangles[t * 3 + 2] * 3;
+    const ax = vertices[i0];
+    const ay = vertices[i0 + 1];
+    const az = vertices[i0 + 2];
+    const bx = vertices[i1];
+    const by = vertices[i1 + 1];
+    const bz = vertices[i1 + 2];
+    const cx = vertices[i2];
+    const cy = vertices[i2 + 1];
+    const cz = vertices[i2 + 2];
+    const a = vKey(ax, ay, az);
+    const b = vKey(bx, by, bz);
+    const c = vKey(cx, cy, cz);
+    for (const e of [`${a}->${b}`, `${b}->${c}`, `${c}->${a}`]) {
+      if (seen.has(e)) collisions++;
+      else seen.add(e);
+    }
+    volume += ax * (by * cz - bz * cy) + bx * (cy * az - cz * ay) + cx * (ay * bz - az * by);
+  }
+  return { collisions, volume: volume / 6 };
+}
+
+function measureStep(label: string, shape: Shape3D): StepMetrics {
+  const m = mesh(shape, { tolerance: 0.01, angularTolerance: 5 });
+  const { collisions, volume } = metricsFromMesh(m.vertices, m.triangles);
+  return {
+    label,
+    triangleCount: m.triangles.length / 3,
+    faceGroupCount: m.faceGroups.length,
+    directedEdgeCollisions: collisions,
+    signedVolume: volume,
+  };
+}
+
+const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+  width: 4.5,
+  depth: 4.5,
+  gridUnitMm: 42,
+  magnetHoles: false,
+  magnetDiameter: 6.5,
+  magnetDepth: 2.4,
+  paddingLeft: 0,
+  paddingRight: 0,
+  paddingFront: 0,
+  paddingBack: 0,
+  fractionalEdgeX: 'end',
+  fractionalEdgeY: 'end',
+  lightweight: true,
+  ...overrides,
+});
+
+interface NamedConfig {
+  readonly name: string;
+  readonly params: BaseplateParams;
+}
+
+// Mirror the configs covered by the existing scenario winding test plus the
+// user-reported 13×9 reproducer from #1490.
+const CONFIGS: readonly NamedConfig[] = [
+  {
+    name: 'corner-1',
+    params: defaults({
+      paddingLeft: 7,
+      fractionalEdgeX: 'start',
+      fractionalEdgeY: 'start',
+      connectorNubs: true,
+      edges: { left: 'exterior', right: 'join', front: 'exterior', back: 'join' },
+    }),
+  },
+  {
+    name: 'corner-3',
+    params: defaults({
+      paddingLeft: 7,
+      paddingBack: 7,
+      fractionalEdgeX: 'start',
+      fractionalEdgeY: 'end',
+      connectorNubs: true,
+      edges: { left: 'exterior', right: 'join', front: 'join', back: 'exterior' },
+    }),
+  },
+  {
+    name: 'corner-4',
+    params: defaults({
+      paddingRight: 7,
+      paddingBack: 7,
+      fractionalEdgeX: 'end',
+      fractionalEdgeY: 'end',
+      connectorNubs: true,
+      edges: { left: 'join', right: 'exterior', front: 'join', back: 'exterior' },
+    }),
+  },
+  {
+    name: 'edge-x-1',
+    params: defaults({
+      width: 4.5,
+      depth: 5,
+      paddingRight: 7,
+      fractionalEdgeX: 'end',
+      connectorNubs: true,
+      edges: { left: 'join', right: 'exterior', front: 'join', back: 'join' },
+    }),
+  },
+  // User-reported reproducer (#1490): 13×9 padded baseplate with magnets +
+  // lightweight cuts + connectors. The user's exported STLs from this config
+  // were the original failure case that motivated the downstream repair.
+  {
+    name: 'user-13x9-magnets-padded',
+    params: defaults({
+      width: 13,
+      depth: 9,
+      paddingLeft: 7,
+      paddingRight: 7,
+      paddingFront: 7,
+      paddingBack: 7,
+      magnetHoles: true,
+      lightweight: true,
+      connectorNubs: true,
+      edges: { left: 'exterior', right: 'exterior', front: 'exterior', back: 'exterior' },
+    }),
+  },
+];
+
+function formatStepRow(m: StepMetrics): string {
+  const tris = m.triangleCount.toString().padStart(6);
+  const groups = m.faceGroupCount.toString().padStart(5);
+  const collisions = m.directedEdgeCollisions.toString().padStart(6);
+  const vol = m.signedVolume.toFixed(0).padStart(10);
+  return `  ${m.label.padEnd(22)}  tris=${tris}  faces=${groups}  edge-dupes=${collisions}  vol=${vol}`;
+}
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 60_000);
+
+test('diagnose: does repairMeshWinding actually flip triangles for these configs?', () => {
+  /* eslint-disable no-console */
+  console.log('\n========================================================================');
+  console.log('  Raw mesh() vs repairMeshWinding output');
+  console.log('========================================================================');
+  for (const cfg of CONFIGS) {
+    // Match the production export pipeline: forExport=false uses the
+    // simplified pocket cutter (the multi-section loft that forExport=true
+    // builds doesn't reliably tessellate or export — see exportBaseplate).
+    const solid = buildBaseplateSolid(cfg.params, false);
+    try {
+      const m = mesh(solid, { tolerance: 0.01, angularTolerance: 5 });
+      const before = metricsFromMesh(m.vertices, m.triangles);
+      const repaired = repairMeshWinding(m.vertices, m.triangles);
+      const after = metricsFromMesh(m.vertices, repaired);
+
+      let flipped = 0;
+      for (let t = 0; t < m.triangles.length; t += 3) {
+        if (
+          m.triangles[t] !== repaired[t] ||
+          m.triangles[t + 1] !== repaired[t + 1] ||
+          m.triangles[t + 2] !== repaired[t + 2]
+        ) {
+          flipped++;
+        }
+      }
+
+      console.log(`  ${cfg.name.padEnd(24)}`);
+      console.log(
+        `    raw      : edge-dupes=${before.collisions.toString().padStart(6)}  ` +
+          `vol=${before.volume.toFixed(0).padStart(10)}`
+      );
+      console.log(
+        `    repaired : edge-dupes=${after.collisions.toString().padStart(6)}  ` +
+          `vol=${after.volume.toFixed(0).padStart(10)}  ` +
+          `triangles-flipped=${flipped}/${m.triangles.length / 3}`
+      );
+    } finally {
+      solid.delete();
+    }
+  }
+  console.log('========================================================================\n');
+  /* eslint-enable no-console */
+}, 300_000);
+
+test('diagnose buildBaseplateSolid winding step-by-step', () => {
+  /* eslint-disable no-console */
+  console.log('\n========================================================================');
+  console.log('  buildBaseplateSolid — per-step winding diagnosis (issue #1494)');
+  console.log('========================================================================');
+  console.log('  Metrics:');
+  console.log('    edge-dupes  = directed edges appearing more than once across all triangles');
+  console.log('                  (>0 means inconsistent triangle winding)');
+  console.log('    vol         = signed mesh volume (negative => mesh is globally inverted)');
+
+  for (const cfg of CONFIGS) {
+    console.log('\n------------------------------------------------------------------------');
+    console.log(`  ${cfg.name}`);
+    console.log('------------------------------------------------------------------------');
+    const steps: StepMetrics[] = [];
+    const probe: BaseplateProbe = (label, shape) => {
+      steps.push(measureStep(label, shape));
+    };
+    try {
+      // Match the production export pipeline (forExport=false).
+      const solid = buildBaseplateSolid(cfg.params, false, undefined, probe);
+      solid.delete();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.log(`  ! buildBaseplateSolid threw: ${msg}`);
+    }
+    for (const m of steps) console.log(formatStepRow(m));
+  }
+  console.log('\n========================================================================\n');
+  /* eslint-enable no-console */
+}, 300_000);

--- a/src/features/generation/worker/generators/__dual-kernel__/diagnoseBaseplateWinding.test.ts
+++ b/src/features/generation/worker/generators/__dual-kernel__/diagnoseBaseplateWinding.test.ts
@@ -31,13 +31,14 @@
  * config (corner-3 / corner-4 / edge-x-1) diverges from a passing one
  * (corner-1).
  */
-import { test, beforeAll } from 'vitest';
+import { test, beforeAll, beforeEach } from 'vitest';
 import { mesh } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import type { BaseplateParams } from '@/shared/types/bin';
 import { initBrepjs } from './wasmInit';
 import {
   buildBaseplateSolid,
+  clearBaseplateCaches,
   type BaseplateProbe,
 } from '@/features/generation/worker/generators/baseplateGenerator';
 import { repairMeshWinding } from '@/shared/generation/repairMeshWinding';
@@ -204,6 +205,16 @@ function formatStepRow(m: StepMetrics): string {
 beforeAll(async () => {
   await initBrepjs();
 }, 60_000);
+
+// `buildBaseplateSolid` memoizes the rectangular slab + pockets via
+// `slabWithPocketsCache`. Without clearing between configs (and between the
+// two tests), the second invocation of any config short-circuits past the
+// `slabExtruded` and `pocketsCut` probe events — defeating the step-walker's
+// purpose. Clear before every test so each diagnostic walks the full
+// construction path.
+beforeEach(() => {
+  clearBaseplateCaches();
+});
 
 test('diagnose: does repairMeshWinding actually flip triangles for these configs?', () => {
   /* eslint-disable no-console */

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -1065,8 +1065,13 @@ function cutInBatches(solid: Shape3D, tools: Shape3D[]): Shape3D {
  *
  * Test-only: pass to `buildBaseplateSolid` to inspect intermediate solids
  * without modifying production code. The probe receives a *borrowed* handle
- * to the current baseplate solid — the caller must not delete or mutate it,
- * but may call non-mutating queries (mesh, measureVolume, describe). Used by
+ * to the current baseplate solid that is valid only synchronously for the
+ * duration of the callback invocation. The callback must not delete or
+ * mutate it, and may only perform immediate non-mutating queries (mesh,
+ * measureVolume, describe). Do not store, return, or otherwise retain
+ * `shape`, and do not use it after the callback returns — later build
+ * steps may replace and dispose the underlying WASM object, leaving any
+ * retained reference as a use-after-free. Used by
  * `__dual-kernel__/diagnoseBaseplateWinding.test.ts` to identify which BREP
  * op introduces face-orientation inconsistency in #1490-class configs.
  */

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -1063,17 +1063,10 @@ function cutInBatches(solid: Shape3D, tools: Shape3D[]): Shape3D {
 /**
  * Diagnostic probe invoked at each baseplate construction milestone.
  *
- * Test-only: pass to `buildBaseplateSolid` to inspect intermediate solids
- * without modifying production code. The probe receives a *borrowed* handle
- * to the current baseplate solid that is valid only synchronously for the
- * duration of the callback invocation. The callback must not delete or
- * mutate it, and may only perform immediate non-mutating queries (mesh,
- * measureVolume, describe). Do not store, return, or otherwise retain
- * `shape`, and do not use it after the callback returns — later build
- * steps may replace and dispose the underlying WASM object, leaving any
- * retained reference as a use-after-free. Used by
- * `__dual-kernel__/diagnoseBaseplateWinding.test.ts` to identify which BREP
- * op introduces face-orientation inconsistency in #1490-class configs.
+ * Test-only. `shape` is a *borrowed* handle valid only for the synchronous
+ * duration of the call — do not retain, delete, or mutate it. Later build
+ * steps may dispose the underlying WASM object, making any retained reference
+ * a use-after-free.
  */
 export type BaseplateProbe = (label: string, shape: Shape3D) => void;
 
@@ -1247,10 +1240,13 @@ export function buildBaseplateSolid(
     ];
     const preBoolean = baseplate;
     const pipelineResult = booleanPipeline(baseplate, steps);
+    let pipelineLabel = 'connectorPipeline';
     if (isOk(pipelineResult)) {
       baseplate = pipelineResult.value;
     } else {
-      // Fallback: sequential fuseAll then cutAll
+      // Fallback: sequential fuseAll then cutAll. Tag the probe so the
+      // diagnostic can tell which path produced the final solid (#1494).
+      pipelineLabel = 'connectorPipelineFallback';
       if (nubs.length > 0) {
         baseplate = tagOp('connectorFuse', () =>
           unwrap(fuseAll([baseplate, ...nubs] as ValidSolid[]))
@@ -1267,16 +1263,21 @@ export function buildBaseplateSolid(
     if (baseplate !== preBoolean) preBoolean.delete();
     for (const n of nubs) n.delete();
     for (const c of connHoles) c.delete();
-    probe?.('connectorPipeline', baseplate);
+    probe?.(pipelineLabel, baseplate);
   }
 
   onProgress?.(0.6);
 
   onProgress?.(0.8);
 
+  // Probe before the final translate: the +Z shift preserves topology,
+  // orientation, and signed volume, so the diagnostic sees identical
+  // metrics either way — and a probe throw here can't strand `baseplate`
+  // (already in scope, freed after `translate` returns) or `finalBaseplate`
+  // (not yet created).
+  probe?.('final', baseplate);
   const finalBaseplate = translate(baseplate, [0, 0, totalHeight]);
   baseplate.delete();
-  probe?.('final', finalBaseplate);
   return finalBaseplate;
 }
 

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -1061,6 +1061,18 @@ function cutInBatches(solid: Shape3D, tools: Shape3D[]): Shape3D {
 }
 
 /**
+ * Diagnostic probe invoked at each baseplate construction milestone.
+ *
+ * Test-only: pass to `buildBaseplateSolid` to inspect intermediate solids
+ * without modifying production code. The probe receives a *borrowed* handle
+ * to the current baseplate solid — the caller must not delete or mutate it,
+ * but may call non-mutating queries (mesh, measureVolume, describe). Used by
+ * `__dual-kernel__/diagnoseBaseplateWinding.test.ts` to identify which BREP
+ * op introduces face-orientation inconsistency in #1490-class configs.
+ */
+export type BaseplateProbe = (label: string, shape: Shape3D) => void;
+
+/**
  * Build the complete baseplate BREP solid.
  *
  * Without magnets: slab height = SOCKET_HEIGHT (5mm). Pockets are through-cut
@@ -1074,10 +1086,11 @@ function cutInBatches(solid: Shape3D, tools: Shape3D[]): Shape3D {
  * The slab profile has rounded exterior corners (PLATE_CORNER_RADIUS),
  * which carry through the full height including the magnet floor.
  */
-function buildBaseplateSolid(
+export function buildBaseplateSolid(
   params: BaseplateParams,
   forExport: boolean = true,
-  onProgress?: (progress: number) => void
+  onProgress?: (progress: number) => void,
+  probe?: BaseplateProbe
 ): Shape3D {
   const {
     width,
@@ -1123,6 +1136,7 @@ function buildBaseplateSolid(
     ).extrude(-totalHeight);
     baseplate = translate(extrudedSlab, [slabOffsetX, slabOffsetY, 0]);
     extrudedSlab.delete();
+    probe?.('slabExtruded', baseplate);
 
     onProgress?.(0.2);
 
@@ -1154,6 +1168,7 @@ function buildBaseplateSolid(
     baseplate = unwrap(clone(baseplate));
     onProgress?.(0.5);
   }
+  probe?.('pocketsCut', baseplate);
 
   // Apply corner rounding as a post-cache step — this is fast (single boolean
   // cut) and avoids redoing expensive pocket cuts when corner radius changes.
@@ -1184,6 +1199,7 @@ function buildBaseplateSolid(
     baseplate = tagOp('cornerClipIntersect', () => unwrap(intersect(baseplate, roundedTranslated)));
     oldBaseplate.delete();
     roundedTranslated.delete();
+    probe?.('cornerIntersected', baseplate);
   }
 
   // 2a. Magnet hole cutters — built and cut in batches to limit WASM memory.
@@ -1191,6 +1207,7 @@ function buildBaseplateSolid(
   if (magnetHoles) {
     const holes = buildMagnetHoles(width, depth, magnetDiameter / 2, magnetDepth, cellOpts);
     baseplate = cutInBatches(baseplate, holes);
+    probe?.('magnetHolesCut', baseplate);
   }
 
   // 2a-ii. Lightweight floor cutters (cross-shaped material removal)
@@ -1203,6 +1220,7 @@ function buildBaseplateSolid(
       cellOpts
     );
     baseplate = cutInBatches(baseplate, floorCutters);
+    probe?.('lightweightFloorCut', baseplate);
   }
 
   onProgress?.(0.4);
@@ -1244,6 +1262,7 @@ function buildBaseplateSolid(
     if (baseplate !== preBoolean) preBoolean.delete();
     for (const n of nubs) n.delete();
     for (const c of connHoles) c.delete();
+    probe?.('connectorPipeline', baseplate);
   }
 
   onProgress?.(0.6);
@@ -1252,6 +1271,7 @@ function buildBaseplateSolid(
 
   const finalBaseplate = translate(baseplate, [0, 0, totalHeight]);
   baseplate.delete();
+  probe?.('final', finalBaseplate);
   return finalBaseplate;
 }
 
@@ -1299,14 +1319,17 @@ export async function exportBaseplate(
 /**
  * Build binary STL from brepjs mesh output.
  *
- * brepjs/OCCT can emit tessellated meshes whose face orientations aren't
- * consistent across the whole solid: for some baseplate piece configs
+ * brepjs/OCCT historically emitted tessellated meshes whose face orientations
+ * weren't consistent across the whole solid: for some baseplate piece configs
  * (corner-3, corner-4, edge-x-1) the bottom face and parts of the
- * dovetail/pocket walls are wound backwards, causing slicers to flag
- * thousands of "non-manifold edges" (#1490). Which BREP op produces the
- * inversion is still under investigation upstream — see the tracking issue
- * linked from #1490 — so we run a downstream BFS winding repair before
- * emitting the STL.
+ * dovetail/pocket walls were wound backwards, causing slicers to flag
+ * thousands of "non-manifold edges" (#1490). The downstream `repairMeshWinding`
+ * BFS pass corrects this before emitting the STL.
+ *
+ * Investigation status (#1494): with brepjs 15.6.1 + OCCT kernel, the repair
+ * is currently a no-op for every known piece config — see
+ * `__dual-kernel__/diagnoseBaseplateWinding.test.ts`. The pass is kept as a
+ * defensive net for any future regression in brepjs/OCCT tessellation.
  *
  * (An even earlier version applied a per-triangle (cross · sum-of-vertex-
  * normals) heuristic which mis-fired on ~7% of triangles at curved/shared

--- a/src/shared/generation/repairMeshWinding.ts
+++ b/src/shared/generation/repairMeshWinding.ts
@@ -28,6 +28,16 @@
  * Reusable for any flat-indexed triangle mesh (vertex stride 3, tri stride 3).
  * Currently only wired into baseplate STL export; bins/dividers use the same
  * brepjs meshing path and can adopt this if the same symptom surfaces there.
+ *
+ * **Status (issue #1494):** as of brepjs 15.6.1 + OCCT kernel, this repair is
+ * a no-op for every known piece config — the corner-3/corner-4/edge-x-1
+ * scenario tests pass with the repair disabled, and the
+ * `__dual-kernel__/diagnoseBaseplateWinding` step-walker shows
+ * `triangles-flipped=0` even on the 13×9 magnet+lightweight reproducer that
+ * originally motivated this code. Kept as a defensive net for any future
+ * regression in brepjs/OCCT tessellation: if a downstream version reintroduces
+ * the inconsistency, this pass will silently absorb it before the user sees
+ * Bambu Studio errors.
  */
 
 import { createLogger } from '@/core/logger';


### PR DESCRIPTION
## Summary

Closes the upstream investigation tracked in #1494 (deferred from the downstream-fix PR #1493).

- Adds a **`BaseplateProbe`** hook to `buildBaseplateSolid` so diagnostic tests can inspect the intermediate solid at every construction milestone (`slabExtruded`, `pocketsCut`, `cornerIntersected`, `magnetHolesCut`, `lightweightFloorCut`, `connectorPipeline`, `final`). Production cost: one null-check per milestone.
- Adds **`__dual-kernel__/diagnoseBaseplateWinding.test.ts`** — a step-walker that meshes each intermediate solid with the same tessellation parameters as the production STL export path and reports `directedEdgeCollisions` and `signedVolume` per step. A second test diffs raw `mesh()` output against `repairMeshWinding(...)` output to quantify how many triangles the repair actually flips.
- Updates docstrings in `repairMeshWinding.ts` and the `buildBaseplateSTL` block in `baseplateGenerator.ts` to record the investigation status.

## Findings

For every config — `corner-1`, `corner-3`, `corner-4`, `edge-x-1`, magnet baseplate, **and the user-reported 13×9 magnet+lightweight+connector reproducer from #1490** — `mesh()` already produces 0 directed-edge collisions and positive signed volume:

| config                       | tris    | edge-dupes | signed vol | triangles flipped by repair |
| ---------------------------- | ------- | ---------- | ---------- | --------------------------- |
| corner-1                     | 15,540  | 0          | 37,859     | **0** / 15,540              |
| corner-3                     | 15,584  | 0          | 44,847     | **0** / 15,584              |
| corner-4                     | 15,504  | 0          | 45,005     | **0** / 15,504              |
| edge-x-1                     | 15,584  | 0          | 40,615     | **0** / 15,584              |
| user 13×9 padded + magnets   | 219,584 | 0          | 500,980    | **0** / 219,584             |

`repairMeshWinding` is a complete no-op on the current brepjs 15.6.1 + OCCT kernel.

Independent verification: with `repairMeshWinding` disabled (via a temporary env-var hack, reverted in this commit), all 6 tests in `baseplateGenerator.scenario.winding.test.ts` still pass — no `directedEdgeCollisions > 0` and no `signedVolume < 0` failures.

## Conclusion

Per the acceptance criteria of #1494: **document why the downstream repair is the correct long-term fix**. The brepjs/OCCT tessellation bug that #1490 surfaced is no longer reproducible on brepjs 15.6.1 + OCCT kernel — either an upstream fix landed since the user's original export, or the bug was gated on environmental state (kernel init order, mesh cache state) that the current codebase no longer hits.

The repair stays in place as a defensive net for any future regression: its overhead is one BFS per export, which is acceptable insurance against the user-visible Bambu Studio failure.

## Test plan
- [x] `pnpm exec vitest run --config vitest.profile.config.ts src/features/generation/worker/generators/__dual-kernel__/diagnoseBaseplateWinding` — diagnostic test passes and prints the per-step + raw-vs-repaired tables.
- [x] `pnpm run test:run src/features/generation/worker/generators/baseplateGenerator.scenario.winding.test.ts` — all 6 existing winding scenario tests pass with the repair re-enabled.
- [x] `pnpm run test:run src/shared/generation/repairMeshWinding.test.ts` — all 9 unit tests pass.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm run lint` — clean (8 pre-existing unrelated warnings in `baseplateDirectMesh.ts`).