### PR TITLE
fix(sync): graduation prep — 10 verified defects

### DIFF
--- a/api/lib/lwwTiebreaker.test.ts
+++ b/api/lib/lwwTiebreaker.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalPayloadHash, compareForTiebreaker } from './lwwTiebreaker';
+
+describe('canonicalPayloadHash', () => {
+  it('produces identical hashes for object key orderings that differ', () => {
+    const a = { name: 'Alpha', x: 1, y: 2 };
+    const b = { y: 2, x: 1, name: 'Alpha' };
+    expect(canonicalPayloadHash(a)).toBe(canonicalPayloadHash(b));
+  });
+
+  it('produces identical hashes for nested objects with reordered keys', () => {
+    const a = { meta: { author: 'a', updated: 1 }, body: 'x' };
+    const b = { body: 'x', meta: { updated: 1, author: 'a' } };
+    expect(canonicalPayloadHash(a)).toBe(canonicalPayloadHash(b));
+  });
+
+  it('produces different hashes for different array orderings', () => {
+    expect(canonicalPayloadHash([1, 2, 3])).not.toBe(canonicalPayloadHash([3, 2, 1]));
+  });
+
+  it('coerces NaN / Infinity to null (matches JSON.stringify behavior)', () => {
+    expect(canonicalPayloadHash(NaN)).toBe(canonicalPayloadHash(null));
+    expect(canonicalPayloadHash(Infinity)).toBe(canonicalPayloadHash(null));
+  });
+});
+
+describe('compareForTiebreaker', () => {
+  it('returns 0 when payloads are equal (no unnecessary write)', () => {
+    const candidate = { layout: { name: 'A' } };
+    const incumbent = { layout: { name: 'A' } };
+    expect(compareForTiebreaker(candidate, incumbent)).toBe(0);
+  });
+
+  it('deterministically picks the same winner regardless of caller order', () => {
+    const a = { layout: { name: 'A' } };
+    const b = { layout: { name: 'B' } };
+    const ab = compareForTiebreaker(a, b);
+    const ba = compareForTiebreaker(b, a);
+    expect(ab).not.toBe(0);
+    expect(ab).toBe(-ba as -1 | 0 | 1);
+  });
+
+  it('picks the same winner across machines (deterministic on content alone)', () => {
+    // Same content, different memory addresses — must hash the same.
+    const x1 = { layout: { name: 'A' } };
+    const x2 = { layout: { name: 'A' } };
+    expect(canonicalPayloadHash(x1)).toBe(canonicalPayloadHash(x2));
+  });
+});

--- a/api/lib/lwwTiebreaker.ts
+++ b/api/lib/lwwTiebreaker.ts
@@ -1,0 +1,53 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Deterministic tiebreaker for LWW writes that arrive with the same
+ * `modifiedAt`. Two devices that produce the same `modifiedAt` for
+ * distinct payloads must agree on which payload wins, regardless of
+ * which one happened to land at the server first. Without this, the
+ * "winner" is whoever raced to the index first — opaque to the user
+ * and non-reproducible across reties.
+ *
+ * Approach: SHA-256 of a canonical JSON encoding (object keys sorted
+ * recursively, no whitespace). The lexicographically larger hash wins.
+ *
+ * Hash collisions on 256 bits with the universe of plausible payloads
+ * are not a concern; identical hashes mean identical payloads, in which
+ * case the tiebreaker is a no-op (returns 0, caller treats existing as
+ * still winning so no unnecessary write happens).
+ */
+export function canonicalPayloadHash(payload: unknown): string {
+  return createHash('sha256').update(canonicalize(payload)).digest('hex');
+}
+
+/**
+ * Compare two payloads for tiebreaker purposes.
+ *
+ *   +1 → `candidate` wins (its hash is lexicographically larger)
+ *   −1 → `incumbent` wins
+ *    0 → equal payloads (functionally identical; no write needed)
+ */
+export function compareForTiebreaker(candidate: unknown, incumbent: unknown): -1 | 0 | 1 {
+  const cHash = canonicalPayloadHash(candidate);
+  const iHash = canonicalPayloadHash(incumbent);
+  if (cHash > iHash) return 1;
+  if (cHash < iHash) return -1;
+  return 0;
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : 'null';
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (Array.isArray(value)) return '[' + value.map((v) => canonicalize(v)).join(',') + ']';
+  if (typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    const parts = keys.map(
+      (k) => JSON.stringify(k) + ':' + canonicalize((value as Record<string, unknown>)[k])
+    );
+    return '{' + parts.join(',') + '}';
+  }
+  // undefined / functions / symbols collapse to null — same as JSON.stringify.
+  return 'null';
+}

--- a/api/lib/lwwTiebreaker.ts
+++ b/api/lib/lwwTiebreaker.ts
@@ -1,32 +1,15 @@
 import { createHash } from 'node:crypto';
 
-/**
- * Deterministic tiebreaker for LWW writes that arrive with the same
- * `modifiedAt`. Two devices that produce the same `modifiedAt` for
- * distinct payloads must agree on which payload wins, regardless of
- * which one happened to land at the server first. Without this, the
- * "winner" is whoever raced to the index first — opaque to the user
- * and non-reproducible across reties.
- *
- * Approach: SHA-256 of a canonical JSON encoding (object keys sorted
- * recursively, no whitespace). The lexicographically larger hash wins.
- *
- * Hash collisions on 256 bits with the universe of plausible payloads
- * are not a concern; identical hashes mean identical payloads, in which
- * case the tiebreaker is a no-op (returns 0, caller treats existing as
- * still winning so no unnecessary write happens).
- */
+// SHA-256 over a canonical JSON encoding (recursively sorted keys, no
+// whitespace) so two devices computing the same modifiedAt for distinct
+// payloads converge on the same winner regardless of arrival order.
 export function canonicalPayloadHash(payload: unknown): string {
-  return createHash('sha256').update(canonicalize(payload)).digest('hex');
+  const h = createHash('sha256');
+  hashInto(h, payload);
+  return h.digest('hex');
 }
 
-/**
- * Compare two payloads for tiebreaker purposes.
- *
- *   +1 → `candidate` wins (its hash is lexicographically larger)
- *   −1 → `incumbent` wins
- *    0 → equal payloads (functionally identical; no write needed)
- */
+// +1 candidate wins, -1 incumbent wins, 0 equal payloads (no write needed).
 export function compareForTiebreaker(candidate: unknown, incumbent: unknown): -1 | 0 | 1 {
   const cHash = canonicalPayloadHash(candidate);
   const iHash = canonicalPayloadHash(incumbent);
@@ -35,19 +18,42 @@ export function compareForTiebreaker(candidate: unknown, incumbent: unknown): -1
   return 0;
 }
 
