### PR TITLE
fix(bin-designer): handle diagonally-adjacent holes in custom shapes

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.diagonal-holes.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.diagonal-holes.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+/**
+ * Regression for the bug where two empty mask cells touching only diagonally
+ * (a saddle vertex on the polygon boundary) merged into one self-touching
+ * figure-8 hole loop and made the BREP cut produce non-manifold geometry.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+import { buildParams } from './__kernel-tests__/scenarioTypes';
+import { assertStructurallyValid } from './__kernel-tests__/meshAssertions';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { CellMask } from '@/shared/utils/cellMask';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30_000);
+
+// 4×4 mask in half-cells (= 2×2 bin). Two empty half-cells touch only at
+// the corner (1, 1) in grid units: a / saddle.
+const DIAGONAL_HOLES_SLASH: CellMask = {
+  cols: 4,
+  rows: 4,
+  cells: [
+    // row 0 (bottom)
+    1, 1, 1, 1,
+    // row 1
+    1, 1, 0, 1,
+    // row 2
+    1, 0, 1, 1,
+    // row 3 (top)
+    1, 1, 1, 1,
+  ] as (0 | 1)[],
+};
+
+// Same configuration mirrored — empty cells on the \ diagonal.
+const DIAGONAL_HOLES_BACKSLASH: CellMask = {
+  cols: 4,
+  rows: 4,
+  cells: [1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1] as (0 | 1)[],
+};
+
+describe('bin generation with diagonally-adjacent mask holes', () => {
+  it.each([
+    { id: '/-saddle', mask: DIAGONAL_HOLES_SLASH },
+    { id: '\\-saddle', mask: DIAGONAL_HOLES_BACKSLASH },
+  ])('generates a valid mesh for $id custom shape', ({ id, mask }) => {
+    const generateBin = getGenerateBin();
+    const params = buildParams({
+      width: 2,
+      depth: 2,
+      cellMask: mask,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat', stackingLip: false, solid: true },
+    });
+
+    const mesh = generateBin(params, undefined, false);
+    assertStructurallyValid(mesh, id);
+    expect(mesh.triangleCount).toBeGreaterThan(0);
+  });
+});

--- a/src/features/generation/worker/generators/binGenerator.scenario.diagonal-holes.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.diagonal-holes.test.ts
@@ -32,11 +32,20 @@ const DIAGONAL_HOLES_SLASH: CellMask = {
   ] as (0 | 1)[],
 };
 
-// Same configuration mirrored — empty cells on the \ diagonal.
+// Mirror of the / saddle — empties run along the \ diagonal instead.
 const DIAGONAL_HOLES_BACKSLASH: CellMask = {
   cols: 4,
   rows: 4,
-  cells: [1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1] as (0 | 1)[],
+  cells: [
+    // row 0 (bottom)
+    1, 1, 1, 1,
+    // row 1
+    1, 0, 1, 1,
+    // row 2
+    1, 1, 0, 1,
+    // row 3 (top)
+    1, 1, 1, 1,
+  ] as (0 | 1)[],
 };
 
 describe('bin generation with diagonally-adjacent mask holes', () => {

--- a/src/shared/utils/cellMask.test.ts
+++ b/src/shared/utils/cellMask.test.ts
@@ -482,6 +482,65 @@ describe('maskToPolygon', () => {
     expect(Math.min(...holeYs)).toBeCloseTo(0.5);
     expect(Math.max(...holeYs)).toBeCloseTo(1.0);
   });
+
+  // Two empty cells sharing only a corner used to merge into one self-touching
+  // figure-8 loop, breaking downstream BREP cuts. They must come back as two
+  // distinct simple hole loops.
+  it('returns two separate hole loops when two empty cells touch only diagonally (/-saddle)', () => {
+    const m = mask([
+      [1, 1, 1, 1],
+      [1, 0, 1, 1],
+      [1, 1, 0, 1],
+      [1, 1, 1, 1],
+    ]);
+    const loops = maskToPolygon(m);
+    expect(loops).toHaveLength(3);
+    expect(loops[0]).toHaveLength(4);
+
+    const holes = loops.slice(1);
+    for (const hole of holes) {
+      expect(hole).toHaveLength(4);
+      expect(new Set(hole.map((p) => `${p.x},${p.y}`)).size).toBe(4);
+    }
+
+    const bounds = holes
+      .map((h) => ({
+        minX: Math.min(...h.map((p) => p.x)),
+        maxX: Math.max(...h.map((p) => p.x)),
+        minY: Math.min(...h.map((p) => p.y)),
+        maxY: Math.max(...h.map((p) => p.y)),
+      }))
+      .sort((a, b) => a.minX - b.minX || a.minY - b.minY);
+
+    expect(bounds[0]).toEqual({
+      minX: expect.closeTo(0.5),
+      maxX: expect.closeTo(1.0),
+      minY: expect.closeTo(1.0),
+      maxY: expect.closeTo(1.5),
+    });
+    expect(bounds[1]).toEqual({
+      minX: expect.closeTo(1.0),
+      maxX: expect.closeTo(1.5),
+      minY: expect.closeTo(0.5),
+      maxY: expect.closeTo(1.0),
+    });
+  });
+
+  it('returns two separate hole loops for the mirror \\-saddle configuration', () => {
+    const m = mask([
+      [1, 1, 1, 1],
+      [1, 1, 0, 1],
+      [1, 0, 1, 1],
+      [1, 1, 1, 1],
+    ]);
+    const loops = maskToPolygon(m);
+    expect(loops).toHaveLength(3);
+
+    for (const hole of loops.slice(1)) {
+      expect(hole).toHaveLength(4);
+      expect(new Set(hole.map((p) => `${p.x},${p.y}`)).size).toBe(4);
+    }
+  });
 });
 
 describe('classifyShape', () => {

--- a/src/shared/utils/cellMask.ts
+++ b/src/shared/utils/cellMask.ts
@@ -327,8 +327,29 @@ export function maskToPolygon(mask: CellMask): readonly MaskLoop[] {
   }
 
   const key = (x: number, y: number): string => `${x},${y}`;
-  const byStart = new Map<string, Edge>();
-  for (const e of edges) byStart.set(key(e.fx, e.fy), e);
+  // Saddle handling: at the corner shared by two diagonally-adjacent empty
+  // cells, two outgoing edges start from the same vertex. Group by start so
+  // both candidates survive (a plain Map would overwrite one).
+  const byStart = new Map<string, Edge[]>();
+  for (const e of edges) {
+    const k = key(e.fx, e.fy);
+    const list = byStart.get(k);
+    if (list) list.push(e);
+    else byStart.set(k, [e]);
+  }
+
+  // Index of the empty cell on the RIGHT of `e` (edges have filled-on-left by
+  // construction). Two edges that bound the same empty cell belong to the same
+  // hole loop — used at a saddle to chain edges from one hole together rather
+  // than crossing the diagonal into the other hole.
+  const rightCellKey = (e: Edge): number => {
+    const dx = Math.sign(e.tx - e.fx);
+    const dy = Math.sign(e.ty - e.fy);
+    // Right-perpendicular of (dx, dy) is (dy, -dx); step half a half-cell.
+    const cx = (e.fx + e.tx) / 2 + (dy * s) / 2;
+    const cy = (e.fy + e.ty) / 2 - (dx * s) / 2;
+    return Math.floor(cy / s) * cols + Math.floor(cx / s);
+  };
 
   /** Collapse collinear runs → keep only vertices where direction changes. */
   const collapse = (walk: Edge[]): Point2[] => {
@@ -360,21 +381,22 @@ export function maskToPolygon(mask: CellMask): readonly MaskLoop[] {
     return a / 2;
   };
 
-  // Chain edges into every closed loop — each connected boundary (outer or
-  // hole) consumes its edges exactly once.
+  // Chain edges into every closed loop. Consumption is tracked per edge (not
+  // per start vertex) so both outgoing edges at a saddle can be walked.
   const loops: Point2[][] = [];
-  const consumed = new Set<string>();
+  const consumed = new Set<Edge>();
   for (const startEdge of edges) {
-    const k = key(startEdge.fx, startEdge.fy);
-    if (consumed.has(k)) continue;
+    if (consumed.has(startEdge)) continue;
     const walk: Edge[] = [];
     let cur: Edge | undefined = startEdge;
-    while (cur) {
-      const ck = key(cur.fx, cur.fy);
-      if (consumed.has(ck)) break;
-      consumed.add(ck);
+    while (cur && !consumed.has(cur)) {
+      consumed.add(cur);
       walk.push(cur);
-      cur = byStart.get(key(cur.tx, cur.ty));
+      const candidates = byStart.get(key(cur.tx, cur.ty));
+      if (!candidates) break;
+      const isSaddle = candidates.length > 1;
+      const curRight = isSaddle ? rightCellKey(cur) : 0;
+      cur = candidates.find((c) => !consumed.has(c) && (!isSaddle || rightCellKey(c) === curRight));
     }
     if (walk.length > 0) loops.push(collapse(walk));
   }

--- a/src/shared/utils/cellMask.ts
+++ b/src/shared/utils/cellMask.ts
@@ -395,8 +395,15 @@ export function maskToPolygon(mask: CellMask): readonly MaskLoop[] {
       const candidates = byStart.get(key(cur.tx, cur.ty));
       if (!candidates) break;
       const isSaddle = candidates.length > 1;
-      const curRight = isSaddle ? rightCellKey(cur) : 0;
-      cur = candidates.find((c) => !consumed.has(c) && (!isSaddle || rightCellKey(c) === curRight));
+      const curRight: number = isSaddle ? rightCellKey(cur) : 0;
+      let next: Edge | undefined;
+      for (const c of candidates) {
+        if (consumed.has(c)) continue;
+        if (isSaddle && rightCellKey(c) !== curRight) continue;
+        next = c;
+        break;
+      }
+      cur = next;
     }
     if (walk.length > 0) loops.push(collapse(walk));
   }


### PR DESCRIPTION
## Summary

In the bin-designer custom-shape, creating two empty cells that touch only diagonally produced non-manifold bin geometry. The polygon tracer in `maskToPolygon` saw both empty cells share a single corner vertex (a *saddle*) and merged their distinct perimeters into one self-touching figure-8 loop — downstream BREP cuts then failed.

The trace algorithm collects every boundary edge and chains them by start vertex. The previous implementation stored that mapping as `Map<string, Edge>`, so the second outgoing edge at the saddle overwrote the first.

**Fix:**
- `byStart` now groups outgoing edges per vertex into a list.
- Consumption is tracked per `Edge` reference instead of per start vertex.
- At a saddle, the chain picks the outgoing edge that bounds the **same empty cell** as the incoming edge — ensuring each hole's loop is walked separately rather than crossing the diagonal touch.

## Test plan

- [x] Added `maskToPolygon` unit tests for both `/` and `\` saddle orientations (3 loops, two simple 4-vertex hole loops).
- [x] Added BREP-kernel regression `binGenerator.scenario.diagonal-holes.test.ts` that generates a 2×2 bin with each saddle orientation and asserts a structurally valid mesh.
- [x] Existing 51 cellMask unit tests + 22 polygon-related generation tests + 2783 bin-designer/shared-utils tests pass.
- [x] `pnpm run typecheck`, `pnpm exec eslint`, all pre-commit checks (boundaries, i18n, exhaustiveness, component-structure, missing-tests) pass.