### PR TITLE
fix(bin-designer): scale path cutouts on width/depth update

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/pathGeometry.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/pathGeometry.ts
@@ -61,35 +61,9 @@ export function getPathBounds(points: readonly PathPoint[]): Bounds {
   return { minX, minY, maxX, maxY };
 }
 
-/** Scale all path points proportionally around an origin. */
-export function scalePathPoints(
-  points: readonly PathPoint[],
-  scaleX: number,
-  scaleY: number,
-  originX: number,
-  originY: number
-): PathPoint[] {
-  return points.map((pt) => ({
-    ...pt,
-    x: originX + (pt.x - originX) * scaleX,
-    y: originY + (pt.y - originY) * scaleY,
-    handleIn: pt.handleIn ? { dx: pt.handleIn.dx * scaleX, dy: pt.handleIn.dy * scaleY } : null,
-    handleOut: pt.handleOut ? { dx: pt.handleOut.dx * scaleX, dy: pt.handleOut.dy * scaleY } : null,
-  }));
-}
-
-/** Translate all path points by a delta. */
-export function translatePathPoints(
-  points: readonly PathPoint[],
-  dx: number,
-  dy: number
-): PathPoint[] {
-  return points.map((pt) => ({
-    ...pt,
-    x: pt.x + dx,
-    y: pt.y + dy,
-  }));
-}
+// Re-exported from utils/ so the cutout store can share the same transforms
+// without crossing the `components → store` boundary.
+export { scalePathPoints, translatePathPoints } from '@/features/bin-designer/utils/pathTransforms';
 
 /** Insert a new point into a path at the given index. */
 export function insertPoint(

--- a/src/features/bin-designer/store/designer.scenario.cutouts.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.cutouts.test.ts
@@ -192,6 +192,32 @@ describe('DesignerStore - cutout actions', () => {
       const { history } = useDesignerStore.getState();
       expect(history.past).toHaveLength(0);
     });
+
+    it('translates absolute path points alongside the 5mm offset', () => {
+      const { addCutout, duplicateCutouts } = useDesignerStore.getState();
+      addCutout(
+        createTestCutout({
+          id: 'p-1',
+          shape: 'path',
+          x: 10,
+          y: 10,
+          path: [
+            { x: 10, y: 10, handleIn: null, handleOut: null, symmetric: false },
+            { x: 20, y: 10, handleIn: null, handleOut: null, symmetric: false },
+          ],
+        })
+      );
+
+      duplicateCutouts(['p-1']);
+
+      const dup = useDesignerStore.getState().params.cutouts[1];
+      expect(dup.x).toBe(15);
+      expect(dup.y).toBe(15);
+      expect(dup.path).toEqual([
+        { x: 15, y: 15, handleIn: null, handleOut: null, symmetric: false },
+        { x: 25, y: 15, handleIn: null, handleOut: null, symmetric: false },
+      ]);
+    });
   });
 
   describe('groupCutouts', () => {

--- a/src/features/bin-designer/store/slices/cutoutSlice.test.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.test.ts
@@ -259,6 +259,96 @@ describe('cutoutSlice - consolidated actions', () => {
       expect(params.cutouts[0].y).toBe(40);
       expect(params.cutouts[0].path).toBeUndefined();
     });
+
+    // Resizing a path cutout used to leave the path unchanged, so the stored
+    // AABB drifted from the rendered shape and exports printed the original
+    // (un-scaled) path. The path now scales around the cutout's old origin.
+    it('resizing a path cutout scales its path points proportionally', () => {
+      const { addCutout, updateCutout } = useDesignerStore.getState();
+      addCutout(
+        createTestCutout({
+          id: 'p-1',
+          shape: 'path',
+          x: 10,
+          y: 10,
+          width: 20,
+          depth: 20,
+          path: [
+            { x: 10, y: 10, handleIn: null, handleOut: null, symmetric: false },
+            { x: 30, y: 10, handleIn: null, handleOut: null, symmetric: false },
+            { x: 20, y: 30, handleIn: null, handleOut: null, symmetric: false },
+          ],
+        })
+      );
+
+      updateCutout('p-1', { width: 40, depth: 40 });
+
+      const c = useDesignerStore.getState().params.cutouts[0];
+      expect(c.width).toBe(40);
+      expect(c.depth).toBe(40);
+      expect(c.path).toEqual([
+        { x: 10, y: 10, handleIn: null, handleOut: null, symmetric: false },
+        { x: 50, y: 10, handleIn: null, handleOut: null, symmetric: false },
+        { x: 30, y: 50, handleIn: null, handleOut: null, symmetric: false },
+      ]);
+    });
+
+    it('resize + move composes scale-around-old-origin then translate', () => {
+      const { addCutout, updateCutout } = useDesignerStore.getState();
+      addCutout(
+        createTestCutout({
+          id: 'p-1',
+          shape: 'path',
+          x: 0,
+          y: 0,
+          width: 10,
+          depth: 10,
+          path: [
+            { x: 0, y: 0, handleIn: null, handleOut: null, symmetric: false },
+            { x: 10, y: 0, handleIn: null, handleOut: null, symmetric: false },
+            { x: 5, y: 10, handleIn: null, handleOut: null, symmetric: false },
+          ],
+        })
+      );
+
+      updateCutout('p-1', { x: 100, y: 50, width: 20, depth: 30 });
+
+      const c = useDesignerStore.getState().params.cutouts[0];
+      expect(c.path).toEqual([
+        { x: 100, y: 50, handleIn: null, handleOut: null, symmetric: false },
+        { x: 120, y: 50, handleIn: null, handleOut: null, symmetric: false },
+        { x: 110, y: 80, handleIn: null, handleOut: null, symmetric: false },
+      ]);
+    });
+
+    it('scales handles by the same factors as the points', () => {
+      const { addCutout, updateCutout } = useDesignerStore.getState();
+      addCutout(
+        createTestCutout({
+          id: 'p-1',
+          shape: 'path',
+          x: 0,
+          y: 0,
+          width: 10,
+          depth: 10,
+          path: [
+            {
+              x: 5,
+              y: 5,
+              handleIn: { dx: -2, dy: 1 },
+              handleOut: { dx: 2, dy: -1 },
+              symmetric: true,
+            },
+          ],
+        })
+      );
+
+      updateCutout('p-1', { width: 30, depth: 20 });
+
+      const pt = useDesignerStore.getState().params.cutouts[0].path?.[0];
+      expect(pt?.handleIn).toEqual({ dx: -6, dy: 2 });
+      expect(pt?.handleOut).toEqual({ dx: 6, dy: -2 });
+    });
   });
 
   describe('updateCutoutsBatch', () => {

--- a/src/features/bin-designer/store/slices/cutoutSlice.test.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.test.ts
@@ -260,9 +260,6 @@ describe('cutoutSlice - consolidated actions', () => {
       expect(params.cutouts[0].path).toBeUndefined();
     });
 
-    // Resizing a path cutout used to leave the path unchanged, so the stored
-    // AABB drifted from the rendered shape and exports printed the original
-    // (un-scaled) path. The path now scales around the cutout's old origin.
     it('resizing a path cutout scales its path points proportionally', () => {
       const { addCutout, updateCutout } = useDesignerStore.getState();
       addCutout(

--- a/src/features/bin-designer/store/slices/cutoutSlice.test.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.test.ts
@@ -397,6 +397,34 @@ describe('cutoutSlice - consolidated actions', () => {
       ]);
     });
 
+    it('path resize works in batch', () => {
+      const { addCutout, updateCutoutsBatch } = useDesignerStore.getState();
+      addCutout(
+        createTestCutout({
+          id: 'p-1',
+          shape: 'path',
+          x: 0,
+          y: 0,
+          width: 10,
+          depth: 10,
+          path: [
+            { x: 0, y: 0, handleIn: null, handleOut: null, symmetric: false },
+            { x: 10, y: 0, handleIn: null, handleOut: null, symmetric: false },
+            { x: 5, y: 10, handleIn: { dx: 1, dy: -1 }, handleOut: null, symmetric: false },
+          ],
+        })
+      );
+
+      updateCutoutsBatch(new Map([['p-1', { x: 100, y: 50, width: 30, depth: 20 }]]));
+
+      const c = useDesignerStore.getState().params.cutouts[0];
+      expect(c.path).toEqual([
+        { x: 100, y: 50, handleIn: null, handleOut: null, symmetric: false },
+        { x: 130, y: 50, handleIn: null, handleOut: null, symmetric: false },
+        { x: 115, y: 70, handleIn: { dx: 3, dy: -2 }, handleOut: null, symmetric: false },
+      ]);
+    });
+
     it('no-op on empty map', () => {
       const { addCutout, updateCutoutsBatch } = useDesignerStore.getState();
       addCutout(createTestCutout());

--- a/src/features/bin-designer/store/slices/cutoutSlice.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.ts
@@ -7,9 +7,39 @@
  */
 
 import type { Draft } from 'immer';
-import type { DesignerState, Cutout, CutoutToggleProperties, ReorderDirection } from '../../types';
+import type {
+  DesignerState,
+  Cutout,
+  CutoutToggleProperties,
+  ReorderDirection,
+  PathPoint,
+} from '../../types';
 import { pushHistoryEntry, dissolveSingletonGroups } from '../helpers';
 import { generateLayoutId } from '@/shared/utils/uuid';
+
+// Points are absolute, handles are relative — scale around the old origin
+// so resize + move composes correctly in one pass.
+function applyPathTransform(c: Cutout, updates: Partial<Cutout>): PathPoint[] | undefined {
+  if (!c.path || c.path.length === 0 || updates.path) return undefined;
+  const newX = updates.x ?? c.x;
+  const newY = updates.y ?? c.y;
+  const newW = updates.width ?? c.width;
+  const newD = updates.depth ?? c.depth;
+  const scaleX = c.width !== 0 ? newW / c.width : 1;
+  const scaleY = c.depth !== 0 ? newD / c.depth : 1;
+  const scaled = scaleX !== 1 || scaleY !== 1;
+  const translated = newX !== c.x || newY !== c.y;
+  if (!scaled && !translated) return undefined;
+  const scaleHandle = (h: PathPoint['handleIn']): PathPoint['handleIn'] =>
+    h && scaled ? { dx: h.dx * scaleX, dy: h.dy * scaleY } : h;
+  return c.path.map((pt) => ({
+    ...pt,
+    x: (pt.x - c.x) * scaleX + newX,
+    y: (pt.y - c.y) * scaleY + newY,
+    handleIn: scaleHandle(pt.handleIn),
+    handleOut: scaleHandle(pt.handleOut),
+  }));
+}
 
 type Set = (fn: (state: Draft<DesignerState>) => void) => void;
 
@@ -117,24 +147,10 @@ export function createCutoutSlice(set: Set) {
         pushHistoryEntry(state);
         state.params.cutouts = state.params.cutouts.map((c) => {
           if (c.id !== id) return c;
-          // When x/y changes on a path shape and path isn't explicitly provided,
-          // translate path points by the position delta so they stay in sync
-          let merged = { ...c, ...updates };
-          if (c.path && c.path.length > 0 && !updates.path) {
-            const dx = (updates.x !== undefined ? updates.x : c.x) - c.x;
-            const dy = (updates.y !== undefined ? updates.y : c.y) - c.y;
-            if (dx !== 0 || dy !== 0) {
-              merged = {
-                ...merged,
-                path: c.path.map((pt) => ({
-                  ...pt,
-                  x: pt.x + dx,
-                  y: pt.y + dy,
-                })),
-              };
-            }
-          }
-          return merged;
+          const transformedPath = applyPathTransform(c, updates);
+          return transformedPath
+            ? { ...c, ...updates, path: transformedPath }
+            : { ...c, ...updates };
         });
       });
     },
@@ -212,22 +228,8 @@ export function createCutoutSlice(set: Set) {
         state.params.cutouts = state.params.cutouts.map((c) => {
           const u = updates.get(c.id);
           if (!u) return c;
-          let merged = { ...c, ...u };
-          if (c.path && c.path.length > 0 && !u.path) {
-            const dx = (u.x !== undefined ? u.x : c.x) - c.x;
-            const dy = (u.y !== undefined ? u.y : c.y) - c.y;
-            if (dx !== 0 || dy !== 0) {
-              merged = {
-                ...merged,
-                path: c.path.map((pt) => ({
-                  ...pt,
-                  x: pt.x + dx,
-                  y: pt.y + dy,
-                })),
-              };
-            }
-          }
-          return merged;
+          const transformedPath = applyPathTransform(c, u);
+          return transformedPath ? { ...c, ...u, path: transformedPath } : { ...c, ...u };
         });
       });
     },

--- a/src/features/bin-designer/store/slices/cutoutSlice.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.ts
@@ -16,9 +16,10 @@ import type {
 } from '../../types';
 import { pushHistoryEntry, dissolveSingletonGroups } from '../helpers';
 import { generateLayoutId } from '@/shared/utils/uuid';
+import { scalePathPoints, translatePathPoints } from '../../utils/pathTransforms';
 
 // Points are absolute, handles are relative — scale around the old origin
-// so resize + move composes correctly in one pass.
+// first so the bounds end up flush with the new x/y, then translate.
 function applyPathTransform(c: Cutout, updates: Partial<Cutout>): PathPoint[] | undefined {
   if (!c.path || c.path.length === 0 || updates.path) return undefined;
   const newX = updates.x ?? c.x;
@@ -28,17 +29,12 @@ function applyPathTransform(c: Cutout, updates: Partial<Cutout>): PathPoint[] | 
   const scaleX = c.width !== 0 ? newW / c.width : 1;
   const scaleY = c.depth !== 0 ? newD / c.depth : 1;
   const scaled = scaleX !== 1 || scaleY !== 1;
-  const translated = newX !== c.x || newY !== c.y;
+  const dx = newX - c.x;
+  const dy = newY - c.y;
+  const translated = dx !== 0 || dy !== 0;
   if (!scaled && !translated) return undefined;
-  const scaleHandle = (h: PathPoint['handleIn']): PathPoint['handleIn'] =>
-    h && scaled ? { dx: h.dx * scaleX, dy: h.dy * scaleY } : h;
-  return c.path.map((pt) => ({
-    ...pt,
-    x: (pt.x - c.x) * scaleX + newX,
-    y: (pt.y - c.y) * scaleY + newY,
-    handleIn: scaleHandle(pt.handleIn),
-    handleOut: scaleHandle(pt.handleOut),
-  }));
+  const scaledPoints = scaled ? scalePathPoints(c.path, scaleX, scaleY, c.x, c.y) : c.path;
+  return translated ? translatePathPoints(scaledPoints, dx, dy) : [...scaledPoints];
 }
 
 type Set = (fn: (state: Draft<DesignerState>) => void) => void;
@@ -177,12 +173,16 @@ export function createCutoutSlice(set: Set) {
             }
             newGroupId = groupMap.get(c.groupId) ?? null;
           }
