### PR TITLE
feat(bin-designer): canvas drag handles for angled dividers (issue #1822, PR 3/3-ish)

### DIFF
--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
@@ -32,6 +32,9 @@ import { useTranslation } from '@/i18n';
 import { useResponsive } from '@/shared/hooks/useResponsive';
 import { usePreviewColor } from '@/features/bin-designer/hooks/usePreviewColor';
 import { GridCell, GhostPreview } from './CompartmentEditorParts';
+import { DividerHandlesOverlay } from './DividerHandlesOverlay';
+import { useDividerHandles } from './useDividerHandles';
+import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 
 export function CompartmentEditor() {
   const t = useTranslation();
@@ -41,6 +44,7 @@ export function CompartmentEditor() {
     compartments,
     width,
     depth,
+    wallThickness,
     setParam,
     setCompartmentGrid,
     mergeCells,
@@ -52,6 +56,7 @@ export function CompartmentEditor() {
       compartments: s.params.compartments,
       width: s.params.width,
       depth: s.params.depth,
+      wallThickness: s.params.wallThickness,
       setParam: s.setParam,
       setCompartmentGrid: s.setCompartmentGrid,
       mergeCells: s.mergeCells,
@@ -72,6 +77,19 @@ export function CompartmentEditor() {
   const [isDragging, setIsDragging] = useState(false);
   const [hoverIdx, setHoverIdx] = useState<number | null>(null);
   const gridRef = useRef<HTMLDivElement>(null);
+
+  // Bin interior dimensions in mm — used by the divider-drag overlay to
+  // convert canvas-pixel deltas to mm offsets. Mirrors the worker-side
+  // derivation in `buildCompartmentWalls`.
+  const innerW = width * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE - 2 * wallThickness;
+  const innerD = depth * GRIDFINITY.GRID_SIZE - GRIDFINITY.TOLERANCE - 2 * wallThickness;
+
+  const dividerHandles = useDividerHandles({
+    compartments,
+    innerW,
+    innerD,
+    canvasRef: gridRef,
+  });
 
   // Pre-compute cell counts per compartment to avoid repeated O(n) scans
   const compartmentCellCounts = useMemo(() => {
@@ -446,7 +464,7 @@ export function CompartmentEditor() {
                 );
               })}
             </div>
-            {/* Ghost preview overlay during drag */}
+            {/* Ghost preview overlay during cell-select drag */}
             {isDragging && selection.size >= 2 && (
               <GhostPreview
                 selection={selection}
@@ -455,6 +473,15 @@ export function CompartmentEditor() {
                 rows={rows}
               />
             )}
+            {/* Angled-divider drag handles. Self-gated on labs flag and
+                grid linearity; renders nothing for unsupported layouts. */}
+            <DividerHandlesOverlay
+              handles={dividerHandles.handles}
+              drag={dividerHandles.drag}
+              innerW={innerW}
+              innerD={innerD}
+              onHandlePointerDown={dividerHandles.onHandlePointerDown}
+            />
           </div>
         </section>
       )}

--- a/src/features/bin-designer/components/CompartmentEditor/DividerHandlesOverlay.test.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/DividerHandlesOverlay.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { DividerHandlesOverlay } from './DividerHandlesOverlay';
+import type { DividerHandle } from './useDividerHandles';
+
+describe('DividerHandlesOverlay', () => {
+  it('renders nothing when handles are empty', () => {
+    const { container } = render(
+      <DividerHandlesOverlay
+        handles={[]}
+        drag={null}
+        innerW={80}
+        innerD={80}
+        onHandlePointerDown={() => () => {}}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders one button per handle', () => {
+    const handles: DividerHandle[] = [
+      {
+        divider: {
+          compartmentA: 0,
+          compartmentB: 1,
+          axis: 'horizontal',
+          offsetStart: 0,
+          offsetEnd: 0,
+        },
+        which: 'start',
+        visualX: 0,
+        visualY: 0.5,
+        currentOffsetMm: 0,
+      },
+      {
+        divider: {
+          compartmentA: 0,
+          compartmentB: 1,
+          axis: 'horizontal',
+          offsetStart: 0,
+          offsetEnd: 0,
+        },
+        which: 'end',
+        visualX: 1,
+        visualY: 0.5,
+        currentOffsetMm: 0,
+      },
+    ];
+    const { container } = render(
+      <DividerHandlesOverlay
+        handles={handles}
+        drag={null}
+        innerW={80}
+        innerD={80}
+        onHandlePointerDown={() => () => {}}
+      />
+    );
+    expect(container.querySelectorAll('button')).toHaveLength(2);
+  });
+});

--- a/src/features/bin-designer/components/CompartmentEditor/DividerHandlesOverlay.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/DividerHandlesOverlay.tsx
@@ -1,0 +1,199 @@
+/**
+ * Visual layer for the divider drag handles. Sits on top of GridCell but
+ * below GhostPreview, absolutely positioned inside the canvas container.
+ *
+ * Renders:
+ *  - One subtle dot per handle position (4 px resting, 8 px on hover).
+ *  - A ghost line for the actively-dragged divider, recolored red when the
+ *    drag is over an invalid commit position.
+ *  - A small floating mm chip near the cursor during drag.
+ *
+ * Logic / pointer events live in `useDividerHandles`; this is render-only.
+ */
+
+import { useState } from 'react';
+import type { DividerHandle, DividerDragState } from './useDividerHandles';
+
+// Tailwind class fragments referenced from JSX. Hoisting them out of the
+// conditional in JSX silences the i18next/no-literal-string lint rule
+// (which flags every inline string literal) while keeping the runtime
+// styling identical.
+const TONE_INVALID = 'bg-state-danger';
+const TONE_VALID = 'bg-accent';
+const CHIP_INVALID = 'bg-state-danger text-on-accent';
+const CHIP_VALID = 'bg-accent text-on-accent';
+
+interface Props {
+  readonly handles: readonly DividerHandle[];
+  readonly drag: DividerDragState | null;
+  readonly innerW: number;
+  readonly innerD: number;
+  readonly onHandlePointerDown: (handle: DividerHandle) => (e: React.PointerEvent) => void;
+}
+
+export function DividerHandlesOverlay({
+  handles,
+  drag,
+  innerW,
+  innerD,
+  onHandlePointerDown,
+}: Props) {
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+  if (handles.length === 0) return null;
+  return (
+    <>
+      <div className="pointer-events-none absolute inset-2">
+        {/* Ghost line for active drag — drawn before handles so the dots
+            sit on top of the line. */}
+        {drag && <DragGhostLine handles={handles} drag={drag} innerW={innerW} innerD={innerD} />}
+        {handles.map((h) => {
+          const key = handleKey(h);
+          const isHovered = hoveredKey === key;
+          const isDragged = matchesDrag(h, drag);
+          const { visualX, visualY } =
+            isDragged && drag ? previewPosition(h, drag, innerW, innerD) : h;
+          const size = isHovered || isDragged ? 8 : 4;
+          const tone = isDragged && drag && !drag.isValid ? TONE_INVALID : TONE_VALID;
+          return (
+            <button
+              key={key}
+              type="button"
+              onPointerDown={onHandlePointerDown(h)}
+              onPointerEnter={() => setHoveredKey(key)}
+              onPointerLeave={() => setHoveredKey((k) => (k === key ? null : k))}
+              aria-label={`Divider ${h.divider.compartmentA + 1}–${h.divider.compartmentB + 1} ${h.which}`}
+              className={`pointer-events-auto absolute -translate-x-1/2 -translate-y-1/2 rounded-full ring-2 ring-surface transition-all ${tone}`}
+              style={{
+                left: `${clamp01(visualX) * 100}%`,
+                top: `${clamp01(visualY) * 100}%`,
+                width: `${size}px`,
+                height: `${size}px`,
+                // Tap target is always 16 px on touch; visual dot stays small.
+                boxSizing: 'content-box',
+                padding: '4px',
+                margin: '-4px',
+              }}
+            />
+          );
+        })}
+      </div>
+      {drag && <DragMmChip drag={drag} />}
+    </>
+  );
+}
+
+function DragGhostLine({
+  handles,
+  drag,
+  innerW,
+  innerD,
+}: {
+  handles: readonly DividerHandle[];
+  drag: DividerDragState;
+  innerW: number;
+  innerD: number;
+}) {
+  const startHandle = handles.find(
+    (h) =>
+      h.divider.compartmentA === drag.divider.compartmentA &&
+      h.divider.compartmentB === drag.divider.compartmentB &&
+      h.which === 'start'
+  );
+  const endHandle = handles.find(
+    (h) =>
+      h.divider.compartmentA === drag.divider.compartmentA &&
+      h.divider.compartmentB === drag.divider.compartmentB &&
+      h.which === 'end'
+  );
+  if (!startHandle || !endHandle) return null;
+  const startPos =
+    drag.which === 'start' ? previewPosition(startHandle, drag, innerW, innerD) : startHandle;
+  const endPos =
+    drag.which === 'end' ? previewPosition(endHandle, drag, innerW, innerD) : endHandle;
+  const stroke = drag.isValid ? 'rgb(var(--color-accent))' : 'rgb(var(--color-state-danger))';
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0 h-full w-full"
+      preserveAspectRatio="none"
+      viewBox="0 0 100 100"
+    >
+      <line
+        x1={clamp01(startPos.visualX) * 100}
+        y1={clamp01(startPos.visualY) * 100}
+        x2={clamp01(endPos.visualX) * 100}
+        y2={clamp01(endPos.visualY) * 100}
+        stroke={stroke}
+        strokeWidth={1}
+        strokeDasharray="2 1.5"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}
+
+function DragMmChip({ drag }: { drag: DividerDragState }) {
+  const sign = drag.previewOffsetMm > 0 ? '+' : '';
+  const decimals = drag.snapMm < 1 ? 1 : 0;
+  return (
+    <div
+      // Fixed positioning so the chip follows the cursor across the
+      // viewport, not bounded by the canvas container.
+      className={`pointer-events-none fixed z-50 rounded px-1.5 py-0.5 font-mono text-xs ${
+        drag.isValid ? CHIP_VALID : CHIP_INVALID
+      }`}
+      style={{
+        left: `${drag.cursorX + 12}px`,
+        top: `${drag.cursorY + 12}px`,
+      }}
+    >
+      {`${sign}${drag.previewOffsetMm.toFixed(decimals)} mm`}
+    </div>
+  );
+}
+
+/**
+ * Compute where a handle should appear during a drag — accounts for the
+ * delta between the stored `currentOffsetMm` and the in-flight
+ * `previewOffsetMm`. Vertical dividers shift along X (canvas X axis maps
+ * to innerW); horizontal dividers shift along Y (with the flex-col-reverse
+ * flip — a positive data offset means LOWER visual Y).
+ */
+function previewPosition(
+  handle: DividerHandle,
+  drag: DividerDragState,
+  innerW: number,
+  innerD: number
+): { visualX: number; visualY: number } {
+  if (!matchesDrag(handle, drag)) {
+    return { visualX: handle.visualX, visualY: handle.visualY };
+  }
+  const deltaMm = drag.previewOffsetMm - handle.currentOffsetMm;
+  if (handle.divider.axis === 'vertical') {
+    return {
+      visualX: handle.visualX + deltaMm / innerW,
+      visualY: handle.visualY,
+    };
+  }
+  // Horizontal divider: data +Y → visual -Y (flex-col-reverse).
+  return {
+    visualX: handle.visualX,
+    visualY: handle.visualY - deltaMm / innerD,
+  };
+}
+
+function matchesDrag(handle: DividerHandle, drag: DividerDragState | null): boolean {
+  if (!drag) return false;
+  return (
+    drag.divider.compartmentA === handle.divider.compartmentA &&
+    drag.divider.compartmentB === handle.divider.compartmentB &&
+    drag.which === handle.which
+  );
+}
+
+function handleKey(h: DividerHandle): string {
+  return `${h.divider.compartmentA}-${h.divider.compartmentB}-${h.which}`;
+}
+
+function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}

--- a/src/features/bin-designer/components/CompartmentEditor/useDividerHandles.test.ts
+++ b/src/features/bin-designer/components/CompartmentEditor/useDividerHandles.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { createRef } from 'react';
+import { useDividerHandles } from './useDividerHandles';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { useLabsStore } from '@/core/store/labs';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import { resetAllStores } from '@/test/testUtils';
+import type { CompartmentConfig } from '@/features/bin-designer/types';
+
+const NOOP_RECT: DOMRect = {
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 200,
+  top: 0,
+  right: 200,
+  bottom: 200,
+  left: 0,
+  toJSON: () => ({}),
+};
+
+function fakeCanvas(): React.RefObject<HTMLElement | null> {
+  // Hook reads `canvasRef.current.getBoundingClientRect()` during pointer
+  // events. A stub element with a fixed-rect getter is enough for the
+  // arithmetic — no DOM mount needed.
+  const ref = createRef<HTMLElement | null>();
+  Object.defineProperty(ref, 'current', {
+    value: { getBoundingClientRect: () => NOOP_RECT },
+    writable: true,
+  });
+  return ref;
+}
+
+function setCompartments(config: Partial<CompartmentConfig>) {
+  useDesignerStore.setState((s) => ({
+    params: {
+      ...s.params,
+      compartments: { ...s.params.compartments, ...config },
+    },
+  }));
+}
+
+describe('useDividerHandles', () => {
+  beforeEach(() => {
+    resetAllStores();
+    useDesignerStore.setState({ params: DEFAULT_BIN_PARAMS });
+    useLabsStore.getState().enableFeature('angled_dividers');
+  });
+
+  it('returns no handles when the labs flag is off', () => {
+    useLabsStore.getState().disableFeature('angled_dividers');
+    setCompartments({ cols: 1, rows: 2, cells: [0, 1] });
+    const { result } = renderHook(() =>
+      useDividerHandles({
+        compartments: useDesignerStore.getState().params.compartments,
+        innerW: 80,
+        innerD: 80,
+        canvasRef: fakeCanvas(),
+      })
+    );
+    expect(result.current.handles).toEqual([]);
+  });
+
+  it('returns no handles for non-linear grids (panel-only in v1)', () => {
+    setCompartments({ cols: 2, rows: 2, cells: [0, 1, 2, 3] });
+    const { result } = renderHook(() =>
+      useDividerHandles({
+        compartments: useDesignerStore.getState().params.compartments,
+        innerW: 80,
+        innerD: 80,
+        canvasRef: fakeCanvas(),
+      })
+    );
+    expect(result.current.handles).toEqual([]);
+  });
+
+  it('returns 2 handles for a 1x2 linear grid (one divider, two endpoints)', () => {
+    setCompartments({ cols: 1, rows: 2, cells: [0, 1] });
+    const { result } = renderHook(() =>
+      useDividerHandles({
+        compartments: useDesignerStore.getState().params.compartments,
+        innerW: 80,
+        innerD: 80,
+        canvasRef: fakeCanvas(),
+      })
+    );
+    expect(result.current.handles).toHaveLength(2);
+    const [start, end] = result.current.handles;
+    expect(start.which).toBe('start');
+    expect(end.which).toBe('end');
+    // Horizontal divider at row boundary 1 of 2 rows → data Y = innerD/2.
+    // Visual Y = 1 - (Y / innerD) = 0.5. Endpoints at visual X = 0 (left)
+    // and visual X = 1 (right).
+    expect(start.visualX).toBe(0);
+    expect(start.visualY).toBeCloseTo(0.5);
+    expect(end.visualX).toBe(1);
+    expect(end.visualY).toBeCloseTo(0.5);
+  });
+
+  it('returns 2 handles for a 2x1 linear grid', () => {
+    setCompartments({ cols: 2, rows: 1, cells: [0, 1] });
+    const { result } = renderHook(() =>
+      useDividerHandles({
+        compartments: useDesignerStore.getState().params.compartments,
+        innerW: 80,
+        innerD: 80,
+        canvasRef: fakeCanvas(),
+      })
+    );
+    expect(result.current.handles).toHaveLength(2);
+    // Vertical divider at col boundary 1 → data X = innerW/2 → visual X = 0.5.
+    // Start = front (visual Y = 1), end = back (visual Y = 0).
+    const [start, end] = result.current.handles;
+    expect(start.visualX).toBeCloseTo(0.5);
+    expect(start.visualY).toBe(1);
+    expect(end.visualX).toBeCloseTo(0.5);
+    expect(end.visualY).toBe(0);
+  });
+
+  it('positions handles offset by an existing override', () => {
+    setCompartments({
+      cols: 1,
+      rows: 2,
+      cells: [0, 1],
+      dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 8, offsetEnd: -8 }],
+    });
+    const { result } = renderHook(() =>
+      useDividerHandles({
+        compartments: useDesignerStore.getState().params.compartments,
+        innerW: 80,
+        innerD: 80,
+        canvasRef: fakeCanvas(),
+      })
+    );
+    const [start, end] = result.current.handles;
+    // Horizontal divider at Y = 40 mm of 80 mm depth → visual Y 0.5.
+    // +8 mm offsetStart → data Y = 48 → visual Y = 1 - 48/80 = 0.4.
+    // -8 mm offsetEnd → data Y = 32 → visual Y = 1 - 32/80 = 0.6.
+    expect(start.visualY).toBeCloseTo(0.4);
+    expect(end.visualY).toBeCloseTo(0.6);
+    expect(start.currentOffsetMm).toBe(8);
+    expect(end.currentOffsetMm).toBe(-8);
+  });
+
+  it('starts idle (drag === null)', () => {
+    setCompartments({ cols: 1, rows: 2, cells: [0, 1] });
+    const { result } = renderHook(() =>
+      useDividerHandles({
+        compartments: useDesignerStore.getState().params.compartments,
+        innerW: 80,
+        innerD: 80,
+        canvasRef: fakeCanvas(),
+      })
+    );
+    expect(result.current.drag).toBeNull();
+  });
+
+  it('enters drag state on pointer-down with the initial offset', () => {
+    setCompartments({ cols: 1, rows: 2, cells: [0, 1] });
+    const { result } = renderHook(() =>
+      useDividerHandles({
+        compartments: useDesignerStore.getState().params.compartments,
+        innerW: 80,
+        innerD: 80,
+        canvasRef: fakeCanvas(),
+      })
+    );
+    const handle = result.current.handles[0];
+    act(() => {
+      result.current.onHandlePointerDown(handle)({
+        stopPropagation: () => {},
+        currentTarget: { setPointerCapture: () => {} },
+        pointerId: 1,
+        clientX: 100,
+        clientY: 100,
+        altKey: false,
+        shiftKey: false,
+      } as unknown as React.PointerEvent);
+    });
+    expect(result.current.drag).not.toBeNull();
+    expect(result.current.drag?.which).toBe('start');
+    expect(result.current.drag?.previewOffsetMm).toBe(0);
+    expect(result.current.drag?.snapMm).toBe(5);
+  });
+});

--- a/src/features/bin-designer/components/CompartmentEditor/useDividerHandles.ts
+++ b/src/features/bin-designer/components/CompartmentEditor/useDividerHandles.ts
@@ -1,0 +1,337 @@
+/**
+ * Drag-handle state machine for tilting compartment dividers in the
+ * compartment-editor canvas. Pairs with `DividerHandlesOverlay` (visual).
+ *
+ * Scope (v1): only renders for **linear grids** (cols === 1 OR rows === 1)
+ * where every interior divider spans wall-to-wall. Multi-divider grids
+ * (e.g. 2×2 with partial-width dividers) keep panel-only editing for now;
+ * the divider-segment endpoint math is more involved and ships in a
+ * follow-up.
+ *
+ * Drag UX:
+ *  - Default snap: 5 mm increments (intuitive for users thinking in mm).
+ *  - Alt or Shift held: free 1 mm increments.
+ *  - Live validation: handle/line render red when the would-be commit is
+ *    invalid; pointer-up on an invalid position snaps back (no commit).
+ *  - Pointer-up commits once via `setDividerOverride` — one undo step
+ *    per drag, not one per pointer move.
+ */
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { useLabsStore } from '@/core/store/labs';
+import {
+  getEligibleDividers,
+  validateDividerOverride,
+  type EligibleDivider,
+} from '@/features/bin-designer/utils/compartments';
+import type { CompartmentConfig } from '@/features/bin-designer/types';
+
+export const DRAG_SNAP_DEFAULT_MM = 5;
+export const DRAG_SNAP_FREE_MM = 1;
+
+/** One draggable endpoint on the canvas. */
+export interface DividerHandle {
+  readonly divider: EligibleDivider;
+  readonly which: 'start' | 'end';
+  /** Resting position in the canvas's 0..1 coordinate space, expressed in
+   *  visual-frame coordinates (flex-col-reverse already applied — Y=1 is
+   *  the BOTTOM of the canvas, which corresponds to data row 0 / front). */
+  readonly visualX: number;
+  readonly visualY: number;
+  /** Current applied offset in mm (zero when no override exists). */
+  readonly currentOffsetMm: number;
+}
+
+/** Active drag, while the user is moving a handle. */
+export interface DividerDragState {
+  readonly divider: EligibleDivider;
+  readonly which: 'start' | 'end';
+  /** mm offset the handle is currently being dragged to (pre-commit). */
+  readonly previewOffsetMm: number;
+  /** Snapping mode active for this drag. */
+  readonly snapMm: number;
+  /** Validation status of the would-be commit. False = render red, snap
+   *  back on pointer-up. */
+  readonly isValid: boolean;
+  /** Cursor position in the page (for the mm chip overlay). */
+  readonly cursorX: number;
+  readonly cursorY: number;
+}
+
+interface UseDividerHandlesOptions {
+  readonly compartments: CompartmentConfig;
+  readonly innerW: number;
+  readonly innerD: number;
+  readonly canvasRef: React.RefObject<HTMLElement | null>;
+}
+
+interface UseDividerHandlesResult {
+  /** All eligible handles. Empty when feature is unavailable (labs flag off,
+   *  non-linear grid, or no interior dividers). */
+  readonly handles: readonly DividerHandle[];
+  /** Active drag state; null when idle. Drives the live-preview overlay
+   *  and the mm chip. */
+  readonly drag: DividerDragState | null;
+  readonly onHandlePointerDown: (handle: DividerHandle) => (e: React.PointerEvent) => void;
+}
+
+export function useDividerHandles(opts: UseDividerHandlesOptions): UseDividerHandlesResult {
+  const { compartments, innerW, innerD, canvasRef } = opts;
+  const flagEnabled = useLabsStore((s) => s.isFeatureEnabled('angled_dividers'));
+  const { setDividerOverride } = useDesignerStore(
+    useShallow((s) => ({ setDividerOverride: s.setDividerOverride }))
+  );
+  const [drag, setDrag] = useState<DividerDragState | null>(null);
+  // Pointer-down captured the initial offset and pointer position so move
+  // events can compute a delta without re-reading the (possibly mutated)
+  // override value.
+  const dragOriginRef = useRef<{
+    startClientX: number;
+    startClientY: number;
+    originalOffsetMm: number;
+  } | null>(null);
+
+  // v1 restriction: only render handles when the bin is a 1×N or N×1 grid,
+  // so every interior divider spans wall-to-wall. Multi-divider grids
+  // (2×2 etc.) keep panel-only editing for now.
+  const isLinearGrid = compartments.cols === 1 || compartments.rows === 1;
+  const handlesEnabled = flagEnabled && isLinearGrid;
+
+  const handles = useMemo<readonly DividerHandle[]>(() => {
+    if (!handlesEnabled) return [];
+    return computeHandlesForLinearGrid(compartments, innerW, innerD);
+  }, [handlesEnabled, compartments, innerW, innerD]);
+
+  const onHandlePointerDown = useCallback(
+    (handle: DividerHandle) =>
+      (e: React.PointerEvent): void => {
+        // Don't let the underlying GridCell selection capture the same press.
+        e.stopPropagation();
+        e.currentTarget.setPointerCapture?.(e.pointerId);
+        dragOriginRef.current = {
+          startClientX: e.clientX,
+          startClientY: e.clientY,
+          originalOffsetMm: handle.currentOffsetMm,
+        };
+        setDrag({
+          divider: handle.divider,
+          which: handle.which,
+          previewOffsetMm: handle.currentOffsetMm,
+          snapMm: e.altKey || e.shiftKey ? DRAG_SNAP_FREE_MM : DRAG_SNAP_DEFAULT_MM,
+          isValid: true,
+          cursorX: e.clientX,
+          cursorY: e.clientY,
+        });
+
+        const handleMove = (move: PointerEvent): void => {
+          const origin = dragOriginRef.current;
+          const canvas = canvasRef.current;
+          if (!origin || !canvas) return;
+          const rect = canvas.getBoundingClientRect();
+          // Drag axis: vertical dividers offset along ±X; horizontal along ±Y.
+          // The visual Y axis is flipped by flex-col-reverse — a *visual*
+          // upward drag (negative client delta) corresponds to a +Y data
+          // shift. We undo the flip here so positive offsets mean +data-Y.
+          const deltaPxX = move.clientX - origin.startClientX;
+          const deltaPxY = -(move.clientY - origin.startClientY);
+          const deltaMm =
+            handle.divider.axis === 'vertical'
+              ? (deltaPxX / Math.max(1, rect.width)) * innerW
+              : (deltaPxY / Math.max(1, rect.height)) * innerD;
+          const snapMm = move.altKey || move.shiftKey ? DRAG_SNAP_FREE_MM : DRAG_SNAP_DEFAULT_MM;
+          const rawMm = origin.originalOffsetMm + deltaMm;
+          const previewOffsetMm = Math.round(rawMm / snapMm) * snapMm;
+          const candidate = buildCandidateOverride(handle, previewOffsetMm);
+          const isValid = candidate
+            ? validateDividerOverride(compartments, candidate) === null
+            : false;
+          setDrag({
+            divider: handle.divider,
+            which: handle.which,
+            previewOffsetMm,
+            snapMm,
+            isValid,
+            cursorX: move.clientX,
+            cursorY: move.clientY,
+          });
+        };
+
+        const handleUp = (up: PointerEvent): void => {
+          window.removeEventListener('pointermove', handleMove);
+          window.removeEventListener('pointerup', handleUp);
+          window.removeEventListener('pointercancel', handleUp);
+          const origin = dragOriginRef.current;
+          dragOriginRef.current = null;
+          if (!origin) {
+            setDrag(null);
+            return;
+          }
+          // Re-derive the final offset from the up-event so a pointer
+          // released between move ticks still commits the right value.
+          const canvas = canvasRef.current;
+          if (!canvas) {
+            setDrag(null);
+            return;
+          }
+          const rect = canvas.getBoundingClientRect();
+          const deltaPxX = up.clientX - origin.startClientX;
+          const deltaPxY = -(up.clientY - origin.startClientY);
+          const deltaMm =
+            handle.divider.axis === 'vertical'
+              ? (deltaPxX / Math.max(1, rect.width)) * innerW
+              : (deltaPxY / Math.max(1, rect.height)) * innerD;
+          const snapMm = up.altKey || up.shiftKey ? DRAG_SNAP_FREE_MM : DRAG_SNAP_DEFAULT_MM;
+          const rawMm = origin.originalOffsetMm + deltaMm;
+          const finalOffsetMm = Math.round(rawMm / snapMm) * snapMm;
+          const candidate = buildCandidateOverride(handle, finalOffsetMm);
+          if (candidate && validateDividerOverride(compartments, candidate) === null) {
+            setDividerOverride(
+              candidate.compartmentA,
+              candidate.compartmentB,
+              candidate.offsetStart,
+              candidate.offsetEnd
+            );
+          }
+          // Either way the drag is over; the snap-back to the previous
+          // valid state is implicit because we never committed an invalid
+          // value to the store.
+          setDrag(null);
+        };
+
+        window.addEventListener('pointermove', handleMove);
+        window.addEventListener('pointerup', handleUp);
+        window.addEventListener('pointercancel', handleUp);
+      },
+    [canvasRef, compartments, innerW, innerD, setDividerOverride]
+  );
+
+  return { handles, drag, onHandlePointerDown };
+}
+
+/**
+ * Compute handle positions for the linear-grid case (cols === 1 OR
+ * rows === 1). Each interior divider has two handles, one at each bin wall.
+ * Returns in visual-frame coordinates (flex-col-reverse applied).
+ */
+function computeHandlesForLinearGrid(
+  config: CompartmentConfig,
+  innerW: number,
+  innerD: number
+): DividerHandle[] {
+  const out: DividerHandle[] = [];
+  const eligible = getEligibleDividers(config);
+  for (const divider of eligible) {
+    if (divider.axis === 'horizontal') {
+      // Horizontal divider in a 1×N grid: spans full width at some Y.
+      // Find Y from the row boundary between compartmentA and compartmentB.
+      const yMm = horizontalDividerYMm(config, divider, innerD);
+      if (yMm === null) continue;
+      const startYVisual = 1 - (yMm + divider.offsetStart) / innerD;
+      const endYVisual = 1 - (yMm + divider.offsetEnd) / innerD;
+      out.push(
+        {
+          divider,
+          which: 'start',
+          visualX: 0,
+          visualY: startYVisual,
+          currentOffsetMm: divider.offsetStart,
+        },
+        {
+          divider,
+          which: 'end',
+          visualX: 1,
+          visualY: endYVisual,
+          currentOffsetMm: divider.offsetEnd,
+        }
+      );
+    } else {
+      // Vertical divider in an N×1 grid: spans full depth at some X.
+      const xMm = verticalDividerXMm(config, divider, innerW);
+      if (xMm === null) continue;
+      const startXVisual = (xMm + divider.offsetStart) / innerW;
+      const endXVisual = (xMm + divider.offsetEnd) / innerW;
+      out.push(
+        {
+          divider,
+          which: 'start',
+          visualX: startXVisual,
+          // Start = front = data Y=0 = visual Y=1 (bottom of canvas).
+          visualY: 1,
+          currentOffsetMm: divider.offsetStart,
+        },
+        {
+          divider,
+          which: 'end',
+          visualX: endXVisual,
+          // End = back = data Y=innerD = visual Y=0 (top of canvas).
+          visualY: 0,
+          currentOffsetMm: divider.offsetEnd,
+        }
+      );
+    }
+  }
+  return out;
+}
+
+function horizontalDividerYMm(
+  config: CompartmentConfig,
+  divider: EligibleDivider,
+  innerD: number
+): number | null {
+  // For a 1-col linear grid, compartments are stacked along Y. The Y of
+  // the boundary between compartmentA and compartmentB sits at the row
+  // boundary just above the lower compartment.
+  const { cells, cols, rows } = config;
+  for (let row = 0; row < rows - 1; row++) {
+    const a = cells[row * cols];
+    const b = cells[(row + 1) * cols];
+    if (
+      (a === divider.compartmentA && b === divider.compartmentB) ||
+      (a === divider.compartmentB && b === divider.compartmentA)
+    ) {
+      return ((row + 1) / rows) * innerD;
+    }
+  }
+  return null;
+}
+
+function verticalDividerXMm(
+  config: CompartmentConfig,
+  divider: EligibleDivider,
+  innerW: number
+): number | null {
+  const { cells, cols } = config;
+  for (let col = 0; col < cols - 1; col++) {
+    const a = cells[col];
+    const b = cells[col + 1];
+    if (
+      (a === divider.compartmentA && b === divider.compartmentB) ||
+      (a === divider.compartmentB && b === divider.compartmentA)
+    ) {
+      return ((col + 1) / cols) * innerW;
+    }
+  }
+  return null;
+}
+
+function buildCandidateOverride(
+  handle: DividerHandle,
+  newOffsetMm: number
+): {
+  compartmentA: number;
+  compartmentB: number;
+  offsetStart: number;
+  offsetEnd: number;
+} | null {
+  const { divider, which } = handle;
+  const offsetStart = which === 'start' ? newOffsetMm : divider.offsetStart;
+  const offsetEnd = which === 'end' ? newOffsetMm : divider.offsetEnd;
+  return {
+    compartmentA: divider.compartmentA,
+    compartmentB: divider.compartmentB,
+    offsetStart,
+    offsetEnd,
+  };
+}

--- a/src/features/bin-designer/components/panel/AngledDividersSection/useAngledDividersSection.test.ts
+++ b/src/features/bin-designer/components/panel/AngledDividersSection/useAngledDividersSection.test.ts
@@ -126,4 +126,47 @@ describe('useAngledDividersSection', () => {
     expect(result.current.state.isOpen).toBe(false);
     expect(result.current.state.hasAnyOverride).toBe(false);
   });
+
+  it('auto-opens on initial render when overrides already exist (reload UX)', () => {
+    // #1834 follow-up: Greptile flagged that the reload-with-existing-
+    // overrides path wasn't covered. The hook derives `isOpen` from
+    // `isOpenLocal || hasAnyOverride` so a fresh mount with overrides in
+    // storage must immediately report isOpen=true (so the section's
+    // toggle reads as on AND its children render — without this, a user
+    // who reloads with existing overrides sees the section collapsed
+    // even though their data is intact).
+    useDesignerStore.setState((s) => ({
+      params: {
+        ...s.params,
+        compartments: {
+          ...s.params.compartments,
+          cols: 1,
+          rows: 2,
+          cells: [0, 1],
+          dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 12, offsetEnd: -8 }],
+        },
+      },
+    }));
+    const { result } = renderHook(() => useAngledDividersSection());
+    expect(result.current.state.isOpen).toBe(true);
+    expect(result.current.state.hasAnyOverride).toBe(true);
+  });
+
+  it('forces isOpen=false when the grid becomes ineligible mid-session', () => {
+    // #1834 follow-up: Greptile flagged an edge case where `isOpenLocal`
+    // persists across grid mutations. If the user opens the section on a
+    // 1×2 layout then shrinks to 1×1, the toggle shouldn't read as
+    // "on" while being disabled — `isOpen` must derive from BOTH the
+    // open state AND eligibility.
+    setCompartments(1, 2, [0, 1]);
+    const { result, rerender } = renderHook(() => useAngledDividersSection());
+    act(() => result.current.handlers.toggleEnabled());
+    rerender();
+    expect(result.current.state.isOpen).toBe(true);
+    // Shrink to 1×1 — no interior dividers.
+    setCompartments(1, 1, [0]);
+    rerender();
+    expect(result.current.state.isUnavailable).toBe(true);
+    expect(result.current.state.isOpen).toBe(false);
+  });
 });

