### PR TITLE
fix(bin-designer): #1835 canvas-drag review — 8 items (2 critical)

### DIFF
--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
@@ -77,6 +77,11 @@ export function CompartmentEditor() {
   const [isDragging, setIsDragging] = useState(false);
   const [hoverIdx, setHoverIdx] = useState<number | null>(null);
   const gridRef = useRef<HTMLDivElement>(null);
+  // Ref to the *inner* flex container that holds GridCells. Used by the
+  // divider-drag math so mm-per-pixel matches the GridCell coordinate
+  // space (the outer `gridRef` includes the container's padding + border,
+  // which would skew the conversion).
+  const gridCellsRef = useRef<HTMLDivElement>(null);
 
   // Bin interior dimensions in mm — used by the divider-drag overlay to
   // convert canvas-pixel deltas to mm offsets. Mirrors the worker-side
@@ -88,7 +93,7 @@ export function CompartmentEditor() {
     compartments,
     innerW,
     innerD,
-    canvasRef: gridRef,
+    canvasRef: gridCellsRef,
   });
 
   // Pre-compute cell counts per compartment to avoid repeated O(n) scans
@@ -427,7 +432,7 @@ export function CompartmentEditor() {
             )}
             {/* Use flex-col-reverse to match 3D orientation: row 0 = front = bottom of UI */}
             {/* No gap - merged cells should visually connect; borders handle separation */}
-            <div className="relative flex h-full w-full flex-col-reverse">
+            <div ref={gridCellsRef} className="relative flex h-full w-full flex-col-reverse">
               {Array.from({ length: rows }, (_, visualRow) => {
                 const dataRow = visualRow; // flex-col-reverse handles the flip
                 return (
@@ -463,6 +468,19 @@ export function CompartmentEditor() {
                   </div>
                 );
               })}
+              {/* Angled-divider drag handles. Lives INSIDE the flex
+                  container so its `inset-0` matches the GridCell
+                  coordinate space (the outer `gridRef` includes padding
+                  and border, which would skew positioning). Self-gated
+                  on labs flag + grid linearity; renders nothing
+                  otherwise. */}
+              <DividerHandlesOverlay
+                handles={dividerHandles.handles}
+                drag={dividerHandles.drag}
+                innerW={innerW}
+                innerD={innerD}
+                onHandlePointerDown={dividerHandles.onHandlePointerDown}
+              />
             </div>
             {/* Ghost preview overlay during cell-select drag */}
             {isDragging && selection.size >= 2 && (
@@ -473,15 +491,6 @@ export function CompartmentEditor() {
                 rows={rows}
               />
             )}
-            {/* Angled-divider drag handles. Self-gated on labs flag and
-                grid linearity; renders nothing for unsupported layouts. */}
-            <DividerHandlesOverlay
-              handles={dividerHandles.handles}
-              drag={dividerHandles.drag}
-              innerW={innerW}
-              innerD={innerD}
-              onHandlePointerDown={dividerHandles.onHandlePointerDown}
-            />
           </div>
         </section>
       )}

--- a/src/features/bin-designer/components/CompartmentEditor/DividerHandlesOverlay.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/DividerHandlesOverlay.tsx
@@ -1,6 +1,13 @@
 /**
- * Visual layer for the divider drag handles. Sits on top of GridCell but
- * below GhostPreview, absolutely positioned inside the canvas container.
+ * Visual layer for the divider drag handles. Renders on top of the cell
+ * grid AND on top of `GhostPreview` (CompartmentEditor renders this
+ * sibling last) so the handles + ghost line + mm chip are never occluded
+ * by the cell-selection overlay.
+ *
+ * Positioned with `inset-0` (not `inset-2`) so the handle coordinate
+ * space matches the GridCell flex container's coordinate space — Greptile
+ * flagged the prior `inset-2` mismatch on #1835. Pair with `canvasRef`
+ * pointing at that same flex container in `useDividerHandles`.
  *
  * Renders:
  *  - One subtle dot per handle position (4 px resting, 8 px on hover).
@@ -12,6 +19,7 @@
  */
 
 import { useState } from 'react';
+import { useTranslation } from '@/i18n';
 import type { DividerHandle, DividerDragState } from './useDividerHandles';
 
 // Tailwind class fragments referenced from JSX. Hoisting them out of the
