### PR TITLE
test(scenarios): extend lid + customShape kernel coverage

### DIFF
--- a/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
@@ -432,4 +432,93 @@ describe('lid generation and export scenarios', () => {
       }
     }, 60_000);
   });
+
+  describe('extended lid coverage', () => {
+    it('builds a valid lid for a 1.5×1.5 half-bin', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(makeParams({}, { width: 1.5, depth: 1.5, height: 3 }));
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, '1.5x1.5 lid');
+    });
+
+    it('builds a valid lid for a tall (height 10) bin', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(makeParams({}, { width: 2, depth: 2, height: 10 }));
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, 'tall lid');
+      // Lid Z height is bin-height-independent — top of lid should still
+      // fall within ~1U of its anchor.
+      const bb = boundingBox(result!.vertices);
+      expect(bb.maxZ - bb.minZ).toBeGreaterThan(4);
+      expect(bb.maxZ - bb.minZ).toBeLessThan(DEFAULT_BIN_PARAMS.heightUnitMm * 2);
+    });
+
+    it('builds a valid lid for a custom heightUnitMm (10mm)', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(
+        makeParams({}, { width: 2, depth: 2, height: 3, heightUnitMm: 10 })
+      );
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, 'custom heightUnitMm lid');
+    });
+
+    it('builds a valid lid for an L-shape polygon + magnet holes', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(
+        makeParams({ magnetHoles: true }, { width: 3, depth: 3, height: 3, cellMask: L_SHAPE_MASK })
+      );
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, 'L+magnet lid');
+    });
+
+    it('builds a valid lid for a U-shape polygon', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(
+        makeParams({}, { width: 3, depth: 3, height: 3, cellMask: U_SHAPE_MASK })
+      );
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, 'U-shape lid');
+    });
+
+    it('builds a valid lid for a slotted bin (lid is independent of bin style)', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(
+        makeParams({}, { width: 2, depth: 2, height: 4, style: 'slotted' })
+      );
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, 'slotted-bin lid');
+    });
+
+    it('builds a valid lid with thick walls (2.4mm) — lip clearance check', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(
+        makeParams({}, { width: 2, depth: 2, height: 3, wallThickness: 2.4 })
+      );
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, 'thick-wall lid');
+    });
+
+    it('builds a valid lid with only-front click rail enabled', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(
+        makeParams(
+          { clickRails: { front: true, back: false, left: false, right: false } },
+          { width: 2, depth: 2, height: 3 }
+        )
+      );
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, 'front-only-rail lid');
+    });
+
+    it('lid mesh is approximately translation-invariant in X for square bins', async () => {
+      // Sanity invariant: 2×2 lid mesh from a fresh build should match its
+      // own triangle count across two independent builds (deterministic).
+      const { generateLid } = await import('./lidOrchestrator');
+      const a = generateLid(makeParams({}, { width: 2, depth: 2, height: 3 }));
+      const b = generateLid(makeParams({}, { width: 2, depth: 2, height: 3 }));
+      expect(a).not.toBeNull();
+      expect(b).not.toBeNull();
+      expect(a!.triangleCount).toBe(b!.triangleCount);
+    });
+  });
 });

--- a/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
@@ -446,8 +446,8 @@ describe('lid generation and export scenarios', () => {
       const result = generateLid(makeParams({}, { width: 2, depth: 2, height: 10 }));
       expect(result).not.toBeNull();
       assertStructurallyValid(result!, 'tall lid');
-      // Lid Z height is bin-height-independent — top of lid should still
-      // fall within ~1U of its anchor.
+      // Lid Z thickness is bin-height-independent — the lid mesh is the
+      // same vertical extent whether the bin is 3U or 10U.
       const bb = boundingBox(result!.vertices);
       expect(bb.maxZ - bb.minZ).toBeGreaterThan(4);
       expect(bb.maxZ - bb.minZ).toBeLessThan(DEFAULT_BIN_PARAMS.heightUnitMm * 2);
@@ -510,9 +510,7 @@ describe('lid generation and export scenarios', () => {
       assertStructurallyValid(result!, 'front-only-rail lid');
     });
 
-    it('lid mesh is approximately translation-invariant in X for square bins', async () => {
-      // Sanity invariant: 2×2 lid mesh from a fresh build should match its
-      // own triangle count across two independent builds (deterministic).
+    it('lid mesh is deterministic: identical inputs produce the same triangle count', async () => {
       const { generateLid } = await import('./lidOrchestrator');
       const a = generateLid(makeParams({}, { width: 2, depth: 2, height: 3 }));
       const b = generateLid(makeParams({}, { width: 2, depth: 2, height: 3 }));

--- a/src/features/generation/worker/generators/scenarios/customShape.ts
+++ b/src/features/generation/worker/generators/scenarios/customShape.ts
@@ -299,4 +299,114 @@ export const customShapes: ScenarioCase[] = [
       wallPattern: { enabled: true, pattern: 'honeycomb' as const },
     },
   }),
+
+  defineScenario('custom-shape', '3×3 L with scoop (polygon scoop placement)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: L_SHAPE_MASK,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      scoop: { enabled: true, radius: 'auto' },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('custom-shape', '3×3 T with lip + scoop (concave perimeter + scoop)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: T_SHAPE_MASK,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      scoop: { enabled: true, radius: 'auto' },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('custom-shape', '3×3 U with handles + label (multi-feature polygon)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      height: 5,
+      cellMask: U_SHAPE_MASK,
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        front: { ...DEFAULT_HANDLE_SIDE, enabled: true },
+      },
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('custom-shape', '3×3 O-shape + magnet base + lip', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: O_SHAPE_MASK,
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        style: 'magnet',
+        stackingLip: true,
+      },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('custom-shape', '3×3 O-shape + half sockets', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: O_SHAPE_MASK,
+      base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('custom-shape', '3×3 L tall (10u) + lip (z-extrusion stability)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      height: 10,
+      cellMask: L_SHAPE_MASK,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('custom-shape', '4×3 asymmetric L (non-square bounding box)', {
+    // Wider than tall; tests that polygon path handles non-square masks.
+    assert: 'structural',
+    params: {
+      width: 4,
+      depth: 3,
+      cellMask: buildMask([
+        [1, 1, 1, 1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 0, 0, 0, 0],
+        [1, 1, 1, 1, 0, 0, 0, 0],
+      ]),
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('custom-shape', '3×3 L + slotted bin (polygon + slots)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: L_SHAPE_MASK,
+      style: 'slotted',
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    timeout: 60_000,
+  }),
 ];


### PR DESCRIPTION
## Summary
- \`customShape.ts\`: +8 scenarios covering polygon × scoop / handles / label / lid / slotted / asymmetric / tall combinations
- \`lidGenerator.scenario.test.ts\`: +9 scenarios covering bin×lid coupling (fractional, tall, custom heightUnitMm, polygon, slotted, thick walls, single-rail, determinism)
- All scenarios use structural assertions; no snapshot churn

Part of a 9-PR scenario coverage expansion (PR4 of 9). PR4 closes the lid + custom-shape coverage gap identified during planning.

## Test plan
- [x] \`pnpm run typecheck\` clean
- [x] \`pnpm vitest run binGenerator.scenario.test.ts lidGenerator.scenario.test.ts\` → 239 passed
- [ ] CI green