### PR TITLE
feat(cqrs): migrate remaining 5 library commands to v2 (library complete)

### DIFF
--- a/src/core/cqrs/events/libraryEvents.ts
+++ b/src/core/cqrs/events/libraryEvents.ts
@@ -24,9 +24,18 @@ export type LibraryEntryDeletedEvent = BaseDomainEvent<
   { readonly layoutId: LayoutId }
 >;
 
+/**
+ * `entry` was added in the v2 migration so apply() can push the duplicated
+ * entry deterministically. v1-era persisted events have only the ids — the
+ * `entry?` shape lets v1 events still satisfy the type.
+ */
 export type LibraryEntryDuplicatedEvent = BaseDomainEvent<
   'library.entryDuplicated',
-  { readonly sourceLayoutId: LayoutId; readonly newLayoutId: LayoutId }
+  {
+    readonly sourceLayoutId: LayoutId;
+    readonly newLayoutId: LayoutId;
+    readonly entry?: LayoutEntry;
+  }
 >;
 
 export type LibraryActiveSwitchedEvent = BaseDomainEvent<

--- a/src/core/cqrs/v2/domain/library/clearCloudShare.test.ts
+++ b/src/core/cqrs/v2/domain/library/clearCloudShare.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import type { CloudShareInfo } from '@/core/types';
+import { clearCloudShare } from './clearCloudShare';
+import { makeLibrary, makeEntry } from './_testHelpers';
+
+const sampleShare: CloudShareInfo = {
+  id: 'share_abc',
+  deleteToken: 'token',
+  sharedAt: 1000,
+  permission: 'view',
+};
+
+describe('v2 library.clearCloudShare', () => {
+  it('emits library.cloudShareCleared with the layoutId', () => {
+    const library = makeLibrary();
+    const result = clearCloudShare.handle({ layoutId: 'layout_1' }, { aggregate: library });
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.event.payload.layoutId).toBe('layout_1');
+  });
+
+  it('apply() clears cloudShare on the matching entry', () => {
+    const entry = makeEntry('layout_1');
+    entry.cloudShare = sampleShare;
+    const library = makeLibrary({ entries: [entry] });
+
+    const result = clearCloudShare.handle({ layoutId: 'layout_1' }, { aggregate: library });
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(library, (draft) => {
+      clearCloudShare.apply(
+        { type: 'library.cloudShareCleared', payload: result.value.event.payload },
+        draft
+      );
+    });
+    expect(applied.entries[0].cloudShare).toBeUndefined();
+  });
+});

--- a/src/core/cqrs/v2/domain/library/clearCloudShare.ts
+++ b/src/core/cqrs/v2/domain/library/clearCloudShare.ts
@@ -1,0 +1,36 @@
+/**
+ * library.clearCloudShare — v2 (defineCommand) shape, library aggregate.
+ *
+ * Clears cloudShare metadata on the matching entry. The
+ * libraryPersistence subscriber listens for the emitted
+ * `library.cloudShareCleared` event and persists the library snapshot.
+ */
+
+import { z } from 'zod';
+import { ok } from '@/core/result';
+import { layoutId as toLayoutId } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({ layoutId: z.string().min(1) });
+
+export const clearCloudShare = defineCommand({
+  type: 'library.clearCloudShare',
+  aggregate: 'library',
+  aggregateId: () => 'library',
+  payload: payloadSchema,
+  emitted: 'library.cloudShareCleared',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.libraryClearCloudShare',
+  middleware: { undoCapture: false, validate: true, analytics: true },
+  handle: (payload) => {
+    const layoutId = toLayoutId(payload.layoutId);
+    return ok({
+      value: undefined,
+      event: { payload: { layoutId } },
+    });
+  },
+  apply: (event, draft) => {
+    const entry = draft.entries.find((e) => e.id === event.payload.layoutId);
+    if (entry) entry.cloudShare = undefined;
+  },
+});

