### PR TITLE
test(scenarios): expand thin-axis kernel scenarios

### DIFF
--- a/src/features/generation/worker/generators/scenarios/baseStyles.ts
+++ b/src/features/generation/worker/generators/scenarios/baseStyles.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import type { BaseStyle } from '@/shared/types/bin';
+import { assertBoundingBoxMatchesParams } from '../__kernel-tests__/meshAssertions';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
@@ -12,19 +13,82 @@ const baseStyleList: Array<{ style: BaseStyle; label: string }> = [
   { style: 'flat', label: 'flat' },
 ];
 
-export const baseStyles: ScenarioCase[] = baseStyleList.flatMap(({ style, label }) => [
-  defineScenario('base styles', `${label} base with lip`, {
+export const baseStyles: ScenarioCase[] = [
+  ...baseStyleList.flatMap(({ style, label }) => [
+    defineScenario('base styles', `${label} base with lip`, {
+      params: {
+        width: 1,
+        depth: 1,
+        base: { ...DEFAULT_BIN_PARAMS.base, style, stackingLip: true },
+      },
+    }),
+    defineScenario('base styles', `${label} base no lip`, {
+      params: {
+        width: 1,
+        depth: 1,
+        base: { ...DEFAULT_BIN_PARAMS.base, style, stackingLip: false },
+      },
+    }),
+  ]),
+
+  ...baseStyleList.map(({ style, label }) =>
+    defineScenario('base styles', `${label} base at 4×4 (stress)`, {
+      assert: 'structural',
+      params: {
+        width: 4,
+        depth: 4,
+        base: { ...DEFAULT_BIN_PARAMS.base, style },
+      },
+      timeout: 60_000,
+      customAssert: (result, params) => {
+        assertBoundingBoxMatchesParams(result, params, `4x4-${label}`);
+      },
+    })
+  ),
+
+  ...baseStyleList
+    .filter(({ style }) => style !== 'flat')
+    .map(({ style, label }) =>
+      defineScenario('base styles', `${label} base + half sockets`, {
+        assert: 'structural',
+        params: {
+          base: {
+            ...DEFAULT_BIN_PARAMS.base,
+            style,
+            halfSockets: true,
+          },
+        },
+      })
+    ),
+
+  defineScenario('base styles', '0.5×0.5 standard base (minimum half-bin)', {
+    assert: 'structural',
     params: {
-      width: 1,
-      depth: 1,
-      base: { ...DEFAULT_BIN_PARAMS.base, style, stackingLip: true },
+      width: 0.5,
+      depth: 0.5,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'standard' },
     },
   }),
-  defineScenario('base styles', `${label} base no lip`, {
+
+  defineScenario('base styles', '0.5×0.5 flat base no lip (degenerate-guard)', {
+    assert: 'structural',
     params: {
-      width: 1,
-      depth: 1,
-      base: { ...DEFAULT_BIN_PARAMS.base, style, stackingLip: false },
+      width: 0.5,
+      depth: 0.5,
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        style: 'flat',
+        stackingLip: false,
+      },
     },
   }),
-]);
+
+  defineScenario('base styles', '1.5×2.5 fractional + screw base', {
+    assert: 'structural',
+    params: {
+      width: 1.5,
+      depth: 2.5,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'screw' },
+    },
+  }),
+];

--- a/src/features/generation/worker/generators/scenarios/baseStyles.ts
+++ b/src/features/generation/worker/generators/scenarios/baseStyles.ts
@@ -1,6 +1,9 @@
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import type { BaseStyle } from '@/shared/types/bin';
-import { assertBoundingBoxMatchesParams } from '../__kernel-tests__/meshAssertions';
+import {
+  assertBoundingBoxMatchesParams,
+  assertNoDegenerateTriangles,
+} from '../__kernel-tests__/meshAssertions';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
@@ -80,6 +83,9 @@ export const baseStyles: ScenarioCase[] = [
         style: 'flat',
         stackingLip: false,
       },
+    },
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, '0.5x0.5-flat-nolip');
     },
   }),
 

