### PR TITLE
feat(cqrs): migrate fill commands to v2; delete _fillMeta side-channel

### DIFF
--- a/src/core/cqrs/events/binEvents.ts
+++ b/src/core/cqrs/events/binEvents.ts
@@ -53,12 +53,21 @@ export type BinMovedFromStagingEvent = BaseDomainEvent<
   }
 >;
 
+/**
+ * `fillType`, `width`, `depth` were added in the v2 migration so the fill
+ * analytics subscriber can derive what the v1 `_fillMeta` field used to
+ * carry. v1-era persisted events have no `fillType` — analytics treats
+ * those as unknown-source fills.
+ */
 export type LayerFilledEvent = BaseDomainEvent<
   'bin.layerFilled',
   {
     readonly layerId: LayerId;
     readonly binsCreated: number;
     readonly bins: ReadonlyArray<Bin>;
+    readonly fillType?: 'uniform' | 'gaps';
+    readonly width?: number;
+    readonly depth?: number;
   }
 >;
 

--- a/src/core/cqrs/events/binEvents.ts
+++ b/src/core/cqrs/events/binEvents.ts
@@ -56,8 +56,9 @@ export type BinMovedFromStagingEvent = BaseDomainEvent<
 /**
  * `fillType`, `width`, `depth` were added in the v2 migration so the fill
  * analytics subscriber can derive what the v1 `_fillMeta` field used to
- * carry. v1-era persisted events have no `fillType` — analytics treats
- * those as unknown-source fills.
+ * carry. v1-era persisted events have no `fillType` — the subscriber
+ * silently ignores those (re-emitting them would distort current-period
+ * metrics).
  */
 export type LayerFilledEvent = BaseDomainEvent<
   'bin.layerFilled',

--- a/src/core/cqrs/index.ts
+++ b/src/core/cqrs/index.ts
@@ -162,4 +162,8 @@ export { createCqrsMutations } from './integration/mutationsAdapter';
 
 export { applyEvent, replayEvents } from './projection/replay';
 
-export { connectSelectionPruning, connectLibraryPersistence } from './subscribers';
+export {
+  connectSelectionPruning,
+  connectLibraryPersistence,
+  connectFillAnalytics,
+} from './subscribers';

--- a/src/core/cqrs/subscribers/fillAnalytics.test.ts
+++ b/src/core/cqrs/subscribers/fillAnalytics.test.ts
@@ -99,6 +99,10 @@ describe('fillAnalytics subscriber', () => {
     bus.publish(makeFillEvent('gaps', [makeBin('b_1')]));
 
     expect(mlTracking.trackFill).toHaveBeenCalledWith('gaps', 1, layerId('layer_1'), undefined);
+    // markFeatureUsed('fill') fires for ALL fill types — assert here too
+    // to catch a silent regression if it gets accidentally moved into a
+    // uniform-only branch.
+    expect(markFeatureUsed).toHaveBeenCalledWith('fill');
     expect(trackFillOperation).toHaveBeenCalledWith('fill_gaps', 1);
     expect(trackBinCreated).toHaveBeenCalledWith({ method: 'fill_gaps', count: 1 });
   });

