### PR TITLE
feat(seo): localize generator pages for de/fr/es/pt-BR

### DIFF
--- a/content/de/gridfinity-baseplate-generator.md
+++ b/content/de/gridfinity-baseplate-generator.md
@@ -1,0 +1,103 @@
+---
+title: Gridfinity-Grundplatten-Generator — Kostenloser Online-STL-Creator
+description: Gridfinity-Grundplatten-Generator mit Echtzeit-3D-Vorschau. Rastergröße, Magnetlöcher, Verbindungsnoppen und Randabstand konfigurieren. Export als STL, STEP oder 3MF. Kostenloses Browser-Tool.
+keywords: gridfinity grundplatte generator, gridfinity baseplate, individuelle gridfinity grundplatte, gridfinity STL, schubladen grundplatte, magnet grundplatte
+schema: HowTo
+breadcrumbs:
+  - name: Start
+    url: https://gridfinitylayouttool.com/de/
+  - name: Grundplatten-Generator
+    url: https://gridfinitylayouttool.com/de/gridfinity-baseplate-generator
+howTo:
+  name: So erzeugst du eine individuelle Gridfinity-Grundplatte
+  description: Rastergröße festlegen, Funktionen konfigurieren, in 3D ansehen und deine individuelle Gridfinity-Grundplatte als STL, STEP oder 3MF herunterladen.
+  totalTime: PT3M
+  tools:
+    - Webbrowser
+  steps:
+    - name: Grundplatten-Maße festlegen
+      text: Wähle Breite und Tiefe in Gridfinity-Rastereinheiten oder synchronisiere mit deinem bestehenden Layout, um die Schubladengröße automatisch zu übernehmen.
+    - name: Funktionen konfigurieren
+      text: Magnetlöcher für magnetische Bin-Befestigung aktivieren, Verbindungsnoppen für Halbzellen-Ausrichtung ergänzen und Randabstand pro Seite einstellen, damit es in die Schublade passt.
+    - name: In 3D ansehen
+      text: Die Echtzeit-3D-Vorschau aktualisiert sich, sobald du Parameter änderst. Drehe und zoome, um die Grundplatte aus jedem Winkel zu prüfen.
+    - name: Exportieren und drucken
+      text: Lade deine Grundplatte als STL, STEP oder 3MF herunter. Große Grundplatten werden automatisch in druckbettgerechte Teile aufgeteilt.
+softwareApplication:
+  name: Gridfinity-Grundplatten-Generator
+  description: Parametrischer Gridfinity-Grundplatten-Generator mit Echtzeit-3D-Vorschau. Rastergröße einstellen, Magnetlöcher und Verbindungsnoppen ergänzen, Randabstand konfigurieren und als STL, STEP oder 3MF exportieren. Kostenloses Browser-Tool.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  offers:
+    price: '0'
+    priceCurrency: USD
+  featureList:
+    - Parametrische Grundplatten-Maße synchronisiert mit dem Layout
+    - Export als STL, STEP und 3MF
+    - Magnetloch-Vertiefungen (6 mm × 2 mm)
+    - Halbzellen-Verbindungsnoppen
+    - Randabstand pro Seite einstellbar
+    - An-Schublade-anpassen-Modus mit automatischer Größenwahl
+    - Automatische Aufteilung bei Überschreitung des Druckbetts
+    - Echtzeit-3D-Vorschau
+    - Läuft im Browser, keine Installation nötig
+faqs:
+  - q: Welche Dateiformate kann ich für Grundplatten exportieren?
+    a: Der Generator exportiert STL (Standard für 3D-Druck), STEP (für CAD-Bearbeitung) und 3MF (modernes Format mit Farbe und Materialdaten). Die meisten Slicer unterstützen alle drei.
+  - q: Kann die Grundplatte Magnetlöcher enthalten?
+    a: Ja. Aktiviere Magnetlöcher, um 6 mm × 2 mm Vertiefungen an jeder Rasterkreuzung zu erzeugen. Sie halten Neodym-Standardmagnete, damit Bins sicher auf der Grundplatte einrasten.
+  - q: Was passiert, wenn meine Grundplatte zu groß für mein Druckbett ist?
+    a: Der Generator erkennt automatisch, wenn eine Grundplatte das Druckbett überschreitet, und teilt sie in druckbare Stücke. Du erhältst eine ZIP-Datei mit allen Teilen, bereit zum Drucken und Zusammensetzen.
+  - q: Kann ich die Grundplatte exakt auf meine Schubladenmaße anpassen?
+    a: Ja. Synchronisiere die Grundplatte mit deinem Layout, damit sie deine Schublade exakt abdeckt. Per-Seite-Randabstand erlaubt Feintuning, damit die Grundplatte bündig sitzt.
+  - q: Wie unterscheidet sich das vom Herunterladen von Printables oder Thangs?
+    a: Vorgefertigte Grundplatten kommen in festen Größen. Dieser Generator erstellt eine Grundplatte, die exakt zu deinen Schubladenmaßen passt — mit genau den Funktionen, die du brauchst. Läuft im Browser mit visueller Oberfläche und Echtzeit-3D-Vorschau.
+  - q: Funktionieren diese Grundplatten mit Standard-Gridfinity-Bins?
+    a: Ja. Sie nutzen das Standard-42-mm-Raster und Sockelprofil. Kompatibel mit jedem Gridfinity-Bin beliebiger Herkunft.
+navCta:
+  label: Generator öffnen
+  href: /baseplate?standalone=1
+---
+
+# Gridfinity-Grundplatten-Generator
+
+Ein parametrischer Grundplatten-Generator, der in deinem Browser läuft. Rastergröße festlegen, Magnetlöcher und Randabstand konfigurieren, 3D-Vorschau prüfen und als STL-, STEP- oder 3MF-Datei herunterladen. Nichts zu installieren. Teil der [Gridfinity-Generator-Suite](/de/gridfinity-generator), zu der auch der Bin-Generator und der Layout-Planer gehören.
+
+[CTA: Grundplatte generieren](/baseplate?standalone=1)
+
+## So funktioniert es
+
+1. **Größe festlegen.** Wähle Breite und Tiefe in Rastereinheiten oder synchronisiere mit deinem bestehenden Layout, um die Schubladengröße automatisch zu übernehmen.
+2. **Funktionen konfigurieren.** Aktiviere Magnetlöcher für magnetische Befestigung, ergänze Verbindungsnoppen für Halbzellen-Ausrichtung und stelle den Randabstand pro Seite ein.
+3. **Vorschau prüfen.** Die 3D-Ansicht aktualisiert sich sofort, wenn du Einstellungen änderst. Drehe und zoome aus jedem Winkel.
+4. **Herunterladen und drucken.** Export als STL für deinen Slicer, STEP für CAD-Bearbeitung oder 3MF für Farb- und Materialunterstützung. Große Grundplatten teilen sich automatisch.
+
+> Alle Berechnungen laufen lokal. Deine Designs bleiben auf deinem Gerät, außer du teilst sie.
+
+## Funktionen
+
+**Rastergröße.** Stelle die Grundplatte auf beliebige Breite und Tiefe in Standard-Gridfinity-Rastereinheiten (je 42 mm) ein. Synchronisiere mit deinem Layout, um Schubladenmaße automatisch zu übernehmen.
+
+**Magnetlöcher.** Ergänze 6 mm × 2 mm Vertiefungen an jeder Rasterkreuzung für Standard-Neodym-Magnete. Bins rasten sicher auf der Grundplatte ein, ohne zu verrutschen.
+
+**Verbindungsnoppen.** Halbzellen-Stifte an Rasterkreuzungen helfen, Bins präzise auszurichten — besonders nützlich mit dem Halb-Bin-Modus für 0,5-Einheit-Präzision.
+
+**Randabstand.** Konfiguriere den Randabstand pro Seite unabhängig — links, rechts, vorn und hinten. Feinjustierung, damit die Grundplatte bündig in deiner Schublade sitzt, ohne Lücken oder Klemmen.
+
+**Automatische Aufteilung.** Grundplatten, die dein Druckbett überschreiten, werden automatisch in druckbare Teile aufgeteilt. Lade eine ZIP-Datei mit allen Teilen herunter, bereit zum Drucken und Zusammensetzen.
+
+## Exportformate
+
+| Format   | Wann sinnvoll                                                                              |
+| -------- | ------------------------------------------------------------------------------------------ |
+| **STL**  | Direkt in deinen Slicer. Funktioniert mit PrusaSlicer, Cura, OrcaSlicer und allen anderen. |
+| **STEP** | In Fusion 360, FreeCAD oder SolidWorks öffnen, um vor dem Druck weiter zu bearbeiten.      |
+| **3MF**  | Enthält Farb- und Materialdaten. Gut für Multi-Material-Drucker.                           |
+
+## Nächste Schritte
+
+Brauchst du individuelle Bins zur Grundplatte? Nutze den [Bin-Generator](/de/gridfinity-bin-generator), um Bins mit Kompartimenten, Aussparungen und Beschriftungslaschen zu erstellen. Plane deine gesamte Schublade mit dem [Layout-Planer](/de/) oder schau in die [Größenübersicht](/de/gridfinity-sizes), um deine Maße zu finden.
+
+[CTA: Grundplatte generieren](/baseplate?standalone=1)

