### PR TITLE
feat(bin-designer): foundation for engraved text on label tabs and cutouts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Bin → position (x,y), size (w,d,h), layerId, category, label, notes, customPro
 3. **Half-Bin Mode**: 0.5 increments. Helpers: `snapToHalf()`, `snapToGrid()`, `isFractional()`. `HALF_BIN_SCALE = 2`.
 4. **Multi-Layout**: Each layout stored by UUID (`gridfinity-layout-{uuid}`). Library index tracks metadata only.
 5. **Wall Pattern Border Rule**: Any feature that cuts through a wall (cutouts, handles, etc.) MUST have corresponding border clipping in `wallPatternBuilder.ts`. Cutout/handle clips use `CUTOUT_BORDER_WIDTH` (1.5mm); divider junction clips use `max(CUTOUT_BORDER_WIDTH, shapeRadius)` so larger hex prisms (4u+ bins) can't bleed into divider walls. Without border clipping, hex prisms overlap the cut region producing jagged edges.
+6. **Compartment IDs are not stable**: `normalizeIds()` renumbers `compartments.cells` on every merge/split, so any parallel per-compartment array (e.g. `compartmentTexts`) must be reindexed in lockstep via `normalizeIdsWithRemap()` + `remapCompartmentTexts()`. Resetting the grid (`setCompartmentGrid`) regenerates IDs from scratch — drop parallel arrays rather than carry ghost values onto unrelated cells.
 
 ### Result Type (`src/core/result/`)
 

--- a/api/lib/designerValidation.test.ts
+++ b/api/lib/designerValidation.test.ts
@@ -645,4 +645,58 @@ describe('validateDesignerShare', () => {
       }
     });
   });
+
+  describe('textDefaults validation', () => {
+    function withTextDefaults(td: unknown) {
+      const payload = validPayload() as ReturnType<typeof validPayload> & {
+        params: { textDefaults?: unknown };
+      };
+      payload.params.textDefaults = td;
+      return validateDesignerShare(payload, JSON.stringify(payload).length);
+    }
+
+    it('accepts the canonical defaults', () => {
+      const result = withTextDefaults({
+        font: 'atkinson',
+        mode: 'engrave',
+        depth: 0.4,
+        margin: 1.5,
+        minFontSize: 3,
+        maxFontSize: 20,
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects non-object', () => {
+      expect(withTextDefaults('oops').valid).toBe(false);
+    });
+
+    it('rejects unknown keys', () => {
+      const result = withTextDefaults({ font: 'atkinson', evil: 1 });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.error.message).toMatch(/unknown key/);
+    });
+
+    it('rejects unsupported fonts', () => {
+      const result = withTextDefaults({ font: 'comic-sans' });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.error.message).toMatch(/font/);
+    });
+
+    it('rejects unsupported modes', () => {
+      const result = withTextDefaults({ mode: 'blast' });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.error.message).toMatch(/mode/);
+    });
+
+    it('rejects negative depth (crafted-share guard)', () => {
+      const result = withTextDefaults({ depth: -1 });
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects out-of-range maxFontSize (crafted-share guard)', () => {
+      const result = withTextDefaults({ maxFontSize: 1e9 });
+      expect(result.valid).toBe(false);
+    });
+  });
 });

--- a/api/lib/designerValidation.test.ts
+++ b/api/lib/designerValidation.test.ts
@@ -197,6 +197,42 @@ describe('validateDesignerShare', () => {
       const result = validateDesignerShare(payload, JSON.stringify(payload).length);
       expect(result.valid).toBe(true);
     });
+
+    it('accepts compartmentTexts with valid strings', () => {
+      const payload = validPayload();
+      (payload.params.compartments as Record<string, unknown>).compartmentTexts = ['SCREWS'];
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects compartmentTexts that is not an array', () => {
+      const payload = validPayload();
+      (payload.params.compartments as Record<string, unknown>).compartmentTexts = 'oops';
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects compartmentTexts entries that are not strings', () => {
+      const payload = validPayload();
+      (payload.params.compartments as Record<string, unknown>).compartmentTexts = [123];
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects compartmentTexts entries over 50 characters', () => {
+      const payload = validPayload();
+      (payload.params.compartments as Record<string, unknown>).compartmentTexts = ['x'.repeat(51)];
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects compartmentTexts longer than cols × rows', () => {
+      // valid payload has cols=1 rows=1 → max 1 entry
+      const payload = validPayload();
+      (payload.params.compartments as Record<string, unknown>).compartmentTexts = ['A', 'B'];
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(false);
+    });
   });
 
   describe('label tab validation', () => {
@@ -590,6 +626,22 @@ describe('validateDesignerShare', () => {
       expect(result.valid).toBe(false);
       if (!result.valid) {
         expect(result.error.message).toMatch(/unknown corner/);
+      }
+    });
+
+    // `migrateFeatureColors` (defaults.ts) unconditionally writes a `text`
+    // field. The validator must accept it or every cloud share fails 400
+    // for users on the post-migration build.
+    it('accepts the text zone hex (engraved-text color slot)', () => {
+      const result = withColors({ body: '#3b82f6', text: '#22c55e' });
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects a non-hex text zone color', () => {
+      const result = withColors({ body: '#3b82f6', text: 'not-a-hex' });
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.message).toMatch(/text/);
       }
     });
   });

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -102,6 +102,7 @@ const ALLOWED_PARAM_KEYS = new Set<string>([
   'splitConnectors',
   'featureColors',
   'lid',
+  'textDefaults',
 ]);
 
 /**

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -31,6 +31,8 @@ const VALID_LABEL_TAB_SUPPORTS = ['bracket', 'solid', 'fillet'] as const;
 const VALID_INSERT_SHAPES = ['rectangle', 'circle', 'hexagon', 'rounded-rect', 'slot'] as const;
 const VALID_WALL_CUTOUT_SHAPES = ['u-shape', 'scoop', 'funnel'] as const;
 const VALID_ROTATIONS = [0, 90, 180, 270] as const;
+const VALID_TEXT_FONTS = ['atkinson', 'jetbrains-mono', 'allerta-stencil'] as const;
+const VALID_TEXT_MODES = ['engrave', 'emboss', 'through-cut'] as const;
 
 // Constraints (server-side copies of client DESIGNER_CONSTRAINTS)
 const CONSTRAINTS = {
@@ -317,6 +319,62 @@ function validateWalls(walls: unknown): string | null {
   return null;
 }
 
+const ALLOWED_TEXT_DEFAULTS_KEYS = new Set([
+  'font',
+  'mode',
+  'depth',
+  'margin',
+  'minFontSize',
+  'maxFontSize',
+]);
+
+/**
+ * Caps mirror the geometry-pipeline safe ranges that ship in the next PR;
+ * keeping them server-side now means a crafted share can't smuggle in a
+ * `depth: -1` or `maxFontSize: 1e9` that crashes the BREP worker.
+ */
+function validateTextDefaults(value: unknown): string | null {
+  if (!isObject(value)) return 'textDefaults must be an object';
+
+  for (const key of Object.keys(value)) {
+    if (!ALLOWED_TEXT_DEFAULTS_KEYS.has(key)) {
+      return `textDefaults has unknown key: ${key}`;
+    }
+  }
+
+  if (
+    value.font !== undefined &&
+    !VALID_TEXT_FONTS.includes(value.font as (typeof VALID_TEXT_FONTS)[number])
+  ) {
+    return `textDefaults.font must be one of: ${VALID_TEXT_FONTS.join(', ')}`;
+  }
+  if (
+    value.mode !== undefined &&
+    !VALID_TEXT_MODES.includes(value.mode as (typeof VALID_TEXT_MODES)[number])
+  ) {
+    return `textDefaults.mode must be one of: ${VALID_TEXT_MODES.join(', ')}`;
+  }
+  if (value.depth !== undefined && (!isNumber(value.depth) || !inRange(value.depth, 0, 10))) {
+    return 'textDefaults.depth must be 0-10';
+  }
+  if (value.margin !== undefined && (!isNumber(value.margin) || !inRange(value.margin, 0, 50))) {
+    return 'textDefaults.margin must be 0-50';
+  }
+  if (
+    value.minFontSize !== undefined &&
+    (!isNumber(value.minFontSize) || !inRange(value.minFontSize, 0.5, 100))
+  ) {
+    return 'textDefaults.minFontSize must be 0.5-100';
+  }
+  if (
+    value.maxFontSize !== undefined &&
+    (!isNumber(value.maxFontSize) || !inRange(value.maxFontSize, 0.5, 200))
+  ) {
+    return 'textDefaults.maxFontSize must be 0.5-200';
+  }
+  return null;
+}
+
 function validateLabel(label: unknown): string | null {
   if (!isObject(label)) return 'label must be an object';
   if (!isBoolean(label.enabled)) return 'label.enabled must be boolean';
@@ -561,6 +619,11 @@ export function validateDesignerShare(body: unknown, sizeBytes: number): Designe
   if (params.featureColors !== undefined) {
     const fcErr = validateFeatureColors(params.featureColors);
     if (fcErr) return validationError('INVALID_PARAMS', fcErr);
+  }
+
+  if (params.textDefaults !== undefined) {
+    const tdErr = validateTextDefaults(params.textDefaults);
+    if (tdErr) return validationError('INVALID_PARAMS', tdErr);
   }
 
   // Inserts

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -260,6 +260,27 @@ function validateCompartments(compartments: unknown): string | null {
   if (compartments.cells.length !== expectedLength) {
     return `compartments.cells length must be cols × rows (${expectedLength})`;
   }
+  // Optional per-compartment engraved text. Mirrors the client-side
+  // `TEXT_MAX_LENGTH = 50` cap so a direct HTTP POST can't smuggle in
+  // unbounded strings that bypass `setCompartmentText`. Array length
+  // can't exceed the total cell count (one slot per possible compartment ID).
+  if (compartments.compartmentTexts !== undefined) {
+    if (!Array.isArray(compartments.compartmentTexts)) {
+      return 'compartments.compartmentTexts must be an array';
+    }
+    if (compartments.compartmentTexts.length > expectedLength) {
+      return `compartments.compartmentTexts length must not exceed cols × rows (${expectedLength})`;
+    }
+    for (let i = 0; i < compartments.compartmentTexts.length; i++) {
+      const t = compartments.compartmentTexts[i];
+      if (typeof t !== 'string') {
+        return `compartments.compartmentTexts[${i}] must be a string`;
+      }
+      if (t.length > 50) {
+        return `compartments.compartmentTexts[${i}] must not exceed 50 characters`;
+      }
+    }
+  }
   return null;
 }
 
@@ -356,6 +377,7 @@ const ALLOWED_FEATURE_COLOR_KEYS = new Set([
   'base',
   'scoop',
   'dividers',
+  'text',
 ]);
 const ALLOWED_LIP_CORNER_KEYS = new Set<string>(LIP_CORNERS);
 
@@ -378,7 +400,7 @@ function validateFeatureColors(value: unknown): string | null {
     return 'featureColors.enabled must be boolean';
   }
 
-  for (const key of ['body', 'labelTab', 'base', 'scoop', 'dividers'] as const) {
+  for (const key of ['body', 'labelTab', 'base', 'scoop', 'dividers', 'text'] as const) {
     if (value[key] !== undefined && !isValidColor(value[key])) {
       return `featureColors.${key} must be a hex color`;
     }

--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -101,6 +101,18 @@ export const FEATURE_FLAGS = [
     graduatedAt: '2026-05',
     requiresRefresh: false,
   },
+  {
+    id: 'embedded_text',
+    name: 'Engraved Text',
+    description:
+      'Engrave, emboss, or cut text directly into label tabs and beside cutouts. Type a label per compartment or per cutout and it prints into the model.',
+    status: 'experimental',
+    risk: 'medium',
+    warning:
+      'Geometry pipeline and editor UI ship in follow-up updates. Currently only stores the text data and migrates existing designs.',
+    addedAt: '2026-05',
+    requiresRefresh: false,
+  },
 ] as const satisfies readonly FeatureFlag[];
 
 export type FeatureId = (typeof FEATURE_FLAGS)[number]['id'];

--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -109,9 +109,10 @@ export const FEATURE_FLAGS = [
     status: 'experimental',
     risk: 'medium',
     warning:
-      'Geometry pipeline and editor UI ship in follow-up updates. Currently only stores the text data and migrates existing designs.',
+      'Coming soon. The editor UI and 3D engraving pipeline ship in follow-up updates; flipping this flag today has no visible effect.',
     addedAt: '2026-05',
     requiresRefresh: false,
+    comingSoon: true,
   },
 ] as const satisfies readonly FeatureFlag[];
 

--- a/src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
+++ b/src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
@@ -235,6 +235,7 @@ export function ExportDialog() {
                 base: t('binDesigner.colors.base'),
                 scoop: t('binDesigner.colors.scoop'),
                 dividers: t('binDesigner.colors.dividers'),
+                text: t('binDesigner.colors.text'),
               } satisfies Record<ColorZone, string>
             }
           />

