### PR TITLE
feat(cqrs): v2 defineCommand foundations + type-inference tests

### DIFF
--- a/src/core/cqrs/v2/Mutations.ts
+++ b/src/core/cqrs/v2/Mutations.ts
@@ -15,20 +15,33 @@
  */
 
 import type { Result } from '@/core/result';
-import type { AnyCommandDef, CommandDefShape } from './types';
+import type { AggregateName, AnyCommandDef, CommandDefShape } from './types';
 import type { Registry } from './createRegistry';
 
-/** Extract the value type from a command def. */
+/**
+ * Extract the value type from a command def.
+ *
+ * The seventh slot uses `AggregateName` (the full union) rather than `never`:
+ * `'layout' extends never` is `false`, which would make the conditional
+ * collapse to `never` for any concrete command def. `'layout' extends AggregateName`
+ * is trivially true, so the conditional matches and `infer V` succeeds.
+ */
 export type ValueOf<C> =
-  C extends CommandDefShape<string, unknown, infer V, string, unknown, unknown, never> ? V : never;
+  C extends CommandDefShape<string, unknown, infer V, string, unknown, unknown, AggregateName>
+    ? V
+    : never;
 
 /** Extract the error union from a command def — the union of every `err()` return inside `handle`. */
 export type ErrorOf<C> =
-  C extends CommandDefShape<string, unknown, unknown, string, unknown, infer E, never> ? E : never;
+  C extends CommandDefShape<string, unknown, unknown, string, unknown, infer E, AggregateName>
+    ? E
+    : never;
 
 /** Extract the payload type from a command def. */
 export type PayloadOf<C> =
-  C extends CommandDefShape<string, infer P, unknown, string, unknown, unknown, never> ? P : never;
+  C extends CommandDefShape<string, infer P, unknown, string, unknown, unknown, AggregateName>
+    ? P
+    : never;
 
 /**
  * Mutations surface derived from a registry. One method per command,

--- a/src/core/cqrs/v2/Mutations.ts
+++ b/src/core/cqrs/v2/Mutations.ts
@@ -1,0 +1,44 @@
+/**
+ * Mutations<R> — auto-derived typed mutation surface from a registry.
+ *
+ * Maps each command in the registry to a callable keyed by the command's
+ * literal `type` string. Payload, return value, and error union are all
+ * inferred per command — no `as T` casts, no central interface that
+ * must be hand-maintained alongside the registry.
+ *
+ * Usage (target shape, no runtime in this PR):
+ *   const mutations = createMutations(registry, commandBus);
+ *   mutations['bin.add']({ ... });   // Result<BinId, ValidationError>
+ *
+ * PR 2 ships the type only — runtime `createMutations()` lands when the
+ * first domain (bin/) migrates and needs a real dispatcher.
+ */
+
+import type { Result } from '@/core/result';
+import type { AnyCommandDef, CommandDefShape } from './types';
+import type { Registry } from './createRegistry';
+
+/** Extract the value type from a command def. */
+export type ValueOf<C> =
+  C extends CommandDefShape<string, unknown, infer V, string, unknown, unknown, never> ? V : never;
+
+/** Extract the error union from a command def — the union of every `err()` return inside `handle`. */
+export type ErrorOf<C> =
+  C extends CommandDefShape<string, unknown, unknown, string, unknown, infer E, never> ? E : never;
+
+/** Extract the payload type from a command def. */
+export type PayloadOf<C> =
+  C extends CommandDefShape<string, infer P, unknown, string, unknown, unknown, never> ? P : never;
+
+/**
+ * Mutations surface derived from a registry. One method per command,
+ * keyed by the command's literal `type`.
+ */
+export type Mutations<R extends Registry<readonly AnyCommandDef[]>> =
+  R extends Registry<infer T>
+    ? {
+        readonly [K in T[number] as K['type']]: (
+          payload: PayloadOf<K>
+        ) => Result<ValueOf<K>, ErrorOf<K>>;
+      }
+    : never;

