### PR TITLE
fix(test): route help dispatcher test to jsdom env

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,11 @@ const domIncludes = [
   // All .test.tsx files are React component tests and need jsdom.
   'src/**/*.test.tsx',
   'src/shared/components/**/*.test.{ts,tsx}',
+  // `src/shared/help/` tests live directly under the prefix with no
+  // sub-directory, which not every glob implementation matches via `**/`.
+  // Both patterns guarantee the dispatcher test lands in jsdom env.
+  'src/shared/help/*.test.{ts,tsx}',
+  'src/shared/help/**/*.test.{ts,tsx}',
   'src/shared/hooks/**/*.test.{ts,tsx}',
   'src/shared/webgl/**/*.test.{ts,tsx}',
   'src/features/**/components/**/*.test.{ts,tsx}',


### PR DESCRIPTION
## Summary

PR #1744 moved `helpJumpDispatcher.test.ts` from `src/shell/Modals/HelpModal/` to `src/shared/help/` but the dom-project glob `'src/shared/help/**/*.test.{ts,tsx}'` failed to match it — the file lives directly under the prefix with no intermediate sub-directory, and not every glob implementation treats `**/` as zero-or-more directories.

The result: the test fell through to the unit project's node environment and failed with `document is not defined`. The Unit Tests (2/2) check on #1744 reported this failure but the PR was merged through it, so the dispatcher's load-bearing primitives (MutationObserver wait, focus-descendant lookup, inert-aware ready-check, pulse application) have **no CI coverage on main right now**.

## Fix

Add both a single-depth and recursive pattern to the dom includes:

```ts
'src/shared/help/*.test.{ts,tsx}',
'src/shared/help/**/*.test.{ts,tsx}',
```

This guarantees the test lands in jsdom env regardless of how the glob implementation handles `**/` against files directly under the prefix.

## Test plan

- [x] `pnpm exec vitest run --shard 2/2` locally — 5702 tests pass (was failing before the fix)
- [ ] CI Unit Tests (2/2) green on this PR

## Follow-up

This restores CI coverage for the dispatcher behavior. No production behavior changes; this is a test-config-only fix.