### PR TITLE
fix(export): emit 3MF Materials Extension colorgroup for Bambu/Orca + spec audit

### DIFF
--- a/src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.tsx
+++ b/src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.tsx
@@ -1,8 +1,9 @@
 /**
  * Filament-mapping preview shown in the export dialog when the design
- * is multi-color and the format is 3MF. Mirrors what slicers see in
- * the 3MF basematerials section so users can plan their AMS/MMU slots
- * before opening the slicer.
+ * is multi-color and the format is 3MF. Mirrors the 3MF Materials
+ * Extension `<m:colorgroup>` block — the structure BambuStudio /
+ * OrcaSlicer parse for their "Standard 3MF Import Color" dialog — so
+ * users can plan their AMS/MMU slots before opening the slicer.
  */
 
 import { useId, useState } from 'react';

--- a/src/features/bin-designer/utils/materialMapping.ts
+++ b/src/features/bin-designer/utils/materialMapping.ts
@@ -23,7 +23,7 @@ import { classifyLipCorner, computeLipBBoxCenter } from './lipCornerClassifier';
  * zones whose feature isn't enabled, so a stale color on a hidden zone
  * (e.g. a lip corner recolor on a stacking-lip-off bin) doesn't trip
  * multi-color export. Matches the preview's gating. Returns null when
