### PR TITLE
fix(baseplate): #1847 — dovetail positions honor fractionalEdge under rotation

### DIFF
--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { computeBaseplateTiling, pieceToBaseplateParams, colToLetter } from './splitPlanner';
 import { TONGUE_PROTRUSION } from '@/features/generation/worker/generators/generatorConstants';
+import { computeConnectorPositions } from '@/features/generation/worker/generators/connectorUtils';
 import type { BaseplateParams } from '@/shared/types/bin';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
@@ -1060,6 +1061,106 @@ describe('preferIdenticalPieces', () => {
     } else {
       expect(fractionalParams.fractionalEdgeX).toBe(fractional.fractionalEdgeX);
     }
+  });
+});
+
+describe('preferIdenticalPieces × fractional dimensions — dovetail alignment (#1847)', () => {
+  /**
+   * 9.5 × 9.5 plate with `preferIdenticalPieces` tiles into 2×2 = {A1, B1, A2, B2}.
+   * B2 (4.5 × 4.5) is the only piece that's fractional on both axes AND gets the
+   * 180° canonicalization rotation, so its `fractionalEdgeX/Y` are flipped to
+   * `'start'`. Before the connector-builder fix, B2's dovetail positions still
+   * used the end-side formula and landed 21mm off the cell boundaries — A2's
+   * right-edge dovetails (correctly at `frac='end'`) couldn't seat with B2's
+   * left-edge dovetails (off by half a grid unit).
+   *
+   * This test runs the full pipeline (tiling → per-piece params → connector
+   * positions → placement rotation → world coords) and asserts every shared
+   * join edge has matching world-space dovetail positions.
+   */
+  it('aligns connectors across every shared join edge for 9.5×9.5', () => {
+    const G = 42;
+    const parent: BaseplateParams = {
+      width: 9.5,
+      depth: 9.5,
+      gridUnitMm: G,
+      magnetHoles: false,
+      magnetDiameter: 6.5,
+      magnetDepth: 2,
+      paddingLeft: 0,
+      paddingRight: 0,
+      paddingFront: 0,
+      paddingBack: 0,
+      fractionalEdgeX: 'end',
+      fractionalEdgeY: 'end',
+      connectorNubs: true,
+      preferIdenticalPieces: true,
+      lightweight: true,
+    };
+    const tiling = computeBaseplateTiling(parent, 256, 256);
+    const totalW = parent.width * G;
+    const totalD = parent.depth * G;
+
+    const placedConnectors = tiling.pieces.map((p) => {
+      const pp = pieceToBaseplateParams(p, parent);
+      const halfW = (pp.width * G) / 2;
+      const halfD = (pp.depth * G) / 2;
+      const cxWorld = p.gridOffsetX * G + halfW - totalW / 2;
+      const cyWorld = p.gridOffsetY * G + halfD - totalD / 2;
+      const local = computeConnectorPositions(
+        pp.width,
+        pp.depth,
+        G,
+        10,
+        pp.width * G,
+        pp.depth * G,
+        0,
+        0,
+        pp.edges as { left: string; right: string; front: string; back: string },
+        pp.invertDovetails ?? false,
+        pp.fractionalEdgeX,
+        pp.fractionalEdgeY
+      );
+      const rotated = p.placementRotationDeg === 180;
+      return {
+        label: p.label,
+        col: p.col,
+        row: p.row,
+        connectors: local.map((c) => ({
+          x: cxWorld + (rotated ? -c.cx : c.cx),
+          y: cyWorld + (rotated ? -c.cy : c.cy),
+        })),
+      };
+    });
+
+    // For every adjacent pair, the connectors on their shared edge must be a
+    // strict permutation in world space. A position on one piece must have a
+    // partner on the other; an orphan means a print-time mismatch.
+    function assertAdjacentMatch(aLabel: string, bLabel: string, axis: 'x' | 'y'): void {
+      const a = placedConnectors.find((p) => p.label === aLabel);
+      const b = placedConnectors.find((p) => p.label === bLabel);
+      expect(a, `piece ${aLabel} missing`).toBeDefined();
+      expect(b, `piece ${bLabel} missing`).toBeDefined();
+      // Join-edge connectors: between A and B, the shared edge sits at some
+      // constant axis coordinate. The "matching" connectors are those whose
+      // shared-axis coordinate is identical between the two pieces.
+      const aPositions = a!.connectors.map((c) => `${c.x.toFixed(3)},${c.y.toFixed(3)}`);
+      const bPositions = b!.connectors.map((c) => `${c.x.toFixed(3)},${c.y.toFixed(3)}`);
+      const shared = aPositions.filter((p) => bPositions.includes(p));
+      // 2×2 tiling: every adjacent pair shares exactly one join edge with
+      // ⌈dim⌉-1 connectors. For 9.5 split into [5, 4.5], each shared edge
+      // has 4 connectors (matching cell boundaries within the smaller of the
+      // two adjacent pieces' depths/widths).
+      expect(
+        shared.length,
+        `${aLabel} ↔ ${bLabel} (${axis}-axis join) should share 4 connectors, got ${shared.length}`
+      ).toBe(4);
+    }
+
+    assertAdjacentMatch('A1', 'B1', 'x');
+    assertAdjacentMatch('A2', 'B2', 'x');
+    assertAdjacentMatch('A1', 'A2', 'y');
+    assertAdjacentMatch('B1', 'B2', 'y');
   });
 });
 

