### PR TITLE
feat(help): add unified search to MobileHelpModal

### DIFF
--- a/src/shell/Mobile/MobileHelpModal/MobileHelpModal.test.tsx
+++ b/src/shell/Mobile/MobileHelpModal/MobileHelpModal.test.tsx
@@ -1,12 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MobileHelpModal } from './MobileHelpModal';
 import { resetAllStores } from '@/test/testUtils';
 
 vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => {
+  useTranslation: () => (key: string, vars?: Record<string, string>) => {
     if (key === 'mobile.help') return 'Mobile Help';
     if (key === 'common.close') return 'Close';
+    if (key === 'help.searchPlaceholder') return 'Search shortcuts and features...';
+    if (key === 'help.noResultsFor' && vars) return `No matches for "${vars.query}"`;
     return key;
   },
 }));
@@ -32,5 +34,32 @@ describe('MobileHelpModal', () => {
     const onClose = vi.fn();
     render(<MobileHelpModal isOpen={true} onClose={onClose} />);
     expect(screen.getByText('Mobile Help')).toBeInTheDocument();
+  });
+
+  it('shows the search input', () => {
+    const onClose = vi.fn();
+    render(<MobileHelpModal isOpen={true} onClose={onClose} />);
+    expect(screen.getByPlaceholderText('Search shortcuts and features...')).toBeInTheDocument();
+  });
+
+  it('hides the gesture sections and shows results when typing', () => {
+    const onClose = vi.fn();
+    render(<MobileHelpModal isOpen={true} onClose={onClose} />);
+
+    const input = screen.getByPlaceholderText('Search shortcuts and features...');
+    fireEvent.change(input, { target: { value: 'bed size' } });
+
+    // The "Drawing & Selection" section is hidden when searching.
+    expect(screen.queryByText('mobile.help.drawingSelection')).toBeNull();
+  });
+
+  it('shows the no-results message when no matches', () => {
+    const onClose = vi.fn();
+    render(<MobileHelpModal isOpen={true} onClose={onClose} />);
+
+    const input = screen.getByPlaceholderText('Search shortcuts and features...');
+    fireEvent.change(input, { target: { value: 'xyznonexistent' } });
+
+    expect(screen.getByText('No matches for "xyznonexistent"')).toBeInTheDocument();
   });
 });

--- a/src/shell/Mobile/MobileHelpModal/MobileHelpModal.test.tsx
+++ b/src/shell/Mobile/MobileHelpModal/MobileHelpModal.test.tsx
@@ -9,6 +9,7 @@ vi.mock('@/i18n', () => ({
     if (key === 'common.close') return 'Close';
     if (key === 'help.searchPlaceholder') return 'Search shortcuts and features...';
     if (key === 'help.noResultsFor' && vars) return `No matches for "${vars.query}"`;
+    if (key === 'help.searchResultsAriaLabel') return 'Search results';
     return key;
   },
 }));
@@ -51,6 +52,8 @@ describe('MobileHelpModal', () => {
 
     // The "Drawing & Selection" section is hidden when searching.
     expect(screen.queryByText('mobile.help.drawingSelection')).toBeNull();
+    // ...and the results list is rendered (matched by its aria-label).
+    expect(screen.getByLabelText('Search results')).toBeInTheDocument();
   });
 
   it('shows the no-results message when no matches', () => {
@@ -61,5 +64,22 @@ describe('MobileHelpModal', () => {
     fireEvent.change(input, { target: { value: 'xyznonexistent' } });
 
     expect(screen.getByText('No matches for "xyznonexistent"')).toBeInTheDocument();
+  });
+
+  it('clears the search query when the modal is closed (no stale filter on reopen)', () => {
+    const onClose = vi.fn();
+    const { rerender } = render(<MobileHelpModal isOpen={true} onClose={onClose} />);
+
+    const input = screen.getByPlaceholderText('Search shortcuts and features...');
+    fireEvent.change(input, { target: { value: 'bed size' } });
+    expect(input.value).toBe('bed size');
+
+    // Trigger the X close button — the handler should clear search first.
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(onClose).toHaveBeenCalled();
+
+    rerender(<MobileHelpModal isOpen={true} onClose={onClose} />);
+    const reopenedInput = screen.getByPlaceholderText('Search shortcuts and features...');
+    expect(reopenedInput.value).toBe('');
   });
 });

