### PR TITLE
feat(cqrs): migrate bin.duplicate + bin.moveFromStaging to v2

### DIFF
--- a/src/core/cqrs/events/binEvents.ts
+++ b/src/core/cqrs/events/binEvents.ts
@@ -36,6 +36,12 @@ export type BinMovedToStagingEvent = BaseDomainEvent<
   { readonly id: BinId; readonly previousLayerId: LayerId }
 >;
 
+/**
+ * `height` was added in the v2 migration so apply() can reproduce the
+ * full mutation without consulting current layout state. v1-era persisted
+ * events have no height — the optional shape keeps them readable; the
+ * v2 apply() falls back to leaving height untouched when missing.
+ */
 export type BinMovedFromStagingEvent = BaseDomainEvent<
   'bin.movedFromStaging',
   {
@@ -43,6 +49,7 @@ export type BinMovedFromStagingEvent = BaseDomainEvent<
     readonly layerId: LayerId;
     readonly x: number;
     readonly y: number;
+    readonly height?: number;
   }
 >;
 

--- a/src/core/cqrs/projection/replay.ts
+++ b/src/core/cqrs/projection/replay.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Layout } from '@/core/types';
-import { gridUnits, mm } from '@/core/types';
+import { gridUnits, heightUnits, mm } from '@/core/types';
 import { STAGING_ID } from '@/core/constants';
 import type { DomainEvent } from '../events';
 
@@ -54,6 +54,12 @@ export function applyEvent(layout: Layout, event: DomainEvent): Layout {
         bin.layerId = event.payload.layerId;
         bin.x = gridUnits(event.payload.x);
         bin.y = gridUnits(event.payload.y);
+        // height was added to the payload in v2 (defineCommand migration).
+        // v1-era persisted events have no height — leave it untouched in
+        // that case (preserves prior replay behavior).
+        if (event.payload.height !== undefined) {
+          bin.height = heightUnits(event.payload.height);
+        }
       }
       break;
     }

--- a/src/core/cqrs/v2/domain/bin/duplicateBin.test.ts
+++ b/src/core/cqrs/v2/domain/bin/duplicateBin.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { STAGING_ID } from '@/core/constants';
+import { layerId, gridUnits } from '@/core/types';
+import type * as PosthogModule from '@/shared/analytics/posthog';
+import { duplicateBin } from './duplicateBin';
+import { makeLayout, makeBin } from './_testHelpers';
+
+// trackBinCreated is a side-effecting analytics call. Stub it so tests
+// don't try to dispatch to PostHog.
+vi.mock('@/shared/analytics/posthog', async () => {
+  const actual = await vi.importActual<typeof PosthogModule>('@/shared/analytics/posthog');
+  return {
+    ...actual,
+    trackBinCreated: vi.fn(),
+  };
+});
+
+describe('v2 bin.duplicate', () => {
+  it('places the duplicate to the right when there is room', () => {
+    const source = makeBin('bin_src', { x: gridUnits(0), y: gridUnits(0) });
+    const layout = makeLayout({ bins: [source] });
+
+    const result = duplicateBin.handle({ id: 'bin_src' }, { aggregate: layout });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.newBin.x).toBe(gridUnits(1));
+    expect(result.value.event.payload.newBin.y).toBe(gridUnits(0));
+    expect(result.value.event.payload.newBin.layerId).toBe(layerId('layer_1'));
+    expect(result.value.event.payload.sourceId).toBe(source.id);
+  });
+
+  it('falls back to staging when no adjacent placement fits', () => {
+    // Fill all four cardinal slots around the source bin so the search exhausts.
+    const source = makeBin('bin_src', { x: gridUnits(2), y: gridUnits(2) });
+    const right = makeBin('bin_right', { x: gridUnits(3), y: gridUnits(2) });
+    const left = makeBin('bin_left', { x: gridUnits(1), y: gridUnits(2) });
+    const above = makeBin('bin_above', { x: gridUnits(2), y: gridUnits(3) });
+    const below = makeBin('bin_below', { x: gridUnits(2), y: gridUnits(1) });
+    const layout = makeLayout({ bins: [source, right, left, above, below] });
+
+    const result = duplicateBin.handle({ id: 'bin_src' }, { aggregate: layout });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.newBin.layerId).toBe(STAGING_ID);
+    expect(result.value.event.payload.newBin.x).toBe(gridUnits(0));
+    expect(result.value.event.payload.newBin.y).toBe(gridUnits(0));
+  });
+
+  it('duplicates a staging bin into staging at (0, 0)', () => {
+    const source = makeBin('bin_src', { layerId: STAGING_ID });
+    const layout = makeLayout({ bins: [source] });
+
+    const result = duplicateBin.handle({ id: 'bin_src' }, { aggregate: layout });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.newBin.layerId).toBe(STAGING_ID);
+  });
+
+  it('errors when the source bin does not exist', () => {
+    const layout = makeLayout();
+    const result = duplicateBin.handle({ id: 'bin_gone' }, { aggregate: layout });
+    expect(result.ok).toBe(false);
+  });
+
+  it('apply() round-trip: applying the event pushes the resolved newBin', () => {
+    const source = makeBin('bin_src');
+    const layout = makeLayout({ bins: [source] });
+    const result = duplicateBin.handle({ id: 'bin_src' }, { aggregate: layout });
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(layout, (draft) => {
+      duplicateBin.apply({ type: 'bin.duplicated', payload: result.value.event.payload }, draft);
+    });
+
+    expect(applied.bins).toHaveLength(2);
+    expect(applied.bins[1]).toEqual(result.value.event.payload.newBin);
+  });
+});

