### PR TITLE
refactor(generation): split dividerBlendBuilder into focused modules

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"e0d5e36a-8e10-4983-bda2-9bb8009d749e","pid":2666998,"procStart":"149329676","acquiredAt":1777453338169}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"e0d5e36a-8e10-4983-bda2-9bb8009d749e","pid":2666998,"procStart":"149329676","acquiredAt":1777453338169}

--- a/src/features/generation/worker/generators/dividerBlendBuilder.ts
+++ b/src/features/generation/worker/generators/dividerBlendBuilder.ts
@@ -9,388 +9,32 @@
  * Case 3 — Parallel divider visible through cutout: flat horizontal trim
  *
  * Standard (fused wall) bin style only — slotted bins are skipped.
+ *
+ * Sub-modules:
+ *   - `dividerBlendTypes`     — interfaces, predicates, ramp-zone descriptor
+ *   - `dividerBlendResolvers` — pure resolveOuterCutouts / collectDividers
+ *   - `dividerBlendCuts`      — buildEndTrimCut / buildRampCut / buildParallelTrimCut
  */
 
-import { box, draw, translate, rotate } from 'brepjs';
 import type { Shape3D } from 'brepjs';
-import type { BinParams, WallCutoutShape } from '@/shared/types/bin';
-import { sketch } from './meshUtils';
+import type { BinParams } from '@/shared/types/bin';
 import { fuseAllOrNull } from './utils/shapeOps';