--- a/src/shell/Mobile/MobileHelpModal/MobileHelpModal.tsx
+++ b/src/shell/Mobile/MobileHelpModal/MobileHelpModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { useTranslation } from '@/i18n';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import { getAllHelpEntries } from '@/shell/Modals/HelpModal/helpEntryAggregator';
@@ -61,6 +61,13 @@ export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
   const trimmedQuery = searchQuery.trim();
   const isSearching = trimmedQuery.length > 0;
 
+  // Reset search on every close path so re-opening starts at the gesture
+  // sections, not a stale filtered view.
+  const handleClose = useCallback(() => {
+    setSearchQuery('');
+    onClose();
+  }, [onClose]);
+
   const allEntries = useMemo(() => getAllHelpEntries(), []);
   const rankedResults = useMemo(
     () => (isSearching ? searchHelpEntries(allEntries, trimmedQuery, t) : []),
@@ -72,7 +79,7 @@ export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
 
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        onClose();
+        handleClose();
       }
     };
 
@@ -83,7 +90,7 @@ export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
       document.body.style.overflow = '';
       document.removeEventListener('keydown', handleEscape);
     };
-  }, [isOpen, onClose]);
+  }, [isOpen, handleClose]);
 
   if (!isOpen) return null;
 
@@ -93,7 +100,7 @@ export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
     <div
       className="fixed inset-0 flex items-end sm:items-center justify-center z-50 animate-fade-in"
       style={STYLES.overlay}
-      onClick={onClose}
+      onClick={handleClose}
       role="presentation"
     >
       <div role="presentation" onClick={(e) => e.stopPropagation()}>
@@ -114,7 +121,7 @@ export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
               {t('mobile.help')}
             </h2>
             <button
-              onClick={onClose}
+              onClick={handleClose}
               className="btn btn-ghost w-10 h-10 p-0"
               aria-label={t('common.close')}
             >
@@ -132,6 +139,8 @@ export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
           {/* Search */}
           <div className="relative mb-4">
             <svg
+              aria-hidden="true"
+              focusable="false"
               className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-content-tertiary"
               fill="none"
               viewBox="0 0 24 24"
