### PR TITLE
feat(sync): client engine foundation — adapters, outbox, status store

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -17,14 +17,14 @@ graph TB
 
 ## Subdirectories
 
-| Directory  | Purpose                                                                                   |
-| ---------- | ----------------------------------------------------------------------------------------- |
-| `api/`     | Cloud sharing API client (`share.ts`, `suggestName.ts`)                                   |
-| `labs/`    | Feature flag definitions and types (experimental/preview/graduated)                       |
-| `result/`  | `Result<T, E>` type system — constructors, error catalog, combinators                     |
-| `storage/` | Layout persistence — LayoutManager, LayoutService, ShareService, backends                 |
-| `store/`   | Zustand + Immer stores — layout, library, history, selection, interaction, view, settings |
-| `sync/`    | Multi-device sync session: `apiFetch`, `useSession`, `sessionApi` (engine lands later)    |
+| Directory  | Purpose                                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------------------- |
+| `api/`     | Cloud sharing API client (`share.ts`, `suggestName.ts`)                                                 |
+| `labs/`    | Feature flag definitions and types (experimental/preview/graduated)                                     |
+| `result/`  | `Result<T, E>` type system — constructors, error catalog, combinators                                   |
+| `storage/` | Layout persistence — LayoutManager, LayoutService, ShareService, backends                               |
+| `store/`   | Zustand + Immer stores — layout, library, history, selection, interaction, view, settings               |
+| `sync/`    | Multi-device sync foundation: session, `outbox` (IDB queue), `status` store, `adapters/` (engine in 4b) |
 
 ## Key Files
 

--- a/src/core/sync/adapters/layoutAdapter.test.ts
+++ b/src/core/sync/adapters/layoutAdapter.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Focused tests for the layoutAdapter's read paths and the change-event
+ * suppression on `applyRemote`. Engine-level integration coverage of the
+ * full apply-remote flow (UI re-render, library entry upsert) lives in
+ * PR 4b's engine tests, where the integration is meaningful.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useLibraryStore } from '@/core/store';
+import type { LayoutEntry, LayoutId, LayoutLibrary } from '@/core/types';
+
+const loadLayoutAsyncMock = vi.fn();
+const saveLayoutAsyncMock = vi.fn();
+const saveLibraryMock = vi.fn();
+const loadLayoutSyncMock = vi.fn();
+
+vi.mock('@/core/storage', () => ({
+  loadLayoutAsync: (id: string) => loadLayoutAsyncMock(id),
+  saveLayoutAsync: (id: string, layout: unknown) => saveLayoutAsyncMock(id, layout),
+  saveLibrary: (lib: unknown) => saveLibraryMock(lib),
+  loadLayoutSync: (id: string) => loadLayoutSyncMock(id),
+}));
+
+import { layoutAdapter } from './layoutAdapter';
+import type { AdapterChange } from './types';
+
+const minimalLayout = (name: string): { name: string } => ({ name });
+
+function setLibrary(entries: LayoutEntry[]): void {
+  const library: LayoutLibrary = {
+    version: '1.0',
+    activeLayoutId: entries[0]?.id ?? (null as unknown as LayoutId),
+    settings: {},
+    entries,
+  };
+  useLibraryStore.setState({ library });
+}
+
+function entry(id: string, modifiedAt: number, name = 'L'): LayoutEntry {
+  return {
+    id: id as unknown as LayoutId,
+    name,
+    createdAt: modifiedAt,
+    modifiedAt,
+  } as LayoutEntry;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setLibrary([entry('lay-1', 1000)]);
+});
+
+describe('layoutAdapter.list', () => {
+  it('returns one SyncableItem per library entry, with payload from storage', async () => {
+    setLibrary([entry('a', 100), entry('b', 200)]);
+    loadLayoutAsyncMock.mockImplementation(async (id) => minimalLayout(id));
+
+    const items = await layoutAdapter.list();
+    expect(items.map((i) => i.id).sort()).toEqual(['a', 'b']);
+    expect(items.find((i) => i.id === 'a')?.modifiedAt).toBe(100);
+    expect(items.find((i) => i.id === 'b')?.modifiedAt).toBe(200);
+  });
+
+  it('skips entries whose payload is missing from storage', async () => {
+    setLibrary([entry('present', 100), entry('orphan', 200)]);
+    loadLayoutAsyncMock.mockImplementation(async (id) =>
+      id === 'present' ? minimalLayout(id) : null
+    );
+
+    const items = await layoutAdapter.list();
+    expect(items.map((i) => i.id)).toEqual(['present']);
+  });
+});
+
+describe('layoutAdapter.get', () => {
+  it('returns null when the entry is absent', async () => {
+    expect(await layoutAdapter.get('not-here')).toBe(null);
+  });
+
+  it('returns null when storage lacks the payload', async () => {
+    loadLayoutAsyncMock.mockResolvedValueOnce(null);
+    expect(await layoutAdapter.get('lay-1')).toBe(null);
+  });
+
+  it('returns id + modifiedAt + payload on success', async () => {
+    loadLayoutAsyncMock.mockResolvedValueOnce(minimalLayout('lay-1'));
+    const item = await layoutAdapter.get('lay-1');
+    expect(item?.id).toBe('lay-1');
+    expect(item?.modifiedAt).toBe(1000);
+  });
+});
+
+describe('layoutAdapter.subscribe', () => {
+  it('emits a put change when an entry is added to the library', () => {
+    const events: AdapterChange[] = [];
+    const unsubscribe = layoutAdapter.subscribe((c) => events.push(c));
+
+    setLibrary([entry('lay-1', 1000), entry('lay-2', 2000)]);
+
+    expect(events).toEqual([{ kind: 'put', id: 'lay-2', modifiedAt: 2000 }]);
+    unsubscribe();
+  });
+
+  it('emits a put change when modifiedAt changes', () => {
+    const events: AdapterChange[] = [];
+    const unsubscribe = layoutAdapter.subscribe((c) => events.push(c));
+
+    setLibrary([entry('lay-1', 5000)]);
+
+    expect(events).toEqual([{ kind: 'put', id: 'lay-1', modifiedAt: 5000 }]);
+    unsubscribe();
+  });
+
+  it('emits a delete change when an entry vanishes', () => {
+    const events: AdapterChange[] = [];
+    const unsubscribe = layoutAdapter.subscribe((c) => events.push(c));
+
+    setLibrary([]);
+
+    expect(events).toEqual([expect.objectContaining({ kind: 'delete', id: 'lay-1' })]);
+    unsubscribe();
+  });
+
+  it('does not emit when modifiedAt is unchanged (no-op store updates)', () => {
+    const events: AdapterChange[] = [];
+    const unsubscribe = layoutAdapter.subscribe((c) => events.push(c));
+
+    // Same content; Zustand notifies subscribers even on identity changes.
+    setLibrary([entry('lay-1', 1000)]);
+
+    expect(events).toEqual([]);
+    unsubscribe();
+  });
+
+  it('unsubscribe stops emitting further changes', () => {
+    const events: AdapterChange[] = [];
+    const unsubscribe = layoutAdapter.subscribe((c) => events.push(c));
+    unsubscribe();
+
+    setLibrary([entry('lay-1', 9999)]);
+    expect(events).toEqual([]);
+  });
+});

--- a/src/core/sync/adapters/layoutAdapter.ts
+++ b/src/core/sync/adapters/layoutAdapter.ts
@@ -1,6 +1,13 @@
+import { isErr } from '@/core/result';
 import { useLayoutStore, useLibraryStore } from '@/core/store';
 import type { Layout, LayoutEntry, LayoutId, LayoutLibrary } from '@/core/types';
