### PR TITLE
fix(analytics): filter browser-extension noise from PostHog capture

### DIFF
--- a/src/shared/analytics/posthog/errorFilters.test.ts
+++ b/src/shared/analytics/posthog/errorFilters.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { filterExceptionForPosthog, shouldIgnoreError } from './errorFilters';
+
+describe('shouldIgnoreError — message patterns', () => {
+  it.each([
+    'Error: No Listener: tabs:outgoing.message.ready',
+    'No Listener: tabs:incoming.foo',
+    'Invalid call to runtime.sendMessage(). Tab not found.',
+    'Extension context invalidated.',
+    'Script error.',
+    'Script error',
+    'ResizeObserver loop limit exceeded',
+    'ResizeObserver loop completed with undelivered notifications.',
+  ])('ignores %j', (msg) => {
+    expect(shouldIgnoreError(msg)).toBe(true);
+  });
+
+  it.each([
+    'Cannot read properties of null (reading addEventListener)',
+    'Error creating WebGL context',
+    'Failed to fetch dynamically imported module',
+    'TypeError: foo is not a function',
+  ])('does NOT ignore real app error %j', (msg) => {
+    expect(shouldIgnoreError(msg)).toBe(false);
+  });
+
+  it('ignores empty / undefined message safely', () => {
+    expect(shouldIgnoreError(null)).toBe(false);
+    expect(shouldIgnoreError(undefined)).toBe(false);
+    expect(shouldIgnoreError('')).toBe(false);
+  });
+});
+
+describe('shouldIgnoreError — source patterns', () => {
+  it.each([
+    'chrome-extension://abc123/content.js',
+    'moz-extension://uuid/script.js',
+    'safari-web-extension://abc/foo.js',
+    'safari-extension://abc/foo.js',
+  ])('ignores %j', (source) => {
+    expect(shouldIgnoreError('TypeError: x', source)).toBe(true);
+  });
+
+  it('does NOT ignore app sources', () => {
+    expect(shouldIgnoreError('TypeError: x', '/assets/main-abc.js')).toBe(false);
+    expect(shouldIgnoreError('TypeError: x', 'https://gridfinitylayouttool.com/foo.js')).toBe(
+      false
+    );
+  });
+});
+
+describe('filterExceptionForPosthog', () => {
+  it('passes non-$exception events through unchanged', () => {
+    const e = { event: '$pageview', properties: { url: '/baseplate' } };
+    expect(filterExceptionForPosthog(e)).toBe(e);
+  });
+
+  it('drops $exception events whose $exception_list value matches a filter', () => {
+    const e = {
+      event: '$exception',
+      properties: {
+        $exception_list: [{ value: 'No Listener: tabs:outgoing.message.ready' }],
+      },
+    };
+    expect(filterExceptionForPosthog(e)).toBeNull();
+  });
+
+  it('drops $exception events using $exception_values fallback', () => {
+    const e = {
+      event: '$exception',
+      properties: { $exception_values: ['Invalid call to runtime.sendMessage(). Tab not found.'] },
+    };
+    expect(filterExceptionForPosthog(e)).toBeNull();
+  });
+
+  it('passes $exception events for real app errors through', () => {
+    const e = {
+      event: '$exception',
+      properties: {
+        $exception_list: [{ value: 'Cannot read properties of null (reading foo)' }],
+      },
+    };
+    expect(filterExceptionForPosthog(e)).toBe(e);
+  });
+});

--- a/src/shared/analytics/posthog/errorFilters.test.ts
+++ b/src/shared/analytics/posthog/errorFilters.test.ts
@@ -82,4 +82,19 @@ describe('filterExceptionForPosthog', () => {
     };
     expect(filterExceptionForPosthog(e)).toBe(e);
   });
+
+  it('keeps $exception when only a non-primary cause matches a filter', () => {
+    // Real app error wraps an extension error as Error.cause — keep the event,
+    // since the user-visible failure is the primary (app) error.
+    const e = {
+      event: '$exception',
+      properties: {
+        $exception_list: [
+          { value: 'TypeError: appCode is undefined' },
+          { value: 'No Listener: tabs:outgoing.message.ready' },
+        ],
+      },
+    };
+    expect(filterExceptionForPosthog(e)).toBe(e);
+  });
 });

