### PR TITLE
fix(lazy): wrap design-linking dynamic imports with lazyWithRetry

### DIFF
--- a/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
+++ b/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy } from 'react';
+import { Suspense } from 'react';
 import { CONSTRAINTS, DEFAULT_CATEGORY_COLOR, STAGING_ID } from '@/core/constants';
 import { RulerIcon } from '@/design-system/Icon';
 import { useHalfBinModeStore } from '@/core/store/halfBinMode';
@@ -10,12 +10,12 @@ import { SelectDropdown } from '@/shared/components/SelectDropdown';
 import { CustomPropertiesEditor } from '../CustomPropertiesEditor';
 import { STLSearchDropdown } from '@/shell/STLSearchDropdown';
 import { useTranslation } from '@/i18n';
+import { lazyWithRetry, namedExport } from '@/shared/utils/lazyWithRetry';
 
-// Lazy load LinkedDesignSection
-const LinkedDesignSection = lazy(() =>
-  import('@/features/design-linking/components/LinkedDesignSection').then((m) => ({
-    default: m.LinkedDesignSection,
-  }))
+const LinkedDesignSection = lazyWithRetry(() =>
+  import('@/features/design-linking/components/LinkedDesignSection').then(
+    namedExport('LinkedDesignSection')
+  )
 );
 
 interface SingleBinInspectorProps {

--- a/src/shell/Mobile/BinContextMenu/BinContextMenu.tsx
+++ b/src/shell/Mobile/BinContextMenu/BinContextMenu.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useState } from 'react';
+import { Suspense, useState } from 'react';
 import { batch } from '@/core/cqrs';
 import {
   useLayoutStore,
@@ -22,13 +22,11 @@ import { mlTracking } from '@/shared/analytics/useMLTracking';
 import { findBinById } from '@/shared/utils/entity';
 import { isOk } from '@/core/result';
 import { useTranslation } from '@/i18n';
+import { lazyWithRetry, namedExport } from '@/shared/utils/lazyWithRetry';
 import type { Bin, GridUnits, LayerId } from '@/core/types';
 
-// Lazy load design-linking section
-const BinContextMenuDesignSection = lazy(() =>
-  import('../BinContextMenuDesignSection').then((m) => ({
-    default: m.BinContextMenuDesignSection,
-  }))
+const BinContextMenuDesignSection = lazyWithRetry(() =>
+  import('../BinContextMenuDesignSection').then(namedExport('BinContextMenuDesignSection'))
 );
 
 interface BinContextMenuProps {


### PR DESCRIPTION
## Summary

While checking PostHog for new errors after the smoke-rollback chain was unblocked, I dug into a long-running intermittent error issue (\`019c4af6-...\`) that has been collecting events since 2026-02-11. It surfaces with mixed titles in PostHog (\"illegal operation attempted on a revoked proxy\", \"Cannot read properties of undefined (reading 'trim')\") but the actual fingerprint is over the stack frame, and the events are all chunk-load failures:

\`\`\`
TypeError: Failed to fetch dynamically imported module: https://gridfinitylayouttool.com/assets/LinkedDesignSection-C-Pnnnk1.js
TypeError: Cannot read properties of undefined (reading 'trim')   // bundled webpack error from 404 main-BBD6f_fd.js
\`\`\`

These come from users with an open tab on an older build whose lazy chunks were renamed by a subsequent deploy.

## Why it leaked

The project has \`lazyWithRetry\` (\`src/shared/utils/lazyWithRetry.ts\`) that retries failed dynamic imports and then reloads the page. **Two call sites still use raw \`React.lazy()\`:**

- \`SingleBinInspector.tsx\` → \`LinkedDesignSection\` (the chunk in the PostHog events)
- \`BinContextMenu.tsx\` → \`BinContextMenuDesignSection\`

Both are design-linking entry points and were added before \`lazyWithRetry\` was the project norm. Without retry, the rejected import promise hits the global \`unhandledrejection\` listener in \`src/shared/analytics/posthog/init.ts:110\` and \`captureException\` ships it.

## Fix

Swap both for \`lazyWithRetry(...)\` with \`namedExport()\` — matching the pattern every other lazy import already uses.

## Test plan

- [x] Tests pass: \`pnpm exec vitest run src/features/bin-inspector/ src/shell/Mobile/BinContextMenu/\` (147/147)
- [x] Typecheck clean
- [x] Lint clean
- [x] \`grep -rn "= lazy(" src/\` returns 0 hits — all lazy imports now go through retry wrapper

## Follow-up (not in this PR)

The PostHog error grouping is conflating different exception messages under one fingerprint because the stack shape is identical (all paths through the dynamic-import handler). Worth a separate look at PostHog's fingerprint rules for this issue once new occurrences stop arriving — easier to triage if chunk-load failures get their own group.