--- a/src/core/cqrs/v2/domain/library/duplicateEntry.test.ts
+++ b/src/core/cqrs/v2/domain/library/duplicateEntry.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { duplicateEntry } from './duplicateEntry';
+import { makeLibrary, makeEntry } from './_testHelpers';
+
+describe('v2 library.duplicateEntry', () => {
+  it('emits an event with a new entry derived from the source', () => {
+    const library = makeLibrary({
+      entries: [makeEntry('layout_1', 'Original')],
+    });
+    const result = duplicateEntry.handle({ sourceLayoutId: 'layout_1' }, { aggregate: library });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.sourceLayoutId).toBe('layout_1');
+    expect(result.value.event.payload.entry.name).toBe('Original (copy)');
+    expect(result.value.event.payload.entry.id).toBe(result.value.event.payload.newLayoutId);
+  });
+
+  it('errors when the source entry does not exist', () => {
+    const library = makeLibrary();
+    const result = duplicateEntry.handle({ sourceLayoutId: 'layout_gone' }, { aggregate: library });
+    expect(result.ok).toBe(false);
+  });
+
+  it('apply() pushes the duplicated entry onto the draft', () => {
+    const library = makeLibrary({ entries: [makeEntry('layout_1')] });
+    const result = duplicateEntry.handle({ sourceLayoutId: 'layout_1' }, { aggregate: library });
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(library, (draft) => {
+      duplicateEntry.apply(
+        { type: 'library.entryDuplicated', payload: result.value.event.payload },
+        draft
+      );
+    });
+    expect(applied.entries).toHaveLength(2);
+    expect(applied.entries[1]).toEqual(result.value.event.payload.entry);
+  });
+});

--- a/src/core/cqrs/v2/domain/library/duplicateEntry.ts
+++ b/src/core/cqrs/v2/domain/library/duplicateEntry.ts
@@ -1,0 +1,71 @@
+/**
+ * library.duplicateEntry — v2 (defineCommand) shape, library aggregate.
+ *
+ * Validates the source entry exists, generates a new LayoutId, and emits
+ * the full new entry in the event payload. apply() pushes — no re-fetch
+ * needed.
+ */
+
+import { z } from 'zod';
+import type { Result, LayoutError } from '@/core/result';
+import { ok, err, layoutInvalidOperation } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
+import { generateLayoutId } from '@/shared/utils';
+import { layoutId as toLayoutId } from '@/core/types';
+import type { LayoutEntry, LayoutId } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({ sourceLayoutId: z.string().min(1) });
+
+export const duplicateEntry = defineCommand({
+  type: 'library.duplicateEntry',
+  aggregate: 'library',
+  aggregateId: () => 'library',
+  payload: payloadSchema,
+  emitted: 'library.entryDuplicated',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.libraryDuplicateEntry',
+  middleware: { undoCapture: false, validate: true, analytics: true },
+  handle: (
+    payload,
+    ctx
+  ): Result<
+    {
+      value: LayoutId;
+      event: {
+        payload: { sourceLayoutId: LayoutId; newLayoutId: LayoutId; entry: LayoutEntry };
+      };
+    },
+    LayoutError
+  > => {
+    const sourceLayoutId = toLayoutId(payload.sourceLayoutId);
+    const source = ctx.aggregate.entries.find((e) => e.id === sourceLayoutId);
+    if (!source) {
+      return err(
+        layoutInvalidOperation(
+          'library.duplicateEntry',
+          `Source layout ${sourceLayoutId} not found`
+        )
+      );
+    }
+
+    const newLayoutId = generateLayoutId();
+    const now = Date.now();
+    const entry: LayoutEntry = {
+      id: newLayoutId,
+      name: `${source.name} (copy)`.slice(0, CONSTRAINTS.NAME_MAX_LENGTH),
+      createdAt: now,
+      modifiedAt: now,
+      author: ctx.aggregate.settings.authorName,
+      preview: { ...source.preview },
+    };
+
+    return ok({
+      value: newLayoutId,
+      event: { payload: { sourceLayoutId, newLayoutId, entry } },
+    });
+  },
+  apply: (event, draft) => {
+    draft.entries.push(event.payload.entry);
+  },
+});