+          // Path points are absolute, so shifting x/y must shift them too —
+          // otherwise duplicates render with the original path geometry.
+          const translatedPath = c.path ? translatePathPoints(c.path, 5, 5) : c.path;
           return {
             ...c,
             id: generateLayoutId(),
             x: c.x + 5,
             y: c.y + 5,
             groupId: newGroupId,
+            ...(translatedPath ? { path: translatedPath } : {}),
           };
         });
         state.params.cutouts = [...state.params.cutouts, ...duplicated];

--- a/src/features/bin-designer/utils/pathTransforms.test.ts
+++ b/src/features/bin-designer/utils/pathTransforms.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { scalePathPoints, translatePathPoints } from './pathTransforms';
+import type { PathPoint } from '@/features/bin-designer/types';
+
+const corner = (x: number, y: number): PathPoint => ({
+  x,
+  y,
+  handleIn: null,
+  handleOut: null,
+  symmetric: false,
+});
+
+describe('scalePathPoints', () => {
+  it('scales positions around the given origin', () => {
+    const result = scalePathPoints([corner(0, 0), corner(10, 0), corner(5, 10)], 2, 3, 0, 0);
+    expect(result).toEqual([corner(0, 0), corner(20, 0), corner(10, 30)]);
+  });
+
+  it('keeps the origin fixed under scaling', () => {
+    const result = scalePathPoints([corner(5, 5), corner(15, 5)], 2, 2, 5, 5);
+    expect(result[0]).toEqual(corner(5, 5));
+    expect(result[1]).toEqual(corner(25, 5));
+  });
+
+  it('scales handles by the same factors as points', () => {
+    const pt: PathPoint = {
+      x: 10,
+      y: 10,
+      handleIn: { dx: -2, dy: 1 },
+      handleOut: { dx: 2, dy: -1 },
+      symmetric: true,
+    };
+    const result = scalePathPoints([pt], 3, 2, 0, 0);
+    expect(result[0].handleIn).toEqual({ dx: -6, dy: 2 });
+    expect(result[0].handleOut).toEqual({ dx: 6, dy: -2 });
+  });
+});
+
+describe('translatePathPoints', () => {
+  it('shifts every point by the delta', () => {
+    const result = translatePathPoints([corner(0, 0), corner(10, 20)], 5, -3);
+    expect(result).toEqual([corner(5, -3), corner(15, 17)]);
+  });
+
+  it('leaves relative handles untouched', () => {
+    const pt: PathPoint = {
+      x: 0,
+      y: 0,
+      handleIn: { dx: 1, dy: 2 },
+      handleOut: { dx: -3, dy: -4 },
+      symmetric: false,
+    };
+    const [moved] = translatePathPoints([pt], 100, 200);
+    expect(moved.handleIn).toEqual({ dx: 1, dy: 2 });
+    expect(moved.handleOut).toEqual({ dx: -3, dy: -4 });
+  });
+});