--- a/content/de/gridfinity-bin-generator.md
+++ b/content/de/gridfinity-bin-generator.md
@@ -1,0 +1,128 @@
+---
+title: Gridfinity-Bin-Generator — Kostenloser Online-STL-Creator
+description: Gridfinity-Bin-Generator mit visuellem Editor und Echtzeit-3D-Vorschau. Maße einstellen, Kompartimente und Aussparungen ergänzen, als STL, STEP oder 3MF exportieren. Kostenloses Browser-Tool.
+keywords: gridfinity generator, gridfinity bin generator, gridfinity STL generator, custom gridfinity bins, gridfinity designer, online gridfinity generator
+schema: HowTo
+breadcrumbs:
+  - name: Start
+    url: https://gridfinitylayouttool.com/de/
+  - name: Bin-Generator
+    url: https://gridfinitylayouttool.com/de/gridfinity-bin-generator
+howTo:
+  name: So erzeugst du einen individuellen Gridfinity-Bin
+  description: Maße festlegen, Funktionen ergänzen, in 3D ansehen und deinen individuellen Gridfinity-Bin als STL, STEP oder 3MF herunterladen.
+  totalTime: PT5M
+  tools:
+    - Webbrowser
+  steps:
+    - name: Bin-Maße festlegen
+      text: Wähle Breite, Tiefe und Höhe in Gridfinity-Rastereinheiten. Eine Einheit ist 42 mm breit und 7 mm hoch.
+    - name: Boden und Funktionen wählen
+      text: Wähle einen Bodenstil (Standard, Magnet, Schraube oder flach). Ergänze nach Bedarf Kompartimente, Wandaussparungen, Beschriftungslaschen oder Schaufelrampen.
+    - name: In 3D ansehen
+      text: Die Echtzeit-3D-Vorschau aktualisiert sich, sobald du Parameter änderst. Drehe und zoome, um dein Design aus jedem Winkel zu prüfen.
+    - name: Exportieren und drucken
+      text: Lade deinen Bin als STL-, STEP- oder 3MF-Datei herunter. Öffne ihn in deinem Slicer und drucke.
+softwareApplication:
+  name: Gridfinity-Bin-Generator
+  description: Parametrischer Gridfinity-Bin-Generator mit Echtzeit-3D-Vorschau. Maße einstellen, Kompartimente, Aussparungen und Labels ergänzen, dann als STL, STEP oder 3MF exportieren. Kostenloses Browser-Tool.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  offers:
+    price: '0'
+    priceCurrency: USD
+  featureList:
+    - Parametrische Bin-Maße (Breite, Tiefe, Höhe)
+    - Export als STL, STEP und 3MF
+    - 6 Bodenstile inklusive Magnet und Schraube
+    - Wabenmuster für Wände
+    - Konfigurierbare Kompartimente mit entnehmbaren Trennstegen
+    - Schaufelrampen für leichteren Zugriff
+    - Wandaussparungen pro Seite
+    - Beschriftungslaschen mit Halterung oder geschlossen
+    - Boden-Einsätze (Rechteck, Kreis, Sechseck, Schlitz)
+    - Eigener Aussparungseditor mit Stift-Werkzeug
+    - Echtzeit-3D-Vorschau
+    - Halb-Bin-Modus mit 0,5-Einheit-Präzision
+    - Läuft im Browser, keine Installation nötig
+faqs:
+  - q: Welche Dateiformate kann ich exportieren?
+    a: Der Generator exportiert STL (Standard für 3D-Druck), STEP (für CAD-Bearbeitung) und 3MF (modernes Format mit Farbe und Materialdaten). Die meisten Slicer unterstützen alle drei.
+  - q: Muss ich Software installieren?
+    a: Nein. Es läuft im Browser. Seite öffnen und loslegen — nichts herunterladen oder installieren.
+  - q: Wie unterscheidet sich das von OpenSCAD-Gridfinity-Generatoren?
+    a: OpenSCAD-Generatoren erfordern Softwareinstallation und Code-Anpassungen für Parameteränderungen. Dieser Generator läuft im Browser mit visueller Oberfläche und Echtzeit-3D-Vorschau. Du siehst Änderungen sofort.
+  - q: Kann ich Bins mit individuellen Aussparungen erstellen?
+    a: Ja. Der Aussparungseditor ermöglicht rechteckige, kreisförmige oder freie Aussparungen. Mit dem Stift-Werkzeug zeichnest du komplexe Formen mit Bézier-Kurven für Werkzeughalter, Kabelmanagement oder beliebige Formen.
+  - q: Passen diese Bins auf meine Grundplatten?
+    a: Ja. Sie nutzen das Standard-42-mm-Raster und Sockelprofil. Kompatibel mit jeder Gridfinity-Grundplatte beliebiger Herkunft.
+  - q: Kann ich speichern und später weitermachen?
+    a: Ja. Designs werden automatisch im Browser gespeichert. Vergib einen Namen und sie bleiben sitzungsübergreifend erhalten.
+  - q: Wie groß können Bins sein?
+    a: Bis zu 8×8 Rastereinheiten (336 mm × 336 mm). Für größere Flächen plane mehrere Bins gemeinsam im Layout-Planer.
+  - q: Wo bekomme ich Grundplatten her?
+    a: Nutze den Grundplatten-Generator, um eine passende Grundplatte für deine Schublade zu erstellen — mit optionalen Magnetlöchern und Randabstand. Export als STL, STEP oder 3MF.
+navCta:
+  label: Generator öffnen
+  href: /designer
+---
+
+# Gridfinity-Bin-Generator
+
+Ein parametrischer Bin-Generator, der in deinem Browser läuft. Maße einstellen, Kompartimente oder Aussparungen ergänzen, 3D-Vorschau prüfen und als STL-, STEP- oder 3MF-Datei herunterladen. Nichts zu installieren. Teil der [Gridfinity-Generator-Suite](/de/gridfinity-generator), zu der auch der Grundplatten-Generator und der Layout-Planer gehören.
+
+[CTA: Bin erstellen](/designer)
+
+## So funktioniert es
+
+1. **Größe festlegen.** Wähle Breite, Tiefe und Höhe in Rastereinheiten. Etwas zwischen Standardgrößen? Der Halb-Bin-Modus erlaubt 0,5-Einheit-Präzision.
+2. **Funktionen ergänzen.** Kompartimente, Wandaussparungen, Schaufelrampen, Beschriftungslaschen — aktiviere sie und feinjustiere mit Schiebereglern.
+3. **Vorschau prüfen.** Die 3D-Ansicht aktualisiert sich sofort, wenn du Einstellungen änderst. Drehe und zoome aus jedem Winkel.
+4. **Herunterladen und drucken.** Export als STL für deinen Slicer, STEP für CAD-Bearbeitung oder 3MF für Farb- und Materialunterstützung.
+
+> Alle Berechnungen laufen lokal. Deine Designs bleiben auf deinem Gerät, außer du teilst sie.
+
+## Funktionen
+
+**Kompartimente.** Teile einen Bin in ein Raster aus Abschnitten auf, bis zu 8×8. Trennwände werden automatisch erzeugt. Entnehmbare Trennstege lassen sich als separate Dateien exportieren, wenn du später umkonfigurieren willst, ohne neu zu drucken.
+
+**Schaufelrampen und Wandaussparungen.** Schaufelrampen erleichtern den Zugriff auf Kleinteile am Boden. Wandaussparungen — U-förmige Kerben an jeder Seite — erlauben seitliches Herausziehen.
+
+**Beschriftungslaschen.** Eine Leiste an der Rückwand hält Etikettstreifen. Wähle Halterung oder geschlossene Stütze und die Breite pro Spalte.
+
+Für Teile, die fixiert bleiben müssen, schneiden **Boden-Einsätze** geformte Vertiefungen in den Boden — Kreise für Batterien, Sechsecke für Bits, Rechtecke für Bauteile. Tiefe und Rotation passend zu deinen Teilen einstellen.
+
+Der **Aussparungseditor** verarbeitet ungewöhnliche Formen. Wechsle in den Vollkörper-Modus, fräse von oben aus und nutze das Stift-Werkzeug, um freie Pfade für Schraubenschlüssel, Zangen oder andere Profilformen zu zeichnen.
+
+## Boden-Befestigungsoptionen
+
+So verbindest du den Bin mit deiner Grundplatte:
+
+- **Standard** — der voreingestellte Gridfinity-Sockel
+- **Magnet** — eingelassene Vertiefungen für 6 mm × 2 mm Magnete
+- **Schraube** — Löcher für Gewindeeinsätze
+- **Magnet & Schraube** — beide Methoden für maximalen Halt
+- **Beschwert** — schwererer Boden ohne Magnete
+- **Flach** — kein Sockel, ohne Grundplatte verwendbar
+
+## Exportformate
+
+| Format   | Wann sinnvoll                                                                              |
+| -------- | ------------------------------------------------------------------------------------------ |
+| **STL**  | Direkt in deinen Slicer. Funktioniert mit PrusaSlicer, Cura, OrcaSlicer und allen anderen. |
+| **STEP** | In Fusion 360, FreeCAD oder SolidWorks öffnen, um vor dem Druck weiter zu bearbeiten.      |
+| **3MF**  | Enthält Farb- und Materialdaten. Gut für Multi-Material-Drucker.                           |
+
+## Warum statt OpenSCAD?
+
+OpenSCAD-Gridfinity-Generatoren funktionieren, aber du musst Software installieren und Code bearbeiten, um einen Parameter zu ändern. Dieser läuft im Browser mit visueller Oberfläche. Du siehst das Ergebnis sofort, statt auf das Rendering zu warten.
+
+Außerdem exportiert er STEP und 3MF — nicht nur STL — und funktioniert auch auf deinem Smartphone, falls du unterwegs etwas prüfen musst.
+
+## Nächste Schritte
+
+Neu bei Gridfinity? Lies [Was ist Gridfinity?](/de/what-is-gridfinity) für die Grundlagen. Schon klar, was du brauchst? Schau in die [Größenübersicht](/de/gridfinity-sizes), um deine Maße zu finden, oder direkt in den [Planungsleitfaden](/de/guide), um eine ganze Schublade zu planen.
+
+[CTA: Bin erstellen](/designer)

--- a/content/de/gridfinity-sizes.md
+++ b/content/de/gridfinity-sizes.md
@@ -1,0 +1,116 @@
+---
+title: Gridfinity-Größen — Bin-Maße und Einheiten-Übersicht
+description: Wie groß ist eine Gridfinity-Einheit? 42-mm-Raster, 7-mm-Höhenstufen. Schnellreferenz für Bin-Größen, Schubladenumrechnung und was wohin passt.
+keywords: gridfinity größen, gridfinity maße, gridfinity bin größen, gridfinity höheneinheiten, gridfinity 42mm, gridfinity rastergröße
+schema: Article
+breadcrumbs:
+  - name: Start
+    url: https://gridfinitylayouttool.com/de/
+  - name: Größenübersicht
+    url: https://gridfinitylayouttool.com/de/gridfinity-sizes
+faqs:
+  - q: Wie groß ist eine Gridfinity-Rastereinheit?
+    a: Eine Gridfinity-Rastereinheit ist 42 mm × 42 mm. Ein 2×3-Bin ist 84 mm breit und 126 mm tief. Alle Gridfinity-Bins und -Grundplatten nutzen diesen Standard.
+  - q: Wie hoch ist eine Gridfinity-Höheneinheit?
+    a: Eine Höheneinheit (1U) ist 7 mm. Ein 3U-Bin hat etwa 21 mm Innenhöhe. Gängige Höhen reichen von 2U (14 mm) bis 10U (70 mm).
+  - q: Wie berechne ich, wie viele Gridfinity-Einheiten in meine Schublade passen?
+    a: Miss die Innenbreite und -tiefe deiner Schublade in Millimetern. Teile jeweils durch 42 und runde ab. Eine 380 mm × 260 mm große Schublade fasst zum Beispiel 9 × 6 Gridfinity-Einheiten.
+  - q: Was ist der Halb-Bin-Modus?
+    a: Der Halb-Bin-Modus erlaubt 0,5-Einheit-Schritte (21 mm) für Bins, die in Bereiche kleiner als eine volle Rastereinheit passen müssen. Ein 1,5×2-Bin wäre 63 mm × 84 mm.
+---
+
+# Gridfinity-Größen und Maße
+
+Gridfinity arbeitet mit zwei Zahlen: **Rastereinheiten** für Breite und Tiefe eines Bins und **Höheneinheiten** für die Höhe. Sobald du diese kennst, weißt du, was in deine Schublade passt und welche Bins du drucken solltest.
+
+## Rastereinheiten (Breite und Tiefe)
+
+**1 Rastereinheit = 42 mm.** Jeder Gridfinity-Bin und jede Grundplatte nutzt das. Ein „2×3"-Bin ist 2 Einheiten breit (84 mm) und 3 Einheiten tief (126 mm).
+
+| Rastergröße | Millimeter | Zoll (ca.) |
+| ----------- | ---------- | ---------- |
+| 1 Einheit   | 42 mm      | 1,65″      |
+| 2 Einheiten | 84 mm      | 3,31″      |
+| 3 Einheiten | 126 mm     | 4,96″      |
+| 4 Einheiten | 168 mm     | 6,61″      |
+| 5 Einheiten | 210 mm     | 8,27″      |
+| 6 Einheiten | 252 mm     | 9,92″      |
+| 7 Einheiten | 294 mm     | 11,57″     |
+| 8 Einheiten | 336 mm     | 13,23″     |
+
+### Halb-Bin-Modus
+
+Für engere Passungen nutzt der Halb-Bin-Modus **0,5-Einheit-Schritte (21 mm)**. Ein 1,5×2,5-Bin wäre 63 mm × 105 mm. Im Layout-Tool mit `H` aktivieren.
+
+## Höheneinheiten
+
+**1 Höheneinheit (1U) = 7 mm.** So viel vertikalen Platz hast du im Bin. Ein 3U-Bin hält Teile bis ca. 21 mm Höhe.
+
+| Höhe | Innen (mm) | Typische Nutzung                          |
+| ---- | ---------- | ----------------------------------------- |
+| 2U   | 14 mm      | SD-Karten, kleine Schrauben, Büroklammern |
+| 3U   | 21 mm      | USB-Sticks, AA-Batterien, Bolzen          |
+| 4U   | 28 mm      | Stifte, Marker, Bohrer                    |
+| 5U   | 35 mm      | Scheren, Klebebandrollen, Kleinwerkzeug   |
+| 6U   | 42 mm      | Schraubendreher, Zangen (Standardtiefe)   |
+| 7U   | 49 mm      | Spraydosen, größeres Handwerkzeug         |
+| 8U   | 56 mm      | Klebeflaschen, hohe Behälter              |
+| 10U  | 70 mm      | Tiefe Lagerung, sperrige Teile            |
+
+> **Höhenprüfung:** Dein höchster Bin plus Grundplatte (~5 mm) muss in die geschlossene Schublade passen. Miss die Innenhöhe der geschlossenen Schublade, bevor du hohe Bins planst.
+
+## Schubladenmaße umrechnen
+
+Mit dem Maßband die Innenmaße der Schublade in Millimetern erfassen. Dann:
+
+1. Innenbreite und -tiefe in Millimetern messen
+2. Jeweils durch 42 teilen
+3. Auf die nächste ganze Zahl abrunden (oder halbe Zahl im Halb-Bin-Modus)
+
+### Beispiel
+
+```text
+Schubladenbreite: 380 mm ÷ 42 = 9,04 → 9 Einheiten
+Schubladentiefe:  520 mm ÷ 42 = 12,38 → 12 Einheiten
+Layout-Größe:     9 × 12 (378 mm × 504 mm)
+Lücke am Rand:    2 mm Breite, 16 mm Tiefe
+```
+
+Kleine Lücken am Rand sind normal. Grundplatten müssen nicht jeden Millimeter abdecken. Meistens wird die Grundplatte mittig platziert und die Lücke ignoriert.
+
+## Gängige Bin-Größen
+
+Diese werden am häufigsten gedruckt. Alle (oder eine beliebige andere Größe) lassen sich im [Bin-Generator](/de/gridfinity-bin-generator) erstellen.
+
+| Bin-Größe | Maße (mm) | Typische Nutzung                            |
+| --------- | --------- | ------------------------------------------- |
+| 1×1       | 42 × 42   | Einzelne Schrauben, Muttern, Kleinteile     |
+| 1×2       | 42 × 84   | Stifte, USB-Kabel, Batterien in einer Reihe |
+| 1×3       | 42 × 126  | Schraubendreher, Lineale, lange Werkzeuge   |
+| 2×2       | 84 × 84   | Klebeband, Klebestifte, Maßbänder           |
+| 2×3       | 84 × 126  | Zangen, Drahtschneider, mittleres Werkzeug  |
+| 3×3       | 126 × 126 | Bohrer-Sets, große Zubehörteile             |
+| 4×2       | 168 × 84  | Steckschlüssel, Messschieber                |
+
+## Passt es auf dein Druckbett?
+
+Die meisten FDM-Drucker haben ein 220–256 mm Bett, das Bins bis ca. 5×5 oder 6×6 Einheiten handhabt. Größere werden geteilt oder in Abschnitten gedruckt. Das Layout-Tool nutzt standardmäßig 256 mm und markiert Bins, die nicht passen.
+
+## Schnellreferenz
+
+| Maß                 | Wert              |
+| ------------------- | ----------------- |
+| Rastereinheit       | 42 mm × 42 mm     |
+| Halbe Rastereinheit | 21 mm             |
+| Höheneinheit (1U)   | 7 mm              |
+| Grundplattendicke   | ~5 mm             |
+| Standard-Druckbett  | 256 mm            |
+| Maximales Raster    | 50 × 50 Einheiten |
+
+## Nächste Schritte
+
+Jetzt, wo du die Größen kennst, kannst du einen [individuellen Bin generieren](/de/gridfinity-bin-generator) oder den [Layout-Planer](/de/) öffnen, um zu sehen, wie Bins in deine Schublade passen.
+
+Neu bei Gridfinity? [Hier ist die Kurzfassung](/de/what-is-gridfinity) zum System.
+
+[CTA: Layout planen](/)

