### PR TITLE
refactor(cqrs): move library cloudShare persistence into event subscriber

### DIFF
--- a/src/core/cqrs/index.ts
+++ b/src/core/cqrs/index.ts
@@ -162,4 +162,4 @@ export { createCqrsMutations } from './integration/mutationsAdapter';
 
 export { applyEvent, replayEvents } from './projection/replay';
 
-export { connectSelectionPruning } from './subscribers';
+export { connectSelectionPruning, connectLibraryPersistence } from './subscribers';

--- a/src/core/cqrs/integration/mutationsAdapter.ts
+++ b/src/core/cqrs/integration/mutationsAdapter.ts
@@ -15,6 +15,8 @@ import type {
   Category,
   Layer,
   Drawer,
+  LayoutId,
+  CloudShareInfo,
   BaseplateParams,
 } from '@/core/types';
 import type { Result, ValidationError, LayoutError } from '@/core/result';
@@ -167,6 +169,14 @@ export function createCqrsMutations(bus: CommandBus): Mutations {
 
     setBaseplateParams(params: BaseplateParams): void {
       bus.dispatch(createCommand('layout.setBaseplateParams', { params }));
+    },
+
+    setCloudShare(layoutId: LayoutId, share: CloudShareInfo): void {
+      bus.dispatch(createCommand('library.setCloudShare', { layoutId, shareInfo: share }));
+    },
+
+    clearCloudShare(layoutId: LayoutId): void {
+      bus.dispatch(createCommand('library.clearCloudShare', { layoutId }));
     },
   };
 }

--- a/src/core/cqrs/subscribers/index.ts
+++ b/src/core/cqrs/subscribers/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { connectSelectionPruning } from './selectionPruning';
+export { connectLibraryPersistence } from './libraryPersistence';

--- a/src/core/cqrs/subscribers/libraryPersistence.test.ts
+++ b/src/core/cqrs/subscribers/libraryPersistence.test.ts
@@ -8,6 +8,7 @@ import { layoutId } from '@/core/types';
 import type { LayoutLibrary, CloudShareInfo } from '@/core/types';
 import { connectLibraryPersistence } from './libraryPersistence';
 import { ok } from '@/core/result';
+import { resetLibraryStore } from '@/test/testUtils';
 
 import type * as StorageModule from '@/core/storage';
 
