### PR TITLE
test(scenarios): expand bin-design permutation coverage (9 PRs bundled)

### DIFF
--- a/src/features/bin-designer/store/designer.scenario.customShape.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.customShape.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+import {
+  MASK_CELLS_PER_UNIT,
+  buildFullMask,
+  isAllFilled,
+  isPartialMask,
+} from '@/shared/utils/cellMask';
+import type { CellMask } from '@/shared/utils/cellMask';
+
+/** Build a 2D mask from rows where row 0 is the visual top. */
+function maskFromRows(rows: (0 | 1)[][]): CellMask {
+  const bottomFirst = rows.slice().reverse();
+  const cols = bottomFirst[0]?.length ?? 0;
+  return { cols, rows: bottomFirst.length, cells: bottomFirst.flat() };
+}
+
+// 2×2 bin L-shape: 4×4 half-cell mask, bottom-right 2×2 empty
+const L_2X2: CellMask = maskFromRows([
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 0, 0],
+  [1, 1, 0, 0],
+]);
+
+// 3×3 bin O-shape: 6×6 mask with center 2×2 empty
+const O_3X3: CellMask = maskFromRows([
+  [1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1],
+  [1, 1, 0, 0, 1, 1],
+  [1, 1, 0, 0, 1, 1],
+  [1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1],
+]);
+
+describe('DesignerStore - custom shape (cellMask) actions', () => {
+  beforeEach(() => {
+    useDesignerStore.setState(useDesignerStore.getInitialState());
+  });
+
+  describe('setCellMask basic', () => {
+    it('starts with no cellMask (rectangle bin)', () => {
+      expect(useDesignerStore.getState().params.cellMask).toBeUndefined();
+    });
+
+    it('sets a valid partial mask matching dimensions', () => {
+      const { setCellMask } = useDesignerStore.getState();
+      // Default bin is 2×2 — L_2X2 mask matches (cols=4, rows=4)
+      setCellMask(L_2X2);
+
+      const { cellMask } = useDesignerStore.getState().params;
+      expect(cellMask).toBeDefined();
+      expect(isPartialMask(cellMask)).toBe(true);
+    });
+
+    it('clears the mask when setCellMask(undefined)', () => {
+      const { setCellMask } = useDesignerStore.getState();
+      setCellMask(L_2X2);
+      expect(useDesignerStore.getState().params.cellMask).toBeDefined();
+
+      setCellMask(undefined);
+      expect(useDesignerStore.getState().params.cellMask).toBeUndefined();
+    });
+
+    it('normalizes a fully-filled mask to undefined', () => {
+      const { setCellMask } = useDesignerStore.getState();
+      const fullMask = buildFullMask(2, 2);
+      expect(isAllFilled(fullMask)).toBe(true);
+
+      setCellMask(fullMask);
+      expect(useDesignerStore.getState().params.cellMask).toBeUndefined();
+    });
+
+    it('pushes history on setCellMask', () => {
+      const { setCellMask } = useDesignerStore.getState();
+      const before = useDesignerStore.getState().history.past.length;
+
+      setCellMask(L_2X2);
+      expect(useDesignerStore.getState().history.past.length).toBe(before + 1);
+    });
+  });
+
+  describe('setCellMask validation', () => {
+    it('rejects mask whose cols mismatch width', () => {
+      const { setCellMask } = useDesignerStore.getState();
+      // Default width=2 → expects cols = 4. Provide cols = 6 (3×3).
+      setCellMask(O_3X3);
+
+      expect(useDesignerStore.getState().params.cellMask).toBeUndefined();
+    });
+
+    it('rejects mask whose rows mismatch depth', () => {
+      const { setCellMask } = useDesignerStore.getState();
+      // 2×2 bin expects 4×4. Provide 4×6 (cols match, rows mismatch).
+      const bad: CellMask = {
+        cols: 2 * MASK_CELLS_PER_UNIT,
+        rows: 3 * MASK_CELLS_PER_UNIT,
+        cells: new Array(2 * MASK_CELLS_PER_UNIT * 3 * MASK_CELLS_PER_UNIT).fill(1),
+      };
+      setCellMask(bad);
+
+      expect(useDesignerStore.getState().params.cellMask).toBeUndefined();
+    });
+
+    it('rejects an empty mask (no filled cells)', () => {
+      const { setCellMask } = useDesignerStore.getState();
+      const empty: CellMask = {
+        cols: 4,
+        rows: 4,
+        cells: new Array(16).fill(0),
+      };
+      setCellMask(empty);
+
+      expect(useDesignerStore.getState().params.cellMask).toBeUndefined();
+    });
+  });
+
+  describe('undo/redo for cellMask', () => {
+    it('undo restores the previous mask state', () => {
+      const { setCellMask, undo } = useDesignerStore.getState();
+      setCellMask(L_2X2);
+      expect(useDesignerStore.getState().params.cellMask).toBeDefined();
+
+      undo();
+      expect(useDesignerStore.getState().params.cellMask).toBeUndefined();
+    });
+
+    it('redo re-applies the mask', () => {
+      const { setCellMask, undo, redo } = useDesignerStore.getState();
+      setCellMask(L_2X2);
+      undo();
+      redo();
+
+      expect(useDesignerStore.getState().params.cellMask).toBeDefined();
+      expect(isPartialMask(useDesignerStore.getState().params.cellMask)).toBe(true);
+    });
+
+    it('undoes through a clear → set → clear sequence', () => {
+      const { setCellMask, undo } = useDesignerStore.getState();
+      setCellMask(L_2X2);
+      setCellMask(undefined);
+
+      // Currently undefined → undo → L_2X2 → undo → undefined
+      undo();
+      expect(useDesignerStore.getState().params.cellMask).toBeDefined();
+      undo();
+      expect(useDesignerStore.getState().params.cellMask).toBeUndefined();
+    });
+  });
+
+  describe('cellMask + dimension changes', () => {
+    it('clears mask when dimensions change such that it would not match', () => {
+      const { setCellMask, setParam } = useDesignerStore.getState();
+      setCellMask(L_2X2);
+      expect(useDesignerStore.getState().params.cellMask).toBeDefined();
+
+      // Changing width to 3 reshapes the mask via reshapeOrClearMask
+      setParam('width', 3);
+      const { cellMask } = useDesignerStore.getState().params;
+      // Either reshaped to a new valid mask or cleared — but not stale 4×4.
+      if (cellMask) {
+        expect(cellMask.cols).toBe(3 * MASK_CELLS_PER_UNIT);
+      }
+    });
+
+    it('setParams() with new dimensions also reshapes mask', () => {
+      const { setCellMask, setParams } = useDesignerStore.getState();
+      setCellMask(L_2X2);
+      setParams({ width: 3, depth: 3 });
+
+      const { cellMask } = useDesignerStore.getState().params;
+      if (cellMask) {
+        expect(cellMask.cols).toBe(3 * MASK_CELLS_PER_UNIT);
+        expect(cellMask.rows).toBe(3 * MASK_CELLS_PER_UNIT);
+      }
+    });
+  });
+
+  describe('cellMask + other params', () => {
+    it('setting cellMask preserves unrelated params', () => {
+      const { setCellMask, updateBase } = useDesignerStore.getState();
+      updateBase({ stackingLip: false });
+      setCellMask(L_2X2);
+
+      const { params } = useDesignerStore.getState();
+      expect(params.cellMask).toBeDefined();
+      expect(params.base.stackingLip).toBe(false);
+    });
+
+    it('clearing cellMask preserves unrelated params', () => {
+      const { setCellMask, updateBase } = useDesignerStore.getState();
+      setCellMask(L_2X2);
+      updateBase({ stackingLip: false });
+      setCellMask(undefined);
+
+      const { params } = useDesignerStore.getState();
+      expect(params.cellMask).toBeUndefined();
+      expect(params.base.stackingLip).toBe(false);
+    });
+  });
+});

--- a/src/features/bin-designer/store/designer.scenario.handles.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.handles.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+
+describe('DesignerStore - handle cutout actions', () => {
+  beforeEach(() => {
+    useDesignerStore.setState(useDesignerStore.getInitialState());
+  });
+
+  describe('updateHandles', () => {
+    it('enables handles master toggle', () => {
+      const { updateHandles } = useDesignerStore.getState();
+      updateHandles({ enabled: true });
+      expect(useDesignerStore.getState().params.handles.enabled).toBe(true);
+    });
+
+    it('preserves per-side state on master toggle', () => {
+      // Flip 'back' (default false) to true and 'front' (default true) to
+      // false so we have a non-default per-side state. If the master
+      // toggle accidentally reset sides to defaults, both assertions
+      // below would flip the wrong way.
+      const { updateHandles, updateHandleSide } = useDesignerStore.getState();
+      updateHandleSide('back', { enabled: true });
+      updateHandleSide('front', { enabled: false });
+      updateHandles({ enabled: true });
+
+      const { handles } = useDesignerStore.getState().params;
+      expect(handles.back.enabled).toBe(true);
+      expect(handles.front.enabled).toBe(false);
+    });
+
+    it('pushes history on update', () => {
+      const { updateHandles } = useDesignerStore.getState();
+      const start = useDesignerStore.getState().history.past.length;
+
+      updateHandles({ enabled: true });
+      expect(useDesignerStore.getState().history.past.length).toBe(start + 1);
+    });
+  });
+
+  describe('updateHandleSide', () => {
+    // Default handles state: front/left/right enabled, back disabled. We
+    // exercise toggles relative to that — using 'back' as the safest
+    // "off → on" side.
+    it('enables the back side (the default-off side)', () => {
+      const { updateHandleSide } = useDesignerStore.getState();
+      updateHandleSide('back', { enabled: true });
+
+      const { handles } = useDesignerStore.getState().params;
+      expect(handles.back.enabled).toBe(true);
+    });
+
+    it('disables a default-enabled side (front)', () => {
+      const { updateHandleSide } = useDesignerStore.getState();
+      expect(useDesignerStore.getState().params.handles.front.enabled).toBe(true);
+
+      updateHandleSide('front', { enabled: false });
+      expect(useDesignerStore.getState().params.handles.front.enabled).toBe(false);
+    });
+
+    it('toggling one side does not affect another', () => {
+      const { updateHandleSide } = useDesignerStore.getState();
+      updateHandleSide('front', { enabled: false });
+
+      // left still default-true
+      expect(useDesignerStore.getState().params.handles.left.enabled).toBe(true);
+    });
+
+    it('can round-trip a side enable/disable', () => {
+      const { updateHandleSide } = useDesignerStore.getState();
+      updateHandleSide('back', { enabled: true });
+      updateHandleSide('back', { enabled: false });
+
+      expect(useDesignerStore.getState().params.handles.back.enabled).toBe(false);
+    });
+
+    it('pushes history per side update', () => {
+      const { updateHandleSide } = useDesignerStore.getState();
+      const start = useDesignerStore.getState().history.past.length;
+
+      updateHandleSide('back', { enabled: true });
+      updateHandleSide('front', { enabled: false });
+
+      expect(useDesignerStore.getState().history.past.length).toBe(start + 2);
+    });
+  });
+
+  describe('undo/redo for handles', () => {
+    it('undo reverts a back-side enable (default-off → on)', () => {
+      const { updateHandleSide, undo } = useDesignerStore.getState();
+      updateHandleSide('back', { enabled: true });
+      undo();
+
+      expect(useDesignerStore.getState().params.handles.back.enabled).toBe(false);
+    });
+
+    it('redo restores a back-side enable', () => {
+      const { updateHandleSide, undo, redo } = useDesignerStore.getState();
+      updateHandleSide('back', { enabled: true });
+      undo();
+      redo();
+
+      expect(useDesignerStore.getState().params.handles.back.enabled).toBe(true);
+    });
+
+    it('undoes through a 4-side disable sequence', () => {
+      // Start from defaults (front/left/right=true, back=false). Disable
+      // them in order; each undo step restores the previous side.
+      const { updateHandleSide, undo } = useDesignerStore.getState();
+      updateHandleSide('front', { enabled: false });
+      updateHandleSide('left', { enabled: false });
+      updateHandleSide('right', { enabled: false });
+      updateHandleSide('back', { enabled: true });
+
+      undo();
+      expect(useDesignerStore.getState().params.handles.back.enabled).toBe(false);
+      undo();
+      expect(useDesignerStore.getState().params.handles.right.enabled).toBe(true);
+      undo();
+      expect(useDesignerStore.getState().params.handles.left.enabled).toBe(true);
+      undo();
+      expect(useDesignerStore.getState().params.handles.front.enabled).toBe(true);
+    });
+  });
+
+  describe('handle × wall interactions', () => {
+    it('handles and walls update independently', () => {
+      const { updateHandleSide, updateWallSide } = useDesignerStore.getState();
+      updateHandleSide('front', { enabled: true });
+      updateWallSide('front', { enabled: true });
+
+      const { handles, walls } = useDesignerStore.getState().params;
+      expect(handles.front.enabled).toBe(true);
+      expect(walls.front.enabled).toBe(true);
+    });
+
+    it('disabling all handle sides individually does not auto-disable master', () => {
+      // Verify there's no hidden cascade: per-side toggles don't flip
+      // handles.enabled. The master is independent — user can re-enable.
+      const { updateHandles, updateHandleSide } = useDesignerStore.getState();
+      updateHandles({ enabled: true });
+      updateHandleSide('front', { enabled: true });
+      updateHandleSide('front', { enabled: false });
+
+      expect(useDesignerStore.getState().params.handles.enabled).toBe(true);
+    });
+  });
+});