--- a/src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.test.tsx
+++ b/src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.test.tsx
@@ -28,12 +28,14 @@ const zoneLabels: Record<ColorZone, string> = {
 
 function buildColors(overrides: Partial<FeatureColorConfig> = {}): FeatureColorConfig {
   return {
+    enabled: true,
     body: '#ffffff',
     lip: { frontLeft: '#ffffff', frontRight: '#ffffff', backRight: '#ffffff', backLeft: '#ffffff' },
     labelTab: '#ffffff',
     base: '#ffffff',
     scoop: '#ffffff',
     dividers: '#ffffff',
+    text: '#ffffff',
     ...overrides,
   };
 }

--- a/src/features/bin-designer/components/PreviewCanvas/ColorToolOverlay.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/ColorToolOverlay.tsx
@@ -39,6 +39,8 @@ function defaultForZone(zone: ColorZone): string {
       return DEFAULT_FEATURE_COLOR_CONFIG.scoop;
     case 'dividers':
       return DEFAULT_FEATURE_COLOR_CONFIG.dividers;
+    case 'text':
+      return DEFAULT_FEATURE_COLOR_CONFIG.text;
     case 'lip:frontLeft':
       return DEFAULT_FEATURE_COLOR_CONFIG.lip.frontLeft;
     case 'lip:frontRight':

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsActionsMenu.test.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsActionsMenu.test.tsx
@@ -14,12 +14,14 @@ vi.mock('@/design-system/Popover/Popover', () => ({
 }));
 
 const fc: FeatureColorConfig = {
+  enabled: false,
   body: '#aaaaaa',
   lip: { frontLeft: '#aaaaaa', frontRight: '#aaaaaa', backRight: '#aaaaaa', backLeft: '#aaaaaa' },
   labelTab: '#aaaaaa',
   base: '#aaaaaa',
   scoop: '#aaaaaa',
   dividers: '#aaaaaa',
+  text: '#aaaaaa',
 };
 
 describe('ColorsActionsMenu', () => {

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.test.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.test.tsx
@@ -16,6 +16,7 @@ function colors(overrides: Partial<FeatureColorConfig> = {}): FeatureColorConfig
     base: SINGLE,
     scoop: SINGLE,
     dividers: SINGLE,
+    text: SINGLE,
     ...overrides,
   };
 }

--- a/src/features/bin-designer/constants/defaults.test.ts
+++ b/src/features/bin-designer/constants/defaults.test.ts
@@ -385,6 +385,7 @@ describe('migrateParams', () => {
       base: '#d4d8dc',
       scoop: '#d4d8dc',
       dividers: '#d4d8dc',
+      text: '#d4d8dc',
     });
   });
 
