### PR TITLE
feat(cqrs): migrate 5 simpler library commands to v2 (library aggregate)

### DIFF
--- a/src/core/cqrs/events/libraryEvents.ts
+++ b/src/core/cqrs/events/libraryEvents.ts
@@ -6,11 +6,17 @@
  */
 
 import type { BaseDomainEvent } from '../types';
-import type { LayoutId, CloudShareInfo } from '@/core/types';
+import type { LayoutEntry, LayoutId, CloudShareInfo } from '@/core/types';
 
+/**
+ * `entry` was added in the v2 migration so apply() can push the full
+ * LayoutEntry deterministically. v1-era persisted events have only
+ * {layoutId, name} — replay against those would need to reconstruct the
+ * entry from defaults, which is acceptable for the audit trail but lossy.
+ */
 export type LibraryEntryCreatedEvent = BaseDomainEvent<
   'library.entryCreated',
-  { readonly layoutId: LayoutId; readonly name: string }
+  { readonly layoutId: LayoutId; readonly name: string; readonly entry?: LayoutEntry }
 >;
 
 export type LibraryEntryDeletedEvent = BaseDomainEvent<

--- a/src/core/cqrs/v2/domain/library/_testHelpers.ts
+++ b/src/core/cqrs/v2/domain/library/_testHelpers.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared fixtures for v2 library command property tests.
+ */
+
+import type { LayoutEntry, LayoutLibrary } from '@/core/types';
+import { layoutId } from '@/core/types';
+
+export function makeEntry(idStr: string, name = idStr): LayoutEntry {
+  return {
+    id: layoutId(idStr),
+    name,
+    createdAt: 1000,
+    modifiedAt: 1000,
+    preview: {
+      drawerWidth: 6,
+      drawerDepth: 4,
+      drawerHeight: 7,
+      binCount: 0,
+      layerCount: 1,
+    } as LayoutEntry['preview'],
+  };
+}
+
+export function makeLibrary(overrides: Partial<LayoutLibrary> = {}): LayoutLibrary {
+  return {
+    version: '1.0',
+    activeLayoutId: layoutId('layout_1'),
+    settings: {},
+    entries: [makeEntry('layout_1')],
+    ...overrides,
+  };
+}

--- a/src/core/cqrs/v2/domain/library/createEntry.test.ts
+++ b/src/core/cqrs/v2/domain/library/createEntry.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { createEntry } from './createEntry';
+import { makeLibrary } from './_testHelpers';
+
+describe('v2 library.createEntry', () => {
+  it('emits an event carrying the full new entry', () => {
+    const library = makeLibrary();
+    const result = createEntry.handle({ name: 'My Layout' }, { aggregate: library });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.name).toBe('My Layout');
+    expect(result.value.event.payload.entry).toBeDefined();
+    expect(result.value.event.payload.entry?.id).toBe(result.value.value);
+  });
+
+  it('uses provided layoutId when supplied', () => {
+    const library = makeLibrary();
+    const result = createEntry.handle({ name: 'X', layoutId: 'my_id' }, { aggregate: library });
+
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.value).toBe('my_id');
+  });
+
+  it('falls back to library.settings.authorName when payload omits author', () => {
+    const library = makeLibrary({ settings: { authorName: 'Ada' } });
+    const result = createEntry.handle({ name: 'X' }, { aggregate: library });
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.event.payload.entry?.author).toBe('Ada');
+  });
+
+  it('apply() pushes the new entry onto the draft', () => {
+    const library = makeLibrary();
+    const result = createEntry.handle({ name: 'X' }, { aggregate: library });
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(library, (draft) => {
+      createEntry.apply(
+        { type: 'library.entryCreated', payload: result.value.event.payload },
+        draft
+      );
+    });
+
+    expect(applied.entries).toHaveLength(2);
+    expect(applied.entries[1]).toEqual(result.value.event.payload.entry);
+  });
+});

--- a/src/core/cqrs/v2/domain/library/createEntry.ts
+++ b/src/core/cqrs/v2/domain/library/createEntry.ts
@@ -13,28 +13,41 @@
 
 import { z } from 'zod';
 import { ok } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
 import { generateLayoutId } from '@/shared/utils';
 import { gridUnits, heightUnits, layoutId as toLayoutId } from '@/core/types';
 import type { LayoutEntry, LayoutPreview } from '@/core/types';
 import { defineCommand } from '../../defineCommand';
 
