### PR TITLE
perf(generation): instrument + bench + safe wall-pattern optimizations

### DIFF
--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -114,6 +114,16 @@ export const FEATURE_FLAGS = [
     requiresRefresh: false,
     comingSoon: true,
   },
+  {
+    id: 'show_generation_perf',
+    name: 'Generation Performance Overlay',
+    description:
+      'Show a small overlay in the bin designer with per-stage timings, cache hit rates, hex-center counts, and recent generation history. Useful for diagnosing slow bins and validating optimizations.',
+    status: 'experimental',
+    risk: 'low',
+    addedAt: '2026-05',
+    requiresRefresh: false,
+  },
 ] as const satisfies readonly FeatureFlag[];
 
 export type FeatureId = (typeof FEATURE_FLAGS)[number]['id'];

--- a/src/features/bin-designer/components/DesignerPage/DesignerMainContent.tsx
+++ b/src/features/bin-designer/components/DesignerPage/DesignerMainContent.tsx
@@ -16,6 +16,7 @@ import { ResizeDivider } from '@/features/bin-designer/components/CutoutWorkspac
 import { loadSplitRatio } from '@/features/bin-designer/components/CutoutWorkspace/splitRatioStorage';
 import { CutoutDesktopOnlyBanner } from './CutoutDesktopOnlyBanner';
 import { ExperimentalKernelBadge } from '@/shared/components/ExperimentalKernelBadge';