--- a/content/es/gridfinity-baseplate-generator.md
+++ b/content/es/gridfinity-baseplate-generator.md
@@ -1,0 +1,103 @@
+---
+title: Generador de placas base Gridfinity — Creador STL en línea gratis
+description: Generador de placas base Gridfinity con vista previa 3D en tiempo real. Configura tamaño de cuadrícula, orificios para imanes, conectores y márgenes. Exporta a STL, STEP o 3MF. Herramienta gratuita en el navegador.
+keywords: generador placa gridfinity, gridfinity baseplate, placa gridfinity personalizada, gridfinity STL, placa para cajón, placa con imanes
+schema: HowTo
+breadcrumbs:
+  - name: Inicio
+    url: https://gridfinitylayouttool.com/es/
+  - name: Generador de placas
+    url: https://gridfinitylayouttool.com/es/gridfinity-baseplate-generator
+howTo:
+  name: Cómo generar una placa base Gridfinity personalizada
+  description: Configura el tamaño de cuadrícula, ajusta las funciones, previsualiza en 3D y descarga tu placa base Gridfinity como STL, STEP o 3MF.
+  totalTime: PT3M
+  tools:
+    - Navegador web
+  steps:
+    - name: Definir dimensiones de la placa
+      text: Elige ancho y profundidad en unidades de cuadrícula Gridfinity, o sincroniza con tu layout existente para adoptar el tamaño del cajón automáticamente.
+    - name: Configurar funciones
+      text: Activa los orificios para imanes para fijación magnética, añade conectores para alinear a media celda y ajusta los márgenes por lado para que encaje en el cajón.
+    - name: Vista previa en 3D
+      text: La vista 3D se actualiza al instante cuando cambias parámetros. Rota y haz zoom para inspeccionar la placa desde todos los ángulos.
+    - name: Exportar e imprimir
+      text: Descarga tu placa como STL, STEP o 3MF. Las placas grandes se dividen automáticamente en piezas que entran en tu cama de impresión.
+softwareApplication:
+  name: Generador de placas base Gridfinity
+  description: Generador paramétrico de placas Gridfinity con vista previa 3D en tiempo real. Ajusta el tamaño de cuadrícula, añade orificios para imanes y conectores, configura los márgenes y exporta a STL, STEP o 3MF. Herramienta gratuita en el navegador.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  offers:
+    price: '0'
+    priceCurrency: USD
+  featureList:
+    - Dimensiones paramétricas sincronizadas con el layout
+    - Exportación a STL, STEP y 3MF
+    - Cavidades para imanes (6 mm × 2 mm)
+    - Conectores de media celda
+    - Margen configurable por lado
+    - Modo ajuste-al-cajón con dimensionado automático
+    - División automática para placas que exceden la cama
+    - Vista previa 3D en tiempo real
+    - Funciona en el navegador, sin instalar nada
+faqs:
+  - q: ¿Qué formatos puedo exportar para las placas?
+    a: El generador exporta STL (formato estándar para impresión 3D), STEP (para edición CAD) y 3MF (formato moderno con color y material). La mayoría de los slicers aceptan los tres.
+  - q: ¿La placa puede incluir orificios para imanes?
+    a: Sí. Activa los orificios para añadir cavidades de 6 mm × 2 mm en cada intersección de la cuadrícula. Sostienen imanes de neodimio estándar para que los bins queden bien fijados.
+  - q: ¿Qué pasa si mi placa es demasiado grande para la cama de impresión?
+    a: El generador detecta automáticamente cuando una placa excede tu cama y la divide en piezas imprimibles. Obtienes un ZIP con todas las piezas listas para imprimir y ensamblar.
+  - q: ¿Puedo ajustar la placa a las medidas exactas de mi cajón?
+    a: Sí. Sincroniza la placa con tu layout para que adopte el tamaño del cajón automáticamente. Los márgenes por lado permiten afinar el ajuste y que la placa quede plana en el cajón.
+  - q: ¿En qué se diferencia de descargar placas de Printables o Thangs?
+    a: Las placas prefabricadas vienen en tamaños fijos. Este generador crea una placa que se ajusta exactamente a las medidas de tu cajón, con las funciones que necesites. Funciona en el navegador con interfaz visual y vista 3D en tiempo real.
+  - q: ¿Estas placas funcionan con bins Gridfinity estándar?
+    a: Sí. Usan la cuadrícula estándar de 42 mm y el perfil de socket. Compatibles con cualquier bin Gridfinity de cualquier origen.
+navCta:
+  label: Abrir generador
+  href: /baseplate?standalone=1
+---
+
+# Generador de placas base Gridfinity
+
+Un generador paramétrico de placas que funciona en tu navegador. Define el tamaño de la cuadrícula, configura orificios para imanes y márgenes, revisa la vista previa 3D y descarga un archivo STL, STEP o 3MF. Sin instalación. Parte de la [suite Gridfinity Generator](/es/gridfinity-generator), que también incluye el generador de bins y el planificador de layout.
+
+[CTA: Generar placa](/baseplate?standalone=1)
+
+## Cómo funciona
+
+1. **Define el tamaño.** Elige ancho y profundidad en unidades de cuadrícula, o sincroniza con tu layout existente para adoptar el tamaño del cajón automáticamente.
+2. **Configura las funciones.** Activa orificios para imanes para fijación magnética, añade conectores para alinear a media celda y ajusta los márgenes por lado.
+3. **Revisa la vista previa.** La vista 3D se actualiza al instante cuando cambias los ajustes. Rota y haz zoom para verlo desde todos los ángulos.
+4. **Descarga e imprime.** Exporta como STL para tu slicer, STEP para editar en CAD o 3MF para color y material. Las placas grandes se dividen automáticamente.
+
+> Todo el cálculo es local. Tus diseños se quedan en tu dispositivo salvo que los compartas.
+
+## Funciones
+
+**Tamaño de cuadrícula.** Define la placa con cualquier ancho y profundidad en unidades de cuadrícula Gridfinity estándar (42 mm cada una). Sincroniza con tu layout para adoptar las medidas del cajón automáticamente.
+
+**Orificios para imanes.** Añade cavidades de 6 mm × 2 mm en cada intersección de la cuadrícula para imanes de neodimio estándar. Los bins quedan bien fijados sin deslizarse.
+
+**Conectores.** Pivotes de media celda en las intersecciones ayudan a alinear los bins con precisión — muy útil con el modo medio-bin para precisión de 0,5 unidad.
+
+**Márgenes.** Configura el margen por lado de forma independiente — izquierda, derecha, frente y atrás. Afina el ajuste para que la placa quede plana en tu cajón, sin huecos ni interferencias.
+
+**División automática.** Las placas que exceden tu cama de impresión se dividen automáticamente en piezas imprimibles. Descarga un ZIP con todas las piezas listas para imprimir y ensamblar.
+
+## Formatos de exportación
+
+| Formato  | Cuándo usarlo                                                                          |
+| -------- | -------------------------------------------------------------------------------------- |
+| **STL**  | Envíalo directo al slicer. Funciona con PrusaSlicer, Cura, OrcaSlicer y todo lo demás. |
+| **STEP** | Abre en Fusion 360, FreeCAD o SolidWorks para editar antes de imprimir.                |
+| **3MF**  | Incluye color y material. Bueno para impresoras multimaterial.                         |
+
+## Siguientes pasos
+
+¿Necesitas bins a medida para tu placa? Usa el [generador de bins](/es/gridfinity-bin-generator) para crear bins con compartimentos, recortes y etiquetas. Planifica el cajón entero con el [planificador de layout](/es/), o consulta la [referencia de tamaños](/es/gridfinity-sizes) para calcular tus medidas.
+
+[CTA: Generar placa](/baseplate?standalone=1)

--- a/content/es/gridfinity-bin-generator.md
+++ b/content/es/gridfinity-bin-generator.md
@@ -1,0 +1,128 @@
+---
+title: Generador de bins Gridfinity — Creador STL en línea gratis
+description: Generador de bins Gridfinity con editor visual y vista previa 3D en tiempo real. Ajusta dimensiones, añade compartimentos y recortes, exporta a STL, STEP o 3MF. Herramienta gratuita en el navegador.
+keywords: generador gridfinity, gridfinity bin generator, generador STL gridfinity, bins gridfinity personalizados, diseñador gridfinity, gridfinity en línea
+schema: HowTo
+breadcrumbs:
+  - name: Inicio
+    url: https://gridfinitylayouttool.com/es/
+  - name: Generador de bins
+    url: https://gridfinitylayouttool.com/es/gridfinity-bin-generator
+howTo:
+  name: Cómo generar un bin Gridfinity personalizado
+  description: Ajusta las dimensiones, añade funciones, previsualiza en 3D y descarga tu bin Gridfinity como STL, STEP o 3MF.
+  totalTime: PT5M
+  tools:
+    - Navegador web
+  steps:
+    - name: Ajustar las dimensiones del bin
+      text: Elige ancho, profundidad y altura en unidades de cuadrícula Gridfinity. Cada unidad mide 42 mm de ancho y 7 mm de alto.
+    - name: Elegir base y funciones
+      text: Selecciona un estilo de base (estándar, imán, tornillo o plana). Añade compartimentos, recortes en pared, etiquetas o rampas según necesites.
+    - name: Vista previa en 3D
+      text: La vista 3D en tiempo real se actualiza al cambiar parámetros. Rota y haz zoom para revisar tu diseño desde todos los ángulos.
+    - name: Exportar e imprimir
+      text: Descarga tu bin como STL, STEP o 3MF. Ábrelo en tu slicer e imprime.
+softwareApplication:
+  name: Generador de bins Gridfinity
+  description: Generador paramétrico de bins Gridfinity con vista previa 3D en tiempo real. Ajusta dimensiones, añade compartimentos, recortes y etiquetas y exporta a STL, STEP o 3MF. Herramienta gratuita en el navegador.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  offers:
+    price: '0'
+    priceCurrency: USD
+  featureList:
+    - Dimensiones de bin paramétricas (ancho, profundidad, altura)
+    - Exportación a STL, STEP y 3MF
+    - 6 estilos de base, incluyendo imán y tornillo
+    - Patrones de pared tipo panal
+    - Compartimentos configurables con separadores extraíbles
+    - Rampas para alcanzar piezas pequeñas
+    - Recortes en pared por lado
+    - Etiquetas con soporte en escuadra o macizo
+    - Insertos de suelo (rectángulo, círculo, hexágono, ranura)
+    - Editor de recortes con herramienta pluma
+    - Vista previa 3D en tiempo real
+    - Modo medio-bin con precisión de 0,5 unidad
+    - Funciona en el navegador, sin instalar nada
+faqs:
+  - q: ¿Qué formatos puedo exportar?
+    a: El generador exporta STL (formato estándar para impresión 3D), STEP (para edición CAD) y 3MF (formato moderno con color y material). La mayoría de los slicers aceptan los tres.
+  - q: ¿Necesito instalar algún software?
+    a: No. Funciona en el navegador. Abre la página y empieza — no hay nada que descargar ni instalar.
+  - q: ¿En qué se diferencia de los generadores Gridfinity de OpenSCAD?
+    a: Los generadores OpenSCAD requieren instalar software y editar código para cambiar parámetros. Este generador corre en el navegador con interfaz visual y vista 3D en tiempo real. Ves los cambios al instante.
+  - q: ¿Puedo crear bins con recortes personalizados?
+    a: Sí. El editor de recortes permite añadir formas rectangulares, circulares o personalizadas. Con la herramienta pluma dibujas formas complejas con curvas Bézier para portaherramientas, gestión de cables o cualquier forma especial.
+  - q: ¿Estos bins encajan con mis placas base?
+    a: Sí. Usan la cuadrícula estándar de 42 mm y el perfil de socket. Compatibles con cualquier placa base Gridfinity de cualquier origen.
+  - q: ¿Puedo guardar y volver más tarde?
+    a: Sí. Los diseños se guardan automáticamente en tu navegador. Pon un nombre al diseño y persistirá entre sesiones.
+  - q: ¿Cuán grandes pueden ser los bins?
+    a: Hasta 8×8 unidades de cuadrícula (336 mm × 336 mm). Para espacios mayores, usa el planificador de layout para combinar varios bins.
+  - q: ¿Dónde consigo placas base?
+    a: Usa el generador de placas para crear una placa adaptada a tu cajón, con orificios de imán y márgenes opcionales. Exporta como STL, STEP o 3MF.
+navCta:
+  label: Abrir generador
+  href: /designer
+---
+
+# Generador de bins Gridfinity
+
+Un generador paramétrico de bins que funciona en tu navegador. Ajusta las dimensiones, añade compartimentos o recortes, revisa la vista previa 3D y descarga un archivo STL, STEP o 3MF. Sin instalación. Parte de la [suite Gridfinity Generator](/es/gridfinity-generator), que también incluye el generador de placas y el planificador de layout.
+
+[CTA: Crear un bin](/designer)
+
+## Cómo funciona
+
+1. **Define el tamaño.** Elige ancho, profundidad y altura en unidades de cuadrícula. ¿Necesitas algo entre tamaños estándar? El modo medio-bin da precisión de 0,5 unidad.
+2. **Añade lo necesario.** Compartimentos, recortes en pared, rampas, etiquetas — actívalos y ajusta con sliders.
+3. **Revisa la vista previa.** La vista 3D se actualiza al instante cuando cambias los ajustes. Rota y haz zoom para verlo desde todos los ángulos.
+4. **Descarga e imprime.** Exporta como STL para tu slicer, STEP para editar en CAD o 3MF para color y material.
+
+> Todo el cálculo es local. Tus diseños se quedan en tu dispositivo salvo que los compartas.
+
+## Funciones
+
+**Compartimentos.** Divide un bin en una cuadrícula de secciones, hasta 8×8. Las paredes divisorias se generan automáticamente. Puedes exportar separadores extraíbles como archivos aparte para reconfigurar sin reimprimir.
+
+**Rampas y recortes en pared.** Las rampas facilitan llegar a las piezas pequeñas del fondo. Los recortes en pared — muescas en U en cualquier lado — permiten sacar cosas hacia el lateral.
+
+**Etiquetas.** Una repisa en la pared trasera sostiene las tiras de etiquetas. Elige soporte en escuadra o macizo y define el ancho por columna.
+
+Para objetos que deben quedarse fijos, los **insertos de suelo** cortan cavidades con forma en el fondo — círculos para pilas, hexágonos para puntas, rectángulos para componentes. Ajusta profundidad y rotación según lo que guardes.
+
+El **editor de recortes** maneja formas inusuales. Cambia a modo macizo, talla desde arriba y usa la herramienta pluma para dibujar trayectos libres para llaves, alicates o cualquier perfil atípico.
+
+## Opciones de base
+
+Cómo conecta el bin a tu placa base:
+
+- **Estándar** — el socket Gridfinity por defecto
+- **Imán** — cavidades para imanes de 6 mm × 2 mm
+- **Tornillo** — orificios para insertos roscados
+- **Imán y tornillo** — ambos métodos para máxima sujeción
+- **Lastrada** — base más pesada sin imanes
+- **Plana** — sin socket, para uso sin placa base
+
+## Formatos de exportación
+
+| Formato  | Cuándo usarlo                                                                          |
+| -------- | -------------------------------------------------------------------------------------- |
+| **STL**  | Envíalo directo al slicer. Funciona con PrusaSlicer, Cura, OrcaSlicer y todo lo demás. |
+| **STEP** | Abre en Fusion 360, FreeCAD o SolidWorks para editar antes de imprimir.                |
+| **3MF**  | Incluye color y material. Bueno para impresoras multimaterial.                         |
+
+## ¿Por qué esto en vez de OpenSCAD?
+
+Los generadores Gridfinity en OpenSCAD funcionan, pero hay que instalar software y editar código para cambiar un parámetro. Este corre en el navegador con interfaz visual. Ves el resultado al instante sin esperar a un renderizado.
+
+Además exporta STEP y 3MF — no solo STL — y funciona en tu móvil si necesitas revisar algo sobre la marcha.
+
+## Siguientes pasos
+
+¿Nuevo en Gridfinity? Lee [¿Qué es Gridfinity?](/es/what-is-gridfinity) para los fundamentos. ¿Sabes ya lo que quieres? Mira la [referencia de tamaños](/es/gridfinity-sizes) para calcular tus dimensiones, o pasa a la [guía de planificación](/es/guide) para organizar un cajón entero.
+
+[CTA: Crear un bin](/designer)