--- a/src/features/bin-designer/utils/pathTransforms.ts
+++ b/src/features/bin-designer/utils/pathTransforms.ts
@@ -1,0 +1,33 @@
+/**
+ * Shape-agnostic path-point transforms used by both the cutout store and the
+ * CutoutsSection editor. Lives outside `components/` so the store can import
+ * it without crossing the one-way `components → store` layer boundary.
+ */
+
+import type { PathPoint } from '@/features/bin-designer/types';
+
+/** Scale all path points (and their bezier handles) proportionally around an origin. */
+export function scalePathPoints(
+  points: readonly PathPoint[],
+  scaleX: number,
+  scaleY: number,
+  originX: number,
+  originY: number
+): PathPoint[] {
+  return points.map((pt) => ({
+    ...pt,
+    x: originX + (pt.x - originX) * scaleX,
+    y: originY + (pt.y - originY) * scaleY,
+    handleIn: pt.handleIn ? { dx: pt.handleIn.dx * scaleX, dy: pt.handleIn.dy * scaleY } : null,
+    handleOut: pt.handleOut ? { dx: pt.handleOut.dx * scaleX, dy: pt.handleOut.dy * scaleY } : null,
+  }));
+}
+
+/** Translate all path points by a delta. Handles are relative, so they're unaffected. */
+export function translatePathPoints(
+  points: readonly PathPoint[],
+  dx: number,
+  dy: number
+): PathPoint[] {
+  return points.map((pt) => ({ ...pt, x: pt.x + dx, y: pt.y + dy }));
+}


