### PR TITLE
chore: harden supply chain against npm + actions attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
       prefix: 'chore(deps)'
     labels:
       - 'dependencies'
+    # Mirror the pnpm `minimumReleaseAge` cooldown (see pnpm-workspace.yaml).
+    # Keeps Dependabot from opening PRs that would fail install anyway, and
+    # widens the detection window for compromised releases.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     groups:
       # Group all minor and patch updates together
       minor-and-patch:
@@ -71,3 +77,9 @@ updates:
     labels:
       - 'ci'
       - 'dependencies'
+    # Cooldown for actions too — defends against the tj-actions tag-retag class
+    # of attack where a compromised maintainer republishes a tag to a malicious
+    # commit. By the time Dependabot opens the PR, the bad version has usually
+    # been detected and rolled back.
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,7 @@ updates:
       prefix: 'chore(deps)'
     labels:
       - 'dependencies'
-    # Mirror the pnpm `minimumReleaseAge` cooldown (see pnpm-workspace.yaml).
-    # Keeps Dependabot from opening PRs that would fail install anyway, and
-    # widens the detection window for compromised releases.
+    # Mirrors pnpm minimumReleaseAge — see SECURITY.md.
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -77,9 +75,6 @@ updates:
     labels:
       - 'ci'
       - 'dependencies'
