### PR TITLE
chore(security): add Content-Security-Policy-Report-Only

### DIFF
--- a/e2e/smoke/pwa-smoke.spec.ts
+++ b/e2e/smoke/pwa-smoke.spec.ts
@@ -25,6 +25,11 @@ const IGNORED_CONSOLE_PATTERNS: RegExp[] = [
   /posthog/i,
   // React DevTools nag
   /Download the React DevTools/i,
+  // CSP-Report-Only violations are by design surfaced (not enforced) so the
+  // soak window can collect signal. They show up as console errors but are
+  // not actual bugs. Enforced-CSP violations (without "report-only") are
+  // still caught by this assertion.
+  /report-only Content Security Policy/i,
 ];
 
 test('boots ?smoke=1 fixture and exposes a fresh /version.json', async ({ page, baseURL }) => {

--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,10 @@
         {
           "key": "Permissions-Policy",
           "value": "camera=(), microphone=(), geolocation=(), browsing-topics=()"
+        },
+        {
+          "key": "Content-Security-Policy-Report-Only",
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://*.posthog.com https://*.liveblocks.io wss://*.liveblocks.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
         }
       ]
     },

--- a/vercel.json
+++ b/vercel.json
@@ -20,7 +20,7 @@
         },
         {
           "key": "Content-Security-Policy-Report-Only",
-          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://*.posthog.com https://*.liveblocks.io wss://*.liveblocks.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; child-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://*.posthog.com https://*.liveblocks.io wss://*.liveblocks.io; base-uri 'self'; form-action 'self'; object-src 'none'"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Adds a CSP in **report-only** mode so violations surface in browser DevTools without breaking real users. After a soak window (1–2 weeks of real traffic), tighten the directives based on actual violations and flip the header name from `Content-Security-Policy-Report-Only` to enforced `Content-Security-Policy`.

Initial directive set (intentionally permissive — we'd rather log false positives than break the app):

| Directive | Value | Why |
|---|---|---|
| `default-src` | `'self'` | conservative default |
| `script-src` | `'self' 'wasm-unsafe-eval'` | brepkit-wasm, brepjs-opencascade, Three.js compile WASM |
| `worker-src` | `'self' blob:` | Vite ESM workers + PWA service worker |
| `child-src` | `'self' blob:` | fallback for browsers that pre-date `worker-src` |
| `style-src` | `'self' 'unsafe-inline'` | Tailwind 4 runtime / inline `style` attrs |
| `img-src` | `'self' data: blob:` | bin previews, canvas exports, PWA icons |
| `font-src` | `'self' data:` | inline-encoded fonts |
| `connect-src` | `'self' https://*.posthog.com https://*.liveblocks.io wss://*.liveblocks.io` | analytics + collab websockets |
| `base-uri` | `'self'` | block `<base>` injection |
| `form-action` | `'self'` | block form posts to attacker origins |
| `object-src` | `'none'` | block plugins |

`frame-ancestors` is **deliberately omitted from the global header**: the per-route enforced CSP on `/storage-bridge.html` legitimately allows framing from `https://www.gridfinitylayouttool.com`, and a global `frame-ancestors 'none'` would emit one false-positive violation per legit embed during the soak. Will reintroduce frame-ancestors at enforcement time, scoped to exclude storage-bridge.html.

No `report-uri` / `report-to` in this PR — violations land in the browser console and DevTools "Issues" tab. The PWA smoke test was updated to ignore *report-only* console errors so the soak signal doesn't fail CI; **enforced** CSP violations would still trip the gate. A follow-up will wire `SecurityPolicyViolationEvent` into PostHog for systematic violation collection.

## Test plan

- [ ] CI green (smoke test was failing on a `vercel.live` preview-comments iframe violation; fixed by ignoring report-only console errors)
- [ ] After deploy, `curl -sI https://<preview>.vercel.app | grep -i content-security` shows the report-only header
- [ ] In a Chrome incognito window with DevTools open, exercise the app (load home, designer, share, collab, print) and watch the Issues panel — anything that shows up is either (a) a directive we need to widen, or (b) a real bug we need to fix before enforcement
- [ ] PostHog flow still works end-to-end (events posting, source-map upload — the latter is build-time so unaffected)
- [ ] Liveblocks collab still connects (tests the `wss://*.liveblocks.io` directive)

## Follow-ups

- [ ] Wire `SecurityPolicyViolationEvent` listener → `posthog.capture('csp_violation', ...)` so we can grade violations during the soak from real traffic
- [ ] After 1–2 weeks of clean reports, rename header → `Content-Security-Policy` and reintroduce `frame-ancestors 'self'` (scoped so storage-bridge.html keeps its own per-route CSP)