### PR TITLE
refactor(generation): split wallPatternBuilder into focused modules

### DIFF
--- a/src/features/generation/worker/generators/wallPatternBuilder.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.ts
@@ -7,28 +7,20 @@
  * clipping logic that don't fit the single cacheKey/build interface.
  *
  * Called as a special case after the generic feature runner in featuresStage.
+ *
+ * Sub-modules:
+ *   - `wallPatternTypes`     — shared interfaces + cache name constants
+ *   - `wallPatternCompound`  — per-wall hex compound construction + caching
+ *   - `wallPatternClips`     — cutout/handle/ramp clipping passes
  */
 
-import {
-  drawPolysides,
-  drawRectangle,
-  unwrap,
-  cut,
-  fuse,
-  clone,
-  compound,
-  composeTransforms,
-  transformCopy,
-  translate,
-  rotate,
-} from 'brepjs';
-import type { Shape3D, TransformOp } from 'brepjs';
+import { drawPolysides, unwrap, clone } from 'brepjs';
+import type { Shape3D } from 'brepjs';
 import type { PipelineContext } from './pipeline/types';
-import type { WallPatternDescriptor } from './wallPatterns';
 import { LIP_HEIGHT, LIP_TAPER_WIDTH } from './generatorConstants';
 import { sketch } from './meshUtils';
 import { buildCacheKey, quantize, compactKey } from './cacheKeyUtils';
