### PR TITLE
feat(bin-designer): angled-dividers polish + flag graduation (PR 4 of 4)

### DIFF
--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -119,11 +119,12 @@ export const FEATURE_FLAGS = [
     name: 'Angled Dividers',
     description:
       'Tilt the dividers between compartments to make wedge-shaped slots — handy for silverware drawers where utensils pack better head-to-toe.',
-    status: 'experimental',
+    status: 'graduated',
     risk: 'medium',
     warning:
-      'Panel UI ships now (numeric mm offsets per divider). Canvas drag handles arrive in the next update. Scoops and label tabs auto-skip compartments touching a tilted divider.',
+      'Scoops, label tabs, slot mode, and floor inserts auto-skip compartments touching a tilted divider.',
     addedAt: '2026-05',
+    graduatedAt: '2026-05',
     requiresRefresh: false,
   },
 ] as const satisfies readonly FeatureFlag[];

--- a/src/features/bin-designer/components/CompartmentEditor/useDividerHandles.test.ts
+++ b/src/features/bin-designer/components/CompartmentEditor/useDividerHandles.test.ts
@@ -48,19 +48,10 @@ describe('useDividerHandles', () => {
     useLabsStore.getState().enableFeature('angled_dividers');
   });
 
-  it('returns no handles when the labs flag is off', () => {
-    useLabsStore.getState().disableFeature('angled_dividers');
-    setCompartments({ cols: 1, rows: 2, cells: [0, 1] });
-    const { result } = renderHook(() =>
-      useDividerHandles({
-        compartments: useDesignerStore.getState().params.compartments,
-        innerW: 80,
-        innerD: 80,
-        canvasRef: fakeCanvas(),
-      })
-    );
-    expect(result.current.handles).toEqual([]);
-  });
+  // Note: prior to graduation the feature was experimental and could be
+  // disabled; that test was removed when `angled_dividers` graduated. The
+  // hook now always honors eligibility (linear grid + interior dividers)
+  // since graduated flags are always enabled.
 
   it('returns no handles for non-linear grids (panel-only in v1)', () => {
     setCompartments({ cols: 2, rows: 2, cells: [0, 1, 2, 3] });
@@ -295,28 +286,57 @@ describe('useDividerHandles', () => {
   });
 
   it('removes window listeners on unmount mid-drag (no leak)', () => {
-    // Regression for the listener-leak fix on #1837: if the component
-    // unmounted mid-drag, window pointer listeners would persist and
-    // later try to setDrag on an unmounted component.
+    // Regression for the listener-leak fix on #1837 — strengthened in
+    // PR 4 by spying on add/removeEventListener so a reintroduced leak
+    // fails the test directly, not via the indirect "no store
+    // mutation" signal alone (React 18 silently suppresses setState
+    // on unmounted components, so that proxy can miss real leaks).
     setCompartments({ cols: 1, rows: 2, cells: [0, 1] });
-    const { result, unmount } = renderHook(() =>
-      useDividerHandles({
-        compartments: useDesignerStore.getState().params.compartments,
-        innerW: 80,
-        innerD: 80,
-        canvasRef: fakeCanvas(),
-      })
-    );
-    pointerDown(result);
-    expect(result.current.drag).not.toBeNull();
-    unmount();
-    // Post-unmount: a window pointer-move/up event must NOT throw or
-    // attempt to update state. We can't directly observe listener
-    // count, so the cleanest check is that the act doesn't surface
-    // errors and the store stays unchanged.
-    expect(() => {
-      window.dispatchEvent(new PointerEvent('pointerup', { clientX: 100, clientY: 150 }));
-    }).not.toThrow();
-    expect(useDesignerStore.getState().params.compartments.dividerOverrides).toBeUndefined();
+    const adds: string[] = [];
+    const removes: string[] = [];
+    const origAdd = window.addEventListener.bind(window);
+    const origRemove = window.removeEventListener.bind(window);
+    window.addEventListener = ((type: string, ...args: unknown[]) => {
+      if (type === 'pointermove' || type === 'pointerup' || type === 'pointercancel') {
+        adds.push(type);
+      }
+
+      return origAdd(type as never, ...(args as any));
+    }) as typeof window.addEventListener;
+    window.removeEventListener = ((type: string, ...args: unknown[]) => {
+      if (type === 'pointermove' || type === 'pointerup' || type === 'pointercancel') {
+        removes.push(type);
+      }
+
+      return origRemove(type as never, ...(args as any));
+    }) as typeof window.removeEventListener;
+    try {
+      const { result, unmount } = renderHook(() =>
+        useDividerHandles({
+          compartments: useDesignerStore.getState().params.compartments,
+          innerW: 80,
+          innerD: 80,
+          canvasRef: fakeCanvas(),
+        })
+      );
+      pointerDown(result);
+      expect(result.current.drag).not.toBeNull();
+      // 3 listeners registered on pointer-down (move, up, cancel).
+      const addsBeforeUnmount = adds.length;
+      expect(addsBeforeUnmount).toBeGreaterThanOrEqual(3);
+      unmount();
+      // The useEffect cleanup must invoke `dragCleanupRef`, which
+      // removes the same 3 listeners. Removes count >= adds count
+      // proves no leak.
+      expect(removes.length).toBeGreaterThanOrEqual(addsBeforeUnmount);
+      // Defense-in-depth: post-unmount events still must not commit.
+      expect(() => {
+        window.dispatchEvent(new PointerEvent('pointerup', { clientX: 100, clientY: 150 }));
+      }).not.toThrow();
+      expect(useDesignerStore.getState().params.compartments.dividerOverrides).toBeUndefined();
+    } finally {
+      window.addEventListener = origAdd;
+      window.removeEventListener = origRemove;
+    }
   });
 });