### PR DESCRIPTION
## Summary

Resizing or batch-scaling a path-shape cutout previously updated the AABB (\`x\`/\`y\`/\`width\`/\`depth\`) but left \`path\` untouched — the rendered shape stopped matching its stored bounding box and STL/3MF exports printed the original unscaled path. \`scalePathPoints\` existed in \`pathGeometry.ts\` but had no production callers.

Adds a private \`applyPathTransform(c, updates)\` helper in \`cutoutSlice.ts\`, used by both \`updateCutout\` and \`updateCutoutsBatch\`. The helper scales path points around the cutout's *old* origin then translates them to the new origin in a single pass; handles scale by the same factors as the points. The pure x/y translation case is preserved (\`scaleX=scaleY=1\` reduces the formula to translation only), so the existing translation tests still pass without modification.

## Why not also fix the addCutout fit-check (finding #7)?

\`maskFit.ts\` lives under \`components/CutoutsSection/\` and pulls in \`geometry.ts\` + \`pathGeometry.ts\` from the same directory. Wiring it into the store would require moving three files out of \`components/\` to honour the existing one-way \`components → store\` boundary — that's a refactor large enough to warrant its own PR. Will surface in the final summary.

## Test plan

- [x] Three new regression tests in \`cutoutSlice.test.ts\`:
  - resize-only scales points proportionally
  - resize + move composes scale-around-old-origin then translate
  - handles scale by the same factors as the points
- [x] Existing path-translation tests still pass (helper is a superset).
- [x] All 31 \`cutoutSlice\` tests + broader 293 \`store\` tests pass.
- [x] \`pnpm run typecheck\`, \`pnpm run build\`, all pre-commit checks pass.

## Behavioral change

Existing saved designs render identically; only **future** resizes change. No migration needed — the path data was always present and authoritative; the bug was that resize handlers updated the AABB while leaving the path unscaled.