### PR TITLE
feat(baseplate): auto-stack copies of each part in 3MF export

### DIFF
--- a/src/features/baseplate/README.md
+++ b/src/features/baseplate/README.md
@@ -25,7 +25,7 @@ graph TB
 - `components/BaseplatePanel.tsx` — parameter controls: grid size, padding, magnets, split mini-map
 - `components/BaseplatePreview.tsx` — Three.js 3D preview with assembled/exploded split views
 - `hooks/useBaseplateGeneration.ts` — two-phase lifecycle: synchronous direct-mesh preview (sub-100ms) + async BREP swap once WASM bridge ready, epoch-based stale detection
-- `hooks/useBaseplateExport.ts` — export pipeline: single-piece or parallel split with ZIP packaging
+- `hooks/useBaseplateExport.ts` — export pipeline: single-piece or parallel split with ZIP packaging; 3MF format optionally stacks N copies of each part via 3MF instancing
 - `store/baseplatePageStore.ts` — ephemeral UI state (generation status, tiling, piece selection)
 - `utils/splitPlanner.ts` — 2D optimal tiling: partitions grid into print-bed-sized pieces
 - `utils/buildFullParams.ts` — resolves sync mode: drawer dims vs custom width/depth

--- a/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
+++ b/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
@@ -90,6 +90,8 @@ export function BaseplatePage() {
   const exportFileNameConfig = useBaseplatePageStore((s) => s.exportFileNameConfig);
   const setExportFileNameConfig = useBaseplatePageStore((s) => s.setExportFileNameConfig);
   const tiling = useBaseplatePageStore((s) => s.tiling);
+  const stackCopies = useBaseplatePageStore((s) => s.stackCopies);
+  const setStackCopies = useBaseplatePageStore((s) => s.setStackCopies);
 
   const [splitEnabled, setSplitEnabled] = useState(true);
 
@@ -258,6 +260,18 @@ export function BaseplatePage() {
                 checkboxLabel: t('baseplate.export.enableSplit'),
                 checked: splitEnabled,
                 onCheckedChange: setSplitEnabled,
+              }
+            : null
+        }
+        stackOptions={
+          activeFormat === '3mf'
+            ? {
+                label: t('baseplate.export.stackCopies'),
+                description: t('baseplate.export.stackCopiesDescription'),
+                value: stackCopies,
+                onChange: setStackCopies,
+                min: 1,
+                max: 20,
               }
             : null
         }

--- a/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
+++ b/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
@@ -23,7 +23,7 @@ import { HeaderSupportLinks } from '@/shared/components/HeaderSupportLinks';
 import { useBaseplateRouting } from '@/shared/hooks/useBaseplateRouting';
 import { useBaseplateGeneration } from '../../hooks/useBaseplateGeneration';
 import { useBaseplateExport } from '../../hooks/useBaseplateExport';
-import { useBaseplatePageStore } from '../../store/baseplatePageStore';
+import { useBaseplatePageStore, MAX_STACK_COPIES } from '../../store/baseplatePageStore';
 import { generateBaseplateFileName, toNamingParams } from '../../utils/fileNaming';
 import { buildFullParams } from '../../utils/buildFullParams';
 import { BaseplatePanel } from '../BaseplatePanel/BaseplatePanel';
@@ -271,7 +271,7 @@ export function BaseplatePage() {
                 value: stackCopies,
                 onChange: setStackCopies,
                 min: 1,
-                max: 20,
+                max: MAX_STACK_COPIES,
               }
             : null
         }

--- a/src/features/baseplate/hooks/useBaseplateExport.ts
+++ b/src/features/baseplate/hooks/useBaseplateExport.ts
@@ -40,13 +40,22 @@ const FORMAT_EXTENSIONS: Record<ExportFileFormat, string> = {
   '3mf': '.3mf',
 };
 
