### PR TITLE
feat(seo): add FAQPage and BreadcrumbList schema to /guide and /what-is-gridfinity

### DIFF
--- a/content/guide.md
+++ b/content/guide.md
@@ -3,6 +3,28 @@ title: How to Plan a Gridfinity Drawer Layout
 description: A practical guide to planning Gridfinity drawer layouts. Measure your drawer, figure out what bins you need, and export a print list.
 keywords: gridfinity planner, gridfinity layout, how to plan gridfinity, drawer organizer planning, gridfinity guide
 schema: HowTo
+breadcrumbs:
+  - name: Home
+    url: https://gridfinitylayouttool.com/
+  - name: Planning Guide
+    url: https://gridfinitylayouttool.com/guide
+faqs:
+  - q: How do I measure a drawer for Gridfinity?
+    a: Measure the inside dimensions of the drawer in millimeters — width (left to right), depth (front to back), and clearance height (bottom to top with the drawer closed). Take measurements at several spots since drawers are rarely perfect rectangles, and use the smallest value for each dimension to be safe.
+  - q: How do I convert drawer dimensions to Gridfinity grid units?
+    a: Divide each dimension by 42mm and round down. For example, a 380mm × 260mm drawer fits a 9×6 grid (378mm × 252mm), leaving small gaps at the edges. The gaps are fine — baseplates don't need to fill every millimeter.
+  - q: What bin sizes should I use for Gridfinity?
+    a: As a starting point — 1×1 with dividers for small screws and components; 1×2 or 2×2 for pens, USB drives, and batteries; 1×3 or 1×4 for screwdrivers and pliers; 2×2 or 2×3 for tape and glue; 3×3 or larger for big tools. You can always print different sizes later if something doesn't fit right.
+  - q: How tall can a Gridfinity bin be?
+    a: Bin height is limited only by your drawer's clearance and your printer's Z height. Heights are measured in 7mm units (U). A 6U bin is 42mm tall internally, a 9U bin is 63mm tall. Check your tallest bin plus 5mm for the baseplate against the drawer's closed clearance before printing.
+  - q: Should I use multiple layers in deep drawers?
+    a: Yes, if you have height clearance. Stack bins vertically with layer 1 on the bottom. Keep heavy items on the bottom, frequently-used items on top. This works well for separating flat items (cables) from tall bins, or for keeping electrical separate from mechanical.
+  - q: How do I export a Gridfinity print list?
+    a: Once your layout is done in the tool, the print list shows every bin size, the quantity needed, filament estimates in grams, and search links for each size on Printables, Thangs, and MakerWorld. You can also generate custom bins directly with the built-in bin generator and export STL, STEP, or 3MF files.
+  - q: How much empty space should I leave in a Gridfinity drawer?
+    a: Leave 10-20% empty space. A drawer that's 100% planned today becomes a problem tomorrow when your collection grows or your needs change. Empty grid squares cost nothing and give you room to add bins later.
+  - q: What is the best printer for Gridfinity?
+    a: Any FDM printer with at least a 256mm × 256mm bed prints Gridfinity bins comfortably. Bambu Lab X1, A1, and P1S are popular for their speed. Prusa MK4 and Ender 3 V3 KE also work well. For drawers larger than 6×6 grid units you'll want to either tile baseplates or use a larger-format printer like the Bambu X1E or a Voron 2.4.
 ---
 
 # How to Plan a Gridfinity Drawer Layout

--- a/content/what-is-gridfinity.md
+++ b/content/what-is-gridfinity.md
@@ -3,6 +3,30 @@ title: What is Gridfinity?
 description: Gridfinity is a free, open-source 3D-printed storage system. Learn how the 42mm grid works and why makers use it.
 keywords: gridfinity, what is gridfinity, drawer organizer, 3D printing, modular storage, Zack Freedman
 schema: Article
