### PR TITLE
fix(bin-designer): tearing-safe useCustomBins + idle-aware autosave wait

### DIFF
--- a/src/features/bin-designer/hooks/useAutoSave.test.ts
+++ b/src/features/bin-designer/hooks/useAutoSave.test.ts
@@ -230,4 +230,39 @@ describe('useAutoSave', () => {
       expect.objectContaining({ style: 'descriptive', customName: '' })
     );
   });
+
+  // `idle` is the pre-generation state — saving immediately on idle captured a
+  // thumbnail of an empty canvas when an effect fired before the param change
+  // had kicked off generation.
+  it('waits for generation to complete before saving when status starts at idle', async () => {
+    mockUpdateDesignParams();
+    useDesignerStore.setState({
+      currentDesignId: 'existing-id',
+      generation: { status: 'idle', mesh: null, progress: 0, epoch: 0 },
+    });
+
+    renderHook(() => useAutoSave());
+
+    act(() => {
+      useDesignerStore.getState().setParam('width', 4);
+    });
+
+    // Debounce elapses; waitForGenerationComplete starts polling.
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    // Worker hasn't reported back yet — save must not have fired.
+    expect(DesignerStorage.updateDesignParams).not.toHaveBeenCalled();
+
+    // Now generation finishes; save should proceed within the next poll + render delay.
+    act(() => {
+      useDesignerStore.setState({
+        generation: { status: 'complete', mesh: null, progress: 1, epoch: 1 },
+      });
+    });
+    await advanceThroughSave();
+
+    expect(DesignerStorage.updateDesignParams).toHaveBeenCalledOnce();
+  });
 });

--- a/src/features/bin-designer/hooks/useAutoSave.ts
+++ b/src/features/bin-designer/hooks/useAutoSave.ts
@@ -31,8 +31,12 @@ function isAborted(token: { current: boolean }): boolean {
 }
 
 /**
- * Wait for generation to reach 'complete' or 'error' status.
- * Polls the store at 200ms intervals up to a maximum wait time.
+ * Wait for generation to reach a terminal status (`'complete'` or `'error'`).
+ *
+ * `'idle'` is excluded — it's the pre-generation state, and treating it as
+ * terminal would let autosave capture an empty-canvas thumbnail before the
+ * worker has started. The timeout still applies if the worker is stuck.
+ *
  * Returns the final status, or null if cancelled via AbortSignal.
  */
 function waitForGenerationComplete(
@@ -47,7 +51,7 @@ function waitForGenerationComplete(
         return;
       }
       const status = useDesignerStore.getState().generation.status;
-      if (status === 'complete' || status === 'error' || status === 'idle') {
+      if (status === 'complete' || status === 'error') {
         resolve(status);
         return;
       }

--- a/src/features/bin-designer/hooks/useCustomBins.test.ts
+++ b/src/features/bin-designer/hooks/useCustomBins.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { useCustomBins, resetCustomBinsCache } from './useCustomBins';
 import { upsertRegistryEntry, type CustomBinRef } from '../store/customBinRegistry';
 
@@ -62,5 +62,35 @@ describe('useCustomBins', () => {
 
     const { result } = renderHook(() => useCustomBins());
     expect(result.current[0]).toEqual(ref);
+  });
+
+  // Two consumers must observe the same snapshot reference until a registry
+  // event fires. Previously, mounting a second consumer reloaded the cache
+  // inside `subscribe()`, swapping the first consumer's snapshot reference
+  // without notifying it — a useSyncExternalStore tearing-contract violation.
+  it('keeps already-mounted consumers in sync when another consumer mounts', () => {
+    upsertRegistryEntry(makeRef('bin-1'));
+
+    const { result: a } = renderHook(() => useCustomBins());
+    const snapshotBefore = a.current;
+    expect(snapshotBefore).toHaveLength(1);
+
+    // Second consumer mounts; first consumer's snapshot must not silently change.
+    renderHook(() => useCustomBins());
+    expect(a.current).toBe(snapshotBefore);
+  });
+
+  it('notifies both consumers when the registry updates', () => {
+    const { result: a } = renderHook(() => useCustomBins());
+    const { result: b } = renderHook(() => useCustomBins());
+    expect(a.current).toHaveLength(0);
+    expect(b.current).toHaveLength(0);
+
+    act(() => {
+      upsertRegistryEntry(makeRef('bin-1'));
+    });
+    expect(a.current).toHaveLength(1);
+    expect(b.current).toHaveLength(1);
+    expect(a.current).toBe(b.current);
   });
 });

