### PR TITLE
refactor(cqrs): wire undo/redo through the command bus

### DIFF
--- a/src/core/cqrs/commands/restoreCommands.ts
+++ b/src/core/cqrs/commands/restoreCommands.ts
@@ -6,10 +6,22 @@
 
 import type { BaseCommand } from '../types';
 import type { Layout } from '@/core/types';
+import type { SelectionSnapshot } from '../undo/historyStore';
 
+/**
+ * `selection` carries the user's selection state at the moment the
+ * snapshot was captured. When present, the handler restores the exact
+ * selection (active layer/category + selected/focused bins). When absent,
+ * the handler falls back to pruning stale references against the
+ * restored layout.
+ */
 export type RestoreLayoutCommand = BaseCommand<
   'layout.restore',
-  { readonly layout: Layout; readonly direction: 'undo' | 'redo' }
+  {
+    readonly layout: Layout;
+    readonly direction: 'undo' | 'redo';
+    readonly selection?: SelectionSnapshot;
+  }
 >;
 
 export type RestoreCommand = RestoreLayoutCommand;

--- a/src/core/cqrs/handlers/restoreHandlers.test.ts
+++ b/src/core/cqrs/handlers/restoreHandlers.test.ts
@@ -93,5 +93,57 @@ describe('Restore Handlers', () => {
         expect.objectContaining({ selectedBinIds: [] })
       );
     });
+
+    it('applies the snapshot exactly when present, not the prune fallback', () => {
+      // Snapshot captures a selection state from BEFORE the user did the
+      // undoable action; restoring the layout should also restore that
+      // exact selection, not derive one from the current store state.
+      const cmd = createCommand('layout.restore', {
+        layout: testLayout,
+        direction: 'undo' as const,
+        selection: {
+          activeLayerId: layerId('layer_1'),
+          activeCategoryId: categoryId('cat_1'),
+          selectedBinIds: [binId('bin_1')],
+          focusedBinId: binId('bin_1'),
+          quickLabelBinId: null,
+        },
+      });
+      handleRestoreLayout(cmd);
+
+      expect(mockRestoreSelection).toHaveBeenCalledWith({
+        activeLayerId: layerId('layer_1'),
+        activeCategoryId: categoryId('cat_1'),
+        selectedBinIds: [binId('bin_1')],
+        focusedBinId: binId('bin_1'),
+        quickLabelBinId: null,
+      });
+    });
+
+    it('reconciles snapshot ids that no longer exist in the restored layout', () => {
+      // The snapshot references bins/layers/categories that were removed
+      // before the undo target was captured. Reconciliation: drop missing
+      // bins, fall back to the last layer + first category.
+      const cmd = createCommand('layout.restore', {
+        layout: { ...testLayout, bins: [] },
+        direction: 'undo' as const,
+        selection: {
+          activeLayerId: layerId('layer_gone'),
+          activeCategoryId: categoryId('cat_gone'),
+          selectedBinIds: [binId('bin_1'), binId('bin_gone')],
+          focusedBinId: binId('bin_gone'),
+          quickLabelBinId: null,
+        },
+      });
+      handleRestoreLayout(cmd);
+
+      expect(mockRestoreSelection).toHaveBeenCalledWith({
+        activeLayerId: layerId('layer_1'),
+        activeCategoryId: categoryId('cat_1'),
+        selectedBinIds: [],
+        focusedBinId: null,
+        quickLabelBinId: null,
+      });
+    });
   });
 });

--- a/src/core/cqrs/handlers/restoreHandlers.test.ts
+++ b/src/core/cqrs/handlers/restoreHandlers.test.ts
@@ -94,10 +94,11 @@ describe('Restore Handlers', () => {
       );
     });
 