--- a/content/es/gridfinity-sizes.md
+++ b/content/es/gridfinity-sizes.md
@@ -1,0 +1,116 @@
+---
+title: Tamaños Gridfinity — Dimensiones de bins y guía de unidades
+description: ¿Cuánto mide una unidad Gridfinity? Cuadrícula de 42 mm, incrementos de altura de 7 mm. Tablas de referencia para bins, conversión de cajón y qué entra dónde.
+keywords: tamaños gridfinity, dimensiones gridfinity, tamaños bin gridfinity, unidades altura gridfinity, gridfinity 42mm, cuadrícula gridfinity
+schema: Article
+breadcrumbs:
+  - name: Inicio
+    url: https://gridfinitylayouttool.com/es/
+  - name: Referencia de tamaños
+    url: https://gridfinitylayouttool.com/es/gridfinity-sizes
+faqs:
+  - q: ¿Cuánto mide una unidad de cuadrícula Gridfinity?
+    a: Una unidad de cuadrícula Gridfinity mide 42 mm × 42 mm. Un bin 2×3 mide 84 mm de ancho y 126 mm de profundidad. Todos los bins y placas Gridfinity usan este estándar.
+  - q: ¿Cuánto mide una unidad de altura Gridfinity?
+    a: Una unidad de altura (1U) son 7 mm. Un bin 3U tiene unos 21 mm de altura interior. Las alturas habituales van de 2U (14 mm) a 10U (70 mm).
+  - q: ¿Cómo calculo cuántas unidades Gridfinity caben en mi cajón?
+    a: Mide el ancho y la profundidad interiores del cajón en milímetros. Divide cada uno entre 42 y redondea hacia abajo. Por ejemplo, un cajón de 380 mm × 260 mm caben 9 × 6 unidades Gridfinity.
+  - q: ¿Qué es el modo medio-bin?
+    a: El modo medio-bin permite incrementos de 0,5 unidad (21 mm) para bins que deben caber en espacios menores que una unidad completa. Un bin 1,5×2 sería 63 mm × 84 mm.
+---
+
+# Tamaños y dimensiones Gridfinity
+
+Gridfinity usa dos números: **unidades de cuadrícula** para el ancho y la profundidad de un bin, y **unidades de altura** para la altura. Conociéndolas, sabes qué cabe en tu cajón y qué bins imprimir.
+
+## Unidades de cuadrícula (ancho y profundidad)
+
+**1 unidad de cuadrícula = 42 mm.** Todos los bins y placas Gridfinity lo usan. Un bin «2×3» mide 2 unidades de ancho (84 mm) y 3 de profundidad (126 mm).
+
+| Unidades | Milímetros | Pulgadas (aprox.) |
+| -------- | ---------- | ----------------- |
+| 1 unidad | 42 mm      | 1,65″             |
+| 2        | 84 mm      | 3,31″             |
+| 3        | 126 mm     | 4,96″             |
+| 4        | 168 mm     | 6,61″             |
+| 5        | 210 mm     | 8,27″             |
+| 6        | 252 mm     | 9,92″             |
+| 7        | 294 mm     | 11,57″            |
+| 8        | 336 mm     | 13,23″            |
+
+### Modo medio-bin
+
+Para encajes más ajustados, el modo medio-bin usa **incrementos de 0,5 unidad (21 mm)**. Un bin 1,5×2,5 sería 63 mm × 105 mm. Actívalo en la herramienta de layout pulsando `H`.
+
+## Unidades de altura
+
+**1 unidad de altura (1U) = 7 mm.** Es el espacio vertical disponible dentro del bin. Un bin 3U admite objetos de hasta unos 21 mm de alto.
+
+| Altura | Interior (mm) | Uso típico                                        |
+| ------ | ------------- | ------------------------------------------------- |
+| 2U     | 14 mm         | Tarjetas SD, tornillos pequeños, clips            |
+| 3U     | 21 mm         | Memorias USB, pilas AA, pernos                    |
+| 4U     | 28 mm         | Bolígrafos, rotuladores, brocas                   |
+| 5U     | 35 mm         | Tijeras, rollos de cinta, herramientas pequeñas   |
+| 6U     | 42 mm         | Destornilladores, alicates (profundidad estándar) |
+| 7U     | 49 mm         | Aerosoles, herramientas de mano grandes           |
+| 8U     | 56 mm         | Botes de pegamento, contenedores altos            |
+| 10U    | 70 mm         | Almacenamiento profundo, objetos voluminosos      |
+
+> **Comprueba la altura libre:** Tu bin más alto más la placa (~5 mm) debe entrar con el cajón cerrado. Mide la altura interior del cajón cerrado antes de optar por bins altos.
+
+## Convertir las medidas de tu cajón
+
+Coge un metro y saca las dimensiones interiores del cajón en milímetros. Luego:
+
+1. Mide ancho y profundidad interiores en milímetros
+2. Divide cada uno entre 42
+3. Redondea hacia abajo a la unidad (o media unidad, en modo medio-bin)
+
+### Ejemplo
+
+```text
+Ancho del cajón:        380 mm ÷ 42 = 9,04 → 9 unidades
+Profundidad del cajón:  520 mm ÷ 42 = 12,38 → 12 unidades
+Tamaño de layout:       9 × 12 (378 mm × 504 mm)
+Huecos en los bordes:   2 mm de ancho, 16 mm de profundidad
+```
+
+Es normal tener pequeños huecos en los bordes. Las placas base no necesitan cubrir cada milímetro. Lo más común es centrar las placas e ignorar el hueco.
+
+## Tamaños de bin habituales
+
+Estos son los que más se imprimen. Puedes crear cualquiera (o un tamaño a medida) en el [generador de bins](/es/gridfinity-bin-generator).
+
+| Bin | Dimensiones (mm) | Usos comunes                                  |
+| --- | ---------------- | --------------------------------------------- |
+| 1×1 | 42 × 42          | Tornillos sueltos, tuercas, componentes mini  |
+| 1×2 | 42 × 84          | Bolígrafos, cables USB, pilas en fila         |
+| 1×3 | 42 × 126         | Destornilladores, reglas, herramientas largas |
+| 2×2 | 84 × 84          | Cinta, barras de pegamento, flexómetros       |
+| 2×3 | 84 × 126         | Alicates, cortacables, herramientas medianas  |
+| 3×3 | 126 × 126        | Juegos de brocas, accesorios grandes          |
+| 4×2 | 168 × 84         | Llaves de vaso, calibres                      |
+
+## ¿Cabe en tu cama de impresión?
+
+La mayoría de las impresoras FDM tienen una cama de 220–256 mm, que admite bins de hasta 5×5 o 6×6 unidades. Para algo mayor hay que dividir o imprimir en secciones. La herramienta de layout asume por defecto una cama de 256 mm y marca los bins que no caben.
+
+## Referencia rápida
+
+| Medida                     | Valor            |
+| -------------------------- | ---------------- |
+| Unidad de cuadrícula       | 42 mm × 42 mm    |
+| Media unidad de cuadrícula | 21 mm            |
+| Unidad de altura (1U)      | 7 mm             |
+| Grosor de placa base       | ~5 mm            |
+| Cama de impresión defecto  | 256 mm           |
+| Cuadrícula máx. (herr.)    | 50 × 50 unidades |
+
+## Siguientes pasos
+
+Ahora que conoces los tamaños, [genera un bin personalizado](/es/gridfinity-bin-generator) o abre el [planificador de layout](/es/) para ver cómo encajan los bins en tu cajón.
+
+¿Nuevo en Gridfinity? [Aquí tienes una visión general](/es/what-is-gridfinity) del sistema.
+
+[CTA: Planificar mi layout](/)

