### PR TITLE
chore(deps): pin fast-uri to ^3.1.2 to close two high-severity advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
       "@surma/rollup-plugin-off-main-thread>magic-string": "0.30.21",
       "workbox-build>@rollup/plugin-node-resolve": "^16.0.0",
       "@apideck/better-ajv-errors>ajv": "^8.17.1",
+      "fast-uri": "^3.1.2",
       "serialize-javascript": "^7.0.3",
       "eslint-plugin-react-hooks>eslint": "^10.0.3",
       "eslint-plugin-jsx-a11y>eslint": "^10.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   '@surma/rollup-plugin-off-main-thread>magic-string': 0.30.21
   workbox-build>@rollup/plugin-node-resolve: ^16.0.0
   '@apideck/better-ajv-errors>ajv': ^8.17.1
+  fast-uri: ^3.1.2
   serialize-javascript: ^7.0.3
   eslint-plugin-react-hooks>eslint: ^10.0.3
   eslint-plugin-jsx-a11y>eslint: ^10.0.3
@@ -5654,10 +5655,10 @@ packages:
         integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==,
       }
 
-  fast-uri@3.1.0:
+  fast-uri@3.1.2:
     resolution:
       {
-        integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
+        integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==,
       }
 
   fastq@1.20.1:
@@ -11615,7 +11616,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12445,7 +12446,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a pnpm override pinning `fast-uri >= 3.1.2` across the dependency graph
- Closes Dependabot alerts #68 (`GHSA-q3j6-qgpj-74h6`, path traversal via percent-encoded dot segments) and #69 (`GHSA-v39h-62p7-jpjc`, host confusion via percent-encoded authority delimiters)

## Context

`fast-uri@3.1.0` was being pulled in transitively via two paths, both `devDependencies`:

- `vite-plugin-pwa` → `workbox-build` → `ajv` → `fast-uri` (build-time PWA service-worker generation)
- `@vercel/node` → `@vercel/static-config` → `ajv` → `fast-uri` (deploy-time `vercel.json` validation)

Neither consumer parses request URLs at runtime — `fast-uri` never reaches the browser bundle or the Vercel runtime request path — so real-world exposure of these CVEs in this project is low. Patching anyway since the override is one line and Dependabot tracks the upstream advisory regardless of contextual reach.

After the override, `pnpm why fast-uri` shows a single `fast-uri@3.1.2` resolution covering both ancestor chains.

## Test plan

- [x] `pnpm install` — lockfile regenerates cleanly, `fast-uri@3.1.2` resolves for all consumers
- [x] `pnpm run typecheck` — passes
- [ ] CI: lint, unit tests, build, PWA smoke test