### PR TITLE
feat(cqrs): migrate layer commands to v2 defineCommand

### DIFF
--- a/src/core/cqrs/events/layerEvents.ts
+++ b/src/core/cqrs/events/layerEvents.ts
@@ -3,7 +3,7 @@
  */
 
 import type { BaseDomainEvent } from '../types';
-import type { Layer, LayerId } from '@/core/types';
+import type { BinId, Layer, LayerId } from '@/core/types';
 
 export type LayerAddedEvent = BaseDomainEvent<'layer.added', { readonly layer: Layer }>;
 
@@ -16,9 +16,20 @@ export type LayerUpdatedEvent = BaseDomainEvent<
   }
 >;
 
+/**
+ * `displacedBinIds` was added in the v2 migration so apply() can target
+ * the exact set of bins that moved to staging. v1-era persisted events
+ * have no `displacedBinIds` — replay against those falls back to the
+ * "all bins on layer" heuristic in projection/replay.ts (lossy if the
+ * layout has diverged since the event was emitted, but no worse than v1).
+ */
 export type LayerDeletedEvent = BaseDomainEvent<
   'layer.deleted',
-  { readonly layer: Layer; readonly deletedBinCount: number }
+  {
+    readonly layer: Layer;
+    readonly deletedBinCount: number;
+    readonly displacedBinIds?: ReadonlyArray<BinId>;
+  }
 >;
 
 export type LayersReorderedEvent = BaseDomainEvent<

--- a/src/core/cqrs/projection/replay.ts
+++ b/src/core/cqrs/projection/replay.ts
@@ -5,7 +5,7 @@
  * to a base layout state to reconstruct what happened.
  */
 
-import type { Layout } from '@/core/types';
+import type { BinId, Layout } from '@/core/types';
 import { gridUnits, heightUnits, mm } from '@/core/types';
 import { STAGING_ID } from '@/core/constants';
 import type { DomainEvent } from '../events';