-    # Cooldown for actions too — defends against the tj-actions tag-retag class
-    # of attack where a compromised maintainer republishes a tag to a malicious
-    # commit. By the time Dependabot opens the PR, the bad version has usually
-    # been detected and rolled back.
+    # Action tag-retag defense — see SECURITY.md.
     cooldown:
       default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
     if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -67,13 +67,13 @@ jobs:
       matrix:
         shard: ${{ github.event_name == 'pull_request' && fromJSON('["1/2", "2/2"]') || fromJSON('["1/1"]') }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -100,7 +100,7 @@ jobs:
           fi
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure() && github.ref == 'refs/heads/main'
         with:
           name: coverage-report
@@ -114,13 +114,13 @@ jobs:
     if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,17 +26,17 @@ jobs:
       matrix:
         language: [javascript-typescript]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,7 +14,7 @@ jobs:
     name: Auto-label PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,16 +1,9 @@
 name: OSV Scan
 
-# Scans the lockfile against the OSV/GHSA advisory database. Catches known-bad
-# package versions you may be exposed to, including supply-chain compromises
-# that have been disclosed since the last install. Complements the
-# `minimumReleaseAge` cooldown (which prevents installing fresh-from-publish
-# versions): OSV catches old-but-known-bad, cooldown catches new-but-untrusted.
-#
-# Policy:
-#   - PRs: report-only. We don't block merges since transitive deps sometimes
-#     can't be updated atomically with the rest of a feature PR.
-#   - main / weekly: hard fail so the dashboard stays loud and someone has to
-#     either patch or explicitly waive the finding.
+# Complements the pnpm minimumReleaseAge cooldown: cooldown blocks
+# fresh-but-untrusted, OSV blocks old-but-known-bad.
+# PRs are report-only (transitive deps can't always be updated atomically with
+# a feature PR); main + weekly schedule fail closed so the dashboard stays loud.
 
 on:
   pull_request:
@@ -18,12 +11,7 @@ on:
   push:
     branches: [main]
   schedule:
-    - cron: '0 6 * * 1' # Weekly Monday 6am UTC
-
-permissions:
-  contents: read
-  security-events: write
-  actions: read
+    - cron: '0 6 * * 1'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -34,6 +22,9 @@ jobs:
     name: OSV Scan (report-only)
     if: github.event_name == 'pull_request'
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=pnpm-lock.yaml
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,0 +1,52 @@
+name: OSV Scan
+
+# Scans the lockfile against the OSV/GHSA advisory database. Catches known-bad
+# package versions you may be exposed to, including supply-chain compromises
+# that have been disclosed since the last install. Complements the
+# `minimumReleaseAge` cooldown (which prevents installing fresh-from-publish
+# versions): OSV catches old-but-known-bad, cooldown catches new-but-untrusted.
+#
+# Policy:
+#   - PRs: report-only. We don't block merges since transitive deps sometimes
+#     can't be updated atomically with the rest of a feature PR.
+#   - main / weekly: hard fail so the dashboard stays loud and someone has to
+#     either patch or explicitly waive the finding.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1' # Weekly Monday 6am UTC
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan-pr:
+    name: OSV Scan (report-only)
+    if: github.event_name == 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+  scan-main:
+    name: OSV Scan (blocking)
+    if: github.event_name != 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=pnpm-lock.yaml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/smoke-postpromote.yml
+++ b/.github/workflows/smoke-postpromote.yml
@@ -38,7 +38,7 @@ jobs:
       DEPLOY_ID: ${{ github.event.deployment.id }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Resolve smoke target URL
         id: target
@@ -65,7 +65,7 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload trace on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smoke-postpromote-trace
           path: test-results/

--- a/.github/workflows/smoke-preview.yml
+++ b/.github/workflows/smoke-preview.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Dependabot PR runs do not have access to repo Actions secrets, including
       # VERCEL_AUTOMATION_BYPASS_SECRET — so the preview will return 401 and the
@@ -125,7 +125,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.preview.outputs.status == 'ready'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -151,7 +151,7 @@ jobs:
 
       - name: Upload trace on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smoke-preview-trace
           path: test-results/

--- a/.npmrc
+++ b/.npmrc
@@ -1,11 +1,7 @@
-# Supply-chain settings for this repo live in pnpm-workspace.yaml
-# (minimumReleaseAge, ignoreScripts, allowBuilds, overrides, peerDependencyRules)
-# pnpm 11 only reads auth + registry settings from .npmrc.
-#
-# The min-release-age line below is for npm/Yarn fallback compatibility — pnpm
-# ignores it but anyone running `npm install` (e.g. during a Vercel/CI step
-# that bypasses pnpm) will still get the cooldown.
-min-release-age=10080
+# pnpm reads supply-chain settings from pnpm-workspace.yaml (see SECURITY.md).
+# This file is for tools that bypass pnpm — e.g. npm-CLI install paths.
+# npm reads min-release-age in days; pnpm reads minimumReleaseAge in minutes.
+min-release-age=7
 
 fund=false
 engine-strict=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,12 @@
+# Supply-chain settings for this repo live in pnpm-workspace.yaml
+# (minimumReleaseAge, ignoreScripts, allowBuilds, overrides, peerDependencyRules)
+# pnpm 11 only reads auth + registry settings from .npmrc.
+#
+# The min-release-age line below is for npm/Yarn fallback compatibility — pnpm
+# ignores it but anyone running `npm install` (e.g. during a Vercel/CI step
+# that bypasses pnpm) will still get the cooldown.
+min-release-age=10080
+
+fund=false
+engine-strict=true
+save-exact=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ The app will be available at `http://localhost:5173`.
 ### Prerequisites
 
 - **Node.js 24+** (see `.nvmrc` — use `nvm use` to switch)
-- **pnpm 10+** (`corepack enable` to install)
+- **pnpm 11+** (`corepack enable` to install)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To set expectations, this tool deliberately does not:
 
 ## Local Development
 
-Requires **Node.js 24+** and **pnpm 10+**. Use `nvm use` to switch to the correct version (requires [nvm](https://github.com/nvm-sh/nvm)).
+Requires **Node.js 24+** and **pnpm 11+**. Use `nvm use` to switch to the correct version (requires [nvm](https://github.com/nvm-sh/nvm)).
 
 ```bash
 git clone https://github.com/andymai/gridfinity-layout-tool.git

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,3 +26,33 @@ This project implements:
 - Content filtering for user-generated data
 - No storage of sensitive user data
 - All secrets externalized via environment variables
+
+## Supply Chain
+
+In response to the 2025–2026 wave of npm and GitHub Actions supply-chain
+attacks (Shai-Hulud worm, chalk/debug compromise, tj-actions tag retag,
+prt-scan AI campaign, durabletask PyPI poisoning), the build is configured
+to fail closed on the patterns those attacks exploited:
+
+| Defense                                                  | Where                                      | What it blocks                                                                                                             |
+| -------------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `minimumReleaseAge: 10080` (7d cooldown)                 | `pnpm-workspace.yaml`                      | Fresh malicious uploads — most are detected & taken down within hours. Would have blocked axios, chalk/debug, durabletask. |
+| `ignoreScripts: true` + `allowBuilds` allowlist          | `pnpm-workspace.yaml`                      | Postinstall / lifecycle script execution by default. This is the Shai-Hulud worm's primary spread vector.                  |
+| All GitHub Actions pinned to commit SHA                  | `.github/workflows/*.yml`                  | Tag-retag attacks (tj-actions class). Tags are mutable; commit SHAs are not.                                               |
+| `pull_request_target` workflows never `checkout` PR code | `.github/workflows/{labeler,pr-title}.yml` | Pwn requests — fork PR code running with write-token in base context.                                                      |
+| OSV scan (PRs report-only, main blocking)                | `.github/workflows/osv-scan.yml`           | Known-CVE versions in the lockfile.                                                                                        |
+| Dependabot cooldown (7d / 14d major)                     | `.github/dependabot.yml`                   | Dependabot suggesting fresh-from-publish versions that would fail install anyway.                                          |
+| CodeQL analysis                                          | `.github/workflows/codeql.yml`             | First-party code vulns.                                                                                                    |
+
+**Cooldown exclusions** are deliberate and listed in
+[`pnpm-workspace.yaml`](pnpm-workspace.yaml) under `minimumReleaseAgeExclude`.
+They cover user-authored packages (no security benefit from delaying our own
+releases) and high-trust org scopes that release frequently and lockstep.
+
+**Adding a build script allow-list entry** (`allowBuilds`) is a security
+decision. Audit the package's postinstall behavior before adding.
+
+**External advisory monitoring:** the
+[Socket GitHub App](https://github.com/marketplace/socket-security) is
+installed for behavioral analysis of new dependency PRs. Findings appear
+inline on PR diffs.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A web app for designing and planning Gridfinity drawer organizer layouts",
   "license": "AGPL-3.0-only",
   "type": "module",
-  "packageManager": "pnpm@10.30.0",
+  "packageManager": "pnpm@11.2.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/andymai/gridfinity-layout-tool.git"
@@ -116,43 +116,6 @@
     "*.{json,md,yml,yaml}": [
       "prettier --write"
     ]
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "core-js",
-      "esbuild",
-      "protobufjs",
-      "unrs-resolver"
-    ],
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "vite-plugin-pwa>vite": "^8.0.0"
-      }
-    },
-    "overrides": {
-      "@vercel/node>undici": "^7.20.0",
-      "path-to-regexp": "6.3.0",
-      "@rollup/plugin-replace>magic-string": "0.30.21",
-      "@surma/rollup-plugin-off-main-thread>magic-string": "0.30.21",
-      "workbox-build>@rollup/plugin-node-resolve": "^16.0.0",
-      "@apideck/better-ajv-errors>ajv": "^8.17.1",
-      "fast-uri": "^3.1.2",
-      "serialize-javascript": "^7.0.3",
-      "eslint-plugin-react-hooks>eslint": "^10.0.3",
-      "eslint-plugin-jsx-a11y>eslint": "^10.0.3",
-      "eslint-plugin-jsx-a11y>minimatch": "^3.1.3",
-      "@vercel/build-utils>minimatch": "^10.2.3",
-      "@vercel/python-analysis>minimatch": "^10.2.3",
-      "@vercel/static-config>ajv": "^8.18.0",
-      "glob>minimatch": "^10.2.3",
-      "flatted": "^3.4.2",
-      "posthog-js>dompurify": "^3.4.0",
-      "protobufjs": "^7.5.8",
-      "eslint-plugin-i18next>lodash": "^4.18.1",
-      "vitest-axe>lodash-es": "^4.18.1",
-      "picomatch@>=4.0.0 <4.0.4": "^4.0.4",
-      "@vercel/python-analysis>smol-toml": "^1.6.1"
-    }
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,28 +1,17 @@
 packages:
   - 'packages/*'
 
-# Supply-chain hardening — see SECURITY.md "Supply Chain" section.
-#
-# Cooldown: reject any package version published less than 7 days ago.
-# Would have blocked axios (Mar 2026), chalk/debug (Sep 2025), durabletask
-# (May 2026), and most Shai-Hulud worm waves outright.
-# pnpm 11 default is 1440 (1 day); we want a wider window.
+# Supply-chain hardening — see SECURITY.md for rationale.
+# Cooldown unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
 
-# Bypass the cooldown for packages we author or otherwise trust to publish
-# safely. Author-owned packages (brepjs, brepkit-wasm) get no security benefit
-# from the cooldown; we'd just be slowing our own release cadence. Reputable
-# org-scoped packages (PostHog, Vercel, TypeScript ESLint, DefinitelyTyped @types)
-# are listed because they release frequently and lockstep — without the bypass,
-# every typescript-eslint or @types/node bump would block install for a week.
-# A compromise of these orgs is still possible but is the same vector the rest
-# of the codebase defends against (Socket, osv-scanner, advisory monitoring).
+# Excluded: user-authored packages (no security benefit from cooldown) +
+# high-trust org scopes that release lockstep (would block install for a
+# week on every dep bump). The trailing entries are temporary — see TODO.
 minimumReleaseAgeExclude:
-  # User-authored — no security benefit from the cooldown.
   - brepjs
   - brepkit-wasm
   - occt-wasm
-  # Reputable orgs that release frequently and lockstep.
   - '@types/*'
   - '@typescript-eslint/*'
   - typescript-eslint
@@ -31,23 +20,16 @@ minimumReleaseAgeExclude:
   - '@vercel/*'
   - '@protobufjs/*'
   - protobufjs
-  # TODO: remove once aged (target 2026-05-26+). These are widely used utility
-  # packages whose latest versions happen to fall inside the 7-day window as of
-  # this PR; they will age in within ~2-3 days. Tracked: keep this block short.
+  # TODO: remove after 2026-05-26 once these have aged past the 7-day window.
   - dompurify
   - lru-cache
   - preact
   - tsx
 
-# Block install / postinstall / prepare scripts by default. Packages that
-# legitimately need to build are allow-listed in `allowBuilds` below.
-# Single highest-value defense against the Shai-Hulud worm class, which
-# spreads via npm lifecycle scripts.
+# Blocks Shai-Hulud-class worms that spread via npm lifecycle scripts.
+# Packages that need to build are listed in allowBuilds.
 ignoreScripts: true
 
-# Allow-list for build scripts. Adding a package here means its postinstall /
-# install / prepare / build hooks are trusted to execute. Add ONLY packages
-# whose install behavior you have audited or that are clearly native modules.
 allowBuilds:
   core-js: true
   esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,83 @@
 packages:
   - 'packages/*'
+
+# Supply-chain hardening — see SECURITY.md "Supply Chain" section.
+#
+# Cooldown: reject any package version published less than 7 days ago.
+# Would have blocked axios (Mar 2026), chalk/debug (Sep 2025), durabletask
+# (May 2026), and most Shai-Hulud worm waves outright.
+# pnpm 11 default is 1440 (1 day); we want a wider window.
+minimumReleaseAge: 10080
+
+# Bypass the cooldown for packages we author or otherwise trust to publish
+# safely. Author-owned packages (brepjs, brepkit-wasm) get no security benefit
+# from the cooldown; we'd just be slowing our own release cadence. Reputable
+# org-scoped packages (PostHog, Vercel, TypeScript ESLint, DefinitelyTyped @types)
+# are listed because they release frequently and lockstep — without the bypass,
+# every typescript-eslint or @types/node bump would block install for a week.
+# A compromise of these orgs is still possible but is the same vector the rest
+# of the codebase defends against (Socket, osv-scanner, advisory monitoring).
+minimumReleaseAgeExclude:
+  # User-authored — no security benefit from the cooldown.
+  - brepjs
+  - brepkit-wasm
+  - occt-wasm
+  # Reputable orgs that release frequently and lockstep.
+  - '@types/*'
+  - '@typescript-eslint/*'
+  - typescript-eslint
+  - '@posthog/*'
+  - posthog-js
+  - '@vercel/*'
+  - '@protobufjs/*'
+  - protobufjs
+  # TODO: remove once aged (target 2026-05-26+). These are widely used utility
+  # packages whose latest versions happen to fall inside the 7-day window as of
+  # this PR; they will age in within ~2-3 days. Tracked: keep this block short.
+  - dompurify
+  - lru-cache
+  - preact
+  - tsx
+
+# Block install / postinstall / prepare scripts by default. Packages that
+# legitimately need to build are allow-listed in `allowBuilds` below.
+# Single highest-value defense against the Shai-Hulud worm class, which
+# spreads via npm lifecycle scripts.
+ignoreScripts: true
+
+# Allow-list for build scripts. Adding a package here means its postinstall /
+# install / prepare / build hooks are trusted to execute. Add ONLY packages
+# whose install behavior you have audited or that are clearly native modules.
+allowBuilds:
+  core-js: true
+  esbuild: true
+  protobufjs: true
+  unrs-resolver: true
+
+peerDependencyRules:
+  allowedVersions:
+    vite-plugin-pwa>vite: '^8.0.0'
+
+overrides:
+  '@vercel/node>undici': '^7.20.0'
+  path-to-regexp: '6.3.0'
+  '@rollup/plugin-replace>magic-string': '0.30.21'
+  '@surma/rollup-plugin-off-main-thread>magic-string': '0.30.21'
+  'workbox-build>@rollup/plugin-node-resolve': '^16.0.0'
+  '@apideck/better-ajv-errors>ajv': '^8.17.1'
+  fast-uri: '^3.1.2'
+  serialize-javascript: '^7.0.3'
+  'eslint-plugin-react-hooks>eslint': '^10.0.3'
+  'eslint-plugin-jsx-a11y>eslint': '^10.0.3'
+  'eslint-plugin-jsx-a11y>minimatch': '^3.1.3'
+  '@vercel/build-utils>minimatch': '^10.2.3'
+  '@vercel/python-analysis>minimatch': '^10.2.3'
+  '@vercel/static-config>ajv': '^8.18.0'
+  'glob>minimatch': '^10.2.3'
+  flatted: '^3.4.2'
+  'posthog-js>dompurify': '^3.4.0'
+  protobufjs: '^7.5.8'
+  'eslint-plugin-i18next>lodash': '^4.18.1'
+  'vitest-axe>lodash-es': '^4.18.1'
+  'picomatch@>=4.0.0 <4.0.4': '^4.0.4'
+  '@vercel/python-analysis>smol-toml': '^1.6.1'


### PR DESCRIPTION
## Summary

Defense-in-depth against the 2025-2026 wave of supply-chain attacks (Shai-Hulud worm, chalk/debug, tj-actions, durabletask, prt-scan). Each defense maps to a specific attack class:

| Defense | What it blocks |
|---|---|
| `minimumReleaseAge: 10080` (7d cooldown) in `pnpm-workspace.yaml` | Fresh malicious uploads. Would have blocked axios, chalk/debug, durabletask outright. |
| `ignoreScripts: true` + `allowBuilds` allowlist | Postinstall lifecycle scripts — Shai-Hulud's primary spread vector. |
| All Actions SHA-pinned (`actions/*`, `github/codeql-action`, etc.) | tj-actions tag-retag class. Tags are mutable; SHAs aren't. |
| OSV scan workflow (PRs report-only, main blocking) | Known-CVE versions in the lockfile. |
| Dependabot cooldown (7d / 14d major) | Bot opening PRs for fresh-published versions that would fail install anyway. |

## Changes

- `pnpm-workspace.yaml`: moved `pnpm.{overrides,peerDependencyRules,onlyBuiltDependencies}` here from `package.json` (pnpm 11 no longer reads them from the package). Added supply-chain config + `allowBuilds` (replaces `onlyBuiltDependencies`). Added `minimumReleaseAgeExclude` for trusted scopes.
- `.npmrc`: new — npm-CLI compat fallback (`min-release-age` in days for any tool that bypasses pnpm).
- `package.json`: `packageManager` bumped 10.30.0 → 11.2.2; `pnpm` block removed (migrated above).
- `.github/workflows/*`: pinned `actions/checkout`, `setup-node`, `upload-artifact`, `labeler`, `create-github-app-token`, `github/codeql-action/{init,autobuild,analyze}` to commit SHAs.
- `.github/workflows/osv-scan.yml`: new — runs osv-scanner-action; report-only on PRs, blocking on push/weekly.
- `.github/dependabot.yml`: added `cooldown` blocks for both npm and github-actions ecosystems.
- `SECURITY.md`: new "Supply Chain" section documenting the defense matrix and exclusion rationale.
- `README.md` / `CONTRIBUTING.md`: prerequisite bumped to pnpm 11+.

## Cooldown exclusions

The `minimumReleaseAgeExclude` list in `pnpm-workspace.yaml` is deliberate:

- **Author-owned packages**: no security benefit from delaying our own releases.
- **High-trust org scopes** that release lockstep (`@types/*`, `@typescript-eslint/*`, `@posthog/*`, `@vercel/*`, `@protobufjs/*`). Without the bypass, every `@types/node` or typescript-eslint bump would block install for a week.
- **Temporary single-package entries** (target removal 2026-05-26+): their latest versions sit inside the 7-day window today and age out shortly. TODO comment in the yaml.

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds under pnpm 11.2.2 with the new policy
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test:run` — 847 files / 11785 tests pass
- [x] All actions verified pinned (no `@vN` left)
- [ ] CI green
- [ ] Greptile review
- [ ] OSV scan workflow runs (first invocation)