-function convertStlTo3mf(stlData: ArrayBuffer, name: string): Blob {
+function convertStlTo3mf(stlData: ArrayBuffer, name: string, stackCopies: number): Blob {
   const parseResult = parseSTLBinary(stlData);
   if (isErr(parseResult)) {
     throw new Error(getUserMessage(parseResult.error));
   }
   const { vertices, normals } = parseResult.value;
   const printSettings = useSettingsStore.getState().settings.printSettings;
+
+  // Stacked instances reference the same mesh translated along Z; compute the
+  // per-instance Z stride from the source mesh's bbox so each copy sits flush
+  // on top of the one below it.
+  const stack =
+    stackCopies > 1
+      ? { count: stackCopies, zHeightMm: meshZExtent(vertices), spacingMm: 0 }
+      : undefined;
+
   return export3MF(vertices, normals, {
     name,
     printSettings: {
@@ -57,7 +66,21 @@ function convertStlTo3mf(stlData: ArrayBuffer, name: string): Blob {
       estimatedMinutes: 0,
       estimatedGrams: 0,
     },
+    stack,
   });
+}
+
+function meshZExtent(vertices: Float32Array): number {
+  if (vertices.length < 3) return 0;
+  let minZ = Infinity;
+  let maxZ = -Infinity;
+  for (let i = 2; i < vertices.length; i += 3) {
+    const z = vertices[i];
+    if (z < minZ) minZ = z;
+    if (z > maxZ) maxZ = z;
+  }
+  const extent = maxZ - minZ;
+  return Number.isFinite(extent) && extent > 0 ? extent : 0;
 }
 
 export function useBaseplateExport(): UseBaseplateExportReturn {
@@ -87,6 +110,7 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
   const exportFileNameConfig = useBaseplatePageStore((s) => s.exportFileNameConfig);
   const exportProgress = useBaseplatePageStore((s) => s.exportProgress);
   const setExportProgress = useBaseplatePageStore((s) => s.setExportProgress);
+  const stackCopies = useBaseplatePageStore((s) => s.stackCopies);
   const [isExporting, setIsExporting] = useState(false);
 
   const hasSingleMesh = mesh !== null && mesh.vertices !== null && mesh.error === null;
@@ -164,7 +188,7 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
             let data = uniqueExports[i];
 
             if (format === '3mf') {
-              const blob = convertStlTo3mf(data, `${baseNameNoExt}_${name}`);
+              const blob = convertStlTo3mf(data, `${baseNameNoExt}_${name}`, stackCopies);
               data = await blob.arrayBuffer();
             }
 
@@ -202,7 +226,7 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
           // Single piece export
           if (format === '3mf') {
             const stlResult = await bridge.exportBaseplate(fullParams, 'stl');
-            const blob = convertStlTo3mf(stlResult.data, baseNameNoExt);
+            const blob = convertStlTo3mf(stlResult.data, baseNameNoExt, stackCopies);
             triggerDownload(blob, baseName);
           } else {
             const result = await bridge.exportBaseplate(fullParams, format);
@@ -236,6 +260,7 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
       tiling,
       exportFileNameConfig,
       setExportProgress,
+      stackCopies,
     ]
   );
 

--- a/src/features/baseplate/hooks/useBaseplateExport.ts
+++ b/src/features/baseplate/hooks/useBaseplateExport.ts
@@ -50,10 +50,14 @@ function convertStlTo3mf(stlData: ArrayBuffer, name: string, stackCopies: number
 
   // Stacked instances reference the same mesh translated along Z; compute the
   // per-instance Z stride from the source mesh's bbox so each copy sits flush
-  // on top of the one below it.
+  // on top of the one below it. A degenerate mesh (zero Z extent) would
+  // produce a stride of 0 and silently overlap every copy at Z=0, so the
+  // option is suppressed in that case and the export degrades to a single
+  // instance instead.
+  const zHeight = meshZExtent(vertices);
   const stack =
-    stackCopies > 1
-      ? { count: stackCopies, zHeightMm: meshZExtent(vertices), spacingMm: 0 }
+    stackCopies > 1 && zHeight > 0
+      ? { count: stackCopies, zHeightMm: zHeight, spacingMm: 0 }
       : undefined;
 
   return export3MF(vertices, normals, {

--- a/src/features/baseplate/store/baseplatePageStore.test.ts
+++ b/src/features/baseplate/store/baseplatePageStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useBaseplatePageStore } from './baseplatePageStore';
+import { useBaseplatePageStore, MAX_STACK_COPIES } from './baseplatePageStore';
 import type { PieceMeshEntry } from './baseplatePageStore';
 import type { BaseplateTiling } from '../types/tiling';
 
@@ -360,6 +360,36 @@ describe('baseplatePageStore', () => {
 
       expect(useBaseplatePageStore.getState().hoveredPieceLabel).toBeNull();
       expect(useBaseplatePageStore.getState().selectedPieceLabel).toBeNull();
+    });
+  });
+
+  describe('setStackCopies', () => {
+    it('defaults to 1', () => {
+      expect(useBaseplatePageStore.getState().stackCopies).toBe(1);
+    });
+
+    it('clamps below 1 to 1', () => {
+      useBaseplatePageStore.getState().setStackCopies(0);
+      expect(useBaseplatePageStore.getState().stackCopies).toBe(1);
+      useBaseplatePageStore.getState().setStackCopies(-5);
+      expect(useBaseplatePageStore.getState().stackCopies).toBe(1);
+    });
+
+    it('clamps above MAX_STACK_COPIES', () => {
+      useBaseplatePageStore.getState().setStackCopies(200);
+      expect(useBaseplatePageStore.getState().stackCopies).toBe(MAX_STACK_COPIES);
+    });
+
+    it('floors fractional values', () => {
+      useBaseplatePageStore.getState().setStackCopies(3.7);
+      expect(useBaseplatePageStore.getState().stackCopies).toBe(3);
+    });
+
+    it('falls back to 1 for non-finite input', () => {
+      useBaseplatePageStore.getState().setStackCopies(Number.NaN);
+      expect(useBaseplatePageStore.getState().stackCopies).toBe(1);
+      useBaseplatePageStore.getState().setStackCopies(Number.POSITIVE_INFINITY);
+      expect(useBaseplatePageStore.getState().stackCopies).toBe(1);
     });
   });
 });

