### PR TITLE
feat(labs): graduate cloud_sync — sign in to sync across devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Plan and design [Gridfinity](https://www.youtube.com/c/ZackFreedman) drawer orga
 - **Print List** — Optimized print list with filament, time, and cost estimates
 - **Inspiration Gallery** — Browse curated example layouts across workshop, kitchen, office, hobby, and personal themes
 - **Cloud Sharing** — Share layouts via link with optional real-time collaboration
+- **Cloud Sync** — Sign in with Google or GitHub to sync your layouts and bin designs across devices
 - **PWA** — Installable, works offline
 
 ## Scope
@@ -41,7 +42,7 @@ To set expectations, this tool deliberately does not:
 
 - **Slice models for printing** — export STL / STEP / 3MF and slice in Bambu Studio, PrusaSlicer, OrcaSlicer, etc.
 - **Replace general-purpose CAD** — the Bin Designer is parametric but stays within the Gridfinity spec; for arbitrary shapes use Fusion, OpenSCAD, etc.
-- **Require accounts** — layouts live in your browser; cloud sharing is opt-in and link-based
+- **Require accounts** — layouts live in your browser by default; signing in for Cloud Sync and link-based sharing are both opt-in
 - **Support legacy browsers** — needs a modern browser with WebGL support
 
 ## Built With

--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -95,12 +95,11 @@ export const FEATURE_FLAGS = [
     name: 'Cloud Sync (sign in)',
     description:
       'Sign in with Google or GitHub to sync your layouts and bin designs across devices. Your library follows you to any browser you sign in on.',
-    status: 'experimental',
+    status: 'graduated',
     risk: 'medium',
-    warning:
-      'Reload the page after toggling. You can sign out at any time and choose to keep the synced library on this device or wipe it.',
     addedAt: '2026-05',
-    requiresRefresh: true,
+    graduatedAt: '2026-05',
+    requiresRefresh: false,
   },
 ] as const satisfies readonly FeatureFlag[];
 


### PR DESCRIPTION
## Summary

`cloud_sync` was the only experimental Labs flag remaining after PR #1691 closed the graduation audit's 10-defect blocker list (plus 5 review-pass + 5 Greptile/Copilot review fixes). Flipping it to `graduated` makes Cloud Sync default-on for every user.

## Flag changes (`src/core/labs/features.ts`)

- `status`: `experimental` → `graduated`
- `graduatedAt`: `2026-05`
- `requiresRefresh`: `true` → `false` — `SyncSessionMount` lazy-loads and only does work after auth; no reload needed
- `warning` removed — the post-toggle reload note no longer applies

## README

- Added Cloud Sync to the Features list
- Refined the "Require accounts" Scope line — accounts remain optional; sign-in unlocks cross-device sync but is not required for any other feature

## Runtime cost for anonymous users

- One lazy chunk download on first paint (cached thereafter)
- One `/api/auth/me` request (short-circuits at the session layer before touching Redis when no cookie is present)
- Zero periodic polling — `usePeriodicPoll` only mounts when status is `authenticated`

## Deferred (tracked, not graduation blockers)

- PostHog telemetry on engine events
- Runtime kill switch (env var or PostHog feature-flag override inside `useFeatureFlag`)

## Test plan

- [x] Labs tests — 74/74 pass
- [x] Sync + bin-designer/sync + api/sync tests — 338/338 pass
- [x] Typecheck — clean
- [x] Lint — clean
- [ ] Manual smoke on Vercel preview: anonymous user gets sync chunks lazy-loaded; sign-in works; sign-out clears state