### PR TITLE
fix(bin-designer): keep material attach intact across multi-color toggle

### DIFF
--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -124,6 +124,18 @@ graph TB
     to identity — a single uniform scalar would distort circles and rotated
     shapes. Path bounds use `getPathBounds` (flattened bezier) so curves that
     bow outward beyond their anchors aren't clipped.
+13. **`BinMesh` multi↔single material switch needs distinct keys** — the
+    multi-color branch passes `material` as a `<mesh>` **prop** (array of
+    `MeshStandardMaterial`), the single-color branch declares the material as
+    a `<meshStandardMaterial>` **child**. Without keys, R3F (9.x) reuses the
+    same `THREE.Mesh` across the toggle and the post-order commit clobbers
+    the freshly attached child material: child-attach runs first, then the
+    parent's prop-diff resets the removed `material` prop to a memoized
+    `new Mesh()` default (`MeshBasicMaterial`) via `diffProps`. The
+    user-visible symptom is a mesh with no emissive glow whose color picker
+    no longer takes. Don't remove the `key="multi-color"` /
+    `key="single-color"` props — and if you add a third branch (e.g. a new
+    material strategy) give it its own key too.
 
 ## Integration
 

--- a/src/features/bin-designer/components/preview/BinMesh/BinMesh.tsx
+++ b/src/features/bin-designer/components/preview/BinMesh/BinMesh.tsx
@@ -238,10 +238,14 @@ export function BinMesh({ wireframe, color, onZoneClick }: BinMeshProps) {
       }
     : {};
 
+  // Distinct keys force unmount/remount across the multi↔single switch. If we
+  // reuse the same <mesh>, R3F's prop-diff resets the removed `material` prop
+  // to a memoized MeshBasicMaterial after the child-material attach has run,
+  // clobbering the new material — no emissive glow, color picker stuck.
   const fineMesh = materials ? (
-    <mesh geometry={geometry} material={materials} {...meshProps} />
+    <mesh key="multi-color" geometry={geometry} material={materials} {...meshProps} />
   ) : (
-    <mesh geometry={geometry} {...meshProps}>
+    <mesh key="single-color" geometry={geometry} {...meshProps}>
       <meshStandardMaterial {...singleMatProps} />
     </mesh>
   );


### PR DESCRIPTION
## Summary

Disabling the per-design multi-color toggle stripped the bin's emissive glow and froze the 3D preview color picker.

`BinMesh` swapped between two `<mesh>` shapes — `material` as a **prop** (multi-color) vs. as a child `<meshStandardMaterial>` (single-color). R3F 9.6.1 reused the same `THREE.Mesh` instance and the post-order commit order produced a broken final state:

1. New child material attached → `mesh.material = newMaterial` ✓
2. Parent's prop diff ran. `diffProps` (`events-b389eeca.esm.js:343`) saw `material` was removed and set `changedProps.material = defaultBasicMaterial` from a memoized `new Mesh()` prototype. `applyProps` then **clobbered** the just-attached material with a default `MeshBasicMaterial`.

That explains both symptoms together: the visible material became a random-color basic material (no emissive), and color-picker prop updates went to an orphan `MeshStandardMaterial` no longer attached to the mesh.

**Why it surfaced now:** before #1674 (`graduate multi-color export with per-design toggle`), multi-color was a session-stable Labs flag. Users never toggled it live, so the broken transition path was never exercised.

**Fix:** distinct `key` props on the two `<mesh>` branches force unmount/remount across the toggle, so the new mesh's material attach is the final mutation.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test:run` (11089 tests pass)
- [x] `pnpm run lint` (no new warnings)
- [ ] Manual: enable multi-color, set a body color, toggle multi-color off — bin should switch to the preview color with the emissive glow restored
- [ ] Manual: with multi-color off, open the preview color picker — picking a swatch should update the bin color
- [ ] Manual: toggle multi-color back on — multi-zone rendering should resume cleanly