### PR TITLE
fix(generation): build compartmented bins as multi-cavity cut (#1753)

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -34,21 +34,21 @@ exports[`bin styles > 2×2 standard 1`] = `2812`;
 
 exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1300`;
 
-exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3308`;
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3052`;
 
-exports[`combined features > 2×2 label tabs with merged compartments 1`] = `5308`;
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `4332`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `7492`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `5352`;
 
 exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `18048`;
 
 exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2812`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `3524`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `2852`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3624`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `2880`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `5268`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `3140`;
 
 exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `2918`;
 
@@ -112,17 +112,17 @@ exports[`height > 2×2 height minimum (2u) 1`] = `2812`;
 
 exports[`height > 2×2 height tall (10u) 1`] = `2812`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6876`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6572`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6812`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6508`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6960`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6636`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6960`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6636`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `7216`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `6676`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `7072`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `6532`;
 
 exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `6940`;
 
@@ -152,7 +152,7 @@ exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3304`;
 
 exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4000`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4888`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4132`;
 
 exports[`scoop > 2×2 scoop auto radius 1`] = `4000`;
 

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -40,7 +40,10 @@ import {
 import { getBoxCache, setBoxCache, getLipCache, setLipCache } from './shapeCache';
 import { buildCacheKey, quantize } from './cacheKeyUtils';
 import { hashMask, isPartialMask, type CellMask } from '@/shared/utils/cellMask';
+import { createLogger } from '@/core/logger';
 import { buildMaskDrawing, buildMaskDrawingInset, buildMaskHoleDrawings } from './maskPolygon';
+
+const logger = createLogger('boxBuilder');
 
 /**
  * Build a hollow-walls + closed-floor shell without relying on brepjs
@@ -310,11 +313,22 @@ export function buildBinBox(
         }
         scope.register(box);
         return setBoxCache(boxKey, result);
-      } catch {
+      } catch (e: unknown) {
         // Defensive only — context.ts is supposed to gate this path with
         // `compartmentCavitiesAreViable` so cuts can't fail in practice.
         // If a cut does throw, fall through to the regular hollow-shell
-        // path below so the bin is at least usable (sans dividers).
+        // path below so the bin is at least usable. The bin will be
+        // divider-less (compartmentWallsFeature is also gated off when
+        // `compartmentsBakedIntoShell` is true) — surface that via a
+        // console warning so the silent degradation is observable in
+        // dev/logs rather than only at the next user complaint.
+        const msg = e instanceof Error ? e.message : String(e);
+        logger.warn('[buildBinBox] multi-cavity cut failed; bin will be built without dividers', {
+          err: msg,
+          width: gridW,
+          depth: gridD,
+          cavities: compartmentCavityDrawings.length,
+        });
       }
     }
 

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -135,11 +135,26 @@ export function buildBinBox(
   solid: boolean,
   cutoutTopOffset: number = 0,
   gridUnitMm: number = SIZE,
-  cellMask?: CellMask
+  cellMask?: CellMask,
+  /**
+   * Per-compartment cavity drawings used by the multi-cavity cut path.
+   * When provided with length > 1 (and `solid` is false, mask is rectangular),
+   * the box is built as `outer − each cavity` instead of `outer ⊖ inner` +
+   * fused dividers, so the divider walls are residue from the cut and meet
+   * the cavity floor cleanly (no fuse T-junction). See `compartmentBuilder`
+   * `buildCompartmentCavityDrawings` and issue #1753.
+   */
+  compartmentCavityDrawings?: readonly Drawing[],
+  compartmentCavityKey?: string
 ): Shape3D {
   const polygon = isPartialMask(cellMask);
+  const useMultiCavity =
+    !solid &&
+    !polygon &&
+    compartmentCavityDrawings !== undefined &&
+    compartmentCavityDrawings.length > 1;
   const boxKey = buildCacheKey(
-    'v2',
+    'v3',
     quantize(gridW),
     quantize(gridD),
     quantize(gridUnitMm),
@@ -147,7 +162,8 @@ export function buildBinBox(
     quantize(wallThickness),
     solid,
     quantize(cutoutTopOffset),
-    polygon ? hashMask(cellMask) : 'rect'
+    polygon ? hashMask(cellMask) : 'rect',
+    useMultiCavity ? (compartmentCavityKey ?? 'comp') : 'none'
   );
   const cached = getBoxCache(boxKey);
   if (cached) {
@@ -272,6 +288,33 @@ export function buildBinBox(
       const innerD = outerD - 2 * wallThickness;
       if (innerW <= 0 || innerD <= 0) {
         return setBoxCache(boxKey, box);
+      }
+    }
+
+    if (useMultiCavity) {
+      // Multi-cavity cut path: walls are the natural residue between cuts.
+      // Each compartment cavity is extruded from Z=wallThickness up past the
+      // top (COPLANAR_MARGIN clears the rim) and cut from the outer
+      // extrusion. The resulting wall faces meet the cavity floor as part
+      // of a single solid — no fuse seam, no non-manifold T-junction (#1753).
+      try {
+        let result: Shape3D = box;
+        const cavityHeight = wallHeight - wallThickness + COPLANAR_MARGIN;
+        for (const cavityDrawing of compartmentCavityDrawings) {
+          const cavity = scope.register(
+            sketch(cavityDrawing, 'XY', wallThickness).extrude(cavityHeight)
+          );
+          const prev = result;
+          result = unwrap(cut(prev as ValidSolid, cavity as ValidSolid));
+          if (prev !== box) scope.register(prev);
+        }
+        scope.register(box);
+        return setBoxCache(boxKey, result);
+      } catch {
+        // Defensive only — context.ts is supposed to gate this path with
+        // `compartmentCavitiesAreViable` so cuts can't fail in practice.
+        // If a cut does throw, fall through to the regular hollow-shell
+        // path below so the bin is at least usable (sans dividers).
       }
     }
 

--- a/src/features/generation/worker/generators/compartmentBuilder.scenario.manifold.test.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.scenario.manifold.test.ts
@@ -3,17 +3,21 @@
  * Regression test for issue #1753 — partitioned bins exported with
  * non-manifold geometry per BambuStudio.
  *
- * Compartment divider walls are fused into the bin shell as positive solids
- * via the boolean stage's batch `fuseAll`. Where a wall meets the cavity
- * floor (T-junction at Z = wallThickness), OCCT's General Fuse Algorithm
- * leaves coincident edges and same-domain face fragments along the seam.
- * STL slicers (BambuStudio) flag those duplicated edges as non-manifold and
- * "repair" the result as solid infill.
+ * Old shell construction: hollow rectangular shell + each compartment wall
+ * fused on top as a separate positive solid (`compartmentWallsFeature`,
+ * `target: 'fuse'`). Where a wall met the cavity floor at Z=wallThickness,
+ * OCCT's General Fuse Algorithm left a T-junction with coincident edges
+ * between the wall's vertical face and the floor's horizontal face — STL
+ * slicers (BambuStudio) flagged those duplicate edges as non-manifold and
+ * "repaired" them as solid infill.
  *
- * Fix: pass `{ simplify: forExport }` to the fuse pass (booleanStage), which
- * runs OCCT's `ShapeUpgrade_UnifySameDomain` to merge the coincident edges
- * and same-domain faces. The cut pass already used this flag; the fuse pass
- * had been called with no options.
+ * Fix in this PR: when compartments are amenable (rectangular footprint,
+ * non-solid, non-slotted, rectangular comps with viable post-inset dims),
+ * rebuild the bin as `outer_extrusion − each_compartment_cavity` directly
+ * in `buildBinBox`. Walls are cut residue between cavities, so every face
+ * shares edges on a single solid — no fuse seam, no T-junction. See
+ * `compartmentBuilder.buildCompartmentCavityDrawings` and
+ * `pipeline/context.compartmentsBakedIntoShell`.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import type { BinParams } from '@/shared/types/bin';
@@ -124,12 +128,14 @@ describe('compartmentBuilder — partition export manifold-ness (issue #1753)', 
   );
 
   it(
-    '2×2 bin with merged top-half (L-shape) compartments exports watertight STL',
+    '2×2 bin with top row merged into one compartment exports watertight STL',
     async () => {
       clearAllCaches();
-      // Two cells merged into one big compartment + two separate ones.
+      // [0,0,1,2] = top row merged into compartment 0 + two single-cell
+      // compartments in the bottom row. Stresses the "merged-bounding-box"
+      // cavity drawing path (a single rectangle spanning both columns).
       const params = withCompartments(2, 2, [0, 0, 1, 2], { width: 2, depth: 2 });
-      expectWatertight(analyzeManifold((await exportBin(params, 'stl')).data), 'L-shape merged');
+      expectWatertight(analyzeManifold((await exportBin(params, 'stl')).data), 'top-row merged');
     },
     TEST_TIMEOUT_MS
   );

--- a/src/features/generation/worker/generators/compartmentBuilder.scenario.manifold.test.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.scenario.manifold.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment node
+/**
+ * Regression test for issue #1753 — partitioned bins exported with
+ * non-manifold geometry per BambuStudio.
+ *
+ * Compartment divider walls are fused into the bin shell as positive solids
+ * via the boolean stage's batch `fuseAll`. Where a wall meets the cavity
+ * floor (T-junction at Z = wallThickness), OCCT's General Fuse Algorithm
+ * leaves coincident edges and same-domain face fragments along the seam.
+ * STL slicers (BambuStudio) flag those duplicated edges as non-manifold and
+ * "repair" the result as solid infill.
+ *
+ * Fix: pass `{ simplify: forExport }` to the fuse pass (booleanStage), which
+ * runs OCCT's `ShapeUpgrade_UnifySameDomain` to merge the coincident edges
+ * and same-domain faces. The cut pass already used this flag; the fuse pass
+ * had been called with no options.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { BinParams } from '@/shared/types/bin';
+import { isOk } from '@/core/result';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { parseSTLBinary } from '@/shared/generation/stlParser';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import { exportBin } from './binExporter';
+import { clearAllCaches } from './shapeCache';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+interface ManifoldStats {
+  triangleCount: number;
+  nonManifoldEdges: number;
+  boundaryEdges: number;
+}
+
+function analyzeManifold(stl: ArrayBuffer): ManifoldStats {
+  const parsed = parseSTLBinary(stl);
+  if (!isOk(parsed)) throw new Error('STL parse failed');
+  const { vertices } = parsed.value;
+  const triangleCount = vertices.length / 9;
+
+  const QUANTIZE = 1e4;
+  const vKey = (x: number, y: number, z: number): string =>
+    `${Math.round(x * QUANTIZE)},${Math.round(y * QUANTIZE)},${Math.round(z * QUANTIZE)}`;
+  const eKey = (a: string, b: string): string => (a < b ? `${a}|${b}` : `${b}|${a}`);
+
+  const edgeCount = new Map<string, number>();
+  for (let t = 0; t < triangleCount; t++) {
+    const base = t * 9;
+    const keys = [
+      vKey(vertices[base], vertices[base + 1], vertices[base + 2]),
+      vKey(vertices[base + 3], vertices[base + 4], vertices[base + 5]),
+      vKey(vertices[base + 6], vertices[base + 7], vertices[base + 8]),
+    ];
+    for (let i = 0; i < 3; i++) {
+      const k = eKey(keys[i], keys[(i + 1) % 3]);
+      edgeCount.set(k, (edgeCount.get(k) ?? 0) + 1);
+    }
+  }
+
+  let nonManifoldEdges = 0;
+  let boundaryEdges = 0;
+  for (const count of edgeCount.values()) {
+    if (count === 1) boundaryEdges++;
+    else if (count > 2) nonManifoldEdges++;
+  }
+  return { triangleCount, nonManifoldEdges, boundaryEdges };
+}
+
+function withCompartments(
+  cols: number,
+  rows: number,
+  cells: readonly number[],
+  overrides: Partial<BinParams> = {}
+): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    ...overrides,
+    compartments: { cols, rows, cells: [...cells], thickness: 1.2 },
+  };
+}
+
+describe('compartmentBuilder — partition export manifold-ness (issue #1753)', () => {
+  const TEST_TIMEOUT_MS = 90_000;
+
+  function expectWatertight(stats: ManifoldStats, label: string): void {
+    expect(stats.nonManifoldEdges, `${label}: non-manifold edges`).toBe(0);
+    expect(stats.boundaryEdges, `${label}: boundary edges`).toBe(0);
+  }
+
+  it(
+    '2×2 bin with a single full-span divider exports watertight STL',
+    async () => {
+      clearAllCaches();
+      const params = withCompartments(2, 1, [0, 1], { width: 2, depth: 2 });
+      expectWatertight(analyzeManifold((await exportBin(params, 'stl')).data), '2×1 split');
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    '2×2 bin with 4 separate compartments exports watertight STL',
+    async () => {
+      clearAllCaches();
+      const params = withCompartments(2, 2, [0, 1, 2, 3], { width: 2, depth: 2 });
+      expectWatertight(analyzeManifold((await exportBin(params, 'stl')).data), '2×2 four-comp');
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    "1×4 bin with 2×8 compartments (reporter's case shape) exports watertight STL",
+    async () => {
+      clearAllCaches();
+      const cells = Array.from({ length: 16 }, (_, i) => i);
+      const params = withCompartments(2, 8, cells, { width: 1, depth: 4, height: 5 });
+      expectWatertight(
+        analyzeManifold((await exportBin(params, 'stl')).data),
+        '1×4 with 2×8 comps'
+      );
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    '2×2 bin with merged top-half (L-shape) compartments exports watertight STL',
+    async () => {
+      clearAllCaches();
+      // Two cells merged into one big compartment + two separate ones.
+      const params = withCompartments(2, 2, [0, 0, 1, 2], { width: 2, depth: 2 });
+      expectWatertight(analyzeManifold((await exportBin(params, 'stl')).data), 'L-shape merged');
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  // ── Known gap (polygon-mask + compartments) ─────────────────────────────
+  // Bins with a non-rectangular footprint (L/T/U cellMask) still take the
+  // additive-fuse compartment path and remain susceptible to the original
+  // T-junction non-manifold bug. The multi-cavity-cut path in `buildBinBox`
+  // only handles rectangular footprints today; extending it to clip
+  // compartment cavities against an arbitrary polygon mask is a follow-up.
+  // Unskip and verify when that work lands.
+  it.skip(
+    'TODO #1753 follow-up: L-shaped (polygon-mask) bin with compartments exports watertight STL',
+    async () => {
+      clearAllCaches();
+      const cellMask = {
+        cols: 2,
+        rows: 2,
+        cells: [true, true, true, false], // L-shape: bottom-right cell missing
+      };
+      const params: BinParams = {
+        ...DEFAULT_BIN_PARAMS,
+        width: 2,
+        depth: 2,
+        cellMask,
+        compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
+      };
+      expectWatertight(analyzeManifold((await exportBin(params, 'stl')).data), 'L-shape mask');
+    },
+    TEST_TIMEOUT_MS
+  );
+});

--- a/src/features/generation/worker/generators/compartmentBuilder.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.ts
@@ -5,12 +5,127 @@
  * Walls appear at boundaries between cells with different compartment IDs.
  */
 
-import { box, withScope, clone, unwrap, fuseAll } from 'brepjs';
-import type { Shape3D, ValidSolid, DisposalScope } from 'brepjs';
+import { box, withScope, clone, unwrap, fuseAll, draw } from 'brepjs';
+import type { Shape3D, ValidSolid, DisposalScope, Drawing } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
 
 // Re-export for backwards compatibility with existing imports
 export { fuseAllOrNull } from './utils/shapeOps';
+
+/**
+ * Whether the bin's compartments produce internal divider walls (>1 distinct
+ * compartment ID). Single-compartment bins (`cells: [0]` or all identical)
+ * don't need walls — the inner cavity is a single region.
+ */
+export function hasMultipleCompartments(params: BinParams): boolean {
+  const { cells } = params.compartments;
+  if (cells.length === 0) return false;
+  return new Set(cells).size > 1;
+}
+
+/**
+ * Build per-compartment cavity drawings (rectangular footprints in the XY
+ * plane) used to subtract cavities from the bin's outer extrusion, producing
+ * the divider walls as natural cut residue between compartments.
+ *
+ * Each cavity rectangle spans the compartment's cell bounding box, inset by
+ * `thickness/2` on every shared internal boundary (so adjacent compartments
+ * leave `thickness` of wall between them) and aligned flush with the bin's
+ * inner wall surface on each exterior boundary.
+ *
+ * Non-rectangular compartments (cells with the same ID forming an L-shape,
+ * etc.) are approximated by their bounding box; multi-cavity cut is therefore
+ * only safe for compartments that fill their bounding box. Callers should
+ * verify via `compartmentsAreRectangular` before using this path.
+ */
+export function buildCompartmentCavityDrawings(
+  params: BinParams,
+  innerW: number,
+  innerD: number
+): readonly Drawing[] {
+  const { cols, rows, thickness, cells } = params.compartments;
+  const cellW = innerW / cols;
+  const cellD = innerD / rows;
+  const half = thickness / 2;
+
+  const compIds = Array.from(new Set(cells));
+  const drawings: Drawing[] = [];
+
+  for (const id of compIds) {
+    const bounds = findCompartmentBounds(id, cols, rows, cells);
+    if (!bounds) continue;
+    const { minCol, maxCol, minRow, maxRow } = bounds;
+
+    // Cavity rectangle in the bin's inner frame (origin at center of inner cavity)
+    const xMin = -innerW / 2 + minCol * cellW + (minCol > 0 ? half : 0);
+    const xMax = -innerW / 2 + (maxCol + 1) * cellW - (maxCol < cols - 1 ? half : 0);
+    const yMin = -innerD / 2 + minRow * cellD + (minRow > 0 ? half : 0);
+    const yMax = -innerD / 2 + (maxRow + 1) * cellD - (maxRow < rows - 1 ? half : 0);
+
+    drawings.push(
+      draw([xMin, yMin]).lineTo([xMax, yMin]).lineTo([xMax, yMax]).lineTo([xMin, yMax]).close()
+    );
+  }
+
+  return drawings;
+}
+
+/**
+ * Whether every compartment is a rectangle (its cells fully fill its
+ * bounding box). Required precondition for the multi-cavity-cut shell
+ * path; non-rectangular compartments fall back to the additive-fuse path.
+ */
+export function compartmentsAreRectangular(params: BinParams): boolean {
+  const { cols, rows, cells } = params.compartments;
+  const compIds = new Set(cells);
+  for (const id of compIds) {
+    const bounds = findCompartmentBounds(id, cols, rows, cells);
+    if (!bounds) continue;
+    const { minCol, maxCol, minRow, maxRow } = bounds;
+    for (let r = minRow; r <= maxRow; r++) {
+      for (let c = minCol; c <= maxCol; c++) {
+        if (cells[r * cols + c] !== id) return false;
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * Tight precondition check for the multi-cavity-cut shell path. Verifies
+ * that every per-compartment cavity rectangle would have positive width and
+ * depth after inset by `thickness/2` on shared boundaries. If any cavity
+ * would collapse, the upstream cut would fail in OCCT — better to fall
+ * through to the additive-fuse path now than crash buildBinBox later.
+ */
+export function compartmentCavitiesAreViable(
+  params: BinParams,
+  innerW: number,
+  innerD: number
+): boolean {
+  if (innerW <= 0 || innerD <= 0) return false;
+  const { cols, rows, thickness, cells } = params.compartments;
+  if (cols < 1 || rows < 1 || cells.length !== cols * rows) return false;
+  const cellW = innerW / cols;
+  const cellD = innerD / rows;
+  const half = thickness / 2;
+  // Minimum viable cavity dimension: 2× wall thickness so each compartment
+  // still has usable interior after the inset (same heuristic the additive
+  // path uses in `buildCompartmentWallsInScope`).
+  const minDim = thickness * 2;
+  const compIds = new Set(cells);
+  for (const id of compIds) {
+    const bounds = findCompartmentBounds(id, cols, rows, cells);
+    if (!bounds) return false;
+    const { minCol, maxCol, minRow, maxRow } = bounds;
+    const compW =
+      (maxCol - minCol + 1) * cellW - (minCol > 0 ? half : 0) - (maxCol < cols - 1 ? half : 0);
+    const compD =
+      (maxRow - minRow + 1) * cellD - (minRow > 0 ? half : 0) - (maxRow < rows - 1 ? half : 0);
+    if (compW < minDim || compD < minDim) return false;
+  }
+  return true;
+}
 
 /** Build a positioned wall segment solid. */
 function buildWallSegment(w: number, d: number, height: number, x: number, y: number): Shape3D {
@@ -168,7 +283,8 @@ export const compartmentWallsFeature: FeatureBuilder = {
   name: 'compartmentWalls',
   tag: FeatureTag.DIVIDER,
   target: 'fuse',
-  shouldBuild: (ctx) => !ctx.dimensions.isSlotted,
+  // Skip when walls are already in the shell (multi-cavity cut path, #1753).
+  shouldBuild: (ctx) => !ctx.dimensions.isSlotted && !ctx.dimensions.compartmentsBakedIntoShell,
   cacheKey: (ctx) => {
     const { dimensions: dim, params } = ctx;
     return compactKey(

--- a/src/features/generation/worker/generators/pipeline/context.test.ts
+++ b/src/features/generation/worker/generators/pipeline/context.test.ts
@@ -51,14 +51,15 @@ describe('createInitialContext', () => {
     expect(ctx.dimensions.wallHeight).toBe(21); // No socket deduction for flat
   });
 
-  it('produces versioned shellKey with v5 prefix including gridUnitMm', () => {
+  it('produces versioned shellKey with v6 prefix including gridUnitMm and compartments segment', () => {
     const ctx = createInitialContext(createTestParams());
 
-    // shellKey uses buildCacheKey with v5 prefix, gridUnitMm, and quantized floats
-    // forExport is no longer in the key since shell geometry is identical for preview/export.
-    // Final segment is 'rect' when no cellMask is in use; mask hash otherwise.
+    // shellKey uses buildCacheKey with v6 prefix, gridUnitMm, quantized floats,
+    // a 'rect' mask segment (no cellMask), and a 'none' compartments segment
+    // (single-compartment default — no multi-cavity cut path). v6 bumped from
+    // v5 when the compartments segment was added (#1753).
     const expected = [
-      'v5',
+      'v6',
       2,
       2,
       42, // gridUnitMm
@@ -74,6 +75,7 @@ describe('createInitialContext', () => {
       false,
       false,
       'rect',
+      'none',
     ].join('|');
 
     expect(ctx.dimensions.shellKey).toBe(expected);

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -14,6 +14,11 @@ import {
   SOCKET_HEIGHT,
   LIP_SMALL_TAPER,
 } from '../generatorConstants';
+import {
+  compartmentCavitiesAreViable,
+  compartmentsAreRectangular,
+  hasMultipleCompartments,
+} from '../compartmentBuilder';
 // SIZE and HEIGHT_UNIT are kept as fallback defaults for backwards compatibility
 // with callers (or serialized designs) that predate gridUnitMm/heightUnitMm.
 import type { ProgressFn } from '../meshUtils';
@@ -55,14 +60,44 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
   // already clears the actual lip base at wallHeight - LIP_OVERLAP.
   const interiorHeight = hasLip ? wallHeight - LIP_SMALL_TAPER : wallHeight;
 
+  // Bake compartment walls into the shell as a single multi-cavity cut when
+  // the shape is amenable to that path: rectangular footprint (no polygon
+  // mask), not solid mode, not slotted, the compartments are rectangles
+  // (their cells fill their bounding box), and every per-compartment cavity
+  // has viable post-inset dimensions. This avoids the fuse T-junction at
+  // the cavity floor that BambuStudio flagged as non-manifold (#1753).
+  //
+  // TODO #1753: polygon-mask bins (L/T/U footprints) with compartments
+  // still use the additive-fuse path and remain susceptible to the
+  // T-junction non-manifold bug. See the skipped scenario in
+  // `compartmentBuilder.scenario.manifold.test.ts` ("polygon-mask gap").
+  const compartmentsBakedIntoShell =
+    !isSlotted &&
+    !solid &&
+    !isPartialMask(params.cellMask) &&
+    hasMultipleCompartments(params) &&
+    compartmentsAreRectangular(params) &&
+    compartmentCavitiesAreViable(params, innerW, innerD);
+
   // Shell cache key — versioned + quantized for deterministic matching.
   // Mask hash is included only when the mask triggers the polygon path so
-  // rectangular bins continue to share the existing cache bucket.
+  // rectangular bins continue to share the existing cache bucket. The
+  // compartments segment is "none" unless the bin uses the multi-cavity
+  // cut path, so single-compartment bins keep their existing cache bucket.
   const { cellMask } = params;
   const maskKeySegment = isPartialMask(cellMask) ? hashMask(cellMask) : 'rect';
+  const compartmentsKey = compartmentsBakedIntoShell
+    ? buildCacheKey(
+        'comp',
+        params.compartments.cols,
+        params.compartments.rows,
+        quantize(params.compartments.thickness),
+        params.compartments.cells.join(',')
+      )
+    : 'none';
   const shellKey = compactKey(
     buildCacheKey(
-      'v5',
+      'v6',
       quantize(params.width),
       quantize(params.depth),
       quantize(gridUnit),
@@ -77,7 +112,8 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
       quantize(params.wallThickness),
       params.base.stackingLip,
       solid,
-      maskKeySegment
+      maskKeySegment,
+      compartmentsKey
     )
   );
 
@@ -98,6 +134,7 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
     shellKey,
     withMagnet,
     withScrew,
+    compartmentsBakedIntoShell,
   };
 }
 

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -15,6 +15,7 @@ import { checkCancelled, isAbortError } from '../../utils/abort';
 import { buildBaseSocket } from '../../socketBuilder';
 import { buildBinBox, buildTopShape } from '../../boxBuilder';
 import { buildCompartmentCavityDrawings } from '../../compartmentBuilder';
+import { buildCacheKey, compactKey, quantize } from '../../cacheKeyUtils';
 import { getShellCache, setShellCache } from '../../shapeCache';
 import { LIP_OVERLAP } from '../../generatorConstants';
 import { FeatureTag } from '../../featureTags';
@@ -50,8 +51,18 @@ export const shellStage: PipelineStage = {
     const compartmentCavityDrawings = dim.compartmentsBakedIntoShell
       ? buildCompartmentCavityDrawings(params, dim.innerW, dim.innerD)
       : undefined;
+    // Built via the standard cacheKey helpers so `thickness` is quantized
+    // the same way as in `dim.shellKey` (avoids float-drift cache misses).
     const compartmentCavityKey = dim.compartmentsBakedIntoShell
-      ? `${params.compartments.cols}x${params.compartments.rows}:${params.compartments.cells.join(',')}:${params.compartments.thickness}`
+      ? compactKey(
+          buildCacheKey(
+            'comp',
+            params.compartments.cols,
+            params.compartments.rows,
+            quantize(params.compartments.thickness),
+            params.compartments.cells.join(',')
+          )
+        )
       : undefined;
 
     const bin = withScope((scope: DisposalScope) => {

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -14,6 +14,7 @@ import type { PipelineContext, PipelineStage } from '../types';
 import { checkCancelled, isAbortError } from '../../utils/abort';
 import { buildBaseSocket } from '../../socketBuilder';
 import { buildBinBox, buildTopShape } from '../../boxBuilder';
+import { buildCompartmentCavityDrawings } from '../../compartmentBuilder';
 import { getShellCache, setShellCache } from '../../shapeCache';
 import { LIP_OVERLAP } from '../../generatorConstants';
 import { FeatureTag } from '../../featureTags';
@@ -42,6 +43,17 @@ export const shellStage: PipelineStage = {
 
     const cutoutTopOffset = dim.solid ? params.cutoutConfig.topOffset : 0;
 
+    // Compute per-compartment cavity drawings only when the multi-cavity cut
+    // path will be taken (rectangular bin + non-solid + rectangular comps).
+    // The cache key in `dim.shellKey` already discriminates on the comp grid
+    // so we can safely pass `undefined` for the default path.
+    const compartmentCavityDrawings = dim.compartmentsBakedIntoShell
+      ? buildCompartmentCavityDrawings(params, dim.innerW, dim.innerD)
+      : undefined;
+    const compartmentCavityKey = dim.compartmentsBakedIntoShell
+      ? `${params.compartments.cols}x${params.compartments.rows}:${params.compartments.cells.join(',')}:${params.compartments.thickness}`
+      : undefined;
+
     const bin = withScope((scope: DisposalScope) => {
       const binBody = buildBinBox(
         params.width,
@@ -51,7 +63,9 @@ export const shellStage: PipelineStage = {
         dim.solid,
         cutoutTopOffset,
         params.gridUnitMm,
-        params.cellMask
+        params.cellMask,
+        compartmentCavityDrawings,
+        compartmentCavityKey
       );
       collectOrigins(binBody, FeatureTag.BASE, originToTag);
 

--- a/src/features/generation/worker/generators/pipeline/types.ts
+++ b/src/features/generation/worker/generators/pipeline/types.ts
@@ -32,6 +32,15 @@ export interface BinDimensions {
   readonly shellKey: string;
   readonly withMagnet: boolean;
   readonly withScrew: boolean;
+  /**
+   * True when the shell is built with compartment cavities subtracted
+   * directly (per-compartment cavity cut). In that path the divider
+   * walls are residue from the cut, not separately-fused solids, so
+   * `compartmentWallsFeature` is skipped to avoid double-walling.
+   * See `compartmentBuilder.buildCompartmentCavityDrawings` and
+   * `boxBuilder.buildBinBox` for the cut path.
+   */
+  readonly compartmentsBakedIntoShell: boolean;
 }
 
 /** Immutable context threaded through pipeline stages. */

--- a/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
+++ b/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
@@ -166,9 +166,14 @@ export const honeycombJunction: ScenarioCase[] = [
         // triangle delta a few percent up at thick wallThickness. A real
         // junction-clip failure adds hundreds of hex prism triangles (>>10%)
         // so the loosened bound still catches the regression this test
-        // exists for.
+        // exists for. The lower bound (>= 1) catches a divider-regression
+        // where compartments collapse to a no-op (delta would be 0).
         const delta = Math.abs(withDivider.triangleCount - noDivider.triangleCount);
         const maxDelta = noDivider.triangleCount * 0.1;
+        expect(
+          delta,
+          'divider produced identical geometry — divider path may have regressed'
+        ).toBeGreaterThan(0);
         expect(
           delta,
           `divider changed triangle count by ${delta} (max ${Math.round(maxDelta)}); junction clip depth may be too shallow`
@@ -208,9 +213,14 @@ export const honeycombJunction: ScenarioCase[] = [
         // triangle delta a few percent up at thick wallThickness. A real
         // junction-clip failure adds hundreds of hex prism triangles (>>10%)
         // so the loosened bound still catches the regression this test
-        // exists for.
+        // exists for. The lower bound (>= 1) catches a divider-regression
+        // where compartments collapse to a no-op (delta would be 0).
         const delta = Math.abs(withDivider.triangleCount - noDivider.triangleCount);
         const maxDelta = noDivider.triangleCount * 0.1;
+        expect(
+          delta,
+          'divider produced identical geometry — divider path may have regressed'
+        ).toBeGreaterThan(0);
         expect(
           delta,
           `divider changed triangle count by ${delta} (max ${Math.round(maxDelta)}); junction clip depth may be too shallow`
@@ -251,9 +261,14 @@ export const honeycombJunction: ScenarioCase[] = [
           // cuts through the junction would add hundreds of extra triangles;
           // with the multi-cavity cut shell path the divider is cut residue
           // and can slightly *reduce* total triangles. Either way, the delta
-          // should stay within 5%.
+          // should stay within 5%. The lower bound (>= 1) catches a
+          // divider-regression where compartments collapse to a no-op.
           const delta = Math.abs(withDivider.triangleCount - noDivider.triangleCount);
           const maxDelta = noDivider.triangleCount * 0.05;
+          expect(
+            delta,
+            'divider produced identical geometry — divider path may have regressed'
+          ).toBeGreaterThan(0);
           expect(
             delta,
             `divider changed triangle count by ${delta} (max ${Math.round(maxDelta)}); junction blocking may be broken`

--- a/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
+++ b/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
@@ -159,15 +159,20 @@ export const honeycombJunction: ScenarioCase[] = [
         walls: ALL_SIDES_OFF,
       },
       assert: (noDivider, withDivider) => {
-        expect(withDivider.triangleCount, 'divider should add triangles').toBeGreaterThan(
-          noDivider.triangleCount
-        );
-        const increase = withDivider.triangleCount - noDivider.triangleCount;
-        const maxIncrease = noDivider.triangleCount * 0.05;
+        // Junction blocking: the divider should not dramatically change the
+        // triangle count in either direction. The multi-cavity cut shell
+        // path (#1753) gives compartment cavities sharp inner corners where
+        // the single-cavity hollow had rounded ones, which shifts the
+        // triangle delta a few percent up at thick wallThickness. A real
+        // junction-clip failure adds hundreds of hex prism triangles (>>10%)
+        // so the loosened bound still catches the regression this test
+        // exists for.
+        const delta = Math.abs(withDivider.triangleCount - noDivider.triangleCount);
+        const maxDelta = noDivider.triangleCount * 0.1;
         expect(
-          increase,
-          `divider added ${increase} tris (max ${Math.round(maxIncrease)}); junction clip depth may be too shallow`
-        ).toBeLessThanOrEqual(maxIncrease);
+          delta,
+          `divider changed triangle count by ${delta} (max ${Math.round(maxDelta)}); junction clip depth may be too shallow`
+        ).toBeLessThanOrEqual(maxDelta);
       },
     },
     timeout: 60_000,
@@ -196,15 +201,20 @@ export const honeycombJunction: ScenarioCase[] = [
         walls: ALL_SIDES_OFF,
       },
       assert: (noDivider, withDivider) => {
-        expect(withDivider.triangleCount, 'divider should add triangles').toBeGreaterThan(
-          noDivider.triangleCount
-        );
-        const increase = withDivider.triangleCount - noDivider.triangleCount;
-        const maxIncrease = noDivider.triangleCount * 0.05;
+        // Junction blocking: the divider should not dramatically change the
+        // triangle count in either direction. The multi-cavity cut shell
+        // path (#1753) gives compartment cavities sharp inner corners where
+        // the single-cavity hollow had rounded ones, which shifts the
+        // triangle delta a few percent up at thick wallThickness. A real
+        // junction-clip failure adds hundreds of hex prism triangles (>>10%)
+        // so the loosened bound still catches the regression this test
+        // exists for.
+        const delta = Math.abs(withDivider.triangleCount - noDivider.triangleCount);
+        const maxDelta = noDivider.triangleCount * 0.1;
         expect(
-          increase,
-          `divider added ${increase} tris (max ${Math.round(maxIncrease)}); junction clip depth may be too shallow`
-        ).toBeLessThanOrEqual(maxIncrease);
+          delta,
+          `divider changed triangle count by ${delta} (max ${Math.round(maxDelta)}); junction clip depth may be too shallow`
+        ).toBeLessThanOrEqual(maxDelta);
       },
     },
     timeout: 60_000,
@@ -236,19 +246,18 @@ export const honeycombJunction: ScenarioCase[] = [
           walls: ALL_SIDES_OFF,
         },
         assert: (noDivider, withDivider) => {
-          // Divider adds geometry, so withDivider > noDivider
-          expect(withDivider.triangleCount, 'divider should add triangles').toBeGreaterThan(
-            noDivider.triangleCount
-          );
-          // But junction blocking removes hex prisms, so the increase is small.
-          // Without blocking, hex cuts through the junction would add hundreds
-          // of extra triangles. Cap the increase at 5% to catch regressions.
-          const increase = withDivider.triangleCount - noDivider.triangleCount;
-          const maxIncrease = noDivider.triangleCount * 0.05;
+          // Junction blocking: the divider should not cause a dramatic
+          // triangle count change in either direction. Without blocking, hex
+          // cuts through the junction would add hundreds of extra triangles;
+          // with the multi-cavity cut shell path the divider is cut residue
+          // and can slightly *reduce* total triangles. Either way, the delta
+          // should stay within 5%.
+          const delta = Math.abs(withDivider.triangleCount - noDivider.triangleCount);
+          const maxDelta = noDivider.triangleCount * 0.05;
           expect(
-            increase,
-            `divider added ${increase} triangles (max ${Math.round(maxIncrease)}); junction blocking may be broken`
-          ).toBeLessThanOrEqual(maxIncrease);
+            delta,
+            `divider changed triangle count by ${delta} (max ${Math.round(maxDelta)}); junction blocking may be broken`
+          ).toBeLessThanOrEqual(maxDelta);
         },
       },
       timeout: 60_000,


### PR DESCRIPTION
## Summary

- Rebuild compartmented bins as `outer_extrusion − each_compartment_cavity` instead of `hollow_shell + fused_walls`, eliminating the OCCT T-junction at the cavity floor that BambuStudio flagged as non-manifold.
- Affects rectangular bins only; polygon-mask + compartments still go through the old fuse path (tracked as a skipped follow-up test).
- 4 new scenario tests assert 0 non-manifold edges; 13 existing triangleCount snapshots regenerated (all *decreased* — cut residue is simpler than fused boxes).

## Why

Reporter's 1×4 bin with 2×8 compartments produced **1026 non-manifold edges** in the exported STL. Smaller cases reproduced the same class: 2×1 single divider = 204, 2×2 four compartments = 454. Diagnostic by Z coordinate localised every bad edge to `Z = wallThickness` (cavity floor surface) — the wall vertical face and floor horizontal face met at a T-junction, and OCCT's General Fuse Algorithm left coincident edges along the seam. UnifySameDomain (`simplify: true` on `fuseAll`) is a no-op for this case because the offending edges are between geometrically distinct surfaces.

Building the bin as a single solid (outer extrusion) and cutting out each compartment cavity gives walls as natural cut-residue. All faces share edges on a single solid — no fuse seam, no T-junction. After the refactor, **all four scenarios above report 0 non-manifold edges**.

## What changed

| File | Change |
|---|---|
| ` compartmentBuilder.ts` | Added `hasMultipleCompartments`, `compartmentsAreRectangular`, `compartmentCavitiesAreViable`, `buildCompartmentCavityDrawings`. `compartmentWallsFeature.shouldBuild` skips when walls are baked in. |
| `boxBuilder.ts` | New multi-cavity cut branch in `buildBinBox` (cache key bumped v2 → v3). |
| `pipeline/context.ts` | Computes `compartmentsBakedIntoShell` upfront (rectangular bin + non-solid + non-slotted + rectangular comps + viable post-inset dims). Shell cache key bumped v5 → v6. |
| `pipeline/types.ts` | Adds `compartmentsBakedIntoShell` to `BinDimensions`. |
| `pipeline/stages/shellStage.ts` | Passes cavity drawings to `buildBinBox` when the flag is set. |
| `scenarios/honeycombJunction.ts` | Three `withDivider > noDivider` assertions widened to `|delta| ≤ 10%` — the old +5% increase bound assumed fused walls always add triangles; the cut path is now slightly simpler. |
| `compartmentBuilder.scenario.manifold.test.ts` | New regression test (4 active scenarios + 1 skipped polygon-mask follow-up). |
| `__snapshots__/binGenerator.scenario.test.ts.snap` | 13 triangleCount snapshots regenerated. |

## Known gap

Polygon-mask bins (L/T/U footprints) with compartments still take the additive-fuse path and remain susceptible to the original bug. Tracked via a skipped scenario in `compartmentBuilder.scenario.manifold.test.ts` (`it.skip` with TODO comment) and a `TODO #1753` comment next to the `compartmentsBakedIntoShell` predicate in `pipeline/context.ts`. To unblock: compute compartment cavities clipped to the polygon mask.

## Test plan

- [x] `pnpm exec vitest run src/features/generation/worker/generators/compartmentBuilder.scenario.manifold.test.ts` — 4 passed, 1 skipped (the polygon-mask gap follow-up)
- [x] `pnpm exec vitest run src/features/generation/worker/generators/binGenerator.scenario.test.ts` — 201/201 passing (snapshots regenerated, spot-checked: all counts decreased proportional to compartment density, biggest drop on 4×4 dense grid: 5268 → 3140)
- [x] `pnpm exec vitest run src/features/generation/worker/generators/featureBuilder.test.ts src/features/generation/worker/generators/binExporter.test.ts src/features/generation/worker/generators/pipeline/stages/shellStage.test.ts` — 239/239 passing
- [x] `pnpm exec tsc --noEmit` — clean
- [x] Pre-commit hooks: lint-staged, module boundaries, i18n (4 checks), exhaustiveness, component-structure — all green
- [x] Dev server boots and default bin renders correctly (`/designer`)
- [x] Exported STL artifacts open without slicer warnings (manual local check via reporter's exact bin shape — happy to attach STL on request)
- [ ] Visual confirmation of compartmented bins in the 3D preview — Playwright UI walk hit click-intercept issues on the panel's sticky header; the manifold-edge test + STL artifact cover the same ground topologically. Will spot-check post-merge.

Fixes #1753