--- a/src/features/generation/worker/generators/scenarios/binStyles.ts
+++ b/src/features/generation/worker/generators/scenarios/binStyles.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import type { BinParams, BinStyle } from '@/shared/types/bin';
+import { assertBoundingBoxMatchesParams } from '../__kernel-tests__/meshAssertions';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
@@ -9,8 +10,78 @@ const binStyleList: Array<{ style: BinStyle; base?: Partial<BinParams['base']>; 
   { style: 'solid', base: { solid: true }, label: 'solid' },
 ];
 
-export const binStyles: ScenarioCase[] = binStyleList.map(({ style, base, label }) =>
-  defineScenario('bin styles', `2\u00d72 ${label}`, {
-    params: { style, base: { ...DEFAULT_BIN_PARAMS.base, ...base } },
-  })
-);
+export const binStyles: ScenarioCase[] = [
+  ...binStyleList.map(({ style, base, label }) =>
+    defineScenario('bin styles', `2×2 ${label}`, {
+      params: { style, base: { ...DEFAULT_BIN_PARAMS.base, ...base } },
+    })
+  ),
+
+  ...binStyleList.map(({ style, base, label }) =>
+    defineScenario('bin styles', `2×2 ${label} no lip`, {
+      assert: 'structural',
+      params: {
+        style,
+        base: { ...DEFAULT_BIN_PARAMS.base, ...base, stackingLip: false },
+      },
+      customAssert: (result, params) => {
+        assertBoundingBoxMatchesParams(result, params, `${label}-nolip`);
+      },
+    })
+  ),
+
+  ...binStyleList.map(({ style, base, label }) =>
+    defineScenario('bin styles', `4×4 ${label} (stress)`, {
+      assert: 'structural',
+      params: {
+        width: 4,
+        depth: 4,
+        style,
+        base: { ...DEFAULT_BIN_PARAMS.base, ...base },
+      },
+      timeout: 60_000,
+      customAssert: (result, params) => {
+        assertBoundingBoxMatchesParams(result, params, `4x4-${label}`);
+      },
+    })
+  ),
+
+  defineScenario('bin styles', '2×2 solid + halfSockets', {
+    assert: 'structural',
+    params: {
+      style: 'solid',
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true, halfSockets: true },
+    },
+  }),
+
+  defineScenario('bin styles', '2×2 slotted + magnet base', {
+    assert: 'structural',
+    params: {
+      style: 'slotted',
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet' },
+    },
+  }),
+
+  defineScenario('bin styles', '1×1 slotted + tall (8u)', {
+    assert: 'structural',
+    params: {
+      width: 1,
+      depth: 1,
+      height: 8,
+      style: 'slotted',
+    },
+  }),
+
+  defineScenario('bin styles', '2×2 solid + flat base + no lip', {
+    assert: 'structural',
+    params: {
+      style: 'solid',
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        solid: true,
+        style: 'flat',
+        stackingLip: false,
+      },
+    },
+  }),
+];

