### PR TITLE
fix(sync): record sizeBytes from sanitized payload, not raw request

### DIFF
--- a/api/sync/README.md
+++ b/api/sync/README.md
@@ -55,9 +55,13 @@ type IndexEntry = {
 ```
 
 `sizeBytes` is measured against the **sanitized** payload — the same bytes the
-blob stores — so quota accounting matches reality. The 500 KB size cap on PUT
-is checked separately against the raw request bytes so the handler doesn't
-waste cycles validating huge inputs.
+blob stores — so quota accounting matches reality. Each kind also has a
+**pre-validation cap** that bounds CPU on huge inputs: layouts use
+`SHARE_CONSTRAINTS.MAX_SIZE_BYTES` (500 KB, measured on `{ layout }`); designs
+use `CONSTRAINTS.MAX_PAYLOAD_BYTES` (100 KB, measured on
+`{ name, type, version, params }`). The pre-validation count is intentionally a
+subset of the request body, not the full HTTP payload — its only job is to gate
+the validator's workload.
 
 ## LWW + tombstone semantics (PUT)
 

--- a/api/sync/README.md
+++ b/api/sync/README.md
@@ -54,6 +54,11 @@ type IndexEntry = {
 //           bumps the cache key for /api/sync/manifest's 304 path.
 ```
 
+`sizeBytes` is measured against the **sanitized** payload — the same bytes the
+blob stores — so quota accounting matches reality. The 500 KB size cap on PUT
+is checked separately against the raw request bytes so the handler doesn't
+waste cycles validating huge inputs.
+
 ## LWW + tombstone semantics (PUT)
 
 Every write supplies a `modifiedAt` (ms epoch) representing the client's view of when the change happened. The server compares against the existing entry:

--- a/api/sync/designs/[id].test.ts
+++ b/api/sync/designs/[id].test.ts
@@ -177,6 +177,44 @@ describe('PUT', () => {
     expect((body.envelope.design.params as { width: number }).width).toBe(2);
   });
 
+  it('records sizeBytes for the post-sanitization payload, not the raw request', async () => {
+    const { default: handler } = await import('./[id]');
+    // Extra params field the share validator strips. Without the
+    // post-validation size fix, the index would record the request-size
+    // while the blob holds the smaller sanitized params, drifting apart.
+    const dirty = { ...VALID_DESIGN, garbage: 'x'.repeat(200) };
+    await handler(
+      makeReq({
+        method: 'PUT',
+        body: { design: { name: 'Test', params: dirty }, modifiedAt: 1000 },
+      }),
+      makeRes() as unknown as VercelResponse
+    );
+
+    const storedEnvelope = [...blobStore.values()][0] as {
+      design: { name: string; params: unknown };
+    };
+    const indexHash = [...redisHashes.values()].find((h) => h.size > 0);
+    const encoded = [...(indexHash?.values() ?? [])][0];
+    const entry = JSON.parse(encoded ?? '{}') as { sizeBytes: number };
+
+    const expected = Buffer.byteLength(
+      JSON.stringify({
+        name: storedEnvelope.design.name,
+        type: 'designer',
+        version: 1,
+        params: storedEnvelope.design.params,
+      }),
+      'utf8'
+    );
+    expect(entry.sizeBytes).toBe(expected);
+    const requestBytes = Buffer.byteLength(
+      JSON.stringify({ name: 'Test', type: 'designer', version: 1, params: dirty }),
+      'utf8'
+    );
+    expect(entry.sizeBytes).toBeLessThan(requestBytes);
+  });
+
   it('accepts the legacy bare-BinParams shape and stores it with an empty name', async () => {
     const { default: handler } = await import('./[id]');
     const res = makeRes();

--- a/api/sync/designs/[id].ts
+++ b/api/sync/designs/[id].ts
@@ -160,19 +160,25 @@ async function handlePut(
   // posts have no name; they persist as '' and the adapter falls back.
   const name = sanitizeString(unwrapped.name ?? '', MAX_NAME_LENGTH);
 
-  // Reuse the share-payload validator. `sizeBytes` measures name + params
-  // together so the size cap, quota math, and stored envelope all agree.
+  // The size cap guards against work on huge inputs, so check it against
+  // the raw request. Quota math and the index entry below use the
+  // post-sanitization size — otherwise the user is charged for bytes the
+  // validator stripped, and the index drifts from what the blob stores.
   const validationPayload = {
     type: 'designer' as const,
     version: 1 as const,
     params: unwrapped.params,
   };
-  const sizeBytes = Buffer.byteLength(JSON.stringify({ name, ...validationPayload }), 'utf8');
-  const validation = validateDesignerShare(validationPayload, sizeBytes);
+  const requestBytes = Buffer.byteLength(JSON.stringify({ name, ...validationPayload }), 'utf8');
+  const validation = validateDesignerShare(validationPayload, requestBytes);
   if (!validation.valid) {
     res.status(400).json({ error: validation.error.message, code: ErrorCode.VALIDATION_ERROR });
     return;
   }
+  const sizeBytes = Buffer.byteLength(
+    JSON.stringify({ name, type: 'designer', version: 1, params: validation.payload.params }),
+    'utf8'
+  );
 
   const existing = await getEntry(redis, userId, 'designs', id);
   // `deletedAt === undefined` is the explicit live-entry check.

--- a/api/sync/designs/[id].ts
+++ b/api/sync/designs/[id].ts
@@ -160,17 +160,22 @@ async function handlePut(
   // posts have no name; they persist as '' and the adapter falls back.
   const name = sanitizeString(unwrapped.name ?? '', MAX_NAME_LENGTH);
 
-  // The size cap guards against work on huge inputs, so check it against
-  // the raw request. Quota math and the index entry below use the
-  // post-sanitization size — otherwise the user is charged for bytes the
-  // validator stripped, and the index drifts from what the blob stores.
+  // Two byte counts intentionally: `preValidationBytes` is what the
+  // validator's 100 KB size cap sees — purely a CPU guard against huge
+  // params. `sizeBytes` is what we actually store after sanitization, and
+  // it's what the quota check and index entry track. Without the split,
+  // users get charged for bytes the validator stripped and the index
+  // drifts from what the blob holds.
   const validationPayload = {
     type: 'designer' as const,
     version: 1 as const,
     params: unwrapped.params,
   };
-  const requestBytes = Buffer.byteLength(JSON.stringify({ name, ...validationPayload }), 'utf8');
-  const validation = validateDesignerShare(validationPayload, requestBytes);
+  const preValidationBytes = Buffer.byteLength(
+    JSON.stringify({ name, ...validationPayload }),
+    'utf8'
+  );
+  const validation = validateDesignerShare(validationPayload, preValidationBytes);
   if (!validation.valid) {
     res.status(400).json({ error: validation.error.message, code: ErrorCode.VALIDATION_ERROR });
     return;

--- a/api/sync/layouts/[id].test.ts
+++ b/api/sync/layouts/[id].test.ts
@@ -208,6 +208,30 @@ describe('PUT — LWW + tombstone', () => {
     expect(res._status).toBe(200);
   });
 
+  it('records sizeBytes for the post-sanitization payload, not the raw request', async () => {
+    const { default: handler } = await import('./[id]');
+    // Extra top-level fields the share validator drops. Without the
+    // post-validation size fix, the index would record the request-size
+    // (including these bytes) while the blob would store the smaller
+    // sanitized layout — drifting the two apart.
+    const dirty = { ...VALID_LAYOUT, garbage: 'x'.repeat(200), alsoGarbage: true };
+    await handler(
+      makeReq({ method: 'PUT', body: { layout: dirty, modifiedAt: 1000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+
+    const storedEnvelope = [...blobStore.values()][0] as { layout: unknown };
+    const indexHash = [...redisHashes.values()].find((h) => h.size > 0);
+    const encoded = [...(indexHash?.values() ?? [])][0];
+    const entry = JSON.parse(encoded ?? '{}') as { sizeBytes: number };
+
+    const expected = Buffer.byteLength(JSON.stringify({ layout: storedEnvelope.layout }), 'utf8');
+    expect(entry.sizeBytes).toBe(expected);
+    // Sanity: the dirty payload was strictly larger than what we stored.
+    const requestBytes = Buffer.byteLength(JSON.stringify({ layout: dirty }), 'utf8');
+    expect(entry.sizeBytes).toBeLessThan(requestBytes);
+  });
+
   it('rejects with 409 when the existing entry is newer (stale write)', async () => {
     const { default: handler } = await import('./[id]');
     await handler(

--- a/api/sync/layouts/[id].ts
+++ b/api/sync/layouts/[id].ts
@@ -125,12 +125,14 @@ async function handlePut(
     return;
   }
 
-  // The size cap guards against work on huge inputs, so check it against
-  // the raw request. Quota math and the index entry below use the
-  // post-sanitization size — otherwise the user is charged for bytes the
-  // validator stripped, and the index drifts from what the blob stores.
-  const requestBytes = Buffer.byteLength(JSON.stringify({ layout }), 'utf8');
-  const validation = validateShareLayout(layout, requestBytes);
+  // Two byte counts intentionally: `preValidationBytes` is what the
+  // validator's 500 KB size cap sees — purely a CPU guard against huge
+  // inputs. `sizeBytes` is what we actually store after sanitization, and
+  // it's what the quota check and index entry track. Without the split,
+  // users get charged for bytes the validator stripped and the index
+  // drifts from what the blob holds.
+  const preValidationBytes = Buffer.byteLength(JSON.stringify({ layout }), 'utf8');
+  const validation = validateShareLayout(layout, preValidationBytes);
   if (isValidationError(validation)) {
     res.status(400).json({ error: validation.error.message, code: validation.error.code });
     return;

--- a/api/sync/layouts/[id].ts
+++ b/api/sync/layouts/[id].ts
@@ -125,13 +125,17 @@ async function handlePut(
     return;
   }
 
-  const serialized = JSON.stringify({ layout });
-  const sizeBytes = Buffer.byteLength(serialized, 'utf8');
-  const validation = validateShareLayout(layout, sizeBytes);
+  // The size cap guards against work on huge inputs, so check it against
+  // the raw request. Quota math and the index entry below use the
+  // post-sanitization size — otherwise the user is charged for bytes the
+  // validator stripped, and the index drifts from what the blob stores.
+  const requestBytes = Buffer.byteLength(JSON.stringify({ layout }), 'utf8');
+  const validation = validateShareLayout(layout, requestBytes);
   if (isValidationError(validation)) {
     res.status(400).json({ error: validation.error.message, code: validation.error.code });
     return;
   }
+  const sizeBytes = Buffer.byteLength(JSON.stringify({ layout: validation.layout }), 'utf8');
 
   const existing = await getEntry(redis, userId, 'layouts', id);
 


### PR DESCRIPTION
## Summary

The PUT handlers in `api/sync/{layouts,designs}/[id].ts` measured `sizeBytes` against the raw request body, then stored the sanitized payload in the blob. When validation stripped fields, the index recorded *more* bytes than the blob actually held — so the user's quota was charged for bytes they didn't store.

The size cap on PUT still uses raw-request bytes (guards against expensive validation of huge inputs), but the quota check and the `IndexEntry` now both measure the post-validation payload. After this, the byte invariant is exact:

```
blob.size − envelope_overhead === index.sizeBytes
```

A companion audit tool (PR #1708) found 27 drifting entries in production today (~5 KB total across all users, 0.02% of the 10 MB quota at most). That's existing data; this PR makes new writes correct going forward. Cleanup of existing drift can be done with `pnpm sync-admin suggest drift` from #1708.

## Test plan

- [x] Added invariant test in `api/sync/layouts/[id].test.ts`: PUT a layout with extra fields the validator drops, then assert `entry.sizeBytes === byteLength(JSON.stringify({ layout: storedBlob.layout }))` AND that it's strictly less than the raw request size.
- [x] Added the same invariant test in `api/sync/designs/[id].test.ts` (covering the design wrapper's `{ name, type, version, params }` shape).
- [x] Existing 30 sync handler tests still pass.
- [x] `pnpm typecheck` clean.
- [x] Pre-commit hooks pass (boundaries, i18n, exhaustiveness, component structure, missing-tests, README reminders).
- [x] README updated: `api/sync/README.md` now documents that `sizeBytes` is post-sanitization and that the size cap uses request bytes separately.