+breadcrumbs:
+  - name: Home
+    url: https://gridfinitylayouttool.com/
+  - name: What is Gridfinity?
+    url: https://gridfinitylayouttool.com/what-is-gridfinity
+faqs:
+  - q: What is a Gridfinity bin?
+    a: A Gridfinity bin is a 3D-printed storage container that sits on a Gridfinity baseplate. Bins come in grid sizes (1×1, 2×2, 3×1, etc., where 1 unit equals 42mm) and heights measured in 7mm increments. The profiled base mates with the baseplate pattern so bins stay put when you open the drawer but lift out easily.
+  - q: How big is a Gridfinity unit?
+    a: One Gridfinity grid unit is 42mm × 42mm. Heights use a separate 7mm increment, often called "U". So a 2×2 bin with height 3U is roughly 84mm × 84mm × 21mm internal.
+  - q: What is the difference between a Gridfinity bin and a baseplate?
+    a: Baseplates are flat tiles that go in your drawer and form the 42mm grid. Bins are the containers that hold your stuff and rest on the baseplate's pattern. You print baseplates once to cover the drawer, then print whatever bins you need on top.
+  - q: What filament should I use for Gridfinity bins?
+    a: PLA is the standard choice and what most community designs are optimized for. PETG works well if you want more durability or impact resistance. ASA or ABS make sense if the bins live somewhere warm (garage, attic). Avoid PLA in hot cars.
+  - q: How much filament does a Gridfinity bin use?
+    a: A typical 2×2 bin uses about 20-40 grams of PLA depending on height and infill. A 1×1 bin is around 8-15g. Baseplates are heavier per unit — roughly 25-30g per grid unit.
+  - q: How long does a Gridfinity bin take to print?
+    a: A 2×2 bin runs about 1-2 hours at standard speeds (50-80 mm/s). Bambu Lab and other fast printers cut this to 20-40 minutes. Baseplates take longer per unit because of the surface area.
+  - q: Do Gridfinity bins fall out when you open the drawer?
+    a: No. The baseplate's raised pattern creates enough friction to hold bins in place during normal drawer use. They're not locked, so you can lift them straight up to remove them, but they don't slide around when you open or close the drawer.
+  - q: Can I buy Gridfinity bins instead of printing them?
+    a: Yes — many sellers offer pre-printed bins on Etsy, Amazon, and direct-from-maker shops. It's an option if you don't have a 3D printer, though printing yourself is usually cheaper per bin once you account for shipping.
+  - q: Is Gridfinity free?
+    a: Yes. Gridfinity is open-source. The community designs are free to download from Printables, Thangs, and MakerWorld. Your only cost is filament.
 ---
 
 # What is Gridfinity?
@@ -48,24 +72,6 @@ Search for what you need (e.g., "gridfinity 2x2 battery holder") and you'll find
 3. **A plan.** How many grid units fit, what bins you need, where they go.
 
 This tool helps with step 3. Mock up your layout, see how everything fits, then export a list of what to print. You can also [generate custom bins](/gridfinity-bin-generator) with STL, STEP, and 3MF export directly in your browser.
-
-## Common Questions
-
-### What filament should I use?
-
-PLA for most things. PETG if you want more durability. ASA if it's going somewhere hot.
-
-### How long do bins take to print?
-
-A 2×2 bin runs about 1-2 hours depending on height and your printer speed.
-
-### Can I buy pre-printed bins?
-
-Yes, people sell them on Etsy. It's an option if you don't have a printer.
-
-### Do bins fall out when you open the drawer?
-
-No. The baseplate pattern creates enough friction to hold them in place during normal use. They're not locked down, so you can lift them out, but they don't slide around.
 
 ## Next Step
 

--- a/public/content.css
+++ b/public/content.css
@@ -24,7 +24,8 @@
   --color-accent-hover: #fbbf24;
 
   /* Typography */
-  --font-sans: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-sans:
+    'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 
   /* Spacing */
@@ -44,7 +45,9 @@
 /* ===========================================
    BASE RESET & DEFAULTS
    =========================================== */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
@@ -214,8 +217,8 @@ body {
 }
 
 /* External links get a subtle indicator */
