### PR TITLE
refactor(generation): split GenerationBridge into focused modules

### DIFF
--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -7,217 +7,89 @@
  * Includes params-level deduplication: if generate() is called with the same
  * parameters as the last successful generation, the cached result is returned
  * immediately without dispatching to the worker.
+ *
+ * The class itself focuses on the lifecycle state machine. Concern-specific
+ * pieces live in sibling modules:
+ *   - `bridgeTypes.ts`: public types + `ExportTimeoutError`
+ *   - `bridgeHelpers.ts`: `paramsFingerprint`, threading-info validation,
+ *     dedup-cache initialization
+ *   - `bridgeMessageHandler.ts`: worker `error` + `message` listener install
+ *   - `bridgeExports.ts`: the 8 export methods (delegated 1:1 from this class)
  */
 
 import type { BinParams, BaseplateParams, SplitConnectorConfig } from '@/shared/types/bin';
-import type {
-  WorkerMessage,
-  WorkerResponse,
-  WorkerCacheStats,
-  MeshData,
-  GenerationStage,
-  ExportFormat,
-  ExportErrorCode,
-  SplitExportPiece,
-  SplitPreviewPiece,
-  CombinedExportPiece,
-  FaceGroupData,
-  KernelName,
-  KernelPerfCategory,
-} from './types';
+import type { WorkerMessage, WorkerResponse, WorkerCacheStats, ExportFormat } from './types';
 import { AdaptiveDebounce } from './adaptiveDebounce';
-import { computeBaseplateTimeoutMs, computeGenerationTimeoutMs } from './generationTimeout';
+import {
+  generateBin as generateBinImpl,
+  generateBaseplate as generateBaseplateImpl,
+} from './bridgeGeneration';
+import {
+  ExportTimeoutError,
+  type ProgressCallback,
+  type GenerationResult,
+  type ExportResult,
+  type DividersExportResult,
+  type CombinedExportResult,
+  type SplitExportResult,
+  type SplitPreviewResult,
+  type BaseplateExportResult,
+  type CacheStatsCallback,
+  type KernelPerfStatsCallback,
+  type ThreadingInfo,
+  type DedupCache,
+  type ExportSlot,
+  type PendingExport,
+} from './bridgeTypes';
+import { extractThreadingInfo, createDedupCache } from './bridgeHelpers';
+import { installMessageHandler } from './bridgeMessageHandler';
+import {
+  exportBin as exportBinImpl,
+  exportDividers as exportDividersImpl,
+  exportCombined as exportCombinedImpl,
+  exportSplitBin as exportSplitBinImpl,
+  generateSplitPreview as generateSplitPreviewImpl,
+  generateSplitPreviewRange as generateSplitPreviewRangeImpl,
+  exportSplitBinRange as exportSplitBinRangeImpl,
+  exportBaseplate as exportBaseplateImpl,
+} from './bridgeExports';
+import type { KernelName } from './types';
 
