### PR TITLE
feat(bin-designer): foundation for angled dividers (issue #1822)

### DIFF
--- a/api/lib/designerValidation.test.ts
+++ b/api/lib/designerValidation.test.ts
@@ -233,6 +233,62 @@ describe('validateDesignerShare', () => {
       const result = validateDesignerShare(payload, JSON.stringify(payload).length);
       expect(result.valid).toBe(false);
     });
+
+    it('accepts a well-formed dividerOverrides array', () => {
+      const payload = validPayload();
+      (payload.params.compartments as Record<string, unknown>).cols = 1;
+      (payload.params.compartments as Record<string, unknown>).rows = 2;
+      (payload.params.compartments as Record<string, unknown>).cells = [0, 1];
+      (payload.params.compartments as Record<string, unknown>).dividerOverrides = [
+        { compartmentA: 0, compartmentB: 1, offsetStart: 10, offsetEnd: -8 },
+      ];
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects unordered dividerOverrides pair', () => {
+      const payload = validPayload();
+      (payload.params.compartments as Record<string, unknown>).cols = 1;
+      (payload.params.compartments as Record<string, unknown>).rows = 2;
+      (payload.params.compartments as Record<string, unknown>).cells = [0, 1];
+      (payload.params.compartments as Record<string, unknown>).dividerOverrides = [
+        { compartmentA: 1, compartmentB: 0, offsetStart: 0, offsetEnd: 0 },
+      ];
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects dividerOverrides with offsets out of range', () => {
+      const payload = validPayload();
+      (payload.params.compartments as Record<string, unknown>).cols = 1;
+      (payload.params.compartments as Record<string, unknown>).rows = 2;
+      (payload.params.compartments as Record<string, unknown>).cells = [0, 1];
+      (payload.params.compartments as Record<string, unknown>).dividerOverrides = [
+        { compartmentA: 0, compartmentB: 1, offsetStart: 9999, offsetEnd: 0 },
+      ];
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects duplicate dividerOverrides pairs', () => {
+      const payload = validPayload();
+      (payload.params.compartments as Record<string, unknown>).cols = 1;
+      (payload.params.compartments as Record<string, unknown>).rows = 2;
+      (payload.params.compartments as Record<string, unknown>).cells = [0, 1];
+      (payload.params.compartments as Record<string, unknown>).dividerOverrides = [
+        { compartmentA: 0, compartmentB: 1, offsetStart: 5, offsetEnd: 0 },
+        { compartmentA: 0, compartmentB: 1, offsetStart: 10, offsetEnd: 0 },
+      ];
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects dividerOverrides that is not an array', () => {
+      const payload = validPayload();
+      (payload.params.compartments as Record<string, unknown>).dividerOverrides = 'oops';
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(false);
+    });
   });
 
   describe('label tab validation', () => {

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -283,6 +283,46 @@ function validateCompartments(compartments: unknown): string | null {
       }
     }
   }
+  // Optional per-divider tilt overrides. Mirrors the client-side
+  // `DIVIDER_OFFSET_MAX_MM = 200` cap and the canonical pair ordering rule
+  // (compartmentA < compartmentB) so a direct HTTP POST can't smuggle in
+  // unordered or absurd overrides that bypass the store action.
+  if (compartments.dividerOverrides !== undefined) {
+    if (!Array.isArray(compartments.dividerOverrides)) {
+      return 'compartments.dividerOverrides must be an array';
+    }
+    if (compartments.dividerOverrides.length > expectedLength * 2) {
+      // Generous upper bound: at most ~2× cell count of unique pairs.
+      return `compartments.dividerOverrides length is unreasonably large`;
+    }
+    const seenPairs = new Set<string>();
+    for (let i = 0; i < compartments.dividerOverrides.length; i++) {
+      const o = compartments.dividerOverrides[i] as Record<string, unknown>;
+      if (!isObject(o)) {
+        return `compartments.dividerOverrides[${i}] must be an object`;
+      }
+      if (!isNumber(o.compartmentA) || !Number.isInteger(o.compartmentA) || o.compartmentA < 0) {
+        return `compartments.dividerOverrides[${i}].compartmentA must be a non-negative integer`;
+      }
+      if (!isNumber(o.compartmentB) || !Number.isInteger(o.compartmentB) || o.compartmentB < 0) {
+        return `compartments.dividerOverrides[${i}].compartmentB must be a non-negative integer`;
+      }
+      if (o.compartmentA >= o.compartmentB) {
+        return `compartments.dividerOverrides[${i}] must have compartmentA < compartmentB`;
+      }
+      if (!isNumber(o.offsetStart) || !inRange(o.offsetStart, -200, 200)) {
+        return `compartments.dividerOverrides[${i}].offsetStart must be -200..200`;
+      }
+      if (!isNumber(o.offsetEnd) || !inRange(o.offsetEnd, -200, 200)) {
+        return `compartments.dividerOverrides[${i}].offsetEnd must be -200..200`;
+      }
+      const key = `${o.compartmentA}|${o.compartmentB}`;
+      if (seenPairs.has(key)) {
+        return `compartments.dividerOverrides has duplicate pair ${key}`;
+      }
+      seenPairs.add(key);
+    }
+  }
   return null;
 }
 

--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -114,6 +114,19 @@ export const FEATURE_FLAGS = [
     requiresRefresh: false,
     comingSoon: true,
   },
+  {
+    id: 'angled_dividers',
+    name: 'Angled Dividers',
+    description:
+      'Tilt the dividers between compartments to make wedge-shaped slots — handy for silverware drawers where utensils pack better head-to-toe.',
+    status: 'experimental',
+    risk: 'medium',
+    warning:
+      'Coming soon. The geometry pipeline already understands tilted dividers; the editor UI for setting offsets ships in the next update.',
+    addedAt: '2026-05',
+    requiresRefresh: false,
+    comingSoon: true,
+  },
 ] as const satisfies readonly FeatureFlag[];
 
 export type FeatureId = (typeof FEATURE_FLAGS)[number]['id'];

