### PR TITLE
feat(analytics): emit per-cache hit rates in generation_cache_stats

### DIFF
--- a/src/shared/analytics/posthog/eventsPerformance.test.ts
+++ b/src/shared/analytics/posthog/eventsPerformance.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const trackEventMock = vi.fn();
+
+vi.mock('./trackEvent', () => ({
+  trackEvent: (name: string, properties?: Record<string, unknown>) => {
+    trackEventMock(name, properties);
+  },
+  getDeviceType: () => 'desktop',
+}));
+
+import { trackCachePerformance } from './eventsPerformance';
+
+beforeEach(() => {
+  trackEventMock.mockReset();
+});
+
+describe('trackCachePerformance', () => {
+  it('emits aggregate properties without per-cache fields when per_cache is omitted', () => {
+    trackCachePerformance({
+      total_hits: 12,
+      total_misses: 4,
+      total_evictions: 1,
+      hit_rate: 0.75,
+      cache_count: 3,
+    });
+
+    expect(trackEventMock).toHaveBeenCalledWith('generation_cache_stats', {
+      total_hits: 12,
+      total_misses: 4,
+      total_evictions: 1,
+      hit_rate: 0.75,
+      cache_count: 3,
+    });
+  });
+
+  it('flattens per-cache hit rate and evictions into top-level properties', () => {
+    trackCachePerformance({
+      total_hits: 10,
+      total_misses: 10,
+      total_evictions: 2,
+      hit_rate: 0.5,
+      cache_count: 2,
+      per_cache: [
+        { name: 'socket', hits: 8, misses: 2, evictions: 0, size: 5, maxSize: 20 },
+        { name: 'shell', hits: 2, misses: 8, evictions: 2, size: 5, maxSize: 15 },
+      ],
+    });
+
+    expect(trackEventMock).toHaveBeenCalledWith('generation_cache_stats', {
+      total_hits: 10,
+      total_misses: 10,
+      total_evictions: 2,
+      hit_rate: 0.5,
+      cache_count: 2,
+      cache_socket_hit_rate: 0.8,
+      cache_socket_evictions: 0,
+      cache_shell_hit_rate: 0.2,
+      cache_shell_evictions: 2,
+    });
+  });
+
+  it('replaces hyphens in cache names with underscores so PostHog keys stay ergonomic', () => {
+    trackCachePerformance({
+      total_hits: 4,
+      total_misses: 0,
+      total_evictions: 0,
+      hit_rate: 1,
+      cache_count: 1,
+      per_cache: [
+        { name: 'baseplate-mesh-result', hits: 4, misses: 0, evictions: 0, size: 1, maxSize: 32 },
+      ],
+    });
+
+    const props = trackEventMock.mock.calls[0]?.[1] as Record<string, number>;
+    expect(props).toHaveProperty('cache_baseplate_mesh_result_hit_rate', 1);
+    expect(props).not.toHaveProperty('cache_baseplate-mesh-result_hit_rate');
+  });
+
+  it('skips caches with zero activity to avoid NaN', () => {
+    trackCachePerformance({
+      total_hits: 5,
+      total_misses: 0,
+      total_evictions: 0,
+      hit_rate: 1,
+      cache_count: 2,
+      per_cache: [
+        { name: 'used', hits: 5, misses: 0, evictions: 0, size: 1, maxSize: 10 },
+        { name: 'idle', hits: 0, misses: 0, evictions: 0, size: 0, maxSize: 10 },
+      ],
+    });
+
+    const props = trackEventMock.mock.calls[0]?.[1] as Record<string, number>;
+    expect(props).toHaveProperty('cache_used_hit_rate', 1);
+    expect(props).not.toHaveProperty('cache_idle_hit_rate');
+  });
+});

--- a/src/shared/analytics/posthog/eventsPerformance.test.ts
+++ b/src/shared/analytics/posthog/eventsPerformance.test.ts
@@ -61,7 +61,7 @@ describe('trackCachePerformance', () => {
     });
   });
 