@@ -39,10 +47,11 @@ export function DividerHandlesOverlay({
   onHandlePointerDown,
 }: Props) {
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+  const t = useTranslation();
   if (handles.length === 0) return null;
   return (
     <>
-      <div className="pointer-events-none absolute inset-2">
+      <div className="pointer-events-none absolute inset-0">
         {/* Ghost line for active drag — drawn before handles so the dots
             sit on top of the line. */}
         {drag && <DragGhostLine handles={handles} drag={drag} innerW={innerW} innerD={innerD} />}
@@ -61,7 +70,10 @@ export function DividerHandlesOverlay({
               onPointerDown={onHandlePointerDown(h)}
               onPointerEnter={() => setHoveredKey(key)}
               onPointerLeave={() => setHoveredKey((k) => (k === key ? null : k))}
-              aria-label={`Divider ${h.divider.compartmentA + 1}–${h.divider.compartmentB + 1} ${h.which}`}
+              aria-label={t(`binDesigner.angledDividers.handleAriaLabel.${h.which}`, {
+                a: String(h.divider.compartmentA + 1),
+                b: String(h.divider.compartmentB + 1),
+              })}
               className={`pointer-events-auto absolute -translate-x-1/2 -translate-y-1/2 rounded-full ring-2 ring-surface transition-all ${tone}`}
               style={{
                 left: `${clamp01(visualX) * 100}%`,
@@ -69,9 +81,14 @@ export function DividerHandlesOverlay({
                 width: `${size}px`,
                 height: `${size}px`,
                 // Tap target is always 16 px on touch; visual dot stays small.
+                // `touch-action: none` blocks the OS from interpreting drag
+                // gestures as page scroll/zoom — required since the React
+                // pointer-down handler can't reliably preventDefault on
+                // passive touch events.
                 boxSizing: 'content-box',
                 padding: '4px',
                 margin: '-4px',
+                touchAction: 'none',
               }}
             />
           );

--- a/src/features/bin-designer/components/CompartmentEditor/useDividerHandles.test.ts
+++ b/src/features/bin-designer/components/CompartmentEditor/useDividerHandles.test.ts
@@ -169,6 +169,7 @@ describe('useDividerHandles', () => {
     const handle = result.current.handles[0];
     act(() => {
       result.current.onHandlePointerDown(handle)({
+        preventDefault: () => {},
         stopPropagation: () => {},
         currentTarget: { setPointerCapture: () => {} },
         pointerId: 1,
@@ -182,5 +183,33 @@ describe('useDividerHandles', () => {
     expect(result.current.drag?.which).toBe('start');
     expect(result.current.drag?.previewOffsetMm).toBe(0);
     expect(result.current.drag?.snapMm).toBe(5);
+  });
+
+  it('enters free-snap (0.5 mm) when Alt is held on pointer-down', () => {
+    setCompartments({ cols: 1, rows: 2, cells: [0, 1] });
+    const { result } = renderHook(() =>
+      useDividerHandles({
+        compartments: useDesignerStore.getState().params.compartments,
+        innerW: 80,
+        innerD: 80,
+        canvasRef: fakeCanvas(),
+      })
+    );
+    const handle = result.current.handles[0];
+    act(() => {
+      result.current.onHandlePointerDown(handle)({
+        preventDefault: () => {},
+        stopPropagation: () => {},
+        currentTarget: { setPointerCapture: () => {} },
+        pointerId: 1,
+        clientX: 100,
+        clientY: 100,
+        altKey: true,
+        shiftKey: false,
+      } as unknown as React.PointerEvent);
+    });
+    // Free-snap matches the panel's ANGLED_DIVIDER_UI_STEP so both paths
+    // produce values from the same granularity grid.
+    expect(result.current.drag?.snapMm).toBe(0.5);
   });
 });

--- a/src/features/bin-designer/components/CompartmentEditor/useDividerHandles.ts
+++ b/src/features/bin-designer/components/CompartmentEditor/useDividerHandles.ts
@@ -17,7 +17,7 @@
  *    per drag, not one per pointer move.
  */
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useLabsStore } from '@/core/store/labs';
@@ -29,7 +29,10 @@ import {
 import type { CompartmentConfig } from '@/features/bin-designer/types';
 
 export const DRAG_SNAP_DEFAULT_MM = 5;
-export const DRAG_SNAP_FREE_MM = 1;
+// Matches the panel's `ANGLED_DIVIDER_UI_STEP` so canvas free-snap and
+// panel stepper produce values from the same granularity grid (Greptile
+// flagged the 1 mm-vs-0.5 mm mismatch on PR #1835).
+export const DRAG_SNAP_FREE_MM = 0.5;
 
 /** One draggable endpoint on the canvas. */
 export interface DividerHandle {
@@ -92,6 +95,12 @@ export function useDividerHandles(opts: UseDividerHandlesOptions): UseDividerHan
     startClientY: number;
     originalOffsetMm: number;
   } | null>(null);
+  // Cleanup hook for the active drag's window listeners. Set when a drag
+  // starts, called on natural pointerup/cancel AND on unmount. Prevents
+  // listener leaks if the component unmounts mid-drag (route change,
+  // labs flag toggle, etc.) — Greptile flagged the leak on PR #1835.
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => dragCleanupRef.current?.(), []);
 
   // v1 restriction: only render handles when the bin is a 1×N or N×1 grid,
   // so every interior divider spans wall-to-wall. Multi-divider grids
@@ -107,7 +116,12 @@ export function useDividerHandles(opts: UseDividerHandlesOptions): UseDividerHan
   const onHandlePointerDown = useCallback(
     (handle: DividerHandle) =>
       (e: React.PointerEvent): void => {
-        // Don't let the underlying GridCell selection capture the same press.
+        // Prevent default + stop propagation: blocks text selection, page
+        // scrolling, and the underlying GridCell selection from competing
+        // with the drag. The `touch-action: none` style on the button
+        // handles the touch equivalent (we can't `preventDefault` a
+        // passive touch event reliably).
+        e.preventDefault();
         e.stopPropagation();
         e.currentTarget.setPointerCapture?.(e.pointerId);
         dragOriginRef.current = {
@@ -125,74 +139,65 @@ export function useDividerHandles(opts: UseDividerHandlesOptions): UseDividerHan
           cursorY: e.clientY,
         });
 
-        const handleMove = (move: PointerEvent): void => {
+        const computeOffsetMm = (clientX: number, clientY: number, altOrShift: boolean) => {
           const origin = dragOriginRef.current;
           const canvas = canvasRef.current;
-          if (!origin || !canvas) return;
+          if (!origin || !canvas) return null;
           const rect = canvas.getBoundingClientRect();
-          // Drag axis: vertical dividers offset along ±X; horizontal along ±Y.
-          // The visual Y axis is flipped by flex-col-reverse — a *visual*
-          // upward drag (negative client delta) corresponds to a +Y data
-          // shift. We undo the flip here so positive offsets mean +data-Y.
-          const deltaPxX = move.clientX - origin.startClientX;
-          const deltaPxY = -(move.clientY - origin.startClientY);
+          const deltaPxX = clientX - origin.startClientX;
+          const deltaPxY = -(clientY - origin.startClientY);
           const deltaMm =
             handle.divider.axis === 'vertical'
               ? (deltaPxX / Math.max(1, rect.width)) * innerW
               : (deltaPxY / Math.max(1, rect.height)) * innerD;
-          const snapMm = move.altKey || move.shiftKey ? DRAG_SNAP_FREE_MM : DRAG_SNAP_DEFAULT_MM;
+          const snapMm = altOrShift ? DRAG_SNAP_FREE_MM : DRAG_SNAP_DEFAULT_MM;
           const rawMm = origin.originalOffsetMm + deltaMm;
-          const previewOffsetMm = Math.round(rawMm / snapMm) * snapMm;
-          const candidate = buildCandidateOverride(handle, previewOffsetMm);
+          return {
+            offsetMm: Math.round(rawMm / snapMm) * snapMm,
+            snapMm,
+          };
+        };
+
+        const handleMove = (move: PointerEvent): void => {
+          const result = computeOffsetMm(move.clientX, move.clientY, move.altKey || move.shiftKey);
+          if (!result) return;
+          const candidate = buildCandidateOverride(handle, result.offsetMm);
           const isValid = candidate
             ? validateDividerOverride(compartments, candidate) === null
             : false;
           setDrag({
             divider: handle.divider,
             which: handle.which,
-            previewOffsetMm,
-            snapMm,
+            previewOffsetMm: result.offsetMm,
+            snapMm: result.snapMm,
             isValid,
             cursorX: move.clientX,
             cursorY: move.clientY,
           });
         };
 
-        const handleUp = (up: PointerEvent): void => {
-          window.removeEventListener('pointermove', handleMove);
-          window.removeEventListener('pointerup', handleUp);
-          window.removeEventListener('pointercancel', handleUp);
+        const finishDrag = (commit: boolean, up?: PointerEvent): void => {
+          dragCleanupRef.current?.();
+          dragCleanupRef.current = null;
           const origin = dragOriginRef.current;
           dragOriginRef.current = null;
-          if (!origin) {
+          if (!commit || !origin || !up) {
             setDrag(null);
             return;
           }
           // Re-derive the final offset from the up-event so a pointer
           // released between move ticks still commits the right value.
-          const canvas = canvasRef.current;
-          if (!canvas) {
-            setDrag(null);
-            return;
-          }
-          const rect = canvas.getBoundingClientRect();
-          const deltaPxX = up.clientX - origin.startClientX;
-          const deltaPxY = -(up.clientY - origin.startClientY);
-          const deltaMm =
-            handle.divider.axis === 'vertical'
-              ? (deltaPxX / Math.max(1, rect.width)) * innerW
-              : (deltaPxY / Math.max(1, rect.height)) * innerD;
-          const snapMm = up.altKey || up.shiftKey ? DRAG_SNAP_FREE_MM : DRAG_SNAP_DEFAULT_MM;
-          const rawMm = origin.originalOffsetMm + deltaMm;
-          const finalOffsetMm = Math.round(rawMm / snapMm) * snapMm;
-          const candidate = buildCandidateOverride(handle, finalOffsetMm);
-          if (candidate && validateDividerOverride(compartments, candidate) === null) {
-            setDividerOverride(
-              candidate.compartmentA,
-              candidate.compartmentB,
-              candidate.offsetStart,
-              candidate.offsetEnd
-            );
+          const result = computeOffsetMm(up.clientX, up.clientY, up.altKey || up.shiftKey);
+          if (result) {
+            const candidate = buildCandidateOverride(handle, result.offsetMm);
+            if (candidate && validateDividerOverride(compartments, candidate) === null) {
+              setDividerOverride(
+                candidate.compartmentA,
+                candidate.compartmentB,
+                candidate.offsetStart,
+                candidate.offsetEnd
+              );
+            }
           }
           // Either way the drag is over; the snap-back to the previous
           // valid state is implicit because we never committed an invalid
@@ -200,9 +205,21 @@ export function useDividerHandles(opts: UseDividerHandlesOptions): UseDividerHan
           setDrag(null);
         };
 
+        const handleUp = (up: PointerEvent): void => finishDrag(true, up);
+        // pointercancel = the OS or browser took over (gesture, context
+        // menu, alert). The cancel event carries `clientX: 0, clientY: 0`
+        // on some platforms — committing using that delta could silently
+        // write an unintended override. Abort cleanly instead.
+        const handleCancel = (): void => finishDrag(false);
+
         window.addEventListener('pointermove', handleMove);
         window.addEventListener('pointerup', handleUp);
-        window.addEventListener('pointercancel', handleUp);
+        window.addEventListener('pointercancel', handleCancel);
+        dragCleanupRef.current = (): void => {
+          window.removeEventListener('pointermove', handleMove);
+          window.removeEventListener('pointerup', handleUp);
+          window.removeEventListener('pointercancel', handleCancel);
+        };
       },
     [canvasRef, compartments, innerW, innerD, setDividerOverride]
   );

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -87,6 +87,8 @@
   "binDesigner.angledDividers.offsetStart": "Anfang (mm)",
   "binDesigner.angledDividers.offsetEnd": "Ende (mm)",
   "binDesigner.angledDividers.resetRow": "Trennwand zurücksetzen",
+  "binDesigner.angledDividers.handleAriaLabel.start": "Startpunkt der Trennwand zwischen Fach {a} und Fach {b} ziehen",
+  "binDesigner.angledDividers.handleAriaLabel.end": "Endpunkt der Trennwand zwischen Fach {a} und Fach {b} ziehen",
   "binDesigner.compartmentNumberLabel": "Fach {n}",
   "binDesigner.textMode": "Stil",
   "binDesigner.textMode.engrave": "Gravieren",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1386,6 +1386,10 @@ const en: Record<string, string> = {
   'binDesigner.angledDividers.offsetStart': 'Start (mm)',
   'binDesigner.angledDividers.offsetEnd': 'End (mm)',
   'binDesigner.angledDividers.resetRow': 'Reset divider to straight',
+  'binDesigner.angledDividers.handleAriaLabel.start':
+    'Drag start endpoint of divider between Comp {a} and Comp {b}',
+  'binDesigner.angledDividers.handleAriaLabel.end':
+    'Drag end endpoint of divider between Comp {a} and Comp {b}',
   'binDesigner.compartmentNumberLabel': 'Comp. {n}',
   'binDesigner.textMode': 'Style',
   'binDesigner.textMode.engrave': 'Engrave',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -87,6 +87,8 @@
   "binDesigner.angledDividers.offsetStart": "Inicio (mm)",
   "binDesigner.angledDividers.offsetEnd": "Fin (mm)",
   "binDesigner.angledDividers.resetRow": "Restablecer divisor",
+  "binDesigner.angledDividers.handleAriaLabel.start": "Arrastrar punto inicial del divisor entre Compart. {a} y Compart. {b}",
+  "binDesigner.angledDividers.handleAriaLabel.end": "Arrastrar punto final del divisor entre Compart. {a} y Compart. {b}",
   "binDesigner.compartmentNumberLabel": "Compart. {n}",
   "binDesigner.textMode": "Estilo",
   "binDesigner.textMode.engrave": "Grabado",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -87,6 +87,8 @@
   "binDesigner.angledDividers.offsetStart": "Début (mm)",
   "binDesigner.angledDividers.offsetEnd": "Fin (mm)",
   "binDesigner.angledDividers.resetRow": "Réinitialiser le séparateur",
+  "binDesigner.angledDividers.handleAriaLabel.start": "Faire glisser le point de départ du séparateur entre Comp. {a} et Comp. {b}",
+  "binDesigner.angledDividers.handleAriaLabel.end": "Faire glisser le point final du séparateur entre Comp. {a} et Comp. {b}",
   "binDesigner.compartmentNumberLabel": "Compart. {n}",
   "binDesigner.textMode": "Type",
   "binDesigner.textMode.engrave": "Gravure",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -87,6 +87,8 @@
   "binDesigner.angledDividers.offsetStart": "Forside (mm)",
   "binDesigner.angledDividers.offsetEnd": "Slutt (mm)",
   "binDesigner.angledDividers.resetRow": "Nullstill skillevegg",
+  "binDesigner.angledDividers.handleAriaLabel.start": "Dra startpunktet til skilleveggen mellom Rom {a} og Rom {b}",
+  "binDesigner.angledDividers.handleAriaLabel.end": "Dra sluttpunktet til skilleveggen mellom Rom {a} og Rom {b}",
   "binDesigner.compartmentNumberLabel": "Rom {n}",
   "binDesigner.textMode": "Stil",
   "binDesigner.textMode.engrave": "Graver",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -87,6 +87,8 @@
   "binDesigner.angledDividers.offsetStart": "Begin (mm)",
   "binDesigner.angledDividers.offsetEnd": "Eind (mm)",
   "binDesigner.angledDividers.resetRow": "Scheiding herstellen",
+  "binDesigner.angledDividers.handleAriaLabel.start": "Sleep het beginpunt van de scheiding tussen Vak {a} en Vak {b}",
+  "binDesigner.angledDividers.handleAriaLabel.end": "Sleep het eindpunt van de scheiding tussen Vak {a} en Vak {b}",
   "binDesigner.compartmentNumberLabel": "Vak {n}",
   "binDesigner.textMode": "Stijl",
   "binDesigner.textMode.engrave": "Graveren",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -87,6 +87,8 @@
   "binDesigner.angledDividers.offsetStart": "Início (mm)",
   "binDesigner.angledDividers.offsetEnd": "Fim (mm)",
   "binDesigner.angledDividers.resetRow": "Redefinir divisória",
+  "binDesigner.angledDividers.handleAriaLabel.start": "Arrastar ponto inicial da divisória entre Compart. {a} e Compart. {b}",
+  "binDesigner.angledDividers.handleAriaLabel.end": "Arrastar ponto final da divisória entre Compart. {a} e Compart. {b}",
   "binDesigner.compartmentNumberLabel": "Compart. {n}",
   "binDesigner.textMode": "Estilo",
   "binDesigner.textMode.engrave": "Gravar",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1128,6 +1128,8 @@
   "binDesigner.angledDividers.offsetStart": "Början (mm)",
   "binDesigner.angledDividers.offsetEnd": "Slut (mm)",
   "binDesigner.angledDividers.resetRow": "Återställ avdelare",
+  "binDesigner.angledDividers.handleAriaLabel.start": "Dra startpunkten för avdelaren mellan Fack {a} och Fack {b}",
+  "binDesigner.angledDividers.handleAriaLabel.end": "Dra slutpunkten för avdelaren mellan Fack {a} och Fack {b}",
   "binDesigner.compartmentNumberLabel": "Fack {n}",
   "binDesigner.textMode": "Stil",
   "binDesigner.textMode.engrave": "Gravera",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1128,6 +1128,8 @@
   "binDesigner.angledDividers.offsetStart": "Початок (мм)",
   "binDesigner.angledDividers.offsetEnd": "Кінець (мм)",
   "binDesigner.angledDividers.resetRow": "Скинути перегородку",
+  "binDesigner.angledDividers.handleAriaLabel.start": "Перетягніть початкову точку перегородки між Відсік {a} та Відсік {b}",
+  "binDesigner.angledDividers.handleAriaLabel.end": "Перетягніть кінцеву точку перегородки між Відсік {a} та Відсік {b}",
   "binDesigner.compartmentNumberLabel": "Відсік {n}",
   "binDesigner.textMode": "Стиль",
   "binDesigner.textMode.engrave": "Гравірувати",


### PR DESCRIPTION
## Summary

Follow-up to #1835 (merged). Greptile gave it 3/5; 8 review items, all real. **Two are critical**: pointercancel could silently commit unintended overrides, and the window listeners leaked on unmount.

## Critical fixes

**1. `pointercancel` could write wrong overrides.**
The cancel handler shared `handleUp`, which re-derives a final offset from `up.clientX/Y` — but `pointercancel` events carry `clientX: 0, clientY: 0` on some platforms (Chrome, certain touch devices), producing a delta that can pass `validateDividerOverride` and silently write an override the user never intended. Touch users + devices with gesture takeover were the most exposed.

**Fix:** split the handlers. `handleUp` commits; new `handleCancel` aborts and resets state without writing. Both share a single `finishDrag(commit, up?)` so the cleanup path is identical.

**2. Window-listener leak on unmount.**
The `pointermove/up/cancel` listeners were registered inside the pointer-down handler and only removed on natural pointer-up. If the component unmounted mid-drag (route change, labs flag toggle, etc.), the listeners leaked and would later try to `setDrag` on an unmounted component.

**Fix:** new `dragCleanupRef` captures the listener-removal closure when a drag starts. A top-level `useEffect` cleanup invokes it on unmount; natural drag-end also invokes it. Either path leaves zero listeners.

## Other real items

- **`preventDefault()` + `touch-action: none`** on the handle button — blocks text selection, page scrolling, and OS gesture interpretation during drag. Required for clean touch drag (React's passive touch events can't reliably preventDefault).
- **`DRAG_SNAP_FREE_MM` changed from 1 mm to 0.5 mm** — matches the panel's `ANGLED_DIVIDER_UI_STEP` so canvas free-snap and panel stepper produce values from the same granularity grid. The `decimals` guard in the chip (`snapMm < 1`) now actually fires for free-snap drags (was dead code at 1 mm).
- **`aria-label` now goes through `useTranslation()`** — was a hardcoded English template literal in an accessibility attribute. New keys `binDesigner.angledDividers.handleAriaLabel.start` / `.end`, mirrored across all 8 locales.
- **`getBoundingClientRect` now reads from inner ref.** New `gridCellsRef` points at the flex container holding GridCells, instead of the outer `gridRef` (which includes padding + border). mm-per-pixel now matches the rendered cell coordinate space exactly.
- **Overlay moved INSIDE the flex container** using `inset-0` instead of `inset-2`. Handle dot positions now align precisely with the GridCell boundaries (Greptile noted the prior 8 px offset).
- **Doc comment corrected.** Handles paint ABOVE GhostPreview (CompartmentEditor renders this sibling last), not below as the prior doc claimed.

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` 0 errors
- [x] `pnpm run check:i18n` all 8 locales aligned (1900 keys)
- [x] 2260 bin-designer tests pass (+1 free-snap regression test)
- [ ] Manual: drag a handle, trigger context menu mid-drag → no override committed; reload labs flag mid-drag → no listener leak (devtools); Alt-drag → mm chip shows decimals (e.g. `+5.5 mm`); touch drag → no page scroll

## Pushed back on nothing
All 8 review items were real correctness, security, or contract gaps — no opinion items in this round.