--- a/src/features/bin-designer/store/designer.scenario.lid.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.lid.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+import {
+  shouldGenerateLid,
+  checkLidCompatibility,
+  hasLidBlocker,
+} from '@/features/bin-designer/utils/lidCompatibility';
+import { DEFAULT_LID_CONFIG } from '@/features/bin-designer/types/lid';
+
+describe('DesignerStore - lid actions', () => {
+  beforeEach(() => {
+    useDesignerStore.setState(useDesignerStore.getInitialState());
+  });
+
+  describe('updateLid', () => {
+    it('enables lid with single partial update', () => {
+      const { updateLid } = useDesignerStore.getState();
+      updateLid({ enabled: true });
+
+      const { params } = useDesignerStore.getState();
+      expect(params.lid.enabled).toBe(true);
+      // Other fields preserved
+      expect(params.lid.stackableTop).toBe(DEFAULT_LID_CONFIG.stackableTop);
+      expect(params.lid.magnetHoles).toBe(DEFAULT_LID_CONFIG.magnetHoles);
+    });
+
+    it('preserves unrelated lid fields on partial update', () => {
+      const { updateLid } = useDesignerStore.getState();
+      updateLid({ enabled: true, magnetHoles: true });
+      updateLid({ stackableTop: true });
+
+      const { params } = useDesignerStore.getState();
+      expect(params.lid.enabled).toBe(true);
+      expect(params.lid.magnetHoles).toBe(true);
+      expect(params.lid.stackableTop).toBe(true);
+    });
+
+    it('clickRails is replaced wholesale, not deep-merged', () => {
+      // Set a distinctive initial state, then replace with a different
+      // object. If updateLid deep-merged, sides from the first update
+      // would survive into the second. They must not — replacement
+      // semantics matter so the user-visible toggles match the state.
+      const { updateLid } = useDesignerStore.getState();
+      updateLid({
+        clickRails: { front: true, back: true, left: true, right: false },
+      });
+      updateLid({
+        clickRails: { front: false, back: true, left: false, right: true },
+      });
+
+      const { params } = useDesignerStore.getState();
+      expect(params.lid.clickRails).toEqual({
+        front: false,
+        back: true,
+        left: false,
+        right: true,
+      });
+    });
+
+    it('updates clickRailCoverage independently', () => {
+      const { updateLid } = useDesignerStore.getState();
+      updateLid({ clickRailCoverage: 75 });
+
+      expect(useDesignerStore.getState().params.lid.clickRailCoverage).toBe(75);
+    });
+
+    it('pushes history on each update', () => {
+      const { updateLid } = useDesignerStore.getState();
+      const initialHistoryLen = useDesignerStore.getState().history.past.length;
+
+      updateLid({ enabled: true });
+      updateLid({ magnetHoles: true });
+
+      expect(useDesignerStore.getState().history.past.length).toBe(initialHistoryLen + 2);
+    });
+
+    it('clears future history on update after undo', () => {
+      const { updateLid, undo } = useDesignerStore.getState();
+      updateLid({ enabled: true });
+      undo();
+      expect(useDesignerStore.getState().history.future).toHaveLength(1);
+
+      updateLid({ magnetHoles: true });
+      expect(useDesignerStore.getState().history.future).toHaveLength(0);
+    });
+  });
+
+  describe('undo/redo for lid', () => {
+    it('undo reverts lid update', () => {
+      const { updateLid, undo } = useDesignerStore.getState();
+      updateLid({ enabled: true });
+      expect(useDesignerStore.getState().params.lid.enabled).toBe(true);
+
+      undo();
+      expect(useDesignerStore.getState().params.lid.enabled).toBe(false);
+    });
+
+    it('redo restores lid update', () => {
+      const { updateLid, undo, redo } = useDesignerStore.getState();
+      updateLid({ enabled: true });
+      undo();
+      redo();
+
+      expect(useDesignerStore.getState().params.lid.enabled).toBe(true);
+    });
+
+    it('handles deep lid state changes through undo stack', () => {
+      const { updateLid, undo } = useDesignerStore.getState();
+      updateLid({ enabled: true });
+      updateLid({ magnetHoles: true });
+      updateLid({ stackableTop: true });
+      updateLid({ clickRailCoverage: 100 });
+
+      // Walk back through stack
+      undo();
+      expect(useDesignerStore.getState().params.lid.clickRailCoverage).toBe(
+        DEFAULT_LID_CONFIG.clickRailCoverage
+      );
+
+      undo();
+      expect(useDesignerStore.getState().params.lid.stackableTop).toBe(false);
+
+      undo();
+      expect(useDesignerStore.getState().params.lid.magnetHoles).toBe(false);
+
+      undo();
+      expect(useDesignerStore.getState().params.lid.enabled).toBe(false);
+    });
+  });
+
+  describe('compatibility checks', () => {
+    it('shouldGenerateLid is false when lid disabled', () => {
+      const { params } = useDesignerStore.getState();
+      expect(shouldGenerateLid(params)).toBe(false);
+    });
+
+    it('shouldGenerateLid is true when lid enabled on default bin', () => {
+      const { updateLid } = useDesignerStore.getState();
+      updateLid({ enabled: true });
+      expect(shouldGenerateLid(useDesignerStore.getState().params)).toBe(true);
+    });
+
+    it('shouldGenerateLid is false when stacking lip is disabled', () => {
+      const { updateLid, updateBase } = useDesignerStore.getState();
+      updateLid({ enabled: true });
+      updateBase({ stackingLip: false });
+
+      expect(shouldGenerateLid(useDesignerStore.getState().params)).toBe(false);
+    });
+
+    it('shouldGenerateLid short-circuits on stackingLip off (no issues, just gated)', () => {
+      // shouldGenerateLid bypasses checkLidCompatibility when stackingLip is
+      // off — it's a hard precondition, not a "compatibility" finding.
+      const { updateLid, updateBase } = useDesignerStore.getState();
+      updateLid({ enabled: true });
+      updateBase({ stackingLip: false });
+
+      expect(shouldGenerateLid(useDesignerStore.getState().params)).toBe(false);
+    });
+
+    it('checkLidCompatibility flags wall cutouts on all four sides as a blocker', () => {
+      const { updateLid, updateWalls, updateWallSide } = useDesignerStore.getState();
+      updateLid({ enabled: true });
+      updateWalls({ enabled: true });
+      updateWallSide('front', { enabled: true });
+      updateWallSide('back', { enabled: true });
+      updateWallSide('left', { enabled: true });
+      updateWallSide('right', { enabled: true });
+
+      const issues = checkLidCompatibility(useDesignerStore.getState().params);
+      expect(issues.length).toBeGreaterThan(0);
+      expect(hasLidBlocker(issues)).toBe(true);
+    });
+
+    it('checkLidCompatibility flags label tabs as a warning (back rail conflict)', () => {
+      const { updateLid, updateLabel } = useDesignerStore.getState();
+      updateLid({ enabled: true });
+      updateLabel({ enabled: true });
+
+      const issues = checkLidCompatibility(useDesignerStore.getState().params);
+      expect(issues.some((i) => i.id === 'labelTabs')).toBe(true);
+    });
+
+    it('checkLidCompatibility flags wall pattern as a warning', () => {
+      const { updateLid, updateWallPattern } = useDesignerStore.getState();
+      updateLid({ enabled: true });
+      updateWallPattern({ enabled: true });
+
+      const issues = checkLidCompatibility(useDesignerStore.getState().params);
+      expect(issues.some((i) => i.id === 'wallPattern')).toBe(true);
+    });
+  });
+
+  describe('lid + bin param interactions', () => {
+    it('toggling halfSockets does not affect lid config', () => {
+      const { updateLid, updateBase } = useDesignerStore.getState();
+      updateLid({ enabled: true, magnetHoles: true });
+
+      const beforeLid = useDesignerStore.getState().params.lid;
+      updateBase({ halfSockets: true });
+
+      expect(useDesignerStore.getState().params.lid).toEqual(beforeLid);
+    });
+
+    it('changing wallThickness preserves lid config', () => {
+      const { updateLid, setParam } = useDesignerStore.getState();
+      updateLid({ enabled: true });
+
+      const beforeLid = useDesignerStore.getState().params.lid;
+      setParam('wallThickness', 1.6);
+
+      expect(useDesignerStore.getState().params.lid).toEqual(beforeLid);
+    });
+
+    it('changing dimensions preserves lid config', () => {
+      const { updateLid, setParams } = useDesignerStore.getState();
+      updateLid({ enabled: true, magnetHoles: true });
+
+      setParams({ width: 3, depth: 3 });
+      expect(useDesignerStore.getState().params.lid.enabled).toBe(true);
+      expect(useDesignerStore.getState().params.lid.magnetHoles).toBe(true);
+    });
+  });
+
+  describe('clickRails edge cases', () => {
+    it('all-false clickRails creates friction-fit configuration', () => {
+      const { updateLid } = useDesignerStore.getState();
+      updateLid({
+        enabled: true,
+        clickRails: { front: false, back: false, left: false, right: false },
+      });
+
+      const { params } = useDesignerStore.getState();
+      expect(Object.values(params.lid.clickRails).every((v) => v === false)).toBe(true);
+      // Should still pass compatibility check
+      expect(shouldGenerateLid(params)).toBe(true);
+    });
+
+    it('toggling a single rail side via updateLid', () => {
+      const { updateLid } = useDesignerStore.getState();
+      updateLid({ enabled: true });
+      updateLid({
+        clickRails: {
+          ...useDesignerStore.getState().params.lid.clickRails,
+          back: false,
+        },
+      });
+
+      const { clickRails } = useDesignerStore.getState().params.lid;
+      expect(clickRails.front).toBe(true);
+      expect(clickRails.back).toBe(false);
+      expect(clickRails.left).toBe(true);
+      expect(clickRails.right).toBe(true);
+    });
+
+    it('all valid coverage options can be set', () => {
+      const { updateLid } = useDesignerStore.getState();
+      for (const cov of [50, 75, 100] as const) {
+        updateLid({ clickRailCoverage: cov });
+        expect(useDesignerStore.getState().params.lid.clickRailCoverage).toBe(cov);
+      }
+    });
+  });
+});

