### PR TITLE
fix(generation): cut divider notches through lip in split slotted bins

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.split-slotted-lip.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-slotted-lip.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment node
+/**
+ * Scenario tests for slotted bins with stacking lip when split (#1652).
+ *
+ * Verifies that the separately-built lip in split bins gets cut at slot
+ * positions, so removable dividers can slide in from the top without being
+ * blocked by the lip's inner overhang.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
+import type { BinParams, SplitConnectorConfig } from '@/shared/types/bin';
+import { initBrepjs, getGenerateSplitPreview } from './__kernel-tests__/wasmInit';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+const NO_CONNECTORS: SplitConnectorConfig = {
+  ...DEFAULT_SPLIT_CONNECTOR_CONFIG,
+  enabled: false,
+};
+
+/** Count vertices whose Z is at or above the threshold (in the lip zone). */
+function countLipVertices(vertices: Float32Array, zMin: number): number {
+  let count = 0;
+  for (let i = 0; i < vertices.length; i += 3) {
+    if (vertices[i + 2] >= zMin) count++;
+  }
+  return count;
+}
+
+describe('slotted bin split with stacking lip (#1652)', () => {
+  /**
+   * Cutting divider notches through the lip produces new cut faces (one per
+   * slot per piece-side), and each cut face contributes additional vertices
+   * to the tessellated lip mesh. A slotted+lip+split piece should therefore
+   * carry noticeably more lip-zone vertices than the equivalent unslotted
+   * (standard style) piece, where the lip remains intact.
+   *
+   * Without the fix from #1652, the lip in split bins was built fresh and
+   * never cut, so slotted and standard pieces would have identical lip
+   * geometry and this assertion would fail.
+   */
+  it('lip cuts add geometry vs unslotted equivalent (X-axis slots)', () => {
+    const generateSplitPreview = getGenerateSplitPreview();
+    const baseParams: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 6,
+      depth: 2,
+      height: 3,
+    };
+    const slottedParams: BinParams = {
+      ...baseParams,
+      style: 'slotted',
+      slotConfig: {
+        x: { enabled: true, pitch: 42 },
+        y: { enabled: false, pitch: 42 },
+      },
+    };
+
+    const slottedResult = generateSplitPreview(slottedParams, [0], [], NO_CONNECTORS);
+    const flatResult = generateSplitPreview(baseParams, [0], [], NO_CONNECTORS);
+
+    const wallTopZ = baseParams.height * baseParams.heightUnitMm;
+    const lipZMin = wallTopZ + 0.1;
+
+    expect(slottedResult.pieces).toHaveLength(2);
+    expect(flatResult.pieces).toHaveLength(2);
+
+    for (let i = 0; i < slottedResult.pieces.length; i++) {
+      const slottedLip = countLipVertices(slottedResult.pieces[i].vertices, lipZMin);
+      const flatLip = countLipVertices(flatResult.pieces[i].vertices, lipZMin);
+      expect(
+        slottedLip,
+        `piece ${slottedResult.pieces[i].label}: expected more lip vertices ` +
+          `from slot cuts (slotted=${slottedLip}, flat=${flatLip})`
+      ).toBeGreaterThan(flatLip);
+    }
+  }, 120000);
+
+  it('lip cuts add geometry on both axes when both slot axes are enabled', () => {
+    const generateSplitPreview = getGenerateSplitPreview();
+    const baseParams: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 6,
+      depth: 6,
+      height: 3,
+    };
+    const slottedParams: BinParams = {
+      ...baseParams,
+      style: 'slotted',
+      slotConfig: {
+        x: { enabled: true, pitch: 42 },
+        y: { enabled: true, pitch: 42 },
+      },
+    };
+
+    const slottedResult = generateSplitPreview(slottedParams, [0], [0], NO_CONNECTORS);
+    const flatResult = generateSplitPreview(baseParams, [0], [0], NO_CONNECTORS);
+
+    const wallTopZ = baseParams.height * baseParams.heightUnitMm;
+    const lipZMin = wallTopZ + 0.1;
+
+    expect(slottedResult.pieces).toHaveLength(4);
+    expect(flatResult.pieces).toHaveLength(4);
+
+    for (let i = 0; i < slottedResult.pieces.length; i++) {
+      const slottedLip = countLipVertices(slottedResult.pieces[i].vertices, lipZMin);
+      const flatLip = countLipVertices(flatResult.pieces[i].vertices, lipZMin);
+      expect(
+        slottedLip,
+        `piece ${slottedResult.pieces[i].label}: expected more lip vertices ` +
+          `from slot cuts (slotted=${slottedLip}, flat=${flatLip})`
+      ).toBeGreaterThan(flatLip);
+    }
+  }, 180000);
+});
+
+describe('slotted bin split with stacking lip + wall thickness extremes', () => {
+  // Regression: at certain wall thicknesses (e.g. 1.6mm) the body+lip fuse
+  // could crash. The split fix should remain stable across thicknesses.
+  for (const wallThickness of [0.95, 1.6, 2.0]) {
+    it(`slotted split with wall thickness ${wallThickness}mm completes without error`, () => {
+      const generateSplitPreview = getGenerateSplitPreview();
+      const params: BinParams = {
+        ...DEFAULT_BIN_PARAMS,
+        width: 6,
+        depth: 2,
+        height: 3,
+        wallThickness,
+        style: 'slotted',
+        slotConfig: {
+          x: { enabled: true, pitch: 42 },
+          y: { enabled: false, pitch: 42 },
+        },
+      };
+
+      const result = generateSplitPreview(params, [0], [], NO_CONNECTORS);
+      expect(result.pieces).toHaveLength(2);
+      for (const piece of result.pieces) {
+        expect(piece.vertices.length).toBeGreaterThan(100);
+      }
+    }, 120000);
+  }
+});

