### PR TITLE
fix(preview): set Z-up on drei cameras at construction time

### DIFF
--- a/src/features/baseplate/components/BaseplatePreview/BaseplateCameraRig.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplateCameraRig.tsx
@@ -27,6 +27,9 @@ import { distanceToOrthoZoom, orthoZoomToDistance } from '@/shared/utils/cameraP
 /** Default vertical FOV (degrees) used for the perspective camera and round-trip math. */
 const CAMERA_FOV = 45;
 
+/** World is Z-up across the baseplate preview; pass to drei cameras at construction. */
+const UP_Z: [number, number, number] = [0, 0, 1];
+
 /** Outside-of-hook helper to keep the react-hooks immutability rule satisfied. */
 function setOrthoZoom(ortho: OrthographicCameraImpl, zoom: number): void {
   ortho.zoom = zoom;
@@ -134,6 +137,11 @@ export function BaseplateCameraRig({
         ref={perspRef}
         makeDefault={projection === 'perspective'}
         position={initialPosition}
+        // Z-up at construction time. Without this the camera is born Three.js-
+        // default Y-up; OrbitControls binds before CameraController's effect
+        // flips up, and caches its spherical angles relative to the Y-up pose
+        // — visible as a 90° roll about the view axis on first render.
+        up={UP_Z}
         fov={fov}
         near={near}
         far={far}
@@ -142,6 +150,7 @@ export function BaseplateCameraRig({
         ref={orthoRef}
         makeDefault={projection === 'orthographic'}
         position={initialPosition}
+        up={UP_Z}
         near={orthoNear}
         far={orthoFar}
         left={-halfW}

--- a/src/features/bin-designer/components/PreviewCanvas/previewCanvasCamera.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/previewCanvasCamera.tsx
@@ -49,6 +49,9 @@ export const CAMERA_PRESETS: Record<CameraPreset, [number, number, number]> = {
   isometric: [0.6, -0.6, 0.5],
 };
 
+/** World is Z-up across the bin designer; pass to drei cameras at construction. */
+const UP_Z: [number, number, number] = [0, 0, 1];
+
 /** Animation duration for camera transitions (ms) */
 const TRANSITION_DURATION = 500;
 /** Animation duration for auto-framing (ms) */
@@ -468,6 +471,11 @@ export function CameraRig({
         ref={perspRef}
         makeDefault={projection === 'perspective'}
         position={initialPosition}
+        // Z-up at construction time. Without this the camera is born Three.js-
+        // default Y-up; OrbitControls binds before CameraController's effect
+        // flips up, and caches its spherical angles relative to the Y-up
+        // pose — visible as a 90° roll about the view axis on first render.
+        up={UP_Z}
         fov={fov}
         near={near}
         far={far}
@@ -476,6 +484,7 @@ export function CameraRig({
         ref={orthoRef}
         makeDefault={projection === 'orthographic'}
         position={initialPosition}
+        up={UP_Z}
         near={orthoNear}
         far={orthoFar}
         left={-halfW}


### PR DESCRIPTION
## The bug
After #1870 merged, both 3D viewports (bin designer + baseplate) rendered the camera rolled ~90° about the view axis on initial load — the bin appeared tipped on its side instead of standing on the floor grid.

## Root cause
PR #1870 removed the `Canvas camera={...}` prop and let drei's `<PerspectiveCamera makeDefault>` provide the active camera. Drei creates the camera Three.js-default **Y-up**.

The existing `Canvas onCreated` callback that called `camera.up.set(0, 0, 1)` still runs, but on R3F's transient default camera — which gets discarded the instant drei's makeDefault camera mounts. So the up reset never reached the real camera.

`CameraController`'s first-mount effect *does* call `camera.up.set(0, 0, 1)`, but `<OrbitControls makeDefault>` binds **before** that effect runs and caches its spherical angles relative to the Y-up pose. Result: camera rolled 90° on first render.

## Fix
Pass `up={[0, 0, 1]}` directly to both drei cameras (perspective + orthographic) in `CameraRig` and `BaseplateCameraRig` so they're born Z-up *before* OrbitControls binds.

## Verification
Captured Playwright screenshots before/after against `/designer`. Pre-fix: bin tipped on its side, floor grid barely visible. Post-fix: bin stands on grid, proper 3/4 isometric view, identical to pre-#1870 behavior.