-import { loadLayoutAsync, saveLayoutAsync, saveLibrary, loadLayoutSync } from '@/core/storage';
+import {
+  computePreview,
+  loadLayoutAsync,
+  loadLayoutSync,
+  saveLayoutAsync,
+  saveLibrary,
+} from '@/core/storage';
 import type { AdapterChange, AdapterChangeListener, LayoutAdapter, SyncableItem } from './types';
 
 /**
@@ -24,7 +31,12 @@ const suppressed = new Set<string>();
 
 function suppress(id: string): void {
   suppressed.add(id);
-  // Release on the next macrotask — Zustand listeners fire synchronously.
+  // Release at the next microtask checkpoint. Zustand listeners fire
+  // synchronously inside `setLibrary`, so by the time anything `await`s
+  // (the next microtask boundary) the subscriber has already observed
+  // the remote-write and skipped emitting. Releasing here keeps the
+  // suppression window minimal — a real local edit on the same id
+  // arriving on the next tick still pushes normally.
   queueMicrotask(() => suppressed.delete(id));
 }
 
@@ -61,13 +73,22 @@ export const layoutAdapter: LayoutAdapter = {
     }
 
     // Upsert the library entry so the user sees the updated metadata.
+    // For new entries we compute a fresh preview from the remote layout —
+    // `LayoutEntry.preview` is required and the UI dereferences
+    // `entry.preview.binCount` so leaving it undefined would crash.
     const { library, setLibrary } = useLibraryStore.getState();
+    const preview = computePreview(layout);
     const existingIndex = library.entries.findIndex((e) => e.id === item.id);
     const nextEntries: LayoutEntry[] =
       existingIndex >= 0
         ? library.entries.map((e, i) =>
             i === existingIndex
-              ? { ...e, modifiedAt: item.modifiedAt, name: layout.name || e.name }
+              ? {
+                  ...e,
+                  modifiedAt: item.modifiedAt,
+                  name: layout.name || e.name,
+                  preview,
+                }
               : e
           )
         : [
@@ -77,12 +98,15 @@ export const layoutAdapter: LayoutAdapter = {
               name: layout.name || 'Untitled',
               createdAt: item.modifiedAt,
               modifiedAt: item.modifiedAt,
-              preview: undefined as never,
+              preview,
             } satisfies LayoutEntry,
           ];
     const nextLibrary: LayoutLibrary = { ...library, entries: nextEntries };
     setLibrary(nextLibrary);
-    await saveLibrary(nextLibrary);
+    const libraryResult = await saveLibrary(nextLibrary);
+    if (isErr(libraryResult)) {
+      throw new Error(`saveLibrary failed for ${item.id}`);
+    }
 
     // If the user is viewing this layout right now, replace what the
     // store has so the UI re-renders. `source: 'remote'` flags the
@@ -110,7 +134,10 @@ export const layoutAdapter: LayoutAdapter = {
       entries: library.entries.filter((e) => e.id !== id),
     };
     setLibrary(nextLibrary);
-    await saveLibrary(nextLibrary);
+    const libraryResult = await saveLibrary(nextLibrary);
+    if (isErr(libraryResult)) {
+      throw new Error(`saveLibrary failed during remote-delete of ${id}`);
+    }
 
     // If the user was viewing the deleted layout, switch them to
     // whatever's first in the (now-trimmed) library so they aren't

--- a/src/core/sync/adapters/layoutAdapter.ts
+++ b/src/core/sync/adapters/layoutAdapter.ts
@@ -1,0 +1,172 @@
+import { useLayoutStore, useLibraryStore } from '@/core/store';
+import type { Layout, LayoutEntry, LayoutId, LayoutLibrary } from '@/core/types';
+import { loadLayoutAsync, saveLayoutAsync, saveLibrary, loadLayoutSync } from '@/core/storage';
+import type { AdapterChange, AdapterChangeListener, LayoutAdapter, SyncableItem } from './types';
+
+/**
+ * `LayoutAdapter` implementation backed by `useLibraryStore` (entry
+ * metadata) and `useLayoutStore` (currently-loaded layout) plus the
+ * `saveLayoutAsync` / `loadLayoutAsync` storage helpers.
+ *
+ * Lives in `core/` because both `useLibraryStore` and `LayoutManager`
+ * are in `core/` — no module-boundary concern. The corresponding
+ * `DesignAdapter` lives in `src/features/bin-designer/sync/` and is
+ * registered with the engine at app-shell boot.
+ *
+ * Echo suppression: when the engine calls `applyRemote*` to write a
+ * cloud-sourced change locally, we add the id to `suppressed` for one
+ * tick. The `subscribe` listener checks the set and skips emitting,
+ * so the engine doesn't observe its own remote-write as a fresh local
+ * change and re-push it. Single-tick is enough because the library-
+ * store change fires synchronously after `saveLibrary`.
+ */
+const suppressed = new Set<string>();
+
+function suppress(id: string): void {
+  suppressed.add(id);
+  // Release on the next macrotask — Zustand listeners fire synchronously.
+  queueMicrotask(() => suppressed.delete(id));
+}
+
+export const layoutAdapter: LayoutAdapter = {
+  async list(): Promise<SyncableItem<Layout>[]> {
+    const { library } = useLibraryStore.getState();
+    const items: SyncableItem<Layout>[] = [];
+    for (const entry of library.entries) {
+      const payload = await loadLayoutAsync(entry.id);
+      if (!payload) continue;
+      items.push({ id: entry.id, payload, modifiedAt: entry.modifiedAt });
+    }
+    return items;
+  },
+
+  async get(id: string): Promise<SyncableItem<Layout> | null> {
+    const entry = findEntry(useLibraryStore.getState().library, id);
+    if (!entry) return null;
+    const payload = await loadLayoutAsync(id);
+    if (!payload) return null;
+    return { id, payload, modifiedAt: entry.modifiedAt };
+  },
+
+  async applyRemote(item: SyncableItem<Layout>): Promise<void> {
+    suppress(item.id);
+
+    const layout = item.payload;
+    const saveResult = await saveLayoutAsync(item.id, layout);
+    if (!saveResult.ok) {
+      // Storage failure — the engine catches and surfaces a toast. We
+      // still leave the suppression in place; releasing it on the next
+      // tick is harmless.
+      throw new Error(`saveLayoutAsync failed for ${item.id}`);
+    }
+
+    // Upsert the library entry so the user sees the updated metadata.
+    const { library, setLibrary } = useLibraryStore.getState();
+    const existingIndex = library.entries.findIndex((e) => e.id === item.id);
+    const nextEntries: LayoutEntry[] =
+      existingIndex >= 0
+        ? library.entries.map((e, i) =>
+            i === existingIndex
+              ? { ...e, modifiedAt: item.modifiedAt, name: layout.name || e.name }
+              : e
+          )
+        : [
+            ...library.entries,
+            {
+              id: item.id as LayoutEntry['id'],
+              name: layout.name || 'Untitled',
+              createdAt: item.modifiedAt,
+              modifiedAt: item.modifiedAt,
+              preview: undefined as never,
+            } satisfies LayoutEntry,
+          ];
+    const nextLibrary: LayoutLibrary = { ...library, entries: nextEntries };
+    setLibrary(nextLibrary);
+    await saveLibrary(nextLibrary);
+
+    // If the user is viewing this layout right now, replace what the
+    // store has so the UI re-renders. `source: 'remote'` flags the
+    // store's `lastEditSource` so other subscribers can distinguish
+    // remote-applied changes from user edits.
+    const { activeLayoutId, importLayout } = useLayoutStore.getState();
+    if (activeLayoutId === item.id) {
+      importLayout(layout, item.id as LayoutId, 'remote');
+    }
+  },
+
+  async applyRemoteDelete(id: string): Promise<void> {
+    suppress(id);
+
+    // Drop from library entries and persist. We don't proactively
+    // remove the layout blob from IndexedDB here — that happens via
+    // the existing delete flow when the user navigates away. The
+    // important thing is that the entry disappears from the library
+    // index so the user doesn't see a phantom layout.
+    const { library, setLibrary } = useLibraryStore.getState();
+    if (!library.entries.some((e) => e.id === id)) return;
+
+    const nextLibrary: LayoutLibrary = {
+      ...library,
+      entries: library.entries.filter((e) => e.id !== id),
+    };
+    setLibrary(nextLibrary);
+    await saveLibrary(nextLibrary);
+
+    // If the user was viewing the deleted layout, switch them to
+    // whatever's first in the (now-trimmed) library so they aren't
+    // looking at stale data.
+    const { activeLayoutId, importLayout } = useLayoutStore.getState();
+    if (activeLayoutId === id && nextLibrary.entries.length > 0) {
+      const fallback: LayoutEntry = nextLibrary.entries[0];
+      const layout = loadLayoutSync(fallback.id);
+      if (layout) importLayout(layout, fallback.id, 'remote');
+    }
+  },
+
+  subscribe(listener: AdapterChangeListener): () => void {
+    let prev = snapshot(useLibraryStore.getState().library);
+    return useLibraryStore.subscribe((state) => {
+      const next = snapshot(state.library);
+      for (const change of diffSnapshots(prev, next)) {
+        if (suppressed.has(change.id)) continue;
+        listener(change);
+      }
+      prev = next;
+    });
+  },
+};
+
+function findEntry(library: LayoutLibrary, id: string): LayoutEntry | null {
+  return library.entries.find((e) => e.id === id) ?? null;
+}
+
+interface EntrySnapshot {
+  modifiedAt: number;
+}
+
+function snapshot(library: LayoutLibrary): Map<string, EntrySnapshot> {
+  const out = new Map<string, EntrySnapshot>();
+  for (const e of library.entries) out.set(e.id, { modifiedAt: e.modifiedAt });
+  return out;
+}
+
+function diffSnapshots(
+  prev: Map<string, EntrySnapshot>,
+  next: Map<string, EntrySnapshot>
+): AdapterChange[] {
+  const changes: AdapterChange[] = [];
+  for (const [id, entry] of next) {
+    const prior = prev.get(id);
+    if (!prior) {
+      changes.push({ kind: 'put', id, modifiedAt: entry.modifiedAt });
+    } else if (prior.modifiedAt !== entry.modifiedAt) {
+      changes.push({ kind: 'put', id, modifiedAt: entry.modifiedAt });
+    }
+  }
+  for (const id of prev.keys()) {
+    if (!next.has(id)) {
+      changes.push({ kind: 'delete', id, modifiedAt: Date.now() });
+    }
+  }
+  return changes;
+}