--- a/src/core/cqrs/v2/domain/library/importLayout.test.ts
+++ b/src/core/cqrs/v2/domain/library/importLayout.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import type * as StorageModule from '@/core/storage';
+import { importLayout } from './importLayout';
+import { makeLibrary } from './_testHelpers';
+
+// computePreview lives in @/core/storage and reads from a real Layout.
+// Stub it so the test can pass an opaque layout payload.
+vi.mock('@/core/storage', async () => {
+  const actual = await vi.importActual<typeof StorageModule>('@/core/storage');
+  return {
+    ...actual,
+    computePreview: vi.fn(() => ({
+      drawerWidth: 6,
+      drawerDepth: 4,
+      drawerHeight: 7,
+      binCount: 3,
+      layerCount: 1,
+    })),
+  };
+});
+
+describe('v2 library.importLayout', () => {
+  it('builds an entry from the imported layout via computePreview', () => {
+    const library = makeLibrary();
+    const result = importLayout.handle(
+      { layout: { foo: 'bar' }, name: 'Imported' },
+      { aggregate: library }
+    );
+
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.event.payload.entry?.name).toBe('Imported');
+    expect(result.value.event.payload.entry?.preview.binCount).toBe(3);
+  });
+
+  it('apply() pushes the new entry onto the draft', () => {
+    const library = makeLibrary();
+    const result = importLayout.handle(
+      { layout: { foo: 'bar' }, name: 'X' },
+      { aggregate: library }
+    );
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(library, (draft) => {
+      importLayout.apply(
+        { type: 'library.entryCreated', payload: result.value.event.payload },
+        draft
+      );
+    });
+    expect(applied.entries).toHaveLength(2);
+    expect(applied.entries[1]).toEqual(result.value.event.payload.entry);
+  });
+});

--- a/src/core/cqrs/v2/domain/library/importLayout.ts
+++ b/src/core/cqrs/v2/domain/library/importLayout.ts
@@ -1,0 +1,61 @@
+/**
+ * library.importLayout — v2 (defineCommand) shape, library aggregate.
+ *
+ * Creates a new library entry from an imported Layout. Computes the
+ * preview from the layout via `computePreview`. Emits the same
+ * `library.entryCreated` event as createEntry so downstream subscribers
+ * (analytics, persistence) handle imports identically.
+ */
+
+import { z } from 'zod';
+import { ok } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
+import { generateLayoutId } from '@/shared/utils';
+import { computePreview } from '@/core/storage';
+import type { Layout, LayoutEntry } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({
+  layout: z.unknown(),
+  name: z.string().min(1).max(CONSTRAINTS.NAME_MAX_LENGTH),
+});
+
+export const importLayout = defineCommand({
+  type: 'library.importLayout',
+  aggregate: 'library',
+  aggregateId: () => 'library',
+  payload: payloadSchema,
+  emitted: 'library.entryCreated',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.libraryImportLayout',
+  middleware: { undoCapture: false, validate: true, analytics: true },
+  handle: (payload, ctx) => {
+    // Central validation treats `layout` as `unknown`; computePreview
+    // expects a Layout. Trust the caller (matches v1 — v1 handler also
+    // passes payload.layout straight to computePreview).
+    const layout = payload.layout as Layout;
+    const id = generateLayoutId();
+    const name = payload.name.slice(0, CONSTRAINTS.NAME_MAX_LENGTH);
+    const now = Date.now();
+    const entry: LayoutEntry = {
+      id,
+      name,
+      createdAt: now,
+      modifiedAt: now,
+      author: ctx.aggregate.settings.authorName,
+      preview: computePreview(layout),
+    };
+
+    return ok({
+      value: id,
+      event: { payload: { layoutId: id, name, entry } },
+    });
+  },
+  apply: (event, draft) => {
+    // Same shape as createEntry's apply — entry is always populated by
+    // the v2 handler but typed optional for v1-replay back-compat.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- entry is optional on the event type
+    if (event.payload.entry === undefined) return;
+    draft.entries.push(event.payload.entry);
+  },
+});

--- a/src/core/cqrs/v2/domain/library/importLayout.ts
+++ b/src/core/cqrs/v2/domain/library/importLayout.ts
@@ -52,10 +52,24 @@ export const importLayout = defineCommand({
     });
   },
   apply: (event, draft) => {
-    // Same shape as createEntry's apply — entry is always populated by
-    // the v2 handler but typed optional for v1-replay back-compat.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- entry is optional on the event type
-    if (event.payload.entry === undefined) return;
-    draft.entries.push(event.payload.entry);
+    // Same fallback as createEntry.apply(): v2 handler always populates
+    // `entry`, but v1-era persisted events have only {layoutId, name}.
+    // Reconstruct a best-effort entry from defaults so replay produces
+    // *something* instead of silently dropping the import event.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- entry is optional on the event type for v1 back-compat
+    const entry: LayoutEntry = event.payload.entry ?? {
+      id: event.payload.layoutId,
+      name: event.payload.name,
+      createdAt: 0,
+      modifiedAt: 0,
+      preview: {
+        drawerWidth: 6 as LayoutEntry['preview']['drawerWidth'],
+        drawerDepth: 4 as LayoutEntry['preview']['drawerDepth'],
+        drawerHeight: 7 as LayoutEntry['preview']['drawerHeight'],
+        binCount: 0,
+        layerCount: 1,
+      },
+    };
+    draft.entries.push(entry);
   },
 });