--- a/src/core/cqrs/v2/createRegistry.ts
+++ b/src/core/cqrs/v2/createRegistry.ts
@@ -1,0 +1,30 @@
+/**
+ * createRegistry — assembles a typed registry of v2 command definitions.
+ *
+ * Takes an `as const` tuple of command defs and returns a registry that
+ * preserves each command's full type, plus a `byType` lookup keyed by
+ * the command's literal `type` string.
+ *
+ * Explicit array assembly (not auto-discovery) so the dependency graph
+ * is greppable and tree-shakeable.
+ */
+
+import type { AnyCommandDef } from './types';
+
+/**
+ * Lookup map keyed by each command's literal `type`, preserving the
+ * command's full inferred type.
+ */
+export type RegistryByType<T extends readonly AnyCommandDef[]> = {
+  readonly [K in T[number] as K['type']]: K;
+};
+
+export interface Registry<T extends readonly AnyCommandDef[]> {
+  readonly commands: T;
+  readonly byType: RegistryByType<T>;
+}
+
+export function createRegistry<const T extends readonly AnyCommandDef[]>(commands: T): Registry<T> {
+  const byType = Object.fromEntries(commands.map((c) => [c.type, c])) as RegistryByType<T>;
+  return { commands, byType };
+}

--- a/src/core/cqrs/v2/createRegistry.ts
+++ b/src/core/cqrs/v2/createRegistry.ts
@@ -25,6 +25,15 @@ export interface Registry<T extends readonly AnyCommandDef[]> {
 }
 
 export function createRegistry<const T extends readonly AnyCommandDef[]>(commands: T): Registry<T> {
+  const seen = new Set<string>();
+  for (const command of commands) {
+    if (seen.has(command.type)) {
+      throw new Error(
+        `createRegistry: duplicate command type "${command.type}" — every command must register a unique type`
+      );
+    }
+    seen.add(command.type);
+  }
   const byType = Object.fromEntries(commands.map((c) => [c.type, c])) as RegistryByType<T>;
   return { commands, byType };
 }

--- a/src/core/cqrs/v2/defineCommand.ts
+++ b/src/core/cqrs/v2/defineCommand.ts
@@ -1,0 +1,37 @@
+/**
+ * defineCommand — typed identity factory for v2 commands.
+ *
+ * Captures all generic parameters from the literal object passed in.
+ * No runtime transformation; the value returned is the same value
+ * passed in, with its types fully narrowed.
+ *
+ * Example:
+ *   const addBin = defineCommand({
+ *     type: 'bin.add',
+ *     aggregate: 'layout',
+ *     payload: z.object({ ... }),
+ *     emitted: 'bin.added',
+ *     handle: (payload, ctx) => ok({ value: ..., event: { payload: ... } }),
+ *     apply: (event, draft) => { draft.bins.push(event.payload.bin); },
+ *     ...
+ *   });
+ */
+
+import type { z } from 'zod';
+import type { AggregateName, CommandDefShape } from './types';
+
+export function defineCommand<
+  TType extends string,
+  TPayload,
+  TValue,
+  TEventType extends string,
+  TEventPayload,
+  TError,
+  A extends AggregateName,
+>(
+  def: CommandDefShape<TType, TPayload, TValue, TEventType, TEventPayload, TError, A> & {
+    readonly payload: z.ZodType<TPayload>;
+  }
+): CommandDefShape<TType, TPayload, TValue, TEventType, TEventPayload, TError, A> {
+  return def;
+}

