### PR TITLE
chore: prevent chunk-init capture bugs (#1466 / #1558 class)

### DIFF
--- a/e2e/smoke/pwa-smoke.spec.ts
+++ b/e2e/smoke/pwa-smoke.spec.ts
@@ -7,6 +7,9 @@ import { test, expect, type ConsoleMessage } from '@playwright/test';
  * - Serves a parseable `/version.json` whose hash matches the one the runtime
  *   reports — catches the wwwMigration-class bug where the SW precache and the
  *   deployed asset graph disagree.
+ * - Drives one bin-creation click through the live command bus — catches
+ *   chunk-init capture bugs (#1466 pattern, #1558) where a singleton like
+ *   `commandBus` is `undefined` when a closure captured it during module-init.
  *
  * Runs under `playwright.smoke.config.ts`, single chromium project, against
  * `PLAYWRIGHT_TEST_BASE_URL`. Used by both PR-preview and post-promote workflows.
@@ -89,6 +92,18 @@ test('boots ?smoke=1 fixture and exposes a fresh /version.json', async ({ page, 
   expect(runtimeVersion, 'smoke harness did not expose __SMOKE_BUILD_INFO__').toBeTruthy();
   expect(runtimeVersion?.version).toBe(versionJson.version);
   expect(runtimeVersion?.gitSha).toBe(versionJson.gitSha);
+
+  // Click on the grid to dispatch bin.add through the live command bus.
+  // The smoke layout has 1 layer + 1 category, so this is a happy-path draw.
+  // A chunk-init capture bug (commandBus undefined inside cqrsMutations)
+  // surfaces here as a `pageerror` — caught by the `errors` assertion below.
+  const grid = page.locator('[role="application"]');
+  const gridBox = await grid.boundingBox();
+  expect(gridBox, 'grid bounding box not measurable').toBeTruthy();
+  if (gridBox) {
+    await page.mouse.click(gridBox.x + 50, gridBox.y + gridBox.height - 50);
+    await expect(page.locator('[data-bin-id]')).toHaveCount(1, { timeout: 5_000 });
+  }
 
   // Console must be clean (excluding ignored patterns).
   expect(errors, `unexpected console errors: ${errors.join('\n')}`).toHaveLength(0);

--- a/e2e/smoke/pwa-smoke.spec.ts
+++ b/e2e/smoke/pwa-smoke.spec.ts
@@ -96,12 +96,16 @@ test('boots ?smoke=1 fixture and exposes a fresh /version.json', async ({ page, 
   // Click on the grid to dispatch bin.add through the live command bus.
   // The smoke layout has 1 layer + 1 category, so this is a happy-path draw.
   // A chunk-init capture bug (commandBus undefined inside cqrsMutations)
-  // surfaces here as a `pageerror` — caught by the `errors` assertion below.
+  // surfaces here as a `pageerror`.
   const grid = page.locator('[role="application"]');
   const gridBox = await grid.boundingBox();
   expect(gridBox, 'grid bounding box not measurable').toBeTruthy();
   if (gridBox) {
     await page.mouse.click(gridBox.x + 50, gridBox.y + gridBox.height - 50);
+    // Assert errors before bin-count so a runtime exception (the very bug
+    // class this assertion guards against) shows up in the failure message
+    // instead of being masked by a "no [data-bin-id] within 5s" timeout.
+    expect(errors, `bin-add dispatch raised: ${errors.join('\n')}`).toHaveLength(0);
     await expect(page.locator('[data-bin-id]')).toHaveCount(1, { timeout: 5_000 });
   }
 

--- a/eslint-rules/no-init-time-imported-call.js
+++ b/eslint-rules/no-init-time-imported-call.js
@@ -1,0 +1,85 @@
+/**
+ * Flag top-level `const x = fn(importedY)` where both the callee and an
+ * argument come from imports. Such calls capture imported bindings into
+ * long-lived closures at module-init; under chunk-level static-import
+ * cycles the captured binding can be `undefined` (see #1466, #1558).
+ *
+ * The safe alternative is a lazy singleton:
+ *   let _x;
+ *   function getX() { return (_x ??= fn(importedY)); }
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow capturing imported bindings into module-init closures (chunk-init cycle hazard)',
+    },
+    schema: [],
+    messages: {
+      capture:
+        "Calling imported `{{callee}}` with imported `{{arg}}` at module-init captures `{{arg}}` into a closure. " +
+        'Under chunk-level static-import cycles (#1466) the captured value may be `undefined` at runtime. ' +
+        'Wrap in a lazy singleton (e.g. `let cached; function getX() { return cached ??= {{callee}}({{arg}}); }`).',
+    },
+  },
+  create(context) {
+    /** @type {Set<string>} Identifiers brought in by `import` statements in this module. */
+    const importedNames = new Set();
+
+    // React HOCs and similar APIs that store the captured argument but only
+    // INVOKE it during render / commit phase — by then every chunk is loaded.
+    // Adding others here is fine as long as they share that property.
+    const SAFE_CALLEES = new Set([
+      'memo',
+      'forwardRef',
+      'lazy',
+      'createContext',
+    ]);
+
+    function isTopLevelDeclarator(declarator) {
+      const decl = declarator.parent;
+      if (!decl || decl.type !== 'VariableDeclaration') return false;
+      const parent = decl.parent;
+      if (!parent) return false;
+      // `const x = ...` directly in the program OR `export const x = ...`
+      if (parent.type === 'Program') return true;
+      if (parent.type === 'ExportNamedDeclaration' && parent.parent?.type === 'Program') {
+        return true;
+      }
+      return false;
+    }
+
+    return {
+      ImportDeclaration(node) {
+        for (const spec of node.specifiers) {
+          // Default, namespace, and named imports all expose a `local` binding.
+          importedNames.add(spec.local.name);
+        }
+      },
+      VariableDeclarator(node) {
+        if (!isTopLevelDeclarator(node)) return;
+        const init = node.init;
+        if (!init || init.type !== 'CallExpression') return;
+        if (init.callee.type !== 'Identifier') return;
+        if (!importedNames.has(init.callee.name)) return;
+        if (SAFE_CALLEES.has(init.callee.name)) return;
+
+        for (const arg of init.arguments) {
+          if (arg.type === 'Identifier' && importedNames.has(arg.name)) {
+            context.report({
+              node: init,
+              messageId: 'capture',
+              data: { callee: init.callee.name, arg: arg.name },
+            });
+            return;
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint-rules/no-init-time-imported-call.js
+++ b/eslint-rules/no-init-time-imported-call.js
@@ -20,9 +20,11 @@ const rule = {
     schema: [],
     messages: {
       capture:
-        "Calling imported `{{callee}}` with imported `{{arg}}` at module-init captures `{{arg}}` into a closure. " +
-        'Under chunk-level static-import cycles (#1466) the captured value may be `undefined` at runtime. ' +
-        'Wrap in a lazy singleton (e.g. `let cached; function getX() { return cached ??= {{callee}}({{arg}}); }`).',
+        'Calling imported `{{callee}}` with imported `{{arg}}` at module-init evaluates with ' +
+        '`{{arg}}` whatever value the import resolves to AT THIS MOMENT — and under ' +
+        'chunk-level static-import cycles (#1466) that may be `undefined`. If `{{callee}}` ' +
+        'retains `{{arg}}` (closure or stored field), that undefined sticks. Defer the call ' +
+        'until first use (e.g. `let cached; function getX() { return cached ??= {{callee}}({{arg}}); }`).',
     },
   },
   create(context) {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@ import i18next from 'eslint-plugin-i18next'
 import boundaries from 'eslint-plugin-boundaries'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
+import noInitTimeImportedCall from './eslint-rules/no-init-time-imported-call.js'
 
 export default defineConfig([
   globalIgnores(['dist', 'coverage', 'e2e', 'scripts', 'benchmarks', 'reports', 'playwright.config.ts', 'playwright.smoke.config.ts', 'playwright-ct.config.ts', 'playwright', '**/*.visual.tsx']),
@@ -22,6 +23,7 @@ export default defineConfig([
     ],
     plugins: {
       i18next: fixupPluginRules(i18next),
+      local: { rules: { 'no-init-time-imported-call': noInitTimeImportedCall } },
     },
     languageOptions: {
       ecmaVersion: 2020,
@@ -38,6 +40,8 @@ export default defineConfig([
       },
     },
     rules: {
+      // Catch chunk-init capture hazards (#1466, #1558).
+      'local/no-init-time-imported-call': 'error',
       // TypeScript strict rules
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': ['error', {

--- a/scripts/no-init-time-imported-call.test.ts
+++ b/scripts/no-init-time-imported-call.test.ts
@@ -1,0 +1,75 @@
+import { RuleTester } from 'eslint';
+// @ts-expect-error -- JS rule, no .d.ts; loaded for behavior tests only.
+import rule from '../eslint-rules/no-init-time-imported-call.js';
+
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+tester.run('no-init-time-imported-call', rule, {
+  valid: [
+    // Calling an imported function with a literal arg — no captured binding.
+    { code: `import { ok } from 'mod'; export const OK = ok(undefined);` },
+    // Calling a LOCAL function (not imported) with an imported arg.
+    {
+      code: `
+        import { dep } from 'mod';
+        function build(x) { return x; }
+        export const X = build(dep);
+      `,
+    },
+    // Calling an imported function with no args.
+    { code: `import { make } from 'mod'; export const X = make();` },
+    // Lazy singleton — call lives inside a function, not at module-init.
+    {
+      code: `
+        import { make, dep } from 'mod';
+        let cached;
+        export function getX() { return (cached ??= make(dep)); }
+      `,
+    },
+    // Top-level call NOT in a variable declarator (e.g. side-effect).
+    { code: `import { side } from 'mod'; side();` },
+    // React.memo / forwardRef defer arg usage until render — safe.
+    {
+      code: `
+        import { memo } from 'react';
+        import { areEqual, Component } from './c';
+        export const Wrapped = memo(Component, areEqual);
+      `,
+    },
+    {
+      code: `
+        import { forwardRef } from 'react';
+        import { Inner } from './c';
+        export const Outer = forwardRef(Inner);
+      `,
+    },
+  ],
+  invalid: [
+    // The exact pattern that broke #1558.
+    {
+      code: `
+        import { createCqrsMutations, commandBus } from '@/core/cqrs';
+        export const cqrsMutations = createCqrsMutations(commandBus);
+      `,
+      errors: [{ messageId: 'capture' }],
+    },
+    // Same pattern without `export`.
+    {
+      code: `
+        import { build, dep } from 'mod';
+        const x = build(dep);
+      `,
+      errors: [{ messageId: 'capture' }],
+    },
+    // Captured binding is the second arg.
+    {
+      code: `
+        import { build, a, dep } from 'mod';
+        export const x = build(a, dep);
+      `,
+      errors: [{ messageId: 'capture' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Two guardrails so the bug class that bit us in #1466 and just again in #1558 doesn't slip through unnoticed.

## 1. Smoke test draws a bin

`e2e/smoke/pwa-smoke.spec.ts` now clicks the grid and asserts a `[data-bin-id]` element appears. The previous spec only verified the React tree mounted — it would *not* have caught #1558 because the failure (\`Cannot read properties of undefined (reading 'dispatch')\`) only fires when the user dispatches a command, not at boot. Driving one bin-add through the live production-built command bus closes that gap.

## 2. ESLint rule: \`local/no-init-time-imported-call\`

A custom flat-config rule that flags top-level
\`\`\`ts
import { fn, dep } from 'mod';
export const x = fn(dep);
\`\`\`
where both \`fn\` and an arg come from imports. Capturing an imported binding into a long-lived closure at module-init is the exact shape of #1558 (\`createCqrsMutations(commandBus)\`). The rule message points to the lazy-singleton fix.

Allowlist for React HOCs that defer arg usage until render: \`memo\`, \`forwardRef\`, \`lazy\`, \`createContext\`.

The rule passes on the entire current \`src/\` tree.

## Test plan

- [x] 10 unit tests for the rule — valid, invalid, allowlist
- [x] \`pnpm exec eslint 'src/**/*.{ts,tsx}'\` clean
- [x] \`pnpm typecheck\` clean
- [x] Smoke spec parses and runs locally; bin-click portion verified (the only failure is a pre-existing favicon.ico 404 from \`vite preview\` that doesn't fire on Vercel preview)
- [ ] Smoke runs against Vercel preview in CI