--- a/src/features/baseplate/store/baseplatePageStore.ts
+++ b/src/features/baseplate/store/baseplatePageStore.ts
@@ -79,6 +79,8 @@ interface BaseplatePageState {
   exportFileNameConfig: ExportFileNameConfig;
   /** Progress for multi-piece export: null when not exporting */
   exportProgress: { current: number; total: number } | null;
+  /** 3MF export only: number of vertical copies stacked per part. Default 1. */
+  stackCopies: number;
 
   setGenerationStatus: (status: GenerationStatus) => void;
   setGenerationResult: (result: MeshResult) => void;
@@ -94,6 +96,7 @@ interface BaseplatePageState {
   setExportFileNameConfig: (config: ExportFileNameConfig) => void;
   setExportProgress: (progress: { current: number; total: number } | null) => void;
   setDedupStats: (stats: DedupStats | null) => void;
+  setStackCopies: (copies: number) => void;
 }
 
 export const useBaseplatePageStore = create<BaseplatePageState>()(
@@ -114,6 +117,7 @@ export const useBaseplatePageStore = create<BaseplatePageState>()(
     exportDialogOpen: false,
     exportFileNameConfig: { style: 'descriptive', customName: '', format: 'stl' },
     exportProgress: null,
+    stackCopies: 1,
 
     setGenerationStatus: (status) => {
       set((state) => {
@@ -202,6 +206,12 @@ export const useBaseplatePageStore = create<BaseplatePageState>()(
     setDedupStats: (stats) => {
       set((state) => {
         state.dedupStats = stats;
+      });
+    },
+
+    setStackCopies: (copies) => {
+      set((state) => {
+        state.stackCopies = Math.max(1, Math.floor(copies));
       });
     },
   }))

--- a/src/features/baseplate/store/baseplatePageStore.ts
+++ b/src/features/baseplate/store/baseplatePageStore.ts
@@ -17,6 +17,9 @@ type WasmStatus = 'unloaded' | 'loading' | 'ready' | 'error';
 /** View mode for split baseplates: assembled (no gaps) or exploded (gaps between pieces). */
 export type SplitViewMode = 'assembled' | 'exploded';
 
+/** Upper bound for the 3MF stack-copies stepper. Mirrored by the UI's `max` attr. */
+export const MAX_STACK_COPIES = 20;
+
 interface MeshResult {
   readonly vertices: Float32Array | null;
   readonly normals: Float32Array | null;
@@ -213,7 +216,9 @@ export const useBaseplatePageStore = create<BaseplatePageState>()(
       set((state) => {
         // Math.floor(NaN) / Math.max(1, NaN) both return NaN, which would
         // poison every downstream comparison. Default unsafe input to 1.
-        state.stackCopies = Number.isFinite(copies) ? Math.max(1, Math.floor(copies)) : 1;
+        state.stackCopies = Number.isFinite(copies)
+          ? Math.min(MAX_STACK_COPIES, Math.max(1, Math.floor(copies)))
+          : 1;
       });
     },
   }))

--- a/src/features/baseplate/store/baseplatePageStore.ts
+++ b/src/features/baseplate/store/baseplatePageStore.ts
@@ -211,7 +211,9 @@ export const useBaseplatePageStore = create<BaseplatePageState>()(
 
     setStackCopies: (copies) => {
       set((state) => {
-        state.stackCopies = Math.max(1, Math.floor(copies));
+        // Math.floor(NaN) / Math.max(1, NaN) both return NaN, which would
+        // poison every downstream comparison. Default unsafe input to 1.
+        state.stackCopies = Number.isFinite(copies) ? Math.max(1, Math.floor(copies)) : 1;
       });
     },
   }))

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -708,4 +708,88 @@ describe('threemfExporter', () => {
       expect(contentTypes).toContain('Extension="rels"');
     });
   });