--- a/src/features/bin-designer/store/slices/paramSlice.ts
+++ b/src/features/bin-designer/store/slices/paramSlice.ts
@@ -30,6 +30,7 @@ import {
   isRectangularSelection,
   normalizeIdsWithRemap,
   remapCompartmentTexts,
+  remapDividerOverrides,
 } from '../../utils/compartments';
 import { validateCompartmentSizes } from '../../utils/validation';
 import { defaultsForNewDesign, pushHistoryEntry } from '../helpers';
@@ -254,9 +255,13 @@ export function createParamSlice(set: Set, get: Get) {
         for (let i = 0; i < rows * cols; i++) {
           cells.push(i);
         }
-        // Old per-compartment text would attach to unrelated cells once
-        // IDs regenerate — drop it.
-        const { compartmentTexts: _drop, ...keepCompartments } = state.params.compartments;
+        // Old per-compartment text and divider overrides would attach to
+        // unrelated cells once IDs regenerate — drop them.
+        const {
+          compartmentTexts: _dropTexts,
+          dividerOverrides: _dropOverrides,
+          ...keepCompartments
+        } = state.params.compartments;
         state.params.compartments = {
           ...keepCompartments,
           cols,
@@ -284,10 +289,14 @@ export function createParamSlice(set: Set, get: Get) {
         }
         const { cells: normalized, remap } = normalizeIdsWithRemap(newCells);
         const prevTexts = state.params.compartments.compartmentTexts;
+        const prevOverrides = state.params.compartments.dividerOverrides;
         state.params.compartments = {
           ...state.params.compartments,
           cells: normalized,
           ...(prevTexts ? { compartmentTexts: remapCompartmentTexts(prevTexts, remap) } : {}),
+          ...(prevOverrides
+            ? { dividerOverrides: remapDividerOverrides(prevOverrides, remap) }
+            : {}),
         };
       });
     },
@@ -321,10 +330,14 @@ export function createParamSlice(set: Set, get: Get) {
         }
         const { cells: normalized, remap } = normalizeIdsWithRemap(newCells);
         const prevTexts = state.params.compartments.compartmentTexts;
+        const prevOverrides = state.params.compartments.dividerOverrides;
         state.params.compartments = {
           ...state.params.compartments,
           cells: normalized,
           ...(prevTexts ? { compartmentTexts: remapCompartmentTexts(prevTexts, remap) } : {}),
+          ...(prevOverrides
+            ? { dividerOverrides: remapDividerOverrides(prevOverrides, remap) }
+            : {}),
         };
       });
     },

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -175,6 +175,46 @@ export interface CompartmentConfig {
    * `Draft`s, which require mutable element types.
    */
   readonly compartmentTexts?: string[];
+  /**
+   * Optional per-divider tilt overrides. Each entry shifts the endpoints of
+   * one interior divider away from its axis-aligned grid position, producing
+   * an angled (tapered) divider — useful for wedge-shaped compartments
+   * (e.g. silverware drawer dividers that follow utensil taper).
+   *
+   * The override applies to the unique segment between two adjacent
+   * compartments identified by `compartmentA < compartmentB` (canonical
+   * ordering enforced by the validator). Dropped via
+   * `remapDividerOverrides` on any cell mutation that renumbers IDs.
+   */
+  readonly dividerOverrides?: DividerOverride[];
+}
+
+/**
+ * One tilted-divider override. The underlying axis-aligned divider exists
+ * because two adjacent compartments share a boundary; the override shifts
+ * the divider's endpoints away from that boundary line.
+ *
+ * Coordinate system:
+ * - For a **vertical** divider (compartments stacked horizontally), positive
+ *   `offsetStart` shifts the FRONT endpoint (y = 0 edge) in +X; positive
+ *   `offsetEnd` shifts the BACK endpoint (y = innerD edge) in +X.
+ * - For a **horizontal** divider (compartments stacked vertically), positive
+ *   `offsetStart` shifts the LEFT endpoint (x = 0 edge) in +Y; positive
+ *   `offsetEnd` shifts the RIGHT endpoint (x = innerW edge) in +Y.
+ *
+ * Setting both offsets equal translates the divider without tilting it.
+ * Setting `offsetEnd = -offsetStart` produces a symmetric tilt around the
+ * divider midpoint.
+ */
+export interface DividerOverride {
+  /** Lower of the two compartment IDs (canonical pair ordering). */
+  readonly compartmentA: number;
+  /** Higher of the two compartment IDs. Must be > compartmentA. */
+  readonly compartmentB: number;
+  /** Signed mm shift of the start endpoint perpendicular to the divider axis. */
+  readonly offsetStart: number;
+  /** Signed mm shift of the end endpoint perpendicular to the divider axis. */
+  readonly offsetEnd: number;
 }
 
 /** Scoop ramp configuration for compartment accessibility */

--- a/src/features/bin-designer/utils/compartments.test.ts
+++ b/src/features/bin-designer/utils/compartments.test.ts
@@ -15,10 +15,15 @@ import {
   normalizeIds,
   normalizeIdsWithRemap,
   remapCompartmentTexts,
+  remapDividerOverrides,
+  validateDividerOverride,
+  validateDividerOverrides,
+  compartmentHasTiltedEdge,
+  compartmentHasTiltedBackWall,
   deriveWallSegments,
   fromDividerConfig,
 } from '@/features/bin-designer/utils/compartments';
