### PR TITLE
fix(generation): #1822 — manifold coverage + booleanStage simplify

### DIFF
--- a/src/features/generation/worker/generators/compartmentBuilder.scenario.manifold.test.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.scenario.manifold.test.ts
@@ -168,3 +168,277 @@ describe('compartmentBuilder — partition export manifold-ness (issue #1753)', 
     TEST_TIMEOUT_MS
   );
 });
+
+/**
+ * Regression coverage around issue #1822 — tilted dividers on half-grid
+ * bins. Locks in that the multi-cavity-cut path (#1844) produces a clean,
+ * manifold mesh across the tilt × halfSockets × bin-shape × compartment
+ * matrix.
+ *
+ * Diagnosis note: the reporter's bin was non-manifold, but the matrix
+ * below (which excludes label tabs) is manifold across the board. The
+ * actual non-manifold trigger turned out to be the label-tab feature
+ * the reporter had enabled — its gusset back faces sit coincident with
+ * the bin's inner back wall on fuse, leaving duplicate triangles that
+ * BambuStudio reports. That case is captured as it.skip TODO tests at
+ * the end of this describe block (see follow-up comments).
+ *
+ * Matrix axes (kept tight to fit the test budget):
+ *   - halfSockets {true, false}        — confirms halfSockets doesn't
+ *                                        regress the multi-cavity path
+ *   - bin shape {1×6, 1.5×6, 2×6}      — integer, half-grid, larger
+ *   - tilt magnitude {0, 10, 40, 90mm} — baseline + reporter + near-max
+ *   - compartment topology {1×2, 2×1, 2×2} — single, width-axis, crossing
+ *
+ * We don't take the full Cartesian product — only the diagonals that
+ * isolate which axis would trigger regression if the geometry path
+ * changed.
+ */
+
+function withTiltedDivider(
+  params: BinParams,
+  offsetStart: number,
+  offsetEnd: number,
+  compartmentA = 0,
+  compartmentB = 1
+): BinParams {
+  const overrides =
+    offsetStart === 0 && offsetEnd === 0
+      ? undefined
+      : [{ compartmentA, compartmentB, offsetStart, offsetEnd }];
+  return {
+    ...params,
+    compartments: {
+      ...params.compartments,
+      ...(overrides ? { dividerOverrides: overrides } : {}),
+    },
+  };
+}
+
+function withHalfSockets(params: BinParams): BinParams {
+  return { ...params, base: { ...params.base, halfSockets: true } };
+}
+
+describe('compartmentBuilder — half-sockets + tilted divider manifold (issue #1822)', () => {
+  const TEST_TIMEOUT_MS = 90_000;
+
+  function expectWatertight(stats: ManifoldStats, label: string): void {
+    expect(stats.nonManifoldEdges, `${label}: non-manifold edges`).toBe(0);
+    expect(stats.boundaryEdges, `${label}: boundary edges`).toBe(0);
+  }
+
+  // Baseline: halfSockets + axis-aligned divider must remain manifold.
+  // If this ever fails, the bug isn't tilt-specific — the fix needs to
+  // address halfSockets + multi-cavity-cut more broadly.
+  it(
+    '1.5×6 halfSockets + axis-aligned divider (no tilt) — baseline',
+    async () => {
+      clearAllCaches();
+      const base = withCompartments(1, 2, [0, 1], { width: 1.5, depth: 6, height: 6 });
+      const params = withHalfSockets(withTiltedDivider(base, 0, 0));
+      expectWatertight(
+        analyzeManifold((await exportBin(params, 'stl')).data),
+        '1.5×6 halfSockets baseline'
+      );
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  // Reporter's exact configuration: 1.5×6×6, halfSockets, ±40mm symmetric tilt.
+  // Direct repro of the user's BambuStudio non-manifold warning.
+  it(
+    "1.5×6 halfSockets + ±40mm tilted divider — reporter's case",
+    async () => {
+      clearAllCaches();
+      const base = withCompartments(1, 2, [0, 1], { width: 1.5, depth: 6, height: 6 });
+      const params = withHalfSockets(withTiltedDivider(base, -40, 40));
+      expectWatertight(
+        analyzeManifold((await exportBin(params, 'stl')).data),
+        '1.5×6 halfSockets ±40 — reporter'
+      );
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  // Mild 10mm symmetric tilt — same configuration as the existing
+  // tilted-dividers scenario test, but with halfSockets enabled.
+  // Catches the bug earlier in tilt magnitude so fixes that only
+  // help extreme tilts don't pass the suite.
+  it(
+    '1.5×6 halfSockets + ±10mm tilted divider — mild tilt',
+    async () => {
+      clearAllCaches();
+      const base = withCompartments(1, 2, [0, 1], { width: 1.5, depth: 6, height: 6 });
+      const params = withHalfSockets(withTiltedDivider(base, -10, 10));
+      expectWatertight(
+        analyzeManifold((await exportBin(params, 'stl')).data),
+        '1.5×6 halfSockets ±10 — mild'
+      );
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  // Extreme tilt approaching the viability gate (cavityCorners would
+  // collapse below thickness*2 mm interior). Verifies the gate doesn't
+  // admit pathological geometry that the fix can't handle.
+  it(
+    '1.5×6 halfSockets + ±90mm tilted divider — near-max tilt',
+    async () => {
+      clearAllCaches();
+      const base = withCompartments(1, 2, [0, 1], { width: 1.5, depth: 6, height: 6 });
+      const params = withHalfSockets(withTiltedDivider(base, -90, 90));
+      expectWatertight(
+        analyzeManifold((await exportBin(params, 'stl')).data),
+        '1.5×6 halfSockets ±90 — near-max'
+      );
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  // halfSockets OFF + tilted divider — isolates whether the bug requires
+  // half-cells or whether tilt alone is enough. (Prior art:
+  // binGenerator.scenario.tilted-dividers.test.ts only asserts geometry
+  // changed, not that it's manifold.)
+  it(
+    '1.5×6 halfSockets=false + ±40mm tilted divider — isolates halfSockets role',
+    async () => {
+      clearAllCaches();
+      const base = withCompartments(1, 2, [0, 1], { width: 1.5, depth: 6, height: 6 });
+      const params = withTiltedDivider(base, -40, 40);
+      expectWatertight(
+        analyzeManifold((await exportBin(params, 'stl')).data),
+        '1.5×6 no-halfSockets ±40'
+      );
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  // Integer width + halfSockets + tilt — isolates whether the half-grid
+  // width is load-bearing or whether halfSockets alone is enough.
+  it(
+    '1×6 halfSockets + ±40mm tilted divider — isolates 1.5-width role',
+    async () => {
+      clearAllCaches();
+      const base = withCompartments(1, 2, [0, 1], { width: 1, depth: 6, height: 6 });
+      const params = withHalfSockets(withTiltedDivider(base, -40, 40));
+      expectWatertight(
+        analyzeManifold((await exportBin(params, 'stl')).data),
+        '1×6 halfSockets ±40'
+      );
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  // 2×6 + halfSockets + tilt — larger integer width. Sanity that the
+  // fix doesn't only happen to work at narrow widths.
+  it(
+    '2×6 halfSockets + ±40mm tilted divider — larger integer width',
+    async () => {
+      clearAllCaches();
+      const base = withCompartments(1, 2, [0, 1], { width: 2, depth: 6, height: 6 });
+      const params = withHalfSockets(withTiltedDivider(base, -40, 40));
+      expectWatertight(
+        analyzeManifold((await exportBin(params, 'stl')).data),
+        '2×6 halfSockets ±40'
+      );
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  // Divider in the WIDTH axis (cols=2, rows=1). 1.5-wide means cellW ≈ 30mm
+  // per cell; a ±10mm tilt is the most we can apply before the cavity
+  // viability gate would reject it.
+  it(
+    '1.5×6 halfSockets + width-axis tilted divider — cols=2 rows=1',
+    async () => {
+      clearAllCaches();
+      const base = withCompartments(2, 1, [0, 1], { width: 1.5, depth: 6, height: 6 });
+      const params = withHalfSockets(withTiltedDivider(base, -10, 10));
+      expectWatertight(
+        analyzeManifold((await exportBin(params, 'stl')).data),
+        '1.5×6 halfSockets ±10 width-axis'
+      );
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  // 2×2 four-compartment with two tilted dividers (one horizontal,
+  // one vertical) — stresses the interaction of multiple tilted
+  // cavities baked into a single shell cut.
+  it(
+    '2×6 halfSockets + 2×2 compartments with two tilted dividers — crossing tilts',
+    async () => {
+      clearAllCaches();
+      const base = withCompartments(2, 2, [0, 1, 2, 3], { width: 2, depth: 6, height: 6 });
+      const overrides = [
+        { compartmentA: 0, compartmentB: 1, offsetStart: 20, offsetEnd: -20 }, // vertical divider tilt
+        { compartmentA: 0, compartmentB: 2, offsetStart: 30, offsetEnd: -30 }, // horizontal divider tilt
+      ];
+      const params: BinParams = withHalfSockets({
+        ...base,
+        compartments: { ...base.compartments, dividerOverrides: overrides },
+      });
+      expectWatertight(
+        analyzeManifold((await exportBin(params, 'stl')).data),
+        '2×6 halfSockets 2×2 crossing tilts'
+      );
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  // Label-tab repro: the actual feature combination the reporter must
+  // have had (their 3MF has ~35336 triangles, matching label-enabled +
+  // tilted divider on a 1.5×6×6 halfSockets bin). The reporter mentioned
+  // only the tilted divider; investigation showed the non-manifold edges
+  // are produced by the label tab's gusset back faces (coplanar with the
+  // bin's inner back wall), independent of the divider tilt.
+  //
+  // TODO(#1822 follow-up): drive the residual ~444 NM to 0. Diagnosed
+  // root cause is OCCT GFA leaving the gusset back faces coincident with
+  // the bin's inner back wall on fuse — neither `simplify`, fuzzy-value
+  // tolerance, `COPLANAR_OVERLAP` overshoot, nor a final `simplify()`
+  // pass coalesces them. The `optimisation: 'sameFace'` hint does fix it
+  // (drops to ~126) but makes OCCT throw on scoop and split-bin fuses
+  // where no exact-shared face exists, so it can't be applied globally
+  // in booleanStage. Likely needs per-target fuse options (split the
+  // booleanStage into label-tab-aware passes) or a structural rework
+  // (cut a slot in the wall and seat the tab into it rather than
+  // fusing). Tracking as known gap until then.
+  it.skip(
+    'TODO #1822 follow-up: 1.5×6 halfSockets + ±40mm tilted divider + label tab — full reporter config',
+    async () => {
+      clearAllCaches();
+      const base = withCompartments(1, 2, [0, 1], { width: 1.5, depth: 6, height: 6 });
+      const params: BinParams = {
+        ...withHalfSockets(withTiltedDivider(base, -40, 40)),
+        label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+      };
+      expectWatertight(
+        analyzeManifold((await exportBin(params, 'stl')).data),
+        '1.5×6 halfSockets ±40 + label — full reporter config'
+      );
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  // Label tab + axis-aligned divider — both compartments get tabs. Same
+  // gusset-back-face coplanarity bug as above, slightly higher NM count
+  // (~642) because both compartments contribute gusset arrays. See the
+  // TODO on the previous test for the diagnosed root cause.
+  it.skip(
+    'TODO #1822 follow-up: 1.5×6 halfSockets + axis-aligned divider + label tab — both compartments tabbed',
+    async () => {
+      clearAllCaches();
+      const base = withCompartments(1, 2, [0, 1], { width: 1.5, depth: 6, height: 6 });
+      const params: BinParams = {
+        ...withHalfSockets(base),
+        label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+      };
+      expectWatertight(
+        analyzeManifold((await exportBin(params, 'stl')).data),
+        '1.5×6 halfSockets + label — both compartments tabbed'
+      );
+    },
+    TEST_TIMEOUT_MS
+  );
+});

--- a/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
@@ -99,7 +99,19 @@ export const booleanStage: PipelineStage = {
 
     if (ctx.fuseTargets.length > 0) {
       checkCancelled(signal);
-      const { shape, telemetry } = unwrap(fuseAllBisect([bin, ...ctx.fuseTargets] as ValidSolid[]));
+      // `simplify: forExport` merges same-domain faces left behind by
+      // the n-way fuse — mirrors what the cut path already passes. Fuse
+      // was previously the outlier, accumulating duplicate / coincident
+      // faces from additive features (label tabs, scoop ramps) that
+      // share a face with the shell. Slicers (BambuStudio) flag the
+      // resulting duplicate triangles as non-manifold (#1822 — partial
+      // fix; see labelTab gusset-back-face follow-up).
+      const { shape, telemetry } = unwrap(
+        fuseAllBisect([bin, ...ctx.fuseTargets] as ValidSolid[], {
+          simplify: forExport,
+          signal,
+        })
+      );
       recordIfRecovered('fuse', telemetry);
       bin = shape;
     }

--- a/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
@@ -95,22 +95,19 @@ export const booleanStage: PipelineStage = {
 
     checkCancelled(signal);
 
-    const cutOpts = { simplify: forExport, signal } as BooleanOpts;
+    // Shared by fuse and cut passes — `simplify: forExport` merges
+    // same-domain faces left behind by the n-way boolean, and `signal`
+    // threads cancellation through. Fuse used to drop both, accumulating
+    // duplicate / coincident faces from additive features (label tabs,
+    // scoop ramps) that share a face with the shell; slicers (BambuStudio)
+    // flag the resulting duplicate triangles as non-manifold (#1822 —
+    // partial fix; see labelTab gusset-back-face follow-up).
+    const boolOpts = { simplify: forExport, signal } as BooleanOpts;
 
     if (ctx.fuseTargets.length > 0) {
       checkCancelled(signal);
-      // `simplify: forExport` merges same-domain faces left behind by
-      // the n-way fuse — mirrors what the cut path already passes. Fuse
-      // was previously the outlier, accumulating duplicate / coincident
-      // faces from additive features (label tabs, scoop ramps) that
-      // share a face with the shell. Slicers (BambuStudio) flag the
-      // resulting duplicate triangles as non-manifold (#1822 — partial
-      // fix; see labelTab gusset-back-face follow-up).
       const { shape, telemetry } = unwrap(
-        fuseAllBisect([bin, ...ctx.fuseTargets] as ValidSolid[], {
-          simplify: forExport,
-          signal,
-        })
+        fuseAllBisect([bin, ...ctx.fuseTargets] as ValidSolid[], boolOpts)
       );
       recordIfRecovered('fuse', telemetry);
       bin = shape;
@@ -118,12 +115,12 @@ export const booleanStage: PipelineStage = {
 
     if (ctx.cutTargets.length > 0) {
       checkCancelled(signal);
-      bin = applyCutPass(bin, originalSolid, ctx.cutTargets, 'cut', cutOpts);
+      bin = applyCutPass(bin, originalSolid, ctx.cutTargets, 'cut', boolOpts);
     }
 
     if (ctx.patternCutTargets.length > 0) {
       checkCancelled(signal);
-      bin = applyCutPass(bin, originalSolid, ctx.patternCutTargets, 'pattern_cut', cutOpts);
+      bin = applyCutPass(bin, originalSolid, ctx.patternCutTargets, 'pattern_cut', boolOpts);
     }
 
     if (bin !== originalSolid) originalSolid.delete();


### PR DESCRIPTION
## Summary

Issue #1822 reporter's 3MF was non-manifold. Diagnosis pivoted twice during investigation: the expected fix path (tilt + halfSockets reintroducing T-junctions through the socket-body fuse) turned out to be clean across the matrix — the actual NM trigger was the label tab feature the reporter had enabled. Each gusset's back face sits coincident with the bin's inner back wall on fuse, leaving duplicate triangles BambuStudio flags.

## Changes

- **`booleanStage.ts`** — fuse now passes `simplify: forExport` to `fuseAllBisect`, mirroring what the cut path already does. Pre-existing inconsistency: every cut got `simplify`, fuse was the outlier. Same change also threads the abort `signal` through (was previously dropped). Doesn't fully close #1822 by itself, but is a clearly-correct fix for an inconsistency and reduces the surface area of similar bugs.

- **`compartmentBuilder.scenario.manifold.test.ts`** — 13-case regression matrix for #1844 (the original #1822 fix that wired `dividerOverrides` through the multi-cavity-cut path):
  - halfSockets {true, false} × bin shape {1×6, 1.5×6, 2×6} × tilt {0, 10mm, 40mm reporter, 90mm near-max} × compartment topology {1×2, 2×1, 2×2}
  - Plus 2 `it.skip` TODO tests capturing the label-tab + halfSockets repro for follow-up, with the diagnosed root cause documented inline.

## Why the label-tab fix isn't in this PR

The clean fix for the gusset back-face coincidence is `optimisation: 'sameFace'` on `fuseAllBisect` — drops NM from 444 → ~126 in labs. But applied globally in `booleanStage` it makes OCCT throw on scoop-ramp and split-bin fuses where no exact-shared face exists (`splits bin with scoop enabled`, `splits bin with label tabs`, etc fail). Tried `optimisation: 'commonFace'`, `fuzzyValue: 1e-5`, `COPLANAR_OVERLAP` overshoot on the tab geometry, and a final `simplify()` pass on the bin — none coalesce the residual gusset back faces without breaking the split path. The proper fix needs per-target fuse-option control (split the booleanStage into label-tab-aware passes) or a structural rework (cut a slot in the wall and seat the tab into it instead of fusing). Tracked as `it.skip` TODO tests so the next iteration can pick them up.

## Test plan

- [x] `pnpm exec vitest run src/features/generation/worker/generators/compartmentBuilder.scenario.manifold.test.ts` → 13 pass / 3 skipped
- [x] `pnpm exec vitest run src/features/generation/` → 1146 pass / 3 skipped (no new failures from booleanStage change)
- [x] `pnpm run typecheck` → clean
- [x] `pnpm run lint` → 0 errors (10 pre-existing warnings in unrelated files)
- [ ] Greptile review
- [ ] User to verify the reporter's exact bin (1.5×6×6 + half-grid + tilted divider + label tab) still warns in BambuStudio — partial improvement only this PR