### PR TITLE
fix(bin-designer): skip generation epoch on cosmetic cutout mutations

### DIFF
--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -52,7 +52,7 @@ graph TB
 
 ## Critical Concepts
 
-- **Epoch pattern**: `store.setParam()` increments epoch → triggers regeneration
+- **Epoch pattern**: `store.setParam()` increments epoch → triggers regeneration. Cosmetic cutout mutations (lock/hide/z-reorder/showAllCutouts) call `pushHistoryEntry(state, { affectsGeometry: false })` so undo still works but the worker doesn't re-run — only properties the worker reads (everything except `locked`/`hidden`/`zIndex`) bump the epoch
 - **Mesh cache**: 100MB budget, attached to history for instant undo
 - **Custom bin registry**: Syncs to localStorage for Layout Planner palette
 - **Ghost overlays**: Lightweight Three.js primitives render during `generationStatus === 'generating'` for instant visual feedback before BREP mesh completes. Components: `GhostDividers`, `GhostWireframe`, `GhostCompartmentPreview`, `GhostLabelTabs`, `GhostScoops`, `GhostCutouts`, `GhostWallCutouts`, `GhostSlotLines`, `GhostDividerPieces`

--- a/src/features/bin-designer/store/helpers.ts
+++ b/src/features/bin-designer/store/helpers.ts
@@ -68,8 +68,16 @@ export function setPendingMeshCache(mesh: CachedMesh | null): void {
  * Push current params (with pending mesh) to history past array.
  * Skips if inside a transaction (already pushed on transaction start).
  * Evicts old caches if memory budget exceeded.
+ *
+ * Pass `{ affectsGeometry: false }` for cosmetic mutations (lock, hide,
+ * z-reorder, etc.) — the entry is still captured for undo, but the
+ * generation epoch isn't bumped, so the worker doesn't re-run on every
+ * lock/hide click.
  */
-export function pushHistoryEntry(state: Draft<DesignerState>): void {
+export function pushHistoryEntry(
+  state: Draft<DesignerState>,
+  options: { affectsGeometry?: boolean } = {}
+): void {
   // Inside a transaction, the entry was already pushed at startTransaction
   if (state.transactionDepth > 0) return;
 
@@ -92,10 +100,11 @@ export function pushHistoryEntry(state: Draft<DesignerState>): void {
   const evicted = evictIfNeeded(newPast, []);
   state.history.past = evicted.past as HistoryEntry[];
   state.history.future = evicted.future as HistoryEntry[];
-  state.generation.epoch += 1;
-
-  // Clear cached mesh for the previous params; new params need a fresh result
-  pendingMeshCache = null;
+  if (options.affectsGeometry ?? true) {
+    state.generation.epoch += 1;
+    // Clear cached mesh for the previous params; new params need a fresh result
+    pendingMeshCache = null;
+  }
 }
 
 /**

--- a/src/features/bin-designer/store/slices/cutoutSlice.test.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.test.ts
@@ -367,4 +367,71 @@ describe('cutoutSlice - consolidated actions', () => {
       expect(afterHistoryLength).toBe(beforeHistoryLength);
     });
   });
+
+  // The cutoutBuilder worker reads neither `locked`, `hidden`, nor `zIndex`
+  // (verified by inspection: none appear in `src/features/generation/worker/`),
+  // so flipping those fields must not bump the generation epoch. Otherwise
+  // every lock/hide/reorder click kicks off a brepjs run that produces the
+  // identical mesh.
+  describe('cosmetic mutations do not bump generation.epoch', () => {
+    it('setCutoutProperty (lock) leaves epoch unchanged', () => {
+      const { addCutout, setCutoutProperty } = useDesignerStore.getState();
+      addCutout(createTestCutout({ id: 'c-1' }));
+      const epochBefore = useDesignerStore.getState().generation.epoch;
+
+      setCutoutProperty(['c-1'], { locked: true });
+
+      expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore);
+    });
+
+    it('setCutoutProperty (hide) leaves epoch unchanged', () => {
+      const { addCutout, setCutoutProperty } = useDesignerStore.getState();
+      addCutout(createTestCutout({ id: 'c-1' }));
+      const epochBefore = useDesignerStore.getState().generation.epoch;
+
+      setCutoutProperty(['c-1'], { hidden: true });
+
+      expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore);
+    });
+
+    it('reorderCutouts leaves epoch unchanged', () => {
+      const { addCutout, reorderCutouts } = useDesignerStore.getState();
+      addCutout(createTestCutout({ id: 'c-1' }));
+      addCutout(createTestCutout({ id: 'c-2' }));
+      const epochBefore = useDesignerStore.getState().generation.epoch;
+
+      reorderCutouts(['c-1'], 'forward');
+
+      expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore);
+    });
+
+    it('showAllCutouts leaves epoch unchanged', () => {
+      const { addCutout, showAllCutouts } = useDesignerStore.getState();
+      addCutout(createTestCutout({ id: 'c-1', hidden: true }));
+      const epochBefore = useDesignerStore.getState().generation.epoch;
+
+      showAllCutouts();
+
+      expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore);
+    });
+
+    it('addCutout still bumps epoch (geometric)', () => {
+      const { addCutout } = useDesignerStore.getState();
+      const epochBefore = useDesignerStore.getState().generation.epoch;
+
+      addCutout(createTestCutout({ id: 'c-1' }));
+
+      expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore + 1);
+    });
+
+    it('history entry is still captured so undo restores prior state', () => {
+      const { addCutout, setCutoutProperty, undo } = useDesignerStore.getState();
+      addCutout(createTestCutout({ id: 'c-1', locked: false }));
+      setCutoutProperty(['c-1'], { locked: true });
+
+      expect(useDesignerStore.getState().params.cutouts[0].locked).toBe(true);
+      undo();
+      expect(useDesignerStore.getState().params.cutouts[0].locked).toBe(false);
+    });
+  });
 });

--- a/src/features/bin-designer/store/slices/cutoutSlice.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.ts
@@ -16,10 +16,13 @@ type Set = (fn: (state: Draft<DesignerState>) => void) => void;
 export function createCutoutSlice(set: Set) {
   // Core actions
 
+  // locked/hidden/zIndex are editor-only state — the worker reads neither
+  // (see cutoutBuilder.ts), so these mutations get history but skip the
+  // generation epoch.
   const setCutoutProperty = (ids: readonly string[], partial: CutoutToggleProperties): void => {
     if (ids.length === 0) return;
     set((state) => {
-      pushHistoryEntry(state);
+      pushHistoryEntry(state, { affectsGeometry: false });
       const idSet = new Set(ids);
       state.params.cutouts = state.params.cutouts.map((c) =>
         idSet.has(c.id) ? { ...c, ...partial } : c
@@ -30,7 +33,7 @@ export function createCutoutSlice(set: Set) {
   const reorderCutouts = (ids: readonly string[], direction: ReorderDirection): void => {
     if (ids.length === 0) return;
     set((state) => {
-      pushHistoryEntry(state);
+      pushHistoryEntry(state, { affectsGeometry: false });
       const idSet = new Set(ids);
 
       switch (direction) {
@@ -68,7 +71,7 @@ export function createCutoutSlice(set: Set) {
     set((state) => {
       const hasHidden = state.params.cutouts.some((c) => c.hidden);
       if (!hasHidden) return;
-      pushHistoryEntry(state);
+      pushHistoryEntry(state, { affectsGeometry: false });
       state.params.cutouts = state.params.cutouts.map((c) =>
         c.hidden ? { ...c, hidden: false } : c
       );


### PR DESCRIPTION
## Summary

Locking, hiding, z-reordering, and `showAllCutouts` mutate **editor-only** state — the BREP worker reads none of `locked`, `hidden`, or `zIndex` (verified in \`cutoutBuilder.ts\` and the rest of \`worker/generators/\`). Previously these clicks bumped \`generation.epoch\` via \`pushHistoryEntry\`, kicking off a full brepjs run per click that produced the identical mesh.

\`pushHistoryEntry\` now takes an optional \`affectsGeometry\` flag (defaults to \`true\`, so all existing callers stay correct without modification). The four cosmetic actions in \`cutoutSlice\` pass \`false\`:
- \`setCutoutProperty\` (lock/unlock/hide/show — \`CutoutToggleProperties\` is only those keys)
- \`reorderCutouts\` (forward/backward/front/back)
- \`showAllCutouts\`

**Group/ungroup are NOT marked cosmetic** — \`buildGroupedCutouts\` fuses members into a single shape with a unified scoop fillet, so grouping genuinely changes geometry. (The reviewer's original sketch suggested marking them cosmetic; that would have produced wrong output.)

History is still pushed in both branches, so undo restores prior state regardless of the flag.

## Test plan

- [x] Six new regression tests in \`cutoutSlice.test.ts\` verify epoch is unchanged for lock/hide/reorder/showAllCutouts, that geometric \`addCutout\` still bumps epoch, and that undo still restores cosmetic mutations.
- [x] All 28 existing + new \`cutoutSlice\` tests pass; broader 448-test bin-designer suite passes.
- [x] \`pnpm run typecheck\`, all pre-commit checks pass (one warning: \`store/helpers.ts\` has no sibling test — pre-existing, not introduced by this PR).