--- a/content/fr/gridfinity-baseplate-generator.md
+++ b/content/fr/gridfinity-baseplate-generator.md
@@ -1,0 +1,103 @@
+---
+title: Générateur de plaques de base Gridfinity — Créateur STL en ligne gratuit
+description: Générateur de plaques de base Gridfinity avec aperçu 3D en temps réel. Configurez la taille de grille, les trous d’aimants, les connecteurs et les marges. Export en STL, STEP ou 3MF. Outil de navigateur gratuit.
+keywords: gridfinity générateur plaque, gridfinity baseplate, plaque gridfinity personnalisée, gridfinity STL, plaque pour tiroir, plaque magnétique
+schema: HowTo
+breadcrumbs:
+  - name: Accueil
+    url: https://gridfinitylayouttool.com/fr/
+  - name: Générateur de plaques
+    url: https://gridfinitylayouttool.com/fr/gridfinity-baseplate-generator
+howTo:
+  name: Comment générer une plaque de base Gridfinity personnalisée
+  description: Réglez la taille de grille, configurez les fonctionnalités, prévisualisez en 3D et téléchargez votre plaque de base Gridfinity en STL, STEP ou 3MF.
+  totalTime: PT3M
+  tools:
+    - Navigateur web
+  steps:
+    - name: Régler les dimensions de la plaque
+      text: Choisissez largeur et profondeur en unités de grille Gridfinity, ou synchronisez avec votre layout existant pour adopter la taille du tiroir automatiquement.
+    - name: Configurer les fonctionnalités
+      text: Activez les trous d’aimants pour la fixation magnétique, ajoutez des connecteurs pour l’alignement demi-cellule et réglez les marges par côté pour l’ajustement au tiroir.
+    - name: Aperçu en 3D
+      text: L’aperçu 3D en temps réel se met à jour quand vous changez les paramètres. Tournez et zoomez pour inspecter chaque angle.
+    - name: Exporter et imprimer
+      text: Téléchargez votre plaque en STL, STEP ou 3MF. Les grandes plaques se divisent automatiquement en pièces qui rentrent sur votre plateau.
+softwareApplication:
+  name: Générateur de plaques de base Gridfinity
+  description: Générateur paramétrique de plaques Gridfinity avec aperçu 3D en temps réel. Réglez la taille de grille, ajoutez trous d’aimants et connecteurs, configurez les marges et exportez en STL, STEP ou 3MF. Outil de navigateur gratuit.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  offers:
+    price: '0'
+    priceCurrency: USD
+  featureList:
+    - Dimensions paramétriques synchronisées au layout
+    - Export en STL, STEP et 3MF
+    - Cavités pour aimants (6 mm × 2 mm)
+    - Connecteurs demi-cellule
+    - Marges configurables par côté
+    - Mode ajustement-au-tiroir avec dimensionnement automatique
+    - Division automatique pour les plaques dépassant le plateau
+    - Aperçu 3D en temps réel
+    - Tourne dans le navigateur, aucune installation
+faqs:
+  - q: Quels formats puis-je exporter pour les plaques ?
+    a: Le générateur exporte en STL (format standard pour l’impression 3D), STEP (pour l’édition CAO) et 3MF (format moderne avec couleur et matière). La plupart des slicers acceptent les trois.
+  - q: La plaque peut-elle inclure des trous d’aimants ?
+    a: Oui. Activez les trous d’aimants pour ajouter des cavités 6 mm × 2 mm à chaque intersection de grille. Elles reçoivent des aimants néodyme standard pour que les bins se fixent solidement.
+  - q: Que faire si ma plaque est trop grande pour mon plateau d’impression ?
+    a: Le générateur détecte automatiquement quand une plaque dépasse votre plateau et la divise en pièces imprimables. Vous recevez un ZIP avec toutes les pièces prêtes à imprimer et assembler.
+  - q: Puis-je ajuster la plaque aux dimensions exactes de mon tiroir ?
+    a: Oui. Synchronisez la plaque avec votre layout pour qu’elle adopte la taille de votre tiroir automatiquement. Les marges par côté permettent d’affiner l’ajustement.
+  - q: En quoi est-ce différent de télécharger des plaques sur Printables ou Thangs ?
+    a: Les plaques pré-faites viennent en tailles fixes. Ce générateur crée une plaque qui correspond exactement aux dimensions de votre tiroir, avec les fonctionnalités dont vous avez besoin. Il tourne dans le navigateur avec une interface visuelle et un aperçu 3D en temps réel.
+  - q: Ces plaques fonctionnent-elles avec les bins Gridfinity standard ?
+    a: Oui. Elles utilisent la grille 42 mm et le profil de socket standard. Compatibles avec n’importe quel bin Gridfinity, peu importe la source.
+navCta:
+  label: Ouvrir le générateur
+  href: /baseplate?standalone=1
+---
+
+# Générateur de plaques de base Gridfinity
+
+Un générateur paramétrique de plaques qui tourne dans votre navigateur. Réglez la taille de grille, configurez trous d’aimants et marges, vérifiez l’aperçu 3D et téléchargez un fichier STL, STEP ou 3MF. Rien à installer. Fait partie de la [suite Gridfinity Generator](/fr/gridfinity-generator), qui inclut aussi le générateur de bins et le planificateur de layout.
+
+[CTA: Générer une plaque](/baseplate?standalone=1)
+
+## Comment ça marche
+
+1. **Réglez la taille.** Choisissez largeur et profondeur en unités de grille, ou synchronisez avec votre layout existant pour adopter la taille du tiroir automatiquement.
+2. **Configurez les fonctionnalités.** Activez les trous d’aimants pour la fixation magnétique, ajoutez des connecteurs pour l’alignement demi-cellule et réglez les marges par côté.
+3. **Vérifiez l’aperçu.** La vue 3D se met à jour instantanément quand vous changez les réglages. Tournez et zoomez pour voir chaque angle.
+4. **Téléchargez et imprimez.** Export en STL pour votre slicer, STEP pour éditer en CAO, ou 3MF pour la couleur et les matières. Les grandes plaques se divisent automatiquement.
+
+> Tout le calcul se fait localement. Vos designs restent sur votre appareil sauf si vous les partagez.
+
+## Fonctionnalités
+
+**Taille de grille.** Réglez la plaque à n’importe quelle largeur et profondeur en unités de grille Gridfinity standard (42 mm chacune). Synchronisez avec votre layout pour adopter automatiquement les dimensions du tiroir.
+
+**Trous d’aimants.** Ajoutez des cavités 6 mm × 2 mm à chaque intersection de grille pour aimants néodyme standard. Les bins se fixent solidement sans glisser.
+
+**Connecteurs.** Des picots demi-cellule aux intersections aident à aligner précisément les bins — particulièrement utile avec le mode demi-bin pour la précision 0,5 unité.
+
+**Marges.** Configurez la marge par côté indépendamment — gauche, droite, avant, arrière. Affinez l’ajustement pour que la plaque soit bien plate dans votre tiroir, sans jeu ni interférence.
+
+**Division automatique.** Les plaques dépassant votre plateau d’impression sont automatiquement divisées en pièces imprimables. Téléchargez un ZIP avec toutes les pièces prêtes à imprimer et assembler.
+
+## Formats d’export
+
+| Format   | Quand l’utiliser                                                                            |
+| -------- | ------------------------------------------------------------------------------------------- |
+| **STL**  | Direct dans votre slicer. Fonctionne avec PrusaSlicer, Cura, OrcaSlicer et tous les autres. |
+| **STEP** | Ouvrez dans Fusion 360, FreeCAD ou SolidWorks pour modifier avant impression.               |
+| **3MF**  | Inclut couleur et matière. Bien pour les imprimantes multi-matériaux.                       |
+
+## Étapes suivantes
+
+Besoin de bins sur mesure pour votre plaque ? Utilisez le [générateur de bins](/fr/gridfinity-bin-generator) pour créer des bins avec compartiments, découpes et étiquettes. Planifiez tout votre tiroir avec le [planificateur de layout](/fr/), ou consultez la [référence des tailles](/fr/gridfinity-sizes) pour trouver vos dimensions.
+
+[CTA: Générer une plaque](/baseplate?standalone=1)

--- a/content/fr/gridfinity-bin-generator.md
+++ b/content/fr/gridfinity-bin-generator.md
@@ -1,0 +1,128 @@
+---
+title: Générateur de bins Gridfinity — Créateur STL en ligne gratuit
+description: Générateur de bins Gridfinity avec éditeur visuel et aperçu 3D en temps réel. Réglez les dimensions, ajoutez compartiments et découpes, exportez en STL, STEP ou 3MF. Outil de navigateur gratuit.
+keywords: gridfinity générateur, gridfinity bin generator, gridfinity STL, bins gridfinity personnalisés, gridfinity designer, gridfinity en ligne
+schema: HowTo
+breadcrumbs:
+  - name: Accueil
+    url: https://gridfinitylayouttool.com/fr/
+  - name: Générateur de bins
+    url: https://gridfinitylayouttool.com/fr/gridfinity-bin-generator
+howTo:
+  name: Comment générer un bin Gridfinity personnalisé
+  description: Réglez les dimensions, ajoutez des fonctionnalités, prévisualisez en 3D et téléchargez votre bin Gridfinity en STL, STEP ou 3MF.
+  totalTime: PT5M
+  tools:
+    - Navigateur web
+  steps:
+    - name: Régler les dimensions du bin
+      text: Choisissez largeur, profondeur et hauteur en unités de grille Gridfinity. Chaque unité fait 42 mm de large et 7 mm de haut.
+    - name: Choisir base et fonctionnalités
+      text: Sélectionnez un style de base (standard, aimant, vis, ou plat). Ajoutez compartiments, découpes murales, étiquettes ou rampes au besoin.
+    - name: Aperçu en 3D
+      text: L’aperçu 3D en temps réel se met à jour quand vous changez les paramètres. Tournez et zoomez pour inspecter chaque angle.
+    - name: Exporter et imprimer
+      text: Téléchargez votre bin en STL, STEP ou 3MF. Ouvrez-le dans votre slicer et imprimez.
+softwareApplication:
+  name: Générateur de bins Gridfinity
+  description: Générateur paramétrique de bins Gridfinity avec aperçu 3D en temps réel. Réglez les dimensions, ajoutez compartiments, découpes et étiquettes, puis exportez en STL, STEP ou 3MF. Outil de navigateur gratuit.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  offers:
+    price: '0'
+    priceCurrency: USD
+  featureList:
+    - Dimensions de bin paramétriques (largeur, profondeur, hauteur)
+    - Export en STL, STEP et 3MF
+    - 6 styles de fixation de base dont aimant et vis
+    - Motifs muraux nid d’abeille
+    - Compartiments configurables avec séparateurs amovibles
+    - Rampes pour atteindre les petites pièces
+    - Découpes murales par côté
+    - Étiquettes avec support en équerre ou plein
+    - Inserts au sol (rectangle, cercle, hexagone, fente)
+    - Éditeur de découpes avec outil plume
+    - Aperçu 3D en temps réel
+    - Mode demi-bin avec précision 0,5 unité
+    - Tourne dans le navigateur, aucune installation
+faqs:
+  - q: Quels formats puis-je exporter ?
+    a: Le générateur exporte en STL (format standard pour l’impression 3D), STEP (pour l’édition CAO) et 3MF (format moderne avec couleur et matière). La plupart des slicers acceptent les trois.
+  - q: Faut-il installer un logiciel ?
+    a: Non. Tout tourne dans votre navigateur. Ouvrez la page et c’est parti — rien à télécharger ou installer.
+  - q: En quoi est-ce différent des générateurs Gridfinity OpenSCAD ?
+    a: Les générateurs OpenSCAD demandent d’installer un logiciel et de modifier du code pour changer un paramètre. Celui-ci tourne dans votre navigateur avec une interface visuelle et un aperçu 3D en temps réel. Vous voyez les changements instantanément.
+  - q: Puis-je créer des bins avec des découpes personnalisées ?
+    a: Oui. L’éditeur de découpes permet d’ajouter des découpes rectangulaires, circulaires ou personnalisées. Avec l’outil plume, vous dessinez des formes complexes en courbes de Bézier pour porte-outils, gestion de câbles ou toute forme particulière.
+  - q: Ces bins iront-ils sur mes plaques de base ?
+    a: Oui. Ils utilisent la grille 42 mm et le profil de socket standard. Compatibles avec n’importe quelle plaque de base Gridfinity, peu importe la source.
+  - q: Puis-je sauvegarder et reprendre plus tard ?
+    a: Oui. Les designs sont sauvegardés automatiquement dans votre navigateur. Nommez un design et il persiste entre les sessions.
+  - q: Quelle taille maximale pour un bin ?
+    a: Jusqu’à 8×8 unités de grille (336 mm × 336 mm). Pour plus grand, utilisez le planificateur de layout pour disposer plusieurs bins ensemble.
+  - q: Où trouver les plaques de base ?
+    a: Utilisez le générateur de plaques pour créer une plaque dimensionnée à votre tiroir, avec trous d’aimants et marges optionnels. Export en STL, STEP ou 3MF.
+navCta:
+  label: Ouvrir le générateur
+  href: /designer
+---
+
+# Générateur de bins Gridfinity
+
+Un générateur paramétrique de bins qui tourne dans votre navigateur. Réglez les dimensions, ajoutez compartiments ou découpes, vérifiez l’aperçu 3D et téléchargez un fichier STL, STEP ou 3MF. Rien à installer. Fait partie de la [suite Gridfinity Generator](/fr/gridfinity-generator), qui inclut aussi le générateur de plaques et le planificateur de layout.
+
+[CTA: Créer un bin](/designer)
+
+## Comment ça marche
+
+1. **Réglez la taille.** Choisissez largeur, profondeur et hauteur en unités de grille. Besoin d’une taille intermédiaire ? Le mode demi-bin donne 0,5 unité de précision.
+2. **Ajoutez ce qu’il faut.** Compartiments, découpes murales, rampes, étiquettes — activez-les et ajustez avec des curseurs.
+3. **Vérifiez l’aperçu.** La vue 3D se met à jour instantanément quand vous changez les réglages. Tournez et zoomez pour voir chaque angle.
+4. **Téléchargez et imprimez.** Export en STL pour votre slicer, STEP pour éditer en CAO, ou 3MF pour la couleur et les matières.
+
+> Tout le calcul se fait localement. Vos designs restent sur votre appareil sauf si vous les partagez.
+
+## Fonctionnalités
+
+**Compartiments.** Divisez un bin en grille de sections, jusqu’à 8×8. Les murs de séparation se génèrent automatiquement. Vous pouvez exporter des séparateurs amovibles en fichiers séparés pour reconfigurer sans réimprimer.
+
+**Rampes et découpes murales.** Les rampes facilitent l’accès aux petites pièces au fond. Les découpes murales — encoches en U sur n’importe quel côté — permettent de sortir les objets sur le côté.
+
+**Étiquettes.** Une étagère au mur arrière reçoit les bandes d’étiquettes. Choisissez équerre ou support plein et fixez la largeur par colonne.
+
+Pour les objets qui doivent rester en place, les **inserts au sol** creusent des cavités dans le fond — cercles pour piles, hexagones pour embouts, rectangles pour composants. Réglez profondeur et rotation selon ce que vous rangez.
+
+L’**éditeur de découpes** gère les formes inhabituelles. Passez en mode solide, creusez par le haut et utilisez l’outil plume pour tracer des chemins libres pour clés, pinces ou tout profil atypique.
+
+## Options de fixation de base
+
+Comment le bin se connecte à votre plaque de base :
+
+- **Standard** — la socket Gridfinity par défaut
+- **Aimant** — cavités intégrées pour aimants 6 mm × 2 mm
+- **Vis** — trous pour inserts filetés
+- **Aimant et vis** — les deux pour un maintien maximal
+- **Lesté** — base plus lourde sans aimants
+- **Plat** — sans socket, pour utilisation sans plaque
+
+## Formats d’export
+
+| Format   | Quand l’utiliser                                                                            |
+| -------- | ------------------------------------------------------------------------------------------- |
+| **STL**  | Direct dans votre slicer. Fonctionne avec PrusaSlicer, Cura, OrcaSlicer et tous les autres. |
+| **STEP** | Ouvrez dans Fusion 360, FreeCAD ou SolidWorks pour modifier avant impression.               |
+| **3MF**  | Inclut couleur et matière. Bien pour les imprimantes multi-matériaux.                       |
+
+## Pourquoi pas OpenSCAD ?
+
+Les générateurs Gridfinity OpenSCAD fonctionnent, mais il faut installer un logiciel et modifier du code pour changer un paramètre. Celui-ci tourne dans votre navigateur avec une interface visuelle. Vous voyez le résultat immédiatement, sans attendre un rendu.
+
+Il exporte aussi STEP et 3MF — pas seulement STL — et fonctionne sur votre téléphone si vous devez vérifier quelque chose en déplacement.
+
+## Étapes suivantes
+
+Nouveau à Gridfinity ? Lisez [Qu’est-ce que Gridfinity ?](/fr/what-is-gridfinity) pour les bases. Vous savez déjà ce qu’il vous faut ? Consultez la [référence des tailles](/fr/gridfinity-sizes) pour trouver vos dimensions, ou passez directement au [guide de planification](/fr/guide) pour aménager un tiroir complet.
+
+[CTA: Créer un bin](/designer)