--- a/src/features/bin-designer/store/designer.scenario.walls.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.walls.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+
+describe('DesignerStore - wall cutout actions', () => {
+  beforeEach(() => {
+    useDesignerStore.setState(useDesignerStore.getInitialState());
+  });
+
+  describe('updateWalls', () => {
+    it('enables walls feature master toggle', () => {
+      const { updateWalls } = useDesignerStore.getState();
+      updateWalls({ enabled: true });
+
+      expect(useDesignerStore.getState().params.walls.enabled).toBe(true);
+    });
+
+    it('updates shape (u-shape → scoop → funnel)', () => {
+      const { updateWalls } = useDesignerStore.getState();
+      updateWalls({ shape: 'scoop' });
+      expect(useDesignerStore.getState().params.walls.shape).toBe('scoop');
+
+      updateWalls({ shape: 'funnel' });
+      expect(useDesignerStore.getState().params.walls.shape).toBe('funnel');
+
+      updateWalls({ shape: 'u-shape' });
+      expect(useDesignerStore.getState().params.walls.shape).toBe('u-shape');
+    });
+
+    it('preserves unrelated wall fields on partial update', () => {
+      const { updateWalls } = useDesignerStore.getState();
+      updateWalls({ enabled: true, shape: 'scoop' });
+      updateWalls({ width: 60 });
+
+      const { walls } = useDesignerStore.getState().params;
+      expect(walls.enabled).toBe(true);
+      expect(walls.shape).toBe('scoop');
+      expect(walls.width).toBe(60);
+    });
+
+    it('pushes history on update', () => {
+      const { updateWalls } = useDesignerStore.getState();
+      const beforeLen = useDesignerStore.getState().history.past.length;
+
+      updateWalls({ enabled: true });
+
+      expect(useDesignerStore.getState().history.past.length).toBe(beforeLen + 1);
+    });
+  });
+
+  describe('updateWallSide', () => {
+    it('enables a single default-off side independently', () => {
+      // Default: front/back disabled, left/right enabled.
+      const { updateWallSide } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true });
+
+      const { walls } = useDesignerStore.getState().params;
+      expect(walls.front.enabled).toBe(true);
+      expect(walls.back.enabled).toBe(false);
+    });
+
+    it('updates width/depth per side independently', () => {
+      const { updateWallSide } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true, width: 50, depth: 40 });
+      updateWallSide('back', { enabled: true, width: 70, depth: 50 });
+
+      const { walls } = useDesignerStore.getState().params;
+      expect(walls.front.width).toBe(50);
+      expect(walls.front.depth).toBe(40);
+      expect(walls.back.width).toBe(70);
+      expect(walls.back.depth).toBe(50);
+    });
+
+    it('updates alignment on a side without disturbing other sides', () => {
+      const { updateWallSide } = useDesignerStore.getState();
+      updateWallSide('left', { enabled: true, alignment: 'left' });
+      updateWallSide('right', { enabled: true });
+
+      const { walls } = useDesignerStore.getState().params;
+      expect(walls.left.alignment).toBe('left');
+      expect(walls.right.enabled).toBe(true);
+    });
+
+    it('can disable a previously enabled side', () => {
+      const { updateWallSide } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true });
+      updateWallSide('front', { enabled: false });
+
+      expect(useDesignerStore.getState().params.walls.front.enabled).toBe(false);
+    });
+
+    it('pushes history per side update', () => {
+      const { updateWallSide } = useDesignerStore.getState();
+      const start = useDesignerStore.getState().history.past.length;
+
+      updateWallSide('front', { enabled: true });
+      updateWallSide('back', { enabled: true });
+      updateWallSide('left', { enabled: true });
+
+      expect(useDesignerStore.getState().history.past.length).toBe(start + 3);
+    });
+  });
+
+  describe('undo/redo for walls', () => {
+    it('undo reverts a wall-side enable', () => {
+      const { updateWallSide, undo } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true });
+      undo();
+
+      expect(useDesignerStore.getState().params.walls.front.enabled).toBe(false);
+    });
+
+    it('redo restores a wall-side enable', () => {
+      const { updateWallSide, undo, redo } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true });
+      undo();
+      redo();
+
+      expect(useDesignerStore.getState().params.walls.front.enabled).toBe(true);
+    });
+
+    it('undoes through a 4-sided toggle sequence', () => {
+      // Default: front/back disabled, left/right enabled. Toggle each so
+      // every step is an actual state change.
+      const { updateWallSide, undo } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true });
+      updateWallSide('back', { enabled: true });
+      updateWallSide('left', { enabled: false });
+      updateWallSide('right', { enabled: false });
+
+      undo();
+      expect(useDesignerStore.getState().params.walls.right.enabled).toBe(true);
+      undo();
+      expect(useDesignerStore.getState().params.walls.left.enabled).toBe(true);
+      undo();
+      expect(useDesignerStore.getState().params.walls.back.enabled).toBe(false);
+      undo();
+      expect(useDesignerStore.getState().params.walls.front.enabled).toBe(false);
+    });
+  });
+
+  describe('shape × side combinations', () => {
+    it('switching shape to scoop preserves per-side state', () => {
+      const { updateWalls, updateWallSide } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true, width: 60 });
+      updateWalls({ shape: 'scoop' });
+
+      const { walls } = useDesignerStore.getState().params;
+      expect(walls.shape).toBe('scoop');
+      expect(walls.front.enabled).toBe(true);
+      expect(walls.front.width).toBe(60);
+    });
+
+    it('switching shape to funnel preserves alignment', () => {
+      const { updateWalls, updateWallSide } = useDesignerStore.getState();
+      updateWallSide('front', { enabled: true, alignment: 'left' });
+      updateWalls({ shape: 'funnel' });
+
+      expect(useDesignerStore.getState().params.walls.front.alignment).toBe('left');
+    });
+  });
+});

--- a/src/features/bin-designer/store/designer.scenario.workflows.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.workflows.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Multi-action workflow scenarios.
+ *
+ * Verifies state coherence under realistic user sequences:
+ * create → group → modify → undo across multiple resource types.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+import type { Cutout, Insert } from '@/features/bin-designer/types';
+
+const cutout = (overrides: Partial<Cutout> = {}): Cutout => ({
+  id: 'c1',
+  shape: 'rectangle',
+  x: 0,
+  y: 0,
+  width: 15,
+  depth: 15,
+  cutDepth: 5,
+  rotation: 0,
+  cornerRadius: 0,
+  label: '',
+  groupId: null,
+  ...overrides,
+});
+
+const insert = (overrides: Partial<Insert> = {}): Insert => ({
+  id: 'i1',
+  templateId: null,
+  shape: 'circle',
+  x: 0,
+  y: 0,
+  width: 20,
+  depth: 20,
+  cutDepth: 5,
+  rotation: 0,
+  cornerRadius: 0,
+  label: '',
+  ...overrides,
+});
+
+describe('DesignerStore - multi-action workflows', () => {
+  beforeEach(() => {
+    useDesignerStore.setState(useDesignerStore.getInitialState());
+  });
+
+  describe('cutout lifecycle', () => {
+    it('add → update → remove → undo trail walks back through each step', () => {
+      const { addCutout, updateCutout, removeCutout, undo } = useDesignerStore.getState();
+
+      addCutout(cutout({ id: 'c1', width: 10 }));
+      updateCutout('c1', { width: 25 });
+      removeCutout('c1');
+
+      expect(useDesignerStore.getState().params.cutouts).toHaveLength(0);
+      undo();
+      expect(useDesignerStore.getState().params.cutouts).toHaveLength(1);
+      expect(useDesignerStore.getState().params.cutouts[0].width).toBe(25);
+      undo();
+      expect(useDesignerStore.getState().params.cutouts[0].width).toBe(10);
+      undo();
+      expect(useDesignerStore.getState().params.cutouts).toHaveLength(0);
+    });
+
+    it('add → group two → ungroup keeps both cutouts', () => {
+      const { addCutout, groupCutouts, ungroupCutouts } = useDesignerStore.getState();
+
+      addCutout(cutout({ id: 'a', x: -10 }));
+      addCutout(cutout({ id: 'b', x: 10 }));
+      groupCutouts(['a', 'b']);
+
+      let cuts = useDesignerStore.getState().params.cutouts;
+      expect(cuts).toHaveLength(2);
+      expect(cuts[0].groupId).not.toBeNull();
+      expect(cuts[0].groupId).toBe(cuts[1].groupId);
+
+      ungroupCutouts(['a', 'b']);
+      cuts = useDesignerStore.getState().params.cutouts;
+      expect(cuts).toHaveLength(2);
+      expect(cuts[0].groupId).toBeNull();
+      expect(cuts[1].groupId).toBeNull();
+    });
+
+    it('group → remove member → group dissolves to singleton (null groupId)', () => {
+      const { addCutout, groupCutouts, removeCutout } = useDesignerStore.getState();
+
+      addCutout(cutout({ id: 'a', x: -10 }));
+      addCutout(cutout({ id: 'b', x: 10 }));
+      groupCutouts(['a', 'b']);
+      removeCutout('b');
+
+      const remaining = useDesignerStore.getState().params.cutouts;
+      expect(remaining).toHaveLength(1);
+      // dissolveSingletonGroups clears groupId when only one member left
+      expect(remaining[0].groupId).toBeNull();
+    });
+  });
+
+  describe('cross-feature workflows', () => {
+    it('create insert → enable scoop → toggle solid mode → all state coherent', () => {
+      const { addInsert, updateScoop, updateBase } = useDesignerStore.getState();
+
+      addInsert(insert({ id: 'i1' }));
+      updateScoop({ enabled: true });
+      updateBase({ solid: true });
+
+      const { params } = useDesignerStore.getState();
+      expect(params.inserts).toHaveLength(1);
+      expect(params.scoop.enabled).toBe(true);
+      expect(params.base.solid).toBe(true);
+    });
+
+    it('add cutout → group with another → enable lid → state coherent', () => {
+      const { addCutout, groupCutouts, updateLid } = useDesignerStore.getState();
+
+      addCutout(cutout({ id: 'a' }));
+      addCutout(cutout({ id: 'b', x: 20 }));
+      groupCutouts(['a', 'b']);
+      updateLid({ enabled: true });
+
+      const { params } = useDesignerStore.getState();
+      expect(params.cutouts).toHaveLength(2);
+      expect(params.cutouts[0].groupId).not.toBeNull();
+      expect(params.lid.enabled).toBe(true);
+    });
+
+    it('add insert + add cutout coexist independently', () => {
+      const { addInsert, addCutout } = useDesignerStore.getState();
+      addInsert(insert({ id: 'i1' }));
+      addCutout(cutout({ id: 'c1' }));
+
+      const { params } = useDesignerStore.getState();
+      expect(params.inserts).toHaveLength(1);
+      expect(params.cutouts).toHaveLength(1);
+    });
+  });
+
+  describe('undo across feature boundaries', () => {
+    it('undo walks back across insert/cutout/lid/scoop changes', () => {
+      const { addInsert, addCutout, updateLid, updateScoop, undo } = useDesignerStore.getState();
+
+      addInsert(insert({ id: 'i1' })); // [1]
+      addCutout(cutout({ id: 'c1' })); // [2]
+      updateLid({ enabled: true }); // [3]
+      updateScoop({ enabled: true }); // [4]
+
+      // Latest first
+      undo(); // undoes scoop
+      expect(useDesignerStore.getState().params.scoop.enabled).toBe(false);
+      expect(useDesignerStore.getState().params.lid.enabled).toBe(true);
+
+      undo(); // undoes lid
+      expect(useDesignerStore.getState().params.lid.enabled).toBe(false);
+      expect(useDesignerStore.getState().params.cutouts).toHaveLength(1);
+
+      undo(); // undoes cutout
+      expect(useDesignerStore.getState().params.cutouts).toHaveLength(0);
+      expect(useDesignerStore.getState().params.inserts).toHaveLength(1);
+
+      undo(); // undoes insert
+      expect(useDesignerStore.getState().params.inserts).toHaveLength(0);
+    });
+  });
+
+  describe('compartments + bin style transitions', () => {
+    it('split compartments work after style switches', () => {
+      const { setCompartmentGrid, setParam } = useDesignerStore.getState();
+
+      setCompartmentGrid(2, 2);
+      setParam('style', 'slotted');
+      setParam('style', 'standard');
+
+      const { params } = useDesignerStore.getState();
+      expect(params.compartments.cols).toBe(2);
+      expect(params.compartments.rows).toBe(2);
+      expect(params.style).toBe('standard');
+    });
+
+    it('enabling base.solid keeps inserts but ignores compartments in geometry', () => {
+      const { addInsert, setCompartmentGrid, updateBase } = useDesignerStore.getState();
+
+      setCompartmentGrid(2, 2);
+      addInsert(insert({ id: 'i1' }));
+      updateBase({ solid: true });
+
+      const { params } = useDesignerStore.getState();
+      expect(params.base.solid).toBe(true);
+      expect(params.inserts).toHaveLength(1);
+      // compartments data persists even though solid-mode generator ignores it
+      expect(params.compartments.cols).toBe(2);
+    });
+  });
+
+  describe('redo invariants', () => {
+    it('redo after partial undo restores latest state', () => {
+      const { addInsert, updateLid, undo, redo } = useDesignerStore.getState();
+
+      addInsert(insert({ id: 'i1' }));
+      updateLid({ enabled: true });
+      undo(); // undo lid
+      redo(); // redo lid
+
+      const { params } = useDesignerStore.getState();
+      expect(params.inserts).toHaveLength(1);
+      expect(params.lid.enabled).toBe(true);
+    });
+
+    it('new action after undo clears redo stack', () => {
+      const { addInsert, addCutout, undo } = useDesignerStore.getState();
+
+      addInsert(insert({ id: 'i1' }));
+      undo();
+      expect(useDesignerStore.getState().history.future).toHaveLength(1);
+
+      addCutout(cutout({ id: 'c1' }));
+      expect(useDesignerStore.getState().history.future).toHaveLength(0);
+    });
+  });
+});