--- a/src/core/cqrs/v2/domain/bin/duplicateBin.ts
+++ b/src/core/cqrs/v2/domain/bin/duplicateBin.ts
@@ -1,0 +1,121 @@
+/**
+ * bin.duplicate — v2 (defineCommand) shape.
+ *
+ * Migration note: the per-command refactor for bin.duplicate moves the
+ * 5-placement search out of the v1 store mutation
+ * (binActions.duplicateBin:139-163) into handle(). The event payload
+ * carries the resolved {newBin}, so apply() is a dumb push and replay
+ * does not re-run the search against potentially-different layout state.
+ *
+ * Search order (matches v1): right -> below -> left -> above -> staging.
+ * Staging-source bins always duplicate to staging at (0, 0).
+ */
+
+import { z } from 'zod';
+import type { Result, ValidationError, LayoutError } from '@/core/result';
+import { ok, err } from '@/core/result';
+import { generateBinId, STAGING_ID } from '@/core/constants';
+import { canPlaceBin } from '@/shared/utils/validation';
+import { layoutInvalidOperation } from '@/core/result';
+import { trackBinCreated } from '@/shared/analytics/posthog';
+import type { Bin, BinId, GridUnits, LayerId } from '@/core/types';
+import { binId as toBinId, gridUnits } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({ id: z.string().min(1) });
+
+interface Placement {
+  layerId: LayerId;
+  x: GridUnits;
+  y: GridUnits;
+}
+
+/** Try the four cardinal offsets in v1's search order. Returns the first
+ * placement that passes canPlaceBin, or null if none fit. */
+function findAdjacentPlacement(
+  bin: Bin,
+  layout: Parameters<typeof canPlaceBin>[2]
+): Placement | null {
+  const offsets: Array<{ dx: number; dy: number }> = [
+    { dx: bin.width, dy: 0 }, // right
+    { dx: 0, dy: -(bin.depth as number) }, // below (y decreases visually)
+    { dx: -(bin.width as number), dy: 0 }, // left
+    { dx: 0, dy: bin.depth }, // above
+  ];
+
+  for (const { dx, dy } of offsets) {
+    const x = ((bin.x as number) + dx) as GridUnits;
+    const y = ((bin.y as number) + dy) as GridUnits;
+    const result = canPlaceBin(
+      { x, y, width: bin.width, depth: bin.depth, height: bin.height },
+      bin.layerId,
+      layout
+    );
+    if (result.valid) return { layerId: bin.layerId, x, y };
+  }
+  return null;
+}
+
+export const duplicateBin = defineCommand({
+  type: 'bin.duplicate',
+  aggregate: 'layout',
+  aggregateId: () => 'layout',
+  payload: payloadSchema,
+  emitted: 'bin.duplicated',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.binDuplicate',
+  middleware: { undoCapture: true, validate: true, analytics: true },
+  handle: (
+    payload,
+    ctx
+  ): Result<
+    { value: BinId; event: { payload: { sourceId: BinId; newBin: Bin } } },
+    ValidationError | LayoutError
+  > => {
+    const sourceId = toBinId(payload.id);
+    const source = ctx.aggregate.bins.find((b) => b.id === sourceId);
+    if (!source) {
+      return err(layoutInvalidOperation('duplicateBin', `Bin ${sourceId} not found`));
+    }
+
+    // Resolve placement: staging bins always copy to staging (0, 0); grid
+    // bins try the 4 adjacent slots and fall back to staging if none fit.
+    const placement: Placement =
+      source.layerId === STAGING_ID
+        ? { layerId: STAGING_ID, x: gridUnits(0), y: gridUnits(0) }
+        : (findAdjacentPlacement(source, ctx.aggregate) ?? {
+            layerId: STAGING_ID,
+            x: gridUnits(0),
+            y: gridUnits(0),
+          });
+
+    const newBin: Bin = {
+      ...source,
+      id: generateBinId(),
+      layerId: placement.layerId,
+      x: placement.x,
+      y: placement.y,
+    };
+
+    // Mirror v1 behaviour: emit the granular bin-creation analytics event.
+    // The cqrs analytics middleware also tracks the command dispatch, but
+    // the per-method aggregation (added vs duplicated vs filled) lives in
+    // trackBinCreated. Future refinement: move this to a subscriber on
+    // bin.duplicated.
+    trackBinCreated({
+      method: 'duplicate',
+      count: 1,
+      width: source.width,
+      depth: source.depth,
+      height: source.height,
+    });
+
+    return ok({
+      value: newBin.id,
+      event: { payload: { sourceId, newBin } },
+    });
+  },
+  apply: (event, draft) => {
+    draft.bins.push(event.payload.newBin);
+  },
+});