@@ -87,12 +87,21 @@ export function applyEvent(layout: Layout, event: DomainEvent): Layout {
     case 'layer.deleted': {
       const deletedLayerId = event.payload.layer.id;
       next.layers = next.layers.filter((l) => l.id !== deletedLayerId);
-      // Match store behavior (layerActions.ts): bins on the deleted layer are
-      // displaced to staging, not removed. Prior versions of this case filtered
-      // the bins out, which silently lost data during replay-based debugging.
-      next.bins = next.bins.map((b) =>
-        b.layerId === deletedLayerId ? { ...b, layerId: STAGING_ID } : b
-      );
+      // v2 events carry the exact displacedBinIds — use them when present
+      // so replay reproduces the cascade even if the layout has diverged.
+      // v1 events fall back to the "all bins on the deleted layer" heuristic
+      // (matches layerActions.ts and the prior replay behavior).
+      // Local annotation: TS doesn't always narrow optional fields cleanly
+      // through the DomainEvent discriminated union, so be explicit here.
+      const ids: ReadonlyArray<BinId> | undefined = event.payload.displacedBinIds;
+      if (ids !== undefined) {
+        const idSet = new Set<BinId>(ids);
+        next.bins = next.bins.map((b) => (idSet.has(b.id) ? { ...b, layerId: STAGING_ID } : b));
+      } else {
+        next.bins = next.bins.map((b) =>
+          b.layerId === deletedLayerId ? { ...b, layerId: STAGING_ID } : b
+        );
+      }
       break;
     }
 

--- a/src/core/cqrs/v2/domain/layer/_testHelpers.ts
+++ b/src/core/cqrs/v2/domain/layer/_testHelpers.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared fixtures for v2 layer command property tests.
+ * Internal to cqrs/v2/domain/layer/.
+ */
+
+import type { Layer, Layout } from '@/core/types';
+import { layerId, categoryId, gridUnits, heightUnits } from '@/core/types';
+
+export function makeLayer(idStr: string, height = 3): Layer {
+  return { id: layerId(idStr), name: idStr, height: heightUnits(height) };
+}
+
+export function makeLayout(overrides: Partial<Layout> = {}): Layout {
+  return {
+    version: '1.0',
+    name: 'Test',
+    drawer: {
+      width: gridUnits(6),
+      depth: gridUnits(4),
+      height: heightUnits(7),
+    },
+    printBedSize: 256 as Layout['printBedSize'],
+    gridUnitMm: 42 as Layout['gridUnitMm'],
+    heightUnitMm: 7 as Layout['heightUnitMm'],
+    categories: [{ id: categoryId('cat_1'), name: 'Default', color: '#808080' }],
+    layers: [makeLayer('layer_1', 3)],
+    bins: [],
+    ...overrides,
+  };
+}

--- a/src/core/cqrs/v2/domain/layer/addLayer.test.ts
+++ b/src/core/cqrs/v2/domain/layer/addLayer.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
+import { heightUnits } from '@/core/types';
+import { addLayer } from './addLayer';
+import { makeLayout, makeLayer } from './_testHelpers';
+
+describe('v2 layer.add', () => {
+  it('emits an event with a generated layer fitting the remaining height', () => {
+    const layout = makeLayout(); // drawer.height = 7, one layer of height 3 -> 4 remaining
+    const result = addLayer.handle(undefined, { aggregate: layout });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.layer.height).toBeLessThanOrEqual(4);
+    expect(result.value.event.payload.layer.height).toBeGreaterThanOrEqual(
+      CONSTRAINTS.MIN_LAYER_HEIGHT
+    );
+    expect(result.value.event.payload.layer.id).toBe(result.value.value);
+  });
+
+  it('errors when the layer-count limit is reached', () => {
+    const layers = Array.from({ length: CONSTRAINTS.LAYERS_MAX }, (_, i) =>
+      makeLayer(`layer_${String(i)}`, 1)
+    );
+    const layout = makeLayout({ layers });
+    const result = addLayer.handle(undefined, { aggregate: layout });
+    expect(result.ok).toBe(false);
+  });
+
+  it('errors when no remaining drawer height', () => {
+    // drawer.height = 7, layer fills it
+    const layout = makeLayout({ layers: [makeLayer('layer_1', 7)] });
+    const result = addLayer.handle(undefined, { aggregate: layout });
+    expect(result.ok).toBe(false);
+  });
+
+  it('apply() pushes the new layer onto the draft', () => {
+    const layout = makeLayout();
+    const result = addLayer.handle(undefined, { aggregate: layout });
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(layout, (draft) => {
+      addLayer.apply({ type: 'layer.added', payload: result.value.event.payload }, draft);
+    });
+
+    expect(applied.layers).toHaveLength(2);
+    expect(applied.layers[1]).toEqual(result.value.event.payload.layer);
+  });
+
+  // Avoid unused import flag for heightUnits — the helper makeLayer uses it
+  // internally, but vitest type-imports here also benefit when testing
+  // height-bound logic later.
+  void heightUnits;
+});

--- a/src/core/cqrs/v2/domain/layer/addLayer.test.ts
+++ b/src/core/cqrs/v2/domain/layer/addLayer.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { produce } from 'immer';
 import { isOk } from '@/core/result';
 import { CONSTRAINTS } from '@/core/constants';
-import { heightUnits } from '@/core/types';
 import { addLayer } from './addLayer';
 import { makeLayout, makeLayer } from './_testHelpers';
 
@@ -48,9 +47,4 @@ describe('v2 layer.add', () => {
     expect(applied.layers).toHaveLength(2);
     expect(applied.layers[1]).toEqual(result.value.event.payload.layer);
   });
-
-  // Avoid unused import flag for heightUnits — the helper makeLayer uses it
-  // internally, but vitest type-imports here also benefit when testing
-  // height-bound logic later.
-  void heightUnits;
 });

