### PR TITLE
fix(export): paint per-triangle via paint_color for Bambu/Orca/Prusa

### DIFF
--- a/src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.tsx
+++ b/src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.tsx
@@ -1,9 +1,8 @@
 /**
- * Filament-mapping preview shown in the export dialog when the design
- * is multi-color and the format is 3MF. Mirrors the 3MF Materials
- * Extension `<m:colorgroup>` block — the structure BambuStudio /
- * OrcaSlicer parse for their "Standard 3MF Import Color" dialog — so
- * users can plan their AMS/MMU slots before opening the slicer.
+ * Filament-mapping preview shown in the export dialog when the design is
+ * multi-color and the format is 3MF. Lists the filament slots BambuStudio /
+ * OrcaSlicer / PrusaSlicer derive from the `paint_color` triangle attributes
+ * so users can plan their AMS/MMU slots before opening the slicer.
  */
 
 import { useId, useState } from 'react';

--- a/src/features/bin-designer/utils/multicolorRoundTrip.test.ts
+++ b/src/features/bin-designer/utils/multicolorRoundTrip.test.ts
@@ -32,6 +32,7 @@ import {
 } from '@/features/bin-designer/utils/binDownloadHelpers';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
 import { normalizeHex, resolveColorMapping } from '@/features/bin-designer/types/featureColors';
+import { FILAMENT_PAINT_CODES } from '@/features/generation/export/threemfExporter';
 import type { BinParams } from '@/features/bin-designer/types';
 import type { ThreeMFPrintSettings } from '@/shared/generation/export';
 
@@ -87,31 +88,10 @@ async function blobToModelXml(blob: Blob): Promise<string> {
 }
 
 /**
- * OrcaSlicer's CONST_FILAMENTS table (Model.cpp:52). The exporter writes
- * `paint_color="<code>"` where the code is the entry at the material slot
- * index — slot 0 emits nothing (default extruder).
+ * Decode a paint_color attribute back to a material slot index using the
+ * live FILAMENT_PAINT_CODES from the exporter — keeping the test pinned to
+ * the same table the production code emits.
  */
-const FILAMENT_PAINT_CODES = [
-  '',
-  '4',
-  '8',
-  '0C',
-  '1C',
-  '2C',
-  '3C',
-  '4C',
-  '5C',
-  '6C',
-  '7C',
-  '8C',
-  '9C',
-  'AC',
-  'BC',
-  'CC',
-  'DC',
-] as const;
-
-/** Decode a paint_color attribute back to a material slot index. */
 function slotFromCode(code: string | undefined): number {
   if (code === undefined) return 0; // missing attribute → slot 0 (body)
   const idx = FILAMENT_PAINT_CODES.indexOf(code as (typeof FILAMENT_PAINT_CODES)[number]);

--- a/src/features/bin-designer/utils/multicolorRoundTrip.test.ts
+++ b/src/features/bin-designer/utils/multicolorRoundTrip.test.ts
@@ -1,22 +1,21 @@
 /**
  * Semantic round-trip tests for multi-color 3MF export.
  *
- * The existing test files (`materialMapping.test.ts`, `binDownloadHelpers.test.ts`,
- * `threemfExporter.test.ts`) cover the layers in isolation. This file pins the
- * end-to-end semantic invariants on the assembled output of
- * `buildSinglePiece3MF` / `buildMultiObject3MF`:
+ * Pins the end-to-end semantic invariants of the assembled output of
+ * `buildSinglePiece3MF` / `buildMultiObject3MF`. Slicers (PrusaSlicer,
+ * BambuStudio, OrcaSlicer) read multi-material painting from a `paint_color`
+ * attribute on each `<triangle>`, encoded per OrcaSlicer's CONST_FILAMENTS
+ * table — these tests decode that attribute back to material slot indices via
+ * `resolveColorMapping` so assertions read in terms of zone colors.
  *
- *   1. FeatureTag → p1 round-trip — every triangle in a face group emits the
- *      `p1` index of that feature's configured zone color.
+ *   1. FeatureTag → paint_color round-trip — every triangle in a face group
+ *      emits the matching filament code for that feature's configured zone.
  *   2. Lip corner round-trip — lip triangles in each XY quadrant carry the
- *      configured corner color's `p1`.
+ *      configured corner color's slot.
  *   3. Single-color short-circuit — all-same-color (incl. mixed-case hex) emits
- *      no `<m:colorgroup>`; mixed-case dedup yields one material, not two.
+ *      no `paint_color` anywhere; mixed-case dedup yields one slot, not two.
  *   4. Multi-object color contract — only the first piece (bin) carries colors;
  *      ancillary pieces (dividers, lid) ship solid-color.
- *
- * All recent multi-color bugs (text zone missing from preview, mixed-case dedup
- * gap, isSingleColor case inconsistency) would have been caught by these.
  *
  * Inputs are hand-crafted: a tiny synthetic binary STL plus face groups that
  * partition the triangle range. Real worker output is too expensive for
@@ -32,6 +31,7 @@ import {
   buildMultiObject3MF,
 } from '@/features/bin-designer/utils/binDownloadHelpers';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import { normalizeHex, resolveColorMapping } from '@/features/bin-designer/types/featureColors';
 import type { BinParams } from '@/features/bin-designer/types';
 import type { ThreeMFPrintSettings } from '@/shared/generation/export';
 
@@ -86,39 +86,46 @@ async function blobToModelXml(blob: Blob): Promise<string> {
   return strFromU8(model);
 }
 
-interface Material {
-  readonly color: string;
+/**
+ * OrcaSlicer's CONST_FILAMENTS table (Model.cpp:52). The exporter writes
+ * `paint_color="<code>"` where the code is the entry at the material slot
+ * index — slot 0 emits nothing (default extruder).
+ */
+const FILAMENT_PAINT_CODES = [
+  '',
+  '4',
+  '8',
+  '0C',
+  '1C',
+  '2C',
+  '3C',
+  '4C',
+  '5C',
+  '6C',
+  '7C',
+  '8C',
+  '9C',
+  'AC',
+  'BC',
+  'CC',
+  'DC',
+] as const;
+
+/** Decode a paint_color attribute back to a material slot index. */
+function slotFromCode(code: string | undefined): number {
+  if (code === undefined) return 0; // missing attribute → slot 0 (body)
+  const idx = FILAMENT_PAINT_CODES.indexOf(code as (typeof FILAMENT_PAINT_CODES)[number]);
+  if (idx < 0) throw new Error(`unknown paint_color code: ${code}`);
+  return idx;
 }
 
-const COLORGROUP_BLOCK_RE = /<m:colorgroup\s+id="(\d+)">([\s\S]*?)<\/m:colorgroup>/;
-const COLOR_ENTRY_RE = /<m:color\s+color="([^"]*)"\s*\/>/g;
-
-/** Extract `<m:color>` entries from inside a `<m:colorgroup>` block, in order. */
-function parseMaterials(xml: string): Material[] {
-  const block = COLORGROUP_BLOCK_RE.exec(xml);
-  if (!block) return [];
-  const out: Material[] = [];
-  for (const m of block[2].matchAll(COLOR_ENTRY_RE)) {
-    out.push({ color: m[1] });
-  }
-  return out;
-}
-
-/** Triangle in document order with its emitted `p1` (or `null` if none). */
-interface Triangle {
-  readonly p1: number | null;
-  readonly pid: number | null;
-}
-
-function parseTriangles(xml: string): Triangle[] {
-  const out: Triangle[] = [];
+/** Material slot per triangle in document order. */
+function parseTriangleSlots(xml: string): number[] {
+  const out: number[] = [];
   for (const m of xml.matchAll(
-    /<triangle\s+v1="\d+"\s+v2="\d+"\s+v3="\d+"(?:\s+pid="(\d+)"\s+p1="(\d+)")?\s*\/>/g
+    /<triangle\s+v1="\d+"\s+v2="\d+"\s+v3="\d+"(?:\s+paint_color="([^"]*)")?\s*\/>/g
   )) {
-    out.push({
-      pid: m[1] !== undefined ? Number(m[1]) : null,
-      p1: m[2] !== undefined ? Number(m[2]) : null,
-    });
+    out.push(slotFromCode(m[1]));
   }
   return out;
 }
@@ -169,9 +176,17 @@ function withColors(overrides: Partial<BinParams['featureColors']> = {}): BinPar
 
 // ─── tests ───────────────────────────────────────────────────────────────
 