--- a/content/fr/gridfinity-sizes.md
+++ b/content/fr/gridfinity-sizes.md
@@ -1,0 +1,116 @@
+---
+title: Tailles Gridfinity — Dimensions des bins et guide des unités
+description: Quelle est la taille d’une unité Gridfinity ? Grille de 42 mm, incréments de hauteur de 7 mm. Tableaux de référence pour bins, conversion de tiroir et ce qui rentre où.
+keywords: tailles gridfinity, dimensions gridfinity, gridfinity bin tailles, unités hauteur gridfinity, gridfinity 42mm, gridfinity grille
+schema: Article
+breadcrumbs:
+  - name: Accueil
+    url: https://gridfinitylayouttool.com/fr/
+  - name: Référence des tailles
+    url: https://gridfinitylayouttool.com/fr/gridfinity-sizes
+faqs:
+  - q: Quelle est la taille d’une unité de grille Gridfinity ?
+    a: Une unité de grille Gridfinity fait 42 mm × 42 mm. Un bin 2×3 fait 84 mm de large et 126 mm de profondeur. Tous les bins et plaques Gridfinity utilisent ce standard.
+  - q: Quelle est la hauteur d’une unité Gridfinity ?
+    a: Une unité de hauteur (1U) fait 7 mm. Un bin 3U a environ 21 mm de hauteur intérieure. Les hauteurs courantes vont de 2U (14 mm) à 10U (70 mm).
+  - q: Comment calculer combien d’unités Gridfinity rentrent dans mon tiroir ?
+    a: Mesurez la largeur et la profondeur intérieures du tiroir en millimètres. Divisez chacune par 42 et arrondissez vers le bas. Par exemple, un tiroir de 380 mm × 260 mm contient 9 × 6 unités Gridfinity.
+  - q: Qu’est-ce que le mode demi-bin ?
+    a: Le mode demi-bin permet des incréments de 0,5 unité (21 mm) pour les bins qui doivent rentrer dans des espaces plus petits qu’une unité complète. Un bin 1,5×2 ferait 63 mm × 84 mm.
+---
+
+# Tailles et dimensions Gridfinity
+
+Gridfinity utilise deux nombres : les **unités de grille** pour la largeur et la profondeur d’un bin, et les **unités de hauteur** pour la hauteur. Une fois que vous les connaissez, vous savez ce qui rentre dans votre tiroir et quels bins imprimer.
+
+## Unités de grille (largeur et profondeur)
+
+**1 unité de grille = 42 mm.** Chaque bin et plaque de base Gridfinity utilise ça. Un bin « 2×3 » fait 2 unités de large (84 mm) et 3 unités de profondeur (126 mm).
+
+| Taille de grille | Millimètres | Pouces (env.) |
+| ---------------- | ----------- | ------------- |
+| 1 unité          | 42 mm       | 1,65″         |
+| 2 unités         | 84 mm       | 3,31″         |
+| 3 unités         | 126 mm      | 4,96″         |
+| 4 unités         | 168 mm      | 6,61″         |
+| 5 unités         | 210 mm      | 8,27″         |
+| 6 unités         | 252 mm      | 9,92″         |
+| 7 unités         | 294 mm      | 11,57″        |
+| 8 unités         | 336 mm      | 13,23″        |
+
+### Mode demi-bin
+
+Pour les ajustements plus serrés, le mode demi-bin utilise des **incréments de 0,5 unité (21 mm)**. Un bin 1,5×2,5 ferait 63 mm × 105 mm. Activez-le dans l’outil layout avec `H`.
+
+## Unités de hauteur
+
+**1 unité de hauteur (1U) = 7 mm.** C’est l’espace vertical disponible dans le bin. Un bin 3U accueille des objets jusqu’à environ 21 mm de haut.
+
+| Hauteur | Intérieur (mm) | Usage typique                                |
+| ------- | -------------- | -------------------------------------------- |
+| 2U      | 14 mm          | Cartes SD, petites vis, trombones            |
+| 3U      | 21 mm          | Clés USB, piles AA, boulons                  |
+| 4U      | 28 mm          | Stylos, marqueurs, forets                    |
+| 5U      | 35 mm          | Ciseaux, rouleaux d’adhésif, petit outillage |
+| 6U      | 42 mm          | Tournevis, pinces (profondeur standard)      |
+| 7U      | 49 mm          | Bombes aérosols, gros outils à main          |
+| 8U      | 56 mm          | Tubes de colle, contenants hauts             |
+| 10U     | 70 mm          | Rangement profond, objets volumineux         |
+
+> **Vérification de garde :** Votre bin le plus haut plus la plaque (~5 mm) doit rentrer tiroir fermé. Mesurez la hauteur intérieure du tiroir fermé avant de partir sur des bins hauts.
+
+## Convertir les mesures de votre tiroir
+
+Mesurez les dimensions intérieures du tiroir en millimètres. Puis :
+
+1. Mesurez largeur et profondeur intérieures en millimètres
+2. Divisez chacune par 42
+3. Arrondissez vers le bas à l’unité (ou demi, en mode demi-bin)
+
+### Exemple
+
+```text
+Largeur tiroir :    380 mm ÷ 42 = 9,04 → 9 unités
+Profondeur tiroir : 520 mm ÷ 42 = 12,38 → 12 unités
+Taille de layout :  9 × 12 (378 mm × 504 mm)
+Marge aux bords :   2 mm largeur, 16 mm profondeur
+```
+
+De petites marges sur les bords sont normales. Les plaques de base n’ont pas besoin de couvrir chaque millimètre. Le plus souvent, on centre les plaques et on ignore la marge.
+
+## Tailles de bins courantes
+
+Voilà ce que la plupart des gens impriment. Vous pouvez créer toutes ces tailles (ou n’importe quelle taille sur mesure) dans le [générateur de bins](/fr/gridfinity-bin-generator).
+
+| Taille bin | Dimensions (mm) | Usages courants                          |
+| ---------- | --------------- | ---------------------------------------- |
+| 1×1        | 42 × 42         | Vis isolées, écrous, petits composants   |
+| 1×2        | 42 × 84         | Stylos, câbles USB, piles en ligne       |
+| 1×3        | 42 × 126        | Tournevis, règles, longs outils          |
+| 2×2        | 84 × 84         | Adhésif, bâtons de colle, mètres à ruban |
+| 2×3        | 84 × 126        | Pinces, coupe-fils, outils moyens        |
+| 3×3        | 126 × 126       | Jeux de forets, grands accessoires       |
+| 4×2        | 168 × 84        | Douilles, rangement de pieds à coulisse  |
+
+## Ça rentre sur votre plateau d’impression ?
+
+La plupart des imprimantes FDM ont un plateau de 220–256 mm, qui gère les bins jusqu’à environ 5×5 ou 6×6 unités. Au-delà, il faut diviser ou imprimer en sections. L’outil layout est par défaut à un plateau de 256 mm et signale les bins qui ne rentrent pas.
+
+## Référence rapide
+
+| Mesure                      | Valeur         |
+| --------------------------- | -------------- |
+| Unité de grille             | 42 mm × 42 mm  |
+| Demi unité de grille        | 21 mm          |
+| Unité de hauteur (1U)       | 7 mm           |
+| Épaisseur plaque de base    | ~5 mm          |
+| Plateau d’impression défaut | 256 mm         |
+| Grille max (outil)          | 50 × 50 unités |
+
+## Étapes suivantes
+
+Maintenant que vous connaissez les tailles, [générez un bin personnalisé](/fr/gridfinity-bin-generator) ou ouvrez le [planificateur de layout](/fr/) pour voir comment les bins s’organisent dans votre tiroir.
+
+Nouveau à Gridfinity ? [Voici une présentation rapide](/fr/what-is-gridfinity) du système.
+
+[CTA: Planifier votre layout](/)