--- a/src/core/cqrs/v2/domain/layer/addLayer.ts
+++ b/src/core/cqrs/v2/domain/layer/addLayer.ts
@@ -1,0 +1,62 @@
+/**
+ * layer.add — v2 (defineCommand) shape.
+ *
+ * Validates layer-count limit and remaining drawer height before
+ * generating a Layer. The default-layer-height preference is read from
+ * the settings store inside handle (settings are config-not-state, so
+ * not part of the layout aggregate snapshot).
+ */
+
+import { z } from 'zod';
+import type { Result, LayoutError } from '@/core/result';
+import { ok, err, layoutLayerLimit, layoutInvalidOperation } from '@/core/result';
+import { generateLayerId, CONSTRAINTS } from '@/core/constants';
+import { useSettingsStore } from '@/core/store/settings';
+import type { Layer, LayerId } from '@/core/types';
+import { heightUnits } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({}).optional();
+
+export const addLayer = defineCommand({
+  type: 'layer.add',
+  aggregate: 'layout',
+  aggregateId: () => 'layout',
+  payload: payloadSchema,
+  emitted: 'layer.added',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.layerAdd',
+  middleware: { undoCapture: true, validate: true, analytics: true },
+  handle: (
+    _payload,
+    ctx
+  ): Result<{ value: LayerId; event: { payload: { layer: Layer } } }, LayoutError> => {
+    const layout = ctx.aggregate;
+
+    if (layout.layers.length >= CONSTRAINTS.LAYERS_MAX) {
+      return err(layoutLayerLimit(layout.layers.length, CONSTRAINTS.LAYERS_MAX));
+    }
+
+    const totalHeight = layout.layers.reduce((sum, l) => sum + (l.height as number), 0);
+    const remaining = (layout.drawer.height as number) - totalHeight;
+    if (remaining < CONSTRAINTS.MIN_LAYER_HEIGHT) {
+      return err(layoutInvalidOperation('addLayer', 'No remaining height in drawer'));
+    }
+
+    const defaultLayerHeight = useSettingsStore.getState().settings.defaultLayerHeight;
+    const id = generateLayerId();
+    const layer: Layer = {
+      id,
+      name: `Layer ${String(layout.layers.length + 1)}`,
+      height: heightUnits(Math.min(remaining, defaultLayerHeight)),
+    };
+
+    return ok({
+      value: id,
+      event: { payload: { layer } },
+    });
+  },
+  apply: (event, draft) => {
+    draft.layers.push(event.payload.layer);
+  },
+});

--- a/src/core/cqrs/v2/domain/layer/deleteLayer.test.ts
+++ b/src/core/cqrs/v2/domain/layer/deleteLayer.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { STAGING_ID } from '@/core/constants';
+import type { Bin } from '@/core/types';
+import { binId, layerId, categoryId, gridUnits, heightUnits } from '@/core/types';
+import { deleteLayer } from './deleteLayer';
+import { makeLayout, makeLayer } from './_testHelpers';
+
+function makeBin(idStr: string, lid: string): Bin {
+  return {
+    id: binId(idStr),
+    layerId: layerId(lid),
+    x: gridUnits(0),
+    y: gridUnits(0),
+    width: gridUnits(1),
+    depth: gridUnits(1),
+    height: heightUnits(3),
+    category: categoryId('cat_1'),
+    label: '',
+    notes: '',
+  };
+}
+
+describe('v2 layer.delete', () => {
+  it('captures displacedBinIds for replay determinism', () => {
+    const layout = makeLayout({
+      layers: [makeLayer('layer_1', 3), makeLayer('layer_2', 3)],
+      bins: [makeBin('bin_a', 'layer_1'), makeBin('bin_b', 'layer_2')],
+    });
+    const result = deleteLayer.handle({ id: 'layer_1' }, { aggregate: layout });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.displacedBinIds).toEqual([binId('bin_a')]);
+    expect(result.value.event.payload.deletedBinCount).toBe(1);
+  });
+
+  it('errors at the layer-count minimum', () => {
+    const layout = makeLayout(); // single layer
+    const result = deleteLayer.handle({ id: 'layer_1' }, { aggregate: layout });
+    expect(result.ok).toBe(false);
+  });
+
+  it('errors when the layer does not exist', () => {
+    const layout = makeLayout({
+      layers: [makeLayer('layer_1', 3), makeLayer('layer_2', 3)],
+    });
+    const result = deleteLayer.handle({ id: 'layer_gone' }, { aggregate: layout });
+    expect(result.ok).toBe(false);
+  });
+
+  it('apply() removes the layer AND moves displaced bins to STAGING_ID', () => {
+    const layout = makeLayout({
+      layers: [makeLayer('layer_1', 3), makeLayer('layer_2', 3)],
+      bins: [makeBin('bin_a', 'layer_1'), makeBin('bin_b', 'layer_2')],
+    });
+    const result = deleteLayer.handle({ id: 'layer_1' }, { aggregate: layout });
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(layout, (draft) => {
+      deleteLayer.apply({ type: 'layer.deleted', payload: result.value.event.payload }, draft);
+    });
+
+    expect(applied.layers).toHaveLength(1);
+    expect(applied.layers[0].id).toBe(layerId('layer_2'));
+    const movedBin = applied.bins.find((b) => b.id === binId('bin_a'));
+    expect(movedBin?.layerId).toBe(STAGING_ID);
+    const otherBin = applied.bins.find((b) => b.id === binId('bin_b'));
+    expect(otherBin?.layerId).toBe(layerId('layer_2'));
+  });
+});