-import type { CompartmentConfig } from '@/features/bin-designer/types';
+import type { CompartmentConfig, DividerOverride } from '@/features/bin-designer/types';
 
 describe('compartments', () => {
   // =============================================================================
@@ -948,6 +953,254 @@ describe('compartments', () => {
       const ids = getCompartmentIds(result);
       expect(ids.length).toBe(9); // 3×3 = 9 cells
       expect(getCompartmentCount(result)).toBe(9);
+    });
+  });
+
+  // =============================================================================
+  // Divider Override
+  // =============================================================================
+
+  describe('validateDividerOverride', () => {
+    const config: CompartmentConfig = {
+      cols: 1,
+      rows: 2,
+      thickness: 1.2,
+      cells: [0, 1],
+    };
+
+    it('accepts a canonical, in-bounds override between adjacent compartments', () => {
+      expect(
+        validateDividerOverride(config, {
+          compartmentA: 0,
+          compartmentB: 1,
+          offsetStart: 10,
+          offsetEnd: -8,
+        })
+      ).toBeNull();
+    });
+
+    it('rejects unordered pair', () => {
+      expect(
+        validateDividerOverride(config, {
+          compartmentA: 1,
+          compartmentB: 0,
+          offsetStart: 0,
+          offsetEnd: 0,
+        })
+      ).toBe('unordered-pair');
+    });
+
+    it('rejects self-pair', () => {
+      expect(
+        validateDividerOverride(config, {
+          compartmentA: 0,
+          compartmentB: 0,
+          offsetStart: 0,
+          offsetEnd: 0,
+        })
+      ).toBe('self-pair');
+    });
+
+    it('rejects unknown compartment IDs', () => {
+      expect(
+        validateDividerOverride(config, {
+          compartmentA: 0,
+          compartmentB: 9,
+          offsetStart: 0,
+          offsetEnd: 0,
+        })
+      ).toBe('unknown-compartment');
+    });
+
+    it('rejects non-adjacent compartments', () => {
+      // 1×3 grid: compartments 0 and 2 are not adjacent (compartment 1
+      // sits between them).
+      const nonAdj: CompartmentConfig = {
+        cols: 1,
+        rows: 3,
+        thickness: 1.2,
+        cells: [0, 1, 2],
+      };
+      expect(
+        validateDividerOverride(nonAdj, {
+          compartmentA: 0,
+          compartmentB: 2,
+          offsetStart: 0,
+          offsetEnd: 0,
+        })
+      ).toBe('non-adjacent-compartments');
+    });
+
+    it('rejects out-of-bounds offsets', () => {
+      expect(
+        validateDividerOverride(config, {
+          compartmentA: 0,
+          compartmentB: 1,
+          offsetStart: 999,
+          offsetEnd: 0,
+        })
+      ).toBe('offset-out-of-bounds');
+    });
+
+    it('rejects non-finite offsets', () => {
+      expect(
+        validateDividerOverride(config, {
+          compartmentA: 0,
+          compartmentB: 1,
+          offsetStart: Number.POSITIVE_INFINITY,
+          offsetEnd: 0,
+        })
+      ).toBe('offset-not-finite');
+      expect(
+        validateDividerOverride(config, {
+          compartmentA: 0,
+          compartmentB: 1,
+          offsetStart: 0,
+          offsetEnd: Number.NaN,
+        })
+      ).toBe('offset-not-finite');
+    });
+  });
+
+  describe('validateDividerOverrides', () => {
+    const config: CompartmentConfig = {
+      cols: 2,
+      rows: 2,
+      thickness: 1.2,
+      cells: [0, 1, 2, 3],
+    };
+
+    it('rejects duplicate canonical pairs', () => {
+      const result = validateDividerOverrides(config, [
+        { compartmentA: 0, compartmentB: 1, offsetStart: 5, offsetEnd: 0 },
+        { compartmentA: 0, compartmentB: 1, offsetStart: 10, offsetEnd: 0 },
+      ]);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBe('duplicate-pair');
+        expect(result.index).toBe(1);
+      }
+    });
+
+    it('passes on a clean list', () => {
+      const result = validateDividerOverrides(config, [
+        { compartmentA: 0, compartmentB: 1, offsetStart: 5, offsetEnd: 0 },
+        { compartmentA: 2, compartmentB: 3, offsetStart: -3, offsetEnd: 0 },
+      ]);
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('remapDividerOverrides', () => {
+    it('returns empty for undefined / empty input', () => {
+      expect(remapDividerOverrides(undefined, new Map())).toEqual([]);
+      expect(remapDividerOverrides([], new Map([[0, 0]]))).toEqual([]);
+    });
+
+    it('renumbers surviving overrides and preserves canonical ordering', () => {
+      const overrides: DividerOverride[] = [
+        { compartmentA: 0, compartmentB: 1, offsetStart: 5, offsetEnd: -2 },
+        { compartmentA: 1, compartmentB: 2, offsetStart: 0, offsetEnd: 3 },
+      ];
+      // Remap that swaps 0↔1.
+      const remap = new Map([
+        [0, 1],
+        [1, 0],
+        [2, 2],
+      ]);
+      const out = remapDividerOverrides(overrides, remap);
+      expect(out).toEqual([
+        { compartmentA: 0, compartmentB: 1, offsetStart: 5, offsetEnd: -2 },
+        { compartmentA: 0, compartmentB: 2, offsetStart: 0, offsetEnd: 3 },
+      ]);
+    });
+
+    it('drops overrides whose compartment disappeared from the remap', () => {
+      const overrides: DividerOverride[] = [
+        { compartmentA: 0, compartmentB: 1, offsetStart: 5, offsetEnd: 0 },
+        { compartmentA: 1, compartmentB: 2, offsetStart: 3, offsetEnd: 0 },
+      ];
+      // Compartment 2 disappeared (merged into 1).
+      const remap = new Map([
+        [0, 0],
+        [1, 1],
+      ]);
+      const out = remapDividerOverrides(overrides, remap);
+      expect(out).toEqual([{ compartmentA: 0, compartmentB: 1, offsetStart: 5, offsetEnd: 0 }]);
+    });
+
+    it('drops overrides whose two compartments collapsed to the same ID', () => {
+      const overrides: DividerOverride[] = [
+        { compartmentA: 0, compartmentB: 1, offsetStart: 5, offsetEnd: 0 },
+      ];
+      // Compartments 0 and 1 merged to 0.
+      const remap = new Map([
+        [0, 0],
+        [1, 0],
+      ]);
+      expect(remapDividerOverrides(overrides, remap)).toEqual([]);
+    });
+  });
+
+  describe('mergeCells with dividerOverrides', () => {
+    it('remaps surviving overrides after a merge', () => {
+      const config: CompartmentConfig = {
+        cols: 2,
+        rows: 2,
+        thickness: 1.2,
+        cells: [0, 1, 2, 3],
+        dividerOverrides: [
+          { compartmentA: 0, compartmentB: 1, offsetStart: 5, offsetEnd: -3 },
+          { compartmentA: 2, compartmentB: 3, offsetStart: 0, offsetEnd: 8 },
+        ],
+      };
+      // Merge compartments 0 and 1 (top row).
+      const merged = mergeCells(config, [0, 1]);
+      // Top-row override drops; bottom-row override survives with renumbered IDs.
+      expect(merged?.dividerOverrides).toEqual([
+        { compartmentA: 1, compartmentB: 2, offsetStart: 0, offsetEnd: 8 },
+      ]);
+    });
+  });
+
+  describe('compartmentHasTiltedEdge / compartmentHasTiltedBackWall', () => {
+    it('returns false when no overrides exist', () => {
+      const config: CompartmentConfig = {
+        cols: 1,
+        rows: 2,
+        thickness: 1.2,
+        cells: [0, 1],
+      };
+      expect(compartmentHasTiltedEdge(config, 0)).toBe(false);
+      expect(compartmentHasTiltedBackWall(config, 0)).toBe(false);
+    });
+
+    it('detects a tilted edge on either compartment of an override pair', () => {
+      const config: CompartmentConfig = {
+        cols: 1,
+        rows: 2,
+        thickness: 1.2,
+        cells: [0, 1],
+        dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 5, offsetEnd: 0 }],
+      };
+      expect(compartmentHasTiltedEdge(config, 0)).toBe(true);
+      expect(compartmentHasTiltedEdge(config, 1)).toBe(true);
+    });
+
+    it('flags the back-wall tilt only for the front compartment in a 1×2', () => {
+      // 1×2 stacked vertically: row 0 is "front" (closer to y=0), row 1 is
+      // "back". The horizontal divider between them is the BACK wall of
+      // compartment 0 and the FRONT wall of compartment 1. Only compartment
+      // 0's back wall is tilted.
+      const config: CompartmentConfig = {
+        cols: 1,
+        rows: 2,
+        thickness: 1.2,
+        cells: [0, 1],
+        dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 5, offsetEnd: -5 }],
+      };
+      expect(compartmentHasTiltedBackWall(config, 0)).toBe(true);
+      expect(compartmentHasTiltedBackWall(config, 1)).toBe(false);
     });
   });
 });

