### PR TITLE
fix(sync,csp): unblock design sync + tighten CSP for fonts and inline scripts

### DIFF
--- a/api/lib/designerValidation.test.ts
+++ b/api/lib/designerValidation.test.ts
@@ -488,6 +488,27 @@ describe('validateDesignerShare', () => {
       expect(result.valid).toBe(true);
     });
 
+    // The client `migrateParams` backfills `featureColors.enabled` on every
+    // load (see `defaults.ts:230`), so every synced design carries this key.
+    // The validator must accept it or every design sync fails with 400.
+    it('accepts the multi-color enabled toggle', () => {
+      const result = withColors({ enabled: true, body: '#3b82f6' });
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts enabled: false', () => {
+      const result = withColors({ enabled: false, body: '#3b82f6' });
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects non-boolean enabled', () => {
+      const result = withColors({ enabled: 'yes', body: '#3b82f6' });
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.message).toMatch(/enabled/);
+      }
+    });
+
     it('accepts the legacy lip:string shape', () => {
       const result = withColors({ body: '#3b82f6', lip: '#ff0000' });
       expect(result.valid).toBe(true);

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -338,6 +338,7 @@ function isValidColor(v: unknown): boolean {
 
 const LIP_CORNERS = ['frontLeft', 'frontRight', 'backRight', 'backLeft'] as const;
 const ALLOWED_FEATURE_COLOR_KEYS = new Set([
+  'enabled',
   'body',
   'lip',
   'labelTab',
@@ -360,6 +361,10 @@ function validateFeatureColors(value: unknown): string | null {
     if (!ALLOWED_FEATURE_COLOR_KEYS.has(key)) {
       return `featureColors has unknown key: ${key}`;
     }
+  }
+
+  if (value.enabled !== undefined && !isBoolean(value.enabled)) {
+    return 'featureColors.enabled must be boolean';
   }
 
   for (const key of ['body', 'labelTab', 'base', 'scoop', 'dividers'] as const) {

--- a/api/lib/validation.test.ts
+++ b/api/lib/validation.test.ts
@@ -183,6 +183,20 @@ describe('validateShareLayout', () => {
 
       expect(result.valid).toBe(true);
     });
+
+    // Without these guards, a malicious payload like `{ label: 42 }` would
+    // reach `sanitizeString` (which calls `.replace`) and crash the route
+    // with a 500 instead of a clean 400.
+    it.each([
+      ['label', 42],
+      ['notes', { evil: true }],
+      ['category', ['nope']],
+    ])('rejects bins where %s is not a string', (field, badValue) => {
+      const layout = createValidLayout();
+      (layout.bins[0] as unknown as Record<string, unknown>)[field] = badValue;
+      const result = validateShareLayout(layout, 1000);
+      expect(result.valid).toBe(false);
+    });
   });
 
   describe('drawer dimensions', () => {
@@ -319,7 +333,7 @@ describe('validateShareLayout', () => {
 
       expect(result.valid).toBe(true);
       if (result.valid) {
-        expect(result.layout.bins[0].label!.length).toBe(24);
+        expect(result.layout.bins[0].label.length).toBe(24);
       }
     });
 
@@ -330,7 +344,7 @@ describe('validateShareLayout', () => {
 
       expect(result.valid).toBe(true);
       if (result.valid) {
-        expect(result.layout.bins[0].notes!.length).toBe(256);
+        expect(result.layout.bins[0].notes.length).toBe(256);
       }
     });
 

--- a/api/lib/validation.ts
+++ b/api/lib/validation.ts
@@ -68,8 +68,12 @@ interface BinShape {
   depth: number;
   height: number;
   category?: string;
-  label?: string;
-  notes?: string;
+  // `label` and `notes` are always strings (empty when absent) so the cloud
+  // contract matches the local `Bin` invariant. Without this the 3D view
+  // would crash on `bin.notes.trim()` for any synced layout, since the
+  // consumer trusts the static type.
+  label: string;
+  notes: string;
   customProperties?: Record<string, string>;
 }
 
@@ -283,8 +287,8 @@ export function validateShareLayout(data: unknown, jsonSize: number): Validation
       depth: bin.depth,
       height: bin.height,
       category: bin.category ? sanitizeString(bin.category, 64) : undefined,
-      label: bin.label ? sanitizeString(bin.label, SHARE_CONSTRAINTS.LABEL_MAX_LENGTH) : undefined,
-      notes: bin.notes ? sanitizeString(bin.notes, SHARE_CONSTRAINTS.NOTES_MAX_LENGTH) : undefined,
+      label: bin.label ? sanitizeString(bin.label, SHARE_CONSTRAINTS.LABEL_MAX_LENGTH) : '',
+      notes: bin.notes ? sanitizeString(bin.notes, SHARE_CONSTRAINTS.NOTES_MAX_LENGTH) : '',
       customProperties: validatedCustomProperties,
     });
   }

--- a/api/lib/validation.ts
+++ b/api/lib/validation.ts
@@ -68,10 +68,8 @@ interface BinShape {
   depth: number;
   height: number;
   category?: string;
-  // `label` and `notes` are always strings (empty when absent) so the cloud
-  // contract matches the local `Bin` invariant. Without this the 3D view
-  // would crash on `bin.notes.trim()` for any synced layout, since the
-  // consumer trusts the static type.
+  // Required (empty when absent) to match the local `Bin` invariant; the 3D
+  // view crashes on `bin.notes.trim()` if these arrive as undefined.
   label: string;
   notes: string;
   customProperties?: Record<string, string>;
@@ -359,6 +357,9 @@ function isValidLayer(value: unknown): value is LayerShape {
 
 function isValidBin(value: unknown): value is BinShape {
   if (!isObject(value)) return false;
+  // `category`/`label`/`notes` must be string-or-absent before they reach
+  // `sanitizeString`, which calls `.replace` and throws on non-strings.
+  const optString = (v: unknown): boolean => v === undefined || typeof v === 'string';
   return (
     typeof value.id === 'string' &&
     typeof value.layerId === 'string' &&
@@ -369,7 +370,10 @@ function isValidBin(value: unknown): value is BinShape {
     isNumber(value.height) &&
     value.width > 0 &&
     value.depth > 0 &&
-    value.height > 0
+    value.height > 0 &&
+    optString(value.category) &&
+    optString(value.label) &&
+    optString(value.notes)
   );
 }
 

--- a/scripts/check-csp-hashes.test.ts
+++ b/scripts/check-csp-hashes.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'fs';
+import { createHash } from 'crypto';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = join(import.meta.dirname, '..');
+
+function sha256Base64(input: string): string {
+  return createHash('sha256').update(input, 'utf8').digest('base64');
+}
+
+/**
+ * Hash every executable inline `<script>` in `index.html` and assert the
+ * `script-src` directive in `vercel.json` contains that hash.
+ *
+ * CSP inline-script hashes drift on the slightest byte change (a single
+ * whitespace edit breaks them). Without this check, edits to the theme-
+ * detection or www-migration scripts in index.html would silently start
+ * producing CSP violations in production — the policy is report-only
+ * today but is intended to be enforced later.
+ *
+ * `<script type="application/ld+json">` and `<script src="…">` blocks are
+ * intentionally skipped: only the body of an executable inline script is
+ * subject to `script-src`.
+ */
+describe('CSP inline-script hashes are in sync with vercel.json', () => {
+  const html = readFileSync(join(ROOT, 'index.html'), 'utf8');
+  const vercelConfig = readFileSync(join(ROOT, 'vercel.json'), 'utf8');
+
+  // Match <script> with no attributes (executable inline). We deliberately
+  // skip <script type="…"> (JSON-LD) and <script src="…"> (external).
+  const inlineScripts = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+  it('finds at least one inline script to verify', () => {
+    expect(inlineScripts.length).toBeGreaterThan(0);
+  });
+
+  for (const [i, body] of inlineScripts.entries()) {
+    const hash = sha256Base64(body);
+    const directive = `'sha256-${hash}'`;
+    it(`inline script #${i + 1} has matching CSP hash ${directive}`, () => {
+      expect(vercelConfig).toContain(directive);
+    });
+  }
+});

--- a/scripts/check-csp-hashes.test.ts
+++ b/scripts/check-csp-hashes.test.ts
@@ -13,10 +13,12 @@ interface VercelHeader {
   key: string;
   value: string;
 }
+
 interface VercelHeadersEntry {
   source: string;
   headers: VercelHeader[];
 }
+
 interface VercelConfig {
   headers?: VercelHeadersEntry[];
 }

--- a/scripts/check-csp-hashes.test.ts
+++ b/scripts/check-csp-hashes.test.ts
@@ -9,37 +9,75 @@ function sha256Base64(input: string): string {
   return createHash('sha256').update(input, 'utf8').digest('base64');
 }
 
+interface VercelHeader {
+  key: string;
+  value: string;
+}
+interface VercelHeadersEntry {
+  source: string;
+  headers: VercelHeader[];
+}
+interface VercelConfig {
+  headers?: VercelHeadersEntry[];
+}
+
 /**
- * Hash every executable inline `<script>` in `index.html` and assert the
- * `script-src` directive in `vercel.json` contains that hash.
- *
- * CSP inline-script hashes drift on the slightest byte change (a single
- * whitespace edit breaks them). Without this check, edits to the theme-
- * detection or www-migration scripts in index.html would silently start
- * producing CSP violations in production — the policy is report-only
- * today but is intended to be enforced later.
- *
- * `<script type="application/ld+json">` and `<script src="…">` blocks are
- * intentionally skipped: only the body of an executable inline script is
- * subject to `script-src`.
+ * Find executable inline scripts: any <script>…</script> that isn't
+ * `type="…"` (JSON-LD, module, etc.) and isn't `src="…"` (external).
+ * Case-insensitive so `<SCRIPT>` or `<script defer>` aren't silently
+ * skipped — the test exists precisely to catch what `index.html` ships.
  */
+function findInlineScripts(html: string): string[] {
+  const scripts: string[] = [];
+  for (const m of html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi)) {
+    const attrs = m[1];
+    if (/\bsrc\s*=/i.test(attrs)) continue;
+    if (/\btype\s*=/i.test(attrs)) continue;
+    scripts.push(m[2]);
+  }
+  return scripts;
+}
+
+/**
+ * Extract `script-src` source list from every CSP header (enforced and
+ * report-only) declared in vercel.json. A hash that lands in `style-src`
+ * by mistake must not satisfy the test.
+ */
+function scriptSrcDirectives(config: VercelConfig): string[] {
+  const directives: string[] = [];
+  for (const entry of config.headers ?? []) {
+    for (const header of entry.headers) {
+      if (!/^content-security-policy(-report-only)?$/i.test(header.key)) continue;
+      for (const part of header.value.split(';')) {
+        const trimmed = part.trim();
+        if (/^script-src\b/i.test(trimmed)) directives.push(trimmed);
+      }
+    }
+  }
+  return directives;
+}
+
+// CSP inline-script hashes drift on the slightest byte change. Without this
+// check, edits to the theme or www-migration scripts in index.html silently
+// produce CSP violations in production (report-only today, enforced later).
 describe('CSP inline-script hashes are in sync with vercel.json', () => {
   const html = readFileSync(join(ROOT, 'index.html'), 'utf8');
-  const vercelConfig = readFileSync(join(ROOT, 'vercel.json'), 'utf8');
-
-  // Match <script> with no attributes (executable inline). We deliberately
-  // skip <script type="…"> (JSON-LD) and <script src="…"> (external).
-  const inlineScripts = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+  const config = JSON.parse(readFileSync(join(ROOT, 'vercel.json'), 'utf8')) as VercelConfig;
+  const inlineScripts = findInlineScripts(html);
+  const scriptSrcs = scriptSrcDirectives(config);
 
   it('finds at least one inline script to verify', () => {
     expect(inlineScripts.length).toBeGreaterThan(0);
   });
 
+  it('finds at least one script-src directive in vercel.json', () => {
+    expect(scriptSrcs.length).toBeGreaterThan(0);
+  });
+
   for (const [i, body] of inlineScripts.entries()) {
-    const hash = sha256Base64(body);
-    const directive = `'sha256-${hash}'`;
-    it(`inline script #${i + 1} has matching CSP hash ${directive}`, () => {
-      expect(vercelConfig).toContain(directive);
+    const directive = `'sha256-${sha256Base64(body)}'`;
+    it(`inline script #${i + 1} has matching script-src hash ${directive}`, () => {
+      expect(scriptSrcs.some((src) => src.includes(directive))).toBe(true);
     });
   }
 });

--- a/src/core/sync/adapters/layoutAdapter.test.ts
+++ b/src/core/sync/adapters/layoutAdapter.test.ts
@@ -143,63 +143,41 @@ describe('layoutAdapter.subscribe', () => {
   });
 });
 
-/**
- * `normalizeIncomingLayout` heals legacy cloud blobs whose bins were
- * written before `api/lib/validation.ts` started emitting `notes`/`label`
- * as required strings. Without this, the 3D view crashes on `bin.notes.trim()`
- * when the user switches to a synced layout from before the contract fix.
- */
 describe('normalizeIncomingLayout', () => {
-  function binFixture(overrides: Partial<Bin> = {}): Bin {
+  function bin(overrides: Partial<Bin> & { notes?: unknown; label?: unknown } = {}): Bin {
     return {
-      id: 'b1' as Bin['id'],
-      layerId: 'lay-1' as Bin['layerId'],
-      x: 0 as Bin['x'],
-      y: 0 as Bin['y'],
-      width: 1 as Bin['width'],
-      depth: 1 as Bin['depth'],
-      height: 1 as Bin['height'],
-      category: 'cat-1' as Bin['category'],
+      id: 'b1',
+      layerId: 'lay-1',
+      x: 0,
+      y: 0,
+      width: 1,
+      depth: 1,
+      height: 1,
+      category: 'cat-1',
       label: '',
       notes: '',
       ...overrides,
-    };
+    } as Bin;
   }
-  function layoutWith(bins: Bin[]): Layout {
-    return { bins } as unknown as Layout;
-  }
+  const layoutWith = (bins: Bin[]): Layout => ({ bins }) as unknown as Layout;
 
   it('defaults missing notes and label to empty string', () => {
-    // Cast through unknown to simulate the cloud blob shape that predates
-    // the validator contract — `notes`/`label` literally absent from JSON.
-    const legacyBin = binFixture();
-    delete (legacyBin as unknown as { notes?: string }).notes;
-    delete (legacyBin as unknown as { label?: string }).label;
-
-    const out = normalizeIncomingLayout(layoutWith([legacyBin]));
+    const out = normalizeIncomingLayout(layoutWith([bin({ notes: undefined, label: undefined })]));
     expect(out.bins[0].notes).toBe('');
     expect(out.bins[0].label).toBe('');
   });
 
-  it('preserves existing notes and label without copying', () => {
-    const layout = layoutWith([binFixture({ notes: 'hi', label: 'screws' })]);
-    const out = normalizeIncomingLayout(layout);
-    // Reference equality: no allocation when every bin is already valid.
-    // Without this, every poll cycle would rewrite the bin array and
-    // churn downstream selectors using shallow equality.
-    expect(out).toBe(layout);
+  it('returns the same reference when every bin is already valid', () => {
+    // Reference equality matters: without it every poll cycle reallocates
+    // the bin array and churns downstream shallow-equality selectors.
+    const layout = layoutWith([bin({ notes: 'hi', label: 'screws' })]);
+    expect(normalizeIncomingLayout(layout)).toBe(layout);
   });
 
-  it('preserves other bin fields', () => {
-    const bin = binFixture({
-      x: 5 as Bin['x'],
-      y: 7 as Bin['y'],
-      category: 'tools' as Bin['category'],
-    });
-    delete (bin as unknown as { notes?: string }).notes;
-    const out = normalizeIncomingLayout(layoutWith([bin]));
-    expect(out.bins[0].x).toBe(5);
-    expect(out.bins[0].y).toBe(7);
-    expect(out.bins[0].category).toBe('tools');
+  it('preserves other bin fields when healing', () => {
+    const out = normalizeIncomingLayout(
+      layoutWith([bin({ x: 5, y: 7, category: 'tools', notes: undefined })])
+    );
+    expect(out.bins[0]).toMatchObject({ x: 5, y: 7, category: 'tools', notes: '' });
   });
 });

--- a/src/core/sync/adapters/layoutAdapter.test.ts
+++ b/src/core/sync/adapters/layoutAdapter.test.ts
@@ -21,7 +21,8 @@ vi.mock('@/core/storage', () => ({
   loadLayoutSync: (id: string) => loadLayoutSyncMock(id),
 }));
 
-import { layoutAdapter } from './layoutAdapter';
+import { layoutAdapter, normalizeIncomingLayout } from './layoutAdapter';
+import type { Bin, Layout } from '@/core/types';
 import type { AdapterChange } from './types';
 
 const minimalLayout = (name: string): { name: string } => ({ name });
@@ -139,5 +140,66 @@ describe('layoutAdapter.subscribe', () => {
 
     setLibrary([entry('lay-1', 9999)]);
     expect(events).toEqual([]);
+  });
+});
+
+/**
+ * `normalizeIncomingLayout` heals legacy cloud blobs whose bins were
+ * written before `api/lib/validation.ts` started emitting `notes`/`label`
+ * as required strings. Without this, the 3D view crashes on `bin.notes.trim()`
+ * when the user switches to a synced layout from before the contract fix.
+ */
+describe('normalizeIncomingLayout', () => {
+  function binFixture(overrides: Partial<Bin> = {}): Bin {
+    return {
+      id: 'b1' as Bin['id'],
+      layerId: 'lay-1' as Bin['layerId'],
+      x: 0 as Bin['x'],
+      y: 0 as Bin['y'],
+      width: 1 as Bin['width'],
+      depth: 1 as Bin['depth'],
+      height: 1 as Bin['height'],
+      category: 'cat-1' as Bin['category'],
+      label: '',
+      notes: '',
+      ...overrides,
+    };
+  }
+  function layoutWith(bins: Bin[]): Layout {
+    return { bins } as unknown as Layout;
+  }
+
+  it('defaults missing notes and label to empty string', () => {
+    // Cast through unknown to simulate the cloud blob shape that predates
+    // the validator contract — `notes`/`label` literally absent from JSON.
+    const legacyBin = binFixture();
+    delete (legacyBin as unknown as { notes?: string }).notes;
+    delete (legacyBin as unknown as { label?: string }).label;
+
+    const out = normalizeIncomingLayout(layoutWith([legacyBin]));
+    expect(out.bins[0].notes).toBe('');
+    expect(out.bins[0].label).toBe('');
+  });
+
+  it('preserves existing notes and label without copying', () => {
+    const layout = layoutWith([binFixture({ notes: 'hi', label: 'screws' })]);
+    const out = normalizeIncomingLayout(layout);
+    // Reference equality: no allocation when every bin is already valid.
+    // Without this, every poll cycle would rewrite the bin array and
+    // churn downstream selectors using shallow equality.
+    expect(out).toBe(layout);
+  });
+
+  it('preserves other bin fields', () => {
+    const bin = binFixture({
+      x: 5 as Bin['x'],
+      y: 7 as Bin['y'],
+      category: 'tools' as Bin['category'],
+    });
+    delete (bin as unknown as { notes?: string }).notes;
+    const out = normalizeIncomingLayout(layoutWith([bin]));
+    expect(out.bins[0].x).toBe(5);
+    expect(out.bins[0].y).toBe(7);
+    expect(out.bins[0].category).toBe('tools');
   });
 });

--- a/src/core/sync/adapters/layoutAdapter.ts
+++ b/src/core/sync/adapters/layoutAdapter.ts
@@ -1,6 +1,6 @@
 import { isErr } from '@/core/result';
 import { useLayoutStore, useLibraryStore } from '@/core/store';
-import type { Layout, LayoutEntry, LayoutId, LayoutLibrary } from '@/core/types';
+import type { Bin, Layout, LayoutEntry, LayoutId, LayoutLibrary } from '@/core/types';
 import {
   computePreview,
   loadLayoutAsync,
@@ -9,6 +9,40 @@ import {
   saveLibrary,
 } from '@/core/storage';
 import type { AdapterChange, AdapterChangeListener, LayoutAdapter, SyncableItem } from './types';
+
+// `Bin.notes`/`Bin.label` are declared as `string`, but cloud blobs written
+// before the validator started emitting them as required strings literally
+// omit the keys. Modeling that as `unknown` here is the honest input type —
+// otherwise the runtime guard below reads as unreachable to TypeScript.
+type IncomingBin = Omit<Bin, 'notes' | 'label'> & { notes?: unknown; label?: unknown };
+type IncomingLayout = Omit<Layout, 'bins'> & { bins: IncomingBin[] };
+
+/**
+ * Heal legacy cloud blobs whose bins predate the validator fix that always
+ * emits `notes`/`label` as strings. Without this, `bin.notes.trim()` in the
+ * 3D view (`Bin.tsx`) throws on any layout last written before that fix.
+ * New writes are already clean — this only kicks in for stored blobs that
+ * haven't been re-saved since the contract change in `api/lib/validation.ts`.
+ *
+ * Exported for unit testing only; runtime callers should not normalize
+ * twice — `applyRemote` is the single entry point for remote-sourced data.
+ */
+export function normalizeIncomingLayout(layout: Layout): Layout {
+  const incoming = layout as IncomingLayout;
+  const needsHealing = incoming.bins.some(
+    (b) => typeof b.notes !== 'string' || typeof b.label !== 'string'
+  );
+  if (!needsHealing) return layout;
+
+  const bins = incoming.bins.map(
+    (bin): Bin => ({
+      ...bin,
+      notes: typeof bin.notes === 'string' ? bin.notes : '',
+      label: typeof bin.label === 'string' ? bin.label : '',
+    })
+  );
+  return { ...layout, bins };
+}
 
 /**
  * `LayoutAdapter` implementation backed by `useLibraryStore` (entry
@@ -63,7 +97,7 @@ export const layoutAdapter: LayoutAdapter = {
   async applyRemote(item: SyncableItem<Layout>): Promise<void> {
     suppress(item.id);
 
-    const layout = item.payload;
+    const layout = normalizeIncomingLayout(item.payload);
     const saveResult = await saveLayoutAsync(item.id, layout);
     if (!saveResult.ok) {
       // Storage failure — the engine catches and surfaces a toast. We

--- a/src/core/sync/adapters/layoutAdapter.ts
+++ b/src/core/sync/adapters/layoutAdapter.ts
@@ -10,38 +10,31 @@ import {
 } from '@/core/storage';
 import type { AdapterChange, AdapterChangeListener, LayoutAdapter, SyncableItem } from './types';
 
-// `Bin.notes`/`Bin.label` are declared as `string`, but cloud blobs written
-// before the validator started emitting them as required strings literally
-// omit the keys. Modeling that as `unknown` here is the honest input type —
-// otherwise the runtime guard below reads as unreachable to TypeScript.
+// Wider than `Bin` because legacy cloud blobs (pre-validator-fix) literally
+// omit `notes`/`label`. Without this the runtime guard below reads as
+// unreachable to TypeScript.
 type IncomingBin = Omit<Bin, 'notes' | 'label'> & { notes?: unknown; label?: unknown };
 type IncomingLayout = Omit<Layout, 'bins'> & { bins: IncomingBin[] };
 
 /**
- * Heal legacy cloud blobs whose bins predate the validator fix that always
- * emits `notes`/`label` as strings. Without this, `bin.notes.trim()` in the
- * 3D view (`Bin.tsx`) throws on any layout last written before that fix.
- * New writes are already clean — this only kicks in for stored blobs that
- * haven't been re-saved since the contract change in `api/lib/validation.ts`.
- *
- * Exported for unit testing only; runtime callers should not normalize
- * twice — `applyRemote` is the single entry point for remote-sourced data.
+ * Default missing `notes`/`label` to '' so the 3D view's `bin.notes.trim()`
+ * doesn't crash on legacy cloud blobs written before `api/lib/validation.ts`
+ * began emitting both as required strings.
  */
 export function normalizeIncomingLayout(layout: Layout): Layout {
-  const incoming = layout as IncomingLayout;
-  const needsHealing = incoming.bins.some(
-    (b) => typeof b.notes !== 'string' || typeof b.label !== 'string'
-  );
+  const bins = (layout as IncomingLayout).bins;
+  const needsHealing = bins.some((b) => typeof b.notes !== 'string' || typeof b.label !== 'string');
   if (!needsHealing) return layout;
-
-  const bins = incoming.bins.map(
-    (bin): Bin => ({
-      ...bin,
-      notes: typeof bin.notes === 'string' ? bin.notes : '',
-      label: typeof bin.label === 'string' ? bin.label : '',
-    })
-  );
-  return { ...layout, bins };
+  return {
+    ...layout,
+    bins: bins.map(
+      (b): Bin => ({
+        ...b,
+        notes: typeof b.notes === 'string' ? b.notes : '',
+        label: typeof b.label === 'string' ? b.label : '',
+      })
+    ),
+  };
 }
 
 /**

--- a/vercel.json
+++ b/vercel.json
@@ -25,7 +25,7 @@
         },
         {
           "key": "Content-Security-Policy-Report-Only",
-          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; child-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://*.posthog.com https://*.liveblocks.io wss://*.liveblocks.io; base-uri 'self'; form-action 'self'; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-Mw22/ZAJRshXEvS8/Ol3lQ4fuh9u0CpfYpgBaSMgOsE=' 'sha256-ZFh/jA8g0pm0KqxQsSQwlMZCLY+5rjgk3lzDL9ly2KU='; worker-src 'self' blob:; child-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.posthog.com https://*.liveblocks.io wss://*.liveblocks.io https://fonts.googleapis.com https://fonts.gstatic.com; base-uri 'self'; form-action 'self'; object-src 'none'"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Hot fixes for three production issues that surfaced after sign-in + switching to a synced layout:

- **Design sync 400s** — `migrateParams` (`defaults.ts:230`) backfills `featureColors.enabled` on every load, but the server's `ALLOWED_FEATURE_COLOR_KEYS` allowlist didn't include `enabled`, so every PUT was rejected with *"featureColors has unknown key: enabled"*. Allowlist + boolean check + test.
- **3D view crash on synced layouts** (`Cannot read properties of undefined (reading 'trim')`) — `Bin.notes`/`Bin.label` are typed `string` locally, but the share/sync validator stripped empty strings to `undefined`, breaking the invariant on the way through the cloud. Fixed at the source so consumers can trust the type:
  - `api/lib/validation.ts` always emits both fields as strings (empty when absent).
  - `layoutAdapter.normalizeIncomingLayout` heals legacy cloud blobs on `applyRemote` for any stored data that hasn't been re-saved since the contract change.
  - Local IndexedDB reads were already healed by `salvageImport`; inspiration-gallery layouts always set both fields via `createBin` — adapter is the single remaining entry point.
  - `isValidBin` now also rejects non-string `label`/`notes`/`category` so a malicious `{label: 42}` returns a clean 400 instead of crashing in `sanitizeString` (Copilot review).
- **CSP report-only console spam** — service worker prefetches Google Fonts (not allowlisted); two inline `<head>` scripts (theme + www-migration) had no hashes; `fflate` / `troika-three-text` in the prod bundle use `new Function`. Add Google Fonts to `font/style/connect-src`, hash both inline scripts (verified against the browser-reported values), add `'unsafe-eval'` for the bundled libs.
- **CSP hash drift safety net** — `scripts/check-csp-hashes.test.ts` re-hashes every executable inline `<script>` in `index.html` (case-insensitive, attribute-tolerant) and fails if the matching hash isn't present in a `script-src` directive specifically.

The 409 on `/api/sync/layouts/<id>` in the original report is correct LWW behavior — engine's `handleConflict` reads the server's stored payload and overwrites local. Not changed.

## Follow-ups before enforcing CSP

Both Greptile and Copilot flagged `'unsafe-eval'` as a meaningful weakening of `script-src` once the policy moves from report-only to enforcement. The policy is report-only today, but before flipping the switch we should evaluate one of:

- Confirm whether `fflate`'s `new Function` path is actually reached at runtime in our bundle (some builds tree-shake it).
- Upgrade `troika-three-text` to a version that ships without `new Function`, if one exists.
- Move both libraries into a Web Worker with its own relaxed CSP, so the main document policy can drop `'unsafe-eval'`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — only the pre-existing `useMeshGeometry.test.ts` warning
- [x] `pnpm vitest run` on every touched test file (113 tests pass)
- [x] Regression test: `featureColors.enabled` accepted by the designer validator
- [x] Regression test: `isValidBin` rejects non-string `label`/`notes`/`category`
- [x] Unit tests: `normalizeIncomingLayout` defaults missing fields, preserves valid bins by reference, preserves other fields
- [x] CI test: every inline `<script>` hash in `index.html` is present in a `script-src` directive in `vercel.json`
- [ ] Manual: sign in, sync a layout that previously 400'd, confirm design pushes succeed
- [ ] Manual: switch to a synced layout, confirm 3D view renders without the trim crash
- [ ] Manual: open devtools console, confirm Google Fonts + inline script + eval CSP reports are gone (CSP stays report-only)