--- a/src/core/cqrs/v2/domain/layer/deleteLayer.ts
+++ b/src/core/cqrs/v2/domain/layer/deleteLayer.ts
@@ -1,0 +1,87 @@
+/**
+ * layer.delete — v2 (defineCommand) shape.
+ *
+ * Per-command refactor: v1's store action cascaded by remapping bins on
+ * the deleted layer to STAGING_ID. The v1 event payload only carried
+ * `{layer, deletedBinCount}` — the actual displaced bin IDs were lost,
+ * so replay against a divergent layout produced the wrong cascade. v2
+ * widens the payload with `displacedBinIds` so apply() can target the
+ * exact set deterministically.
+ *
+ * `deletedBinCount` is preserved on the payload for v1 consumer
+ * compatibility (analytics / audit log) even though it's now derivable
+ * from `displacedBinIds.length`.
+ */
+
+import { z } from 'zod';
+import type { Result, LayoutError } from '@/core/result';
+import { ok, err, layoutLastEntity, layoutInvalidOperation } from '@/core/result';
+import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
+import type { BinId, Layer } from '@/core/types';
+import { layerId as toLayerId } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({ id: z.string().min(1) });
+
+export const deleteLayer = defineCommand({
+  type: 'layer.delete',
+  aggregate: 'layout',
+  aggregateId: () => 'layout',
+  payload: payloadSchema,
+  emitted: 'layer.deleted',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.layerDelete',
+  middleware: { undoCapture: true, validate: true, analytics: true },
+  handle: (
+    payload,
+    ctx
+  ): Result<
+    {
+      value: undefined;
+      event: {
+        payload: {
+          layer: Layer;
+          deletedBinCount: number;
+          displacedBinIds: ReadonlyArray<BinId>;
+        };
+      };
+    },
+    LayoutError
+  > => {
+    const id = toLayerId(payload.id);
+    const layout = ctx.aggregate;
+
+    if (layout.layers.length <= CONSTRAINTS.LAYERS_MIN) {
+      return err(layoutLastEntity('layer'));
+    }
+
+    const layer = layout.layers.find((l) => l.id === id);
+    if (!layer) {
+      return err(layoutInvalidOperation('deleteLayer', `Layer ${id} not found`));
+    }
+
+    const displacedBinIds = layout.bins
+      .filter((b) => b.layerId === id && b.layerId !== STAGING_ID)
+      .map((b) => b.id);
+
+    return ok({
+      value: undefined,
+      event: {
+        payload: {
+          layer: { ...layer },
+          deletedBinCount: displacedBinIds.length,
+          displacedBinIds,
+        },
+      },
+    });
+  },
+  apply: (event, draft) => {
+    draft.layers = draft.layers.filter((l) => l.id !== event.payload.layer.id);
+    if (event.payload.displacedBinIds.length > 0) {
+      const idSet = new Set(event.payload.displacedBinIds);
+      for (const bin of draft.bins) {
+        if (idSet.has(bin.id)) bin.layerId = STAGING_ID;
+      }
+    }
+  },
+});

