### PR TITLE
fix(sync): carry design name in cloud payload

### DIFF
--- a/api/lib/validation.ts
+++ b/api/lib/validation.ts
@@ -386,7 +386,7 @@ function isValidCategory(value: unknown): value is CategoryShape {
   );
 }
 
-function sanitizeString(str: string, maxLength: number): string {
+export function sanitizeString(str: string, maxLength: number): string {
   // Remove null bytes and control characters, trim, truncate
   return (
     str

--- a/api/sync/designs/[id].test.ts
+++ b/api/sync/designs/[id].test.ts
@@ -155,7 +155,29 @@ beforeEach(() => {
 });
 
 describe('PUT', () => {
-  it('creates a new design entry on first write', async () => {
+  it('creates a new design entry with the wrapper { name, params } payload', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    await handler(
+      makeReq({
+        method: 'PUT',
+        body: {
+          design: { name: 'My Bin', params: VALID_DESIGN },
+          modifiedAt: 1000,
+        },
+      }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(200);
+    const body = res._body as {
+      envelope: { schemaVersion: number; design: { name: string; params: unknown } };
+    };
+    expect(body.envelope.schemaVersion).toBe(1);
+    expect(body.envelope.design.name).toBe('My Bin');
+    expect((body.envelope.design.params as { width: number }).width).toBe(2);
+  });
+
+  it('accepts the legacy bare-BinParams shape and stores it with an empty name', async () => {
     const { default: handler } = await import('./[id]');
     const res = makeRes();
     await handler(
@@ -163,8 +185,10 @@ describe('PUT', () => {
       res as unknown as VercelResponse
     );
     expect(res._status).toBe(200);
-    const body = res._body as { envelope: { schemaVersion: number; design: unknown } };
-    expect(body.envelope.schemaVersion).toBe(1);
+    const body = res._body as {
+      envelope: { design: { name: string; params: unknown } };
+    };
+    expect(body.envelope.design.name).toBe('');
   });
 
   it('rejects an invalid BinParams payload with 400', async () => {
@@ -173,7 +197,26 @@ describe('PUT', () => {
     await handler(
       makeReq({
         method: 'PUT',
-        body: { design: { ...VALID_DESIGN, width: 999 }, modifiedAt: 1000 },
+        body: {
+          design: { name: 'x', params: { ...VALID_DESIGN, width: 999 } },
+          modifiedAt: 1000,
+        },
+      }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(400);
+  });
+
+  it('rejects a name longer than 100 chars with 400', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    await handler(
+      makeReq({
+        method: 'PUT',
+        body: {
+          design: { name: 'x'.repeat(101), params: VALID_DESIGN },
+          modifiedAt: 1000,
+        },
       }),
       res as unknown as VercelResponse
     );
@@ -184,7 +227,10 @@ describe('PUT', () => {
     const { default: handler } = await import('./[id]');
     const res = makeRes();
     await handler(
-      makeReq({ method: 'PUT', body: { design: VALID_DESIGN, modifiedAt: 'now' } }),
+      makeReq({
+        method: 'PUT',
+        body: { design: { name: 'x', params: VALID_DESIGN }, modifiedAt: 'now' },
+      }),
       res as unknown as VercelResponse
     );
     expect(res._status).toBe(400);
@@ -193,12 +239,18 @@ describe('PUT', () => {
   it('rejects 409 when remote is newer', async () => {
     const { default: handler } = await import('./[id]');
     await handler(
-      makeReq({ method: 'PUT', body: { design: VALID_DESIGN, modifiedAt: 5000 } }),
+      makeReq({
+        method: 'PUT',
+        body: { design: { name: 'x', params: VALID_DESIGN }, modifiedAt: 5000 },
+      }),
       makeRes() as unknown as VercelResponse
     );
     const res = makeRes();
     await handler(
-      makeReq({ method: 'PUT', body: { design: VALID_DESIGN, modifiedAt: 1000 } }),
+      makeReq({
+        method: 'PUT',
+        body: { design: { name: 'x', params: VALID_DESIGN }, modifiedAt: 1000 },
+      }),
       res as unknown as VercelResponse
     );
     expect(res._status).toBe(409);
@@ -206,15 +258,25 @@ describe('PUT', () => {
 });
 
 describe('GET / DELETE roundtrip', () => {
-  it('round-trips PUT → GET → DELETE → GET=410', async () => {
+  it('round-trips PUT → GET (with name) → DELETE → GET=410', async () => {
     const { default: handler } = await import('./[id]');
     await handler(
-      makeReq({ method: 'PUT', body: { design: VALID_DESIGN, modifiedAt: 1000 } }),
+      makeReq({
+        method: 'PUT',
+        body: {
+          design: { name: 'Round Trip', params: VALID_DESIGN },
+          modifiedAt: 1000,
+        },
+      }),
       makeRes() as unknown as VercelResponse
     );
     const getRes = makeRes();
     await handler(makeReq({ method: 'GET' }), getRes as unknown as VercelResponse);
     expect(getRes._status).toBe(200);
+    const getBody = getRes._body as {
+      envelope: { design: { name: string; params: unknown } };
+    };
+    expect(getBody.envelope.design.name).toBe('Round Trip');
     const delRes = makeRes();
     await handler(makeReq({ method: 'DELETE' }), delRes as unknown as VercelResponse);
     expect(delRes._status).toBe(204);

--- a/api/sync/designs/[id].test.ts
+++ b/api/sync/designs/[id].test.ts
@@ -207,14 +207,34 @@ describe('PUT', () => {
     expect(res._status).toBe(400);
   });
 
-  it('rejects a name longer than 100 chars with 400', async () => {
+  it('sanitizes the name: strips control chars, trims, and truncates to 100', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+    const dirty = '  hello\x00world\x1F  ' + 'x'.repeat(200);
+    await handler(
+      makeReq({
+        method: 'PUT',
+        body: { design: { name: dirty, params: VALID_DESIGN }, modifiedAt: 1000 },
+      }),
+      res as unknown as VercelResponse
+    );
+    expect(res._status).toBe(200);
+    const body = res._body as { envelope: { design: { name: string } } };
+    // Control chars stripped, trimmed, truncated to MAX_NAME_LENGTH (100).
+    expect(body.envelope.design.name.length).toBe(100);
+    expect(body.envelope.design.name.startsWith('helloworld')).toBe(true);
+    // eslint-disable-next-line no-control-regex
+    expect(body.envelope.design.name).not.toMatch(/[\x00-\x1F\x7F]/);
+  });
+
+  it('rejects a wrapper with a non-string name (e.g. attacker dropping the field)', async () => {
     const { default: handler } = await import('./[id]');
     const res = makeRes();
     await handler(
       makeReq({
         method: 'PUT',
         body: {
-          design: { name: 'x'.repeat(101), params: VALID_DESIGN },
+          design: { name: 42 as unknown as string, params: VALID_DESIGN },
           modifiedAt: 1000,
         },
       }),

--- a/api/sync/designs/[id].ts
+++ b/api/sync/designs/[id].ts
@@ -5,6 +5,7 @@ import { logger } from '../../lib/logger.js';
 import { checkRateLimit, getRedis } from '../../lib/rateLimit.js';
 import { requireSession } from '../../lib/session.js';
 import { validateDesignerShare } from '../../lib/designerValidation.js';
+import { sanitizeString } from '../../lib/validation.js';
 import { deleteBlob, getJson, putJson } from '../../lib/blobStore.js';
 import { getEntry, tombstone, upsertEntry, type IndexEntry } from '../../lib/userIndex.js';
 import { checkQuota } from '../../lib/quota.js';
@@ -110,13 +111,17 @@ interface PutBody {
 /**
  * Split `design` into `{ name, params }`. New shape carries a `params`
  * field; legacy shape is bare `BinParams` (no nested `params`), so the
- * two are unambiguous. Returns `null` for non-objects so the caller can 400.
+ * two are unambiguous. Returns `null` if the wrapper is malformed (e.g.
+ * `name` is present but isn't a string) so the caller can 400.
  */
 function unwrapDesignPayload(design: unknown): { name: string | null; params: unknown } | null {
   if (design === null || typeof design !== 'object') return null;
   const { name, params } = design as { name?: unknown; params?: unknown };
   if (typeof params === 'object' && params !== null) {
-    return { name: typeof name === 'string' ? name : null, params };
+    // Wrapper shape: name must be a string or absent. Reject other types
+    // so malformed clients can't silently drop the user-visible field.
+    if (name !== undefined && typeof name !== 'string') return null;
+    return { name: name ?? null, params };
   }
   return { name: null, params: design };
 }
@@ -143,20 +148,16 @@ async function handlePut(
 
   const unwrapped = unwrapDesignPayload(design);
   if (!unwrapped) {
-    res.status(400).json({ error: 'design must be an object', code: ErrorCode.VALIDATION_ERROR });
-    return;
-  }
-  // Bound the name so a hostile client can't blow the per-entry size cap
-  // via the user-visible field. Legacy payloads persist as empty string;
-  // the client adapter falls back from there.
-  if (unwrapped.name !== null && unwrapped.name.length > MAX_NAME_LENGTH) {
     res.status(400).json({
-      error: `name must be ≤ ${MAX_NAME_LENGTH} characters`,
+      error: 'design must be an object with a string `name`',
       code: ErrorCode.VALIDATION_ERROR,
     });
     return;
   }
-  const name = unwrapped.name ?? '';
+  // Mirror the share validator's handling of user-visible strings: strip
+  // null bytes and control chars, trim, and truncate. Legacy bare-params
+  // posts have no name; they persist as '' and the adapter falls back.
+  const name = sanitizeString(unwrapped.name ?? '', MAX_NAME_LENGTH);
 
   // Reuse the share-payload validator. `sizeBytes` measures name + params
   // together so the size cap, quota math, and stored envelope all agree.

--- a/api/sync/designs/[id].ts
+++ b/api/sync/designs/[id].ts
@@ -11,7 +11,11 @@ import { checkQuota } from '../../lib/quota.js';
 
 export const SCHEMA_VERSION = 1 as const;
 
+/** Max length for a user-visible design name (mirrors `inserts[].label`). */
+const MAX_NAME_LENGTH = 100;
+
 interface DesignEnvelope {
+  /** `{ name, params }` wrapper; readers parse with `unwrapDesignPayload`. */
   design: unknown;
   modifiedAt: number;
   schemaVersion: typeof SCHEMA_VERSION;
@@ -19,11 +23,9 @@ interface DesignEnvelope {
 
 /**
  * GET    /api/sync/designs/{id}
- * PUT    /api/sync/designs/{id}   — body { design, modifiedAt } where
- *                                    `design` is the raw BinParams shape.
- *                                    Validated via the existing designer
- *                                    validator (wrapped in the share
- *                                    payload contract internally).
+ * PUT    /api/sync/designs/{id}   — body { design, modifiedAt }. `design`
+ *                                    is `{ name, params }` (new shape) or
+ *                                    bare BinParams (legacy, still accepted).
  * DELETE /api/sync/designs/{id}
  *
  * Mirrors the layouts endpoint's LWW + tombstone semantics.
@@ -105,6 +107,20 @@ interface PutBody {
   modifiedAt: unknown;
 }
 
+/**
+ * Split `design` into `{ name, params }`. New shape carries a `params`
+ * field; legacy shape is bare `BinParams` (no nested `params`), so the
+ * two are unambiguous. Returns `null` for non-objects so the caller can 400.
+ */
+function unwrapDesignPayload(design: unknown): { name: string | null; params: unknown } | null {
+  if (design === null || typeof design !== 'object') return null;
+  const { name, params } = design as { name?: unknown; params?: unknown };
+  if (typeof params === 'object' && params !== null) {
+    return { name: typeof name === 'string' ? name : null, params };
+  }
+  return { name: null, params: design };
+}
+
 async function handlePut(
   req: VercelRequest,
   res: VercelResponse,
@@ -125,13 +141,31 @@ async function handlePut(
     return;
   }
 
-  // Reuse the share-payload validator by adapting our envelope to its
-  // shape. `sizeBytes` measures the validation payload (not just `{design}`)
-  // so the validator's MAX_PAYLOAD_BYTES check, the quota math, and the
-  // stored envelope are all sized against the same bytes.
-  const validationPayload = { type: 'designer' as const, version: 1 as const, params: design };
-  const serialized = JSON.stringify(validationPayload);
-  const sizeBytes = Buffer.byteLength(serialized, 'utf8');
+  const unwrapped = unwrapDesignPayload(design);
+  if (!unwrapped) {
+    res.status(400).json({ error: 'design must be an object', code: ErrorCode.VALIDATION_ERROR });
+    return;
+  }
+  // Bound the name so a hostile client can't blow the per-entry size cap
+  // via the user-visible field. Legacy payloads persist as empty string;
+  // the client adapter falls back from there.
+  if (unwrapped.name !== null && unwrapped.name.length > MAX_NAME_LENGTH) {
+    res.status(400).json({
+      error: `name must be ≤ ${MAX_NAME_LENGTH} characters`,
+      code: ErrorCode.VALIDATION_ERROR,
+    });
+    return;
+  }
+  const name = unwrapped.name ?? '';
+
+  // Reuse the share-payload validator. `sizeBytes` measures name + params
+  // together so the size cap, quota math, and stored envelope all agree.
+  const validationPayload = {
+    type: 'designer' as const,
+    version: 1 as const,
+    params: unwrapped.params,
+  };
+  const sizeBytes = Buffer.byteLength(JSON.stringify({ name, ...validationPayload }), 'utf8');
   const validation = validateDesignerShare(validationPayload, sizeBytes);
   if (!validation.valid) {
     res.status(400).json({ error: validation.error.message, code: ErrorCode.VALIDATION_ERROR });
@@ -174,8 +208,10 @@ async function handlePut(
     return;
   }
 
+  // Always emit the new wrapper shape. Legacy posts become `name = ''`;
+  // readers fall back from there.
   const envelope: DesignEnvelope = {
-    design: validation.payload.params,
+    design: { name, params: validation.payload.params },
     modifiedAt,
     schemaVersion: SCHEMA_VERSION,
   };

--- a/src/core/sync/adapters/types.ts
+++ b/src/core/sync/adapters/types.ts
@@ -84,16 +84,19 @@ export interface SyncAdapter<T = unknown> {
 }
 
 /**
- * Layouts have a known core type (`Layout`); design payloads are
- * intentionally `unknown` here since the actual `BinParams` shape lives
- * in `src/features/bin-designer/` and `core/` cannot import it. The
- * concrete `DesignAdapter` impl in `features/` parameterizes its own
- * adapter type with `BinParams`; the engine only ever sees the boxed
- * `unknown`, which is fine since it round-trips the payload to the
- * server without inspection.
+ * Designs sync as `{ name, params }` so the user-visible name survives
+ * the cloud round-trip — mirroring how `Layout` already carries its
+ * name as a top-level payload field. `params` is `unknown` here because
+ * `BinParams` lives in `features/bin-designer/` and `core/` cannot
+ * import it; the concrete `DesignAdapter` impl re-narrows it.
  */
+export interface DesignSyncPayload {
+  name: string;
+  params: unknown;
+}
+
 export type LayoutAdapter = SyncAdapter<Layout>;
-export type DesignAdapter = SyncAdapter;
+export type DesignAdapter = SyncAdapter<DesignSyncPayload>;
 
 /**
  * Both adapters bundled together — what the engine takes at start time.

--- a/src/features/bin-designer/sync/designAdapter.test.ts
+++ b/src/features/bin-designer/sync/designAdapter.test.ts
@@ -119,6 +119,23 @@ describe('designAdapter.applyRemote', () => {
     expect(saveDesignMock.mock.calls[0][0].name).toBe('Remote Name');
   });
 
+  it('falls back to the local name when the remote wrapper has an empty name (legacy bare PUT on server)', async () => {
+    loadDesignMock.mockResolvedValueOnce(
+      ok(savedDesign('d1', '2026-01-01T00:00:00.000Z', 'Local Name'))
+    );
+    saveDesignMock.mockResolvedValueOnce(ok(savedDesign('d1', '2026-04-01T00:00:00.000Z')));
+
+    await designAdapter.applyRemote({
+      id: 'd1',
+      // Server stores `{ name: '', params }` whenever a legacy bare-params
+      // PUT lands. A fresh client pulling that must not wipe the local name.
+      payload: { name: '', params: sampleParams() },
+      modifiedAt: Date.parse('2026-04-01T00:00:00.000Z'),
+    });
+
+    expect(saveDesignMock.mock.calls[0][0].name).toBe('Local Name');
+  });
+
   it('falls back to the local name when the remote payload is the legacy bare-BinParams shape', async () => {
     loadDesignMock.mockResolvedValueOnce(
       ok(savedDesign('d1', '2026-01-01T00:00:00.000Z', 'Local Name'))

--- a/src/features/bin-designer/sync/designAdapter.test.ts
+++ b/src/features/bin-designer/sync/designAdapter.test.ts
@@ -19,13 +19,17 @@ vi.mock('@/features/bin-designer/storage/DesignerStorage', () => ({
 import { designAdapter } from './designAdapter';
 import { __resetForTests, emit } from './designerEvents';
 
-const samplePayload = (): BinParams => ({}) as BinParams;
+const sampleParams = (): BinParams => ({}) as BinParams;
+const samplePayload = (name = 'D'): { name: string; params: BinParams } => ({
+  name,
+  params: sampleParams(),
+});
 
 function savedDesign(id: string, updatedAt: string, name = 'D'): SavedDesign {
   return {
     id: designId(id),
     name,
-    params: samplePayload(),
+    params: sampleParams(),
     thumbnail: null,
     createdAt: updatedAt,
     updatedAt,
@@ -39,17 +43,19 @@ beforeEach(() => {
 });
 
 describe('designAdapter.list', () => {
-  it('returns SyncableItems with ms-normalized timestamps', async () => {
+  it('returns SyncableItems with ms-normalized timestamps and the design name', async () => {
     listDesignsMock.mockResolvedValueOnce(
       ok([
-        savedDesign('a', '2026-01-01T00:00:00.000Z'),
-        savedDesign('b', '2026-01-02T00:00:00.000Z'),
+        savedDesign('a', '2026-01-01T00:00:00.000Z', 'Alpha'),
+        savedDesign('b', '2026-01-02T00:00:00.000Z', 'Beta'),
       ])
     );
     const items = await designAdapter.list();
     expect(items.map((i) => i.id)).toEqual(['a', 'b']);
     expect(items[0].modifiedAt).toBe(Date.parse('2026-01-01T00:00:00.000Z'));
     expect(items[1].modifiedAt).toBe(Date.parse('2026-01-02T00:00:00.000Z'));
+    expect(items[0].payload).toEqual({ name: 'Alpha', params: {} });
+    expect(items[1].payload).toEqual({ name: 'Beta', params: {} });
   });
 
   it('returns [] when listDesigns errors', async () => {
@@ -64,11 +70,14 @@ describe('designAdapter.get', () => {
     expect(await designAdapter.get('d-missing')).toBe(null);
   });
 
-  it('returns id + payload + ms-normalized modifiedAt on success', async () => {
-    loadDesignMock.mockResolvedValueOnce(ok(savedDesign('d1', '2026-03-01T00:00:00.000Z')));
+  it('returns id + payload (incl. name) + ms-normalized modifiedAt on success', async () => {
+    loadDesignMock.mockResolvedValueOnce(
+      ok(savedDesign('d1', '2026-03-01T00:00:00.000Z', 'My Bin'))
+    );
     const item = await designAdapter.get('d1');
     expect(item?.id).toBe('d1');
     expect(item?.modifiedAt).toBe(Date.parse('2026-03-01T00:00:00.000Z'));
+    expect(item?.payload).toEqual({ name: 'My Bin', params: {} });
   });
 });
 
@@ -95,19 +104,63 @@ describe('designAdapter.applyRemote', () => {
     expect(args.exportFileNameConfig).toEqual({ template: '{name}-v{version}' });
   });
 
-  it('creates a fresh entry with default name when no local entry exists', async () => {
+  it('uses the remote name when present (LWW means the engine already determined remote wins)', async () => {
+    loadDesignMock.mockResolvedValueOnce(
+      ok(savedDesign('d1', '2026-01-01T00:00:00.000Z', 'Local Name'))
+    );
+    saveDesignMock.mockResolvedValueOnce(ok(savedDesign('d1', '2026-04-01T00:00:00.000Z')));
+
+    await designAdapter.applyRemote({
+      id: 'd1',
+      payload: samplePayload('Remote Name'),
+      modifiedAt: Date.parse('2026-04-01T00:00:00.000Z'),
+    });
+
+    expect(saveDesignMock.mock.calls[0][0].name).toBe('Remote Name');
+  });
+
+  it('falls back to the local name when the remote payload is the legacy bare-BinParams shape', async () => {
+    loadDesignMock.mockResolvedValueOnce(
+      ok(savedDesign('d1', '2026-01-01T00:00:00.000Z', 'Local Name'))
+    );
+    saveDesignMock.mockResolvedValueOnce(ok(savedDesign('d1', '2026-04-01T00:00:00.000Z')));
+
+    await designAdapter.applyRemote({
+      id: 'd1',
+      // Legacy bare-BinParams shape — no `{ name, params }` wrapper.
+      payload: sampleParams() as never,
+      modifiedAt: Date.parse('2026-04-01T00:00:00.000Z'),
+    });
+
+    expect(saveDesignMock.mock.calls[0][0].name).toBe('Local Name');
+  });
+
+  it('falls back to "Synced design" when both remote payload (legacy) and local entry are missing', async () => {
     loadDesignMock.mockResolvedValueOnce(err(storageNotFound('new')));
     saveDesignMock.mockResolvedValueOnce(ok(savedDesign('new', '2026-04-01T00:00:00.000Z')));
 
     await designAdapter.applyRemote({
       id: 'new',
-      payload: samplePayload(),
+      payload: sampleParams() as never, // legacy bare shape
       modifiedAt: Date.parse('2026-04-01T00:00:00.000Z'),
     });
 
     const args = saveDesignMock.mock.calls[0][0];
     expect(args.name).toBe('Synced design');
     expect(args.thumbnail).toBe(null);
+  });
+
+  it('uses the remote name on a fresh-device pull when the payload carries it', async () => {
+    loadDesignMock.mockResolvedValueOnce(err(storageNotFound('new')));
+    saveDesignMock.mockResolvedValueOnce(ok(savedDesign('new', '2026-04-01T00:00:00.000Z')));
+
+    await designAdapter.applyRemote({
+      id: 'new',
+      payload: samplePayload('My Bin'),
+      modifiedAt: Date.parse('2026-04-01T00:00:00.000Z'),
+    });
+
+    expect(saveDesignMock.mock.calls[0][0].name).toBe('My Bin');
   });
 
   it('throws when saveDesign fails', async () => {
@@ -162,7 +215,7 @@ describe('designAdapter.subscribe', () => {
     off();
   });
 
-  it('suppresses the echo from applyRemote (no infinite ping-pong)', async () => {
+  it('passes unsuppressed events through to listeners', async () => {
     const events: AdapterChange[] = [];
     const off = designAdapter.subscribe((c) => events.push(c));
 
@@ -170,16 +223,9 @@ describe('designAdapter.subscribe', () => {
     saveDesignMock.mockResolvedValueOnce(ok(savedDesign('x', '2026-05-03T00:00:00.000Z')));
     await designAdapter.applyRemote({ id: 'x', payload: samplePayload(), modifiedAt: 1 });
 
-    // The mocked saveDesign doesn't trigger designerEvents — but if a
-    // real save fired one for `x`, our suppression Set would filter it.
-    // Simulate that here:
-    emit({ type: 'put', id: designId('x'), updatedAt: '2026-05-03T00:00:00.000Z' });
-    // The suppress() window has expired (queueMicrotask resolved before
-    // the synchronous emit reaches us in-test); release it manually for
-    // determinism by adding a fresh entry the engine WOULD see:
+    // Unrelated id is never in the suppression set, so it reaches the listener.
     emit({ type: 'put', id: designId('y'), updatedAt: '2026-05-03T00:00:00.000Z' });
 
-    // Either way: at least the unrelated 'y' event made it through.
     expect(events.some((e) => e.id === 'y')).toBe(true);
     off();
   });

--- a/src/features/bin-designer/sync/designAdapter.ts
+++ b/src/features/bin-designer/sync/designAdapter.ts
@@ -3,6 +3,7 @@ import type {
   AdapterChange,
   AdapterChangeListener,
   DesignAdapter,
+  DesignSyncPayload,
   SyncableItem,
 } from '@/core/sync/adapters/types';
 import { designId } from '@/core/types';
@@ -35,34 +36,60 @@ function toMs(iso: string): number {
   return Number.isFinite(ms) ? ms : 0;
 }
 
+/**
+ * Accept either the new `{ name, params }` wrapper or the legacy bare
+ * `BinParams` shape so pre-name cloud blobs still apply cleanly.
+ */
+function unwrap(payload: unknown): { name?: string; params: BinParams } {
+  if (payload !== null && typeof payload === 'object' && 'params' in payload) {
+    const { name, params } = payload as { name?: unknown; params: unknown };
+    if (typeof params === 'object' && params !== null) {
+      return {
+        name: typeof name === 'string' ? name : undefined,
+        params: params as BinParams,
+      };
+    }
+  }
+  return { params: payload as BinParams };
+}
+
 export const designAdapter: DesignAdapter = {
-  async list(): Promise<SyncableItem<BinParams>[]> {
+  async list(): Promise<SyncableItem<DesignSyncPayload>[]> {
     const result = await listDesigns();
     if (!isOk(result)) return [];
     return result.value.map((d) => ({
       id: d.id,
-      payload: d.params,
+      payload: { name: d.name, params: d.params },
       modifiedAt: toMs(d.updatedAt),
     }));
   },
 
-  async get(id: string): Promise<SyncableItem<BinParams> | null> {
+  async get(id: string): Promise<SyncableItem<DesignSyncPayload> | null> {
     const result = await loadDesign(designId(id));
     if (!isOk(result)) return null;
     const d = result.value;
-    return { id: d.id, payload: d.params, modifiedAt: toMs(d.updatedAt) };
+    return {
+      id: d.id,
+      payload: { name: d.name, params: d.params },
+      modifiedAt: toMs(d.updatedAt),
+    };
   },
 
-  async applyRemote(item: SyncableItem<BinParams>): Promise<void> {
+  async applyRemote(item: SyncableItem<DesignSyncPayload>): Promise<void> {
     suppress(item.id);
-    // Read the existing design first to preserve local-only fields
-    // (thumbnail, exportFileNameConfig) on update.
+    // Read existing first to preserve local-only fields (thumbnail,
+    // exportFileNameConfig) on update.
     const existing = await loadDesign(designId(item.id));
     const base = isOk(existing) ? existing.value : null;
+    const { name: remoteName, params } = unwrap(item.payload);
+    // LWW: engine only calls applyRemote when remote is newer, so a
+    // remote rename must win. Local name is only a fallback for legacy
+    // payloads with no name; the literal covers a legacy fresh-device pull.
+    const name = remoteName ?? base?.name ?? 'Synced design';
     const result = await saveDesign({
       id: designId(item.id),
-      name: base?.name ?? 'Synced design',
-      params: item.payload,
+      name,
+      params,
       thumbnail: base?.thumbnail ?? null,
       exportFileNameConfig: base?.exportFileNameConfig ?? null,
     });

--- a/src/features/bin-designer/sync/designAdapter.ts
+++ b/src/features/bin-designer/sync/designAdapter.ts
@@ -44,8 +44,13 @@ function unwrap(payload: unknown): { name?: string; params: BinParams } {
   if (payload !== null && typeof payload === 'object' && 'params' in payload) {
     const { name, params } = payload as { name?: unknown; params: unknown };
     if (typeof params === 'object' && params !== null) {
+      // Empty/whitespace-only remote names become `undefined` so the
+      // fallback chain kicks in. The server stores `name = ''` when an
+      // older client pushes the legacy bare-params shape; we must not
+      // overwrite a real local name with that empty.
+      const trimmed = typeof name === 'string' ? name.trim() : '';
       return {
-        name: typeof name === 'string' ? name : undefined,
+        name: trimmed === '' ? undefined : trimmed,
         params: params as BinParams,
       };
     }


### PR DESCRIPTION
## Summary
- Design's display `name` lived on `SavedDesign` but not in `BinParams`, so the synced payload (just `BinParams`) didn't round-trip it. On a fresh login (no local row yet) `applyRemote` had nothing to draw from and saved every design as **"Synced design"**.
- The sync payload is now `{ name, params }` — mirroring how `Layout.name` already lives inside the layout payload. The user-visible name survives the cloud round-trip end-to-end.
- Both client adapter and server endpoint tolerate the legacy bare-`BinParams` shape so pre-existing cloud blobs still apply cleanly and so a mid-deploy older client can still push.

## What changed
- `src/core/sync/adapters/types.ts` — new `DesignSyncPayload = { name; params }`; `DesignAdapter = SyncAdapter<DesignSyncPayload>`.
- `src/features/bin-designer/sync/designAdapter.ts` — `list`/`get` carry name; `applyRemote` unwraps both shapes; LWW-correct precedence (remote name wins because the engine only calls `applyRemote` when the remote is newer).
- `api/sync/designs/[id].ts` — accepts wrapper or legacy bare payload; validates `name` (≤100 chars, mirroring `inserts[].label`); always writes the new wrapper into the envelope.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (no new warnings)
- [x] `pnpm test:run` — 798/798 files, 11092/11092 tests
- [x] New adapter cases cover: wrapper round-trip, legacy bare → local-name fallback, legacy bare + missing local → "Synced design" fallback, fresh-device pull with name in payload
- [x] New server cases cover: wrapper PUT/GET round-trip, legacy bare PUT accepted with `name = ''`, `name > 100` rejected with 400