### PR TITLE
feat(sync): poller + periodic-poll trigger (PR 4c)

### DIFF
--- a/src/core/sync/poller.test.ts
+++ b/src/core/sync/poller.test.ts
@@ -1,0 +1,313 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { __resetForTests, pullNow } from './poller';
+import { useSyncStatusStore } from './status';
+import type { SyncAdapter, SyncAdapters, SyncableItem } from './adapters/types';
+
+const fetchMock = vi.fn();
+
+vi.mock('./apiFetch', () => ({
+  apiFetch: (url: string, init?: RequestInit) => fetchMock(url, init),
+}));
+
+interface MockAdapter extends SyncAdapter {
+  items: Map<string, SyncableItem>;
+}
+
+function makeMockAdapter(): MockAdapter {
+  const items = new Map<string, SyncableItem>();
+  const adapter: MockAdapter = {
+    items,
+    list: vi.fn(async () => Array.from(items.values())),
+    get: vi.fn(async (id: string) => items.get(id) ?? null),
+    applyRemote: vi.fn(async (item) => {
+      items.set(item.id, item);
+    }),
+    applyRemoteDelete: vi.fn(async (id) => {
+      items.delete(id);
+    }),
+    subscribe: vi.fn(() => () => {}),
+  };
+  return adapter;
+}
+
+let layouts: MockAdapter;
+let designs: MockAdapter;
+let adapters: SyncAdapters;
+
+beforeEach(() => {
+  __resetForTests();
+  vi.clearAllMocks();
+  useSyncStatusStore.getState().reset();
+  layouts = makeMockAdapter();
+  designs = makeMockAdapter();
+  adapters = { layouts, designs };
+});
+
+function manifestResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function envelopeResponse(envelope: unknown, indexEntry: unknown): Response {
+  return new Response(JSON.stringify({ envelope, indexEntry }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('pullNow — single-flight + 304 path', () => {
+  it('coalesces concurrent calls into one in-flight pull', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 304 }));
+    await Promise.all([pullNow(adapters), pullNow(adapters), pullNow(adapters)]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns "not-modified" when the server says 304', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 304 }));
+    const result = await pullNow(adapters);
+    expect(result.status).toBe('not-modified');
+  });
+
+  it('returns "unauthorized" on 401', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 401 }));
+    expect((await pullNow(adapters)).status).toBe('unauthorized');
+  });
+
+  it('returns "offline" on network error', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network'));
+    expect((await pullNow(adapters)).status).toBe('offline');
+  });
+});
+
+describe('diff: only-remote (live)', () => {
+  it('downloads and applies via adapter.applyRemote', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        manifestResponse({
+          layouts: { 'lay-1': { modifiedAt: 5000, sizeBytes: 100 } },
+          designs: {},
+          indexUpdatedAt: 5000,
+        })
+      )
+      .mockResolvedValueOnce(
+        envelopeResponse(
+          { layout: { v: 1 }, modifiedAt: 5000, schemaVersion: 1 },
+          { modifiedAt: 5000, sizeBytes: 100 }
+        )
+      );
+
+    const result = await pullNow(adapters);
+    expect(result.status).toBe('applied');
+    expect(result.applied).toBe(1);
+    expect(layouts.applyRemote).toHaveBeenCalledWith({
+      id: 'lay-1',
+      payload: { v: 1 },
+      modifiedAt: 5000,
+    });
+  });
+});
+
+describe('diff: remote newer than local', () => {
+  it('downloads and applies; bumps localMtime', async () => {
+    layouts.items.set('lay-1', { id: 'lay-1', payload: { v: 'old' }, modifiedAt: 1000 });
+    fetchMock
+      .mockResolvedValueOnce(
+        manifestResponse({
+          layouts: { 'lay-1': { modifiedAt: 5000, sizeBytes: 100 } },
+          designs: {},
+          indexUpdatedAt: 5000,
+        })
+      )
+      .mockResolvedValueOnce(
+        envelopeResponse(
+          { layout: { v: 'new' }, modifiedAt: 5000, schemaVersion: 1 },
+          { modifiedAt: 5000, sizeBytes: 100 }
+        )
+      );
+
+    const result = await pullNow(adapters);
+    expect(result.applied).toBe(1);
+    expect(layouts.applyRemote).toHaveBeenCalled();
+  });
+});
+
+describe('diff: local newer than remote (push handles)', () => {
+  it('does NOT pull — the local edit is the source of truth', async () => {
+    layouts.items.set('lay-1', { id: 'lay-1', payload: { v: 'newer' }, modifiedAt: 9000 });
+    fetchMock.mockResolvedValueOnce(
+      manifestResponse({
+        layouts: { 'lay-1': { modifiedAt: 1000, sizeBytes: 100 } },
+        designs: {},
+        indexUpdatedAt: 9000,
+      })
+    );
+
+    const result = await pullNow(adapters);
+    expect(result.applied).toBe(0);
+    expect(layouts.applyRemote).not.toHaveBeenCalled();
+  });
+});
+
+describe('diff: equal mtime', () => {
+  it('does nothing', async () => {
+    layouts.items.set('lay-1', { id: 'lay-1', payload: { v: 1 }, modifiedAt: 5000 });
+    fetchMock.mockResolvedValueOnce(
+      manifestResponse({
+        layouts: { 'lay-1': { modifiedAt: 5000, sizeBytes: 100 } },
+        designs: {},
+        indexUpdatedAt: 5000,
+      })
+    );
+
+    const result = await pullNow(adapters);
+    expect(result.applied).toBe(0);
+    expect(layouts.applyRemote).not.toHaveBeenCalled();
+  });
+});
+
+describe('diff: remote tombstone newer than local', () => {
+  it('applies the tombstone via applyRemoteDelete', async () => {
+    layouts.items.set('lay-1', { id: 'lay-1', payload: { v: 1 }, modifiedAt: 1000 });
+    fetchMock.mockResolvedValueOnce(
+      manifestResponse({
+        layouts: {
+          'lay-1': { modifiedAt: 5000, sizeBytes: 0, deletedAt: 5000 },
+        },
+        designs: {},
+        indexUpdatedAt: 5000,
+      })
+    );
+
+    const result = await pullNow(adapters);
+    expect(result.applied).toBe(1);
+    expect(layouts.applyRemoteDelete).toHaveBeenCalledWith('lay-1');
+  });
+});
+
+describe('diff: remote tombstone older than local', () => {
+  it('does NOT apply the tombstone — local edit is newer', async () => {
+    layouts.items.set('lay-1', { id: 'lay-1', payload: { v: 'fresh' }, modifiedAt: 9000 });
+    fetchMock.mockResolvedValueOnce(
+      manifestResponse({
+        layouts: {
+          'lay-1': { modifiedAt: 5000, sizeBytes: 0, deletedAt: 5000 },
+        },
+        designs: {},
+        indexUpdatedAt: 9000,
+      })
+    );
+
+    const result = await pullNow(adapters);
+    expect(result.applied).toBe(0);
+    expect(layouts.applyRemoteDelete).not.toHaveBeenCalled();
+  });
+});
+
+describe('diff: only-remote tombstone, no local', () => {
+  it('does nothing — nothing to delete locally', async () => {
+    fetchMock.mockResolvedValueOnce(
+      manifestResponse({
+        layouts: { 'lay-1': { modifiedAt: 5000, sizeBytes: 0, deletedAt: 5000 } },
+        designs: {},
+        indexUpdatedAt: 5000,
+      })
+    );
+
+    const result = await pullNow(adapters);
+    expect(result.applied).toBe(0);
+    expect(layouts.applyRemoteDelete).not.toHaveBeenCalled();
+  });
+});
+
+describe('diff: only-local (no remote entry)', () => {
+  it('does NOT apply anything — push handles new items', async () => {
+    layouts.items.set('lay-1', { id: 'lay-1', payload: { v: 1 }, modifiedAt: 5000 });
+    fetchMock.mockResolvedValueOnce(
+      manifestResponse({ layouts: {}, designs: {}, indexUpdatedAt: 5000 })
+    );
+
+    const result = await pullNow(adapters);
+    expect(result.applied).toBe(0);
+  });
+});
+
+describe('diff: mixed kinds', () => {
+  it('applies layouts and designs independently', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        manifestResponse({
+          layouts: { 'lay-1': { modifiedAt: 1000, sizeBytes: 100 } },
+          designs: { 'des-1': { modifiedAt: 2000, sizeBytes: 100 } },
+          indexUpdatedAt: 2000,
+        })
+      )
+      .mockResolvedValueOnce(
+        envelopeResponse(
+          { layout: { v: 1 }, modifiedAt: 1000, schemaVersion: 1 },
+          { modifiedAt: 1000, sizeBytes: 100 }
+        )
+      )
+      .mockResolvedValueOnce(
+        envelopeResponse(
+          { design: { d: 1 }, modifiedAt: 2000, schemaVersion: 1 },
+          { modifiedAt: 2000, sizeBytes: 100 }
+        )
+      );
+
+    const result = await pullNow(adapters);
+    expect(result.applied).toBe(2);
+    expect(layouts.applyRemote).toHaveBeenCalled();
+    expect(designs.applyRemote).toHaveBeenCalled();
+  });
+});
+
+describe('If-Modified-Since', () => {
+  it('first pull omits the header; subsequent pulls send the cached timestamp', async () => {
+    fetchMock
+      .mockResolvedValueOnce(manifestResponse({ layouts: {}, designs: {}, indexUpdatedAt: 5000 }))
+      .mockResolvedValueOnce(new Response(null, { status: 304 }));
+
+    await pullNow(adapters);
+    const firstHeaders = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(firstHeaders['If-Modified-Since']).toBeUndefined();
+
+    await pullNow(adapters);
+    const secondHeaders = (fetchMock.mock.calls[1][1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(secondHeaders['If-Modified-Since']).toBe('5000');
+  });
+});
+
+describe('envelope fetch failure', () => {
+  it('skips items whose envelope fetch fails, applies the rest', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        manifestResponse({
+          layouts: {
+            good: { modifiedAt: 1000, sizeBytes: 100 },
+            bad: { modifiedAt: 1000, sizeBytes: 100 },
+          },
+          designs: {},
+          indexUpdatedAt: 1000,
+        })
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+      .mockResolvedValueOnce(
+        envelopeResponse(
+          { layout: { v: 1 }, modifiedAt: 1000, schemaVersion: 1 },
+          { modifiedAt: 1000, sizeBytes: 100 }
+        )
+      );
+
+    const result = await pullNow(adapters);
+    expect(result.applied).toBe(1);
+  });
+});

--- a/src/core/sync/poller.ts
+++ b/src/core/sync/poller.ts
@@ -1,0 +1,144 @@
+import { apiFetch } from './apiFetch';
+import { useSyncStatusStore } from './status';
+import type { SyncAdapter, SyncAdapters, SyncKind } from './adapters/types';
+
+interface IndexEntry {
+  modifiedAt: number;
+  sizeBytes: number;
+  deletedAt?: number;
+}
+
+interface ManifestResponse {
+  layouts: Record<string, IndexEntry>;
+  designs: Record<string, IndexEntry>;
+  indexUpdatedAt: number;
+}
+
+interface ItemFetchResponse {
+  envelope: { layout?: unknown; design?: unknown; modifiedAt: number; schemaVersion: number };
+  indexEntry: IndexEntry;
+}
+
+export interface PullResult {
+  status: 'not-modified' | 'applied' | 'unauthorized' | 'offline' | 'error';
+  applied?: number;
+  /** Set on 'applied'; the value the next pull should send as If-Modified-Since. */
+  indexUpdatedAt?: number;
+}
+
+let lastIndexUpdatedAt = 0;
+let inFlight: Promise<PullResult> | null = null;
+
+/**
+ * Single-flight pull. Concurrent callers (timer + on-focus) await the
+ * same promise so we never send two manifest fetches at once.
+ */
+export async function pullNow(adapters: SyncAdapters): Promise<PullResult> {
+  if (inFlight) return inFlight;
+  inFlight = run(adapters).finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+/** Test-only: forget the cached `indexUpdatedAt`. */
+export function __resetForTests(): void {
+  lastIndexUpdatedAt = 0;
+  inFlight = null;
+}
+
+async function run(adapters: SyncAdapters): Promise<PullResult> {
+  useSyncStatusStore.getState().beginSync();
+
+  let manifestRes: Response;
+  try {
+    manifestRes = await apiFetch('/api/sync/manifest', {
+      headers: lastIndexUpdatedAt > 0 ? { 'If-Modified-Since': String(lastIndexUpdatedAt) } : {},
+    });
+  } catch {
+    useSyncStatusStore.getState().reportOffline('manifest fetch failed');
+    return { status: 'offline' };
+  }
+
+  if (manifestRes.status === 304) {
+    useSyncStatusStore.getState().succeed();
+    return { status: 'not-modified' };
+  }
+  if (manifestRes.status === 401) {
+    return { status: 'unauthorized' };
+  }
+  if (!manifestRes.ok) {
+    useSyncStatusStore.getState().reportError(`manifest ${manifestRes.status}`);
+    return { status: 'error' };
+  }
+
+  const manifest = (await manifestRes.json()) as ManifestResponse;
+
+  const layoutChanges = await diffKind(adapters.layouts, 'layouts', manifest.layouts);
+  const designChanges = await diffKind(adapters.designs, 'designs', manifest.designs);
+  const applied = layoutChanges + designChanges;
+
+  lastIndexUpdatedAt = manifest.indexUpdatedAt;
+  useSyncStatusStore.getState().succeed();
+  return { status: 'applied', applied, indexUpdatedAt: manifest.indexUpdatedAt };
+}
+
+/**
+ * For each remote entry, decide what to apply locally:
+ *   - tombstone with `deletedAt > local.modifiedAt` → applyRemoteDelete
+ *   - live entry with `modifiedAt > local.modifiedAt` → fetch + applyRemote
+ * Returns the count of items applied.
+ *
+ * Locals not in the manifest aren't our problem — push handles those.
+ */
+async function diffKind(
+  adapter: SyncAdapter,
+  kind: SyncKind,
+  remote: Record<string, IndexEntry>
+): Promise<number> {
+  const localItems = await adapter.list();
+  const localByMtime = new Map<string, number>();
+  for (const item of localItems) localByMtime.set(item.id, item.modifiedAt);
+
+  let applied = 0;
+  for (const [id, entry] of Object.entries(remote)) {
+    const localMtime = localByMtime.get(id);
+
+    if (entry.deletedAt !== undefined) {
+      if (localMtime !== undefined && localMtime < entry.deletedAt) {
+        await adapter.applyRemoteDelete(id);
+        applied++;
+      }
+      continue;
+    }
+
+    if (localMtime === undefined || localMtime < entry.modifiedAt) {
+      const fetched = await fetchEnvelope(kind, id);
+      if (!fetched) continue;
+      const payload = kind === 'layouts' ? fetched.envelope.layout : fetched.envelope.design;
+      if (payload === undefined) continue;
+      await adapter.applyRemote({
+        id,
+        payload,
+        modifiedAt: fetched.envelope.modifiedAt,
+      });
+      applied++;
+    }
+  }
+  return applied;
+}
+
+async function fetchEnvelope(kind: SyncKind, id: string): Promise<ItemFetchResponse | null> {
+  let res: Response;
+  try {
+    res = await apiFetch(`/api/sync/${kind}/${id}`);
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+  try {
+    return (await res.json()) as ItemFetchResponse;
+  } catch {
+    return null;
+  }
+}

--- a/src/core/sync/triggers/usePeriodicPoll.test.ts
+++ b/src/core/sync/triggers/usePeriodicPoll.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { usePeriodicPoll } from './usePeriodicPoll';
+import type { SyncAdapters } from '../adapters/types';
+
+const pullNowMock = vi.fn();
+
+vi.mock('../poller', () => ({
+  pullNow: (adapters: SyncAdapters) => pullNowMock(adapters),
+}));
+
+const noopAdapter = {
+  list: vi.fn(),
+  get: vi.fn(),
+  applyRemote: vi.fn(),
+  applyRemoteDelete: vi.fn(),
+  subscribe: vi.fn(() => () => {}),
+};
+
+const adapters: SyncAdapters = { layouts: noopAdapter, designs: noopAdapter };
+
+function setVisibility(state: 'hidden' | 'visible'): void {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  pullNowMock.mockReset();
+  pullNowMock.mockResolvedValue({ status: 'not-modified' });
+  setVisibility('visible');
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('usePeriodicPoll', () => {
+  it('pulls immediately on mount when the tab is visible', () => {
+    renderHook(() => usePeriodicPoll(adapters));
+    expect(pullNowMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not pull on mount when the tab is hidden', () => {
+    setVisibility('hidden');
+    renderHook(() => usePeriodicPoll(adapters));
+    expect(pullNowMock).not.toHaveBeenCalled();
+  });
+
+  it('polls every 45 seconds while visible', () => {
+    renderHook(() => usePeriodicPoll(adapters));
+    expect(pullNowMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(45_000);
+    expect(pullNowMock).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(45_000);
+    expect(pullNowMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('pulls on visibility flip from hidden → visible', () => {
+    setVisibility('hidden');
+    renderHook(() => usePeriodicPoll(adapters));
+    expect(pullNowMock).not.toHaveBeenCalled();
+
+    setVisibility('visible');
+    expect(pullNowMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('pauses the timer while hidden', () => {
+    renderHook(() => usePeriodicPoll(adapters));
+    expect(pullNowMock).toHaveBeenCalledTimes(1);
+
+    setVisibility('hidden');
+    vi.advanceTimersByTime(120_000);
+    expect(pullNowMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes listeners on unmount', () => {
+    const { unmount } = renderHook(() => usePeriodicPoll(adapters));
+    unmount();
+    pullNowMock.mockReset();
+
+    setVisibility('hidden');
+    setVisibility('visible');
+    vi.advanceTimersByTime(60_000);
+    expect(pullNowMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/sync/triggers/usePeriodicPoll.ts
+++ b/src/core/sync/triggers/usePeriodicPoll.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { pullNow } from '../poller';
+import type { SyncAdapters } from '../adapters/types';
+
+const POLL_INTERVAL_MS = 45_000;
+
+/**
+ * Run a manifest pull every 45 seconds while the tab is visible, plus
+ * an immediate pull when the tab regains focus. Hidden tabs never poll
+ * — they catch up on the next visibility flip.
+ */
+export function usePeriodicPoll(adapters: SyncAdapters): void {
+  useEffect(() => {
+    let timer: number | undefined;
+
+    const schedule = (): void => {
+      if (timer !== undefined) clearInterval(timer);
+      timer = window.setInterval(() => {
+        if (document.visibilityState === 'visible') {
+          void pullNow(adapters);
+        }
+      }, POLL_INTERVAL_MS);
+    };
+
+    const onVisibility = (): void => {
+      if (document.visibilityState === 'visible') {
+        void pullNow(adapters);
+        schedule();
+      } else if (timer !== undefined) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+    };
+
+    if (document.visibilityState === 'visible') {
+      void pullNow(adapters);
+      schedule();
+    }
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      if (timer !== undefined) clearInterval(timer);
+    };
+  }, [adapters]);
+}


### PR DESCRIPTION
## Summary

PR 4c in the multi-device sync rollout: the **pull direction**. Builds on PR 4a (#1595, foundation) and PR 4b (#1596, engine/push). No UI surface yet — engine and poller emit state but no toast subscriber, no boot site mount. Those land in PR 4d.

**Targets `feat/sync-pr4b-engine`** (will retarget upstream once 4a → 4b → 4c rebase chain plays out). Production bundle still has zero sync surface.

## What's in this PR

### Poller (`src/core/sync/poller.ts`)

`pullNow(adapters)` — single-flight. Concurrent callers (timer + on-focus) await the same promise; never two manifest fetches at once.

GET `/api/sync/manifest` with `If-Modified-Since: lastIndexUpdatedAt`; 304 short-circuits. On 200, diffs server index vs `adapter.list()`:

| Server | Local | Action |
|---|---|---|
| Tombstone (`deletedAt`) | exists, `local.mtime < remote.deletedAt` | `applyRemoteDelete` |
| Tombstone | absent OR newer | no-op (nothing to delete OR push will handle) |
| Live (`modifiedAt`) | absent | fetch envelope + `applyRemote` |
| Live | `local.mtime < remote.mtime` | fetch envelope + `applyRemote` |
| Live | `local.mtime ≥ remote.mtime` | no-op (push handles) |

Cached `lastIndexUpdatedAt` keeps idle polls cheap.

### Periodic poll trigger (`src/core/sync/triggers/usePeriodicPoll.ts`)

- Polls every 45s while visible
- Immediate pull on `visibilitychange → visible`
- Hidden tabs don't poll; catch up on next visibility flip

### Echo suppression

The poller calls `adapter.applyRemote` / `.applyRemoteDelete` which already use the per-adapter suppression Set (PR 4a/4b). The engine's outbox subscriber sees the resulting change, checks `suppressed`, skips. No new shared state needed at the engine/poller layer.

## What's NOT in this PR

- Toast subscriber for engine + poller events (deferred to 4d)
- i18n keys (deferred to 4d)
- Boot site (`SyncSessionMount` extension to start engine + poll on auth) — deferred to 4d
- First-sign-in claim flow — PR 5

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run knip` — clean
- [x] `pnpm exec vitest run src/core/sync` — 103/103
  - poller.test.ts — 15 (single-flight, 304, 401, offline, all 8 diff quadrants, mixed kinds, If-Modified-Since wiring, envelope-fetch failure resilience)
  - triggers/usePeriodicPoll.test.ts — 6 (mount visible, mount hidden, 45s interval, focus pull, hidden pause, unmount cleanup)
- [x] `pnpm run build` — verified zero sync surface in `main-*.js`.