### PR TITLE
fix(bin-designer): engraved-text emboss coplanar fix + rotation-aware cutout AABB

### DIFF
--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -23,8 +23,9 @@ import {
   isOk,
   curveLength,
   clone,
+  withScope,
 } from 'brepjs';
-import type { Shape3D, ValidSolid, Edge, Dimension } from 'brepjs';
+import type { Shape3D, ValidSolid, Edge, Dimension, DisposalScope } from 'brepjs';
 import type { BinParams, Cutout, PathPoint } from '@/shared/types/bin';
 import { MIN_PATH_POINTS } from '@/shared/types/bin';
 import {
@@ -35,7 +36,6 @@ import {
 } from './cutoutScoopHelpers';
 import { sketch } from './meshUtils';
 import { fuseAllOrNull } from './compartmentBuilder';
-import { withScope, type DisposalScope } from 'brepjs';
 import { buildTextSolid } from './textBuilder';
 /** Axis-aligned bounding box in XY. */
 export interface AABB {
@@ -51,6 +51,53 @@ export interface AABB {
 function computeRotationSafeAABB(cx: number, cy: number, width: number, depth: number): AABB {
   const diag = Math.sqrt(width ** 2 + depth ** 2) / 2;
   return { minX: cx - diag, minY: cy - diag, maxX: cx + diag, maxY: cy + diag };
+}
+
+/**
+ * Tight world-coord AABB for a cutout, accounting for `cutout.rotation`.
+ *
+ * Projects the four corners through the rotation matrix (around the cutout's
+ * own center) and takes their min/max. Unrotated cutouts return their plain
+ * extent; rotated ones get a true axis-aligned envelope (smaller than
+ * `computeRotationSafeAABB`'s diagonal-based safe box, which would push
+ * adjacent text farther out than necessary).
+ *
+ * `originX/Y` is the bin-interior origin in world coords (= -innerW/2,
+ * -innerD/2), so the returned AABB sits in the interior frame.
+ */
+function cutoutWorldAabb(
+  cutout: Pick<Cutout, 'x' | 'y' | 'width' | 'depth' | 'rotation'>,
+  originX: number,
+  originY: number
+): AABB {
+  const cx = originX + cutout.x + cutout.width / 2;
+  const cy = originY + cutout.y + cutout.depth / 2;
+  const hw = cutout.width / 2;
+  const hd = cutout.depth / 2;
+  if (cutout.rotation === 0) {
+    return { minX: cx - hw, maxX: cx + hw, minY: cy - hd, maxY: cy + hd };
+  }
+  const θ = (cutout.rotation * Math.PI) / 180;
+  const c = Math.cos(θ);
+  const s = Math.sin(θ);
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const [lx, ly] of [
+    [-hw, -hd],
+    [hw, -hd],
+    [hw, hd],
+    [-hw, hd],
+  ] as const) {
+    const wx = cx + lx * c - ly * s;
+    const wy = cy + lx * s + ly * c;
+    if (wx < minX) minX = wx;
+    if (wx > maxX) maxX = wx;
+    if (wy < minY) minY = wy;
+    if (wy > maxY) maxY = wy;
+  }
+  return { minX, maxX, minY, maxY };
 }
 /** Create an extruded cutout shape centered at origin, **without rotation**.
  *  Splitting out rotation lets callers apply axis-aware fillets in the
@@ -682,16 +729,16 @@ export function buildCutoutCuts(
 /**
  * Engraved text adjacent to a cutout, on the bin top surface.
  *
- * Placement: the side picker is interpreted in WORLD coordinates relative to
- * the cutout's AABB — the rotation-aware projection is a follow-up. This
- * keeps the most common case (unrotated cutouts) intuitive and avoids the
- * trig that the design called for but isn't yet load-bearing. Text reads
- * left-to-right in world XY regardless.
+ * The side picker is interpreted in WORLD coordinates (top = +Y, etc.); text
+ * reads left-to-right in world XY regardless of cutout rotation. The cutout
+ * AABB used for placement IS rotation-aware so labels never overlap a rotated
+ * cutout's footprint — `cutoutWorldAabb()` projects the four rotated corners
+ * and takes their min/max.
  *
- * Available space = the gap between the cutout's AABB edge and the bin
- * interior boundary in the chosen direction, minus 2·margin. Returns `null`
- * when even the minimum font size won't fit — better silent skip than a
- * visually broken engraving.
+ * Available space = the gap between the cutout's rotated AABB edge and the
+ * bin interior boundary in the chosen direction, minus 2·margin. Returns
+ * `null` when even the minimum font size won't fit — better silent skip than
+ * a visually broken engraving.
  */
 function buildCutoutLabelEngrave(
   cutout: Cutout,
@@ -704,11 +751,14 @@ function buildCutoutLabelEngrave(
   innerD: number
 ): Shape3D | null {
   const side = cutout.textSide ?? 'top';
-  // World-coord AABB of the cutout (in interior frame: origin at bin center).
-  const aabbMinX = originX + cutout.x;
-  const aabbMaxX = aabbMinX + cutout.width;
-  const aabbMinY = originY + cutout.y;
-  const aabbMaxY = aabbMinY + cutout.depth;
+  // World-coord AABB of the cutout (in interior frame: origin at bin center),
+  // rotation-aware so labels don't overlap a rotated cutout.
+  const {
+    minX: aabbMinX,
+    maxX: aabbMaxX,
+    minY: aabbMinY,
+    maxY: aabbMaxY,
+  } = cutoutWorldAabb(cutout, originX, originY);
 
   // Interior bounds in the same frame.
   const interiorMinX = -innerW / 2;

--- a/src/features/generation/worker/generators/textBuilder.ts
+++ b/src/features/generation/worker/generators/textBuilder.ts
@@ -30,7 +30,7 @@ import { isOk } from '@/core/result';
 import type { TextFontFamily, TextMode } from '@/shared/types/bin';
 
 export interface FitResult {
-  /** Rendered font size in mm; `min` if even the smallest size overflows. */
+  /** Rendered font size in mm; `0` if `fits` is false. */
   readonly fontSize: number;
   /** Whether the chosen size honors both width and depth constraints. */
   readonly fits: boolean;
@@ -168,11 +168,18 @@ export function buildTextSolid(
 
   // Sketch origin: engrave/through-cut start just above the top face and
   // extrude DOWN; emboss starts at the top face and extrudes UP.
+  // All three modes need the EPSILON lift to avoid coplanar boolean fragility:
+  //  - engrave / through-cut: sketch sits ABOVE topZ, extrudes DOWN through it
+  //  - emboss: sketch sits BELOW topZ, extrudes UP through it
+  // Either way the solid penetrates the host's top face by EPSILON so the
+  // fuse/cut surfaces overlap instead of being coincident.
   const sketchOriginZ =
-    options.mode === 'emboss' ? options.topZ : options.topZ + TEXT_BOOLEAN_EPSILON;
+    options.mode === 'emboss'
+      ? options.topZ - TEXT_BOOLEAN_EPSILON
+      : options.topZ + TEXT_BOOLEAN_EPSILON;
   const extrusion =
     options.mode === 'emboss'
-      ? options.depth
+      ? options.depth + TEXT_BOOLEAN_EPSILON
       : options.mode === 'through-cut'
         ? -(options.hostThickness + 2 * TEXT_BOOLEAN_EPSILON)
         : -(options.depth + TEXT_BOOLEAN_EPSILON);


### PR DESCRIPTION
## Summary

Follow-up to #1815 (already merged). Greptile + Copilot left 5 review items; addressing them all.

## Real bug: emboss coplanar face

`buildTextSolid` started the emboss sketch exactly at `topZ` (no EPSILON), creating a coincident bottom face with the host's top surface when the fuse runs. Same OCCT fragility the engrave and through-cut paths explicitly avoid via the EPSILON lift. A fuse failure would be silently swallowed by `applyTabText`'s catch — users would see no emboss text and no error.

**Fix:** all three modes now share the EPSILON treatment:
- engrave: sketch at `topZ + EPSILON`, extrude `-(depth + EPSILON)` (was already correct)
- through-cut: sketch at `topZ + EPSILON`, extrude `-(hostThickness + 2·EPSILON)` (was already correct)
- emboss: sketch at `topZ - EPSILON`, extrude `depth + EPSILON` (was the bug — now matches)

The solid always penetrates the host by EPSILON in the direction of the boolean op so the surfaces overlap instead of being coincident.

## Rotation-aware cutout AABB

Greptile flagged that `buildCutoutLabelEngrave` used `cutout.x/y/width/depth` directly, ignoring `rotation`. For rotated cutouts that AABB is wrong — available space miscomputes and the label can overlap the rotated footprint.

**Fix:** new `cutoutWorldAabb()` projects the four cutout corners through the rotation matrix around the cutout's center and takes their min/max. Unrotated cutouts return their plain extent (fast path); rotated cutouts get a true axis-aligned envelope — tighter than `computeRotationSafeAABB()`'s diagonal-based safe box, which would push labels farther out than needed in the 95% unrotated case.

## Smaller items
- **FitResult JSDoc** said `min` on overflow; code returns `0`. Updated to match.
- **Duplicate `brepjs` import** in `cutoutBuilder.ts` — `withScope` / `DisposalScope` were in a separate statement instead of merged. Consolidated.

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` 0 errors
- [x] 16 affected tests pass (textBuilder.scenario + labelTabBuilder including the emboss path)
- [ ] Manual: enable emboss mode on a label tab, type text — confirm raised text appears (no silent fuse failure)
- [ ] Manual: rotate a cutout 45°, enable engrave label — confirm label sits outside the rotated footprint, not overlapping it

## Note

This is the 5th cleanup PR in the engraved-text track. Automerge keeps firing in the gap between push and the wakeup, so each review round lands as its own PR. Functionally fine; if you'd prefer manual merges to consolidate, I can stop auto-enabling it going forward.