### PR TITLE
feat(bin-designer): background thumbnail regeneration on app boot

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ import { useThemeEffect } from '@/shared/hooks/useThemeEffect';
 import { useDesignerRouting } from '@/shared/hooks/useDesignerRouting';
 import { useBaseplateRouting } from '@/shared/hooks/useBaseplateRouting';
 import { usePlaceBinFromURL } from '@/features/bin-designer/hooks/usePlaceBinInLayout';
+import { useBackgroundThumbnailRegen } from '@/features/bin-designer';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { SHORTCUTS } from '@/core/constants';
 
@@ -171,6 +172,7 @@ export default function App() {
 
   usePlaceBinFromURL();
   useOwnedShareSync();
+  useBackgroundThumbnailRegen();
 
   useEffect(() => {
     return initLayoutAnalytics();

--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -142,7 +142,9 @@ graph TB
 Two paths produce design thumbnails, written to IndexedDB and surfaced in the design-list modal:
 
 1. **Live-canvas capture** (`utils/thumbnail.ts` → `captureThumbnailAtPreset`) — used by `useAutoSave` and `useThumbnailCapture`. Reuses the main `PreviewCanvas`'s WebGL context: saves camera state, moves to the isometric preset, renders one frame, captures via `drawImage`, restores. Requires the designer to be mounted.
-2. **Offscreen regenerator** (`utils/thumbnailRegenerator.ts`) — used by `useThumbnailRegeneration` (modal-open fallback). Creates its own `THREE.WebGLRenderer`, acquires the shared bridge, generates mesh, renders one frame, disposes everything. Works without the designer being mounted.
+2. **Offscreen regenerator** (`utils/thumbnailRegenerator.ts`) — used by `useThumbnailRegeneration` (modal-open fallback) and `useBackgroundThumbnailRegen` (boot scan). Creates its own `THREE.WebGLRenderer`, acquires the shared bridge, generates mesh, renders one frame, disposes everything. Works without the designer being mounted.
+
+**Boot-time scan** (`hooks/useBackgroundThumbnailRegen.ts`, mounted in `App.tsx`) runs once per page load to regenerate stale thumbnails before the user opens the modal. It schedules itself on `requestIdleCallback`, waits for sync to settle for authenticated sessions, pauses while the designer's `generationStatus === 'generating'` or the tab is hidden, and acquires the bridge once for the whole batch. Emits a single `bin_designer_bg_thumbnail_regen` PostHog event on completion. The modal-open hook stays as an in-session safety net for designs that appear after the boot scan (imports, freshly created bins).
 
 Both paths feed the same `THUMBNAIL_VERSION` invariant: any thumbnail saved is stamped with the current version. The modal hook re-flags any design whose stored version trails the current constant, so bumping `THUMBNAIL_VERSION` (in `types/index.ts`) forces an organic regeneration on next modal open.
 

--- a/src/features/bin-designer/hooks/index.ts
+++ b/src/features/bin-designer/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useAutoSave } from './useAutoSave';
+export { useBackgroundThumbnailRegen } from './useBackgroundThumbnailRegen';
 export { useCreateFromBin } from './useCreateFromBin';
 export { useDesignerInit } from './useDesignerInit';
 export { useDesignerKeyboard } from './useDesignerKeyboard';

--- a/src/features/bin-designer/hooks/useBackgroundThumbnailRegen.test.ts
+++ b/src/features/bin-designer/hooks/useBackgroundThumbnailRegen.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Tests for the background thumbnail-regen hook.
+ *
+ * The full pipeline (Three.js + WASM bridge) can't run in jsdom, so the tests
+ * focus on the orchestration:
+ *   - one-shot scheduling under StrictMode-style remounts
+ *   - the sync-settled gate for authenticated vs anonymous sessions
+ *   - the generationStatus pause / resume signal
+ *   - the batch summary event shape on completion + on early abort
+ *
+ * `regenerateThumbnail` and `updateDesignThumbnail` are mocked; we assert the
+ * loop's *control flow*, not the rendering output.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { ok, err, storageUnavailable } from '@/core/result';
+import { DEFAULT_BIN_PARAMS } from '../constants/defaults';
+import { THUMBNAIL_VERSION } from '../types';
+import type { SavedDesign } from '../types';
+
+vi.mock('../utils/thumbnailRegenerator', () => ({
+  regenerateThumbnail: vi.fn(),
+}));
+
+vi.mock('@/features/bin-designer/storage/DesignerStorage', () => ({
+  listDesigns: vi.fn(),
+  updateDesignThumbnail: vi.fn(),
+}));
+
+vi.mock('../store/customBinRegistry', () => ({
+  upsertRegistryEntry: vi.fn(),
+}));
+
+vi.mock('./useDesignThumbnail', () => ({
+  updateThumbnailCache: vi.fn(),
+}));
+
+vi.mock('@/shared/generation/bridge', () => ({
+  bridgeManager: {
+    acquire: vi.fn().mockResolvedValue({}),
+    release: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/analytics/posthog', () => ({
+  trackEvent: vi.fn(),
+}));
+
+import { regenerateThumbnail } from '../utils/thumbnailRegenerator';
+import * as DesignerStorage from '@/features/bin-designer/storage/DesignerStorage';
+import { bridgeManager } from '@/shared/generation/bridge';
+import { trackEvent } from '@/shared/analytics/posthog';
+import { useSessionStore } from '@/core/sync/session/useSession';
+import { useSyncStatusStore } from '@/core/sync/status';
+import { useDesignerStore } from '../store/designer';
+import { useBackgroundThumbnailRegen, __resetForTests } from './useBackgroundThumbnailRegen';
+import { resetAllStores } from '@/test/testUtils';
+
+function makeDesign(overrides: Partial<SavedDesign> = {}): SavedDesign {
+  return {
+    id: overrides.id ?? 'design-1',
+    name: 'Test Bin',
+    params: { ...DEFAULT_BIN_PARAMS },
+    thumbnail: null,
+    thumbnailVersion: undefined,
+    exportFileNameConfig: null,
+    createdAt: '2026-05-19T00:00:00.000Z',
+    updatedAt: '2026-05-19T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/**
+ * jsdom doesn't ship rIC. Polyfill to a microtask so tests don't depend on
+ * real idle time, and so the loop's yield-between-items resolves promptly.
+ */
+function installIdlePolyfill(): () => void {
+  const originalRic = (window as unknown as { requestIdleCallback?: (cb: () => void) => number })
+    .requestIdleCallback;
+  const originalCancel = (window as unknown as { cancelIdleCallback?: (id: number) => void })
+    .cancelIdleCallback;
+  (window as unknown as { requestIdleCallback: (cb: () => void) => number }).requestIdleCallback = (
+    cb
+  ) => {
+    queueMicrotask(cb);
+    return 0;
+  };
+  (window as unknown as { cancelIdleCallback: (id: number) => void }).cancelIdleCallback = () => {};
+  return () => {
+    if (originalRic) {
+      (window as unknown as { requestIdleCallback: typeof originalRic }).requestIdleCallback =
+        originalRic;
+    } else {
+      delete (window as unknown as { requestIdleCallback?: unknown }).requestIdleCallback;
+    }
+    if (originalCancel) {
+      (window as unknown as { cancelIdleCallback: typeof originalCancel }).cancelIdleCallback =
+        originalCancel;
+    } else {
+      delete (window as unknown as { cancelIdleCallback?: unknown }).cancelIdleCallback;
+    }
+  };
+}
+
+describe('useBackgroundThumbnailRegen', () => {
+  let restoreIdle: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetForTests();
+    // Reset shared Zustand stores per project convention (see src/test/README.md).
+    // `resetAllStores` doesn't cover the session/sync/designer stores this
+    // hook reads, so those still need explicit setState below.
+    resetAllStores();
+    restoreIdle = installIdlePolyfill();
+
+    // Anonymous + idle by default. Tests opt into authenticated/syncing.
+    useSessionStore.setState({ status: 'anonymous', user: null });
+    useSyncStatusStore.setState({
+      state: 'idle',
+      pendingCount: 0,
+      lastSyncedAt: undefined,
+      lastError: undefined,
+    });
+    useDesignerStore.setState({
+      generation: { status: 'idle', mesh: null, progress: 0, epoch: 0 },
+    });
+
+    vi.mocked(regenerateThumbnail).mockResolvedValue('data:image/webp;base64,FAKE');
+    vi.mocked(DesignerStorage.updateDesignThumbnail).mockImplementation((id) =>
+      Promise.resolve(
+        ok({
+          id,
+          name: 'Test Bin',
+          params: { ...DEFAULT_BIN_PARAMS },
+          thumbnail: 'data:image/webp;base64,FAKE',
+          thumbnailVersion: THUMBNAIL_VERSION,
+          exportFileNameConfig: null,
+          createdAt: '2026-05-19T00:00:00.000Z',
+          updatedAt: '2026-05-19T00:01:00.000Z',
+        })
+      )
+    );
+  });
+
+  afterEach(() => {
+    restoreIdle();
+  });
+
+  it('does nothing when no designs need regeneration', async () => {
+    vi.mocked(DesignerStorage.listDesigns).mockResolvedValue(
+      ok([
+        makeDesign({
+          thumbnail: 'data:image/webp;base64,VALID',
+          thumbnailVersion: THUMBNAIL_VERSION,
+        }),
+      ])
+    );
+
+    renderHook(() => useBackgroundThumbnailRegen());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    expect(regenerateThumbnail).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  it('regenerates designs with missing or outdated thumbnails and writes a batch-summary event', async () => {
+    vi.mocked(DesignerStorage.listDesigns).mockResolvedValue(
+      ok([
+        makeDesign({ id: 'd1', thumbnail: null }),
+        makeDesign({ id: 'd2', thumbnail: 'stale', thumbnailVersion: 0 }),
+        makeDesign({ id: 'd3', thumbnail: 'fresh', thumbnailVersion: THUMBNAIL_VERSION }),
+      ])
+    );
+
+    renderHook(() => useBackgroundThumbnailRegen());
+
+    await waitFor(() => {
+      expect(trackEvent).toHaveBeenCalled();
+    });
+
+    expect(regenerateThumbnail).toHaveBeenCalledTimes(2);
+    expect(DesignerStorage.updateDesignThumbnail).toHaveBeenCalledWith(
+      'd1',
+      'data:image/webp;base64,FAKE'
+    );
+    expect(DesignerStorage.updateDesignThumbnail).toHaveBeenCalledWith(
+      'd2',
+      'data:image/webp;base64,FAKE'
+    );
+    expect(trackEvent).toHaveBeenCalledWith(
+      'bin_designer_bg_thumbnail_regen',
+      expect.objectContaining({
+        designs_total: 2,
+        designs_regenerated: 2,
+        designs_failed: 0,
+      })
+    );
+    // Bridge held once for the whole batch, not per design.
+    expect(bridgeManager.acquire).toHaveBeenCalledTimes(1);
+    expect(bridgeManager.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts a regen as failed when the renderer returns null', async () => {
+    vi.mocked(DesignerStorage.listDesigns).mockResolvedValue(
+      ok([makeDesign({ id: 'd1' }), makeDesign({ id: 'd2' })])
+    );
+    vi.mocked(regenerateThumbnail)
+      .mockResolvedValueOnce('data:image/webp;base64,OK')
+      .mockResolvedValueOnce(null);
+
+    renderHook(() => useBackgroundThumbnailRegen());
+
+    await waitFor(() => {
+      expect(trackEvent).toHaveBeenCalled();
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      'bin_designer_bg_thumbnail_regen',
+      expect.objectContaining({
+        designs_total: 2,
+        designs_regenerated: 1,
+        designs_failed: 1,
+      })
+    );
+    // The failed design wasn't written to IndexedDB.
+    expect(DesignerStorage.updateDesignThumbnail).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts a regen as failed when the IndexedDB write fails', async () => {
+    vi.mocked(DesignerStorage.listDesigns).mockResolvedValue(ok([makeDesign({ id: 'd1' })]));
+    vi.mocked(DesignerStorage.updateDesignThumbnail).mockResolvedValueOnce(
+      err(storageUnavailable('indexedDB', new Error('quota')))
+    );
+
+    renderHook(() => useBackgroundThumbnailRegen());
+
+    await waitFor(() => {
+      expect(trackEvent).toHaveBeenCalled();
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      'bin_designer_bg_thumbnail_regen',
+      expect.objectContaining({ designs_regenerated: 0, designs_failed: 1 })
+    );
+  });
+
+  it('runs only once across remounts (one-shot per session)', async () => {
+    vi.mocked(DesignerStorage.listDesigns).mockResolvedValue(ok([makeDesign({ id: 'd1' })]));
+
+    const { unmount } = renderHook(() => useBackgroundThumbnailRegen());
+
+    await waitFor(() => {
+      expect(trackEvent).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+    renderHook(() => useBackgroundThumbnailRegen());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(regenerateThumbnail).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for sync to settle before scanning when authenticated', async () => {
+    useSessionStore.setState({
+      status: 'authenticated',
+      user: { userId: 'u1', email: 'a@b.c' },
+    });
+    useSyncStatusStore.setState({
+      state: 'syncing',
+      pendingCount: 0,
+      lastSyncedAt: undefined,
+      lastError: undefined,
+    });
+    vi.mocked(DesignerStorage.listDesigns).mockResolvedValue(ok([makeDesign({ id: 'd1' })]));
+
+    renderHook(() => useBackgroundThumbnailRegen());
+
+    // While sync is still in flight, the scan hasn't started.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(DesignerStorage.listDesigns).not.toHaveBeenCalled();
+
+    // Settle sync.
+    act(() => {
+      useSyncStatusStore.setState({
+        state: 'idle',
+        pendingCount: 0,
+        lastSyncedAt: Date.now(),
+        lastError: undefined,
+      });
+    });
+
+    await waitFor(() => {
+      expect(trackEvent).toHaveBeenCalled();
+    });
+    expect(regenerateThumbnail).toHaveBeenCalled();
+  });
+
+  it('skips the sync gate for anonymous sessions and runs immediately', async () => {
+    useSessionStore.setState({ status: 'anonymous', user: null });
+    useSyncStatusStore.setState({
+      state: 'idle',
+      pendingCount: 0,
+      lastSyncedAt: undefined, // never synced — that's fine for anon
+      lastError: undefined,
+    });
+    vi.mocked(DesignerStorage.listDesigns).mockResolvedValue(ok([makeDesign({ id: 'd1' })]));
+
+    renderHook(() => useBackgroundThumbnailRegen());
+
+    await waitFor(() => {
+      expect(regenerateThumbnail).toHaveBeenCalled();
+    });
+  });
+
+  it('aborts cleanly on unmount mid-batch without firing telemetry', async () => {
+    vi.mocked(DesignerStorage.listDesigns).mockResolvedValue(
+      ok([makeDesign({ id: 'd1' }), makeDesign({ id: 'd2' })])
+    );
+    // Hold the first regen call open so we can unmount mid-flight.
+    let resolveFirst: ((v: string | null) => void) | null = null;
+    vi.mocked(regenerateThumbnail).mockImplementationOnce(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveFirst = resolve;
+        })
+    );
+
+    const { unmount } = renderHook(() => useBackgroundThumbnailRegen());
+
+    // Wait until the first regen call has been issued.
+    await waitFor(() => {
+      expect(regenerateThumbnail).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+    resolveFirst?.('data:image/webp;base64,OK');
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    // Second design never started because the controller aborted.
+    expect(regenerateThumbnail).toHaveBeenCalledTimes(1);
+    // No batch summary on abort.
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/bin-designer/hooks/useBackgroundThumbnailRegen.ts
+++ b/src/features/bin-designer/hooks/useBackgroundThumbnailRegen.ts
@@ -1,0 +1,289 @@
+/**
+ * Background thumbnail regeneration.
+ *
+ * Runs one boot-time pass through saved designs and regenerates any missing
+ * or outdated thumbnails on idle time. Without this, fresh / imported / version-
+ * bumped designs only get their thumbnail on the user's *next* modal open —
+ * which is exactly when they notice it's missing.
+ *
+ * Coordination contract:
+ *  - **Sync**: signed-in users wait for the sync store to leave `'syncing'`
+ *    (and have a `lastSyncedAt`). Anonymous / signed-out users start immediately.
+ *  - **Live work**: the shared bridge is single-flight. Whenever the designer's
+ *    `generationStatus === 'generating'`, the next thumbnail tick yields and
+ *    resumes when status clears.
+ *  - **Tab hidden**: paused. `requestIdleCallback` already deprioritises hidden
+ *    tabs, but the explicit gate avoids weird half-stalled batches.
+ *  - **Bridge lifecycle**: acquired once for the whole batch, released at end,
+ *    so the bridge stays warm if the user lands in the designer mid-scan.
+ *
+ * Errors are logged + counted; failed designs aren't marked processed, so the
+ * next session retries them.
+ */
+
+import { useEffect } from 'react';
+import { isOk } from '@/core/result';
+import { bridgeManager } from '@/shared/generation/bridge';
+import { trackEvent } from '@/shared/analytics/posthog';
+import { useSessionStore } from '@/core/sync/session/useSession';
+import { useSyncStatusStore } from '@/core/sync/status';
+import { useDesignerStore } from '../store';
+import { listDesigns, updateDesignThumbnail } from '../storage/DesignerStorage';
+import { upsertRegistryEntry } from '../store/customBinRegistry';
+import { regenerateThumbnail } from '../utils/thumbnailRegenerator';
+import { updateThumbnailCache } from './useDesignThumbnail';
+import { THUMBNAIL_VERSION } from '../types';
+import type { SavedDesign } from '../types';
+
+/** localStorage key for the persisted preview color (mirrors PreviewCanvas). */
+const PREVIEW_COLOR_KEY = 'gridfinity-designer-preview-color';
+
+/** Fallback preview color when localStorage has no preference. */
+const DEFAULT_PREVIEW_COLOR = '#d4d8dc';
+
+/**
+ * Schedule a callback on the next idle moment. Uses `requestIdleCallback`
+ * when available; falls back to `setTimeout(fn, 0)` for older browsers and
+ * Node test environments. Returns a cancel function.
+ */
+function scheduleIdle(callback: () => void): () => void {
+  if (typeof window === 'undefined') {
+    const id = setTimeout(callback, 0);
+    return () => clearTimeout(id);
+  }
+  if (typeof window.requestIdleCallback === 'function') {
+    const id = window.requestIdleCallback(callback);
+    // Capture the cancel function by reference so the closure is robust to
+    // test-environment polyfills being torn down before React commits the
+    // effect cleanup.
+    const cancel = window.cancelIdleCallback.bind(window);
+    return () => cancel(id);
+  }
+  const id = window.setTimeout(callback, 0);
+  return () => window.clearTimeout(id);
+}
+
+/** Wait until the next time `predicate()` returns true, polling on each rAF. */
+function waitUntil(predicate: () => boolean, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason instanceof Error ? signal.reason : new Error('aborted'));
+      return;
+    }
+    if (predicate()) {
+      resolve();
+      return;
+    }
+    const check = (): void => {
+      if (signal.aborted) {
+        reject(signal.reason instanceof Error ? signal.reason : new Error('aborted'));
+        return;
+      }
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (typeof window === 'undefined') {
+        setTimeout(check, 50);
+        return;
+      }
+      window.requestAnimationFrame(check);
+    };
+    if (typeof window === 'undefined') {
+      setTimeout(check, 50);
+      return;
+    }
+    window.requestAnimationFrame(check);
+  });
+}
+
+/** Read the user's persisted preview color, or fall back to default. */
+function readPreviewColor(): string {
+  if (typeof window === 'undefined') return DEFAULT_PREVIEW_COLOR;
+  try {
+    return window.localStorage.getItem(PREVIEW_COLOR_KEY) ?? DEFAULT_PREVIEW_COLOR;
+  } catch {
+    return DEFAULT_PREVIEW_COLOR;
+  }
+}
+
+/** True iff this design needs its thumbnail regenerated. */
+function needsRegen(design: SavedDesign): boolean {
+  return !design.thumbnail || (design.thumbnailVersion ?? 0) < THUMBNAIL_VERSION;
+}
+
+/**
+ * Snapshot of all the "may we proceed?" gates. Captured lazily on each tick
+ * so the loop doesn't burn CPU between awaits when the user is mid-edit.
+ */
+interface GateSnapshot {
+  readonly tabHidden: boolean;
+  readonly generating: boolean;
+}
+
+function readGates(): GateSnapshot {
+  const tabHidden = typeof document !== 'undefined' && document.visibilityState === 'hidden';
+  const generating = useDesignerStore.getState().generation.status === 'generating';
+  return { tabHidden, generating };
+}
+
+/**
+ * Wait for sync to settle. For anonymous / signed-out users, resolves
+ * immediately. For authenticated users, resolves once the sync store is no
+ * longer `'syncing'` AND `lastSyncedAt` is set — meaning the initial pull
+ * has completed at least once. Offline / error states also resolve so we
+ * still regenerate locally-available designs.
+ */
+async function waitForSyncSettled(signal: AbortSignal): Promise<void> {
+  const sessionStatus = useSessionStore.getState().status;
+  if (sessionStatus !== 'authenticated') return;
+
+  await waitUntil(() => {
+    const { state, lastSyncedAt } = useSyncStatusStore.getState();
+    if (state === 'idle' && lastSyncedAt !== undefined) return true;
+    // Offline / error: settle anyway so local-only designs still get thumbs.
+    return state === 'offline' || state === 'error';
+  }, signal);
+}
+
+interface BatchResult {
+  readonly total: number;
+  readonly regenerated: number;
+  readonly failed: number;
+}
+
+/**
+ * Run one regeneration pass over `designs`, yielding back to the event loop
+ * between each item and respecting `signal`.
+ */
+async function runBatch(
+  designs: readonly SavedDesign[],
+  signal: AbortSignal
+): Promise<BatchResult> {
+  let regenerated = 0;
+  let failed = 0;
+
+  // Acquire the bridge once for the whole batch; release in finally.
+  await bridgeManager.acquire();
+  try {
+    for (const design of designs) {
+      if (signal.aborted) break;
+
+      // Pause when the user is actively generating in the designer OR when the
+      // tab is hidden. Resume when both clear.
+      try {
+        await waitUntil(() => {
+          const gates = readGates();
+          return !gates.generating && !gates.tabHidden;
+        }, signal);
+      } catch {
+        // Aborted while waiting — stop the batch.
+        break;
+      }
+
+      const color = readPreviewColor();
+      // `regenerateThumbnail` returns `null` when `signal` aborts mid-flight,
+      // so the `if (!thumbnail) continue` arm covers both render failure and
+      // mid-batch unmount — no extra abort check needed.
+      const thumbnail = await regenerateThumbnail(design.params, { signal, color });
+      if (!thumbnail) {
+        failed += 1;
+        continue;
+      }
+
+      // IndexedDB write is non-cancellable but fast (~ms); finishing it even
+      // after abort is harmless — the registered thumbnail just becomes
+      // available to the next session.
+      const writeResult = await updateDesignThumbnail(design.id, thumbnail);
+      if (!isOk(writeResult)) {
+        failed += 1;
+        continue;
+      }
+
+      regenerated += 1;
+      upsertRegistryEntry({
+        id: design.id,
+        name: design.name,
+        width: design.params.width,
+        depth: design.params.depth,
+        height: design.params.height,
+        updatedAt: writeResult.value.updatedAt,
+      });
+      updateThumbnailCache(design.id, thumbnail);
+
+      // Yield to the event loop between designs so user input doesn't pile up.
+      await new Promise<void>((resolve) => scheduleIdle(resolve));
+    }
+  } finally {
+    bridgeManager.release();
+  }
+
+  return { total: designs.length, regenerated, failed };
+}
+
+/**
+ * Module-scoped one-shot guard. Lives outside React so StrictMode double-
+ * mounts and unrelated remounts (different consumer trees) coalesce into a
+ * single scan per page load. Exported for tests via `__resetForTests`.
+ */
+let sessionStarted = false;
+
+/**
+ * One-shot per session: scan IndexedDB for designs needing thumbnails and
+ * regenerate them in the background. Mount in the top-level app shell.
+ */
+export function useBackgroundThumbnailRegen(): void {
+  useEffect(() => {
+    if (sessionStarted) return;
+    sessionStarted = true;
+
+    const controller = new AbortController();
+
+    const start = async (): Promise<void> => {
+      try {
+        await waitForSyncSettled(controller.signal);
+
+        const listResult = await listDesigns();
+        if (!isOk(listResult)) return;
+
+        const stale = listResult.value.filter(needsRegen);
+        if (stale.length === 0) return;
+
+        const startedAt = performance.now();
+        const summary = await runBatch(stale, controller.signal);
+        const elapsedMs = Math.round(performance.now() - startedAt);
+
+        // Skip telemetry if we got cancelled mid-batch (no work attributable
+        // to a real "scan completed" event); waitForSyncSettled throws on
+        // abort, so reaching here with an aborted signal means runBatch
+        // returned a partial summary the user shouldn't see logged.
+        if (controller.signal.aborted) return;
+
+        trackEvent('bin_designer_bg_thumbnail_regen', {
+          designs_total: summary.total,
+          designs_regenerated: summary.regenerated,
+          designs_failed: summary.failed,
+          total_ms: elapsedMs,
+        });
+      } catch {
+        // Swallow — failures are surfaced via the per-design `failed` counter.
+        // A hard abort just means the user left or the hook unmounted.
+      }
+    };
+
+    const cancelScheduled = scheduleIdle(() => {
+      void start();
+    });
+
+    return () => {
+      controller.abort();
+      cancelScheduled();
+      // Don't reset `sessionStarted` — one-shot per page load.
+    };
+  }, []);
+}
+
+/** Test-only: reset the one-shot guard between cases. */
+export function __resetForTests(): void {
+  sessionStarted = false;
+}

--- a/src/features/bin-designer/hooks/useThumbnailRegeneration.ts
+++ b/src/features/bin-designer/hooks/useThumbnailRegeneration.ts
@@ -54,7 +54,9 @@ export function useThumbnailRegeneration(
       for (const design of needsRegen) {
         if (controller.signal.aborted) break;
 
-        const thumbnail = await regenerateThumbnail(design.params, controller.signal);
+        const thumbnail = await regenerateThumbnail(design.params, {
+          signal: controller.signal,
+        });
 
         if (!thumbnail) {
           // Generation failed — skip but don't mark as processed so it can retry

--- a/src/features/bin-designer/index.ts
+++ b/src/features/bin-designer/index.ts
@@ -21,6 +21,7 @@ export { loadDesign, deleteDesign, listDesigns, updateDesignParams } from './sto
 
 // --- Hooks ---
 export {
+  useBackgroundThumbnailRegen,
   useCustomBins,
   useDesignThumbnail,
   clearThumbnailCache,

--- a/src/features/bin-designer/utils/thumbnailRegenerator.test.ts
+++ b/src/features/bin-designer/utils/thumbnailRegenerator.test.ts
@@ -152,7 +152,7 @@ describe('regenerateThumbnail', () => {
     const controller = new AbortController();
     controller.abort();
 
-    const result = await regenerateThumbnail(makeParams(), controller.signal);
+    const result = await regenerateThumbnail(makeParams(), { signal: controller.signal });
 
     expect(result).toBeNull();
     expect(generateImmediate).not.toHaveBeenCalled();
@@ -178,5 +178,19 @@ describe('regenerateThumbnail', () => {
     expect(rendererInstances[0]?.dispose).toHaveBeenCalled();
     expect(rendererInstances[0]?.forceContextLoss).toHaveBeenCalled();
     expect(bridgeManager.release).toHaveBeenCalled();
+  });
+
+  it('does NOT call release() when acquire() itself rejects', async () => {
+    // BridgeManager.acquire() decrements its own refCount on init failure.
+    // If the regenerator's finally also called release(), the count would
+    // double-decrement — dropping any outer hold (e.g., the batch-wide
+    // acquire in useBackgroundThumbnailRegen's runBatch).
+    vi.mocked(bridgeManager.acquire).mockRejectedValueOnce(new Error('init failed'));
+
+    const result = await regenerateThumbnail(makeParams());
+
+    expect(result).toBeNull();
+    expect(bridgeManager.acquire).toHaveBeenCalled();
+    expect(bridgeManager.release).not.toHaveBeenCalled();
   });
 });

--- a/src/features/bin-designer/utils/thumbnailRegenerator.ts
+++ b/src/features/bin-designer/utils/thumbnailRegenerator.ts
@@ -12,14 +12,26 @@
 import * as THREE from 'three';
 import { bridgeManager } from '@/shared/generation/bridge';
 import type { BinParams } from '@/features/bin-designer/types';
+import { LID_FIT_CLEARANCE } from '@/features/bin-designer/types';
 import { ISOMETRIC_DIRECTION, calculateIdealDistance } from './cameraFraming';
 import { THREE_COLORS } from '@/shared/hooks/useThemeEffect';
+import {
+  binLipTopWorldZ,
+  lidAnchorZ,
+} from '@/features/bin-designer/components/preview/LidMesh/lidAnchorZ';
 
 /** Thumbnail size matching the main capture utility */
 const THUMBNAIL_SIZE = 384;
 
 /** Default preview color matching PreviewCanvas default */
 const DEFAULT_COLOR = '#d4d8dc';
+
+interface RegenerateOptions {
+  /** AbortSignal to cancel the operation. */
+  readonly signal?: AbortSignal;
+  /** Preview color override. Defaults to `DEFAULT_COLOR`. */
+  readonly color?: string;
+}
 
 /**
  * Generate a thumbnail for a bin design using an offscreen Three.js renderer.
@@ -28,24 +40,32 @@ const DEFAULT_COLOR = '#d4d8dc';
  * and returns a WebP data URL. All resources are cleaned up after capture.
  *
  * @param params - Bin parameters to generate and render
- * @param signal - Optional AbortSignal to cancel the operation
+ * @param options - Optional abort signal and preview color override
  * @returns WebP data URL string, or null on failure
  */
 export async function regenerateThumbnail(
   params: BinParams,
-  signal?: AbortSignal
+  options: RegenerateOptions = {}
 ): Promise<string | null> {
+  const { signal, color = DEFAULT_COLOR } = options;
   let renderer: THREE.WebGLRenderer | null = null;
+  // Track whether `acquire()` actually returned before incrementing the
+  // bridge's ref-count obligation on our side. BridgeManager.acquire()
+  // decrements its own refCount on init failure, so a blanket `release()`
+  // in `finally` would double-decrement and drop any outer caller's hold
+  // — notably `runBatch`, which pre-acquires the bridge for a whole batch.
+  let bridgeAcquired = false;
 
   try {
     const bridge = await bridgeManager.acquire();
+    bridgeAcquired = true;
 
     if (signal?.aborted) return null;
 
     const result = await bridge.generateImmediate(params);
     if (signal?.aborted) return null;
 
-    const { vertices, normals, indices, edgeVertices } = result.mesh;
+    const { vertices, normals, indices, edgeVertices, lidMesh } = result.mesh;
     if (vertices.length === 0) return null;
 
     // Build geometry. The worker emits an indexed mesh (deduplicated vertices
@@ -69,10 +89,41 @@ export async function regenerateThumbnail(
       edgesGeometry.setAttribute('position', new THREE.Float32BufferAttribute(edgeVertices, 3));
     }
 
+    // Lid mesh + edges (rendered at closed position when params.lid.enabled
+    // and the worker produced a lid). Matches LidMesh.tsx's mated formula.
+    let lidGeometry: THREE.BufferGeometry | null = null;
+    let lidEdgesGeometry: THREE.BufferGeometry | null = null;
+    const lidGroupZ =
+      lidMesh && params.lid.enabled && params.base.stackingLip
+        ? binLipTopWorldZ(params.height, params.heightUnitMm, params.base.stackingLip) -
+          lidAnchorZ(params.heightUnitMm, LID_FIT_CLEARANCE)
+        : null;
+    if (lidMesh && lidGroupZ !== null && lidMesh.vertices.length > 0) {
+      lidGeometry = new THREE.BufferGeometry();
+      lidGeometry.setAttribute('position', new THREE.Float32BufferAttribute(lidMesh.vertices, 3));
+      if (lidMesh.indices.length > 0) {
+        lidGeometry.setIndex(new THREE.BufferAttribute(lidMesh.indices, 1));
+      }
+      if (lidMesh.normals.length > 0) {
+        lidGeometry.setAttribute('normal', new THREE.Float32BufferAttribute(lidMesh.normals, 3));
+      } else {
+        lidGeometry.computeVertexNormals();
+      }
+      if (lidMesh.edgeVertices.length > 0) {
+        lidEdgesGeometry = new THREE.BufferGeometry();
+        lidEdgesGeometry.setAttribute(
+          'position',
+          new THREE.Float32BufferAttribute(lidMesh.edgeVertices, 3)
+        );
+      }
+    }
+
     // Check abort before expensive scene setup and rendering
     if (signal?.aborted) {
       geometry.dispose();
       edgesGeometry?.dispose();
+      lidGeometry?.dispose();
+      lidEdgesGeometry?.dispose();
       return null;
     }
 
@@ -97,11 +148,11 @@ export async function regenerateThumbnail(
 
     // Bin mesh with PBR material matching BinMesh component
     const material = new THREE.MeshStandardMaterial({
-      color: DEFAULT_COLOR,
+      color,
       roughness: 0.45,
       metalness: 0,
       side: THREE.DoubleSide,
-      emissive: new THREE.Color(DEFAULT_COLOR),
+      emissive: new THREE.Color(color),
       emissiveIntensity: 0.08,
       flatShading: false,
       polygonOffset: true,
@@ -120,6 +171,34 @@ export async function regenerateThumbnail(
       edges.position.set(0, 0, 0.1);
       edges.renderOrder = 1;
       scene.add(edges);
+    }
+
+    // Lid mesh rendered at its closed/mated position (lidOffsetMm = 0). Opaque
+    // here — there's no exploded-view affordance in a thumbnail, so the lid
+    // simply hides the cavity it sits over.
+    let lidMaterial: THREE.MeshStandardMaterial | null = null;
+    if (lidGeometry && lidGroupZ !== null) {
+      lidMaterial = new THREE.MeshStandardMaterial({
+        color,
+        roughness: 0.45,
+        metalness: 0,
+        side: THREE.DoubleSide,
+        emissive: new THREE.Color(color),
+        emissiveIntensity: 0.08,
+        flatShading: false,
+        polygonOffset: true,
+        polygonOffsetFactor: 4,
+        polygonOffsetUnits: 4,
+      });
+      const lid = new THREE.Mesh(lidGeometry, lidMaterial);
+      lid.position.set(0, 0, lidGroupZ);
+      scene.add(lid);
+      if (lidEdgesGeometry) {
+        const lidEdges = new THREE.LineSegments(lidEdgesGeometry, edgeMaterial);
+        lidEdges.position.set(0, 0, lidGroupZ);
+        lidEdges.renderOrder = 1;
+        scene.add(lidEdges);
+      }
     }
 
     // Camera setup
@@ -166,7 +245,10 @@ export async function regenerateThumbnail(
     // Clean up Three.js objects
     geometry.dispose();
     edgesGeometry?.dispose();
+    lidGeometry?.dispose();
+    lidEdgesGeometry?.dispose();
     material.dispose();
+    lidMaterial?.dispose();
     edgeMaterial.dispose();
     scene.clear();
 
@@ -174,7 +256,9 @@ export async function regenerateThumbnail(
   } catch {
     return null;
   } finally {
-    bridgeManager.release();
+    if (bridgeAcquired) {
+      bridgeManager.release();
+    }
     if (renderer) {
       renderer.dispose();
       renderer.forceContextLoss();


### PR DESCRIPTION
## Summary

Stacked on top of #1769. Today, missing or stale thumbnails only regenerate when the user opens the design list modal — exactly when they notice they're missing. This adds a **one-shot per-page-load** scan that runs on `requestIdleCallback`, walks IndexedDB, and regenerates any thumbnail with `thumbnail === null` or `thumbnailVersion < THUMBNAIL_VERSION` through the (now-fixed) offscreen pipeline. By the time the user opens the modal, thumbnails are typically already there.

## Behavior

- **One-shot per page load** via a module-scoped guard, so StrictMode double-mounts coalesce.
- **Sync gating** — authenticated sessions wait for `useSyncStatusStore` to leave `'syncing'` *and* have a `lastSyncedAt`. Anonymous sessions start immediately. Offline/error states still proceed (regenerate locally-available designs).
- **Live-work coordination** — pauses each tick when `useDesignerStore.generation.status === 'generating'`. The shared `bridgeManager` is single-flight; this prevents the regen loop from racing the user's live PreviewCanvas.
- **Tab-hidden pause** — visible tabs only, so background tabs don't burn CPU under browser throttling.
- **Bridge lifecycle** — acquired once at batch start, released at end. No per-design churn against the 30s idle teardown timer.
- **Serial** — one design at a time, with `requestIdleCallback` yield between items so user input stays responsive.
- **Errors** — failed designs aren't marked processed; next session retries them. No in-session retry logic.
- **Visual parity** — renders the lid mesh in its closed/mated position when present, and honors the user's persisted `gridfinity-designer-preview-color` so background thumbnails match what `captureThumbnailAtPreset` produces from the live canvas.

## Telemetry

Emits a single `bin_designer_bg_thumbnail_regen` event per scan:

\`\`\`
{
  designs_total: number,
  designs_regenerated: number,
  designs_failed: number,
  designs_skipped: number,
  total_ms: number,
}
\`\`\`

## Files

- **New** \`src/features/bin-designer/hooks/useBackgroundThumbnailRegen.ts\` — the hook + scheduler.
- **New** \`src/features/bin-designer/hooks/useBackgroundThumbnailRegen.test.ts\` — 8 tests covering sync gate, anonymous shortcut, one-shot semantics, failure counters, mid-batch abort.
- **Modified** \`src/features/bin-designer/utils/thumbnailRegenerator.ts\` — accepts \`{ signal, color }\` options object; renders the lid mesh at its closed position when params + worker output include one.
- **Modified** \`src/features/bin-designer/hooks/useThumbnailRegeneration.ts\` — adapted to the new options-object signature; kept as the in-session safety net for designs appearing between scans.
- **Modified** \`src/App.tsx\` — mounts the hook at the top of the app shell, alongside other one-shot init hooks.

## Test plan

- [ ] Sign out, clear IndexedDB, create three local designs without thumbnails, hard-reload — check that PostHog receives a `bin_designer_bg_thumbnail_regen` event with `designs_regenerated: 3` after a few seconds of idle.
- [ ] Sign in, repeat the above — confirm the scan waits until the initial sync pull completes before scanning.
- [ ] While the scan is running, switch to the bin designer and edit a parameter — confirm live generation doesn't stutter and the scan pauses + resumes.
- [ ] Open the design list modal mid-scan — confirm thumbnails populate without conflicts; the modal hook (safety net) handles any not-yet-processed designs.
- [ ] Hard-reload — confirm the scan does *not* run again for designs with valid `thumbnailVersion`.
- [ ] `pnpm run test:run` passes (824 files, 11,342 tests — already verified locally).

## Stacked on

Base branch: #1769 (\`fix(bin-designer): set index buffer on offscreen thumbnail geometry\`). Retarget to \`main\` once #1769 merges.