### PR TITLE
fix(bin-designer): ghost previews track params.gridUnitMm

### DIFF
--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -382,12 +382,12 @@ export function PreviewCanvas() {
             {!showSplitPieces && <BinSplitLines />}
 
             {/* Footprint grid */}
-            <FootprintGrid width={width} depth={depth} />
+            <FootprintGrid width={width} depth={depth} gridUnitMm={params.gridUnitMm} />
 
             {/* Dimension markers and labels — hidden for split pieces */}
             {!showSplitPieces && (
               <>
-                <BinAxisLabels width={width} depth={depth} />
+                <BinAxisLabels width={width} depth={depth} gridUnitMm={params.gridUnitMm} />
                 <BinDimensions
                   width={width}
                   depth={depth}
@@ -396,7 +396,12 @@ export function PreviewCanvas() {
                   heightUnitMm={params.heightUnitMm}
                   stackingLip={params.base.stackingLip}
                 />
-                <BinNameLabel width={width} depth={depth} name={designName} />
+                <BinNameLabel
+                  width={width}
+                  depth={depth}
+                  gridUnitMm={params.gridUnitMm}
+                  name={designName}
+                />
               </>
             )}
 

--- a/src/features/bin-designer/components/preview/FootprintGrid/FootprintGrid.tsx
+++ b/src/features/bin-designer/components/preview/FootprintGrid/FootprintGrid.tsx
@@ -65,8 +65,9 @@ const gridFragmentShader = /* glsl */ `
 
 /**
  * Renders a Gridfinity-sized infinite grid using a custom shader.
- * Grid lines at 42mm intervals are aligned with the bin's cell boundaries,
- * so the bin appears correctly placed on the grid cells it occupies.
+ * Grid lines at `gridUnitMm` intervals (Gridfinity standard = 42mm) are
+ * aligned with the bin's cell boundaries, so the bin appears correctly
+ * placed on the grid cells it occupies.
  */
 export function FootprintGrid({ width, depth, gridUnitMm }: FootprintGridProps) {
   const colors = useThreeColors();

--- a/src/features/bin-designer/components/preview/FootprintGrid/FootprintGrid.tsx
+++ b/src/features/bin-designer/components/preview/FootprintGrid/FootprintGrid.tsx
@@ -1,8 +1,8 @@
 /**
  * Infinite-fade Gridfinity grid for the bin designer 3D preview.
- * Uses a custom fragment shader to render a grid at 42mm intervals
- * aligned with the bin's grid cell boundaries, fading out radially.
- * The bin sits correctly on top of the grid cells it occupies.
+ * Uses a custom fragment shader to render a grid at gridUnitMm intervals
+ * (default 42mm) aligned with the bin's grid cell boundaries, fading out
+ * radially. The bin sits correctly on top of the grid cells it occupies.
  */
 
 import { useMemo, useEffect } from 'react';
@@ -15,12 +15,14 @@ interface FootprintGridProps {
   width: number;
   /** Bin depth in grid units */
   depth: number;
+  /** Per-layout grid unit in mm (defaults to standard 42mm) */
+  gridUnitMm?: number;
 }
 
 /** How many grid units the floor extends beyond the bin footprint */
 const GRID_EXTENT = 14;
-/** Minimum floor size to avoid clipping on small bins */
-const MIN_FLOOR_SIZE = GRIDFINITY.GRID_SIZE * 16;
+/** Minimum floor size as a multiple of one grid unit */
+const MIN_FLOOR_GRID_UNITS = 16;
 
 const gridVertexShader = /* glsl */ `
   varying vec2 vWorldPos;
@@ -66,27 +68,28 @@ const gridFragmentShader = /* glsl */ `
  * Grid lines at 42mm intervals are aligned with the bin's cell boundaries,
  * so the bin appears correctly placed on the grid cells it occupies.
  */
-export function FootprintGrid({ width, depth }: FootprintGridProps) {
+export function FootprintGrid({ width, depth, gridUnitMm }: FootprintGridProps) {
   const colors = useThreeColors();
+  const GS = gridUnitMm ?? GRIDFINITY.GRID_SIZE;
   // Floor size: extends well beyond the bin for the "infinite" illusion
   const maxDim = Math.max(width, depth);
-  const floorSize = Math.max((maxDim + GRID_EXTENT * 2) * GRIDFINITY.GRID_SIZE, MIN_FLOOR_SIZE);
+  const floorSize = Math.max((maxDim + GRID_EXTENT * 2) * GS, GS * MIN_FLOOR_GRID_UNITS);
 
   // Grid offset: shift the grid pattern so lines align with the bin's cell boundaries
   // The bin is centered at origin, so offset by half the nominal width/depth
-  const offsetX = (width * GRIDFINITY.GRID_SIZE) / 2;
-  const offsetY = (depth * GRIDFINITY.GRID_SIZE) / 2;
+  const offsetX = (width * GS) / 2;
+  const offsetY = (depth * GS) / 2;
 
   // Fade distances: grid stays crisp near the bin, fades out toward edges
-  const fadeStart = (maxDim / 2 + 4) * GRIDFINITY.GRID_SIZE;
-  const fadeEnd = (maxDim / 2 + GRID_EXTENT) * GRIDFINITY.GRID_SIZE;
+  const fadeStart = (maxDim / 2 + 4) * GS;
+  const fadeEnd = (maxDim / 2 + GRID_EXTENT) * GS;
 
   const material = useMemo(() => {
     return new THREE.ShaderMaterial({
       vertexShader: gridVertexShader,
       fragmentShader: gridFragmentShader,
       uniforms: {
-        gridSize: { value: GRIDFINITY.GRID_SIZE },
+        gridSize: { value: GS },
         gridOffset: { value: new THREE.Vector2(offsetX, offsetY) },
         fadeStart: { value: fadeStart },
         fadeEnd: { value: fadeEnd },
@@ -97,7 +100,7 @@ export function FootprintGrid({ width, depth }: FootprintGridProps) {
       transparent: true,
       depthWrite: false,
     });
-  }, [offsetX, offsetY, fadeStart, fadeEnd, colors.footprintLine]);
+  }, [GS, offsetX, offsetY, fadeStart, fadeEnd, colors.footprintLine]);
 
   // Dispose shader material on unmount/change
   useEffect(() => {

--- a/src/features/bin-designer/components/preview/GhostCompartmentPreview/GhostCompartmentPreview.tsx
+++ b/src/features/bin-designer/components/preview/GhostCompartmentPreview/GhostCompartmentPreview.tsx
@@ -34,6 +34,7 @@ export function GhostCompartmentPreview() {
     width,
     depth,
     height,
+    gridUnitMm,
     heightUnitMm,
     wallThickness,
     cols,
@@ -45,6 +46,7 @@ export function GhostCompartmentPreview() {
       width: s.params.width,
       depth: s.params.depth,
       height: s.params.height,
+      gridUnitMm: s.params.gridUnitMm,
       heightUnitMm: s.params.heightUnitMm,
       wallThickness: s.params.wallThickness,
       cols: s.params.compartments.cols,
@@ -55,8 +57,8 @@ export function GhostCompartmentPreview() {
   );
 
   // Calculate bin dimensions
-  const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
-  const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+  const outerW = width * gridUnitMm - GRIDFINITY.TOLERANCE;
+  const outerD = depth * gridUnitMm - GRIDFINITY.TOLERANCE;
   const innerW = outerW - 2 * wallThickness;
   const innerD = outerD - 2 * wallThickness;
   const totalH = height * heightUnitMm;

--- a/src/features/bin-designer/components/preview/GhostCutouts/GhostCutouts.tsx
+++ b/src/features/bin-designer/components/preview/GhostCutouts/GhostCutouts.tsx
@@ -155,19 +155,29 @@ export function GhostCutouts() {
   const { invalidate } = useThree();
   const lineRef = useRef<LineSegments2 | null>(null);
 
-  const { width, depth, height, heightUnitMm, wallThickness, cutouts, base, generationStatus } =
-    useDesignerStore(
-      useShallow((s) => ({
-        width: s.params.width,
-        depth: s.params.depth,
-        height: s.params.height,
-        heightUnitMm: s.params.heightUnitMm,
-        wallThickness: s.params.wallThickness,
-        cutouts: s.params.cutouts,
-        base: s.params.base,
-        generationStatus: s.generation.status,
-      }))
-    );
+  const {
+    width,
+    depth,
+    height,
+    gridUnitMm,
+    heightUnitMm,
+    wallThickness,
+    cutouts,
+    base,
+    generationStatus,
+  } = useDesignerStore(
+    useShallow((s) => ({
+      width: s.params.width,
+      depth: s.params.depth,
+      height: s.params.height,
+      gridUnitMm: s.params.gridUnitMm,
+      heightUnitMm: s.params.heightUnitMm,
+      wallThickness: s.params.wallThickness,
+      cutouts: s.params.cutouts,
+      base: s.params.base,
+      generationStatus: s.generation.status,
+    }))
+  );
 
   const selectedIds = useCutoutSelection((s) => s.selectedIds);
   const previewOverrides = useCutoutSelection((s) => s.previewOverrides);
@@ -178,8 +188,8 @@ export function GhostCutouts() {
   const wallHeight = isFlat ? totalH : totalH - GRIDFINITY.BASE_HEIGHT;
   const floorZ = isFlat ? 0 : GRIDFINITY.BASE_HEIGHT;
 
-  const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
-  const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+  const outerW = width * gridUnitMm - GRIDFINITY.TOLERANCE;
+  const outerD = depth * gridUnitMm - GRIDFINITY.TOLERANCE;
   const innerW = outerW - 2 * wallThickness;
   const innerD = outerD - 2 * wallThickness;
   const originX = -innerW / 2;

--- a/src/features/bin-designer/components/preview/GhostDividerPieces/GhostDividerPieces.tsx
+++ b/src/features/bin-designer/components/preview/GhostDividerPieces/GhostDividerPieces.tsx
@@ -44,6 +44,7 @@ export function GhostDividerPieces() {
     width,
     depth,
     height,
+    gridUnitMm,
     heightUnitMm,
     wallThickness,
     style,
@@ -56,6 +57,7 @@ export function GhostDividerPieces() {
       width: s.params.width,
       depth: s.params.depth,
       height: s.params.height,
+      gridUnitMm: s.params.gridUnitMm,
       heightUnitMm: s.params.heightUnitMm,
       wallThickness: s.params.wallThickness,
       style: s.params.style,
@@ -66,8 +68,8 @@ export function GhostDividerPieces() {
     }))
   );
 
-  const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
-  const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+  const outerW = width * gridUnitMm - GRIDFINITY.TOLERANCE;
+  const outerD = depth * gridUnitMm - GRIDFINITY.TOLERANCE;
   const innerW = outerW - 2 * wallThickness;
   const innerD = outerD - 2 * wallThickness;
   const totalH = height * heightUnitMm;

--- a/src/features/bin-designer/components/preview/GhostDividers/GhostDividers.tsx
+++ b/src/features/bin-designer/components/preview/GhostDividers/GhostDividers.tsx
@@ -29,23 +29,33 @@ export function GhostDividers() {
   const { invalidate } = useThree();
   const lineRef = useRef<LineSegments2 | null>(null);
 
-  const { width, depth, height, heightUnitMm, wallThickness, cols, rows, generationStatus } =
-    useDesignerStore(
-      useShallow((s) => ({
-        width: s.params.width,
-        depth: s.params.depth,
-        height: s.params.height,
-        heightUnitMm: s.params.heightUnitMm,
-        wallThickness: s.params.wallThickness,
-        cols: s.params.compartments.cols,
-        rows: s.params.compartments.rows,
-        generationStatus: s.generation.status,
-      }))
-    );
+  const {
+    width,
+    depth,
+    height,
+    gridUnitMm,
+    heightUnitMm,
+    wallThickness,
+    cols,
+    rows,
+    generationStatus,
+  } = useDesignerStore(
+    useShallow((s) => ({
+      width: s.params.width,
+      depth: s.params.depth,
+      height: s.params.height,
+      gridUnitMm: s.params.gridUnitMm,
+      heightUnitMm: s.params.heightUnitMm,
+      wallThickness: s.params.wallThickness,
+      cols: s.params.compartments.cols,
+      rows: s.params.compartments.rows,
+      generationStatus: s.generation.status,
+    }))
+  );
 
   // Calculate bin dimensions
-  const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
-  const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+  const outerW = width * gridUnitMm - GRIDFINITY.TOLERANCE;
+  const outerD = depth * gridUnitMm - GRIDFINITY.TOLERANCE;
   const innerW = outerW - 2 * wallThickness;
   const innerD = outerD - 2 * wallThickness;
   const totalH = height * heightUnitMm;

--- a/src/features/bin-designer/components/preview/GhostHandles/GhostHandles.tsx
+++ b/src/features/bin-designer/components/preview/GhostHandles/GhostHandles.tsx
@@ -29,6 +29,7 @@ export function GhostHandles() {
     width,
     depth,
     height,
+    gridUnitMm,
     heightUnitMm,
     wallThickness,
     style,
@@ -42,6 +43,7 @@ export function GhostHandles() {
       width: s.params.width,
       depth: s.params.depth,
       height: s.params.height,
+      gridUnitMm: s.params.gridUnitMm,
       heightUnitMm: s.params.heightUnitMm,
       wallThickness: s.params.wallThickness,
       style: s.params.style,
@@ -53,8 +55,8 @@ export function GhostHandles() {
     }))
   );
 
-  const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
-  const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+  const outerW = width * gridUnitMm - GRIDFINITY.TOLERANCE;
+  const outerD = depth * gridUnitMm - GRIDFINITY.TOLERANCE;
   const innerW = outerW - 2 * wallThickness;
   const innerD = outerD - 2 * wallThickness;
 

--- a/src/features/bin-designer/components/preview/GhostLabelTabs/GhostLabelTabs.tsx
+++ b/src/features/bin-designer/components/preview/GhostLabelTabs/GhostLabelTabs.tsx
@@ -25,6 +25,7 @@ export function GhostLabelTabs() {
     width,
     depth,
     height,
+    gridUnitMm,
     heightUnitMm,
     wallThickness,
     style,
@@ -36,6 +37,7 @@ export function GhostLabelTabs() {
       width: s.params.width,
       depth: s.params.depth,
       height: s.params.height,
+      gridUnitMm: s.params.gridUnitMm,
       heightUnitMm: s.params.heightUnitMm,
       wallThickness: s.params.wallThickness,
       style: s.params.style,
@@ -46,8 +48,8 @@ export function GhostLabelTabs() {
   );
   const { cols, rows, thickness, cells } = compartments;
 
-  const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
-  const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+  const outerW = width * gridUnitMm - GRIDFINITY.TOLERANCE;
+  const outerD = depth * gridUnitMm - GRIDFINITY.TOLERANCE;
   const innerW = outerW - 2 * wallThickness;
   const innerD = outerD - 2 * wallThickness;
   const totalH = height * heightUnitMm;

--- a/src/features/bin-designer/components/preview/GhostScoops/GhostScoops.tsx
+++ b/src/features/bin-designer/components/preview/GhostScoops/GhostScoops.tsx
@@ -32,6 +32,7 @@ export function GhostScoops() {
     width,
     depth,
     height,
+    gridUnitMm,
     heightUnitMm,
     wallThickness,
     style,
@@ -44,6 +45,7 @@ export function GhostScoops() {
       width: s.params.width,
       depth: s.params.depth,
       height: s.params.height,
+      gridUnitMm: s.params.gridUnitMm,
       heightUnitMm: s.params.heightUnitMm,
       wallThickness: s.params.wallThickness,
       style: s.params.style,
@@ -55,8 +57,8 @@ export function GhostScoops() {
   );
   const { cols, rows, cells } = compartments;
 
-  const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
-  const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+  const outerW = width * gridUnitMm - GRIDFINITY.TOLERANCE;
+  const outerD = depth * gridUnitMm - GRIDFINITY.TOLERANCE;
   const innerW = outerW - 2 * wallThickness;
   const innerD = outerD - 2 * wallThickness;
 

--- a/src/features/bin-designer/components/preview/GhostSlotLines/GhostSlotLines.tsx
+++ b/src/features/bin-designer/components/preview/GhostSlotLines/GhostSlotLines.tsx
@@ -35,6 +35,7 @@ export function GhostSlotLines() {
     width,
     depth,
     height,
+    gridUnitMm,
     heightUnitMm,
     wallThickness,
     style,
@@ -47,6 +48,7 @@ export function GhostSlotLines() {
       width: s.params.width,
       depth: s.params.depth,
       height: s.params.height,
+      gridUnitMm: s.params.gridUnitMm,
       heightUnitMm: s.params.heightUnitMm,
       wallThickness: s.params.wallThickness,
       style: s.params.style,
@@ -57,8 +59,8 @@ export function GhostSlotLines() {
     }))
   );
 
-  const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
-  const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+  const outerW = width * gridUnitMm - GRIDFINITY.TOLERANCE;
+  const outerD = depth * gridUnitMm - GRIDFINITY.TOLERANCE;
   const innerW = outerW - 2 * wallThickness;
   const innerD = outerD - 2 * wallThickness;
   const totalH = height * heightUnitMm;

--- a/src/features/bin-designer/components/preview/GhostWallCutouts/GhostWallCutouts.tsx
+++ b/src/features/bin-designer/components/preview/GhostWallCutouts/GhostWallCutouts.tsx
@@ -27,22 +27,32 @@ export function GhostWallCutouts() {
   const { invalidate } = useThree();
   const lineRef = useRef<LineSegments2 | null>(null);
 
-  const { width, depth, height, heightUnitMm, wallThickness, walls, baseStyle, generationStatus } =
-    useDesignerStore(
-      useShallow((s) => ({
-        width: s.params.width,
-        depth: s.params.depth,
-        height: s.params.height,
-        heightUnitMm: s.params.heightUnitMm,
-        wallThickness: s.params.wallThickness,
-        walls: s.params.walls,
-        baseStyle: s.params.base.style,
-        generationStatus: s.generation.status,
-      }))
-    );
+  const {
+    width,
+    depth,
+    height,
+    gridUnitMm,
+    heightUnitMm,
+    wallThickness,
+    walls,
+    baseStyle,
+    generationStatus,
+  } = useDesignerStore(
+    useShallow((s) => ({
+      width: s.params.width,
+      depth: s.params.depth,
+      height: s.params.height,
+      gridUnitMm: s.params.gridUnitMm,
+      heightUnitMm: s.params.heightUnitMm,
+      wallThickness: s.params.wallThickness,
+      walls: s.params.walls,
+      baseStyle: s.params.base.style,
+      generationStatus: s.generation.status,
+    }))
+  );
 
-  const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
-  const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+  const outerW = width * gridUnitMm - GRIDFINITY.TOLERANCE;
+  const outerD = depth * gridUnitMm - GRIDFINITY.TOLERANCE;
   const innerW = outerW - 2 * wallThickness;
   const innerD = outerD - 2 * wallThickness;
   const totalH = height * heightUnitMm;

--- a/src/features/bin-designer/components/preview/GhostWireframe/GhostWireframe.test.tsx
+++ b/src/features/bin-designer/components/preview/GhostWireframe/GhostWireframe.test.tsx
@@ -5,6 +5,10 @@ import { useDesignerStore } from '@/features/bin-designer/store';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import { GhostWireframe } from './GhostWireframe';
 
+const { capturedPositions } = vi.hoisted(() => ({
+  capturedPositions: [] as number[][],
+}));
+
 vi.mock('@react-three/fiber', () => ({
   Canvas: ({ children }: { children: ReactNode }) => <div data-testid="r3f-canvas">{children}</div>,
   useThree: () => ({
@@ -69,7 +73,9 @@ vi.mock('three/examples/jsm/lines/LineMaterial.js', () => ({
 
 vi.mock('three/examples/jsm/lines/LineSegmentsGeometry.js', () => ({
   LineSegmentsGeometry: class MockLineSegmentsGeometry {
-    setPositions = vi.fn();
+    setPositions(positions: number[]) {
+      capturedPositions.push([...positions]);
+    }
     dispose = vi.fn();
   },
 }));
@@ -77,6 +83,7 @@ vi.mock('three/examples/jsm/lines/LineSegmentsGeometry.js', () => ({
 describe('GhostWireframe', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    capturedPositions.length = 0;
     useDesignerStore.setState({
       params: DEFAULT_BIN_PARAMS,
       generation: {
@@ -105,6 +112,31 @@ describe('GhostWireframe', () => {
     });
     const { container } = render(<GhostWireframe />);
     expect(container.firstChild).not.toBeNull();
+  });
+
+  it('outer dimensions track params.gridUnitMm (regression for #1807-follow-up)', () => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, width: 2, depth: 2, gridUnitMm: 30 },
+      generation: {
+        status: 'generating',
+        mesh: null,
+        progress: 0,
+        epoch: 0,
+      },
+    });
+    render(<GhostWireframe />);
+
+    expect(capturedPositions.length).toBeGreaterThan(0);
+    const positions = capturedPositions[0];
+    let maxAbsX = 0;
+    let maxAbsY = 0;
+    for (let i = 0; i < positions.length; i += 3) {
+      maxAbsX = Math.max(maxAbsX, Math.abs(positions[i]));
+      maxAbsY = Math.max(maxAbsY, Math.abs(positions[i + 1]));
+    }
+    // outerW = 2 × 30 − 0.5 = 59.5 → halfW = 29.75 (would be 41.75 with hardcoded 42)
+    expect(maxAbsX).toBeCloseTo(29.75, 5);
+    expect(maxAbsY).toBeCloseTo(29.75, 5);
   });
 
   it('renders nothing when generation is complete', () => {

--- a/src/features/bin-designer/components/preview/GhostWireframe/GhostWireframe.tsx
+++ b/src/features/bin-designer/components/preview/GhostWireframe/GhostWireframe.tsx
@@ -29,19 +29,20 @@ export function GhostWireframe() {
   const { invalidate } = useThree();
   const lineRef = useRef<LineSegments2 | null>(null);
 
-  const { width, depth, height, heightUnitMm, generationStatus } = useDesignerStore(
+  const { width, depth, height, gridUnitMm, heightUnitMm, generationStatus } = useDesignerStore(
     useShallow((s) => ({
       width: s.params.width,
       depth: s.params.depth,
       height: s.params.height,
+      gridUnitMm: s.params.gridUnitMm,
       heightUnitMm: s.params.heightUnitMm,
       generationStatus: s.generation.status,
     }))
   );
 
   // Calculate bin dimensions
-  const outerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
-  const outerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE;
+  const outerW = width * gridUnitMm - GRIDFINITY.TOLERANCE;
+  const outerD = depth * gridUnitMm - GRIDFINITY.TOLERANCE;
   const totalH = height * heightUnitMm;
 
   // Only show during generation

--- a/src/shared/components/preview/BinNameLabel.tsx
+++ b/src/shared/components/preview/BinNameLabel.tsx
@@ -14,6 +14,8 @@ interface BinNameLabelProps {
   width: number;
   /** Bin depth in grid units (for vertical positioning relative to bin edge) */
   depth: number;
+  /** Grid unit size in mm (defaults to standard 42mm) */
+  gridUnitMm?: number;
   /** Design name to display */
   name: string;
 }
@@ -28,12 +30,13 @@ const FRONT_OFFSET = 32;
  * Bin name label displayed on the floor in front of the bin.
  * Uppercase text centered on the bin's width.
  */
-export function BinNameLabel({ width, depth, name }: BinNameLabelProps) {
+export function BinNameLabel({ width, depth, gridUnitMm, name }: BinNameLabelProps) {
   const colors = useThreeColors();
   if (!name.trim()) return null;
 
-  const outerW = width * GRIDFINITY.GRID_SIZE;
-  const halfD = (depth * GRIDFINITY.GRID_SIZE) / 2;
+  const GS = gridUnitMm ?? GRIDFINITY.GRID_SIZE;
+  const outerW = width * GS;
+  const halfD = (depth * GS) / 2;
 
   const textY = -halfD - FRONT_OFFSET;
 


### PR DESCRIPTION
## Summary

Ghost preview overlays in the bin designer (wireframe, cutouts, handles, scoops, dividers, label tabs, slot lines, divider pieces, wall cutouts, compartment preview) hardcoded `GRIDFINITY.GRID_SIZE` (42mm) when computing `outerW` / `outerD`. The mesh generator reads `params.gridUnitMm`, which is now user-configurable in the 20–60mm range via Physical Units (#1787). At any non-42mm grid unit, the ghosts diverged from the real bin by `width × (gridUnitMm − 42)` per axis — e.g. a 2-unit bin at 30mm showed a ghost wireframe 24mm too wide overall, cutouts in the wrong positions, dividers floating outside the mesh.

The symmetric `heightUnitMm` half of this fix shipped in #1448 (`dcd3fac8`) — the matching `gridUnitMm` half was missed across the same 10 ghost components plus `FootprintGrid` and shared `BinNameLabel`.

## Changes

- 10 ghost components in `bin-designer/components/preview/` now read `s.params.gridUnitMm` via `useDesignerStore(useShallow(...))` and use it in place of the hardcoded constant.
- `FootprintGrid` accepts an optional `gridUnitMm` prop (fallback to 42mm to keep sibling tests passing) and threads it through the shader uniform, fade radii, and floor extent.
- Shared `BinNameLabel` accepts an optional `gridUnitMm` prop matching the fallback shape already used by shared `BinAxisLabels`.
- `PreviewCanvas` now passes `params.gridUnitMm` to `FootprintGrid`, `BinAxisLabels`, and `BinNameLabel`.
- Regression test in `GhostWireframe.test.tsx` captures `LineSegmentsGeometry.setPositions` args and asserts max |x| matches the `gridUnitMm`-derived half-width (29.75mm at `gridUnitMm=30`) — would have caught the original bug.

## Test plan

- [x] `pnpm typecheck` — no new errors in changed files (`booleanStage.ts` pre-existing, unrelated)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm vitest run src/features/bin-designer src/features/baseplate` — 2545 / 2545 passed
- [x] `pnpm vitest run src/shared/components/preview` — 8 / 8 passed
- [x] `pnpm vitest run src/features/bin-designer/components/preview` — 115 / 115 passed
- [ ] Manual: set Physical Units to 30mm grid, drag a cutout / resize a bin / change compartments and confirm the ghost overlays now match the regenerated mesh instead of floating at 42mm-based phantom boundaries.