### PR TITLE
feat: sync-admin CLI for blob/index integrity audits

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "check:readme-reminders": "./scripts/check-readme-reminders.sh",
     "check:missing-tests": "./scripts/check-missing-tests.sh",
     "check:component-structure": "./scripts/check-component-structure.sh",
+    "sync-admin": "tsx scripts/sync-admin/index.ts",
     "bench": "vitest bench",
     "bench:json": "vitest bench --outputJson benchmarks/latest.json",
     "knip": "knip",

--- a/scripts/sync-admin/README.md
+++ b/scripts/sync-admin/README.md
@@ -1,9 +1,8 @@
 # sync-admin
 
 Operator toolkit for the cloud-sync subsystem. Reads from production Vercel Blob
-
-- Redis (via `.env.production.local`) and reports on integrity. **Read-only**:
-  mutations are emitted as shell commands the operator pastes after review.
+and Redis (via `.env.production.local`) and reports on integrity. **Read-only**:
+mutations are emitted as shell commands the operator pastes after review.
 
 ## Setup
 
@@ -87,15 +86,15 @@ bash drift-fixes.sh
 
 ## Shared flags
 
-| Flag                      | Applies to                 | Effect                                             |
-| ------------------------- | -------------------------- | -------------------------------------------------- |
-| `--json`                  | all                        | Machine-readable output (use with `pnpm --silent`) |
-| `--strict`                | audit, user, tombstones    | Exit 1 if any error/warning finding present        |
-| `--kind=layouts\|designs` | most                       | Restrict to one item kind                          |
-| `--user=<uid>`            | audit, suggest, tombstones | Restrict to one user                               |
-| `--no-payload-fetch`      | audit, user, suggest       | Skip per-blob HTTP fetch (skips envelope checks)   |
-| `--suggest`               | audit                      | Inline fix commands beneath each finding           |
-| `--older-than=Nd`         | tombstones, suggest        | Stale-tombstone age threshold (default 90d)        |
+| Flag                      | Applies to                 | Effect                                                                               |
+| ------------------------- | -------------------------- | ------------------------------------------------------------------------------------ |
+| `--json`                  | all                        | Machine-readable output (use with `pnpm --silent`)                                   |
+| `--strict`                | audit, user, tombstones    | Exit 1 if any finding present (errors, warnings, _and_ info — e.g. stale tombstones) |
+| `--kind=layouts\|designs` | most                       | Restrict to one item kind                                                            |
+| `--user=<uid>`            | audit, suggest, tombstones | Restrict to one user                                                                 |
+| `--no-payload-fetch`      | audit, user, suggest       | Skip per-blob HTTP fetch (skips envelope checks)                                     |
+| `--suggest`               | audit                      | Inline fix commands beneath each finding                                             |
+| `--older-than=Nd`         | tombstones, suggest        | Stale-tombstone age threshold (default 90d)                                          |
 
 ## Finding kinds
 

