### PR TITLE
fix(generation): cut lid magnet holes before fusing stack grid

### DIFF
--- a/src/features/generation/worker/generators/lidBuilder.ts
+++ b/src/features/generation/worker/generators/lidBuilder.ts
@@ -5,12 +5,12 @@
  * stacking lip. The lid is built in lid-local coordinates so it can be
  * positioned and exported independently of the bin.
  *
- * Geometry breakdown:
+ * Geometry breakdown (in build order):
  *   - `buildLidFloor`     — flat plate at the top              (lidProfile)
  *   - `buildMatingShell`  — inverted-lip wall                  (lidProfile)
  *   - `addClickRails`     — tapered snap rails on each wall    (lidClickRail)
- *   - `buildStackGrid`    — Gridfinity lip profile on top      (lidStackGrid)
  *   - `cutMagnetHoles`    — standard magnet pattern through floor (lidMagnets)
+ *   - `buildStackGrid`    — Gridfinity lip profile on top      (lidStackGrid)
  *
  * Coordinate convention:
  *   Z = 0          : top of lid floor
@@ -76,7 +76,20 @@ export function buildLid(params: BinParams, originToTag?: Map<number, number>): 
       body = addClickRails(scope, body, inputs, originToTag);
     }
 
-    // 3. Optional Gridfinity stack grid on top
+    // 3. Optional magnet holes through the floor.
+    //    Cut BEFORE the stack grid fuses on top: the cylinder's 0.1mm
+    //    coplanar overshoot above Z=0 would otherwise hang inside the
+    //    pocket cavity (a void INSIDE the body), and some OCCT/WASM
+    //    builds produce malformed output when trimming a cutter whose
+    //    top sits in an internal void (issue #1655). Cut-first makes
+    //    the overshoot land in empty space ABOVE the body — a clean
+    //    through-cut. Order swap is safe because magnet positions sit
+    //    inside the pocket footprint, so cylinders never touch the slab.
+    if (inputs.magnetHoles) {
+      body = cutMagnetHoles(scope, body, inputs);
+    }
+
+    // 4. Optional Gridfinity stack grid on top
     if (inputs.stackableTop) {
       const stackGrid = scope.register(buildStackGrid(scope, inputs));
       if (originToTag) {
@@ -84,11 +97,6 @@ export function buildLid(params: BinParams, originToTag?: Map<number, number>): 
       }
       scope.register(body);
       body = unwrap(fuse(body, stackGrid));
-    }
-
-    // 4. Optional magnet holes through the floor
-    if (inputs.magnetHoles) {
-      body = cutMagnetHoles(scope, body, inputs);
     }
 
     return body as ValidSolid;

--- a/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
@@ -178,6 +178,32 @@ describe('generateLid scenarios', () => {
     expect(withMagnets!.triangleCount).not.toBe(without!.triangleCount);
   });
 
+  it('exports STL for stackable lid with magnet holes (regression #1655)', async () => {
+    // Stackable top + magnet holes used to fuse the slab BEFORE cutting
+    // magnet pockets, leaving each cylinder's coplanar-margin overshoot
+    // hanging inside the pocket cavity (a void inside the body's bounding
+    // volume). OCCT/WASM builds varied on whether they could trim that
+    // configuration cleanly — Firefox succeeded, some Chrome builds failed
+    // with STL_EXPORT_FAILED. Now the magnet cut runs against the
+    // floor-only body so the overshoot lands in empty space above the
+    // body, which is a topologically simpler through-cut.
+    const { exportLid } = await import('./lidOrchestrator');
+    const result = await exportLid(
+      makeParams(
+        { stackableTop: true, magnetHoles: true },
+        {
+          width: 2,
+          depth: 1,
+          height: 4,
+          base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet' },
+        }
+      ),
+      'stl'
+    );
+    expect(result).not.toBeNull();
+    expect(result!.data.byteLength).toBeGreaterThan(0);
+  }, 60_000);
+
   it('builds a valid mesh for half-bin width (2.5×2) with magnets', async () => {
     // Regression: prior to the forEachCell-based magnet iteration, the
     // hole loop ran `for (cx = 0; cx < cellsX; cx++)` over a fractional

--- a/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
@@ -54,7 +54,7 @@ function makeParams(lid: Partial<LidConfig>, extra: Partial<BinParams> = {}): Bi
   };
 }
 
-describe('generateLid scenarios', () => {
+describe('lid generation and export scenarios', () => {
   it('returns null when lid is disabled', async () => {
     const { generateLid } = await import('./lidOrchestrator');
     expect(generateLid(DEFAULT_BIN_PARAMS)).toBeNull();


### PR DESCRIPTION
## Summary

- Reorder `buildLid` so `cutMagnetHoles` runs against the floor-only body BEFORE `buildStackGrid` fuses on top. Fixes #1655.
- The magnet cylinder cutter extends 0.1mm above Z=0 for a coplanar bite. With the stack grid fused first, that overshoot lands inside the pocket cavity — a void INSIDE the body's bounding volume — and some OCCT/WASM builds (e.g. some Chrome versions) produce malformed output trimming a cutter whose top sits in an internal void, surfacing as `STL_EXPORT_FAILED`. Firefox handles it cleanly, which matches the user-reported "works in Firefox, fails in Chrome" pattern on the issue.
- Cut-first puts the overshoot in empty space ABOVE the body — a topologically simpler through-cut. The order swap is safe because magnet positions sit inside the pocket footprint where the slab has been cut away, so cylinders never touch the slab material.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (changed files)
- [x] Full vitest suite (10942 tests pass, one new regression test added)
- [x] Added `exportLid` regression test driving the 2x1x4 + magnet base + stackable lid + magnet holes path from #1655. The existing scenario tests only drove `generateLid` — meshing can succeed while `exportSTL` still rejects the topology, so coverage now extends through the STL writer.
- [ ] Manual export of a 2x1x4 magnet bin + lid + magnet holes in Chrome (request from issue author Gavin McFall — left unchecked because reproduction is browser/WASM-build-specific).