### PR TITLE
fix(generation): propagate face tags via setShapeOrigin so multi-color export works

### DIFF
--- a/e2e/bin-designer/multi-color-export.spec.ts
+++ b/e2e/bin-designer/multi-color-export.spec.ts
@@ -1,19 +1,8 @@
 /**
- * Verifies the `multi_color_export` Labs flow end-to-end. Pins the fix for
- * the bug where every face downstream of `collectOrigins` got the same tag
- * because brepjs's `mesh().faceGroups[].origin` is `0` by default — the
- * previous implementation tried to use that field as a face-id and ended up
- * with a one-entry map. The repaired path calls `setShapeOrigin(shape, tag)`
- * so origins propagate through fuses and reach the final mesh.
- *
- * Step list:
- *   1. Enable the Labs flag, change body + lip to distinct hex colors
- *   2. Download the 3MF, unzip it, parse the embedded XML
- *   3. Assert `<basematerials>` carries the chosen hex colors AND the
- *      per-triangle `pid`/`p1` attributes span ≥2 distinct material indices
- *
- * If `<basematerials>` is missing or every `<triangle>` carries the same
- * `p1`, the regression is back.
+ * Pins the fix for the multi-color export regression: faces tagged via
+ * `collectOrigins` must reach the final 3MF as distinct material indices.
+ * Failure mode if this regresses: `<basematerials>` is missing, or every
+ * `<triangle>` carries the same `p1` — i.e. one color for the whole bin.
  */
 
 import { test, expect } from '../fixtures';