--- a/src/core/cqrs/v2/domain/library/renameEntry.test.ts
+++ b/src/core/cqrs/v2/domain/library/renameEntry.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
+import { renameEntry } from './renameEntry';
+import { makeLibrary, makeEntry } from './_testHelpers';
+
+describe('v2 library.renameEntry', () => {
+  it('captures previousName from the existing entry', () => {
+    const library = makeLibrary({
+      entries: [makeEntry('layout_1', 'Old')],
+    });
+    const result = renameEntry.handle(
+      { layoutId: 'layout_1', name: 'New' },
+      { aggregate: library }
+    );
+
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.event.payload).toEqual({
+      layoutId: 'layout_1',
+      name: 'New',
+      previousName: 'Old',
+    });
+  });
+
+  it('previousName is empty string when the entry does not exist', () => {
+    const library = makeLibrary();
+    const result = renameEntry.handle(
+      { layoutId: 'layout_gone', name: 'X' },
+      { aggregate: library }
+    );
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.event.payload.previousName).toBe('');
+  });
+
+  it('truncates name to NAME_MAX_LENGTH inside handle', () => {
+    const library = makeLibrary();
+    const long = 'x'.repeat(CONSTRAINTS.NAME_MAX_LENGTH + 50);
+    const result = renameEntry.handle({ layoutId: 'layout_1', name: long }, { aggregate: library });
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.event.payload.name.length).toBe(CONSTRAINTS.NAME_MAX_LENGTH);
+  });
+
+  it('apply() sets the entry name on the draft', () => {
+    const library = makeLibrary({
+      entries: [makeEntry('layout_1', 'Original')],
+    });
+    const result = renameEntry.handle(
+      { layoutId: 'layout_1', name: 'Renamed' },
+      { aggregate: library }
+    );
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(library, (draft) => {
+      renameEntry.apply(
+        { type: 'library.entryRenamed', payload: result.value.event.payload },
+        draft
+      );
+    });
+    expect(applied.entries[0].name).toBe('Renamed');
+  });
+});

--- a/src/core/cqrs/v2/domain/library/renameEntry.ts
+++ b/src/core/cqrs/v2/domain/library/renameEntry.ts
@@ -1,0 +1,43 @@
+/**
+ * library.renameEntry — v2 (defineCommand) shape, library aggregate.
+ *
+ * Captures previousName for undo replay. Truncates inside handle()
+ * even though the central schema enforces a max — keeps event payload
+ * identical to what apply() installs.
+ */
+
+import { z } from 'zod';
+import { ok } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
+import { layoutId as toLayoutId } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({
+  layoutId: z.string().min(1),
+  name: z.string().min(1).max(CONSTRAINTS.NAME_MAX_LENGTH),
+});
+
+export const renameEntry = defineCommand({
+  type: 'library.renameEntry',
+  aggregate: 'library',
+  aggregateId: () => 'library',
+  payload: payloadSchema,
+  emitted: 'library.entryRenamed',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.libraryRenameEntry',
+  middleware: { undoCapture: false, validate: true, analytics: true },
+  handle: (payload, ctx) => {
+    const layoutId = toLayoutId(payload.layoutId);
+    const entry = ctx.aggregate.entries.find((e) => e.id === layoutId);
+    const previousName = entry?.name ?? '';
+    const name = payload.name.slice(0, CONSTRAINTS.NAME_MAX_LENGTH);
+    return ok({
+      value: undefined,
+      event: { payload: { layoutId, name, previousName } },
+    });
+  },
+  apply: (event, draft) => {
+    const entry = draft.entries.find((e) => e.id === event.payload.layoutId);
+    if (entry) entry.name = event.payload.name;
+  },
+});