--- a/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
@@ -432,4 +432,91 @@ describe('lid generation and export scenarios', () => {
       }
     }, 60_000);
   });
+
+  describe('extended lid coverage', () => {
+    it('builds a valid lid for a 1.5×1.5 half-bin', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(makeParams({}, { width: 1.5, depth: 1.5, height: 3 }));
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, '1.5x1.5 lid');
+    });
+
+    it('builds a valid lid for a tall (height 10) bin', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(makeParams({}, { width: 2, depth: 2, height: 10 }));
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, 'tall lid');
+      // Lid Z thickness is bin-height-independent — the lid mesh is the
+      // same vertical extent whether the bin is 3U or 10U.
+      const bb = boundingBox(result!.vertices);
+      expect(bb.maxZ - bb.minZ).toBeGreaterThan(4);
+      expect(bb.maxZ - bb.minZ).toBeLessThan(DEFAULT_BIN_PARAMS.heightUnitMm * 2);
+    });
+
+    it('builds a valid lid for a custom heightUnitMm (10mm)', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(
+        makeParams({}, { width: 2, depth: 2, height: 3, heightUnitMm: 10 })
+      );
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, 'custom heightUnitMm lid');
+    });
+
+    it('builds a valid lid for an L-shape polygon + magnet holes', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(
+        makeParams({ magnetHoles: true }, { width: 3, depth: 3, height: 3, cellMask: L_SHAPE_MASK })
+      );
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, 'L+magnet lid');
+    });
+
+    it('builds a valid lid for a U-shape polygon', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(
+        makeParams({}, { width: 3, depth: 3, height: 3, cellMask: U_SHAPE_MASK })
+      );
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, 'U-shape lid');
+    });
+
+    it('builds a valid lid for a slotted bin (lid is independent of bin style)', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(
+        makeParams({}, { width: 2, depth: 2, height: 4, style: 'slotted' })
+      );
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, 'slotted-bin lid');
+    });
+
+    it('builds a valid lid with thick walls (2.4mm) — lip clearance check', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(
+        makeParams({}, { width: 2, depth: 2, height: 3, wallThickness: 2.4 })
+      );
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, 'thick-wall lid');
+    });
+
+    it('builds a valid lid with only-front click rail enabled', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const result = generateLid(
+        makeParams(
+          { clickRails: { front: true, back: false, left: false, right: false } },
+          { width: 2, depth: 2, height: 3 }
+        )
+      );
+      expect(result).not.toBeNull();
+      assertStructurallyValid(result!, 'front-only-rail lid');
+    });
+
+    it('lid mesh is deterministic: identical inputs produce the same triangle count', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const a = generateLid(makeParams({}, { width: 2, depth: 2, height: 3 }));
+      const b = generateLid(makeParams({}, { width: 2, depth: 2, height: 3 }));
+      expect(a).not.toBeNull();
+      expect(b).not.toBeNull();
+      expect(a!.triangleCount).toBe(b!.triangleCount);
+    });
+  });
 });

--- a/src/features/generation/worker/generators/scenarios/baseStyles.ts
+++ b/src/features/generation/worker/generators/scenarios/baseStyles.ts
@@ -1,5 +1,9 @@
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import type { BaseStyle } from '@/shared/types/bin';
+import {
+  assertBoundingBoxMatchesParams,
+  assertNoDegenerateTriangles,
+} from '../__kernel-tests__/meshAssertions';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
@@ -12,19 +16,85 @@ const baseStyleList: Array<{ style: BaseStyle; label: string }> = [
   { style: 'flat', label: 'flat' },
 ];
 
-export const baseStyles: ScenarioCase[] = baseStyleList.flatMap(({ style, label }) => [
-  defineScenario('base styles', `${label} base with lip`, {
+export const baseStyles: ScenarioCase[] = [
+  ...baseStyleList.flatMap(({ style, label }) => [
+    defineScenario('base styles', `${label} base with lip`, {
+      params: {
+        width: 1,
+        depth: 1,
+        base: { ...DEFAULT_BIN_PARAMS.base, style, stackingLip: true },
+      },
+    }),
+    defineScenario('base styles', `${label} base no lip`, {
+      params: {
+        width: 1,
+        depth: 1,
+        base: { ...DEFAULT_BIN_PARAMS.base, style, stackingLip: false },
+      },
+    }),
+  ]),
+
+  ...baseStyleList.map(({ style, label }) =>
+    defineScenario('base styles', `${label} base at 4×4 (stress)`, {
+      assert: 'structural',
+      params: {
+        width: 4,
+        depth: 4,
+        base: { ...DEFAULT_BIN_PARAMS.base, style },
+      },
+      timeout: 60_000,
+      customAssert: (result, params) => {
+        assertBoundingBoxMatchesParams(result, params, `4x4-${label}`);
+      },
+    })
+  ),
+
+  ...baseStyleList
+    .filter(({ style }) => style !== 'flat')
+    .map(({ style, label }) =>
+      defineScenario('base styles', `${label} base + half sockets`, {
+        assert: 'structural',
+        params: {
+          base: {
+            ...DEFAULT_BIN_PARAMS.base,
+            style,
+            halfSockets: true,
+          },
+        },
+      })
+    ),
+
+  defineScenario('base styles', '0.5×0.5 standard base (minimum half-bin)', {
+    assert: 'structural',
     params: {
-      width: 1,
-      depth: 1,
-      base: { ...DEFAULT_BIN_PARAMS.base, style, stackingLip: true },
+      width: 0.5,
+      depth: 0.5,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'standard' },
     },
   }),
-  defineScenario('base styles', `${label} base no lip`, {
+
+  defineScenario('base styles', '0.5×0.5 flat base no lip (degenerate-guard)', {
+    assert: 'structural',
     params: {
-      width: 1,
-      depth: 1,
-      base: { ...DEFAULT_BIN_PARAMS.base, style, stackingLip: false },
+      width: 0.5,
+      depth: 0.5,
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        style: 'flat',
+        stackingLip: false,
+      },
+    },
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, '0.5x0.5-flat-nolip');
     },
   }),
-]);
+
+  defineScenario('base styles', '1.5×2.5 fractional + screw base', {
+    assert: 'structural',
+    params: {
+      width: 1.5,
+      depth: 2.5,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'screw' },
+    },
+  }),
+];

--- a/src/features/generation/worker/generators/scenarios/binStyles.ts
+++ b/src/features/generation/worker/generators/scenarios/binStyles.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import type { BinParams, BinStyle } from '@/shared/types/bin';
+import { assertBoundingBoxMatchesParams } from '../__kernel-tests__/meshAssertions';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
@@ -9,8 +10,78 @@ const binStyleList: Array<{ style: BinStyle; base?: Partial<BinParams['base']>; 
   { style: 'solid', base: { solid: true }, label: 'solid' },
 ];
 
-export const binStyles: ScenarioCase[] = binStyleList.map(({ style, base, label }) =>
-  defineScenario('bin styles', `2\u00d72 ${label}`, {
-    params: { style, base: { ...DEFAULT_BIN_PARAMS.base, ...base } },
-  })
-);
+export const binStyles: ScenarioCase[] = [
+  ...binStyleList.map(({ style, base, label }) =>
+    defineScenario('bin styles', `2×2 ${label}`, {
+      params: { style, base: { ...DEFAULT_BIN_PARAMS.base, ...base } },
+    })
+  ),
+
+  ...binStyleList.map(({ style, base, label }) =>
+    defineScenario('bin styles', `2×2 ${label} no lip`, {
+      assert: 'structural',
+      params: {
+        style,
+        base: { ...DEFAULT_BIN_PARAMS.base, ...base, stackingLip: false },
+      },
+      customAssert: (result, params) => {
+        assertBoundingBoxMatchesParams(result, params, `${label}-nolip`);
+      },
+    })
+  ),
+
+  ...binStyleList.map(({ style, base, label }) =>
+    defineScenario('bin styles', `4×4 ${label} (stress)`, {
+      assert: 'structural',
+      params: {
+        width: 4,
+        depth: 4,
+        style,
+        base: { ...DEFAULT_BIN_PARAMS.base, ...base },
+      },
+      timeout: 60_000,
+      customAssert: (result, params) => {
+        assertBoundingBoxMatchesParams(result, params, `4x4-${label}`);
+      },
+    })
+  ),
+
+  defineScenario('bin styles', '2×2 solid + halfSockets', {
+    assert: 'structural',
+    params: {
+      style: 'solid',
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true, halfSockets: true },
+    },
+  }),
+
+  defineScenario('bin styles', '2×2 slotted + magnet base', {
+    assert: 'structural',
+    params: {
+      style: 'slotted',
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet' },
+    },
+  }),
+
+  defineScenario('bin styles', '1×1 slotted + tall (8u)', {
+    assert: 'structural',
+    params: {
+      width: 1,
+      depth: 1,
+      height: 8,
+      style: 'slotted',
+    },
+  }),
+
+  defineScenario('bin styles', '2×2 solid + flat base + no lip', {
+    assert: 'structural',
+    params: {
+      style: 'solid',
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        solid: true,
+        style: 'flat',
+        stackingLip: false,
+      },
+    },
+  }),
+];

--- a/src/features/generation/worker/generators/scenarios/customShape.ts
+++ b/src/features/generation/worker/generators/scenarios/customShape.ts
@@ -299,4 +299,114 @@ export const customShapes: ScenarioCase[] = [
       wallPattern: { enabled: true, pattern: 'honeycomb' as const },
     },
   }),
