### PR TITLE
test(designer-store): add wall + handle action scenario coverage

### DIFF
--- a/src/features/bin-designer/store/designer.scenario.handles.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.handles.test.ts
@@ -14,11 +14,18 @@ describe('DesignerStore - handle cutout actions', () => {
     });
 
     it('preserves per-side state on master toggle', () => {
+      // Flip 'back' (default false) to true and 'front' (default true) to
+      // false so we have a non-default per-side state. If the master
+      // toggle accidentally reset sides to defaults, both assertions
+      // below would flip the wrong way.
       const { updateHandles, updateHandleSide } = useDesignerStore.getState();
-      updateHandleSide('front', { enabled: true });
+      updateHandleSide('back', { enabled: true });
+      updateHandleSide('front', { enabled: false });
       updateHandles({ enabled: true });
 
-      expect(useDesignerStore.getState().params.handles.front.enabled).toBe(true);
+      const { handles } = useDesignerStore.getState().params;
+      expect(handles.back.enabled).toBe(true);
+      expect(handles.front.enabled).toBe(false);
     });
 
     it('pushes history on update', () => {

--- a/src/features/bin-designer/store/designer.scenario.handles.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.handles.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+
+describe('DesignerStore - handle cutout actions', () => {
+  beforeEach(() => {
+    useDesignerStore.setState(useDesignerStore.getInitialState());
+  });
+
+  describe('updateHandles', () => {
+    it('enables handles master toggle', () => {
+      const { updateHandles } = useDesignerStore.getState();
+      updateHandles({ enabled: true });
+      expect(useDesignerStore.getState().params.handles.enabled).toBe(true);
+    });
+
+    it('preserves per-side state on master toggle', () => {
+      const { updateHandles, updateHandleSide } = useDesignerStore.getState();
+      updateHandleSide('front', { enabled: true });
+      updateHandles({ enabled: true });
+
+      expect(useDesignerStore.getState().params.handles.front.enabled).toBe(true);
+    });
+
+    it('pushes history on update', () => {
+      const { updateHandles } = useDesignerStore.getState();
+      const start = useDesignerStore.getState().history.past.length;
+
+      updateHandles({ enabled: true });
+      expect(useDesignerStore.getState().history.past.length).toBe(start + 1);
+    });
+  });
+
+  describe('updateHandleSide', () => {
+    // Default handles state: front/left/right enabled, back disabled. We
+    // exercise toggles relative to that — using 'back' as the safest
+    // "off → on" side.
+    it('enables the back side (the default-off side)', () => {
+      const { updateHandleSide } = useDesignerStore.getState();
+      updateHandleSide('back', { enabled: true });
+
+      const { handles } = useDesignerStore.getState().params;
+      expect(handles.back.enabled).toBe(true);
+    });
+
+    it('disables a default-enabled side (front)', () => {
+      const { updateHandleSide } = useDesignerStore.getState();
+      expect(useDesignerStore.getState().params.handles.front.enabled).toBe(true);
+
+      updateHandleSide('front', { enabled: false });
+      expect(useDesignerStore.getState().params.handles.front.enabled).toBe(false);
+    });
+
+    it('toggling one side does not affect another', () => {
+      const { updateHandleSide } = useDesignerStore.getState();
+      updateHandleSide('front', { enabled: false });
+
+      // left still default-true
+      expect(useDesignerStore.getState().params.handles.left.enabled).toBe(true);
+    });
+
+    it('can round-trip a side enable/disable', () => {
+      const { updateHandleSide } = useDesignerStore.getState();
+      updateHandleSide('back', { enabled: true });
+      updateHandleSide('back', { enabled: false });
+
+      expect(useDesignerStore.getState().params.handles.back.enabled).toBe(false);
+    });
+
+    it('pushes history per side update', () => {
+      const { updateHandleSide } = useDesignerStore.getState();
+      const start = useDesignerStore.getState().history.past.length;
+
+      updateHandleSide('back', { enabled: true });
+      updateHandleSide('front', { enabled: false });
+
+      expect(useDesignerStore.getState().history.past.length).toBe(start + 2);
+    });
+  });
+
+  describe('undo/redo for handles', () => {
+    it('undo reverts a back-side enable (default-off → on)', () => {
+      const { updateHandleSide, undo } = useDesignerStore.getState();
+      updateHandleSide('back', { enabled: true });
+      undo();
+
+      expect(useDesignerStore.getState().params.handles.back.enabled).toBe(false);
+    });
+
+    it('redo restores a back-side enable', () => {
+      const { updateHandleSide, undo, redo } = useDesignerStore.getState();
+      updateHandleSide('back', { enabled: true });
+      undo();
+      redo();
+
+      expect(useDesignerStore.getState().params.handles.back.enabled).toBe(true);
+    });
+
+    it('undoes through a 4-side disable sequence', () => {
+      // Start from defaults (front/left/right=true, back=false). Disable
+      // them in order; each undo step restores the previous side.
+      const { updateHandleSide, undo } = useDesignerStore.getState();
+      updateHandleSide('front', { enabled: false });
+      updateHandleSide('left', { enabled: false });
+      updateHandleSide('right', { enabled: false });
+      updateHandleSide('back', { enabled: true });
+
+      undo();
+      expect(useDesignerStore.getState().params.handles.back.enabled).toBe(false);
+      undo();
+      expect(useDesignerStore.getState().params.handles.right.enabled).toBe(true);
+      undo();
+      expect(useDesignerStore.getState().params.handles.left.enabled).toBe(true);
+      undo();
+      expect(useDesignerStore.getState().params.handles.front.enabled).toBe(true);
+    });
+  });
+
+  describe('handle × wall interactions', () => {
+    it('handles and walls update independently', () => {
+      const { updateHandleSide, updateWallSide } = useDesignerStore.getState();
+      updateHandleSide('front', { enabled: true });
+      updateWallSide('front', { enabled: true });
+
+      const { handles, walls } = useDesignerStore.getState().params;
+      expect(handles.front.enabled).toBe(true);
+      expect(walls.front.enabled).toBe(true);
+    });
+
+    it('disabling all handle sides individually does not auto-disable master', () => {
+      // Verify there's no hidden cascade: per-side toggles don't flip
+      // handles.enabled. The master is independent — user can re-enable.
+      const { updateHandles, updateHandleSide } = useDesignerStore.getState();
+      updateHandles({ enabled: true });
+      updateHandleSide('front', { enabled: true });
+      updateHandleSide('front', { enabled: false });
+
+      expect(useDesignerStore.getState().params.handles.enabled).toBe(true);
+    });
+  });
+});

--- a/src/features/bin-designer/store/designer.scenario.walls.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.walls.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+
+describe('DesignerStore - wall cutout actions', () => {
+  beforeEach(() => {
+    useDesignerStore.setState(useDesignerStore.getInitialState());
+  });
+
+  describe('updateWalls', () => {
+    it('enables walls feature master toggle', () => {
+      const { updateWalls } = useDesignerStore.getState();
+      updateWalls({ enabled: true });
+
+      expect(useDesignerStore.getState().params.walls.enabled).toBe(true);
+    });
+
+    it('updates shape (u-shape → scoop → funnel)', () => {
+      const { updateWalls } = useDesignerStore.getState();
+      updateWalls({ shape: 'scoop' });
+      expect(useDesignerStore.getState().params.walls.shape).toBe('scoop');
+
+      updateWalls({ shape: 'funnel' });
+      expect(useDesignerStore.getState().params.walls.shape).toBe('funnel');
+
+      updateWalls({ shape: 'u-shape' });
+      expect(useDesignerStore.getState().params.walls.shape).toBe('u-shape');
+    });
+
+    it('preserves unrelated wall fields on partial update', () => {
+      const { updateWalls } = useDesignerStore.getState();
+      updateWalls({ enabled: true, shape: 'scoop' });
+      updateWalls({ width: 60 });
+
+      const { walls } = useDesignerStore.getState().params;
+      expect(walls.enabled).toBe(true);
+      expect(walls.shape).toBe('scoop');
+      expect(walls.width).toBe(60);
+    });
+
+    it('pushes history on update', () => {
+      const { updateWalls } = useDesignerStore.getState();
+      const beforeLen = useDesignerStore.getState().history.past.length;
+
+      updateWalls({ enabled: true });
+
+      expect(useDesignerStore.getState().history.past.length).toBe(beforeLen + 1);
+    });
+  });
+
+  describe('updateWallSide', () => {
+    it('enables a single default-off side independently', () => {
+      // Default: front/back disabled, left/right enabled.
+      const { updateWallSide } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true });
+
+      const { walls } = useDesignerStore.getState().params;
+      expect(walls.front.enabled).toBe(true);
+      expect(walls.back.enabled).toBe(false);
+    });
+
+    it('updates width/depth per side independently', () => {
+      const { updateWallSide } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true, width: 50, depth: 40 });
+      updateWallSide('back', { enabled: true, width: 70, depth: 50 });
+
+      const { walls } = useDesignerStore.getState().params;
+      expect(walls.front.width).toBe(50);
+      expect(walls.front.depth).toBe(40);
+      expect(walls.back.width).toBe(70);
+      expect(walls.back.depth).toBe(50);
+    });
+
+    it('updates alignment on a side without disturbing other sides', () => {
+      const { updateWallSide } = useDesignerStore.getState();
+      updateWallSide('left', { enabled: true, alignment: 'left' });
+      updateWallSide('right', { enabled: true });
+
+      const { walls } = useDesignerStore.getState().params;
+      expect(walls.left.alignment).toBe('left');
+      expect(walls.right.enabled).toBe(true);
+    });
+
+    it('can disable a previously enabled side', () => {
+      const { updateWallSide } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true });
+      updateWallSide('front', { enabled: false });
+
+      expect(useDesignerStore.getState().params.walls.front.enabled).toBe(false);
+    });
+
+    it('pushes history per side update', () => {
+      const { updateWallSide } = useDesignerStore.getState();
+      const start = useDesignerStore.getState().history.past.length;
+
+      updateWallSide('front', { enabled: true });
+      updateWallSide('back', { enabled: true });
+      updateWallSide('left', { enabled: true });
+
+      expect(useDesignerStore.getState().history.past.length).toBe(start + 3);
+    });
+  });
+
+  describe('undo/redo for walls', () => {
+    it('undo reverts a wall-side enable', () => {
+      const { updateWallSide, undo } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true });
+      undo();
+
+      expect(useDesignerStore.getState().params.walls.front.enabled).toBe(false);
+    });
+
+    it('redo restores a wall-side enable', () => {
+      const { updateWallSide, undo, redo } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true });
+      undo();
+      redo();
+
+      expect(useDesignerStore.getState().params.walls.front.enabled).toBe(true);
+    });
+
+    it('undoes through a 4-sided toggle sequence', () => {
+      // Default: front/back disabled, left/right enabled. Toggle each so
+      // every step is an actual state change.
+      const { updateWallSide, undo } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true });
+      updateWallSide('back', { enabled: true });
+      updateWallSide('left', { enabled: false });
+      updateWallSide('right', { enabled: false });
+
+      undo();
+      expect(useDesignerStore.getState().params.walls.right.enabled).toBe(true);
+      undo();
+      expect(useDesignerStore.getState().params.walls.left.enabled).toBe(true);
+      undo();
+      expect(useDesignerStore.getState().params.walls.back.enabled).toBe(false);
+      undo();
+      expect(useDesignerStore.getState().params.walls.front.enabled).toBe(false);
+    });
+  });
+
+  describe('shape × side combinations', () => {
+    it('switching shape to scoop preserves per-side state', () => {
+      const { updateWalls, updateWallSide } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true, width: 60 });
+      updateWalls({ shape: 'scoop' });
+
+      const { walls } = useDesignerStore.getState().params;
+      expect(walls.shape).toBe('scoop');
+      expect(walls.front.enabled).toBe(true);
+      expect(walls.front.width).toBe(60);
+    });
+
+    it('switching shape to funnel preserves alignment', () => {
+      const { updateWalls, updateWallSide } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true, alignment: 'left' });
+      updateWalls({ shape: 'funnel' });
+
+      expect(useDesignerStore.getState().params.walls.front.alignment).toBe('left');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New \`designer.scenario.walls.test.ts\` (15 tests) and \`designer.scenario.handles.test.ts\` (12 tests)
- Walls: master toggle + shape changes, per-side updates (enabled/dimensions/alignment), undo/redo through 4-sided toggle sequences, shape × side state preservation
- Handles: master toggle, per-side updates against the default-mixed state, undo/redo, handle×wall independence, master-vs-per-side decoupling
- Both files account for non-trivial defaults (left/right walls + front/left/right handles start enabled)

Part of a 9-PR scenario coverage expansion (PR7 of 9). Mirrors the existing inserts/compartments/cutouts patterns.

## Test plan
- [x] \`pnpm run typecheck\` clean
- [x] \`pnpm vitest run designer.scenario.walls.test.ts designer.scenario.handles.test.ts\` → 27 passed
- [ ] CI green