--- a/scripts/sync-admin/README.md
+++ b/scripts/sync-admin/README.md
@@ -1,0 +1,131 @@
+# sync-admin
+
+Operator toolkit for the cloud-sync subsystem. Reads from production Vercel Blob
+
+- Redis (via `.env.production.local`) and reports on integrity. **Read-only**:
+  mutations are emitted as shell commands the operator pastes after review.
+
+## Setup
+
+```bash
+vercel env pull .env.production.local
+pnpm sync-admin --help
+```
+
+Credentials needed in `.env.production.local`:
+
+- `BLOB_READ_WRITE_TOKEN` — Vercel Blob
+- `REDIS_URL` — Redis Cloud connection string
+
+A banner with the target Redis host + blob token prefix prints on every run so
+the operator can sanity-check what they're about to scan.
+
+## Commands
+
+### `audit`
+
+Full integrity scan: blob ↔ index reconciliation, envelope validation, payload
+validation (via the same `validateShareLayout` / `validateDesignerShare` the
+PUT endpoints use), and sanitization-drift detection.
+
+```bash
+pnpm sync-admin audit                       # human-readable report
+pnpm sync-admin audit --suggest             # inline fix commands per finding
+pnpm sync-admin audit --no-payload-fetch    # fast path, skips HTTP fetch
+pnpm sync-admin audit --strict              # exit non-zero on any finding (CI)
+pnpm --silent sync-admin audit --json       # structured output for piping
+```
+
+### `user <uid>`
+
+Drill into a single user: list their blobs, live entries, tombstones, and any
+findings.
+
+```bash
+pnpm sync-admin user 589314dfbe7f...
+pnpm sync-admin user 589314dfbe7f... --kind=designs
+```
+
+### `users`
+
+Table of all users sorted by total blob bytes desc. Use to spot capacity
+outliers.
+
+```bash
+pnpm sync-admin users
+pnpm --silent sync-admin users --json | jq '.[0]'
+```
+
+### `tombstones`
+
+List tombstones across all users (or `--user=<uid>`), with age and stale
+status. Default stale threshold: 90 days (matches `TOMBSTONE_RETENTION_MS` in
+`api/lib/userIndex.ts`).
+
+```bash
+pnpm sync-admin tombstones
+pnpm sync-admin tombstones --older-than=180d
+```
+
+### `suggest <category>`
+
+Emit shell commands that would remediate findings of one category. Output is
+designed to be reviewed and pasted; nothing runs automatically.
+
+| Category           | Emits                                                        |
+| ------------------ | ------------------------------------------------------------ |
+| `drift`            | `redis-cli EVAL` that rewrites `sizeBytes` to match the blob |
+| `orphans`          | `vercel blob rm` (orphan blob) or `HDEL` (missing blob)      |
+| `stale-tombstones` | `redis-cli HDEL` for tombstones older than the threshold     |
+| `malformed`        | `HGET` (inspect) then commented `HDEL` (uncomment to apply)  |
+
+```bash
+pnpm sync-admin suggest drift > drift-fixes.sh
+# review drift-fixes.sh, then:
+bash drift-fixes.sh
+```
+
+## Shared flags
+
+| Flag                      | Applies to                 | Effect                                             |
+| ------------------------- | -------------------------- | -------------------------------------------------- |
+| `--json`                  | all                        | Machine-readable output (use with `pnpm --silent`) |
+| `--strict`                | audit, user, tombstones    | Exit 1 if any error/warning finding present        |
+| `--kind=layouts\|designs` | most                       | Restrict to one item kind                          |
+| `--user=<uid>`            | audit, suggest, tombstones | Restrict to one user                               |
+| `--no-payload-fetch`      | audit, user, suggest       | Skip per-blob HTTP fetch (skips envelope checks)   |
+| `--suggest`               | audit                      | Inline fix commands beneath each finding           |
+| `--older-than=Nd`         | tombstones, suggest        | Stale-tombstone age threshold (default 90d)        |
+
+## Finding kinds
+
+| Kind                    | Severity | Means                                                        |
+| ----------------------- | -------- | ------------------------------------------------------------ |
+| `orphan_blob`           | error    | Blob exists, no live index entry                             |
+| `missing_blob`          | error    | Live index entry exists, no blob                             |
+| `tombstone_with_blob`   | error    | Index says deleted, blob survives                            |
+| `malformed_index_entry` | error    | Index hash value isn't parseable JSON                        |
+| `modifiedAt_mismatch`   | error    | Envelope's `modifiedAt` differs from index entry's           |
+| `envelope_invalid`      | error    | Envelope shape wrong: bad `schemaVersion` / `modifiedAt`     |
+| `payload_invalid`       | error    | `validateShareLayout` / `validateDesignerShare` rejected     |
+| `sanitization_drift`    | warn     | Index `sizeBytes` over-counts (quota leak in system's favor) |
+| `stale_tombstone`       | info     | Tombstone older than retention; safe to sweep                |
+
+## CI usage
+
+```bash
+pnpm sync-admin audit --strict --no-payload-fetch
+```
+
+Exits 1 on any error/warning. `--no-payload-fetch` keeps the run sub-second
+without sacrificing membership + drift detection.
+
+## Implementation notes
+
+- Imports `validateShareLayout`, `validateDesignerShare`, `userIndexKey`,
+  `TOMBSTONE_RETENTION_MS` directly from `api/lib/` so production validation
+  changes are reflected automatically.
+- Bounded concurrency of 16 in-flight blob fetches via `lib/concurrency.ts`.
+- The envelope-overhead delta math lives in `lib/delta.ts`; see comments
+  there for the precise byte accounting that distinguishes "expected" from
+  "drift".

--- a/scripts/sync-admin/README.md
+++ b/scripts/sync-admin/README.md
@@ -109,6 +109,7 @@ bash drift-fixes.sh
 | `envelope_invalid`      | error    | Envelope shape wrong: bad `schemaVersion` / `modifiedAt`     |
 | `payload_invalid`       | error    | `validateShareLayout` / `validateDesignerShare` rejected     |
 | `sanitization_drift`    | warn     | Index `sizeBytes` over-counts (quota leak in system's favor) |
+| `listing_size_mismatch` | warn     | Vercel Blob listing's `size` differs from fetched byte count |
 | `stale_tombstone`       | info     | Tombstone older than retention; safe to sweep                |
 
 ## CI usage

--- a/scripts/sync-admin/__tests__/args.test.ts
+++ b/scripts/sync-admin/__tests__/args.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { parseArgs } from '../lib/args';
+
+describe('parseArgs', () => {
+  it('parses bare command', () => {
+    const a = parseArgs(['audit']);
+    expect(a.command).toBe('audit');
+    expect(a.json).toBe(false);
+  });
+
+  it('parses flags and positional', () => {
+    const a = parseArgs(['user', 'abc123', '--json', '--strict']);
+    expect(a.command).toBe('user');
+    expect(a.positional).toEqual(['abc123']);
+    expect(a.json).toBe(true);
+    expect(a.strict).toBe(true);
+  });
+
+  it('parses --kind with validation', () => {
+    expect(parseArgs(['audit', '--kind=layouts']).kind).toBe('layouts');
+    expect(parseArgs(['audit', '--kind=designs']).kind).toBe('designs');
+    expect(() => parseArgs(['audit', '--kind=banana'])).toThrow();
+  });
+
+  it('parses --older-than', () => {
+    expect(parseArgs(['tombstones', '--older-than=30d']).olderThanMs).toBe(30 * 86400000);
+    expect(() => parseArgs(['tombstones', '--older-than=30'])).toThrow();
+  });
+
+  it('rejects unknown flags', () => {
+    expect(() => parseArgs(['audit', '--banana'])).toThrow(/Unknown flag/);
+  });
+
+  it('parses --user', () => {
+    expect(parseArgs(['audit', '--user=abc']).user).toBe('abc');
+  });
+});

--- a/scripts/sync-admin/__tests__/args.test.ts
+++ b/scripts/sync-admin/__tests__/args.test.ts
@@ -34,4 +34,8 @@ describe('parseArgs', () => {
   it('parses --user', () => {
     expect(parseArgs(['audit', '--user=abc']).user).toBe('abc');
   });
+
+  it('rejects empty --user= to prevent accidental full-production scans', () => {
+    expect(() => parseArgs(['audit', '--user='])).toThrow(/cannot be empty/);
+  });
 });

--- a/scripts/sync-admin/__tests__/concurrency.test.ts
+++ b/scripts/sync-admin/__tests__/concurrency.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { pMap } from '../lib/concurrency';
+
+describe('pMap', () => {
+  it('preserves order', async () => {
+    const out = await pMap([1, 2, 3, 4, 5], async (n) => n * 2, 2);
+    expect(out).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it('bounds in-flight count', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const work = (): Promise<number> =>
+      new Promise((res) => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        setTimeout(() => {
+          inFlight--;
+          res(1);
+        }, 5);
+      });
+    await pMap(
+      Array.from({ length: 20 }, () => 0),
+      work,
+      4
+    );
+    expect(peak).toBeLessThanOrEqual(4);
+  });
+
+  it('handles empty input', async () => {
+    expect(await pMap([], async () => 1, 4)).toEqual([]);
+  });
+});

--- a/scripts/sync-admin/__tests__/delta.test.ts
+++ b/scripts/sync-admin/__tests__/delta.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { expectedEnvelopeDelta } from '../lib/delta';
+
+describe('expectedEnvelopeDelta', () => {
+  it('layouts: 32 + digit-count of modifiedAt', () => {
+    expect(expectedEnvelopeDelta('layouts', 1_700_000_000_000)).toBe(45);
+    expect(expectedEnvelopeDelta('layouts', 1_000_000_000_000)).toBe(45);
+    expect(expectedEnvelopeDelta('layouts', 100_000)).toBe(38);
+  });
+
+  it('designs: 13 + digit-count of modifiedAt', () => {
+    expect(expectedEnvelopeDelta('designs', 1_700_000_000_000)).toBe(26);
+    expect(expectedEnvelopeDelta('designs', 100_000)).toBe(19);
+  });
+
+  it('matches actual blob/index difference for canonical layout envelope', () => {
+    const layout = { drawer: { width: 5, depth: 5, height: 3 }, bins: [] };
+    const modifiedAt = 1_780_000_000_000;
+    const indexBody = JSON.stringify({ layout });
+    const blobBody = JSON.stringify({ layout, modifiedAt, schemaVersion: 1 });
+    const actual = Buffer.byteLength(blobBody) - Buffer.byteLength(indexBody);
+    expect(actual).toBe(expectedEnvelopeDelta('layouts', modifiedAt));
+  });
+
+  it('matches actual blob/index difference for canonical design envelope', () => {
+    const params = { width: 1, depth: 2, height: 6, base: {} };
+    const name = 'My design';
+    const modifiedAt = 1_780_000_000_000;
+    const indexBody = JSON.stringify({ name, type: 'designer', version: 1, params });
+    const blobBody = JSON.stringify({ design: { name, params }, modifiedAt, schemaVersion: 1 });
+    const actual = Buffer.byteLength(blobBody) - Buffer.byteLength(indexBody);
+    expect(actual).toBe(expectedEnvelopeDelta('designs', modifiedAt));
+  });
+});

--- a/scripts/sync-admin/__tests__/findings.test.ts
+++ b/scripts/sync-admin/__tests__/findings.test.ts
@@ -94,12 +94,12 @@ describe('analyze', () => {
     expect(findings.find((f) => f.kind === 'missing_blob')).toBeDefined();
   });
 
-  it('flags tombstone with surviving blob', async () => {
+  it('flags tombstone with surviving blob exactly once (no duplicate orphan_blob)', async () => {
     const blob = layoutBlob('u1', 'zombie');
     const entry = tombstoneEntry('u1', 'zombie', T);
-    mockPayload({ layout: layoutPayload, modifiedAt: T, schemaVersion: 1 });
-    const findings = await analyze(makeInventory([blob], [entry]));
-    expect(findings.find((f) => f.kind === 'tombstone_with_blob')).toBeDefined();
+    const findings = await analyze(makeInventory([blob], [entry]), { fetchPayloads: false });
+    expect(findings.filter((f) => f.kind === 'tombstone_with_blob')).toHaveLength(1);
+    expect(findings.filter((f) => f.kind === 'orphan_blob')).toHaveLength(0);
   });
 
   it('flags sanitization drift when index sizeBytes is higher than blob - envelope overhead', async () => {
@@ -157,6 +157,18 @@ describe('analyze', () => {
     mockPayload({ layout: layoutPayload, modifiedAt: T, schemaVersion: 2 });
     const findings = await analyze(makeInventory([blob], [entry]));
     expect(findings.find((f) => f.kind === 'envelope_invalid')).toBeDefined();
+  });
+
+  it('flags listing_size_mismatch when fetched bytes diverge from listing.size', async () => {
+    const blob = layoutBlob('u1', 'a');
+    const entry = layoutEntry('u1', 'a');
+    const body = JSON.stringify({ layout: layoutPayload, modifiedAt: T, schemaVersion: 1 });
+    const oversized = { ...blob, size: Buffer.byteLength(body) + 50 };
+    mockPayload({ layout: layoutPayload, modifiedAt: T, schemaVersion: 1 });
+    const findings = await analyze(makeInventory([oversized], [entry]));
+    const m = findings.find((f) => f.kind === 'listing_size_mismatch');
+    expect(m).toBeDefined();
+    expect((m?.data as { listingSize: number }).listingSize).toBe(Buffer.byteLength(body) + 50);
   });
 
   it('skips payload fetching when fetchPayloads=false', async () => {

--- a/scripts/sync-admin/__tests__/findings.test.ts
+++ b/scripts/sync-admin/__tests__/findings.test.ts
@@ -102,7 +102,7 @@ describe('analyze', () => {
     expect(findings.filter((f) => f.kind === 'orphan_blob')).toHaveLength(0);
   });
 
-  it('flags sanitization drift when index sizeBytes is higher than blob - envelope overhead', async () => {
+  it('flags sanitization drift when index over-counts (delta < expected)', async () => {
     const blob = layoutBlob('u1', 'x');
     const inflated = layoutEntry(
       'u1',
@@ -110,11 +110,60 @@ describe('analyze', () => {
       T,
       blob.size - expectedEnvelopeDelta('layouts', T) + 100
     );
-    mockPayload({ layout: layoutPayload, modifiedAt: T, schemaVersion: 1 });
-    const findings = await analyze(makeInventory([blob], [inflated]));
+    const findings = await analyze(makeInventory([blob], [inflated]), { fetchPayloads: false });
     const drift = findings.find((f) => f.kind === 'sanitization_drift');
     expect(drift).toBeDefined();
     expect((drift?.data as { drift: number }).drift).toBe(-100);
+    expect(findings.some((f) => f.kind === 'index_size_undercount')).toBe(false);
+  });
+
+  it('flags index_size_undercount when index under-counts (delta > expected)', async () => {
+    const blob = layoutBlob('u1', 'x');
+    const undercount = layoutEntry(
+      'u1',
+      'x',
+      T,
+      blob.size - expectedEnvelopeDelta('layouts', T) - 50
+    );
+    const findings = await analyze(makeInventory([blob], [undercount]), { fetchPayloads: false });
+    const f = findings.find((finding) => finding.kind === 'index_size_undercount');
+    expect(f).toBeDefined();
+    expect(f?.severity).toBe('error');
+    expect((f?.data as { drift: number }).drift).toBe(50);
+    expect(findings.some((finding) => finding.kind === 'sanitization_drift')).toBe(false);
+  });
+
+  it('skips payload validation for malformed index rows', async () => {
+    const blob = layoutBlob('u1', 'mal');
+    const malformed: IndexRow = {
+      uid: 'u1',
+      kind: 'layouts',
+      id: 'mal',
+      entry: { modifiedAt: NaN, sizeBytes: NaN },
+      tombstone: false,
+    };
+    const findings = await analyze(makeInventory([blob], [malformed]));
+    expect(findings.some((f) => f.kind === 'malformed_index_entry')).toBe(true);
+    expect(findings.some((f) => f.kind === 'modifiedAt_mismatch')).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('flags fetch_timeout when fetch exceeds the deadline', async () => {
+    const blob = layoutBlob('u1', 'slow');
+    const entry = layoutEntry('u1', 'slow');
+    fetchMock.mockImplementationOnce(async (_url: string, opts?: { signal?: AbortSignal }) => {
+      return new Promise((_, reject) => {
+        opts?.signal?.addEventListener('abort', () => {
+          const err = new DOMException('timed out', 'TimeoutError');
+          reject(err);
+        });
+      });
+    });
+    const findings = await analyze(makeInventory([blob], [entry]), {
+      fetchPayloads: true,
+      fetchTimeoutMs: 5,
+    });
+    expect(findings.find((f) => f.kind === 'fetch_timeout')).toBeDefined();
   });
 
   it('flags stale tombstone older than retention', async () => {

--- a/scripts/sync-admin/__tests__/findings.test.ts
+++ b/scripts/sync-admin/__tests__/findings.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { analyze } from '../lib/findings';
+import { expectedEnvelopeDelta } from '../lib/delta';
+import type { Inventory, BlobRow, IndexRow } from '../lib/types';
+import { itemKey } from '../lib/inventory';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+beforeEach(() => fetchMock.mockReset());
+
+function makeInventory(blobs: BlobRow[], indexRows: IndexRow[]): Inventory {
+  const blobMap = new Map<string, BlobRow>();
+  const blobUsers = new Set<string>();
+  for (const b of blobs) {
+    blobMap.set(itemKey(b.uid, b.kind, b.id), b);
+    blobUsers.add(b.uid);
+  }
+  const indexMap = new Map<string, IndexRow>();
+  const redisUsers = new Set<string>();
+  for (const r of indexRows) {
+    indexMap.set(itemKey(r.uid, r.kind, r.id), r);
+    redisUsers.add(r.uid);
+  }
+  return { blobs, blobMap, indexRows, indexMap, blobUsers, redisUsers };
+}
+
+const T = 1_780_000_000_000;
+const layoutPayload = {
+  drawer: { width: 5, depth: 5, height: 3 },
+  gridUnitMm: 42,
+  heightUnitMm: 7,
+  printBedSize: 256,
+  bins: [],
+  layers: [{ id: 'l1', name: 'L1', heightUnits: 3 }],
+  categories: [{ id: 'c1', name: 'C1', color: '#000000' }],
+};
+
+function layoutBlob(uid: string, id: string, modifiedAt = T, payload = layoutPayload): BlobRow {
+  const body = JSON.stringify({ layout: payload, modifiedAt, schemaVersion: 1 });
+  return {
+    uid,
+    kind: 'layouts',
+    id,
+    size: Buffer.byteLength(body),
+    url: `https://blob/${uid}/${id}`,
+    uploadedAt: new Date(modifiedAt),
+  };
+}
+
+function layoutEntry(uid: string, id: string, modifiedAt = T, sizeBytes?: number): IndexRow {
+  const indexBody = JSON.stringify({ layout: layoutPayload });
+  return {
+    uid,
+    kind: 'layouts',
+    id,
+    entry: { modifiedAt, sizeBytes: sizeBytes ?? Buffer.byteLength(indexBody) },
+    tombstone: false,
+  };
+}
+
+function tombstoneEntry(uid: string, id: string, deletedAt: number): IndexRow {
+  return {
+    uid,
+    kind: 'layouts',
+    id,
+    entry: { modifiedAt: deletedAt, sizeBytes: 0, deletedAt },
+    tombstone: true,
+  };
+}
+
+function mockPayload(body: unknown): void {
+  fetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => JSON.stringify(body) });
+}
+
+describe('analyze', () => {
+  it('clean inventory produces no membership findings', async () => {
+    const blob = layoutBlob('u1', 'a');
+    const entry = layoutEntry('u1', 'a');
+    const findings = await analyze(makeInventory([blob], [entry]), { fetchPayloads: false });
+    expect(findings).toEqual([]);
+  });
+
+  it('flags orphan blob (blob without index entry)', async () => {
+    const blob = layoutBlob('u1', 'orphan');
+    mockPayload({ layout: layoutPayload, modifiedAt: T, schemaVersion: 1 });
+    const findings = await analyze(makeInventory([blob], []));
+    expect(findings.find((f) => f.kind === 'orphan_blob')).toBeDefined();
+  });
+
+  it('flags missing blob (index entry without blob)', async () => {
+    const entry = layoutEntry('u1', 'gone');
+    const findings = await analyze(makeInventory([], [entry]));
+    expect(findings.find((f) => f.kind === 'missing_blob')).toBeDefined();
+  });
+
+  it('flags tombstone with surviving blob', async () => {
+    const blob = layoutBlob('u1', 'zombie');
+    const entry = tombstoneEntry('u1', 'zombie', T);
+    mockPayload({ layout: layoutPayload, modifiedAt: T, schemaVersion: 1 });
+    const findings = await analyze(makeInventory([blob], [entry]));
+    expect(findings.find((f) => f.kind === 'tombstone_with_blob')).toBeDefined();
+  });
+
+  it('flags sanitization drift when index sizeBytes is higher than blob - envelope overhead', async () => {
+    const blob = layoutBlob('u1', 'x');
+    const inflated = layoutEntry(
+      'u1',
+      'x',
+      T,
+      blob.size - expectedEnvelopeDelta('layouts', T) + 100
+    );
+    mockPayload({ layout: layoutPayload, modifiedAt: T, schemaVersion: 1 });
+    const findings = await analyze(makeInventory([blob], [inflated]));
+    const drift = findings.find((f) => f.kind === 'sanitization_drift');
+    expect(drift).toBeDefined();
+    expect((drift?.data as { drift: number }).drift).toBe(-100);
+  });
+
+  it('flags stale tombstone older than retention', async () => {
+    const old = Date.now() - 100 * 86400000;
+    const entry = tombstoneEntry('u1', 'old', old);
+    const findings = await analyze(makeInventory([], [entry]), { fetchPayloads: false });
+    expect(findings.find((f) => f.kind === 'stale_tombstone')).toBeDefined();
+  });
+
+  it('does not flag recent tombstone as stale', async () => {
+    const recent = Date.now() - 10 * 86400000;
+    const entry = tombstoneEntry('u1', 'recent', recent);
+    const findings = await analyze(makeInventory([], [entry]), { fetchPayloads: false });
+    expect(findings.find((f) => f.kind === 'stale_tombstone')).toBeUndefined();
+  });
+
+  it('flags malformed index entries', async () => {
+    const malformed: IndexRow = {
+      uid: 'u1',
+      kind: 'layouts',
+      id: 'bad',
+      entry: { modifiedAt: NaN, sizeBytes: NaN },
+      tombstone: false,
+    };
+    const findings = await analyze(makeInventory([], [malformed]), { fetchPayloads: false });
+    expect(findings.find((f) => f.kind === 'malformed_index_entry')).toBeDefined();
+  });
+
+  it('flags modifiedAt mismatch between envelope and index', async () => {
+    const blob = layoutBlob('u1', 'mm', T);
+    const entry = layoutEntry('u1', 'mm', T + 9999);
+    mockPayload({ layout: layoutPayload, modifiedAt: T, schemaVersion: 1 });
+    const findings = await analyze(makeInventory([blob], [entry]));
+    expect(findings.find((f) => f.kind === 'modifiedAt_mismatch')).toBeDefined();
+  });
+
+  it('flags invalid schemaVersion in envelope', async () => {
+    const blob = layoutBlob('u1', 'sv');
+    const entry = layoutEntry('u1', 'sv');
+    mockPayload({ layout: layoutPayload, modifiedAt: T, schemaVersion: 2 });
+    const findings = await analyze(makeInventory([blob], [entry]));
+    expect(findings.find((f) => f.kind === 'envelope_invalid')).toBeDefined();
+  });
+
+  it('skips payload fetching when fetchPayloads=false', async () => {
+    const blob = layoutBlob('u1', 'a');
+    const entry = layoutEntry('u1', 'a');
+    await analyze(makeInventory([blob], [entry]), { fetchPayloads: false });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/sync-admin/__tests__/inventory.test.ts
+++ b/scripts/sync-admin/__tests__/inventory.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { isMalformedRow, parseRow } from '../lib/inventory';
+
+describe('parseRow', () => {
+  it('parses a well-formed live entry', () => {
+    const r = parseRow('u', 'layouts', 'id', JSON.stringify({ modifiedAt: 1, sizeBytes: 2 }));
+    expect(r.tombstone).toBe(false);
+    expect(isMalformedRow(r)).toBe(false);
+    expect(r.entry.modifiedAt).toBe(1);
+  });
+
+  it('parses a tombstone entry', () => {
+    const r = parseRow(
+      'u',
+      'layouts',
+      'id',
+      JSON.stringify({ modifiedAt: 1, sizeBytes: 0, deletedAt: 5 })
+    );
+    expect(r.tombstone).toBe(true);
+  });
+
+  it('flags wrong-typed modifiedAt as malformed', () => {
+    const r = parseRow('u', 'layouts', 'id', JSON.stringify({ modifiedAt: 'now', sizeBytes: 2 }));
+    expect(isMalformedRow(r)).toBe(true);
+  });
+
+  it('flags null sizeBytes as malformed', () => {
+    const r = parseRow('u', 'layouts', 'id', JSON.stringify({ modifiedAt: 1, sizeBytes: null }));
+    expect(isMalformedRow(r)).toBe(true);
+  });
+
+  it('flags unparseable JSON as malformed', () => {
+    const r = parseRow('u', 'layouts', 'id', 'not-json');
+    expect(isMalformedRow(r)).toBe(true);
+  });
+});

--- a/scripts/sync-admin/__tests__/inventory.test.ts
+++ b/scripts/sync-admin/__tests__/inventory.test.ts
@@ -29,6 +29,16 @@ describe('parseRow', () => {
     expect(isMalformedRow(r)).toBe(true);
   });
 
+  it('flags non-finite modifiedAt as malformed', () => {
+    const r = parseRow('u', 'layouts', 'id', '{"modifiedAt":1e9999,"sizeBytes":10}');
+    expect(isMalformedRow(r)).toBe(true);
+  });
+
+  it('flags non-finite deletedAt as malformed', () => {
+    const r = parseRow('u', 'layouts', 'id', '{"modifiedAt":1,"sizeBytes":0,"deletedAt":1e9999}');
+    expect(isMalformedRow(r)).toBe(true);
+  });
+
   it('flags unparseable JSON as malformed', () => {
     const r = parseRow('u', 'layouts', 'id', 'not-json');
     expect(isMalformedRow(r)).toBe(true);

--- a/scripts/sync-admin/__tests__/suggest.test.ts
+++ b/scripts/sync-admin/__tests__/suggest.test.ts
@@ -4,7 +4,7 @@ import { expectedEnvelopeDelta } from '../lib/delta';
 import type { Finding } from '../lib/types';
 
 describe('suggestFor', () => {
-  it('drift suggestion encodes the recomputed sizeBytes', () => {
+  it('drift suggestion encodes the recomputed sizeBytes and guards on modifiedAt', () => {
     const modifiedAt = 1_780_000_000_000;
     const blobSize = 1000;
     const finding: Finding = {
@@ -16,13 +16,43 @@ describe('suggestFor', () => {
       detail: '',
       data: { indexSize: 1500, blobSize, modifiedAt },
     };
-    const lines = suggestFor(finding);
+    const out = suggestFor(finding).join('\n');
     const expected = blobSize - expectedEnvelopeDelta('layouts', modifiedAt);
-    expect(lines.join('\n')).toContain(`${expected}`);
-    expect(lines.join('\n')).toContain(`'users:u1:index:layouts'`);
+    expect(out).toContain(`${expected}`);
+    expect(out).toContain(`'users:u1:index:layouts'`);
+    // Stale-modifiedAt guard and indexUpdatedAt bump are both wired.
+    expect(out).toContain('stale-modifiedAt');
+    expect(out).toContain(`'users:u1:indexUpdatedAt'`);
   });
 
-  it('orphan blob suggestion emits `vercel blob rm`', () => {
+  it('drift suggestion is empty when blobSize would yield a negative recomputed size', () => {
+    const finding: Finding = {
+      kind: 'sanitization_drift',
+      uid: 'u1',
+      itemKind: 'layouts',
+      id: 'l1',
+      severity: 'warn',
+      detail: '',
+      data: { blobSize: 10, modifiedAt: 1_780_000_000_000 },
+    };
+    expect(suggestFor(finding)).toEqual([]);
+  });
+
+  it('drift suggestion handles modifiedAt === 0', () => {
+    const finding: Finding = {
+      kind: 'sanitization_drift',
+      uid: 'u1',
+      itemKind: 'layouts',
+      id: 'l1',
+      severity: 'warn',
+      detail: '',
+      data: { blobSize: 1000, modifiedAt: 0 },
+    };
+    // Should not silently treat 0 as missing — should compute against expected envelope.
+    expect(suggestFor(finding)).not.toEqual([]);
+  });
+
+  it('orphan blob suggestion preflight-checks the index before deleting the blob', () => {
     const finding: Finding = {
       kind: 'orphan_blob',
       uid: 'u1',
@@ -31,12 +61,15 @@ describe('suggestFor', () => {
       severity: 'error',
       detail: '',
     };
-    const lines = suggestFor(finding);
-    expect(lines.some((l) => l.startsWith('vercel blob rm'))).toBe(true);
-    expect(lines.join('\n')).toContain('users/u1/designs/d1.json');
+    const out = suggestFor(finding).join('\n');
+    expect(out).toContain('vercel blob rm');
+    expect(out).toContain('users/u1/designs/d1.json');
+    // Preflight guard against an item that got re-uploaded between audit and remediation.
+    expect(out).toContain('redis-cli');
+    expect(out).toContain('HGET');
   });
 
-  it('missing blob suggestion emits HDEL', () => {
+  it('missing blob suggestion emits HDEL guarded on audited modifiedAt', () => {
     const finding: Finding = {
       kind: 'missing_blob',
       uid: 'u1',
@@ -44,8 +77,11 @@ describe('suggestFor', () => {
       id: 'l1',
       severity: 'error',
       detail: '',
+      data: { modifiedAt: 1_780_000_000_000, sizeBytes: 100 },
     };
-    expect(suggestFor(finding).join('\n')).toContain('HDEL');
+    const out = suggestFor(finding).join('\n');
+    expect(out).toContain('HDEL');
+    expect(out).toContain('stale-modifiedAt');
   });
 
   it("escapes single quotes via the '\\'' bash idiom", () => {
@@ -67,6 +103,7 @@ describe('suggestFor', () => {
 describe('categoryOf', () => {
   it.each([
     ['sanitization_drift', 'drift'],
+    ['index_size_undercount', 'drift'],
     ['orphan_blob', 'orphans'],
     ['tombstone_with_blob', 'orphans'],
     ['missing_blob', 'orphans'],

--- a/scripts/sync-admin/__tests__/suggest.test.ts
+++ b/scripts/sync-admin/__tests__/suggest.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { suggestFor, categoryOf, SUGGEST_CATEGORIES } from '../lib/suggest';
+import { expectedEnvelopeDelta } from '../lib/delta';
+import type { Finding } from '../lib/types';
+
+describe('suggestFor', () => {
+  it('drift suggestion encodes the recomputed sizeBytes', () => {
+    const modifiedAt = 1_780_000_000_000;
+    const blobSize = 1000;
+    const finding: Finding = {
+      kind: 'sanitization_drift',
+      uid: 'u1',
+      itemKind: 'layouts',
+      id: 'l1',
+      severity: 'warn',
+      detail: '',
+      data: { indexSize: 1500, blobSize, modifiedAt },
+    };
+    const lines = suggestFor(finding);
+    const expected = blobSize - expectedEnvelopeDelta('layouts', modifiedAt);
+    expect(lines.join('\n')).toContain(`${expected}`);
+    expect(lines.join('\n')).toContain(`'users:u1:index:layouts'`);
+  });
+
+  it('orphan blob suggestion emits `vercel blob rm`', () => {
+    const finding: Finding = {
+      kind: 'orphan_blob',
+      uid: 'u1',
+      itemKind: 'designs',
+      id: 'd1',
+      severity: 'error',
+      detail: '',
+    };
+    const lines = suggestFor(finding);
+    expect(lines.some((l) => l.startsWith('vercel blob rm'))).toBe(true);
+    expect(lines.join('\n')).toContain('users/u1/designs/d1.json');
+  });
+
+  it('missing blob suggestion emits HDEL', () => {
+    const finding: Finding = {
+      kind: 'missing_blob',
+      uid: 'u1',
+      itemKind: 'layouts',
+      id: 'l1',
+      severity: 'error',
+      detail: '',
+    };
+    expect(suggestFor(finding).join('\n')).toContain('HDEL');
+  });
+
+  it("escapes single quotes via the '\\'' bash idiom", () => {
+    const finding: Finding = {
+      kind: 'orphan_blob',
+      uid: "u'1",
+      itemKind: 'layouts',
+      id: "id'odd",
+      severity: 'error',
+      detail: '',
+    };
+    const out = suggestFor(finding).join('\n');
+    // Every literal apostrophe from the input must be wrapped as `'\''`.
+    expect(out).toContain(`'u'\\''1'`);
+    expect(out).toContain(`id'\\''odd`);
+  });
+});
+
+describe('categoryOf', () => {
+  it.each([
+    ['sanitization_drift', 'drift'],
+    ['orphan_blob', 'orphans'],
+    ['tombstone_with_blob', 'orphans'],
+    ['missing_blob', 'orphans'],
+    ['stale_tombstone', 'stale-tombstones'],
+    ['malformed_index_entry', 'malformed'],
+  ] as const)('%s -> %s', (kind, expected) => {
+    expect(categoryOf({ kind, uid: '', severity: 'warn', detail: '' } as Finding)).toBe(expected);
+  });
+
+  it('returns undefined for findings with no fix category', () => {
+    expect(
+      categoryOf({ kind: 'envelope_invalid', uid: '', severity: 'error', detail: '' } as Finding)
+    ).toBeUndefined();
+  });
+
+  it('SUGGEST_CATEGORIES enumerates the public list', () => {
+    expect(SUGGEST_CATEGORIES).toEqual(['drift', 'orphans', 'stale-tombstones', 'malformed']);
+  });
+});

--- a/scripts/sync-admin/commands/audit.ts
+++ b/scripts/sync-admin/commands/audit.ts
@@ -26,8 +26,7 @@ export async function audit(args: Args): Promise<number> {
       printHuman(inv, findings, args.suggest);
     }
 
-    const hasErrors = findings.some((f) => f.severity === 'error' || f.severity === 'warn');
-    return args.strict && hasErrors ? 1 : 0;
+    return args.strict && findings.length > 0 ? 1 : 0;
   } finally {
     await redis.quit();
   }

--- a/scripts/sync-admin/commands/audit.ts
+++ b/scripts/sync-admin/commands/audit.ts
@@ -1,0 +1,100 @@
+import { analyze } from '../lib/findings.js';
+import { buildInventory } from '../lib/inventory.js';
+import { colors, formatFinding } from '../lib/output.js';
+import { connect } from '../lib/redis.js';
+import { categoryOf, suggestFor } from '../lib/suggest.js';
+import type { Args } from '../lib/args.js';
+import type { Finding } from '../lib/types.js';
+
+export async function audit(args: Args): Promise<number> {
+  const redis = connect();
+  try {
+    const inv = await buildInventory(redis, { user: args.user, kind: args.kind });
+    const findings = await analyze(inv, { fetchPayloads: !args.noPayloadFetch });
+
+    if (args.json) {
+      const payload = {
+        summary: summarize(inv, findings),
+        findings: findings.map((f) => ({
+          ...f,
+          suggestions: args.suggest ? suggestFor(f) : undefined,
+          category: categoryOf(f),
+        })),
+      };
+      process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    } else {
+      printHuman(inv, findings, args.suggest);
+    }
+
+    const hasErrors = findings.some((f) => f.severity === 'error' || f.severity === 'warn');
+    return args.strict && hasErrors ? 1 : 0;
+  } finally {
+    await redis.quit();
+  }
+}
+
+function summarize(
+  inv: ReturnType<typeof buildInventory> extends Promise<infer T> ? T : never,
+  findings: Finding[]
+) {
+  return {
+    blobs: inv.blobs.length,
+    indexEntries: inv.indexRows.length,
+    liveEntries: inv.indexRows.filter((r) => !r.tombstone).length,
+    tombstones: inv.indexRows.filter((r) => r.tombstone).length,
+    blobUsers: inv.blobUsers.size,
+    redisUsers: inv.redisUsers.size,
+    findings: {
+      total: findings.length,
+      errors: findings.filter((f) => f.severity === 'error').length,
+      warnings: findings.filter((f) => f.severity === 'warn').length,
+      info: findings.filter((f) => f.severity === 'info').length,
+      byKind: groupCount(findings, (f) => f.kind),
+    },
+  };
+}
+
+function groupCount<T, K extends string>(items: readonly T[], key: (t: T) => K): Record<K, number> {
+  const out = {} as Record<K, number>;
+  for (const item of items) {
+    const k = key(item);
+    out[k] = (out[k] ?? 0) + 1;
+  }
+  return out;
+}
+
+function printHuman(
+  inv: {
+    blobs: { length: number };
+    indexRows: { tombstone: boolean }[];
+    blobUsers: Set<string>;
+    redisUsers: Set<string>;
+  },
+  findings: Finding[],
+  withSuggestions: boolean
+): void {
+  const live = inv.indexRows.filter((r) => !r.tombstone).length;
+  const tombs = inv.indexRows.length - live;
+  console.log(colors.bold('=== sync-admin audit ==='));
+  console.log(`Blobs scanned:   ${inv.blobs.length}`);
+  console.log(`Index entries:   ${inv.indexRows.length}  (live: ${live}, tombstones: ${tombs})`);
+  console.log(`Users:           ${inv.blobUsers.size} in blob, ${inv.redisUsers.size} in redis`);
+  console.log(
+    `Findings:        ${findings.length}  (errors: ${findings.filter((f) => f.severity === 'error').length}, warnings: ${findings.filter((f) => f.severity === 'warn').length}, info: ${findings.filter((f) => f.severity === 'info').length})`
+  );
+
+  if (findings.length === 0) {
+    console.log(`\n${colors.cyan('✓ no findings')}`);
+    return;
+  }
+
+  console.log('');
+  for (const f of findings) {
+    console.log(formatFinding(f));
+    if (withSuggestions) {
+      const lines = suggestFor(f);
+      for (const line of lines) console.log(colors.dim('    ' + line));
+      if (lines.length > 0) console.log('');
+    }
+  }
+}

--- a/scripts/sync-admin/commands/suggest.ts
+++ b/scripts/sync-admin/commands/suggest.ts
@@ -4,11 +4,20 @@ import { colors } from '../lib/output.js';
 import { connect } from '../lib/redis.js';
 import {
   categoryOf,
+  SCRIPT_PREAMBLE,
   SUGGEST_CATEGORIES,
   suggestFor,
   type SuggestCategory,
 } from '../lib/suggest.js';
 import type { Args } from '../lib/args.js';
+
+// stale-tombstones + malformed live entirely in Redis, no Blob calls needed.
+const NEEDS_BLOBS: Record<SuggestCategory, boolean> = {
+  drift: true,
+  orphans: true,
+  'stale-tombstones': false,
+  malformed: false,
+};
 
 export async function suggest(args: Args): Promise<number> {
   const cat = args.positional[0] as SuggestCategory | undefined;
@@ -19,9 +28,15 @@ export async function suggest(args: Args): Promise<number> {
 
   const redis = connect();
   try {
-    const inv = await buildInventory(redis, { user: args.user, kind: args.kind });
+    const inv = await buildInventory(redis, {
+      user: args.user,
+      kind: args.kind,
+      skipBlobs: !NEEDS_BLOBS[cat],
+    });
     const findings = await analyze(inv, {
-      fetchPayloads: !args.noPayloadFetch,
+      // Payload fetching only contributes envelope/payload findings, none of
+      // which feed into `suggest`'s categories. Skip the fetch pass entirely.
+      fetchPayloads: false,
       staleTombstoneMs: args.olderThanMs,
     });
     const matched = findings.filter((f) => categoryOf(f) === cat);
@@ -41,6 +56,7 @@ export async function suggest(args: Args): Promise<number> {
       console.log(colors.cyan(`✓ no findings in category "${cat}"`));
       return 0;
     }
+    for (const line of SCRIPT_PREAMBLE) console.log(line);
     console.log(`# sync-admin suggest ${cat} — ${matched.length} finding(s)`);
     console.log(`# Review each command before running.`);
     console.log('');

--- a/scripts/sync-admin/commands/suggest.ts
+++ b/scripts/sync-admin/commands/suggest.ts
@@ -1,0 +1,55 @@
+import { analyze } from '../lib/findings.js';
+import { buildInventory } from '../lib/inventory.js';
+import { colors } from '../lib/output.js';
+import { connect } from '../lib/redis.js';
+import {
+  categoryOf,
+  SUGGEST_CATEGORIES,
+  suggestFor,
+  type SuggestCategory,
+} from '../lib/suggest.js';
+import type { Args } from '../lib/args.js';
+
+export async function suggest(args: Args): Promise<number> {
+  const cat = args.positional[0] as SuggestCategory | undefined;
+  if (!cat || !SUGGEST_CATEGORIES.includes(cat)) {
+    console.error(`suggest <category> required. One of: ${SUGGEST_CATEGORIES.join(', ')}`);
+    return 2;
+  }
+
+  const redis = connect();
+  try {
+    const inv = await buildInventory(redis, { user: args.user, kind: args.kind });
+    const findings = await analyze(inv, {
+      fetchPayloads: !args.noPayloadFetch,
+      staleTombstoneMs: args.olderThanMs,
+    });
+    const matched = findings.filter((f) => categoryOf(f) === cat);
+
+    if (args.json) {
+      process.stdout.write(
+        JSON.stringify(
+          matched.map((f) => ({ ...f, suggestions: suggestFor(f) })),
+          null,
+          2
+        ) + '\n'
+      );
+      return 0;
+    }
+
+    if (matched.length === 0) {
+      console.log(colors.cyan(`✓ no findings in category "${cat}"`));
+      return 0;
+    }
+    console.log(`# sync-admin suggest ${cat} — ${matched.length} finding(s)`);
+    console.log(`# Review each command before running.`);
+    console.log('');
+    for (const f of matched) {
+      for (const line of suggestFor(f)) console.log(line);
+      console.log('');
+    }
+    return 0;
+  } finally {
+    await redis.quit();
+  }
+}

--- a/scripts/sync-admin/commands/tombstones.ts
+++ b/scripts/sync-admin/commands/tombstones.ts
@@ -16,7 +16,12 @@ interface TombRow {
 export async function tombstones(args: Args): Promise<number> {
   const redis = connect();
   try {
-    const inv = await buildInventory(redis, { user: args.user, kind: args.kind });
+    // Tombstones live entirely in Redis; skip the Blob listing.
+    const inv = await buildInventory(redis, {
+      user: args.user,
+      kind: args.kind,
+      skipBlobs: true,
+    });
     const staleAge = args.olderThanMs ?? TOMBSTONE_RETENTION_MS;
     const now = Date.now();
     const rows: TombRow[] = inv.indexRows

--- a/scripts/sync-admin/commands/tombstones.ts
+++ b/scripts/sync-admin/commands/tombstones.ts
@@ -1,0 +1,61 @@
+import { TOMBSTONE_RETENTION_MS } from '../../../api/lib/userIndex.js';
+import { buildInventory } from '../lib/inventory.js';
+import { colors, formatTable } from '../lib/output.js';
+import { connect } from '../lib/redis.js';
+import type { Args } from '../lib/args.js';
+
+interface TombRow {
+  uid: string;
+  kind: 'layouts' | 'designs';
+  id: string;
+  deletedAt: number;
+  ageMs: number;
+  stale: boolean;
+}
+
+export async function tombstones(args: Args): Promise<number> {
+  const redis = connect();
+  try {
+    const inv = await buildInventory(redis, { user: args.user, kind: args.kind });
+    const staleAge = args.olderThanMs ?? TOMBSTONE_RETENTION_MS;
+    const now = Date.now();
+    const rows: TombRow[] = inv.indexRows
+      .filter((r) => r.tombstone)
+      .map((r) => {
+        const deletedAt = r.entry.deletedAt ?? r.entry.modifiedAt;
+        const ageMs = now - deletedAt;
+        return { uid: r.uid, kind: r.kind, id: r.id, deletedAt, ageMs, stale: ageMs > staleAge };
+      })
+      .sort((a, b) => b.ageMs - a.ageMs);
+
+    if (args.json) {
+      process.stdout.write(
+        JSON.stringify({ staleThresholdMs: staleAge, tombstones: rows }, null, 2) + '\n'
+      );
+    } else {
+      console.log(
+        colors.bold(
+          `=== tombstones (${rows.length}, stale threshold ${Math.round(staleAge / 86400000)}d) ===`
+        )
+      );
+      console.log(
+        formatTable(
+          ['uid', 'kind', 'id', 'deleted', 'age (d)', 'stale'],
+          rows.map((r) => [
+            r.uid.slice(0, 12) + '…',
+            r.kind,
+            r.id,
+            new Date(r.deletedAt).toISOString().slice(0, 10),
+            (r.ageMs / 86400000).toFixed(0),
+            r.stale ? colors.yellow('yes') : 'no',
+          ])
+        )
+      );
+    }
+
+    const staleCount = rows.filter((r) => r.stale).length;
+    return args.strict && staleCount > 0 ? 1 : 0;
+  } finally {
+    await redis.quit();
+  }
+}

--- a/scripts/sync-admin/commands/user.ts
+++ b/scripts/sync-admin/commands/user.ts
@@ -1,0 +1,100 @@
+import { analyze } from '../lib/findings.js';
+import { buildInventory } from '../lib/inventory.js';
+import { colors, formatFinding, formatTable } from '../lib/output.js';
+import { connect } from '../lib/redis.js';
+import { suggestFor } from '../lib/suggest.js';
+import type { Args } from '../lib/args.js';
+
+export async function user(args: Args): Promise<number> {
+  const uid = args.positional[0];
+  if (!uid) {
+    console.error('user <uid> is required');
+    return 2;
+  }
+  const redis = connect();
+  try {
+    const inv = await buildInventory(redis, { user: uid, kind: args.kind });
+    const findings = await analyze(inv, { fetchPayloads: !args.noPayloadFetch });
+
+    if (args.json) {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            uid,
+            blobs: inv.blobs,
+            indexRows: inv.indexRows,
+            findings: findings.map((f) => ({
+              ...f,
+              suggestions: args.suggest ? suggestFor(f) : undefined,
+            })),
+          },
+          null,
+          2
+        ) + '\n'
+      );
+    } else {
+      printHuman(uid, inv, findings);
+    }
+
+    const hasErrors = findings.some((f) => f.severity === 'error' || f.severity === 'warn');
+    return args.strict && hasErrors ? 1 : 0;
+  } finally {
+    await redis.quit();
+  }
+}
+
+function printHuman(
+  uid: string,
+  inv: {
+    blobs: { kind: string; id: string; size: number; uploadedAt: Date }[];
+    indexRows: {
+      kind: string;
+      id: string;
+      tombstone: boolean;
+      entry: { modifiedAt: number; sizeBytes: number; deletedAt?: number };
+    }[];
+  },
+  findings: readonly { severity: string }[]
+): void {
+  console.log(colors.bold(`=== user ${uid} ===`));
+  const live = inv.indexRows.filter((r) => !r.tombstone);
+  const tombs = inv.indexRows.filter((r) => r.tombstone);
+  console.log(`Blobs:         ${inv.blobs.length}`);
+  console.log(`Live entries:  ${live.length}`);
+  console.log(`Tombstones:    ${tombs.length}`);
+  console.log('');
+
+  if (inv.blobs.length) {
+    console.log(colors.bold('Blobs:'));
+    console.log(
+      formatTable(
+        ['kind', 'id', 'size', 'uploaded'],
+        inv.blobs.map((b) => [b.kind, b.id, b.size, b.uploadedAt.toISOString().slice(0, 10)])
+      )
+    );
+    console.log('');
+  }
+
+  if (tombs.length) {
+    console.log(colors.bold('Tombstones:'));
+    console.log(
+      formatTable(
+        ['kind', 'id', 'deletedAt'],
+        tombs.map((r) => [
+          r.kind,
+          r.id,
+          new Date(r.entry.deletedAt ?? r.entry.modifiedAt).toISOString().slice(0, 10),
+        ])
+      )
+    );
+    console.log('');
+  }
+
+  if (findings.length) {
+    console.log(colors.bold('Findings:'));
+    for (const f of findings as Parameters<typeof formatFinding>[0][])
+      console.log(formatFinding(f));
+  } else {
+    console.log(colors.cyan('✓ no findings'));
+  }
+}

--- a/scripts/sync-admin/commands/users.ts
+++ b/scripts/sync-admin/commands/users.ts
@@ -66,6 +66,12 @@ function computeStats(inv: Inventory): UserStats[] {
     return s;
   };
 
+  // Seed from index rows so users whose blobs are all missing (or who only
+  // have tombstones) are still represented in the table.
+  for (const r of inv.indexRows) {
+    const s = get(r.uid);
+    if (r.tombstone) s.tombstones++;
+  }
   for (const b of inv.blobs) {
     const s = get(b.uid);
     if (b.kind === 'layouts') {
@@ -78,9 +84,6 @@ function computeStats(inv: Inventory): UserStats[] {
     s.totalBytes += b.size;
     const ms = b.uploadedAt.getTime();
     if (s.oldestItem === 0 || ms < s.oldestItem) s.oldestItem = ms;
-  }
-  for (const r of inv.indexRows) {
-    if (r.tombstone) get(r.uid).tombstones++;
   }
 
   return [...map.values()].sort((a, b) => b.totalBytes - a.totalBytes);

--- a/scripts/sync-admin/commands/users.ts
+++ b/scripts/sync-admin/commands/users.ts
@@ -1,0 +1,87 @@
+import { buildInventory } from '../lib/inventory.js';
+import { colors, formatTable } from '../lib/output.js';
+import { connect } from '../lib/redis.js';
+import type { Args } from '../lib/args.js';
+import type { Inventory } from '../lib/types.js';
+
+interface UserStats {
+  uid: string;
+  layoutsCount: number;
+  layoutsBytes: number;
+  designsCount: number;
+  designsBytes: number;
+  tombstones: number;
+  oldestItem: number;
+  totalBytes: number;
+}
+
+export async function users(args: Args): Promise<number> {
+  const redis = connect();
+  try {
+    const inv = await buildInventory(redis, { kind: args.kind });
+    const stats = computeStats(inv);
+
+    if (args.json) {
+      process.stdout.write(JSON.stringify(stats, null, 2) + '\n');
+    } else {
+      console.log(colors.bold(`=== users (${stats.length}) ===`));
+      console.log(
+        formatTable(
+          ['uid', 'layouts', 'layouts KB', 'designs', 'designs KB', 'tombs', 'oldest'],
+          stats.map((s) => [
+            s.uid.slice(0, 16) + '…',
+            s.layoutsCount,
+            (s.layoutsBytes / 1024).toFixed(1),
+            s.designsCount,
+            (s.designsBytes / 1024).toFixed(1),
+            s.tombstones,
+            s.oldestItem ? new Date(s.oldestItem).toISOString().slice(0, 10) : '—',
+          ])
+        )
+      );
+    }
+    return 0;
+  } finally {
+    await redis.quit();
+  }
+}
+
+function computeStats(inv: Inventory): UserStats[] {
+  const map = new Map<string, UserStats>();
+  const get = (uid: string): UserStats => {
+    let s = map.get(uid);
+    if (!s) {
+      s = {
+        uid,
+        layoutsCount: 0,
+        layoutsBytes: 0,
+        designsCount: 0,
+        designsBytes: 0,
+        tombstones: 0,
+        oldestItem: 0,
+        totalBytes: 0,
+      };
+      map.set(uid, s);
+    }
+    return s;
+  };
+
+  for (const b of inv.blobs) {
+    const s = get(b.uid);
+    if (b.kind === 'layouts') {
+      s.layoutsCount++;
+      s.layoutsBytes += b.size;
+    } else {
+      s.designsCount++;
+      s.designsBytes += b.size;
+    }
+    s.totalBytes += b.size;
+    const ms = b.uploadedAt.getTime();
+    if (s.oldestItem === 0 || ms < s.oldestItem) s.oldestItem = ms;
+  }
+  for (const r of inv.indexRows) {
+    if (r.tombstone) get(r.uid).tombstones++;
+  }
+
+  return [...map.values()].sort((a, b) => b.totalBytes - a.totalBytes);
+}

--- a/scripts/sync-admin/index.ts
+++ b/scripts/sync-admin/index.ts
@@ -1,0 +1,82 @@
+import { audit } from './commands/audit.js';
+import { suggest } from './commands/suggest.js';
+import { tombstones } from './commands/tombstones.js';
+import { user } from './commands/user.js';
+import { users } from './commands/users.js';
+import { parseArgs, type Args } from './lib/args.js';
+import { printBanner } from './lib/banner.js';
+import { loadEnv, requireEnv } from './lib/env.js';
+
+const COMMANDS: Record<string, (a: Args) => Promise<number>> = {
+  audit,
+  user,
+  users,
+  tombstones,
+  suggest,
+};
+
+const HELP = `sync-admin — operator toolkit for the cloud-sync subsystem
+
+Usage:
+  pnpm sync-admin <command> [flags]
+
+Commands:
+  audit                  Integrity check: reconcile blobs ↔ index, validate envelopes, detect drift
+  user <uid>             Inspect one user's blobs, index entries, and findings
+  users                  Table of all users sorted by total bytes
+  tombstones             List tombstones with age and stale status
+  suggest <category>     Emit shell commands for: drift | orphans | stale-tombstones | malformed
+
+Flags:
+  --json                 Machine-readable output
+  --strict               Exit non-zero if any error/warning finding present
+  --kind=layouts|designs Restrict to one item kind
+  --user=<uid>           Restrict to one user (audit/tombstones/suggest)
+  --no-payload-fetch     Skip per-blob HTTP fetch (faster; envelope checks skipped)
+  --suggest              For \`audit\`: inline fix commands beneath each finding
+  --older-than=Nd        For \`tombstones\` / \`suggest stale-tombstones\`: age threshold (default 90d)
+  --help                 Show this message
+
+Examples:
+  pnpm sync-admin audit
+  pnpm sync-admin audit --suggest --strict
+  pnpm sync-admin user 589314dfbe7f...
+  pnpm sync-admin users --json | jq '.[0]'
+  pnpm sync-admin tombstones --older-than=180d
+  pnpm sync-admin suggest drift > fixes.sh
+`;
+
+async function main(): Promise<number> {
+  let args: Args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+
+  if (args.help || !args.command) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  loadEnv();
+  requireEnv('REDIS_URL');
+  requireEnv('BLOB_READ_WRITE_TOKEN');
+  printBanner();
+
+  const handler = COMMANDS[args.command];
+  if (!handler) {
+    console.error(`Unknown command: ${args.command}`);
+    process.stdout.write('\n' + HELP);
+    return 2;
+  }
+  return handler(args);
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });

--- a/scripts/sync-admin/lib/args.ts
+++ b/scripts/sync-admin/lib/args.ts
@@ -1,0 +1,53 @@
+import type { Kind } from './types.js';
+
+export interface Args {
+  command: string;
+  positional: string[];
+  json: boolean;
+  strict: boolean;
+  suggest: boolean;
+  noPayloadFetch: boolean;
+  kind?: Kind;
+  user?: string;
+  olderThanMs?: number;
+  help: boolean;
+}
+
+const KINDS: Kind[] = ['layouts', 'designs'];
+
+function parseOlderThan(v: string): number {
+  const m = v.match(/^(\d+)d$/);
+  if (!m) throw new Error(`--older-than expects e.g. 90d, got "${v}"`);
+  return parseInt(m[1], 10) * 24 * 60 * 60 * 1000;
+}
+
+export function parseArgs(argv: readonly string[]): Args {
+  const a: Args = {
+    command: '',
+    positional: [],
+    json: false,
+    strict: false,
+    suggest: false,
+    noPayloadFetch: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--json') a.json = true;
+    else if (arg === '--strict') a.strict = true;
+    else if (arg === '--suggest') a.suggest = true;
+    else if (arg === '--no-payload-fetch') a.noPayloadFetch = true;
+    else if (arg === '--help' || arg === '-h') a.help = true;
+    else if (arg.startsWith('--kind=')) {
+      const v = arg.slice('--kind='.length);
+      if (!KINDS.includes(v as Kind)) throw new Error(`--kind must be one of ${KINDS.join('|')}`);
+      a.kind = v as Kind;
+    } else if (arg.startsWith('--user=')) a.user = arg.slice('--user='.length);
+    else if (arg.startsWith('--older-than='))
+      a.olderThanMs = parseOlderThan(arg.slice('--older-than='.length));
+    else if (arg.startsWith('--')) throw new Error(`Unknown flag: ${arg}`);
+    else if (!a.command) a.command = arg;
+    else a.positional.push(arg);
+  }
+  return a;
+}

--- a/scripts/sync-admin/lib/args.ts
+++ b/scripts/sync-admin/lib/args.ts
@@ -42,8 +42,11 @@ export function parseArgs(argv: readonly string[]): Args {
       const v = arg.slice('--kind='.length);
       if (!KINDS.includes(v as Kind)) throw new Error(`--kind must be one of ${KINDS.join('|')}`);
       a.kind = v as Kind;
-    } else if (arg.startsWith('--user=')) a.user = arg.slice('--user='.length);
-    else if (arg.startsWith('--older-than='))
+    } else if (arg.startsWith('--user=')) {
+      const v = arg.slice('--user='.length);
+      if (!v) throw new Error('--user= cannot be empty — omit the flag to scan all users');
+      a.user = v;
+    } else if (arg.startsWith('--older-than='))
       a.olderThanMs = parseOlderThan(arg.slice('--older-than='.length));
     else if (arg.startsWith('--')) throw new Error(`Unknown flag: ${arg}`);
     else if (!a.command) a.command = arg;

--- a/scripts/sync-admin/lib/banner.ts
+++ b/scripts/sync-admin/lib/banner.ts
@@ -1,12 +1,18 @@
+import { createHash } from 'node:crypto';
+
 export function printBanner(): void {
   const redisUrl = process.env.REDIS_URL ?? '';
   const blobToken = process.env.BLOB_READ_WRITE_TOKEN ?? '';
   const host = redisUrl.match(/@([^:]+)/)?.[1] ?? '<unknown>';
-  const tokenPrefix = blobToken.slice(0, 28);
+  // Short non-reversible fingerprint so the operator can verify they're
+  // pointed at the expected token without leaking any of it into logs.
+  const tokenFp = blobToken
+    ? createHash('sha256').update(blobToken).digest('hex').slice(0, 8)
+    : '—';
   const stream = process.stderr;
   stream.write('────────────────────────────────────────────────\n');
   stream.write(`  sync-admin\n`);
   stream.write(`  Redis: ${host}\n`);
-  stream.write(`  Blob token: ${tokenPrefix}…\n`);
+  stream.write(`  Blob token fingerprint: ${tokenFp}\n`);
   stream.write('────────────────────────────────────────────────\n');
 }

--- a/scripts/sync-admin/lib/banner.ts
+++ b/scripts/sync-admin/lib/banner.ts
@@ -1,0 +1,12 @@
+export function printBanner(): void {
+  const redisUrl = process.env.REDIS_URL ?? '';
+  const blobToken = process.env.BLOB_READ_WRITE_TOKEN ?? '';
+  const host = redisUrl.match(/@([^:]+)/)?.[1] ?? '<unknown>';
+  const tokenPrefix = blobToken.slice(0, 28);
+  const stream = process.stderr;
+  stream.write('────────────────────────────────────────────────\n');
+  stream.write(`  sync-admin\n`);
+  stream.write(`  Redis: ${host}\n`);
+  stream.write(`  Blob token: ${tokenPrefix}…\n`);
+  stream.write('────────────────────────────────────────────────\n');
+}

--- a/scripts/sync-admin/lib/concurrency.ts
+++ b/scripts/sync-admin/lib/concurrency.ts
@@ -1,0 +1,18 @@
+export async function pMap<T, R>(
+  items: readonly T[],
+  fn: (item: T, index: number) => Promise<R>,
+  concurrency = 16
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+    }
+  }
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}

--- a/scripts/sync-admin/lib/delta.ts
+++ b/scripts/sync-admin/lib/delta.ts
@@ -1,0 +1,18 @@
+import type { Kind } from './types.js';
+
+/**
+ * Expected `blob.size - index.sizeBytes` when the validator made no
+ * byte-level change to the payload. Anything beyond this is sanitization
+ * drift — bytes the validator stripped that the index still accounts for.
+ *
+ *   Layouts: blob is `{"layout":<L>,"modifiedAt":N,"schemaVersion":1}`,
+ *            index sizeBytes is `byteLen({"layout":<L>})`.
+ *            Overhead = `,"modifiedAt":` (14) + digits(N) + `,"schemaVersion":1` (18).
+ *   Designs: blob is `{"design":{"name":..,"params":..},"modifiedAt":N,"schemaVersion":1}`,
+ *            index sizeBytes is `byteLen({"name":..,"type":"designer","version":1,"params":..})`.
+ *            Net delta = 13 + digits(N).
+ */
+export function expectedEnvelopeDelta(kind: Kind, modifiedAt: number): number {
+  const digits = String(modifiedAt).length;
+  return (kind === 'layouts' ? 32 : 13) + digits;
+}

--- a/scripts/sync-admin/lib/env.ts
+++ b/scripts/sync-admin/lib/env.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+
+const ENV_FILES = ['.env.production.local', '.env.local'];
+
+export function loadEnv(): void {
+  for (const file of ENV_FILES) {
+    try {
+      const body = readFileSync(file, 'utf8');
+      for (const line of body.split('\n')) {
+        const m = line.match(/^([A-Z_]+)="?([^"\n]*)"?$/);
+        if (m && !process.env[m[1]]) process.env[m[1]] = m[2];
+      }
+    } catch {}
+  }
+}
+
+export function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`Missing required env var: ${name}`);
+    console.error(`Run \`vercel env pull .env.production.local\` to refresh credentials.`);
+    process.exit(2);
+  }
+  return v;
+}

--- a/scripts/sync-admin/lib/findings.ts
+++ b/scripts/sync-admin/lib/findings.ts
@@ -95,14 +95,14 @@ export async function analyze(
 
   for (const blob of inv.blobs) {
     const row = inv.indexMap.get(itemKey(blob.uid, blob.kind, blob.id));
-    if (!row || row.tombstone) {
+    if (!row) {
       findings.push({
         kind: 'orphan_blob',
         uid: blob.uid,
         itemKind: blob.kind,
         id: blob.id,
         severity: 'error',
-        detail: row ? 'blob survives a tombstone' : 'blob has no index entry',
+        detail: 'blob has no index entry',
         data: { blobSize: blob.size },
       });
     }
@@ -123,12 +123,12 @@ export async function analyze(
 }
 
 async function validateBlob(
-  blob: { uid: string; kind: 'layouts' | 'designs'; id: string; url: string },
+  blob: { uid: string; kind: 'layouts' | 'designs'; id: string; url: string; size: number },
   inv: Inventory
 ): Promise<Finding[]> {
   const out: Finding[] = [];
   let body: unknown;
-  let bytes = 0;
+  let fetchedBytes = 0;
   try {
     const r = await fetch(blob.url);
     if (!r.ok) {
@@ -144,7 +144,7 @@ async function validateBlob(
       ];
     }
     const text = await r.text();
-    bytes = Buffer.byteLength(text, 'utf8');
+    fetchedBytes = Buffer.byteLength(text, 'utf8');
     body = JSON.parse(text);
   } catch (err) {
     return [
@@ -246,7 +246,18 @@ async function validateBlob(
     }
   }
 
-  void bytes;
+  if (fetchedBytes !== blob.size) {
+    out.push({
+      kind: 'listing_size_mismatch',
+      uid: blob.uid,
+      itemKind: blob.kind,
+      id: blob.id,
+      severity: 'warn',
+      detail: `listing reports ${blob.size}B, fetched ${fetchedBytes}B`,
+      data: { listingSize: blob.size, fetchedBytes },
+    });
+  }
+
   return out;
 }
 

--- a/scripts/sync-admin/lib/findings.ts
+++ b/scripts/sync-admin/lib/findings.ts
@@ -1,0 +1,261 @@
+import { validateShareLayout, isValidationError } from '../../../api/lib/validation.js';
+import { validateDesignerShare } from '../../../api/lib/designerValidation.js';
+import { TOMBSTONE_RETENTION_MS } from '../../../api/lib/userIndex.js';
+import { pMap } from './concurrency.js';
+import { expectedEnvelopeDelta } from './delta.js';
+import { isMalformedRow, itemKey } from './inventory.js';
+import type { Finding, Inventory } from './types.js';
+
+interface AnalyzeOpts {
+  fetchPayloads: boolean;
+  staleTombstoneMs?: number;
+}
+
+export async function analyze(
+  inv: Inventory,
+  opts: AnalyzeOpts = { fetchPayloads: true }
+): Promise<Finding[]> {
+  const findings: Finding[] = [];
+  const staleAge = opts.staleTombstoneMs ?? TOMBSTONE_RETENTION_MS;
+  const now = Date.now();
+
+  for (const row of inv.indexRows) {
+    if (isMalformedRow(row)) {
+      findings.push({
+        kind: 'malformed_index_entry',
+        uid: row.uid,
+        itemKind: row.kind,
+        id: row.id,
+        severity: 'error',
+        detail: `index entry not parseable as { modifiedAt, sizeBytes }`,
+      });
+      continue;
+    }
+
+    const blob = inv.blobMap.get(itemKey(row.uid, row.kind, row.id));
+
+    if (row.tombstone) {
+      const age = now - (row.entry.deletedAt ?? row.entry.modifiedAt);
+      if (blob) {
+        findings.push({
+          kind: 'tombstone_with_blob',
+          uid: row.uid,
+          itemKind: row.kind,
+          id: row.id,
+          severity: 'error',
+          detail: `tombstone has surviving blob (deleted ${Math.round(age / 86400000)}d ago)`,
+          data: { blobSize: blob.size, ageMs: age },
+        });
+      } else if (age > staleAge) {
+        findings.push({
+          kind: 'stale_tombstone',
+          uid: row.uid,
+          itemKind: row.kind,
+          id: row.id,
+          severity: 'info',
+          detail: `tombstone older than ${Math.round(staleAge / 86400000)}d`,
+          data: { ageMs: age },
+        });
+      }
+      continue;
+    }
+
+    if (!blob) {
+      findings.push({
+        kind: 'missing_blob',
+        uid: row.uid,
+        itemKind: row.kind,
+        id: row.id,
+        severity: 'error',
+        detail: 'live index entry has no blob',
+        data: { sizeBytes: row.entry.sizeBytes, modifiedAt: row.entry.modifiedAt },
+      });
+      continue;
+    }
+
+    const expected = expectedEnvelopeDelta(row.kind, row.entry.modifiedAt);
+    const delta = blob.size - row.entry.sizeBytes;
+    if (delta !== expected) {
+      findings.push({
+        kind: 'sanitization_drift',
+        uid: row.uid,
+        itemKind: row.kind,
+        id: row.id,
+        severity: 'warn',
+        detail: `index sizeBytes over-counts by ${expected - delta}B (quota leak)`,
+        data: {
+          indexSize: row.entry.sizeBytes,
+          blobSize: blob.size,
+          drift: delta - expected,
+          modifiedAt: row.entry.modifiedAt,
+        },
+      });
+    }
+  }
+
+  for (const blob of inv.blobs) {
+    const row = inv.indexMap.get(itemKey(blob.uid, blob.kind, blob.id));
+    if (!row || row.tombstone) {
+      findings.push({
+        kind: 'orphan_blob',
+        uid: blob.uid,
+        itemKind: blob.kind,
+        id: blob.id,
+        severity: 'error',
+        detail: row ? 'blob survives a tombstone' : 'blob has no index entry',
+        data: { blobSize: blob.size },
+      });
+    }
+  }
+
+  if (opts.fetchPayloads) {
+    const liveBlobs = inv.blobs.filter((b) => {
+      const r = inv.indexMap.get(itemKey(b.uid, b.kind, b.id));
+      return r && !r.tombstone;
+    });
+    const payloadFindings = await pMap(liveBlobs, async (blob) => {
+      return validateBlob(blob, inv);
+    });
+    for (const list of payloadFindings) findings.push(...list);
+  }
+
+  return findings;
+}
+
+async function validateBlob(
+  blob: { uid: string; kind: 'layouts' | 'designs'; id: string; url: string },
+  inv: Inventory
+): Promise<Finding[]> {
+  const out: Finding[] = [];
+  let body: unknown;
+  let bytes = 0;
+  try {
+    const r = await fetch(blob.url);
+    if (!r.ok) {
+      return [
+        {
+          kind: 'envelope_invalid',
+          uid: blob.uid,
+          itemKind: blob.kind,
+          id: blob.id,
+          severity: 'error',
+          detail: `HTTP ${r.status} fetching blob`,
+        },
+      ];
+    }
+    const text = await r.text();
+    bytes = Buffer.byteLength(text, 'utf8');
+    body = JSON.parse(text);
+  } catch (err) {
+    return [
+      {
+        kind: 'envelope_invalid',
+        uid: blob.uid,
+        itemKind: blob.kind,
+        id: blob.id,
+        severity: 'error',
+        detail: err instanceof Error ? err.message : String(err),
+      },
+    ];
+  }
+
+  if (!body || typeof body !== 'object') {
+    out.push({
+      kind: 'envelope_invalid',
+      uid: blob.uid,
+      itemKind: blob.kind,
+      id: blob.id,
+      severity: 'error',
+      detail: 'envelope not an object',
+    });
+    return out;
+  }
+  const env = body as Record<string, unknown>;
+  if (env.schemaVersion !== 1) {
+    out.push({
+      kind: 'envelope_invalid',
+      uid: blob.uid,
+      itemKind: blob.kind,
+      id: blob.id,
+      severity: 'error',
+      detail: `schemaVersion=${String(env.schemaVersion)} (expected 1)`,
+    });
+  }
+  if (typeof env.modifiedAt !== 'number' || !Number.isFinite(env.modifiedAt)) {
+    out.push({
+      kind: 'envelope_invalid',
+      uid: blob.uid,
+      itemKind: blob.kind,
+      id: blob.id,
+      severity: 'error',
+      detail: `modifiedAt=${String(env.modifiedAt)}`,
+    });
+  } else {
+    const row = inv.indexMap.get(itemKey(blob.uid, blob.kind, blob.id));
+    if (row && !row.tombstone && row.entry.modifiedAt !== env.modifiedAt) {
+      out.push({
+        kind: 'modifiedAt_mismatch',
+        uid: blob.uid,
+        itemKind: blob.kind,
+        id: blob.id,
+        severity: 'error',
+        detail: `envelope=${env.modifiedAt} index=${row.entry.modifiedAt}`,
+        data: { envelope: env.modifiedAt, index: row.entry.modifiedAt },
+      });
+    }
+  }
+
+  if (blob.kind === 'layouts') {
+    const inner = JSON.stringify({ layout: env.layout });
+    const v = validateShareLayout(env.layout, Buffer.byteLength(inner, 'utf8'));
+    if (isValidationError(v)) {
+      out.push({
+        kind: 'payload_invalid',
+        uid: blob.uid,
+        itemKind: blob.kind,
+        id: blob.id,
+        severity: 'error',
+        detail: `${v.error.code}: ${v.error.message}`,
+      });
+    }
+  } else {
+    const u = unwrapDesign(env.design);
+    if (!u) {
+      out.push({
+        kind: 'payload_invalid',
+        uid: blob.uid,
+        itemKind: blob.kind,
+        id: blob.id,
+        severity: 'error',
+        detail: 'design payload not unwrappable',
+      });
+    } else {
+      const wrapped = { type: 'designer' as const, version: 1 as const, params: u.params };
+      const inner = JSON.stringify(wrapped);
+      const v = validateDesignerShare(wrapped, Buffer.byteLength(inner, 'utf8'));
+      if (!v.valid) {
+        out.push({
+          kind: 'payload_invalid',
+          uid: blob.uid,
+          itemKind: blob.kind,
+          id: blob.id,
+          severity: 'error',
+          detail: `${v.error.code}: ${v.error.message}`,
+        });
+      }
+    }
+  }
+
+  void bytes;
+  return out;
+}
+
+function unwrapDesign(design: unknown): { name: string | null; params: unknown } | null {
+  if (design === null || typeof design !== 'object') return null;
+  const { name, params } = design as { name?: unknown; params?: unknown };
+  if (typeof params === 'object' && params !== null) {
+    if (name !== undefined && typeof name !== 'string') return null;
+    return { name: (name as string) ?? null, params };
+  }
+  return { name: null, params: design };
+}

--- a/scripts/sync-admin/lib/findings.ts
+++ b/scripts/sync-admin/lib/findings.ts
@@ -9,7 +9,11 @@ import type { Finding, Inventory } from './types.js';
 interface AnalyzeOpts {
   fetchPayloads: boolean;
   staleTombstoneMs?: number;
+  /** Per-fetch deadline in ms. Default 15s. */
+  fetchTimeoutMs?: number;
 }
+
+const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
 
 export async function analyze(
   inv: Inventory,
@@ -75,7 +79,8 @@ export async function analyze(
 
     const expected = expectedEnvelopeDelta(row.kind, row.entry.modifiedAt);
     const delta = blob.size - row.entry.sizeBytes;
-    if (delta !== expected) {
+    if (delta < expected) {
+      // index > what's stored: user is over-charged. Fix is safe (lowers sizeBytes).
       findings.push({
         kind: 'sanitization_drift',
         uid: row.uid,
@@ -83,6 +88,24 @@ export async function analyze(
         id: row.id,
         severity: 'warn',
         detail: `index sizeBytes over-counts by ${expected - delta}B (quota leak)`,
+        data: {
+          indexSize: row.entry.sizeBytes,
+          blobSize: blob.size,
+          drift: delta - expected,
+          modifiedAt: row.entry.modifiedAt,
+        },
+      });
+    } else if (delta > expected) {
+      // index < what's stored: index under-counts the blob. Suggests the blob
+      // was rewritten without a matching index update, or some other atomicity
+      // gap. Severity bumped to error since it can hide quota usage.
+      findings.push({
+        kind: 'index_size_undercount',
+        uid: row.uid,
+        itemKind: row.kind,
+        id: row.id,
+        severity: 'error',
+        detail: `index sizeBytes under-counts by ${delta - expected}B`,
         data: {
           indexSize: row.entry.sizeBytes,
           blobSize: blob.size,
@@ -109,12 +132,15 @@ export async function analyze(
   }
 
   if (opts.fetchPayloads) {
+    const timeoutMs = opts.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
     const liveBlobs = inv.blobs.filter((b) => {
       const r = inv.indexMap.get(itemKey(b.uid, b.kind, b.id));
-      return r && !r.tombstone;
+      // Skip rows that are tombstoned or malformed — payload-validation
+      // findings would be misleading or use NaN values in the detail line.
+      return r && !r.tombstone && !isMalformedRow(r);
     });
     const payloadFindings = await pMap(liveBlobs, async (blob) => {
-      return validateBlob(blob, inv);
+      return validateBlob(blob, inv, timeoutMs);
     });
     for (const list of payloadFindings) findings.push(...list);
   }
@@ -124,13 +150,14 @@ export async function analyze(
 
 async function validateBlob(
   blob: { uid: string; kind: 'layouts' | 'designs'; id: string; url: string; size: number },
-  inv: Inventory
+  inv: Inventory,
+  timeoutMs: number
 ): Promise<Finding[]> {
   const out: Finding[] = [];
   let body: unknown;
   let fetchedBytes = 0;
   try {
-    const r = await fetch(blob.url);
+    const r = await fetch(blob.url, { signal: AbortSignal.timeout(timeoutMs) });
     if (!r.ok) {
       return [
         {
@@ -147,14 +174,19 @@ async function validateBlob(
     fetchedBytes = Buffer.byteLength(text, 'utf8');
     body = JSON.parse(text);
   } catch (err) {
+    const isTimeout = err instanceof DOMException && err.name === 'TimeoutError';
     return [
       {
-        kind: 'envelope_invalid',
+        kind: isTimeout ? 'fetch_timeout' : 'envelope_invalid',
         uid: blob.uid,
         itemKind: blob.kind,
         id: blob.id,
         severity: 'error',
-        detail: err instanceof Error ? err.message : String(err),
+        detail: isTimeout
+          ? `blob fetch exceeded ${timeoutMs}ms`
+          : err instanceof Error
+            ? err.message
+            : String(err),
       },
     ];
   }

--- a/scripts/sync-admin/lib/inventory.ts
+++ b/scripts/sync-admin/lib/inventory.ts
@@ -8,10 +8,12 @@ import type { BlobRow, Inventory, IndexRow, Kind } from './types.js';
 interface BuildOpts {
   user?: string;
   kind?: Kind;
+  /** Skip the Vercel Blob listing — only Redis index data is needed. */
+  skipBlobs?: boolean;
 }
 
 export async function buildInventory(redis: Redis, opts: BuildOpts = {}): Promise<Inventory> {
-  const blobs = await listBlobs(opts);
+  const blobs = opts.skipBlobs ? [] : await listBlobs(opts);
   const blobMap = new Map<string, BlobRow>();
   const blobUsers = new Set<string>();
   for (const b of blobs) {
@@ -80,20 +82,21 @@ async function readIndexes(redis: Redis, opts: BuildOpts): Promise<IndexRow[]> {
 }
 
 export function parseRow(uid: string, kind: Kind, id: string, encoded: string): IndexRow {
+  const malformed: IndexRow = {
+    uid,
+    kind,
+    id,
+    entry: { modifiedAt: NaN, sizeBytes: NaN },
+    tombstone: false,
+  };
   try {
     const entry = JSON.parse(encoded) as IndexEntry;
-    if (typeof entry.modifiedAt !== 'number' || typeof entry.sizeBytes !== 'number') {
-      return { uid, kind, id, entry: { modifiedAt: NaN, sizeBytes: NaN }, tombstone: false };
-    }
+    if (!Number.isFinite(entry.modifiedAt) || !Number.isFinite(entry.sizeBytes)) return malformed;
+    // Match userIndex.parseEntry: deletedAt is either absent or a finite number.
+    if (entry.deletedAt !== undefined && !Number.isFinite(entry.deletedAt)) return malformed;
     return { uid, kind, id, entry, tombstone: entry.deletedAt !== undefined };
   } catch {
-    return {
-      uid,
-      kind,
-      id,
-      entry: { modifiedAt: NaN, sizeBytes: NaN },
-      tombstone: false,
-    };
+    return malformed;
   }
 }
 

--- a/scripts/sync-admin/lib/inventory.ts
+++ b/scripts/sync-admin/lib/inventory.ts
@@ -79,11 +79,11 @@ async function readIndexes(redis: Redis, opts: BuildOpts): Promise<IndexRow[]> {
   return out;
 }
 
-function parseRow(uid: string, kind: Kind, id: string, encoded: string): IndexRow {
+export function parseRow(uid: string, kind: Kind, id: string, encoded: string): IndexRow {
   try {
     const entry = JSON.parse(encoded) as IndexEntry;
     if (typeof entry.modifiedAt !== 'number' || typeof entry.sizeBytes !== 'number') {
-      return { uid, kind, id, entry, tombstone: entry.deletedAt !== undefined };
+      return { uid, kind, id, entry: { modifiedAt: NaN, sizeBytes: NaN }, tombstone: false };
     }
     return { uid, kind, id, entry, tombstone: entry.deletedAt !== undefined };
   } catch {

--- a/scripts/sync-admin/lib/inventory.ts
+++ b/scripts/sync-admin/lib/inventory.ts
@@ -1,0 +1,102 @@
+import { list } from '@vercel/blob';
+import type Redis from 'ioredis';
+import { userIndexKey } from '../../../api/lib/redisKeys.js';
+import type { IndexEntry } from '../../../api/lib/userIndex.js';
+import { scanKeys } from './redis.js';
+import type { BlobRow, Inventory, IndexRow, Kind } from './types.js';
+
+interface BuildOpts {
+  user?: string;
+  kind?: Kind;
+}
+
+export async function buildInventory(redis: Redis, opts: BuildOpts = {}): Promise<Inventory> {
+  const blobs = await listBlobs(opts);
+  const blobMap = new Map<string, BlobRow>();
+  const blobUsers = new Set<string>();
+  for (const b of blobs) {
+    blobMap.set(itemKey(b.uid, b.kind, b.id), b);
+    blobUsers.add(b.uid);
+  }
+
+  const indexRows = await readIndexes(redis, opts);
+  const indexMap = new Map<string, IndexRow>();
+  const redisUsers = new Set<string>();
+  for (const r of indexRows) {
+    indexMap.set(itemKey(r.uid, r.kind, r.id), r);
+    redisUsers.add(r.uid);
+  }
+
+  return { blobs, blobMap, indexRows, indexMap, blobUsers, redisUsers };
+}
+
+export function itemKey(uid: string, kind: Kind, id: string): string {
+  return `${uid}/${kind}/${id}`;
+}
+
+async function listBlobs(opts: BuildOpts): Promise<BlobRow[]> {
+  const prefix = opts.user ? `users/${opts.user}/` : 'users/';
+  const out: BlobRow[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await list({ prefix, cursor, limit: 1000 });
+    for (const b of page.blobs) {
+      const parts = b.pathname.split('/');
+      if (parts[0] !== 'users' || !parts[1]) continue;
+      if (parts[2] !== 'layouts' && parts[2] !== 'designs') continue;
+      if (opts.kind && parts[2] !== opts.kind) continue;
+      const file = parts[3] ?? '';
+      if (!file.endsWith('.json')) continue;
+      out.push({
+        uid: parts[1],
+        kind: parts[2],
+        id: file.slice(0, -5),
+        size: b.size,
+        url: b.url,
+        uploadedAt: b.uploadedAt instanceof Date ? b.uploadedAt : new Date(b.uploadedAt),
+      });
+    }
+    cursor = page.cursor;
+  } while (cursor);
+  return out;
+}
+
+async function readIndexes(redis: Redis, opts: BuildOpts): Promise<IndexRow[]> {
+  const kinds: Kind[] = opts.kind ? [opts.kind] : ['layouts', 'designs'];
+  const out: IndexRow[] = [];
+  for (const kind of kinds) {
+    const keys = opts.user
+      ? [userIndexKey(opts.user, kind)]
+      : await scanKeys(redis, `users:*:index:${kind}`);
+    for (const key of keys) {
+      const uid = key.split(':')[1];
+      const raw = await redis.hgetall(key);
+      for (const [id, encoded] of Object.entries(raw)) {
+        out.push(parseRow(uid, kind, id, encoded));
+      }
+    }
+  }
+  return out;
+}
+
+function parseRow(uid: string, kind: Kind, id: string, encoded: string): IndexRow {
+  try {
+    const entry = JSON.parse(encoded) as IndexEntry;
+    if (typeof entry.modifiedAt !== 'number' || typeof entry.sizeBytes !== 'number') {
+      return { uid, kind, id, entry, tombstone: entry.deletedAt !== undefined };
+    }
+    return { uid, kind, id, entry, tombstone: entry.deletedAt !== undefined };
+  } catch {
+    return {
+      uid,
+      kind,
+      id,
+      entry: { modifiedAt: NaN, sizeBytes: NaN },
+      tombstone: false,
+    };
+  }
+}
+
+export function isMalformedRow(r: IndexRow): boolean {
+  return Number.isNaN(r.entry.modifiedAt) || Number.isNaN(r.entry.sizeBytes);
+}

--- a/scripts/sync-admin/lib/output.ts
+++ b/scripts/sync-admin/lib/output.ts
@@ -35,9 +35,3 @@ export function formatTable(
   for (const r of rows) lines.push(fmtRow(r));
   return lines.join('\n');
 }
-
-export function emit(payload: unknown, asJson: boolean): void {
-  if (asJson) {
-    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
-  }
-}

--- a/scripts/sync-admin/lib/output.ts
+++ b/scripts/sync-admin/lib/output.ts
@@ -1,0 +1,43 @@
+import type { Finding } from './types.js';
+
+const COLOR = process.stdout.isTTY && !process.env.NO_COLOR;
+const c = {
+  red: (s: string) => (COLOR ? `\x1b[31m${s}\x1b[0m` : s),
+  yellow: (s: string) => (COLOR ? `\x1b[33m${s}\x1b[0m` : s),
+  cyan: (s: string) => (COLOR ? `\x1b[36m${s}\x1b[0m` : s),
+  dim: (s: string) => (COLOR ? `\x1b[2m${s}\x1b[0m` : s),
+  bold: (s: string) => (COLOR ? `\x1b[1m${s}\x1b[0m` : s),
+};
+
+export const colors = c;
+
+export function severityLabel(sev: Finding['severity']): string {
+  if (sev === 'error') return c.red('ERROR');
+  if (sev === 'warn') return c.yellow('WARN ');
+  return c.dim('INFO ');
+}
+
+export function formatFinding(f: Finding): string {
+  const id = f.id ? `${f.uid.slice(0, 12)}…/${f.itemKind}/${f.id}` : f.uid.slice(0, 12) + '…';
+  return `  ${severityLabel(f.severity)}  ${c.bold(f.kind)}  ${id}  — ${f.detail}`;
+}
+
+export function formatTable(
+  headers: readonly string[],
+  rows: readonly (readonly (string | number)[])[]
+): string {
+  const widths = headers.map((h, i) =>
+    Math.max(String(h).length, ...rows.map((r) => String(r[i] ?? '').length))
+  );
+  const fmtRow = (r: readonly (string | number)[]): string =>
+    r.map((v, i) => String(v ?? '').padEnd(widths[i])).join('  ');
+  const lines = [c.bold(fmtRow(headers))];
+  for (const r of rows) lines.push(fmtRow(r));
+  return lines.join('\n');
+}
+
+export function emit(payload: unknown, asJson: boolean): void {
+  if (asJson) {
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+  }
+}

--- a/scripts/sync-admin/lib/redis.ts
+++ b/scripts/sync-admin/lib/redis.ts
@@ -1,0 +1,21 @@
+import Redis from 'ioredis';
+import { requireEnv } from './env.js';
+
+export function connect(): Redis {
+  return new Redis(requireEnv('REDIS_URL'), {
+    maxRetriesPerRequest: 2,
+    connectTimeout: 5000,
+    commandTimeout: 5000,
+  });
+}
+
+export async function scanKeys(redis: Redis, pattern: string): Promise<string[]> {
+  const out: string[] = [];
+  let cursor = '0';
+  do {
+    const [next, batch] = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', 500);
+    out.push(...batch);
+    cursor = next;
+  } while (cursor !== '0');
+  return out;
+}

--- a/scripts/sync-admin/lib/redis.ts
+++ b/scripts/sync-admin/lib/redis.ts
@@ -10,12 +10,14 @@ export function connect(): Redis {
 }
 
 export async function scanKeys(redis: Redis, pattern: string): Promise<string[]> {
-  const out: string[] = [];
+  // SCAN can yield the same key more than once during a single iteration;
+  // a Set keeps the audit from double-counting.
+  const out = new Set<string>();
   let cursor = '0';
   do {
     const [next, batch] = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', 500);
-    out.push(...batch);
+    for (const k of batch) out.add(k);
     cursor = next;
   } while (cursor !== '0');
-  return out;
+  return [...out];
 }

--- a/scripts/sync-admin/lib/suggest.ts
+++ b/scripts/sync-admin/lib/suggest.ts
@@ -1,4 +1,4 @@
-import { userIndexKey } from '../../../api/lib/redisKeys.js';
+import { userIndexKey, userIndexUpdatedAtKey } from '../../../api/lib/redisKeys.js';
 import { expectedEnvelopeDelta } from './delta.js';
 import type { Finding } from './types.js';
 
@@ -13,6 +13,7 @@ export const SUGGEST_CATEGORIES: readonly SuggestCategory[] = [
 
 const FINDING_TO_CATEGORY: Partial<Record<Finding['kind'], SuggestCategory>> = {
   sanitization_drift: 'drift',
+  index_size_undercount: 'drift',
   orphan_blob: 'orphans',
   missing_blob: 'orphans',
   stale_tombstone: 'stale-tombstones',
@@ -20,9 +21,29 @@ const FINDING_TO_CATEGORY: Partial<Record<Finding['kind'], SuggestCategory>> = {
   tombstone_with_blob: 'orphans',
 };
 
+/**
+ * Header to emit at the top of a `suggest <category>` script so the file is
+ * runnable standalone. The audit process loaded creds inside Node; the saved
+ * file has to source them itself before any redis-cli / vercel blob calls.
+ */
+export const SCRIPT_PREAMBLE = [
+  '#!/usr/bin/env bash',
+  'set -euo pipefail',
+  '',
+  '# Load REDIS_URL + BLOB_READ_WRITE_TOKEN from .env.production.local.',
+  '# Run `vercel env pull .env.production.local` to refresh.',
+  'if [ -f .env.production.local ]; then',
+  '  set -a; . ./.env.production.local; set +a',
+  'fi',
+  ': "${REDIS_URL:?REDIS_URL not set; run \\`vercel env pull .env.production.local\\` first}"',
+  ': "${BLOB_READ_WRITE_TOKEN:?BLOB_READ_WRITE_TOKEN not set; run \\`vercel env pull .env.production.local\\` first}"',
+  '',
+];
+
 export function suggestFor(f: Finding): string[] {
   switch (f.kind) {
     case 'sanitization_drift':
+    case 'index_size_undercount':
       return driftSuggestion(f);
     case 'orphan_blob':
       return orphanBlobSuggestion(f);
@@ -45,60 +66,93 @@ export function categoryOf(f: Finding): SuggestCategory | undefined {
 
 function driftSuggestion(f: Finding): string[] {
   if (!f.id || !f.itemKind) return [];
-  const data = (f.data ?? {}) as { indexSize?: number; blobSize?: number };
-  if (typeof data.blobSize !== 'number') return [];
-  const modifiedAt = (f.data as { modifiedAt?: number } | undefined)?.modifiedAt;
-  const newSize = modifiedAt
-    ? data.blobSize - expectedEnvelopeDelta(f.itemKind, modifiedAt)
-    : data.blobSize;
-  const key = userIndexKey(f.uid, f.itemKind);
+  const data = (f.data ?? {}) as { blobSize?: number; modifiedAt?: number };
+  if (typeof data.blobSize !== 'number' || typeof data.modifiedAt !== 'number') return [];
+  const newSize = data.blobSize - expectedEnvelopeDelta(f.itemKind, data.modifiedAt);
+  if (!Number.isFinite(newSize) || newSize < 0) return [];
+  const indexKey = userIndexKey(f.uid, f.itemKind);
+  const updatedAtKey = userIndexUpdatedAtKey(f.uid);
+  // Lua: read-modify-write the entry, but only if the audited modifiedAt
+  // still matches — guards against the user updating the item between the
+  // audit and the fix. Also bumps indexUpdatedAt so the manifest endpoint's
+  // If-Modified-Since 304 path can't serve the stale sizeBytes.
   return [
     `# ${f.detail}`,
     `redis-cli -u "$REDIS_URL" --no-auth-warning EVAL '`,
     `  local raw = redis.call("HGET", KEYS[1], ARGV[1])`,
-    `  if not raw then return "no entry" end`,
+    `  if not raw then return "absent" end`,
     `  local entry = cjson.decode(raw)`,
+    `  if tostring(entry.modifiedAt) ~= ARGV[3] then return "stale-modifiedAt" end`,
     `  entry.sizeBytes = tonumber(ARGV[2])`,
-    `  return redis.call("HSET", KEYS[1], ARGV[1], cjson.encode(entry))`,
-    `' 1 ${shq(key)} ${shq(f.id)} ${newSize}`,
+    `  redis.call("HSET", KEYS[1], ARGV[1], cjson.encode(entry))`,
+    `  redis.call("SET", KEYS[2], ARGV[4])`,
+    `  return "ok"`,
+    `' 2 ${shq(indexKey)} ${shq(updatedAtKey)} ${shq(f.id)} ${newSize} ${shq(String(data.modifiedAt))} "$(date +%s%3N)"`,
   ];
 }
 
 function orphanBlobSuggestion(f: Finding): string[] {
   if (!f.id || !f.itemKind) return [];
   const blobPath = `users/${f.uid}/${f.itemKind}/${f.id}.json`;
+  const indexKey = userIndexKey(f.uid, f.itemKind);
+  // Preflight: re-check the index entry just before deletion. A live entry
+  // means the user re-uploaded between audit and remediation, so we abort.
   return [
-    `# ${f.detail} — review before deletion`,
-    `# Inspect first:`,
-    `#   pnpm sync-admin user ${shq(f.uid)} --kind=${f.itemKind} --json | jq '.blobs[] | select(.id==${shq(f.id)})'`,
-    `vercel blob rm ${shq(blobPath)} --yes`,
+    `# ${f.detail} — preflight checks index is still absent before deleting blob`,
+    `# Inspect: pnpm sync-admin user ${shq(f.uid)} --kind=${f.itemKind} --json | jq --arg id ${shq(f.id)} '.blobs[] | select(.id == $id)'`,
+    `if [ "$(redis-cli -u "$REDIS_URL" --no-auth-warning HGET ${shq(indexKey)} ${shq(f.id)})" = "" ]; then`,
+    `  vercel blob rm ${shq(blobPath)} --yes`,
+    `else`,
+    `  echo "skip: ${blobPath} — index entry now present, item likely re-uploaded"`,
+    `fi`,
   ];
 }
 
 function tombstoneWithBlobSuggestion(f: Finding): string[] {
   if (!f.id || !f.itemKind) return [];
   const blobPath = `users/${f.uid}/${f.itemKind}/${f.id}.json`;
+  const indexKey = userIndexKey(f.uid, f.itemKind);
   return [
-    `# ${f.detail} — tombstone says deleted but blob remains`,
-    `vercel blob rm ${shq(blobPath)} --yes`,
+    `# ${f.detail} — preflight checks index is still tombstoned before deleting blob`,
+    `if redis-cli -u "$REDIS_URL" --no-auth-warning HGET ${shq(indexKey)} ${shq(f.id)} | grep -q '"deletedAt"'; then`,
+    `  vercel blob rm ${shq(blobPath)} --yes`,
+    `else`,
+    `  echo "skip: ${blobPath} — index entry no longer tombstoned (item restored)"`,
+    `fi`,
   ];
 }
 
 function missingBlobSuggestion(f: Finding): string[] {
   if (!f.id || !f.itemKind) return [];
+  const data = (f.data ?? {}) as { modifiedAt?: number };
+  if (typeof data.modifiedAt !== 'number') return [];
   const key = userIndexKey(f.uid, f.itemKind);
   return [
-    `# ${f.detail} — index entry without blob (failed PUT or manual delete)`,
-    `redis-cli -u "$REDIS_URL" --no-auth-warning HDEL ${shq(key)} ${shq(f.id)}`,
+    `# ${f.detail} — guarded on audited modifiedAt`,
+    `redis-cli -u "$REDIS_URL" --no-auth-warning EVAL '`,
+    `  local raw = redis.call("HGET", KEYS[1], ARGV[1])`,
+    `  if not raw then return "already-gone" end`,
+    `  local entry = cjson.decode(raw)`,
+    `  if tostring(entry.modifiedAt) ~= ARGV[2] then return "stale-modifiedAt" end`,
+    `  return redis.call("HDEL", KEYS[1], ARGV[1])`,
+    `' 1 ${shq(key)} ${shq(f.id)} ${shq(String(data.modifiedAt))}`,
   ];
 }
 
 function staleTombstoneSuggestion(f: Finding): string[] {
   if (!f.id || !f.itemKind) return [];
   const key = userIndexKey(f.uid, f.itemKind);
+  // Lua: only delete if the entry is still a tombstone (deletedAt present).
+  // Catches the case where the user re-uploaded after the audit.
   return [
-    `# ${f.detail}`,
-    `redis-cli -u "$REDIS_URL" --no-auth-warning HDEL ${shq(key)} ${shq(f.id)}`,
+    `# ${f.detail} — guarded on still-tombstoned state`,
+    `redis-cli -u "$REDIS_URL" --no-auth-warning EVAL '`,
+    `  local raw = redis.call("HGET", KEYS[1], ARGV[1])`,
+    `  if not raw then return "already-gone" end`,
+    `  local entry = cjson.decode(raw)`,
+    `  if entry.deletedAt == nil then return "restored" end`,
+    `  return redis.call("HDEL", KEYS[1], ARGV[1])`,
+    `' 1 ${shq(key)} ${shq(f.id)}`,
   ];
 }
 

--- a/scripts/sync-admin/lib/suggest.ts
+++ b/scripts/sync-admin/lib/suggest.ts
@@ -1,0 +1,117 @@
+import { userIndexKey } from '../../../api/lib/redisKeys.js';
+import { expectedEnvelopeDelta } from './delta.js';
+import type { Finding } from './types.js';
+
+export type SuggestCategory = 'drift' | 'orphans' | 'stale-tombstones' | 'malformed';
+
+export const SUGGEST_CATEGORIES: readonly SuggestCategory[] = [
+  'drift',
+  'orphans',
+  'stale-tombstones',
+  'malformed',
+];
+
+const FINDING_TO_CATEGORY: Partial<Record<Finding['kind'], SuggestCategory>> = {
+  sanitization_drift: 'drift',
+  orphan_blob: 'orphans',
+  missing_blob: 'orphans',
+  stale_tombstone: 'stale-tombstones',
+  malformed_index_entry: 'malformed',
+  tombstone_with_blob: 'orphans',
+};
+
+export function suggestFor(f: Finding): string[] {
+  switch (f.kind) {
+    case 'sanitization_drift':
+      return driftSuggestion(f);
+    case 'orphan_blob':
+      return orphanBlobSuggestion(f);
+    case 'tombstone_with_blob':
+      return tombstoneWithBlobSuggestion(f);
+    case 'missing_blob':
+      return missingBlobSuggestion(f);
+    case 'stale_tombstone':
+      return staleTombstoneSuggestion(f);
+    case 'malformed_index_entry':
+      return malformedSuggestion(f);
+    default:
+      return [];
+  }
+}
+
+export function categoryOf(f: Finding): SuggestCategory | undefined {
+  return FINDING_TO_CATEGORY[f.kind];
+}
+
+function driftSuggestion(f: Finding): string[] {
+  if (!f.id || !f.itemKind) return [];
+  const data = (f.data ?? {}) as { indexSize?: number; blobSize?: number };
+  if (typeof data.blobSize !== 'number') return [];
+  const modifiedAt = (f.data as { modifiedAt?: number } | undefined)?.modifiedAt;
+  const newSize = modifiedAt
+    ? data.blobSize - expectedEnvelopeDelta(f.itemKind, modifiedAt)
+    : data.blobSize;
+  const key = userIndexKey(f.uid, f.itemKind);
+  return [
+    `# ${f.detail}`,
+    `redis-cli -u "$REDIS_URL" --no-auth-warning EVAL '`,
+    `  local raw = redis.call("HGET", KEYS[1], ARGV[1])`,
+    `  if not raw then return "no entry" end`,
+    `  local entry = cjson.decode(raw)`,
+    `  entry.sizeBytes = tonumber(ARGV[2])`,
+    `  return redis.call("HSET", KEYS[1], ARGV[1], cjson.encode(entry))`,
+    `' 1 ${shq(key)} ${shq(f.id)} ${newSize}`,
+  ];
+}
+
+function orphanBlobSuggestion(f: Finding): string[] {
+  if (!f.id || !f.itemKind) return [];
+  const blobPath = `users/${f.uid}/${f.itemKind}/${f.id}.json`;
+  return [
+    `# ${f.detail} — review before deletion`,
+    `# Inspect first:`,
+    `#   pnpm sync-admin user ${shq(f.uid)} --kind=${f.itemKind} --json | jq '.blobs[] | select(.id==${shq(f.id)})'`,
+    `vercel blob rm ${shq(blobPath)} --yes`,
+  ];
+}
+
+function tombstoneWithBlobSuggestion(f: Finding): string[] {
+  if (!f.id || !f.itemKind) return [];
+  const blobPath = `users/${f.uid}/${f.itemKind}/${f.id}.json`;
+  return [
+    `# ${f.detail} — tombstone says deleted but blob remains`,
+    `vercel blob rm ${shq(blobPath)} --yes`,
+  ];
+}
+
+function missingBlobSuggestion(f: Finding): string[] {
+  if (!f.id || !f.itemKind) return [];
+  const key = userIndexKey(f.uid, f.itemKind);
+  return [
+    `# ${f.detail} — index entry without blob (failed PUT or manual delete)`,
+    `redis-cli -u "$REDIS_URL" --no-auth-warning HDEL ${shq(key)} ${shq(f.id)}`,
+  ];
+}
+
+function staleTombstoneSuggestion(f: Finding): string[] {
+  if (!f.id || !f.itemKind) return [];
+  const key = userIndexKey(f.uid, f.itemKind);
+  return [
+    `# ${f.detail}`,
+    `redis-cli -u "$REDIS_URL" --no-auth-warning HDEL ${shq(key)} ${shq(f.id)}`,
+  ];
+}
+
+function malformedSuggestion(f: Finding): string[] {
+  if (!f.id || !f.itemKind) return [];
+  const key = userIndexKey(f.uid, f.itemKind);
+  return [
+    `# ${f.detail} — inspect raw value, then HDEL if unrecoverable`,
+    `redis-cli -u "$REDIS_URL" --no-auth-warning HGET ${shq(key)} ${shq(f.id)}`,
+    `# redis-cli -u "$REDIS_URL" --no-auth-warning HDEL ${shq(key)} ${shq(f.id)}`,
+  ];
+}
+
+function shq(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}

--- a/scripts/sync-admin/lib/types.ts
+++ b/scripts/sync-admin/lib/types.ts
@@ -37,6 +37,7 @@ export type FindingKind =
   | 'envelope_invalid'
   | 'payload_invalid'
   | 'sanitization_drift'
+  | 'listing_size_mismatch'
   | 'stale_tombstone';
 
 export interface Finding {

--- a/scripts/sync-admin/lib/types.ts
+++ b/scripts/sync-admin/lib/types.ts
@@ -1,0 +1,52 @@
+import type { IndexEntry, SyncItemKind } from '../../../api/lib/userIndex.js';
+
+export type Kind = SyncItemKind;
+
+export interface BlobRow {
+  uid: string;
+  kind: Kind;
+  id: string;
+  size: number;
+  url: string;
+  uploadedAt: Date;
+}
+
+export interface IndexRow {
+  uid: string;
+  kind: Kind;
+  id: string;
+  entry: IndexEntry;
+  tombstone: boolean;
+}
+
+export interface Inventory {
+  blobs: BlobRow[];
+  blobMap: Map<string, BlobRow>;
+  indexRows: IndexRow[];
+  indexMap: Map<string, IndexRow>;
+  blobUsers: Set<string>;
+  redisUsers: Set<string>;
+}
+
+export type FindingKind =
+  | 'orphan_blob'
+  | 'tombstone_with_blob'
+  | 'missing_blob'
+  | 'malformed_index_entry'
+  | 'modifiedAt_mismatch'
+  | 'envelope_invalid'
+  | 'payload_invalid'
+  | 'sanitization_drift'
+  | 'stale_tombstone';
+
+export interface Finding {
+  kind: FindingKind;
+  uid: string;
+  itemKind?: Kind;
+  id?: string;
+  severity: 'error' | 'warn' | 'info';
+  detail: string;
+  data?: Record<string, unknown>;
+}
+
+export const PER_USER_QUOTA = { count: 100, bytes: 10 * 1024 * 1024 };

--- a/scripts/sync-admin/lib/types.ts
+++ b/scripts/sync-admin/lib/types.ts
@@ -37,7 +37,9 @@ export type FindingKind =
   | 'envelope_invalid'
   | 'payload_invalid'
   | 'sanitization_drift'
+  | 'index_size_undercount'
   | 'listing_size_mismatch'
+  | 'fetch_timeout'
   | 'stale_tombstone';
 
 export interface Finding {
@@ -49,5 +51,3 @@ export interface Finding {
   detail: string;
   data?: Record<string, unknown>;
 }
-
-export const PER_USER_QUOTA = { count: 100, bytes: 10 * 1024 * 1024 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" },
-    { "path": "./tsconfig.api.json" }
+    { "path": "./tsconfig.api.json" },
+    { "path": "./tsconfig.scripts.json" }
   ]
 }

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.scripts.tsbuildinfo",
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["scripts/sync-admin/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds `pnpm sync-admin <cmd>` — a read-only operator toolkit for the cloud-sync subsystem (Vercel Blob + Redis index). Reports on integrity, surfaces drift, and emits reviewable shell commands for remediation. Never mutates anything itself.

Born from an ad-hoc audit that found systemic `sizeBytes` over-counting in the Redis index: the PUT handlers compute `sizeBytes` against the *raw* payload before validation, but the *sanitized* payload is what lands in the blob. Quota accounting is conservative as a result — not a data risk, but worth surfacing.

## Commands

- `audit` — full integrity scan: blob ↔ index reconciliation, envelope validation, payload validation, sanitization-drift detection
- `user <uid>` — drill into one user's blobs, live entries, tombstones, and findings
- `users` — table of all users sorted by total bytes
- `tombstones` — list with age and stale flag (default 90d threshold matches `TOMBSTONE_RETENTION_MS`)
- `suggest <category>` — emit `redis-cli` / `vercel blob rm` commands for: drift | orphans | stale-tombstones | malformed

Shared flags: `--json`, `--strict`, `--kind`, `--user`, `--no-payload-fetch`, `--suggest`, `--older-than`.

## Design notes

- Imports `validateShareLayout`, `validateDesignerShare`, `userIndexKey`, `TOMBSTONE_RETENTION_MS` directly from `api/lib/` so the audit reflects exactly what production enforces on write.
- Bounded concurrency (16 in-flight) for blob fetches via `lib/concurrency.ts`.
- Envelope-overhead delta math in `lib/delta.ts` distinguishes "expected" from "drift" — see comments for the byte accounting.
- Drift suggestions use `redis-cli EVAL` with a Lua read-modify-write so untouched fields in the `IndexEntry` JSON (especially `modifiedAt`) survive the size correction.
- Banner prints target Redis host + blob token prefix at the top of every run.

## Test plan

- [x] `pnpm exec vitest run scripts/sync-admin` — 36/36 passing (args, concurrency, delta math, finding aggregation with mocked fetch, suggest commands incl. shell-quote escaping)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (one pre-existing warning in an unrelated file)
- [x] Smoke-tested against production: `audit`, `audit --suggest`, `audit --strict` (exits 1 on findings), `audit --json` (pipes cleanly with `pnpm --silent`), `user`, `users`, `tombstones`, `suggest drift`, `suggest stale-tombstones`
- [x] Found 26 sanitization-drift warnings in the current production data (consistent with the ad-hoc audit that motivated this PR)