--- a/src/features/generation/worker/generators/slotBuilder.ts
+++ b/src/features/generation/worker/generators/slotBuilder.ts
@@ -186,17 +186,17 @@ export function buildSlotCuts(
  * pipeline, but the separately-built lip needs its own cutouts so the
  * dividers can slide in from above.
  *
- * The body's wall slot positions are computed with `edgeInset=0` because
- * bodyParams strips `stackingLip` before going through the pipeline. To
- * keep lip cuts aligned with those wall slots, callers should pass
- * `slotPositionsEdgeInset=0` here as well.
- *
  * @param params Bin parameters (with the user's style/slotConfig intact)
  * @param innerW Interior width in mm
  * @param innerD Interior depth in mm
  * @param lipInfo Lip geometry — physical dimensions of the cutters
- * @param slotPositionsEdgeInset Edge inset used when computing slot positions
- *   along each axis. Pass 0 to match split bin body positions.
+ * @param slotPositionsEdgeInset Edge inset (mm) used when computing slot
+ *   positions along each axis. MUST match the value the caller's body used
+ *   when generating its wall slots — otherwise lip cuts will misalign and
+ *   dividers won't slide through. Split bin callers should pass 0 because
+ *   bodyParams strips `stackingLip`, forcing the pipeline to compute body
+ *   slot positions with edgeInset=0. Non-split callers wanting to use this
+ *   helper would pass `lipOverhang` instead to match the normal pipeline.
  * @returns Fused compound of lip cutters, or null if not slotted / no cuts needed
  */
 export function buildLipSlotCuts(
@@ -204,7 +204,7 @@ export function buildLipSlotCuts(
   innerW: number,
   innerD: number,
   lipInfo: LipCutInfo,
-  slotPositionsEdgeInset = 0
+  slotPositionsEdgeInset: number
 ): Shape3D | null {
   if (params.style !== 'slotted') return null;
   if (params.wallThickness < MIN_WALL_FOR_SLOTS) return null;

--- a/src/features/generation/worker/generators/slotBuilder.ts
+++ b/src/features/generation/worker/generators/slotBuilder.ts
@@ -177,6 +177,82 @@ export function buildSlotCuts(
   });
 }
 
+/**
+ * Build only the lip-zone slot cutters for a slotted bin.
+ *
+ * Used by splitBinBuilder where the stacking lip is built and split
+ * separately from the body (to work around an OCCT crash at the lip-wall
+ * junction). The body already has wall slot cuts applied via the normal
+ * pipeline, but the separately-built lip needs its own cutouts so the
+ * dividers can slide in from above.
+ *
+ * The body's wall slot positions are computed with `edgeInset=0` because
+ * bodyParams strips `stackingLip` before going through the pipeline. To
+ * keep lip cuts aligned with those wall slots, callers should pass
+ * `slotPositionsEdgeInset=0` here as well.
+ *
+ * @param params Bin parameters (with the user's style/slotConfig intact)
+ * @param innerW Interior width in mm
+ * @param innerD Interior depth in mm
+ * @param lipInfo Lip geometry — physical dimensions of the cutters
+ * @param slotPositionsEdgeInset Edge inset used when computing slot positions
+ *   along each axis. Pass 0 to match split bin body positions.
+ * @returns Fused compound of lip cutters, or null if not slotted / no cuts needed
+ */
+export function buildLipSlotCuts(
+  params: BinParams,
+  innerW: number,
+  innerD: number,
+  lipInfo: LipCutInfo,
+  slotPositionsEdgeInset = 0
+): Shape3D | null {
+  if (params.style !== 'slotted') return null;
+  if (params.wallThickness < MIN_WALL_FOR_SLOTS) return null;
+
+  const lipOverhang = Math.max(0, lipInfo.lipTaperWidth - params.wallThickness);
+  if (lipOverhang <= 0) return null;
+
+  return withScope((scope: DisposalScope): Shape3D | null => {
+    const { slotConfig } = params;
+    const { slotWidth } = getEffectiveSlotDimensions(params);
+    const lipCutStartZ = lipInfo.wallHeight - lipInfo.lipTaperWidth;
+    const lipCutHeight = lipInfo.lipTaperWidth + lipInfo.lipHeight + 1;
+
+    const cutters: Shape3D[] = [];
+
+    const addAxisLipCuts = (axis: 'x' | 'y', innerCross: number, positions: number[]): void => {
+      const halfSpan = innerCross / 2;
+      for (const crossPos of positions) {
+        const lipCutters = createMirroredLipCutters(
+          lipOverhang,
+          slotWidth,
+          lipCutHeight,
+          halfSpan,
+          crossPos,
+          lipCutStartZ,
+          axis
+        );
+        for (const c of lipCutters) cutters.push(scope.register(c));
+      }
+    };
+
+    if (slotConfig.x.enabled) {
+      const positions = calculateSlotPositions(innerD, slotConfig.x.pitch, slotPositionsEdgeInset);
+      addAxisLipCuts('x', innerW, positions);
+    }
+
+    if (slotConfig.y.enabled) {
+      const positions = calculateSlotPositions(innerW, slotConfig.y.pitch, slotPositionsEdgeInset);
+      addAxisLipCuts('y', innerD, positions);
+    }
+
+    if (cutters.length === 0) return null;
+    const fused =
+      cutters.length === 1 ? cutters[0] : scope.register(unwrap(fuseAll(cutters as ValidSolid[])));
+    return unwrap(clone(fused));
+  });
+}
+
 function buildSlotCutsInScope(
   scope: DisposalScope,
   params: BinParams,

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -9,6 +9,7 @@ import {
   box,
   unwrap,
   fuse,
+  cut,
   clone,
   translate,
   intersect,
@@ -17,16 +18,18 @@ import {
   meshEdges,
   exportSTL,
 } from 'brepjs';
-import type { Shape3D } from 'brepjs';
+import type { Shape3D, ValidSolid } from 'brepjs';
 import type { BinParams, SplitConnectorConfig } from '@/shared/types/bin';
 
 import { SIZE, CLEARANCE, SOCKET_HEIGHT } from './generatorTypes';
+import { LIP_HEIGHT, LIP_TAPER_WIDTH } from './generatorConstants';
 import { toIndexedMeshData } from './utils/mesh';
 import { buildTopShape } from './boxBuilder';
 import { generateBin } from './binOrchestrator';
 import { getLastSolid, setLastSolid } from './shapeCache';
 import { applySplitConnectors, computeCutFaces } from './splitConnectorBuilder';
 import type { BinGeometryContext } from './splitConnectorBuilder';
+import { buildLipSlotCuts } from './slotBuilder';
 import { isAbortError } from './utils/abort';
 
 /** Result of a split export: array of piece buffers with grid labels */
@@ -143,6 +146,34 @@ function splitSolidIntoPieces(
     const lipBase = buildTopShape(params.width, params.depth, true, params.gridUnitMm);
     lipSolid = translate(lipBase, [0, 0, wallTopZ - LIP_FUSE_OVERLAP]);
     lipBase.delete();
+
+    // For slotted bins, cut divider notches through the lip so removable
+    // dividers can slide in from the top. The wall slot cuts already live in
+    // the body solid (applied via the normal pipeline on bodyParams), but the
+    // lip is built fresh here and would otherwise block the dividers.
+    //
+    // Body wall slots were positioned with edgeInset=0 (bodyParams strips
+    // stackingLip, so dim.hasLip=false in the pipeline). Pass the same inset
+    // here to keep the lip cuts aligned with the body's wall slots.
+    if (params.style === 'slotted') {
+      const innerW = outerW - 2 * params.wallThickness;
+      const innerD = outerD - 2 * params.wallThickness;
+      const lipInfo = {
+        wallHeight: wallTopZ,
+        lipHeight: LIP_HEIGHT,
+        lipTaperWidth: LIP_TAPER_WIDTH,
+      };
+      const lipCuts = buildLipSlotCuts(params, innerW, innerD, lipInfo, 0);
+      if (lipCuts) {
+        try {
+          const newLip = unwrap(cut(lipSolid as ValidSolid, lipCuts as ValidSolid));
+          lipSolid.delete();
+          lipSolid = newLip;
+        } finally {
+          lipCuts.delete();
+        }
+      }
+    }
   }
 
   // Boundary arrays: [left edge, ...cut planes, right edge]


### PR DESCRIPTION
## Summary

- Fixes #1652 — removable dividers couldn't be inserted from above when the stacking lip was enabled on split bins
- Adds `buildLipSlotCuts()` in `slotBuilder.ts` that produces only the lip-zone cutters with a configurable position inset
- Applies the lip cuts to the separately-built `lipSolid` in `splitBinBuilder.ts` before per-piece fusing, using `slotPositionsEdgeInset=0` so cuts align with the body's wall slots

## Root cause

`splitBinBuilder` generates the bin body with `stackingLip: false` to work around an OCCT boolean-intersection crash at the lip-wall junction. The lip is then built fresh via `buildTopShape()` and fused per-piece — but never went through the slot-cut pipeline. Non-split slotted bins already cut the lip correctly via `slotCutsFeature`.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] Targeted scenario test: `binGenerator.scenario.split-slotted-lip.test.ts` (new) verifies slotted+lip+split pieces have more lip-zone vertices than unslotted equivalents, on single-axis, both-axis, and across wall thicknesses 0.95mm / 1.6mm / 2.0mm
- [x] Regression: `binGenerator.scenario.split-robustness.test.ts`, `binGenerator.scenario.split-lip-trim.test.ts`, `slotBuilder.test.ts` all pass