--- a/src/features/bin-designer/components/CompartmentEditor/useDividerHandles.ts
+++ b/src/features/bin-designer/components/CompartmentEditor/useDividerHandles.ts
@@ -23,6 +23,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useLabsStore } from '@/core/store/labs';
+import { trackEvent } from '@/shared/analytics/posthog/trackEvent';
 import {
   getEligibleDividers,
   validateDividerOverride,
@@ -35,6 +36,16 @@ export const DRAG_SNAP_DEFAULT_MM = 5;
 // panel stepper produce values from the same granularity grid (Greptile
 // flagged the 1 mm-vs-0.5 mm mismatch on PR #1835).
 export const DRAG_SNAP_FREE_MM = 0.5;
+
+/** Captured at pointer-down; the commit path needs these values even after
+ *  the ref gets cleared in cleanup, so we pass it explicitly to
+ *  `computeOffsetMm`. Extracted from the inline `dragOriginRef` shape so
+ *  the ref + function signature can't drift (Copilot flagged on #1839). */
+interface DragOrigin {
+  readonly startClientX: number;
+  readonly startClientY: number;
+  readonly originalOffsetMm: number;
+}
 
 /** One draggable endpoint on the canvas. */
 export interface DividerHandle {
@@ -92,11 +103,12 @@ export function useDividerHandles(opts: UseDividerHandlesOptions): UseDividerHan
   // Pointer-down captured the initial offset and pointer position so move
   // events can compute a delta without re-reading the (possibly mutated)
   // override value.
-  const dragOriginRef = useRef<{
-    startClientX: number;
-    startClientY: number;
-    originalOffsetMm: number;
-  } | null>(null);
+  const dragOriginRef = useRef<DragOrigin | null>(null);
+  // Whether we've already emitted a `divider_tilt_blocked` event during
+  // the current drag — keeps the analytics signal to "at least one
+  // rejection happened during this drag" rather than one event per
+  // pointer move tick (which would saturate the dashboard).
+  const blockedEventEmittedRef = useRef(false);
   // Cleanup hook for the active drag's window listeners. Set when a drag
   // starts, called on natural pointerup/cancel AND on unmount. Prevents
   // listener leaks if the component unmounts mid-drag (route change,
@@ -131,6 +143,7 @@ export function useDividerHandles(opts: UseDividerHandlesOptions): UseDividerHan
           startClientY: e.clientY,
           originalOffsetMm: handle.currentOffsetMm,
         };
+        blockedEventEmittedRef.current = false;
         setDrag({
           divider: handle.divider,
           which: handle.which,
@@ -147,7 +160,7 @@ export function useDividerHandles(opts: UseDividerHandlesOptions): UseDividerHan
         // null after `finishDrag` zeroed it — Copilot caught the
         // regression on PR #1837 (silent broken commits).
         const computeOffsetMm = (
-          origin: { startClientX: number; startClientY: number; originalOffsetMm: number },
+          origin: DragOrigin,
           clientX: number,
           clientY: number,
           altOrShift: boolean
@@ -180,9 +193,21 @@ export function useDividerHandles(opts: UseDividerHandlesOptions): UseDividerHan
           );
           if (!result) return;
           const candidate = buildCandidateOverride(handle, result.offsetMm);
-          const isValid = candidate
-            ? validateDividerOverride(compartments, candidate) === null
-            : false;
+          const validationError = candidate
+            ? validateDividerOverride(compartments, candidate)
+            : 'unknown-compartment';
+          const isValid = validationError === null;
+          // Emit `divider_tilt_blocked` at most ONCE per drag — the move
+          // handler fires at every pointer event, so emitting per-event
+          // would saturate analytics. The first rejection within a drag
+          // is the signal we care about (and includes the reason code).
+          if (!isValid && !blockedEventEmittedRef.current) {
+            blockedEventEmittedRef.current = true;
+            trackEvent('divider_tilt_blocked', {
+              reason: validationError ?? 'unknown',
+              axis: handle.divider.axis,
+            });
+          }
           setDrag({
             divider: handle.divider,
             which: handle.which,
@@ -215,6 +240,12 @@ export function useDividerHandles(opts: UseDividerHandlesOptions): UseDividerHan
                 candidate.offsetStart,
                 candidate.offsetEnd
               );
+              trackEvent('divider_offset_changed', {
+                axis: handle.divider.axis,
+                offset_start_mm: candidate.offsetStart,
+                offset_end_mm: candidate.offsetEnd,
+                source: 'canvas_drag',
+              });
             }
           }
           // Either way the drag is over; the snap-back to the previous

--- a/src/features/bin-designer/components/panel/AngledDividersSection/AngledDividersSection.test.tsx
+++ b/src/features/bin-designer/components/panel/AngledDividersSection/AngledDividersSection.test.tsx
@@ -15,11 +15,9 @@ describe('AngledDividersSection', () => {
     useLabsStore.getState().enableFeature('angled_dividers');
   });
 
-  it('renders nothing when the labs flag is off', () => {
-    useLabsStore.getState().disableFeature('angled_dividers');
-    const { container } = render(<AngledDividersSection />);
-    expect(container.firstChild).toBeNull();
-  });
+  // The "labs flag off" path was removed when `angled_dividers`
+  // graduated to a stable feature (PR 4). Graduated flags are always
+  // enabled, so the section can't be hidden via the Labs drawer.
 
   it('renders the section title when at least one interior divider exists', () => {
     useDesignerStore.setState((s) => ({

--- a/src/features/bin-designer/components/panel/AngledDividersSection/useAngledDividersSection.test.ts
+++ b/src/features/bin-designer/components/panel/AngledDividersSection/useAngledDividersSection.test.ts
@@ -91,12 +91,10 @@ describe('useAngledDividersSection', () => {
     expect(useDesignerStore.getState().params.compartments.dividerOverrides).toBeUndefined();
   });
 
-  it('hides itself when the labs flag is off', () => {
-    useLabsStore.getState().disableFeature('angled_dividers');
-    setCompartments(1, 2, [0, 1]);
-    const { result } = renderHook(() => useAngledDividersSection());
-    expect(result.current.state.flagEnabled).toBe(false);
-  });
+  // The "labs flag off" test was removed when `angled_dividers`
+  // graduated to a stable feature. `flagEnabled` is always true for
+  // graduated flags, so the section's visibility is now driven purely
+  // by eligibility (rows.length > 0).
 
   it('opens on toggleEnabled even when no overrides exist (first-time UX)', () => {
     // Regression test for the catch-22 in PR #1832: FeatureToggle only

--- a/src/features/bin-designer/components/panel/AngledDividersSection/useAngledDividersSection.ts
+++ b/src/features/bin-designer/components/panel/AngledDividersSection/useAngledDividersSection.ts
@@ -3,6 +3,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useTranslation } from '@/i18n';
 import { useLabsStore } from '@/core/store/labs';
+import { trackEvent } from '@/shared/analytics/posthog/trackEvent';
 import { getEligibleDividers } from '@/features/bin-designer/utils/compartments';
 import type { EligibleDivider } from '@/features/bin-designer/utils/compartments';
 
@@ -69,7 +70,16 @@ export function useAngledDividersSection() {
       const clamped = Math.max(-ANGLED_DIVIDER_UI_MAX, Math.min(ANGLED_DIVIDER_UI_MAX, value));
       const nextStart = which === 'start' ? clamped : row.offsetStart;
       const nextEnd = which === 'end' ? clamped : row.offsetEnd;
+      // No-op guard before the analytics emit so a noisy keystroke loop
+      // (StepperControl can fire on hold-arrow) doesn't saturate PostHog.
+      if (nextStart === row.offsetStart && nextEnd === row.offsetEnd) return;
       setDividerOverride(row.compartmentA, row.compartmentB, nextStart, nextEnd);
+      trackEvent('divider_offset_changed', {
+        axis: row.axis,
+        offset_start_mm: nextStart,
+        offset_end_mm: nextEnd,
+        source: 'panel_input',
+      });
     },
     [setDividerOverride]
   );

--- a/src/features/bin-designer/components/panel/InteriorSection/InteriorSection.tsx
+++ b/src/features/bin-designer/components/panel/InteriorSection/InteriorSection.tsx
@@ -26,7 +26,15 @@ export function InteriorSection() {
   const { state, handlers } = useInteriorSection();
   const t = useTranslation();
   const isCustomShape = useDesignerStore((s) => isPartialMask(s.params.cellMask));
+  const hasAngledDividers = useDesignerStore(
+    (s) => (s.params.compartments.dividerOverrides?.length ?? 0) > 0
+  );
   const customShapeReason = t('binDesigner.shape.custom.hint');
+  // Slot mode uses divider slots, not the compartment grid — angled
+  // dividers don't translate to slot-mode geometry yet. Gate the slotted
+  // card while any override exists so the user gets an explanation
+  // instead of silently losing their tilts.
+  const slottedAngledReason = t('binDesigner.angledDividers.slotIncompatible');
 
   return (
     <div className="space-y-2">
@@ -42,6 +50,13 @@ export function InteriorSection() {
         if (isCustomShape && MODES_REQUIRING_RECTANGULAR_SHAPE.has(mode)) {
           return (
             <FeatureGate key={mode} disabled reason={customShapeReason}>
+              {card}
+            </FeatureGate>
+          );
+        }
+        if (mode === 'slotted' && hasAngledDividers) {
+          return (
+            <FeatureGate key={mode} disabled reason={slottedAngledReason}>
               {card}
             </FeatureGate>
           );

--- a/src/features/bin-designer/utils/compartments.test.ts
+++ b/src/features/bin-designer/utils/compartments.test.ts
@@ -16,6 +16,7 @@ import {
   normalizeIdsWithRemap,
   remapCompartmentTexts,
   remapDividerOverrides,
+  rectStraddlesTiltedDivider,
   validateDividerOverride,
   validateDividerOverrides,
   compartmentHasTiltedEdge,
@@ -1224,6 +1225,54 @@ describe('compartments', () => {
       };
       expect(compartmentHasTiltedBackWall(config, 0)).toBe(true);
       expect(compartmentHasTiltedBackWall(config, 1)).toBe(false);
+    });
+
+    it('rectStraddlesTiltedDivider returns false when no overrides exist', () => {
+      const config: CompartmentConfig = {
+        cols: 1,
+        rows: 2,
+        thickness: 1.2,
+        cells: [0, 1],
+      };
+      const rect = { x: -10, y: -10, width: 20, depth: 20 };
+      expect(rectStraddlesTiltedDivider(config, 80, 80, rect)).toBe(false);
+    });
+
+    it('rectStraddlesTiltedDivider flags an insert that crosses a tilted line', () => {
+      const config: CompartmentConfig = {
+        cols: 1,
+        rows: 2,
+        thickness: 1.2,
+        cells: [0, 1],
+        dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 20, offsetEnd: -20 }],
+      };
+      const rect = { x: -15, y: -15, width: 30, depth: 30 };
+      expect(rectStraddlesTiltedDivider(config, 80, 80, rect)).toBe(true);
+    });
+
+    it('rectStraddlesTiltedDivider returns false for inserts safely inside one wedge', () => {
+      const config: CompartmentConfig = {
+        cols: 1,
+        rows: 2,
+        thickness: 1.2,
+        cells: [0, 1],
+        dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 20, offsetEnd: -20 }],
+      };
+      // Tiny insert in the front-right corner, well inside one wedge.
+      const rect = { x: 30, y: -30, width: 5, depth: 5 };
+      expect(rectStraddlesTiltedDivider(config, 80, 80, rect)).toBe(false);
+    });
+
+    it('rectStraddlesTiltedDivider skips zero-offset overrides', () => {
+      const config: CompartmentConfig = {
+        cols: 1,
+        rows: 2,
+        thickness: 1.2,
+        cells: [0, 1],
+        dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 0, offsetEnd: 0 }],
+      };
+      const rect = { x: -15, y: -15, width: 30, depth: 30 };
+      expect(rectStraddlesTiltedDivider(config, 80, 80, rect)).toBe(false);
     });
 
     it('detects a tilted back wall when the tilt is on a non-minCol neighbor', () => {

--- a/src/features/bin-designer/utils/compartments.ts
+++ b/src/features/bin-designer/utils/compartments.ts
@@ -298,6 +298,105 @@ export function getEligibleDividers(config: CompartmentConfig): EligibleDivider[
 }
 
 /**
+ * True when an axis-aligned rectangle (e.g. a floor insert's footprint)
+ * straddles ANY tilted divider segment. Used by `buildInsertCuts` to skip
+ * inserts that would otherwise cross from one wedge compartment into
+ * another — the resulting cavity would punch through a tilted wall and
+ * produce visually broken geometry.
+ *
+ * The check is conservative: it considers each tilted divider's segment
+ * as an infinite line for the cross test (rather than just the segment),
+ * which over-rejects for inserts placed near the end of a segment but
+ * far past its endpoints. That's the right safety vs. flexibility
+ * trade-off for v1 — false positives only suppress, never produce broken
+ * geometry.
+ *
+ * Rectangle coords are interior-frame mm (origin at bin center).
+ */
+export function rectStraddlesTiltedDivider(
+  config: CompartmentConfig,
+  innerW: number,
+  innerD: number,
+  rect: { x: number; y: number; width: number; depth: number }
+): boolean {
+  const overrides = config.dividerOverrides;
+  if (!overrides || overrides.length === 0) return false;
+  const corners: ReadonlyArray<readonly [number, number]> = [
+    [rect.x, rect.y],
+    [rect.x + rect.width, rect.y],
+    [rect.x + rect.width, rect.y + rect.depth],
+    [rect.x, rect.y + rect.depth],
+  ];
+  const { cols, rows, cells } = config;
+  for (const o of overrides) {
+    // Skip overrides where the offset is zero on both ends (no tilt).
+    if (o.offsetStart === 0 && o.offsetEnd === 0) continue;
+    const endpoints = tiltedDividerEndpoints(o, cols, rows, cells, innerW, innerD);
+    if (!endpoints) continue;
+    const { p1, p2 } = endpoints;
+    // Implicit form of the line through p1 → p2: (x - p1.x) * (p2.y -
+    // p1.y) - (y - p1.y) * (p2.x - p1.x). Positive on one side, negative
+    // on the other. If any two corners produce opposite signs the
+    // rectangle straddles the line.
+    let sawPositive = false;
+    let sawNegative = false;
+    for (const [cx, cy] of corners) {
+      const s = (cx - p1.x) * (p2.y - p1.y) - (cy - p1.y) * (p2.x - p1.x);
+      if (s > 0) sawPositive = true;
+      else if (s < 0) sawNegative = true;
+      if (sawPositive && sawNegative) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * World-frame endpoints (mm, origin at bin center) of a tilted divider.
+ * Returns null when the override doesn't correspond to an interior cell
+ * boundary (e.g. after a non-adjacent remap — defense-in-depth).
+ */
+function tiltedDividerEndpoints(
+  override: DividerOverride,
+  cols: number,
+  rows: number,
+  cells: number[],
+  innerW: number,
+  innerD: number
+): { p1: { x: number; y: number }; p2: { x: number; y: number } } | null {
+  // Vertical divider? Look for the pair sharing a col boundary.
+  for (let col = 0; col < cols - 1; col++) {
+    for (let row = 0; row < rows; row++) {
+      const left = cells[row * cols + col];
+      const right = cells[row * cols + (col + 1)];
+      const [a, b] = left < right ? [left, right] : [right, left];
+      if (a === override.compartmentA && b === override.compartmentB) {
+        const xMm = -innerW / 2 + ((col + 1) / cols) * innerW;
+        return {
+          p1: { x: xMm + override.offsetStart, y: -innerD / 2 },
+          p2: { x: xMm + override.offsetEnd, y: innerD / 2 },
+        };
+      }
+    }
+  }
+  // Horizontal divider.
+  for (let row = 0; row < rows - 1; row++) {
+    for (let col = 0; col < cols; col++) {
+      const top = cells[row * cols + col];
+      const bottom = cells[(row + 1) * cols + col];
+      const [a, b] = top < bottom ? [top, bottom] : [bottom, top];
+      if (a === override.compartmentA && b === override.compartmentB) {
+        const yMm = -innerD / 2 + ((row + 1) / rows) * innerD;
+        return {
+          p1: { x: -innerW / 2, y: yMm + override.offsetStart },
+          p2: { x: innerW / 2, y: yMm + override.offsetEnd },
+        };
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * True when the compartment has at least one tilted boundary (i.e. is one
  * end of a `DividerOverride`). Used by features that can't render against
  * non-axis-aligned edges (scoops, label tabs on the tilted side).

--- a/src/features/generation/worker/generators/insertBuilder.ts
+++ b/src/features/generation/worker/generators/insertBuilder.ts
@@ -17,6 +17,7 @@ import {
 } from 'brepjs';
 import type { Shape3D, ValidSolid, Drawing, DisposalScope } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
+import { rectStraddlesTiltedDivider } from '@/shared/types/bin';
 import { sketch } from './meshUtils';
 /**
  * Build the 2D insert profile (Drawing) for a given insert shape.
@@ -46,9 +47,19 @@ function makeInsertProfile(
 }
 /**
  * Build insert cavity cuts.
+ *
+ * `innerW`/`innerD` are needed only when the bin has tilted dividers — the
+ * worker checks if each insert straddles a tilted divider line and skips
+ * any that would otherwise punch through a wedge into the neighboring
+ * compartment. Default `undefined` keeps the legacy callers working.
  */
-export function buildInsertCuts(params: BinParams): Shape3D | null {
+export function buildInsertCuts(
+  params: BinParams,
+  innerW?: number,
+  innerD?: number
+): Shape3D | null {
   if (params.inserts.length === 0) return null;
+  const hasTiltedDividers = (params.compartments.dividerOverrides?.length ?? 0) > 0;
 
   return withScope((scope: DisposalScope): Shape3D | null => {
     const insertShapes: Shape3D[] = [];
@@ -56,6 +67,23 @@ export function buildInsertCuts(params: BinParams): Shape3D | null {
     for (const insert of params.inserts) {
       // Guard: skip inserts with degenerate dimensions that would crash WASM
       if (insert.cutDepth <= 0 || insert.width <= 0 || insert.depth <= 0) continue;
+
+      // Tilted-divider compat: skip inserts whose footprint crosses a
+      // tilted divider line. The check is conservative — a false positive
+      // only suppresses an insert (visible to the user as "missing");
+      // a false negative would punch through the wedge and produce
+      // visually broken geometry.
+      if (hasTiltedDividers && innerW !== undefined && innerD !== undefined) {
+        const rect = {
+          x: insert.x - insert.width / 2,
+          y: insert.y - insert.depth / 2,
+          width: insert.width,
+          depth: insert.depth,
+        };
+        if (rectStraddlesTiltedDivider(params.compartments, innerW, innerD, rect)) {
+          continue;
+        }
+      }
 
       const profile = makeInsertProfile(
         insert.shape,
@@ -88,9 +116,18 @@ export const insertCutsFeature: FeatureBuilder = {
   target: 'cut',
   shouldBuild: (ctx) => ctx.params.inserts.length > 0,
   cacheKey: (ctx) =>
-    compactKey(buildCacheKey('v1', ctx.dimensions.shellKey, stableSerialize(ctx.params.inserts))),
+    compactKey(
+      buildCacheKey(
+        // `v2`: insert-vs-tilted-divider skip means dividerOverrides
+        // affects which inserts render. Cache namespace bumped.
+        'v2',
+        ctx.dimensions.shellKey,
+        stableSerialize(ctx.params.inserts),
+        stableSerialize(ctx.params.compartments.dividerOverrides ?? [])
+      )
+    ),
   build: (ctx) => {
-    const result = buildInsertCuts(ctx.params);
+    const result = buildInsertCuts(ctx.params, ctx.dimensions.innerW, ctx.dimensions.innerD);
     return result ? [result] : null;
   },
 };

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -89,6 +89,7 @@
   "binDesigner.angledDividers.resetRow": "Trennwand zurücksetzen",
   "binDesigner.angledDividers.handleAriaLabel.start": "Startpunkt der Trennwand zwischen Fach {a} und Fach {b} ziehen",
   "binDesigner.angledDividers.handleAriaLabel.end": "Endpunkt der Trennwand zwischen Fach {a} und Fach {b} ziehen",
+  "binDesigner.angledDividers.slotIncompatible": "Slots werden auf schrägen Trennwänden noch nicht unterstützt — kommt in v2.",
   "binDesigner.compartmentNumberLabel": "Fach {n}",
   "binDesigner.textMode": "Stil",
   "binDesigner.textMode.engrave": "Gravieren",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1189,6 +1189,7 @@
   "binDesigner.angledDividers.resetRow": "Reset divider to straight",
   "binDesigner.angledDividers.handleAriaLabel.start": "Drag start endpoint of divider between Comp {a} and Comp {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Drag end endpoint of divider between Comp {a} and Comp {b}",
+  "binDesigner.angledDividers.slotIncompatible": "Slots aren't supported on angled dividers — coming in v2.",
   "binDesigner.compartmentNumberLabel": "Comp. {n}",
   "binDesigner.textMode": "Style",
   "binDesigner.textMode.engrave": "Engrave",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1390,6 +1390,8 @@ const en: Record<string, string> = {
     'Drag start endpoint of divider between Comp {a} and Comp {b}',
   'binDesigner.angledDividers.handleAriaLabel.end':
     'Drag end endpoint of divider between Comp {a} and Comp {b}',
+  'binDesigner.angledDividers.slotIncompatible':
+    "Slots aren't supported on angled dividers — coming in v2.",
   'binDesigner.compartmentNumberLabel': 'Comp. {n}',
   'binDesigner.textMode': 'Style',
   'binDesigner.textMode.engrave': 'Engrave',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -89,6 +89,7 @@
   "binDesigner.angledDividers.resetRow": "Restablecer divisor",
   "binDesigner.angledDividers.handleAriaLabel.start": "Arrastrar punto inicial del divisor entre Compart. {a} y Compart. {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Arrastrar punto final del divisor entre Compart. {a} y Compart. {b}",
+  "binDesigner.angledDividers.slotIncompatible": "Las ranuras no son compatibles con divisores inclinados — próximamente en v2.",
   "binDesigner.compartmentNumberLabel": "Compart. {n}",
   "binDesigner.textMode": "Estilo",
   "binDesigner.textMode.engrave": "Grabado",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -89,6 +89,7 @@
   "binDesigner.angledDividers.resetRow": "Réinitialiser le séparateur",
   "binDesigner.angledDividers.handleAriaLabel.start": "Faire glisser le point de départ du séparateur entre Comp. {a} et Comp. {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Faire glisser le point final du séparateur entre Comp. {a} et Comp. {b}",
+  "binDesigner.angledDividers.slotIncompatible": "Les fentes ne sont pas compatibles avec les séparateurs inclinés — disponible en v2.",
   "binDesigner.compartmentNumberLabel": "Compart. {n}",
   "binDesigner.textMode": "Type",
   "binDesigner.textMode.engrave": "Gravure",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -89,6 +89,7 @@
   "binDesigner.angledDividers.resetRow": "Nullstill skillevegg",
   "binDesigner.angledDividers.handleAriaLabel.start": "Dra startpunktet til skilleveggen mellom Rom {a} og Rom {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Dra sluttpunktet til skilleveggen mellom Rom {a} og Rom {b}",
+  "binDesigner.angledDividers.slotIncompatible": "Spor støttes ikke for skrå skillevegger ennå — kommer i v2.",
   "binDesigner.compartmentNumberLabel": "Rom {n}",
   "binDesigner.textMode": "Stil",
   "binDesigner.textMode.engrave": "Graver",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -89,6 +89,7 @@
   "binDesigner.angledDividers.resetRow": "Scheiding herstellen",
   "binDesigner.angledDividers.handleAriaLabel.start": "Sleep het beginpunt van de scheiding tussen Vak {a} en Vak {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Sleep het eindpunt van de scheiding tussen Vak {a} en Vak {b}",
+  "binDesigner.angledDividers.slotIncompatible": "Sleuven worden nog niet ondersteund bij schuine scheidingen — beschikbaar in v2.",
   "binDesigner.compartmentNumberLabel": "Vak {n}",
   "binDesigner.textMode": "Stijl",
   "binDesigner.textMode.engrave": "Graveren",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -89,6 +89,7 @@
   "binDesigner.angledDividers.resetRow": "Redefinir divisória",
   "binDesigner.angledDividers.handleAriaLabel.start": "Arrastar ponto inicial da divisória entre Compart. {a} e Compart. {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Arrastar ponto final da divisória entre Compart. {a} e Compart. {b}",
+  "binDesigner.angledDividers.slotIncompatible": "Encaixes ainda não são compatíveis com divisórias inclinadas — em breve na v2.",
   "binDesigner.compartmentNumberLabel": "Compart. {n}",
   "binDesigner.textMode": "Estilo",
   "binDesigner.textMode.engrave": "Gravar",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1130,6 +1130,7 @@
   "binDesigner.angledDividers.resetRow": "Återställ avdelare",
   "binDesigner.angledDividers.handleAriaLabel.start": "Dra startpunkten för avdelaren mellan Fack {a} och Fack {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Dra slutpunkten för avdelaren mellan Fack {a} och Fack {b}",
+  "binDesigner.angledDividers.slotIncompatible": "Spår stöds inte på lutade avdelare ännu — kommer i v2.",
   "binDesigner.compartmentNumberLabel": "Fack {n}",
   "binDesigner.textMode": "Stil",
   "binDesigner.textMode.engrave": "Gravera",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1130,6 +1130,7 @@
   "binDesigner.angledDividers.resetRow": "Скинути перегородку",
   "binDesigner.angledDividers.handleAriaLabel.start": "Перетягніть початкову точку перегородки між Відсік {a} та Відсік {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Перетягніть кінцеву точку перегородки між Відсік {a} та Відсік {b}",
+  "binDesigner.angledDividers.slotIncompatible": "Пази поки не підтримуються для нахилених перегородок — у версії 2.",
   "binDesigner.compartmentNumberLabel": "Відсік {n}",
   "binDesigner.textMode": "Стиль",
   "binDesigner.textMode.engrave": "Гравірувати",

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -76,6 +76,7 @@ export {
 export {
   compartmentHasTiltedEdge,
   compartmentHasTiltedBackWall,
+  rectStraddlesTiltedDivider,
 } from '@/features/bin-designer/utils/compartments';
 export type {
   LidCompatibilityIssue,


### PR DESCRIPTION
## Summary

Final PR in the angled-dividers track (issue #1822). Ships the remaining compat items, analytics, and graduates the labs flag from `experimental` to `graduated` — the feature is now always-on for everyone.

## What ships

**Labs flag graduated.** `angled_dividers` moves from `experimental` to `graduated`. No Labs toggle required. Warning text trimmed to just the compat note: "Scoops, label tabs, slot mode, and floor inserts auto-skip compartments touching a tilted divider."

**Floor insert intersection skip.** Inserts whose footprint straddles a tilted divider line are silently suppressed at build time. Without this, an insert that crosses a wedge would punch through the tilted wall into the adjacent compartment, producing visually broken geometry. New `rectStraddlesTiltedDivider()` helper runs a 4-corner line-side test against each tilted divider. `insertCutsFeature` cache key bumped v1→v2 to include `dividerOverrides`.

**Slot mode gating.** When any divider has an override, the `InteriorSection`'s "Slotted" card is disabled with a tooltip: *"Slots aren't supported on angled dividers — coming in v2."* New i18n key `binDesigner.angledDividers.slotIncompatible` mirrored across all 8 locales. Standard mode + custom-shape (`cellMask`) modes unaffected.

**PostHog events.**
- `divider_offset_changed` — emitted per commit with `source` (`canvas_drag` | `panel_input`), `axis`, and both offsets. Lets us see which UX path users prefer + typical offset magnitudes.
- `divider_tilt_blocked` — emitted at most ONCE per drag when the user holds a handle at an invalid position. Includes the validator's error code (`reason`) so we can see which constraints users hit. Rate-limited to first-rejection-per-drag so a long invalid drag doesn't saturate analytics.

## #1839 review carryovers rolled in
- Extracted `DragOrigin` interface to share between the ref and the `computeOffsetMm` signature (Copilot — prevents the two from drifting).
- Strengthened the listener-leak regression test with `addEventListener` / `removeEventListener` spies. A reintroduced leak now fails the test directly, not via the indirect "no store mutation" proxy that React 18 can mask (Copilot).

## Scope adjustment

Wall-cutout suppression on interior tilted dividers was investigated and determined to be a **phantom requirement** — wall cutouts in this codebase apply to the bin's OUTER walls only (`params.walls.{front,back,left,right}`), not interior dividers. There's nothing to suppress.

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` 0 errors
- [x] `pnpm run check:i18n` green (1901 keys per locale)
- [x] 4 new tests for `rectStraddlesTiltedDivider` covering no-overrides, crossing, safely-inside, and zero-offset-ignore cases
- [x] Improved listener-leak test now spies on add/removeEventListener
- [x] Pre-graduation "labs flag off" tests removed (graduated flags are always enabled)
- [x] 2264 bin-designer tests pass
- [ ] Manual: place a floor insert in a 1×2 layout, tilt the divider through it → insert disappears (suppressed); tilt the divider away → insert reappears
- [ ] Manual: in standard mode with a tilted divider, click the Slotted card → disabled, tooltip shown; clear the override → card re-enabled
- [ ] Manual: Labs drawer no longer shows the Angled Dividers toggle (graduated features aren't in the toggleable list)

## Track summary

This closes the angled-dividers feature track (issue #1822, 13 PRs over the brainstorm → ship → review → polish cycle):

| Layer | PRs |
|---|---|
| Foundation (schema, geometry, validators) | #1827, #1829, #1831 |
| Panel UI | #1832, #1834 |
| Canvas drag handles | #1835, #1837, #1839 |
| Polish + graduation | **#1841** (this PR) |