-/**
- * Deterministic fingerprint for generation params.
- *
- * Uses JSON.stringify with sorted keys to ensure identical params always
- * produce the same string, regardless of property insertion order.
- */
-function paramsFingerprint(params: unknown): string {
-  return JSON.stringify(params, (_, value: unknown) => {
-    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-      const sorted: Record<string, unknown> = {};
-      for (const key of Object.keys(value).sort()) {
-        sorted[key] = (value as Record<string, unknown>)[key];
-      }
-      return sorted;
-    }
-    return value;
-  });
-}
-
-/** Extract threading info from INIT_READY with defensive validation. */
-function extractThreadingInfo(data: {
-  isThreaded: boolean;
-  hardwareConcurrency: number;
-  kernel: KernelName;
-}): ThreadingInfo {
-  const isThreaded = typeof data.isThreaded === 'boolean' ? data.isThreaded : false;
-  const hardwareConcurrency =
-    Number.isFinite(data.hardwareConcurrency) && data.hardwareConcurrency > 0
-      ? data.hardwareConcurrency
-      : 4;
-  const kernel = data.kernel === 'brepkit' ? 'brepkit' : 'opencascade';
-  return { isThreaded, hardwareConcurrency, kernel };
-}
-
-/** Callback for progress updates during generation */
-export type ProgressCallback = (stage: GenerationStage, progress: number) => void;
-
-/** Result from a successful generation */
-export interface GenerationResult {
-  readonly mesh: MeshData;
-  readonly timingMs: number;
-}
-
-/** Result from a successful BREP export */
-export interface ExportResult {
-  readonly data: ArrayBuffer;
-  readonly fileName: string;
-  readonly format: ExportFormat;
-  readonly faceGroups?: readonly FaceGroupData[];
-}
-
-/** Result from a successful dividers export */
-export interface DividersExportResult {
-  readonly data: ArrayBuffer;
-  readonly fileName: string;
-}
-
-/** Result from a combined bin + dividers export */
-export interface CombinedExportResult {
-  readonly pieces: readonly CombinedExportPiece[];
-  readonly format: ExportFormat;
-  readonly faceGroups?: readonly FaceGroupData[];
-}
-
-/** Result from a successful split export */
-export interface SplitExportResult {
-  readonly pieces: readonly SplitExportPiece[];
-}
-
-/** Result from a successful split preview generation (mesh data per piece) */
-export interface SplitPreviewResult {
-  readonly pieces: readonly SplitPreviewPiece[];
-}
-
-/** Result from a successful baseplate export */
-export interface BaseplateExportResult {
-  readonly data: ArrayBuffer;
-  readonly fileName: string;
-  readonly format: ExportFormat;
-}
-
-/** Aggregated cache performance stats for analytics. */
-export interface CacheStatsPayload {
-  readonly total_hits: number;
-  readonly total_misses: number;
-  readonly total_evictions: number;
-  readonly hit_rate: number;
-  readonly cache_count: number;
-  readonly per_cache: readonly WorkerCacheStats[];
-}
-
-/** Callback for cache stats reporting */
-export type CacheStatsCallback = (stats: CacheStatsPayload) => void;
-
-/** Payload for kernel performance stats callback */
-export interface KernelPerfStatsPayload {
-  readonly stats: Readonly<Record<string, KernelPerfCategory>>;
-}
-
-/** Callback for kernel perf stats reporting */
-export type KernelPerfStatsCallback = (payload: KernelPerfStatsPayload) => void;
-
-/** Information about the WASM threading capabilities */
-export interface ThreadingInfo {
-  /** Whether multi-threaded WASM is being used */
-  readonly isThreaded: boolean;
-  /** Number of CPU cores available */
-  readonly hardwareConcurrency: number;
-  /** Which geometry kernel was loaded */
-  readonly kernel: KernelName;
-}
-
-/** Size-1 dedup cache: stores the fingerprint and result of the last successful generation. */
-interface DedupCache {
-  fingerprint: string | null;
-  result: GenerationResult | null;
-  /** Fingerprint of the currently in-flight request (stored so we can cache on success). */
-  pendingFingerprint: string | null;
-}
-
-function createDedupCache(): DedupCache {
-  return { fingerprint: null, result: null, pendingFingerprint: null };
-}
-
-/** Keys for the pending export request slots */
-type ExportSlot = 'export' | 'dividers' | 'combined' | 'split' | 'splitPreview';
-
-/** A pending export request: resolve/reject callbacks + request ID + timeout timer */
-interface PendingExport<T> {
-  readonly resolve: (result: T) => void;
-  readonly reject: (error: Error) => void;
-  readonly requestId: string;
-  /**
-   * Timeout handle that cancels the export and rejects the promise if the
-   * worker becomes unresponsive. Cleared whenever the request resolves,
-   * rejects, or the bridge is torn down.
-   */
-  timer: ReturnType<typeof setTimeout> | null;
-}
-
-/**
- * Custom error thrown when an export request hits its timeout budget.
- * The error message also passes the `/timeout/` regex used by the worker
- * classifier so any downstream wrappers map it to {@link ExportErrorCode}
- * `TIMEOUT` consistently.
- */
-export class ExportTimeoutError extends Error {
-  readonly code: ExportErrorCode = 'TIMEOUT';
-  constructor(message = 'Export timed out — the geometry engine became unresponsive.') {
-    super(message);
-    this.name = 'ExportTimeoutError';
-  }
-}
-
-/**
- * GenerationBridge manages a single Web Worker instance for geometry generation.
- *
- * Key behaviors:
- * - Debounces rapid generate() calls (200ms)
- * - Cancels in-flight requests when a new one arrives
- * - Provides Promise-based API over the message-passing protocol
- */
-
-/**
- * Defensive fallback timeout for {@link startGenerationTimeout} when a caller
- * omits an explicit budget. Current callers (bin and baseplate generation)
- * pass complexity-aware budgets from {@link computeGenerationTimeoutMs} and
- * {@link computeBaseplateTimeoutMs} respectively; the default is kept so a
- * future caller added without a budget still cancels on unresponsive workers.
- */
-const DEFAULT_GENERATION_TIMEOUT_MS = 30_000;
+export type {
+  ProgressCallback,
+  GenerationResult,
+  ExportResult,
+  DividersExportResult,
+  CombinedExportResult,
+  SplitExportResult,
+  SplitPreviewResult,
+  BaseplateExportResult,
+  CacheStatsPayload,
+  CacheStatsCallback,
+  KernelPerfStatsPayload,
+  KernelPerfStatsCallback,
+  ThreadingInfo,
+} from './bridgeTypes';
+export { ExportTimeoutError } from './bridgeTypes';
 
 export class GenerationBridge {
   private readonly kernel: KernelName;
-  private worker: Worker | null = null;
-  private initPromise: Promise<void> | null = null;
-  private currentRequestId: string | null = null;
-  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
-  private generationTimer: ReturnType<typeof setTimeout> | null = null;
-  private pendingResolve: ((result: GenerationResult) => void) | null = null;
-  private pendingReject: ((error: Error) => void) | null = null;
-  private onProgress: ProgressCallback | null = null;
+  worker: Worker | null = null;
+  initPromise: Promise<void> | null = null;
+  currentRequestId: string | null = null;
+  debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  generationTimer: ReturnType<typeof setTimeout> | null = null;
+  pendingResolve: ((result: GenerationResult) => void) | null = null;
+  pendingReject: ((error: Error) => void) | null = null;
+  onProgress: ProgressCallback | null = null;
   private requestCounter = 0;
   private destroyed = false;
-  private adaptiveDebounce = new AdaptiveDebounce();
-  private threadingInfo: ThreadingInfo | null = null;
+  readonly adaptiveDebounce = new AdaptiveDebounce();
+  threadingInfo: ThreadingInfo | null = null;
 
   /** Size-1 dedup caches for bin and baseplate generation. */
-  private binCache: DedupCache = createDedupCache();
-  private baseplateCache: DedupCache = createDedupCache();
+  binCache: DedupCache = createDedupCache();
+  baseplateCache: DedupCache = createDedupCache();
 
   /** Optional callback for cache performance stats (called after each generation). */
   onCacheStats: CacheStatsCallback | null = null;
@@ -225,13 +97,13 @@ export class GenerationBridge {
   /** Optional callback for kernel performance stats (called after each generation). */
   onKernelPerfStats: KernelPerfStatsCallback | null = null;
 
+  /** Pending export requests keyed by slot. Only one per slot at a time. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Values are PendingExport<T> with different T per slot; type safety is enforced at each call site
+  readonly pendingExports = new Map<ExportSlot, PendingExport<any>>();
+
   constructor(kernel: KernelName = 'opencascade') {
     this.kernel = kernel;
   }
-
-  /** Pending export requests keyed by slot. Only one per slot at a time. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Values are PendingExport<T> with different T per slot; type safety is enforced at each call site
-  private pendingExports = new Map<ExportSlot, PendingExport<any>>();
 
   /**
    * Initialize the worker. Resolves when the worker signals INIT_READY.
@@ -250,15 +122,12 @@ export class GenerationBridge {
     }
 
     this.initPromise = this.tryInit().catch((firstError: unknown) => {
-      // Tear down the failed worker before retrying
       this.worker?.terminate();
       this.worker = null;
 
       if (this.destroyed) throw firstError;
 
       return this.tryInit().catch((retryError: unknown) => {
-        // Both attempts failed — throw the retry error (more recent/relevant)
-        // but preserve the first error for diagnostics
         const message = retryError instanceof Error ? retryError.message : String(retryError);
         const firstMessage = firstError instanceof Error ? firstError.message : String(firstError);
         throw new Error(`${message} (first attempt: ${firstMessage})`);
@@ -306,71 +175,19 @@ export class GenerationBridge {
 
         this.postMessage({ type: 'INIT', kernel: this.kernel });
       } catch (e) {
-        reject(new Error(`Failed to create worker: ${e instanceof Error ? e.message : String(e)}`));
+        reject(e instanceof Error ? e : new Error(String(e)));
       }
     });
   }
 
-  /**
-   * Generate mesh geometry from bin parameters.
-   *
-   * Debounces calls by adaptive delay (50-300ms). Cancels any in-flight request.
-   * Returns the generated mesh data and timing information.
-   */
+  /** Generate bin mesh — debounced. */
   generate(params: BinParams, onProgress?: ProgressCallback): Promise<GenerationResult> {
-    return this.generateInternal(params, onProgress, true);
+    return generateBinImpl(this, params, onProgress, true);
   }
 
-  /**
-   * Generate immediately without debounce.
-   * Useful for initial generation or user-triggered regeneration.
-   */
+  /** Generate immediately without debounce — for initial generation or user-triggered regeneration. */
   generateImmediate(params: BinParams, onProgress?: ProgressCallback): Promise<GenerationResult> {
-    return this.generateInternal(params, onProgress, false);
-  }
-
-  /**
-   * Internal generation handler shared by generate and generateImmediate.
-   */
-  private generateInternal(
-    params: BinParams,
-    onProgress: ProgressCallback | undefined,
-    debounce: boolean
-  ): Promise<GenerationResult> {
-    if (this.destroyed) {
-      return Promise.reject(new Error('Bridge has been destroyed'));
-    }
-
-    // Deduplication: return cached result if params haven't changed
-    const fingerprint = paramsFingerprint(params);
-    if (this.binCache.fingerprint === fingerprint && this.binCache.result) {
-      return Promise.resolve(this.binCache.result);
-    }
-
-    // Cancel any pending debounce
-    if (this.debounceTimer !== null) {
-      clearTimeout(this.debounceTimer);
-      this.debounceTimer = null;
-    }
-
-    // Reject any in-flight request
-    this.cancelCurrentRequest();
-
-    this.onProgress = onProgress ?? null;
-
-    return new Promise<GenerationResult>((resolve, reject) => {
-      this.pendingResolve = resolve;
-      this.pendingReject = reject;
-
-      if (debounce) {
-        this.debounceTimer = setTimeout(() => {
-          this.debounceTimer = null;
-          this.sendGenerateMessage(params, fingerprint);
-        }, this.adaptiveDebounce.getDelay());
-      } else {
-        this.sendGenerateMessage(params, fingerprint);
-      }
-    });
+    return generateBinImpl(this, params, onProgress, false);
   }
 
   /** Cancel any in-flight generation request */
@@ -389,7 +206,6 @@ export class GenerationBridge {
 
     this.cancel();
 
-    // Reject all pending exports
     for (const pending of this.pendingExports.values()) {
       this.clearExportTimer(pending);
       pending.reject(new Error('Bridge destroyed'));
@@ -409,89 +225,29 @@ export class GenerationBridge {
     this.baseplateCache = createDedupCache();
   }
 
-  /**
-   * Export the current (or regenerated) bin solid in the specified format.
-   * Returns a Promise that resolves with the binary file data.
-   *
-   * If the worker has a cached solid from a previous generate() call,
-   * it exports directly. Otherwise, it regenerates the solid first.
-   */
-  async exportBin(
+  // ── Export methods (delegate to bridgeExports) ────────────────────
+
+  exportBin(
     params: BinParams,
     format: ExportFormat,
     options?: { tolerance?: number; angularTolerance?: number }
   ): Promise<ExportResult> {
-    const requestId = await this.prepareExport('export');
-
-    return new Promise<ExportResult>((resolve, reject) => {
-      this.pendingExports.set('export', { resolve, reject, requestId, timer: null });
-      this.startExportTimeout('export', requestId, computeGenerationTimeoutMs(params));
-      this.postMessage({
-        type: 'EXPORT',
-        payload: {
-          params,
-          requestId,
-          format,
-          tolerance: options?.tolerance,
-          angularTolerance: options?.angularTolerance,
-        },
-      });
-    });
+    return exportBinImpl(this, params, format, options);
   }
 
-  /**
-   * Export divider pieces as a combined STL file.
-   * Returns a Promise that resolves with the binary file data.
-   */
-  async exportDividers(params: BinParams): Promise<DividersExportResult> {
-    const requestId = await this.prepareExport('dividers');
-
-    return new Promise<DividersExportResult>((resolve, reject) => {
-      this.pendingExports.set('dividers', { resolve, reject, requestId, timer: null });
-      this.startExportTimeout('dividers', requestId, computeGenerationTimeoutMs(params));
-      this.postMessage({
-        type: 'EXPORT_DIVIDERS',
-        payload: { params, requestId },
-      });
-    });
+  exportDividers(params: BinParams): Promise<DividersExportResult> {
+    return exportDividersImpl(this, params);
   }
 
-  /**
-   * Export bin + divider pieces in a single worker call.
-   *
-   * Returns labeled pieces that the caller packages per format:
-   * - STL: multiple pieces → ZIP
-   * - STEP: single compound assembly piece
-   * - No dividers: single bin piece
-   */
-  async exportCombined(
+  exportCombined(
     params: BinParams,
     format: ExportFormat,
     options?: { tolerance?: number; angularTolerance?: number }
   ): Promise<CombinedExportResult> {
-    const requestId = await this.prepareExport('combined');
-
-    return new Promise<CombinedExportResult>((resolve, reject) => {
-      this.pendingExports.set('combined', { resolve, reject, requestId, timer: null });
-      this.startExportTimeout('combined', requestId, computeGenerationTimeoutMs(params));
-      this.postMessage({
-        type: 'EXPORT_COMBINED',
-        payload: {
-          params,
-          requestId,
-          format,
-          tolerance: options?.tolerance,
-          angularTolerance: options?.angularTolerance,
-        },
-      });
-    });
+    return exportCombinedImpl(this, params, format, options);
   }
 
-  /**
-   * Export the current bin solid split into pieces via boolean cuts.
-   * Returns a Promise resolving with an array of STL ArrayBuffers, one per piece.
-   */
-  async exportSplitBin(
+  exportSplitBin(
     params: BinParams,
     cutPlanesX: readonly number[],
     cutPlanesY: readonly number[],
@@ -501,93 +257,36 @@ export class GenerationBridge {
       splitConnectorConfig?: SplitConnectorConfig;
     }
   ): Promise<SplitExportResult> {
-    const requestId = await this.prepareExport('split');
-
-    return new Promise<SplitExportResult>((resolve, reject) => {
-      this.pendingExports.set('split', { resolve, reject, requestId, timer: null });
-      this.startExportTimeout('split', requestId, computeGenerationTimeoutMs(params));
-      this.postMessage({
-        type: 'EXPORT_SPLIT',
-        payload: {
-          params,
-          requestId,
-          cutPlanesX,
-          cutPlanesY,
-          tolerance: options?.tolerance,
-          angularTolerance: options?.angularTolerance,
-          splitConnectorConfig: options?.splitConnectorConfig,
-        },
-      });
-    });
+    return exportSplitBinImpl(this, params, cutPlanesX, cutPlanesY, options);
   }
 
-  /**
-   * Generate split bin piece meshes for 3D preview rendering.
-   * Returns MeshData per piece instead of STL, for use in Three.js scene.
-   */
-  async generateSplitPreview(
+  generateSplitPreview(
     params: BinParams,
     cutPlanesX: readonly number[],
     cutPlanesY: readonly number[],
-    options?: {
-      splitConnectorConfig?: SplitConnectorConfig;
-    }
+    options?: { splitConnectorConfig?: SplitConnectorConfig }
   ): Promise<SplitPreviewResult> {
-    const requestId = await this.prepareExport('splitPreview');
-
-    return new Promise<SplitPreviewResult>((resolve, reject) => {
-      this.pendingExports.set('splitPreview', { resolve, reject, requestId, timer: null });
-      this.startExportTimeout('splitPreview', requestId, computeGenerationTimeoutMs(params));
-      this.postMessage({
-        type: 'GENERATE_SPLIT_PREVIEW',
-        payload: {
-          params,
-          requestId,
-          cutPlanesX,
-          cutPlanesY,
-          splitConnectorConfig: options?.splitConnectorConfig,
-        },
-      });
-    });
+    return generateSplitPreviewImpl(this, params, cutPlanesX, cutPlanesY, options);
   }
 
-  /**
-   * Generate split preview meshes for a subset of pieces.
-   * Used by the worker pool to distribute piece processing across workers.
-   */
-  async generateSplitPreviewRange(
+  generateSplitPreviewRange(
     params: BinParams,
     cutPlanesX: readonly number[],
     cutPlanesY: readonly number[],
     pieceIndices: readonly number[],
-    options?: {
-      splitConnectorConfig?: SplitConnectorConfig;
-    }
+    options?: { splitConnectorConfig?: SplitConnectorConfig }
   ): Promise<SplitPreviewResult> {
-    const requestId = await this.prepareExport('splitPreview');
-
-    return new Promise<SplitPreviewResult>((resolve, reject) => {
-      this.pendingExports.set('splitPreview', { resolve, reject, requestId, timer: null });
-      this.startExportTimeout('splitPreview', requestId, computeGenerationTimeoutMs(params));
-      this.postMessage({
-        type: 'GENERATE_SPLIT_PREVIEW_RANGE',
-        payload: {
-          params,
-          requestId,
-          cutPlanesX,
-          cutPlanesY,
-          pieceIndices,
-          splitConnectorConfig: options?.splitConnectorConfig,
-        },
-      });
-    });
+    return generateSplitPreviewRangeImpl(
+      this,
+      params,
+      cutPlanesX,
+      cutPlanesY,
+      pieceIndices,
+      options
+    );
   }
 
-  /**
-   * Export split bin pieces for a subset of piece indices.
-   * Used by the worker pool to distribute piece export across workers.
-   */
-  async exportSplitBinRange(
+  exportSplitBinRange(
     params: BinParams,
     cutPlanesX: readonly number[],
     cutPlanesY: readonly number[],
@@ -598,122 +297,30 @@ export class GenerationBridge {
       splitConnectorConfig?: SplitConnectorConfig;
     }
   ): Promise<SplitExportResult> {
-    const requestId = await this.prepareExport('split');
-
-    return new Promise<SplitExportResult>((resolve, reject) => {
-      this.pendingExports.set('split', { resolve, reject, requestId, timer: null });
-      this.startExportTimeout('split', requestId, computeGenerationTimeoutMs(params));
-      this.postMessage({
-        type: 'EXPORT_SPLIT_RANGE',
-        payload: {
-          params,
-          requestId,
-          cutPlanesX,
-          cutPlanesY,
-          pieceIndices,
-          tolerance: options?.tolerance,
-          angularTolerance: options?.angularTolerance,
-          splitConnectorConfig: options?.splitConnectorConfig,
-        },
-      });
-    });
+    return exportSplitBinRangeImpl(this, params, cutPlanesX, cutPlanesY, pieceIndices, options);
   }
 
-  /**
-   * Generate baseplate mesh from baseplate parameters.
-   * Uses the same debounce and cancellation as bin generation.
-   */
   generateBaseplate(
     params: BaseplateParams,
     onProgress?: ProgressCallback
   ): Promise<GenerationResult> {
-    return this.generateBaseplateInternal(params, onProgress, true);
+    return generateBaseplateImpl(this, params, onProgress, true);
   }
 
-  /**
-   * Generate baseplate mesh immediately without debounce.
-   * Used by the worker pool for parallel split piece generation.
-   */
+  /** Used by the worker pool for parallel split piece generation. */
   generateBaseplateImmediate(
     params: BaseplateParams,
     onProgress?: ProgressCallback
   ): Promise<GenerationResult> {
-    return this.generateBaseplateInternal(params, onProgress, false);
+    return generateBaseplateImpl(this, params, onProgress, false);
   }
 
-  private generateBaseplateInternal(
-    params: BaseplateParams,
-    onProgress: ProgressCallback | undefined,
-    debounce: boolean
-  ): Promise<GenerationResult> {
-    if (this.destroyed) {
-      return Promise.reject(new Error('Bridge has been destroyed'));
-    }
-
-    // Deduplication: return cached result if params haven't changed
-    const fingerprint = paramsFingerprint(params);
-    if (this.baseplateCache.fingerprint === fingerprint && this.baseplateCache.result) {
-      return Promise.resolve(this.baseplateCache.result);
-    }
-
-    if (this.debounceTimer !== null) {
-      clearTimeout(this.debounceTimer);
-      this.debounceTimer = null;
-    }
-
-    this.cancelCurrentRequest();
-    this.onProgress = onProgress ?? null;
-
-    return new Promise<GenerationResult>((resolve, reject) => {
-      this.pendingResolve = resolve;
-      this.pendingReject = reject;
-
-      const sendMessage = (): void => {
-        const requestId = this.nextRequestId();
-        this.currentRequestId = requestId;
-        this.baseplateCache.pendingFingerprint = fingerprint;
-        this.startGenerationTimeout(requestId, computeBaseplateTimeoutMs(params));
-        this.postMessage({
-          type: 'GENERATE_BASEPLATE',
-          payload: { params, requestId },
-        });
-      };
-
-      if (debounce) {
-        this.debounceTimer = setTimeout(() => {
-          this.debounceTimer = null;
-          sendMessage();
-        }, this.adaptiveDebounce.getDelay());
-      } else {
-        sendMessage();
-      }
-    });
-  }
-
-  /**
-   * Export baseplate in the specified format.
-   */
-  async exportBaseplate(
+  exportBaseplate(
     params: BaseplateParams,
     format: ExportFormat,
     options?: { tolerance?: number; angularTolerance?: number }
   ): Promise<BaseplateExportResult> {
-    const requestId = await this.prepareExport('export');
-
-    return new Promise<BaseplateExportResult>((resolve, reject) => {
-      this.pendingExports.set('export', { resolve, reject, requestId, timer: null });
-      this.startExportTimeout('export', requestId, computeBaseplateTimeoutMs(params));
-      this.postMessage({
-        type: 'EXPORT_BASEPLATE',
-        payload: {
-          params,
-          requestId,
-          format,
-          tolerance: options?.tolerance,
-          angularTolerance: options?.angularTolerance,
-        },
-      });
-    });
+    return exportBaseplateImpl(this, params, format, options);
   }
 
   /** Whether the bridge has been destroyed */
@@ -721,25 +328,24 @@ export class GenerationBridge {
     return this.destroyed;
   }
 
-  /**
-   * Get threading information after initialization.
-   * Returns null if not yet initialized.
-   */
+  /** Get threading information after initialization. Returns null if not yet initialized. */
   getThreadingInfo(): ThreadingInfo | null {
     return this.threadingInfo;
   }
+
+  // ── Internal helpers (used by sibling modules + this class) ───────
+
   /**
    * Prepare an export slot: check destroyed state, ensure worker is initialized,
    * reject any existing pending export on the same slot, and return a new request ID.
    */
-  private async prepareExport(slot: ExportSlot): Promise<string> {
+  async prepareExport(slot: ExportSlot): Promise<string> {
     if (this.destroyed) {
       throw new Error('Bridge has been destroyed');
     }
 
     await this.init();
 
-    // Reject any pending export on this slot (only one at a time)
     const existing = this.pendingExports.get(slot);
     if (existing) {
       this.clearExportTimer(existing);
@@ -750,11 +356,8 @@ export class GenerationBridge {
     return this.nextRequestId();
   }
 
-  /**
-   * Resolve a pending export by slot, if the request ID matches.
-   * Returns true if the export was resolved, false if stale/missing.
-   */
-  private resolveExport(slot: ExportSlot, requestId: string, result: unknown): boolean {
+  /** Resolve a pending export by slot, if the request ID matches. */
+  resolveExport(slot: ExportSlot, requestId: string, result: unknown): boolean {
     const pending = this.pendingExports.get(slot);
     if (pending && pending.requestId === requestId) {
       this.pendingExports.delete(slot);
@@ -765,11 +368,8 @@ export class GenerationBridge {
     return false;
   }
 
-  /**
-   * Reject a pending export by request ID, checking all slots.
-   * Returns true if a matching export was found and rejected.
-   */
-  private rejectExportByRequestId(requestId: string, error: Error): boolean {
+  /** Reject a pending export by request ID, checking all slots. */
+  rejectExportByRequestId(requestId: string, error: Error): boolean {
     for (const [slot, pending] of this.pendingExports) {
       if (pending.requestId === requestId) {
         this.pendingExports.delete(slot);
@@ -782,7 +382,7 @@ export class GenerationBridge {
   }
 
   /** Clear an export's timeout timer, if any. */
-  private clearExportTimer(pending: PendingExport<unknown>): void {
+  clearExportTimer(pending: PendingExport<unknown>): void {
     if (pending.timer !== null) {
       clearTimeout(pending.timer);
       pending.timer = null;
@@ -791,12 +391,10 @@ export class GenerationBridge {
 
   /**
    * Start a timeout that cancels an in-flight export if the worker doesn't
-   * respond in time. On fire, sends `CANCEL`, removes the pending entry, and
-   * rejects with an {@link ExportTimeoutError}. The slot identifies which
-   * pending entry to look up — only the originating request can be cancelled
-   * (a later request that took the same slot is left alone).
+   * respond. On fire, sends `CANCEL`, removes the pending entry, and rejects
+   * with an `ExportTimeoutError`.
    */
-  private startExportTimeout(slot: ExportSlot, requestId: string, timeoutMs: number): void {
+  startExportTimeout(slot: ExportSlot, requestId: string, timeoutMs: number): void {
     const pending = this.pendingExports.get(slot);
     if (!pending) return;
     pending.timer = setTimeout(() => {
@@ -804,210 +402,16 @@ export class GenerationBridge {
       if (!current || current.requestId !== requestId) return;
       this.pendingExports.delete(slot);
       current.timer = null;
-      // Best-effort cancel; the worker may already be wedged.
       this.postMessage({ type: 'CANCEL', requestId });
       current.reject(new ExportTimeoutError());
     }, timeoutMs);
   }
 
-  private sendGenerateMessage(params: BinParams, fingerprint: string): void {
-    const requestId = this.nextRequestId();
-    this.currentRequestId = requestId;
-    this.binCache.pendingFingerprint = fingerprint;
-
-    this.startGenerationTimeout(requestId, computeGenerationTimeoutMs(params));
-
-    this.postMessage({
-      type: 'GENERATE',
-      payload: { params, requestId },
-    });
-  }
-
-  /**
-   * Start a timeout to recover from unresponsive workers (WASM OOM, infinite loops).
-   * Cleared in clearPending() when the worker responds (success, error, or cancel).
-   *
-   * Bin and baseplate generations pass complexity-aware budgets; callers
-   * without params fall back to {@link DEFAULT_GENERATION_TIMEOUT_MS}.
-   */
-  private startGenerationTimeout(
-    requestId: string,
-    timeoutMs: number = DEFAULT_GENERATION_TIMEOUT_MS
-  ): void {
-    this.clearGenerationTimer();
-    this.generationTimer = setTimeout(() => {
-      if (this.currentRequestId === requestId && this.pendingReject) {
-        const reject = this.pendingReject;
-        this.clearPending();
-        // Send cancel so the worker can abort if it's still alive
-        this.postMessage({ type: 'CANCEL', requestId });
-        reject(
-          new Error(
-            'Generation timed out — this design may be too complex. Try reducing grid size or disabling features like magnets, compartments, or wall patterns.'
-          )
-        );
-      }
-    }, timeoutMs);
-  }
-
   private setupMessageHandler(): void {
-    if (!this.worker) return;
-
-    // Handle worker crashes (WASM OOM, unrecoverable kernel errors).
-    // Without this, a worker crash leaves pending Promises unresolved
-    // and the UI stuck in "generating" state forever.
-    this.worker.addEventListener('error', (e) => {
-      e.preventDefault();
-      const message = e.message || 'Worker crashed unexpectedly (possible out-of-memory)';
-
-      // Tear down the dead worker so subsequent calls don't post to it.
-      // Clearing initPromise allows re-init on the next generate() call.
-      if (this.worker) {
-        this.worker.terminate();
-        this.worker = null;
-      }
-      this.initPromise = null;
-      this.threadingInfo = null;
-
-      // Reject the pending generation promise so the UI can show an error
-      if (this.pendingReject) {
-        const reject = this.pendingReject;
-        this.clearPending();
-        reject(new Error(message));
-      }
-
-      // Reject all pending exports
-      for (const pending of this.pendingExports.values()) {
-        this.clearExportTimer(pending);
-        pending.reject(new Error(message));
-      }
-      this.pendingExports.clear();
-    });
-
-    this.worker.addEventListener('message', (event: MessageEvent<WorkerResponse>) => {
-      const response = event.data;
-
-      switch (response.type) {
-        case 'PROGRESS':
-          if (response.requestId === this.currentRequestId && this.onProgress) {
-            this.onProgress(response.stage, response.progress);
-          }
-          break;
-
-        case 'MESH_RESULT':
-          if (response.requestId === this.currentRequestId && this.pendingResolve) {
-            this.adaptiveDebounce.recordTiming(response.timingMs);
-            const resolve = this.pendingResolve;
-            // Lid is optional: assemble it only when the worker actually sent
-            // lid arrays. All five lid fields land or are absent together.
-            const lidMesh =
-              response.lidVertices &&
-              response.lidNormals &&
-              response.lidIndices &&
-              response.lidEdgeVertices &&
-              response.lidTriangleCount !== undefined
-                ? {
-                    vertices: response.lidVertices,
-                    normals: response.lidNormals,
-                    indices: response.lidIndices,
-                    edgeVertices: response.lidEdgeVertices,
-                    triangleCount: response.lidTriangleCount,
-                    faceGroups: response.lidFaceGroups,
-                  }
-                : undefined;
-            const result: GenerationResult = {
-              mesh: {
-                vertices: response.vertices,
-                normals: response.normals,
-                indices: response.indices,
-                edgeVertices: response.edgeVertices,
-                triangleCount: response.triangleCount,
-                faceGroups: response.faceGroups,
-                coarseLOD: response.coarseLOD,
-                lidMesh,
-              },
-              timingMs: response.timingMs,
-            };
-
-            // Cache for deduplication (bin or baseplate — only one is in-flight)
-            this.commitDedupCache(this.binCache, result);
-            this.commitDedupCache(this.baseplateCache, result);
-
-            this.clearPending();
-            resolve(result);
-          }
-          break;
-
-        case 'ERROR':
-          if (response.requestId === this.currentRequestId && this.pendingReject) {
-            const reject = this.pendingReject;
-            this.clearPending();
-            reject(new Error(response.error));
-          } else {
-            this.rejectExportByRequestId(response.requestId, new Error(response.error));
-          }
-          break;
-
-        case 'EXPORT_RESULT':
-          this.resolveExport('export', response.requestId, {
-            data: response.data,
-            fileName: response.fileName,
-            format: response.format,
-            faceGroups: response.faceGroups,
-          });
-          break;
-
-        case 'BASEPLATE_EXPORT_RESULT':
-          this.resolveExport('export', response.requestId, {
-            data: response.data,
-            fileName: response.fileName,
-            format: response.format,
-          });
-          break;
-
-        case 'DIVIDERS_EXPORT_RESULT':
-          this.resolveExport('dividers', response.requestId, {
-            data: response.data,
-            fileName: response.fileName,
-          });
-          break;
-
-        case 'COMBINED_EXPORT_RESULT':
-          this.resolveExport('combined', response.requestId, {
-            pieces: response.pieces,
-            format: response.format,
-            faceGroups: response.faceGroups,
-          });
-          break;
-
-        case 'SPLIT_EXPORT_RESULT':
-          this.resolveExport('split', response.requestId, {
-            pieces: response.pieces,
-          });
-          break;
-
-        case 'SPLIT_PREVIEW_RESULT':
-          this.resolveExport('splitPreview', response.requestId, {
-            pieces: response.pieces,
-          });
-          break;
-
-        case 'CACHE_STATS':
-          this.handleCacheStats(response.caches);
-          break;
-
-        case 'KERNEL_PERF_STATS':
-          this.onKernelPerfStats?.({ stats: response.stats });
-          break;
-
-        case 'INIT_READY':
-          // Already handled during init
-          break;
-      }
-    });
+    installMessageHandler(this);
   }
 
-  private handleCacheStats(caches: readonly WorkerCacheStats[]): void {
+  handleCacheStats(caches: readonly WorkerCacheStats[]): void {
     if (!this.onCacheStats) return;
 
     let totalHits = 0;
@@ -1031,7 +435,7 @@ export class GenerationBridge {
     });
   }
 
-  private cancelCurrentRequest(): void {
+  cancelCurrentRequest(): void {
     if (this.currentRequestId && this.worker) {
       this.postMessage({ type: 'CANCEL', requestId: this.currentRequestId });
     }
@@ -1044,7 +448,7 @@ export class GenerationBridge {
   }
 
   /** If this cache has a pending fingerprint, promote it to the cached result and clear pending. */
-  private commitDedupCache(cache: DedupCache, result: GenerationResult): void {
+  commitDedupCache(cache: DedupCache, result: GenerationResult): void {
     if (cache.pendingFingerprint) {
       cache.fingerprint = cache.pendingFingerprint;
       cache.result = result;
@@ -1052,7 +456,7 @@ export class GenerationBridge {
     }
   }
 
-  private clearPending(): void {
+  clearPending(): void {
     this.clearGenerationTimer();
     this.pendingResolve = null;
     this.pendingReject = null;
@@ -1069,11 +473,11 @@ export class GenerationBridge {
     }
   }
 
-  private postMessage(message: WorkerMessage): void {
+  postMessage(message: WorkerMessage): void {
     this.worker?.postMessage(message);
   }
 
-  private nextRequestId(): string {
+  nextRequestId(): string {
     return `gen_${++this.requestCounter}_${Date.now()}`;
   }
 }

--- a/src/features/generation/bridge/bridgeExports.ts
+++ b/src/features/generation/bridge/bridgeExports.ts
@@ -1,0 +1,250 @@
+/**
+ * Export-method implementations for `GenerationBridge`.
+ *
+ * Every export follows the same template: prepare a slot (which gives us a
+ * requestId and rejects any superseded pending request), wrap a Promise that
+ * registers the resolve/reject pair against the slot, start the timeout, and
+ * post the worker message. Extracted to siblings so the bridge file stays
+ * focused on the worker lifecycle + state machine.
+ */
+
+import type { BinParams, BaseplateParams, SplitConnectorConfig } from '@/shared/types/bin';
+import type { WorkerMessage, ExportFormat } from './types';
+import { computeBaseplateTimeoutMs, computeGenerationTimeoutMs } from './generationTimeout';
+import type {
+  ExportResult,
+  DividersExportResult,
+  CombinedExportResult,
+  SplitExportResult,
+  SplitPreviewResult,
+  BaseplateExportResult,
+  ExportSlot,
+  PendingExport,
+} from './bridgeTypes';
+
+export interface BridgeExportContext {
+  prepareExport: (slot: ExportSlot) => Promise<string>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- pendingExports values are PendingExport<T> with different T per slot; type safety enforced at each call site
+  readonly pendingExports: Map<ExportSlot, PendingExport<any>>;
+  startExportTimeout: (slot: ExportSlot, requestId: string, timeoutMs: number) => void;
+  postMessage: (message: WorkerMessage) => void;
+}
+
+/**
+ * Run an export request: prepare the slot, register the Promise callbacks,
+ * start the timeout, and post the worker message. Returned Promise resolves
+ * when the worker sends back the result (handled by the message handler).
+ */
+function runExport<T>(
+  ctx: BridgeExportContext,
+  slot: ExportSlot,
+  timeoutMs: number,
+  buildMessage: (requestId: string) => WorkerMessage
+): Promise<T> {
+  return ctx.prepareExport(slot).then(
+    (requestId) =>
+      new Promise<T>((resolve, reject) => {
+        ctx.pendingExports.set(slot, {
+          resolve: resolve as (result: unknown) => void,
+          reject,
+          requestId,
+          timer: null,
+        });
+        ctx.startExportTimeout(slot, requestId, timeoutMs);
+        ctx.postMessage(buildMessage(requestId));
+      })
+  );
+}
+
+export function exportBin(
+  ctx: BridgeExportContext,
+  params: BinParams,
+  format: ExportFormat,
+  options?: { tolerance?: number; angularTolerance?: number }
+): Promise<ExportResult> {
+  return runExport<ExportResult>(
+    ctx,
+    'export',
+    computeGenerationTimeoutMs(params),
+    (requestId) => ({
+      type: 'EXPORT',
+      payload: {
+        params,
+        requestId,
+        format,
+        tolerance: options?.tolerance,
+        angularTolerance: options?.angularTolerance,
+      },
+    })
+  );
+}
+
+export function exportDividers(
+  ctx: BridgeExportContext,
+  params: BinParams
+): Promise<DividersExportResult> {
+  return runExport<DividersExportResult>(
+    ctx,
+    'dividers',
+    computeGenerationTimeoutMs(params),
+    (requestId) => ({ type: 'EXPORT_DIVIDERS', payload: { params, requestId } })
+  );
+}
+
+export function exportCombined(
+  ctx: BridgeExportContext,
+  params: BinParams,
+  format: ExportFormat,
+  options?: { tolerance?: number; angularTolerance?: number }
+): Promise<CombinedExportResult> {
+  return runExport<CombinedExportResult>(
+    ctx,
+    'combined',
+    computeGenerationTimeoutMs(params),
+    (requestId) => ({
+      type: 'EXPORT_COMBINED',
+      payload: {
+        params,
+        requestId,
+        format,
+        tolerance: options?.tolerance,
+        angularTolerance: options?.angularTolerance,
+      },
+    })
+  );
+}
+
+export function exportSplitBin(
+  ctx: BridgeExportContext,
+  params: BinParams,
+  cutPlanesX: readonly number[],
+  cutPlanesY: readonly number[],
+  options?: {
+    tolerance?: number;
+    angularTolerance?: number;
+    splitConnectorConfig?: SplitConnectorConfig;
+  }
+): Promise<SplitExportResult> {
+  return runExport<SplitExportResult>(
+    ctx,
+    'split',
+    computeGenerationTimeoutMs(params),
+    (requestId) => ({
+      type: 'EXPORT_SPLIT',
+      payload: {
+        params,
+        requestId,
+        cutPlanesX,
+        cutPlanesY,
+        tolerance: options?.tolerance,
+        angularTolerance: options?.angularTolerance,
+        splitConnectorConfig: options?.splitConnectorConfig,
+      },
+    })
+  );
+}
+
+export function generateSplitPreview(
+  ctx: BridgeExportContext,
+  params: BinParams,
+  cutPlanesX: readonly number[],
+  cutPlanesY: readonly number[],
+  options?: { splitConnectorConfig?: SplitConnectorConfig }
+): Promise<SplitPreviewResult> {
+  return runExport<SplitPreviewResult>(
+    ctx,
+    'splitPreview',
+    computeGenerationTimeoutMs(params),
+    (requestId) => ({
+      type: 'GENERATE_SPLIT_PREVIEW',
+      payload: {
+        params,
+        requestId,
+        cutPlanesX,
+        cutPlanesY,
+        splitConnectorConfig: options?.splitConnectorConfig,
+      },
+    })
+  );
+}
+
+export function generateSplitPreviewRange(
+  ctx: BridgeExportContext,
+  params: BinParams,
+  cutPlanesX: readonly number[],
+  cutPlanesY: readonly number[],
+  pieceIndices: readonly number[],
+  options?: { splitConnectorConfig?: SplitConnectorConfig }
+): Promise<SplitPreviewResult> {
+  return runExport<SplitPreviewResult>(
+    ctx,
+    'splitPreview',
+    computeGenerationTimeoutMs(params),
+    (requestId) => ({
+      type: 'GENERATE_SPLIT_PREVIEW_RANGE',
+      payload: {
+        params,
+        requestId,
+        cutPlanesX,
+        cutPlanesY,
+        pieceIndices,
+        splitConnectorConfig: options?.splitConnectorConfig,
+      },
+    })
+  );
+}
+
+export function exportSplitBinRange(
+  ctx: BridgeExportContext,
+  params: BinParams,
+  cutPlanesX: readonly number[],
+  cutPlanesY: readonly number[],
+  pieceIndices: readonly number[],
+  options?: {
+    tolerance?: number;
+    angularTolerance?: number;
+    splitConnectorConfig?: SplitConnectorConfig;
+  }
+): Promise<SplitExportResult> {
+  return runExport<SplitExportResult>(
+    ctx,
+    'split',
+    computeGenerationTimeoutMs(params),
+    (requestId) => ({
+      type: 'EXPORT_SPLIT_RANGE',
+      payload: {
+        params,
+        requestId,
+        cutPlanesX,
+        cutPlanesY,
+        pieceIndices,
+        tolerance: options?.tolerance,
+        angularTolerance: options?.angularTolerance,
+        splitConnectorConfig: options?.splitConnectorConfig,
+      },
+    })
+  );
+}
+
+export function exportBaseplate(
+  ctx: BridgeExportContext,
+  params: BaseplateParams,
+  format: ExportFormat,
+  options?: { tolerance?: number; angularTolerance?: number }
+): Promise<BaseplateExportResult> {
+  return runExport<BaseplateExportResult>(
+    ctx,
+    'export',
+    computeBaseplateTimeoutMs(params),
+    (requestId) => ({
+      type: 'EXPORT_BASEPLATE',
+      payload: {
+        params,
+        requestId,
+        format,
+        tolerance: options?.tolerance,
+        angularTolerance: options?.angularTolerance,
+      },
+    })
+  );
+}

--- a/src/features/generation/bridge/bridgeGeneration.ts
+++ b/src/features/generation/bridge/bridgeGeneration.ts
@@ -1,0 +1,159 @@
+/**
+ * Generation flow for `GenerationBridge` — bin and baseplate.
+ *
+ * Both flows share the same shape:
+ *   1. Reject if destroyed.
+ *   2. Check the dedup cache; return cached result on hit.
+ *   3. Cancel any in-flight request and pending debounce.
+ *   4. Set up the resolve/reject promise and the generation timeout.
+ *   5. Either debounce or send the worker message immediately.
+ *
+ * Extracted from the bridge class to keep the state-machine file focused on
+ * lifecycle. Each function takes a `BridgeGenerationContext` — a narrow view
+ * of the private fields it needs to mutate.
+ */
+
+import type { BinParams, BaseplateParams } from '@/shared/types/bin';
+import type { WorkerMessage } from './types';
+import type { AdaptiveDebounce } from './adaptiveDebounce';
+import { computeBaseplateTimeoutMs, computeGenerationTimeoutMs } from './generationTimeout';
+import { paramsFingerprint } from './bridgeHelpers';
+import type { ProgressCallback, GenerationResult, DedupCache } from './bridgeTypes';
+
+const DEFAULT_GENERATION_TIMEOUT_MS = 30_000;
+
+export interface BridgeGenerationContext {
+  readonly isDestroyed: boolean;
+  readonly binCache: DedupCache;
+  readonly baseplateCache: DedupCache;
+  readonly adaptiveDebounce: AdaptiveDebounce;
+  debounceTimer: ReturnType<typeof setTimeout> | null;
+  generationTimer: ReturnType<typeof setTimeout> | null;
+  pendingResolve: ((result: GenerationResult) => void) | null;
+  pendingReject: ((error: Error) => void) | null;
+  currentRequestId: string | null;
+  onProgress: ProgressCallback | null;
+  cancelCurrentRequest: () => void;
+  clearPending: () => void;
+  postMessage: (message: WorkerMessage) => void;
+  nextRequestId: () => string;
+}
+
+export function generateBin(
+  ctx: BridgeGenerationContext,
+  params: BinParams,
+  onProgress: ProgressCallback | undefined,
+  debounce: boolean
+): Promise<GenerationResult> {
+  if (ctx.isDestroyed) {
+    return Promise.reject(new Error('Bridge has been destroyed'));
+  }
+
+  const fingerprint = paramsFingerprint(params);
+  if (ctx.binCache.fingerprint === fingerprint && ctx.binCache.result) {
+    return Promise.resolve(ctx.binCache.result);
+  }
+
+  if (ctx.debounceTimer !== null) {
+    clearTimeout(ctx.debounceTimer);
+    ctx.debounceTimer = null;
+  }
+
+  ctx.cancelCurrentRequest();
+  ctx.onProgress = onProgress ?? null;
+
+  return new Promise<GenerationResult>((resolve, reject) => {
+    ctx.pendingResolve = resolve;
+    ctx.pendingReject = reject;
+
+    const send = (): void => {
+      const requestId = ctx.nextRequestId();
+      ctx.currentRequestId = requestId;
+      ctx.binCache.pendingFingerprint = fingerprint;
+      startGenerationTimeout(ctx, requestId, computeGenerationTimeoutMs(params));
+      ctx.postMessage({ type: 'GENERATE', payload: { params, requestId } });
+    };
+
+    if (debounce) {
+      ctx.debounceTimer = setTimeout(() => {
+        ctx.debounceTimer = null;
+        send();
+      }, ctx.adaptiveDebounce.getDelay());
+    } else {
+      send();
+    }
+  });
+}
+
+export function generateBaseplate(
+  ctx: BridgeGenerationContext,
+  params: BaseplateParams,
+  onProgress: ProgressCallback | undefined,
+  debounce: boolean
+): Promise<GenerationResult> {
+  if (ctx.isDestroyed) {
+    return Promise.reject(new Error('Bridge has been destroyed'));
+  }
+
+  const fingerprint = paramsFingerprint(params);
+  if (ctx.baseplateCache.fingerprint === fingerprint && ctx.baseplateCache.result) {
+    return Promise.resolve(ctx.baseplateCache.result);
+  }
+
+  if (ctx.debounceTimer !== null) {
+    clearTimeout(ctx.debounceTimer);
+    ctx.debounceTimer = null;
+  }
+
+  ctx.cancelCurrentRequest();
+  ctx.onProgress = onProgress ?? null;
+
+  return new Promise<GenerationResult>((resolve, reject) => {
+    ctx.pendingResolve = resolve;
+    ctx.pendingReject = reject;
+
+    const send = (): void => {
+      const requestId = ctx.nextRequestId();
+      ctx.currentRequestId = requestId;
+      ctx.baseplateCache.pendingFingerprint = fingerprint;
+      startGenerationTimeout(ctx, requestId, computeBaseplateTimeoutMs(params));
+      ctx.postMessage({ type: 'GENERATE_BASEPLATE', payload: { params, requestId } });
+    };
+
+    if (debounce) {
+      ctx.debounceTimer = setTimeout(() => {
+        ctx.debounceTimer = null;
+        send();
+      }, ctx.adaptiveDebounce.getDelay());
+    } else {
+      send();
+    }
+  });
+}
+
+/**
+ * Start a timeout to recover from unresponsive workers (WASM OOM, infinite loops).
+ * Cleared in clearPending() when the worker responds (success, error, or cancel).
+ */
+function startGenerationTimeout(
+  ctx: BridgeGenerationContext,
+  requestId: string,
+  timeoutMs: number = DEFAULT_GENERATION_TIMEOUT_MS
+): void {
+  if (ctx.generationTimer !== null) {
+    clearTimeout(ctx.generationTimer);
+    ctx.generationTimer = null;
+  }
+  ctx.generationTimer = setTimeout(() => {
+    if (ctx.currentRequestId === requestId && ctx.pendingReject) {
+      const reject = ctx.pendingReject;
+      ctx.clearPending();
+      ctx.postMessage({ type: 'CANCEL', requestId });
+      reject(
+        new Error(
+          'Generation timed out — this design may be too complex. Try reducing grid size or disabling features like magnets, compartments, or wall patterns.'
+        )
+      );
+    }
+  }, timeoutMs);
+}

--- a/src/features/generation/bridge/bridgeGeneration.ts
+++ b/src/features/generation/bridge/bridgeGeneration.ts
@@ -20,8 +20,6 @@ import { computeBaseplateTimeoutMs, computeGenerationTimeoutMs } from './generat
 import { paramsFingerprint } from './bridgeHelpers';
 import type { ProgressCallback, GenerationResult, DedupCache } from './bridgeTypes';
 
-const DEFAULT_GENERATION_TIMEOUT_MS = 30_000;
-
 export interface BridgeGenerationContext {
   readonly isDestroyed: boolean;
   readonly binCache: DedupCache;
@@ -138,7 +136,7 @@ export function generateBaseplate(
 function startGenerationTimeout(
   ctx: BridgeGenerationContext,
   requestId: string,
-  timeoutMs: number = DEFAULT_GENERATION_TIMEOUT_MS
+  timeoutMs: number
 ): void {
   if (ctx.generationTimer !== null) {
     clearTimeout(ctx.generationTimer);

--- a/src/features/generation/bridge/bridgeHelpers.ts
+++ b/src/features/generation/bridge/bridgeHelpers.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure helpers for the generation bridge: deterministic params fingerprint,
+ * INIT_READY threading-info validation, and dedup-cache initialization.
+ */
+
+import type { KernelName } from './types';
+import type { DedupCache, ThreadingInfo } from './bridgeTypes';
+
+/**
+ * Deterministic fingerprint for generation params.
+ *
+ * Uses JSON.stringify with sorted keys to ensure identical params always
+ * produce the same string, regardless of property insertion order.
+ */
+export function paramsFingerprint(params: unknown): string {
+  return JSON.stringify(params, (_, value: unknown) => {
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      const sorted: Record<string, unknown> = {};
+      for (const key of Object.keys(value).sort()) {
+        sorted[key] = (value as Record<string, unknown>)[key];
+      }
+      return sorted;
+    }
+    return value;
+  });
+}
+
+/** Extract threading info from INIT_READY with defensive validation. */
+export function extractThreadingInfo(data: {
+  isThreaded: boolean;
+  hardwareConcurrency: number;
+  kernel: KernelName;
+}): ThreadingInfo {
+  const isThreaded = typeof data.isThreaded === 'boolean' ? data.isThreaded : false;
+  const hardwareConcurrency =
+    Number.isFinite(data.hardwareConcurrency) && data.hardwareConcurrency > 0
+      ? data.hardwareConcurrency
+      : 4;
+  const kernel = data.kernel === 'brepkit' ? 'brepkit' : 'opencascade';
+  return { isThreaded, hardwareConcurrency, kernel };
+}
+
+export function createDedupCache(): DedupCache {
+  return { fingerprint: null, result: null, pendingFingerprint: null };
+}

--- a/src/features/generation/bridge/bridgeMessageHandler.ts
+++ b/src/features/generation/bridge/bridgeMessageHandler.ts
@@ -1,0 +1,206 @@
+/**
+ * Worker-message handler for `GenerationBridge`.
+ *
+ * The bridge installs this listener on its worker; the listener routes
+ * each WorkerResponse to the appropriate state mutation (generation
+ * resolve/reject, export resolve/reject, cache stats, kernel perf stats).
+ *
+ * Extracted from the bridge class to keep the state-machine file focused on
+ * lifecycle. The handler captures the bridge as a `MessageHandlerContext`
+ * — a narrow view of the private fields it needs to mutate.
+ */
+
+import type { WorkerResponse, WorkerCacheStats } from './types';
+import type { AdaptiveDebounce } from './adaptiveDebounce';
+import type {
+  ProgressCallback,
+  GenerationResult,
+  CacheStatsCallback,
+  KernelPerfStatsCallback,
+  DedupCache,
+  ExportSlot,
+  PendingExport,
+  ThreadingInfo,
+} from './bridgeTypes';
+
+export interface MessageHandlerContext {
+  worker: Worker | null;
+  initPromise: Promise<void> | null;
+  threadingInfo: ThreadingInfo | null;
+  currentRequestId: string | null;
+  pendingResolve: ((result: GenerationResult) => void) | null;
+  pendingReject: ((error: Error) => void) | null;
+  onProgress: ProgressCallback | null;
+  onCacheStats: CacheStatsCallback | null;
+  onKernelPerfStats: KernelPerfStatsCallback | null;
+  readonly adaptiveDebounce: AdaptiveDebounce;
+  readonly binCache: DedupCache;
+  readonly baseplateCache: DedupCache;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- pendingExports values are PendingExport<T> with different T per slot; type safety enforced at each call site
+  readonly pendingExports: Map<ExportSlot, PendingExport<any>>;
+  clearPending: () => void;
+  clearExportTimer: (pending: PendingExport<unknown>) => void;
+  resolveExport: (slot: ExportSlot, requestId: string, result: unknown) => boolean;
+  rejectExportByRequestId: (requestId: string, error: Error) => boolean;
+  commitDedupCache: (cache: DedupCache, result: GenerationResult) => void;
+  handleCacheStats: (caches: readonly WorkerCacheStats[]) => void;
+}
+
+/**
+ * Install the worker error + message listeners on `ctx.worker`.
+ * Caller must have a non-null worker before calling.
+ */
+export function installMessageHandler(ctx: MessageHandlerContext): void {
+  if (!ctx.worker) return;
+
+  // Handle worker crashes (WASM OOM, unrecoverable kernel errors).
+  // Without this, a worker crash leaves pending Promises unresolved and the
+  // UI stuck in "generating" state forever.
+  ctx.worker.addEventListener('error', (e) => {
+    e.preventDefault();
+    const message = e.message || 'Worker crashed unexpectedly (possible out-of-memory)';
+
+    // Tear down the dead worker so subsequent calls don't post to it.
+    // Clearing initPromise allows re-init on the next generate() call.
+    if (ctx.worker) {
+      ctx.worker.terminate();
+      ctx.worker = null;
+    }
+    ctx.initPromise = null;
+    ctx.threadingInfo = null;
+
+    if (ctx.pendingReject) {
+      const reject = ctx.pendingReject;
+      ctx.clearPending();
+      reject(new Error(message));
+    }
+
+    for (const pending of ctx.pendingExports.values()) {
+      ctx.clearExportTimer(pending);
+      pending.reject(new Error(message));
+    }
+    ctx.pendingExports.clear();
+  });
+
+  ctx.worker.addEventListener('message', (event: MessageEvent<WorkerResponse>) => {
+    const response = event.data;
+
+    switch (response.type) {
+      case 'PROGRESS':
+        if (response.requestId === ctx.currentRequestId && ctx.onProgress) {
+          ctx.onProgress(response.stage, response.progress);
+        }
+        break;
+
+      case 'MESH_RESULT':
+        if (response.requestId === ctx.currentRequestId && ctx.pendingResolve) {
+          ctx.adaptiveDebounce.recordTiming(response.timingMs);
+          const resolve = ctx.pendingResolve;
+          // Lid is optional: assemble it only when the worker actually sent
+          // lid arrays. All five lid fields land or are absent together.
+          const lidMesh =
+            response.lidVertices &&
+            response.lidNormals &&
+            response.lidIndices &&
+            response.lidEdgeVertices &&
+            response.lidTriangleCount !== undefined
+              ? {
+                  vertices: response.lidVertices,
+                  normals: response.lidNormals,
+                  indices: response.lidIndices,
+                  edgeVertices: response.lidEdgeVertices,
+                  triangleCount: response.lidTriangleCount,
+                  faceGroups: response.lidFaceGroups,
+                }
+              : undefined;
+          const result: GenerationResult = {
+            mesh: {
+              vertices: response.vertices,
+              normals: response.normals,
+              indices: response.indices,
+              edgeVertices: response.edgeVertices,
+              triangleCount: response.triangleCount,
+              faceGroups: response.faceGroups,
+              coarseLOD: response.coarseLOD,
+              lidMesh,
+            },
+            timingMs: response.timingMs,
+          };
+
+          // Cache for deduplication (bin or baseplate — only one is in-flight)
+          ctx.commitDedupCache(ctx.binCache, result);
+          ctx.commitDedupCache(ctx.baseplateCache, result);
+
+          ctx.clearPending();
+          resolve(result);
+        }
+        break;
+
+      case 'ERROR':
+        if (response.requestId === ctx.currentRequestId && ctx.pendingReject) {
+          const reject = ctx.pendingReject;
+          ctx.clearPending();
+          reject(new Error(response.error));
+        } else {
+          ctx.rejectExportByRequestId(response.requestId, new Error(response.error));
+        }
+        break;
+
+      case 'EXPORT_RESULT':
+        ctx.resolveExport('export', response.requestId, {
+          data: response.data,
+          fileName: response.fileName,
+          format: response.format,
+          faceGroups: response.faceGroups,
+        });
+        break;
+
+      case 'BASEPLATE_EXPORT_RESULT':
+        ctx.resolveExport('export', response.requestId, {
+          data: response.data,
+          fileName: response.fileName,
+          format: response.format,
+        });
+        break;
+
+      case 'DIVIDERS_EXPORT_RESULT':
+        ctx.resolveExport('dividers', response.requestId, {
+          data: response.data,
+          fileName: response.fileName,
+        });
+        break;
+
+      case 'COMBINED_EXPORT_RESULT':
+        ctx.resolveExport('combined', response.requestId, {
+          pieces: response.pieces,
+          format: response.format,
+          faceGroups: response.faceGroups,
+        });
+        break;
+
+      case 'SPLIT_EXPORT_RESULT':
+        ctx.resolveExport('split', response.requestId, {
+          pieces: response.pieces,
+        });
+        break;
+
+      case 'SPLIT_PREVIEW_RESULT':
+        ctx.resolveExport('splitPreview', response.requestId, {
+          pieces: response.pieces,
+        });
+        break;
+
+      case 'CACHE_STATS':
+        ctx.handleCacheStats(response.caches);
+        break;
+
+      case 'KERNEL_PERF_STATS':
+        ctx.onKernelPerfStats?.({ stats: response.stats });
+        break;
+
+      case 'INIT_READY':
+        // Already handled during init
+        break;
+    }
+  });
+}

--- a/src/features/generation/bridge/bridgeTypes.ts
+++ b/src/features/generation/bridge/bridgeTypes.ts
@@ -1,0 +1,134 @@
+/**
+ * Public type surface for `GenerationBridge` — extracted so the bridge file
+ * itself stays focused on the worker-lifecycle state machine.
+ */
+
+import type {
+  WorkerCacheStats,
+  MeshData,
+  GenerationStage,
+  ExportFormat,
+  ExportErrorCode,
+  SplitExportPiece,
+  SplitPreviewPiece,
+  CombinedExportPiece,
+  FaceGroupData,
+  KernelName,
+  KernelPerfCategory,
+} from './types';
+
+/** Callback for progress updates during generation */
+export type ProgressCallback = (stage: GenerationStage, progress: number) => void;
+
+/** Result from a successful generation */
+export interface GenerationResult {
+  readonly mesh: MeshData;
+  readonly timingMs: number;
+}
+
+/** Result from a successful BREP export */
+export interface ExportResult {
+  readonly data: ArrayBuffer;
+  readonly fileName: string;
+  readonly format: ExportFormat;
+  readonly faceGroups?: readonly FaceGroupData[];
+}
+
+/** Result from a successful dividers export */
+export interface DividersExportResult {
+  readonly data: ArrayBuffer;
+  readonly fileName: string;
+}
+
+/** Result from a combined bin + dividers export */
+export interface CombinedExportResult {
+  readonly pieces: readonly CombinedExportPiece[];
+  readonly format: ExportFormat;
+  readonly faceGroups?: readonly FaceGroupData[];
+}
+
+/** Result from a successful split export */
+export interface SplitExportResult {
+  readonly pieces: readonly SplitExportPiece[];
+}
+
+/** Result from a successful split preview generation (mesh data per piece) */
+export interface SplitPreviewResult {
+  readonly pieces: readonly SplitPreviewPiece[];
+}
+
+/** Result from a successful baseplate export */
+export interface BaseplateExportResult {
+  readonly data: ArrayBuffer;
+  readonly fileName: string;
+  readonly format: ExportFormat;
+}
+
+/** Aggregated cache performance stats for analytics. */
+export interface CacheStatsPayload {
+  readonly total_hits: number;
+  readonly total_misses: number;
+  readonly total_evictions: number;
+  readonly hit_rate: number;
+  readonly cache_count: number;
+  readonly per_cache: readonly WorkerCacheStats[];
+}
+
+/** Callback for cache stats reporting */
+export type CacheStatsCallback = (stats: CacheStatsPayload) => void;
+
+/** Payload for kernel performance stats callback */
+export interface KernelPerfStatsPayload {
+  readonly stats: Readonly<Record<string, KernelPerfCategory>>;
+}
+
+/** Callback for kernel perf stats reporting */
+export type KernelPerfStatsCallback = (payload: KernelPerfStatsPayload) => void;
+
+/** Information about the WASM threading capabilities */
+export interface ThreadingInfo {
+  /** Whether multi-threaded WASM is being used */
+  readonly isThreaded: boolean;
+  /** Number of CPU cores available */
+  readonly hardwareConcurrency: number;
+  /** Which geometry kernel was loaded */
+  readonly kernel: KernelName;
+}
+
+/** Size-1 dedup cache: stores the fingerprint and result of the last successful generation. */
+export interface DedupCache {
+  fingerprint: string | null;
+  result: GenerationResult | null;
+  /** Fingerprint of the currently in-flight request (stored so we can cache on success). */
+  pendingFingerprint: string | null;
+}
+
+/** Keys for the pending export request slots */
+export type ExportSlot = 'export' | 'dividers' | 'combined' | 'split' | 'splitPreview';
+
+/** A pending export request: resolve/reject callbacks + request ID + timeout timer */
+export interface PendingExport<T> {
+  readonly resolve: (result: T) => void;
+  readonly reject: (error: Error) => void;
+  readonly requestId: string;
+  /**
+   * Timeout handle that cancels the export and rejects the promise if the
+   * worker becomes unresponsive. Cleared whenever the request resolves,
+   * rejects, or the bridge is torn down.
+   */
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+/**
+ * Custom error thrown when an export request hits its timeout budget.
+ * The error message also passes the `/timeout/` regex used by the worker
+ * classifier so any downstream wrappers map it to {@link ExportErrorCode}
+ * `TIMEOUT` consistently.
+ */
+export class ExportTimeoutError extends Error {
+  readonly code: ExportErrorCode = 'TIMEOUT';
+  constructor(message = 'Export timed out — the geometry engine became unresponsive.') {
+    super(message);
+    this.name = 'ExportTimeoutError';
+  }
+}


### PR DESCRIPTION
## Summary

Decompose the 1079-LOC `GenerationBridge.ts` into 5 sibling modules. The class file is now **483 LOC** focused on the worker-lifecycle state machine; concern-specific code lives in siblings that the class delegates to one-to-one.

### Decomposition

| Module | LOC | Concern |
|---|---|---|
| `bridgeTypes.ts` | 134 | Public types (`GenerationResult`, `ExportResult`, `CacheStatsPayload`, …), internal `DedupCache`/`ExportSlot`/`PendingExport`, `ExportTimeoutError` class |
| `bridgeHelpers.ts` | 45 | `paramsFingerprint`, `extractThreadingInfo`, `createDedupCache` |
| `bridgeMessageHandler.ts` | 206 | `installMessageHandler` — wires worker `error` + `message` listeners; takes a `MessageHandlerContext` view of the bridge |
| `bridgeExports.ts` | 250 | 8 export methods + shared `runExport` helper that captures the prepare/register/timeout/post template |
| `bridgeGeneration.ts` | 159 | `generateBin` + `generateBaseplate` flows with shared timeout helper |

`GenerationBridge.ts`: **1079 → 483 LOC**.

### Why this shape

The class is fundamentally a coordinated state machine — the worker, debounce timer, generation timer, dedup caches, and pending-export map are all mutated across many methods. Rather than extract methods to mixin classes (awkward) or reach into `private` fields from siblings (a real leak), each sibling defines a structural context interface, and the class fields satisfying those interfaces were promoted from `private` to non-private. The interfaces ARE the public description of those fields; access from siblings now goes through them rather than through field-level encapsulation.

### Public API preserved

`GenerationBridge`'s public methods and the types re-exported from `bridge/index.ts` are byte-identical. Consumers (`BridgeManager`, `WorkerPool`, `bridgeRef.ts`, the test suite) compile unchanged.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` — 0 warnings
- [x] `pnpm exec vitest run src/features/generation/bridge` — **6 test files / 104 tests pass (239ms)**, including `GenerationBridge.test.ts` which exercises init/generate/cancel/destroy/export flows
- [x] `pnpm run build` — succeeds

PR 5 in the gap-closing series. PRs 1-4 (#1513, #1514, #1515, #1516) merged.