### PR TITLE
fix(bin-designer): include text zone in slicer handoff preview

### DIFF
--- a/src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.test.tsx
+++ b/src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.test.tsx
@@ -24,6 +24,7 @@ const zoneLabels: Record<ColorZone, string> = {
   base: 'Base',
   scoop: 'Scoop',
   dividers: 'Dividers',
+  text: 'Text',
 };
 
 function buildColors(overrides: Partial<FeatureColorConfig> = {}): FeatureColorConfig {
@@ -66,5 +67,24 @@ describe('SlicerHandoffPreview', () => {
     expect(screen.getByText(/filament:n=2/)).toBeInTheDocument();
     // First filament's zone list should mention both Body and Label.
     expect(screen.getByText(/Body, Label/)).toBeInTheDocument();
+  });
+
+  it('includes the text zone when it diverges from body', () => {
+    // Regression guard: the manually-curated `ordered` list previously
+    // omitted 'text', so a body+text design rendered as single-filament
+    // and the preview was hidden — even though the 3MF export shipped
+    // two materials. Walking ZONE_ORDER keeps the preview in lockstep
+    // with the exporter's `resolveColorMapping`.
+    render(
+      <SlicerHandoffPreview
+        featureColors={buildColors({ text: '#ff0000' })}
+        activeZones={new Set<ColorZone>(['body', 'text'])}
+        zoneLabels={zoneLabels}
+      />
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText(/filament:n=1/)).toBeInTheDocument();
+    expect(screen.getByText(/filament:n=2/)).toBeInTheDocument();
+    expect(screen.getByText(/^Text$/)).toBeInTheDocument();
   });
 });

--- a/src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.tsx
+++ b/src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.tsx
@@ -7,11 +7,7 @@
 
 import { useId, useState } from 'react';
 import { ChevronDownIcon } from '@/design-system/Icon';
-import {
-  LIP_CORNERS,
-  getZoneColor,
-  lipCornerZone,
-} from '@/features/bin-designer/types/featureColors';
+import { ZONE_ORDER, getZoneColor } from '@/features/bin-designer/types/featureColors';
 import type { ColorZone, FeatureColorConfig } from '@/features/bin-designer/types/featureColors';
 import { useTranslation } from '@/i18n';
 
