### PR TITLE
fix(baseplate): show proactive fallback when WebGL is unavailable

### DIFF
--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
@@ -34,6 +34,8 @@ import { useBaseplatePresetTransition } from './useBaseplatePresetTransition';
 import { BaseplatePreviewControls } from './BaseplatePreviewControls';
 import { overlayStatusText } from './overlayStatusText';
 import { useGenerationElapsed } from './useGenerationElapsed';
+import { PanelErrorBoundary } from '@/shell/PanelErrorBoundary';
+import { detectWebGL, WebGLFallback } from '@/shared/webgl';
 
 interface BaseplatePreviewProps {
   width: number;
@@ -59,6 +61,7 @@ export function BaseplatePreview({
   const invalidateRef = useRef<(() => void) | null>(null);
   const { isDesktop } = useResponsive();
   const filamentColor = useSettingsStore((s) => s.settings.baseplateFilamentColor);
+  const webgl = detectWebGL();
 
   const {
     wasmStatus,
@@ -212,53 +215,35 @@ export function BaseplatePreview({
         </div>
       )}
 
+      {!webgl.available && webgl.reason ? (
+        <WebGLFallback reason={webgl.reason} component="baseplate" />
+      ) : null}
+
       <div
-        className={`h-full w-full transition-opacity duration-500 ${hasAnyMesh ? 'opacity-100' : 'opacity-0'}`}
+        className={`h-full w-full transition-opacity duration-500 ${hasAnyMesh ? 'opacity-100' : 'opacity-0'} ${webgl.available ? '' : 'hidden'}`}
       >
-        <Canvas
-          frameloop="demand"
-          camera={{
-            position: new THREE.Vector3(100, -100, 80),
-            fov: 45,
-            near: 0.1,
-            far: 20000,
-          }}
-          onCreated={({ camera }) => {
-            camera.up.set(0, 0, 1);
-            camera.lookAt(0, 0, totalH / 2);
-          }}
-          gl={{ antialias: true }}
-          onPointerMissed={handlePointerMissed}
-        >
-          <GradientBackground />
-          <SceneLighting />
+        <PanelErrorBoundary panelName="3D Preview">
+          <Canvas
+            frameloop="demand"
+            camera={{
+              position: new THREE.Vector3(100, -100, 80),
+              fov: 45,
+              near: 0.1,
+              far: 20000,
+            }}
+            onCreated={({ camera }) => {
+              camera.up.set(0, 0, 1);
+              camera.lookAt(0, 0, totalH / 2);
+            }}
+            gl={{ antialias: true }}
+            onPointerMissed={handlePointerMissed}
+          >
+            <GradientBackground />
+            <SceneLighting />
 
-          <CameraController
-            controlsRef={controlsRef}
-            invalidateRef={invalidateRef}
-            width={width}
-            depth={depth}
-            gridUnitMm={gridUnitMm}
-            paddingLeft={paddingLeft}
-            paddingRight={paddingRight}
-            paddingFront={paddingFront}
-            paddingBack={paddingBack}
-          />
-
-          {isSplit ? (
-            <SplitBaseplateMeshes
-              totalWidthUnits={width}
-              totalDepthUnits={depth}
-              gridUnitMm={gridUnitMm}
-              isPreview={hasDirectPreview}
-            />
-          ) : (
-            <BaseplateMesh color={filamentColor} isPreview={hasDirectPreview} />
-          )}
-
-          {/* Ghost outline only in assembled mode -- exploded scatters pieces beyond slab bounds */}
-          {splitViewMode !== 'exploded' && (
-            <GhostPaddingOutline
+            <CameraController
+              controlsRef={controlsRef}
+              invalidateRef={invalidateRef}
               width={width}
               depth={depth}
               gridUnitMm={gridUnitMm}
@@ -266,16 +251,22 @@ export function BaseplatePreview({
               paddingRight={paddingRight}
               paddingFront={paddingFront}
               paddingBack={paddingBack}
-              isGenerating={generationStatus === 'generating'}
             />
-          )}
 
-          <FootprintGrid width={width} depth={depth} gridUnitMm={gridUnitMm} />
-          {/* Hide measurement labels in exploded mode -- pieces scatter beyond these positions */}
-          {splitViewMode !== 'exploded' && (
-            <>
-              <BinAxisLabels width={width} depth={depth} gridUnitMm={gridUnitMm} />
-              <DimensionLabels
+            {isSplit ? (
+              <SplitBaseplateMeshes
+                totalWidthUnits={width}
+                totalDepthUnits={depth}
+                gridUnitMm={gridUnitMm}
+                isPreview={hasDirectPreview}
+              />
+            ) : (
+              <BaseplateMesh color={filamentColor} isPreview={hasDirectPreview} />
+            )}
+
+            {/* Ghost outline only in assembled mode -- exploded scatters pieces beyond slab bounds */}
+            {splitViewMode !== 'exploded' && (
+              <GhostPaddingOutline
                 width={width}
                 depth={depth}
                 gridUnitMm={gridUnitMm}
@@ -283,26 +274,44 @@ export function BaseplatePreview({
                 paddingRight={paddingRight}
                 paddingFront={paddingFront}
                 paddingBack={paddingBack}
+                isGenerating={generationStatus === 'generating'}
               />
-            </>
-          )}
+            )}
 
-          <OrbitControls
-            ref={controlsRef}
-            makeDefault
-            target={[0, 0, totalH / 2]}
-            enableDamping
-            dampingFactor={0.12}
-            rotateSpeed={0.8}
-            minDistance={20}
-            maxDistance={maxOrbitDistance}
-            maxPolarAngle={Math.PI * 0.85}
-            minPolarAngle={Math.PI * 0.05}
-            enablePan={isDesktop}
-            onStart={handleOrbitStart}
-            onEnd={handleOrbitEnd}
-          />
-        </Canvas>
+            <FootprintGrid width={width} depth={depth} gridUnitMm={gridUnitMm} />
+            {/* Hide measurement labels in exploded mode -- pieces scatter beyond these positions */}
+            {splitViewMode !== 'exploded' && (
+              <>
+                <BinAxisLabels width={width} depth={depth} gridUnitMm={gridUnitMm} />
+                <DimensionLabels
+                  width={width}
+                  depth={depth}
+                  gridUnitMm={gridUnitMm}
+                  paddingLeft={paddingLeft}
+                  paddingRight={paddingRight}
+                  paddingFront={paddingFront}
+                  paddingBack={paddingBack}
+                />
+              </>
+            )}
+
+            <OrbitControls
+              ref={controlsRef}
+              makeDefault
+              target={[0, 0, totalH / 2]}
+              enableDamping
+              dampingFactor={0.12}
+              rotateSpeed={0.8}
+              minDistance={20}
+              maxDistance={maxOrbitDistance}
+              maxPolarAngle={Math.PI * 0.85}
+              minPolarAngle={Math.PI * 0.05}
+              enablePan={isDesktop}
+              onStart={handleOrbitStart}
+              onEnd={handleOrbitEnd}
+            />
+          </Canvas>
+        </PanelErrorBoundary>
       </div>
 
       {/* Camera controls + view toggle overlay */}

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
@@ -217,56 +217,32 @@ export function BaseplatePreview({
 
       {!webgl.available && webgl.reason ? (
         <WebGLFallback reason={webgl.reason} component="baseplate" />
-      ) : null}
+      ) : (
+        <div
+          className={`h-full w-full transition-opacity duration-500 ${hasAnyMesh ? 'opacity-100' : 'opacity-0'}`}
+        >
+          <PanelErrorBoundary panelName="3D Preview">
+            <Canvas
+              frameloop="demand"
+              camera={{
+                position: new THREE.Vector3(100, -100, 80),
+                fov: 45,
+                near: 0.1,
+                far: 20000,
+              }}
+              onCreated={({ camera }) => {
+                camera.up.set(0, 0, 1);
+                camera.lookAt(0, 0, totalH / 2);
+              }}
+              gl={{ antialias: true }}
+              onPointerMissed={handlePointerMissed}
+            >
+              <GradientBackground />
+              <SceneLighting />
 
-      <div
-        className={`h-full w-full transition-opacity duration-500 ${hasAnyMesh ? 'opacity-100' : 'opacity-0'} ${webgl.available ? '' : 'hidden'}`}
-      >
-        <PanelErrorBoundary panelName="3D Preview">
-          <Canvas
-            frameloop="demand"
-            camera={{
-              position: new THREE.Vector3(100, -100, 80),
-              fov: 45,
-              near: 0.1,
-              far: 20000,
-            }}
-            onCreated={({ camera }) => {
-              camera.up.set(0, 0, 1);
-              camera.lookAt(0, 0, totalH / 2);
-            }}
-            gl={{ antialias: true }}
-            onPointerMissed={handlePointerMissed}
-          >
-            <GradientBackground />
-            <SceneLighting />
-
-            <CameraController
-              controlsRef={controlsRef}
-              invalidateRef={invalidateRef}
-              width={width}
-              depth={depth}
-              gridUnitMm={gridUnitMm}
-              paddingLeft={paddingLeft}
-              paddingRight={paddingRight}
-              paddingFront={paddingFront}
-              paddingBack={paddingBack}
-            />
-
-            {isSplit ? (
-              <SplitBaseplateMeshes
-                totalWidthUnits={width}
-                totalDepthUnits={depth}
-                gridUnitMm={gridUnitMm}
-                isPreview={hasDirectPreview}
-              />
-            ) : (
-              <BaseplateMesh color={filamentColor} isPreview={hasDirectPreview} />
-            )}
-
-            {/* Ghost outline only in assembled mode -- exploded scatters pieces beyond slab bounds */}
-            {splitViewMode !== 'exploded' && (
-              <GhostPaddingOutline
+              <CameraController
+                controlsRef={controlsRef}
+                invalidateRef={invalidateRef}
                 width={width}
                 depth={depth}
                 gridUnitMm={gridUnitMm}
@@ -274,16 +250,22 @@ export function BaseplatePreview({
                 paddingRight={paddingRight}
                 paddingFront={paddingFront}
                 paddingBack={paddingBack}
-                isGenerating={generationStatus === 'generating'}
               />
-            )}
 
-            <FootprintGrid width={width} depth={depth} gridUnitMm={gridUnitMm} />
-            {/* Hide measurement labels in exploded mode -- pieces scatter beyond these positions */}
-            {splitViewMode !== 'exploded' && (
-              <>
-                <BinAxisLabels width={width} depth={depth} gridUnitMm={gridUnitMm} />
-                <DimensionLabels
+              {isSplit ? (
+                <SplitBaseplateMeshes
+                  totalWidthUnits={width}
+                  totalDepthUnits={depth}
+                  gridUnitMm={gridUnitMm}
+                  isPreview={hasDirectPreview}
+                />
+              ) : (
+                <BaseplateMesh color={filamentColor} isPreview={hasDirectPreview} />
+              )}
+
+              {/* Ghost outline only in assembled mode -- exploded scatters pieces beyond slab bounds */}
+              {splitViewMode !== 'exploded' && (
+                <GhostPaddingOutline
                   width={width}
                   depth={depth}
                   gridUnitMm={gridUnitMm}
@@ -291,28 +273,46 @@ export function BaseplatePreview({
                   paddingRight={paddingRight}
                   paddingFront={paddingFront}
                   paddingBack={paddingBack}
+                  isGenerating={generationStatus === 'generating'}
                 />
-              </>
-            )}
+              )}
 
-            <OrbitControls
-              ref={controlsRef}
-              makeDefault
-              target={[0, 0, totalH / 2]}
-              enableDamping
-              dampingFactor={0.12}
-              rotateSpeed={0.8}
-              minDistance={20}
-              maxDistance={maxOrbitDistance}
-              maxPolarAngle={Math.PI * 0.85}
-              minPolarAngle={Math.PI * 0.05}
-              enablePan={isDesktop}
-              onStart={handleOrbitStart}
-              onEnd={handleOrbitEnd}
-            />
-          </Canvas>
-        </PanelErrorBoundary>
-      </div>
+              <FootprintGrid width={width} depth={depth} gridUnitMm={gridUnitMm} />
+              {/* Hide measurement labels in exploded mode -- pieces scatter beyond these positions */}
+              {splitViewMode !== 'exploded' && (
+                <>
+                  <BinAxisLabels width={width} depth={depth} gridUnitMm={gridUnitMm} />
+                  <DimensionLabels
+                    width={width}
+                    depth={depth}
+                    gridUnitMm={gridUnitMm}
+                    paddingLeft={paddingLeft}
+                    paddingRight={paddingRight}
+                    paddingFront={paddingFront}
+                    paddingBack={paddingBack}
+                  />
+                </>
+              )}
+
+              <OrbitControls
+                ref={controlsRef}
+                makeDefault
+                target={[0, 0, totalH / 2]}
+                enableDamping
+                dampingFactor={0.12}
+                rotateSpeed={0.8}
+                minDistance={20}
+                maxDistance={maxOrbitDistance}
+                maxPolarAngle={Math.PI * 0.85}
+                minPolarAngle={Math.PI * 0.05}
+                enablePan={isDesktop}
+                onStart={handleOrbitStart}
+                onEnd={handleOrbitEnd}
+              />
+            </Canvas>
+          </PanelErrorBoundary>
+        </div>
+      )}
 
       {/* Camera controls + view toggle overlay */}
       <BaseplatePreviewControls

--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -58,6 +58,7 @@ import { useToastStore } from '@/core/store/toast';
 import { useSettingsStore } from '@/core/store/settings';
 import { CameraController, usePresetTransition, SceneLighting } from './previewCanvasCamera';
 import { TouchHint, GeneratingIndicator } from './previewCanvasOverlays';
+import { detectWebGL, WebGLFallback } from '@/shared/webgl';
 import { ColorToolOverlay } from './ColorToolOverlay';
 import type { ColorZone } from '@/features/bin-designer/types/featureColors';
 import { PipetteIcon } from '@/design-system/Icon';
@@ -83,6 +84,7 @@ export function PreviewCanvas() {
   const t = useTranslation();
   const controlsRef = useRef<OrbitControlsType>(null);
   const invalidateRef = useRef<(() => void) | null>(null);
+  const webgl = detectWebGL();
   const [wireframe, setWireframe] = useState(false);
   const [activePreset, setActivePreset] = useState<CameraPreset | null>('isometric');
   // Lid explode slider (mm above the snapped position). Default = mid-explode
@@ -302,7 +304,9 @@ export function PreviewCanvas() {
         {statusAnnouncement}
       </div>
 
-      {showSkeleton ? (
+      {!webgl.available && webgl.reason ? (
+        <WebGLFallback reason={webgl.reason} component="designer" />
+      ) : showSkeleton ? (
         <PreviewSkeleton
           wasmStatus={wasmStatus}
           generationStatus={generationStatus}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1779,5 +1779,8 @@
   "binDesigner.colors.zone.labelTab": "Beschriftungslasche",
   "binDesigner.colors.zone.base": "Basis",
   "binDesigner.colors.zone.scoop": "Mulde",
-  "binDesigner.colors.zone.dividers": "Trennwände"
+  "binDesigner.colors.zone.dividers": "Trennwände",
+  "webgl.fallback.title": "Ihr Browser konnte 3D-Rendering nicht laden",
+  "webgl.fallback.body": "WebGL ist deaktiviert oder wird nicht unterstützt. Aktivieren Sie die Hardwarebeschleunigung in den Browsereinstellungen, aktualisieren Sie die Grafiktreiber oder wechseln Sie den Browser.",
+  "webgl.fallback.helpLink": "WebGL-Unterstützung prüfen"
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1780,5 +1780,8 @@
   "engagement.support": "Support on Ko-fi",
   "engagement.feedbackThankYou": "Thanks for your feedback! If you enjoy the tool, consider supporting on Ko-fi.",
   "engagement.layoutPromotion.message": "Planning another drawer? Save this layout and start a new one.",
-  "engagement.layoutPromotion.action": "Open Layout Library"
+  "engagement.layoutPromotion.action": "Open Layout Library",
+  "webgl.fallback.title": "Your browser couldn't load 3D rendering",
+  "webgl.fallback.body": "WebGL is disabled or unsupported. Try enabling hardware acceleration in your browser settings, updating your graphics drivers, or switching browsers.",
+  "webgl.fallback.helpLink": "Check WebGL support"
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2082,6 +2082,12 @@ const en: Record<string, string> = {
   'engagement.layoutPromotion.message':
     'Planning another drawer? Save this layout and start a new one.',
   'engagement.layoutPromotion.action': 'Open Layout Library',
+
+  // WebGL unavailable fallback
+  'webgl.fallback.title': "Your browser couldn't load 3D rendering",
+  'webgl.fallback.body':
+    'WebGL is disabled or unsupported. Try enabling hardware acceleration in your browser settings, updating your graphics drivers, or switching browsers.',
+  'webgl.fallback.helpLink': 'Check WebGL support',
 };
 
 export default en;

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1779,5 +1779,8 @@
   "binDesigner.colors.zone.labelTab": "Pestaña de etiqueta",
   "binDesigner.colors.zone.base": "Base",
   "binDesigner.colors.zone.scoop": "Rampa",
-  "binDesigner.colors.zone.dividers": "Divisores"
+  "binDesigner.colors.zone.dividers": "Divisores",
+  "webgl.fallback.title": "Tu navegador no pudo cargar el renderizado 3D",
+  "webgl.fallback.body": "WebGL está desactivado o no es compatible. Intenta activar la aceleración por hardware en la configuración del navegador, actualizar los controladores gráficos o cambiar de navegador.",
+  "webgl.fallback.helpLink": "Comprobar compatibilidad con WebGL"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1779,5 +1779,8 @@
   "binDesigner.colors.zone.labelTab": "Languette d'étiquette",
   "binDesigner.colors.zone.base": "Base",
   "binDesigner.colors.zone.scoop": "Cuiller",
-  "binDesigner.colors.zone.dividers": "Séparateurs"
+  "binDesigner.colors.zone.dividers": "Séparateurs",
+  "webgl.fallback.title": "Votre navigateur n'a pas pu charger le rendu 3D",
+  "webgl.fallback.body": "WebGL est désactivé ou non pris en charge. Activez l'accélération matérielle dans les paramètres du navigateur, mettez à jour les pilotes graphiques ou changez de navigateur.",
+  "webgl.fallback.helpLink": "Vérifier la prise en charge de WebGL"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1779,5 +1779,8 @@
   "binDesigner.colors.zone.labelTab": "Merkelapp",
   "binDesigner.colors.zone.base": "Sokkel",
   "binDesigner.colors.zone.scoop": "Skje",
-  "binDesigner.colors.zone.dividers": "Skillevegger"
+  "binDesigner.colors.zone.dividers": "Skillevegger",
+  "webgl.fallback.title": "Nettleseren din kunne ikke laste 3D-gjengivelse",
+  "webgl.fallback.body": "WebGL er deaktivert eller støttes ikke. Prøv å aktivere maskinvareakselerasjon i nettleserinnstillingene, oppdatere grafikkdriverne eller bytte nettleser.",
+  "webgl.fallback.helpLink": "Sjekk WebGL-støtte"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1779,5 +1779,8 @@
   "binDesigner.colors.zone.labelTab": "Labellipje",
   "binDesigner.colors.zone.base": "Voet",
   "binDesigner.colors.zone.scoop": "Schepje",
-  "binDesigner.colors.zone.dividers": "Tussenschotten"
+  "binDesigner.colors.zone.dividers": "Tussenschotten",
+  "webgl.fallback.title": "Je browser kon 3D-weergave niet laden",
+  "webgl.fallback.body": "WebGL is uitgeschakeld of wordt niet ondersteund. Schakel hardwareversnelling in de browserinstellingen in, werk je grafische stuurprogramma's bij of probeer een andere browser.",
+  "webgl.fallback.helpLink": "WebGL-ondersteuning controleren"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1779,5 +1779,8 @@
   "binDesigner.colors.zone.labelTab": "Aba de etiqueta",
   "binDesigner.colors.zone.base": "Base",
   "binDesigner.colors.zone.scoop": "Concha",
-  "binDesigner.colors.zone.dividers": "Divisores"
+  "binDesigner.colors.zone.dividers": "Divisores",
+  "webgl.fallback.title": "Seu navegador não conseguiu carregar a renderização 3D",
+  "webgl.fallback.body": "O WebGL está desativado ou não é compatível. Tente ativar a aceleração de hardware nas configurações do navegador, atualizar os drivers gráficos ou trocar de navegador.",
+  "webgl.fallback.helpLink": "Verificar suporte ao WebGL"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1779,5 +1779,8 @@
   "binDesigner.colors.zone.labelTab": "Etikettflik",
   "binDesigner.colors.zone.base": "Bas",
   "binDesigner.colors.zone.scoop": "Skopa",
-  "binDesigner.colors.zone.dividers": "Avdelare"
+  "binDesigner.colors.zone.dividers": "Avdelare",
+  "webgl.fallback.title": "Din webbläsare kunde inte ladda 3D-rendering",
+  "webgl.fallback.body": "WebGL är inaktiverat eller stöds inte. Försök aktivera hårdvaruacceleration i webbläsarinställningarna, uppdatera grafikdrivrutinerna eller byt webbläsare.",
+  "webgl.fallback.helpLink": "Kontrollera WebGL-stöd"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1779,5 +1779,8 @@
   "binDesigner.colors.zone.labelTab": "Вкладка етикетки",
   "binDesigner.colors.zone.base": "Основа",
   "binDesigner.colors.zone.scoop": "Жолоб",
-  "binDesigner.colors.zone.dividers": "Перегородки"
+  "binDesigner.colors.zone.dividers": "Перегородки",
+  "webgl.fallback.title": "Ваш браузер не зміг завантажити 3D-рендеринг",
+  "webgl.fallback.body": "WebGL вимкнено або не підтримується. Увімкніть апаратне прискорення в налаштуваннях браузера, оновіть графічні драйвери або спробуйте інший браузер.",
+  "webgl.fallback.helpLink": "Перевірити підтримку WebGL"
 }

--- a/src/shared/webgl/WebGLFallback.test.tsx
+++ b/src/shared/webgl/WebGLFallback.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { track3DRenderError } = vi.hoisted(() => ({ track3DRenderError: vi.fn() }));
+vi.mock('@/shared/analytics/posthog', () => ({ track3DRenderError }));
+
+import { WebGLFallback } from './WebGLFallback';
+
+afterEach(() => {
+  track3DRenderError.mockClear();
+});
+
+describe('WebGLFallback', () => {
+  it('renders the localized title and a help link', () => {
+    render(<WebGLFallback reason="context-failed" component="baseplate" />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://get.webgl.org/');
+  });
+
+  it('reports the unavailable reason on mount', () => {
+    render(<WebGLFallback reason="context-lost" component="designer" />);
+    expect(track3DRenderError).toHaveBeenCalledWith('designer', 'webgl-unavailable:context-lost');
+  });
+});

--- a/src/shared/webgl/WebGLFallback.tsx
+++ b/src/shared/webgl/WebGLFallback.tsx
@@ -21,7 +21,6 @@ export function WebGLFallback({ reason, component }: WebGLFallbackProps) {
     <div
       className="flex h-full min-h-[200px] w-full flex-col items-center justify-center p-6 text-center"
       role="alert"
-      aria-live="polite"
     >
       <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-error/20">
         <svg

--- a/src/shared/webgl/WebGLFallback.tsx
+++ b/src/shared/webgl/WebGLFallback.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import { useTranslation } from '@/i18n';
+import { track3DRenderError } from '@/shared/analytics/posthog';
+import type { WebGLUnavailableReason } from './detectWebGL';
+
+interface WebGLFallbackProps {
+  reason: WebGLUnavailableReason;
+  component: string;
+}
+
+const HELP_URL = 'https://get.webgl.org/';
+
+export function WebGLFallback({ reason, component }: WebGLFallbackProps) {
+  const t = useTranslation();
+
+  useEffect(() => {
+    track3DRenderError(component, `webgl-unavailable:${reason}`);
+  }, [component, reason]);
+
+  return (
+    <div
+      className="flex h-full min-h-[200px] w-full flex-col items-center justify-center p-6 text-center"
+      role="alert"
+      aria-live="polite"
+    >
+      <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-error/20">
+        <svg
+          className="h-6 w-6 text-error"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+          />
+        </svg>
+      </div>
+      <h3 className="mb-1 text-sm font-medium text-content">{t('webgl.fallback.title')}</h3>
+      <p className="mb-3 max-w-[280px] text-xs text-content-secondary">
+        {t('webgl.fallback.body')}
+      </p>
+      <a
+        href={HELP_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="rounded bg-surface-secondary px-3 py-1.5 text-xs font-medium transition-colors hover:bg-surface-elevated"
+      >
+        {t('webgl.fallback.helpLink')}
+      </a>
+    </div>
+  );
+}

--- a/src/shared/webgl/detectWebGL.test.ts
+++ b/src/shared/webgl/detectWebGL.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { detectWebGL, resetWebGLDetectionCacheForTests } from './detectWebGL';
+
+afterEach(() => {
+  resetWebGLDetectionCacheForTests();
+  vi.restoreAllMocks();
+});
+
+describe('detectWebGL', () => {
+  it('returns available when getContext returns a non-lost WebGL context', () => {
+    const fakeGl = { isContextLost: () => false } as unknown as WebGLRenderingContext;
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(((kind: string) =>
+      kind === 'webgl2' ? fakeGl : null) as typeof HTMLCanvasElement.prototype.getContext);
+
+    expect(detectWebGL()).toEqual({ available: true });
+  });
+
+  it('falls back to webgl1 when webgl2 is unavailable', () => {
+    const fakeGl = { isContextLost: () => false } as unknown as WebGLRenderingContext;
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(((kind: string) =>
+      kind === 'webgl' ? fakeGl : null) as typeof HTMLCanvasElement.prototype.getContext);
+
+    expect(detectWebGL()).toEqual({ available: true });
+  });
+
+  it('reports context-failed when no context can be acquired', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+    expect(detectWebGL()).toEqual({ available: false, reason: 'context-failed' });
+  });
+
+  it('reports context-failed when getContext throws', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    expect(detectWebGL()).toEqual({ available: false, reason: 'context-failed' });
+  });
+
+  it('reports context-lost when the returned context is already lost', () => {
+    const fakeGl = { isContextLost: () => true } as unknown as WebGLRenderingContext;
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(fakeGl);
+    expect(detectWebGL()).toEqual({ available: false, reason: 'context-lost' });
+  });
+
+  it('memoizes the first result across calls', () => {
+    const spy = vi
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockReturnValue({ isContextLost: () => false } as unknown as WebGLRenderingContext);
+
+    detectWebGL();
+    detectWebGL();
+    detectWebGL();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/shared/webgl/detectWebGL.ts
+++ b/src/shared/webgl/detectWebGL.ts
@@ -1,0 +1,48 @@
+export type WebGLUnavailableReason =
+  | 'no-document'
+  | 'no-canvas'
+  | 'context-failed'
+  | 'context-lost';
+
+export interface WebGLDetectionResult {
+  available: boolean;
+  reason?: WebGLUnavailableReason;
+}
+
+let cached: WebGLDetectionResult | null = null;
+
+function probe(): WebGLDetectionResult {
+  if (typeof document === 'undefined') {
+    return { available: false, reason: 'no-document' };
+  }
+
+  let canvas: HTMLCanvasElement;
+  try {
+    canvas = document.createElement('canvas');
+  } catch {
+    return { available: false, reason: 'no-canvas' };
+  }
+
+  let gl: WebGLRenderingContext | WebGL2RenderingContext | null;
+  try {
+    gl =
+      canvas.getContext('webgl2') ??
+      canvas.getContext('webgl') ??
+      (canvas.getContext('experimental-webgl') as WebGLRenderingContext | null);
+  } catch {
+    return { available: false, reason: 'context-failed' };
+  }
+
+  if (!gl) return { available: false, reason: 'context-failed' };
+  if (gl.isContextLost()) return { available: false, reason: 'context-lost' };
+  return { available: true };
+}
+
+export function detectWebGL(): WebGLDetectionResult {
+  cached ??= probe();
+  return cached;
+}
+
+export function resetWebGLDetectionCacheForTests(): void {
+  cached = null;
+}

--- a/src/shared/webgl/index.ts
+++ b/src/shared/webgl/index.ts
@@ -1,0 +1,3 @@
+export { detectWebGL } from './detectWebGL';
+export type { WebGLDetectionResult, WebGLUnavailableReason } from './detectWebGL';
+export { WebGLFallback } from './WebGLFallback';

--- a/src/test/setup-dom.ts
+++ b/src/test/setup-dom.ts
@@ -35,6 +35,25 @@ if (typeof Element !== 'undefined') {
   Element.prototype.hasPointerCapture = () => false;
 }
 
+// jsdom returns null for any WebGL context; teach getContext to return a
+// non-lost context object instead so detectWebGL() resolves "available" by
+// default. Tests covering the WebGL-unavailable path override this locally
+// with vi.spyOn.
+if (typeof HTMLCanvasElement !== 'undefined') {
+  const minimalWebGl = { isContextLost: () => false } as unknown as WebGLRenderingContext;
+  const originalGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function (
+    this: HTMLCanvasElement,
+    contextId: string,
+    options?: unknown
+  ): RenderingContext | null {
+    if (contextId === 'webgl' || contextId === 'webgl2' || contextId === 'experimental-webgl') {
+      return minimalWebGl;
+    }
+    return originalGetContext.call(this, contextId as '2d', options);
+  } as typeof HTMLCanvasElement.prototype.getContext;
+}
+
 if (typeof window !== 'undefined') {
   // Mock matchMedia for responsive hook tests
   Object.defineProperty(window, 'matchMedia', {

--- a/src/test/setup-dom.ts
+++ b/src/test/setup-dom.ts
@@ -5,6 +5,7 @@
 import '@testing-library/jest-dom';
 import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
+import { resetWebGLDetectionCacheForTests } from '@/shared/webgl/detectWebGL';
 
 // Suppress jsdom-environment noise from Three.js / React Three Fiber.
 if (typeof window !== 'undefined') {
@@ -101,4 +102,5 @@ afterEach(() => {
   if (typeof document !== 'undefined') {
     cleanup();
   }
+  resetWebGLDetectionCacheForTests();
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,7 @@ const domIncludes = [
   'src/**/*.test.tsx',
   'src/shared/components/**/*.test.{ts,tsx}',
   'src/shared/hooks/**/*.test.{ts,tsx}',
+  'src/shared/webgl/**/*.test.{ts,tsx}',
   'src/features/**/components/**/*.test.{ts,tsx}',
   'src/features/**/hooks/**/*.test.{ts,tsx}',
   'src/design-system/**/*.test.{ts,tsx}',


### PR DESCRIPTION
## Summary

Last-24h PostHog showed 3 active error issues on the project — 2 of 3 traced to a real gap: the baseplate's `<Canvas>` has **no error boundary and no proactive WebGL check**, so users on browsers without WebGL (HW accel disabled, GPU blocklisted, blocking extensions) silently see a permanently invisible canvas. The same path is wrapped properly in the bin-designer's `PreviewCanvas`, but that's defensive only — when R3F throws, the generic "3D Preview Error" boundary fires with no actionable copy.

This PR ships:

- **`src/shared/webgl/`**: memoized `detectWebGL()` utility + `<WebGLFallback>` component with specific, localized copy (HW accel / drivers / browser change) and a link to `https://get.webgl.org/`. Tracks via existing `track3DRenderError`.
- **`BaseplatePreview.tsx`**: proactive check renders `<WebGLFallback>` when WebGL is unavailable; wraps the live Canvas in `PanelErrorBoundary` for runtime context-loss as defense-in-depth.
- **`PreviewCanvas.tsx`** (designer): same proactive check, ahead of the existing skeleton/canvas branches.
- **i18n**: 3 keys × 9 locales (`webgl.fallback.title|body|helpLink`).
- **`setup-dom.ts`**: returns a non-lost WebGL context object from `HTMLCanvasElement.prototype.getContext` so existing DOM tests don't all fall into the fallback path under jsdom. Tests that cover the unavailable branch override locally.

## PostHog issues addressed

| Issue | Resolution |
|---|---|
| `Error: Error creating WebGL context` (unhandled) on `/baseplate` | Closed by proactive fallback |
| `Error: Error creating WebGL context` (handled) on `/baseplate` | Closed by proactive fallback |
| `TypeError: Cannot read properties of null (reading 'addEventListener')` on `/designer` | Out of scope — single occurrence, no in-app stack frames, originates in vendor code. Watching for trend. |

## Follow-ups (not in this PR)

- **Sourcemap upload pipeline**: `vite.config.ts` already emits `sourcemap: 'hidden'` but nothing uploads `.map` files to PostHog. Every prod stack trace today is opaque (`o/<` shows up where real frames should). Worth wiring up `@posthog/cli sourcemap upload` to the deploy step.
- **Mid-session WebGL context-loss UX**: today the `PanelErrorBoundary` catches but shows generic copy. Could surface the same `<WebGLFallback>` from the boundary's render path.

## Test plan

- [x] `pnpm exec vitest run src/shared/webgl/ src/features/bin-designer/components/PreviewCanvas/ src/features/baseplate/components/BaseplatePreview/` — 70/70 pass
- [x] `pnpm run typecheck` — clean
- [x] `pnpm exec eslint` on changed files — clean
- [x] `pnpm run check:i18n` / `check:i18n:interpolation` / `check:i18n:values` — all 9 locales match
- [ ] Manual: disable Firefox HW accel, load `/baseplate`, confirm fallback renders
- [ ] Manual: same on `/designer`