### PR TITLE
feat(seo): add de/fr/es/pt-BR locales for /what-is-gridfinity and /guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,9 +54,13 @@ scripts/train-bin-recommender/.env*
 scripts/train-bin-recommender/__pycache__/
 scripts/train-bin-recommender/.venv/
 
-# Generated content pages (built from content/*.md)
+# Generated content pages (built from content/*.md and content/{locale}/*.md)
 public/what-is-gridfinity/
 public/guide/
+public/de/
+public/fr/
+public/es/
+public/pt-BR/
 public/content.*.css
 
 # Generated English locale JSON (source of truth is en.ts)

--- a/content/de/guide.md
+++ b/content/de/guide.md
@@ -1,0 +1,144 @@
+---
+title: Eine Gridfinity-Schublade planen — Anleitung
+description: Praktischer Leitfaden zum Planen von Gridfinity-Schubladenlayouts. Schublade ausmessen, passende Bins bestimmen und eine Druckliste exportieren.
+keywords: gridfinity planer, gridfinity layout, gridfinity planen, schubladeneinsatz planen, gridfinity anleitung
+schema: HowTo
+breadcrumbs:
+  - name: Start
+    url: https://gridfinitylayouttool.com/de/
+  - name: Planungsleitfaden
+    url: https://gridfinitylayouttool.com/de/guide
+faqs:
+  - q: Wie messe ich eine Schublade für Gridfinity aus?
+    a: Miss die Innenmaße der Schublade in Millimetern — Breite (links nach rechts), Tiefe (vorn nach hinten) und Höhe (vom Boden bis zur geschlossenen Decke). Miss an mehreren Stellen, weil Schubladen selten exakte Rechtecke sind, und nimm pro Dimension den kleinsten Wert, um sicherzugehen.
+  - q: Wie rechne ich Schubladenmaße in Gridfinity-Rastereinheiten um?
+    a: Teile jede Dimension durch 42 mm und runde ab. Eine 380 mm × 260 mm große Schublade fasst zum Beispiel ein 9×6-Raster (378 mm × 252 mm) — kleine Lücken am Rand bleiben. Das ist in Ordnung, Grundplatten müssen nicht jeden Millimeter füllen.
+  - q: Welche Bin-Größen sollte ich für Gridfinity nehmen?
+    a: Als Ausgangspunkt — 1×1 mit Trennstegen für kleine Schrauben und Bauteile; 1×2 oder 2×2 für Stifte, USB-Sticks und Batterien; 1×3 oder 1×4 für Schraubendreher und Zangen; 2×2 oder 2×3 für Klebeband und Kleber; 3×3 oder größer für großes Werkzeug. Du kannst später jederzeit andere Größen drucken, falls etwas nicht passt.
+  - q: Wie hoch kann ein Gridfinity-Bin sein?
+    a: Die Höhe ist nur durch die Schubladenhöhe und den Z-Aufbauraum deines Druckers begrenzt. Höhen werden in 7-mm-Einheiten (U) gemessen. Ein 6U-Bin ist innen 42 mm hoch, ein 9U-Bin 63 mm. Prüfe vor dem Druck deinen höchsten Bin plus 5 mm für die Grundplatte gegen die Schubladenhöhe im geschlossenen Zustand.
+  - q: Sollte ich mehrere Ebenen in tiefen Schubladen nutzen?
+    a: Ja, falls Höhe zur Verfügung steht. Stapele Bins vertikal mit Ebene 1 unten. Schweres unten, häufig Genutztes oben. Funktioniert gut, um Flaches (Kabel) von hohen Bins zu trennen oder Elektrik und Mechanik auseinanderzuhalten.
+  - q: Wie exportiere ich eine Gridfinity-Druckliste?
+    a: Sobald dein Layout fertig ist, zeigt die Druckliste jede Bin-Größe, die benötigte Anzahl, Filamentschätzungen in Gramm und Such-Links für jede Größe auf Printables, Thangs und MakerWorld. Du kannst auch Custom-Bins direkt im integrierten Bin-Generator erzeugen und als STL-, STEP- oder 3MF-Datei exportieren.
+  - q: Wie viel Leerraum sollte ich in einer Gridfinity-Schublade lassen?
+    a: Lass 10–20 % frei. Eine heute zu 100 % verplante Schublade wird zum Problem, sobald deine Sammlung wächst oder sich der Bedarf ändert. Leere Rasterfelder kosten nichts und geben Spielraum für später.
+  - q: Welcher Drucker ist der beste für Gridfinity?
+    a: Jeder FDM-Drucker mit mindestens 256 mm × 256 mm Druckbett druckt Gridfinity-Bins problemlos. Bambu Lab X1, A1 und P1S sind wegen ihrer Geschwindigkeit beliebt. Prusa MK4 und Ender 3 V3 KE funktionieren ebenfalls gut. Für Schubladen größer als 6×6 Einheiten kachelst du entweder die Grundplatten oder nimmst einen Drucker mit größerem Format wie Bambu X1E oder Voron 2.4.
+---
+
+# Eine Gridfinity-Schublade planen — Anleitung
+
+Drucken ohne Plan verschwendet Filament. Du druckst Bins nach, weil du Größen falsch geschätzt hast, lässt ungewollte Lücken oder vergisst, was du eigentlich brauchst. Diese Anleitung zeigt, wie du vor dem Druck misst, planst und eine Druckliste bekommst.
+
+## Schublade ausmessen
+
+Hol dir die Innenmaße in Millimetern. Du brauchst:
+
+- **Breite** — links nach rechts
+- **Tiefe** — vorn nach hinten
+- **Höhe** — Boden bis Decke (Freiraum bei geschlossener Schublade)
+
+Miss an mehreren Stellen. Schubladen sind selten exakte Rechtecke, besonders bei älteren Möbeln. Nimm zur Sicherheit den kleinsten Wert.
+
+### In Rastereinheiten umrechnen
+
+Gridfinity nutzt 42-mm-Einheiten. Teilen und abrunden:
+
+```text
+Breite: 380 mm ÷ 42 = 9,04 → 9 Einheiten
+Tiefe:  260 mm ÷ 42 = 6,19 → 6 Einheiten
+```
+
+Ein 9×6-Raster sind 378 mm × 252 mm. Du hast kleine Lücken am Rand — das ist okay. Grundplatten müssen nicht jeden Millimeter füllen.
+
+## Klären, was reinkommt
+
+Den Schritt überspringen die meisten — und bereuen es.
+
+Nimm alles aus der Schublade. Gruppieren:
+
+- Tägliche Sachen
+- Wöchentliche Sachen
+- Zeug, das du vergessen hattest
+
+Das Tägliche muss greifbar sein. Das Wöchentliche kann nach hinten. Das Vergessene braucht vielleicht gar keinen Bin.
+
+### Gegenstände den Bin-Größen zuordnen
+
+Grobe Richtwerte:
+
+| Inhalt                        | Bin-Größe         |
+| ----------------------------- | ----------------- |
+| M3-Schrauben, Kleinteile      | 1×1 mit Trennsteg |
+| Stifte, USB-Sticks, Batterien | 1×2 oder 2×2      |
+| Schraubendreher, Zangen       | 1×3 oder 1×4      |
+| Klebeband, Klebeflaschen      | 2×2 oder 2×3      |
+| Großes Werkzeug               | 3×3 oder größer   |
+
+Verbeiß dich nicht — du kannst später immer andere Bins drucken.
+
+## Das Layout planen
+
+Öffne das Tool und stelle die Rastergröße ein. Ziehe Bins auf. Das Tool verhindert Überlappung und Überlauf.
+
+**Häufig Benutztes nach vorn.** Was greifst du beim Öffnen zuerst? Das gehört nach vorn.
+
+**Zusammengehöriges gruppieren.** Schraubendreher an einer Stelle, Messwerkzeug an einer anderen. Du erinnerst dich später leichter.
+
+**Etwas Leerraum lassen.** Deine Sammlung wächst. Eine heute zu 100 % verplante Schublade ist morgen ein Problem.
+
+### Ebenen für tiefe Schubladen
+
+Bei genug Höhe kannst du Bins vertikal stapeln. Ebene 1 ist unten.
+
+Funktioniert gut für:
+
+- Flaches unten (Kabel, Kleinteile), höhere Bins darüber
+- Elektrik und Mechanik trennen
+
+Schweres unten, häufig Genutztes oben.
+
+## Druckliste exportieren
+
+Wenn das Layout sitzt, exportierst du eine Druckliste:
+
+- Jede Bin-Größe mit Stückzahl
+- Filamentschätzung in Gramm
+- Such-Links pro Größe
+
+### STL-Dateien finden
+
+Du kannst [Custom-Bins generieren](/de/gridfinity-bin-generator) — direkt im integrierten Bin-Generator: Maße wählen, Boden, Kompartimente, dann als STL, STEP oder 3MF exportieren.
+
+Für Spezialbins (werkzeugspezifische Halter, komplexe Formen) durchsuche die Community-Quellen:
+
+- [Printables](https://www.printables.com/search/models?q=gridfinity) — größte Auswahl
+- [Thangs](https://thangs.com/search/gridfinity) — gut für ähnliche Designs
+- [MakerWorld](https://makerworld.com/en/search/models?keyword=gridfinity) — Bambu-Lab-Community
+
+Beispielsuche: „gridfinity 2x2 3U“ findet 2×2-Bins mit 3 Höheneinheiten.
+
+## Vor dem Druck
+
+### Erst mit Pappe testen
+
+> Schneide Pappe auf deine Bin-Größen (42 mm pro Rastereinheit) und ordne sie in der Schublade an. Fühlt sich etwas falsch an, hast du noch kein Filament verbraucht.
+
+### Erst einen Bin drucken
+
+Druck einen Bin, bevor du 20 druckst. Prüfe Passung, Höhe und Designgefühl. Passe Druckereinstellungen bei Bedarf an.
+
+### Höhe prüfen
+
+Dein höchster Bin plus Grundplatte (etwa 5 mm) muss in die geschlossene Schublade passen. Vor dem Druck hoher Bins prüfen.
+
+## Häufige Fehler
+
+**Zu viele winzige Bins.** Ein Raster aus 1×1-Bins sieht ordentlich aus, ist aber im Alltag nervig. Größere Bins mit Trennstegen sind meist besser.
+
+**Jedes Feld füllen.** Lässt keinen Platz für Neues. Plane 10–20 % Leerraum ein.
+
+**Ignorieren, was du tatsächlich nutzt.** Organisiere nicht nach Wunschvorstellung, sondern nach dem, was du wirklich greifst.
+
+[CTA: Layout-Tool öffnen](/de/)

--- a/content/de/what-is-gridfinity.md
+++ b/content/de/what-is-gridfinity.md
@@ -1,0 +1,80 @@
+---
+title: Was ist Gridfinity?
+description: Gridfinity ist ein kostenloses, quelloffenes 3D-gedrucktes Ordnungssystem. So funktioniert das 42-mm-Raster und warum Maker es nutzen.
+keywords: gridfinity, was ist gridfinity, schubladeneinsatz, 3D-Druck, modulares Ordnungssystem, Zack Freedman
+schema: Article
+breadcrumbs:
+  - name: Start
+    url: https://gridfinitylayouttool.com/de/
+  - name: Was ist Gridfinity?
+    url: https://gridfinitylayouttool.com/de/what-is-gridfinity
+faqs:
+  - q: Was ist ein Gridfinity-Bin?
+    a: Ein Gridfinity-Bin ist ein 3D-gedruckter Aufbewahrungsbehälter, der auf einer Gridfinity-Grundplatte sitzt. Bins gibt es in Rastergrößen (1×1, 2×2, 3×1 usw., wobei 1 Einheit 42 mm entspricht) und in Höhen in 7-mm-Schritten. Der profilierte Boden greift in das Muster der Grundplatte, sodass die Bins beim Öffnen der Schublade an Ort und Stelle bleiben, sich aber leicht herausnehmen lassen.
+  - q: Wie groß ist eine Gridfinity-Einheit?
+    a: Eine Gridfinity-Rastereinheit misst 42 mm × 42 mm. Für die Höhe gilt ein eigenes 7-mm-Inkrement, oft als „U“ bezeichnet. Ein 2×2-Bin mit 3U Höhe ist also etwa 84 mm × 84 mm × 21 mm innen.
+  - q: Was ist der Unterschied zwischen einem Gridfinity-Bin und einer Grundplatte?
+    a: Grundplatten sind flache Kacheln, die in die Schublade gelegt werden und das 42-mm-Raster bilden. Bins sind die Behälter, die deine Sachen aufnehmen und auf dem Muster der Grundplatte ruhen. Die Grundplatten druckst du einmal aus, danach beliebige Bins darauf.
+  - q: Welches Filament eignet sich für Gridfinity-Bins?
+    a: PLA ist die Standardwahl und für die meisten Community-Designs optimiert. PETG bietet mehr Schlagfestigkeit und Haltbarkeit. ASA oder ABS sind sinnvoll, wenn die Bins an warmen Orten liegen (Garage, Dachboden). PLA gehört nicht ins heiße Auto.
+  - q: Wie viel Filament verbraucht ein Gridfinity-Bin?
+    a: Ein typischer 2×2-Bin braucht etwa 20–40 Gramm PLA, je nach Höhe und Infill. Ein 1×1-Bin liegt bei 8–15 g. Grundplatten sind pro Einheit schwerer — etwa 25–30 g pro Rastereinheit.
+  - q: Wie lange dauert der Druck eines Gridfinity-Bins?
+    a: Ein 2×2-Bin braucht etwa 1–2 Stunden bei Standardgeschwindigkeit (50–80 mm/s). Bambu Lab und andere schnelle Drucker schaffen es in 20–40 Minuten. Grundplatten dauern pro Einheit länger, da sie mehr Fläche bedecken.
+  - q: Fallen Gridfinity-Bins beim Öffnen der Schublade heraus?
+    a: Nein. Das Muster der Grundplatte erzeugt genug Reibung, um die Bins bei normaler Schubladennutzung an Ort und Stelle zu halten. Sie sind nicht verriegelt — du hebst sie einfach gerade nach oben heraus — verrutschen aber nicht beim Auf- oder Zumachen.
+  - q: Kann ich Gridfinity-Bins kaufen, statt sie zu drucken?
+    a: Ja — viele Anbieter verkaufen fertig gedruckte Bins auf Etsy, Amazon oder direkt vom Maker. Eine Option ohne 3D-Drucker, allerdings ist Selberdrucken nach Versand meist günstiger pro Bin.
+  - q: Ist Gridfinity kostenlos?
+    a: Ja. Gridfinity ist quelloffen. Die Community-Designs lassen sich kostenlos von Printables, Thangs und MakerWorld herunterladen. Du zahlst nur das Filament.
+---
+
+# Was ist Gridfinity?
+
+Gridfinity ist ein modulares Ordnungssystem, das du selbst in 3D ausdruckst. Zack Freedman, ein Maker und YouTuber, hat es 2022 veröffentlicht. Allein auf Printables gibt es inzwischen über 10.000 kostenlose Designs.
+
+Die Idee ist einfach: Alles basiert auf einem 42-mm-Raster. Bins ruhen auf Grundplatten. Grundplatten lassen sich kacheln, um jede Schublade zu füllen. Wenn du neu sortieren willst, hebst du die Bins einfach heraus und verschiebst sie.
+
+## So funktioniert es
+
+Ein Gridfinity-Aufbau besteht aus zwei Teilen:
+
+**Grundplatten** kommen in deine Schublade. Es sind flache Raster mit einem erhabenen Muster, das die Bins fixiert. Du kachelst sie, um die vorhandene Fläche abzudecken.
+
+**Bins** nehmen deine Sachen auf. Sie gibt es in Rastergrößen (1×1, 2×2, 3×1 usw.) und in Höhen in 7-mm-Schritten. Ein 3U-Bin bietet etwa 21 mm Innenhöhe.
+
+Die Bins haben einen profilierten Boden, der ins Muster der Grundplatte greift. Sie bleiben beim Öffnen der Schublade liegen, lassen sich aber leicht herausnehmen, wenn du sie brauchst.
+
+## Warum Leute es nutzen
+
+**Du druckst genau das, was du brauchst.** Kein 12er-Pack kaufen, wenn du nur 2 brauchst. Keine Suche nach der passenden Größe. Wenn es einen Bin für deine speziellen Bohrer oder Schrauben gibt, druckst du ihn.
+
+**Alles ist kompatibel.** Ein 2×2-Bin von Designer A passt auf die Grundplatte von Designer B. Jedes Design folgt derselben Spezifikation.
+
+**Es ist kostenlos.** Die Designs sind Open Source. Die einzigen Kosten sind das Filament. Ein typischer Bin braucht 20–40 Gramm PLA.
+
+## Designs finden
+
+Die Community hat Bins für die meisten Bedarfe gemacht: Schraubendreherhalter, Batterieordnungen, Bohreraufnahmen, Kabelmanagement.
+
+Die wichtigsten Quellen:
+
+- [Printables](https://www.printables.com/search/models?q=gridfinity) — größte Auswahl, gute Filter
+- [Thangs](https://thangs.com/search/gridfinity) — Suche nach ähnlicher Form
+- [MakerWorld](https://makerworld.com/en/search/models?keyword=gridfinity) — beliebt bei Bambu-Besitzern
+
+Suche nach dem, was du brauchst (z. B. „gridfinity 2x2 battery holder“), und du findest Optionen.
+
+## Was du zum Start brauchst
+
+1. **Einen 3D-Drucker.** Jeder FDM-Drucker funktioniert. PLA ist Standard.
+2. **Maße.** Die Innenmaße deiner Schublade in Millimetern. Siehe die [Größenübersicht](/gridfinity-sizes) für die Umrechnung.
+3. **Einen Plan.** Wie viele Rastereinheiten passen rein, welche Bins du brauchst, wo sie hingehören.
+
+Dieses Tool hilft bei Schritt 3. Mock dein Layout, sieh, wie alles passt, und exportiere eine Druckliste. Du kannst auch [Custom-Bins generieren](/gridfinity-bin-generator) und direkt im Browser als STL, STEP oder 3MF exportieren.
+
+## Nächster Schritt
+
+Wenn du bereit bist, eine Schublade zu planen, führt dich der Leitfaden durchs Messen, Planen und Exportieren einer Druckliste.
+
+[CTA: Zum Planungsleitfaden](/de/guide)

--- a/content/es/guide.md
+++ b/content/es/guide.md
@@ -1,0 +1,144 @@
+---
+title: Cómo planificar un cajón Gridfinity
+description: Guía práctica para planificar layouts de cajón Gridfinity. Mide tu cajón, decide qué bins necesitas y exporta una lista de impresión.
+keywords: planificador gridfinity, layout gridfinity, cómo planificar gridfinity, organizar cajón, guía gridfinity
+schema: HowTo
+breadcrumbs:
+  - name: Inicio
+    url: https://gridfinitylayouttool.com/es/
+  - name: Guía de planificación
+    url: https://gridfinitylayouttool.com/es/guide
+faqs:
+  - q: ¿Cómo mido un cajón para Gridfinity?
+    a: Mide las dimensiones interiores del cajón en milímetros — ancho (izquierda a derecha), profundidad (delante a detrás) y altura libre (del fondo al techo con el cajón cerrado). Toma varias mediciones, ya que los cajones rara vez son rectángulos perfectos, y usa el valor más pequeño de cada dimensión para ir seguro.
+  - q: ¿Cómo convierto las dimensiones del cajón a unidades de cuadrícula Gridfinity?
+    a: Divide cada dimensión entre 42 mm y redondea hacia abajo. Por ejemplo, un cajón de 380 mm × 260 mm admite una cuadrícula 9×6 (378 mm × 252 mm), dejando pequeños huecos en los bordes. Los huecos están bien — las placas base no necesitan cubrir cada milímetro.
+  - q: ¿Qué tamaños de bin usar para Gridfinity?
+    a: Como punto de partida — 1×1 con separadores para tornillos pequeños y componentes; 1×2 o 2×2 para bolígrafos, USBs y pilas; 1×3 o 1×4 para destornilladores y alicates; 2×2 o 2×3 para cinta y pegamento; 3×3 o más para herramientas grandes. Siempre puedes imprimir otros tamaños más adelante si algo no encaja.
+  - q: ¿Hasta qué altura puede tener un bin Gridfinity?
+    a: La altura solo está limitada por la altura libre de tu cajón y el eje Z de tu impresora. Las alturas se miden en unidades de 7 mm (U). Un bin 6U mide 42 mm de alto por dentro; un 9U, 63 mm. Comprueba el bin más alto más 5 mm para la placa base contra la altura libre con el cajón cerrado antes de imprimir.
+  - q: ¿Conviene usar varias capas en cajones profundos?
+    a: Sí, si tienes altura suficiente. Apila bins verticalmente con la capa 1 abajo. Lo pesado abajo, lo de uso frecuente arriba. Funciona bien para separar objetos planos (cables) de bins altos, o para mantener lo eléctrico apartado de lo mecánico.
+  - q: ¿Cómo exporto una lista de impresión Gridfinity?
+    a: Cuando termines el layout, la lista de impresión muestra cada tamaño de bin, la cantidad necesaria, las estimaciones de filamento en gramos y enlaces de búsqueda por tamaño en Printables, Thangs y MakerWorld. También puedes generar bins personalizados directamente con el generador integrado y exportar STL, STEP o 3MF.
+  - q: ¿Cuánto espacio vacío debo dejar en un cajón Gridfinity?
+    a: Deja entre un 10 y un 20 % de espacio libre. Un cajón planificado al 100 % hoy se convierte en problema mañana cuando tu colección crezca o cambien tus necesidades. Las casillas vacías no cuestan nada y dan margen para añadir bins más tarde.
+  - q: ¿Cuál es la mejor impresora para Gridfinity?
+    a: Cualquier impresora FDM con cama de al menos 256 mm × 256 mm imprime bins Gridfinity sin problema. Las Bambu Lab X1, A1 y P1S son populares por su velocidad. Prusa MK4 y Ender 3 V3 KE también funcionan bien. Para cajones por encima de 6×6 unidades, o teselas las placas base o pasas a un formato grande como Bambu X1E o Voron 2.4.
+---
+
+# Cómo planificar un cajón Gridfinity
+
+Imprimir sin un plan es desperdiciar filamento. Acabas reimprimiendo bins porque acertaste mal con los tamaños, dejando huecos no buscados u olvidando lo que querías. Esta guía cubre cómo medir, planificar y obtener una lista de impresión antes de empezar.
+
+## Mide tu cajón
+
+Saca las dimensiones interiores en milímetros. Necesitas:
+
+- **Ancho** — de izquierda a derecha
+- **Profundidad** — de delante a atrás
+- **Altura** — del fondo al techo (espacio libre con el cajón cerrado)
+
+Mide en varios puntos. Los cajones rara vez son rectángulos perfectos, sobre todo en muebles antiguos. Usa el valor más pequeño para ir sobre seguro.
+
+### Convierte a unidades de cuadrícula
+
+Gridfinity usa unidades de 42 mm. Divide y redondea hacia abajo:
+
+```text
+Ancho:        380 mm ÷ 42 = 9,04 → 9 unidades
+Profundidad:  260 mm ÷ 42 = 6,19 → 6 unidades
+```
+
+Una cuadrícula 9×6 es 378 mm × 252 mm. Tendrás pequeños huecos en los bordes — está bien. Las placas base no necesitan cubrir cada milímetro.
+
+## Decide qué guardar dentro
+
+Es el paso que casi todo el mundo se salta — y lamenta.
+
+Saca todo del cajón. Agrupa:
+
+- Cosas de uso diario
+- Cosas de uso semanal
+- Cosas que habías olvidado
+
+Lo diario tiene que estar accesible. Lo semanal puede ir al fondo. Lo olvidado quizá ni necesite bin.
+
+### Asocia objetos a tamaños de bin
+
+Pautas:
+
+| Contenido                      | Tamaño de bin       |
+| ------------------------------ | ------------------- |
+| Tornillos M3, componentes mini | 1×1 con separadores |
+| Bolígrafos, USB, pilas         | 1×2 o 2×2           |
+| Destornilladores, alicates     | 1×3 o 1×4           |
+| Cinta, pegamento               | 2×2 o 2×3           |
+| Herramientas grandes           | 3×3 o más           |
+
+No obsesionarse — siempre puedes imprimir otros bins después.
+
+## Planifica el layout
+
+Abre la herramienta y fija el tamaño de la cuadrícula. Arrastra para crear bins. La herramienta no te deja solapar ni salirte.
+
+**Lo de uso frecuente, delante.** Cuando abres el cajón, ¿qué coges primero? Eso va delante.
+
+**Agrupa lo relacionado.** Destornilladores en un sitio, herramientas de medida en otro. Recordarás dónde está cada cosa.
+
+**Deja algo de espacio vacío.** Tu colección crecerá. Un cajón planificado al 100 % hoy es un problema mañana.
+
+### Capas para cajones profundos
+
+Si tienes altura, puedes apilar bins en vertical. La capa 1 es la de abajo.
+
+Funciona bien para:
+
+- Plano abajo (cables, piezas pequeñas), bins altos encima
+- Separar lo eléctrico de lo mecánico
+
+Lo pesado abajo, lo de uso frecuente arriba.
+
+## Exporta tu lista de impresión
+
+Cuando tengas el layout listo, exporta una lista de impresión:
+
+- Cada tamaño de bin y cantidad
+- Estimaciones de filamento en gramos
+- Enlaces de búsqueda por tamaño
+
+### Encontrar archivos STL
+
+Puedes [generar bins personalizados](/es/gridfinity-bin-generator) directamente con el generador integrado — eliges dimensiones, estilo de base, compartimentos y exportas a STL, STEP o 3MF.
+
+Para bins especializados (soportes específicos, formas complejas), busca en los repositorios comunitarios:
+
+- [Printables](https://www.printables.com/search/models?q=gridfinity) — la mayor selección
+- [Thangs](https://thangs.com/search/gridfinity) — bueno para encontrar diseños similares
+- [MakerWorld](https://makerworld.com/en/search/models?keyword=gridfinity) — comunidad Bambu Lab
+
+Búsqueda de ejemplo: «gridfinity 2x2 3U» encuentra bins 2×2 de 3 unidades de altura.
+
+## Antes de imprimir
+
+### Prueba primero con cartón
+
+> Recorta cartón al tamaño de tus bins (42 mm por unidad de cuadrícula) y disponlos en el cajón. Si algo no encaja, no has gastado filamento.
+
+### Imprime un bin primero
+
+Antes de imprimir 20, imprime uno. Comprueba el ajuste, la altura y que te gusta el diseño. Ajusta la configuración de impresión si hace falta.
+
+### Verifica la altura libre
+
+El bin más alto más la placa base (unos 5 mm) tiene que entrar con el cajón cerrado. Mídelo antes de comprometerte con bins altos.
+
+## Errores comunes
+
+**Demasiados bins diminutos.** Una cuadrícula de bins 1×1 parece ordenada pero es incómoda en el uso diario. Bins más grandes con separadores suelen funcionar mejor.
+
+**Llenar cada casilla.** No deja sitio para cosas nuevas. Planifica un 10–20 % de espacio vacío.
+
+**Ignorar lo que usas de verdad.** No organices alrededor de lo que crees que «deberías» tener. Organiza alrededor de lo que realmente coges.
+
+[CTA: Abrir la herramienta de layout](/es/)

--- a/content/es/what-is-gridfinity.md
+++ b/content/es/what-is-gridfinity.md
@@ -1,0 +1,80 @@
+---
+title: ¿Qué es Gridfinity?
+description: Gridfinity es un sistema de organización impreso en 3D, libre y de código abierto. Conoce cómo funciona la cuadrícula de 42 mm y por qué los makers lo usan.
+keywords: gridfinity, qué es gridfinity, organizador de cajón, impresión 3D, almacenamiento modular, Zack Freedman
+schema: Article
+breadcrumbs:
+  - name: Inicio
+    url: https://gridfinitylayouttool.com/es/
+  - name: ¿Qué es Gridfinity?
+    url: https://gridfinitylayouttool.com/es/what-is-gridfinity
+faqs:
+  - q: ¿Qué es un bin Gridfinity?
+    a: Un bin Gridfinity es un contenedor impreso en 3D que se apoya sobre una placa base Gridfinity. Los bins vienen en tamaños de cuadrícula (1×1, 2×2, 3×1, etc., donde 1 unidad equivale a 42 mm) y en alturas en incrementos de 7 mm. Su base perfilada encaja con el patrón de la placa base, así los bins quedan fijos al abrir el cajón pero se levantan con facilidad.
+  - q: ¿Cuánto mide una unidad Gridfinity?
+    a: Una unidad de cuadrícula Gridfinity mide 42 mm × 42 mm. La altura usa un incremento aparte de 7 mm, normalmente llamado «U». Por lo tanto, un bin 2×2 de 3U de alto mide unos 84 mm × 84 mm × 21 mm por dentro.
+  - q: ¿Cuál es la diferencia entre un bin Gridfinity y una placa base?
+    a: Las placas base son las losetas planas que van en el cajón y forman la cuadrícula de 42 mm. Los bins son los contenedores que guardan tus cosas y se apoyan sobre el patrón de la placa. Imprimes las placas una vez para cubrir el cajón y luego imprimes los bins que necesites encima.
+  - q: ¿Qué filamento conviene usar para bins Gridfinity?
+    a: El PLA es la opción estándar y para la que están optimizados la mayoría de diseños comunitarios. El PETG funciona mejor si buscas mayor resistencia al impacto. El ASA o ABS tienen sentido si los bins viven en un sitio cálido (garaje, ático). Evita el PLA en un coche al sol.
+  - q: ¿Cuánto filamento gasta un bin Gridfinity?
+    a: Un bin 2×2 típico consume unos 20–40 g de PLA según altura y relleno. Un 1×1 ronda los 8–15 g. Las placas base pesan más por unidad — alrededor de 25–30 g por unidad de cuadrícula.
+  - q: ¿Cuánto tarda en imprimirse un bin Gridfinity?
+    a: Un bin 2×2 tarda entre 1 y 2 horas a velocidad estándar (50–80 mm/s). Bambu Lab y otras impresoras rápidas lo bajan a 20–40 minutos. Las placas base tardan más por unidad porque cubren más superficie.
+  - q: ¿Se caen los bins Gridfinity al abrir el cajón?
+    a: No. El patrón en relieve de la placa base genera suficiente fricción para mantener los bins fijos en el uso normal del cajón. No están bloqueados — los levantas hacia arriba para retirarlos — pero no se deslizan al abrir o cerrar el cajón.
+  - q: ¿Puedo comprar bins Gridfinity en vez de imprimirlos?
+    a: Sí — muchos vendedores ofrecen bins ya impresos en Etsy, Amazon y directamente desde los makers. Es una opción si no tienes impresora 3D, aunque imprimirlos tú suele salir más barato por bin una vez sumado el envío.
+  - q: ¿Gridfinity es gratis?
+    a: Sí. Gridfinity es de código abierto. Los diseños comunitarios se descargan gratis desde Printables, Thangs y MakerWorld. Tu único coste es el filamento.
+---
+
+# ¿Qué es Gridfinity?
+
+Gridfinity es un sistema de organización modular que tú mismo imprimes en 3D. Zack Freedman, un maker y YouTuber, lo publicó en 2022. Hoy hay más de 10 000 diseños gratuitos solo en Printables.
+
+La idea es sencilla: todo usa una cuadrícula de 42 mm. Los bins se apoyan sobre placas base. Las placas se embaldosan para cubrir cualquier cajón. Cuando quieras reorganizar, levantas los bins y los mueves.
+
+## Cómo funciona
+
+Una configuración Gridfinity tiene dos partes:
+
+**Placas base** que van en tu cajón. Son cuadrículas planas con un patrón en relieve que sujeta los bins. Las embaldosas para cubrir el espacio que tengas.
+
+**Bins** que guardan tus cosas. Vienen en tamaños de cuadrícula (1×1, 2×2, 3×1, etc.) y alturas en incrementos de 7 mm. Un bin 3U te da unos 21 mm de altura interior.
+
+Los bins tienen una base perfilada que encaja con el patrón de la placa base. Se quedan en su sitio al abrir el cajón pero se levantan fácilmente cuando los necesitas.
+
+## Por qué la gente lo usa
+
+**Imprimes exactamente lo que necesitas.** Sin packs de 12 cuando solo te hacen falta 2. Sin buscar el tamaño justo. Si existe un bin para tus brocas o tornillos concretos, lo imprimes.
+
+**Todo es compatible.** Un bin 2×2 de un diseñador funciona con la placa base de otro. Cada diseño sigue la misma especificación.
+
+**Es gratis.** Los diseños son de código abierto. El único coste es el filamento. Un bin típico usa 20–40 g de PLA.
+
+## Encontrar diseños
+
+La comunidad ha creado bins para casi cualquier uso común: portadestornilladores, organizadores de pilas, bandejas para brocas, gestión de cables.
+
+Los repositorios principales:
+
+- [Printables](https://www.printables.com/search/models?q=gridfinity) — la colección más grande, buenos filtros
+- [Thangs](https://thangs.com/search/gridfinity) — búsqueda por forma similar
+- [MakerWorld](https://makerworld.com/en/search/models?keyword=gridfinity) — popular entre usuarios Bambu
+
+Busca lo que necesites (p. ej. «gridfinity 2x2 battery holder») y aparecerán opciones.
+
+## Qué necesitas para empezar
+
+1. **Una impresora 3D.** Cualquier FDM sirve. El PLA es el estándar.
+2. **Medidas.** Las dimensiones interiores de tu cajón en milímetros. Mira la [referencia de tamaños](/gridfinity-sizes) para la conversión.
+3. **Un plan.** Cuántas unidades de cuadrícula entran, qué bins necesitas y dónde van.
+
+Esta herramienta te ayuda con el paso 3. Maqueta tu diseño, mira cómo encaja todo y exporta una lista de lo que hay que imprimir. También puedes [generar bins personalizados](/gridfinity-bin-generator) con exportación a STL, STEP y 3MF directamente en el navegador.
+
+## Siguiente paso
+
+Si ya estás listo para planificar un cajón, la guía explica cómo medir, planificar y exportar una lista de impresión.
+
+[CTA: Leer la guía de planificación](/es/guide)

--- a/content/fr/guide.md
+++ b/content/fr/guide.md
@@ -1,0 +1,144 @@
+---
+title: Comment planifier un tiroir Gridfinity
+description: Guide pratique pour planifier des layouts de tiroir Gridfinity. Mesurez votre tiroir, déterminez les bins nécessaires et exportez une liste d’impression.
+keywords: gridfinity planificateur, gridfinity layout, comment planifier gridfinity, organiser tiroir, guide gridfinity
+schema: HowTo
+breadcrumbs:
+  - name: Accueil
+    url: https://gridfinitylayouttool.com/fr/
+  - name: Guide de planification
+    url: https://gridfinitylayouttool.com/fr/guide
+faqs:
+  - q: Comment mesurer un tiroir pour Gridfinity ?
+    a: Mesurez les dimensions intérieures du tiroir en millimètres — largeur (gauche à droite), profondeur (avant à arrière) et hauteur libre (du fond au plafond du tiroir fermé). Prenez plusieurs mesures, les tiroirs étant rarement parfaitement rectangulaires, et retenez la plus petite valeur par dimension pour être sûr.
+  - q: Comment convertir les dimensions du tiroir en unités de grille Gridfinity ?
+    a: Divisez chaque dimension par 42 mm et arrondissez vers le bas. Par exemple, un tiroir de 380 mm × 260 mm accepte une grille 9×6 (378 mm × 252 mm), avec de petits écarts sur les bords. Les écarts ne sont pas un problème — les plaques de base n’ont pas besoin de remplir chaque millimètre.
+  - q: Quelles tailles de bins choisir pour Gridfinity ?
+    a: Comme point de départ — 1×1 avec séparateurs pour petites vis et composants ; 1×2 ou 2×2 pour stylos, clés USB et piles ; 1×3 ou 1×4 pour tournevis et pinces ; 2×2 ou 2×3 pour adhésif et tubes de colle ; 3×3 ou plus pour les gros outils. Vous pourrez toujours imprimer d’autres tailles plus tard si quelque chose ne va pas.
+  - q: Quelle hauteur maximale pour un bin Gridfinity ?
+    a: La hauteur n’est limitée que par la hauteur libre de votre tiroir et la course Z de votre imprimante. Les hauteurs se mesurent en unités de 7 mm (U). Un bin 6U fait 42 mm de haut intérieurement, un 9U fait 63 mm. Vérifiez votre bin le plus haut plus 5 mm pour la plaque face à la hauteur du tiroir fermé avant d’imprimer.
+  - q: Faut-il utiliser plusieurs couches dans les tiroirs profonds ?
+    a: Oui, si la hauteur le permet. Empilez les bins verticalement, la couche 1 en bas. Mettez le lourd en bas, le fréquent en haut. Très utile pour séparer objets plats (câbles) et bins hauts, ou pour isoler l’électrique du mécanique.
+  - q: Comment exporter une liste d’impression Gridfinity ?
+    a: Une fois votre layout terminé, la liste d’impression montre chaque taille de bin, la quantité nécessaire, les estimations de filament en grammes et des liens de recherche par taille sur Printables, Thangs et MakerWorld. Vous pouvez aussi générer des bins personnalisés directement avec le générateur intégré et exporter en STL, STEP ou 3MF.
+  - q: Combien d’espace vide laisser dans un tiroir Gridfinity ?
+    a: Laissez 10 à 20 % d’espace libre. Un tiroir planifié à 100 % aujourd’hui devient un problème demain, dès que votre collection grandit ou que les besoins changent. Les cases vides ne coûtent rien et laissent de la marge.
+  - q: Quelle est la meilleure imprimante pour Gridfinity ?
+    a: Toute imprimante FDM avec au moins 256 mm × 256 mm de plateau imprime les bins Gridfinity confortablement. Les Bambu Lab X1, A1 et P1S sont populaires pour leur vitesse. Prusa MK4 et Ender 3 V3 KE marchent bien aussi. Pour les tiroirs au-delà de 6×6 unités, soit vous carrelez les plaques de base, soit vous prenez un grand format type Bambu X1E ou Voron 2.4.
+---
+
+# Comment planifier un tiroir Gridfinity
+
+Imprimer sans plan, c’est gaspiller du filament. Vous finissez par réimprimer des bins parce que vous vous êtes trompé sur les tailles, vous laissez des trous non voulus, ou vous oubliez ce qu’il fallait. Ce guide couvre comment mesurer, planifier et obtenir une liste d’impression avant de démarrer.
+
+## Mesurer votre tiroir
+
+Récupérez les dimensions intérieures en millimètres. Il vous faut :
+
+- **Largeur** — gauche à droite
+- **Profondeur** — avant à arrière
+- **Hauteur** — du fond au plafond (hauteur libre tiroir fermé)
+
+Mesurez à plusieurs endroits. Les tiroirs sont rarement de parfaits rectangles, surtout dans les meubles anciens. Prenez la plus petite valeur pour être sûr.
+
+### Convertir en unités de grille
+
+Gridfinity utilise des unités de 42 mm. Divisez et arrondissez vers le bas :
+
+```text
+Largeur :    380 mm ÷ 42 = 9,04 → 9 unités
+Profondeur : 260 mm ÷ 42 = 6,19 → 6 unités
+```
+
+Une grille 9×6 fait 378 mm × 252 mm. Vous aurez de petits écarts sur les bords — c’est sans importance. Les plaques de base n’ont pas besoin de couvrir chaque millimètre.
+
+## Déterminer ce qui rentre dedans
+
+C’est l’étape que tout le monde saute, et que tout le monde regrette.
+
+Videz complètement le tiroir. Regroupez :
+
+- Le quotidien
+- L’hebdomadaire
+- Les trucs que vous aviez oubliés
+
+Le quotidien doit être accessible. L’hebdomadaire peut aller au fond. Les oubliés n’ont peut-être pas besoin d’un bin du tout.
+
+### Faire correspondre objets et tailles de bin
+
+Repères :
+
+| Contenu                   | Taille de bin        |
+| ------------------------- | -------------------- |
+| Vis M3, petits composants | 1×1 avec séparateurs |
+| Stylos, clés USB, piles   | 1×2 ou 2×2           |
+| Tournevis, pinces         | 1×3 ou 1×4           |
+| Adhésif, colle            | 2×2 ou 2×3           |
+| Gros outils               | 3×3 ou plus          |
+
+Ne vous obsédez pas — vous pourrez toujours imprimer d’autres bins plus tard.
+
+## Planifier le layout
+
+Ouvrez l’outil et fixez la taille de la grille. Glissez pour créer des bins. L’outil empêche les chevauchements et les débordements.
+
+**Le fréquent vers l’avant.** Quand vous ouvrez le tiroir, qu’est-ce que vous attrapez en premier ? Ça va devant.
+
+**Regroupez par usage.** Tournevis à un endroit, outils de mesure à un autre. Vous vous souviendrez plus facilement.
+
+**Laissez du vide.** Votre collection va grandir. Un tiroir planifié à 100 % aujourd’hui est un problème demain.
+
+### Couches pour tiroirs profonds
+
+Si vous avez de la hauteur, vous pouvez empiler les bins verticalement. La couche 1 est en bas.
+
+Bien adapté à :
+
+- Plat en bas (câbles, petites pièces), bins hauts au-dessus
+- Séparer électrique et mécanique
+
+Le lourd en bas, le fréquent en haut.
+
+## Exporter votre liste d’impression
+
+Quand le layout vous convient, exportez une liste d’impression :
+
+- Chaque taille de bin et la quantité
+- Estimations de filament en grammes
+- Liens de recherche par taille
+
+### Trouver des fichiers STL
+
+Vous pouvez [générer des bins personnalisés](/fr/gridfinity-bin-generator) directement avec le générateur intégré — choisissez vos dimensions, le style de base, les compartiments, puis exportez en STL, STEP ou 3MF.
+
+Pour les bins spécialisés (porte-outils spécifiques, formes complexes), parcourez les dépôts communautaires :
+
+- [Printables](https://www.printables.com/search/models?q=gridfinity) — plus large sélection
+- [Thangs](https://thangs.com/search/gridfinity) — utile pour trouver des designs similaires
+- [MakerWorld](https://makerworld.com/en/search/models?keyword=gridfinity) — communauté Bambu Lab
+
+Exemple de recherche : « gridfinity 2x2 3U » trouve des bins 2×2 de 3 unités de hauteur.
+
+## Avant d’imprimer
+
+### Testez d’abord en carton
+
+> Découpez du carton aux tailles de vos bins (42 mm par unité de grille) et disposez-les dans le tiroir. Si quelque chose cloche, vous n’avez pas perdu de filament.
+
+### Imprimez un bin d’abord
+
+Avant d’en imprimer 20, imprimez-en un. Vérifiez l’ajustement, la hauteur, et confirmez que le design vous plaît. Ajustez les réglages d’impression si besoin.
+
+### Vérifiez la garde
+
+Votre bin le plus haut plus la plaque (environ 5 mm) doit rentrer tiroir fermé. Mesurez-le avant de vous lancer sur des bins hauts.
+
+## Erreurs courantes
+
+**Trop de petits bins.** Une grille de bins 1×1 paraît organisée mais agace à l’usage. Des bins plus grands avec séparateurs sont en général meilleurs.
+
+**Remplir chaque case.** Plus de place pour les nouveautés. Prévoyez 10 à 20 % de vide.
+
+**Ignorer ce que vous utilisez vraiment.** N’organisez pas autour de ce que vous croyez devoir posséder. Organisez autour de ce que vous attrapez réellement.
+
+[CTA: Ouvrir l’outil de layout](/fr/)

--- a/content/fr/what-is-gridfinity.md
+++ b/content/fr/what-is-gridfinity.md
@@ -1,0 +1,80 @@
+---
+title: Qu’est-ce que Gridfinity ?
+description: Gridfinity est un système de rangement 3D libre et gratuit. Découvrez comment fonctionne la grille de 42 mm et pourquoi les makers l’utilisent.
+keywords: gridfinity, qu’est-ce que gridfinity, organisateur tiroir, impression 3D, rangement modulaire, Zack Freedman
+schema: Article
+breadcrumbs:
+  - name: Accueil
+    url: https://gridfinitylayouttool.com/fr/
+  - name: Qu’est-ce que Gridfinity ?
+    url: https://gridfinitylayouttool.com/fr/what-is-gridfinity
+faqs:
+  - q: Qu’est-ce qu’un bin Gridfinity ?
+    a: Un bin Gridfinity est un bac de rangement imprimé en 3D qui se pose sur une plaque de base Gridfinity. Les bins existent en tailles de grille (1×1, 2×2, 3×1, etc., où 1 unité fait 42 mm) et en hauteurs par paliers de 7 mm. Leur base profilée s’imbrique dans le motif de la plaque pour rester en place quand on ouvre le tiroir, tout en se retirant facilement.
+  - q: Quelle est la taille d’une unité Gridfinity ?
+    a: Une unité de grille Gridfinity mesure 42 mm × 42 mm. La hauteur utilise un incrément séparé de 7 mm, souvent noté « U ». Un bin 2×2 de hauteur 3U mesure donc environ 84 mm × 84 mm × 21 mm intérieur.
+  - q: Quelle différence entre un bin Gridfinity et une plaque de base ?
+    a: Les plaques de base sont les dalles plates qui se posent dans le tiroir et forment la grille de 42 mm. Les bins sont les contenants qui reçoivent vos affaires et reposent sur le motif de la plaque. Vous imprimez les plaques une fois pour couvrir le tiroir, puis tous les bins que vous voulez par-dessus.
+  - q: Quel filament utiliser pour les bins Gridfinity ?
+    a: Le PLA est le choix standard, optimisé pour la plupart des designs de la communauté. Le PETG fonctionne mieux si vous voulez plus de résistance aux chocs. L’ASA ou l’ABS conviennent si les bins vivent dans un endroit chaud (garage, grenier). Évitez le PLA dans une voiture en plein soleil.
+  - q: Combien de filament consomme un bin Gridfinity ?
+    a: Un bin 2×2 type consomme environ 20 à 40 g de PLA selon sa hauteur et son taux de remplissage. Un 1×1 tourne entre 8 et 15 g. Les plaques de base sont plus lourdes par unité — autour de 25 à 30 g par unité de grille.
+  - q: Combien de temps pour imprimer un bin Gridfinity ?
+    a: Un bin 2×2 prend environ 1 à 2 heures à vitesse standard (50–80 mm/s). Bambu Lab et d’autres imprimantes rapides réduisent ça à 20–40 minutes. Les plaques de base prennent plus de temps par unité à cause de leur surface.
+  - q: Les bins Gridfinity tombent-ils quand on ouvre le tiroir ?
+    a: Non. Le motif en relief de la plaque de base crée assez de friction pour maintenir les bins en place lors de l’usage normal du tiroir. Ils ne sont pas verrouillés — vous les soulevez tout droit pour les retirer — mais ils ne glissent pas quand vous ouvrez ou fermez le tiroir.
+  - q: Puis-je acheter des bins Gridfinity au lieu de les imprimer ?
+    a: Oui — beaucoup de vendeurs proposent des bins prêts à l’emploi sur Etsy, Amazon et en direct depuis l’atelier des makers. C’est une option si vous n’avez pas d’imprimante 3D, même si imprimer vous-même revient généralement moins cher par bin une fois les frais de port pris en compte.
+  - q: Gridfinity est-il gratuit ?
+    a: Oui. Gridfinity est open source. Les designs communautaires se téléchargent gratuitement sur Printables, Thangs et MakerWorld. Le seul coût, c’est le filament.
+---
+
+# Qu’est-ce que Gridfinity ?
+
+Gridfinity est un système de rangement modulaire que vous imprimez vous-même en 3D. Zack Freedman, un maker et YouTubeur, l’a publié en 2022. On compte aujourd’hui plus de 10 000 designs gratuits rien que sur Printables.
+
+L’idée est simple : tout repose sur une grille de 42 mm. Les bins se posent sur des plaques de base. Les plaques se carrelent pour couvrir n’importe quel tiroir. Quand vous voulez réorganiser, vous soulevez les bins et vous les déplacez.
+
+## Comment ça marche
+
+Une installation Gridfinity a deux parties :
+
+**Les plaques de base** vont dans votre tiroir. Ce sont des grilles plates avec un motif en relief qui maintient les bins. Vous les carrelez pour couvrir l’espace disponible.
+
+**Les bins** reçoivent vos affaires. Ils existent en tailles de grille (1×1, 2×2, 3×1, etc.) et en hauteurs par paliers de 7 mm. Un bin 3U offre environ 21 mm de hauteur intérieure.
+
+Les bins ont une base profilée qui s’imbrique dans le motif de la plaque. Ils restent en place quand vous ouvrez le tiroir, mais se soulèvent facilement quand vous en avez besoin.
+
+## Pourquoi les gens l’utilisent
+
+**Vous imprimez exactement ce qu’il vous faut.** Pas de pack de 12 alors qu’il vous en faut 2. Pas de chasse à la bonne taille. S’il existe un bin pour vos forets ou vos vis, vous l’imprimez.
+
+**Tout est compatible.** Un bin 2×2 d’un designer fonctionne avec la plaque d’un autre. Chaque design suit la même spécification.
+
+**C’est gratuit.** Les designs sont open source. Le seul coût, c’est le filament. Un bin typique consomme 20 à 40 g de PLA.
+
+## Trouver des designs
+
+La communauté a fait des bins pour la plupart des besoins courants : porte-tournevis, organiseurs de piles, bacs à forets, gestion de câbles.
+
+Les principaux dépôts :
+
+- [Printables](https://www.printables.com/search/models?q=gridfinity) — plus grande collection, bons filtres
+- [Thangs](https://thangs.com/search/gridfinity) — recherche par forme similaire
+- [MakerWorld](https://makerworld.com/en/search/models?keyword=gridfinity) — populaire chez les propriétaires Bambu
+
+Cherchez ce qu’il vous faut (par ex. « gridfinity 2x2 battery holder ») et vous trouverez des options.
+
+## Ce qu’il vous faut pour commencer
+
+1. **Une imprimante 3D.** N’importe quelle FDM fait l’affaire. Le PLA est la norme.
+2. **Des mesures.** Les dimensions intérieures de votre tiroir en millimètres. Voir la [référence des tailles](/gridfinity-sizes) pour la conversion.
+3. **Un plan.** Combien d’unités de grille rentrent, quels bins il vous faut, où ils vont.
+
+Cet outil aide pour l’étape 3. Maquettez votre layout, voyez comment tout s’imbrique, puis exportez une liste de ce qu’il faut imprimer. Vous pouvez aussi [générer des bins personnalisés](/gridfinity-bin-generator) avec export STL, STEP et 3MF directement dans votre navigateur.
+
+## Étape suivante
+
+Si vous êtes prêt à planifier un tiroir, le guide couvre la mesure, la planification et l’export d’une liste d’impression.
+
+[CTA: Lire le guide de planification](/fr/guide)

--- a/content/pt-BR/guide.md
+++ b/content/pt-BR/guide.md
@@ -1,0 +1,144 @@
+---
+title: Como planejar uma gaveta Gridfinity
+description: Guia prático para planejar layouts de gaveta Gridfinity. Meça a gaveta, escolha os bins certos e exporte uma lista de impressão.
+keywords: planejador gridfinity, layout gridfinity, como planejar gridfinity, organizar gaveta, guia gridfinity
+schema: HowTo
+breadcrumbs:
+  - name: Início
+    url: https://gridfinitylayouttool.com/pt-BR/
+  - name: Guia de planejamento
+    url: https://gridfinitylayouttool.com/pt-BR/guide
+faqs:
+  - q: Como medir uma gaveta para Gridfinity?
+    a: Meça as dimensões internas da gaveta em milímetros — largura (esquerda para direita), profundidade (frente para trás) e altura livre (do fundo ao teto com a gaveta fechada). Tire várias medidas, já que gavetas raramente são retângulos perfeitos, e use o menor valor em cada dimensão para garantir.
+  - q: Como converter as dimensões da gaveta em unidades de grade Gridfinity?
+    a: Divida cada dimensão por 42 mm e arredonde para baixo. Por exemplo, uma gaveta de 380 mm × 260 mm comporta uma grade 9×6 (378 mm × 252 mm), deixando pequenas folgas nas bordas. As folgas são aceitáveis — as placas-base não precisam preencher cada milímetro.
+  - q: Quais tamanhos de bin usar no Gridfinity?
+    a: Como ponto de partida — 1×1 com divisórias para parafusos pequenos e componentes; 1×2 ou 2×2 para canetas, pen drives e pilhas; 1×3 ou 1×4 para chaves de fenda e alicates; 2×2 ou 2×3 para fita e cola; 3×3 ou maior para ferramentas grandes. Sempre dá para imprimir outros tamanhos depois se algo não encaixar.
+  - q: Qual é a altura máxima de um bin Gridfinity?
+    a: A altura é limitada apenas pela altura livre da gaveta e pelo curso Z da impressora. As alturas são medidas em unidades de 7 mm (U). Um bin 6U tem 42 mm de altura interna; um 9U, 63 mm. Antes de imprimir, confira a altura do seu bin mais alto, somando 5 mm da placa-base, contra a altura livre da gaveta fechada.
+  - q: Vale a pena usar várias camadas em gavetas profundas?
+    a: Sim, se houver altura disponível. Empilhe bins verticalmente, com a camada 1 embaixo. O pesado fica embaixo; o de uso frequente, em cima. Funciona bem para separar itens planos (cabos) de bins altos, ou para isolar o elétrico do mecânico.
+  - q: Como exporto uma lista de impressão Gridfinity?
+    a: Quando o layout estiver pronto, a lista de impressão mostra cada tamanho de bin, a quantidade necessária, as estimativas de filamento em gramas e links de busca por tamanho no Printables, Thangs e MakerWorld. Você também pode gerar bins personalizados direto no gerador integrado e exportar STL, STEP ou 3MF.
+  - q: Quanto espaço vazio devo deixar numa gaveta Gridfinity?
+    a: Deixe entre 10 e 20 % de espaço livre. Uma gaveta planejada a 100 % hoje vira um problema amanhã quando a sua coleção crescer ou as suas necessidades mudarem. Casas vazias da grade não custam nada e dão margem para incluir bins depois.
+  - q: Qual é a melhor impressora para Gridfinity?
+    a: Qualquer impressora FDM com mesa de pelo menos 256 mm × 256 mm imprime bins Gridfinity com folga. As Bambu Lab X1, A1 e P1S são populares pela velocidade. Prusa MK4 e Ender 3 V3 KE também funcionam bem. Para gavetas acima de 6×6 unidades, ou você divide as placas-base em peças, ou usa um formato grande tipo Bambu X1E ou Voron 2.4.
+---
+
+# Como planejar uma gaveta Gridfinity
+
+Imprimir sem plano desperdiça filamento. Você acaba reimprimindo bins porque errou os tamanhos, deixa lacunas indesejadas ou esquece do que precisava. Este guia cobre como medir, planejar e tirar uma lista de impressão antes de começar.
+
+## Meça a gaveta
+
+Pegue as dimensões internas em milímetros. Você precisa de:
+
+- **Largura** — da esquerda para a direita
+- **Profundidade** — da frente para o fundo
+- **Altura** — do fundo ao teto (espaço livre com a gaveta fechada)
+
+Meça em vários pontos. Gavetas raramente são retângulos perfeitos, sobretudo em móveis antigos. Use o menor valor para garantir.
+
+### Converta para unidades de grade
+
+Gridfinity usa unidades de 42 mm. Divida e arredonde para baixo:
+
+```text
+Largura:      380 mm ÷ 42 = 9,04 → 9 unidades
+Profundidade: 260 mm ÷ 42 = 6,19 → 6 unidades
+```
+
+Uma grade 9×6 é 378 mm × 252 mm. Você terá pequenas folgas nas bordas — tudo bem. As placas-base não precisam cobrir cada milímetro.
+
+## Defina o que vai dentro
+
+É o passo que quase todo mundo pula — e se arrepende.
+
+Tire tudo da gaveta. Agrupe:
+
+- Itens de uso diário
+- Itens de uso semanal
+- Coisas que você tinha esquecido
+
+O diário precisa estar acessível. O semanal pode ir para o fundo. O esquecido talvez nem precise de bin.
+
+### Associe itens a tamanhos de bin
+
+Referências:
+
+| Conteúdo                       | Tamanho de bin     |
+| ------------------------------ | ------------------ |
+| Parafusos M3, componentes mini | 1×1 com divisórias |
+| Canetas, pen drives, pilhas    | 1×2 ou 2×2         |
+| Chaves de fenda, alicates      | 1×3 ou 1×4         |
+| Fita, cola                     | 2×2 ou 2×3         |
+| Ferramentas grandes            | 3×3 ou maior       |
+
+Sem obsessão — sempre dá para imprimir outros bins depois.
+
+## Planeje o layout
+
+Abra a ferramenta e defina o tamanho da grade. Arraste para criar bins. A ferramenta impede sobreposição e estouro de área.
+
+**O de uso frequente, à frente.** Ao abrir a gaveta, o que você pega primeiro? Vai na frente.
+
+**Agrupe o que tem a ver.** Chaves de fenda num ponto, ferramentas de medida em outro. Você se lembra mais fácil.
+
+**Deixe espaço vazio.** Sua coleção vai crescer. Uma gaveta planejada a 100 % hoje vira um problema amanhã.
+
+### Camadas para gavetas profundas
+
+Se sobra altura, empilhe bins na vertical. A camada 1 fica embaixo.
+
+Funciona bem para:
+
+- Plano embaixo (cabos, peças pequenas), bins altos em cima
+- Separar elétrico de mecânico
+
+Pesado embaixo; uso frequente em cima.
+
+## Exporte a lista de impressão
+
+Quando o layout estiver bom, exporte uma lista de impressão:
+
+- Cada tamanho de bin com quantidade
+- Estimativas de filamento em gramas
+- Links de busca por tamanho
+
+### Encontrar arquivos STL
+
+Você pode [gerar bins personalizados](/pt-BR/gridfinity-bin-generator) diretamente no gerador integrado — escolha as dimensões, o estilo da base, os compartimentos e exporte para STL, STEP ou 3MF.
+
+Para bins especializados (suportes específicos, formas complexas), procure nos repositórios da comunidade:
+
+- [Printables](https://www.printables.com/search/models?q=gridfinity) — maior seleção
+- [Thangs](https://thangs.com/search/gridfinity) — bom para encontrar designs parecidos
+- [MakerWorld](https://makerworld.com/en/search/models?keyword=gridfinity) — comunidade Bambu Lab
+
+Exemplo de busca: "gridfinity 2x2 3U" encontra bins 2×2 com 3 unidades de altura.
+
+## Antes de imprimir
+
+### Faça um teste com papelão primeiro
+
+> Recorte papelão no tamanho dos bins (42 mm por unidade de grade) e arrume na gaveta. Se algo parecer errado, você não gastou filamento.
+
+### Imprima um bin antes
+
+Antes de imprimir 20, imprima um. Confira o encaixe, a altura e se gosta do design. Ajuste a configuração da impressora se necessário.
+
+### Verifique a folga
+
+Seu bin mais alto, somado à placa-base (cerca de 5 mm), precisa caber com a gaveta fechada. Confira antes de partir para bins altos.
+
+## Erros comuns
+
+**Bins miudinhos demais.** Uma grade de bins 1×1 parece organizada, mas é chato no dia a dia. Bins maiores com divisórias costumam funcionar melhor.
+
+**Preencher cada casa.** Não sobra espaço para novidades. Planeje 10–20 % de espaço vazio.
+
+**Ignorar o que você realmente usa.** Não organize com base no que você acha que deveria ter. Organize com base no que realmente pega.
+
+[CTA: Abrir a ferramenta de layout](/pt-BR/)

--- a/content/pt-BR/what-is-gridfinity.md
+++ b/content/pt-BR/what-is-gridfinity.md
@@ -1,0 +1,80 @@
+---
+title: O que é Gridfinity?
+description: Gridfinity é um sistema de organização impresso em 3D, gratuito e de código aberto. Veja como funciona a grade de 42 mm e por que os makers o usam.
+keywords: gridfinity, o que é gridfinity, organizador de gaveta, impressão 3D, armazenamento modular, Zack Freedman
+schema: Article
+breadcrumbs:
+  - name: Início
+    url: https://gridfinitylayouttool.com/pt-BR/
+  - name: O que é Gridfinity?
+    url: https://gridfinitylayouttool.com/pt-BR/what-is-gridfinity
+faqs:
+  - q: O que é um bin Gridfinity?
+    a: Um bin Gridfinity é um recipiente impresso em 3D que se apoia em uma placa-base Gridfinity. Os bins vêm em tamanhos de grade (1×1, 2×2, 3×1 etc., em que 1 unidade equivale a 42 mm) e em alturas em incrementos de 7 mm. A base perfilada encaixa no padrão da placa-base — os bins ficam firmes ao abrir a gaveta, mas saem com facilidade.
+  - q: Qual é o tamanho de uma unidade Gridfinity?
+    a: Uma unidade de grade Gridfinity mede 42 mm × 42 mm. A altura usa um incremento separado de 7 mm, geralmente chamado de "U". Assim, um bin 2×2 com 3U de altura mede cerca de 84 mm × 84 mm × 21 mm internamente.
+  - q: Qual é a diferença entre um bin Gridfinity e uma placa-base?
+    a: As placas-base são as peças planas que vão na gaveta e formam a grade de 42 mm. Os bins são os recipientes que guardam as suas coisas e se apoiam no padrão da placa. Você imprime as placas uma vez para cobrir a gaveta e depois imprime os bins que precisar por cima.
+  - q: Qual filamento usar para bins Gridfinity?
+    a: PLA é a escolha padrão e a maioria dos designs da comunidade é otimizada para ele. PETG funciona bem se você quer mais resistência a impacto. ASA ou ABS fazem sentido se os bins ficam em local quente (garagem, sótão). Evite PLA em carro fechado no sol.
+  - q: Quanto filamento um bin Gridfinity consome?
+    a: Um bin 2×2 típico consome cerca de 20 a 40 g de PLA, dependendo da altura e do preenchimento. Um 1×1 fica em torno de 8 a 15 g. As placas-base pesam mais por unidade — algo como 25 a 30 g por unidade de grade.
+  - q: Quanto tempo leva para imprimir um bin Gridfinity?
+    a: Um bin 2×2 leva de 1 a 2 horas em velocidade padrão (50–80 mm/s). Bambu Lab e outras impressoras rápidas reduzem isso para 20–40 minutos. Placas-base demoram mais por unidade devido à área.
+  - q: Os bins Gridfinity caem quando a gaveta é aberta?
+    a: Não. O padrão em relevo da placa-base cria atrito suficiente para manter os bins no lugar no uso normal da gaveta. Eles não ficam travados — você levanta direto para retirar —, mas não escorregam ao abrir ou fechar.
+  - q: Posso comprar bins Gridfinity em vez de imprimir?
+    a: Sim — vários vendedores oferecem bins prontos no Mercado Livre, Etsy, Amazon e diretamente com makers. É uma opção se você não tem impressora 3D, embora imprimir você mesmo costume sair mais barato por bin depois de contabilizar o frete.
+  - q: Gridfinity é gratuito?
+    a: Sim. Gridfinity é de código aberto. Os designs da comunidade podem ser baixados de graça no Printables, Thangs e MakerWorld. O único custo é o filamento.
+---
+
+# O que é Gridfinity?
+
+Gridfinity é um sistema modular de organização que você imprime em 3D. Zack Freedman, maker e youtuber, lançou o sistema em 2022. Hoje há mais de 10 000 designs gratuitos só no Printables.
+
+A ideia é simples: tudo usa uma grade de 42 mm. Os bins se apoiam em placas-base. As placas se encaixam lado a lado para cobrir qualquer gaveta. Quando quiser reorganizar, é só levantar os bins e mover.
+
+## Como funciona
+
+Um conjunto Gridfinity tem duas partes:
+
+**Placas-base** vão na gaveta. São grades planas com um padrão em relevo que prende os bins. Você as encaixa para cobrir o espaço disponível.
+
+**Bins** guardam as suas coisas. Vêm em tamanhos de grade (1×1, 2×2, 3×1 etc.) e em alturas em incrementos de 7 mm. Um bin 3U tem cerca de 21 mm de altura interna.
+
+Os bins têm base perfilada que encaixa no padrão da placa. Eles ficam no lugar ao abrir a gaveta, mas se soltam facilmente quando você precisa.
+
+## Por que usar
+
+**Você imprime exatamente o que precisa.** Sem comprar pacote de 12 quando quer 2. Sem caçar o tamanho certo. Se existe um bin para a sua broca ou parafuso específico, você imprime.
+
+**Tudo é compatível.** Um bin 2×2 de um designer funciona com a placa de outro. Todos os designs seguem a mesma especificação.
+
+**É gratuito.** Os designs são abertos. O único custo é o filamento. Um bin típico consome 20–40 g de PLA.
+
+## Encontrar designs
+
+A comunidade já fez bins para a maioria dos usos comuns: porta-chaves de fenda, organizadores de pilhas, bandejas de brocas, gerenciamento de cabos.
+
+Os repositórios principais:
+
+- [Printables](https://www.printables.com/search/models?q=gridfinity) — maior acervo, bons filtros
+- [Thangs](https://thangs.com/search/gridfinity) — busca por forma semelhante
+- [MakerWorld](https://makerworld.com/en/search/models?keyword=gridfinity) — popular entre donos de Bambu
+
+Pesquise o que precisa (por exemplo, "gridfinity 2x2 battery holder") e você encontra opções.
+
+## O que precisa para começar
+
+1. **Uma impressora 3D.** Qualquer FDM serve. PLA é o padrão.
+2. **Medidas.** As dimensões internas da gaveta em milímetros. Veja a [referência de tamanhos](/gridfinity-sizes) para a conversão.
+3. **Um plano.** Quantas unidades de grade cabem, quais bins você precisa e onde vão.
+
+Esta ferramenta ajuda no passo 3. Monte seu layout, veja como tudo encaixa e exporte a lista do que imprimir. Você também pode [gerar bins personalizados](/gridfinity-bin-generator) com exportação para STL, STEP e 3MF direto no navegador.
+
+## Próximo passo
+
+Se já está pronto para planejar uma gaveta, o guia mostra como medir, planejar e exportar a lista de impressão.
+
+[CTA: Ler o guia de planejamento](/pt-BR/guide)

--- a/public/content.css
+++ b/public/content.css
@@ -424,6 +424,10 @@ body {
   display: none;
 }
 
+.content-faq__question::marker {
+  content: '';
+}
+
 .content-faq__question::after {
   content: '+';
   font-size: 1.25rem;

--- a/public/gridfinity-baseplate-generator/index.html
+++ b/public/gridfinity-baseplate-generator/index.html
@@ -185,7 +185,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.40582006.css">
+  <link rel="stylesheet" href="/content.4b35985d.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/public/gridfinity-bin-generator/index.html
+++ b/public/gridfinity-bin-generator/index.html
@@ -181,7 +181,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.40582006.css">
+  <link rel="stylesheet" href="/content.4b35985d.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/public/gridfinity-sizes/index.html
+++ b/public/gridfinity-sizes/index.html
@@ -119,7 +119,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.40582006.css">
+  <link rel="stylesheet" href="/content.4b35985d.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -11,6 +11,8 @@
   <meta name="author" content="Andy Aragon">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://gridfinitylayouttool.com/privacy">
+  <link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/privacy">
+  <link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/privacy">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="article">
@@ -19,6 +21,7 @@
   <meta property="og:description" content="Privacy Policy for Gridfinity Layout Tool. Layouts stay in your browser by default; sign-in is optional. Learn what we collect and how it&#039;s used.">
   <meta property="og:image" content="https://gridfinitylayouttool.com/og-image.png">
   <meta property="og:site_name" content="Gridfinity Layout Tool">
+  <meta property="og:locale" content="en_US">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -57,7 +57,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.40582006.css">
+  <link rel="stylesheet" href="/content.4b35985d.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://gridfinitylayouttool.com/</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <image:image>
@@ -14,7 +15,7 @@
   </url>
   <url>
     <loc>https://gridfinitylayouttool.com/gridfinity-generator</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.95</priority>
     <image:image>
@@ -25,31 +26,139 @@
   </url>
   <url>
     <loc>https://gridfinitylayouttool.com/what-is-gridfinity</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/what-is-gridfinity"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/de/what-is-gridfinity</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/what-is-gridfinity"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/fr/what-is-gridfinity</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/what-is-gridfinity"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/es/what-is-gridfinity</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/what-is-gridfinity"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/pt-BR/what-is-gridfinity</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/what-is-gridfinity"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/what-is-gridfinity"/>
   </url>
   <url>
     <loc>https://gridfinitylayouttool.com/guide</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/guide"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/guide"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/guide"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/guide"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/guide"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/guide"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/de/guide</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/guide"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/guide"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/guide"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/guide"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/guide"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/guide"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/fr/guide</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/guide"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/guide"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/guide"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/guide"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/guide"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/guide"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/es/guide</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/guide"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/guide"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/guide"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/guide"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/guide"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/guide"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/pt-BR/guide</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/guide"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/guide"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/guide"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/guide"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/guide"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/guide"/>
   </url>
   <url>
     <loc>https://gridfinitylayouttool.com/gridfinity-bin-generator</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gridfinitylayouttool.com/gridfinity-baseplate-generator</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gridfinitylayouttool.com/gridfinity-sizes</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/public/terms/index.html
+++ b/public/terms/index.html
@@ -11,6 +11,8 @@
   <meta name="author" content="Andy Aragon">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://gridfinitylayouttool.com/terms">
+  <link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/terms">
+  <link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/terms">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="article">
@@ -19,6 +21,7 @@
   <meta property="og:description" content="Terms of Service for Gridfinity Layout Tool. Understand your rights and responsibilities when using this app.">
   <meta property="og:image" content="https://gridfinitylayouttool.com/og-image.png">
   <meta property="og:site_name" content="Gridfinity Layout Tool">
+  <meta property="og:locale" content="en_US">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">

--- a/public/terms/index.html
+++ b/public/terms/index.html
@@ -57,7 +57,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/content.40582006.css">
+  <link rel="stylesheet" href="/content.4b35985d.css">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">

--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -226,16 +226,21 @@ function generateHtml(
     });
   }
 
-  if (faqs && faqs.length > 0) {
+  const renderedFaqs = faqs?.map((faq) => ({
+    q: faq.q,
+    answerHtml: marked.parseInline(escapeHtml(faq.a)) as string,
+  }));
+
+  if (renderedFaqs && renderedFaqs.length > 0) {
     structuredDataBlocks.push({
       '@context': 'https://schema.org',
       '@type': 'FAQPage',
-      mainEntity: faqs.map((faq) => ({
+      mainEntity: renderedFaqs.map((faq) => ({
         '@type': 'Question',
         name: faq.q,
         acceptedAnswer: {
           '@type': 'Answer',
-          text: faq.a,
+          text: faq.answerHtml,
         },
       })),
     });
@@ -250,7 +255,7 @@ ${safeJsonLd(block)}
     .join('\n');
 
   const breadcrumbsHtml = renderBreadcrumbs(breadcrumbs);
-  const faqsHtml = renderFaqs(faqs, locale);
+  const faqsHtml = renderFaqs(renderedFaqs, locale);
 
   return `<!DOCTYPE html>
 <html lang="${labels.lang}">
@@ -389,13 +394,18 @@ ${items}
 `;
 }
 
-function renderFaqs(faqs: FaqEntry[] | undefined, locale: Locale): string {
+interface RenderedFaq {
+  q: string;
+  answerHtml: string;
+}
+
+function renderFaqs(faqs: RenderedFaq[] | undefined, locale: Locale): string {
   if (!faqs || faqs.length === 0) return '';
   const items = faqs
     .map(
       (faq) => `    <details class="content-faq">
       <summary class="content-faq__question">${escapeHtml(faq.q)}</summary>
-      <div class="content-faq__answer">${marked.parseInline(faq.a) as string}</div>
+      <div class="content-faq__answer">${faq.answerHtml}</div>
     </details>`
     )
     .join('\n');
@@ -563,12 +573,17 @@ function build(): void {
 
   const localesBySlug = new Map<string, Set<Locale>>();
   for (const entry of entries) {
-    if (!localesBySlug.has(entry.slug)) localesBySlug.set(entry.slug, new Set());
-    localesBySlug.get(entry.slug)!.add(entry.locale);
+    let locales = localesBySlug.get(entry.slug);
+    if (!locales) {
+      locales = new Set<Locale>();
+      localesBySlug.set(entry.slug, locales);
+    }
+    locales.add(entry.locale);
   }
 
   for (const entry of entries) {
-    processFile(entry.filePath, entry.slug, entry.locale, localesBySlug.get(entry.slug)!);
+    const locales = localesBySlug.get(entry.slug) ?? new Set<Locale>();
+    processFile(entry.filePath, entry.slug, entry.locale, locales);
   }
 
   // Update CSS filename in hand-crafted content pages

--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -16,7 +16,113 @@ const CONTENT_DIR = path.join(process.cwd(), 'content');
 const OUTPUT_DIR = path.join(process.cwd(), 'public');
 const SITE_URL = 'https://gridfinitylayouttool.com';
 
-// Will be set during build after hashing the CSS
+const SUPPORTED_LOCALES = ['en', 'de', 'fr', 'es', 'pt-BR'] as const;
+type Locale = (typeof SUPPORTED_LOCALES)[number];
+const DEFAULT_LOCALE: Locale = 'en';
+
+const LOCALE_LABELS: Record<Locale, { lang: string; openTool: string; siteName: string }> = {
+  en: { lang: 'en', openTool: 'Open Tool', siteName: 'Gridfinity Layout Tool' },
+  de: { lang: 'de', openTool: 'Tool öffnen', siteName: 'Gridfinity Layout Tool' },
+  fr: { lang: 'fr', openTool: 'Ouvrir l’outil', siteName: 'Gridfinity Layout Tool' },
+  es: { lang: 'es', openTool: 'Abrir herramienta', siteName: 'Gridfinity Layout Tool' },
+  'pt-BR': { lang: 'pt-BR', openTool: 'Abrir ferramenta', siteName: 'Gridfinity Layout Tool' },
+};
+
+const FAQ_HEADING: Record<Locale, string> = {
+  en: 'Frequently Asked Questions',
+  de: 'Häufig gestellte Fragen',
+  fr: 'Questions fréquentes',
+  es: 'Preguntas frecuentes',
+  'pt-BR': 'Perguntas frequentes',
+};
+
+const FOOTER_COPY: Record<Locale, string> = {
+  en: 'Free to use.',
+  de: 'Kostenlos nutzbar.',
+  fr: 'Gratuit.',
+  es: 'Uso gratuito.',
+  'pt-BR': 'Uso gratuito.',
+};
+
+const FOOTER_LINKS: Record<
+  Locale,
+  {
+    generator: string;
+    whatIs: string;
+    bin: string;
+    baseplate: string;
+    sizes: string;
+    guide: string;
+    privacy: string;
+    terms: string;
+  }
+> = {
+  en: {
+    generator: 'Generator',
+    whatIs: 'What is Gridfinity?',
+    bin: 'Bin Generator',
+    baseplate: 'Baseplate Generator',
+    sizes: 'Sizes Reference',
+    guide: 'Planning Guide',
+    privacy: 'Privacy',
+    terms: 'Terms',
+  },
+  de: {
+    generator: 'Generator',
+    whatIs: 'Was ist Gridfinity?',
+    bin: 'Bin-Generator',
+    baseplate: 'Grundplatten-Generator',
+    sizes: 'Größenübersicht',
+    guide: 'Planungsleitfaden',
+    privacy: 'Datenschutz',
+    terms: 'Nutzungsbedingungen',
+  },
+  fr: {
+    generator: 'Générateur',
+    whatIs: 'Qu’est-ce que Gridfinity ?',
+    bin: 'Générateur de bins',
+    baseplate: 'Générateur de plaques',
+    sizes: 'Référence des tailles',
+    guide: 'Guide de planification',
+    privacy: 'Confidentialité',
+    terms: 'Conditions',
+  },
+  es: {
+    generator: 'Generador',
+    whatIs: '¿Qué es Gridfinity?',
+    bin: 'Generador de bins',
+    baseplate: 'Generador de placas',
+    sizes: 'Referencia de tamaños',
+    guide: 'Guía de planificación',
+    privacy: 'Privacidad',
+    terms: 'Términos',
+  },
+  'pt-BR': {
+    generator: 'Gerador',
+    whatIs: 'O que é Gridfinity?',
+    bin: 'Gerador de bins',
+    baseplate: 'Gerador de placas',
+    sizes: 'Referência de tamanhos',
+    guide: 'Guia de planejamento',
+    privacy: 'Privacidade',
+    terms: 'Termos',
+  },
+};
+
+function getUrl(slug: string, locale: Locale): string {
+  return locale === DEFAULT_LOCALE ? `${SITE_URL}/${slug}` : `${SITE_URL}/${locale}/${slug}`;
+}
+
+function getOutputDir(slug: string, locale: Locale): string {
+  return locale === DEFAULT_LOCALE
+    ? path.join(OUTPUT_DIR, slug)
+    : path.join(OUTPUT_DIR, locale, slug);
+}
+
+function localizedPath(slug: string, locale: Locale): string {
+  return locale === DEFAULT_LOCALE ? `/${slug}` : `/${locale}/${slug}`;
+}
+
 let cssFilename = 'content.css';
 
 interface FaqEntry {
@@ -42,10 +148,31 @@ interface Frontmatter {
 /**
  * Generate the HTML template for a content page
  */
-function generateHtml(content: string, frontmatter: Frontmatter, slug: string): string {
+function generateHtml(
+  content: string,
+  frontmatter: Frontmatter,
+  slug: string,
+  locale: Locale,
+  availableLocales: ReadonlySet<Locale>
+): string {
   const { title, description, keywords, ogImage, schema, faqs, breadcrumbs } = frontmatter;
-  const canonicalUrl = `${SITE_URL}/${slug}`;
+  const canonicalUrl = getUrl(slug, locale);
   const image = ogImage || `${SITE_URL}/og-image.png`;
+  const labels = LOCALE_LABELS[locale];
+  const homeUrl = locale === DEFAULT_LOCALE ? '/' : `/${locale}/`;
+  const ogLocaleMap: Record<Locale, string> = {
+    en: 'en_US',
+    de: 'de_DE',
+    fr: 'fr_FR',
+    es: 'es_ES',
+    'pt-BR': 'pt_BR',
+  };
+  const hreflangLinks = SUPPORTED_LOCALES.filter((l) => availableLocales.has(l))
+    .map((l) => `  <link rel="alternate" hreflang="${l}" href="${getUrl(slug, l)}">`)
+    .join('\n');
+  const xDefaultLink = availableLocales.has(DEFAULT_LOCALE)
+    ? `  <link rel="alternate" hreflang="x-default" href="${getUrl(slug, DEFAULT_LOCALE)}">`
+    : '';
 
   const primarySchema =
     schema === 'HowTo'
@@ -123,14 +250,14 @@ ${safeJsonLd(block)}
     .join('\n');
 
   const breadcrumbsHtml = renderBreadcrumbs(breadcrumbs);
-  const faqsHtml = renderFaqs(faqs);
+  const faqsHtml = renderFaqs(faqs, locale);
 
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="${labels.lang}">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${escapeHtml(title)} | Gridfinity Layout Tool</title>
+  <title>${escapeHtml(title)} | ${labels.siteName}</title>
 
   <!-- SEO Meta Tags -->
   <meta name="description" content="${escapeHtml(description)}">
@@ -138,19 +265,22 @@ ${safeJsonLd(block)}
   <meta name="author" content="Andy Aragon">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="${canonicalUrl}">
+${hreflangLinks}
+${xDefaultLink}
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="article">
   <meta property="og:url" content="${canonicalUrl}">
-  <meta property="og:title" content="${escapeHtml(title)} | Gridfinity Layout Tool">
+  <meta property="og:title" content="${escapeHtml(title)} | ${labels.siteName}">
   <meta property="og:description" content="${escapeHtml(description)}">
   <meta property="og:image" content="${image}">
-  <meta property="og:site_name" content="Gridfinity Layout Tool">
+  <meta property="og:site_name" content="${labels.siteName}">
+  <meta property="og:locale" content="${ogLocaleMap[locale]}">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:url" content="${canonicalUrl}">
-  <meta name="twitter:title" content="${escapeHtml(title)} | Gridfinity Layout Tool">
+  <meta name="twitter:title" content="${escapeHtml(title)} | ${labels.siteName}">
   <meta name="twitter:description" content="${escapeHtml(description)}">
   <meta name="twitter:image" content="${image}">
 
@@ -178,17 +308,17 @@ ${structuredDataScripts}
 
   <!-- Navigation -->
   <nav class="content-nav" aria-label="Main navigation">
-    <a href="/" class="content-nav__logo">
+    <a href="${homeUrl}" class="content-nav__logo">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <rect x="3" y="3" width="7" height="7" rx="1"/>
         <rect x="14" y="3" width="7" height="7" rx="1"/>
         <rect x="3" y="14" width="7" height="7" rx="1"/>
         <rect x="14" y="14" width="7" height="7" rx="1"/>
       </svg>
-      <span>Gridfinity Layout Tool</span>
+      <span>${labels.siteName}</span>
     </a>
-    <a href="/" class="content-nav__cta">
-      Open Tool
+    <a href="${homeUrl}" class="content-nav__cta">
+      ${escapeHtml(labels.openTool)}
     </a>
   </nav>
 
@@ -201,17 +331,17 @@ ${breadcrumbsHtml}${content}${faqsHtml}
   <footer class="content-page">
     <div class="content-footer">
       <div class="content-footer__links">
-        <a href="/gridfinity-generator">Generator</a>
-        <a href="/what-is-gridfinity">What is Gridfinity?</a>
-        <a href="/gridfinity-bin-generator">Bin Generator</a>
-        <a href="/gridfinity-baseplate-generator">Baseplate Generator</a>
-        <a href="/gridfinity-sizes">Sizes Reference</a>
-        <a href="/guide">Planning Guide</a>
-        <a href="/privacy">Privacy</a>
-        <a href="/terms">Terms</a>
+        <a href="/gridfinity-generator">${escapeHtml(FOOTER_LINKS[locale].generator)}</a>
+        <a href="${localizedPath('what-is-gridfinity', locale)}">${escapeHtml(FOOTER_LINKS[locale].whatIs)}</a>
+        <a href="/gridfinity-bin-generator">${escapeHtml(FOOTER_LINKS[locale].bin)}</a>
+        <a href="/gridfinity-baseplate-generator">${escapeHtml(FOOTER_LINKS[locale].baseplate)}</a>
+        <a href="/gridfinity-sizes">${escapeHtml(FOOTER_LINKS[locale].sizes)}</a>
+        <a href="${localizedPath('guide', locale)}">${escapeHtml(FOOTER_LINKS[locale].guide)}</a>
+        <a href="${localizedPath('privacy', locale)}">${escapeHtml(FOOTER_LINKS[locale].privacy)}</a>
+        <a href="${localizedPath('terms', locale)}">${escapeHtml(FOOTER_LINKS[locale].terms)}</a>
       </div>
       <p class="content-footer__copyright">
-        © ${new Date().getFullYear()} Gridfinity Layout Tool. Free to use.
+        © ${new Date().getFullYear()} ${labels.siteName}. ${escapeHtml(FOOTER_COPY[locale])}
       </p>
     </div>
   </footer>
@@ -259,7 +389,7 @@ ${items}
 `;
 }
 
-function renderFaqs(faqs: FaqEntry[] | undefined): string {
+function renderFaqs(faqs: FaqEntry[] | undefined, locale: Locale): string {
   if (!faqs || faqs.length === 0) return '';
   const items = faqs
     .map(
@@ -271,7 +401,7 @@ function renderFaqs(faqs: FaqEntry[] | undefined): string {
     .join('\n');
   return `
   <section class="content-faqs" aria-labelledby="faq-heading">
-    <h2 id="faq-heading" class="content-h2">Frequently Asked Questions</h2>
+    <h2 id="faq-heading" class="content-h2">${escapeHtml(FAQ_HEADING[locale])}</h2>
 ${items}
   </section>
 `;
@@ -319,41 +449,62 @@ function configureMarked(): void {
   });
 }
 
-/**
- * Process a single markdown file
- */
-function processFile(filePath: string): void {
+function processFile(
+  filePath: string,
+  slug: string,
+  locale: Locale,
+  availableLocales: ReadonlySet<Locale>
+): void {
   const fileContent = fs.readFileSync(filePath, 'utf-8');
   const { data, content } = matter(fileContent);
-
   const frontmatter = data as Frontmatter;
 
-  // Validate required frontmatter
   if (!frontmatter.title || !frontmatter.description) {
     console.error(`Missing required frontmatter in ${filePath}`);
     process.exit(1);
   }
 
-  // Get slug from filename (e.g., "what-is-gridfinity.md" -> "what-is-gridfinity")
-  const slug = path.basename(filePath, '.md');
-
-  // Convert markdown to HTML
   const htmlContent = marked(content);
+  const fullHtml = generateHtml(htmlContent as string, frontmatter, slug, locale, availableLocales);
 
-  // Generate full HTML page
-  const fullHtml = generateHtml(htmlContent as string, frontmatter, slug);
-
-  // Create output directory
-  const outputPath = path.join(OUTPUT_DIR, slug);
-  if (!fs.existsSync(outputPath)) {
-    fs.mkdirSync(outputPath, { recursive: true });
-  }
-
-  // Write HTML file
+  const outputPath = getOutputDir(slug, locale);
+  fs.mkdirSync(outputPath, { recursive: true });
   const outputFile = path.join(outputPath, 'index.html');
   fs.writeFileSync(outputFile, fullHtml);
 
-  console.log(`✓ Generated ${outputFile}`);
+  console.log(`✓ Generated ${path.relative(process.cwd(), outputFile)}`);
+}
+
+interface DiscoveredEntry {
+  slug: string;
+  locale: Locale;
+  filePath: string;
+}
+
+function discoverContent(): DiscoveredEntry[] {
+  const entries: DiscoveredEntry[] = [];
+
+  for (const f of fs.readdirSync(CONTENT_DIR).filter((n) => n.endsWith('.md'))) {
+    entries.push({
+      slug: path.basename(f, '.md'),
+      locale: DEFAULT_LOCALE,
+      filePath: path.join(CONTENT_DIR, f),
+    });
+  }
+
+  for (const locale of SUPPORTED_LOCALES.filter((l) => l !== DEFAULT_LOCALE)) {
+    const localeDir = path.join(CONTENT_DIR, locale);
+    if (!fs.existsSync(localeDir)) continue;
+    for (const f of fs.readdirSync(localeDir).filter((n) => n.endsWith('.md'))) {
+      entries.push({
+        slug: path.basename(f, '.md'),
+        locale,
+        filePath: path.join(localeDir, f),
+      });
+    }
+  }
+
+  return entries;
 }
 
 /**
@@ -404,17 +555,20 @@ function build(): void {
   // Hash and copy CSS file first (sets cssFilename for HTML generation)
   processCss();
 
-  // Get all markdown files
-  const files = fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith('.md'));
-
-  if (files.length === 0) {
+  const entries = discoverContent();
+  if (entries.length === 0) {
     console.log('No markdown files found in content/');
     return;
   }
 
-  // Process each file
-  for (const file of files) {
-    processFile(path.join(CONTENT_DIR, file));
+  const localesBySlug = new Map<string, Set<Locale>>();
+  for (const entry of entries) {
+    if (!localesBySlug.has(entry.slug)) localesBySlug.set(entry.slug, new Set());
+    localesBySlug.get(entry.slug)!.add(entry.locale);
+  }
+
+  for (const entry of entries) {
+    processFile(entry.filePath, entry.slug, entry.locale, localesBySlug.get(entry.slug)!);
   }
 
   // Update CSS filename in hand-crafted content pages
@@ -435,7 +589,7 @@ function build(): void {
     }
   }
 
-  console.log(`\n✓ Built ${files.length} content page(s)`);
+  console.log(`\n✓ Built ${entries.length} content page(s) across ${localesBySlug.size} slug(s)`);
 }
 
 // Run build

--- a/vercel.json
+++ b/vercel.json
@@ -112,6 +112,46 @@
       ]
     },
     {
+      "source": "/de/:path((?!api/).*)",
+      "headers": [
+        { "key": "Content-Language", "value": "de" },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
+        }
+      ]
+    },
+    {
+      "source": "/fr/:path((?!api/).*)",
+      "headers": [
+        { "key": "Content-Language", "value": "fr" },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
+        }
+      ]
+    },
+    {
+      "source": "/es/:path((?!api/).*)",
+      "headers": [
+        { "key": "Content-Language", "value": "es" },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
+        }
+      ]
+    },
+    {
+      "source": "/pt-BR/:path((?!api/).*)",
+      "headers": [
+        { "key": "Content-Language", "value": "pt-BR" },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
+        }
+      ]
+    },
+    {
       "source": "/content.:hash.css",
       "headers": [
         {
@@ -197,6 +237,17 @@
       "destination": "/gridfinity-baseplate-generator/index.html"
     },
     { "source": "/gridfinity-sizes", "destination": "/gridfinity-sizes/index.html" },
+    { "source": "/de/what-is-gridfinity", "destination": "/de/what-is-gridfinity/index.html" },
+    { "source": "/de/guide", "destination": "/de/guide/index.html" },
+    { "source": "/fr/what-is-gridfinity", "destination": "/fr/what-is-gridfinity/index.html" },
+    { "source": "/fr/guide", "destination": "/fr/guide/index.html" },
+    { "source": "/es/what-is-gridfinity", "destination": "/es/what-is-gridfinity/index.html" },
+    { "source": "/es/guide", "destination": "/es/guide/index.html" },
+    {
+      "source": "/pt-BR/what-is-gridfinity",
+      "destination": "/pt-BR/what-is-gridfinity/index.html"
+    },
+    { "source": "/pt-BR/guide", "destination": "/pt-BR/guide/index.html" },
     { "source": "/designer", "destination": "/" },
     { "source": "/baseplate", "destination": "/" },
     { "source": "/s/:id([a-zA-Z0-9]{12})", "destination": "/" },


### PR DESCRIPTION
Stacked on **#1711**. Targets `seo/faq-breadcrumb-schema` — merge that one first, then rebase this onto `main`.

## Summary

Captures the 40% non-USA traffic that the English-only site currently leaves on the table. Two highest-value SEO landing pages (`/what-is-gridfinity`, `/guide`) now have crawlable, server-rendered HTML in German, French, Spanish, and Brazilian Portuguese at locale-prefixed URLs.

8 new translated markdown files under `content/{de,fr,es,pt-BR}/` — translations anchored to the in-app i18n locale glossary so that "Bin" stays as the Gridfinity-specific loanword across all locales, baseplate becomes Grundplatte / plaque de base / placa base / placa-base, etc.

`scripts/build-content.ts` now scans both `content/*.md` (English) and `content/{locale}/*.md` (translations), emitting:
- English at `public/{slug}/index.html` (unchanged behavior)
- Other locales at `public/{locale}/{slug}/index.html`
- Each page declares its locale via `<html lang>`, `og:locale`, and a full bidirectional hreflang cluster (en + 4 locales + x-default)
- Footer, nav CTA, and "Frequently Asked Questions" heading localized via per-locale label maps

`sitemap.xml` expanded from 7 to 15 URLs, each carrying its own `xhtml:link` hreflang alternates per Google's sitemap-hreflang recommendation.

`vercel.json` now sets `Content-Language` headers on the `/de/`, `/fr/`, `/es/`, `/pt-BR/` subtrees, the same `public, max-age=3600, stale-while-revalidate=86400` cache headers as the existing English content paths, and explicit rewrites for the 8 new locale content URLs.

## Intentional non-changes

**Root `index.html` hreflang is unchanged.** Its body is English-only client-rendered React — declaring `hreflang="de"` from `/` to `/` would tell Googlebot the German variant is in English, which suppresses non-English ranking. The pre-existing comment in the head explains this. The locale ranking targets are the real, crawlable, server-rendered locale variants of `/what-is-gridfinity` and `/guide`, which fully self-declare hreflang.

**Privacy and terms stay English-only.** They're legal-compliance pages, not SEO ranking targets, so the limited translation budget went to product-content pages instead.

**Hand-crafted pages (`/gridfinity-{generator,bin-generator,baseplate-generator,sizes}`) stay English-only.** Migrating them to markdown so they flow through the same i18n pipeline is the follow-up PR.

## Test plan

- [x] `pnpm exec tsx scripts/build-content.ts` emits 12 pages across 4 slugs (4 EN + 4 DE + 4 FR + 4 ES + 4 PT-BR... wait, 8 markdown × locales = expected count)
- [x] Every generated JSON-LD block parses as valid JSON
- [x] `<html lang>` matches the locale on every page
- [x] Hreflang cluster on each page lists all 5 locales bidirectionally + x-default
- [x] `sitemap.xml` is valid XML, every locale URL has 6 `xhtml:link` alternates
- [x] `vercel.json` is valid JSON
- [x] Typecheck passes against `tsconfig.scripts.json`
- [x] All pre-commit hooks (boundaries, i18n × 3, exhaustiveness, component structure, missing tests, readme reminders) pass
- [ ] Google Search Console picks up locale variants after sitemap submission post-deploy
- [ ] Manual smoke test of `/de/guide` and `/fr/what-is-gridfinity` in production