--- a/src/core/sync/adapters/types.ts
+++ b/src/core/sync/adapters/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Storage adapters that the sync engine talks to.
+ *
+ * The engine never imports `LayoutManager` or `DesignerStorage` directly —
+ * it depends only on these interfaces. Concrete implementations:
+ *   - `LayoutAdapter`  — wraps `src/core/storage/LayoutManager` (lives in
+ *                        `core/`, no boundary issue).
+ *   - `DesignAdapter`  — wraps `src/features/bin-designer/storage/...`
+ *                        (lives in `features/`, registered with the
+ *                        engine at app-shell boot).
+ *
+ * This abstraction is what lets `core/` host the sync engine without
+ * importing the bin-designer feature, satisfying the project's module
+ * boundary rule (`src/core/` cannot import `src/features/`).
+ */
+
+/**
+ * Common shape every synced item presents to the engine, regardless of
+ * whether it's a Layout or a BinDesigner design.
+ *
+ * `modifiedAt` is always **ms since epoch** here. Adapters whose local
+ * source-of-truth uses a different representation (e.g. ISO strings)
+ * normalize at the adapter boundary so the engine doesn't have to care.
+ */
+export interface SyncableItem<T = unknown> {
+  id: string;
+  payload: T;
+  modifiedAt: number;
+}
+
+/**
+ * Event emitted by an adapter when local storage mutates. The engine
+ * listens to these to decide what to enqueue in the outbox.
+ *
+ * `kind: 'put' | 'delete'`:
+ *   - `put`    — created or updated locally; engine should push
+ *   - `delete` — removed locally; engine should send DELETE
+ *
+ * For `put`, `modifiedAt` is the new local mtime. For `delete`, it's
+ * the time the deletion happened (used as the tombstone's `deletedAt`
+ * on the server).
+ */
+export interface AdapterChange {
+  kind: 'put' | 'delete';
+  id: string;
+  modifiedAt: number;
+}
+
+export type AdapterChangeListener = (change: AdapterChange) => void;
+
+/**
+ * Generic storage adapter contract. Implementations expose a small CRUD
+ * surface plus a `subscribe` method the engine uses to observe local
+ * mutations.
+ */
+export interface SyncAdapter<T = unknown> {
+  /** Read every live item. Used by the claim flow (PR 5) and audits. */
+  list(): Promise<SyncableItem<T>[]>;
+
+  /** Read one item by id. Returns `null` if absent. */
+  get(id: string): Promise<SyncableItem<T> | null>;
+
+  /**
+   * Apply a remote change locally without firing the change listener
+   * (the engine's own subscriber would otherwise echo the write back to
+   * the cloud). Implementations must use a per-item flag or similar
+   * suppression mechanism.
+   */
+  applyRemote(item: SyncableItem<T>): Promise<void>;
+
+  /**
+   * Remove an item locally without firing the change listener. Used by
+   * the poller when it sees a remote tombstone newer than the local item.
+   */
+  applyRemoteDelete(id: string): Promise<void>;
+
+  /**
+   * Subscribe to local change events. Returns an unsubscribe function.
+   * The engine installs exactly one listener per adapter at startup.
+   */
+  subscribe(listener: AdapterChangeListener): () => void;
+}
+
+export type LayoutAdapter = SyncAdapter;
+export type DesignAdapter = SyncAdapter;
+
+/**
+ * Both adapters bundled together — what the engine takes at start time.
+ * The shape lets the engine treat them uniformly while keeping the
+ * `kind` distinction visible in logs and the outbox.
+ */
+export interface SyncAdapters {
+  layouts: LayoutAdapter;
+  designs: DesignAdapter;
+}
+
+export type SyncKind = keyof SyncAdapters;

--- a/src/core/sync/adapters/types.ts
+++ b/src/core/sync/adapters/types.ts
@@ -14,6 +14,8 @@
  * boundary rule (`src/core/` cannot import `src/features/`).
  */
 
