### PR TITLE
fix(cqrs): build cqrsMutations lazily to avoid chunk-init undefined bus

### DIFF
--- a/src/shared/contexts/MutationsContext.tsx
+++ b/src/shared/contexts/MutationsContext.tsx
@@ -91,8 +91,14 @@ export interface Mutations {
 
 const MutationsContext = createContext<Mutations | null>(null);
 
-/** CQRS-backed mutations singleton (stable across renders) */
-const cqrsMutations: Mutations = createCqrsMutations(commandBus);
+// Lazy: building at module init would capture `commandBus` before its
+// chunk has evaluated under chunk-level static-import cycles (#1466),
+// so every mutation would close over `undefined` and throw on dispatch.
+let cqrsMutationsSingleton: Mutations | null = null;
+function getCqrsMutations(): Mutations {
+  cqrsMutationsSingleton ??= createCqrsMutations(commandBus);
+  return cqrsMutationsSingleton;
+}
 
 /**
  * Hook to access mutations.
@@ -100,7 +106,7 @@ const cqrsMutations: Mutations = createCqrsMutations(commandBus);
  */
 export function useMutations(): Mutations {
   const context = useContext(MutationsContext);
-  return context ?? cqrsMutations;
+  return context ?? getCqrsMutations();
 }
 
 /**
@@ -108,7 +114,7 @@ export function useMutations(): Mutations {
  * Used to provide mutations through React context for collab mode compatibility.
  */
 export function LocalMutationsProvider({ children }: { children: ReactNode }) {
-  const mutations = useMemo<Mutations>(() => cqrsMutations, []);
+  const mutations = useMemo<Mutations>(() => getCqrsMutations(), []);
 
   return <MutationsContext.Provider value={mutations}>{children}</MutationsContext.Provider>;
 }


### PR DESCRIPTION
## Summary

Hotfix for #1558. Bin creation broke in 4.60.0 with `Cannot read properties of undefined (reading 'dispatch')` inside `addBin`.

## Root cause

Chunk-level static-import cycle (#1466 pattern):

- `main` statically imports `useMutations` from `@/shared/contexts`
- Vite placed `MutationsContext` + `mutationsAdapter` into the `CollabProvider` chunk
- `MutationsContext` eagerly called `createCqrsMutations(commandBus)` at module init, capturing `commandBus` into every mutation closure
- `commandBus` lives in the `main` chunk; when `CollabProvider` chunk initialized during `main`'s evaluation, `commandBus` was still `undefined`, so every mutation closed over `undefined` and threw on dispatch

Verified by inspecting the production sourcemaps: `MutationsContext.tsx` and `mutationsAdapter.ts` are owned by `CollabProvider-*.js`, while `bus/commandBus.ts` is owned by `main-*.js`.

## Fix

Build the `cqrsMutations` singleton lazily on first read so the captured `commandBus` reference is taken after all chunks have evaluated.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run src/shared/contexts/ src/core/cqrs/integration/` — 10 tests pass
- [x] Production build succeeds and chunk split unchanged
- [ ] Manual verification: draw a bin in deployed preview

Closes #1558