-import { findWallSegments } from './compartmentBuilder';
-import { buildSingleCutout } from './featureBuilder';
-import { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
-import { LIP_HEIGHT, COPLANAR_MARGIN } from './generatorConstants';
+import { COPLANAR_MARGIN } from './generatorConstants';
+import {
+  type RampZone,
+  MIN_DIM,
+  dividerTouchesWall,
+  getWallFaceInfo,
+  isPerpendicular,
+} from './dividerBlendTypes';
+import { collectDividers, resolveOuterCutouts } from './dividerBlendResolvers';
+import { buildEndTrimCut, buildParallelTrimCut, buildRampCut } from './dividerBlendCuts';
+import type { FeatureBuilder } from './pipeline/featureBuilder';
+import { FeatureTag } from './featureTags';
+import { buildCacheKey, quantize, stableSerialize, compactKey } from './cacheKeyUtils';
 
-/** Resolved outer-wall cutout geometry in bin-global coordinates. */
-interface OuterWallCutoutInfo {
-  readonly side: 'front' | 'back' | 'left' | 'right';
-  /** Full wall span along the span axis (mm). */
-  readonly wallSpan: number;
-  /** Cutout width (mm). */
-  readonly cutWidth: number;
-  /** Cutout height from wall top (mm). */
-  readonly userCutHeight: number;
-  /** Z coordinate of cutout bottom edge. */
-  readonly cutBottom: number;
-  /** Cutout center offset from wall center along span axis (mm). */
-  readonly centerOffset: number;
-  /** Left edge of cutout in global span-axis coords (mm). */
-  readonly cutLeft: number;
-  /** Right edge of cutout in global span-axis coords (mm). */
-  readonly cutRight: number;
-  /** Coordinate of the wall face (e.g. -innerD/2 for front). */
-  readonly wallFaceCoord: number;
-  /** Sign of inward direction from this wall (+1 for front, -1 for back). */
-  readonly inwardSign: number;
-  /** Span axis: 'x' for front/back, 'y' for left/right. */
-  readonly spanAxis: 'x' | 'y';
-}
-
-/** Divider wall segment in bin-global coordinates. */
-interface DividerInfo {
-  /** Vertical = between columns (runs along Y), horizontal = between rows (runs along X). */
-  readonly axis: 'vertical' | 'horizontal';
-  /** Position along the perpendicular axis (X for vertical dividers, Y for horizontal). */
-  readonly posAlongPerp: number;
-  /** Start of segment along span axis (mm). */
-  readonly spanStart: number;
-  /** End of segment along span axis (mm). */
-  readonly spanEnd: number;
-  /** Divider wall thickness (mm). */
-  readonly thickness: number;
-}
-
-/** Minimum geometry dimension to avoid degenerate shapes (mm). */
-const MIN_DIM = 0.5;
-
-/** Tolerance for matching divider endpoints to wall face coordinates (mm). */
-const WALL_TOUCH_TOL = 0.01;
-
-/** Minimal wall face descriptor shared by cutout info and junction detection. */
-interface WallFaceInfo {
-  readonly wallFaceCoord: number;
-  readonly inwardSign: number;
-  readonly spanAxis: 'x' | 'y';
-}
-
-/** Build a WallFaceInfo for a given side from bin inner dimensions. */
-function getWallFaceInfo(
-  side: 'front' | 'back' | 'left' | 'right',
-  innerW: number,
-  innerD: number
-): WallFaceInfo {
-  const info: Record<string, WallFaceInfo> = {
-    front: { wallFaceCoord: -innerD / 2, inwardSign: 1, spanAxis: 'x' },
-    back: { wallFaceCoord: innerD / 2, inwardSign: -1, spanAxis: 'x' },
-    left: { wallFaceCoord: -innerW / 2, inwardSign: 1, spanAxis: 'y' },
-    right: { wallFaceCoord: innerW / 2, inwardSign: -1, spanAxis: 'y' },
-  };
-  return info[side];
-}
-
-/**
- * Resolve outer-wall cutout geometry for all enabled sides.
- * Pure function — no brepjs dependency.
- */
-export function resolveOuterCutouts(
-  params: BinParams,
-  innerW: number,
-  innerD: number,
-  wallHeight: number
-): OuterWallCutoutInfo[] {
-  if (!params.walls.enabled) return [];
-
-  const interiorHeight = wallHeight - params.wallThickness;
-  const result: OuterWallCutoutInfo[] = [];
-
-  const sides: Array<{
-    key: 'front' | 'back' | 'left' | 'right';
-    wallSpan: number;
-    wallFaceCoord: number;
-    inwardSign: number;
-    spanAxis: 'x' | 'y';
-  }> = [
-    { key: 'front', wallSpan: innerW, wallFaceCoord: -innerD / 2, inwardSign: 1, spanAxis: 'x' },
-    { key: 'back', wallSpan: innerW, wallFaceCoord: innerD / 2, inwardSign: -1, spanAxis: 'x' },
-    { key: 'left', wallSpan: innerD, wallFaceCoord: -innerW / 2, inwardSign: 1, spanAxis: 'y' },
-    { key: 'right', wallSpan: innerD, wallFaceCoord: innerW / 2, inwardSign: -1, spanAxis: 'y' },
-  ];
-
-  for (const side of sides) {
-    const cfg = params.walls[side.key];
-    if (!cfg.enabled) continue;
-
-    const cutWidth =
-      cfg.widthMm !== null
-        ? Math.min(cfg.widthMm, side.wallSpan)
-        : side.wallSpan * (cfg.width / 100);
-
-    const userCutHeight = interiorHeight * (cfg.depth / 100);
-    if (cutWidth < 0.1 || userCutHeight < 0.1) continue;
-
-    const centerOffset = computeCutoutCenter(
-      side.wallSpan,
-      cutWidth,
-      params.wallThickness,
-      cfg.alignment,
-      cfg.offset
-    );
-
-    result.push({
-      side: side.key,
-      wallSpan: side.wallSpan,
-      cutWidth,
-      userCutHeight,
-      cutBottom: wallHeight - userCutHeight,
-      centerOffset,
-      cutLeft: centerOffset - cutWidth / 2,
-      cutRight: centerOffset + cutWidth / 2,
-      wallFaceCoord: side.wallFaceCoord,
-      inwardSign: side.inwardSign,
-      spanAxis: side.spanAxis,
-    });
-  }
-
-  return result;
-}
-
-/**
- * Collect divider wall segments from the compartment grid.
- * Pure function — mirrors compartmentBuilder logic.
- */
-export function collectDividers(params: BinParams, innerW: number, innerD: number): DividerInfo[] {
-  const { cols, rows, thickness, cells } = params.compartments;
-  if (cols <= 1 && rows <= 1) return [];
-  if (new Set(cells).size <= 1) return [];
-
-  const cellW = innerW / cols;
-  const cellD = innerD / rows;
-
-  // Mirror buildCompartmentWalls small-cell guard:
-  // skip axes where cells are too narrow for viable divider geometry.
-  const effectiveCellW = (innerW - (cols - 1) * thickness) / cols;
-  const effectiveCellD = (innerD - (rows - 1) * thickness) / rows;
-  const canBuildVertical = effectiveCellW >= thickness * 2;
-  const canBuildHorizontal = effectiveCellD >= thickness * 2;
-
-  const dividers: DividerInfo[] = [];
-
-  // Vertical dividers (between columns, run along Y)
-  if (canBuildVertical)
-    for (let colBoundary = 1; colBoundary < cols; colBoundary++) {
-      const xPos = -innerW / 2 + colBoundary * cellW;
-      const segments = findWallSegments(rows, (row) => {
-        const leftId = cells[row * cols + (colBoundary - 1)];
-        const rightId = cells[row * cols + colBoundary];
-        return leftId !== rightId;
-      });
-      for (const [start, end] of segments) {
-        dividers.push({
-          axis: 'vertical',
-          posAlongPerp: xPos,
-          spanStart: -innerD / 2 + start * cellD,
-          spanEnd: -innerD / 2 + end * cellD,
-          thickness,
-        });
-      }
-    }
-
-  // Horizontal dividers (between rows, run along X)
-  if (canBuildHorizontal)
-    for (let rowBoundary = 1; rowBoundary < rows; rowBoundary++) {
-      const yPos = -innerD / 2 + rowBoundary * cellD;
-      const segments = findWallSegments(cols, (col) => {
-        const topId = cells[(rowBoundary - 1) * cols + col];
-        const bottomId = cells[rowBoundary * cols + col];
-        return topId !== bottomId;
-      });
-      for (const [start, end] of segments) {
-        dividers.push({
-          axis: 'horizontal',
-          posAlongPerp: yPos,
-          spanStart: -innerW / 2 + start * cellW,
-          spanEnd: -innerW / 2 + end * cellW,
-          thickness,
-        });
-      }
-    }
-
-  return dividers;
-}
-
-/**
- * Check if a divider is perpendicular to a given wall face.
- * Vertical dividers (run along Y) are perpendicular to front/back walls.
- * Horizontal dividers (run along X) are perpendicular to left/right walls.
- */
-function isPerpendicular(divider: DividerInfo, wall: WallFaceInfo): boolean {
-  if (divider.axis === 'vertical') return wall.spanAxis === 'x'; // front/back
-  return wall.spanAxis === 'y'; // left/right
-}
-
-/**
- * Check if a divider's end touches a specific wall face.
- */
-function dividerTouchesWall(divider: DividerInfo, wall: WallFaceInfo): boolean {
-  if (divider.axis === 'vertical' && wall.spanAxis === 'x') {
-    // Vertical divider, front/back wall
-    if (wall.inwardSign > 0)
-      return Math.abs(divider.spanStart - wall.wallFaceCoord) < WALL_TOUCH_TOL;
-    return Math.abs(divider.spanEnd - wall.wallFaceCoord) < WALL_TOUCH_TOL;
-  }
-  if (divider.axis === 'horizontal' && wall.spanAxis === 'y') {
-    // Horizontal divider, left/right wall
-    if (wall.inwardSign > 0)
-      return Math.abs(divider.spanStart - wall.wallFaceCoord) < WALL_TOUCH_TOL;
-    return Math.abs(divider.spanEnd - wall.wallFaceCoord) < WALL_TOUCH_TOL;
-  }
-  return false;
-}
-
-/**
- * Case 1: Trim divider end to match cutout profile.
- *
- * When a perpendicular divider terminates within the cutout's horizontal span,
- * cut its end to follow the same profile shape as the outer-wall cutout.
- */
-function buildEndTrimCut(
-  divider: DividerInfo,
-  cutout: OuterWallCutoutInfo,
-  cutoutShape: WallCutoutShape,
-  wallHeight: number,
-  hasLip: boolean
-): Shape3D | null {
-  const overshoot = (hasLip ? LIP_HEIGHT : 0) + 2;
-  // Extrude deep enough to cut through divider thickness + margins
-  const extrudeDepth = divider.thickness + 2 * COPLANAR_MARGIN;
-
-  // Position at the cutout center (not the divider) so the profile shape
-  // matches the outer wall cutout exactly. The narrow extrusion only intersects
-  // the divider end where it's coplanar with the wall face.
-  const isVertical = divider.axis === 'vertical';
-
-  return buildSingleCutout(
-    cutoutShape,
-    cutout.cutWidth,
-    cutout.userCutHeight,
-    overshoot,
-    extrudeDepth,
-    wallHeight,
-    {
-      x: isVertical ? cutout.centerOffset : cutout.wallFaceCoord,
-      y: isVertical ? cutout.wallFaceCoord : cutout.centerOffset,
-      rotateZ: isVertical ? 0 : 90,
-    }
-  );
-}
-
-/**
- * Case 2: Ramp from full height to cutout bottom.
- *
- * A straight-slope wedge cut where a perpendicular divider is adjacent to
- * (just outside) the cutout span. Ramp length = userCutHeight, capped at
- * half the divider's span length. Creates a ~45° slope.
- */
-function buildRampCut(
-  divider: DividerInfo,
-  cutout: OuterWallCutoutInfo,
-  wallHeight: number
-): Shape3D | null {
-  const segLength = divider.spanEnd - divider.spanStart;
-  const rampLen = Math.min(cutout.userCutHeight, segLength / 2);
-  if (rampLen < MIN_DIM) return null;
-
-  const rampHeight = cutout.userCutHeight;
-  if (rampHeight < MIN_DIM) return null;
-
-  // Triangular profile on XZ plane: X = distance from wall (inward), Z = height.
-  // At X=0 (wall face) the cut goes down to cutBottom; at X=rampLen (inward)
-  // the cut is at wallHeight (full height). The triangle removes the wedge
-  // from the divider top near the wall face.
-  const profile = draw([0, wallHeight])
-    .lineTo([rampLen, wallHeight])
-    .lineTo([0, wallHeight - rampHeight])
-    .close();
-
-  const extrudeLen = divider.thickness + 2 * COPLANAR_MARGIN;
-  // Each transform allocates a new WASM handle while the previous becomes
-  // garbage. Dispose intermediates so only the final positioned shape lives.
-  const extruded = sketch(profile, 'XZ').extrude(extrudeLen);
-  const centered = translate(extruded, [0, extrudeLen / 2, 0]);
-  extruded.delete();
-  let shape = centered;
-
-  // Rotate and translate so X (inward) maps to the correct bin axis.
-  // Rotation around Z: +90° maps (x,y) → (-y, x), -90° maps (x,y) → (y, -x).
-  const isVertical = divider.axis === 'vertical';
-
-  if (isVertical) {
-    // Vertical divider near front/back wall.
-    // Profile X (inward) must map to bin Y direction.
-    // Extrusion Y must map to bin X (divider thickness axis).
-    const wallEnd = cutout.inwardSign > 0 ? divider.spanStart : divider.spanEnd;
-
-    // Front wall (inwardSign=+1): inward = +Y → rotate +90° maps X → +Y
-    // Back wall (inwardSign=-1): inward = -Y → rotate -90° maps X → -Y (via y=-x flip)
-    const rotated = rotate(shape, cutout.inwardSign > 0 ? 90 : -90, { axis: [0, 0, 1] });
-    shape.delete();
-    const positioned = translate(rotated, [divider.posAlongPerp, wallEnd, 0]);
-    rotated.delete();
-    return positioned;
-  }
-
-  // Horizontal divider near left/right wall.
-  // Profile X (inward) stays as bin X for left wall (+X inward).
-  // For right wall (-X inward), rotate 180° to flip.
-  const wallEnd = cutout.inwardSign > 0 ? divider.spanStart : divider.spanEnd;
-
-  if (cutout.inwardSign < 0) {
-    const rotated = rotate(shape, 180, { axis: [0, 0, 1] });
-    shape.delete();
-    shape = rotated;
-  }
-  const positioned = translate(shape, [wallEnd, divider.posAlongPerp, 0]);
-  shape.delete();
-  return positioned;
-}
-
-/**
- * Case 3: Flat horizontal trim for parallel divider visible through cutout.
- *
- * When a divider runs parallel to a wall with a cutout, and the divider's
- * span overlaps the cutout's horizontal span, trim the divider top down to
- * the cutout bottom height within the overlapping region.
- */
-function buildParallelTrimCut(divider: DividerInfo, cutout: OuterWallCutoutInfo): Shape3D | null {
-  // Compute overlap between divider span and cutout span (both in global coords)
-  const overlapStart = Math.max(divider.spanStart, cutout.cutLeft);
-  const overlapEnd = Math.min(divider.spanEnd, cutout.cutRight);
-  const overlapWidth = overlapEnd - overlapStart;
-  if (overlapWidth < MIN_DIM) return null;
-
-  const trimHeight = cutout.userCutHeight;
-  if (trimHeight < MIN_DIM) return null;
-
-  const overlapCenter = (overlapStart + overlapEnd) / 2;
-  const boxThickness = divider.thickness + 2 * COPLANAR_MARGIN;
-  const boxHeight = trimHeight + COPLANAR_MARGIN; // extend above wall top
-
-  const isHorizontalDivider = divider.axis === 'horizontal';
-
-  if (isHorizontalDivider) {
-    // Horizontal divider runs along X, parallel to front/back wall.
-    // cutout.spanAxis === 'x', so overlap is along X.
-    return box(overlapWidth, boxThickness, boxHeight, {
-      at: [overlapCenter, divider.posAlongPerp, cutout.cutBottom + boxHeight / 2],
-    });
-  }
-
-  // Vertical divider runs along Y, parallel to left/right wall.
-  // cutout.spanAxis === 'y', so overlap is along Y.
-  return box(boxThickness, overlapWidth, boxHeight, {
-    at: [divider.posAlongPerp, overlapCenter, cutout.cutBottom + boxHeight / 2],
-  });
-}
+export type { RampZone } from './dividerBlendTypes';
+export { resolveOuterCutouts, collectDividers } from './dividerBlendResolvers';
 
 /**
  * Build all divider-cutout blend cuts.
@@ -491,16 +135,6 @@ export function buildDividerBlends(
 }
 
 // --- Ramp zone data for wall pattern clipping ---
-
-/** Ramp zone descriptor for hex pattern clipping on a specific wall. */
-export interface RampZone {
-  /** Offset along the wall span from wall center (mm). */
-  readonly offsetAlongWall: number;
-  /** Width of the ramp zone along the wall span (mm). */
-  readonly width: number;
-  /** Height of the ramp zone (mm). */
-  readonly height: number;
-}
 
 /**
  * Compute ramp zones that face a specific wall, for hex pattern clipping.
@@ -604,10 +238,6 @@ export function computeDividerJunctionZones(
 }
 
 // --- FeatureBuilder protocol ---
-
-import type { FeatureBuilder } from './pipeline/featureBuilder';
-import { FeatureTag } from './featureTags';
-import { buildCacheKey, quantize, stableSerialize, compactKey } from './cacheKeyUtils';
 
 export const dividerBlendFeature: FeatureBuilder = {
   name: 'dividerCutoutBlend',

--- a/src/features/generation/worker/generators/dividerBlendCuts.ts
+++ b/src/features/generation/worker/generators/dividerBlendCuts.ts
@@ -13,7 +13,10 @@ import { box, draw, translate, rotate } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import type { WallCutoutShape } from '@/shared/types/bin';
 import { sketch } from './meshUtils';
-import { buildSingleCutout } from './featureBuilder';
+// Import directly from wallCutoutBuilder rather than the featureBuilder
+// barrel so only the cutout-shape builder is pulled in — the barrel
+// otherwise re-exports every builder, inflating this module's transitive deps.
+import { buildSingleCutout } from './wallCutoutBuilder';
 import { LIP_HEIGHT, COPLANAR_MARGIN } from './generatorConstants';
 import { type DividerInfo, type OuterWallCutoutInfo, MIN_DIM } from './dividerBlendTypes';
 

--- a/src/features/generation/worker/generators/dividerBlendCuts.ts
+++ b/src/features/generation/worker/generators/dividerBlendCuts.ts
@@ -1,0 +1,166 @@
+/**
+ * brepjs cut-solid builders for the three divider/cutout blend cases.
+ *
+ *   Case 1 — `buildEndTrimCut`: divider ends within cutout span;
+ *           trim end to match the cutout profile.
+ *   Case 2 — `buildRampCut`: divider just outside the cutout edge;
+ *           ~45° wedge ramps from cutout-bottom up to full wall height.
+ *   Case 3 — `buildParallelTrimCut`: divider runs parallel to a wall
+ *           with a cutout; flat horizontal trim across the overlap.
+ */
+
+import { box, draw, translate, rotate } from 'brepjs';
+import type { Shape3D } from 'brepjs';
+import type { WallCutoutShape } from '@/shared/types/bin';
+import { sketch } from './meshUtils';
+import { buildSingleCutout } from './featureBuilder';
+import { LIP_HEIGHT, COPLANAR_MARGIN } from './generatorConstants';
+import { type DividerInfo, type OuterWallCutoutInfo, MIN_DIM } from './dividerBlendTypes';
+
+/**
+ * Case 1: Trim divider end to match cutout profile.
+ *
+ * When a perpendicular divider terminates within the cutout's horizontal span,
+ * cut its end to follow the same profile shape as the outer-wall cutout.
+ */
+export function buildEndTrimCut(
+  divider: DividerInfo,
+  cutout: OuterWallCutoutInfo,
+  cutoutShape: WallCutoutShape,
+  wallHeight: number,
+  hasLip: boolean
+): Shape3D | null {
+  const overshoot = (hasLip ? LIP_HEIGHT : 0) + 2;
+  // Extrude deep enough to cut through divider thickness + margins
+  const extrudeDepth = divider.thickness + 2 * COPLANAR_MARGIN;
+
+  // Position at the cutout center (not the divider) so the profile shape
+  // matches the outer wall cutout exactly. The narrow extrusion only intersects
+  // the divider end where it's coplanar with the wall face.
+  const isVertical = divider.axis === 'vertical';
+
+  return buildSingleCutout(
+    cutoutShape,
+    cutout.cutWidth,
+    cutout.userCutHeight,
+    overshoot,
+    extrudeDepth,
+    wallHeight,
+    {
+      x: isVertical ? cutout.centerOffset : cutout.wallFaceCoord,
+      y: isVertical ? cutout.wallFaceCoord : cutout.centerOffset,
+      rotateZ: isVertical ? 0 : 90,
+    }
+  );
+}
+
+/**
+ * Case 2: Ramp from full height to cutout bottom.
+ *
+ * A straight-slope wedge cut where a perpendicular divider is adjacent to
+ * (just outside) the cutout span. Ramp length = userCutHeight, capped at
+ * half the divider's span length. Creates a ~45° slope.
+ */
+export function buildRampCut(
+  divider: DividerInfo,
+  cutout: OuterWallCutoutInfo,
+  wallHeight: number
+): Shape3D | null {
+  const segLength = divider.spanEnd - divider.spanStart;
+  const rampLen = Math.min(cutout.userCutHeight, segLength / 2);
+  if (rampLen < MIN_DIM) return null;
+
+  const rampHeight = cutout.userCutHeight;
+  if (rampHeight < MIN_DIM) return null;
+
+  // Triangular profile on XZ plane: X = distance from wall (inward), Z = height.
+  // At X=0 (wall face) the cut goes down to cutBottom; at X=rampLen (inward)
+  // the cut is at wallHeight (full height). The triangle removes the wedge
+  // from the divider top near the wall face.
+  const profile = draw([0, wallHeight])
+    .lineTo([rampLen, wallHeight])
+    .lineTo([0, wallHeight - rampHeight])
+    .close();
+
+  const extrudeLen = divider.thickness + 2 * COPLANAR_MARGIN;
+  // Each transform allocates a new WASM handle while the previous becomes
+  // garbage. Dispose intermediates so only the final positioned shape lives.
+  const extruded = sketch(profile, 'XZ').extrude(extrudeLen);
+  const centered = translate(extruded, [0, extrudeLen / 2, 0]);
+  extruded.delete();
+  let shape = centered;
+
+  // Rotate and translate so X (inward) maps to the correct bin axis.
+  // Rotation around Z: +90° maps (x,y) → (-y, x), -90° maps (x,y) → (y, -x).
+  const isVertical = divider.axis === 'vertical';
+
+  if (isVertical) {
+    // Vertical divider near front/back wall.
+    // Profile X (inward) must map to bin Y direction.
+    // Extrusion Y must map to bin X (divider thickness axis).
+    const wallEnd = cutout.inwardSign > 0 ? divider.spanStart : divider.spanEnd;
+
+    // Front wall (inwardSign=+1): inward = +Y → rotate +90° maps X → +Y
+    // Back wall (inwardSign=-1): inward = -Y → rotate -90° maps X → -Y (via y=-x flip)
+    const rotated = rotate(shape, cutout.inwardSign > 0 ? 90 : -90, { axis: [0, 0, 1] });
+    shape.delete();
+    const positioned = translate(rotated, [divider.posAlongPerp, wallEnd, 0]);
+    rotated.delete();
+    return positioned;
+  }
+
+  // Horizontal divider near left/right wall.
+  // Profile X (inward) stays as bin X for left wall (+X inward).
+  // For right wall (-X inward), rotate 180° to flip.
+  const wallEnd = cutout.inwardSign > 0 ? divider.spanStart : divider.spanEnd;
+
+  if (cutout.inwardSign < 0) {
+    const rotated = rotate(shape, 180, { axis: [0, 0, 1] });
+    shape.delete();
+    shape = rotated;
+  }
+  const positioned = translate(shape, [wallEnd, divider.posAlongPerp, 0]);
+  shape.delete();
+  return positioned;
+}
+
+/**
+ * Case 3: Flat horizontal trim for parallel divider visible through cutout.
+ *
+ * When a divider runs parallel to a wall with a cutout, and the divider's
+ * span overlaps the cutout's horizontal span, trim the divider top down to
+ * the cutout bottom height within the overlapping region.
+ */
+export function buildParallelTrimCut(
+  divider: DividerInfo,
+  cutout: OuterWallCutoutInfo
+): Shape3D | null {
+  // Compute overlap between divider span and cutout span (both in global coords)
+  const overlapStart = Math.max(divider.spanStart, cutout.cutLeft);
+  const overlapEnd = Math.min(divider.spanEnd, cutout.cutRight);
+  const overlapWidth = overlapEnd - overlapStart;
+  if (overlapWidth < MIN_DIM) return null;
+
+  const trimHeight = cutout.userCutHeight;
+  if (trimHeight < MIN_DIM) return null;
+
+  const overlapCenter = (overlapStart + overlapEnd) / 2;
+  const boxThickness = divider.thickness + 2 * COPLANAR_MARGIN;
+  const boxHeight = trimHeight + COPLANAR_MARGIN; // extend above wall top
+
+  const isHorizontalDivider = divider.axis === 'horizontal';
+
+  if (isHorizontalDivider) {
+    // Horizontal divider runs along X, parallel to front/back wall.
+    // cutout.spanAxis === 'x', so overlap is along X.
+    return box(overlapWidth, boxThickness, boxHeight, {
+      at: [overlapCenter, divider.posAlongPerp, cutout.cutBottom + boxHeight / 2],
+    });
+  }
+
+  // Vertical divider runs along Y, parallel to left/right wall.
+  // cutout.spanAxis === 'y', so overlap is along Y.
+  return box(boxThickness, overlapWidth, boxHeight, {
+    at: [divider.posAlongPerp, overlapCenter, cutout.cutBottom + boxHeight / 2],
+  });
+}

--- a/src/features/generation/worker/generators/dividerBlendResolvers.ts
+++ b/src/features/generation/worker/generators/dividerBlendResolvers.ts
@@ -1,0 +1,144 @@
+/**
+ * Pure resolvers that derive the divider/cutout geometry inputs the
+ * blend builder needs from the user's `BinParams`.
+ *
+ * No brepjs dependency — both functions can be called from
+ * `computeRampZones` / `computeDividerJunctionZones` (used by the wall
+ * pattern builder) without dragging the WASM solid-modeling kernel
+ * along.
+ */
+
+import type { BinParams } from '@/shared/types/bin';
+import { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
+import { findWallSegments } from './compartmentBuilder';
+import type { DividerInfo, OuterWallCutoutInfo } from './dividerBlendTypes';
+
+/**
+ * Resolve outer-wall cutout geometry for all enabled sides.
+ * Pure function — no brepjs dependency.
+ */
+export function resolveOuterCutouts(
+  params: BinParams,
+  innerW: number,
+  innerD: number,
+  wallHeight: number
+): OuterWallCutoutInfo[] {
+  if (!params.walls.enabled) return [];
+
+  const interiorHeight = wallHeight - params.wallThickness;
+  const result: OuterWallCutoutInfo[] = [];
+
+  const sides: Array<{
+    key: 'front' | 'back' | 'left' | 'right';
+    wallSpan: number;
+    wallFaceCoord: number;
+    inwardSign: number;
+    spanAxis: 'x' | 'y';
+  }> = [
+    { key: 'front', wallSpan: innerW, wallFaceCoord: -innerD / 2, inwardSign: 1, spanAxis: 'x' },
+    { key: 'back', wallSpan: innerW, wallFaceCoord: innerD / 2, inwardSign: -1, spanAxis: 'x' },
+    { key: 'left', wallSpan: innerD, wallFaceCoord: -innerW / 2, inwardSign: 1, spanAxis: 'y' },
+    { key: 'right', wallSpan: innerD, wallFaceCoord: innerW / 2, inwardSign: -1, spanAxis: 'y' },
+  ];
+
+  for (const side of sides) {
+    const cfg = params.walls[side.key];
+    if (!cfg.enabled) continue;
+
+    const cutWidth =
+      cfg.widthMm !== null
+        ? Math.min(cfg.widthMm, side.wallSpan)
+        : side.wallSpan * (cfg.width / 100);
+
+    const userCutHeight = interiorHeight * (cfg.depth / 100);
+    if (cutWidth < 0.1 || userCutHeight < 0.1) continue;
+
+    const centerOffset = computeCutoutCenter(
+      side.wallSpan,
+      cutWidth,
+      params.wallThickness,
+      cfg.alignment,
+      cfg.offset
+    );
+
+    result.push({
+      side: side.key,
+      wallSpan: side.wallSpan,
+      cutWidth,
+      userCutHeight,
+      cutBottom: wallHeight - userCutHeight,
+      centerOffset,
+      cutLeft: centerOffset - cutWidth / 2,
+      cutRight: centerOffset + cutWidth / 2,
+      wallFaceCoord: side.wallFaceCoord,
+      inwardSign: side.inwardSign,
+      spanAxis: side.spanAxis,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Collect divider wall segments from the compartment grid.
+ * Pure function — mirrors compartmentBuilder logic.
+ */
+export function collectDividers(params: BinParams, innerW: number, innerD: number): DividerInfo[] {
+  const { cols, rows, thickness, cells } = params.compartments;
+  if (cols <= 1 && rows <= 1) return [];
+  if (new Set(cells).size <= 1) return [];
+
+  const cellW = innerW / cols;
+  const cellD = innerD / rows;
+
+  // Mirror buildCompartmentWalls small-cell guard:
+  // skip axes where cells are too narrow for viable divider geometry.
+  const effectiveCellW = (innerW - (cols - 1) * thickness) / cols;
+  const effectiveCellD = (innerD - (rows - 1) * thickness) / rows;
+  const canBuildVertical = effectiveCellW >= thickness * 2;
+  const canBuildHorizontal = effectiveCellD >= thickness * 2;
+
+  const dividers: DividerInfo[] = [];
+
+  // Vertical dividers (between columns, run along Y)
+  if (canBuildVertical)
+    for (let colBoundary = 1; colBoundary < cols; colBoundary++) {
+      const xPos = -innerW / 2 + colBoundary * cellW;
+      const segments = findWallSegments(rows, (row) => {
+        const leftId = cells[row * cols + (colBoundary - 1)];
+        const rightId = cells[row * cols + colBoundary];
+        return leftId !== rightId;
+      });
+      for (const [start, end] of segments) {
+        dividers.push({
+          axis: 'vertical',
+          posAlongPerp: xPos,
+          spanStart: -innerD / 2 + start * cellD,
+          spanEnd: -innerD / 2 + end * cellD,
+          thickness,
+        });
+      }
+    }
+
+  // Horizontal dividers (between rows, run along X)
+  if (canBuildHorizontal)
+    for (let rowBoundary = 1; rowBoundary < rows; rowBoundary++) {
+      const yPos = -innerD / 2 + rowBoundary * cellD;
+      const segments = findWallSegments(cols, (col) => {
+        const topId = cells[(rowBoundary - 1) * cols + col];
+        const bottomId = cells[rowBoundary * cols + col];
+        return topId !== bottomId;
+      });
+      for (const [start, end] of segments) {
+        dividers.push({
+          axis: 'horizontal',
+          posAlongPerp: yPos,
+          spanStart: -innerW / 2 + start * cellW,
+          spanEnd: -innerW / 2 + end * cellW,
+          thickness,
+        });
+      }
+    }
+
+  return dividers;
+}

--- a/src/features/generation/worker/generators/dividerBlendResolvers.ts
+++ b/src/features/generation/worker/generators/dividerBlendResolvers.ts
@@ -2,10 +2,12 @@
  * Pure resolvers that derive the divider/cutout geometry inputs the
  * blend builder needs from the user's `BinParams`.
  *
- * No brepjs dependency — both functions can be called from
- * `computeRampZones` / `computeDividerJunctionZones` (used by the wall
- * pattern builder) without dragging the WASM solid-modeling kernel
- * along.
+ * Functions here perform pure JS computation — they don't call brepjs
+ * directly. (The transitive import of `findWallSegments` from
+ * `compartmentBuilder` does load the brepjs module at evaluation time;
+ * the data-only property is on the call paths, not the dep graph.)
+ * Reused by the wall-pattern builder via `computeRampZones` and
+ * `computeDividerJunctionZones`.
  */
 
 import type { BinParams } from '@/shared/types/bin';

--- a/src/features/generation/worker/generators/dividerBlendTypes.ts
+++ b/src/features/generation/worker/generators/dividerBlendTypes.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared types, constants, and predicates for the divider-cutout blend
+ * pipeline. Split out so the resolvers (`dividerBlendResolvers`) and cut
+ * builders (`dividerBlendCuts`) can each import only what they need.
+ */
+
+/** Resolved outer-wall cutout geometry in bin-global coordinates. */
+export interface OuterWallCutoutInfo {
+  readonly side: 'front' | 'back' | 'left' | 'right';
+  /** Full wall span along the span axis (mm). */
+  readonly wallSpan: number;
+  /** Cutout width (mm). */
+  readonly cutWidth: number;
+  /** Cutout height from wall top (mm). */
+  readonly userCutHeight: number;
+  /** Z coordinate of cutout bottom edge. */
+  readonly cutBottom: number;
+  /** Cutout center offset from wall center along span axis (mm). */
+  readonly centerOffset: number;
+  /** Left edge of cutout in global span-axis coords (mm). */
+  readonly cutLeft: number;
+  /** Right edge of cutout in global span-axis coords (mm). */
+  readonly cutRight: number;
+  /** Coordinate of the wall face (e.g. -innerD/2 for front). */
+  readonly wallFaceCoord: number;
+  /** Sign of inward direction from this wall (+1 for front, -1 for back). */
+  readonly inwardSign: number;
+  /** Span axis: 'x' for front/back, 'y' for left/right. */
+  readonly spanAxis: 'x' | 'y';
+}
+
+/** Divider wall segment in bin-global coordinates. */
+export interface DividerInfo {
+  /** Vertical = between columns (runs along Y), horizontal = between rows (runs along X). */
+  readonly axis: 'vertical' | 'horizontal';
+  /** Position along the perpendicular axis (X for vertical dividers, Y for horizontal). */
+  readonly posAlongPerp: number;
+  /** Start of segment along span axis (mm). */
+  readonly spanStart: number;
+  /** End of segment along span axis (mm). */
+  readonly spanEnd: number;
+  /** Divider wall thickness (mm). */
+  readonly thickness: number;
+}
+
+/** Minimum geometry dimension to avoid degenerate shapes (mm). */
+export const MIN_DIM = 0.5;
+
+/** Tolerance for matching divider endpoints to wall face coordinates (mm). */
+export const WALL_TOUCH_TOL = 0.01;
+
+/** Minimal wall face descriptor shared by cutout info and junction detection. */
+export interface WallFaceInfo {
+  readonly wallFaceCoord: number;
+  readonly inwardSign: number;
+  readonly spanAxis: 'x' | 'y';
+}
+
+/** Build a WallFaceInfo for a given side from bin inner dimensions. */
+export function getWallFaceInfo(
+  side: 'front' | 'back' | 'left' | 'right',
+  innerW: number,
+  innerD: number
+): WallFaceInfo {
+  const info: Record<string, WallFaceInfo> = {
+    front: { wallFaceCoord: -innerD / 2, inwardSign: 1, spanAxis: 'x' },
+    back: { wallFaceCoord: innerD / 2, inwardSign: -1, spanAxis: 'x' },
+    left: { wallFaceCoord: -innerW / 2, inwardSign: 1, spanAxis: 'y' },
+    right: { wallFaceCoord: innerW / 2, inwardSign: -1, spanAxis: 'y' },
+  };
+  return info[side];
+}
+
+/**
+ * Check if a divider is perpendicular to a given wall face.
+ * Vertical dividers (run along Y) are perpendicular to front/back walls.
+ * Horizontal dividers (run along X) are perpendicular to left/right walls.
+ */
+export function isPerpendicular(divider: DividerInfo, wall: WallFaceInfo): boolean {
+  if (divider.axis === 'vertical') return wall.spanAxis === 'x'; // front/back
+  return wall.spanAxis === 'y'; // left/right
+}
+
+/**
+ * Check if a divider's end touches a specific wall face.
+ */
+export function dividerTouchesWall(divider: DividerInfo, wall: WallFaceInfo): boolean {
+  if (divider.axis === 'vertical' && wall.spanAxis === 'x') {
+    // Vertical divider, front/back wall
+    if (wall.inwardSign > 0)
+      return Math.abs(divider.spanStart - wall.wallFaceCoord) < WALL_TOUCH_TOL;
+    return Math.abs(divider.spanEnd - wall.wallFaceCoord) < WALL_TOUCH_TOL;
+  }
+  if (divider.axis === 'horizontal' && wall.spanAxis === 'y') {
+    // Horizontal divider, left/right wall
+    if (wall.inwardSign > 0)
+      return Math.abs(divider.spanStart - wall.wallFaceCoord) < WALL_TOUCH_TOL;
+    return Math.abs(divider.spanEnd - wall.wallFaceCoord) < WALL_TOUCH_TOL;
+  }
+  return false;
+}
+
+/** Ramp zone descriptor for hex pattern clipping on a specific wall. */
+export interface RampZone {
+  /** Offset along the wall span from wall center (mm). */
+  readonly offsetAlongWall: number;
+  /** Width of the ramp zone along the wall span (mm). */
+  readonly width: number;
+  /** Height of the ramp zone (mm). */
+  readonly height: number;
+}

--- a/src/features/generation/worker/generators/dividerBlendTypes.ts
+++ b/src/features/generation/worker/generators/dividerBlendTypes.ts
@@ -62,7 +62,9 @@ export function getWallFaceInfo(
   innerW: number,
   innerD: number
 ): WallFaceInfo {
-  const info: Record<string, WallFaceInfo> = {
+  // Tighter than Record<string, …> so a typo or missing side breaks
+  // compilation rather than returning undefined at runtime.
+  const info: Record<'front' | 'back' | 'left' | 'right', WallFaceInfo> = {
     front: { wallFaceCoord: -innerD / 2, inwardSign: 1, spanAxis: 'x' },
     back: { wallFaceCoord: innerD / 2, inwardSign: -1, spanAxis: 'x' },
     left: { wallFaceCoord: -innerW / 2, inwardSign: 1, spanAxis: 'y' },


### PR DESCRIPTION
## Summary
Split the 648-LOC dividerBlendBuilder.ts into a slim orchestrator plus three focused modules. Public API preserved via re-exports; 28 tests still pass.
- dividerBlendTypes.ts (111 LOC): types + predicates + RampZone + constants.
- dividerBlendResolvers.ts (144 LOC): pure resolveOuterCutouts / collectDividers (no brepjs dep).
- dividerBlendCuts.ts (166 LOC): the three brepjs cut-solid factories.
- dividerBlendBuilder.ts (278 LOC): orchestrator + zone helpers + FeatureBuilder export.

## Test plan
- [x] pnpm run typecheck
- [x] pnpm run lint
- [x] pnpm exec vitest run src/features/generation/worker/generators/dividerBlend — 28 pass