-  it('replaces hyphens in cache names with underscores so PostHog keys stay ergonomic', () => {
+  it('normalises any non-alphanumeric character so PostHog keys stay ergonomic', () => {
     trackCachePerformance({
       total_hits: 4,
       total_misses: 0,
@@ -70,12 +70,33 @@ describe('trackCachePerformance', () => {
       cache_count: 1,
       per_cache: [
         { name: 'baseplate-mesh-result', hits: 4, misses: 0, evictions: 0, size: 1, maxSize: 32 },
+        { name: 'Feature.Builder (v2)', hits: 2, misses: 0, evictions: 0, size: 1, maxSize: 10 },
       ],
     });
 
     const props = trackEventMock.mock.calls[0]?.[1] as Record<string, number>;
     expect(props).toHaveProperty('cache_baseplate_mesh_result_hit_rate', 1);
+    expect(props).toHaveProperty('cache_feature_builder_v2_hit_rate', 1);
     expect(props).not.toHaveProperty('cache_baseplate-mesh-result_hit_rate');
+  });
+
+  it('drops colliding entries and records the collision count for HogQL visibility', () => {
+    trackCachePerformance({
+      total_hits: 6,
+      total_misses: 4,
+      total_evictions: 0,
+      hit_rate: 0.6,
+      cache_count: 2,
+      per_cache: [
+        { name: 'feature-socket', hits: 4, misses: 0, evictions: 0, size: 1, maxSize: 10 },
+        { name: 'feature_socket', hits: 2, misses: 4, evictions: 5, size: 1, maxSize: 10 },
+      ],
+    });
+
+    const props = trackEventMock.mock.calls[0]?.[1] as Record<string, number>;
+    expect(props).toHaveProperty('cache_feature_socket_hit_rate', 1);
+    expect(props).toHaveProperty('cache_feature_socket_evictions', 0);
+    expect(props).toHaveProperty('cache_key_collisions', 1);
   });
 
   it('skips caches with zero activity to avoid NaN', () => {

--- a/src/shared/analytics/posthog/eventsPerformance.ts
+++ b/src/shared/analytics/posthog/eventsPerformance.ts
@@ -9,7 +9,11 @@
 import type { WorkerCacheStats } from '@/shared/types/generation';
 import { trackEvent } from './trackEvent';
 
-const toCacheKey = (name: string): string => name.replace(/-/g, '_');
+const toCacheKey = (name: string): string =>
+  name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '');
 
 /**
  * Track WASM threading status when generation bridge initializes.
@@ -46,13 +50,21 @@ export function trackCachePerformance(stats: {
     cache_count: stats.cache_count,
   };
 
+  const seenKeys = new Set<string>();
+  let collisions = 0;
   for (const c of stats.per_cache ?? []) {
     const total = c.hits + c.misses;
     if (total === 0) continue;
     const key = toCacheKey(c.name);
+    if (seenKeys.has(key)) {
+      collisions++;
+      continue;
+    }
+    seenKeys.add(key);
     properties[`cache_${key}_hit_rate`] = Math.round((c.hits / total) * 1000) / 1000;
     properties[`cache_${key}_evictions`] = c.evictions;
   }
+  if (collisions > 0) properties.cache_key_collisions = collisions;
 
   trackEvent('generation_cache_stats', properties);
 }

--- a/src/shared/analytics/posthog/eventsPerformance.ts
+++ b/src/shared/analytics/posthog/eventsPerformance.ts
@@ -6,7 +6,10 @@
  * preview's two-stage timing (direct mesh vs. final BREP).
  */
 
+import type { WorkerCacheStats } from '@/shared/types/generation';
 import { trackEvent } from './trackEvent';
+
+const toCacheKey = (name: string): string => name.replace(/-/g, '_');
 
 /**
  * Track WASM threading status when generation bridge initializes.
@@ -22,6 +25,10 @@ export function trackWasmThreadingStatus(isThreaded: boolean, hardwareConcurrenc
 /**
  * Track generation cache performance for capacity planning.
  * Called after each geometry generation with per-generation hit/miss/eviction deltas.
+ *
+ * Per-cache hit_rate and evictions are flattened into top-level properties
+ * (`cache_<name>_hit_rate`, `cache_<name>_evictions`) so PostHog filters/aggregates
+ * can identify which cache is dragging the aggregate hit rate down.
  */
 export function trackCachePerformance(stats: {
   total_hits: number;
@@ -29,14 +36,25 @@ export function trackCachePerformance(stats: {
   total_evictions: number;
   hit_rate: number;
   cache_count: number;
+  per_cache?: readonly WorkerCacheStats[];
 }): void {
-  trackEvent('generation_cache_stats', {
+  const properties: Record<string, number> = {
     total_hits: stats.total_hits,
     total_misses: stats.total_misses,
     total_evictions: stats.total_evictions,
     hit_rate: stats.hit_rate,
     cache_count: stats.cache_count,
-  });
+  };
+
+  for (const c of stats.per_cache ?? []) {
+    const total = c.hits + c.misses;
+    if (total === 0) continue;
+    const key = toCacheKey(c.name);
+    properties[`cache_${key}_hit_rate`] = Math.round((c.hits / total) * 1000) / 1000;
+    properties[`cache_${key}_evictions`] = c.evictions;
+  }
+
+  trackEvent('generation_cache_stats', properties);
 }
 
 const toSnakeCase = (s: string): string => s.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);

--- a/src/shared/types/generation.ts
+++ b/src/shared/types/generation.ts
@@ -5,5 +5,10 @@
  * This barrel export allows other features (e.g., bin-designer) to
  * depend on these types without a cross-feature import violation.
  */
-export type { FaceGroupData, CoarseLODData, LidMeshData } from '@/features/generation/bridge/types';
+export type {
+  FaceGroupData,
+  CoarseLODData,
+  LidMeshData,
+  WorkerCacheStats,
+} from '@/features/generation/bridge/types';
 export { FeatureTag } from '@/features/generation/worker/generators/featureTags';


### PR DESCRIPTION
## Summary

- `GenerationBridge.handleCacheStats()` already builds `per_cache: WorkerCacheStats[]`, but `trackCachePerformance` only forwarded aggregate fields — so the **"which cache is missing"** investigation from #1788 idea (1) was unanswerable from PostHog.
- Flattens per-cache `hit_rate` and `evictions` into top-level event properties: `cache_<name>_hit_rate`, `cache_<name>_evictions`.
- Names are normalized (`-` → `_`, e.g. `baseplate-mesh-result` → `baseplate_mesh_result`) so HogQL doesn't need to bracket-quote keys on every query.
- Zero-activity caches are skipped to avoid `NaN` and property bloat.

## Why now

Posted empirical analysis on #1788 ([comment](https://github.com/andymai/gridfinity-layout-tool/issues/1788#issuecomment-4500168951)): session-weighted hit rate is **62.3%** (well below the 85% gate the issue set), and p95 boolean ops dominate the long tail at **1,418 ms** vs tessellate at 562 ms. The headline recommendation in the issue (progressive LOD) doesn't address the dominant bottleneck — but to make the cache-side investigation actionable we need per-cache visibility, which this PR adds. The next concrete step is boolean batch bisection (issue idea 4), pending review of the reprioritization.

## Test plan

- [x] `pnpm run test:run -- src/shared/analytics/posthog/eventsPerformance.test.ts` — 4 new sibling tests cover: aggregate-only path, per-cache flattening, hyphen normalization, zero-activity skip.
- [x] `pnpm run typecheck` clean.
- [x] Full vitest suite green (11,558 passed).
- [ ] After merge: wait ~1–2 days for events to accumulate, then run a HogQL aggregate over `cache_*_hit_rate` properties to confirm which cache is dragging the aggregate down.