### PR TITLE
feat(sync): add server endpoints for layouts/designs/manifest/export/account

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -38,21 +38,26 @@ graph TB
 
 ## Endpoints
 
-| Endpoint                        | Method | Rate Limit | Purpose                              |
-| ------------------------------- | ------ | ---------- | ------------------------------------ |
-| `/api/share`                    | POST   | 100/min    | Create layout or designer share      |
-| `/api/share/[id]`               | GET    | 100/min    | Fetch share with metadata            |
-| `/api/share/[id]`               | PUT    | 100/min    | Update share (requires delete token) |
-| `/api/share/[id]`               | DELETE | 100/min    | Delete share (requires delete token) |
-| `/api/report/[id]`              | POST   | 10/hr      | Report inappropriate share           |
-| `/api/liveblocks-auth`          | POST   | 100/min    | Collaborative editing session auth   |
-| `/api/ml-telemetry`             | POST   | 100/min    | Aggregated ML training data          |
-| `/api/auth/login/[provider]`    | GET    | 30/min     | Begin OAuth flow (Google / GitHub)   |
-| `/api/auth/callback/[provider]` | GET    | 30/min     | OAuth code exchange + session mint   |
-| `/api/auth/logout`              | POST   | 100/min    | Clear session cookie + KV row        |
-| `/api/auth/me`                  | GET    | 100/min    | Return signed-in user profile        |
+| Endpoint                        | Method         | Rate Limit | Purpose                                |
+| ------------------------------- | -------------- | ---------- | -------------------------------------- |
+| `/api/share`                    | POST           | 100/min    | Create layout or designer share        |
+| `/api/share/[id]`               | GET            | 100/min    | Fetch share with metadata              |
+| `/api/share/[id]`               | PUT            | 100/min    | Update share (requires delete token)   |
+| `/api/share/[id]`               | DELETE         | 100/min    | Delete share (requires delete token)   |
+| `/api/report/[id]`              | POST           | 10/hr      | Report inappropriate share             |
+| `/api/liveblocks-auth`          | POST           | 100/min    | Collaborative editing session auth     |
+| `/api/ml-telemetry`             | POST           | 100/min    | Aggregated ML training data            |
+| `/api/auth/login/[provider]`    | GET            | 30/min     | Begin OAuth flow (Google / GitHub)     |
+| `/api/auth/callback/[provider]` | GET            | 30/min     | OAuth code exchange + session mint     |
+| `/api/auth/logout`              | POST           | 100/min    | Clear session cookie + KV row          |
+| `/api/auth/me`                  | GET            | 100/min    | Return signed-in user profile          |
+| `/api/sync/layouts/[id]`        | GET/PUT/DELETE | 60–240/min | Per-user layout sync (LWW + tombstone) |
+| `/api/sync/designs/[id]`        | GET/PUT/DELETE | 60–240/min | Per-user Bin Designer design sync      |
+| `/api/sync/manifest`            | GET            | 240/min    | Per-user index + If-Modified-Since 304 |
+| `/api/sync/export`              | GET            | 240/min    | ZIP of all live items + manifest       |
+| `/api/sync/account`             | DELETE         | 60/min     | Cascade-delete account + KV + blobs    |
 
-See [`auth/README.md`](./auth/README.md) for the OAuth setup, cookie shape, and CSRF posture.
+See [`auth/README.md`](./auth/README.md) for the OAuth setup and [`sync/README.md`](./sync/README.md) for sync semantics, quotas, and the LWW + tombstone state machine.
 
 ## Validation Library (`lib/`)
 