+
+  defineScenario('custom-shape', '3×3 L with scoop (polygon scoop placement)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: L_SHAPE_MASK,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      scoop: { enabled: true, radius: 'auto' },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('custom-shape', '3×3 T with lip + scoop (concave perimeter + scoop)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: T_SHAPE_MASK,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      scoop: { enabled: true, radius: 'auto' },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('custom-shape', '3×3 U with handles + label (multi-feature polygon)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      height: 5,
+      cellMask: U_SHAPE_MASK,
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        front: { ...DEFAULT_HANDLE_SIDE, enabled: true },
+      },
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('custom-shape', '3×3 O-shape + magnet base + lip', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: O_SHAPE_MASK,
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        style: 'magnet',
+        stackingLip: true,
+      },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('custom-shape', '3×3 O-shape + half sockets', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: O_SHAPE_MASK,
+      base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('custom-shape', '3×3 L tall (10u) + lip (z-extrusion stability)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      height: 10,
+      cellMask: L_SHAPE_MASK,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('custom-shape', '4×3 asymmetric L (non-square bounding box)', {
+    // Wider than tall; tests that polygon path handles non-square masks.
+    assert: 'structural',
+    params: {
+      width: 4,
+      depth: 3,
+      cellMask: buildMask([
+        [1, 1, 1, 1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 0, 0, 0, 0],
+        [1, 1, 1, 1, 0, 0, 0, 0],
+      ]),
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('custom-shape', '3×3 L + slotted bin (polygon + slots)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      cellMask: L_SHAPE_MASK,
+      style: 'slotted',
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    timeout: 60_000,
+  }),
 ];

--- a/src/features/generation/worker/generators/scenarios/halfSockets.ts
+++ b/src/features/generation/worker/generators/scenarios/halfSockets.ts
@@ -1,17 +1,104 @@
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import {
+  assertBoundingBoxMatchesParams,
+  assertNoDegenerateTriangles,
+} from '../__kernel-tests__/meshAssertions';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
+const existing = [
+  { w: 1, d: 1, label: '1×1' },
+  { w: 1.5, d: 1.5, label: '1.5×1.5' },
+  { w: 2, d: 2, label: '2×2' },
+];
+
 export const halfSockets: ScenarioCase[] = [
-  { w: 1, d: 1, label: '1\u00d71' },
-  { w: 1.5, d: 1.5, label: '1.5\u00d71.5' },
-  { w: 2, d: 2, label: '2\u00d72' },
-].map(({ w, d, label }) =>
-  defineScenario('half-sockets', `${label} with half sockets`, {
+  ...existing.map(({ w, d, label }) =>
+    defineScenario('half-sockets', `${label} with half sockets`, {
+      params: {
+        width: w,
+        depth: d,
+        base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
+      },
+    })
+  ),
+
+  defineScenario('half-sockets', '0.5×1 half-bin with half sockets', {
+    assert: 'structural',
     params: {
-      width: w,
-      depth: d,
+      width: 0.5,
+      depth: 1,
       base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
     },
-  })
-);
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '0.5x1-halfSockets');
+      assertNoDegenerateTriangles(result, '0.5x1-halfSockets');
+    },
+  }),
+
+  defineScenario('half-sockets', '2.5×2.5 fractional + half sockets', {
+    assert: 'structural',
+    params: {
+      width: 2.5,
+      depth: 2.5,
+      base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
+    },
+  }),
+
+  defineScenario('half-sockets', '3×3 with half sockets (stress)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('half-sockets', '2×2 half sockets + screw base', {
+    assert: 'structural',
+    params: {
+      base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true, style: 'screw' },
+    },
+  }),
+
+  defineScenario('half-sockets', '2×2 half sockets + magnet+screw base', {
+    assert: 'structural',
+    params: {
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        halfSockets: true,
+        style: 'magnet_and_screw',
+      },
+    },
+  }),
+
+  defineScenario('half-sockets', '2×2 half sockets + tall (12u)', {
+    assert: 'structural',
+    params: {
+      height: 12,
+      base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
+    },
+  }),
+
+  defineScenario('half-sockets', '2×2 half sockets + weighted base', {
+    assert: 'structural',
+    params: {
+      base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true, style: 'weighted' },
+    },
+  }),
+
+  defineScenario('half-sockets', '1×1 half sockets + no lip + tall (10u)', {
+    assert: 'structural',
+    params: {
+      width: 1,
+      depth: 1,
+      height: 10,
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        halfSockets: true,
+        stackingLip: false,
+      },
+    },
+  }),
+];

--- a/src/features/generation/worker/generators/scenarios/heights.ts
+++ b/src/features/generation/worker/generators/scenarios/heights.ts
@@ -1,7 +1,56 @@
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import {
+  assertBoundingBoxMatchesParams,
+  assertNoDegenerateTriangles,
+} from '../__kernel-tests__/meshAssertions';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
 export const heightVariations: ScenarioCase[] = [
-  defineScenario('height', '2\u00d72 height minimum (2u)', { params: { height: 2 } }),
-  defineScenario('height', '2\u00d72 height tall (10u)', { params: { height: 10 } }),
+  defineScenario('height', '2×2 height minimum (2u)', { params: { height: 2 } }),
+  defineScenario('height', '2×2 height tall (10u)', { params: { height: 10 } }),
+
+  ...[3, 4, 5, 6, 8, 15, 20].map((h) =>
+    defineScenario('height', `2×2 height ${h}u (structural)`, {
+      assert: 'structural',
+      params: { height: h },
+      customAssert: (result, params) => {
+        assertBoundingBoxMatchesParams(result, params, `height-${h}u`);
+      },
+    })
+  ),
+
+  defineScenario('height', '1×1 height 20u (tall + narrow)', {
+    assert: 'structural',
+    params: { width: 1, depth: 1, height: 20 },
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '1x1x20');
+      assertNoDegenerateTriangles(result, '1x1x20');
+    },
+  }),
+
+  defineScenario('height', '4×4 height 6u (wide + tall, stress)', {
+    assert: 'structural',
+    params: { width: 4, depth: 4, height: 6 },
+    timeout: 60_000,
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '4x4x6');
+    },
+  }),
+
+  defineScenario('height', '2×2 height 2u no lip', {
+    assert: 'structural',
+    params: { height: 2, base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false } },
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '2x2x2-nolip');
+    },
+  }),
+
+  defineScenario('height', '2×2 height 20u no lip', {
+    assert: 'structural',
+    params: { height: 20, base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false } },
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '2x2x20-nolip');
+    },
+  }),
 ];

--- a/src/features/generation/worker/generators/scenarios/index.ts
+++ b/src/features/generation/worker/generators/scenarios/index.ts
@@ -1,9 +1,9 @@
 /**
  * Aggregated scenario definitions for bin generation tests.
  *
- * Each category file exports an array of ScenarioCase objects.
- * This index re-exports them as a single ordered array matching the
- * original `binGenerator.scenarios.ts` order exactly.
+ * Each category file exports an array of ScenarioCase objects. The
+ * historical categories below preserve their original definition order;
+ * new categories are appended to the end of `ALL_SCENARIOS`.
  */
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
@@ -31,6 +31,7 @@ import { lipWall } from './lipWall';
 import { handles } from './handles';
 import { honeycombJunction } from './honeycombJunction';
 import { customShapes } from './customShape';
+import { permutationMatrix } from './permutationMatrix';
 
 export type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
@@ -63,4 +64,5 @@ export const ALL_SCENARIOS: readonly ScenarioCase[] = [
   ...handles,
   ...honeycombJunction,
   ...customShapes,
+  ...permutationMatrix,
 ];

--- a/src/features/generation/worker/generators/scenarios/index.ts
+++ b/src/features/generation/worker/generators/scenarios/index.ts
@@ -32,6 +32,7 @@ import { handles } from './handles';
 import { honeycombJunction } from './honeycombJunction';
 import { customShapes } from './customShape';
 import { permutationMatrix } from './permutationMatrix';
+import { regressions } from './regressions';
 
 export type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
@@ -65,4 +66,5 @@ export const ALL_SCENARIOS: readonly ScenarioCase[] = [
   ...honeycombJunction,
   ...customShapes,
   ...permutationMatrix,
+  ...regressions,
 ];

--- a/src/features/generation/worker/generators/scenarios/index.ts
+++ b/src/features/generation/worker/generators/scenarios/index.ts
@@ -33,6 +33,7 @@ import { honeycombJunction } from './honeycombJunction';
 import { customShapes } from './customShape';
 import { permutationMatrix } from './permutationMatrix';
 import { regressions } from './regressions';
+import { solidCutoutMatrix } from './solidCutoutMatrix';
 
 export type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
@@ -67,4 +68,5 @@ export const ALL_SCENARIOS: readonly ScenarioCase[] = [
   ...customShapes,
   ...permutationMatrix,
   ...regressions,
+  ...solidCutoutMatrix,
 ];