--- a/src/features/bin-designer/utils/compartments.ts
+++ b/src/features/bin-designer/utils/compartments.ts
@@ -8,7 +8,7 @@
  * - Deriving divider wall segments from the cell map
  */
 
-import type { CompartmentConfig } from '../types';
+import type { CompartmentConfig, DividerOverride } from '../types';
 
 // Grid Creation
 
@@ -160,6 +160,150 @@ export function validateCompartmentGrid(config: CompartmentConfig): number[] {
   return invalid;
 }
 
+// Divider Override Validation
+
+/** Maximum absolute offset in mm for a single divider endpoint. Generous —
+ *  the worker will additionally clip the divider to the bin interior at
+ *  generation time, but this stops absurd inputs before they hit storage. */
+export const DIVIDER_OFFSET_MAX_MM = 200;
+
+export type DividerOverrideValidationError =
+  | 'unordered-pair'
+  | 'self-pair'
+  | 'unknown-compartment'
+  | 'non-adjacent-compartments'
+  | 'offset-not-finite'
+  | 'offset-out-of-bounds'
+  | 'duplicate-pair';
+
+/**
+ * Structural validation for a single `DividerOverride` against a compartment
+ * config. Returns `null` if valid, or an error code suitable for displaying
+ * a tooltip / rejecting a store mutation.
+ *
+ * Geometric viability (min compartment area, clearance to other dividers,
+ * convexity of resulting wedges) is validated separately at drag-commit
+ * time and at generation time — the helpers here are structural only so
+ * the validator stays cheap to call from anywhere.
+ */
+export function validateDividerOverride(
+  config: CompartmentConfig,
+  override: DividerOverride
+): DividerOverrideValidationError | null {
+  const { compartmentA, compartmentB, offsetStart, offsetEnd } = override;
+  if (compartmentA === compartmentB) return 'self-pair';
+  if (compartmentA >= compartmentB) return 'unordered-pair';
+  const ids = new Set(config.cells);
+  if (!ids.has(compartmentA) || !ids.has(compartmentB)) return 'unknown-compartment';
+  if (!Number.isFinite(offsetStart) || !Number.isFinite(offsetEnd)) return 'offset-not-finite';
+  if (
+    Math.abs(offsetStart) > DIVIDER_OFFSET_MAX_MM ||
+    Math.abs(offsetEnd) > DIVIDER_OFFSET_MAX_MM
+  ) {
+    return 'offset-out-of-bounds';
+  }
+  if (!compartmentsAreAdjacent(config, compartmentA, compartmentB)) {
+    return 'non-adjacent-compartments';
+  }
+  return null;
+}
+
+/**
+ * Validate a full list of overrides. Catches duplicates (same pair appearing
+ * twice) in addition to per-entry structural checks.
+ */
+export function validateDividerOverrides(
+  config: CompartmentConfig,
+  overrides: readonly DividerOverride[]
+): { ok: true } | { ok: false; index: number; error: DividerOverrideValidationError } {
+  const seen = new Set<string>();
+  for (let i = 0; i < overrides.length; i++) {
+    const o = overrides[i];
+    const err = validateDividerOverride(config, o);
+    if (err) return { ok: false, index: i, error: err };
+    const key = `${o.compartmentA}|${o.compartmentB}`;
+    if (seen.has(key)) return { ok: false, index: i, error: 'duplicate-pair' };
+    seen.add(key);
+  }
+  return { ok: true };
+}
+
+/**
+ * True when the compartment has at least one tilted boundary (i.e. is one
+ * end of a `DividerOverride`). Used by features that can't render against
+ * non-axis-aligned edges (scoops, label tabs on the tilted side).
+ */
+export function compartmentHasTiltedEdge(
+  config: CompartmentConfig,
+  compartmentId: number
+): boolean {
+  const overrides = config.dividerOverrides;
+  if (!overrides || overrides.length === 0) return false;
+  for (const o of overrides) {
+    if (o.compartmentA === compartmentId || o.compartmentB === compartmentId) return true;
+  }
+  return false;
+}
+
+/**
+ * True when the compartment's BACK wall is a tilted divider. Used by label
+ * tabs which attach to the back wall and can't currently render on a tilt.
+ *
+ * "Back" = the +Y direction in interior coords (the higher-row neighbor in
+ * the cell grid). A back wall is tilted when the compartment has a back
+ * neighbor (not touching the bin's actual back wall) AND a divider override
+ * pairs the two compartments.
+ */
+export function compartmentHasTiltedBackWall(
+  config: CompartmentConfig,
+  compartmentId: number
+): boolean {
+  const overrides = config.dividerOverrides;
+  if (!overrides || overrides.length === 0) return false;
+  const bounds = getCompartmentBounds(config, compartmentId);
+  if (!bounds) return false;
+  if (bounds.maxRow === config.rows - 1) return false;
+  const backRow = bounds.maxRow + 1;
+  const neighborId = config.cells[backRow * config.cols + bounds.minCol];
+  if (neighborId === compartmentId) return false;
+  const [a, b] =
+    compartmentId < neighborId ? [compartmentId, neighborId] : [neighborId, compartmentId];
+  for (const o of overrides) {
+    const [oa, ob] =
+      o.compartmentA < o.compartmentB
+        ? [o.compartmentA, o.compartmentB]
+        : [o.compartmentB, o.compartmentA];
+    if (oa === a && ob === b) return true;
+  }
+  return false;
+}
+
+/**
+ * True when two compartments share at least one cell-boundary edge. With the
+ * existing rectangle constraint, that boundary is automatically contiguous;
+ * no further "single segment" check is needed in practice.
+ */
+function compartmentsAreAdjacent(config: CompartmentConfig, a: number, b: number): boolean {
+  const { cols, rows, cells } = config;
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const id = cells[row * cols + col];
+      if (id !== a && id !== b) continue;
+      // Check right neighbor
+      if (col + 1 < cols) {
+        const r = cells[row * cols + (col + 1)];
+        if ((id === a && r === b) || (id === b && r === a)) return true;
+      }
+      // Check bottom neighbor
+      if (row + 1 < rows) {
+        const d = cells[(row + 1) * cols + col];
+        if ((id === a && d === b) || (id === b && d === a)) return true;
+      }
+    }
+  }
+  return false;
+}
+
 // Merge / Split Operations
 
 /**
@@ -189,6 +333,9 @@ export function mergeCells(
     cells: normalized,
     ...(config.compartmentTexts && {
       compartmentTexts: remapCompartmentTexts(config.compartmentTexts, remap),
+    }),
+    ...(config.dividerOverrides && {
+      dividerOverrides: remapDividerOverrides(config.dividerOverrides, remap),
     }),
   };
 }
@@ -222,6 +369,9 @@ export function splitCompartment(
     cells: normalized,
     ...(config.compartmentTexts && {
       compartmentTexts: remapCompartmentTexts(config.compartmentTexts, remap),
+    }),
+    ...(config.dividerOverrides && {
+      dividerOverrides: remapDividerOverrides(config.dividerOverrides, remap),
     }),
   };
 }
@@ -280,6 +430,36 @@ export function remapCompartmentTexts(
   for (const [oldId, newId] of remap) {
     const t = oldTexts[oldId];
     if (typeof t === 'string') out[newId] = t;
+  }
+  return out;
+}
+
+/**
+ * Reindex divider overrides through an `oldId → newId` remap.
+ *
+ * Drops any override whose endpoint compartment disappeared (cells stomped
+ * before normalize ran) OR whose two endpoints collapsed to the same ID
+ * (their boundary no longer exists). Surviving overrides keep canonical
+ * `compartmentA < compartmentB` ordering.
+ */
+export function remapDividerOverrides(
+  oldOverrides: readonly DividerOverride[] | undefined,
+  remap: ReadonlyMap<number, number>
+): DividerOverride[] {
+  if (!oldOverrides || oldOverrides.length === 0) return [];
+  const out: DividerOverride[] = [];
+  for (const o of oldOverrides) {
+    const newA = remap.get(o.compartmentA);
+    const newB = remap.get(o.compartmentB);
+    if (newA === undefined || newB === undefined) continue;
+    if (newA === newB) continue;
+    const [a, b] = newA < newB ? [newA, newB] : [newB, newA];
+    out.push({
+      compartmentA: a,
+      compartmentB: b,
+      offsetStart: o.offsetStart,
+      offsetEnd: o.offsetEnd,
+    });
   }
   return out;
 }