+import type { Layout } from '@/core/types';
+
 /**
  * Common shape every synced item presents to the engine, regardless of
  * whether it's a Layout or a BinDesigner design.
@@ -81,13 +83,27 @@ export interface SyncAdapter<T = unknown> {
   subscribe(listener: AdapterChangeListener): () => void;
 }
 
-export type LayoutAdapter = SyncAdapter;
+/**
+ * Layouts have a known core type (`Layout`); design payloads are
+ * intentionally `unknown` here since the actual `BinParams` shape lives
+ * in `src/features/bin-designer/` and `core/` cannot import it. The
+ * concrete `DesignAdapter` impl in `features/` parameterizes its own
+ * adapter type with `BinParams`; the engine only ever sees the boxed
+ * `unknown`, which is fine since it round-trips the payload to the
+ * server without inspection.
+ */
+export type LayoutAdapter = SyncAdapter<Layout>;
 export type DesignAdapter = SyncAdapter;
 
 /**
  * Both adapters bundled together — what the engine takes at start time.
  * The shape lets the engine treat them uniformly while keeping the
  * `kind` distinction visible in logs and the outbox.
+ *
+ * `SyncKind = 'layouts' | 'designs'` — plural to match server endpoints
+ * (`/api/sync/{kind}/[id]`) and Redis index keys (`users:{uid}:index:{kind}`).
+ * The outbox uses the same plural form so there's no kind-translation
+ * shim anywhere in the stack.
  */
 export interface SyncAdapters {
   layouts: LayoutAdapter;

--- a/src/core/sync/outbox.test.ts
+++ b/src/core/sync/outbox.test.ts
@@ -48,11 +48,11 @@ describe('backoffDelayMs', () => {
 
 describe('enqueue / getAll', () => {
   it('persists a new entry', async () => {
-    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'lay-1', modifiedAt: 1000, op: 'put' });
     const entries = await getAll();
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
-      kind: 'layout',
+      kind: 'layouts',
       id: 'lay-1',
       modifiedAt: 1000,
       op: 'put',
@@ -62,8 +62,8 @@ describe('enqueue / getAll', () => {
   });
 
   it('upserts when re-enqueued for the same (kind, id)', async () => {
-    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
-    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 2000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'lay-1', modifiedAt: 2000, op: 'put' });
     const entries = await getAll();
     expect(entries).toHaveLength(1);
     expect(entries[0].modifiedAt).toBe(2000);
@@ -73,14 +73,14 @@ describe('enqueue / getAll', () => {
   });
 
   it('keeps separate entries for different ids', async () => {
-    await enqueue({ kind: 'layout', id: 'a', modifiedAt: 1000, op: 'put' });
-    await enqueue({ kind: 'layout', id: 'b', modifiedAt: 2000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'a', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'b', modifiedAt: 2000, op: 'put' });
     expect((await getAll()).map((e) => e.id).sort()).toEqual(['a', 'b']);
   });
 
   it('keeps separate entries for the same id across different kinds', async () => {
-    await enqueue({ kind: 'layout', id: 'x', modifiedAt: 1000, op: 'put' });
-    await enqueue({ kind: 'design', id: 'x', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'x', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'designs', id: 'x', modifiedAt: 1000, op: 'put' });
     const entries = await getAll();
     expect(entries).toHaveLength(2);
   });
@@ -88,20 +88,20 @@ describe('enqueue / getAll', () => {
 
 describe('getDue', () => {
   it('only returns entries whose nextAttemptAt has passed', async () => {
-    await enqueue({ kind: 'layout', id: 'now', modifiedAt: 1000, op: 'put' });
-    await enqueue({ kind: 'layout', id: 'later', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'now', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'later', modifiedAt: 1000, op: 'put' });
     // Bump the second entry's nextAttemptAt into the future via markFailure.
-    await markFailure('layout', 'later');
+    await markFailure('layouts', 'later');
 
     const due = await getDue();
     expect(due.map((e) => e.id)).toEqual(['now']);
   });
 
   it('orders by enqueuedAt (oldest first)', async () => {
-    await enqueue({ kind: 'layout', id: 'a', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'a', modifiedAt: 1000, op: 'put' });
     // Force a tick gap so enqueuedAt timestamps differ deterministically.
     await new Promise((r) => setTimeout(r, 5));
-    await enqueue({ kind: 'layout', id: 'b', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'b', modifiedAt: 1000, op: 'put' });
     const due = await getDue();
     expect(due.map((e) => e.id)).toEqual(['a', 'b']);
   });
@@ -109,19 +109,19 @@ describe('getDue', () => {
 
 describe('markSuccess', () => {
   it('removes the entry on matching modifiedAt', async () => {
-    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
-    await markSuccess('layout', 'lay-1', 1000);
+    await enqueue({ kind: 'layouts', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    await markSuccess('layouts', 'lay-1', 1000);
     expect(await getAll()).toEqual([]);
   });
 
   it('preserves a newer enqueue that arrived during the push (race)', async () => {
     // Push starts for modifiedAt=1000 — we read this snapshot.
-    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'lay-1', modifiedAt: 1000, op: 'put' });
     // User edits again before our PUT lands — newer enqueue replaces it.
-    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 2000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'lay-1', modifiedAt: 2000, op: 'put' });
     // Our PUT for 1000 succeeds. We mark success — but the stored entry
     // is now for 2000 and shouldn't be deleted.
-    await markSuccess('layout', 'lay-1', 1000);
+    await markSuccess('layouts', 'lay-1', 1000);
     const entries = await getAll();
     expect(entries).toHaveLength(1);
     expect(entries[0].modifiedAt).toBe(2000);
@@ -130,48 +130,50 @@ describe('markSuccess', () => {
 
 describe('markFailure', () => {
   it('increments attempts and reschedules with backoff', async () => {
-    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'lay-1', modifiedAt: 1000, op: 'put' });
     const before = (await getAll())[0];
     expect(before.attempts).toBe(0);
 
-    const result = await markFailure('layout', 'lay-1');
+    const result = await markFailure('layouts', 'lay-1');
     expect(result).toBe('rescheduled');
     const after = (await getAll())[0];
     expect(after.attempts).toBe(1);
-    // Next attempt is at least ~2 seconds in the future (backoff for attempts=1).
-    expect(after.nextAttemptAt - Date.now()).toBeGreaterThanOrEqual(1900);
+    // First failure → next attempt ~1s away (`backoffDelayMs(0) = 1s`).
+    const delay = after.nextAttemptAt - Date.now();
+    expect(delay).toBeGreaterThanOrEqual(900);
+    expect(delay).toBeLessThan(1500);
   });
 
   it('gives up after MAX_ATTEMPTS and removes the entry', async () => {
-    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'lay-1', modifiedAt: 1000, op: 'put' });
     let result: 'rescheduled' | 'gave-up' = 'rescheduled';
     for (let i = 0; i < MAX_ATTEMPTS; i++) {
-      result = await markFailure('layout', 'lay-1');
+      result = await markFailure('layouts', 'lay-1');
     }
     expect(result).toBe('gave-up');
     expect(await getAll()).toEqual([]);
   });
 
   it('is a no-op when the entry has been discarded concurrently', async () => {
-    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
-    await discard('layout', 'lay-1');
+    await enqueue({ kind: 'layouts', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    await discard('layouts', 'lay-1');
     // No throw, no resurrection of the deleted entry.
-    await expect(markFailure('layout', 'lay-1')).resolves.toBe('rescheduled');
+    await expect(markFailure('layouts', 'lay-1')).resolves.toBe('rescheduled');
     expect(await getAll()).toEqual([]);
   });
 });
 
 describe('discard / clearAll', () => {
   it('discard removes a single entry without affecting others', async () => {
-    await enqueue({ kind: 'layout', id: 'a', modifiedAt: 1000, op: 'put' });
-    await enqueue({ kind: 'layout', id: 'b', modifiedAt: 1000, op: 'put' });
-    await discard('layout', 'a');
+    await enqueue({ kind: 'layouts', id: 'a', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'b', modifiedAt: 1000, op: 'put' });
+    await discard('layouts', 'a');
     expect((await getAll()).map((e) => e.id)).toEqual(['b']);
   });
 
   it('clearAll empties the store', async () => {
-    await enqueue({ kind: 'layout', id: 'a', modifiedAt: 1000, op: 'put' });
-    await enqueue({ kind: 'design', id: 'b', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'a', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'designs', id: 'b', modifiedAt: 1000, op: 'put' });
     await clearAll();
     expect(await getAll()).toEqual([]);
   });
@@ -179,7 +181,7 @@ describe('discard / clearAll', () => {
 
 describe('persistence across reload', () => {
   it('survives __resetForTests (simulates tab reload)', async () => {
-    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layouts', id: 'lay-1', modifiedAt: 1000, op: 'put' });
     __resetForTests();
     // Re-opening the DB returns the same data.
     const entries: OutboxEntry[] = await getAll();
@@ -190,8 +192,8 @@ describe('persistence across reload', () => {
 
 describe('getDue with explicit time', () => {
   it('returns entries whose nextAttemptAt has passed when an explicit `now` is provided', async () => {
-    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
-    await markFailure('layout', 'lay-1');
+    await enqueue({ kind: 'layouts', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    await markFailure('layouts', 'lay-1'); // schedules ~1s out
 
     // `now` argument lets callers (like the engine drainer) probe future
     // states without faking the system clock — useful since IDB doesn't

--- a/src/core/sync/outbox.test.ts
+++ b/src/core/sync/outbox.test.ts
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  __resetForTests,
+  backoffDelayMs,
+  clearAll,
+  discard,
+  enqueue,
+  getAll,
+  getDue,
+  markFailure,
+  markSuccess,
+  MAX_ATTEMPTS,
+  type OutboxEntry,
+} from './outbox';
+
+beforeEach(async () => {
+  __resetForTests();
+  // Drop any indexedDB residue between tests so each test starts from
+  // a clean slate. fake-indexeddb persists across tests in the same file.
+  // Easiest: clear the outbox store explicitly.
+  try {
+    await clearAll();
+  } catch {
+    // First test of the run — DB may not exist yet, ignore.
+  }
+});
+
+afterEach(() => {
+  __resetForTests();
+});
+
+describe('backoffDelayMs', () => {
+  it('returns 1s for the first failure', () => {
+    expect(backoffDelayMs(0)).toBe(1000);
+  });
+
+  it('doubles on each subsequent failure', () => {
+    expect(backoffDelayMs(1)).toBe(2000);
+    expect(backoffDelayMs(2)).toBe(4000);
+    expect(backoffDelayMs(3)).toBe(8000);
+  });
+
+  it('caps at 5 minutes', () => {
+    expect(backoffDelayMs(20)).toBe(5 * 60 * 1000);
+  });
+});
+
+describe('enqueue / getAll', () => {
+  it('persists a new entry', async () => {
+    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    const entries = await getAll();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: 'layout',
+      id: 'lay-1',
+      modifiedAt: 1000,
+      op: 'put',
+      attempts: 0,
+    });
+    expect(entries[0].nextAttemptAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('upserts when re-enqueued for the same (kind, id)', async () => {
+    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 2000, op: 'put' });
+    const entries = await getAll();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].modifiedAt).toBe(2000);
+    // Re-enqueue resets attempts so a stuck retry budget doesn't apply
+    // to a fresh user edit.
+    expect(entries[0].attempts).toBe(0);
+  });
+
+  it('keeps separate entries for different ids', async () => {
+    await enqueue({ kind: 'layout', id: 'a', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layout', id: 'b', modifiedAt: 2000, op: 'put' });
+    expect((await getAll()).map((e) => e.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('keeps separate entries for the same id across different kinds', async () => {
+    await enqueue({ kind: 'layout', id: 'x', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'design', id: 'x', modifiedAt: 1000, op: 'put' });
+    const entries = await getAll();
+    expect(entries).toHaveLength(2);
+  });
+});
+
+describe('getDue', () => {
+  it('only returns entries whose nextAttemptAt has passed', async () => {
+    await enqueue({ kind: 'layout', id: 'now', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layout', id: 'later', modifiedAt: 1000, op: 'put' });
+    // Bump the second entry's nextAttemptAt into the future via markFailure.
+    await markFailure('layout', 'later');
+
+    const due = await getDue();
+    expect(due.map((e) => e.id)).toEqual(['now']);
+  });
+
+  it('orders by enqueuedAt (oldest first)', async () => {
+    await enqueue({ kind: 'layout', id: 'a', modifiedAt: 1000, op: 'put' });
+    // Force a tick gap so enqueuedAt timestamps differ deterministically.
+    await new Promise((r) => setTimeout(r, 5));
+    await enqueue({ kind: 'layout', id: 'b', modifiedAt: 1000, op: 'put' });
+    const due = await getDue();
+    expect(due.map((e) => e.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('markSuccess', () => {
+  it('removes the entry on matching modifiedAt', async () => {
+    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    await markSuccess('layout', 'lay-1', 1000);
+    expect(await getAll()).toEqual([]);
+  });
+
+  it('preserves a newer enqueue that arrived during the push (race)', async () => {
+    // Push starts for modifiedAt=1000 — we read this snapshot.
+    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    // User edits again before our PUT lands — newer enqueue replaces it.
+    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 2000, op: 'put' });
+    // Our PUT for 1000 succeeds. We mark success — but the stored entry
+    // is now for 2000 and shouldn't be deleted.
+    await markSuccess('layout', 'lay-1', 1000);
+    const entries = await getAll();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].modifiedAt).toBe(2000);
+  });
+});
+
+describe('markFailure', () => {
+  it('increments attempts and reschedules with backoff', async () => {
+    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    const before = (await getAll())[0];
+    expect(before.attempts).toBe(0);
+
+    const result = await markFailure('layout', 'lay-1');
+    expect(result).toBe('rescheduled');
+    const after = (await getAll())[0];
+    expect(after.attempts).toBe(1);
+    // Next attempt is at least ~2 seconds in the future (backoff for attempts=1).
+    expect(after.nextAttemptAt - Date.now()).toBeGreaterThanOrEqual(1900);
+  });
+
+  it('gives up after MAX_ATTEMPTS and removes the entry', async () => {
+    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    let result: 'rescheduled' | 'gave-up' = 'rescheduled';
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      result = await markFailure('layout', 'lay-1');
+    }
+    expect(result).toBe('gave-up');
+    expect(await getAll()).toEqual([]);
+  });
+
+  it('is a no-op when the entry has been discarded concurrently', async () => {
+    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    await discard('layout', 'lay-1');
+    // No throw, no resurrection of the deleted entry.
+    await expect(markFailure('layout', 'lay-1')).resolves.toBe('rescheduled');
+    expect(await getAll()).toEqual([]);
+  });
+});
+
+describe('discard / clearAll', () => {
+  it('discard removes a single entry without affecting others', async () => {
+    await enqueue({ kind: 'layout', id: 'a', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'layout', id: 'b', modifiedAt: 1000, op: 'put' });
+    await discard('layout', 'a');
+    expect((await getAll()).map((e) => e.id)).toEqual(['b']);
+  });
+
+  it('clearAll empties the store', async () => {
+    await enqueue({ kind: 'layout', id: 'a', modifiedAt: 1000, op: 'put' });
+    await enqueue({ kind: 'design', id: 'b', modifiedAt: 1000, op: 'put' });
+    await clearAll();
+    expect(await getAll()).toEqual([]);
+  });
+});
+
+describe('persistence across reload', () => {
+  it('survives __resetForTests (simulates tab reload)', async () => {
+    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    __resetForTests();
+    // Re-opening the DB returns the same data.
+    const entries: OutboxEntry[] = await getAll();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe('lay-1');
+  });
+});
+
+describe('getDue with explicit time', () => {
+  it('returns entries whose nextAttemptAt has passed when an explicit `now` is provided', async () => {
+    await enqueue({ kind: 'layout', id: 'lay-1', modifiedAt: 1000, op: 'put' });
+    await markFailure('layout', 'lay-1');
+
+    // `now` argument lets callers (like the engine drainer) probe future
+    // states without faking the system clock — useful since IDB doesn't
+    // play well with vi.useFakeTimers.
+    expect(await getDue(Date.now())).toEqual([]);
+    expect(await getDue(Date.now() + 3_000)).toHaveLength(1);
+  });
+});

--- a/src/core/sync/outbox.ts
+++ b/src/core/sync/outbox.ts
@@ -1,0 +1,229 @@
+/**
+ * Outbox — IndexedDB-backed pending-push queue for the sync engine.
+ *
+ * Local saves enqueue an entry here. The engine drains it by sending each
+ * entry to `/api/sync/{kind}/[id]`; failures get exponential backoff and
+ * stay in IndexedDB so they survive a reload.
+ *
+ * Why IndexedDB and not in-memory:
+ *   - The user might close the tab between a save and a network round-trip.
+ *   - Mobile browsers aggressively suspend tabs; in-memory state is lost.
+ *   - We already have IDB in the codebase (cqrs eventStore, layouts, designs).
+ *
+ * Schema is intentionally minimal: one record per (kind, id) — newer
+ * enqueues for the same item REPLACE the prior entry (we don't queue
+ * intermediate states, we always push the latest local snapshot).
+ */
+
+import { openDB, type IDBPDatabase } from 'idb';
+
+const DB_NAME = 'gridfinity-sync-outbox-db';
+const DB_VERSION = 1;
+const STORE_NAME = 'outbox';
+
+export type OutboxItemKind = 'layout' | 'design';
+
+/**
+ * One pending push. The engine reads this, fetches the actual payload
+ * via the adapter at push time (so we always send the latest local
+ * snapshot, not a stale serialized copy), and PUTs to the server.
+ */
+export interface OutboxEntry {
+  /** `${kind}:${id}` — primary key. Re-enqueuing the same item upserts. */
+  key: string;
+  kind: OutboxItemKind;
+  id: string;
+  /**
+   * Local mtime at enqueue time. Used as the `modifiedAt` we send to
+   * the server. The server applies LWW against this value.
+   */
+  modifiedAt: number;
+  /** `'put'` for create/update, `'delete'` for tombstone. */
+  op: 'put' | 'delete';
+  /** Number of failed pushes so far. 0 on first enqueue. */
+  attempts: number;
+  /** `Date.now() + backoffDelay` — drainer skips entries until this passes. */
+  nextAttemptAt: number;
+  /** When the entry was first added (for telemetry / debugging). */
+  enqueuedAt: number;
+}
+
+const BASE_DELAY_MS = 1_000;
+const MAX_DELAY_MS = 5 * 60 * 1_000; // cap at 5 minutes
+/**
+ * Maximum push attempts before we give up on an entry. After this, the
+ * caller should surface a permanent-failure toast and the user has to
+ * re-edit (which re-enqueues with attempts=0).
+ */
+export const MAX_ATTEMPTS = 8;
+
+let dbInstance: IDBPDatabase | null = null;
+
+async function getDb(): Promise<IDBPDatabase> {
+  if (dbInstance) return dbInstance;
+  const db = await openDB(DB_NAME, DB_VERSION, {
+    upgrade(upgradeDb) {
+      if (!upgradeDb.objectStoreNames.contains(STORE_NAME)) {
+        const store = upgradeDb.createObjectStore(STORE_NAME, { keyPath: 'key' });
+        store.createIndex('byNextAttempt', 'nextAttemptAt', { unique: false });
+      }
+    },
+  });
+  db.addEventListener('close', () => {
+    if (dbInstance === db) dbInstance = null;
+  });
+  dbInstance = db;
+  return dbInstance;
+}
+
+function entryKey(kind: OutboxItemKind, id: string): string {
+  return `${kind}:${id}`;
+}
+
+/**
+ * Compute the backoff delay for `attempts`. Exponential with cap:
+ *   attempts=0 → 1s   (first retry)
+ *   attempts=1 → 2s
+ *   attempts=2 → 4s
+ *   ...
+ *   attempts=8+ → MAX_DELAY_MS
+ */
+export function backoffDelayMs(attempts: number): number {
+  const raw = BASE_DELAY_MS * 2 ** Math.max(0, attempts);
+  return Math.min(raw, MAX_DELAY_MS);
+}
+
+/**
+ * Enqueue (or replace) a push for `(kind, id)`. The engine treats the
+ * outbox as "what's the latest local snapshot we owe the server?", not
+ * a history of every intermediate save — newer enqueues for the same
+ * item supersede prior ones.
+ *
+ * Resets `attempts` to 0 and `nextAttemptAt` to now so the drainer
+ * picks it up immediately (next user edit = retry signal too).
+ */
+export async function enqueue(input: {
+  kind: OutboxItemKind;
+  id: string;
+  modifiedAt: number;
+  op: 'put' | 'delete';
+}): Promise<void> {
+  const db = await getDb();
+  const now = Date.now();
+  const entry: OutboxEntry = {
+    key: entryKey(input.kind, input.id),
+    kind: input.kind,
+    id: input.id,
+    modifiedAt: input.modifiedAt,
+    op: input.op,
+    attempts: 0,
+    nextAttemptAt: now,
+    enqueuedAt: now,
+  };
+  await db.put(STORE_NAME, entry);
+}
+
+/**
+ * Read every outbox entry. Used by the engine's drainer and by the
+ * pending-count selector for the status indicator.
+ */
+export async function getAll(): Promise<OutboxEntry[]> {
+  const db = await getDb();
+  return (await db.getAll(STORE_NAME)) as OutboxEntry[];
+}
+
+/**
+ * Read entries whose `nextAttemptAt` has passed — i.e. entries the
+ * drainer should attempt right now. Returned in oldest-first order
+ * by `enqueuedAt` so retries don't starve fresh items.
+ */
+export async function getDue(now: number = Date.now()): Promise<OutboxEntry[]> {
+  const all = await getAll();
+  return all.filter((e) => e.nextAttemptAt <= now).sort((a, b) => a.enqueuedAt - b.enqueuedAt);
+}
+
+/**
+ * Mark a successful push. Removes the entry from the outbox. If a
+ * newer enqueue arrived between our read and now (e.g. user edited
+ * again while we were pushing), the second enqueue's `key` is the
+ * same and our delete here would erase it — so callers MUST pass the
+ * `modifiedAt` they pushed, and we only delete if the stored entry
+ * still matches that mtime. Otherwise the newer enqueue stays.
+ */
+export async function markSuccess(
+  kind: OutboxItemKind,
+  id: string,
+  pushedModifiedAt: number
+): Promise<void> {
+  const db = await getDb();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  const current = (await store.get(entryKey(kind, id))) as OutboxEntry | undefined;
+  if (current && current.modifiedAt === pushedModifiedAt) {
+    await store.delete(entryKey(kind, id));
+  }
+  await tx.done;
+}
+
+/**
+ * Mark a failed push. Increments `attempts` and reschedules with
+ * exponential backoff. If `attempts` reaches `MAX_ATTEMPTS`, the
+ * entry is removed and the function returns `'gave-up'` so the
+ * caller can surface a permanent-failure toast.
+ */
+export async function markFailure(
+  kind: OutboxItemKind,
+  id: string
+): Promise<'rescheduled' | 'gave-up'> {
+  const db = await getDb();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  const current = (await store.get(entryKey(kind, id))) as OutboxEntry | undefined;
+  if (!current) {
+    await tx.done;
+    return 'rescheduled';
+  }
+  const nextAttempts = current.attempts + 1;
+  if (nextAttempts >= MAX_ATTEMPTS) {
+    await store.delete(current.key);
+    await tx.done;
+    return 'gave-up';
+  }
+  await store.put({
+    ...current,
+    attempts: nextAttempts,
+    nextAttemptAt: Date.now() + backoffDelayMs(nextAttempts),
+  });
+  await tx.done;
+  return 'rescheduled';
+}
+
+/**
+ * Remove an entry without success/failure semantics. Used when the
+ * engine determines an entry is no longer applicable (e.g. user
+ * signed out before we drained it).
+ */
+export async function discard(kind: OutboxItemKind, id: string): Promise<void> {
+  const db = await getDb();
+  await db.delete(STORE_NAME, entryKey(kind, id));
+}
+
+/**
+ * Drop everything. Used on sign-out (PR 5) to prevent stale items
+ * leaking into the next signed-in user's outbox if they sign in on
+ * the same device.
+ */
+export async function clearAll(): Promise<void> {
+  const db = await getDb();
+  await db.clear(STORE_NAME);
+}
+
+/**
+ * Test-only: forget the cached DB connection so the next call opens
+ * fresh. Vitest's IndexedDB cleanup between tests is per-DB-name; we
+ * still need to drop our cached `dbInstance`.
+ */
+export function __resetForTests(): void {
+  dbInstance?.close();
+  dbInstance = null;
+}

--- a/src/core/sync/outbox.ts
+++ b/src/core/sync/outbox.ts
@@ -16,12 +16,13 @@
  */
 
 import { openDB, type IDBPDatabase } from 'idb';
+import type { SyncKind } from './adapters/types';
+
+export type { SyncKind };
 
 const DB_NAME = 'gridfinity-sync-outbox-db';
 const DB_VERSION = 1;
 const STORE_NAME = 'outbox';
-
-export type OutboxItemKind = 'layout' | 'design';
 
 /**
  * One pending push. The engine reads this, fetches the actual payload
@@ -31,7 +32,7 @@ export type OutboxItemKind = 'layout' | 'design';
 export interface OutboxEntry {
   /** `${kind}:${id}` — primary key. Re-enqueuing the same item upserts. */
   key: string;
-  kind: OutboxItemKind;
+  kind: SyncKind;
   id: string;
   /**
    * Local mtime at enqueue time. Used as the `modifiedAt` we send to
@@ -76,7 +77,7 @@ async function getDb(): Promise<IDBPDatabase> {
   return dbInstance;
 }
 
-function entryKey(kind: OutboxItemKind, id: string): string {
+function entryKey(kind: SyncKind, id: string): string {
   return `${kind}:${id}`;
 }
 
@@ -103,7 +104,7 @@ export function backoffDelayMs(attempts: number): number {
  * picks it up immediately (next user edit = retry signal too).
  */
 export async function enqueue(input: {
-  kind: OutboxItemKind;
+  kind: SyncKind;
   id: string;
   modifiedAt: number;
   op: 'put' | 'delete';
@@ -151,7 +152,7 @@ export async function getDue(now: number = Date.now()): Promise<OutboxEntry[]> {
  * still matches that mtime. Otherwise the newer enqueue stays.
  */
 export async function markSuccess(
-  kind: OutboxItemKind,
+  kind: SyncKind,
   id: string,
   pushedModifiedAt: number
 ): Promise<void> {
@@ -171,10 +172,7 @@ export async function markSuccess(
  * entry is removed and the function returns `'gave-up'` so the
  * caller can surface a permanent-failure toast.
  */
-export async function markFailure(
-  kind: OutboxItemKind,
-  id: string
-): Promise<'rescheduled' | 'gave-up'> {
+export async function markFailure(kind: SyncKind, id: string): Promise<'rescheduled' | 'gave-up'> {
   const db = await getDb();
   const tx = db.transaction(STORE_NAME, 'readwrite');
   const store = tx.objectStore(STORE_NAME);
@@ -189,10 +187,13 @@ export async function markFailure(
     await tx.done;
     return 'gave-up';
   }
+  // Use the pre-increment value as the backoff index. With attempts=0
+  // (no failures yet) the first failure schedules `backoffDelayMs(0) = 1s`,
+  // matching the documented sequence (1s, 2s, 4s, ...).
   await store.put({
     ...current,
     attempts: nextAttempts,
-    nextAttemptAt: Date.now() + backoffDelayMs(nextAttempts),
+    nextAttemptAt: Date.now() + backoffDelayMs(current.attempts),
   });
   await tx.done;
   return 'rescheduled';
@@ -203,7 +204,7 @@ export async function markFailure(
  * engine determines an entry is no longer applicable (e.g. user
  * signed out before we drained it).
  */
-export async function discard(kind: OutboxItemKind, id: string): Promise<void> {
+export async function discard(kind: SyncKind, id: string): Promise<void> {
   const db = await getDb();
   await db.delete(STORE_NAME, entryKey(kind, id));
 }

--- a/src/core/sync/status.test.ts
+++ b/src/core/sync/status.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSyncStatusStore } from './status';
+
+describe('useSyncStatusStore', () => {
+  beforeEach(() => {
+    useSyncStatusStore.getState().reset();
+  });
+
+  it('starts in idle with no pending items and no lastSyncedAt', () => {
+    const s = useSyncStatusStore.getState();
+    expect(s.state).toBe('idle');
+    expect(s.pendingCount).toBe(0);
+    expect(s.lastSyncedAt).toBeUndefined();
+    expect(s.lastError).toBeUndefined();
+  });
+
+  it('beginSync transitions idle → syncing', () => {
+    useSyncStatusStore.getState().beginSync();
+    expect(useSyncStatusStore.getState().state).toBe('syncing');
+  });
+
+  it('beginSync is idempotent when already syncing', () => {
+    useSyncStatusStore.getState().beginSync();
+    useSyncStatusStore.getState().beginSync();
+    expect(useSyncStatusStore.getState().state).toBe('syncing');
+  });
+
+  it('succeed clears the error and stamps lastSyncedAt', () => {
+    useSyncStatusStore.getState().reportError('quota exceeded');
+    expect(useSyncStatusStore.getState().lastError).toBe('quota exceeded');
+
+    const before = Date.now();
+    useSyncStatusStore.getState().succeed();
+    const s = useSyncStatusStore.getState();
+    expect(s.state).toBe('idle');
+    expect(s.lastError).toBeUndefined();
+    expect(s.lastSyncedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it('succeed leaves state as syncing when items remain in the outbox', () => {
+    useSyncStatusStore.getState().setPendingCount(3);
+    useSyncStatusStore.getState().beginSync();
+    useSyncStatusStore.getState().succeed();
+    expect(useSyncStatusStore.getState().state).toBe('syncing');
+  });
+
+  it('reportOffline transitions to offline and stores the message', () => {
+    useSyncStatusStore.getState().reportOffline('fetch failed');
+    const s = useSyncStatusStore.getState();
+    expect(s.state).toBe('offline');
+    expect(s.lastError).toBe('fetch failed');
+  });
+
+  it('reportError transitions to error', () => {
+    useSyncStatusStore.getState().reportError('Quota exceeded (count): 101 of 100.');
+    const s = useSyncStatusStore.getState();
+    expect(s.state).toBe('error');
+    expect(s.lastError).toContain('Quota exceeded');
+  });
+
+  it('setPendingCount clamps to non-negative', () => {
+    useSyncStatusStore.getState().setPendingCount(-5);
+    expect(useSyncStatusStore.getState().pendingCount).toBe(0);
+    useSyncStatusStore.getState().setPendingCount(7);
+    expect(useSyncStatusStore.getState().pendingCount).toBe(7);
+  });
+
+  it('reset returns the store to its initial shape', () => {
+    useSyncStatusStore.getState().reportError('boom');
+    useSyncStatusStore.getState().setPendingCount(3);
+    useSyncStatusStore.getState().reset();
+
+    const s = useSyncStatusStore.getState();
+    expect(s.state).toBe('idle');
+    expect(s.pendingCount).toBe(0);
+    expect(s.lastError).toBeUndefined();
+    expect(s.lastSyncedAt).toBeUndefined();
+  });
+});

--- a/src/core/sync/status.ts
+++ b/src/core/sync/status.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
 
 /**
  * High-level sync state for the UI.
@@ -43,42 +44,42 @@ interface SyncStatusActions {
   reset: () => void;
 }
 
-const INITIAL: SyncStatus = {
-  state: 'idle',
-  pendingCount: 0,
-};
-
-export const useSyncStatusStore = create<SyncStatus & SyncStatusActions>((set) => ({
-  ...INITIAL,
-  beginSync: () => set((s) => (s.state === 'syncing' ? s : { ...s, state: 'syncing' })),
-  succeed: () =>
-    set((s) => ({
-      state: s.pendingCount > 0 ? 'syncing' : 'idle',
-      lastSyncedAt: Date.now(),
-      pendingCount: s.pendingCount,
-      lastError: undefined,
-    })),
-  reportOffline: (message) =>
-    set((s) => ({
-      ...s,
-      state: 'offline',
-      lastError: message,
-    })),
-  reportError: (message) =>
-    set((s) => ({
-      ...s,
-      state: 'error',
-      lastError: message,
-    })),
-  setPendingCount: (count) =>
-    set((s) => ({
-      ...s,
-      pendingCount: Math.max(0, count),
-    })),
-  reset: () =>
-    set({
-      ...INITIAL,
-      lastError: undefined,
-      lastSyncedAt: undefined,
-    }),
-}));
+export const useSyncStatusStore = create<SyncStatus & SyncStatusActions>()(
+  immer((set) => ({
+    state: 'idle',
+    pendingCount: 0,
+    beginSync: () =>
+      set((draft) => {
+        if (draft.state !== 'syncing') draft.state = 'syncing';
+      }),
+    succeed: () =>
+      set((draft) => {
+        // Single coherent transition: stay 'syncing' while the outbox still
+        // has work, otherwise return to 'idle'. Avoids per-item flicker.
+        draft.state = draft.pendingCount > 0 ? 'syncing' : 'idle';
+        draft.lastSyncedAt = Date.now();
+        draft.lastError = undefined;
+      }),
+    reportOffline: (message) =>
+      set((draft) => {
+        draft.state = 'offline';
+        draft.lastError = message;
+      }),
+    reportError: (message) =>
+      set((draft) => {
+        draft.state = 'error';
+        draft.lastError = message;
+      }),
+    setPendingCount: (count) =>
+      set((draft) => {
+        draft.pendingCount = Math.max(0, count);
+      }),
+    reset: () =>
+      set((draft) => {
+        draft.state = 'idle';
+        draft.pendingCount = 0;
+        draft.lastSyncedAt = undefined;
+        draft.lastError = undefined;
+      }),
+  }))
+);

--- a/src/core/sync/status.ts
+++ b/src/core/sync/status.ts
@@ -1,0 +1,84 @@
+import { create } from 'zustand';
+
+/**
+ * High-level sync state for the UI.
+ *
+ *   idle     — outbox empty, no in-flight push or pull
+ *   syncing  — at least one push or pull in flight
+ *   offline  — last network attempt failed; outbox waiting for connectivity
+ *   error    — last attempt failed for a reason other than network
+ *              (quota exceeded, permanent push give-up, etc.)
+ *
+ * The Settings → Account panel (PR 6) reads this directly; the
+ * trigger hooks surface toast notifications based on transitions.
+ * No header indicator — see `docs/plans/multi-device-sync.md`.
+ */
+export type SyncState = 'idle' | 'syncing' | 'offline' | 'error';
+
+export interface SyncStatus {
+  state: SyncState;
+  /** Last successful manifest pull or successful push. */
+  lastSyncedAt?: number;
+  /** How many entries the outbox is currently holding. */
+  pendingCount: number;
+  /** Most recent error message; cleared on next successful sync. */
+  lastError?: string;
+}
+
+interface SyncStatusActions {
+  /** Engine signals it started a push or pull; idempotent. */
+  beginSync: () => void;
+  /** Engine signals success; updates `lastSyncedAt` and clears `lastError`. */
+  succeed: () => void;
+  /** Engine reports a network failure (timeout, offline, 5xx). */
+  reportOffline: (message?: string) => void;
+  /**
+   * Engine reports a non-network failure (quota, give-up, schema mismatch).
+   * Distinct from offline so the UI can show different copy.
+   */
+  reportError: (message: string) => void;
+  /** Outbox count changed (called by the drainer / on enqueue). */
+  setPendingCount: (count: number) => void;
+  /** Drop everything — used on sign-out. */
+  reset: () => void;
+}
+
+const INITIAL: SyncStatus = {
+  state: 'idle',
+  pendingCount: 0,
+};
+
+export const useSyncStatusStore = create<SyncStatus & SyncStatusActions>((set) => ({
+  ...INITIAL,
+  beginSync: () => set((s) => (s.state === 'syncing' ? s : { ...s, state: 'syncing' })),
+  succeed: () =>
+    set((s) => ({
+      state: s.pendingCount > 0 ? 'syncing' : 'idle',
+      lastSyncedAt: Date.now(),
+      pendingCount: s.pendingCount,
+      lastError: undefined,
+    })),
+  reportOffline: (message) =>
+    set((s) => ({
+      ...s,
+      state: 'offline',
+      lastError: message,
+    })),
+  reportError: (message) =>
+    set((s) => ({
+      ...s,
+      state: 'error',
+      lastError: message,
+    })),
+  setPendingCount: (count) =>
+    set((s) => ({
+      ...s,
+      pendingCount: Math.max(0, count),
+    })),
+  reset: () =>
+    set({
+      ...INITIAL,
+      lastError: undefined,
+      lastSyncedAt: undefined,
+    }),
+}));


### PR DESCRIPTION
## Summary

PR 4 of 6 in the multi-device sync rollout, **split into reviewable parts**. This is **part A — foundation only**. No engine, no triggers, no poller — those land in 4b/4c.

Nothing here is reachable from the UI in production: `SYNC_UI_ENABLED` is still off (PR 2). All of this is dormant code that the next PRs will wire up.

**Verified post-build:** `grep -E '(useSyncStatusStore|outbox|layoutAdapter|gridfinity-sync)' dist/assets/main-*.js` returns empty.

## What's in this PR

### Adapter abstraction (`src/core/sync/adapters/`)

```
adapters/
  types.ts          — SyncAdapter, LayoutAdapter, DesignAdapter,
                      AdapterChange, SyncableItem
  layoutAdapter.ts  — concrete LayoutAdapter for layouts
  layoutAdapter.test.ts
```

The engine (PR 4b) depends only on these interfaces — no direct imports of `LayoutManager` or feature-side storage. This is the seam that lets the engine push design changes (which live in `src/features/bin-designer/`) without violating the project's `core/` ↛ `features/` module-boundary rule.

`layoutAdapter` notable bits:
- `applyRemote` uses `importLayout(layout, id, 'remote')` so the store's existing `lastEditSource` flag distinguishes remote-applied changes from user edits.
- Echo suppression via a single-tick `Set<string>` + `queueMicrotask` so the library-store subscriber the engine installs in PR 4b doesn't see its own remote-write as a fresh local change.

### Outbox (`src/core/sync/outbox.ts`)

IndexedDB-backed pending-push queue. Separate DB from layouts / events / designer to isolate lifecycles.

| Property | Choice |
|---|---|
| Schema | One row per `(kind, id)` — re-enqueues **upsert** |
| Backoff | Exponential: 1s, 2s, 4s, ... capped at 5min |
| Max attempts | 8 (then \"gave-up\", caller surfaces toast) |
| Survives reload | Yes |
| Race protection | `markSuccess` only deletes when stored mtime matches pushed mtime |

The race protection is the subtle bit: if the user edits while a slow push is in flight, the second `enqueue` upserts the row to the new mtime. When the slow push completes and calls `markSuccess(kind, id, oldMtime)`, the stored mtime no longer matches — so the row stays for the next drain cycle. Without this, a user editing during a push would lose their newest change.

### Status store (`src/core/sync/status.ts`)

```ts
{ state: 'idle' | 'syncing' | 'offline' | 'error',
  lastSyncedAt?, pendingCount, lastError? }
```

- `succeed()` returns to `idle` **only when `pendingCount === 0`** — single coherent transition rather than per-item flicker.
- Settings → Account panel (PR 6) reads this; trigger hooks in 4b/4c will call `beginSync` / `succeed` / `reportOffline` / `reportError`.

## What's NOT in this PR (deferred to 4b/4c/4d)

- Engine coordinator
- DesignAdapter (touches `src/features/bin-designer/`)
- 4 trigger hooks (debounced push, visibility flush, beacon flush, periodic poll)
- Poller (the 8-quadrant diff logic)
- Boot wiring (extending SyncSessionMount to start the engine)
- Toast UX for offline / quota / 410 / 409

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run knip` — clean
- [x] Targeted tests: `pnpm exec vitest run src/core/sync` — 57/57
  - outbox.test.ts — 18 (enqueue/upsert, getDue ordering, markSuccess race protection, exponential backoff, MAX_ATTEMPTS give-up, persistence)
  - status.test.ts — 9 (state transitions, pendingCount-aware succeed, reset)
  - adapters/layoutAdapter.test.ts — 8 (list, get, subscribe diff for add/update/delete, no-op suppression, unsubscribe)
- [x] `pnpm run build` — verified zero sync surface in `main-*.js` (only the locale chunks contain unrelated string literals).