+
+  // Issue #1642 — auto-stack copies in 3MF. The exporter uses 3MF instancing
+  // (single object, multiple <item> entries with Z translation) so file size
+  // stays constant regardless of copy count.
+  describe('stack option (issue #1642)', () => {
+    it('emits a single <item> when stack is omitted', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const xml = extractModelXML(build3MFBuffer(vertices, normals, { name: 'test' }));
+      const items = xml.match(/<item /g) ?? [];
+      expect(items).toHaveLength(1);
+      expect(xml).not.toContain('transform=');
+    });
+
+    it('emits a single <item> when stack.count is 1', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const xml = extractModelXML(
+        build3MFBuffer(vertices, normals, {
+          name: 'test',
+          stack: { count: 1, zHeightMm: 7, spacingMm: 0 },
+        })
+      );
+      expect((xml.match(/<item /g) ?? []).length).toBe(1);
+    });
+
+    it('emits N <item> entries with Z translation when stack.count > 1', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const xml = extractModelXML(
+        build3MFBuffer(vertices, normals, {
+          name: 'test',
+          stack: { count: 3, zHeightMm: 7, spacingMm: 0 },
+        })
+      );
+      const items = xml.match(/<item [^/]*\/>/g) ?? [];
+      expect(items).toHaveLength(3);
+      expect(items[0]).toContain('transform="1 0 0 0 1 0 0 0 1 0 0 0"');
+      expect(items[1]).toContain('transform="1 0 0 0 1 0 0 0 1 0 0 7"');
+      expect(items[2]).toContain('transform="1 0 0 0 1 0 0 0 1 0 0 14"');
+    });
+
+    it('adds spacingMm to each successive Z stride', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const xml = extractModelXML(
+        build3MFBuffer(vertices, normals, {
+          name: 'test',
+          stack: { count: 2, zHeightMm: 5, spacingMm: 0.5 },
+        })
+      );
+      const items = xml.match(/transform="[^"]+"/g) ?? [];
+      expect(items[0]).toBe('transform="1 0 0 0 1 0 0 0 1 0 0 0"');
+      expect(items[1]).toBe('transform="1 0 0 0 1 0 0 0 1 0 0 5.5"');
+    });
+
+    it('still references a single object even when stacking many copies', () => {
+      const { vertices, normals } = createTwoTriangles();
+      const xml = extractModelXML(
+        build3MFBuffer(vertices, normals, {
+          name: 'test',
+          stack: { count: 10, zHeightMm: 7, spacingMm: 0 },
+        })
+      );
+      // The mesh is emitted once even though there are 10 placements.
+      expect((xml.match(/<object /g) ?? []).length).toBe(1);
+      expect((xml.match(/<item /g) ?? []).length).toBe(10);
+    });
+
+    it('honors all build items when reading back as a slicer would', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const xml = extractModelXML(
+        build3MFBuffer(vertices, normals, {
+          name: 'test',
+          stack: { count: 4, zHeightMm: 7, spacingMm: 0 },
+        })
+      );
+      const objectIdMatch = xml.match(/<object id="(\d+)"/);
+      expect(objectIdMatch).not.toBeNull();
+      const objectId = objectIdMatch?.[1] ?? '';
+      const items = xml.match(/<item objectid="(\d+)"/g) ?? [];
+      expect(items.length).toBe(4);
+      // Every item references the single emitted object.
+      for (const item of items) {
+        expect(item).toContain(`objectid="${objectId}"`);
+      }
+    });
+  });
 });

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -42,6 +42,18 @@ export interface ThreeMFOptions {
   readonly printSettings?: ThreeMFPrintSettings;
   /** Optional multi-material color configuration */
   readonly colorConfig?: ThreeMFColorConfig;
+  /**
+   * Optional vertical stacking. The mesh is emitted once and referenced by
+   * `count` build items, each translated by `i * (zHeight + spacingMm)` along Z.
+   * `zHeight` should be the source mesh's Z extent (max - min Z over its
+   * vertices). Slicers see each instance as a separate placement and slice them
+   * together, which is the auto-stack workflow requested by issue #1642.
+   */
+  readonly stack?: {
+    readonly count: number;
+    readonly zHeightMm: number;
+    readonly spacingMm: number;
+  };
 }
 
 /** Suggested print settings embedded as metadata */