--- a/src/features/generation/worker/generators/compartmentBuilder.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.ts
@@ -5,9 +5,10 @@
  * Walls appear at boundaries between cells with different compartment IDs.
  */
 
-import { box, withScope, clone, unwrap, fuseAll, draw } from 'brepjs';
+import { box, withScope, clone, unwrap, fuseAll, draw, intersect } from 'brepjs';
 import type { Shape3D, ValidSolid, DisposalScope, Drawing } from 'brepjs';
-import type { BinParams } from '@/shared/types/bin';
+import type { BinParams, DividerOverride } from '@/shared/types/bin';
+import { sketch } from './meshUtils';
 
 // Re-export for backwards compatibility with existing imports
 export { fuseAllOrNull } from './utils/shapeOps';
@@ -133,6 +134,64 @@ function buildWallSegment(w: number, d: number, height: number, x: number, y: nu
 }
 
 /**
+ * Build a tilted divider wall as a parallelogram prism whose long axis runs
+ * from `(startX, startY)` to `(endX, endY)`. Thickness is applied
+ * perpendicular to that axis (not world-aligned) so the divider looks like
+ * a tilted ribbon, not a squished box.
+ *
+ * Clipped to the bin interior so any parallelogram corners that overshoot
+ * the bin wall (which happens whenever the tilt is non-zero) are sliced
+ * cleanly at the wall plane.
+ */
+function buildTiltedWallSegment(
+  scope: DisposalScope,
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number,
+  thickness: number,
+  height: number,
+  binInnerW: number,
+  binInnerD: number
+): Shape3D {
+  const dx = endX - startX;
+  const dy = endY - startY;
+  const len = Math.hypot(dx, dy);
+  // Perpendicular unit vector (rotated 90° CCW from the divider direction).
+  const px = -dy / len;
+  const py = dx / len;
+  const half = thickness / 2;
+
+  const pen = draw([startX + px * half, startY + py * half])
+    .lineTo([endX + px * half, endY + py * half])
+    .lineTo([endX - px * half, endY - py * half])
+    .lineTo([startX - px * half, startY - py * half])
+    .close();
+  const prism = scope.register(sketch(pen, 'XY', 0).extrude(height));
+  // Clip the parallelogram corners that overshoot the bin's perpendicular
+  // wall. For zero-tilt segments the clip is a no-op; for tilted segments
+  // it shears off the "ears" that would otherwise poke through the wall.
+  const clipBox = scope.register(box(binInnerW, binInnerD, height, { at: [0, 0, height / 2] }));
+  return scope.register(unwrap(intersect(prism as ValidSolid, clipBox)));
+}
+
+/** Canonical-pair key for an override lookup map. */
+function overrideKey(a: number, b: number): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+function buildOverrideLookup(
+  overrides: readonly DividerOverride[] | undefined
+): Map<string, DividerOverride> {
+  const lookup = new Map<string, DividerOverride>();
+  if (!overrides) return lookup;
+  for (const o of overrides) {
+    lookup.set(overrideKey(o.compartmentA, o.compartmentB), o);
+  }
+  return lookup;
+}
+
+/**
  * Find consecutive wall segments along a boundary line.
  * Returns array of [start, end) index pairs where walls are needed.
  */
