### PR TITLE
fix(export): translate brepjs export Err to a user-readable message (#1757)

### DIFF
--- a/src/features/bin-designer/utils/binDownloadHelpers.test.ts
+++ b/src/features/bin-designer/utils/binDownloadHelpers.test.ts
@@ -190,4 +190,17 @@ describe('buildReportIssueUrl', () => {
     expect(json).toHaveProperty('featureColors');
     expect(json).toHaveProperty('wallThickness', params.wallThickness);
   });
+
+  it('does not flag renumbered-but-unmerged compartments as merged', () => {
+    // Each cell has a unique ID — these are 4 distinct compartments, not
+    // merged, even though the IDs aren't in `0..N-1` order. A positional
+    // `id !== i` check would false-positive here.
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      compartments: { cols: 2, rows: 2, thickness: 1.2, cells: [3, 2, 1, 0] },
+    };
+    const url = buildReportIssueUrl(params, new Error('test'), 'stl');
+    const json = extractParams(url);
+    expect((json.compartments as { merged: boolean }).merged).toBe(false);
+  });
 });

--- a/src/features/bin-designer/utils/binDownloadHelpers.test.ts
+++ b/src/features/bin-designer/utils/binDownloadHelpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { buildSinglePiece3MF, buildMultiObject3MF } from './binDownloadHelpers';
+import {
+  buildSinglePiece3MF,
+  buildMultiObject3MF,
+  buildReportIssueUrl,
+} from './binDownloadHelpers';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
 import type { BinParams } from '@/features/bin-designer/types';
 import type { CombinedExportResult } from '@/shared/generation/bridge';
@@ -138,5 +142,52 @@ describe('binDownloadHelpers — multi-color export gate', () => {
       // Ancillary pieces (dividers, lid) always ship solid-color.
       expect(objects[1].colorConfig).toBeUndefined();
     });
+  });
+});
+
+describe('buildReportIssueUrl', () => {
+  function extractBody(url: string): string {
+    return new URL(url).searchParams.get('body') ?? '';
+  }
+
+  function extractParams(url: string): Record<string, unknown> {
+    const body = extractBody(url);
+    const match = body.match(/```json\n([\s\S]*?)\n```/);
+    if (!match) throw new Error('no JSON block in body');
+    return JSON.parse(match[1]) as Record<string, unknown>;
+  }
+
+  it('includes scoop config when scoop is enabled (issue #1757 — scoop was previously omitted)', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 3.5,
+      depth: 11,
+      height: 9,
+      scoop: { enabled: true, radius: 'auto' },
+    };
+    const url = buildReportIssueUrl(params, new Error('test'), 'stl');
+    const json = extractParams(url);
+    expect(json.scoop).toEqual({ enabled: true, radius: 'auto' });
+  });
+
+  it('marks scoop as `false` when disabled (so its state is unambiguous)', () => {
+    const url = buildReportIssueUrl(DEFAULT_BIN_PARAMS, new Error('test'), 'stl');
+    const json = extractParams(url);
+    expect(json.scoop).toBe(false);
+  });
+
+  it('captures compartments + walls + label + lid + featureColors flags', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      compartments: { cols: 2, rows: 2, thickness: 1.2, cells: [0, 0, 1, 1] }, // merged cells
+      label: { enabled: true, support: 'bracket', depth: 12, width: 100, alignment: 'left' },
+    };
+    const url = buildReportIssueUrl(params, new Error('test'), 'stl');
+    const json = extractParams(url);
+    expect(json.compartments).toEqual({ cols: 2, rows: 2, merged: true });
+    expect(json.label).toMatchObject({ enabled: true, support: 'bracket', depth: 12 });
+    expect(json).toHaveProperty('lid');
+    expect(json).toHaveProperty('featureColors');
+    expect(json).toHaveProperty('wallThickness', params.wallThickness);
   });
 });

