### PR TITLE
fix(bin-designer): scale SVG imports to physical units and curve-aware bounds

### DIFF
--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -110,6 +110,15 @@ graph TB
     main-thread copy in `LidMesh.tsx` mirrors it because the worker module
     isn't importable here. **Update both in lockstep** — silent drift causes
     the preview to misalign vs. the exported geometry.
+12. **SVG import unit contract** — `svgImport/svgParser.ts` treats user units
+    as mm 1:1 unless the SVG declares a physical `width`/`height`
+    (mm/cm/in/pt/pc/Q) **and** carries an explicit `viewBox`. Without a real
+    viewBox the fallback parses width/height with `parseFloat` (drops unit
+    suffixes), so scaling is skipped to avoid producing wildly wrong sizes.
+    Genuinely non-square aspect ratios (sx/sy diverge > 0.5%) also fall back
+    to identity — a single uniform scalar would distort circles and rotated
+    shapes. Path bounds use `getPathBounds` (flattened bezier) so curves that
+    bow outward beyond their anchors aren't clipped.
 
 ## Integration
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgConvertShapes.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgConvertShapes.ts
@@ -15,6 +15,7 @@ import type { ParsedCutoutSpec } from './types';
 import type { Matrix } from './svgTransform';
 import type { ViewBox } from './types';
 import { applyMatrix, isIdentityOrTranslate, transformPoint } from './svgTransform';