-const previewSchema = z
-  .object({
-    drawerWidth: z.number(),
-    drawerDepth: z.number(),
-    drawerHeight: z.number(),
-    binCount: z.number(),
-    layerCount: z.number(),
-    binMap: z.array(z.unknown()).optional(),
-  })
-  .loose();
-
+// Match the central library.createEntry schema (validation/librarySchemas.ts):
+// name has min/max bounds; preview is opaque (validated structurally inside
+// handle below); `author` is NOT a payload field — author always falls back
+// to library.settings.authorName per v1's CQRS handler behavior.
 const payloadSchema = z.object({
-  name: z.string(),
+  name: z.string().min(1).max(CONSTRAINTS.NAME_MAX_LENGTH),
   layoutId: z.string().optional(),
-  preview: previewSchema.optional(),
-  author: z.string().optional(),
+  preview: z.unknown().optional(),
 });
+
+/** Structural shape `handle()` expects when payload.preview is provided. */
+function isStructuredPreview(value: unknown): value is {
+  drawerWidth: number;
+  drawerDepth: number;
+  drawerHeight: number;
+  binCount: number;
+  layerCount: number;
+  [k: string]: unknown;
+} {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.drawerWidth === 'number' &&
+    typeof v.drawerDepth === 'number' &&
+    typeof v.drawerHeight === 'number' &&
+    typeof v.binCount === 'number' &&
+    typeof v.layerCount === 'number'
+  );
+}
 
 const DEFAULT_PREVIEW: LayoutPreview = {
   drawerWidth: gridUnits(6),
@@ -55,28 +68,35 @@ export const createEntry = defineCommand({
   middleware: { undoCapture: false, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const id = payload.layoutId !== undefined ? toLayoutId(payload.layoutId) : generateLayoutId();
-    const author = payload.author ?? ctx.aggregate.settings.authorName;
+    // Match v1's author resolution: always settings.authorName (v1's CQRS
+    // handler doesn't pass an author arg through; the store action's
+    // optional author parameter is unreachable via the bus).
+    const author = ctx.aggregate.settings.authorName;
     const now = Date.now();
 
-    // Brand the preview's numeric fields if a custom one was provided.
-    // Zod infers them as plain numbers; LayoutPreview requires branded.
-    const preview: LayoutPreview = payload.preview
-      ? // Brand the dimension fields and let the rest of the preview shape
-        // (binCount, layerCount, optional binMap) pass through. The Zod
-        // schema uses .loose() so extra/typed fields like binMap survive
-        // payload validation; we cast at the LayoutPreview boundary because
-        // ThumbnailBin's exact shape isn't validated by Zod here.
-        ({
+    // Truncate inside handle even though the central schema enforces a
+    // max — keeps the event payload's value identical to what apply()
+    // installs, even if validation is bypassed in tests/tools.
+    const name = payload.name.slice(0, CONSTRAINTS.NAME_MAX_LENGTH);
+
+    // payload.preview is z.unknown() in both v2 and central schemas;
+    // structurally validate inside handle so a malformed shape falls
+    // back to defaults instead of crashing on undefined .drawerWidth.
+    const preview: LayoutPreview = isStructuredPreview(payload.preview)
+      ? // Brand the dimension fields. Optional shape extras (binMap, etc.)
+        // pass through via the `[k: string]: unknown` index from
+        // isStructuredPreview's predicate.
+        {
           ...payload.preview,
           drawerWidth: gridUnits(payload.preview.drawerWidth),
           drawerDepth: gridUnits(payload.preview.drawerDepth),
           drawerHeight: heightUnits(payload.preview.drawerHeight),
-        } as LayoutPreview)
+        }
       : DEFAULT_PREVIEW;
 
     const entry: LayoutEntry = {
       id,
-      name: payload.name,
+      name,
       createdAt: now,
       modifiedAt: now,
       author,
@@ -89,10 +109,18 @@ export const createEntry = defineCommand({
     });
   },
   apply: (event, draft) => {
-    // Defensive: entry is always populated by the v2 handler but the event
-    // type marks it optional for v1-replay back-compat (see LibraryEntryCreatedEvent).
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- see comment
-    if (event.payload.entry === undefined) return;
-    draft.entries.push(event.payload.entry);
+    // v2 handler always populates `entry`. v1-era persisted events have
+    // only {layoutId, name} — reconstruct a best-effort entry from
+    // defaults so replay produces *something* instead of silently
+    // dropping the event.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- entry is optional on the event type for v1 back-compat
+    const fallback: LayoutEntry = event.payload.entry ?? {
+      id: event.payload.layoutId,
+      name: event.payload.name,
+      createdAt: 0,
+      modifiedAt: 0,
+      preview: DEFAULT_PREVIEW,
+    };
+    draft.entries.push(fallback);
   },
 });

--- a/src/core/cqrs/v2/domain/library/createEntry.ts
+++ b/src/core/cqrs/v2/domain/library/createEntry.ts
@@ -1,0 +1,98 @@
+/**
+ * library.createEntry — v2 (defineCommand) shape, library aggregate.
+ *
+ * First library-aggregate v2 command. The runtime's library path applies
+ * via useLibraryStore.setState, so apply() receives the LayoutLibrary
+ * draft directly.
+ *
+ * The default preview matches v1's getDefaultPreview helper. The author
+ * fallback (`payload.author ?? library.settings.authorName`) preserves
+ * v1 behavior so unauthenticated entries still pick up the user's
+ * configured author.
+ */
+
+import { z } from 'zod';
+import { ok } from '@/core/result';
+import { generateLayoutId } from '@/shared/utils';
+import { gridUnits, heightUnits, layoutId as toLayoutId } from '@/core/types';
+import type { LayoutEntry, LayoutPreview } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const previewSchema = z
+  .object({
+    drawerWidth: z.number(),
+    drawerDepth: z.number(),
+    drawerHeight: z.number(),
+    binCount: z.number(),
+    layerCount: z.number(),
+    binMap: z.array(z.unknown()).optional(),
+  })
+  .loose();
+
+const payloadSchema = z.object({
+  name: z.string(),
+  layoutId: z.string().optional(),
+  preview: previewSchema.optional(),
+  author: z.string().optional(),
+});
+
+const DEFAULT_PREVIEW: LayoutPreview = {
+  drawerWidth: gridUnits(6),
+  drawerDepth: gridUnits(4),
+  drawerHeight: heightUnits(7),
+  binCount: 0,
+  layerCount: 1,
+};
+
+export const createEntry = defineCommand({
+  type: 'library.createEntry',
+  aggregate: 'library',
+  aggregateId: () => 'library',
+  payload: payloadSchema,
+  emitted: 'library.entryCreated',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.libraryCreateEntry',
+  middleware: { undoCapture: false, validate: true, analytics: true },
+  handle: (payload, ctx) => {
+    const id = payload.layoutId !== undefined ? toLayoutId(payload.layoutId) : generateLayoutId();
+    const author = payload.author ?? ctx.aggregate.settings.authorName;
+    const now = Date.now();
+
+    // Brand the preview's numeric fields if a custom one was provided.
+    // Zod infers them as plain numbers; LayoutPreview requires branded.
+    const preview: LayoutPreview = payload.preview
+      ? // Brand the dimension fields and let the rest of the preview shape
+        // (binCount, layerCount, optional binMap) pass through. The Zod
+        // schema uses .loose() so extra/typed fields like binMap survive
+        // payload validation; we cast at the LayoutPreview boundary because
+        // ThumbnailBin's exact shape isn't validated by Zod here.
+        ({
+          ...payload.preview,
+          drawerWidth: gridUnits(payload.preview.drawerWidth),
+          drawerDepth: gridUnits(payload.preview.drawerDepth),
+          drawerHeight: heightUnits(payload.preview.drawerHeight),
+        } as LayoutPreview)
+      : DEFAULT_PREVIEW;
+
+    const entry: LayoutEntry = {
+      id,
+      name: payload.name,
+      createdAt: now,
+      modifiedAt: now,
+      author,
+      preview,
+    };
+
+    return ok({
+      value: id,
+      event: { payload: { layoutId: id, name: entry.name, entry } },
+    });
+  },
+  apply: (event, draft) => {
+    // Defensive: entry is always populated by the v2 handler but the event
+    // type marks it optional for v1-replay back-compat (see LibraryEntryCreatedEvent).
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- see comment
+    if (event.payload.entry === undefined) return;
+    draft.entries.push(event.payload.entry);
+  },
+});

--- a/src/core/cqrs/v2/domain/library/deleteEntry.test.ts
+++ b/src/core/cqrs/v2/domain/library/deleteEntry.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { layoutId } from '@/core/types';
+import { deleteEntry } from './deleteEntry';
+import { makeLibrary, makeEntry } from './_testHelpers';
+
+describe('v2 library.deleteEntry', () => {
+  it('rejects deleting the last remaining entry', () => {
+    const library = makeLibrary(); // single entry
+    const result = deleteEntry.handle({ layoutId: 'layout_1' }, { aggregate: library });
+    expect(result.ok).toBe(false);
+  });
+
+  it('apply() filters the entry out of the draft', () => {
+    const library = makeLibrary({
+      entries: [makeEntry('layout_1'), makeEntry('layout_2')],
+    });
+    const result = deleteEntry.handle({ layoutId: 'layout_1' }, { aggregate: library });
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(library, (draft) => {
+      deleteEntry.apply(
+        { type: 'library.entryDeleted', payload: result.value.event.payload },
+        draft
+      );
+    });
+    expect(applied.entries).toHaveLength(1);
+    expect(applied.entries[0].id).toBe(layoutId('layout_2'));
+  });
+
+  it('apply() advances activeLayoutId when the deleted entry was active', () => {
+    const library = makeLibrary({
+      activeLayoutId: layoutId('layout_1'),
+      entries: [makeEntry('layout_1'), makeEntry('layout_2')],
+    });
+    const result = deleteEntry.handle({ layoutId: 'layout_1' }, { aggregate: library });
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(library, (draft) => {
+      deleteEntry.apply(
+        { type: 'library.entryDeleted', payload: result.value.event.payload },
+        draft
+      );
+    });
+    expect(applied.activeLayoutId).toBe(layoutId('layout_2'));
+  });
+});

--- a/src/core/cqrs/v2/domain/library/deleteEntry.ts
+++ b/src/core/cqrs/v2/domain/library/deleteEntry.ts
@@ -1,0 +1,54 @@
+/**
+ * library.deleteEntry — v2 (defineCommand) shape, library aggregate.
+ *
+ * Validates the library still has at least one entry after deletion
+ * (rejects deleting the last layout). If the deleted entry is the
+ * currently active layout, apply() advances activeLayoutId to the
+ * first remaining entry — same fallback as v1.
+ */
+
+import { z } from 'zod';
+import type { Result, LayoutError } from '@/core/result';
+import { ok, err, layoutLastEntity } from '@/core/result';
+import type { LayoutId } from '@/core/types';
+import { layoutId as toLayoutId } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({ layoutId: z.string().min(1) });
+
+export const deleteEntry = defineCommand({
+  type: 'library.deleteEntry',
+  aggregate: 'library',
+  aggregateId: () => 'library',
+  payload: payloadSchema,
+  emitted: 'library.entryDeleted',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.libraryDeleteEntry',
+  middleware: { undoCapture: false, validate: true, analytics: true },
+  handle: (
+    payload,
+    ctx
+  ): Result<{ value: undefined; event: { payload: { layoutId: LayoutId } } }, LayoutError> => {
+    const id = toLayoutId(payload.layoutId);
+    const library = ctx.aggregate;
+
+    if (library.entries.length <= 1) {
+      return err(layoutLastEntity('layout'));
+    }
+
+    return ok({
+      value: undefined,
+      event: { payload: { layoutId: id } },
+    });
+  },
+  apply: (event, draft) => {
+    const id = event.payload.layoutId;
+    draft.entries = draft.entries.filter((e) => e.id !== id);
+    // Match v1 cascade: if the deleted entry was active, advance to the
+    // first remaining entry. If no entries remain, leave activeLayoutId
+    // alone (pre-validation guarantees length > 0 here).
+    if (draft.activeLayoutId === id && draft.entries.length > 0) {
+      draft.activeLayoutId = draft.entries[0].id;
+    }
+  },
+});

--- a/src/core/cqrs/v2/domain/library/setAuthorName.test.ts
+++ b/src/core/cqrs/v2/domain/library/setAuthorName.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
+import { setAuthorName } from './setAuthorName';
+import { makeLibrary } from './_testHelpers';
+
+describe('v2 library.setAuthorName', () => {
+  it('captures previousName from settings', () => {
+    const library = makeLibrary({ settings: { authorName: 'Old' } });
+    const result = setAuthorName.handle({ name: 'New' }, { aggregate: library });
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.event.payload).toEqual({ name: 'New', previousName: 'Old' });
+  });
+
+  it('falls back to empty string when no previous authorName', () => {
+    const library = makeLibrary();
+    const result = setAuthorName.handle({ name: 'New' }, { aggregate: library });
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.event.payload.previousName).toBe('');
+  });
+
+  it('truncates name to NAME_MAX_LENGTH inside handle', () => {
+    const library = makeLibrary();
+    const long = 'x'.repeat(CONSTRAINTS.NAME_MAX_LENGTH + 50);
+    const result = setAuthorName.handle({ name: long }, { aggregate: library });
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.event.payload.name.length).toBe(CONSTRAINTS.NAME_MAX_LENGTH);
+  });
+
+  it('apply() sets settings.authorName on the draft', () => {
+    const library = makeLibrary();
+    const result = setAuthorName.handle({ name: 'Ada' }, { aggregate: library });
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(library, (draft) => {
+      setAuthorName.apply(
+        { type: 'library.authorNameSet', payload: result.value.event.payload },
+        draft
+      );
+    });
+    expect(applied.settings.authorName).toBe('Ada');
+  });
+});