--- a/src/features/bin-designer/utils/binDownloadHelpers.ts
+++ b/src/features/bin-designer/utils/binDownloadHelpers.ts
@@ -73,6 +73,11 @@ export function formatPieceDisplayName(
  * Build a GitHub issue URL with bin params + error class prefilled. Lets the
  * "Report issue" toast action drop users into a complete bug report instead
  * of asking them to copy/paste failure context.
+ *
+ * The snapshot covers every BinParams field that materially affects the
+ * generated solid (so reports are reproducible). Fields added carelessly
+ * here will balloon the URL — keep the shape compact and prefer counts /
+ * enabled flags over full nested config when the nested data is large.
  */
 export function buildReportIssueUrl(
   params: BinParams,
@@ -93,12 +98,25 @@ export function buildReportIssueUrl(
         height: params.height,
         gridUnitMm: params.gridUnitMm,
         heightUnitMm: params.heightUnitMm,
+        wallThickness: params.wallThickness,
         style: params.style,
         base: { style: params.base.style, stackingLip: params.base.stackingLip },
+        compartments: {
+          cols: params.compartments.cols,
+          rows: params.compartments.rows,
+          merged: params.compartments.cells.some((id, i) => id !== i),
+        },
+        scoop: params.scoop.enabled ? { enabled: true, radius: params.scoop.radius } : false,
+        label: params.label.enabled
+          ? { enabled: true, support: params.label.support, depth: params.label.depth }
+          : false,
         wallPattern: params.wallPattern.enabled ? params.wallPattern.pattern : null,
+        walls: params.walls.enabled ? { shape: params.walls.shape } : false,
         handles: params.handles.enabled,
         cutouts: params.cutouts.length,
         inserts: params.inserts.length,
+        lid: params.lid.enabled,
+        featureColors: params.featureColors.enabled,
       },
       null,
       2

--- a/src/features/bin-designer/utils/binDownloadHelpers.ts
+++ b/src/features/bin-designer/utils/binDownloadHelpers.ts
@@ -104,7 +104,10 @@ export function buildReportIssueUrl(
         compartments: {
           cols: params.compartments.cols,
           rows: params.compartments.rows,
-          merged: params.compartments.cells.some((id, i) => id !== i),
+          // Duplicate IDs = at least two cells share a compartment. Robust
+          // against renumbered-but-unmerged designs (where a positional
+          // `id !== i` check would false-positive).
+          merged: new Set(params.compartments.cells).size !== params.compartments.cells.length,
         },
         scoop: params.scoop.enabled ? { enabled: true, radius: params.scoop.radius } : false,
         label: params.label.enabled

--- a/src/features/generation/worker/generators/binExporter.ts
+++ b/src/features/generation/worker/generators/binExporter.ts
@@ -2,7 +2,7 @@
  * Bin export — converts the last generated solid to STL or STEP format.
  */
 
-import { unwrap, exportSTL, exportSTEP, mesh } from 'brepjs';
+import { exportSTL, exportSTEP, mesh } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
 import type { ExportFormat, FaceGroupData } from '../../bridge/types';
 
@@ -10,6 +10,7 @@ import { generateBin } from './binOrchestrator';
 import { FeatureTag } from './featureTags';
 import { getLastSolid, isLastSolidExportQuality, setLastSolid } from './shapeCache';
 import { EXPORT_ANGULAR_TOLERANCE, EXPORT_TOLERANCE } from './utils/tolerances';
+import { unwrapExportBlob } from './utils/exportUnwrap';
 
 /** Export result with binary data and suggested file name. */
 export interface ExportResult {
@@ -48,7 +49,7 @@ async function runExportAttempt(
   if (format === 'step') {
     // STEP carries exact BREP geometry; faceGroups don't ride along, so
     // skip the re-mesh that the STL/3MF path needs.
-    const blob = unwrap(exportSTEP(solid));
+    const blob = unwrapExportBlob(exportSTEP(solid), 'STEP');
     const data = await blob.arrayBuffer();
     return { data, fileName: `${name}.step` };
   }
@@ -67,12 +68,13 @@ async function runExportAttempt(
     }));
   }
 
-  const blob = unwrap(
+  const blob = unwrapExportBlob(
     exportSTL(solid, {
       tolerance: EXPORT_TOLERANCE,
       angularTolerance: EXPORT_ANGULAR_TOLERANCE,
       binary: true,
-    })
+    }),
+    'STL'
   );
   const data = await blob.arrayBuffer();
   return { data, fileName: `${name}.stl`, faceGroups };

--- a/src/features/generation/worker/generators/dividerExport.ts
+++ b/src/features/generation/worker/generators/dividerExport.ts
@@ -11,6 +11,7 @@ import type { BinParams } from '@/shared/types/bin';
 import type { ExportFormat, CombinedExportPiece } from '../../bridge/types';
 import { GRIDFINITY } from '@/shared/constants/bin';
 import { buildUniqueDividerPieces } from './dividerBuilder';
+import { unwrapExportBlob } from './utils/exportUnwrap';
 
 const CLEARANCE = GRIDFINITY.TOLERANCE;
 const SOCKET_HEIGHT = GRIDFINITY.SOCKET_HEIGHT;
@@ -61,12 +62,13 @@ export async function exportDividers(
       nextPieceToFree = i + 1;
     }
 
-    const blob = unwrap(
+    const blob = unwrapExportBlob(
       exportSTL(combined, {
         tolerance: 0.01,
         angularTolerance: 5,
         binary: true,
-      })
+      }),
+      'STL'
     );
     const data = await blob.arrayBuffer();
 