+import { getPathBounds } from '../pathGeometry';
 
 export function wrapSingle(spec: ParsedCutoutSpec | null): ParsedCutoutSpec[] | null {
   return spec ? [spec] : null;
@@ -69,22 +70,18 @@ export function pointsToPathSpec(
   return pathPointsToSpec(pathPoints);
 }
 
-/** Compute bounds from anchor points (does not account for bezier handle extents). */
+/**
+ * Build a path spec with bounds from the flattened bezier curve.
+ *
+ * Anchor-only bounds clip cutouts whose curves bow outward beyond their
+ * anchors (logos, organic shapes), producing a too-small bbox that breaks
+ * selection handles and downstream geometry placement. `getPathBounds`
+ * flattens the curve, matching what the renderer / vertex editor compute.
+ */
 export function pathPointsToSpec(pathPoints: PathPoint[]): ParsedCutoutSpec | null {
   if (pathPoints.length < 2) return null;
 
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-
-  for (const pt of pathPoints) {
-    if (pt.x < minX) minX = pt.x;
-    if (pt.y < minY) minY = pt.y;
-    if (pt.x > maxX) maxX = pt.x;
-    if (pt.y > maxY) maxY = pt.y;
-  }
-
+  const { minX, minY, maxX, maxY } = getPathBounds(pathPoints);
   const width = maxX - minX;
   const depth = maxY - minY;
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgLength.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgLength.test.ts
@@ -66,4 +66,9 @@ describe('parseSvgLengthMm', () => {
   it('handles scientific notation', () => {
     expect(parseSvgLengthMm('1e2mm')).toBe(100);
   });
+
+  it('accepts an explicit + sign (SVG/CSS number grammar)', () => {
+    expect(parseSvgLengthMm('+100mm')).toBe(100);
+    expect(parseSvgLengthMm('+2in')).toBeCloseTo(50.8, 5);
+  });
 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgLength.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgLength.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { parseSvgLengthMm } from './svgLength';
+
+describe('parseSvgLengthMm', () => {
+  it('returns null for null/empty/unparseable input', () => {
+    expect(parseSvgLengthMm(null)).toBeNull();
+    expect(parseSvgLengthMm(undefined)).toBeNull();
+    expect(parseSvgLengthMm('')).toBeNull();
+    expect(parseSvgLengthMm('   ')).toBeNull();
+    expect(parseSvgLengthMm('abc')).toBeNull();
+  });
+
+  it('returns null for non-positive values', () => {
+    expect(parseSvgLengthMm('0mm')).toBeNull();
+    expect(parseSvgLengthMm('-10mm')).toBeNull();
+  });
+
+  it('returns null for relative or unknown units', () => {
+    expect(parseSvgLengthMm('50%')).toBeNull();
+    expect(parseSvgLengthMm('1em')).toBeNull();
+    expect(parseSvgLengthMm('3rem')).toBeNull();
+  });
+
+  it('returns null for unitless values (caller keeps user units)', () => {
+    expect(parseSvgLengthMm('100')).toBeNull();
+    expect(parseSvgLengthMm('100.5')).toBeNull();
+  });
+
+  it('returns null for px (CSS unit, not physical)', () => {
+    expect(parseSvgLengthMm('100px')).toBeNull();
+  });
+
+  it('converts mm 1:1', () => {
+    expect(parseSvgLengthMm('100mm')).toBe(100);
+    expect(parseSvgLengthMm('50.5mm')).toBe(50.5);
+  });
+
+  it('converts cm to mm', () => {
+    expect(parseSvgLengthMm('5cm')).toBe(50);
+  });
+
+  it('converts inches to mm', () => {
+    expect(parseSvgLengthMm('2in')).toBeCloseTo(50.8, 5);
+  });
+
+  it('converts points to mm', () => {
+    // 72pt = 1in = 25.4mm
+    expect(parseSvgLengthMm('72pt')).toBeCloseTo(25.4, 5);
+  });
+
+  it('converts picas to mm', () => {
+    // 1pc = 12pt = 1/6 in = 25.4/6 mm
+    expect(parseSvgLengthMm('6pc')).toBeCloseTo(25.4, 5);
+  });
+
+  it('converts Q (quarter mm) to mm', () => {
+    expect(parseSvgLengthMm('4Q')).toBe(1);
+  });
+
+  it('handles whitespace and case variations', () => {
+    expect(parseSvgLengthMm('  100MM  ')).toBe(100);
+    expect(parseSvgLengthMm('100 mm')).toBe(100);
+    expect(parseSvgLengthMm('2IN')).toBeCloseTo(50.8, 5);
+  });
+
+  it('handles scientific notation', () => {
+    expect(parseSvgLengthMm('1e2mm')).toBe(100);
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgLength.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgLength.ts
@@ -1,0 +1,50 @@
+/**
+ * Parses SVG length attributes (width, height) with optional physical units
+ * and converts to millimeters. Used to compute the user-units → mm scale
+ * factor for the imported geometry.
+ *
+ * Only physical/absolute units are recognized (mm, cm, in, pt, pc, Q).
+ * Unitless values, percentages, and px are intentionally returned as `null`
+ * so the caller falls back to 1:1 user-unit semantics — historically how
+ * SVGs without explicit physical sizing have been imported.
+ */
+
+type PhysicalUnit = 'mm' | 'cm' | 'in' | 'pt' | 'pc' | 'q';
+
+const PHYSICAL_UNIT_TO_MM: Record<PhysicalUnit, number> = {
+  mm: 1,
+  cm: 10,
+  in: 25.4,
+  pt: 25.4 / 72,
+  pc: 25.4 / 6,
+  q: 0.25,
+};
+
+const LENGTH_RE = /^(-?\d*\.?\d+(?:[eE][+-]?\d+)?)\s*([a-zA-Z%]*)$/;
+
+function isPhysicalUnit(unit: string): unit is PhysicalUnit {
+  return unit in PHYSICAL_UNIT_TO_MM;
+}
+
+/**
+ * Parse an SVG length attribute and return its value in millimeters.
+ *
+ * Returns `null` if:
+ * - the input is null/empty/unparseable,
+ * - the unit is `%` (relative — can't resolve without a parent length),
+ * - the unit is `px` or absent (caller should keep the user-unit value as-is).
+ *
+ * @example parseSvgLengthMm("100mm") → 100
+ * @example parseSvgLengthMm("2in")   → 50.8
+ * @example parseSvgLengthMm("200")   → null
+ */
+export function parseSvgLengthMm(str: string | null | undefined): number | null {
+  if (!str) return null;
+  const match = str.trim().match(LENGTH_RE);
+  if (!match) return null;
+  const value = parseFloat(match[1]);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  const unit = match[2].toLowerCase();
+  if (!isPhysicalUnit(unit)) return null;
+  return value * PHYSICAL_UNIT_TO_MM[unit];
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgLength.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgLength.ts
@@ -20,7 +20,7 @@ const PHYSICAL_UNIT_TO_MM: Record<PhysicalUnit, number> = {
   q: 0.25,
 };
 
-const LENGTH_RE = /^(-?\d*\.?\d+(?:[eE][+-]?\d+)?)\s*([a-zA-Z%]*)$/;
+const LENGTH_RE = /^([-+]?\d*\.?\d+(?:[eE][+-]?\d+)?)\s*([a-zA-Z%]*)$/;
 
 function isPhysicalUnit(unit: string): unit is PhysicalUnit {
   return unit in PHYSICAL_UNIT_TO_MM;

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgParser.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgParser.test.ts
@@ -441,6 +441,21 @@ describe('parseSvgString', () => {
       expect(result.value[0].width).toBeCloseTo(99.975, 2);
     });
 
+    it('does not apply physical scaling when no explicit viewBox is present', () => {
+      // The fallback viewBox is parseFloat'd from width/height and silently
+      // drops unit suffixes — `width="1in"` would yield viewBox.width=1 and
+      // a wildly wrong 25.4 mm/unit scale. Skip scaling when there's no real
+      // viewBox to anchor it against.
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1in" height="1in">
+        <rect x="0" y="0" width="50" height="50"/>
+      </svg>`;
+      const result = parseSvgString(svg);
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      // Identity scale → cutout matches the source attribute (50 user units)
+      expect(result.value[0].width).toBe(50);
+    });
+
     it('falls back to identity when only one of width/height has units', () => {
       // Mixed/incomplete physical sizing → don't attempt to scale
       const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="100mm" height="100" viewBox="0 0 200 200">
@@ -516,22 +531,22 @@ describe('parseSvgString', () => {
     });
   });
 
-  // Issue #1643 — "imports as a square" / "displays at wrong scale" caused
-  // partly by anchor-only bounds clipping curves that bow outward.
+  // Issue #1643 — anchor-only bounds clipped curves whose handles extend
+  // beyond the anchor extents. `pathPointsToSpec` now uses flattened bezier
+  // bounds so the spec bbox tracks the visible curve.
   describe('bezier bounds (issue #1643)', () => {
-    it('reflects outward-bowing curves in the bbox', () => {
-      // Path bows outward: anchors are at x=0 and x=10 but the curve apex
-      // reaches x≈12.5 via handles. Anchor-only bounds would say width=10.
+    it('reflects curve extent (not just anchors) in the bbox', () => {
+      // Two anchors at the same SVG y=50 with control handles pulled to
+      // y=30 and y=70. Anchor-only bounds → depth=0 → spec rejected as
+      // degenerate. Flattened bounds capture the curve dipping ~5 units
+      // off the anchor line in cutout space.
       const svg = svgWrap('<path d="M 0 50 C 25 30 25 70 50 50 Z"/>');
       const result = parseSvgString(svg);
       expect(isOk(result)).toBe(true);
       if (!isOk(result)) return;
       const spec = result.value[0];
       expect(spec.shape).toBe('path');
-      // Bbox y must extend below 30 (curve dips toward y=30 in SVG → top in cutout)
-      // Verify width matches anchor span (x ∈ [0,50])
       expect(spec.width).toBeCloseTo(50, 0);
-      // Depth grows past anchor span (anchor y=50 only) due to curve reach
       expect(spec.depth).toBeGreaterThan(0);
     });
   });

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgParser.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgParser.test.ts
@@ -356,4 +356,156 @@ describe('parseSvgString', () => {
       expect(centerY).toBeCloseTo(50, 0);
     });
   });
+
+  // Issue #1643 — "wrong scale" failure mode.
+  // SVGs from drawing tools (Inkscape, Illustrator) commonly carry physical
+  // dimensions (mm/in) with a much larger viewBox; importing them at 1:1
+  // produced cutouts orders of magnitude too large.
+  describe('physical units (issue #1643)', () => {
+    it('scales user units → mm when SVG declares physical width/height in mm', () => {
+      // Inkscape-style: 100mm canvas with 800-unit viewBox (10x oversampling)
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="100mm" height="100mm" viewBox="0 0 800 800">
+        <rect x="0" y="0" width="80" height="80"/>
+      </svg>`;
+      const result = parseSvgString(svg);
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+
+      // 80 user units * (100mm / 800) = 10mm
+      expect(result.value[0].width).toBeCloseTo(10, 5);
+      expect(result.value[0].depth).toBeCloseTo(10, 5);
+    });
+
+    it('scales when SVG declares dimensions in inches', () => {
+      // 1in = 25.4mm; viewBox 100x100 → user-unit = 0.254mm
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1in" height="1in" viewBox="0 0 100 100">
+        <rect x="0" y="0" width="50" height="50"/>
+      </svg>`;
+      const result = parseSvgString(svg);
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+
+      expect(result.value[0].width).toBeCloseTo(12.7, 3);
+    });
+
+    it('keeps unitless width/height at 1:1 (preserves historical behavior)', () => {
+      // Without physical units we can't know the intended physical scale —
+      // current contract is 1 user unit = 1 mm, leave as-is.
+      const result = parseSvgString(svgWrap('<rect x="0" y="0" width="42" height="42"/>'));
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      expect(result.value[0].width).toBe(42);
+    });
+
+    it('scales path point coordinates and handles', () => {
+      // Real curves must scale uniformly so the visual shape is preserved
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="50mm" height="50mm" viewBox="0 0 100 100">
+        <path d="M 0 0 C 50 0 50 100 100 100"/>
+      </svg>`;
+      const result = parseSvgString(svg);
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      const spec = result.value[0];
+      expect(spec.shape).toBe('path');
+      // Path is open (no Z) — pathPointsToSpec needs ≥2 anchors and produces a spec
+      expect(spec.path).toBeDefined();
+      // Bbox spans the full curve, scaled 50/100 = 0.5
+      expect(spec.width).toBeCloseTo(50, 1);
+      expect(spec.depth).toBeCloseTo(50, 1);
+    });
+
+    it('falls back to identity when only one of width/height has units', () => {
+      // Mixed/incomplete physical sizing → don't attempt to scale
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="100mm" height="100" viewBox="0 0 200 200">
+        <rect x="0" y="0" width="50" height="50"/>
+      </svg>`;
+      const result = parseSvgString(svg);
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      expect(result.value[0].width).toBe(50);
+    });
+  });
+
+  // Issue #1643 — fixtures resembling real-world editor output.
+  describe('real-world fixtures (issue #1643)', () => {
+    it('parses an Inkscape-style heart icon at the declared physical size', () => {
+      // Heart silhouette in a 25mm × 25mm icon authored in Inkscape
+      // (viewBox 100 × 100 → user-unit scale = 0.25)
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="25mm" height="25mm" viewBox="0 0 100 100">
+        <path d="M 50 30 C 50 10 80 10 80 35 C 80 60 50 80 50 90 C 50 80 20 60 20 35 C 20 10 50 10 50 30 Z"/>
+      </svg>`;
+      const result = parseSvgString(svg);
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+
+      const spec = result.value[0];
+      expect(spec.shape).toBe('path');
+      // 25mm canvas → bbox should fit comfortably under 25mm in both axes
+      expect(spec.width).toBeLessThanOrEqual(25);
+      expect(spec.depth).toBeLessThanOrEqual(25);
+      // Heart has real area in both axes (>10mm at 25mm canvas)
+      expect(spec.width).toBeGreaterThan(10);
+      expect(spec.depth).toBeGreaterThan(10);
+    });
+
+    it('parses a multi-contour SVG (icon set) into multiple specs', () => {
+      // Three icon glyphs side-by-side, e.g. a custom set
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="60mm" height="20mm" viewBox="0 0 60 20">
+        <circle cx="10" cy="10" r="8"/>
+        <rect x="22" y="2" width="16" height="16" rx="2"/>
+        <polygon points="50,2 58,18 42,18"/>
+      </svg>`;
+      const result = parseSvgString(svg);
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+
+      expect(result.value).toHaveLength(3);
+      // 1mm-per-user-unit physical scale, so dimensions equal the source attrs
+      expect(result.value[0].width).toBe(16); // circle dia
+      expect(result.value[1].width).toBe(16); // rect width
+    });
+
+    it('handles nested group transforms with physical scaling combined', () => {
+      // A logo with a rotated group inside a translated group, in a physically
+      // sized SVG — the most common "wrong scale + wrong shape" combo
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="40mm" height="40mm" viewBox="0 0 80 80">
+        <g transform="translate(40 40)">
+          <g transform="rotate(45)">
+            <rect x="-10" y="-10" width="20" height="20"/>
+          </g>
+        </g>
+      </svg>`;
+      const result = parseSvgString(svg);
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+
+      const spec = result.value[0];
+      // Rotation forces the rect through the rasterize path, producing a path
+      expect(spec.shape).toBe('path');
+      // Diamond inscribed in a 20-unit square has bbox ≈ 28.28 user units;
+      // physically scaled by 40/80 = 0.5 → bbox ≈ 14.14mm.
+      expect(spec.width).toBeCloseTo(14.142, 1);
+      expect(spec.depth).toBeCloseTo(14.142, 1);
+    });
+  });
+
+  // Issue #1643 — "imports as a square" / "displays at wrong scale" caused
+  // partly by anchor-only bounds clipping curves that bow outward.
+  describe('bezier bounds (issue #1643)', () => {
+    it('reflects outward-bowing curves in the bbox', () => {
+      // Path bows outward: anchors are at x=0 and x=10 but the curve apex
+      // reaches x≈12.5 via handles. Anchor-only bounds would say width=10.
+      const svg = svgWrap('<path d="M 0 50 C 25 30 25 70 50 50 Z"/>');
+      const result = parseSvgString(svg);
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      const spec = result.value[0];
+      expect(spec.shape).toBe('path');
+      // Bbox y must extend below 30 (curve dips toward y=30 in SVG → top in cutout)
+      // Verify width matches anchor span (x ∈ [0,50])
+      expect(spec.width).toBeCloseTo(50, 0);
+      // Depth grows past anchor span (anchor y=50 only) due to curve reach
+      expect(spec.depth).toBeGreaterThan(0);
+    });
+  });
 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgParser.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgParser.test.ts
@@ -414,6 +414,33 @@ describe('parseSvgString', () => {
       expect(spec.depth).toBeCloseTo(50, 1);
     });
 
+    it('falls back to identity for genuinely non-square SVGs (avoids silent distortion)', () => {
+      // 200mm × 100mm with viewBox 200x200 → sx=1, sy=0.5 — uniform scaling
+      // would silently shrink the canvas, so we keep user units instead.
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="200mm" height="100mm" viewBox="0 0 200 200">
+        <rect x="0" y="0" width="100" height="100"/>
+      </svg>`;
+      const result = parseSvgString(svg);
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      // Identity scale → cutout matches the source attribute (100 user units)
+      expect(result.value[0].width).toBe(100);
+      expect(result.value[0].depth).toBe(100);
+    });
+
+    it('absorbs sub-percent sx/sy drift from real-world exports as a single scalar', () => {
+      // Tools occasionally export 100mm × 99.95mm with viewBox 100x100 due to
+      // float rounding — that's still effectively uniform, so apply the average.
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="100mm" height="99.95mm" viewBox="0 0 100 100">
+        <rect x="0" y="0" width="100" height="100"/>
+      </svg>`;
+      const result = parseSvgString(svg);
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      // (1 + 0.9995) / 2 = 0.99975 ≈ 1
+      expect(result.value[0].width).toBeCloseTo(99.975, 2);
+    });
+
     it('falls back to identity when only one of width/height has units', () => {
       // Mixed/incomplete physical sizing → don't attempt to scale
       const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="100mm" height="100" viewBox="0 0 200 200">

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgParser.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgParser.ts
@@ -116,18 +116,25 @@ export function parseSvgString(svgString: string): Result<ParsedCutoutSpec[], Sv
  * Returns 1 (identity) unless the SVG declares physical dimensions in real
  * units (mm, cm, in, pt, pc, Q). Without explicit units, user-units are
  * treated as 1mm — preserving the import behavior callers historically relied on.
+ *
+ * Genuinely non-square SVGs (e.g. width="200mm" height="100mm" viewBox 200×200)
+ * also fall back to identity: a single uniform scalar can't honor non-uniform
+ * stretching without distorting circles and rotated shapes, so importing at
+ * 1:1 user units is the predictable choice.
  */
+const NON_SQUARE_TOLERANCE = 0.005;
+
 function resolveUserUnitToMm(svg: SVGSVGElement, viewBox: ViewBox): number {
   const physicalWidth = parseSvgLengthMm(svg.getAttribute('width'));
   const physicalHeight = parseSvgLengthMm(svg.getAttribute('height'));
   if (physicalWidth === null || physicalHeight === null) return 1;
 
-  // Average sx and sy so minor non-uniform aspect ratios resolve to a single
-  // scalar. Real-world SVGs from drawing tools occasionally drift by < 0.1%.
   const sx = physicalWidth / viewBox.width;
   const sy = physicalHeight / viewBox.height;
-  const scale = (sx + sy) / 2;
-  return Number.isFinite(scale) && scale > 0 ? scale : 1;
+  if (!Number.isFinite(sx) || !Number.isFinite(sy) || sx <= 0 || sy <= 0) return 1;
+
+  if (Math.abs(sx - sy) / Math.max(sx, sy) > NON_SQUARE_TOLERANCE) return 1;
+  return (sx + sy) / 2;
 }
 
 function parseViewBox(svg: SVGSVGElement): ViewBox {

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgParser.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgParser.ts
@@ -27,6 +27,8 @@ import {
   wrapSingle,
 } from './svgConvertShapes';
 import { convertPath } from './svgConvertPath';
+import { parseSvgLengthMm } from './svgLength';
+import { scaleParsedSpec } from './svgScaleSpec';
 
 export type { ViewBox } from './types';
 
@@ -73,6 +75,7 @@ export function parseSvgString(svgString: string): Result<ParsedCutoutSpec[], Sv
   }
 
   const viewBox = parseViewBox(svgRoot);
+  const userUnitToMm = resolveUserUnitToMm(svgRoot, viewBox);
 
   const specs: ParsedCutoutSpec[] = [];
 
@@ -100,7 +103,31 @@ export function parseSvgString(svgString: string): Result<ParsedCutoutSpec[], Sv
     });
   }
 
+  if (userUnitToMm !== 1) {
+    return ok(specs.map((s) => scaleParsedSpec(s, userUnitToMm)));
+  }
+
   return ok(specs);
+}
+
+/**
+ * Compute the user-unit → mm scale factor.
+ *
+ * Returns 1 (identity) unless the SVG declares physical dimensions in real
+ * units (mm, cm, in, pt, pc, Q). Without explicit units, user-units are
+ * treated as 1mm — preserving the import behavior callers historically relied on.
+ */
+function resolveUserUnitToMm(svg: SVGSVGElement, viewBox: ViewBox): number {
+  const physicalWidth = parseSvgLengthMm(svg.getAttribute('width'));
+  const physicalHeight = parseSvgLengthMm(svg.getAttribute('height'));
+  if (physicalWidth === null || physicalHeight === null) return 1;
+
+  // Average sx and sy so minor non-uniform aspect ratios resolve to a single
+  // scalar. Real-world SVGs from drawing tools occasionally drift by < 0.1%.
+  const sx = physicalWidth / viewBox.width;
+  const sy = physicalHeight / viewBox.height;
+  const scale = (sx + sy) / 2;
+  return Number.isFinite(scale) && scale > 0 ? scale : 1;
 }
 
 function parseViewBox(svg: SVGSVGElement): ViewBox {

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgParser.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgParser.ts
@@ -74,8 +74,8 @@ export function parseSvgString(svgString: string): Result<ParsedCutoutSpec[], Sv
     });
   }
 
-  const viewBox = parseViewBox(svgRoot);
-  const userUnitToMm = resolveUserUnitToMm(svgRoot, viewBox);
+  const { viewBox, hasExplicitViewBox } = parseViewBox(svgRoot);
+  const userUnitToMm = hasExplicitViewBox ? resolveUserUnitToMm(svgRoot, viewBox) : 1;
 
   const specs: ParsedCutoutSpec[] = [];
 
@@ -137,7 +137,7 @@ function resolveUserUnitToMm(svg: SVGSVGElement, viewBox: ViewBox): number {
   return (sx + sy) / 2;
 }
 
-function parseViewBox(svg: SVGSVGElement): ViewBox {
+function parseViewBox(svg: SVGSVGElement): { viewBox: ViewBox; hasExplicitViewBox: boolean } {
   const vb = svg.getAttribute('viewBox');
   if (vb) {
     const parts = vb
@@ -150,14 +150,22 @@ function parseViewBox(svg: SVGSVGElement): ViewBox {
       parts[2] > 0 &&
       parts[3] > 0
     ) {
-      return { minX: parts[0], minY: parts[1], width: parts[2], height: parts[3] };
+      return {
+        viewBox: { minX: parts[0], minY: parts[1], width: parts[2], height: parts[3] },
+        hasExplicitViewBox: true,
+      };
     }
   }
 
-  // Fallback to width/height attributes
+  // The fallback drops unit suffixes (parseFloat("1in") → 1), so it is not a
+  // valid basis for physical-unit scaling — callers must guard with
+  // hasExplicitViewBox before computing user-unit-to-mm scale.
   const w = parseFloat(svg.getAttribute('width') ?? '0');
   const h = parseFloat(svg.getAttribute('height') ?? '0');
-  return { minX: 0, minY: 0, width: w || 100, height: h || 100 };
+  return {
+    viewBox: { minX: 0, minY: 0, width: w || 100, height: h || 100 },
+    hasExplicitViewBox: false,
+  };
 }
 
 function convertElement(el: Element, matrix: Matrix, viewBox: ViewBox): ParsedCutoutSpec[] | null {

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgScaleSpec.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgScaleSpec.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { scaleParsedSpec } from './svgScaleSpec';
+import type { ParsedCutoutSpec } from './types';
+
+const baseRect: ParsedCutoutSpec = {
+  shape: 'rectangle',
+  x: 10,
+  y: 20,
+  width: 30,
+  depth: 40,
+  cornerRadius: 2,
+  rotation: 0,
+};
+
+describe('scaleParsedSpec', () => {
+  it('returns identity when scale is 1', () => {
+    const out = scaleParsedSpec(baseRect, 1);
+    expect(out).toBe(baseRect);
+  });
+
+  it('scales position, size, and corner radius', () => {
+    const out = scaleParsedSpec(baseRect, 0.5);
+    expect(out).toEqual({
+      shape: 'rectangle',
+      x: 5,
+      y: 10,
+      width: 15,
+      depth: 20,
+      cornerRadius: 1,
+      rotation: 0,
+    });
+  });
+
+  it('preserves rotation (rotation is unitless)', () => {
+    const out = scaleParsedSpec({ ...baseRect, rotation: 45 }, 2);
+    expect(out.rotation).toBe(45);
+  });
+
+  it('scales path point coordinates and handle deltas', () => {
+    const spec: ParsedCutoutSpec = {
+      shape: 'path',
+      x: 10,
+      y: 10,
+      width: 20,
+      depth: 20,
+      cornerRadius: 0,
+      rotation: 0,
+      path: [
+        { x: 10, y: 10, handleIn: null, handleOut: { dx: 4, dy: 0 }, symmetric: false },
+        { x: 30, y: 30, handleIn: { dx: -4, dy: 0 }, handleOut: null, symmetric: false },
+      ],
+    };
+    const out = scaleParsedSpec(spec, 0.25);
+    expect(out.path).toEqual([
+      { x: 2.5, y: 2.5, handleIn: null, handleOut: { dx: 1, dy: 0 }, symmetric: false },
+      { x: 7.5, y: 7.5, handleIn: { dx: -1, dy: 0 }, handleOut: null, symmetric: false },
+    ]);
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgScaleSpec.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgScaleSpec.ts
@@ -1,0 +1,42 @@
+/**
+ * Scale a ParsedCutoutSpec by a uniform factor (user units → mm).
+ *
+ * Applied at the tail of `parseSvgString` when the SVG declares physical
+ * width/height (e.g. `width="100mm"`) so a `<rect width="80">` inside a
+ * `viewBox="0 0 800 800"` resolves to a 10mm cutout instead of 80mm.
+ *
+ * Path point coordinates are scaled in place; bezier handle deltas are
+ * scaled as well so the curve shape is preserved at the new size.
+ */
+
+import type { PathPoint } from '@/features/bin-designer/types';
+import type { ParsedCutoutSpec } from './types';
+
+export function scaleParsedSpec(spec: ParsedCutoutSpec, scale: number): ParsedCutoutSpec {
+  if (scale === 1) return spec;
+
+  const base = {
+    ...spec,
+    x: spec.x * scale,
+    y: spec.y * scale,
+    width: spec.width * scale,
+    depth: spec.depth * scale,
+    cornerRadius: spec.cornerRadius * scale,
+  };
+
+  if (spec.path) {
+    return { ...base, path: spec.path.map((pt) => scalePathPoint(pt, scale)) };
+  }
+
+  return base;
+}
+
+function scalePathPoint(pt: PathPoint, scale: number): PathPoint {
+  return {
+    ...pt,
+    x: pt.x * scale,
+    y: pt.y * scale,
+    handleIn: pt.handleIn ? { dx: pt.handleIn.dx * scale, dy: pt.handleIn.dy * scale } : null,
+    handleOut: pt.handleOut ? { dx: pt.handleOut.dx * scale, dy: pt.handleOut.dy * scale } : null,
+  };
+}


### PR DESCRIPTION
## Summary
Closes #1643. The reported "imports invisible / square / wrong scale" failures had three independent root causes:

1. **Wrong scale** — physical `width`/`height` attributes (`100mm`, `2in`, `1cm`, …) were ignored, so an Inkscape file declaring `width="100mm" viewBox="0 0 800 800"` imported at 800mm — 10× too large.
2. **Wrong shape on curves** — `pathPointsToSpec` derived bounds from anchor points only, clipping the bbox of any curve whose handles bowed outward. The cutout's selection bbox no longer matched the visible shape.
3. **Real-world combo** — physically sized SVGs with nested group transforms compounded both bugs.

## Changes
- New `svgLength.ts` parses SVG lengths in `mm`, `cm`, `in`, `pt`, `pc`, `Q`. Unitless / `px` / `%` return `null` so the historical 1:1 user-unit contract is preserved when no physical dimension is declared.
- New `svgScaleSpec.ts` rescales `ParsedCutoutSpec` (and bezier handle deltas) by a uniform factor.
- `svgParser.ts` resolves the user-unit → mm scale once per file (averaging `sx` / `sy` so minor aspect drift in real exports collapses to one scalar) and applies it at the tail of parsing.
- `svgConvertShapes.ts` switches `pathPointsToSpec` to `getPathBounds` (already used by the renderer and vertex editor) so flattened bezier extents drive the bbox.

## Test plan
- [x] `svgLength.test.ts` — every supported unit + null/relative/unparseable cases
- [x] `svgScaleSpec.test.ts` — identity short-circuit + handle delta scaling
- [x] `svgParser.test.ts` adds:
  - physical-unit cases (mm, in, mixed/incomplete units)
  - bezier-bounds case (outward-bowing curve)
  - real-world fixtures: Inkscape heart, multi-shape icon set, nested group + rotation + physical scale
- [x] `pnpm run typecheck`, `pnpm run lint`, `pnpm run quality` clean
- [x] All 1925 bin-designer tests pass