### PR TITLE
fix(bin-designer): engraved-text a11y carryover + typo + test polish

### DIFF
--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
@@ -105,12 +105,12 @@ export function LabelTabsSection() {
         </span>
       </div>
 
-      {/* Alignment */}
+      {/* Alignment — `<span>` heading because no single input owns the group label */}
       <div>
-        <label className="text-xs font-medium text-content-secondary mb-1 block">
+        <span className="text-xs font-medium text-content-secondary mb-1 block">
           {t('binDesigner.tabAlignment')}
-        </label>
-        <div className="flex gap-1">
+        </span>
+        <div role="group" aria-label={t('binDesigner.tabAlignment')} className="flex gap-1">
           {ALIGNMENT_OPTIONS.map((option) => (
             <button
               key={option}
@@ -128,12 +128,12 @@ export function LabelTabsSection() {
         </div>
       </div>
 
-      {/* Support picker */}
+      {/* Support picker — `<span>` heading; segmented control gets the group label */}
       <div>
-        <label className="text-xs font-medium text-content-secondary mb-1 block">
+        <span className="text-xs font-medium text-content-secondary mb-1 block">
           {t('binDesigner.tabSupport')}
-        </label>
-        <div className="flex gap-1">
+        </span>
+        <div role="group" aria-label={t('binDesigner.tabSupport')} className="flex gap-1">
           {SUPPORT_OPTIONS.map((option) => (
             <button
               key={option}

--- a/src/features/generation/worker/generators/textBuilder.scenario.test.ts
+++ b/src/features/generation/worker/generators/textBuilder.scenario.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
-import { buildEngraveCutSolid } from './textBuilder';
+import { buildEngraveCutSolid, TEXT_BOOLEAN_EPSILON } from './textBuilder';
 import { loadFont, withScope, mesh, clone, unwrap, type Shape3D } from 'brepjs';
 import { isErr } from '@/core/result';
 import { readFileSync } from 'node:fs';
@@ -68,7 +68,7 @@ describe('buildEngraveCutSolid', () => {
     expect(solid).toBeNull();
   });
 
-  it('places the solid below the topZ plane (extruded downward into the host)', () => {
+  it('starts just above topZ (EPSILON lift) and extrudes downward by depth + EPSILON', () => {
     // `clone(...)` lifts the shape out of the disposal scope so we can call
     // `mesh()` on it after the scope's scratch handles are freed.
     const solid = withScope((scope): Shape3D | null => {
@@ -84,10 +84,13 @@ describe('buildEngraveCutSolid', () => {
       if (z > maxZ) maxZ = z;
       if (z < minZ) minZ = z;
     }
-    // Top of the solid sits just above topZ (the EPSILON lift); bottom sits
-    // at most `depth + EPSILON` below it.
+    // Top of the solid sits exactly EPSILON above topZ; bottom is depth +
+    // EPSILON below it. Tessellation slack is bounded by the mesh
+    // `tolerance` arg above (0.5mm), so use that — `TEXT_BOOLEAN_EPSILON`
+    // is the analytical bound; tessellation can never undercut it.
+    const MESH_SLACK = 0.5;
     expect(maxZ).toBeGreaterThan(BASE.topZ);
     expect(minZ).toBeLessThan(BASE.topZ);
-    expect(BASE.topZ - minZ).toBeLessThan(BASE.depth + 0.1);
+    expect(BASE.topZ - minZ).toBeLessThan(BASE.depth + TEXT_BOOLEAN_EPSILON + MESH_SLACK);
   });
 });

--- a/src/features/generation/worker/generators/textBuilder.ts
+++ b/src/features/generation/worker/generators/textBuilder.ts
@@ -120,8 +120,10 @@ export interface BuildTextSolidOptions {
 
 /** Lift sketches above the host top face so booleans don't touch coincident
  *  surfaces (an OCCT fragility point that occasionally produces nullspace
- *  results). 0.01mm is below any printable feature. */
-const EPSILON = 0.01;
+ *  results). 0.01mm is below any printable feature. Exported so tests can
+ *  assert against the same tolerance the runtime uses instead of duplicating
+ *  the magic number. */
+export const TEXT_BOOLEAN_EPSILON = 0.01;
 
 /**
  * Apply the stencil-font auto-swap for through-cut mode. The user's font
@@ -166,13 +168,14 @@ export function buildTextSolid(
 
   // Sketch origin: engrave/through-cut start just above the top face and
   // extrude DOWN; emboss starts at the top face and extrudes UP.
-  const sketchOriginZ = options.mode === 'emboss' ? options.topZ : options.topZ + EPSILON;
+  const sketchOriginZ =
+    options.mode === 'emboss' ? options.topZ : options.topZ + TEXT_BOOLEAN_EPSILON;
   const extrusion =
     options.mode === 'emboss'
       ? options.depth
       : options.mode === 'through-cut'
-        ? -(options.hostThickness + 2 * EPSILON)
-        : -(options.depth + EPSILON);
+        ? -(options.hostThickness + 2 * TEXT_BOOLEAN_EPSILON)
+        : -(options.depth + TEXT_BOOLEAN_EPSILON);
 
   const sketches = sketchText(
     trimmed,

--- a/src/features/generation/worker/wasmInstantiator.ts
+++ b/src/features/generation/worker/wasmInstantiator.ts
@@ -142,7 +142,7 @@ export async function loadOcctWasm(): Promise<WasmLoadResult> {
   // Engraved-text APIs are kernel-agnostic at brepjs's surface but use
   // OCCT primitives under the hood; occt-wasm satisfies them, so font
   // loading mirrors the default-kernel path. brepkit-wasm intentionally
-  // skipped — it doesn't implement the topology ops textBlueprints needs.
+  // skipped — it doesn't implement the topology ops textBuilder needs.
   await loadEmbeddedFonts();
 
   return { isThreaded: false, hardwareConcurrency };


### PR DESCRIPTION
## Summary

Follow-up to #1812 (already merged) and #1815 (already merged). Greptile + Copilot left 4 review items on #1812 that landed unaddressed in both merges; addressing them here.

## Items addressed

1. **a11y (Greptile carryover).** #1812 fixed the "Engraved text" group heading from `<label>` to `<span>`, but Greptile also flagged that the existing "Alignment" and "Support" headings in the same file have the same bug — `<label>` without `htmlFor` is treated as plain text by screen readers. Both are now `<span>` and the button groups carry `role="group"` + `aria-label` so screen readers still announce the section.

2. **Typo (Greptile P2 + Copilot).** `wasmInstantiator` inline comment said `textBlueprints` (no such module exists) instead of `textBuilder`. Matches the JSDoc on `loadEmbeddedFonts` just above.

3. **Test name (Copilot).** Scenario test was titled "places the solid below the topZ plane" but its assertions explicitly require `maxZ > topZ` (because of the EPSILON lift). Renamed to "starts just above topZ (EPSILON lift) and extrudes downward by depth + EPSILON" — matches the invariant the test actually checks.

4. **Test tolerance (Copilot).** Hard-coded `0.1` slack now references the exported `TEXT_BOOLEAN_EPSILON` constant plus an explicit `MESH_SLACK` for tessellation. `TEXT_BOOLEAN_EPSILON` is now exported from `textBuilder` and the runtime uses it instead of a private `EPSILON`, so the runtime and tests can't drift apart.

## Test plan
- [x] `pnpm run typecheck` clean
- [x] 18 affected tests pass (textBuilder.scenario + LabelTabsSection)
- [ ] Manual: tab through Alignment / Support / Engraved-text headings with a screen reader — confirm announced as group labels not plain text

## Note on the rapid-fire PR cycle

This is the 4th cleanup PR in the engraved-text track (#1811, #1812, this PR after #1815). Automerge fires faster than Greptile + the 7-min review window, so each round of feedback lands as its own PR rather than additional commits. The feature track is complete after this one barring fresh Greptile findings.