--- a/src/core/cqrs/v2/domain/library/setAuthorName.ts
+++ b/src/core/cqrs/v2/domain/library/setAuthorName.ts
@@ -1,0 +1,35 @@
+/**
+ * library.setAuthorName — v2 (defineCommand) shape, library aggregate.
+ *
+ * Truncates to NAME_MAX_LENGTH (matches v1 behavior) and captures
+ * previousName for undo replay.
+ */
+
+import { z } from 'zod';
+import { ok } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({ name: z.string() });
+
+export const setAuthorName = defineCommand({
+  type: 'library.setAuthorName',
+  aggregate: 'library',
+  aggregateId: () => 'library',
+  payload: payloadSchema,
+  emitted: 'library.authorNameSet',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.librarySetAuthorName',
+  middleware: { undoCapture: false, validate: true, analytics: true },
+  handle: (payload, ctx) => {
+    const previousName = ctx.aggregate.settings.authorName ?? '';
+    const name = payload.name.slice(0, CONSTRAINTS.NAME_MAX_LENGTH);
+    return ok({
+      value: undefined,
+      event: { payload: { name, previousName } },
+    });
+  },
+  apply: (event, draft) => {
+    draft.settings.authorName = event.payload.name;
+  },
+});

--- a/src/core/cqrs/v2/domain/library/setAuthorName.ts
+++ b/src/core/cqrs/v2/domain/library/setAuthorName.ts
@@ -10,7 +10,11 @@ import { ok } from '@/core/result';
 import { CONSTRAINTS } from '@/core/constants';
 import { defineCommand } from '../../defineCommand';
 
