### PR TITLE
refactor(cqrs): rename history.ts into cqrs/undo/

### DIFF
--- a/src/core/cqrs/bus/commandBus.test.ts
+++ b/src/core/cqrs/bus/commandBus.test.ts
@@ -36,7 +36,7 @@ vi.mock('@/core/store/library', () => ({
   },
 }));
 
-vi.mock('@/core/store/history', () => ({
+vi.mock('@/core/cqrs/undo/historyStore', () => ({
   useHistoryStore: {
     getState: () => ({
       push: vi.fn(),

--- a/src/core/cqrs/middleware/undoCapture.test.ts
+++ b/src/core/cqrs/middleware/undoCapture.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { ok, err } from '@/core/result';
 import { layoutInvalidOperation } from '@/core/result/constructors';
 import { useLayoutStore } from '@/core/store/layout';
-import { useHistoryStore } from '@/core/store/history';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { resetLayoutStore, resetHistoryStore, createTestLayout } from '@/test/testUtils';
 import { undoCaptureMiddleware, batch, _resetUndoCaptureState } from './undoCapture';
 import type { Command } from '../commands';

--- a/src/core/cqrs/middleware/undoCapture.ts
+++ b/src/core/cqrs/middleware/undoCapture.ts
@@ -10,7 +10,7 @@
  */
 
 import { useLayoutStore } from '@/core/store/layout';
-import { useHistoryStore, captureSelectionSnapshot } from '@/core/store/history';
+import { useHistoryStore, captureSelectionSnapshot } from '@/core/cqrs/undo/historyStore';
 import { isOk } from '@/core/result';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
 import type { Command } from '../commands';

--- a/src/core/cqrs/undo/historyStore.test.ts
+++ b/src/core/cqrs/undo/historyStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { useHistoryStore } from '@/core/store/history';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useLayoutStore } from '@/core/store/layout';
 import { useSelectionStore } from '@/core/store/selection';
 import { createDefaultLayout, CONSTRAINTS } from '@/core/constants';

--- a/src/core/cqrs/undo/historyStore.ts
+++ b/src/core/cqrs/undo/historyStore.ts
@@ -1,9 +1,9 @@
 import { create } from 'zustand';
 import type { Layout, BinId, LayerId, CategoryId } from '@/core/types';
 import type { CommandType } from '@/core/cqrs/commands';
-import { useLayoutStore } from './layout';
-import { useSelectionStore } from './selection';
-import { useToastStore } from './toast';
+import { useLayoutStore } from '@/core/store/layout';
+import { useSelectionStore } from '@/core/store/selection';
+import { useToastStore } from '@/core/store/toast';
 import { CONSTRAINTS } from '@/core/constants';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
 import { getCommandDescriptionKey } from '@/core/cqrs/commandDescriptions';
@@ -34,11 +34,6 @@ export function captureSelectionSnapshot(): SelectionSnapshot {
 }
 
 /**
- * Restore selection from a snapshot, reconciling against the restored layout.
- * A snapshotted ID that no longer exists in the restored layout falls back to
- * the same pruning logic used before snapshots were captured.
- */
-/**
  * Fallback active-layer id when the snapshotted/current id is no longer in
  * the restored layout. Matches `handleRestoreLayout` in restoreHandlers.ts:
  * use the last layer in data order (= top layer in the UI, since the UI
@@ -49,6 +44,11 @@ function fallbackActiveLayerId(restoredLayout: Layout): LayerId {
   return restoredLayout.layers[restoredLayout.layers.length - 1].id;
 }
 
+/**
+ * Restore selection from a snapshot, reconciling against the restored layout.
+ * A snapshotted ID that no longer exists in the restored layout falls back to
+ * the same pruning logic used before snapshots were captured.
+ */
 function restoreSelectionFromSnapshot(restoredLayout: Layout, snapshot: SelectionSnapshot): void {
   const binIds = new Set(restoredLayout.bins.map((b) => b.id));
   const layerIds = new Set(restoredLayout.layers.map((l) => l.id));
@@ -157,6 +157,12 @@ function applySelection(restoredLayout: Layout, snapshot: SelectionSnapshot | un
  * History store — undo/redo stack (max 100 states).
  * Undo snapshots are captured automatically by the CQRS undo middleware.
  * Use `batch()` from `@/core/cqrs` to group multiple mutations into one undo step.
+ *
+ * Lives under `cqrs/undo/` (not `core/store/`) because undo is a CQRS
+ * concern: snapshots are pushed by `undoCaptureMiddleware`, popped by
+ * `useHistoryStore.undo/redo`, and apply via `useLayoutStore.restoreLayout`.
+ * Keeping the file here also breaks the historical `core/store/history` ↔
+ * `cqrs/commandDescriptions` cycle.
  */
 export const useHistoryStore = create<HistoryState>((set, get) => ({
   past: [],

--- a/src/core/store/index.ts
+++ b/src/core/store/index.ts
@@ -1,5 +1,4 @@
 export { useLayoutStore } from './layout';
-export { useHistoryStore } from './history';
 export { useToastStore, INITIAL_TOAST_STATE } from './toast';
 export { useLibraryStore, computePreview, createDefaultLibrary } from './library';
 export { useSettingsStore, DEFAULT_SETTINGS } from './settings';

--- a/src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.tsx
+++ b/src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.tsx
@@ -5,7 +5,7 @@ import { useLibraryStore } from '@/core/store/library';
 import { useSharedPreviewStore } from '@/core/store/sharedPreview';
 import { useSelectionStore } from '@/core/store/selection';
 import { useInteractionStore } from '@/core/store/interaction';
-import { useHistoryStore } from '@/core/store/history';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useToastStore } from '@/core/store/toast';
 import { createLayoutEntry, initializeLayoutLibrary } from '@/core/storage';
 import { isErr } from '@/core/result';

--- a/src/features/command-palette/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/features/command-palette/components/CommandPalette/CommandPalette.test.tsx
@@ -3,12 +3,12 @@ import { render } from '@testing-library/react';
 import { CommandPalette } from './CommandPalette';
 import {
   useLayoutStore,
-  useHistoryStore,
   useSelectionStore,
   useViewStore,
   useHalfBinModeStore,
   useInteractionStore,
 } from '@/core/store';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { resetAllStores, createTestLayout } from '@/test/testUtils';
 
 /**

--- a/src/features/command-palette/components/CommandPalette/commandPaletteActionHandlers.ts
+++ b/src/features/command-palette/components/CommandPalette/commandPaletteActionHandlers.ts
@@ -15,13 +15,13 @@ import { useShallow } from 'zustand/react/shallow';
 import { useTranslation } from '@/i18n';
 import {
   useLayoutStore,
-  useHistoryStore,
   useSelectionStore,
   useViewStore,
   useHalfBinModeStore,
   useInteractionStore,
   useToastStore,
 } from '@/core/store';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { batch } from '@/core/cqrs';
 import { useMutations } from '@/shared/contexts';
 import { useLayoutSwitcher } from '@/shared/hooks';

--- a/src/features/command-palette/components/CommandPalette/commandPaletteContextBoosts.ts
+++ b/src/features/command-palette/components/CommandPalette/commandPaletteContextBoosts.ts
@@ -9,13 +9,8 @@
 
 import { useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import {
-  useLayoutStore,
-  useHistoryStore,
-  useSelectionStore,
-  useViewStore,
-  useInteractionStore,
-} from '@/core/store';
+import { useLayoutStore, useSelectionStore, useViewStore, useInteractionStore } from '@/core/store';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { getStagingBins } from '@/shared/utils';
 
 export function useContextBoosts(): Record<string, number> {

--- a/src/features/layout-library/hooks/useLayoutRouting.ts
+++ b/src/features/layout-library/hooks/useLayoutRouting.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import { useLayoutStore, useLibraryStore, useToastStore, useHistoryStore } from '@/core/store';
+import { useLayoutStore, useLibraryStore, useToastStore } from '@/core/store';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useSelectionStore } from '@/core/store/selection';
 import { useSharedPreviewStore } from '@/core/store/sharedPreview';
 import { loadLayoutAsync } from '@/core/storage';

--- a/src/features/snapshots/components/SnapshotHistory/SnapshotHistory.tsx
+++ b/src/features/snapshots/components/SnapshotHistory/SnapshotHistory.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
 import { useLibraryStore } from '@/core/store/library';
-import { useHistoryStore } from '@/core/store/history';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useSnapshotStore } from '@/core/store/snapshots';
 import { useToastStore } from '@/core/store/toast';
 import { restoreSnapshot, createLayoutEntry, deleteSnapshotById } from '@/core/storage';

--- a/src/shared/hooks/useCrossTabSync.test.ts
+++ b/src/shared/hooks/useCrossTabSync.test.ts
@@ -3,7 +3,7 @@ import { renderHook, act } from '@testing-library/react';
 import { useCrossTabSync } from '@/shared/hooks';
 import { useLayoutStore } from '@/core/store/layout';
 import { useLibraryStore } from '@/core/store/library';
-import { useHistoryStore } from '@/core/store/history';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useSelectionStore } from '@/core/store/selection';
 import { useLabsStore, LABS_STORAGE_KEY } from '@/core/store/labs';
 import { resetAllStores, createTestLayout } from '@/test/testUtils';

--- a/src/shared/hooks/useCrossTabSync.ts
+++ b/src/shared/hooks/useCrossTabSync.ts
@@ -1,11 +1,6 @@
 import { useEffect } from 'react';
-import {
-  useLayoutStore,
-  useLibraryStore,
-  useHistoryStore,
-  useLabsStore,
-  LABS_STORAGE_KEY,
-} from '@/core/store';
+import { useLayoutStore, useLibraryStore, useLabsStore, LABS_STORAGE_KEY } from '@/core/store';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useSelectionStore } from '@/core/store/selection';
 import { loadLayoutAsync, loadLibraryAsync } from '@/core/storage';
 import { listenForLibraryChanges } from '@/core/storage/librarySync';

--- a/src/shared/hooks/useKeyboard.test.ts
+++ b/src/shared/hooks/useKeyboard.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useKeyboard } from '@/shared/hooks';
 import { useLayoutStore } from '@/core/store/layout';
-import { useHistoryStore } from '@/core/store/history';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useSelectionStore } from '@/core/store/selection';
 import { useInteractionStore } from '@/core/store/interaction';
 import { useViewStore } from '@/core/store/view';

--- a/src/shared/hooks/useKeyboard.ts
+++ b/src/shared/hooks/useKeyboard.ts
@@ -38,13 +38,13 @@ import { useShallow } from 'zustand/react/shallow';
 import { batch } from '@/core/cqrs';
 import {
   useLayoutStore,
-  useHistoryStore,
   useToastStore,
   useSelectionStore,
   useInteractionStore,
   useViewStore,
   useHalfBinModeStore,
 } from '@/core/store';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useMutations } from '@/shared/contexts';
 import { useDesignerRouting } from '@/shared/hooks/useDesignerRouting';
 import { useGridNavigation } from '@/features/grid-editor';

--- a/src/shared/hooks/useLayoutActivation.ts
+++ b/src/shared/hooks/useLayoutActivation.ts
@@ -11,7 +11,7 @@
 import { useCallback } from 'react';
 import { useLayoutStore } from '@/core/store/layout';
 import { useSelectionStore } from '@/core/store/selection';
-import { useHistoryStore } from '@/core/store/history';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useInteractionStore } from '@/core/store/interaction';
 import { useShallow } from 'zustand/react/shallow';
 import type { Layout, LayoutId } from '@/core/types';

--- a/src/shared/hooks/useLayoutSwitcher.test.ts
+++ b/src/shared/hooks/useLayoutSwitcher.test.ts
@@ -4,7 +4,7 @@ import { useLayoutSwitcher } from '@/shared/hooks/useLayoutSwitcher';
 import { useLayoutStore } from '@/core/store/layout';
 import { useLibraryStore } from '@/core/store/library';
 import { useSelectionStore } from '@/core/store/selection';
-import { useHistoryStore } from '@/core/store/history';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useToastStore } from '@/core/store/toast';
 import { useSharedPreviewStore } from '@/core/store/sharedPreview';
 import { createDefaultLayout, SHARED_PREVIEW_ID } from '@/core/constants';

--- a/src/shared/hooks/useSharedWithMe.test.ts
+++ b/src/shared/hooks/useSharedWithMe.test.ts
@@ -4,7 +4,7 @@ import { useSharedWithMe } from '@/shared/hooks/useSharedWithMe';
 import { useSharedWithMeStore } from '@/core/store/sharedWithMe';
 import { useLayoutStore } from '@/core/store/layout';
 import { useSharedPreviewStore } from '@/core/store/sharedPreview';
-import { useHistoryStore } from '@/core/store/history';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useToastStore } from '@/core/store/toast';
 import { createDefaultLayout } from '@/core/constants';
 import type { SharedWithMeEntry, Layout } from '@/core/types';

--- a/src/shell/Header/Header.test.tsx
+++ b/src/shell/Header/Header.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Header } from '@/shell/Header';
-import { useLayoutStore, useHistoryStore } from '@/core/store';
+import { useLayoutStore } from '@/core/store';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useViewStore } from '@/core/store/view';
 import { resetAllStores } from '@/test/testUtils';
 

--- a/src/shell/Header/Header.tsx
+++ b/src/shell/Header/Header.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, Suspense } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import { useLayoutStore, useHistoryStore, useViewStore } from '@/core/store';
+import { useLayoutStore, useViewStore } from '@/core/store';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useMutations } from '@/shared/contexts';
 import { useResponsive } from '@/shared/hooks';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';

--- a/src/shell/Mobile/MobileHeader/MobileHeader.tsx
+++ b/src/shell/Mobile/MobileHeader/MobileHeader.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useLayoutStore } from '@/core/store/layout';
-import { useHistoryStore, useMobileStore } from '@/core/store';
+import { useMobileStore } from '@/core/store';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useMutations } from '@/shared/contexts';
 import { useCollabMode } from '@/shared/hooks/useCollabMode';
 import { CONSTRAINTS } from '@/core/constants';

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -7,7 +7,7 @@ import type { Result } from '@/core/result/types';
 import { isOk, isErr } from '@/core/result';
 import { createDefaultLayout } from '@/core/constants';
 import { useLayoutStore } from '@/core/store/layout';
-import { useHistoryStore } from '@/core/store/history';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useToastStore, INITIAL_TOAST_STATE } from '@/core/store/toast';
 import { useSettingsStore, DEFAULT_SETTINGS } from '@/core/store/settings';
 import { useLibraryStore } from '@/core/store/library';


### PR DESCRIPTION
## Summary

Pure mechanical rename: `src/core/store/history.ts` → `src/core/cqrs/undo/historyStore.ts`. The `useHistoryStore` selector contract is preserved exactly. All 23 caller files updated to import from the new path.

## Why undo/ belongs under cqrs/, not core/store/

- Snapshots are pushed by `undoCaptureMiddleware` (`cqrs/middleware/`).
- Toasts read `getCommandDescriptionKey` from `cqrs/commandDescriptions.ts` for the human-facing action label.
- The store imports `CommandType` from `cqrs/commands`.

Keeping the file under `core/store/` created a directional cycle: `cqrs/middleware/undoCapture` → `core/store/history` → `cqrs/commands`. After this move, the cycle is gone — undo lives entirely on the cqrs side, with one-way deps into `core/store/{layout,selection,toast}`.

## Where this fits

PR 3 in the CQRS DX redesign sequence. Prior:
- #1538 (PR 1) — library cloudShare persistence subscriber
- #1539 (PR 2) — defineCommand foundations + type tests

Next:
- PR 4 — `undoCoordinator` + wire restore-via-CQRS so undo dispatches `RestoreLayoutCommand` instead of calling `useLayoutStore.restoreLayout` directly.

## What's preserved exactly

`useHistoryStore` keeps the same exported selector surface:
- `canUndo`, `canRedo` (boolean state)
- `undo`, `redo`, `clear`, `push` (actions)
- `SelectionSnapshot`, `HistoryEntry` (types)
- `captureSelectionSnapshot` (helper)

`@/core/store` barrel no longer re-exports `useHistoryStore` — callers now import from `@/core/cqrs/undo/historyStore` directly.

## Test plan

- [x] `pnpm typecheck` — 9.26s (no regression vs ~9s baseline)
- [x] `pnpm test:run` on changed areas — 89 files / 1301 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm knip` — clean
- [x] `pnpm check:boundaries` — clean