@@ -231,6 +290,7 @@ function buildCompartmentWallsInScope(
   if (effectiveCellW < thickness * 2 || effectiveCellD < thickness * 2) return null;
 
   const wallSegments: Shape3D[] = [];
+  const overrideLookup = buildOverrideLookup(params.compartments.dividerOverrides);
 
   // Vertical walls: between column boundaries
   for (let colBoundary = 1; colBoundary < cols; colBoundary++) {
@@ -242,11 +302,34 @@ function buildCompartmentWallsInScope(
     });
 
     for (const [start, end] of segments) {
-      const segLength = (end - start) * cellD;
-      const yCenter = -innerD / 2 + (start + (end - start) / 2) * cellD;
-      wallSegments.push(
-        scope.register(buildWallSegment(thickness, segLength, wallHeight, xPos, yCenter))
-      );
+      const leftId = cells[start * cols + (colBoundary - 1)];
+      const rightId = cells[start * cols + colBoundary];
+      const override = overrideLookup.get(overrideKey(leftId, rightId));
+      if (override) {
+        // Tilted: endpoints shifted in ±X. start = front edge (y = startY),
+        // end = back edge (y = endY).
+        const startY = -innerD / 2 + start * cellD;
+        const endY = -innerD / 2 + end * cellD;
+        wallSegments.push(
+          buildTiltedWallSegment(
+            scope,
+            xPos + override.offsetStart,
+            startY,
+            xPos + override.offsetEnd,
+            endY,
+            thickness,
+            wallHeight,
+            innerW,
+            innerD
+          )
+        );
+      } else {
+        const segLength = (end - start) * cellD;
+        const yCenter = -innerD / 2 + (start + (end - start) / 2) * cellD;
+        wallSegments.push(
+          scope.register(buildWallSegment(thickness, segLength, wallHeight, xPos, yCenter))
+        );
+      }
     }
   }
 
@@ -260,11 +343,34 @@ function buildCompartmentWallsInScope(
     });
 
     for (const [start, end] of segments) {
-      const segLength = (end - start) * cellW;
-      const xCenter = -innerW / 2 + (start + (end - start) / 2) * cellW;
-      wallSegments.push(
-        scope.register(buildWallSegment(segLength, thickness, wallHeight, xCenter, yPos))
-      );
+      const topId = cells[(rowBoundary - 1) * cols + start];
+      const bottomId = cells[rowBoundary * cols + start];
+      const override = overrideLookup.get(overrideKey(topId, bottomId));
+      if (override) {
+        // Tilted: endpoints shifted in ±Y. start = left edge (x = startX),
+        // end = right edge (x = endX).
+        const startX = -innerW / 2 + start * cellW;
+        const endX = -innerW / 2 + end * cellW;
+        wallSegments.push(
+          buildTiltedWallSegment(
+            scope,
+            startX,
+            yPos + override.offsetStart,
+            endX,
+            yPos + override.offsetEnd,
+            thickness,
+            wallHeight,
+            innerW,
+            innerD
+          )
+        );
+      } else {
+        const segLength = (end - start) * cellW;
+        const xCenter = -innerW / 2 + (start + (end - start) / 2) * cellW;
+        wallSegments.push(
+          scope.register(buildWallSegment(segLength, thickness, wallHeight, xCenter, yPos))
+        );
+      }
     }
   }
 