-import { checkCancelled, isAbortError } from './utils/abort';
+import { checkCancelled } from './utils/abort';
 import {
   getFeatureCache,
   setFeatureCache,
@@ -40,11 +32,7 @@ import {
   CUTOUT_BORDER_WIDTH,
   getExpandedCutoutDimensions,
 } from './wallPatterns';
-import { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
 import { computeRampZones, computeDividerJunctionZones } from './dividerBlendBuilder';
-import type { RampZone } from './dividerBlendBuilder';
-import type { WallCutoutShape } from '@/shared/types/bin';
-import { buildSingleCutout } from './featureBuilder';
 import { FeatureTag } from './featureTags';
 import { collectOrigins } from './pipeline/collectOrigins';
 import {
@@ -57,62 +45,13 @@ import type { HandleSegment, HandleWallDef } from '@/shared/utils/handleCutoutCl
 import { computeMultiHandleOffsets } from '@/shared/utils/handleLayout';
 import { isPartialMask } from '@/shared/utils/cellMask';
 import { resolvePolygonSideGeometry } from './maskPolygonEdges';
-
-/**
- * Build a compound of positioned hex prisms for a single wall.
- *
- * Creates one transformCopy per hex center, then groups them with compound()
- * (O(n) topology grouping, not O(n²) fuseAll). Returns null if no elements.
- *
- * This is the expensive part of wall pattern construction (up to ~1000 hex
- * prisms on tall, wide bins). The result is cached in
- * `feature-wallPatternBase` keyed on wall geometry only, so cutout/handle/ramp
- * clip-parameter nudges don't force a rebuild — see buildWallPatterns.
- */
-function buildWallPatternCompound(
-  shapeTemplate: Shape3D,
-  wall: WallPatternDescriptor,
-  halfDepth: number
-): Shape3D | null {
-  const elements: Shape3D[] = [];
-  try {
-    for (const center of wall.centers) {
-      const ops: TransformOp[] = [
-        { type: 'translate', v: [center.x, center.y, -halfDepth] },
-        { type: 'rotate', angle: 90, axis: [1, 0, 0] },
-      ];
-      if (wall.zRotation !== undefined) {
-        ops.push({ type: 'rotate', angle: wall.zRotation, axis: [0, 0, 1] });
-      }
-      ops.push({
-        type: 'translate',
-        v: [wall.translateX, wall.translateY, wall.translateZ],
-      });
-      const trsf = composeTransforms(ops);
-      try {
-        elements.push(transformCopy(shapeTemplate, trsf));
-      } finally {
-        trsf.cleanup();
-      }
-    }
-
-    if (elements.length === 0) return null;
-    if (elements.length === 1) return elements[0];
-
-    const grouped = compound(elements);
-    for (const el of elements) el.delete();
-    return grouped;
-  } catch (e: unknown) {
-    for (const el of elements) el.delete();
-    if (isAbortError(e)) throw e;
-    return null;
-  }
-}
-
-/** Cache name for the uncut per-wall hex compound (shared across cutout/handle/ramp nudges). */
-const WALL_PATTERN_BASE_CACHE = 'wallPatternBase';
-/** Cache name for the post-clip per-wall compound (varies with cutout/handle/ramp params). */
-const WALL_PATTERN_CLIPPED_CACHE = 'wallPatternClipped';
+import {
+  WALL_PATTERN_CLIPPED_CACHE,
+  type CutoutClipParams,
+  type HandleClipParams,
+  type RampZoneClipParams,
+} from './wallPatternTypes';
+import { buildClippedWallPattern } from './wallPatternCompound';
 
 /**
  * Build wall pattern shapes for all walls with per-wall caching
@@ -400,302 +339,4 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
   }
 
   return patternCutTargets;
-}
-
-/**
- * Return the base (uncut) hex compound for a wall, cached by wall geometry.
- *
- * The caller receives an owned clone; the cache retains the original. When the
- * compound has no clips to apply, the clipped pipeline will cache this same
- * clone directly — two cache hits for the price of one.
- */
-function getCachedBaseCompound(
-  shapeTemplate: Shape3D,
-  wall: WallPatternDescriptor,
-  halfDepth: number,
-  baseKey: string
-): Shape3D | null {
-  const cached = getFeatureCache(WALL_PATTERN_BASE_CACHE, baseKey);
-  if (cached) return cached;
-
-  const built = buildWallPatternCompound(shapeTemplate, wall, halfDepth);
-  if (!built) return null;
-  setFeatureCache(WALL_PATTERN_BASE_CACHE, baseKey, built);
-  return unwrap(clone(built));
-}
-
-/**
- * Build a fully-clipped wall pattern by cloning the cached base compound and
- * applying cutout, handle, and ramp-zone cuts. Returns null when the base
- * compound can't be built (degenerate wall).
- */
-function buildClippedWallPattern(
-  shapeTemplate: Shape3D,
-  wall: WallPatternDescriptor,
-  halfDepth: number,
-  baseKey: string,
-  clip: CutoutClipParams | null,
-  handleClip: HandleClipParams | null,
-  rampClip: RampZoneClipParams | null
-): Shape3D | null {
-  const base = getCachedBaseCompound(shapeTemplate, wall, halfDepth, baseKey);
-  if (!base) return null;
-  return applyWallPatternClips(base, wall, clip, handleClip, rampClip);
-}
-
-/** Pre-computed cutout clipping parameters passed to buildWallPatternShape. */
-interface CutoutClipParams {
-  readonly cutoutCfg: {
-    enabled: boolean;
-    widthMm: number | null;
-    width: number;
-    depth: number;
-    alignment: 'left' | 'center' | 'right';
-    offset: number;
-  };
-  readonly cutWidth: number;
-  readonly userCutHeight: number;
-  readonly expandedWidth: number;
-  readonly expandedHeight: number;
-  readonly clipOvershoot: number;
-  readonly clipExtrudeDepth: number;
-  readonly wallHeight: number;
-  readonly wallSpan: number;
-  readonly wallShape: WallCutoutShape;
-  readonly wallThickness: number;
-}
-
-/** Pre-computed handle clipping parameters for a single wall. */
-interface HandleClipParams {
-  readonly segments: HandleSegment[];
-  readonly effectiveHeight: number;
-  readonly centerZ: number;
-  readonly clipExtrudeDepth: number;
-  /** Handle wall positioning (uses handleBuilder convention, not pattern descriptor). */
-  readonly handleWall: HandleWallDef;
-}
-
-/** Pre-computed ramp zone clipping parameters for a single wall. */
-interface RampZoneClipParams {
-  readonly zones: readonly RampZone[];
-  readonly clipExtrudeDepth: number;
-  readonly wallHeight: number;
-  /** Border width for clip boxes — max(CUTOUT_BORDER_WIDTH, shapeRadius)
-   *  so hex prisms don't extend into divider walls at junctions. */
-  readonly border: number;
-}
-
-/**
- * Apply optional cutout/handle/ramp clipping to an owned base hex compound.
- *
- * Takes ownership of `base` and returns either `base` itself (no clips) or a
- * new shape with `base` disposed. Callers must not reuse the original handle.
- */
-function applyWallPatternClips(
-  base: Shape3D,
-  wall: WallPatternDescriptor,
-  clip: CutoutClipParams | null,
-  handleClip: HandleClipParams | null,
-  rampClip: RampZoneClipParams | null
-): Shape3D | null {
-  // --- Cutout border clipping ---
-  let result = base;
-  if (clip && clip.cutWidth >= 0.1 && clip.userCutHeight >= 0.1) {
-    const rotateZ = wall.side === 'left' || wall.side === 'right' ? 90 : 0;
-    const centerOffset = computeCutoutCenter(
-      clip.wallSpan,
-      clip.cutWidth,
-      clip.wallThickness,
-      clip.cutoutCfg.alignment,
-      clip.cutoutCfg.offset
-    );
-
-    const clipSolid = buildSingleCutout(
-      clip.wallShape,
-      clip.expandedWidth,
-      clip.expandedHeight,
-      clip.clipOvershoot,
-      clip.clipExtrudeDepth,
-      clip.wallHeight,
-      {
-        x: rotateZ === 0 ? wall.translateX + centerOffset : wall.translateX,
-        y: rotateZ !== 0 ? wall.translateY + centerOffset : wall.translateY,
-        rotateZ,
-      }
-    );
-
-    try {
-      const clipped = unwrap(cut(result, clipSolid));
-      result.delete();
-      result = clipped;
-    } catch (err: unknown) {
-      if (isAbortError(err)) {
-        result.delete();
-        throw err;
-      }
-      // On non-abort failure, keep result as-is
-    } finally {
-      clipSolid.delete();
-    }
-  }
-
-  // --- Handle border clipping ---
-  if (handleClip && handleClip.segments.length > 0) {
-    const border = CUTOUT_BORDER_WIDTH;
-    const clipBoxes: Shape3D[] = [];
-
-    const hw = handleClip.handleWall;
-    try {
-      for (const seg of handleClip.segments) {
-        const boxW = seg.width + 2 * border;
-        const boxH = handleClip.effectiveHeight + 2 * border;
-        const profile = drawRectangle(boxW, boxH);
-        // Each transform allocates a new WASM handle while the previous
-        // becomes garbage. Dispose the intermediates explicitly so only
-        // the final handle survives in clipBoxes.
-        const extruded = sketch(profile, 'XZ').extrude(handleClip.clipExtrudeDepth);
-        const centered = translate(extruded, [
-          seg.offset,
-          handleClip.clipExtrudeDepth / 2,
-          handleClip.centerZ,
-        ]);
-        extruded.delete();
-        let hbox = centered;
-        if (hw.rotateZ !== 0) {
-          const rotated = rotate(hbox, hw.rotateZ, { axis: [0, 0, 1] });
-          hbox.delete();
-          hbox = rotated;
-        }
-        const positioned = translate(hbox, [hw.x, hw.y, 0]);
-        hbox.delete();
-        clipBoxes.push(positioned);
-      }
-
-      let handleClipSolid: Shape3D;
-      if (clipBoxes.length === 1) {
-        handleClipSolid = clipBoxes[0];
-      } else {
-        handleClipSolid = unwrap(fuse(clipBoxes[0], clipBoxes[1]));
-        clipBoxes[0].delete();
-        clipBoxes[1].delete();
-        for (let i = 2; i < clipBoxes.length; i++) {
-          const merged = unwrap(fuse(handleClipSolid, clipBoxes[i]));
-          handleClipSolid.delete();
-          clipBoxes[i].delete();
-          handleClipSolid = merged;
-        }
-      }
-
-      try {
-        const handleClipped = unwrap(cut(result, handleClipSolid));
-        result.delete();
-        result = handleClipped;
-      } catch (err: unknown) {
-        if (isAbortError(err)) {
-          result.delete();
-          throw err;
-        }
-        // On non-abort failure, keep result as-is
-      } finally {
-        handleClipSolid.delete();
-      }
-    } catch (err: unknown) {
-      for (const b of clipBoxes) {
-        try {
-          b.delete();
-        } catch {
-          /* already cleaned */
-        }
-      }
-      if (isAbortError(err)) {
-        result.delete();
-        throw err;
-      }
-    }
-  }
-
-  // --- Ramp zone border clipping ---
-  if (rampClip && rampClip.zones.length > 0) {
-    const { border, clipExtrudeDepth: rampExtrudeDepth, wallHeight, zones } = rampClip;
-    const rampBoxes: Shape3D[] = [];
-
-    try {
-      for (const zone of zones) {
-        const rboxW = zone.width + 2 * border;
-        const rboxH = zone.height + 2 * border;
-        const profile = drawRectangle(rboxW, rboxH);
-        // Dispose intermediates from each transform.
-        const extruded = sketch(profile, 'XZ').extrude(rampExtrudeDepth);
-        const centerZ = wallHeight - zone.height / 2;
-
-        // Build the box at the ORIGIN (not at offsetAlongWall), rotate to
-        // align with the wall, THEN translate to the wall midpoint plus the
-        // axial offset. Applying the rotation to a pre-offset box negates
-        // the offset for back (zRotation=180) and right (zRotation=-90)
-        // walls because rotation around Z negates the axial component —
-        // so a divider at global X=+a produced a clip box at X=-a on the
-        // back wall, leaving the actual junction unclipped and producing
-        // hex-prism bleed near divider-wall junctions on asymmetric bins.
-        // `offsetAlongWall` is a GLOBAL coordinate (posAlongPerp from
-        // dividerBlendBuilder), so it must be added AFTER rotation, along
-        // whichever global axis the wall runs (X for front/back, Y for
-        // left/right).
-        const centered = translate(extruded, [0, rampExtrudeDepth / 2, centerZ]);
-        extruded.delete();
-        let rbox = centered;
-        if (wall.zRotation !== undefined) {
-          const rotated = rotate(rbox, wall.zRotation, { axis: [0, 0, 1] });
-          rbox.delete();
-          rbox = rotated;
-        }
-        const rotZ = wall.zRotation ?? 0;
-        const offsetX = rotZ === 90 || rotZ === -90 ? 0 : zone.offsetAlongWall;
-        const offsetY = rotZ === 90 || rotZ === -90 ? zone.offsetAlongWall : 0;
-        const positioned = translate(rbox, [
-          wall.translateX + offsetX,
-          wall.translateY + offsetY,
-          0,
-        ]);
-        rbox.delete();
-        rampBoxes.push(positioned);
-      }
-
-      if (rampBoxes.length > 0) {
-        let rampClipSolid = rampBoxes[0];
-        for (let i = 1; i < rampBoxes.length; i++) {
-          const merged = unwrap(fuse(rampClipSolid, rampBoxes[i]));
-          rampClipSolid.delete();
-          rampBoxes[i].delete();
-          rampClipSolid = merged;
-        }
-
-        try {
-          const rampClipped = unwrap(cut(result, rampClipSolid));
-          result.delete();
-          result = rampClipped;
-        } catch (err: unknown) {
-          if (isAbortError(err)) {
-            result.delete();
-            throw err;
-          }
-        } finally {
-          rampClipSolid.delete();
-        }
-      }
-    } catch (err: unknown) {
-      for (const b of rampBoxes) {
-        try {
-          b.delete();
-        } catch {
-          /* already cleaned */
-        }
-      }
-      if (isAbortError(err)) {
-        result.delete();
-        throw err;
-      }
-    }
-  }
-
-  return result;
 }

--- a/src/features/generation/worker/generators/wallPatternClips.ts
+++ b/src/features/generation/worker/generators/wallPatternClips.ts
@@ -1,0 +1,236 @@
+/**
+ * Cutout/handle/ramp clipping passes for wall hex patterns.
+ *
+ * `applyWallPatternClips` takes ownership of the base hex compound and
+ * applies — in order — cutout border clipping, handle border clipping,
+ * and ramp-zone border clipping. Each pass returns a new shape and
+ * disposes the previous handle.
+ *
+ * Each clip box is at least as deep as the hex prism extrusion so it
+ * fully envelops hex prisms at junction/cutout boundaries (#1354).
+ */
+
+import { drawRectangle, unwrap, cut, fuse, translate, rotate } from 'brepjs';
+import type { Shape3D } from 'brepjs';
+import type { WallPatternDescriptor } from './wallPatterns';
+import { sketch } from './meshUtils';
+import { isAbortError } from './utils/abort';
+import { CUTOUT_BORDER_WIDTH } from './wallPatterns';
+import { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
+import { buildSingleCutout } from './featureBuilder';
+import type { CutoutClipParams, HandleClipParams, RampZoneClipParams } from './wallPatternTypes';
+
+/**
+ * Apply optional cutout/handle/ramp clipping to an owned base hex compound.
+ *
+ * Takes ownership of `base` and returns either `base` itself (no clips) or a
+ * new shape with `base` disposed. Callers must not reuse the original handle.
+ */
+export function applyWallPatternClips(
+  base: Shape3D,
+  wall: WallPatternDescriptor,
+  clip: CutoutClipParams | null,
+  handleClip: HandleClipParams | null,
+  rampClip: RampZoneClipParams | null
+): Shape3D | null {
+  // --- Cutout border clipping ---
+  let result = base;
+  if (clip && clip.cutWidth >= 0.1 && clip.userCutHeight >= 0.1) {
+    const rotateZ = wall.side === 'left' || wall.side === 'right' ? 90 : 0;
+    const centerOffset = computeCutoutCenter(
+      clip.wallSpan,
+      clip.cutWidth,
+      clip.wallThickness,
+      clip.cutoutCfg.alignment,
+      clip.cutoutCfg.offset
+    );
+
+    const clipSolid = buildSingleCutout(
+      clip.wallShape,
+      clip.expandedWidth,
+      clip.expandedHeight,
+      clip.clipOvershoot,
+      clip.clipExtrudeDepth,
+      clip.wallHeight,
+      {
+        x: rotateZ === 0 ? wall.translateX + centerOffset : wall.translateX,
+        y: rotateZ !== 0 ? wall.translateY + centerOffset : wall.translateY,
+        rotateZ,
+      }
+    );
+
+    try {
+      const clipped = unwrap(cut(result, clipSolid));
+      result.delete();
+      result = clipped;
+    } catch (err: unknown) {
+      if (isAbortError(err)) {
+        result.delete();
+        throw err;
+      }
+      // On non-abort failure, keep result as-is
+    } finally {
+      clipSolid.delete();
+    }
+  }
+
+  // --- Handle border clipping ---
+  if (handleClip && handleClip.segments.length > 0) {
+    const border = CUTOUT_BORDER_WIDTH;
+    const clipBoxes: Shape3D[] = [];
+
+    const hw = handleClip.handleWall;
+    try {
+      for (const seg of handleClip.segments) {
+        const boxW = seg.width + 2 * border;
+        const boxH = handleClip.effectiveHeight + 2 * border;
+        const profile = drawRectangle(boxW, boxH);
+        // Each transform allocates a new WASM handle while the previous
+        // becomes garbage. Dispose the intermediates explicitly so only
+        // the final handle survives in clipBoxes.
+        const extruded = sketch(profile, 'XZ').extrude(handleClip.clipExtrudeDepth);
+        const centered = translate(extruded, [
+          seg.offset,
+          handleClip.clipExtrudeDepth / 2,
+          handleClip.centerZ,
+        ]);
+        extruded.delete();
+        let hbox = centered;
+        if (hw.rotateZ !== 0) {
+          const rotated = rotate(hbox, hw.rotateZ, { axis: [0, 0, 1] });
+          hbox.delete();
+          hbox = rotated;
+        }
+        const positioned = translate(hbox, [hw.x, hw.y, 0]);
+        hbox.delete();
+        clipBoxes.push(positioned);
+      }
+
+      let handleClipSolid: Shape3D;
+      if (clipBoxes.length === 1) {
+        handleClipSolid = clipBoxes[0];
+      } else {
+        handleClipSolid = unwrap(fuse(clipBoxes[0], clipBoxes[1]));
+        clipBoxes[0].delete();
+        clipBoxes[1].delete();
+        for (let i = 2; i < clipBoxes.length; i++) {
+          const merged = unwrap(fuse(handleClipSolid, clipBoxes[i]));
+          handleClipSolid.delete();
+          clipBoxes[i].delete();
+          handleClipSolid = merged;
+        }
+      }
+
+      try {
+        const handleClipped = unwrap(cut(result, handleClipSolid));
+        result.delete();
+        result = handleClipped;
+      } catch (err: unknown) {
+        if (isAbortError(err)) {
+          result.delete();
+          throw err;
+        }
+        // On non-abort failure, keep result as-is
+      } finally {
+        handleClipSolid.delete();
+      }
+    } catch (err: unknown) {
+      for (const b of clipBoxes) {
+        try {
+          b.delete();
+        } catch {
+          /* already cleaned */
+        }
+      }
+      if (isAbortError(err)) {
+        result.delete();
+        throw err;
+      }
+    }
+  }
+
+  // --- Ramp zone border clipping ---
+  if (rampClip && rampClip.zones.length > 0) {
+    const { border, clipExtrudeDepth: rampExtrudeDepth, wallHeight, zones } = rampClip;
+    const rampBoxes: Shape3D[] = [];
+
+    try {
+      for (const zone of zones) {
+        const rboxW = zone.width + 2 * border;
+        const rboxH = zone.height + 2 * border;
+        const profile = drawRectangle(rboxW, rboxH);
+        // Dispose intermediates from each transform.
+        const extruded = sketch(profile, 'XZ').extrude(rampExtrudeDepth);
+        const centerZ = wallHeight - zone.height / 2;
+
+        // Build the box at the ORIGIN (not at offsetAlongWall), rotate to
+        // align with the wall, THEN translate to the wall midpoint plus the
+        // axial offset. Applying the rotation to a pre-offset box negates
+        // the offset for back (zRotation=180) and right (zRotation=-90)
+        // walls because rotation around Z negates the axial component —
+        // so a divider at global X=+a produced a clip box at X=-a on the
+        // back wall, leaving the actual junction unclipped and producing
+        // hex-prism bleed near divider-wall junctions on asymmetric bins.
+        // `offsetAlongWall` is a GLOBAL coordinate (posAlongPerp from
+        // dividerBlendBuilder), so it must be added AFTER rotation, along
+        // whichever global axis the wall runs (X for front/back, Y for
+        // left/right).
+        const centered = translate(extruded, [0, rampExtrudeDepth / 2, centerZ]);
+        extruded.delete();
+        let rbox = centered;
+        if (wall.zRotation !== undefined) {
+          const rotated = rotate(rbox, wall.zRotation, { axis: [0, 0, 1] });
+          rbox.delete();
+          rbox = rotated;
+        }
+        const rotZ = wall.zRotation ?? 0;
+        const offsetX = rotZ === 90 || rotZ === -90 ? 0 : zone.offsetAlongWall;
+        const offsetY = rotZ === 90 || rotZ === -90 ? zone.offsetAlongWall : 0;
+        const positioned = translate(rbox, [
+          wall.translateX + offsetX,
+          wall.translateY + offsetY,
+          0,
+        ]);
+        rbox.delete();
+        rampBoxes.push(positioned);
+      }
+
+      if (rampBoxes.length > 0) {
+        let rampClipSolid = rampBoxes[0];
+        for (let i = 1; i < rampBoxes.length; i++) {
+          const merged = unwrap(fuse(rampClipSolid, rampBoxes[i]));
+          rampClipSolid.delete();
+          rampBoxes[i].delete();
+          rampClipSolid = merged;
+        }
+
+        try {
+          const rampClipped = unwrap(cut(result, rampClipSolid));
+          result.delete();
+          result = rampClipped;
+        } catch (err: unknown) {
+          if (isAbortError(err)) {
+            result.delete();
+            throw err;
+          }
+        } finally {
+          rampClipSolid.delete();
+        }
+      }
+    } catch (err: unknown) {
+      for (const b of rampBoxes) {
+        try {
+          b.delete();
+        } catch {
+          /* already cleaned */
+        }
+      }
+      if (isAbortError(err)) {
+        result.delete();
+        throw err;
+      }
+    }
+  }
+
+  return result;
+}

--- a/src/features/generation/worker/generators/wallPatternClips.ts
+++ b/src/features/generation/worker/generators/wallPatternClips.ts
@@ -78,6 +78,10 @@ export function applyWallPatternClips(
   if (handleClip && handleClip.segments.length > 0) {
     const border = CUTOUT_BORDER_WIDTH;
     const clipBoxes: Shape3D[] = [];
+    // Tracks the in-flight fuse-merge result so the catch can dispose it
+    // if an intermediate fuse() throws. Set to null once ownership is
+    // handed off to handleClipSolid (or never created on the singleton path).
+    let pendingMerge: Shape3D | null = null;
 
     const hw = handleClip.handleWall;
     try {
@@ -110,15 +114,19 @@ export function applyWallPatternClips(
       if (clipBoxes.length === 1) {
         handleClipSolid = clipBoxes[0];
       } else {
-        handleClipSolid = unwrap(fuse(clipBoxes[0], clipBoxes[1]));
+        let current: Shape3D = unwrap(fuse(clipBoxes[0], clipBoxes[1]));
+        pendingMerge = current;
         clipBoxes[0].delete();
         clipBoxes[1].delete();
         for (let i = 2; i < clipBoxes.length; i++) {
-          const merged = unwrap(fuse(handleClipSolid, clipBoxes[i]));
-          handleClipSolid.delete();
+          const merged: Shape3D = unwrap(fuse(current, clipBoxes[i]));
+          current.delete();
           clipBoxes[i].delete();
-          handleClipSolid = merged;
+          current = merged;
+          pendingMerge = current;
         }
+        handleClipSolid = current;
+        pendingMerge = null; // ownership transferred to handleClipSolid
       }
 
       try {
@@ -142,6 +150,13 @@ export function applyWallPatternClips(
           /* already cleaned */
         }
       }
+      if (pendingMerge) {
+        try {
+          pendingMerge.delete();
+        } catch {
+          /* already cleaned */
+        }
+      }
       if (isAbortError(err)) {
         result.delete();
         throw err;
@@ -153,6 +168,9 @@ export function applyWallPatternClips(
   if (rampClip && rampClip.zones.length > 0) {
     const { border, clipExtrudeDepth: rampExtrudeDepth, wallHeight, zones } = rampClip;
     const rampBoxes: Shape3D[] = [];
+    // See handle-clip block for why pendingMerge is tracked separately
+    // from rampBoxes — the in-flight fuse intermediate isn't in either pool.
+    let pendingMerge: Shape3D | null = null;
 
     try {
       for (const zone of zones) {
@@ -196,13 +214,17 @@ export function applyWallPatternClips(
       }
 
       if (rampBoxes.length > 0) {
-        let rampClipSolid = rampBoxes[0];
+        let current: Shape3D = rampBoxes[0];
+        pendingMerge = current;
         for (let i = 1; i < rampBoxes.length; i++) {
-          const merged = unwrap(fuse(rampClipSolid, rampBoxes[i]));
-          rampClipSolid.delete();
+          const merged: Shape3D = unwrap(fuse(current, rampBoxes[i]));
+          current.delete();
           rampBoxes[i].delete();
-          rampClipSolid = merged;
+          current = merged;
+          pendingMerge = current;
         }
+        const rampClipSolid = current;
+        pendingMerge = null; // ownership transferred to rampClipSolid
 
         try {
           const rampClipped = unwrap(cut(result, rampClipSolid));
@@ -221,6 +243,13 @@ export function applyWallPatternClips(
       for (const b of rampBoxes) {
         try {
           b.delete();
+        } catch {
+          /* already cleaned */
+        }
+      }
+      if (pendingMerge) {
+        try {
+          pendingMerge.delete();
         } catch {
           /* already cleaned */
         }

--- a/src/features/generation/worker/generators/wallPatternCompound.ts
+++ b/src/features/generation/worker/generators/wallPatternCompound.ts
@@ -32,7 +32,7 @@ import { applyWallPatternClips } from './wallPatternClips';
  * Creates one transformCopy per hex center, then groups them with compound()
  * (O(n) topology grouping, not O(n²) fuseAll). Returns null if no elements.
  */
-export function buildWallPatternCompound(
+function buildWallPatternCompound(
   shapeTemplate: Shape3D,
   wall: WallPatternDescriptor,
   halfDepth: number
@@ -78,8 +78,10 @@ export function buildWallPatternCompound(
  * The caller receives an owned clone; the cache retains the original. When the
  * compound has no clips to apply, the clipped pipeline will cache this same
  * clone directly — two cache hits for the price of one.
+ *
+ * Kept private so the base cache is only reachable via `buildClippedWallPattern`.
  */
-export function getCachedBaseCompound(
+function getCachedBaseCompound(
   shapeTemplate: Shape3D,
   wall: WallPatternDescriptor,
   halfDepth: number,

--- a/src/features/generation/worker/generators/wallPatternCompound.ts
+++ b/src/features/generation/worker/generators/wallPatternCompound.ts
@@ -1,0 +1,114 @@
+/**
+ * Per-wall hex prism compound construction + cache lookup.
+ *
+ * `buildWallPatternCompound` is the expensive part of wall pattern
+ * construction (up to ~1000 hex prisms on tall, wide bins). It uses
+ * `transformCopy` + `compound` to group elements with O(n) topology
+ * grouping rather than O(n²) `fuseAll`.
+ *
+ * `getCachedBaseCompound` keys the result on wall geometry only so
+ * cutout/handle/ramp parameter nudges don't force a rebuild (#1422).
+ *
+ * `buildClippedWallPattern` chains the cached base through
+ * `applyWallPatternClips`.
+ */
+
+import { unwrap, clone, compound, composeTransforms, transformCopy } from 'brepjs';
+import type { Shape3D, TransformOp } from 'brepjs';
+import type { WallPatternDescriptor } from './wallPatterns';
+import { isAbortError } from './utils/abort';
+import { getFeatureCache, setFeatureCache } from './shapeCache';
+import {
+  WALL_PATTERN_BASE_CACHE,
+  type CutoutClipParams,
+  type HandleClipParams,
+  type RampZoneClipParams,
+} from './wallPatternTypes';
+import { applyWallPatternClips } from './wallPatternClips';
+
+/**
+ * Build a compound of positioned hex prisms for a single wall.
+ *
+ * Creates one transformCopy per hex center, then groups them with compound()
+ * (O(n) topology grouping, not O(n²) fuseAll). Returns null if no elements.
+ */
+export function buildWallPatternCompound(
+  shapeTemplate: Shape3D,
+  wall: WallPatternDescriptor,
+  halfDepth: number
+): Shape3D | null {
+  const elements: Shape3D[] = [];
+  try {
+    for (const center of wall.centers) {
+      const ops: TransformOp[] = [
+        { type: 'translate', v: [center.x, center.y, -halfDepth] },
+        { type: 'rotate', angle: 90, axis: [1, 0, 0] },
+      ];
+      if (wall.zRotation !== undefined) {
+        ops.push({ type: 'rotate', angle: wall.zRotation, axis: [0, 0, 1] });
+      }
+      ops.push({
+        type: 'translate',
+        v: [wall.translateX, wall.translateY, wall.translateZ],
+      });
+      const trsf = composeTransforms(ops);
+      try {
+        elements.push(transformCopy(shapeTemplate, trsf));
+      } finally {
+        trsf.cleanup();
+      }
+    }
+
+    if (elements.length === 0) return null;
+    if (elements.length === 1) return elements[0];
+
+    const grouped = compound(elements);
+    for (const el of elements) el.delete();
+    return grouped;
+  } catch (e: unknown) {
+    for (const el of elements) el.delete();
+    if (isAbortError(e)) throw e;
+    return null;
+  }
+}
+
+/**
+ * Return the base (uncut) hex compound for a wall, cached by wall geometry.
+ *
+ * The caller receives an owned clone; the cache retains the original. When the
+ * compound has no clips to apply, the clipped pipeline will cache this same
+ * clone directly — two cache hits for the price of one.
+ */
+export function getCachedBaseCompound(
+  shapeTemplate: Shape3D,
+  wall: WallPatternDescriptor,
+  halfDepth: number,
+  baseKey: string
+): Shape3D | null {
+  const cached = getFeatureCache(WALL_PATTERN_BASE_CACHE, baseKey);
+  if (cached) return cached;
+
+  const built = buildWallPatternCompound(shapeTemplate, wall, halfDepth);
+  if (!built) return null;
+  setFeatureCache(WALL_PATTERN_BASE_CACHE, baseKey, built);
+  return unwrap(clone(built));
+}
+
+/**
+ * Build a fully-clipped wall pattern by cloning the cached base compound and
+ * applying cutout, handle, and ramp-zone cuts. Returns null when the base
+ * compound can't be built (degenerate wall).
+ */
+export function buildClippedWallPattern(
+  shapeTemplate: Shape3D,
+  wall: WallPatternDescriptor,
+  halfDepth: number,
+  baseKey: string,
+  clip: CutoutClipParams | null,
+  handleClip: HandleClipParams | null,
+  rampClip: RampZoneClipParams | null
+): Shape3D | null {
+  const base = getCachedBaseCompound(shapeTemplate, wall, halfDepth, baseKey);
+  if (!base) return null;
+  return applyWallPatternClips(base, wall, clip, handleClip, rampClip);
+}

--- a/src/features/generation/worker/generators/wallPatternTypes.ts
+++ b/src/features/generation/worker/generators/wallPatternTypes.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared type and constant definitions for the wall pattern pipeline.
+ *
+ * Split out so `wallPatternBuilder` (orchestrator), `wallPatternCompound`
+ * (base hex compounds), and `wallPatternClips` (cutout/handle/ramp clipping)
+ * can all import without a circular dependency.
+ */
+
+import type { HandleSegment, HandleWallDef } from '@/shared/utils/handleCutoutClip';
+import type { WallCutoutShape } from '@/shared/types/bin';
+import type { RampZone } from './dividerBlendBuilder';
+
+/** Cache name for the uncut per-wall hex compound (shared across cutout/handle/ramp nudges). */
+export const WALL_PATTERN_BASE_CACHE = 'wallPatternBase';
+/** Cache name for the post-clip per-wall compound (varies with cutout/handle/ramp params). */
+export const WALL_PATTERN_CLIPPED_CACHE = 'wallPatternClipped';
+
+/** Pre-computed cutout clipping parameters passed to applyWallPatternClips. */
+export interface CutoutClipParams {
+  readonly cutoutCfg: {
+    enabled: boolean;
+    widthMm: number | null;
+    width: number;
+    depth: number;
+    alignment: 'left' | 'center' | 'right';
+    offset: number;
+  };
+  readonly cutWidth: number;
+  readonly userCutHeight: number;
+  readonly expandedWidth: number;
+  readonly expandedHeight: number;
+  readonly clipOvershoot: number;
+  readonly clipExtrudeDepth: number;
+  readonly wallHeight: number;
+  readonly wallSpan: number;
+  readonly wallShape: WallCutoutShape;
+  readonly wallThickness: number;
+}
+
+/** Pre-computed handle clipping parameters for a single wall. */
+export interface HandleClipParams {
+  readonly segments: HandleSegment[];
+  readonly effectiveHeight: number;
+  readonly centerZ: number;
+  readonly clipExtrudeDepth: number;
+  /** Handle wall positioning (uses handleBuilder convention, not pattern descriptor). */
+  readonly handleWall: HandleWallDef;
+}
+
+/** Pre-computed ramp zone clipping parameters for a single wall. */
+export interface RampZoneClipParams {
+  readonly zones: readonly RampZone[];
+  readonly clipExtrudeDepth: number;
+  readonly wallHeight: number;
+  /** Border width for clip boxes — max(CUTOUT_BORDER_WIDTH, shapeRadius)
+   *  so hex prisms don't extend into divider walls at junctions. */
+  readonly border: number;
+}


### PR DESCRIPTION
## Summary
Split the 701-LOC `wallPatternBuilder.ts` into a slim orchestrator plus three focused modules:
- `wallPatternTypes.ts` (58 LOC): cache constants + clip-param interfaces.
- `wallPatternCompound.ts` (114 LOC): hex prism construction + cache lookup + clipped-pattern entry point.
- `wallPatternClips.ts` (236 LOC): cutout / handle / ramp-zone clipping passes.
- `wallPatternBuilder.ts` (342 LOC): orchestrator only — clip-param construction + cache key composition.

## Test plan
- [x] \`pnpm run typecheck\`
- [x] \`pnpm run lint\`
- [x] \`pnpm exec vitest run src/features/generation/worker/generators/wallPattern\` — 20 pass
- [x] No public API change — \`buildWallPatterns\` still the only export