@@ -117,10 +119,13 @@ export async function exportDividerPiecesSeparately(
   try {
     for (let i = 0; i < pieces.length; i++) {
       if (format === 'step') {
-        const blob = unwrap(exportSTEP(pieces[i]));
+        const blob = unwrapExportBlob(exportSTEP(pieces[i]), 'STEP');
         results.push({ data: await blob.arrayBuffer(), label: labels[i] });
       } else {
-        const blob = unwrap(exportSTL(pieces[i], { tolerance, angularTolerance, binary: true }));
+        const blob = unwrapExportBlob(
+          exportSTL(pieces[i], { tolerance, angularTolerance, binary: true }),
+          'STL'
+        );
         results.push({ data: await blob.arrayBuffer(), label: labels[i] });
       }
     }

--- a/src/features/generation/worker/generators/lidOrchestrator.ts
+++ b/src/features/generation/worker/generators/lidOrchestrator.ts
@@ -6,7 +6,7 @@
  * rejects (lid disabled, no stacking lip, or a blocker is active).
  */
 
-import { mesh, meshEdges, rotate, unwrap, exportSTL, exportSTEP } from 'brepjs';
+import { mesh, meshEdges, rotate, exportSTL, exportSTEP } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
 import type { LidMeshData, ExportFormat } from '../../bridge/types';
@@ -16,6 +16,7 @@ import { toIndexedMeshData } from './utils/mesh';
 import { computeTessellationTolerances } from './utils/tolerances';
 import { checkCancelled } from './meshUtils';
 import { shouldGenerateLid } from '@/shared/types/bin';
+import { unwrapExportBlob } from './utils/exportUnwrap';
 
 /**
  * Rotate the lid 180° around the X axis so the floor's outer surface
@@ -119,17 +120,18 @@ export async function exportLid(
   // caller-owned and must be released once the export buffer is built.
   try {
     if (format === 'step') {
-      const blob = unwrap(exportSTEP(solid));
+      const blob = unwrapExportBlob(exportSTEP(solid), 'STEP');
       const data = await blob.arrayBuffer();
       return { data, fileName: `${name}.step` };
     }
 
-    const blob = unwrap(
+    const blob = unwrapExportBlob(
       exportSTL(solid, {
         tolerance,
         angularTolerance,
         binary: true,
-      })
+      }),
+      'STL'
     );
     const data = await blob.arrayBuffer();
     return { data, fileName: `${name}.stl` };

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -22,6 +22,7 @@ import type { Shape3D, ValidSolid } from 'brepjs';
 import type { BinParams, SplitConnectorConfig } from '@/shared/types/bin';
 
 import { SIZE, CLEARANCE, SOCKET_HEIGHT } from './generatorTypes';
+import { unwrapExportBlob } from './utils/exportUnwrap';
 import { LIP_HEIGHT, LIP_TAPER_WIDTH } from './generatorConstants';
 import { toIndexedMeshData } from './utils/mesh';
 import { buildTopShape } from './boxBuilder';
@@ -449,7 +450,10 @@ export async function exportSplitBin(
     // un-tessellated. Calling mesh() first runs BRepMesh_IncrementalMesh which
     // fills in the missing triangulation on cut-plane faces.
     mesh(pieceSolid, { tolerance, angularTolerance, cache: false });
-    const blob = unwrap(exportSTL(pieceSolid, { tolerance, angularTolerance, binary: true }));
+    const blob = unwrapExportBlob(
+      exportSTL(pieceSolid, { tolerance, angularTolerance, binary: true }),
+      'STL'
+    );
     const data = await blob.arrayBuffer();
     pieceSolid.delete();
     pieces.push({ data, label, col, row });
@@ -538,7 +542,10 @@ export async function exportSplitBinRange(
     const { solid: pieceSolid, label, col, row } = splitPieces[idx];
     // Force complete tessellation (see exportSplitBin comment for rationale)
     mesh(pieceSolid, { tolerance, angularTolerance, cache: false });
-    const blob = unwrap(exportSTL(pieceSolid, { tolerance, angularTolerance, binary: true }));
+    const blob = unwrapExportBlob(
+      exportSTL(pieceSolid, { tolerance, angularTolerance, binary: true }),
+      'STL'
+    );
     const data = await blob.arrayBuffer();
     pieceSolid.delete();
     pieces.push({ data, label, col, row });

--- a/src/features/generation/worker/generators/utils/exportUnwrap.test.ts
+++ b/src/features/generation/worker/generators/utils/exportUnwrap.test.ts
@@ -41,6 +41,21 @@ describe('unwrapExportBlob', () => {
     }
   });
 
+  it('falls back to the default suggestion when BrepError suggestion is an empty string', () => {
+    // brepjs may serialize a missing suggestion as `""`; `??` would let it
+    // through and the user would see no hint. Guard against that.
+    const result = err(
+      ioError('STL_EXPORT_FAILED', 'Failed to write STL file', undefined, undefined, '')
+    );
+    try {
+      unwrapExportBlob(result, 'STL');
+      expect.fail('should have thrown');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      expect(msg).toMatch(/disabling features one at a time/i);
+    }
+  });
+
   it('preserves the structured BrepError via `cause`', () => {
     const brepErr = ioError('STL_EXPORT_FAILED', 'Failed to write STL file');
     const result = err(brepErr);

--- a/src/features/generation/worker/generators/utils/exportUnwrap.test.ts
+++ b/src/features/generation/worker/generators/utils/exportUnwrap.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { ok, err, ioError } from 'brepjs';
+import { unwrapExportBlob } from './exportUnwrap';
+
+describe('unwrapExportBlob', () => {
+  it('returns the Blob from an Ok result', () => {
+    const blob = new Blob(['stl bytes']);
+    const result = ok(blob);
+    expect(unwrapExportBlob(result, 'STL')).toBe(blob);
+  });
+
+  it('throws a friendly Error for an STL Err, omitting "Called unwrap" jargon', () => {
+    const result = err(ioError('STL_EXPORT_FAILED', 'Failed to write STL file'));
+    expect(() => unwrapExportBlob(result, 'STL')).toThrow(
+      /Failed to write STL file \(STL_EXPORT_FAILED\)/
+    );
+    expect(() => unwrapExportBlob(result, 'STL')).not.toThrow(/Called unwrap/);
+  });
+
+  it('uses the BrepError suggestion when present', () => {
+    const result = err(
+      ioError('STL_EXPORT_FAILED', 'Failed to write STL file', undefined, undefined, 'Try X.')
+    );
+    try {
+      unwrapExportBlob(result, 'STL');
+      expect.fail('should have thrown');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      expect(msg).toContain('Try X.');
+    }
+  });
+
+  it('falls back to a default suggestion when BrepError omits one', () => {
+    const result = err(ioError('STL_EXPORT_FAILED', 'Failed to write STL file'));
+    try {
+      unwrapExportBlob(result, 'STL');
+      expect.fail('should have thrown');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      expect(msg).toMatch(/disabling features one at a time/i);
+    }
+  });
+
+  it('preserves the structured BrepError via `cause`', () => {
+    const brepErr = ioError('STL_EXPORT_FAILED', 'Failed to write STL file');
+    const result = err(brepErr);
+    try {
+      unwrapExportBlob(result, 'STL');
+      expect.fail('should have thrown');
+    } catch (e) {
+      expect(e instanceof Error && e.cause).toBe(brepErr);
+      expect(e instanceof Error && e.name).toBe('ExportFailed');
+    }
+  });
+
+  it('uses a STEP-specific default suggestion for STEP exports', () => {
+    const result = err(ioError('STEP_EXPORT_FAILED', 'Failed to write STEP file'));
+    try {
+      unwrapExportBlob(result, 'STEP');
+      expect.fail('should have thrown');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      expect(msg).toMatch(/STEP requires valid BREP geometry/i);
+    }
+  });
+});

--- a/src/features/generation/worker/generators/utils/exportUnwrap.ts
+++ b/src/features/generation/worker/generators/utils/exportUnwrap.ts
@@ -1,5 +1,5 @@
 /**
- * Unwrap helpers for brepjs export Results (STL/STEP/IGES).
+ * Unwrap helpers for brepjs export Results (STL and STEP).
  *
  * brepjs returns `Result<Blob, BrepError>` from its export functions. Using
  * brepjs's `unwrap()` rethrows with `"Called unwrap on an Err: [IO] STL_EXPORT_FAILED: ..."`,
@@ -36,9 +36,10 @@ export function unwrapExportBlob(result: Result<Blob>, format: ExportFormat): Bl
   const error = result.error as BrepLikeError;
   const code = error.code ?? 'UNKNOWN';
   const detail = error.message ?? `${format} export failed`;
-  const suggestion = error.suggestion ?? DEFAULT_SUGGESTION[format];
-  const tail = suggestion ? ` — ${suggestion}` : '';
-  throw Object.assign(new Error(`${detail} (${code})${tail}`, { cause: error }), {
+  // `||` (not `??`): brepjs may serialize a missing suggestion as `""`, and
+  // an empty string here would silently drop the default actionable hint.
+  const suggestion = error.suggestion || DEFAULT_SUGGESTION[format];
+  throw Object.assign(new Error(`${detail} (${code}) — ${suggestion}`, { cause: error }), {
     name: 'ExportFailed',
   });
 }

--- a/src/features/generation/worker/generators/utils/exportUnwrap.ts
+++ b/src/features/generation/worker/generators/utils/exportUnwrap.ts
@@ -1,0 +1,44 @@
+/**
+ * Unwrap helpers for brepjs export Results (STL/STEP/IGES).
+ *
+ * brepjs returns `Result<Blob, BrepError>` from its export functions. Using
+ * brepjs's `unwrap()` rethrows with `"Called unwrap on an Err: [IO] STL_EXPORT_FAILED: ..."`,
+ * which leaks Rust-style panic phrasing into the user-facing toast. This
+ * helper unpacks the structured error and throws an `Error` whose message is
+ * a plain sentence the user can act on.
+ */
+
+import { isOk, type Result } from 'brepjs';
+
+interface BrepLikeError {
+  readonly kind?: string;
+  readonly code?: string;
+  readonly message?: string;
+  readonly suggestion?: string;
+}
+
+type ExportFormat = 'STL' | 'STEP';
+
+const DEFAULT_SUGGESTION: Record<ExportFormat, string> = {
+  STL: 'Try disabling features one at a time (scoop, cutouts, handles, wall pattern) to find the failing combination, then report the issue.',
+  STEP: 'Try a simpler bin configuration — STEP requires valid BREP geometry, which complex feature combinations can violate.',
+};
+
+/**
+ * Extract a Blob from an export Result, throwing a user-readable Error on failure.
+ *
+ * The thrown error preserves the structured `BrepError` via `cause` so
+ * telemetry retains the full code/kind/metadata, while the surfaced
+ * message stays short and actionable.
+ */
+export function unwrapExportBlob(result: Result<Blob>, format: ExportFormat): Blob {
+  if (isOk(result)) return result.value;
+  const error = result.error as BrepLikeError;
+  const code = error.code ?? 'UNKNOWN';
+  const detail = error.message ?? `${format} export failed`;
+  const suggestion = error.suggestion ?? DEFAULT_SUGGESTION[format];
+  const tail = suggestion ? ` — ${suggestion}` : '';
+  throw Object.assign(new Error(`${detail} (${code})${tail}`, { cause: error }), {
+    name: 'ExportFailed',
+  });
+}


### PR DESCRIPTION
## Summary

- Replaces `unwrap(exportSTL/STEP(...))` with a structured helper (`unwrapExportBlob`) so the user-facing toast no longer reads `"Called unwrap() on an Err: [IO] STL_EXPORT_FAILED: Failed to write STL file"`. brepjs already returns a structured `Result<Blob, BrepError>` carrying `code`/`message`/`suggestion`; the helper uses them and falls back to a format-specific hint when the kernel provides none.
- Adds the missing `scoop` config to the GitHub "Report issue" prefill. The #1757 reporter found the failure went away when they disabled the finger scoop, but the bug-report body said `cutouts: 0, inserts: 0` with no scoop field, so the report was misleading on its face. Also adds compartment merge state, walls, label tab, lid, featureColors, and wallThickness for repro-grade reports.

### Affected call sites

The helper is wired into the four `exportSTL` and three `exportSTEP` paths that show up in PostHog (132 occurrences / 11 users in 10 days):

- `splitBinBuilder.ts` — `exportSplitBin`, `exportSplitBinRange`
- `binExporter.ts` — `exportBin` (STL + STEP)
- `dividerExport.ts` — `exportDividers`, `exportDividerPiecesSeparately`
- `lidOrchestrator.ts` — `exportLid`

Non-export `unwrap()` calls (clone/intersect/fuse/cut) are left alone — those failures are already classified by `classifyExportError` into `BREP_BOOLEAN_FAILED` and don't surface the same jargon.

### Out of scope — follow-up issue #1760

The underlying STL geometry failure is **broader than #1757 suggested**. Isolated bisection (in a deterministic single-test repro) shows the trigger is **scoop + a depth that requires splitting + tall walls (height ≥ ~9)** — not the half-bin width or the missing lip from the original report. Filed as #1760 with the full bisection matrix and a likely-cause hypothesis.

This PR intentionally does **not** ship the failing scenario test (would block CI). The matrix is in #1760 so a follow-up has a deterministic repro.

## Test plan

- [x] `pnpm vitest run src/features/generation/worker/generators/utils/exportUnwrap.test.ts src/features/bin-designer/utils/binDownloadHelpers.test.ts` — 16/16 pass (includes new tests for empty-string suggestion + renumbered-unmerged compartments per review feedback)
- [x] `pnpm vitest run src/features/generation/worker/generators/binExporter.test.ts` — 5/5 pass
- [x] `pnpm run typecheck`
- [x] Lint clean on touched files
- [ ] Manual: trigger a known-failing export (e.g. the #1757 params) and confirm the toast reads `"Failed to write STL file (STL_EXPORT_FAILED) — Try disabling features one at a time…"` instead of the unwrap jargon
- [ ] Manual: trigger a failure, click "Report issue", confirm prefilled body includes `scoop: { enabled: true, ... }`

Closes #1757 (error messaging + bug-report serialization).
Tracks #1760 (underlying geometry failure).