@@ -80,6 +81,7 @@ describe('libraryPersistence subscriber', () => {
   let unsubscribe: () => void;
 
   beforeEach(() => {
+    resetLibraryStore();
     bus = createEventBus();
     unsubscribe = connectLibraryPersistence(bus);
     vi.mocked(saveLibrary).mockClear();
@@ -87,6 +89,8 @@ describe('libraryPersistence subscriber', () => {
 
   afterEach(() => {
     unsubscribe();
+    bus.clear();
+    resetLibraryStore();
   });
 
   it('persists library when library.cloudShareUpdated fires', () => {

--- a/src/core/cqrs/subscribers/libraryPersistence.test.ts
+++ b/src/core/cqrs/subscribers/libraryPersistence.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createEventBus } from '../bus/eventBus';
+import type { EventBus } from '../bus/eventBus';
+import type { DomainEvent } from '../events';
+import { eventId, correlationId, commandId } from '../types';
+import { useLibraryStore } from '@/core/store/library';
+import { layoutId } from '@/core/types';
+import type { LayoutLibrary, CloudShareInfo } from '@/core/types';
+import { connectLibraryPersistence } from './libraryPersistence';
+import { ok } from '@/core/result';
+
+import type * as StorageModule from '@/core/storage';
+
+vi.mock('@/core/storage', async () => {
+  const actual = await vi.importActual<typeof StorageModule>('@/core/storage');
+  return {
+    ...actual,
+    saveLibrary: vi.fn(() => Promise.resolve(ok(undefined))),
+  };
+});
+
+import { saveLibrary } from '@/core/storage';
+
+function makeEvent<T extends DomainEvent['type']>(
+  type: T,
+  payload: Extract<DomainEvent, { type: T }>['payload']
+): DomainEvent {
+  return {
+    type,
+    payload,
+    meta: {
+      id: eventId(`evt_${Math.random()}`),
+      timestamp: Date.now(),
+      correlationId: correlationId('cor_1'),
+      commandId: commandId('cmd_1'),
+      aggregateId: layoutId('layout_1'),
+      version: 1,
+      schemaVersion: 1,
+    },
+  } as DomainEvent;
+}
+
+function makeShareInfo(): CloudShareInfo {
+  return {
+    id: 'share-1',
+    deleteToken: 'token-1',
+    permission: 'view',
+    sharedAt: Date.now(),
+  };
+}
+
+function seedLibraryWithEntry(entryId: string, withCloudShare = false): LayoutLibrary {
+  const library: LayoutLibrary = {
+    version: '1.0',
+    activeLayoutId: layoutId(entryId),
+    settings: {},
+    entries: [
+      {
+        id: layoutId(entryId),
+        name: 'Test',
+        createdAt: Date.now(),
+        modifiedAt: Date.now(),
+        preview: {
+          drawerWidth: 10,
+          drawerDepth: 8,
+          drawerHeight: 12,
+          binCount: 0,
+          layerCount: 1,
+        },
+        ...(withCloudShare ? { cloudShare: makeShareInfo() } : {}),
+      },
+    ],
+  };
+  useLibraryStore.setState({ library, isLoaded: true });
+  return library;
+}
+
+describe('libraryPersistence subscriber', () => {
+  let bus: EventBus;
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    bus = createEventBus();
+    unsubscribe = connectLibraryPersistence(bus);
+    vi.mocked(saveLibrary).mockClear();
+  });
+
+  afterEach(() => {
+    unsubscribe();
+  });
+
+  it('persists library when library.cloudShareUpdated fires', () => {
+    seedLibraryWithEntry('layout-1', true);
+
+    bus.publish(
+      makeEvent('library.cloudShareUpdated', {
+        layoutId: layoutId('layout-1'),
+        shareInfo: makeShareInfo(),
+      })
+    );
+
+    expect(saveLibrary).toHaveBeenCalledTimes(1);
+    const snapshot = vi.mocked(saveLibrary).mock.calls[0][0];
+    expect(snapshot.entries[0].cloudShare).toBeDefined();
+  });
+
+  it('persists library when library.cloudShareCleared fires', () => {
+    seedLibraryWithEntry('layout-1', false);
+
+    bus.publish(
+      makeEvent('library.cloudShareCleared', {
+        layoutId: layoutId('layout-1'),
+      })
+    );
+
+    expect(saveLibrary).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not persist for unrelated events', () => {
+    seedLibraryWithEntry('layout-1', false);
+
+    bus.publish(
+      makeEvent('library.entryCreated', {
+        layoutId: layoutId('layout-2'),
+        name: 'Another',
+      })
+    );
+
+    expect(saveLibrary).not.toHaveBeenCalled();
+  });
+
+  it('detaches via structuredClone before saving (no Immer proxy leak)', () => {
+    // Mutate the store after the subscriber fires; the snapshot passed to
+    // saveLibrary should reflect the state at the moment of the event, and
+    // must not be a live reference to the store.
+    seedLibraryWithEntry('layout-1', true);
+
+    bus.publish(
+      makeEvent('library.cloudShareUpdated', {
+        layoutId: layoutId('layout-1'),
+        shareInfo: makeShareInfo(),
+      })
+    );
+
+    const snapshot = vi.mocked(saveLibrary).mock.calls[0][0];
+    expect(snapshot).not.toBe(useLibraryStore.getState().library);
+  });
+
+  it('unsubscribe stops persisting', () => {
+    seedLibraryWithEntry('layout-1', false);
+    unsubscribe();
+
+    bus.publish(
+      makeEvent('library.cloudShareCleared', {
+        layoutId: layoutId('layout-1'),
+      })
+    );
+
+    expect(saveLibrary).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/cqrs/subscribers/libraryPersistence.ts
+++ b/src/core/cqrs/subscribers/libraryPersistence.ts
@@ -1,0 +1,43 @@
+/**
+ * Library Persistence Event Subscriber
+ *
+ * Persists the library to IndexedDB immediately when cloudShare metadata
+ * changes. Other library mutations (createEntry, deleteEntry, updateEntry,
+ * etc.) are persisted indirectly via {@link useAutoSave}, which atomically
+ * saves layout + library together with a 1s debounce.
+ *
+ * cloudShare needs immediate persistence because it's library-only metadata
+ * that wouldn't trigger useAutoSave (which keys off layout changes).
+ */
+
+import type { UnsubscribeFn } from '../types';
+import type { EventBus } from '../bus/eventBus';
+import { useLibraryStore } from '@/core/store/library';
+import { saveLibrary } from '@/core/storage';
+import { isErr } from '@/core/result';
+
+function persistLibrary(): void {
+  const snapshot = structuredClone(useLibraryStore.getState().library);
+  void saveLibrary(snapshot).then((result) => {
+    if (isErr(result)) {
+      console.warn('[library] Background save failed:', result.error.code, result.error.message);
+    }
+  });
+}
+
+/**
+ * Connect library persistence subscriber to the event bus.
+ * Returns an unsubscribe function that removes all subscribers.
+ */
+export function connectLibraryPersistence(bus: EventBus): UnsubscribeFn {
+  const unsubscribers: UnsubscribeFn[] = [];
+
+  unsubscribers.push(bus.subscribe('library.cloudShareUpdated', () => persistLibrary()));
+  unsubscribers.push(bus.subscribe('library.cloudShareCleared', () => persistLibrary()));
+
+  return () => {
+    for (const unsub of unsubscribers) {
+      unsub();
+    }
+  };
+}

--- a/src/core/store/library.test.ts
+++ b/src/core/store/library.test.ts
@@ -636,8 +636,8 @@ describe('clearCloudShare', () => {
   });
 });
 
-describe('setCloudShare persist safety', () => {
-  it('should persist library without accessing revoked proxy', () => {
+describe('setCloudShare', () => {
+  it('sets cloudShare on the entry', () => {
     const store = useLibraryStore.getState();
     const preview: LayoutPreview = {
       drawerWidth: 10,
@@ -647,14 +647,16 @@ describe('setCloudShare persist safety', () => {
       layerCount: 1,
     };
     const entry = store.createEntry('Test', 'layout-1' as LayoutId, preview);
-    expect(() => {
-      store.setCloudShare(entry.id, {
-        id: 'share-1',
-        deleteToken: 'token-1',
-        permission: 'view',
-        sharedAt: Date.now(),
-      });
-    }).not.toThrow();
+    const share = {
+      id: 'share-1',
+      deleteToken: 'token-1',
+      permission: 'view' as const,
+      sharedAt: Date.now(),
+    };
+
+    store.setCloudShare(entry.id, share);
+
+    expect(useLibraryStore.getState().getEntry(entry.id)?.cloudShare).toEqual(share);
   });
 });
 

--- a/src/core/store/library.ts
+++ b/src/core/store/library.ts
@@ -10,21 +10,7 @@ import type {
 import { gridUnits, heightUnits } from '@/core/types';
 import { CONSTRAINTS, getDefaultDrawerSize } from '@/core/constants';
 import type { Result, Unit, LayoutError } from '@/core/result';
-import { err, layoutLastEntity, OK, isErr } from '@/core/result';
-import { saveLibrary } from '@/core/storage';
-
-/**
- * Persist library in the background, logging on failure.
- * Uses structuredClone to detach from Immer proxies before the async save.
- */
-function persistLibrary(): void {
-  const snapshot = structuredClone(useLibraryStore.getState().library);
-  void saveLibrary(snapshot).then((result) => {
-    if (isErr(result)) {
-      console.warn('[library] Background save failed:', result.error.code, result.error.message);
-    }
-  });
-}
+import { err, layoutLastEntity, OK } from '@/core/result';
 
 // Re-export computePreview for backward compatibility with existing imports
 export { computePreview } from '@/core/storage';
@@ -226,8 +212,6 @@ export const useLibraryStore = create<LibraryState>()(
           entry.cloudShare = share;
         }
       });
-      // Persist library immediately so cloudShare survives refresh
-      persistLibrary();
     },
 
     clearCloudShare: (layoutId) => {
@@ -237,8 +221,6 @@ export const useLibraryStore = create<LibraryState>()(
           entry.cloudShare = undefined;
         }
       });
-      // Persist library immediately
-      persistLibrary();
     },
   }))
 );

--- a/src/features/cloud-share/hooks/useCloudShare.test.ts
+++ b/src/features/cloud-share/hooks/useCloudShare.test.ts
@@ -28,6 +28,16 @@ vi.mock('@/core/storage', async () => {
   };
 });
 
+// Mock useMutations — useCloudShare reads setCloudShare/clearCloudShare from it
+const setCloudShareSpy = vi.fn();
+const clearCloudShareSpy = vi.fn();
+vi.mock('@/shared/contexts/MutationsContext', () => ({
+  useMutations: () => ({
+    setCloudShare: setCloudShareSpy,
+    clearCloudShare: clearCloudShareSpy,
+  }),
+}));
+
 const TEST_LAYOUT_ID = 'test-layout-id';
 
 function createTestLibrary(cloudShare?: CloudShareInfo): LayoutLibrary {
@@ -245,9 +255,6 @@ describe('useCloudShare', () => {
         ok({ success: true as const, message: 'Deleted' })
       );
 
-      const clearCloudShareSpy = vi.fn();
-      useLibraryStore.setState({ clearCloudShare: clearCloudShareSpy });
-
       const { result } = renderHook(() => useCloudShare());
 
       let success: boolean | undefined;
@@ -285,9 +292,6 @@ describe('useCloudShare', () => {
       });
 
       vi.mocked(shareApi.deleteShare).mockResolvedValue(err(apiNotFound('already-deleted')));
-
-      const clearCloudShareSpy = vi.fn();
-      useLibraryStore.setState({ clearCloudShare: clearCloudShareSpy });
 
       const { result } = renderHook(() => useCloudShare());
 

--- a/src/features/cloud-share/hooks/useCloudShare.ts
+++ b/src/features/cloud-share/hooks/useCloudShare.ts
@@ -19,6 +19,7 @@ import { isOk, getUserMessage } from '@/core/result';
 import type { ApiError } from '@/core/result';
 import { copyToClipboard } from '@/core/storage';
 import { commandBus, createCommand } from '@/core/cqrs';
+import { useMutations } from '@/shared/contexts/MutationsContext';
 import { slugify } from '@/shared/utils/slug';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
 
@@ -71,15 +72,15 @@ export function useCloudShare(layoutId?: string): CloudShareState & CloudShareAc
     };
   }, []);
 
-  const { activeLayoutId, entries, authorName, setCloudShare, clearCloudShare } = useLibraryStore(
+  const { activeLayoutId, entries, authorName } = useLibraryStore(
     useShallow((state) => ({
       activeLayoutId: state.library.activeLayoutId,
       entries: state.library.entries,
       authorName: state.library.settings.authorName,
-      setCloudShare: state.setCloudShare,
-      clearCloudShare: state.clearCloudShare,
     }))
   );
+
+  const { setCloudShare, clearCloudShare } = useMutations();
 
   const layout = useLayoutStore((state) => state.layout);
   const announceToScreenReader = useInteractionStore((state) => state.announceToScreenReader);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,7 +15,12 @@ import { initializeLayoutLibrary, loadSharedWithMe } from '@/core/storage';
 import { isOk } from '@/core/result';
 import type { Locale } from '@/i18n/types.ts';
 import { recoverFromBadWwwMigration } from '@/core/storage/wwwMigrationRecovery';
-import { connectEventStoreToBus, connectSelectionPruning, eventBus } from '@/core/cqrs';
+import {
+  connectEventStoreToBus,
+  connectLibraryPersistence,
+  connectSelectionPruning,
+  eventBus,
+} from '@/core/cqrs';
 import { connectDesignLinking } from '@/features/design-linking/subscribers';
 import { InitErrorFallback } from '@/shell/InitErrorFallback';
 import { isSmokeMode } from '@/shared/utils/smokeMode';
@@ -112,6 +117,10 @@ if (isSmokeMode()) {
       // Connect selection pruning — automatically cleans stale bin/layer/category
       // references from selection store when entities are deleted or moved
       connectSelectionPruning(eventBus);
+
+      // Persist library to IndexedDB immediately when cloudShare metadata changes
+      // (other library fields are persisted via useAutoSave's debounced flow)
+      connectLibraryPersistence(eventBus);
 
       // Connect design-linking — bridges CQRS events to syncEventBus for
       // design dimension cascade between linked bins and designs

--- a/src/shared/contexts/MutationsContext.tsx
+++ b/src/shared/contexts/MutationsContext.tsx
@@ -27,6 +27,8 @@ import type {
   BinId,
   LayerId,
   CategoryId,
+  LayoutId,
+  CloudShareInfo,
   BaseplateParams,
 } from '@/core/types';
 import type { Result, ValidationError, LayoutError } from '@/core/result';
@@ -81,6 +83,10 @@ export interface Mutations {
   setGridUnitMm: (mm: number) => void;
   setHeightUnitMm: (mm: number) => void;
   setBaseplateParams: (params: BaseplateParams) => void;
+
+  // Library cloud-share operations
+  setCloudShare: (layoutId: LayoutId, share: CloudShareInfo) => void;
+  clearCloudShare: (layoutId: LayoutId) => void;
 }
 
 const MutationsContext = createContext<Mutations | null>(null);


### PR DESCRIPTION
## Summary

- Extracts inline `persistLibrary()` from `setCloudShare`/`clearCloudShare` Zustand mutations into a dedicated CQRS event subscriber (`connectLibraryPersistence`).
- Routes `useCloudShare` through `useMutations()` instead of pulling mutations directly off `useLibraryStore` — cloudShare now flows through the command bus, fires the corresponding domain events, and the subscriber persists.
- Library store mutations are now pure Zustand+Immer `set()` calls with no I/O. This is the prerequisite for a future migration to `apply(event, draft)`-style handlers where `apply` must be a pure draft writer.

## Why

Library `setCloudShare`/`clearCloudShare` mutations performed an inline `structuredClone` + async `saveLibrary()` after each `set()`. This made the store a hidden I/O boundary and would block the planned CQRS DX redesign (where `apply` is the only writer and must be pure). Other library fields are persisted indirectly via `useAutoSave`'s 1s debounce; cloudShare needed immediate persistence because it isn't part of the layout payload that triggers `useAutoSave`.

## Behavioral parity

cloudShare changes still persist immediately (no debounce). The persistence now happens in response to the `library.cloudShareUpdated` / `library.cloudShareCleared` events emitted by the existing `handleSetCloudShare` / `handleClearCloudShare` handlers, instead of as an inline side-effect of the store mutation.

## Test plan

- [x] New unit tests for `libraryPersistence` subscriber (events trigger save, unrelated events don't, structuredClone detaches from store, unsubscribe stops persisting)
- [x] `useCloudShare` test mocking updated from `useLibraryStore.setState({ clearCloudShare: spy })` to module-mock of `@/shared/contexts/MutationsContext`
- [x] Library store test "setCloudShare persist safety" reframed to assert mutation correctness (cloudShare is set on the entry); the original "no proxy revocation throw" assertion is moot now that the inline `structuredClone` is gone
- [x] Full vitest suite (10289 tests) green
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm knip` all clean