### PR TITLE
fix(bin-designer): address #1809 review (a11y + occt-wasm fonts + tests)

### DIFF
--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
@@ -137,9 +137,11 @@ export function LabelTabsSection() {
       </div>
 
       <div>
-        <label className="text-xs font-medium text-content-secondary mb-1 block">
+        {/* Heading for the group of compartment inputs — `<span>`, not `<label>`,
+            because there is no single input to associate via htmlFor. */}
+        <span className="text-xs font-medium text-content-secondary mb-1 block">
           {t('binDesigner.tabEngravedText')}
-        </label>
+        </span>
         <ul className="flex flex-col gap-1.5">
           {state.compartmentTextRows.map((row) => (
             <li key={row.id} className="flex items-center gap-2">
@@ -153,7 +155,7 @@ export function LabelTabsSection() {
                 maxLength={TEXT_MAX_LENGTH}
                 onChange={(e) => handlers.setCompartmentText(row.id, e.target.value)}
                 placeholder={t('binDesigner.tabEngravedTextPlaceholder')}
-                aria-label={t('binDesigner.tabEngravedTextAriaLabel', { n: row.id + 1 })}
+                aria-label={t('binDesigner.tabEngravedTextAriaLabel', { n: row.displayNumber })}
               />
             </li>
           ))}

--- a/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
@@ -110,11 +110,18 @@ export function useLabelTabsSection() {
   const compartmentTextRows = useMemo(() => {
     const ids = getCompartmentIds(compartments);
     const texts = compartments.compartmentTexts ?? [];
-    return ids.map((id, idx) => ({
-      id,
-      label: t('binDesigner.compartmentNumberLabel', { n: idx + 1 }),
-      value: texts[id] ?? '',
-    }));
+    // `displayNumber` is the source of truth for what the user sees AND what
+    // the aria-label announces — keep them in lockstep so a future change
+    // to ID ordering can't silently desync the two.
+    return ids.map((id, idx) => {
+      const displayNumber = idx + 1;
+      return {
+        id,
+        displayNumber,
+        label: t('binDesigner.compartmentNumberLabel', { n: displayNumber }),
+        value: texts[id] ?? '',
+      };
+    });
   }, [compartments, t]);
 
   return {

--- a/src/features/generation/worker/generators/textBuilder.scenario.test.ts
+++ b/src/features/generation/worker/generators/textBuilder.scenario.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+/**
+ * Scenario tests for `buildEngraveCutSolid` — needs a real OCCT kernel
+ * since `sketchText().extrude()` materializes geometry. Kept separate from
+ * `textBuilder.test.ts` so the fast `fitFontSize` unit tests don't pay the
+ * ~30s kernel-init cost.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import { buildEngraveCutSolid } from './textBuilder';
+import { loadFont, withScope, mesh, clone, unwrap, type Shape3D } from 'brepjs';
+import { isErr } from '@/core/result';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+beforeAll(async () => {
+  await initBrepjs();
+  const buffer = readFileSync(
+    resolve(__dirname, '../assets/fonts/AtkinsonHyperlegible-Regular.ttf')
+  );
+  const result = await loadFont(
+    buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
+    'atkinson'
+  );
+  if (isErr(result)) throw new Error(`Font load failed: ${result.error.message}`);
+}, 30_000);
+
+const BASE = {
+  text: 'M4',
+  fontFamily: 'atkinson' as const,
+  availW: 30,
+  availD: 10,
+  centerX: 15,
+  centerY: -5,
+  topZ: 12,
+  depth: 0.4,
+  margin: 1.5,
+  minFontSize: 3,
+  maxFontSize: 20,
+};
+
+describe('buildEngraveCutSolid', () => {
+  it('returns a non-null solid for a simple ASCII string', () => {
+    const solid = withScope((scope) => buildEngraveCutSolid(scope, BASE));
+    expect(solid).not.toBeNull();
+  });
+
+  it('returns null for empty / whitespace-only text', () => {
+    expect(withScope((scope) => buildEngraveCutSolid(scope, { ...BASE, text: '' }))).toBeNull();
+    expect(withScope((scope) => buildEngraveCutSolid(scope, { ...BASE, text: '   ' }))).toBeNull();
+  });
+
+  it('returns null when the font family is not loaded', () => {
+    const solid = withScope((scope) =>
+      buildEngraveCutSolid(scope, {
+        ...BASE,
+        // @ts-expect-error — testing runtime guard with an unregistered family
+        fontFamily: 'jetbrains-mono',
+      })
+    );
+    expect(solid).toBeNull();
+  });
+
+  it('returns null when even the minimum font size overflows the area', () => {
+    const solid = withScope((scope) =>
+      buildEngraveCutSolid(scope, { ...BASE, availW: 2, minFontSize: 8 })
+    );
+    expect(solid).toBeNull();
+  });
+
+  it('places the solid below the topZ plane (extruded downward into the host)', () => {
+    // `clone(...)` lifts the shape out of the disposal scope so we can call
+    // `mesh()` on it after the scope's scratch handles are freed.
+    const solid = withScope((scope): Shape3D | null => {
+      const s = buildEngraveCutSolid(scope, BASE);
+      return s ? unwrap(clone(s)) : null;
+    });
+    expect(solid).not.toBeNull();
+    const tessellated = mesh(solid!, { tolerance: 0.5, angularTolerance: 15 });
+    let maxZ = -Infinity;
+    let minZ = Infinity;
+    for (let i = 2; i < tessellated.vertices.length; i += 3) {
+      const z = tessellated.vertices[i];
+      if (z > maxZ) maxZ = z;
+      if (z < minZ) minZ = z;
+    }
+    // Top of the solid sits just above topZ (the EPSILON lift); bottom sits
+    // at most `depth + EPSILON` below it.
+    expect(maxZ).toBeGreaterThan(BASE.topZ);
+    expect(minZ).toBeLessThan(BASE.topZ);
+    expect(BASE.topZ - minZ).toBeLessThan(BASE.depth + 0.1);
+  });
+});

--- a/src/features/generation/worker/wasmInstantiator.ts
+++ b/src/features/generation/worker/wasmInstantiator.ts
@@ -57,8 +57,9 @@ export async function loadOpenCascade(): Promise<WasmLoadResult> {
  * downgrades to a no-op (label tabs without engraving), so a network
  * blip on the font asset never bricks the whole generation pipeline.
  *
- * Only called for OCCT-based kernels; brepkit-wasm doesn't currently
- * implement the topology operations textBuilder needs.
+ * Called from both OCCT loaders (`loadOpenCascade` and `loadOcctWasm`);
+ * brepkit-wasm skips font loading because it doesn't implement the
+ * topology operations `textBuilder` needs.
  */
 async function loadEmbeddedFonts(): Promise<void> {
   try {
@@ -125,6 +126,12 @@ export async function loadOcctWasm(): Promise<WasmLoadResult> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument -- see comment above
   const adapter = new OcctWasmAdapter(kernel.getRawModule() as any, kernel.getRawKernel() as any);
   registerKernel('occt-wasm', adapter);
+
+  // Engraved-text APIs are kernel-agnostic at brepjs's surface but use
+  // OCCT primitives under the hood; occt-wasm satisfies them, so font
+  // loading mirrors the default-kernel path. brepkit-wasm intentionally
+  // skipped — it doesn't implement the topology ops textBlueprints needs.
+  await loadEmbeddedFonts();
 
   return { isThreaded: false, hardwareConcurrency };
 }


### PR DESCRIPTION
## Summary

Self-review follow-up to #1809 (already merged). 4 review items from Greptile + Copilot that didn't make it into #1811 (which also merged before this batch was ready). None block the feature; all are real quality improvements.

## Items addressed

1. **a11y — section heading.** Greptile P2: the "Engraved text" heading was a `<label>` with no `htmlFor`; screen readers treated it as plain text rather than a group label. Changed to `<span>` per Greptile's suggestion.

2. **a11y — aria/visible desync.** Copilot: the input's `aria-label` interpolated `row.id + 1` while the visible "Comp. N" used `idx + 1`. They happen to match today because `normalizeIds` produces contiguous IDs, but a future ordering change could silently desync them. Added `displayNumber` as a first-class field on `compartmentTextRows` so both bindings share one source.

3. **Worker fonts for occt-wasm.** Copilot: `loadEmbeddedFonts()` was only called from `loadOpenCascade()`. Users on the experimental `occt_wasm_kernel` labs flag would have engraved text silently no-op even though the kernel supports it. Now called from both. `brepkit-wasm` intentionally skipped (missing topology ops); doc clarified.

4. **`buildEngraveCutSolid` direct test coverage.** Copilot: `textBuilder.test.ts` only exercised `fitFontSize` (cheap, no kernel needed). The geometry function had no direct test. Added `textBuilder.scenario.test.ts` (kernel-backed) covering:
   - non-null solid for a simple string
   - null for empty / whitespace text
   - null when font family is unloaded
   - null when min font size overflows the area
   - Z extents: solid sits just above `topZ` (EPSILON lift) and extends downward by no more than `depth + EPSILON`

   Split into a separate file so the ~30s kernel init doesn't tax every run of the existing fast unit tests.

## Test plan
- [x] \`pnpm run typecheck\` clean
- [x] \`pnpm run lint\` 0 errors
- [x] 18 affected tests pass (LabelTabsSection + textBuilder.scenario)
- [ ] Manual: toggle occt-wasm kernel in labs, enable label tabs, type text — confirm engraving renders
- [ ] Manual: screen reader announces the section heading as text, then each input as "Engraved text for compartment N"