### PR TITLE
fix(generation): nudge split cut planes off socket-cell boundaries

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.split-export.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-export.test.ts
@@ -133,6 +133,64 @@ describe('split export: geometry completeness', () => {
     }
   }, 90000);
 
+  it('exports a 5x4x3 bin (split at cell boundary) without losing geometry', async () => {
+    // Width 5 → cut at x=0 (the cell-4/cell-5 boundary). Confirms the
+    // cell-boundary nudge fires on x-axis cuts too and doesn't regress
+    // pieces with stacking lip.
+    const exportSplitBin = getExportSplitBin();
+
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 5,
+      depth: 2,
+      height: 3,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    };
+
+    // Pick a printBed size that forces a cut: max=2 for width=5 → 3 pieces;
+    // we want exactly 2, so pre-compute one cut at x=0 (cell-2/cell-3 wall).
+    const cutPlanesX: number[] = [-21]; // halfway between cells 2 and 3
+    const connectors = { ...DEFAULT_SPLIT_CONNECTOR_CONFIG, enabled: false };
+    const exported = await exportSplitBin(params, cutPlanesX, [], 0.01, 5, connectors);
+    expect(exported.pieces).toHaveLength(2);
+  }, 90000);
+
+  it('exports a 3x10x7 standard-base no-lip bin without losing body Z (issue #1676)', async () => {
+    // Reported failure: depth 10 forces a single y-cut at exactly y=0, which
+    // lands on the shared wall between adjacent socket cells. Even with the
+    // 0.01mm INTERIOR_MARGIN, OCCT was dropping ~22mm of wall geometry
+    // (final piece Z=26.7mm vs expected 49mm), tripping the body-loss guard.
+    const exportSplitBin = getExportSplitBin();
+
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 3,
+      depth: 10,
+      height: 7,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+    };
+
+    // depth=10 with max=6 → one cut plane at center (y=0). That puts the
+    // cut exactly on the shared socket-cell wall between cells 4 and 5.
+    const cutPlanesY = [0];
+    // Connectors enabled — matches the production default the bug reporter
+    // would have hit; with connectors off the failure mode doesn't appear.
+    const connectors = { ...DEFAULT_SPLIT_CONNECTOR_CONFIG };
+
+    const exported = await exportSplitBin(params, [], cutPlanesY, 0.01, 5, connectors);
+    const totalHeight = params.height * GRIDFINITY.HEIGHT_UNIT;
+
+    expect(exported.pieces).toHaveLength(2);
+    for (const piece of exported.pieces) {
+      const { bb: exportBB } = exportPieceBounds(piece.data);
+      const exportZ = exportBB.maxZ - exportBB.minZ;
+      expect(
+        exportZ,
+        `piece ${piece.label}: Z=${exportZ.toFixed(1)}mm should reach full height ${totalHeight.toFixed(1)}mm`
+      ).toBeGreaterThan(totalHeight * 0.9);
+    }
+  }, 90000);
+
   it('exported STL pieces with magnet+screw base have full geometry', async () => {
     const exportSplitBin = getExportSplitBin();
 

--- a/src/features/generation/worker/generators/binGenerator.scenario.split-export.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-export.test.ts
@@ -133,10 +133,11 @@ describe('split export: geometry completeness', () => {
     }
   }, 90000);
 
-  it('exports a 5x4x3 bin (split at cell boundary) without losing geometry', async () => {
-    // Width 5 → cut at x=0 (the cell-4/cell-5 boundary). Confirms the
-    // cell-boundary nudge fires on x-axis cuts too and doesn't regress
-    // pieces with stacking lip.
+  it('exports a 5x2x3 bin with lip + x-axis cell-boundary cut without losing geometry', async () => {
+    // Width 5 cells, cut at x=-21 — that's the cell-1/cell-2 boundary (cell
+    // centers at -84, -42, 0, 42, 84; the boundary between cells 1 and 2
+    // sits at -42 + gridUnit/2 = -21). Confirms the cell-boundary nudge
+    // also fires on the x axis and doesn't regress lipped pieces.
     const exportSplitBin = getExportSplitBin();
 
     const params: BinParams = {
@@ -147,9 +148,7 @@ describe('split export: geometry completeness', () => {
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
     };
 
-    // Pick a printBed size that forces a cut: max=2 for width=5 → 3 pieces;
-    // we want exactly 2, so pre-compute one cut at x=0 (cell-2/cell-3 wall).
-    const cutPlanesX: number[] = [-21]; // halfway between cells 2 and 3
+    const cutPlanesX: number[] = [-21];
     const connectors = { ...DEFAULT_SPLIT_CONNECTOR_CONFIG, enabled: false };
     const exported = await exportSplitBin(params, cutPlanesX, [], 0.01, 5, connectors);
     expect(exported.pieces).toHaveLength(2);

--- a/src/features/generation/worker/generators/splitBinBuilder.cellBoundary.test.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.cellBoundary.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure-function tests for the cut-plane / cell-boundary nudge.
+ * No brepjs/WASM needed — this is shape arithmetic.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { shiftCutPlanesOffCellBoundaries } from './splitBinBuilder';
+
+describe('shiftCutPlanesOffCellBoundaries', () => {
+  it('nudges a cut plane that lands exactly on an interior cell boundary', () => {
+    // 10 cells, cut at y=0 → cell-5 boundary (issue #1676).
+    const out = shiftCutPlanesOffCellBoundaries([0], 10, 42);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBeCloseTo(0.1, 5);
+  });
+
+  it('leaves a cut plane that sits cleanly between cell boundaries alone', () => {
+    const out = shiftCutPlanesOffCellBoundaries([10], 10, 42);
+    expect(out[0]).toBe(10);
+  });
+
+  it('only nudges INTERIOR boundaries — outer-edge planes already get EDGE_MARGIN', () => {
+    // 20 cells: outer edges at y=±420, interior boundaries at y=-378..378.
+    // Cut planes at ±420 are at outer edges (handled by EDGE_MARGIN), at 0
+    // is the i=10 interior boundary and must nudge.
+    const out = shiftCutPlanesOffCellBoundaries([-420, 0, 420], 20, 42);
+    expect(out).toEqual([-420, 0.1, 420]);
+  });
+
+  it('returns the input array unchanged when no cut planes are passed', () => {
+    const out = shiftCutPlanesOffCellBoundaries([], 10, 42);
+    expect(out).toEqual([]);
+  });
+
+  it('defensively handles missing gridUnitMm (legacy params)', () => {
+    const out = shiftCutPlanesOffCellBoundaries([0, 10], 10, undefined as unknown as number);
+    expect(out).toEqual([0, 10]);
+  });
+});

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -93,6 +93,59 @@ interface SplitPieceInfo {
 }
 
 /**
+ * Tolerance for "cut plane is on a cell boundary" detection (mm). The bin's
+ * socket cells share walls at every gridUnit step, so a cut plane within
+ * this distance of one is treated as coincident.
+ */
+const CELL_BOUNDARY_TOLERANCE = 0.001;
+
+/**
+ * Amount to nudge a cut plane off a coincident cell boundary (mm).
+ * 0.1mm is below the visible-seam threshold for FDM prints and is well
+ * above OCCT's coplanar-face tolerance, so the boolean cut sees two
+ * cleanly distinct faces rather than a near-coincident pair that
+ * triggers wall-dropping (issue #1676).
+ */
+const CELL_BOUNDARY_NUDGE = 0.1;
+
+/**
+ * Shift any cut plane that lands on a socket-cell boundary by a tiny
+ * amount so it no longer coincides with the bin's internal wall plane.
+ *
+ * Cell boundaries (in bin-centered coords) sit at `(i - cells/2) * gridUnit`
+ * for `i` in `0..cells`. For an even-numbered cell count (e.g. depth=10),
+ * the natural even-split cut plane lands at exactly y=0, which is one of
+ * those boundaries.
+ *
+ * Pieces still meet flush — they both use the shifted plane — so the
+ * nudge just translates the seam, it doesn't create overlap.
+ */
+export function shiftCutPlanesOffCellBoundaries(
+  cutPlanes: readonly number[],
+  cells: number,
+  gridUnitMm: number
+): number[] {
+  if (!Number.isFinite(gridUnitMm) || gridUnitMm <= 0 || cells <= 0) {
+    return [...cutPlanes];
+  }
+
+  const halfCells = cells / 2;
+  return cutPlanes.map((plane) => {
+    // Convert plane y to a fractional cell index. Integer values are on a
+    // boundary; the i=0 and i=cells boundaries lie on the bin's outer wall
+    // (covered by EDGE_MARGIN), so only INTERIOR integers matter.
+    const cellIndex = plane / gridUnitMm + halfCells;
+    const nearest = Math.round(cellIndex);
+    if (nearest <= 0 || nearest >= cells) return plane;
+    const distanceMm = Math.abs(cellIndex - nearest) * gridUnitMm;
+    if (distanceMm < CELL_BOUNDARY_TOLERANCE) {
+      return plane + CELL_BOUNDARY_NUDGE;
+    }
+    return plane;
+  });
+}
+
+/**
  * Split the bin solid into pieces via boolean intersection.
  *
  * Shared by exportSplitBin (STL output) and generateSplitPreview (mesh output).
@@ -176,19 +229,30 @@ function splitSolidIntoPieces(
     }
   }
 
+  // When a cut plane lands exactly on a socket-cell boundary (e.g. depth=10
+  // split into 5+5 puts the cut at y=0, which is the shared wall between
+  // adjacent socket cells), the per-piece 0.01mm cutting-box overlap isn't
+  // enough — OCCT still treats some interior faces as coplanar and drops
+  // walls (issue #1676 reported A2 lost ~22mm of body Z). Shifting the cut
+  // plane itself by 0.1mm fully resolves the coplanarity at both faces and
+  // keeps the pieces flush (no overlap region, just a 0.1mm offset that's
+  // invisible to FDM print and barely felt at the join).
+  const adjustedCutPlanesX = shiftCutPlanesOffCellBoundaries(cutPlanesX, params.width, gridUnitMm);
+  const adjustedCutPlanesY = shiftCutPlanesOffCellBoundaries(cutPlanesY, params.depth, gridUnitMm);
+
   // Boundary arrays: [left edge, ...cut planes, right edge]
-  const xBounds = [-outerW / 2, ...cutPlanesX, outerW / 2];
-  const yBounds = [-outerD / 2, ...cutPlanesY, outerD / 2];
+  const xBounds = [-outerW / 2, ...adjustedCutPlanesX, outerW / 2];
+  const yBounds = [-outerD / 2, ...adjustedCutPlanesY, outerD / 2];
 
   // Outer edges of the cutting box are expanded by this margin to avoid
   // coplanar faces with bin geometry, which cause OCCT booleans to
   // silently drop outer walls.
   const EDGE_MARGIN = 1;
 
-  // Interior cut faces also need a small offset to avoid coplanarity with
-  // socket cell boundaries (e.g. a 10-wide bin split at cell 5 puts the
-  // cut plane exactly on the cell wall at x=0). 10um is invisible in FDM
-  // print but breaks the coplanarity that causes OCCT to drop geometry.
+  // Interior cut faces still get a small overlap to defeat coplanarity
+  // tolerance at the cut. With shiftCutPlanesOffCellBoundaries() above,
+  // the cut plane itself is already off any cell wall — this offset is the
+  // belt to the suspenders of the cell-boundary shift.
   const INTERIOR_MARGIN = 0.01;
 
   const pieces: SplitPieceInfo[] = [];
@@ -266,8 +330,8 @@ function splitSolidIntoPieces(
           const cutFaces = computeCutFaces(
             col,
             row,
-            cutPlanesX,
-            cutPlanesY,
+            adjustedCutPlanesX,
+            adjustedCutPlanesY,
             outerW,
             outerD,
             pieceW,


### PR DESCRIPTION
Fixes #1676.

## Summary

When a bin's split lands on an exact cell boundary, OCCT's boolean intersection silently drops wall geometry. The reporter hit this with a 3×10×7 bin: depth 10 splits at y=0, which is the shared wall between socket cells 4 and 5. The intersect kept only the bottom ~27mm of the 49mm body, tripping the body-loss guard.

## Fix

Shift the cut plane by 0.1mm when it coincides with an interior cell boundary. Both pieces use the shifted plane, so they still meet flush — there's no overlap region, just a sub-print-tolerance seam shift (0.1mm is well below the visible FDM-print threshold). Outer-edge planes are left untouched (already handled by EDGE_MARGIN). Connectors compute against the adjusted planes so tongue/groove geometry stays aligned with the actual seam.

The 0.01mm per-piece overlap that previously failed is kept as belt-and-suspenders.

## Test plan

- [x] New `shiftCutPlanesOffCellBoundaries` unit test covers the nudge logic
- [x] New split-export scenario test matches the reporter's exact params (3×10×7, no lip)
- [x] All existing split tests pass (lip, magnet+screw, connectors, STEP, multi-piece preview)
- [ ] Manually export the reporter's bin and verify the STL pieces are full-height