@@ -451,6 +452,9 @@ describe('migrateParams', () => {
       base: '#ef4444',
       scoop: '#ef4444',
       dividers: '#ef4444',
+      // Text zone was added in v4.109. Old payloads default to inheriting the
+      // label-tab color so single-color users see no shift on migrate.
+      text: '#22c55e',
     };
     const firstPass = migrateParams({ featureColors: hex });
     const secondPass = migrateParams(firstPass);

--- a/src/features/bin-designer/constants/defaults.ts
+++ b/src/features/bin-designer/constants/defaults.ts
@@ -23,6 +23,10 @@ import type { FeatureColorConfig } from '../types/featureColors';
 import type { LidConfig } from '../types/lid';
 import { DEFAULT_LID_CONFIG, LID_CLICK_RAIL_COVERAGE_OPTIONS } from '../types/lid';
 import type { LidClickRails } from '../types/lid';
+import type { TextStyleDefaults } from '../types/text';
+import { DEFAULT_TEXT_STYLE_DEFAULTS } from '../types/text';
+
+export { DEFAULT_TEXT_STYLE_DEFAULTS };
 
 /** Default slot configuration: vertical (x-axis) enabled, 20mm pitch */
 const DEFAULT_SLOT_CONFIG: SlotConfig = {
@@ -165,6 +169,7 @@ export const DEFAULT_FEATURE_COLOR_CONFIG: FeatureColorConfig = {
   base: '#d4d8dc',
   scoop: '#d4d8dc',
   dividers: '#d4d8dc',
+  text: '#d4d8dc',
 } as const;
 
 interface LegacyFeatureColorInput {
@@ -176,6 +181,7 @@ interface LegacyFeatureColorInput {
   base?: string;
   scoop?: string;
   dividers?: string;
+  text?: string;
 }
 
 function resolveColor(raw: string | undefined, fallback: string): string {
@@ -216,6 +222,9 @@ function migrateFeatureColors(raw: LegacyFeatureColorInput | undefined): Feature
   const base = resolveColor(raw.base, body);
   const scoop = resolveColor(raw.scoop, body);
   const dividers = resolveColor(raw.dividers, body);
+  // Text defaults to the label-tab color so single-color designs see no shift
+  // when this field is added by migration.
+  const text = resolveColor(raw.text, labelTab);
 
   // Pre-`enabled` design counts as multi-color if body or any zone diverges
   // from the default — zone editors only existed behind the old Labs flag, so
@@ -224,10 +233,19 @@ function migrateFeatureColors(raw: LegacyFeatureColorInput | undefined): Feature
   const isCustom = (c: string): boolean => c.toLowerCase() !== bodyLower;
   const hasCustomColor =
     bodyLower !== DEFAULT_FEATURE_COLOR_CONFIG.body.toLowerCase() ||
-    [labelTab, base, scoop, dividers].some(isCustom) ||
+    [labelTab, base, scoop, dividers, text].some(isCustom) ||
     [lip.frontLeft, lip.frontRight, lip.backRight, lip.backLeft].some(isCustom);
 
-  return { enabled: raw.enabled ?? hasCustomColor, body, lip, labelTab, base, scoop, dividers };
+  return {
+    enabled: raw.enabled ?? hasCustomColor,
+    body,
+    lip,
+    labelTab,
+    base,
+    scoop,
+    dividers,
+    text,
+  };
 }
 
 /** Default bin parameters: 2x2x3 standard bin with no compartments */
@@ -285,6 +303,7 @@ export const DEFAULT_BIN_PARAMS: BinParams = {
   wallPattern: DEFAULT_WALL_PATTERN_CONFIG,
   featureColors: DEFAULT_FEATURE_COLOR_CONFIG,
   lid: DEFAULT_LID_CONFIG,
+  textDefaults: DEFAULT_TEXT_STYLE_DEFAULTS,
 } as const;
 
 /** Default generation state */
@@ -633,5 +652,9 @@ export function migrateParams(params: MigrateParamsInput): BinParams {
     ...(params.splitConnectors !== undefined
       ? { splitConnectors: { ...DEFAULT_SPLIT_CONNECTOR_CONFIG, ...params.splitConnectors } }
       : {}),
+    textDefaults: {
+      ...DEFAULT_TEXT_STYLE_DEFAULTS,
+      ...((params as { textDefaults?: Partial<TextStyleDefaults> }).textDefaults ?? {}),
+    },
   };
 }

--- a/src/features/bin-designer/constants/defaults.ts
+++ b/src/features/bin-designer/constants/defaults.ts
@@ -26,8 +26,6 @@ import type { LidClickRails } from '../types/lid';
 import type { TextStyleDefaults } from '../types/text';
 import { DEFAULT_TEXT_STYLE_DEFAULTS } from '../types/text';
 
-export { DEFAULT_TEXT_STYLE_DEFAULTS };
-
 /** Default slot configuration: vertical (x-axis) enabled, 20mm pitch */
 const DEFAULT_SLOT_CONFIG: SlotConfig = {
   x: { enabled: true, pitch: 20 },

--- a/src/features/bin-designer/store/designer.scenario.compartments.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.compartments.test.ts
@@ -756,6 +756,18 @@ describe('DesignerStore - compartment actions', () => {
       expect(useDesignerStore.getState().history.past.length).toBe(beforeHistoryLength);
     });
 
+    it('is cleared when the grid is resized (avoids ghost text on regenerated IDs)', () => {
+      const { setCompartmentGrid, setCompartmentText } = useDesignerStore.getState();
+      setCompartmentGrid(2, 2);
+      setCompartmentText(0, 'SCREWS');
+      setCompartmentText(3, 'WASHERS');
+
+      setCompartmentGrid(3, 3);
+
+      const { params } = useDesignerStore.getState();
+      expect(params.compartments.compartmentTexts).toBeUndefined();
+    });
+
     it('drops trailing empty slots from the stored array', () => {
       const { setCompartmentGrid, setCompartmentText } = useDesignerStore.getState();
       setCompartmentGrid(3, 1);

--- a/src/features/bin-designer/store/designer.scenario.compartments.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.compartments.test.ts
@@ -713,4 +713,59 @@ describe('DesignerStore - compartment actions', () => {
       expect(history.past.length).toBeLessThanOrEqual(DESIGNER_CONSTRAINTS.MAX_HISTORY);
     });
   });
+
+  describe('setCompartmentText', () => {
+    it('stores text on the specified compartment', () => {
+      const { setCompartmentGrid, setCompartmentText } = useDesignerStore.getState();
+      setCompartmentGrid(2, 1);
+      setCompartmentText(0, 'SCREWS');
+
+      const { params } = useDesignerStore.getState();
+      expect(params.compartments.compartmentTexts).toEqual(['SCREWS']);
+    });
+
+    it('clamps text to TEXT_MAX_LENGTH (50 chars)', () => {
+      const { setCompartmentGrid, setCompartmentText } = useDesignerStore.getState();
+      setCompartmentGrid(1, 1);
+      setCompartmentText(0, 'x'.repeat(100));
+
+      const { params } = useDesignerStore.getState();
+      expect(params.compartments.compartmentTexts?.[0]).toHaveLength(50);
+    });
+
+    it('does not push history for a no-op write', () => {
+      const { setCompartmentGrid, setCompartmentText } = useDesignerStore.getState();
+      setCompartmentGrid(1, 1);
+      setCompartmentText(0, 'A');
+      const beforeHistoryLength = useDesignerStore.getState().history.past.length;
+
+      // Same value again — must not push a history entry. This matters
+      // because the UI calls setCompartmentText on every keystroke; without
+      // this guard, pasting the same value would spawn one undo step per
+      // character.
+      setCompartmentText(0, 'A');
+      expect(useDesignerStore.getState().history.past.length).toBe(beforeHistoryLength);
+    });
+
+    it('does not push history when re-clearing an already-empty slot', () => {
+      const { setCompartmentGrid, setCompartmentText } = useDesignerStore.getState();
+      setCompartmentGrid(1, 1);
+      const beforeHistoryLength = useDesignerStore.getState().history.past.length;
+
+      setCompartmentText(0, '');
+      expect(useDesignerStore.getState().history.past.length).toBe(beforeHistoryLength);
+    });
+
+    it('drops trailing empty slots from the stored array', () => {
+      const { setCompartmentGrid, setCompartmentText } = useDesignerStore.getState();
+      setCompartmentGrid(3, 1);
+      setCompartmentText(0, 'A');
+      setCompartmentText(2, 'C');
+      // Clear the last entry → trailing-empty trim should shrink the array.
+      setCompartmentText(2, '');
+
+      const { params } = useDesignerStore.getState();
+      expect(params.compartments.compartmentTexts).toEqual(['A']);
+    });
+  });
 });

--- a/src/features/bin-designer/store/slices/paramSlice.ts
+++ b/src/features/bin-designer/store/slices/paramSlice.ts
@@ -334,10 +334,19 @@ export function createParamSlice(set: Set, get: Get) {
     },
 
     setCompartmentText: (compartmentId: number, text: string) => {
+      const { params } = get();
+      const clamped = text.slice(0, TEXT_MAX_LENGTH);
+      const prev = params.compartments.compartmentTexts ?? [];
+      // No-op short-circuit: writing the same text to the same slot must
+      // not push a history entry. The UI calls this on every keystroke, so
+      // a no-op would create one undoable step per character of e.g.
+      // pasting the same value back in — and would defeat the trailing-
+      // empty trim by spawning empty mutations on already-clear slots.
+      const current = prev[compartmentId] ?? '';
+      if (current === clamped) return;
+
       set((state) => {
         pushHistoryEntry(state);
-        const clamped = text.slice(0, TEXT_MAX_LENGTH);
-        const prev = state.params.compartments.compartmentTexts ?? [];
         const next = prev.slice();
         // Grow with empty slots so the array length covers compartmentId.
         while (next.length <= compartmentId) next.push('');

--- a/src/features/bin-designer/store/slices/paramSlice.ts
+++ b/src/features/bin-designer/store/slices/paramSlice.ts
@@ -254,8 +254,11 @@ export function createParamSlice(set: Set, get: Get) {
         for (let i = 0; i < rows * cols; i++) {
           cells.push(i);
         }
+        // Old per-compartment text would attach to unrelated cells once
+        // IDs regenerate — drop it.
+        const { compartmentTexts: _drop, ...keepCompartments } = state.params.compartments;
         state.params.compartments = {
-          ...state.params.compartments,
+          ...keepCompartments,
           cols,
           rows,
           cells,
@@ -337,21 +340,15 @@ export function createParamSlice(set: Set, get: Get) {
       const { params } = get();
       const clamped = text.slice(0, TEXT_MAX_LENGTH);
       const prev = params.compartments.compartmentTexts ?? [];
-      // No-op short-circuit: writing the same text to the same slot must
-      // not push a history entry. The UI calls this on every keystroke, so
-      // a no-op would create one undoable step per character of e.g.
-      // pasting the same value back in — and would defeat the trailing-
-      // empty trim by spawning empty mutations on already-clear slots.
-      const current = prev[compartmentId] ?? '';
-      if (current === clamped) return;
+      // No-op guard: the UI calls this on every keystroke, so an unchanged
+      // value must not push a history entry (would be one undo step per char).
+      if ((prev[compartmentId] ?? '') === clamped) return;
 
       set((state) => {
         pushHistoryEntry(state);
         const next = prev.slice();
-        // Grow with empty slots so the array length covers compartmentId.
         while (next.length <= compartmentId) next.push('');
         next[compartmentId] = clamped;
-        // Drop trailing empty slots so identical no-op writes don't bloat the JSON.
         while (next.length > 0 && next[next.length - 1] === '') next.pop();
         state.params.compartments = {
           ...state.params.compartments,

--- a/src/features/bin-designer/store/slices/paramSlice.ts
+++ b/src/features/bin-designer/store/slices/paramSlice.ts
@@ -19,7 +19,10 @@ import type {
   HandleSide,
   HandleWallSide,
   LidConfig,
+  TextStyleDefaults,
+  TextStyleOverride,
 } from '../../types';
+import { TEXT_MAX_LENGTH } from '../../types/text';
 import type { LipColorConfig } from '../../types/featureColors';
 import { DEFAULT_BIN_PARAMS } from '../../constants';
 import { isErr } from '@/core/result';
@@ -333,12 +336,12 @@ export function createParamSlice(set: Set, get: Get) {
     setCompartmentText: (compartmentId: number, text: string) => {
       set((state) => {
         pushHistoryEntry(state);
-        const trimmed = text.slice(0, 50);
+        const clamped = text.slice(0, TEXT_MAX_LENGTH);
         const prev = state.params.compartments.compartmentTexts ?? [];
         const next = prev.slice();
         // Grow with empty slots so the array length covers compartmentId.
         while (next.length <= compartmentId) next.push('');
-        next[compartmentId] = trimmed;
+        next[compartmentId] = clamped;
         // Drop trailing empty slots so identical no-op writes don't bloat the JSON.
         while (next.length > 0 && next[next.length - 1] === '') next.pop();
         state.params.compartments = {
@@ -348,14 +351,14 @@ export function createParamSlice(set: Set, get: Get) {
       });
     },
 
-    setTextDefaults: (partial: Partial<BinParams['textDefaults']>) => {
+    setTextDefaults: (partial: Partial<TextStyleDefaults>) => {
       set((state) => {
         pushHistoryEntry(state);
         state.params.textDefaults = { ...state.params.textDefaults, ...partial };
       });
     },
 
-    setLabelTabTextStyle: (overrides: BinParams['label']['textStyle'] | null) => {
+    setLabelTabTextStyle: (overrides: TextStyleOverride | null) => {
       set((state) => {
         pushHistoryEntry(state);
         if (overrides === null) {

--- a/src/features/bin-designer/store/slices/paramSlice.ts
+++ b/src/features/bin-designer/store/slices/paramSlice.ts
@@ -23,7 +23,11 @@ import type {
 import type { LipColorConfig } from '../../types/featureColors';
 import { DEFAULT_BIN_PARAMS } from '../../constants';
 import { isErr } from '@/core/result';
-import { isRectangularSelection, normalizeIds } from '../../utils/compartments';
+import {
+  isRectangularSelection,
+  normalizeIdsWithRemap,
+  remapCompartmentTexts,
+} from '../../utils/compartments';
 import { validateCompartmentSizes } from '../../utils/validation';
 import { defaultsForNewDesign, pushHistoryEntry } from '../helpers';
 import {
@@ -186,6 +190,7 @@ export function createParamSlice(set: Set, get: Get) {
       base?: string;
       scoop?: string;
       dividers?: string;
+      text?: string;
     }) => {
       set((state) => {
         pushHistoryEntry(state);
@@ -271,9 +276,12 @@ export function createParamSlice(set: Set, get: Get) {
         for (const idx of cellIndices) {
           newCells[idx] = targetId;
         }
+        const { cells: normalized, remap } = normalizeIdsWithRemap(newCells);
+        const prevTexts = state.params.compartments.compartmentTexts;
         state.params.compartments = {
           ...state.params.compartments,
-          cells: normalizeIds(newCells),
+          cells: normalized,
+          ...(prevTexts ? { compartmentTexts: remapCompartmentTexts(prevTexts, remap) } : {}),
         };
       });
     },
@@ -305,9 +313,12 @@ export function createParamSlice(set: Set, get: Get) {
             }
           }
         }
+        const { cells: normalized, remap } = normalizeIdsWithRemap(newCells);
+        const prevTexts = state.params.compartments.compartmentTexts;
         state.params.compartments = {
           ...state.params.compartments,
-          cells: normalizeIds(newCells),
+          cells: normalized,
+          ...(prevTexts ? { compartmentTexts: remapCompartmentTexts(prevTexts, remap) } : {}),
         };
       });
     },
@@ -316,6 +327,43 @@ export function createParamSlice(set: Set, get: Get) {
       set((state) => {
         pushHistoryEntry(state);
         state.params.compartments = { ...DEFAULT_BIN_PARAMS.compartments };
+      });
+    },
+
+    setCompartmentText: (compartmentId: number, text: string) => {
+      set((state) => {
+        pushHistoryEntry(state);
+        const trimmed = text.slice(0, 50);
+        const prev = state.params.compartments.compartmentTexts ?? [];
+        const next = prev.slice();
+        // Grow with empty slots so the array length covers compartmentId.
+        while (next.length <= compartmentId) next.push('');
+        next[compartmentId] = trimmed;
+        // Drop trailing empty slots so identical no-op writes don't bloat the JSON.
+        while (next.length > 0 && next[next.length - 1] === '') next.pop();
+        state.params.compartments = {
+          ...state.params.compartments,
+          ...(next.length > 0 ? { compartmentTexts: next } : { compartmentTexts: undefined }),
+        };
+      });
+    },
+
+    setTextDefaults: (partial: Partial<BinParams['textDefaults']>) => {
+      set((state) => {
+        pushHistoryEntry(state);
+        state.params.textDefaults = { ...state.params.textDefaults, ...partial };
+      });
+    },
+
+    setLabelTabTextStyle: (overrides: BinParams['label']['textStyle'] | null) => {
+      set((state) => {
+        pushHistoryEntry(state);
+        if (overrides === null) {
+          const { textStyle: _omit, ...rest } = state.params.label;
+          state.params.label = rest;
+        } else {
+          state.params.label = { ...state.params.label, textStyle: overrides };
+        }
       });
     },
 

--- a/src/features/bin-designer/types/featureColors.test.ts
+++ b/src/features/bin-designer/types/featureColors.test.ts
@@ -14,12 +14,14 @@ const SINGLE = '#d4d8dc';
 
 function colors(overrides: Partial<FeatureColorConfig> = {}): FeatureColorConfig {
   return {
+    enabled: false,
     body: SINGLE,
     lip: { frontLeft: SINGLE, frontRight: SINGLE, backRight: SINGLE, backLeft: SINGLE },
     labelTab: SINGLE,
     base: SINGLE,
     scoop: SINGLE,
     dividers: SINGLE,
+    text: SINGLE,
     ...overrides,
   };
 }
@@ -114,12 +116,14 @@ describe('isSingleColor', () => {
 describe('resolveColorMapping', () => {
   it('puts body at index 0 and dedupes equal colors', () => {
     const c: FeatureColorConfig = {
+      enabled: false,
       body: '#aaa',
       lip: { frontLeft: '#aaa', frontRight: '#aaa', backRight: '#aaa', backLeft: '#aaa' },
       labelTab: '#aaa',
       base: '#bbb',
       scoop: '#aaa',
       dividers: '#aaa',
+      text: '#aaa',
     };
     const { colors: palette, colorToIndex, defaultIndex } = resolveColorMapping(c);
     expect(defaultIndex).toBe(0);

--- a/src/features/bin-designer/types/featureColors.ts
+++ b/src/features/bin-designer/types/featureColors.ts
@@ -42,6 +42,12 @@ export interface FeatureColorConfig {
   readonly scoop: string;
   /** Interior compartment dividers (FeatureTag.DIVIDER). */
   readonly dividers: string;
+  /**
+   * Engraved text on label tabs and adjacent to cutouts (FeatureTag.TEXT).
+   * Defaults to the label-tab color so single-color users see no change;
+   * multi-material printers can paint a contrasting filament here.
+   */
+  readonly text: string;
 }
 
 /**
@@ -60,7 +66,8 @@ export type ColorZone =
   | 'labelTab'
   | 'base'
   | 'scoop'
-  | 'dividers';
+  | 'dividers'
+  | 'text';
 
 /** Hover target — accepts every ColorZone plus the lip group header. */
 export type HoverableZone = ColorZone | 'lip';
@@ -80,6 +87,7 @@ export const ZONE_ORDER: readonly ColorZone[] = [
   'base',
   'scoop',
   'dividers',
+  'text',
 ] as const;
 
 /** Position of a zone in ZONE_ORDER. */
@@ -99,6 +107,8 @@ export function getZoneColor(c: FeatureColorConfig, z: ColorZone): string {
       return c.scoop;
     case 'dividers':
       return c.dividers;
+    case 'text':
+      return c.text;
     case 'lip:frontLeft':
       return c.lip.frontLeft;
     case 'lip:frontRight':
@@ -128,6 +138,8 @@ export function featureTagToColorZone(tag: number): ColorZone | null {
       return 'scoop';
     case FeatureTag.DIVIDER:
       return 'dividers';
+    case FeatureTag.TEXT:
+      return 'text';
     case FeatureTag.LIP:
       return null;
     default:
@@ -166,7 +178,11 @@ export interface ActiveZonesParams {
   readonly base: { readonly style: BaseStyle; readonly stackingLip: boolean };
   readonly label: { readonly enabled: boolean };
   readonly scoop: { readonly enabled: boolean };
-  readonly compartments: { readonly cells: readonly number[] };
+  readonly compartments: {
+    readonly cells: readonly number[];
+    readonly compartmentTexts?: readonly string[];
+  };
+  readonly cutouts?: readonly { readonly engraveLabel?: boolean; readonly label: string }[];
 }
 
 /**
@@ -180,6 +196,11 @@ export function computeActiveZones(p: ActiveZonesParams): ReadonlySet<ColorZone>
   const cells = p.compartments.cells;
   const firstCell = cells[0] ?? 0;
   const hasDividers = cells.length > 1 && cells.some((c) => c !== firstCell);
+  const hasTabText =
+    p.label.enabled && (p.compartments.compartmentTexts ?? []).some((t) => t.trim().length > 0);
+  const hasCutoutText = (p.cutouts ?? []).some(
+    (c) => c.engraveLabel === true && c.label.trim().length > 0
+  );
 
   const zones = new Set<ColorZone>(['body']);
   if (p.base.style !== 'flat') zones.add('base');
@@ -189,6 +210,7 @@ export function computeActiveZones(p: ActiveZonesParams): ReadonlySet<ColorZone>
   if (p.label.enabled) zones.add('labelTab');
   if (p.scoop.enabled) zones.add('scoop');
   if (hasDividers) zones.add('dividers');
+  if (hasTabText || hasCutoutText) zones.add('text');
   return zones;
 }
 

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -169,6 +169,10 @@ export interface CompartmentConfig {
    * after `normalizeIds`. Empty / missing entries render no text on the tab.
    * Length need not equal compartment count; trailing slots are treated as
    * empty. Kept in lockstep with `cells` via `normalizeIdsWithRemap`.
+   *
+   * Element type intentionally `string[]` (not `readonly string[]`) to mirror
+   * sibling `cells: number[]`. The whole `params` tree passes through Immer
+   * `Draft`s, which require mutable element types.
    */
   readonly compartmentTexts?: string[];
 }

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -34,7 +34,7 @@ export type {
   TextStyleDefaults,
   TextStyleOverride,
 } from './text';
-export { TEXT_MAX_LENGTH, TEXT_WARN_LENGTH } from './text';
+export { TEXT_MAX_LENGTH } from './text';
 
 /**
  * Eyedropper click anchor: which zone was hit and the viewport coords

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -25,6 +25,16 @@ import type { DesignId } from '@/core/types';
 import type { CellMask } from '@/shared/utils/cellMask';
 import type { ColorZone, FeatureColorConfig, HoverableZone, LipColorConfig } from './featureColors';
 import type { LidConfig } from './lid';
+import type { TextStyleDefaults, TextStyleOverride, CutoutTextSide } from './text';
+
+export type {
+  TextMode,
+  TextFontFamily,
+  CutoutTextSide,
+  TextStyleDefaults,
+  TextStyleOverride,
+} from './text';
+export { TEXT_MAX_LENGTH, TEXT_WARN_LENGTH } from './text';
 
 /**
  * Eyedropper click anchor: which zone was hit and the viewport coords
@@ -154,6 +164,13 @@ export interface CompartmentConfig {
    * Cells with the same ID must form a rectangle.
    */
   readonly cells: number[];
+  /**
+   * Optional per-compartment engraved label text, indexed by compartment ID
+   * after `normalizeIds`. Empty / missing entries render no text on the tab.
+   * Length need not equal compartment count; trailing slots are treated as
+   * empty. Kept in lockstep with `cells` via `normalizeIdsWithRemap`.
+   */
+  readonly compartmentTexts?: string[];
 }
 
 /** Scoop ramp configuration for compartment accessibility */
@@ -180,6 +197,11 @@ export interface LabelTabConfig {
   readonly width: number;
   /** Horizontal alignment within each compartment column */
   readonly alignment: LabelTabAlignment;
+  /**
+   * Optional per-design style override for engraved compartment text on
+   * label tabs. When omitted, `BinParams.textDefaults` apply unchanged.
+   */
+  readonly textStyle?: TextStyleOverride;
 }
 
 /** Handle-eligible wall sides (outer walls only, no interior dividers) */
@@ -321,6 +343,12 @@ export interface BinParams {
   readonly splitConnectors?: SplitConnectorConfig;
   /** Per-feature filament color assignment for multi-color 3MF export. */
   readonly featureColors: FeatureColorConfig;
+  /**
+   * Design-level defaults for engraved text geometry on label tabs and
+   * adjacent to cutouts. Individual instances may attach a
+   * `TextStyleOverride` that selectively overrides these fields.
+   */
+  readonly textDefaults: TextStyleDefaults;
   /** Click-lock lid configuration. Lid is generated as a separate companion solid. */
   readonly lid: LidConfig;
   /**
@@ -464,6 +492,23 @@ export interface Cutout {
   readonly zIndex?: number;
   /** Path vertices for pen tool shapes (required when shape === 'path') */
   readonly path?: PathPoint[];
+  /**
+   * When true, `label` is also engraved on the bin top adjacent to this
+   * cutout. Default false so existing designs render unchanged after
+   * adding this field.
+   */
+  readonly engraveLabel?: boolean;
+  /**
+   * Which side of the cutout (in its local rotated frame) the engraved
+   * label sits on. Defaults to 'top' (back-of-cutout in local frame).
+   * Ignored when `engraveLabel` is false.
+   */
+  readonly textSide?: CutoutTextSide;
+  /**
+   * Optional per-cutout style override. When omitted, the design-level
+   * `BinParams.textDefaults` apply. Ignored when `engraveLabel` is false.
+   */
+  readonly textStyle?: TextStyleOverride;
 }
 
 // Generation Types
@@ -684,6 +729,7 @@ export interface DesignerState {
     base?: string;
     scoop?: string;
     dividers?: string;
+    text?: string;
   }) => void;
   updateLid: (partial: Partial<LidConfig>) => void;
 
@@ -708,6 +754,11 @@ export interface DesignerState {
   mergeCells: (cellIndices: readonly number[]) => void;
   splitCompartment: (compartmentId: number) => void;
   resetCompartments: () => void;
+  setCompartmentText: (compartmentId: number, text: string) => void;
+
+  // Text style actions (engraved text on label tabs and cutouts)
+  setTextDefaults: (partial: Partial<TextStyleDefaults>) => void;
+  setLabelTabTextStyle: (overrides: TextStyleOverride | null) => void;
 
   // Wall pattern actions
   updateWallPattern: (partial: Partial<WallPatternConfig>) => void;

--- a/src/features/bin-designer/types/text.ts
+++ b/src/features/bin-designer/types/text.ts
@@ -1,0 +1,67 @@
+/**
+ * Embedded text type definitions.
+ *
+ * Text engraved/embossed/cut into label tabs and adjacent to cutouts.
+ * Geometry is produced by `textBuilder` at generation time using
+ * brepjs `sketchText` + `extrude`. Fonts are loaded once at worker init.
+ *
+ * Style is scoped: `TextStyleDefaults` lives on `BinParams.textDefaults`
+ * (design-wide defaults) and individual instances may attach a
+ * `TextStyleOverride` to selectively override fields.
+ */
+
+/** Geometry interaction mode of an engraved text instance. */
+export type TextMode = 'engrave' | 'emboss' | 'through-cut';
+
+/**
+ * Bundled font family. `allerta-stencil` is auto-substituted when
+ * `mode === 'through-cut'` regardless of the picked family because
+ * non-stencil glyphs have free-floating counter islands.
+ */
+export type TextFontFamily = 'atkinson' | 'jetbrains-mono' | 'allerta-stencil';
+
+/**
+ * Which side of a cutout the engraved text sits on, expressed in the
+ * cutout's local frame (rotates with the cutout). Text orientation
+ * itself stays world-aligned for legibility.
+ */
+export type CutoutTextSide = 'top' | 'bottom' | 'left' | 'right';
+
+/** Design-level defaults inherited by every text instance unless overridden. */
+export interface TextStyleDefaults {
+  readonly font: TextFontFamily;
+  readonly mode: TextMode;
+  /** Engrave depth or emboss height in mm. */
+  readonly depth: number;
+  /** Padding to host edge for auto-fit, in mm. */
+  readonly margin: number;
+  /** Auto-fit floor in mm; legibility minimum. */
+  readonly minFontSize: number;
+  /** Auto-fit ceiling in mm. */
+  readonly maxFontSize: number;
+}
+
+/**
+ * Per-instance override. Any subset of `TextStyleDefaults`, plus an
+ * optional `fontSizeOverride` that bypasses auto-fit and locks the
+ * rendered size to an explicit mm value.
+ */
+export type TextStyleOverride = Partial<TextStyleDefaults> & {
+  readonly fontSizeOverride?: number;
+};
+
+/** Hard upper bound on a single text string. Beyond this, input is rejected. */
+export const TEXT_MAX_LENGTH = 50;
+
+/** Soft warning threshold for input length. */
+export const TEXT_WARN_LENGTH = 20;
+
+/** Default engraved-text style applied to every text instance unless overridden. */
+export const DEFAULT_TEXT_STYLE_DEFAULTS: TextStyleDefaults = {
+  font: 'atkinson',
+  mode: 'engrave',
+  depth: 0.4,
+  margin: 1.5,
+  minFontSize: 3,
+  maxFontSize: 20,
+} as const;

--- a/src/features/bin-designer/types/text.ts
+++ b/src/features/bin-designer/types/text.ts
@@ -1,16 +1,11 @@
 /**
- * Embedded text type definitions.
+ * Style for text engraved/embossed/cut into label tabs and adjacent to cutouts.
  *
- * Text engraved/embossed/cut into label tabs and adjacent to cutouts.
- * Geometry is produced by `textBuilder` at generation time using
- * brepjs `sketchText` + `extrude`. Fonts are loaded once at worker init.
- *
- * Style is scoped: `TextStyleDefaults` lives on `BinParams.textDefaults`
- * (design-wide defaults) and individual instances may attach a
- * `TextStyleOverride` to selectively override fields.
+ * Scoping: `TextStyleDefaults` lives on `BinParams.textDefaults` (design-wide);
+ * individual instances may attach a `TextStyleOverride` to selectively override
+ * any subset of those fields.
  */
 
-/** Geometry interaction mode of an engraved text instance. */
 export type TextMode = 'engrave' | 'emboss' | 'through-cut';
 
 /**
@@ -27,7 +22,6 @@ export type TextFontFamily = 'atkinson' | 'jetbrains-mono' | 'allerta-stencil';
  */
 export type CutoutTextSide = 'top' | 'bottom' | 'left' | 'right';
 
-/** Design-level defaults inherited by every text instance unless overridden. */
 export interface TextStyleDefaults {
   readonly font: TextFontFamily;
   readonly mode: TextMode;
@@ -41,22 +35,14 @@ export interface TextStyleDefaults {
   readonly maxFontSize: number;
 }
 
-/**
- * Per-instance override. Any subset of `TextStyleDefaults`, plus an
- * optional `fontSizeOverride` that bypasses auto-fit and locks the
- * rendered size to an explicit mm value.
- */
+/** `fontSizeOverride` bypasses auto-fit and locks the size to a mm value. */
 export type TextStyleOverride = Partial<TextStyleDefaults> & {
   readonly fontSizeOverride?: number;
 };
 
-/** Hard upper bound on a single text string. Beyond this, input is rejected. */
+/** Hard cap on a single text string — input above this is rejected. */
 export const TEXT_MAX_LENGTH = 50;
 
-/** Soft warning threshold for input length. */
-export const TEXT_WARN_LENGTH = 20;
-
-/** Default engraved-text style applied to every text instance unless overridden. */
 export const DEFAULT_TEXT_STYLE_DEFAULTS: TextStyleDefaults = {
   font: 'atkinson',
   mode: 'engrave',

--- a/src/features/bin-designer/utils/compartments.test.ts
+++ b/src/features/bin-designer/utils/compartments.test.ts
@@ -13,6 +13,8 @@ import {
   mergeCells,
   splitCompartment,
   normalizeIds,
+  normalizeIdsWithRemap,
+  remapCompartmentTexts,
   deriveWallSegments,
   fromDividerConfig,
 } from '@/features/bin-designer/utils/compartments';
@@ -584,6 +586,108 @@ describe('compartments', () => {
       const result = normalizeIds(cells);
       // First occurrence: 10 -> 0, 5 -> 1, 8 -> 2
       expect(result).toEqual([0, 0, 1, 2]);
+    });
+  });
+
+  describe('normalizeIdsWithRemap', () => {
+    it('exposes the oldId -> newId remap alongside normalized cells', () => {
+      const { cells, remap } = normalizeIdsWithRemap([10, 10, 5, 8]);
+      expect(cells).toEqual([0, 0, 1, 2]);
+      expect(remap.get(10)).toBe(0);
+      expect(remap.get(5)).toBe(1);
+      expect(remap.get(8)).toBe(2);
+    });
+
+    it('returns empty cells + empty remap for an empty input', () => {
+      const { cells, remap } = normalizeIdsWithRemap([]);
+      expect(cells).toEqual([]);
+      expect(remap.size).toBe(0);
+    });
+  });
+
+  describe('remapCompartmentTexts', () => {
+    it('returns empty array for undefined or empty input', () => {
+      expect(remapCompartmentTexts(undefined, new Map())).toEqual([]);
+      expect(remapCompartmentTexts([], new Map([[0, 0]]))).toEqual([]);
+    });
+
+    it('migrates per-compartment text into the new ID slots', () => {
+      // Original IDs 0,1,2 → remapped to 0,1,2 (no change)
+      const remap = new Map([
+        [0, 0],
+        [1, 1],
+        [2, 2],
+      ]);
+      const out = remapCompartmentTexts(['A', 'B', 'C'], remap);
+      expect(out).toEqual(['A', 'B', 'C']);
+    });
+
+    it('handles renumbering across split (new IDs get empty strings)', () => {
+      // Split compartment 1 into two: 1 stays, new 2 appears, old 2 → 3
+      const remap = new Map([
+        [0, 0],
+        [1, 1],
+        [3, 2],
+        [2, 3],
+      ]);
+      const out = remapCompartmentTexts(['A', 'B', 'C'], remap);
+      // 'A' stays at new 0, 'B' stays at new 1, original 3 had no text → '',
+      // and 'C' (old 2) moves to new 3.
+      expect(out).toEqual(['A', 'B', '', 'C']);
+    });
+
+    it('handles renumbering across merge (collapsed IDs drop out)', () => {
+      // Merge: ids 0,1 both map to new 0; old 2 → new 1
+      const remap = new Map([
+        [0, 0],
+        [1, 0],
+        [2, 1],
+      ]);
+      const out = remapCompartmentTexts(['A', 'B', 'C'], remap);
+      // 'A' wins index 0 (insertion order — but Map iterates in insertion order,
+      // so the contract is "later writers stomp earlier", giving us 'B' at slot 0
+      // when 1 is processed second). To pin the behavior down:
+      // For [0,0] → out[0]='A'; for [1,0] → out[0]='B'; for [2,1] → out[1]='C'.
+      expect(out).toEqual(['B', 'C']);
+    });
+  });
+
+  describe('mergeCells with compartmentTexts', () => {
+    it('keeps the target compartment text after a merge', () => {
+      // 2×2 with cells [0,1,2,3] and texts ['A','B','C','D']. Merge indices
+      // [0,1] (top row). targetId = min(0,1) = 0, so the merged compartment
+      // keeps text 'A'. The remaining compartments (old 2,3 → new 1,2) keep
+      // 'C' and 'D'.
+      const config: CompartmentConfig = {
+        cols: 2,
+        rows: 2,
+        thickness: 1.2,
+        cells: [0, 1, 2, 3],
+        compartmentTexts: ['A', 'B', 'C', 'D'],
+      };
+      const merged = mergeCells(config, [0, 1]);
+      expect(merged?.cells).toEqual([0, 0, 1, 2]);
+      expect(merged?.compartmentTexts).toEqual(['A', 'C', 'D']);
+    });
+  });
+
+  describe('splitCompartment with compartmentTexts', () => {
+    it('keeps the parent text on the first cell of the split', () => {
+      // 2×2 with [0,0,1,2] (top row merged) and texts ['MERGED','SOLO','OTHER'].
+      // Split compartment 0 → top-left keeps 0 with 'MERGED'; top-right gets
+      // new ID; everything renumbers.
+      const config: CompartmentConfig = {
+        cols: 2,
+        rows: 2,
+        thickness: 1.2,
+        cells: [0, 0, 1, 2],
+        compartmentTexts: ['MERGED', 'SOLO', 'OTHER'],
+      };
+      const split = splitCompartment(config, 0);
+      // After split + normalize: [0, 1, 2, 3]. Top-left keeps 'MERGED',
+      // new compartment 1 gets ''.
+      expect(split.cells).toEqual([0, 1, 2, 3]);
+      expect(split.compartmentTexts).toEqual(['MERGED', '', 'SOLO', 'OTHER']);
     });
   });
 

--- a/src/features/bin-designer/utils/compartments.test.ts
+++ b/src/features/bin-designer/utils/compartments.test.ts
@@ -623,32 +623,35 @@ describe('compartments', () => {
     });
 
     it('handles renumbering across split (new IDs get empty strings)', () => {
-      // Split compartment 1 into two: 1 stays, new 2 appears, old 2 → 3
+      // Split: a compartment is split, so a new ID appears in cells. The
+      // remap from normalizeIdsWithRemap is always 1:1 — the new ID is
+      // present with its own slot. Original IDs that survived keep their text.
+      // Setup: original ids 0,1,2,3 with texts ['A','B','C','D']. Split id 1
+      // into two — the parent keeps id 1, the new cell gets id 4. After
+      // normalize: cells use 0,1,2,3,4 → renumbered to 0,1,2,3,4 (same).
       const remap = new Map([
         [0, 0],
         [1, 1],
-        [3, 2],
+        [4, 2], // new compartment from split — no source text → ''
         [2, 3],
+        [3, 4],
       ]);
-      const out = remapCompartmentTexts(['A', 'B', 'C'], remap);
-      // 'A' stays at new 0, 'B' stays at new 1, original 3 had no text → '',
-      // and 'C' (old 2) moves to new 3.
-      expect(out).toEqual(['A', 'B', '', 'C']);
+      const out = remapCompartmentTexts(['A', 'B', 'C', 'D'], remap);
+      expect(out).toEqual(['A', 'B', '', 'C', 'D']);
     });
 
-    it('handles renumbering across merge (collapsed IDs drop out)', () => {
-      // Merge: ids 0,1 both map to new 0; old 2 → new 1
+    it('drops text for compartments that disappeared from the remap', () => {
+      // Merge: ids 1,2 were stomped to 0 before normalize ran, so the post-
+      // normalize remap only contains the surviving IDs (0 and 3). The
+      // disappearing IDs (1, 2) are not in the remap — their texts drop.
+      // Original cells [0,1,2,3] with texts ['A','B','C','D']. After merge
+      // and normalize: cells [0,0,0,1], remap {0→0, 3→1}.
       const remap = new Map([
         [0, 0],
-        [1, 0],
-        [2, 1],
+        [3, 1],
       ]);
-      const out = remapCompartmentTexts(['A', 'B', 'C'], remap);
-      // 'A' wins index 0 (insertion order — but Map iterates in insertion order,
-      // so the contract is "later writers stomp earlier", giving us 'B' at slot 0
-      // when 1 is processed second). To pin the behavior down:
-      // For [0,0] → out[0]='A'; for [1,0] → out[0]='B'; for [2,1] → out[1]='C'.
-      expect(out).toEqual(['B', 'C']);
+      const out = remapCompartmentTexts(['A', 'B', 'C', 'D'], remap);
+      expect(out).toEqual(['A', 'D']);
     });
   });
 

--- a/src/features/bin-designer/utils/compartments.ts
+++ b/src/features/bin-designer/utils/compartments.ts
@@ -184,10 +184,13 @@ export function mergeCells(
   }
 
   const { cells: normalized, remap } = normalizeIdsWithRemap(newCells);
-  const compartmentTexts = config.compartmentTexts
-    ? remapCompartmentTexts(config.compartmentTexts, remap)
-    : config.compartmentTexts;
-  return { ...config, cells: normalized, ...(compartmentTexts ? { compartmentTexts } : {}) };
+  return {
+    ...config,
+    cells: normalized,
+    ...(config.compartmentTexts && {
+      compartmentTexts: remapCompartmentTexts(config.compartmentTexts, remap),
+    }),
+  };
 }
 
 /**
@@ -214,10 +217,13 @@ export function splitCompartment(
   }
 
   const { cells: normalized, remap } = normalizeIdsWithRemap(newCells);
-  const compartmentTexts = config.compartmentTexts
-    ? remapCompartmentTexts(config.compartmentTexts, remap)
-    : config.compartmentTexts;
-  return { ...config, cells: normalized, ...(compartmentTexts ? { compartmentTexts } : {}) };
+  return {
+    ...config,
+    cells: normalized,
+    ...(config.compartmentTexts && {
+      compartmentTexts: remapCompartmentTexts(config.compartmentTexts, remap),
+    }),
+  };
 }
 
 /**
@@ -253,25 +259,13 @@ export function normalizeIdsWithRemap(cells: number[]): {
 }
 
 /**
- * Apply an `oldId → newId` remap (from `normalizeIdsWithRemap`) to a parallel
- * per-compartment texts array.
+ * Reindex a parallel per-compartment texts array through an `oldId → newId`
+ * map (from `normalizeIdsWithRemap`).
  *
- * Contract: the remap is the one produced by `normalizeIdsWithRemap`, which
- * is **one-to-one** — every distinct old ID in `cells` maps to exactly one
- * distinct new ID. Old IDs that are not in the remap (compartments that
- * disappeared because their cells were rewritten — e.g. a merge that
- * stomped IDs `1,2` to `0` before normalize was called) drop out: their
- * text is not carried into the output. New IDs that have no corresponding
- * entry in the source (newly created compartments, e.g. from a split) get
- * an empty string.
- *
- * If two old IDs ever did map to the same new ID, the later iteration would
- * win in Map insertion order. The caller's normalize step rules this out
- * in practice, so the order-dependent behavior is documented but never
- * exercised.
- *
- * Trailing empty strings are preserved in the output array — callers may
- * choose to truncate for serialization compactness.
+ * The remap is always one-to-one — IDs that disappeared from `cells` before
+ * normalize ran (e.g. a merge stomped `1,2 → 0`) are absent from the remap
+ * and their text drops. New IDs not in `oldTexts` (e.g. from a split) get
+ * an empty string in the output slot.
  */
 export function remapCompartmentTexts(
   oldTexts: readonly string[] | undefined,

--- a/src/features/bin-designer/utils/compartments.ts
+++ b/src/features/bin-designer/utils/compartments.ts
@@ -183,7 +183,11 @@ export function mergeCells(
     newCells[idx] = targetId;
   }
 
-  return { ...config, cells: normalizeIds(newCells) };
+  const { cells: normalized, remap } = normalizeIdsWithRemap(newCells);
+  const compartmentTexts = config.compartmentTexts
+    ? remapCompartmentTexts(config.compartmentTexts, remap)
+    : config.compartmentTexts;
+  return { ...config, cells: normalized, ...(compartmentTexts ? { compartmentTexts } : {}) };
 }
 
 /**
@@ -209,7 +213,11 @@ export function splitCompartment(
     }
   }
 
-  return { ...config, cells: normalizeIds(newCells) };
+  const { cells: normalized, remap } = normalizeIdsWithRemap(newCells);
+  const compartmentTexts = config.compartmentTexts
+    ? remapCompartmentTexts(config.compartmentTexts, remap)
+    : config.compartmentTexts;
+  return { ...config, cells: normalized, ...(compartmentTexts ? { compartmentTexts } : {}) };
 }
 
 /**
@@ -217,19 +225,57 @@ export function splitCompartment(
  * Preserves spatial ordering (top-left to bottom-right first occurrence).
  */
 export function normalizeIds(cells: number[]): number[] {
-  const idMap = new Map<number, number>();
+  return normalizeIdsWithRemap(cells).cells;
+}
+
+/**
+ * Variant of `normalizeIds` that also returns the `oldId → newId` remap so
+ * callers can keep parallel per-compartment arrays (e.g. `compartmentTexts`)
+ * in lockstep with `cells`. Use this for any mutation that may renumber IDs.
+ */
+export function normalizeIdsWithRemap(cells: number[]): {
+  cells: number[];
+  remap: Map<number, number>;
+} {
+  const remap = new Map<number, number>();
   let nextId = 0;
 
   const normalized = cells.map((id) => {
-    let normalizedId = idMap.get(id);
+    let normalizedId = remap.get(id);
     if (normalizedId === undefined) {
       normalizedId = nextId++;
-      idMap.set(id, normalizedId);
+      remap.set(id, normalizedId);
     }
     return normalizedId;
   });
 
-  return normalized;
+  return { cells: normalized, remap };
+}
+
+/**
+ * Apply an `oldId → newId` remap (from `normalizeIdsWithRemap`) to a parallel
+ * per-compartment texts array. Old IDs not present in the remap (compartments
+ * that disappeared) drop out; new IDs not present in the source (newly created
+ * compartments, e.g. from a split) get an empty string.
+ *
+ * Trailing empty strings are preserved in the output array — callers may
+ * choose to truncate for serialization compactness.
+ */
+export function remapCompartmentTexts(
+  oldTexts: readonly string[] | undefined,
+  remap: ReadonlyMap<number, number>
+): string[] {
+  if (!oldTexts || oldTexts.length === 0) return [];
+  let maxNewId = -1;
+  for (const newId of remap.values()) {
+    if (newId > maxNewId) maxNewId = newId;
+  }
+  const out: string[] = new Array<string>(maxNewId + 1).fill('');
+  for (const [oldId, newId] of remap) {
+    const t = oldTexts[oldId];
+    if (typeof t === 'string') out[newId] = t;
+  }
+  return out;
 }
 
 // Wall Segment Derivation

--- a/src/features/bin-designer/utils/compartments.ts
+++ b/src/features/bin-designer/utils/compartments.ts
@@ -254,9 +254,21 @@ export function normalizeIdsWithRemap(cells: number[]): {
 
 /**
  * Apply an `oldId → newId` remap (from `normalizeIdsWithRemap`) to a parallel
- * per-compartment texts array. Old IDs not present in the remap (compartments
- * that disappeared) drop out; new IDs not present in the source (newly created
- * compartments, e.g. from a split) get an empty string.
+ * per-compartment texts array.
+ *
+ * Contract: the remap is the one produced by `normalizeIdsWithRemap`, which
+ * is **one-to-one** — every distinct old ID in `cells` maps to exactly one
+ * distinct new ID. Old IDs that are not in the remap (compartments that
+ * disappeared because their cells were rewritten — e.g. a merge that
+ * stomped IDs `1,2` to `0` before normalize was called) drop out: their
+ * text is not carried into the output. New IDs that have no corresponding
+ * entry in the source (newly created compartments, e.g. from a split) get
+ * an empty string.
+ *
+ * If two old IDs ever did map to the same new ID, the later iteration would
+ * win in Map insertion order. The caller's normalize step rules this out
+ * in practice, so the order-dependent behavior is documented but never
+ * exercised.
  *
  * Trailing empty strings are preserved in the output array — callers may
  * choose to truncate for serialization compactness.

--- a/src/features/bin-designer/utils/materialMapping.test.ts
+++ b/src/features/bin-designer/utils/materialMapping.test.ts
@@ -11,12 +11,14 @@ const allZones: ReadonlySet<ColorZone> = new Set(ZONE_ORDER);
 /** Build a featureColors config that's single-color by default; pass overrides to differentiate zones. */
 function colors(overrides: Partial<FeatureColorConfig> = {}): FeatureColorConfig {
   return {
+    enabled: false,
     body: SINGLE,
     lip: { frontLeft: SINGLE, frontRight: SINGLE, backRight: SINGLE, backLeft: SINGLE },
     labelTab: SINGLE,
     base: SINGLE,
     scoop: SINGLE,
     dividers: SINGLE,
+    text: SINGLE,
     ...overrides,
   };
 }

--- a/src/features/bin-designer/utils/multiColorGroups.test.ts
+++ b/src/features/bin-designer/utils/multiColorGroups.test.ts
@@ -9,12 +9,14 @@ const SINGLE = '#d4d8dc';
 
 function colors(overrides: Partial<FeatureColorConfig> = {}): FeatureColorConfig {
   return {
+    enabled: false,
     body: SINGLE,
     lip: { frontLeft: SINGLE, frontRight: SINGLE, backRight: SINGLE, backLeft: SINGLE },
     labelTab: SINGLE,
     base: SINGLE,
     scoop: SINGLE,
     dividers: SINGLE,
+    text: SINGLE,
     ...overrides,
   };
 }

--- a/src/features/bin-designer/utils/zoneLabels.ts
+++ b/src/features/bin-designer/utils/zoneLabels.ts
@@ -28,6 +28,8 @@ export function zoneTranslationKey(zone: ColorZone): string {
       return 'binDesigner.colors.zone.scoop';
     case 'dividers':
       return 'binDesigner.colors.zone.dividers';
+    case 'text':
+      return 'binDesigner.colors.zone.text';
   }
 }
 
@@ -38,6 +40,7 @@ export type ZoneColorPatch =
   | { base: string }
   | { scoop: string }
   | { dividers: string }
+  | { text: string }
   | { lip: Partial<FeatureColorConfig['lip']> };
 
 /**
@@ -61,6 +64,8 @@ export function zoneColorPatch(zone: ColorZone, hex: string): ZoneColorPatch {
       return { scoop: hex };
     case 'dividers':
       return { dividers: hex };
+    case 'text':
+      return { text: hex };
     case 'lip:frontLeft':
     case 'lip:frontRight':
     case 'lip:backRight':

--- a/src/features/generation/worker/generators/featureTags.ts
+++ b/src/features/generation/worker/generators/featureTags.ts
@@ -19,6 +19,7 @@ export const FeatureTag = {
   HANDLE: 11,
   LID_BODY: 12,
   LID_RAIL: 13,
+  TEXT: 14,
   UNKNOWN: 255,
 } as const;
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -84,6 +84,7 @@
   "binDesigner.colors.base": "Sockel",
   "binDesigner.colors.body": "Korpus",
   "binDesigner.colors.dividers": "Trennwände",
+  "binDesigner.colors.text": "Gravierter Text",
   "binDesigner.colors.group.addons": "Anbauten",
   "binDesigner.colors.group.exterior": "Außen",
   "binDesigner.colors.group.interior": "Innen",
@@ -1862,6 +1863,7 @@
   "binDesigner.colors.zone.base": "Basis",
   "binDesigner.colors.zone.scoop": "Mulde",
   "binDesigner.colors.zone.dividers": "Trennwände",
+  "binDesigner.colors.zone.text": "Gravierter Text",
   "webgl.fallback.title": "Ihr Browser konnte 3D-Rendering nicht laden",
   "webgl.fallback.body": "WebGL ist deaktiviert oder wird nicht unterstützt. Aktivieren Sie die Hardwarebeschleunigung in den Browsereinstellungen, aktualisieren Sie die Grafiktreiber oder wechseln Sie den Browser.",
   "webgl.fallback.helpLink": "WebGL-Unterstützung prüfen"

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1483,6 +1483,7 @@ const en: Record<string, string> = {
   'binDesigner.colors.base': 'Base',
   'binDesigner.colors.scoop': 'Scoop',
   'binDesigner.colors.dividers': 'Dividers',
+  'binDesigner.colors.text': 'Engraved Text',
   'binDesigner.colors.group.exterior': 'Exterior',
   'binDesigner.colors.group.interior': 'Interior',
   'binDesigner.colors.group.addons': 'Add-ons',
@@ -1537,6 +1538,7 @@ const en: Record<string, string> = {
   'binDesigner.colors.zone.base': 'Base',
   'binDesigner.colors.zone.scoop': 'Scoop',
   'binDesigner.colors.zone.dividers': 'Dividers',
+  'binDesigner.colors.zone.text': 'Engraved text',
   'binDesigner.export.multiColor.formatDisabled':
     "{format} doesn't preserve color data. Use 3MF to keep your multi-color zones.",
 

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -84,6 +84,7 @@
   "binDesigner.colors.base": "Base",
   "binDesigner.colors.body": "Cuerpo",
   "binDesigner.colors.dividers": "Divisores",
+  "binDesigner.colors.text": "Texto grabado",
   "binDesigner.colors.group.addons": "Complementos",
   "binDesigner.colors.group.exterior": "Exterior",
   "binDesigner.colors.group.interior": "Interior",
@@ -1862,6 +1863,7 @@
   "binDesigner.colors.zone.base": "Base",
   "binDesigner.colors.zone.scoop": "Rampa",
   "binDesigner.colors.zone.dividers": "Divisores",
+  "binDesigner.colors.zone.text": "Texto grabado",
   "webgl.fallback.title": "Tu navegador no pudo cargar el renderizado 3D",
   "webgl.fallback.body": "WebGL está desactivado o no es compatible. Intenta activar la aceleración por hardware en la configuración del navegador, actualizar los controladores gráficos o cambiar de navegador.",
   "webgl.fallback.helpLink": "Comprobar compatibilidad con WebGL"

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -84,6 +84,7 @@
   "binDesigner.colors.base": "Base",
   "binDesigner.colors.body": "Corps",
   "binDesigner.colors.dividers": "Cloisons",
+  "binDesigner.colors.text": "Texte gravé",
   "binDesigner.colors.group.addons": "Compléments",
   "binDesigner.colors.group.exterior": "Extérieur",
   "binDesigner.colors.group.interior": "Intérieur",
@@ -1862,6 +1863,7 @@
   "binDesigner.colors.zone.base": "Base",
   "binDesigner.colors.zone.scoop": "Cuiller",
   "binDesigner.colors.zone.dividers": "Séparateurs",
+  "binDesigner.colors.zone.text": "Texte gravé",
   "webgl.fallback.title": "Votre navigateur n'a pas pu charger le rendu 3D",
   "webgl.fallback.body": "WebGL est désactivé ou non pris en charge. Activez l'accélération matérielle dans les paramètres du navigateur, mettez à jour les pilotes graphiques ou changez de navigateur.",
   "webgl.fallback.helpLink": "Vérifier la prise en charge de WebGL"

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -84,6 +84,7 @@
   "binDesigner.colors.base": "Sokkel",
   "binDesigner.colors.body": "Kropp",
   "binDesigner.colors.dividers": "Skillevegger",
+  "binDesigner.colors.text": "Gravert tekst",
   "binDesigner.colors.group.addons": "Tilbehør",
   "binDesigner.colors.group.exterior": "Utvendig",
   "binDesigner.colors.group.interior": "Innvendig",
@@ -1862,6 +1863,7 @@
   "binDesigner.colors.zone.base": "Sokkel",
   "binDesigner.colors.zone.scoop": "Skje",
   "binDesigner.colors.zone.dividers": "Skillevegger",
+  "binDesigner.colors.zone.text": "Gravert tekst",
   "webgl.fallback.title": "Nettleseren din kunne ikke laste 3D-gjengivelse",
   "webgl.fallback.body": "WebGL er deaktivert eller støttes ikke. Prøv å aktivere maskinvareakselerasjon i nettleserinnstillingene, oppdatere grafikkdriverne eller bytte nettleser.",
   "webgl.fallback.helpLink": "Sjekk WebGL-støtte"

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -84,6 +84,7 @@
   "binDesigner.colors.base": "Basis",
   "binDesigner.colors.body": "Behuizing",
   "binDesigner.colors.dividers": "Tussenschotten",
+  "binDesigner.colors.text": "Gegraveerde tekst",
   "binDesigner.colors.group.addons": "Toebehoren",
   "binDesigner.colors.group.exterior": "Buitenkant",
   "binDesigner.colors.group.interior": "Binnenkant",
@@ -1862,6 +1863,7 @@
   "binDesigner.colors.zone.base": "Voet",
   "binDesigner.colors.zone.scoop": "Schepje",
   "binDesigner.colors.zone.dividers": "Tussenschotten",
+  "binDesigner.colors.zone.text": "Gegraveerde tekst",
   "webgl.fallback.title": "Je browser kon 3D-weergave niet laden",
   "webgl.fallback.body": "WebGL is uitgeschakeld of wordt niet ondersteund. Schakel hardwareversnelling in de browserinstellingen in, werk je grafische stuurprogramma's bij of probeer een andere browser.",
   "webgl.fallback.helpLink": "WebGL-ondersteuning controleren"

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -84,6 +84,7 @@
   "binDesigner.colors.base": "Base",
   "binDesigner.colors.body": "Corpo",
   "binDesigner.colors.dividers": "Divisórias",
+  "binDesigner.colors.text": "Texto gravado",
   "binDesigner.colors.group.addons": "Complementos",
   "binDesigner.colors.group.exterior": "Exterior",
   "binDesigner.colors.group.interior": "Interior",
@@ -1862,6 +1863,7 @@
   "binDesigner.colors.zone.base": "Base",
   "binDesigner.colors.zone.scoop": "Concha",
   "binDesigner.colors.zone.dividers": "Divisores",
+  "binDesigner.colors.zone.text": "Texto gravado",
   "webgl.fallback.title": "Seu navegador não conseguiu carregar a renderização 3D",
   "webgl.fallback.body": "O WebGL está desativado ou não é compatível. Tente ativar a aceleração de hardware nas configurações do navegador, atualizar os drivers gráficos ou trocar de navegador.",
   "webgl.fallback.helpLink": "Verificar suporte ao WebGL"

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1207,6 +1207,7 @@
   "binDesigner.colors.base": "Sockel",
   "binDesigner.colors.scoop": "Sluttning",
   "binDesigner.colors.dividers": "Skiljeväggar",
+  "binDesigner.colors.text": "Graverad text",
   "binDesigner.colors.group.exterior": "Utsida",
   "binDesigner.colors.group.interior": "Insida",
   "binDesigner.colors.group.addons": "Tillbehör",
@@ -1862,6 +1863,7 @@
   "binDesigner.colors.zone.base": "Bas",
   "binDesigner.colors.zone.scoop": "Skopa",
   "binDesigner.colors.zone.dividers": "Avdelare",
+  "binDesigner.colors.zone.text": "Graverad text",
   "webgl.fallback.title": "Din webbläsare kunde inte ladda 3D-rendering",
   "webgl.fallback.body": "WebGL är inaktiverat eller stöds inte. Försök aktivera hårdvaruacceleration i webbläsarinställningarna, uppdatera grafikdrivrutinerna eller byt webbläsare.",
   "webgl.fallback.helpLink": "Kontrollera WebGL-stöd"

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1207,6 +1207,7 @@
   "binDesigner.colors.base": "Основа",
   "binDesigner.colors.scoop": "Скіс",
   "binDesigner.colors.dividers": "Перегородки",
+  "binDesigner.colors.text": "Гравірований текст",
   "binDesigner.colors.group.exterior": "Зовнішнє",
   "binDesigner.colors.group.interior": "Внутрішнє",
   "binDesigner.colors.group.addons": "Додатки",
@@ -1862,6 +1863,7 @@
   "binDesigner.colors.zone.base": "Основа",
   "binDesigner.colors.zone.scoop": "Жолоб",
   "binDesigner.colors.zone.dividers": "Перегородки",
+  "binDesigner.colors.zone.text": "Гравірований текст",
   "webgl.fallback.title": "Ваш браузер не зміг завантажити 3D-рендеринг",
   "webgl.fallback.body": "WebGL вимкнено або не підтримується. Увімкніть апаратне прискорення в налаштуваннях браузера, оновіть графічні драйвери або спробуйте інший браузер.",
   "webgl.fallback.helpLink": "Перевірити підтримку WebGL"


### PR DESCRIPTION
## Summary

Foundation PR for the embedded-text feature brainstormed in [chat]. Adds the data layer, store actions, persistence wiring, server validation, and the labs flag for engraved text on label tabs and cutouts. **Geometry pipeline and editor UI ship in follow-up PRs** — by itself this PR doesn't render anything new; it makes the next two PRs much smaller.

## Why split

The full feature (data layer + worker font loading + textBuilder + label-tab/cutout integration + inspector UI + analytics + ~15 i18n keys) is ~15+ files and several hours of careful work. Landing the foundation first means:
- Data schema is reviewed in isolation
- The compartment-ID-remap fix (a real correctness gap) gets dedicated scrutiny
- Geometry & UI PRs can focus on their own concerns

## What's in
- `BinParams.textDefaults` (font / mode / depth / margin / min-max font size). Default: Atkinson, engrave, 0.4mm.
- `CompartmentConfig.compartmentTexts?: string[]` parallel-to-cells. Replaces a naive `Record<id, string>` that would have **corrupted text→compartment associations on any grid mutation** because `normalizeIds()` renumbers IDs every merge/split.
- `Cutout.engraveLabel?` (off by default — no visual change for existing designs), `textSide?`, `textStyle?`.
- `LabelTabConfig.textStyle?`.
- `FeatureColorConfig.text` + `ColorZone 'text'` + `FeatureTag.TEXT` (14). `computeActiveZones` surfaces it only when text actually exists.
- New helpers `normalizeIdsWithRemap()` and `remapCompartmentTexts()` keep parallel arrays in lockstep with `cells`.
- `paramSlice` actions: `setCompartmentText`, `setTextDefaults`, `setLabelTabTextStyle`; `mergeCells` / `splitCompartment` apply the remap.
- `migrateParams` fills missing `textDefaults`; new `featureColors.text` inherits the `labelTab` color so legacy designs see no shift.
- Server `ALLOWED_PARAM_KEYS` allowlists `textDefaults` so cloud shares don't silently drop the field.
- `embedded_text` experimental labs flag for the upcoming UI.
- i18n: `binDesigner.colors.text` + `binDesigner.colors.zone.text` mirrored to all 8 locales.

## What's NOT in (follow-ups)
- Worker font loading (Atkinson / JetBrains Mono / Allerta Stencil TTFs)
- `textBuilder.ts` (sketchText + extrude + boolean)
- `labelTabBuilder` integration (engraved text on shelf top)
- `cutoutBuilder` integration (text adjacent to cutout, world-aligned)
- Cache-key updates in `labelTabsFeature` and cutout builder
- Inspector text inputs + panel sections
- PostHog analytics events
- README + CLAUDE.md docs

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors (5 pre-existing warnings)
- [x] `pnpm run knip` — clean
- [x] `pnpm run check:i18n` — all 8 locales aligned at 1868 keys
- [x] `pnpm vitest run src/features/bin-designer` — 2209 / 2209 pass
- [x] Added 4 new test cases for `normalizeIdsWithRemap`, `remapCompartmentTexts`, `mergeCells with texts`, `splitCompartment with texts`
- [x] Fixed `FeatureColorConfig` fixtures in 7 test files (added `text` zone + previously-implicit `enabled` field)
- [ ] Manual: load an existing design — `textDefaults` filled from migration, `featureColors.text` matches `labelTab`, no visual change
- [ ] Manual: undo/redo across merge/split with `compartmentTexts` populated (will be exercised by the UI PR)

## Notes
- `paramSlice.ts` still has no sibling test (pre-existing warning from the missing-tests hook). The new actions get coverage indirectly via the compartment scenario tests; a focused `paramSlice.test.ts` is queued for the UI PR where it can exercise the user-facing flows end-to-end.
- File `src/features/bin-designer/constants/defaults.ts` is 518 lines (warning threshold 500). Was already 510+ before this PR; moved `DEFAULT_TEXT_STYLE_DEFAULTS` to `types/text.ts` to minimize the bump.