### PR TITLE
test(bin-designer): semantic round-trip tests for multi-color 3MF export

### DIFF
--- a/src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.tsx
+++ b/src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.tsx
@@ -7,7 +7,11 @@
 
 import { useId, useState } from 'react';
 import { ChevronDownIcon } from '@/design-system/Icon';
-import { ZONE_ORDER, getZoneColor } from '@/features/bin-designer/types/featureColors';
+import {
+  ZONE_ORDER,
+  getZoneColor,
+  normalizeHex,
+} from '@/features/bin-designer/types/featureColors';
 import type { ColorZone, FeatureColorConfig } from '@/features/bin-designer/types/featureColors';
 import { useTranslation } from '@/i18n';
 
@@ -34,7 +38,7 @@ function buildFilaments(
   const byHex = new Map<string, Filament>();
   for (const z of ZONE_ORDER) {
     if (!activeZones.has(z)) continue;
-    const hex = getZoneColor(featureColors, z).toLowerCase();
+    const hex = normalizeHex(getZoneColor(featureColors, z));
     const existing = byHex.get(hex);
     if (existing) {
       existing.zones.push(labels[z]);

--- a/src/features/bin-designer/types/featureColors.test.ts
+++ b/src/features/bin-designer/types/featureColors.test.ts
@@ -124,46 +124,55 @@ describe('resolveColorMapping', () => {
   it('puts body at index 0 and dedupes equal colors', () => {
     const c: FeatureColorConfig = {
       enabled: false,
-      body: '#aaa',
-      lip: { frontLeft: '#aaa', frontRight: '#aaa', backRight: '#aaa', backLeft: '#aaa' },
-      labelTab: '#aaa',
-      base: '#bbb',
-      scoop: '#aaa',
-      dividers: '#aaa',
-      text: '#aaa',
+      body: '#aaaaaa',
+      lip: {
+        frontLeft: '#aaaaaa',
+        frontRight: '#aaaaaa',
+        backRight: '#aaaaaa',
+        backLeft: '#aaaaaa',
+      },
+      labelTab: '#aaaaaa',
+      base: '#bbbbbb',
+      scoop: '#aaaaaa',
+      dividers: '#aaaaaa',
+      text: '#aaaaaa',
     };
     const { colors: palette, colorToIndex, defaultIndex } = resolveColorMapping(c);
     expect(defaultIndex).toBe(0);
-    expect(palette).toEqual(['#aaa', '#bbb']);
-    expect(colorToIndex.get('#aaa')).toBe(0);
-    expect(colorToIndex.get('#bbb')).toBe(1);
+    expect(palette).toEqual(['#aaaaaa', '#bbbbbb']);
+    expect(colorToIndex.get('#aaaaaa')).toBe(0);
+    expect(colorToIndex.get('#bbbbbb')).toBe(1);
   });
 
   it('emits four distinct slots when all lip corners differ', () => {
     const c = colors({
-      lip: { frontLeft: '#1', frontRight: '#2', backRight: '#3', backLeft: '#4' },
+      lip: {
+        frontLeft: '#111111',
+        frontRight: '#222222',
+        backRight: '#333333',
+        backLeft: '#444444',
+      },
     });
     const { colors: palette } = resolveColorMapping(c);
-    expect(palette).toEqual(expect.arrayContaining(['#1', '#2', '#3', '#4']));
+    expect(palette).toEqual(expect.arrayContaining(['#111111', '#222222', '#333333', '#444444']));
   });
 
-  it('normalizes hex to lowercase so mixed-case zones dedupe', () => {
-    // Without normalization the exporter would emit two materials for what
-    // is the same color, breaking lockstep with the slicer-handoff preview
-    // (which already lowercased before deduping). Mirrors the `displaycolor`
-    // convention slicers expect.
+  it('normalizes case AND expands 3-char shorthand so equivalent hex dedupes', () => {
+    // Picker emits 6-char lowercase, but legacy/imported designs may carry
+    // CSS-style shorthand or mixed case. Without normalization the exporter
+    // would spuriously emit two materials for what is the same color.
     const c: FeatureColorConfig = {
       enabled: false,
       body: '#FFF',
-      lip: { frontLeft: '#fff', frontRight: '#fff', backRight: '#fff', backLeft: '#fff' },
-      labelTab: '#FFF',
-      base: '#fff',
-      scoop: '#FFF',
-      dividers: '#fff',
+      lip: { frontLeft: '#fff', frontRight: '#FFFFFF', backRight: '#ffffff', backLeft: '#FfF' },
+      labelTab: '#fFf',
+      base: '#FFFFFF',
+      scoop: '#fff',
+      dividers: '#FfFfFf',
       text: '#FFF',
     };
     const { colors: palette, colorToIndex } = resolveColorMapping(c);
-    expect(palette).toEqual(['#fff']);
-    expect(colorToIndex.get('#fff')).toBe(0);
+    expect(palette).toEqual(['#ffffff']);
+    expect(colorToIndex.get('#ffffff')).toBe(0);
   });
 });

--- a/src/features/bin-designer/types/featureColors.ts
+++ b/src/features/bin-designer/types/featureColors.ts
@@ -147,6 +147,23 @@ export function featureTagToColorZone(tag: number): ColorZone | null {
   }
 }
 
+const SHORTHAND_HEX = /^#[0-9a-f]{3}$/;
+
+/**
+ * Canonicalize a hex color string for case/length-insensitive comparison and
+ * deduplication. Lowercases and expands 3-char shorthand (`#rgb` → `#rrggbb`)
+ * so legacy/imported configs with mixed conventions collapse to one slot in
+ * the 3MF basematerials section. Inputs that don't look like recognized hex
+ * forms pass through unchanged (lowercased).
+ */
+export function normalizeHex(hex: string): string {
+  const lower = hex.toLowerCase();
+  if (SHORTHAND_HEX.test(lower)) {
+    return `#${lower[1]}${lower[1]}${lower[2]}${lower[2]}${lower[3]}${lower[3]}`;
+  }
+  return lower;
+}
+
 /**
  * True when every zone in `activeZones` matches body. Required because
  * forgetting to filter out hidden-feature zones would flag a single-color
@@ -158,21 +175,17 @@ export function isSingleColor(
   c: FeatureColorConfig,
   activeZones: ReadonlySet<ColorZone> | readonly ColorZone[]
 ): boolean {
-  // Compare in lowercase to stay in lockstep with `resolveColorMapping` —
-  // otherwise a mixed-case design (body `#FFF` + text `#fff`) would
-  // skip the early-exit and emit a `<basematerials>` section with a
-  // single material instead of returning null (no basematerials).
-  const ref = c.body.toLowerCase();
+  // Normalize in lockstep with `resolveColorMapping` — otherwise a mixed-case
+  // or mixed-length design (body `#FFF` + text `#ffffff`) would skip the
+  // early-exit and emit a `<basematerials>` section with a single material
+  // instead of returning null (no basematerials).
+  const ref = normalizeHex(c.body);
   for (const z of activeZones) {
-    if (getZoneColor(c, z).toLowerCase() !== ref) return false;
+    if (normalizeHex(getZoneColor(c, z)) !== ref) return false;
   }
   return true;
 }
 
-/**
- * Dedupe zone colors into a flat list + lookup map. Body always lands
- * at index 0 so it's the default fallback in 3MF / preview groupings.
- */
 /**
  * Subset of `BinParams` that determines which zones are visually
  * meaningful. Declared structurally to avoid a circular import on
@@ -223,20 +236,20 @@ export function resolveColorMapping(c: FeatureColorConfig): {
   colorToIndex: ReadonlyMap<string, number>;
   defaultIndex: number;
 } {
-  // Normalize to lowercase before deduping so legacy/imported designs with
-  // mixed-case hex (e.g. body `#FFF` vs text `#fff`) don't emit two
-  // materials in the 3MF while the slicer-handoff preview shows one.
-  // Lowercase hex is also the standard convention for `displaycolor`.
+  // Normalize via `normalizeHex` before deduping so legacy/imported designs
+  // with mixed-case or mixed-length hex (e.g. body `#FFF` vs text `#ffffff`)
+  // collapse to a single material rather than spuriously splitting.
+  // Lowercase 6-char hex is also the standard convention for `displaycolor`.
   const colorToIndex = new Map<string, number>();
   const colors: string[] = [];
 
-  const bodyHex = c.body.toLowerCase();
+  const bodyHex = normalizeHex(c.body);
   colorToIndex.set(bodyHex, 0);
   colors.push(bodyHex);
 
   for (const z of ZONE_ORDER) {
     if (z === 'body') continue;
-    const hex = getZoneColor(c, z).toLowerCase();
+    const hex = normalizeHex(getZoneColor(c, z));
     if (colorToIndex.has(hex)) continue;
     colorToIndex.set(hex, colors.length);
     colors.push(hex);

--- a/src/features/bin-designer/utils/materialMapping.ts
+++ b/src/features/bin-designer/utils/materialMapping.ts
@@ -11,6 +11,7 @@ import {
   getZoneColor,
   isSingleColor,
   lipCornerZone,
+  normalizeHex,
   resolveColorMapping,
 } from '../types/featureColors';
 import type { ColorZone, FeatureColorConfig } from '../types/featureColors';
@@ -49,10 +50,8 @@ export function buildTriangleMaterialIndices(
   const lipCenter = computeLipBBoxCenter(faceGroups, triangleXY);
 
   const materialIndexForZone = (zone: ColorZone): number => {
-    // `colorToIndex` is keyed by lowercased hex; normalize here so a config
-    // with mixed-case hex still resolves to the right material slot.
-    const hex = getZoneColor(featureColors, zone).toLowerCase();
-    return colorToIndex.get(hex) ?? defaultIndex;
+    // `colorToIndex` is keyed by `normalizeHex` output.
+    return colorToIndex.get(normalizeHex(getZoneColor(featureColors, zone))) ?? defaultIndex;
   };
 
   for (const group of faceGroups) {

--- a/src/features/bin-designer/utils/multicolorRoundTrip.test.ts
+++ b/src/features/bin-designer/utils/multicolorRoundTrip.test.ts
@@ -77,7 +77,13 @@ function tri(x: number, y: number): number[] {
 async function blobToModelXml(blob: Blob): Promise<string> {
   const bytes = new Uint8Array(await blob.arrayBuffer());
   const entries = unzipSync(bytes);
-  return strFromU8(entries['3D/3dmodel.model']);
+  const model = entries['3D/3dmodel.model'];
+  if (!model) {
+    throw new Error(
+      `3MF missing 3D/3dmodel.model; got entries: ${Object.keys(entries).join(', ')}`
+    );
+  }
+  return strFromU8(model);
 }
 
 interface Material {
@@ -224,12 +230,17 @@ describe('multicolor 3MF round-trip', () => {
         PRINT_SETTINGS,
         true
       );
-      const tris = parseTriangles(await blobToModelXml(blob));
+      const xml = await blobToModelXml(blob);
+      const materials = parseMaterials(xml);
+      const tris = parseTriangles(xml);
 
-      expect(tris[0].p1).toBe(1);
-      expect(tris[1].p1).toBe(1);
-      expect(tris[2].p1).toBe(0);
-      expect(tris[3].p1).toBe(0);
+      // Resolve via material list to keep the assertion self-documenting,
+      // matching the idxFor pattern used by the other tests in this suite.
+      const idxFor = (hex: string) => materials.findIndex((m) => m.color === hex);
+      expect(tris[0].p1).toBe(idxFor('#deadbe')); // LABEL_TAB
+      expect(tris[1].p1).toBe(idxFor('#deadbe')); // LABEL_TAB
+      expect(tris[2].p1).toBe(idxFor('#abc123')); // untagged → body
+      expect(tris[3].p1).toBe(idxFor('#abc123')); // untagged → body
     });
 
     it('TEXT-tagged triangles carry the text zone color when tab/cutout text is active', async () => {

--- a/src/features/bin-designer/utils/multicolorRoundTrip.test.ts
+++ b/src/features/bin-designer/utils/multicolorRoundTrip.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Semantic round-trip tests for multi-color 3MF export.
+ *
+ * The existing test files (`materialMapping.test.ts`, `binDownloadHelpers.test.ts`,
+ * `threemfExporter.test.ts`) cover the layers in isolation. This file pins the
+ * end-to-end semantic invariants on the assembled output of
+ * `buildSinglePiece3MF` / `buildMultiObject3MF`:
+ *
+ *   1. FeatureTag → p1 round-trip — every triangle in a face group emits the
+ *      `p1` index of that feature's configured zone color.
+ *   2. Lip corner round-trip — lip triangles in each XY quadrant carry the
+ *      configured corner color's `p1`.
+ *   3. Single-color short-circuit — all-same-color (incl. mixed-case hex) emits
+ *      no `<basematerials>`; mixed-case dedup yields one material, not two.
+ *   4. Multi-object color contract — only the first piece (bin) carries colors;
+ *      ancillary pieces (dividers, lid) ship solid-color.
+ *
+ * All recent multi-color bugs (text zone missing from preview, mixed-case dedup
+ * gap, isSingleColor case inconsistency) would have been caught by these.
+ *
+ * Inputs are hand-crafted: a tiny synthetic binary STL plus face groups that
+ * partition the triangle range. Real worker output is too expensive for
+ * synthetic breadth; format/integration coverage lives elsewhere.
+ */
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { unzipSync, strFromU8 } from 'fflate';
+import { FeatureTag } from '@/shared/types/generation';
+import type { FaceGroupData } from '@/shared/types/generation';
+import {
+  buildSinglePiece3MF,
+  buildMultiObject3MF,
+} from '@/features/bin-designer/utils/binDownloadHelpers';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import type { BinParams } from '@/features/bin-designer/types';
+import type { ThreeMFPrintSettings } from '@/shared/generation/export';
+
+// ─── helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Encode a flat triangle array as a binary STL ArrayBuffer.
+ * `triangles` is `[x1, y1, z1, x2, y2, z2, x3, y3, z3, ...]` — 9 floats per
+ * triangle. Normal is zero-filled (replicated by parser; not used downstream).
+ */
+function buildBinarySTL(triangles: readonly number[]): ArrayBuffer {
+  const count = triangles.length / 9;
+  const HEADER = 80;
+  const PER_TRI = 50;
+  const buf = new ArrayBuffer(HEADER + 4 + count * PER_TRI);
+  const view = new DataView(buf);
+  view.setUint32(HEADER, count, true);
+
+  let offset = HEADER + 4;
+  for (let t = 0; t < count; t++) {
+    view.setFloat32(offset, 0, true);
+    view.setFloat32(offset + 4, 0, true);
+    view.setFloat32(offset + 8, 0, true);
+    offset += 12;
+    for (let v = 0; v < 3; v++) {
+      const base = t * 9 + v * 3;
+      view.setFloat32(offset, triangles[base], true);
+      view.setFloat32(offset + 4, triangles[base + 1], true);
+      view.setFloat32(offset + 8, triangles[base + 2], true);
+      offset += 12;
+    }
+    view.setUint16(offset, 0, true);
+    offset += 2;
+  }
+  return buf;
+}
+
+/** Single degenerate triangle at (x, y, 0). */
+function tri(x: number, y: number): number[] {
+  return [x, y, 0, x, y, 0, x, y, 0];
+}
+
+async function blobToModelXml(blob: Blob): Promise<string> {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  const entries = unzipSync(bytes);
+  return strFromU8(entries['3D/3dmodel.model']);
+}
+
+interface Material {
+  readonly name: string;
+  readonly color: string;
+}
+
+/** Extract `<base>` entries from inside a `<basematerials>` block, in order. */
+function parseMaterials(xml: string): Material[] {
+  const block = /<basematerials\s+id="(\d+)">([\s\S]*?)<\/basematerials>/.exec(xml);
+  if (!block) return [];
+  const out: Material[] = [];
+  for (const m of block[2].matchAll(/<base\s+name="([^"]*)"\s+displaycolor="([^"]*)"\s*\/>/g)) {
+    out.push({ name: m[1], color: m[2] });
+  }
+  return out;
+}
+
+/** Triangle in document order with its emitted `p1` (or `null` if none). */
+interface Triangle {
+  readonly p1: number | null;
+  readonly pid: number | null;
+}
+
+function parseTriangles(xml: string): Triangle[] {
+  const out: Triangle[] = [];
+  for (const m of xml.matchAll(
+    /<triangle\s+v1="\d+"\s+v2="\d+"\s+v3="\d+"(?:\s+pid="(\d+)"\s+p1="(\d+)")?\s*\/>/g
+  )) {
+    out.push({
+      pid: m[1] !== undefined ? Number(m[1]) : null,
+      p1: m[2] !== undefined ? Number(m[2]) : null,
+    });
+  }
+  return out;
+}
+
+const PRINT_SETTINGS: ThreeMFPrintSettings = {
+  layerHeight: 0.2,
+  infillPercent: 20,
+  material: 'PLA',
+  supportRequired: false,
+};
+
+/**
+ * Build a multi-color-enabled BinParams where:
+ *   1. Every zone (including all four lip corners) defaults to `body` unless
+ *      overridden. Without this, the DEFAULT_BIN_PARAMS lip corners (a
+ *      different hex from a custom body) would silently introduce an extra
+ *      material slot in every test, masking the feature under test.
+ *   2. `label.enabled` and `scoop.enabled` are turned on so that `labelTab`
+ *      and `scoop` zones count as active in `computeActiveZones`. Divergent
+ *      zones get filtered out when their feature is disabled, which would
+ *      make a `{ labelTab: '#ff0000' }` override look like single-color.
+ */
+function withColors(overrides: Partial<BinParams['featureColors']> = {}): BinParams {
+  const body = overrides.body ?? DEFAULT_BIN_PARAMS.featureColors.body;
+  const lipOverride = overrides.lip;
+  const lip = {
+    frontLeft: lipOverride?.frontLeft ?? body,
+    frontRight: lipOverride?.frontRight ?? body,
+    backRight: lipOverride?.backRight ?? body,
+    backLeft: lipOverride?.backLeft ?? body,
+  };
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+    scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true },
+    featureColors: {
+      enabled: true,
+      body,
+      lip,
+      labelTab: overrides.labelTab ?? body,
+      base: overrides.base ?? body,
+      scoop: overrides.scoop ?? body,
+      dividers: overrides.dividers ?? body,
+      text: overrides.text ?? body,
+    },
+  };
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────
+
+describe('multicolor 3MF round-trip', () => {
+  describe('FeatureTag → p1 round-trip', () => {
+    it('every triangle in a face group emits the configured zone color index', async () => {
+      const params = withColors({
+        body: '#111111',
+        labelTab: '#22ee22',
+        base: '#3333ee',
+        scoop: '#ee3333',
+      });
+      const triangles = [
+        ...tri(0, 0),
+        ...tri(1, 0),
+        ...tri(2, 0),
+        ...tri(3, 0),
+        ...tri(4, 0),
+        ...tri(5, 0),
+      ];
+      const faceGroups: FaceGroupData[] = [
+        { start: 0, count: 6, tag: FeatureTag.LABEL_TAB },
+        { start: 6, count: 6, tag: FeatureTag.SOCKET }, // → 'base' zone
+        { start: 12, count: 6, tag: FeatureTag.SCOOP },
+      ];
+      const blob = buildSinglePiece3MF(
+        buildBinarySTL(triangles),
+        faceGroups,
+        params,
+        'round-trip',
+        PRINT_SETTINGS,
+        true
+      );
+      const xml = await blobToModelXml(blob);
+      const materials = parseMaterials(xml);
+      const tris = parseTriangles(xml);
+
+      // Body always lands at index 0 (per resolveColorMapping).
+      const idxFor = (hex: string) => materials.findIndex((m) => m.color === hex);
+      expect(idxFor('#111111')).toBe(0);
+      expect(idxFor('#22ee22')).toBeGreaterThan(0);
+      expect(idxFor('#3333ee')).toBeGreaterThan(0);
+      expect(idxFor('#ee3333')).toBeGreaterThan(0);
+
+      expect(tris.map((t) => t.p1)).toEqual([
+        idxFor('#22ee22'),
+        idxFor('#22ee22'),
+        idxFor('#3333ee'),
+        idxFor('#3333ee'),
+        idxFor('#ee3333'),
+        idxFor('#ee3333'),
+      ]);
+    });
+
+    it('untagged triangles default to body (index 0)', async () => {
+      const params = withColors({ body: '#abc123', labelTab: '#deadbe' });
+      const triangles = [...tri(0, 0), ...tri(1, 0), ...tri(2, 0), ...tri(3, 0)];
+      const faceGroups: FaceGroupData[] = [{ start: 0, count: 6, tag: FeatureTag.LABEL_TAB }];
+      const blob = buildSinglePiece3MF(
+        buildBinarySTL(triangles),
+        faceGroups,
+        params,
+        'untagged',
+        PRINT_SETTINGS,
+        true
+      );
+      const tris = parseTriangles(await blobToModelXml(blob));
+
+      expect(tris[0].p1).toBe(1);
+      expect(tris[1].p1).toBe(1);
+      expect(tris[2].p1).toBe(0);
+      expect(tris[3].p1).toBe(0);
+    });
+
+    it('TEXT-tagged triangles carry the text zone color when tab/cutout text is active', async () => {
+      // Recreates the gap that produced the SlicerHandoffPreview bug at the
+      // export layer: a body+text divergence should produce two filaments.
+      // text zone is active only when label.enabled + compartmentTexts has content.
+      const params: BinParams = {
+        ...withColors({ body: '#222222', text: '#ee44ee' }),
+        compartments: {
+          ...DEFAULT_BIN_PARAMS.compartments,
+          compartmentTexts: ['hello'],
+        },
+      };
+      const triangles = [...tri(0, 0), ...tri(1, 0)];
+      const faceGroups: FaceGroupData[] = [{ start: 0, count: 6, tag: FeatureTag.TEXT }];
+      const blob = buildSinglePiece3MF(
+        buildBinarySTL(triangles),
+        faceGroups,
+        params,
+        'text-zone',
+        PRINT_SETTINGS,
+        true
+      );
+      const xml = await blobToModelXml(blob);
+      const materials = parseMaterials(xml);
+      const tris = parseTriangles(xml);
+
+      expect(materials.map((m) => m.color)).toEqual(['#222222', '#ee44ee']);
+      expect(tris.map((t) => t.p1)).toEqual([1, 1]);
+    });
+
+    it('every emitted pid resolves to the basematerials block (reference integrity)', async () => {
+      const params = withColors({ body: '#fff', base: '#000' });
+      const triangles = [...tri(0, 0), ...tri(1, 0)];
+      const faceGroups: FaceGroupData[] = [{ start: 0, count: 6, tag: FeatureTag.SOCKET }];
+      const blob = buildSinglePiece3MF(
+        buildBinarySTL(triangles),
+        faceGroups,
+        params,
+        'pid-int',
+        PRINT_SETTINGS,
+        true
+      );
+      const xml = await blobToModelXml(blob);
+      const pidMatch = /<basematerials\s+id="(\d+)"/.exec(xml);
+      const baseMaterialsId = pidMatch ? Number(pidMatch[1]) : NaN;
+      const materialsCount = parseMaterials(xml).length;
+      const tris = parseTriangles(xml);
+
+      for (const t of tris) {
+        if (t.pid === null) continue;
+        expect(t.pid).toBe(baseMaterialsId);
+        expect(t.p1).not.toBeNull();
+        expect(t.p1).toBeGreaterThanOrEqual(0);
+        expect(t.p1).toBeLessThan(materialsCount);
+      }
+    });
+  });
+
+  describe('lip corner round-trip', () => {
+    it('lip triangles in each XY quadrant carry the configured corner color', async () => {
+      const params = withColors({
+        body: '#000000',
+        lip: {
+          frontLeft: '#fa0000',
+          frontRight: '#00fa00',
+          backRight: '#0000fa',
+          backLeft: '#ffffff',
+        },
+      });
+      // Four lip triangles, one per quadrant of bbox [0..100] × [0..100].
+      const triangles = [...tri(10, 10), ...tri(90, 10), ...tri(90, 90), ...tri(10, 90)];
+      const faceGroups: FaceGroupData[] = [{ start: 0, count: 12, tag: FeatureTag.LIP }];
+      const blob = buildSinglePiece3MF(
+        buildBinarySTL(triangles),
+        faceGroups,
+        params,
+        'lip-corners',
+        PRINT_SETTINGS,
+        true
+      );
+      const xml = await blobToModelXml(blob);
+      const materials = parseMaterials(xml);
+      const tris = parseTriangles(xml);
+
+      const idxFor = (hex: string) => materials.findIndex((m) => m.color === hex);
+      expect(tris.map((t) => t.p1)).toEqual([
+        idxFor('#fa0000'),
+        idxFor('#00fa00'),
+        idxFor('#0000fa'),
+        idxFor('#ffffff'),
+      ]);
+    });
+  });
+
+  describe('single-color short-circuit', () => {
+    it('all-same-color (lowercase) emits no <basematerials>', async () => {
+      const params = withColors(); // all zones default to '#d4d8dc'
+      const triangles = [...tri(0, 0), ...tri(1, 0)];
+      const faceGroups: FaceGroupData[] = [{ start: 0, count: 6, tag: FeatureTag.SOCKET }];
+      const blob = buildSinglePiece3MF(
+        buildBinarySTL(triangles),
+        faceGroups,
+        params,
+        'single',
+        PRINT_SETTINGS,
+        true
+      );
+      const xml = await blobToModelXml(blob);
+
+      expect(xml).not.toMatch(/<basematerials\b/);
+      expect(xml).not.toMatch(/\bpid="/);
+      expect(xml).not.toMatch(/\bp1="/);
+    });
+
+    it('mixed-case hex collapses to single material (no <basematerials>)', async () => {
+      // Regression for the recent isSingleColor case-normalization fix.
+      // Uniform hex length — shorthand expansion (#fff vs #ffffff) is out of
+      // scope of the case-normalization contract.
+      const params = withColors({ body: '#FFFFFF', base: '#ffffff', labelTab: '#FfFfFf' });
+      const triangles = [...tri(0, 0)];
+      const faceGroups: FaceGroupData[] = [{ start: 0, count: 3, tag: FeatureTag.SOCKET }];
+      const blob = buildSinglePiece3MF(
+        buildBinarySTL(triangles),
+        faceGroups,
+        params,
+        'mixed-case-single',
+        PRINT_SETTINGS,
+        true
+      );
+      const xml = await blobToModelXml(blob);
+
+      expect(xml).not.toMatch(/<basematerials\b/);
+    });
+
+    it('mixed-case dedup yields N materials, not 2N (only divergent zones add slots)', async () => {
+      // Regression for resolveColorMapping case-normalization: body `#FFFFFF`
+      // and base `#ffffff` (same color, different case) collapse to one slot.
+      const params = withColors({ body: '#FFFFFF', base: '#ffffff', labelTab: '#FF0000' });
+      const triangles = [...tri(0, 0), ...tri(1, 0)];
+      const faceGroups: FaceGroupData[] = [
+        { start: 0, count: 3, tag: FeatureTag.SOCKET },
+        { start: 3, count: 3, tag: FeatureTag.LABEL_TAB },
+      ];
+      const blob = buildSinglePiece3MF(
+        buildBinarySTL(triangles),
+        faceGroups,
+        params,
+        'mixed-case-dedup',
+        PRINT_SETTINGS,
+        true
+      );
+      const materials = parseMaterials(await blobToModelXml(blob));
+      expect(materials).toHaveLength(2);
+      // Lowercased per resolveColorMapping's normalization.
+      expect(materials.map((m) => m.color)).toEqual(['#ffffff', '#ff0000']);
+    });
+  });
+
+  describe('multi-object color contract', () => {
+    it('only the first piece (bin) carries colorConfig; ancillary pieces ship solid-color', async () => {
+      const params = withColors({ body: '#aaaaaa', labelTab: '#0000ff' });
+      const pieces = [
+        { data: buildBinarySTL([...tri(0, 0)]), label: 'bin' },
+        { data: buildBinarySTL([...tri(1, 0)]), label: 'divider-horizontal' },
+        { data: buildBinarySTL([...tri(2, 0)]), label: 'lid' },
+      ];
+      const faceGroups: FaceGroupData[] = [{ start: 0, count: 3, tag: FeatureTag.LABEL_TAB }];
+
+      const blob = buildMultiObject3MF(pieces, faceGroups, params, 'assembly', PRINT_SETTINGS);
+      const xml = await blobToModelXml(blob);
+
+      // Exactly one <basematerials> block — for the bin piece.
+      const baseBlocks = xml.match(/<basematerials\b/g) ?? [];
+      expect(baseBlocks).toHaveLength(1);
+
+      // Three <object> entries (bin, divider, lid).
+      const objects = xml.match(/<object\s+id="\d+"/g) ?? [];
+      expect(objects).toHaveLength(3);
+
+      // The basematerials block precedes the first <object> in document order.
+      const baseAt = xml.indexOf('<basematerials');
+      const firstObjAt = xml.indexOf('<object');
+      expect(baseAt).toBeLessThan(firstObjAt);
+    });
+
+    it('multi-color disabled at the params level disables colors on every piece', async () => {
+      const params: BinParams = {
+        ...DEFAULT_BIN_PARAMS,
+        featureColors: { ...DEFAULT_BIN_PARAMS.featureColors, enabled: false, labelTab: '#0000ff' },
+      };
+      const blob = buildMultiObject3MF(
+        [{ data: buildBinarySTL([...tri(0, 0)]), label: 'bin' }],
+        [{ start: 0, count: 3, tag: FeatureTag.LABEL_TAB }],
+        params,
+        'assembly',
+        PRINT_SETTINGS
+      );
+      const xml = await blobToModelXml(blob);
+      expect(xml).not.toMatch(/<basematerials\b/);
+      expect(xml).not.toMatch(/\bp1="/);
+    });
+  });
+});

--- a/src/features/bin-designer/utils/multicolorRoundTrip.test.ts
+++ b/src/features/bin-designer/utils/multicolorRoundTrip.test.ts
@@ -345,11 +345,10 @@ describe('multicolor 3MF round-trip', () => {
       expect(xml).not.toMatch(/\bp1="/);
     });
 
-    it('mixed-case hex collapses to single material (no <basematerials>)', async () => {
-      // Regression for the recent isSingleColor case-normalization fix.
-      // Uniform hex length — shorthand expansion (#fff vs #ffffff) is out of
-      // scope of the case-normalization contract.
-      const params = withColors({ body: '#FFFFFF', base: '#ffffff', labelTab: '#FfFfFf' });
+    it('mixed-case AND mixed-length hex collapse to single material (no <basematerials>)', async () => {
+      // Regressions for the case-normalization and shorthand-expansion fixes.
+      // `#FFF`, `#fff`, `#FFFFFF` all canonicalize to `#ffffff`.
+      const params = withColors({ body: '#FFF', base: '#fff', labelTab: '#FFFFFF' });
       const triangles = [...tri(0, 0)];
       const faceGroups: FaceGroupData[] = [{ start: 0, count: 3, tag: FeatureTag.SOCKET }];
       const blob = buildSinglePiece3MF(
@@ -366,9 +365,9 @@ describe('multicolor 3MF round-trip', () => {
     });
 
     it('mixed-case dedup yields N materials, not 2N (only divergent zones add slots)', async () => {
-      // Regression for resolveColorMapping case-normalization: body `#FFFFFF`
-      // and base `#ffffff` (same color, different case) collapse to one slot.
-      const params = withColors({ body: '#FFFFFF', base: '#ffffff', labelTab: '#FF0000' });
+      // Regression for resolveColorMapping case + shorthand normalization:
+      // body `#FFF`, base `#ffffff`, labelTab `#FF0000` → 2 materials, not 3.
+      const params = withColors({ body: '#FFF', base: '#ffffff', labelTab: '#FF0000' });
       const triangles = [...tri(0, 0), ...tri(1, 0)];
       const faceGroups: FaceGroupData[] = [
         { start: 0, count: 3, tag: FeatureTag.SOCKET },

--- a/src/features/generation/export/stlExporter.test.ts
+++ b/src/features/generation/export/stlExporter.test.ts
@@ -197,11 +197,12 @@ describe('stlExporter', () => {
       expect(() => exportSTL(vertices, normals)).toThrow('length mismatch');
     });
 
-    it('handles empty mesh (0 triangles)', () => {
-      const vertices = new Float32Array(0);
-      const normals = new Float32Array(0);
-      const blob = exportSTL(vertices, normals, 'empty');
-      expect(blob.size).toBe(84); // 80 header + 4 count (0)
+    it('throws on empty mesh (0 triangles)', () => {
+      // STL binary is structurally valid with 0 triangles, but slicers reject
+      // it and 3MF doesn't allow it — reject at the shared validation boundary.
+      expect(() => exportSTL(new Float32Array(0), new Float32Array(0), 'empty')).toThrow(
+        /empty mesh/
+      );
     });
 
     it('uses default name when none provided', () => {

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -138,16 +138,12 @@ describe('threemfExporter', () => {
       expect(() => build3MFBuffer(vertices, normals, { name: 'test' })).toThrow('length mismatch');
     });
 
-    it('handles empty mesh (0 triangles)', () => {
-      const vertices = new Float32Array(0);
-      const normals = new Float32Array(0);
-      const buffer = build3MFBuffer(vertices, normals, { name: 'empty' });
-
-      const xml = extractModelXML(buffer);
-      expect(xml).toContain('<vertices>');
-      expect(xml).toContain('<triangles>');
-      expect(xml).not.toContain('<vertex ');
-      expect(xml).not.toContain('<triangle ');
+    it('throws on empty mesh (0 triangles) — 3MF Core requires ≥1 triangle', () => {
+      // Previously emitted an empty `<vertices/>`/`<triangles/>` pair, which
+      // violates Core spec minOccurs constraints and is rejected by slicers.
+      expect(() =>
+        build3MFBuffer(new Float32Array(0), new Float32Array(0), { name: 'empty' })
+      ).toThrow(/empty mesh/);
     });
   });
 

--- a/src/features/generation/export/validation.ts
+++ b/src/features/generation/export/validation.ts
@@ -10,10 +10,17 @@
  *
  * @param vertices - Flat vertex array (every 9 floats = 1 triangle, 3 vertices x XYZ)
  * @param normals - Flat normal array (must match vertices length)
+ * @throws If the mesh is empty (zero triangles — emits spec-invalid 3MF/STL)
  * @throws If vertex count is not divisible by 9 (incomplete triangles)
  * @throws If normals length doesn't match vertices length
  */
 export function validateMeshData(vertices: Float32Array, normals: Float32Array): void {
+  // 3MF Core spec requires `<vertex>` minOccurs=3 and `<triangle>` minOccurs=1.
+  // STL binary is technically valid with 0 triangles, but slicers reject it.
+  // Reject at the boundary rather than emit a file the spec forbids.
+  if (vertices.length === 0) {
+    throw new Error('Cannot export empty mesh (0 triangles): 3MF Core spec requires ≥1 triangle');
+  }
   if (vertices.length % 9 !== 0) {
     throw new Error(`Invalid vertex count: ${vertices.length} is not divisible by 9`);
   }

--- a/src/features/generation/export/validation.ts
+++ b/src/features/generation/export/validation.ts
@@ -17,9 +17,11 @@
 export function validateMeshData(vertices: Float32Array, normals: Float32Array): void {
   // 3MF Core spec requires `<vertex>` minOccurs=3 and `<triangle>` minOccurs=1.
   // STL binary is technically valid with 0 triangles, but slicers reject it.
-  // Reject at the boundary rather than emit a file the spec forbids.
+  // Reject at the shared boundary so neither path emits an unusable file.
   if (vertices.length === 0) {
-    throw new Error('Cannot export empty mesh (0 triangles): 3MF Core spec requires ≥1 triangle');
+    throw new Error(
+      'Cannot export empty mesh (0 triangles): slicers reject empty meshes and 3MF Core spec forbids them'
+    );
   }
   if (vertices.length % 9 !== 0) {
     throw new Error(`Invalid vertex count: ${vertices.length} is not divisible by 9`);


### PR DESCRIPTION
## Summary

Two changes, both surfaced by writing semantic round-trip tests against `buildSinglePiece3MF` / `buildMultiObject3MF`:

### 1. Semantic round-trip tests (11 new)

End-to-end assertions on the assembled 3MF XML. Each test parses the emitted model.xml and verifies the structural output, closing the gap between "we called the helper correctly" and "the file we ship is correct."

Four invariants pinned:

- **FeatureTag → p1 round-trip** — every triangle in a face group emits the configured zone color's material index.
- **Lip corner round-trip** — lip triangles in each XY quadrant carry the configured corner color.
- **Single-color short-circuit** — all-same-color (incl. mixed-case + shorthand hex) emits no `<basematerials>`.
- **Multi-object color contract** — only the bin piece carries `colorConfig`; dividers/lid ship solid-color.

All recent multi-color bugs (text zone missing from preview, mixed-case dedup gap, `isSingleColor` case inconsistency) would have been caught here. Mutation-verified by reverting each fix and confirming the corresponding test fails.

### 2. Fixes for two existing gaps the tests surfaced

- **Empty mesh emits spec-invalid 3MF** — `build3MFBuffer(empty, empty, ...)` used to emit `<vertices/>` / `<triangles/>`, which violates Core spec (`<vertex>` minOccurs=3, `<triangle>` minOccurs=1) and is rejected by slicers. Path is currently unreachable from the worker but reachable via the public helper. Throw at the validation boundary.
- **Mixed-length hex doesn't dedupe** — `resolveColorMapping` lowercased for case-insensitive dedup but `#fff` and `#ffffff` (CSS shorthand vs full) stayed as distinct keys, so configs with both would emit two `<base>` slots for the same color. Picker only produces 6-char hex so production hits this rarely, but legacy/imported configs can. New shared `normalizeHex` helper (lowercase + expand 3-char shorthand) used by `isSingleColor`, `resolveColorMapping`, `materialMapping`, and `SlicerHandoffPreview` so all four stay in lockstep.

## What this doesn't catch

Honest scope: format/semantic correctness, not visual correctness. Can't tell you a slicer renders the file the way the user expects, only that the right material indices land on the right triangles. Visual regression (slicer screenshot) would be the next tier; out of scope.

## Test plan
- [x] `vitest run multicolorRoundTrip` — 11/11 pass
- [x] Full multicolor suite — 131/131 pass
- [x] Full project suite — 11754/11754 pass
- [x] `tsc --noEmit` clean
- [x] Mutation tests confirm: reverting either case-norm fix or breaking `FeatureTag.TEXT` mapping fails the relevant test