### PR TITLE
feat(cqrs): migrate category commands to v2 defineCommand

### DIFF
--- a/src/core/cqrs/v2/domain/category/_testHelpers.ts
+++ b/src/core/cqrs/v2/domain/category/_testHelpers.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared fixtures for v2 category command property tests.
+ */
+
+import type { Bin, Category, Layout } from '@/core/types';
+import { binId, layerId, categoryId, gridUnits, heightUnits } from '@/core/types';
+
+export function makeCategory(idStr: string, name = idStr, color = '#808080'): Category {
+  return { id: categoryId(idStr), name, color };
+}
+
+export function makeBin(idStr: string, catId: string): Bin {
+  return {
+    id: binId(idStr),
+    layerId: layerId('layer_1'),
+    x: gridUnits(0),
+    y: gridUnits(0),
+    width: gridUnits(1),
+    depth: gridUnits(1),
+    height: heightUnits(3),
+    category: categoryId(catId),
+    label: '',
+    notes: '',
+  };
+}
+
+export function makeLayout(overrides: Partial<Layout> = {}): Layout {
+  return {
+    version: '1.0',
+    name: 'Test',
+    drawer: {
+      width: gridUnits(6),
+      depth: gridUnits(4),
+      height: heightUnits(7),
+    },
+    printBedSize: 256 as Layout['printBedSize'],
+    gridUnitMm: 42 as Layout['gridUnitMm'],
+    heightUnitMm: 7 as Layout['heightUnitMm'],
+    categories: [makeCategory('cat_1', 'Default')],
+    layers: [{ id: layerId('layer_1'), name: 'L1', height: heightUnits(3) }],
+    bins: [],
+    ...overrides,
+  };
+}

