### PR TITLE
fix(api,security): close validator enum gap, tighten CodeQL regex, relax browsing-topics

### DIFF
--- a/api/lib/designerValidation.test.ts
+++ b/api/lib/designerValidation.test.ts
@@ -133,7 +133,7 @@ describe('validateDesignerShare', () => {
     });
 
     it('accepts all valid bin styles', () => {
-      for (const style of ['standard', 'slotted']) {
+      for (const style of ['standard', 'slotted', 'solid']) {
         const payload = validPayload();
         (payload.params as Record<string, unknown>).style = style;
         const result = validateDesignerShare(payload, JSON.stringify(payload).length);
@@ -148,6 +148,15 @@ describe('validateDesignerShare', () => {
       (payload.params.base as Record<string, unknown>).style = 'floating';
       const result = validateDesignerShare(payload, JSON.stringify(payload).length);
       expect(result.valid).toBe(false);
+    });
+
+    it('accepts all valid base styles', () => {
+      for (const style of ['standard', 'magnet', 'screw', 'magnet_and_screw', 'weighted', 'flat']) {
+        const payload = validPayload();
+        (payload.params.base as Record<string, unknown>).style = style;
+        const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+        expect(result.valid).toBe(true);
+      }
     });
 
     it('rejects non-boolean stackingLip', () => {
@@ -236,6 +245,14 @@ describe('validateDesignerShare', () => {
       const payload = validPayload();
       (payload.params.label as Record<string, unknown>).enabled = true;
       (payload.params.label as Record<string, unknown>).support = 'solid';
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts fillet label tab support', () => {
+      const payload = validPayload();
+      (payload.params.label as Record<string, unknown>).enabled = true;
+      (payload.params.label as Record<string, unknown>).support = 'fillet';
       const result = validateDesignerShare(payload, JSON.stringify(payload).length);
       expect(result.valid).toBe(true);
     });

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -14,10 +14,20 @@ import {
   validationError,
 } from './validationUtils.js';
 
-// Type-safe enum validation
-const VALID_BIN_STYLES = ['standard', 'slotted'] as const;
-const VALID_BASE_STYLES = ['standard', 'magnet', 'screw', 'magnet_and_screw', 'weighted'] as const;
-const VALID_LABEL_TAB_SUPPORTS = ['bracket', 'solid'] as const;
+// Type-safe enum validation. Mirror the client unions in
+// `src/features/bin-designer/types/index.ts` — when a value is added there
+// it must be added here too, otherwise cloud sync PUTs from up-to-date
+// clients will be rejected with a 400.
+const VALID_BIN_STYLES = ['standard', 'slotted', 'solid'] as const;
+const VALID_BASE_STYLES = [
+  'standard',
+  'magnet',
+  'screw',
+  'magnet_and_screw',
+  'weighted',
+  'flat',
+] as const;
+const VALID_LABEL_TAB_SUPPORTS = ['bracket', 'solid', 'fillet'] as const;
 const VALID_INSERT_SHAPES = ['rectangle', 'circle', 'hexagon', 'rounded-rect', 'slot'] as const;
 const VALID_WALL_CUTOUT_SHAPES = ['u-shape', 'scoop', 'funnel'] as const;
 const VALID_ROTATIONS = [0, 90, 180, 270] as const;

--- a/scripts/check-csp-hashes.test.ts
+++ b/scripts/check-csp-hashes.test.ts
@@ -28,10 +28,16 @@ interface VercelConfig {
  * `type="…"` (JSON-LD, module, etc.) and isn't `src="…"` (external).
  * Case-insensitive so `<SCRIPT>` or `<script defer>` aren't silently
  * skipped — the test exists precisely to catch what `index.html` ships.
+ *
+ * Closing tag matches anything between `</script` and `>` (not just
+ * pure whitespace) so browser-permissive forms like `</script foo=bar>`
+ * or `</script\n\tjunk>` still terminate the body — otherwise CodeQL
+ * `js/bad-tag-filter` (and a real `index.html` typo) could slip a
+ * script past hash verification.
  */
 function findInlineScripts(html: string): string[] {
   const scripts: string[] = [];
-  for (const m of html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi)) {
+  for (const m of html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi)) {
     const attrs = m[1];
     if (/\bsrc\s*=/i.test(attrs)) continue;
     if (/\btype\s*=/i.test(attrs)) continue;

--- a/vercel.json
+++ b/vercel.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "Permissions-Policy",
-          "value": "camera=(), microphone=(), geolocation=(), browsing-topics=()"
+          "value": "camera=(), microphone=(), geolocation=()"
         },
         {
           "key": "Content-Security-Policy-Report-Only",


### PR DESCRIPTION
## Summary

Three small, related fixes bundled into one PR — none big enough to justify its own.

### 1. Validator enum gap (the only one that's actively breaking prod)

`src/features/bin-designer/types/index.ts` already ships:

- `BinStyle = 'standard' | 'slotted' | 'solid'`
- `BaseStyle = 'standard' | 'magnet' | 'screw' | 'magnet_and_screw' | 'weighted' | 'flat'`
- `LabelTabSupport = 'bracket' | 'solid' | 'fillet'`

…but the server-side allowlists in `api/lib/designerValidation.ts` were never widened. Any design using a `solid` bin, `flat` base, or `fillet` label-tab support 400s on cloud-sync PUT — same shape as the `featureColors.enabled` regression #1677 just fixed.

Add the missing values plus a tightened comment pointing the next person at the source-of-truth client unions. Three new test cases cover the additions.

### 2. CodeQL `js/bad-tag-filter` (high, alert #22) in `check-csp-hashes.test.ts`

The closing-tag regex `</script\s*>` only accepts pure whitespace before `>`, but the HTML spec lets browsers terminate scripts on permissive forms like `</script foo=\"bar\">` or `</script\n\tjunk>`. A typo in `index.html` matching one of those forms would slip past the hash-drift check because `findInlineScripts` wouldn't find the script body at all.

Switch to `</script\b[^>]*>` — `\b` keeps us from grabbing `</scripts>` (a different element) and `[^>]*` mirrors browser parsing.

### 3. Drop `browsing-topics=()` from `Permissions-Policy`

The header currently force-disables Google's Topics API. Moving to \"browser default\" — we don't want to opt every user out unilaterally. Camera/microphone/geolocation stay locked at `()`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `npx vitest run api/lib/designerValidation.test.ts` — 54/54 pass (3 new cases for the enum additions)
- [x] `npx vitest run scripts/check-csp-hashes.test.ts` — 4/4 pass against the real `index.html`
- [ ] After merge, verify CodeQL alert #22 closes on the next analysis run
- [ ] Manual: save a design with `style: 'solid'`, `base.style: 'flat'`, or `label.support: 'fillet'` and confirm cloud sync no longer 400s