--- a/src/features/generation/worker/generators/baseplateConnectors.ts
+++ b/src/features/generation/worker/generators/baseplateConnectors.ts
@@ -37,6 +37,7 @@ import {
   COPLANAR_OVERLAP,
   sketch,
 } from './generatorTypes';
+import { computeCellBoundariesMm } from './cellDecomposition';
 
 /**
  * Half the separation between the tongue and groove of a paired connector,
@@ -77,6 +78,14 @@ export function buildConnectors(
   const cl = TONGUE_CLEARANCE;
   const ext = COPLANAR_MARGIN;
 
+  // Boundary positions derived from the cell layout so dovetails stay on cell
+  // edges regardless of which side the fractional half-cell sits on (#1847).
+  // Under preferIdenticalPieces, rotated pieces are generated with the
+  // fractional edge flipped — without honoring that here the dovetails would
+  // land half a grid unit off and the printed pieces wouldn't seat together.
+  const yBoundaries = computeCellBoundariesMm(params.depth, gridUnit, params.fractionalEdgeY);
+  const xBoundaries = computeCellBoundariesMm(params.width, gridUnit, params.fractionalEdgeX);
+
   type Side = 'left' | 'right' | 'front' | 'back';
 
   /**
@@ -98,8 +107,7 @@ export function buildConnectors(
     isMale: boolean;
     maleOffsetSign: -1 | 1;
     wallPos: number;
-    numBoundaries: number;
-    boundaryPos: (k: number) => number;
+    boundaries: readonly number[];
     protrudeAxis: 'x' | 'y';
     protrudeDir: -1 | 1;
   }> = [
@@ -108,8 +116,7 @@ export function buildConnectors(
       isMale: !invert,
       maleOffsetSign: 1,
       wallPos: -halfW + slabOffsetX,
-      numBoundaries: Math.ceil(params.depth) - 1,
-      boundaryPos: (k) => k * gridUnit - (params.depth * gridUnit) / 2,
+      boundaries: yBoundaries,
       protrudeAxis: 'x',
       protrudeDir: -1,
     },
@@ -118,8 +125,7 @@ export function buildConnectors(
       isMale: invert,
       maleOffsetSign: -1,
       wallPos: halfW + slabOffsetX,
-      numBoundaries: Math.ceil(params.depth) - 1,
-      boundaryPos: (k) => k * gridUnit - (params.depth * gridUnit) / 2,
+      boundaries: yBoundaries,
       protrudeAxis: 'x',
       protrudeDir: 1,
     },
@@ -128,8 +134,7 @@ export function buildConnectors(
       isMale: !invert,
       maleOffsetSign: -1,
       wallPos: -halfD + slabOffsetY,
-      numBoundaries: Math.ceil(params.width) - 1,
-      boundaryPos: (k) => k * gridUnit - (params.width * gridUnit) / 2,
+      boundaries: xBoundaries,
       protrudeAxis: 'y',
       protrudeDir: -1,
     },
@@ -138,15 +143,14 @@ export function buildConnectors(
       isMale: invert,
       maleOffsetSign: 1,
       wallPos: halfD + slabOffsetY,
-      numBoundaries: Math.ceil(params.width) - 1,
-      boundaryPos: (k) => k * gridUnit - (params.width * gridUnit) / 2,
+      boundaries: xBoundaries,
       protrudeAxis: 'y',
       protrudeDir: 1,
     },
   ];
 
   for (const def of edgeDefs) {
-    if (edges[def.side] !== 'join' || def.numBoundaries <= 0) continue;
+    if (edges[def.side] !== 'join' || def.boundaries.length === 0) continue;
 
     // Build an XY point with wall/boundary coords assigned to the correct axis.
     // When protruding along X, wall is on X and boundary is on Y; vice versa for Y.
@@ -155,8 +159,7 @@ export function buildConnectors(
         ? (wallCoord: number, bpCoord: number): [number, number] => [wallCoord, bpCoord]
         : (wallCoord: number, bpCoord: number): [number, number] => [bpCoord, wallCoord];
 
-    for (let k = 1; k <= def.numBoundaries; k++) {
-      const bp = def.boundaryPos(k);
+    for (const bp of def.boundaries) {
       const w = def.wallPos;
       const d = def.protrudeDir;
 

--- a/src/features/generation/worker/generators/baseplateConnectors.ts
+++ b/src/features/generation/worker/generators/baseplateConnectors.ts
@@ -78,11 +78,8 @@ export function buildConnectors(
   const cl = TONGUE_CLEARANCE;
   const ext = COPLANAR_MARGIN;
 
-  // Boundary positions derived from the cell layout so dovetails stay on cell
-  // edges regardless of which side the fractional half-cell sits on (#1847).
-  // Under preferIdenticalPieces, rotated pieces are generated with the
-  // fractional edge flipped — without honoring that here the dovetails would
-  // land half a grid unit off and the printed pieces wouldn't seat together.
+  // Honors fractionalEdgeX/Y so dovetails land on cell boundaries even when
+  // the half-cell is at the start (rotated piece under preferIdenticalPieces).
   const yBoundaries = computeCellBoundariesMm(params.depth, gridUnit, params.fractionalEdgeY);
   const xBoundaries = computeCellBoundariesMm(params.width, gridUnit, params.fractionalEdgeX);
 

--- a/src/features/generation/worker/generators/baseplateDirectMesh.ts
+++ b/src/features/generation/worker/generators/baseplateDirectMesh.ts
@@ -184,7 +184,9 @@ export function generateBaseplateDirect(
       slabOffsetX,
       slabOffsetY,
       edges,
-      params.invertDovetails
+      params.invertDovetails,
+      fractionalEdgeX,
+      fractionalEdgeY
     );
     for (const pos of connPositions) {
       if (pos.isMale) {

--- a/src/features/generation/worker/generators/cellDecomposition.test.ts
+++ b/src/features/generation/worker/generators/cellDecomposition.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { decomposeCells, decomposeHalfCells, forEachCell } from './cellDecomposition';
+import {
+  decomposeCells,
+  decomposeHalfCells,
+  forEachCell,
+  computeCellBoundariesMm,
+} from './cellDecomposition';
 import type { CellInfo } from './cellDecomposition';
 import { SIZE } from './generatorConstants';
 
@@ -108,5 +113,37 @@ describe('forEachCell', () => {
     expect(cells[0].centerX).toBe(-25);
     expect(cells[1].centerX).toBe(25);
     expect(cells[0].centerY).toBe(0);
+  });
+});
+
+describe('computeCellBoundariesMm', () => {
+  it('returns empty array for a single-cell axis', () => {
+    expect(computeCellBoundariesMm(1, 42)).toEqual([]);
+    expect(computeCellBoundariesMm(0.5, 42)).toEqual([]);
+  });
+
+  it('integer axis: boundaries are evenly spaced regardless of fractional edge', () => {
+    // depth=5 → cells [1,1,1,1,1]. Boundaries at 42, 84, 126, 168 (mm from start).
+    // Centered at totalMm/2 = 105 → -63, -21, 21, 63.
+    expect(computeCellBoundariesMm(5, 42, 'end')).toEqual([-63, -21, 21, 63]);
+    expect(computeCellBoundariesMm(5, 42, 'start')).toEqual([-63, -21, 21, 63]);
+  });
+
+  it('fractional axis, end-side: full cells precede half cell', () => {
+    // depth=4.5 → cells [1,1,1,1,0.5]. Boundaries at 42, 84, 126, 168 (mm from start).
+    // Centered at totalMm/2 = 94.5 → -52.5, -10.5, 31.5, 73.5.
+    expect(computeCellBoundariesMm(4.5, 42, 'end')).toEqual([-52.5, -10.5, 31.5, 73.5]);
+  });
+
+  it('fractional axis, start-side: half cell precedes full cells, shifts boundaries by -gridUnit/2', () => {
+    // depth=4.5 → cells reversed to [0.5,1,1,1,1]. Boundaries at 21, 63, 105, 147.
+    // Centered at 94.5 → -73.5, -31.5, 10.5, 52.5.
+    expect(computeCellBoundariesMm(4.5, 42, 'start')).toEqual([-73.5, -31.5, 10.5, 52.5]);
+  });
+
+  it('honors custom gridUnitMm', () => {
+    // depth=2.5, grid=50 → cells [1,1,0.5] frac=end. Boundaries at 50, 100.
+    // Centered at 62.5 → -12.5, 37.5.
+    expect(computeCellBoundariesMm(2.5, 50, 'end')).toEqual([-12.5, 37.5]);
   });
 });

--- a/src/features/generation/worker/generators/cellDecomposition.ts
+++ b/src/features/generation/worker/generators/cellDecomposition.ts
@@ -36,6 +36,35 @@ export function decomposeCells(gridUnits: number): number[] {
 }
 
 /**
+ * Compute the mm-positions of inter-cell boundaries along an axis, relative to
+ * the piece center (axis spans `[-axisUnits*gridUnitMm/2, +axisUnits*gridUnitMm/2]`).
+ *
+ * Mirrors `forEachCell`'s cell layout exactly: when the fractional half-cell
+ * sits at the start, every full-cell boundary shifts by half a grid unit in
+ * the negative direction. Used by the dovetail connector builders so that
+ * tongues/grooves always land on cell boundaries regardless of where the half
+ * cell ends up (#1847).
+ *
+ * Returns an empty array when the axis has only one cell (no interior boundaries).
+ */
+export function computeCellBoundariesMm(
+  axisUnits: number,
+  gridUnitMm: number,
+  fractionalEdge: 'start' | 'end' = 'end'
+): number[] {
+  const cells = decomposeCells(axisUnits);
+  if (fractionalEdge === 'start') cells.reverse();
+  const totalMm = axisUnits * gridUnitMm;
+  const offsets: number[] = [];
+  let pos = 0;
+  for (let i = 0; i < cells.length - 1; i++) {
+    pos += cells[i] * gridUnitMm;
+    offsets.push(pos - totalMm / 2);
+  }
+  return offsets;
+}
+
+/**
  * Decompose a grid dimension into all 0.5-unit cells (half sockets mode).
  * Each 1-unit cell becomes two 0.5-unit cells; trailing half-cells stay 0.5.
  *

--- a/src/features/generation/worker/generators/cellDecomposition.ts
+++ b/src/features/generation/worker/generators/cellDecomposition.ts
@@ -39,11 +39,8 @@ export function decomposeCells(gridUnits: number): number[] {
  * Compute the mm-positions of inter-cell boundaries along an axis, relative to
  * the piece center (axis spans `[-axisUnits*gridUnitMm/2, +axisUnits*gridUnitMm/2]`).
  *
- * Mirrors `forEachCell`'s cell layout exactly: when the fractional half-cell
- * sits at the start, every full-cell boundary shifts by half a grid unit in
- * the negative direction. Used by the dovetail connector builders so that
- * tongues/grooves always land on cell boundaries regardless of where the half
- * cell ends up (#1847).
+ * When the fractional half-cell sits at the start, every full-cell boundary
+ * shifts by half a grid unit in the negative direction.
  *
  * Returns an empty array when the axis has only one cell (no interior boundaries).
  */

