### PR TITLE
test(bin-designer): #1842 review — load-bearing partial-span + slotted regression coverage (FINAL)

### DIFF
--- a/src/features/bin-designer/components/panel/AngledDividersSection/useAngledDividersSection.test.ts
+++ b/src/features/bin-designer/components/panel/AngledDividersSection/useAngledDividersSection.test.ts
@@ -167,4 +167,36 @@ describe('useAngledDividersSection', () => {
     expect(result.current.state.isUnavailable).toBe(true);
     expect(result.current.state.isOpen).toBe(false);
   });
+
+  it('reports isUnavailable with the non-standard-mode reason for slotted bins', () => {
+    // Greptile flagged on #1840 that the slotted-mode blind spot let
+    // users tilt knobs that did nothing once already in slotted mode.
+    // The fix gates `useAngledDividersSection` on style==='standard';
+    // this test prevents regression.
+    setCompartments(1, 2, [0, 1]);
+    useDesignerStore.setState((s) => ({ params: { ...s.params, style: 'slotted' } }));
+    const { result } = renderHook(() => useAngledDividersSection());
+    expect(result.current.state.isUnavailable).toBe(true);
+    // Translation renders to English here; assert against the actual
+    // string so we're testing the right branch fired (the
+    // `unavailableNoBoundary` branch would say "interior dividers"
+    // instead).
+    expect(result.current.meta.disabledReason).toContain('standard compartment grid');
+  });
+
+  it('reports isUnavailable for solid (cutout) bins too', () => {
+    setCompartments(1, 2, [0, 1]);
+    useDesignerStore.setState((s) => ({ params: { ...s.params, style: 'solid' } }));
+    const { result } = renderHook(() => useAngledDividersSection());
+    expect(result.current.state.isUnavailable).toBe(true);
+  });
+
+  it('reports isAvailable for standard-mode bins with eligible dividers', () => {
+    // Sanity check that the new style gate doesn't accidentally
+    // suppress the standard-mode path.
+    setCompartments(1, 2, [0, 1]);
+    const { result } = renderHook(() => useAngledDividersSection());
+    expect(result.current.state.isUnavailable).toBe(false);
+    expect(result.current.meta.disabledReason).toBeUndefined();
+  });
 });

--- a/src/features/bin-designer/utils/compartments.test.ts
+++ b/src/features/bin-designer/utils/compartments.test.ts
@@ -1264,17 +1264,24 @@ describe('compartments', () => {
     });
 
     it('rectStraddlesTiltedDivider uses partial-span endpoints for non-linear grids', () => {
-      // Regression test for the bug Copilot caught on PR #1840:
+      // Regression for the bug Copilot caught on PR #1840:
       // `tiltedDividerEndpoints` was using full-bin endpoints (y: ±innerD/2)
       // for ALL dividers, including partial-span ones. For a 2×2 grid
       // with cells [0,1,2,3], the override on (0,1) applies ONLY to row
-      // 0's segment of the col-1 boundary — y range [-innerD/2,0], not
-      // the full bin depth.
+      // 0's segment — y range [-innerD/2, 0], not the full bin.
       //
-      // An insert at the BOTTOM of the bin (in row 1's range, where the
-      // (0,1) divider doesn't exist) shouldn't be flagged as straddling
-      // the (0,1) tilt. With the bug, the line was extrapolated to the
-      // full bin and the bottom insert was incorrectly flagged.
+      // CRITICAL: this test must FAIL with the pre-fix code AND PASS
+      // with the post-fix code. The first version of this test (PR
+      // #1842) chose insert positions that produced the same outcome
+      // under both code paths — passing trivially. The positions below
+      // were derived from the actual line geometry:
+      //   - Old full-span line: from (15, -40) to (-15, 40), slope
+      //     -3/8 in y/x. At y=20, line x = -7.5.
+      //   - New partial-span line: from (15, -40) to (-15, 0). At y=20
+      //     (extrapolated), line x = -30.
+      // An insert at x = [-10, 0], y = [20, 25] crosses the old line
+      // (corners on both sides of x=-7.5..-9.375) but sits entirely to
+      // the right of the new line (corners all at x > -30).
       const config: CompartmentConfig = {
         cols: 2,
         rows: 2,
@@ -1285,12 +1292,15 @@ describe('compartments', () => {
           { compartmentA: 0, compartmentB: 1, offsetStart: 15, offsetEnd: -15 },
         ],
       };
-      // Insert in row-1's range (y > 0), well away from the row-0 segment.
-      const bottomInsert = { x: -5, y: 25, width: 10, depth: 10 };
-      expect(rectStraddlesTiltedDivider(config, 80, 80, bottomInsert)).toBe(false);
-      // Insert in row-0's range (y < 0), straddling the tilt — should flag.
-      const topInsert = { x: -10, y: -30, width: 20, depth: 20 };
-      expect(rectStraddlesTiltedDivider(config, 80, 80, topInsert)).toBe(true);
+      // Insert at (x=-10..0, y=20..25): straddles the old extrapolated
+      // line, sits cleanly on one side of the post-fix partial-span line.
+      const partialSpanInsert = { x: -10, y: 20, width: 10, depth: 5 };
+      expect(rectStraddlesTiltedDivider(config, 80, 80, partialSpanInsert)).toBe(false);
+      // Insert in row-0's range that genuinely crosses the partial-span
+      // line — must straddle in both old and new code. Sanity check
+      // that the helper still catches real intersections.
+      const inRangeInsert = { x: -10, y: -35, width: 20, depth: 10 };
+      expect(rectStraddlesTiltedDivider(config, 80, 80, inRangeInsert)).toBe(true);
     });
 
     it('rectStraddlesTiltedDivider skips zero-offset overrides', () => {


### PR DESCRIPTION
## Summary

**Final PR in the angled-dividers track (issue #1822).** Greptile 4/5 on #1842 with 2 real test-quality items; this PR addresses both. Per user direction this is the last PR regardless of further review.

## Items

**1. Load-bearing partial-span regression test.**
The 2×2 partial-span test I added in #1842 chose insert positions that produced the same outcome under BOTH pre-fix and post-fix code paths — the test passed regardless of whether the fix was present. Greptile + Copilot both correctly flagged it as not guarding the reported bug.

Recalculated positions from the actual line geometry:
- Old (full-span) line at y=20: x = -7.5
- New (partial-span) line at y=20: x = -30 (extrapolated)
- Insert at x=[-10, 0], y=[20, 25]: straddles old (corners x=-10 left of -7.5, x=0 right of it) but not new (all corners right of x=-30)

Added a second assertion with an insert that crosses the partial-span segment in its actual y range — sanity check that the helper still catches real intersections.

**2. Slotted-mode regression coverage.**
The slotted/solid-mode gate added in #1842 had no test. Added three:
- `slotted` → `isUnavailable=true` with non-standard-mode reason
- `solid` → `isUnavailable=true`
- `standard` with eligible dividers → `isUnavailable=false` (sanity)

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` 0 errors
- [x] 2268 bin-designer tests pass (+4 new — 1 strengthened partial-span + 3 style-gating)

## Closing the track

11 PRs total for issue #1822 (foundation through final polish). Total feature surface: schema + validator + worker geometry + scoop/tab/insert/slot compat + panel UI + canvas drag handles + PostHog events + 8-locale i18n + ~120 unit tests + ~10 critical bugs caught by Greptile/Copilot review across the chain. Labs flag graduated to stable. **Feature complete; closing the track.**