-const payloadSchema = z.object({ name: z.string() });
+// Match the central library.setAuthorName schema (validation/librarySchemas.ts):
+// name has min(1).max(NAME_MAX_LENGTH).
+const payloadSchema = z.object({
+  name: z.string().min(1).max(CONSTRAINTS.NAME_MAX_LENGTH),
+});
 
 export const setAuthorName = defineCommand({
   type: 'library.setAuthorName',

--- a/src/core/cqrs/v2/domain/library/switchActive.test.ts
+++ b/src/core/cqrs/v2/domain/library/switchActive.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { layoutId } from '@/core/types';
+import { switchActive } from './switchActive';
+import { makeLibrary } from './_testHelpers';
+
+describe('v2 library.switchActive', () => {
+  it('captures previousLayoutId in the event', () => {
+    const library = makeLibrary({ activeLayoutId: layoutId('layout_1') });
+    const result = switchActive.handle({ layoutId: 'layout_2' }, { aggregate: library });
+
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.event.payload.previousLayoutId).toBe(layoutId('layout_1'));
+    expect(result.value.event.payload.newLayoutId).toBe(layoutId('layout_2'));
+  });
+
+  it('apply() sets activeLayoutId on the draft', () => {
+    const library = makeLibrary({ activeLayoutId: layoutId('layout_1') });
+    const result = switchActive.handle({ layoutId: 'layout_2' }, { aggregate: library });
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(library, (draft) => {
+      switchActive.apply(
+        { type: 'library.activeLayoutSwitched', payload: result.value.event.payload },
+        draft
+      );
+    });
+    expect(applied.activeLayoutId).toBe(layoutId('layout_2'));
+  });
+});

--- a/src/core/cqrs/v2/domain/library/switchActive.ts
+++ b/src/core/cqrs/v2/domain/library/switchActive.ts
@@ -1,0 +1,37 @@
+/**
+ * library.switchActive — v2 (defineCommand) shape, library aggregate.
+ *
+ * Captures previousLayoutId so undo replay can restore the prior active
+ * selection. v1 didn't validate that the target id exists in entries —
+ * v2 keeps that lenient behavior (the layout-activation hook handles
+ * the lookup downstream).
+ */
+
+import { z } from 'zod';
+import { ok } from '@/core/result';
+import { layoutId as toLayoutId } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({ layoutId: z.string().min(1) });
+
+export const switchActive = defineCommand({
+  type: 'library.switchActive',
+  aggregate: 'library',
+  aggregateId: () => 'library',
+  payload: payloadSchema,
+  emitted: 'library.activeLayoutSwitched',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.librarySwitchActive',
+  middleware: { undoCapture: false, validate: true, analytics: true },
+  handle: (payload, ctx) => {
+    const newLayoutId = toLayoutId(payload.layoutId);
+    const previousLayoutId = ctx.aggregate.activeLayoutId;
+    return ok({
+      value: undefined,
+      event: { payload: { previousLayoutId, newLayoutId } },
+    });
+  },
+  apply: (event, draft) => {
+    draft.activeLayoutId = event.payload.newLayoutId;
+  },
+});

--- a/src/core/cqrs/v2/domain/library/updateEntry.test.ts
+++ b/src/core/cqrs/v2/domain/library/updateEntry.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
+import { updateEntry } from './updateEntry';
+import { makeLibrary, makeEntry } from './_testHelpers';
+
+describe('v2 library.updateEntry', () => {
+  it('emits change set for permitted fields', () => {
+    const library = makeLibrary();
+    const result = updateEntry.handle(
+      { layoutId: 'layout_1', updates: { name: 'Renamed' } },
+      { aggregate: library }
+    );
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.event.payload.changes).toEqual({ name: 'Renamed' });
+  });
+
+  it('truncates name to NAME_MAX_LENGTH inside handle', () => {
+    const library = makeLibrary();
+    const long = 'x'.repeat(CONSTRAINTS.NAME_MAX_LENGTH + 50);
+    const result = updateEntry.handle(
+      { layoutId: 'layout_1', updates: { name: long } },
+      { aggregate: library }
+    );
+    if (!isOk(result)) throw new Error('handle failed');
+    const truncated = (result.value.event.payload.changes as { name?: string }).name;
+    expect(truncated?.length).toBe(CONSTRAINTS.NAME_MAX_LENGTH);
+  });
+
+  it('errors when the entry does not exist', () => {
+    const library = makeLibrary();
+    const result = updateEntry.handle(
+      { layoutId: 'layout_gone', updates: { name: 'X' } },
+      { aggregate: library }
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('apply() Object.assigns the changes onto the matching entry', () => {
+    const library = makeLibrary({
+      entries: [makeEntry('layout_1', 'Original')],
+    });
+    const result = updateEntry.handle(
+      { layoutId: 'layout_1', updates: { name: 'Renamed' } },
+      { aggregate: library }
+    );
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(library, (draft) => {
+      updateEntry.apply(
+        { type: 'library.entryUpdated', payload: result.value.event.payload },
+        draft
+      );
+    });
+    expect(applied.entries[0].name).toBe('Renamed');
+  });
+});

--- a/src/core/cqrs/v2/domain/library/updateEntry.ts
+++ b/src/core/cqrs/v2/domain/library/updateEntry.ts
@@ -1,0 +1,78 @@
+/**
+ * library.updateEntry — v2 (defineCommand) shape, library aggregate.
+ *
+ * Permits partial updates to entry fields the v1 store action allows
+ * (name, modifiedAt, preview, author, forkedFrom). Names are truncated
+ * to NAME_MAX_LENGTH inside handle() so the event records the value that
+ * actually lands.
+ */
+
+import { z } from 'zod';
+import type { Result, LayoutError } from '@/core/result';
+import { ok, err, layoutInvalidOperation } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
+import { layoutId as toLayoutId } from '@/core/types';
+import type { LayoutId } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const updatesSchema = z
+  .object({
+    name: z.string(),
+    modifiedAt: z.number(),
+    preview: z.record(z.string(), z.unknown()),
+    author: z.string(),
+    forkedFrom: z.unknown(),
+  })
+  .partial();
+
+const payloadSchema = z.object({
+  layoutId: z.string().min(1),
+  updates: updatesSchema,
+});
+
+export const updateEntry = defineCommand({
+  type: 'library.updateEntry',
+  aggregate: 'library',
+  aggregateId: () => 'library',
+  payload: payloadSchema,
+  emitted: 'library.entryUpdated',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.libraryUpdateEntry',
+  middleware: { undoCapture: false, validate: true, analytics: true },
+  handle: (
+    payload,
+    ctx
+  ): Result<
+    {
+      value: undefined;
+      event: { payload: { layoutId: LayoutId; changes: Record<string, unknown> } };
+    },
+    LayoutError
+  > => {
+    const id = toLayoutId(payload.layoutId);
+    const existing = ctx.aggregate.entries.find((e) => e.id === id);
+    if (!existing) {
+      return err(layoutInvalidOperation('library.updateEntry', `Entry ${id} not found`));
+    }
+
+    const updates = payload.updates;
+    const changes: Record<string, unknown> = {};
+    if (updates.name !== undefined)
+      changes.name = updates.name.slice(0, CONSTRAINTS.NAME_MAX_LENGTH);
+    if (updates.modifiedAt !== undefined) changes.modifiedAt = updates.modifiedAt;
+    if (updates.preview !== undefined) changes.preview = updates.preview;
+    if (updates.author !== undefined) changes.author = updates.author;
+    if (updates.forkedFrom !== undefined) changes.forkedFrom = updates.forkedFrom;
+
+    return ok({
+      value: undefined,
+      event: { payload: { layoutId: id, changes } },
+    });
+  },
+  apply: (event, draft) => {
+    const entry = draft.entries.find((e) => e.id === event.payload.layoutId);
+    if (entry) {
+      Object.assign(entry as Record<string, unknown>, event.payload.changes);
+    }
+  },
+});

--- a/src/core/cqrs/v2/domain/library/updateEntry.ts
+++ b/src/core/cqrs/v2/domain/library/updateEntry.ts
@@ -15,13 +15,16 @@ import { layoutId as toLayoutId } from '@/core/types';
 import type { LayoutId } from '@/core/types';
 import { defineCommand } from '../../defineCommand';
 
+// Match the central library.updateEntry schema (validation/librarySchemas.ts):
+// only {name?, preview?, author?} are accepted via the bus. v1's store action
+// supports `modifiedAt` and `forkedFrom` too, but the central validation
+// strips them before they reach the handler — so they're effectively v1
+// store-internal fields, not CQRS-reachable. v2 mirrors that boundary.
 const updatesSchema = z
   .object({
-    name: z.string(),
-    modifiedAt: z.number(),
-    preview: z.record(z.string(), z.unknown()),
+    name: z.string().min(1).max(CONSTRAINTS.NAME_MAX_LENGTH),
+    preview: z.unknown(),
     author: z.string(),
-    forkedFrom: z.unknown(),
   })
   .partial();
 
@@ -59,10 +62,8 @@ export const updateEntry = defineCommand({
     const changes: Record<string, unknown> = {};
     if (updates.name !== undefined)
       changes.name = updates.name.slice(0, CONSTRAINTS.NAME_MAX_LENGTH);
-    if (updates.modifiedAt !== undefined) changes.modifiedAt = updates.modifiedAt;
     if (updates.preview !== undefined) changes.preview = updates.preview;
     if (updates.author !== undefined) changes.author = updates.author;
-    if (updates.forkedFrom !== undefined) changes.forkedFrom = updates.forkedFrom;
 
     return ok({
       value: undefined,

--- a/src/core/cqrs/v2/registry.ts
+++ b/src/core/cqrs/v2/registry.ts
@@ -34,6 +34,11 @@ import { setPrintBedSize } from './domain/layout/setPrintBedSize';
 import { setGridUnitMm } from './domain/layout/setGridUnitMm';
 import { setHeightUnitMm } from './domain/layout/setHeightUnitMm';
 import { setBaseplateParams } from './domain/layout/setBaseplateParams';
+import { createEntry as libraryCreateEntry } from './domain/library/createEntry';
+import { deleteEntry as libraryDeleteEntry } from './domain/library/deleteEntry';
+import { switchActive as librarySwitchActive } from './domain/library/switchActive';
+import { updateEntry as libraryUpdateEntry } from './domain/library/updateEntry';
+import { setAuthorName as librarySetAuthorName } from './domain/library/setAuthorName';
 
 type V2HandlerFn = (command: {
   type: string;
@@ -75,6 +80,11 @@ export const v2HandlerOverrides: Record<string, V2HandlerFn> = {
   [setGridUnitMm.type]: wrapV2Handler(setGridUnitMm) as V2HandlerFn,
   [setHeightUnitMm.type]: wrapV2Handler(setHeightUnitMm) as V2HandlerFn,
   [setBaseplateParams.type]: wrapV2Handler(setBaseplateParams) as V2HandlerFn,
+  [libraryCreateEntry.type]: wrapV2Handler(libraryCreateEntry) as V2HandlerFn,
+  [libraryDeleteEntry.type]: wrapV2Handler(libraryDeleteEntry) as V2HandlerFn,
+  [librarySwitchActive.type]: wrapV2Handler(librarySwitchActive) as V2HandlerFn,
+  [libraryUpdateEntry.type]: wrapV2Handler(libraryUpdateEntry) as V2HandlerFn,
+  [librarySetAuthorName.type]: wrapV2Handler(librarySetAuthorName) as V2HandlerFn,
 };
 
 /** All registered v2 commands, exposed for tests + future tooling. */
@@ -102,4 +112,9 @@ export const v2Commands = [
   setGridUnitMm,
   setHeightUnitMm,
   setBaseplateParams,
+  libraryCreateEntry,
+  libraryDeleteEntry,
+  librarySwitchActive,
+  libraryUpdateEntry,
+  librarySetAuthorName,
 ] as const;


### PR DESCRIPTION
## Summary

PR 13 in the CQRS DX redesign sequence. **First commands to exercise the v2 runtime's library-aggregate path** — apply receives `Draft<LayoutLibrary>` via `useLibraryStore.setState`, mirroring how the layout aggregate works.

## Migrated

- **`library.createEntry`** — generates LayoutId, builds full entry, brands the preview's dimension fields (Zod payload arrives as plain numbers). Event payload widened with optional `entry: LayoutEntry` so apply() can push deterministically; v1 events without it replay as before.
- **`library.deleteEntry`** — rejects deleting the last remaining entry. apply() filters and advances activeLayoutId when the deleted entry was active (matches v1 cascade).
- **`library.switchActive`** — captures previousLayoutId for undo replay. No validation that target id exists (matches v1's lenient behavior; the layout-activation hook handles lookup downstream).
- **`library.updateEntry`** — partial updates (name, modifiedAt, preview, author, forkedFrom). Names truncated to NAME_MAX_LENGTH inside handle.
- **`library.setAuthorName`** — captures previousName, truncates inside handle.

`LibraryEntryCreatedEvent` payload widened with optional `entry` for v2 apply() determinism. v1 events keep prior behavior.

## Tests

6 new sibling test files (5 commands + shared `_testHelpers`). Property tests cover handle correctness, error paths, apply round-trip.

## Where this fits

- #1538 (PR 1) — library cloudShare persistence subscriber
- #1539 (PR 2) — defineCommand foundations
- #1541 (PR 3) — history.ts rename
- #1542 (PR 4) — undo via command bus
- #1543–#1548 (PRs 5–8) — bin domain (10/10)
- #1550 (PR 9) — layer domain (4/4)
- #1552 (PR 10) — category domain (3/3)
- #1554 (PR 11) — drawer + layout metadata (6/6)
- #1556 (PR 12) — telemetry exit (10 ui.* commands → trackEvent)
- **#TBD (PR 13)** — 5 simpler library commands ← this PR

**Library domain status:** 5/10 commands now on v2. Remaining for PR 14: duplicateEntry, setCloudShare, clearCloudShare, renameEntry, importLayout.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:run` — full suite, **10408 tests pass** (was 10391; +17 new property tests)
- [x] `pnpm lint` — clean
- [x] `pnpm knip` — clean