--- a/src/core/cqrs/v2/sample.ts
+++ b/src/core/cqrs/v2/sample.ts
@@ -1,0 +1,65 @@
+/**
+ * Sample v2 command definitions used to drive type-inference tests.
+ *
+ * NOT registered with the live commandBus — these exist solely to prove
+ * that `defineCommand({...})` captures the right types end-to-end and
+ * that `Mutations<typeof registry>` produces a usable surface.
+ *
+ * Will be deleted in PR 11 (cleanup) once the real domain commands are
+ * in place under `cqrs/v2/domain/`.
+ */
+
+import { z } from 'zod';
+import { ok, err } from '@/core/result';
+import type { ValidationError, LayoutError } from '@/core/result';
+import { validationOutOfBounds, layoutInvalidOperation } from '@/core/result';
+import { defineCommand } from './defineCommand';
+import { createRegistry } from './createRegistry';
+
+export const sampleAddBin = defineCommand({
+  type: 'sample.bin.add',
+  aggregate: 'layout',
+  aggregateId: () => 'sample-layout',
+  payload: z.object({
+    layerId: z.string().min(1),
+    x: z.number().gte(0),
+    y: z.number().gte(0),
+  }),
+  emitted: 'sample.bin.added',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.binAdd',
+  middleware: { undoCapture: true, validate: true },
+  handle: (payload, _ctx) => {
+    if (payload.x > 100) {
+      return err<ValidationError>(validationOutOfBounds('out_of_bounds'));
+    }
+    return ok({
+      value: 'bin_123' as const,
+      event: { payload: { id: 'bin_123', layerId: payload.layerId, x: payload.x, y: payload.y } },
+    });
+  },
+  apply: (_event, _draft) => {
+    // Pure draft mutation — sample only, no real Layout shape coupling
+  },
+});
+
+export const sampleDeleteBin = defineCommand({
+  type: 'sample.bin.delete',
+  aggregate: 'layout',
+  aggregateId: () => 'sample-layout',
+  payload: z.object({ id: z.string().min(1) }),
+  emitted: 'sample.bin.deleted',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.binDelete',
+  handle: (payload, _ctx) => {
+    if (!payload.id.startsWith('bin_')) {
+      return err<LayoutError>(layoutInvalidOperation('deleteBin', `Bad id ${payload.id}`));
+    }
+    return ok({ value: undefined, event: { payload: { id: payload.id } } });
+  },
+  apply: (_event, _draft) => {
+    // Pure draft mutation — sample only
+  },
+});
+
+export const sampleRegistry = createRegistry([sampleAddBin, sampleDeleteBin] as const);

--- a/src/core/cqrs/v2/types.test.ts
+++ b/src/core/cqrs/v2/types.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect, expectTypeOf } from 'vitest';
 import type { Result, ValidationError, LayoutError } from '@/core/result';
 import { sampleAddBin, sampleDeleteBin, sampleRegistry } from './sample';
+import { createRegistry } from './createRegistry';
 import type { Mutations, PayloadOf, ValueOf, ErrorOf } from './Mutations';
 
 describe('v2 type inference', () => {
@@ -85,9 +86,16 @@ describe('v2 type inference', () => {
   });
 });
 
