### PR TITLE
refactor(cqrs): strip rot-bait comments across v2 files

### DIFF
--- a/src/core/cqrs/commands/index.ts
+++ b/src/core/cqrs/commands/index.ts
@@ -66,8 +66,8 @@ export type { DesignerCommand, DesignerSaveCommand } from './designerCommands';
 
 export type { RestoreCommand, RestoreLayoutCommand } from './restoreCommands';
 
-// UI commands removed in PR 12 (telemetry exit) — they're now direct
-// trackEvent() calls; see src/shared/analytics/posthog/trackEvent.ts.
+// ui.* events flow through src/shared/analytics/posthog/trackEvent.ts
+// directly — they're not commands (no aggregate, no apply, no undo).
 
 import type { BinCommand } from './binCommands';
 import type { LayerCommand } from './layerCommands';

--- a/src/core/cqrs/commands/index.ts
+++ b/src/core/cqrs/commands/index.ts
@@ -66,8 +66,9 @@ export type { DesignerCommand, DesignerSaveCommand } from './designerCommands';
 
 export type { RestoreCommand, RestoreLayoutCommand } from './restoreCommands';
 
-// ui.* events flow through src/shared/analytics/posthog/trackEvent.ts
-// directly — they're not commands (no aggregate, no apply, no undo).
+// ui.* PostHog analytics events flow through trackEvent() in
+// `@/shared/analytics/posthog` directly — they're not CQRS commands
+// (no aggregate, no apply, no undo).
 
 import type { BinCommand } from './binCommands';
 import type { LayerCommand } from './layerCommands';

--- a/src/core/cqrs/events/binEvents.ts
+++ b/src/core/cqrs/events/binEvents.ts
@@ -36,12 +36,9 @@ export type BinMovedToStagingEvent = BaseDomainEvent<
   { readonly id: BinId; readonly previousLayerId: LayerId }
 >;
 
-/**
- * `height` was added in the v2 migration so apply() can reproduce the
- * full mutation without consulting current layout state. v1-era persisted
- * events have no height — the optional shape keeps them readable; the
- * v2 apply() falls back to leaving height untouched when missing.
- */
+// `height` is optional only for back-compat with persisted events that
+// predate the field; new events always include it. apply() leaves
+// `bin.height` untouched when reading an event without it.
 export type BinMovedFromStagingEvent = BaseDomainEvent<
   'bin.movedFromStaging',
   {
@@ -53,13 +50,10 @@ export type BinMovedFromStagingEvent = BaseDomainEvent<
   }
 >;
 
