### PR TITLE
fix(api): security audit fixes (3 MED, 4 LOW)

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -50,13 +50,13 @@ graph TB
 
 ## Validation Library (`lib/`)
 
-| File                    | Purpose                                                                    |
-| ----------------------- | -------------------------------------------------------------------------- |
-| `validation.ts`         | Layout schema: 500KB max, 2500 bins, sanitize strings, validate hex colors |
-| `designerValidation.ts` | BinParams schema: 100KB max, enum checking, dimension constraints          |
-| `contentFilter.ts`      | Blocklist (~30 terms), XSS pattern detection, spam filtering               |
-| `rateLimit.ts`          | Sliding window counters via Redis; fail-closed if Redis unavailable        |
-| `shared.ts`             | Share ID validation, `hashToken()` (SHA-256), error codes                  |
+| File                    | Purpose                                                                         |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| `validation.ts`         | Layout schema: 500KB max, 2500 bins, sanitize strings, validate hex colors      |
+| `designerValidation.ts` | BinParams schema: 100KB max, enum checking, dimension constraints               |
+| `contentFilter.ts`      | Blocklist (~30 terms) with NFKD + confusable normalization, XSS / spam patterns |
+| `rateLimit.ts`          | Sliding window counters via Redis; fail-closed if Redis unavailable             |
+| `shared.ts`             | Share ID validation, `hashToken()` (SHA-256), error codes                       |
 
 ## Share System
 
@@ -70,10 +70,21 @@ graph TB
 ```
 1. Client generates 32-char hex token (128-bit entropy)
 2. Server hashes: SHA-256(TOKEN_SALT + token)
-3. Hash stored in Blob metadata (deleteTokenHash)
+3. Hash stored in Redis (`share:hash:{id}`); legacy shares may have it in blob metadata
 4. Client presents original token for PUT/DELETE
 5. Constant-time comparison prevents timing attacks
 ```
+
+**Redis key namespaces (see `lib/redisKeys.ts`):**
+
+| Key                       | Purpose                                              |
+| ------------------------- | ---------------------------------------------------- |
+| `share:hash:{id}`         | Delete-token hash (acquired AFTER blob put succeeds) |
+| `share:reports:{id}`      | Abuse-report counter (1-year TTL)                    |
+| `share:lastAccessed:{id}` | ISO timestamp of last GET (1-year TTL)               |
+| `ratelimit:{action}:{ip}` | Sliding-window rate-limit counter                    |
+
+Share creation uses `put({ allowOverwrite: false })` as an atomic CAS lock — concurrent POSTs racing on the same shareId produce exactly one winner.
 
 **Share ID formats (backwards compatible):**
 

--- a/api/lib/contentFilter.test.ts
+++ b/api/lib/contentFilter.test.ts
@@ -165,6 +165,94 @@ describe('filterLayoutContent', () => {
     });
   });
 
