### PR TITLE
fix(settings): tighten physical unit bounds and add reset

### DIFF
--- a/scripts/i18n-values-allowlist.json
+++ b/scripts/i18n-values-allowlist.json
@@ -1,6 +1,7 @@
 {
   "maxShortValueLength": 3,
   "keys": [
+    "settings.gridfinityStandardMm",
     "auth.providerGithub",
     "auth.providerGoogle",
     "dock.syncStatusOffline",

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -28,6 +28,15 @@ export const CONSTRAINTS = {
   MIN_BIN_HEIGHT: 2, // Minimum bin height in units (1U = base only, no usable cavity)
   MIN_LAYER_HEIGHT: 2, // Minimum layer height in units (1U = socket base only)
   PRINT_GAP_MM: 10, // Gap between bins on print bed
+  // Physical unit bounds. Standard Gridfinity is 42mm grid / 7mm height; the
+  // range here covers half-pitch (21mm) and mini-Gridfinity (25mm) variants
+  // with a small buffer, while rejecting obviously-wrong values like "300".
+  GRID_UNIT_MM_MIN: 20,
+  GRID_UNIT_MM_MAX: 60,
+  GRID_UNIT_MM_DEFAULT: 42,
+  HEIGHT_UNIT_MM_MIN: 3,
+  HEIGHT_UNIT_MM_MAX: 20,
+  HEIGHT_UNIT_MM_DEFAULT: 7,
   // Layout library constraints
   LAYOUTS_MAX: 500, // Max layouts in library (IndexedDB storage)
   LAYOUTS_WARNING_THRESHOLD: 450, // Show warning at this count

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1407,6 +1407,8 @@
   "settings.defaultCategories": "Standard-Kategorien",
   "settings.defaultCategoriesHint": "Kategorien für neue Layouts:",
   "settings.defaultGridUnit": "Rastereinheit",
+  "settings.gridfinityStandardMm": "Standard-Gridfinity: {value}mm",
+  "settings.resetGridfinityStandard": "Auf Standard-Gridfinity zurücksetzen",
   "settings.defaultLayerHeight": "Standard-Lagenhöhe",
   "settings.defaultPreferences": "Standardeinstellungen",
   "settings.defaultPreferencesHint": "Neue Layouts verwenden diese Einstellungen:",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -670,6 +670,8 @@
   "settings.defaultLayerHeight": "Default Layer Height",
   "settings.defaultPrintBedSize": "Print Bed",
   "settings.defaultGridUnit": "Grid Unit",
+  "settings.gridfinityStandardMm": "Standard Gridfinity: {value}mm",
+  "settings.resetGridfinityStandard": "Reset to Gridfinity Standard",
   "settings.copiedFromLayout": "Defaults copied from current layout",
   "settings.confirmResetAll": "Reset all settings to their defaults? This cannot be undone.",
   "settings.resetAllConfirmed": "All settings reset",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -765,6 +765,8 @@ const en: Record<string, string> = {
   'settings.defaultLayerHeight': 'Default Layer Height',
   'settings.defaultPrintBedSize': 'Print Bed',
   'settings.defaultGridUnit': 'Grid Unit',
+  'settings.gridfinityStandardMm': 'Standard Gridfinity: {value}mm',
+  'settings.resetGridfinityStandard': 'Reset to Gridfinity Standard',
   'settings.copiedFromLayout': 'Defaults copied from current layout',
   'settings.confirmResetAll': 'Reset all settings to their defaults? This cannot be undone.',
   'settings.resetAllConfirmed': 'All settings reset',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1407,6 +1407,8 @@
   "settings.defaultCategories": "Categorías Predeterminadas",
   "settings.defaultCategoriesHint": "Categorías usadas al crear nuevos diseños:",
   "settings.defaultGridUnit": "Unidad de rejilla",
+  "settings.gridfinityStandardMm": "Gridfinity estándar: {value}mm",
+  "settings.resetGridfinityStandard": "Restablecer a Gridfinity estándar",
   "settings.defaultLayerHeight": "Altura de capa predeterminada",
   "settings.defaultPreferences": "Preferencias Predeterminadas",
   "settings.defaultPreferencesHint": "Los nuevos diseños usarán esta configuración:",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1407,6 +1407,8 @@
   "settings.defaultCategories": "Catégories par défaut",
   "settings.defaultCategoriesHint": "Catégories utilisées lors de la création de nouveaux layouts :",
   "settings.defaultGridUnit": "Unité de grille",
+  "settings.gridfinityStandardMm": "Gridfinity standard : {value}mm",
+  "settings.resetGridfinityStandard": "Réinitialiser à Gridfinity standard",
   "settings.defaultLayerHeight": "Hauteur de couche par défaut",
   "settings.defaultPreferences": "Préférences par défaut",
   "settings.defaultPreferencesHint": "Les nouveaux layouts utiliseront ces paramètres :",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1407,6 +1407,8 @@
   "settings.defaultCategories": "Standardkategorier",
   "settings.defaultCategoriesHint": "Kategorier brukt ved opprettelse av nye layouts:",
   "settings.defaultGridUnit": "Rutenettenhet",
+  "settings.gridfinityStandardMm": "Standard Gridfinity: {value}mm",
+  "settings.resetGridfinityStandard": "Tilbakestill til standard Gridfinity",
   "settings.defaultLayerHeight": "Standard laghøyde",
   "settings.defaultPreferences": "Standardinnstillinger",
   "settings.defaultPreferencesHint": "Nye layouts vil bruke disse innstillingene:",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1407,6 +1407,8 @@
   "settings.defaultCategories": "Standaard Categorieën",
   "settings.defaultCategoriesHint": "Categorieën gebruikt bij het maken van nieuwe layouts:",
   "settings.defaultGridUnit": "Rastereenheid",
+  "settings.gridfinityStandardMm": "Standaard Gridfinity: {value}mm",
+  "settings.resetGridfinityStandard": "Terugzetten naar standaard Gridfinity",
   "settings.defaultLayerHeight": "Standaard laaghoogte",
   "settings.defaultPreferences": "Standaard voorkeuren",
   "settings.defaultPreferencesHint": "Nieuwe layouts gebruiken deze instellingen:",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1407,6 +1407,8 @@
   "settings.defaultCategories": "Categorias Padrão",
   "settings.defaultCategoriesHint": "Categorias usadas ao criar novos layouts:",
   "settings.defaultGridUnit": "Unidade da grade",
+  "settings.gridfinityStandardMm": "Gridfinity padrão: {value}mm",
+  "settings.resetGridfinityStandard": "Redefinir para Gridfinity padrão",
   "settings.defaultLayerHeight": "Altura padrão da camada",
   "settings.defaultPreferences": "Preferências Padrão",
   "settings.defaultPreferencesHint": "Novos layouts usarão estas configurações:",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -611,6 +611,8 @@
   "settings.defaultLayerHeight": "Standardlagerhöjd",
   "settings.defaultPrintBedSize": "Utskriftsbädd",
   "settings.defaultGridUnit": "Rutnätsenhet",
+  "settings.gridfinityStandardMm": "Standard Gridfinity: {value}mm",
+  "settings.resetGridfinityStandard": "Återställ till standard Gridfinity",
   "settings.copiedFromLayout": "Standardvärden kopierade från nuvarande layout",
   "settings.confirmResetAll": "Återställ alla inställningar till standard? Detta kan inte ångras.",
   "settings.resetAllConfirmed": "Alla inställningar återställda",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -611,6 +611,8 @@
   "settings.defaultLayerHeight": "Стандартна висота шару",
   "settings.defaultPrintBedSize": "Друкарський стіл",
   "settings.defaultGridUnit": "Одиниця сітки",
+  "settings.gridfinityStandardMm": "Стандарт Gridfinity: {value}мм",
+  "settings.resetGridfinityStandard": "Скинути до стандарту Gridfinity",
   "settings.copiedFromLayout": "Стандартні налаштування скопійовано з поточної розкладки",
   "settings.confirmResetAll": "Скинути всі налаштування до стандартних? Цю дію неможливо скасувати.",
   "settings.resetAllConfirmed": "Усі налаштування скинуто",

--- a/src/shared/components/DeferredNumberInput/DeferredNumberInput.test.tsx
+++ b/src/shared/components/DeferredNumberInput/DeferredNumberInput.test.tsx
@@ -155,6 +155,19 @@ describe('DeferredNumberInput', () => {
       expect(mockOnChange).not.toHaveBeenCalled();
       expect(input).toHaveDisplayValue('5');
     });
+
+    it('does not clamp on focus+blur of an out-of-range value when the user did not edit', () => {
+      // Legacy persisted value (300) sits outside the new bounds. Focusing and
+      // blurring without typing must NOT silently rewrite the stored value.
+      render(<DeferredNumberInput {...defaultProps} value={300} max={60} />);
+
+      const input = screen.getByRole('spinbutton');
+      fireEvent.focus(input);
+      fireEvent.blur(input);
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+      expect(input).toHaveDisplayValue('300');
+    });
   });
 
   describe('committing on Enter', () => {

--- a/src/shared/components/DeferredNumberInput/DeferredNumberInput.tsx
+++ b/src/shared/components/DeferredNumberInput/DeferredNumberInput.tsx
@@ -46,6 +46,11 @@ export function DeferredNumberInput({
   }
 
   const commit = useCallback(() => {
+    // Skip when text is unchanged so focus+blur on a value that's now out of
+    // the min/max range doesn't silently clamp it and emit an undo entry —
+    // persisted data stays put until the user actually edits.
+    if (localValue === formatValue(value)) return;
+
     const parsed = parseFloat(localValue);
     if (!isNaN(parsed)) {
       const clamped = Math.max(min, Math.min(max, parsed));

--- a/src/shared/hooks/useDrawerSettings.test.ts
+++ b/src/shared/hooks/useDrawerSettings.test.ts
@@ -411,6 +411,24 @@ describe('useDrawerSettings', () => {
 
       expect(result.current.printBedSize).toBe(300);
     });
+
+    it('resetGridfinityStandard restores 42mm/7mm from non-standard values', () => {
+      const { result } = renderHook(() => useDrawerSettings());
+
+      act(() => {
+        result.current.setGridUnitMm(50);
+        result.current.setHeightUnitMm(10);
+      });
+      expect(result.current.gridUnitMm).toBe(50);
+      expect(result.current.heightUnitMm).toBe(10);
+
+      act(() => {
+        result.current.resetGridfinityStandard();
+      });
+
+      expect(result.current.gridUnitMm).toBe(CONSTRAINTS.GRID_UNIT_MM_DEFAULT);
+      expect(result.current.heightUnitMm).toBe(CONSTRAINTS.HEIGHT_UNIT_MM_DEFAULT);
+    });
   });
 
   describe('computed values', () => {

--- a/src/shared/hooks/useDrawerSettings.ts
+++ b/src/shared/hooks/useDrawerSettings.ts
@@ -88,6 +88,7 @@ export interface UseDrawerSettingsReturn {
   setGridUnitMm: (value: number) => void;
   setHeightUnitMm: (value: number) => void;
   setPrintBedSize: (value: number, depth?: number) => void;
+  resetGridfinityStandard: () => void;
 
   // STL site toggle
   toggleSTLSite: (siteId: string) => void;
@@ -363,6 +364,13 @@ export function useDrawerSettings(): UseDrawerSettingsReturn {
     activeLayerHeight,
   ]);
 
+  const resetGridfinityStandard = useCallback(() => {
+    batch(() => {
+      setGridUnitMm(CONSTRAINTS.GRID_UNIT_MM_DEFAULT);
+      setHeightUnitMm(CONSTRAINTS.HEIGHT_UNIT_MM_DEFAULT);
+    });
+  }, [setGridUnitMm, setHeightUnitMm]);
+
   // Save current categories as defaults
   const handleSaveCategoriesAsDefaults = useCallback(() => {
     saveCategoriesAsDefaults(currentCategories);
@@ -426,6 +434,7 @@ export function useDrawerSettings(): UseDrawerSettingsReturn {
     setGridUnitMm,
     setHeightUnitMm,
     setPrintBedSize,
+    resetGridfinityStandard,
     toggleSTLSite,
 
     showSaveDefaultsConfirm,

--- a/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
+++ b/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
@@ -57,6 +57,7 @@ export function MobileSettingsPanel() {
     setGridUnitMm,
     setHeightUnitMm,
     setPrintBedSize,
+    resetGridfinityStandard,
     showSaveDefaultsConfirm,
     setShowSaveDefaultsConfirm,
     showHalfBinBlockedModal,
@@ -164,25 +165,39 @@ export function MobileSettingsPanel() {
         <SectionHeader title={t('settings.gridSettings')} />
 
         <div className="space-y-3">
-          <SettingsRow label="1 grid unit" unit="mm" variant="mobile">
-            <DeferredNumberInput
-              value={gridUnitMm}
-              onChange={setGridUnitMm}
-              className="input w-20 h-10 text-center"
-              min={1}
-              max={200}
-            />
-          </SettingsRow>
+          <div>
+            <SettingsRow label="1 grid unit" unit="mm" variant="mobile">
+              <DeferredNumberInput
+                value={gridUnitMm}
+                onChange={setGridUnitMm}
+                className="input w-20 h-10 text-center"
+                min={CONSTRAINTS.GRID_UNIT_MM_MIN}
+                max={CONSTRAINTS.GRID_UNIT_MM_MAX}
+              />
+            </SettingsRow>
+            <p className="text-xs text-content-tertiary mt-1">
+              {t('settings.gridfinityStandardMm', {
+                value: CONSTRAINTS.GRID_UNIT_MM_DEFAULT,
+              })}
+            </p>
+          </div>
 
-          <SettingsRow label="1u height" unit="mm" variant="mobile">
-            <DeferredNumberInput
-              value={heightUnitMm}
-              onChange={setHeightUnitMm}
-              className="input w-20 h-10 text-center"
-              min={1}
-              max={50}
-            />
-          </SettingsRow>
+          <div>
+            <SettingsRow label="1u height" unit="mm" variant="mobile">
+              <DeferredNumberInput
+                value={heightUnitMm}
+                onChange={setHeightUnitMm}
+                className="input w-20 h-10 text-center"
+                min={CONSTRAINTS.HEIGHT_UNIT_MM_MIN}
+                max={CONSTRAINTS.HEIGHT_UNIT_MM_MAX}
+              />
+            </SettingsRow>
+            <p className="text-xs text-content-tertiary mt-1">
+              {t('settings.gridfinityStandardMm', {
+                value: CONSTRAINTS.HEIGHT_UNIT_MM_DEFAULT,
+              })}
+            </p>
+          </div>
 
           <SettingsRow label="Print bed size" unit="mm" variant="mobile">
             <PrintBedInput
@@ -192,6 +207,18 @@ export function MobileSettingsPanel() {
               variant="mobile"
             />
           </SettingsRow>
+
+          <button
+            type="button"
+            onClick={resetGridfinityStandard}
+            disabled={
+              gridUnitMm === CONSTRAINTS.GRID_UNIT_MM_DEFAULT &&
+              heightUnitMm === CONSTRAINTS.HEIGHT_UNIT_MM_DEFAULT
+            }
+            className="w-full text-sm py-2 px-3 rounded-lg text-content-secondary hover:text-content hover:bg-surface-hover border border-stroke-subtle transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-content-secondary disabled:hover:bg-transparent"
+          >
+            {t('settings.resetGridfinityStandard')}
+          </button>
 
           <div className="text-sm text-right text-content-disabled">
             {t('mobile.settings.maxBinSize')}

--- a/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
@@ -183,18 +183,31 @@ export function DefaultsTab() {
               variant="compact"
             />
           </SettingsRow>
-          <SettingsRow label={t('settings.defaultGridUnit')} htmlFor="defaultGridUnit" unit="mm">
-            <DeferredNumberInput
-              id="defaultGridUnit"
-              value={settings.defaultGridUnitMm}
-              onChange={(value) =>
-                updateSetting('defaultGridUnitMm', Math.max(1, Math.min(200, value)))
-              }
-              min={1}
-              max={200}
-              className="input w-14 py-0.5 px-1 text-xs text-right"
-            />
-          </SettingsRow>
+          <div>
+            <SettingsRow label={t('settings.defaultGridUnit')} htmlFor="defaultGridUnit" unit="mm">
+              <DeferredNumberInput
+                id="defaultGridUnit"
+                value={settings.defaultGridUnitMm}
+                onChange={(value) =>
+                  updateSetting(
+                    'defaultGridUnitMm',
+                    Math.max(
+                      CONSTRAINTS.GRID_UNIT_MM_MIN,
+                      Math.min(CONSTRAINTS.GRID_UNIT_MM_MAX, value)
+                    )
+                  )
+                }
+                min={CONSTRAINTS.GRID_UNIT_MM_MIN}
+                max={CONSTRAINTS.GRID_UNIT_MM_MAX}
+                className="input w-14 py-0.5 px-1 text-xs text-right"
+              />
+            </SettingsRow>
+            <p className="text-[10px] text-content-tertiary mt-0.5">
+              {t('settings.gridfinityStandardMm', {
+                value: CONSTRAINTS.GRID_UNIT_MM_DEFAULT,
+              })}
+            </p>
+          </div>
         </div>
 
         {/* Copy from current layout */}

--- a/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
@@ -188,15 +188,7 @@ export function DefaultsTab() {
               <DeferredNumberInput
                 id="defaultGridUnit"
                 value={settings.defaultGridUnitMm}
-                onChange={(value) =>
-                  updateSetting(
-                    'defaultGridUnitMm',
-                    Math.max(
-                      CONSTRAINTS.GRID_UNIT_MM_MIN,
-                      Math.min(CONSTRAINTS.GRID_UNIT_MM_MAX, value)
-                    )
-                  )
-                }
+                onChange={(value) => updateSetting('defaultGridUnitMm', value)}
                 min={CONSTRAINTS.GRID_UNIT_MM_MIN}
                 max={CONSTRAINTS.GRID_UNIT_MM_MAX}
                 className="input w-14 py-0.5 px-1 text-xs text-right"

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -93,6 +93,7 @@ export function Sidebar() {
     setGridUnitMm,
     setHeightUnitMm,
     setPrintBedSize,
+    resetGridfinityStandard,
     showHalfBinBlockedModal,
     setShowHalfBinBlockedModal,
     halfBinViolation,
@@ -459,11 +460,16 @@ export function Sidebar() {
                         id="gridUnit"
                         value={gridUnitMm}
                         onChange={setGridUnitMm}
-                        min={1}
-                        max={200}
+                        min={CONSTRAINTS.GRID_UNIT_MM_MIN}
+                        max={CONSTRAINTS.GRID_UNIT_MM_MAX}
                         className="input w-14 py-0.5 px-1 text-xs text-right"
                       />
                     </SettingsRow>
+                    <p className="text-[10px] text-content-tertiary mt-0.5">
+                      {t('settings.gridfinityStandardMm', {
+                        value: CONSTRAINTS.GRID_UNIT_MM_DEFAULT,
+                      })}
+                    </p>
                   </div>
                   <div data-help-target="height-unit">
                     <SettingsRow
@@ -476,11 +482,16 @@ export function Sidebar() {
                         id="heightUnit"
                         value={heightUnitMm}
                         onChange={setHeightUnitMm}
-                        min={1}
-                        max={50}
+                        min={CONSTRAINTS.HEIGHT_UNIT_MM_MIN}
+                        max={CONSTRAINTS.HEIGHT_UNIT_MM_MAX}
                         className="input w-14 py-0.5 px-1 text-xs text-right"
                       />
                     </SettingsRow>
+                    <p className="text-[10px] text-content-tertiary mt-0.5">
+                      {t('settings.gridfinityStandardMm', {
+                        value: CONSTRAINTS.HEIGHT_UNIT_MM_DEFAULT,
+                      })}
+                    </p>
                   </div>
                   <div data-help-target="print-bed-size">
                     <SettingsRow
@@ -498,6 +509,17 @@ export function Sidebar() {
                       />
                     </SettingsRow>
                   </div>
+                  <button
+                    type="button"
+                    onClick={resetGridfinityStandard}
+                    disabled={
+                      gridUnitMm === CONSTRAINTS.GRID_UNIT_MM_DEFAULT &&
+                      heightUnitMm === CONSTRAINTS.HEIGHT_UNIT_MM_DEFAULT
+                    }
+                    className="w-full text-[11px] py-1.5 px-2 mt-1 rounded text-content-tertiary hover:text-content hover:bg-surface-hover border border-stroke-subtle transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-content-tertiary disabled:hover:bg-transparent"
+                  >
+                    {t('settings.resetGridfinityStandard')}
+                  </button>
                 </div>
               </CollapsibleSection>
             </div>


### PR DESCRIPTION
## Summary

- Tighten grid unit bounds **1-200mm → 20-60mm** and height unit **1-50mm → 3-20mm**. Covers Gridfinity Standard (42/7), half-pitch (21/7), and mini-Gridfinity (25/7); rejects obvious nonsense like a 300mm grid unit.
- Add "Standard Gridfinity: Nmm" helper text below each input in Sidebar, MobileSettingsPanel, and the Settings → Defaults tab.
- Add "Reset to Gridfinity Standard" button (disabled when already at 42/7) in Sidebar and MobileSettingsPanel.

Driven by a real user typing 300/500 into these fields — bounds + helper + reset together solve both *"what does this mean?"* and *"how do I undo this?"*.

## Behaviour notes

- Clamping happens at commit time via `DeferredNumberInput`'s built-in `min`/`max`.
- Reset is atomic via the existing CQRS `batch()` (undoable like any other unit change).
- **Existing layouts with out-of-bound values are not migrated** — clamping only fires when the user next edits the input. Avoids silent mutation of persisted data.

## Test plan

- [ ] Type `300` into grid unit → clamps to `60` on blur
- [ ] Type `500` into height unit → clamps to `20` on blur
- [ ] Reset button restores both fields to `42` / `7`
- [ ] Reset button is disabled when already at `42` / `7`
- [ ] Helper text renders correctly in all 9 locales
- [ ] Loading a legacy layout with `gridUnitMm: 300` still displays `300` (no auto-clamp on load)