--- a/src/features/generation/worker/generators/connectorUtils.test.ts
+++ b/src/features/generation/worker/generators/connectorUtils.test.ts
@@ -79,3 +79,113 @@ describe('computeConnectorPositions', () => {
     expect(result).toEqual([]);
   });
 });
+
+describe('computeConnectorPositions — fractional-cell placement (#1847)', () => {
+  /**
+   * For a 4.5-unit depth with the half-cell at the END (default), the four
+   * inter-cell boundaries are at grid positions 1, 2, 3, 4. In piece-local
+   * coordinates (centered on the piece, totalD = 189mm), that's
+   * (k * 42) - 94.5 for k = 1..4 → -52.5, -10.5, 31.5, 73.5.
+   */
+  it('frac=end: places left-edge dovetails at expected positions for depth=4.5', () => {
+    const result = computeConnectorPositions(
+      4.5,
+      4.5,
+      42,
+      10,
+      4.5 * 42,
+      4.5 * 42,
+      0,
+      0,
+      { left: 'join', right: 'open', front: 'open', back: 'open' },
+      false,
+      'end',
+      'end'
+    );
+    const ys = result.map((p) => p.cy).sort((a, b) => a - b);
+    expect(ys).toEqual([-52.5, -10.5, 31.5, 73.5]);
+  });
+
+  /**
+   * For a 4.5-unit depth with the half-cell at the START, the cell layout is
+   * [0.5, 1, 1, 1, 1] in grid units; boundaries at grid positions 0.5, 1.5,
+   * 2.5, 3.5. In piece-local coords (totalD = 189mm) they shift left by half
+   * a grid unit: -73.5, -31.5, 10.5, 52.5.
+   *
+   * Before the fix this test failed because the formula assumed the half-cell
+   * was always at the end, producing -52.5, -10.5, 31.5, 73.5 — dovetails 21mm
+   * off from the actual cell boundaries.
+   */
+  it('frac=start: shifts left-edge dovetails by half a grid unit for depth=4.5', () => {
+    const result = computeConnectorPositions(
+      4.5,
+      4.5,
+      42,
+      10,
+      4.5 * 42,
+      4.5 * 42,
+      0,
+      0,
+      { left: 'join', right: 'open', front: 'open', back: 'open' },
+      false,
+      'end',
+      'start'
+    );
+    const ys = result.map((p) => p.cy).sort((a, b) => a - b);
+    expect(ys).toEqual([-73.5, -31.5, 10.5, 52.5]);
+  });
+
+  it('frac=start on width axis: shifts front-edge dovetails for width=4.5', () => {
+    const result = computeConnectorPositions(
+      4.5,
+      4.5,
+      42,
+      10,
+      4.5 * 42,
+      4.5 * 42,
+      0,
+      0,
+      { left: 'open', right: 'open', front: 'join', back: 'open' },
+      false,
+      'start',
+      'end'
+    );
+    const xs = result.map((p) => p.cx).sort((a, b) => a - b);
+    expect(xs).toEqual([-73.5, -31.5, 10.5, 52.5]);
+  });
+
+  it('integer depth: fractionalEdgeY is irrelevant', () => {
+    const end = computeConnectorPositions(
+      5,
+      5,
+      42,
+      10,
+      5 * 42,
+      5 * 42,
+      0,
+      0,
+      { left: 'join', right: 'open', front: 'open', back: 'open' },
+      false,
+      'end',
+      'end'
+    );
+    const start = computeConnectorPositions(
+      5,
+      5,
+      42,
+      10,
+      5 * 42,
+      5 * 42,
+      0,
+      0,
+      { left: 'join', right: 'open', front: 'open', back: 'open' },
+      false,
+      'end',
+      'start'
+    );
+    const endYs = end.map((p) => p.cy).sort((a, b) => a - b);
+    const startYs = start.map((p) => p.cy).sort((a, b) => a - b);
+    expect(endYs).toEqual(startYs);
+    expect(endYs).toEqual([-63, -21, 21, 63]);
+  });
+});