--- a/src/features/generation/worker/generators/scenarios/permutationMatrix.ts
+++ b/src/features/generation/worker/generators/scenarios/permutationMatrix.ts
@@ -1,0 +1,481 @@
+import {
+  DEFAULT_BIN_PARAMS,
+  DEFAULT_HANDLE_SIDE,
+  DISABLED_WALL_CUTOUT,
+} from '@/shared/constants/bin';
+import {
+  assertBoundingBoxMatchesParams,
+  assertNoDegenerateTriangles,
+} from '../__kernel-tests__/meshAssertions';
+import { defineScenario, makeInsert, makeCutout } from '../__kernel-tests__/scenarioTypes';
+import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
+
+const ENABLED_SIDE = { ...DEFAULT_HANDLE_SIDE, enabled: true } as const;
+
+const CAT = 'permutation matrix';
+
+export const permutationMatrix: ScenarioCase[] = [
+  // ─── Lip junction × interior features ─────────────────────────────────────
+  // NOTE: params here intentionally mirror the snapshot-mode scenario in
+  // combinedFeatures.ts. The matrix variant adds a bounding-box customAssert
+  // so this configuration is locked against silent dimension drift even when
+  // the snapshot would be updated for an unrelated triangle-count change.
+  defineScenario(CAT, '2×2 lip + 2×2 compartments + scoop', {
+    assert: 'structural',
+    params: {
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
+      scoop: { enabled: true, radius: 'auto' },
+    },
+    timeout: 60_000,
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, 'lip+compart+scoop');
+    },
+  }),
+
+  defineScenario(CAT, '2×2 lip + thin walls (0.4mm) + tall (12u)', {
+    assert: 'structural',
+    params: {
+      height: 12,
+      wallThickness: 0.4,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, 'lip+thin+tall');
+      assertNoDegenerateTriangles(result, 'lip+thin+tall');
+    },
+  }),
+
+  defineScenario(CAT, '2×2 lip + half sockets + magnet base', {
+    assert: 'structural',
+    params: {
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        stackingLip: true,
+        halfSockets: true,
+        style: 'magnet',
+      },
+    },
+  }),
+
+  defineScenario(CAT, '2×2 slotted + lip + handle holes (multi-cut + lip)', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      style: 'slotted',
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        front: ENABLED_SIDE,
+        left: ENABLED_SIDE,
+      },
+    },
+    timeout: 60_000,
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, 'slotted+lip+handles');
+    },
+  }),
+
+  // ─── Floor + wall cut collisions ──────────────────────────────────────────
+  defineScenario(CAT, '3×3 inserts + wall cutouts (floor + walls)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      height: 5,
+      inserts: [
+        makeInsert({ id: 'a', shape: 'circle', x: 0, y: 0, width: 18, depth: 18, cutDepth: 4 }),
+      ],
+      walls: {
+        ...DEFAULT_BIN_PARAMS.walls,
+        enabled: true,
+        front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 60, depth: 50 },
+        back: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 60, depth: 50 },
+      },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, '2×2 cutouts + handles + label tab (3 cuts)', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      cutouts: [makeCutout({ id: 'c1', shape: 'circle', cutDepth: 3 })],
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        right: ENABLED_SIDE,
+      },
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket' },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, '3×2 inserts + scoop + compartments (floor + back wall + interior)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 2,
+      inserts: [
+        makeInsert({ id: 'l', shape: 'circle', x: -25, y: 0, width: 15, depth: 15, cutDepth: 3 }),
+        makeInsert({ id: 'r', shape: 'circle', x: 25, y: 0, width: 15, depth: 15, cutDepth: 3 }),
+      ],
+      compartments: { cols: 3, rows: 1, cells: [0, 1, 2], thickness: 0.8 },
+      scoop: { enabled: true, radius: 'auto' },
+    },
+    timeout: 60_000,
+  }),
+
+  // ─── Half sockets × sub-features ──────────────────────────────────────────
+  defineScenario(CAT, '0.5×0.5 magnet base + half sockets (sub-grid pocket stress)', {
+    assert: 'structural',
+    params: {
+      width: 0.5,
+      depth: 0.5,
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        style: 'magnet',
+        halfSockets: true,
+      },
+    },
+  }),
+
+  defineScenario(CAT, '2×2 half sockets + honeycomb walls', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, '2×2 half sockets + handles', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        front: ENABLED_SIDE,
+        back: ENABLED_SIDE,
+      },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, '2×2 half sockets + scoop + lip', {
+    assert: 'structural',
+    params: {
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        halfSockets: true,
+        stackingLip: true,
+      },
+      scoop: { enabled: true, radius: 'auto' },
+    },
+    timeout: 60_000,
+  }),
+
+  // ─── Wall pattern intersections (honeycomb border clipping) ──────────────
+  defineScenario(CAT, '3×3 honeycomb + handles + label (3 cut-throughs)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      height: 6,
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        front: ENABLED_SIDE,
+        left: ENABLED_SIDE,
+      },
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+    },
+    timeout: 120_000,
+  }),
+
+  defineScenario(CAT, '4×4 honeycomb + wall cutouts + lip (hex prism + border)', {
+    assert: 'structural',
+    params: {
+      width: 4,
+      depth: 4,
+      height: 5,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      walls: {
+        ...DEFAULT_BIN_PARAMS.walls,
+        enabled: true,
+        front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 80, depth: 50 },
+        back: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 80, depth: 50 },
+      },
+    },
+    timeout: 120_000,
+  }),
+
+  defineScenario(CAT, '1.5×1.5 honeycomb + fractional + lip', {
+    assert: 'structural',
+    params: {
+      width: 1.5,
+      depth: 1.5,
+      height: 4,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+    },
+    timeout: 60_000,
+  }),
+
+  // ─── Solid mode × cuts ───────────────────────────────────────────────────
+  defineScenario(CAT, '2×2 solid + label tab bracket (top cut through solid)', {
+    assert: 'structural',
+    params: {
+      height: 4,
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        solid: true,
+        stackingLip: false,
+      },
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket' },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, '2×2 solid + handles (cuts above solid surface)', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        solid: true,
+        stackingLip: false,
+      },
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        front: ENABLED_SIDE,
+        back: ENABLED_SIDE,
+      },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, '2×2 solid + grouped cutouts at varying depths', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        solid: true,
+        stackingLip: false,
+      },
+      cutouts: [
+        makeCutout({ id: 'shallow', x: -10, cutDepth: 2, groupId: 'g1' }),
+        makeCutout({ id: 'deep', x: 10, cutDepth: 6, groupId: 'g1' }),
+      ],
+    },
+    timeout: 60_000,
+  }),
+
+  // ─── 4×4 stress: many features at scale ───────────────────────────────────
+  defineScenario(CAT, '4×4 magnet + compartments + scoop + label (mega)', {
+    assert: 'structural',
+    params: {
+      width: 4,
+      depth: 4,
+      height: 6,
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        style: 'magnet',
+        stackingLip: true,
+      },
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
+      scoop: { enabled: true, radius: 'auto' },
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+    },
+    timeout: 120_000,
+  }),
+
+  defineScenario(CAT, '4×4 slotted + handles + label + lip (multi-cut stress)', {
+    assert: 'structural',
+    params: {
+      width: 4,
+      depth: 4,
+      height: 6,
+      style: 'slotted',
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        front: ENABLED_SIDE,
+        right: ENABLED_SIDE,
+      },
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+    },
+    timeout: 120_000,
+  }),
+
+  defineScenario(CAT, '4×4 honeycomb + handles + scoop + lip + halfSockets', {
+    assert: 'structural',
+    params: {
+      width: 4,
+      depth: 4,
+      height: 6,
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        stackingLip: true,
+        halfSockets: true,
+      },
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      scoop: { enabled: true, radius: 'auto' },
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        front: ENABLED_SIDE,
+      },
+    },
+    timeout: 180_000,
+  }),
+
+  // ─── Slotted × interior ─────────────────────────────────────────────────
+  defineScenario(CAT, '2×2 slotted + compartments + scoop', {
+    assert: 'structural',
+    params: {
+      style: 'slotted',
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
+      scoop: { enabled: true, radius: 'auto' },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, '2×2 slotted + inserts + lip', {
+    assert: 'structural',
+    params: {
+      style: 'slotted',
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      inserts: [makeInsert({ shape: 'circle', width: 20, depth: 20, cutDepth: 4 })],
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, '2×2 slotted + handles + label', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      style: 'slotted',
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        front: ENABLED_SIDE,
+        left: ENABLED_SIDE,
+      },
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+    },
+    timeout: 60_000,
+  }),
+
+  // ─── Fractional dimensions × features ────────────────────────────────────
+  defineScenario(CAT, '1.5×1.5 lip + scoop', {
+    assert: 'structural',
+    params: {
+      width: 1.5,
+      depth: 1.5,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      scoop: { enabled: true, radius: 'auto' },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, '2.5×1 handles + lip (asymmetric + lip)', {
+    assert: 'structural',
+    params: {
+      width: 2.5,
+      depth: 1,
+      height: 5,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        front: ENABLED_SIDE,
+      },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, '0.5×2 magnet + lip + half sockets (long half-bin stress)', {
+    assert: 'structural',
+    params: {
+      width: 0.5,
+      depth: 2,
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        style: 'magnet',
+        stackingLip: true,
+        halfSockets: true,
+      },
+    },
+    timeout: 60_000,
+  }),
+
+  // ─── Label-tab × interior interactions ──────────────────────────────────
+  defineScenario(CAT, '2×2 label tab + compartments + scoop (3-way)', {
+    assert: 'structural',
+    params: {
+      compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 0.8 },
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket' },
+      scoop: { enabled: true, radius: 'auto' },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, '2×2 label tab solid + thick walls (gusset edge case)', {
+    assert: 'structural',
+    params: {
+      height: 4,
+      wallThickness: 2.0,
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'solid' },
+    },
+  }),
+
+  // ─── Magnet + screw × multiple features ─────────────────────────────────
+  defineScenario(CAT, '3×3 magnet+screw base + scoop + label + lip', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      height: 5,
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        style: 'magnet_and_screw',
+        stackingLip: true,
+      },
+      scoop: { enabled: true, radius: 'auto' },
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, '2×2 weighted base + compartments + scoop', {
+    assert: 'structural',
+    params: {
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'weighted' },
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
+      scoop: { enabled: true, radius: 'auto' },
+    },
+    timeout: 60_000,
+  }),
+
+  // ─── Scoop interactions ───────────────────────────────────────────────
+  defineScenario(CAT, '2×2 scoop + tall (10u) + lip + thick walls', {
+    assert: 'structural',
+    params: {
+      height: 10,
+      wallThickness: 1.6,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      scoop: { enabled: true, radius: 'auto' },
+    },
+    timeout: 60_000,
+  }),
+];

