### PR TITLE
feat(help): ⌘K initialQuery + empty-state CTA + telemetry

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,6 +111,19 @@ export default function App() {
   const { open: commandPaletteOpen, setOpen: setCommandPaletteOpen } = useCommandPalette({
     disabled: isDesignerRoute || isBaseplateRoute,
   });
+  const [commandPaletteInitialQuery, setCommandPaletteInitialQuery] = useState('');
+
+  // Allow external surfaces (e.g. HelpModal's empty-state fall-through) to open
+  // the command palette pre-filled with a query via a window event — matches
+  // the existing `open-settings-modal` / `switch-to-designer` dispatch pattern.
+  useEffect(() => {
+    const handler = (e: CustomEvent<{ query?: string }>) => {
+      setCommandPaletteInitialQuery(e.detail.query ?? '');
+      setCommandPaletteOpen(true);
+    };
+    window.addEventListener('open-command-palette', handler as EventListener);
+    return () => window.removeEventListener('open-command-palette', handler as EventListener);
+  }, [setCommandPaletteOpen]);
   const { isMobile, isTablet } = useResponsive();
 
   const { shouldShowWelcome, shouldShowDrawTutorial, markWelcomeComplete } = useOnboarding();
@@ -443,7 +456,11 @@ export default function App() {
       <ToastContainer />
       {!isMobile && commandPaletteOpen && (
         <Suspense fallback={null}>
-          <CommandPalette open={commandPaletteOpen} onOpenChange={setCommandPaletteOpen} />
+          <CommandPalette
+            open={commandPaletteOpen}
+            onOpenChange={setCommandPaletteOpen}
+            initialQuery={commandPaletteInitialQuery}
+          />
         </Suspense>
       )}
       {isLabsDrawerOpen && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -458,7 +458,12 @@ export default function App() {
         <Suspense fallback={null}>
           <CommandPalette
             open={commandPaletteOpen}
-            onOpenChange={setCommandPaletteOpen}
+            onOpenChange={(open: boolean) => {
+              setCommandPaletteOpen(open);
+              // Clear the initial query on close so the next ⌘K open
+              // (which bypasses the event listener) doesn't see a stale value.
+              if (!open) setCommandPaletteInitialQuery('');
+            }}
             initialQuery={commandPaletteInitialQuery}
           />
         </Suspense>

--- a/src/features/command-palette/components/CommandPalette/CommandPalette.tsx
+++ b/src/features/command-palette/components/CommandPalette/CommandPalette.tsx
@@ -21,10 +21,19 @@ import { CategoryIcon, CommandItem } from './commandPaletteParts';
 interface CommandPaletteProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /**
+   * Optional initial query to seed the search input when the palette opens.
+   * Used by the Help modal's empty-state fall-through so users land here with
+   * their query already typed.
+   */
+  initialQuery?: string;
 }
 
-export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
+export function CommandPalette({ open, onOpenChange, initialQuery = '' }: CommandPaletteProps) {
   const t = useTranslation();
+  // App.tsx unmounts this component when closed (`{commandPaletteOpen && <CommandPalette/>}`),
+  // so the initial state runs fresh on every open — no need to re-seed via effect.
+  const [searchValue, setSearchValue] = useState(initialQuery);
 
   // Frecency tracking
   const recordUsage = useRecentCommandsStore((s) => s.recordUsage);
@@ -148,6 +157,8 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
               ))}
             </svg>
             <Command.Input
+              value={searchValue}
+              onValueChange={setSearchValue}
               placeholder={t('commandPalette.placeholder')}
               className="flex-1 py-3.5 text-[15px] bg-transparent text-content placeholder:text-content-tertiary outline-none"
               // eslint-disable-next-line jsx-a11y/no-autofocus -- Intentional autofocus for modal/dialog UX

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -855,6 +855,7 @@
   "help.mouse.shiftClick": "Shift + Klick",
   "help.searchPlaceholder": "Tastaturkürzel und Funktionen suchen...",
   "help.goTo": "Gehe zu",
+  "help.openCommandPaletteWithQuery": "Stattdessen alle Befehle durchsuchen",
   "help.kind.shortcut": "Tastaturkürzel",
   "help.kind.feature": "Funktion",
   "help.kind.tip": "Tipp",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -685,6 +685,7 @@
   "help.searchPlaceholder": "Search shortcuts and features...",
   "help.commandPaletteTip": "Quick tip: Use the command palette for fast access to all actions",
   "help.goTo": "Go to",
+  "help.openCommandPaletteWithQuery": "Search all commands instead",
   "help.kind.shortcut": "Shortcut",
   "help.kind.feature": "Feature",
   "help.kind.tip": "Tip",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -784,6 +784,7 @@ const en: Record<string, string> = {
   'help.searchPlaceholder': 'Search shortcuts and features...',
   'help.commandPaletteTip': 'Quick tip: Use the command palette for fast access to all actions',
   'help.goTo': 'Go to',
+  'help.openCommandPaletteWithQuery': 'Search all commands instead',
   'help.kind.shortcut': 'Shortcut',
   'help.kind.feature': 'Feature',
   'help.kind.tip': 'Tip',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -855,6 +855,7 @@
   "help.mouse.shiftClick": "Shift + Clic",
   "help.searchPlaceholder": "Buscar atajos y funciones...",
   "help.goTo": "Ir a",
+  "help.openCommandPaletteWithQuery": "Buscar en todos los comandos",
   "help.kind.shortcut": "Atajo",
   "help.kind.feature": "Función",
   "help.kind.tip": "Consejo",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -855,6 +855,7 @@
   "help.mouse.shiftClick": "Shift + Clic",
   "help.searchPlaceholder": "Rechercher des raccourcis et fonctionnalités...",
   "help.goTo": "Aller à",
+  "help.openCommandPaletteWithQuery": "Rechercher dans toutes les commandes",
   "help.kind.shortcut": "Raccourci",
   "help.kind.feature": "Fonctionnalité",
   "help.kind.tip": "Astuce",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -855,6 +855,7 @@
   "help.mouse.shiftClick": "Shift + klikk",
   "help.searchPlaceholder": "Søk i snarveier og funksjoner...",
   "help.goTo": "Gå til",
+  "help.openCommandPaletteWithQuery": "Søk i alle kommandoer i stedet",
   "help.kind.shortcut": "Snarvei",
   "help.kind.feature": "Funksjon",
   "help.kind.tip": "Tips",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -855,6 +855,7 @@
   "help.mouse.shiftClick": "Shift + Klik",
   "help.searchPlaceholder": "Sneltoetsen en functies zoeken...",
   "help.goTo": "Ga naar",
+  "help.openCommandPaletteWithQuery": "In plaats daarvan alle commando's zoeken",
   "help.kind.shortcut": "Sneltoets",
   "help.kind.feature": "Functie",
   "help.kind.tip": "Tip",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -855,6 +855,7 @@
   "help.mouse.shiftClick": "Shift + Clic",
   "help.searchPlaceholder": "Pesquisar atalhos e recursos...",
   "help.goTo": "Ir para",
+  "help.openCommandPaletteWithQuery": "Pesquisar todos os comandos",
   "help.kind.shortcut": "Atalho",
   "help.kind.feature": "Recurso",
   "help.kind.tip": "Dica",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -625,6 +625,7 @@
   "help.title": "Kortkommandon",
   "help.searchPlaceholder": "Sök kortkommandon och funktioner...",
   "help.goTo": "Gå till",
+  "help.openCommandPaletteWithQuery": "Sök bland alla kommandon istället",
   "help.kind.shortcut": "Kortkommando",
   "help.kind.feature": "Funktion",
   "help.kind.tip": "Tips",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -625,6 +625,7 @@
   "help.title": "Клавіатурні скорочення",
   "help.searchPlaceholder": "Пошук скорочень і функцій...",
   "help.goTo": "Перейти",
+  "help.openCommandPaletteWithQuery": "Натомість шукати серед усіх команд",
   "help.kind.shortcut": "Скорочення",
   "help.kind.feature": "Функція",
   "help.kind.tip": "Порада",

--- a/src/shared/analytics/posthog/events.ts
+++ b/src/shared/analytics/posthog/events.ts
@@ -159,9 +159,9 @@ function sanitizeQuery(query: string): string {
   return query.trim().toLowerCase().slice(0, 80);
 }
 
-export function trackHelpSearchJump(entry_id: string, query: string, position: number): void {
+export function trackHelpSearchJump(entryId: string, query: string, position: number): void {
   trackEvent('help_search_jump', {
-    entry_id,
+    entry_id: entryId,
     query: sanitizeQuery(query),
     position,
   });

--- a/src/shared/analytics/posthog/events.ts
+++ b/src/shared/analytics/posthog/events.ts
@@ -147,3 +147,30 @@ export function trackGalleryOpened(layoutCount: number): void {
 export function trackGalleryClosed(reason: 'applied_template' | 'dismissed'): void {
   trackEvent('gallery_closed', { reason });
 }
+
+// HELP MODAL TRACKING
+
+/**
+ * Sanitize a help search query before sending to telemetry: lowercase + truncated
+ * to 80 chars so PII-shaped strings (an email, a long phrase, etc.) can't slip
+ * through verbatim. Not a privacy guarantee, but a sensible limit.
+ */
+function sanitizeQuery(query: string): string {
+  return query.trim().toLowerCase().slice(0, 80);
+}
+
+export function trackHelpSearchJump(entry_id: string, query: string, position: number): void {
+  trackEvent('help_search_jump', {
+    entry_id,
+    query: sanitizeQuery(query),
+    position,
+  });
+}
+
+export function trackHelpSearchEmpty(query: string): void {
+  trackEvent('help_search_empty', { query: sanitizeQuery(query) });
+}
+
+export function trackHelpCommandPaletteFallthrough(query: string): void {
+  trackEvent('help_command_palette_fallthrough', { query: sanitizeQuery(query) });
+}

--- a/src/shell/Modals/HelpModal/HelpModal.tsx
+++ b/src/shell/Modals/HelpModal/HelpModal.tsx
@@ -23,6 +23,11 @@ import {
 import { getAllHelpEntries } from './helpEntryAggregator';
 import { searchHelpEntries } from './helpSearch';
 import { HelpSearchResultRow } from './HelpSearchResultRow';
+import {
+  trackHelpSearchEmpty,
+  trackHelpSearchJump,
+  trackHelpCommandPaletteFallthrough,
+} from '@/shared/analytics/posthog/events';
 
 interface HelpModalProps {
   isOpen: boolean;
@@ -63,6 +68,16 @@ export function HelpModal({ isOpen, onClose, isTablet = false }: HelpModalProps)
     if (!isSearching) return [];
     return searchHelpEntries(allEntries, trimmedQuery, t);
   }, [allEntries, trimmedQuery, isSearching, t]);
+
+  // Telemetry: fire once per zero-result query so we can see which terms users
+  // type that the catalog doesn't cover. Debounced via the trimmedQuery key —
+  // each new query that hits zero results is captured exactly once.
+  useEffect(() => {
+    if (!isOpen) return;
+    if (isSearching && rankedResults.length === 0) {
+      trackHelpSearchEmpty(trimmedQuery);
+    }
+  }, [isOpen, isSearching, rankedResults.length, trimmedQuery]);
 
   if (!isOpen) return null;
 
@@ -264,18 +279,34 @@ interface SearchResultsListProps {
 
 function SearchResultsList({ results, modifierKey, query, onJump }: SearchResultsListProps) {
   const t = useTranslation();
+  const openCommandPalette = () => {
+    trackHelpCommandPaletteFallthrough(query);
+    window.dispatchEvent(new CustomEvent('open-command-palette', { detail: { query } }));
+    onJump();
+  };
+
   if (results.length === 0) {
     return (
-      <div className="text-center py-8 text-content-tertiary text-sm">
-        {t('help.noResultsFor', { query })}
+      <div className="text-center py-10 px-4 space-y-4">
+        <p className="text-content-tertiary text-sm">{t('help.noResultsFor', { query })}</p>
+        <button type="button" onClick={openCommandPalette} className="btn btn-secondary btn-sm">
+          {t('help.openCommandPaletteWithQuery')}
+        </button>
       </div>
     );
   }
   return (
     <ul aria-label={t('help.searchResultsAriaLabel')} className="space-y-1">
-      {results.map(({ entry }) => (
+      {results.map(({ entry }, index) => (
         <li key={entry.id}>
-          <HelpSearchResultRow entry={entry} modifierKey={modifierKey} onJump={onJump} />
+          <HelpSearchResultRow
+            entry={entry}
+            modifierKey={modifierKey}
+            onJump={() => {
+              trackHelpSearchJump(entry.id, query, index);
+              onJump();
+            }}
+          />
         </li>
       ))}
     </ul>

--- a/src/shell/Modals/HelpModal/HelpModal.tsx
+++ b/src/shell/Modals/HelpModal/HelpModal.tsx
@@ -69,14 +69,17 @@ export function HelpModal({ isOpen, onClose, isTablet = false }: HelpModalProps)
     return searchHelpEntries(allEntries, trimmedQuery, t);
   }, [allEntries, trimmedQuery, isSearching, t]);
 
-  // Telemetry: fire once per zero-result query so we can see which terms users
-  // type that the catalog doesn't cover. Debounced via the trimmedQuery key —
-  // each new query that hits zero results is captured exactly once.
+  // Telemetry: fire on settled zero-result queries so we don't capture every
+  // intermediate substring while the user is still typing (e.g. "x", "xy",
+  // "xyz" → just "xyz"). 600ms after the last keystroke is enough to skip
+  // mid-typing snapshots without feeling laggy.
   useEffect(() => {
     if (!isOpen) return;
-    if (isSearching && rankedResults.length === 0) {
+    if (!isSearching || rankedResults.length > 0) return;
+    const timer = window.setTimeout(() => {
       trackHelpSearchEmpty(trimmedQuery);
-    }
+    }, 600);
+    return () => window.clearTimeout(timer);
   }, [isOpen, isSearching, rankedResults.length, trimmedQuery]);
 
   if (!isOpen) return null;


### PR DESCRIPTION
## Summary

Completes the natural-language help search rollout with three additions that close the discovery loop:

1. **⌘K accepts an `initialQuery`** prop — pre-fills the command palette search input on open.
2. **Empty-state CTA** in HelpModal — when the help search has zero results, a "Search all commands instead" button opens ⌘K with the typed query.
3. **PostHog telemetry** for measuring how the redesign performs.

## What changes

### CommandPalette API
- New optional `initialQuery?: string` prop. `CommandPalette` is unmounted between opens (`App.tsx:444`), so the existing `useState(initialQuery)` initializer handles re-seeding without a useEffect.
- `Command.Input` becomes controlled with internal state, syncing via `value` / `onValueChange`.

### App-level dispatch
- New `open-command-palette` window event with `{ query?: string }` payload, mirroring the existing `open-settings-modal` / `switch-to-designer` convention. App.tsx listens, sets the initial query and opens the palette. Decouples HelpModal from CommandPalette.

### HelpModal empty-state
- When `searchHelpEntries` returns zero results, a "Search all commands instead" button dispatches `open-command-palette` with the current query. Users land in ⌘K with their text pre-filled rather than hitting a second dead-end.

### Telemetry (PostHog)
| Event | Payload | Fires when |
|---|---|---|
| `help_search_jump` | `entry_id`, `query`, `position` | A result is clicked |
| `help_search_empty` | `query` | A query yields zero results (once per unique query) |
| `help_command_palette_fallthrough` | `query` | The CTA opens ⌘K |

Query strings are lowercased and truncated to 80 chars before send (`sanitizeQuery`) to limit accidental PII leakage. Not a privacy guarantee — a sensible cap.

### i18n
- One new key (`help.openCommandPaletteWithQuery`) translated across all 9 locales.

## Test plan

- [x] `pnpm run typecheck`, `pnpm run lint`, `pnpm run check:i18n` clean
- [x] 179 targeted tests pass (`HelpModal`, `command-palette`, `analytics/posthog`)
- [ ] Manual: open Help, search "xyzunknown", see CTA, click → ⌘K opens with "xyzunknown" in its input
- [ ] Manual: verify the 3 PostHog events fire in the Network tab during the same flow

## Follow-up

This concludes the natural-language help search initiative kicked off in #1737. Remaining work tracked as out-of-scope per memory:
- MobileSettingsPanel `data-help-target` markers so the mobile Go-to button can be enabled
- Additional catalog entries (drawer/sidebar tools beyond the 5 added in #1739)