### PR TITLE
fix(generation): #1850 — drop scoop rim fillet that broke STL export

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.issue-1850.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.issue-1850.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+/**
+ * Regression for issue #1850: STL export failed (STL_EXPORT_FAILED) for the
+ * user's 6×6×6 bin with a 4×4 merged compartment + auto-radius scoop, plus
+ * a small matrix of single-compartment shapes that hit the same failure.
+ *
+ * Root cause: the scoop's 2D profile traversed wall→arc→floor where the arc
+ * is tangent to the wall at one end and the floor at the other. Tangent
+ * meetings appear as 180° turns in the polygon, so the corresponding
+ * longitudinal edges of the extruded scoop sat at cusps. brepjs's `fillet()`
+ * on these cusp edges returned `Ok` with degenerate topology that downstream
+ * `StlAPI.Write` rejected. The fillet was a purely cosmetic 2mm rim — sharp
+ * edges print and function identically — so `scoopRampBuilder` no longer
+ * applies it. See scoopRampBuilder.ts for the long comment.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { BinParams } from '@/shared/types/bin';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import { exportBin } from './binExporter';
+import { clearAllCaches } from './shapeCache';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+beforeEach(() => clearAllCaches());
+
+function singleCompartmentScoop(w: number, d: number, h: number): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    width: w,
+    depth: d,
+    height: h,
+    base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+    compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
+    scoop: { enabled: true, radius: 'auto' },
+  };
+}
+
+describe('issue #1850 — scoop STL export at single-compartment wide bins', () => {
+  it('exports 6×6×6 with 4×4 merged compartment + auto scoop (exact user config)', async () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 6,
+      depth: 6,
+      height: 6,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+      compartments: {
+        cols: 4,
+        rows: 4,
+        thickness: 1.2,
+        cells: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      },
+      scoop: { enabled: true, radius: 'auto' },
+    };
+    const result = await exportBin(params, 'stl');
+    expect(result.data.byteLength).toBeGreaterThan(0);
+  }, 120000);
+
+  it('exports 6×6×3 + single compartment + auto scoop (short walls + wide compartment)', async () => {
+    const result = await exportBin(singleCompartmentScoop(6, 6, 3), 'stl');
+    expect(result.data.byteLength).toBeGreaterThan(0);
+  }, 120000);
+
+  it('exports 3×3×6 + single compartment + auto scoop (tall walls + auto radius 18.5mm)', async () => {
+    const result = await exportBin(singleCompartmentScoop(3, 3, 6), 'stl');
+    expect(result.data.byteLength).toBeGreaterThan(0);
+  }, 120000);
+
+  it('exports 4×4×3 + single compartment + auto scoop (mid-width + short walls)', async () => {
+    const result = await exportBin(singleCompartmentScoop(4, 4, 3), 'stl');
+    expect(result.data.byteLength).toBeGreaterThan(0);
+  }, 120000);
+});

--- a/src/features/generation/worker/generators/binGenerator.scenario.issue-1850.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.issue-1850.test.ts
@@ -1,17 +1,9 @@
 // @vitest-environment node
 /**
- * Regression for issue #1850: STL export failed (STL_EXPORT_FAILED) for the
- * user's 6×6×6 bin with a 4×4 merged compartment + auto-radius scoop, plus
- * a small matrix of single-compartment shapes that hit the same failure.
- *
- * Root cause: the scoop's 2D profile traversed wall→arc→floor where the arc
- * is tangent to the wall at one end and the floor at the other. Tangent
- * meetings appear as 180° turns in the polygon, so the corresponding
- * longitudinal edges of the extruded scoop sat at cusps. brepjs's `fillet()`
- * on these cusp edges returned `Ok` with degenerate topology that downstream
- * `StlAPI.Write` rejected. The fillet was a purely cosmetic 2mm rim — sharp
- * edges print and function identically — so `scoopRampBuilder` no longer
- * applies it. See scoopRampBuilder.ts for the long comment.
+ * STL export must succeed for auto-radius scoops across single-compartment
+ * and merged-compartment bins. These configs previously hit STL_EXPORT_FAILED
+ * because the scoop's cusp rim edges produced degenerate topology after
+ * filleting (issue #1850).
  */
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';

--- a/src/features/generation/worker/generators/binGenerator.scenario.issue-1850.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.issue-1850.test.ts
@@ -64,4 +64,16 @@ describe('issue #1850 — scoop STL export at single-compartment wide bins', () 
     const result = await exportBin(singleCompartmentScoop(4, 4, 3), 'stl');
     expect(result.data.byteLength).toBeGreaterThan(0);
   }, 120000);
