### PR TITLE
fix(baseplate): split planner reserves bed budget for dovetail tongues (#1498)

### DIFF
--- a/src/features/baseplate/utils/printGuide.test.ts
+++ b/src/features/baseplate/utils/printGuide.test.ts
@@ -120,4 +120,21 @@ describe('generatePrintGuide', () => {
     expect(guide).toContain('padding:');
     expect(guide).toContain('3mm');
   });
+
+  it('Size line includes dovetail tongue protrusion when connectorNubs is enabled (#1498)', () => {
+    // 4×4 grid, no padding, dovetails on. 4 units * 42mm = 168mm slab.
+    // Edge piece with one male join edge → bbox 168 + 1.5 = 169.5mm.
+    const params = makeParams({
+      width: 8,
+      depth: 4,
+      connectorNubs: true,
+    });
+    const guide = buildGuide(params);
+
+    // Each piece (4 wide) has one male join edge with invertDovetails=false:
+    // - left piece: right=join is female (no protrusion) → 168.0mm
+    // - right piece: left=join is male (1.5mm protrusion) → 169.5mm
+    expect(guide).toContain('168.0 × 168.0');
+    expect(guide).toContain('169.5 × 168.0');
+  });
 });

--- a/src/features/baseplate/utils/printGuide.ts
+++ b/src/features/baseplate/utils/printGuide.ts
@@ -16,6 +16,9 @@ import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 const SOCKET_HEIGHT = GRIDFINITY_SPEC.SOCKET_HEIGHT;
 /** Retaining floor thickness above magnet holes (generation-specific, not in GRIDFINITY_SPEC) */
 const MAGNET_FLOOR = 0.5;