-// Runtime no-op so vitest's test runner registers the file.
-describe('v2 runtime smoke', () => {
-  it('registry contains both sample commands', () => {
+describe('v2 registry runtime', () => {
+  it('contains both sample commands', () => {
     expect(sampleRegistry.commands).toHaveLength(2);
+  });
+
+  it('throws when two commands declare the same type', () => {
+    expect(() =>
+      createRegistry([sampleAddBin, sampleAddBin] as const)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: createRegistry: duplicate command type "sample.bin.add" — every command must register a unique type]`
+    );
   });
 });

--- a/src/core/cqrs/v2/types.test.ts
+++ b/src/core/cqrs/v2/types.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Type-inference tests for v2 foundations.
+ *
+ * Validates that `defineCommand({...})` plus `createRegistry([...])` plus
+ * `Mutations<typeof registry>` thread types end-to-end without collapsing
+ * to `unknown`, `never`, or `any`. These tests run at typecheck time —
+ * they assert structural type equality, not runtime behavior.
+ *
+ * Decision gate: if `pnpm typecheck` regresses by >2 seconds when this
+ * file is added, the per-command typed-dispatcher fallback (Pass 2 risk
+ * mitigation) becomes the path forward instead.
+ */
+
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import type { Result, ValidationError, LayoutError } from '@/core/result';
+import { sampleAddBin, sampleDeleteBin, sampleRegistry } from './sample';
+import type { Mutations, PayloadOf, ValueOf, ErrorOf } from './Mutations';
+
+describe('v2 type inference', () => {
+  describe('defineCommand captures literal types', () => {
+    it('infers `type` as a string literal, not widened string', () => {
+      expectTypeOf(sampleAddBin.type).toEqualTypeOf<'sample.bin.add'>();
+      expectTypeOf(sampleDeleteBin.type).toEqualTypeOf<'sample.bin.delete'>();
+    });
+
+    it('infers `aggregate` as the literal name', () => {
+      expectTypeOf(sampleAddBin.aggregate).toEqualTypeOf<'layout'>();
+    });
+
+    it('infers `emitted` as the literal event type string', () => {
+      expectTypeOf(sampleAddBin.emitted).toEqualTypeOf<'sample.bin.added'>();
+    });
+  });
+
+  describe('PayloadOf / ValueOf / ErrorOf extractors', () => {
+    it('extracts payload from defineCommand return', () => {
+      expectTypeOf<PayloadOf<typeof sampleAddBin>>().toEqualTypeOf<{
+        layerId: string;
+        x: number;
+        y: number;
+      }>();
+    });
+
+    it('extracts value type from handle return', () => {
+      expectTypeOf<ValueOf<typeof sampleAddBin>>().toEqualTypeOf<'bin_123'>();
+      expectTypeOf<ValueOf<typeof sampleDeleteBin>>().toEqualTypeOf<undefined>();
+    });
+
+    it('extracts error union from handle return', () => {
+      expectTypeOf<ErrorOf<typeof sampleAddBin>>().toEqualTypeOf<ValidationError>();
+      expectTypeOf<ErrorOf<typeof sampleDeleteBin>>().toEqualTypeOf<LayoutError>();
+    });
+  });
+
+  describe('Mutations<R> derived from registry', () => {
+    type M = Mutations<typeof sampleRegistry>;
+
+    it('exposes one method per command, keyed by command type', () => {
+      expectTypeOf<keyof M>().toEqualTypeOf<'sample.bin.add' | 'sample.bin.delete'>();
+    });
+
+    it('infers payload type per method', () => {
+      expectTypeOf<Parameters<M['sample.bin.add']>[0]>().toEqualTypeOf<{
+        layerId: string;
+        x: number;
+        y: number;
+      }>();
+      expectTypeOf<Parameters<M['sample.bin.delete']>[0]>().toEqualTypeOf<{ id: string }>();
+    });
+
+    it('infers Result<value, error> per method', () => {
+      expectTypeOf<ReturnType<M['sample.bin.add']>>().toEqualTypeOf<
+        Result<'bin_123', ValidationError>
+      >();
+      expectTypeOf<ReturnType<M['sample.bin.delete']>>().toEqualTypeOf<
+        Result<undefined, LayoutError>
+      >();
+    });
+  });
+
+  describe('Registry preserves byType lookup', () => {
+    it('preserves the full command def under byType[K]', () => {
+      expectTypeOf(sampleRegistry.byType['sample.bin.add']).toEqualTypeOf<typeof sampleAddBin>();
+    });
+  });
+});
+
+// Runtime no-op so vitest's test runner registers the file.
+describe('v2 runtime smoke', () => {
+  it('registry contains both sample commands', () => {
+    expect(sampleRegistry.commands).toHaveLength(2);
+  });
+});

--- a/src/core/cqrs/v2/types.ts
+++ b/src/core/cqrs/v2/types.ts
@@ -12,6 +12,7 @@
  */
 
 import type { z } from 'zod';
+import type { Draft } from 'immer';
 import type { Result } from '@/core/result';
 import type { Layout, LayoutLibrary } from '@/core/types';
 
@@ -35,12 +36,18 @@ export interface AggregateRoot {
 }
 
 /**
- * Mutable Immer draft shape per aggregate. `apply()` writes through this.
+ * Mutable Immer draft shape per aggregate. `apply()` receives the draft
+ * for its declared aggregate and writes through it directly. Wrapped in
+ * Immer's `Draft<T>` so the deep-readonly bits of the source types
+ * (Layout's branded `Mm`/`GridUnits`, frozen arrays, etc.) become
+ * writable for the duration of `apply()`.
+ *
+ * Designer is `unknown` until that migration lands.
  */
 export interface AggregateDraft {
-  readonly layout: Layout;
-  readonly library: LayoutLibrary;
-  readonly designer: unknown;
+  layout: Draft<Layout>;
+  library: Draft<LayoutLibrary>;
+  designer: unknown;
 }
 
 /**

--- a/src/core/cqrs/v2/types.ts
+++ b/src/core/cqrs/v2/types.ts
@@ -1,0 +1,127 @@
+/**
+ * CQRS v2 Foundations — Types
+ *
+ * Type-only foundations for the redesigned `defineCommand({...})` shape.
+ * No runtime here — the goal is to validate that a single literal-object
+ * command definition can drive end-to-end type inference for payload,
+ * value, error union, event payload, and the auto-derived `Mutations`
+ * surface, without inference collapsing or compile-time regressing.
+ *
+ * v1 (the existing surface under cqrs/commands, cqrs/handlers, etc.)
+ * remains the source of truth until per-domain migrations land.
+ */
+
+import type { z } from 'zod';
+import type { Result } from '@/core/result';
+import type { Layout, LayoutLibrary } from '@/core/types';
+
+/**
+ * Aggregate roots that commands can target. The aggregate selects which
+ * store's draft `apply()` receives.
+ */
+export type AggregateName = 'layout' | 'library' | 'designer';
+
+/**
+ * Read-only snapshot shape per aggregate.
+ *
+ * Designer is `unknown` until the designer migration lands — the type
+ * stays open so `defineCommand({ aggregate: 'designer', ... })` does not
+ * lock in a shape we may want to revise during PR 7.
+ */
+export interface AggregateRoot {
+  readonly layout: Layout;
+  readonly library: LayoutLibrary;
+  readonly designer: unknown;
+}
+
+/**
+ * Mutable Immer draft shape per aggregate. `apply()` writes through this.
+ */
+export interface AggregateDraft {
+  readonly layout: Layout;
+  readonly library: LayoutLibrary;
+  readonly designer: unknown;
+}
+
+/**
+ * Context passed to `handle()`. Read-only by construction — handlers
+ * cannot mutate state directly. Planning logic (placement search,
+ * ID generation, validation against current state) lives here.
+ *
+ * Future PRs extend this with `ids` (generators) and `refs` (read-only
+ * snapshots of other aggregates for cross-aggregate queries).
+ */
+export interface HandleCtx<A extends AggregateName> {
+  readonly aggregate: AggregateRoot[A];
+}
+
+/**
+ * Successful handle return. The event payload alone (plus apply) must
+ * deterministically reproduce the mutation — this is the core invariant
+ * of the v2 design.
+ */
+export interface HandleSuccess<TValue, TEventPayload> {
+  readonly value: TValue;
+  readonly event: { readonly payload: TEventPayload };
+}
+
+/**
+ * Per-command middleware flags. Replaces the central middlewareConfig
+ * profile registry — each command declares its own middleware policy
+ * inline.
+ */
+export interface MiddlewareFlags {
+  readonly undoCapture?: boolean;
+  readonly validate?: boolean;
+  readonly analytics?: boolean | { readonly eventName?: string };
+}
+
+/**
+ * The shape of a single command definition. All generic parameters are
+ * inferred from the literal passed to `defineCommand({...})`.
+ */
+export interface CommandDefShape<
+  TType extends string,
+  TPayload,
+  TValue,
+  TEventType extends string,
+  TEventPayload,
+  TError,
+  A extends AggregateName,
+> {
+  readonly type: TType;
+  readonly aggregate: A;
+  readonly aggregateId: (payload: TPayload, ctx: HandleCtx<A>) => string;
+  readonly payload: z.ZodType<TPayload>;
+  readonly emitted: TEventType;
+  readonly schemaVersion: number;
+  readonly descriptionKey: string;
+  readonly middleware?: MiddlewareFlags;
+  readonly handle: (
+    payload: TPayload,
+    ctx: HandleCtx<A>
+  ) => Result<HandleSuccess<TValue, TEventPayload>, TError>;
+  readonly apply: (
+    event: { readonly type: TEventType; readonly payload: TEventPayload },
+    draft: AggregateDraft[A]
+  ) => void;
+}
+
+/**
+ * Minimal structural shape required for a value to act as a command def
+ * in a heterogeneous collection (e.g. the registry array).
+ *
+ * We intentionally do NOT use `CommandDefShape<string, unknown, ...>` as
+ * the constraint: function-arg contravariance would block concrete defs
+ * (whose `handle` takes a narrower payload) from being assignable. The
+ * static parts (`type`, `aggregate`, `emitted`) are enough to drive
+ * registry assembly and `Mutations<R>` derivation; the function fields
+ * are accessed via the preserved literal type, not via this constraint.
+ */
+export interface AnyCommandDef {
+  readonly type: string;
+  readonly aggregate: AggregateName;
+  readonly emitted: string;
+  readonly schemaVersion: number;
+  readonly descriptionKey: string;
+}


### PR DESCRIPTION
## Summary

Type-only foundations for the redesigned CQRS command surface. **No callers migrate yet** — this PR exists to validate that the proposed `defineCommand({...})` shape can drive end-to-end inference for payload, value, error union, event payload, and an auto-derived `Mutations<R>` surface, **without inference collapsing or compile-time regressing**.

## Why now

The full CQRS DX redesign sequences ~10 PRs. PR 1 (library persistence subscriber) shipped in #1538. This PR (PR 2) is foundations-only so the most consequential risk — type-inference health — is validated *before* any caller depends on the new API. Pass-2 review of the v3 plan flagged: "if type inference adds >2s to typecheck, fall back to per-command typed dispatchers and a thin manual `Mutations` object."

**Decision-gate result:** typecheck 9.16s (no regression vs ~9s baseline), inference works as designed.

## What's in the PR

New under `src/core/cqrs/v2/`:
- `types.ts` — `CommandDefShape`, `AggregateName`, `AggregateRoot`/`Draft` (Designer is `unknown` until that migration lands), `HandleCtx`, `MiddlewareFlags`, `AnyCommandDef`
- `defineCommand.ts` — typed identity factory; captures all generics from the literal
- `createRegistry.ts` — explicit array assembly, preserves per-command literal types under `byType`
- `Mutations.ts` — `Mutations<R>` mapped type + `PayloadOf`/`ValueOf`/`ErrorOf` extractors
- `sample.ts` — two sample commands driving type-inference assertions (deleted in PR 11 cleanup)
- `types.test.ts` — vitest `expectTypeOf` assertions covering literal type capture, extractor correctness, end-to-end `Mutations` derivation

## Architectural note

`AnyCommandDef` intentionally constrains only static fields (`type`, `aggregate`, `emitted`, `schemaVersion`, `descriptionKey`). The function fields (`handle`, `apply`, `aggregateId`) are excluded because **function-arg contravariance** would block concrete defs (whose `handle` takes a narrower payload) from being assignable to a registry array typed `readonly AnyCommandDef[]`. The registry preserves the function fields via the literal type `T[number]`, not via the constraint, so type info isn't lost — only the gatekeeping shape is loosened.

## What's NOT in this PR

- Runtime `createMutations(registry, bus)` dispatcher — lands when the first domain (bin/) migrates and needs a real wire-up
- `historyStore` rename — PR 3
- `undoCoordinator` + restore-via-CQRS wiring — PR 4
- Any caller migration — PRs 5–9

## Test plan

- [x] `pnpm typecheck` — clean, 9.16s (no regression)
- [x] `pnpm test:run src/core/cqrs/v2/` — 11/11 pass
- [x] `pnpm lint` — clean
- [x] `pnpm knip` — clean
- [x] `pnpm check:boundaries` — clean
- [x] `pnpm check:exhaustiveness` — clean