### PR TITLE
feat(bin-designer): raise compartment row/col cap from 8 to 12

### DIFF
--- a/src/features/bin-designer/constants/gridfinity.ts
+++ b/src/features/bin-designer/constants/gridfinity.ts
@@ -27,7 +27,8 @@ export const DESIGNER_CONSTRAINTS = {
   // Compartment grid
   MIN_COMPARTMENT_GRID: 1, // min rows/cols
   // Max rows/cols. Bumped from 8 to 12 per #1871 after measuring generation
-  // time across grid sizes (see `__kernel-tests__/compartments.perf.test.ts`):
+  // time across grid sizes (see
+  // `src/features/generation/worker/generators/__kernel-tests__/compartments.perf.test.ts`):
   // worst case (no label tabs) 12×12 finishes in ~14s, under the 30s base
   // timeout. 16×16 hits ~39s and risks timeout failures, so 12 is the safe
   // ceiling without also raising `BASE_TIMEOUT_MS`.

--- a/src/features/bin-designer/constants/gridfinity.ts
+++ b/src/features/bin-designer/constants/gridfinity.ts
@@ -26,7 +26,12 @@ export const DESIGNER_CONSTRAINTS = {
   HEIGHT_STEP: 1, // height units
   // Compartment grid
   MIN_COMPARTMENT_GRID: 1, // min rows/cols
-  MAX_COMPARTMENT_GRID: 8, // max rows/cols
+  // Max rows/cols. Bumped from 8 to 12 per #1871 after measuring generation
+  // time across grid sizes (see `__kernel-tests__/compartments.perf.test.ts`):
+  // worst case (no label tabs) 12×12 finishes in ~14s, under the 30s base
+  // timeout. 16×16 hits ~39s and risks timeout failures, so 12 is the safe
+  // ceiling without also raising `BASE_TIMEOUT_MS`.
+  MAX_COMPARTMENT_GRID: 12,
   MIN_COMPARTMENT_THICKNESS: 0.4, // mm divider wall thickness
   MAX_COMPARTMENT_THICKNESS: 2.4, // mm divider wall thickness
   COMPARTMENT_THICKNESS_STEP: 0.1, // mm (legacy — use WALL_THICKNESS_OPTIONS)

--- a/src/features/bin-designer/utils/validation.test.ts
+++ b/src/features/bin-designer/utils/validation.test.ts
@@ -102,13 +102,14 @@ describe('validateBinParams', () => {
     });
 
     it('should reject cols above maximum', () => {
+      const overMax = DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID + 1;
       const result = validateBinParams(
         makeParams({
           compartments: {
-            cols: 9,
+            cols: overMax,
             rows: 1,
             thickness: 1.2,
-            cells: Array(9)
+            cells: Array(overMax)
               .fill(0)
               .map((_, i) => i),
           },
@@ -631,11 +632,12 @@ describe('validateCompartmentSizes', () => {
     expectOk(result);
   });
 
-  it('includes helpful error message', () => {
+  it('includes helpful error message with bin-size suggestion', () => {
     const result = validateCompartmentSizes(0.5, 0.5, 1.2, 4, 1, 1.2);
     const error = expectErr(result);
-    expect(error.message).toContain('Compartment cells too small');
-    expect(error.message).toContain('min');
+    expect(error.message).toContain('cell-size limit');
+    expect(error.message).toContain('5mm minimum');
+    expect(error.message).toMatch(/up to \d+ columns/);
   });
 
   it('rejects cols less than 1', () => {

--- a/src/features/bin-designer/utils/validation.test.ts
+++ b/src/features/bin-designer/utils/validation.test.ts
@@ -3,6 +3,7 @@ import {
   validateBinParams,
   computeMinCellSize,
   validateCompartmentSizes,
+  maxCompartmentsForInner,
 } from '@/features/bin-designer/utils/validation';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
 import { GRIDFINITY, DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants/gridfinity';
@@ -627,8 +628,9 @@ describe('validateCompartmentSizes', () => {
   });
 
   it('accepts large bin with max grid', () => {
-    // 8-unit bin, 8x8 grid, 1.2mm dividers
-    const result = validateCompartmentSizes(8, 8, 1.2, 8, 8, 1.2);
+    // 8-unit bin, MAX×MAX compartment grid, 1.2mm dividers
+    const max = DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID;
+    const result = validateCompartmentSizes(8, 8, 1.2, max, max, 1.2);
     expectOk(result);
   });
 
@@ -652,5 +654,59 @@ describe('validateCompartmentSizes', () => {
     const error = expectErr(result);
     expect(error.code).toBe('COMPARTMENT_GRID_INVALID');
     expect(error.field).toBe('compartments.rows');
+  });
+});
+
+describe('maxCompartmentsForInner', () => {
+  // 5mm minimum cell size + thickness gives N*(5+t) - t ≤ inner ⇒ N ≤ (inner+t)/(5+t)
+  // These cases lock down the inverse-math formula since the validator error
+  // message surfaces the result to end users.
+  it('returns 1 when inner span is smaller than minimum cell size', () => {
+    expect(maxCompartmentsForInner(4, 1.2)).toBe(1);
+  });
+
+  it('returns 1 when inner span exactly equals minimum cell size', () => {
+    expect(maxCompartmentsForInner(5, 1.2)).toBe(1);
+  });
+
+  it('returns 2 when inner span comfortably fits two cells with one divider', () => {
+    // 2 cells × 5mm + 1 divider × 1.2mm = 11.2mm minimum
+    // Use 11.3 to stay off the IEEE-754 boundary (the helper makes no
+    // epsilon-rounding guarantees, only the floor of the literal ratio).
+    expect(maxCompartmentsForInner(11.3, 1.2)).toBe(2);
+    // Just under should still be 1
+    expect(maxCompartmentsForInner(11.1, 1.2)).toBe(1);
+  });
+
+  it('scales linearly with inner span for a fixed thickness', () => {
+    // 1 unit (40mm inner ≈ 1×42 - tolerance - 2*0.95): 5+5+5+5+5+5 = 30, with 5 dividers @1.2 = 36 → fits 6
+    expect(maxCompartmentsForInner(40, 1.2)).toBe(6);
+    // 2 units (~83mm inner): can fit ~13 columns
+    expect(maxCompartmentsForInner(83, 1.2)).toBe(13);
+  });
+
+  it('thicker dividers reduce the max count', () => {
+    // 40mm inner with 0.4mm dividers ⇒ floor(40.4 / 5.4) = 7
+    expect(maxCompartmentsForInner(40, 0.4)).toBe(7);
+    // 40mm inner with 2.4mm dividers ⇒ floor(42.4 / 7.4) = 5
+    expect(maxCompartmentsForInner(40, 2.4)).toBe(5);
+  });
+
+  it('clamps to at least 1 for degenerate inputs', () => {
+    expect(maxCompartmentsForInner(0, 1.2)).toBe(1);
+    expect(maxCompartmentsForInner(-10, 1.2)).toBe(1);
+    expect(maxCompartmentsForInner(50, 0)).toBe(10); // 0-thickness edge case
+  });
+});
+
+describe('validator surfaces the suggested-cap in the error message', () => {
+  // Direct check: a known-tight bin should produce a specific suggested count.
+  // Locks the message-rendering path (helper → message) against future refactors.
+  it('reports the same N that maxCompartmentsForInner computes', () => {
+    // 1×1 bin = ~40mm inner; with 1.2mm dividers, 6 cols max per the helper.
+    // Request 12 cols → should fail with "...up to 6 columns."
+    const result = validateCompartmentSizes(1, 1, 1.2, 12, 1, 1.2);
+    const error = expectErr(result);
+    expect(error.message).toContain('up to 6 columns');
   });
 });

--- a/src/features/bin-designer/utils/validation.ts
+++ b/src/features/bin-designer/utils/validation.ts
@@ -284,15 +284,21 @@ function cellSizeLimitMessage(axis: 'columns' | 'rows', maxCount: number): strin
   return `You've hit the cell-size limit (${DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE}mm minimum). At this ${dimension} you can fit up to ${maxCount} ${axis}.`;
 }
 
-/** Result of computing minimum cell dimensions (in mm) */
+/** Result of computing minimum cell dimensions (in mm). */
 export interface MinCellSize {
   readonly minCellW: number;
   readonly minCellD: number;
+  /** Inner-cavity width (mm) excluding outer walls/tolerance. */
+  readonly innerW: number;
+  /** Inner-cavity depth (mm) excluding outer walls/tolerance. */
+  readonly innerD: number;
 }
 
 /**
  * Computes the minimum individual cell dimensions (mm) for a compartment grid,
- * accounting for inner bin dimensions and divider thickness.
+ * accounting for inner bin dimensions and divider thickness. Returns the inner
+ * span too so callers needing the inverse — "how many compartments fit?" —
+ * don't duplicate the inner-cavity formula.
  *
  * Used to determine if a grid configuration would produce degenerate geometry.
  */
@@ -314,7 +320,7 @@ export function computeMinCellSize(
   const minCellW = (innerW - dividersW) / cols;
   const minCellD = (innerD - dividersD) / rows;
 
-  return { minCellW, minCellD };
+  return { minCellW, minCellD, innerW, innerD };
 }
 
 /**
@@ -341,7 +347,7 @@ export function validateCompartmentSizes(
   }
   if (cols <= 1 && rows <= 1) return ok(undefined);
 
-  const { minCellW, minCellD } = computeMinCellSize(
+  const { minCellW, minCellD, innerW, innerD } = computeMinCellSize(
     width,
     depth,
     wallThickness,
@@ -350,9 +356,6 @@ export function validateCompartmentSizes(
     dividerThickness,
     gridUnitMm
   );
-
-  const innerW = width * gridUnitMm - GRIDFINITY.TOLERANCE - 2 * wallThickness;
-  const innerD = depth * gridUnitMm - GRIDFINITY.TOLERANCE - 2 * wallThickness;
 
   if (cols > 1 && minCellW < DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE) {
     return err({

--- a/src/features/bin-designer/utils/validation.ts
+++ b/src/features/bin-designer/utils/validation.ts
@@ -236,9 +236,10 @@ export function validateBinParams(params: BinParams): Result<BinParams, Designer
       const totalDividerWidth = maxDividers * params.compartments.thickness;
       const cellWidth = (innerWidth - totalDividerWidth) / params.compartments.cols;
       if (cellWidth < DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE) {
+        const maxCols = maxCompartmentsForInner(innerWidth, params.compartments.thickness);
         return err({
           code: 'COMPARTMENT_TOO_SMALL',
-          message: `Too many columns: cells would be ${cellWidth.toFixed(1)}mm wide (min ${DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE}mm)`,
+          message: cellSizeLimitMessage('columns', maxCols),
           field: 'compartments.cols',
         });
       }
@@ -248,9 +249,10 @@ export function validateBinParams(params: BinParams): Result<BinParams, Designer
       const totalDividerDepth = maxDividers * params.compartments.thickness;
       const cellDepth = (innerDepth - totalDividerDepth) / params.compartments.rows;
       if (cellDepth < DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE) {
+        const maxRows = maxCompartmentsForInner(innerDepth, params.compartments.thickness);
         return err({
           code: 'COMPARTMENT_TOO_SMALL',
-          message: `Too many rows: cells would be ${cellDepth.toFixed(1)}mm deep (min ${DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE}mm)`,
+          message: cellSizeLimitMessage('rows', maxRows),
           field: 'compartments.rows',
         });
       }
@@ -258,6 +260,28 @@ export function validateBinParams(params: BinParams): Result<BinParams, Designer
   }
 
   return ok(params);
+}
+
+/**
+ * Largest compartment count that keeps each cell ≥ `MIN_COMPARTMENT_SIZE` along
+ * an inner span. Derived from `N*cell + (N-1)*thickness ≤ inner` with
+ * `cell = MIN_COMPARTMENT_SIZE`, solved for N. Returns at least 1.
+ */
+export function maxCompartmentsForInner(innerMm: number, thicknessMm: number): number {
+  const denom = DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE + thicknessMm;
+  if (denom <= 0) return 1;
+  return Math.max(1, Math.floor((innerMm + thicknessMm) / denom));
+}
+
+/**
+ * Friendly cell-size error: "You've hit the cell-size limit (5mm minimum). At
+ * this bin width you can fit up to N columns." — keeps the actionable bin-
+ * size suggestion in a single sentence instead of leaning on the cells-would-
+ * be-N.Nmm technical form.
+ */
+function cellSizeLimitMessage(axis: 'columns' | 'rows', maxCount: number): string {
+  const dimension = axis === 'columns' ? 'bin width' : 'bin depth';
+  return `You've hit the cell-size limit (${DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE}mm minimum). At this ${dimension} you can fit up to ${maxCount} ${axis}.`;
 }
 
 /** Result of computing minimum cell dimensions (in mm) */
@@ -327,10 +351,13 @@ export function validateCompartmentSizes(
     gridUnitMm
   );
 
+  const innerW = width * gridUnitMm - GRIDFINITY.TOLERANCE - 2 * wallThickness;
+  const innerD = depth * gridUnitMm - GRIDFINITY.TOLERANCE - 2 * wallThickness;
+
   if (cols > 1 && minCellW < DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE) {
     return err({
       code: 'COMPARTMENT_TOO_SMALL',
-      message: `Compartment cells too small (${minCellW.toFixed(1)}mm wide, min ${DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE}mm). Reduce grid size or increase bin dimensions.`,
+      message: cellSizeLimitMessage('columns', maxCompartmentsForInner(innerW, dividerThickness)),
       field: 'compartments.cols',
     });
   }
@@ -338,7 +365,7 @@ export function validateCompartmentSizes(
   if (rows > 1 && minCellD < DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE) {
     return err({
       code: 'COMPARTMENT_TOO_SMALL',
-      message: `Compartment cells too small (${minCellD.toFixed(1)}mm deep, min ${DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE}mm). Reduce grid size or increase bin dimensions.`,
+      message: cellSizeLimitMessage('rows', maxCompartmentsForInner(innerD, dividerThickness)),
       field: 'compartments.rows',
     });
   }

--- a/src/features/generation/worker/generators/__kernel-tests__/compartments.perf.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/compartments.perf.test.ts
@@ -15,12 +15,14 @@
  */
 // @vitest-environment node
 import { appendFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './wasmInit';
 import { buildParams } from './scenarioTypes';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 
-const OUT_FILE = '/tmp/compartments-bench-results.log';
+const OUT_FILE = join(tmpdir(), 'compartments-bench-results.log');
 
 beforeAll(async () => {
   await initBrepjs();
@@ -40,8 +42,11 @@ interface BenchRow {
   triangleCount: number;
 }
 
-const WARMUP_RUNS = 0;
-const MEASURE_RUNS = 1;
+// 1 warmup so the shell cache is hot when measurement starts; 2 measured runs
+// averaged together so a single transient (GC pause, OS noise) doesn't sway
+// the cap decision. Tradeoff: full sweep now takes ~7-10 min instead of ~3.
+const WARMUP_RUNS = 1;
+const MEASURE_RUNS = 2;
 
 /** Build a uniform N×M compartment grid with each cell its own compartment. */
 function makeCells(cols: number, rows: number): number[] {

--- a/src/features/generation/worker/generators/__kernel-tests__/compartments.perf.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/compartments.perf.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Compartment grid scaling benchmark.
+ *
+ * Quantifies bin generation time as a function of compartment row/col count,
+ * so we can pick a sensible `MAX_COMPARTMENT_GRID` cap (issue #1871). Each
+ * grid is generated on the same fixed-size bin (8×8 grid units = 336×336mm)
+ * so cell size stays >5mm even at 32×32. Tested both with and without label
+ * tabs enabled, since labels add per-cell engraving geometry.
+ *
+ * Run in isolation via the profile config — excluded from CI:
+ *   pnpm exec vitest run --config vitest.profile.config.ts compartments.perf
+ *
+ * This file lives under `__kernel-tests__/` so the main `vitest.config.ts`
+ * exclude pattern for that directory keeps it off the CI critical path.
+ */
+// @vitest-environment node
+import { appendFileSync, writeFileSync } from 'node:fs';
+import { describe, it, beforeAll } from 'vitest';
+import { initBrepjs, getGenerateBin } from './wasmInit';
+import { buildParams } from './scenarioTypes';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+
+const OUT_FILE = '/tmp/compartments-bench-results.log';
+
+beforeAll(async () => {
+  await initBrepjs();
+  writeFileSync(OUT_FILE, `compartments bench — ${new Date().toISOString()}\n\n`);
+}, 30_000);
+
+function emit(line: string): void {
+  appendFileSync(OUT_FILE, line + '\n');
+}
+
+interface BenchRow {
+  cols: number;
+  rows: number;
+  cells: number;
+  labels: boolean;
+  avgMs: number;
+  triangleCount: number;
+}
+
+const WARMUP_RUNS = 0;
+const MEASURE_RUNS = 1;
+
+/** Build a uniform N×M compartment grid with each cell its own compartment. */
+function makeCells(cols: number, rows: number): number[] {
+  return Array.from({ length: cols * rows }, (_, i) => i);
+}
+
+function benchOne(cols: number, rows: number, labels: boolean): BenchRow {
+  const generateBin = getGenerateBin();
+  const params = buildParams({
+    width: 8,
+    depth: 8,
+    height: 4,
+    base: { ...DEFAULT_BIN_PARAMS.base, style: 'socket', stackingLip: true },
+    compartments: {
+      cols,
+      rows,
+      thickness: 1.2,
+      cells: makeCells(cols, rows),
+    },
+    label: { ...DEFAULT_BIN_PARAMS.label, enabled: labels },
+  });
+
+  // Warm up to fill shell cache
+  for (let i = 0; i < WARMUP_RUNS; i++) {
+    generateBin(params, undefined, false);
+  }
+
+  const times: number[] = [];
+  let triangleCount = 0;
+  for (let i = 0; i < MEASURE_RUNS; i++) {
+    const start = performance.now();
+    const result = generateBin(params, undefined, false);
+    times.push(performance.now() - start);
+    triangleCount = result.triangleCount;
+  }
+
+  const avgMs = times.reduce((a, b) => a + b, 0) / times.length;
+  return { cols, rows, cells: cols * rows, labels, avgMs, triangleCount };
+}
+
+function printTable(label: string, rows: BenchRow[]): void {
+  emit('');
+  emit(`  === ${label} ===`);
+  emit('  grid     cells    labels   avg ms    tris');
+  emit('  ──────── ──────── ──────── ──────── ────────');
+  for (const r of rows) {
+    const cells = [
+      `${r.cols}×${r.rows}`.padEnd(9),
+      String(r.cells).padEnd(9),
+      (r.labels ? 'yes' : 'no').padEnd(9),
+      r.avgMs.toFixed(0).padEnd(9),
+      String(r.triangleCount),
+    ];
+    emit('  ' + cells.join(''));
+  }
+  emit('');
+}
+
+describe('compartment grid scaling on 8×8 bin', () => {
+  // Smaller sweep + per-row streaming so we can pick a cap from partial output
+  // if the run gets killed at the very large grids.
+  const GRIDS = [4, 8, 12, 16, 20];
+
+  it('uniform-grid bench (no labels)', () => {
+    const results: BenchRow[] = [];
+    for (const n of GRIDS) {
+      const row = benchOne(n, n, false);
+      emit(`  [no-labels] ${n}×${n} = ${row.avgMs.toFixed(0)}ms (${row.triangleCount} tris)`);
+      results.push(row);
+    }
+    printTable('no labels', results);
+  });
+
+  it('uniform-grid bench (with label tabs)', () => {
+    const results: BenchRow[] = [];
+    for (const n of GRIDS) {
+      const row = benchOne(n, n, true);
+      emit(`  [labels]    ${n}×${n} = ${row.avgMs.toFixed(0)}ms (${row.triangleCount} tris)`);
+      results.push(row);
+    }
+    printTable('with label tabs', results);
+  });
+});


### PR DESCRIPTION
Closes #1871.

## Summary

Reporter wanted to subdivide a 5×5 bin into more than 8 rows/cols (the previous cap). Bumped `MAX_COMPARTMENT_GRID` from **8 → 12** after measuring generation time across grid sizes.

## Benchmark (8×8 grid bin, varying compartment grid)

| Grid | No labels | With labels |
|------|-----------|-------------|
| 4×4 | 3.6s | 1.7s |
| 8×8 | **5.0s** ← prev cap | 3.2s |
| 12×12 | 14.0s | **4.4s** ← new cap |
| 16×16 | 39.4s ⚠️ | 5.7s |
| 20×20 | 109s ⚠️ | 8.4s |

**Why 12 and not 16:** 16×16 with no labels hits 39s, exceeding the 30s `BASE_TIMEOUT_MS` in `bridge/generationTimeout.ts` — would produce failed generations. 12×12 worst case (14s) stays comfortably inside the timeout, while typical case (with labels, 4.4s) remains interactive.

The benchmark lives at `src/features/generation/worker/generators/__kernel-tests__/compartments.perf.test.ts`, excluded from CI (matches the existing `__kernel-tests__/**` pattern). Re-run with:
```
pnpm exec vitest run --config vitest.profile.config.ts compartments.perf
```

## Also: friendlier cell-size error message

Old: `Too many columns: cells would be 3.2mm wide (min 5mm)`
New: `You've hit the cell-size limit (5mm minimum). At this bin width you can fit up to 4 columns.`

The new message tells users exactly how many compartments their current bin can hold, via a new `maxCompartmentsForInner()` helper that does the inverse math.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors (10 pre-existing warnings)
- [x] `pnpm exec vitest run src/features/bin-designer src/shared` — 4584/4584 pass
- [x] Playwright spot check on `/designer`:
  - Columns/Rows stepper `max` attr = 12 ✓
  - Stepper accepts 12, clamps 13 → 12 ✓
- [ ] Try in dev: a few high-compartment configs, confirm generation completes without freezing the UI