--- a/src/features/generation/worker/generators/scenarios/halfSockets.ts
+++ b/src/features/generation/worker/generators/scenarios/halfSockets.ts
@@ -1,17 +1,104 @@
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import {
+  assertBoundingBoxMatchesParams,
+  assertNoDegenerateTriangles,
+} from '../__kernel-tests__/meshAssertions';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
+const existing = [
+  { w: 1, d: 1, label: '1×1' },
+  { w: 1.5, d: 1.5, label: '1.5×1.5' },
+  { w: 2, d: 2, label: '2×2' },
+];
+
 export const halfSockets: ScenarioCase[] = [
-  { w: 1, d: 1, label: '1\u00d71' },
-  { w: 1.5, d: 1.5, label: '1.5\u00d71.5' },
-  { w: 2, d: 2, label: '2\u00d72' },
-].map(({ w, d, label }) =>
-  defineScenario('half-sockets', `${label} with half sockets`, {
+  ...existing.map(({ w, d, label }) =>
+    defineScenario('half-sockets', `${label} with half sockets`, {
+      params: {
+        width: w,
+        depth: d,
+        base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
+      },
+    })
+  ),
+
+  defineScenario('half-sockets', '0.5×1 half-bin with half sockets', {
+    assert: 'structural',
     params: {
-      width: w,
-      depth: d,
+      width: 0.5,
+      depth: 1,
       base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
     },
-  })
-);
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '0.5x1-halfSockets');
+      assertNoDegenerateTriangles(result, '0.5x1-halfSockets');
+    },
+  }),
+
+  defineScenario('half-sockets', '2.5×2.5 fractional + half sockets', {
+    assert: 'structural',
+    params: {
+      width: 2.5,
+      depth: 2.5,
+      base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
+    },
+  }),
+
+  defineScenario('half-sockets', '3×3 with half sockets (stress)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('half-sockets', '2×2 half sockets + screw base', {
+    assert: 'structural',
+    params: {
+      base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true, style: 'screw' },
+    },
+  }),
+
+  defineScenario('half-sockets', '2×2 half sockets + magnet+screw base', {
+    assert: 'structural',
+    params: {
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        halfSockets: true,
+        style: 'magnet_and_screw',
+      },
+    },
+  }),
+
+  defineScenario('half-sockets', '2×2 half sockets + tall (12u)', {
+    assert: 'structural',
+    params: {
+      height: 12,
+      base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
+    },
+  }),
+
+  defineScenario('half-sockets', '2×2 half sockets + weighted base', {
+    assert: 'structural',
+    params: {
+      base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true, style: 'weighted' },
+    },
+  }),
+
+  defineScenario('half-sockets', '1×1 half sockets + no lip + tall (10u)', {
+    assert: 'structural',
+    params: {
+      width: 1,
+      depth: 1,
+      height: 10,
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        halfSockets: true,
+        stackingLip: false,
+      },
+    },
+  }),
+];

--- a/src/features/generation/worker/generators/scenarios/heights.ts
+++ b/src/features/generation/worker/generators/scenarios/heights.ts
@@ -1,7 +1,56 @@
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import {
+  assertBoundingBoxMatchesParams,
+  assertNoDegenerateTriangles,
+} from '../__kernel-tests__/meshAssertions';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
 export const heightVariations: ScenarioCase[] = [
-  defineScenario('height', '2\u00d72 height minimum (2u)', { params: { height: 2 } }),
-  defineScenario('height', '2\u00d72 height tall (10u)', { params: { height: 10 } }),
+  defineScenario('height', '2×2 height minimum (2u)', { params: { height: 2 } }),
+  defineScenario('height', '2×2 height tall (10u)', { params: { height: 10 } }),
+
+  ...[3, 4, 5, 6, 8, 15, 20].map((h) =>
+    defineScenario('height', `2×2 height ${h}u (structural)`, {
+      assert: 'structural',
+      params: { height: h },
+      customAssert: (result, params) => {
+        assertBoundingBoxMatchesParams(result, params, `height-${h}u`);
+      },
+    })
+  ),
+
+  defineScenario('height', '1×1 height 20u (tall + narrow)', {
+    assert: 'structural',
+    params: { width: 1, depth: 1, height: 20 },
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '1x1x20');
+      assertNoDegenerateTriangles(result, '1x1x20');
+    },
+  }),
+
+  defineScenario('height', '4×4 height 6u (wide + tall, stress)', {
+    assert: 'structural',
+    params: { width: 4, depth: 4, height: 6 },
+    timeout: 60_000,
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '4x4x6');
+    },
+  }),
+
+  defineScenario('height', '2×2 height 2u no lip', {
+    assert: 'structural',
+    params: { height: 2, base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false } },
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '2x2x2-nolip');
+    },
+  }),
+
+  defineScenario('height', '2×2 height 20u no lip', {
+    assert: 'structural',
+    params: { height: 20, base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false } },
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '2x2x20-nolip');
+    },
+  }),
 ];