--- a/content/pt-BR/gridfinity-baseplate-generator.md
+++ b/content/pt-BR/gridfinity-baseplate-generator.md
@@ -1,0 +1,103 @@
+---
+title: Gerador de placas-base Gridfinity — Criador STL online gratuito
+description: Gerador de placas-base Gridfinity com prévia 3D em tempo real. Configure tamanho da grade, furos de ímã, conectores e folgas. Exporte para STL, STEP ou 3MF. Ferramenta gratuita no navegador.
+keywords: gerador placa gridfinity, gridfinity baseplate, placa gridfinity personalizada, gridfinity STL, placa para gaveta, placa com ímã
+schema: HowTo
+breadcrumbs:
+  - name: Início
+    url: https://gridfinitylayouttool.com/pt-BR/
+  - name: Gerador de placas-base
+    url: https://gridfinitylayouttool.com/pt-BR/gridfinity-baseplate-generator
+howTo:
+  name: Como gerar uma placa-base Gridfinity personalizada
+  description: Defina o tamanho da grade, configure os recursos, visualize em 3D e baixe sua placa-base Gridfinity em STL, STEP ou 3MF.
+  totalTime: PT3M
+  tools:
+    - Navegador web
+  steps:
+    - name: Definir dimensões da placa
+      text: Escolha largura e profundidade em unidades de grade Gridfinity, ou sincronize com seu layout existente para adotar o tamanho da gaveta automaticamente.
+    - name: Configurar recursos
+      text: Ative furos de ímã para fixação magnética, adicione conectores para alinhamento meia-célula e ajuste as folgas por lado para encaixar na gaveta.
+    - name: Prévia em 3D
+      text: A prévia 3D atualiza na hora quando você muda parâmetros. Gire e dê zoom para inspecionar a placa de todos os ângulos.
+    - name: Exportar e imprimir
+      text: Baixe sua placa em STL, STEP ou 3MF. Placas grandes são divididas automaticamente em peças que cabem na sua mesa de impressão.
+softwareApplication:
+  name: Gerador de placas-base Gridfinity
+  description: Gerador paramétrico de placas Gridfinity com prévia 3D em tempo real. Defina o tamanho da grade, adicione furos de ímã e conectores, configure as folgas e exporte para STL, STEP ou 3MF. Ferramenta gratuita no navegador.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  offers:
+    price: '0'
+    priceCurrency: USD
+  featureList:
+    - Dimensões paramétricas sincronizadas com o layout
+    - Exportação para STL, STEP e 3MF
+    - Cavidades para ímãs (6 mm × 2 mm)
+    - Conectores meia-célula
+    - Folga configurável por lado
+    - Modo ajusta-à-gaveta com dimensionamento automático
+    - Divisão automática para placas que excedem a mesa
+    - Prévia 3D em tempo real
+    - Roda no navegador, sem instalar nada
+faqs:
+  - q: Quais formatos posso exportar para as placas?
+    a: O gerador exporta STL (formato padrão para impressão 3D), STEP (para edição CAD) e 3MF (formato moderno com cor e material). A maioria dos slicers aceita os três.
+  - q: A placa pode incluir furos de ímã?
+    a: Sim. Ative os furos para adicionar cavidades de 6 mm × 2 mm em cada interseção da grade. Elas seguram ímãs de neodímio padrão para que os bins fiquem bem fixados.
+  - q: E se minha placa for grande demais para a mesa de impressão?
+    a: O gerador detecta automaticamente quando uma placa excede sua mesa e a divide em peças imprimíveis. Você recebe um ZIP com todas as peças prontas para imprimir e montar.
+  - q: Posso ajustar a placa às medidas exatas da minha gaveta?
+    a: Sim. Sincronize a placa com seu layout para adotar o tamanho da gaveta automaticamente. As folgas por lado permitem afinar o encaixe para que a placa fique plana no fundo.
+  - q: Como isso difere de baixar placas no Printables ou no Thangs?
+    a: Placas pré-feitas vêm em tamanhos fixos. Este gerador cria uma placa que combina exatamente com as medidas da sua gaveta, com os recursos que você precisa. Roda no navegador com interface visual e prévia 3D em tempo real.
+  - q: Essas placas funcionam com bins Gridfinity padrão?
+    a: Sim. Usam a grade padrão de 42 mm e o perfil do socket. Compatíveis com qualquer bin Gridfinity de qualquer fonte.
+navCta:
+  label: Abrir gerador
+  href: /baseplate?standalone=1
+---
+
+# Gerador de placas-base Gridfinity
+
+Um gerador paramétrico de placas que roda no seu navegador. Defina o tamanho da grade, configure furos de ímã e folgas, confira a prévia 3D e baixe um arquivo STL, STEP ou 3MF. Nada para instalar. Parte da [suíte Gridfinity Generator](/pt-BR/gridfinity-generator), que também inclui o gerador de bins e o planejador de layout.
+
+[CTA: Gerar placa](/baseplate?standalone=1)
+
+## Como funciona
+
+1. **Defina o tamanho.** Escolha largura e profundidade em unidades de grade, ou sincronize com seu layout existente para adotar o tamanho da gaveta automaticamente.
+2. **Configure os recursos.** Ative os furos de ímã para fixação magnética, adicione conectores para alinhamento meia-célula e ajuste as folgas por lado.
+3. **Confira a prévia.** A visualização 3D atualiza na hora quando você muda os ajustes. Gire e dê zoom para ver todos os ângulos.
+4. **Baixe e imprima.** Exporte em STL para seu slicer, STEP para editar em CAD ou 3MF para cor e material. Placas grandes são divididas automaticamente.
+
+> Todo o processamento é local. Seus designs ficam no seu dispositivo a menos que você os compartilhe.
+
+## Recursos
+
+**Tamanho de grade.** Defina a placa com qualquer largura e profundidade em unidades de grade Gridfinity padrão (42 mm cada). Sincronize com seu layout para adotar as medidas da gaveta automaticamente.
+
+**Furos de ímã.** Adicione cavidades de 6 mm × 2 mm em cada interseção da grade para ímãs de neodímio padrão. Os bins ficam bem fixados sem deslizar.
+
+**Conectores.** Pinos meia-célula nas interseções ajudam a alinhar os bins com precisão — muito útil com o modo meio-bin para precisão de 0,5 unidade.
+
+**Folgas.** Configure a folga por lado independentemente — esquerda, direita, frente e trás. Afine o encaixe para que a placa fique plana na gaveta, sem espaços ou interferência.
+
+**Divisão automática.** Placas que excedem sua mesa de impressão são divididas automaticamente em peças imprimíveis. Baixe um ZIP com todas as peças prontas para imprimir e montar.
+
+## Formatos de exportação
+
+| Formato  | Quando usar                                                                         |
+| -------- | ----------------------------------------------------------------------------------- |
+| **STL**  | Direto no seu slicer. Funciona com PrusaSlicer, Cura, OrcaSlicer e todos os outros. |
+| **STEP** | Abra no Fusion 360, FreeCAD ou SolidWorks para editar antes de imprimir.            |
+| **3MF**  | Inclui cor e material. Bom para impressoras multi-material.                         |
+
+## Próximos passos
+
+Precisa de bins sob medida para a placa? Use o [gerador de bins](/pt-BR/gridfinity-bin-generator) para criar bins com compartimentos, recortes e etiquetas. Planeje a gaveta inteira com o [planejador de layout](/pt-BR/), ou confira a [referência de tamanhos](/pt-BR/gridfinity-sizes) para encontrar suas medidas.
+
+[CTA: Gerar placa](/baseplate?standalone=1)

--- a/content/pt-BR/gridfinity-bin-generator.md
+++ b/content/pt-BR/gridfinity-bin-generator.md
@@ -1,0 +1,128 @@
+---
+title: Gerador de bins Gridfinity — Criador STL online gratuito
+description: Gerador de bins Gridfinity com editor visual e prévia 3D em tempo real. Defina dimensões, adicione compartimentos e recortes, exporte para STL, STEP ou 3MF. Ferramenta gratuita no navegador.
+keywords: gridfinity gerador, gerador de bins gridfinity, gerador STL gridfinity, bins gridfinity personalizados, designer gridfinity, gridfinity online
+schema: HowTo
+breadcrumbs:
+  - name: Início
+    url: https://gridfinitylayouttool.com/pt-BR/
+  - name: Gerador de bins
+    url: https://gridfinitylayouttool.com/pt-BR/gridfinity-bin-generator
+howTo:
+  name: Como gerar um bin Gridfinity personalizado
+  description: Defina as dimensões, adicione recursos, visualize em 3D e baixe seu bin Gridfinity em STL, STEP ou 3MF.
+  totalTime: PT5M
+  tools:
+    - Navegador web
+  steps:
+    - name: Definir dimensões do bin
+      text: Escolha largura, profundidade e altura em unidades de grade Gridfinity. Cada unidade tem 42 mm de largura e 7 mm de altura.
+    - name: Escolher base e recursos
+      text: Selecione um estilo de base (padrão, ímã, parafuso ou plana). Adicione compartimentos, recortes na parede, etiquetas ou rampas conforme necessário.
+    - name: Prévia em 3D
+      text: A prévia 3D em tempo real atualiza conforme você muda parâmetros. Gire e dê zoom para inspecionar de todos os ângulos.
+    - name: Exportar e imprimir
+      text: Baixe seu bin em STL, STEP ou 3MF. Abra no seu slicer e imprima.
+softwareApplication:
+  name: Gerador de bins Gridfinity
+  description: Gerador paramétrico de bins Gridfinity com prévia 3D em tempo real. Defina dimensões, adicione compartimentos, recortes e etiquetas, e exporte para STL, STEP ou 3MF. Ferramenta gratuita no navegador.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  offers:
+    price: '0'
+    priceCurrency: USD
+  featureList:
+    - Dimensões de bin paramétricas (largura, profundidade, altura)
+    - Exportação para STL, STEP e 3MF
+    - 6 estilos de base incluindo ímã e parafuso
+    - Padrões de parede em colmeia
+    - Compartimentos configuráveis com divisórias removíveis
+    - Rampas para alcançar peças pequenas
+    - Recortes na parede por lado
+    - Etiquetas com suporte em escora ou maciço
+    - Insertos no piso (retângulo, círculo, hexágono, fenda)
+    - Editor de recortes com ferramenta caneta
+    - Prévia 3D em tempo real
+    - Modo meio-bin com precisão de 0,5 unidade
+    - Roda no navegador, sem instalar nada
+faqs:
+  - q: Quais formatos posso exportar?
+    a: O gerador exporta STL (formato padrão para impressão 3D), STEP (para edição CAD) e 3MF (formato moderno com cor e material). A maioria dos slicers aceita os três.
+  - q: Preciso instalar algum software?
+    a: Não. Roda no navegador. Abra a página e comece — não há nada para baixar ou instalar.
+  - q: Como isso difere dos geradores Gridfinity em OpenSCAD?
+    a: Geradores OpenSCAD exigem instalar software e editar código para mudar parâmetros. Este roda no navegador com interface visual e prévia 3D em tempo real. Você vê as mudanças na hora.
+  - q: Posso criar bins com recortes personalizados?
+    a: Sim. O editor de recortes permite adicionar formas retangulares, circulares ou personalizadas. Use a caneta para desenhar formas complexas com curvas Bézier para porta-ferramentas, gerenciamento de cabos ou qualquer formato especial.
+  - q: Esses bins encaixam nas minhas placas-base?
+    a: Sim. Usam a grade padrão de 42 mm e o perfil do socket. Compatíveis com qualquer placa-base Gridfinity de qualquer fonte.
+  - q: Posso salvar e voltar depois?
+    a: Sim. Os designs são salvos automaticamente no seu navegador. Dê um nome ao design e ele persiste entre sessões.
+  - q: Qual é o tamanho máximo de um bin?
+    a: Até 8×8 unidades de grade (336 mm × 336 mm). Para espaços maiores, use o planejador de layout para organizar vários bins juntos.
+  - q: Onde consigo as placas-base?
+    a: Use o gerador de placas-base para criar uma placa ajustada à sua gaveta, com furos de ímã e folga opcional. Exporte como STL, STEP ou 3MF.
+navCta:
+  label: Abrir gerador
+  href: /designer
+---
+
+# Gerador de bins Gridfinity
+
+Um gerador paramétrico de bins que roda no seu navegador. Defina as dimensões, adicione compartimentos ou recortes, confira a prévia 3D e baixe um arquivo STL, STEP ou 3MF. Nada para instalar. Parte da [suíte Gridfinity Generator](/pt-BR/gridfinity-generator), que também inclui o gerador de placas e o planejador de layout.
+
+[CTA: Criar um bin](/designer)
+
+## Como funciona
+
+1. **Defina o tamanho.** Escolha largura, profundidade e altura em unidades de grade. Precisa de um tamanho intermediário? O modo meio-bin dá precisão de 0,5 unidade.
+2. **Adicione o que precisar.** Compartimentos, recortes na parede, rampas, etiquetas — ative-os e ajuste com sliders.
+3. **Confira a prévia.** A visualização 3D atualiza na hora quando você muda os ajustes. Gire e dê zoom para ver todos os ângulos.
+4. **Baixe e imprima.** Exporte em STL para seu slicer, STEP para editar em CAD ou 3MF para suporte a cor e material.
+
+> Todo o processamento é local. Seus designs ficam no seu dispositivo a menos que você os compartilhe.
+
+## Recursos
+
+**Compartimentos.** Divida um bin em uma grade de seções, até 8×8. As divisórias se geram automaticamente. Você pode exportar divisórias removíveis como arquivos separados para reconfigurar sem reimprimir.
+
+**Rampas e recortes na parede.** Rampas facilitam alcançar peças pequenas no fundo. Recortes na parede — entalhes em U em qualquer lado — permitem retirar coisas pelo lado.
+
+**Etiquetas.** Uma prateleira na parede traseira segura as tiras de etiquetas. Escolha suporte em escora ou maciço e defina a largura por coluna.
+
+Para itens que precisam ficar no lugar, **insertos no piso** abrem cavidades com forma no fundo — círculos para pilhas, hexágonos para bits, retângulos para componentes. Ajuste a profundidade e a rotação de acordo com o que você guarda.
+
+O **editor de recortes** lida com formas incomuns. Mude para o modo sólido, recorte de cima e use a caneta para desenhar trajetos livres para chaves, alicates ou qualquer perfil atípico.
+
+## Opções de base
+
+Como o bin se conecta à sua placa-base:
+
+- **Padrão** — o socket Gridfinity padrão
+- **Ímã** — cavidades para ímãs de 6 mm × 2 mm
+- **Parafuso** — furos para insertos roscados
+- **Ímã e parafuso** — os dois para máxima fixação
+- **Lastreada** — base mais pesada sem ímãs
+- **Plana** — sem socket, para uso sem placa-base
+
+## Formatos de exportação
+
+| Formato  | Quando usar                                                                         |
+| -------- | ----------------------------------------------------------------------------------- |
+| **STL**  | Direto no seu slicer. Funciona com PrusaSlicer, Cura, OrcaSlicer e todos os outros. |
+| **STEP** | Abra no Fusion 360, FreeCAD ou SolidWorks para editar antes de imprimir.            |
+| **3MF**  | Inclui cor e material. Bom para impressoras multi-material.                         |
+
+## Por que isso em vez de OpenSCAD?
+
+Geradores Gridfinity em OpenSCAD funcionam, mas você precisa instalar software e editar código para mudar um parâmetro. Este roda no navegador com interface visual. Você vê o resultado na hora, sem esperar renderização.
+
+Também exporta STEP e 3MF — não só STL — e funciona no celular se você precisar conferir algo no caminho.
+
+## Próximos passos
+
+Novo no Gridfinity? Leia [O que é Gridfinity?](/pt-BR/what-is-gridfinity) para o básico. Já sabe o que precisa? Confira a [referência de tamanhos](/pt-BR/gridfinity-sizes) para encontrar suas dimensões, ou vá direto ao [guia de planejamento](/pt-BR/guide) para organizar uma gaveta inteira.
+
+[CTA: Criar um bin](/designer)