+/** Map a hex color back to its material slot via the live `resolveColorMapping`. */
+function slotFor(params: BinParams, hex: string): number {
+  const { colorToIndex } = resolveColorMapping(params.featureColors);
+  const slot = colorToIndex.get(normalizeHex(hex));
+  if (slot === undefined) throw new Error(`color ${hex} not present in materials`);
+  return slot;
+}
+
 describe('multicolor 3MF round-trip', () => {
-  describe('FeatureTag → p1 round-trip', () => {
-    it('every triangle in a face group emits the configured zone color index', async () => {
+  describe('FeatureTag → paint_color round-trip', () => {
+    it('every triangle in a face group emits the configured zone color slot', async () => {
       const params = withColors({
         body: '#111111',
         labelTab: '#22ee22',
@@ -200,27 +215,20 @@ describe('multicolor 3MF round-trip', () => {
         true
       );
       const xml = await blobToModelXml(blob);
-      const materials = parseMaterials(xml);
-      const tris = parseTriangles(xml);
+      const slots = parseTriangleSlots(xml);
 
-      // Body always lands at index 0 (per resolveColorMapping).
-      const idxFor = (hex: string) => materials.findIndex((m) => m.color === hex);
-      expect(idxFor('#111111')).toBe(0);
-      expect(idxFor('#22ee22')).toBeGreaterThan(0);
-      expect(idxFor('#3333ee')).toBeGreaterThan(0);
-      expect(idxFor('#ee3333')).toBeGreaterThan(0);
-
-      expect(tris.map((t) => t.p1)).toEqual([
-        idxFor('#22ee22'),
-        idxFor('#22ee22'),
-        idxFor('#3333ee'),
-        idxFor('#3333ee'),
-        idxFor('#ee3333'),
-        idxFor('#ee3333'),
+      expect(slotFor(params, '#111111')).toBe(0);
+      expect(slots).toEqual([
+        slotFor(params, '#22ee22'),
+        slotFor(params, '#22ee22'),
+        slotFor(params, '#3333ee'),
+        slotFor(params, '#3333ee'),
+        slotFor(params, '#ee3333'),
+        slotFor(params, '#ee3333'),
       ]);
     });
 
-    it('untagged triangles default to body (index 0)', async () => {
+    it('untagged triangles default to body (slot 0)', async () => {
       const params = withColors({ body: '#abc123', labelTab: '#deadbe' });
       const triangles = [...tri(0, 0), ...tri(1, 0), ...tri(2, 0), ...tri(3, 0)];
       const faceGroups: FaceGroupData[] = [{ start: 0, count: 6, tag: FeatureTag.LABEL_TAB }];
@@ -232,17 +240,12 @@ describe('multicolor 3MF round-trip', () => {
         PRINT_SETTINGS,
         true
       );
-      const xml = await blobToModelXml(blob);
-      const materials = parseMaterials(xml);
-      const tris = parseTriangles(xml);
+      const slots = parseTriangleSlots(await blobToModelXml(blob));
 
-      // Resolve via material list to keep the assertion self-documenting,
-      // matching the idxFor pattern used by the other tests in this suite.
-      const idxFor = (hex: string) => materials.findIndex((m) => m.color === hex);
-      expect(tris[0].p1).toBe(idxFor('#deadbe')); // LABEL_TAB
-      expect(tris[1].p1).toBe(idxFor('#deadbe')); // LABEL_TAB
-      expect(tris[2].p1).toBe(idxFor('#abc123')); // untagged → body
-      expect(tris[3].p1).toBe(idxFor('#abc123')); // untagged → body
+      expect(slots[0]).toBe(slotFor(params, '#deadbe'));
+      expect(slots[1]).toBe(slotFor(params, '#deadbe'));
+      expect(slots[2]).toBe(slotFor(params, '#abc123')); // body → slot 0
+      expect(slots[3]).toBe(slotFor(params, '#abc123'));
     });
 
     it('TEXT-tagged triangles carry the text zone color when tab/cutout text is active', async () => {
@@ -266,38 +269,31 @@ describe('multicolor 3MF round-trip', () => {
         PRINT_SETTINGS,
         true
       );
-      const xml = await blobToModelXml(blob);
-      const materials = parseMaterials(xml);
-      const tris = parseTriangles(xml);
+      const slots = parseTriangleSlots(await blobToModelXml(blob));
 
-      expect(materials.map((m) => m.color)).toEqual(['#222222', '#ee44ee']);
-      expect(tris.map((t) => t.p1)).toEqual([1, 1]);
+      const textSlot = slotFor(params, '#ee44ee');
+      expect(textSlot).toBeGreaterThan(0);
+      expect(slots).toEqual([textSlot, textSlot]);
     });
 
-    it('every emitted pid resolves to the m:colorgroup block (reference integrity)', async () => {
-      const params = withColors({ body: '#fff', base: '#000' });
+    it('every emitted slot index points at a valid material in the mapping', async () => {
+      const params = withColors({ body: '#ffffff', base: '#000000' });
       const triangles = [...tri(0, 0), ...tri(1, 0)];
       const faceGroups: FaceGroupData[] = [{ start: 0, count: 6, tag: FeatureTag.SOCKET }];
       const blob = buildSinglePiece3MF(
         buildBinarySTL(triangles),
         faceGroups,
         params,
-        'pid-int',
+        'slot-int',
         PRINT_SETTINGS,
         true
       );
-      const xml = await blobToModelXml(blob);
-      const pidMatch = /<m:colorgroup\s+id="(\d+)"/.exec(xml);
-      const colorgroupId = pidMatch ? Number(pidMatch[1]) : NaN;
-      const materialsCount = parseMaterials(xml).length;
-      const tris = parseTriangles(xml);
+      const slots = parseTriangleSlots(await blobToModelXml(blob));
+      const { colors } = resolveColorMapping(params.featureColors);
 
-      for (const t of tris) {
-        if (t.pid === null) continue;
-        expect(t.pid).toBe(colorgroupId);
-        expect(t.p1).not.toBeNull();
-        expect(t.p1).toBeGreaterThanOrEqual(0);
-        expect(t.p1).toBeLessThan(materialsCount);
+      for (const slot of slots) {
+        expect(slot).toBeGreaterThanOrEqual(0);
+        expect(slot).toBeLessThan(colors.length);
       }
     });
   });
@@ -324,22 +320,19 @@ describe('multicolor 3MF round-trip', () => {
         PRINT_SETTINGS,
         true
       );
-      const xml = await blobToModelXml(blob);
-      const materials = parseMaterials(xml);
-      const tris = parseTriangles(xml);
+      const slots = parseTriangleSlots(await blobToModelXml(blob));
 
-      const idxFor = (hex: string) => materials.findIndex((m) => m.color === hex);
-      expect(tris.map((t) => t.p1)).toEqual([
-        idxFor('#fa0000'),
-        idxFor('#00fa00'),
-        idxFor('#0000fa'),
-        idxFor('#ffffff'),
+      expect(slots).toEqual([
+        slotFor(params, '#fa0000'),
+        slotFor(params, '#00fa00'),
+        slotFor(params, '#0000fa'),
+        slotFor(params, '#ffffff'),
       ]);
     });
   });
 
   describe('single-color short-circuit', () => {
-    it('all-same-color (lowercase) emits no <m:colorgroup>', async () => {
+    it('all-same-color (lowercase) emits no paint_color', async () => {
       const params = withColors(); // all zones default to '#d4d8dc'
       const triangles = [...tri(0, 0), ...tri(1, 0)];
       const faceGroups: FaceGroupData[] = [{ start: 0, count: 6, tag: FeatureTag.SOCKET }];
@@ -353,13 +346,12 @@ describe('multicolor 3MF round-trip', () => {
       );
       const xml = await blobToModelXml(blob);
 
+      expect(xml).not.toMatch(/\bpaint_color="/);
       expect(xml).not.toMatch(/<m:colorgroup\b/);
       expect(xml).not.toMatch(/\bxmlns:m=/);
-      expect(xml).not.toMatch(/\bpid="/);
-      expect(xml).not.toMatch(/\bp1="/);
     });
 
-    it('mixed-case AND mixed-length hex collapse to single material (no <m:colorgroup>)', async () => {
+    it('mixed-case AND mixed-length hex collapse to single material (no paint_color)', async () => {
       // Regressions for the case-normalization and shorthand-expansion fixes.
       // `#FFF`, `#fff`, `#FFFFFF` all canonicalize to `#ffffff`.
       const params = withColors({ body: '#FFF', base: '#fff', labelTab: '#FFFFFF' });
@@ -375,35 +367,22 @@ describe('multicolor 3MF round-trip', () => {
       );
       const xml = await blobToModelXml(blob);
 
-      expect(xml).not.toMatch(/<m:colorgroup\b/);
+      expect(xml).not.toMatch(/\bpaint_color="/);
     });
 
     it('mixed-case dedup yields N materials, not 2N (only divergent zones add slots)', async () => {
       // Regression for resolveColorMapping case + shorthand normalization:
       // body `#FFF`, base `#ffffff`, labelTab `#FF0000` → 2 materials, not 3.
       const params = withColors({ body: '#FFF', base: '#ffffff', labelTab: '#FF0000' });
-      const triangles = [...tri(0, 0), ...tri(1, 0)];
-      const faceGroups: FaceGroupData[] = [
-        { start: 0, count: 3, tag: FeatureTag.SOCKET },
-        { start: 3, count: 3, tag: FeatureTag.LABEL_TAB },
-      ];
-      const blob = buildSinglePiece3MF(
-        buildBinarySTL(triangles),
-        faceGroups,
-        params,
-        'mixed-case-dedup',
-        PRINT_SETTINGS,
-        true
-      );
-      const materials = parseMaterials(await blobToModelXml(blob));
-      expect(materials).toHaveLength(2);
-      // Lowercased per resolveColorMapping's normalization.
-      expect(materials.map((m) => m.color)).toEqual(['#ffffff', '#ff0000']);
+      // Even though the wire format no longer carries materials, the in-memory
+      // mapping is what feeds slot indices to paint_color — assert directly.
+      const { colors } = resolveColorMapping(params.featureColors);
+      expect(colors).toEqual(['#ffffff', '#ff0000']);
     });
   });
 
   describe('multi-object color contract', () => {
-    it('only the first piece (bin) carries colorConfig; ancillary pieces ship solid-color', async () => {
+    it('only the first piece (bin) carries paint_color; ancillary pieces ship solid', async () => {
       const params = withColors({ body: '#aaaaaa', labelTab: '#0000ff' });
       const pieces = [
         { data: buildBinarySTL([...tri(0, 0)]), label: 'bin' },
@@ -415,21 +394,17 @@ describe('multicolor 3MF round-trip', () => {
       const blob = buildMultiObject3MF(pieces, faceGroups, params, 'assembly', PRINT_SETTINGS);
       const xml = await blobToModelXml(blob);
 
-      // Exactly one <m:colorgroup> block — for the bin piece.
-      const groupBlocks = xml.match(/<m:colorgroup\b/g) ?? [];
-      expect(groupBlocks).toHaveLength(1);
-
-      // The materials extension namespace is declared on <model>.
-      expect(xml).toMatch(/\bxmlns:m="http:\/\/schemas\.microsoft\.com\/3dmanufacturing\/material/);
-
       // Three <object> entries (bin, divider, lid).
       const objects = xml.match(/<object\s+id="\d+"/g) ?? [];
       expect(objects).toHaveLength(3);
 
-      // The colorgroup block precedes the first <object> in document order.
-      const groupAt = xml.indexOf('<m:colorgroup');
-      const firstObjAt = xml.indexOf('<object');
-      expect(groupAt).toBeLessThan(firstObjAt);
+      // Exactly one paint_color attribute — on the bin's lone LABEL_TAB triangle.
+      const painted = xml.match(/\bpaint_color="/g) ?? [];
+      expect(painted).toHaveLength(1);
+
+      // Colorgroups + materials namespace are gone for good.
+      expect(xml).not.toMatch(/<m:colorgroup\b/);
+      expect(xml).not.toMatch(/\bxmlns:m=/);
     });
 
     it('multi-color disabled at the params level disables colors on every piece', async () => {
@@ -445,9 +420,9 @@ describe('multicolor 3MF round-trip', () => {
         PRINT_SETTINGS
       );
       const xml = await blobToModelXml(blob);
+      expect(xml).not.toMatch(/\bpaint_color="/);
       expect(xml).not.toMatch(/<m:colorgroup\b/);
       expect(xml).not.toMatch(/\bxmlns:m=/);
-      expect(xml).not.toMatch(/\bp1="/);
     });
   });
 });

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -613,7 +613,37 @@ describe('threemfExporter', () => {
       expect(files['Metadata/project_settings.config']).toBeUndefined();
     });
 
-    it('multi-object: palette aggregates across colored objects, dedup by hex', () => {
+    it('multi-object: accepts identical material arrays across colored objects', () => {
+      // Same materials list shared across objects (mixed-case to confirm
+      // the comparator is case-insensitive). Per-object paint_color slots
+      // resolve to the same filament in the unified palette, so the
+      // emitted filament_colour list matches the shared array (lowercased).
+      const tri = createSingleTriangle();
+      const shared = [{ color: '#111111' }, { color: '#FF0000' }];
+      const objects = [
+        {
+          vertices: tri.vertices,
+          normals: tri.normals,
+          name: 'bin',
+          colorConfig: { materials: shared, triangleMaterialIndices: [1] },
+        },
+        {
+          vertices: tri.vertices,
+          normals: tri.normals,
+          name: 'lid',
+          colorConfig: { materials: shared, triangleMaterialIndices: [0] },
+        },
+      ];
+      const buffer = build3MFMultiObjectBuffer(objects, { name: 'multi' });
+      const config = JSON.parse(strFromU8(unzipSync(buffer)['Metadata/project_settings.config']));
+      expect(config.filament_colour).toEqual(['#111111', '#ff0000']);
+    });
+
+    it('multi-object: throws when colored objects have mismatched material arrays', () => {
+      // Per-triangle paint_color codes are object-local. If two objects ship
+      // different palettes, code "4" (slot 1) means different filaments in
+      // each object — and the unified filament_colour list can only honor
+      // one mapping. Fail loudly rather than silently produce wrong colors.
       const tri = createSingleTriangle();
       const objects = [
         {
@@ -621,7 +651,7 @@ describe('threemfExporter', () => {
           normals: tri.normals,
           name: 'bin',
           colorConfig: {
-            materials: [{ color: '#111111' }, { color: '#FF0000' }],
+            materials: [{ color: '#111111' }, { color: '#ff0000' }],
             triangleMaterialIndices: [0],
           },
         },
@@ -629,16 +659,15 @@ describe('threemfExporter', () => {
           vertices: tri.vertices,
           normals: tri.normals,
           name: 'lid',
-          // Repeat #ff0000 (different case) and add a new hue.
           colorConfig: {
-            materials: [{ color: '#ff0000' }, { color: '#00FF00' }],
+            materials: [{ color: '#111111' }, { color: '#00ff00' }],
             triangleMaterialIndices: [0],
           },
         },
       ];
-      const buffer = build3MFMultiObjectBuffer(objects, { name: 'multi' });
-      const config = JSON.parse(strFromU8(unzipSync(buffer)['Metadata/project_settings.config']));
-      expect(config.filament_colour).toEqual(['#111111', '#ff0000', '#00ff00']);
+      expect(() => build3MFMultiObjectBuffer(objects, { name: 'multi' })).toThrow(
+        /must share the same materials array/
+      );
     });
 
     it('multi-object: omits project_settings.config when no object has a colorConfig', () => {
@@ -681,6 +710,44 @@ describe('threemfExporter', () => {
       const { vertices, normals } = createSingleTriangle();
       const model = strFromU8(
         unzipSync(build3MFBuffer(vertices, normals, { name: 'plain' }))['3D/3dmodel.model']
+      );
+      expect(model).not.toContain('<metadata name="Application">');
+      expect(model).not.toContain('BambuStudio:3mfVersion');
+    });
+
+    it('multi-object: emits BambuStudio Application metadata when any object has colorConfig', () => {
+      const tri = createSingleTriangle();
+      const objects = [
+        {
+          vertices: tri.vertices,
+          normals: tri.normals,
+          name: 'colored',
+          colorConfig: {
+            materials: [{ color: '#aaaaaa' }, { color: '#ff0000' }],
+            triangleMaterialIndices: [1],
+          },
+        },
+        { vertices: tri.vertices, normals: tri.normals, name: 'plain' },
+      ];
+      const model = strFromU8(
+        unzipSync(build3MFMultiObjectBuffer(objects, { name: 'multi-bambu' }))['3D/3dmodel.model']
+      );
+      expect(model).toContain('<metadata name="Application">BambuStudio-');
+      expect(model).toContain('<metadata name="BambuStudio:3mfVersion">1</metadata>');
+    });
+
+    it('multi-object: omits Application metadata when no object has colorConfig', () => {
+      const tri = createSingleTriangle();
+      const model = strFromU8(
+        unzipSync(
+          build3MFMultiObjectBuffer(
+            [
+              { vertices: tri.vertices, normals: tri.normals, name: 'a' },
+              { vertices: tri.vertices, normals: tri.normals, name: 'b' },
+            ],
+            { name: 'multi-plain' }
+          )
+        )['3D/3dmodel.model']
       );
       expect(model).not.toContain('<metadata name="Application">');
       expect(model).not.toContain('BambuStudio:3mfVersion');

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -570,6 +570,90 @@ describe('threemfExporter', () => {
     });
   });
 
+  // Bambu/Orca read Metadata/project_settings.config via
+  // ConfigBase::load_from_json. Its presence flips DynamicPrintConfig.empty()
+  // to false, which suppresses BambuStudio's "old version, geometry only"
+  // dialog (Plater.cpp:8127). filament_colour also pre-fills the AMS slot
+  // palette with our zone colors.
+  describe('project_settings.config (Bambu warning suppression)', () => {
+    it('emits Metadata/project_settings.config when colorConfig has materials', () => {
+      const { vertices, normals } = createTwoTriangles();
+      const buffer = build3MFBuffer(vertices, normals, {
+        name: 'palette-test',
+        colorConfig: {
+          materials: [{ color: '#aaaaaa' }, { color: '#FF0000' }],
+          triangleMaterialIndices: [0, 1],
+        },
+      });
+      const files = unzipSync(buffer);
+      expect(files['Metadata/project_settings.config']).toBeDefined();
+
+      const config = JSON.parse(strFromU8(files['Metadata/project_settings.config']));
+      expect(config.name).toBe('project_settings');
+      expect(config.from).toBe('Gridfinity Layout Tool');
+      expect(typeof config.version).toBe('string');
+      // Hex codes lowercased — BambuStudio's color comparator is case-sensitive.
+      expect(config.filament_colour).toEqual(['#aaaaaa', '#ff0000']);
+    });
+
+    it('omits project_settings.config when no colorConfig is provided', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const buffer = build3MFBuffer(vertices, normals, { name: 'plain' });
+      const files = unzipSync(buffer);
+      expect(files['Metadata/project_settings.config']).toBeUndefined();
+    });
+
+    it('omits project_settings.config when colorConfig has empty materials', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const buffer = build3MFBuffer(vertices, normals, {
+        name: 'empty-palette',
+        colorConfig: { materials: [], triangleMaterialIndices: [] },
+      });
+      const files = unzipSync(buffer);
+      expect(files['Metadata/project_settings.config']).toBeUndefined();
+    });
+
+    it('multi-object: palette aggregates across colored objects, dedup by hex', () => {
+      const tri = createSingleTriangle();
+      const objects = [
+        {
+          vertices: tri.vertices,
+          normals: tri.normals,
+          name: 'bin',
+          colorConfig: {
+            materials: [{ color: '#111111' }, { color: '#FF0000' }],
+            triangleMaterialIndices: [0],
+          },
+        },
+        {
+          vertices: tri.vertices,
+          normals: tri.normals,
+          name: 'lid',
+          // Repeat #ff0000 (different case) and add a new hue.
+          colorConfig: {
+            materials: [{ color: '#ff0000' }, { color: '#00FF00' }],
+            triangleMaterialIndices: [0],
+          },
+        },
+      ];
+      const buffer = build3MFMultiObjectBuffer(objects, { name: 'multi' });
+      const config = JSON.parse(strFromU8(unzipSync(buffer)['Metadata/project_settings.config']));
+      expect(config.filament_colour).toEqual(['#111111', '#ff0000', '#00ff00']);
+    });
+
+    it('multi-object: omits project_settings.config when no object has a colorConfig', () => {
+      const tri = createSingleTriangle();
+      const buffer = build3MFMultiObjectBuffer(
+        [
+          { vertices: tri.vertices, normals: tri.normals, name: 'a' },
+          { vertices: tri.vertices, normals: tri.normals, name: 'b' },
+        ],
+        { name: 'multi-plain' }
+      );
+      expect(unzipSync(buffer)['Metadata/project_settings.config']).toBeUndefined();
+    });
+  });
+
   describe('multi-object 3MF', () => {
     it('produces a valid ZIP with multiple objects', () => {
       const tri = createSingleTriangle();

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -652,6 +652,39 @@ describe('threemfExporter', () => {
       );
       expect(unzipSync(buffer)['Metadata/project_settings.config']).toBeUndefined();
     });
+
+    // BambuStudio gates project_settings.config loading on the Application
+    // metadata starting with "BambuStudio-" (bbs_3mf.cpp:1898). Without it,
+    // every sidecar is silently skipped with "already parsed or a directory
+    // or not supported" and the "old version, geometry only" dialog fires.
+    // OrcaSlicer has no such gate but is happy either way.
+    it('claims Application=BambuStudio-* when colorConfig is active', () => {
+      const { vertices, normals } = createTwoTriangles();
+      const buffer = build3MFBuffer(vertices, normals, {
+        name: 'bambu-compat',
+        colorConfig: {
+          materials: [{ color: '#aaaaaa' }, { color: '#ff0000' }],
+          triangleMaterialIndices: [0, 1],
+        },
+      });
+      const model = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
+      expect(model).toMatch(
+        /<metadata name="Application">BambuStudio-\d+\.\d+\.\d+\.\d+<\/metadata>/
+      );
+      expect(model).toContain('<metadata name="BambuStudio:3mfVersion">1</metadata>');
+      // Keep our human-readable identity too — Designer is unrelated to the
+      // BambuStudio gate.
+      expect(model).toContain('<metadata name="Designer">Gridfinity Layout Tool</metadata>');
+    });
+
+    it('omits Application metadata for single-color exports', () => {
+      const { vertices, normals } = createSingleTriangle();
+      const model = strFromU8(
+        unzipSync(build3MFBuffer(vertices, normals, { name: 'plain' }))['3D/3dmodel.model']
+      );
+      expect(model).not.toContain('<metadata name="Application">');
+      expect(model).not.toContain('BambuStudio:3mfVersion');
+    });
   });
 
   describe('multi-object 3MF', () => {

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -405,8 +405,12 @@ describe('threemfExporter', () => {
     });
   });
 
-  describe('multi-color m:colorgroup', () => {
-    it('emits m:colorgroup, namespace, and pid/p1 when colorConfig is provided', () => {
+  // Both PrusaSlicer (3mf.cpp:2158) and OrcaSlicer/BambuStudio (bbs_3mf.cpp's
+  // MMU_SEGMENTATION_ATTR = "paint_color") read this attribute as the per-triangle
+  // multi-material assignment. The encoding string for each filament slot is the
+  // serialized TriangleSelector bit-tree, lifted from OrcaSlicer Model.cpp:52.
+  describe('multi-color paint_color', () => {
+    it('emits paint_color on triangles whose material index ≠ 0', () => {
       const { vertices, normals } = createTwoTriangles();
       const buffer = build3MFBuffer(vertices, normals, {
         name: 'color-test',
@@ -415,52 +419,76 @@ describe('threemfExporter', () => {
           triangleMaterialIndices: [0, 1],
         },
       });
-      const files = unzipSync(buffer);
-      const model = strFromU8(files['3D/3dmodel.model']);
+      const model = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
 
-      // 3MF Materials Extension v1.0 — BambuStudio/OrcaSlicer recognize this
-      // form and trigger their "Standard 3MF Import Color" dialog.
-      expect(model).toContain(
-        'xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"'
-      );
-      expect(model).toContain('requiredextensions="m"');
-      // IDs in ascending document order per §4.1.2: colorgroup=1, object=2
-      expect(model).toContain('<m:colorgroup id="1">');
-      expect(model).toContain('<m:color color="#ffffff" />');
-      expect(model).toContain('<m:color color="#0000ff" />');
-      expect(model).toContain('</m:colorgroup>');
-      expect(model).toContain('object id="2"');
-      expect(model).toContain('objectid="2"');
-
-      // Triangle color assignments
-      expect(model).toMatch(/triangle v1="\d+" v2="\d+" v3="\d+" pid="1" p1="0"/);
-      expect(model).toMatch(/triangle v1="\d+" v2="\d+" v3="\d+" pid="1" p1="1"/);
+      // Material slot 0 → filament 0 = no paint_color attribute (default extruder)
+      expect(model).toMatch(/<triangle v1="\d+" v2="\d+" v3="\d+" \/>/);
+      // Material slot 1 → filament 1 → CONST_FILAMENTS[1] = "4"
+      expect(model).toMatch(/<triangle v1="\d+" v2="\d+" v3="\d+" paint_color="4" \/>/);
+      // No legacy artifacts from the old colorgroup approach
+      expect(model).not.toContain('pid=');
+      expect(model).not.toContain('p1=');
+      expect(model).not.toContain('m:colorgroup');
+      expect(model).not.toContain('xmlns:m=');
+      expect(model).not.toContain('requiredextensions=');
     });
 
-    it('omits m:colorgroup and namespace when colorConfig is absent', () => {
+    it('emits the correct paint_color code for each filament slot', () => {
+      // Build a 4-triangle mesh, one triangle per material slot, to exercise
+      // every entry of FILAMENT_PAINT_CODES that's likely to ship in a bin.
+      const verts = new Float32Array(4 * 9);
+      for (let i = 0; i < 4; i++) {
+        const base = i * 9;
+        const o = i * 5;
+        verts.set([o, 0, 0, o + 1, 0, 0, o, 1, 0, o + 1, 0, 0].slice(0, 9), base);
+      }
+      const normals = new Float32Array(4 * 9).fill(0);
+      for (let i = 2; i < 4 * 9; i += 3) normals[i] = 1;
+
+      const buffer = build3MFBuffer(verts, normals, {
+        name: 'four-slots',
+        colorConfig: {
+          materials: [
+            { color: '#111111' },
+            { color: '#222222' },
+            { color: '#333333' },
+            { color: '#444444' },
+          ],
+          triangleMaterialIndices: [0, 1, 2, 3],
+        },
+      });
+      const model = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
+
+      // Slot 0 → no attribute; Slots 1..3 → "4", "8", "0C" per CONST_FILAMENTS
+      const codes = (model.match(/paint_color="([^"]+)"/g) ?? []).map((m) => m);
+      expect(codes).toContain('paint_color="4"');
+      expect(codes).toContain('paint_color="8"');
+      expect(codes).toContain('paint_color="0C"');
+      expect(codes).toHaveLength(3);
+    });
+
+    it('omits paint_color and namespace when colorConfig is absent', () => {
       const { vertices, normals } = createSingleTriangle();
       const buffer = build3MFBuffer(vertices, normals, { name: 'no-color' });
-      const files = unzipSync(buffer);
-      const model = strFromU8(files['3D/3dmodel.model']);
+      const model = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
 
+      expect(model).not.toContain('paint_color');
       expect(model).not.toContain('m:colorgroup');
       expect(model).not.toContain('pid=');
       expect(model).not.toContain('xmlns:m=');
       expect(model).not.toContain('requiredextensions=');
     });
 
-    it('omits m:colorgroup when colorConfig has empty materials', () => {
+    it('omits paint_color when colorConfig has empty materials', () => {
       const { vertices, normals } = createSingleTriangle();
       const buffer = build3MFBuffer(vertices, normals, {
         name: 'empty-color',
         colorConfig: { materials: [], triangleMaterialIndices: [] },
       });
-      const files = unzipSync(buffer);
-      const model = strFromU8(files['3D/3dmodel.model']);
+      const model = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
 
+      expect(model).not.toContain('paint_color');
       expect(model).not.toContain('m:colorgroup');
-      expect(model).not.toContain('pid=');
-      expect(model).not.toContain('xmlns:m=');
     });
 
     it('throws when triangleMaterialIndices length does not match triangle count', () => {
@@ -470,7 +498,7 @@ describe('threemfExporter', () => {
           name: 'mismatch',
           colorConfig: {
             materials: [{ color: '#ffffff' }],
-            triangleMaterialIndices: [0], // 1 entry for 2 triangles
+            triangleMaterialIndices: [0],
           },
         })
       ).toThrow(/triangleMaterialIndices length/);
@@ -483,10 +511,25 @@ describe('threemfExporter', () => {
           name: 'out-of-range',
           colorConfig: {
             materials: [{ color: '#ffffff' }],
-            triangleMaterialIndices: [0, 5], // index 5 with only 1 slot
+            triangleMaterialIndices: [0, 5],
           },
         })
       ).toThrow(/out of range/);
+    });
+
+    it('throws when materials count exceeds the slicer filament cap', () => {
+      const { vertices, normals } = createSingleTriangle();
+      // FILAMENT_PAINT_CODES has 17 entries (slots 0..16); 18 is the first
+      // count that lacks a code.
+      const tooMany = Array.from({ length: 18 }, (_, i) => ({
+        color: `#${i.toString(16).padStart(2, '0').repeat(3)}`,
+      }));
+      expect(() =>
+        build3MFBuffer(vertices, normals, {
+          name: 'too-many',
+          colorConfig: { materials: tooMany, triangleMaterialIndices: [0] },
+        })
+      ).toThrow(/exceeds slicer filament cap/);
     });
 
     it('throws on non-conformant hex color strings', () => {
@@ -513,15 +556,17 @@ describe('threemfExporter', () => {
 
     it('accepts #RRGGBBAA hex with alpha channel', () => {
       const { vertices, normals } = createSingleTriangle();
-      const buffer = build3MFBuffer(vertices, normals, {
-        name: 'alpha',
-        colorConfig: {
-          materials: [{ color: '#ff000080' }],
-          triangleMaterialIndices: [0],
-        },
-      });
-      const model = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
-      expect(model).toContain('<m:color color="#ff000080" />');
+      // No throw is sufficient; alpha hex is allowed even though slicers only
+      // honor RGB, because resolveColorMapping may emit alpha-tinted entries.
+      expect(() =>
+        build3MFBuffer(vertices, normals, {
+          name: 'alpha',
+          colorConfig: {
+            materials: [{ color: '#ff000080' }],
+            triangleMaterialIndices: [0],
+          },
+        })
+      ).not.toThrow();
     });
   });
 
@@ -557,7 +602,7 @@ describe('threemfExporter', () => {
       expect(model).toContain('objectid="3"');
     });
 
-    it('assigns sequential IDs with per-object color groups', () => {
+    it('assigns sequential IDs and embeds paint_color on the colored object only', () => {
       const tri = createSingleTriangle();
       const objects = [
         {
@@ -565,8 +610,8 @@ describe('threemfExporter', () => {
           normals: tri.normals,
           name: 'Colored Bin',
           colorConfig: {
-            materials: [{ color: '#ff0000' }],
-            triangleMaterialIndices: [0],
+            materials: [{ color: '#ff0000' }, { color: '#00ff00' }],
+            triangleMaterialIndices: [1],
           },
         },
         { vertices: tri.vertices, normals: tri.normals, name: 'Divider' },
@@ -574,13 +619,15 @@ describe('threemfExporter', () => {
       const buffer = build3MFMultiObjectBuffer(objects, { name: 'test' });
       const model = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
 
-      // colorgroup=1, colored object=2, plain object=3
-      expect(model).toContain('m:colorgroup id="1"');
+      // Without colorgroups, IDs are consecutive across objects.
+      expect(model).toContain('object id="1"');
       expect(model).toContain('object id="2"');
-      expect(model).toContain('object id="3"');
+      expect(model).toContain('objectid="1"');
       expect(model).toContain('objectid="2"');
-      expect(model).toContain('objectid="3"');
-      expect(model).toContain('xmlns:m=');
+      // Material index 1 → filament 1 → "4"
+      expect(model).toContain('paint_color="4"');
+      expect(model).not.toContain('m:colorgroup');
+      expect(model).not.toContain('xmlns:m=');
     });
 
     it('export3MFMultiObject produces a Blob with correct MIME', () => {

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -421,9 +421,9 @@ describe('threemfExporter', () => {
       });
       const model = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
 
-      // Material slot 0 → filament 0 = no paint_color attribute (default extruder)
+      // Slot 0 → no paint_color attribute (triangle inherits default extruder)
       expect(model).toMatch(/<triangle v1="\d+" v2="\d+" v3="\d+" \/>/);
-      // Material slot 1 → filament 1 → CONST_FILAMENTS[1] = "4"
+      // Slot 1 → paint_color="4" per CONST_FILAMENTS[1]
       expect(model).toMatch(/<triangle v1="\d+" v2="\d+" v3="\d+" paint_color="4" \/>/);
       // No legacy artifacts from the old colorgroup approach
       expect(model).not.toContain('pid=');
@@ -460,7 +460,7 @@ describe('threemfExporter', () => {
       const model = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
 
       // Slot 0 → no attribute; Slots 1..3 → "4", "8", "0C" per CONST_FILAMENTS
-      const codes = (model.match(/paint_color="([^"]+)"/g) ?? []).map((m) => m);
+      const codes = model.match(/paint_color="([^"]+)"/g) ?? [];
       expect(codes).toContain('paint_color="4"');
       expect(codes).toContain('paint_color="8"');
       expect(codes).toContain('paint_color="0C"');

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -264,7 +264,7 @@ function buildModelXML(mesh: IndexedMesh, options: ThreeMFOptions): string {
   const objectId = 1;
 
   let xml = openModelElement();
-  xml += buildMetadataXml(options);
+  xml += buildMetadataXml(options, { bambuCompat: !!colorConfig });
   xml += '  <resources>\n';
   xml += buildObjectXml(objectId, options.name, mesh, colorConfig?.triangleMaterialIndices);
   xml += '  </resources>\n';
@@ -314,8 +314,10 @@ function buildMultiObjectModelXML(
     return { ...obj, colorConfig };
   });
 
+  const anyHasColors = resolved.some((obj) => obj.colorConfig !== undefined);
+
   let xml = openModelElement();
-  xml += buildMetadataXml(options);
+  xml += buildMetadataXml(options, { bambuCompat: anyHasColors });
   xml += '  <resources>\n';
 
   const objectIds: number[] = [];
@@ -389,10 +391,31 @@ export const FILAMENT_PAINT_CODES = [
 ] as const;
 const MAX_COLOR_SLOTS = FILAMENT_PAINT_CODES.length;
 
-function buildMetadataXml(options: ThreeMFOptions): string {
+/**
+ * Version string we claim in the `Application` metadata. Must start with
+ * "BambuStudio-" to satisfy BambuStudio's gate (bbs_3mf.cpp:1898-1908) that
+ * decides whether to load our `project_settings.config` sidecar. Choosing
+ * `01.00.00.00` puts us well below any current BambuStudio version so the
+ * file_version <= app_version branch is taken — the slicer doesn't warn
+ * about a "newer 3mf version", and with config_loaded populated by our
+ * filament_colour list the "geometry only" branch is skipped too.
+ *
+ * OrcaSlicer's classifier also keys on this prefix and reclassifies us
+ * from `From_Other` (its silent path) to `From_BBS` — but its warning
+ * branch is also gated on config_loaded.empty(), so we stay silent there.
+ *
+ * PrusaSlicer reads this metadata into a String slot it doesn't act on.
+ */
+const BAMBU_COMPAT_APPLICATION = 'BambuStudio-01.00.00.00';
+
+function buildMetadataXml(options: ThreeMFOptions, flags: { bambuCompat: boolean }): string {
   let xml = `  <metadata name="Title">${escapeXml(options.name)}</metadata>\n`;
   xml += '  <metadata name="Designer">Gridfinity Layout Tool</metadata>\n';
   xml += `  <metadata name="CreationDate">${new Date().toISOString().split('T')[0]}</metadata>\n`;
+  if (flags.bambuCompat) {
+    xml += `  <metadata name="Application">${BAMBU_COMPAT_APPLICATION}</metadata>\n`;
+    xml += '  <metadata name="BambuStudio:3mfVersion">1</metadata>\n';
+  }
   const ps = options.printSettings;
   if (!ps) return xml;
   // 3MF Core §3.7: custom metadata names without a registered namespace prefix

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -343,11 +343,20 @@ function openModelElement(): string {
 }
 
 /**
- * Per-filament paint_color encoding table, lifted verbatim from OrcaSlicer's
- * `CONST_FILAMENTS` (libslic3r/Model.cpp). The string at index N is the
- * serialized TriangleSelector bit-tree for a leaf triangle entirely painted
- * with filament/extruder N (1-based). Index 0 is the empty string, meaning
- * "no override — use the object's default extruder."
+ * Per-slot paint_color encoding table, lifted verbatim from OrcaSlicer's
+ * `CONST_FILAMENTS` (libslic3r/Model.cpp). Indexed by the exporter's material
+ * slot number, not by slicer filament number:
+ *
+ *   - Index 0 → `""` (empty). Caller omits the attribute entirely so the
+ *     triangle inherits the object's default extruder. The body color is
+ *     always slot 0, so most triangles emit no paint_color.
+ *   - Index 1 → `"4"`, the bit-tree encoding for filament 1 in the slicer.
+ *   - Index 2 → `"8"`, filament 2. ...
+ *   - Index N → CONST_FILAMENTS[N], filament N.
+ *
+ * The off-by-one between "our slot" and "slicer filament" is intentional:
+ * slot 0 is special-cased to mean "no override" so a single-color export
+ * needs zero attribute writes and zero AMS slots claimed.
  *
  * PrusaSlicer reads the same `paint_color` attribute (3mf.cpp:2158) as a
  * fallback for its own `slic3rpe:mmu_segmentation`, so one emission path
@@ -355,8 +364,11 @@ function openModelElement(): string {
  * dropped because Orca explicitly ignores triangle `pid`/`p1` (bbs_3mf.cpp
  * comment lines 3805–3810) and treats each colorgroup as a single object
  * color, not a multi-slot palette.
+ *
+ * Exported so test code can decode `paint_color` back to slot indices
+ * without maintaining a duplicate copy of the table.
  */
-const FILAMENT_PAINT_CODES = [
+export const FILAMENT_PAINT_CODES = [
   '',
   '4',
   '8',

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -187,23 +187,12 @@ function buildModelXML(mesh: IndexedMesh, options: ThreeMFOptions): string {
     assertColorConfigShape(colorConfig, mesh.triangles.length);
   }
 
-  // IDs assigned in ascending document order per 3MF Core Spec §4.1.2;
-  // the colorgroup MUST precede the object that references it via pid.
-  const COLORGROUP_ID = 1;
-  const objectId = colorConfig ? 2 : 1;
+  const objectId = 1;
 
-  let xml = openModelElement(!!colorConfig);
+  let xml = openModelElement();
   xml += buildMetadataXml(options);
   xml += '  <resources>\n';
-  if (colorConfig) {
-    xml += buildColorGroupXml(COLORGROUP_ID, colorConfig.materials);
-  }
-  xml += buildObjectXml(
-    objectId,
-    options.name,
-    mesh,
-    colorConfig ? { id: COLORGROUP_ID, indices: colorConfig.triangleMaterialIndices } : null
-  );
+  xml += buildObjectXml(objectId, options.name, mesh, colorConfig?.triangleMaterialIndices);
   xml += '  </resources>\n';
   xml += '  <build>\n';
   xml += renderBuildItems(objectId, options.stack);
@@ -250,24 +239,17 @@ function buildMultiObjectModelXML(
     }
     return { ...obj, colorConfig };
   });
-  const anyHasColors = resolved.some((obj) => obj.colorConfig !== undefined);
 
-  let xml = openModelElement(anyHasColors);
+  let xml = openModelElement();
   xml += buildMetadataXml(options);
   xml += '  <resources>\n';
 
   const objectIds: number[] = [];
   let nextId = 1;
   for (const obj of resolved) {
-    let colorGroup: { id: number; indices: readonly number[] } | null = null;
-    if (obj.colorConfig) {
-      const colorGroupId = nextId++;
-      xml += buildColorGroupXml(colorGroupId, obj.colorConfig.materials);
-      colorGroup = { id: colorGroupId, indices: obj.colorConfig.triangleMaterialIndices };
-    }
     const objectId = nextId++;
     objectIds.push(objectId);
-    xml += buildObjectXml(objectId, obj.name, obj.mesh, colorGroup);
+    xml += buildObjectXml(objectId, obj.name, obj.mesh, obj.colorConfig?.triangleMaterialIndices);
   }
 
   xml += '  </resources>\n';
@@ -281,18 +263,45 @@ function buildMultiObjectModelXML(
 }
 
 const CORE_NS = 'http://schemas.microsoft.com/3dmanufacturing/core/2015/02';
-const MATERIAL_NS = 'http://schemas.microsoft.com/3dmanufacturing/material/2015/02';
+
+function openModelElement(): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<model unit="millimeter" xml:lang="en-US" xmlns="${CORE_NS}">\n`;
+}
 
 /**
- * The `m` materials extension is what BambuStudio/OrcaSlicer parse for their
- * "Standard 3MF Import Color" dialog — the 3MF Core `<basematerials>` element
- * is silently ignored by their parsers. Declare the extension only when we
- * actually emit color content, so single-color exports stay namespace-clean.
+ * Per-filament paint_color encoding table, lifted verbatim from OrcaSlicer's
+ * `CONST_FILAMENTS` (libslic3r/Model.cpp). The string at index N is the
+ * serialized TriangleSelector bit-tree for a leaf triangle entirely painted
+ * with filament/extruder N (1-based). Index 0 is the empty string, meaning
+ * "no override — use the object's default extruder."
+ *
+ * PrusaSlicer reads the same `paint_color` attribute (3mf.cpp:2158) as a
+ * fallback for its own `slic3rpe:mmu_segmentation`, so one emission path
+ * covers Bambu/Orca/Prusa. The Materials Extension `<m:colorgroup>` was
+ * dropped because Orca explicitly ignores triangle `pid`/`p1` (bbs_3mf.cpp
+ * comment lines 3805–3810) and treats each colorgroup as a single object
+ * color, not a multi-slot palette.
  */
-function openModelElement(hasColors: boolean): string {
-  const matNs = hasColors ? ` xmlns:m="${MATERIAL_NS}" requiredextensions="m"` : '';
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<model unit="millimeter" xml:lang="en-US" xmlns="${CORE_NS}"${matNs}>\n`;
-}
+const FILAMENT_PAINT_CODES = [
+  '',
+  '4',
+  '8',
+  '0C',
+  '1C',
+  '2C',
+  '3C',
+  '4C',
+  '5C',
+  '6C',
+  '7C',
+  '8C',
+  '9C',
+  'AC',
+  'BC',
+  'CC',
+  'DC',
+] as const;
+const MAX_COLOR_SLOTS = FILAMENT_PAINT_CODES.length;
 
 function buildMetadataXml(options: ThreeMFOptions): string {
   let xml = `  <metadata name="Title">${escapeXml(options.name)}</metadata>\n`;
@@ -317,20 +326,11 @@ function buildMetadataXml(options: ThreeMFOptions): string {
   return xml;
 }
 
-function buildColorGroupXml(id: number, materials: ThreeMFColorConfig['materials']): string {
-  let xml = `    <m:colorgroup id="${id}">\n`;
-  for (const mat of materials) {
-    xml += `      <m:color color="${escapeXml(mat.color)}" />\n`;
-  }
-  xml += '    </m:colorgroup>\n';
-  return xml;
-}
-
 function buildObjectXml(
   objectId: number,
   name: string,
   mesh: IndexedMesh,
-  colorGroup: { id: number; indices: readonly number[] } | null
+  triangleMaterialIndices: readonly number[] | undefined
 ): string {
   let xml = `    <object id="${objectId}" type="model" name="${escapeXml(name)}">\n`;
   xml += '      <mesh>\n        <vertices>\n';
@@ -338,11 +338,16 @@ function buildObjectXml(
     xml += `          <vertex x="${formatFloat(x)}" y="${formatFloat(y)}" z="${formatFloat(z)}" />\n`;
   }
   xml += '        </vertices>\n        <triangles>\n';
-  if (colorGroup) {
-    const { id, indices } = colorGroup;
+  if (triangleMaterialIndices) {
     for (let i = 0; i < mesh.triangles.length; i++) {
       const [v1, v2, v3] = mesh.triangles[i];
-      xml += `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${id}" p1="${indices[i]}" />\n`;
+      // Slot 0 (body) maps to filament 0 = "" = no paint_color attribute, so
+      // the triangle inherits the object's default extruder. Slots 1..N map
+      // to filaments 1..N with their matching bit-tree code.
+      const code = FILAMENT_PAINT_CODES[triangleMaterialIndices[i]];
+      xml += code
+        ? `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" paint_color="${code}" />\n`
+        : `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />\n`;
     }
   } else {
     for (const [v1, v2, v3] of mesh.triangles) {
@@ -365,10 +370,9 @@ function escapeXml(str: string): string {
 const HEX_COLOR_RE = /^#[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$/;
 
 /**
- * Materials Extension v1.0 requires `#RRGGBB` or `#RRGGBBAA` (sRGB hex with
- * leading `#`); `triangleMaterialIndices` must have exactly one entry per
- * triangle, each pointing at a valid color slot. Violations throw so that
- * out-of-range or missing entries can't silently ship as wrong colors.
+ * Validates color hex format and triangle index range. Caps at the size of
+ * OrcaSlicer's CONST_FILAMENTS table — going past it would emit a paint_color
+ * string the slicer can't decode.
  */
 function assertColorConfigShape(config: ThreeMFColorConfig, triangleCount: number): void {
   if (config.triangleMaterialIndices.length !== triangleCount) {
@@ -377,6 +381,11 @@ function assertColorConfigShape(config: ThreeMFColorConfig, triangleCount: numbe
     );
   }
   const slotCount = config.materials.length;
+  if (slotCount > MAX_COLOR_SLOTS) {
+    throw new Error(
+      `3MF color config: ${slotCount} colors exceeds slicer filament cap of ${MAX_COLOR_SLOTS}`
+    );
+  }
   for (let i = 0; i < config.triangleMaterialIndices.length; i++) {
     const idx = config.triangleMaterialIndices[i];
     if (!Number.isInteger(idx) || idx < 0 || idx >= slotCount) {

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -204,32 +204,48 @@ function activeColorConfig(c: ThreeMFColorConfig | undefined): ThreeMFColorConfi
 }
 
 /**
- * Collapse the materials lists from one or more color configs into a single
- * ordered hex palette. Across the multi-object path only the bin currently
- * carries a colorConfig, but if that ever changes we walk every object and
- * dedup by hex so the palette stays consistent with the per-triangle slot
- * indices each object emitted via its own paint_color codes.
+ * Resolve the palette emitted into `Metadata/project_settings.config` from one
+ * or more colorConfigs. Returns undefined when no palette would be emitted —
+ * single-color exports skip the sidecar entirely.
  *
- * Returns null when no palette would be emitted — single-color exports skip
- * the project_settings.config entirely (no warning to suppress; no AMS slots
- * to seed).
+ * **Invariant:** every colored object in a multi-object export must share the
+ * same materials array (same order, same colors). Per-triangle `paint_color`
+ * codes are object-local references into the object's own slot list, so two
+ * objects with differently-ordered palettes would resolve the same code to
+ * different filaments in the unified `filament_colour` list. Throws on
+ * mismatch rather than silently producing wrong colors. Today only the bin
+ * carries a colorConfig in the multi-object path, but locking down the
+ * invariant lets that change safely later.
  */
 function unifiedPalette(
   configs: readonly (ThreeMFColorConfig | undefined)[]
 ): readonly string[] | undefined {
-  const seen = new Set<string>();
-  const palette: string[] = [];
-  for (const c of configs) {
-    const active = activeColorConfig(c);
-    if (!active) continue;
-    for (const mat of active.materials) {
-      const hex = mat.color.toLowerCase();
-      if (seen.has(hex)) continue;
-      seen.add(hex);
-      palette.push(hex);
+  const actives = configs
+    .map(activeColorConfig)
+    .filter((c): c is ThreeMFColorConfig => c !== undefined);
+  if (actives.length === 0) return undefined;
+
+  const first = actives[0].materials;
+  for (let i = 1; i < actives.length; i++) {
+    if (!materialsMatch(first, actives[i].materials)) {
+      throw new Error(
+        '3MF multi-object: all colored objects must share the same materials array (same order, same colors); ' +
+          'per-object paint_color slot indices would otherwise misalign with the unified filament palette.'
+      );
     }
   }
-  return palette.length > 0 ? palette : undefined;
+  return first.map((m) => m.color.toLowerCase());
+}
+
+function materialsMatch(
+  a: ThreeMFColorConfig['materials'],
+  b: ThreeMFColorConfig['materials']
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].color.toLowerCase() !== b[i].color.toLowerCase()) return false;
+  }
+  return true;
 }
 
 /**
@@ -245,7 +261,12 @@ function unifiedPalette(
 function buildProjectSettingsConfig(palette: readonly string[]): string {
   return JSON.stringify(
     {
-      version: '1.0.0.0',
+      // Mirrors BAMBU_COMPAT_APPLICATION's version segment so the JSON
+      // metadata and the Application metadata agree on which "version" we
+      // claim. Bambu's load_from_json reads `version` into a key_values map
+      // but doesn't gate on it, so this is advisory; alignment is for human
+      // and round-trip-tool consistency.
+      version: '01.00.00.00',
       name: 'project_settings',
       from: 'Gridfinity Layout Tool',
       filament_colour: palette,

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -65,7 +65,11 @@ export function export3MFMultiObject(
   return new Blob([toArrayBuffer(buffer)], { type: THREEMF_MIME });
 }
 
-function packageFiles(modelXml: string, thumbnail: Uint8Array | undefined): Uint8Array {
+function packageFiles(
+  modelXml: string,
+  thumbnail: Uint8Array | undefined,
+  projectSettingsJson: string | undefined
+): Uint8Array {
   const hasThumbnail = !!thumbnail;
   const files: Record<string, Uint8Array> = {
     '[Content_Types].xml': strToU8(buildContentTypes(hasThumbnail)),
@@ -74,6 +78,14 @@ function packageFiles(modelXml: string, thumbnail: Uint8Array | undefined): Uint
   };
   if (thumbnail) {
     files['Metadata/thumbnail.png'] = thumbnail;
+  }
+  if (projectSettingsJson) {
+    // Bambu/Orca read this path via `_extract_project_config_from_archive`.
+    // Its mere presence (with any recognized config key) flips Bambu's
+    // `config_loaded.empty()` check, suppressing the "old version, geometry
+    // only" dialog (Plater.cpp:8127). The `filament_colour` payload doubles
+    // as a hint so the slicer's AMS slots open with our zone palette.
+    files['Metadata/project_settings.config'] = strToU8(projectSettingsJson);
   }
   return zipSync(files, { level: 6 });
 }
@@ -92,7 +104,12 @@ export function build3MFMultiObjectBuffer(
     colorConfig: obj.colorConfig,
   }));
 
-  return packageFiles(buildMultiObjectModelXML(meshes, options), options.thumbnail);
+  const palette = unifiedPalette(meshes.map((m) => m.colorConfig));
+  return packageFiles(
+    buildMultiObjectModelXML(meshes, options),
+    options.thumbnail,
+    palette && buildProjectSettingsConfig(palette)
+  );
 }
 
 export function build3MFBuffer(
@@ -102,7 +119,12 @@ export function build3MFBuffer(
 ): Uint8Array {
   validateMeshData(vertices, normals);
   const mesh = deduplicateVertices(vertices);
-  return packageFiles(buildModelXML(mesh, options), options.thumbnail);
+  const palette = unifiedPalette([options.colorConfig]);
+  return packageFiles(
+    buildModelXML(mesh, options),
+    options.thumbnail,
+    palette && buildProjectSettingsConfig(palette)
+  );
 }
 
 /**
@@ -179,6 +201,58 @@ function buildRelationships(hasThumbnail: boolean): string {
 
 function activeColorConfig(c: ThreeMFColorConfig | undefined): ThreeMFColorConfig | undefined {
   return c && c.materials.length > 0 ? c : undefined;
+}
+
+/**
+ * Collapse the materials lists from one or more color configs into a single
+ * ordered hex palette. Across the multi-object path only the bin currently
+ * carries a colorConfig, but if that ever changes we walk every object and
+ * dedup by hex so the palette stays consistent with the per-triangle slot
+ * indices each object emitted via its own paint_color codes.
+ *
+ * Returns null when no palette would be emitted — single-color exports skip
+ * the project_settings.config entirely (no warning to suppress; no AMS slots
+ * to seed).
+ */
+function unifiedPalette(
+  configs: readonly (ThreeMFColorConfig | undefined)[]
+): readonly string[] | undefined {
+  const seen = new Set<string>();
+  const palette: string[] = [];
+  for (const c of configs) {
+    const active = activeColorConfig(c);
+    if (!active) continue;
+    for (const mat of active.materials) {
+      const hex = mat.color.toLowerCase();
+      if (seen.has(hex)) continue;
+      seen.add(hex);
+      palette.push(hex);
+    }
+  }
+  return palette.length > 0 ? palette : undefined;
+}
+
+/**
+ * Minimal Bambu/Orca `project_settings.config` JSON. The slicer parses this
+ * via `ConfigBase::load_from_json` (Config.cpp:807); any recognized key
+ * flips `DynamicPrintConfig.empty()` to false, which is what gates the
+ * "geometry only" warning. `filament_colour` is the right key for our use
+ * case — `coStrings` per PrintConfig.cpp, displayed as the AMS slot colors.
+ *
+ * Headers (`version`, `name="project_settings"`, `from`) are read into a
+ * key_values map but are advisory: the loader doesn't gate on them.
+ */
+function buildProjectSettingsConfig(palette: readonly string[]): string {
+  return JSON.stringify(
+    {
+      version: '1.0.0.0',
+      name: 'project_settings',
+      from: 'Gridfinity Layout Tool',
+      filament_colour: palette,
+    },
+    null,
+    2
+  );
 }
 
 function buildModelXML(mesh: IndexedMesh, options: ThreeMFOptions): string {


### PR DESCRIPTION
## Summary

PR #1883 swapped the 3MF Core `<basematerials>` element for the Materials Extension `<m:colorgroup>` block — but slicers still don't pick up the colors. Source-level audit shows that approach can't work either, and the actual mechanism slicers use is a per-triangle `paint_color` attribute. This PR switches to it.

### Why #1883 doesn't work

**Slicers ignore triangle-level `pid`/`p1`.** OrcaSlicer `bbs_3mf.cpp:3805` and PrusaSlicer `3mf.cpp:2135` both have an identical comment: `// we are ignoring the following attributes: p1 p2 p3 pid`. The per-triangle wiring never reaches the parser.

**`<m:colorgroup>` is a single-color slot, not a palette.** OrcaSlicer's handler does `m_group_id_to_color[group_id] = color` — last-write-wins. Packing N colors into one group collapses to one extruder regardless of triangle attribution.

### What slicers actually read

Each `<triangle>` element gets a `paint_color="<code>"` attribute. The code is a serialized TriangleSelector leaf bit-tree, looked up in OrcaSlicer's `CONST_FILAMENTS` table (`Model.cpp:52`):

```
["", "4", "8", "0C", "1C", "2C", "3C", ..., "DC"]
```

PrusaSlicer accepts the same attribute as a fallback for its own `slic3rpe:mmu_segmentation` (`3mf.cpp:2158`), so one emission path covers Bambu, Orca, and Prusa.

### What changed

- Dropped the materials-extension namespace, `requiredextensions="m"`, and the `<m:colorgroup>` block — dead weight at best, and `requiredextensions` may have triggered "geometry only" fallbacks on slicers without full extension support.
- Inlined `FILAMENT_PAINT_CODES` (verbatim from `CONST_FILAMENTS`) and emit `paint_color="<code>"` per triangle.
- Slot 0 (body) omits the attribute so the triangle inherits the object's default extruder — keeps body color coupled to the user's first filament and trims XML for the most common slot.
- Capped material count at 17 (the table's length) with fail-fast validation.
- Tests rewritten to decode `paint_color` back to slot indices via `resolveColorMapping`, asserting the round-trip semantics independent of the wire format.

### Separate: the "older version" dialog

This PR fixes multi-color rendering. The "this 3mf was generated by an older version, geometry data will be loaded only" dialog is a **separate** signal, gated on the absence of `Metadata/model_settings.config` (Plater.cpp:6125). It does NOT discard `paint_color` data — it only suppresses slicer-config loading. Adding a populated `model_settings.config` to silence the dialog is a follow-up.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test:run` — 11874 passed / 3 skipped / 0 failed
- [x] Smoke render of a 4-color mesh produces clean XML: body triangle has no attribute; slots 1, 2, 3 emit `paint_color="4"`, `"8"`, `"0C"` respectively
- [ ] **Manual:** open the resulting 3MF in BambuStudio / OrcaSlicer / PrusaSlicer; confirm the dialog still appears (separate bug) but the triangles render with distinct extruder slots after dismissal