--- a/src/shared/analytics/posthog/errorFilters.ts
+++ b/src/shared/analytics/posthog/errorFilters.ts
@@ -50,8 +50,13 @@ interface ExceptionEventLike {
 }
 
 /**
- * PostHog `before_send` hook. Drops `$exception` events that match the
- * extension/noise filters; passes everything else through unchanged.
+ * PostHog `before_send` hook. Drops `$exception` events whose **primary**
+ * exception matches the extension/noise filters; passes everything else
+ * through unchanged.
+ *
+ * Only the first entry in `$exception_list` / `$exception_values` is
+ * checked. Subsequent entries are `Error.cause` chains — if a real app
+ * error wrapped extension noise as a cause, we want to keep the event.
  *
  * Typed loosely (input ExceptionEventLike | null, returning same shape) so
  * posthog-js's BeforeSendFn signature accepts it — it passes CaptureResult,
@@ -62,11 +67,8 @@ export function filterExceptionForPosthog(
 ): ExceptionEventLike | null {
   if (!event) return event;
   if (event.event !== '$exception') return event;
-  const list = event.properties?.$exception_list ?? [];
-  const values = event.properties?.$exception_values ?? [];
-  const messages = [...list.map((e) => e.value), ...values];
-  for (const msg of messages) {
-    if (shouldIgnoreError(msg)) return null;
-  }
+  const primary =
+    event.properties?.$exception_list?.[0]?.value ?? event.properties?.$exception_values?.[0];
+  if (shouldIgnoreError(primary)) return null;
   return event;
 }

--- a/src/shared/analytics/posthog/errorFilters.ts
+++ b/src/shared/analytics/posthog/errorFilters.ts
@@ -1,0 +1,72 @@
+/**
+ * Browser-extension and platform noise we don't want in PostHog.
+ *
+ * Extensions (ad blockers, password managers, dev tools, etc.) inject scripts
+ * into the page context. When those scripts throw, our `window.onerror` /
+ * `unhandledrejection` listeners catch them and PostHog's `capture_exceptions`
+ * also auto-captures them — surfacing as errors whose only stack frame points
+ * at `init.ts`, looking like our bug. They're not.
+ */
+
+const IGNORED_MESSAGE_PATTERNS: readonly RegExp[] = [
+  // Safari Web Extensions message bus
+  /No Listener: tabs:/i,
+  // Chrome extension API surfaces
+  /Invalid call to runtime\.sendMessage/i,
+  /Extension context invalidated/i,
+  // Generic same-origin script error from a script we didn't load
+  /^Script error\.?$/,
+  // Extension content-script DOM observers (very common, never actionable)
+  /ResizeObserver loop (limit exceeded|completed with undelivered notifications)/i,
+];
+
+const IGNORED_SOURCE_PATTERNS: readonly RegExp[] = [
+  /^(chrome|moz|safari-web|safari)-extension:\/\//,
+];
+
+export function shouldIgnoreError(
+  message: string | null | undefined,
+  source?: string | null
+): boolean {
+  if (message) {
+    for (const pattern of IGNORED_MESSAGE_PATTERNS) {
+      if (pattern.test(message)) return true;
+    }
+  }
+  if (source) {
+    for (const pattern of IGNORED_SOURCE_PATTERNS) {
+      if (pattern.test(source)) return true;
+    }
+  }
+  return false;
+}
+
+interface ExceptionEventLike {
+  event?: string;
+  properties?: {
+    $exception_list?: Array<{ value?: string }>;
+    $exception_values?: string[];
+  };
+}
+
+/**
+ * PostHog `before_send` hook. Drops `$exception` events that match the
+ * extension/noise filters; passes everything else through unchanged.
+ *
+ * Typed loosely (input ExceptionEventLike | null, returning same shape) so
+ * posthog-js's BeforeSendFn signature accepts it — it passes CaptureResult,
+ * which structurally satisfies ExceptionEventLike for the fields we read.
+ */
+export function filterExceptionForPosthog(
+  event: ExceptionEventLike | null
+): ExceptionEventLike | null {
+  if (!event) return event;
+  if (event.event !== '$exception') return event;
+  const list = event.properties?.$exception_list ?? [];
+  const values = event.properties?.$exception_values ?? [];
+  const messages = [...list.map((e) => e.value), ...values];
+  for (const msg of messages) {
+    if (shouldIgnoreError(msg)) return null;
+  }
+  return event;
+}