--- a/src/features/generation/worker/generators/scenarios/regressions.ts
+++ b/src/features/generation/worker/generators/scenarios/regressions.ts
@@ -1,0 +1,462 @@
+/**
+ * Regression locks for previously-fixed bin generation bugs.
+ *
+ * Each scenario corresponds to a closed GitHub issue + fix PR.
+ * The customAssert is the specific invariant the fix restored —
+ * not a triangle-count snapshot. If a future change reintroduces
+ * the same bug class, the customAssert fails noisily.
+ */
+import { expect } from 'vitest';
+import {
+  DEFAULT_BIN_PARAMS,
+  DEFAULT_HANDLE_SIDE,
+  DISABLED_WALL_CUTOUT,
+  GRIDFINITY,
+} from '@/shared/constants/bin';
+import {
+  assertBoundingBoxMatchesParams,
+  assertNoDegenerateTriangles,
+  boundingBox,
+  countWallVerticesInZone,
+  hasNoNaNOrInfinity,
+} from '../__kernel-tests__/meshAssertions';
+import { defineScenario, makeCutout } from '../__kernel-tests__/scenarioTypes';
+import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
+
+const ENABLED_SIDE = { ...DEFAULT_HANDLE_SIDE, enabled: true } as const;
+const SIZE = GRIDFINITY.GRID_SIZE;
+const TOL = GRIDFINITY.TOLERANCE;
+const CAT = 'regressions';
+
+export const regressions: ScenarioCase[] = [
+  // #1753 / PR #1756 — compartmented bins were generating non-manifold geometry
+  // because each compartment wall was fused individually; fix restructured to a
+  // single multi-cavity cut. Invariant: no degenerate triangles, no NaN.
+  defineScenario(CAT, '#1753 compartmented bin is manifold (multi-cavity cut)', {
+    assert: 'structural',
+    params: {
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
+    },
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, '#1753 manifold');
+      expect(hasNoNaNOrInfinity(result.vertices)).toBe(true);
+      expect(hasNoNaNOrInfinity(result.normals)).toBe(true);
+    },
+  }),
+
+  // #1760 / PR #1765 — split STL export failed for scoop + tall walls (h>=9)
+  // with lip enabled. Fix bypassed OCCT STL writer for split pieces.
+  // Invariant: mesh validity at height 10 + scoop + lip in export mode.
+  defineScenario(CAT, '#1760 scoop + tall (h=10) + lip + export mode', {
+    assert: 'structural',
+    params: {
+      height: 10,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      scoop: { enabled: true, radius: 'auto' },
+    },
+    forExport: true,
+    timeout: 60_000,
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '#1760');
+      assertNoDegenerateTriangles(result, '#1760');
+    },
+  }),
+
+  // #1681 — split cut planes intersected socket-cell boundaries causing
+  // non-manifold split pieces on fractional bins. Fix nudged planes off.
+  defineScenario(CAT, '#1681 fractional + scoop near socket boundary', {
+    assert: 'structural',
+    params: {
+      width: 2.5,
+      depth: 2,
+      scoop: { enabled: true, radius: 'auto' },
+    },
+    timeout: 60_000,
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, '#1681');
+    },
+  }),
+
+  // #1657 — lid magnet holes had to be cut before fusing stack grid; otherwise
+  // boolean ops left non-manifold edges. Invariant on a lidless-bin proxy:
+  // half-sockets + magnet base + lip should still produce manifold mesh.
+  defineScenario(CAT, '#1657 magnet base + half sockets + lip (pre-fuse cut order)', {
+    assert: 'structural',
+    params: {
+      base: {
+        ...DEFAULT_BIN_PARAMS.base,
+        style: 'magnet',
+        halfSockets: true,
+        stackingLip: true,
+      },
+    },
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, '#1657');
+    },
+  }),
+
+  // #1653 — divider notches needed to cut through the lip in split slotted
+  // bins; otherwise the lip blocked the divider slot. Invariant: enabling
+  // the stacking lip must NOT erase the slot notches — so the lip-on
+  // mesh should have MORE triangles than the lip-off baseline (lip adds
+  // geometry) AND the lip should peak above wallHeight. If the lip-on
+  // mesh is suspiciously close to or smaller than lip-off, the notch cut
+  // through the lip probably failed silently.
+  defineScenario(CAT, '#1653 slotted + lip + slot notches', {
+    assert: 'structural',
+    params: {
+      width: 4,
+      depth: 2,
+      height: 6,
+      style: 'slotted',
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    timeout: 60_000,
+    customAssert: (result) => {
+      const wallHeight = 6 * GRIDFINITY.HEIGHT_UNIT;
+      const bb = boundingBox(result.vertices);
+      expect(bb.maxZ, '#1653: lip peaks above wallHeight').toBeGreaterThan(wallHeight);
+    },
+    compareWith: {
+      params: {
+        width: 4,
+        depth: 2,
+        height: 6,
+        style: 'slotted',
+        base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+      },
+      assert: (lipOn, lipOff) => {
+        // Lip adds geometry; if notches don't cut through it the savings
+        // would be much larger, so lipOn ≥ lipOff is the floor.
+        expect(
+          lipOn.triangleCount,
+          '#1653: slotted+lip should not regress below slotted+nolip triangle count'
+        ).toBeGreaterThanOrEqual(lipOff.triangleCount);
+      },
+    },
+  }),
+
+  // #1487 / PR #1491 — stacking lip lost angled support beneath the overhang;
+  // fix restored the support geometry. Invariant: lip-band vertex count on
+  // outer walls is non-trivial (support spans corner-to-corner).
+  defineScenario(CAT, '#1487 stacking lip has angled support beneath', {
+    assert: 'structural',
+    params: {
+      height: 4,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    customAssert: (result) => {
+      const wallHeight = 4 * GRIDFINITY.HEIGHT_UNIT;
+      const outerW = 2 * SIZE - TOL;
+      const outerD = 2 * SIZE - TOL;
+      // Look for vertices just BELOW lip junction (the support angle)
+      const supportBand = countWallVerticesInZone(
+        result,
+        outerW,
+        outerD,
+        wallHeight - 3.0,
+        wallHeight - 0.5,
+        1.5
+      );
+      expect(supportBand.left).toBeGreaterThan(0);
+      expect(supportBand.right).toBeGreaterThan(0);
+      expect(supportBand.front).toBeGreaterThan(0);
+      expect(supportBand.back).toBeGreaterThan(0);
+    },
+  }),
+
+  // #1448 / #1445 — exporting with custom heightUnitMm produced incorrect Z
+  // dimension. Invariant: bounding-box Z matches height * heightUnitMm.
+  defineScenario(CAT, '#1448 custom heightUnitMm respected in export', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      heightUnitMm: 10,
+    },
+    forExport: true,
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '#1448');
+    },
+  }),
+
+  // #1437 — wall pattern + dividers had overlapping geometry near junctions.
+  // Invariant: honeycomb + compartments → no degenerate triangles, valid manifold.
+  defineScenario(CAT, '#1437 honeycomb + dividers — no junction overlap', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      height: 5,
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
+    },
+    timeout: 120_000,
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, '#1437');
+    },
+  }),
+
+  // #1404 — oversized bins (>print bed) had to split into MINIMUM equal pieces
+  // not maximum. Proxy: large bin generates without crashing or degenerates.
+  defineScenario(CAT, '#1404 oversized 8×4 bin (would need split)', {
+    assert: 'structural',
+    params: { width: 8, depth: 4, height: 4 },
+    timeout: 120_000,
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '#1404');
+    },
+  }),
+
+  // #1379 — 4×3 (and similar elongated) bins had stacking lip overhanging the
+  // outer X/Y bound. lipWall.ts locks 4×3 + 6×2; we lock 3×5 here as an
+  // independent witness of the same class.
+  defineScenario(CAT, '#1379 3×5 lip does not overhang outer bound', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 5,
+      height: 6,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    timeout: 120_000,
+    customAssert: (result) => {
+      const outerW = 3 * SIZE - TOL;
+      const outerD = 5 * SIZE - TOL;
+      const bb = boundingBox(result.vertices);
+      expect(bb.maxX - bb.minX, '#1379: lip X extent').toBeLessThanOrEqual(outerW + 1.0);
+      expect(bb.maxY - bb.minY, '#1379: lip Y extent').toBeLessThanOrEqual(outerD + 1.0);
+    },
+  }),
+
+  // #1354 / PR #1355 — honeycomb pattern left holes at thick walls (>0.8mm)
+  // in divider regions because hex prism extrusion exceeded the clip depth.
+  // Invariant: thick walls + honeycomb + compartments still produces valid mesh.
+  defineScenario(CAT, '#1354 honeycomb + thick walls (1.6mm) + compartments', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      wallThickness: 1.6,
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
+    },
+    timeout: 120_000,
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, '#1354');
+    },
+  }),
+
+  // #1351 / #1348 — honeycomb pattern bled into divider-wall junctions.
+  // Invariant: divider junctions remain clean (no degenerate triangles where
+  // hex prisms would have overlapped).
+  defineScenario(CAT, '#1351 honeycomb cleanly blocked at divider junctions', {
+    assert: 'structural',
+    params: {
+      width: 4,
+      depth: 2,
+      height: 5,
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 0.8 },
+    },
+    timeout: 120_000,
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, '#1351');
+    },
+  }),
+
+  // #1314 — visible seam where outer wall met stacking lip. Invariant:
+  // continuous vertex zone at lip junction (left/right/front/back all have
+  // contributing vertices).
+  defineScenario(CAT, '#1314 no wall-to-lip seam (continuous junction)', {
+    assert: 'structural',
+    params: {
+      height: 4,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    customAssert: (result) => {
+      const wallHeight = 4 * GRIDFINITY.HEIGHT_UNIT;
+      const outerW = 2 * SIZE - TOL;
+      const outerD = 2 * SIZE - TOL;
+      const stats = countWallVerticesInZone(
+        result,
+        outerW,
+        outerD,
+        wallHeight - 1.0,
+        wallHeight + 1.0,
+        1.5
+      );
+      expect(stats.left).toBeGreaterThanOrEqual(2);
+      expect(stats.right).toBeGreaterThanOrEqual(2);
+      expect(stats.front).toBeGreaterThanOrEqual(2);
+      expect(stats.back).toBeGreaterThanOrEqual(2);
+    },
+  }),
+
+  // #1306 — stacking lip overhang on rectangular bins didn't match outer
+  // bound. Same class as #1379. Lock 5×2 elongated bin here.
+  defineScenario(CAT, '#1306 5×2 rectangular lip overhang in bounds', {
+    assert: 'structural',
+    params: {
+      width: 5,
+      depth: 2,
+      height: 4,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    timeout: 60_000,
+    customAssert: (result) => {
+      const outerW = 5 * SIZE - TOL;
+      const outerD = 2 * SIZE - TOL;
+      const bb = boundingBox(result.vertices);
+      expect(bb.maxX - bb.minX).toBeLessThanOrEqual(outerW + 1.0);
+      expect(bb.maxY - bb.minY).toBeLessThanOrEqual(outerD + 1.0);
+    },
+  }),
+
+  // #1305 — at 2u height, label tabs had to be disabled because there was
+  // no room. Repro: 2u + label.enabled=true should still produce valid mesh
+  // (gracefully suppressed or geometrically bounded).
+  defineScenario(CAT, '#1305 2u bin with label tab enabled (graceful)', {
+    assert: 'structural',
+    params: {
+      height: 2,
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+    },
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '#1305');
+    },
+  }),
+
+  // #1206 — label tab support didn't reach the shelf front edge; gusset
+  // calculation was off. Invariant: label tab solid + reasonable height
+  // produces valid mesh with no degenerates.
+  defineScenario(CAT, '#1206 label tab solid reaches front edge', {
+    assert: 'structural',
+    params: {
+      height: 4,
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'solid', depth: 15 },
+    },
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, '#1206');
+    },
+  }),
+
+  // #921 / PR #923 — non-manifold slot geometry on STL export. Invariant:
+  // slotted + export mode produces manifold (no degenerate triangles).
+  defineScenario(CAT, '#921 slotted bin export is manifold', {
+    assert: 'structural',
+    params: { style: 'slotted', height: 4 },
+    forExport: true,
+    timeout: 60_000,
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, '#921');
+    },
+  }),
+
+  // #377 — finger scoop geometry orientation was wrong (scoop faced the
+  // wrong wall). Invariant: scoop + bin produces valid mesh and the bin's
+  // back-wall vertex count is reduced (scoop carves from one side).
+  defineScenario(CAT, '#377 finger scoop geometry orientation', {
+    assert: 'structural',
+    params: { scoop: { enabled: true, radius: 'auto' } },
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, '#377');
+    },
+  }),
+
+  // #371 — wall cutout geometry was positioned incorrectly. Invariant:
+  // wall cutouts produce valid mesh, bounding box matches outer dimensions.
+  defineScenario(CAT, '#371 wall cutout geometry positioned correctly', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      walls: {
+        ...DEFAULT_BIN_PARAMS.walls,
+        enabled: true,
+        front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 50, depth: 40 },
+      },
+    },
+    timeout: 60_000,
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '#371');
+    },
+  }),
+
+  // #351 — invalid compartment mesh at minimum thickness produced
+  // non-manifold output. Invariant: very thin compartment thickness still
+  // generates structurally valid mesh.
+  defineScenario(CAT, '#351 minimum compartment thickness guard', {
+    assert: 'structural',
+    params: {
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.4 },
+    },
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, '#351');
+    },
+  }),
+
+  // #449 — incorrect stacking lip height. Invariant: lip top vertex ≥
+  // wallHeight (peaks above) but bounding box Z reasonably close to expected.
+  defineScenario(CAT, '#449 stacking lip height correct', {
+    assert: 'structural',
+    params: {
+      height: 6,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    customAssert: (result) => {
+      const wallHeight = 6 * GRIDFINITY.HEIGHT_UNIT;
+      const bb = boundingBox(result.vertices);
+      expect(bb.maxZ, '#449: lip peaks above wallHeight').toBeGreaterThan(wallHeight);
+      // Lip shouldn't exceed wallHeight by more than ~5mm (lip is ~4.4mm tall)
+      expect(bb.maxZ - wallHeight).toBeLessThan(6);
+    },
+  }),
+
+  // #1344 — magnet hole diameter was being interpreted as radius. Proxy:
+  // magnet base + reasonable diameter generates valid mesh with bounding
+  // box matching outer dimensions.
+  defineScenario(CAT, '#1344 magnet base diameter (not radius) interpreted', {
+    assert: 'structural',
+    params: {
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet', magnetDiameter: 6.5 },
+    },
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '#1344');
+    },
+  }),
+
+  // Solid-mode + cutout regression — cutoutTopOffset >= wallHeight previously
+  // caused degenerate fillHeight; existing edgeCases covers structural validity,
+  // we add the actual cutout-into-solid-from-top variant.
+  defineScenario(CAT, '#solid top-cutout degenerate fillHeight guard', {
+    assert: 'structural',
+    params: {
+      height: 4,
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true, stackingLip: false },
+      cutoutConfig: { topOffset: 5 },
+      cutouts: [makeCutout({ id: 'top-cut', width: 20, depth: 20, cutDepth: 8 })],
+    },
+    timeout: 60_000,
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, '#solid-top');
+    },
+  }),
+
+  // Combined regression — multiple historical bug classes in one bin.
+  // Locks "everything that has ever broken" into a single canary scenario.
+  defineScenario(CAT, '#canary lip + scoop + compartments + magnet base + tall', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      height: 8,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet', stackingLip: true },
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
+      scoop: { enabled: true, radius: 'auto' },
+      handles: { ...DEFAULT_BIN_PARAMS.handles, enabled: true, front: ENABLED_SIDE },
+    },
+    timeout: 180_000,
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '#canary');
+      assertNoDegenerateTriangles(result, '#canary');
+    },
+  }),
+];

