### PR TITLE
test(bin-designer): make through-cut scenario test actually exercise geometry

### DIFF
--- a/src/features/generation/worker/generators/textBuilder.scenario.test.ts
+++ b/src/features/generation/worker/generators/textBuilder.scenario.test.ts
@@ -13,16 +13,21 @@ import { isErr } from '@/core/result';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-beforeAll(async () => {
-  await initBrepjs();
-  const buffer = readFileSync(
-    resolve(__dirname, '../assets/fonts/AtkinsonHyperlegible-Regular.ttf')
-  );
+async function loadTtf(filename: string, family: string): Promise<void> {
+  const buffer = readFileSync(resolve(__dirname, `../assets/fonts/${filename}`));
   const result = await loadFont(
     buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
-    'atkinson'
+    family
   );
-  if (isErr(result)) throw new Error(`Font load failed: ${result.error.message}`);
+  if (isErr(result)) throw new Error(`Font load failed for ${family}: ${result.error.message}`);
+}
+
+beforeAll(async () => {
+  await initBrepjs();
+  // Atkinson covers engrave/emboss; Allerta Stencil is required for the
+  // through-cut path because `resolveEffectiveFont` auto-swaps to it.
+  await loadTtf('AtkinsonHyperlegible-Regular.ttf', 'atkinson');
+  await loadTtf('AllertaStencil-Regular.ttf', 'allerta-stencil');
 }, 30_000);
 
 const BASE = {
@@ -54,8 +59,8 @@ describe('buildTextSolid (engrave)', () => {
   });
 
   it('returns null when the font family is not loaded', () => {
-    // `jetbrains-mono` isn't loaded in this test file (only Atkinson) — so
-    // the runtime guard should return null.
+    // `jetbrains-mono` isn't loaded in this test file (only Atkinson +
+    // Allerta Stencil) — the runtime guard should return null.
     const r = withScope((scope) =>
       buildTextSolid(scope, { ...BASE, fontFamily: 'jetbrains-mono' })
     );
@@ -116,20 +121,31 @@ describe('buildTextSolid (emboss)', () => {
 });
 
 describe('buildTextSolid (through-cut)', () => {
-  it('reports op:cut and extends through the full hostThickness', () => {
+  it('reports op:cut and extends through the full hostThickness (stencil auto-swapped)', () => {
+    // Pass `fontFamily: 'atkinson'` to also assert the stencil auto-swap
+    // path — `resolveEffectiveFont` forces Allerta Stencil for through-cut
+    // regardless of the requested family.
+    let opCaptured: 'cut' | 'fuse' | null = null;
     const solid = withScope((scope): Shape3D | null => {
-      const r = buildTextSolid(scope, { ...BASE, mode: 'through-cut' });
-      return r ? unwrap(clone(r.solid)) : null;
+      const r = buildTextSolid(scope, { ...BASE, mode: 'through-cut', fontFamily: 'atkinson' });
+      expect(r).not.toBeNull();
+      opCaptured = r!.op;
+      return unwrap(clone(r!.solid));
     });
-    // Without Allerta Stencil loaded, the swap returns null — that's the
-    // documented behavior. Skip the depth assertion if so.
-    if (solid === null) return;
-    const tessellated = mesh(solid, { tolerance: 0.5, angularTolerance: 15 });
+    expect(opCaptured).toBe('cut');
+    const tessellated = mesh(solid!, { tolerance: 0.5, angularTolerance: 15 });
     let minZ = Infinity;
+    let maxZ = -Infinity;
     for (let i = 2; i < tessellated.vertices.length; i += 3) {
-      if (tessellated.vertices[i] < minZ) minZ = tessellated.vertices[i];
+      const z = tessellated.vertices[i];
+      if (z < minZ) minZ = z;
+      if (z > maxZ) maxZ = z;
     }
-    // Should extend at least hostThickness below topZ (plus a 2·EPSILON slack)
-    expect(BASE.topZ - minZ).toBeGreaterThan(BASE.hostThickness - TEXT_BOOLEAN_EPSILON);
+    // Span: topZ + EPSILON down to topZ - hostThickness - EPSILON. The
+    // total Z extent must reach hostThickness so the cut produces a clean
+    // exit on both faces of the host.
+    expect(maxZ - minZ).toBeGreaterThanOrEqual(BASE.hostThickness);
+    expect(maxZ).toBeGreaterThan(BASE.topZ);
+    expect(BASE.topZ - minZ).toBeGreaterThanOrEqual(BASE.hostThickness - TEXT_BOOLEAN_EPSILON);
   });
 });


### PR DESCRIPTION
## Summary

Addresses Greptile + Copilot review on #1821 (merged). The new through-cut scenario test I added in that PR was silently passing — Greptile correctly flagged this in the 4/5 review.

## Root cause

\`beforeAll\` only loaded Atkinson. For through-cut, \`resolveEffectiveFont\` returns \`'allerta-stencil'\` (the auto-swap), \`getFont('allerta-stencil')\` returns \`undefined\`, and \`buildTextSolid\` early-returns \`null\`. The test's \`if (solid === null) return;\` then skipped every assertion. The describe block existed but the test was a no-op.

## Fix

- \`beforeAll\` now loads both Atkinson AND Allerta Stencil. Extracted a small \`loadTtf(filename, family)\` helper to keep the setup readable.
- The through-cut test now passes \`fontFamily: 'atkinson'\` explicitly — this also asserts the auto-swap path because we're requesting Atkinson but the result must be a non-null solid (which is only possible if the swap fired and Allerta Stencil resolved).
- Drops the misleading \`if (solid === null) return;\` short-circuit so the assertion list is non-skippable.
- Added explicit \`expect(opCaptured).toBe('cut')\` and \`expect(maxZ - minZ).toBeGreaterThanOrEqual(hostThickness)\` so the through-cut depth guarantee is the gate the test runs.

## Evidence

Test runtime went from **0.8s → 2.1s** — the geometry is actually being built and tessellated now instead of short-circuiting at the null guard.

## Test plan
- [x] \`pnpm run typecheck\` clean
- [x] \`pnpm vitest run textBuilder.scenario.test.ts\` — 7/7 pass