@@ -31,19 +27,12 @@ function buildFilaments(
   activeZones: ReadonlySet<ColorZone>,
   labels: Record<ColorZone, string>
 ): Filament[] {
-  // Body always lands first so its filament index is 0 — mirrors the
-  // 3MF exporter's `resolveColorMapping` ordering.
-  const ordered: ColorZone[] = [
-    'body',
-    ...LIP_CORNERS.map(lipCornerZone),
-    'labelTab',
-    'base',
-    'scoop',
-    'dividers',
-  ];
-
+  // Walk ZONE_ORDER so this stays in lockstep with the 3MF exporter's
+  // `resolveColorMapping` — both must enumerate the same zones in the same
+  // order or the preview understates the filament count (the `text` zone
+  // was silently dropped here while the exporter shipped it).
   const byHex = new Map<string, Filament>();
-  for (const z of ordered) {
+  for (const z of ZONE_ORDER) {
     if (!activeZones.has(z)) continue;
     const hex = getZoneColor(featureColors, z).toLowerCase();
     const existing = byHex.get(hex);

--- a/src/features/bin-designer/types/featureColors.test.ts
+++ b/src/features/bin-designer/types/featureColors.test.ts
@@ -102,6 +102,13 @@ describe('isSingleColor', () => {
     expect(isSingleColor(c, ZONE_ORDER)).toBe(false);
   });
 
+  it('treats mixed-case hex as the same color', () => {
+    // Locks in case-insensitive equality so this gate stays consistent
+    // with `resolveColorMapping`'s lowercase deduplication.
+    const c = colors({ body: '#FFF', labelTab: '#fff', text: '#FFF' });
+    expect(isSingleColor(c, ['body', 'labelTab', 'text'])).toBe(true);
+  });
+
   it("respects activeZones — disabled lip corners with different colors don't count", () => {
     // The user changed the lip color, then turned off the stacking lip.
     // Lip corners aren't active any more, so the bin is single-color from

--- a/src/features/bin-designer/types/featureColors.test.ts
+++ b/src/features/bin-designer/types/featureColors.test.ts
@@ -139,4 +139,24 @@ describe('resolveColorMapping', () => {
     const { colors: palette } = resolveColorMapping(c);
     expect(palette).toEqual(expect.arrayContaining(['#1', '#2', '#3', '#4']));
   });
+
+  it('normalizes hex to lowercase so mixed-case zones dedupe', () => {
+    // Without normalization the exporter would emit two materials for what
+    // is the same color, breaking lockstep with the slicer-handoff preview
+    // (which already lowercased before deduping). Mirrors the `displaycolor`
+    // convention slicers expect.
+    const c: FeatureColorConfig = {
+      enabled: false,
+      body: '#FFF',
+      lip: { frontLeft: '#fff', frontRight: '#fff', backRight: '#fff', backLeft: '#fff' },
+      labelTab: '#FFF',
+      base: '#fff',
+      scoop: '#FFF',
+      dividers: '#fff',
+      text: '#FFF',
+    };
+    const { colors: palette, colorToIndex } = resolveColorMapping(c);
+    expect(palette).toEqual(['#fff']);
+    expect(colorToIndex.get('#fff')).toBe(0);
+  });
 });

--- a/src/features/bin-designer/types/featureColors.ts
+++ b/src/features/bin-designer/types/featureColors.ts
@@ -219,15 +219,20 @@ export function resolveColorMapping(c: FeatureColorConfig): {
   colorToIndex: ReadonlyMap<string, number>;
   defaultIndex: number;
 } {
+  // Normalize to lowercase before deduping so legacy/imported designs with
+  // mixed-case hex (e.g. body `#FFF` vs text `#fff`) don't emit two
+  // materials in the 3MF while the slicer-handoff preview shows one.
+  // Lowercase hex is also the standard convention for `displaycolor`.
   const colorToIndex = new Map<string, number>();
   const colors: string[] = [];
 
-  colorToIndex.set(c.body, 0);
-  colors.push(c.body);
+  const bodyHex = c.body.toLowerCase();
+  colorToIndex.set(bodyHex, 0);
+  colors.push(bodyHex);
 
   for (const z of ZONE_ORDER) {
     if (z === 'body') continue;
-    const hex = getZoneColor(c, z);
+    const hex = getZoneColor(c, z).toLowerCase();
     if (colorToIndex.has(hex)) continue;
     colorToIndex.set(hex, colors.length);
     colors.push(hex);

--- a/src/features/bin-designer/types/featureColors.ts
+++ b/src/features/bin-designer/types/featureColors.ts
@@ -158,9 +158,13 @@ export function isSingleColor(
   c: FeatureColorConfig,
   activeZones: ReadonlySet<ColorZone> | readonly ColorZone[]
 ): boolean {
-  const ref = c.body;
+  // Compare in lowercase to stay in lockstep with `resolveColorMapping` —
+  // otherwise a mixed-case design (body `#FFF` + text `#fff`) would
+  // skip the early-exit and emit a `<basematerials>` section with a
+  // single material instead of returning null (no basematerials).
+  const ref = c.body.toLowerCase();
   for (const z of activeZones) {
-    if (getZoneColor(c, z) !== ref) return false;
+    if (getZoneColor(c, z).toLowerCase() !== ref) return false;
   }
   return true;
 }

--- a/src/features/bin-designer/utils/materialMapping.ts
+++ b/src/features/bin-designer/utils/materialMapping.ts
@@ -49,7 +49,9 @@ export function buildTriangleMaterialIndices(
   const lipCenter = computeLipBBoxCenter(faceGroups, triangleXY);
 
   const materialIndexForZone = (zone: ColorZone): number => {
-    const hex = getZoneColor(featureColors, zone);
+    // `colorToIndex` is keyed by lowercased hex; normalize here so a config
+    // with mixed-case hex still resolves to the right material slot.
+    const hex = getZoneColor(featureColors, zone).toLowerCase();
     return colorToIndex.get(hex) ?? defaultIndex;
   };
 


### PR DESCRIPTION
## Summary
- `SlicerHandoffPreview` walked a manually-curated zone array that omitted `'text'`. A body+text design rendered as a single filament and the preview hid itself, even though the 3MF exporter shipped two materials. Surfaced while auditing multicolor export end-to-end.
- Replaced the curated list with `ZONE_ORDER` so the preview stays in lockstep with the exporter's `resolveColorMapping`.
- Added a regression test that asserts body+text produces 2 filaments with the Text zone listed; also fixed the test fixture's missing `text` label (pre-existing TS2741 on that file).

## Test plan
- [x] `vitest run src/features/bin-designer/components/ExportDialog` — 30/30 pass
- [x] `vitest run` for `threemfExporter`, `materialMapping`, `lipCornerClassifier`, `binDownloadHelpers`, `SlicerHandoffPreview` — 77/77 pass
- [x] `tsc --noEmit -p tsconfig.app.json` — clean
- [x] `eslint` on changed files — clean
- [ ] Manual: enable Labs > Multi-Color 3MF Export, create a design with engraved label text, change only the text color, open Export dialog with 3MF format — slicer handoff preview should now appear and list both Body and Text filaments