### PR TITLE
test(bin-designer): pin multi-color 3D preview with visual regression

### DIFF
--- a/e2e/bin-designer/multi-color-preview.spec.ts
+++ b/e2e/bin-designer/multi-color-preview.spec.ts
@@ -17,19 +17,9 @@ const LABS_KEY = 'gridfinity-labs-v1';
 const LAB_FLAG = 'multi_color_export';
 const BODY_HEX = '#00aaff';
 const LIP_HEX = '#ff0066';
-
-function hexToRgb(hex: string): [number, number, number] {
-  const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
-  if (!m) throw new Error(`bad hex: ${hex}`);
-  return [parseInt(m[1]!, 16), parseInt(m[2]!, 16), parseInt(m[3]!, 16)];
-}
-
-function rgbDistSq(
-  a: readonly [number, number, number],
-  b: readonly [number, number, number]
-): number {
-  return (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2;
-}
+const PER_CHANNEL_TOLERANCE = 64;
+// 0.25% of pixels ≈ a 48×48 block on a 1280×720 canvas
+const MIN_PIXEL_RATIO = 0.0025;
 
 test.describe('Bin Designer — multi-color 3D preview', () => {
   test.beforeEach(async ({ page }) => {
@@ -71,57 +61,88 @@ test.describe('Bin Designer — multi-color 3D preview', () => {
       });
     }
 
-    // Allow worker regeneration + frame paint after color change
-    await page.waitForTimeout(2500);
-
-    // Read pixels from the WebGL canvas via an offscreen 2D context. WebGL
-    // canvases can't expose getImageData directly; routing through a 2D
-    // canvas lets us inspect the framebuffer without server-side PNG decoding.
-    const pixelStats = await page.evaluate(
-      ({ bodyHex, lipHex, perChannelTol, minRatio }) => {
-        const hexToRgb = (hex: string): [number, number, number] => {
-          const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
-          if (!m) throw new Error(`bad hex: ${hex}`);
-          return [parseInt(m[1]!, 16), parseInt(m[2]!, 16), parseInt(m[3]!, 16)];
-        };
-        const distSq = (a: number[], b: number[]): number =>
-          (a[0]! - b[0]!) ** 2 + (a[1]! - b[1]!) ** 2 + (a[2]! - b[2]!) ** 2;
-
-        const src = document.querySelector('canvas');
-        if (!src) throw new Error('canvas not found');
-        const w = src.width;
-        const h = src.height;
-        const off = document.createElement('canvas');
-        off.width = w;
-        off.height = h;
-        const ctx = off.getContext('2d');
-        if (!ctx) throw new Error('no 2d context');
-        ctx.drawImage(src, 0, 0);
-        const data = ctx.getImageData(0, 0, w, h).data;
-
-        const bodyRgb = hexToRgb(bodyHex);
-        const lipRgb = hexToRgb(lipHex);
-        const threshSq = 3 * perChannelTol * perChannelTol;
-        let bodyHits = 0;
-        let lipHits = 0;
-        for (let i = 0; i < data.length; i += 4) {
-          const px = [data[i]!, data[i + 1]!, data[i + 2]!];
-          if (distSq(px, bodyRgb) < threshSq) bodyHits++;
-          else if (distSq(px, lipRgb) < threshSq) lipHits++;
+    // Poll the framebuffer until both colors are present rather than sleeping
+    // a fixed interval. The first paint after the color change happens after
+    // a worker round-trip; on a slow CI runner this can be a few seconds, on
+    // a fast machine it's tens of ms. Poll fails fast on a real regression
+    // and never sleeps longer than needed.
+    await expect
+      .poll(
+        async () => sampleCanvas(page, BODY_HEX, LIP_HEX, PER_CHANNEL_TOLERANCE, MIN_PIXEL_RATIO),
+        {
+          timeout: 15000,
+          intervals: [200, 500, 1000],
+          message: 'multi-color preview never produced both body and lip pixels',
         }
-        const total = w * h;
-        return { bodyHits, lipHits, total, minHits: Math.floor(total * minRatio) };
-      },
-      { bodyHex: BODY_HEX, lipHex: LIP_HEX, perChannelTol: 64, minRatio: 0.0025 }
-    );
-
-    expect(
-      pixelStats.bodyHits,
-      `body color (${BODY_HEX}) pixel count out of ${pixelStats.total}`
-    ).toBeGreaterThan(pixelStats.minHits);
-    expect(
-      pixelStats.lipHits,
-      `lip color (${LIP_HEX}) pixel count out of ${pixelStats.total}`
-    ).toBeGreaterThan(pixelStats.minHits);
+      )
+      .toMatchObject({ bodyOk: true, lipOk: true });
   });
 });
+
+interface PixelSample {
+  bodyHits: number;
+  lipHits: number;
+  total: number;
+  minHits: number;
+  bodyOk: boolean;
+  lipOk: boolean;
+}
+
+/**
+ * Read pixels from the WebGL canvas via an offscreen 2D context — WebGL
+ * canvases can't expose getImageData directly. Returns hit counts for the
+ * body and lip colors plus boolean gates the caller polls against.
+ */
+async function sampleCanvas(
+  page: import('@playwright/test').Page,
+  bodyHex: string,
+  lipHex: string,
+  perChannelTol: number,
+  minRatio: number
+): Promise<PixelSample> {
+  return page.evaluate(
+    (args: { bodyHex: string; lipHex: string; perChannelTol: number; minRatio: number }) => {
+      const hexToRgb = (hex: string): [number, number, number] => {
+        const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+        if (!m) throw new Error(`bad hex: ${hex}`);
+        return [parseInt(m[1]!, 16), parseInt(m[2]!, 16), parseInt(m[3]!, 16)];
+      };
+      const distSq = (a: number[], b: number[]): number =>
+        (a[0]! - b[0]!) ** 2 + (a[1]! - b[1]!) ** 2 + (a[2]! - b[2]!) ** 2;
+
+      const src = document.querySelector('canvas');
+      if (!src) throw new Error('canvas not found');
+      const w = src.width;
+      const h = src.height;
+      const off = document.createElement('canvas');
+      off.width = w;
+      off.height = h;
+      const ctx = off.getContext('2d');
+      if (!ctx) throw new Error('no 2d context');
+      ctx.drawImage(src, 0, 0);
+      const data = ctx.getImageData(0, 0, w, h).data;
+
+      const bodyRgb = hexToRgb(args.bodyHex);
+      const lipRgb = hexToRgb(args.lipHex);
+      const threshSq = 3 * args.perChannelTol * args.perChannelTol;
+      let bodyHits = 0;
+      let lipHits = 0;
+      for (let i = 0; i < data.length; i += 4) {
+        const px = [data[i]!, data[i + 1]!, data[i + 2]!];
+        if (distSq(px, bodyRgb) < threshSq) bodyHits++;
+        else if (distSq(px, lipRgb) < threshSq) lipHits++;
+      }
+      const total = w * h;
+      const minHits = Math.floor(total * args.minRatio);
+      return {
+        bodyHits,
+        lipHits,
+        total,
+        minHits,
+        bodyOk: bodyHits > minHits,
+        lipOk: lipHits > minHits,
+      };
+    },
+    { bodyHex, lipHex, perChannelTol, minRatio }
+  );
+}

--- a/e2e/bin-designer/multi-color-preview.spec.ts
+++ b/e2e/bin-designer/multi-color-preview.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * Visual regression guard for the multi-color 3D preview.
+ *
+ * The existing 3MF export e2e covers the export pipeline; this covers the
+ * preview itself. After setting distinct body and lip colors, the rendered
+ * canvas must contain pixels that match (or are close to) both colors —
+ * verifying the worker→bridge→BinMesh→Three.js path produces multi-material
+ * output, not a single-color collapse.
+ *
+ * If setShapeOrigin, face-group propagation, or material wiring regresses,
+ * the lip pixels stop matching the lip hex and this test fails.
+ */
+
+import { test, expect } from '../fixtures';
+
+const LABS_KEY = 'gridfinity-labs-v1';
+const LAB_FLAG = 'multi_color_export';
+const BODY_HEX = '#00aaff';
+const LIP_HEX = '#ff0066';
+
+function hexToRgb(hex: string): [number, number, number] {
+  const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+  if (!m) throw new Error(`bad hex: ${hex}`);
+  return [parseInt(m[1]!, 16), parseInt(m[2]!, 16), parseInt(m[3]!, 16)];
+}
+
+function rgbDistSq(
+  a: readonly [number, number, number],
+  b: readonly [number, number, number]
+): number {
+  return (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2;
+}
+
+test.describe('Bin Designer — multi-color 3D preview', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(
+      ({ key, flag }) => {
+        const prefs = {
+          enabledFeatures: { [flag]: true },
+          lastModified: new Date().toISOString(),
+          version: 1,
+        };
+        try {
+          localStorage.setItem(key, JSON.stringify(prefs));
+        } catch {
+          /* visibility assertion below will fail loudly if labs init breaks */
+        }
+      },
+      { key: LABS_KEY, flag: LAB_FLAG }
+    );
+  });
+
+  test('rendered preview contains pixels matching both body and lip colors', async ({ page }) => {
+    await page.goto('/designer');
+    const canvas = page.locator('canvas').first();
+    await expect(canvas).toBeVisible({ timeout: 30000 });
+
+    for (const [label, hex] of [
+      [/^Body: /i, BODY_HEX],
+      [/^Stacking Lip: /i, LIP_HEX],
+    ] as const) {
+      const trigger = page.getByRole('button', { name: label });
+      await expect(trigger).toBeVisible({ timeout: 5000 });
+      await trigger.click();
+      const popover = page.locator('[role="dialog"]').last();
+      await popover.getByRole('textbox').first().fill(hex);
+      await page.keyboard.press('Enter');
+      await page.keyboard.press('Escape');
+      await expect(page.getByRole('button', { name: new RegExp(`${hex}$`, 'i') })).toBeVisible({
+        timeout: 5000,
+      });
+    }
+
+    // Allow worker regeneration + frame paint after color change
+    await page.waitForTimeout(2500);
+
+    // Read pixels from the WebGL canvas via an offscreen 2D context. WebGL
+    // canvases can't expose getImageData directly; routing through a 2D
+    // canvas lets us inspect the framebuffer without server-side PNG decoding.
+    const pixelStats = await page.evaluate(
+      ({ bodyHex, lipHex, perChannelTol, minRatio }) => {
+        const hexToRgb = (hex: string): [number, number, number] => {
+          const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+          if (!m) throw new Error(`bad hex: ${hex}`);
+          return [parseInt(m[1]!, 16), parseInt(m[2]!, 16), parseInt(m[3]!, 16)];
+        };
+        const distSq = (a: number[], b: number[]): number =>
+          (a[0]! - b[0]!) ** 2 + (a[1]! - b[1]!) ** 2 + (a[2]! - b[2]!) ** 2;
+
+        const src = document.querySelector('canvas');
+        if (!src) throw new Error('canvas not found');
+        const w = src.width;
+        const h = src.height;
+        const off = document.createElement('canvas');
+        off.width = w;
+        off.height = h;
+        const ctx = off.getContext('2d');
+        if (!ctx) throw new Error('no 2d context');
+        ctx.drawImage(src, 0, 0);
+        const data = ctx.getImageData(0, 0, w, h).data;
+
+        const bodyRgb = hexToRgb(bodyHex);
+        const lipRgb = hexToRgb(lipHex);
+        const threshSq = 3 * perChannelTol * perChannelTol;
+        let bodyHits = 0;
+        let lipHits = 0;
+        for (let i = 0; i < data.length; i += 4) {
+          const px = [data[i]!, data[i + 1]!, data[i + 2]!];
+          if (distSq(px, bodyRgb) < threshSq) bodyHits++;
+          else if (distSq(px, lipRgb) < threshSq) lipHits++;
+        }
+        const total = w * h;
+        return { bodyHits, lipHits, total, minHits: Math.floor(total * minRatio) };
+      },
+      { bodyHex: BODY_HEX, lipHex: LIP_HEX, perChannelTol: 64, minRatio: 0.0025 }
+    );
+
+    expect(
+      pixelStats.bodyHits,
+      `body color (${BODY_HEX}) pixel count out of ${pixelStats.total}`
+    ).toBeGreaterThan(pixelStats.minHits);
+    expect(
+      pixelStats.lipHits,
+      `lip color (${LIP_HEX}) pixel count out of ${pixelStats.total}`
+    ).toBeGreaterThan(pixelStats.minHits);
+  });
+});