--- a/src/core/cqrs/v2/domain/library/setCloudShare.test.ts
+++ b/src/core/cqrs/v2/domain/library/setCloudShare.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import type { CloudShareInfo } from '@/core/types';
+import { setCloudShare } from './setCloudShare';
+import { makeLibrary, makeEntry } from './_testHelpers';
+
+const sampleShare: CloudShareInfo = {
+  id: 'share_abc',
+  deleteToken: 'token',
+  sharedAt: 1000,
+  permission: 'view',
+};
+
+describe('v2 library.setCloudShare', () => {
+  it('emits library.cloudShareUpdated with the share info', () => {
+    const library = makeLibrary();
+    const result = setCloudShare.handle(
+      { layoutId: 'layout_1', shareInfo: { ...sampleShare, url: 'https://example.com' } },
+      { aggregate: library }
+    );
+
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.event.payload.shareInfo.id).toBe('share_abc');
+  });
+
+  it('apply() sets cloudShare on the matching entry', () => {
+    const library = makeLibrary({ entries: [makeEntry('layout_1')] });
+    const result = setCloudShare.handle(
+      { layoutId: 'layout_1', shareInfo: { ...sampleShare, url: 'https://example.com' } },
+      { aggregate: library }
+    );
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(library, (draft) => {
+      setCloudShare.apply(
+        { type: 'library.cloudShareUpdated', payload: result.value.event.payload },
+        draft
+      );
+    });
+    expect(applied.entries[0].cloudShare?.id).toBe('share_abc');
+  });
+
+  it('apply() no-ops when the layoutId is unknown', () => {
+    const library = makeLibrary();
+    const result = setCloudShare.handle(
+      { layoutId: 'layout_gone', shareInfo: { ...sampleShare, url: 'https://example.com' } },
+      { aggregate: library }
+    );
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const applied = produce(library, (draft) => {
+      setCloudShare.apply(
+        { type: 'library.cloudShareUpdated', payload: result.value.event.payload },
+        draft
+      );
+    });
+    expect(applied).toEqual(library);
+  });
+});

--- a/src/core/cqrs/v2/domain/library/setCloudShare.ts
+++ b/src/core/cqrs/v2/domain/library/setCloudShare.ts
@@ -1,0 +1,48 @@
+/**
+ * library.setCloudShare — v2 (defineCommand) shape, library aggregate.
+ *
+ * Sets cloudShare metadata on the matching entry. The libraryPersistence
+ * subscriber (`cqrs/subscribers/libraryPersistence.ts`, wired in PR 1)
+ * listens for the emitted `library.cloudShareUpdated` event and persists
+ * the library snapshot — so the v2 path's behavior matches v1 end-to-end.
+ *
+ * No-ops silently when the layout id isn't in entries (same as v1).
+ */
+
+import { z } from 'zod';
+import { ok } from '@/core/result';
+import { layoutId as toLayoutId } from '@/core/types';
+import type { CloudShareInfo } from '@/core/types';
+import { defineCommand } from '../../defineCommand';
+
+const payloadSchema = z.object({
+  layoutId: z.string().min(1),
+  shareInfo: z.object({ id: z.string(), url: z.string() }).loose(),
+});
+
+export const setCloudShare = defineCommand({
+  type: 'library.setCloudShare',
+  aggregate: 'library',
+  aggregateId: () => 'library',
+  payload: payloadSchema,
+  emitted: 'library.cloudShareUpdated',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.librarySetCloudShare',
+  middleware: { undoCapture: false, validate: true, analytics: true },
+  handle: (payload) => {
+    const layoutId = toLayoutId(payload.layoutId);
+    // Central schema enforces {id, url} + .loose() — full CloudShareInfo
+    // shape (deleteToken, sharedAt, permission) is supplied by callers
+    // and trusted here. Cast through unknown because the validator only
+    // guarantees the two required fields.
+    const shareInfo = payload.shareInfo as unknown as CloudShareInfo;
+    return ok({
+      value: undefined,
+      event: { payload: { layoutId, shareInfo } },
+    });
+  },
+  apply: (event, draft) => {
+    const entry = draft.entries.find((e) => e.id === event.payload.layoutId);
+    if (entry) entry.cloudShare = event.payload.shareInfo;
+  },
+});