@@ -277,7 +383,7 @@ function buildCompartmentWallsInScope(
 
 import type { FeatureBuilder } from './pipeline/featureBuilder';
 import { FeatureTag } from './featureTags';
-import { buildCacheKey, quantize, compactKey } from './cacheKeyUtils';
+import { buildCacheKey, quantize, compactKey, stableSerialize } from './cacheKeyUtils';
 
 export const compartmentWallsFeature: FeatureBuilder = {
   name: 'compartmentWalls',
@@ -289,7 +395,7 @@ export const compartmentWallsFeature: FeatureBuilder = {
     const { dimensions: dim, params } = ctx;
     return compactKey(
       buildCacheKey(
-        'v1',
+        'v2',
         dim.shellKey,
         quantize(dim.innerW),
         quantize(dim.innerD),
@@ -297,7 +403,10 @@ export const compartmentWallsFeature: FeatureBuilder = {
         params.compartments.cols,
         params.compartments.rows,
         quantize(params.compartments.thickness),
-        params.compartments.cells.join(',')
+        params.compartments.cells.join(','),
+        // Tilted-divider overrides change the wall geometry. `v1` → `v2`
+        // bumps the namespace so any cached pre-feature mesh is rebuilt.
+        stableSerialize(params.compartments.dividerOverrides ?? [])
       )
     );
   },

--- a/src/features/generation/worker/generators/featureBuilder.test.ts
+++ b/src/features/generation/worker/generators/featureBuilder.test.ts
@@ -110,6 +110,46 @@ describe('buildCompartmentWalls', () => {
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
   }, 30000);
+
+  it('builds walls when a divider has a tilt override (1×2)', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      compartments: {
+        cols: 1,
+        rows: 2,
+        cells: [0, 1],
+        thickness: 1.2,
+        dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 10, offsetEnd: -10 }],
+      },
+    };
+    const result = buildCompartmentWalls(params, 80, 80, 16);
+    expect(result).not.toBeNull();
+    const meshed = meshShape(result);
+    expect(meshed.vertices.length).toBeGreaterThan(0);
+  }, 30000);
+
+  it('tilted divider produces a different mesh than the equivalent straight one', () => {
+    const base: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      compartments: { cols: 1, rows: 2, cells: [0, 1], thickness: 1.2 },
+    };
+    const tilted: BinParams = {
+      ...base,
+      compartments: {
+        ...base.compartments,
+        dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 12, offsetEnd: -12 }],
+      },
+    };
+    const straight = buildCompartmentWalls(base, 80, 80, 16);
+    const skew = buildCompartmentWalls(tilted, 80, 80, 16);
+    expect(straight).not.toBeNull();
+    expect(skew).not.toBeNull();
+    // Tilted divider has different vertex topology than the axis-aligned
+    // box — at minimum, vertex counts differ.
+    const straightMesh = meshShape(straight);
+    const skewMesh = meshShape(skew);
+    expect(skewMesh.vertices.length).not.toBe(straightMesh.vertices.length);
+  }, 30000);
 });
 
 describe('buildInsertCuts', () => {

--- a/src/features/generation/worker/generators/labelTabBuilder.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.ts
@@ -8,6 +8,7 @@
 import { draw, unwrap, fuseAll, fuse, cut, translate, withScope, clone } from 'brepjs';
 import type { Shape3D, ValidSolid, Drawing, DisposalScope } from 'brepjs';
 import type { BinParams, TextStyleDefaults, TextStyleOverride } from '@/shared/types/bin';
+import { compartmentHasTiltedBackWall } from '@/shared/types/bin';
 import { sketch } from './meshUtils';
 import { buildFilletProfile } from './filletProfile';
 import { buildTextSolid } from './textBuilder';
@@ -101,6 +102,14 @@ function buildLabelTabsInScope(
       // Check if this cell has a back edge (last row, or different compId behind)
       const hasBackEdge = isLastRow || cellId !== nextRowCellId;
       if (!hasBackEdge) {
+        col++;
+        continue;
+      }
+
+      // Skip tabs whose back wall is a tilted divider — the shelf and gusset
+      // geometry assumes an axis-aligned back wall. The compartment text
+      // input still persists in storage; only the rendering is suppressed.
+      if (compartmentHasTiltedBackWall(params.compartments, cellId)) {
         col++;
         continue;
       }
@@ -327,7 +336,9 @@ export const labelTabsFeature: FeatureBuilder = {
     const { dimensions: dim, params } = ctx;
     return compactKey(
       buildCacheKey(
-        'v2',
+        // `v3`: tab generation now skips compartments whose back wall is a
+        // tilted divider, so dividerOverrides affects output.
+        'v3',
         dim.shellKey,
         stableSerialize(params.label),
         quantize(dim.innerW),
@@ -340,6 +351,7 @@ export const labelTabsFeature: FeatureBuilder = {
         // `stableSerialize` (not `.join(sep)`) avoids the collision where
         // e.g. `['ab','c']` and `['a','bc']` produce the same key.
         stableSerialize(params.compartments.compartmentTexts ?? []),
+        stableSerialize(params.compartments.dividerOverrides ?? []),
         stableSerialize(params.textDefaults)
       )
     );

--- a/src/features/generation/worker/generators/scoopRampBuilder.ts
+++ b/src/features/generation/worker/generators/scoopRampBuilder.ts
@@ -17,6 +17,7 @@ import {
 import { LIP_SMALL_TAPER, LIP_TAPER_WIDTH } from './generatorConstants';
 import { findCompartmentBounds } from './compartmentBuilder';
 import { applyFilletWithFallback } from './cutoutBuilder';
+import { compartmentHasTiltedEdge } from '@/shared/types/bin';
 /**
  * Build finger scoop ramps that curve from the bin floor up to the front wall.
  *
@@ -81,6 +82,12 @@ function buildScoopRampsInScope(
       const compId = cells[row * cols + col];
       if (processedCompartments.has(compId)) continue;
       processedCompartments.add(compId);
+
+      // Scoop ramps assume axis-aligned compartment floors. When a divider
+      // override tilts one of this compartment's walls, the floor becomes a
+      // wedge/trapezoid and the ramp math no longer applies. Silently skip;
+      // the UI surfaces a tooltip explaining why.
+      if (compartmentHasTiltedEdge(params.compartments, compId)) continue;
 
       const bounds = findCompartmentBounds(compId, cols, rows, cells);
       if (!bounds) continue;
@@ -221,7 +228,9 @@ export const scoopRampsFeature: FeatureBuilder = {
     const { dimensions: dim, params } = ctx;
     return compactKey(
       buildCacheKey(
-        'v1',
+        // `v2`: scoop now skips compartments with any tilted edge, so the
+        // dividerOverrides shape affects output. Cache namespace bumped.
+        'v2',
         dim.shellKey,
         stableSerialize(params.scoop),
         params.style,
@@ -232,7 +241,8 @@ export const scoopRampsFeature: FeatureBuilder = {
         dim.hasLip,
         params.compartments.cols,
         params.compartments.rows,
-        params.compartments.cells.join(',')
+        params.compartments.cells.join(','),
+        stableSerialize(params.compartments.dividerOverrides ?? [])
       )
     );
   },

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -43,6 +43,7 @@ export type {
   CutoutTextSide,
   TextStyleDefaults,
   TextStyleOverride,
+  DividerOverride,
 } from '@/features/bin-designer/types';
 
 export {
@@ -66,6 +67,16 @@ export {
   hasLidBlocker,
   computeDisabledRails,
 } from '@/features/bin-designer/utils/lidCompatibility';
+
+/**
+ * Re-export compartment-edge predicates so worker-side feature builders
+ * (scoop ramps, label tabs) can ask "does this compartment have a tilted
+ * boundary?" without crossing the feature boundary.
+ */
+export {
+  compartmentHasTiltedEdge,
+  compartmentHasTiltedBackWall,
+} from '@/features/bin-designer/utils/compartments';
 export type {
   LidCompatibilityIssue,
   LidCompatibilityId,


### PR DESCRIPTION
## Summary

Foundation PR for the angled-divider feature requested in #1822 (tapered dividers for silverware-drawer–style bins). Ships data model + geometry pipeline + scoop/label-tab compat. Editor UI and the rest of the compat matrix land in follow-up PRs in this track, all behind the same \`angled_dividers\` labs flag.

## What ships

**Schema.** \`DividerOverride { compartmentA, compartmentB, offsetStart, offsetEnd }\` on \`CompartmentConfig.dividerOverrides?\`. Each entry shifts one interior divider's endpoints by signed mm. Canonical \`compartmentA < compartmentB\` ordering; lazy (omitted when no divider is tilted, so existing designs round-trip unchanged).

**Worker geometry.** \`compartmentBuilder\` walks the cell-derived wall segments unchanged, but when a segment's two adjacent compartments have a matching override it builds a tilted parallelogram prism instead of an axis-aligned box. Thickness is applied perpendicular to the divider direction (not world-aligned) so the divider looks like a tilted ribbon, and the prism is intersected with the bin interior to slice the corner overrun cleanly at the wall plane.

**Remap.** Mirroring the \`remapCompartmentTexts\` pattern, \`remapDividerOverrides()\` reindexes through \`normalizeIds\` after merge/split. Overrides drop on \`setCompartmentGrid\` (full reset).

**Feature degrade.** Scoop ramps and label tabs skip compartments adjacent to a tilted divider (scoop assumes axis-aligned floor; tab shelf assumes axis-aligned back wall). New helpers \`compartmentHasTiltedEdge\` / \`compartmentHasTiltedBackWall\` re-exported from \`@/shared/types/bin\` so the worker generators consume them without crossing the feature boundary. Cache keys bumped: \`compartmentWallsFeature\` v1→v2, \`scoopRampsFeature\` v1→v2, \`labelTabsFeature\` v2→v3.

**Validator.** Structural checks (ordered pair, known compartments, adjacency, finite offsets, ±200 mm, no duplicates) with typed error codes for tooltip surfacing. Geometric viability (min compartment area, clearance) lands with the editor UI PR.

**Server-side validation.** Deep \`dividerOverrides\` check in \`api/lib/designerValidation.ts\` mirroring the client-side rules — crafted-share payloads can't smuggle in unordered pairs, out-of-range offsets, or duplicates.

**Labs flag.** \`angled_dividers\`, experimental, \`comingSoon: true\`. The data path is live for direct schema testing; UI ships next.

## Deferred to follow-up PRs in this track

- **Editor UI** (PR 2): drag handles on divider endpoints in the compartment editor canvas; \"Tilt divider\" subsection in the compartments panel with two numeric mm inputs matching the issue's diagram; grid snap default + Alt/Shift free-mm.
- **Remaining compat** (PR 3): floor-insert clipping/suppression in wedge compartments, slot toggle gating when any divider is tilted, wall-cutout suppression on tilted interior dividers, integration tests across the matrix, flag graduation.

## Test plan
- [x] \`pnpm run typecheck\` clean
- [x] \`pnpm run lint\` 0 errors
- [x] 110 unit tests in \`compartments.test.ts\` pass (19 new: validator, remap, predicates, merge-with-overrides)
- [x] 28 generator tests in \`featureBuilder.test.ts\` pass (2 new: tilted-divider builds non-null + differs from straight)
- [x] 73 server-validation tests pass (5 new: dividerOverrides accept/reject paths)
- [x] 2235 bin-designer tests pass (no regressions)

## Schema example

\`\`\`ts
compartments: {
  cols: 1,
  rows: 2,
  thickness: 1.2,
  cells: [0, 1],
  dividerOverrides: [
    { compartmentA: 0, compartmentB: 1, offsetStart: 12, offsetEnd: -8 },
  ],
}
\`\`\`

Builds a 1×2 bin with the horizontal divider tilted +12 mm at its left end and −8 mm at its right end, producing two wedge-shaped compartments. The scoop toggle on both compartments will be skipped at generation; the label tab on compartment 0 (front) will be skipped because its back wall is tilted; the label tab on compartment 1 (back) will build normally since its back wall is still the bin's actual back wall.