### PR TITLE
fix(staging): keep fractional-depth bins inside the stash grid

### DIFF
--- a/src/features/staging/README.md
+++ b/src/features/staging/README.md
@@ -32,3 +32,4 @@ Bins with `layerId === '__staging__'` are stored here, not on any layer.
 1. **STAGING_ID is magic string** - `'__staging__'`, not a real layer
 2. **Bins don't count in print list** until placed
 3. **Cloud-share excludes staging** - filtered from sync fingerprint
+4. **Fractional-depth bins need ceiled `gridHeight` + `alignSelf: 'end'`** — `repeat(N, ...)` silently drops a non-integer N (collapsing the explicit grid), so `gridHeight` ceils `maxY`. The ceiled row span is taller than the bin's pixel height, so any fractional-depth bin must align to the end (bottom) of its grid area or it drifts above grid Y=0.

--- a/src/features/staging/components/Staging/Staging.test.tsx
+++ b/src/features/staging/components/Staging/Staging.test.tsx
@@ -572,18 +572,6 @@ describe('Staging', () => {
 
   describe('grid positioning regressions', () => {
     /**
-     * Returns the inline `display: grid` container that holds the staging cells/bins.
-     * jsdom preserves inline styles, so we filter <div>s by `style.display`.
-     */
-    function findStagingGridContainer(): HTMLElement {
-      const grids = Array.from(document.querySelectorAll<HTMLElement>('div')).filter(
-        (el) => el.style.display === 'grid'
-      );
-      expect(grids).toHaveLength(1);
-      return grids[0];
-    }
-
-    /**
      * Repro for the "bins spill below the stash grid" bug. When a staged bin has a
      * fractional depth that pushes `maxY` (= y + depth) to a non-integer, gridHeight
      * becomes fractional and `gridTemplateRows: repeat(2.5, 38px)` is invalid CSS,
@@ -594,7 +582,7 @@ describe('Staging', () => {
 
       render(<Staging />);
 
-      const grid = findStagingGridContainer();
+      const grid = screen.getByTestId('staging-grid');
       const match = grid.style.gridTemplateRows.match(/repeat\(([\d.]+),/);
       expect(match).toBeTruthy();
       const rowCount = parseFloat(match![1]);
@@ -635,8 +623,9 @@ describe('Staging', () => {
 
       render(<Staging />);
 
-      const grid = findStagingGridContainer();
+      const grid = screen.getByTestId('staging-grid');
       const rowsMatch = grid.style.gridTemplateRows.match(/repeat\(([\d.]+),/);
+      expect(rowsMatch).toBeTruthy();
       const rowCount = parseFloat(rowsMatch![1]);
 
       const bins = document.querySelectorAll<HTMLElement>('[data-staging-bin-id]');

--- a/src/features/staging/components/Staging/Staging.test.tsx
+++ b/src/features/staging/components/Staging/Staging.test.tsx
@@ -570,6 +570,96 @@ describe('Staging', () => {
     });
   });
 
+  describe('grid positioning regressions', () => {
+    /**
+     * Returns the inline `display: grid` container that holds the staging cells/bins.
+     * jsdom preserves inline styles, so we filter <div>s by `style.display`.
+     */
+    function findStagingGridContainer(): HTMLElement {
+      const grids = Array.from(document.querySelectorAll<HTMLElement>('div')).filter(
+        (el) => el.style.display === 'grid'
+      );
+      expect(grids).toHaveLength(1);
+      return grids[0];
+    }
+
+    /**
+     * Repro for the "bins spill below the stash grid" bug. When a staged bin has a
+     * fractional depth that pushes `maxY` (= y + depth) to a non-integer, gridHeight
+     * becomes fractional and `gridTemplateRows: repeat(2.5, 38px)` is invalid CSS,
+     * which collapses the explicit grid and causes bins to overflow below the panel.
+     */
+    it('keeps fractional-depth bins inside the explicit grid', () => {
+      addStagedBins([{ width: 2, depth: 2.5 }]);
+
+      render(<Staging />);
+
+      const grid = findStagingGridContainer();
+      const match = grid.style.gridTemplateRows.match(/repeat\(([\d.]+),/);
+      expect(match).toBeTruthy();
+      const rowCount = parseFloat(match![1]);
+
+      expect(Number.isInteger(rowCount)).toBe(true);
+      // 2.5 should round up so the 2.5-deep bin fits within the explicit grid
+      expect(rowCount).toBeGreaterThanOrEqual(3);
+    });
+
+    it('aligns fractional-depth bins to the bottom of their grid area', () => {
+      // y=0 means the bin sits at the bottom of the grid. With a fractional depth,
+      // the bin's pixel height is shorter than its (ceiled) row span, so we need
+      // alignSelf:'end' to keep the bottom edge at grid Y=0 instead of floating up.
+      addStagedBins([{ width: 2, depth: 2.5 }]);
+
+      render(<Staging />);
+
+      const bin = document.querySelector<HTMLElement>('[data-staging-bin-id]');
+      expect(bin).toBeTruthy();
+      expect(bin!.style.alignSelf).toBe('end');
+    });
+
+    it('does not force alignment for whole-cell-depth bins', () => {
+      addStagedBins([{ width: 2, depth: 2 }]);
+
+      render(<Staging />);
+
+      const bin = document.querySelector<HTMLElement>('[data-staging-bin-id]');
+      expect(bin).toBeTruthy();
+      expect(bin!.style.alignSelf).toBe('');
+    });
+
+    it('places every bin within the explicit grid rows', () => {
+      addStagedBins([
+        { width: 2, depth: 2.5 },
+        { width: 1, depth: 1 },
+      ]);
+
+      render(<Staging />);
+
+      const grid = findStagingGridContainer();
+      const rowsMatch = grid.style.gridTemplateRows.match(/repeat\(([\d.]+),/);
+      const rowCount = parseFloat(rowsMatch![1]);
+
+      const bins = document.querySelectorAll<HTMLElement>('[data-staging-bin-id]');
+      expect(bins.length).toBeGreaterThan(0);
+
+      for (const bin of bins) {
+        const gridRow = bin.style.gridRow; // e.g., "1 / span 3"
+        const startMatch = gridRow.match(/^([\d.]+)/);
+        const spanMatch = gridRow.match(/span\s+([\d.]+)/);
+        expect(startMatch).toBeTruthy();
+        expect(spanMatch).toBeTruthy();
+
+        const start = parseFloat(startMatch![1]);
+        const span = parseFloat(spanMatch![1]);
+
+        expect(Number.isInteger(start)).toBe(true);
+        expect(Number.isInteger(span)).toBe(true);
+        expect(start).toBeGreaterThanOrEqual(1);
+        expect(start + span - 1).toBeLessThanOrEqual(rowCount);
+      }
+    });
+  });
+
   describe('bin title/tooltip', () => {
     it('shows bin info in title attribute', () => {
       addStagedBins([{ label: 'Test Bin', width: 3, depth: 2, height: 4 }]);

--- a/src/features/staging/components/Staging/Staging.tsx
+++ b/src/features/staging/components/Staging/Staging.tsx
@@ -141,11 +141,13 @@ export function Staging() {
     return packBins(bins, gridCols);
   }, [stagingBins, gridCols]);
 
-  // Calculate required grid height (minimum 2 rows when bins present, 1 when empty)
+  // Calculate required grid height (minimum 2 rows when bins present, 1 when empty).
+  // Ceil because CSS Grid `repeat(N, ...)` requires an integer; a fractional N is
+  // dropped as invalid, collapsing the explicit grid and pushing bins below it.
   const gridHeight = useMemo(() => {
     if (packedBins.length === 0) return 1;
     const maxY = Math.max(...packedBins.map((b) => b.y + b.depth));
-    return Math.max(2, maxY);
+    return Math.max(2, Math.ceil(maxY));
   }, [packedBins]);
 
   const getCategory = (categoryId: string) => layout.categories.find((c) => c.id === categoryId);

--- a/src/features/staging/components/Staging/Staging.tsx
+++ b/src/features/staging/components/Staging/Staging.tsx
@@ -541,6 +541,7 @@ export function Staging() {
           >
             {/* CSS Grid container */}
             <div
+              data-testid="staging-grid"
               className="absolute inset-0"
               style={{
                 display: 'grid',

--- a/src/features/staging/components/Staging/StagingBin.tsx
+++ b/src/features/staging/components/Staging/StagingBin.tsx
@@ -209,8 +209,10 @@ export const StagingBin = memo(function StagingBin({
       style={{
         gridColumn: `${bin.x + 1} / span ${gridColSpan}`,
         gridRow: `${gridRowStart} / span ${gridRowSpan}`,
-        // Align fractional-depth bins to bottom of their grid cell
-        alignSelf: hasFractionalBin && bin.depth < 1 ? 'end' : undefined,
+        // Pin fractional-depth bins to the bottom of their grid area so they sit at
+        // grid Y = bin.y. Without this, the explicit pixel height + default start
+        // alignment would push the bin upward inside its (ceiled) row span.
+        alignSelf: bin.depth % 1 !== 0 ? 'end' : undefined,
         ...(!isDragging && { backgroundColor: categoryColor }),
         // Override size for fractional bins
         ...(cssWidthOverride !== undefined && { width: cssWidthOverride }),


### PR DESCRIPTION
## Summary
- Stashed bins with a non-integer depth (half-bin mode or a bin-designer custom dimension) were rendering **outside** the gray stash grid container — appearing as a row below the panel — only sometimes.
- Root cause: `gridHeight` was `Math.max(2, maxY)` where `maxY = y + depth` could be fractional. A fractional `repeat(N, ...)` is invalid CSS, so `gridTemplateRows` was dropped, the explicit grid collapsed, and bins flowed into auto-sized implicit rows beyond the panel's fixed pixel height.
- Fix is two lines:
  - `Staging.tsx`: ceil `gridHeight` so `repeat()` always gets an integer.
  - `StagingBin.tsx`: extend the bottom-alignment rule (`alignSelf: 'end'`) to all fractional depths, not just sub-cell ones, so `y=0` stays anchored to the grid floor inside the now-larger ceiled row span.

## Why it was intermittent
Integer-only depths never trigger the bug — `maxY` lands on an integer and CSS Grid is happy. It only surfaces when half-bin mode or the bin designer produces a fractional depth that pushes `y + depth` past an integer boundary.

## Test plan
- [x] `pnpm vitest run src/features/staging/` — 146/146 pass (added 3 regression tests inside the new `grid positioning regressions` describe block)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] Manual smoke test: stash a bin with a fractional depth (e.g., 2.5) and confirm it sits inside the stash grid, anchored to the bottom

## Files
- `src/features/staging/components/Staging/Staging.tsx` — `Math.ceil(maxY)` + comment
- `src/features/staging/components/Staging/StagingBin.tsx` — broaden `alignSelf` rule + comment
- `src/features/staging/components/Staging/Staging.test.tsx` — 3 new regression tests covering grid template integrity, bin row containment, and bottom-anchoring