### PR TITLE
fix(baseplate): scale orbit zoom-out cap to baseplate size

### DIFF
--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
@@ -8,7 +8,7 @@
  * The slab extends asymmetrically when padding differs per side.
  */
 
-import { useRef, useCallback, useState } from 'react';
+import { useRef, useCallback, useMemo, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import { useShallow } from 'zustand/react/shallow';
@@ -25,6 +25,7 @@ import { useResponsive } from '@/shared/hooks/useResponsive';
 import { useSettingsStore } from '@/core/store';
 import { useTranslation } from '@/i18n';
 import type { CameraPreset } from './cameraUtils';
+import { calculateIdealDistance, calculateMaxOrbitDistance } from './cameraUtils';
 import { BaseplateMesh } from './BaseplateMesh';
 import { SceneLighting } from './SceneLighting';
 import { CameraController } from './CameraController';
@@ -132,6 +133,24 @@ export function BaseplatePreview({
   );
 
   const totalH = GRIDFINITY_SPEC.SOCKET_HEIGHT;
+
+  const maxOrbitDistance = useMemo(
+    () =>
+      calculateMaxOrbitDistance(
+        calculateIdealDistance(
+          width,
+          depth,
+          gridUnitMm,
+          paddingLeft,
+          paddingRight,
+          paddingFront,
+          paddingBack,
+          45
+        )
+      ),
+    [width, depth, gridUnitMm, paddingLeft, paddingRight, paddingFront, paddingBack]
+  );
+
   const hasAnyMesh = isSplit ? hasSplitMeshes : hasMesh;
   const hasError = wasmStatus === 'error' || generationStatus === 'error';
   const isWasmLoading = !hasError && wasmStatus !== 'ready';
@@ -202,7 +221,7 @@ export function BaseplatePreview({
             position: new THREE.Vector3(100, -100, 80),
             fov: 45,
             near: 0.1,
-            far: 2000,
+            far: 20000,
           }}
           onCreated={({ camera }) => {
             camera.up.set(0, 0, 1);
@@ -276,7 +295,7 @@ export function BaseplatePreview({
             dampingFactor={0.12}
             rotateSpeed={0.8}
             minDistance={20}
-            maxDistance={800}
+            maxDistance={maxOrbitDistance}
             maxPolarAngle={Math.PI * 0.85}
             minPolarAngle={Math.PI * 0.05}
             enablePan={isDesktop}

--- a/src/features/baseplate/components/BaseplatePreview/CameraController.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/CameraController.tsx
@@ -1,10 +1,23 @@
 import { useRef, useEffect, useMemo } from 'react';
 import { useThree, useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
+import { PerspectiveCamera } from 'three';
 import type { OrbitControls as OrbitControlsType } from 'three-stdlib';
 import type { RefObject } from 'react';
 import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
-import { CAMERA_PRESETS, easeOutCubic, calculateIdealDistance } from './cameraUtils';
+import {
+  CAMERA_PRESETS,
+  easeOutCubic,
+  calculateIdealDistance,
+  calculateMaxOrbitDistance,
+  calculateFarPlane,
+} from './cameraUtils';
+
+function setCameraFar(camera: THREE.Camera, far: number): void {
+  if (!(camera instanceof PerspectiveCamera)) return;
+  camera.far = far;
+  camera.updateProjectionMatrix();
+}
 
 /**
  * Camera controller that frames the baseplate on mount.
@@ -56,6 +69,15 @@ export function CameraController({
       ),
     [width, depth, gridUnitMm, paddingLeft, paddingRight, paddingFront, paddingBack]
   );
+
+  // Keep the far plane ahead of the user's zoom-out range. Without this,
+  // the geometry's farthest corner clips off-screen at maximum zoom for
+  // large baseplates (50×50 + 100mm padding pushes the corner past 21m).
+  useEffect(() => {
+    const targetFar = calculateFarPlane(calculateMaxOrbitDistance(idealDistance));
+    setCameraFar(camera, targetFar);
+    invalidate();
+  }, [camera, idealDistance, invalidate]);
 
   const animRef = useRef<{
     startPos: THREE.Vector3;

--- a/src/features/baseplate/components/BaseplatePreview/cameraUtils.test.ts
+++ b/src/features/baseplate/components/BaseplatePreview/cameraUtils.test.ts
@@ -8,10 +8,12 @@ const {
   easeOutCubic,
   calculateIdealDistance,
   calculateMaxOrbitDistance,
+  calculateFarPlane,
   CAMERA_PRESETS,
   FRAME_FILL,
   MAX_DISTANCE_FACTOR,
   MAX_DISTANCE_FLOOR,
+  FAR_PLANE_FLOOR,
 } = await import('./cameraUtils');
 
 describe('cameraUtils', () => {
@@ -73,13 +75,37 @@ describe('cameraUtils', () => {
       expect(calculateMaxOrbitDistance(ideal)).toBe(ideal * MAX_DISTANCE_FACTOR);
     });
 
-    it('exceeds framing distance for the largest baseplate (16x16, 50mm padding/side)', () => {
+    it('exceeds framing distance at the supported upper bound (50x50, 100mm padding/side)', () => {
       // Regression: maxDistance used to be hardcoded to 800, which clamped
       // before the framing distance for any baseplate above ~10x10 grid units.
-      const ideal = calculateIdealDistance(16, 16, 42, 50, 50, 50, 50, 45);
+      // GRID_MAX is 50 and PADDING_MAX is 100mm/side, so this is the true
+      // worst case the panel can reach.
+      const ideal = calculateIdealDistance(50, 50, 42, 100, 100, 100, 100, 45);
       const max = calculateMaxOrbitDistance(ideal);
       expect(max).toBeGreaterThan(ideal);
       expect(max).toBeGreaterThan(800);
+    });
+  });
+
+  describe('calculateFarPlane', () => {
+    it('respects the floor for tiny zoom-out caps', () => {
+      expect(calculateFarPlane(10)).toBe(FAR_PLANE_FLOOR);
+    });
+
+    it('keeps geometry inside the frustum at the supported upper bound', () => {
+      // Regression: with the camera at maxOrbitDistance, the far corner of
+      // the slab still has to sit inside the frustum or it clips off-screen.
+      const ideal = calculateIdealDistance(50, 50, 42, 100, 100, 100, 100, 45);
+      const max = calculateMaxOrbitDistance(ideal);
+      const far = calculateFarPlane(max);
+
+      // Bounding sphere of the baseplate (slab + socket height).
+      const halfW = (50 * 42 + 100 + 100) / 2;
+      const boundingRadius = Math.sqrt(2 * halfW * halfW);
+
+      // Camera at maxOrbitDistance from center, so the farthest corner of
+      // the slab is `max + boundingRadius` from the camera.
+      expect(far).toBeGreaterThan(max + boundingRadius);
     });
   });
 });

--- a/src/features/baseplate/components/BaseplatePreview/cameraUtils.test.ts
+++ b/src/features/baseplate/components/BaseplatePreview/cameraUtils.test.ts
@@ -4,8 +4,15 @@ vi.mock('@/shared/printSettings/gridfinityGeometry', () => ({
   GRIDFINITY_SPEC: { SOCKET_HEIGHT: 5 },
 }));
 
-const { easeOutCubic, calculateIdealDistance, CAMERA_PRESETS, FRAME_FILL } =
-  await import('./cameraUtils');
+const {
+  easeOutCubic,
+  calculateIdealDistance,
+  calculateMaxOrbitDistance,
+  CAMERA_PRESETS,
+  FRAME_FILL,
+  MAX_DISTANCE_FACTOR,
+  MAX_DISTANCE_FLOOR,
+} = await import('./cameraUtils');
 
 describe('cameraUtils', () => {
   describe('easeOutCubic', () => {
@@ -53,6 +60,26 @@ describe('cameraUtils', () => {
     it('is between 0 and 1', () => {
       expect(FRAME_FILL).toBeGreaterThan(0);
       expect(FRAME_FILL).toBeLessThan(1);
+    });
+  });
+
+  describe('calculateMaxOrbitDistance', () => {
+    it('respects the floor for tiny ideal distances', () => {
+      expect(calculateMaxOrbitDistance(10)).toBe(MAX_DISTANCE_FLOOR);
+    });
+
+    it('scales with ideal distance once past the floor', () => {
+      const ideal = MAX_DISTANCE_FLOOR; // exactly at the floor
+      expect(calculateMaxOrbitDistance(ideal)).toBe(ideal * MAX_DISTANCE_FACTOR);
+    });
+
+    it('exceeds framing distance for the largest baseplate (16x16, 50mm padding/side)', () => {
+      // Regression: maxDistance used to be hardcoded to 800, which clamped
+      // before the framing distance for any baseplate above ~10x10 grid units.
+      const ideal = calculateIdealDistance(16, 16, 42, 50, 50, 50, 50, 45);
+      const max = calculateMaxOrbitDistance(ideal);
+      expect(max).toBeGreaterThan(ideal);
+      expect(max).toBeGreaterThan(800);
     });
   });
 });

--- a/src/features/baseplate/components/BaseplatePreview/cameraUtils.ts
+++ b/src/features/baseplate/components/BaseplatePreview/cameraUtils.ts
@@ -16,6 +16,12 @@ export const TRANSITION_DURATION = 500;
 /** Margin factor: how much of the viewport the baseplate should fill */
 export const FRAME_FILL = 0.65;
 
+/** Headroom multiplier on top of the framing distance when capping zoom-out. */
+export const MAX_DISTANCE_FACTOR = 3;
+
+/** Floor for max orbit distance so small baseplates still feel zoomable. */
+export const MAX_DISTANCE_FLOOR = 800;
+
 /** Cubic ease-out used for all preview animations (crossfade, camera transitions). */
 export function easeOutCubic(t: number): number {
   return 1 - Math.pow(1 - t, 3);
@@ -45,4 +51,15 @@ export function calculateIdealDistance(
 
   const halfFovRad = (fov / 2) * (Math.PI / 180);
   return (boundingRadius / Math.sin(halfFovRad)) * (1 / FRAME_FILL);
+}
+
+/**
+ * Cap on how far the user can orbit out from the baseplate.
+ *
+ * Why: A static cap (we used to ship 800mm) clamped before the framing
+ * distance for any baseplate larger than ~10×10 grid units, so users
+ * physically could not pull back far enough to see the whole part.
+ */
+export function calculateMaxOrbitDistance(idealDistance: number): number {
+  return Math.max(MAX_DISTANCE_FLOOR, idealDistance * MAX_DISTANCE_FACTOR);
 }

--- a/src/features/baseplate/components/BaseplatePreview/cameraUtils.ts
+++ b/src/features/baseplate/components/BaseplatePreview/cameraUtils.ts
@@ -63,3 +63,16 @@ export function calculateIdealDistance(
 export function calculateMaxOrbitDistance(idealDistance: number): number {
   return Math.max(MAX_DISTANCE_FLOOR, idealDistance * MAX_DISTANCE_FACTOR);
 }
+
+/** Floor for the camera far plane so tiny baseplates still look right. */
+export const FAR_PLANE_FLOOR = 2000;
+
+/**
+ * Camera far-plane distance that comfortably contains the geometry at any
+ * allowed zoom-out level. The 1.5× factor is the buffer for the baseplate's
+ * own bounding radius — when the camera is at `maxOrbitDistance`, the far
+ * corner of the slab still sits ahead of it.
+ */
+export function calculateFarPlane(maxOrbitDistance: number): number {
+  return Math.max(FAR_PLANE_FLOOR, maxOrbitDistance * 1.5);
+}


### PR DESCRIPTION
## Summary

`OrbitControls.maxDistance` in the baseplate preview was hardcoded to `800mm`, which clamped before the natural framing distance for any baseplate above ~10×10 grid units. A 16×16 baseplate with 50mm padding/side needs ~2,200mm to fit on screen — users couldn't pull back far enough to view the whole part.

- Derive `maxDistance` from the framing distance: `max(800, idealDistance × 3)`. Floor preserves zoom-out feel for small baseplates; the multiplier gives headroom past framing for large ones.
- Bump camera `far` plane from `2000` → `20000` so geometry isn't clipped at the new zoom-out range. (Static, not reactive — `<Canvas camera>` only applies on creation.)
- Reuses the existing `calculateIdealDistance` math from `cameraUtils.ts`; no new geometry code.

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm run test:run` — full suite passes (10,391 tests)
- [x] `pnpm exec eslint` on changed files — clean
- [x] New regression test in `cameraUtils.test.ts` asserts max-size baseplate (16×16, 50mm padding/side) can be framed past the old 800mm cap
- [ ] Manual: open baseplate generator, set 16×16 grid, verify zoom-out reaches a full overview