-.content-body a[target="_blank"]::after {
-  content: " ↗";
+.content-body a[target='_blank']::after {
+  content: ' ↗';
   font-size: 0.75em;
   opacity: 0.7;
 }
@@ -339,6 +342,116 @@ body {
   background-color: var(--color-surface);
   border-radius: 4px;
   color: var(--color-accent);
+}
+
+/* ===========================================
+   BREADCRUMBS
+   =========================================== */
+.content-breadcrumbs {
+  margin-bottom: var(--space-xl);
+  font-size: 0.875rem;
+}
+
+.content-breadcrumbs__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  color: var(--color-content-tertiary);
+}
+
+.content-breadcrumbs__item {
+  display: inline-flex;
+  align-items: center;
+}
+
+.content-breadcrumbs__item:not(:last-child)::after {
+  content: '/';
+  margin-left: var(--space-xs);
+  color: var(--color-content-disabled);
+}
+
+.content-breadcrumbs__item a {
+  color: var(--color-content-tertiary);
+  text-decoration: none;
+}
+
+.content-breadcrumbs__item a:hover {
+  color: var(--color-accent);
+}
+
+.content-breadcrumbs__item a:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.content-breadcrumbs__item[aria-current='page'] {
+  color: var(--color-content);
+}
+
+/* ===========================================
+   FAQ ACCORDION
+   =========================================== */
+.content-faqs {
+  margin-top: var(--space-2xl);
+}
+
+.content-faq {
+  border-bottom: 1px solid var(--color-stroke-subtle);
+  padding: var(--space-md) 0;
+}
+
+.content-faq:first-of-type {
+  border-top: 1px solid var(--color-stroke-subtle);
+}
+
+.content-faq__question {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-content);
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.content-faq__question::-webkit-details-marker {
+  display: none;
+}
+
+.content-faq__question::after {
+  content: '+';
+  font-size: 1.25rem;
+  font-weight: 400;
+  color: var(--color-content-tertiary);
+  transition: transform 0.15s ease;
+}
+
+.content-faq[open] .content-faq__question::after {
+  content: '−';
+}
+
+.content-faq__question:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.content-faq__answer {
+  margin-top: var(--space-sm);
+  color: var(--color-content-secondary);
+  line-height: 1.6;
+}
+
+.content-faq__answer a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 /* ===========================================

--- a/public/content.css
+++ b/public/content.css
@@ -424,6 +424,10 @@ body {
   display: none;
 }
 
+.content-faq__question::marker {
+  content: '';
+}
+
 .content-faq__question::after {
   content: '+';
   font-size: 1.25rem;

--- a/public/gridfinity-baseplate-generator/index.html
+++ b/public/gridfinity-baseplate-generator/index.html
@@ -185,7 +185,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.9609870d.css">
+  <link rel="stylesheet" href="/content.40582006.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/public/gridfinity-baseplate-generator/index.html
+++ b/public/gridfinity-baseplate-generator/index.html
@@ -185,7 +185,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.40582006.css">
+  <link rel="stylesheet" href="/content.4b35985d.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/public/gridfinity-bin-generator/index.html
+++ b/public/gridfinity-bin-generator/index.html
@@ -181,7 +181,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.40582006.css">
+  <link rel="stylesheet" href="/content.4b35985d.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/public/gridfinity-bin-generator/index.html
+++ b/public/gridfinity-bin-generator/index.html
@@ -181,7 +181,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.9609870d.css">
+  <link rel="stylesheet" href="/content.40582006.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/public/gridfinity-sizes/index.html
+++ b/public/gridfinity-sizes/index.html
@@ -119,7 +119,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.40582006.css">
+  <link rel="stylesheet" href="/content.4b35985d.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/public/gridfinity-sizes/index.html
+++ b/public/gridfinity-sizes/index.html
@@ -119,7 +119,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.9609870d.css">
+  <link rel="stylesheet" href="/content.40582006.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -54,7 +54,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.9609870d.css">
+  <link rel="stylesheet" href="/content.40582006.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -54,7 +54,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.40582006.css">
+  <link rel="stylesheet" href="/content.4b35985d.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/public/terms/index.html
+++ b/public/terms/index.html
@@ -54,7 +54,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.9609870d.css">
+  <link rel="stylesheet" href="/content.40582006.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/public/terms/index.html
+++ b/public/terms/index.html
@@ -54,7 +54,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.40582006.css">
+  <link rel="stylesheet" href="/content.4b35985d.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -19,24 +19,35 @@ const SITE_URL = 'https://gridfinitylayouttool.com';
 // Will be set during build after hashing the CSS
 let cssFilename = 'content.css';
 
+interface FaqEntry {
+  q: string;
+  a: string;
+}
+
+interface BreadcrumbEntry {
+  name: string;
+  url: string;
+}
+
 interface Frontmatter {
   title: string;
   description: string;
   keywords?: string;
   ogImage?: string;
   schema?: 'Article' | 'HowTo';
+  faqs?: FaqEntry[];
+  breadcrumbs?: BreadcrumbEntry[];
 }
 
 /**
  * Generate the HTML template for a content page
  */
 function generateHtml(content: string, frontmatter: Frontmatter, slug: string): string {
-  const { title, description, keywords, ogImage, schema } = frontmatter;
+  const { title, description, keywords, ogImage, schema, faqs, breadcrumbs } = frontmatter;
   const canonicalUrl = `${SITE_URL}/${slug}`;
   const image = ogImage || `${SITE_URL}/og-image.png`;
 
-  // Generate structured data based on schema type
-  const structuredData =
+  const primarySchema =
     schema === 'HowTo'
       ? {
           '@context': 'https://schema.org',
@@ -73,6 +84,47 @@ function generateHtml(content: string, frontmatter: Frontmatter, slug: string): 
           },
         };
 
