### PR TITLE
fix(labs): render EngineSelector in Settings → Labs tab

### DIFF
--- a/src/features/labs/components/EngineSelector/EngineSelector.tsx
+++ b/src/features/labs/components/EngineSelector/EngineSelector.tsx
@@ -6,11 +6,9 @@ import { trackEvent } from '@/shared/analytics/posthog/trackEvent';
 import { useTranslation } from '@/i18n';
 import { FeatureStatusBadge } from '../FeatureStatusBadge';
 import { InfoIcon } from '../icons';
+import { BREPKIT_ID, OCCT_WASM_ID } from './kernelIds';
 
 type Engine = 'default' | 'occt-wasm' | 'brepkit';
-
-const BREPKIT_ID = 'brepkit_kernel' as const;
-const OCCT_WASM_ID = 'occt_wasm_kernel' as const;
 
 const ENGINE_FLAGS: Record<Engine, { brepkit: boolean; occt: boolean }> = {
   default: { brepkit: false, occt: false },

--- a/src/features/labs/components/EngineSelector/index.ts
+++ b/src/features/labs/components/EngineSelector/index.ts
@@ -1,1 +1,2 @@
 export { EngineSelector } from './EngineSelector';
+export { KERNEL_FEATURE_IDS } from './kernelIds';

--- a/src/features/labs/components/EngineSelector/kernelIds.ts
+++ b/src/features/labs/components/EngineSelector/kernelIds.ts
@@ -1,0 +1,3 @@
+export const BREPKIT_ID = 'brepkit_kernel' as const;
+export const OCCT_WASM_ID = 'occt_wasm_kernel' as const;
+export const KERNEL_FEATURE_IDS = [BREPKIT_ID, OCCT_WASM_ID] as const;

--- a/src/features/labs/components/LabsDrawer/LabsDrawer.test.tsx
+++ b/src/features/labs/components/LabsDrawer/LabsDrawer.test.tsx
@@ -55,6 +55,7 @@ vi.mock('../GraduatedSection', () => ({
 
 vi.mock('../EngineSelector', () => ({
   EngineSelector: () => <div data-testid="engine-selector">Engine Selector</div>,
+  KERNEL_FEATURE_IDS: ['brepkit_kernel', 'occt_wasm_kernel'] as const,
 }));
 
 vi.mock('../icons', () => ({

--- a/src/features/labs/components/LabsDrawer/LabsDrawer.tsx
+++ b/src/features/labs/components/LabsDrawer/LabsDrawer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useLabsStore } from '@/core/store';
 import { getToggleableFeatures, getGraduatedFeatures, type FeatureId } from '@/core/labs';
-import { EngineSelector } from '../EngineSelector';
+import { EngineSelector, KERNEL_FEATURE_IDS } from '../EngineSelector';
 import { FeatureCard } from '../FeatureCard';
 import { GraduatedSection } from '../GraduatedSection';
 import { SparklesIcon, CloseIcon } from '../icons';
@@ -43,7 +43,7 @@ export function LabsDrawer() {
   };
 
   const toggleableFeatures = getToggleableFeatures().filter(
-    (f) => f.id !== 'brepkit_kernel' && f.id !== 'occt_wasm_kernel'
+    (f) => !KERNEL_FEATURE_IDS.some((id) => id === f.id)
   );
   const graduatedFeatures = getGraduatedFeatures();
 

--- a/src/features/labs/components/index.ts
+++ b/src/features/labs/components/index.ts
@@ -4,4 +4,5 @@ export { LabsDrawer } from './LabsDrawer';
 export { FeatureCard } from './FeatureCard';
 export { FeatureStatusBadge } from './FeatureStatusBadge';
 export { GraduatedSection } from './GraduatedSection';
-export { SparklesIcon, CloseIcon, ChevronRightIcon } from './icons';
+export { EngineSelector, KERNEL_FEATURE_IDS } from './EngineSelector';
+export { SparklesIcon, CloseIcon, ChevronRightIcon, InfoIcon } from './icons';

--- a/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.test.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.test.tsx
@@ -35,7 +35,7 @@ vi.mock('@/core/labs', () => ({
   getGraduatedFeatures: () => [],
 }));
 
-vi.mock('@/features/labs/components/FeatureCard', () => ({
+vi.mock('@/features/labs/components', () => ({
   FeatureCard: ({
     feature,
     isEnabled,
@@ -61,20 +61,12 @@ vi.mock('@/features/labs/components/FeatureCard', () => ({
       {feature.titleKey}
     </div>
   ),
-}));
-
-vi.mock('@/features/labs/components/GraduatedSection', () => ({
   GraduatedSection: () => <div data-testid="graduated-section">Graduated</div>,
-}));
-
-vi.mock('@/features/labs/components/icons', () => ({
   SparklesIcon: ({ className }: { className?: string }) => (
     <svg className={className} data-testid="sparkles-icon" />
   ),
-}));
-
-vi.mock('@/features/labs/components/EngineSelector', () => ({
   EngineSelector: () => <div data-testid="engine-selector">Engine Selector</div>,
+  KERNEL_FEATURE_IDS: ['brepkit_kernel', 'occt_wasm_kernel'] as const,
 }));
 
 describe('LabsTab', () => {

--- a/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.test.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.test.tsx
@@ -73,6 +73,10 @@ vi.mock('@/features/labs/components/icons', () => ({
   ),
 }));
 
+vi.mock('@/features/labs/components/EngineSelector', () => ({
+  EngineSelector: () => <div data-testid="engine-selector">Engine Selector</div>,
+}));
+
 describe('LabsTab', () => {
   it('renders labs heading', () => {
     render(<LabsTab />);
@@ -108,5 +112,10 @@ describe('LabsTab', () => {
   it('renders GraduatedSection component', () => {
     render(<LabsTab />);
     expect(screen.getByTestId('graduated-section')).toBeInTheDocument();
+  });
+
+  it('renders the EngineSelector', () => {
+    render(<LabsTab />);
+    expect(screen.getByTestId('engine-selector')).toBeInTheDocument();
   });
 });

--- a/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.tsx
@@ -2,10 +2,13 @@ import { useShallow } from 'zustand/react/shallow';
 import { useLabsStore } from '@/core/store';
 import { getToggleableFeatures, getGraduatedFeatures } from '@/core/labs';
 import type { FeatureId } from '@/core/labs';
-import { EngineSelector } from '@/features/labs/components/EngineSelector';
-import { FeatureCard } from '@/features/labs/components/FeatureCard';
-import { GraduatedSection } from '@/features/labs/components/GraduatedSection';
-import { SparklesIcon } from '@/features/labs/components/icons';
+import {
+  EngineSelector,
+  FeatureCard,
+  GraduatedSection,
+  KERNEL_FEATURE_IDS,
+  SparklesIcon,
+} from '@/features/labs/components';
 import { useTranslation } from '@/i18n';
 
 export function LabsTab() {
@@ -19,7 +22,7 @@ export function LabsTab() {
   );
 
   const toggleableFeatures = getToggleableFeatures().filter(
-    (f) => f.id !== 'brepkit_kernel' && f.id !== 'occt_wasm_kernel'
+    (f) => !KERNEL_FEATURE_IDS.some((id) => id === f.id)
   );
   const graduatedFeatures = getGraduatedFeatures();
 

--- a/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.tsx
@@ -2,6 +2,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useLabsStore } from '@/core/store';
 import { getToggleableFeatures, getGraduatedFeatures } from '@/core/labs';
 import type { FeatureId } from '@/core/labs';
+import { EngineSelector } from '@/features/labs/components/EngineSelector';
 import { FeatureCard } from '@/features/labs/components/FeatureCard';
 import { GraduatedSection } from '@/features/labs/components/GraduatedSection';
 import { SparklesIcon } from '@/features/labs/components/icons';
@@ -17,7 +18,9 @@ export function LabsTab() {
     }))
   );
 
-  const toggleableFeatures = getToggleableFeatures();
+  const toggleableFeatures = getToggleableFeatures().filter(
+    (f) => f.id !== 'brepkit_kernel' && f.id !== 'occt_wasm_kernel'
+  );
   const graduatedFeatures = getGraduatedFeatures();
 
   return (
@@ -28,6 +31,10 @@ export function LabsTab() {
           <h3 className="text-base font-semibold text-content">{t('settings.labs')}</h3>
         </div>
         <p className="text-sm text-content-tertiary mb-4">{t('settings.labsHint')}</p>
+
+        <div className="mb-3">
+          <EngineSelector />
+        </div>
 
         {toggleableFeatures.length > 0 ? (
           <div className="space-y-3">


### PR DESCRIPTION
## Summary
- The Labs drawer and the Settings modal's Labs tab both render the toggleable feature catalog. The PR that introduced `EngineSelector` (#1606) only wired it into the drawer and only filtered the two kernel flags out of the drawer's `FeatureCard` list.
- The Settings → Labs tab therefore still showed `brepkit_kernel` and `occt_wasm_kernel` as two independent `Switch` toggles — undoing the mutual-exclusivity affordance and letting users flip both on with no UX signal.
- `LabsTab.tsx` now mirrors `LabsDrawer.tsx`: renders `EngineSelector` above the FeatureCard list and excludes the two kernel flags from `getToggleableFeatures()`.

## Test plan
- [x] `pnpm exec vitest run src/shell/Modals/SettingsModal/tabs/LabsTab src/features/labs` — 69/69 passing (8 test files)
- [x] `pnpm exec tsc -p tsconfig.app.json --noEmit` — clean
- [x] `pnpm exec eslint src/shell/Modals/SettingsModal/tabs/LabsTab` — clean
- [ ] Manually open Settings → Labs and confirm the segmented control replaces the two toggle switches

## Why this slipped past #1606
Greptile/iter-2 review only audited the diff vs main; neither agent went looking for OTHER places that mirror `LabsDrawer`'s feature listing. The `LabsTab` is structurally a clone of the drawer body but lives in a different feature folder (`shell/Modals/SettingsModal/tabs/LabsTab/`), so a search for "FeatureCard usage" would have caught it but a search for "kernel" did not. Worth a note in `src/features/labs/README.md` next time we add or change feature-list UI — there are now two surfaces to keep in sync.