### PR TITLE
fix(analytics): use posthog.captureException for valid $exception_list schema

### DIFF
--- a/src/shared/analytics/posthog/eventsErrors.test.ts
+++ b/src/shared/analytics/posthog/eventsErrors.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const captureExceptionMock = vi.fn();
+const captureMock = vi.fn();
+const getPosthogInstanceMock = vi.fn();
+
+vi.mock('./init', () => ({
+  getPosthogInstance: () => getPosthogInstanceMock(),
+}));
+
+vi.mock('./trackEvent', () => ({
+  trackEvent: vi.fn(),
+  getDeviceType: () => 'desktop',
+}));
+
+vi.mock('@/core/store/interaction', () => ({
+  useInteractionStore: { getState: () => ({ interaction: null }) },
+}));
+
+vi.mock('@/core/store/layout', () => ({
+  useLayoutStore: {
+    getState: () => ({
+      layout: {
+        drawer: { width: 10, depth: 8, height: 12 },
+        bins: [],
+        layers: [],
+        categories: [],
+      },
+    }),
+  },
+}));
+
+import { captureException } from './eventsErrors';
+
+beforeEach(() => {
+  captureExceptionMock.mockReset();
+  captureMock.mockReset();
+  getPosthogInstanceMock.mockReset();
+  getPosthogInstanceMock.mockReturnValue({
+    captureException: captureExceptionMock,
+    capture: captureMock,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('captureException', () => {
+  it('delegates to posthog.captureException so the SDK builds $exception_list', () => {
+    const error = new Error('boom');
+    captureException(error);
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock.mock.calls[0][0]).toBe(error);
+  });
+
+  it('does not fire a manual $exception event with legacy flat fields', () => {
+    captureException(new Error('boom'));
+
+    const manualExceptionCall = captureMock.mock.calls.find(([name]) => name === '$exception');
+    expect(manualExceptionCall).toBeUndefined();
+  });
+
+  it('passes layout context and additional context as additionalProperties', () => {
+    captureException(new Error('boom'), { boundary: 'root' });
+
+    const [, additionalProperties] = captureExceptionMock.mock.calls[0];
+    expect(additionalProperties).toMatchObject({
+      boundary: 'root',
+      drawer_size: '10x8x12',
+      bin_count: 0,
+      device_type: 'desktop',
+    });
+  });
+
+  it('no-ops when posthog is not initialized', () => {
+    getPosthogInstanceMock.mockReturnValue(null);
+    expect(() => captureException(new Error('boom'))).not.toThrow();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors thrown by posthog so analytics never breaks the app', () => {
+    captureExceptionMock.mockImplementation(() => {
+      throw new Error('posthog blew up');
+    });
+    expect(() => captureException(new Error('boom'))).not.toThrow();
+  });
+});

--- a/src/shared/analytics/posthog/eventsErrors.test.ts
+++ b/src/shared/analytics/posthog/eventsErrors.test.ts
@@ -44,7 +44,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  vi.restoreAllMocks();
+  vi.resetAllMocks();
 });
 
 describe('captureException', () => {

--- a/src/shared/analytics/posthog/eventsErrors.ts
+++ b/src/shared/analytics/posthog/eventsErrors.ts
@@ -38,16 +38,19 @@ function getLayoutContext(): Record<string, unknown> {
 /**
  * Capture an exception with layout context.
  * Use this for caught errors that you want to track.
+ *
+ * Delegates to posthog-js's native `captureException`, which constructs the
+ * required `$exception_list` payload (with parsed stack frames + mechanism)
+ * that PostHog's ingestion pipeline now requires. Manually firing `$exception`
+ * with the legacy flat fields produces serde "missing field $exception_list"
+ * warnings and the events get dropped.
  */
 export function captureException(error: Error, additionalContext?: Record<string, unknown>): void {
   const posthogInstance = getPosthogInstance();
   if (!posthogInstance) return;
 
   try {
-    posthogInstance.capture('$exception', {
-      $exception_message: error.message,
-      $exception_type: error.name,
-      $exception_stack_trace_raw: error.stack,
+    posthogInstance.captureException(error, {
       ...getLayoutContext(),
       ...additionalContext,
     });


### PR DESCRIPTION
## Summary

- PostHog ingestion was warning `serde error: missing field $exception_list` and dropping events
- `eventsErrors.ts` was firing `$exception` manually with the legacy flat fields (`$exception_message`, `$exception_type`, `$exception_stack_trace_raw`) — capture-rs now requires the structured `$exception_list` array
- Switched to `posthog.captureException(error, additionalProperties)` from `posthog-js@^1.372.8`, which builds the proper payload (parsed stack frames + handled/unhandled mechanism) internally
- Layout-context enrichment is preserved as `additionalProperties`

## Test plan

- [x] New sibling test `eventsErrors.test.ts` covers: SDK delegation, no manual `$exception` event is fired, layout-context propagation, no-op when posthog isn't initialized, errors thrown by posthog are swallowed
- [x] All 5 tests pass
- [x] `pnpm run typecheck` clean for changed files (pre-existing brepjs/occt-wasm/arctic errors are unrelated)
- [ ] After merge: confirm PostHog "Error tracking" view receives properly-structured exceptions and the ingestion warning stops appearing

## Follow-up (out of scope)

`init.ts` enables `capture_exceptions: true` *and* installs global `error`/`unhandledrejection` listeners that also call `captureException`, so unhandled errors are now reported through both paths. Both produce valid schemas after this fix, but the duplication may inflate dashboards — worth dropping one path in a separate PR.