+  describe('Unicode bypass resistance (MED-2 regression)', () => {
+    it('blocks Cyrillic homoglyph "е" inside slur', () => {
+      // Cyrillic 'е' (U+0435) replacing Latin 'e' — would have passed pre-fix.
+      const result = filterLayoutContent({
+        name: 'niggеr drawer',
+        bins: [],
+        categories: [{ name: 'Default' }],
+      });
+
+      expect(result.passed).toBe(false);
+    });
+
+    it('blocks zero-width-space inside slur', () => {
+      const result = filterLayoutContent({
+        name: 'ni​gger',
+        bins: [],
+        categories: [{ name: 'Default' }],
+      });
+
+      expect(result.passed).toBe(false);
+    });
+
+    it('blocks zero-width-joiner inside slur', () => {
+      const result = filterLayoutContent({
+        name: 'ni‍gger',
+        bins: [],
+        categories: [{ name: 'Default' }],
+      });
+
+      expect(result.passed).toBe(false);
+    });
+
+    it('blocks fullwidth Latin slur', () => {
+      // ｎｉｇｇｅｒ — fullwidth forms (U+FF4E etc.) fold to ASCII via NFKC.
+      const result = filterLayoutContent({
+        name: 'ｎｉｇｇｅｒ',
+        bins: [],
+        categories: [{ name: 'Default' }],
+      });
+
+      expect(result.passed).toBe(false);
+    });
+
+    it('blocks slur with single combining accent', () => {
+      // 'ńigger' — single combining acute on n. Single accent should NOT trigger
+      // the zalgo pattern (>=5), so we rely on the strip-combining normalization.
+      const result = filterLayoutContent({
+        name: 'ńigger',
+        bins: [],
+        categories: [{ name: 'Default' }],
+      });
+
+      expect(result.passed).toBe(false);
+    });
+
+    it('blocks BOM inside slur', () => {
+      const result = filterLayoutContent({
+        name: 'ni﻿gger',
+        bins: [],
+        categories: [{ name: 'Default' }],
+      });
+
+      expect(result.passed).toBe(false);
+    });
+
+    it('blocks digit substitution (e.g. n1gger)', () => {
+      const result = filterLayoutContent({
+        name: 'n1gger',
+        bins: [],
+        categories: [{ name: 'Default' }],
+      });
+
+      expect(result.passed).toBe(false);
+    });
+
+    it('still passes legitimate text containing confusable chars', () => {
+      // e.g. a layout name with a Cyrillic name shouldn't be blocked unless
+      // it actually maps to a slur after normalization.
+      const result = filterLayoutContent({
+        name: 'Алексей drawer',
+        bins: [],
+        categories: [{ name: 'Default' }],
+      });
+
+      expect(result.passed).toBe(true);
+    });
+  });
+
   describe('edge cases', () => {
     it('handles undefined label and notes', () => {
       const result = filterLayoutContent({

--- a/api/lib/contentFilter.test.ts
+++ b/api/lib/contentFilter.test.ts
@@ -198,7 +198,7 @@ describe('filterLayoutContent', () => {
     });
 
     it('blocks fullwidth Latin slur', () => {
-      // ｎｉｇｇｅｒ — fullwidth forms (U+FF4E etc.) fold to ASCII via NFKC.
+      // ｎｉｇｇｅｒ — fullwidth forms (U+FF4E etc.) fold to ASCII via NFKD.
       const result = filterLayoutContent({
         name: 'ｎｉｇｇｅｒ',
         bins: [],

--- a/api/lib/contentFilter.ts
+++ b/api/lib/contentFilter.ts
@@ -99,20 +99,83 @@ export function filterLayoutContent(layout: {
   return { passed: true };
 }
 
+// Confusable Latin-letter mapping for the small alphabet our blocklist needs.
+// Covers Cyrillic homoglyphs and other look-alikes that survive NFKC. Defense-
+// in-depth on top of the report flow — not a complete confusables table.
+const CONFUSABLE_TO_LATIN: Record<string, string> = {
+  // Cyrillic
+  а: 'a',
+  в: 'b',
+  с: 'c',
+  е: 'e',
+  һ: 'h',
+  і: 'i',
+  ј: 'j',
+  к: 'k',
+  м: 'm',
+  о: 'o',
+  р: 'p',
+  ѕ: 's',
+  т: 't',
+  у: 'y',
+  х: 'x',
+  // Greek
+  α: 'a',
+  β: 'b',
+  ε: 'e',
+  ι: 'i',
+  ο: 'o',
+  ρ: 'p',
+  τ: 't',
+  // Common typographic substitutes
+  '0': 'o',
+  '1': 'i',
+  '3': 'e',
+  '4': 'a',
+  '5': 's',
+  '7': 't',
+  '@': 'a',
+  $: 's',
+  '!': 'i',
+};
+
+// Strip zero-width (U+200B–U+200D, U+FEFF) and combining marks (U+0300–U+036F).
+// Unicode escapes (not literal characters) so the source stays ASCII-only.
+const INVISIBLE_AND_COMBINING = new RegExp('[\u0300-\u036f\u200B-\u200D\uFEFF]', 'g');
+
+/**
+ * Normalize text for blocklist matching. NFKD decomposes precomposed accents
+ * AND folds compatibility forms (fullwidth, ligatures); zero-width and combining
+ * marks are then stripped; confusable Latin look-alikes are mapped back to ASCII.
+ *
+ * NFKD (not NFKC) is required: NFKC would re-compose `n` + COMBINING_ACUTE
+ * back into `ń`, leaving the combining mark unreachable to the strip step.
+ */
+function normalizeForBlocklist(text: string): string {
+  const folded = text.normalize('NFKD').toLowerCase().replace(INVISIBLE_AND_COMBINING, '');
+  let out = '';
+  for (const ch of folded) {
+    out += CONFUSABLE_TO_LATIN[ch] ?? ch;
+  }
+  return out.trim();
+}
+
 /**
  * Check a single text string for offensive content.
  */
 function checkText(text: string): ContentFilterResult {
-  const normalized = text.toLowerCase().trim();
+  const normalized = normalizeForBlocklist(text);
 
-  // Check blocklist
+  // Check blocklist against the normalized form so Unicode tricks
+  // (homoglyphs, zero-width chars, fullwidth, combining marks) can't bypass.
   for (const term of BLOCKLIST) {
     if (normalized.includes(term)) {
       return { passed: false, reason: 'contains prohibited content' };
     }
   }
 
-  // Check harmful patterns
+  // Pattern matching runs against the *raw* text — the zalgo detector
+  // explicitly looks for combining-mark spam, which normalization would erase.
   for (const pattern of HARMFUL_PATTERNS) {
     if (pattern.test(text)) {
       return { passed: false, reason: 'contains prohibited patterns' };

--- a/api/lib/contentFilter.ts
+++ b/api/lib/contentFilter.ts
@@ -100,8 +100,18 @@ export function filterLayoutContent(layout: {
 }
 
 // Confusable Latin-letter mapping for the small alphabet our blocklist needs.
-// Covers Cyrillic homoglyphs and other look-alikes that survive NFKC. Defense-
-// in-depth on top of the report flow — not a complete confusables table.
+// Covers Cyrillic and Greek homoglyphs that NFKD doesn't fold (decomposition
+// only separates marks, it doesn't change script). Defense-in-depth on top
+// of the report flow — not a complete confusables table.
+//
+// Scope is intentionally narrow: we map only characters that are visually
+// indistinguishable from their Latin counterparts in common UI fonts AND
+// have no legitimate ASCII-text use. Digits and punctuation (@, $, !, 5,
+// 7, etc.) are deliberately NOT mapped — they appear in legitimate layout
+// names like "Bin 1/4 inch" or "@home storage" and would rewrite ordinary
+// text into unpredictable strings as the blocklist grows. Only the four
+// classic leetspeak digit substitutions (0/1/3/4) are kept because those
+// appear most often in actual bypass attempts.
 const CONFUSABLE_TO_LATIN: Record<string, string> = {
   // Cyrillic
   а: 'a',
@@ -127,16 +137,11 @@ const CONFUSABLE_TO_LATIN: Record<string, string> = {
   ο: 'o',
   ρ: 'p',
   τ: 't',
-  // Common typographic substitutes
+  // Classic leetspeak digit substitutions (kept narrow — see note above)
   '0': 'o',
   '1': 'i',
   '3': 'e',
   '4': 'a',
-  '5': 's',
-  '7': 't',
-  '@': 'a',
-  $: 's',
-  '!': 'i',
 };
 
 // Strip zero-width (U+200B–U+200D, U+FEFF) and combining marks (U+0300–U+036F).

--- a/api/lib/designerValidation.test.ts
+++ b/api/lib/designerValidation.test.ts
@@ -405,4 +405,60 @@ describe('validateDesignerShare', () => {
       expect(result.valid).toBe(true);
     });
   });
+
+  describe('top-level params allowlist (LOW-3 regression)', () => {
+    it('strips unknown keys from params before storage', () => {
+      const payload = validPayload() as { params: Record<string, unknown> } & Record<
+        string,
+        unknown
+      >;
+      payload.params.attackerControlled = 'evil';
+      payload.params.__proto__ = { polluted: true };
+      payload.params.someInternalFlag = true;
+
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(Object.hasOwn(result.payload.params, 'attackerControlled')).toBe(false);
+        expect(Object.hasOwn(result.payload.params, 'someInternalFlag')).toBe(false);
+        // __proto__ is dropped both by JSON.parse semantics and our explicit allowlist.
+        expect(Object.hasOwn(result.payload.params, '__proto__')).toBe(false);
+        // Known keys survive.
+        expect(result.payload.params.width).toBe(2);
+        expect(result.payload.params.base).toBeDefined();
+        expect(result.payload.params.compartments).toBeDefined();
+      }
+    });
+
+    it('preserves optional cellMask when present', () => {
+      const payload = validPayload();
+      payload.params = {
+        ...payload.params,
+        cellMask: { cols: 2, rows: 2, cells: [1, 1, 1, 1] },
+      } as typeof payload.params;
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.payload.params.cellMask).toEqual({
+          cols: 2,
+          rows: 2,
+          cells: [1, 1, 1, 1],
+        });
+      }
+    });
+
+    it('preserves legacy dividers field for backwards compatibility', () => {
+      const payload = validPayload() as ReturnType<typeof validPayload> & {
+        params: { compartments?: unknown; dividers?: unknown };
+      };
+      delete payload.params.compartments;
+      payload.params.dividers = { x: 1, y: 1, thickness: 1.2 };
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.payload.params.dividers).toEqual({ x: 1, y: 1, thickness: 1.2 });
+      }
+    });
+  });
 });

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -50,6 +50,65 @@ const CONSTRAINTS = {
   MAX_MASK_DIMENSION: 20,
 } as const;
 
+/**
+ * Top-level keys allowed inside `params` after validation.
+ *
+ * Defense-in-depth: the validator only deep-validates the structurally-
+ * significant fields, but unknown keys (e.g. attacker-controlled junk,
+ * `__proto__`, future fields not yet in the schema) must not be persisted
+ * verbatim into the public blob. Anything outside this set is silently
+ * dropped during sanitization.
+ *
+ * Mirrors the top-level `BinParams` keys in
+ * `src/features/bin-designer/types/index.ts`. Update both together when
+ * adding a new generator-level parameter.
+ */
+const ALLOWED_PARAM_KEYS = new Set<string>([
+  // Dimensions & units
+  'width',
+  'depth',
+  'height',
+  'gridUnitMm',
+  'heightUnitMm',
+  'wallThickness',
+  // Style
+  'style',
+  // Sub-objects (deep-validated below)
+  'base',
+  'compartments',
+  'dividers', // legacy alternative to compartments
+  'label',
+  'walls',
+  'inserts',
+  'cellMask',
+  // Sub-objects not deep-validated (yet) — passed through but key-checked
+  'scoop',
+  'handles',
+  'slotConfig',
+  'dividerPieces',
+  'cutouts',
+  'cutoutConfig',
+  'wallPattern',
+  'splitConnectors',
+  'featureColors',
+  'lid',
+]);
+
+/**
+ * Build a sanitized copy of the params object containing only allowlisted
+ * top-level keys. Drops unknown / future / attacker-controlled keys before
+ * the payload reaches the public blob.
+ */
+function pickAllowedParams(params: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(params)) {
+    if (ALLOWED_PARAM_KEYS.has(key)) {
+      out[key] = params[key];
+    }
+  }
+  return out;
+}
+
 export interface DesignerSharePayload {
   type: 'designer';
   version: 1;
@@ -413,7 +472,7 @@ export function validateDesignerShare(body: unknown, sizeBytes: number): Designe
     payload: {
       type: 'designer',
       version: 1,
-      params: params,
+      params: pickAllowedParams(params),
     },
   };
 }

--- a/api/lib/rateLimit.ts
+++ b/api/lib/rateLimit.ts
@@ -145,7 +145,14 @@ function hashIP(ip: string): string {
 
 /**
  * Get client IP from request headers.
- * Vercel sets x-forwarded-for header.
+ *
+ * SECURITY: assumes a Vercel deployment. Vercel's edge network always sets
+ * `x-forwarded-for` itself and **overrides** any value the client supplied,
+ * so the leftmost value is the trusted client IP. If this code is ever run
+ * behind a different proxy (or directly), this header is client-controllable
+ * and per-IP rate limits become spoofable. On non-Vercel deployments, take
+ * the rightmost trusted IP from a known-length proxy chain instead.
+ *
  * Supports both Fetch API Request and Node.js IncomingHttpHeaders.
  */
 export function getClientIP(

--- a/api/lib/redisKeys.test.ts
+++ b/api/lib/redisKeys.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   shareHashKey,
   shareReportKey,
+  shareLastAccessedKey,
   rateLimitKey,
   sessionKey,
   userSessionsKey,
@@ -18,6 +19,10 @@ describe('redisKeys', () => {
 
     it('shareReportKey produces share:reports:{id}', () => {
       expect(shareReportKey('abc123')).toBe('share:reports:abc123');
+    });
+
+    it('shareLastAccessedKey produces share:lastAccessed:{id}', () => {
+      expect(shareLastAccessedKey('abc123')).toBe('share:lastAccessed:abc123');
     });
   });
 
@@ -53,7 +58,7 @@ describe('redisKeys', () => {
 
   describe('namespace separation', () => {
     it('share keys never collide with sync keys', () => {
-      const shareKeys = [shareHashKey('a'), shareReportKey('a')];
+      const shareKeys = [shareHashKey('a'), shareReportKey('a'), shareLastAccessedKey('a')];
       const syncKeys = [
         sessionKey('a'),
         userSessionsKey('a'),
@@ -84,6 +89,7 @@ describe('redisKeys', () => {
       const shared = await import('./shared');
       expect(shared.shareHashKey).toBe(shareHashKey);
       expect(shared.shareReportKey).toBe(shareReportKey);
+      expect(shared.shareLastAccessedKey).toBe(shareLastAccessedKey);
     });
   });
 });

--- a/api/lib/redisKeys.ts
+++ b/api/lib/redisKeys.ts
@@ -8,6 +8,7 @@
  * Namespaces in use:
  *   share:hash:{id}                 → delete-token hash for an anonymous share
  *   share:reports:{id}              → abuse-report counter for a share
+ *   share:lastAccessed:{id}         → ISO timestamp of last GET for a share
  *   ratelimit:{action}:{scope}      → sliding-window rate-limit counter
  *   session:{token}                 → user session record (sync feature)
  *   users:{uid}:sessions            → SET of session tokens owned by a user
@@ -26,6 +27,11 @@ export function shareHashKey(shareId: string): string {
 /** Abuse-report counter for an anonymous share. */
 export function shareReportKey(shareId: string): string {
   return `share:reports:${shareId}`;
+}
+
+/** ISO timestamp of the last GET for a share (cheap view-tracking, no blob write). */
+export function shareLastAccessedKey(shareId: string): string {
+  return `share:lastAccessed:${shareId}`;
 }
 
 /** Sliding-window rate-limit counter. `scope` is hashedIP for anonymous, userId for authed. */

--- a/api/lib/shared.ts
+++ b/api/lib/shared.ts
@@ -132,7 +132,10 @@ export interface ShareMetadata {
 
 // Redis key builders live in `./redisKeys.ts` (single source of truth).
 // Re-exported here to preserve existing import paths from share endpoints.
-export { shareHashKey, shareReportKey } from './redisKeys.js';
+export { shareHashKey, shareReportKey, shareLastAccessedKey } from './redisKeys.js';
+
+/** TTL for share:lastAccessed keys (1 year — matches the report-counter TTL). */
+export const SHARE_LAST_ACCESSED_TTL_SECONDS = 365 * 24 * 60 * 60;
 
 /**
  * Shared data structure for stored shares.

--- a/api/lib/shared.ts
+++ b/api/lib/shared.ts
@@ -123,7 +123,13 @@ export interface ShareMetadata {
   deleteTokenHash?: string;
   createdAt: string;
   lastUpdatedAt: string;
-  lastAccessedAt: string;
+  /**
+   * Last-access tracking lives in Redis (share:lastAccessed:{id}) — the blob
+   * field is only retained for backwards compatibility with pre-migration
+   * shares. New shares omit it entirely; PUT clears it on legacy shares.
+   * Code reading "when was this last accessed" MUST consult Redis, not this.
+   */
+  lastAccessedAt?: string;
   permission: 'view' | 'edit';
   authorName?: string;
   /** Stored in Redis (share:reports:{id}). May be present in blob for pre-migration shares. */

--- a/api/liveblocks-auth.ts
+++ b/api/liveblocks-auth.ts
@@ -14,6 +14,15 @@ import type { ShareData } from './lib/shared.js';
  * - 'edit' permission grants FULL_ACCESS (read + write)
  * - 'view' permission grants READ_ACCESS (read only)
  *
+ * SECURITY — userId trust model:
+ * `userId` is supplied by the client and only checked for non-empty string.
+ * It is signed into the Liveblocks token but is NOT a privilege boundary —
+ * room access is gated by the share's permission level, not by who claims
+ * which userId. Two clients can claim the same userId and become
+ * indistinguishable in presence/cursors. Acceptable for an anonymous-only
+ * product; if identity becomes a privilege concern (private rooms, named
+ * accounts), issue userIds server-side and tie them to a session cookie.
+ *
  * @see https://liveblocks.io/docs/authentication
  */
 

--- a/api/report/[id].ts
+++ b/api/report/[id].ts
@@ -5,6 +5,15 @@ import { REPORT_THRESHOLD } from '../lib/contentFilter.js';
 import { isValidShareId, ErrorCode, methodNotAllowed, shareReportKey } from '../lib/shared.js';
 import { logger } from '../lib/logger.js';
 
+/**
+ * SECURITY — report counter inflation:
+ * Counters are protected only by per-IP rate limiting (10/hr). A botnet
+ * with 5+ residential IPs can reach REPORT_THRESHOLD on any share, so
+ * the threshold is currently a manual-review trigger only — there is NO
+ * automated takedown. Before wiring up automated takedown, add a CAPTCHA
+ * (or proof-of-work, or unique-IP requirement) to the report flow so the
+ * threshold can't be hit by IP rotation alone.
+ */
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end();
   if (req.method !== 'POST') {

--- a/api/share.ts
+++ b/api/share.ts
@@ -123,7 +123,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       logger.error('Share creation failed: Redis unavailable, cannot persist delete token hash');
       return res.status(503).json({
         error: 'Service temporarily unavailable. Please try again.',
-        code: ErrorCode.SERVER_ERROR,
+        code: ErrorCode.SERVICE_UNAVAILABLE,
       });
     }
 
@@ -133,28 +133,35 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const nowIso = new Date().toISOString();
 
     // deleteTokenHash and reportCount are in Redis, not in the public blob,
-    // to prevent exposure via the CDN URL.
+    // to prevent exposure via the CDN URL. lastAccessedAt is also in Redis
+    // (share:lastAccessed:{id}); we omit it from the blob to avoid persisting
+    // a permanently-stale creation-time value that could mislead future
+    // tooling reading directly from the blob.
     const shareData: ShareData = {
       layout: sharePayload,
       metadata: {
         createdAt: nowIso,
         lastUpdatedAt: nowIso,
-        lastAccessedAt: nowIso,
         permission,
         authorName: typeof authorName === 'string' ? authorName.slice(0, 64) : undefined,
       },
     };
 
-    // Acquire the slot atomically: put() with allowOverwrite=false (default)
-    // is the CAS primitive. Two concurrent POSTs racing on the same shareId
-    // produce exactly one winner here; the loser throws and we return 409.
-    // This must happen BEFORE the Redis hash write — otherwise the loser's
-    // hash could clobber the winner's hash in Redis (the original bug).
+    // Acquire the slot atomically: put() with allowOverwrite=false is the CAS
+    // primitive. Two concurrent POSTs racing on the same shareId produce
+    // exactly one winner here; the loser throws and we return 409. This must
+    // happen BEFORE the Redis hash write — otherwise the loser's hash could
+    // clobber the winner's hash in Redis (the original bug).
+    //
+    // SECURITY: allowOverwrite MUST stay false. The MED-1 race fix depends on
+    // it. Don't rely on the library default (which is currently false but
+    // could change in a future major version).
     try {
       await put(blobPath, JSON.stringify(shareData), {
         access: 'public',
         contentType: 'application/json',
         addRandomSuffix: false,
+        allowOverwrite: false,
       });
     } catch (putErr) {
       // The blob already exists (or some other put failure). Probe with head()

--- a/api/share.ts
+++ b/api/share.ts
@@ -1,4 +1,4 @@
-import { put, head } from '@vercel/blob';
+import { put, head, del } from '@vercel/blob';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP, getRedis } from './lib/rateLimit.js';
 import { logger } from './lib/logger.js';
@@ -114,29 +114,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     // Use client-provided layoutId as the share ID
     const shareId = layoutId;
+    const blobPath = `shares/${shareId}.json`;
 
-    // Prevent overwriting an existing share with the same ID
-    const existing = await head(`shares/${shareId}.json`).catch(() => null);
-    if (existing) {
-      return res.status(409).json({
-        error: 'A share with this ID already exists.',
-        code: ErrorCode.VALIDATION_ERROR,
-      });
-    }
-
-    const deleteToken = generateDeleteToken();
-    const deleteTokenHash = await hashToken(deleteToken);
-
-    const now = new Date();
-    const nowIso = now.toISOString();
-
-    // Store deleteTokenHash in Redis (not in the public blob).
-    // Fail-closed in production: if Redis is unavailable the hash can't be persisted,
-    // which would make the share permanently unmodifiable.
+    // Fail-closed in production: if Redis is unavailable, the delete-token hash
+    // can't be persisted (the share would be permanently unmodifiable).
     const redis = getRedis();
-    if (redis) {
-      await redis.set(shareHashKey(shareId), deleteTokenHash);
-    } else if (process.env.VERCEL_ENV === 'production') {
+    if (!redis && process.env.VERCEL_ENV === 'production') {
       logger.error('Share creation failed: Redis unavailable, cannot persist delete token hash');
       return res.status(503).json({
         error: 'Service temporarily unavailable. Please try again.',
@@ -144,8 +127,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       });
     }
 
-    // Prepare data to store — deleteTokenHash and reportCount are in Redis,
-    // not in the public blob, to prevent exposure via the CDN URL.
+    const deleteToken = generateDeleteToken();
+    const deleteTokenHash = await hashToken(deleteToken);
+
+    const nowIso = new Date().toISOString();
+
+    // deleteTokenHash and reportCount are in Redis, not in the public blob,
+    // to prevent exposure via the CDN URL.
     const shareData: ShareData = {
       layout: sharePayload,
       metadata: {
@@ -157,12 +145,46 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       },
     };
 
-    // Store in Vercel Blob
-    await put(`shares/${shareId}.json`, JSON.stringify(shareData), {
-      access: 'public',
-      contentType: 'application/json',
-      addRandomSuffix: false,
-    });
+    // Acquire the slot atomically: put() with allowOverwrite=false (default)
+    // is the CAS primitive. Two concurrent POSTs racing on the same shareId
+    // produce exactly one winner here; the loser throws and we return 409.
+    // This must happen BEFORE the Redis hash write — otherwise the loser's
+    // hash could clobber the winner's hash in Redis (the original bug).
+    try {
+      await put(blobPath, JSON.stringify(shareData), {
+        access: 'public',
+        contentType: 'application/json',
+        addRandomSuffix: false,
+      });
+    } catch (putErr) {
+      // The blob already exists (or some other put failure). Probe with head()
+      // to distinguish "lost the race" from genuine errors.
+      const collided = await head(blobPath).catch(() => null);
+      if (collided) {
+        return res.status(409).json({
+          error: 'A share with this ID already exists.',
+          code: ErrorCode.VALIDATION_ERROR,
+        });
+      }
+      throw putErr;
+    }
+
+    // Persist delete-token hash now that we own the slot. If Redis fails here
+    // we must roll back the blob, otherwise we'd leave an orphan share with
+    // no delete token (permanently unmodifiable).
+    if (redis) {
+      try {
+        await redis.set(shareHashKey(shareId), deleteTokenHash);
+      } catch (redisErr) {
+        await del(blobPath).catch((delErr: unknown) => {
+          logger.error('Rollback failed: orphan blob left after Redis write failure', {
+            id: shareId,
+            error: delErr instanceof Error ? delErr.message : String(delErr),
+          });
+        });
+        throw redisErr;
+      }
+    }
 
     // Return success response
     const shareUrl = `${getBaseUrl()}/${type === 'designer' ? 'd' : 'l'}/${shareId}`;

--- a/api/share/[id].ts
+++ b/api/share/[id].ts
@@ -13,6 +13,8 @@ import {
   getBaseUrl,
   shareHashKey,
   shareReportKey,
+  shareLastAccessedKey,
+  SHARE_LAST_ACCESSED_TTL_SECONDS,
   type ShareData,
 } from '../lib/shared.js';
 
@@ -79,26 +81,26 @@ async function handleGet(req: VercelRequest, res: VercelResponse, _id: string, b
 
     const shareData = (await response.json()) as ShareData;
 
-    // Update lastAccessedAt timestamp (fire-and-forget, don't block response)
-    const now = new Date().toISOString();
-    const updatedData: ShareData = {
-      ...shareData,
-      metadata: {
-        ...shareData.metadata,
-        lastAccessedAt: now,
-      },
-    };
-    put(blobPath, JSON.stringify(updatedData), {
-      access: 'public',
-      contentType: 'application/json',
-      addRandomSuffix: false,
-    }).catch((err: unknown) => {
-      logger.warn('Failed to update lastAccessedAt for share', {
-        id: _id,
-        error: err instanceof Error ? err.message : String(err),
-        stack: err instanceof Error ? err.stack : undefined,
-      });
-    });
+    // Track lastAccessedAt in Redis instead of rewriting the blob on every GET.
+    // Cheap, atomic, and avoids the per-view Blob-write amplification that
+    // existed when this was a put() with allowOverwrite=false (which silently
+    // errored every time). Fire-and-forget — never block the response.
+    const redisForAccess = getRedis();
+    if (redisForAccess) {
+      redisForAccess
+        .set(
+          shareLastAccessedKey(_id),
+          new Date().toISOString(),
+          'EX',
+          SHARE_LAST_ACCESSED_TTL_SECONDS
+        )
+        .catch((err: unknown) => {
+          logger.warn('Failed to update lastAccessedAt for share', {
+            id: _id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+    }
 
     // Return layout with public metadata (exclude sensitive fields)
     return res.status(200).json({
@@ -361,7 +363,7 @@ async function handleDelete(
     // Delete the blob and clean up Redis keys
     await del(blobPath);
     if (redis) {
-      await redis.del(shareHashKey(_id), shareReportKey(_id));
+      await redis.del(shareHashKey(_id), shareReportKey(_id), shareLastAccessedKey(_id));
     }
 
     return res.status(200).json({

--- a/api/share/[id].ts
+++ b/api/share/[id].ts
@@ -202,12 +202,18 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string, bl
 
     const now = new Date().toISOString();
 
+    // Strip the legacy lastAccessedAt field on any rewrite — its source of
+    // truth is now Redis (share:lastAccessed:{id}). Preserving the spread
+    // would carry forward the stale creation-time value indefinitely.
+    const { lastAccessedAt: _drop, ...metadataWithoutAccess } = existingData.metadata;
+    void _drop;
+
     // Permission-only update (no layout provided)
     if (!layout) {
       const updatedData: ShareData = {
         ...existingData,
         metadata: {
-          ...existingData.metadata,
+          ...metadataWithoutAccess,
           permission: newPermission,
           lastUpdatedAt: now,
         },
@@ -249,11 +255,12 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string, bl
       });
     }
 
-    // Update share data (preserve original deleteTokenHash and createdAt)
+    // Update share data (preserve original deleteTokenHash and createdAt;
+    // drop legacy lastAccessedAt — see note above).
     const updatedData: ShareData = {
       layout: validationResult.layout,
       metadata: {
-        ...existingData.metadata,
+        ...metadataWithoutAccess,
         permission: newPermission,
         lastUpdatedAt: now,
       },


### PR DESCRIPTION
## Summary

Closes all MED and LOW findings from the 2026-05 security audit. No exploitable findings remain. Quality gate green; full unit suite (10,442 tests) passing.

## Findings addressed

### MED-1 — Share-creation race (`api/share.ts`)
The old flow used `head()`-then-409 as a pre-check, then wrote the delete-token hash to Redis, **then** wrote the blob. Two concurrent POSTs racing on the same `shareId` (or a transient `head()` failure) could leave the **losing** requester holding the **winner's** delete-token hash in Redis.

**Fix:** Use `put({ allowOverwrite: false })` as the atomic CAS lock. The blob write is the slot-acquisition primitive; only after it succeeds do we write the Redis hash. If Redis write fails, the orphan blob is rolled back via `del()`.

### MED-2 — Content-filter Unicode bypass (`api/lib/contentFilter.ts`)
Verified working bypasses (all now blocked):
- Cyrillic homoglyphs: `niggеr` (U+0435 instead of `e`)
- Zero-width chars: `ni​gger`, `ni‍gger`, `ni﻿gger`
- Fullwidth: `ｎｉｇｇｅｒ`
- Single combining accent: `ńigger`
- Digit substitution: `n1gger`

**Fix:** NFKD-decompose, lowercase, strip combining marks (U+0300–U+036F) and zero-width chars (U+200B–U+200D, U+FEFF), then map confusable Cyrillic/Greek/typographic glyphs back to ASCII before blocklist matching. Pattern matching still runs against the raw text so the zalgo detector keeps working.

### MED-3 — `lastAccessedAt` write-on-read (`api/share/[id].ts`)
The GET handler called `put()` without `allowOverwrite: true`, so every view silently threw and the field never updated. Also wasted a Vercel Blob write per view.

**Fix:** Track `lastAccessedAt` in Redis under a new `share:lastAccessed:{id}` key (1-year TTL). Cheap, atomic, no Blob amplification per view.

### LOW-1 — Liveblocks `userId` trust assumption
**Fix:** Added security comment to `api/liveblocks-auth.ts` documenting that `userId` is client-supplied and is *not* a privilege boundary (room access is gated by share permission, not userId).

### LOW-2 — Report-counter inflation across IPs
**Fix:** Added security comment to `api/report/[id].ts` noting that the threshold is currently a manual-review trigger only — must add CAPTCHA / proof-of-work before wiring up automated takedown.

### LOW-3 — Designer params allowlist (`api/lib/designerValidation.ts`)
The validator only deep-validated some `BinParams` fields and stored unknown keys verbatim.

**Fix:** Top-level allowlist (`ALLOWED_PARAM_KEYS`) of legitimate `BinParams` keys. Anything outside the set is dropped before the payload reaches the public blob, including `__proto__`, attacker-controlled junk, and future fields not yet in the schema.

### LOW-4 — `getClientIP()` Vercel-only assumption
**Fix:** Added security comment to `api/lib/rateLimit.ts` documenting that `x-forwarded-for` first-hop trust is safe on Vercel only, and what to change for non-Vercel deployments.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run knip` passes
- [x] Full unit suite passes (10,442 tests in 738 files)
- [x] New tests:
  - 8 Unicode bypass-resistance regressions in `contentFilter.test.ts`
  - 3 allowlist regressions in `designerValidation.test.ts`
  - `shareLastAccessedKey` covered in `redisKeys.test.ts`
- [x] All pre-commit hooks pass (lint-staged, module boundaries, i18n × 4, exhaustiveness, missing-tests, readme reminders)