### PR TITLE
refactor(bin-designer): split useCutoutInteraction into focused sub-hooks

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.ts
@@ -40,7 +40,7 @@ export function cloneCutoutsWithGroups(
   });
 }
 
-/** Clamp a position so the cutout stays within bin bounds. */
+/** Clamp a position so the cutout stays within bin bounds (both lower and upper). */
 export function clampedOffset(
   original: Cutout,
   offset: number,
@@ -48,8 +48,8 @@ export function clampedOffset(
   binDepth: number
 ): { x: number; y: number } {
   return {
-    x: Math.min(original.x + offset, binWidth - original.width),
-    y: Math.min(original.y + offset, binDepth - original.depth),
+    x: Math.max(0, Math.min(original.x + offset, binWidth - original.width)),
+    y: Math.max(0, Math.min(original.y + offset, binDepth - original.depth)),
   };
 }
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure helpers for cutout interaction: cloning with group-id remapping,
+ * paste-position clamping, and default cutout construction.
+ */
+
+import type { Cutout, CutoutShape } from '@/features/bin-designer/types';
+
+export interface ClonedCutout extends Cutout {
+  readonly originalId: string;
+}
+
+/**
+ * Clone cutouts and remap any shared groupId so the clones form their own
+ * independent group (preserves "selected together" semantics for paste).
+ * `offsetFn` lets callers reposition each clone relative to its source.
+ */
+export function cloneCutoutsWithGroups(
+  originals: readonly Cutout[],
+  offsetFn?: (original: Cutout) => { x: number; y: number }
+): readonly ClonedCutout[] {
+  const groupMap = new Map<string, string>();
+  return originals.map((original) => {
+    const newId = crypto.randomUUID();
+    let newGroupId: string | null = null;
+    if (original.groupId) {
+      if (!groupMap.has(original.groupId)) {
+        groupMap.set(original.groupId, crypto.randomUUID());
+      }
+      newGroupId = groupMap.get(original.groupId) ?? null;
+    }
+    const pos = offsetFn ? offsetFn(original) : { x: original.x, y: original.y };
+    return {
+      ...original,
+      id: newId,
+      x: pos.x,
+      y: pos.y,
+      groupId: newGroupId,
+      originalId: original.id,
+    };
+  });
+}
+
+/** Clamp a position so the cutout stays within bin bounds. */
+export function clampedOffset(
+  original: Cutout,
+  offset: number,
+  binWidth: number,
+  binDepth: number
+): { x: number; y: number } {
+  return {
+    x: Math.min(original.x + offset, binWidth - original.width),
+    y: Math.min(original.y + offset, binDepth - original.depth),
+  };
+}
+
+/**
+ * Clone cutouts, add each to the layout, and select the new set.
+ * Returns the cloned cutouts (with originalId) for further use.
+ */
+export function addClonedCutouts(
+  originals: readonly Cutout[],
+  onAdd: (cutout: Cutout) => void,
+  setSelection: (sel: ReadonlySet<string>) => void,
+  offsetFn?: (original: Cutout) => { x: number; y: number }
+): readonly ClonedCutout[] {
+  const clones = cloneCutoutsWithGroups(originals, offsetFn);
+  for (const { originalId: _, ...cutout } of clones) {
+    onAdd(cutout);
+  }
+  setSelection(new Set(clones.map((c) => c.id)));
+  return clones;
+}
+
+/** Default cutout properties shared by click-to-place and draw-to-place. */
+export function createDefaultCutout(
+  id: string,
+  shape: CutoutShape,
+  x: number,
+  y: number,
+  width: number,
+  depth: number
+): Cutout {
+  return {
+    id,
+    shape,
+    x,
+    y,
+    width,
+    depth,
+    cutDepth: 5,
+    rotation: 0,
+    cornerRadius: 0,
+    label: '',
+    groupId: null,
+  };
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutInteractionTypes.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutInteractionTypes.ts
@@ -1,0 +1,119 @@
+/**
+ * Type definitions and shared constants for the cutout interaction state machine.
+ *
+ * The `InteractionMode` discriminated union drives every pointer/keyboard
+ * handler — a single `mode.type` switch produces the entire UX behavior.
+ */
+
+import type { Cutout, CutoutShape } from '@/features/bin-designer/types';
+import type { CellMask } from '@/shared/utils/cellMask';
+import type { MaskCellSize } from './maskFit';
+import type { PathDrawingMode, VertexEditMode } from './handlers';
+import type { StartRect } from './geometry';
+
+/** Direction for resize handles */
+export type ResizeHandle = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w';
+
+/** Default sizes for click-to-place (mm) */
+export const DEFAULT_RECT_SIZE = 20;
+export const DEFAULT_CIRCLE_SIZE = 15;
+
+/** Paste offset in mm — each successive paste shifts by this amount */
+export const PASTE_OFFSET = 2;
+
+export type InteractionMode =
+  | { readonly type: 'idle' }
+  | { readonly type: 'placing'; readonly shape: CutoutShape }
+  | {
+      readonly type: 'pending-place';
+      readonly shape: CutoutShape;
+      readonly startMmX: number;
+      readonly startMmY: number;
+    }
+  | {
+      readonly type: 'drawing';
+      readonly shape: CutoutShape;
+      readonly startMmX: number;
+      readonly startMmY: number;
+    }
+  | {
+      readonly type: 'dragging';
+      readonly startX: number;
+      readonly startY: number;
+      readonly offsets: ReadonlyMap<string, { readonly dx: number; readonly dy: number }>;
+    }
+  | {
+      readonly type: 'resizing';
+      readonly cutoutId: string;
+      readonly handle: ResizeHandle;
+      readonly startRect: StartRect;
+    }
+  | {
+      readonly type: 'rotating';
+      readonly cutoutId: string;
+      readonly startAngle: number;
+      readonly initialRotation: number;
+    }
+  | {
+      readonly type: 'group-rotating';
+      readonly startAngle: number;
+      readonly center: { readonly x: number; readonly y: number };
+      readonly initialStates: ReadonlyMap<
+        string,
+        { readonly x: number; readonly y: number; readonly rotation: number }
+      >;
+    }
+  | {
+      readonly type: 'group-scaling';
+      readonly startDist: number;
+      readonly center: { readonly x: number; readonly y: number };
+      readonly initialStates: ReadonlyMap<
+        string,
+        {
+          readonly x: number;
+          readonly y: number;
+          readonly width: number;
+          readonly depth: number;
+        }
+      >;
+    }
+  | { readonly type: 'marquee'; readonly startX: number; readonly startY: number }
+  | PathDrawingMode
+  | VertexEditMode
+  | { readonly type: 'ruler-ready' }
+  | {
+      readonly type: 'measuring';
+      readonly startX: number;
+      readonly startY: number;
+      /** When true, return to ruler-ready on pointer up; otherwise return to idle (Shift+drag) */
+      readonly sticky: boolean;
+    };
+
+/** Preview overrides applied during drag/resize for visual feedback */
+export type PreviewMap = ReadonlyMap<string, Partial<Cutout>>;
+
+export interface UseCutoutInteractionOptions {
+  readonly cutouts: readonly Cutout[];
+  readonly onUpdate: (id: string, updates: Partial<Cutout>) => void;
+  readonly onRemove: (id: string) => void;
+  readonly onAdd: (cutout: Cutout) => void;
+  readonly onGroup?: (cutoutIds: readonly string[]) => void;
+  readonly onUngroup?: (cutoutIds: readonly string[]) => void;
+  readonly onUpdateBatch?: (updates: ReadonlyMap<string, Partial<Cutout>>) => void;
+  readonly onRemoveBatch?: (ids: readonly string[]) => void;
+  readonly onUndo?: () => void;
+  readonly onRedo?: () => void;
+  readonly canUndo?: boolean;
+  readonly canRedo?: boolean;
+  readonly onLock?: (ids: readonly string[]) => void;
+  readonly onUnlock?: (ids: readonly string[]) => void;
+  readonly startTransaction?: () => void;
+  readonly commitTransaction?: () => void;
+  readonly binWidth: number;
+  readonly binDepth: number;
+  readonly gridSize?: number;
+  /** Non-rectangular footprint mask — when present, rejects placements outside the polygon. */
+  readonly cellMask?: CellMask;
+  /** Mm per mask cell. Required alongside cellMask; X/Y differ on non-square bins. */
+  readonly maskCellSize?: MaskCellSize;
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/rulerHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/rulerHandler.ts
@@ -10,7 +10,7 @@ import type { Cutout } from '@/features/bin-designer/types';
 import { getRotatedBounds } from '../geometry';
 
 /** A snap target point derived from cutout geometry */
-interface SnapTarget {
+export interface SnapTarget {
   readonly x: number;
   readonly y: number;
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutClipboard.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutClipboard.ts
@@ -1,0 +1,105 @@
+/**
+ * Clipboard sub-hook for cutout copy/paste/duplicate.
+ *
+ * Owns the clipboard array and paste-counter ref. Exposes copy/paste/duplicate
+ * handlers that integrate with the toast system and respect polygon mask
+ * constraints.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import type { Cutout } from '@/features/bin-designer/types';
+import type { CellMask } from '@/shared/utils/cellMask';
+import type { MaskCellSize } from './maskFit';
+import { useToastStore } from '@/core/store/toast';
+import { useTranslation } from '@/i18n';
+import { cutoutFitsInMask } from './maskFit';
+import { addClonedCutouts, clampedOffset } from './cutoutHelpers';
+import { PASTE_OFFSET } from './cutoutInteractionTypes';
+
+interface UseCutoutClipboardOptions {
+  readonly cutouts: readonly Cutout[];
+  readonly selection: ReadonlySet<string>;
+  readonly setSelection: (sel: ReadonlySet<string>) => void;
+  readonly onAdd: (cutout: Cutout) => void;
+  readonly binWidth: number;
+  readonly binDepth: number;
+  readonly cellMask?: CellMask;
+  readonly maskCellSize?: MaskCellSize;
+}
+
+export interface CutoutClipboard {
+  readonly clipboard: readonly Cutout[];
+  readonly copySelected: () => void;
+  readonly pasteFromClipboard: () => void;
+  readonly duplicateSelected: () => void;
+}
+
+export function useCutoutClipboard({
+  cutouts,
+  selection,
+  setSelection,
+  onAdd,
+  binWidth,
+  binDepth,
+  cellMask,
+  maskCellSize,
+}: UseCutoutClipboardOptions): CutoutClipboard {
+  const addToast = useToastStore((s) => s.addToast);
+  const t = useTranslation();
+  const [clipboard, setClipboard] = useState<readonly Cutout[]>([]);
+  const pasteCountRef = useRef(0);
+
+  const copySelected = useCallback(() => {
+    const selected = cutouts.filter((c) => selection.has(c.id));
+    if (selected.length > 0) {
+      setClipboard(selected);
+      pasteCountRef.current = 0;
+      addToast({
+        message: t('toast.cutoutsCopied', { count: selected.length }),
+        type: 'info',
+        duration: 2000,
+      });
+    }
+  }, [cutouts, selection, addToast, t]);
+
+  const pasteFromClipboard = useCallback(() => {
+    if (clipboard.length === 0) return;
+    pasteCountRef.current += 1;
+    const offset = PASTE_OFFSET * pasteCountRef.current;
+
+    // Polygon bins: drop originals whose offset clone would overhang the mask.
+    // User can re-paste at a different location rather than losing the clipboard.
+    const placeable =
+      cellMask && maskCellSize
+        ? clipboard.filter((orig) => {
+            const pos = clampedOffset(orig, offset, binWidth, binDepth);
+            return cutoutFitsInMask({ ...orig, ...pos }, cellMask, maskCellSize);
+          })
+        : clipboard;
+    if (placeable.length === 0) return;
+
+    addClonedCutouts(placeable, onAdd, setSelection, (original) =>
+      clampedOffset(original, offset, binWidth, binDepth)
+    );
+  }, [clipboard, onAdd, setSelection, binWidth, binDepth, cellMask, maskCellSize]);
+
+  const duplicateSelected = useCallback(() => {
+    const selected = cutouts.filter((c) => selection.has(c.id));
+    if (selected.length === 0) return;
+
+    const placeable =
+      cellMask && maskCellSize
+        ? selected.filter((orig) => {
+            const pos = clampedOffset(orig, PASTE_OFFSET, binWidth, binDepth);
+            return cutoutFitsInMask({ ...orig, ...pos }, cellMask, maskCellSize);
+          })
+        : selected;
+    if (placeable.length === 0) return;
+
+    addClonedCutouts(placeable, onAdd, setSelection, (original) =>
+      clampedOffset(original, PASTE_OFFSET, binWidth, binDepth)
+    );
+  }, [cutouts, selection, onAdd, setSelection, binWidth, binDepth, cellMask, maskCellSize]);
+
+  return { clipboard, copySelected, pasteFromClipboard, duplicateSelected };
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutContextMenu.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutContextMenu.ts
@@ -1,0 +1,28 @@
+/**
+ * Right-click context menu state for the cutout workspace.
+ *
+ * Position is in viewport coordinates (px); the consumer component renders
+ * the menu at this position when non-null.
+ */
+
+import { useCallback, useState } from 'react';
+
+export interface CutoutContextMenu {
+  readonly contextMenu: { readonly x: number; readonly y: number } | null;
+  readonly openContextMenu: (x: number, y: number) => void;
+  readonly closeContextMenu: () => void;
+}
+
+export function useCutoutContextMenu(): CutoutContextMenu {
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+
+  const openContextMenu = useCallback((x: number, y: number) => {
+    setContextMenu({ x, y });
+  }, []);
+
+  const closeContextMenu = useCallback(() => {
+    setContextMenu(null);
+  }, []);
+
+  return { contextMenu, openContextMenu, closeContextMenu };
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.ts
@@ -5,248 +5,34 @@
  * Keyboard shortcuts: Delete, Ctrl+A, arrows (nudge), Escape.
  *
  * Pointer-move logic for each interaction mode is delegated to focused
- * handler functions in ./handlers/ — this hook orchestrates transitions
- * and wires shared state.
+ * handler functions in ./handlers/. Concern-specific state and effects
+ * (clipboard, context menu, undo toasts, keyboard shortcuts, recovery,
+ * transform starters, path tool) live in sibling sub-hooks below.
  */
 
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
-import type { Cutout, CutoutShape, PathPoint } from '@/features/bin-designer/types';
-import type { CellMask } from '@/shared/utils/cellMask';
+import type { Cutout, CutoutShape } from '@/features/bin-designer/types';
 import { useCutoutSelection } from '@/features/bin-designer/store';
-import { useToastStore } from '@/core/store/toast';
-import { useTranslation } from '@/i18n';
-import {
-  snapToGrid,
-  MIN_CUTOUT_SIZE,
-  computeBounds,
-  getRotatedBounds,
-  type AlignmentGuide,
-} from './geometry';
-import { cutoutFitsInMask, rectFitsInMask, type MaskCellSize } from './maskFit';
-import {
-  getPathBounds,
-  CLOSE_SNAP_THRESHOLD,
-  clampPathToBounds,
-  isSelfIntersecting,
-} from './pathGeometry';
-import {
-  handlePendingPlaceMove,
-  handleDragMove,
-  handleResizeMove,
-  handleRotateMove,
-  handleGroupRotateMove,
-  handleGroupScaleMove,
-  handleDrawMove,
-  handleCutoutKeyDown,
-  handlePathDrawingPointerDown,
-  handlePathDrawingPointerMove,
-  handlePathDrawingPointerUp,
-  handlePathDrawingVertexDown,
-  handleVertexEditPointerDown,
-  handleVertexEditPointerMove,
-  handleVertexEditPointerUp,
-} from './handlers';
+import { snapToGrid, getRotatedBounds, type AlignmentGuide } from './geometry';
+import { cutoutFitsInMask } from './maskFit';
+import type { PathDrawingPreviewState, SegmentHoverInfo } from './handlers';
+import { collectSnapTargets } from './handlers/rulerHandler';
 import type { RulerMeasurement } from './handlers/rulerHandler';
 import {
-  collectSnapTargets,
-  snapToNearestTarget,
-  computeMeasurement,
-} from './handlers/rulerHandler';
-import type { PathDrawingMode, PathDrawingPreviewState, SegmentHoverInfo } from './handlers';
-import type { VertexEditMode } from './handlers';
-import type { StartRect } from './geometry';
+  type InteractionMode,
+  type PreviewMap,
+  type UseCutoutInteractionOptions,
+} from './cutoutInteractionTypes';
+import { useCutoutClipboard } from './useCutoutClipboard';
+import { useCutoutContextMenu } from './useCutoutContextMenu';
+import { useCutoutUndoToasts } from './useCutoutUndoToasts';
+import { useCutoutKeyboardShortcuts } from './useCutoutKeyboardShortcuts';
+import { useCutoutRecovery } from './useCutoutRecovery';
+import { useCutoutTransformStarters } from './useCutoutTransformStarters';
+import { useCutoutPathTool } from './useCutoutPathTool';
+import { useCutoutPointerHandlers } from './useCutoutPointerHandlers';
 
-/** Direction for resize handles */
-export type ResizeHandle = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w';
-
-/** Default sizes for click-to-place (mm) */
-const DEFAULT_RECT_SIZE = 20;
-const DEFAULT_CIRCLE_SIZE = 15;
-
-export type InteractionMode =
-  | { readonly type: 'idle' }
-  | { readonly type: 'placing'; readonly shape: CutoutShape }
-  | {
-      readonly type: 'pending-place';
-      readonly shape: CutoutShape;
-      readonly startMmX: number;
-      readonly startMmY: number;
-    }
-  | {
-      readonly type: 'drawing';
-      readonly shape: CutoutShape;
-      readonly startMmX: number;
-      readonly startMmY: number;
-    }
-  | {
-      readonly type: 'dragging';
-      readonly startX: number;
-      readonly startY: number;
-      readonly offsets: ReadonlyMap<string, { readonly dx: number; readonly dy: number }>;
-    }
-  | {
-      readonly type: 'resizing';
-      readonly cutoutId: string;
-      readonly handle: ResizeHandle;
-      readonly startRect: StartRect;
-    }
-  | {
-      readonly type: 'rotating';
-      readonly cutoutId: string;
-      readonly startAngle: number;
-      readonly initialRotation: number;
-    }
-  | {
-      readonly type: 'group-rotating';
-      readonly startAngle: number;
-      readonly center: { readonly x: number; readonly y: number };
-      readonly initialStates: ReadonlyMap<
-        string,
-        { readonly x: number; readonly y: number; readonly rotation: number }
-      >;
-    }
-  | {
-      readonly type: 'group-scaling';
-      readonly startDist: number;
-      readonly center: { readonly x: number; readonly y: number };
-      readonly initialStates: ReadonlyMap<
-        string,
-        {
-          readonly x: number;
-          readonly y: number;
-          readonly width: number;
-          readonly depth: number;
-        }
-      >;
-    }
-  | { readonly type: 'marquee'; readonly startX: number; readonly startY: number }
-  | PathDrawingMode
-  | VertexEditMode
-  | { readonly type: 'ruler-ready' }
-  | {
-      readonly type: 'measuring';
-      readonly startX: number;
-      readonly startY: number;
-      /** When true, return to ruler-ready on pointer up; otherwise return to idle (Shift+drag) */
-      readonly sticky: boolean;
-    };
-
-/** Preview overrides applied during drag/resize for visual feedback */
-export type PreviewMap = ReadonlyMap<string, Partial<Cutout>>;
-
-interface UseCutoutInteractionOptions {
-  readonly cutouts: readonly Cutout[];
-  readonly onUpdate: (id: string, updates: Partial<Cutout>) => void;
-  readonly onRemove: (id: string) => void;
-  readonly onAdd: (cutout: Cutout) => void;
-  readonly onGroup?: (cutoutIds: readonly string[]) => void;
-  readonly onUngroup?: (cutoutIds: readonly string[]) => void;
-  readonly onUpdateBatch?: (updates: ReadonlyMap<string, Partial<Cutout>>) => void;
-  readonly onRemoveBatch?: (ids: readonly string[]) => void;
-  readonly onUndo?: () => void;
-  readonly onRedo?: () => void;
-  readonly canUndo?: boolean;
-  readonly canRedo?: boolean;
-  readonly onLock?: (ids: readonly string[]) => void;
-  readonly onUnlock?: (ids: readonly string[]) => void;
-  readonly startTransaction?: () => void;
-  readonly commitTransaction?: () => void;
-  readonly binWidth: number;
-  readonly binDepth: number;
-  readonly gridSize?: number;
-  /** Non-rectangular footprint mask — when present, rejects placements outside the polygon. */
-  readonly cellMask?: CellMask;
-  /** Mm per mask cell. Required alongside cellMask; X/Y differ on non-square bins. */
-  readonly maskCellSize?: MaskCellSize;
-}
-
-/** Paste offset in mm — each successive paste shifts by this amount */
-const PASTE_OFFSET = 2;
-
-interface ClonedCutout extends Cutout {
-  readonly originalId: string;
-}
-
-function cloneCutoutsWithGroups(
-  originals: readonly Cutout[],
-  offsetFn?: (original: Cutout) => { x: number; y: number }
-): readonly ClonedCutout[] {
-  const groupMap = new Map<string, string>();
-  return originals.map((original) => {
-    const newId = crypto.randomUUID();
-    let newGroupId: string | null = null;
-    if (original.groupId) {
-      if (!groupMap.has(original.groupId)) {
-        groupMap.set(original.groupId, crypto.randomUUID());
-      }
-      newGroupId = groupMap.get(original.groupId) ?? null;
-    }
-    const pos = offsetFn ? offsetFn(original) : { x: original.x, y: original.y };
-    return {
-      ...original,
-      id: newId,
-      x: pos.x,
-      y: pos.y,
-      groupId: newGroupId,
-      originalId: original.id,
-    };
-  });
-}
-
-/** Clamp a position so the cutout stays within bin bounds. */
-function clampedOffset(
-  original: Cutout,
-  offset: number,
-  binWidth: number,
-  binDepth: number
-): { x: number; y: number } {
-  return {
-    x: Math.min(original.x + offset, binWidth - original.width),
-    y: Math.min(original.y + offset, binDepth - original.depth),
-  };
-}
-
-/**
- * Clone cutouts, add each to the layout, and select the new set.
- * Returns the cloned cutouts (with originalId) for further use.
- */
-function addClonedCutouts(
-  originals: readonly Cutout[],
-  onAdd: (cutout: Cutout) => void,
-  setSelection: (sel: ReadonlySet<string>) => void,
-  offsetFn?: (original: Cutout) => { x: number; y: number }
-): readonly ClonedCutout[] {
-  const clones = cloneCutoutsWithGroups(originals, offsetFn);
-  for (const { originalId: _, ...cutout } of clones) {
-    onAdd(cutout);
-  }
-  setSelection(new Set(clones.map((c) => c.id)));
-  return clones;
-}
-
-/** Default cutout properties shared by click-to-place and draw-to-place. */
-function createDefaultCutout(
-  id: string,
-  shape: CutoutShape,
-  x: number,
-  y: number,
-  width: number,
-  depth: number
-): Cutout {
-  return {
-    id,
-    shape,
-    x,
-    y,
-    width,
-    depth,
-    cutDepth: 5,
-    rotation: 0,
-    cornerRadius: 0,
-    label: '',
-    groupId: null,
-  };
-}
+export type { ResizeHandle, InteractionMode, PreviewMap } from './cutoutInteractionTypes';
 
 export function useCutoutInteraction({
   cutouts,
@@ -271,9 +57,6 @@ export function useCutoutInteraction({
   cellMask,
   maskCellSize,
 }: UseCutoutInteractionOptions) {
-  const addToast = useToastStore((s) => s.addToast);
-  const t = useTranslation();
-
   const [mode, setMode] = useState<InteractionMode>({ type: 'placing', shape: 'rectangle' });
   const [selection, setSelection] = useState<ReadonlySet<string>>(new Set());
   const [preview, setPreview] = useState<PreviewMap>(new Map());
@@ -283,12 +66,6 @@ export function useCutoutInteraction({
   const containerRef = useRef<HTMLElement | null>(null);
   /** Track whether the dead zone has been exceeded during this drag/resize */
   const pastDeadZoneRef = useRef(false);
-  /** Clipboard for copy/paste operations */
-  const [clipboard, setClipboard] = useState<readonly Cutout[]>([]);
-  /** Track number of pastes since last copy to increment offset */
-  const pasteCountRef = useRef(0);
-  /** Context menu state */
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   /** Drawing preview (corner-to-corner shape being drawn) */
   const [drawingPreview, setDrawingPreview] = useState<{
     x: number;
@@ -321,7 +98,6 @@ export function useCutoutInteraction({
     (id: string, additive: boolean) => {
       const cutout = cutouts.find((c) => c.id === id);
       if (!cutout) return;
-      // Hidden cutouts cannot be selected
       if (cutout.hidden) return;
 
       setSelection((prev) => {
@@ -436,631 +212,102 @@ export function useCutoutInteraction({
     [selection, cutouts, onUpdate, onUpdateBatch, binWidth, binDepth, cellMask, maskCellSize]
   );
 
-  // ── Clipboard ──────────────────────────────────────────────────────
+  // ── Sub-hooks: clipboard, context menu, undo toasts ───────────────
 
-  const copySelected = useCallback(() => {
-    const selected = cutouts.filter((c) => selection.has(c.id));
-    if (selected.length > 0) {
-      setClipboard(selected);
-      pasteCountRef.current = 0;
-      addToast({
-        message: t('toast.cutoutsCopied', { count: selected.length }),
-        type: 'info',
-        duration: 2000,
-      });
-    }
-  }, [cutouts, selection, addToast, t]);
-
-  const pasteFromClipboard = useCallback(() => {
-    if (clipboard.length === 0) return;
-    pasteCountRef.current += 1;
-    const offset = PASTE_OFFSET * pasteCountRef.current;
-
-    // Polygon bins: drop originals whose offset clone would overhang the mask.
-    // User can re-paste at a different location rather than losing the clipboard.
-    const placeable =
-      cellMask && maskCellSize
-        ? clipboard.filter((orig) => {
-            const pos = clampedOffset(orig, offset, binWidth, binDepth);
-            return cutoutFitsInMask({ ...orig, ...pos }, cellMask, maskCellSize);
-          })
-        : clipboard;
-    if (placeable.length === 0) return;
-
-    addClonedCutouts(placeable, onAdd, setSelection, (original) =>
-      clampedOffset(original, offset, binWidth, binDepth)
-    );
-  }, [clipboard, onAdd, binWidth, binDepth, cellMask, maskCellSize]);
-
-  const duplicateSelected = useCallback(() => {
-    const selected = cutouts.filter((c) => selection.has(c.id));
-    if (selected.length === 0) return;
-
-    const placeable =
-      cellMask && maskCellSize
-        ? selected.filter((orig) => {
-            const pos = clampedOffset(orig, PASTE_OFFSET, binWidth, binDepth);
-            return cutoutFitsInMask({ ...orig, ...pos }, cellMask, maskCellSize);
-          })
-        : selected;
-    if (placeable.length === 0) return;
-
-    addClonedCutouts(placeable, onAdd, setSelection, (original) =>
-      clampedOffset(original, PASTE_OFFSET, binWidth, binDepth)
-    );
-  }, [cutouts, selection, onAdd, binWidth, binDepth, cellMask, maskCellSize]);
-
-  // ── Path tool ────────────────────────────────────────────────────
-
-  /** Commit a closed path as a new cutout. */
-  const commitPath = useCallback(
-    (points: readonly PathPoint[]) => {
-      // Clamp to bin bounds so cutout never extends outside the bin surface
-      const clamped = clampPathToBounds(points, binWidth, binDepth);
-
-      // Reject self-intersecting paths that would produce invalid 3D geometry
-      if (isSelfIntersecting(clamped)) {
-        setPathDrawingPreview(null);
-        setMode({ type: 'idle' });
-        return;
-      }
-
-      const { minX, minY, maxX, maxY } = getPathBounds(clamped);
-
-      // Polygon bins: reject paths whose bounds overhang the mask.
-      if (
-        cellMask &&
-        maskCellSize &&
-        !rectFitsInMask(cellMask, minX, minY, maxX - minX, maxY - minY, maskCellSize)
-      ) {
-        setPathDrawingPreview(null);
-        setMode({ type: 'idle' });
-        return;
-      }
-
-      const newId = crypto.randomUUID();
-      onAdd({
-        ...createDefaultCutout(newId, 'path', minX, minY, maxX - minX, maxY - minY),
-        path: clamped,
-      });
-      setSelection(new Set([newId]));
-      setMode({ type: 'idle' });
-      setPathDrawingPreview(null);
-    },
-    [onAdd, binWidth, binDepth, cellMask, maskCellSize]
-  );
-
-  /** Handle path background click (first click or subsequent). */
-  const handlePathBackgroundDown = useCallback(
-    (mmX: number, mmY: number, shiftKey: boolean) => {
-      const bounds = { binWidth, binDepth, cellMask, maskCellSize };
-      const pathMode = mode.type === 'path-drawing' ? mode : null;
-      handlePathDrawingPointerDown(pathMode, mmX, mmY, shiftKey, bounds, snap, {
-        setMode,
-        setPathDrawingPreview,
-        commitPath,
-      });
-    },
-    [mode, binWidth, binDepth, cellMask, maskCellSize, snap, commitPath]
-  );
-
-  /** Handle clicking an existing vertex while drawing (to reposition or close). */
-  const onPathDrawingVertexDown = useCallback(
-    (index: number, _mmX: number, _mmY: number) => {
-      if (mode.type !== 'path-drawing') return;
-      handlePathDrawingVertexDown(mode, index, {
-        setMode,
-        setPathDrawingPreview,
-        commitPath,
-      });
-    },
-    [mode, commitPath]
-  );
-
-  /** Enter vertex editing mode for a path cutout (on double-click). */
-  const enterVertexEditing = useCallback(
-    (cutoutId: string) => {
-      const cutout = cutouts.find((c) => c.id === cutoutId);
-      if (!cutout || cutout.shape !== 'path') return;
-      setSelection(new Set([cutoutId]));
-      setMode({
-        type: 'vertex-editing',
-        cutoutId,
-        selectedPointIndex: null,
-        dragTarget: null,
-      });
-    },
-    [cutouts]
-  );
-
-  /** Handle vertex point down from PathEditOverlay3D. */
-  const handleVertexPointDown = useCallback(
-    (index: number, _mmX: number, _mmY: number) => {
-      if (mode.type !== 'vertex-editing') return;
-      startTransaction?.();
-      setMode({
-        ...mode,
-        selectedPointIndex: index,
-        dragTarget: { type: 'vertex', index },
-      });
-    },
-    [mode, startTransaction]
-  );
-
-  /** Handle vertex handle down from PathEditOverlay3D. */
-  const handleVertexHandleDown = useCallback(
-    (index: number, handleType: 'in' | 'out', _mmX: number, _mmY: number) => {
-      if (mode.type !== 'vertex-editing') return;
-      startTransaction?.();
-      setMode({
-        ...mode,
-        dragTarget: { type: 'handle', index, handleType },
-      });
-    },
-    [mode, startTransaction]
-  );
-
-  /** Handle background click during vertex editing (segment insertion or exit). */
-  const handleVertexBackgroundDown = useCallback(
-    (mmX: number, mmY: number) => {
-      if (mode.type !== 'vertex-editing') return;
-      const cutout = cutouts.find((c) => c.id === mode.cutoutId);
-      if (!cutout) {
-        setMode({ type: 'idle' });
-        return;
-      }
-      // Start a transaction so the split + any subsequent drag = one undo step
-      startTransaction?.();
-      handleVertexEditPointerDown(mode, { mmX, mmY, altKey: false }, cutout, CLOSE_SNAP_THRESHOLD, {
-        setMode,
-        setPreview,
-        onUpdate,
-        setSegmentHover,
-      });
-    },
-    [mode, cutouts, onUpdate, startTransaction]
-  );
-
-  // ── Context menu ───────────────────────────────────────────────────
-
-  const openContextMenu = useCallback((x: number, y: number) => {
-    setContextMenu({ x, y });
-  }, []);
-
-  const closeContextMenu = useCallback(() => {
-    setContextMenu(null);
-  }, []);
-
-  // ── Undo/Redo with toast feedback ─────────────────────────────────
-
-  const undoWithToast = useCallback(() => {
-    if (!canUndo) return;
-    onUndo?.();
-    addToast({ message: t('toast.undone'), type: 'info', duration: 2000 });
-  }, [canUndo, onUndo, addToast, t]);
-
-  const redoWithToast = useCallback(() => {
-    if (!canRedo) return;
-    onRedo?.();
-    addToast({ message: t('toast.redone'), type: 'info', duration: 2000 });
-  }, [canRedo, onRedo, addToast, t]);
-
-  // ── Drag lifecycle ─────────────────────────────────────────────────
-
-  const startDrag = useCallback(
-    (id: string, mmX: number, mmY: number, altKey?: boolean) => {
-      // Locked cutouts cannot be dragged
-      const target = cutouts.find((c) => c.id === id);
-      if (target?.locked) return;
-
-      // Determine effective selection, handling stale closure for grouped cutouts.
-      // When clicking a grouped cutout, selectCutout runs first and sets selection
-      // to the whole group, but React batches updates so `selection` here may still
-      // be the old value. Compute the correct set eagerly.
-      let effectiveSelection: ReadonlySet<string>;
-      if (selection.has(id)) {
-        effectiveSelection = selection;
-      } else {
-        const cutout = cutouts.find((c) => c.id === id);
-        if (cutout?.groupId) {
-          const groupIds = cutouts.filter((c) => c.groupId === cutout.groupId).map((c) => c.id);
-          effectiveSelection = new Set(groupIds);
-        } else {
-          effectiveSelection = new Set([id]);
-        }
-        setSelection(effectiveSelection);
-      }
-
-      // Block drag if any member of the effective selection is locked
-      const anyLocked = cutouts.some((c) => effectiveSelection.has(c.id) && c.locked);
-      if (anyLocked) return;
-
-      // Alt+drag: duplicate selected cutouts in-place, then drag the clones
-      let dragSelection = effectiveSelection;
-      let cloneOriginMap: ReadonlyMap<string, string> | null = null;
-      if (altKey) {
-        const selected = cutouts.filter((c) => effectiveSelection.has(c.id));
-        const clones = addClonedCutouts(selected, onAdd, setSelection);
-        cloneOriginMap = new Map(clones.map((c) => [c.id, c.originalId]));
-        dragSelection = new Set(clones.map((c) => c.id));
-      }
-
-      // Store offset from cursor to each selected cutout's origin
-      const offsets = new Map<string, { dx: number; dy: number }>();
-      for (const selectedId of dragSelection) {
-        const lookupId = cloneOriginMap?.get(selectedId) ?? selectedId;
-        const cutout = cutouts.find((c) => c.id === lookupId);
-        if (cutout) {
-          offsets.set(selectedId, { dx: cutout.x - mmX, dy: cutout.y - mmY });
-        }
-      }
-
-      pastDeadZoneRef.current = false;
-      setMode({ type: 'dragging', startX: mmX, startY: mmY, offsets });
-    },
-    [selection, cutouts, onAdd]
-  );
-
-  // ── Resize lifecycle ───────────────────────────────────────────────
-
-  const startResize = useCallback(
-    (id: string, handle: ResizeHandle, _mmX: number, _mmY: number) => {
-      const cutout = cutouts.find((c) => c.id === id);
-      if (!cutout) return;
-      if (cutout.locked) return;
-
-      pastDeadZoneRef.current = false;
-      setMode({
-        type: 'resizing',
-        cutoutId: id,
-        handle,
-        startRect: { x: cutout.x, y: cutout.y, width: cutout.width, depth: cutout.depth },
-      });
-    },
-    [cutouts]
-  );
-
-  // ── Rotate lifecycle ───────────────────────────────────────────────
-
-  const startRotation = useCallback(
-    (id: string, startAngle: number) => {
-      const cutout = cutouts.find((c) => c.id === id);
-      if (!cutout) return;
-      if (cutout.locked) return;
-
-      pastDeadZoneRef.current = false;
-      setMode({
-        type: 'rotating',
-        cutoutId: id,
-        startAngle,
-        initialRotation: cutout.rotation,
-      });
-    },
-    [cutouts]
-  );
-
-  // ── Group rotate lifecycle ─────────────────────────────────────────
-
-  const startGroupRotation = useCallback(
-    (startAngle: number) => {
-      const selectedCutouts = cutouts.filter((c) => selection.has(c.id));
-      if (selectedCutouts.length < 2) return;
-      const bounds = computeBounds(selectedCutouts);
-      const center = {
-        x: (bounds.minX + bounds.maxX) / 2,
-        y: (bounds.minY + bounds.maxY) / 2,
-      };
-      const initialStates = new Map<string, { x: number; y: number; rotation: number }>();
-      for (const c of selectedCutouts) {
-        initialStates.set(c.id, { x: c.x, y: c.y, rotation: c.rotation });
-      }
-      pastDeadZoneRef.current = false;
-      setMode({ type: 'group-rotating', startAngle, center, initialStates });
-    },
-    [cutouts, selection]
-  );
-
-  // ── Group scale lifecycle ──────────────────────────────────────────
-
-  const startGroupScale = useCallback(
-    (mmX: number, mmY: number) => {
-      const selectedCutouts = cutouts.filter((c) => selection.has(c.id));
-      if (selectedCutouts.length < 2) return;
-      const bounds = computeBounds(selectedCutouts);
-      const center = {
-        x: (bounds.minX + bounds.maxX) / 2,
-        y: (bounds.minY + bounds.maxY) / 2,
-      };
-      const startDist = Math.sqrt((mmX - center.x) ** 2 + (mmY - center.y) ** 2);
-      const initialStates = new Map<
-        string,
-        { x: number; y: number; width: number; depth: number }
-      >();
-      for (const c of selectedCutouts) {
-        initialStates.set(c.id, { x: c.x, y: c.y, width: c.width, depth: c.depth });
-      }
-      pastDeadZoneRef.current = false;
-      setMode({ type: 'group-scaling', startDist, center, initialStates });
-    },
-    [cutouts, selection]
-  );
-
-  // ── Pointer move — delegates to mode-specific handlers ─────────────
-
-  const handlePointerMove = useCallback(
-    (mmX: number, mmY: number, shiftKey?: boolean, altKey?: boolean) => {
-      const event = { mmX, mmY, shiftKey, altKey };
-      const bounds = { binWidth, binDepth, cellMask, maskCellSize };
-
-      switch (mode.type) {
-        case 'pending-place':
-          handlePendingPlaceMove(mode, event, setMode);
-          break;
-
-        case 'dragging':
-          handleDragMove(mode, event, cutouts, bounds, snap, pastDeadZoneRef, {
-            setPreview,
-            setActiveGuides,
-          });
-          break;
-
-        case 'resizing':
-          handleResizeMove(mode, event, cutouts, bounds, snap, pastDeadZoneRef, {
-            setPreview,
-          });
-          break;
-
-        case 'rotating':
-          handleRotateMove(mode, event, cutouts, bounds, pastDeadZoneRef, {
-            setPreview,
-          });
-          break;
-
-        case 'group-rotating':
-          handleGroupRotateMove(mode, event, cutouts, bounds, pastDeadZoneRef, {
-            setPreview,
-          });
-          break;
-
-        case 'group-scaling':
-          handleGroupScaleMove(mode, event, cutouts, bounds, pastDeadZoneRef, {
-            setPreview,
-          });
-          break;
-
-        case 'drawing':
-          handleDrawMove(mode, event, bounds, snap, {
-            setDrawingPreview,
-          });
-          break;
-
-        case 'path-drawing':
-          handlePathDrawingPointerMove(mode, event, bounds, snap, {
-            setMode,
-            setPathDrawingPreview,
-            commitPath,
-          });
-          break;
-
-        case 'vertex-editing': {
-          const editCutout = cutouts.find((c) => c.id === mode.cutoutId);
-          if (editCutout) {
-            handleVertexEditPointerMove(mode, event, editCutout, bounds, snap, {
-              setPreview,
-              setSegmentHover,
-            });
-          }
-          break;
-        }
-
-        case 'measuring': {
-          const snapped = snapToNearestTarget(mmX, mmY, rulerSnapTargets, rulerZoomRef.current);
-          setRulerMeasurement(computeMeasurement(mode.startX, mode.startY, snapped.x, snapped.y));
-          break;
-        }
-      }
-    },
-    [mode, cutouts, binWidth, binDepth, cellMask, maskCellSize, snap, commitPath, rulerSnapTargets]
-  );
-
-  // ── Pointer up (commit) ────────────────────────────────────────────
-
-  /** Click-to-place: create a default-sized shape centered at the click position. */
-  const commitPendingPlace = useCallback(
-    (placeMode: Extract<InteractionMode, { type: 'pending-place' }>) => {
-      const defaultSize = placeMode.shape === 'circle' ? DEFAULT_CIRCLE_SIZE : DEFAULT_RECT_SIZE;
-      const x = Math.max(
-        0,
-        Math.min(snap(placeMode.startMmX - defaultSize / 2), binWidth - defaultSize)
-      );
-      const y = Math.max(
-        0,
-        Math.min(snap(placeMode.startMmY - defaultSize / 2), binDepth - defaultSize)
-      );
-
-      // Polygon mask: reject click-to-place inside an unfilled notch.
-      if (
-        cellMask &&
-        maskCellSize &&
-        !rectFitsInMask(cellMask, x, y, defaultSize, defaultSize, maskCellSize)
-      ) {
-        setMode({ type: 'idle' });
-        return;
-      }
-
-      const newId = crypto.randomUUID();
-      onAdd(createDefaultCutout(newId, placeMode.shape, x, y, defaultSize, defaultSize));
-      setSelection(new Set([newId]));
-      setMode({ type: 'idle' });
-    },
-    [snap, binWidth, binDepth, cellMask, maskCellSize, onAdd]
-  );
-
-  /**
-   * Augment drag preview with translated path coordinates, then commit all
-   * preview updates to the store.
-   */
-  const commitTransformPreview = useCallback(
-    (isDrag: boolean) => {
-      if (!pastDeadZoneRef.current || preview.size === 0) return;
-
-      // For path cutouts during drag, translate absolute path point coordinates
-      // to match the new x/y bounding box position.
-      const augmented = new Map(preview);
-      if (isDrag) {
-        for (const [id, updates] of augmented) {
-          const cutout = cutouts.find((c) => c.id === id);
-          if (
-            cutout?.shape === 'path' &&
-            cutout.path &&
-            updates.x !== undefined &&
-            updates.y !== undefined
-          ) {
-            const dx = updates.x - cutout.x;
-            const dy = updates.y - cutout.y;
-            if (dx !== 0 || dy !== 0) {
-              augmented.set(id, {
-                ...updates,
-                path: cutout.path.map((pt) => ({
-                  ...pt,
-                  x: pt.x + dx,
-                  y: pt.y + dy,
-                })),
-              });
-            }
-          }
-        }
-      }
-      if (onUpdateBatch && augmented.size > 1) {
-        onUpdateBatch(augmented);
-      } else {
-        for (const [id, updates] of augmented) {
-          onUpdate(id, updates);
-        }
-      }
-    },
-    [preview, cutouts, onUpdate, onUpdateBatch]
-  );
-
-  /** Commit the draw-to-place preview as a new cutout. */
-  const commitDrawing = useCallback(() => {
-    if (
-      drawingPreview &&
-      drawingPreview.width >= MIN_CUTOUT_SIZE &&
-      drawingPreview.depth >= MIN_CUTOUT_SIZE
-    ) {
-      const newId = crypto.randomUUID();
-      onAdd(
-        createDefaultCutout(
-          newId,
-          drawingPreview.shape,
-          drawingPreview.x,
-          drawingPreview.y,
-          drawingPreview.width,
-          drawingPreview.depth
-        )
-      );
-      setSelection(new Set([newId]));
-    }
-    setDrawingPreview(null);
-    setMode({ type: 'idle' });
-  }, [drawingPreview, onAdd]);
-
-  const handlePointerUp = useCallback(() => {
-    switch (mode.type) {
-      case 'pending-place':
-        commitPendingPlace(mode);
-        return;
-
-      case 'dragging':
-      case 'resizing':
-      case 'rotating':
-      case 'group-rotating':
-      case 'group-scaling':
-        commitTransformPreview(mode.type === 'dragging');
-        setPreview(new Map());
-        setActiveGuides([]);
-        setMode({ type: 'idle' });
-        return;
-
-      case 'drawing':
-        commitDrawing();
-        return;
-
-      case 'path-drawing':
-        handlePathDrawingPointerUp(mode, { setMode });
-        return;
-
-      case 'vertex-editing': {
-        const editCutout = cutouts.find((c) => c.id === mode.cutoutId);
-        if (editCutout) {
-          handleVertexEditPointerUp(mode, editCutout, preview, {
-            setMode,
-            setPreview,
-            onUpdate,
-            setSegmentHover,
-          });
-        }
-        commitTransaction?.();
-        return;
-      }
-
-      case 'measuring':
-        // Sticky mode (toolbar): stay in ruler-ready for repeated measurements
-        // One-off (Shift+drag): return to idle
-        setMode({ type: mode.sticky ? 'ruler-ready' : 'idle' });
-        return;
-    }
-  }, [
-    mode,
-    preview,
+  const { clipboard, copySelected, pasteFromClipboard, duplicateSelected } = useCutoutClipboard({
     cutouts,
+    selection,
+    setSelection,
+    onAdd,
+    binWidth,
+    binDepth,
+    cellMask,
+    maskCellSize,
+  });
+
+  const { contextMenu, openContextMenu, closeContextMenu } = useCutoutContextMenu();
+
+  const { undoWithToast, redoWithToast } = useCutoutUndoToasts({
+    canUndo,
+    canRedo,
+    onUndo,
+    onRedo,
+  });
+
+  // ── Sub-hooks: path tool, transform lifecycle starters ────────────
+
+  const {
+    commitPath,
+    handlePathBackgroundDown,
+    onPathDrawingVertexDown,
+    enterVertexEditing,
+    handleVertexPointDown,
+    handleVertexHandleDown,
+    handleVertexBackgroundDown,
+  } = useCutoutPathTool({
+    mode,
+    setMode,
+    cutouts,
+    onAdd,
     onUpdate,
-    commitPendingPlace,
-    commitTransformPreview,
-    commitDrawing,
+    setSelection,
+    setPathDrawingPreview,
+    setPreview,
+    setSegmentHover,
+    snap,
+    binWidth,
+    binDepth,
+    cellMask,
+    maskCellSize,
+    startTransaction,
+  });
+
+  const { startDrag, startResize, startRotation, startGroupRotation, startGroupScale } =
+    useCutoutTransformStarters({
+      cutouts,
+      selection,
+      setSelection,
+      onAdd,
+      setMode,
+      pastDeadZoneRef,
+    });
+
+  // ── Sub-hook: pointer move/up dispatcher ──────────────────────────
+
+  const { handlePointerMove, handlePointerUp } = useCutoutPointerHandlers({
+    mode,
+    setMode,
+    cutouts,
+    preview,
+    setPreview,
+    setActiveGuides,
+    drawingPreview,
+    setDrawingPreview,
+    setPathDrawingPreview,
+    setSegmentHover,
+    setSelection,
+    setRulerMeasurement,
+    snap,
+    binWidth,
+    binDepth,
+    cellMask,
+    maskCellSize,
+    rulerSnapTargets,
+    rulerZoomRef,
+    pastDeadZoneRef,
+    commitPath,
+    onAdd,
+    onUpdate,
+    onUpdateBatch,
     commitTransaction,
-  ]);
+  });
 
-  // ── Keyboard shortcuts — delegates to handler ──────────────────────
+  // ── Sub-hooks: keyboard shortcuts, recovery effects ───────────────
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      handleCutoutKeyDown(e, {
-        selection,
-        cutouts,
-        mode,
-        deleteSelected,
-        deselectAll,
-        selectAll,
-        nudgeSelected,
-        copySelected,
-        pasteFromClipboard,
-        duplicateSelected,
-        onUndo: undoWithToast,
-        onRedo: redoWithToast,
-        onGroup,
-        onUngroup,
-        onUpdate,
-        onUpdateBatch,
-        onLock,
-        onUnlock,
-        setPreview,
-        clearActiveGuides: () => setActiveGuides([]),
-        clearDrawingPreview: () => setDrawingPreview(null),
-        clearPathDrawingPreview: () => setPathDrawingPreview(null),
-        setPathDrawingPreview,
-        setMode,
-        setSegmentHover,
-        setSelection,
-      });
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [
+  useCutoutKeyboardShortcuts({
     selection,
     cutouts,
+    mode,
     deleteSelected,
     deselectAll,
     selectAll,
@@ -1076,55 +323,24 @@ export function useCutoutInteraction({
     onUpdateBatch,
     onLock,
     onUnlock,
+    setPreview,
+    setActiveGuides,
+    setDrawingPreview,
+    setPathDrawingPreview,
+    setMode,
+    setSegmentHover,
+    setSelection,
+  });
+
+  useCutoutRecovery({
     mode,
-  ]);
-
-  // ── Recovery: reset on lost pointer / visibility change ────────────
-
-  useEffect(() => {
-    const reset = () => {
-      if (mode.type === 'path-drawing' && mode.activePointDrag) {
-        // Cancel in-progress handle drag but preserve the placed path points
-        setMode({ ...mode, activePointDrag: false, repositionIndex: null });
-        return;
-      }
-      if (
-        mode.type !== 'idle' &&
-        mode.type !== 'placing' &&
-        mode.type !== 'marquee' &&
-        mode.type !== 'vertex-editing' &&
-        mode.type !== 'path-drawing' &&
-        mode.type !== 'ruler-ready'
-      ) {
-        setPreview(new Map());
-        setActiveGuides([]);
-        setDrawingPreview(null);
-        setPathDrawingPreview(null);
-        setRulerMeasurement(null);
-        setMode({ type: 'idle' });
-      }
-    };
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === 'hidden') reset();
-    };
-    window.addEventListener('pointercancel', reset);
-    window.addEventListener('blur', reset);
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    return () => {
-      window.removeEventListener('pointercancel', reset);
-      window.removeEventListener('blur', reset);
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
-  }, [mode]);
-
-  // Clear ruler measurement when leaving ruler modes (e.g. pressing Escape)
-  /* eslint-disable react-hooks/set-state-in-effect -- clearing transient visual state when mode changes */
-  useEffect(() => {
-    if (mode.type !== 'measuring' && mode.type !== 'ruler-ready') {
-      setRulerMeasurement(null);
-    }
-  }, [mode.type]);
-  /* eslint-enable react-hooks/set-state-in-effect */
+    setMode,
+    setPreview,
+    setActiveGuides,
+    setDrawingPreview,
+    setPathDrawingPreview,
+    setRulerMeasurement,
+  });
 
   // ── Derived state ──────────────────────────────────────────────────
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutKeyboardShortcuts.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutKeyboardShortcuts.ts
@@ -1,0 +1,134 @@
+/**
+ * Keyboard shortcut effect for the cutout workspace.
+ *
+ * Wires the global `keydown` listener to `handleCutoutKeyDown`, which routes
+ * each event to the appropriate parent action (delete, copy, paste, nudge,
+ * undo, group, lock, etc.).
+ */
+
+import { useEffect } from 'react';
+import type { Cutout } from '@/features/bin-designer/types';
+import { handleCutoutKeyDown } from './handlers';
+import type { PathDrawingPreviewState, SegmentHoverInfo } from './handlers';
+import type { InteractionMode, PreviewMap } from './cutoutInteractionTypes';
+import type { AlignmentGuide } from './geometry';
+
+interface UseCutoutKeyboardShortcutsOptions {
+  readonly selection: ReadonlySet<string>;
+  readonly cutouts: readonly Cutout[];
+  readonly mode: InteractionMode;
+  readonly deleteSelected: () => void;
+  readonly deselectAll: () => void;
+  readonly selectAll: () => void;
+  readonly nudgeSelected: (dx: number, dy: number) => void;
+  readonly copySelected: () => void;
+  readonly pasteFromClipboard: () => void;
+  readonly duplicateSelected: () => void;
+  readonly undoWithToast: () => void;
+  readonly redoWithToast: () => void;
+  readonly onGroup?: (cutoutIds: readonly string[]) => void;
+  readonly onUngroup?: (cutoutIds: readonly string[]) => void;
+  readonly onUpdate: (id: string, updates: Partial<Cutout>) => void;
+  readonly onUpdateBatch?: (updates: ReadonlyMap<string, Partial<Cutout>>) => void;
+  readonly onLock?: (ids: readonly string[]) => void;
+  readonly onUnlock?: (ids: readonly string[]) => void;
+  readonly setPreview: (next: PreviewMap | ((prev: PreviewMap) => PreviewMap)) => void;
+  readonly setActiveGuides: React.Dispatch<React.SetStateAction<AlignmentGuide[]>>;
+  readonly setDrawingPreview: (next: null) => void;
+  readonly setPathDrawingPreview: (next: PathDrawingPreviewState | null) => void;
+  readonly setMode: (next: InteractionMode) => void;
+  readonly setSegmentHover: (next: SegmentHoverInfo | null) => void;
+  readonly setSelection: (next: ReadonlySet<string>) => void;
+}
+
+export function useCutoutKeyboardShortcuts(deps: UseCutoutKeyboardShortcutsOptions): void {
+  const {
+    selection,
+    cutouts,
+    mode,
+    deleteSelected,
+    deselectAll,
+    selectAll,
+    nudgeSelected,
+    copySelected,
+    pasteFromClipboard,
+    duplicateSelected,
+    undoWithToast,
+    redoWithToast,
+    onGroup,
+    onUngroup,
+    onUpdate,
+    onUpdateBatch,
+    onLock,
+    onUnlock,
+    setPreview,
+    setActiveGuides,
+    setDrawingPreview,
+    setPathDrawingPreview,
+    setMode,
+    setSegmentHover,
+    setSelection,
+  } = deps;
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      handleCutoutKeyDown(e, {
+        selection,
+        cutouts,
+        mode,
+        deleteSelected,
+        deselectAll,
+        selectAll,
+        nudgeSelected,
+        copySelected,
+        pasteFromClipboard,
+        duplicateSelected,
+        onUndo: undoWithToast,
+        onRedo: redoWithToast,
+        onGroup,
+        onUngroup,
+        onUpdate,
+        onUpdateBatch,
+        onLock,
+        onUnlock,
+        setPreview,
+        clearActiveGuides: () => setActiveGuides([]),
+        clearDrawingPreview: () => setDrawingPreview(null),
+        clearPathDrawingPreview: () => setPathDrawingPreview(null),
+        setPathDrawingPreview,
+        setMode,
+        setSegmentHover,
+        setSelection,
+      });
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [
+    selection,
+    cutouts,
+    mode,
+    deleteSelected,
+    deselectAll,
+    selectAll,
+    nudgeSelected,
+    copySelected,
+    pasteFromClipboard,
+    duplicateSelected,
+    undoWithToast,
+    redoWithToast,
+    onGroup,
+    onUngroup,
+    onUpdate,
+    onUpdateBatch,
+    onLock,
+    onUnlock,
+    setPreview,
+    setActiveGuides,
+    setDrawingPreview,
+    setPathDrawingPreview,
+    setMode,
+    setSegmentHover,
+    setSelection,
+  ]);
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPathTool.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPathTool.ts
@@ -1,0 +1,238 @@
+/**
+ * Path-drawing and vertex-editing handlers for the cutout workspace.
+ *
+ * The pen tool emits a sequence of clicks that build a path; this hook owns
+ * the transitions for "background click", "vertex click during draw", and the
+ * vertex-edit follow-up flow (point/handle/background down).
+ *
+ * Mask + bounds enforcement happens before commit so an invalid path silently
+ * resets to idle rather than producing geometry that overhangs the bin.
+ */
+
+import { useCallback } from 'react';
+import type { Cutout, PathPoint } from '@/features/bin-designer/types';
+import type { CellMask } from '@/shared/utils/cellMask';
+import {
+  handlePathDrawingPointerDown,
+  handlePathDrawingVertexDown,
+  handleVertexEditPointerDown,
+} from './handlers';
+import type { PathDrawingPreviewState, SegmentHoverInfo } from './handlers';
+import {
+  CLOSE_SNAP_THRESHOLD,
+  clampPathToBounds,
+  getPathBounds,
+  isSelfIntersecting,
+} from './pathGeometry';
+import { rectFitsInMask, type MaskCellSize } from './maskFit';
+import { createDefaultCutout } from './cutoutHelpers';
+import type { InteractionMode, PreviewMap } from './cutoutInteractionTypes';
+
+interface UseCutoutPathToolOptions {
+  readonly mode: InteractionMode;
+  readonly setMode: (mode: InteractionMode) => void;
+  readonly cutouts: readonly Cutout[];
+  readonly onAdd: (cutout: Cutout) => void;
+  readonly onUpdate: (id: string, updates: Partial<Cutout>) => void;
+  readonly setSelection: (sel: ReadonlySet<string>) => void;
+  readonly setPathDrawingPreview: (next: PathDrawingPreviewState | null) => void;
+  readonly setPreview: (next: PreviewMap | ((prev: PreviewMap) => PreviewMap)) => void;
+  readonly setSegmentHover: (next: SegmentHoverInfo | null) => void;
+  readonly snap: (v: number) => number;
+  readonly binWidth: number;
+  readonly binDepth: number;
+  readonly cellMask?: CellMask;
+  readonly maskCellSize?: MaskCellSize;
+  readonly startTransaction?: () => void;
+}
+
+export interface CutoutPathTool {
+  readonly commitPath: (points: readonly PathPoint[]) => void;
+  readonly handlePathBackgroundDown: (mmX: number, mmY: number, shiftKey: boolean) => void;
+  readonly onPathDrawingVertexDown: (index: number, mmX: number, mmY: number) => void;
+  readonly enterVertexEditing: (cutoutId: string) => void;
+  readonly handleVertexPointDown: (index: number, mmX: number, mmY: number) => void;
+  readonly handleVertexHandleDown: (
+    index: number,
+    handleType: 'in' | 'out',
+    mmX: number,
+    mmY: number
+  ) => void;
+  readonly handleVertexBackgroundDown: (mmX: number, mmY: number) => void;
+}
+
+export function useCutoutPathTool({
+  mode,
+  setMode,
+  cutouts,
+  onAdd,
+  onUpdate,
+  setSelection,
+  setPathDrawingPreview,
+  setPreview,
+  setSegmentHover,
+  snap,
+  binWidth,
+  binDepth,
+  cellMask,
+  maskCellSize,
+  startTransaction,
+}: UseCutoutPathToolOptions): CutoutPathTool {
+  /** Commit a closed path as a new cutout. */
+  const commitPath = useCallback(
+    (points: readonly PathPoint[]) => {
+      // Clamp to bin bounds so cutout never extends outside the bin surface
+      const clamped = clampPathToBounds(points, binWidth, binDepth);
+
+      // Reject self-intersecting paths that would produce invalid 3D geometry
+      if (isSelfIntersecting(clamped)) {
+        setPathDrawingPreview(null);
+        setMode({ type: 'idle' });
+        return;
+      }
+
+      const { minX, minY, maxX, maxY } = getPathBounds(clamped);
+
+      // Polygon bins: reject paths whose bounds overhang the mask.
+      if (
+        cellMask &&
+        maskCellSize &&
+        !rectFitsInMask(cellMask, minX, minY, maxX - minX, maxY - minY, maskCellSize)
+      ) {
+        setPathDrawingPreview(null);
+        setMode({ type: 'idle' });
+        return;
+      }
+
+      const newId = crypto.randomUUID();
+      onAdd({
+        ...createDefaultCutout(newId, 'path', minX, minY, maxX - minX, maxY - minY),
+        path: clamped,
+      });
+      setSelection(new Set([newId]));
+      setMode({ type: 'idle' });
+      setPathDrawingPreview(null);
+    },
+    [
+      onAdd,
+      setSelection,
+      setMode,
+      setPathDrawingPreview,
+      binWidth,
+      binDepth,
+      cellMask,
+      maskCellSize,
+    ]
+  );
+
+  /** Handle path background click (first click or subsequent). */
+  const handlePathBackgroundDown = useCallback(
+    (mmX: number, mmY: number, shiftKey: boolean) => {
+      const bounds = { binWidth, binDepth, cellMask, maskCellSize };
+      const pathMode = mode.type === 'path-drawing' ? mode : null;
+      handlePathDrawingPointerDown(pathMode, mmX, mmY, shiftKey, bounds, snap, {
+        setMode,
+        setPathDrawingPreview,
+        commitPath,
+      });
+    },
+    [
+      mode,
+      binWidth,
+      binDepth,
+      cellMask,
+      maskCellSize,
+      snap,
+      commitPath,
+      setMode,
+      setPathDrawingPreview,
+    ]
+  );
+
+  /** Handle clicking an existing vertex while drawing (to reposition or close). */
+  const onPathDrawingVertexDown = useCallback(
+    (index: number, _mmX: number, _mmY: number) => {
+      if (mode.type !== 'path-drawing') return;
+      handlePathDrawingVertexDown(mode, index, {
+        setMode,
+        setPathDrawingPreview,
+        commitPath,
+      });
+    },
+    [mode, commitPath, setMode, setPathDrawingPreview]
+  );
+
+  /** Enter vertex editing mode for a path cutout (on double-click). */
+  const enterVertexEditing = useCallback(
+    (cutoutId: string) => {
+      const cutout = cutouts.find((c) => c.id === cutoutId);
+      if (!cutout || cutout.shape !== 'path') return;
+      setSelection(new Set([cutoutId]));
+      setMode({
+        type: 'vertex-editing',
+        cutoutId,
+        selectedPointIndex: null,
+        dragTarget: null,
+      });
+    },
+    [cutouts, setSelection, setMode]
+  );
+
+  /** Handle vertex point down from PathEditOverlay3D. */
+  const handleVertexPointDown = useCallback(
+    (index: number, _mmX: number, _mmY: number) => {
+      if (mode.type !== 'vertex-editing') return;
+      startTransaction?.();
+      setMode({
+        ...mode,
+        selectedPointIndex: index,
+        dragTarget: { type: 'vertex', index },
+      });
+    },
+    [mode, startTransaction, setMode]
+  );
+
+  /** Handle vertex handle down from PathEditOverlay3D. */
+  const handleVertexHandleDown = useCallback(
+    (index: number, handleType: 'in' | 'out', _mmX: number, _mmY: number) => {
+      if (mode.type !== 'vertex-editing') return;
+      startTransaction?.();
+      setMode({
+        ...mode,
+        dragTarget: { type: 'handle', index, handleType },
+      });
+    },
+    [mode, startTransaction, setMode]
+  );
+
+  /** Handle background click during vertex editing (segment insertion or exit). */
+  const handleVertexBackgroundDown = useCallback(
+    (mmX: number, mmY: number) => {
+      if (mode.type !== 'vertex-editing') return;
+      const cutout = cutouts.find((c) => c.id === mode.cutoutId);
+      if (!cutout) {
+        setMode({ type: 'idle' });
+        return;
+      }
+      // Start a transaction so the split + any subsequent drag = one undo step
+      startTransaction?.();
+      handleVertexEditPointerDown(mode, { mmX, mmY, altKey: false }, cutout, CLOSE_SNAP_THRESHOLD, {
+        setMode,
+        setPreview,
+        onUpdate,
+        setSegmentHover,
+      });
+    },
+    [mode, cutouts, onUpdate, startTransaction, setMode, setPreview, setSegmentHover]
+  );
+
+  return {
+    commitPath,
+    handlePathBackgroundDown,
+    onPathDrawingVertexDown,
+    enterVertexEditing,
+    handleVertexPointDown,
+    handleVertexHandleDown,
+    handleVertexBackgroundDown,
+  };
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPointerHandlers.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPointerHandlers.ts
@@ -26,10 +26,8 @@ import {
 } from './handlers';
 import type { PathDrawingPreviewState, SegmentHoverInfo } from './handlers';
 import { snapToNearestTarget, computeMeasurement } from './handlers/rulerHandler';
-import type { RulerMeasurement, collectSnapTargets } from './handlers/rulerHandler';
+import type { RulerMeasurement, SnapTarget } from './handlers/rulerHandler';
 import { MIN_CUTOUT_SIZE, type AlignmentGuide } from './geometry';
-
-type RulerSnapTargets = ReturnType<typeof collectSnapTargets>;
 import { rectFitsInMask, type MaskCellSize } from './maskFit';
 import { createDefaultCutout } from './cutoutHelpers';
 import {
@@ -65,7 +63,7 @@ interface UseCutoutPointerHandlersOptions {
   readonly binDepth: number;
   readonly cellMask?: CellMask;
   readonly maskCellSize?: MaskCellSize;
-  readonly rulerSnapTargets: RulerSnapTargets;
+  readonly rulerSnapTargets: readonly SnapTarget[];
   readonly rulerZoomRef: React.RefObject<number>;
   readonly pastDeadZoneRef: React.RefObject<boolean>;
   readonly commitPath: (points: readonly PathPoint[]) => void;

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPointerHandlers.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPointerHandlers.ts
@@ -1,0 +1,376 @@
+/**
+ * Pointer move/up dispatcher for the cutout interaction state machine.
+ *
+ * `handlePointerMove` is a single switch over `mode.type` that routes the
+ * event to the appropriate domain handler (drag, resize, rotate, draw, path,
+ * vertex, ruler). `handlePointerUp` commits whatever transient state the
+ * current mode produced — pending place / drag preview / drawing preview /
+ * path / vertex edit / measurement.
+ */
+
+import { useCallback } from 'react';
+import type { Cutout, CutoutShape, PathPoint } from '@/features/bin-designer/types';
+import type { CellMask } from '@/shared/utils/cellMask';
+import {
+  handlePendingPlaceMove,
+  handleDragMove,
+  handleResizeMove,
+  handleRotateMove,
+  handleGroupRotateMove,
+  handleGroupScaleMove,
+  handleDrawMove,
+  handlePathDrawingPointerMove,
+  handlePathDrawingPointerUp,
+  handleVertexEditPointerMove,
+  handleVertexEditPointerUp,
+} from './handlers';
+import type { PathDrawingPreviewState, SegmentHoverInfo } from './handlers';
+import { snapToNearestTarget, computeMeasurement } from './handlers/rulerHandler';
+import type { RulerMeasurement, collectSnapTargets } from './handlers/rulerHandler';
+import { MIN_CUTOUT_SIZE, type AlignmentGuide } from './geometry';
+
+type RulerSnapTargets = ReturnType<typeof collectSnapTargets>;
+import { rectFitsInMask, type MaskCellSize } from './maskFit';
+import { createDefaultCutout } from './cutoutHelpers';
+import {
+  type InteractionMode,
+  type PreviewMap,
+  DEFAULT_RECT_SIZE,
+  DEFAULT_CIRCLE_SIZE,
+} from './cutoutInteractionTypes';
+
+interface DrawingPreviewState {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly depth: number;
+  readonly shape: CutoutShape;
+}
+
+interface UseCutoutPointerHandlersOptions {
+  readonly mode: InteractionMode;
+  readonly setMode: (next: InteractionMode) => void;
+  readonly cutouts: readonly Cutout[];
+  readonly preview: PreviewMap;
+  readonly setPreview: (next: PreviewMap | ((prev: PreviewMap) => PreviewMap)) => void;
+  readonly setActiveGuides: React.Dispatch<React.SetStateAction<AlignmentGuide[]>>;
+  readonly drawingPreview: DrawingPreviewState | null;
+  readonly setDrawingPreview: (next: DrawingPreviewState | null) => void;
+  readonly setPathDrawingPreview: (next: PathDrawingPreviewState | null) => void;
+  readonly setSegmentHover: (next: SegmentHoverInfo | null) => void;
+  readonly setSelection: (next: ReadonlySet<string>) => void;
+  readonly setRulerMeasurement: (next: RulerMeasurement | null) => void;
+  readonly snap: (v: number) => number;
+  readonly binWidth: number;
+  readonly binDepth: number;
+  readonly cellMask?: CellMask;
+  readonly maskCellSize?: MaskCellSize;
+  readonly rulerSnapTargets: RulerSnapTargets;
+  readonly rulerZoomRef: React.RefObject<number>;
+  readonly pastDeadZoneRef: React.RefObject<boolean>;
+  readonly commitPath: (points: readonly PathPoint[]) => void;
+  readonly onAdd: (cutout: Cutout) => void;
+  readonly onUpdate: (id: string, updates: Partial<Cutout>) => void;
+  readonly onUpdateBatch?: (updates: ReadonlyMap<string, Partial<Cutout>>) => void;
+  readonly commitTransaction?: () => void;
+}
+
+export interface CutoutPointerHandlers {
+  readonly handlePointerMove: (
+    mmX: number,
+    mmY: number,
+    shiftKey?: boolean,
+    altKey?: boolean
+  ) => void;
+  readonly handlePointerUp: () => void;
+}
+
+export function useCutoutPointerHandlers(
+  opts: UseCutoutPointerHandlersOptions
+): CutoutPointerHandlers {
+  const {
+    mode,
+    setMode,
+    cutouts,
+    preview,
+    setPreview,
+    setActiveGuides,
+    drawingPreview,
+    setDrawingPreview,
+    setPathDrawingPreview,
+    setSegmentHover,
+    setSelection,
+    setRulerMeasurement,
+    snap,
+    binWidth,
+    binDepth,
+    cellMask,
+    maskCellSize,
+    rulerSnapTargets,
+    rulerZoomRef,
+    pastDeadZoneRef,
+    commitPath,
+    onAdd,
+    onUpdate,
+    onUpdateBatch,
+    commitTransaction,
+  } = opts;
+
+  const handlePointerMove = useCallback(
+    (mmX: number, mmY: number, shiftKey?: boolean, altKey?: boolean) => {
+      const event = { mmX, mmY, shiftKey, altKey };
+      const bounds = { binWidth, binDepth, cellMask, maskCellSize };
+
+      switch (mode.type) {
+        case 'pending-place':
+          handlePendingPlaceMove(mode, event, setMode);
+          break;
+
+        case 'dragging':
+          handleDragMove(mode, event, cutouts, bounds, snap, pastDeadZoneRef, {
+            setPreview,
+            setActiveGuides,
+          });
+          break;
+
+        case 'resizing':
+          handleResizeMove(mode, event, cutouts, bounds, snap, pastDeadZoneRef, {
+            setPreview,
+          });
+          break;
+
+        case 'rotating':
+          handleRotateMove(mode, event, cutouts, bounds, pastDeadZoneRef, {
+            setPreview,
+          });
+          break;
+
+        case 'group-rotating':
+          handleGroupRotateMove(mode, event, cutouts, bounds, pastDeadZoneRef, {
+            setPreview,
+          });
+          break;
+
+        case 'group-scaling':
+          handleGroupScaleMove(mode, event, cutouts, bounds, pastDeadZoneRef, {
+            setPreview,
+          });
+          break;
+
+        case 'drawing':
+          handleDrawMove(mode, event, bounds, snap, {
+            setDrawingPreview,
+          });
+          break;
+
+        case 'path-drawing':
+          handlePathDrawingPointerMove(mode, event, bounds, snap, {
+            setMode,
+            setPathDrawingPreview,
+            commitPath,
+          });
+          break;
+
+        case 'vertex-editing': {
+          const editCutout = cutouts.find((c) => c.id === mode.cutoutId);
+          if (editCutout) {
+            handleVertexEditPointerMove(mode, event, editCutout, bounds, snap, {
+              setPreview,
+              setSegmentHover,
+            });
+          }
+          break;
+        }
+
+        case 'measuring': {
+          const snapped = snapToNearestTarget(mmX, mmY, rulerSnapTargets, rulerZoomRef.current);
+          setRulerMeasurement(computeMeasurement(mode.startX, mode.startY, snapped.x, snapped.y));
+          break;
+        }
+      }
+    },
+    [
+      mode,
+      cutouts,
+      binWidth,
+      binDepth,
+      cellMask,
+      maskCellSize,
+      snap,
+      commitPath,
+      rulerSnapTargets,
+      rulerZoomRef,
+      pastDeadZoneRef,
+      setMode,
+      setPreview,
+      setActiveGuides,
+      setDrawingPreview,
+      setPathDrawingPreview,
+      setSegmentHover,
+      setRulerMeasurement,
+    ]
+  );
+
+  /** Click-to-place: create a default-sized shape centered at the click position. */
+  const commitPendingPlace = useCallback(
+    (placeMode: Extract<InteractionMode, { type: 'pending-place' }>) => {
+      const defaultSize = placeMode.shape === 'circle' ? DEFAULT_CIRCLE_SIZE : DEFAULT_RECT_SIZE;
+      const x = Math.max(
+        0,
+        Math.min(snap(placeMode.startMmX - defaultSize / 2), binWidth - defaultSize)
+      );
+      const y = Math.max(
+        0,
+        Math.min(snap(placeMode.startMmY - defaultSize / 2), binDepth - defaultSize)
+      );
+
+      // Polygon mask: reject click-to-place inside an unfilled notch.
+      if (
+        cellMask &&
+        maskCellSize &&
+        !rectFitsInMask(cellMask, x, y, defaultSize, defaultSize, maskCellSize)
+      ) {
+        setMode({ type: 'idle' });
+        return;
+      }
+
+      const newId = crypto.randomUUID();
+      onAdd(createDefaultCutout(newId, placeMode.shape, x, y, defaultSize, defaultSize));
+      setSelection(new Set([newId]));
+      setMode({ type: 'idle' });
+    },
+    [snap, binWidth, binDepth, cellMask, maskCellSize, onAdd, setSelection, setMode]
+  );
+
+  /**
+   * Augment drag preview with translated path coordinates, then commit all
+   * preview updates to the store.
+   */
+  const commitTransformPreview = useCallback(
+    (isDrag: boolean) => {
+      if (!pastDeadZoneRef.current || preview.size === 0) return;
+
+      // For path cutouts during drag, translate absolute path point coordinates
+      // to match the new x/y bounding box position.
+      const augmented = new Map(preview);
+      if (isDrag) {
+        for (const [id, updates] of augmented) {
+          const cutout = cutouts.find((c) => c.id === id);
+          if (
+            cutout?.shape === 'path' &&
+            cutout.path &&
+            updates.x !== undefined &&
+            updates.y !== undefined
+          ) {
+            const dx = updates.x - cutout.x;
+            const dy = updates.y - cutout.y;
+            if (dx !== 0 || dy !== 0) {
+              augmented.set(id, {
+                ...updates,
+                path: cutout.path.map((pt) => ({
+                  ...pt,
+                  x: pt.x + dx,
+                  y: pt.y + dy,
+                })),
+              });
+            }
+          }
+        }
+      }
+      if (onUpdateBatch && augmented.size > 1) {
+        onUpdateBatch(augmented);
+      } else {
+        for (const [id, updates] of augmented) {
+          onUpdate(id, updates);
+        }
+      }
+    },
+    [preview, cutouts, onUpdate, onUpdateBatch, pastDeadZoneRef]
+  );
+
+  /** Commit the draw-to-place preview as a new cutout. */
+  const commitDrawing = useCallback(() => {
+    if (
+      drawingPreview &&
+      drawingPreview.width >= MIN_CUTOUT_SIZE &&
+      drawingPreview.depth >= MIN_CUTOUT_SIZE
+    ) {
+      const newId = crypto.randomUUID();
+      onAdd(
+        createDefaultCutout(
+          newId,
+          drawingPreview.shape,
+          drawingPreview.x,
+          drawingPreview.y,
+          drawingPreview.width,
+          drawingPreview.depth
+        )
+      );
+      setSelection(new Set([newId]));
+    }
+    setDrawingPreview(null);
+    setMode({ type: 'idle' });
+  }, [drawingPreview, onAdd, setSelection, setDrawingPreview, setMode]);
+
+  const handlePointerUp = useCallback(() => {
+    switch (mode.type) {
+      case 'pending-place':
+        commitPendingPlace(mode);
+        return;
+
+      case 'dragging':
+      case 'resizing':
+      case 'rotating':
+      case 'group-rotating':
+      case 'group-scaling':
+        commitTransformPreview(mode.type === 'dragging');
+        setPreview(new Map());
+        setActiveGuides([]);
+        setMode({ type: 'idle' });
+        return;
+
+      case 'drawing':
+        commitDrawing();
+        return;
+
+      case 'path-drawing':
+        handlePathDrawingPointerUp(mode, { setMode });
+        return;
+
+      case 'vertex-editing': {
+        const editCutout = cutouts.find((c) => c.id === mode.cutoutId);
+        if (editCutout) {
+          handleVertexEditPointerUp(mode, editCutout, preview, {
+            setMode,
+            setPreview,
+            onUpdate,
+            setSegmentHover,
+          });
+        }
+        commitTransaction?.();
+        return;
+      }
+
+      case 'measuring':
+        // Sticky mode (toolbar): stay in ruler-ready for repeated measurements
+        // One-off (Shift+drag): return to idle
+        setMode({ type: mode.sticky ? 'ruler-ready' : 'idle' });
+        return;
+    }
+  }, [
+    mode,
+    preview,
+    cutouts,
+    onUpdate,
+    commitPendingPlace,
+    commitTransformPreview,
+    commitDrawing,
+    commitTransaction,
+    setMode,
+    setPreview,
+    setActiveGuides,
+    setSegmentHover,
+  ]);
+
+  return { handlePointerMove, handlePointerUp };
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutRecovery.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutRecovery.ts
@@ -1,0 +1,93 @@
+/**
+ * Recovery effects for the cutout interaction state machine.
+ *
+ * Listens for `pointercancel`, `blur`, and `visibilitychange` to drop
+ * preview/drag state when the user backgrounds the tab, switches windows,
+ * or otherwise loses pointer capture mid-interaction. Also clears ruler
+ * measurement when leaving ruler modes.
+ */
+
+import { useEffect } from 'react';
+import type { PathDrawingPreviewState } from './handlers';
+import type { RulerMeasurement } from './handlers/rulerHandler';
+import type { InteractionMode, PreviewMap } from './cutoutInteractionTypes';
+import type { AlignmentGuide } from './geometry';
+
+interface DrawingPreviewState {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly depth: number;
+  readonly shape: 'rectangle' | 'circle' | 'path';
+}
+
+interface UseCutoutRecoveryOptions {
+  readonly mode: InteractionMode;
+  readonly setMode: (next: InteractionMode) => void;
+  readonly setPreview: (next: PreviewMap) => void;
+  readonly setActiveGuides: (next: AlignmentGuide[]) => void;
+  readonly setDrawingPreview: (next: DrawingPreviewState | null) => void;
+  readonly setPathDrawingPreview: (next: PathDrawingPreviewState | null) => void;
+  readonly setRulerMeasurement: (next: RulerMeasurement | null) => void;
+}
+
+export function useCutoutRecovery({
+  mode,
+  setMode,
+  setPreview,
+  setActiveGuides,
+  setDrawingPreview,
+  setPathDrawingPreview,
+  setRulerMeasurement,
+}: UseCutoutRecoveryOptions): void {
+  useEffect(() => {
+    const reset = () => {
+      if (mode.type === 'path-drawing' && mode.activePointDrag) {
+        // Cancel in-progress handle drag but preserve the placed path points
+        setMode({ ...mode, activePointDrag: false, repositionIndex: null });
+        return;
+      }
+      if (
+        mode.type !== 'idle' &&
+        mode.type !== 'placing' &&
+        mode.type !== 'marquee' &&
+        mode.type !== 'vertex-editing' &&
+        mode.type !== 'path-drawing' &&
+        mode.type !== 'ruler-ready'
+      ) {
+        setPreview(new Map());
+        setActiveGuides([]);
+        setDrawingPreview(null);
+        setPathDrawingPreview(null);
+        setRulerMeasurement(null);
+        setMode({ type: 'idle' });
+      }
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') reset();
+    };
+    window.addEventListener('pointercancel', reset);
+    window.addEventListener('blur', reset);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      window.removeEventListener('pointercancel', reset);
+      window.removeEventListener('blur', reset);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [
+    mode,
+    setMode,
+    setPreview,
+    setActiveGuides,
+    setDrawingPreview,
+    setPathDrawingPreview,
+    setRulerMeasurement,
+  ]);
+
+  // Clear ruler measurement when leaving ruler modes (e.g. pressing Escape)
+  useEffect(() => {
+    if (mode.type !== 'measuring' && mode.type !== 'ruler-ready') {
+      setRulerMeasurement(null);
+    }
+  }, [mode.type, setRulerMeasurement]);
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutTransformStarters.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutTransformStarters.ts
@@ -1,0 +1,175 @@
+/**
+ * Transform-lifecycle starters for the cutout workspace.
+ *
+ * Each `start*` callback transitions `mode` from idle/selected into a
+ * dragging/resizing/rotating state, capturing the initial geometry needed
+ * to compute deltas during pointer-move.
+ *
+ * Locked-cutout guards live here so a stray click on a locked shape can't
+ * begin a transform; group-aware drag selection handles the React-batching
+ * staleness that would otherwise leave a single-id selection at drag start.
+ */
+
+import { useCallback } from 'react';
+import type { Cutout } from '@/features/bin-designer/types';
+import { computeBounds } from './geometry';
+import { addClonedCutouts } from './cutoutHelpers';
+import type { InteractionMode, ResizeHandle } from './cutoutInteractionTypes';
+
+interface UseCutoutTransformStartersOptions {
+  readonly cutouts: readonly Cutout[];
+  readonly selection: ReadonlySet<string>;
+  readonly setSelection: (sel: ReadonlySet<string>) => void;
+  readonly onAdd: (cutout: Cutout) => void;
+  readonly setMode: (mode: InteractionMode) => void;
+  readonly pastDeadZoneRef: React.RefObject<boolean>;
+}
+
+export interface CutoutTransformStarters {
+  readonly startDrag: (id: string, mmX: number, mmY: number, altKey?: boolean) => void;
+  readonly startResize: (id: string, handle: ResizeHandle, mmX: number, mmY: number) => void;
+  readonly startRotation: (id: string, startAngle: number) => void;
+  readonly startGroupRotation: (startAngle: number) => void;
+  readonly startGroupScale: (mmX: number, mmY: number) => void;
+}
+
+export function useCutoutTransformStarters({
+  cutouts,
+  selection,
+  setSelection,
+  onAdd,
+  setMode,
+  pastDeadZoneRef,
+}: UseCutoutTransformStartersOptions): CutoutTransformStarters {
+  const startDrag = useCallback(
+    (id: string, mmX: number, mmY: number, altKey?: boolean) => {
+      // Locked cutouts cannot be dragged
+      const target = cutouts.find((c) => c.id === id);
+      if (target?.locked) return;
+
+      // Determine effective selection, handling stale closure for grouped cutouts.
+      // When clicking a grouped cutout, selectCutout runs first and sets selection
+      // to the whole group, but React batches updates so `selection` here may still
+      // be the old value. Compute the correct set eagerly.
+      let effectiveSelection: ReadonlySet<string>;
+      if (selection.has(id)) {
+        effectiveSelection = selection;
+      } else {
+        const cutout = cutouts.find((c) => c.id === id);
+        if (cutout?.groupId) {
+          const groupIds = cutouts.filter((c) => c.groupId === cutout.groupId).map((c) => c.id);
+          effectiveSelection = new Set(groupIds);
+        } else {
+          effectiveSelection = new Set([id]);
+        }
+        setSelection(effectiveSelection);
+      }
+
+      // Block drag if any member of the effective selection is locked
+      const anyLocked = cutouts.some((c) => effectiveSelection.has(c.id) && c.locked);
+      if (anyLocked) return;
+
+      // Alt+drag: duplicate selected cutouts in-place, then drag the clones
+      let dragSelection = effectiveSelection;
+      let cloneOriginMap: ReadonlyMap<string, string> | null = null;
+      if (altKey) {
+        const selected = cutouts.filter((c) => effectiveSelection.has(c.id));
+        const clones = addClonedCutouts(selected, onAdd, setSelection);
+        cloneOriginMap = new Map(clones.map((c) => [c.id, c.originalId]));
+        dragSelection = new Set(clones.map((c) => c.id));
+      }
+
+      // Store offset from cursor to each selected cutout's origin
+      const offsets = new Map<string, { dx: number; dy: number }>();
+      for (const selectedId of dragSelection) {
+        const lookupId = cloneOriginMap?.get(selectedId) ?? selectedId;
+        const cutout = cutouts.find((c) => c.id === lookupId);
+        if (cutout) {
+          offsets.set(selectedId, { dx: cutout.x - mmX, dy: cutout.y - mmY });
+        }
+      }
+
+      pastDeadZoneRef.current = false;
+      setMode({ type: 'dragging', startX: mmX, startY: mmY, offsets });
+    },
+    [selection, cutouts, onAdd, setSelection, setMode, pastDeadZoneRef]
+  );
+
+  const startResize = useCallback(
+    (id: string, handle: ResizeHandle, _mmX: number, _mmY: number) => {
+      const cutout = cutouts.find((c) => c.id === id);
+      if (!cutout) return;
+      if (cutout.locked) return;
+
+      pastDeadZoneRef.current = false;
+      setMode({
+        type: 'resizing',
+        cutoutId: id,
+        handle,
+        startRect: { x: cutout.x, y: cutout.y, width: cutout.width, depth: cutout.depth },
+      });
+    },
+    [cutouts, setMode, pastDeadZoneRef]
+  );
+
+  const startRotation = useCallback(
+    (id: string, startAngle: number) => {
+      const cutout = cutouts.find((c) => c.id === id);
+      if (!cutout) return;
+      if (cutout.locked) return;
+
+      pastDeadZoneRef.current = false;
+      setMode({
+        type: 'rotating',
+        cutoutId: id,
+        startAngle,
+        initialRotation: cutout.rotation,
+      });
+    },
+    [cutouts, setMode, pastDeadZoneRef]
+  );
+
+  const startGroupRotation = useCallback(
+    (startAngle: number) => {
+      const selectedCutouts = cutouts.filter((c) => selection.has(c.id));
+      if (selectedCutouts.length < 2) return;
+      const bounds = computeBounds(selectedCutouts);
+      const center = {
+        x: (bounds.minX + bounds.maxX) / 2,
+        y: (bounds.minY + bounds.maxY) / 2,
+      };
+      const initialStates = new Map<string, { x: number; y: number; rotation: number }>();
+      for (const c of selectedCutouts) {
+        initialStates.set(c.id, { x: c.x, y: c.y, rotation: c.rotation });
+      }
+      pastDeadZoneRef.current = false;
+      setMode({ type: 'group-rotating', startAngle, center, initialStates });
+    },
+    [cutouts, selection, setMode, pastDeadZoneRef]
+  );
+
+  const startGroupScale = useCallback(
+    (mmX: number, mmY: number) => {
+      const selectedCutouts = cutouts.filter((c) => selection.has(c.id));
+      if (selectedCutouts.length < 2) return;
+      const bounds = computeBounds(selectedCutouts);
+      const center = {
+        x: (bounds.minX + bounds.maxX) / 2,
+        y: (bounds.minY + bounds.maxY) / 2,
+      };
+      const startDist = Math.sqrt((mmX - center.x) ** 2 + (mmY - center.y) ** 2);
+      const initialStates = new Map<
+        string,
+        { x: number; y: number; width: number; depth: number }
+      >();
+      for (const c of selectedCutouts) {
+        initialStates.set(c.id, { x: c.x, y: c.y, width: c.width, depth: c.depth });
+      }
+      pastDeadZoneRef.current = false;
+      setMode({ type: 'group-scaling', startDist, center, initialStates });
+    },
+    [cutouts, selection, setMode, pastDeadZoneRef]
+  );
+
+  return { startDrag, startResize, startRotation, startGroupRotation, startGroupScale };
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutUndoToasts.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutUndoToasts.ts
@@ -1,0 +1,46 @@
+/**
+ * Undo/redo wrappers that emit toast feedback.
+ *
+ * Pure UI sugar — the actual undo/redo lives in the host store; this hook
+ * just couples it to the shared toast queue so the user gets confirmation.
+ */
+
+import { useCallback } from 'react';
+import { useToastStore } from '@/core/store/toast';
+import { useTranslation } from '@/i18n';
+
+interface UseCutoutUndoToastsOptions {
+  readonly canUndo?: boolean;
+  readonly canRedo?: boolean;
+  readonly onUndo?: () => void;
+  readonly onRedo?: () => void;
+}
+
+export interface CutoutUndoToasts {
+  readonly undoWithToast: () => void;
+  readonly redoWithToast: () => void;
+}
+
+export function useCutoutUndoToasts({
+  canUndo,
+  canRedo,
+  onUndo,
+  onRedo,
+}: UseCutoutUndoToastsOptions): CutoutUndoToasts {
+  const addToast = useToastStore((s) => s.addToast);
+  const t = useTranslation();
+
+  const undoWithToast = useCallback(() => {
+    if (!canUndo) return;
+    onUndo?.();
+    addToast({ message: t('toast.undone'), type: 'info', duration: 2000 });
+  }, [canUndo, onUndo, addToast, t]);
+
+  const redoWithToast = useCallback(() => {
+    if (!canRedo) return;
+    onRedo?.();
+    addToast({ message: t('toast.redone'), type: 'info', duration: 2000 });
+  }, [canRedo, onRedo, addToast, t]);
+
+  return { undoWithToast, redoWithToast };
+}


### PR DESCRIPTION
## Summary

Decompose the 1213-LOC `useCutoutInteraction.ts` into 9 sibling files organized by concern. The parent hook becomes a thin orchestrator (429 LOC) that owns the shared state machine and composes domain-specific sub-hooks. The hook's return shape is identical, so all consumers (CutoutWorkspace, etc.) are unchanged.

### Decomposition

| File | LOC | Concern |
|---|---|---|
| `cutoutInteractionTypes.ts` | 119 | `InteractionMode` union, `ResizeHandle`, `PreviewMap`, options interface, size constants |
| `cutoutHelpers.ts` | 96 | Pure helpers: clone-with-groups, paste-clamp, addClonedCutouts, createDefaultCutout |
| `useCutoutClipboard.ts` | 105 | Clipboard state + mask-aware copy/paste/duplicate |
| `useCutoutContextMenu.ts` | 28 | Right-click menu state |
| `useCutoutUndoToasts.ts` | 46 | Toast-wrapped undo/redo |
| `useCutoutKeyboardShortcuts.ts` | 134 | `keydown` listener effect |
| `useCutoutRecovery.ts` | 93 | `pointercancel` / `blur` / `visibilitychange` resets + ruler cleanup |
| `useCutoutTransformStarters.ts` | 175 | `start*` handlers (drag/resize/rotate/group-rotate/group-scale) |
| `useCutoutPathTool.ts` | 238 | Path drawing + vertex editing handlers |
| `useCutoutPointerHandlers.ts` | 376 | `handlePointerMove` dispatcher + `handlePointerUp` + three commit fns |

`useCutoutInteraction.ts`: **1213 LOC → 429 LOC**. The orchestrator now holds only the shared state declarations (mode, selection, preview, snap, ruler, etc.), the selection/bulk callbacks (selectCutout, deselectAll, deleteSelected, nudgeSelected), the store-sync effects, and the sub-hook composition.

### Public API preserved

`useCutoutInteraction`'s return shape is byte-identical to before. Type re-exports (`ResizeHandle`, `InteractionMode`, `PreviewMap`) are preserved at the parent hook so existing import paths continue to resolve.

### Incidental cleanup

- Replaced deprecated `React.MutableRefObject` with `React.RefObject` on new sub-hook signatures (no behavior change — just the React 19 type).
- Removed an `eslint-disable react-hooks/set-state-in-effect` that the rule no longer flags after the recovery effect was restructured.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` — 0 warnings
- [x] `pnpm run test:run` — **703 test files / 10,278 tests pass**, including the existing `useCutoutInteraction.test.ts` suite which exercises the public hook surface end-to-end
- [x] `pnpm run build` — succeeds

This is PR 3 in the gap-closing series. PR 1 (#1513) and PR 2 (#1514) are merged.