@@ -307,14 +319,38 @@ function buildModelXML(mesh: IndexedMesh, options: ThreeMFOptions): string {
   xml += '    </object>\n';
   xml += '  </resources>\n';
 
-  // Build instructions
+  // Build instructions — one or many instances of the single object.
   xml += '  <build>\n';
-  xml += `    <item objectid="${colorConfig ? OBJECT_ID : 1}" />\n`;
+  xml += renderBuildItems(colorConfig ? OBJECT_ID : 1, options.stack);
   xml += '  </build>\n';
 
   xml += '</model>';
   return xml;
 }
+
+/**
+ * Emit one or N `<item>` build entries for an object.
+ *
+ * 3MF transforms are row-major 3×4 (`m11..m13 m21..m23 m31..m33 m41..m43`);
+ * the trailing m41/m42/m43 row carries the translation. Since stacking is a
+ * pure Z translation, the rotation/scale block is the identity matrix and
+ * only m43 changes per copy.
+ */
+function renderBuildItems(objectId: number, stack: ThreeMFOptions['stack']): string {
+  const count = stack && stack.count > 1 ? Math.floor(stack.count) : 1;
+  if (count === 1) {
+    return `    <item objectid="${objectId}" />\n`;
+  }
+
+  const stride = (stack?.zHeightMm ?? 0) + (stack?.spacingMm ?? 0);
+  let out = '';
+  for (let i = 0; i < count; i++) {
+    const dz = formatFloat(i * stride);
+    out += `    <item objectid="${objectId}" transform="1 0 0 0 1 0 0 0 1 0 0 ${dz}" />\n`;
+  }
+  return out;
+}
+
 function buildMultiObjectModelXML(
   objects: readonly {
     mesh: IndexedMesh;

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -48,6 +48,10 @@ export interface ThreeMFOptions {
    * `zHeight` should be the source mesh's Z extent (max - min Z over its
    * vertices). Slicers see each instance as a separate placement and slice them
    * together, which is the auto-stack workflow requested by issue #1642.
+   *
+   * Honored by `export3MF` / `build3MFBuffer` (single-object export) only;
+   * `export3MFMultiObject` ignores this field — stacking a heterogeneous bin +
+   * lid pair has no slicer-friendly interpretation.
    */
   readonly stack?: {
     readonly count: number;

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -20,6 +20,8 @@
   "baseplate.export.enableSplit": "In Teile aufteilen",
   "baseplate.export.splitBanner": "Grundplatte überschreitet {size}mm Druckbett — wird als {count} Teile in einer ZIP mit Druckanleitung exportiert",
   "baseplate.export.splitSuccess": "Grundplatte exportiert ({count} Teile)",
+  "baseplate.export.stackCopies": "Kopien pro Teil",
+  "baseplate.export.stackCopiesDescription": "Stapelt vertikale Kopien jedes Grundplatten-Teils im 3MF zur Stapelverarbeitung im Slicer.",
   "baseplate.export.success": "{format}-Grundplatte erfolgreich exportiert",
   "baseplate.export.threeDModel": "3D-Modell",
   "baseplate.export.threeDModelDescription": "Ein druckbares Grundplatten-Modell exportieren",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1007,6 +1007,8 @@
   "baseplate.export.threeDModel": "3D Model",
   "baseplate.export.threeDModelDescription": "Export a printable baseplate model",
   "baseplate.export.dedupSuccess": "Baseplate exported ({unique} unique pieces, {total} total)",
+  "baseplate.export.stackCopies": "Copies per part",
+  "baseplate.export.stackCopiesDescription": "Stack vertical copies of each baseplate piece in the 3MF for slicer batching.",
   "baseplate.generation.dedupProgress": "Refining {unique} unique pieces ({skipped} duplicates skipped)",
   "halfBinBlocked.title": "Cannot Disable Half-Bin Mode",
   "halfBinBlocked.message": "Some bins use fractional dimensions. Resize or delete these bins before disabling half-bin mode.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1151,6 +1151,9 @@ const en: Record<string, string> = {
   'baseplate.export.threeDModel': '3D Model',
   'baseplate.export.threeDModelDescription': 'Export a printable baseplate model',
   'baseplate.export.dedupSuccess': 'Baseplate exported ({unique} unique pieces, {total} total)',
+  'baseplate.export.stackCopies': 'Copies per part',
+  'baseplate.export.stackCopiesDescription':
+    'Stack vertical copies of each baseplate piece in the 3MF for slicer batching.',
   'baseplate.generation.dedupProgress':
     'Refining {unique} unique pieces ({skipped} duplicates skipped)',
 

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -20,6 +20,8 @@
   "baseplate.export.enableSplit": "Dividir en piezas",
   "baseplate.export.splitBanner": "La placa base excede la cama de impresión de {size}mm — se exportará como {count} piezas en un ZIP con guía de impresión",
   "baseplate.export.splitSuccess": "Placa base exportada ({count} piezas)",
+  "baseplate.export.stackCopies": "Copias por pieza",
+  "baseplate.export.stackCopiesDescription": "Apila copias verticales de cada pieza de placa base en el 3MF para procesar por lotes en el slicer.",
   "baseplate.export.success": "Placa base {format} exportada correctamente",
   "baseplate.export.threeDModel": "Modelo 3D",
   "baseplate.export.threeDModelDescription": "Exportar un modelo de placa base imprimible",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -20,6 +20,8 @@
   "baseplate.export.enableSplit": "Diviser en pièces",
   "baseplate.export.splitBanner": "La plaque de base dépasse le plateau d'impression de {size}mm — sera exportée en {count} pièces dans un ZIP avec guide d'impression",
   "baseplate.export.splitSuccess": "Plaque de base exportée ({count} pièces)",
+  "baseplate.export.stackCopies": "Copies par pièce",
+  "baseplate.export.stackCopiesDescription": "Empile des copies verticales de chaque pièce de plaque de base dans le 3MF pour le traitement par lots du slicer.",
   "baseplate.export.success": "Plaque de base {format} exportée avec succès",
   "baseplate.export.threeDModel": "Modèle 3D",
   "baseplate.export.threeDModelDescription": "Exporter un modèle de plaque de base imprimable",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -20,6 +20,8 @@
   "baseplate.export.enableSplit": "Del opp i biter",
   "baseplate.export.splitBanner": "Bunnplaten overskrider {size}mm printflate — eksporteres som {count} deler i en ZIP med utskriftsguide",
   "baseplate.export.splitSuccess": "Bunnplate eksportert ({count} deler)",
+  "baseplate.export.stackCopies": "Kopier per del",
+  "baseplate.export.stackCopiesDescription": "Stable vertikale kopier av hver bunnplatedel i 3MF-en for slicer-batching.",
   "baseplate.export.success": "{format}-bunnplate eksportert",
   "baseplate.export.threeDModel": "3D-modell",
   "baseplate.export.threeDModelDescription": "Eksporter en printbar bunnplatemodell",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -20,6 +20,8 @@
   "baseplate.export.enableSplit": "Opsplitsen in onderdelen",
   "baseplate.export.splitBanner": "Basisplaat overschrijdt {size}mm printbed — wordt geëxporteerd als {count} onderdelen in een ZIP met printgids",
   "baseplate.export.splitSuccess": "Basisplaat geëxporteerd ({count} onderdelen)",
+  "baseplate.export.stackCopies": "Kopieën per onderdeel",
+  "baseplate.export.stackCopiesDescription": "Stapelt verticale kopieën van elk basisplaat-onderdeel in het 3MF voor batchverwerking in de slicer.",
   "baseplate.export.success": "{format}-basisplaat succesvol geëxporteerd",
   "baseplate.export.threeDModel": "3D-model",
   "baseplate.export.threeDModelDescription": "Exporteer een printbaar basisplaatmodel",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -20,6 +20,8 @@
   "baseplate.export.enableSplit": "Dividir em peças",
   "baseplate.export.splitBanner": "A placa base excede a mesa de impressão de {size}mm — será exportada como {count} peças em um ZIP com guia de impressão",
   "baseplate.export.splitSuccess": "Placa base exportada ({count} peças)",
+  "baseplate.export.stackCopies": "Cópias por peça",
+  "baseplate.export.stackCopiesDescription": "Empilha cópias verticais de cada peça da placa base no 3MF para processamento em lote no slicer.",
   "baseplate.export.success": "Placa base {format} exportada com sucesso",
   "baseplate.export.threeDModel": "Modelo 3D",
   "baseplate.export.threeDModelDescription": "Exportar um modelo de placa base imprimível",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -948,6 +948,8 @@
   "baseplate.export.threeDModel": "3D-modell",
   "baseplate.export.threeDModelDescription": "Exportera en utskriftsbar bottenplattmodell",
   "baseplate.export.dedupSuccess": "Bottenplatta exporterad ({unique} unika delar, {total} totalt)",
+  "baseplate.export.stackCopies": "Kopior per del",
+  "baseplate.export.stackCopiesDescription": "Staplar vertikala kopior av varje bottenplattedel i 3MF-filen för batchhantering i slicern.",
   "baseplate.generation.dedupProgress": "Förfinar {unique} unika delar ({skipped} dubbletter hoppade över)",
   "halfBinBlocked.title": "Kan inte inaktivera halvfack-läge",
   "halfBinBlocked.message": "Vissa fack använder bråkmått. Ändra storlek eller radera dessa fack innan du inaktiverar halvfack-läget.",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -948,6 +948,8 @@
   "baseplate.export.threeDModel": "3D-модель",
   "baseplate.export.threeDModelDescription": "Експортувати придатну для друку модель базової плити",
   "baseplate.export.dedupSuccess": "Базову плиту експортовано (унікальних частин: {unique}, усього: {total})",
+  "baseplate.export.stackCopies": "Копій на деталь",
+  "baseplate.export.stackCopiesDescription": "Накладає вертикальні копії кожної частини базової плити у 3MF для пакетної обробки в слайсері.",
   "baseplate.generation.dedupProgress": "Уточнення {unique} унікальних частин (пропущено дублікатів: {skipped})",
   "halfBinBlocked.title": "Не можна вимкнути режим напівбіна",
   "halfBinBlocked.message": "Деякі біни мають дробові розміри. Змініть їх розмір або видаліть, перш ніж вимикати режим напівбіна.",

--- a/src/shared/components/ExportDialog/ExportDialog.test.tsx
+++ b/src/shared/components/ExportDialog/ExportDialog.test.tsx
@@ -127,4 +127,67 @@ describe('ExportDialog', () => {
     );
     expect(screen.getByText('Download Dividers')).toBeInTheDocument();
   });
+
+  describe('stackOptions (issue #1642)', () => {
+    const stackProps = (overrides: Partial<NonNullable<ExportDialogProps['stackOptions']>> = {}) =>
+      ({
+        label: 'Copies per part',
+        description: 'Stack vertically',
+        value: 1,
+        onChange: vi.fn(),
+        min: 1,
+        max: 20,
+        ...overrides,
+      }) as NonNullable<ExportDialogProps['stackOptions']>;
+
+    it('does not render the stack input when stackOptions is null', () => {
+      render(<ExportDialog {...defaultProps} stackOptions={null} />);
+      expect(screen.queryByLabelText('Copies per part')).not.toBeInTheDocument();
+    });
+
+    it('renders a numeric input bound to the provided value', () => {
+      render(<ExportDialog {...defaultProps} stackOptions={stackProps({ value: 3 })} />);
+      const input = screen.getByLabelText('Copies per part');
+      expect(input).toHaveAttribute('type', 'number');
+      expect(input.value).toBe('3');
+    });
+
+    it('forwards parsed integer changes to onChange', () => {
+      const onChange = vi.fn();
+      render(<ExportDialog {...defaultProps} stackOptions={stackProps({ onChange })} />);
+      fireEvent.change(screen.getByLabelText('Copies per part'), { target: { value: '5' } });
+      expect(onChange).toHaveBeenCalledWith(5);
+    });
+
+    it('clamps values above max', () => {
+      const onChange = vi.fn();
+      render(<ExportDialog {...defaultProps} stackOptions={stackProps({ onChange, max: 10 })} />);
+      fireEvent.change(screen.getByLabelText('Copies per part'), { target: { value: '99' } });
+      expect(onChange).toHaveBeenCalledWith(10);
+    });
+
+    it('clamps values below min', () => {
+      const onChange = vi.fn();
+      render(<ExportDialog {...defaultProps} stackOptions={stackProps({ onChange, min: 1 })} />);
+      fireEvent.change(screen.getByLabelText('Copies per part'), { target: { value: '0' } });
+      expect(onChange).toHaveBeenCalledWith(1);
+    });
+
+    it('ignores unparseable input rather than firing NaN', () => {
+      const onChange = vi.fn();
+      render(<ExportDialog {...defaultProps} stackOptions={stackProps({ onChange })} />);
+      fireEvent.change(screen.getByLabelText('Copies per part'), { target: { value: '' } });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('renders the description text when provided', () => {
+      render(
+        <ExportDialog
+          {...defaultProps}
+          stackOptions={stackProps({ description: 'Stack vertically for slicer batching' })}
+        />
+      );
+      expect(screen.getByText('Stack vertically for slicer batching')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/shared/components/ExportDialog/ExportDialog.tsx
+++ b/src/shared/components/ExportDialog/ExportDialog.tsx
@@ -58,6 +58,16 @@ export interface ExportDialogProps {
     onCheckedChange: (v: boolean) => void;
   } | null;
 
+  /** Optional vertical-stack control (3MF only — STL/STEP have no instancing). */
+  stackOptions?: {
+    label: string;
+    description?: string;
+    value: number;
+    onChange: (v: number) => void;
+    min: number;
+    max: number;
+  } | null;
+
   /** Optional print estimates */
   estimates?: readonly { label: string; value: string }[] | null;
   estimatesTitle?: string;
@@ -94,6 +104,7 @@ export function ExportDialog({
   downloadLabel,
   exportProgress,
   splitBanner,
+  stackOptions,
   estimates,
   estimatesTitle,
   estimatesDisclaimer,
@@ -246,6 +257,38 @@ export function ExportDialog({
                   {splitBanner.checkboxLabel}
                 </span>
               </label>
+            </div>
+          )}
+
+          {/* Vertical Stacking */}
+          {stackOptions && (
+            <div className="mb-4">
+              <label
+                htmlFor="export-stack-copies"
+                className="mb-2 block text-sm font-medium text-content-secondary"
+              >
+                {stackOptions.label}
+              </label>
+              <input
+                id="export-stack-copies"
+                type="number"
+                min={stackOptions.min}
+                max={stackOptions.max}
+                step={1}
+                value={stackOptions.value}
+                onChange={(e) => {
+                  const next = Number.parseInt(e.target.value, 10);
+                  if (Number.isFinite(next)) {
+                    stackOptions.onChange(
+                      Math.max(stackOptions.min, Math.min(stackOptions.max, next))
+                    );
+                  }
+                }}
+                className="w-24 rounded-md border border-stroke-subtle bg-surface px-3 py-2 text-sm text-content outline-none focus:border-stroke"
+              />
+              {stackOptions.description && (
+                <p className="mt-1 text-xs text-content-secondary">{stackOptions.description}</p>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## Summary
Closes #1642. The baseplate Print Export dialog now exposes a "Copies per part" stepper (1–20, default 1) when the format is 3MF. Stacking is implemented as 3MF instancing — one `<object>` is referenced by N `<item transform="..." />` entries with per-instance Z translation — so the file size is constant regardless of copy count.

## How it works
- `threemfExporter.ts` — `ThreeMFOptions` gains an optional `stack: { count, zHeightMm, spacingMm }`. `buildModelXML` emits a single `<item>` when `count <= 1`, otherwise N items at `dz = i * (zHeightMm + spacingMm)`.
- `useBaseplateExport.ts` — `convertStlTo3mf` measures the source mesh's Z extent from the parsed STL vertex array and passes it as `zHeightMm`. `spacingMm` defaults to 0 so the workflow matches users' existing manual slicer-stack convention.
- `baseplatePageStore.ts` — `stackCopies` + `setStackCopies` (clamped to ≥ 1).
- `ExportDialog.tsx` — new optional `stackOptions` prop renders a numeric stepper between the split banner and the progress bar; the baseplate page only passes it when `format === '3mf'` (STL/STEP would require literal mesh duplication).

## Test plan
- [x] `threemfExporter.test.ts` adds the issue-#1642 stack suite: omitted/single-copy short-circuits, N items at the right Z stride, spacing folds into the stride, single `<object>` even with 10 placements, every item references the same objectid.
- [x] `pnpm run typecheck`, `pnpm run quality`, `pnpm run build` clean
- [x] `pnpm run check:i18n`, `check:i18n:values`, `check:i18n:interpolation` all green (added 2 keys × 9 locales)
- [x] All 358 baseplate + threemfExporter tests pass

## Format scope
Stacking applies to 3MF only. STL has no instancing — each copy must be a literal mesh duplicate, which would inflate file size N× without slicer benefits. STEP exports are also unaffected; that path already folds compound assemblies for the lid pairing.