--- a/src/features/generation/worker/generators/scenarios/solidCutoutMatrix.ts
+++ b/src/features/generation/worker/generators/scenarios/solidCutoutMatrix.ts
@@ -1,0 +1,297 @@
+/**
+ * Solid-mode × cutout permutation coverage.
+ *
+ * Targets the underexplored matrix of:
+ *   - cutoutTopOffset × cutDepth × stacking lip
+ *   - multiple grouped cutouts at varying rotations
+ *   - solid mode × label tabs (entirely missing before)
+ *   - solid + handles + cutout interactions
+ */
+import { expect } from 'vitest';
+import { DEFAULT_BIN_PARAMS, DEFAULT_HANDLE_SIDE } from '@/shared/constants/bin';
+import {
+  assertBoundingBoxMatchesParams,
+  assertNoDegenerateTriangles,
+} from '../__kernel-tests__/meshAssertions';
+import { defineScenario, makeCutout } from '../__kernel-tests__/scenarioTypes';
+import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
+
+const ENABLED_SIDE = { ...DEFAULT_HANDLE_SIDE, enabled: true } as const;
+const SOLID_BASE = { ...DEFAULT_BIN_PARAMS.base, solid: true, stackingLip: false };
+const CAT = 'solid+cutout matrix';
+
+export const solidCutoutMatrix: ScenarioCase[] = [
+  // ─── Solid mode silently ignores label tabs and handles ─────────────────
+  // featuresStage short-circuits in solid mode and applies only cutout cuts
+  // (see pipeline/stages/featuresStage.ts: `if (dim.solid) ... return ctx`).
+  // These scenarios lock in that contract: setting `label.enabled` or
+  // enabling handle sides on a solid bin must NOT alter the mesh.
+  defineScenario(CAT, 'solid + label tab bracket params ignored (no geometry change)', {
+    assert: 'structural',
+    params: {
+      height: 4,
+      base: SOLID_BASE,
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket' },
+    },
+    timeout: 60_000,
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, 'solid+label-bracket');
+    },
+    compareWith: {
+      params: { height: 4, base: SOLID_BASE },
+      assert: (withLabel, withoutLabel) => {
+        expect(
+          withLabel.triangleCount,
+          'solid+label should match plain solid — features stage short-circuits'
+        ).toBe(withoutLabel.triangleCount);
+      },
+    },
+  }),
+
+  defineScenario(CAT, 'solid + label tab solid params ignored', {
+    assert: 'structural',
+    params: {
+      height: 4,
+      base: SOLID_BASE,
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'solid' },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, 'solid + label tab + thick walls — label still ignored', {
+    assert: 'structural',
+    params: {
+      height: 4,
+      wallThickness: 2.0,
+      base: SOLID_BASE,
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'solid', depth: 3 },
+    },
+  }),
+
+  defineScenario(CAT, 'solid + label (ignored) + cutout (applied)', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      base: SOLID_BASE,
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket' },
+      cutouts: [makeCutout({ id: 'c1', shape: 'circle', cutDepth: 4 })],
+    },
+    timeout: 60_000,
+  }),
+
+  // ─── Solid + handle params (also ignored) + cutouts ──────────────────────
+  // Same short-circuit applies to handles — only the cutout takes effect.
+  defineScenario(CAT, 'solid + handle params ignored + cutout (only cutout cuts)', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      base: SOLID_BASE,
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        left: ENABLED_SIDE,
+        right: ENABLED_SIDE,
+      },
+      cutouts: [makeCutout({ id: 'c1', cutDepth: 3 })],
+    },
+    timeout: 60_000,
+  }),
+
+  // ─── topOffset × cutDepth matrix ─────────────────────────────────────────
+  // At height=5 and heightUnitMm=7, solidSurfaceZ ≈ wallHeight - topOffset
+  // ≈ 30 - topOffset. A cut reaches the floor when cutDepth >= solidSurfaceZ.
+  ...[
+    { offset: 0, depth: 3, label: 'flush + shallow' },
+    { offset: 0, depth: 10, label: 'flush + medium' },
+    { offset: 5, depth: 3, label: 'mid-offset + shallow' },
+    { offset: 5, depth: 15, label: 'mid-offset + deep' },
+    { offset: 20, depth: 2, label: 'high-offset + shallow' },
+    { offset: 20, depth: 30, label: 'high-offset + deep (past floor)' },
+  ].map(({ offset, depth, label }) =>
+    defineScenario(CAT, `solid topOffset=${offset} cutDepth=${depth} (${label})`, {
+      assert: 'structural',
+      params: {
+        height: 5,
+        base: SOLID_BASE,
+        cutoutConfig: { topOffset: offset },
+        cutouts: [makeCutout({ id: 'c1', width: 20, depth: 20, cutDepth: depth })],
+      },
+      timeout: 60_000,
+    })
+  ),
+
+  // ─── Multiple grouped cutouts at rotations ───────────────────────────────
+  defineScenario(CAT, 'solid + 4 grouped cutouts at 0/30/60/90°', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      height: 5,
+      base: SOLID_BASE,
+      cutouts: [
+        makeCutout({ id: 'a', x: -20, y: -20, rotation: 0, groupId: 'g1' }),
+        makeCutout({ id: 'b', x: 20, y: -20, rotation: 30, groupId: 'g1' }),
+        makeCutout({ id: 'c', x: -20, y: 20, rotation: 60, groupId: 'g1' }),
+        makeCutout({ id: 'd', x: 20, y: 20, rotation: 90, groupId: 'g1' }),
+      ],
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, 'solid + grouped cutouts varying depth in same group', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 2,
+      height: 6,
+      base: SOLID_BASE,
+      cutouts: [
+        makeCutout({ id: 's1', x: -20, cutDepth: 2, groupId: 'g1' }),
+        makeCutout({ id: 's2', x: 0, cutDepth: 5, groupId: 'g1' }),
+        makeCutout({ id: 's3', x: 20, cutDepth: 8, groupId: 'g1' }),
+      ],
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, 'solid + grouped cutouts with scoop at 45°', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      base: SOLID_BASE,
+      cutouts: [
+        makeCutout({
+          id: 'sc1',
+          x: -10,
+          y: -10,
+          width: 15,
+          depth: 15,
+          rotation: 45,
+          scoopRadius: 2,
+          groupId: 'g1',
+        }),
+        makeCutout({
+          id: 'sc2',
+          x: 10,
+          y: 10,
+          width: 15,
+          depth: 15,
+          rotation: 45,
+          scoopRadius: 2,
+          groupId: 'g1',
+        }),
+      ],
+    },
+    timeout: 60_000,
+  }),
+
+  // ─── topOffset + stacking lip (solid + lip on, edge case) ───────────────
+  defineScenario(CAT, 'solid + lip + cutout topOffset 5mm', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true, stackingLip: true },
+      cutoutConfig: { topOffset: 5 },
+      cutouts: [makeCutout({ id: 'c1', cutDepth: 8 })],
+    },
+    timeout: 60_000,
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, 'solid+lip+topOffset');
+    },
+  }),
+
+  defineScenario(CAT, 'solid + lip + multiple cutouts (manifold under fuse)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 3,
+      height: 5,
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true, stackingLip: true },
+      cutouts: [
+        makeCutout({ id: 'l', x: -25, cutDepth: 4 }),
+        makeCutout({ id: 'r', x: 25, cutDepth: 4 }),
+        makeCutout({ id: 'c', x: 0, y: 0, cutDepth: 4 }),
+      ],
+    },
+    timeout: 60_000,
+    customAssert: (result) => {
+      assertNoDegenerateTriangles(result, 'solid+lip+multiCut');
+    },
+  }),
+
+  // ─── Path cutouts in solid mode ──────────────────────────────────────────
+  defineScenario(CAT, 'solid + path cutout (triangle) + topOffset', {
+    assert: 'structural',
+    params: {
+      height: 5,
+      base: SOLID_BASE,
+      cutoutConfig: { topOffset: 5 },
+      cutouts: [
+        makeCutout({
+          id: 'tri',
+          shape: 'path',
+          x: 10,
+          y: 10,
+          width: 20,
+          depth: 20,
+          cutDepth: 6,
+          path: [
+            { x: 10, y: 10, handleIn: null, handleOut: null, symmetric: false },
+            { x: 30, y: 10, handleIn: null, handleOut: null, symmetric: false },
+            { x: 20, y: 30, handleIn: null, handleOut: null, symmetric: false },
+          ],
+        }),
+      ],
+    },
+    timeout: 60_000,
+  }),
+
+  // ─── Stress: solid + 6 features ─────────────────────────────────────────
+  defineScenario(CAT, '4×4 solid + lip + label + handles + cutout + topOffset (mega)', {
+    assert: 'structural',
+    params: {
+      width: 4,
+      depth: 4,
+      height: 6,
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true, stackingLip: true },
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        front: ENABLED_SIDE,
+      },
+      cutoutConfig: { topOffset: 3 },
+      cutouts: [makeCutout({ id: 'mega', shape: 'circle', width: 30, depth: 30, cutDepth: 8 })],
+    },
+    timeout: 180_000,
+    customAssert: (result) => {
+      expect(result.triangleCount).toBeGreaterThan(100);
+      assertNoDegenerateTriangles(result, 'solid-mega');
+    },
+  }),
+
+  // ─── Fractional + solid + cutouts ───────────────────────────────────────
+  defineScenario(CAT, '1.5×1.5 solid + cutout + label', {
+    assert: 'structural',
+    params: {
+      width: 1.5,
+      depth: 1.5,
+      height: 4,
+      base: SOLID_BASE,
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+      cutouts: [makeCutout({ id: 'frac', width: 15, depth: 15, cutDepth: 3 })],
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario(CAT, '0.5×0.5 solid + cutout (smallest + cut)', {
+    assert: 'structural',
+    params: {
+      width: 0.5,
+      depth: 0.5,
+      height: 3,
+      base: SOLID_BASE,
+      cutouts: [makeCutout({ id: 'tiny', width: 8, depth: 8, cutDepth: 2 })],
+    },
+  }),
+];

--- a/src/features/generation/worker/generators/scenarios/wallThickness.ts
+++ b/src/features/generation/worker/generators/scenarios/wallThickness.ts
@@ -1,11 +1,63 @@
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { assertBoundingBoxMatchesParams } from '../__kernel-tests__/meshAssertions';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
 export const wallThickness: ScenarioCase[] = [
-  defineScenario('wall thickness', '2\u00d72 thin (0.4mm) walls', {
+  defineScenario('wall thickness', '2×2 thin (0.4mm) walls', {
     params: { wallThickness: 0.4 },
   }),
-  defineScenario('wall thickness', '2\u00d72 thick (2.4mm) walls', {
+  defineScenario('wall thickness', '2×2 thick (2.4mm) walls', {
     params: { wallThickness: 2.4 },
+  }),
+
+  ...[1.0, 1.2, 1.6, 2.0].map((wt) =>
+    defineScenario('wall thickness', `2×2 wall ${wt.toFixed(1)}mm (structural)`, {
+      assert: 'structural',
+      params: { wallThickness: wt },
+      customAssert: (result, params) => {
+        assertBoundingBoxMatchesParams(result, params, `wall-${wt.toFixed(1)}mm`);
+      },
+    })
+  ),
+
+  defineScenario('wall thickness', '2×2 thin walls + stacking lip (stability)', {
+    assert: 'structural',
+    params: {
+      wallThickness: 0.4,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, 'thin+lip');
+    },
+  }),
+
+  defineScenario('wall thickness', '2×2 thick walls + compartments (inner-volume squeeze)', {
+    assert: 'structural',
+    params: {
+      wallThickness: 2.4,
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
+    },
+    timeout: 60_000,
+  }),
+
+  defineScenario('wall thickness', '4×4 thick walls (stress)', {
+    assert: 'structural',
+    params: { width: 4, depth: 4, wallThickness: 2.4 },
+    timeout: 60_000,
+    customAssert: (result, params) => {
+      assertBoundingBoxMatchesParams(result, params, '4x4-thick');
+    },
+  }),
+
+  defineScenario('wall thickness', '1×1 thin walls + lip + tall (12u)', {
+    assert: 'structural',
+    params: {
+      width: 1,
+      depth: 1,
+      height: 12,
+      wallThickness: 0.4,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    },
   }),
 ];


### PR DESCRIPTION
## Summary

Bundles 9 already-reviewed PRs (#1775–#1783) into a single deploy. Adds 211 new scenario tests across the kernel and designer-store layers, covering:

- **Thin-axis expansion** (#1775) — heights, wallThickness, binStyles, halfSockets, baseStyles with structural+customAssert
- **Permutation matrix** (#1776) — 30 hand-curated N-way feature interaction scenarios
- **Regression locks** (#1777) — 22 reproductions of closed bug issues with bug-specific invariant assertions, including compareWith for #1653
- **Lid + customShape** (#1778) — bin×lid coupling and polygon × scoop/handle/label/lid/slotted combos
- **Solid + cutout matrix** (#1779) — solid mode × label-tab-ignored contract (with compareWith proving mesh-equality), topOffset×cutDepth matrix
- **Designer-store lid actions** (#1780) — updateLid, compatibility helpers, deep-merge detection
- **Designer-store walls + handles** (#1781) — per-side toggles against non-default defaults, undo/redo through 4-sided sequences
- **Designer-store custom shape** (#1782) — setCellMask CRUD, validation, reshape on dimension change
- **Designer-store workflows** (#1783) — multi-action sequences and undo across feature boundaries

Each constituent PR had its review comments addressed before merging into this integration branch.

## Test plan
- [x] Each constituent PR: \`pnpm run typecheck\` clean + scenario suite green
- [x] All 13 review-driven follow-up commits pushed and addressed
- [ ] CI green on the bundled diff