### PR TITLE
ci(smoke): short-circuit preview smoke on Dependabot PRs

### DIFF
--- a/.github/workflows/smoke-preview.yml
+++ b/.github/workflows/smoke-preview.yml
@@ -40,8 +40,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Dependabot PR runs do not have access to repo Actions secrets, including
+      # VERCEL_AUTOMATION_BYPASS_SECRET — so the preview will return 401 and the
+      # smoke spec cannot run. Short-circuit cleanly: dep bumps still get
+      # coverage from Build, Unit Tests, Quality, and CodeQL.
+      - name: Skip — Dependabot PR
+        if: github.actor == 'dependabot[bot]'
+        run: |
+          echo "::warning::Dependabot PR — VERCEL_AUTOMATION_BYPASS_SECRET unavailable; preview smoke is N/A."
+          echo "Coverage for this PR comes from CI Build, Unit Tests, Quality, and CodeQL."
+
       - name: Resolve Vercel preview URL
         id: preview
+        if: github.actor != 'dependabot[bot]'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

- Dependabot PR runs do not have access to repository Actions secrets, so `VERCEL_AUTOMATION_BYPASS_SECRET` is empty and the Vercel preview returns 401 — the smoke spec then fails on every Dependabot PR.
- Skip the smoke job for Dependabot PRs at the step level, keeping the check reporting "success". Coverage for dep bumps comes from CI Build, Unit Tests, Quality, and CodeQL.
- Step-level skip (rather than job-level `if:`) keeps the check semantics safe if the smoke check is ever marked required in branch protection.

## Test plan

- [x] CI workflow lint / YAML parses
- [x] On this PR (non-Dependabot author), smoke job runs as before
- [ ] After merge, rebase open Dependabot PRs (#1502–#1505) and confirm the "PWA Smoke Test" check completes successfully with a warning, no 401