### PR TITLE
fix(bin-designer): #1840 review — partial-span tilt coverage + 3 smaller

### DIFF
--- a/src/features/bin-designer/components/CompartmentEditor/useDividerHandles.ts
+++ b/src/features/bin-designer/components/CompartmentEditor/useDividerHandles.ts
@@ -201,10 +201,14 @@ export function useDividerHandles(opts: UseDividerHandlesOptions): UseDividerHan
           // handler fires at every pointer event, so emitting per-event
           // would saturate analytics. The first rejection within a drag
           // is the signal we care about (and includes the reason code).
-          if (!isValid && !blockedEventEmittedRef.current) {
+          if (!isValid && validationError !== null && !blockedEventEmittedRef.current) {
+            // `validationError` is non-null whenever `isValid` is false
+            // (the two are derived from the same `validateDividerOverride`
+            // call). Belt-and-suspenders null check makes the invariant
+            // explicit so future refactors can't silently emit `'unknown'`.
             blockedEventEmittedRef.current = true;
             trackEvent('divider_tilt_blocked', {
-              reason: validationError ?? 'unknown',
+              reason: validationError,
               axis: handle.divider.axis,
             });
           }

--- a/src/features/bin-designer/components/panel/AngledDividersSection/useAngledDividersSection.ts
+++ b/src/features/bin-designer/components/panel/AngledDividersSection/useAngledDividersSection.ts
@@ -19,10 +19,11 @@ export interface AngledDividerRow extends EligibleDivider {
 }
 
 export function useAngledDividersSection() {
-  const { compartments, setDividerOverride, removeDividerOverride, clearDividerOverrides } =
+  const { compartments, style, setDividerOverride, removeDividerOverride, clearDividerOverrides } =
     useDesignerStore(
       useShallow((s) => ({
         compartments: s.params.compartments,
+        style: s.params.style,
         setDividerOverride: s.setDividerOverride,
         removeDividerOverride: s.removeDividerOverride,
         clearDividerOverrides: s.clearDividerOverrides,
@@ -105,9 +106,19 @@ export function useAngledDividersSection() {
     }
   }, [isOpen, hasAnyOverride, clearDividerOverrides]);
 
-  const isUnavailable = !hasEligibleDividers;
+  // `standard` is the only interior style that uses the compartment-grid
+  // path. Slotted (divider slots) and solid (cutouts) bypass it entirely
+  // and dividerOverrides would have no effect — hide the section so
+  // users in those modes don't see a knob that does nothing. Closes the
+  // one-directional gap Greptile flagged on #1840 (the reverse direction
+  // — slotted-mode-already-set then add an override — was previously
+  // unguarded).
+  const styleSupportsOverrides = style === 'standard';
+  const isUnavailable = !styleSupportsOverrides || !hasEligibleDividers;
   const disabledReason = isUnavailable
-    ? t('binDesigner.angledDividers.unavailableNoBoundary')
+    ? styleSupportsOverrides
+      ? t('binDesigner.angledDividers.unavailableNoBoundary')
+      : t('binDesigner.angledDividers.unavailableNonStandardMode')
     : undefined;
 
   const summary = useMemo(() => {

--- a/src/features/bin-designer/utils/compartments.test.ts
+++ b/src/features/bin-designer/utils/compartments.test.ts
@@ -1263,6 +1263,36 @@ describe('compartments', () => {
       expect(rectStraddlesTiltedDivider(config, 80, 80, rect)).toBe(false);
     });
 
+    it('rectStraddlesTiltedDivider uses partial-span endpoints for non-linear grids', () => {
+      // Regression test for the bug Copilot caught on PR #1840:
+      // `tiltedDividerEndpoints` was using full-bin endpoints (y: ±innerD/2)
+      // for ALL dividers, including partial-span ones. For a 2×2 grid
+      // with cells [0,1,2,3], the override on (0,1) applies ONLY to row
+      // 0's segment of the col-1 boundary — y range [-innerD/2,0], not
+      // the full bin depth.
+      //
+      // An insert at the BOTTOM of the bin (in row 1's range, where the
+      // (0,1) divider doesn't exist) shouldn't be flagged as straddling
+      // the (0,1) tilt. With the bug, the line was extrapolated to the
+      // full bin and the bottom insert was incorrectly flagged.
+      const config: CompartmentConfig = {
+        cols: 2,
+        rows: 2,
+        thickness: 1.2,
+        cells: [0, 1, 2, 3],
+        dividerOverrides: [
+          // Tilt only the top-row half of the vertical boundary.
+          { compartmentA: 0, compartmentB: 1, offsetStart: 15, offsetEnd: -15 },
+        ],
+      };
+      // Insert in row-1's range (y > 0), well away from the row-0 segment.
+      const bottomInsert = { x: -5, y: 25, width: 10, depth: 10 };
+      expect(rectStraddlesTiltedDivider(config, 80, 80, bottomInsert)).toBe(false);
+      // Insert in row-0's range (y < 0), straddling the tilt — should flag.
+      const topInsert = { x: -10, y: -30, width: 20, depth: 20 };
+      expect(rectStraddlesTiltedDivider(config, 80, 80, topInsert)).toBe(true);
+    });
+
     it('rectStraddlesTiltedDivider skips zero-offset overrides', () => {
       const config: CompartmentConfig = {
         cols: 1,

--- a/src/features/bin-designer/utils/compartments.ts
+++ b/src/features/bin-designer/utils/compartments.ts
@@ -363,34 +363,60 @@ function tiltedDividerEndpoints(
   innerW: number,
   innerD: number
 ): { p1: { x: number; y: number }; p2: { x: number; y: number } } | null {
-  // Vertical divider? Look for the pair sharing a col boundary.
+  // Vertical divider: find the contiguous run of rows where the pair
+  // (left=a, right=b) or (left=b, right=a) holds at the same col
+  // boundary. The worker's `findPairAwareRuns` derives segment endpoints
+  // from that run, NOT from the bin walls — so partial-span dividers
+  // (e.g. a 2×2 where override applies to only the top half of a column
+  // boundary) need the segment's true row-range, not the full bin depth.
+  // Greptile flagged the bug on PR #1840: full-span endpoints can make
+  // `rectStraddlesTiltedDivider` miss inserts that actually cross a
+  // partial-span tilted segment.
   for (let col = 0; col < cols - 1; col++) {
+    let runStart: number | null = null;
+    let runEnd: number | null = null;
     for (let row = 0; row < rows; row++) {
       const left = cells[row * cols + col];
       const right = cells[row * cols + (col + 1)];
       const [a, b] = left < right ? [left, right] : [right, left];
-      if (a === override.compartmentA && b === override.compartmentB) {
-        const xMm = -innerW / 2 + ((col + 1) / cols) * innerW;
-        return {
-          p1: { x: xMm + override.offsetStart, y: -innerD / 2 },
-          p2: { x: xMm + override.offsetEnd, y: innerD / 2 },
-        };
-      }
+      const matches = a === override.compartmentA && b === override.compartmentB;
+      if (matches && runStart === null) runStart = row;
+      if (matches) runEnd = row + 1;
+      else if (runStart !== null) break; // run ended; non-contiguous would be invalid
+    }
+    if (runStart !== null && runEnd !== null) {
+      const xMm = -innerW / 2 + ((col + 1) / cols) * innerW;
+      const cellD = innerD / rows;
+      const yStart = -innerD / 2 + runStart * cellD;
+      const yEnd = -innerD / 2 + runEnd * cellD;
+      return {
+        p1: { x: xMm + override.offsetStart, y: yStart },
+        p2: { x: xMm + override.offsetEnd, y: yEnd },
+      };
     }
   }
-  // Horizontal divider.
+  // Horizontal divider: symmetric — partial-span across a column range.
   for (let row = 0; row < rows - 1; row++) {
+    let runStart: number | null = null;
+    let runEnd: number | null = null;
     for (let col = 0; col < cols; col++) {
       const top = cells[row * cols + col];
       const bottom = cells[(row + 1) * cols + col];
       const [a, b] = top < bottom ? [top, bottom] : [bottom, top];
-      if (a === override.compartmentA && b === override.compartmentB) {
-        const yMm = -innerD / 2 + ((row + 1) / rows) * innerD;
-        return {
-          p1: { x: -innerW / 2, y: yMm + override.offsetStart },
-          p2: { x: innerW / 2, y: yMm + override.offsetEnd },
-        };
-      }
+      const matches = a === override.compartmentA && b === override.compartmentB;
+      if (matches && runStart === null) runStart = col;
+      if (matches) runEnd = col + 1;
+      else if (runStart !== null) break;
+    }
+    if (runStart !== null && runEnd !== null) {
+      const yMm = -innerD / 2 + ((row + 1) / rows) * innerD;
+      const cellW = innerW / cols;
+      const xStart = -innerW / 2 + runStart * cellW;
+      const xEnd = -innerW / 2 + runEnd * cellW;
+      return {
+        p1: { x: xStart, y: yMm + override.offsetStart },
+        p2: { x: xEnd, y: yMm + override.offsetEnd },
+      };
     }
   }
   return null;

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -90,6 +90,7 @@
   "binDesigner.angledDividers.handleAriaLabel.start": "Startpunkt der Trennwand zwischen Fach {a} und Fach {b} ziehen",
   "binDesigner.angledDividers.handleAriaLabel.end": "Endpunkt der Trennwand zwischen Fach {a} und Fach {b} ziehen",
   "binDesigner.angledDividers.slotIncompatible": "Slots werden auf schrägen Trennwänden noch nicht unterstützt — kommt in v2.",
+  "binDesigner.angledDividers.unavailableNonStandardMode": "Schräge Trennwände gelten nur für das Standard-Fachraster.",
   "binDesigner.compartmentNumberLabel": "Fach {n}",
   "binDesigner.textMode": "Stil",
   "binDesigner.textMode.engrave": "Gravieren",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1190,6 +1190,7 @@
   "binDesigner.angledDividers.handleAriaLabel.start": "Drag start endpoint of divider between Comp {a} and Comp {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Drag end endpoint of divider between Comp {a} and Comp {b}",
   "binDesigner.angledDividers.slotIncompatible": "Slots aren't supported on angled dividers — coming in v2.",
+  "binDesigner.angledDividers.unavailableNonStandardMode": "Angled dividers only apply to the standard compartment grid.",
   "binDesigner.compartmentNumberLabel": "Comp. {n}",
   "binDesigner.textMode": "Style",
   "binDesigner.textMode.engrave": "Engrave",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1392,6 +1392,8 @@ const en: Record<string, string> = {
     'Drag end endpoint of divider between Comp {a} and Comp {b}',
   'binDesigner.angledDividers.slotIncompatible':
     "Slots aren't supported on angled dividers — coming in v2.",
+  'binDesigner.angledDividers.unavailableNonStandardMode':
+    'Angled dividers only apply to the standard compartment grid.',
   'binDesigner.compartmentNumberLabel': 'Comp. {n}',
   'binDesigner.textMode': 'Style',
   'binDesigner.textMode.engrave': 'Engrave',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -90,6 +90,7 @@
   "binDesigner.angledDividers.handleAriaLabel.start": "Arrastrar punto inicial del divisor entre Compart. {a} y Compart. {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Arrastrar punto final del divisor entre Compart. {a} y Compart. {b}",
   "binDesigner.angledDividers.slotIncompatible": "Las ranuras no son compatibles con divisores inclinados — próximamente en v2.",
+  "binDesigner.angledDividers.unavailableNonStandardMode": "Los divisores inclinados solo se aplican a la cuadrícula estándar de compartimentos.",
   "binDesigner.compartmentNumberLabel": "Compart. {n}",
   "binDesigner.textMode": "Estilo",
   "binDesigner.textMode.engrave": "Grabado",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -90,6 +90,7 @@
   "binDesigner.angledDividers.handleAriaLabel.start": "Faire glisser le point de départ du séparateur entre Comp. {a} et Comp. {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Faire glisser le point final du séparateur entre Comp. {a} et Comp. {b}",
   "binDesigner.angledDividers.slotIncompatible": "Les fentes ne sont pas compatibles avec les séparateurs inclinés — disponible en v2.",
+  "binDesigner.angledDividers.unavailableNonStandardMode": "Les séparateurs inclinés ne s'appliquent qu'à la grille standard de compartiments.",
   "binDesigner.compartmentNumberLabel": "Compart. {n}",
   "binDesigner.textMode": "Type",
   "binDesigner.textMode.engrave": "Gravure",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -90,6 +90,7 @@
   "binDesigner.angledDividers.handleAriaLabel.start": "Dra startpunktet til skilleveggen mellom Rom {a} og Rom {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Dra sluttpunktet til skilleveggen mellom Rom {a} og Rom {b}",
   "binDesigner.angledDividers.slotIncompatible": "Spor støttes ikke for skrå skillevegger ennå — kommer i v2.",
+  "binDesigner.angledDividers.unavailableNonStandardMode": "Skrå skillevegger gjelder bare for det standard rutenettet for rom.",
   "binDesigner.compartmentNumberLabel": "Rom {n}",
   "binDesigner.textMode": "Stil",
   "binDesigner.textMode.engrave": "Graver",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -90,6 +90,7 @@
   "binDesigner.angledDividers.handleAriaLabel.start": "Sleep het beginpunt van de scheiding tussen Vak {a} en Vak {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Sleep het eindpunt van de scheiding tussen Vak {a} en Vak {b}",
   "binDesigner.angledDividers.slotIncompatible": "Sleuven worden nog niet ondersteund bij schuine scheidingen — beschikbaar in v2.",
+  "binDesigner.angledDividers.unavailableNonStandardMode": "Schuine scheidingen gelden alleen voor het standaard vakkenraster.",
   "binDesigner.compartmentNumberLabel": "Vak {n}",
   "binDesigner.textMode": "Stijl",
   "binDesigner.textMode.engrave": "Graveren",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -90,6 +90,7 @@
   "binDesigner.angledDividers.handleAriaLabel.start": "Arrastar ponto inicial da divisória entre Compart. {a} e Compart. {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Arrastar ponto final da divisória entre Compart. {a} e Compart. {b}",
   "binDesigner.angledDividers.slotIncompatible": "Encaixes ainda não são compatíveis com divisórias inclinadas — em breve na v2.",
+  "binDesigner.angledDividers.unavailableNonStandardMode": "Divisórias inclinadas se aplicam apenas à grade padrão de compartimentos.",
   "binDesigner.compartmentNumberLabel": "Compart. {n}",
   "binDesigner.textMode": "Estilo",
   "binDesigner.textMode.engrave": "Gravar",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1131,6 +1131,7 @@
   "binDesigner.angledDividers.handleAriaLabel.start": "Dra startpunkten för avdelaren mellan Fack {a} och Fack {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Dra slutpunkten för avdelaren mellan Fack {a} och Fack {b}",
   "binDesigner.angledDividers.slotIncompatible": "Spår stöds inte på lutade avdelare ännu — kommer i v2.",
+  "binDesigner.angledDividers.unavailableNonStandardMode": "Lutade avdelare gäller endast standardrutnätet för fack.",
   "binDesigner.compartmentNumberLabel": "Fack {n}",
   "binDesigner.textMode": "Stil",
   "binDesigner.textMode.engrave": "Gravera",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1131,6 +1131,7 @@
   "binDesigner.angledDividers.handleAriaLabel.start": "Перетягніть початкову точку перегородки між Відсік {a} та Відсік {b}",
   "binDesigner.angledDividers.handleAriaLabel.end": "Перетягніть кінцеву точку перегородки між Відсік {a} та Відсік {b}",
   "binDesigner.angledDividers.slotIncompatible": "Пази поки не підтримуються для нахилених перегородок — у версії 2.",
+  "binDesigner.angledDividers.unavailableNonStandardMode": "Нахилені перегородки застосовуються лише до стандартної сітки відсіків.",
   "binDesigner.compartmentNumberLabel": "Відсік {n}",
   "binDesigner.textMode": "Стиль",
   "binDesigner.textMode.engrave": "Гравірувати",


### PR DESCRIPTION
## Summary

Greptile gave #1840 a 3/5. **One real correctness bug** + 3 smaller items. All addressed.

## Real bug — `tiltedDividerEndpoints` assumed full-span dividers

The helper computed line endpoints at the bin walls (y: ±innerD/2 or x: ±innerW/2) for ALL dividers. For **partial-span dividers in non-linear grids** (e.g. a 2×2 with cells `[0,1,2,3]` where the override on (0,1) applies only to row 0's segment of the col-1 boundary), the actual segment runs from y=0 to y=innerD/2 — not the full bin depth. Using the wrong endpoints changed the line slope and could make `rectStraddlesTiltedDivider` return FALSE when an insert actually crossed a tilted partial-span segment, **reintroducing the "insert punches through wedge wall" geometry break that this helper was meant to prevent**.

Multi-divider layouts (only reachable via panel + direct JSON since the canvas restricts to linear grids) were the exposed path. Most users with the silverware-drawer use case (1×2 or 2×1) wouldn't hit it; users building 2×2 or larger grids with overrides would.

**Fix:** derive the actual segment span from the cells grid. Walk the col/row boundary and find the contiguous run where (left=a, right=b) or (top=a, bottom=b) holds. Use that range's endpoints. Matches the worker's `findPairAwareRuns` from #1829 so the suppression check and the actual rendered geometry can't disagree.

Added a 2×2 regression test that would have caught the bug.

## Slotted-mode blind spot (Greptile medium)

`InteriorSection` only gated the *select-slotted-when-angled* direction. The reverse (already in slotted, then add an override) was unguarded — the panel section would happily render in slotted mode where the field has no effect, letting users tilt knobs that do nothing.

**Fix:** `useAngledDividersSection` now gates on `style === 'standard'`. Non-standard modes (slotted, solid) report `isUnavailable` with a specific reason. The InteriorSection gate on the slotted card remains for the *create* direction.

## Dead-code fallback (Greptile P2)

`reason: validationError ?? 'unknown'` — `validationError` is always non-null when `isValid` is false (they're derived from the same call), so the fallback was unreachable. Replaced with an explicit `validationError !== null` guard so the invariant is checked AND a future refactor that violates it crashes loudly instead of silently emitting `'unknown'`.

## Test coverage gap (Copilot)

The `rectStraddlesTiltedDivider` tests only covered 1×2 full-span cases. Added a 2×2 partial-span regression that hits both the new bug fix and the original full-span path.

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` 0 errors
- [x] `pnpm run check:i18n` green (1902 keys per locale)
- [x] 117 unit tests pass (1 new partial-span regression)
- [x] 2265 bin-designer tests pass

## Pushed back on nothing
All 4 review items were real — one correctness bug + 3 smaller-but-real gaps.