### PR TITLE
feat(seo): emit googlebot/bingbot meta on all generated content pages

### DIFF
--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -362,6 +362,8 @@ ${safeJsonLd(block)}
   ${keywords ? `<meta name="keywords" content="${escapeHtml(keywords)}">` : ''}
   <meta name="author" content="Andy Aragon">
   <meta name="robots" content="index, follow">
+  <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
+  <meta name="bingbot" content="index, follow, max-snippet:-1, max-image-preview:large">
   <link rel="canonical" href="${canonicalUrl}">
 ${hreflangLinks}
 ${xDefaultLink}


### PR DESCRIPTION
The SPA root \`index.html\` declares \`googlebot: max-snippet:-1, max-image-preview:large, max-video-preview:-1\` and \`bingbot: max-snippet:-1, max-image-preview:large\`. The markdown-generated content pages had neither — so Google and Bing default to truncated snippets and small image previews there.

This adds both directives to the build template so all 15 generated pages (English + de/fr/es/pt-BR locale variants) get the same SERP treatment as the SPA: full-length snippets and large image previews.

Was also present on the pre-migration hand-crafted pages (\`/gridfinity-bin-generator\`, etc.) and got dropped in #1717 — this restores parity.

## Test plan

- [x] Build succeeds; all 15 pages contain both meta tags
- [x] Same directives as the existing SPA root \`index.html\` for consistency
- [ ] Search Console rich-result preview shows large images post-deploy