### PR TITLE
feat(seo): target 'gridfinity generator' with dedicated landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,14 +18,14 @@
     <meta name="revisit-after" content="7 days">
     <link rel="canonical" href="https://gridfinitylayouttool.com/">
 
-    <!-- International targeting: hreflang for multilingual/multiregional SEO -->
-    <!-- All locales point to same URL since language is auto-detected client-side -->
+    <!-- International targeting: only declare languages we actually serve.
+         Per Google's hreflang spec, every URL in the set must serve content
+         in the declared language. The page's body is English; the in-app UI
+         localizes client-side after JS runs, but Google's crawler sees the
+         English noscript fallback, so declaring de/nl/es/fr/pt-BR alternates
+         pointing here would tell Googlebot "the German version is in
+         English" — which can suppress non-English ranking. -->
     <link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/">
-    <link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/">
-    <link rel="alternate" hreflang="nl" href="https://gridfinitylayouttool.com/">
-    <link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/">
-    <link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/">
-    <link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/">
     <link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/">
 
     <!-- Open Graph / Facebook -->

--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-    <title>Gridfinity Layout Tool — Free Bin Generator & Planner</title>
+    <title>Gridfinity Generator & Layout Planner — Free Online Bin & Baseplate Tool</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Gridfinity bin generator, baseplate generator, and layout planner. Make bins and baseplates with configurable dimensions, export STL/STEP/3MF, and plan your drawer layout. Free, runs in your browser.">
-    <meta name="keywords" content="gridfinity, gridfinity generator, gridfinity bin generator, gridfinity layout, drawer organizer, 3D printing, gridfinity planner, gridfinity STL, gridfinity bins">
+    <meta name="description" content="Free Gridfinity generator and layout planner. Make custom bins and baseplates, configure dimensions and features, preview in 3D, and export STL/STEP/3MF. Runs in your browser, no account, works offline.">
+    <meta name="keywords" content="gridfinity generator, gridfinity, gridfinity bin generator, gridfinity baseplate generator, gridfinity layout, drawer organizer, 3D printing, gridfinity planner, gridfinity STL, gridfinity bins, gridfinity 3MF">
     <meta name="author" content="Andy Aragon">
     <meta name="robots" content="index, follow">
     <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
@@ -31,8 +31,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://gridfinitylayouttool.com/">
-    <meta property="og:title" content="Gridfinity Layout Tool — Free Bin Generator & Planner">
-    <meta property="og:description" content="Gridfinity bin generator and layout planner. Make bins with configurable dimensions, export STL/STEP/3MF, and plan your drawer layout. Free, runs in your browser.">
+    <meta property="og:title" content="Gridfinity Generator & Layout Planner — Free Online Bin & Baseplate Tool">
+    <meta property="og:description" content="Free Gridfinity generator and layout planner. Make custom bins and baseplates, configure dimensions, preview in 3D, and export STL/STEP/3MF. Runs in your browser.">
     <meta property="og:image" content="https://gridfinitylayouttool.com/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -43,8 +43,8 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://gridfinitylayouttool.com/">
-    <meta name="twitter:title" content="Gridfinity Layout Tool — Free Bin Generator & Planner">
-    <meta name="twitter:description" content="Gridfinity bin generator and layout planner. Make bins with configurable dimensions, export STL/STEP/3MF, and plan your drawer layout. Free, runs in your browser.">
+    <meta name="twitter:title" content="Gridfinity Generator & Layout Planner — Free Online Bin & Baseplate Tool">
+    <meta name="twitter:description" content="Free Gridfinity generator and layout planner. Make custom bins and baseplates, configure dimensions, preview in 3D, and export STL/STEP/3MF. Runs in your browser.">
     <meta name="twitter:image" content="https://gridfinitylayouttool.com/og-image.png">
     <meta name="twitter:image:alt" content="Gridfinity Layout Tool interface showing a grid-based drawer layout editor with colorful storage bins">
 
@@ -280,7 +280,7 @@
         "@context": "https://schema.org",
         "@type": "WebSite",
         "name": "Gridfinity Layout Tool",
-        "alternateName": ["Gridfinity Planner", "Gridfinity Bin Generator", "Gridfinity Baseplate Generator", "Gridfinity Drawer Organizer Tool", "Gridfinity Bin Layout Tool", "Gridfinity STL Generator"],
+        "alternateName": ["Gridfinity Generator", "Gridfinity Bin Generator", "Gridfinity Baseplate Generator", "Gridfinity Planner", "Gridfinity Drawer Organizer Tool", "Gridfinity Bin Layout Tool", "Gridfinity STL Generator"],
         "url": "https://gridfinitylayouttool.com/",
         "description": "Gridfinity bin generator and drawer layout planner. Free, runs in your browser.",
         "inLanguage": "en-US",

--- a/public/gridfinity-baseplate-generator/index.html
+++ b/public/gridfinity-baseplate-generator/index.html
@@ -217,7 +217,7 @@
   <!-- Main Content -->
   <main id="main-content" class="content-page content-body">
 <h1 class="content-h1">Gridfinity Baseplate Generator</h1>
-<p>A parametric baseplate generator that runs in your browser. Set your grid size, configure magnet holes and edge padding, check the 3D preview, and download an STL, STEP, or 3MF file. Nothing to install.</p>
+<p>A parametric baseplate generator that runs in your browser. Set your grid size, configure magnet holes and edge padding, check the 3D preview, and download an STL, STEP, or 3MF file. Nothing to install. Part of the <a href="/gridfinity-generator">Gridfinity Generator</a> suite, which also includes the bin generator and the layout planner.</p>
 
 <p><a href="/baseplate?standalone=1" class="content-cta">Start Generating &rarr;</a></p>
 
@@ -297,6 +297,7 @@
   <footer class="content-page">
     <div class="content-footer">
       <div class="content-footer__links">
+        <a href="/gridfinity-generator">Generator</a>
         <a href="/what-is-gridfinity">What is Gridfinity?</a>
         <a href="/gridfinity-bin-generator">Bin Generator</a>
         <a href="/gridfinity-baseplate-generator">Baseplate Generator</a>

--- a/public/gridfinity-bin-generator/index.html
+++ b/public/gridfinity-bin-generator/index.html
@@ -213,7 +213,7 @@
   <!-- Main Content -->
   <main id="main-content" class="content-page content-body">
 <h1 class="content-h1">Gridfinity Bin Generator</h1>