+  const structuredDataBlocks: object[] = [primarySchema];
+
+  if (breadcrumbs && breadcrumbs.length > 0) {
+    structuredDataBlocks.push({
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: breadcrumbs.map((crumb, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: crumb.name,
+        item: crumb.url,
+      })),
+    });
+  }
+
+  if (faqs && faqs.length > 0) {
+    structuredDataBlocks.push({
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: faqs.map((faq) => ({
+        '@type': 'Question',
+        name: faq.q,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: faq.a,
+        },
+      })),
+    });
+  }
+
+  const structuredDataScripts = structuredDataBlocks
+    .map(
+      (block) => `  <script type="application/ld+json">
+${safeJsonLd(block)}
+  </script>`
+    )
+    .join('\n');
+
+  const breadcrumbsHtml = renderBreadcrumbs(breadcrumbs);
+  const faqsHtml = renderFaqs(faqs);
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -103,9 +155,7 @@ function generateHtml(content: string, frontmatter: Frontmatter, slug: string): 
   <meta name="twitter:image" content="${image}">
 
   <!-- Structured Data -->
-  <script type="application/ld+json">
-${safeJsonLd(structuredData)}
-  </script>
+${structuredDataScripts}
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -144,7 +194,7 @@ ${safeJsonLd(structuredData)}
 
   <!-- Main Content -->
   <main id="main-content" class="content-page content-body">
-${content}
+${breadcrumbsHtml}${content}${faqsHtml}
   </main>
 
   <!-- Footer -->