--- a/src/core/cqrs/v2/registry.ts
+++ b/src/core/cqrs/v2/registry.ts
@@ -39,6 +39,11 @@ import { deleteEntry as libraryDeleteEntry } from './domain/library/deleteEntry'
 import { switchActive as librarySwitchActive } from './domain/library/switchActive';
 import { updateEntry as libraryUpdateEntry } from './domain/library/updateEntry';
 import { setAuthorName as librarySetAuthorName } from './domain/library/setAuthorName';
+import { duplicateEntry as libraryDuplicateEntry } from './domain/library/duplicateEntry';
+import { setCloudShare as librarySetCloudShare } from './domain/library/setCloudShare';
+import { clearCloudShare as libraryClearCloudShare } from './domain/library/clearCloudShare';
+import { renameEntry as libraryRenameEntry } from './domain/library/renameEntry';
+import { importLayout as libraryImportLayout } from './domain/library/importLayout';
 
 type V2HandlerFn = (command: {
   type: string;
@@ -85,6 +90,11 @@ export const v2HandlerOverrides: Record<string, V2HandlerFn> = {
   [librarySwitchActive.type]: wrapV2Handler(librarySwitchActive) as V2HandlerFn,
   [libraryUpdateEntry.type]: wrapV2Handler(libraryUpdateEntry) as V2HandlerFn,
   [librarySetAuthorName.type]: wrapV2Handler(librarySetAuthorName) as V2HandlerFn,
+  [libraryDuplicateEntry.type]: wrapV2Handler(libraryDuplicateEntry) as V2HandlerFn,
+  [librarySetCloudShare.type]: wrapV2Handler(librarySetCloudShare) as V2HandlerFn,
+  [libraryClearCloudShare.type]: wrapV2Handler(libraryClearCloudShare) as V2HandlerFn,
+  [libraryRenameEntry.type]: wrapV2Handler(libraryRenameEntry) as V2HandlerFn,
+  [libraryImportLayout.type]: wrapV2Handler(libraryImportLayout) as V2HandlerFn,
 };
 
 /** All registered v2 commands, exposed for tests + future tooling. */
@@ -117,4 +127,9 @@ export const v2Commands = [
   librarySwitchActive,
   libraryUpdateEntry,
   librarySetAuthorName,
+  libraryDuplicateEntry,
+  librarySetCloudShare,
+  libraryClearCloudShare,
+  libraryRenameEntry,
+  libraryImportLayout,
 ] as const;


### PR DESCRIPTION
## Summary

PR 14 in the CQRS DX redesign sequence. **Library domain now 10/10 on v2.**

## Migrated

- **`library.duplicateEntry`** — validates source exists, generates new LayoutId, builds full entry with `(copy)` suffix (truncated to NAME_MAX_LENGTH). apply() pushes — no re-fetch needed.
- **`library.setCloudShare`** — emits `library.cloudShareUpdated`. The libraryPersistence subscriber (PR 1) listens for that event and persists the library snapshot, so end-to-end behavior matches v1 exactly. Cast through `unknown` for `CloudShareInfo` (central schema is loose so type doesn't guarantee full shape).
- **`library.clearCloudShare`** — same pattern; emits `library.cloudShareCleared`.
- **`library.renameEntry`** — captures previousName for undo replay, truncates inside handle.
- **`library.importLayout`** — creates entry from imported Layout via `computePreview`; emits the same `library.entryCreated` event as createEntry so downstream subscribers (analytics, persistence) handle imports identically.

## Tests

5 new sibling test files. Property tests cover handle correctness (source-not-found for duplicate, missing-id for cloud share, name truncation), apply round-trip, and the libraryPersistence subscriber interaction (no-op when layoutId unknown).

## Where this fits

| Status | Domain | PR |
|---|---|---|
| ✅ | bin (10/10) | #1543–#1548 |
| ✅ | layer (4/4) | #1550 |
| ✅ | category (3/3) | #1552 |
| ✅ | drawer + layout metadata (6/6) | #1554 |
| ✅ | library (10/10) | #1557 + this PR |
| ✅ | ui.* removed from CQRS | #1556 |
| ⚠️ | designer.save | still v1 (intentional) |
| ⚠️ | layout.restore | still v1 (replace-entire-root doesn't fit apply-on-draft) |

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:run` — full suite, **10422 tests pass** (was 10408; +14 new property tests)
- [x] `pnpm lint` — clean
- [x] `pnpm knip` — clean