-<p>A parametric bin generator that runs in your browser. Set your dimensions, add compartments or cutouts, check the 3D preview, and download an STL, STEP, or 3MF file. Nothing to install.</p>
+<p>A parametric bin generator that runs in your browser. Set your dimensions, add compartments or cutouts, check the 3D preview, and download an STL, STEP, or 3MF file. Nothing to install. Part of the <a href="/gridfinity-generator">Gridfinity Generator</a> suite, which also includes the baseplate generator and the layout planner.</p>
 
 <p><a href="/designer" class="content-cta">Start Making a Bin &rarr;</a></p>
 
@@ -305,6 +305,7 @@
   <footer class="content-page">
     <div class="content-footer">
       <div class="content-footer__links">
+        <a href="/gridfinity-generator">Generator</a>
         <a href="/what-is-gridfinity">What is Gridfinity?</a>
         <a href="/gridfinity-bin-generator">Bin Generator</a>
         <a href="/gridfinity-baseplate-generator">Baseplate Generator</a>

--- a/public/gridfinity-generator/index.html
+++ b/public/gridfinity-generator/index.html
@@ -1,0 +1,570 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gridfinity Generator — Free Online Bin & Baseplate Generator</title>
+
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Free Gridfinity generator. Make custom bins and baseplates in your browser, preview in 3D, and export STL, STEP, or 3MF. No installation, no account, runs offline.">
+  <meta name="keywords" content="gridfinity generator, gridfinity bin generator, gridfinity baseplate generator, gridfinity STL generator, online gridfinity generator, free gridfinity generator, custom gridfinity, gridfinity 3MF, gridfinity STEP">
+  <meta name="author" content="Andy Aragon">
+  <meta name="robots" content="index, follow">
+  <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
+  <meta name="bingbot" content="index, follow, max-snippet:-1, max-image-preview:large">
+  <link rel="canonical" href="https://gridfinitylayouttool.com/gridfinity-generator">
+
+  <!-- International targeting: hreflang self-references (matches homepage pattern) -->
+  <link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-generator">
+  <link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/gridfinity-generator">
+  <link rel="alternate" hreflang="nl" href="https://gridfinitylayouttool.com/gridfinity-generator">
+  <link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/gridfinity-generator">
+  <link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/gridfinity-generator">
+  <link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/gridfinity-generator">
+  <link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-generator">
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://gridfinitylayouttool.com/gridfinity-generator">
+  <meta property="og:title" content="Gridfinity Generator — Free Online Bin & Baseplate Generator">
+  <meta property="og:description" content="Free Gridfinity generator. Make custom bins and baseplates in your browser, preview in 3D, and export STL, STEP, or 3MF.">
+  <meta property="og:image" content="https://gridfinitylayouttool.com/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="Gridfinity generator interface showing a bin design with compartments and a 3D preview">
+  <meta property="og:site_name" content="Gridfinity Layout Tool">
+  <meta property="og:locale" content="en_US">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://gridfinitylayouttool.com/gridfinity-generator">
+  <meta name="twitter:title" content="Gridfinity Generator — Free Online Bin & Baseplate Generator">
+  <meta name="twitter:description" content="Free Gridfinity generator. Make custom bins and baseplates in your browser, preview in 3D, and export STL, STEP, or 3MF.">
+  <meta name="twitter:image" content="https://gridfinitylayouttool.com/og-image.png">
+  <meta name="twitter:image:alt" content="Gridfinity generator interface showing a bin design with compartments and a 3D preview">
+
+  <!-- Structured Data: SoftwareApplication scoped to "Gridfinity Generator" -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "Gridfinity Generator",
+  "alternateName": ["Gridfinity Bin Generator", "Gridfinity Baseplate Generator", "Gridfinity STL Generator"],
+  "url": "https://gridfinitylayouttool.com/gridfinity-generator",
+  "description": "Free online Gridfinity generator for bins and baseplates. Set dimensions, configure features, preview in 3D, and export STL, STEP, or 3MF. Runs in your browser, works offline as a PWA.",
+  "applicationCategory": "DesignApplication",
+  "applicationSubCategory": "3D Printing Tools",
+  "operatingSystem": "Any",
+  "browserRequirements": "Requires JavaScript. Requires HTML5.",
+  "permissions": "none",
+  "isAccessibleForFree": true,
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD",
+    "availability": "https://schema.org/InStock"
+  },
+  "author": {
+    "@type": "Person",
+    "name": "Andy Aragon"
+  },
+  "featureList": [
+    "Parametric bin generator with real-time 3D preview",
+    "Parametric baseplate generator with magnet hole grid",
+    "STL, STEP, and 3MF export",
+    "Six base attachment styles (standard, magnet, screw, magnet+screw, weighted, flat)",
+    "Configurable compartments up to 8 by 8",
+    "Per-side wall cutouts (U-shape, scoop, funnel)",
+    "Label tabs with bracket or solid support",
+    "Honeycomb wall patterns",
+    "Floor inserts (rectangle, circle, hexagon, slot)",
+    "Custom-shape footprint via cell mask",
+    "Half-bin mode for 0.5 unit precision",
+    "Automatic baseplate splitting to fit any print bed",
+    "Configurable per-side baseplate edge padding",
+    "Magnet holes (6mm x 2mm) at every grid intersection",
+    "Filament usage estimate",
+    "Works offline as a Progressive Web App",
+    "No account, no installation, no ads"
+  ]
+}
+  </script>
+
+  <!-- Structured Data: HowTo - "How to use the Gridfinity Generator" -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to use the Gridfinity Generator",
+  "description": "Pick the generator (bin or baseplate), set your dimensions, configure features, preview the result in 3D, and download an STL, STEP, or 3MF file ready for slicing.",
+  "image": "https://gridfinitylayouttool.com/og-image.png",
+  "totalTime": "PT3M",
+  "tool": [
+    { "@type": "HowToTool", "name": "Web browser" },
+    { "@type": "HowToTool", "name": "3D printer (for printing the result)" }
+  ],
+  "supply": [
+    { "@type": "HowToSupply", "name": "PLA, PETG, or ABS filament" }
+  ],
+  "step": [
+    {
+      "@type": "HowToStep",
+      "name": "Open the generator",
+      "text": "Pick the bin generator for storage bins or the baseplate generator for the grid that bins clip into. Both run in your browser.",
+      "position": 1
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Set the dimensions",
+      "text": "Bins and baseplates use the standard Gridfinity 42mm grid unit. Enter width and depth in grid units. For bins, enter height in 7mm units. Enable half-bin mode if you need 0.5 unit precision.",
+      "position": 2
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Configure features",
+      "text": "For bins, choose a base attachment style and toggle compartments, scoop ramps, label tabs, wall cutouts, or floor inserts. For baseplates, toggle magnet holes and set per-side edge padding.",
+      "position": 3
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Preview in 3D",
+      "text": "The 3D preview updates in real time as you change parameters. Rotate, zoom, and inspect from every angle before exporting.",
+      "position": 4
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Export the file",
+      "text": "Download as STL for slicing, STEP for further CAD editing, or 3MF for color and material metadata. Large baseplates split automatically to fit your print bed.",
+      "position": 5
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Slice and print",
+      "text": "Open the file in PrusaSlicer, OrcaSlicer, Bambu Studio, Cura, or any other slicer. Most Gridfinity bins print well with 0.2mm layers and 15 to 20 percent infill.",
+      "position": 6
+    }
+  ]
+}
+  </script>
+
+  <!-- Structured Data: FAQPage - 18 unique questions targeting "gridfinity generator" intent -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is the Gridfinity Generator free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The Gridfinity Generator is completely free, has no ads, requires no account, and works offline once loaded. There is no paid tier and no usage limit."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What does the Gridfinity Generator make?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It generates two things: storage bins and the baseplates they clip into. Both are produced as ready-to-print files in STL, STEP, or 3MF format. You can also plan a whole drawer layout, place bins on it, and export a print list."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need to install software to use the Gridfinity Generator?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. It runs entirely in your browser. There is nothing to download or install. You can also install it as a Progressive Web App for offline use."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does the Gridfinity Generator work on mobile?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The generator works on iPhone, iPad, Android phones and tablets. You can configure a bin on your phone, save it to your device, and email or AirDrop the STL to a desktop slicer."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What file formats does the Gridfinity Generator export?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "STL for direct slicing, STEP for editing in CAD applications like Fusion 360 or FreeCAD, and 3MF for slicers that benefit from richer metadata such as color or material assignments. Most modern slicers accept all three formats."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will bins from the generator fit my existing Gridfinity baseplates?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The generator follows the standard Gridfinity 42mm grid and the standard socket profile, so bins fit any official or community-made Gridfinity baseplate. The same applies in reverse: baseplates from the generator accept any standard Gridfinity bin."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can the Gridfinity Generator make baseplates with magnet holes?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The baseplate generator places 6mm by 2mm magnet holes at each grid intersection by default. You can toggle them off if you do not want magnets, or keep them and skip the magnets while printing."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are there size limits in the Gridfinity Generator?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Bins can be up to 8 by 8 grid units (336mm by 336mm) and 20 height units (140mm) tall. Baseplates can be larger and are automatically split into pieces that fit your printer bed when needed."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does the Gridfinity Generator support half-bin sizes?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Enable half-bin mode for 0.5 unit precision, which lets you make bins like 1.5 by 2.5 to fit awkward drawer gaps. Half-bin support extends through the layout planner so half-size bins place cleanly next to full-size ones."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I customize the bin floor and walls?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. You can add compartments with removable dividers, scoop ramps for easier access, label tabs on the back wall, U-shape or scoop cutouts on any wall, honeycomb wall patterns, and shaped floor inserts (rectangle, circle, hexagon, slot, rounded rectangle) for organizing parts."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does the Gridfinity Generator compare to OpenSCAD scripts?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "OpenSCAD scripts are powerful but require installing software, editing parameters in code, and waiting for renders. The Gridfinity Generator runs in your browser, gives you a visual interface with sliders and toggles, and previews in 3D in real time. Both produce standard-compliant files."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does the Gridfinity Generator compare to Fusion 360?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Fusion 360 is a full parametric CAD package with a steep learning curve. The Gridfinity Generator is purpose-built for Gridfinity, so common tasks (set dimensions, add a magnet base, export STL) take seconds rather than minutes. If you want to combine a Gridfinity bin with custom geometry, export STEP and continue editing in Fusion."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Should I use the Gridfinity Generator or download bins from MakerWorld and Printables?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Use the generator when you need an exact size, a specific feature (label tab, magnet holes, scoop), or a custom-shape footprint. Use MakerWorld or Printables when someone has already designed a specialized holder for the exact item you want to store, like a multi-tool or a specific socket set."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I save my Gridfinity Generator designs?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Designs save automatically to your browser. You can name them, come back later, and export shareable links so others can open the same configuration. No account is required."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does the Gridfinity Generator estimate filament usage?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The print modal shows an estimated filament length and weight per bin. Useful for budgeting filament when planning a full drawer of bins."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is my data private when I use the Gridfinity Generator?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "All bin and baseplate generation runs locally in your browser. Designs persist in your browser's local storage and are never uploaded unless you explicitly create a shareable link. Anonymous usage analytics help us improve the tool, with no personal data attached."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does the Gridfinity Generator support multi-color or multi-material printing?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The 3MF export carries per-feature color metadata, so slicers like Bambu Studio and OrcaSlicer can paint different parts of the bin in different filaments. Useful for color-coded label tabs or two-tone bins on multi-material printers."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which slicers work with the Gridfinity Generator output?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "All major slicers: PrusaSlicer, OrcaSlicer, Bambu Studio, Cura, SuperSlicer, IdeaMaker, and Simplify3D. The STL output is standard and slicer-agnostic. The 3MF output is best with slicers that read multi-material metadata."
+      }
+    }
+  ]
+}
+  </script>
+
+  <!-- Structured Data: BreadcrumbList -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://gridfinitylayouttool.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Gridfinity Generator", "item": "https://gridfinitylayouttool.com/gridfinity-generator" }
+  ]
+}
+  </script>
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
+
+  <!-- Styles -->
+  <link rel="stylesheet" href="/content.9609870d.css">
+
+  <!-- Favicon -->
+  <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">
+  <link rel="icon" type="image/png" sizes="48x48" href="/icons/favicon-48.png">
+
+  <!-- Mobile -->
+  <meta name="theme-color" content="#0f0f12">
+</head>
+<body>
+  <!-- Skip to content link for accessibility -->
+  <a href="#main-content" class="skip-link">Skip to content</a>
+
+  <!-- Navigation -->
+  <nav class="content-nav" aria-label="Main navigation">
+    <a href="/" class="content-nav__logo">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <rect x="3" y="3" width="7" height="7" rx="1"/>
+        <rect x="14" y="3" width="7" height="7" rx="1"/>
+        <rect x="3" y="14" width="7" height="7" rx="1"/>
+        <rect x="14" y="14" width="7" height="7" rx="1"/>
+      </svg>
+      <span>Gridfinity Layout Tool</span>
+    </a>
+    <a href="/designer?utm_source=gridfinity-generator&amp;utm_medium=nav" class="content-nav__cta">
+      Open Generator
+    </a>
+  </nav>
+
+  <!-- Main Content -->
+  <main id="main-content" class="content-page content-body">
+
+    <h1 class="content-h1">Gridfinity Generator</h1>
+    <p>A free online Gridfinity generator for storage bins and baseplates. Set the dimensions, pick the features you need, and download an STL, STEP, or 3MF file. It runs in your browser &mdash; nothing to install &mdash; and works offline once loaded. Two generators, one tool, no account.</p>
+
+    <p>
+      <a href="/designer?utm_source=gridfinity-generator&amp;utm_medium=hero&amp;utm_campaign=bin" class="content-cta">Open Bin Generator &rarr;</a>
+      &nbsp;
+      <a href="/baseplate?utm_source=gridfinity-generator&amp;utm_medium=hero&amp;utm_campaign=baseplate" class="content-cta">Open Baseplate Generator &rarr;</a>
+    </p>
+
+    <h2 class="content-h2">What This Generator Makes</h2>
+    <p>Gridfinity is a modular storage system designed by Zack Freedman. It defines a 42mm grid where bins click into baseplates. To actually use Gridfinity, you need both pieces: bins sized to your stuff, and baseplates sized to your drawer. This generator handles both.</p>
+
+    <p><strong>Bins</strong> are the open-top containers that hold your stuff. The bin generator lets you pick a size, choose a base attachment style (plain, magnet, screw, weighted, or flat), then layer on features &mdash; compartments to subdivide the interior, scoop ramps for easy access, label tabs for the back wall, wall cutouts for sliding things out sideways, floor inserts shaped to specific items (circles for batteries, hexagons for bits), and decorative wall patterns.</p>
+
+    <p><strong>Baseplates</strong> are the grid that bins clip into. The baseplate generator lets you set the grid size, configure 6mm by 2mm magnet holes at every intersection, add per-side edge padding so the baseplate fits your drawer exactly, and split large baseplates into pieces that fit your printer bed automatically.</p>
+
+    <p>You can also use the generator's <a href="/">layout planner</a> to lay bins out on a baseplate, drag them around, and export a print list of every bin you need. That's the third tool in the suite, but the bin and baseplate generators are the parametric workhorses.</p>
+
+    <h2 class="content-h2">How It Works</h2>
+    <ol class="content-list">
+      <li><strong>Pick the generator.</strong> Open the bin generator if you're making storage bins, or the baseplate generator if you're making the grid they clip into.</li>
+      <li><strong>Set the dimensions.</strong> Width and depth in grid units (1 unit = 42mm). Height in units of 7mm for bins. Half-bin mode lets you go in 0.5 unit increments.</li>
+      <li><strong>Configure features.</strong> Toggle and adjust the parts you need. Defaults are sensible &mdash; you can ship a basic bin with two clicks.</li>
+      <li><strong>Preview in 3D.</strong> The render updates live as you change parameters. Drag to rotate, scroll to zoom, click again to deselect.</li>
+      <li><strong>Export.</strong> Download as STL, STEP, or 3MF. Large baseplates split into multiple files automatically.</li>
+      <li><strong>Slice and print.</strong> Open the file in your slicer of choice. Standard Gridfinity prints fine at 0.2mm layers with 15&ndash;20% infill.</li>
+    </ol>
+
+    <div class="content-callout">
+      <p>Everything runs locally. Nothing is uploaded unless you explicitly create a shareable link.</p>
+    </div>
+
+    <h2 class="content-h2">Bin Generator: What You Can Configure</h2>
+
+    <h3 class="content-h3">Dimensions</h3>
+    <p>Width, depth, and height. Width and depth go from 0.5 to 8 grid units (21mm to 336mm). Height goes from 2 to 20 height units (14mm to 140mm). One height unit equals 7mm, which is the standard Gridfinity unit defined by Zack Freedman's original spec.</p>
+
+    <h3 class="content-h3">Base Attachment Styles</h3>
+    <p>Six options for how the bin sits on a baseplate:</p>
+    <ul class="content-list">
+      <li><strong>Standard</strong> &mdash; the default Gridfinity socket. Works with all baseplates.</li>
+      <li><strong>Magnet</strong> &mdash; cavities for 6mm by 2mm magnets. Glue magnets in to keep bins from sliding.</li>
+      <li><strong>Screw</strong> &mdash; threaded holes for M3 inserts. Good for heavy bins or in vehicles.</li>
+      <li><strong>Magnet &amp; Screw</strong> &mdash; both. Maximum hold for things you don't want moving.</li>
+      <li><strong>Weighted</strong> &mdash; thicker base for ballast without hardware.</li>
+      <li><strong>Flat</strong> &mdash; no socket at all. For when you want a bin shape but no Gridfinity attachment.</li>
+    </ul>
+
+    <h3 class="content-h3">Compartments</h3>
+    <p>Split the interior into a grid of up to 8 by 8 compartments. The generator builds the dividers automatically and adjusts wall thickness for the size you've chosen. Dividers can also be exported as separate removable pieces &mdash; useful when you want to reconfigure a bin without reprinting it.</p>
+
+    <h3 class="content-h3">Wall Features</h3>
+    <p>Three wall features address different use cases:</p>
+    <ul class="content-list">
+      <li><strong>Wall cutouts</strong> &mdash; U-shape, scoop, or funnel notches on any of the four sides plus interior dividers. Lets you slide things out sideways or thread cables through.</li>
+      <li><strong>Scoop ramps</strong> &mdash; angled floor at the front so small parts collect at the front edge for easy pickup.</li>
+      <li><strong>Wall patterns</strong> &mdash; honeycomb or other decorative patterns for ventilated bins or just visual style.</li>
+    </ul>
+
+    <h3 class="content-h3">Label Tabs</h3>
+    <p>A small shelf on the back wall for label strips. Pick bracket support (lighter, prints faster) or solid support (more rigid). Configure the tab depth, width, and per-column alignment. Label tabs are nice for tool drawers where you want to mark what's in each bin without reading it.</p>
+
+    <h3 class="content-h3">Floor Inserts</h3>
+    <p>Cavities cut into the bin floor in five shapes &mdash; rectangle, circle, hexagon, rounded rectangle, slot &mdash; with configurable depth and rotation. This is what you use to make a battery holder, a bit holder, an O-ring tray, or a screw sorter. Place up to 20 inserts per bin and configure each one independently.</p>
+
+    <h3 class="content-h3">Custom Shapes</h3>
+    <p>Most bins are rectangles, but the generator also supports custom footprints via a cell mask. Switch to mask mode and paint cells on a half-bin grid &mdash; the bin becomes that shape. Useful for fitting awkward drawer corners or building L-shaped or T-shaped bins. The mask is preserved in shareable links.</p>
+
+    <h3 class="content-h3">Cutout Editor</h3>
+    <p>For shapes that don't fit any preset, the cutout editor lets you draw freeform paths with a pen tool. Bezier handles let you make smooth curves; corner mode locks angles for straight cuts. Carve out the silhouette of a wrench, a multitool, or anything else &mdash; the generator creates the cavity automatically.</p>
+
+    <h2 class="content-h2">Baseplate Generator: What You Can Configure</h2>
+
+    <h3 class="content-h3">Grid Size</h3>
+    <p>Width and depth in grid units. The generator scales seamlessly from 1 by 1 up to drawer-sized baseplates of dozens of units per side.</p>
+
+    <h3 class="content-h3">Magnet Holes</h3>
+    <p>Standard Gridfinity uses 6mm by 2mm round magnets at each grid intersection. The baseplate generator places them by default; you can disable them entirely if you don't want magnets. Magnets keep bins from sliding when the drawer opens or closes, which matters if you're carrying the drawer or running a tool truck.</p>
+
+    <h3 class="content-h3">Edge Padding</h3>
+    <p>Drawers rarely measure to a clean multiple of 42mm. Edge padding adds extra material to each side of the baseplate so it fills the drawer end-to-end without wasted space. Padding can be different on each side, which lets you center the grid or push it toward one edge.</p>
+
+    <h3 class="content-h3">Print Bed Splitting</h3>
+    <p>Set your printer's bed size and the generator splits large baseplates into pieces that fit. Each piece comes out aligned so they tile back together perfectly. Optional dovetail or tongue-and-groove connectors keep the pieces aligned during use.</p>
+
+    <h2 class="content-h2">Output Formats</h2>
+    <p>Three export formats, picked for different downstream tools.</p>
+    <table>
+      <thead>
+        <tr><th>Format</th><th>When to use it</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>STL</strong></td>
+          <td>Standard 3D printing format. Open in any slicer. The default unless you have a specific reason to pick something else.</td>
+        </tr>
+        <tr>
+          <td><strong>STEP</strong></td>
+          <td>Parametric CAD format. Open in Fusion 360, FreeCAD, SolidWorks, Onshape, or any other CAD package. Useful when you want to combine a Gridfinity bin with custom geometry, or when you want clean editable surfaces rather than triangulated mesh.</td>
+        </tr>
+        <tr>
+          <td><strong>3MF</strong></td>
+          <td>Modern format with metadata for color and material. Best paired with multi-material printers (Bambu A1 / X1, Prusa XL with toolchanger, MMU3). Slicers that support 3MF preserve the per-feature color hints from the generator, so a label-tab bin can print the tab in a different filament without manual painting.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>All three formats are produced from the same source geometry, so dimensions and tolerances are identical regardless of which you pick. Pick by what your slicer or downstream tool prefers.</p>
+
+    <h2 class="content-h2">How It Compares</h2>
+
+    <h3 class="content-h3">vs. OpenSCAD scripts (kennethjiang, vector76, others)</h3>
+    <p>OpenSCAD scripts have been the workhorse of the Gridfinity community since the project started. They are powerful and free. They are also code &mdash; to change a bin's height, you edit a parameter in a text file and re-run the renderer. The render takes seconds for simple bins, minutes for complex ones.</p>
+    <p>This generator runs in your browser with sliders and toggles. The 3D preview is real-time, not a render queue. You can adjust a magnet depth and see the effect instantly. STEP and 3MF outputs are first-class, not after-thoughts. If you're comfortable with OpenSCAD code and the customizer GUI is enough, those scripts are great. If you prefer a visual interface or you're on a phone, this is faster.</p>
+
+    <h3 class="content-h3">vs. Fusion 360 (and other parametric CAD)</h3>
+    <p>Fusion 360 is full-featured CAD: parameters, sketches, history, assemblies, simulations, all of it. You can absolutely build Gridfinity bins in Fusion. The cost is the learning curve and the per-task time &mdash; setting up sketches and constraints for a bin you'll print once is overkill.</p>
+    <p>This generator is single-purpose. It knows what a Gridfinity bin is and what features people add. Common tasks take seconds. The trade-off: if your design needs custom geometry beyond what the generator exposes, you'll hit a wall. The fix is to export STEP and continue editing in Fusion or FreeCAD &mdash; you get the easy parametric scaffolding for free, then take over for the parts the generator can't express.</p>
+
+    <h3 class="content-h3">vs. Downloading from MakerWorld and Printables</h3>
+    <p>MakerWorld and Printables host thousands of Gridfinity bins designed for specific items: socket holders for specific brands, multi-tool inserts, screwdriver organizers. If someone has already designed exactly the holder you need, downloading it is faster than re-designing it.</p>
+    <p>The generator wins for generic bins (you need a 2x3 with a scoop), exact sizes (your drawer is 296mm so you need a 3.5x2.5 with edge padding), and combinations no one else has uploaded (you want a 1x4 with magnets, two compartments, a label tab, and a circular floor insert for a battery). The two approaches complement each other &mdash; a typical drawer mixes generated generic bins with one or two community-designed specialized holders.</p>
+
+    <h2 class="content-h2">Common Use Cases</h2>
+
+    <h3 class="content-h3">Workshop and tool drawers</h3>
+    <p>The most common use of the Gridfinity Generator is organizing tool drawers in a workshop or garage. Wrenches go in long thin bins with scoop ramps; sockets in compartmented bins with circular floor inserts sized to the socket diameter; small parts (screws, washers, O-rings) in 1x1 or 1x2 bins with magnet bases so a closing drawer doesn't fling them around. Label tabs along the back of each bin make tool inventory glanceable, which matters when the drawer is at knee height.</p>
+
+    <h3 class="content-h3">Electronics workbench</h3>
+    <p>For an electronics bench, the generator handles the stuff that doesn't fit anywhere else: SMD component reels, breadboards, jumper-wire bundles, and the disorderly mass of USB cables. Honeycomb wall patterns are popular here because they let you see what's in a bin without picking it up. The cutout editor draws perfect cradles for soldering irons or hot-air guns.</p>
+
+    <h3 class="content-h3">Kitchen drawers</h3>
+    <p>Kitchen-drawer Gridfinity has become a thing in the last year. The generator's per-side wall cutouts are useful for utensil drawers (a U-cutout lets a long wooden spoon stick out one end), and the half-bin mode covers awkward drawer widths. PETG is the recommended material for kitchen use because of its higher temperature tolerance.</p>
+
+    <h3 class="content-h3">Hobby and craft supplies</h3>
+    <p>Crafters use the floor-insert feature for everything from miniature paint pots to bead trays to embroidery floss spools. The custom cutout editor is especially valuable here because hobby items rarely come in standard sizes &mdash; the pen tool lets you draw the exact silhouette of a dice tray, a sewing-machine bobbin, or a brush row.</p>
+
+    <h3 class="content-h3">3D printing supplies (recursive)</h3>
+    <p>Plenty of people print Gridfinity bins to organize the supplies they use to print Gridfinity bins: nozzle bins, hex driver holders, filament sample swatches, M3 hardware. The generator's magnet-and-screw base style is overkill for an indoor desk drawer but exactly right for a tool chest you wheel around.</p>
+
+    <h2 class="content-h2">Printing Tips</h2>
+    <p>Most Gridfinity bins from the generator print with default slicer settings, but a few details produce better results.</p>
+
+    <p><strong>Layer height.</strong> 0.2mm is the standard. Drop to 0.16mm or 0.12mm for prominent label tabs or bins printed in a way that shows top-layer detail. Coarser 0.28mm layers print faster and are fine for utility bins where finish doesn't matter.</p>
+
+    <p><strong>Infill.</strong> 15&ndash;20% gyroid or grid infill is plenty for the bin walls. The base socket and stacking lip benefit from 100% infill in the bottom 1.5mm, which most slicers handle automatically when you set 4 or more bottom layers.</p>
+
+    <p><strong>Supports.</strong> Most bins print without supports. Wall cutouts and label tabs may benefit from tree supports if the geometry overhangs by more than 60 degrees. Floor inserts (cavities cut downward into the floor) never need supports because they're carved out, not built up.</p>
+
+    <p><strong>Material.</strong> PLA is the default and works for almost any indoor application. PETG is the right pick for kitchen drawers, garages, or anywhere temperatures or chemicals are a concern. ABS or ASA add durability for tool drawers in vehicles or unheated workshops. PLA-CF and PETG-CF print with similar settings to their non-carbon variants and produce stiffer bins.</p>
+
+    <p><strong>Print orientation.</strong> Bins print bottom-down, the default orientation when the slicer reads the file. Baseplates also print bottom-down. Don't rotate before slicing &mdash; the file is already oriented for ideal layer adhesion.</p>
+
+    <p><strong>Tolerances.</strong> The generator builds in standard Gridfinity tolerance (~0.25mm clearance on socket fits). If your printer is dimensionally accurate, bins drop into baseplates with a satisfying click. If they're loose, your printer's flow is over-extruding; if they don't fit, your printer's flow is under-extruding. Calibrating flow is the fix &mdash; not adjusting the generator.</p>
+
+    <h2 class="content-h2">Frequently Asked Questions</h2>
+
+    <h3 class="content-h3">Is it really free?</h3>
+    <p>Yes. No paid tier, no premium features behind a wall, no signup, no email collection. Anonymous usage analytics run in the background to help prioritize what to improve, with no personal data attached. The full source for both generators is openly licensed and the code is auditable.</p>
+
+    <h3 class="content-h3">Does it work offline?</h3>
+    <p>Yes. The Gridfinity Generator is a Progressive Web App. After your first visit, it caches itself and works offline indefinitely. You can install it to your home screen on iOS, Android, ChromeOS, or desktop. Useful if your shop's internet is flaky or you want to design while on the road.</p>
+
+    <h3 class="content-h3">What's the difference between the bin generator and the baseplate generator?</h3>
+    <p>Bins are the containers. Baseplates are the grids. You need both to actually use Gridfinity: bins click into baseplates so they don't slide around when you open the drawer. The generators are separate because the parameters are different (bins have compartments and label tabs; baseplates have magnet hole patterns and edge padding) but they share the same Gridfinity standard, so anything you make in one fits anything from the other.</p>
+
+    <h3 class="content-h3">Can I generate hundreds of bins at once?</h3>
+    <p>Use the layout planner. Open a drawer, drag bins onto the grid, then export the print list &mdash; it groups bins by size and tells you exactly how many of each to print. Each unique bin design is a single STL; you print as many copies as you need from the slicer.</p>
+
+    <h3 class="content-h3">How accurate is the generated geometry?</h3>
+    <p>The generator follows Zack Freedman's official Gridfinity spec to within standard 3D printing tolerances. Bins from the generator interlock with community baseplates and vice versa. The standard print tolerance margin is built in, so you don't need to scale or offset anything.</p>
+
+    <h3 class="content-h3">What if I want a feature the generator doesn't have?</h3>
+    <p>Two paths. Either request it (the generator gets new features regularly) or export STEP and add the feature in CAD. STEP preserves edges and faces as parametric geometry, so a Fusion 360 user can add a custom cutout or a fillet without re-modeling the bin.</p>
+
+    <h3 class="content-h3">Does it support custom Gridfinity standards (like Gridfinity Rebuilt or vector76's variants)?</h3>
+    <p>The generator follows the standard 42mm Gridfinity spec. Some community variants change the grid pitch or socket profile &mdash; bins from those variants won't interlock with bins from this generator. If you've already invested in a non-standard variant, stick with the matching generator. For new builds, standard Gridfinity has the largest ecosystem and is the safest choice.</p>
+
+    <h3 class="content-h3">Can I share my designs?</h3>
+    <p>Yes. Both bin and baseplate designs produce shareable links. Send a link, and the recipient opens the same configuration in their browser without any login. Sharing is opt-in &mdash; designs stay local until you create a link.</p>
+
+    <h2 class="content-h2">Open the Generator</h2>
+    <p>Two starting points. Pick the one you need first &mdash; you can switch between them any time.</p>
+    <p>
+      <a href="/designer?utm_source=gridfinity-generator&amp;utm_medium=footer&amp;utm_campaign=bin" class="content-cta">Open Bin Generator &rarr;</a>
+      &nbsp;
+      <a href="/baseplate?utm_source=gridfinity-generator&amp;utm_medium=footer&amp;utm_campaign=baseplate" class="content-cta">Open Baseplate Generator &rarr;</a>
+    </p>
+
+    <p>New to Gridfinity? Start with <a href="/what-is-gridfinity">What is Gridfinity?</a> for the basics, or jump to the <a href="/guide">drawer planning guide</a> if you already know what you want and need to lay it out. The <a href="/gridfinity-sizes">sizes reference</a> covers grid units and standard dimensions.</p>
+
+    <hr>
+
+    <p><small><em>By Andy Aragon, maker of the Gridfinity Layout Tool. Last updated 2026-05-05. The Gridfinity Generator is an independent tool and is not affiliated with Zack Freedman or any company.</em></small></p>
+
+  </main>
+
+  <!-- Footer -->
+  <footer class="content-page">
+    <div class="content-footer">
+      <div class="content-footer__links">
+        <a href="/gridfinity-generator">Generator</a>
+        <a href="/what-is-gridfinity">What is Gridfinity?</a>
+        <a href="/gridfinity-bin-generator">Bin Generator</a>
+        <a href="/gridfinity-baseplate-generator">Baseplate Generator</a>
+        <a href="/gridfinity-sizes">Sizes Reference</a>
+        <a href="/guide">Planning Guide</a>
+        <a href="/privacy">Privacy</a>
+        <a href="/terms">Terms</a>
+      </div>
+      <p class="content-footer__copyright">
+        &copy; 2026 Gridfinity Layout Tool. Free to use.
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/public/gridfinity-generator/index.html
+++ b/public/gridfinity-generator/index.html
@@ -14,13 +14,11 @@
   <meta name="bingbot" content="index, follow, max-snippet:-1, max-image-preview:large">
   <link rel="canonical" href="https://gridfinitylayouttool.com/gridfinity-generator">
 
-  <!-- International targeting: hreflang self-references (matches homepage pattern) -->
+  <!-- International targeting: only declare languages we actually serve.
+       Per Google's hreflang spec, every URL in the set must serve content
+       in the declared language. The page is English-only, so we declare
+       only en + x-default. -->
   <link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-generator">
-  <link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/gridfinity-generator">
-  <link rel="alternate" hreflang="nl" href="https://gridfinitylayouttool.com/gridfinity-generator">
-  <link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/gridfinity-generator">
-  <link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/gridfinity-generator">
-  <link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/gridfinity-generator">
   <link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-generator">
 
   <!-- Open Graph / Facebook -->
@@ -343,7 +341,7 @@
       </svg>
       <span>Gridfinity Layout Tool</span>
     </a>
-    <a href="/designer?utm_source=gridfinity-generator&amp;utm_medium=nav" class="content-nav__cta">
+    <a href="/designer?utm_source=gridfinity-generator&amp;utm_medium=nav&amp;utm_campaign=bin" class="content-nav__cta">
       Open Generator
     </a>
   </nav>

--- a/public/gridfinity-sizes/index.html
+++ b/public/gridfinity-sizes/index.html
@@ -277,6 +277,7 @@ Gap at edges:  2mm width, 16mm depth
   <footer class="content-page">
     <div class="content-footer">
       <div class="content-footer__links">
+        <a href="/gridfinity-generator">Generator</a>
         <a href="/what-is-gridfinity">What is Gridfinity?</a>
         <a href="/gridfinity-bin-generator">Bin Generator</a>
         <a href="/gridfinity-baseplate-generator">Baseplate Generator</a>

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -173,6 +173,7 @@
   <footer class="content-page">
     <div class="content-footer">
       <div class="content-footer__links">
+        <a href="/gridfinity-generator">Generator</a>
         <a href="/what-is-gridfinity">What is Gridfinity?</a>
         <a href="/gridfinity-bin-generator">Bin Generator</a>
         <a href="/gridfinity-baseplate-generator">Baseplate Generator</a>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,7 @@
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://gridfinitylayouttool.com/</loc>
-    <lastmod>2026-01-20</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <image:image>
@@ -13,32 +13,43 @@
     </image:image>
   </url>
   <url>
+    <loc>https://gridfinitylayouttool.com/gridfinity-generator</loc>
+    <lastmod>2026-05-05</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.95</priority>
+    <image:image>
+      <image:loc>https://gridfinitylayouttool.com/og-image.png</image:loc>
+      <image:title>Gridfinity Generator - Free Online Bin and Baseplate Generator</image:title>
+      <image:caption>Free Gridfinity generator for storage bins and baseplates. Configure dimensions and features, preview in 3D, export STL, STEP, or 3MF.</image:caption>
+    </image:image>
+  </url>
+  <url>
     <loc>https://gridfinitylayouttool.com/what-is-gridfinity</loc>
-    <lastmod>2026-01-20</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://gridfinitylayouttool.com/guide</loc>
-    <lastmod>2026-01-20</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://gridfinitylayouttool.com/gridfinity-bin-generator</loc>
-    <lastmod>2026-02-12</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gridfinitylayouttool.com/gridfinity-baseplate-generator</loc>
-    <lastmod>2026-02-28</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gridfinitylayouttool.com/gridfinity-sizes</loc>
-    <lastmod>2026-02-12</lastmod>
+    <lastmod>2026-05-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/public/terms/index.html
+++ b/public/terms/index.html
@@ -144,6 +144,7 @@
   <footer class="content-page">
     <div class="content-footer">
       <div class="content-footer__links">
+        <a href="/gridfinity-generator">Generator</a>
         <a href="/what-is-gridfinity">What is Gridfinity?</a>
         <a href="/gridfinity-bin-generator">Bin Generator</a>
         <a href="/gridfinity-baseplate-generator">Baseplate Generator</a>

--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -151,6 +151,7 @@ ${content}
   <footer class="content-page">
     <div class="content-footer">
       <div class="content-footer__links">
+        <a href="/gridfinity-generator">Generator</a>
         <a href="/what-is-gridfinity">What is Gridfinity?</a>
         <a href="/gridfinity-bin-generator">Bin Generator</a>
         <a href="/gridfinity-baseplate-generator">Baseplate Generator</a>

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,8 @@
   "ignoreCommand": "bash scripts/vercel-ignore.sh",
   "trailingSlash": false,
   "redirects": [
-    { "source": "/generator", "destination": "/gridfinity-bin-generator", "permanent": true },
+    { "source": "/generator", "destination": "/gridfinity-generator", "permanent": true },
+    { "source": "/generators", "destination": "/gridfinity-generator", "permanent": true },
     { "source": "/sizes", "destination": "/gridfinity-sizes", "permanent": true }
   ],
   "headers": [


### PR DESCRIPTION
## Summary

- New `/gridfinity-generator` hub page (~2,800-word long-form pillar) targeting the head term, with two CTAs deep-linking to the existing in-app `/designer` and `/baseplate` routes via UTM-tagged URLs.
- Concentrates topical authority on the head term: `/generator` redirect repointed to the new hub, all 5 existing landing pages cross-link to it, homepage `<title>` / meta / JSON-LD `alternateName` lead with "Gridfinity Generator".
- Sitemap `<lastmod>` bumped to today across all URLs (existing dates were Jan/Feb 2026 — Google had no signal to re-crawl since then) and the new URL added at priority 0.95.

## What ships

### New page (`public/gridfinity-generator/index.html`)

- ~2,800 words of original content — hero, what it generates, how it works, bin generator features, baseplate generator features, output formats, comparison vs OpenSCAD/Fusion 360/MakerWorld, common use cases, printing tips, FAQ
- Four JSON-LD blocks: `SoftwareApplication` scoped to "Gridfinity Generator", `HowTo` (6 steps), `FAQPage` (18 unique Qs targeting head-term intent — none duplicate the homepage's), `BreadcrumbList`
- Two primary CTAs: `/designer?utm_source=gridfinity-generator&utm_medium=hero&utm_campaign=bin` and `/baseplate?…&utm_campaign=baseplate`
- Tertiary CTAs in nav and at the bottom of the page (different `utm_medium` for funnel attribution)
- Hreflang self-references matching the homepage pattern (English-only for v1)
- Author byline + last-updated date (E-E-A-T)
- Honest comparison vs OpenSCAD, Fusion 360, MakerWorld/Printables — explicitly avoids direct-competitor SaaS comparisons (those age into liability)
- Reuses existing `/og-image.png` and `/content.9609870d.css`

### Cross-linking + topical cluster

- 5 existing landing pages (`gridfinity-bin-generator`, `gridfinity-baseplate-generator`, `gridfinity-sizes`, `guide`, `what-is-gridfinity`) get `/gridfinity-generator` as the first footer link
- `gridfinity-bin-generator` and `gridfinity-baseplate-generator` also get an in-content "Part of the Gridfinity Generator suite" link near the top, so authority flows up the cluster from the strongest existing pages
- `scripts/build-content.ts` footer template updated so the 4 markdown-built landing pages (gitignored) regenerate with the link

### Homepage (`index.html`)

- `<title>` now reads "Gridfinity Generator & Layout Planner — Free Online Bin & Baseplate Tool" (preserves both head terms)
- Meta description + OG/Twitter description rewritten to lead with "Gridfinity generator"
- `WebSite.alternateName` JSON-LD now starts with "Gridfinity Generator"
- Keywords meta updated to include "gridfinity baseplate generator", "gridfinity 3MF"

### Sitemap (`public/sitemap.xml`)

- New URL at priority 0.95 with image:image entry
- **All `<lastmod>` values bumped from stale Jan/Feb 2026 → 2026-05-05** — this is the actual lever for triggering Google to re-crawl the site (the staleness itself was signaling "nothing has changed since January")

### Redirects (`vercel.json`)

- `/generator` → `/gridfinity-generator` (was → `/gridfinity-bin-generator`)
- `/generators` → `/gridfinity-generator` (new — covers the plural typo)

## How attribution / tracking works (no inline JS, no bundle bloat)

Static pages can't access build-time env vars. Adding inline PostHog hurts LCP (Core Web Vitals = SEO). Solution: **every CTA carries UTM params**. The React app at `/designer` and `/baseplate` already loads PostHog via the main bundle, and PostHog auto-captures `utm_source`, `utm_medium`, `utm_campaign` on the first pageview. So clicks from the SEO landing page → `/designer` arrive in PostHog with full attribution, with zero additional code on the static page.

UTM convention used:
- `utm_source=gridfinity-generator`
- `utm_medium=hero | nav | footer | mid-page`
- `utm_campaign=bin | baseplate`

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm run lint` clean
- [x] `pnpm run knip` clean
- [x] `pnpm run build` produces `dist/gridfinity-generator/index.html`
- [x] `pnpm exec tsx scripts/build-content.ts` regenerates the 4 markdown-built pages with the new footer link
- [x] All 10,430 unit tests pass
- [x] Sitemap XML validates
- [x] All 4 JSON-LD blocks parse and match the @types they declare
- [x] All pre-commit hooks pass (lint-staged, module boundaries, i18n × 4, exhaustiveness, missing-tests, readme reminders)
- [ ] **Verify on Vercel preview** — open the preview URL, click both CTAs, confirm UTM params land on the React app and PostHog captures them
- [ ] **Manual: verify in GSC after deploy** — submit `https://gridfinitylayouttool.com/sitemap.xml` and request indexing for `/gridfinity-generator`. Note: the apex domain (not www) is the canonical property to submit under.