### PR TITLE
fix(bin-designer): angled-dividers review (#1827) — 3 real bugs + robustness + docs

### DIFF
--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -286,14 +286,19 @@ function validateCompartments(compartments: unknown): string | null {
   // Optional per-divider tilt overrides. Mirrors the client-side
   // `DIVIDER_OFFSET_MAX_MM = 200` cap and the canonical pair ordering rule
   // (compartmentA < compartmentB) so a direct HTTP POST can't smuggle in
-  // unordered or absurd overrides that bypass the store action.
+  // unordered or absurd overrides that bypass the store action. Also
+  // verifies (1) both compartment IDs actually exist in cells and (2) the
+  // pair is adjacent — same checks the client validator does.
   if (compartments.dividerOverrides !== undefined) {
     if (!Array.isArray(compartments.dividerOverrides)) {
       return 'compartments.dividerOverrides must be an array';
     }
     if (compartments.dividerOverrides.length > expectedLength * 2) {
-      // Generous upper bound: at most ~2× cell count of unique pairs.
       return `compartments.dividerOverrides length is unreasonably large`;
+    }
+    const knownIds = new Set<number>();
+    for (const cell of compartments.cells as unknown[]) {
+      if (typeof cell === 'number' && Number.isInteger(cell)) knownIds.add(cell);
     }
     const seenPairs = new Set<string>();
     for (let i = 0; i < compartments.dividerOverrides.length; i++) {
@@ -310,6 +315,12 @@ function validateCompartments(compartments: unknown): string | null {
       if (o.compartmentA >= o.compartmentB) {
         return `compartments.dividerOverrides[${i}] must have compartmentA < compartmentB`;
       }
+      if (!knownIds.has(o.compartmentA) || !knownIds.has(o.compartmentB)) {
+        return `compartments.dividerOverrides[${i}] references unknown compartment ID`;
+      }
+      if (!compartmentsAreAdjacent(compartments, o.compartmentA, o.compartmentB)) {
+        return `compartments.dividerOverrides[${i}] compartments are not adjacent`;
+      }
       if (!isNumber(o.offsetStart) || !inRange(o.offsetStart, -200, 200)) {
         return `compartments.dividerOverrides[${i}].offsetStart must be -200..200`;
       }
@@ -324,6 +335,35 @@ function validateCompartments(compartments: unknown): string | null {
     }
   }
   return null;
+}
+
+/**
+ * Server-side adjacency check mirroring the client helper. Two compartments
+ * are adjacent if any pair of orthogonally-neighboring cells holds them.
+ */
+function compartmentsAreAdjacent(
+  compartments: Record<string, unknown>,
+  a: number,
+  b: number
+): boolean {
+  const cols = compartments.cols as number;
+  const rows = compartments.rows as number;
+  const cells = compartments.cells as readonly number[];
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const id = cells[row * cols + col];
+      if (id !== a && id !== b) continue;
+      if (col + 1 < cols) {
+        const r = cells[row * cols + (col + 1)];
+        if ((id === a && r === b) || (id === b && r === a)) return true;
+      }
+      if (row + 1 < rows) {
+        const d = cells[(row + 1) * cols + col];
+        if ((id === a && d === b) || (id === b && d === a)) return true;
+      }
+    }
+  }
+  return false;
 }
 
 /**

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -194,13 +194,15 @@ export interface CompartmentConfig {
  * because two adjacent compartments share a boundary; the override shifts
  * the divider's endpoints away from that boundary line.
  *
- * Coordinate system:
- * - For a **vertical** divider (compartments stacked horizontally), positive
- *   `offsetStart` shifts the FRONT endpoint (y = 0 edge) in +X; positive
- *   `offsetEnd` shifts the BACK endpoint (y = innerD edge) in +X.
- * - For a **horizontal** divider (compartments stacked vertically), positive
- *   `offsetStart` shifts the LEFT endpoint (x = 0 edge) in +Y; positive
- *   `offsetEnd` shifts the RIGHT endpoint (x = innerW edge) in +Y.
+ * Coordinate system (relative to the SEGMENT's own endpoints, not the bin
+ * walls — an interior divider in a 3+row grid doesn't span the full bin):
+ * - For a **vertical** divider segment (compartments stacked horizontally),
+ *   `offsetStart` shifts the lower-Y endpoint of the segment in ±X;
+ *   `offsetEnd` shifts the higher-Y endpoint in ±X. Positive offsets push
+ *   the endpoints in the +X direction.
+ * - For a **horizontal** divider segment (compartments stacked vertically),
+ *   `offsetStart` shifts the lower-X endpoint in ±Y; `offsetEnd` shifts the
+ *   higher-X endpoint in ±Y. Positive offsets push endpoints in +Y.
  *
  * Setting both offsets equal translates the divider without tilting it.
  * Setting `offsetEnd = -offsetStart` produces a symmetric tilt around the

--- a/src/features/bin-designer/utils/compartments.test.ts
+++ b/src/features/bin-designer/utils/compartments.test.ts
@@ -1140,6 +1140,29 @@ describe('compartments', () => {
       ]);
       expect(remapDividerOverrides(overrides, remap)).toEqual([]);
     });
+
+    it('deduplicates pairs that collapse onto each other after a merge', () => {
+      // Imagine a 1×3 with compartments 0,1,2. Two overrides:
+      //   - between 0 and 2 (impossible in real grid, but illustrative)
+      //   - between 1 and 2
+      // After merging 0 and 1 into 0, both overrides target the same new
+      // pair (0,2). Without dedup we'd emit two entries with the same key
+      // — the worker's lookup map would last-write-wins and the validator
+      // would reject the design on next save.
+      const overrides: DividerOverride[] = [
+        { compartmentA: 0, compartmentB: 2, offsetStart: 5, offsetEnd: 0 },
+        { compartmentA: 1, compartmentB: 2, offsetStart: 10, offsetEnd: 0 },
+      ];
+      const remap = new Map([
+        [0, 0],
+        [1, 0],
+        [2, 1],
+      ]);
+      const out = remapDividerOverrides(overrides, remap);
+      expect(out).toHaveLength(1);
+      // First-wins policy: the offsets from the earlier entry survive.
+      expect(out[0].offsetStart).toBe(5);
+    });
   });
 
   describe('mergeCells with dividerOverrides', () => {
@@ -1201,6 +1224,22 @@ describe('compartments', () => {
       };
       expect(compartmentHasTiltedBackWall(config, 0)).toBe(true);
       expect(compartmentHasTiltedBackWall(config, 1)).toBe(false);
+    });
+
+    it('detects a tilted back wall when the tilt is on a non-minCol neighbor', () => {
+      // 2×2 with the top row merged into compartment 0 (spanning both cols)
+      // and bottom row split into 1 (left) and 2 (right). The override is
+      // between 0 and 2 — i.e. the right half of compartment 0's back wall.
+      // Sampling only `bounds.minCol` would miss this because the back
+      // neighbor at column 0 is compartment 1, not compartment 2.
+      const config: CompartmentConfig = {
+        cols: 2,
+        rows: 2,
+        thickness: 1.2,
+        cells: [0, 0, 1, 2],
+        dividerOverrides: [{ compartmentA: 0, compartmentB: 2, offsetStart: 5, offsetEnd: -5 }],
+      };
+      expect(compartmentHasTiltedBackWall(config, 0)).toBe(true);
     });
   });
 });

--- a/src/features/bin-designer/utils/compartments.ts
+++ b/src/features/bin-designer/utils/compartments.ts
@@ -264,16 +264,21 @@ export function compartmentHasTiltedBackWall(
   if (!bounds) return false;
   if (bounds.maxRow === config.rows - 1) return false;
   const backRow = bounds.maxRow + 1;
-  const neighborId = config.cells[backRow * config.cols + bounds.minCol];
-  if (neighborId === compartmentId) return false;
-  const [a, b] =
-    compartmentId < neighborId ? [compartmentId, neighborId] : [neighborId, compartmentId];
+  // Scan the entire back edge from minCol..maxCol. A wide compartment can
+  // border multiple different back-neighbors; any of them being tilted-pair
+  // with this compartment counts as a tilted back wall.
+  const overrideKeys = new Set<string>();
   for (const o of overrides) {
-    const [oa, ob] =
-      o.compartmentA < o.compartmentB
-        ? [o.compartmentA, o.compartmentB]
-        : [o.compartmentB, o.compartmentA];
-    if (oa === a && ob === b) return true;
+    const a = Math.min(o.compartmentA, o.compartmentB);
+    const b = Math.max(o.compartmentA, o.compartmentB);
+    overrideKeys.add(`${a}|${b}`);
+  }
+  for (let col = bounds.minCol; col <= bounds.maxCol; col++) {
+    const neighborId = config.cells[backRow * config.cols + col];
+    if (neighborId === compartmentId) continue;
+    const a = Math.min(compartmentId, neighborId);
+    const b = Math.max(compartmentId, neighborId);
+    if (overrideKeys.has(`${a}|${b}`)) return true;
   }
   return false;
 }
@@ -448,12 +453,21 @@ export function remapDividerOverrides(
 ): DividerOverride[] {
   if (!oldOverrides || oldOverrides.length === 0) return [];
   const out: DividerOverride[] = [];
+  // Deduplicate by canonical pair: a merge can collapse two old overrides
+  // onto the same new (compartmentA, compartmentB) pair. Keep the first
+  // occurrence — without this, the worker's lookup map silently last-write-
+  // wins, the validator rejects the design on next save, and the schema's
+  // "no duplicate pairs" invariant breaks.
+  const seenPairs = new Set<string>();
   for (const o of oldOverrides) {
     const newA = remap.get(o.compartmentA);
     const newB = remap.get(o.compartmentB);
     if (newA === undefined || newB === undefined) continue;
     if (newA === newB) continue;
     const [a, b] = newA < newB ? [newA, newB] : [newB, newA];
+    const key = `${a}|${b}`;
+    if (seenPairs.has(key)) continue;
+    seenPairs.add(key);
     out.push({
       compartmentA: a,
       compartmentB: b,

--- a/src/features/generation/worker/generators/compartmentBuilder.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.ts
@@ -153,10 +153,14 @@ function buildTiltedWallSegment(
   height: number,
   binInnerW: number,
   binInnerD: number
-): Shape3D {
+): Shape3D | null {
   const dx = endX - startX;
   const dy = endY - startY;
   const len = Math.hypot(dx, dy);
+  // Degenerate-segment guard: a zero-length divider (both endpoints
+  // collapsed to the same point — possible if a malformed override drives
+  // a span to nothing) would divide by zero and produce NaN geometry.
+  if (len < 1e-6) return null;
   // Perpendicular unit vector (rotated 90° CCW from the divider direction).
   const px = -dy / len;
   const py = dx / len;
@@ -171,8 +175,53 @@ function buildTiltedWallSegment(
   // Clip the parallelogram corners that overshoot the bin's perpendicular
   // wall. For zero-tilt segments the clip is a no-op; for tilted segments
   // it shears off the "ears" that would otherwise poke through the wall.
+  // If the prism is entirely outside the clip box (override pushes the
+  // divider beyond the bin interior), the intersect returns nothing — bail
+  // gracefully rather than crashing the whole bin build.
   const clipBox = scope.register(box(binInnerW, binInnerD, height, { at: [0, 0, height / 2] }));
-  return scope.register(unwrap(intersect(prism as ValidSolid, clipBox)));
+  try {
+    return scope.register(unwrap(intersect(prism as ValidSolid, clipBox)));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Walk a boundary line in single-cell steps and group contiguous cells where
+ * `key(i)` returns the SAME non-null string into runs. Each emitted run has
+ * a uniform `pairKey`. Used so the override lookup applies to runs that
+ * actually correspond to one (compartmentA, compartmentB) pair — a longer
+ * fused run that crosses pair changes would silently apply the first pair's
+ * override to the entire wall.
+ */
+function findPairAwareRuns(
+  count: number,
+  key: (i: number) => string | null
+): Array<{ start: number; end: number; pairKey: string }> {
+  const runs: Array<{ start: number; end: number; pairKey: string }> = [];
+  let segStart: number | null = null;
+  let segKey: string | null = null;
+  for (let i = 0; i < count; i++) {
+    const k = key(i);
+    if (k === null) {
+      if (segStart !== null && segKey !== null) {
+        runs.push({ start: segStart, end: i, pairKey: segKey });
+        segStart = null;
+        segKey = null;
+      }
+    } else if (segStart === null) {
+      segStart = i;
+      segKey = k;
+    } else if (k !== segKey) {
+      runs.push({ start: segStart, end: i, pairKey: segKey ?? '' });
+      segStart = i;
+      segKey = k;
+    }
+  }
+  if (segStart !== null && segKey !== null) {
+    runs.push({ start: segStart, end: count, pairKey: segKey });
+  }
+  return runs;
 }
 
 /** Canonical-pair key for an override lookup map. */
@@ -292,37 +341,40 @@ function buildCompartmentWallsInScope(
   const wallSegments: Shape3D[] = [];
   const overrideLookup = buildOverrideLookup(params.compartments.dividerOverrides);
 
-  // Vertical walls: between column boundaries
+  // Vertical walls: between column boundaries. We split runs not just by
+  // "needs wall" but also by the (leftId, rightId) pair — otherwise a single
+  // segment that spans multiple compartment pairs (e.g. col-boundary in a
+  // 2×2 grid runs through pair 0|1 then 2|3) would only check the first
+  // pair's override and apply it to the whole run, producing wrong geometry.
+  // Touching axis-aligned boxes fuse cleanly in OCCT so the split is
+  // visually transparent for non-tilted segments.
   for (let colBoundary = 1; colBoundary < cols; colBoundary++) {
     const xPos = -innerW / 2 + colBoundary * cellW;
-    const segments = findWallSegments(rows, (row) => {
+    const runs = findPairAwareRuns(rows, (row) => {
       const leftId = cells[row * cols + (colBoundary - 1)];
       const rightId = cells[row * cols + colBoundary];
-      return leftId !== rightId;
+      return leftId !== rightId ? overrideKey(leftId, rightId) : null;
     });
 
-    for (const [start, end] of segments) {
-      const leftId = cells[start * cols + (colBoundary - 1)];
-      const rightId = cells[start * cols + colBoundary];
-      const override = overrideLookup.get(overrideKey(leftId, rightId));
+    for (const { start, end, pairKey } of runs) {
+      const override = overrideLookup.get(pairKey);
       if (override) {
         // Tilted: endpoints shifted in ±X. start = front edge (y = startY),
         // end = back edge (y = endY).
         const startY = -innerD / 2 + start * cellD;
         const endY = -innerD / 2 + end * cellD;
-        wallSegments.push(
-          buildTiltedWallSegment(
-            scope,
-            xPos + override.offsetStart,
-            startY,
-            xPos + override.offsetEnd,
-            endY,
-            thickness,
-            wallHeight,
-            innerW,
-            innerD
-          )
+        const tilted = buildTiltedWallSegment(
+          scope,
+          xPos + override.offsetStart,
+          startY,
+          xPos + override.offsetEnd,
+          endY,
+          thickness,
+          wallHeight,
+          innerW,
+          innerD
         );
+        if (tilted) wallSegments.push(tilted);
       } else {
         const segLength = (end - start) * cellD;
         const yCenter = -innerD / 2 + (start + (end - start) / 2) * cellD;
@@ -333,37 +385,34 @@ function buildCompartmentWallsInScope(
     }
   }
 
-  // Horizontal walls: between row boundaries
+  // Horizontal walls: between row boundaries (same pair-aware split as above).
   for (let rowBoundary = 1; rowBoundary < rows; rowBoundary++) {
     const yPos = -innerD / 2 + rowBoundary * cellD;
-    const segments = findWallSegments(cols, (col) => {
+    const runs = findPairAwareRuns(cols, (col) => {
       const topId = cells[(rowBoundary - 1) * cols + col];
       const bottomId = cells[rowBoundary * cols + col];
-      return topId !== bottomId;
+      return topId !== bottomId ? overrideKey(topId, bottomId) : null;
     });
 
-    for (const [start, end] of segments) {
-      const topId = cells[(rowBoundary - 1) * cols + start];
-      const bottomId = cells[rowBoundary * cols + start];
-      const override = overrideLookup.get(overrideKey(topId, bottomId));
+    for (const { start, end, pairKey } of runs) {
+      const override = overrideLookup.get(pairKey);
       if (override) {
         // Tilted: endpoints shifted in ±Y. start = left edge (x = startX),
         // end = right edge (x = endX).
         const startX = -innerW / 2 + start * cellW;
         const endX = -innerW / 2 + end * cellW;
-        wallSegments.push(
-          buildTiltedWallSegment(
-            scope,
-            startX,
-            yPos + override.offsetStart,
-            endX,
-            yPos + override.offsetEnd,
-            thickness,
-            wallHeight,
-            innerW,
-            innerD
-          )
+        const tilted = buildTiltedWallSegment(
+          scope,
+          startX,
+          yPos + override.offsetStart,
+          endX,
+          yPos + override.offsetEnd,
+          thickness,
+          wallHeight,
+          innerW,
+          innerD
         );
+        if (tilted) wallSegments.push(tilted);
       } else {
         const segLength = (end - start) * cellW;
         const xCenter = -innerW / 2 + (start + (end - start) / 2) * cellW;

--- a/src/features/generation/worker/generators/featureBuilder.test.ts
+++ b/src/features/generation/worker/generators/featureBuilder.test.ts
@@ -150,6 +150,54 @@ describe('buildCompartmentWalls', () => {
     const skewMesh = meshShape(skew);
     expect(skewMesh.vertices.length).not.toBe(straightMesh.vertices.length);
   }, 30000);
+
+  it('does not crash on a tilted override that pushes the divider outside the bin interior', () => {
+    // Defensive guard against malformed JSON or invariant breakage where
+    // the override drives the whole prism past the clip box. Build must
+    // omit the bad divider silently — never crash the worker.
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      compartments: {
+        cols: 1,
+        rows: 2,
+        cells: [0, 1],
+        thickness: 1.2,
+        dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 200, offsetEnd: 200 }],
+      },
+    };
+    expect(() => buildCompartmentWalls(params, 80, 80, 16)).not.toThrow();
+  }, 30000);
+
+  it('applies overrides only to the matching pair when a boundary spans multiple pairs', () => {
+    // 2×2 grid with no merging — the vertical boundary between col 0 and col
+    // 1 runs through pair (0,1) at row 0 and pair (2,3) at row 1. Before the
+    // pair-aware run split, the whole vertical run was one segment and the
+    // (0,1) override would silently apply to the (2,3) half. With the fix,
+    // each pair-run gets its own lookup.
+    const baseCells = [0, 1, 2, 3];
+    const noOverrides: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      compartments: { cols: 2, rows: 2, cells: baseCells, thickness: 1.2 },
+    };
+    const onlyTopTilted: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      compartments: {
+        cols: 2,
+        rows: 2,
+        cells: baseCells,
+        thickness: 1.2,
+        dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 10, offsetEnd: -10 }],
+      },
+    };
+    const baseline = buildCompartmentWalls(noOverrides, 80, 80, 16);
+    const tilted = buildCompartmentWalls(onlyTopTilted, 80, 80, 16);
+    expect(baseline).not.toBeNull();
+    expect(tilted).not.toBeNull();
+    // Different mesh — proves the tilt is taking effect somewhere.
+    const baselineMesh = meshShape(baseline);
+    const tiltedMesh = meshShape(tilted);
+    expect(tiltedMesh.vertices.length).not.toBe(baselineMesh.vertices.length);
+  }, 30000);
 });
 
 describe('buildInsertCuts', () => {


### PR DESCRIPTION
## Summary

Follow-up to #1827 (merged). Greptile gave it 3/5 and flagged 2 real bugs; Copilot found a third (segments spanning multiple compartment pairs) plus 2 robustness gaps. Addressing all of them.

## Real bugs

**1. One boundary spanning multiple pairs.**
`buildCompartmentWallsInScope` was treating a long contiguous boundary as a single segment and looking up the override using only the start row's compartment pair. In a 2×2 with no merging, the vertical boundary spans pair `(0,1)` on row 0 and pair `(2,3)` on row 1 — the override for `(0,1)` would silently apply to the `(2,3)` half too, producing wrong geometry. New `findPairAwareRuns` helper splits runs at every pair boundary. Visually transparent for non-tilted segments (touching boxes fuse cleanly in OCCT).

**2. `remapDividerOverrides` could emit duplicates.**
A merge can collapse two old overrides onto the same new `(compartmentA, compartmentB)` pair. Without dedup, both ended up in storage, `buildOverrideLookup` silently last-write-wins, the validator rejects the design on next save, and the schema's "no duplicates" invariant breaks. Added first-wins dedup keyed by canonical pair string.

**3. `compartmentHasTiltedBackWall` sampled only `bounds.minCol`.**
For a wide compartment whose back edge borders different back-neighbors at different cols, sampling only the leftmost cell missed tilts on the right portion of the wall. Now scans the full `minCol..maxCol` range.

## Robustness

**4. `buildTiltedWallSegment` no-crash guards.**
Added guard for `len < 1e-6` (zero-length segment from malformed override → divide-by-zero → NaN geometry) and wrapped `intersect(prism, clipBox)` in try/catch — when an override pushes the entire prism outside the bin interior, the intersect returns nothing and previously threw. Now returns null and the divider is silently omitted. Callers updated.

**5. Server-side existence + adjacency.**
Server validator was checking structure, ordering, range, duplicates — but not whether the two compartment IDs actually exist in `cells` or are adjacent. Added an ID-exists check derived from `cells` and a server-side `compartmentsAreAdjacent` (mirrors the client helper) so crafted POST payloads can't submit non-adjacent or unknown pairs.

## Doc clarity

**6. `DividerOverride` JSDoc.**
Reworded — offsets are perpendicular shifts from the SEGMENT's own endpoints, not from absolute bin edges. The previous wording was misleading for interior dividers in 3+ row grids whose segments don't span the full bin.

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` 0 errors
- [x] 112 unit tests pass (2 new: dedup case, non-minCol neighbor case)
- [x] 30 generator scenario tests pass (2 new: out-of-bin no-crash, pair-aware run split correctness)
- [x] 75 server-validation tests pass