-function canonicalize(value: unknown): string {
-  if (value === null) return 'null';
-  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : 'null';
-  if (typeof value === 'string') return JSON.stringify(value);
-  if (typeof value === 'boolean') return value ? 'true' : 'false';
-  if (Array.isArray(value)) return '[' + value.map((v) => canonicalize(v)).join(',') + ']';
+function hashInto(h: ReturnType<typeof createHash>, value: unknown): void {
+  if (value === null) {
+    h.update('null');
+    return;
+  }
+  if (typeof value === 'number') {
+    h.update(Number.isFinite(value) ? String(value) : 'null');
+    return;
+  }
+  if (typeof value === 'string') {
+    h.update(JSON.stringify(value));
+    return;
+  }
+  if (typeof value === 'boolean') {
+    h.update(value ? 'true' : 'false');
+    return;
+  }
+  if (Array.isArray(value)) {
+    h.update('[');
+    for (let i = 0; i < value.length; i++) {
+      if (i > 0) h.update(',');
+      hashInto(h, value[i]);
+    }
+    h.update(']');
+    return;
+  }
   if (typeof value === 'object') {
     const keys = Object.keys(value).sort();
-    const parts = keys.map(
-      (k) => JSON.stringify(k) + ':' + canonicalize((value as Record<string, unknown>)[k])
-    );
-    return '{' + parts.join(',') + '}';
+    h.update('{');
+    for (let i = 0; i < keys.length; i++) {
+      if (i > 0) h.update(',');
+      h.update(JSON.stringify(keys[i]) + ':');
+      hashInto(h, (value as Record<string, unknown>)[keys[i]]);
+    }
+    h.update('}');
+    return;
   }
-  // undefined / functions / symbols collapse to null — same as JSON.stringify.
-  return 'null';
+  h.update('null');
 }

--- a/api/lib/redisKeys.ts
+++ b/api/lib/redisKeys.ts
@@ -63,3 +63,8 @@ export function userIndexKey(userId: string, kind: SyncItemKind): string {
 export function userIndexUpdatedAtKey(userId: string): string {
   return `users:${userId}:indexUpdatedAt`;
 }
+
+/** Ms timestamp of the last tombstone sweep — gates how often `upsertEntry` HGETALLs. */
+export function userTombstoneSweptAtKey(userId: string): string {
+  return `users:${userId}:tombstoneSweptAt`;
+}

--- a/api/lib/userIndex.test.ts
+++ b/api/lib/userIndex.test.ts
@@ -150,6 +150,13 @@ describe('userIndex', () => {
   });
 
   describe('tombstone sweep on upsertEntry', () => {
+    // Force the sweep gate to fire on every upsert in this block by pretending
+    // the last sweep was long ago. Production gates sweeps to once per hour.
+    function forceSweepEligible(): void {
+      const ctx = mockRedis as unknown as { store: Map<string, string> };
+      ctx.store.set('users:u1:tombstoneSweptAt', String(Date.now() - 2 * 60 * 60 * 1_000));
+    }
+
     it('removes tombstones older than the retention window when a new entry is upserted', async () => {
       const now = Date.now();
       const stale = now - TOMBSTONE_RETENTION_MS - 1_000;
@@ -161,6 +168,7 @@ describe('userIndex', () => {
         modifiedAt: fresh,
         sizeBytes: 100,
       });
+      forceSweepEligible();
 
       await upsertEntry(mockRedis, 'u1', 'layouts', 'new-entry', {
         modifiedAt: now,
@@ -178,6 +186,7 @@ describe('userIndex', () => {
         modifiedAt: ancient,
         sizeBytes: 100,
       });
+      forceSweepEligible();
       await upsertEntry(mockRedis, 'u1', 'layouts', 'trigger', {
         modifiedAt: Date.now(),
         sizeBytes: 200,
@@ -190,12 +199,27 @@ describe('userIndex', () => {
     it('skips the id being written even when it is itself a stale tombstone (no self-conflict)', async () => {
       const stale = Date.now() - TOMBSTONE_RETENTION_MS - 1_000;
       await tombstone(mockRedis, 'u1', 'layouts', 'self', stale);
+      forceSweepEligible();
 
       await tombstone(mockRedis, 'u1', 'layouts', 'self', Date.now());
 
       const entry = await getEntry(mockRedis, 'u1', 'layouts', 'self');
       expect(entry).not.toBeNull();
       expect(entry?.deletedAt).toBeGreaterThan(stale);
+    });
+
+    it('skips the HGETALL scan when the last sweep was recent', async () => {
+      // Seed a recent sweep timestamp; the next upsert must not call hgetall.
+      const ctx = mockRedis as unknown as { store: Map<string, string> };
+      ctx.store.set('users:u1:tombstoneSweptAt', String(Date.now() - 60_000));
+      const hgetallSpy = vi.spyOn(mockRedis, 'hgetall');
+
+      await upsertEntry(mockRedis, 'u1', 'layouts', 'a', {
+        modifiedAt: Date.now(),
+        sizeBytes: 100,
+      });
+
+      expect(hgetallSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/api/lib/userIndex.test.ts
+++ b/api/lib/userIndex.test.ts
@@ -150,17 +150,11 @@ describe('userIndex', () => {
   });
 
   describe('tombstone sweep on upsertEntry', () => {
-    // Tombstones used to live forever in the user-index hash. Every
-    // manifest poll HGETALLs that hash, so a power user who churned a
-    // lot of items would inflate every poll response forever. The fix
-    // is an opportunistic sweep: on each write, delete tombstones older
-    // than TOMBSTONE_RETENTION_MS.
     it('removes tombstones older than the retention window when a new entry is upserted', async () => {
       const now = Date.now();
       const stale = now - TOMBSTONE_RETENTION_MS - 1_000;
       const fresh = now - 1_000;
 
-      // Seed: one stale tombstone, one fresh tombstone, one live entry.
       await tombstone(mockRedis, 'u1', 'layouts', 'old-deleted', stale);
       await tombstone(mockRedis, 'u1', 'layouts', 'recent-deleted', fresh);
       await upsertEntry(mockRedis, 'u1', 'layouts', 'alive', {
@@ -168,7 +162,6 @@ describe('userIndex', () => {
         sizeBytes: 100,
       });
 
-      // Another write triggers the sweep.
       await upsertEntry(mockRedis, 'u1', 'layouts', 'new-entry', {
         modifiedAt: now,
         sizeBytes: 200,
@@ -198,8 +191,6 @@ describe('userIndex', () => {
       const stale = Date.now() - TOMBSTONE_RETENTION_MS - 1_000;
       await tombstone(mockRedis, 'u1', 'layouts', 'self', stale);
 
-      // Re-tombstone with a fresh deletedAt: the entry must end up
-      // present with the new value, not deleted by the sweep step.
       await tombstone(mockRedis, 'u1', 'layouts', 'self', Date.now());
 
       const entry = await getEntry(mockRedis, 'u1', 'layouts', 'self');

--- a/api/lib/userIndex.test.ts
+++ b/api/lib/userIndex.test.ts
@@ -4,6 +4,7 @@ import {
   getEntry,
   getIndex,
   getIndexUpdatedAt,
+  TOMBSTONE_RETENTION_MS,
   tombstone,
   upsertEntry,
   type IndexEntry,
@@ -21,6 +22,11 @@ function makeRedisMock() {
     hashes.set(k, h);
     return isNew ? 1 : 0;
   };
+  const hdelKey = (k: string, field: string): number => {
+    const h = hashes.get(k);
+    if (!h) return 0;
+    return h.delete(field) ? 1 : 0;
+  };
   const setKey = (k: string, v: string): 'OK' => {
     store.set(k, v);
     return 'OK';
@@ -32,12 +38,13 @@ function makeRedisMock() {
     set: vi.fn(async (k: string, v: string) => setKey(k, v)),
     hset: vi.fn(async (k: string, field: string, val: string) => hsetKey(k, field, val)),
     hget: vi.fn(async (k: string, field: string) => hashes.get(k)?.get(field) ?? null),
+    hdel: vi.fn(async (k: string, field: string) => hdelKey(k, field)),
     hgetall: vi.fn(async (k: string) => {
       const h = hashes.get(k);
       if (!h) return {};
       return Object.fromEntries(h);
     }),
-    pipeline: vi.fn(() => makePipelineMock(setKey, hsetKey)),
+    pipeline: vi.fn(() => makePipelineMock(setKey, hsetKey, hdelKey)),
   } as unknown as Redis & {
     store: Map<string, string>;
     hashes: Map<string, Map<string, string>>;
@@ -46,7 +53,8 @@ function makeRedisMock() {
 
 function makePipelineMock(
   setKey: (k: string, v: string) => 'OK',
-  hsetKey: (k: string, field: string, val: string) => number
+  hsetKey: (k: string, field: string, val: string) => number,
+  hdelKey: (k: string, field: string) => number
 ) {
   const queue: Array<() => [Error | null, unknown]> = [];
   const pipe = {
@@ -56,6 +64,10 @@ function makePipelineMock(
     },
     hset: (k: string, field: string, val: string) => {
       queue.push(() => [null, hsetKey(k, field, val)]);
+      return pipe;
+    },
+    hdel: (k: string, field: string) => {
+      queue.push(() => [null, hdelKey(k, field)]);
       return pipe;
     },
     exec: vi.fn(async () => queue.map((fn) => fn())),
@@ -135,5 +147,64 @@ describe('userIndex', () => {
 
   it('getIndexUpdatedAt returns 0 for a user who has never written', async () => {
     expect(await getIndexUpdatedAt(mockRedis, 'fresh-user')).toBe(0);
+  });
+
+  describe('tombstone sweep on upsertEntry', () => {
+    // Tombstones used to live forever in the user-index hash. Every
+    // manifest poll HGETALLs that hash, so a power user who churned a
+    // lot of items would inflate every poll response forever. The fix
+    // is an opportunistic sweep: on each write, delete tombstones older
+    // than TOMBSTONE_RETENTION_MS.
+    it('removes tombstones older than the retention window when a new entry is upserted', async () => {
+      const now = Date.now();
+      const stale = now - TOMBSTONE_RETENTION_MS - 1_000;
+      const fresh = now - 1_000;
+
+      // Seed: one stale tombstone, one fresh tombstone, one live entry.
+      await tombstone(mockRedis, 'u1', 'layouts', 'old-deleted', stale);
+      await tombstone(mockRedis, 'u1', 'layouts', 'recent-deleted', fresh);
+      await upsertEntry(mockRedis, 'u1', 'layouts', 'alive', {
+        modifiedAt: fresh,
+        sizeBytes: 100,
+      });
+
+      // Another write triggers the sweep.
+      await upsertEntry(mockRedis, 'u1', 'layouts', 'new-entry', {
+        modifiedAt: now,
+        sizeBytes: 200,
+      });
+
+      const index = await getIndex(mockRedis, 'u1', 'layouts');
+      expect(Object.keys(index).sort()).toEqual(['alive', 'new-entry', 'recent-deleted']);
+      expect(index['old-deleted']).toBeUndefined();
+    });
+
+    it('does not remove non-tombstone (live) entries even if they are very old', async () => {
+      const ancient = Date.now() - TOMBSTONE_RETENTION_MS * 10;
+      await upsertEntry(mockRedis, 'u1', 'layouts', 'ancient-live', {
+        modifiedAt: ancient,
+        sizeBytes: 100,
+      });
+      await upsertEntry(mockRedis, 'u1', 'layouts', 'trigger', {
+        modifiedAt: Date.now(),
+        sizeBytes: 200,
+      });
+
+      const index = await getIndex(mockRedis, 'u1', 'layouts');
+      expect(index['ancient-live']).toBeDefined();
+    });
+
+    it('skips the id being written even when it is itself a stale tombstone (no self-conflict)', async () => {
+      const stale = Date.now() - TOMBSTONE_RETENTION_MS - 1_000;
+      await tombstone(mockRedis, 'u1', 'layouts', 'self', stale);
+
+      // Re-tombstone with a fresh deletedAt: the entry must end up
+      // present with the new value, not deleted by the sweep step.
+      await tombstone(mockRedis, 'u1', 'layouts', 'self', Date.now());
+
+      const entry = await getEntry(mockRedis, 'u1', 'layouts', 'self');
+      expect(entry).not.toBeNull();
+      expect(entry?.deletedAt).toBeGreaterThan(stale);
+    });
   });
 });

--- a/api/lib/userIndex.ts
+++ b/api/lib/userIndex.ts
@@ -50,7 +50,8 @@ export async function getEntry(
 /**
  * Insert or replace an entry, atomically bumping `indexUpdatedAt` so
  * `/api/sync/manifest` can serve `If-Modified-Since` 304s without reading
- * the hash.
+ * the hash. Also sweeps tombstones older than `TOMBSTONE_RETENTION_MS`
+ * so the user-index hash doesn't grow unboundedly over a user's lifetime.
  */
 export async function upsertEntry(
   redis: Redis,
@@ -59,15 +60,47 @@ export async function upsertEntry(
   id: string,
   entry: IndexEntry
 ): Promise<void> {
+  const now = Date.now();
+  const staleTombstoneIds = await findStaleTombstones(redis, userId, kind, now);
   const pipeline = redis.pipeline();
   pipeline.hset(userIndexKey(userId, kind), id, JSON.stringify(entry));
-  pipeline.set(userIndexUpdatedAtKey(userId), String(Date.now()));
+  for (const staleId of staleTombstoneIds) {
+    if (staleId === id) continue;
+    pipeline.hdel(userIndexKey(userId, kind), staleId);
+  }
+  pipeline.set(userIndexUpdatedAtKey(userId), String(now));
   const run = pipeline.exec.bind(pipeline);
   const results = await run();
   if (results === null) throw new Error('userIndex pipeline failed: redis connection lost');
   for (const [err] of results) {
     if (err) throw err;
   }
+}
+
+/**
+ * How long tombstones live in the index hash. Tombstones serve to inform
+ * cross-device sync that an item was deleted; 90 days covers the longest
+ * legitimate offline propagation window (a user signs in on a long-dormant
+ * device and still gets the deletes that happened on their primary device).
+ * Beyond that, a tombstone is no longer useful — keeping it forever just
+ * inflates every manifest poll response.
+ */
+export const TOMBSTONE_RETENTION_MS = 90 * 24 * 60 * 60 * 1_000;
+
+async function findStaleTombstones(
+  redis: Redis,
+  userId: string,
+  kind: SyncItemKind,
+  now: number
+): Promise<string[]> {
+  const raw = await redis.hgetall(userIndexKey(userId, kind));
+  const stale: string[] = [];
+  for (const [id, encoded] of Object.entries(raw)) {
+    const parsed = parseEntry(encoded);
+    if (!parsed?.deletedAt) continue;
+    if (now - parsed.deletedAt > TOMBSTONE_RETENTION_MS) stale.push(id);
+  }
+  return stale;
 }
 
 /**

--- a/api/lib/userIndex.ts
+++ b/api/lib/userIndex.ts
@@ -50,8 +50,7 @@ export async function getEntry(
 /**
  * Insert or replace an entry, atomically bumping `indexUpdatedAt` so
  * `/api/sync/manifest` can serve `If-Modified-Since` 304s without reading
- * the hash. Also sweeps tombstones older than `TOMBSTONE_RETENTION_MS`
- * so the user-index hash doesn't grow unboundedly over a user's lifetime.
+ * the hash. Opportunistically sweeps tombstones past `TOMBSTONE_RETENTION_MS`.
  */
 export async function upsertEntry(
   redis: Redis,
@@ -77,14 +76,9 @@ export async function upsertEntry(
   }
 }
 
-/**
- * How long tombstones live in the index hash. Tombstones serve to inform
- * cross-device sync that an item was deleted; 90 days covers the longest
- * legitimate offline propagation window (a user signs in on a long-dormant
- * device and still gets the deletes that happened on their primary device).
- * Beyond that, a tombstone is no longer useful — keeping it forever just
- * inflates every manifest poll response.
- */
+// 90 days covers the longest legitimate offline propagation window for a
+// dormant device to still pick up deletes; beyond that the tombstone just
+// bloats every manifest poll.
 export const TOMBSTONE_RETENTION_MS = 90 * 24 * 60 * 60 * 1_000;
 
 async function findStaleTombstones(
@@ -96,6 +90,8 @@ async function findStaleTombstones(
   const raw = await redis.hgetall(userIndexKey(userId, kind));
   const stale: string[] = [];
   for (const [id, encoded] of Object.entries(raw)) {
+    // Substring check avoids JSON.parse on every live entry.
+    if (!encoded.includes('"deletedAt"')) continue;
     const parsed = parseEntry(encoded);
     if (!parsed?.deletedAt) continue;
     if (now - parsed.deletedAt > TOMBSTONE_RETENTION_MS) stale.push(id);

--- a/api/lib/userIndex.ts
+++ b/api/lib/userIndex.ts
@@ -1,5 +1,10 @@
 import type { Redis } from 'ioredis';
-import { userIndexKey, userIndexUpdatedAtKey, type SyncItemKind } from './redisKeys.js';
+import {
+  userIndexKey,
+  userIndexUpdatedAtKey,
+  userTombstoneSweptAtKey,
+  type SyncItemKind,
+} from './redisKeys.js';
 
 export type { SyncItemKind } from './redisKeys.js';
 
@@ -50,7 +55,9 @@ export async function getEntry(
 /**
  * Insert or replace an entry, atomically bumping `indexUpdatedAt` so
  * `/api/sync/manifest` can serve `If-Modified-Since` 304s without reading
- * the hash. Opportunistically sweeps tombstones past `TOMBSTONE_RETENTION_MS`.
+ * the hash. Opportunistically sweeps tombstones past `TOMBSTONE_RETENTION_MS`,
+ * but only every `SWEEP_INTERVAL_MS` — otherwise every write would HGETALL
+ * the whole index just to discover there's nothing to clean up.
  */
 export async function upsertEntry(
   redis: Redis,
@@ -60,7 +67,8 @@ export async function upsertEntry(
   entry: IndexEntry
 ): Promise<void> {
   const now = Date.now();
-  const staleTombstoneIds = await findStaleTombstones(redis, userId, kind, now);
+  const dueForSweep = await shouldSweep(redis, userId, now);
+  const staleTombstoneIds = dueForSweep ? await findStaleTombstones(redis, userId, kind, now) : [];
   const pipeline = redis.pipeline();
   pipeline.hset(userIndexKey(userId, kind), id, JSON.stringify(entry));
   for (const staleId of staleTombstoneIds) {
@@ -68,6 +76,9 @@ export async function upsertEntry(
     pipeline.hdel(userIndexKey(userId, kind), staleId);
   }
   pipeline.set(userIndexUpdatedAtKey(userId), String(now));
+  if (dueForSweep) {
+    pipeline.set(userTombstoneSweptAtKey(userId), String(now));
+  }
   const run = pipeline.exec.bind(pipeline);
   const results = await run();
   if (results === null) throw new Error('userIndex pipeline failed: redis connection lost');
@@ -80,6 +91,18 @@ export async function upsertEntry(
 // dormant device to still pick up deletes; beyond that the tombstone just
 // bloats every manifest poll.
 export const TOMBSTONE_RETENTION_MS = 90 * 24 * 60 * 60 * 1_000;
+
+// Sweep at most once per hour per user. Bounded growth between sweeps is
+// tiny (one tombstone per delete) and amortizes the HGETALL cost.
+const SWEEP_INTERVAL_MS = 60 * 60 * 1_000;
+
+async function shouldSweep(redis: Redis, userId: string, now: number): Promise<boolean> {
+  const raw = await redis.get(userTombstoneSweptAtKey(userId));
+  if (raw === null) return true;
+  const lastSweep = Number(raw);
+  if (!Number.isFinite(lastSweep)) return true;
+  return now - lastSweep >= SWEEP_INTERVAL_MS;
+}
 
 async function findStaleTombstones(
   redis: Redis,

--- a/api/lib/validation.test.ts
+++ b/api/lib/validation.test.ts
@@ -243,6 +243,35 @@ describe('validateShareLayout', () => {
         expect(result.error.code).toBe('VALIDATION_ERROR');
       }
     });
+
+    it('rejects unbounded drawer height (1e9)', () => {
+      // Regression: drawer.height was only `> 0`. A corrupted device
+      // can persist absurd values that round-trip to other devices.
+      const layout = createValidLayout();
+      layout.drawer.height = 1_000_000_000;
+      const result = validateShareLayout(layout, 1000);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe('VALIDATION_ERROR');
+      }
+    });
+
+    it('rejects drawer height below 1', () => {
+      const layout = createValidLayout();
+      layout.drawer.height = 0;
+      const result = validateShareLayout(layout, 1000);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it('accepts drawer height at the GRID_MAX cap (50)', () => {
+      const layout = createValidLayout();
+      layout.drawer.height = 50;
+      const result = validateShareLayout(layout, 1000);
+
+      expect(result.valid).toBe(true);
+    });
   });
 
   describe('layer limits', () => {

--- a/api/lib/validation.test.ts
+++ b/api/lib/validation.test.ts
@@ -245,8 +245,6 @@ describe('validateShareLayout', () => {
     });
 
     it('rejects unbounded drawer height (1e9)', () => {
-      // Regression: drawer.height was only `> 0`. A corrupted device
-      // can persist absurd values that round-trip to other devices.
       const layout = createValidLayout();
       layout.drawer.height = 1_000_000_000;
       const result = validateShareLayout(layout, 1000);
@@ -257,9 +255,9 @@ describe('validateShareLayout', () => {
       }
     });
 
-    it('rejects drawer height below 1', () => {
+    it('rejects drawer height below HEIGHT_MIN (mirrors client MIN_LAYER_HEIGHT=2)', () => {
       const layout = createValidLayout();
-      layout.drawer.height = 0;
+      layout.drawer.height = 1;
       const result = validateShareLayout(layout, 1000);
 
       expect(result.valid).toBe(false);
@@ -291,7 +289,7 @@ describe('validateShareLayout', () => {
       layout.layers = Array.from({ length: 11 }, (_, i) => ({
         id: `layer${i}`,
         name: `Layer ${i}`,
-        height: 1,
+        height: 2,
       }));
       const result = validateShareLayout(layout, 1000);
 
@@ -306,7 +304,7 @@ describe('validateShareLayout', () => {
       layout.layers = Array.from({ length: 10 }, (_, i) => ({
         id: `layer${i}`,
         name: `Layer ${i}`,
-        height: 1,
+        height: 2,
       }));
       const result = validateShareLayout(layout, 1000);
 

--- a/api/lib/validation.ts
+++ b/api/lib/validation.ts
@@ -341,7 +341,11 @@ function isValidDrawer(value: unknown): value is DrawerShape {
     isNumber(value.height) &&
     value.width > 0 &&
     value.depth > 0 &&
-    value.height > 0
+    // `drawer.height` is HeightUnits in the domain model (7mm each); the
+    // client UI caps it at GRID_MAX (50). Without this server-side bound
+    // a corrupted device can persist absurd values (e.g. 1e9) that then
+    // round-trip via sync to other devices.
+    inRange(value.height, 1, SHARE_CONSTRAINTS.GRID_MAX)
   );
 }
 
@@ -351,7 +355,7 @@ function isValidLayer(value: unknown): value is LayerShape {
     typeof value.id === 'string' &&
     typeof value.name === 'string' &&
     isNumber(value.height) &&
-    value.height > 0
+    inRange(value.height, 1, SHARE_CONSTRAINTS.GRID_MAX)
   );
 }
 
@@ -370,7 +374,7 @@ function isValidBin(value: unknown): value is BinShape {
     isNumber(value.height) &&
     value.width > 0 &&
     value.depth > 0 &&
-    value.height > 0 &&
+    inRange(value.height, 1, SHARE_CONSTRAINTS.GRID_MAX) &&
     optString(value.category) &&
     optString(value.label) &&
     optString(value.notes)

--- a/api/lib/validation.ts
+++ b/api/lib/validation.ts
@@ -17,6 +17,10 @@ const SHARE_CONSTRAINTS = {
   NAME_MAX_LENGTH: 64,
   LABEL_MAX_LENGTH: 24,
   NOTES_MAX_LENGTH: 256,
+  // Mirrors client `CONSTRAINTS.MIN_BIN_HEIGHT` / `MIN_LAYER_HEIGHT` (2).
+  // Server <-> client divergence would let a peer persist height=1 that the
+  // recipient's CQRS schema rejects on the next mutation.
+  HEIGHT_MIN: 2,
   VALID_EXPIRATIONS: [30, 60, 90, 365] as const,
   // Custom properties constraints
   CUSTOM_PROPERTY_MAX_COUNT: 50,
@@ -341,11 +345,9 @@ function isValidDrawer(value: unknown): value is DrawerShape {
     isNumber(value.height) &&
     value.width > 0 &&
     value.depth > 0 &&
-    // `drawer.height` is HeightUnits in the domain model (7mm each); the
-    // client UI caps it at GRID_MAX (50). Without this server-side bound
-    // a corrupted device can persist absurd values (e.g. 1e9) that then
-    // round-trip via sync to other devices.
-    inRange(value.height, 1, SHARE_CONSTRAINTS.GRID_MAX)
+    // HeightUnits (7mm each), capped at GRID_MAX so a corrupted client
+    // can't sync absurd values to other devices.
+    inRange(value.height, SHARE_CONSTRAINTS.HEIGHT_MIN, SHARE_CONSTRAINTS.GRID_MAX)
   );
 }
 
@@ -355,7 +357,7 @@ function isValidLayer(value: unknown): value is LayerShape {
     typeof value.id === 'string' &&
     typeof value.name === 'string' &&
     isNumber(value.height) &&
-    inRange(value.height, 1, SHARE_CONSTRAINTS.GRID_MAX)
+    inRange(value.height, SHARE_CONSTRAINTS.HEIGHT_MIN, SHARE_CONSTRAINTS.GRID_MAX)
   );
 }
 
@@ -374,7 +376,7 @@ function isValidBin(value: unknown): value is BinShape {
     isNumber(value.height) &&
     value.width > 0 &&
     value.depth > 0 &&
-    inRange(value.height, 1, SHARE_CONSTRAINTS.GRID_MAX) &&
+    inRange(value.height, SHARE_CONSTRAINTS.HEIGHT_MIN, SHARE_CONSTRAINTS.GRID_MAX) &&
     optString(value.category) &&
     optString(value.label) &&
     optString(value.notes)

--- a/api/sync/designs/[id].ts
+++ b/api/sync/designs/[id].ts
@@ -190,16 +190,19 @@ async function handlePut(
     if (existing.modifiedAt === modifiedAt) {
       // Equal-ms tie: hash over `{ name, params }` so renames also participate.
       const stored = await getJson<DesignEnvelope>(blobPath(userId, id));
-      const candidate = { name, params: validation.payload.params };
-      const order = compareForTiebreaker(candidate, stored?.design);
-      if (order <= 0) {
-        res.status(409).json({
-          error: 'A newer version already exists.',
-          code: ErrorCode.VALIDATION_ERROR,
-          stored,
-          indexEntry: existing,
-        });
-        return;
+      // See layouts/[id].ts for the missing-blob rationale.
+      if (stored !== null) {
+        const candidate = { name, params: validation.payload.params };
+        const order = compareForTiebreaker(candidate, stored.design);
+        if (order <= 0) {
+          res.status(409).json({
+            error: 'A newer version already exists.',
+            code: ErrorCode.VALIDATION_ERROR,
+            stored,
+            indexEntry: existing,
+          });
+          return;
+        }
       }
     }
   }

--- a/api/sync/designs/[id].ts
+++ b/api/sync/designs/[id].ts
@@ -9,6 +9,7 @@ import { sanitizeString } from '../../lib/validation.js';
 import { deleteBlob, getJson, putJson } from '../../lib/blobStore.js';
 import { getEntry, tombstone, upsertEntry, type IndexEntry } from '../../lib/userIndex.js';
 import { checkQuota } from '../../lib/quota.js';
+import { compareForTiebreaker } from '../../lib/lwwTiebreaker.js';
 
 export const SCHEMA_VERSION = 1 as const;
 
@@ -175,15 +176,34 @@ async function handlePut(
 
   const existing = await getEntry(redis, userId, 'designs', id);
   // `deletedAt === undefined` is the explicit live-entry check.
-  if (existing && existing.deletedAt === undefined && existing.modifiedAt >= modifiedAt) {
-    const stored = await getJson<DesignEnvelope>(blobPath(userId, id));
-    res.status(409).json({
-      error: 'A newer version already exists.',
-      code: ErrorCode.VALIDATION_ERROR,
-      stored,
-      indexEntry: existing,
-    });
-    return;
+  if (existing && existing.deletedAt === undefined) {
+    if (existing.modifiedAt > modifiedAt) {
+      const stored = await getJson<DesignEnvelope>(blobPath(userId, id));
+      res.status(409).json({
+        error: 'A newer version already exists.',
+        code: ErrorCode.VALIDATION_ERROR,
+        stored,
+        indexEntry: existing,
+      });
+      return;
+    }
+    if (existing.modifiedAt === modifiedAt) {
+      // Equal-ms tie: deterministic tiebreaker on canonical payload hash.
+      // Compare the wrapped `{ name, params }` shape so name changes also
+      // participate in the tiebreak (not just params).
+      const stored = await getJson<DesignEnvelope>(blobPath(userId, id));
+      const candidate = { name, params: validation.payload.params };
+      const order = compareForTiebreaker(candidate, stored?.design);
+      if (order <= 0) {
+        res.status(409).json({
+          error: 'A newer version already exists.',
+          code: ErrorCode.VALIDATION_ERROR,
+          stored,
+          indexEntry: existing,
+        });
+        return;
+      }
+    }
   }
 
   if (existing?.deletedAt !== undefined && existing.deletedAt >= modifiedAt) {

--- a/api/sync/designs/[id].ts
+++ b/api/sync/designs/[id].ts
@@ -188,9 +188,7 @@ async function handlePut(
       return;
     }
     if (existing.modifiedAt === modifiedAt) {
-      // Equal-ms tie: deterministic tiebreaker on canonical payload hash.
-      // Compare the wrapped `{ name, params }` shape so name changes also
-      // participate in the tiebreak (not just params).
+      // Equal-ms tie: hash over `{ name, params }` so renames also participate.
       const stored = await getJson<DesignEnvelope>(blobPath(userId, id));
       const candidate = { name, params: validation.payload.params };
       const order = compareForTiebreaker(candidate, stored?.design);

--- a/api/sync/export.test.ts
+++ b/api/sync/export.test.ts
@@ -114,8 +114,7 @@ function makeRes(): MockRes {
     },
     end() {
       this._ended = true;
-      // Streaming consumers (export ZIP) flush via write() + end(); the
-      // tests reach for `_body` so consolidate the chunks here.
+      // Consolidate streamed chunks into `_body` so existing assertions still work.
       if (this._chunks.length > 0) {
         this._body = Buffer.concat(this._chunks);
       }
@@ -233,11 +232,6 @@ describe('GET /api/sync/export', () => {
   });
 
   it('streams chunks via res.write/res.end rather than buffering with res.send', async () => {
-    // Regression: previous implementation called `zipSync` and `res.send(buffer)`
-    // — the full archive lived in memory before any byte hit the wire. The
-    // streaming rewrite must surface chunks through `write()` and finalize
-    // with `end()`. Verify the consumed transport, not the payload bytes
-    // (a separate test already round-trips the archive contents).
     await seedItem('layouts', 'lay-1', 1000, {
       layout: { name: 'L1' },
       modifiedAt: 1000,
@@ -250,8 +244,6 @@ describe('GET /api/sync/export', () => {
 
     expect(res._chunks.length).toBeGreaterThan(0);
     expect(res._ended).toBe(true);
-    // No single buffered `send` call — the response body was assembled
-    // chunk-by-chunk by the streaming Zip writer.
     expect(res.headersSent).toBe(true);
   });
 

--- a/api/sync/export.test.ts
+++ b/api/sync/export.test.ts
@@ -69,11 +69,14 @@ vi.mock('../lib/blobStore', () => ({
 interface MockRes {
   _status: number;
   _body: unknown;
+  _chunks: Buffer[];
   _headers: Record<string, string>;
   _ended: boolean;
+  headersSent: boolean;
   status(code: number): MockRes;
   json(body: unknown): MockRes;
   send(body: unknown): MockRes;
+  write(chunk: Uint8Array | Buffer | string): boolean;
   end(): MockRes;
   setHeader(k: string, v: string): MockRes;
 }
@@ -82,8 +85,10 @@ function makeRes(): MockRes {
   return {
     _status: 0,
     _body: null,
+    _chunks: [],
     _headers: {},
     _ended: false,
+    headersSent: false,
     status(code) {
       this._status = code;
       return this;
@@ -96,8 +101,24 @@ function makeRes(): MockRes {
       this._body = body;
       return this;
     },
+    write(chunk) {
+      this.headersSent = true;
+      const buf =
+        typeof chunk === 'string'
+          ? Buffer.from(chunk)
+          : Buffer.isBuffer(chunk)
+            ? chunk
+            : Buffer.from(chunk);
+      this._chunks.push(buf);
+      return true;
+    },
     end() {
       this._ended = true;
+      // Streaming consumers (export ZIP) flush via write() + end(); the
+      // tests reach for `_body` so consolidate the chunks here.
+      if (this._chunks.length > 0) {
+        this._body = Buffer.concat(this._chunks);
+      }
       return this;
     },
     setHeader(k, v) {
@@ -209,6 +230,29 @@ describe('GET /api/sync/export', () => {
     const manifest = JSON.parse(strFromU8(zip['manifest.json']));
     expect(manifest.layouts).toHaveProperty('lay-live');
     expect(manifest.layouts).not.toHaveProperty('lay-dead');
+  });
+
+  it('streams chunks via res.write/res.end rather than buffering with res.send', async () => {
+    // Regression: previous implementation called `zipSync` and `res.send(buffer)`
+    // — the full archive lived in memory before any byte hit the wire. The
+    // streaming rewrite must surface chunks through `write()` and finalize
+    // with `end()`. Verify the consumed transport, not the payload bytes
+    // (a separate test already round-trips the archive contents).
+    await seedItem('layouts', 'lay-1', 1000, {
+      layout: { name: 'L1' },
+      modifiedAt: 1000,
+      schemaVersion: 1,
+    });
+
+    const { default: handler } = await import('./export');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+
+    expect(res._chunks.length).toBeGreaterThan(0);
+    expect(res._ended).toBe(true);
+    // No single buffered `send` call — the response body was assembled
+    // chunk-by-chunk by the streaming Zip writer.
+    expect(res.headersSent).toBe(true);
   });
 
   it('returns 429 when rate-limited', async () => {

--- a/api/sync/export.ts
+++ b/api/sync/export.ts
@@ -24,10 +24,6 @@ import {
  *
  * Tombstones are excluded — the user asked to export their data, not
  * the audit trail of deletions.
- *
- * The ZIP streams chunks directly to the response — heap stays bounded
- * regardless of library size, so the 10MB-per-kind quota doesn't have
- * to translate into a ~20MB resident buffer per concurrent request.
  */
 export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
   if (!requireMethod(req, res, ['GET'])) return;
@@ -87,17 +83,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
           )
         )
       );
-      await streamEnvelopes(addFile, session.userId, 'layouts', Object.keys(liveLayouts));
-      await streamEnvelopes(addFile, session.userId, 'designs', Object.keys(liveDesigns));
+      await Promise.all([
+        streamEnvelopes(addFile, session.userId, 'layouts', Object.keys(liveLayouts)),
+        streamEnvelopes(addFile, session.userId, 'designs', Object.keys(liveDesigns)),
+      ]);
     });
   } catch (error) {
     logger.error('sync/export failed', {
       userId: session.userId,
       error: error instanceof Error ? error.message : String(error),
     });
-    // If we've already started streaming, the headers + 200 are committed
-    // and we can't send a JSON error; just terminate so the client sees
-    // a truncated ZIP and the next call surfaces the real error.
+    // Headers + 200 already flushed: can't switch to a JSON error.
     if (res.headersSent) {
       try {
         res.end();
@@ -120,18 +116,8 @@ function filterLive(index: Record<string, IndexEntry>): Record<string, IndexEntr
 
 type AddFile = (filename: string, contents: Uint8Array) => void;
 
-/**
- * Wrap fflate's callback-based streaming Zip writer in a Promise that
- * resolves once the trailing chunk has been written. The `build`
- * callback receives an `addFile` helper that pushes one whole-file
- * entry at a time; we do not need per-file streaming (entries are
- * sized in tens of KB), only archive-level streaming so peak heap
- * stays bounded.
- *
- * `level: 6` matches the prior JSZip default; keeps archive sizes
- * stable across the migration so existing client roundtrips behave
- * identically.
- */
+// `level: 6` matches the prior JSZip default; keeps archive sizes stable
+// across the migration so existing client roundtrips behave identically.
 function streamZipToResponse(
   res: VercelResponse,
   build: (addFile: AddFile) => Promise<void>
@@ -174,9 +160,7 @@ async function streamEnvelopes(
   kind: SyncItemKind,
   ids: string[]
 ): Promise<void> {
-  // Fetch envelopes in parallel; missing blobs are skipped (they shouldn't
-  // happen, but if a blob delete races with the index read we don't want
-  // the export to fail).
+  // Missing blobs (index/blob race) are skipped rather than failing the export.
   const envelopes = await Promise.all(
     ids.map((id) => getJson<unknown>(`users/${userId}/${kind}/${id}.json`))
   );

--- a/api/sync/export.ts
+++ b/api/sync/export.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { zipSync, strToU8 } from 'fflate';
+import { Zip, ZipDeflate, strToU8 } from 'fflate';
 import { requireMethod } from '../lib/method.js';
 import { ErrorCode } from '../lib/shared.js';
 import { logger } from '../lib/logger.js';
@@ -25,9 +25,9 @@ import {
  * Tombstones are excluded — the user asked to export their data, not
  * the audit trail of deletions.
  *
- * The ZIP is built in-memory. With the 10MB-per-kind quota, the worst
- * case is ~20MB pre-compression which is still well within Vercel
- * function memory limits and HTTP response timeouts.
+ * The ZIP streams chunks directly to the response — heap stays bounded
+ * regardless of library size, so the 10MB-per-kind quota doesn't have
+ * to translate into a ~20MB resident buffer per concurrent request.
  */
 export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
   if (!requireMethod(req, res, ['GET'])) return;
@@ -63,41 +63,49 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
     const liveLayouts = filterLive(layoutsIndex);
     const liveDesigns = filterLive(designsIndex);
 
-    const files: Record<string, Uint8Array> = {
-      'manifest.json': strToU8(
-        JSON.stringify(
-          {
-            layouts: liveLayouts,
-            designs: liveDesigns,
-            indexUpdatedAt,
-            exportedAt: Date.now(),
-            schemaVersion: 1,
-          },
-          null,
-          2
-        )
-      ),
-    };
-
-    await Promise.all([
-      addEnvelopes(files, session.userId, 'layouts', Object.keys(liveLayouts)),
-      addEnvelopes(files, session.userId, 'designs', Object.keys(liveDesigns)),
-    ]);
-
-    // `level: 6` matches the prior JSZip default; keeps archive sizes stable
-    // across the migration so existing client roundtrips behave identically.
-    const buffer = Buffer.from(zipSync(files, { level: 6 }));
     res.setHeader('Content-Type', 'application/zip');
     res.setHeader(
       'Content-Disposition',
       `attachment; filename="gridfinity-export-${session.userId.slice(0, 8)}.zip"`
     );
-    res.status(200).send(buffer);
+    res.status(200);
+
+    await streamZipToResponse(res, async (addFile) => {
+      addFile(
+        'manifest.json',
+        strToU8(
+          JSON.stringify(
+            {
+              layouts: liveLayouts,
+              designs: liveDesigns,
+              indexUpdatedAt,
+              exportedAt: Date.now(),
+              schemaVersion: 1,
+            },
+            null,
+            2
+          )
+        )
+      );
+      await streamEnvelopes(addFile, session.userId, 'layouts', Object.keys(liveLayouts));
+      await streamEnvelopes(addFile, session.userId, 'designs', Object.keys(liveDesigns));
+    });
   } catch (error) {
     logger.error('sync/export failed', {
       userId: session.userId,
       error: error instanceof Error ? error.message : String(error),
     });
+    // If we've already started streaming, the headers + 200 are committed
+    // and we can't send a JSON error; just terminate so the client sees
+    // a truncated ZIP and the next call surfaces the real error.
+    if (res.headersSent) {
+      try {
+        res.end();
+      } catch {
+        /* nothing to do */
+      }
+      return;
+    }
     res.status(500).json({ error: 'Server error', code: ErrorCode.SERVER_ERROR });
   }
 }
@@ -110,8 +118,58 @@ function filterLive(index: Record<string, IndexEntry>): Record<string, IndexEntr
   return out;
 }
 
-async function addEnvelopes(
-  files: Record<string, Uint8Array>,
+type AddFile = (filename: string, contents: Uint8Array) => void;
+
+/**
+ * Wrap fflate's callback-based streaming Zip writer in a Promise that
+ * resolves once the trailing chunk has been written. The `build`
+ * callback receives an `addFile` helper that pushes one whole-file
+ * entry at a time; we do not need per-file streaming (entries are
+ * sized in tens of KB), only archive-level streaming so peak heap
+ * stays bounded.
+ *
+ * `level: 6` matches the prior JSZip default; keeps archive sizes
+ * stable across the migration so existing client roundtrips behave
+ * identically.
+ */
+function streamZipToResponse(
+  res: VercelResponse,
+  build: (addFile: AddFile) => Promise<void>
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
+
+    const zip = new Zip((err, chunk, final) => {
+      if (err) {
+        settle(() => reject(err instanceof Error ? err : new Error(String(err))));
+        return;
+      }
+      if (chunk.length > 0) res.write(chunk);
+      if (final) {
+        res.end();
+        settle(resolve);
+      }
+    });
+
+    build((filename, contents) => {
+      const entry = new ZipDeflate(filename, { level: 6 });
+      zip.add(entry);
+      entry.push(contents, true);
+    })
+      .then(() => zip.end())
+      .catch((error: unknown) =>
+        settle(() => reject(error instanceof Error ? error : new Error(String(error))))
+      );
+  });
+}
+
+async function streamEnvelopes(
+  addFile: AddFile,
   userId: string,
   kind: SyncItemKind,
   ids: string[]
@@ -125,7 +183,7 @@ async function addEnvelopes(
   for (let i = 0; i < ids.length; i++) {
     const envelope = envelopes[i];
     if (envelope) {
-      files[`${kind}/${ids[i]}.json`] = strToU8(JSON.stringify(envelope, null, 2));
+      addFile(`${kind}/${ids[i]}.json`, strToU8(JSON.stringify(envelope, null, 2)));
     }
   }
 }

--- a/api/sync/layouts/[id].test.ts
+++ b/api/sync/layouts/[id].test.ts
@@ -139,7 +139,7 @@ const VALID_LAYOUT = {
   name: 'Test Layout',
   drawer: { width: 5, depth: 5, height: 3 },
   bins: [],
-  layers: [{ id: 'layer-1', name: 'Layer 1', height: 1 }],
+  layers: [{ id: 'layer-1', name: 'Layer 1', height: 2 }],
   categories: [{ id: 'cat-1', name: 'Default', color: '#ff0000' }],
   printBedSize: 256,
   gridUnitMm: 42,
@@ -272,35 +272,37 @@ describe('PUT — LWW + tombstone', () => {
     expect(res._status).toBe(200);
   });
 
-  it('equal-ms LWW: resolves by canonical payload hash, deterministic across devices', async () => {
-    // Regression: `existing.modifiedAt >= modifiedAt` used `>=`, so an
-    // equal-ms write was silently 409'd. Two devices that produce the
-    // same modifiedAt for distinct payloads should converge on the
-    // SAME winner regardless of arrival order — not on "whoever raced
-    // to the index first."
+  it('equal-ms LWW: tiebreaker is deterministic and complementary across orderings', async () => {
     const { default: handler } = await import('./[id]');
+    const A = { ...VALID_LAYOUT, name: 'Aardvark' };
+    const B = { ...VALID_LAYOUT, name: 'Zebra' };
 
-    // First write installs the incumbent.
-    const incumbent = { ...VALID_LAYOUT, name: 'Aardvark' };
     await handler(
-      makeReq({ method: 'PUT', body: { layout: incumbent, modifiedAt: 1000 } }),
+      makeReq({ method: 'PUT', body: { layout: A, modifiedAt: 1000 } }),
       makeRes() as unknown as VercelResponse
     );
-
-    // Equal-ms write with a distinct payload — should be resolved by
-    // tiebreaker, NOT auto-409'd just because mtimes match. We test
-    // both directions to confirm determinism.
-    const candidate = { ...VALID_LAYOUT, name: 'Zebra' };
-    const res = makeRes();
+    const res1 = makeRes();
     await handler(
-      makeReq({ method: 'PUT', body: { layout: candidate, modifiedAt: 1000 } }),
-      res as unknown as VercelResponse
+      makeReq({ method: 'PUT', body: { layout: B, modifiedAt: 1000 } }),
+      res1 as unknown as VercelResponse
     );
 
-    // The hash of the candidate either beats or loses the incumbent —
-    // either way the test must pass with a status reflecting the
-    // tiebreaker outcome (200 if candidate wins, 409 if incumbent wins).
-    expect([200, 409]).toContain(res._status);
+    redisStore = new Map();
+    redisHashes = new Map();
+    blobStore.clear();
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: B, modifiedAt: 1000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+    const res2 = makeRes();
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: A, modifiedAt: 1000 } }),
+      res2 as unknown as VercelResponse
+    );
+
+    // Asymmetry across orderings proves determinism: auto-409 yields [409,409], unconditional [200,200].
+    const statuses = [res1._status, res2._status].sort();
+    expect(statuses).toEqual([200, 409]);
   });
 
   it('equal-ms LWW: identical payloads return 409 (no unnecessary write)', async () => {
@@ -314,7 +316,6 @@ describe('PUT — LWW + tombstone', () => {
       makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 1000 } }),
       res as unknown as VercelResponse
     );
-    // Hash equal → order === 0 → incumbent wins (no churn).
     expect(res._status).toBe(409);
   });
 

--- a/api/sync/layouts/[id].test.ts
+++ b/api/sync/layouts/[id].test.ts
@@ -272,6 +272,52 @@ describe('PUT — LWW + tombstone', () => {
     expect(res._status).toBe(200);
   });
 
+  it('equal-ms LWW: resolves by canonical payload hash, deterministic across devices', async () => {
+    // Regression: `existing.modifiedAt >= modifiedAt` used `>=`, so an
+    // equal-ms write was silently 409'd. Two devices that produce the
+    // same modifiedAt for distinct payloads should converge on the
+    // SAME winner regardless of arrival order — not on "whoever raced
+    // to the index first."
+    const { default: handler } = await import('./[id]');
+
+    // First write installs the incumbent.
+    const incumbent = { ...VALID_LAYOUT, name: 'Aardvark' };
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: incumbent, modifiedAt: 1000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+
+    // Equal-ms write with a distinct payload — should be resolved by
+    // tiebreaker, NOT auto-409'd just because mtimes match. We test
+    // both directions to confirm determinism.
+    const candidate = { ...VALID_LAYOUT, name: 'Zebra' };
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: candidate, modifiedAt: 1000 } }),
+      res as unknown as VercelResponse
+    );
+
+    // The hash of the candidate either beats or loses the incumbent —
+    // either way the test must pass with a status reflecting the
+    // tiebreaker outcome (200 if candidate wins, 409 if incumbent wins).
+    expect([200, 409]).toContain(res._status);
+  });
+
+  it('equal-ms LWW: identical payloads return 409 (no unnecessary write)', async () => {
+    const { default: handler } = await import('./[id]');
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 1000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: VALID_LAYOUT, modifiedAt: 1000 } }),
+      res as unknown as VercelResponse
+    );
+    // Hash equal → order === 0 → incumbent wins (no churn).
+    expect(res._status).toBe(409);
+  });
+
   it('rejects 400 when modifiedAt is missing or non-numeric', async () => {
     const { default: handler } = await import('./[id]');
     const res = makeRes();

--- a/api/sync/layouts/[id].ts
+++ b/api/sync/layouts/[id].ts
@@ -150,10 +150,7 @@ async function handlePut(
       return;
     }
     if (existing.modifiedAt === modifiedAt) {
-      // Equal-ms tie: deterministic tiebreaker on canonical payload hash
-      // so two devices that produce the same modifiedAt for distinct
-      // payloads converge on the same winner — instead of the opaque
-      // "whoever raced to the index first" behavior.
+      // Equal-ms tie: deterministic tiebreaker so concurrent devices converge.
       const stored = await getJson<LayoutEnvelope>(blobPath(userId, id));
       const order = compareForTiebreaker(validation.layout, stored?.layout);
       if (order <= 0) {
@@ -165,8 +162,6 @@ async function handlePut(
         });
         return;
       }
-      // order === 1: candidate hash sorts lexicographically larger, so it
-      // wins the tie and falls through to the normal write path below.
     }
   }
 

--- a/api/sync/layouts/[id].ts
+++ b/api/sync/layouts/[id].ts
@@ -8,6 +8,7 @@ import { isValidationError, validateShareLayout } from '../../lib/validation.js'
 import { deleteBlob, getJson, putJson } from '../../lib/blobStore.js';
 import { getEntry, tombstone, upsertEntry, type IndexEntry } from '../../lib/userIndex.js';
 import { checkQuota } from '../../lib/quota.js';
+import { compareForTiebreaker } from '../../lib/lwwTiebreaker.js';
 
 export const SCHEMA_VERSION = 1 as const;
 
@@ -137,15 +138,36 @@ async function handlePut(
   // LWW comparison. `deletedAt === undefined` is the explicit live-entry
   // check — `!existing.deletedAt` would also accept 0/NaN, which would
   // misclassify any future tombstone written with such a value.
-  if (existing && existing.deletedAt === undefined && existing.modifiedAt >= modifiedAt) {
-    const stored = await getJson<LayoutEnvelope>(blobPath(userId, id));
-    res.status(409).json({
-      error: 'A newer version already exists.',
-      code: ErrorCode.VALIDATION_ERROR,
-      stored,
-      indexEntry: existing,
-    });
-    return;
+  if (existing && existing.deletedAt === undefined) {
+    if (existing.modifiedAt > modifiedAt) {
+      const stored = await getJson<LayoutEnvelope>(blobPath(userId, id));
+      res.status(409).json({
+        error: 'A newer version already exists.',
+        code: ErrorCode.VALIDATION_ERROR,
+        stored,
+        indexEntry: existing,
+      });
+      return;
+    }
+    if (existing.modifiedAt === modifiedAt) {
+      // Equal-ms tie: deterministic tiebreaker on canonical payload hash
+      // so two devices that produce the same modifiedAt for distinct
+      // payloads converge on the same winner — instead of the opaque
+      // "whoever raced to the index first" behavior.
+      const stored = await getJson<LayoutEnvelope>(blobPath(userId, id));
+      const order = compareForTiebreaker(validation.layout, stored?.layout);
+      if (order <= 0) {
+        res.status(409).json({
+          error: 'A newer version already exists.',
+          code: ErrorCode.VALIDATION_ERROR,
+          stored,
+          indexEntry: existing,
+        });
+        return;
+      }
+      // order === 1: candidate hash sorts lexicographically larger, so it
+      // wins the tie and falls through to the normal write path below.
+    }
   }
 
   // Tombstone protection: a stale edit can't resurrect a deletion that

--- a/api/sync/layouts/[id].ts
+++ b/api/sync/layouts/[id].ts
@@ -152,15 +152,21 @@ async function handlePut(
     if (existing.modifiedAt === modifiedAt) {
       // Equal-ms tie: deterministic tiebreaker so concurrent devices converge.
       const stored = await getJson<LayoutEnvelope>(blobPath(userId, id));
-      const order = compareForTiebreaker(validation.layout, stored?.layout);
-      if (order <= 0) {
-        res.status(409).json({
-          error: 'A newer version already exists.',
-          code: ErrorCode.VALIDATION_ERROR,
-          stored,
-          indexEntry: existing,
-        });
-        return;
+      // Blob missing while index entry exists = divergence (deleted blob,
+      // failed prior write, etc.). Let the candidate repair it instead of
+      // running a tiebreaker against `undefined`, which would arbitrarily
+      // 409 a write that could have fixed the gap.
+      if (stored !== null) {
+        const order = compareForTiebreaker(validation.layout, stored.layout);
+        if (order <= 0) {
+          res.status(409).json({
+            error: 'A newer version already exists.',
+            code: ErrorCode.VALIDATION_ERROR,
+            stored,
+            indexEntry: existing,
+          });
+          return;
+        }
       }
     }
   }

--- a/src/core/sync/adapters/layoutAdapter.test.ts
+++ b/src/core/sync/adapters/layoutAdapter.test.ts
@@ -13,12 +13,14 @@ const loadLayoutAsyncMock = vi.fn();
 const saveLayoutAsyncMock = vi.fn();
 const saveLibraryMock = vi.fn();
 const loadLayoutSyncMock = vi.fn();
+const computePreviewMock = vi.fn();
 
 vi.mock('@/core/storage', () => ({
   loadLayoutAsync: (id: string) => loadLayoutAsyncMock(id),
   saveLayoutAsync: (id: string, layout: unknown) => saveLayoutAsyncMock(id, layout),
   saveLibrary: (lib: unknown) => saveLibraryMock(lib),
   loadLayoutSync: (id: string) => loadLayoutSyncMock(id),
+  computePreview: (layout: unknown) => computePreviewMock(layout),
 }));
 
 import { layoutAdapter, normalizeIncomingLayout } from './layoutAdapter';
@@ -140,6 +142,47 @@ describe('layoutAdapter.subscribe', () => {
 
     setLibrary([entry('lay-1', 9999)]);
     expect(events).toEqual([]);
+  });
+});
+
+describe('layoutAdapter.applyRemote — echo suppression', () => {
+  // Regression: `suppress(id)` used to run BEFORE the first `await`, and the
+  // `queueMicrotask` cleanup fired on that await boundary — clearing the
+  // suppression before `setLibrary` fired its synchronous subscribers. The
+  // engine then observed the remote-applied change as a fresh local edit
+  // and pushed it back to the server. Fix moves `suppress` to immediately
+  // before `setLibrary` so the synchronous listener firing sees the flag.
+  it('does not emit a listener event for the id being remote-applied', async () => {
+    setLibrary([entry('echo-1', 1000)]);
+    saveLayoutAsyncMock.mockResolvedValue({ ok: true, value: undefined });
+    saveLibraryMock.mockResolvedValue({ ok: true, value: undefined });
+    computePreviewMock.mockReturnValue({ binCount: 0 });
+
+    const events: AdapterChange[] = [];
+    const unsubscribe = layoutAdapter.subscribe((c) => events.push(c));
+
+    await layoutAdapter.applyRemote({
+      id: 'echo-1',
+      payload: { name: 'Remote', bins: [] } as unknown as Layout,
+      modifiedAt: 5000,
+    });
+
+    expect(events.filter((e) => e.id === 'echo-1')).toEqual([]);
+    unsubscribe();
+  });
+
+  it('does not emit a listener event for applyRemoteDelete', async () => {
+    setLibrary([entry('echo-2', 1000)]);
+    saveLibraryMock.mockResolvedValue({ ok: true, value: undefined });
+    loadLayoutSyncMock.mockReturnValue(null);
+
+    const events: AdapterChange[] = [];
+    const unsubscribe = layoutAdapter.subscribe((c) => events.push(c));
+
+    await layoutAdapter.applyRemoteDelete('echo-2');
+
+    expect(events.filter((e) => e.id === 'echo-2')).toEqual([]);
+    unsubscribe();
   });
 });
 

--- a/src/core/sync/adapters/layoutAdapter.test.ts
+++ b/src/core/sync/adapters/layoutAdapter.test.ts
@@ -146,12 +146,6 @@ describe('layoutAdapter.subscribe', () => {
 });
 
 describe('layoutAdapter.applyRemote — echo suppression', () => {
-  // Regression: `suppress(id)` used to run BEFORE the first `await`, and the
-  // `queueMicrotask` cleanup fired on that await boundary — clearing the
-  // suppression before `setLibrary` fired its synchronous subscribers. The
-  // engine then observed the remote-applied change as a fresh local edit
-  // and pushed it back to the server. Fix moves `suppress` to immediately
-  // before `setLibrary` so the synchronous listener firing sees the flag.
   it('does not emit a listener event for the id being remote-applied', async () => {
     setLibrary([entry('echo-1', 1000)]);
     saveLayoutAsyncMock.mockResolvedValue({ ok: true, value: undefined });

--- a/src/core/sync/adapters/layoutAdapter.ts
+++ b/src/core/sync/adapters/layoutAdapter.ts
@@ -48,22 +48,19 @@ export function normalizeIncomingLayout(layout: Layout): Layout {
  * registered with the engine at app-shell boot.
  *
  * Echo suppression: when the engine calls `applyRemote*` to write a
- * cloud-sourced change locally, we add the id to `suppressed` for one
- * tick. The `subscribe` listener checks the set and skips emitting,
- * so the engine doesn't observe its own remote-write as a fresh local
- * change and re-push it. Single-tick is enough because the library-
- * store change fires synchronously after `saveLibrary`.
+ * cloud-sourced change locally, we add the id to `suppressed` immediately
+ * before the synchronous `setLibrary` call that triggers subscribers.
+ * The listener checks the set and skips emitting, so the engine doesn't
+ * observe its own remote-write as a fresh local change and re-push it.
+ * Cleanup is scheduled via `queueMicrotask`: zustand fires subscribers
+ * synchronously inside `setLibrary`, so the cleanup runs at the next
+ * await boundary — after the subscriber has already observed the
+ * remote-write and skipped.
  */
 const suppressed = new Set<string>();
 
 function suppress(id: string): void {
   suppressed.add(id);
-  // Release at the next microtask checkpoint. Zustand listeners fire
-  // synchronously inside `setLibrary`, so by the time anything `await`s
-  // (the next microtask boundary) the subscriber has already observed
-  // the remote-write and skipped emitting. Releasing here keeps the
-  // suppression window minimal — a real local edit on the same id
-  // arriving on the next tick still pushes normally.
   queueMicrotask(() => suppressed.delete(id));
 }
 
@@ -88,14 +85,9 @@ export const layoutAdapter: LayoutAdapter = {
   },
 
   async applyRemote(item: SyncableItem<Layout>): Promise<void> {
-    suppress(item.id);
-
     const layout = normalizeIncomingLayout(item.payload);
     const saveResult = await saveLayoutAsync(item.id, layout);
     if (!saveResult.ok) {
-      // Storage failure — the engine catches and surfaces a toast. We
-      // still leave the suppression in place; releasing it on the next
-      // tick is harmless.
       throw new Error(`saveLayoutAsync failed for ${item.id}`);
     }
 
@@ -129,6 +121,7 @@ export const layoutAdapter: LayoutAdapter = {
             } satisfies LayoutEntry,
           ];
     const nextLibrary: LayoutLibrary = { ...library, entries: nextEntries };
+    suppress(item.id);
     setLibrary(nextLibrary);
     const libraryResult = await saveLibrary(nextLibrary);
     if (isErr(libraryResult)) {
@@ -146,8 +139,6 @@ export const layoutAdapter: LayoutAdapter = {
   },
 
   async applyRemoteDelete(id: string): Promise<void> {
-    suppress(id);
-
     // Drop from library entries and persist. We don't proactively
     // remove the layout blob from IndexedDB here — that happens via
     // the existing delete flow when the user navigates away. The
@@ -160,6 +151,7 @@ export const layoutAdapter: LayoutAdapter = {
       ...library,
       entries: library.entries.filter((e) => e.id !== id),
     };
+    suppress(id);
     setLibrary(nextLibrary);
     const libraryResult = await saveLibrary(nextLibrary);
     if (isErr(libraryResult)) {

--- a/src/core/sync/adapters/layoutAdapter.ts
+++ b/src/core/sync/adapters/layoutAdapter.ts
@@ -47,15 +47,10 @@ export function normalizeIncomingLayout(layout: Layout): Layout {
  * `DesignAdapter` lives in `src/features/bin-designer/sync/` and is
  * registered with the engine at app-shell boot.
  *
- * Echo suppression: when the engine calls `applyRemote*` to write a
- * cloud-sourced change locally, we add the id to `suppressed` immediately
- * before the synchronous `setLibrary` call that triggers subscribers.
- * The listener checks the set and skips emitting, so the engine doesn't
- * observe its own remote-write as a fresh local change and re-push it.
- * Cleanup is scheduled via `queueMicrotask`: zustand fires subscribers
- * synchronously inside `setLibrary`, so the cleanup runs at the next
- * await boundary — after the subscriber has already observed the
- * remote-write and skipped.
+ * Echo suppression: `suppress(id)` must run immediately before the
+ * synchronous `setLibrary` call that fires subscribers — zustand
+ * notifies listeners synchronously, so the microtask-scheduled cleanup
+ * runs after the listener has already observed and skipped.
  */
 const suppressed = new Set<string>();
 

--- a/src/core/sync/dialogs/AccountMismatchDialog.test.tsx
+++ b/src/core/sync/dialogs/AccountMismatchDialog.test.tsx
@@ -63,11 +63,7 @@ describe('AccountMismatchDialog', () => {
   });
 
   it('makes the non-destructive Merge button the primary action', () => {
-    // Regression: Discard was `variant="primary"` so a reflex Enter press
-    // on dialog open would wipe local data. The dialog's own docstring
-    // says Escape and reflex inputs must not cause either outcome —
-    // primary must be the safe (merge) path, danger emphasizes the
-    // destructive (discard) path.
+    // A reflex Enter on dialog open must not fire the destructive discard.
     render(
       <AccountMismatchDialog
         isOpen={true}
@@ -78,8 +74,6 @@ describe('AccountMismatchDialog', () => {
     );
     const merge = screen.getByText(/syncDialog\.accountMismatch\.merge/).closest('button');
     const discard = screen.getByText('syncDialog.accountMismatch.discard').closest('button');
-    // Primary variant uses `from-accent`; danger uses `from-error`/`to-danger`.
-    // See `src/design-system/variants.ts:145`.
     expect(merge?.className).toMatch(/from-accent/);
     expect(discard?.className).toMatch(/to-danger/);
   });

--- a/src/core/sync/dialogs/AccountMismatchDialog.test.tsx
+++ b/src/core/sync/dialogs/AccountMismatchDialog.test.tsx
@@ -62,6 +62,28 @@ describe('AccountMismatchDialog', () => {
     expect(onChoice).not.toHaveBeenCalled();
   });
 
+  it('makes the non-destructive Merge button the primary action', () => {
+    // Regression: Discard was `variant="primary"` so a reflex Enter press
+    // on dialog open would wipe local data. The dialog's own docstring
+    // says Escape and reflex inputs must not cause either outcome —
+    // primary must be the safe (merge) path, danger emphasizes the
+    // destructive (discard) path.
+    render(
+      <AccountMismatchDialog
+        isOpen={true}
+        localCount={3}
+        newAccountLabel="a@example.com"
+        onChoice={vi.fn()}
+      />
+    );
+    const merge = screen.getByText(/syncDialog\.accountMismatch\.merge/).closest('button');
+    const discard = screen.getByText('syncDialog.accountMismatch.discard').closest('button');
+    // Primary variant uses `from-accent`; danger uses `from-error`/`to-danger`.
+    // See `src/design-system/variants.ts:145`.
+    expect(merge?.className).toMatch(/from-accent/);
+    expect(discard?.className).toMatch(/to-danger/);
+  });
+
   it('passes count and account to the message body', () => {
     render(
       <AccountMismatchDialog

--- a/src/core/sync/dialogs/AccountMismatchDialog.tsx
+++ b/src/core/sync/dialogs/AccountMismatchDialog.tsx
@@ -34,11 +34,11 @@ export function AccountMismatchDialog({
         </p>
       </Dialog.Body>
       <Dialog.Footer>
-        <Button variant="ghost" onClick={() => onChoice('merge')}>
-          {t('syncDialog.accountMismatch.merge', { account: newAccountLabel })}
-        </Button>
-        <Button variant="primary" onClick={() => onChoice('discard')}>
+        <Button variant="danger" onClick={() => onChoice('discard')}>
           {t('syncDialog.accountMismatch.discard')}
+        </Button>
+        <Button variant="primary" onClick={() => onChoice('merge')}>
+          {t('syncDialog.accountMismatch.merge', { account: newAccountLabel })}
         </Button>
       </Dialog.Footer>
     </Dialog.Root>

--- a/src/core/sync/engine.test.ts
+++ b/src/core/sync/engine.test.ts
@@ -235,21 +235,10 @@ describe('push: 413 quota exceeded', () => {
 
 describe('push: uncaught rejections in fire-and-forget paths', () => {
   it('reports a network rejection from the scheduled drain via reportError instead of bubbling unhandled', async () => {
-    // fetch rejects (network error / abort). Without the catch wrapper,
-    // this surfaces as `window.unhandledrejection` — invisible to the
-    // user and useless for diagnosis.
     fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
 
     engine.start(adapters);
-    // triggerChange goes through onLocalChange → scheduleDrain → setTimeout
-    // → drain. The drain rejection must be caught at the setTimeout
-    // boundary, not allowed to bubble as unhandled. We avoid `flushNow`
-    // here because the test wants to exercise the fire-and-forget path,
-    // not the direct-await path.
     layoutsAdapter.triggerChange({ kind: 'put', id: 'lay-1', modifiedAt: 1000 });
-    // Wait long enough for the setTimeout-scheduled drain to fire and
-    // the rejection to flow through the catch wrapper into the status
-    // store. 50ms is generous; the actual scheduled delay is 0ms.
     await new Promise((r) => setTimeout(r, 50));
 
     expect(useSyncStatusStore.getState().state).toBe('error');
@@ -275,9 +264,6 @@ describe('push: 429 rate-limited', () => {
 
     const entries = await outboxGetAll();
     expect(entries).toHaveLength(1);
-    // attempts MUST NOT be incremented — 429 is server throttling, not a
-    // push-payload failure. Burning the attempts budget on rate limits
-    // would let a busy minute drop legitimate writes.
     expect(entries[0].attempts).toBe(0);
     expect(entries[0].nextAttemptAt).toBeGreaterThan(Date.now() + 3_000);
     expect(useSyncStatusStore.getState().state).toBe('offline');
@@ -294,9 +280,22 @@ describe('push: 429 rate-limited', () => {
     const entries = await outboxGetAll();
     expect(entries).toHaveLength(1);
     expect(entries[0].attempts).toBe(0);
-    // First retry at ~1s after now (jitter adds 0-200ms).
     expect(entries[0].nextAttemptAt).toBeGreaterThanOrEqual(Date.now() + 900);
     expect(entries[0].nextAttemptAt).toBeLessThan(Date.now() + 2_000);
+  });
+
+  it('falls back to backoff when Retry-After is 0 (no immediate-retry loop)', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, { status: 429, headers: { 'Retry-After': '0' } })
+    );
+
+    engine.start(adapters);
+    layoutsAdapter.triggerChange({ kind: 'put', id: 'lay-1', modifiedAt: 1000 });
+    await flush();
+
+    const entries = await outboxGetAll();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].nextAttemptAt).toBeGreaterThanOrEqual(Date.now() + 900);
   });
 });
 

--- a/src/core/sync/engine.test.ts
+++ b/src/core/sync/engine.test.ts
@@ -233,6 +233,49 @@ describe('push: 413 quota exceeded', () => {
   });
 });
 
+describe('push: 429 rate-limited', () => {
+  it('reschedules without bumping attempts, reports offline, and does not give up', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Too many requests' }), {
+        status: 429,
+        headers: { 'Content-Type': 'application/json', 'Retry-After': '5' },
+      })
+    );
+
+    engine.start(adapters);
+    const events: engine.EngineEvent[] = [];
+    engine.onEngineEvent((e) => events.push(e));
+
+    layoutsAdapter.triggerChange({ kind: 'put', id: 'lay-1', modifiedAt: 1000 });
+    await flush();
+
+    const entries = await outboxGetAll();
+    expect(entries).toHaveLength(1);
+    // attempts MUST NOT be incremented — 429 is server throttling, not a
+    // push-payload failure. Burning the attempts budget on rate limits
+    // would let a busy minute drop legitimate writes.
+    expect(entries[0].attempts).toBe(0);
+    expect(entries[0].nextAttemptAt).toBeGreaterThan(Date.now() + 3_000);
+    expect(useSyncStatusStore.getState().state).toBe('offline');
+    expect(events.filter((e) => e.type === 'sync-error' && e.reason === 'gave-up')).toEqual([]);
+  });
+
+  it('falls back to exponential backoff when Retry-After is absent', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 429 }));
+
+    engine.start(adapters);
+    layoutsAdapter.triggerChange({ kind: 'put', id: 'lay-1', modifiedAt: 1000 });
+    await flush();
+
+    const entries = await outboxGetAll();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].attempts).toBe(0);
+    // First retry at ~1s after now (jitter adds 0-200ms).
+    expect(entries[0].nextAttemptAt).toBeGreaterThanOrEqual(Date.now() + 900);
+    expect(entries[0].nextAttemptAt).toBeLessThan(Date.now() + 2_000);
+  });
+});
+
 describe('push: 5xx / network failure', () => {
   it('reschedules with backoff and reports offline', async () => {
     fetchMock.mockResolvedValueOnce(new Response(null, { status: 503 }));

--- a/src/core/sync/engine.test.ts
+++ b/src/core/sync/engine.test.ts
@@ -284,6 +284,37 @@ describe('push: 429 rate-limited', () => {
     expect(entries[0].nextAttemptAt).toBeLessThan(Date.now() + 2_000);
   });
 
+  it('bumps the per-(kind,id) rate-limit counter so backoff actually escalates', async () => {
+    // Regression: previous impl passed `entry.attempts` to
+    // `rateLimitedBackoffMs`, but `rescheduleWithoutAttempt` keeps attempts
+    // at 0 — so every 429 retried at ~1s forever. Engine now tracks a
+    // separate counter that drives the exponent.
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 429 }));
+
+    engine.start(adapters);
+    layoutsAdapter.triggerChange({ kind: 'put', id: 'lay-1', modifiedAt: 1000 });
+    await flush();
+
+    const counter = engine.__getEngineStateForTests()?.rateLimitedRetries.get('layouts:lay-1');
+    expect(counter).toBe(1);
+  });
+
+  it('resets the rate-limit counter when a push succeeds', async () => {
+    // Seed a counter as if we'd hit several 429s already, then have the
+    // next push return 200 and assert the counter is cleared. Easier
+    // than chaining 429-then-200 through the real backoff timer.
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    engine.start(adapters);
+    engine.__getEngineStateForTests()?.rateLimitedRetries.set('layouts:lay-1', 3);
+
+    layoutsAdapter.triggerChange({ kind: 'put', id: 'lay-1', modifiedAt: 1000 });
+    await flush();
+
+    expect(
+      engine.__getEngineStateForTests()?.rateLimitedRetries.get('layouts:lay-1')
+    ).toBeUndefined();
+  });
+
   it('falls back to backoff when Retry-After is 0 (no immediate-retry loop)', async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(null, { status: 429, headers: { 'Retry-After': '0' } })

--- a/src/core/sync/engine.test.ts
+++ b/src/core/sync/engine.test.ts
@@ -233,6 +233,30 @@ describe('push: 413 quota exceeded', () => {
   });
 });
 
+describe('push: uncaught rejections in fire-and-forget paths', () => {
+  it('reports a network rejection from the scheduled drain via reportError instead of bubbling unhandled', async () => {
+    // fetch rejects (network error / abort). Without the catch wrapper,
+    // this surfaces as `window.unhandledrejection` — invisible to the
+    // user and useless for diagnosis.
+    fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    engine.start(adapters);
+    // triggerChange goes through onLocalChange → scheduleDrain → setTimeout
+    // → drain. The drain rejection must be caught at the setTimeout
+    // boundary, not allowed to bubble as unhandled. We avoid `flushNow`
+    // here because the test wants to exercise the fire-and-forget path,
+    // not the direct-await path.
+    layoutsAdapter.triggerChange({ kind: 'put', id: 'lay-1', modifiedAt: 1000 });
+    // Wait long enough for the setTimeout-scheduled drain to fire and
+    // the rejection to flow through the catch wrapper into the status
+    // store. 50ms is generous; the actual scheduled delay is 0ms.
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(useSyncStatusStore.getState().state).toBe('error');
+    expect(useSyncStatusStore.getState().lastError).toContain('Failed to fetch');
+  });
+});
+
 describe('push: 429 rate-limited', () => {
   it('reschedules without bumping attempts, reports offline, and does not give up', async () => {
     fetchMock.mockResolvedValueOnce(

--- a/src/core/sync/engine.ts
+++ b/src/core/sync/engine.ts
@@ -5,8 +5,10 @@ import {
   getAll as outboxGetAll,
   markFailure as outboxMarkFailure,
   markSuccess as outboxMarkSuccess,
+  rescheduleWithoutAttempt as outboxRescheduleWithoutAttempt,
   type OutboxEntry,
 } from './outbox';
+import { parseRetryAfter, rateLimitedBackoffMs } from './retryAfter';
 import { useSyncStatusStore } from './status';
 import type { AdapterChange, SyncAdapter, SyncAdapters, SyncKind } from './adapters/types';
 
@@ -250,7 +252,18 @@ async function handleFailure(
   entry: OutboxEntry,
   s: EngineState
 ): Promise<void> {
-  // 401 is handled by apiFetch (forced sign-out). 4xx (other) gives up.
+  // 429 is server throttling, not a payload problem — retry indefinitely
+  // and don't burn the `attempts` budget. Honor `Retry-After` if the
+  // server sends it; otherwise back off exponentially with jitter.
+  if (res.status === 429) {
+    const delayMs =
+      parseRetryAfter(res.headers.get('Retry-After')) ?? rateLimitedBackoffMs(entry.attempts);
+    await outboxRescheduleWithoutAttempt(entry.kind, entry.id, delayMs);
+    useSyncStatusStore.getState().reportOffline('Rate limited');
+    scheduleDrain(s, delayMs);
+    return;
+  }
+  // 401 is handled by apiFetch (forced sign-out). Other 4xx gives up.
   // 5xx / network retries with backoff.
   const isClientError = res.status >= 400 && res.status < 500 && res.status !== 401;
   if (isClientError) {

--- a/src/core/sync/engine.ts
+++ b/src/core/sync/engine.ts
@@ -30,6 +30,14 @@ interface EngineState {
   drainTimer: ReturnType<typeof setTimeout> | null;
   /** Set to true while `stop()` is tearing down — drainer skips its tail. */
   stopping: boolean;
+  /**
+   * Per-(kind, id) count of consecutive 429s without a server-provided
+   * Retry-After. Drives `rateLimitedBackoffMs`'s exponent. Distinct from
+   * `OutboxEntry.attempts` — that field is intentionally not bumped for
+   * rate-limit responses so they don't burn the gave-up budget. Cleared
+   * on any non-429 outcome for the same item.
+   */
+  rateLimitedRetries: Map<string, number>;
 }
 
 let state: EngineState | null = null;
@@ -44,6 +52,7 @@ export function start(adapters: SyncAdapters): void {
     listeners: new Set(),
     drainTimer: null,
     stopping: false,
+    rateLimitedRetries: new Map(),
   };
   state = s;
 
@@ -156,6 +165,7 @@ async function sendOne(
   if (entry.op === 'delete') {
     const res = await apiFetch(url, { method: 'DELETE' });
     if (res.ok || res.status === 404 || res.status === 410) {
+      s.rateLimitedRetries.delete(`${entry.kind}:${entry.id}`);
       await markPushSucceeded(entry.kind, entry.id, entry.modifiedAt);
       return;
     }
@@ -183,6 +193,7 @@ async function sendOne(
   });
 
   if (res.ok) {
+    s.rateLimitedRetries.delete(`${entry.kind}:${entry.id}`);
     await markPushSucceeded(entry.kind, entry.id, latest.modifiedAt);
     return;
   }
@@ -254,17 +265,31 @@ async function handleFailure(
   entry: OutboxEntry,
   s: EngineState
 ): Promise<void> {
-  // 429: don't burn the attempts budget on server throttling.
+  // 429: don't burn the attempts budget on server throttling. `attempts`
+  // stays at 0 so MAX_ATTEMPTS doesn't trip — but we still need an
+  // escalating delay across consecutive 429s, so track that in a separate
+  // per-(kind, id) counter on the engine state. `Retry-After` overrides
+  // the counter entirely (server knows best).
   if (res.status === 429) {
+    const key = `${entry.kind}:${entry.id}`;
     const retryAfter = parseRetryAfter(res.headers.get('Retry-After'));
     // `Retry-After: 0` would otherwise pass through `??` and re-fire immediately.
-    const delayMs =
-      retryAfter !== null && retryAfter > 0 ? retryAfter : rateLimitedBackoffMs(entry.attempts);
+    let delayMs: number;
+    if (retryAfter !== null && retryAfter > 0) {
+      delayMs = retryAfter;
+    } else {
+      const prior = s.rateLimitedRetries.get(key) ?? 0;
+      delayMs = rateLimitedBackoffMs(prior);
+      s.rateLimitedRetries.set(key, prior + 1);
+    }
     await outboxRescheduleWithoutAttempt(entry.kind, entry.id, delayMs);
     useSyncStatusStore.getState().reportOffline('Rate limited');
     scheduleDrain(s, delayMs);
     return;
   }
+  // Any non-429 outcome for this item resets the rate-limit counter so
+  // an unrelated transient failure doesn't carry yesterday's exponent.
+  s.rateLimitedRetries.delete(`${entry.kind}:${entry.id}`);
   // 401 is handled by apiFetch (forced sign-out). Other 4xx gives up.
   // 5xx / network retries with backoff.
   const isClientError = res.status >= 400 && res.status < 500 && res.status !== 401;

--- a/src/core/sync/engine.ts
+++ b/src/core/sync/engine.ts
@@ -254,12 +254,12 @@ async function handleFailure(
   entry: OutboxEntry,
   s: EngineState
 ): Promise<void> {
-  // 429 is server throttling, not a payload problem — retry indefinitely
-  // and don't burn the `attempts` budget. Honor `Retry-After` if the
-  // server sends it; otherwise back off exponentially with jitter.
+  // 429: don't burn the attempts budget on server throttling.
   if (res.status === 429) {
+    const retryAfter = parseRetryAfter(res.headers.get('Retry-After'));
+    // `Retry-After: 0` would otherwise pass through `??` and re-fire immediately.
     const delayMs =
-      parseRetryAfter(res.headers.get('Retry-After')) ?? rateLimitedBackoffMs(entry.attempts);
+      retryAfter !== null && retryAfter > 0 ? retryAfter : rateLimitedBackoffMs(entry.attempts);
     await outboxRescheduleWithoutAttempt(entry.kind, entry.id, delayMs);
     useSyncStatusStore.getState().reportOffline('Rate limited');
     scheduleDrain(s, delayMs);
@@ -315,15 +315,8 @@ async function safeReadError(res: Response): Promise<string | undefined> {
   }
 }
 
-/**
- * Surface an uncaught error from a fire-and-forget path. Without this,
- * a fetch rejection (network error, abort) or IDB failure inside
- * `drain`, `rehydrate`, or `onLocalChange` would bubble up as a
- * `window.unhandledrejection` — visible in DevTools, invisible to
- * the user, and useless for diagnosis. Route it through the status
- * store so the UI reflects "something is broken" and the message
- * lands in the toast / Account tab error surface.
- */
+// Route fire-and-forget rejections into the status store so the UI
+// surfaces them instead of letting them escape as window.unhandledrejection.
 function reportUncaught(label: string, error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);
   useSyncStatusStore.getState().reportError(`${label}: ${message}`);

--- a/src/core/sync/engine.ts
+++ b/src/core/sync/engine.ts
@@ -51,12 +51,14 @@ export function start(adapters: SyncAdapters): void {
     const adapter = adapters[kind];
     s.unsubscribers.push(
       adapter.subscribe((change) => {
-        void onLocalChange(s, kind, change);
+        onLocalChange(s, kind, change).catch((error: unknown) =>
+          reportUncaught('onLocalChange', error)
+        );
       })
     );
   }
 
-  void rehydrate(s);
+  rehydrate(s).catch((error: unknown) => reportUncaught('rehydrate', error));
 }
 
 export function stop(): void {
@@ -102,7 +104,7 @@ function scheduleDrain(s: EngineState, delayMs: number): void {
   s.drainTimer = setTimeout(
     () => {
       s.drainTimer = null;
-      void drain(s);
+      drain(s).catch((error: unknown) => reportUncaught('drain', error));
     },
     Math.max(0, delayMs)
   );
@@ -311,6 +313,20 @@ async function safeReadError(res: Response): Promise<string | undefined> {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Surface an uncaught error from a fire-and-forget path. Without this,
+ * a fetch rejection (network error, abort) or IDB failure inside
+ * `drain`, `rehydrate`, or `onLocalChange` would bubble up as a
+ * `window.unhandledrejection` — visible in DevTools, invisible to
+ * the user, and useless for diagnosis. Route it through the status
+ * store so the UI reflects "something is broken" and the message
+ * lands in the toast / Account tab error surface.
+ */
+function reportUncaught(label: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  useSyncStatusStore.getState().reportError(`${label}: ${message}`);
 }
 
 function emitEngineEvent(s: EngineState, event: EngineEvent): void {

--- a/src/core/sync/outbox.ts
+++ b/src/core/sync/outbox.ts
@@ -199,12 +199,7 @@ export async function markFailure(kind: SyncKind, id: string): Promise<'reschedu
   return 'rescheduled';
 }
 
-/**
- * Reschedule an entry without bumping `attempts`. Used for 429 responses
- * where the failure is server-side throttling, not a problem with the
- * payload — counting it against the attempt budget would let a busy
- * minute exhaust `MAX_ATTEMPTS` and drop legitimate writes.
- */
+// Reschedule for 429 throttling without consuming the MAX_ATTEMPTS budget.
 export async function rescheduleWithoutAttempt(
   kind: SyncKind,
   id: string,

--- a/src/core/sync/outbox.ts
+++ b/src/core/sync/outbox.ts
@@ -200,6 +200,32 @@ export async function markFailure(kind: SyncKind, id: string): Promise<'reschedu
 }
 
 /**
+ * Reschedule an entry without bumping `attempts`. Used for 429 responses
+ * where the failure is server-side throttling, not a problem with the
+ * payload — counting it against the attempt budget would let a busy
+ * minute exhaust `MAX_ATTEMPTS` and drop legitimate writes.
+ */
+export async function rescheduleWithoutAttempt(
+  kind: SyncKind,
+  id: string,
+  delayMs: number
+): Promise<void> {
+  const db = await getDb();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  const current = (await store.get(entryKey(kind, id))) as OutboxEntry | undefined;
+  if (!current) {
+    await tx.done;
+    return;
+  }
+  await store.put({
+    ...current,
+    nextAttemptAt: Date.now() + Math.max(0, delayMs),
+  });
+  await tx.done;
+}
+
+/**
  * Remove an entry without success/failure semantics. Used when the
  * engine determines an entry is no longer applicable (e.g. user
  * signed out before we drained it).

--- a/src/core/sync/poller.test.ts
+++ b/src/core/sync/poller.test.ts
@@ -80,6 +80,17 @@ describe('pullNow — single-flight + 304 path', () => {
     fetchMock.mockRejectedValueOnce(new Error('network'));
     expect((await pullNow(adapters)).status).toBe('offline');
   });
+
+  it('returns "offline" on 429 (rate-limit) instead of error', async () => {
+    // Regression: pull side was reporting error on 429, diverging from
+    // the push side which honors Retry-After and treats 429 as throttling.
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, { status: 429, headers: { 'Retry-After': '5' } })
+    );
+    const result = await pullNow(adapters);
+    expect(result.status).toBe('offline');
+    expect(useSyncStatusStore.getState().state).toBe('offline');
+  });
 });
 
 describe('diff: only-remote (live)', () => {

--- a/src/core/sync/poller.ts
+++ b/src/core/sync/poller.ts
@@ -41,18 +41,13 @@ export async function pullNow(adapters: SyncAdapters): Promise<PullResult> {
   return inFlight;
 }
 
-/**
- * Reset the poller's per-user high-water mark. Call on sign-out so the
- * next sign-in's first poll doesn't use the prior user's
- * `lastIndexUpdatedAt` as its `If-Modified-Since` — that mismatch would
- * silently skip a fresh manifest scan for the new account.
- */
+// Reset on sign-out: without this the next user's first poll would send
+// the prior user's `lastIndexUpdatedAt` as `If-Modified-Since`.
 export function resetPullState(): void {
   lastIndexUpdatedAt = 0;
   inFlight = null;
 }
 
-/** Test-only alias retained for legacy callers in test files. */
 export function __resetForTests(): void {
   resetPullState();
 }
@@ -76,6 +71,13 @@ async function run(adapters: SyncAdapters): Promise<PullResult> {
   }
   if (manifestRes.status === 401) {
     return { status: 'unauthorized' };
+  }
+  if (manifestRes.status === 429) {
+    // Server throttling, not a real error. Treat as transient offline so
+    // the periodic poll caller backs off — mirrors the push-side 429
+    // handling in `engine.ts`.
+    useSyncStatusStore.getState().reportOffline('Rate limited');
+    return { status: 'offline' };
   }
   if (!manifestRes.ok) {
     useSyncStatusStore.getState().reportError(`manifest ${manifestRes.status}`);

--- a/src/core/sync/poller.ts
+++ b/src/core/sync/poller.ts
@@ -41,10 +41,20 @@ export async function pullNow(adapters: SyncAdapters): Promise<PullResult> {
   return inFlight;
 }
 
-/** Test-only: forget the cached `indexUpdatedAt`. */
-export function __resetForTests(): void {
+/**
+ * Reset the poller's per-user high-water mark. Call on sign-out so the
+ * next sign-in's first poll doesn't use the prior user's
+ * `lastIndexUpdatedAt` as its `If-Modified-Since` — that mismatch would
+ * silently skip a fresh manifest scan for the new account.
+ */
+export function resetPullState(): void {
   lastIndexUpdatedAt = 0;
   inFlight = null;
+}
+
+/** Test-only alias retained for legacy callers in test files. */
+export function __resetForTests(): void {
+  resetPullState();
 }
 
 async function run(adapters: SyncAdapters): Promise<PullResult> {

--- a/src/core/sync/poller.ts
+++ b/src/core/sync/poller.ts
@@ -28,6 +28,11 @@ export interface PullResult {
 
 let lastIndexUpdatedAt = 0;
 let inFlight: Promise<PullResult> | null = null;
+// Bumped by `resetPullState`. `run()` captures the value at call time;
+// if it changes before the run finishes, the run abandons its writes.
+// Prevents a pre-reset pull from re-installing the prior user's
+// `lastIndexUpdatedAt` after sign-out.
+let generation = 0;
 
 /**
  * Single-flight pull. Concurrent callers (timer + on-focus) await the
@@ -35,24 +40,27 @@ let inFlight: Promise<PullResult> | null = null;
  */
 export async function pullNow(adapters: SyncAdapters): Promise<PullResult> {
   if (inFlight) return inFlight;
-  inFlight = run(adapters).finally(() => {
+  inFlight = run(adapters, generation).finally(() => {
     inFlight = null;
   });
   return inFlight;
 }
 
 // Reset on sign-out: without this the next user's first poll would send
-// the prior user's `lastIndexUpdatedAt` as `If-Modified-Since`.
+// the prior user's `lastIndexUpdatedAt` as `If-Modified-Since`. Bumping
+// `generation` also poisons any in-flight `run()` so its late completion
+// can't re-install stale state.
 export function resetPullState(): void {
   lastIndexUpdatedAt = 0;
   inFlight = null;
+  generation++;
 }
 
 export function __resetForTests(): void {
   resetPullState();
 }
 
-async function run(adapters: SyncAdapters): Promise<PullResult> {
+async function run(adapters: SyncAdapters, capturedGeneration: number): Promise<PullResult> {
   useSyncStatusStore.getState().beginSync();
 
   let manifestRes: Response;
@@ -61,9 +69,13 @@ async function run(adapters: SyncAdapters): Promise<PullResult> {
       headers: lastIndexUpdatedAt > 0 ? { 'If-Modified-Since': String(lastIndexUpdatedAt) } : {},
     });
   } catch {
-    useSyncStatusStore.getState().reportOffline('manifest fetch failed');
+    if (capturedGeneration === generation) {
+      useSyncStatusStore.getState().reportOffline('manifest fetch failed');
+    }
     return { status: 'offline' };
   }
+
+  if (capturedGeneration !== generation) return { status: 'offline' };
 
   if (manifestRes.status === 304) {
     useSyncStatusStore.getState().succeed();
@@ -89,6 +101,11 @@ async function run(adapters: SyncAdapters): Promise<PullResult> {
   const layoutChanges = await diffKind(adapters.layouts, 'layouts', manifest.layouts);
   const designChanges = await diffKind(adapters.designs, 'designs', manifest.designs);
   const applied = layoutChanges + designChanges;
+
+  // Reset happened mid-flight — drop our results to avoid re-installing the
+  // prior user's high-water mark or applying writes that belong to a session
+  // that's been torn down.
+  if (capturedGeneration !== generation) return { status: 'offline' };
 
   lastIndexUpdatedAt = manifest.indexUpdatedAt;
   useSyncStatusStore.getState().succeed();

--- a/src/core/sync/retryAfter.test.ts
+++ b/src/core/sync/retryAfter.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { parseRetryAfter, rateLimitedBackoffMs } from './retryAfter';
+
+describe('parseRetryAfter', () => {
+  it('returns null for missing header', () => {
+    expect(parseRetryAfter(null)).toBe(null);
+  });
+
+  it('returns null for empty / whitespace', () => {
+    expect(parseRetryAfter('')).toBe(null);
+    expect(parseRetryAfter('   ')).toBe(null);
+  });
+
+  it('parses delta-seconds (integer) into ms', () => {
+    expect(parseRetryAfter('30')).toBe(30_000);
+    expect(parseRetryAfter('0')).toBe(0);
+    expect(parseRetryAfter('1')).toBe(1_000);
+  });
+
+  it('rejects non-integer / non-numeric strings that are not parseable as dates', () => {
+    expect(parseRetryAfter('thirty')).toBe(null);
+    expect(parseRetryAfter('-5')).toBe(null);
+  });
+
+  it('parses HTTP-date format', () => {
+    const now = Date.parse('2026-05-16T12:00:00.000Z');
+    const future = 'Sat, 16 May 2026 12:00:30 GMT';
+    expect(parseRetryAfter(future, now)).toBe(30_000);
+  });
+
+  it('returns 0 when HTTP-date is in the past', () => {
+    const now = Date.parse('2026-05-16T12:00:30.000Z');
+    const past = 'Sat, 16 May 2026 12:00:00 GMT';
+    expect(parseRetryAfter(past, now)).toBe(0);
+  });
+
+  it('caps unreasonably large delta-seconds at 1h', () => {
+    expect(parseRetryAfter('999999')).toBe(60 * 60 * 1_000);
+  });
+
+  it('caps unreasonably large HTTP-date deltas at 1h', () => {
+    const now = Date.parse('2026-05-16T12:00:00.000Z');
+    const farFuture = 'Sat, 16 May 2026 23:59:00 GMT';
+    expect(parseRetryAfter(farFuture, now)).toBe(60 * 60 * 1_000);
+  });
+});
+
+describe('rateLimitedBackoffMs', () => {
+  it('starts at ~1s for the first attempt', () => {
+    expect(rateLimitedBackoffMs(0)).toBeGreaterThanOrEqual(1_000);
+    expect(rateLimitedBackoffMs(0)).toBeLessThan(1_200);
+  });
+
+  it('doubles per attempt up to the 30s cap', () => {
+    expect(rateLimitedBackoffMs(1)).toBeGreaterThanOrEqual(2_000);
+    expect(rateLimitedBackoffMs(1)).toBeLessThan(2_200);
+    expect(rateLimitedBackoffMs(2)).toBeGreaterThanOrEqual(4_000);
+    expect(rateLimitedBackoffMs(3)).toBeGreaterThanOrEqual(8_000);
+    expect(rateLimitedBackoffMs(4)).toBeGreaterThanOrEqual(16_000);
+  });
+
+  it('caps the base at 30s even for large attempt counts', () => {
+    expect(rateLimitedBackoffMs(20)).toBeGreaterThanOrEqual(30_000);
+    expect(rateLimitedBackoffMs(20)).toBeLessThan(30_200);
+  });
+
+  it('clamps negative attempt counts to 0', () => {
+    expect(rateLimitedBackoffMs(-1)).toBeGreaterThanOrEqual(1_000);
+    expect(rateLimitedBackoffMs(-1)).toBeLessThan(1_200);
+  });
+});

--- a/src/core/sync/retryAfter.ts
+++ b/src/core/sync/retryAfter.ts
@@ -1,5 +1,6 @@
 // Parse RFC 9110 §10.2.3 `Retry-After`: either `delta-seconds` or `HTTP-date`.
-// Returns null when absent/malformed; result is capped at 1h.
+// Returns null when absent/malformed; 0 for past HTTP-dates (engine callers
+// treat 0 as "no usable hint" and fall back to their own backoff). Capped at 1h.
 const MAX_RETRY_AFTER_MS = 60 * 60 * 1_000;
 
 export function parseRetryAfter(value: string | null, now: number = Date.now()): number | null {

--- a/src/core/sync/retryAfter.ts
+++ b/src/core/sync/retryAfter.ts
@@ -1,13 +1,5 @@
-/**
- * Parse an HTTP `Retry-After` header value into a delay in milliseconds.
- *
- * Per RFC 9110 §10.2.3 the value is either:
- *   - `delta-seconds`: a non-negative integer number of seconds
- *   - `HTTP-date`: an absolute date (RFC 1123 format)
- *
- * Returns null if the value is absent, malformed, in the past, or
- * unreasonably large (capped at 1h to bound the wait window).
- */
+// Parse RFC 9110 §10.2.3 `Retry-After`: either `delta-seconds` or `HTTP-date`.
+// Returns null when absent/malformed; result is capped at 1h.
 const MAX_RETRY_AFTER_MS = 60 * 60 * 1_000;
 
 export function parseRetryAfter(value: string | null, now: number = Date.now()): number | null {
@@ -21,10 +13,8 @@ export function parseRetryAfter(value: string | null, now: number = Date.now()):
     return Math.min(seconds * 1_000, MAX_RETRY_AFTER_MS);
   }
 
-  // Only attempt Date.parse on strings that look like a real HTTP-date
-  // (RFC 1123 / RFC 850 / asctime — all start with a 3+ letter token).
-  // Without this gate, V8 happily parses things like "-5" into nonsensical
-  // year-month epochs.
+  // Gate Date.parse on a leading 3-letter token; otherwise V8 parses
+  // junk like "-5" into nonsensical epochs.
   if (!/^[A-Za-z]{3}/.test(trimmed)) return null;
   const asDate = Date.parse(trimmed);
   if (!Number.isFinite(asDate)) return null;
@@ -33,16 +23,12 @@ export function parseRetryAfter(value: string | null, now: number = Date.now()):
   return Math.min(delta, MAX_RETRY_AFTER_MS);
 }
 
-/**
- * Exponential backoff for rate-limited (429) retries when no `Retry-After`
- * header is present. Uses the attempt counter as the exponent (capped at
- * 5 so it can't blow past 30s on a busy minute), then adds 0-200ms of
- * jitter so concurrent tabs don't synchronize their retries.
- */
+// Exponential backoff for 429 retries with jitter to desynchronize tabs.
 export function rateLimitedBackoffMs(attempts: number): number {
   const exponent = Math.min(Math.max(0, attempts), 5);
-  const base = 1_000 * 2 ** exponent;
-  const capped = Math.min(base, 30_000);
+  // Cap the deterministic part before adding jitter so saturated tabs
+  // don't all collapse to exactly 30s (thundering herd).
+  const base = Math.min(1_000 * 2 ** exponent, 30_000);
   const jitter = Math.floor(Math.random() * 200);
-  return capped + jitter;
+  return base + jitter;
 }

--- a/src/core/sync/retryAfter.ts
+++ b/src/core/sync/retryAfter.ts
@@ -1,0 +1,48 @@
+/**
+ * Parse an HTTP `Retry-After` header value into a delay in milliseconds.
+ *
+ * Per RFC 9110 §10.2.3 the value is either:
+ *   - `delta-seconds`: a non-negative integer number of seconds
+ *   - `HTTP-date`: an absolute date (RFC 1123 format)
+ *
+ * Returns null if the value is absent, malformed, in the past, or
+ * unreasonably large (capped at 1h to bound the wait window).
+ */
+const MAX_RETRY_AFTER_MS = 60 * 60 * 1_000;
+
+export function parseRetryAfter(value: string | null, now: number = Date.now()): number | null {
+  if (value === null) return null;
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number(trimmed);
+    if (!Number.isFinite(seconds) || seconds < 0) return null;
+    return Math.min(seconds * 1_000, MAX_RETRY_AFTER_MS);
+  }
+
+  // Only attempt Date.parse on strings that look like a real HTTP-date
+  // (RFC 1123 / RFC 850 / asctime — all start with a 3+ letter token).
+  // Without this gate, V8 happily parses things like "-5" into nonsensical
+  // year-month epochs.
+  if (!/^[A-Za-z]{3}/.test(trimmed)) return null;
+  const asDate = Date.parse(trimmed);
+  if (!Number.isFinite(asDate)) return null;
+  const delta = asDate - now;
+  if (delta <= 0) return 0;
+  return Math.min(delta, MAX_RETRY_AFTER_MS);
+}
+
+/**
+ * Exponential backoff for rate-limited (429) retries when no `Retry-After`
+ * header is present. Uses the attempt counter as the exponent (capped at
+ * 5 so it can't blow past 30s on a busy minute), then adds 0-200ms of
+ * jitter so concurrent tabs don't synchronize their retries.
+ */
+export function rateLimitedBackoffMs(attempts: number): number {
+  const exponent = Math.min(Math.max(0, attempts), 5);
+  const base = 1_000 * 2 ** exponent;
+  const capped = Math.min(base, 30_000);
+  const jitter = Math.floor(Math.random() * 200);
+  return capped + jitter;
+}

--- a/src/core/sync/session/useSession.test.ts
+++ b/src/core/sync/session/useSession.test.ts
@@ -94,6 +94,36 @@ describe('useSessionLifecycle', () => {
     });
     expect(useSessionStore.getState().status).toBe('anonymous');
   });
+
+  it('forced-sign-out clears outbox + resets poller (cross-account leak guard)', async () => {
+    // Without these cleanups, user A's queued PUTs survive into a user B
+    // sign-in that picks 'merge' in the mismatch dialog, leaking A's
+    // edits into B's account.
+    const outboxModule = await import('../outbox');
+    const pollerModule = await import('../poller');
+    const clearAllSpy = vi.spyOn(outboxModule, 'clearAll').mockResolvedValueOnce();
+    const resetPullStateSpy = vi.spyOn(pollerModule, 'resetPullState').mockImplementation(() => {});
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ userId: 'u1', provider: 'google', email: 'a@x' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    renderHook(() => useSessionLifecycle());
+    await waitFor(() => {
+      expect(useSessionStore.getState().status).toBe('authenticated');
+    });
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('gflt:forced-sign-out'));
+    });
+
+    expect(clearAllSpy).toHaveBeenCalled();
+    expect(resetPullStateSpy).toHaveBeenCalled();
+    clearAllSpy.mockRestore();
+    resetPullStateSpy.mockRestore();
+  });
 });
 
 describe('applyRemoteState (broadcast-receiver path)', () => {

--- a/src/core/sync/session/useSession.ts
+++ b/src/core/sync/session/useSession.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import { useEffect } from 'react';
 import { FORCED_SIGN_OUT_EVENT } from '../apiFetch';
+import { clearAll as clearOutbox } from '../outbox';
+import { resetPullState } from '../poller';
 import { getMe, type SessionUser } from './sessionApi';
 
 export type SessionStatus = 'unknown' | 'anonymous' | 'authenticated';
@@ -114,6 +116,16 @@ export function useSessionLifecycle(): void {
       }
     };
     const onForcedSignOut = () => {
+      // Cookie is already invalid — any pending push will 401 too. Wipe
+      // the outbox and reset the manifest high-water mark so a later
+      // sign-in (especially as a different user via the mismatch flow's
+      // 'merge' path) can't drain the prior user's queued PUTs under
+      // the new account. Pending edits since the last successful push
+      // are sacrificed; cross-account leakage would be worse.
+      void clearOutbox().catch(() => {
+        /* IDB failure is non-blocking; setAnonymous below still flips UI */
+      });
+      resetPullState();
       useSessionStore.getState().setAnonymous();
     };
     const onChannelMessage = (e: MessageEvent<SessionBroadcast | undefined>) => {

--- a/src/core/sync/signOut.test.ts
+++ b/src/core/sync/signOut.test.ts
@@ -8,6 +8,7 @@ const getPendingEntriesMock = vi.fn();
 const apiSignOutMock = vi.fn();
 const clearOutboxMock = vi.fn();
 const stopEngineMock = vi.fn();
+const resetPullStateMock = vi.fn();
 
 vi.mock('./engine', () => ({
   flushNow: () => flushNowMock(),
@@ -21,6 +22,10 @@ vi.mock('./session/sessionApi', () => ({
 
 vi.mock('./outbox', () => ({
   clearAll: () => clearOutboxMock(),
+}));
+
+vi.mock('./poller', () => ({
+  resetPullState: () => resetPullStateMock(),
 }));
 
 interface MockAdapter extends SyncAdapter {
@@ -218,6 +223,29 @@ describe('runSignOut — outbox flush', () => {
     const result = await promise;
     expect(result.status).toBe('kept');
     expect(apiSignOutMock).toHaveBeenCalled();
+  });
+});
+
+describe('runSignOut — poller high-water reset', () => {
+  // Regression: poller.ts holds `lastIndexUpdatedAt` at module scope as
+  // a per-user high-water mark. Without resetting it on sign-out the
+  // next sign-in's first poll sends the prior user's timestamp as
+  // `If-Modified-Since`, and silently skips a fresh manifest scan for
+  // the new account.
+  it('resets the poller high-water mark on the keep path', async () => {
+    await runSignOut({ adapters, promptKeepLocal: promptKeep, onAnonymous });
+    expect(resetPullStateMock).toHaveBeenCalled();
+  });
+
+  it('resets the poller high-water mark on the wipe path', async () => {
+    await runSignOut({ adapters, promptKeepLocal: promptWipe, onAnonymous });
+    expect(resetPullStateMock).toHaveBeenCalled();
+  });
+
+  it('does not reset the poller on cancel (user is still signed in)', async () => {
+    const promptCancel: KeepLocalPrompt = vi.fn(async () => 'cancel');
+    await runSignOut({ adapters, promptKeepLocal: promptCancel, onAnonymous });
+    expect(resetPullStateMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/core/sync/signOut.test.ts
+++ b/src/core/sync/signOut.test.ts
@@ -227,11 +227,6 @@ describe('runSignOut — outbox flush', () => {
 });
 
 describe('runSignOut — poller high-water reset', () => {
-  // Regression: poller.ts holds `lastIndexUpdatedAt` at module scope as
-  // a per-user high-water mark. Without resetting it on sign-out the
-  // next sign-in's first poll sends the prior user's timestamp as
-  // `If-Modified-Since`, and silently skips a fresh manifest scan for
-  // the new account.
   it('resets the poller high-water mark on the keep path', async () => {
     await runSignOut({ adapters, promptKeepLocal: promptKeep, onAnonymous });
     expect(resetPullStateMock).toHaveBeenCalled();

--- a/src/core/sync/signOut.ts
+++ b/src/core/sync/signOut.ts
@@ -1,6 +1,7 @@
 import { signOut as apiSignOut } from './session/sessionApi';
 import { flushNow, getPendingEntries, stop as stopEngine } from './engine';
 import { clearAll as clearOutbox } from './outbox';
+import { resetPullState } from './poller';
 import { clearLastSignedInUserId } from './claim';
 import type { SyncAdapters } from './adapters/types';
 
@@ -58,6 +59,12 @@ export async function runSignOut(ctx: SignOutContext): Promise<SignOutResult> {
   } catch {
     /* server-side logout best-effort; client state still flips below */
   }
+
+  // Clear the poller's per-user high-water mark before flipping anonymous.
+  // Without this, a subsequent sign-in on the same device would send the
+  // prior user's `lastIndexUpdatedAt` as `If-Modified-Since` and silently
+  // skip the fresh manifest scan for the new account.
+  resetPullState();
 
   ctx.onAnonymous();
   return { status: choice === 'wipe' ? 'wiped' : 'kept' };

--- a/src/core/sync/signOut.ts
+++ b/src/core/sync/signOut.ts
@@ -60,10 +60,6 @@ export async function runSignOut(ctx: SignOutContext): Promise<SignOutResult> {
     /* server-side logout best-effort; client state still flips below */
   }
 
-  // Clear the poller's per-user high-water mark before flipping anonymous.
-  // Without this, a subsequent sign-in on the same device would send the
-  // prior user's `lastIndexUpdatedAt` as `If-Modified-Since` and silently
-  // skip the fresh manifest scan for the new account.
   resetPullState();
 
   ctx.onAnonymous();

--- a/src/core/sync/triggers/useBeaconFlush.test.ts
+++ b/src/core/sync/triggers/useBeaconFlush.test.ts
@@ -43,24 +43,55 @@ function makeAdapters(layoutPayload: Record<string, unknown> | null = { v: 1 }):
   };
 }
 
-async function firePageHide(): Promise<void> {
+function fireVisibilityHidden(): void {
+  Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+function firePageHide(): void {
   window.dispatchEvent(new Event('pagehide'));
-  // The handler is async; let microtasks settle.
+}
+
+// Visibility-hidden does async prep; let the IDB read and adapter.get
+// promises resolve before pagehide. In real life the gap between the
+// two events is typically tens to hundreds of ms.
+async function settlePrep(): Promise<void> {
   await new Promise((r) => setTimeout(r, 10));
 }
 
 describe('useBeaconFlush', () => {
-  it('sends a beacon for each pending PUT', async () => {
+  it('sends a beacon for each pending PUT after the visibility-hidden prep completes', async () => {
     getPendingEntriesMock.mockResolvedValueOnce([
       { kind: 'layouts', id: 'lay-1', op: 'put', modifiedAt: 1000 },
       { kind: 'designs', id: 'des-1', op: 'put', modifiedAt: 2000 },
     ]);
     renderHook(() => useBeaconFlush(makeAdapters()));
-    await firePageHide();
+    fireVisibilityHidden();
+    await settlePrep();
+    firePageHide();
 
     expect(sendBeaconMock).toHaveBeenCalledTimes(2);
     expect(sendBeaconMock).toHaveBeenCalledWith('/api/sync/layouts/lay-1', expect.any(Blob));
     expect(sendBeaconMock).toHaveBeenCalledWith('/api/sync/designs/des-1', expect.any(Blob));
+  });
+
+  it('fires sendBeacon synchronously on pagehide — no awaits between the event and the call', async () => {
+    // Regression: previous implementation `await`ed `getPendingEntries`
+    // and each `adapter.get` after pagehide fired, defeating the whole
+    // point of using sendBeacon as an unload-survival mechanism. Now
+    // the prep happens on the earlier visibility-hidden event; pagehide
+    // is purely synchronous transmission.
+    getPendingEntriesMock.mockResolvedValueOnce([
+      { kind: 'layouts', id: 'lay-1', op: 'put', modifiedAt: 1000 },
+    ]);
+    renderHook(() => useBeaconFlush(makeAdapters()));
+    fireVisibilityHidden();
+    await settlePrep();
+
+    // No `await` after firing pagehide — sendBeacon must have been
+    // invoked before this assertion line even runs.
+    firePageHide();
+    expect(sendBeaconMock).toHaveBeenCalledTimes(1);
   });
 
   it('skips DELETE entries (sendBeacon is POST-shaped)', async () => {
@@ -68,7 +99,9 @@ describe('useBeaconFlush', () => {
       { kind: 'layouts', id: 'lay-1', op: 'delete', modifiedAt: 1000 },
     ]);
     renderHook(() => useBeaconFlush(makeAdapters()));
-    await firePageHide();
+    fireVisibilityHidden();
+    await settlePrep();
+    firePageHide();
     expect(sendBeaconMock).not.toHaveBeenCalled();
   });
 
@@ -78,7 +111,9 @@ describe('useBeaconFlush', () => {
       { kind: 'layouts', id: 'too-big', op: 'put', modifiedAt: 1000 },
     ]);
     renderHook(() => useBeaconFlush(makeAdapters(huge)));
-    await firePageHide();
+    fireVisibilityHidden();
+    await settlePrep();
+    firePageHide();
     expect(sendBeaconMock).not.toHaveBeenCalled();
   });
 
@@ -87,7 +122,9 @@ describe('useBeaconFlush', () => {
       { kind: 'layouts', id: 'gone', op: 'put', modifiedAt: 1000 },
     ]);
     renderHook(() => useBeaconFlush(makeAdapters(null)));
-    await firePageHide();
+    fireVisibilityHidden();
+    await settlePrep();
+    firePageHide();
     expect(sendBeaconMock).not.toHaveBeenCalled();
   });
 
@@ -96,8 +133,10 @@ describe('useBeaconFlush', () => {
       { kind: 'layouts', id: 'lay-1', op: 'put', modifiedAt: 1000 },
     ]);
     const { unmount } = renderHook(() => useBeaconFlush(makeAdapters()));
+    fireVisibilityHidden();
+    await settlePrep();
     unmount();
-    await firePageHide();
+    firePageHide();
     expect(sendBeaconMock).not.toHaveBeenCalled();
   });
 });

--- a/src/core/sync/triggers/useBeaconFlush.test.ts
+++ b/src/core/sync/triggers/useBeaconFlush.test.ts
@@ -52,9 +52,7 @@ function firePageHide(): void {
   window.dispatchEvent(new Event('pagehide'));
 }
 
-// Visibility-hidden does async prep; let the IDB read and adapter.get
-// promises resolve before pagehide. In real life the gap between the
-// two events is typically tens to hundreds of ms.
+// Let visibility-hidden's IDB read + adapter.get settle before pagehide.
 async function settlePrep(): Promise<void> {
   await new Promise((r) => setTimeout(r, 10));
 }
@@ -76,11 +74,6 @@ describe('useBeaconFlush', () => {
   });
 
   it('fires sendBeacon synchronously on pagehide — no awaits between the event and the call', async () => {
-    // Regression: previous implementation `await`ed `getPendingEntries`
-    // and each `adapter.get` after pagehide fired, defeating the whole
-    // point of using sendBeacon as an unload-survival mechanism. Now
-    // the prep happens on the earlier visibility-hidden event; pagehide
-    // is purely synchronous transmission.
     getPendingEntriesMock.mockResolvedValueOnce([
       { kind: 'layouts', id: 'lay-1', op: 'put', modifiedAt: 1000 },
     ]);
@@ -88,9 +81,8 @@ describe('useBeaconFlush', () => {
     fireVisibilityHidden();
     await settlePrep();
 
-    // No `await` after firing pagehide — sendBeacon must have been
-    // invoked before this assertion line even runs.
     firePageHide();
+    // No await between firePageHide and this assertion — sendBeacon must have already fired.
     expect(sendBeaconMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/core/sync/triggers/useBeaconFlush.ts
+++ b/src/core/sync/triggers/useBeaconFlush.ts
@@ -16,9 +16,15 @@ interface PreparedBeacon {
 export function useBeaconFlush(adapters: SyncAdapters): void {
   useEffect(() => {
     let prepared: PreparedBeacon[] = [];
+    // Monotonic token so a slow earlier refresh can't overwrite a newer
+    // one. Without this, two visibility-hidden events in flight would race
+    // and the later (fresher) result could be clobbered by the earlier.
+    let refreshSeq = 0;
 
     const refreshPrepared = async (): Promise<void> => {
-      prepared = await collectBeacons(adapters);
+      const mySeq = ++refreshSeq;
+      const next = await collectBeacons(adapters);
+      if (mySeq === refreshSeq) prepared = next;
     };
 
     const onVisibility = (): void => {

--- a/src/core/sync/triggers/useBeaconFlush.ts
+++ b/src/core/sync/triggers/useBeaconFlush.ts
@@ -9,23 +9,10 @@ interface PreparedBeacon {
   blob: Blob;
 }
 
-/**
- * On `pagehide`, send a beacon for every pending outbox PUT so the
- * server learns about the latest state even if the tab is closing.
- * `fetch` would be cancelled at unload; `sendBeacon` survives. DELETE
- * entries are skipped — beacon can't express the verb; the next session
- * picks them up from the persisted outbox.
- *
- * Two-phase flow: `visibilitychange → hidden` does the async prep (IDB
- * reads, adapter snapshots), and `pagehide` fires every prepared beacon
- * synchronously with zero awaits. The earlier `visibilitychange` signal
- * usually arrives well before `pagehide`, so by the time the browser is
- * tearing the page down, the data is already a `Blob` ready to ship.
- *
- * Cache is refreshed on every visibility-hidden transition — a user who
- * tabs away and comes back to edit more sees a fresh prep on the next
- * transition.
- */
+// Async prep on `visibilitychange → hidden`, synchronous send on `pagehide`.
+// `fetch` is cancelled at unload but `sendBeacon` survives, so beacons must
+// be pre-built before the browser tears the page down. DELETE entries are
+// skipped (beacon has no verb); the next session replays them from the outbox.
 export function useBeaconFlush(adapters: SyncAdapters): void {
   useEffect(() => {
     let prepared: PreparedBeacon[] = [];
@@ -37,18 +24,14 @@ export function useBeaconFlush(adapters: SyncAdapters): void {
     const onVisibility = (): void => {
       if (typeof document === 'undefined') return;
       if (document.visibilityState === 'hidden') {
-        // Best-effort; if it doesn't finish before pagehide the next
-        // session's outbox replay still catches the changes.
         refreshPrepared().catch(() => {
-          /* swallow — beacon is best-effort */
+          /* best-effort */
         });
       }
     };
 
+    // No awaits — must stay synchronous inside the unload window.
     const onPageHide = (): void => {
-      // SYNCHRONOUS path: no awaits. By this point `prepared` was filled
-      // by the prior visibility-hidden tick, so every beacon fires right
-      // here in the unload window where the browser actually waits.
       if (typeof navigator === 'undefined' || typeof navigator.sendBeacon !== 'function') return;
       for (const { url, blob } of prepared) {
         try {

--- a/src/core/sync/triggers/useBeaconFlush.ts
+++ b/src/core/sync/triggers/useBeaconFlush.ts
@@ -1,9 +1,13 @@
 import { useEffect } from 'react';
 import { getPendingEntries } from '../engine';
-import type { OutboxEntry } from '../outbox';
 import type { SyncAdapters, SyncKind } from '../adapters/types';
 
 const BEACON_MAX_BYTES = 60 * 1024;
+
+interface PreparedBeacon {
+  url: string;
+  blob: Blob;
+}
 
 /**
  * On `pagehide`, send a beacon for every pending outbox PUT so the
@@ -11,28 +15,68 @@ const BEACON_MAX_BYTES = 60 * 1024;
  * `fetch` would be cancelled at unload; `sendBeacon` survives. DELETE
  * entries are skipped — beacon can't express the verb; the next session
  * picks them up from the persisted outbox.
+ *
+ * Two-phase flow: `visibilitychange → hidden` does the async prep (IDB
+ * reads, adapter snapshots), and `pagehide` fires every prepared beacon
+ * synchronously with zero awaits. The earlier `visibilitychange` signal
+ * usually arrives well before `pagehide`, so by the time the browser is
+ * tearing the page down, the data is already a `Blob` ready to ship.
+ *
+ * Cache is refreshed on every visibility-hidden transition — a user who
+ * tabs away and comes back to edit more sees a fresh prep on the next
+ * transition.
  */
 export function useBeaconFlush(adapters: SyncAdapters): void {
   useEffect(() => {
-    const onPageHide = (): void => {
-      void beaconFlushAll(adapters);
+    let prepared: PreparedBeacon[] = [];
+
+    const refreshPrepared = async (): Promise<void> => {
+      prepared = await collectBeacons(adapters);
     };
+
+    const onVisibility = (): void => {
+      if (typeof document === 'undefined') return;
+      if (document.visibilityState === 'hidden') {
+        // Best-effort; if it doesn't finish before pagehide the next
+        // session's outbox replay still catches the changes.
+        refreshPrepared().catch(() => {
+          /* swallow — beacon is best-effort */
+        });
+      }
+    };
+
+    const onPageHide = (): void => {
+      // SYNCHRONOUS path: no awaits. By this point `prepared` was filled
+      // by the prior visibility-hidden tick, so every beacon fires right
+      // here in the unload window where the browser actually waits.
+      if (typeof navigator === 'undefined' || typeof navigator.sendBeacon !== 'function') return;
+      for (const { url, blob } of prepared) {
+        try {
+          navigator.sendBeacon(url, blob);
+        } catch {
+          /* next session retries from the persisted outbox */
+        }
+      }
+    };
+
+    document.addEventListener('visibilitychange', onVisibility);
     window.addEventListener('pagehide', onPageHide);
     return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
       window.removeEventListener('pagehide', onPageHide);
     };
   }, [adapters]);
 }
 
-async function beaconFlushAll(adapters: SyncAdapters): Promise<void> {
-  if (typeof navigator === 'undefined' || typeof navigator.sendBeacon !== 'function') return;
-  let entries: OutboxEntry[];
+async function collectBeacons(adapters: SyncAdapters): Promise<PreparedBeacon[]> {
+  if (typeof navigator === 'undefined' || typeof navigator.sendBeacon !== 'function') return [];
+  let entries;
   try {
     entries = await getPendingEntries();
   } catch {
-    return;
+    return [];
   }
-
+  const prepared: PreparedBeacon[] = [];
   for (const entry of entries) {
     if (entry.op === 'delete') continue;
     const adapter = adapters[entry.kind];
@@ -43,17 +87,12 @@ async function beaconFlushAll(adapters: SyncAdapters): Promise<void> {
       continue;
     }
     if (!payload) continue;
-
     const body = bodyForKind(entry.kind, payload.payload, payload.modifiedAt);
-    const json = JSON.stringify(body);
-    const blob = new Blob([json], { type: 'application/json' });
+    const blob = new Blob([JSON.stringify(body)], { type: 'application/json' });
     if (blob.size > BEACON_MAX_BYTES) continue;
-    try {
-      navigator.sendBeacon(`/api/sync/${entry.kind}/${entry.id}`, blob);
-    } catch {
-      /* next session retries from the persisted outbox */
-    }
+    prepared.push({ url: `/api/sync/${entry.kind}/${entry.id}`, blob });
   }
+  return prepared;
 }
 
 function bodyForKind(kind: SyncKind, payload: unknown, modifiedAt: number): object {

--- a/src/features/bin-designer/sync/designAdapter.test.ts
+++ b/src/features/bin-designer/sync/designAdapter.test.ts
@@ -232,6 +232,58 @@ describe('designAdapter.subscribe', () => {
     off();
   });
 
+  it('suppresses the emit triggered by saveDesign during applyRemote', async () => {
+    // Regression: the previous implementation released suppression on a
+    // `queueMicrotask` cleanup that fired at the first `await` boundary,
+    // BEFORE `saveDesign`'s internal `emit` ran. The engine would then
+    // observe the remote-applied change as a fresh local edit and push
+    // it back. Fix wraps the work in try/finally so suppression spans
+    // every microtask up to and including the emit.
+    const events: AdapterChange[] = [];
+    const off = designAdapter.subscribe((c) => events.push(c));
+
+    loadDesignMock.mockResolvedValueOnce(err(storageNotFound('echo-id')));
+    saveDesignMock.mockImplementationOnce(async (input: SavedDesign) => {
+      // Real `saveDesign` emits a 'put' event synchronously after the
+      // IndexedDB write completes — i.e. past at least one internal
+      // `await` boundary. Reproduce that timing here.
+      emit({
+        type: 'put',
+        id: designId('echo-id'),
+        updatedAt: '2026-05-04T00:00:00.000Z',
+      });
+      return ok({ ...input, createdAt: input.updatedAt });
+    });
+
+    await designAdapter.applyRemote({
+      id: 'echo-id',
+      payload: samplePayload(),
+      modifiedAt: Date.parse('2026-05-04T00:00:00.000Z'),
+    });
+
+    expect(events.filter((e) => e.id === 'echo-id')).toEqual([]);
+    off();
+  });
+
+  it('suppresses the emit triggered by deleteDesign during applyRemoteDelete', async () => {
+    const events: AdapterChange[] = [];
+    const off = designAdapter.subscribe((c) => events.push(c));
+
+    deleteDesignMock.mockImplementationOnce(async () => {
+      emit({
+        type: 'delete',
+        id: designId('echo-del'),
+        deletedAt: '2026-05-04T00:00:00.000Z',
+      });
+      return ok(undefined);
+    });
+
+    await designAdapter.applyRemoteDelete('echo-del');
+
+    expect(events.filter((e) => e.id === 'echo-del')).toEqual([]);
+    off();
+  });
+
   it('passes unsuppressed events through to listeners', async () => {
     const events: AdapterChange[] = [];
     const off = designAdapter.subscribe((c) => events.push(c));

--- a/src/features/bin-designer/sync/designAdapter.test.ts
+++ b/src/features/bin-designer/sync/designAdapter.test.ts
@@ -233,20 +233,12 @@ describe('designAdapter.subscribe', () => {
   });
 
   it('suppresses the emit triggered by saveDesign during applyRemote', async () => {
-    // Regression: the previous implementation released suppression on a
-    // `queueMicrotask` cleanup that fired at the first `await` boundary,
-    // BEFORE `saveDesign`'s internal `emit` ran. The engine would then
-    // observe the remote-applied change as a fresh local edit and push
-    // it back. Fix wraps the work in try/finally so suppression spans
-    // every microtask up to and including the emit.
     const events: AdapterChange[] = [];
     const off = designAdapter.subscribe((c) => events.push(c));
 
     loadDesignMock.mockResolvedValueOnce(err(storageNotFound('echo-id')));
     saveDesignMock.mockImplementationOnce(async (input: SavedDesign) => {
-      // Real `saveDesign` emits a 'put' event synchronously after the
-      // IndexedDB write completes — i.e. past at least one internal
-      // `await` boundary. Reproduce that timing here.
+      // Reproduce real `saveDesign` timing: emit past an internal await.
       emit({
         type: 'put',
         id: designId('echo-id'),

--- a/src/features/bin-designer/sync/designAdapter.ts
+++ b/src/features/bin-designer/sync/designAdapter.ts
@@ -22,13 +22,9 @@ import { subscribe as subscribeDesignerEvents } from './designerEvents';
 // SavedDesign stores `updatedAt` as ISO; the cloud envelope is ms. We
 // normalize at this boundary so the engine never sees ISO strings.
 
-// Echo suppression. Unlike `layoutAdapter`, the trigger is `emit()`
-// fired *inside* `saveDesign`/`deleteDesign` — past one or more internal
-// `await` boundaries that drain microtasks. A microtask-scheduled cleanup
-// would release the suppression before the emit, so we hold it for the
-// full duration of the async work via `try`/`finally`. The engine
-// serializes `applyRemote*` per-(kind, id), so a concurrent local edit
-// on the same id is not possible during this window.
+// Held across the full `saveDesign`/`deleteDesign` await chain because
+// the `emit()` that needs suppression fires past internal await boundaries;
+// a microtask cleanup would release too early.
 const suppressed = new Set<string>();
 
 function toMs(iso: string): number {

--- a/src/features/bin-designer/sync/designAdapter.ts
+++ b/src/features/bin-designer/sync/designAdapter.ts
@@ -22,14 +22,14 @@ import { subscribe as subscribeDesignerEvents } from './designerEvents';
 // SavedDesign stores `updatedAt` as ISO; the cloud envelope is ms. We
 // normalize at this boundary so the engine never sees ISO strings.
 
+// Echo suppression. Unlike `layoutAdapter`, the trigger is `emit()`
+// fired *inside* `saveDesign`/`deleteDesign` — past one or more internal
+// `await` boundaries that drain microtasks. A microtask-scheduled cleanup
+// would release the suppression before the emit, so we hold it for the
+// full duration of the async work via `try`/`finally`. The engine
+// serializes `applyRemote*` per-(kind, id), so a concurrent local edit
+// on the same id is not possible during this window.
 const suppressed = new Set<string>();
-
-function suppress(id: string): void {
-  suppressed.add(id);
-  queueMicrotask(() => {
-    suppressed.delete(id);
-  });
-}
 
 function toMs(iso: string): number {
   const ms = Date.parse(iso);
@@ -81,33 +81,41 @@ export const designAdapter: DesignAdapter = {
   },
 
   async applyRemote(item: SyncableItem<DesignSyncPayload>): Promise<void> {
-    suppress(item.id);
-    // Read existing first to preserve local-only fields (thumbnail,
-    // exportFileNameConfig) on update.
-    const existing = await loadDesign(designId(item.id));
-    const base = isOk(existing) ? existing.value : null;
-    const { name: remoteName, params } = unwrap(item.payload);
-    // LWW: engine only calls applyRemote when remote is newer, so a
-    // remote rename must win. Local name is only a fallback for legacy
-    // payloads with no name; the literal covers a legacy fresh-device pull.
-    const name = remoteName ?? base?.name ?? 'Synced design';
-    const result = await saveDesign({
-      id: designId(item.id),
-      name,
-      params,
-      thumbnail: base?.thumbnail ?? null,
-      exportFileNameConfig: base?.exportFileNameConfig ?? null,
-    });
-    if (!isOk(result)) {
-      throw new Error(`saveDesign failed for ${item.id}`);
+    suppressed.add(item.id);
+    try {
+      // Read existing first to preserve local-only fields (thumbnail,
+      // exportFileNameConfig) on update.
+      const existing = await loadDesign(designId(item.id));
+      const base = isOk(existing) ? existing.value : null;
+      const { name: remoteName, params } = unwrap(item.payload);
+      // LWW: engine only calls applyRemote when remote is newer, so a
+      // remote rename must win. Local name is only a fallback for legacy
+      // payloads with no name; the literal covers a legacy fresh-device pull.
+      const name = remoteName ?? base?.name ?? 'Synced design';
+      const result = await saveDesign({
+        id: designId(item.id),
+        name,
+        params,
+        thumbnail: base?.thumbnail ?? null,
+        exportFileNameConfig: base?.exportFileNameConfig ?? null,
+      });
+      if (!isOk(result)) {
+        throw new Error(`saveDesign failed for ${item.id}`);
+      }
+    } finally {
+      suppressed.delete(item.id);
     }
   },
 
   async applyRemoteDelete(id: string): Promise<void> {
-    suppress(id);
-    const result = await deleteDesign(designId(id));
-    if (!isOk(result) && result.error.code !== 'STORAGE_NOT_FOUND') {
-      throw new Error(`deleteDesign failed for ${id}`);
+    suppressed.add(id);
+    try {
+      const result = await deleteDesign(designId(id));
+      if (!isOk(result) && result.error.code !== 'STORAGE_NOT_FOUND') {
+        throw new Error(`deleteDesign failed for ${id}`);
+      }
+    } finally {
+      suppressed.delete(id);
     }
   },
 


### PR DESCRIPTION
## Summary

Closes the 10 verified defects flagged in the cloud_sync graduation audit. UX/product opinions from the audit (sign-in placement, persistent error surfacing, copy improvements) are deliberately NOT included — those are open product questions, not graduation blockers.

Each fix is its own commit so review can proceed hunk-by-hunk and any single fix is independently revertable.

## Fixes

| Commit | Defect |
| --- | --- |
| `fix(sync): repair echo suppression race in adapters` | `suppress(id)` ran before the first `await`; `queueMicrotask` cleanup drained on that await boundary, so `setLibrary`'s synchronous listener firing saw an empty suppression set and the engine pushed the remote-applied change back to the server. `layoutAdapter` moves `suppress` to immediately before `setLibrary`; `designAdapter` switches to `try/finally` because its trigger fires *inside* `saveDesign`'s async body. |
| `fix(sync): swap AccountMismatchDialog button variants` | Discard was `variant="primary"`, so reflex Enter wiped local data. The dialog's own docstring warns against this. Merge is now primary; Discard is `variant="danger"`. |
| `fix(sync): honor Retry-After + exp backoff on 429` | 429 was caught by `isClientError` in `handleFailure` and emitted as `gave-up`, dropping legitimate writes whenever a user hit `sync.write 60/min`. New branch parses `Retry-After` (delta-seconds or HTTP-date, capped at 1h), falls back to jittered exp backoff (1s → 30s cap), and reschedules without incrementing `attempts`. |
| `fix(sync): catch unhandled rejections in engine push path` | `setTimeout(() => void drain(s))`, `void onLocalChange`, and `void rehydrate` all leaked `window.unhandledrejection` on fetch / IDB failures. Routes them through `reportError` so the UI reflects the broken state. |
| `feat(sync): sweep tombstones older than 90 days` | Per-user index hash grew unboundedly; every 45s/tab manifest poll HGETALLs it. Opportunistic sweep on every `upsertEntry` removes tombstones with `deletedAt > 90d` ago, folded into the same pipeline as the write. |
| `fix(api): bound drawer/layer/bin height in validateShareLayout` | `height` was only `> 0`. A corrupted device could persist `1e9` and round-trip it via sync. Replaced with `inRange(..., 1, GRID_MAX)` matching the client UI's cap. |
| `refactor(sync): stream export ZIP via fflate` | `zipSync` loaded every envelope into memory; peak heap ~110MB at worst-case quotas. README already promised "Stream a ZIP." Replaced with fflate's `Zip` writer piping chunks directly to the response; heap stays bounded. |
| `fix(sync): fire sendBeacon before awaiting` | `pagehide` handler `await`ed IDB before calling `sendBeacon`, defeating the unload-survival mechanism. Split into `visibilitychange → hidden` (async prep) + `pagehide` (synchronous fire of the cached blobs). |
| `fix(sync): clear lastIndexUpdatedAt on sign-out` | `poller.ts` held the per-user high-water mark at module scope; sign-out cleared outbox + last-user but not this. A subsequent sign-in on the same device sent the prior user's timestamp as `If-Modified-Since` and silently skipped the manifest scan. |
| `fix(sync): deterministic tiebreaker on equal-ms LWW` | `existing.modifiedAt >= modifiedAt` silently 409'd equal-ms writes — opaque "whoever got there first" wins. New branch resolves ties via SHA-256 of canonical JSON (sorted keys), so two devices producing the same `modifiedAt` for distinct payloads converge on the same winner. |

## Decisions made up front (asked before coding)

- **Scope**: 10 code defects only. Telemetry + kill switch deferred — those are product/ops decisions, not bug fixes.
- **PR strategy**: one large PR, one commit per fix.
- **429 retry**: honor `Retry-After`, else exp backoff with jitter, unlimited retries (rate limit is throttling, not push-payload failure).
- **Tombstone retention**: 90 days, opportunistic sweep on writes.
- **Equal-ms LWW**: deterministic hash tiebreaker.
- **Tests**: unit-only, regression test per fix.

## What's intentionally NOT in this PR

Audit items the user explicitly deferred as separate decisions:

- PostHog telemetry on engine events (no events emitted today)
- Runtime kill switch (env var or PostHog FF check inside `useFeatureFlag`)
- UX opinions: persistent failure surface, claim-merged confirmation toast, sign-in entry-point changes, quota copy improvements

These are tracked as graduation prerequisites separately.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` — passes
- [x] `pnpm exec vitest run` on all sync-related paths — 324/324 pass
- [x] Pre-commit hooks (i18n × 3, exhaustiveness, module boundaries, etc.) — pass on every commit
- [ ] Greptile / Copilot review surface land — wait 5-10 min per memory before automerge
- [ ] Manual smoke (post-merge in preview): sign in → sign out → sign in again → confirm fresh manifest scan
- [ ] Manual smoke: trip rate limit and verify retry without `gave-up` toast