### PR TITLE
feat(cqrs): migrate bin.add to v2 defineCommand (proof of concept)

### DIFF
--- a/src/core/cqrs/handlers/index.ts
+++ b/src/core/cqrs/handlers/index.ts
@@ -13,11 +13,15 @@ import { libraryHandlers } from './libraryHandlers';
 import { designerHandlers } from './designerHandlers';
 import { restoreHandlers } from './restoreHandlers';
 import { uiHandlers } from './uiHandlers';
+import { v2HandlerOverrides } from '../v2/registry';
 
 export { resetVersionCounters } from './shared';
 
 type HandlerFn = (command: never) => CommandResult<unknown, DomainEvent>;
 
+// v2 overrides spread LAST so migrated commands route through defineCommand
+// wrappers instead of the v1 handler. Other commands keep the v1 path until
+// their domain migrates.
 const handlerRegistry: Record<string, HandlerFn> = {
   ...binHandlers,
   ...layerHandlers,
@@ -27,6 +31,7 @@ const handlerRegistry: Record<string, HandlerFn> = {
   ...designerHandlers,
   ...restoreHandlers,
   ...uiHandlers,
+  ...(v2HandlerOverrides as Record<string, HandlerFn>),
 };
 
 export function getHandler(

--- a/src/core/cqrs/integration/pipeline.test.ts
+++ b/src/core/cqrs/integration/pipeline.test.ts
@@ -70,7 +70,17 @@ const mockStore = {
 };
 
 vi.mock('@/core/store/layout', () => ({
-  useLayoutStore: { getState: () => mockStore },
+  useLayoutStore: {
+    getState: () => mockStore,
+    // v2 wrapper (cqrs/v2/runtime.ts) calls setState directly on the layout
+    // store. Mirror the real Zustand+Immer signature: producer receives a
+    // mutable draft of the whole store state, including `layout` and
+    // `lastEditSource`. Apply the producer to mockStore so tests see the
+    // mutation reflected in subsequent getState() calls.
+    setState: (producer: (state: typeof mockStore & { lastEditSource: string | null }) => void) => {
+      producer(mockStore as typeof mockStore & { lastEditSource: string | null });
+    },
+  },
 }));
 
 vi.mock('@/core/store/library', () => ({

--- a/src/core/cqrs/v2/domain/bin/addBin.test.ts
+++ b/src/core/cqrs/v2/domain/bin/addBin.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Property tests for the v2 `bin.add` command.
+ *
+ * Two invariants every defineCommand should hold:
+ *
+ * 1. handle() determinism — a pure function of (payload, ctx). Calling it
+ *    twice against the same frozen layout snapshot must produce structurally
+ *    identical output (modulo the freshly-generated BinId).
+ *
+ * 2. apply() round-trip — applying the event produced by handle() to the
+ *    same starting layout must produce the same Layout state as the v1
+ *    native execution. This is the core invariant of v2: "the event payload
+ *    + apply alone reproduce the mutation."
+ */
+
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import type { Bin, Layout } from '@/core/types';
+import { binId, layerId, categoryId } from '@/core/types';
+import { addBin } from './addBin';
+
+function makeLayout(overrides: Partial<Layout> = {}): Layout {
+  return {
+    version: '1.0',
+    name: 'Test',
+    drawer: { width: 6, depth: 4, height: 7 } as Layout['drawer'],
+    printBedSize: 256 as Layout['printBedSize'],
+    gridUnitMm: 42 as Layout['gridUnitMm'],
+    heightUnitMm: 7 as Layout['heightUnitMm'],
+    categories: [{ id: categoryId('cat_1'), name: 'Default', color: '#808080' }],
+    layers: [{ id: layerId('layer_1'), name: 'Layer 1', height: 3 }],
+    bins: [],
+    ...overrides,
+  };
+}
+
+const validPayload = {
+  layerId: layerId('layer_1'),
+  x: 0,
+  y: 0,
+  width: 1,
+  depth: 1,
+  height: 3,
+  category: categoryId('cat_1'),
+  label: '',
+  notes: '',
+};
+
+describe('v2 bin.add', () => {
+  describe('handle()', () => {
+    it('returns ok with new bin in event payload when placement is valid', () => {
+      const layout = makeLayout();
+      const result = addBin.handle(validPayload, { aggregate: layout });
+
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      expect(typeof result.value.value).toBe('string');
+      expect(result.value.value.length).toBeGreaterThan(0);
+      expect(result.value.event.payload.bin).toMatchObject(validPayload);
+      expect(result.value.event.payload.bin.id).toBe(result.value.value);
+    });
+
+    it('returns err when layerId references a non-existent layer', () => {
+      const layout = makeLayout();
+      const result = addBin.handle(
+        { ...validPayload, layerId: layerId('layer_gone') },
+        { aggregate: layout }
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('VALIDATION_INVALID_LAYER');
+    });
+
+    it('returns err when placement collides with existing bin', () => {
+      const existing: Bin = {
+        id: binId('bin_existing'),
+        layerId: layerId('layer_1'),
+        x: 0,
+        y: 0,
+        width: 1,
+        depth: 1,
+        height: 3,
+        category: categoryId('cat_1'),
+        label: '',
+        notes: '',
+      };
+      const layout = makeLayout({ bins: [existing] });
+      const result = addBin.handle(validPayload, { aggregate: layout });
+
+      expect(result.ok).toBe(false);
+    });
+
+    it('is deterministic: two invocations against same layout produce structurally identical events (modulo BinId)', () => {
+      const layout = makeLayout();
+      const r1 = addBin.handle(validPayload, { aggregate: layout });
+      const r2 = addBin.handle(validPayload, { aggregate: layout });
+
+      expect(isOk(r1) && isOk(r2)).toBe(true);
+      if (!isOk(r1) || !isOk(r2)) return;
+
+      // BinIds differ (generateBinId is non-deterministic by design — fresh
+      // id per call). Everything else must match exactly.
+      const { id: id1, ...rest1 } = r1.value.event.payload.bin;
+      const { id: id2, ...rest2 } = r2.value.event.payload.bin;
+      expect(id1).not.toBe(id2);
+      expect(rest1).toEqual(rest2);
+    });
+  });
+
+  describe('apply() round-trip', () => {
+    it('applying the event to L0 yields the same bin set as native push', () => {
+      const layout = makeLayout();
+      const result = addBin.handle(validPayload, { aggregate: layout });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+
+      // Apply path: produce a draft, apply the event
+      const applied = produce(layout, (draft) => {
+        addBin.apply({ type: 'bin.added', payload: result.value.event.payload }, draft);
+      });
+
+      // Native equivalent: push the bin directly
+      const native = produce(layout, (draft) => {
+        draft.bins.push(result.value.event.payload.bin);
+      });
+
+      expect(applied.bins).toEqual(native.bins);
+      expect(applied).toEqual(native);
+    });
+
+    it('applying the event onto an empty layout produces exactly one bin', () => {
+      const layout = makeLayout();
+      const result = addBin.handle(validPayload, { aggregate: layout });
+      if (!isOk(result)) throw new Error('handle failed');
+
+      const applied = produce(layout, (draft) => {
+        addBin.apply({ type: 'bin.added', payload: result.value.event.payload }, draft);
+      });
+
+      expect(applied.bins).toHaveLength(1);
+      expect(applied.bins[0]).toEqual(result.value.event.payload.bin);
+    });
+  });
+
+  describe('definition metadata', () => {
+    it('declares the expected static fields', () => {
+      expect(addBin.type).toBe('bin.add');
+      expect(addBin.aggregate).toBe('layout');
+      expect(addBin.emitted).toBe('bin.added');
+      expect(addBin.schemaVersion).toBe(1);
+      expect(addBin.descriptionKey).toBe('undo.action.binAdd');
+    });
+  });
+});

--- a/src/core/cqrs/v2/domain/bin/addBin.ts
+++ b/src/core/cqrs/v2/domain/bin/addBin.ts
@@ -16,6 +16,13 @@ import { canPlaceBin } from '@/shared/utils/validation';
 import { toPlacementError } from '@/core/store/layout/helpers';
 import { validationInvalidLayer } from '@/core/result';
 import type { Bin } from '@/core/types';
+import {
+  layerId as toLayerId,
+  categoryId as toCategoryId,
+  designId as toDesignId,
+  gridUnits,
+  heightUnits,
+} from '@/core/types';
 import { defineCommand } from '../../defineCommand';
 
 const payloadSchema = z.object({
@@ -43,25 +50,51 @@ export const addBin = defineCommand({
   descriptionKey: 'undo.action.binAdd',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
-    const id = generateBinId();
-    const bin: Bin = { ...payload, id } as Bin;
+    // Brand at the CQRS boundary (codebase convention: brand on
+    // deserialization). Payload arrives as plain strings/numbers from Zod;
+    // Bin and downstream APIs require branded LayerId/CategoryId/GridUnits/
+    // HeightUnits. Brand once up front so the rest of the handler is type-
+    // safe end-to-end.
+    const layerId = toLayerId(payload.layerId);
+    const category = toCategoryId(payload.category);
+    const x = gridUnits(payload.x);
+    const y = gridUnits(payload.y);
+    const width = gridUnits(payload.width);
+    const depth = gridUnits(payload.depth);
+    const height = heightUnits(payload.height);
+    const clearanceHeight =
+      payload.clearanceHeight !== undefined ? heightUnits(payload.clearanceHeight) : undefined;
+    const linkedDesignId =
+      payload.linkedDesignId !== undefined ? toDesignId(payload.linkedDesignId) : undefined;
 
-    if (bin.layerId !== STAGING_ID) {
-      const layer = ctx.aggregate.layers.find((l) => l.id === bin.layerId);
+    if (layerId !== STAGING_ID) {
+      const layer = ctx.aggregate.layers.find((l) => l.id === layerId);
       if (!layer) {
-        return err(validationInvalidLayer(bin.layerId));
+        return err(validationInvalidLayer(layerId));
       }
 
-      const rect = { x: bin.x, y: bin.y, width: bin.width, depth: bin.depth };
-      const validationResult = canPlaceBin(
-        { ...rect, height: bin.height },
-        bin.layerId,
-        ctx.aggregate
-      );
+      const rect = { x, y, width, depth };
+      const validationResult = canPlaceBin({ ...rect, height }, layerId, ctx.aggregate);
       if (!validationResult.valid) {
         return err(toPlacementError(validationResult.reason, rect));
       }
     }
+
+    // Generate the BinId only after validation passes so rejected commands
+    // don't burn an id.
+    const bin: Bin = {
+      ...payload,
+      id: generateBinId(),
+      layerId,
+      category,
+      x,
+      y,
+      width,
+      depth,
+      height,
+      clearanceHeight,
+      linkedDesignId,
+    };
 
     return ok({
       value: bin.id,

--- a/src/core/cqrs/v2/domain/bin/addBin.ts
+++ b/src/core/cqrs/v2/domain/bin/addBin.ts
@@ -1,0 +1,74 @@
+/**
+ * bin.add command — v2 (defineCommand) shape.
+ *
+ * Mirrors the contract of the v1 `handleAddBin` + `useLayoutStore.addBin`
+ * pair, but split along v2's boundary:
+ * - `handle()`: validate against frozen layout snapshot, generate the new
+ *   BinId, return the full `Bin` object inside the event payload.
+ * - `apply()`: push the bin onto the layout draft. No re-read needed —
+ *   the event carries everything.
+ */
+
+import { z } from 'zod';
+import { ok, err } from '@/core/result';
+import { generateBinId, STAGING_ID, CONSTRAINTS } from '@/core/constants';
+import { canPlaceBin } from '@/shared/utils/validation';
+import { toPlacementError } from '@/core/store/layout/helpers';
+import { validationInvalidLayer } from '@/core/result';
+import type { Bin } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({
+  layerId: z.string().min(1),
+  x: z.number().min(0),
+  y: z.number().min(0),
+  width: z.number().gt(0).max(CONSTRAINTS.GRID_MAX),
+  depth: z.number().gt(0).max(CONSTRAINTS.GRID_MAX),
+  height: z.number().min(CONSTRAINTS.MIN_BIN_HEIGHT),
+  clearanceHeight: z.number().min(0).optional(),
+  category: z.string().min(1),
+  label: z.string().max(CONSTRAINTS.LABEL_MAX_LENGTH),
+  notes: z.string().max(CONSTRAINTS.NOTES_MAX_LENGTH),
+  customProperties: z.record(z.string(), z.string()).optional(),
+  linkedDesignId: z.string().optional(),
+});
+
+export const addBin = defineCommand({
+  type: 'bin.add',
+  aggregate: 'layout',
+  aggregateId: () => 'layout',
+  payload: payloadSchema,
+  emitted: 'bin.added',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.binAdd',
+  middleware: { undoCapture: true, validate: true, analytics: true },
+  handle: (payload, ctx) => {
+    const id = generateBinId();
+    const bin: Bin = { ...payload, id } as Bin;
+
+    if (bin.layerId !== STAGING_ID) {
+      const layer = ctx.aggregate.layers.find((l) => l.id === bin.layerId);
+      if (!layer) {
+        return err(validationInvalidLayer(bin.layerId));
+      }
+
+      const rect = { x: bin.x, y: bin.y, width: bin.width, depth: bin.depth };
+      const validationResult = canPlaceBin(
+        { ...rect, height: bin.height },
+        bin.layerId,
+        ctx.aggregate
+      );
+      if (!validationResult.valid) {
+        return err(toPlacementError(validationResult.reason, rect));
+      }
+    }
+
+    return ok({
+      value: bin.id,
+      event: { payload: { bin } },
+    });
+  },
+  apply: (event, draft) => {
+    draft.bins.push(event.payload.bin);
+  },
+});

--- a/src/core/cqrs/v2/registry.ts
+++ b/src/core/cqrs/v2/registry.ts
@@ -1,0 +1,31 @@
+/**
+ * v2 Command Registry
+ *
+ * Lists all migrated v2 commands. Imported by `handlers/index.ts` to
+ * install v2 wrapped handlers, overriding the corresponding v1 entries.
+ *
+ * As more domains migrate, add their commands here. Once all v1 entries
+ * are gone, the v1 handler imports in `handlers/index.ts` can be removed.
+ */
+
+import type { CommandResult, CommandMeta } from '../types';
+import type { DomainEvent } from '../events';
+import { wrapV2Handler } from './runtime';
+import { addBin } from './domain/bin/addBin';
+
+export const v2Commands = [addBin] as const;
+
+type V2HandlerFn = (command: {
+  type: string;
+  payload: unknown;
+  meta: CommandMeta;
+}) => CommandResult<unknown, DomainEvent>;
+
+/**
+ * Map of v2 command type → wrapped handler. Spread into the existing
+ * handler registry in `handlers/index.ts` so the bus dispatches v2
+ * commands through the new path while v1 commands keep working unchanged.
+ */
+export const v2HandlerOverrides: Record<string, V2HandlerFn> = Object.fromEntries(
+  v2Commands.map((def) => [def.type, wrapV2Handler(def) as V2HandlerFn])
+);

--- a/src/core/cqrs/v2/runtime.ts
+++ b/src/core/cqrs/v2/runtime.ts
@@ -1,0 +1,118 @@
+/**
+ * v2 Runtime Bridge
+ *
+ * Wraps a `defineCommand({...})` definition as a v1-shape `CommandHandler`
+ * so it can be installed into the existing handler registry. The bus is
+ * unchanged — middleware (validation, undoCapture, analytics) runs first,
+ * then the wrapper executes the definition's `handle()` and applies the
+ * resulting event via `apply()` against an Immer draft of the appropriate
+ * store.
+ *
+ * The same store-mutation pathway is used for live commands AND replay,
+ * which is the core invariant of the v2 design: the event payload alone
+ * (plus apply) reproduces the state change.
+ */
+
+import { useLayoutStore } from '@/core/store/layout';
+import { useLibraryStore } from '@/core/store/library';
+import { ok, err, isErr } from '@/core/result';
+import type { CommandResult, CommandMeta } from '../types';
+import type { DomainEvent, DomainEventType } from '../events';
+import { createEventMeta } from '../handlers/shared';
+import type { AggregateName, CommandDefShape, HandleCtx } from './types';
+
+/**
+ * Read a frozen snapshot of the aggregate root for `handle()` to inspect.
+ */
+function aggregateSnapshot<A extends AggregateName>(aggregate: A): HandleCtx<A>['aggregate'] {
+  switch (aggregate) {
+    case 'layout':
+      return useLayoutStore.getState().layout as HandleCtx<A>['aggregate'];
+    case 'library':
+      return useLibraryStore.getState().library as HandleCtx<A>['aggregate'];
+    case 'designer':
+      // Designer aggregate not yet wired (see v2/types.ts AggregateDraft).
+      throw new Error('v2: designer aggregate not yet wired');
+    default: {
+      const _exhaustive: never = aggregate;
+      throw new Error(`v2: unknown aggregate ${_exhaustive as string}`);
+    }
+  }
+}
+
+/**
+ * Apply `mutate` against the appropriate store's Immer draft. Mirrors the
+ * existing `setLocal` pattern for the layout store (stamps `lastEditSource`
+ * so dirty-tracking + autosave work as before).
+ */
+function applyToDraft<A extends AggregateName>(
+  aggregate: A,
+  mutate: (draft: HandleCtx<A>['aggregate']) => void
+): void {
+  switch (aggregate) {
+    case 'layout':
+      useLayoutStore.setState((state) => {
+        mutate(state.layout as HandleCtx<A>['aggregate']);
+        state.lastEditSource = 'local';
+      });
+      return;
+    case 'library':
+      useLibraryStore.setState((state) => {
+        mutate(state.library as HandleCtx<A>['aggregate']);
+      });
+      return;
+    case 'designer':
+      throw new Error('v2: designer aggregate not yet wired');
+    default: {
+      const _exhaustive: never = aggregate;
+      throw new Error(`v2: unknown aggregate ${_exhaustive as string}`);
+    }
+  }
+}
+
+/**
+ * Convert a `defineCommand` definition into a v1-shape `CommandHandler`
+ * the existing bus can dispatch. Validation middleware runs first (using
+ * the schema in `validation/schemas.ts`); this wrapper trusts the payload
+ * has been validated by the time it executes.
+ */
+export function wrapV2Handler<
+  TType extends string,
+  TPayload,
+  TValue,
+  TEventType extends string,
+  TEventPayload,
+  TError,
+  A extends AggregateName,
+>(
+  def: CommandDefShape<TType, TPayload, TValue, TEventType, TEventPayload, TError, A>
+): (command: {
+  type: TType;
+  payload: TPayload;
+  meta: CommandMeta;
+}) => CommandResult<TValue, DomainEvent> {
+  return (command) => {
+    const ctx: HandleCtx<A> = { aggregate: aggregateSnapshot(def.aggregate) };
+
+    const handleResult = def.handle(command.payload, ctx);
+    if (isErr(handleResult)) {
+      // TError isn't structurally guaranteed to satisfy CommandResult's
+      // error union (LayoutError | ValidationError) — we trust handlers to
+      // return errors from that union by convention. Cast keeps the
+      // wrapper type-erasure-free at the boundary.
+      return err(handleResult.error as never);
+    }
+
+    const { value, event } = handleResult.value;
+    const eventWithType = { type: def.emitted, payload: event.payload };
+
+    applyToDraft(def.aggregate, (draft) => {
+      def.apply(eventWithType, draft);
+    });
+
+    const meta = createEventMeta(command.meta, def.emitted as DomainEventType);
+    const fullEvent = { ...eventWithType, meta } as DomainEvent;
+
+    return ok({ value, events: [fullEvent] });
+  };
+}


### PR DESCRIPTION
## Summary

First production command migrated to the v2 `defineCommand` shape. Validates the runtime adapter end-to-end and establishes the pattern for subsequent migrations.

## What's new

- **`v2/runtime.ts`** — `wrapV2Handler()` converts a `defineCommand` into a v1-shape `CommandHandler`. Validation middleware still runs first (Zod schema in `validation/schemas.ts`); the wrapper trusts payload by the time it executes. `handle()` runs against a frozen aggregate snapshot; `apply()` runs against an Immer draft of the appropriate store, mirroring the existing `setLocal` pattern (stamps `lastEditSource` so autosave still works).
- **`v2/domain/bin/addBin.ts`** — the migrated command. `handle()` generates the BinId, validates layer existence + placement against the snapshot, returns the full `Bin` in the event payload. `apply()` pushes onto the draft. **The "re-read after Immer mutation" smell from v1's `handleAddBin` is gone** — the event carries everything.
- **`v2/registry.ts`** — list of v2 commands + the `v2HandlerOverrides` map spread into the existing handler registry.
- **`handlers/index.ts`** — spreads `v2HandlerOverrides` last so migrated commands route through `defineCommand` wrappers; v1 commands keep working unchanged.

## Caller side: zero changes

`mutationsAdapter.addBin` still calls `commandBus.dispatch(createCommand('bin.add', ...))`. The bus now routes to the v2 wrapper instead of v1's `handleAddBin` via the registry override. No `MutationsContext` rewiring needed.

## Tests

Two **property tests** per the v2 design invariants:
1. **`handle()` determinism**: two invocations against the same layout produce structurally identical events (modulo BinId).
2. **`apply()` round-trip**: `produce(layout, apply(event)) === produce(layout, push(event.bin))`. Plus an empty-layout case.

Plus:
- `pipeline.test.ts` mock extended with `setState` (v2 wrapper now calls it; the v1 path used `getState().addBin` only).
- **All 10311 existing tests pass** — behavioral parity preserved end-to-end.

## What's NOT in this PR

- Other 9 bin commands stay on v1 — migrated in subsequent PRs.
- `mutationsAdapter` not yet replaced by auto-derived `createMutations(registry)` — happens once enough commands have migrated to make that worthwhile.

## Where this fits

PR 5 in the CQRS DX redesign sequence:
- #1538 (PR 1) — library cloudShare persistence subscriber
- #1539 (PR 2) — defineCommand foundations + type tests
- #1541 (PR 3) — history.ts rename to cqrs/undo/
- #1542 (PR 4) — undo via command bus
- **#TBD (PR 5)** — bin.add v2 migration ← this PR

Next: PR 6 migrates the remaining bin commands (update, delete, deleteBatch, duplicate, moveToStaging, moveFromStaging, fillLayer, fillGaps, clearLayer), each with the per-command refactor checklist (e.g. duplicate's 5-placement search moves into `handle()`).

## Test plan

- [x] `pnpm typecheck` — 8.98s (no regression vs ~9s baseline)
- [x] `pnpm test:run` — full suite, 10311 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm knip` — clean
- [x] `pnpm check:boundaries` — clean
- [x] Property tests verify v2 design invariants for the migrated command