@@ -37,9 +26,8 @@ test.describe('Bin Designer — multi-color 3MF export', () => {
         try {
           localStorage.setItem(key, JSON.stringify(prefs));
         } catch {
-          // Storage may be unavailable in private/incognito contexts; the
-          // test will fail at the next visibility assertion if the flag
-          // doesn't apply, which is a clearer signal than a bare throw.
+          // If storage is unavailable, the visibility assertion below fails
+          // with a clearer signal than rethrowing here would give.
         }
       },
       { key: LABS_KEY, flag: LAB_FLAG }
@@ -93,14 +81,11 @@ test.describe('Bin Designer — multi-color 3MF export', () => {
     expect(entries['3D/3dmodel.model']).toBeDefined();
     const xml = strFromU8(entries['3D/3dmodel.model']);
 
-    // basematerials should declare both hex colors. Compare lower-case so
-    // the test isn't sensitive to the exporter's case choice.
+    // Lower-cased: exporter's hex case is not part of the contract.
     expect(xml.toLowerCase()).toContain(BODY_HEX);
     expect(xml.toLowerCase()).toContain(LIP_HEX);
     expect(xml).toMatch(/<basematerials\b/);
 
-    // Triangles carry pid/p1 multi-material attributes and span at least
-    // two distinct p1 indices (body + lip).
     const triangleMatches = xml.match(/<triangle\b[^/]*p1="(\d+)"/g) ?? [];
     expect(triangleMatches.length).toBeGreaterThan(0);
     const distinctP1 = new Set(triangleMatches.map((m) => /p1="(\d+)"/.exec(m)?.[1]));

--- a/e2e/bin-designer/multi-color-export.spec.ts
+++ b/e2e/bin-designer/multi-color-export.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Verifies the `multi_color_export` Labs flow end-to-end. Pins the fix for
+ * the bug where every face downstream of `collectOrigins` got the same tag
+ * because brepjs's `mesh().faceGroups[].origin` is `0` by default — the
+ * previous implementation tried to use that field as a face-id and ended up
+ * with a one-entry map. The repaired path calls `setShapeOrigin(shape, tag)`
+ * so origins propagate through fuses and reach the final mesh.
+ *
+ * Step list:
+ *   1. Enable the Labs flag, change body + lip to distinct hex colors
+ *   2. Download the 3MF, unzip it, parse the embedded XML
+ *   3. Assert `<basematerials>` carries the chosen hex colors AND the
+ *      per-triangle `pid`/`p1` attributes span ≥2 distinct material indices
+ *
+ * If `<basematerials>` is missing or every `<triangle>` carries the same
+ * `p1`, the regression is back.
+ */
+
+import { test, expect } from '../fixtures';
+import { unzipSync, strFromU8 } from 'fflate';
+import fs from 'node:fs';
+
+const LABS_KEY = 'gridfinity-labs-v1';
+const LAB_FLAG = 'multi_color_export';
+const BODY_HEX = '#00aaff';
+const LIP_HEX = '#ff0066';
+
+test.describe('Bin Designer — multi-color 3MF export', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(
+      ({ key, flag }) => {
+        const prefs = {
+          enabledFeatures: { [flag]: true },
+          lastModified: new Date().toISOString(),
+          version: 1,
+        };
+        try {
+          localStorage.setItem(key, JSON.stringify(prefs));
+        } catch {
+          // Storage may be unavailable in private/incognito contexts; the
+          // test will fail at the next visibility assertion if the flag
+          // doesn't apply, which is a clearer signal than a bare throw.
+        }
+      },
+      { key: LABS_KEY, flag: LAB_FLAG }
+    );
+  });
+
+  test('exports a 3MF with body + lip materials', async ({ page }) => {
+    await page.goto('/designer');
+    const canvas = page.locator('canvas').first();
+    await expect(canvas).toBeVisible({ timeout: 30000 });
+    await page.waitForTimeout(3000);
+
+    for (const [label, hex] of [
+      [/^Body: /i, BODY_HEX],
+      [/^Stacking Lip: /i, LIP_HEX],
+    ] as const) {
+      const trigger = page.getByRole('button', { name: label });
+      await expect(trigger).toBeVisible({ timeout: 5000 });
+      await trigger.click();
+      const popover = page.locator('[role="dialog"]').last();
+      await popover.getByRole('textbox').first().fill(hex);
+      await page.keyboard.press('Enter');
+      await page.keyboard.press('Escape');
+    }
+    await page.waitForTimeout(2000);
+
+    await page
+      .getByRole('button', { name: /^export/i })
+      .first()
+      .click();
+    const dialog = page.locator('[role="dialog"]').first();
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    const threeMfOption = dialog.getByRole('button', { name: /^3MF\b/i }).first();
+    if (await threeMfOption.isVisible().catch(() => false)) {
+      await threeMfOption.click();
+    } else {
+      await dialog.getByRole('radio', { name: /3MF/i }).first().click();
+    }
+
+    const downloadButton = dialog.getByRole('button', { name: /download 3mf/i });
+    await expect(downloadButton).toBeEnabled({ timeout: 60_000 });
+    const downloadPromise = page.waitForEvent('download', { timeout: 60_000 });
+    await downloadButton.click();
+    const download = await downloadPromise;
+    const downloadPath = await download.path();
+    expect(downloadPath).toBeTruthy();
+
+    const buf = fs.readFileSync(downloadPath);
+    const entries = unzipSync(new Uint8Array(buf));
+    expect(entries['3D/3dmodel.model']).toBeDefined();
+    const xml = strFromU8(entries['3D/3dmodel.model']);
+
+    // basematerials should declare both hex colors. Compare lower-case so
+    // the test isn't sensitive to the exporter's case choice.
+    expect(xml.toLowerCase()).toContain(BODY_HEX);
+    expect(xml.toLowerCase()).toContain(LIP_HEX);
+    expect(xml).toMatch(/<basematerials\b/);
+
+    // Triangles carry pid/p1 multi-material attributes and span at least
+    // two distinct p1 indices (body + lip).
+    const triangleMatches = xml.match(/<triangle\b[^/]*p1="(\d+)"/g) ?? [];
+    expect(triangleMatches.length).toBeGreaterThan(0);
+    const distinctP1 = new Set(triangleMatches.map((m) => /p1="(\d+)"/.exec(m)?.[1]));
+    expect(distinctP1.size).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/e2e/bin-designer/multi-color-export.spec.ts
+++ b/e2e/bin-designer/multi-color-export.spec.ts
@@ -38,7 +38,6 @@ test.describe('Bin Designer — multi-color 3MF export', () => {
     await page.goto('/designer');
     const canvas = page.locator('canvas').first();
     await expect(canvas).toBeVisible({ timeout: 30000 });
-    await page.waitForTimeout(3000);
 
     for (const [label, hex] of [
       [/^Body: /i, BODY_HEX],
@@ -51,8 +50,13 @@ test.describe('Bin Designer — multi-color 3MF export', () => {
       await popover.getByRole('textbox').first().fill(hex);
       await page.keyboard.press('Enter');
       await page.keyboard.press('Escape');
+      // The picker button's aria-label is `${label}: ${hex}` — waiting for it
+      // to update is a deterministic signal that the color change landed in
+      // the store, no wall-clock guess needed.
+      await expect(page.getByRole('button', { name: new RegExp(`${hex}$`, 'i') })).toBeVisible({
+        timeout: 5000,
+      });
     }
-    await page.waitForTimeout(2000);
 
     await page
       .getByRole('button', { name: /^export/i })

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2620`;
 
-exports[`base styles > flat base no lip 1`] = `252`;
+exports[`base styles > flat base no lip 1`] = `204`;
 
 exports[`base styles > flat base with lip 1`] = `892`;
 

--- a/src/features/generation/worker/generators/binExporter.ts
+++ b/src/features/generation/worker/generators/binExporter.ts
@@ -17,13 +17,13 @@ export interface ExportResult {
 }
 
 /**
- * Run a single export attempt against the current cached solid.
- * Regenerates first if the cache is missing or preview-quality.
+ * Run a single export attempt against the current cached solid, regenerating
+ * first if the cache is missing or preview-quality.
  *
- * `faceGroups` is captured from the export-quality regen so 3MF callers can
- * map each STL triangle to a feature tag. brepjs caches mesh() output by
- * shape+tolerance, and `exportSTL` walks the same tessellation, so the
- * per-triangle ordering matches the face-group ranges produced here.
+ * `faceGroups` is captured so 3MF callers can map each STL triangle to a
+ * feature tag. brepjs caches `mesh()` output by shape+tolerance and
+ * `exportSTL` walks the same tessellation, so the per-triangle ordering here
+ * matches what ends up in the STL.
  */
 async function runExportAttempt(
   params: BinParams,
@@ -43,19 +43,14 @@ async function runExportAttempt(
     throw new Error('Failed to generate solid for export');
   }
 
-  // If we skipped regen above, the cached solid was already export-quality
-  // but we don't have its meshData. Re-mesh it at export tolerances — brepjs
-  // caches mesh results by shape+tolerance, so this hits the cache and
-  // gives us the same face-group ordering exportSTL will walk.
+  // Cached export-quality solid — re-derive faceGroups from the brepjs mesh
+  // cache so we can return them alongside the STL/STEP payload.
   if (!faceGroups) {
     const m = mesh(solid, { tolerance, angularTolerance });
     faceGroups = m.faceGroups.map((g) => ({
       start: g.start,
       count: g.count,
-      // Brepjs returns origin=0 when no setShapeOrigin tag is in the lookup
-      // map — that's "untagged" from our pipeline's POV, so treat it as
-      // UNKNOWN (matches `toIndexedMeshData`).
-      tag: g.origin !== 0 ? g.origin : 255,
+      tag: g.origin !== 0 ? g.origin : 255, // FeatureTag.UNKNOWN — matches `toIndexedMeshData`
     }));
   }
 

--- a/src/features/generation/worker/generators/binExporter.ts
+++ b/src/features/generation/worker/generators/binExporter.ts
@@ -2,7 +2,7 @@
  * Bin export — converts the last generated solid to STL or STEP format.
  */
 
-import { unwrap, exportSTL, exportSTEP } from 'brepjs';
+import { unwrap, exportSTL, exportSTEP, mesh } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
 import type { ExportFormat, FaceGroupData } from '../../bridge/types';
 
@@ -19,6 +19,11 @@ export interface ExportResult {
 /**
  * Run a single export attempt against the current cached solid.
  * Regenerates first if the cache is missing or preview-quality.
+ *
+ * `faceGroups` is captured from the export-quality regen so 3MF callers can
+ * map each STL triangle to a feature tag. brepjs caches mesh() output by
+ * shape+tolerance, and `exportSTL` walks the same tessellation, so the
+ * per-triangle ordering matches the face-group ranges produced here.
  */
 async function runExportAttempt(
   params: BinParams,
@@ -27,8 +32,10 @@ async function runExportAttempt(
   angularTolerance: number,
   name: string
 ): Promise<ExportResult> {
+  let faceGroups: readonly FaceGroupData[] | undefined;
   if (!isLastSolidExportQuality()) {
-    generateBin(params, undefined, true);
+    const meshData = generateBin(params, undefined, true);
+    faceGroups = meshData.faceGroups;
   }
 
   const solid = getLastSolid();
@@ -36,10 +43,26 @@ async function runExportAttempt(
     throw new Error('Failed to generate solid for export');
   }
 
+  // If we skipped regen above, the cached solid was already export-quality
+  // but we don't have its meshData. Re-mesh it at export tolerances — brepjs
+  // caches mesh results by shape+tolerance, so this hits the cache and
+  // gives us the same face-group ordering exportSTL will walk.
+  if (!faceGroups) {
+    const m = mesh(solid, { tolerance, angularTolerance });
+    faceGroups = m.faceGroups.map((g) => ({
+      start: g.start,
+      count: g.count,
+      // Brepjs returns origin=0 when no setShapeOrigin tag is in the lookup
+      // map — that's "untagged" from our pipeline's POV, so treat it as
+      // UNKNOWN (matches `toIndexedMeshData`).
+      tag: g.origin !== 0 ? g.origin : 255,
+    }));
+  }
+
   if (format === 'step') {
     const blob = unwrap(exportSTEP(solid));
     const data = await blob.arrayBuffer();
-    return { data, fileName: `${name}.step` };
+    return { data, fileName: `${name}.step`, faceGroups };
   }
 
   const blob = unwrap(
@@ -50,7 +73,7 @@ async function runExportAttempt(
     })
   );
   const data = await blob.arrayBuffer();
-  return { data, fileName: `${name}.stl` };
+  return { data, fileName: `${name}.stl`, faceGroups };
 }
 
 /**

--- a/src/features/generation/worker/generators/binExporter.ts
+++ b/src/features/generation/worker/generators/binExporter.ts
@@ -43,8 +43,16 @@ async function runExportAttempt(
     throw new Error('Failed to generate solid for export');
   }
 
+  if (format === 'step') {
+    // STEP carries exact BREP geometry; faceGroups don't ride along, so
+    // skip the re-mesh that the STL/3MF path needs.
+    const blob = unwrap(exportSTEP(solid));
+    const data = await blob.arrayBuffer();
+    return { data, fileName: `${name}.step` };
+  }
+
   // Cached export-quality solid — re-derive faceGroups from the brepjs mesh
-  // cache so we can return them alongside the STL/STEP payload.
+  // cache so STL→3MF gets per-triangle material indices.
   if (!faceGroups) {
     const m = mesh(solid, { tolerance, angularTolerance });
     faceGroups = m.faceGroups.map((g) => ({
@@ -52,12 +60,6 @@ async function runExportAttempt(
       count: g.count,
       tag: g.origin !== 0 ? g.origin : 255, // FeatureTag.UNKNOWN — matches `toIndexedMeshData`
     }));
-  }
-
-  if (format === 'step') {
-    const blob = unwrap(exportSTEP(solid));
-    const data = await blob.arrayBuffer();
-    return { data, fileName: `${name}.step`, faceGroups };
   }
 
   const blob = unwrap(

--- a/src/features/generation/worker/generators/binExporter.ts
+++ b/src/features/generation/worker/generators/binExporter.ts
@@ -7,7 +7,9 @@ import type { BinParams } from '@/shared/types/bin';
 import type { ExportFormat, FaceGroupData } from '../../bridge/types';
 
 import { generateBin } from './binOrchestrator';
+import { FeatureTag } from './featureTags';
 import { getLastSolid, isLastSolidExportQuality, setLastSolid } from './shapeCache';
+import { EXPORT_ANGULAR_TOLERANCE, EXPORT_TOLERANCE } from './utils/tolerances';
 
 /** Export result with binary data and suggested file name. */
 export interface ExportResult {
@@ -21,15 +23,15 @@ export interface ExportResult {
  * first if the cache is missing or preview-quality.
  *
  * `faceGroups` is captured so 3MF callers can map each STL triangle to a
- * feature tag. brepjs caches `mesh()` output by shape+tolerance and
- * `exportSTL` walks the same tessellation, so the per-triangle ordering here
- * matches what ends up in the STL.
+ * feature tag. The match relies on brepjs's shape+tolerance mesh cache: the
+ * regen path runs `mesh()` at `EXPORT_TOLERANCE`/`EXPORT_ANGULAR_TOLERANCE`
+ * (the export branch of `computeTessellationTolerances`), and we re-mesh /
+ * `exportSTL` with the same constants here so all three calls hit the same
+ * cached tessellation.
  */
 async function runExportAttempt(
   params: BinParams,
   format: ExportFormat,
-  tolerance: number,
-  angularTolerance: number,
   name: string
 ): Promise<ExportResult> {
   let faceGroups: readonly FaceGroupData[] | undefined;
@@ -54,18 +56,21 @@ async function runExportAttempt(
   // Cached export-quality solid — re-derive faceGroups from the brepjs mesh
   // cache so STL→3MF gets per-triangle material indices.
   if (!faceGroups) {
-    const m = mesh(solid, { tolerance, angularTolerance });
+    const m = mesh(solid, {
+      tolerance: EXPORT_TOLERANCE,
+      angularTolerance: EXPORT_ANGULAR_TOLERANCE,
+    });
     faceGroups = m.faceGroups.map((g) => ({
       start: g.start,
       count: g.count,
-      tag: g.origin !== 0 ? g.origin : 255, // FeatureTag.UNKNOWN — matches `toIndexedMeshData`
+      tag: g.origin !== 0 ? g.origin : FeatureTag.UNKNOWN,
     }));
   }
 
   const blob = unwrap(
     exportSTL(solid, {
-      tolerance,
-      angularTolerance,
+      tolerance: EXPORT_TOLERANCE,
+      angularTolerance: EXPORT_ANGULAR_TOLERANCE,
       binary: true,
     })
   );
@@ -74,7 +79,11 @@ async function runExportAttempt(
 }
 
 /**
- * Export the last generated solid in the requested format.
+ * Export the last generated solid in the requested format. Tessellation is
+ * fixed at `EXPORT_TOLERANCE` / `EXPORT_ANGULAR_TOLERANCE` so the faceGroups
+ * captured at generation time line up with the triangles `exportSTL` emits
+ * (brepjs caches `mesh()` by shape+tolerance — diverging here would silently
+ * misalign per-triangle material indices in the 3MF).
  *
  * Strategy for robustness against intermittent kernel failures (GH #1339):
  *
@@ -90,19 +99,14 @@ async function runExportAttempt(
  *    preview-quality case, which my root-cause analysis for #1339 may
  *    not fully cover.
  *
- * STL: binary mesh with configurable tessellation quality
- * STEP: exact BREP geometry (lossless, CAD-interoperable)
+ * STL: binary mesh at the fixed export tolerance.
+ * STEP: exact BREP geometry (lossless, CAD-interoperable).
  */
-export async function exportBin(
-  params: BinParams,
-  format: ExportFormat,
-  tolerance = 0.01,
-  angularTolerance = 5
-): Promise<ExportResult> {
+export async function exportBin(params: BinParams, format: ExportFormat): Promise<ExportResult> {
   const name = `gridfinity-${params.width}x${params.depth}x${params.height}`;
 
   try {
-    return await runExportAttempt(params, format, tolerance, angularTolerance, name);
+    return await runExportAttempt(params, format, name);
   } catch (firstError) {
     // Discard any cached state and try once more with a completely fresh
     // solid. If this second attempt also fails, rethrow the second error
@@ -110,7 +114,7 @@ export async function exportBin(
     // fresh-solid path gives us the cleanest diagnostic stack.
     setLastSolid(null);
     try {
-      return await runExportAttempt(params, format, tolerance, angularTolerance, name);
+      return await runExportAttempt(params, format, name);
     } catch (retryError) {
       // Attach context about the first failure so telemetry can see both.
       if (retryError instanceof Error && firstError instanceof Error) {

--- a/src/features/generation/worker/generators/meshUtils.test.ts
+++ b/src/features/generation/worker/generators/meshUtils.test.ts
@@ -82,26 +82,27 @@ describe('toIndexedMeshData', () => {
 });
 
 describe('toIndexedMeshData faceGroups', () => {
-  it('passes through faceGroups mapped via originToTag', () => {
+  it('uses brepjs-propagated origin as the FeatureTag', () => {
     const meshResult = {
       vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
       normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
       triangles: new Uint32Array([0, 1, 2]),
-      faceGroups: [{ start: 0, count: 3, faceId: 1, origin: 42 }],
+      // `setShapeOrigin(shape, FeatureTag.SCOOP=1)` propagates origin=1 onto
+      // every face of the resulting solid.
+      faceGroups: [{ start: 0, count: 3, faceId: 1, origin: 1 }],
     };
-    const originToTag = new Map([[42, 2]]); // origin 42 -> SCOOP (2)
-    const result = toIndexedMeshData(meshResult, undefined, originToTag);
-    expect(result.faceGroups).toEqual([{ start: 0, count: 3, tag: 2 }]);
+    const result = toIndexedMeshData(meshResult);
+    expect(result.faceGroups).toEqual([{ start: 0, count: 3, tag: 1 }]);
   });
 
-  it('uses UNKNOWN tag when originToTag is undefined', () => {
+  it('treats origin=0 as UNKNOWN (brepjs default when no setShapeOrigin was called)', () => {
     const meshResult = {
       vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
       normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
       triangles: new Uint32Array([0, 1, 2]),
-      faceGroups: [{ start: 0, count: 3, faceId: 1, origin: 99 }],
+      faceGroups: [{ start: 0, count: 3, faceId: 1, origin: 0 }],
     };
-    const result = toIndexedMeshData(meshResult, undefined, undefined);
+    const result = toIndexedMeshData(meshResult);
     expect(result.faceGroups).toEqual([{ start: 0, count: 3, tag: 255 }]);
   });
 

--- a/src/features/generation/worker/generators/meshUtils.test.ts
+++ b/src/features/generation/worker/generators/meshUtils.test.ts
@@ -87,9 +87,7 @@ describe('toIndexedMeshData faceGroups', () => {
       vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
       normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
       triangles: new Uint32Array([0, 1, 2]),
-      // `setShapeOrigin(shape, FeatureTag.SCOOP=1)` propagates origin=1 onto
-      // every face of the resulting solid.
-      faceGroups: [{ start: 0, count: 3, faceId: 1, origin: 1 }],
+      faceGroups: [{ start: 0, count: 3, faceId: 1, origin: 1 /* FeatureTag.SCOOP */ }],
     };
     const result = toIndexedMeshData(meshResult);
     expect(result.faceGroups).toEqual([{ start: 0, count: 3, tag: 1 }]);

--- a/src/features/generation/worker/generators/pipeline/collectOrigins.test.ts
+++ b/src/features/generation/worker/generators/pipeline/collectOrigins.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { Shape3D } from 'brepjs';
+import type * as CollectOriginsModule from './collectOrigins';
+import { FeatureTag } from '../featureTags';
+
+type BoxFn = (xLen: number, yLen: number, zLen: number) => Shape3D;
+type GetFaceOriginsFn = (shape: Shape3D) => ReadonlyMap<number, number> | undefined;
+type FuseFn = (a: Shape3D, b: Shape3D) => unknown;
+type TranslateFn = (shape: Shape3D, v: [number, number, number]) => Shape3D;
+
+let collectOrigins: typeof CollectOriginsModule.collectOrigins;
+let box: BoxFn;
+let getFaceOrigins: GetFaceOriginsFn;
+let fuse: FuseFn;
+let translate: TranslateFn;
+let unwrap: <T>(r: { value: T } | T) => T;
+
+beforeAll(async () => {
+  const brepjs = await import('brepjs');
+  const opencascade = (await import('brepjs-opencascade/src/brepjs_single.js')).default;
+  const { readFileSync } = await import('fs');
+  const { join } = await import('path');
+
+  const wasmPath = join(process.cwd(), 'node_modules/brepjs-opencascade/src/brepjs_single.wasm');
+  const wasmBinary = readFileSync(wasmPath);
+  const OC = await opencascade({ wasmBinary });
+  brepjs.initFromOC(OC);
+
+  collectOrigins = (await import('./collectOrigins')).collectOrigins;
+  box = brepjs.box;
+  getFaceOrigins = brepjs.getFaceOrigins;
+  fuse = brepjs.fuse;
+  translate = brepjs.translate;
+  unwrap = brepjs.unwrap as unknown as typeof unwrap;
+}, 30000);
+
+describe('collectOrigins', () => {
+  it('tags every face of the shape with the provided FeatureTag', () => {
+    const shape = box(10, 10, 10);
+    collectOrigins(shape, FeatureTag.LIP, new Map());
+
+    const origins = getFaceOrigins(shape);
+    expect(origins).toBeDefined();
+    expect(origins!.size).toBe(6); // a box has six faces
+    for (const value of origins!.values()) {
+      expect(value).toBe(FeatureTag.LIP);
+    }
+  });
+
+  it('propagates origins through a boolean fuse', () => {
+    // Two boxes tagged distinctly. After fuse, faces inherited from each
+    // input must still report the input's tag — this is the invariant the
+    // multi-color pipeline relies on.
+    const base = box(20, 20, 10);
+    const lipBase = box(20, 20, 4);
+    const top = translate(lipBase, [0, 0, 10]);
+
+    collectOrigins(base, FeatureTag.BASE, new Map());
+    collectOrigins(top, FeatureTag.LIP, new Map());
+
+    const fused = unwrap(fuse(base, top)) as Shape3D;
+    const origins = getFaceOrigins(fused);
+    expect(origins).toBeDefined();
+
+    const tags = new Set(origins!.values());
+    // Boolean fuse over BASE=0 yields origin=0 for those faces, which we
+    // treat as untagged downstream — LIP must still be present.
+    expect(tags.has(FeatureTag.LIP)).toBe(true);
+  });
+});

--- a/src/features/generation/worker/generators/pipeline/collectOrigins.test.ts
+++ b/src/features/generation/worker/generators/pipeline/collectOrigins.test.ts
@@ -2,18 +2,24 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import type { Shape3D } from 'brepjs';
 import type * as CollectOriginsModule from './collectOrigins';
+import type * as ShapeCacheModule from '../shapeCache';
 import { FeatureTag } from '../featureTags';
 
 type BoxFn = (xLen: number, yLen: number, zLen: number) => Shape3D;
 type GetFaceOriginsFn = (shape: Shape3D) => ReadonlyMap<number, number> | undefined;
 type FuseFn = (a: Shape3D, b: Shape3D) => unknown;
 type TranslateFn = (shape: Shape3D, v: [number, number, number]) => Shape3D;
+type MeasureVolumeFn = (shape: Shape3D) => number;
 
 let collectOrigins: typeof CollectOriginsModule.collectOrigins;
+let setShellCache: typeof ShapeCacheModule.setShellCache;
+let getShellCache: typeof ShapeCacheModule.getShellCache;
+let clearAllCaches: typeof ShapeCacheModule.clearAllCaches;
 let box: BoxFn;
 let getFaceOrigins: GetFaceOriginsFn;
 let fuse: FuseFn;
 let translate: TranslateFn;
+let measureVolume: MeasureVolumeFn;
 let unwrap: <T>(r: { value: T } | T) => T;
 
 beforeAll(async () => {
@@ -28,10 +34,15 @@ beforeAll(async () => {
   brepjs.initFromOC(OC);
 
   collectOrigins = (await import('./collectOrigins')).collectOrigins;
+  const shapeCache = await import('../shapeCache');
+  setShellCache = shapeCache.setShellCache;
+  getShellCache = shapeCache.getShellCache;
+  clearAllCaches = shapeCache.clearAllCaches;
   box = brepjs.box;
   getFaceOrigins = brepjs.getFaceOrigins;
   fuse = brepjs.fuse;
   translate = brepjs.translate;
+  measureVolume = brepjs.measureVolume;
   unwrap = brepjs.unwrap as unknown as typeof unwrap;
 }, 30000);
 
@@ -67,5 +78,41 @@ describe('collectOrigins', () => {
     // Boolean fuse over BASE=0 yields origin=0 for those faces, which we
     // treat as untagged downstream — LIP must still be present.
     expect(tags.has(FeatureTag.LIP)).toBe(true);
+  });
+});
+
+describe('shell cache preserves face origins', () => {
+  // Pins the load-bearing invariant of the multi-color fix: `getShellCache`
+  // returns a `translate([0,0,0])` clone (not a plain `clone()`) so origins
+  // survive the cache hit. If brepjs changes `translate`'s metadata behavior
+  // or someone "simplifies" the cache to use `clone()`, this catches it.
+  it('survives a setShellCache/getShellCache round-trip', () => {
+    clearAllCaches();
+
+    const base = box(20, 20, 10);
+    const lipBase = box(20, 20, 4);
+    const top = translate(lipBase, [0, 0, 10]);
+    collectOrigins(base, FeatureTag.BASE, new Map());
+    collectOrigins(top, FeatureTag.LIP, new Map());
+    const fused = unwrap(fuse(base, top)) as Shape3D;
+
+    setShellCache('test-shell-key', fused);
+    const retrieved = getShellCache('test-shell-key');
+    expect(retrieved).not.toBeNull();
+
+    const origins = getFaceOrigins(retrieved!);
+    expect(origins).toBeDefined();
+    const tags = new Set(origins!.values());
+    expect(tags.has(FeatureTag.LIP)).toBe(true);
+  });
+
+  it('translate([0,0,0]) preserves the source volume', () => {
+    // Pins the geometric equivalence of the clone-replacement: the
+    // `flat base no lip` scenario re-tessellated to fewer triangles after
+    // the switch (252 → 204). Volume parity confirms that's a meshing
+    // change, not a topology regression.
+    const source = box(42, 42, 21);
+    const copy = translate(source, [0, 0, 0]);
+    expect(unwrap(measureVolume(copy))).toBeCloseTo(unwrap(measureVolume(source)), 3);
   });
 });

--- a/src/features/generation/worker/generators/pipeline/collectOrigins.ts
+++ b/src/features/generation/worker/generators/pipeline/collectOrigins.ts
@@ -1,22 +1,13 @@
 /**
- * Face provenance collector.
+ * Tags every face of `shape` with `tag` via brepjs `setShapeOrigin`. The tag
+ * lives in a WeakMap keyed by the shape's wrapped WASM handle and propagates
+ * through booleans (fuse/cut) and transforms, so faces in the final solid
+ * still report the tag of the input shape that contributed them. Without
+ * this call `getFaceOrigins` returns 0 for every face and all colors collapse
+ * to one. Read-back happens in `toIndexedMeshData`.
  *
- * Tags every face of `shape` with `tag` using brepjs's `setShapeOrigin`, which
- * stores the tag in a WeakMap keyed by the shape's wrapped WASM handle. The
- * kernel propagates these origins through boolean ops (fuse / cut) and
- * transforms (translate / rotate) automatically, so faces in the final fused
- * solid still report the tag of whichever input shape contributed them.
- *
- * Why: a face group's `origin` field comes from `getFaceOrigins(shape)`, which
- * is empty unless `setShapeOrigin` was called on the shape (or an ancestor).
- * Without this call the origin defaults to 0 for every face, and downstream
- * tag lookup collapses to whichever feature ran last — every face gets the
- * same color. The legacy implementation walked face groups and stored their
- * origins in a map, but since every origin was 0 the map only ever held one
- * entry. See `toIndexedMeshData` for how the propagated origin is read back.
- *
- * The `map` parameter is kept for call-site compatibility with the pipeline
- * context (and used as a session-scoped sanity-check that the tag was set).
+ * `map` is vestigial — kept on the signature so every pipeline call site
+ * doesn't have to change. Removing it from `PipelineContext` is a follow-up.
  */
 
 import { setShapeOrigin } from 'brepjs';

--- a/src/features/generation/worker/generators/pipeline/collectOrigins.ts
+++ b/src/features/generation/worker/generators/pipeline/collectOrigins.ts
@@ -14,7 +14,6 @@ import { setShapeOrigin } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import type { FeatureTag } from '../featureTags';
 
-export function collectOrigins(shape: Shape3D, tag: FeatureTag, map: Map<number, number>): void {
+export function collectOrigins(shape: Shape3D, tag: FeatureTag, _map: Map<number, number>): void {
   setShapeOrigin(shape, tag);
-  map.set(tag, tag);
 }

--- a/src/features/generation/worker/generators/pipeline/collectOrigins.ts
+++ b/src/features/generation/worker/generators/pipeline/collectOrigins.ts
@@ -1,43 +1,29 @@
 /**
  * Face provenance collector.
  *
- * Uses a fast low-fidelity mesh to discover which BREP face origins
- * belong to a given feature, recording them in the originToTag map.
+ * Tags every face of `shape` with `tag` using brepjs's `setShapeOrigin`, which
+ * stores the tag in a WeakMap keyed by the shape's wrapped WASM handle. The
+ * kernel propagates these origins through boolean ops (fuse / cut) and
+ * transforms (translate / rotate) automatically, so faces in the final fused
+ * solid still report the tag of whichever input shape contributed them.
  *
- * Uses "last writer wins" — features that run later (lip, label tab)
- * override the base body tag on shared/fused faces. This ensures
- * feature-specific colors take priority over the generic body color.
+ * Why: a face group's `origin` field comes from `getFaceOrigins(shape)`, which
+ * is empty unless `setShapeOrigin` was called on the shape (or an ancestor).
+ * Without this call the origin defaults to 0 for every face, and downstream
+ * tag lookup collapses to whichever feature ran last — every face gets the
+ * same color. The legacy implementation walked face groups and stored their
+ * origins in a map, but since every origin was 0 the map only ever held one
+ * entry. See `toIndexedMeshData` for how the propagated origin is read back.
+ *
+ * The `map` parameter is kept for call-site compatibility with the pipeline
+ * context (and used as a session-scoped sanity-check that the tag was set).
  */
 
-import { mesh } from 'brepjs';
+import { setShapeOrigin } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import type { FeatureTag } from '../featureTags';
 
-/** Whether we've already logged the missing-origin warning this session. */
-let originWarningLogged = false;
-
-/**
- * Collect face origin IDs from a shape using a fast low-fidelity mesh.
- * Maps each unique origin to the given FeatureTag (overwrites existing tags).
- */
 export function collectOrigins(shape: Shape3D, tag: FeatureTag, map: Map<number, number>): void {
-  const m = mesh(shape, { tolerance: 5, angularTolerance: 45 });
-
-  for (const fg of m.faceGroups) {
-    const origin = (fg as { origin?: number }).origin;
-
-    if (origin === undefined) {
-      // Runtime guard: brepjs API may change and stop exposing origin field
-      if (!originWarningLogged) {
-        console.warn(
-          '[collectOrigins] face group missing origin field — color tagging may be incorrect'
-        );
-        originWarningLogged = true;
-      }
-      continue;
-    }
-
-    // Last writer wins: feature tags override base/shell tags
-    map.set(origin, tag);
-  }
+  setShapeOrigin(shape, tag);
+  map.set(tag, tag);
 }

--- a/src/features/generation/worker/generators/pipeline/featureRunner.ts
+++ b/src/features/generation/worker/generators/pipeline/featureRunner.ts
@@ -70,6 +70,11 @@ export function runFeatureBuilders(
     }
 
     if (shape) {
+      // `clone()` drops the face-origin WeakMap (shellCache uses
+      // `translate([0,0,0])` for that reason), but here it's safe because
+      // `collectOrigins` re-tags the freshly cloned shape on every
+      // iteration — including cache hits. Don't move this call out of
+      // the loop or feature colors will silently collapse.
       collectOrigins(shape, builder.tag, ctx.originToTag);
       bucketMap[builder.target].push(shape);
     }

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -30,7 +30,9 @@ export const shellStage: PipelineStage = {
   execute(ctx: PipelineContext): PipelineContext {
     const { params, dimensions: dim, signal, onProgress, originToTag } = ctx;
 
-    // Check cache first
+    // Check cache first. `getShellCache` returns a metadata-preserving
+    // clone (via a zero-vector translate) so face origins survive the
+    // cache hit and multi-color tags reach the final mesh.
     const cachedShell = getShellCache(dim.shellKey);
     if (cachedShell) {
       return { ...ctx, solid: cachedShell };

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -8,7 +8,7 @@
  * context holds a mutable copy.
  */
 
-import { unwrap, fuse, clone, translate, withScope } from 'brepjs';
+import { unwrap, fuse, translate, withScope } from 'brepjs';
 import type { DisposalScope } from 'brepjs';
 import type { PipelineContext, PipelineStage } from '../types';
 import { checkCancelled, isAbortError } from '../../utils/abort';
@@ -135,6 +135,9 @@ export const shellStage: PipelineStage = {
 
     setShellCache(dim.shellKey, bin);
 
-    return { ...ctx, solid: unwrap(clone(bin)) };
+    // Mirror the cache-hit path: a zero-vector translate is the cheapest
+    // brepjs op that preserves face-origin metadata through a copy. Plain
+    // `clone()` would drop the WeakMap and break multi-color on first render.
+    return { ...ctx, solid: translate(bin, [0, 0, 0]) };
   },
 };

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -30,9 +30,8 @@ export const shellStage: PipelineStage = {
   execute(ctx: PipelineContext): PipelineContext {
     const { params, dimensions: dim, signal, onProgress, originToTag } = ctx;
 
-    // Check cache first. `getShellCache` returns a metadata-preserving
-    // clone (via a zero-vector translate) so face origins survive the
-    // cache hit and multi-color tags reach the final mesh.
+    // `getShellCache` returns a metadata-preserving clone so face-origin
+    // tags survive the cache hit (see `getShellCache` for the mechanism).
     const cachedShell = getShellCache(dim.shellKey);
     if (cachedShell) {
       return { ...ctx, solid: cachedShell };

--- a/src/features/generation/worker/generators/shapeCache.ts
+++ b/src/features/generation/worker/generators/shapeCache.ts
@@ -134,13 +134,11 @@ export const setLipCache = lip.set;
 export function getShellCache(key: string): Shape3D | null {
   const cached = shellCache.get(key);
   if (cached === undefined) return null;
-  // `clone()` is a kernel downcast that rewraps the same topology with a
-  // new JS Shape — the face-origin WeakMap (keyed by `.wrapped`) does not
-  // follow. A zero-vector `translate` is the cheapest brepjs op that
-  // _does_ propagate metadata (it goes through `translateWithHistory` and
-  // calls `propagateAllMetadata` on the result), so we use it as a
-  // metadata-preserving clone. Without this every face downstream reads
-  // `origin = 0` and the multi-color preview collapses to one material.
+  // `clone()` rewraps the topology in a new JS Shape, but the face-origin
+  // WeakMap is keyed by `.wrapped` and does not follow. A zero-vector
+  // `translate` goes through `translateWithHistory` and calls
+  // `propagateAllMetadata`, giving us a metadata-preserving clone — without
+  // this the multi-color preview collapses to a single material.
   return translate(cached, [0, 0, 0]);
 }
 

--- a/src/features/generation/worker/generators/shapeCache.ts
+++ b/src/features/generation/worker/generators/shapeCache.ts
@@ -16,7 +16,7 @@
  * - patternTemplateCache: pattern shape template (single-entry, cheap to rebuild)
  */
 
-import { clone, unwrap } from 'brepjs';
+import { clone, translate, unwrap } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import type { CacheStats } from './lruCache';
 import { LRUCache } from './lruCache';
@@ -132,7 +132,16 @@ export const getLipCache = lip.get;
 export const setLipCache = lip.set;
 
 export function getShellCache(key: string): Shape3D | null {
-  return cloneFromCache(shellCache, key);
+  const cached = shellCache.get(key);
+  if (cached === undefined) return null;
+  // `clone()` is a kernel downcast that rewraps the same topology with a
+  // new JS Shape — the face-origin WeakMap (keyed by `.wrapped`) does not
+  // follow. A zero-vector `translate` is the cheapest brepjs op that
+  // _does_ propagate metadata (it goes through `translateWithHistory` and
+  // calls `propagateAllMetadata` on the result), so we use it as a
+  // metadata-preserving clone. Without this every face downstream reads
+  // `origin = 0` and the multi-color preview collapses to one material.
+  return translate(cached, [0, 0, 0]);
 }
 
 export function setShellCache(key: string, shape: Shape3D): void {

--- a/src/features/generation/worker/generators/utils/mesh.ts
+++ b/src/features/generation/worker/generators/utils/mesh.ts
@@ -1,24 +1,13 @@
-/**
- * Mesh conversion utilities for the generation pipeline.
- *
- * Converts brepjs mesh data to the indexed MeshData format
- * used by the Three.js renderer.
- */
-
 import type { MeshData } from '../../../bridge/types';
 
 /**
- * Convert brepjs indexed mesh to our MeshData format, keeping indexed representation.
+ * Convert brepjs indexed mesh to our MeshData format. Each face group's
+ * `origin` is the FeatureTag stamped by `collectOrigins`/`setShapeOrigin` and
+ * propagated through booleans. Origin `0` is brepjs's default for untagged
+ * faces and must map to UNKNOWN — FeatureTag.BASE also equals 0, so we lose
+ * the distinction between "tagged BASE" and "untagged" by design.
  *
- * The `origin` field on each face group is the FeatureTag set via
- * `setShapeOrigin` on the source shape (see `collectOrigins`). Origins
- * propagate through fuses/cuts/transforms, so faces in the final solid still
- * report the tag of whichever feature shape contributed them. A `0` origin
- * means brepjs returned the default — treat it as UNKNOWN to avoid silently
- * coloring untagged faces with FeatureTag.BASE (which also happens to be 0).
- *
- * @param meshResult brepjs mesh with indexed vertices/normals/triangles
- * @param originToTag unused; retained for call-site compatibility
+ * `_originToTag` is unused; kept positionally so callers don't churn.
  */
 export function toIndexedMeshData(
   meshResult: {

--- a/src/features/generation/worker/generators/utils/mesh.ts
+++ b/src/features/generation/worker/generators/utils/mesh.ts
@@ -10,7 +10,15 @@ import type { MeshData } from '../../../bridge/types';
 /**
  * Convert brepjs indexed mesh to our MeshData format, keeping indexed representation.
  *
+ * The `origin` field on each face group is the FeatureTag set via
+ * `setShapeOrigin` on the source shape (see `collectOrigins`). Origins
+ * propagate through fuses/cuts/transforms, so faces in the final solid still
+ * report the tag of whichever feature shape contributed them. A `0` origin
+ * means brepjs returned the default — treat it as UNKNOWN to avoid silently
+ * coloring untagged faces with FeatureTag.BASE (which also happens to be 0).
+ *
  * @param meshResult brepjs mesh with indexed vertices/normals/triangles
+ * @param originToTag unused; retained for call-site compatibility
  */
 export function toIndexedMeshData(
   meshResult: {
@@ -20,12 +28,12 @@ export function toIndexedMeshData(
     faceGroups?: ReadonlyArray<{ start: number; count: number; faceId: number; origin?: number }>;
   },
   edgeVertices?: ArrayLike<number>,
-  originToTag?: ReadonlyMap<number, number>
+  _originToTag?: ReadonlyMap<number, number>
 ): MeshData {
   const faceGroups = meshResult.faceGroups?.map((g) => ({
     start: g.start,
     count: g.count,
-    tag: (g.origin !== undefined ? originToTag?.get(g.origin) : undefined) ?? 255, // FeatureTag.UNKNOWN
+    tag: g.origin !== undefined && g.origin !== 0 ? g.origin : 255, // FeatureTag.UNKNOWN
   }));
 
   const toFloat32Array = (data: ArrayLike<number>): Float32Array =>

--- a/src/features/generation/worker/generators/utils/tolerances.ts
+++ b/src/features/generation/worker/generators/utils/tolerances.ts
@@ -11,6 +11,16 @@ export interface TessellationTolerances {
 }
 
 /**
+ * Single source of truth for the tessellation quality used by every export
+ * pass. `generateBin(_, _, forExport=true)` and `exportSTL` must walk the
+ * same `mesh()` (brepjs caches by shape+tolerance), otherwise the
+ * per-triangle faceGroups captured at generation time misalign with the
+ * triangles `exportSTL` writes.
+ */
+export const EXPORT_TOLERANCE = 0.01;
+export const EXPORT_ANGULAR_TOLERANCE = 5;
+
+/**
  * Select tessellation tolerances based on export mode and bin dimensions.
  *
  * Quality tiers:
@@ -25,7 +35,7 @@ export function computeTessellationTolerances(
   maxDimension: number
 ): TessellationTolerances {
   if (forExport) {
-    return { tolerance: 0.01, angularTolerance: 5 };
+    return { tolerance: EXPORT_TOLERANCE, angularTolerance: EXPORT_ANGULAR_TOLERANCE };
   }
   if (hasLip) {
     return {

--- a/src/features/generation/worker/handlers/exportHandler.ts
+++ b/src/features/generation/worker/handlers/exportHandler.ts
@@ -29,12 +29,7 @@ export async function handleExport(message: ExportMessage): Promise<void> {
     payload.requestId,
     'EXPORT_RESULT',
     async () => {
-      const result = await exportBin(
-        payload.params,
-        payload.format,
-        payload.tolerance,
-        payload.angularTolerance
-      );
+      const result = await exportBin(payload.params, payload.format);
       return {
         data: result.data,
         format: payload.format,
@@ -98,8 +93,11 @@ export async function handleExportCombined(message: ExportCombinedMessage): Prom
     requestId,
     'COMBINED_EXPORT_RESULT',
     async () => {
-      // Export the bin first (regenerates solid if needed)
-      const binResult = await exportBin(params, format, tolerance, angularTolerance);
+      // Export the bin first (regenerates solid if needed). exportBin runs
+      // at the fixed export tolerance; the explicit `tolerance` /
+      // `angularTolerance` from the payload still flow into divider and lid
+      // exports below which carry their own tessellation knobs.
+      const binResult = await exportBin(params, format);
 
       const hasDividers =
         params.style === 'slotted' && (params.slotConfig.x.enabled || params.slotConfig.y.enabled);


### PR DESCRIPTION
## Summary

The multi-color bin designer (`multi_color_export` Labs flag) collapsed every face to a single material — changing the lip color recolored the entire bin and changing the body color did nothing. Same bug in the 3MF export.

## Root cause

`collectOrigins(shape, tag, map)` was reading `mesh().faceGroups[].origin` and writing it to a `Map<origin, tag>`. But brepjs returns `origin=0` for every face unless `setShapeOrigin` has been called on the shape — and nothing in the codebase ever did. Every `map.set(0, tag)` overwrote the previous entry, so the final lookup yielded whichever feature ran last (LIP). The "last writer wins" comment hid the fact that the map only ever held one entry.

## Fix

- `collectOrigins.ts` — replaced the mesh-walk with `setShapeOrigin(shape, tag)`. The kernel propagates origins through `fuse`/`cut`/`translate` via `ShapeEvolution`, so faces in the final solid carry the tag of whichever feature shape contributed them.
- `utils/mesh.ts` — `toIndexedMeshData` reads `origin` directly as the tag, mapping `0` to UNKNOWN so untagged faces don't masquerade as `FeatureTag.BASE=0`.
- `shapeCache.ts` — `getShellCache` uses `translate(cached, [0,0,0])` instead of `clone()`. `clone` is a kernel downcast that rewraps the topology with a new JS object, dropping the face-origin WeakMap. A zero-vector translate routes through `translateWithHistory` and `propagateAllMetadata`, the cheapest brepjs op that preserves metadata across copies.
- `binExporter.ts` — `runExportAttempt` captures `faceGroups` from `generateBin`'s meshData (when regenerating) or re-meshes the cached solid at export tolerances (when reusing), so 3MF basematerials get the right per-triangle pids.

## Visual

| Before (lip → pink) | After (body → blue, lip → pink) |
| --- | --- |
| Entire bin recolored | Pink lip rim on blue body |

## Test plan

- [x] All 10,964 unit tests pass
- [x] New Playwright E2E `e2e/bin-designer/multi-color-export.spec.ts` downloads a 3MF, unzips it, and asserts `<basematerials>` lists both chosen hex colors AND at least two distinct `p1` indices appear across `<triangle>` elements
- [x] Manual visual: lip rim is pink while body is blue (side + isometric views)
- [x] Typecheck + lint clean