-/**
- * `fillType`, `width`, `depth` were added in the v2 migration so the fill
- * analytics subscriber can derive what the v1 `_fillMeta` field used to
- * carry. v1-era persisted events have no `fillType` — the subscriber
- * silently ignores those (re-emitting them would distort current-period
- * metrics).
- */
+// `fillType`, `width`, `depth` carry the metadata the fill-analytics
+// subscriber needs to distinguish uniform vs gap fills. Optional only
+// for back-compat with persisted events that predate the fields; the
+// subscriber silently ignores events without `fillType`.
 export type LayerFilledEvent = BaseDomainEvent<
   'bin.layerFilled',
   {

--- a/src/core/cqrs/events/drawerEvents.ts
+++ b/src/core/cqrs/events/drawerEvents.ts
@@ -5,12 +5,10 @@
 import type { BaseDomainEvent } from '../types';
 import type { BinId, Drawer, BaseplateParams } from '@/core/types';
 
-/**
- * `displacedBinIds` was added in the v2 migration so apply() can target
- * the exact bins displaced by the drawer-shrink cascade. v1-era persisted
- * events have only the `binsDisplacedToStaging` count — replay against
- * those falls back to leaving bins untouched (matches prior behavior).
- */
+// `displacedBinIds` records the exact set of bins displaced by a
+// drawer-shrink cascade. Optional only for back-compat with persisted
+// events that carried only the count; replay leaves bins untouched
+// in that case.
 export type DrawerUpdatedEvent = BaseDomainEvent<
   'drawer.updated',
   {

--- a/src/core/cqrs/events/layerEvents.ts
+++ b/src/core/cqrs/events/layerEvents.ts
@@ -16,13 +16,10 @@ export type LayerUpdatedEvent = BaseDomainEvent<
   }
 >;
 
-/**
- * `displacedBinIds` was added in the v2 migration so apply() can target
- * the exact set of bins that moved to staging. v1-era persisted events
- * have no `displacedBinIds` — replay against those falls back to the
- * "all bins on layer" heuristic in projection/replay.ts (lossy if the
- * layout has diverged since the event was emitted, but no worse than v1).
- */
+// `displacedBinIds` records the exact set of bins that cascaded to
+// staging when the layer was deleted. Optional only for back-compat
+// with persisted events that predate the field — projection/replay.ts
+// falls back to the "all bins on layer" heuristic in that case.
 export type LayerDeletedEvent = BaseDomainEvent<
   'layer.deleted',
   {

--- a/src/core/cqrs/events/libraryEvents.ts
+++ b/src/core/cqrs/events/libraryEvents.ts
@@ -8,12 +8,9 @@
 import type { BaseDomainEvent } from '../types';
 import type { LayoutEntry, LayoutId, CloudShareInfo } from '@/core/types';
 
-/**
- * `entry` was added in the v2 migration so apply() can push the full
- * LayoutEntry deterministically. v1-era persisted events have only
- * {layoutId, name} — replay against those would need to reconstruct the
- * entry from defaults, which is acceptable for the audit trail but lossy.
- */
+// `entry` carries the full LayoutEntry so apply() can push
+// deterministically. Optional only for back-compat with persisted
+// events that carried only {layoutId, name}.
 export type LibraryEntryCreatedEvent = BaseDomainEvent<
   'library.entryCreated',
   { readonly layoutId: LayoutId; readonly name: string; readonly entry?: LayoutEntry }
@@ -24,11 +21,9 @@ export type LibraryEntryDeletedEvent = BaseDomainEvent<
   { readonly layoutId: LayoutId }
 >;
 
-/**
- * `entry` was added in the v2 migration so apply() can push the duplicated
- * entry deterministically. v1-era persisted events have only the ids — the
- * `entry?` shape lets v1 events still satisfy the type.
- */
+// `entry` carries the duplicated LayoutEntry so apply() can push it
+// deterministically. Optional only for back-compat with persisted
+// events that carried only the ids.
 export type LibraryEntryDuplicatedEvent = BaseDomainEvent<
   'library.entryDuplicated',
   {

--- a/src/core/cqrs/handlers/index.ts
+++ b/src/core/cqrs/handlers/index.ts
@@ -12,17 +12,14 @@ import { drawerHandlers } from './drawerHandlers';
 import { libraryHandlers } from './libraryHandlers';
 import { designerHandlers } from './designerHandlers';
 import { restoreHandlers } from './restoreHandlers';
-// UI handlers removed in PR 12 (telemetry exit) — ui.* commands are now
-// direct trackEvent() calls instead of bus dispatches.
 import { v2HandlerOverrides } from '../v2/registry';
 
 export { resetVersionCounters } from './shared';
 
 type HandlerFn = (command: never) => CommandResult<unknown, DomainEvent>;
 
-// v2 overrides spread LAST so migrated commands route through defineCommand
-// wrappers instead of the v1 handler. Other commands keep the v1 path until
-// their domain migrates.
+// v2 overrides spread LAST: migrated commands route through their
+// defineCommand wrappers; the rest keep the legacy handler path.
 const handlerRegistry: Record<string, HandlerFn> = {
   ...binHandlers,
   ...layerHandlers,

--- a/src/core/cqrs/middleware/middlewareConfig.test.ts
+++ b/src/core/cqrs/middleware/middlewareConfig.test.ts
@@ -67,9 +67,6 @@ describe('getMiddlewareFlags', () => {
     }
   });
 
-  // 'ui' profile and ui.* commands removed in PR 12 (telemetry exit) —
-  // ui.* events are now direct trackEvent() calls, not bus dispatches.
-
   it('returns restore profile for layout.restore', () => {
     const flags = getMiddlewareFlags('layout.restore');
     expect(flags).toEqual({ validation: false, undo: false });

--- a/src/core/cqrs/projection/replay.ts
+++ b/src/core/cqrs/projection/replay.ts
@@ -1,8 +1,10 @@
 /**
- * Event Replay — Rebuild state from an event stream.
+ * Event Replay — rebuild state from an event stream.
  *
- * Primarily a debugging/dev tool for v1. Applies domain events
- * to a base layout state to reconstruct what happened.
+ * Debugging/dev tool. Pure-function reducer over DomainEvent — no
+ * dependency on the live store; safe to run against arbitrary baseline
+ * + history. Operates on the legacy event stream, separate from the
+ * v2 apply()/draft path.
  */
 
 import type { BinId, Layout } from '@/core/types';
@@ -54,9 +56,8 @@ export function applyEvent(layout: Layout, event: DomainEvent): Layout {
         bin.layerId = event.payload.layerId;
         bin.x = gridUnits(event.payload.x);
         bin.y = gridUnits(event.payload.y);
-        // height was added to the payload in v2 (defineCommand migration).
-        // v1-era persisted events have no height — leave it untouched in
-        // that case (preserves prior replay behavior).
+        // `height` is optional for back-compat with persisted events
+        // that predate the field; leave it untouched in that case.
         if (event.payload.height !== undefined) {
           bin.height = heightUnits(event.payload.height);
         }
@@ -87,12 +88,11 @@ export function applyEvent(layout: Layout, event: DomainEvent): Layout {
     case 'layer.deleted': {
       const deletedLayerId = event.payload.layer.id;
       next.layers = next.layers.filter((l) => l.id !== deletedLayerId);
-      // v2 events carry the exact displacedBinIds — use them when present
-      // so replay reproduces the cascade even if the layout has diverged.
-      // v1 events fall back to the "all bins on the deleted layer" heuristic
-      // (matches layerActions.ts and the prior replay behavior).
-      // Local annotation: TS doesn't always narrow optional fields cleanly
-      // through the DomainEvent discriminated union, so be explicit here.
+      // Use the explicit `displacedBinIds` set when present so replay
+      // reproduces the cascade even against a divergent layout; fall
+      // back to "all bins on the deleted layer" for events that predate
+      // the field. (Local annotation: TS doesn't narrow optional fields
+      // cleanly through the DomainEvent discriminated union.)
       const ids: ReadonlyArray<BinId> | undefined = event.payload.displacedBinIds;
       if (ids !== undefined) {
         const idSet = new Set<BinId>(ids);

--- a/src/core/cqrs/v2/Mutations.ts
+++ b/src/core/cqrs/v2/Mutations.ts
@@ -3,15 +3,14 @@
  *
  * Maps each command in the registry to a callable keyed by the command's
  * literal `type` string. Payload, return value, and error union are all
- * inferred per command — no `as T` casts, no central interface that
- * must be hand-maintained alongside the registry.
+ * inferred per command — no `as T` casts, no central interface to
+ * hand-maintain alongside the registry.
  *
- * Usage (target shape, no runtime in this PR):
  *   const mutations = createMutations(registry, commandBus);
  *   mutations['bin.add']({ ... });   // Result<BinId, ValidationError>
  *
- * PR 2 ships the type only — runtime `createMutations()` lands when the
- * first domain (bin/) migrates and needs a real dispatcher.
+ * Type only today; runtime `createMutations()` lands when callers move
+ * off the existing `MutationsContext` adapter.
  */
 
 import type { Result } from '@/core/result';

--- a/src/core/cqrs/v2/domain/bin/addBin.ts
+++ b/src/core/cqrs/v2/domain/bin/addBin.ts
@@ -1,12 +1,6 @@
 /**
- * bin.add command — v2 (defineCommand) shape.
- *
- * Mirrors the contract of the v1 `handleAddBin` + `useLayoutStore.addBin`
- * pair, but split along v2's boundary:
- * - `handle()`: validate against frozen layout snapshot, generate the new
- *   BinId, return the full `Bin` object inside the event payload.
- * - `apply()`: push the bin onto the layout draft. No re-read needed —
- *   the event carries everything.
+ * Add a bin: validate against the layout snapshot, generate a BinId, emit
+ * the full Bin in the event so apply() is a deterministic push.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/bin/clearLayer.ts
+++ b/src/core/cqrs/v2/domain/bin/clearLayer.ts
@@ -1,12 +1,8 @@
 /**
- * bin.clearLayer — v2 (defineCommand) shape.
- *
- * Capture the full set of bins being removed in the event payload so undo
- * can restore them. v1 reported `binsRemoved` as a count — v2 keeps that
- * for backward compatibility but the source of truth is `bins.length`.
- *
- * No validation: clearing an empty layer is a no-op (emits an event with
- * an empty bins array, which apply() short-circuits on).
+ * Clear all bins on a layer. Captures the full set in the event payload
+ * so undo can restore them; `binsRemoved: number` is preserved for v1
+ * consumer compatibility even though it duplicates `bins.length`.
+ * Empty layer is a valid no-op.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/bin/deleteBin.ts
+++ b/src/core/cqrs/v2/domain/bin/deleteBin.ts
@@ -1,9 +1,6 @@
 /**
- * bin.delete — v2 (defineCommand) shape.
- *
- * Capture the bin in the event payload before removing it. Replay-complete:
- * `apply()` filters the bin from the draft, but the full bin lives in the
- * event for undo (and as the audit-log record of what was deleted).
+ * Delete a bin. The event payload carries the full Bin so undo can
+ * reconstruct it (and so the audit log records what was deleted).
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/bin/deleteBins.ts
+++ b/src/core/cqrs/v2/domain/bin/deleteBins.ts
@@ -1,13 +1,7 @@
 /**
- * bin.deleteBatch — v2 (defineCommand) shape.
- *
- * Capture the bins being deleted in the event payload (full Bin objects)
- * so undo replay reconstructs them, not just their ids. v1 was lenient
- * about empty-or-missing ids — v2 mirrors that: an empty result is valid,
- * just emits no event.
- *
- * The handler only emits when at least one of the requested ids actually
- * matched an existing bin — keeps the event log free of no-op deletions.
+ * Delete multiple bins. The event payload carries the full Bin objects
+ * so undo can reconstruct them, not just their ids. Lenient on
+ * empty-or-missing ids: empty `bins` is a valid no-op result.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/bin/duplicateBin.ts
+++ b/src/core/cqrs/v2/domain/bin/duplicateBin.ts
@@ -1,14 +1,9 @@
 /**
- * bin.duplicate — v2 (defineCommand) shape.
- *
- * Migration note: the per-command refactor for bin.duplicate moves the
- * 5-placement search out of the v1 store mutation
- * (binActions.duplicateBin:139-163) into handle(). The event payload
- * carries the resolved {newBin}, so apply() is a dumb push and replay
- * does not re-run the search against potentially-different layout state.
- *
- * Search order (matches v1): right -> below -> left -> above -> staging.
- * Staging-source bins always duplicate to staging at (0, 0).
+ * Duplicate a bin. handle() runs the placement search (right → below →
+ * left → above → staging fallback) and emits the resolved {newBin} so
+ * apply() is a deterministic push — replay won't re-run the search
+ * against possibly-divergent layout state. Staging-source bins always
+ * duplicate to staging at (0, 0).
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/bin/fillGaps.ts
+++ b/src/core/cqrs/v2/domain/bin/fillGaps.ts
@@ -1,15 +1,12 @@
 /**
- * bin.fillGaps — v2 (defineCommand) shape.
+ * Fill empty gaps in a layer. Sibling to fillLayer; emits the same
+ * `bin.layerFilled` event but with `fillType: 'gaps'` so the analytics
+ * subscriber can distinguish the two.
  *
- * Sibling to fillLayer. Same shape: planning runs in handle() against the
- * frozen layout snapshot; the resulting bins are encoded in the event
- * payload with `fillType: 'gaps'` so the analytics subscriber can
- * distinguish uniform vs gap-fill operations.
- *
- * Returns `result.addedCount` (matching v1's return). Today this equals
- * `bins.length`, but the underlying helper distinguishes the two for
- * forward compatibility — keep the v1 return shape so callers that
- * already destructure `addedCount` aren't broken if the helper diverges.
+ * Returns `result.addedCount`. Today this equals `bins.length`, but the
+ * underlying helper distinguishes them for forward compatibility — keep
+ * this shape so callers that already destructure `addedCount` aren't
+ * broken if the helper diverges.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/bin/fillLayer.ts
+++ b/src/core/cqrs/v2/domain/bin/fillLayer.ts
@@ -1,13 +1,9 @@
 /**
- * bin.fillLayer — v2 (defineCommand) shape.
- *
- * The planning helper `fillAllWithSize` is called inside handle() against
- * the frozen layout snapshot. The resulting bins are encoded in the event
- * payload (along with `fillType: 'uniform'`, `width`, and `depth`) so
- * apply() is a deterministic push and the fill-analytics subscriber has
- * everything it needs without poking at transient store state.
- *
- * Replaces v1's `useLayoutStore.fillLayer` + `_fillMeta` side-channel.
+ * Fill a layer with uniform-sized bins. `fillAllWithSize` runs against
+ * the frozen layout snapshot; the resulting bins go into the event
+ * payload alongside `fillType: 'uniform'`, `width`, `depth` so apply()
+ * is a deterministic push and the fill-analytics subscriber has
+ * everything it needs without reading transient store state.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/bin/moveBinFromStaging.ts
+++ b/src/core/cqrs/v2/domain/bin/moveBinFromStaging.ts
@@ -1,14 +1,9 @@
 /**
- * bin.moveFromStaging — v2 (defineCommand) shape.
- *
- * Migration note: the v1 event payload carried only `{id, layerId, x, y}`
- * which left replay drift — the bin's height needed to be re-derived from
- * the layer at apply time, and projection/replay.ts didn't update height
- * at all. The v2 event payload includes the resolved height so apply() is
- * deterministic without consulting the current layout state.
- *
- * `height` is optional on the type for backward compatibility with v1
- * persisted events; the v2 handler always populates it.
+ * Move a bin out of staging into a layer. handle() resolves the target
+ * layer's height (the bin's new height) and includes it in the event
+ * payload so apply() doesn't need to consult layout state. Tightens
+ * v1 by rejecting non-staging source bins (v1 silently re-stamped
+ * height — a footgun).
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/bin/moveBinToStaging.ts
+++ b/src/core/cqrs/v2/domain/bin/moveBinToStaging.ts
@@ -1,9 +1,7 @@
 /**
- * bin.moveToStaging — v2 (defineCommand) shape.
- *
- * Capture the previousLayerId so undo can restore the bin to its prior
- * layer placement. The bin itself stays in the layout — only its layerId
- * changes to STAGING_ID.
+ * Move a bin to staging. The bin stays in the layout; only `layerId`
+ * changes to STAGING_ID. Captures `previousLayerId` so undo restores
+ * the prior placement.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/bin/updateBin.ts
+++ b/src/core/cqrs/v2/domain/bin/updateBin.ts
@@ -1,11 +1,8 @@
 /**
- * bin.update — v2 (defineCommand) shape.
- *
- * Validate the bin exists, validate the merged placement when spatial
- * fields change (matching the v1 store action's logic exactly), and emit
- * `bin.updated` with both `changes` (the requested updates) and `previous`
- * (the prior values for those fields) so undo replay can reconstruct
- * either direction.
+ * Update bin fields. Validates merged placement against the layout when
+ * spatial fields change (same gate as the v1 store action); the event
+ * carries both `changes` and `previous` so undo can revert in either
+ * direction.
  */
 
 import { z } from 'zod';
@@ -109,7 +106,6 @@ export const updateBin = defineCommand({
     const merged: Bin = { ...existing, ...changes };
 
     // Validate placement when spatial properties change for on-grid bins.
-    // Mirrors the v1 store-action gate exactly.
     const spatial =
       changes.x !== undefined ||
       changes.y !== undefined ||

--- a/src/core/cqrs/v2/domain/category/addCategory.ts
+++ b/src/core/cqrs/v2/domain/category/addCategory.ts
@@ -1,8 +1,6 @@
 /**
- * category.add — v2 (defineCommand) shape.
- *
- * Validates the per-layout category count limit, generates the new
- * CategoryId, returns the full Category in the event payload.
+ * Add a category. Validates the per-layout count limit; the event
+ * payload carries the full Category so apply() is a deterministic push.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/category/deleteCategory.ts
+++ b/src/core/cqrs/v2/domain/category/deleteCategory.ts
@@ -1,17 +1,9 @@
 /**
- * category.delete — v2 (defineCommand) shape.
- *
- * Per-command refactor (per Pass 3 plan): this is precondition
- * enforcement, not a cascade. v1 rejects when any bin references the
- * category — v2 keeps that behavior exactly. handle() validates in this
- * order (matches v1's order in createCategoryActions.deleteCategory so
- * the same input produces the same first-failure error):
- *   1. no bins reference it
- *   2. layout still has at least CATEGORIES_MIN categories afterward
- *   3. category exists
- *
- * apply() filters the category out of the draft. No bin reassignment
- * happens because deletion is blocked when any bin uses it.
+ * Delete a category. Precondition enforcement, NOT a cascade — handle()
+ * rejects when any bin references the category. Validation order is
+ * deliberate (in-use → min-count → exists) so the first-failure error
+ * matches what users have been seeing for years; reordering would break
+ * tests that assert specific failure types.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/category/updateCategory.ts
+++ b/src/core/cqrs/v2/domain/category/updateCategory.ts
@@ -1,9 +1,7 @@
 /**
- * category.update — v2 (defineCommand) shape.
- *
- * Validates the category exists, captures previous values for the fields
- * being updated, and emits `category.updated`. apply() does Object.assign
- * over the matching draft entry.
+ * Update category fields. Captures `previous` values for the fields
+ * being changed so undo can revert. apply() Object.assigns onto the
+ * matching draft entry.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/drawer/updateDrawer.ts
+++ b/src/core/cqrs/v2/domain/drawer/updateDrawer.ts
@@ -1,18 +1,15 @@
 /**
- * drawer.update — v2 (defineCommand) shape.
+ * Update drawer dims and cascade out-of-bounds bins to staging.
  *
- * Per-command refactor (per Pass 3 plan):
- * 1. Clamping (width/depth in [GRID_MIN, GRID_MAX], height >= sum of layer
- *    heights) moves into handle() so the event payload's `changes` always
- *    reflects the value that will actually be stored.
- * 2. The bin-displacement cascade (out-of-bounds bins moved to STAGING)
- *    is precomputed in handle() and the displaced IDs are encoded in the
- *    event payload as `displacedBinIds`. apply() applies the drawer change
- *    AND the displacement deterministically — no subscriber needed.
+ * Clamping (width/depth in [GRID_MIN, GRID_MAX], height >= sum of layer
+ * heights) happens in handle() so the event's `changes` always reflects
+ * the value that lands. The displaced bin set is also precomputed in
+ * handle() and goes into the event as `displacedBinIds`, so apply()
+ * applies the drawer change AND the displacement deterministically.
  *
- * Event payload widened from v1's `binsDisplacedToStaging: number` to
- * `displacedBinIds: ReadonlyArray<BinId>`. v1-era persisted events without
- * displacedBinIds keep prior replay behavior (heuristic in projection/replay.ts).
+ * `displacedBinIds` is optional on the event type for back-compat with
+ * persisted events that predate the field (those carried only the
+ * count); replay leaves bin state untouched in that case.
  */
 
 import { z } from 'zod';
@@ -71,8 +68,8 @@ export const updateDrawer = defineCommand({
     const layout = ctx.aggregate;
     const drawer = layout.drawer;
 
-    // Resolve clamped/derived values up-front so the event records exactly
-    // what apply() will install. Mirrors the v1 setLocal mutator's logic.
+    // Resolve clamped/derived values up-front so the event records
+    // exactly what apply() will install.
     const changes: Partial<Drawer> = {};
     if (payload.width !== undefined) {
       changes.width = gridUnits(clamp(payload.width, CONSTRAINTS.GRID_MIN, CONSTRAINTS.GRID_MAX));

--- a/src/core/cqrs/v2/domain/layer/addLayer.ts
+++ b/src/core/cqrs/v2/domain/layer/addLayer.ts
@@ -1,10 +1,8 @@
 /**
- * layer.add — v2 (defineCommand) shape.
- *
- * Validates layer-count limit and remaining drawer height before
- * generating a Layer. The default-layer-height preference is read from
- * the settings store inside handle (settings are config-not-state, so
- * not part of the layout aggregate snapshot).
+ * Add a layer. Validates layer-count limit and remaining drawer height
+ * before generating one. Reads `defaultLayerHeight` from the settings
+ * store directly — settings are config-not-state, outside the layout
+ * aggregate snapshot.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/layer/deleteLayer.ts
+++ b/src/core/cqrs/v2/domain/layer/deleteLayer.ts
@@ -1,16 +1,10 @@
 /**
- * layer.delete — v2 (defineCommand) shape.
- *
- * Per-command refactor: v1's store action cascaded by remapping bins on
- * the deleted layer to STAGING_ID. The v1 event payload only carried
- * `{layer, deletedBinCount}` — the actual displaced bin IDs were lost,
- * so replay against a divergent layout produced the wrong cascade. v2
- * widens the payload with `displacedBinIds` so apply() can target the
- * exact set deterministically.
- *
- * `deletedBinCount` is preserved on the payload for v1 consumer
- * compatibility (analytics / audit log) even though it's now derivable
- * from `displacedBinIds.length`.
+ * Delete a layer. Bins on the layer cascade to STAGING_ID. The event
+ * payload's `displacedBinIds` records the exact set so apply() can
+ * target deterministically (replay would otherwise re-derive the set
+ * against possibly-divergent layout state). `deletedBinCount` is kept
+ * for downstream consumer compatibility even though it duplicates the
+ * array length.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/layer/reorderLayers.ts
+++ b/src/core/cqrs/v2/domain/layer/reorderLayers.ts
@@ -1,13 +1,9 @@
 /**
- * layer.reorder — v2 (defineCommand) shape.
- *
- * Validates indices and runs the reorder collision check against the
- * frozen layout snapshot before emitting. apply() does the actual array
- * splice on the draft.
- *
- * The event payload (`{fromIndex, toIndex}`) is sufficient for replay:
- * given the layout state at replay time, applying the same move
- * deterministically produces the same ordering.
+ * Reorder layers. Validates indices and runs the collision check against
+ * the layout snapshot before emitting; apply() does the splice on the
+ * draft. Self-move (`fromIndex === toIndex`) succeeds and emits but
+ * apply() short-circuits — the event in the audit log records that the
+ * user attempted a reorder.
  */
 
 import { z } from 'zod';
@@ -40,10 +36,6 @@ export const reorderLayers = defineCommand({
     const { fromIndex, toIndex } = payload;
     const layout = ctx.aggregate;
 
-    // Self-move: succeed and emit; apply is a no-op. Matches v1 (the v1
-    // store action returns OK without doing anything; the v1 handler
-    // emits the event regardless). The event in the audit log is benign
-    // signal that the user attempted a reorder.
     if (fromIndex === toIndex) {
       return ok({ value: undefined, event: { payload: { fromIndex, toIndex } } });
     }

--- a/src/core/cqrs/v2/domain/layer/updateLayer.ts
+++ b/src/core/cqrs/v2/domain/layer/updateLayer.ts
@@ -1,11 +1,8 @@
 /**
- * layer.update — v2 (defineCommand) shape.
- *
- * Per-command refactor: the v1 store action did the height-clamp inside
- * the setLocal mutator (so clamping was a hidden side effect of the
- * write). v2 inlines the clamp into handle so the event payload's
- * `changes.height` always reflects the value that will actually be
- * stored — no replay drift between native and apply paths.
+ * Update layer fields. height is clamped against the remaining drawer
+ * space (drawer.height minus other layers' heights) inside handle() so
+ * the event payload's `changes.height` always equals the value that
+ * lands.
  */
 
 import { z } from 'zod';
@@ -66,8 +63,6 @@ export const updateLayer = defineCommand({
     const changes: Partial<Layer> = {};
     if (payload.updates.name !== undefined) changes.name = payload.updates.name;
     if (payload.updates.height !== undefined) {
-      // Inline the clamp so the event records the value that will actually
-      // be stored. Other layers' heights cap how much room remains.
       const othersHeight = layout.layers
         .filter((l) => l.id !== id)
         .reduce((sum, l) => sum + (l.height as number), 0);

--- a/src/core/cqrs/v2/domain/layout/setBaseplateParams.ts
+++ b/src/core/cqrs/v2/domain/layout/setBaseplateParams.ts
@@ -1,9 +1,8 @@
 /**
- * layout.setBaseplateParams — v2 (defineCommand) shape.
- *
- * Clamps padding/magnet/baseplate-grid fields to their valid ranges
- * (matches v1 setBaseplateParams). The full normalized BaseplateParams
- * object goes into the event payload alongside the previous state.
+ * Set baseplate params. handle() clamps padding (≥ 0), magnet diameter
+ * ([0.5, 20] mm), magnet depth ([0.5, 10] mm), and optional baseplate
+ * grid dims ([0.5, 50]). The normalized object goes into the event
+ * alongside `previousParams` for undo.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/layout/setGridUnitMm.ts
+++ b/src/core/cqrs/v2/domain/layout/setGridUnitMm.ts
@@ -1,7 +1,4 @@
-/**
- * layout.setGridUnitMm — v2 (defineCommand) shape.
- * Clamps to [1, 200] mm. Captures previousMm for undo replay.
- */
+/** Set the grid unit in mm. Clamps to [1, 200]; captures `previousMm` for undo. */
 
 import { z } from 'zod';
 import { ok } from '@/core/result';

--- a/src/core/cqrs/v2/domain/layout/setHeightUnitMm.ts
+++ b/src/core/cqrs/v2/domain/layout/setHeightUnitMm.ts
@@ -1,7 +1,4 @@
-/**
- * layout.setHeightUnitMm — v2 (defineCommand) shape.
- * Clamps to [1, 50] mm. Captures previousMm for undo replay.
- */
+/** Set the height unit in mm. Clamps to [1, 50]; captures `previousMm` for undo. */
 
 import { z } from 'zod';
 import { ok } from '@/core/result';

--- a/src/core/cqrs/v2/domain/layout/setName.ts
+++ b/src/core/cqrs/v2/domain/layout/setName.ts
@@ -1,8 +1,6 @@
 /**
- * layout.setName — v2 (defineCommand) shape.
- *
- * Truncates to NAME_MAX_LENGTH (matches v1 behavior). Captures previousName
- * for undo replay.
+ * Set the layout name. Truncates to NAME_MAX_LENGTH; captures
+ * `previousName` for undo.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/layout/setPrintBedSize.ts
+++ b/src/core/cqrs/v2/domain/layout/setPrintBedSize.ts
@@ -1,8 +1,6 @@
 /**
- * layout.setPrintBedSize — v2 (defineCommand) shape.
- *
- * Clamps both `size` and optional `depth` to [42, 500] mm. Captures
- * previousSize + previousDepth for undo replay.
+ * Set print-bed dimensions. Clamps both `size` and optional `depth` to
+ * [42, 500] mm; captures `previousSize` and `previousDepth` for undo.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/library/clearCloudShare.ts
+++ b/src/core/cqrs/v2/domain/library/clearCloudShare.ts
@@ -1,9 +1,7 @@
 /**
- * library.clearCloudShare — v2 (defineCommand) shape, library aggregate.
- *
- * Clears cloudShare metadata on the matching entry. The
- * libraryPersistence subscriber listens for the emitted
- * `library.cloudShareCleared` event and persists the library snapshot.
+ * Clear cloudShare metadata from a library entry. The
+ * `cqrs/subscribers/libraryPersistence` subscriber listens for
+ * `library.cloudShareCleared` and persists the library snapshot.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/library/createEntry.ts
+++ b/src/core/cqrs/v2/domain/library/createEntry.ts
@@ -1,14 +1,7 @@
 /**
- * library.createEntry — v2 (defineCommand) shape, library aggregate.
- *
- * First library-aggregate v2 command. The runtime's library path applies
- * via useLibraryStore.setState, so apply() receives the LayoutLibrary
- * draft directly.
- *
- * The default preview matches v1's getDefaultPreview helper. The author
- * fallback (`payload.author ?? library.settings.authorName`) preserves
- * v1 behavior so unauthenticated entries still pick up the user's
- * configured author.
+ * Create a new library entry. Author always comes from
+ * `library.settings.authorName` — the central CQRS schema doesn't accept
+ * an `author` payload field, so it can't be passed through the bus.
  */
 
 import { z } from 'zod';
@@ -19,10 +12,9 @@ import { gridUnits, heightUnits, layoutId as toLayoutId } from '@/core/types';
 import type { LayoutEntry, LayoutPreview } from '@/core/types';
 import { defineCommand } from '../../defineCommand';
 
-// Match the central library.createEntry schema (validation/librarySchemas.ts):
-// name has min/max bounds; preview is opaque (validated structurally inside
-// handle below); `author` is NOT a payload field — author always falls back
-// to library.settings.authorName per v1's CQRS handler behavior.
+// Mirrors the central library.createEntry schema in
+// validation/librarySchemas.ts — `preview` is structurally re-validated
+// inside handle() since the central schema treats it as opaque.
 const payloadSchema = z.object({
   name: z.string().min(1).max(CONSTRAINTS.NAME_MAX_LENGTH),
   layoutId: z.string().optional(),
@@ -68,25 +60,19 @@ export const createEntry = defineCommand({
   middleware: { undoCapture: false, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const id = payload.layoutId !== undefined ? toLayoutId(payload.layoutId) : generateLayoutId();
-    // Match v1's author resolution: always settings.authorName (v1's CQRS
-    // handler doesn't pass an author arg through; the store action's
-    // optional author parameter is unreachable via the bus).
     const author = ctx.aggregate.settings.authorName;
     const now = Date.now();
 
-    // Truncate inside handle even though the central schema enforces a
-    // max — keeps the event payload's value identical to what apply()
-    // installs, even if validation is bypassed in tests/tools.
+    // Truncate even though the central schema enforces a max — keeps
+    // the event's value identical to what apply() installs when
+    // validation is bypassed in tests/tools.
     const name = payload.name.slice(0, CONSTRAINTS.NAME_MAX_LENGTH);
 
-    // payload.preview is z.unknown() in both v2 and central schemas;
-    // structurally validate inside handle so a malformed shape falls
-    // back to defaults instead of crashing on undefined .drawerWidth.
+    // Preview is z.unknown() in both v2 and central schemas; structurally
+    // re-check here so a malformed shape falls back to defaults instead
+    // of crashing on undefined .drawerWidth.
     const preview: LayoutPreview = isStructuredPreview(payload.preview)
-      ? // Brand the dimension fields. Optional shape extras (binMap, etc.)
-        // pass through via the `[k: string]: unknown` index from
-        // isStructuredPreview's predicate.
-        {
+      ? {
           ...payload.preview,
           drawerWidth: gridUnits(payload.preview.drawerWidth),
           drawerDepth: gridUnits(payload.preview.drawerDepth),
@@ -109,11 +95,10 @@ export const createEntry = defineCommand({
     });
   },
   apply: (event, draft) => {
-    // v2 handler always populates `entry`. v1-era persisted events have
-    // only {layoutId, name} — reconstruct a best-effort entry from
-    // defaults so replay produces *something* instead of silently
-    // dropping the event.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- entry is optional on the event type for v1 back-compat
+    // Persisted events that predate the `entry` field carry only
+    // {layoutId, name}; reconstruct a best-effort entry from defaults
+    // so replay produces *something* rather than silently dropping the event.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- entry is optional for back-compat with persisted events
     const fallback: LayoutEntry = event.payload.entry ?? {
       id: event.payload.layoutId,
       name: event.payload.name,

--- a/src/core/cqrs/v2/domain/library/createEntry.ts
+++ b/src/core/cqrs/v2/domain/library/createEntry.ts
@@ -13,8 +13,8 @@ import type { LayoutEntry, LayoutPreview } from '@/core/types';
 import { defineCommand } from '../../defineCommand';
 
 // Mirrors the central library.createEntry schema in
-// validation/librarySchemas.ts — `preview` is structurally re-validated
-// inside handle() since the central schema treats it as opaque.
+// `@/core/cqrs/validation/librarySchemas` — `preview` is structurally
+// re-validated inside handle() since the central schema treats it as opaque.
 const payloadSchema = z.object({
   name: z.string().min(1).max(CONSTRAINTS.NAME_MAX_LENGTH),
   layoutId: z.string().optional(),

--- a/src/core/cqrs/v2/domain/library/deleteEntry.ts
+++ b/src/core/cqrs/v2/domain/library/deleteEntry.ts
@@ -1,10 +1,7 @@
 /**
- * library.deleteEntry — v2 (defineCommand) shape, library aggregate.
- *
- * Validates the library still has at least one entry after deletion
- * (rejects deleting the last layout). If the deleted entry is the
- * currently active layout, apply() advances activeLayoutId to the
- * first remaining entry — same fallback as v1.
+ * Delete a library entry. Rejects deleting the last remaining entry.
+ * If the deleted entry was the active layout, apply() advances
+ * `activeLayoutId` to the first remaining entry.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/library/duplicateEntry.ts
+++ b/src/core/cqrs/v2/domain/library/duplicateEntry.ts
@@ -1,9 +1,7 @@
 /**
- * library.duplicateEntry — v2 (defineCommand) shape, library aggregate.
- *
- * Validates the source entry exists, generates a new LayoutId, and emits
- * the full new entry in the event payload. apply() pushes — no re-fetch
- * needed.
+ * Duplicate a library entry. Validates the source exists, generates a
+ * new LayoutId, suffixes the name with " (copy)" (truncated to
+ * NAME_MAX_LENGTH). The event carries the full new entry.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/library/importLayout.ts
+++ b/src/core/cqrs/v2/domain/library/importLayout.ts
@@ -1,8 +1,5 @@
 /**
- * library.importLayout — v2 (defineCommand) shape, library aggregate.
- *
- * Creates a new library entry from an imported Layout. Computes the
- * preview from the layout via `computePreview`. Emits the same
+ * Create a library entry from an imported Layout. Emits the same
  * `library.entryCreated` event as createEntry so downstream subscribers
  * (analytics, persistence) handle imports identically.
  */
@@ -31,8 +28,8 @@ export const importLayout = defineCommand({
   middleware: { undoCapture: false, validate: true, analytics: true },
   handle: (payload, ctx) => {
     // Central validation treats `layout` as `unknown`; computePreview
-    // expects a Layout. Trust the caller (matches v1 — v1 handler also
-    // passes payload.layout straight to computePreview).
+    // expects a Layout. Trust the caller — bus dispatch is internal,
+    // and the prior v1 handler took the same shortcut.
     const layout = payload.layout as Layout;
     const id = generateLayoutId();
     const name = payload.name.slice(0, CONSTRAINTS.NAME_MAX_LENGTH);
@@ -52,11 +49,9 @@ export const importLayout = defineCommand({
     });
   },
   apply: (event, draft) => {
-    // Same fallback as createEntry.apply(): v2 handler always populates
-    // `entry`, but v1-era persisted events have only {layoutId, name}.
-    // Reconstruct a best-effort entry from defaults so replay produces
-    // *something* instead of silently dropping the import event.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- entry is optional on the event type for v1 back-compat
+    // Same fallback as createEntry.apply(): persisted events that
+    // predate the `entry` field carry only {layoutId, name}.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- entry is optional for back-compat with persisted events
     const entry: LayoutEntry = event.payload.entry ?? {
       id: event.payload.layoutId,
       name: event.payload.name,

--- a/src/core/cqrs/v2/domain/library/renameEntry.ts
+++ b/src/core/cqrs/v2/domain/library/renameEntry.ts
@@ -1,9 +1,6 @@
 /**
- * library.renameEntry — v2 (defineCommand) shape, library aggregate.
- *
- * Captures previousName for undo replay. Truncates inside handle()
- * even though the central schema enforces a max — keeps event payload
- * identical to what apply() installs.
+ * Rename a library entry. Captures `previousName` for undo. Truncates
+ * inside handle() so the event records the value that actually lands.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/library/setAuthorName.ts
+++ b/src/core/cqrs/v2/domain/library/setAuthorName.ts
@@ -1,8 +1,6 @@
 /**
- * library.setAuthorName — v2 (defineCommand) shape, library aggregate.
- *
- * Truncates to NAME_MAX_LENGTH (matches v1 behavior) and captures
- * previousName for undo replay.
+ * Set the library's default author name. Truncates to NAME_MAX_LENGTH;
+ * captures `previousName` for undo.
  */
 
 import { z } from 'zod';
@@ -10,8 +8,6 @@ import { ok } from '@/core/result';
 import { CONSTRAINTS } from '@/core/constants';
 import { defineCommand } from '../../defineCommand';
 
-// Match the central library.setAuthorName schema (validation/librarySchemas.ts):
-// name has min(1).max(NAME_MAX_LENGTH).
 const payloadSchema = z.object({
   name: z.string().min(1).max(CONSTRAINTS.NAME_MAX_LENGTH),
 });

--- a/src/core/cqrs/v2/domain/library/setCloudShare.ts
+++ b/src/core/cqrs/v2/domain/library/setCloudShare.ts
@@ -1,12 +1,9 @@
 /**
- * library.setCloudShare — v2 (defineCommand) shape, library aggregate.
- *
- * Sets cloudShare metadata on the matching entry. The libraryPersistence
- * subscriber (`cqrs/subscribers/libraryPersistence.ts`, wired in PR 1)
- * listens for the emitted `library.cloudShareUpdated` event and persists
- * the library snapshot — so the v2 path's behavior matches v1 end-to-end.
- *
- * No-ops silently when the layout id isn't in entries (same as v1).
+ * Set cloudShare metadata on a library entry. The
+ * `cqrs/subscribers/libraryPersistence` subscriber listens for
+ * `library.cloudShareUpdated` and persists the library snapshot
+ * immediately (cloudShare isn't covered by the debounced useAutoSave).
+ * No-ops silently when the layout id isn't in entries.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/library/switchActive.ts
+++ b/src/core/cqrs/v2/domain/library/switchActive.ts
@@ -1,10 +1,7 @@
 /**
- * library.switchActive — v2 (defineCommand) shape, library aggregate.
- *
- * Captures previousLayoutId so undo replay can restore the prior active
- * selection. v1 didn't validate that the target id exists in entries —
- * v2 keeps that lenient behavior (the layout-activation hook handles
- * the lookup downstream).
+ * Switch the active layout. Captures `previousLayoutId` for undo.
+ * No validation that the target id exists — the layout-activation hook
+ * handles lookup downstream.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/library/updateEntry.ts
+++ b/src/core/cqrs/v2/domain/library/updateEntry.ts
@@ -1,10 +1,9 @@
 /**
- * library.updateEntry — v2 (defineCommand) shape, library aggregate.
- *
- * Permits partial updates to entry fields the v1 store action allows
- * (name, modifiedAt, preview, author, forkedFrom). Names are truncated
- * to NAME_MAX_LENGTH inside handle() so the event records the value that
- * actually lands.
+ * Update library entry fields. Accepts only the fields the central
+ * pipeline schema allows (name, preview, author) — the v1 store
+ * action's `modifiedAt` and `forkedFrom` aren't CQRS-reachable (the
+ * validation middleware strips them). Names truncated inside handle()
+ * so the event records the value that lands.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/sample.ts
+++ b/src/core/cqrs/v2/sample.ts
@@ -1,12 +1,7 @@
 /**
- * Sample v2 command definitions used to drive type-inference tests.
- *
- * NOT registered with the live commandBus — these exist solely to prove
- * that `defineCommand({...})` captures the right types end-to-end and
- * that `Mutations<typeof registry>` produces a usable surface.
- *
- * Will be deleted in PR 11 (cleanup) once the real domain commands are
- * in place under `cqrs/v2/domain/`.
+ * Sample command defs used by `types.test.ts` to drive end-to-end
+ * type-inference assertions for `defineCommand` + `createRegistry` +
+ * `Mutations<typeof registry>`. Not registered with the live commandBus.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/types.test.ts
+++ b/src/core/cqrs/v2/types.test.ts
@@ -1,14 +1,10 @@
 /**
- * Type-inference tests for v2 foundations.
- *
- * Validates that `defineCommand({...})` plus `createRegistry([...])` plus
+ * Type-inference tests for the v2 foundations. Validates that
+ * `defineCommand({...})` plus `createRegistry([...])` plus
  * `Mutations<typeof registry>` thread types end-to-end without collapsing
- * to `unknown`, `never`, or `any`. These tests run at typecheck time —
- * they assert structural type equality, not runtime behavior.
- *
- * Decision gate: if `pnpm typecheck` regresses by >2 seconds when this
- * file is added, the per-command typed-dispatcher fallback (Pass 2 risk
- * mitigation) becomes the path forward instead.
+ * to `unknown`, `never`, or `any`. expectTypeOf assertions run at
+ * typecheck time; the runtime smoke test below ensures vitest discovers
+ * the file.
  */
 
 import { describe, it, expect, expectTypeOf } from 'vitest';

--- a/src/core/cqrs/v2/types.ts
+++ b/src/core/cqrs/v2/types.ts
@@ -25,9 +25,8 @@ export type AggregateName = 'layout' | 'library' | 'designer';
 /**
  * Read-only snapshot shape per aggregate.
  *
- * Designer is `unknown` until the designer migration lands — the type
- * stays open so `defineCommand({ aggregate: 'designer', ... })` does not
- * lock in a shape we may want to revise during PR 7.
+ * Designer is `unknown` because no command currently targets that
+ * aggregate; revise the shape if/when one does.
  */
 export interface AggregateRoot {
   readonly layout: Layout;

--- a/src/features/cloud-share/components/ShareModal/ShareModal.test.tsx
+++ b/src/features/cloud-share/components/ShareModal/ShareModal.test.tsx
@@ -24,8 +24,8 @@ vi.mock('@/core/storage', () => ({
   getCloudShareIdFromURL: vi.fn(() => null),
 }));
 
-// Mock telemetry — ui.* analytics are direct trackEvent() calls now
-// (PR 12 telemetry exit; not routed through the CQRS bus).
+// Mock telemetry — ui.* analytics are direct trackEvent() calls
+// (not routed through the CQRS bus).
 import type * as PosthogModule from '@/shared/analytics/posthog';
 const mockTrackEvent = vi.fn();
 vi.mock('@/shared/analytics/posthog', async () => {

--- a/src/features/inspiration-gallery/components/InspirationGallery/InspirationGallery.test.tsx
+++ b/src/features/inspiration-gallery/components/InspirationGallery/InspirationGallery.test.tsx
@@ -12,8 +12,8 @@ vi.mock('@/shared/hooks', async (importOriginal) => ({
   useResponsive: () => ({ isMobile: false, viewportWidth: 1280 }),
 }));
 
-// Mock analytics. ui.* events are now direct trackEvent() calls (PR 12
-// telemetry exit) — no longer routed through the CQRS bus.
+// Mock analytics. ui.* events are direct trackEvent() calls — they
+// don't flow through the CQRS bus.
 const mockTrackBinCreated = vi.fn();
 const mockTrackGalleryOpened = vi.fn();
 const mockTrackGalleryClosed = vi.fn();


### PR DESCRIPTION
## Summary

Cleanup pass over the v2 migration's comment rot. After every domain landed, files all opened with the same `* X — v2 (defineCommand) shape.` boilerplate, every event field carried "added in the v2 migration" preamble, and several files referenced specific PR numbers ("PR 12 telemetry exit", "Per Pass 3 plan"). Once v1 is a memory those comments document the WHAT (visible in the code) and the SHAPE of the migration, not the WHY a future reader needs.

## Sweep

- **47 files**, net **-163 lines** of comment churn
- v2 domain headers rewritten to one short sentence about the command's behavior; load-bearing constraints retained (clamp ranges, validation order, BinId branding boundary, displaced-bin set determinism)
- Event-type field docstrings reframed so back-compat optionality is the WHY, not the migration narrative
- Drop "PR 12 / Pass 3 / v2 migration" references in `commands/index`, `handlers/index`, `projection/replay`, `middlewareConfig.test`, the two posthog test mocks, and `v2/sample.ts`

No behavioral change.

## Test plan

- [x] `pnpm exec vitest run src/core/cqrs/` — 445 tests pass
- [x] `pnpm exec vitest run` for the two touched component test files — 78 tests pass
- [x] `pnpm exec tsc --noEmit` — clean
- [x] All pre-commit hooks green (lint-staged, module boundaries, i18n×4, exhaustiveness, component structure)