+/** Dovetail tongue protrusion past the slab wall on a male join edge (mm).
+ *  Mirrors `TONGUE_PROTRUSION` in `features/generation/.../generatorConstants.ts`. */
+const TONGUE_PROTRUSION_MM = 1.5;
 
 export interface PrintGuideInput {
   readonly tiling: BaseplateTiling;
@@ -93,8 +96,22 @@ function generatePieceTable(
     const params = group.params;
     const count = group.indices.length;
 
-    const widthMm = params.width * params.gridUnitMm + params.paddingLeft + params.paddingRight;
-    const depthMm = params.depth * params.gridUnitMm + params.paddingFront + params.paddingBack;
+    // Slab dimensions plus dovetail tongue protrusion on join edges where the
+    // tongue is male — matches the actual STL bbox so users know what fits the bed.
+    const tongue = parentParams.connectorNubs ? TONGUE_PROTRUSION_MM : 0;
+    const startMale = !parentParams.invertDovetails;
+    const widthMm =
+      params.width * params.gridUnitMm +
+      params.paddingLeft +
+      params.paddingRight +
+      (params.edges?.left === 'join' && startMale ? tongue : 0) +
+      (params.edges?.right === 'join' && !startMale ? tongue : 0);
+    const depthMm =
+      params.depth * params.gridUnitMm +
+      params.paddingFront +
+      params.paddingBack +
+      (params.edges?.front === 'join' && startMale ? tongue : 0) +
+      (params.edges?.back === 'join' && !startMale ? tongue : 0);
     const heightMm =
       SOCKET_HEIGHT + (parentParams.magnetHoles ? MAGNET_FLOOR + parentParams.magnetDepth : 0);
 

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { computeBaseplateTiling, pieceToBaseplateParams, colToLetter } from './splitPlanner';
+import { TONGUE_PROTRUSION } from '@/features/generation/worker/generators/generatorConstants';
 import type { BaseplateParams } from '@/shared/types/bin';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
@@ -570,12 +571,11 @@ describe('computeBaseplateTiling', () => {
     },
     invert: boolean
   ): { widthMm: number; depthMm: number } {
-    const TONGUE = 1.5;
     const startMale = !invert;
-    const leftTongue = piece.edges.left === 'join' && startMale ? TONGUE : 0;
-    const rightTongue = piece.edges.right === 'join' && !startMale ? TONGUE : 0;
-    const frontTongue = piece.edges.front === 'join' && startMale ? TONGUE : 0;
-    const backTongue = piece.edges.back === 'join' && !startMale ? TONGUE : 0;
+    const leftTongue = piece.edges.left === 'join' && startMale ? TONGUE_PROTRUSION : 0;
+    const rightTongue = piece.edges.right === 'join' && !startMale ? TONGUE_PROTRUSION : 0;
+    const frontTongue = piece.edges.front === 'join' && startMale ? TONGUE_PROTRUSION : 0;
+    const backTongue = piece.edges.back === 'join' && !startMale ? TONGUE_PROTRUSION : 0;
     return {
       widthMm:
         piece.widthUnits * 42 + piece.paddingLeft + piece.paddingRight + leftTongue + rightTongue,
@@ -583,6 +583,14 @@ describe('computeBaseplateTiling', () => {
         piece.depthUnits * 42 + piece.paddingFront + piece.paddingBack + frontTongue + backTongue,
     };
   }
+
+  it('TONGUE_PROTRUSION_MM mirrors the generator constant exactly', () => {
+    // splitPlanner duplicates TONGUE_PROTRUSION locally because module
+    // boundaries forbid features/baseplate from importing features/generation.
+    // If the generator constant ever changes, this assertion forces the planner
+    // copy to be updated in lockstep so split fits stay correct.
+    expect(TONGUE_PROTRUSION).toBe(1.5);
+  });
 
   it('accounts for dovetail tongue protrusion when splitting (#1498)', () => {
     // Repro: 512×324mm incl. padding on a 256mm bed with dovetail connectors.
@@ -643,6 +651,54 @@ describe('computeBaseplateTiling', () => {
     expect(tiling.cols).toBe(2);
     const widths = colWidths(params);
     expect(widths).toEqual([6, 6]);
+  });
+
+  it('handles invertDovetails + asymmetric padding without overflow', () => {
+    // Asymmetric padding stresses the per-position capacity calculation.
+    // With invert=true, the male tongue moves to the right/back side, so the
+    // last chunk's exterior side carries paddingEnd while its interior left
+    // is female (no protrusion). Verify pieces still fit.
+    const params = makeParams({
+      width: 12,
+      depth: 7,
+      paddingLeft: 30,
+      paddingRight: 2,
+      paddingFront: 3,
+      paddingBack: 20,
+      connectorNubs: true,
+      invertDovetails: true,
+    });
+
+    const tiling = computeBaseplateTiling(params, 256);
+
+    for (const piece of tiling.pieces) {
+      const { widthMm, depthMm } = actualPieceBbox(piece, true);
+      expect(widthMm).toBeLessThanOrEqual(256);
+      expect(depthMm).toBeLessThanOrEqual(256);
+    }
+  });
+
+  it('handles fractional dimensions with connectorNubs enabled', () => {
+    // Half-bin pieces interact with the tongue-aware capacity check at the
+    // last chunk. Verify the planner still produces a valid partition.
+    const params = makeParams({
+      width: 13.5,
+      depth: 4,
+      paddingLeft: 3,
+      paddingRight: 3,
+      connectorNubs: true,
+    });
+
+    const tiling = computeBaseplateTiling(params, 256);
+
+    for (const piece of tiling.pieces) {
+      const { widthMm, depthMm } = actualPieceBbox(piece, false);
+      expect(widthMm).toBeLessThanOrEqual(256);
+      expect(depthMm).toBeLessThanOrEqual(256);
+    }
+    // Total should still equal the requested dimensions
+    const totalWidth = colWidths(params).reduce((a, b) => a + b, 0);
+    expect(totalWidth).toBe(13.5);
   });
 
   // ─── All pieces always fit on bed ──────────────────────────────────────

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -551,6 +551,54 @@ describe('computeBaseplateTiling', () => {
     }
   });
 
+  // ─── Dovetail tongue protrusion (#1498) ────────────────────────────────
+
+  it('accounts for dovetail tongue protrusion when splitting (#1498)', () => {
+    // Repro: 512×324mm incl. padding on a 256mm bed with dovetail connectors.
+    // Width 512mm = 12 units * 42 + 4mm L/R padding. Depth 324mm = 7 units * 42 + 15mm F/B padding.
+    // Without dovetail accounting the planner picks [6, 6] — but the join edge has
+    // a 1.5mm tongue, making the actual STL 257.5mm wide, exceeding the 256mm bed.
+    const params = makeParams({
+      width: 12,
+      depth: 7,
+      paddingLeft: 4,
+      paddingRight: 4,
+      paddingFront: 15,
+      paddingBack: 15,
+      connectorNubs: true,
+    });
+    const TONGUE_PROTRUSION = 1.5;
+
+    const tiling = computeBaseplateTiling(params, 256);
+
+    for (const piece of tiling.pieces) {
+      const tongueX =
+        (piece.edges.left === 'join' ? TONGUE_PROTRUSION : 0) +
+        (piece.edges.right === 'join' ? TONGUE_PROTRUSION : 0);
+      const tongueY =
+        (piece.edges.front === 'join' ? TONGUE_PROTRUSION : 0) +
+        (piece.edges.back === 'join' ? TONGUE_PROTRUSION : 0);
+      const widthMm = piece.widthUnits * 42 + piece.paddingLeft + piece.paddingRight + tongueX;
+      const depthMm = piece.depthUnits * 42 + piece.paddingFront + piece.paddingBack + tongueY;
+      expect(widthMm).toBeLessThanOrEqual(256);
+      expect(depthMm).toBeLessThanOrEqual(256);
+    }
+  });
+
+  it('ignores dovetail protrusion when connectorNubs is disabled', () => {
+    // Same dimensions as above — without dovetails, 6+6 fits exactly at 256mm.
+    const params = makeParams({
+      width: 12,
+      depth: 4,
+      paddingLeft: 4,
+      paddingRight: 4,
+    });
+    const tiling = computeBaseplateTiling(params, 256);
+    expect(tiling.cols).toBe(2);
+    const widths = colWidths(params);
+    expect(widths).toEqual([6, 6]);
+  });
+
   // ─── All pieces always fit on bed ──────────────────────────────────────
 
   it.each([

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -553,6 +553,37 @@ describe('computeBaseplateTiling', () => {
 
   // ─── Dovetail tongue protrusion (#1498) ────────────────────────────────
 
+  /**
+   * Real STL bbox of a piece, given the male/female convention of `buildConnectors`:
+   * - left/front edges are male tongues when invertDovetails=false; female grooves otherwise.
+   * - Female grooves cut into the slab and don't extend its bbox.
+   */
+  function actualPieceBbox(
+    piece: {
+      widthUnits: number;
+      depthUnits: number;
+      paddingLeft: number;
+      paddingRight: number;
+      paddingFront: number;
+      paddingBack: number;
+      edges: { left: string; right: string; front: string; back: string };
+    },
+    invert: boolean
+  ): { widthMm: number; depthMm: number } {
+    const TONGUE = 1.5;
+    const startMale = !invert;
+    const leftTongue = piece.edges.left === 'join' && startMale ? TONGUE : 0;
+    const rightTongue = piece.edges.right === 'join' && !startMale ? TONGUE : 0;
+    const frontTongue = piece.edges.front === 'join' && startMale ? TONGUE : 0;
+    const backTongue = piece.edges.back === 'join' && !startMale ? TONGUE : 0;
+    return {
+      widthMm:
+        piece.widthUnits * 42 + piece.paddingLeft + piece.paddingRight + leftTongue + rightTongue,
+      depthMm:
+        piece.depthUnits * 42 + piece.paddingFront + piece.paddingBack + frontTongue + backTongue,
+    };
+  }
+
   it('accounts for dovetail tongue protrusion when splitting (#1498)', () => {
     // Repro: 512×324mm incl. padding on a 256mm bed with dovetail connectors.
     // Width 512mm = 12 units * 42 + 4mm L/R padding. Depth 324mm = 7 units * 42 + 15mm F/B padding.
@@ -567,19 +598,34 @@ describe('computeBaseplateTiling', () => {
       paddingBack: 15,
       connectorNubs: true,
     });
-    const TONGUE_PROTRUSION = 1.5;
 
     const tiling = computeBaseplateTiling(params, 256);
 
     for (const piece of tiling.pieces) {
-      const tongueX =
-        (piece.edges.left === 'join' ? TONGUE_PROTRUSION : 0) +
-        (piece.edges.right === 'join' ? TONGUE_PROTRUSION : 0);
-      const tongueY =
-        (piece.edges.front === 'join' ? TONGUE_PROTRUSION : 0) +
-        (piece.edges.back === 'join' ? TONGUE_PROTRUSION : 0);
-      const widthMm = piece.widthUnits * 42 + piece.paddingLeft + piece.paddingRight + tongueX;
-      const depthMm = piece.depthUnits * 42 + piece.paddingFront + piece.paddingBack + tongueY;
+      const { widthMm, depthMm } = actualPieceBbox(piece, false);
+      expect(widthMm).toBeLessThanOrEqual(256);
+      expect(depthMm).toBeLessThanOrEqual(256);
+    }
+  });
+
+  it('accounts for dovetail tongue protrusion with invertDovetails=true', () => {
+    // With invert, the tongue moves to right/back. The planner must reserve bed
+    // space on the opposite side of every join edge.
+    const params = makeParams({
+      width: 12,
+      depth: 7,
+      paddingLeft: 4,
+      paddingRight: 4,
+      paddingFront: 15,
+      paddingBack: 15,
+      connectorNubs: true,
+      invertDovetails: true,
+    });
+
+    const tiling = computeBaseplateTiling(params, 256);
+
+    for (const piece of tiling.pieces) {
+      const { widthMm, depthMm } = actualPieceBbox(piece, true);
       expect(widthMm).toBeLessThanOrEqual(256);
       expect(depthMm).toBeLessThanOrEqual(256);
     }

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -17,6 +17,46 @@ import type { BaseplatePiece, BaseplateTiling, PaddingReductionHint } from '../t
 /** Threshold for detecting a fractional half-unit (avoids floating-point noise). */
 const FRACTIONAL_THRESHOLD = 0.49;
 
+/**
+ * How far the dovetail tongue protrudes past the slab wall on a join edge.
+ * Mirrors `TONGUE_PROTRUSION` in `features/generation/.../generatorConstants.ts`
+ * (cross-feature import is forbidden by module boundaries; keep these in sync).
+ *
+ * The fit checker must subtract this from the bed budget on any join edge whose
+ * tongue is male — otherwise pieces that compute to exactly the bed width on
+ * paper exceed it as STLs (#1498).
+ */
+const TONGUE_PROTRUSION_MM = 1.5;
+
+/**
+ * Per-axis dovetail overhang model: which axis-end carries the male tongue.
+ *
+ * Convention (matches `buildConnectors` in baseplateGenerator):
+ *   left/front are male when invertDovetails=false; right/back are male otherwise.
+ * Females cut into the slab and don't extend its bbox, so they cost nothing.
+ */
+interface DovetailOverhang {
+  /** mm reserved on the start side (low index) when this side is a join edge. */
+  startMaleMm: number;
+  /** mm reserved on the end side (high index) when this side is a join edge. */
+  endMaleMm: number;
+}
+
+const NO_OVERHANG: DovetailOverhang = { startMaleMm: 0, endMaleMm: 0 };
+
+function overhangFor(
+  connectorNubs: boolean | undefined,
+  invertDovetails: boolean | undefined
+): DovetailOverhang {
+  if (!connectorNubs) return NO_OVERHANG;
+  // Both axes follow the same rule: the start side (left / front) is male iff !invertDovetails.
+  const startMale = !invertDovetails;
+  return {
+    startMaleMm: startMale ? TONGUE_PROTRUSION_MM : 0,
+    endMaleMm: startMale ? 0 : TONGUE_PROTRUSION_MM,
+  };
+}
+
 /** Convert a zero-based column index to a letter: 0→A, 1→B, ..., 25→Z */
 export function colToLetter(col: number): string {
   return String.fromCharCode(65 + col);
@@ -36,15 +76,22 @@ function partitionAxis(
   gridUnitMm: number,
   printBedMm: number,
   paddingStart: number,
-  paddingEnd: number
+  paddingEnd: number,
+  overhang: DovetailOverhang = NO_OVERHANG
 ): number[] | null {
   const intPart = Math.floor(totalUnits);
   const hasFrac = totalUnits - intPart >= FRACTIONAL_THRESHOLD;
 
+  // Single-piece (numChunks=1) has no joins, so no tongue overhead.
+  // Multi-piece pieces give up bed-budget on each join edge whose tongue is male.
+  // The middle-piece reservation collapses to a single TONGUE_PROTRUSION because
+  // exactly one of left/right is male regardless of invert orientation.
+  const innerMale = overhang.startMaleMm + overhang.endMaleMm;
+
   const maxWithBoth = Math.floor((printBedMm - paddingStart - paddingEnd) / gridUnitMm);
-  const maxWithStart = Math.floor((printBedMm - paddingStart) / gridUnitMm);
-  const maxWithEnd = Math.floor((printBedMm - paddingEnd) / gridUnitMm);
-  const maxMiddle = Math.floor(printBedMm / gridUnitMm);
+  const maxWithStart = Math.floor((printBedMm - paddingStart - overhang.endMaleMm) / gridUnitMm);
+  const maxWithEnd = Math.floor((printBedMm - paddingEnd - overhang.startMaleMm) / gridUnitMm);
+  const maxMiddle = Math.floor((printBedMm - innerMale) / gridUnitMm);
 
   // Degenerate: bed can't hold even 1 unit in any position
   if (maxWithBoth < 1 || maxWithStart < 1 || maxWithEnd < 1 || maxMiddle < 1) {
@@ -117,7 +164,7 @@ function partitionAxis(
   // Handle fractional 0.5 unit — absorb into last chunk if it fits
   if (hasFrac) {
     const lastIdx = numChunks - 1;
-    const lastOverhead = paddingEnd;
+    const lastOverhead = paddingEnd + overhang.startMaleMm;
     if ((sizes[lastIdx] + 0.5) * gridUnitMm + lastOverhead <= printBedMm) {
       sizes[lastIdx] += 0.5;
     } else {
@@ -145,19 +192,27 @@ function allPiecesFit(
   pL: number,
   pR: number,
   pF: number,
-  pB: number
+  pB: number,
+  xOverhang: DovetailOverhang = NO_OVERHANG,
+  yOverhang: DovetailOverhang = NO_OVERHANG
 ): boolean {
   for (let c = 0; c < colSizes.length; c++) {
     const padLeft = c === 0 ? pL : 0;
     const padRight = c === colSizes.length - 1 ? pR : 0;
-    const widthMm = colSizes[c] * gridUnitMm + padLeft + padRight;
+    // Join edges (interior sides) carry a male tongue's protrusion if the convention
+    // assigns male to that side. Female sides cut into the slab and add nothing.
+    const tongueLeft = c === 0 ? 0 : xOverhang.startMaleMm;
+    const tongueRight = c === colSizes.length - 1 ? 0 : xOverhang.endMaleMm;
+    const widthMm = colSizes[c] * gridUnitMm + padLeft + padRight + tongueLeft + tongueRight;
     if (widthMm > printBedWidthMm + 0.001) return false;
   }
 
   for (let r = 0; r < rowSizes.length; r++) {
     const padFront = r === 0 ? pF : 0;
     const padBack = r === rowSizes.length - 1 ? pB : 0;
-    const depthMm = rowSizes[r] * gridUnitMm + padFront + padBack;
+    const tongueFront = r === 0 ? 0 : yOverhang.startMaleMm;
+    const tongueBack = r === rowSizes.length - 1 ? 0 : yOverhang.endMaleMm;
+    const depthMm = rowSizes[r] * gridUnitMm + padFront + padBack + tongueFront + tongueBack;
     if (depthMm > printBedDepthMm + 0.001) return false;
   }
 
@@ -193,7 +248,9 @@ function findOptimalTiling(
   pL: number,
   pR: number,
   pF: number,
-  pB: number
+  pB: number,
+  xOverhang: DovetailOverhang = NO_OVERHANG,
+  yOverhang: DovetailOverhang = NO_OVERHANG
 ): { colSizes: number[]; rowSizes: number[] } {
   const maxCols = Math.ceil(totalWidth); // absolute upper bound
   const maxRows = Math.ceil(totalDepth);
@@ -205,14 +262,22 @@ function findOptimalTiling(
     // Use > not >= so we still evaluate nc×1 candidates for symmetry tiebreaks.
     if (best && nc > best.pieceCount) break;
 
-    const colSizes = partitionAxis(totalWidth, nc, gridUnitMm, printBedWidthMm, pL, pR);
+    const colSizes = partitionAxis(totalWidth, nc, gridUnitMm, printBedWidthMm, pL, pR, xOverhang);
     if (!colSizes) continue;
 
     for (let nr = 1; nr <= maxRows; nr++) {
       const pieceCount = nc * nr;
       if (best && pieceCount > best.pieceCount) break;
 
-      const rowSizes = partitionAxis(totalDepth, nr, gridUnitMm, printBedDepthMm, pF, pB);
+      const rowSizes = partitionAxis(
+        totalDepth,
+        nr,
+        gridUnitMm,
+        printBedDepthMm,
+        pF,
+        pB,
+        yOverhang
+      );
       if (!rowSizes) continue;
 
       if (
@@ -225,7 +290,9 @@ function findOptimalTiling(
           pL,
           pR,
           pF,
-          pB
+          pB,
+          xOverhang,
+          yOverhang
         )
       ) {
         const score = symmetryScore(colSizes) + symmetryScore(rowSizes);
@@ -264,7 +331,9 @@ function computePaddingReductionHint(
   pR: number,
   pF: number,
   pB: number,
-  currentPieceCount: number
+  currentPieceCount: number,
+  xOverhang: DovetailOverhang = NO_OVERHANG,
+  yOverhang: DovetailOverhang = NO_OVERHANG
 ): PaddingReductionHint | null {
   if (currentPieceCount <= 1) return null;
 
@@ -282,7 +351,9 @@ function computePaddingReductionHint(
       pL - r,
       pR - r,
       pF,
-      pB
+      pB,
+      xOverhang,
+      yOverhang
     );
     const saved = currentPieceCount - result.colSizes.length * result.rowSizes.length;
     if (saved > 0) {
@@ -303,7 +374,9 @@ function computePaddingReductionHint(
       pL,
       pR,
       pF - r,
-      pB - r
+      pB - r,
+      xOverhang,
+      yOverhang
     );
     const saved = currentPieceCount - result.colSizes.length * result.rowSizes.length;
     if (saved > 0) {
@@ -324,7 +397,9 @@ function computePaddingReductionHint(
       pL - r,
       pR - r,
       pF - r,
-      pB - r
+      pB - r,
+      xOverhang,
+      yOverhang
     );
     const saved = currentPieceCount - result.colSizes.length * result.rowSizes.length;
     if (saved > 0) {
@@ -361,7 +436,15 @@ export function computeBaseplateTiling(
     paddingBack,
     fractionalEdgeX,
     fractionalEdgeY,
+    connectorNubs,
+    invertDovetails,
   } = params;
+
+  // Pieces with dovetail connectors include male tongue protrusions in their bbox
+  // (#1498). The planner reserves bed budget for those tongues so the resulting
+  // STLs actually fit the bed.
+  const xOverhang = overhangFor(connectorNubs, invertDovetails);
+  const yOverhang = xOverhang;
 
   // Find optimal tiling using 2D joint search
   const { colSizes: rawColSizes, rowSizes: rawRowSizes } = findOptimalTiling(
@@ -373,7 +456,9 @@ export function computeBaseplateTiling(
     paddingLeft,
     paddingRight,
     paddingFront,
-    paddingBack
+    paddingBack,
+    xOverhang,
+    yOverhang
   );
 
   // Reorder for display: largest pieces at front/left, fractional edges pinned
@@ -448,7 +533,9 @@ export function computeBaseplateTiling(
     paddingRight,
     paddingFront,
     paddingBack,
-    pieceCount
+    pieceCount,
+    xOverhang,
+    yOverhang
   );
 
   return {

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -57,6 +57,33 @@ function overhangFor(
   };
 }
 
+/** Per-position max grid-unit capacity for a multi-chunk axis. */
+interface AxisCapacity {
+  /** Capacity at the start (low-index) chunk: outer=paddingStart, inner=join. */
+  maxFirst: number;
+  /** Capacity at the end (high-index) chunk: inner=join, outer=paddingEnd. */
+  maxLast: number;
+  /** Capacity at any interior chunk: joins on both sides. */
+  maxMiddle: number;
+}
+
+function axisCapacity(
+  printBedMm: number,
+  gridUnitMm: number,
+  paddingStart: number,
+  paddingEnd: number,
+  overhang: DovetailOverhang
+): AxisCapacity {
+  // Multi-piece pieces give up bed-budget on each join edge whose tongue is male.
+  // Middle chunks have both sides joined, but exactly one is male regardless of
+  // invert orientation, so this collapses to a single TONGUE_PROTRUSION.
+  return {
+    maxFirst: Math.floor((printBedMm - paddingStart - overhang.endMaleMm) / gridUnitMm),
+    maxLast: Math.floor((printBedMm - paddingEnd - overhang.startMaleMm) / gridUnitMm),
+    maxMiddle: Math.floor((printBedMm - overhang.startMaleMm - overhang.endMaleMm) / gridUnitMm),
+  };
+}
+
 /** Convert a zero-based column index to a letter: 0→A, 1→B, ..., 25→Z */
 export function colToLetter(col: number): string {
   return String.fromCharCode(65 + col);
@@ -83,18 +110,17 @@ function partitionAxis(
   const hasFrac = totalUnits - intPart >= FRACTIONAL_THRESHOLD;
 
   // Single-piece (numChunks=1) has no joins, so no tongue overhead.
-  // Multi-piece pieces give up bed-budget on each join edge whose tongue is male.
-  // The middle-piece reservation collapses to a single TONGUE_PROTRUSION because
-  // exactly one of left/right is male regardless of invert orientation.
-  const innerMale = overhang.startMaleMm + overhang.endMaleMm;
-
   const maxWithBoth = Math.floor((printBedMm - paddingStart - paddingEnd) / gridUnitMm);
-  const maxWithStart = Math.floor((printBedMm - paddingStart - overhang.endMaleMm) / gridUnitMm);
-  const maxWithEnd = Math.floor((printBedMm - paddingEnd - overhang.startMaleMm) / gridUnitMm);
-  const maxMiddle = Math.floor((printBedMm - innerMale) / gridUnitMm);
+  const { maxFirst, maxLast, maxMiddle } = axisCapacity(
+    printBedMm,
+    gridUnitMm,
+    paddingStart,
+    paddingEnd,
+    overhang
+  );
 
   // Degenerate: bed can't hold even 1 unit in any position
-  if (maxWithBoth < 1 || maxWithStart < 1 || maxWithEnd < 1 || maxMiddle < 1) {
+  if (maxWithBoth < 1 || maxFirst < 1 || maxLast < 1 || maxMiddle < 1) {
     return numChunks === 1 ? [totalUnits] : null;
   }
 
@@ -113,8 +139,8 @@ function partitionAxis(
   // For numChunks >= 2, distribute integer units as evenly as possible.
   // Compute per-position max capacities (first and last carry edge padding).
   const maxPerPos: number[] = Array.from({ length: numChunks }, (_, i) => {
-    if (i === 0) return maxWithStart;
-    if (i === numChunks - 1) return maxWithEnd;
+    if (i === 0) return maxFirst;
+    if (i === numChunks - 1) return maxLast;
     return maxMiddle;
   });
 
@@ -468,7 +494,8 @@ export function computeBaseplateTiling(
     printBedWidthMm,
     paddingLeft,
     paddingRight,
-    fractionalEdgeX === 'start'
+    fractionalEdgeX === 'start',
+    xOverhang
   );
   const rowSizes = reorderForDisplay(
     rawRowSizes,
@@ -476,7 +503,8 @@ export function computeBaseplateTiling(
     printBedDepthMm,
     paddingFront,
     paddingBack,
-    fractionalEdgeY === 'start'
+    fractionalEdgeY === 'start',
+    yOverhang
   );
 
   const isSplit = colSizes.length > 1 || rowSizes.length > 1;
@@ -599,36 +627,42 @@ function reorderForDisplay(
   printBedMm: number,
   paddingFirst: number,
   paddingLast: number,
-  fractionAtStart: boolean
+  fractionAtStart: boolean,
+  overhang: DovetailOverhang = NO_OVERHANG
 ): number[] {
   if (sizes.length <= 1) return sizes;
 
-  const maxAtFirst = Math.floor((printBedMm - paddingFirst) / gridUnitMm);
-  const maxAtLast = Math.floor((printBedMm - paddingLast) / gridUnitMm);
+  // Use the same per-position constraints as partitionAxis so dovetail tongues
+  // are accounted for when reshuffling chunks across positions (#1498).
+  const { maxFirst, maxLast, maxMiddle } = axisCapacity(
+    printBedMm,
+    gridUnitMm,
+    paddingFirst,
+    paddingLast,
+    overhang
+  );
 
   const fracIdx = sizes.findIndex(isFractional);
 
   // When fractionAtStart, pin the fractional piece to position 0 —
   // but only if it actually fits with paddingFirst at that position.
   if (fractionAtStart) {
-    if (fracIdx >= 0 && sizes[fracIdx] <= maxAtFirst) {
-      const maxMiddle = Math.floor(printBedMm / gridUnitMm);
+    if (fracIdx >= 0 && sizes[fracIdx] <= maxFirst) {
       const rest = sizes.filter((_, i) => i !== fracIdx);
-      const sortedRest = sortDescWithEdges(rest, maxMiddle, maxAtLast);
+      const sortedRest = sortDescWithEdges(rest, maxMiddle, maxLast);
       return [sizes[fracIdx], ...sortedRest];
     }
   }
 
   // When fraction exists and belongs at the end, pin it to the last position
   // to prevent sortDescWithEdges from placing it in the middle.
-  if (!fractionAtStart && fracIdx >= 0 && sizes[fracIdx] <= maxAtLast) {
-    const maxMiddle = Math.floor(printBedMm / gridUnitMm);
+  if (!fractionAtStart && fracIdx >= 0 && sizes[fracIdx] <= maxLast) {
     const rest = sizes.filter((_, i) => i !== fracIdx);
-    const sortedRest = sortDescWithEdges(rest, maxAtFirst, maxMiddle);
+    const sortedRest = sortDescWithEdges(rest, maxFirst, maxMiddle);
     return [...sortedRest, sizes[fracIdx]];
   }
 
-  return sortDescWithEdges(sizes, maxAtFirst, maxAtLast);
+  return sortDescWithEdges(sizes, maxFirst, maxLast);
 }
 
 /**

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -29,58 +29,55 @@ const FRACTIONAL_THRESHOLD = 0.49;
 const TONGUE_PROTRUSION_MM = 1.5;
 
 /**
- * Per-axis dovetail overhang model: which axis-end carries the male tongue.
+ * Per-axis configuration: bed budget, padding, and dovetail overhang on each end.
  *
- * Convention (matches `buildConnectors` in baseplateGenerator):
+ * `startMaleMm` / `endMaleMm` are the mm reserved for a male tongue when that
+ * side is a join edge. Convention (matches `buildConnectors` in baseplateGenerator):
  *   left/front are male when invertDovetails=false; right/back are male otherwise.
  * Females cut into the slab and don't extend its bbox, so they cost nothing.
  */
-interface DovetailOverhang {
-  /** mm reserved on the start side (low index) when this side is a join edge. */
-  startMaleMm: number;
-  /** mm reserved on the end side (high index) when this side is a join edge. */
-  endMaleMm: number;
+interface AxisConfig {
+  readonly bedMm: number;
+  readonly paddingStart: number;
+  readonly paddingEnd: number;
+  readonly startMaleMm: number;
+  readonly endMaleMm: number;
 }
 
-const NO_OVERHANG: DovetailOverhang = { startMaleMm: 0, endMaleMm: 0 };
-
-function overhangFor(
+function makeAxisConfig(
+  bedMm: number,
+  paddingStart: number,
+  paddingEnd: number,
   connectorNubs: boolean | undefined,
   invertDovetails: boolean | undefined
-): DovetailOverhang {
-  if (!connectorNubs) return NO_OVERHANG;
+): AxisConfig {
   // Both axes follow the same rule: the start side (left / front) is male iff !invertDovetails.
+  const tongue = connectorNubs ? TONGUE_PROTRUSION_MM : 0;
   const startMale = !invertDovetails;
   return {
-    startMaleMm: startMale ? TONGUE_PROTRUSION_MM : 0,
-    endMaleMm: startMale ? 0 : TONGUE_PROTRUSION_MM,
+    bedMm,
+    paddingStart,
+    paddingEnd,
+    startMaleMm: startMale ? tongue : 0,
+    endMaleMm: startMale ? 0 : tongue,
   };
 }
 
-/** Per-position max grid-unit capacity for a multi-chunk axis. */
-interface AxisCapacity {
-  /** Capacity at the start (low-index) chunk: outer=paddingStart, inner=join. */
-  maxFirst: number;
-  /** Capacity at the end (high-index) chunk: inner=join, outer=paddingEnd. */
-  maxLast: number;
-  /** Capacity at any interior chunk: joins on both sides. */
-  maxMiddle: number;
-}
-
+/**
+ * Per-position max grid-unit capacity for a multi-chunk axis.
+ * Multi-piece pieces give up bed-budget on each join edge whose tongue is male.
+ * Middle chunks have both sides joined, but exactly one is male regardless of
+ * invert orientation, so this collapses to a single TONGUE_PROTRUSION.
+ */
 function axisCapacity(
-  printBedMm: number,
   gridUnitMm: number,
-  paddingStart: number,
-  paddingEnd: number,
-  overhang: DovetailOverhang
-): AxisCapacity {
-  // Multi-piece pieces give up bed-budget on each join edge whose tongue is male.
-  // Middle chunks have both sides joined, but exactly one is male regardless of
-  // invert orientation, so this collapses to a single TONGUE_PROTRUSION.
+  axis: AxisConfig
+): { maxFirst: number; maxLast: number; maxMiddle: number } {
+  const { bedMm, paddingStart, paddingEnd, startMaleMm, endMaleMm } = axis;
   return {
-    maxFirst: Math.floor((printBedMm - paddingStart - overhang.endMaleMm) / gridUnitMm),
-    maxLast: Math.floor((printBedMm - paddingEnd - overhang.startMaleMm) / gridUnitMm),
-    maxMiddle: Math.floor((printBedMm - overhang.startMaleMm - overhang.endMaleMm) / gridUnitMm),
+    maxFirst: Math.floor((bedMm - paddingStart - endMaleMm) / gridUnitMm),
+    maxLast: Math.floor((bedMm - paddingEnd - startMaleMm) / gridUnitMm),
+    maxMiddle: Math.floor((bedMm - startMaleMm - endMaleMm) / gridUnitMm),
   };
 }
 
@@ -88,6 +85,7 @@ function axisCapacity(
 export function colToLetter(col: number): string {
   return String.fromCharCode(65 + col);
 }
+
 /**
  * Partition `totalUnits` into exactly `numChunks` pieces that each fit the bed.
  *
@@ -101,23 +99,15 @@ function partitionAxis(
   totalUnits: number,
   numChunks: number,
   gridUnitMm: number,
-  printBedMm: number,
-  paddingStart: number,
-  paddingEnd: number,
-  overhang: DovetailOverhang = NO_OVERHANG
+  axis: AxisConfig
 ): number[] | null {
+  const { bedMm, paddingStart, paddingEnd, startMaleMm } = axis;
   const intPart = Math.floor(totalUnits);
   const hasFrac = totalUnits - intPart >= FRACTIONAL_THRESHOLD;
 
   // Single-piece (numChunks=1) has no joins, so no tongue overhead.
-  const maxWithBoth = Math.floor((printBedMm - paddingStart - paddingEnd) / gridUnitMm);
-  const { maxFirst, maxLast, maxMiddle } = axisCapacity(
-    printBedMm,
-    gridUnitMm,
-    paddingStart,
-    paddingEnd,
-    overhang
-  );
+  const maxWithBoth = Math.floor((bedMm - paddingStart - paddingEnd) / gridUnitMm);
+  const { maxFirst, maxLast, maxMiddle } = axisCapacity(gridUnitMm, axis);
 
   // Degenerate: bed can't hold even 1 unit in any position
   if (maxWithBoth < 1 || maxFirst < 1 || maxLast < 1 || maxMiddle < 1) {
@@ -125,19 +115,17 @@ function partitionAxis(
   }
 
   if (numChunks === 1) {
-    // Single piece must fit with both paddings
     if (intPart > maxWithBoth) return null;
     if (hasFrac) {
-      if ((intPart + 0.5) * gridUnitMm + paddingStart + paddingEnd <= printBedMm) {
+      if ((intPart + 0.5) * gridUnitMm + paddingStart + paddingEnd <= bedMm) {
         return [totalUnits];
       }
-      return null; // fraction doesn't fit
+      return null;
     }
     return intPart > 0 ? [intPart] : null;
   }
 
   // For numChunks >= 2, distribute integer units as evenly as possible.
-  // Compute per-position max capacities (first and last carry edge padding).
   const maxPerPos: number[] = Array.from({ length: numChunks }, (_, i) => {
     if (i === 0) return maxFirst;
     if (i === numChunks - 1) return maxLast;
@@ -155,7 +143,6 @@ function partitionAxis(
   const sizes: number[] = new Array<number>(numChunks).fill(baseSize);
   let remainder = intPart - baseSize * numChunks;
 
-  // Clamp base sizes that exceed position capacity
   for (let i = 0; i < numChunks; i++) {
     if (sizes[i] > maxPerPos[i]) {
       remainder += sizes[i] - maxPerPos[i];
@@ -163,7 +150,6 @@ function partitionAxis(
     }
   }
 
-  // Distribute remainder one unit at a time
   for (let i = 0; i < numChunks && remainder > 0; i++) {
     const canAdd = maxPerPos[i] - sizes[i];
     if (canAdd > 0) {
@@ -174,7 +160,6 @@ function partitionAxis(
   }
 
   // Pass 2: redistribute any remaining units into slots that still have capacity.
-  // This handles cases where the first-come distribution was capped by maxPerPos.
   for (let i = 0; i < numChunks && remainder > 0; i++) {
     const canAdd = maxPerPos[i] - sizes[i];
     const add = Math.min(canAdd, remainder);
@@ -182,19 +167,17 @@ function partitionAxis(
     remainder -= add;
   }
 
-  if (remainder > 0) return null; // infeasible even with full capacity
-
-  // Any chunk with 0 units means we have more chunks than needed
+  if (remainder > 0) return null;
   if (sizes.some((s) => s <= 0)) return null;
 
   // Handle fractional 0.5 unit — absorb into last chunk if it fits
   if (hasFrac) {
     const lastIdx = numChunks - 1;
-    const lastOverhead = paddingEnd + overhang.startMaleMm;
-    if ((sizes[lastIdx] + 0.5) * gridUnitMm + lastOverhead <= printBedMm) {
+    const lastOverhead = paddingEnd + startMaleMm;
+    if ((sizes[lastIdx] + 0.5) * gridUnitMm + lastOverhead <= bedMm) {
       sizes[lastIdx] += 0.5;
     } else {
-      return null; // fraction doesn't fit, caller should try numChunks+1
+      return null;
     }
   }
 
@@ -202,46 +185,32 @@ function partitionAxis(
 }
 
 /**
- * Verify every piece in a cols × rows grid fits the bed considering its
- * edge-specific padding. Corner pieces get padding on two sides.
- *
- * Because each piece's physical width depends only on its column index and its
- * physical depth depends only on its row index, the two axes are independent —
- * checking each axis separately is sufficient without a cross-product.
+ * Verify every piece fits the bed. Each piece's physical width depends only
+ * on its column index and depth on its row index, so the two axes are
+ * independent — checking each axis separately is sufficient.
  */
 function allPiecesFit(
   colSizes: number[],
   rowSizes: number[],
   gridUnitMm: number,
-  printBedWidthMm: number,
-  printBedDepthMm: number,
-  pL: number,
-  pR: number,
-  pF: number,
-  pB: number,
-  xOverhang: DovetailOverhang = NO_OVERHANG,
-  yOverhang: DovetailOverhang = NO_OVERHANG
+  xAxis: AxisConfig,
+  yAxis: AxisConfig
 ): boolean {
-  for (let c = 0; c < colSizes.length; c++) {
-    const padLeft = c === 0 ? pL : 0;
-    const padRight = c === colSizes.length - 1 ? pR : 0;
+  return chunkSizesFit(colSizes, gridUnitMm, xAxis) && chunkSizesFit(rowSizes, gridUnitMm, yAxis);
+}
+
+function chunkSizesFit(sizes: number[], gridUnitMm: number, axis: AxisConfig): boolean {
+  const last = sizes.length - 1;
+  for (let i = 0; i < sizes.length; i++) {
+    const padStart = i === 0 ? axis.paddingStart : 0;
+    const padEnd = i === last ? axis.paddingEnd : 0;
     // Join edges (interior sides) carry a male tongue's protrusion if the convention
     // assigns male to that side. Female sides cut into the slab and add nothing.
-    const tongueLeft = c === 0 ? 0 : xOverhang.startMaleMm;
-    const tongueRight = c === colSizes.length - 1 ? 0 : xOverhang.endMaleMm;
-    const widthMm = colSizes[c] * gridUnitMm + padLeft + padRight + tongueLeft + tongueRight;
-    if (widthMm > printBedWidthMm + 0.001) return false;
+    const tongueStart = i === 0 ? 0 : axis.startMaleMm;
+    const tongueEnd = i === last ? 0 : axis.endMaleMm;
+    const sizeMm = sizes[i] * gridUnitMm + padStart + padEnd + tongueStart + tongueEnd;
+    if (sizeMm > axis.bedMm + 0.001) return false;
   }
-
-  for (let r = 0; r < rowSizes.length; r++) {
-    const padFront = r === 0 ? pF : 0;
-    const padBack = r === rowSizes.length - 1 ? pB : 0;
-    const tongueFront = r === 0 ? 0 : yOverhang.startMaleMm;
-    const tongueBack = r === rowSizes.length - 1 ? 0 : yOverhang.endMaleMm;
-    const depthMm = rowSizes[r] * gridUnitMm + padFront + padBack + tongueFront + tongueBack;
-    if (depthMm > printBedDepthMm + 0.001) return false;
-  }
-
   return true;
 }
 
@@ -256,7 +225,7 @@ interface TilingCandidate {
   colSizes: number[];
   rowSizes: number[];
   pieceCount: number;
-  score: number; // lower = better symmetry
+  score: number;
 }
 
 /**
@@ -269,16 +238,10 @@ function findOptimalTiling(
   totalWidth: number,
   totalDepth: number,
   gridUnitMm: number,
-  printBedWidthMm: number,
-  printBedDepthMm: number,
-  pL: number,
-  pR: number,
-  pF: number,
-  pB: number,
-  xOverhang: DovetailOverhang = NO_OVERHANG,
-  yOverhang: DovetailOverhang = NO_OVERHANG
+  xAxis: AxisConfig,
+  yAxis: AxisConfig
 ): { colSizes: number[]; rowSizes: number[] } {
-  const maxCols = Math.ceil(totalWidth); // absolute upper bound
+  const maxCols = Math.ceil(totalWidth);
   const maxRows = Math.ceil(totalDepth);
 
   let best: TilingCandidate | null = null;
@@ -288,39 +251,17 @@ function findOptimalTiling(
     // Use > not >= so we still evaluate nc×1 candidates for symmetry tiebreaks.
     if (best && nc > best.pieceCount) break;
 
-    const colSizes = partitionAxis(totalWidth, nc, gridUnitMm, printBedWidthMm, pL, pR, xOverhang);
+    const colSizes = partitionAxis(totalWidth, nc, gridUnitMm, xAxis);
     if (!colSizes) continue;
 
     for (let nr = 1; nr <= maxRows; nr++) {
       const pieceCount = nc * nr;
       if (best && pieceCount > best.pieceCount) break;
 
-      const rowSizes = partitionAxis(
-        totalDepth,
-        nr,
-        gridUnitMm,
-        printBedDepthMm,
-        pF,
-        pB,
-        yOverhang
-      );
+      const rowSizes = partitionAxis(totalDepth, nr, gridUnitMm, yAxis);
       if (!rowSizes) continue;
 
-      if (
-        allPiecesFit(
-          colSizes,
-          rowSizes,
-          gridUnitMm,
-          printBedWidthMm,
-          printBedDepthMm,
-          pL,
-          pR,
-          pF,
-          pB,
-          xOverhang,
-          yOverhang
-        )
-      ) {
+      if (allPiecesFit(colSizes, rowSizes, gridUnitMm, xAxis, yAxis)) {
         const score = symmetryScore(colSizes) + symmetryScore(rowSizes);
         if (
           !best ||
@@ -329,110 +270,59 @@ function findOptimalTiling(
         ) {
           best = { colSizes, rowSizes, pieceCount, score };
         }
-        break; // found valid nr for this nc, smaller nr won't help (already pruned above)
+        break;
       }
     }
   }
 
-  // Fallback: single piece (degenerate bed)
-  if (!best) {
-    return { colSizes: [totalWidth], rowSizes: [totalDepth] };
-  }
-
+  if (!best) return { colSizes: [totalWidth], rowSizes: [totalDepth] };
   return { colSizes: best.colSizes, rowSizes: best.rowSizes };
 }
+
 /**
  * Check if reducing padding would eliminate a split or save pieces.
- *
- * Tests X-axis (left+right) and Y-axis (front+back) independently,
- * reducing each by 1mm increments down to 0.
+ * Tries X-only, Y-only, then both axes together; picks the best result.
  */
 function computePaddingReductionHint(
   totalWidth: number,
   totalDepth: number,
   gridUnitMm: number,
-  printBedWidthMm: number,
-  printBedDepthMm: number,
-  pL: number,
-  pR: number,
-  pF: number,
-  pB: number,
-  currentPieceCount: number,
-  xOverhang: DovetailOverhang = NO_OVERHANG,
-  yOverhang: DovetailOverhang = NO_OVERHANG
+  xAxis: AxisConfig,
+  yAxis: AxisConfig,
+  currentPieceCount: number
 ): PaddingReductionHint | null {
   if (currentPieceCount <= 1) return null;
 
+  const reduceX = Math.min(xAxis.paddingStart, xAxis.paddingEnd);
+  const reduceY = Math.min(yAxis.paddingStart, yAxis.paddingEnd);
+
+  // Find smallest reduction along an axis that saves pieces; null if none works.
+  const trySaving = (maxR: number, build: (r: number) => { x: AxisConfig; y: AxisConfig }) => {
+    for (let r = 1; r <= maxR; r++) {
+      const { x, y } = build(r);
+      const result = findOptimalTiling(totalWidth, totalDepth, gridUnitMm, x, y);
+      const saved = currentPieceCount - result.colSizes.length * result.rowSizes.length;
+      if (saved > 0) return { reductionMm: r, piecesSaved: saved };
+    }
+    return null;
+  };
+
+  const reduce = (axis: AxisConfig, r: number): AxisConfig => ({
+    ...axis,
+    paddingStart: axis.paddingStart - r,
+    paddingEnd: axis.paddingEnd - r,
+  });
+
   const candidates: PaddingReductionHint[] = [];
-
-  // Try reducing X-axis padding (left + right equally)
-  const maxReduceX = Math.min(pL, pR);
-  for (let r = 1; r <= maxReduceX; r++) {
-    const result = findOptimalTiling(
-      totalWidth,
-      totalDepth,
-      gridUnitMm,
-      printBedWidthMm,
-      printBedDepthMm,
-      pL - r,
-      pR - r,
-      pF,
-      pB,
-      xOverhang,
-      yOverhang
-    );
-    const saved = currentPieceCount - result.colSizes.length * result.rowSizes.length;
-    if (saved > 0) {
-      candidates.push({ axis: 'x', reductionMm: r, piecesSaved: saved });
-      break;
-    }
-  }
-
-  // Try reducing Y-axis padding (front + back equally)
-  const maxReduceY = Math.min(pF, pB);
-  for (let r = 1; r <= maxReduceY; r++) {
-    const result = findOptimalTiling(
-      totalWidth,
-      totalDepth,
-      gridUnitMm,
-      printBedWidthMm,
-      printBedDepthMm,
-      pL,
-      pR,
-      pF - r,
-      pB - r,
-      xOverhang,
-      yOverhang
-    );
-    const saved = currentPieceCount - result.colSizes.length * result.rowSizes.length;
-    if (saved > 0) {
-      candidates.push({ axis: 'y', reductionMm: r, piecesSaved: saved });
-      break;
-    }
-  }
-
-  // Try reducing both axes
-  const maxReduceBoth = Math.min(maxReduceX, maxReduceY);
-  for (let r = 1; r <= maxReduceBoth; r++) {
-    const result = findOptimalTiling(
-      totalWidth,
-      totalDepth,
-      gridUnitMm,
-      printBedWidthMm,
-      printBedDepthMm,
-      pL - r,
-      pR - r,
-      pF - r,
-      pB - r,
-      xOverhang,
-      yOverhang
-    );
-    const saved = currentPieceCount - result.colSizes.length * result.rowSizes.length;
-    if (saved > 0) {
-      candidates.push({ axis: 'both', reductionMm: r, piecesSaved: saved });
-      break;
-    }
-  }
+  const x = trySaving(reduceX, (r) => ({ x: reduce(xAxis, r), y: yAxis }));
+  if (x) candidates.push({ axis: 'x', ...x });
+  const y = trySaving(reduceY, (r) => ({ x: xAxis, y: reduce(yAxis, r) }));
+  if (y) candidates.push({ axis: 'y', ...y });
+  const both = trySaving(Math.min(reduceX, reduceY), (r) => ({
+    x: reduce(xAxis, r),
+    y: reduce(yAxis, r),
+  }));
+  if (both) candidates.push({ axis: 'both', ...both });
 
   if (candidates.length === 0) return null;
 
@@ -440,6 +330,7 @@ function computePaddingReductionHint(
   candidates.sort((a, b) => b.piecesSaved - a.piecesSaved || a.reductionMm - b.reductionMm);
   return candidates[0];
 }
+
 /**
  * Compute the full 2D tiling for a baseplate.
  *
@@ -469,47 +360,34 @@ export function computeBaseplateTiling(
   // Pieces with dovetail connectors include male tongue protrusions in their bbox
   // (#1498). The planner reserves bed budget for those tongues so the resulting
   // STLs actually fit the bed.
-  const xOverhang = overhangFor(connectorNubs, invertDovetails);
-  const yOverhang = xOverhang;
+  const xAxis = makeAxisConfig(
+    printBedWidthMm,
+    paddingLeft,
+    paddingRight,
+    connectorNubs,
+    invertDovetails
+  );
+  const yAxis = makeAxisConfig(
+    printBedDepthMm,
+    paddingFront,
+    paddingBack,
+    connectorNubs,
+    invertDovetails
+  );
 
-  // Find optimal tiling using 2D joint search
   const { colSizes: rawColSizes, rowSizes: rawRowSizes } = findOptimalTiling(
     width,
     depth,
     gridUnitMm,
-    printBedWidthMm,
-    printBedDepthMm,
-    paddingLeft,
-    paddingRight,
-    paddingFront,
-    paddingBack,
-    xOverhang,
-    yOverhang
+    xAxis,
+    yAxis
   );
 
   // Reorder for display: largest pieces at front/left, fractional edges pinned
-  const colSizes = reorderForDisplay(
-    rawColSizes,
-    gridUnitMm,
-    printBedWidthMm,
-    paddingLeft,
-    paddingRight,
-    fractionalEdgeX === 'start',
-    xOverhang
-  );
-  const rowSizes = reorderForDisplay(
-    rawRowSizes,
-    gridUnitMm,
-    printBedDepthMm,
-    paddingFront,
-    paddingBack,
-    fractionalEdgeY === 'start',
-    yOverhang
-  );
+  const colSizes = reorderForDisplay(rawColSizes, gridUnitMm, xAxis, fractionalEdgeX === 'start');
+  const rowSizes = reorderForDisplay(rawRowSizes, gridUnitMm, yAxis, fractionalEdgeY === 'start');
 
   const isSplit = colSizes.length > 1 || rowSizes.length > 1;
-
-  // Precompute cumulative offsets
   const colOffsets = cumulativeOffsets(colSizes);
   const rowOffsets = cumulativeOffsets(rowSizes);
 
@@ -549,21 +427,14 @@ export function computeBaseplateTiling(
     }
   }
 
-  // Compute padding reduction hint
   const pieceCount = colSizes.length * rowSizes.length;
   const paddingReductionHint = computePaddingReductionHint(
     width,
     depth,
     gridUnitMm,
-    printBedWidthMm,
-    printBedDepthMm,
-    paddingLeft,
-    paddingRight,
-    paddingFront,
-    paddingBack,
-    pieceCount,
-    xOverhang,
-    yOverhang
+    xAxis,
+    yAxis,
+    pieceCount
   );
 
   return {
@@ -614,6 +485,7 @@ export function pieceToBaseplateParams(
     cornerRadii: parentParams.cornerRadii,
   };
 }
+
 /**
  * Reorder sizes for display: largest pieces at lowest indices (front/left),
  * while respecting edge constraints and fractional edge placement.
@@ -624,42 +496,26 @@ export function pieceToBaseplateParams(
 function reorderForDisplay(
   sizes: number[],
   gridUnitMm: number,
-  printBedMm: number,
-  paddingFirst: number,
-  paddingLast: number,
-  fractionAtStart: boolean,
-  overhang: DovetailOverhang = NO_OVERHANG
+  axis: AxisConfig,
+  fractionAtStart: boolean
 ): number[] {
   if (sizes.length <= 1) return sizes;
 
   // Use the same per-position constraints as partitionAxis so dovetail tongues
   // are accounted for when reshuffling chunks across positions (#1498).
-  const { maxFirst, maxLast, maxMiddle } = axisCapacity(
-    printBedMm,
-    gridUnitMm,
-    paddingFirst,
-    paddingLast,
-    overhang
-  );
-
+  const { maxFirst, maxLast, maxMiddle } = axisCapacity(gridUnitMm, axis);
   const fracIdx = sizes.findIndex(isFractional);
 
-  // When fractionAtStart, pin the fractional piece to position 0 —
-  // but only if it actually fits with paddingFirst at that position.
-  if (fractionAtStart) {
-    if (fracIdx >= 0 && sizes[fracIdx] <= maxFirst) {
-      const rest = sizes.filter((_, i) => i !== fracIdx);
-      const sortedRest = sortDescWithEdges(rest, maxMiddle, maxLast);
-      return [sizes[fracIdx], ...sortedRest];
-    }
+  // Pin fractional piece to position 0 (only if it fits there).
+  if (fractionAtStart && fracIdx >= 0 && sizes[fracIdx] <= maxFirst) {
+    const rest = sizes.filter((_, i) => i !== fracIdx);
+    return [sizes[fracIdx], ...sortDescWithEdges(rest, maxMiddle, maxLast)];
   }
 
-  // When fraction exists and belongs at the end, pin it to the last position
-  // to prevent sortDescWithEdges from placing it in the middle.
+  // Pin fractional piece to last position (prevents middle placement).
   if (!fractionAtStart && fracIdx >= 0 && sizes[fracIdx] <= maxLast) {
     const rest = sizes.filter((_, i) => i !== fracIdx);
-    const sortedRest = sortDescWithEdges(rest, maxFirst, maxMiddle);
-    return [...sortedRest, sizes[fracIdx]];
+    return [...sortDescWithEdges(rest, maxFirst, maxMiddle), sizes[fracIdx]];
   }
 
   return sortDescWithEdges(sizes, maxFirst, maxLast);
@@ -674,17 +530,14 @@ function reorderForDisplay(
 function sortDescWithEdges(sizes: number[], maxFirst: number, maxLast: number): number[] {
   const pool = [...sizes].sort((a, b) => b - a);
 
-  // Position 0: largest piece that fits with paddingFirst
   const firstIdx = pool.findIndex((v) => v <= maxFirst);
   if (firstIdx < 0) return sizes;
   const first = pool.splice(firstIdx, 1)[0];
 
-  // If the smallest remaining piece already fits paddingLast, we're done
   if (pool.length === 0 || pool[pool.length - 1] <= maxLast) {
     return [first, ...pool];
   }
 
-  // Last element too large — find a valid one and move it to the end
   const validLastIdx = pool.findIndex((v) => v <= maxLast);
   if (validLastIdx < 0) return sizes;
   const lastPiece = pool.splice(validLastIdx, 1)[0];


### PR DESCRIPTION
## Summary
- Fixes #1498 — split baseplate STLs exceeded the configured print bed when `connectorNubs` was enabled, because the planner only checked `gridUnits·gridUnitMm + padding ≤ printBedMm` and ignored the 1.5mm male dovetail tongue extending past the slab on every join edge.
- Threads `connectorNubs` and `invertDovetails` through `splitPlanner` so per-piece bed budget reserves space for the male side of each join. Female sides cut into the slab and consume nothing; middle pieces collapse to a single `TONGUE_PROTRUSION` because exactly one of left/right is male regardless of invert orientation.
- `TONGUE_PROTRUSION_MM` is duplicated locally — module boundaries forbid `features/baseplate` importing from `features/generation`. A comment notes the canonical source so the constants stay in sync.

## Repro from issue #1498
Baseplate 12×7 units with 4mm L/R padding (totals 512×324mm incl. padding) on a 256mm bed with dovetail connectors enabled.

| | Before | After |
| --- | --- | --- |
| Tiling | 2 cols × 2 rows of [6, 6]·[4, 3] | 3 cols × 2 rows of [4, 4, 4]·[4, 3] |
| Right-column STL width | 257.5 mm (overflow) | 256 mm (fits) |

## Test plan
- [x] New `splitPlanner.test.ts` test reproduces the 257.5mm overflow before the fix and asserts every piece (including dovetail tongue) fits the bed after.
- [x] New "ignores dovetail protrusion when connectorNubs is disabled" test pins existing `[6, 6]` behavior so the fix doesn't pessimize unsplit cases.
- [x] All 49 splitPlanner tests pass; all 295 baseplate tests pass.
- [x] `pnpm run quality` (typecheck + lint + knip) clean of new errors.