### PR TITLE
fix(generation): bypass OCCT STL writer for split-bin pieces (#1760)

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.split-scoop-tall.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-scoop-tall.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+/**
+ * Regression test for issue #1760: split STL export fails for scoop + tall
+ * walls when the bin is long enough to require splitting.
+ *
+ * The deterministic repro from the bisection matrix in the issue:
+ *   - width 3 or 3.5
+ *   - depth 11 (forces a Y split on the 256mm bed: 11*42 = 462mm > 256mm)
+ *   - height 9 (tall walls)
+ *   - scoop enabled (radius='auto')
+ *   - lip either on or off
+ *   - single mid-depth cut plane (y=0)
+ *
+ * Previously threw `[IO] STL_EXPORT_FAILED: Failed to write STL file` from
+ * `exportSTL`. Single-piece export with the same scoop+tall combo succeeds;
+ * the failure is specific to the boolean-intersected pieces.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DEFAULT_BIN_PARAMS, GRIDFINITY } from '@/shared/constants/bin';
+import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
+import type { BinParams } from '@/shared/types/bin';
+import { initBrepjs, getExportSplitBin } from './__kernel-tests__/wasmInit';
+import { parseSTLBinary } from '@/shared/generation/stlParser';
+import { boundingBox, hasNoNaNOrInfinity } from './__kernel-tests__/meshAssertions';
+import { isOk } from '@/core/result';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+function exportPieceBounds(data: ArrayBuffer) {
+  const result = parseSTLBinary(data);
+  expect(isOk(result), 'STL parse should succeed').toBe(true);
+  if (!isOk(result)) throw new Error('unreachable');
+  const { vertices } = result.value;
+  expect(hasNoNaNOrInfinity(vertices), 'export vertices have NaN/Infinity').toBe(true);
+  return { bb: boundingBox(vertices), triangleCount: vertices.length / 9 };
+}
+
+describe('split export: scoop + tall walls (issue #1760)', () => {
+  const NO_CONNECTORS = { ...DEFAULT_SPLIT_CONNECTOR_CONFIG, enabled: false };
+
+  it('exports 3×11×9 scoop bin with no lip and a mid-depth y-cut', async () => {
+    const exportSplitBin = getExportSplitBin();
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 3,
+      depth: 11,
+      height: 9,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+      scoop: { enabled: true, radius: 'auto' },
+    };
+
+    const exported = await exportSplitBin(params, [], [0], 0.01, 5, NO_CONNECTORS);
+    expect(exported.pieces).toHaveLength(2);
+
+    const totalHeight = params.height * GRIDFINITY.HEIGHT_UNIT;
+    for (const piece of exported.pieces) {
+      const { bb, triangleCount } = exportPieceBounds(piece.data);
+      const exportZ = bb.maxZ - bb.minZ;
+      expect(
+        exportZ,
+        `piece ${piece.label}: Z=${exportZ.toFixed(1)}mm should reach full height ${totalHeight.toFixed(1)}mm`
+      ).toBeGreaterThan(totalHeight * 0.9);
+      expect(
+        triangleCount,
+        `piece ${piece.label}: should have substantial geometry, got ${triangleCount} triangles`
+      ).toBeGreaterThan(100);
+    }
+  }, 120000);
+
+  it('exports 3×11×9 scoop bin with lip and a mid-depth y-cut', async () => {
+    const exportSplitBin = getExportSplitBin();
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 3,
+      depth: 11,
+      height: 9,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      scoop: { enabled: true, radius: 'auto' },
+    };
+
+    const exported = await exportSplitBin(params, [], [0], 0.01, 5, NO_CONNECTORS);
+    expect(exported.pieces).toHaveLength(2);
+
+    const totalHeight = params.height * GRIDFINITY.HEIGHT_UNIT;
+    for (const piece of exported.pieces) {
+      const { bb, triangleCount } = exportPieceBounds(piece.data);
+      const exportZ = bb.maxZ - bb.minZ;
+      expect(
+        exportZ,
+        `piece ${piece.label}: Z=${exportZ.toFixed(1)}mm should exceed wall height ${totalHeight.toFixed(1)}mm (with lip)`
+      ).toBeGreaterThan(totalHeight);
+      expect(
+        triangleCount,
+        `piece ${piece.label}: should have substantial geometry, got ${triangleCount} triangles`
+      ).toBeGreaterThan(100);
+    }
+  }, 120000);
+});

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -460,9 +460,16 @@ function tessellatePiece(
 /**
  * Export the cached (or regenerated) bin solid, split into pieces via boolean cuts.
  *
- * Each piece is independently tessellated to STL.
+ * Each piece is independently tessellated to STL. If tessellation throws
+ * partway through, the remaining piece solids are still disposed so we don't
+ * leak WASM memory.
+ *
+ * `async` is intentional even though the body has no `await` — it keeps the
+ * error-delivery contract (throws arrive as rejected promises) consistent
+ * with the declared return type, matching what every caller expects.
  */
-export function exportSplitBin(
+// eslint-disable-next-line @typescript-eslint/require-await -- see fn doc
+export async function exportSplitBin(
   params: BinParams,
   cutPlanesX: readonly number[],
   cutPlanesY: readonly number[],
@@ -473,13 +480,23 @@ export function exportSplitBin(
   const splitPieces = splitSolidIntoPieces(params, cutPlanesX, cutPlanesY, splitConnectorConfig);
 
   const pieces: SplitExportResult['pieces'] = [];
-
-  for (const piece of splitPieces) {
-    const data = tessellateAndExportPiece(piece, tolerance, angularTolerance);
-    pieces.push({ data, label: piece.label, col: piece.col, row: piece.row });
+  let nextIdx = 0;
+  try {
+    for (; nextIdx < splitPieces.length; nextIdx++) {
+      const piece = splitPieces[nextIdx];
+      const data = tessellateAndExportPiece(piece, tolerance, angularTolerance);
+      pieces.push({ data, label: piece.label, col: piece.col, row: piece.row });
+    }
+  } finally {
+    // tessellateAndExportPiece disposes the solid it processed (including on
+    // throw, via its own try/finally). Clean up any pieces past that point
+    // that were never handed off.
+    for (let i = nextIdx + 1; i < splitPieces.length; i++) {
+      splitPieces[i].solid.delete();
+    }
   }
 
-  return Promise.resolve({ pieces });
+  return { pieces };
 }
 
 /**
@@ -538,10 +555,15 @@ export function generateSplitPreviewRange(
 /**
  * Export split bin pieces for a subset of piece indices.
  *
- * Same as exportSplitBin but only processes the assigned pieces,
- * allowing parallel export across multiple workers.
+ * Same as exportSplitBin but only processes the assigned pieces, allowing
+ * parallel export across multiple workers. Pieces outside `pieceIndices` are
+ * always disposed (even if export throws midway through) to keep WASM
+ * memory bounded.
+ *
+ * `async` is intentional — same rationale as exportSplitBin's doc.
  */
-export function exportSplitBinRange(
+// eslint-disable-next-line @typescript-eslint/require-await -- see fn doc
+export async function exportSplitBinRange(
   params: BinParams,
   cutPlanesX: readonly number[],
   cutPlanesY: readonly number[],
@@ -553,23 +575,25 @@ export function exportSplitBinRange(
   const splitPieces = splitSolidIntoPieces(params, cutPlanesX, cutPlanesY, splitConnectorConfig);
 
   const pieces: SplitExportResult['pieces'] = [];
+  const processed = new Set<number>();
+  try {
+    for (const idx of pieceIndices) {
+      if (idx < 0 || idx >= splitPieces.length) {
+        throw new Error(`Piece index ${idx} out of range [0, ${splitPieces.length})`);
+      }
 
-  for (const idx of pieceIndices) {
-    if (idx < 0 || idx >= splitPieces.length) {
-      throw new Error(`Piece index ${idx} out of range [0, ${splitPieces.length})`);
+      processed.add(idx);
+      const piece = splitPieces[idx];
+      const data = tessellateAndExportPiece(piece, tolerance, angularTolerance);
+      pieces.push({ data, label: piece.label, col: piece.col, row: piece.row });
     }
-
-    const piece = splitPieces[idx];
-    const data = tessellateAndExportPiece(piece, tolerance, angularTolerance);
-    pieces.push({ data, label: piece.label, col: piece.col, row: piece.row });
+  } finally {
+    // tessellateAndExportPiece disposes the solids it processed (including
+    // the one that threw, via its own try/finally). Dispose everything else.
+    for (let i = 0; i < splitPieces.length; i++) {
+      if (!processed.has(i)) splitPieces[i].solid.delete();
+    }
   }
 
-  // Dispose unused split pieces (not in pieceIndices)
-  for (let i = 0; i < splitPieces.length; i++) {
-    if (!pieceIndices.includes(i)) {
-      splitPieces[i].solid.delete();
-    }
-  }
-
-  return Promise.resolve({ pieces });
+  return { pieces };
 }

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -16,13 +16,12 @@ import {
   getBounds,
   mesh,
   meshEdges,
-  exportSTL,
 } from 'brepjs';
 import type { Shape3D, ValidSolid } from 'brepjs';
 import type { BinParams, SplitConnectorConfig } from '@/shared/types/bin';
 
 import { SIZE, CLEARANCE, SOCKET_HEIGHT } from './generatorTypes';
-import { unwrapExportBlob } from './utils/exportUnwrap';
+import { buildSTLBufferFromIndexed } from '@/features/generation/export/stlExporter';
 import { LIP_HEIGHT, LIP_TAPER_WIDTH } from './generatorConstants';
 import { toIndexedMeshData } from './utils/mesh';
 import { buildTopShape } from './boxBuilder';
@@ -377,6 +376,39 @@ function splitSolidIntoPieces(
   return pieces;
 }
 
+/**
+ * Tessellate a split piece and serialize it to a binary STL ArrayBuffer.
+ *
+ * Path: `brepjs.mesh()` → `buildSTLBufferFromIndexed()`.
+ *
+ * We deliberately bypass brepjs's `exportSTL()` (which calls OCCT's
+ * `StlAPI.Write`). For bins with a scoop ramp and walls tall enough that
+ * the scoop radius is sizeable (e.g. height=9 → radius=29mm), the boolean
+ * cut leaves a BREP topology that triangulates correctly via `mesh()` but
+ * trips a silent failure in `StlAPI.Write` — exportSTL returns
+ * `STL_EXPORT_FAILED` regardless of tolerance (issue #1760).
+ *
+ * Writing STL from the meshed triangle buffer ourselves removes the
+ * dependency on OCCT's STL writer; `buildSTLBufferFromIndexed` runs on
+ * the exact same triangles the preview path already renders cleanly.
+ */
+function tessellateAndExportPiece(
+  piece: SplitPieceInfo,
+  tolerance: number,
+  angularTolerance: number
+): ArrayBuffer {
+  const { solid: pieceSolid } = piece;
+  try {
+    const m = mesh(pieceSolid, { tolerance, angularTolerance, cache: false });
+    const vertices = m.vertices instanceof Float32Array ? m.vertices : new Float32Array(m.vertices);
+    const normals = m.normals instanceof Float32Array ? m.normals : new Float32Array(m.normals);
+    const indices = m.triangles instanceof Uint32Array ? m.triangles : new Uint32Array(m.triangles);
+    return buildSTLBufferFromIndexed(vertices, normals, indices, `gridfinity-piece-${piece.label}`);
+  } finally {
+    pieceSolid.delete();
+  }
+}
+
 /** Tessellate a split piece into preview mesh data */
 function tessellatePiece(
   piece: SplitPieceInfo,
@@ -430,7 +462,7 @@ function tessellatePiece(
  *
  * Each piece is independently tessellated to STL.
  */
-export async function exportSplitBin(
+export function exportSplitBin(
   params: BinParams,
   cutPlanesX: readonly number[],
   cutPlanesY: readonly number[],
@@ -442,24 +474,12 @@ export async function exportSplitBin(
 
   const pieces: SplitExportResult['pieces'] = [];
 
-  for (const { solid: pieceSolid, label, col, row } of splitPieces) {
-    // Force complete tessellation before export. Boolean intersection reuses
-    // some original faces (with existing triangulation) but creates new faces
-    // at cut planes (without triangulation). brepjs exportSTL skips meshing
-    // when hasTriangulation() finds ANY tessellated face, leaving new faces
-    // un-tessellated. Calling mesh() first runs BRepMesh_IncrementalMesh which
-    // fills in the missing triangulation on cut-plane faces.
-    mesh(pieceSolid, { tolerance, angularTolerance, cache: false });
-    const blob = unwrapExportBlob(
-      exportSTL(pieceSolid, { tolerance, angularTolerance, binary: true }),
-      'STL'
-    );
-    const data = await blob.arrayBuffer();
-    pieceSolid.delete();
-    pieces.push({ data, label, col, row });
+  for (const piece of splitPieces) {
+    const data = tessellateAndExportPiece(piece, tolerance, angularTolerance);
+    pieces.push({ data, label: piece.label, col: piece.col, row: piece.row });
   }
 
-  return { pieces };
+  return Promise.resolve({ pieces });
 }
 
 /**
@@ -521,7 +541,7 @@ export function generateSplitPreviewRange(
  * Same as exportSplitBin but only processes the assigned pieces,
  * allowing parallel export across multiple workers.
  */
-export async function exportSplitBinRange(
+export function exportSplitBinRange(
   params: BinParams,
   cutPlanesX: readonly number[],
   cutPlanesY: readonly number[],
@@ -539,16 +559,9 @@ export async function exportSplitBinRange(
       throw new Error(`Piece index ${idx} out of range [0, ${splitPieces.length})`);
     }
 
-    const { solid: pieceSolid, label, col, row } = splitPieces[idx];
-    // Force complete tessellation (see exportSplitBin comment for rationale)
-    mesh(pieceSolid, { tolerance, angularTolerance, cache: false });
-    const blob = unwrapExportBlob(
-      exportSTL(pieceSolid, { tolerance, angularTolerance, binary: true }),
-      'STL'
-    );
-    const data = await blob.arrayBuffer();
-    pieceSolid.delete();
-    pieces.push({ data, label, col, row });
+    const piece = splitPieces[idx];
+    const data = tessellateAndExportPiece(piece, tolerance, angularTolerance);
+    pieces.push({ data, label: piece.label, col: piece.col, row: piece.row });
   }
 
   // Dispose unused split pieces (not in pieceIndices)
@@ -558,5 +571,5 @@ export async function exportSplitBinRange(
     }
   }
 
-  return { pieces };
+  return Promise.resolve({ pieces });
 }


### PR DESCRIPTION
## Summary

- Bypass brepjs `exportSTL()` (which calls OCCT's `StlAPI.Write`) in the split-bin export path; route through the in-house `buildSTLBufferFromIndexed` against the same triangle buffer brepjs `mesh()` already returns.
- Adds a scenario test reproducing #1760 (3×11×9 + scoop, with and without lip, mid-depth y-cut).

## Why

The boolean intersect that produces each split piece leaves BREP topology that brepjs `mesh()` triangulates cleanly — the preview path already renders it without issue — but that `StlAPI.Write` rejects with `STL_EXPORT_FAILED` regardless of tessellation tolerance. The bisection in #1760 isolated the trigger to **scoop + depth long enough to force a split + tall walls (height ≥ ~9)**. Single-piece export with the same scoop+tall combo succeeds, so the failure is specific to post-cut pieces. Writing the STL ourselves removes the dependency on OCCT's STL writer; the in-house writer runs on the exact triangles the preview path already validates.

Single-piece export (`binExporter.ts`) keeps the original `exportSTL` path — no boolean cut, no observed failure, no reason to widen the change.

Fixes #1760.

## Test plan

- [x] New scenario `binGenerator.scenario.split-scoop-tall.test.ts` covers the exact #1760 repro (no-lip and lip variants). Was throwing `STL_EXPORT_FAILED`; now produces full-height STL for both pieces.
- [x] All 48 existing split-export + split-robustness scenario tests still pass.
- [x] Adjacent suites (binExporter, split-large-bin, split-lip-trim, split-connectors, split-slotted-lip, split-polygon, dividerExport) still pass.
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.