- * the design is single-color (no basematerials section needed).
+ * the design is single-color (no color group section needed).
  */
 export function buildTriangleMaterialIndices(
   faceGroups: readonly FaceGroupData[],
@@ -36,7 +36,7 @@ export function buildTriangleMaterialIndices(
 
   const { colors, colorToIndex, defaultIndex } = resolveColorMapping(featureColors);
 
-  const materials = colors.map((color) => ({ name: color, color }));
+  const materials = colors.map((color) => ({ color }));
   const indices = new Array<number>(triangleCount).fill(defaultIndex);
 
   const triangleXY = (triIdx: number) => {

--- a/src/features/bin-designer/utils/multicolorRoundTrip.test.ts
+++ b/src/features/bin-designer/utils/multicolorRoundTrip.test.ts
@@ -11,7 +11,7 @@
  *   2. Lip corner round-trip — lip triangles in each XY quadrant carry the
  *      configured corner color's `p1`.
  *   3. Single-color short-circuit — all-same-color (incl. mixed-case hex) emits
- *      no `<basematerials>`; mixed-case dedup yields one material, not two.
+ *      no `<m:colorgroup>`; mixed-case dedup yields one material, not two.
  *   4. Multi-object color contract — only the first piece (bin) carries colors;
  *      ancillary pieces (dividers, lid) ship solid-color.
  *
@@ -87,17 +87,19 @@ async function blobToModelXml(blob: Blob): Promise<string> {
 }
 
 interface Material {
-  readonly name: string;
   readonly color: string;
 }
 
-/** Extract `<base>` entries from inside a `<basematerials>` block, in order. */
+const COLORGROUP_BLOCK_RE = /<m:colorgroup\s+id="(\d+)">([\s\S]*?)<\/m:colorgroup>/;
+const COLOR_ENTRY_RE = /<m:color\s+color="([^"]*)"\s*\/>/g;
+
+/** Extract `<m:color>` entries from inside a `<m:colorgroup>` block, in order. */
 function parseMaterials(xml: string): Material[] {
-  const block = /<basematerials\s+id="(\d+)">([\s\S]*?)<\/basematerials>/.exec(xml);
+  const block = COLORGROUP_BLOCK_RE.exec(xml);
   if (!block) return [];
   const out: Material[] = [];
-  for (const m of block[2].matchAll(/<base\s+name="([^"]*)"\s+displaycolor="([^"]*)"\s*\/>/g)) {
-    out.push({ name: m[1], color: m[2] });
+  for (const m of block[2].matchAll(COLOR_ENTRY_RE)) {
+    out.push({ color: m[1] });
   }
   return out;
 }
@@ -272,7 +274,7 @@ describe('multicolor 3MF round-trip', () => {
       expect(tris.map((t) => t.p1)).toEqual([1, 1]);
     });
 
-    it('every emitted pid resolves to the basematerials block (reference integrity)', async () => {
+    it('every emitted pid resolves to the m:colorgroup block (reference integrity)', async () => {
       const params = withColors({ body: '#fff', base: '#000' });
       const triangles = [...tri(0, 0), ...tri(1, 0)];
       const faceGroups: FaceGroupData[] = [{ start: 0, count: 6, tag: FeatureTag.SOCKET }];
@@ -285,14 +287,14 @@ describe('multicolor 3MF round-trip', () => {
         true
       );
       const xml = await blobToModelXml(blob);
-      const pidMatch = /<basematerials\s+id="(\d+)"/.exec(xml);
-      const baseMaterialsId = pidMatch ? Number(pidMatch[1]) : NaN;
+      const pidMatch = /<m:colorgroup\s+id="(\d+)"/.exec(xml);
+      const colorgroupId = pidMatch ? Number(pidMatch[1]) : NaN;
       const materialsCount = parseMaterials(xml).length;
       const tris = parseTriangles(xml);
 
       for (const t of tris) {
         if (t.pid === null) continue;
-        expect(t.pid).toBe(baseMaterialsId);
+        expect(t.pid).toBe(colorgroupId);
         expect(t.p1).not.toBeNull();
         expect(t.p1).toBeGreaterThanOrEqual(0);
         expect(t.p1).toBeLessThan(materialsCount);
@@ -337,7 +339,7 @@ describe('multicolor 3MF round-trip', () => {
   });
 
   describe('single-color short-circuit', () => {
-    it('all-same-color (lowercase) emits no <basematerials>', async () => {
+    it('all-same-color (lowercase) emits no <m:colorgroup>', async () => {
       const params = withColors(); // all zones default to '#d4d8dc'
       const triangles = [...tri(0, 0), ...tri(1, 0)];
       const faceGroups: FaceGroupData[] = [{ start: 0, count: 6, tag: FeatureTag.SOCKET }];
@@ -351,12 +353,13 @@ describe('multicolor 3MF round-trip', () => {
       );
       const xml = await blobToModelXml(blob);
 
-      expect(xml).not.toMatch(/<basematerials\b/);
+      expect(xml).not.toMatch(/<m:colorgroup\b/);
+      expect(xml).not.toMatch(/\bxmlns:m=/);
       expect(xml).not.toMatch(/\bpid="/);
       expect(xml).not.toMatch(/\bp1="/);
     });
 
-    it('mixed-case AND mixed-length hex collapse to single material (no <basematerials>)', async () => {
+    it('mixed-case AND mixed-length hex collapse to single material (no <m:colorgroup>)', async () => {
       // Regressions for the case-normalization and shorthand-expansion fixes.
       // `#FFF`, `#fff`, `#FFFFFF` all canonicalize to `#ffffff`.
       const params = withColors({ body: '#FFF', base: '#fff', labelTab: '#FFFFFF' });
@@ -372,7 +375,7 @@ describe('multicolor 3MF round-trip', () => {
       );
       const xml = await blobToModelXml(blob);
 
-      expect(xml).not.toMatch(/<basematerials\b/);
+      expect(xml).not.toMatch(/<m:colorgroup\b/);
     });
 
     it('mixed-case dedup yields N materials, not 2N (only divergent zones add slots)', async () => {
@@ -412,18 +415,21 @@ describe('multicolor 3MF round-trip', () => {
       const blob = buildMultiObject3MF(pieces, faceGroups, params, 'assembly', PRINT_SETTINGS);
       const xml = await blobToModelXml(blob);
 
-      // Exactly one <basematerials> block — for the bin piece.
-      const baseBlocks = xml.match(/<basematerials\b/g) ?? [];
-      expect(baseBlocks).toHaveLength(1);
+      // Exactly one <m:colorgroup> block — for the bin piece.
+      const groupBlocks = xml.match(/<m:colorgroup\b/g) ?? [];
+      expect(groupBlocks).toHaveLength(1);
+
+      // The materials extension namespace is declared on <model>.
+      expect(xml).toMatch(/\bxmlns:m="http:\/\/schemas\.microsoft\.com\/3dmanufacturing\/material/);
 
       // Three <object> entries (bin, divider, lid).
       const objects = xml.match(/<object\s+id="\d+"/g) ?? [];
       expect(objects).toHaveLength(3);
 
-      // The basematerials block precedes the first <object> in document order.
-      const baseAt = xml.indexOf('<basematerials');
+      // The colorgroup block precedes the first <object> in document order.
+      const groupAt = xml.indexOf('<m:colorgroup');
       const firstObjAt = xml.indexOf('<object');
-      expect(baseAt).toBeLessThan(firstObjAt);
+      expect(groupAt).toBeLessThan(firstObjAt);
     });
 
     it('multi-color disabled at the params level disables colors on every piece', async () => {
@@ -439,7 +445,8 @@ describe('multicolor 3MF round-trip', () => {
         PRINT_SETTINGS
       );
       const xml = await blobToModelXml(blob);
-      expect(xml).not.toMatch(/<basematerials\b/);
+      expect(xml).not.toMatch(/<m:colorgroup\b/);
+      expect(xml).not.toMatch(/\bxmlns:m=/);
       expect(xml).not.toMatch(/\bp1="/);
     });
   });

--- a/src/features/generation/export/stlExporter.test.ts
+++ b/src/features/generation/export/stlExporter.test.ts
@@ -212,6 +212,17 @@ describe('stlExporter', () => {
       const headerText = String.fromCharCode(...header).replace(/\0+$/, '');
       expect(headerText).toContain('gridfinity-bin');
     });
+
+    it('default header does not start with "solid" (binary STL detection)', () => {
+      // ASCII STL parsers branch on a "solid" prefix. A binary STL whose header
+      // accidentally starts with "solid" gets misread as text. The current
+      // header literal is safe, but the guard exists to survive refactors.
+      const { vertices, normals } = createSingleTriangle();
+      const buffer = buildSTLBuffer(vertices, normals, 'test');
+      const header = new Uint8Array(buffer, 0, 80);
+      const headerText = String.fromCharCode(...header).replace(/\0+$/, '');
+      expect(headerText.toLowerCase()).not.toMatch(/^solid/);
+    });
   });
 
   describe('buildSTLBufferFromIndexed', () => {
@@ -288,14 +299,52 @@ describe('stlExporter', () => {
       expect(view.getFloat32(92, true)).toBeCloseTo(1);
     });
 
-    it('handles empty mesh', () => {
-      const buffer = buildSTLBufferFromIndexed(
-        new Float32Array(0),
-        new Float32Array(0),
-        new Uint32Array(0),
-        'empty'
-      );
-      expect(buffer.byteLength).toBe(84); // header + count only
+    it('rejects empty mesh (slicers reject empty STLs)', () => {
+      expect(() =>
+        buildSTLBufferFromIndexed(
+          new Float32Array(0),
+          new Float32Array(0),
+          new Uint32Array(0),
+          'empty'
+        )
+      ).toThrow(/must be > 0/);
+    });
+
+    it('rejects indices length not divisible by 3', () => {
+      const vertices = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+      const normals = new Float32Array(9);
+      expect(() =>
+        buildSTLBufferFromIndexed(vertices, normals, new Uint32Array([0, 1]), 't')
+      ).toThrow(/divisible by 3/);
+    });
+
+    it('rejects an out-of-range vertex index', () => {
+      const vertices = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]); // 3 verts
+      const normals = new Float32Array(9);
+      expect(() =>
+        buildSTLBufferFromIndexed(vertices, normals, new Uint32Array([0, 1, 99]), 't')
+      ).toThrow(/out of range/);
+    });
+
+    it('rejects a normals/vertices length mismatch when normals are provided', () => {
+      const vertices = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+      const normals = new Float32Array([0, 0, 1, 0, 0, 1]); // length 6, not 9
+      expect(() =>
+        buildSTLBufferFromIndexed(vertices, normals, new Uint32Array([0, 1, 2]), 't')
+      ).toThrow(/normals length/);
+    });
+
+    it('renormalizes non-unit normals to unit length', () => {
+      const vertices = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+      // Normals scaled by 5x — common artifact of upstream boolean ops.
+      const normals = new Float32Array([0, 0, 5, 0, 0, 5, 0, 0, 5]);
+      const buffer = buildSTLBufferFromIndexed(vertices, normals, new Uint32Array([0, 1, 2]), 't');
+      const view = new DataView(buffer);
+      const nx = view.getFloat32(84, true);
+      const ny = view.getFloat32(88, true);
+      const nz = view.getFloat32(92, true);
+      const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+      expect(len).toBeCloseTo(1, 5);
     });
   });
 

--- a/src/features/generation/export/stlExporter.ts
+++ b/src/features/generation/export/stlExporter.ts
@@ -1,10 +1,5 @@
 /**
- * Binary STL file exporter.
- *
- * Produces valid binary STL from mesh vertex/normal arrays.
- * Binary format is preferred over ASCII for smaller file sizes (~50 bytes/tri vs ~200).
- *
- * Format spec:
+ * Binary STL format:
  *   Header:  80 bytes (any text, zero-padded)
  *   Count:   4 bytes (uint32 LE triangle count)
  *   Per tri: 50 bytes (normal 3×f32 + 3 vertices × 3×f32 + attr uint16)
@@ -12,17 +7,10 @@
 
 import { validateMeshData } from './validation';
 
-/**
- * Generates a binary STL Blob from mesh data.
- *
- * @param vertices - Flat vertex array (every 9 floats = 1 triangle, 3 vertices × XYZ)
- * @param normals - Flat normal array (matching vertices layout; uses first vertex normal per triangle)
- * @param name - Model name for the STL header (truncated to 80 chars)
- * @returns Binary STL as a Blob with correct MIME type
- *
- * @throws If vertex count is not divisible by 9 (incomplete triangles)
- * @throws If normals length doesn't match vertices length
- */
+const HEADER_SIZE = 80;
+const COUNT_SIZE = 4;
+const TRIANGLE_SIZE = 50;
+
 export function exportSTL(
   vertices: Float32Array,
   normals: Float32Array,
@@ -32,10 +20,6 @@ export function exportSTL(
   return new Blob([buffer], { type: 'application/sla' });
 }
 
-/**
- * Builds the raw binary STL ArrayBuffer.
- * Exposed separately for direct testing without Blob API limitations.
- */
 export function buildSTLBuffer(
   vertices: Float32Array,
   normals: Float32Array,
@@ -44,28 +28,19 @@ export function buildSTLBuffer(
   validateMeshData(vertices, normals);
 
   const triangleCount = vertices.length / 9;
-  const HEADER_SIZE = 80;
-  const COUNT_SIZE = 4;
-  const TRIANGLE_SIZE = 50; // 12 (normal) + 36 (3 vertices) + 2 (attr)
-  const fileSize = HEADER_SIZE + COUNT_SIZE + triangleCount * TRIANGLE_SIZE;
-
-  const buffer = new ArrayBuffer(fileSize);
+  const buffer = new ArrayBuffer(HEADER_SIZE + COUNT_SIZE + triangleCount * TRIANGLE_SIZE);
   const view = new DataView(buffer);
 
-  // Write header (80 bytes, zero-padded ASCII)
   writeHeader(view, name);
-
-  // Write triangle count (uint32 LE at offset 80)
   view.setUint32(HEADER_SIZE, triangleCount, true);
 
-  // Write triangles
   let offset = HEADER_SIZE + COUNT_SIZE;
   for (let tri = 0; tri < triangleCount; tri++) {
     const vBase = tri * 9;
 
-    // Flat shading: renormalize first-vertex normal so the output's unit-
-    // vector invariant holds even if upstream meshes contain unnormalized
-    // normals (a known hazard after boolean operations).
+    // Flat shading: renormalize the first-vertex normal so the output's
+    // unit-vector invariant holds even if upstream meshes contain
+    // unnormalized normals (a known hazard after boolean operations).
     const nx = normals[vBase];
     const ny = normals[vBase + 1];
     const nz = normals[vBase + 2];
@@ -75,7 +50,6 @@ export function buildSTLBuffer(
     view.setFloat32(offset + 8, nz / len, true);
     offset += 12;
 
-    // 3 vertices (9 floats)
     for (let v = 0; v < 3; v++) {
       const idx = vBase + v * 3;
       view.setFloat32(offset, vertices[idx], true);
@@ -84,7 +58,6 @@ export function buildSTLBuffer(
       offset += 12;
     }
 
-    // Attribute byte count (always 0 for standard STL)
     view.setUint16(offset, 0, true);
     offset += 2;
   }
@@ -92,31 +65,20 @@ export function buildSTLBuffer(
   return buffer;
 }
 
-/**
- * Writes a zero-padded ASCII header into the DataView.
- */
 function writeHeader(view: DataView, name: string): void {
   let header = `Exported by Gridfinity Layout Tool - ${name}`;
   // Binary STL header MUST NOT begin with "solid" — parsers detect ASCII STL
-  // by that prefix and will misread our binary file as text. Prefix is safe
-  // today, but guard against future refactors that reorder the format.
+  // by that prefix and would misread our binary file as text. The current
+  // prefix is safe, but guard against future refactors that reorder it.
   if (/^solid/i.test(header)) {
     header = ' ' + header;
   }
-  const encoder = new TextEncoder();
-  const bytes = encoder.encode(header);
-
-  for (let i = 0; i < 80; i++) {
+  const bytes = new TextEncoder().encode(header);
+  for (let i = 0; i < HEADER_SIZE; i++) {
     view.setUint8(i, i < bytes.length ? bytes[i] : 0);
   }
 }
 
-/**
- * Builds a binary STL ArrayBuffer from indexed mesh data.
- *
- * Dereferences vertices and normals via the index buffer, computing face
- * normals from the cross product when per-vertex normals are unavailable.
- */
 export function buildSTLBufferFromIndexed(
   vertices: Float32Array,
   normals: Float32Array,
@@ -146,12 +108,7 @@ export function buildSTLBufferFromIndexed(
   }
 
   const triangleCount = indices.length / 3;
-  const HEADER_SIZE = 80;
-  const COUNT_SIZE = 4;
-  const TRIANGLE_SIZE = 50;
-  const fileSize = HEADER_SIZE + COUNT_SIZE + triangleCount * TRIANGLE_SIZE;
-
-  const buffer = new ArrayBuffer(fileSize);
+  const buffer = new ArrayBuffer(HEADER_SIZE + COUNT_SIZE + triangleCount * TRIANGLE_SIZE);
   const view = new DataView(buffer);
 
   writeHeader(view, name);
@@ -165,35 +122,32 @@ export function buildSTLBufferFromIndexed(
     const i1 = indices[tri * 3 + 1];
     const i2 = indices[tri * 3 + 2];
 
+    let nx: number;
+    let ny: number;
+    let nz: number;
     if (hasNormals) {
-      // Flat shading: first-vertex normal renormalized so STL viewers that use
-      // it for shading match the cross-product fallback below.
-      const nx = normals[i0 * 3];
-      const ny = normals[i0 * 3 + 1];
-      const nz = normals[i0 * 3 + 2];
-      const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1;
-      view.setFloat32(offset, nx / len, true);
-      view.setFloat32(offset + 4, ny / len, true);
-      view.setFloat32(offset + 8, nz / len, true);
+      // Flat shading: first-vertex normal renormalized so STL viewers that
+      // use it for shading match the cross-product fallback below.
+      nx = normals[i0 * 3];
+      ny = normals[i0 * 3 + 1];
+      nz = normals[i0 * 3 + 2];
     } else {
-      // Compute face normal from cross product
       const ax = vertices[i1 * 3] - vertices[i0 * 3];
       const ay = vertices[i1 * 3 + 1] - vertices[i0 * 3 + 1];
       const az = vertices[i1 * 3 + 2] - vertices[i0 * 3 + 2];
       const bx = vertices[i2 * 3] - vertices[i0 * 3];
       const by = vertices[i2 * 3 + 1] - vertices[i0 * 3 + 1];
       const bz = vertices[i2 * 3 + 2] - vertices[i0 * 3 + 2];
-      const nx = ay * bz - az * by;
-      const ny = az * bx - ax * bz;
-      const nz = ax * by - ay * bx;
-      const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1;
-      view.setFloat32(offset, nx / len, true);
-      view.setFloat32(offset + 4, ny / len, true);
-      view.setFloat32(offset + 8, nz / len, true);
+      nx = ay * bz - az * by;
+      ny = az * bx - ax * bz;
+      nz = ax * by - ay * bx;
     }
+    const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1;
+    view.setFloat32(offset, nx / len, true);
+    view.setFloat32(offset + 4, ny / len, true);
+    view.setFloat32(offset + 8, nz / len, true);
     offset += 12;
 
-    // 3 vertices
     for (const vi of [i0, i1, i2]) {
       view.setFloat32(offset, vertices[vi * 3], true);
       view.setFloat32(offset + 4, vertices[vi * 3 + 1], true);
@@ -208,10 +162,6 @@ export function buildSTLBufferFromIndexed(
   return buffer;
 }
 
-/**
- * Computes the file size in bytes for a given triangle count.
- * Useful for pre-flight checks or progress reporting.
- */
 export function getSTLFileSize(triangleCount: number): number {
-  return 80 + 4 + triangleCount * 50;
+  return HEADER_SIZE + COUNT_SIZE + triangleCount * TRIANGLE_SIZE;
 }

--- a/src/features/generation/export/stlExporter.ts
+++ b/src/features/generation/export/stlExporter.ts
@@ -63,10 +63,16 @@ export function buildSTLBuffer(
   for (let tri = 0; tri < triangleCount; tri++) {
     const vBase = tri * 9;
 
-    // Normal (use first vertex normal of triangle — flat shading)
-    view.setFloat32(offset, normals[vBase], true);
-    view.setFloat32(offset + 4, normals[vBase + 1], true);
-    view.setFloat32(offset + 8, normals[vBase + 2], true);
+    // Flat shading: renormalize first-vertex normal so the output's unit-
+    // vector invariant holds even if upstream meshes contain unnormalized
+    // normals (a known hazard after boolean operations).
+    const nx = normals[vBase];
+    const ny = normals[vBase + 1];
+    const nz = normals[vBase + 2];
+    const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1;
+    view.setFloat32(offset, nx / len, true);
+    view.setFloat32(offset + 4, ny / len, true);
+    view.setFloat32(offset + 8, nz / len, true);
     offset += 12;
 
     // 3 vertices (9 floats)
@@ -90,7 +96,13 @@ export function buildSTLBuffer(
  * Writes a zero-padded ASCII header into the DataView.
  */
 function writeHeader(view: DataView, name: string): void {
-  const header = `Exported by Gridfinity Layout Tool - ${name}`;
+  let header = `Exported by Gridfinity Layout Tool - ${name}`;
+  // Binary STL header MUST NOT begin with "solid" — parsers detect ASCII STL
+  // by that prefix and will misread our binary file as text. Prefix is safe
+  // today, but guard against future refactors that reorder the format.
+  if (/^solid/i.test(header)) {
+    header = ' ' + header;
+  }
   const encoder = new TextEncoder();
   const bytes = encoder.encode(header);
 
@@ -111,6 +123,28 @@ export function buildSTLBufferFromIndexed(
   indices: Uint32Array,
   name: string = 'gridfinity-bin'
 ): ArrayBuffer {
+  if (indices.length === 0 || indices.length % 3 !== 0) {
+    throw new Error(`Indexed STL: indices length ${indices.length} must be > 0 and divisible by 3`);
+  }
+  if (vertices.length === 0 || vertices.length % 3 !== 0) {
+    throw new Error(
+      `Indexed STL: vertices length ${vertices.length} must be > 0 and divisible by 3`
+    );
+  }
+  if (normals.length > 0 && normals.length !== vertices.length) {
+    throw new Error(
+      `Indexed STL: normals length ${normals.length} must be 0 or match vertices length ${vertices.length}`
+    );
+  }
+  const vertexCount = vertices.length / 3;
+  for (let i = 0; i < indices.length; i++) {
+    if (indices[i] >= vertexCount) {
+      throw new Error(
+        `Indexed STL: index ${indices[i]} at position ${i} out of range [0, ${vertexCount})`
+      );
+    }
+  }
+
   const triangleCount = indices.length / 3;
   const HEADER_SIZE = 80;
   const COUNT_SIZE = 4;
@@ -132,10 +166,15 @@ export function buildSTLBufferFromIndexed(
     const i2 = indices[tri * 3 + 2];
 
     if (hasNormals) {
-      // Use first vertex normal of triangle
-      view.setFloat32(offset, normals[i0 * 3], true);
-      view.setFloat32(offset + 4, normals[i0 * 3 + 1], true);
-      view.setFloat32(offset + 8, normals[i0 * 3 + 2], true);
+      // Flat shading: first-vertex normal renormalized so STL viewers that use
+      // it for shading match the cross-product fallback below.
+      const nx = normals[i0 * 3];
+      const ny = normals[i0 * 3 + 1];
+      const nz = normals[i0 * 3 + 2];
+      const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1;
+      view.setFloat32(offset, nx / len, true);
+      view.setFloat32(offset + 4, ny / len, true);
+      view.setFloat32(offset + 8, nz / len, true);
     } else {
       // Compute face normal from cross product
       const ax = vertices[i1 * 3] - vertices[i0 * 3];

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -227,12 +227,26 @@ describe('threemfExporter', () => {
       });
       const xml = extractModelXML(buffer);
 
-      expect(xml).toContain('<metadata name="PrintSettings.LayerHeight">0.2</metadata>');
-      expect(xml).toContain('<metadata name="PrintSettings.InfillPercent">15</metadata>');
-      expect(xml).toContain('<metadata name="PrintSettings.Material">PLA</metadata>');
-      expect(xml).toContain('<metadata name="PrintSettings.SupportRequired">false</metadata>');
-      expect(xml).toContain('<metadata name="PrintSettings.EstimatedMinutes">45</metadata>');
-      expect(xml).toContain('<metadata name="PrintSettings.EstimatedGrams">12</metadata>');
+      // Custom metadata names (no registered namespace prefix) get
+      // preserve="true" per 3MF Core §3.7 so consumers don't strip them.
+      expect(xml).toContain(
+        '<metadata name="PrintSettings.LayerHeight" preserve="true">0.2</metadata>'
+      );
+      expect(xml).toContain(
+        '<metadata name="PrintSettings.InfillPercent" preserve="true">15</metadata>'
+      );
+      expect(xml).toContain(
+        '<metadata name="PrintSettings.Material" preserve="true">PLA</metadata>'
+      );
+      expect(xml).toContain(
+        '<metadata name="PrintSettings.SupportRequired" preserve="true">false</metadata>'
+      );
+      expect(xml).toContain(
+        '<metadata name="PrintSettings.EstimatedMinutes" preserve="true">45</metadata>'
+      );
+      expect(xml).toContain(
+        '<metadata name="PrintSettings.EstimatedGrams" preserve="true">12</metadata>'
+      );
     });
 
     it('omits print settings metadata when not provided', () => {

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -391,49 +391,51 @@ describe('threemfExporter', () => {
     });
   });
 
-  describe('multi-color basematerials', () => {
-    it('emits basematerials and pid/pindex when colorConfig is provided', () => {
+  describe('multi-color m:colorgroup', () => {
+    it('emits m:colorgroup, namespace, and pid/p1 when colorConfig is provided', () => {
       const { vertices, normals } = createTwoTriangles();
       const buffer = build3MFBuffer(vertices, normals, {
         name: 'color-test',
         colorConfig: {
-          materials: [
-            { name: 'White', color: '#ffffff' },
-            { name: 'Blue', color: '#0000ff' },
-          ],
+          materials: [{ color: '#ffffff' }, { color: '#0000ff' }],
           triangleMaterialIndices: [0, 1],
         },
       });
       const files = unzipSync(buffer);
       const model = strFromU8(files['3D/3dmodel.model']);
 
-      // Basematerials in core namespace (no m: prefix — 3MF Core Spec section 5.1)
-      // IDs in ascending document order per §4.1.2: basematerials=1, object=2
-      expect(model).not.toContain('xmlns:m=');
-      expect(model).toContain('<basematerials id="1">');
-      expect(model).toContain('<base name="White" displaycolor="#ffffff" />');
-      expect(model).toContain('<base name="Blue" displaycolor="#0000ff" />');
-      expect(model).toContain('</basematerials>');
+      // 3MF Materials Extension v1.0 — BambuStudio/OrcaSlicer recognize this
+      // form and trigger their "Standard 3MF Import Color" dialog.
+      expect(model).toContain(
+        'xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"'
+      );
+      expect(model).toContain('requiredextensions="m"');
+      // IDs in ascending document order per §4.1.2: colorgroup=1, object=2
+      expect(model).toContain('<m:colorgroup id="1">');
+      expect(model).toContain('<m:color color="#ffffff" />');
+      expect(model).toContain('<m:color color="#0000ff" />');
+      expect(model).toContain('</m:colorgroup>');
       expect(model).toContain('object id="2"');
       expect(model).toContain('objectid="2"');
 
-      // Triangle material assignments
+      // Triangle color assignments
       expect(model).toMatch(/triangle v1="\d+" v2="\d+" v3="\d+" pid="1" p1="0"/);
       expect(model).toMatch(/triangle v1="\d+" v2="\d+" v3="\d+" pid="1" p1="1"/);
     });
 
-    it('omits basematerials when colorConfig is absent', () => {
+    it('omits m:colorgroup and namespace when colorConfig is absent', () => {
       const { vertices, normals } = createSingleTriangle();
       const buffer = build3MFBuffer(vertices, normals, { name: 'no-color' });
       const files = unzipSync(buffer);
       const model = strFromU8(files['3D/3dmodel.model']);
 
-      expect(model).not.toContain('basematerials');
+      expect(model).not.toContain('m:colorgroup');
       expect(model).not.toContain('pid=');
       expect(model).not.toContain('xmlns:m=');
+      expect(model).not.toContain('requiredextensions=');
     });
 
-    it('omits basematerials when colorConfig has empty materials', () => {
+    it('omits m:colorgroup when colorConfig has empty materials', () => {
       const { vertices, normals } = createSingleTriangle();
       const buffer = build3MFBuffer(vertices, normals, {
         name: 'empty-color',
@@ -442,8 +444,70 @@ describe('threemfExporter', () => {
       const files = unzipSync(buffer);
       const model = strFromU8(files['3D/3dmodel.model']);
 
-      expect(model).not.toContain('basematerials');
+      expect(model).not.toContain('m:colorgroup');
       expect(model).not.toContain('pid=');
+      expect(model).not.toContain('xmlns:m=');
+    });
+
+    it('throws when triangleMaterialIndices length does not match triangle count', () => {
+      const { vertices, normals } = createTwoTriangles();
+      expect(() =>
+        build3MFBuffer(vertices, normals, {
+          name: 'mismatch',
+          colorConfig: {
+            materials: [{ color: '#ffffff' }],
+            triangleMaterialIndices: [0], // 1 entry for 2 triangles
+          },
+        })
+      ).toThrow(/triangleMaterialIndices length/);
+    });
+
+    it('throws when a triangle index points outside the materials array', () => {
+      const { vertices, normals } = createTwoTriangles();
+      expect(() =>
+        build3MFBuffer(vertices, normals, {
+          name: 'out-of-range',
+          colorConfig: {
+            materials: [{ color: '#ffffff' }],
+            triangleMaterialIndices: [0, 5], // index 5 with only 1 slot
+          },
+        })
+      ).toThrow(/out of range/);
+    });
+
+    it('throws on non-conformant hex color strings', () => {
+      const { vertices, normals } = createSingleTriangle();
+      expect(() =>
+        build3MFBuffer(vertices, normals, {
+          name: 'bad-hex',
+          colorConfig: {
+            materials: [{ color: 'rgb(255,0,0)' }],
+            triangleMaterialIndices: [0],
+          },
+        })
+      ).toThrow(/#RRGGBB or #RRGGBBAA/);
+      expect(() =>
+        build3MFBuffer(vertices, normals, {
+          name: 'short-hex',
+          colorConfig: {
+            materials: [{ color: '#fff' }],
+            triangleMaterialIndices: [0],
+          },
+        })
+      ).toThrow(/#RRGGBB or #RRGGBBAA/);
+    });
+
+    it('accepts #RRGGBBAA hex with alpha channel', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const buffer = build3MFBuffer(vertices, normals, {
+        name: 'alpha',
+        colorConfig: {
+          materials: [{ color: '#ff000080' }],
+          triangleMaterialIndices: [0],
+        },
+      });
+      const model = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
+      expect(model).toContain('<m:color color="#ff000080" />');
     });
   });
 
@@ -479,7 +543,7 @@ describe('threemfExporter', () => {
       expect(model).toContain('objectid="3"');
     });
 
-    it('assigns sequential IDs with per-object basematerials', () => {
+    it('assigns sequential IDs with per-object color groups', () => {
       const tri = createSingleTriangle();
       const objects = [
         {
@@ -487,7 +551,7 @@ describe('threemfExporter', () => {
           normals: tri.normals,
           name: 'Colored Bin',
           colorConfig: {
-            materials: [{ name: 'Red', color: '#ff0000' }],
+            materials: [{ color: '#ff0000' }],
             triangleMaterialIndices: [0],
           },
         },
@@ -496,12 +560,13 @@ describe('threemfExporter', () => {
       const buffer = build3MFMultiObjectBuffer(objects, { name: 'test' });
       const model = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
 
-      // basematerials=1, colored object=2, plain object=3
-      expect(model).toContain('basematerials id="1"');
+      // colorgroup=1, colored object=2, plain object=3
+      expect(model).toContain('m:colorgroup id="1"');
       expect(model).toContain('object id="2"');
       expect(model).toContain('object id="3"');
       expect(model).toContain('objectid="2"');
       expect(model).toContain('objectid="3"');
+      expect(model).toContain('xmlns:m=');
     });
 
     it('export3MFMultiObject produces a Blob with correct MIME', () => {
@@ -702,6 +767,28 @@ describe('threemfExporter', () => {
       const contentTypes = strFromU8(files['[Content_Types].xml']);
 
       expect(contentTypes).toContain('Extension="rels"');
+    });
+
+    it('omits the thumbnail relationship when no thumbnail is provided', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const buffer = build3MFBuffer(vertices, normals, { name: 'test' });
+      const rels = strFromU8(unzipSync(buffer)['_rels/.rels']);
+
+      expect(rels).not.toContain('thumbnail');
+    });
+
+    it('declares the OPC thumbnail relationship when a thumbnail is included', () => {
+      // Without this Relationship, viewers can't discover the thumbnail PNG
+      // even when Content_Types declares its MIME type.
+      const { vertices, normals } = createSingleTriangle();
+      const thumbnail = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+      const buffer = build3MFBuffer(vertices, normals, { name: 'test', thumbnail });
+      const rels = strFromU8(unzipSync(buffer)['_rels/.rels']);
+
+      expect(rels).toContain('Target="/Metadata/thumbnail.png"');
+      expect(rels).toContain(
+        'Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail"'
+      );
     });
   });
 

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -16,11 +16,11 @@
 import { zipSync, strToU8 } from 'fflate';
 import { validateMeshData } from './validation';
 
-/** Multi-material color configuration for 3MF basematerials extension */
+/** Multi-material color configuration emitted as a 3MF Materials Extension `<m:colorgroup>`. */
 export interface ThreeMFColorConfig {
-  /** Deduplicated materials list (name + displaycolor) */
-  readonly materials: readonly { readonly name: string; readonly color: string }[];
-  /** Per-triangle material index into the materials array (length = triangle count) */
+  /** Deduplicated color list — one entry per filament slot, in `pid`/`p1` index order. */
+  readonly materials: readonly { readonly color: string }[];
+  /** Per-triangle color index into the materials array (length = triangle count) */
   readonly triangleMaterialIndices: readonly number[];
 }
 
@@ -138,7 +138,7 @@ export function build3MFMultiObjectBuffer(
 
   const files: Record<string, Uint8Array> = {
     '[Content_Types].xml': strToU8(buildContentTypes(!!options.thumbnail)),
-    '_rels/.rels': strToU8(buildRelationships()),
+    '_rels/.rels': strToU8(buildRelationships(!!options.thumbnail)),
     '3D/3dmodel.model': strToU8(buildMultiObjectModelXML(meshes, options)),
   };
 
@@ -166,7 +166,7 @@ export function build3MFBuffer(
   // Build ZIP entries
   const files: Record<string, Uint8Array> = {
     '[Content_Types].xml': strToU8(buildContentTypes(!!options.thumbnail)),
-    '_rels/.rels': strToU8(buildRelationships()),
+    '_rels/.rels': strToU8(buildRelationships(!!options.thumbnail)),
     '3D/3dmodel.model': strToU8(buildModelXML(mesh, options)),
   };
 
@@ -233,21 +233,33 @@ function buildContentTypes(hasThumbnail: boolean): string {
   return xml;
 }
 
-function buildRelationships(): string {
+function buildRelationships(hasThumbnail: boolean): string {
   let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
   xml += '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">\n';
   xml +=
     '  <Relationship Target="/3D/3dmodel.model" Id="rel-1" Type="http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel" />\n';
+  if (hasThumbnail) {
+    // OPC §11.3 thumbnail relationship — without this, viewers can't discover
+    // the PNG even though Content_Types declares its MIME type.
+    xml +=
+      '  <Relationship Target="/Metadata/thumbnail.png" Id="rel-2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail" />\n';
+  }
   xml += '</Relationships>';
   return xml;
 }
 
 function buildModelXML(mesh: IndexedMesh, options: ThreeMFOptions): string {
   const NS = 'http://schemas.microsoft.com/3dmanufacturing/core/2015/02';
+  const MATERIAL_NS = 'http://schemas.microsoft.com/3dmanufacturing/material/2015/02';
   const hasColors = options.colorConfig && options.colorConfig.materials.length > 0;
 
   let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
-  xml += `<model unit="millimeter" xml:lang="en-US" xmlns="${NS}">\n`;
+  // The `m` materials extension is what BambuStudio/OrcaSlicer read for the
+  // "Standard 3MF Import Color" dialog — the 3MF Core `<basematerials>` element
+  // is silently ignored by their parsers, so we declare the extension only when
+  // we actually emit color content.
+  const matNs = hasColors ? ` xmlns:m="${MATERIAL_NS}" requiredextensions="m"` : '';
+  xml += `<model unit="millimeter" xml:lang="en-US" xmlns="${NS}"${matNs}>\n`;
 
   // Metadata
   xml += `  <metadata name="Title">${escapeXml(options.name)}</metadata>\n`;
@@ -280,17 +292,18 @@ function buildModelXML(mesh: IndexedMesh, options: ThreeMFOptions): string {
   // Resources
   xml += '  <resources>\n';
 
-  // Basematerials resource (3MF Core Spec section 5.1 — no namespace prefix)
-  // IDs assigned in ascending document order per 3MF Core Spec §4.1.2
-  const BASEMATERIALS_ID = 1;
+  // Color group resource (3MF Materials Extension v1.0).
+  // IDs assigned in ascending document order per 3MF Core Spec §4.1.2.
+  const COLORGROUP_ID = 1;
   const OBJECT_ID = 2;
   const colorConfig = hasColors ? options.colorConfig : undefined;
   if (colorConfig) {
-    xml += `    <basematerials id="${BASEMATERIALS_ID}">\n`;
+    assertColorConfigShape(colorConfig, mesh.triangles.length);
+    xml += `    <m:colorgroup id="${COLORGROUP_ID}">\n`;
     for (const mat of colorConfig.materials) {
-      xml += `      <base name="${escapeXml(mat.name)}" displaycolor="${escapeXml(mat.color)}" />\n`;
+      xml += `      <m:color color="${escapeXml(mat.color)}" />\n`;
     }
-    xml += '    </basematerials>\n';
+    xml += '    </m:colorgroup>\n';
   }
 
   xml += `    <object id="${colorConfig ? OBJECT_ID : 1}" type="model" name="${escapeXml(options.name)}">\n`;
@@ -309,8 +322,7 @@ function buildModelXML(mesh: IndexedMesh, options: ThreeMFOptions): string {
     const indices = colorConfig.triangleMaterialIndices;
     for (let i = 0; i < mesh.triangles.length; i++) {
       const [v1, v2, v3] = mesh.triangles[i];
-      const pindex = indices[i] ?? 0;
-      xml += `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${BASEMATERIALS_ID}" p1="${pindex}" />\n`;
+      xml += `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${COLORGROUP_ID}" p1="${indices[i]}" />\n`;
     }
   } else {
     for (const [v1, v2, v3] of mesh.triangles) {
@@ -364,9 +376,12 @@ function buildMultiObjectModelXML(
   options: ThreeMFOptions
 ): string {
   const NS = 'http://schemas.microsoft.com/3dmanufacturing/core/2015/02';
+  const MATERIAL_NS = 'http://schemas.microsoft.com/3dmanufacturing/material/2015/02';
+  const anyHasColors = objects.some((o) => o.colorConfig && o.colorConfig.materials.length > 0);
 
   let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
-  xml += `<model unit="millimeter" xml:lang="en-US" xmlns="${NS}">\n`;
+  const matNs = anyHasColors ? ` xmlns:m="${MATERIAL_NS}" requiredextensions="m"` : '';
+  xml += `<model unit="millimeter" xml:lang="en-US" xmlns="${NS}"${matNs}>\n`;
 
   // Metadata
   xml += `  <metadata name="Title">${escapeXml(options.name)}</metadata>\n`;
@@ -405,15 +420,16 @@ function buildMultiObjectModelXML(
     const hasColors = obj.colorConfig && obj.colorConfig.materials.length > 0;
     const colorConfig = hasColors ? obj.colorConfig : undefined;
 
-    // Basematerials for this object (if colored)
-    let baseMaterialsId: number | undefined;
+    // Color group for this object (if colored).
+    let colorGroupId: number | undefined;
     if (colorConfig) {
-      baseMaterialsId = nextId++;
-      xml += `    <basematerials id="${baseMaterialsId}">\n`;
+      assertColorConfigShape(colorConfig, obj.mesh.triangles.length);
+      colorGroupId = nextId++;
+      xml += `    <m:colorgroup id="${colorGroupId}">\n`;
       for (const mat of colorConfig.materials) {
-        xml += `      <base name="${escapeXml(mat.name)}" displaycolor="${escapeXml(mat.color)}" />\n`;
+        xml += `      <m:color color="${escapeXml(mat.color)}" />\n`;
       }
-      xml += '    </basematerials>\n';
+      xml += '    </m:colorgroup>\n';
     }
 
     const objectId = nextId++;
@@ -429,12 +445,11 @@ function buildMultiObjectModelXML(
     xml += '        </vertices>\n';
 
     xml += '        <triangles>\n';
-    if (colorConfig && baseMaterialsId !== undefined) {
+    if (colorConfig && colorGroupId !== undefined) {
       const indices = colorConfig.triangleMaterialIndices;
       for (let i = 0; i < obj.mesh.triangles.length; i++) {
         const [v1, v2, v3] = obj.mesh.triangles[i];
-        const pindex = indices[i] ?? 0;
-        xml += `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${baseMaterialsId}" p1="${pindex}" />\n`;
+        xml += `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${colorGroupId}" p1="${indices[i]}" />\n`;
       }
     } else {
       for (const [v1, v2, v3] of obj.mesh.triangles) {
@@ -464,7 +479,44 @@ function escapeXml(str: string): string {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+const HEX_COLOR_RE = /^#[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$/;
+
+/**
+ * Materials Extension v1.0 requires `#RRGGBB` or `#RRGGBBAA` (sRGB hex with
+ * leading `#`). Validate up-front so a stray `rgb(...)`, missing `#`, or
+ * 3-digit shorthand can't ship as a parseable-but-rejected 3MF.
+ *
+ * `triangleMaterialIndices` must have exactly one entry per triangle and each
+ * entry must point at a valid color slot — `?? 0` fallbacks silently produced
+ * wrong colors when callers passed short arrays.
+ */
+function assertColorConfigShape(config: ThreeMFColorConfig, triangleCount: number): void {
+  if (config.triangleMaterialIndices.length !== triangleCount) {
+    throw new Error(
+      `3MF color config: triangleMaterialIndices length ${config.triangleMaterialIndices.length} does not match triangle count ${triangleCount}`
+    );
+  }
+  const slotCount = config.materials.length;
+  for (let i = 0; i < config.triangleMaterialIndices.length; i++) {
+    const idx = config.triangleMaterialIndices[i];
+    if (!Number.isInteger(idx) || idx < 0 || idx >= slotCount) {
+      throw new Error(
+        `3MF color config: triangle ${i} index ${idx} out of range [0, ${slotCount})`
+      );
+    }
+  }
+  for (let i = 0; i < config.materials.length; i++) {
+    const color = config.materials[i].color;
+    if (!HEX_COLOR_RE.test(color)) {
+      throw new Error(
+        `3MF color config: material ${i} color "${color}" is not in #RRGGBB or #RRGGBBAA format`
+      );
+    }
+  }
 }
 
 /**

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -1,30 +1,11 @@
-/**
- * 3MF file exporter (3D Manufacturing Format).
- *
- * Produces a valid OPC (Open Packaging Conventions) ZIP archive containing:
- * - [Content_Types].xml — MIME type declarations
- * - _rels/.rels — Package relationships
- * - 3D/3dmodel.model — Mesh data + metadata in XML
- * - Metadata/thumbnail.png (optional) — Preview image
- *
- * The mesh is stored in indexed format (unique vertices + triangle indices),
- * converted from the flat STL-style vertex arrays used by the generation engine.
- *
- * Spec: https://3mf.io/specification/
- */
-
 import { zipSync, strToU8 } from 'fflate';
 import { validateMeshData } from './validation';
 
-/** Multi-material color configuration emitted as a 3MF Materials Extension `<m:colorgroup>`. */
 export interface ThreeMFColorConfig {
-  /** Deduplicated color list — one entry per filament slot, in `pid`/`p1` index order. */
   readonly materials: readonly { readonly color: string }[];
-  /** Per-triangle color index into the materials array (length = triangle count) */
   readonly triangleMaterialIndices: readonly number[];
 }
 
-/** A single mesh object for multi-object 3MF export */
 export interface ThreeMFObject {
   readonly vertices: Float32Array;
   readonly normals: Float32Array;
@@ -32,26 +13,17 @@ export interface ThreeMFObject {
   readonly colorConfig?: ThreeMFColorConfig;
 }
 
-/** Options for 3MF export */
 export interface ThreeMFOptions {
-  /** Model name for metadata */
   readonly name: string;
-  /** Optional thumbnail PNG as Uint8Array */
   readonly thumbnail?: Uint8Array;
-  /** Optional print settings hints (embedded as metadata) */
   readonly printSettings?: ThreeMFPrintSettings;
-  /** Optional multi-material color configuration */
   readonly colorConfig?: ThreeMFColorConfig;
   /**
-   * Optional vertical stacking. The mesh is emitted once and referenced by
-   * `count` build items, each translated by `i * (zHeight + spacingMm)` along Z.
-   * `zHeight` should be the source mesh's Z extent (max - min Z over its
-   * vertices). Slicers see each instance as a separate placement and slice them
-   * together, which is the auto-stack workflow requested by issue #1642.
-   *
-   * Honored by `export3MF` / `build3MFBuffer` (single-object export) only;
-   * `export3MFMultiObject` ignores this field — stacking a heterogeneous bin +
-   * lid pair has no slicer-friendly interpretation.
+   * Vertical stacking — the mesh is emitted once and referenced by `count`
+   * build items, each translated by `i * (zHeightMm + spacingMm)` along Z so
+   * slicers see each instance as a separate placement (issue #1642).
+   * Honored by single-object export only; `export3MFMultiObject` ignores it
+   * since stacking a heterogeneous bin + lid pair has no slicer interpretation.
    */
   readonly stack?: {
     readonly count: number;
@@ -60,7 +32,6 @@ export interface ThreeMFOptions {
   };
 }
 
-/** Suggested print settings embedded as metadata */
 export interface ThreeMFPrintSettings {
   readonly layerHeight?: number;
   readonly infillPercent?: number;
@@ -70,58 +41,43 @@ export interface ThreeMFPrintSettings {
   readonly estimatedGrams?: number;
 }
 
-/**
- * Indexed mesh representation for 3MF XML.
- * Deduplicated from flat STL-style arrays.
- */
 interface IndexedMesh {
   readonly vertices: readonly [number, number, number][];
   readonly triangles: readonly [number, number, number][];
 }
 
-/**
- * Generates a 3MF file Blob from mesh data.
- *
- * @param vertices - Flat vertex array (every 9 floats = 1 triangle)
- * @param normals - Flat normal array (unused in 3MF, but validated for consistency)
- * @param options - Export options (name, thumbnail, print settings)
- * @returns 3MF file as a Blob
- *
- * @throws If vertex count is not divisible by 9
- * @throws If normals length doesn't match vertices length
- */
+const THREEMF_MIME = 'application/vnd.ms-package.3dmanufacturing-3dmodel+xml';
+
 export function export3MF(
   vertices: Float32Array,
   normals: Float32Array,
   options: ThreeMFOptions
 ): Blob {
   const buffer = build3MFBuffer(vertices, normals, options);
-  return new Blob([toArrayBuffer(buffer)], {
-    type: 'application/vnd.ms-package.3dmanufacturing-3dmodel+xml',
-  });
+  return new Blob([toArrayBuffer(buffer)], { type: THREEMF_MIME });
 }
 
-/**
- * Generates a 3MF file Blob containing multiple named objects.
- *
- * Each object gets its own `<object>` element with a unique id and name,
- * all referenced in the `<build>` section. This allows slicers to display
- * each piece (bin, dividers) as a separate named object.
- */
 export function export3MFMultiObject(
   objects: readonly ThreeMFObject[],
   options: ThreeMFOptions
 ): Blob {
   const buffer = build3MFMultiObjectBuffer(objects, options);
-  return new Blob([toArrayBuffer(buffer)], {
-    type: 'application/vnd.ms-package.3dmanufacturing-3dmodel+xml',
-  });
+  return new Blob([toArrayBuffer(buffer)], { type: THREEMF_MIME });
 }
 
-/**
- * Builds the raw multi-object 3MF ZIP as a Uint8Array.
- * Exposed separately for testing.
- */
+function packageFiles(modelXml: string, thumbnail: Uint8Array | undefined): Uint8Array {
+  const hasThumbnail = !!thumbnail;
+  const files: Record<string, Uint8Array> = {
+    '[Content_Types].xml': strToU8(buildContentTypes(hasThumbnail)),
+    '_rels/.rels': strToU8(buildRelationships(hasThumbnail)),
+    '3D/3dmodel.model': strToU8(modelXml),
+  };
+  if (thumbnail) {
+    files['Metadata/thumbnail.png'] = thumbnail;
+  }
+  return zipSync(files, { level: 6 });
+}
+
 export function build3MFMultiObjectBuffer(
   objects: readonly ThreeMFObject[],
   options: ThreeMFOptions
@@ -136,55 +92,26 @@ export function build3MFMultiObjectBuffer(
     colorConfig: obj.colorConfig,
   }));
 
-  const files: Record<string, Uint8Array> = {
-    '[Content_Types].xml': strToU8(buildContentTypes(!!options.thumbnail)),
-    '_rels/.rels': strToU8(buildRelationships(!!options.thumbnail)),
-    '3D/3dmodel.model': strToU8(buildMultiObjectModelXML(meshes, options)),
-  };
-
-  if (options.thumbnail) {
-    files['Metadata/thumbnail.png'] = options.thumbnail;
-  }
-
-  return zipSync(files, { level: 6 });
+  return packageFiles(buildMultiObjectModelXML(meshes, options), options.thumbnail);
 }
 
-/**
- * Builds the raw 3MF ZIP as a Uint8Array.
- * Exposed separately for testing.
- */
 export function build3MFBuffer(
   vertices: Float32Array,
   normals: Float32Array,
   options: ThreeMFOptions
 ): Uint8Array {
   validateMeshData(vertices, normals);
-
-  // Convert flat arrays to indexed mesh
   const mesh = deduplicateVertices(vertices);
-
-  // Build ZIP entries
-  const files: Record<string, Uint8Array> = {
-    '[Content_Types].xml': strToU8(buildContentTypes(!!options.thumbnail)),
-    '_rels/.rels': strToU8(buildRelationships(!!options.thumbnail)),
-    '3D/3dmodel.model': strToU8(buildModelXML(mesh, options)),
-  };
-
-  if (options.thumbnail) {
-    files['Metadata/thumbnail.png'] = options.thumbnail;
-  }
-
-  return zipSync(files, { level: 6 });
+  return packageFiles(buildModelXML(mesh, options), options.thumbnail);
 }
 
 /**
- * Deduplicates vertices from a flat triangle array into indexed format.
- *
- * Uses a spatial hash map for O(n) deduplication. Vertices within
- * floating-point epsilon (1e-6) are considered identical.
+ * Vertices within 1e-6 (key precision = 6 decimal places) are considered
+ * identical — the hash key uses `toFixed` so floating-point jitter from
+ * boolean operations doesn't fragment otherwise-shared vertices.
  */
 export function deduplicateVertices(vertices: Float32Array): IndexedMesh {
-  const PRECISION = 6; // Decimal places for hash key
+  const PRECISION = 6;
   const uniqueVertices: [number, number, number][] = [];
   const triangles: [number, number, number][] = [];
   const vertexMap = new Map<string, number>();
@@ -199,8 +126,6 @@ export function deduplicateVertices(vertices: Float32Array): IndexedMesh {
       const x = vertices[base];
       const y = vertices[base + 1];
       const z = vertices[base + 2];
-
-      // Hash key with fixed precision to handle floating point
       const key = `${x.toFixed(PRECISION)},${y.toFixed(PRECISION)},${z.toFixed(PRECISION)}`;
 
       let index = vertexMap.get(key);
@@ -217,140 +142,81 @@ export function deduplicateVertices(vertices: Float32Array): IndexedMesh {
 
   return { vertices: uniqueVertices, triangles };
 }
+
 function buildContentTypes(hasThumbnail: boolean): string {
-  let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
-  xml += '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">\n';
-  xml +=
-    '  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />\n';
-  // Use Override (specific path) rather than Default (extension) for the model file.
-  // PrusaSlicer and other slicers generate Override elements; some parsers only handle Override.
-  xml +=
-    '  <Override PartName="/3D/3dmodel.model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml" />\n';
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">',
+    '  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />',
+    // Override (specific path) rather than Default (extension) for the model
+    // file — PrusaSlicer and friends generate Override; some parsers only
+    // handle Override.
+    `  <Override PartName="/3D/3dmodel.model" ContentType="${THREEMF_MIME}" />`,
+  ];
   if (hasThumbnail) {
-    xml += '  <Default Extension="png" ContentType="image/png" />\n';
+    lines.push('  <Default Extension="png" ContentType="image/png" />');
   }
-  xml += '</Types>';
-  return xml;
+  lines.push('</Types>');
+  return lines.join('\n');
 }
 
 function buildRelationships(hasThumbnail: boolean): string {
-  let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
-  xml += '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">\n';
-  xml +=
-    '  <Relationship Target="/3D/3dmodel.model" Id="rel-1" Type="http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel" />\n';
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">',
+    '  <Relationship Target="/3D/3dmodel.model" Id="rel-1" Type="http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel" />',
+  ];
   if (hasThumbnail) {
     // OPC §11.3 thumbnail relationship — without this, viewers can't discover
     // the PNG even though Content_Types declares its MIME type.
-    xml +=
-      '  <Relationship Target="/Metadata/thumbnail.png" Id="rel-2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail" />\n';
+    lines.push(
+      '  <Relationship Target="/Metadata/thumbnail.png" Id="rel-2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail" />'
+    );
   }
-  xml += '</Relationships>';
-  return xml;
+  lines.push('</Relationships>');
+  return lines.join('\n');
+}
+
+function activeColorConfig(c: ThreeMFColorConfig | undefined): ThreeMFColorConfig | undefined {
+  return c && c.materials.length > 0 ? c : undefined;
 }
 
 function buildModelXML(mesh: IndexedMesh, options: ThreeMFOptions): string {
-  const NS = 'http://schemas.microsoft.com/3dmanufacturing/core/2015/02';
-  const MATERIAL_NS = 'http://schemas.microsoft.com/3dmanufacturing/material/2015/02';
-  const hasColors = options.colorConfig && options.colorConfig.materials.length > 0;
-
-  let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
-  // The `m` materials extension is what BambuStudio/OrcaSlicer read for the
-  // "Standard 3MF Import Color" dialog — the 3MF Core `<basematerials>` element
-  // is silently ignored by their parsers, so we declare the extension only when
-  // we actually emit color content.
-  const matNs = hasColors ? ` xmlns:m="${MATERIAL_NS}" requiredextensions="m"` : '';
-  xml += `<model unit="millimeter" xml:lang="en-US" xmlns="${NS}"${matNs}>\n`;
-
-  // Metadata
-  xml += `  <metadata name="Title">${escapeXml(options.name)}</metadata>\n`;
-  xml += '  <metadata name="Designer">Gridfinity Layout Tool</metadata>\n';
-  xml += `  <metadata name="CreationDate">${new Date().toISOString().split('T')[0]}</metadata>\n`;
-
-  // Print settings as custom metadata
-  if (options.printSettings) {
-    const ps = options.printSettings;
-    if (ps.layerHeight !== undefined) {
-      xml += `  <metadata name="PrintSettings.LayerHeight">${ps.layerHeight}</metadata>\n`;
-    }
-    if (ps.infillPercent !== undefined) {
-      xml += `  <metadata name="PrintSettings.InfillPercent">${ps.infillPercent}</metadata>\n`;
-    }
-    if (ps.material) {
-      xml += `  <metadata name="PrintSettings.Material">${escapeXml(ps.material)}</metadata>\n`;
-    }
-    if (ps.supportRequired !== undefined) {
-      xml += `  <metadata name="PrintSettings.SupportRequired">${ps.supportRequired}</metadata>\n`;
-    }
-    if (ps.estimatedMinutes !== undefined) {
-      xml += `  <metadata name="PrintSettings.EstimatedMinutes">${ps.estimatedMinutes}</metadata>\n`;
-    }
-    if (ps.estimatedGrams !== undefined) {
-      xml += `  <metadata name="PrintSettings.EstimatedGrams">${ps.estimatedGrams}</metadata>\n`;
-    }
-  }
-
-  // Resources
-  xml += '  <resources>\n';
-
-  // Color group resource (3MF Materials Extension v1.0).
-  // IDs assigned in ascending document order per 3MF Core Spec §4.1.2.
-  const COLORGROUP_ID = 1;
-  const OBJECT_ID = 2;
-  const colorConfig = hasColors ? options.colorConfig : undefined;
+  const colorConfig = activeColorConfig(options.colorConfig);
   if (colorConfig) {
     assertColorConfigShape(colorConfig, mesh.triangles.length);
-    xml += `    <m:colorgroup id="${COLORGROUP_ID}">\n`;
-    for (const mat of colorConfig.materials) {
-      xml += `      <m:color color="${escapeXml(mat.color)}" />\n`;
-    }
-    xml += '    </m:colorgroup>\n';
   }
 
-  xml += `    <object id="${colorConfig ? OBJECT_ID : 1}" type="model" name="${escapeXml(options.name)}">\n`;
-  xml += '      <mesh>\n';
+  // IDs assigned in ascending document order per 3MF Core Spec §4.1.2;
+  // the colorgroup MUST precede the object that references it via pid.
+  const COLORGROUP_ID = 1;
+  const objectId = colorConfig ? 2 : 1;
 
-  // Vertices
-  xml += '        <vertices>\n';
-  for (const [x, y, z] of mesh.vertices) {
-    xml += `          <vertex x="${formatFloat(x)}" y="${formatFloat(y)}" z="${formatFloat(z)}" />\n`;
-  }
-  xml += '        </vertices>\n';
-
-  // Triangles
-  xml += '        <triangles>\n';
+  let xml = openModelElement(!!colorConfig);
+  xml += buildMetadataXml(options);
+  xml += '  <resources>\n';
   if (colorConfig) {
-    const indices = colorConfig.triangleMaterialIndices;
-    for (let i = 0; i < mesh.triangles.length; i++) {
-      const [v1, v2, v3] = mesh.triangles[i];
-      xml += `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${COLORGROUP_ID}" p1="${indices[i]}" />\n`;
-    }
-  } else {
-    for (const [v1, v2, v3] of mesh.triangles) {
-      xml += `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />\n`;
-    }
+    xml += buildColorGroupXml(COLORGROUP_ID, colorConfig.materials);
   }
-  xml += '        </triangles>\n';
-
-  xml += '      </mesh>\n';
-  xml += '    </object>\n';
+  xml += buildObjectXml(
+    objectId,
+    options.name,
+    mesh,
+    colorConfig ? { id: COLORGROUP_ID, indices: colorConfig.triangleMaterialIndices } : null
+  );
   xml += '  </resources>\n';
-
-  // Build instructions — one or many instances of the single object.
   xml += '  <build>\n';
-  xml += renderBuildItems(colorConfig ? OBJECT_ID : 1, options.stack);
+  xml += renderBuildItems(objectId, options.stack);
   xml += '  </build>\n';
-
   xml += '</model>';
   return xml;
 }
 
 /**
- * Emit one or N `<item>` build entries for an object.
- *
  * 3MF transforms are row-major 3×4 (`m11..m13 m21..m23 m31..m33 m41..m43`);
- * the trailing m41/m42/m43 row carries the translation. Since stacking is a
- * pure Z translation, the rotation/scale block is the identity matrix and
- * only m43 changes per copy.
+ * the trailing m41/m42/m43 row carries the translation. Stacking is a pure
+ * Z translation, so the rotation/scale block stays identity and only m43
+ * changes per copy.
  */
 function renderBuildItems(objectId: number, stack: ThreeMFOptions['stack']): string {
   const count = stack && stack.count > 1 ? Math.floor(stack.count) : 1;
@@ -375,102 +241,115 @@ function buildMultiObjectModelXML(
   }[],
   options: ThreeMFOptions
 ): string {
-  const NS = 'http://schemas.microsoft.com/3dmanufacturing/core/2015/02';
-  const MATERIAL_NS = 'http://schemas.microsoft.com/3dmanufacturing/material/2015/02';
-  const anyHasColors = objects.some((o) => o.colorConfig && o.colorConfig.materials.length > 0);
-
-  let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
-  const matNs = anyHasColors ? ` xmlns:m="${MATERIAL_NS}" requiredextensions="m"` : '';
-  xml += `<model unit="millimeter" xml:lang="en-US" xmlns="${NS}"${matNs}>\n`;
-
-  // Metadata
-  xml += `  <metadata name="Title">${escapeXml(options.name)}</metadata>\n`;
-  xml += '  <metadata name="Designer">Gridfinity Layout Tool</metadata>\n';
-  xml += `  <metadata name="CreationDate">${new Date().toISOString().split('T')[0]}</metadata>\n`;
-
-  if (options.printSettings) {
-    const ps = options.printSettings;
-    if (ps.layerHeight !== undefined) {
-      xml += `  <metadata name="PrintSettings.LayerHeight">${ps.layerHeight}</metadata>\n`;
-    }
-    if (ps.infillPercent !== undefined) {
-      xml += `  <metadata name="PrintSettings.InfillPercent">${ps.infillPercent}</metadata>\n`;
-    }
-    if (ps.material) {
-      xml += `  <metadata name="PrintSettings.Material">${escapeXml(ps.material)}</metadata>\n`;
-    }
-    if (ps.supportRequired !== undefined) {
-      xml += `  <metadata name="PrintSettings.SupportRequired">${ps.supportRequired}</metadata>\n`;
-    }
-    if (ps.estimatedMinutes !== undefined) {
-      xml += `  <metadata name="PrintSettings.EstimatedMinutes">${ps.estimatedMinutes}</metadata>\n`;
-    }
-    if (ps.estimatedGrams !== undefined) {
-      xml += `  <metadata name="PrintSettings.EstimatedGrams">${ps.estimatedGrams}</metadata>\n`;
-    }
-  }
-
-  xml += '  <resources>\n';
-
-  // Emit each object with a unique ID
-  const objectIds: number[] = [];
-  let nextId = 1;
-
-  for (const obj of objects) {
-    const hasColors = obj.colorConfig && obj.colorConfig.materials.length > 0;
-    const colorConfig = hasColors ? obj.colorConfig : undefined;
-
-    // Color group for this object (if colored).
-    let colorGroupId: number | undefined;
+  // Validate every color config up front so an invalid config on object N
+  // can't cost the serialisation of objects 0…N-1.
+  const resolved = objects.map((obj) => {
+    const colorConfig = activeColorConfig(obj.colorConfig);
     if (colorConfig) {
       assertColorConfigShape(colorConfig, obj.mesh.triangles.length);
-      colorGroupId = nextId++;
-      xml += `    <m:colorgroup id="${colorGroupId}">\n`;
-      for (const mat of colorConfig.materials) {
-        xml += `      <m:color color="${escapeXml(mat.color)}" />\n`;
-      }
-      xml += '    </m:colorgroup>\n';
     }
+    return { ...obj, colorConfig };
+  });
+  const anyHasColors = resolved.some((obj) => obj.colorConfig !== undefined);
 
+  let xml = openModelElement(anyHasColors);
+  xml += buildMetadataXml(options);
+  xml += '  <resources>\n';
+
+  const objectIds: number[] = [];
+  let nextId = 1;
+  for (const obj of resolved) {
+    let colorGroup: { id: number; indices: readonly number[] } | null = null;
+    if (obj.colorConfig) {
+      const colorGroupId = nextId++;
+      xml += buildColorGroupXml(colorGroupId, obj.colorConfig.materials);
+      colorGroup = { id: colorGroupId, indices: obj.colorConfig.triangleMaterialIndices };
+    }
     const objectId = nextId++;
     objectIds.push(objectId);
-
-    xml += `    <object id="${objectId}" type="model" name="${escapeXml(obj.name)}">\n`;
-    xml += '      <mesh>\n';
-
-    xml += '        <vertices>\n';
-    for (const [x, y, z] of obj.mesh.vertices) {
-      xml += `          <vertex x="${formatFloat(x)}" y="${formatFloat(y)}" z="${formatFloat(z)}" />\n`;
-    }
-    xml += '        </vertices>\n';
-
-    xml += '        <triangles>\n';
-    if (colorConfig && colorGroupId !== undefined) {
-      const indices = colorConfig.triangleMaterialIndices;
-      for (let i = 0; i < obj.mesh.triangles.length; i++) {
-        const [v1, v2, v3] = obj.mesh.triangles[i];
-        xml += `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${colorGroupId}" p1="${indices[i]}" />\n`;
-      }
-    } else {
-      for (const [v1, v2, v3] of obj.mesh.triangles) {
-        xml += `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />\n`;
-      }
-    }
-    xml += '        </triangles>\n';
-
-    xml += '      </mesh>\n';
-    xml += '    </object>\n';
+    xml += buildObjectXml(objectId, obj.name, obj.mesh, colorGroup);
   }
 
   xml += '  </resources>\n';
-
   xml += '  <build>\n';
   for (const id of objectIds) {
     xml += `    <item objectid="${id}" />\n`;
   }
   xml += '  </build>\n';
-
   xml += '</model>';
+  return xml;
+}
+
+const CORE_NS = 'http://schemas.microsoft.com/3dmanufacturing/core/2015/02';
+const MATERIAL_NS = 'http://schemas.microsoft.com/3dmanufacturing/material/2015/02';
+
+/**
+ * The `m` materials extension is what BambuStudio/OrcaSlicer parse for their
+ * "Standard 3MF Import Color" dialog — the 3MF Core `<basematerials>` element
+ * is silently ignored by their parsers. Declare the extension only when we
+ * actually emit color content, so single-color exports stay namespace-clean.
+ */
+function openModelElement(hasColors: boolean): string {
+  const matNs = hasColors ? ` xmlns:m="${MATERIAL_NS}" requiredextensions="m"` : '';
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<model unit="millimeter" xml:lang="en-US" xmlns="${CORE_NS}"${matNs}>\n`;
+}
+
+function buildMetadataXml(options: ThreeMFOptions): string {
+  let xml = `  <metadata name="Title">${escapeXml(options.name)}</metadata>\n`;
+  xml += '  <metadata name="Designer">Gridfinity Layout Tool</metadata>\n';
+  xml += `  <metadata name="CreationDate">${new Date().toISOString().split('T')[0]}</metadata>\n`;
+  const ps = options.printSettings;
+  if (!ps) return xml;
+  // 3MF Core §3.7: custom metadata names without a registered namespace prefix
+  // should set preserve="true" so consumers don't strip them on round-trip.
+  const custom = (name: string, value: string | number | boolean) =>
+    `  <metadata name="${name}" preserve="true">${value}</metadata>\n`;
+  if (ps.layerHeight !== undefined) xml += custom('PrintSettings.LayerHeight', ps.layerHeight);
+  if (ps.infillPercent !== undefined)
+    xml += custom('PrintSettings.InfillPercent', ps.infillPercent);
+  if (ps.material) xml += custom('PrintSettings.Material', escapeXml(ps.material));
+  if (ps.supportRequired !== undefined)
+    xml += custom('PrintSettings.SupportRequired', ps.supportRequired);
+  if (ps.estimatedMinutes !== undefined)
+    xml += custom('PrintSettings.EstimatedMinutes', ps.estimatedMinutes);
+  if (ps.estimatedGrams !== undefined)
+    xml += custom('PrintSettings.EstimatedGrams', ps.estimatedGrams);
+  return xml;
+}
+
+function buildColorGroupXml(id: number, materials: ThreeMFColorConfig['materials']): string {
+  let xml = `    <m:colorgroup id="${id}">\n`;
+  for (const mat of materials) {
+    xml += `      <m:color color="${escapeXml(mat.color)}" />\n`;
+  }
+  xml += '    </m:colorgroup>\n';
+  return xml;
+}
+
+function buildObjectXml(
+  objectId: number,
+  name: string,
+  mesh: IndexedMesh,
+  colorGroup: { id: number; indices: readonly number[] } | null
+): string {
+  let xml = `    <object id="${objectId}" type="model" name="${escapeXml(name)}">\n`;
+  xml += '      <mesh>\n        <vertices>\n';
+  for (const [x, y, z] of mesh.vertices) {
+    xml += `          <vertex x="${formatFloat(x)}" y="${formatFloat(y)}" z="${formatFloat(z)}" />\n`;
+  }
+  xml += '        </vertices>\n        <triangles>\n';
+  if (colorGroup) {
+    const { id, indices } = colorGroup;
+    for (let i = 0; i < mesh.triangles.length; i++) {
+      const [v1, v2, v3] = mesh.triangles[i];
+      xml += `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${id}" p1="${indices[i]}" />\n`;
+    }
+  } else {
+    for (const [v1, v2, v3] of mesh.triangles) {
+      xml += `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />\n`;
+    }
+  }
+  xml += '        </triangles>\n      </mesh>\n    </object>\n';
   return xml;
 }
 
@@ -487,12 +366,9 @@ const HEX_COLOR_RE = /^#[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$/;
 
 /**
  * Materials Extension v1.0 requires `#RRGGBB` or `#RRGGBBAA` (sRGB hex with
- * leading `#`). Validate up-front so a stray `rgb(...)`, missing `#`, or
- * 3-digit shorthand can't ship as a parseable-but-rejected 3MF.
- *
- * `triangleMaterialIndices` must have exactly one entry per triangle and each
- * entry must point at a valid color slot — `?? 0` fallbacks silently produced
- * wrong colors when callers passed short arrays.
+ * leading `#`); `triangleMaterialIndices` must have exactly one entry per
+ * triangle, each pointing at a valid color slot. Violations throw so that
+ * out-of-range or missing entries can't silently ship as wrong colors.
  */
 function assertColorConfigShape(config: ThreeMFColorConfig, triangleCount: number): void {
   if (config.triangleMaterialIndices.length !== triangleCount) {
@@ -520,31 +396,20 @@ function assertColorConfigShape(config: ThreeMFColorConfig, triangleCount: numbe
 }
 
 /**
- * Safely extract the viewed portion of a Uint8Array as an ArrayBuffer.
- *
  * fflate's browser WASM path can return a Uint8Array backed by a larger
- * pre-allocated ArrayBuffer. Slicing to the view's range avoids including
- * trailing garbage, and produces an ArrayBuffer (not ArrayBufferLike)
- * which satisfies the TS6 BlobPart constraint.
+ * pre-allocated ArrayBuffer. Slicing to the view's range avoids trailing
+ * garbage and produces an ArrayBuffer (not ArrayBufferLike) which satisfies
+ * the TS6 BlobPart constraint.
  */
 function toArrayBuffer(view: Uint8Array): ArrayBuffer {
   return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength) as ArrayBuffer;
 }
 
-/**
- * Format float with up to 6 decimal places, removing trailing zeros.
- * 3MF spec requires reasonable precision without excessive digits.
- */
 function formatFloat(n: number): string {
   return parseFloat(n.toFixed(6)).toString();
 }
 
-/**
- * Computes approximate file size for UI display.
- * Based on typical compression ratios for 3MF XML mesh data.
- */
 export function estimate3MFFileSize(triangleCount: number): number {
-  // Each triangle in XML ≈ 80 chars uncompressed, ~30 after ZIP deflate
-  // Plus ~1KB fixed overhead for metadata/structure
+  // Each triangle ~80 chars in XML, ~30 after ZIP deflate; ~1KB fixed overhead.
   return 1024 + triangleCount * 30;
 }


### PR DESCRIPTION
## Summary

- **Bug**: Multi-color bin designs exported as 3MF imported as **single-color** in BambuStudio — the "Standard 3MF Import Color" filament-mapping dialog never appeared.
- **Root cause**: The exporter emitted the 3MF Core spec's `<basematerials>`/`<base displaycolor>` element. BambuStudio (verified via `bambulab/BambuStudio/src/libslic3r/Format/bbs_3mf.cpp`) and OrcaSlicer only parse `<m:colorgroup>`/`<m:color>` from the 3MF Materials Extension v1.0. They never read `basematerials`, so every multi-color export was silently mapped to a single color.
- **Fix**: Swap to `<m:colorgroup>`/`<m:color>`, declare the extension namespace `xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"` + `requiredextensions="m"` on `<model>` only when color content is present. Triangle `pid`/`p1` references are unchanged — both forms use the Core triangle-property mechanism.

## Spec audit (shipped together)

After finding the root cause was a spec-encoding mistake, I audited both STL and 3MF exporters end-to-end against the ASTM STL and 3MF Core + Materials Extension specs. Findings addressed in this PR:

- **OPC thumbnail relationship was missing** — every multi-color 3MF written a thumbnail PNG that no viewer could discover (Content_Types declared `image/png` but `_rels/.rels` had no `metadata/thumbnail` relationship).
- **`buildSTLBufferFromIndexed` skipped validation** the flat-array path enforced (empty mesh, out-of-range index, normals/vertices length mismatch).
- **Silent miscompliance footguns**: `triangleMaterialIndices.length` mismatch and non-`#RRGGBB` hex colors used to silently fall back to color 0 / pass through unchecked. Now both throw with a precise message.
- **STL normals**: first-vertex normal copied verbatim could violate the unit-vector invariant after upstream booleans returned scaled normals. Renormalized in both flat and indexed paths.
- **STL header**: defensive guard so a future refactor putting the user name first can't accidentally start with "solid" (would misdetect as ASCII STL).
- **XML compliance**: `escapeXml` now also escapes apostrophe.

## Test plan

- [x] `pnpm exec vitest run` on changed test files: 108/108 pass, includes 9 new tests for the invariants (length mismatch, out-of-range index, hex format, RGBA hex, thumbnail relationship, header guard, normal renormalization, indexed-path validation).
- [x] Broader test pass: 2,379 tests across `src/features/bin-designer/` and `src/features/generation/export/` pass.
- [x] `pnpm run typecheck` clean.
- [x] `pnpm exec eslint` on changed files clean.
- [ ] Manual: export a multi-color bin as 3MF, open in BambuStudio, confirm "Standard 3MF Import Color" dialog appears with the configured filaments.
- [ ] Manual: confirm thumbnail now renders in 3MF viewers (Microsoft 3D Viewer, BambuStudio thumbnail panel).