--- a/src/core/cqrs/v2/domain/bin/duplicateBin.ts
+++ b/src/core/cqrs/v2/domain/bin/duplicateBin.ts
@@ -80,6 +80,12 @@ export const duplicateBin = defineCommand({
 
     // Resolve placement: staging bins always copy to staging (0, 0); grid
     // bins try the 4 adjacent slots and fall back to staging if none fit.
+    //
+    // Note: the staging slot at (0, 0) is NOT validated against existing
+    // staging bins — duplicates can silently overlap there. This matches
+    // v1's behavior (binActions.duplicateBin via store.addBin, which also
+    // skips placement validation for STAGING_ID). Staging is a free-form
+    // bucket; callers don't rely on collision-free staging coordinates.
     const placement: Placement =
       source.layerId === STAGING_ID
         ? { layerId: STAGING_ID, x: gridUnits(0), y: gridUnits(0) }

--- a/src/core/cqrs/v2/domain/bin/moveBinFromStaging.test.ts
+++ b/src/core/cqrs/v2/domain/bin/moveBinFromStaging.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { STAGING_ID } from '@/core/constants';
+import { layerId, heightUnits } from '@/core/types';
+import { moveBinFromStaging } from './moveBinFromStaging';
+import { makeLayout, makeBin } from './_testHelpers';
+
+describe('v2 bin.moveFromStaging', () => {
+  it('emits an event whose payload includes the resolved layer height', () => {
+    const bin = makeBin('bin_1', { layerId: STAGING_ID, height: heightUnits(5) });
+    const layout = makeLayout({
+      layers: [{ id: layerId('layer_1'), name: 'L1', height: heightUnits(3) }],
+      bins: [bin],
+    });
+
+    const result = moveBinFromStaging.handle(
+      { id: 'bin_1', layerId: 'layer_1', x: 0, y: 0 },
+      { aggregate: layout }
+    );
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.height).toBe(heightUnits(3));
+    expect(result.value.event.payload.layerId).toBe(layerId('layer_1'));
+  });
+
+  it('errors when the bin does not exist', () => {
+    const layout = makeLayout();
+    const result = moveBinFromStaging.handle(
+      { id: 'bin_gone', layerId: 'layer_1', x: 0, y: 0 },
+      { aggregate: layout }
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('errors when the target layer does not exist', () => {
+    const bin = makeBin('bin_1', { layerId: STAGING_ID });
+    const layout = makeLayout({ bins: [bin] });
+    const result = moveBinFromStaging.handle(
+      { id: 'bin_1', layerId: 'layer_gone', x: 0, y: 0 },
+      { aggregate: layout }
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('errors when placement collides with an existing bin', () => {
+    const occupant = makeBin('bin_occupant', { layerId: layerId('layer_1') });
+    const moving = makeBin('bin_1', { layerId: STAGING_ID });
+    const layout = makeLayout({ bins: [occupant, moving] });
+
+    const result = moveBinFromStaging.handle(
+      { id: 'bin_1', layerId: 'layer_1', x: 0, y: 0 },
+      { aggregate: layout }
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('apply() round-trip: layerId, x, y, AND height are restored', () => {
+    const bin = makeBin('bin_1', { layerId: STAGING_ID, height: heightUnits(5) });
+    const layout = makeLayout({
+      layers: [{ id: layerId('layer_1'), name: 'L1', height: heightUnits(3) }],
+      bins: [bin],
+    });
+    const result = moveBinFromStaging.handle(
+      { id: 'bin_1', layerId: 'layer_1', x: 0, y: 0 },
+      { aggregate: layout }
+    );
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(layout, (draft) => {
+      moveBinFromStaging.apply(
+        { type: 'bin.movedFromStaging', payload: result.value.event.payload },
+        draft
+      );
+    });
+
+    expect(applied.bins[0].layerId).toBe(layerId('layer_1'));
+    expect(applied.bins[0].height).toBe(heightUnits(3));
+  });
+});

--- a/src/core/cqrs/v2/domain/bin/moveBinFromStaging.test.ts
+++ b/src/core/cqrs/v2/domain/bin/moveBinFromStaging.test.ts
@@ -25,6 +25,18 @@ describe('v2 bin.moveFromStaging', () => {
     expect(result.value.event.payload.layerId).toBe(layerId('layer_1'));
   });
 
+  it('errors when the source bin is not in staging (v2 tightening)', () => {
+    const bin = makeBin('bin_1', { layerId: layerId('layer_1') });
+    const layout = makeLayout({ bins: [bin] });
+    const result = moveBinFromStaging.handle(
+      { id: 'bin_1', layerId: 'layer_1', x: 1, y: 1 },
+      { aggregate: layout }
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('LAYOUT_INVALID_OPERATION');
+  });
+
   it('errors when the bin does not exist', () => {
     const layout = makeLayout();
     const result = moveBinFromStaging.handle(

--- a/src/core/cqrs/v2/domain/bin/moveBinFromStaging.ts
+++ b/src/core/cqrs/v2/domain/bin/moveBinFromStaging.ts
@@ -14,6 +14,7 @@
 import { z } from 'zod';
 import type { Result, ValidationError, LayoutError } from '@/core/result';
 import { ok, err } from '@/core/result';
+import { STAGING_ID } from '@/core/constants';
 import { canPlaceBin } from '@/shared/utils/validation';
 import { toPlacementError } from '@/core/store/layout/helpers';
 import { layoutInvalidOperation, validationInvalidLayer } from '@/core/result';
@@ -55,6 +56,20 @@ export const moveBinFromStaging = defineCommand({
     const bin = ctx.aggregate.bins.find((b) => b.id === id);
     if (!bin) {
       return err(layoutInvalidOperation('moveBinFromStaging', `Bin ${id} not found`));
+    }
+
+    // Tighten v2 vs v1: the command name implies the source is in staging.
+    // v1 silently re-moved bins regardless of source layer, which would
+    // also re-stamp the bin's height to the target layer's height — a
+    // footgun. Reject explicitly so the caller picks a more appropriate
+    // command (e.g. bin.update for cross-layer moves).
+    if (bin.layerId !== STAGING_ID) {
+      return err(
+        layoutInvalidOperation(
+          'moveBinFromStaging',
+          `Bin ${id} is not in staging (layerId=${bin.layerId})`
+        )
+      );
     }
 
     const layer = ctx.aggregate.layers.find((l) => l.id === layerId);

--- a/src/core/cqrs/v2/domain/bin/moveBinFromStaging.ts
+++ b/src/core/cqrs/v2/domain/bin/moveBinFromStaging.ts
@@ -1,0 +1,101 @@
+/**
+ * bin.moveFromStaging — v2 (defineCommand) shape.
+ *
+ * Migration note: the v1 event payload carried only `{id, layerId, x, y}`
+ * which left replay drift — the bin's height needed to be re-derived from
+ * the layer at apply time, and projection/replay.ts didn't update height
+ * at all. The v2 event payload includes the resolved height so apply() is
+ * deterministic without consulting the current layout state.
+ *
+ * `height` is optional on the type for backward compatibility with v1
+ * persisted events; the v2 handler always populates it.
+ */
+
+import { z } from 'zod';
+import type { Result, ValidationError, LayoutError } from '@/core/result';
+import { ok, err } from '@/core/result';
+import { canPlaceBin } from '@/shared/utils/validation';
+import { toPlacementError } from '@/core/store/layout/helpers';
+import { layoutInvalidOperation, validationInvalidLayer } from '@/core/result';
+import type { BinId, LayerId, GridUnits, HeightUnits } from '@/core/types';
+import { binId as toBinId, layerId as toLayerId, gridUnits } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({
+  id: z.string().min(1),
+  layerId: z.string().min(1),
+  x: z.number().min(0),
+  y: z.number().min(0),
+});
+
+export const moveBinFromStaging = defineCommand({
+  type: 'bin.moveFromStaging',
+  aggregate: 'layout',
+  aggregateId: () => 'layout',
+  payload: payloadSchema,
+  emitted: 'bin.movedFromStaging',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.binMoveFromStaging',
+  middleware: { undoCapture: true, validate: true, analytics: true },
+  handle: (
+    payload,
+    ctx
+  ): Result<
+    {
+      value: undefined;
+      event: {
+        payload: { id: BinId; layerId: LayerId; x: GridUnits; y: GridUnits; height: HeightUnits };
+      };
+    },
+    ValidationError | LayoutError
+  > => {
+    const id = toBinId(payload.id);
+    const layerId = toLayerId(payload.layerId);
+
+    const bin = ctx.aggregate.bins.find((b) => b.id === id);
+    if (!bin) {
+      return err(layoutInvalidOperation('moveBinFromStaging', `Bin ${id} not found`));
+    }
+
+    const layer = ctx.aggregate.layers.find((l) => l.id === layerId);
+    if (!layer) {
+      return err(validationInvalidLayer(layerId));
+    }
+
+    const x = gridUnits(payload.x);
+    const y = gridUnits(payload.y);
+
+    // Use the layer's height for collision checks (and on the bin itself
+    // after the move) — staging bins keep their original height while in
+    // staging, but a grid placement must fit the layer's slot.
+    const rect = { x, y, width: bin.width, depth: bin.depth };
+    const validationResult = canPlaceBin(
+      { ...rect, height: layer.height },
+      layerId,
+      ctx.aggregate,
+      id
+    );
+    if (!validationResult.valid) {
+      return err(toPlacementError(validationResult.reason, rect));
+    }
+
+    return ok({
+      value: undefined,
+      event: { payload: { id, layerId, x, y, height: layer.height } },
+    });
+  },
+  apply: (event, draft) => {
+    const bin = draft.bins.find((b) => b.id === event.payload.id);
+    if (!bin) return;
+    bin.layerId = event.payload.layerId;
+    bin.x = event.payload.x;
+    bin.y = event.payload.y;
+    // Defensive: height is always populated by the v2 handler, but the
+    // event-payload type marks it optional for v1-replay back-compat.
+    // Don't assume the field is present on a future replay path.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- see comment
+    if (event.payload.height !== undefined) {
+      bin.height = event.payload.height;
+    }
+  },
+});

--- a/src/core/cqrs/v2/registry.ts
+++ b/src/core/cqrs/v2/registry.ts
@@ -15,7 +15,9 @@ import { addBin } from './domain/bin/addBin';
 import { updateBin } from './domain/bin/updateBin';
 import { deleteBin } from './domain/bin/deleteBin';
 import { deleteBins } from './domain/bin/deleteBins';
+import { duplicateBin } from './domain/bin/duplicateBin';
 import { moveBinToStaging } from './domain/bin/moveBinToStaging';
+import { moveBinFromStaging } from './domain/bin/moveBinFromStaging';
 import { clearLayer } from './domain/bin/clearLayer';
 
 type V2HandlerFn = (command: {
@@ -39,7 +41,9 @@ export const v2HandlerOverrides: Record<string, V2HandlerFn> = {
   [updateBin.type]: wrapV2Handler(updateBin) as V2HandlerFn,
   [deleteBin.type]: wrapV2Handler(deleteBin) as V2HandlerFn,
   [deleteBins.type]: wrapV2Handler(deleteBins) as V2HandlerFn,
+  [duplicateBin.type]: wrapV2Handler(duplicateBin) as V2HandlerFn,
   [moveBinToStaging.type]: wrapV2Handler(moveBinToStaging) as V2HandlerFn,
+  [moveBinFromStaging.type]: wrapV2Handler(moveBinFromStaging) as V2HandlerFn,
   [clearLayer.type]: wrapV2Handler(clearLayer) as V2HandlerFn,
 };
 
@@ -49,6 +53,8 @@ export const v2Commands = [
   updateBin,
   deleteBin,
   deleteBins,
+  duplicateBin,
   moveBinToStaging,
+  moveBinFromStaging,
   clearLayer,
 ] as const;


### PR DESCRIPTION
## Summary

PR 7 in the CQRS DX redesign sequence — the two bin commands with non-trivial per-command refactors.

## bin.duplicate

- v1's 5-placement search (`binActions.duplicateBin:139-163`) moved into `handle()`. Search order matches v1 exactly: right → below → left → above → staging fallback. Staging-source bins always copy to staging.
- Event payload carries the resolved `{sourceId, newBin}` so `apply()` is a dumb push and replay does **not** re-run the search against potentially divergent layout state.
- `trackBinCreated()` called inline in `handle()` to preserve the v1 per-method analytics aggregation. Marked as a future refinement candidate for moving into a `bin.duplicated` subscriber.

## bin.moveFromStaging

- v1 event payload carried only `{id, layerId, x, y}`. Replay drift: the bin's height needed to be re-derived from the layer at apply time, and `projection/replay.ts` didn't update height at all.
- v2 widens the `BinMovedFromStagingEvent` payload with optional `height` (optional for v1-replay back-compat; the v2 handler always populates).
- `handle()` validates against `layer.height`, returns it in the event; `apply()` restores `layerId/x/y` AND `height`.

## Tests

2 new sibling test files. Property tests cover:
- `handle()` correctness (staging fallback, source-not-found, layer-not-found, collision)
- `apply()` round-trip equivalence
- The height-restoration invariant for `moveFromStaging`

## Where this fits

- #1538 (PR 1) — library cloudShare persistence subscriber
- #1539 (PR 2) — defineCommand foundations
- #1541 (PR 3) — history.ts rename
- #1542 (PR 4) — undo via command bus
- #1543 (PR 5) — bin.add v2 (proof of concept)
- #1544 (PR 6) — 5 simpler bin commands
- **#TBD (PR 7)** — bin.duplicate + bin.moveFromStaging ← this PR

Next: **PR 8** migrates `bin.fillLayer` + `bin.fillGaps` and deletes `_fillMeta` (the 5-file delta with `layoutAnalytics` subscriber rewire).

## Test plan

- [x] `pnpm typecheck` — 8.96s (no regression)
- [x] `pnpm test:run` — full suite, **10338 tests pass** (was 10328 — +10 new property tests)
- [x] `pnpm lint` — clean
- [x] `pnpm knip` — clean
- [x] `pnpm check:boundaries` — clean