--- a/src/shared/analytics/posthog/init.ts
+++ b/src/shared/analytics/posthog/init.ts
@@ -6,6 +6,7 @@
 import type { PostHog } from 'posthog-js';
 import { useSettingsStore } from '@/core/store/settings';
 import { getStableUserId } from './identity';
+import { filterExceptionForPosthog, shouldIgnoreError } from './errorFilters';
 
 // INITIALIZATION (LAZY LOADED)
 
@@ -55,6 +56,12 @@ export function initAnalytics(): void {
 
         // Performance monitoring - web vitals
         capture_performance: true,
+
+        // Drop extension/platform noise before it ships. Native capture_exceptions
+        // fires independently of our window.onerror handler, so this is the only
+        // place we can filter that path. CaptureResult is a structural superset
+        // of the shape filterExceptionForPosthog reads.
+        before_send: (event) => filterExceptionForPosthog(event) as typeof event,
       });
       posthogInstance = posthog;
 
@@ -92,6 +99,7 @@ export function initAnalytics(): void {
       // A re-entrancy guard prevents infinite loops if captureException itself throws.
       window.addEventListener('error', (event: ErrorEvent) => {
         if (isCapturingGlobalError) return;
+        if (shouldIgnoreError(event.message, event.filename)) return;
         isCapturingGlobalError = true;
         try {
           if (event.error instanceof Error) {
@@ -109,6 +117,9 @@ export function initAnalytics(): void {
 
       window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
         if (isCapturingGlobalError) return;
+        const reasonMsg =
+          event.reason instanceof Error ? event.reason.message : String(event.reason);
+        if (shouldIgnoreError(reasonMsg)) return;
         isCapturingGlobalError = true;
         try {
           const error =


### PR DESCRIPTION
## Summary

The 24h PostHog snapshot after merging #1701 + #1703 showed two new error groups that look like our bugs but aren't:

| Issue | Message | Source |
|---|---|---|
| \`019e17bb\` | \`Invalid call to runtime.sendMessage(). Tab not found.\` | Safari Web Extensions |
| \`019e335e\` | \`No Listener: tabs:outgoing.message.ready\` | Safari Web Extensions |

Both have a single stack frame pointing at our \`init.ts:114\` because that's where our \`unhandledrejection\` listener lives — the actual error originated in an extension content script (most likely a password manager or content blocker). PostHog also independently captures these via its native \`capture_exceptions: true\`, creating a second issue group for each underlying event.

## Fix

Two new files, three wiring points:

- **\`src/shared/analytics/posthog/errorFilters.ts\`** — \`shouldIgnoreError(message, source?)\` predicate + \`filterExceptionForPosthog\` \`$exception\`-event hook. Conservative starter pattern list:
  - \`No Listener: tabs:\` / \`Invalid call to runtime.sendMessage\` / \`Extension context invalidated\` (extension messaging APIs)
  - \`Script error.\` (cross-origin script noise)
  - \`ResizeObserver loop limit exceeded\` / \`...completed with undelivered notifications\` (common content-script DOM mutation noise)
  - Source URLs matching \`(chrome|moz|safari-web|safari)-extension://\`
- **\`init.ts\`** — wired in three places:
  - \`window.addEventListener('error', ...)\` — early-return on match
  - \`window.addEventListener('unhandledrejection', ...)\` — same
  - \`posthog.init({ before_send })\` — covers PostHog's native capture path

The third one is the load-bearing one: without it, \`capture_exceptions: true\` still ships extension noise through the SDK's own listeners, which is exactly what created the two new issue groups above.

## Test plan

- [x] \`pnpm exec vitest run src/shared/analytics/posthog/\` — 97/97 (24 new in errorFilters.test.ts)
- [x] Each pattern has both a positive (\"ignores X\") and negative (\"does NOT ignore real app error Y\") test to guard against future broadening swallowing real signal
- [x] \`pnpm run typecheck\` clean
- [x] Lint clean

## What to watch after deploy

The two new issue groups should stop accumulating events. If a real error in our code happens to match a pattern (low risk given the messages are extension-API-specific), we'll see it disappear — the negative test list documents the line we don't want to cross.