--- a/src/core/cqrs/subscribers/fillAnalytics.test.ts
+++ b/src/core/cqrs/subscribers/fillAnalytics.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createEventBus } from '../bus/eventBus';
+import type { EventBus } from '../bus/eventBus';
+import type { DomainEvent } from '../events';
+import { eventId, correlationId, commandId } from '../types';
+import { layerId, categoryId, binId, gridUnits, heightUnits } from '@/core/types';
+import type { Bin } from '@/core/types';
+import { connectFillAnalytics } from './fillAnalytics';
+
+vi.mock('@/shared/analytics/useMLTracking', () => ({
+  mlTracking: { trackFill: vi.fn() },
+}));
+vi.mock('@/shared/analytics/posthog', () => ({
+  markFeatureUsed: vi.fn(),
+  trackFillOperation: vi.fn(),
+  trackBinCreated: vi.fn(),
+}));
+
+import { mlTracking } from '@/shared/analytics/useMLTracking';
+import { markFeatureUsed, trackFillOperation, trackBinCreated } from '@/shared/analytics/posthog';
+
+function makeBin(idStr: string): Bin {
+  return {
+    id: binId(idStr),
+    layerId: layerId('layer_1'),
+    x: gridUnits(0),
+    y: gridUnits(0),
+    width: gridUnits(1),
+    depth: gridUnits(1),
+    height: heightUnits(3),
+    category: categoryId('cat_1'),
+    label: '',
+    notes: '',
+  };
+}
+
+function makeFillEvent(
+  fillType: 'uniform' | 'gaps' | undefined,
+  bins: Bin[],
+  width?: number,
+  depth?: number
+): DomainEvent {
+  return {
+    type: 'bin.layerFilled',
+    payload: {
+      layerId: layerId('layer_1'),
+      binsCreated: bins.length,
+      bins,
+      ...(fillType ? { fillType } : {}),
+      ...(width !== undefined ? { width } : {}),
+      ...(depth !== undefined ? { depth } : {}),
+    },
+    meta: {
+      id: eventId('evt_1'),
+      timestamp: 0,
+      correlationId: correlationId('cor_1'),
+      commandId: commandId('cmd_1'),
+      aggregateId: layerId('layout_1'),
+      version: 1,
+      schemaVersion: 1,
+    },
+  } as DomainEvent;
+}
+
+describe('fillAnalytics subscriber', () => {
+  let bus: EventBus;
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    bus = createEventBus();
+    unsubscribe = connectFillAnalytics(bus);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    unsubscribe();
+    bus.clear();
+  });
+
+  it('forwards uniform fills to mlTracking + posthog', () => {
+    bus.publish(makeFillEvent('uniform', [makeBin('b_1'), makeBin('b_2')], 1, 1));
+
+    expect(mlTracking.trackFill).toHaveBeenCalledWith('uniform', 2, layerId('layer_1'), {
+      width: 1,
+      depth: 1,
+    });
+    expect(markFeatureUsed).toHaveBeenCalledWith('fill');
+    expect(trackFillOperation).toHaveBeenCalledWith('fill_layer', 2);
+    expect(trackBinCreated).toHaveBeenCalledWith({
+      method: 'fill_layer',
+      count: 2,
+      width: 1,
+      depth: 1,
+      height: 3,
+    });
+  });
+
+  it('forwards gap fills with no width/depth dimensions', () => {
+    bus.publish(makeFillEvent('gaps', [makeBin('b_1')]));
+
+    expect(mlTracking.trackFill).toHaveBeenCalledWith('gaps', 1, layerId('layer_1'), undefined);
+    expect(trackFillOperation).toHaveBeenCalledWith('fill_gaps', 1);
+    expect(trackBinCreated).toHaveBeenCalledWith({ method: 'fill_gaps', count: 1 });
+  });
+
+  it('ignores events without fillType (pre-v2 persisted events)', () => {
+    bus.publish(makeFillEvent(undefined, [makeBin('b_1')]));
+
+    expect(mlTracking.trackFill).not.toHaveBeenCalled();
+    expect(markFeatureUsed).not.toHaveBeenCalled();
+  });
+
+  it('ignores events with empty bins array', () => {
+    bus.publish(makeFillEvent('uniform', [], 1, 1));
+
+    expect(mlTracking.trackFill).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/cqrs/subscribers/fillAnalytics.ts
+++ b/src/core/cqrs/subscribers/fillAnalytics.ts
@@ -1,0 +1,57 @@
+/**
+ * Fill Analytics Event Subscriber
+ *
+ * Replaces the v1 `_fillMeta` side-channel: instead of the bulkActions
+ * setter writing transient metadata into the layout store for the
+ * `layoutAnalytics` subscriber to read-and-clear, the v2 fill commands
+ * carry `fillType` / `width` / `depth` directly in the `bin.layerFilled`
+ * event payload, and this subscriber forwards to the existing PostHog +
+ * mlTracking helpers.
+ *
+ * v1 events without `fillType` (pre-migration persisted events replayed
+ * via the event store) are silently ignored here — the analytics call
+ * sites all expected the metadata, and re-emitting them after the fact
+ * would distort current-period metrics.
+ */
+
+import { mlTracking } from '@/shared/analytics/useMLTracking';
+import { markFeatureUsed, trackFillOperation, trackBinCreated } from '@/shared/analytics/posthog';
+import type { UnsubscribeFn } from '../types';
+import type { EventBus } from '../bus/eventBus';
+
+/**
+ * Connect the fill-analytics subscriber to the event bus. Returns an
+ * unsubscribe function for symmetry with the other subscribers.
+ */
+export function connectFillAnalytics(bus: EventBus): UnsubscribeFn {
+  return bus.subscribe('bin.layerFilled', (event) => {
+    const { layerId, fillType, width, depth, bins } = event.payload;
+    if (!fillType) return; // pre-v2 event without enough metadata
+
+    const count = bins.length;
+    if (count === 0) return;
+
+    // Derive layerHeight from the placed bins — the v1 _fillMeta field
+    // stored layer.height which (after a fill) equals every fill-bin's
+    // height. Using the bin avoids a separate layout lookup.
+    const layerHeight = bins[0].height as number;
+
+    mlTracking.trackFill(
+      fillType,
+      count,
+      layerId,
+      fillType === 'uniform' && width !== undefined && depth !== undefined
+        ? { width, depth }
+        : undefined
+    );
+    markFeatureUsed('fill');
+    trackFillOperation(fillType === 'uniform' ? 'fill_layer' : 'fill_gaps', count);
+    trackBinCreated({
+      method: fillType === 'uniform' ? 'fill_layer' : 'fill_gaps',
+      count,
+      ...(fillType === 'uniform' && width !== undefined && depth !== undefined
+        ? { width, depth, height: layerHeight }
+        : {}),
+    });
+  });
+}

--- a/src/core/cqrs/subscribers/index.ts
+++ b/src/core/cqrs/subscribers/index.ts
@@ -7,3 +7,4 @@
 
 export { connectSelectionPruning } from './selectionPruning';
 export { connectLibraryPersistence } from './libraryPersistence';
+export { connectFillAnalytics } from './fillAnalytics';

--- a/src/core/cqrs/v2/domain/bin/fillGaps.test.ts
+++ b/src/core/cqrs/v2/domain/bin/fillGaps.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { fillGaps } from './fillGaps';
+import { makeLayout, makeBin } from './_testHelpers';
+import { gridUnits, layerId } from '@/core/types';
+
+describe('v2 bin.fillGaps', () => {
+  it('emits a gaps-fill event with bins covering the empty space', () => {
+    // Place a single bin off in the corner; fillGaps should fill the rest.
+    const corner = makeBin('bin_corner', { x: gridUnits(0), y: gridUnits(0) });
+    const layout = makeLayout({ bins: [corner] });
+
+    const result = fillGaps.handle(
+      { layerId: 'layer_1', categoryId: 'cat_1' },
+      { aggregate: layout }
+    );
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.fillType).toBe('gaps');
+    expect(result.value.event.payload.binsCreated).toBeGreaterThan(0);
+    // Width/depth not set for gap fills (mixed bin sizes possible).
+    expect(result.value.event.payload.width).toBeUndefined();
+    expect(result.value.event.payload.depth).toBeUndefined();
+  });
+
+  it('returns 0 + empty event when the layer is already full', () => {
+    const layout = makeLayout();
+
+    // First, fully fill the layer
+    const fillResult = fillGaps.handle(
+      { layerId: 'layer_1', categoryId: 'cat_1' },
+      { aggregate: layout }
+    );
+    if (!isOk(fillResult)) throw new Error('first fill failed');
+
+    const filled = produce(layout, (draft) => {
+      fillGaps.apply({ type: 'bin.layerFilled', payload: fillResult.value.event.payload }, draft);
+    });
+
+    const second = fillGaps.handle(
+      { layerId: 'layer_1', categoryId: 'cat_1' },
+      { aggregate: filled }
+    );
+    expect(isOk(second)).toBe(true);
+    if (!isOk(second)) return;
+    expect(second.value.event.payload.bins).toHaveLength(0);
+  });
+
+  it('apply() pushes the planned bins onto the draft', () => {
+    const layout = makeLayout();
+    const result = fillGaps.handle(
+      { layerId: 'layer_1', categoryId: 'cat_1' },
+      { aggregate: layout }
+    );
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(layout, (draft) => {
+      fillGaps.apply({ type: 'bin.layerFilled', payload: result.value.event.payload }, draft);
+    });
+
+    expect(applied.bins.length).toBe(result.value.event.payload.bins.length);
+    expect(applied.bins.every((b) => b.layerId === layerId('layer_1'))).toBe(true);
+  });
+});

--- a/src/core/cqrs/v2/domain/bin/fillGaps.ts
+++ b/src/core/cqrs/v2/domain/bin/fillGaps.ts
@@ -1,0 +1,69 @@
+/**
+ * bin.fillGaps — v2 (defineCommand) shape.
+ *
+ * Sibling to fillLayer. Same shape: planning runs in handle() against the
+ * frozen layout snapshot; the resulting bins are encoded in the event
+ * payload with `fillType: 'gaps'` so the analytics subscriber can
+ * distinguish uniform vs gap-fill operations.
+ *
+ * Returns `result.addedCount` (matching v1's return) — gap fills can
+ * place a different count than `bins.length` reports when the underlying
+ * helper merges adjacent placements.
+ */
+
+import { z } from 'zod';
+import { ok } from '@/core/result';
+import { calcMaxGridUnits } from '@/core/constants';
+import { fillGaps as runFillGaps } from '@/shared/utils/fill';
+import { layerId as toLayerId, categoryId as toCategoryId } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({
+  layerId: z.string().min(1),
+  categoryId: z.string().min(1),
+  halfBinMode: z.boolean().optional(),
+});
+
+export const fillGaps = defineCommand({
+  type: 'bin.fillGaps',
+  aggregate: 'layout',
+  aggregateId: () => 'layout',
+  payload: payloadSchema,
+  emitted: 'bin.layerFilled',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.layerFillGaps',
+  middleware: { undoCapture: true, validate: true, analytics: true },
+  handle: (payload, ctx) => {
+    const layerId = toLayerId(payload.layerId);
+    const categoryId = toCategoryId(payload.categoryId);
+
+    const maxGrid = calcMaxGridUnits(
+      ctx.aggregate.printBedSize,
+      ctx.aggregate.gridUnitMm,
+      ctx.aggregate.printBedDepth
+    );
+    const result = runFillGaps(
+      ctx.aggregate,
+      layerId,
+      categoryId,
+      Math.min(maxGrid.width, maxGrid.depth),
+      payload.halfBinMode ?? false
+    );
+
+    return ok({
+      value: result.addedCount,
+      event: {
+        payload: {
+          layerId,
+          binsCreated: result.bins.length,
+          bins: result.bins,
+          fillType: 'gaps' as const,
+        },
+      },
+    });
+  },
+  apply: (event, draft) => {
+    if (event.payload.bins.length === 0) return;
+    draft.bins.push(...event.payload.bins);
+  },
+});

--- a/src/core/cqrs/v2/domain/bin/fillGaps.ts
+++ b/src/core/cqrs/v2/domain/bin/fillGaps.ts
@@ -6,9 +6,10 @@
  * payload with `fillType: 'gaps'` so the analytics subscriber can
  * distinguish uniform vs gap-fill operations.
  *
- * Returns `result.addedCount` (matching v1's return) — gap fills can
- * place a different count than `bins.length` reports when the underlying
- * helper merges adjacent placements.
+ * Returns `result.addedCount` (matching v1's return). Today this equals
+ * `bins.length`, but the underlying helper distinguishes the two for
+ * forward compatibility — keep the v1 return shape so callers that
+ * already destructure `addedCount` aren't broken if the helper diverges.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/bin/fillLayer.test.ts
+++ b/src/core/cqrs/v2/domain/bin/fillLayer.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { categoryId, layerId } from '@/core/types';
+import { fillLayer } from './fillLayer';
+import { makeLayout } from './_testHelpers';
+
+describe('v2 bin.fillLayer', () => {
+  it('places bins on the empty layer and emits a uniform-fill event', () => {
+    const layout = makeLayout();
+    const result = fillLayer.handle(
+      { layerId: 'layer_1', width: 1, depth: 1, categoryId: 'cat_1' },
+      { aggregate: layout }
+    );
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.value).toBeGreaterThan(0);
+    expect(result.value.event.payload.fillType).toBe('uniform');
+    expect(result.value.event.payload.width).toBe(1);
+    expect(result.value.event.payload.depth).toBe(1);
+    expect(result.value.event.payload.bins.length).toBe(result.value.event.payload.binsCreated);
+  });
+
+  it('returns 0 + empty event when the layer is already full', () => {
+    const layout = makeLayout();
+    const first = fillLayer.handle(
+      { layerId: 'layer_1', width: 1, depth: 1, categoryId: 'cat_1' },
+      { aggregate: layout }
+    );
+    if (!isOk(first)) throw new Error('first fill failed');
+
+    const filled = produce(layout, (draft) => {
+      fillLayer.apply({ type: 'bin.layerFilled', payload: first.value.event.payload }, draft);
+    });
+
+    const second = fillLayer.handle(
+      { layerId: 'layer_1', width: 1, depth: 1, categoryId: 'cat_1' },
+      { aggregate: filled }
+    );
+
+    expect(isOk(second)).toBe(true);
+    if (!isOk(second)) return;
+    expect(second.value.value).toBe(0);
+    expect(second.value.event.payload.bins).toHaveLength(0);
+  });
+
+  it('apply() pushes the planned bins onto the draft', () => {
+    const layout = makeLayout();
+    const result = fillLayer.handle(
+      { layerId: 'layer_1', width: 2, depth: 2, categoryId: 'cat_1' },
+      { aggregate: layout }
+    );
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(layout, (draft) => {
+      fillLayer.apply({ type: 'bin.layerFilled', payload: result.value.event.payload }, draft);
+    });
+
+    expect(applied.bins.length).toBe(result.value.event.payload.bins.length);
+    expect(applied.bins.every((b) => b.layerId === layerId('layer_1'))).toBe(true);
+    expect(applied.bins.every((b) => b.category === categoryId('cat_1'))).toBe(true);
+  });
+});

--- a/src/core/cqrs/v2/domain/bin/fillLayer.ts
+++ b/src/core/cqrs/v2/domain/bin/fillLayer.ts
@@ -1,0 +1,68 @@
+/**
+ * bin.fillLayer — v2 (defineCommand) shape.
+ *
+ * The planning helper `fillAllWithSize` is called inside handle() against
+ * the frozen layout snapshot. The resulting bins are encoded in the event
+ * payload (along with `fillType: 'uniform'`, `width`, and `depth`) so
+ * apply() is a deterministic push and the fill-analytics subscriber has
+ * everything it needs without poking at transient store state.
+ *
+ * Replaces v1's `useLayoutStore.fillLayer` + `_fillMeta` side-channel.
+ */
+
+import { z } from 'zod';
+import { ok } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
+import { fillAllWithSize } from '@/shared/utils/fill';
+import { layerId as toLayerId, categoryId as toCategoryId } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({
+  layerId: z.string().min(1),
+  width: z.number().gt(0).max(CONSTRAINTS.GRID_MAX),
+  depth: z.number().gt(0).max(CONSTRAINTS.GRID_MAX),
+  categoryId: z.string().min(1),
+  halfBinMode: z.boolean().optional(),
+});
+
+export const fillLayer = defineCommand({
+  type: 'bin.fillLayer',
+  aggregate: 'layout',
+  aggregateId: () => 'layout',
+  payload: payloadSchema,
+  emitted: 'bin.layerFilled',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.layerFill',
+  middleware: { undoCapture: true, validate: true, analytics: true },
+  handle: (payload, ctx) => {
+    const layerId = toLayerId(payload.layerId);
+    const categoryId = toCategoryId(payload.categoryId);
+
+    const result = fillAllWithSize(
+      ctx.aggregate,
+      layerId,
+      payload.width,
+      payload.depth,
+      categoryId,
+      payload.halfBinMode ?? false
+    );
+
+    return ok({
+      value: result.bins.length,
+      event: {
+        payload: {
+          layerId,
+          binsCreated: result.bins.length,
+          bins: result.bins,
+          fillType: 'uniform' as const,
+          width: payload.width,
+          depth: payload.depth,
+        },
+      },
+    });
+  },
+  apply: (event, draft) => {
+    if (event.payload.bins.length === 0) return;
+    draft.bins.push(...event.payload.bins);
+  },
+});

--- a/src/core/cqrs/v2/registry.ts
+++ b/src/core/cqrs/v2/registry.ts
@@ -18,6 +18,8 @@ import { deleteBins } from './domain/bin/deleteBins';
 import { duplicateBin } from './domain/bin/duplicateBin';
 import { moveBinToStaging } from './domain/bin/moveBinToStaging';
 import { moveBinFromStaging } from './domain/bin/moveBinFromStaging';
+import { fillLayer } from './domain/bin/fillLayer';
+import { fillGaps } from './domain/bin/fillGaps';
 import { clearLayer } from './domain/bin/clearLayer';
 
 type V2HandlerFn = (command: {
@@ -44,6 +46,8 @@ export const v2HandlerOverrides: Record<string, V2HandlerFn> = {
   [duplicateBin.type]: wrapV2Handler(duplicateBin) as V2HandlerFn,
   [moveBinToStaging.type]: wrapV2Handler(moveBinToStaging) as V2HandlerFn,
   [moveBinFromStaging.type]: wrapV2Handler(moveBinFromStaging) as V2HandlerFn,
+  [fillLayer.type]: wrapV2Handler(fillLayer) as V2HandlerFn,
+  [fillGaps.type]: wrapV2Handler(fillGaps) as V2HandlerFn,
   [clearLayer.type]: wrapV2Handler(clearLayer) as V2HandlerFn,
 };
 
@@ -56,5 +60,7 @@ export const v2Commands = [
   duplicateBin,
   moveBinToStaging,
   moveBinFromStaging,
+  fillLayer,
+  fillGaps,
   clearLayer,
 ] as const;

--- a/src/core/store/layout/bulkActions.test.ts
+++ b/src/core/store/layout/bulkActions.test.ts
@@ -97,18 +97,6 @@ describe('bulkActions', () => {
       expect(useLayoutStore.getState().layout.bins).toHaveLength(count);
     });
 
-    it('sets _fillMeta when bins are added', () => {
-      const { fillLayer, layout } = useLayoutStore.getState();
-      const lid = layout.layers[0].id;
-      const cid = layout.categories[0].id;
-
-      fillLayer(lid, 1, 1, cid);
-      const meta = useLayoutStore.getState()._fillMeta;
-      expect(meta).not.toBeNull();
-      expect(meta?.type).toBe('uniform');
-      expect(meta?.layerId).toBe(lid);
-    });
-
     it('returns 0 when layer is already full', () => {
       const { fillLayer, layout } = useLayoutStore.getState();
       const lid = layout.layers[0].id;

--- a/src/core/store/layout/bulkActions.ts
+++ b/src/core/store/layout/bulkActions.ts
@@ -16,17 +16,8 @@ export function createBulkActions(setLocal: SetLocal, get: GetState) {
       const result = fillAllWithSize(layout, layerId, width, depth, categoryId, halfBinMode);
 
       if (result.bins.length > 0) {
-        const layer = layout.layers.find((l) => l.id === layerId);
         setLocal((state) => {
           state.layout.bins.push(...result.bins);
-          state._fillMeta = {
-            type: 'uniform',
-            count: result.bins.length,
-            layerId,
-            width,
-            depth,
-            layerHeight: layer?.height ?? 1,
-          };
         });
       }
 
@@ -51,11 +42,6 @@ export function createBulkActions(setLocal: SetLocal, get: GetState) {
       if (result.bins.length > 0) {
         setLocal((state) => {
           state.layout.bins.push(...result.bins);
-          state._fillMeta = {
-            type: 'gaps',
-            count: result.bins.length,
-            layerId,
-          };
         });
       }
 

--- a/src/core/store/layout/index.ts
+++ b/src/core/store/layout/index.ts
@@ -9,7 +9,7 @@ import { createBulkActions } from './bulkActions';
 import { createCoreActions } from './coreActions';
 import type { LayoutState } from './types';
 
-export type { FillMeta, EditSource } from './types';
+export type { EditSource } from './types';
 
 /**
  * Empty placeholder layout used as the initial state.
@@ -54,7 +54,6 @@ export const useLayoutStore = create<LayoutState>()(
       layout: PLACEHOLDER_LAYOUT,
       activeLayoutId: null,
       lastEditSource: null,
-      _fillMeta: null,
 
       ...createBinActions(setLocal, get),
       ...createLayerActions(setLocal, get),

--- a/src/core/store/layout/types.ts
+++ b/src/core/store/layout/types.ts
@@ -12,16 +12,6 @@ import type {
 } from '@/core/types';
 import type { Result, LayoutError, ValidationError } from '@/core/result';
 
-/** Metadata about a fill operation, set by the store and consumed by the analytics subscriber. */
-export interface FillMeta {
-  type: 'uniform' | 'gaps';
-  count: number;
-  layerId: LayerId;
-  width?: number;
-  depth?: number;
-  layerHeight?: number;
-}
-
 /** Source of the last edit to the layout - used to distinguish local edits from remote imports */
 export type EditSource = 'local' | 'remote' | 'init' | null;
 
@@ -29,7 +19,6 @@ export interface LayoutState {
   layout: Layout;
   activeLayoutId: LayoutId | null; // ID of the layout in the library (null for unsaved)
   lastEditSource: EditSource; // Tracks whether last change was local, remote, or initial load
-  _fillMeta: FillMeta | null; // Transient metadata for analytics subscriber (cleared after read)
 
   // Bin operations - all return Result for consistent error handling
   addBin: (bin: Omit<Bin, 'id'>) => Result<BinId, ValidationError>;

--- a/src/core/store/layoutAnalytics.test.ts
+++ b/src/core/store/layoutAnalytics.test.ts
@@ -51,31 +51,9 @@ describe('layoutAnalytics', () => {
     expect(markFeatureUsed).toHaveBeenCalledWith('custom_categories');
   });
 
-  it('tracks fill operations when _fillMeta is set', async () => {
-    const { trackFillOperation, trackBinCreated, markFeatureUsed } =
-      await import('@/shared/analytics/posthog');
-    const { mlTracking } = await import('@/shared/analytics/useMLTracking');
-
-    const lid = useLayoutStore.getState().layout.layers[0].id;
-    useLayoutStore.setState({
-      _fillMeta: {
-        type: 'uniform',
-        count: 10,
-        layerId: lid,
-        width: 2,
-        depth: 3,
-        layerHeight: 4,
-      },
-    });
-
-    expect(mlTracking.trackFill).toHaveBeenCalled();
-    expect(markFeatureUsed).toHaveBeenCalledWith('fill');
-    expect(trackFillOperation).toHaveBeenCalledWith('fill_layer', 10);
-    expect(trackBinCreated).toHaveBeenCalled();
-
-    // _fillMeta should be cleared after consuming
-    expect(useLayoutStore.getState()._fillMeta).toBeNull();
-  });
+  // Fill-operation analytics moved to cqrs/subscribers/fillAnalytics.ts as
+  // part of the v2 defineCommand migration; covered by that subscriber's
+  // own tests against the bin.layerFilled event.
 
   it('tracks paint mode entry and exit', async () => {
     const { trackPaintMode } = await import('@/shared/analytics/posthog');

--- a/src/core/store/layoutAnalytics.ts
+++ b/src/core/store/layoutAnalytics.ts
@@ -4,19 +4,17 @@
  * Reacts to store state changes and fires analytics events.
  * This keeps analytics concerns out of the store actions themselves,
  * making them pure state mutations that are easier to test.
+ *
+ * Note: fill-operation analytics (uniform/gaps fills) used to live here
+ * via the `_fillMeta` side-channel set by bulkActions. As of the v2
+ * defineCommand migration that path is gone — fill events now flow via
+ * `cqrs/subscribers/fillAnalytics.ts` which subscribes to the
+ * `bin.layerFilled` domain event directly.
  */
 
-import { mlTracking } from '@/shared/analytics/useMLTracking';
-import {
-  markFeatureUsed,
-  trackFillOperation,
-  trackBinCreated,
-  trackPaintMode,
-} from '@/shared/analytics/posthog';
-import { useLayoutStore, type FillMeta } from './layout';
+import { markFeatureUsed, trackPaintMode } from '@/shared/analytics/posthog';
+import { useLayoutStore } from './layout';
 import { useInteractionStore, type PaintSize } from './interaction';
-
-export type { FillMeta };
 
 /**
  * Initialize store analytics subscribers.
@@ -39,31 +37,6 @@ export function initLayoutAnalytics(): () => void {
     // Track custom category usage when a category is added
     if (curr.categories.length > prevCategoryCount) {
       markFeatureUsed('custom_categories');
-    }
-
-    // Track fill operations via _fillMeta
-    const meta = state._fillMeta;
-    if (meta) {
-      const w = meta.width ?? 1;
-      const d = meta.depth ?? 1;
-      mlTracking.trackFill(
-        meta.type,
-        meta.count,
-        meta.layerId,
-        meta.type === 'uniform' ? { width: w, depth: d } : undefined
-      );
-      markFeatureUsed('fill');
-      trackFillOperation(meta.type === 'uniform' ? 'fill_layer' : 'fill_gaps', meta.count);
-      trackBinCreated({
-        method: meta.type === 'uniform' ? 'fill_layer' : 'fill_gaps',
-        count: meta.count,
-        ...(meta.type === 'uniform' ? { width: w, depth: d, height: meta.layerHeight ?? 1 } : {}),
-      });
-
-      // Clear fill meta after consuming.
-      // This setState triggers the subscriber again, but the if(meta) guard
-      // above prevents any repeated work on the second invocation.
-      useLayoutStore.setState({ _fillMeta: null });
     }
 
     prevLayerCount = curr.layers.length;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,6 +17,7 @@ import type { Locale } from '@/i18n/types.ts';
 import { recoverFromBadWwwMigration } from '@/core/storage/wwwMigrationRecovery';
 import {
   connectEventStoreToBus,
+  connectFillAnalytics,
   connectLibraryPersistence,
   connectSelectionPruning,
   eventBus,
@@ -121,6 +122,10 @@ if (isSmokeMode()) {
       // Persist library to IndexedDB immediately when cloudShare metadata changes
       // (other library fields are persisted via useAutoSave's debounced flow)
       connectLibraryPersistence(eventBus);
+
+      // Forward bin.layerFilled events to PostHog/mlTracking — replaces the
+      // v1 _fillMeta side-channel that the layout store used to set on fills
+      connectFillAnalytics(eventBus);
 
       // Connect design-linking — bridges CQRS events to syncEventBus for
       // design dimension cascade between linked bins and designs

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -31,7 +31,6 @@ export function resetLayoutStore(): void {
     layout: createDefaultLayout(),
     activeLayoutId: null,
     lastEditSource: null,
-    _fillMeta: null,
   });
 }
 
@@ -73,7 +72,6 @@ export function resetAllStores(): void {
     layout: createDefaultLayout(),
     activeLayoutId: null,
     lastEditSource: null,
-    _fillMeta: null,
   });
 
   useSelectionStore.setState(INITIAL_SELECTION_STATE);


### PR DESCRIPTION
## Summary

Final two bin commands migrated to `defineCommand`. **All 10 bin commands now route through the v2 wrapper.**

## What changed

### `bin.fillLayer` / `bin.fillGaps`

- Planning helpers (`fillAllWithSize`, `fillGaps` utility) called inside `handle()` against the frozen layout snapshot. The resulting bins are encoded in the event payload — `apply()` is a deterministic push.
- `LayerFilledEvent` payload widened with optional `fillType`, `width`, `depth` so the analytics subscriber can derive what `_fillMeta` used to carry. v1-era persisted events without `fillType` are silently ignored by the new subscriber (no metric distortion from re-emitting old events).

### `_fillMeta` deletion (6-file delta)

- `src/core/store/layout/types.ts` — drop `FillMeta` interface + `_fillMeta` field
- `src/core/store/layout/index.ts` — drop `_fillMeta` initializer + barrel re-export
- `src/core/store/layout/bulkActions.ts` — drop `_fillMeta` side-effect writes
- `src/core/store/layout/bulkActions.test.ts` — drop the `_fillMeta` assertion
- `src/core/store/layoutAnalytics.ts` — drop the meta-consumer block + import
- `src/core/store/layoutAnalytics.test.ts` — drop the `_fillMeta`-driven test
- `src/test/testUtils.ts` — drop `_fillMeta` from store reset helpers

### Replacement: `cqrs/subscribers/fillAnalytics.ts`

Subscribes to the `bin.layerFilled` event and forwards to the same `mlTracking` + `trackFillOperation` + `trackBinCreated` helpers the v1 subscriber called. Wired in `main.tsx` alongside `connectSelectionPruning` and `connectLibraryPersistence`. Has its own dedicated test file covering: uniform fills, gap fills, pre-v2 events without `fillType` (ignored), empty-bin events (ignored).

## Where this fits

- #1538 (PR 1) — library cloudShare persistence subscriber
- #1539 (PR 2) — defineCommand foundations
- #1541 (PR 3) — history.ts rename
- #1542 (PR 4) — undo via command bus
- #1543 (PR 5) — bin.add v2 (proof of concept)
- #1544 (PR 6) — 5 simpler bin commands
- #1546 (PR 7) — duplicate + moveFromStaging
- **#TBD (PR 8)** — fillLayer + fillGaps + `_fillMeta` deletion ← this PR

**Bin domain complete.** Subsequent PRs migrate other aggregates (layer, category, drawer, library, designer) following the same pattern.

## Test plan

- [x] `pnpm typecheck` — clean (no regression)
- [x] `pnpm test:run` — full suite, **10347 tests pass** (was 10339; +8 net after deleting the obsolete `_fillMeta` tests and adding 11 new property + subscriber tests)
- [x] `pnpm lint` — clean
- [x] `pnpm knip` — clean
- [x] `pnpm check:boundaries` — clean