--- a/src/shared/components/preview/useMeshGeometry.test.ts
+++ b/src/shared/components/preview/useMeshGeometry.test.ts
@@ -13,10 +13,14 @@ describe('useMeshGeometry', () => {
   // geometry to non-indexed; if the start/count offsets don't survive the
   // conversion, every face renders with material index 0 (body).
   describe('face group offsets', () => {
-    // Two triangles: indices 0..5 = first triangle "body" (materialIndex 0),
-    // indices 6..11 = second triangle "lip" (materialIndex 1). When the user
-    // sees an all-body bin, this end-to-end shape is what the geometry should
-    // expose so Three.js can route each triangle to the right material.
+    // Two triangles sharing an edge between v1 and v2 (a quad split on a
+    // diagonal): triangle 0 = v0,v1,v2 (body, materialIndex 0); triangle 1 =
+    // v1,v3,v2 (lip, materialIndex 1). Indices [0,1,2, 1,3,2] reference only
+    // 4 unique positions, so `toCreasedNormals` actually expands the position
+    // buffer from 4 vertices to 6 — exercising the real index→position offset
+    // remap. With 6 distinct vertices the expansion is a no-op and the test
+    // can't distinguish "groups survived in index space" from "groups
+    // survived in vertex space."
     function makeIndexed(): {
       vertices: Float32Array;
       normals: Float32Array;
@@ -24,28 +28,21 @@ describe('useMeshGeometry', () => {
       edgeVertices: Float32Array;
       faceGroups: readonly { start: number; count: number; materialIndex: number }[];
     } {
+      // prettier-ignore
       const vertices = new Float32Array([
-        0,
-        0,
-        0,
-        1,
-        0,
-        0,
-        0,
-        1,
-        0, // body triangle
-        2,
-        2,
-        0,
-        3,
-        2,
-        0,
-        2,
-        3,
-        0, // lip triangle
+        0, 0, 0, // v0
+        1, 0, 0, // v1
+        0, 1, 0, // v2
+        1, 1, 0, // v3
       ]);
-      const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]);
-      const indices = new Uint32Array([0, 1, 2, 3, 4, 5]);
+      // prettier-ignore
+      const normals = new Float32Array([
+        0, 0, 1,
+        0, 0, 1,
+        0, 0, 1,
+        0, 0, 1,
+      ]);
+      const indices = new Uint32Array([0, 1, 2, 1, 3, 2]);
       return {
         vertices,
         normals,

--- a/src/shared/components/preview/useMeshGeometry.test.ts
+++ b/src/shared/components/preview/useMeshGeometry.test.ts
@@ -1,8 +1,83 @@
 import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
 import { useMeshGeometry } from './useMeshGeometry';
 
 describe('useMeshGeometry', () => {
   it('exports a function', () => {
     expect(typeof useMeshGeometry).toBe('function');
+  });
+
+  // Regression: multi-color preview rendered as single color even though the
+  // worker produced LIP-tagged face groups (issue surfaced by user screenshot
+  // 2026-05-15). The hook adds groups *after* toCreasedNormals converts the
+  // geometry to non-indexed; if the start/count offsets don't survive the
+  // conversion, every face renders with material index 0 (body).
+  describe('face group offsets', () => {
+    // Two triangles: indices 0..5 = first triangle "body" (materialIndex 0),
+    // indices 6..11 = second triangle "lip" (materialIndex 1). When the user
+    // sees an all-body bin, this end-to-end shape is what the geometry should
+    // expose so Three.js can route each triangle to the right material.
+    function makeIndexed(): {
+      vertices: Float32Array;
+      normals: Float32Array;
+      indices: Uint32Array;
+      edgeVertices: Float32Array;
+      faceGroups: readonly { start: number; count: number; materialIndex: number }[];
+    } {
+      const vertices = new Float32Array([
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        1,
+        0, // body triangle
+        2,
+        2,
+        0,
+        3,
+        2,
+        0,
+        2,
+        3,
+        0, // lip triangle
+      ]);
+      const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]);
+      const indices = new Uint32Array([0, 1, 2, 3, 4, 5]);
+      return {
+        vertices,
+        normals,
+        indices,
+        edgeVertices: new Float32Array(0),
+        faceGroups: [
+          { start: 0, count: 3, materialIndex: 0 },
+          { start: 3, count: 3, materialIndex: 1 },
+        ],
+      };
+    }
+
+    it('preserves group offsets through toCreasedNormals (indexed → non-indexed)', () => {
+      const arrays = makeIndexed();
+      const { result } = renderHook(() => useMeshGeometry(arrays));
+      const geometry = result.current.geometry;
+      expect(geometry).not.toBeNull();
+      const groups = geometry!.groups;
+      expect(groups).toHaveLength(2);
+      expect(groups[0]).toMatchObject({ start: 0, count: 3, materialIndex: 0 });
+      expect(groups[1]).toMatchObject({ start: 3, count: 3, materialIndex: 1 });
+    });
+
+    it('keeps the geometry drawable: each group range fits inside the position buffer', () => {
+      const arrays = makeIndexed();
+      const { result } = renderHook(() => useMeshGeometry(arrays));
+      const geometry = result.current.geometry;
+      expect(geometry).not.toBeNull();
+      const posCount = geometry!.attributes['position']!.count;
+      for (const g of geometry!.groups) {
+        expect(g.start + g.count).toBeLessThanOrEqual(posCount);
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

- A user-reported screenshot showed the bin preview rendering as a single color even after #1662 fixed the multi-color export pipeline. Ran the same scenario through Playwright in current main: the preview **does** render correctly (blue body + pink lip, both present in the framebuffer). The original report was almost certainly a stale PWA bundle from before #1662 landed.
- Adds two pieces of test coverage so the next regression is caught at PR time, not via a user screenshot:
  - **\`useMeshGeometry.test.ts\`** — replaces the placeholder (\"exports a function\") with real assertions. Verifies that face groups survive the indexed → non-indexed conversion that \`toCreasedNormals\` performs, and that every group range stays inside the position buffer. This was the highest-suspicion code path in the triage; the test confirms it's actually fine.
  - **\`e2e/bin-designer/multi-color-preview.spec.ts\`** — sets distinct body (\`#00aaff\`) and lip (\`#ff0066\`) colors, screenshots the canvas, and pixel-samples the framebuffer via an offscreen 2D context. Asserts both colors are present above a 0.25% pixel threshold — a roughly 48×48-pixel block of each. Tolerance is 64 per channel to accept emissive/ambient shading without losing discrimination between the two hexes.
- No production code changes. The previous \`multi-color-export.spec.ts\` covers the 3MF export path; this fills the gap for the 3D preview path that the original screenshot was about.

## Test plan

- [x] \`pnpm exec vitest run src/shared/components/preview/useMeshGeometry.test.ts\` — 3 passed
- [x] \`pnpm exec playwright test e2e/bin-designer/multi-color-preview.spec.ts --project=chromium\` — passed in 7.3s
- [ ] After merge: confirm both new tests run in CI on next PR