### PR TITLE
fix(bin-designer): rotation-aware drag clamp + resize joint constraint

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Cutout } from '@/features/bin-designer/types';
+import { handleDragMove } from './dragHandler';
+import { getRotatedBounds } from '../geometry';
+import type { InteractionMode } from '../useCutoutInteraction';
+import type { BinBounds, PointerMoveEvent, PreviewSetters, DeadZoneRef } from './types';
+
+type DraggingMode = Extract<InteractionMode, { type: 'dragging' }>;
+
+function makeCutout(overrides: Partial<Cutout> = {}): Cutout {
+  return {
+    id: 'c-1',
+    shape: 'rectangle',
+    x: 10,
+    y: 10,
+    width: 20,
+    depth: 20,
+    cutDepth: 5,
+    rotation: 0,
+    cornerRadius: 0,
+    label: '',
+    groupId: null,
+    ...overrides,
+  };
+}
+
+function makeMode(
+  startX: number,
+  startY: number,
+  offsets: Array<[string, number, number]>
+): DraggingMode {
+  return {
+    type: 'dragging',
+    startX,
+    startY,
+    offsets: new Map(offsets.map(([id, dx, dy]) => [id, { dx, dy }])),
+  };
+}
+
+const noopSnap = (n: number): number => n;
+const NO_DEAD_ZONE: DeadZoneRef = { current: true };
+
+function makeSetters() {
+  let preview: Map<string, Partial<Cutout>> | null = null;
+  const setPreview = vi.fn((map: Map<string, Partial<Cutout>>) => {
+    preview = map;
+  });
+  return {
+    setPreview,
+    setActiveGuides: vi.fn(),
+    get preview() {
+      return preview;
+    },
+  };
+}
+
+describe('handleDragMove rotation-aware clamping', () => {
+  it('clamps a rotated cutout by its rotated AABB, not its unrotated width', () => {
+    // 20×20 square rotated 45° has a rotated AABB of ≈28.28×28.28; the
+    // unrotated-width clamp would let x reach binWidth - 20 = 80, where the
+    // rotated corner extends to 80 + 24.14 = 104.14, well past the bin.
+    const cutout = makeCutout({ x: 10, y: 10, width: 20, depth: 20, rotation: 45 });
+    const rb = getRotatedBounds(cutout);
+    const overhangX = (rb.maxX - rb.minX - cutout.width) / 2;
+    expect(overhangX).toBeGreaterThan(0);
+
+    const bounds: BinBounds = {
+      binWidth: 100,
+      binDepth: 100,
+      cellMask: undefined,
+      maskCellSize: undefined,
+    };
+    // Drag far past the right edge — pre-fix, x clamped to 80; post-fix to 80 - overhangX.
+    const mode = makeMode(10, 10, [['c-1', 0, 0]]);
+    const event: PointerMoveEvent = { mmX: 500, mmY: 10, shiftKey: false, altKey: false };
+    const setters = makeSetters();
+
+    handleDragMove(
+      mode,
+      event,
+      [cutout],
+      bounds,
+      noopSnap,
+      NO_DEAD_ZONE,
+      setters as unknown as PreviewSetters
+    );
+
+    const patch = setters.preview?.get('c-1');
+    expect(patch).toBeDefined();
+    const x = patch!.x as number;
+    // Rotated AABB right edge must stay within the bin
+    expect(x + cutout.width + overhangX).toBeLessThanOrEqual(bounds.binWidth + 1e-9);
+  });
+
+  it('unrotated cutouts still clamp to the full bin width', () => {
+    const cutout = makeCutout({ x: 0, y: 0, width: 30, depth: 30, rotation: 0 });
+    const bounds: BinBounds = {
+      binWidth: 50,
+      binDepth: 50,
+      cellMask: undefined,
+      maskCellSize: undefined,
+    };
+    const mode = makeMode(0, 0, [['c-1', 0, 0]]);
+    const event: PointerMoveEvent = { mmX: 200, mmY: 0, shiftKey: false, altKey: false };
+    const setters = makeSetters();
+
+    handleDragMove(
+      mode,
+      event,
+      [cutout],
+      bounds,
+      noopSnap,
+      NO_DEAD_ZONE,
+      setters as unknown as PreviewSetters
+    );
+
+    const patch = setters.preview?.get('c-1');
+    expect(patch?.x).toBe(bounds.binWidth - cutout.width);
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.ts
@@ -76,13 +76,11 @@ export function handleDragMove(
     const rb = getRotatedBounds(cutout);
     const overhangX = (rb.maxX - rb.minX - cutout.width) / 2;
     const overhangY = (rb.maxY - rb.minY - cutout.depth) / 2;
-    const minX = overhangX;
-    const minY = overhangY;
     const maxX = bounds.binWidth - cutout.width - overhangX;
     const maxY = bounds.binDepth - cutout.depth - overhangY;
     nextPreview.set(id, {
-      x: Math.max(minX, Math.min(snap(mode.startX + dx + offset.dx), maxX)),
-      y: Math.max(minY, Math.min(snap(mode.startY + dy + offset.dy), maxY)),
+      x: Math.max(overhangX, Math.min(snap(mode.startX + dx + offset.dx), maxX)),
+      y: Math.max(overhangY, Math.min(snap(mode.startY + dy + offset.dy), maxY)),
     });
   }
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.ts
@@ -6,7 +6,12 @@
  */
 
 import type { Cutout } from '@/features/bin-designer/types';
-import { constrainGroupDrag, computeBounds, findAlignmentGuides } from '../geometry';
+import {
+  constrainGroupDrag,
+  computeBounds,
+  findAlignmentGuides,
+  getRotatedBounds,
+} from '../geometry';
 import { cutoutFitsInMask } from '../maskFit';
 import type { InteractionMode } from '../useCutoutInteraction';
 import type { PointerMoveEvent, BinBounds, SnapFn, PreviewSetters, DeadZoneRef } from './types';
@@ -65,10 +70,19 @@ export function handleDragMove(
   for (const [id, offset] of mode.offsets) {
     const cutout = cutouts.find((c) => c.id === id);
     if (!cutout) continue;
-    // Snap, then clamp to bin bounds (snap can round past non-integer edges)
+    // Rotation-aware clamp — a rotated AABB extends past the unrotated
+    // (width × depth) box, so plain `binWidth - cutout.width` lets the corner
+    // drag past the bin edge. Mirrors `nudgeSelected` in useCutoutInteraction.
+    const rb = getRotatedBounds(cutout);
+    const overhangX = (rb.maxX - rb.minX - cutout.width) / 2;
+    const overhangY = (rb.maxY - rb.minY - cutout.depth) / 2;
+    const minX = overhangX;
+    const minY = overhangY;
+    const maxX = bounds.binWidth - cutout.width - overhangX;
+    const maxY = bounds.binDepth - cutout.depth - overhangY;
     nextPreview.set(id, {
-      x: Math.max(0, Math.min(snap(mode.startX + dx + offset.dx), bounds.binWidth - cutout.width)),
-      y: Math.max(0, Math.min(snap(mode.startY + dy + offset.dy), bounds.binDepth - cutout.depth)),
+      x: Math.max(minX, Math.min(snap(mode.startX + dx + offset.dx), maxX)),
+      y: Math.max(minY, Math.min(snap(mode.startY + dy + offset.dy), maxY)),
     });
   }
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Cutout } from '@/features/bin-designer/types';
+import type { ResizeHandle, StartRect } from '../geometry';
+import { handleResizeMove } from './resizeHandler';
+import type { InteractionMode } from '../useCutoutInteraction';
+import type { BinBounds, PointerMoveEvent, PreviewSetters, DeadZoneRef } from './types';
+
+type ResizingMode = Extract<InteractionMode, { type: 'resizing' }>;
+
+function makeCutout(overrides: Partial<Cutout> = {}): Cutout {
+  return {
+    id: 'c-1',
+    shape: 'rectangle',
+    x: 0,
+    y: 0,
+    width: 20,
+    depth: 20,
+    cutDepth: 5,
+    rotation: 0,
+    cornerRadius: 0,
+    label: '',
+    groupId: null,
+    ...overrides,
+  };
+}
+
+function makeMode(
+  startRect: StartRect,
+  handle: ResizeHandle = 'se',
+  cutoutId = 'c-1'
+): ResizingMode {
+  return { type: 'resizing', cutoutId, handle, startRect };
+}
+
+const noopSnap = (n: number): number => n;
+
+function makeSetters(): {
+  setPreview: ReturnType<typeof vi.fn>;
+  preview: Map<string, Partial<Cutout>> | null;
+} {
+  let preview: Map<string, Partial<Cutout>> | null = null;
+  const setPreview = vi.fn((map: Map<string, Partial<Cutout>>) => {
+    preview = map;
+  });
+  return Object.assign(
+    {
+      setPreview,
+      get preview() {
+        return preview;
+      },
+    },
+    {}
+  );
+}
+
+const NO_DEAD_ZONE: DeadZoneRef = { current: true };
+
+describe('handleResizeMove joint-constraint clamping', () => {
+  it('keeps x + width within binWidth when snap rounds width past the bin edge', () => {
+    // Drag the SE handle far past the bin's right edge. With independent
+    // snap-then-clamp, snappedW could exceed binWidth and bypass the x
+    // clamp; the joint constraint must cap width to (binWidth - x).
+    const cutout = makeCutout({ x: 30, y: 30, width: 20, depth: 20 });
+    const bounds: BinBounds = {
+      binWidth: 50,
+      binDepth: 50,
+      cellMask: undefined,
+      maskCellSize: undefined,
+    };
+    const mode = makeMode({ x: 30, y: 30, width: 20, depth: 20 }, 'se');
+    const event: PointerMoveEvent = { mmX: 200, mmY: 200, shiftKey: false, altKey: false };
+    const setters = makeSetters();
+
+    handleResizeMove(
+      mode,
+      event,
+      [cutout],
+      bounds,
+      noopSnap,
+      NO_DEAD_ZONE,
+      setters as unknown as PreviewSetters
+    );
+
+    expect(setters.setPreview).toHaveBeenCalled();
+    const patch = setters.preview?.get('c-1');
+    expect(patch).toBeDefined();
+    const x = patch!.x as number;
+    const w = patch!.width as number;
+    const y = patch!.y as number;
+    const d = patch!.depth as number;
+    expect(x + w).toBeLessThanOrEqual(bounds.binWidth);
+    expect(y + d).toBeLessThanOrEqual(bounds.binDepth);
+  });
+
+  it('does not allow width to fall below MIN_CUTOUT_SIZE even after joint clamping', () => {
+    const cutout = makeCutout({ x: 49.9, y: 49.9, width: 0.1, depth: 0.1 });
+    const bounds: BinBounds = {
+      binWidth: 50,
+      binDepth: 50,
+      cellMask: undefined,
+      maskCellSize: undefined,
+    };
+    const mode = makeMode({ x: 49.9, y: 49.9, width: 0.1, depth: 0.1 }, 'se');
+    const event: PointerMoveEvent = { mmX: 49.95, mmY: 49.95, shiftKey: false, altKey: false };
+    const setters = makeSetters();
+
+    handleResizeMove(
+      mode,
+      event,
+      [cutout],
+      bounds,
+      noopSnap,
+      NO_DEAD_ZONE,
+      setters as unknown as PreviewSetters
+    );
+
+    const patch = setters.preview?.get('c-1');
+    if (patch) {
+      // MIN_CUTOUT_SIZE is 1mm; clamping must not violate it.
+      expect((patch.width as number) ?? 1).toBeGreaterThanOrEqual(1);
+      expect((patch.depth as number) ?? 1).toBeGreaterThanOrEqual(1);
+    }
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Cutout } from '@/features/bin-designer/types';
-import type { ResizeHandle, StartRect } from '../geometry';
+import type { StartRect } from '../geometry';
 import { handleResizeMove } from './resizeHandler';
-import type { InteractionMode } from '../useCutoutInteraction';
+import type { InteractionMode, ResizeHandle } from '../useCutoutInteraction';
 import type { BinBounds, PointerMoveEvent, PreviewSetters, DeadZoneRef } from './types';
 
 type ResizingMode = Extract<InteractionMode, { type: 'resizing' }>;
@@ -54,18 +54,21 @@ const NO_DEAD_ZONE: DeadZoneRef = { current: true };
 
 describe('handleResizeMove joint-constraint clamping', () => {
   it('keeps x + width within binWidth when snap rounds width past the bin edge', () => {
-    // Drag the SE handle far past the bin's right edge. With independent
-    // snap-then-clamp, snappedW could exceed binWidth and bypass the x
-    // clamp; the joint constraint must cap width to (binWidth - x).
-    const cutout = makeCutout({ x: 30, y: 30, width: 20, depth: 20 });
+    // 30mm snap step in a 20mm bin: any non-zero `snap(width)` rounds up to 30
+    // — exceeding binWidth. With the old independent snap-then-clamp, x landed
+    // at 0 with width=30 (overflow); the joint constraint must cap width to
+    // (binWidth - x). noopSnap doesn't reproduce this because the failure
+    // mode is specifically about snap rounding past the bin edge.
+    const snapTo30 = (n: number): number => Math.ceil(n / 30) * 30;
+    const cutout = makeCutout({ x: 5, y: 5, width: 5, depth: 5 });
     const bounds: BinBounds = {
-      binWidth: 50,
-      binDepth: 50,
+      binWidth: 20,
+      binDepth: 20,
       cellMask: undefined,
       maskCellSize: undefined,
     };
-    const mode = makeMode({ x: 30, y: 30, width: 20, depth: 20 }, 'se');
-    const event: PointerMoveEvent = { mmX: 200, mmY: 200, shiftKey: false, altKey: false };
+    const mode = makeMode({ x: 5, y: 5, width: 5, depth: 5 }, 'se');
+    const event: PointerMoveEvent = { mmX: 15, mmY: 15, shiftKey: false, altKey: false };
     const setters = makeSetters();
 
     handleResizeMove(
@@ -73,7 +76,7 @@ describe('handleResizeMove joint-constraint clamping', () => {
       event,
       [cutout],
       bounds,
-      noopSnap,
+      snapTo30,
       NO_DEAD_ZONE,
       setters as unknown as PreviewSetters
     );

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Cutout } from '@/features/bin-designer/types';
-import type { StartRect } from '../geometry';
+import { MIN_CUTOUT_SIZE, type StartRect } from '../geometry';
 import { handleResizeMove } from './resizeHandler';
 import type { InteractionMode, ResizeHandle } from '../useCutoutInteraction';
 import type { BinBounds, PointerMoveEvent, PreviewSetters, DeadZoneRef } from './types';
@@ -116,9 +116,8 @@ describe('handleResizeMove joint-constraint clamping', () => {
 
     const patch = setters.preview?.get('c-1');
     if (patch) {
-      // MIN_CUTOUT_SIZE is 1mm; clamping must not violate it.
-      expect((patch.width as number) ?? 1).toBeGreaterThanOrEqual(1);
-      expect((patch.depth as number) ?? 1).toBeGreaterThanOrEqual(1);
+      expect(patch.width as number).toBeGreaterThanOrEqual(MIN_CUTOUT_SIZE);
+      expect(patch.depth as number).toBeGreaterThanOrEqual(MIN_CUTOUT_SIZE);
     }
   });
 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.test.ts
@@ -42,15 +42,12 @@ function makeSetters(): {
   const setPreview = vi.fn((map: Map<string, Partial<Cutout>>) => {
     preview = map;
   });
-  return Object.assign(
-    {
-      setPreview,
-      get preview() {
-        return preview;
-      },
+  return {
+    setPreview,
+    get preview() {
+      return preview;
     },
-    {}
-  );
+  };
 }
 
 const NO_DEAD_ZONE: DeadZoneRef = { current: true };

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.ts
@@ -61,14 +61,16 @@ export function handleResizeMove(
     event.altKey
   );
 
-  // Snap, then clamp to bin bounds (snap can round past non-integer edges)
-  const snappedW = Math.max(MIN_CUTOUT_SIZE, snap(resized.width));
-  const snappedD = Math.max(MIN_CUTOUT_SIZE, snap(resized.depth));
+  // Snap x/y first, then constrain w/d to fit — otherwise snappedW > binWidth
+  // (small bins, big snap step) leaves x clamped at 0 with the original
+  // snappedW, producing a cutout whose AABB exits the bin.
+  const snappedX = Math.max(0, Math.min(snap(resized.x), bounds.binWidth - MIN_CUTOUT_SIZE));
+  const snappedY = Math.max(0, Math.min(snap(resized.y), bounds.binDepth - MIN_CUTOUT_SIZE));
   const nextPatch = {
-    x: Math.max(0, Math.min(snap(resized.x), bounds.binWidth - snappedW)),
-    y: Math.max(0, Math.min(snap(resized.y), bounds.binDepth - snappedD)),
-    width: snappedW,
-    depth: snappedD,
+    x: snappedX,
+    y: snappedY,
+    width: Math.max(MIN_CUTOUT_SIZE, Math.min(snap(resized.width), bounds.binWidth - snappedX)),
+    depth: Math.max(MIN_CUTOUT_SIZE, Math.min(snap(resized.depth), bounds.binDepth - snappedY)),
   };
 
   // Polygon mask: hard-reject resizes that would overhang the polygon.


### PR DESCRIPTION
## Summary

Two related correctness fixes in the cutout interaction handlers:

### Drag handler — rotation-aware clamp

\`useCutoutInteraction.nudgeSelected\` clamps a rotated cutout against its **rotated** AABB, but \`handleDragMove\` clamped against \`binWidth - cutout.width\` (the unrotated box). A rotated 20×20 square (AABB ≈ 28.28) could be dragged to \`x = binWidth - 20\`, putting its rotated corner ~4mm past the bin edge.

Now uses \`getRotatedBounds()\` to compute per-axis overhang and clamps to \`[overhangX, binWidth - cutout.width - overhangX]\` — mirroring the existing nudge implementation.

### Resize handler — joint clamp on x + width

Snapped \`x\`/\`y\`/\`width\`/\`depth\` were clamped **independently** against the bin, so when snap rounded width past \`binWidth\` (small bins with a large snap step), \`x\` would clamp to 0 with the un-clamped \`snappedW\` intact, producing geometry that exits the bin AABB. Now snaps \`x\` first, then derives \`width = min(snappedW, binWidth - x)\` (same for y/depth), preserving the \`≥ MIN_CUTOUT_SIZE\` floor.

## Why not finding #4 (group-scale pivot)?

The reviewer claimed \`groupScaleHandler\` uses the unrotated AABB center as the rotation pivot, but I traced the math: \`getRotatedBounds()\` puts the rotated AABB at the *same* center as the unrotated box (rotation is around the cutout's own center), so \`(x + w/2, y + d/2)\` is both the rotation pivot and the rotated-AABB center. Existing scale composition produces the right result for the cases I traced.

Including the trace in the commit message in case I'm missing something — happy to revisit if a real failure surfaces.

## Test plan

- [x] New \`dragHandler.test.ts\`: rotated cutout clamps within the rotated AABB; unrotated cutout still clamps to the full bin width.
- [x] New \`resizeHandler.test.ts\`: joint constraint preserves \`x + width ≤ binWidth\`; \`width\` stays \`≥ MIN_CUTOUT_SIZE\` post-clamp.
- [x] All 12 handler tests pass; broader test suite untouched.
- [x] \`pnpm run typecheck\`, all pre-commit checks pass.