--- a/content/pt-BR/gridfinity-sizes.md
+++ b/content/pt-BR/gridfinity-sizes.md
@@ -1,0 +1,116 @@
+---
+title: Tamanhos Gridfinity — Dimensões dos bins e guia de unidades
+description: Qual é o tamanho de uma unidade Gridfinity? Grade de 42 mm, incrementos de altura de 7 mm. Tabelas de referência para bins, conversão de gaveta e o que cabe onde.
+keywords: tamanhos gridfinity, dimensões gridfinity, tamanhos bin gridfinity, unidades altura gridfinity, gridfinity 42mm, grade gridfinity
+schema: Article
+breadcrumbs:
+  - name: Início
+    url: https://gridfinitylayouttool.com/pt-BR/
+  - name: Referência de tamanhos
+    url: https://gridfinitylayouttool.com/pt-BR/gridfinity-sizes
+faqs:
+  - q: Qual é o tamanho de uma unidade de grade Gridfinity?
+    a: Uma unidade de grade Gridfinity mede 42 mm × 42 mm. Um bin 2×3 tem 84 mm de largura e 126 mm de profundidade. Todos os bins e placas Gridfinity usam esse padrão.
+  - q: Qual é a altura de uma unidade Gridfinity?
+    a: Uma unidade de altura (1U) é 7 mm. Um bin 3U tem cerca de 21 mm de altura interna. As alturas comuns vão de 2U (14 mm) a 10U (70 mm).
+  - q: Como calculo quantas unidades Gridfinity cabem na minha gaveta?
+    a: Meça a largura e a profundidade internas da gaveta em milímetros. Divida cada uma por 42 e arredonde para baixo. Por exemplo, uma gaveta de 380 mm × 260 mm comporta 9 × 6 unidades Gridfinity.
+  - q: O que é o modo meio-bin?
+    a: O modo meio-bin permite incrementos de 0,5 unidade (21 mm) para bins que precisam caber em espaços menores que uma unidade completa. Um bin 1,5×2 ficaria 63 mm × 84 mm.
+---
+
+# Tamanhos e dimensões Gridfinity
+
+O Gridfinity usa dois números: **unidades de grade** para a largura e a profundidade de um bin e **unidades de altura** para a altura. Conhecendo-os, você sabe o que cabe na sua gaveta e quais bins imprimir.
+
+## Unidades de grade (largura e profundidade)
+
+**1 unidade de grade = 42 mm.** Todo bin e placa-base Gridfinity usa isso. Um bin "2×3" tem 2 unidades de largura (84 mm) e 3 de profundidade (126 mm).
+
+| Unidades  | Milímetros | Polegadas (aprox.) |
+| --------- | ---------- | ------------------ |
+| 1 unidade | 42 mm      | 1,65″              |
+| 2         | 84 mm      | 3,31″              |
+| 3         | 126 mm     | 4,96″              |
+| 4         | 168 mm     | 6,61″              |
+| 5         | 210 mm     | 8,27″              |
+| 6         | 252 mm     | 9,92″              |
+| 7         | 294 mm     | 11,57″             |
+| 8         | 336 mm     | 13,23″             |
+
+### Modo meio-bin
+
+Para encaixes mais apertados, o modo meio-bin usa **incrementos de 0,5 unidade (21 mm)**. Um bin 1,5×2,5 ficaria 63 mm × 105 mm. Ative-o na ferramenta de layout pressionando `H`.
+
+## Unidades de altura
+
+**1 unidade de altura (1U) = 7 mm.** É o espaço vertical disponível dentro do bin. Um bin 3U comporta itens de até cerca de 21 mm de altura.
+
+| Altura | Interno (mm) | Uso típico                                      |
+| ------ | ------------ | ----------------------------------------------- |
+| 2U     | 14 mm        | Cartões SD, parafusos pequenos, clipes          |
+| 3U     | 21 mm        | Pen drives, pilhas AA, parafusos                |
+| 4U     | 28 mm        | Canetas, marcadores, brocas                     |
+| 5U     | 35 mm        | Tesouras, rolos de fita, ferramentas pequenas   |
+| 6U     | 42 mm        | Chaves de fenda, alicates (profundidade padrão) |
+| 7U     | 49 mm        | Aerossóis, ferramentas grandes                  |
+| 8U     | 56 mm        | Bisnagas de cola, recipientes altos             |
+| 10U    | 70 mm        | Armazenamento profundo, itens volumosos         |
+
+> **Verifique a folga:** Seu bin mais alto somado à placa-base (~5 mm) precisa caber com a gaveta fechada. Meça a altura interna da gaveta fechada antes de optar por bins altos.
+
+## Converter as medidas da gaveta
+
+Pegue uma trena e tire as dimensões internas da gaveta em milímetros. Depois:
+
+1. Meça largura e profundidade internas em milímetros
+2. Divida cada uma por 42
+3. Arredonde para baixo até o inteiro (ou meio, no modo meio-bin)
+
+### Exemplo
+
+```text
+Largura da gaveta:     380 mm ÷ 42 = 9,04 → 9 unidades
+Profundidade da gaveta: 520 mm ÷ 42 = 12,38 → 12 unidades
+Tamanho de layout:     9 × 12 (378 mm × 504 mm)
+Folga nas bordas:      2 mm de largura, 16 mm de profundidade
+```
+
+Pequenas folgas nas bordas são normais. As placas-base não precisam cobrir cada milímetro. Geralmente as pessoas centralizam as placas e ignoram a folga.
+
+## Tamanhos comuns de bin
+
+São os mais impressos. Você pode criar qualquer um (ou um tamanho personalizado) no [gerador de bins](/pt-BR/gridfinity-bin-generator).
+
+| Bin | Dimensões (mm) | Usos comuns                                 |
+| --- | -------------- | ------------------------------------------- |
+| 1×1 | 42 × 42        | Parafusos avulsos, porcas, componentes mini |
+| 1×2 | 42 × 84        | Canetas, cabos USB, pilhas em fila          |
+| 1×3 | 42 × 126       | Chaves de fenda, réguas, ferramentas longas |
+| 2×2 | 84 × 84        | Fita, bastões de cola, trenas               |
+| 2×3 | 84 × 126       | Alicates, cortadores, ferramentas médias    |
+| 3×3 | 126 × 126      | Kits de brocas, acessórios grandes          |
+| 4×2 | 168 × 84       | Soquetes, paquímetros                       |
+
+## Cabe na sua mesa de impressão?
+
+A maioria das impressoras FDM tem mesa de 220–256 mm, que comporta bins até cerca de 5×5 ou 6×6 unidades. Para algo maior é preciso dividir ou imprimir em seções. A ferramenta de layout assume por padrão mesa de 256 mm e sinaliza bins que não cabem.
+
+## Referência rápida
+
+| Medida                   | Valor            |
+| ------------------------ | ---------------- |
+| Unidade de grade         | 42 mm × 42 mm    |
+| Meia unidade de grade    | 21 mm            |
+| Unidade de altura (1U)   | 7 mm             |
+| Espessura da placa-base  | ~5 mm            |
+| Mesa de impressão padrão | 256 mm           |
+| Grade máx. (ferramenta)  | 50 × 50 unidades |
+
+## Próximos passos
+
+Agora que você conhece os tamanhos, [gere um bin personalizado](/pt-BR/gridfinity-bin-generator) ou abra o [planejador de layout](/pt-BR/) para ver como os bins cabem na sua gaveta.
+
+Novo no Gridfinity? [Aqui está uma visão geral](/pt-BR/what-is-gridfinity) de como o sistema funciona.
+
+[CTA: Planejar meu layout](/)

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -149,17 +149,179 @@
     <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-bin-generator"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/de/gridfinity-bin-generator</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-bin-generator"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/fr/gridfinity-bin-generator</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-bin-generator"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/es/gridfinity-bin-generator</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-bin-generator"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/pt-BR/gridfinity-bin-generator</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-bin-generator"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-bin-generator"/>
   </url>
   <url>
     <loc>https://gridfinitylayouttool.com/gridfinity-baseplate-generator</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-baseplate-generator"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/de/gridfinity-baseplate-generator</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-baseplate-generator"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/fr/gridfinity-baseplate-generator</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-baseplate-generator"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/es/gridfinity-baseplate-generator</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-baseplate-generator"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/pt-BR/gridfinity-baseplate-generator</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-baseplate-generator"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-baseplate-generator"/>
   </url>
   <url>
     <loc>https://gridfinitylayouttool.com/gridfinity-sizes</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-sizes"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/de/gridfinity-sizes</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-sizes"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/fr/gridfinity-sizes</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-sizes"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/es/gridfinity-sizes</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-sizes"/>
+  </url>
+  <url>
+    <loc>https://gridfinitylayouttool.com/pt-BR/gridfinity-sizes</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://gridfinitylayouttool.com/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://gridfinitylayouttool.com/de/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://gridfinitylayouttool.com/fr/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://gridfinitylayouttool.com/es/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://gridfinitylayouttool.com/pt-BR/gridfinity-sizes"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://gridfinitylayouttool.com/gridfinity-sizes"/>
   </url>
 </urlset>

--- a/vercel.json
+++ b/vercel.json
@@ -248,6 +248,42 @@
       "destination": "/pt-BR/what-is-gridfinity/index.html"
     },
     { "source": "/pt-BR/guide", "destination": "/pt-BR/guide/index.html" },
+    {
+      "source": "/de/gridfinity-bin-generator",
+      "destination": "/de/gridfinity-bin-generator/index.html"
+    },
+    {
+      "source": "/de/gridfinity-baseplate-generator",
+      "destination": "/de/gridfinity-baseplate-generator/index.html"
+    },
+    { "source": "/de/gridfinity-sizes", "destination": "/de/gridfinity-sizes/index.html" },
+    {
+      "source": "/fr/gridfinity-bin-generator",
+      "destination": "/fr/gridfinity-bin-generator/index.html"
+    },
+    {
+      "source": "/fr/gridfinity-baseplate-generator",
+      "destination": "/fr/gridfinity-baseplate-generator/index.html"
+    },
+    { "source": "/fr/gridfinity-sizes", "destination": "/fr/gridfinity-sizes/index.html" },
+    {
+      "source": "/es/gridfinity-bin-generator",
+      "destination": "/es/gridfinity-bin-generator/index.html"
+    },
+    {
+      "source": "/es/gridfinity-baseplate-generator",
+      "destination": "/es/gridfinity-baseplate-generator/index.html"
+    },
+    { "source": "/es/gridfinity-sizes", "destination": "/es/gridfinity-sizes/index.html" },
+    {
+      "source": "/pt-BR/gridfinity-bin-generator",
+      "destination": "/pt-BR/gridfinity-bin-generator/index.html"
+    },
+    {
+      "source": "/pt-BR/gridfinity-baseplate-generator",
+      "destination": "/pt-BR/gridfinity-baseplate-generator/index.html"
+    },
+    { "source": "/pt-BR/gridfinity-sizes", "destination": "/pt-BR/gridfinity-sizes/index.html" },
     { "source": "/designer", "destination": "/" },
     { "source": "/baseplate", "destination": "/" },
     { "source": "/s/:id([a-zA-Z0-9]{12})", "destination": "/" },


### PR DESCRIPTION
Completes the international SEO push started in #1711 / #1714 / #1717. The 3 generator landing pages (\`/gridfinity-bin-generator\`, \`/gridfinity-baseplate-generator\`, \`/gridfinity-sizes\`) now ship in 4 additional locales — bringing the site's crawlable, locale-targeted HTML count to **27 pages across 7 slugs**.

## Summary

**12 new translation files** under \`content/{de,fr,es,pt-BR}/\`. Terminology anchored to the in-app glossary: "Bin" stays as a loanword across all locales (matching \`grid.bin\` in \`de/fr/es/pt-BR.json\`); "baseplate" becomes Grundplatte / plaque de base / placa base / placa-base.

Each translated page preserves the full schema stack from its English counterpart:
- \`gridfinity-bin-generator\` × 4 locales: HowTo (4 steps) + SoftwareApplication (13 features) + BreadcrumbList + FAQPage (8 Q&A)
- \`gridfinity-baseplate-generator\` × 4 locales: HowTo (4 steps) + SoftwareApplication (9 features) + BreadcrumbList + FAQPage (6 Q&A)
- \`gridfinity-sizes\` × 4 locales: Article + BreadcrumbList + FAQPage (4 Q&A)

Visible HTML and JSON-LD derive from the same markdown frontmatter, so the schema-DOM alignment is automatic per locale (no drift risk).

## Infrastructure

\`sitemap.xml\` regenerated programmatically — grew from 15 to 27 URLs, each carrying its 6-link hreflang cluster (en + 4 locales + x-default). All 5 markdown-driven slugs now have full bidirectional locale coverage.

\`vercel.json\` gets 12 new rewrites mapping the locale content paths to their static HTML output. The locale-subtree \`Content-Language\` + \`Cache-Control\` headers added in #1714 already cover these new URLs via the existing \`/de/(.*) /fr/(.*) /es/(.*) /pt-BR/(.*)\` patterns — no new header rules needed.

## Test plan

- [x] Build succeeds; emits 27 pages across 7 slugs
- [x] Every generated JSON-LD block parses as valid JSON (validated all 12 new locale pages × 3-4 blocks each)
- [x] \`<html lang>\` matches the locale on every page
- [x] Hreflang cluster on each page lists all 5 locales bidirectionally + x-default
- [x] \`sitemap.xml\` is valid XML, every localized URL has 6 \`xhtml:link\` alternates
- [x] \`vercel.json\` is valid JSON
- [ ] Google Search Console picks up the 12 new locale URLs after sitemap re-submission post-deploy
- [ ] Spot-check rendering of \`/de/gridfinity-bin-generator\`, \`/fr/gridfinity-baseplate-generator\`, \`/es/gridfinity-sizes\` in preview deploy