--- a/src/core/cqrs/v2/domain/category/addCategory.test.ts
+++ b/src/core/cqrs/v2/domain/category/addCategory.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
+import { addCategory } from './addCategory';
+import { makeLayout, makeCategory } from './_testHelpers';
+
+describe('v2 category.add', () => {
+  it('emits an event with a generated category', () => {
+    const layout = makeLayout();
+    const result = addCategory.handle({ name: 'New', color: '#ff0000' }, { aggregate: layout });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.category.name).toBe('New');
+    expect(result.value.event.payload.category.color).toBe('#ff0000');
+    expect(result.value.event.payload.category.id).toBe(result.value.value);
+  });
+
+  it('errors when the category-count limit is reached', () => {
+    const categories = Array.from({ length: CONSTRAINTS.CATEGORIES_MAX }, (_, i) =>
+      makeCategory(`cat_${String(i)}`)
+    );
+    const layout = makeLayout({ categories });
+    const result = addCategory.handle(
+      { name: 'Overflow', color: '#000000' },
+      { aggregate: layout }
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('apply() pushes the new category onto the draft', () => {
+    const layout = makeLayout();
+    const result = addCategory.handle({ name: 'New', color: '#00ff00' }, { aggregate: layout });
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(layout, (draft) => {
+      addCategory.apply({ type: 'category.added', payload: result.value.event.payload }, draft);
+    });
+
+    expect(applied.categories).toHaveLength(2);
+    expect(applied.categories[1]).toEqual(result.value.event.payload.category);
+  });
+});

--- a/src/core/cqrs/v2/domain/category/addCategory.ts
+++ b/src/core/cqrs/v2/domain/category/addCategory.ts
@@ -1,0 +1,44 @@
+/**
+ * category.add — v2 (defineCommand) shape.
+ *
+ * Validates the per-layout category count limit, generates the new
+ * CategoryId, returns the full Category in the event payload.
+ */
+
+import { z } from 'zod';
+import type { Result, LayoutError } from '@/core/result';
+import { ok, err, layoutCategoryLimit } from '@/core/result';
+import { generateCategoryId, CONSTRAINTS } from '@/core/constants';
+import type { Category, CategoryId } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({
+  name: z.string().min(1).max(CONSTRAINTS.LABEL_MAX_LENGTH),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+});
+
+export const addCategory = defineCommand({
+  type: 'category.add',
+  aggregate: 'layout',
+  aggregateId: () => 'layout',
+  payload: payloadSchema,
+  emitted: 'category.added',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.categoryAdd',
+  middleware: { undoCapture: true, validate: true, analytics: true },
+  handle: (
+    payload,
+    ctx
+  ): Result<{ value: CategoryId; event: { payload: { category: Category } } }, LayoutError> => {
+    const layout = ctx.aggregate;
+    if (layout.categories.length >= CONSTRAINTS.CATEGORIES_MAX) {
+      return err(layoutCategoryLimit(layout.categories.length, CONSTRAINTS.CATEGORIES_MAX));
+    }
+
+    const category: Category = { ...payload, id: generateCategoryId() };
+    return ok({ value: category.id, event: { payload: { category } } });
+  },
+  apply: (event, draft) => {
+    draft.categories.push(event.payload.category);
+  },
+});

--- a/src/core/cqrs/v2/domain/category/deleteCategory.test.ts
+++ b/src/core/cqrs/v2/domain/category/deleteCategory.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { categoryId } from '@/core/types';
+import { deleteCategory } from './deleteCategory';
+import { makeLayout, makeCategory, makeBin } from './_testHelpers';
+
+describe('v2 category.delete', () => {
+  it('rejects when any bin still references the category (precondition, not cascade)', () => {
+    const layout = makeLayout({
+      categories: [makeCategory('cat_1'), makeCategory('cat_2')],
+      bins: [makeBin('bin_a', 'cat_1')],
+    });
+    const result = deleteCategory.handle({ id: 'cat_1' }, { aggregate: layout });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('LAYOUT_INVALID_OPERATION');
+    if (result.error.code === 'LAYOUT_INVALID_OPERATION') {
+      expect(result.error.reason).toMatch(/in use/);
+    }
+  });
+
+  it('errors at the category-count minimum', () => {
+    const layout = makeLayout(); // single category
+    const result = deleteCategory.handle({ id: 'cat_1' }, { aggregate: layout });
+    expect(result.ok).toBe(false);
+  });
+
+  it('errors when the category does not exist', () => {
+    const layout = makeLayout({
+      categories: [makeCategory('cat_1'), makeCategory('cat_2')],
+    });
+    const result = deleteCategory.handle({ id: 'cat_gone' }, { aggregate: layout });
+    expect(result.ok).toBe(false);
+  });
+
+  it('apply() removes the category when no bins reference it', () => {
+    const layout = makeLayout({
+      categories: [makeCategory('cat_1'), makeCategory('cat_2')],
+    });
+    const result = deleteCategory.handle({ id: 'cat_1' }, { aggregate: layout });
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(layout, (draft) => {
+      deleteCategory.apply(
+        { type: 'category.deleted', payload: result.value.event.payload },
+        draft
+      );
+    });
+
+    expect(applied.categories).toHaveLength(1);
+    expect(applied.categories[0].id).toBe(categoryId('cat_2'));
+  });
+});

--- a/src/core/cqrs/v2/domain/category/deleteCategory.ts
+++ b/src/core/cqrs/v2/domain/category/deleteCategory.ts
@@ -3,10 +3,12 @@
  *
  * Per-command refactor (per Pass 3 plan): this is precondition
  * enforcement, not a cascade. v1 rejects when any bin references the
- * category — v2 keeps that behavior exactly. handle() validates:
- *   1. category exists
- *   2. no bins reference it
- *   3. layout still has at least CATEGORIES_MIN categories afterward
+ * category — v2 keeps that behavior exactly. handle() validates in this
+ * order (matches v1's order in createCategoryActions.deleteCategory so
+ * the same input produces the same first-failure error):
+ *   1. no bins reference it
+ *   2. layout still has at least CATEGORIES_MIN categories afterward
+ *   3. category exists
  *
  * apply() filters the category out of the draft. No bin reassignment
  * happens because deletion is blocked when any bin uses it.

--- a/src/core/cqrs/v2/domain/category/deleteCategory.ts
+++ b/src/core/cqrs/v2/domain/category/deleteCategory.ts
@@ -1,0 +1,68 @@
+/**
+ * category.delete — v2 (defineCommand) shape.
+ *
+ * Per-command refactor (per Pass 3 plan): this is precondition
+ * enforcement, not a cascade. v1 rejects when any bin references the
+ * category — v2 keeps that behavior exactly. handle() validates:
+ *   1. category exists
+ *   2. no bins reference it
+ *   3. layout still has at least CATEGORIES_MIN categories afterward
+ *
+ * apply() filters the category out of the draft. No bin reassignment
+ * happens because deletion is blocked when any bin uses it.
+ */
+
+import { z } from 'zod';
+import type { Result, LayoutError } from '@/core/result';
+import { ok, err, layoutLastEntity, layoutInvalidOperation } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
+import type { Category } from '@/core/types';
+import { categoryId as toCategoryId } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({ id: z.string().min(1) });
+
+export const deleteCategory = defineCommand({
+  type: 'category.delete',
+  aggregate: 'layout',
+  aggregateId: () => 'layout',
+  payload: payloadSchema,
+  emitted: 'category.deleted',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.categoryDelete',
+  middleware: { undoCapture: true, validate: true, analytics: true },
+  handle: (
+    payload,
+    ctx
+  ): Result<{ value: undefined; event: { payload: { category: Category } } }, LayoutError> => {
+    const id = toCategoryId(payload.id);
+    const layout = ctx.aggregate;
+
+    const inUse = layout.bins.filter((b) => b.category === id);
+    if (inUse.length > 0) {
+      return err(
+        layoutInvalidOperation(
+          'deleteCategory',
+          `Category is in use by ${String(inUse.length)} bin${inUse.length > 1 ? 's' : ''}`
+        )
+      );
+    }
+
+    if (layout.categories.length <= CONSTRAINTS.CATEGORIES_MIN) {
+      return err(layoutLastEntity('category'));
+    }
+
+    const category = layout.categories.find((c) => c.id === id);
+    if (!category) {
+      return err(layoutInvalidOperation('deleteCategory', `Category ${id} not found`));
+    }
+
+    return ok({
+      value: undefined,
+      event: { payload: { category: { ...category } } },
+    });
+  },
+  apply: (event, draft) => {
+    draft.categories = draft.categories.filter((c) => c.id !== event.payload.category.id);
+  },
+});

--- a/src/core/cqrs/v2/domain/category/updateCategory.test.ts
+++ b/src/core/cqrs/v2/domain/category/updateCategory.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { updateCategory } from './updateCategory';
+import { makeLayout, makeCategory } from './_testHelpers';
+
+describe('v2 category.update', () => {
+  it('captures previous values for the fields being changed', () => {
+    const layout = makeLayout({ categories: [makeCategory('cat_1', 'OldName', '#abcdef')] });
+    const result = updateCategory.handle(
+      { id: 'cat_1', updates: { name: 'NewName' } },
+      { aggregate: layout }
+    );
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.previous).toEqual({ name: 'OldName' });
+    expect(result.value.event.payload.changes).toEqual({ name: 'NewName' });
+  });
+
+  it('errors when the category does not exist', () => {
+    const layout = makeLayout();
+    const result = updateCategory.handle(
+      { id: 'cat_gone', updates: { name: 'X' } },
+      { aggregate: layout }
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('apply() round-trip equals native Object.assign', () => {
+    const layout = makeLayout();
+    const result = updateCategory.handle(
+      { id: 'cat_1', updates: { color: '#aaaaaa' } },
+      { aggregate: layout }
+    );
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(layout, (draft) => {
+      updateCategory.apply(
+        { type: 'category.updated', payload: result.value.event.payload },
+        draft
+      );
+    });
+
+    expect(applied.categories[0].color).toBe('#aaaaaa');
+  });
+});

--- a/src/core/cqrs/v2/domain/category/updateCategory.ts
+++ b/src/core/cqrs/v2/domain/category/updateCategory.ts
@@ -1,0 +1,77 @@
+/**
+ * category.update — v2 (defineCommand) shape.
+ *
+ * Validates the category exists, captures previous values for the fields
+ * being updated, and emits `category.updated`. apply() does Object.assign
+ * over the matching draft entry.
+ */
+
+import { z } from 'zod';
+import type { Result, LayoutError } from '@/core/result';
+import { ok, err, layoutInvalidOperation } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
+import type { Category, CategoryId } from '@/core/types';
+import { categoryId as toCategoryId } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const updatesSchema = z
+  .object({
+    name: z.string().min(1).max(CONSTRAINTS.LABEL_MAX_LENGTH),
+    color: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+  })
+  .partial();
+
+const payloadSchema = z.object({
+  id: z.string().min(1),
+  updates: updatesSchema,
+});
+
+function capturePrevious(category: Category, changes: Partial<Category>): Partial<Category> {
+  const previous: Partial<Category> = {};
+  for (const key of Object.keys(changes) as Array<keyof Category>) {
+    (previous as Record<string, unknown>)[key as string] = category[key];
+  }
+  return previous;
+}
+
+export const updateCategory = defineCommand({
+  type: 'category.update',
+  aggregate: 'layout',
+  aggregateId: () => 'layout',
+  payload: payloadSchema,
+  emitted: 'category.updated',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.categoryUpdate',
+  middleware: { undoCapture: true, validate: true, analytics: true },
+  handle: (
+    payload,
+    ctx
+  ): Result<
+    {
+      value: undefined;
+      event: {
+        payload: { id: CategoryId; changes: Partial<Category>; previous: Partial<Category> };
+      };
+    },
+    LayoutError
+  > => {
+    const id = toCategoryId(payload.id);
+    const existing = ctx.aggregate.categories.find((c) => c.id === id);
+    if (!existing) {
+      return err(layoutInvalidOperation('updateCategory', `Category ${id} not found`));
+    }
+
+    const changes: Partial<Category> = {};
+    if (payload.updates.name !== undefined) changes.name = payload.updates.name;
+    if (payload.updates.color !== undefined) changes.color = payload.updates.color;
+
+    return ok({
+      value: undefined,
+      event: { payload: { id, changes, previous: capturePrevious(existing, changes) } },
+    });
+  },
+  apply: (event, draft) => {
+    const category = draft.categories.find((c) => c.id === event.payload.id);
+    if (category) Object.assign(category, event.payload.changes);
+  },
+});

--- a/src/core/cqrs/v2/registry.ts
+++ b/src/core/cqrs/v2/registry.ts
@@ -25,6 +25,9 @@ import { addLayer } from './domain/layer/addLayer';
 import { updateLayer } from './domain/layer/updateLayer';
 import { deleteLayer } from './domain/layer/deleteLayer';
 import { reorderLayers } from './domain/layer/reorderLayers';
+import { addCategory } from './domain/category/addCategory';
+import { updateCategory } from './domain/category/updateCategory';
+import { deleteCategory } from './domain/category/deleteCategory';
 
 type V2HandlerFn = (command: {
   type: string;
@@ -57,6 +60,9 @@ export const v2HandlerOverrides: Record<string, V2HandlerFn> = {
   [updateLayer.type]: wrapV2Handler(updateLayer) as V2HandlerFn,
   [deleteLayer.type]: wrapV2Handler(deleteLayer) as V2HandlerFn,
   [reorderLayers.type]: wrapV2Handler(reorderLayers) as V2HandlerFn,
+  [addCategory.type]: wrapV2Handler(addCategory) as V2HandlerFn,
+  [updateCategory.type]: wrapV2Handler(updateCategory) as V2HandlerFn,
+  [deleteCategory.type]: wrapV2Handler(deleteCategory) as V2HandlerFn,
 };
 
 /** All registered v2 commands, exposed for tests + future tooling. */
@@ -75,4 +81,7 @@ export const v2Commands = [
   updateLayer,
   deleteLayer,
   reorderLayers,
+  addCategory,
+  updateCategory,
+  deleteCategory,
 ] as const;


### PR DESCRIPTION
## Summary

PR 10 in the CQRS DX redesign sequence. **All 3 category commands now flow through the v2 wrapper.**

## Per-command notes

### `category.add`
Validates the per-layout category-count limit. Generates the new `CategoryId`, returns the full Category in the event payload.

### `category.update`
Validates exists, captures previous values for the fields being updated, emits with `{id, changes, previous}`. `apply()` does `Object.assign`.

### `category.delete`
**Per-command refactor (per Pass 3 plan): this is precondition enforcement, not a cascade.** v1 rejects when any bin references the category — v2 keeps that behavior exactly. `handle()` validates:
1. category not in use by any bin
2. layout still has at least `CATEGORIES_MIN` categories afterward
3. category exists

`apply()` filters the category out of the draft. No bin reassignment happens because deletion is blocked when any bin uses it.

## Tests

4 new sibling test files (3 commands + shared `_testHelpers`). Property tests cover handle correctness, error paths (limit reached, in-use rejection, min-count, not found), and `apply()` round-trip.

## Where this fits

- #1538 (PR 1) — library cloudShare persistence subscriber
- #1539 (PR 2) — defineCommand foundations
- #1541 (PR 3) — history.ts rename
- #1542 (PR 4) — undo via command bus
- #1543–#1548 (PRs 5–8) — bin domain (10/10)
- #1550 (PR 9) — layer domain (4/4)
- **#TBD (PR 10)** — category domain (3/3) ← this PR

**Layout-aggregate progress: 17 / ~22 commands migrated.** Remaining layout-aggregate commands: `drawer.update`, `layout.setName`, `layout.setPrintBedSize`, `layout.setGridUnitMm`, `layout.setHeightUnitMm`, `layout.setBaseplateParams`, `layout.restore`. PR 11 will tackle drawer + layout metadata commands.

## Test plan

- [x] `pnpm typecheck` — clean (no regression)
- [x] `pnpm test:run` — full suite, **10374 tests pass** (was 10364; +10 new property tests)
- [x] `pnpm lint` — clean