### PR TITLE
fix(bin-designer): cacheKey collision in label-tab text + scenario tests

### DIFF
--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.test.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { LabelTabsSection } from './LabelTabsSection';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { DEFAULT_BIN_PARAMS, DEFAULT_UI_STATE } from '@/features/bin-designer/constants';
@@ -7,7 +7,12 @@ import { DEFAULT_BIN_PARAMS, DEFAULT_UI_STATE } from '@/features/bin-designer/co
 describe('LabelTabsSection', () => {
   beforeEach(() => {
     useDesignerStore.setState({
-      params: { ...DEFAULT_BIN_PARAMS },
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        // Tabs must be enabled for the engraved-text subsection to render.
+        label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+        compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, rows: 1, cells: [0, 1] },
+      },
       ui: { ...DEFAULT_UI_STATE },
     });
   });
@@ -15,5 +20,18 @@ describe('LabelTabsSection', () => {
   it('renders label tabs toggle', () => {
     render(<LabelTabsSection />);
     expect(screen.getByText('Label tabs')).toBeInTheDocument();
+  });
+
+  it('renders one engraved-text input per compartment', () => {
+    render(<LabelTabsSection />);
+    expect(screen.getByLabelText('Engraved text for compartment 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Engraved text for compartment 2')).toBeInTheDocument();
+  });
+
+  it('writes typed text to the store via setCompartmentText', () => {
+    render(<LabelTabsSection />);
+    const input = screen.getByLabelText('Engraved text for compartment 1');
+    fireEvent.change(input, { target: { value: 'SCREWS' } });
+    expect(useDesignerStore.getState().params.compartments.compartmentTexts).toEqual(['SCREWS']);
   });
 });

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
@@ -136,7 +136,6 @@ export function LabelTabsSection() {
         </div>
       </div>
 
-      {/* Engraved compartment text (one input per compartment) */}
       <div>
         <label className="text-xs font-medium text-content-secondary mb-1 block">
           {t('binDesigner.tabEngravedText')}

--- a/src/features/generation/worker/generators/labelTabBuilder.test.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.test.ts
@@ -5,9 +5,23 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { loadFont } from 'brepjs';
+import { isErr } from '@/core/result';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 beforeAll(async () => {
   await initBrepjs();
+  // Engraved-text tests need the bundled Atkinson font; load from disk since
+  // the test env has no `fetch` for `?url` assets.
+  const buffer = readFileSync(
+    resolve(__dirname, '../assets/fonts/AtkinsonHyperlegible-Regular.ttf')
+  );
+  const result = await loadFont(
+    buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
+    'atkinson'
+  );
+  if (isErr(result)) throw new Error(`Font load failed: ${result.error.message}`);
 }, 30_000);
 
 describe('buildLabelTabs', () => {
@@ -75,6 +89,66 @@ describe('buildLabelTabs', () => {
     // The tab's lowest point should be above half the wall height
     // (it sits near the top, not at the floor)
     expect(minZ).toBeGreaterThan(wallHeight / 2);
+  });
+
+  describe('engraved compartment text', () => {
+    it('builds tabs without crashing when compartmentTexts is present', async () => {
+      const { buildLabelTabs } = await import('./labelTabBuilder');
+      const params = {
+        ...DEFAULT_BIN_PARAMS,
+        label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+        compartments: {
+          ...DEFAULT_BIN_PARAMS.compartments,
+          compartmentTexts: ['SCREWS'],
+        },
+      };
+      const result = buildLabelTabs(params, 80, 80, 35, 1.2);
+      expect(result).not.toBeNull();
+    });
+
+    it('cuts material from the shelf when text is present (more faces than without)', async () => {
+      const { buildLabelTabs } = await import('./labelTabBuilder');
+      const { mesh } = await import('brepjs');
+
+      const base = { ...DEFAULT_BIN_PARAMS, label: { ...DEFAULT_BIN_PARAMS.label, enabled: true } };
+      const withText = {
+        ...base,
+        compartments: { ...base.compartments, compartmentTexts: ['ABC'] },
+      };
+
+      const without = buildLabelTabs(base, 80, 80, 35, 1.2);
+      const withEngraved = buildLabelTabs(withText, 80, 80, 35, 1.2);
+      expect(without).not.toBeNull();
+      expect(withEngraved).not.toBeNull();
+
+      const opts = { tolerance: 0.5, angularTolerance: 15 };
+      const meshA = mesh(without!, opts);
+      const meshB = mesh(withEngraved!, opts);
+      // Engraving adds glyph faces — vertex count strictly increases.
+      expect(meshB.vertices.length).toBeGreaterThan(meshA.vertices.length);
+    });
+
+    it('skips engraving when the slot text is empty or whitespace', async () => {
+      const { buildLabelTabs } = await import('./labelTabBuilder');
+      const { mesh } = await import('brepjs');
+
+      const base = { ...DEFAULT_BIN_PARAMS, label: { ...DEFAULT_BIN_PARAMS.label, enabled: true } };
+      const blank = {
+        ...base,
+        compartments: { ...base.compartments, compartmentTexts: ['   '] },
+      };
+
+      const withoutTexts = buildLabelTabs(base, 80, 80, 35, 1.2);
+      const blankText = buildLabelTabs(blank, 80, 80, 35, 1.2);
+      expect(withoutTexts).not.toBeNull();
+      expect(blankText).not.toBeNull();
+
+      const opts = { tolerance: 0.5, angularTolerance: 15 };
+      // Whitespace-only text must be treated as "no text" — identical vertex count.
+      expect(mesh(blankText!, opts).vertices.length).toBe(
+        mesh(withoutTexts!, opts).vertices.length
+      );
+    });
   });
 
   it.each(['solid', 'bracket', 'fillet'] as const)(

--- a/src/features/generation/worker/generators/labelTabBuilder.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.ts
@@ -7,7 +7,7 @@
 
 import { draw, unwrap, fuseAll, fuse, cut, translate, withScope, clone } from 'brepjs';
 import type { Shape3D, ValidSolid, Drawing, DisposalScope } from 'brepjs';
-import type { BinParams } from '@/shared/types/bin';
+import type { BinParams, TextStyleDefaults, TextStyleOverride } from '@/shared/types/bin';
 import { sketch } from './meshUtils';
 import { buildFilletProfile } from './filletProfile';
 import { buildEngraveCutSolid } from './textBuilder';
@@ -265,18 +265,17 @@ function buildLabelTabsInScope(
  * Cut engraved text from the shelf top in the tab's local frame, where
  * the shelf occupies X:[0,tabWidth], Y:[-tabDepth,0], top face at Z=tabHeight.
  *
- * Returns the original tab unchanged when text is empty or the chosen mode
- * is not 'engrave' (other modes ship in later PRs); falls back to unchanged
- * geometry if the boolean fails so a font/auto-fit edge case can't tank the
- * whole label-tab build.
+ * Returns the original tab unchanged when text is empty or mode is not
+ * 'engrave'; falls back to unchanged geometry if the boolean fails so a
+ * font/auto-fit edge case can't tank the whole label-tab build.
  */
 function applyTabEngraveText(
   scope: DisposalScope,
   tabSolid: Shape3D,
   ctx: {
     text: string;
-    textDefaults: BinParams['textDefaults'];
-    labelTextStyle: BinParams['label']['textStyle'];
+    textDefaults: TextStyleDefaults;
+    labelTextStyle: TextStyleOverride | undefined;
     tabWidth: number;
     tabDepth: number;
     tabHeight: number;
@@ -334,9 +333,9 @@ export const labelTabsFeature: FeatureBuilder = {
         params.compartments.cols,
         params.compartments.rows,
         params.compartments.cells.join(','),
-        // Engraved-text inputs participate in cache key so text edits
-        // invalidate the prior mesh. `v1` → `v2` bumps the key namespace.
-        (params.compartments.compartmentTexts ?? []).join(''),
+        // `stableSerialize` (not `.join(sep)`) avoids the collision where
+        // e.g. `['ab','c']` and `['a','bc']` produce the same key.
+        stableSerialize(params.compartments.compartmentTexts ?? []),
         stableSerialize(params.textDefaults)
       )
     );

--- a/src/features/generation/worker/generators/textBuilder.ts
+++ b/src/features/generation/worker/generators/textBuilder.ts
@@ -47,7 +47,6 @@ export function fitFontSize(
   if (!text || availW <= 0 || availD <= 0 || min <= 0 || max < min) {
     return { fontSize: 0, fits: false };
   }
-  // Reject up front if even the minimum doesn't fit.
   const minMetrics = textMetrics(text, { fontSize: min, fontFamily });
   if (!isOk(minMetrics) || minMetrics.value.width > availW || minMetrics.value.height > availD) {
     return { fontSize: 0, fits: false };

--- a/src/features/generation/worker/wasmInstantiator.ts
+++ b/src/features/generation/worker/wasmInstantiator.ts
@@ -58,7 +58,7 @@ export async function loadOpenCascade(): Promise<WasmLoadResult> {
  * blip on the font asset never bricks the whole generation pipeline.
  *
  * Only called for OCCT-based kernels; brepkit-wasm doesn't currently
- * implement the topology operations textBlueprints needs.
+ * implement the topology operations textBuilder needs.
  */
 async function loadEmbeddedFonts(): Promise<void> {
   try {


### PR DESCRIPTION
## Summary

Self-review follow-up to #1809 (merged). The cacheKey for engraved label-tab text was using a `\x01` (SOH) separator-join — collision-vulnerable for crafted input AND brittle to encoding round-trips. Plus tightens types and adds the scenario tests I should have shipped in #1809.

## Why now (not before merge)

I caught these in a post-review loop, but #1809 auto-merged on green CI/Greptile before I could push the cleanup. None of the items break the feature today — `\x01` doesn't normally appear in user text — but the cacheKey is the right thing to fix before the next text-feature PR builds on it.

## Changes

- **cacheKey fix.** `labelTabBuilder` now uses `stableSerialize(compartmentTexts ?? [])` instead of `.join('\x01')`. Matches the convention the rest of the cacheKey uses and is collision-proof.
- **Type tightening.** `applyTabEngraveText` parameters typed with `TextStyleDefaults` / `TextStyleOverride` directly instead of indexed `BinParams['…']` types.
- **New scenario tests** in `labelTabBuilder.test.ts`:
  - builds without crashing when `compartmentTexts` is populated
  - engraving actually cuts material (vertex count strictly greater than the no-text baseline)
  - whitespace-only text is a no-op (vertex parity with no text at all)
  - loads the bundled TTF in `beforeAll` since the kernel-test helper doesn't load fonts
- **New UI tests** in `LabelTabsSection.test.tsx`: one input renders per compartment, typing writes to `setCompartmentText`.
- **Simplifier polish.** Stale `textBlueprints` → `textBuilder` reference fixed; restatement comments removed.

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` 0 errors
- [x] 32 affected tests pass (textBuilder + labelTabBuilder + LabelTabsSection)
- [ ] Manual: type "ab"/"c" in two compartments, then "a"/"bc" — confirm the cache invalidates between them (would have collided under the old key)