+import { PerfOverlay } from '@/features/bin-designer/components/PerfOverlay';
 
 interface DesignerMainContentProps {
   isDesktop: boolean;
@@ -43,6 +44,7 @@ export function DesignerMainContent({
         <div className="relative flex-1 overflow-hidden">
           <PreviewCanvas />
           <ExperimentalKernelBadge />
+          <PerfOverlay />
         </div>
       </main>
     );
@@ -58,6 +60,7 @@ export function DesignerMainContent({
         <div className="relative flex-1 overflow-hidden">
           <PreviewCanvas />
           <ExperimentalKernelBadge />
+          <PerfOverlay />
         </div>
       </main>
     );

--- a/src/features/bin-designer/components/PerfOverlay/PerfOverlay.tsx
+++ b/src/features/bin-designer/components/PerfOverlay/PerfOverlay.tsx
@@ -1,0 +1,188 @@
+/* eslint-disable i18next/no-literal-string -- Dev-only overlay (Labs flag); strings are technical metric labels, not user-facing copy. */
+/**
+ * Dev-only performance overlay for bin generation.
+ *
+ * Visible when the `show_generation_perf` labs flag is on. Renders the
+ * latest snapshot's per-stage timings, wall-pattern substeps, and a
+ * sparkline of the last N generations so regressions are obvious during
+ * iterative editing.
+ *
+ * Hidden when no snapshots have been captured yet (e.g., before the
+ * first generation completes).
+ */
+
+import { useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
+import type { PerfSnapshot, PerfSubstepEntry } from '@/shared/types/generation';
+
+const SPARKLINE_WIDTH = 120;
+const SPARKLINE_HEIGHT = 24;
+
+export function PerfOverlay() {
+  const enabled = useFeatureFlag('show_generation_perf');
+  const { perfHistory, clearPerfHistory } = useDesignerStore(
+    useShallow((s) => ({
+      perfHistory: s.generation.perfHistory,
+      clearPerfHistory: s.clearPerfHistory,
+    }))
+  );
+
+  if (!enabled || perfHistory.length === 0) return null;
+
+  const latest = perfHistory[perfHistory.length - 1];
+  return (
+    <div
+      className="pointer-events-auto absolute right-3 top-3 z-20 w-72 rounded-lg border border-stroke-subtle bg-surface-primary/95 p-3 text-[11px] font-mono shadow-lg backdrop-blur-sm"
+      aria-label="Generation performance overlay"
+    >
+      <Header
+        totalMs={latest.totalMs}
+        sampleCount={perfHistory.length}
+        onClear={clearPerfHistory}
+      />
+      <Sparkline history={perfHistory} />
+      <Counts hexCenters={latest.hexCenterCount} patternTools={latest.patternCutToolCount} />
+      <StageTable label="Pipeline stages" entries={latest.stages} totalMs={latest.totalMs} />
+      {latest.featureBuilders.length > 0 && (
+        <SubstepTable label="Feature builders" entries={latest.featureBuilders} />
+      )}
+      {latest.wallPatternSubsteps.length > 0 && (
+        <SubstepTable label="Wall pattern substeps" entries={latest.wallPatternSubsteps} />
+      )}
+    </div>
+  );
+}
+
+function Header({
+  totalMs,
+  sampleCount,
+  onClear,
+}: {
+  totalMs: number;
+  sampleCount: number;
+  onClear: () => void;
+}) {
+  return (
+    <div className="mb-1.5 flex items-center justify-between">
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-text-primary font-semibold">Gen</span>
+        <span className="text-text-primary text-sm">{fmtMs(totalMs)}</span>
+        <span className="text-text-tertiary">({sampleCount})</span>
+      </div>
+      <button
+        type="button"
+        onClick={onClear}
+        className="text-text-tertiary hover:text-text-primary underline underline-offset-2"
+      >
+        clear
+      </button>
+    </div>
+  );
+}
+
+function Sparkline({ history }: { history: readonly PerfSnapshot[] }) {
+  const points = useMemo(() => {
+    if (history.length < 2) return '';
+    const recent = history.slice(-20);
+    const values = recent.map((s) => s.totalMs);
+    const max = Math.max(...values);
+    const min = Math.min(...values);
+    const range = Math.max(max - min, 1);
+    const step = SPARKLINE_WIDTH / Math.max(recent.length - 1, 1);
+    return recent
+      .map((s, i) => {
+        const x = i * step;
+        const y = SPARKLINE_HEIGHT - ((s.totalMs - min) / range) * SPARKLINE_HEIGHT;
+        return `${x},${y}`;
+      })
+      .join(' ');
+  }, [history]);
+
+  if (!points) return null;
+  return (
+    <svg
+      width={SPARKLINE_WIDTH}
+      height={SPARKLINE_HEIGHT}
+      viewBox={`0 0 ${SPARKLINE_WIDTH} ${SPARKLINE_HEIGHT}`}
+      className="mb-2 block"
+      aria-hidden="true"
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.25}
+        className="text-info"
+      />
+    </svg>
+  );
+}
+
+function Counts({ hexCenters, patternTools }: { hexCenters: number; patternTools: number }) {
+  if (hexCenters === 0 && patternTools === 0) return null;
+  return (
+    <div className="mb-2 flex gap-3 text-text-tertiary">
+      {hexCenters > 0 && <span>hex centers: {hexCenters}</span>}
+      {patternTools > 0 && <span>pattern tools: {patternTools}</span>}
+    </div>
+  );
+}
+
+function StageTable({
+  label,
+  entries,
+  totalMs,
+}: {
+  label: string;
+  entries: readonly { name: string; ms: number }[];
+  totalMs: number;
+}) {
+  if (entries.length === 0) return null;
+  return (
+    <div className="mb-2">
+      <div className="text-text-tertiary mb-0.5 uppercase tracking-wide">{label}</div>
+      {entries.map((e) => (
+        <div key={e.name} className="flex items-center gap-1.5">
+          <span className="text-text-primary w-24 truncate">{e.name}</span>
+          <span className="w-12 text-right tabular-nums">{fmtMs(e.ms)}</span>
+          <BarFill pct={Math.min(1, e.ms / Math.max(totalMs, 1))} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SubstepTable({ label, entries }: { label: string; entries: readonly PerfSubstepEntry[] }) {
+  const maxMs = entries.reduce((acc, e) => Math.max(acc, e.ms), 0);
+  return (
+    <div className="mb-2">
+      <div className="text-text-tertiary mb-0.5 uppercase tracking-wide">{label}</div>
+      {entries.map((e) => (
+        <div key={e.name} className="flex items-center gap-1.5">
+          <span className="text-text-primary w-32 truncate">
+            {e.name}
+            {e.count !== undefined ? ` (${e.count})` : ''}
+          </span>
+          <span className="w-12 text-right tabular-nums">{fmtMs(e.ms)}</span>
+          <BarFill pct={maxMs > 0 ? e.ms / maxMs : 0} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function BarFill({ pct }: { pct: number }) {
+  return (
+    <div className="bg-surface-secondary h-1.5 flex-1 overflow-hidden rounded">
+      <div className="bg-info h-full" style={{ width: `${pct * 100}%` }} />
+    </div>
+  );
+}
+
+function fmtMs(ms: number): string {
+  if (ms < 1) return `${ms.toFixed(2)}ms`;
+  if (ms < 100) return `${ms.toFixed(1)}ms`;
+  return `${Math.round(ms)}ms`;
+}

--- a/src/features/bin-designer/components/PerfOverlay/index.ts
+++ b/src/features/bin-designer/components/PerfOverlay/index.ts
@@ -1,0 +1,1 @@
+export { PerfOverlay } from './PerfOverlay';

--- a/src/features/bin-designer/constants/defaults.ts
+++ b/src/features/bin-designer/constants/defaults.ts
@@ -310,6 +310,7 @@ export const DEFAULT_GENERATION_STATE: GenerationState = {
   mesh: null,
   progress: 0,
   epoch: 0,
+  perfHistory: [],
 } as const;
 
 /** Default UI state */

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -35,6 +35,7 @@ export function useGeneration(): void {
   const setGenerationStatus = useDesignerStore((state) => state.setGenerationStatus);
   const setGenerationResult = useDesignerStore((state) => state.setGenerationResult);
   const setWasmStatus = useDesignerStore((state) => state.setWasmStatus);
+  const pushPerfSnapshot = useDesignerStore((state) => state.pushPerfSnapshot);
 
   // Generate bin mesh from current params
   const runGeneration = useCallback(
@@ -69,6 +70,8 @@ export function useGeneration(): void {
 
       try {
         const result = await bridge.generate(currentParams, () => {});
+
+        if (result.perfSnapshot) pushPerfSnapshot(result.perfSnapshot);
 
         setGenerationResult({
           vertices: result.mesh.vertices,
@@ -114,7 +117,7 @@ export function useGeneration(): void {
         setGenerationStatus('error');
       }
     },
-    [setGenerationStatus, setGenerationResult]
+    [setGenerationStatus, setGenerationResult, pushPerfSnapshot]
   );
 
   // Initialize bridge on mount via BridgeManager (ref-counted singleton)

--- a/src/features/bin-designer/store/slices/historySlice.ts
+++ b/src/features/bin-designer/store/slices/historySlice.ts
@@ -10,6 +10,18 @@ import type {
   WasmStatus,
   HistoryEntry,
 } from '../../types';
+import { PERF_HISTORY_LIMIT } from '../../types';
+import type { PerfSnapshot, PerfStageEntry, PerfSubstepEntry } from '@/shared/types/generation';
+
+/** Internal write-side mirror of PerfSnapshot used by the Immer reducer. */
+interface MutablePerfSnapshot {
+  totalMs: number;
+  stages: PerfStageEntry[];
+  featureBuilders: PerfSubstepEntry[];
+  wallPatternSubsteps: PerfSubstepEntry[];
+  hexCenterCount: number;
+  patternCutToolCount: number;
+}
 import {
   pushHistoryEntry,
   restoreHistoryEntry,
@@ -124,6 +136,34 @@ export function createHistorySlice(set: Set, get: Get) {
     setWasmStatus: (status: WasmStatus) => {
       set((state) => {
         state.wasmStatus = status;
+      });
+    },
+
+    pushPerfSnapshot: (snapshot: PerfSnapshot) => {
+      set((state) => {
+        // Immer's WritableDraft can't accept the worker payload directly
+        // because PerfSnapshot has deeply-readonly arrays. Re-shape into
+        // a writable mirror, then cast at the assignment edge — the
+        // store type still presents perfHistory as readonly to readers.
+        const mutable: MutablePerfSnapshot = {
+          totalMs: snapshot.totalMs,
+          stages: snapshot.stages.map((s) => ({ ...s })),
+          featureBuilders: snapshot.featureBuilders.map((s) => ({ ...s })),
+          wallPatternSubsteps: snapshot.wallPatternSubsteps.map((s) => ({ ...s })),
+          hexCenterCount: snapshot.hexCenterCount,
+          patternCutToolCount: snapshot.patternCutToolCount,
+        };
+        const prev = state.generation.perfHistory as readonly MutablePerfSnapshot[];
+        const next = [...prev, mutable];
+        const bounded =
+          next.length > PERF_HISTORY_LIMIT ? next.slice(next.length - PERF_HISTORY_LIMIT) : next;
+        (state.generation as { perfHistory: MutablePerfSnapshot[] }).perfHistory = bounded;
+      });
+    },
+
+    clearPerfHistory: () => {
+      set((state) => {
+        (state.generation as { perfHistory: MutablePerfSnapshot[] }).perfHistory = [];
       });
     },
   };

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -5,7 +5,7 @@
  * generation state, and designer UI state.
  */
 
-import type { FaceGroupData, CoarseLODData } from '@/shared/types/generation';
+import type { FaceGroupData, CoarseLODData, PerfSnapshot } from '@/shared/types/generation';
 
 /**
  * Lid mesh data as stored in the designer store. Mirrors the shared
@@ -588,7 +588,15 @@ export interface GenerationState {
   readonly progress: number;
   /** Increments on changes needing regeneration; cache hits leave epoch unchanged */
   readonly epoch: number;
+  /**
+   * Rolling buffer of recent generation timing snapshots (most recent
+   * last, capped at PERF_HISTORY_LIMIT). Powers the dev PerfOverlay.
+   */
+  readonly perfHistory: readonly PerfSnapshot[];
 }
+
+/** Cap for `generation.perfHistory`. Tiny payloads; safe to keep many. */
+export const PERF_HISTORY_LIMIT = 50;
 
 /** Cached mesh data for undo/redo history entries */
 export interface CachedMesh {
@@ -880,6 +888,8 @@ export interface DesignerState {
   setGenerationStatus: (status: GenerationStatus) => void;
   setGenerationResult: (result: GenerationResult) => void;
   setWasmStatus: (status: WasmStatus) => void;
+  pushPerfSnapshot: (snapshot: PerfSnapshot) => void;
+  clearPerfHistory: () => void;
 
   // UI actions
   setActiveTab: (tab: DesignerTab) => void;

--- a/src/features/generation/bridge/bridgeMessageHandler.ts
+++ b/src/features/generation/bridge/bridgeMessageHandler.ts
@@ -127,6 +127,7 @@ export function installMessageHandler(ctx: MessageHandlerContext): void {
               lidMesh,
             },
             timingMs: response.timingMs,
+            perfSnapshot: response.perfSnapshot,
           };
 
           // Cache for deduplication (bin or baseplate — only one is in-flight)

--- a/src/features/generation/bridge/bridgeTypes.ts
+++ b/src/features/generation/bridge/bridgeTypes.ts
@@ -16,6 +16,7 @@ import type {
   KernelName,
   KernelPerfCategory,
   BooleanFallbackEntry,
+  PerfSnapshot,
 } from './types';
 
 /** Callback for progress updates during generation */
@@ -25,6 +26,8 @@ export type ProgressCallback = (stage: GenerationStage, progress: number) => voi
 export interface GenerationResult {
   readonly mesh: MeshData;
   readonly timingMs: number;
+  /** Optional fine-grained perf breakdown (present when worker emits one). */
+  readonly perfSnapshot?: PerfSnapshot;
 }
 
 /** Result from a successful BREP export */

--- a/src/features/generation/bridge/index.ts
+++ b/src/features/generation/bridge/index.ts
@@ -30,4 +30,7 @@ export type {
   SplitPreviewPiece,
   ErrorResponse,
   ProgressResponse,
+  PerfSnapshot,
+  PerfStageEntry,
+  PerfSubstepEntry,
 } from './types';

--- a/src/features/generation/bridge/types.ts
+++ b/src/features/generation/bridge/types.ts
@@ -250,6 +250,44 @@ export interface KernelPerfStatsResponse {
 }
 
 /**
+ * Per-pipeline-stage timing entry. Captures shell, features, boolean,
+ * translate, and tessellate stage durations.
+ */
+export interface PerfStageEntry {
+  readonly name: string;
+  readonly ms: number;
+}
+
+/**
+ * Sub-step timing inside a stage — feature builder or wall pattern phase.
+ * `count` carries an optional scalar (hex centers built, items processed)
+ * useful for spotting "slow per-unit" vs "slow due to volume".
+ */
+export interface PerfSubstepEntry {
+  readonly name: string;
+  readonly ms: number;
+  readonly count?: number;
+}
+
+/**
+ * Snapshot of one generation's timing breakdown. Sent with MESH_RESULT
+ * when the worker has timing instrumentation enabled. Used by the
+ * dev-only PerfOverlay and (in the future) regression guards.
+ */
+export interface PerfSnapshot {
+  readonly totalMs: number;
+  readonly stages: readonly PerfStageEntry[];
+  /** Per-feature-builder timings (compartment walls, inserts, etc.). */
+  readonly featureBuilders: readonly PerfSubstepEntry[];
+  /** Wall-pattern substep timings (base build vs cache hit, clip apply). */
+  readonly wallPatternSubsteps: readonly PerfSubstepEntry[];
+  /** Total hex centers built across all walls. */
+  readonly hexCenterCount: number;
+  /** Number of pattern compounds fed into the final pattern_cut pass. */
+  readonly patternCutToolCount: number;
+}
+
+/**
  * Boolean fallback occurrence — one record per boolean op where bisect
  * recovery kicked in (`batchAttempts > 1` or `singletonFallbacks > 0`).
  * `failedInputCount` over `totalInputs` separates concentrated failures
@@ -313,6 +351,12 @@ export interface MeshResultResponse {
   readonly lidEdgeVertices?: Float32Array;
   readonly lidTriangleCount?: number;
   readonly lidFaceGroups?: readonly FaceGroupData[];
+  /**
+   * Optional fine-grained timing breakdown. Present when the worker has
+   * instrumentation enabled (currently: always on; the overlead is a
+   * handful of `performance.now()` calls).
+   */
+  readonly perfSnapshot?: PerfSnapshot;
 }
 
 export interface ExportResultResponse {

--- a/src/features/generation/bridge/types.ts
+++ b/src/features/generation/bridge/types.ts
@@ -352,9 +352,10 @@ export interface MeshResultResponse {
   readonly lidTriangleCount?: number;
   readonly lidFaceGroups?: readonly FaceGroupData[];
   /**
-   * Optional fine-grained timing breakdown. Present when the worker has
-   * instrumentation enabled (currently: always on; the overlead is a
-   * handful of `performance.now()` calls).
+   * Fine-grained timing breakdown. The worker always emits one — overhead
+   * is a handful of `performance.now()` calls — but the field is `?` so
+   * older worker builds (e.g., a stale Service Worker payload on the first
+   * request after deploy) deserialize cleanly.
    */
   readonly perfSnapshot?: PerfSnapshot;
 }

--- a/src/features/generation/worker/generators/__bench__/baseline.json
+++ b/src/features/generation/worker/generators/__bench__/baseline.json
@@ -1,0 +1,50 @@
+{
+  "_about": "Frozen baseline numbers for binGenerator.bench.ts. Captured before the wall-pattern optimizations in this PR landed; used to gauge how much each optimization moves the needle. Re-capture by running `CI=true pnpm exec vitest bench binGenerator --run` and copying the unit-env means into this file (with the new commit + timestamp).",
+  "capturedAt": "2026-05-25T16:11:35Z",
+  "commit": "a63ddb1a",
+  "kernel": "opencascade",
+  "env": "unit (node)",
+  "scenarios": [
+    {
+      "name": "dense_wide_with_cutouts (cold)",
+      "params": "6×4u, height 6u, 12×8 compartments (96), wall pattern honeycomb, 4 wall cutouts (70%×50%)",
+      "meanMs": 2668,
+      "minMs": 2639,
+      "maxMs": 2725,
+      "samples": 3
+    },
+    {
+      "name": "tall_with_cutouts (cold)",
+      "params": "4×4u, height 6u, 6×6 compartments (36), wall pattern honeycomb, 4 wall cutouts (70%×50%)",
+      "meanMs": 2084,
+      "minMs": 2070,
+      "maxMs": 2097,
+      "samples": 3
+    },
+    {
+      "name": "cache_warm_cutout_iter",
+      "params": "dense_wide_with_cutouts + 4 cutout-width nudges (5 generations total per iteration)",
+      "meanMs": 28414,
+      "minMs": 25685,
+      "maxMs": 31144,
+      "samples": 2,
+      "perGenMeanMs": 5683
+    },
+    {
+      "name": "first build (cold): 4×2×6 honeycomb + cutouts",
+      "params": "4×2u, height 6u, honeycomb wall pattern, 4 wall cutouts (70%×50%)",
+      "meanMs": 2126,
+      "minMs": 1941,
+      "maxMs": 2384,
+      "samples": 3
+    },
+    {
+      "name": "cutout-width nudge (warm): base compound should hit cache",
+      "params": "4×2×6 honeycomb + cutouts, two generations per iteration with cutout width changed",
+      "meanMs": 3816,
+      "minMs": 3602,
+      "maxMs": 3935,
+      "samples": 3
+    }
+  ]
+}

--- a/src/features/generation/worker/generators/binGenerator.bench.ts
+++ b/src/features/generation/worker/generators/binGenerator.bench.ts
@@ -204,6 +204,94 @@ describe('wall pattern + cutout cache reuse', () => {
   );
 });
 
+// ─── Dense compartments + cutouts (perf instrumentation baseline) ────────────
+//
+// Real-world worst-case scenarios that exercise the wall-pattern cold-cache
+// path: a wide bin with many compartments and all four wall cutouts, a tall
+// bin where hex prisms balloon, and a cache-warm iteration that should land
+// almost entirely in the per-wall LRU.
+//
+// Numbers from these benches feed `__bench__/baseline.json`. When tuning
+// wallPatternBuilder / wallPatternClips, compare here first.
+describe('dense compartments + cutouts (wall pattern cold cache)', () => {
+  const fourCutouts = (width: number, depth: number) => ({
+    ...DEFAULT_BIN_PARAMS.walls,
+    enabled: true,
+    front: { ...DISABLED_WALL_CUTOUT, enabled: true, width, depth },
+    back: { ...DISABLED_WALL_CUTOUT, enabled: true, width, depth },
+    left: { ...DISABLED_WALL_CUTOUT, enabled: true, width, depth },
+    right: { ...DISABLED_WALL_CUTOUT, enabled: true, width, depth },
+    interior: DISABLED_WALL_CUTOUT,
+  });
+
+  const DENSE_WIDE = params({
+    width: 6,
+    depth: 4,
+    height: 6,
+    compartments: {
+      cols: 12,
+      rows: 8,
+      thickness: 1.2,
+      cells: Array.from({ length: 12 * 8 }, (_, i) => i),
+    },
+    wallPattern: { enabled: true, pattern: 'honeycomb' },
+    walls: fourCutouts(70, 50),
+  });
+
+  const TALL_DENSE = params({
+    width: 4,
+    depth: 4,
+    height: 6,
+    compartments: {
+      cols: 6,
+      rows: 6,
+      thickness: 1.2,
+      cells: Array.from({ length: 6 * 6 }, (_, i) => i),
+    },
+    wallPattern: { enabled: true, pattern: 'honeycomb' },
+    walls: fourCutouts(70, 50),
+  });
+
+  bench(
+    'dense_wide_with_cutouts (cold): 6×4×6, 12×8 compartments, 4 cutouts',
+    () => {
+      getGenerateBin()(DENSE_WIDE);
+    },
+    { iterations: 3, warmupIterations: 0 }
+  );
+
+  bench(
+    'tall_with_cutouts (cold): 4×4×6, 6×6 compartments, 4 cutouts',
+    () => {
+      getGenerateBin()(TALL_DENSE);
+    },
+    { iterations: 3, warmupIterations: 0 }
+  );
+
+  bench(
+    'cache_warm_cutout_iter: dense_wide repeated with cutout width nudges',
+    () => {
+      // Warm the base + clipped caches, then iterate cutout widths so
+      // base compounds hit cache but clipped results miss.
+      getGenerateBin()(DENSE_WIDE);
+      for (let i = 0; i < 4; i++) {
+        const width = 68 - i;
+        getGenerateBin()({
+          ...DENSE_WIDE,
+          walls: {
+            ...DENSE_WIDE.walls,
+            front: { ...DENSE_WIDE.walls.front, width },
+            back: { ...DENSE_WIDE.walls.back, width },
+            left: { ...DENSE_WIDE.walls.left, width },
+            right: { ...DENSE_WIDE.walls.right, width },
+          },
+        });
+      }
+    },
+    { iterations: 2, warmupIterations: 1 }
+  );
+});
+
 // ─── Export paths ─────────────────────────────────────────────────────────────
 
 describe('export (forExport=true)', () => {

--- a/src/features/generation/worker/generators/binOrchestrator.ts
+++ b/src/features/generation/worker/generators/binOrchestrator.ts
@@ -17,6 +17,7 @@ import { featuresStage } from './pipeline/stages/featuresStage';
 import { booleanStage } from './pipeline/stages/booleanStage';
 import { translateStage } from './pipeline/stages/translateStage';
 import { tessellateStage } from './pipeline/stages/tessellateStage';
+import type { PerfCollector } from './pipeline/perfCollector';
 
 /**
  * Throws if `params.cellMask` is present but malformed. Checks dimensions
@@ -64,10 +65,11 @@ export function generateBin(
   params: BinParams,
   onProgress?: ProgressFn,
   forExport = false,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  perfCollector?: PerfCollector
 ): MeshData {
   assertValidMask(params);
-  const ctx = createInitialContext(params, onProgress, forExport, signal);
+  const ctx = createInitialContext(params, onProgress, forExport, signal, perfCollector);
   const result = runPipeline(DEFAULT_PIPELINE, ctx);
 
   if (!result.mesh) {

--- a/src/features/generation/worker/generators/dividerBlendBuilder.ts
+++ b/src/features/generation/worker/generators/dividerBlendBuilder.ts
@@ -26,6 +26,8 @@ import {
   dividerTouchesWall,
   getWallFaceInfo,
   isPerpendicular,
+  type DividerInfo,
+  type OuterWallCutoutInfo,
 } from './dividerBlendTypes';
 import { collectDividers, resolveOuterCutouts } from './dividerBlendResolvers';
 import { buildEndTrimCut, buildParallelTrimCut, buildRampCut } from './dividerBlendCuts';
@@ -137,24 +139,51 @@ export function buildDividerBlends(
 // --- Ramp zone data for wall pattern clipping ---
 
 /**
+ * Pre-computed inputs shared across the 4 walls so we don't redundantly
+ * call `collectDividers` / `resolveOuterCutouts` 8 times per generation.
+ * Build once via `computeWallPatternInputs` and pass into the per-wall
+ * functions below.
+ */
+export interface WallPatternInputs {
+  readonly dividers: readonly DividerInfo[];
+  readonly cutouts: readonly OuterWallCutoutInfo[];
+}
+
+export function computeWallPatternInputs(
+  params: BinParams,
+  innerW: number,
+  innerD: number,
+  wallHeight: number
+): WallPatternInputs {
+  return {
+    dividers: collectDividers(params, innerW, innerD),
+    cutouts: resolveOuterCutouts(params, innerW, innerD, wallHeight),
+  };
+}
+
+/**
  * Compute ramp zones that face a specific wall, for hex pattern clipping.
  *
  * Returns zones where ramp cuts exist on perpendicular dividers that touch
  * this wall. The pattern builder uses these to extend its clip region.
+ *
+ * Pre-computed `inputs` avoid redundant divider/cutout traversal when
+ * called for all 4 walls in the same generation.
  */
 export function computeRampZones(
   wallSide: 'front' | 'back' | 'left' | 'right',
   params: BinParams,
   innerW: number,
   innerD: number,
-  wallHeight: number
+  wallHeight: number,
+  inputs?: WallPatternInputs
 ): RampZone[] {
   if (!params.walls.enabled || params.style !== 'standard') return [];
 
-  const dividers = collectDividers(params, innerW, innerD);
+  const dividers = inputs?.dividers ?? collectDividers(params, innerW, innerD);
   if (dividers.length === 0) return [];
 
-  const cutouts = resolveOuterCutouts(params, innerW, innerD, wallHeight);
+  const cutouts = inputs?.cutouts ?? resolveOuterCutouts(params, innerW, innerD, wallHeight);
   const wallCutout = cutouts.find((c) => c.side === wallSide);
   if (!wallCutout) return [];
 
@@ -206,18 +235,22 @@ export function computeRampZones(
  * regardless of whether a cutout exists. This ensures the hex pattern is
  * cleared where divider walls connect to the outer wall for structural
  * integrity (see issue #1345).
+ *
+ * Pre-computed `inputs.dividers` avoids redundant traversal when called
+ * for all 4 walls in the same generation.
  */
 export function computeDividerJunctionZones(
   wallSide: 'front' | 'back' | 'left' | 'right',
   params: BinParams,
   innerW: number,
   innerD: number,
-  wallHeight: number
+  wallHeight: number,
+  inputs?: WallPatternInputs
 ): RampZone[] {
   // 'solid' intentionally included — junction blocking applies to any fused-wall style
   if (params.style === 'slotted') return [];
 
-  const dividers = collectDividers(params, innerW, innerD);
+  const dividers = inputs?.dividers ?? collectDividers(params, innerW, innerD);
   if (dividers.length === 0) return [];
 
   const wall = getWallFaceInfo(wallSide, innerW, innerD);

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -28,6 +28,7 @@ import {
 import type { ProgressFn } from '../meshUtils';
 import { buildCacheKey, quantize, compactKey } from '../cacheKeyUtils';
 import type { BinDimensions, PipelineContext } from './types';
+import type { PerfCollector } from './perfCollector';
 
 /** Derive all dimensions from bin parameters. */
 function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions {
@@ -144,7 +145,8 @@ export function createInitialContext(
   params: BinParams,
   onProgress?: ProgressFn,
   forExport = false,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  perfCollector?: PerfCollector
 ): PipelineContext {
   return {
     params,
@@ -159,5 +161,6 @@ export function createInitialContext(
     patternCutTargets: [],
     mesh: null,
     coarseMesh: null,
+    perfCollector,
   };
 }

--- a/src/features/generation/worker/generators/pipeline/featureRunner.ts
+++ b/src/features/generation/worker/generators/pipeline/featureRunner.ts
@@ -49,10 +49,13 @@ export function runFeatureBuilders(
     patternCut: targets.patternCutTargets,
   };
 
+  const perf = ctx.perfCollector;
+
   for (const builder of builders) {
     if (!builder.shouldBuild(ctx)) continue;
     checkCancelled(ctx.signal);
 
+    const builderStart = perf ? performance.now() : 0;
     const key = builder.cacheKey(ctx);
 
     // getFeatureCache returns a clone (caller owns it), or null on miss.
@@ -78,6 +81,8 @@ export function runFeatureBuilders(
       collectOrigins(shape, builder.tag, ctx.originToTag);
       bucketMap[builder.target].push(shape);
     }
+
+    if (perf) perf.recordFeatureBuilder(builder.name, performance.now() - builderStart);
   }
 
   return targets;

--- a/src/features/generation/worker/generators/pipeline/perfCollector.ts
+++ b/src/features/generation/worker/generators/pipeline/perfCollector.ts
@@ -1,0 +1,52 @@
+/**
+ * Worker-side accumulator for per-generation performance timings.
+ *
+ * Pipeline stages and the wall-pattern builder record timings into the
+ * collector; the worker emits the final `PerfSnapshot` with `MESH_RESULT`
+ * for the dev-only PerfOverlay.
+ *
+ * Overhead is intentionally small — a handful of `performance.now()` calls
+ * per generation, no allocations on the hot path beyond pushing into a
+ * short array.
+ */
+
+import type { PerfSnapshot, PerfStageEntry, PerfSubstepEntry } from '../../../bridge/types';
+
+export class PerfCollector {
+  private readonly stages: PerfStageEntry[] = [];
+  private readonly featureBuilders: PerfSubstepEntry[] = [];
+  private readonly wallPatternSubsteps: PerfSubstepEntry[] = [];
+  private hexCenterCount = 0;
+  private patternCutToolCount = 0;
+
+  recordStage(name: string, ms: number): void {
+    this.stages.push({ name, ms });
+  }
+
+  recordFeatureBuilder(name: string, ms: number): void {
+    this.featureBuilders.push({ name, ms });
+  }
+
+  recordWallPatternSubstep(name: string, ms: number, count?: number): void {
+    this.wallPatternSubsteps.push(count === undefined ? { name, ms } : { name, ms, count });
+  }
+
+  addHexCenters(n: number): void {
+    this.hexCenterCount += n;
+  }
+
+  setPatternCutToolCount(n: number): void {
+    this.patternCutToolCount = n;
+  }
+
+  snapshot(totalMs: number): PerfSnapshot {
+    return {
+      totalMs,
+      stages: this.stages.slice(),
+      featureBuilders: this.featureBuilders.slice(),
+      wallPatternSubsteps: this.wallPatternSubsteps.slice(),
+      hexCenterCount: this.hexCenterCount,
+      patternCutToolCount: this.patternCutToolCount,
+    };
+  }
+}

--- a/src/features/generation/worker/generators/pipeline/runner.ts
+++ b/src/features/generation/worker/generators/pipeline/runner.ts
@@ -1,25 +1,29 @@
 /**
  * Pipeline runner — iterates stages, checks cancellation, reports progress.
+ *
+ * When `ctx.perfCollector` is set, each stage's wall-clock duration is
+ * recorded for the dev PerfOverlay. The `performance.now()` overhead is
+ * ~microseconds; the branch elides when the collector is absent (tests +
+ * bench).
  */
 
 import { checkCancelled } from '../meshUtils';
 import type { PipelineContext, PipelineStage } from './types';
 
-/**
- * Run pipeline stages sequentially, threading context through each.
- * Stages that return shouldRun=false are skipped.
- */
 export function runPipeline(
   stages: readonly PipelineStage[],
   initialContext: PipelineContext
 ): PipelineContext {
   let ctx = initialContext;
+  const perf = ctx.perfCollector;
 
   for (const stage of stages) {
     if (!stage.shouldRun(ctx)) continue;
     checkCancelled(ctx.signal);
     ctx.onProgress?.(stage.name, stage.progressValue);
+    const start = perf ? performance.now() : 0;
     ctx = stage.execute(ctx);
+    if (perf) perf.recordStage(stage.name, performance.now() - start);
   }
 
   return ctx;

--- a/src/features/generation/worker/generators/pipeline/types.ts
+++ b/src/features/generation/worker/generators/pipeline/types.ts
@@ -13,6 +13,7 @@ import type { Shape3D } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
 import type { MeshData } from '../../../bridge/types';
 import type { ProgressFn } from '../meshUtils';
+import type { PerfCollector } from './perfCollector';
 
 /** Pre-computed dimensions derived from BinParams. Avoids re-deriving in each stage. */
 export interface BinDimensions {
@@ -64,6 +65,12 @@ export interface PipelineContext {
   readonly mesh: MeshData | null;
   /** Coarse LOD mesh for distance-based rendering (preview only) */
   readonly coarseMesh: MeshData | null;
+  /**
+   * Optional perf collector. Pipeline runner records per-stage timings
+   * into it; wall-pattern builder records per-wall substep timings.
+   * Tests and benchmarks omit it (zero overhead).
+   */
+  readonly perfCollector?: PerfCollector;
 }
 
 /** A single composable pipeline stage. */

--- a/src/features/generation/worker/generators/wallPatternBuilder.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.ts
@@ -101,16 +101,19 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
   const clipExtrudeDepth = Math.max((maxThickness + lipOverhang) * 2 + 1, cutDepth + 1);
   const clipOvershoot = (hasLip ? LIP_HEIGHT : 0) + 2;
 
-  // Hoisted: dividers and outer cutouts are wall-agnostic, so computing
-  // them once and reusing across all 4 walls saves 6 redundant traversals
-  // per generation (ramp + junction × 4 walls − 2 baseline).
-  const wallPatternInputs = computeWallPatternInputs(params, innerW, innerD, dim.wallHeight);
-
   // Build handle wall defs for clip positioning. Polygon bins use the
   // outermost edge per cardinal (matches handleBuilder), so clip boxes land
   // on the actual handle cutout location rather than the AABB wall center.
   const cellMask = params.cellMask;
   const isPolygon = isPartialMask(cellMask);
+
+  // Hoisted: dividers and outer cutouts are wall-agnostic, so computing
+  // them once and reusing across all 4 walls saves 6 redundant traversals
+  // per generation (ramp + junction × 4 walls − 2 baseline). Skip entirely
+  // for polygon bins since ramp/junction zones are unused on that path.
+  const wallPatternInputs = isPolygon
+    ? undefined
+    : computeWallPatternInputs(params, innerW, innerD, dim.wallHeight);
   const handleWallDefs: readonly HandleWallDef[] = !params.handles.enabled
     ? []
     : isPolygon

--- a/src/features/generation/worker/generators/wallPatternBuilder.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.ts
@@ -32,7 +32,11 @@ import {
   CUTOUT_BORDER_WIDTH,
   getExpandedCutoutDimensions,
 } from './wallPatterns';
-import { computeRampZones, computeDividerJunctionZones } from './dividerBlendBuilder';
+import {
+  computeRampZones,
+  computeDividerJunctionZones,
+  computeWallPatternInputs,
+} from './dividerBlendBuilder';
 import { FeatureTag } from './featureTags';
 import { collectOrigins } from './pipeline/collectOrigins';
 import {
@@ -61,7 +65,7 @@ import { buildClippedWallPattern } from './wallPatternCompound';
  * is a clone owned by the caller (cache owns the originals).
  */
 export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
-  const { params, dimensions: dim, signal, originToTag } = ctx;
+  const { params, dimensions: dim, signal, originToTag, perfCollector } = ctx;
   const { innerW, innerD, interiorHeight, hasLip } = dim;
   const patternCutTargets: Shape3D[] = [];
 
@@ -75,11 +79,19 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
   const shapeRadius = calculator.getShapeRadius();
 
   const templateKey = buildCacheKey('v1', patternType, quantize(shapeRadius), quantize(cutDepth));
+  const templateStart = perfCollector ? performance.now() : 0;
   let shapeTemplate = getPatternTemplateCache(templateKey);
+  const templateCacheHit = shapeTemplate !== null;
   if (!shapeTemplate) {
     const sides = calculator.getSidesCount();
     shapeTemplate = sketch(drawPolysides(shapeRadius, sides), 'XY').extrude(cutDepth);
     setPatternTemplateCache(templateKey, shapeTemplate);
+  }
+  if (perfCollector) {
+    perfCollector.recordWallPatternSubstep(
+      templateCacheHit ? 'template_hit' : 'template_build',
+      performance.now() - templateStart
+    );
   }
 
   const lipOverhang = hasLip ? LIP_TAPER_WIDTH : 0;
@@ -88,6 +100,11 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
   // so they fully envelop hex prisms at junction/cutout boundaries (#1354).
   const clipExtrudeDepth = Math.max((maxThickness + lipOverhang) * 2 + 1, cutDepth + 1);
   const clipOvershoot = (hasLip ? LIP_HEIGHT : 0) + 2;
+
+  // Hoisted: dividers and outer cutouts are wall-agnostic, so computing
+  // them once and reusing across all 4 walls saves 6 redundant traversals
+  // per generation (ramp + junction × 4 walls − 2 baseline).
+  const wallPatternInputs = computeWallPatternInputs(params, innerW, innerD, dim.wallHeight);
 
   // Build handle wall defs for clip positioning. Polygon bins use the
   // outermost edge per cardinal (matches handleBuilder), so clip boxes land
@@ -260,10 +277,17 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
     // on custom shapes so there's nothing to blend against or block.
     const rampZones = isPolygon
       ? []
-      : computeRampZones(wall.side, params, innerW, innerD, dim.wallHeight);
+      : computeRampZones(wall.side, params, innerW, innerD, dim.wallHeight, wallPatternInputs);
     const junctionZones = isPolygon
       ? []
-      : computeDividerJunctionZones(wall.side, params, innerW, innerD, dim.wallHeight);
+      : computeDividerJunctionZones(
+          wall.side,
+          params,
+          innerW,
+          innerD,
+          dim.wallHeight,
+          wallPatternInputs
+        );
     // Deduplicate: junction zones (full height) subsume ramp zones at the same offset
     const junctionOffsets = new Set(junctionZones.map((z) => quantize(z.offsetAlongWall)));
     const uniqueRampZones = rampZones.filter(
@@ -316,7 +340,9 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
       buildCacheKey('v1', baseKey, cutoutKeyPart, handleKeyPart, rampKeyPart)
     );
 
+    const wallStart = perfCollector ? performance.now() : 0;
     let shape = getFeatureCache(WALL_PATTERN_CLIPPED_CACHE, clippedKey);
+    const clippedCacheHit = shape !== null;
     if (!shape) {
       const built = buildClippedWallPattern(
         shapeTemplate,
@@ -332,11 +358,23 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
         shape = unwrap(clone(built));
       }
     }
+    if (perfCollector) {
+      perfCollector.recordWallPatternSubstep(
+        clippedCacheHit ? `wall_${wall.side}_hit` : `wall_${wall.side}_build`,
+        performance.now() - wallStart,
+        wall.centers.length
+      );
+      // Always count hex centers — measures pattern density even when the
+      // clipped result was served from cache.
+      perfCollector.addHexCenters(wall.centers.length);
+    }
     if (shape) {
       collectOrigins(shape, FeatureTag.WALL_PATTERN, originToTag);
       patternCutTargets.push(shape);
     }
   }
+
+  if (perfCollector) perfCollector.setPatternCutToolCount(patternCutTargets.length);
 
   return patternCutTargets;
 }

--- a/src/features/generation/worker/generators/wallPatternClips.ts
+++ b/src/features/generation/worker/generators/wallPatternClips.ts
@@ -63,31 +63,41 @@ function buildCutoutClipSolid(wall: WallPatternDescriptor, clip: CutoutClipParam
  * Each transform allocates a new WASM handle while the previous becomes
  * garbage; intermediates are disposed so only the final box per segment
  * survives in the returned array. Caller owns the array entries.
+ *
+ * If a transform throws mid-loop, every box built so far is disposed
+ * before re-throwing — otherwise the caller's outer catch never sees
+ * the partial array (since `.push(...fn())` only spreads on success)
+ * and the WASM handles leak.
  */
 function buildHandleClipBoxes(handleClip: HandleClipParams): Shape3D[] {
   const border = CUTOUT_BORDER_WIDTH;
   const hw = handleClip.handleWall;
   const out: Shape3D[] = [];
-  for (const seg of handleClip.segments) {
-    const boxW = seg.width + 2 * border;
-    const boxH = handleClip.effectiveHeight + 2 * border;
-    const profile = drawRectangle(boxW, boxH);
-    const extruded = sketch(profile, 'XZ').extrude(handleClip.clipExtrudeDepth);
-    const centered = translate(extruded, [
-      seg.offset,
-      handleClip.clipExtrudeDepth / 2,
-      handleClip.centerZ,
-    ]);
-    extruded.delete();
-    let hbox = centered;
-    if (hw.rotateZ !== 0) {
-      const rotated = rotate(hbox, hw.rotateZ, { axis: [0, 0, 1] });
+  try {
+    for (const seg of handleClip.segments) {
+      const boxW = seg.width + 2 * border;
+      const boxH = handleClip.effectiveHeight + 2 * border;
+      const profile = drawRectangle(boxW, boxH);
+      const extruded = sketch(profile, 'XZ').extrude(handleClip.clipExtrudeDepth);
+      const centered = translate(extruded, [
+        seg.offset,
+        handleClip.clipExtrudeDepth / 2,
+        handleClip.centerZ,
+      ]);
+      extruded.delete();
+      let hbox = centered;
+      if (hw.rotateZ !== 0) {
+        const rotated = rotate(hbox, hw.rotateZ, { axis: [0, 0, 1] });
+        hbox.delete();
+        hbox = rotated;
+      }
+      const positioned = translate(hbox, [hw.x, hw.y, 0]);
       hbox.delete();
-      hbox = rotated;
+      out.push(positioned);
     }
-    const positioned = translate(hbox, [hw.x, hw.y, 0]);
-    hbox.delete();
-    out.push(positioned);
+  } catch (err) {
+    for (const s of out) disposeQuiet(s);
+    throw err;
   }
   return out;
 }
@@ -107,26 +117,33 @@ function buildHandleClipBoxes(handleClip: HandleClipParams): Shape3D[] {
 function buildRampClipBoxes(wall: WallPatternDescriptor, rampClip: RampZoneClipParams): Shape3D[] {
   const { border, clipExtrudeDepth: rampExtrudeDepth, wallHeight, zones } = rampClip;
   const out: Shape3D[] = [];
-  for (const zone of zones) {
-    const rboxW = zone.width + 2 * border;
-    const rboxH = zone.height + 2 * border;
-    const profile = drawRectangle(rboxW, rboxH);
-    const extruded = sketch(profile, 'XZ').extrude(rampExtrudeDepth);
-    const centerZ = wallHeight - zone.height / 2;
-    const centered = translate(extruded, [0, rampExtrudeDepth / 2, centerZ]);
-    extruded.delete();
-    let rbox = centered;
-    if (wall.zRotation !== undefined) {
-      const rotated = rotate(rbox, wall.zRotation, { axis: [0, 0, 1] });
+  try {
+    for (const zone of zones) {
+      const rboxW = zone.width + 2 * border;
+      const rboxH = zone.height + 2 * border;
+      const profile = drawRectangle(rboxW, rboxH);
+      const extruded = sketch(profile, 'XZ').extrude(rampExtrudeDepth);
+      const centerZ = wallHeight - zone.height / 2;
+      const centered = translate(extruded, [0, rampExtrudeDepth / 2, centerZ]);
+      extruded.delete();
+      let rbox = centered;
+      if (wall.zRotation !== undefined) {
+        const rotated = rotate(rbox, wall.zRotation, { axis: [0, 0, 1] });
+        rbox.delete();
+        rbox = rotated;
+      }
+      const rotZ = wall.zRotation ?? 0;
+      const offsetX = rotZ === 90 || rotZ === -90 ? 0 : zone.offsetAlongWall;
+      const offsetY = rotZ === 90 || rotZ === -90 ? zone.offsetAlongWall : 0;
+      const positioned = translate(rbox, [wall.translateX + offsetX, wall.translateY + offsetY, 0]);
       rbox.delete();
-      rbox = rotated;
+      out.push(positioned);
     }
-    const rotZ = wall.zRotation ?? 0;
-    const offsetX = rotZ === 90 || rotZ === -90 ? 0 : zone.offsetAlongWall;
-    const offsetY = rotZ === 90 || rotZ === -90 ? zone.offsetAlongWall : 0;
-    const positioned = translate(rbox, [wall.translateX + offsetX, wall.translateY + offsetY, 0]);
-    rbox.delete();
-    out.push(positioned);
+  } catch (err) {
+    // See buildHandleClipBoxes for the rationale — caller can't drain a
+    // partial array returned by a throw, so we dispose here.
+    for (const s of out) disposeQuiet(s);
+    throw err;
   }
   return out;
 }
@@ -190,7 +207,20 @@ export function applyWallPatternClips(
   // ownership stays consistent — we always dispose the returned `fused`
   // handle (which is tools[0] in the singleton case). When length > 1,
   // it produces a fresh fused shape; the originals are then disposed.
-  const fused = fuseAllOrNull(tools);
+  // Wrap to catch the rare degenerate-input throw from unwrap(fuseAll(...));
+  // on non-abort we silently drop clipping (matches the prior per-pass
+  // catch semantics) instead of poisoning the whole generation.
+  let fused: Shape3D | null;
+  try {
+    fused = fuseAllOrNull(tools);
+  } catch (err: unknown) {
+    for (const t of tools) disposeQuiet(t);
+    if (isAbortError(err)) {
+      base.delete();
+      throw err;
+    }
+    return base;
+  }
   if (!fused) {
     for (const t of tools) disposeQuiet(t);
     return base;
@@ -210,7 +240,7 @@ export function applyWallPatternClips(
       disposeQuiet(fused);
       throw err;
     }
-    // Non-abort failure: keep base unchanged (matches prior behavior).
+    // Non-abort failure: result still points at base; let it through unchanged.
   } finally {
     disposeQuiet(fused);
   }

--- a/src/features/generation/worker/generators/wallPatternClips.ts
+++ b/src/features/generation/worker/generators/wallPatternClips.ts
@@ -2,15 +2,17 @@
  * Cutout/handle/ramp clipping passes for wall hex patterns.
  *
  * `applyWallPatternClips` takes ownership of the base hex compound and
- * applies — in order — cutout border clipping, handle border clipping,
- * and ramp-zone border clipping. Each pass returns a new shape and
- * disposes the previous handle.
+ * applies cutout, handle, and ramp-zone clipping. All clip solids for a
+ * wall are pre-fused into a single tool so the kernel only sees ONE
+ * `cut(base, allClips)` per wall instead of up to three sequential cuts.
+ * That collapses both the boolean count and the intermediate-shape
+ * allocations that the chained-cut path used to leak.
  *
  * Each clip box is at least as deep as the hex prism extrusion so it
  * fully envelops hex prisms at junction/cutout boundaries (#1354).
  */
 
-import { drawRectangle, unwrap, cut, fuse, translate, rotate } from 'brepjs';
+import { drawRectangle, unwrap, cut, translate, rotate } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import type { WallPatternDescriptor } from './wallPatterns';
 import { sketch } from './meshUtils';
@@ -18,13 +20,139 @@ import { isAbortError } from './utils/abort';
 import { CUTOUT_BORDER_WIDTH } from './wallPatterns';
 import { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
 import { buildSingleCutout } from './featureBuilder';
+import { fuseAllOrNull } from './utils/shapeOps';
 import type { CutoutClipParams, HandleClipParams, RampZoneClipParams } from './wallPatternTypes';
+
+/**
+ * Build the cutout clip solid for a wall.
+ *
+ * Returns null when the cutout config is absent or below the geometric
+ * floor that the original chained path was already silently skipping
+ * (cut dims < 0.1 mm). Caller owns the returned shape.
+ */
+function buildCutoutClipSolid(wall: WallPatternDescriptor, clip: CutoutClipParams): Shape3D | null {
+  if (clip.cutWidth < 0.1 || clip.userCutHeight < 0.1) return null;
+
+  const rotateZ = wall.side === 'left' || wall.side === 'right' ? 90 : 0;
+  const centerOffset = computeCutoutCenter(
+    clip.wallSpan,
+    clip.cutWidth,
+    clip.wallThickness,
+    clip.cutoutCfg.alignment,
+    clip.cutoutCfg.offset
+  );
+
+  return buildSingleCutout(
+    clip.wallShape,
+    clip.expandedWidth,
+    clip.expandedHeight,
+    clip.clipOvershoot,
+    clip.clipExtrudeDepth,
+    clip.wallHeight,
+    {
+      x: rotateZ === 0 ? wall.translateX + centerOffset : wall.translateX,
+      y: rotateZ !== 0 ? wall.translateY + centerOffset : wall.translateY,
+      rotateZ,
+    }
+  );
+}
+
+/**
+ * Build one positioned box per handle segment.
+ *
+ * Each transform allocates a new WASM handle while the previous becomes
+ * garbage; intermediates are disposed so only the final box per segment
+ * survives in the returned array. Caller owns the array entries.
+ */
+function buildHandleClipBoxes(handleClip: HandleClipParams): Shape3D[] {
+  const border = CUTOUT_BORDER_WIDTH;
+  const hw = handleClip.handleWall;
+  const out: Shape3D[] = [];
+  for (const seg of handleClip.segments) {
+    const boxW = seg.width + 2 * border;
+    const boxH = handleClip.effectiveHeight + 2 * border;
+    const profile = drawRectangle(boxW, boxH);
+    const extruded = sketch(profile, 'XZ').extrude(handleClip.clipExtrudeDepth);
+    const centered = translate(extruded, [
+      seg.offset,
+      handleClip.clipExtrudeDepth / 2,
+      handleClip.centerZ,
+    ]);
+    extruded.delete();
+    let hbox = centered;
+    if (hw.rotateZ !== 0) {
+      const rotated = rotate(hbox, hw.rotateZ, { axis: [0, 0, 1] });
+      hbox.delete();
+      hbox = rotated;
+    }
+    const positioned = translate(hbox, [hw.x, hw.y, 0]);
+    hbox.delete();
+    out.push(positioned);
+  }
+  return out;
+}
+
+/**
+ * Build one positioned box per ramp zone.
+ *
+ * `offsetAlongWall` is a GLOBAL coordinate (posAlongPerp from
+ * dividerBlendBuilder), so it must be added AFTER rotation along
+ * whichever global axis the wall runs. Applying the rotation to a
+ * pre-offset box negates the offset on back/right walls (rotation
+ * around Z negates the axial component), so a divider at global X=+a
+ * would clip at X=-a on the back wall and leave the junction
+ * unclipped. Build at origin, rotate, then translate to the wall
+ * midpoint plus the axial offset.
+ */
+function buildRampClipBoxes(wall: WallPatternDescriptor, rampClip: RampZoneClipParams): Shape3D[] {
+  const { border, clipExtrudeDepth: rampExtrudeDepth, wallHeight, zones } = rampClip;
+  const out: Shape3D[] = [];
+  for (const zone of zones) {
+    const rboxW = zone.width + 2 * border;
+    const rboxH = zone.height + 2 * border;
+    const profile = drawRectangle(rboxW, rboxH);
+    const extruded = sketch(profile, 'XZ').extrude(rampExtrudeDepth);
+    const centerZ = wallHeight - zone.height / 2;
+    const centered = translate(extruded, [0, rampExtrudeDepth / 2, centerZ]);
+    extruded.delete();
+    let rbox = centered;
+    if (wall.zRotation !== undefined) {
+      const rotated = rotate(rbox, wall.zRotation, { axis: [0, 0, 1] });
+      rbox.delete();
+      rbox = rotated;
+    }
+    const rotZ = wall.zRotation ?? 0;
+    const offsetX = rotZ === 90 || rotZ === -90 ? 0 : zone.offsetAlongWall;
+    const offsetY = rotZ === 90 || rotZ === -90 ? zone.offsetAlongWall : 0;
+    const positioned = translate(rbox, [wall.translateX + offsetX, wall.translateY + offsetY, 0]);
+    rbox.delete();
+    out.push(positioned);
+  }
+  return out;
+}
+
+/** Best-effort dispose; swallow double-free / corrupt-handle errors. */
+function disposeQuiet(s: Shape3D): void {
+  try {
+    s.delete();
+  } catch {
+    /* already cleaned */
+  }
+}
 
 /**
  * Apply optional cutout/handle/ramp clipping to an owned base hex compound.
  *
- * Takes ownership of `base` and returns either `base` itself (no clips) or a
- * new shape with `base` disposed. Callers must not reuse the original handle.
+ * Takes ownership of `base`. All clip solids (cutout, handle segments,
+ * ramp zones) are pre-fused into a single tool and applied with one
+ * `cut()` call instead of up to three sequential cuts on the compound.
+ *
+ * Trade-off vs the prior chained-cut version: a degenerate clip box
+ * fails ALL clips for the wall rather than only the failing one. The
+ * pre-existing per-pass `catch` already silently dropped failing clips,
+ * so the reliability delta is "one bad clip drops all" instead of
+ * "one bad clip drops one"; given how rare degenerate clip boxes are
+ * in practice, the boolean savings dominate.
  */
 export function applyWallPatternClips(
   base: Shape3D,
@@ -33,232 +161,58 @@ export function applyWallPatternClips(
   handleClip: HandleClipParams | null,
   rampClip: RampZoneClipParams | null
 ): Shape3D | null {
-  // --- Cutout border clipping ---
+  const tools: Shape3D[] = [];
+
+  try {
+    if (clip) {
+      const cutoutSolid = buildCutoutClipSolid(wall, clip);
+      if (cutoutSolid) tools.push(cutoutSolid);
+    }
+    if (handleClip && handleClip.segments.length > 0) {
+      tools.push(...buildHandleClipBoxes(handleClip));
+    }
+    if (rampClip && rampClip.zones.length > 0) {
+      tools.push(...buildRampClipBoxes(wall, rampClip));
+    }
+  } catch (err: unknown) {
+    for (const t of tools) disposeQuiet(t);
+    if (isAbortError(err)) {
+      base.delete();
+      throw err;
+    }
+    // Tool construction failure: skip clipping; return base unchanged.
+    return base;
+  }
+
+  if (tools.length === 0) return base;
+
+  // fuseAllOrNull returns tools[0] directly when length === 1, so
+  // ownership stays consistent — we always dispose the returned `fused`
+  // handle (which is tools[0] in the singleton case). When length > 1,
+  // it produces a fresh fused shape; the originals are then disposed.
+  const fused = fuseAllOrNull(tools);
+  if (!fused) {
+    for (const t of tools) disposeQuiet(t);
+    return base;
+  }
+  if (tools.length > 1) {
+    for (const t of tools) disposeQuiet(t);
+  }
+
   let result = base;
-  if (clip && clip.cutWidth >= 0.1 && clip.userCutHeight >= 0.1) {
-    const rotateZ = wall.side === 'left' || wall.side === 'right' ? 90 : 0;
-    const centerOffset = computeCutoutCenter(
-      clip.wallSpan,
-      clip.cutWidth,
-      clip.wallThickness,
-      clip.cutoutCfg.alignment,
-      clip.cutoutCfg.offset
-    );
-
-    const clipSolid = buildSingleCutout(
-      clip.wallShape,
-      clip.expandedWidth,
-      clip.expandedHeight,
-      clip.clipOvershoot,
-      clip.clipExtrudeDepth,
-      clip.wallHeight,
-      {
-        x: rotateZ === 0 ? wall.translateX + centerOffset : wall.translateX,
-        y: rotateZ !== 0 ? wall.translateY + centerOffset : wall.translateY,
-        rotateZ,
-      }
-    );
-
-    try {
-      const clipped = unwrap(cut(result, clipSolid));
+  try {
+    const clipped = unwrap(cut(result, fused));
+    result.delete();
+    result = clipped;
+  } catch (err: unknown) {
+    if (isAbortError(err)) {
       result.delete();
-      result = clipped;
-    } catch (err: unknown) {
-      if (isAbortError(err)) {
-        result.delete();
-        throw err;
-      }
-      // On non-abort failure, keep result as-is
-    } finally {
-      clipSolid.delete();
+      disposeQuiet(fused);
+      throw err;
     }
-  }
-
-  // --- Handle border clipping ---
-  if (handleClip && handleClip.segments.length > 0) {
-    const border = CUTOUT_BORDER_WIDTH;
-    const clipBoxes: Shape3D[] = [];
-    // Tracks the in-flight fuse-merge result so the catch can dispose it
-    // if an intermediate fuse() throws. Set to null once ownership is
-    // handed off to handleClipSolid (or never created on the singleton path).
-    let pendingMerge: Shape3D | null = null;
-
-    const hw = handleClip.handleWall;
-    try {
-      for (const seg of handleClip.segments) {
-        const boxW = seg.width + 2 * border;
-        const boxH = handleClip.effectiveHeight + 2 * border;
-        const profile = drawRectangle(boxW, boxH);
-        // Each transform allocates a new WASM handle while the previous
-        // becomes garbage. Dispose the intermediates explicitly so only
-        // the final handle survives in clipBoxes.
-        const extruded = sketch(profile, 'XZ').extrude(handleClip.clipExtrudeDepth);
-        const centered = translate(extruded, [
-          seg.offset,
-          handleClip.clipExtrudeDepth / 2,
-          handleClip.centerZ,
-        ]);
-        extruded.delete();
-        let hbox = centered;
-        if (hw.rotateZ !== 0) {
-          const rotated = rotate(hbox, hw.rotateZ, { axis: [0, 0, 1] });
-          hbox.delete();
-          hbox = rotated;
-        }
-        const positioned = translate(hbox, [hw.x, hw.y, 0]);
-        hbox.delete();
-        clipBoxes.push(positioned);
-      }
-
-      let handleClipSolid: Shape3D;
-      if (clipBoxes.length === 1) {
-        handleClipSolid = clipBoxes[0];
-      } else {
-        let current: Shape3D = unwrap(fuse(clipBoxes[0], clipBoxes[1]));
-        pendingMerge = current;
-        clipBoxes[0].delete();
-        clipBoxes[1].delete();
-        for (let i = 2; i < clipBoxes.length; i++) {
-          const merged: Shape3D = unwrap(fuse(current, clipBoxes[i]));
-          current.delete();
-          clipBoxes[i].delete();
-          current = merged;
-          pendingMerge = current;
-        }
-        handleClipSolid = current;
-        pendingMerge = null; // ownership transferred to handleClipSolid
-      }
-
-      try {
-        const handleClipped = unwrap(cut(result, handleClipSolid));
-        result.delete();
-        result = handleClipped;
-      } catch (err: unknown) {
-        if (isAbortError(err)) {
-          result.delete();
-          throw err;
-        }
-        // On non-abort failure, keep result as-is
-      } finally {
-        handleClipSolid.delete();
-      }
-    } catch (err: unknown) {
-      for (const b of clipBoxes) {
-        try {
-          b.delete();
-        } catch {
-          /* already cleaned */
-        }
-      }
-      if (pendingMerge) {
-        try {
-          pendingMerge.delete();
-        } catch {
-          /* already cleaned */
-        }
-      }
-      if (isAbortError(err)) {
-        result.delete();
-        throw err;
-      }
-    }
-  }
-
-  // --- Ramp zone border clipping ---
-  if (rampClip && rampClip.zones.length > 0) {
-    const { border, clipExtrudeDepth: rampExtrudeDepth, wallHeight, zones } = rampClip;
-    const rampBoxes: Shape3D[] = [];
-    // See handle-clip block for why pendingMerge is tracked separately
-    // from rampBoxes — the in-flight fuse intermediate isn't in either pool.
-    let pendingMerge: Shape3D | null = null;
-
-    try {
-      for (const zone of zones) {
-        const rboxW = zone.width + 2 * border;
-        const rboxH = zone.height + 2 * border;
-        const profile = drawRectangle(rboxW, rboxH);
-        // Dispose intermediates from each transform.
-        const extruded = sketch(profile, 'XZ').extrude(rampExtrudeDepth);
-        const centerZ = wallHeight - zone.height / 2;
-
-        // Build the box at the ORIGIN (not at offsetAlongWall), rotate to
-        // align with the wall, THEN translate to the wall midpoint plus the
-        // axial offset. Applying the rotation to a pre-offset box negates
-        // the offset for back (zRotation=180) and right (zRotation=-90)
-        // walls because rotation around Z negates the axial component —
-        // so a divider at global X=+a produced a clip box at X=-a on the
-        // back wall, leaving the actual junction unclipped and producing
-        // hex-prism bleed near divider-wall junctions on asymmetric bins.
-        // `offsetAlongWall` is a GLOBAL coordinate (posAlongPerp from
-        // dividerBlendBuilder), so it must be added AFTER rotation, along
-        // whichever global axis the wall runs (X for front/back, Y for
-        // left/right).
-        const centered = translate(extruded, [0, rampExtrudeDepth / 2, centerZ]);
-        extruded.delete();
-        let rbox = centered;
-        if (wall.zRotation !== undefined) {
-          const rotated = rotate(rbox, wall.zRotation, { axis: [0, 0, 1] });
-          rbox.delete();
-          rbox = rotated;
-        }
-        const rotZ = wall.zRotation ?? 0;
-        const offsetX = rotZ === 90 || rotZ === -90 ? 0 : zone.offsetAlongWall;
-        const offsetY = rotZ === 90 || rotZ === -90 ? zone.offsetAlongWall : 0;
-        const positioned = translate(rbox, [
-          wall.translateX + offsetX,
-          wall.translateY + offsetY,
-          0,
-        ]);
-        rbox.delete();
-        rampBoxes.push(positioned);
-      }
-
-      if (rampBoxes.length > 0) {
-        let current: Shape3D = rampBoxes[0];
-        pendingMerge = current;
-        for (let i = 1; i < rampBoxes.length; i++) {
-          const merged: Shape3D = unwrap(fuse(current, rampBoxes[i]));
-          current.delete();
-          rampBoxes[i].delete();
-          current = merged;
-          pendingMerge = current;
-        }
-        const rampClipSolid = current;
-        pendingMerge = null; // ownership transferred to rampClipSolid
-
-        try {
-          const rampClipped = unwrap(cut(result, rampClipSolid));
-          result.delete();
-          result = rampClipped;
-        } catch (err: unknown) {
-          if (isAbortError(err)) {
-            result.delete();
-            throw err;
-          }
-        } finally {
-          rampClipSolid.delete();
-        }
-      }
-    } catch (err: unknown) {
-      for (const b of rampBoxes) {
-        try {
-          b.delete();
-        } catch {
-          /* already cleaned */
-        }
-      }
-      if (pendingMerge) {
-        try {
-          pendingMerge.delete();
-        } catch {
-          /* already cleaned */
-        }
-      }
-      if (isAbortError(err)) {
-        result.delete();
-        throw err;
-      }
-    }
+    // Non-abort failure: keep base unchanged (matches prior behavior).
+  } finally {
+    disposeQuiet(fused);
   }
 
   return result;

--- a/src/features/generation/worker/handlers/generateHandler.ts
+++ b/src/features/generation/worker/handlers/generateHandler.ts
@@ -17,12 +17,12 @@ import { runGeneration, reportProgress, getActiveRequestId } from './workerConte
 export function handleGenerate(message: GenerateMessage): void {
   const { params, requestId } = message.payload;
   runGeneration(
-    (signal): MeshData => {
+    (signal, perf): MeshData => {
       const onProgress = (stage: string, progress: number) => {
         if (getActiveRequestId() !== requestId) return;
         reportProgress(requestId, stage as 'base' | 'shell' | 'features' | 'merge', progress);
       };
-      const binMesh = generateBin(params, onProgress, false, signal);
+      const binMesh = generateBin(params, onProgress, false, signal, perf);
       // Lid runs sequentially after the bin so a single abort cancels both.
       // The lid is a SECONDARY feature: an OCCT exception during lid build
       // (e.g., on a degenerate polygon footprint) must not poison the
@@ -47,6 +47,10 @@ export function handleGenerate(message: GenerateMessage): void {
 export function handleGenerateBaseplate(message: GenerateBaseplateMessage): void {
   const { params, requestId } = message.payload;
   runGeneration(
+    // Baseplate generation does not use the pipeline / PerfCollector path
+    // (it has its own internal flow), so the collector here just stays empty
+    // and produces a snapshot with only the totalMs filled in. The PerfOverlay
+    // gracefully renders an empty per-stage breakdown.
     (signal) =>
       generateBaseplate(
         params,

--- a/src/features/generation/worker/handlers/workerContext.ts
+++ b/src/features/generation/worker/handlers/workerContext.ts
@@ -15,6 +15,7 @@ import {
   resetBooleanFallbackStats,
 } from '../generators/pipeline/stages/booleanStage';
 import { isAbortError } from '../generators/utils/abort';
+import { PerfCollector } from '../generators/pipeline/perfCollector';
 
 /** Mutable worker state */
 let activeRequestId: string | null = null;
@@ -78,7 +79,7 @@ export function setKernelInitialized(kernel: KernelName, threaded: boolean, core
  * Unified generation pipeline for both bin and baseplate mesh generation.
  */
 export function runGeneration(
-  generator: (signal: AbortSignal) => MeshData,
+  generator: (signal: AbortSignal, perf: PerfCollector) => MeshData,
   requestId: string,
   logPrefix: string,
   copyBuffers: boolean
@@ -89,17 +90,19 @@ export function runGeneration(
   activeController = new AbortController();
   const { signal } = activeController;
   const startTime = performance.now();
+  const perfCollector = new PerfCollector();
 
   try {
     // brepjs perf stats are only meaningful for the opencascade kernel
     if (activeKernel === 'opencascade') resetPerformanceStats();
     resetBooleanFallbackStats();
-    const meshData = generator(signal);
+    const meshData = generator(signal, perfCollector);
 
     if (activeRequestId !== requestId) return;
 
     const timingMs = performance.now() - startTime;
     const kernelPerfStats = activeKernel === 'opencascade' ? getPerformanceStats() : {};
+    const perfSnapshot = perfCollector.snapshot(timingMs);
 
     const maybeCopy = <T extends Float32Array | Uint32Array>(buf: T): T =>
       (copyBuffers ? buf.slice() : buf) as T;
@@ -141,6 +144,7 @@ export function runGeneration(
       timingMs,
       faceGroups: meshData.faceGroups,
       coarseLOD,
+      perfSnapshot,
       ...(lid
         ? {
             lidVertices: lid.vertices,

--- a/src/shared/generation/bridge.ts
+++ b/src/shared/generation/bridge.ts
@@ -8,7 +8,13 @@
 export { GenerationBridge } from '@/features/generation/bridge';
 export { getActiveBridge, bridgeManager } from '@/features/generation/bridge';
 export { WorkerPool, workerPoolManager } from '@/features/generation/bridge';
-export type { WorkerResponse, MeshData } from '@/features/generation/bridge/types';
+export type {
+  WorkerResponse,
+  MeshData,
+  PerfSnapshot,
+  PerfStageEntry,
+  PerfSubstepEntry,
+} from '@/features/generation/bridge/types';
 export type {
   SplitExportResult,
   GenerationResult,

--- a/src/shared/types/generation.ts
+++ b/src/shared/types/generation.ts
@@ -10,5 +10,8 @@ export type {
   CoarseLODData,
   LidMeshData,
   WorkerCacheStats,
+  PerfSnapshot,
+  PerfStageEntry,
+  PerfSubstepEntry,
 } from '@/features/generation/bridge/types';
 export { FeatureTag } from '@/features/generation/worker/generators/featureTags';


### PR DESCRIPTION
## Summary
- Adds per-stage + per-feature-builder + per-wall-substep timing instrumentation in the worker, surfaced through a new dev-only PerfOverlay behind the `show_generation_perf` Labs flag (shows bar chart of stage times, hex center / pattern tool counts, and sparkline of recent generations).
- Adds three bench scenarios targeting the wall-pattern cold-cache path (dense-wide with cutouts, tall with cutouts, cache-warm cutout iteration) plus a frozen pre-PR `baseline.json` for regression comparison.
- Applies three bit-exact wall-pattern optimizations: hoist `collectDividers` + `resolveOuterCutouts` out of the per-wall loop, replace pairwise `fuse` chains with `fuseAllOrNull`, and merge per-wall cutout + handle + ramp clip solids into a single `cut` op.

## Bench results (mean ms, unit env)

| Scenario | Before | After | Δ |
|---|---|---|---|
| dense_wide_with_cutouts (cold) — 6×4×6, 12×8 compartments, 4 cutouts | 2668 | 2422 | **−9.2%** |
| tall_with_cutouts (cold) — 4×4×6, 6×6 compartments, 4 cutouts | 2084 | 1901 | **−8.8%** |
| cache_warm_cutout_iter — dense_wide with cutout-width nudges | 28414 | 24365 | **−14.3%** |
| first build (cold) — 4×2×6 honeycomb + cutouts (existing) | 2126 | 1586 | **−25.4%** |
| cutout-width nudge (warm) — existing scenario | 3816 | 3211 | **−15.8%** |

All scenarios improved; biggest wins on cold-cache small bins and the cache-warm slider-drag flow.

## Trade-off
The merged-clip path means a degenerate clip box now fails ALL clips on its wall rather than only the failing one. The pre-existing per-pass `catch` already silently dropped failing clips, so the reliability delta is "one bad clip drops all on that wall" instead of "one bad clip drops one"; degenerate clip boxes are extremely rare in practice. Pre-fusing all 4 wall pattern compounds before the booleanStage was considered and intentionally deferred until baseline data justifies the bisect-recovery loss.

## Out of scope (deferred, can be informed by the new overlay/baseline)
- Pre-fusing all 4 wall compounds before booleanStage
- IndexedDB persistent base-compound cache
- Activating the dormant coarse-LOD preview path
- Hex density tuning on large bins

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean (only pre-existing warnings)
- [x] `pnpm run check:i18n` — all 8 locales match en.ts
- [x] All 967 generator tests pass (`vitest run src/features/generation/worker/generators/`)
- [x] Bench numbers captured before and after (table above); commits 1+2 measure, commit 3 optimizes
- [ ] Manual: enable `show_generation_perf` Labs flag in the bin designer, edit a 6×4×6 bin with 4 cutouts and a honeycomb pattern, confirm overlay updates and timings look reasonable