+
+  // Lip-offset polygon (lipOffset > 0) has extra wall-top points before the
+  // arc, structurally different from the no-lip path. Cover it so a future
+  // regression on the lip branch doesn't slip through.
+  it('exports 4×4×3 + auto scoop WITH stacking lip', async () => {
+    const params: BinParams = {
+      ...singleCompartmentScoop(4, 4, 3),
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    };
+    const result = await exportBin(params, 'stl');
+    expect(result.data.byteLength).toBeGreaterThan(0);
+  }, 120000);
 });

--- a/src/features/generation/worker/generators/scoopRampBuilder.ts
+++ b/src/features/generation/worker/generators/scoopRampBuilder.ts
@@ -5,7 +5,7 @@
  * to help slide items out of the bin.
  */
 
-import { draw, edgeFinder, getBounds, translate, withScope, clone, unwrap, fuseAll } from 'brepjs';
+import { draw, translate, withScope, clone, unwrap, fuseAll } from 'brepjs';
 import type { Shape3D, ValidSolid, DisposalScope } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
 import { sketch } from './meshUtils';
@@ -16,7 +16,6 @@ import {
 } from '@/shared/utils/scoopCalculations';
 import { LIP_SMALL_TAPER, LIP_TAPER_WIDTH } from './generatorConstants';
 import { findCompartmentBounds } from './compartmentBuilder';
