### PR TITLE
feat(analytics): instrument boolean batch fallbacks (step 1 of #1792)

### DIFF
--- a/src/features/baseplate/hooks/useBaseplateGeneration.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.ts
@@ -33,6 +33,7 @@ import {
   trackWasmThreadingStatus,
   trackCachePerformance,
   trackKernelPerformance,
+  trackBooleanFallbacks,
   trackBaseplatePreviewTiming,
 } from '@/shared/analytics/posthog';
 import { useToastStore } from '@/core/store/toast';
@@ -489,6 +490,7 @@ export function useBaseplateGeneration(): void {
         // Wire up cache stats and kernel perf reporting to PostHog
         bridge.onCacheStats = trackCachePerformance;
         bridge.onKernelPerfStats = trackKernelPerformance;
+        bridge.onBooleanFallbackStats = trackBooleanFallbacks;
 
         // Acquire shared worker pool in the background (don't block initial generation)
         void workerPoolManager

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -9,6 +9,7 @@ import {
   trackWasmThreadingStatus,
   trackCachePerformance,
   trackKernelPerformance,
+  trackBooleanFallbacks,
 } from '@/shared/analytics/posthog';
 import type { BinParams } from '../types';
 
@@ -140,6 +141,7 @@ export function useGeneration(): void {
         // Wire up cache stats and kernel perf reporting to PostHog
         bridge.onCacheStats = trackCachePerformance;
         bridge.onKernelPerfStats = trackKernelPerformance;
+        bridge.onBooleanFallbackStats = trackBooleanFallbacks;
 
         // Trigger initial generation
         const currentState = useDesignerStore.getState();

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -36,6 +36,7 @@ import {
   type BaseplateExportResult,
   type CacheStatsCallback,
   type KernelPerfStatsCallback,
+  type BooleanFallbackStatsCallback,
   type ThreadingInfo,
   type DedupCache,
   type ExportSlot,
@@ -68,6 +69,8 @@ export type {
   CacheStatsCallback,
   KernelPerfStatsPayload,
   KernelPerfStatsCallback,
+  BooleanFallbackStatsPayload,
+  BooleanFallbackStatsCallback,
   ThreadingInfo,
 } from './bridgeTypes';
 export { ExportTimeoutError } from './bridgeTypes';
@@ -96,6 +99,9 @@ export class GenerationBridge {
 
   /** Optional callback for kernel performance stats (called after each generation). */
   onKernelPerfStats: KernelPerfStatsCallback | null = null;
+
+  /** Optional callback for boolean fallback stats (called after each generation that had ≥1 fallback). */
+  onBooleanFallbackStats: BooleanFallbackStatsCallback | null = null;
 
   /** Pending export requests keyed by slot. Only one per slot at a time. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Values are PendingExport<T> with different T per slot; type safety is enforced at each call site

--- a/src/features/generation/bridge/bridgeMessageHandler.ts
+++ b/src/features/generation/bridge/bridgeMessageHandler.ts
@@ -17,6 +17,7 @@ import type {
   GenerationResult,
   CacheStatsCallback,
   KernelPerfStatsCallback,
+  BooleanFallbackStatsCallback,
   DedupCache,
   ExportSlot,
   PendingExport,
@@ -33,6 +34,7 @@ export interface MessageHandlerContext {
   onProgress: ProgressCallback | null;
   onCacheStats: CacheStatsCallback | null;
   onKernelPerfStats: KernelPerfStatsCallback | null;
+  onBooleanFallbackStats: BooleanFallbackStatsCallback | null;
   readonly adaptiveDebounce: AdaptiveDebounce;
   readonly binCache: DedupCache;
   readonly baseplateCache: DedupCache;
@@ -196,6 +198,10 @@ export function installMessageHandler(ctx: MessageHandlerContext): void {
 
       case 'KERNEL_PERF_STATS':
         ctx.onKernelPerfStats?.({ stats: response.stats });
+        break;
+
+      case 'BOOLEAN_FALLBACK_STATS':
+        ctx.onBooleanFallbackStats?.({ records: response.records });
         break;
 
       case 'INIT_READY':

--- a/src/features/generation/bridge/bridgeTypes.ts
+++ b/src/features/generation/bridge/bridgeTypes.ts
@@ -15,6 +15,7 @@ import type {
   FaceGroupData,
   KernelName,
   KernelPerfCategory,
+  BooleanFallbackEntry,
 } from './types';
 
 /** Callback for progress updates during generation */
@@ -84,6 +85,14 @@ export interface KernelPerfStatsPayload {
 
 /** Callback for kernel perf stats reporting */
 export type KernelPerfStatsCallback = (payload: KernelPerfStatsPayload) => void;
+
+/** Payload for boolean fallback stats callback */
+export interface BooleanFallbackStatsPayload {
+  readonly records: readonly BooleanFallbackEntry[];
+}
+
+/** Callback for boolean fallback stats reporting */
+export type BooleanFallbackStatsCallback = (payload: BooleanFallbackStatsPayload) => void;
 
 /** Information about the WASM threading capabilities */
 export interface ThreadingInfo {

--- a/src/features/generation/bridge/types.ts
+++ b/src/features/generation/bridge/types.ts
@@ -211,6 +211,7 @@ export type WorkerResponse =
   | SplitExportResultResponse
   | CacheStatsResponse
   | KernelPerfStatsResponse
+  | BooleanFallbackStatsResponse
   | CleanupDoneResponse
   | ErrorResponse;
 
@@ -246,6 +247,27 @@ export interface KernelPerfStatsResponse {
   readonly type: 'KERNEL_PERF_STATS';
   readonly requestId: string;
   readonly stats: Readonly<Record<string, KernelPerfCategory>>;
+}
+
+/**
+ * Boolean fallback occurrence — one record per batch→sequential fallback.
+ * `category` is the boolean op type, `successfulCount` is how many targets
+ * the sequential pass actually applied (so `targetCount - successfulCount`
+ * is the count that failed both batch and pairwise — usually 1 for
+ * concentrated failures, `targetCount` for structural failures).
+ */
+export interface BooleanFallbackEntry {
+  readonly category: 'fuse' | 'cut' | 'pattern_cut';
+  readonly targetCount: number;
+  readonly successfulCount: number;
+  readonly errorCategory: string;
+}
+
+/** Boolean fallback stats posted after each generation. Empty when no fallback fired. */
+export interface BooleanFallbackStatsResponse {
+  readonly type: 'BOOLEAN_FALLBACK_STATS';
+  readonly requestId: string;
+  readonly records: readonly BooleanFallbackEntry[];
 }
 
 export interface InitReadyResponse {

--- a/src/features/generation/bridge/types.ts
+++ b/src/features/generation/bridge/types.ts
@@ -263,7 +263,11 @@ export interface BooleanFallbackEntry {
   readonly errorCategory: string;
 }
 
-/** Boolean fallback stats posted after each generation. Empty when no fallback fired. */
+/**
+ * Boolean fallback stats posted after a generation if (and only if) at least
+ * one batch→sequential fallback fired. The worker omits this response on the
+ * common no-fallback path to keep main-thread/worker chatter minimal.
+ */
 export interface BooleanFallbackStatsResponse {
   readonly type: 'BOOLEAN_FALLBACK_STATS';
   readonly requestId: string;

--- a/src/features/generation/worker/generators/pipeline/stages/booleanStage.test.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/booleanStage.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  categorizeError,
+  getBooleanFallbackStats,
+  resetBooleanFallbackStats,
+} from './booleanStage';
+
+describe('categorizeError', () => {
+  it('returns the raw message for short OCCT-style errors', () => {
+    expect(categorizeError(new Error('BRepAlgoAPI failed'))).toBe('BRepAlgoAPI failed');
+  });
+
+  it('replaces digit runs with # so identifier-bearing messages collapse to one bucket', () => {
+    expect(
+      categorizeError(new Error('Standard_ConstructionError: face 42 incompatible with face 17'))
+    ).toBe('Standard_ConstructionError: face # incompatible with face #');
+  });
+
+  it('collapses runs of whitespace so wrapped or tabbed messages stay stable', () => {
+    expect(categorizeError(new Error('a\n\tb   c'))).toBe('a b c');
+  });
+
+  it('truncates to 120 chars so a single mega-error cannot expand cardinality', () => {
+    const long = 'x'.repeat(500);
+    expect(categorizeError(new Error(long))).toHaveLength(120);
+  });
+
+  it('stringifies non-Error throwables for tolerance', () => {
+    expect(categorizeError('plain string error')).toBe('plain string error');
+    expect(categorizeError(42)).toBe('#');
+  });
+});
+
+describe('boolean fallback stats', () => {
+  it('starts empty and resets to empty', () => {
+    resetBooleanFallbackStats();
+    expect(getBooleanFallbackStats()).toEqual([]);
+    resetBooleanFallbackStats();
+    expect(getBooleanFallbackStats()).toEqual([]);
+  });
+});

--- a/src/features/generation/worker/generators/pipeline/stages/booleanStage.test.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/booleanStage.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { beforeEach, describe, it, expect } from 'vitest';
 import {
+  type BooleanFallbackRecord,
   categorizeError,
   getBooleanFallbackStats,
   resetBooleanFallbackStats,
@@ -32,10 +33,24 @@ describe('categorizeError', () => {
 });
 
 describe('boolean fallback stats', () => {
-  it('starts empty and resets to empty', () => {
+  beforeEach(() => {
     resetBooleanFallbackStats();
+  });
+
+  it('starts empty and resets to empty', () => {
     expect(getBooleanFallbackStats()).toEqual([]);
     resetBooleanFallbackStats();
+    expect(getBooleanFallbackStats()).toEqual([]);
+  });
+
+  it('returns a defensive copy so callers cannot mutate the internal accumulator', () => {
+    const snapshot = getBooleanFallbackStats() as BooleanFallbackRecord[];
+    snapshot.push({
+      category: 'cut',
+      targetCount: 1,
+      successfulCount: 0,
+      errorCategory: 'mutation attempt',
+    });
     expect(getBooleanFallbackStats()).toEqual([]);
   });
 });

--- a/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
@@ -33,7 +33,7 @@ export interface BooleanFallbackRecord {
 let fallbackRecords: BooleanFallbackRecord[] = [];
 
 export function getBooleanFallbackStats(): readonly BooleanFallbackRecord[] {
-  return fallbackRecords;
+  return fallbackRecords.slice();
 }
 
 export function resetBooleanFallbackStats(): void {

--- a/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
@@ -15,13 +15,50 @@ import type { PipelineContext, PipelineStage } from '../types';
 import type { BooleanOpts } from '../../meshUtils';
 import { checkCancelled, isAbortError } from '../../utils/abort';
 
+export type BooleanFallbackCategory = 'fuse' | 'cut' | 'pattern_cut';
+
+/**
+ * Records one batch→sequential fallback event. The histogram of `targetCount`
+ * vs `successfulCount` is what tells us whether failures are concentrated
+ * (1 bad tool → `successfulCount = targetCount - 1`) or structural
+ * (`successfulCount = 0` → every sequential op also failed).
+ */
+export interface BooleanFallbackRecord {
+  readonly category: BooleanFallbackCategory;
+  readonly targetCount: number;
+  readonly successfulCount: number;
+  readonly errorCategory: string;
+}
+
+let fallbackRecords: BooleanFallbackRecord[] = [];
+
+export function getBooleanFallbackStats(): readonly BooleanFallbackRecord[] {
+  return fallbackRecords;
+}
+
+export function resetBooleanFallbackStats(): void {
+  fallbackRecords = [];
+}
+
+/**
+ * Strip identifier-like digits and trim so OCCT-style messages
+ * ("BRepAlgoAPI: face 42 incompatible with face 17") collapse to a
+ * stable categorical key in PostHog without exploding cardinality.
+ */
+export function categorizeError(e: unknown): string {
+  const msg = e instanceof Error ? e.message : String(e);
+  return msg.replace(/\d+/g, '#').replace(/\s+/g, ' ').trim().slice(0, 120);
+}
+
 /**
  * Try a batch boolean, falling back to sequential pairwise operations.
  * AbortErrors always propagate; other errors are swallowed per-pair.
+ * Records the fallback (if any) for diagnostics — see #1792.
  */
 function batchWithFallback(
   bin: Shape3D,
   targets: readonly Shape3D[],
+  category: BooleanFallbackCategory,
   batch: (bin: Shape3D, targets: readonly Shape3D[]) => Shape3D,
   pairwise: (bin: Shape3D, target: Shape3D) => Shape3D
 ): Shape3D {
@@ -29,34 +66,41 @@ function batchWithFallback(
     return batch(bin, targets);
   } catch (e: unknown) {
     if (isAbortError(e)) throw e;
+    const errorCategory = categorizeError(e);
     let result = bin;
+    let successfulCount = 0;
     for (const target of targets) {
       try {
         const prev = result;
         result = pairwise(result, target);
-        if (prev !== bin) prev.delete(); // Dispose fallback intermediates (not original bin)
+        if (prev !== bin) prev.delete();
+        successfulCount++;
       } catch (inner: unknown) {
         if (isAbortError(inner)) throw inner;
       }
     }
+    fallbackRecords.push({
+      category,
+      targetCount: targets.length,
+      successfulCount,
+      errorCategory,
+    });
     return result;
   }
 }
 
-/**
- * Apply a cut pass: batch-cut targets from bin, disposing the previous
- * intermediate if it was replaced (and isn't the original solid).
- */
 function applyCutPass(
   bin: Shape3D,
   originalSolid: Shape3D,
   targets: readonly Shape3D[],
+  category: BooleanFallbackCategory,
   opts: BooleanOpts
 ): Shape3D {
   const prev = bin;
   const result = batchWithFallback(
     bin,
     targets,
+    category,
     (b, ts) => unwrap(cutAll(b as ValidSolid, [...ts] as ValidSolid[], opts)),
     (b, t) => unwrap(cut(b as ValidSolid, t as ValidSolid))
   );
@@ -82,9 +126,6 @@ export const booleanStage: PipelineStage = {
 
     checkCancelled(signal);
 
-    // Batch fuseAll/cutAll passes with pairwise fallback. cutAll() compounds
-    // tools into a single boolean, preserving better face topology for complex
-    // bins (e.g., slotted + lip) than booleanPipeline()'s sequential approach.
     const cutOpts = { simplify: forExport, signal } as BooleanOpts;
 
     if (ctx.fuseTargets.length > 0) {
@@ -92,6 +133,7 @@ export const booleanStage: PipelineStage = {
       bin = batchWithFallback(
         bin,
         ctx.fuseTargets,
+        'fuse',
         (b, targets) => unwrap(fuseAll([b, ...targets] as ValidSolid[])),
         (b, t) => unwrap(fuse(b as ValidSolid, t as ValidSolid))
       );
@@ -99,12 +141,12 @@ export const booleanStage: PipelineStage = {
 
     if (ctx.cutTargets.length > 0) {
       checkCancelled(signal);
-      bin = applyCutPass(bin, originalSolid, ctx.cutTargets, cutOpts);
+      bin = applyCutPass(bin, originalSolid, ctx.cutTargets, 'cut', cutOpts);
     }
 
     if (ctx.patternCutTargets.length > 0) {
       checkCancelled(signal);
-      bin = applyCutPass(bin, originalSolid, ctx.patternCutTargets, cutOpts);
+      bin = applyCutPass(bin, originalSolid, ctx.patternCutTargets, 'pattern_cut', cutOpts);
     }
 
     if (bin !== originalSolid) originalSolid.delete();

--- a/src/features/generation/worker/handlers/workerContext.ts
+++ b/src/features/generation/worker/handlers/workerContext.ts
@@ -10,6 +10,10 @@ import { getPerformanceStats, resetPerformanceStats } from 'brepjs';
 import type { WorkerResponse, MeshData, KernelName, ExportErrorCode } from '../../bridge/types';
 import { getAllShapeCacheStats, resetAllShapeCacheStats } from '../generators/shapeCache';
 import { getBaseplateCacheStats, resetBaseplateCacheStats } from '../generators/baseplateGenerator';
+import {
+  getBooleanFallbackStats,
+  resetBooleanFallbackStats,
+} from '../generators/pipeline/stages/booleanStage';
 import { isAbortError } from '../generators/utils/abort';
 
 /** Mutable worker state */
@@ -89,6 +93,7 @@ export function runGeneration(
   try {
     // brepjs perf stats are only meaningful for the opencascade kernel
     if (activeKernel === 'opencascade') resetPerformanceStats();
+    resetBooleanFallbackStats();
     const meshData = generator(signal);
 
     if (activeRequestId !== requestId) return;
@@ -170,6 +175,20 @@ export function runGeneration(
 
     if (activeKernel === 'opencascade') {
       respond({ type: 'KERNEL_PERF_STATS', requestId, stats: kernelPerfStats });
+    }
+
+    const fallbackRecords = getBooleanFallbackStats();
+    if (fallbackRecords.length > 0) {
+      respond({
+        type: 'BOOLEAN_FALLBACK_STATS',
+        requestId,
+        records: fallbackRecords.map((r) => ({
+          category: r.category,
+          targetCount: r.targetCount,
+          successfulCount: r.successfulCount,
+          errorCategory: r.errorCategory,
+        })),
+      });
     }
   } catch (e) {
     if (isAbortError(e)) return;

--- a/src/features/generation/worker/handlers/workerContext.ts
+++ b/src/features/generation/worker/handlers/workerContext.ts
@@ -189,6 +189,7 @@ export function runGeneration(
           errorCategory: r.errorCategory,
         })),
       });
+      resetBooleanFallbackStats();
     }
   } catch (e) {
     if (isAbortError(e)) return;

--- a/src/shared/analytics/posthog/events.ts
+++ b/src/shared/analytics/posthog/events.ts
@@ -52,6 +52,7 @@ export {
   trackWasmThreadingStatus,
   trackCachePerformance,
   trackKernelPerformance,
+  trackBooleanFallbacks,
   trackBaseplatePreviewTiming,
 } from './eventsPerformance';
 

--- a/src/shared/analytics/posthog/eventsPerformance.test.ts
+++ b/src/shared/analytics/posthog/eventsPerformance.test.ts
@@ -10,7 +10,7 @@ vi.mock('./trackEvent', () => ({
   getDeviceType: () => 'desktop',
 }));
 
-import { trackCachePerformance } from './eventsPerformance';
+import { trackBooleanFallbacks, trackCachePerformance } from './eventsPerformance';
 
 beforeEach(() => {
   trackEventMock.mockReset();
@@ -115,5 +115,47 @@ describe('trackCachePerformance', () => {
     const props = trackEventMock.mock.calls[0]?.[1] as Record<string, number>;
     expect(props).toHaveProperty('cache_used_hit_rate', 1);
     expect(props).not.toHaveProperty('cache_idle_hit_rate');
+  });
+});
+
+describe('trackBooleanFallbacks', () => {
+  it('emits no events when no fallbacks fired', () => {
+    trackBooleanFallbacks({ records: [] });
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it('emits one event per fallback record with the diagnostic counts', () => {
+    trackBooleanFallbacks({
+      records: [
+        {
+          category: 'cut',
+          targetCount: 8,
+          successfulCount: 7,
+          errorCategory: 'Standard_ConstructionError: face # incompatible',
+        },
+        {
+          category: 'fuse',
+          targetCount: 3,
+          successfulCount: 0,
+          errorCategory: 'BRepAlgoAPI failed',
+        },
+      ],
+    });
+
+    expect(trackEventMock).toHaveBeenCalledTimes(2);
+    expect(trackEventMock).toHaveBeenNthCalledWith(1, 'generation_boolean_fallback', {
+      op_category: 'cut',
+      target_count: 8,
+      successful_count: 7,
+      failed_count: 1,
+      error_category: 'Standard_ConstructionError: face # incompatible',
+    });
+    expect(trackEventMock).toHaveBeenNthCalledWith(2, 'generation_boolean_fallback', {
+      op_category: 'fuse',
+      target_count: 3,
+      successful_count: 0,
+      failed_count: 3,
+      error_category: 'BRepAlgoAPI failed',
+    });
   });
 });

--- a/src/shared/analytics/posthog/eventsPerformance.ts
+++ b/src/shared/analytics/posthog/eventsPerformance.ts
@@ -93,6 +93,34 @@ export function trackKernelPerformance(payload: {
 }
 
 /**
+ * Track each batch→sequential fallback that fires inside `batchWithFallback`.
+ *
+ * One event per fallback record (zero events on the common path). The
+ * `successful_count` / `target_count` ratio is the diagnostic for #1792:
+ *   `successful = target - 1`  → concentrated failure (bisect wins)
+ *   `successful = 0`           → structural failure (bisect doesn't help)
+ *   anything in between        → mixed; investigate `error_category`.
+ */
+export function trackBooleanFallbacks(payload: {
+  records: ReadonlyArray<{
+    category: 'fuse' | 'cut' | 'pattern_cut';
+    targetCount: number;
+    successfulCount: number;
+    errorCategory: string;
+  }>;
+}): void {
+  for (const r of payload.records) {
+    trackEvent('generation_boolean_fallback', {
+      op_category: r.category,
+      target_count: r.targetCount,
+      successful_count: r.successfulCount,
+      failed_count: r.targetCount - r.successfulCount,
+      error_category: r.errorCategory,
+    });
+  }
+}
+
+/**
  * Track time-to-first-mesh (direct-mesh placeholder) and time-to-final-mesh
  * (BREP) for the baseplate page. Lets us validate the perceived-perf win
  * post-launch and catch regressions if the direct-mesh path stalls.

--- a/src/shared/analytics/posthog/index.ts
+++ b/src/shared/analytics/posthog/index.ts
@@ -53,6 +53,7 @@ export {
   trackWasmThreadingStatus,
   trackCachePerformance,
   trackKernelPerformance,
+  trackBooleanFallbacks,
   trackBaseplatePreviewTiming,
   trackGalleryOpened,
   trackGalleryClosed,


### PR DESCRIPTION
## Summary

First of three steps in #1792 — instrument `batchWithFallback` so we can read from PostHog **which failure mode is actually hitting** before deciding on bisect vs. partitioning vs. detect-and-skip.

The diagnostic we need: for every fallback that fires, does the sequential pass eventually succeed (= concentrated, 1-2 bad tools → bisect wins) or does it also fail (= structural, bisect doesn't help)?

## What this PR does

- `booleanStage.ts` records each batch→sequential fallback into a module-level accumulator: `{ category: 'fuse' | 'cut' | 'pattern_cut', targetCount, successfulCount, errorCategory }`.
- `categorizeError` collapses OCCT-style messages by replacing digit runs with `#` and truncating at 120 chars, so a face-id-varying error like `"BRepAlgoAPI: face 42 incompatible with face 17"` collapses to a stable categorical bucket in PostHog.
- Worker flushes records via a new `BOOLEAN_FALLBACK_STATS` response after each successful generation. Empty array → no response.
- Bridge forwards via a new `onBooleanFallbackStats` callback (mirrors the existing `onCacheStats` / `onKernelPerfStats` pattern).
- Both `useGeneration` hooks (bin designer + baseplate) wire the callback to a new `trackBooleanFallbacks` PostHog emitter that produces **one event per record** (zero events when nothing falls back).

## Diagnostic readback (after a few days of data)

```sql
SELECT op_category, error_category,
       sum(failed_count) as failed,
       sum(target_count) as total,
       sum(failed_count) / sum(target_count) as failure_density,
       count() as fallback_events
FROM events
WHERE event = 'generation_boolean_fallback'
  AND timestamp >= now() - INTERVAL 7 DAY
GROUP BY op_category, error_category
ORDER BY fallback_events DESC
```

A `failure_density` near `1/target_count` confirms concentrated failures (bisect wins). Near `1.0` confirms structural (bisect doesn't help — partitioning by category might).

## Test plan

- [x] `pnpm exec vitest run src/shared/analytics/posthog/eventsPerformance.test.ts src/features/generation/worker/generators/pipeline/stages/booleanStage.test.ts` — 13 tests pass: error categorization (digit collapse, whitespace, truncation, non-Error throwables, raw passthrough), reset semantics, emitter behavior (empty → no event, multiple records → one event each with correct counts).
- [x] `pnpm exec vitest run src/features/generation/bridge` — 104 existing bridge tests still pass (no regressions from new response type).
- [x] `pnpm run typecheck` clean.
- [x] ESLint clean on all 12 modified files.
- [x] Pre-commit hooks green (boundaries, i18n × 3, exhaustiveness, component structure).

## Non-goals

- **No bisect implementation.** That's step 3 of #1792, gated on what this PR's data reveals.
- **No tool partitioning.** That's step 2, also gated on the data.
- **No behavior change** to the success path: `batchWithFallback` returns the same Shape3D as before; only the failure path gains a single accumulator push.