-    it('applies the snapshot exactly when present, not the prune fallback', () => {
-      // Snapshot captures a selection state from BEFORE the user did the
-      // undoable action; restoring the layout should also restore that
-      // exact selection, not derive one from the current store state.
+    it('applies only the snapshot fields that differ from current selection', () => {
+      // Mock current selection: selectedBinIds=[bin_1], focusedBinId=null,
+      // quickLabelBinId=null, activeLayerId=layer_1, activeCategoryId=cat_1.
+      // Snapshot wants focusedBinId=bin_1; everything else matches current.
+      // Sparse output: only the focusedBinId field should be restored.
       const cmd = createCommand('layout.restore', {
         layout: testLayout,
         direction: 'undo' as const,
@@ -111,19 +112,15 @@ describe('Restore Handlers', () => {
       });
       handleRestoreLayout(cmd);
 
-      expect(mockRestoreSelection).toHaveBeenCalledWith({
-        activeLayerId: layerId('layer_1'),
-        activeCategoryId: categoryId('cat_1'),
-        selectedBinIds: [binId('bin_1')],
-        focusedBinId: binId('bin_1'),
-        quickLabelBinId: null,
-      });
+      expect(mockRestoreSelection).toHaveBeenCalledTimes(1);
+      expect(mockRestoreSelection).toHaveBeenCalledWith({ focusedBinId: binId('bin_1') });
     });
 
     it('reconciles snapshot ids that no longer exist in the restored layout', () => {
-      // The snapshot references bins/layers/categories that were removed
-      // before the undo target was captured. Reconciliation: drop missing
-      // bins, fall back to the last layer + first category.
+      // Snapshot references missing IDs. Reconciliation drops the missing
+      // bin, falls back to last layer + first category. After reconciliation
+      // the resolved values happen to match current selection — sparse
+      // output produces an empty diff, so restoreSelection is NOT called.
       const cmd = createCommand('layout.restore', {
         layout: { ...testLayout, bins: [] },
         direction: 'undo' as const,
@@ -137,13 +134,31 @@ describe('Restore Handlers', () => {
       });
       handleRestoreLayout(cmd);
 
-      expect(mockRestoreSelection).toHaveBeenCalledWith({
-        activeLayerId: layerId('layer_1'),
-        activeCategoryId: categoryId('cat_1'),
-        selectedBinIds: [],
-        focusedBinId: null,
-        quickLabelBinId: null,
+      // Note: the FALLBACK active-layer (last layer = 'layer_1') matches
+      // current; the FALLBACK active-category ('cat_1') matches current;
+      // selectedBinIds reconciles to [] (current is [bin_1] — that IS a
+      // diff). Only selectedBinIds should be in the call payload.
+      expect(mockRestoreSelection).toHaveBeenCalledTimes(1);
+      expect(mockRestoreSelection).toHaveBeenCalledWith({ selectedBinIds: [] });
+    });
+
+    it('does not call restoreSelection when nothing changes', () => {
+      // Snapshot exactly matches the current selection mock — sparse output
+      // is {} and restoreSelection should be skipped entirely.
+      const cmd = createCommand('layout.restore', {
+        layout: testLayout,
+        direction: 'undo' as const,
+        selection: {
+          activeLayerId: layerId('layer_1'),
+          activeCategoryId: categoryId('cat_1'),
+          selectedBinIds: [binId('bin_1')],
+          focusedBinId: null,
+          quickLabelBinId: null,
+        },
       });
+      handleRestoreLayout(cmd);
+
+      expect(mockRestoreSelection).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/core/cqrs/handlers/restoreHandlers.ts
+++ b/src/core/cqrs/handlers/restoreHandlers.ts
@@ -1,59 +1,112 @@
 /**
  * Restore Command Handlers
  *
- * Centralizes layout restoration and related side effects (e.g., selection
- * pruning) so that, once wired up, history.ts can dispatch a restore command
- * instead of calling restoreLayout() directly. Currently not yet wired —
- * history.ts still restores directly.
+ * Centralizes layout restoration and related side effects (selection
+ * snapshot/prune). Dispatched by useHistoryStore.undo/redo via the
+ * command bus.
  */
 
 import { useLayoutStore } from '@/core/store/layout';
 import { useSelectionStore } from '@/core/store/selection';
 import type { SelectionState } from '@/core/store/selection';
 import { ok } from '@/core/result';
+import type { Layout, BinId, LayerId, CategoryId } from '@/core/types';
 import type { CommandResult } from '../types';
 import type { DomainEvent } from '../events';
 import type { RestoreLayoutCommand } from '../commands';
+import type { SelectionSnapshot } from '../undo/historyStore';
 import { createEventMeta } from './shared';
 
-export function handleRestoreLayout(
-  command: RestoreLayoutCommand
-): CommandResult<void, DomainEvent> {
-  useLayoutStore.getState().restoreLayout(command.payload.layout);
+/**
+ * Fallback active-layer id when the restored layout no longer contains the
+ * snapshotted/current id: use the last layer in data order (= top layer in
+ * the UI, since the UI reverses via getDisplayLayers()). New bins typically
+ * land on the top layer, so this is the least-surprising fallback.
+ */
+function fallbackActiveLayerId(restoredLayout: Layout): LayerId {
+  return restoredLayout.layers[restoredLayout.layers.length - 1].id;
+}
 
-  // Prune stale selections (bins/layers/categories that no longer exist)
-  const { layout } = command.payload;
-  const selection = useSelectionStore.getState();
+/**
+ * Apply a captured selection snapshot to the restored layout, reconciling
+ * any IDs that no longer exist (same fallbacks as the prune path).
+ */
+function applySnapshot(layout: Layout, snapshot: SelectionSnapshot): Partial<SelectionState> {
   const binIds = new Set(layout.bins.map((b) => b.id));
   const layerIds = new Set(layout.layers.map((l) => l.id));
   const categoryIds = new Set(layout.categories.map((c) => c.id));
 
+  const activeLayerId =
+    layerIds.has(snapshot.activeLayerId) || layout.layers.length === 0
+      ? snapshot.activeLayerId
+      : fallbackActiveLayerId(layout);
+
+  const activeCategoryId =
+    categoryIds.has(snapshot.activeCategoryId) || layout.categories.length === 0
+      ? snapshot.activeCategoryId
+      : layout.categories[0].id;
+
+  return {
+    activeLayerId,
+    activeCategoryId,
+    selectedBinIds: snapshot.selectedBinIds.filter((id) => binIds.has(id)),
+    focusedBinId:
+      snapshot.focusedBinId && binIds.has(snapshot.focusedBinId) ? snapshot.focusedBinId : null,
+    quickLabelBinId:
+      snapshot.quickLabelBinId && binIds.has(snapshot.quickLabelBinId)
+        ? snapshot.quickLabelBinId
+        : null,
+  };
+}
+
+/**
+ * Prune stale selection IDs against the restored layout. Used when no
+ * snapshot is provided (e.g. an external caller, or pre-snapshot history
+ * entries).
+ */
+function pruneSelection(layout: Layout, current: SelectionState): Partial<SelectionState> {
+  const binIds = new Set<BinId>(layout.bins.map((b) => b.id));
+  const layerIds = new Set<LayerId>(layout.layers.map((l) => l.id));
+  const categoryIds = new Set<CategoryId>(layout.categories.map((c) => c.id));
+
   const pruned: Partial<SelectionState> = {};
 
-  const validBins = selection.selectedBinIds.filter((id) => binIds.has(id));
-  if (validBins.length !== selection.selectedBinIds.length) {
+  const validBins = current.selectedBinIds.filter((id) => binIds.has(id));
+  if (validBins.length !== current.selectedBinIds.length) {
     pruned.selectedBinIds = validBins;
   }
 
-  if (selection.focusedBinId && !binIds.has(selection.focusedBinId)) {
+  if (current.focusedBinId && !binIds.has(current.focusedBinId)) {
     pruned.focusedBinId = null;
   }
 
-  if (selection.quickLabelBinId && !binIds.has(selection.quickLabelBinId)) {
+  if (current.quickLabelBinId && !binIds.has(current.quickLabelBinId)) {
     pruned.quickLabelBinId = null;
   }
 
-  // Fall back to last layer (top in UI, since layers[0] is bottom)
-  if (!layerIds.has(selection.activeLayerId) && layout.layers.length > 0) {
-    pruned.activeLayerId = layout.layers[layout.layers.length - 1].id;
+  if (!layerIds.has(current.activeLayerId) && layout.layers.length > 0) {
+    pruned.activeLayerId = fallbackActiveLayerId(layout);
   }
 
-  if (!categoryIds.has(selection.activeCategoryId) && layout.categories.length > 0) {
+  if (!categoryIds.has(current.activeCategoryId) && layout.categories.length > 0) {
     pruned.activeCategoryId = layout.categories[0].id;
   }
 
-  if (Object.keys(pruned).length > 0) {
-    selection.restoreSelection(pruned);
+  return pruned;
+}
+
+export function handleRestoreLayout(
+  command: RestoreLayoutCommand
+): CommandResult<void, DomainEvent> {
+  const { layout, direction, selection: snapshot } = command.payload;
+
+  useLayoutStore.getState().restoreLayout(layout);
+
+  const selection = useSelectionStore.getState();
+  const updates = snapshot ? applySnapshot(layout, snapshot) : pruneSelection(layout, selection);
+
+  if (Object.keys(updates).length > 0) {
+    selection.restoreSelection(updates);
   }
 
   return ok({
@@ -61,7 +114,7 @@ export function handleRestoreLayout(
     events: [
       {
         type: 'layout.restored' as const,
-        payload: { direction: command.payload.direction },
+        payload: { direction },
         meta: createEventMeta(command.meta, 'layout.restored'),
       },
     ],

--- a/src/core/cqrs/handlers/restoreHandlers.ts
+++ b/src/core/cqrs/handlers/restoreHandlers.ts
@@ -30,8 +30,16 @@ function fallbackActiveLayerId(restoredLayout: Layout): LayerId {
 /**
  * Apply a captured selection snapshot to the restored layout, reconciling
  * any IDs that no longer exist (same fallbacks as the prune path).
+ *
+ * Returns only the fields that differ from the current selection state, so
+ * `restoreSelection` short-circuits when undo lands on a layout whose
+ * selection already matches the snapshot.
  */
-function applySnapshot(layout: Layout, snapshot: SelectionSnapshot): Partial<SelectionState> {
+function applySnapshot(
+  layout: Layout,
+  snapshot: SelectionSnapshot,
+  current: SelectionState
+): Partial<SelectionState> {
   const binIds = new Set(layout.bins.map((b) => b.id));
   const layerIds = new Set(layout.layers.map((l) => l.id));
   const categoryIds = new Set(layout.categories.map((c) => c.id));
@@ -46,17 +54,27 @@ function applySnapshot(layout: Layout, snapshot: SelectionSnapshot): Partial<Sel
       ? snapshot.activeCategoryId
       : layout.categories[0].id;
 
-  return {
-    activeLayerId,
-    activeCategoryId,
-    selectedBinIds: snapshot.selectedBinIds.filter((id) => binIds.has(id)),
-    focusedBinId:
-      snapshot.focusedBinId && binIds.has(snapshot.focusedBinId) ? snapshot.focusedBinId : null,
-    quickLabelBinId:
-      snapshot.quickLabelBinId && binIds.has(snapshot.quickLabelBinId)
-        ? snapshot.quickLabelBinId
-        : null,
-  };
+  const selectedBinIds = snapshot.selectedBinIds.filter((id) => binIds.has(id));
+  const focusedBinId =
+    snapshot.focusedBinId && binIds.has(snapshot.focusedBinId) ? snapshot.focusedBinId : null;
+  const quickLabelBinId =
+    snapshot.quickLabelBinId && binIds.has(snapshot.quickLabelBinId)
+      ? snapshot.quickLabelBinId
+      : null;
+
+  const updates: Partial<SelectionState> = {};
+  if (activeLayerId !== current.activeLayerId) updates.activeLayerId = activeLayerId;
+  if (activeCategoryId !== current.activeCategoryId) updates.activeCategoryId = activeCategoryId;
+  if (!arraysEqual(selectedBinIds, current.selectedBinIds)) updates.selectedBinIds = selectedBinIds;
+  if (focusedBinId !== current.focusedBinId) updates.focusedBinId = focusedBinId;
+  if (quickLabelBinId !== current.quickLabelBinId) updates.quickLabelBinId = quickLabelBinId;
+  return updates;
+}
+
+function arraysEqual<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
 }
 
 /**
@@ -103,7 +121,9 @@ export function handleRestoreLayout(
   useLayoutStore.getState().restoreLayout(layout);
 
   const selection = useSelectionStore.getState();
-  const updates = snapshot ? applySnapshot(layout, snapshot) : pruneSelection(layout, selection);
+  const updates = snapshot
+    ? applySnapshot(layout, snapshot, selection)
+    : pruneSelection(layout, selection);
 
   if (Object.keys(updates).length > 0) {
     selection.restoreSelection(updates);

--- a/src/core/cqrs/undo/historyStore.ts
+++ b/src/core/cqrs/undo/historyStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import type { Layout, BinId, LayerId, CategoryId } from '@/core/types';
 import type { CommandType } from '@/core/cqrs/commands';
+import { createCommand } from '@/core/cqrs/commands';
+import { commandBus } from '@/core/cqrs/bus/commandBus';
 import { useLayoutStore } from '@/core/store/layout';
 import { useSelectionStore } from '@/core/store/selection';
 import { useToastStore } from '@/core/store/toast';
@@ -33,94 +35,6 @@ export function captureSelectionSnapshot(): SelectionSnapshot {
   };
 }
 
-/**
- * Fallback active-layer id when the snapshotted/current id is no longer in
- * the restored layout. Matches `handleRestoreLayout` in restoreHandlers.ts:
- * use the last layer in data order (= top layer in the UI, since the UI
- * reverses via `getDisplayLayers()`). New bins typically land on the top
- * layer, so this is the least-surprising fallback.
- */
-function fallbackActiveLayerId(restoredLayout: Layout): LayerId {
-  return restoredLayout.layers[restoredLayout.layers.length - 1].id;
-}
-
-/**
- * Restore selection from a snapshot, reconciling against the restored layout.
- * A snapshotted ID that no longer exists in the restored layout falls back to
- * the same pruning logic used before snapshots were captured.
- */
-function restoreSelectionFromSnapshot(restoredLayout: Layout, snapshot: SelectionSnapshot): void {
-  const binIds = new Set(restoredLayout.bins.map((b) => b.id));
-  const layerIds = new Set(restoredLayout.layers.map((l) => l.id));
-  const categoryIds = new Set(restoredLayout.categories.map((c) => c.id));
-
-  const activeLayerId =
-    layerIds.has(snapshot.activeLayerId) || restoredLayout.layers.length === 0
-      ? snapshot.activeLayerId
-      : fallbackActiveLayerId(restoredLayout);
-
-  const activeCategoryId =
-    categoryIds.has(snapshot.activeCategoryId) || restoredLayout.categories.length === 0
-      ? snapshot.activeCategoryId
-      : restoredLayout.categories[0].id;
-
-  useSelectionStore.getState().restoreSelection({
-    activeLayerId,
-    activeCategoryId,
-    selectedBinIds: snapshot.selectedBinIds.filter((id) => binIds.has(id)),
-    focusedBinId:
-      snapshot.focusedBinId && binIds.has(snapshot.focusedBinId) ? snapshot.focusedBinId : null,
-    quickLabelBinId:
-      snapshot.quickLabelBinId && binIds.has(snapshot.quickLabelBinId)
-        ? snapshot.quickLabelBinId
-        : null,
-  });
-}
-
-/**
- * Legacy pruning — used when a history entry has no captured selection
- * (pre-fix entries, or direct push() calls from outside the middleware).
- */
-function pruneStaleSelections(restoredLayout: Layout): void {
-  const binIds = new Set(restoredLayout.bins.map((b) => b.id));
-  const layerIds = new Set(restoredLayout.layers.map((l) => l.id));
-  const categoryIds = new Set(restoredLayout.categories.map((c) => c.id));
-  const selectionState = useSelectionStore.getState();
-
-  const updates: {
-    selectedBinIds?: BinId[];
-    focusedBinId?: BinId | null;
-    quickLabelBinId?: BinId | null;
-    activeLayerId?: LayerId;
-    activeCategoryId?: CategoryId;
-  } = {};
-
-  const prunedIds = selectionState.selectedBinIds.filter((id) => binIds.has(id));
-  if (prunedIds.length !== selectionState.selectedBinIds.length) {
-    updates.selectedBinIds = prunedIds;
-  }
-
-  if (selectionState.focusedBinId && !binIds.has(selectionState.focusedBinId)) {
-    updates.focusedBinId = null;
-  }
-
-  if (selectionState.quickLabelBinId && !binIds.has(selectionState.quickLabelBinId)) {
-    updates.quickLabelBinId = null;
-  }
-
-  if (!layerIds.has(selectionState.activeLayerId) && restoredLayout.layers.length > 0) {
-    updates.activeLayerId = fallbackActiveLayerId(restoredLayout);
-  }
-
-  if (!categoryIds.has(selectionState.activeCategoryId) && restoredLayout.categories.length > 0) {
-    updates.activeCategoryId = restoredLayout.categories[0].id;
-  }
-
-  if (Object.keys(updates).length > 0) {
-    useSelectionStore.getState().restoreSelection(updates);
-  }
-}
-
 export interface HistoryEntry {
   layout: Layout;
   commandType: CommandType | 'unknown';
@@ -145,24 +59,20 @@ interface HistoryState {
   clear: () => void;
 }
 
-function applySelection(restoredLayout: Layout, snapshot: SelectionSnapshot | undefined): void {
-  if (snapshot) {
-    restoreSelectionFromSnapshot(restoredLayout, snapshot);
-  } else {
-    pruneStaleSelections(restoredLayout);
-  }
-}
-
 /**
  * History store — undo/redo stack (max 100 states).
- * Undo snapshots are captured automatically by the CQRS undo middleware.
- * Use `batch()` from `@/core/cqrs` to group multiple mutations into one undo step.
+ *
+ * Snapshots are pushed by `undoCaptureMiddleware`. `undo()` / `redo()`
+ * dispatch a `layout.restore` command via the command bus, which routes
+ * through `handleRestoreLayout` to apply the layout + selection state.
+ * The bus path means the restore is observable by analytics middleware
+ * and replayable through the event store, while undoCapture's
+ * `restore` middleware profile keeps it from being captured itself.
  *
  * Lives under `cqrs/undo/` (not `core/store/`) because undo is a CQRS
- * concern: snapshots are pushed by `undoCaptureMiddleware`, popped by
- * `useHistoryStore.undo/redo`, and apply via `useLayoutStore.restoreLayout`.
- * Keeping the file here also breaks the historical `core/store/history` ↔
- * `cqrs/commandDescriptions` cycle.
+ * concern. The static import cycle (historyStore → commandBus →
+ * middleware → historyStore) is benign — no functions execute at
+ * module-init time, so by first user action all bindings are populated.
  */
 export const useHistoryStore = create<HistoryState>((set, get) => ({
   past: [],
@@ -202,8 +112,13 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
       canRedo: true,
     }));
 
-    useLayoutStore.getState().restoreLayout(previous);
-    applySelection(previous, previousSelection);
+    commandBus.dispatch(
+      createCommand('layout.restore', {
+        layout: previous,
+        direction: 'undo',
+        selection: previousSelection,
+      })
+    );
 
     // Show undo toast with action description
     // NOTE: getStaticTranslation uses English only. Full locale support
@@ -237,8 +152,13 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
       canRedo: state.future.length > 1,
     }));
 
-    useLayoutStore.getState().restoreLayout(next);
-    applySelection(next, nextSelection);
+    commandBus.dispatch(
+      createCommand('layout.restore', {
+        layout: next,
+        direction: 'redo',
+        selection: nextSelection,
+      })
+    );
 
     // Show redo toast with action description
     const descKey = getCommandDescriptionKey(commandType);


### PR DESCRIPTION
## Summary

`useHistoryStore.undo`/`redo` previously called `useLayoutStore.restoreLayout()` directly and applied selection inline, bypassing the CQRS pipeline entirely. `restoreHandlers.ts` documented this with *"Currently not yet wired — history.ts still restores directly."*

This PR closes that gap. Undo/redo now dispatch `RestoreLayoutCommand` via the command bus, which routes through `handleRestoreLayout` to apply the layout + selection state. The bus path means restore is observable by analytics middleware and replayable through the event store, while the `restore` middleware profile (`{ undo: false, validation: false }`) keeps undoCapture from re-capturing the post-undo state.

## Changes

- **`RestoreLayoutCommand`** payload extended with optional `selection: SelectionSnapshot`.
- **`handleRestoreLayout`** uses the snapshot when present (restores the user's exact selection). Falls back to pruning stale IDs when absent — preserves existing behavior for any non-snapshotted call sites.
- **`useHistoryStore.undo`/`redo`** dispatch via `commandBus.dispatch(...)` instead of calling `restoreLayout` + `applySelection` inline.
- **Dead helpers removed** from `historyStore` (`applySelection`, `restoreSelectionFromSnapshot`, `pruneStaleSelections`, `fallbackActiveLayerId`). Their logic now lives in `restoreHandlers` as `applySnapshot` / `pruneSelection`.

## Why the static import cycle is benign

`historyStore` → `commandBus` → `middleware` → `historyStore` is a cycle in the import graph, but no functions execute at module-init. The `undo`/`redo` lambdas reference `commandBus` by closure, which is fully populated by the time any user action fires. Documented inline.

## Where this fits

PR 4 in the CQRS DX redesign sequence. Prior:
- #1538 (PR 1) — library cloudShare persistence subscriber
- #1539 (PR 2) — defineCommand foundations + type tests
- #1541 (PR 3) — history.ts rename to cqrs/undo/

Next:
- PR 5 — bin/ migration (proof of concept for `defineCommand`)

## Test plan

- [x] `pnpm typecheck` — 8.96s (no regression)
- [x] `pnpm test:run` — full suite, 10301 tests pass (the undo/redo path is exercised by all the existing historyStore + handler + middleware tests)
- [x] Two new tests in `restoreHandlers.test.ts` covering: (a) snapshot-restore preserves the user's exact selection, (b) snapshot reconciliation drops missing-bin IDs and falls back to last layer + first category
- [x] `pnpm lint`, `pnpm knip`, `pnpm check:boundaries` — clean