-import { applyFilletWithFallback } from './cutoutBuilder';
 import { compartmentHasTiltedEdge } from '@/shared/types/bin';
 /**
  * Build finger scoop ramps that curve from the bin floor up to the front wall.
@@ -153,51 +152,18 @@ function buildScoopRampsInScope(
       }
       const profile = pen.close();
 
-      // Sketch on YZ plane and extrude along X for the compartment width
-      let scoopSolid = scope.register(sketch(profile, 'YZ', -compW / 2).extrude(compW));
-
-      // Fillet the two longitudinal edges where the ramp meets the wall and floor.
-      // Before translation, the scoop solid spans X=[-compW/2, +compW/2] with
-      // Y=[lipOffset, lipOffset+radius], Z=[0, radius]. The sharp edges are:
-      //   - Top-of-ramp: (Y~lipOffset, Z~radius) -- ramp meets wall/lip
-      //   - Floor-of-ramp: (Y~lipOffset+radius, Z~0) -- ramp meets bin floor
-      const filletR = Math.min(2, radius / 4);
-      if (filletR >= 0.5) {
-        const smoothEdges = edgeFinder()
-          .when((e) => {
-            const b = getBounds(e);
-            // Edge must run along X (span most of the compartment width)
-            if (b.xMax - b.xMin < compW * 0.5) return false;
-            // Top-of-ramp edge: Y~lipOffset, Z~radius
-            const isTop =
-              Math.abs(b.yMin - lipOffset) < 0.5 &&
-              Math.abs(b.yMax - lipOffset) < 0.5 &&
-              Math.abs(b.zMin - radius) < 0.5 &&
-              Math.abs(b.zMax - radius) < 0.5;
-            // Floor-of-ramp edge: Y~lipOffset+radius, Z~0
-            const floorY = lipOffset + radius;
-            const isFloor =
-              Math.abs(b.yMin - floorY) < 0.5 &&
-              Math.abs(b.yMax - floorY) < 0.5 &&
-              Math.abs(b.zMin) < 0.5 &&
-              Math.abs(b.zMax) < 0.5;
-            return isTop || isFloor;
-          })
-          .findAll(scoopSolid);
-        // Note: edges returned by findAll come from brepjs's per-shape
-        // topology cache — they're NOT owned by the caller. Disposing them
-        // here would double-free. They're released when the parent shape
-        // (registered below) is disposed by the scope.
-        if (smoothEdges.length > 0) {
-          const filleted = applyFilletWithFallback(scoopSolid, smoothEdges, filletR);
-          // applyFilletWithFallback returns either a new shape (success) or
-          // the same shape (all fallbacks failed). Only register when it's
-          // a new allocation; otherwise we'd double-register.
-          if (filleted !== scoopSolid) {
-            scoopSolid = scope.register(filleted);
-          }
-        }
-      }
+      // Sketch on YZ plane and extrude along X for the compartment width.
+      //
+      // We previously filleted the longitudinal top-of-ramp (Y=lipOffset,
+      // Z=radius) and floor-of-ramp (Y=lipOffset+radius, Z=0) edges by 2mm.
+      // Both edges sit at the polygon's tangent reversals (the wall is tangent
+      // to the arc at the top, the floor is tangent to the arc at the floor)
+      // — the brepjs `fillet()` call returns `Ok` for these cusp edges but the
+      // resulting solid carries degenerate topology that `StlAPI.Write` later
+      // rejects with STL_EXPORT_FAILED (#1850). The fillet was purely
+      // cosmetic — sharp rim edges print and function identically — so we
+      // skip it to keep export robust across all bin sizes.
+      const scoopSolid = scope.register(sketch(profile, 'YZ', -compW / 2).extrude(compW));
 
       // Position: center X at compartment center, Y at front edge of compartment
       const compCenterX = -innerW / 2 + (minCol + compCols / 2) * cellW;
@@ -228,9 +194,11 @@ export const scoopRampsFeature: FeatureBuilder = {
     const { dimensions: dim, params } = ctx;
     return compactKey(
       buildCacheKey(
-        // `v2`: scoop now skips compartments with any tilted edge, so the
-        // dividerOverrides shape affects output. Cache namespace bumped.
-        'v2',
+        // `v3`: scoop no longer fillets its top/floor rim edges (#1850 — the
+        // fillet sat at a cusp in the 2D profile, producing degenerate
+        // topology that broke STL export at wider bin sizes). Bumping the
+        // namespace invalidates any v2 entries cached with the old rim.
+        'v3',
         dim.shellKey,
         stableSerialize(params.scoop),
         params.style,

--- a/src/features/generation/worker/generators/scoopRampBuilder.ts
+++ b/src/features/generation/worker/generators/scoopRampBuilder.ts
@@ -152,17 +152,11 @@ function buildScoopRampsInScope(
       }
       const profile = pen.close();
 
-      // Sketch on YZ plane and extrude along X for the compartment width.
-      //
-      // We previously filleted the longitudinal top-of-ramp (Y=lipOffset,
-      // Z=radius) and floor-of-ramp (Y=lipOffset+radius, Z=0) edges by 2mm.
-      // Both edges sit at the polygon's tangent reversals (the wall is tangent
-      // to the arc at the top, the floor is tangent to the arc at the floor)
-      // — the brepjs `fillet()` call returns `Ok` for these cusp edges but the
-      // resulting solid carries degenerate topology that `StlAPI.Write` later
-      // rejects with STL_EXPORT_FAILED (#1850). The fillet was purely
-      // cosmetic — sharp rim edges print and function identically — so we
-      // skip it to keep export robust across all bin sizes.
+      // Do not fillet the longitudinal rim edges (top-of-ramp at Y=lipOffset,
+      // Z=radius; floor-of-ramp at Y=lipOffset+radius, Z=0). The arc is tangent
+      // to the wall and floor at those points, so the edges sit at polygon
+      // cusps — brepjs `fillet()` returns Ok but produces degenerate topology
+      // that fails STL export.
       const scoopSolid = scope.register(sketch(profile, 'YZ', -compW / 2).extrude(compW));
 
       // Position: center X at compartment center, Y at front edge of compartment
@@ -194,10 +188,6 @@ export const scoopRampsFeature: FeatureBuilder = {
     const { dimensions: dim, params } = ctx;
     return compactKey(
       buildCacheKey(
-        // `v3`: scoop no longer fillets its top/floor rim edges (#1850 — the
-        // fillet sat at a cusp in the 2D profile, producing degenerate
-        // topology that broke STL export at wider bin sizes). Bumping the
-        // namespace invalidates any v2 entries cached with the old rim.
         'v3',
         dim.shellKey,
         stableSerialize(params.scoop),


### PR DESCRIPTION
## Summary
- Closes #1850: STL export was failing with `STL_EXPORT_FAILED` / `STL_FILE_READ_ERROR` for any single-compartment (or merged-compartment) bin with an auto-radius scoop once the compartment got wide enough — the user's 6×6×6 with a 4×4 merged + auto scoop is the smallest concrete example, but 6×6×3, 5×5×6, 4×4×3, 3×3×6 all triggered the same failure.
- Root cause: the scoop's 2D profile traverses `wall → arc → floor`, where the arc is tangent to both the wall (top of ramp) and the floor (front of ramp). Tangent contacts read as 180° turns in the polygon, so the corresponding longitudinal edges of the extruded scoop sit at cusps. `brepjs.fillet()` on those cusp edges returns `Ok` with degenerate topology — `mesh()` succeeds but `StlAPI.Write` rejects the triangulation.
- Fix: stop attempting the 2mm rim fillet in `scoopRampBuilder`. It was purely cosmetic — sharp rims print and function identically as a finger scoop. Scoop scenario snapshots are unchanged, so the fillet was already failing silently in those configs (kernel quietly dropped it on small bins).

## Test plan
- [x] Added `binGenerator.scenario.issue-1850.test.ts` covering the user's exact config + 3 representative cases from the bisection matrix
- [x] All 4 new regression tests pass
- [x] All 335 existing scenario tests pass (no snapshot drift)
- [x] All 1,136 generation tests pass
- [x] `pnpm run typecheck` clean