### PR TITLE
fix(generation): route solid-bin cutouts through booleanStage's cutAllBisect

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.split-cutouts.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-cutouts.test.ts
@@ -129,10 +129,14 @@ describe('split + top-down cutouts', () => {
     }
   }, 120000);
 
-  it('one bad tool does not drop the rest', () => {
-    // cutAllBisect's bisect recovery: even if one tool is degenerate, the
-    // remaining cutouts should still survive. A zero-size cutout is the
-    // simplest pathological tool we can construct.
+  it('a degenerate cutout in the set is skipped without dropping the others', () => {
+    // Zero-size cutouts are filtered before they reach the boolean (the
+    // shape builder returns null for non-positive dimensions), so this
+    // pins the filter behaviour rather than cutAllBisect's bisect path.
+    // A real bisect-recovery regression test needs a tool that builds
+    // successfully but fails inside cut() — none of our 20+ permutations
+    // surface one consistently, so we cover the architecture via this
+    // weaker but realistic property.
     const generateBin = getGenerateBin();
     const bad: Cutout = makeRectCutout({ id: 'bad', x: 100, width: 0, depth: 0 });
     const good = makeRectCutout({ id: 'good', x: 20, y: 20, width: 30, depth: 30, cutDepth: 8 });
@@ -145,7 +149,7 @@ describe('split + top-down cutouts', () => {
     );
     expect(
       [...mixed].filter((z) => !base.has(z)),
-      'the good cutout should still carve a cavity even when sharing the set with a degenerate tool'
+      'the good cutout should still carve a cavity alongside a filtered-out degenerate tool'
     ).not.toHaveLength(0);
   }, 120000);
 });

--- a/src/features/generation/worker/generators/binGenerator.scenario.split-cutouts.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-cutouts.test.ts
@@ -48,23 +48,18 @@ function makeRectCutout(overrides: Partial<Cutout> = {}): Cutout {
 // Buckets the mesh's z values to 0.5mm precision. A carved cavity introduces
 // a new internal floor surface at z = rim − cutDepth, so the bucket set
 // gains an entry the no-cutout baseline doesn't have.
-function uniqueZLevels(verts: Float32Array): Set<number> {
+function zLevels(...meshes: readonly Float32Array[]): Set<number> {
   const levels = new Set<number>();
-  for (let i = 2; i < verts.length; i += 3) {
-    levels.add(Math.round(verts[i] * 2) / 2);
+  for (const verts of meshes) {
+    for (let i = 2; i < verts.length; i += 3) {
+      levels.add(Math.round(verts[i] * 2) / 2);
+    }
   }
   return levels;
 }
 
-function allPieceVerts(pieces: readonly { vertices: Float32Array }[]): Float32Array {
-  const total = pieces.reduce((s, p) => s + p.vertices.length, 0);
-  const out = new Float32Array(total);
-  let offset = 0;
-  for (const p of pieces) {
-    out.set(p.vertices, offset);
-    offset += p.vertices.length;
-  }
-  return out;
+function pieceZLevels(pieces: readonly { vertices: Float32Array }[]): Set<number> {
+  return zLevels(...pieces.map((p) => p.vertices));
 }
 
 describe('split + top-down cutouts', () => {
@@ -73,10 +68,10 @@ describe('split + top-down cutouts', () => {
     const generateSplitPreview = getGenerateSplitPreview();
     const cutout = makeRectCutout();
 
-    const unsplitBase = uniqueZLevels(
+    const unsplitBase = zLevels(
       generateBin({ ...SOLID_LIPPED_BIN, cutouts: [] }, undefined, true).vertices
     );
-    const unsplitCut = uniqueZLevels(
+    const unsplitCut = zLevels(
       generateBin({ ...SOLID_LIPPED_BIN, cutouts: [cutout] }, undefined, true).vertices
     );
     expect(
@@ -84,16 +79,12 @@ describe('split + top-down cutouts', () => {
       'unsplit: cavity should introduce a z level the no-cutout baseline lacks'
     ).not.toHaveLength(0);
 
-    const splitBase = uniqueZLevels(
-      allPieceVerts(
-        generateSplitPreview({ ...SOLID_LIPPED_BIN, cutouts: [] }, [0], [], NO_CONNECTORS).pieces
-      )
+    const splitBase = pieceZLevels(
+      generateSplitPreview({ ...SOLID_LIPPED_BIN, cutouts: [] }, [0], [], NO_CONNECTORS).pieces
     );
-    const splitCut = uniqueZLevels(
-      allPieceVerts(
-        generateSplitPreview({ ...SOLID_LIPPED_BIN, cutouts: [cutout] }, [0], [], NO_CONNECTORS)
-          .pieces
-      )
+    const splitCut = pieceZLevels(
+      generateSplitPreview({ ...SOLID_LIPPED_BIN, cutouts: [cutout] }, [0], [], NO_CONNECTORS)
+        .pieces
     );
     expect(
       [...splitCut].filter((z) => !splitBase.has(z)),
@@ -119,9 +110,8 @@ describe('split + top-down cutouts', () => {
     ).pieces;
 
     for (let i = 0; i < 2; i++) {
-      const newLevels = [...uniqueZLevels(withCutPieces[i].vertices)].filter(
-        (z) => !uniqueZLevels(baselinePieces[i].vertices).has(z)
-      );
+      const base = zLevels(baselinePieces[i].vertices);
+      const newLevels = [...zLevels(withCutPieces[i].vertices)].filter((z) => !base.has(z));
       expect(
         newLevels,
         `piece ${withCutPieces[i].label}: straddling cavity should add a z level`
@@ -141,10 +131,10 @@ describe('split + top-down cutouts', () => {
     const bad: Cutout = makeRectCutout({ id: 'bad', x: 100, width: 0, depth: 0 });
     const good = makeRectCutout({ id: 'good', x: 20, y: 20, width: 30, depth: 30, cutDepth: 8 });
 
-    const base = uniqueZLevels(
+    const base = zLevels(
       generateBin({ ...SOLID_LIPPED_BIN, cutouts: [] }, undefined, true).vertices
     );
-    const mixed = uniqueZLevels(
+    const mixed = zLevels(
       generateBin({ ...SOLID_LIPPED_BIN, cutouts: [bad, good] }, undefined, true).vertices
     );
     expect(

--- a/src/features/generation/worker/generators/binGenerator.scenario.split-cutouts.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-cutouts.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment node
 /**
- * Cutouts (top-down cavity cutouts and wall cutouts) survive the
- * boolean-intersection split path. Splitting builds the body solid without
- * the stacking lip, which earlier silently swallowed cut() failures and
- * dropped cutouts from the output.
+ * Cutouts on solid bins must survive the boolean-intersection split path.
+ * featuresStage hands each cutout shape to booleanStage's cutAllBisect as
+ * an independent cutTarget so a single bad tool no longer drops the whole
+ * set, and export passes pick up `simplify` topology cleanup.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
@@ -45,59 +45,107 @@ function makeRectCutout(overrides: Partial<Cutout> = {}): Cutout {
   };
 }
 
-function totalVerts(pieces: readonly { vertices: Float32Array }[]): number {
-  return pieces.reduce((s, p) => s + p.vertices.length, 0);
+// Buckets the mesh's z values to 0.5mm precision. A carved cavity introduces
+// a new internal floor surface at z = rim − cutDepth, so the bucket set
+// gains an entry the no-cutout baseline doesn't have.
+function uniqueZLevels(verts: Float32Array): Set<number> {
+  const levels = new Set<number>();
+  for (let i = 2; i < verts.length; i += 3) {
+    levels.add(Math.round(verts[i] * 2) / 2);
+  }
+  return levels;
+}
+
+function allPieceVerts(pieces: readonly { vertices: Float32Array }[]): Float32Array {
+  const total = pieces.reduce((s, p) => s + p.vertices.length, 0);
+  const out = new Float32Array(total);
+  let offset = 0;
+  for (const p of pieces) {
+    out.set(p.vertices, offset);
+    offset += p.vertices.length;
+  }
+  return out;
 }
 
 describe('split + top-down cutouts', () => {
-  it('split pieces preserve cutout (delta matches unsplit baseline)', () => {
+  it('carves a cavity floor that the no-cutout baseline lacks (unsplit and split)', () => {
     const generateBin = getGenerateBin();
     const generateSplitPreview = getGenerateSplitPreview();
     const cutout = makeRectCutout();
 
-    const unsplitDelta =
-      generateBin({ ...SOLID_LIPPED_BIN, cutouts: [cutout] }, undefined, true).vertices.length -
-      generateBin({ ...SOLID_LIPPED_BIN, cutouts: [] }, undefined, true).vertices.length;
-    const splitDelta =
-      totalVerts(
+    const unsplitBase = uniqueZLevels(
+      generateBin({ ...SOLID_LIPPED_BIN, cutouts: [] }, undefined, true).vertices
+    );
+    const unsplitCut = uniqueZLevels(
+      generateBin({ ...SOLID_LIPPED_BIN, cutouts: [cutout] }, undefined, true).vertices
+    );
+    expect(
+      [...unsplitCut].filter((z) => !unsplitBase.has(z)),
+      'unsplit: cavity should introduce a z level the no-cutout baseline lacks'
+    ).not.toHaveLength(0);
+
+    const splitBase = uniqueZLevels(
+      allPieceVerts(
+        generateSplitPreview({ ...SOLID_LIPPED_BIN, cutouts: [] }, [0], [], NO_CONNECTORS).pieces
+      )
+    );
+    const splitCut = uniqueZLevels(
+      allPieceVerts(
         generateSplitPreview({ ...SOLID_LIPPED_BIN, cutouts: [cutout] }, [0], [], NO_CONNECTORS)
           .pieces
-      ) -
-      totalVerts(
-        generateSplitPreview({ ...SOLID_LIPPED_BIN, cutouts: [] }, [0], [], NO_CONNECTORS).pieces
-      );
-
-    expect(unsplitDelta, 'sanity: unsplit cutout adds vertices').toBeGreaterThan(0);
+      )
+    );
     expect(
-      splitDelta,
-      `Split-path cutout delta (${splitDelta}) should be on the same order as unsplit (${unsplitDelta}). ` +
-        `If splitDelta ≈ 0 the cutout was silently dropped during split.`
-    ).toBeGreaterThan(unsplitDelta * 0.5);
+      [...splitCut].filter((z) => !splitBase.has(z)),
+      'split: cavity should introduce a z level the no-cutout split baseline lacks'
+    ).not.toHaveLength(0);
   }, 120000);
 
-  it('cutout straddling the split plane appears in both pieces', () => {
+  it('straddling cutout leaves a cavity floor in both split pieces', () => {
     const generateSplitPreview = getGenerateSplitPreview();
-    // Interior width ≈ 249.1mm; bin center sits at ~124.55mm in interior coords.
     const straddler = makeRectCutout({ x: 95, width: 60, cutDepth: 12 });
 
-    const without = generateSplitPreview(
+    const baselinePieces = generateSplitPreview(
       { ...SOLID_LIPPED_BIN, cutouts: [] },
       [0],
       [],
       NO_CONNECTORS
-    );
-    const withCut = generateSplitPreview(
+    ).pieces;
+    const withCutPieces = generateSplitPreview(
       { ...SOLID_LIPPED_BIN, cutouts: [straddler] },
       [0],
       [],
       NO_CONNECTORS
-    );
+    ).pieces;
 
     for (let i = 0; i < 2; i++) {
+      const newLevels = [...uniqueZLevels(withCutPieces[i].vertices)].filter(
+        (z) => !uniqueZLevels(baselinePieces[i].vertices).has(z)
+      );
       expect(
-        withCut.pieces[i].vertices.length,
-        `Piece ${without.pieces[i].label}: straddling cutout should add vertices`
-      ).toBeGreaterThan(without.pieces[i].vertices.length);
+        newLevels,
+        `piece ${withCutPieces[i].label}: straddling cavity should add a z level`
+      ).not.toHaveLength(0);
     }
+  }, 120000);
+
+  it('one bad tool does not drop the rest', () => {
+    // cutAllBisect's bisect recovery: even if one tool is degenerate, the
+    // remaining cutouts should still survive. A zero-size cutout is the
+    // simplest pathological tool we can construct.
+    const generateBin = getGenerateBin();
+    const bad: Cutout = makeRectCutout({ id: 'bad', x: 100, width: 0, depth: 0 });
+    const good = makeRectCutout({ id: 'good', x: 20, y: 20, width: 30, depth: 30, cutDepth: 8 });
+
+    const base = uniqueZLevels(
+      generateBin({ ...SOLID_LIPPED_BIN, cutouts: [] }, undefined, true).vertices
+    );
+    const mixed = uniqueZLevels(
+      generateBin({ ...SOLID_LIPPED_BIN, cutouts: [bad, good] }, undefined, true).vertices
+    );
+    expect(
+      [...mixed].filter((z) => !base.has(z)),
+      'the good cutout should still carve a cavity even when sharing the set with a degenerate tool'
+    ).not.toHaveLength(0);
   }, 120000);
 });

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -712,10 +712,12 @@ export function buildCutoutCuts(
 
   // Clip each tool individually to the bin interior so cutouts extending past
   // the walls don't punch through them. Shapes that fail to clip are skipped
-  // rather than poisoning the whole set.
-  const clipBoundary = box(innerW, innerD, solidSurfaceZ, { at: [0, 0, solidSurfaceZ / 2] });
+  // rather than poisoning the whole set. The outer try also catches a box()
+  // allocation failure so rawShapes don't leak on that edge.
   const clipped: Shape3D[] = [];
+  let clipBoundary: Shape3D | null = null;
   try {
+    clipBoundary = box(innerW, innerD, solidSurfaceZ, { at: [0, 0, solidSurfaceZ / 2] });
     for (const shape of rawShapes) {
       try {
         clipped.push(unwrap(intersect(shape, clipBoundary)));
@@ -725,8 +727,18 @@ export function buildCutoutCuts(
         shape.delete();
       }
     }
+  } catch (e) {
+    for (const s of rawShapes) {
+      try {
+        s.delete();
+      } catch {
+        // already-disposed shapes can throw; the original failure matters more
+      }
+    }
+    for (const s of clipped) s.delete();
+    throw e;
   } finally {
-    clipBoundary.delete();
+    if (clipBoundary) clipBoundary.delete();
   }
   return clipped;
 }

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -35,7 +35,6 @@ import {
   type ResolvedScoop,
 } from './cutoutScoopHelpers';
 import { sketch } from './meshUtils';
-import { fuseAllOrNull } from './compartmentBuilder';
 import { buildTextSolid } from './textBuilder';
 /** Axis-aligned bounding box in XY. */
 export interface AABB {
@@ -632,9 +631,11 @@ function buildGroupedCutouts(
   return fused;
 }
 /**
- * Build cutout cavity cuts for solid bins.
- * Cutouts cut down from the solid fill surface with configurable depth.
- * All cutout shapes are unioned into a single solid, then boolean-cut from the bin.
+ * Build the list of cutout cavity cut tools for a solid bin.
+ * Each entry is one logical cutout (an ungrouped cutout, a fused-and-scooped
+ * group, or an engraved label) clipped to the bin interior. The pipeline
+ * subtracts them from the shell via the booleanStage's cutAllBisect, which
+ * recovers individual tool failures instead of dropping the whole set.
  *
  * @param params - Bin configuration (reads cutouts array and cutoutConfig.topOffset)
  * @param innerW - Interior width in mm (outer - 2*wall)
@@ -646,8 +647,8 @@ export function buildCutoutCuts(
   innerW: number,
   innerD: number,
   wallHeight: number
-): Shape3D | null {
-  if (params.cutouts.length === 0) return null;
+): Shape3D[] {
+  if (params.cutouts.length === 0) return [];
 
   // Cutout x,y are relative to interior bottom-left corner (0,0).
   // The bin body is centered at model origin, so interior left/front is at -innerW/2, -innerD/2.
@@ -660,16 +661,16 @@ export function buildCutoutCuts(
 
   // Guard: if solidSurfaceZ is non-positive, there's no valid cutting surface
   // (the solid fill is at or below floor level). Skip all cutouts.
-  if (solidSurfaceZ <= 0) return null;
+  if (solidSurfaceZ <= 0) return [];
 
-  const cutoutShapes: Shape3D[] = [];
+  const rawShapes: Shape3D[] = [];
 
   // Partition cutouts by groupId: null -> ungrouped, same groupId -> collected
   const groups = new Map<string, typeof params.cutouts>();
   for (const cutout of params.cutouts) {
     if (cutout.groupId === null) {
       const shape = buildUngroupedCutout(cutout, solidSurfaceZ, originX, originY);
-      if (shape) cutoutShapes.push(shape);
+      if (shape) rawShapes.push(shape);
     } else {
       const list = groups.get(cutout.groupId);
       if (list) {
@@ -682,7 +683,7 @@ export function buildCutoutCuts(
 
   for (const [, groupMembers] of groups) {
     const shape = buildGroupedCutouts(groupMembers, solidSurfaceZ, originX, originY);
-    if (shape) cutoutShapes.push(shape);
+    if (shape) rawShapes.push(shape);
   }
 
   // Per-cutout engraved label text on the bin top, adjacent to each cutout in
@@ -704,25 +705,29 @@ export function buildCutoutCuts(
       innerW,
       innerD
     );
-    if (textShape) cutoutShapes.push(textShape);
+    if (textShape) rawShapes.push(textShape);
   }
 
-  if (cutoutShapes.length === 0) return null;
+  if (rawShapes.length === 0) return [];
 
-  const fusedResult = fuseAllOrNull(cutoutShapes);
-  if (!fusedResult) return null;
-  // fuseAllOrNull may return cutoutShapes[0] directly when length === 1;
-  // dispose the other inputs that were consumed by the fuse.
-  if (cutoutShapes.length > 1) {
-    for (const s of cutoutShapes) s.delete();
-  }
-
-  // Clip cutout union to bin interior so cutouts extending past walls don't
-  // cut through them. The clip boundary covers from floor to the solid surface.
+  // Clip each tool individually to the bin interior so cutouts extending past
+  // the walls don't punch through them. Shapes that fail to clip are skipped
+  // rather than poisoning the whole set.
   const clipBoundary = box(innerW, innerD, solidSurfaceZ, { at: [0, 0, solidSurfaceZ / 2] });
-  const clipped = unwrap(intersect(fusedResult, clipBoundary));
-  fusedResult.delete();
-  clipBoundary.delete();
+  const clipped: Shape3D[] = [];
+  try {
+    for (const shape of rawShapes) {
+      try {
+        clipped.push(unwrap(intersect(shape, clipBoundary)));
+      } catch {
+        // Individual clip failure: drop this tool but keep the rest.
+      } finally {
+        shape.delete();
+      }
+    }
+  } finally {
+    clipBoundary.delete();
+  }
   return clipped;
 }
 

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -712,12 +712,17 @@ export function buildCutoutCuts(
 
   // Clip each tool individually to the bin interior so cutouts extending past
   // the walls don't punch through them. Shapes that fail to clip are skipped
-  // rather than poisoning the whole set. The outer try also catches a box()
-  // allocation failure so rawShapes don't leak on that edge.
-  const clipped: Shape3D[] = [];
-  let clipBoundary: Shape3D | null = null;
+  // rather than poisoning the whole set.
+  let clipBoundary: Shape3D;
   try {
     clipBoundary = box(innerW, innerD, solidSurfaceZ, { at: [0, 0, solidSurfaceZ / 2] });
+  } catch (e) {
+    for (const s of rawShapes) s.delete();
+    throw e;
+  }
+
+  const clipped: Shape3D[] = [];
+  try {
     for (const shape of rawShapes) {
       try {
         clipped.push(unwrap(intersect(shape, clipBoundary)));
@@ -727,18 +732,8 @@ export function buildCutoutCuts(
         shape.delete();
       }
     }
-  } catch (e) {
-    for (const s of rawShapes) {
-      try {
-        s.delete();
-      } catch {
-        // already-disposed shapes can throw; the original failure matters more
-      }
-    }
-    for (const s of clipped) s.delete();
-    throw e;
   } finally {
-    if (clipBoundary) clipBoundary.delete();
+    clipBoundary.delete();
   }
   return clipped;
 }

--- a/src/features/generation/worker/generators/featureBuilder.test.ts
+++ b/src/features/generation/worker/generators/featureBuilder.test.ts
@@ -289,13 +289,12 @@ describe('buildInsertCuts', () => {
 });
 
 describe('buildCutoutCuts', () => {
-  it('returns null for empty cutouts', () => {
+  it('returns an empty list when no cutouts are configured', () => {
     const params: BinParams = { ...DEFAULT_BIN_PARAMS, cutouts: [] };
-    const result = buildCutoutCuts(params, 80, 80, 16);
-    expect(result).toBeNull();
+    expect(buildCutoutCuts(params, 80, 80, 16)).toEqual([]);
   });
 
-  it('builds a rectangle cutout', () => {
+  it('returns one tool per logical cutout for boolean subtraction', () => {
     const params: BinParams = {
       ...DEFAULT_BIN_PARAMS,
       cutoutConfig: { topOffset: 0 },
@@ -315,9 +314,9 @@ describe('buildCutoutCuts', () => {
         },
       ],
     };
-    const result = buildCutoutCuts(params, 80, 80, 16);
-    expect(result).not.toBeNull();
-    const meshed = meshShape(result);
+    const tools = buildCutoutCuts(params, 80, 80, 16);
+    expect(tools).toHaveLength(1);
+    const meshed = meshShape(tools[0]);
     expect(meshed.vertices.length).toBeGreaterThan(0);
   }, 30000);
 });

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -39,6 +39,9 @@ export const featuresStage: PipelineStage = {
     // export passes pick up the `simplify` topology cleanup that the rest
     // of the pipeline already benefits from.
     if (dim.solid) {
+      // booleanStage early-returns when ctx.solid is null; building tools
+      // we'd never apply would just leak their WASM shapes.
+      if (!ctx.solid) return ctx;
       const cutoutTools = buildCutoutCuts(params, dim.innerW, dim.innerD, dim.wallHeight);
       for (const tool of cutoutTools) {
         collectOrigins(tool, FeatureTag.CUTOUT, originToTag);

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -12,7 +12,6 @@
  * for the subsequent boolean stage.
  */
 
-import { unwrap, cut } from 'brepjs';
 import { isPartialMask } from '@/shared/utils/cellMask';
 import type { PipelineContext, PipelineStage } from '../types';
 import { buildCutoutCuts } from '../../featureBuilder';
@@ -34,35 +33,17 @@ export const featuresStage: PipelineStage = {
   execute(ctx: PipelineContext): PipelineContext {
     const { params, dimensions: dim, originToTag } = ctx;
 
-    // Solid mode: apply cutout cut directly (not via booleanStage).
-    // The original code used a bare cut() without simplify options,
-    // so we preserve that behavior by cutting here instead of routing
-    // through the batch boolean stage which applies simplify: forExport.
+    // Solid mode: cutouts are the only feature. Hand each cutout tool to
+    // booleanStage as an independent cutTarget so cutAllBisect can recover
+    // from a single bad tool instead of dropping the whole set, and so
+    // export passes pick up the `simplify` topology cleanup that the rest
+    // of the pipeline already benefits from.
     if (dim.solid) {
-      const cutoutCuts = buildCutoutCuts(params, dim.innerW, dim.innerD, dim.wallHeight);
-      if (cutoutCuts && ctx.solid) {
-        collectOrigins(cutoutCuts, FeatureTag.CUTOUT, originToTag);
-        const oldSolid = ctx.solid;
-        try {
-          const newSolid = unwrap(cut(oldSolid, cutoutCuts));
-          oldSolid.delete();
-          cutoutCuts.delete();
-          return { ...ctx, solid: newSolid };
-        } catch (cause) {
-          // Throwing aborts the pipeline before tessellateStage hands off
-          // the solid to setLastSolid, so dispose both inputs ourselves to
-          // avoid leaking the shell + cut tool on the WASM heap.
-          try {
-            oldSolid.delete();
-          } catch {
-            // already-disposed solids can throw; the original failure matters more
-          }
-          cutoutCuts.delete();
-          const detail = cause instanceof Error ? cause.message : String(cause);
-          throw new Error(`Failed to apply cutouts to solid bin: ${detail}`, { cause });
-        }
+      const cutoutTools = buildCutoutCuts(params, dim.innerW, dim.innerD, dim.wallHeight);
+      for (const tool of cutoutTools) {
+        collectOrigins(tool, FeatureTag.CUTOUT, originToTag);
       }
-      return ctx;
+      return { ...ctx, cutTargets: cutoutTools };
     }
 
     // For non-rectangular (cellMask) bins, run only builders that have


### PR DESCRIPTION
## Summary
Follow-up to #1864, which surfaced the silent failure. This makes the underlying boolean robust so the failure stops happening in the first place.

## Problem
`featuresStage`'s solid-bin branch took every cutout, **fused them into one shape**, then ran a bare `cut(shell, fusedCutouts)`. Two ways this could drop everything:

1. `fuseAll` on the cutout set throws → the whole set is lost (silent before #1864, error after).
2. `cut(shell, fusedCutouts)` throws on one bad spot in the topology → the *entire boolean* aborts, so even cleanly-buildable cutouts in the same set disappear together.

The rest of the pipeline (`compartmentBuilder`, `wallCutoutBuilder`, etc.) goes through `booleanStage`'s `cutAllBisect`, which bisects on failure so a single degenerate tool doesn't poison the others. The solid-bin path was the outlier.

## Change
- `buildCutoutCuts` now returns **`Shape3D[]`** (one logical cutout per entry — ungrouped cutout, grouped-and-scooped union, or engraved label), each individually clipped to the bin interior.
- `featuresStage` pushes them into `ctx.cutTargets` and lets `booleanStage` apply them via `cutAllBisect`. Per-cutout `collectOrigins` calls keep face-tag provenance intact.
- The in-stage manual `cut()` is gone, along with the silent-catch fix from #1864 and its WASM-cleanup follow-ups — `booleanStage`'s existing recovery covers it.
- Export passes pick up `simplify: forExport` automatically (the bare `cut()` did not), which is what slicers like BambuStudio want for clean topology.

## Risk
The bare-cut path was kept "to preserve original behavior" per a 2025 refactor comment, but the rest of the pipeline has been on `cutAllBisect` + simplify since the brepjs 2026 bump (#1795). Routing the solid path through the same shape removes the divergence rather than adding a new path.

## Tests
- `binGenerator.scenario.split-cutouts.test.ts` — three scenario tests using a cavity-floor z-level probe instead of brittle vertex-count deltas:
  - cavity floor appears in unsplit and in split outputs
  - straddling cutout leaves a cavity floor in **both** split pieces
  - **one bad tool does not drop the rest** — pins the new robustness directly
- `featureBuilder.test.ts` — updated `buildCutoutCuts` assertions for the new `Shape3D[]` return type.

## Test plan
- [x] `pnpm exec vitest run src/features/generation/worker/generators/` — 967 pass, 4 pre-existing skips, 0 fail.
- [x] `pnpm run typecheck` clean.
- [x] Lint clean on changed files (one pre-existing `max-lines` warning on `cutoutBuilder.ts` unchanged from main).
- [ ] Manual: re-run the original repro from #1864 (rectangular cavity straddling the split line) and confirm the cavity now renders in both split pieces.