### PR TITLE
fix(seo): address Copilot review on build-content.ts

### DIFF
--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -145,7 +145,7 @@ interface HowToFrontmatter {
   description?: string;
   totalTime?: string;
   tools?: string[];
-  steps: HowToStep[];
+  steps?: HowToStep[];
 }
 
 interface SoftwareApplicationFrontmatter {
@@ -415,7 +415,7 @@ ${structuredDataScripts}
       </svg>
       <span>${labels.siteName}</span>
     </a>
-    <a href="${navCta?.href ?? homeUrl}" class="content-nav__cta">
+    <a href="${escapeHtml(navCta?.href ?? homeUrl)}" class="content-nav__cta">
       ${escapeHtml(navCta?.label ?? labels.openTool)}
     </a>
   </nav>
@@ -565,6 +565,16 @@ function processFile(
   if (!frontmatter.title || !frontmatter.description) {
     console.error(`Missing required frontmatter in ${filePath}`);
     process.exit(1);
+  }
+
+  if (frontmatter.softwareApplication) {
+    const sa = frontmatter.softwareApplication;
+    if (!sa.name || !sa.applicationCategory) {
+      console.error(
+        `softwareApplication in ${filePath} is missing required fields (need 'name' and 'applicationCategory')`
+      );
+      process.exit(1);
+    }
   }
 
   const htmlContent = marked(content);


### PR DESCRIPTION
Follow-up to #1717. Copilot left 3 inline findings after the auto-merge fired — all legitimate and fixed here.

## Changes

**1. \`navCta.href\` is now HTML-escaped** (\`scripts/build-content.ts:420\`). The label was already escaped via \`escapeHtml(navCta?.label ?? labels.openTool)\`, but the href was interpolated raw. Now wrapped with \`escapeHtml\` to match the breadcrumb-URL pattern elsewhere in the file. Today's frontmatter values are clean (\`/designer\`, \`/baseplate?standalone=1\`), so no rendered output changes — this is defense in depth against future bad input.

**2. \`softwareApplication\` frontmatter is now validated** (\`scripts/build-content.ts:558\`). Previously, a typo like \`softwareApplication: {}\` (empty object) would silently emit a JSON-LD block with \`undefined\` properties dropped by \`JSON.stringify\`, leaving an invalid schema in production. \`processFile\` now fails the build with a clear error when \`name\` or \`applicationCategory\` is missing. Verified by inducing a failure and confirming the build halts with the right error message before reverting.

**3. \`HowToFrontmatter.steps\` is now optional in the type** (\`scripts/build-content.ts:148\`). The runtime code uses \`howTo?.steps && howTo.steps.length > 0\` to conditionally add the \`step\` array, so the type was lying when it said \`steps: HowToStep[]\` (required). Aligned the type with the actual contract.

## Test plan

- [x] Typecheck passes against \`tsconfig.scripts.json\`
- [x] \`pnpm exec tsx scripts/build-content.ts\` still emits 15 pages across 7 slugs
- [x] Validation rejects malformed \`softwareApplication\` (verified by inducing a failure)
- [x] \`navCta.href\` still renders correctly for the two current consumers (\`/designer\`, \`/baseplate?standalone=1\`)