### PR TITLE
chore(eslint): enforce core→features|shell and design-system→* layer rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -178,12 +178,21 @@ export default defineConfig([
       'boundaries/dependency-nodes': ['import', 'dynamic-import'],
     },
     rules: {
-      // Primary rule: features cannot import from OTHER features (same feature is OK).
-      // This is a STRICTER superset of the bash mirror in scripts/check-module-boundaries.sh:
-      // (1) it inspects dynamic imports too (not just static — see boundaries/dependency-nodes
-      // above), and (2) it has explicit exceptions for design-linking -> bin-designer and
-      // bin-inspector -> design-linking. All other module relationships (core↔shared,
-      // shared→features, etc.) are unrestricted.
+      // Layer rules. Three kinds of constraint coexist:
+      //   1. Cross-feature: features cannot import from OTHER features (with
+      //      named exceptions for design-linking -> bin-designer and
+      //      bin-inspector -> design-linking integration layers).
+      //   2. `core/` is infrastructure: disallowed from `feature` and `shell`.
+      //      (`core/` -> `shared/` stays allowed; several `core/storage/*`
+      //      modules consume shared utilities/analytics by design.)
+      //   3. `design-system/` is UI primitives: disallowed from every
+      //      application-level layer (`feature`, `shell`, `shared`, `core`).
+      //
+      // This is a STRICTER superset of the bash mirror in
+      // scripts/check-module-boundaries.sh — it also inspects dynamic
+      // imports (see `boundaries/dependency-nodes` above).
+      // Remaining edges (shared→feature, feature→shell) are intentionally
+      // unrestricted today; tightening them needs a per-violator cleanup pass.
       'boundaries/dependencies': ['error', {
         default: 'allow',
         rules: [
@@ -203,6 +212,24 @@ export default defineConfig([
           {
             from: [{ type: 'feature', captured: { featureName: 'bin-inspector' } }],
             allow: [{ to: { type: 'feature', captured: { featureName: 'design-linking' } } }],
+          },
+          // `core/` is infrastructure — it must not depend on features or the
+          // app shell. (`core/` -> `shared/` is intentionally allowed; many
+          // `core/storage/*` modules use shared utilities/analytics.)
+          { from: [{ type: 'core' }], disallow: [{ to: { type: 'feature' } }, { to: { type: 'shell' } }] },
+          // `design-system/` is UI primitives — it must not depend on any
+          // application-level layer. UI primitives take strings via props;
+          // they never read translations themselves, so `i18n` is in the
+          // disallow list alongside the app layers.
+          {
+            from: [{ type: 'design-system' }],
+            disallow: [
+              { to: { type: 'feature' } },
+              { to: { type: 'shell' } },
+              { to: { type: 'i18n' } },
+              { to: { type: 'shared' } },
+              { to: { type: 'core' } },
+            ],
           },
         ],
       }],

--- a/src/core/storage/BulkArchiveService.ts
+++ b/src/core/storage/BulkArchiveService.ts
@@ -107,6 +107,10 @@ export async function exportAllLayouts(
       if (designIds.size > 0) {
         linkedDesigns = [];
         try {
+          // Dynamic import — same rationale as ShareService.ts: keeps the
+          // bin-designer chunk out of core/storage's entry. Future cleanup
+          // could move this service to shared/ or invert the loader.
+          // eslint-disable-next-line boundaries/dependencies
           const { loadDesign } = await import('@/features/bin-designer/storage/DesignerStorage');
           for (const id of designIds) {
             const result = await loadDesign(id);

--- a/src/core/storage/ShareService.ts
+++ b/src/core/storage/ShareService.ts
@@ -52,6 +52,12 @@ export async function exportLayoutJSONWithDesigns(layout: Layout): Promise<strin
   // Look up each design from IndexedDB
   const linkedDesigns: LinkedDesignExport[] = [];
   if (designIds.size > 0) {
+    // Dynamic import keeps the bin-designer chunk out of the core/storage
+    // entry; the layer rule's `disallow` covers static imports but flags
+    // dynamic ones too. Until the call site is inverted to pass the
+    // loader in (or this service moves to shared/), the exception is
+    // documented here.
+    // eslint-disable-next-line boundaries/dependencies
     const { loadDesign } = await import('@/features/bin-designer/storage/DesignerStorage');
     for (const id of designIds) {
       const result = await loadDesign(id);
@@ -177,6 +183,9 @@ export async function restoreEmbeddedDesigns(
     return { layout, importedDesignCount: 0 };
   }
 
+  // Dynamic import — same code-splitting rationale as the loadDesign call
+  // above; see comment there for the cleanup follow-up.
+  // eslint-disable-next-line boundaries/dependencies
   const { saveDesign } = await import('@/features/bin-designer/storage/DesignerStorage');
   const designIdMap = new Map<string, DesignId>();
   let importedDesignCount = 0;


### PR DESCRIPTION
## Summary

\`eslint-plugin-boundaries\` was already wired for cross-feature checks but defaulted to \`allow\` for every other layer edge — the architectural audit found that gap was the root cause of the \`core/sync\` → \`features/bin-designer\` violations cleaned up in #1773. With the violations cleared, this PR tightens the rule so the same class of regression can't slip back in.

## Rules added

- **\`core\` cannot depend on \`feature\` or \`shell\`** — \`core/\` is infrastructure. (\`core\` → \`shared\` stays allowed because several \`core/storage/*\` modules legitimately use shared utilities/analytics.)
- **\`design-system\` cannot depend on \`feature\`, \`shell\`, \`shared\`, or \`core\`** — UI primitives are strictly bottom-of-the-stack.

## Pre-existing exceptions

Two dynamic imports in \`core/storage/\` keep the bin-designer chunk out of the core entry by lazy-loading the design loader:

- \`BulkArchiveService.ts:110\` — \`await import('@/features/bin-designer/storage/DesignerStorage')\`
- \`ShareService.ts:55, :180\` — same pattern

The new layer rule's \`dynamic-import\` detection flags them. They're suppressed in place with \`eslint-disable-next-line boundaries/dependencies\` + a comment pointing at the cleanup follow-up (either move these services to \`shared/\` or invert the loader as a parameter). Three suppressions total.

## Remaining unenforced edges

Documented as deferred in the config comment; each needs a per-violator cleanup pass before tightening:

- \`shared\` → \`feature\` — 8 files (the \`shared/types/bin.ts\`, \`shared/constants/bin.ts\`, \`shared/generation/*\` re-export barrels)
- \`feature\` → \`shell\` — 5+ files

## Test plan

- [x] \`pnpm run lint\` — passes (only pre-existing warning in \`useMeshGeometry.test.ts\`)
- [x] \`pnpm run typecheck\` — passes
- [x] Targeted tests in \`src/core/storage\` — 540 tests pass
- [ ] CI green