### PR TITLE
fix(bin-designer): #1829 follow-up review (3 items)

### DIFF
--- a/api/lib/designerValidation.test.ts
+++ b/api/lib/designerValidation.test.ts
@@ -289,6 +289,23 @@ describe('validateDesignerShare', () => {
       const result = validateDesignerShare(payload, JSON.stringify(payload).length);
       expect(result.valid).toBe(false);
     });
+
+    it('rejects non-integer cells (float, string, or negative)', () => {
+      // Cells must be non-negative integers so dividerOverrides' knownIds
+      // set is well-formed. A crafted payload could otherwise smuggle in
+      // floats and silently break the adjacency check.
+      const floats = validPayload();
+      (floats.params.compartments as Record<string, unknown>).cells = [0.5];
+      expect(validateDesignerShare(floats, JSON.stringify(floats).length).valid).toBe(false);
+
+      const strings = validPayload();
+      (strings.params.compartments as Record<string, unknown>).cells = ['0'];
+      expect(validateDesignerShare(strings, JSON.stringify(strings).length).valid).toBe(false);
+
+      const negatives = validPayload();
+      (negatives.params.compartments as Record<string, unknown>).cells = [-1];
+      expect(validateDesignerShare(negatives, JSON.stringify(negatives).length).valid).toBe(false);
+    });
   });
 
   describe('label tab validation', () => {

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -262,6 +262,17 @@ function validateCompartments(compartments: unknown): string | null {
   if (compartments.cells.length !== expectedLength) {
     return `compartments.cells length must be cols × rows (${expectedLength})`;
   }
+  // Each cell must be a non-negative integer compartment ID. The
+  // dividerOverrides validator below derives its knownIds set from cells
+  // and runs an adjacency check that assumes integer IDs — a crafted
+  // payload could otherwise smuggle in floats/strings and break both
+  // checks silently.
+  for (let i = 0; i < compartments.cells.length; i++) {
+    const c = compartments.cells[i] as unknown;
+    if (typeof c !== 'number' || !Number.isInteger(c) || c < 0) {
+      return `compartments.cells[${i}] must be a non-negative integer`;
+    }
+  }
   // Optional per-compartment engraved text. Mirrors the client-side
   // `TEXT_MAX_LENGTH = 50` cap so a direct HTTP POST can't smuggle in
   // unbounded strings that bypass `setCompartmentText`. Array length

--- a/src/features/generation/worker/generators/compartmentBuilder.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.ts
@@ -199,27 +199,28 @@ function findPairAwareRuns(
   key: (i: number) => string | null
 ): Array<{ start: number; end: number; pairKey: string }> {
   const runs: Array<{ start: number; end: number; pairKey: string }> = [];
-  let segStart: number | null = null;
-  let segKey: string | null = null;
+  // Carry start + key as a single nullable tuple so segStart and segKey can
+  // never disagree (one set, the other still null). Prior shape stored them
+  // separately and TypeScript couldn't prove the invariant; reviewers
+  // flagged the `segKey ?? ''` fallback as either dead code or a silent
+  // misroute waiting to happen.
+  let open: { start: number; key: string } | null = null;
   for (let i = 0; i < count; i++) {
     const k = key(i);
     if (k === null) {
-      if (segStart !== null && segKey !== null) {
-        runs.push({ start: segStart, end: i, pairKey: segKey });
-        segStart = null;
-        segKey = null;
+      if (open !== null) {
+        runs.push({ start: open.start, end: i, pairKey: open.key });
+        open = null;
       }
-    } else if (segStart === null) {
-      segStart = i;
-      segKey = k;
-    } else if (k !== segKey) {
-      runs.push({ start: segStart, end: i, pairKey: segKey ?? '' });
-      segStart = i;
-      segKey = k;
+    } else if (open === null) {
+      open = { start: i, key: k };
+    } else if (k !== open.key) {
+      runs.push({ start: open.start, end: i, pairKey: open.key });
+      open = { start: i, key: k };
     }
   }
-  if (segStart !== null && segKey !== null) {
-    runs.push({ start: segStart, end: count, pairKey: segKey });
+  if (open !== null) {
+    runs.push({ start: open.start, end: count, pairKey: open.key });
   }
   return runs;
 }

--- a/src/features/generation/worker/generators/featureBuilder.test.ts
+++ b/src/features/generation/worker/generators/featureBuilder.test.ts
@@ -170,33 +170,78 @@ describe('buildCompartmentWalls', () => {
 
   it('applies overrides only to the matching pair when a boundary spans multiple pairs', () => {
     // 2×2 grid with no merging — the vertical boundary between col 0 and col
-    // 1 runs through pair (0,1) at row 0 and pair (2,3) at row 1. Before the
-    // pair-aware run split, the whole vertical run was one segment and the
-    // (0,1) override would silently apply to the (2,3) half. With the fix,
-    // each pair-run gets its own lookup.
+    // 1 runs through pair (0,1) at row 0 and pair (2,3) at row 1. Before
+    // the pair-aware run split, the whole vertical run was one segment and
+    // the (0,1) override would silently apply to the (2,3) half — meaning
+    // an override on ONLY (0,1) would produce identical geometry to
+    // overriding BOTH pairs (because the bottom half secretly got the
+    // same tilt). With the fix, top-only-override and both-override
+    // produce DIFFERENT meshes.
+    //
+    // This is the load-bearing assertion. The previous version of this
+    // test only compared against baseline, which would still pass if the
+    // bug persisted (the buggy code does change the mesh — it just
+    // changes the wrong part).
     const baseCells = [0, 1, 2, 3];
-    const noOverrides: BinParams = {
-      ...DEFAULT_BIN_PARAMS,
-      compartments: { cols: 2, rows: 2, cells: baseCells, thickness: 1.2 },
-    };
-    const onlyTopTilted: BinParams = {
+    const make = (
+      overrides: {
+        compartmentA: number;
+        compartmentB: number;
+        offsetStart: number;
+        offsetEnd: number;
+      }[]
+    ): BinParams => ({
       ...DEFAULT_BIN_PARAMS,
       compartments: {
         cols: 2,
         rows: 2,
         cells: baseCells,
         thickness: 1.2,
-        dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 10, offsetEnd: -10 }],
+        dividerOverrides: overrides,
       },
+    });
+
+    const topOnly = buildCompartmentWalls(
+      make([{ compartmentA: 0, compartmentB: 1, offsetStart: 10, offsetEnd: -10 }]),
+      80,
+      80,
+      16
+    );
+    // Use a DIFFERENT tilt for (2,3) than for (0,1) so the two halves
+    // can't fuse into one indistinguishable parallelogram. With matched
+    // offsets, two adjacent identical parallelograms fuse into a single
+    // larger parallelogram with the same vertex count as the buggy
+    // single-run output — the test would pass trivially and not catch
+    // the bug. With mismatched offsets, the bottom half has a distinct
+    // angle and can't fuse cleanly.
+    const bothPairs = buildCompartmentWalls(
+      make([
+        { compartmentA: 0, compartmentB: 1, offsetStart: 10, offsetEnd: -10 },
+        { compartmentA: 2, compartmentB: 3, offsetStart: -8, offsetEnd: 8 },
+      ]),
+      80,
+      80,
+      16
+    );
+    expect(topOnly).not.toBeNull();
+    expect(bothPairs).not.toBeNull();
+    // Use centroid (sum of vertex positions) as the discriminator rather
+    // than vertex count: OCCT's fuse may normalize coincident vertices,
+    // and two parallelograms with the same vertex count can land at
+    // different positions. The centroid catches positional differences
+    // even when the count happens to match.
+    const sumXYZ = (mesh: { vertices: ArrayLike<number> }): number => {
+      let s = 0;
+      for (let i = 0; i < mesh.vertices.length; i++) s += mesh.vertices[i];
+      return s;
     };
-    const baseline = buildCompartmentWalls(noOverrides, 80, 80, 16);
-    const tilted = buildCompartmentWalls(onlyTopTilted, 80, 80, 16);
-    expect(baseline).not.toBeNull();
-    expect(tilted).not.toBeNull();
-    // Different mesh — proves the tilt is taking effect somewhere.
-    const baselineMesh = meshShape(baseline);
-    const tiltedMesh = meshShape(tilted);
-    expect(tiltedMesh.vertices.length).not.toBe(baselineMesh.vertices.length);
+    const topOnlySum = sumXYZ(meshShape(topOnly));
+    const bothSum = sumXYZ(meshShape(bothPairs));
+    // Pre-fix: these would be identical because the (0,1) override would
+    // silently tilt both halves of the boundary and the (2,3) override
+    // would be a no-op. Post-fix: they differ because only the (2,3)
+    // half changes — proving the override is now scoped to its pair.
+    expect(Math.abs(topOnlySum - bothSum)).toBeGreaterThan(0.01);
   }, 30000);
 });
 


### PR DESCRIPTION
## Summary

Greptile gave #1829 a 4/5 with no blockers; Copilot found 3 valid items, all addressed.

## Items

**1. `findPairAwareRuns` segKey ?? '' dead-code.**
`segKey` was nullable in TypeScript's view because two separate variables couldn't prove the "segStart non-null ⇒ segKey non-null" invariant. The `?? ''` fallback would silently produce an empty-string pair key on a future invariant break — masking the bug as a silent miss across every override lookup. CLAUDE.md prohibits non-null assertions, so refactored to a single nullable tuple `open: { start; key } | null` — the invariant is now type-safe by construction (the two fields can never disagree).

**2. Pair-aware test only proved divergence, not the fix.**
The previous version asserted top-only-overridden differed from baseline. The bug also changes geometry (it just changes the wrong part), so the assertion would have passed even with the bug present. Rewrote to compare top-only-overridden vs both-pairs-overridden — load-bearing because if the bug existed, both configs would produce identical output. Also switched the discriminator from vertex count (OCCT's fuse normalizes coincident vertices, making counts brittle) to centroid sum (catches positional differences). The fix required: distinct offsets per pair (matched offsets fuse into one bigger parallelogram with the same vertex count) AND a position-based metric.

**3. Server-side per-cell integer check.**
`validateCompartments` only validated `cells.length`, not that each entry was a non-negative integer. The `dividerOverrides` validator below derives its `knownIds` Set from cells and runs adjacency checks that assume integer IDs — a crafted payload could otherwise smuggle in floats/strings/negatives and silently bypass both. Added a per-cell type+integer+non-negative gate.

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` 0 errors
- [x] 30 generator scenario tests pass (the pair-aware test now actually asserts the right thing — verified it FAILS with `findWallSegments` instead of `findPairAwareRuns`)
- [x] 74 server-validation tests pass (+1 for the new cell-integer check)