@@ -146,6 +155,7 @@ export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder={t('help.searchPlaceholder')}
+              aria-label={t('help.searchPlaceholder')}
               className="w-full pl-9 pr-9 py-2 text-sm rounded-md bg-surface border border-stroke-subtle text-content placeholder:text-content-tertiary"
             />
             {searchQuery && (
@@ -154,7 +164,14 @@ export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
                 className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded text-content-tertiary hover:text-content"
                 aria-label={t('layouts.clearSearch')}
               >
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg
+                  aria-hidden="true"
+                  focusable="false"
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
                   {ICON_PATHS.close.map((d) => (
                     <path
                       key={d}
@@ -174,7 +191,7 @@ export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
               results={rankedResults}
               modifierKey={modifierKey}
               query={trimmedQuery}
-              onJump={onClose}
+              onJump={handleClose}
             />
           ) : (
             <div className="space-y-5">

--- a/src/shell/Mobile/MobileHelpModal/MobileHelpModal.tsx
+++ b/src/shell/Mobile/MobileHelpModal/MobileHelpModal.tsx
@@ -1,5 +1,10 @@
-import { useEffect, type CSSProperties } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { useTranslation } from '@/i18n';
+import { ICON_PATHS } from '@/shared/constants/iconPaths';
+import { getAllHelpEntries } from '@/shell/Modals/HelpModal/helpEntryAggregator';
+import { searchHelpEntries } from '@/shell/Modals/HelpModal/helpSearch';
+import { HelpSearchResultRow } from '@/shell/Modals/HelpModal/HelpSearchResultRow';
+import { getModifierKey } from '@/shell/Modals/HelpModal/helpModalStyles';
 
 // Style constants to avoid recreating objects on each render
 const STYLES = {
@@ -52,6 +57,15 @@ interface MobileHelpModalProps {
  */
 export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
   const t = useTranslation();
+  const [searchQuery, setSearchQuery] = useState('');
+  const trimmedQuery = searchQuery.trim();
+  const isSearching = trimmedQuery.length > 0;
+
+  const allEntries = useMemo(() => getAllHelpEntries(), []);
+  const rankedResults = useMemo(
+    () => (isSearching ? searchHelpEntries(allEntries, trimmedQuery, t) : []),
+    [allEntries, trimmedQuery, isSearching, t]
+  );
 
   useEffect(() => {
     if (!isOpen) return;
@@ -72,6 +86,8 @@ export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
   }, [isOpen, onClose]);
 
   if (!isOpen) return null;
+
+  const modifierKey = getModifierKey();
 
   return (
     <div
@@ -113,140 +129,226 @@ export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
             </button>
           </div>
 
-          <div className="space-y-5">
-            {/* Drawing & Selection */}
-            <section>
-              <h3 className="mb-3" style={STYLES.sectionHeader}>
-                {t('mobile.help.drawingSelection')}
-              </h3>
-              <div className="space-y-3 p-3 rounded-lg" style={STYLES.sectionContent}>
-                <GestureRow
-                  icon={<TapIcon />}
-                  gesture={t('help.gesture.tapBin')}
-                  description={t('help.gesture.selectBin')}
-                />
-                <GestureRow
-                  icon={<DragIcon />}
-                  gesture={t('help.gesture.dragEmpty')}
-                  description={t('help.gesture.drawNewBin')}
-                />
-                <GestureRow
-                  icon={<DragIcon />}
-                  gesture={t('help.gesture.dragSelected')}
-                  description={t('help.gesture.moveBin')}
-                />
-                <GestureRow
-                  icon={<LongPressIcon />}
-                  gesture={t('help.gesture.longPress')}
-                  description={t('help.gesture.openContextMenu')}
-                />
-              </div>
-            </section>
-
-            {/* Editing */}
-            <section>
-              <h3 className="mb-3" style={STYLES.sectionHeader}>
-                {t('mobile.help.editing')}
-              </h3>
-              <div className="space-y-3 p-3 rounded-lg" style={STYLES.sectionContent}>
-                <GestureRow
-                  icon={<DragEdgeIcon />}
-                  gesture={t('help.gesture.dragEdge')}
-                  description={t('help.gesture.resizeBin')}
-                />
-                <GestureRow
-                  icon={<DragCornerIcon />}
-                  gesture={t('help.gesture.dragCorner')}
-                  description={t('help.gesture.resizeWidthDepth')}
-                />
-                <GestureRow
-                  icon={<DragIcon />}
-                  gesture={t('help.gesture.dragToStash')}
-                  description={t('help.gesture.moveToStaging')}
-                />
-              </div>
-            </section>
-
-            {/* Paint Mode */}
-            <section>
-              <h3 className="mb-3" style={STYLES.sectionHeader}>
-                {t('mobile.help.paintMode')}
-              </h3>
-              <div className="space-y-3 p-3 rounded-lg" style={STYLES.sectionContent}>
-                <GestureRow
-                  icon={<TapIcon />}
-                  gesture={t('help.gesture.tapPalette')}
-                  description={t('help.gesture.enterPaintMode')}
-                />
-                <GestureRow
-                  icon={<DragIcon />}
-                  gesture={t('help.gesture.dragGrid')}
-                  description={t('help.gesture.fillArea')}
-                />
-                <GestureRow
-                  icon={<TapIcon />}
-                  gesture={t('help.gesture.tapClose', { button: t('common.close') })}
-                  description={t('help.gesture.exitPaintMode')}
-                />
-              </div>
-            </section>
-
-            {/* Navigation */}
-            <section>
-              <h3 className="mb-3" style={STYLES.sectionHeader}>
-                {t('mobile.help.navigation')}
-              </h3>
-              <div className="space-y-3 p-3 rounded-lg" style={STYLES.sectionContent}>
-                <GestureRow
-                  icon={<SwipeDownIcon />}
-                  gesture={t('help.gesture.swipeDown')}
-                  description={t('help.gesture.closeBottomSheet')}
-                />
-                <GestureRow
-                  icon={<TapIcon />}
-                  gesture={t('help.gesture.tapLayer')}
-                  description={t('help.gesture.switchLayers')}
-                />
-                <GestureRow
-                  icon={<TapIcon />}
-                  gesture={t('help.gesture.tapStriped')}
-                  description={t('help.gesture.jumpToBlocking')}
-                />
-              </div>
-            </section>
-
-            {/* Tips */}
-            <section>
-              <h3 className="mb-3" style={STYLES.sectionHeader}>
-                {t('mobile.help.tips')}
-              </h3>
-              <ul className="space-y-2 p-3 rounded-lg" style={STYLES.tipsList}>
-                <li className="flex items-start gap-2">
-                  <span style={STYLES.colorPrimary}>•</span>
-                  <span>{t('mobile.help.longPressABinToDuplicateDeleteOrMov')}</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <span style={STYLES.colorPrimary}>•</span>
-                  <span>{t('mobile.help.tapThe3dCubeIconToSeeYourLayoutInIs')}</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <span style={STYLES.colorPrimary}>•</span>
-                  <span>{t('mobile.help.withKeyboardMToMoveBinsRToResizeVFo')}</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <span style={STYLES.colorPrimary}>•</span>
-                  <span>{t('mobile.help.oversizedBinsAreAutomaticallySplitF')}</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <span style={STYLES.colorPrimary}>•</span>
-                  <span>{t('mobile.help.yourLayoutAutoSavesToYourBrowser')}</span>
-                </li>
-              </ul>
-            </section>
+          {/* Search */}
+          <div className="relative mb-4">
+            <svg
+              className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-content-tertiary"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              {ICON_PATHS.search.map((d) => (
+                <path key={d} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
+              ))}
+            </svg>
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder={t('help.searchPlaceholder')}
+              className="w-full pl-9 pr-9 py-2 text-sm rounded-md bg-surface border border-stroke-subtle text-content placeholder:text-content-tertiary"
+            />
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery('')}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded text-content-tertiary hover:text-content"
+                aria-label={t('layouts.clearSearch')}
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  {ICON_PATHS.close.map((d) => (
+                    <path
+                      key={d}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d={d}
+                    />
+                  ))}
+                </svg>
+              </button>
+            )}
           </div>
+
+          {isSearching ? (
+            <MobileSearchResultsList
+              results={rankedResults}
+              modifierKey={modifierKey}
+              query={trimmedQuery}
+              onJump={onClose}
+            />
+          ) : (
+            <div className="space-y-5">
+              {/* Drawing & Selection */}
+              <section>
+                <h3 className="mb-3" style={STYLES.sectionHeader}>
+                  {t('mobile.help.drawingSelection')}
+                </h3>
+                <div className="space-y-3 p-3 rounded-lg" style={STYLES.sectionContent}>
+                  <GestureRow
+                    icon={<TapIcon />}
+                    gesture={t('help.gesture.tapBin')}
+                    description={t('help.gesture.selectBin')}
+                  />
+                  <GestureRow
+                    icon={<DragIcon />}
+                    gesture={t('help.gesture.dragEmpty')}
+                    description={t('help.gesture.drawNewBin')}
+                  />
+                  <GestureRow
+                    icon={<DragIcon />}
+                    gesture={t('help.gesture.dragSelected')}
+                    description={t('help.gesture.moveBin')}
+                  />
+                  <GestureRow
+                    icon={<LongPressIcon />}
+                    gesture={t('help.gesture.longPress')}
+                    description={t('help.gesture.openContextMenu')}
+                  />
+                </div>
+              </section>
+
+              {/* Editing */}
+              <section>
+                <h3 className="mb-3" style={STYLES.sectionHeader}>
+                  {t('mobile.help.editing')}
+                </h3>
+                <div className="space-y-3 p-3 rounded-lg" style={STYLES.sectionContent}>
+                  <GestureRow
+                    icon={<DragEdgeIcon />}
+                    gesture={t('help.gesture.dragEdge')}
+                    description={t('help.gesture.resizeBin')}
+                  />
+                  <GestureRow
+                    icon={<DragCornerIcon />}
+                    gesture={t('help.gesture.dragCorner')}
+                    description={t('help.gesture.resizeWidthDepth')}
+                  />
+                  <GestureRow
+                    icon={<DragIcon />}
+                    gesture={t('help.gesture.dragToStash')}
+                    description={t('help.gesture.moveToStaging')}
+                  />
+                </div>
+              </section>
+
+              {/* Paint Mode */}
+              <section>
+                <h3 className="mb-3" style={STYLES.sectionHeader}>
+                  {t('mobile.help.paintMode')}
+                </h3>
+                <div className="space-y-3 p-3 rounded-lg" style={STYLES.sectionContent}>
+                  <GestureRow
+                    icon={<TapIcon />}
+                    gesture={t('help.gesture.tapPalette')}
+                    description={t('help.gesture.enterPaintMode')}
+                  />
+                  <GestureRow
+                    icon={<DragIcon />}
+                    gesture={t('help.gesture.dragGrid')}
+                    description={t('help.gesture.fillArea')}
+                  />
+                  <GestureRow
+                    icon={<TapIcon />}
+                    gesture={t('help.gesture.tapClose', { button: t('common.close') })}
+                    description={t('help.gesture.exitPaintMode')}
+                  />
+                </div>
+              </section>
+
+              {/* Navigation */}
+              <section>
+                <h3 className="mb-3" style={STYLES.sectionHeader}>
+                  {t('mobile.help.navigation')}
+                </h3>
+                <div className="space-y-3 p-3 rounded-lg" style={STYLES.sectionContent}>
+                  <GestureRow
+                    icon={<SwipeDownIcon />}
+                    gesture={t('help.gesture.swipeDown')}
+                    description={t('help.gesture.closeBottomSheet')}
+                  />
+                  <GestureRow
+                    icon={<TapIcon />}
+                    gesture={t('help.gesture.tapLayer')}
+                    description={t('help.gesture.switchLayers')}
+                  />
+                  <GestureRow
+                    icon={<TapIcon />}
+                    gesture={t('help.gesture.tapStriped')}
+                    description={t('help.gesture.jumpToBlocking')}
+                  />
+                </div>
+              </section>
+
+              {/* Tips */}
+              <section>
+                <h3 className="mb-3" style={STYLES.sectionHeader}>
+                  {t('mobile.help.tips')}
+                </h3>
+                <ul className="space-y-2 p-3 rounded-lg" style={STYLES.tipsList}>
+                  <li className="flex items-start gap-2">
+                    <span style={STYLES.colorPrimary}>•</span>
+                    <span>{t('mobile.help.longPressABinToDuplicateDeleteOrMov')}</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span style={STYLES.colorPrimary}>•</span>
+                    <span>{t('mobile.help.tapThe3dCubeIconToSeeYourLayoutInIs')}</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span style={STYLES.colorPrimary}>•</span>
+                    <span>{t('mobile.help.withKeyboardMToMoveBinsRToResizeVFo')}</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span style={STYLES.colorPrimary}>•</span>
+                    <span>{t('mobile.help.oversizedBinsAreAutomaticallySplitF')}</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span style={STYLES.colorPrimary}>•</span>
+                    <span>{t('mobile.help.yourLayoutAutoSavesToYourBrowser')}</span>
+                  </li>
+                </ul>
+              </section>
+            </div>
+          )}
         </div>
       </div>
     </div>
+  );
+}
+
+interface MobileSearchResultsListProps {
+  results: ReturnType<typeof searchHelpEntries>;
+  modifierKey: string;
+  query: string;
+  onJump: () => void;
+}
+
+function MobileSearchResultsList({
+  results,
+  modifierKey,
+  query,
+  onJump,
+}: MobileSearchResultsListProps) {
+  const t = useTranslation();
+  if (results.length === 0) {
+    return (
+      <div className="text-center py-6 text-content-tertiary text-sm">
+        {t('help.noResultsFor', { query })}
+      </div>
+    );
+  }
+  return (
+    <ul aria-label={t('help.searchResultsAriaLabel')} className="space-y-1">
+      {results.map(({ entry }) => (
+        <li key={entry.id}>
+          <HelpSearchResultRow
+            entry={entry}
+            modifierKey={modifierKey}
+            onJump={onJump}
+            showJumpButton={false}
+          />
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/src/shell/Modals/HelpModal/HelpSearchResultRow.test.tsx
+++ b/src/shell/Modals/HelpModal/HelpSearchResultRow.test.tsx
@@ -67,4 +67,25 @@ describe('HelpSearchResultRow', () => {
     expect(screen.queryByRole('button', { name: 'help.goTo' })).toBeNull();
     expect(screen.getByText('help.tip.halfBin')).toBeTruthy();
   });
+
+  it('suppresses the Go-to button on feature entries when showJumpButton=false', () => {
+    const feature: HelpEntry = {
+      id: 'feature/grid-editor/print-bed-size',
+      kind: 'feature',
+      titleKey: 'help.target.printBedSize.title',
+      descriptionKey: 'help.target.printBedSize.description',
+      target: { surface: 'sidebar:physical-units', controlId: 'print-bed-size' },
+    };
+    render(
+      <HelpSearchResultRow
+        entry={feature}
+        modifierKey="⌘"
+        onJump={vi.fn()}
+        showJumpButton={false}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'help.goTo' })).toBeNull();
+    expect(screen.getByText('help.target.printBedSize.title')).toBeTruthy();
+  });
 });

--- a/src/shell/Modals/HelpModal/HelpSearchResultRow.tsx
+++ b/src/shell/Modals/HelpModal/HelpSearchResultRow.tsx
@@ -14,9 +14,20 @@ interface HelpSearchResultRowProps {
   entry: HelpEntry;
   modifierKey: string;
   onJump: () => void;
+  /**
+   * Whether to render the Go-to deep-link button on feature entries.
+   * Defaults to true; mobile suppresses it until mobile surfaces expose
+   * data-help-target attributes (planned follow-up).
+   */
+  showJumpButton?: boolean;
 }
 
-export function HelpSearchResultRow({ entry, modifierKey, onJump }: HelpSearchResultRowProps) {
+export function HelpSearchResultRow({
+  entry,
+  modifierKey,
+  onJump,
+  showJumpButton = true,
+}: HelpSearchResultRowProps) {
   const t = useTranslation();
   const title = t(entry.titleKey);
   const description = entry.titleKey === entry.descriptionKey ? null : t(entry.descriptionKey);
@@ -34,7 +45,7 @@ export function HelpSearchResultRow({ entry, modifierKey, onJump }: HelpSearchRe
       </div>
       {entry.kind === 'shortcut' ? (
         <ShortcutKeyCaps entry={entry} modifierKey={modifierKey} />
-      ) : entry.kind === 'feature' ? (
+      ) : entry.kind === 'feature' && showJumpButton ? (
         <button
           type="button"
           className="btn btn-secondary btn-sm shrink-0"


### PR DESCRIPTION
## Summary

Mirrors the natural-language Help search shipped for desktop (#1737) onto the mobile help modal.

## What changes

- `MobileHelpModal.tsx`: search bar at the top; typing collapses the existing gesture sections and renders a `MobileSearchResultsList` against the shared catalog.
- `HelpSearchResultRow.tsx`: new optional `showJumpButton` prop (default `true`) so the desktop modal is unchanged and mobile can suppress the Go-to button cleanly without forking the component.
- 3 new sibling tests covering search bar presence, section-hiding while typing, and the no-results message.

## Why feature entries are description-only on mobile (for now)

The desktop `Sidebar` is not mounted on mobile (per `MobileSettingsPanel.tsx:308`). The dispatcher's window event would fire to no listener and the `[data-help-target]` element wouldn't exist in the mobile DOM. Rather than show a broken Go-to button, mobile entries render their title + description + Feature badge only. A follow-up PR will:

1. Add `data-help-target` markers to `MobileSettingsPanel` controls (Print bed, drawer size, grid unit, height unit, half-bin, etc).
2. Add help-jump listeners to `MobileSettingsPanel` so it opens itself + the right tab/section before the dispatcher pulses.
3. Drop the `showJumpButton={false}` override here.

Until then, the user gets the "what exists and what it does" benefit on mobile — a strict improvement over today's zero-results dead-end.

## Test plan

- [x] `pnpm run typecheck`, `pnpm run lint` clean
- [x] 6 sibling tests pass
- [ ] Manual on mobile: open Help, search "bed size", see Print bed size result with description (no Go-to button)
- [ ] Manual on mobile: clear search, original gesture sections return