--- a/src/features/bin-designer/hooks/useCustomBins.ts
+++ b/src/features/bin-designer/hooks/useCustomBins.ts
@@ -9,46 +9,40 @@
 import { useSyncExternalStore } from 'react';
 import { loadRegistry, subscribeToRegistry, type CustomBinRef } from '../store/customBinRegistry';
 
-// Cache the registry result to prevent useSyncExternalStore infinite loops
+// useSyncExternalStore requires referentially stable snapshots between notifications.
+// `cachedRegistry` is only reassigned inside `notifyAll` (or on the 0→1 subscriber
+// transition, when no consumer can observe the change yet).
 let cachedRegistry: CustomBinRef[] = loadRegistry();
+const subscribers = new Set<() => void>();
 
-// Track subscribers for storage event notifications
-const storageSubscribers = new Set<() => void>();
+function notifyAll(): void {
+  cachedRegistry = loadRegistry();
+  subscribers.forEach((cb) => cb());
+}
+
+subscribeToRegistry(notifyAll);
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (e) => {
+    if (e.key === 'gridfinity-custom-bins-v1' || e.key === null) {
+      notifyAll();
+    }
+  });
+}
 
 function subscribe(callback: () => void): () => void {
-  // Refresh cache on subscribe to catch any updates that happened
-  // before this hook instance mounted (e.g., upsertRegistryEntry called
-  // while no hooks were active)
-  cachedRegistry = loadRegistry();
-
-  // Subscribe to registry changes (same-tab updates)
-  const unsubscribeRegistry = subscribeToRegistry(() => {
+  // Catches registry writes that landed while nothing was subscribed.
+  if (subscribers.size === 0) {
     cachedRegistry = loadRegistry();
-    callback();
-  });
-
-  // Also track for storage events (cross-tab updates)
-  storageSubscribers.add(callback);
-
+  }
+  subscribers.add(callback);
   return () => {
-    unsubscribeRegistry();
-    storageSubscribers.delete(callback);
+    subscribers.delete(callback);
   };
 }
 
 function getSnapshot(): CustomBinRef[] {
-  // Return cached value - useSyncExternalStore expects referential stability
   return cachedRegistry;
-}
-
-// Listen for storage events from other tabs
-if (typeof window !== 'undefined') {
-  window.addEventListener('storage', (e) => {
-    if (e.key === 'gridfinity-custom-bins-v1' || e.key === null) {
-      cachedRegistry = loadRegistry();
-      storageSubscribers.forEach((cb) => cb());
-    }
-  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Two store-hook correctness fixes in the bin designer:

### `useCustomBins` — `useSyncExternalStore` tearing-contract violation

`cachedRegistry` was reassigned inside `subscribe()`, so a second consumer mounting could change the snapshot reference for the first consumer **without notifying it**. React requires `getSnapshot` to return referentially stable values between subscription notifications.

The fix moves mutation into `notifyAll` (called from registry-change events and cross-tab `storage` events), with the only exception being a 0→1 subscriber refresh — when there are no consumers, nobody can observe the swap, so it's safe.

### `useAutoSave` — `'idle'` treated as terminal

`waitForGenerationComplete` resolved on `status === 'idle'`, but `'idle'` is the pre-generation state. If autosave's debounce fired before the worker had started, the helper returned immediately and captured a thumbnail of an empty canvas. Removed `'idle'` from the terminal set; the existing 5s timeout still covers worker-stuck cases.

## Test plan

- [x] New regression tests in `useCustomBins.test.ts`: snapshot reference remains stable when a second consumer mounts; both consumers receive identical references after a registry update.
- [x] New regression test in `useAutoSave.test.ts`: autosave with `status === 'idle'` polls until generation completes, only then writes through to storage.
- [x] All 14 existing tests in both files pass; broader 445-test bin-designer hooks+store suite passes.
- [x] `pnpm run typecheck`, all pre-commit checks pass.