--- a/src/features/generation/worker/generators/connectorUtils.test.ts
+++ b/src/features/generation/worker/generators/connectorUtils.test.ts
@@ -111,10 +111,6 @@ describe('computeConnectorPositions — fractional-cell placement (#1847)', () =
    * [0.5, 1, 1, 1, 1] in grid units; boundaries at grid positions 0.5, 1.5,
    * 2.5, 3.5. In piece-local coords (totalD = 189mm) they shift left by half
    * a grid unit: -73.5, -31.5, 10.5, 52.5.
-   *
-   * Before the fix this test failed because the formula assumed the half-cell
-   * was always at the end, producing -52.5, -10.5, 31.5, 73.5 — dovetails 21mm
-   * off from the actual cell boundaries.
    */
   it('frac=start: shifts left-edge dovetails by half a grid unit for depth=4.5', () => {
     const result = computeConnectorPositions(

--- a/src/features/generation/worker/generators/connectorUtils.ts
+++ b/src/features/generation/worker/generators/connectorUtils.ts
@@ -5,6 +5,8 @@
  * Only used by baseplateDirectMesh.ts — the BREP generator uses dovetail
  * connectors from splitConnectorBuilder.ts instead.
  */
+import { computeCellBoundariesMm } from './cellDecomposition';
+
 export interface ConnectorPos {
   cx: number;
   cy: number;
@@ -24,7 +26,9 @@ export function computeConnectorPositions(
   slabOffsetX: number,
   slabOffsetY: number,
   edges: { left: string; right: string; front: string; back: string },
-  invertDovetails?: boolean
+  invertDovetails?: boolean,
+  fractionalEdgeX: 'start' | 'end' = 'end',
+  fractionalEdgeY: 'start' | 'end' = 'end'
 ): ConnectorPos[] {
   const positions: ConnectorPos[] = [];
   const zCenter = totalHeight / 2;
@@ -32,64 +36,57 @@ export function computeConnectorPositions(
   const halfD = totalD / 2;
   const invert = !!invertDovetails;
 
+  // Boundary positions derived from the cell layout so dovetails stay on cell
+  // edges regardless of which side the fractional half-cell sits on (#1847).
+  const yBoundaries = computeCellBoundariesMm(depth, gridUnitMm, fractionalEdgeY);
+  const xBoundaries = computeCellBoundariesMm(width, gridUnitMm, fractionalEdgeX);
+
   const edgeDefs: ReadonlyArray<{
     side: keyof typeof edges;
-    numBoundaries: number;
-    position: (k: number) => { cx: number; cy: number };
+    boundaries: readonly number[];
+    position: (bp: number) => { cx: number; cy: number };
     nx: number;
     ny: number;
     isMale: boolean;
   }> = [
     {
       side: 'left',
-      numBoundaries: Math.ceil(depth) - 1,
-      position: (k) => ({
-        cx: -halfW + slabOffsetX,
-        cy: k * gridUnitMm - (depth * gridUnitMm) / 2,
-      }),
+      boundaries: yBoundaries,
+      position: (bp) => ({ cx: -halfW + slabOffsetX, cy: bp }),
       nx: -1,
       ny: 0,
       isMale: !invert,
     },
     {
       side: 'right',
-      numBoundaries: Math.ceil(depth) - 1,
-      position: (k) => ({
-        cx: halfW + slabOffsetX,
-        cy: k * gridUnitMm - (depth * gridUnitMm) / 2,
-      }),
+      boundaries: yBoundaries,
+      position: (bp) => ({ cx: halfW + slabOffsetX, cy: bp }),
       nx: 1,
       ny: 0,
       isMale: invert,
     },
     {
       side: 'front',
-      numBoundaries: Math.ceil(width) - 1,
-      position: (k) => ({
-        cx: k * gridUnitMm - (width * gridUnitMm) / 2,
-        cy: -halfD + slabOffsetY,
-      }),
+      boundaries: xBoundaries,
+      position: (bp) => ({ cx: bp, cy: -halfD + slabOffsetY }),
       nx: 0,
       ny: -1,
       isMale: !invert,
     },
     {
       side: 'back',
-      numBoundaries: Math.ceil(width) - 1,
-      position: (k) => ({
-        cx: k * gridUnitMm - (width * gridUnitMm) / 2,
-        cy: halfD + slabOffsetY,
-      }),
+      boundaries: xBoundaries,
+      position: (bp) => ({ cx: bp, cy: halfD + slabOffsetY }),
       nx: 0,
       ny: 1,
       isMale: invert,
     },
   ];
 
-  for (const { side, numBoundaries, position, nx, ny, isMale } of edgeDefs) {
-    if (edges[side] !== 'join' || numBoundaries <= 0) continue;
-    for (let k = 1; k <= numBoundaries; k++) {
-      const { cx, cy } = position(k);
+  for (const { side, boundaries, position, nx, ny, isMale } of edgeDefs) {
+    if (edges[side] !== 'join' || boundaries.length === 0) continue;
+    for (const bp of boundaries) {
+      const { cx, cy } = position(bp);
       positions.push({ cx, cy, cz: zCenter, nx, ny, isMale });
     }
   }

--- a/src/features/generation/worker/generators/connectorUtils.ts
+++ b/src/features/generation/worker/generators/connectorUtils.ts
@@ -36,8 +36,8 @@ export function computeConnectorPositions(
   const halfD = totalD / 2;
   const invert = !!invertDovetails;
 
-  // Boundary positions derived from the cell layout so dovetails stay on cell
-  // edges regardless of which side the fractional half-cell sits on (#1847).
+  // Honors fractionalEdgeX/Y so dovetails land on cell boundaries even when
+  // the half-cell is at the start (rotated piece under preferIdenticalPieces).
   const yBoundaries = computeCellBoundariesMm(depth, gridUnitMm, fractionalEdgeY);
   const xBoundaries = computeCellBoundariesMm(width, gridUnitMm, fractionalEdgeX);
 


### PR DESCRIPTION
## Summary

Fixes #1847 — 9.5 × 9.5 baseplate with dovetail connectors prints with A2/B2 mismatch when `preferIdenticalPieces` is enabled.

## Root cause

The connector boundary formula in both connector paths
(`baseplateConnectors.ts` BREP, `connectorUtils.ts` direct-mesh) was
```
boundaryPos(k) = k * gridUnit - depth * gridUnit / 2
```
which hard-codes the assumption that the fractional half-cell sits at
the END of the axis. Under `preferIdenticalPieces`, the canonicalization
rotates some pieces 180° and flips their `fractionalEdgeX/Y` to `start`
to compensate — but this formula kept using the end-side layout, so
dovetails landed half a grid unit (21mm at 42mm grid) off the actual
cell boundaries.

For 9.5 × 9.5 with `preferIdenticalPieces`, **only B2 hits this** —
it's the single piece that's both fractional on both axes and gets a
180° rotation. Its left-edge dovetails went to world Y `(157.5, 115.5, 73.5, 31.5)`
while A2's right-edge dovetails sat at `(52.5, 94.5, 136.5, 178.5)`.
Connected preview hid this because dovetails interlocked with the slab;
the exported STL and the printed model had the unmatched joint.

The slab/pocket layout was already correct via `forEachCell` — only
the dovetail builders never followed.

## Fix

New helper `computeCellBoundariesMm` in `cellDecomposition.ts` that
mirrors `forEachCell`'s decomposition (reverses cells when fractional
edge is at start). Both connector paths now derive boundaries from
this helper rather than the end-only formula.

- `connectorUtils.ts`: added `fractionalEdgeX/Y` parameters (default
  `'end'` for backwards compat), used to build the boundary array.
- `baseplateConnectors.ts`: reads `params.fractionalEdgeX/Y` (already
  in scope), feeds the helper.
- `baseplateDirectMesh.ts`: passes the fractional-edge params through
  (already destructured from params).

## Tests

5 new tests directly on `computeCellBoundariesMm` in
`cellDecomposition.test.ts` (single-cell, integer, frac=end, frac=start,
custom grid unit) plus 4 in `connectorUtils.test.ts` covering end vs
start placement on both axes plus the integer-depth invariance check.

The `frac=start` cases would have failed before the fix — they assert
positions `[-73.5, -31.5, 10.5, 52.5]` while the buggy formula
produces `[-52.5, -10.5, 31.5, 73.5]` (21mm off).

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` 0 errors (10 pre-existing warnings unrelated)
- [x] `pnpm run check:i18n` green (1900 keys per locale)
- [x] 1274 tests pass across baseplate + generation suites (1 skipped, pre-existing)
- [ ] Manual verification on the 9.5×9.5 + dovetail + `preferIdenticalPieces` scenario