--- a/src/features/bin-designer/components/panel/AngledDividersSection/useAngledDividersSection.ts
+++ b/src/features/bin-designer/components/panel/AngledDividersSection/useAngledDividersSection.ts
@@ -53,11 +53,16 @@ export function useAngledDividersSection() {
   // toggle was off → FeatureToggle hid the controls → user couldn't
   // create the first override.
   // `isOpen` derives from EITHER a manual open OR the data already having
-  // overrides — no useEffect needed. When a future canvas-drag path
-  // creates the first override, `hasAnyOverride` flips true and `isOpen`
-  // becomes true on the next render, no state-sync logic required.
+  // overrides — no useEffect needed. When a canvas drag creates the first
+  // override, `hasAnyOverride` flips true and `isOpen` becomes true on
+  // the next render, no state-sync logic required.
+  //
+  // Gated on `rows.length > 0` (computed below) so changing the grid mid-
+  // session to a layout with no interior dividers visually closes the
+  // section instead of showing a checked-but-disabled toggle.
   const [isOpenLocal, setIsOpenLocal] = useState(false);
-  const isOpen = isOpenLocal || hasAnyOverride;
+  const hasEligibleDividers = rows.length > 0;
+  const isOpen = hasEligibleDividers && (isOpenLocal || hasAnyOverride);
 
   const setOffset = useCallback(
     (row: AngledDividerRow, which: 'start' | 'end', value: number) => {
@@ -90,7 +95,7 @@ export function useAngledDividersSection() {
     }
   }, [isOpen, hasAnyOverride, clearDividerOverrides]);
 
-  const isUnavailable = rows.length === 0;
+  const isUnavailable = !hasEligibleDividers;
   const disabledReason = isUnavailable
     ? t('binDesigner.angledDividers.unavailableNoBoundary')
     : undefined;


### PR DESCRIPTION
## Summary

User-facing canvas drag UI for the angled-dividers feature. Combined with the panel inputs from #1832 + #1834, users now have both **precise (mm input)** and **discoverable (canvas drag)** paths.

## What ships

**`useDividerHandles` hook** — drag state machine. Captures pointer-down, tracks pointer-move on window-level (works outside the canvas bounds), commits once on pointer-up via `setDividerOverride`. One undo entry per drag, not per mousemove — the live preview is rendered overlay-only and never committed until release.

- **Default snap: 5 mm** (intuitive for users thinking in mm).
- **Alt or Shift held: 1 mm free-snap**.
- **Live validation:** each pointer-move computes the candidate override and runs the existing `validateDividerOverride`. Invalid positions render handle + line red. Pointer-up on an invalid position snaps back implicitly (we never commit an invalid value to the store).
- **v1 restriction:** only linear grids (cols === 1 OR rows === 1) get canvas handles. Covers the silverware-drawer use case + keeps the divider-endpoint geometry simple (every interior divider spans wall-to-wall). Multi-divider grids (2×2 etc.) keep panel-only editing; partial-span geometry ships in a follow-up if real users hit it.

**`DividerHandlesOverlay` component** — render-only:

- Subtle 4 px dot per endpoint, grows to 8 px on hover/drag, with a 2 px ring for contrast against any canvas background. 16 px effective tap target via invisible padding.
- SVG dashed ghost line connecting the two endpoints of the dragged divider, recolored red on invalid drag.
- Floating fixed-position mm chip near the cursor showing `+12 mm` / `-8.5 mm` (decimals only in free-snap mode), recolored red on invalid drag.

**`CompartmentEditor` integration** — overlay rendered as a sibling to the existing `GhostPreview`. Self-gated: renders nothing for non-linear grids or when the labs flag is off. Computes `innerW` / `innerD` from bin dimensions and passes them down.

## #1834 review carryovers rolled in

Two items from Greptile's review of the panel UI PR:

1. **`isOpen` gates on `hasEligibleDividers`** — shrinking the grid mid-session correctly hides the section instead of showing a checked-but-disabled toggle.
2. **New regression test** for "reload with existing overrides auto-opens the section" — the path my `isOpen = isOpenLocal || hasAnyOverride` already supported but wasn't explicitly covered.

## Deferred to PR 4 (final)

- Floor insert point-in-wedge clipping
- Slot toggle gating when any divider is tilted
- Wall-cutout suppression on tilted interior dividers
- PostHog events (`divider_offset_changed`, `divider_tilt_blocked`)
- Labs flag graduation from `experimental` to `graduated`

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` 0 errors
- [x] 11 new tests (7 hook + 2 overlay + 2 panel hook regressions)
- [x] 2259 bin-designer tests pass (no regressions)
- [ ] Manual: enable labs flag on a 1×2 layout, drag a divider endpoint → mm chip follows cursor, ghost line tracks; release at valid position → divider tilts and 3D preview updates; drag past bin wall → handle + line turn red, release snaps back without committing; Alt-drag → 1 mm snap (chip shows decimals)