### PR TITLE
docs: refresh README — trim narrative, fix drift, restyle hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<div align="center">
+
 # Gridfinity Layout Tool
 
 [![CI](https://github.com/andymai/gridfinity-layout-tool/actions/workflows/ci.yml/badge.svg)](https://github.com/andymai/gridfinity-layout-tool/actions/workflows/ci.yml)
@@ -6,13 +8,16 @@
 
 Plan and design [Gridfinity](https://www.youtube.com/c/ZackFreedman) drawer organizer layouts for 3D printing — right in your browser.
 
-**Live:** [gridfinitylayouttool.com](https://gridfinitylayouttool.com)
+### → [**gridfinitylayouttool.com**](https://gridfinitylayouttool.com)
+
+</div>
 
 ## Features
 
-- **Layout Planner** — Drag-and-drop bin placement with multi-layer support
+- **Layout Planner** — Drag-and-drop bin placement with stacked layers and color-coded categories
 - **3D Preview** — Isometric visualization of your drawer layout
 - **Bin Designer** — Parametric 3D bin generator with STL export
+- **Baseplate Generator** — 3D-printable Gridfinity baseplates with automatic splitting and STL / STEP / 3MF export
 - **Print List** — Optimized print list with filament, time, and cost estimates
 - **Inspiration Gallery** — Browse curated example layouts across workshop, kitchen, office, hobby, and personal themes
 - **Cloud Sharing** — Share layouts via link with optional real-time collaboration
@@ -20,21 +25,12 @@ Plan and design [Gridfinity](https://www.youtube.com/c/ZackFreedman) drawer orga
 
 ## Built With
 
-| Technology                                   | Purpose                                                |
-| -------------------------------------------- | ------------------------------------------------------ |
-| [React 19](https://react.dev)                | UI framework                                           |
-| [TypeScript](https://www.typescriptlang.org) | Type safety                                            |
-| [Zustand](https://github.com/pmndrs/zustand) | State management                                       |
-| [Three.js](https://threejs.org)              | 3D visualization                                       |
-| [brepjs](https://github.com/andymai/brepjs)  | Parametric 3D geometry & STL export (OpenCascade WASM) |
-| [Tailwind CSS 4](https://tailwindcss.com)    | Styling                                                |
-| [Vitest](https://vitest.dev)                 | Unit testing                                           |
-| [Playwright](https://playwright.dev)         | End-to-end testing                                     |
-| [Vercel](https://vercel.com)                 | Hosting & serverless API                               |
+- **[brepjs](https://github.com/andymai/brepjs)** — Parametric 3D geometry & STL export (OpenCascade WASM)
+- **[Three.js](https://threejs.org)** — 3D visualization
 
 ## Local Development
 
-Requires **Node.js 20+** and **pnpm 10+**. Use `nvm use` to switch to the correct version (requires [nvm](https://github.com/nvm-sh/nvm)).
+Requires **Node.js 24+** and **pnpm 10+**. Use `nvm use` to switch to the correct version (requires [nvm](https://github.com/nvm-sh/nvm)).
 
 ```bash
 git clone https://github.com/andymai/gridfinity-layout-tool.git


### PR DESCRIPTION
## Summary

- **Cuts that don't serve the narrative.** Drops Bin Inspector, Version History, and Multi-Language bullets — table-stakes infrastructure that diluted the stronger differentiators. Collapses the 9-row Built With table to brepjs + Three.js, the two libraries that actually explain how this tool exists in a browser.
- **Drift fixes.** Adds Baseplate Generator (a major user-facing feature missing from the list); rewords Layout Planner to mention stacked layers and color-coded categories; bumps Node.js requirement 20+ → 24+ to match `.nvmrc`; strips stale version numbers from the tech list.
- **Hero restyle.** Wraps title / badges / tagline / live link in a centered `<div align="center">` block and promotes the live URL to an H3 CTA so it's the second thing the eye lands on after the title.

## Test plan

- [x] `prettier --check README.md` passes
- [x] All pre-commit hooks pass (boundaries, i18n×3, exhaustiveness, component-structure, missing-tests, readme-reminders)
- [ ] Visually confirm the centered hero renders correctly on the GitHub PR diff preview
- [ ] Confirm the H3 CTA → live URL is visibly more prominent than the prior plain-text Live link