@@ -187,6 +237,44 @@ function escapeHtml(str: string): string {
  */
 function safeJsonLd(data: object): string {
   return JSON.stringify(data, null, 2).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
+}
+
+function renderBreadcrumbs(breadcrumbs: BreadcrumbEntry[] | undefined): string {
+  if (!breadcrumbs || breadcrumbs.length === 0) return '';
+  const items = breadcrumbs
+    .map((crumb, index) => {
+      const isLast = index === breadcrumbs.length - 1;
+      const name = escapeHtml(crumb.name);
+      if (isLast) {
+        return `      <li class="content-breadcrumbs__item" aria-current="page">${name}</li>`;
+      }
+      return `      <li class="content-breadcrumbs__item"><a href="${escapeHtml(crumb.url)}">${name}</a></li>`;
+    })
+    .join('\n');
+  return `<nav class="content-breadcrumbs" aria-label="Breadcrumb">
+    <ol class="content-breadcrumbs__list">
+${items}
+    </ol>
+  </nav>
+`;
+}
+
+function renderFaqs(faqs: FaqEntry[] | undefined): string {
+  if (!faqs || faqs.length === 0) return '';
+  const items = faqs
+    .map(
+      (faq) => `    <details class="content-faq">
+      <summary class="content-faq__question">${escapeHtml(faq.q)}</summary>
+      <div class="content-faq__answer">${marked.parseInline(faq.a) as string}</div>
+    </details>`
+    )
+    .join('\n');
+  return `
+  <section class="content-faqs" aria-labelledby="faq-heading">
+    <h2 id="faq-heading" class="content-h2">Frequently Asked Questions</h2>
+${items}
+  </section>
+`;
 }
 
 /**

--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -99,16 +99,21 @@ function generateHtml(content: string, frontmatter: Frontmatter, slug: string): 
     });
   }
 
-  if (faqs && faqs.length > 0) {
+  const renderedFaqs = faqs?.map((faq) => ({
+    q: faq.q,
+    answerHtml: marked.parseInline(escapeHtml(faq.a)) as string,
+  }));
+
+  if (renderedFaqs && renderedFaqs.length > 0) {
     structuredDataBlocks.push({
       '@context': 'https://schema.org',
       '@type': 'FAQPage',
-      mainEntity: faqs.map((faq) => ({
+      mainEntity: renderedFaqs.map((faq) => ({
         '@type': 'Question',
         name: faq.q,
         acceptedAnswer: {
           '@type': 'Answer',
-          text: faq.a,
+          text: faq.answerHtml,
         },
       })),
     });
@@ -123,7 +128,7 @@ ${safeJsonLd(block)}
     .join('\n');
 
   const breadcrumbsHtml = renderBreadcrumbs(breadcrumbs);
-  const faqsHtml = renderFaqs(faqs);
+  const faqsHtml = renderFaqs(renderedFaqs);
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -259,13 +264,18 @@ ${items}
 `;
 }
 
-function renderFaqs(faqs: FaqEntry[] | undefined): string {
+interface RenderedFaq {
+  q: string;
+  answerHtml: string;
+}
+
+function renderFaqs(faqs: RenderedFaq[] | undefined): string {
   if (!faqs || faqs.length === 0) return '';
   const items = faqs
     .map(
       (faq) => `    <details class="content-faq">
       <summary class="content-faq__question">${escapeHtml(faq.q)}</summary>
-      <div class="content-faq__answer">${marked.parseInline(faq.a) as string}</div>
+      <div class="content-faq__answer">${faq.answerHtml}</div>
     </details>`
     )
     .join('\n');


### PR DESCRIPTION
## Summary

Closes the last two landing-page gaps in our rich-result schema coverage.

After a per-page audit, only `/guide` and `/what-is-gridfinity` were missing FAQPage and BreadcrumbList — every other landing page (`/`, `/gridfinity-generator`, `/gridfinity-bin-generator`, `/gridfinity-baseplate-generator`, `/gridfinity-sizes`) already shipped SoftwareApplication + FAQPage + BreadcrumbList + HowTo.

`scripts/build-content.ts` now supports `faqs` and `breadcrumbs` arrays in markdown frontmatter:

- **Breadcrumbs** render as a visible `<nav aria-label="Breadcrumb">` at the top of the page + matching `BreadcrumbList` JSON-LD.
- **FAQs** render as a visible `<details>` accordion section at the bottom of the page + matching `FAQPage` JSON-LD.
- Both visible HTML and JSON-LD are generated from the same frontmatter source so Google's "schema must match the visible content" requirement can't drift.

8 FAQs added to `/guide` (measuring, grid units, bin sizes, layers, print lists, empty space, printers).
9 FAQs added to `/what-is-gridfinity` (what a bin is, grid units, bin vs baseplate, filament, weight, print time, drawer behavior, buying vs printing, cost).

## Test plan

- [x] `pnpm exec tsx scripts/build-content.ts` succeeds
- [x] All JSON-LD blocks on the two pages parse as valid JSON
- [x] Each FAQ entry has a matching `<details>`/`<summary>`/answer DOM node
- [x] Existing `Article` and `HowTo` schemas preserved on the two pages
- [x] All other pages unaffected (only their `content.<hash>.css` reference bumped)
- [x] Pre-commit hooks (boundaries, i18n × 3, exhaustiveness, component structure, missing tests) pass
- [ ] Google Rich Results Test confirms FAQPage + BreadcrumbList on the two URLs after deploy
- [ ] Search Console shows no schema validation errors after the next crawl