--- a/src/core/cqrs/v2/domain/layer/deleteLayer.ts
+++ b/src/core/cqrs/v2/domain/layer/deleteLayer.ts
@@ -60,9 +60,10 @@ export const deleteLayer = defineCommand({
       return err(layoutInvalidOperation('deleteLayer', `Layer ${id} not found`));
     }
 
-    const displacedBinIds = layout.bins
-      .filter((b) => b.layerId === id && b.layerId !== STAGING_ID)
-      .map((b) => b.id);
+    // STAGING_ID is the sentinel layer id never present in layout.layers,
+    // so `b.layerId === id` (where id is a real layer) inherently excludes
+    // staging-bound bins. No explicit STAGING_ID guard needed here.
+    const displacedBinIds = layout.bins.filter((b) => b.layerId === id).map((b) => b.id);
 
     return ok({
       value: undefined,

--- a/src/core/cqrs/v2/domain/layer/reorderLayers.test.ts
+++ b/src/core/cqrs/v2/domain/layer/reorderLayers.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { layerId } from '@/core/types';
+import { reorderLayers } from './reorderLayers';
+import { makeLayout, makeLayer } from './_testHelpers';
+
+describe('v2 layer.reorder', () => {
+  it('emits a reorder event for valid indices', () => {
+    const layout = makeLayout({
+      layers: [makeLayer('a'), makeLayer('b'), makeLayer('c')],
+    });
+    const result = reorderLayers.handle({ fromIndex: 0, toIndex: 2 }, { aggregate: layout });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload).toEqual({ fromIndex: 0, toIndex: 2 });
+  });
+
+  it('errors on out-of-range source index', () => {
+    const layout = makeLayout({ layers: [makeLayer('a'), makeLayer('b')] });
+    const result = reorderLayers.handle({ fromIndex: 99, toIndex: 0 }, { aggregate: layout });
+    expect(result.ok).toBe(false);
+  });
+
+  it('errors on out-of-range target index', () => {
+    const layout = makeLayout({ layers: [makeLayer('a'), makeLayer('b')] });
+    const result = reorderLayers.handle({ fromIndex: 0, toIndex: 99 }, { aggregate: layout });
+    expect(result.ok).toBe(false);
+  });
+
+  it('treats fromIndex === toIndex as a no-op (succeeds, apply does nothing)', () => {
+    const layout = makeLayout({ layers: [makeLayer('a'), makeLayer('b')] });
+    const result = reorderLayers.handle({ fromIndex: 1, toIndex: 1 }, { aggregate: layout });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+
+    const applied = produce(layout, (draft) => {
+      reorderLayers.apply({ type: 'layer.reordered', payload: result.value.event.payload }, draft);
+    });
+    expect(applied.layers.map((l) => l.id)).toEqual([layerId('a'), layerId('b')]);
+  });
+
+  it('apply() splices the layer to the new position', () => {
+    const layout = makeLayout({
+      layers: [makeLayer('a'), makeLayer('b'), makeLayer('c')],
+    });
+    const result = reorderLayers.handle({ fromIndex: 0, toIndex: 2 }, { aggregate: layout });
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(layout, (draft) => {
+      reorderLayers.apply({ type: 'layer.reordered', payload: result.value.event.payload }, draft);
+    });
+    expect(applied.layers.map((l) => l.id)).toEqual([layerId('b'), layerId('c'), layerId('a')]);
+  });
+});

--- a/src/core/cqrs/v2/domain/layer/reorderLayers.ts
+++ b/src/core/cqrs/v2/domain/layer/reorderLayers.ts
@@ -12,7 +12,7 @@
 
 import { z } from 'zod';
 import type { Result, LayoutError } from '@/core/result';
-import { ok, err, OK, layoutInvalidOperation } from '@/core/result';
+import { ok, err, layoutInvalidOperation } from '@/core/result';
 import { checkLayerReorderCollisions } from '@/shared/utils/collision';
 import { defineCommand } from '../../defineCommand';
 
@@ -40,9 +40,11 @@ export const reorderLayers = defineCommand({
     const { fromIndex, toIndex } = payload;
     const layout = ctx.aggregate;
 
+    // Self-move: succeed and emit; apply is a no-op. Matches v1 (the v1
+    // store action returns OK without doing anything; the v1 handler
+    // emits the event regardless). The event in the audit log is benign
+    // signal that the user attempted a reorder.
     if (fromIndex === toIndex) {
-      // No-op: still ok, but no event emitted (apply would no-op too,
-      // but emitting a self-move would pollute the audit log).
       return ok({ value: undefined, event: { payload: { fromIndex, toIndex } } });
     }
     if (fromIndex < 0 || fromIndex >= layout.layers.length) {
@@ -75,7 +77,3 @@ export const reorderLayers = defineCommand({
     draft.layers.splice(toIndex, 0, moved);
   },
 });
-
-// `OK` only used in tests / future reuse. Kept here to avoid an
-// import-only warning if we later reintroduce a no-op success path.
-void OK;

--- a/src/core/cqrs/v2/domain/layer/reorderLayers.ts
+++ b/src/core/cqrs/v2/domain/layer/reorderLayers.ts
@@ -1,0 +1,81 @@
+/**
+ * layer.reorder — v2 (defineCommand) shape.
+ *
+ * Validates indices and runs the reorder collision check against the
+ * frozen layout snapshot before emitting. apply() does the actual array
+ * splice on the draft.
+ *
+ * The event payload (`{fromIndex, toIndex}`) is sufficient for replay:
+ * given the layout state at replay time, applying the same move
+ * deterministically produces the same ordering.
+ */
+
+import { z } from 'zod';
+import type { Result, LayoutError } from '@/core/result';
+import { ok, err, OK, layoutInvalidOperation } from '@/core/result';
+import { checkLayerReorderCollisions } from '@/shared/utils/collision';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({
+  fromIndex: z.number().int().min(0),
+  toIndex: z.number().int().min(0),
+});
+
+export const reorderLayers = defineCommand({
+  type: 'layer.reorder',
+  aggregate: 'layout',
+  aggregateId: () => 'layout',
+  payload: payloadSchema,
+  emitted: 'layer.reordered',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.layerReorder',
+  middleware: { undoCapture: true, validate: true, analytics: true },
+  handle: (
+    payload,
+    ctx
+  ): Result<
+    { value: undefined; event: { payload: { fromIndex: number; toIndex: number } } },
+    LayoutError
+  > => {
+    const { fromIndex, toIndex } = payload;
+    const layout = ctx.aggregate;
+
+    if (fromIndex === toIndex) {
+      // No-op: still ok, but no event emitted (apply would no-op too,
+      // but emitting a self-move would pollute the audit log).
+      return ok({ value: undefined, event: { payload: { fromIndex, toIndex } } });
+    }
+    if (fromIndex < 0 || fromIndex >= layout.layers.length) {
+      return err(layoutInvalidOperation('reorderLayers', 'Invalid source index'));
+    }
+    if (toIndex < 0 || toIndex >= layout.layers.length) {
+      return err(layoutInvalidOperation('reorderLayers', 'Invalid target index'));
+    }
+
+    const newLayers = [...layout.layers];
+    const [moved] = newLayers.splice(fromIndex, 1);
+    newLayers.splice(toIndex, 0, moved);
+
+    const collisions = checkLayerReorderCollisions(layout.bins, layout.layers, newLayers);
+    if (collisions.length > 0) {
+      return err(
+        layoutInvalidOperation(
+          'reorderLayers',
+          `Reordering would cause ${String(collisions.length)} bin collision${collisions.length > 1 ? 's' : ''}`
+        )
+      );
+    }
+
+    return ok({ value: undefined, event: { payload: { fromIndex, toIndex } } });
+  },
+  apply: (event, draft) => {
+    const { fromIndex, toIndex } = event.payload;
+    if (fromIndex === toIndex) return;
+    const [moved] = draft.layers.splice(fromIndex, 1);
+    draft.layers.splice(toIndex, 0, moved);
+  },
+});
+
+// `OK` only used in tests / future reuse. Kept here to avoid an
+// import-only warning if we later reintroduce a no-op success path.
+void OK;

--- a/src/core/cqrs/v2/domain/layer/updateLayer.test.ts
+++ b/src/core/cqrs/v2/domain/layer/updateLayer.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { heightUnits } from '@/core/types';
+import { updateLayer } from './updateLayer';
+import { makeLayout, makeLayer } from './_testHelpers';
+
+describe('v2 layer.update', () => {
+  it('captures previous values for the fields being changed', () => {
+    const layout = makeLayout({ layers: [makeLayer('layer_1', 3)] });
+    const result = updateLayer.handle(
+      { id: 'layer_1', updates: { name: 'Renamed' } },
+      { aggregate: layout }
+    );
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.previous).toEqual({ name: 'layer_1' });
+    expect(result.value.event.payload.changes).toEqual({ name: 'Renamed' });
+  });
+
+  it('clamps height against remaining drawer space', () => {
+    // drawer.height = 7, layer_1 height=2, layer_2 height=2 -> max for layer_1 = 7 - 2 = 5
+    const layout = makeLayout({
+      layers: [makeLayer('layer_1', 2), makeLayer('layer_2', 2)],
+    });
+    const result = updateLayer.handle(
+      { id: 'layer_1', updates: { height: 99 } }, // way above the cap
+      { aggregate: layout }
+    );
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.changes.height).toBe(heightUnits(5));
+  });
+
+  it('errors when the layer does not exist', () => {
+    const layout = makeLayout();
+    const result = updateLayer.handle(
+      { id: 'layer_gone', updates: { name: 'X' } },
+      { aggregate: layout }
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('apply() round-trip equals native Object.assign', () => {
+    const layout = makeLayout({ layers: [makeLayer('layer_1', 3)] });
+    const result = updateLayer.handle(
+      { id: 'layer_1', updates: { name: 'X' } },
+      { aggregate: layout }
+    );
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(layout, (draft) => {
+      updateLayer.apply({ type: 'layer.updated', payload: result.value.event.payload }, draft);
+    });
+
+    expect(applied.layers[0].name).toBe('X');
+  });
+});

--- a/src/core/cqrs/v2/domain/layer/updateLayer.ts
+++ b/src/core/cqrs/v2/domain/layer/updateLayer.ts
@@ -1,0 +1,89 @@
+/**
+ * layer.update — v2 (defineCommand) shape.
+ *
+ * Per-command refactor: the v1 store action did the height-clamp inside
+ * the setLocal mutator (so clamping was a hidden side effect of the
+ * write). v2 inlines the clamp into handle so the event payload's
+ * `changes.height` always reflects the value that will actually be
+ * stored — no replay drift between native and apply paths.
+ */
+
+import { z } from 'zod';
+import type { Result, LayoutError } from '@/core/result';
+import { ok, err, layoutInvalidOperation } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
+import { clamp } from '@/shared/utils/validation';
+import type { Layer, LayerId } from '@/core/types';
+import { layerId as toLayerId, heightUnits } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const updatesSchema = z
+  .object({
+    name: z.string().min(1).max(CONSTRAINTS.NAME_MAX_LENGTH),
+    height: z.number().min(CONSTRAINTS.MIN_LAYER_HEIGHT),
+  })
+  .partial();
+
+const payloadSchema = z.object({
+  id: z.string().min(1),
+  updates: updatesSchema,
+});
+
+function capturePrevious(layer: Layer, changes: Partial<Layer>): Partial<Layer> {
+  const previous: Partial<Layer> = {};
+  for (const key of Object.keys(changes) as Array<keyof Layer>) {
+    (previous as Record<string, unknown>)[key as string] = layer[key];
+  }
+  return previous;
+}
+
+export const updateLayer = defineCommand({
+  type: 'layer.update',
+  aggregate: 'layout',
+  aggregateId: () => 'layout',
+  payload: payloadSchema,
+  emitted: 'layer.updated',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.layerUpdate',
+  middleware: { undoCapture: true, validate: true, analytics: true },
+  handle: (
+    payload,
+    ctx
+  ): Result<
+    {
+      value: undefined;
+      event: { payload: { id: LayerId; changes: Partial<Layer>; previous: Partial<Layer> } };
+    },
+    LayoutError
+  > => {
+    const id = toLayerId(payload.id);
+    const layout = ctx.aggregate;
+    const existing = layout.layers.find((l) => l.id === id);
+    if (!existing) {
+      return err(layoutInvalidOperation('updateLayer', `Layer ${id} not found`));
+    }
+
+    const changes: Partial<Layer> = {};
+    if (payload.updates.name !== undefined) changes.name = payload.updates.name;
+    if (payload.updates.height !== undefined) {
+      // Inline the clamp so the event records the value that will actually
+      // be stored. Other layers' heights cap how much room remains.
+      const othersHeight = layout.layers
+        .filter((l) => l.id !== id)
+        .reduce((sum, l) => sum + (l.height as number), 0);
+      const maxHeight = (layout.drawer.height as number) - othersHeight;
+      changes.height = heightUnits(
+        clamp(payload.updates.height, CONSTRAINTS.MIN_LAYER_HEIGHT, maxHeight)
+      );
+    }
+
+    return ok({
+      value: undefined,
+      event: { payload: { id, changes, previous: capturePrevious(existing, changes) } },
+    });
+  },
+  apply: (event, draft) => {
+    const layer = draft.layers.find((l) => l.id === event.payload.id);
+    if (layer) Object.assign(layer, event.payload.changes);
+  },
+});

--- a/src/core/cqrs/v2/registry.ts
+++ b/src/core/cqrs/v2/registry.ts
@@ -21,6 +21,10 @@ import { moveBinFromStaging } from './domain/bin/moveBinFromStaging';
 import { fillLayer } from './domain/bin/fillLayer';
 import { fillGaps } from './domain/bin/fillGaps';
 import { clearLayer } from './domain/bin/clearLayer';
+import { addLayer } from './domain/layer/addLayer';
+import { updateLayer } from './domain/layer/updateLayer';
+import { deleteLayer } from './domain/layer/deleteLayer';
+import { reorderLayers } from './domain/layer/reorderLayers';
 
 type V2HandlerFn = (command: {
   type: string;
@@ -49,6 +53,10 @@ export const v2HandlerOverrides: Record<string, V2HandlerFn> = {
   [fillLayer.type]: wrapV2Handler(fillLayer) as V2HandlerFn,
   [fillGaps.type]: wrapV2Handler(fillGaps) as V2HandlerFn,
   [clearLayer.type]: wrapV2Handler(clearLayer) as V2HandlerFn,
+  [addLayer.type]: wrapV2Handler(addLayer) as V2HandlerFn,
+  [updateLayer.type]: wrapV2Handler(updateLayer) as V2HandlerFn,
+  [deleteLayer.type]: wrapV2Handler(deleteLayer) as V2HandlerFn,
+  [reorderLayers.type]: wrapV2Handler(reorderLayers) as V2HandlerFn,
 };
 
 /** All registered v2 commands, exposed for tests + future tooling. */
@@ -63,4 +71,8 @@ export const v2Commands = [
   fillLayer,
   fillGaps,
   clearLayer,
+  addLayer,
+  updateLayer,
+  deleteLayer,
+  reorderLayers,
 ] as const;


### PR DESCRIPTION
## Summary

PR 9 in the CQRS DX redesign sequence. **All 4 layer commands now flow through the v2 wrapper.**

## Per-command notes

### `layer.add`
Generates the new Layer with name and clamped height inside `handle()`. Reads `defaultLayerHeight` from the settings store (config-not-state, outside the layout aggregate snapshot).

### `layer.update`
**Per-command refactor**: v1 store action did the height-clamp inside the `setLocal` mutator (hidden side-effect of the write). v2 inlines the clamp into `handle()` so the event payload's `changes.height` always reflects the value that will actually be stored — **no replay drift between native and apply paths**.

### `layer.delete`
**Per-command refactor**: v1 event payload only carried `{layer, deletedBinCount}`. The actual displaced bin IDs were lost, so replay against a divergent layout produced the wrong cascade.
- v2 widens `LayerDeletedEvent` payload with optional `displacedBinIds: ReadonlyArray<BinId>` so `apply()` can target the exact set.
- v1 events without `displacedBinIds` keep prior behavior (heuristic: "all bins on the deleted layer").
- `projection/replay.ts` updated to use `displacedBinIds` when present, fall back otherwise.

### `layer.reorder`
Validates indices and runs the reorder collision check against the frozen layout snapshot. `apply()` does the array splice. `fromIndex === toIndex` is a no-op (success result, apply does nothing).

## Tests

5 new sibling test files (4 commands + shared `_testHelpers`). Property tests cover handle correctness, error paths, and `apply()` round-trip equivalence.

## Where this fits

- #1538 (PR 1) — library cloudShare persistence subscriber
- #1539 (PR 2) — defineCommand foundations
- #1541 (PR 3) — history.ts rename
- #1542 (PR 4) — undo via command bus
- #1543–#1548 (PRs 5–8) — bin domain (10/10 commands)
- **#TBD (PR 9)** — layer domain (4/4 commands) ← this PR

Next: **PR 10** migrates `category.add` / `category.update` / `category.delete`.

## Test plan

- [x] `pnpm typecheck` — clean (no regression)
- [x] `pnpm test:run` — full suite, **10364 tests pass** (was 10347; +17 new property tests)
- [x] `pnpm lint` — clean
- [x] `pnpm knip` — clean
- [x] `pnpm check:boundaries` — clean