--- a/src/features/generation/worker/generators/scenarios/wallThickness.ts
+++ b/src/features/generation/worker/generators/scenarios/wallThickness.ts
@@ -1,11 +1,63 @@
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { assertBoundingBoxMatchesParams } from '../__kernel-tests__/meshAssertions';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
 export const wallThickness: ScenarioCase[] = [
-  defineScenario('wall thickness', '2\u00d72 thin (0.4mm) walls', {
+  defineScenario('wall thickness', '2×2 thin (0.4mm) walls', {
     params: { wallThickness: 0.4 },
   }),
-  defineScenario('wall thickness', '2\u00d72 thick (2.4mm) walls', {
+  defineScenario('wall thickness', '2×2 thick (2.4mm) walls', {
     params: { wallThickness: 2.4 },
+  }),
+
+  ...[1.0, 1.2, 1.6, 2.0].map((wt) =>
+    defineScenario('wall thickness', `2×2 wall ${wt.toFixed(1)}mm (structural)`, {
+      assert: 'structural',
+      params: { wallThickness: wt },
+      customAssert: (result, params) => {
+        assertBoundingBoxMatchesParams(result, params, `wall-${wt}mm`);
+      },
+    })
+  ),
+
+  defineScenario('wall thickness', '2×2 thin walls + stacking lip (stability)', {
+    assert: 'structural',
+    params: {
+      wallThickness: 0.4,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, 'thin+lip');
+    },
+  }),
+
+  defineScenario('wall thickness', '2×2 thick walls + compartments (inner-volume squeeze)', {
+    assert: 'structural',
+    params: {
+      wallThickness: 2.4,
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('wall thickness', '4×4 thick walls (stress)', {
+    assert: 'structural',
+    params: { width: 4, depth: 4, wallThickness: 2.4 },
+    timeout: 60_000,
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '4x4-thick');
+    },
+  }),
+
+  defineScenario('wall thickness', '1×1 thin walls + lip + tall (12u)', {
+    assert: 'structural',
+    params: {
+      width: 1,
+      depth: 1,
+      height: 12,
+      wallThickness: 0.4,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
   }),
 ];

--- a/src/features/generation/worker/generators/scenarios/wallThickness.ts
+++ b/src/features/generation/worker/generators/scenarios/wallThickness.ts
@@ -16,7 +16,7 @@ export const wallThickness: ScenarioCase[] = [
       assert: 'structural',
       params: { wallThickness: wt },
       customAssert: (result, params) => {
-        assertBoundingBoxMatchesParams(result, params, `wall-${wt}mm`);
+        assertBoundingBoxMatchesParams(result, params, `wall-${wt.toFixed(1)}mm`);
       },
     })
   ),


### PR DESCRIPTION
## Summary
- Adds ~49 structural+customAssert scenarios across heights, wallThickness, binStyles, halfSockets, baseStyles
- Existing cases retained as snapshot anchors; new cases use `assert: 'structural'` + targeted customAsserts (bounding-box, degenerate-triangle) so the snapshot file does not churn
- Covers 4×4 stress, thin-walled stability with stacking lip, fractional half-bin geometry with non-flat bases, and base-style × half-sockets cross product

Part of a 9-PR scenario coverage expansion campaign. This PR1 establishes the structural+customAssert pattern that subsequent PRs (permutation matrix, regressions, lid/customShape, solid+cutout, designer-store scenarios) build on.

## Test plan
- [x] \`pnpm run typecheck\` clean
- [x] \`pnpm vitest run src/features/generation/worker/generators/binGenerator.scenario.test.ts\` → 252 passed (was ~198 baseline + flatMap expansion)
- [ ] CI green