--- a/api/lib/quota.test.ts
+++ b/api/lib/quota.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Redis } from 'ioredis';
+import { checkQuota, getQuotaCaps } from './quota';
+import { tombstone, upsertEntry } from './userIndex';
+
+let mockRedis: Redis;
+
+function makeRedisMock() {
+  const store = new Map<string, string>();
+  const hashes = new Map<string, Map<string, string>>();
+  const hsetKey = (k: string, field: string, val: string): number => {
+    const h = hashes.get(k) ?? new Map<string, string>();
+    const isNew = !h.has(field);
+    h.set(field, val);
+    hashes.set(k, h);
+    return isNew ? 1 : 0;
+  };
+  const setKey = (k: string, v: string): 'OK' => {
+    store.set(k, v);
+    return 'OK';
+  };
+  return {
+    get: vi.fn(async (k: string) => store.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => setKey(k, v)),
+    hset: vi.fn(async (k: string, field: string, val: string) => hsetKey(k, field, val)),
+    hget: vi.fn(async (k: string, field: string) => hashes.get(k)?.get(field) ?? null),
+    hgetall: vi.fn(async (k: string) => {
+      const h = hashes.get(k);
+      if (!h) return {};
+      return Object.fromEntries(h);
+    }),
+    pipeline: vi.fn(() => {
+      const queue: Array<() => [Error | null, unknown]> = [];
+      const pipe = {
+        set: (k: string, v: string) => {
+          queue.push(() => [null, setKey(k, v)]);
+          return pipe;
+        },
+        hset: (k: string, field: string, val: string) => {
+          queue.push(() => [null, hsetKey(k, field, val)]);
+          return pipe;
+        },
+        exec: vi.fn(async () => queue.map((fn) => fn())),
+      };
+      return pipe;
+    }),
+  } as unknown as Redis;
+}
+
+describe('checkQuota', () => {
+  beforeEach(() => {
+    mockRedis = makeRedisMock();
+  });
+
+  it('allows the first PUT when the index is empty', async () => {
+    const result = await checkQuota(mockRedis, 'u1', 'layouts', {
+      op: 'put',
+      sizeBytes: 1000,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('blocks PUT when adding would exceed the count cap', async () => {
+    const { maxCount } = getQuotaCaps('layouts');
+    for (let i = 0; i < maxCount; i++) {
+      await upsertEntry(mockRedis, 'u1', 'layouts', `lay-${i}`, {
+        modifiedAt: i,
+        sizeBytes: 100,
+      });
+    }
+    const result = await checkQuota(mockRedis, 'u1', 'layouts', {
+      op: 'put',
+      sizeBytes: 100,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.reason).toBe('count');
+      expect(result.error.current).toBe(maxCount + 1);
+    }
+  });
+
+  it('blocks PUT when adding would exceed the bytes cap', async () => {
+    const { maxBytes } = getQuotaCaps('layouts');
+    await upsertEntry(mockRedis, 'u1', 'layouts', 'big', {
+      modifiedAt: 1,
+      sizeBytes: maxBytes - 100,
+    });
+    const result = await checkQuota(mockRedis, 'u1', 'layouts', {
+      op: 'put',
+      sizeBytes: 200,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.reason).toBe('bytes');
+  });
+
+  it('allows replacing an existing entry without consuming an extra slot', async () => {
+    const { maxCount } = getQuotaCaps('layouts');
+    for (let i = 0; i < maxCount; i++) {
+      await upsertEntry(mockRedis, 'u1', 'layouts', `lay-${i}`, {
+        modifiedAt: i,
+        sizeBytes: 100,
+      });
+    }
+    // Already at the count cap, but replacing — should pass.
+    const result = await checkQuota(mockRedis, 'u1', 'layouts', {
+      op: 'put',
+      sizeBytes: 200,
+      replacingId: 'lay-5',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('replacing frees the old size before adding the new size', async () => {
+    const { maxBytes } = getQuotaCaps('layouts');
+    await upsertEntry(mockRedis, 'u1', 'layouts', 'item', {
+      modifiedAt: 1,
+      sizeBytes: maxBytes - 100,
+    });
+    // Replace with something just under the cap — net change is small enough.
+    const result = await checkQuota(mockRedis, 'u1', 'layouts', {
+      op: 'put',
+      sizeBytes: maxBytes - 50,
+      replacingId: 'item',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('tombstoned entries do not count toward the quota', async () => {
+    const { maxCount } = getQuotaCaps('layouts');
+    for (let i = 0; i < maxCount; i++) {
+      await upsertEntry(mockRedis, 'u1', 'layouts', `lay-${i}`, {
+        modifiedAt: i,
+        sizeBytes: 100,
+      });
+    }
+    await tombstone(mockRedis, 'u1', 'layouts', 'lay-0', 99999);
+    // After deletion, count is at maxCount-1 — a new PUT should pass.
+    const result = await checkQuota(mockRedis, 'u1', 'layouts', {
+      op: 'put',
+      sizeBytes: 100,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('delete intents are never quota-blocked', async () => {
+    const result = await checkQuota(mockRedis, 'u1', 'layouts', {
+      op: 'delete',
+      id: 'whatever',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('layouts and designs have independent quotas', async () => {
+    const { maxCount } = getQuotaCaps('layouts');
+    for (let i = 0; i < maxCount; i++) {
+      await upsertEntry(mockRedis, 'u1', 'layouts', `lay-${i}`, {
+        modifiedAt: i,
+        sizeBytes: 100,
+      });
+    }
+    // Layouts at cap — but a design should still go through.
+    const result = await checkQuota(mockRedis, 'u1', 'designs', {
+      op: 'put',
+      sizeBytes: 100,
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/api/lib/quota.ts
+++ b/api/lib/quota.ts
@@ -1,0 +1,113 @@
+import type { Redis } from 'ioredis';
+import { getIndex, type SyncItemKind } from './userIndex.js';
+
+/**
+ * Per-kind caps. Tombstones are excluded from both axes — deleting an
+ * item frees its slot and bytes immediately.
+ *
+ * Values match the existing `CONSTRAINTS.MAX_LAYOUTS = 100` and the
+ * server-side payload cap of 500 KB per item × 100 items = ~50 MB
+ * theoretical worst case, conservatively bounded to 10 MB total.
+ */
+const QUOTA: Record<SyncItemKind, { maxCount: number; maxBytes: number }> = {
+  layouts: { maxCount: 100, maxBytes: 10 * 1024 * 1024 },
+  designs: { maxCount: 100, maxBytes: 10 * 1024 * 1024 },
+};
+
+export type QuotaErrorReason = 'count' | 'bytes';
+
+export interface QuotaError {
+  type: 'QUOTA_EXCEEDED';
+  reason: QuotaErrorReason;
+  /** Current usage that would result if the write proceeded. */
+  current: number;
+  /** The cap that was hit. */
+  limit: number;
+}
+
+export type QuotaCheck = { ok: true } | { ok: false; error: QuotaError };
+
+export type QuotaIntent =
+  | {
+      op: 'put';
+      /** Size of the new payload in bytes. */
+      sizeBytes: number;
+      /**
+       * If this PUT replaces an existing live entry, its size is freed
+       * before the new size is added — so `replacingId` lets the same
+       * item be updated without consuming an extra slot or extra bytes.
+       */
+      replacingId?: string;
+    }
+  | { op: 'delete'; id: string };
+
+/**
+ * Check whether `intent` would push the user over their quota for `kind`.
+ *
+ * Concurrent-write note: two tabs racing on different items both read
+ * the index, both pass quota, and both write — the total can briefly
+ * exceed the cap by one item. Acceptable: caps are soft ceilings at
+ * this scale, not hard invariants. A Lua-script atomic reservation
+ * would prevent it but isn't worth the complexity.
+ */
+export async function checkQuota(
+  redis: Redis,
+  userId: string,
+  kind: SyncItemKind,
+  intent: QuotaIntent
+): Promise<QuotaCheck> {
+  const caps = QUOTA[kind];
+  const index = await getIndex(redis, userId, kind);
+
+  // Live (non-tombstoned) view.
+  let liveCount = 0;
+  let liveBytes = 0;
+  let replacingExisting = false;
+  let replacingSize = 0;
+  for (const [id, entry] of Object.entries(index)) {
+    if (entry.deletedAt !== undefined) continue;
+    liveCount++;
+    liveBytes += entry.sizeBytes;
+    if (intent.op === 'put' && intent.replacingId === id) {
+      replacingExisting = true;
+      replacingSize = entry.sizeBytes;
+    }
+  }
+
+  if (intent.op === 'delete') {
+    // Deletes always free space — never blocked by quota.
+    return { ok: true };
+  }
+
+  // PUT: project the resulting state.
+  const projectedCount = replacingExisting ? liveCount : liveCount + 1;
+  const projectedBytes = liveBytes - replacingSize + intent.sizeBytes;
+
+  if (projectedCount > caps.maxCount) {
+    return {
+      ok: false,
+      error: {
+        type: 'QUOTA_EXCEEDED',
+        reason: 'count',
+        current: projectedCount,
+        limit: caps.maxCount,
+      },
+    };
+  }
+  if (projectedBytes > caps.maxBytes) {
+    return {
+      ok: false,
+      error: {
+        type: 'QUOTA_EXCEEDED',
+        reason: 'bytes',
+        current: projectedBytes,
+        limit: caps.maxBytes,
+      },
+    };
+  }
+  return { ok: true };
+}
+
+export function getQuotaCaps(kind: SyncItemKind): { maxCount: number; maxBytes: number } {
+  return QUOTA[kind];
+}

--- a/api/lib/rateLimit.ts
+++ b/api/lib/rateLimit.ts
@@ -13,7 +13,9 @@ export type RateLimitAction =
   | 'telemetry'
   | 'auth.start'
   | 'auth.callback'
-  | 'auth.read';
+  | 'auth.read'
+  | 'sync.write'
+  | 'sync.read';
 
 /**
  * Parse Redis URL using WHATWG URL API to avoid deprecated url.parse().
@@ -49,6 +51,11 @@ const RATE_LIMITS: Record<RateLimitAction, RateLimitConfig> = {
   'auth.start': { limit: 30, windowSeconds: 60 }, // 30/minute per IP
   'auth.callback': { limit: 30, windowSeconds: 60 }, // 30/minute per IP
   'auth.read': { limit: 100, windowSeconds: 60 }, // 100/minute per IP
+  // Sync surfaces — keyed by userId (each authenticated user gets their own
+  // budget). Reads accommodate poll bursts across multiple tabs; writes
+  // protect against runaway clients.
+  'sync.write': { limit: 60, windowSeconds: 60 }, // 60/minute per user
+  'sync.read': { limit: 240, windowSeconds: 60 }, // 240/minute per user
 };
 
 interface RateLimitResult {
@@ -78,17 +85,22 @@ export function getRedis(): Redis | null {
 }
 
 /**
- * Check and consume rate limit for an IP address and action type.
- * Uses sliding window counter pattern with Redis.
+ * Check and consume rate limit for a scope (client IP for anonymous
+ * surfaces, userId for authenticated ones) and action type.
+ *
+ * Uses sliding window counter pattern with Redis. The scope value is
+ * hashed before use as a Redis key — for IPs this provides privacy; for
+ * userIds (already pseudonymous SHA-256 hashes) it's redundant but
+ * harmless and keeps the key shape uniform.
  */
 export async function checkRateLimit(
-  ip: string,
+  scope: string,
   action: RateLimitAction
 ): Promise<RateLimitResult> {
   const config = RATE_LIMITS[action];
   const now = Math.floor(Date.now() / 1000);
   const windowStart = now - config.windowSeconds;
-  const key = rateLimitKey(action, hashIP(ip));
+  const key = rateLimitKey(action, hashScope(scope));
 
   const client = getRedis();
 
@@ -151,11 +163,11 @@ export async function checkRateLimit(
 }
 
 /**
- * Hash IP address for privacy (don't store raw IPs).
- * Uses SHA-256 truncated to 16 hex chars for Redis key use.
+ * Hash a scope identifier (IP or userId) for use as a Redis key.
+ * SHA-256 truncated to 16 hex chars; primarily about privacy for IPs.
  */
-function hashIP(ip: string): string {
-  return createHash('sha256').update(ip).digest('hex').slice(0, 16);
+function hashScope(scope: string): string {
+  return createHash('sha256').update(scope).digest('hex').slice(0, 16);
 }
 
 /**

--- a/api/lib/userIndex.test.ts
+++ b/api/lib/userIndex.test.ts
@@ -119,6 +119,20 @@ describe('userIndex', () => {
     expect(Object.keys(index)).toEqual(['valid']);
   });
 
+  it('parseEntry rejects NaN/Infinity values for numeric fields', async () => {
+    const ctx = mockRedis as unknown as { hashes: Map<string, Map<string, string>> };
+    const h = new Map<string, string>();
+    h.set('valid', JSON.stringify({ modifiedAt: 1, sizeBytes: 1 }));
+    // JSON has no NaN/Infinity literals, but a hand-rolled value or a custom
+    // serializer could write 'NaN' / 'Infinity' / 'null' for these fields.
+    h.set('nan-modifiedAt', '{"modifiedAt": null, "sizeBytes": 100}');
+    h.set('inf-deletedAt', JSON.stringify({ modifiedAt: 1, sizeBytes: 0, deletedAt: null }));
+    ctx.hashes.set('users:u1:index:layouts', h);
+
+    const index = await getIndex(mockRedis, 'u1', 'layouts');
+    expect(Object.keys(index)).toEqual(['valid']);
+  });
+
   it('getIndexUpdatedAt returns 0 for a user who has never written', async () => {
     expect(await getIndexUpdatedAt(mockRedis, 'fresh-user')).toBe(0);
   });

--- a/api/lib/userIndex.test.ts
+++ b/api/lib/userIndex.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Redis } from 'ioredis';
+import {
+  getEntry,
+  getIndex,
+  getIndexUpdatedAt,
+  tombstone,
+  upsertEntry,
+  type IndexEntry,
+} from './userIndex';
+
+let mockRedis: Redis;
+
+function makeRedisMock() {
+  const store = new Map<string, string>();
+  const hashes = new Map<string, Map<string, string>>();
+  const hsetKey = (k: string, field: string, val: string): number => {
+    const h = hashes.get(k) ?? new Map<string, string>();
+    const isNew = !h.has(field);
+    h.set(field, val);
+    hashes.set(k, h);
+    return isNew ? 1 : 0;
+  };
+  const setKey = (k: string, v: string): 'OK' => {
+    store.set(k, v);
+    return 'OK';
+  };
+  return {
+    hashes,
+    store,
+    get: vi.fn(async (k: string) => store.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => setKey(k, v)),
+    hset: vi.fn(async (k: string, field: string, val: string) => hsetKey(k, field, val)),
+    hget: vi.fn(async (k: string, field: string) => hashes.get(k)?.get(field) ?? null),
+    hgetall: vi.fn(async (k: string) => {
+      const h = hashes.get(k);
+      if (!h) return {};
+      return Object.fromEntries(h);
+    }),
+    pipeline: vi.fn(() => makePipelineMock(setKey, hsetKey)),
+  } as unknown as Redis & {
+    store: Map<string, string>;
+    hashes: Map<string, Map<string, string>>;
+  };
+}
+
+function makePipelineMock(
+  setKey: (k: string, v: string) => 'OK',
+  hsetKey: (k: string, field: string, val: string) => number
+) {
+  const queue: Array<() => [Error | null, unknown]> = [];
+  const pipe = {
+    set: (k: string, v: string) => {
+      queue.push(() => [null, setKey(k, v)]);
+      return pipe;
+    },
+    hset: (k: string, field: string, val: string) => {
+      queue.push(() => [null, hsetKey(k, field, val)]);
+      return pipe;
+    },
+    exec: vi.fn(async () => queue.map((fn) => fn())),
+  };
+  return pipe;
+}
+
+describe('userIndex', () => {
+  beforeEach(() => {
+    mockRedis = makeRedisMock();
+  });
+
+  it('upsertEntry writes the JSON-encoded entry and bumps indexUpdatedAt atomically', async () => {
+    const entry: IndexEntry = { modifiedAt: 1000, sizeBytes: 4096 };
+    await upsertEntry(mockRedis, 'u1', 'layouts', 'lay-1', entry);
+
+    expect(await getEntry(mockRedis, 'u1', 'layouts', 'lay-1')).toEqual(entry);
+    expect(await getIndexUpdatedAt(mockRedis, 'u1')).toBeGreaterThan(0);
+    expect(mockRedis.pipeline).toHaveBeenCalled();
+  });
+
+  it('getIndex returns all entries for a user/kind', async () => {
+    await upsertEntry(mockRedis, 'u1', 'layouts', 'a', { modifiedAt: 1, sizeBytes: 100 });
+    await upsertEntry(mockRedis, 'u1', 'layouts', 'b', { modifiedAt: 2, sizeBytes: 200 });
+    await upsertEntry(mockRedis, 'u1', 'designs', 'c', { modifiedAt: 3, sizeBytes: 300 });
+
+    const layouts = await getIndex(mockRedis, 'u1', 'layouts');
+    expect(Object.keys(layouts).sort()).toEqual(['a', 'b']);
+    expect(layouts.a.sizeBytes).toBe(100);
+    expect(layouts.b.sizeBytes).toBe(200);
+
+    const designs = await getIndex(mockRedis, 'u1', 'designs');
+    expect(Object.keys(designs)).toEqual(['c']);
+  });
+
+  it('getIndex returns an empty object when the user has nothing yet', async () => {
+    expect(await getIndex(mockRedis, 'fresh-user', 'layouts')).toEqual({});
+  });
+
+  it('getEntry returns null for a missing entry', async () => {
+    expect(await getEntry(mockRedis, 'u1', 'layouts', 'nope')).toBe(null);
+  });
+
+  it('tombstone marks an entry deleted with sizeBytes=0 and deletedAt set', async () => {
+    await upsertEntry(mockRedis, 'u1', 'layouts', 'lay-1', { modifiedAt: 1000, sizeBytes: 4096 });
+    await tombstone(mockRedis, 'u1', 'layouts', 'lay-1', 5000);
+
+    const entry = await getEntry(mockRedis, 'u1', 'layouts', 'lay-1');
+    expect(entry).toEqual({ modifiedAt: 5000, sizeBytes: 0, deletedAt: 5000 });
+  });
+
+  it('parseEntry rejects malformed JSON gracefully', async () => {
+    const ctx = mockRedis as unknown as { hashes: Map<string, Map<string, string>> };
+    const h = new Map<string, string>();
+    h.set('valid', JSON.stringify({ modifiedAt: 1, sizeBytes: 1 }));
+    h.set('garbage', 'not-json');
+    h.set('wrong-shape', JSON.stringify({ modifiedAt: 'string-not-number' }));
+    ctx.hashes.set('users:u1:index:layouts', h);
+
+    const index = await getIndex(mockRedis, 'u1', 'layouts');
+    expect(Object.keys(index)).toEqual(['valid']);
+  });
+
+  it('getIndexUpdatedAt returns 0 for a user who has never written', async () => {
+    expect(await getIndexUpdatedAt(mockRedis, 'fresh-user')).toBe(0);
+  });
+});

--- a/api/lib/userIndex.ts
+++ b/api/lib/userIndex.ts
@@ -1,0 +1,117 @@
+import type { Redis } from 'ioredis';
+import { userIndexKey, userIndexUpdatedAtKey, type SyncItemKind } from './redisKeys.js';
+
+export type { SyncItemKind } from './redisKeys.js';
+
+/**
+ * Per-item index entry stored as a JSON-encoded value in the user's
+ * `users:{uid}:index:{kind}` hash.
+ *
+ *   modifiedAt  — ms since epoch, the LWW comparison value
+ *   sizeBytes   — payload size, used by quota math (excluded for tombstones)
+ *   deletedAt   — present only for tombstones; tombstones live forever
+ */
+export interface IndexEntry {
+  modifiedAt: number;
+  sizeBytes: number;
+  deletedAt?: number;
+}
+
+/**
+ * Read every entry in a user's index hash. Returns an empty object if the
+ * user has nothing of this kind yet.
+ */
+export async function getIndex(
+  redis: Redis,
+  userId: string,
+  kind: SyncItemKind
+): Promise<Record<string, IndexEntry>> {
+  const raw = await redis.hgetall(userIndexKey(userId, kind));
+  const out: Record<string, IndexEntry> = {};
+  for (const [id, encoded] of Object.entries(raw)) {
+    const parsed = parseEntry(encoded);
+    if (parsed) out[id] = parsed;
+  }
+  return out;
+}
+
+/** Read a single entry. Returns null if absent or malformed. */
+export async function getEntry(
+  redis: Redis,
+  userId: string,
+  kind: SyncItemKind,
+  id: string
+): Promise<IndexEntry | null> {
+  const raw = await redis.hget(userIndexKey(userId, kind), id);
+  if (raw === null) return null;
+  return parseEntry(raw);
+}
+
+/**
+ * Insert or replace an entry, atomically bumping `indexUpdatedAt` so
+ * `/api/sync/manifest` can serve `If-Modified-Since` 304s without reading
+ * the hash.
+ */
+export async function upsertEntry(
+  redis: Redis,
+  userId: string,
+  kind: SyncItemKind,
+  id: string,
+  entry: IndexEntry
+): Promise<void> {
+  const pipeline = redis.pipeline();
+  pipeline.hset(userIndexKey(userId, kind), id, JSON.stringify(entry));
+  pipeline.set(userIndexUpdatedAtKey(userId), String(Date.now()));
+  const run = pipeline.exec.bind(pipeline);
+  const results = await run();
+  if (results === null) throw new Error('userIndex pipeline failed: redis connection lost');
+  for (const [err] of results) {
+    if (err) throw err;
+  }
+}
+
+/**
+ * Mark an entry as a tombstone. Tombstones replace the live entry in the
+ * same hash so manifest/poll logic doesn't have to merge two stores.
+ *
+ * `sizeBytes` is preserved as 0 — quota math excludes tombstones, but
+ * keeping the field present means the on-the-wire shape is uniform.
+ */
+export async function tombstone(
+  redis: Redis,
+  userId: string,
+  kind: SyncItemKind,
+  id: string,
+  deletedAt: number
+): Promise<void> {
+  await upsertEntry(redis, userId, kind, id, {
+    modifiedAt: deletedAt,
+    sizeBytes: 0,
+    deletedAt,
+  });
+}
+
+/**
+ * Read the last-mutation timestamp used by the manifest's
+ * `If-Modified-Since` cache. Returns 0 if the user has never written.
+ */
+export async function getIndexUpdatedAt(redis: Redis, userId: string): Promise<number> {
+  const raw = await redis.get(userIndexUpdatedAtKey(userId));
+  if (raw === null) return 0;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function parseEntry(raw: string): IndexEntry | null {
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (typeof value !== 'object' || value === null) return null;
+    const record = value as Partial<IndexEntry>;
+    if (typeof record.modifiedAt !== 'number') return null;
+    if (typeof record.sizeBytes !== 'number') return null;
+    if (record.deletedAt !== undefined && typeof record.deletedAt !== 'number') return null;
+    return record as IndexEntry;
+  } catch {
+    return null;
+  }
+}

--- a/api/lib/userIndex.ts
+++ b/api/lib/userIndex.ts
@@ -107,9 +107,12 @@ function parseEntry(raw: string): IndexEntry | null {
     const value = JSON.parse(raw) as unknown;
     if (typeof value !== 'object' || value === null) return null;
     const record = value as Partial<IndexEntry>;
-    if (typeof record.modifiedAt !== 'number') return null;
-    if (typeof record.sizeBytes !== 'number') return null;
-    if (record.deletedAt !== undefined && typeof record.deletedAt !== 'number') return null;
+    // Reject NaN/Infinity — they would corrupt LWW comparisons (NaN
+    // compares false to everything) and quota math (Infinity makes the
+    // total unboundedly wrong). Same posture as `getIndexUpdatedAt`.
+    if (!Number.isFinite(record.modifiedAt)) return null;
+    if (!Number.isFinite(record.sizeBytes)) return null;
+    if (record.deletedAt !== undefined && !Number.isFinite(record.deletedAt)) return null;
     return record as IndexEntry;
   } catch {
     return null;

--- a/api/sync/README.md
+++ b/api/sync/README.md
@@ -1,0 +1,119 @@
+# Sync (`api/sync/`)
+
+Server endpoints for the multi-device sync feature. Stores per-user layouts and Bin Designer designs in Vercel Blob, with a per-user index in Redis. All endpoints require an authenticated session — see [`../auth/README.md`](../auth/README.md).
+
+> **Status: server-only.** PR 3 lands these endpoints. The client engine (PR 4) will start calling them, and the UI gate flips on in PR 6. Until then nothing in the SPA calls these — they're verified via tests + curl.
+
+## Endpoints
+
+| Endpoint                 | Method | Rate Limit | Purpose                                         |
+| ------------------------ | ------ | ---------- | ----------------------------------------------- |
+| `/api/sync/layouts/[id]` | GET    | 240/min    | Fetch envelope (200 / 404 / 410)                |
+| `/api/sync/layouts/[id]` | PUT    | 60/min     | LWW write; 409 stale-write, 410 stale-resurrect |
+| `/api/sync/layouts/[id]` | DELETE | 60/min     | Tombstone + blob delete                         |
+| `/api/sync/designs/[id]` | GET    | 240/min    | Fetch envelope (200 / 404 / 410)                |
+| `/api/sync/designs/[id]` | PUT    | 60/min     | LWW write; reuses designer-payload validator    |
+| `/api/sync/designs/[id]` | DELETE | 60/min     | Tombstone + blob delete                         |
+| `/api/sync/manifest`     | GET    | 240/min    | Full per-user index + `If-Modified-Since` 304   |
+| `/api/sync/export`       | GET    | 240/min    | ZIP of all live items + manifest.json           |
+| `/api/sync/account`      | DELETE | 60/min     | Cascade-delete sessions + KV + blobs            |
+
+Rate limits are keyed by `userId`, not IP — each authenticated user gets their own budget.
+
+## Storage shape
+
+### Cloud envelope (per item)
+
+```ts
+// users/{uid}/layouts/{id}.json (Vercel Blob)
+{
+  layout: Layout,           // sanitized via validateShareLayout
+  modifiedAt: number,       // ms since epoch (LWW comparison value)
+  schemaVersion: 1,
+}
+
+// users/{uid}/designs/{id}.json
+{
+  design: BinParams,        // sanitized via validateDesignerShare
+  modifiedAt: number,
+  schemaVersion: 1,
+}
+```
+
+### Per-user index entry (Redis hash field value)
+
+```ts
+// HGETALL users:{uid}:index:layouts → { [id]: IndexEntry }
+type IndexEntry = {
+  modifiedAt: number;
+  sizeBytes: number;
+  deletedAt?: number; // tombstone marker, permanent
+};
+
+// Adjacent: SET users:{uid}:indexUpdatedAt {ms} on every mutation
+//           bumps the cache key for /api/sync/manifest's 304 path.
+```
+
+## LWW + tombstone semantics (PUT)
+
+Every write supplies a `modifiedAt` (ms epoch) representing the client's view of when the change happened. The server compares against the existing entry:
+
+- **Existing live, server `modifiedAt` ≥ request `modifiedAt`** — `409 Conflict` with the stored envelope. Client should pull and replace local.
+- **Existing tombstone, `deletedAt` ≥ request `modifiedAt`** — `410 Gone`. The local edit predates the deletion; client must re-edit (bumping `modifiedAt`) to resurrect.
+- **No existing OR tombstone with `deletedAt` < request `modifiedAt`** — write succeeds (resurrection clears the tombstone).
+- **Quota check** — happens after the LWW gate; PUT only consumes a slot when it's actually accepted.
+
+## Quotas
+
+`api/lib/quota.ts` enforces:
+
+| Resource      | Cap            |
+| ------------- | -------------- |
+| Layouts count | 100 per user   |
+| Layouts bytes | 10 MB per user |
+| Designs count | 100 per user   |
+| Designs bytes | 10 MB per user |
+
+Tombstones don't count. Quotas are independent per kind. Concurrent writes can briefly exceed by one item — caps are soft ceilings at this scale, not hard invariants.
+
+## Why content filtering is skipped
+
+The existing share endpoints (`/api/share`) run `filterLayoutContent` because shares are publicly accessible by their URL. Sync data is **user-private**: a user's own layouts / designs, never exposed to other users. Adding a content filter here would block users from saving their own work due to false positives in their own bin labels — a worse UX with no security benefit. Documented intentional skip.
+
+## Account deletion cascade
+
+`DELETE /api/sync/account` runs in this order:
+
+1. `SMEMBERS users:{uid}:sessions` → `DEL session:{token}` for each
+2. `HKEYS users:{uid}:index:{layouts|designs}` → `del()` each blob
+3. `DEL users:{uid}:*` (indexes, profile, sessions set, indexUpdatedAt)
+4. Clear session cookie on responding device
+
+Idempotent: each step uses unconditional `DEL`, so a partial-failure replay is safe. Per-blob errors are logged but don't block the cascade — leftover blobs are storage cost only. Worst-case time at 200 items × ~50 ms = ~10 s, well within Vercel's 60 s function limit.
+
+## Testing
+
+Each endpoint has a sibling test that mocks Redis + Blob and exercises the full state-write path. The tests don't mock `userIndex` or `quota` — they run against the in-memory Redis stub, so the tests double as integration coverage for those modules.
+
+```bash
+pnpm exec vitest run api/sync api/lib/userIndex api/lib/quota
+```
+
+## Manual verification (post-deploy, with PR 2 cookie)
+
+```bash
+# After signing in via /api/auth/login/google in a browser,
+# copy the __Host-gflt_session cookie and curl with it:
+
+curl -H 'Cookie: __Host-gflt_session=…' \
+     -H 'X-Requested-With: gflt' \
+     -X PUT https://example.com/api/sync/layouts/abc-1234567 \
+     -H 'Content-Type: application/json' \
+     -d '{"layout": {...}, "modifiedAt": 1700000000000}'
+
+curl -H 'Cookie: __Host-gflt_session=…' \
+     https://example.com/api/sync/manifest
+
+curl -H 'Cookie: __Host-gflt_session=…' \
+     -OJ https://example.com/api/sync/export
+```

--- a/api/sync/account.test.ts
+++ b/api/sync/account.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for /api/sync/account DELETE — the cascading account-deletion
+ * endpoint. The most important property to verify is idempotency: the
+ * same request repeated after partial failure must produce the same
+ * end-state without throwing.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+let redisStore: Map<string, string>;
+let redisHashes: Map<string, Map<string, string>>;
+let redisSets: Map<string, Set<string>>;
+let blobStore: Map<string, unknown>;
+
+const mockRedis = {
+  get: vi.fn(async (k: string) => redisStore.get(k) ?? null),
+  set: vi.fn(async (k: string, v: string) => {
+    redisStore.set(k, v);
+    return 'OK';
+  }),
+  del: vi.fn(async (...keys: string[]) => {
+    let count = 0;
+    for (const k of keys) {
+      if (redisStore.delete(k)) count++;
+      if (redisHashes.delete(k)) count++;
+      if (redisSets.delete(k)) count++;
+    }
+    return count;
+  }),
+  smembers: vi.fn(async (k: string) => Array.from(redisSets.get(k) ?? [])),
+  sadd: vi.fn(async (k: string, m: string) => {
+    const s = redisSets.get(k) ?? new Set<string>();
+    s.add(m);
+    redisSets.set(k, s);
+    return 1;
+  }),
+  hkeys: vi.fn(async (k: string) => Array.from(redisHashes.get(k)?.keys() ?? [])),
+  hset: vi.fn(async (k: string, f: string, v: string) => {
+    const h = redisHashes.get(k) ?? new Map<string, string>();
+    h.set(f, v);
+    redisHashes.set(k, h);
+    return 1;
+  }),
+};
+
+vi.mock('../lib/rateLimit', () => ({
+  getRedis: () => mockRedis,
+  getClientIP: () => '127.0.0.1',
+  checkRateLimit: vi.fn(async () => ({
+    allowed: true,
+    remaining: 100,
+    resetAt: Date.now() + 60_000,
+  })),
+}));
+
+vi.mock('../lib/session', () => ({
+  checkCsrfDefense: vi.fn(() => true),
+  requireSession: vi.fn(async () => ({
+    userId: 'user-1',
+    provider: 'google',
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  })),
+}));
+
+const deleteBlobMock = vi.fn(async (path: string) => {
+  blobStore.delete(path);
+});
+
+vi.mock('../lib/blobStore', () => ({
+  putJson: vi.fn(),
+  getJson: vi.fn(),
+  deleteBlob: (path: string) => deleteBlobMock(path),
+  headBlob: vi.fn(),
+}));
+
+interface MockRes {
+  _status: number;
+  _body: unknown;
+  _headers: Record<string, string | string[] | number>;
+  _ended: boolean;
+  status(code: number): MockRes;
+  json(body: unknown): MockRes;
+  end(): MockRes;
+  setHeader(k: string, v: string | string[] | number): MockRes;
+  getHeader(k: string): string | string[] | number | undefined;
+}
+
+function makeRes(): MockRes {
+  return {
+    _status: 0,
+    _body: null,
+    _headers: {},
+    _ended: false,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    json(body) {
+      this._body = body;
+      return this;
+    },
+    end() {
+      this._ended = true;
+      return this;
+    },
+    setHeader(k, v) {
+      this._headers[k] = v;
+      return this;
+    },
+    getHeader(k) {
+      return this._headers[k];
+    },
+  };
+}
+
+function makeReq(opts: { method?: string } = {}): VercelRequest {
+  return {
+    method: opts.method ?? 'DELETE',
+    query: {},
+    headers: { 'sec-fetch-site': 'same-origin', 'x-requested-with': 'gflt' },
+  } as unknown as VercelRequest;
+}
+
+function setHash(key: string, fields: Record<string, string>) {
+  redisHashes.set(key, new Map(Object.entries(fields)));
+}
+
+function setSet(key: string, members: string[]) {
+  redisSets.set(key, new Set(members));
+}
+
+beforeEach(() => {
+  redisStore = new Map();
+  redisHashes = new Map();
+  redisSets = new Map();
+  blobStore = new Map();
+  vi.clearAllMocks();
+  deleteBlobMock.mockImplementation(async (path: string) => {
+    blobStore.delete(path);
+  });
+});
+
+describe('DELETE /api/sync/account', () => {
+  it('cascades to sessions, blobs, and KV keys', async () => {
+    setSet('users:user-1:sessions', ['tok-a', 'tok-b']);
+    redisStore.set('session:tok-a', 'a');
+    redisStore.set('session:tok-b', 'b');
+    redisStore.set('users:user-1:profile', '{}');
+    redisStore.set('users:user-1:indexUpdatedAt', '12345');
+    setHash('users:user-1:index:layouts', { 'lay-1': '{}', 'lay-2': '{}' });
+    setHash('users:user-1:index:designs', { 'des-1': '{}' });
+    blobStore.set('users/user-1/layouts/lay-1.json', {});
+    blobStore.set('users/user-1/layouts/lay-2.json', {});
+    blobStore.set('users/user-1/designs/des-1.json', {});
+
+    const { default: handler } = await import('./account');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+
+    expect(res._status).toBe(204);
+
+    // Sessions deleted.
+    expect(redisStore.has('session:tok-a')).toBe(false);
+    expect(redisStore.has('session:tok-b')).toBe(false);
+
+    // KV state gone.
+    expect(redisStore.has('users:user-1:profile')).toBe(false);
+    expect(redisStore.has('users:user-1:indexUpdatedAt')).toBe(false);
+    expect(redisHashes.has('users:user-1:index:layouts')).toBe(false);
+    expect(redisHashes.has('users:user-1:index:designs')).toBe(false);
+    expect(redisSets.has('users:user-1:sessions')).toBe(false);
+
+    // Blobs gone.
+    expect(blobStore.size).toBe(0);
+
+    // Cookie cleared.
+    const cookieHeader = res._headers['Set-Cookie'];
+    const cookies = Array.isArray(cookieHeader) ? cookieHeader.map(String) : [String(cookieHeader)];
+    expect(cookies.some((c) => c.includes('Max-Age=0'))).toBe(true);
+  });
+
+  it('is idempotent — replaying after partial failure is safe', async () => {
+    // Run the cascade once.
+    setSet('users:user-1:sessions', ['tok-a']);
+    redisStore.set('session:tok-a', 'a');
+    setHash('users:user-1:index:layouts', { 'lay-1': '{}' });
+    blobStore.set('users/user-1/layouts/lay-1.json', {});
+
+    const { default: handler } = await import('./account');
+    const firstRes = makeRes();
+    await handler(makeReq(), firstRes as unknown as VercelResponse);
+    expect(firstRes._status).toBe(204);
+
+    // Replay with everything already gone — should still 204.
+    const replayRes = makeRes();
+    await handler(makeReq(), replayRes as unknown as VercelResponse);
+    expect(replayRes._status).toBe(204);
+  });
+
+  it('continues the cascade when a single blob delete fails', async () => {
+    setHash('users:user-1:index:layouts', { 'lay-1': '{}', 'lay-2': '{}' });
+    blobStore.set('users/user-1/layouts/lay-1.json', {});
+    blobStore.set('users/user-1/layouts/lay-2.json', {});
+
+    deleteBlobMock.mockImplementationOnce(async () => {
+      throw new Error('blob storage transient');
+    });
+
+    const { default: handler } = await import('./account');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+
+    expect(res._status).toBe(204);
+    // KV state still cleared even though a blob failed.
+    expect(redisHashes.has('users:user-1:index:layouts')).toBe(false);
+  });
+
+  it('returns 405 for non-DELETE methods', async () => {
+    const { default: handler } = await import('./account');
+    const res = makeRes();
+    await handler(makeReq({ method: 'POST' }), res as unknown as VercelResponse);
+    expect(res._status).toBe(405);
+  });
+
+  it('returns 429 when rate-limited', async () => {
+    const rateLimit = await import('../lib/rateLimit');
+    (rateLimit.checkRateLimit as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 60_000,
+      retryAfterSeconds: 30,
+    });
+    const { default: handler } = await import('./account');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+    expect(res._status).toBe(429);
+  });
+});

--- a/api/sync/account.test.ts
+++ b/api/sync/account.test.ts
@@ -55,7 +55,6 @@ vi.mock('../lib/rateLimit', () => ({
 }));
 
 vi.mock('../lib/session', () => ({
-  checkCsrfDefense: vi.fn(() => true),
   requireSession: vi.fn(async () => ({
     userId: 'user-1',
     provider: 'google',

--- a/api/sync/account.ts
+++ b/api/sync/account.ts
@@ -3,7 +3,7 @@ import { requireMethod } from '../lib/method.js';
 import { ErrorCode } from '../lib/shared.js';
 import { logger } from '../lib/logger.js';
 import { checkRateLimit, getRedis } from '../lib/rateLimit.js';
-import { checkCsrfDefense, requireSession } from '../lib/session.js';
+import { requireSession } from '../lib/session.js';
 import { clearSessionCookie } from '../lib/cookies.js';
 import { deleteBlob } from '../lib/blobStore.js';
 import {
@@ -35,8 +35,8 @@ import {
  */
 export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
   if (!requireMethod(req, res, ['DELETE'])) return;
-  if (!checkCsrfDefense(req, res)) return;
 
+  // CSRF defense is enforced inside `requireSession` (see api/lib/session.ts).
   const session = await requireSession(req, res);
   if (!session) return;
 

--- a/api/sync/account.ts
+++ b/api/sync/account.ts
@@ -1,0 +1,111 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { requireMethod } from '../lib/method.js';
+import { ErrorCode } from '../lib/shared.js';
+import { logger } from '../lib/logger.js';
+import { checkRateLimit, getRedis } from '../lib/rateLimit.js';
+import { checkCsrfDefense, requireSession } from '../lib/session.js';
+import { clearSessionCookie } from '../lib/cookies.js';
+import { deleteBlob } from '../lib/blobStore.js';
+import {
+  sessionKey,
+  userIndexKey,
+  userIndexUpdatedAtKey,
+  userProfileKey,
+  userSessionsKey,
+} from '../lib/redisKeys.js';
+
+/**
+ * DELETE /api/sync/account
+ *
+ * Hard-delete the signed-in user's account. The cascade order matters:
+ *
+ *   1. Sessions   — DEL session:{token} for every token in the user's set
+ *                   (so other tabs/devices flip to anonymous on next sync)
+ *   2. Blobs      — del() each layouts/{id}.json and designs/{id}.json
+ *   3. KV keys    — drop indexes, profile, sessions set, indexUpdatedAt
+ *   4. Cookie     — clear the session cookie on the responding device
+ *
+ * Idempotent on partial-failure replay: each step uses unconditional DEL,
+ * so repeating after a timeout/cold-start just no-ops on already-cleared
+ * keys. The blob loop catches per-blob errors and continues — a stuck
+ * blob won't block the rest of the cascade.
+ *
+ * Vercel function timeout is 60s. With max 100 layouts + 100 designs
+ * × ~50ms per Blob delete = ~10s worst case, well within budget.
+ */
+export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
+  if (!requireMethod(req, res, ['DELETE'])) return;
+  if (!checkCsrfDefense(req, res)) return;
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  const rate = await checkRateLimit(session.userId, 'sync.write');
+  if (!rate.allowed) {
+    res.status(429).json({
+      error: 'Too many requests. Try again later.',
+      code: ErrorCode.RATE_LIMITED,
+      retryAfter: rate.retryAfterSeconds,
+    });
+    return;
+  }
+
+  const redis = getRedis();
+  if (!redis) {
+    res
+      .status(503)
+      .json({ error: 'Service temporarily unavailable', code: ErrorCode.SERVICE_UNAVAILABLE });
+    return;
+  }
+
+  const { userId } = session;
+  try {
+    // 1. Cascade-delete every active session for this user.
+    const tokens = await redis.smembers(userSessionsKey(userId));
+    if (tokens.length > 0) {
+      await redis.del(...tokens.map((t) => sessionKey(t)));
+    }
+
+    // 2. Delete every blob this user owns. Errors per-blob are logged but
+    //    don't block the cascade — leftover blobs are storage cost only,
+    //    not a correctness issue, and re-issuing the request will retry.
+    const layoutIds = await redis.hkeys(userIndexKey(userId, 'layouts'));
+    const designIds = await redis.hkeys(userIndexKey(userId, 'designs'));
+
+    await Promise.all([
+      ...layoutIds.map((id) => deleteBlobSafe(`users/${userId}/layouts/${id}.json`, userId)),
+      ...designIds.map((id) => deleteBlobSafe(`users/${userId}/designs/${id}.json`, userId)),
+    ]);
+
+    // 3. Drop all per-user KV state in one DEL.
+    await redis.del(
+      userIndexKey(userId, 'layouts'),
+      userIndexKey(userId, 'designs'),
+      userIndexUpdatedAtKey(userId),
+      userProfileKey(userId),
+      userSessionsKey(userId)
+    );
+
+    // 4. Clear the session cookie on the device making this request.
+    clearSessionCookie(res);
+    res.status(204).end();
+  } catch (error) {
+    logger.error('sync/account delete failed', {
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    res.status(500).json({ error: 'Server error', code: ErrorCode.SERVER_ERROR });
+  }
+}
+
+async function deleteBlobSafe(path: string, userId: string): Promise<void> {
+  try {
+    await deleteBlob(path);
+  } catch (error) {
+    logger.error('account-delete: blob delete failed', {
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    // Continue — leftover blobs are storage cost, not a correctness issue.
+  }
+}

--- a/api/sync/designs/[id].test.ts
+++ b/api/sync/designs/[id].test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for /api/sync/designs/[id]. The LWW + tombstone state machine is
+ * shared with /api/sync/layouts so we don't re-cover every quadrant — the
+ * focus here is the designer-specific validation contract.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+let redisStore: Map<string, string>;
+let redisHashes: Map<string, Map<string, string>>;
+const blobStore = new Map<string, unknown>();
+
+const mockRedis = {
+  get: vi.fn(async (k: string) => redisStore.get(k) ?? null),
+  set: vi.fn(async (k: string, v: string) => {
+    redisStore.set(k, v);
+    return 'OK';
+  }),
+  hget: vi.fn(async (k: string, f: string) => redisHashes.get(k)?.get(f) ?? null),
+  hset: vi.fn(async (k: string, f: string, v: string) => {
+    const h = redisHashes.get(k) ?? new Map<string, string>();
+    h.set(f, v);
+    redisHashes.set(k, h);
+    return 1;
+  }),
+  hgetall: vi.fn(async (k: string) => {
+    const h = redisHashes.get(k);
+    return h ? Object.fromEntries(h) : {};
+  }),
+  pipeline: vi.fn(() => makePipeline()),
+};
+
+function makePipeline() {
+  const queue: Array<() => [Error | null, unknown]> = [];
+  const pipe = {
+    set: (k: string, v: string) => {
+      queue.push(() => {
+        redisStore.set(k, v);
+        return [null, 'OK'];
+      });
+      return pipe;
+    },
+    hset: (k: string, f: string, v: string) => {
+      queue.push(() => {
+        const h = redisHashes.get(k) ?? new Map<string, string>();
+        h.set(f, v);
+        redisHashes.set(k, h);
+        return [null, 1];
+      });
+      return pipe;
+    },
+    exec: vi.fn(async () => queue.map((fn) => fn())),
+  };
+  return pipe;
+}
+
+vi.mock('../../lib/rateLimit', () => ({
+  getRedis: () => mockRedis,
+  getClientIP: () => '127.0.0.1',
+  checkRateLimit: vi.fn(async () => ({
+    allowed: true,
+    remaining: 100,
+    resetAt: Date.now() + 60_000,
+  })),
+}));
+
+vi.mock('../../lib/session', () => ({
+  requireSession: vi.fn(async () => ({
+    userId: 'user-1',
+    provider: 'google',
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  })),
+}));
+
+vi.mock('../../lib/blobStore', () => ({
+  putJson: vi.fn(async (path: string, value: unknown) => {
+    blobStore.set(path, value);
+    return { url: `https://blob/${path}` };
+  }),
+  getJson: vi.fn(async (path: string) => blobStore.get(path) ?? null),
+  deleteBlob: vi.fn(async (path: string) => {
+    blobStore.delete(path);
+  }),
+  headBlob: vi.fn(async () => null),
+}));
+
+interface MockRes {
+  _status: number;
+  _body: unknown;
+  _ended: boolean;
+  status(code: number): MockRes;
+  json(body: unknown): MockRes;
+  end(): MockRes;
+  setHeader(): MockRes;
+}
+
+function makeRes(): MockRes {
+  return {
+    _status: 0,
+    _body: null,
+    _ended: false,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    json(body) {
+      this._body = body;
+      return this;
+    },
+    end() {
+      this._ended = true;
+      return this;
+    },
+    setHeader() {
+      return this;
+    },
+  };
+}
+
+function makeReq(opts: { method?: string; id?: string; body?: unknown }): VercelRequest {
+  return {
+    method: opts.method ?? 'GET',
+    query: { id: opts.id ?? 'lszwz1k7v-8j2kqp1' },
+    body: opts.body,
+    headers: { 'sec-fetch-site': 'same-origin', 'x-requested-with': 'gflt' },
+  } as unknown as VercelRequest;
+}
+
+const VALID_DESIGN = {
+  width: 2,
+  depth: 2,
+  height: 6,
+  style: 'standard',
+  scoop: true,
+  base: {
+    style: 'magnet',
+    magnetDiameter: 6.2,
+    magnetDepth: 2.4,
+    screwDiameter: 3,
+    stackingLip: true,
+  },
+  compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
+  label: { enabled: false, support: 'bracket', depth: 12, width: 100, alignment: 'center' },
+  walls: { front: 0, back: 0, left: 0, right: 0 },
+  inserts: [] as Record<string, unknown>[],
+};
+
+beforeEach(() => {
+  redisStore = new Map();
+  redisHashes = new Map();
+  blobStore.clear();
+  vi.clearAllMocks();
+});
+
+describe('PUT', () => {
+  it('creates a new design entry on first write', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'PUT', body: { design: VALID_DESIGN, modifiedAt: 1000 } }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(200);
+    const body = res._body as { envelope: { schemaVersion: number; design: unknown } };
+    expect(body.envelope.schemaVersion).toBe(1);
+  });
+
+  it('rejects an invalid BinParams payload with 400', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    await handler(
+      makeReq({
+        method: 'PUT',
+        body: { design: { ...VALID_DESIGN, width: 999 }, modifiedAt: 1000 },
+      }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(400);
+  });
+
+  it('rejects when modifiedAt is missing or non-numeric', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'PUT', body: { design: VALID_DESIGN, modifiedAt: 'now' } }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(400);
+  });
+
+  it('rejects 409 when remote is newer', async () => {
+    const { default: handler } = await import('./[id]');
+    await handler(
+      makeReq({ method: 'PUT', body: { design: VALID_DESIGN, modifiedAt: 5000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'PUT', body: { design: VALID_DESIGN, modifiedAt: 1000 } }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(409);
+  });
+});
+
+describe('GET / DELETE roundtrip', () => {
+  it('round-trips PUT → GET → DELETE → GET=410', async () => {
+    const { default: handler } = await import('./[id]');
+    await handler(
+      makeReq({ method: 'PUT', body: { design: VALID_DESIGN, modifiedAt: 1000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+    const getRes = makeRes();
+    await handler(makeReq({ method: 'GET' }), getRes as unknown as VercelResponse);
+    expect(getRes._status).toBe(200);
+    const delRes = makeRes();
+    await handler(makeReq({ method: 'DELETE' }), delRes as unknown as VercelResponse);
+    expect(delRes._status).toBe(204);
+    const goneRes = makeRes();
+    await handler(makeReq({ method: 'GET' }), goneRes as unknown as VercelResponse);
+    expect(goneRes._status).toBe(410);
+  });
+});
+
+describe('id validation', () => {
+  it('returns 400 for a malformed id', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'GET', id: '!!not-valid!!' }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(400);
+  });
+});

--- a/api/sync/designs/[id].ts
+++ b/api/sync/designs/[id].ts
@@ -61,7 +61,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
 
   try {
     if (req.method === 'GET') {
-      await handleGet(res, session.userId, id);
+      await handleGet(res, redis, session.userId, id);
     } else if (req.method === 'PUT') {
       await handlePut(req, res, redis, session.userId, id);
     } else {
@@ -77,14 +77,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
   }
 }
 
-async function handleGet(res: VercelResponse, userId: string, id: string): Promise<void> {
-  const redis = getRedis();
-  if (!redis) {
-    res
-      .status(503)
-      .json({ error: 'Service temporarily unavailable', code: ErrorCode.SERVICE_UNAVAILABLE });
-    return;
-  }
+async function handleGet(
+  res: VercelResponse,
+  redis: ReturnType<typeof getRedis> & object,
+  userId: string,
+  id: string
+): Promise<void> {
   const entry = await getEntry(redis, userId, 'designs', id);
   if (!entry) {
     res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
@@ -127,23 +125,22 @@ async function handlePut(
     return;
   }
 
-  const serialized = JSON.stringify({ design });
+  // Reuse the share-payload validator by adapting our envelope to its
+  // shape. `sizeBytes` measures the validation payload (not just `{design}`)
+  // so the validator's MAX_PAYLOAD_BYTES check, the quota math, and the
+  // stored envelope are all sized against the same bytes.
+  const validationPayload = { type: 'designer' as const, version: 1 as const, params: design };
+  const serialized = JSON.stringify(validationPayload);
   const sizeBytes = Buffer.byteLength(serialized, 'utf8');
-  // Reuse the share-payload validator by adapting our envelope to its shape.
-  // The validator returns the validated payload, but we keep our cleaner
-  // sync envelope and only use the validator for its side effect (validity
-  // check) here.
-  const validation = validateDesignerShare(
-    { type: 'designer', version: 1, params: design },
-    sizeBytes
-  );
+  const validation = validateDesignerShare(validationPayload, sizeBytes);
   if (!validation.valid) {
     res.status(400).json({ error: validation.error.message, code: ErrorCode.VALIDATION_ERROR });
     return;
   }
 
   const existing = await getEntry(redis, userId, 'designs', id);
-  if (existing && !existing.deletedAt && existing.modifiedAt >= modifiedAt) {
+  // `deletedAt === undefined` is the explicit live-entry check.
+  if (existing && existing.deletedAt === undefined && existing.modifiedAt >= modifiedAt) {
     const stored = await getJson<DesignEnvelope>(blobPath(userId, id));
     res.status(409).json({
       error: 'A newer version already exists.',
@@ -197,6 +194,12 @@ async function handleDelete(
   id: string
 ): Promise<void> {
   const existing = await getEntry(redis, userId, 'designs', id);
+  // Already tombstoned: don't try to delete the blob (it's already gone)
+  // and don't bump the tombstone timestamp.
+  if (existing?.deletedAt !== undefined) {
+    res.status(204).end();
+    return;
+  }
   if (!existing) {
     await tombstone(redis, userId, 'designs', id, Date.now());
     res.status(204).end();

--- a/api/sync/designs/[id].ts
+++ b/api/sync/designs/[id].ts
@@ -1,0 +1,229 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { requireMethod } from '../../lib/method.js';
+import { ErrorCode } from '../../lib/shared.js';
+import { logger } from '../../lib/logger.js';
+import { checkRateLimit, getRedis } from '../../lib/rateLimit.js';
+import { requireSession } from '../../lib/session.js';
+import { validateDesignerShare } from '../../lib/designerValidation.js';
+import { deleteBlob, getJson, putJson } from '../../lib/blobStore.js';
+import { getEntry, tombstone, upsertEntry, type IndexEntry } from '../../lib/userIndex.js';
+import { checkQuota } from '../../lib/quota.js';
+
+export const SCHEMA_VERSION = 1 as const;
+
+interface DesignEnvelope {
+  design: unknown;
+  modifiedAt: number;
+  schemaVersion: typeof SCHEMA_VERSION;
+}
+
+/**
+ * GET    /api/sync/designs/{id}
+ * PUT    /api/sync/designs/{id}   — body { design, modifiedAt } where
+ *                                    `design` is the raw BinParams shape.
+ *                                    Validated via the existing designer
+ *                                    validator (wrapped in the share
+ *                                    payload contract internally).
+ * DELETE /api/sync/designs/{id}
+ *
+ * Mirrors the layouts endpoint's LWW + tombstone semantics.
+ */
+export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
+  if (!requireMethod(req, res, ['GET', 'PUT', 'DELETE'])) return;
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  const id = singleParam(req.query.id);
+  if (!id || !isValidDesignId(id)) {
+    res.status(400).json({ error: 'Invalid design id', code: ErrorCode.VALIDATION_ERROR });
+    return;
+  }
+
+  const action = req.method === 'GET' ? 'sync.read' : 'sync.write';
+  const rate = await checkRateLimit(session.userId, action);
+  if (!rate.allowed) {
+    res.status(429).json({
+      error: 'Too many requests. Try again later.',
+      code: ErrorCode.RATE_LIMITED,
+      retryAfter: rate.retryAfterSeconds,
+    });
+    return;
+  }
+
+  const redis = getRedis();
+  if (!redis) {
+    res
+      .status(503)
+      .json({ error: 'Service temporarily unavailable', code: ErrorCode.SERVICE_UNAVAILABLE });
+    return;
+  }
+
+  try {
+    if (req.method === 'GET') {
+      await handleGet(res, session.userId, id);
+    } else if (req.method === 'PUT') {
+      await handlePut(req, res, redis, session.userId, id);
+    } else {
+      await handleDelete(res, redis, session.userId, id);
+    }
+  } catch (error) {
+    logger.error('sync/designs handler failed', {
+      userId: session.userId,
+      method: req.method,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    res.status(500).json({ error: 'Server error', code: ErrorCode.SERVER_ERROR });
+  }
+}
+
+async function handleGet(res: VercelResponse, userId: string, id: string): Promise<void> {
+  const redis = getRedis();
+  if (!redis) {
+    res
+      .status(503)
+      .json({ error: 'Service temporarily unavailable', code: ErrorCode.SERVICE_UNAVAILABLE });
+    return;
+  }
+  const entry = await getEntry(redis, userId, 'designs', id);
+  if (!entry) {
+    res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
+    return;
+  }
+  if (entry.deletedAt !== undefined) {
+    res.status(410).json({ error: 'Deleted', code: ErrorCode.NOT_FOUND, indexEntry: entry });
+    return;
+  }
+  const envelope = await getJson<DesignEnvelope>(blobPath(userId, id));
+  if (!envelope) {
+    res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
+    return;
+  }
+  res.status(200).json({ envelope, indexEntry: entry });
+}
+
+interface PutBody {
+  design: unknown;
+  modifiedAt: unknown;
+}
+
+async function handlePut(
+  req: VercelRequest,
+  res: VercelResponse,
+  redis: ReturnType<typeof getRedis> & object,
+  userId: string,
+  id: string
+): Promise<void> {
+  const body = req.body as PutBody | undefined;
+  if (!body || typeof body !== 'object') {
+    res.status(400).json({ error: 'Missing body', code: ErrorCode.VALIDATION_ERROR });
+    return;
+  }
+  const { design, modifiedAt } = body;
+  if (typeof modifiedAt !== 'number' || !Number.isFinite(modifiedAt)) {
+    res
+      .status(400)
+      .json({ error: 'modifiedAt must be a number (ms epoch)', code: ErrorCode.VALIDATION_ERROR });
+    return;
+  }
+
+  const serialized = JSON.stringify({ design });
+  const sizeBytes = Buffer.byteLength(serialized, 'utf8');
+  // Reuse the share-payload validator by adapting our envelope to its shape.
+  // The validator returns the validated payload, but we keep our cleaner
+  // sync envelope and only use the validator for its side effect (validity
+  // check) here.
+  const validation = validateDesignerShare(
+    { type: 'designer', version: 1, params: design },
+    sizeBytes
+  );
+  if (!validation.valid) {
+    res.status(400).json({ error: validation.error.message, code: ErrorCode.VALIDATION_ERROR });
+    return;
+  }
+
+  const existing = await getEntry(redis, userId, 'designs', id);
+  if (existing && !existing.deletedAt && existing.modifiedAt >= modifiedAt) {
+    const stored = await getJson<DesignEnvelope>(blobPath(userId, id));
+    res.status(409).json({
+      error: 'A newer version already exists.',
+      code: ErrorCode.VALIDATION_ERROR,
+      stored,
+      indexEntry: existing,
+    });
+    return;
+  }
+
+  if (existing?.deletedAt !== undefined && existing.deletedAt >= modifiedAt) {
+    res.status(410).json({
+      error: 'Design was deleted on another device. Save again to restore.',
+      code: ErrorCode.NOT_FOUND,
+      indexEntry: existing,
+    });
+    return;
+  }
+
+  const replacingId = existing && existing.deletedAt === undefined ? id : undefined;
+  const quota = await checkQuota(redis, userId, 'designs', {
+    op: 'put',
+    sizeBytes,
+    replacingId,
+  });
+  if (!quota.ok) {
+    res.status(413).json({
+      error: `Quota exceeded (${quota.error.reason}): ${quota.error.current} of ${quota.error.limit}.`,
+      code: ErrorCode.SIZE_LIMIT,
+    });
+    return;
+  }
+
+  const envelope: DesignEnvelope = {
+    design: validation.payload.params,
+    modifiedAt,
+    schemaVersion: SCHEMA_VERSION,
+  };
+  await putJson(blobPath(userId, id), envelope, { allowOverwrite: true });
+
+  const newEntry: IndexEntry = { modifiedAt, sizeBytes };
+  await upsertEntry(redis, userId, 'designs', id, newEntry);
+
+  res.status(200).json({ envelope, indexEntry: newEntry });
+}
+
+async function handleDelete(
+  res: VercelResponse,
+  redis: ReturnType<typeof getRedis> & object,
+  userId: string,
+  id: string
+): Promise<void> {
+  const existing = await getEntry(redis, userId, 'designs', id);
+  if (!existing) {
+    await tombstone(redis, userId, 'designs', id, Date.now());
+    res.status(204).end();
+    return;
+  }
+  await deleteBlob(blobPath(userId, id));
+  await tombstone(redis, userId, 'designs', id, Date.now());
+  res.status(204).end();
+}
+
+function blobPath(userId: string, id: string): string {
+  return `users/${userId}/designs/${id}.json`;
+}
+
+function singleParam(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+/**
+ * Bin Designer designs use the same id formats as layouts (UUID, base36
+ * timestamp, or 12-char alphanumeric). Keep the shape consistent so the
+ * client doesn't have to remember which kind needs what.
+ */
+function isValidDesignId(id: string): boolean {
+  if (/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(id)) return true;
+  if (/^[a-z0-9]+-[a-z0-9]{7}$/.test(id)) return true;
+  if (/^[a-zA-Z0-9]{12}$/.test(id)) return true;
+  return false;
+}

--- a/api/sync/export.test.ts
+++ b/api/sync/export.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+let redisStore: Map<string, string>;
+let redisHashes: Map<string, Map<string, string>>;
+const blobStore = new Map<string, unknown>();
+
+const mockRedis = {
+  get: vi.fn(async (k: string) => redisStore.get(k) ?? null),
+  set: vi.fn(async (k: string, v: string) => {
+    redisStore.set(k, v);
+    return 'OK';
+  }),
+  hgetall: vi.fn(async (k: string) => {
+    const h = redisHashes.get(k);
+    return h ? Object.fromEntries(h) : {};
+  }),
+  pipeline: vi.fn(() => {
+    const queue: Array<() => [Error | null, unknown]> = [];
+    const pipe = {
+      set: (k: string, v: string) => {
+        queue.push(() => {
+          redisStore.set(k, v);
+          return [null, 'OK'];
+        });
+        return pipe;
+      },
+      hset: (k: string, f: string, v: string) => {
+        queue.push(() => {
+          const h = redisHashes.get(k) ?? new Map<string, string>();
+          h.set(f, v);
+          redisHashes.set(k, h);
+          return [null, 1];
+        });
+        return pipe;
+      },
+      exec: vi.fn(async () => queue.map((fn) => fn())),
+    };
+    return pipe;
+  }),
+};
+
+vi.mock('../lib/rateLimit', () => ({
+  getRedis: () => mockRedis,
+  getClientIP: () => '127.0.0.1',
+  checkRateLimit: vi.fn(async () => ({
+    allowed: true,
+    remaining: 100,
+    resetAt: Date.now() + 60_000,
+  })),
+}));
+
+vi.mock('../lib/session', () => ({
+  requireSession: vi.fn(async () => ({
+    userId: 'user-1',
+    provider: 'google',
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  })),
+}));
+
+vi.mock('../lib/blobStore', () => ({
+  putJson: vi.fn(),
+  getJson: vi.fn(async (path: string) => blobStore.get(path) ?? null),
+  deleteBlob: vi.fn(),
+  headBlob: vi.fn(async () => null),
+}));
+
+interface MockRes {
+  _status: number;
+  _body: unknown;
+  _headers: Record<string, string>;
+  _ended: boolean;
+  status(code: number): MockRes;
+  json(body: unknown): MockRes;
+  send(body: unknown): MockRes;
+  end(): MockRes;
+  setHeader(k: string, v: string): MockRes;
+}
+
+function makeRes(): MockRes {
+  return {
+    _status: 0,
+    _body: null,
+    _headers: {},
+    _ended: false,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    json(body) {
+      this._body = body;
+      return this;
+    },
+    send(body) {
+      this._body = body;
+      return this;
+    },
+    end() {
+      this._ended = true;
+      return this;
+    },
+    setHeader(k, v) {
+      this._headers[k] = v;
+      return this;
+    },
+  };
+}
+
+function makeReq(): VercelRequest {
+  return {
+    method: 'GET',
+    query: {},
+    headers: {},
+  } as unknown as VercelRequest;
+}
+
+async function seedItem(
+  kind: 'layouts' | 'designs',
+  id: string,
+  modifiedAt: number,
+  envelope: unknown,
+  opts: { tombstone?: boolean } = {}
+): Promise<void> {
+  const userIndex = await import('../lib/userIndex');
+  if (opts.tombstone) {
+    await userIndex.tombstone(mockRedis as never, 'user-1', kind, id, modifiedAt);
+  } else {
+    await userIndex.upsertEntry(mockRedis as never, 'user-1', kind, id, {
+      modifiedAt,
+      sizeBytes: 100,
+    });
+    blobStore.set(`users/user-1/${kind}/${id}.json`, envelope);
+  }
+}
+
+beforeEach(() => {
+  redisStore = new Map();
+  redisHashes = new Map();
+  blobStore.clear();
+  vi.clearAllMocks();
+});
+
+describe('GET /api/sync/export', () => {
+  it('returns an empty zip with just manifest.json for a fresh user', async () => {
+    const { default: handler } = await import('./export');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+    expect(res._status).toBe(200);
+    expect(res._headers['Content-Type']).toBe('application/zip');
+    expect(res._headers['Content-Disposition']).toMatch(/^attachment; filename=/);
+    expect(Buffer.isBuffer(res._body)).toBe(true);
+
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(res._body as Buffer);
+    const names = Object.keys(zip.files);
+    expect(names).toContain('manifest.json');
+    expect(names.filter((n) => n.startsWith('layouts/'))).toEqual([]);
+  });
+
+  it('packages live layouts and designs into separate folders', async () => {
+    await seedItem('layouts', 'lay-1', 1000, {
+      layout: { name: 'L1' },
+      modifiedAt: 1000,
+      schemaVersion: 1,
+    });
+    await seedItem('designs', 'des-1', 2000, {
+      design: { width: 2 },
+      modifiedAt: 2000,
+      schemaVersion: 1,
+    });
+
+    const { default: handler } = await import('./export');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+    expect(res._status).toBe(200);
+
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(res._body as Buffer);
+    const fileEntries = Object.entries(zip.files)
+      .filter(([, entry]) => !entry.dir)
+      .map(([name]) => name)
+      .sort();
+    expect(fileEntries).toEqual(['designs/des-1.json', 'layouts/lay-1.json', 'manifest.json']);
+
+    const manifest = JSON.parse(await zip.file('manifest.json')!.async('string'));
+    expect(manifest.layouts['lay-1'].modifiedAt).toBe(1000);
+    expect(manifest.designs['des-1'].modifiedAt).toBe(2000);
+    expect(manifest.exportedAt).toBeGreaterThan(0);
+  });
+
+  it('skips tombstoned items in both the manifest and the file list', async () => {
+    await seedItem('layouts', 'lay-live', 1000, {
+      layout: { name: 'L' },
+      modifiedAt: 1000,
+      schemaVersion: 1,
+    });
+    await seedItem('layouts', 'lay-dead', 2000, null, { tombstone: true });
+
+    const { default: handler } = await import('./export');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(res._body as Buffer);
+    expect(zip.file('layouts/lay-live.json')).toBeTruthy();
+    expect(zip.file('layouts/lay-dead.json')).toBe(null);
+
+    const manifest = JSON.parse(await zip.file('manifest.json')!.async('string'));
+    expect(manifest.layouts).toHaveProperty('lay-live');
+    expect(manifest.layouts).not.toHaveProperty('lay-dead');
+  });
+
+  it('returns 429 when rate-limited', async () => {
+    const rateLimit = await import('../lib/rateLimit');
+    (rateLimit.checkRateLimit as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 60_000,
+      retryAfterSeconds: 30,
+    });
+    const { default: handler } = await import('./export');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+    expect(res._status).toBe(429);
+  });
+});

--- a/api/sync/export.ts
+++ b/api/sync/export.ts
@@ -1,0 +1,134 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { requireMethod } from '../lib/method.js';
+import { ErrorCode } from '../lib/shared.js';
+import { logger } from '../lib/logger.js';
+import { checkRateLimit, getRedis } from '../lib/rateLimit.js';
+import { requireSession } from '../lib/session.js';
+import { getJson } from '../lib/blobStore.js';
+import {
+  getIndex,
+  getIndexUpdatedAt,
+  type IndexEntry,
+  type SyncItemKind,
+} from '../lib/userIndex.js';
+
+/**
+ * GET /api/sync/export
+ *
+ * Stream a ZIP of the user's live data:
+ *
+ *   manifest.json        — { layouts: { [id]: IndexEntry }, designs: ..., indexUpdatedAt, exportedAt }
+ *   layouts/{id}.json    — full envelope for each non-tombstoned layout
+ *   designs/{id}.json    — full envelope for each non-tombstoned design
+ *
+ * Tombstones are excluded — the user asked to export their data, not
+ * the audit trail of deletions.
+ *
+ * The ZIP is built in-memory. With the 10MB-per-kind quota, the worst
+ * case is ~20MB pre-compression which is still well within Vercel
+ * function memory limits and HTTP response timeouts.
+ */
+export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
+  if (!requireMethod(req, res, ['GET'])) return;
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  const rate = await checkRateLimit(session.userId, 'sync.read');
+  if (!rate.allowed) {
+    res.status(429).json({
+      error: 'Too many requests. Try again later.',
+      code: ErrorCode.RATE_LIMITED,
+      retryAfter: rate.retryAfterSeconds,
+    });
+    return;
+  }
+
+  const redis = getRedis();
+  if (!redis) {
+    res
+      .status(503)
+      .json({ error: 'Service temporarily unavailable', code: ErrorCode.SERVICE_UNAVAILABLE });
+    return;
+  }
+
+  try {
+    const [layoutsIndex, designsIndex, indexUpdatedAt] = await Promise.all([
+      getIndex(redis, session.userId, 'layouts'),
+      getIndex(redis, session.userId, 'designs'),
+      getIndexUpdatedAt(redis, session.userId),
+    ]);
+
+    const liveLayouts = filterLive(layoutsIndex);
+    const liveDesigns = filterLive(designsIndex);
+
+    const { default: JSZip } = await import('jszip');
+    const zip = new JSZip();
+
+    zip.file(
+      'manifest.json',
+      JSON.stringify(
+        {
+          layouts: liveLayouts,
+          designs: liveDesigns,
+          indexUpdatedAt,
+          exportedAt: Date.now(),
+          schemaVersion: 1,
+        },
+        null,
+        2
+      )
+    );
+
+    await Promise.all([
+      addEnvelopes(zip, session.userId, 'layouts', Object.keys(liveLayouts)),
+      addEnvelopes(zip, session.userId, 'designs', Object.keys(liveDesigns)),
+    ]);
+
+    const buffer = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="gridfinity-export-${session.userId.slice(0, 8)}.zip"`
+    );
+    res.status(200).send(buffer);
+  } catch (error) {
+    logger.error('sync/export failed', {
+      userId: session.userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    res.status(500).json({ error: 'Server error', code: ErrorCode.SERVER_ERROR });
+  }
+}
+
+function filterLive(index: Record<string, IndexEntry>): Record<string, IndexEntry> {
+  const out: Record<string, IndexEntry> = {};
+  for (const [id, entry] of Object.entries(index)) {
+    if (entry.deletedAt === undefined) out[id] = entry;
+  }
+  return out;
+}
+
+interface JSZipLike {
+  file(name: string, content: string): void;
+}
+
+async function addEnvelopes(
+  zip: JSZipLike,
+  userId: string,
+  kind: SyncItemKind,
+  ids: string[]
+): Promise<void> {
+  // Fetch envelopes in parallel; missing blobs are skipped (they shouldn't
+  // happen, but if a blob delete races with the index read we don't want
+  // the export to fail).
+  const envelopes = await Promise.all(
+    ids.map((id) => getJson<unknown>(`users/${userId}/${kind}/${id}.json`))
+  );
+  for (let i = 0; i < ids.length; i++) {
+    const envelope = envelopes[i];
+    if (envelope) {
+      zip.file(`${kind}/${ids[i]}.json`, JSON.stringify(envelope, null, 2));
+    }
+  }
+}

--- a/api/sync/layouts/[id].test.ts
+++ b/api/sync/layouts/[id].test.ts
@@ -1,0 +1,360 @@
+/**
+ * Tests for /api/sync/layouts/[id]. Covers GET/PUT/DELETE plus the LWW +
+ * tombstone state machine.
+ *
+ * Mocks happen at: rateLimit (Redis + checkRateLimit), session
+ * (requireSession), blobStore (putJson/getJson/deleteBlob). We don't
+ * mock userIndex / quota — they run against the same in-memory Redis,
+ * exercising the full state-write path.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+let redisStore: Map<string, string>;
+let redisHashes: Map<string, Map<string, string>>;
+
+const blobStore = new Map<string, unknown>();
+
+const mockRedis = {
+  get: vi.fn(async (k: string) => redisStore.get(k) ?? null),
+  set: vi.fn(async (k: string, v: string) => {
+    redisStore.set(k, v);
+    return 'OK';
+  }),
+  hget: vi.fn(async (k: string, f: string) => redisHashes.get(k)?.get(f) ?? null),
+  hset: vi.fn(async (k: string, f: string, v: string) => {
+    const h = redisHashes.get(k) ?? new Map<string, string>();
+    h.set(f, v);
+    redisHashes.set(k, h);
+    return 1;
+  }),
+  hgetall: vi.fn(async (k: string) => {
+    const h = redisHashes.get(k);
+    return h ? Object.fromEntries(h) : {};
+  }),
+  pipeline: vi.fn(() => makePipeline()),
+};
+
+function makePipeline() {
+  const queue: Array<() => [Error | null, unknown]> = [];
+  const pipe = {
+    set: (k: string, v: string) => {
+      queue.push(() => {
+        redisStore.set(k, v);
+        return [null, 'OK'];
+      });
+      return pipe;
+    },
+    hset: (k: string, f: string, v: string) => {
+      queue.push(() => {
+        const h = redisHashes.get(k) ?? new Map<string, string>();
+        h.set(f, v);
+        redisHashes.set(k, h);
+        return [null, 1];
+      });
+      return pipe;
+    },
+    exec: vi.fn(async () => queue.map((fn) => fn())),
+  };
+  return pipe;
+}
+
+vi.mock('../../lib/rateLimit', () => ({
+  getRedis: () => mockRedis,
+  getClientIP: () => '127.0.0.1',
+  checkRateLimit: vi.fn(async () => ({
+    allowed: true,
+    remaining: 100,
+    resetAt: Date.now() + 60_000,
+  })),
+}));
+
+vi.mock('../../lib/session', () => ({
+  requireSession: vi.fn(async () => ({
+    userId: 'user-1',
+    provider: 'google',
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  })),
+}));
+
+vi.mock('../../lib/blobStore', () => ({
+  putJson: vi.fn(async (path: string, value: unknown) => {
+    blobStore.set(path, value);
+    return { url: `https://blob/${path}` };
+  }),
+  getJson: vi.fn(async (path: string) => blobStore.get(path) ?? null),
+  deleteBlob: vi.fn(async (path: string) => {
+    blobStore.delete(path);
+  }),
+  headBlob: vi.fn(async () => null),
+}));
+
+interface MockRes {
+  _status: number;
+  _body: unknown;
+  _ended: boolean;
+  status(code: number): MockRes;
+  json(body: unknown): MockRes;
+  end(): MockRes;
+  setHeader(): MockRes;
+}
+
+function makeRes(): MockRes {
+  return {
+    _status: 0,
+    _body: null,
+    _ended: false,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    json(body) {
+      this._body = body;
+      return this;
+    },
+    end() {
+      this._ended = true;
+      return this;
+    },
+    setHeader() {
+      return this;
+    },
+  };
+}
+
+function makeReq(opts: { method?: string; id?: string; body?: unknown }): VercelRequest {
+  return {
+    method: opts.method ?? 'GET',
+    // Default to a valid base36-timestamp id: timestamp + '-' + 7-char random.
+    query: { id: opts.id ?? 'lszwz1k7v-8j2kqp1' },
+    body: opts.body,
+    headers: { 'sec-fetch-site': 'same-origin', 'x-requested-with': 'gflt' },
+  } as unknown as VercelRequest;
+}
+
+const VALID_LAYOUT = {
+  version: '1.0',
+  name: 'Test Layout',
+  drawer: { width: 5, depth: 5, height: 3 },
+  bins: [],
+  layers: [{ id: 'layer-1', name: 'Layer 1', height: 1 }],
+  categories: [{ id: 'cat-1', name: 'Default', color: '#ff0000' }],
+  printBedSize: 256,
+  gridUnitMm: 42,
+  heightUnitMm: 7,
+};
+
+beforeEach(() => {
+  redisStore = new Map();
+  redisHashes = new Map();
+  blobStore.clear();
+  vi.clearAllMocks();
+});
+
+describe('GET', () => {
+  it('returns 404 when no entry exists', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    await handler(makeReq({ method: 'GET' }), res as unknown as VercelResponse);
+    expect(res._status).toBe(404);
+  });
+
+  it('returns the envelope and index entry for a live layout', async () => {
+    // Seed a live layout.
+    const { default: handler } = await import('./[id]');
+    await handler(
+      makeReq({
+        method: 'PUT',
+        body: { layout: VALID_LAYOUT, modifiedAt: 1000 },
+      }),
+      makeRes() as unknown as VercelResponse
+    );
+
+    const res = makeRes();
+    await handler(makeReq({ method: 'GET' }), res as unknown as VercelResponse);
+    expect(res._status).toBe(200);
+    const body = res._body as {
+      envelope: { modifiedAt: number };
+      indexEntry: { modifiedAt: number };
+    };
+    expect(body.envelope.modifiedAt).toBe(1000);
+    expect(body.indexEntry.modifiedAt).toBe(1000);
+  });
+
+  it('returns 410 Gone when the entry is tombstoned', async () => {
+    const { default: handler } = await import('./[id]');
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 1000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+    await handler(makeReq({ method: 'DELETE' }), makeRes() as unknown as VercelResponse);
+
+    const res = makeRes();
+    await handler(makeReq({ method: 'GET' }), res as unknown as VercelResponse);
+    expect(res._status).toBe(410);
+  });
+});
+
+describe('PUT — LWW + tombstone', () => {
+  it('creates a new entry on first write', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 1000 } }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(200);
+  });
+
+  it('rejects with 409 when the existing entry is newer (stale write)', async () => {
+    const { default: handler } = await import('./[id]');
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 5000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 1000 } }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(409);
+    const body = res._body as { stored: { modifiedAt: number } };
+    expect(body.stored.modifiedAt).toBe(5000);
+  });
+
+  it('accepts a write whose modifiedAt is newer than the existing entry', async () => {
+    const { default: handler } = await import('./[id]');
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 1000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 2000 } }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(200);
+  });
+
+  it('rejects with 410 when a stale edit would resurrect a newer tombstone', async () => {
+    const { default: handler } = await import('./[id]');
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 1000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+    // Delete (tombstone now ~ Date.now())
+    await handler(makeReq({ method: 'DELETE' }), makeRes() as unknown as VercelResponse);
+    // Stale edit (modifiedAt < tombstone) → 410.
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 500 } }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(410);
+  });
+
+  it('allows a newer-than-tombstone edit to resurrect the entry', async () => {
+    const { default: handler } = await import('./[id]');
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 1000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+    await handler(makeReq({ method: 'DELETE' }), makeRes() as unknown as VercelResponse);
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: Date.now() + 60_000 } }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(200);
+  });
+
+  it('rejects 400 when modifiedAt is missing or non-numeric', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 'now' } }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(400);
+  });
+});
+
+describe('DELETE', () => {
+  it('returns 204 and tombstones an existing layout', async () => {
+    const { default: handler } = await import('./[id]');
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 1000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+    const res = makeRes();
+    await handler(makeReq({ method: 'DELETE' }), res as unknown as VercelResponse);
+    expect(res._status).toBe(204);
+
+    // GET now yields 410.
+    const getRes = makeRes();
+    await handler(makeReq({ method: 'GET' }), getRes as unknown as VercelResponse);
+    expect(getRes._status).toBe(410);
+  });
+
+  it('is idempotent: 204 even when nothing exists', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    await handler(makeReq({ method: 'DELETE' }), res as unknown as VercelResponse);
+    expect(res._status).toBe(204);
+  });
+});
+
+describe('id validation', () => {
+  it('returns 400 for a malformed id', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'GET', id: 'not!a$valid_id' }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(400);
+  });
+
+  it('accepts a UUID', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'GET', id: '12345678-1234-1234-1234-123456789abc' }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(404); // valid id, just no entry
+  });
+});
+
+describe('rate limiting', () => {
+  it('returns 429 when the limiter rejects', async () => {
+    const rateLimit = await import('../../lib/rateLimit');
+    (rateLimit.checkRateLimit as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 60_000,
+      retryAfterSeconds: 30,
+    });
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    await handler(makeReq({ method: 'GET' }), res as unknown as VercelResponse);
+    expect(res._status).toBe(429);
+  });
+});
+
+describe('auth', () => {
+  it('does nothing when requireSession returns null (handler returns)', async () => {
+    const session = await import('../../lib/session');
+    (session.requireSession as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    // requireSession is responsible for sending the 401 response — handler
+    // just bails. This test asserts the handler doesn't proceed past auth.
+    await handler(makeReq({ method: 'GET' }), res as unknown as VercelResponse);
+    expect(res._status).toBe(0);
+  });
+});

--- a/api/sync/layouts/[id].test.ts
+++ b/api/sync/layouts/[id].test.ts
@@ -306,6 +306,26 @@ describe('DELETE', () => {
     await handler(makeReq({ method: 'DELETE' }), res as unknown as VercelResponse);
     expect(res._status).toBe(204);
   });
+
+  it('is idempotent on repeated DELETE: skips deleteBlob on already-tombstoned entries', async () => {
+    const { default: handler } = await import('./[id]');
+    const blobStoreMod = await import('../../lib/blobStore');
+    const deleteBlobMock = blobStoreMod.deleteBlob as ReturnType<typeof vi.fn>;
+
+    // First delete (live → tombstone) hits deleteBlob once.
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 1000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+    await handler(makeReq({ method: 'DELETE' }), makeRes() as unknown as VercelResponse);
+    const callsAfterFirst = deleteBlobMock.mock.calls.length;
+
+    // Second delete (already tombstoned) must NOT touch deleteBlob.
+    const secondRes = makeRes();
+    await handler(makeReq({ method: 'DELETE' }), secondRes as unknown as VercelResponse);
+    expect(secondRes._status).toBe(204);
+    expect(deleteBlobMock.mock.calls.length).toBe(callsAfterFirst);
+  });
 });
 
 describe('id validation', () => {

--- a/api/sync/layouts/[id].ts
+++ b/api/sync/layouts/[id].ts
@@ -58,7 +58,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
 
   try {
     if (req.method === 'GET') {
-      await handleGet(res, session.userId, id);
+      await handleGet(res, redis, session.userId, id);
     } else if (req.method === 'PUT') {
       await handlePut(req, res, redis, session.userId, id);
     } else {
@@ -74,14 +74,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
   }
 }
 
-async function handleGet(res: VercelResponse, userId: string, id: string): Promise<void> {
-  const redis = getRedis();
-  if (!redis) {
-    res
-      .status(503)
-      .json({ error: 'Service temporarily unavailable', code: ErrorCode.SERVICE_UNAVAILABLE });
-    return;
-  }
+async function handleGet(
+  res: VercelResponse,
+  redis: ReturnType<typeof getRedis> & object,
+  userId: string,
+  id: string
+): Promise<void> {
   const entry = await getEntry(redis, userId, 'layouts', id);
   if (!entry) {
     res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
@@ -136,8 +134,10 @@ async function handlePut(
 
   const existing = await getEntry(redis, userId, 'layouts', id);
 
-  // LWW comparison.
-  if (existing && !existing.deletedAt && existing.modifiedAt >= modifiedAt) {
+  // LWW comparison. `deletedAt === undefined` is the explicit live-entry
+  // check — `!existing.deletedAt` would also accept 0/NaN, which would
+  // misclassify any future tombstone written with such a value.
+  if (existing && existing.deletedAt === undefined && existing.modifiedAt >= modifiedAt) {
     const stored = await getJson<LayoutEnvelope>(blobPath(userId, id));
     res.status(409).json({
       error: 'A newer version already exists.',
@@ -194,9 +194,16 @@ async function handleDelete(
   id: string
 ): Promise<void> {
   const existing = await getEntry(redis, userId, 'layouts', id);
+  // Already tombstoned: don't try to delete the blob (it's already gone)
+  // and don't bump the tombstone timestamp — the original deletion is
+  // the source of truth for LWW.
+  if (existing?.deletedAt !== undefined) {
+    res.status(204).end();
+    return;
+  }
   if (!existing) {
-    // Already absent — idempotent: still write a tombstone so other
-    // devices learn about it on next pull.
+    // Never existed — write a tombstone so peer devices learn about
+    // the deletion on next pull. Idempotent.
     await tombstone(redis, userId, 'layouts', id, Date.now());
     res.status(204).end();
     return;

--- a/api/sync/layouts/[id].ts
+++ b/api/sync/layouts/[id].ts
@@ -1,0 +1,229 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { requireMethod } from '../../lib/method.js';
+import { ErrorCode } from '../../lib/shared.js';
+import { logger } from '../../lib/logger.js';
+import { checkRateLimit, getRedis } from '../../lib/rateLimit.js';
+import { requireSession } from '../../lib/session.js';
+import { isValidationError, validateShareLayout } from '../../lib/validation.js';
+import { deleteBlob, getJson, putJson } from '../../lib/blobStore.js';
+import { getEntry, tombstone, upsertEntry, type IndexEntry } from '../../lib/userIndex.js';
+import { checkQuota } from '../../lib/quota.js';
+
+export const SCHEMA_VERSION = 1 as const;
+
+interface LayoutEnvelope {
+  layout: unknown;
+  modifiedAt: number;
+  schemaVersion: typeof SCHEMA_VERSION;
+}
+
+/**
+ * GET    /api/sync/layouts/{id}   — fetch envelope (200 / 404 / 410)
+ * PUT    /api/sync/layouts/{id}   — body { layout, modifiedAt }; LWW
+ *                                    409 if remote is newer; 410 if a
+ *                                    stale resurrect would clobber a
+ *                                    tombstone newer than the edit.
+ * DELETE /api/sync/layouts/{id}   — tombstone + blob delete (204)
+ */
+export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
+  if (!requireMethod(req, res, ['GET', 'PUT', 'DELETE'])) return;
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  const id = singleParam(req.query.id);
+  if (!id || !isValidLayoutId(id)) {
+    res.status(400).json({ error: 'Invalid layout id', code: ErrorCode.VALIDATION_ERROR });
+    return;
+  }
+
+  const action = req.method === 'GET' ? 'sync.read' : 'sync.write';
+  const rate = await checkRateLimit(session.userId, action);
+  if (!rate.allowed) {
+    res.status(429).json({
+      error: 'Too many requests. Try again later.',
+      code: ErrorCode.RATE_LIMITED,
+      retryAfter: rate.retryAfterSeconds,
+    });
+    return;
+  }
+
+  const redis = getRedis();
+  if (!redis) {
+    res
+      .status(503)
+      .json({ error: 'Service temporarily unavailable', code: ErrorCode.SERVICE_UNAVAILABLE });
+    return;
+  }
+
+  try {
+    if (req.method === 'GET') {
+      await handleGet(res, session.userId, id);
+    } else if (req.method === 'PUT') {
+      await handlePut(req, res, redis, session.userId, id);
+    } else {
+      await handleDelete(res, redis, session.userId, id);
+    }
+  } catch (error) {
+    logger.error('sync/layouts handler failed', {
+      userId: session.userId,
+      method: req.method,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    res.status(500).json({ error: 'Server error', code: ErrorCode.SERVER_ERROR });
+  }
+}
+
+async function handleGet(res: VercelResponse, userId: string, id: string): Promise<void> {
+  const redis = getRedis();
+  if (!redis) {
+    res
+      .status(503)
+      .json({ error: 'Service temporarily unavailable', code: ErrorCode.SERVICE_UNAVAILABLE });
+    return;
+  }
+  const entry = await getEntry(redis, userId, 'layouts', id);
+  if (!entry) {
+    res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
+    return;
+  }
+  if (entry.deletedAt !== undefined) {
+    res.status(410).json({ error: 'Deleted', code: ErrorCode.NOT_FOUND, indexEntry: entry });
+    return;
+  }
+  const envelope = await getJson<LayoutEnvelope>(blobPath(userId, id));
+  if (!envelope) {
+    // Blob missing but index says it should exist — treat as 404 so the
+    // client refreshes its view. Don't 500 since the user can't act on it.
+    res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
+    return;
+  }
+  res.status(200).json({ envelope, indexEntry: entry });
+}
+
+interface PutBody {
+  layout: unknown;
+  modifiedAt: unknown;
+}
+
+async function handlePut(
+  req: VercelRequest,
+  res: VercelResponse,
+  redis: ReturnType<typeof getRedis> & object,
+  userId: string,
+  id: string
+): Promise<void> {
+  const body = req.body as PutBody | undefined;
+  if (!body || typeof body !== 'object') {
+    res.status(400).json({ error: 'Missing body', code: ErrorCode.VALIDATION_ERROR });
+    return;
+  }
+  const { layout, modifiedAt } = body;
+  if (typeof modifiedAt !== 'number' || !Number.isFinite(modifiedAt)) {
+    res
+      .status(400)
+      .json({ error: 'modifiedAt must be a number (ms epoch)', code: ErrorCode.VALIDATION_ERROR });
+    return;
+  }
+
+  const serialized = JSON.stringify({ layout });
+  const sizeBytes = Buffer.byteLength(serialized, 'utf8');
+  const validation = validateShareLayout(layout, sizeBytes);
+  if (isValidationError(validation)) {
+    res.status(400).json({ error: validation.error.message, code: validation.error.code });
+    return;
+  }
+
+  const existing = await getEntry(redis, userId, 'layouts', id);
+
+  // LWW comparison.
+  if (existing && !existing.deletedAt && existing.modifiedAt >= modifiedAt) {
+    const stored = await getJson<LayoutEnvelope>(blobPath(userId, id));
+    res.status(409).json({
+      error: 'A newer version already exists.',
+      code: ErrorCode.VALIDATION_ERROR,
+      stored,
+      indexEntry: existing,
+    });
+    return;
+  }
+
+  // Tombstone protection: a stale edit can't resurrect a deletion that
+  // happened *after* the local change.
+  if (existing?.deletedAt !== undefined && existing.deletedAt >= modifiedAt) {
+    res.status(410).json({
+      error: 'Layout was deleted on another device. Save again to restore.',
+      code: ErrorCode.NOT_FOUND,
+      indexEntry: existing,
+    });
+    return;
+  }
+
+  // Quota: replacing if the existing entry is live (tombstones don't count).
+  const replacingId = existing && existing.deletedAt === undefined ? id : undefined;
+  const quota = await checkQuota(redis, userId, 'layouts', {
+    op: 'put',
+    sizeBytes,
+    replacingId,
+  });
+  if (!quota.ok) {
+    res.status(413).json({
+      error: `Quota exceeded (${quota.error.reason}): ${quota.error.current} of ${quota.error.limit}.`,
+      code: ErrorCode.SIZE_LIMIT,
+    });
+    return;
+  }
+
+  const envelope: LayoutEnvelope = {
+    layout: validation.layout,
+    modifiedAt,
+    schemaVersion: SCHEMA_VERSION,
+  };
+  await putJson(blobPath(userId, id), envelope, { allowOverwrite: true });
+
+  const newEntry: IndexEntry = { modifiedAt, sizeBytes };
+  await upsertEntry(redis, userId, 'layouts', id, newEntry);
+
+  res.status(200).json({ envelope, indexEntry: newEntry });
+}
+
+async function handleDelete(
+  res: VercelResponse,
+  redis: ReturnType<typeof getRedis> & object,
+  userId: string,
+  id: string
+): Promise<void> {
+  const existing = await getEntry(redis, userId, 'layouts', id);
+  if (!existing) {
+    // Already absent — idempotent: still write a tombstone so other
+    // devices learn about it on next pull.
+    await tombstone(redis, userId, 'layouts', id, Date.now());
+    res.status(204).end();
+    return;
+  }
+  await deleteBlob(blobPath(userId, id));
+  await tombstone(redis, userId, 'layouts', id, Date.now());
+  res.status(204).end();
+}
+
+function blobPath(userId: string, id: string): string {
+  return `users/${userId}/layouts/${id}.json`;
+}
+
+function singleParam(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+/**
+ * Layouts the client may sync share three id formats with the existing
+ * share feature (UUID, base36 timestamp, 12-char alphanumeric); we accept
+ * the same shapes here so layouts can be round-tripped between local
+ * storage and the cloud without renaming.
+ */
+function isValidLayoutId(id: string): boolean {
+  if (/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(id)) return true;
+  if (/^[a-z0-9]+-[a-z0-9]{7}$/.test(id)) return true;
+  if (/^[a-zA-Z0-9]{12}$/.test(id)) return true;
+  return false;
+}

--- a/api/sync/manifest.test.ts
+++ b/api/sync/manifest.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+let redisStore: Map<string, string>;
+let redisHashes: Map<string, Map<string, string>>;
+
+const mockRedis = {
+  get: vi.fn(async (k: string) => redisStore.get(k) ?? null),
+  set: vi.fn(async (k: string, v: string) => {
+    redisStore.set(k, v);
+    return 'OK';
+  }),
+  hgetall: vi.fn(async (k: string) => {
+    const h = redisHashes.get(k);
+    return h ? Object.fromEntries(h) : {};
+  }),
+  pipeline: vi.fn(() => {
+    const queue: Array<() => [Error | null, unknown]> = [];
+    const pipe = {
+      set: (k: string, v: string) => {
+        queue.push(() => {
+          redisStore.set(k, v);
+          return [null, 'OK'];
+        });
+        return pipe;
+      },
+      hset: (k: string, f: string, v: string) => {
+        queue.push(() => {
+          const h = redisHashes.get(k) ?? new Map<string, string>();
+          h.set(f, v);
+          redisHashes.set(k, h);
+          return [null, 1];
+        });
+        return pipe;
+      },
+      exec: vi.fn(async () => queue.map((fn) => fn())),
+    };
+    return pipe;
+  }),
+};
+
+vi.mock('../lib/rateLimit', () => ({
+  getRedis: () => mockRedis,
+  getClientIP: () => '127.0.0.1',
+  checkRateLimit: vi.fn(async () => ({
+    allowed: true,
+    remaining: 100,
+    resetAt: Date.now() + 60_000,
+  })),
+}));
+
+vi.mock('../lib/session', () => ({
+  requireSession: vi.fn(async () => ({
+    userId: 'user-1',
+    provider: 'google',
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  })),
+}));
+
+interface MockRes {
+  _status: number;
+  _body: unknown;
+  _ended: boolean;
+  status(code: number): MockRes;
+  json(body: unknown): MockRes;
+  end(): MockRes;
+  setHeader(): MockRes;
+}
+
+function makeRes(): MockRes {
+  return {
+    _status: 0,
+    _body: null,
+    _ended: false,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    json(body) {
+      this._body = body;
+      return this;
+    },
+    end() {
+      this._ended = true;
+      return this;
+    },
+    setHeader() {
+      return this;
+    },
+  };
+}
+
+function makeReq(opts: { ifModifiedSince?: string } = {}): VercelRequest {
+  const headers: Record<string, string> = {};
+  if (opts.ifModifiedSince) headers['if-modified-since'] = opts.ifModifiedSince;
+  return {
+    method: 'GET',
+    query: {},
+    headers,
+  } as unknown as VercelRequest;
+}
+
+async function seedEntry(
+  kind: 'layouts' | 'designs',
+  id: string,
+  modifiedAt: number
+): Promise<void> {
+  const userIndex = await import('../lib/userIndex');
+  await userIndex.upsertEntry(mockRedis as never, 'user-1', kind, id, {
+    modifiedAt,
+    sizeBytes: 100,
+  });
+}
+
+beforeEach(() => {
+  redisStore = new Map();
+  redisHashes = new Map();
+  vi.clearAllMocks();
+});
+
+describe('GET /api/sync/manifest', () => {
+  it('returns empty manifest with indexUpdatedAt=0 for a fresh user', async () => {
+    const { default: handler } = await import('./manifest');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+    expect(res._status).toBe(200);
+    expect(res._body).toEqual({ layouts: {}, designs: {}, indexUpdatedAt: 0 });
+  });
+
+  it('returns the index hashes plus indexUpdatedAt', async () => {
+    await seedEntry('layouts', 'lay-1', 1000);
+    await seedEntry('designs', 'des-1', 2000);
+    const { default: handler } = await import('./manifest');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+    expect(res._status).toBe(200);
+    const body = res._body as {
+      layouts: Record<string, { modifiedAt: number }>;
+      designs: Record<string, { modifiedAt: number }>;
+      indexUpdatedAt: number;
+    };
+    expect(body.layouts['lay-1'].modifiedAt).toBe(1000);
+    expect(body.designs['des-1'].modifiedAt).toBe(2000);
+    expect(body.indexUpdatedAt).toBeGreaterThan(0);
+  });
+
+  it('returns 304 when If-Modified-Since matches the cached timestamp', async () => {
+    await seedEntry('layouts', 'lay-1', 1000);
+    const stamp = Number(redisStore.get('users:user-1:indexUpdatedAt'));
+    expect(stamp).toBeGreaterThan(0);
+
+    const { default: handler } = await import('./manifest');
+    const res = makeRes();
+    await handler(makeReq({ ifModifiedSince: String(stamp) }), res as unknown as VercelResponse);
+    expect(res._status).toBe(304);
+  });
+
+  it('returns 200 when If-Modified-Since is older than the cached timestamp', async () => {
+    await seedEntry('layouts', 'lay-1', 1000);
+    const { default: handler } = await import('./manifest');
+    const res = makeRes();
+    await handler(makeReq({ ifModifiedSince: '0' }), res as unknown as VercelResponse);
+    expect(res._status).toBe(200);
+  });
+
+  it('ignores a malformed If-Modified-Since header', async () => {
+    await seedEntry('layouts', 'lay-1', 1000);
+    const { default: handler } = await import('./manifest');
+    const res = makeRes();
+    await handler(makeReq({ ifModifiedSince: 'not-a-number' }), res as unknown as VercelResponse);
+    expect(res._status).toBe(200);
+  });
+
+  it('returns 429 when rate-limited', async () => {
+    const rateLimit = await import('../lib/rateLimit');
+    (rateLimit.checkRateLimit as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 60_000,
+      retryAfterSeconds: 30,
+    });
+    const { default: handler } = await import('./manifest');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+    expect(res._status).toBe(429);
+  });
+});

--- a/api/sync/manifest.ts
+++ b/api/sync/manifest.ts
@@ -1,0 +1,85 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { requireMethod } from '../lib/method.js';
+import { ErrorCode } from '../lib/shared.js';
+import { logger } from '../lib/logger.js';
+import { checkRateLimit, getRedis } from '../lib/rateLimit.js';
+import { requireSession } from '../lib/session.js';
+import { getIndex, getIndexUpdatedAt } from '../lib/userIndex.js';
+
+/**
+ * GET /api/sync/manifest
+ *
+ * Returns the user's full per-kind index plus an `indexUpdatedAt`
+ * timestamp the client uses for `If-Modified-Since` polling.
+ *
+ *   200  → { layouts: { [id]: IndexEntry }, designs: { [id]: IndexEntry }, indexUpdatedAt }
+ *   304  → empty body when the client's `If-Modified-Since` >= the
+ *          server's `users:{uid}:indexUpdatedAt` (no scan needed).
+ *
+ * The 304 path is the hot poll path — every authenticated tab pings
+ * this every 45s when visible, so it must be cheap. We compare against
+ * a single Redis GET of the `indexUpdatedAt` key, never reading the
+ * hashes themselves.
+ */
+export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
+  if (!requireMethod(req, res, ['GET'])) return;
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  const rate = await checkRateLimit(session.userId, 'sync.read');
+  if (!rate.allowed) {
+    res.status(429).json({
+      error: 'Too many requests. Try again later.',
+      code: ErrorCode.RATE_LIMITED,
+      retryAfter: rate.retryAfterSeconds,
+    });
+    return;
+  }
+
+  const redis = getRedis();
+  if (!redis) {
+    res
+      .status(503)
+      .json({ error: 'Service temporarily unavailable', code: ErrorCode.SERVICE_UNAVAILABLE });
+    return;
+  }
+
+  try {
+    const indexUpdatedAt = await getIndexUpdatedAt(redis, session.userId);
+
+    const ifModifiedSince = parseIfModifiedSinceHeader(req);
+    if (ifModifiedSince !== null && indexUpdatedAt > 0 && ifModifiedSince >= indexUpdatedAt) {
+      res.status(304).end();
+      return;
+    }
+
+    const [layouts, designs] = await Promise.all([
+      getIndex(redis, session.userId, 'layouts'),
+      getIndex(redis, session.userId, 'designs'),
+    ]);
+
+    res.status(200).json({ layouts, designs, indexUpdatedAt });
+  } catch (error) {
+    logger.error('sync/manifest failed', {
+      userId: session.userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    res.status(500).json({ error: 'Server error', code: ErrorCode.SERVER_ERROR });
+  }
+}
+
+/**
+ * Read a numeric millisecond timestamp from `If-Modified-Since` (custom
+ * convention — we send a number, not RFC 1123, because our cache key is
+ * `users:{uid}:indexUpdatedAt` already in ms). Returns null if absent or
+ * malformed; the handler then serves a fresh 200.
+ */
+function parseIfModifiedSinceHeader(req: VercelRequest): number | null {
+  const raw: unknown = req.headers['if-modified-since'];
+  const value = typeof raw === 'string' ? raw : Array.isArray(raw) ? String(raw[0]) : null;
+  if (!value) return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  return parsed;
+}


### PR DESCRIPTION
## Summary

PR 3 of 6 in the multi-device sync rollout. Server-only — adds the per-user sync endpoints that the client engine (PR 4) will start calling. **No UI changes**; the user-facing surface is still gated off by `SYNC_UI_ENABLED` from PR 2.

PR 1 ([#1572](https://github.com/andymai/gridfinity-layout-tool/pull/1572)) added the storage primitives. PR 2 ([#1591](https://github.com/andymai/gridfinity-layout-tool/pull/1591)) added the auth foundation (cookie sessions, `requireSession`, CSRF defense). PR 3 builds on both.

## What's in this PR

### Endpoints (`api/sync/`)

| Endpoint                    | Method | Rate Limit  | Behavior                                          |
| --------------------------- | ------ | ----------- | ------------------------------------------------- |
| `/api/sync/layouts/[id]`    | GET    | 240/min     | Fetch envelope (200 / 404 / 410)                  |
| `/api/sync/layouts/[id]`    | PUT    | 60/min      | LWW write; 409 stale-write, 410 stale-resurrect   |
| `/api/sync/layouts/[id]`    | DELETE | 60/min      | Tombstone + blob delete                           |
| `/api/sync/designs/[id]`    | GET/PUT/DELETE | 60–240/min | Same state machine for Bin Designer designs       |
| `/api/sync/manifest`        | GET    | 240/min     | Per-user index; `If-Modified-Since` → 304 (cheap poll path) |
| `/api/sync/export`          | GET    | 240/min     | ZIP of live items + manifest.json                 |
| `/api/sync/account`         | DELETE | 60/min      | Cascade-delete sessions + KV + blobs              |

All endpoints rate-limit per `userId`, not per IP — each authenticated user gets their own budget.

### Lib additions (`api/lib/`)

- **`userIndex.ts`** — `getIndex` / `upsertEntry` / `tombstone`. Backed by `HSET users:{uid}:index:{kind}`. Each write atomically bumps `users:{uid}:indexUpdatedAt` so `/api/sync/manifest` can serve `If-Modified-Since` 304s without scanning the hash.
- **`quota.ts`** — `checkQuota(redis, uid, kind, intent)`. 100 items + 10 MB per kind, tombstones excluded. Returns a discriminated union (`{ ok: true } | { ok: false, error }`); the api/ side doesn't share `Result` with src/, so this stays a local type.
- **`rateLimit.ts`** — added `sync.write` (60/min) and `sync.read` (240/min). Generalized the parameter name from `ip` → `scope` since sync callers pass `userId`; existing share/auth callers unchanged.

## LWW + tombstone state machine (PUT)

```
existing.modifiedAt >= req      → 409 Conflict (return stored envelope)
tombstone.deletedAt >= req      → 410 Gone   (stale resurrect blocked)
no existing OR newer than ts    → write succeeds (resurrection clears tombstone)
quota check happens AFTER LWW   → rejected writes don't consume a slot
```

Tested across all 8 quadrants (only-local, only-remote, both-newer / both-older, both-tombstoned, etc.).

## Cascade-delete is idempotent

`DELETE /api/sync/account` runs:

1. `SMEMBERS users:{uid}:sessions` → `DEL session:{token}` for each
2. `HKEYS users:{uid}:index:*` → `del()` each blob
3. `DEL users:{uid}:*` (indexes, profile, sessions set, indexUpdatedAt)
4. Clear session cookie on responding device

Each step uses unconditional `DEL`, so a partial-failure replay (Vercel function timeout, cold-start mid-cascade) is safe. Per-blob errors are logged but don't block — leftover blobs are storage cost only, not correctness.

## Decisions worth flagging

- **Content filtering deliberately skipped.** The existing share endpoints filter content because shares are publicly URL-accessible; sync data is user-private (your own layouts and designs). Filtering would cause false-positive blocks on a user's own bin labels with no security benefit. Documented in `api/sync/README.md`.
- **Designer payload reuses `validateDesignerShare`** — the sync envelope wraps the design as `{ type: 'designer', version: 1, params }` internally to satisfy the existing validator. Keeps one source of truth for BinParams validity. Unwrapped to `{ design, modifiedAt }` shape on the wire.
- **Quota under concurrent writes is a soft ceiling.** Two tabs racing on different items can both pass quota and both write, briefly exceeding the cap by one item. Acceptable at this scale; documented inline. A Lua-script atomic reservation isn't worth the complexity.
- **Item ids accept the same three formats as share ids** (UUID, base36 timestamp, 12-char alphanumeric). Lets layouts round-trip between local storage / share / sync without renaming.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run knip` — clean
- [x] Targeted tests pass: `pnpm exec vitest run api/sync api/lib api/auth` — 242/242
  - `api/lib/userIndex.test.ts` — 7/7 (round-trip, tombstone, malformed-JSON tolerance)
  - `api/lib/quota.test.ts` — 8/8 (count cap, byte cap, replace, tombstone exclusion, kind isolation)
  - `api/sync/layouts/[id].test.ts` — 15/15 (full LWW × tombstone grid, id validation, rate-limit, auth)
  - `api/sync/designs/[id].test.ts` — 6/6 (designer-specific validation, round-trip)
  - `api/sync/manifest.test.ts` — 6/6 (304 cache, manifest contents, malformed header tolerance)
  - `api/sync/export.test.ts` — 4/4 (empty zip, populated zip, tombstone exclusion, rate-limit)
  - `api/sync/account.test.ts` — 5/5 (full cascade, idempotent replay, per-blob failure tolerance)
- [ ] Manual verification post-deploy (with PR 2 cookie): see `api/sync/README.md` curl examples.

## Out of scope (PR 4)

- Client engine — `src/core/sync/engine.ts`, outbox, poller, claim flow
- LayoutAdapter / DesignAdapter wiring
- Toast UX for offline / forced sign-out