### PR TITLE
fix(export): drop BambuStudio identity claim - OrcaSlicer rejects it

### DIFF
--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -570,12 +570,16 @@ describe('threemfExporter', () => {
     });
   });
 
-  // Bambu/Orca read Metadata/project_settings.config via
-  // ConfigBase::load_from_json. Its presence flips DynamicPrintConfig.empty()
-  // to false, which suppresses BambuStudio's "old version, geometry only"
-  // dialog (Plater.cpp:8127). filament_colour also pre-fills the AMS slot
-  // palette with our zone colors.
-  describe('project_settings.config (Bambu warning suppression)', () => {
+  // Metadata/project_settings.config primes the slicer's filament palette
+  // via ConfigBase::load_from_json. OrcaSlicer loads it unconditionally and
+  // applies filament_colour to the AMS slots. BambuStudio gates loading on
+  // an "Application=BambuStudio-X.Y.Z" metadata claim we deliberately don't
+  // make (claiming BambuStudio identity caused OrcaSlicer's CLI to reject
+  // the file with a version-check error and the GUI to load a degraded
+  // placeholder). Net effect: Orca users get the AMS palette pre-filled;
+  // Bambu users dismiss a "not from Bambu Lab" dialog once but paint_color
+  // still applies because it lives on triangles in the model XML.
+  describe('project_settings.config (Orca AMS palette seeding)', () => {
     it('emits Metadata/project_settings.config when colorConfig has materials', () => {
       const { vertices, normals } = createTwoTriangles();
       const buffer = build3MFBuffer(vertices, normals, {
@@ -682,40 +686,37 @@ describe('threemfExporter', () => {
       expect(unzipSync(buffer)['Metadata/project_settings.config']).toBeUndefined();
     });
 
-    // BambuStudio gates project_settings.config loading on the Application
-    // metadata starting with "BambuStudio-" (bbs_3mf.cpp:1898). Without it,
-    // every sidecar is silently skipped with "already parsed or a directory
-    // or not supported" and the "old version, geometry only" dialog fires.
-    // OrcaSlicer has no such gate but is happy either way.
-    it('claims Application=BambuStudio-* when colorConfig is active', () => {
+    // We deliberately do NOT claim BambuStudio identity via `<metadata
+    // name="Application">BambuStudio-X.Y.Z</metadata>`. The earlier attempt
+    // backfired: OrcaSlicer's CLI rejected the file outright with
+    // "File Version 1.0.0.0 not supported by current cli version 2.3.1"
+    // (exit -24), and the GUI loaded a degraded placeholder that landed
+    // off-plate, showed as single color, and triggered downstream g-code
+    // path-out-of-bounds and relative-extruder errors. The cost of skipping
+    // the claim is the one-time "the 3mf is not from Bambu Lab, load
+    // geometry data and color data only" dialog in BambuStudio — which is
+    // dismissible and does NOT block paint_color loading (paint_color is on
+    // triangles in the model XML, parsed independently of project config).
+    it('does not claim BambuStudio identity for multi-color exports', () => {
       const { vertices, normals } = createTwoTriangles();
-      const buffer = build3MFBuffer(vertices, normals, {
-        name: 'bambu-compat',
-        colorConfig: {
-          materials: [{ color: '#aaaaaa' }, { color: '#ff0000' }],
-          triangleMaterialIndices: [0, 1],
-        },
-      });
-      const model = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
-      expect(model).toMatch(
-        /<metadata name="Application">BambuStudio-\d+\.\d+\.\d+\.\d+<\/metadata>/
-      );
-      expect(model).toContain('<metadata name="BambuStudio:3mfVersion">1</metadata>');
-      // Keep our human-readable identity too — Designer is unrelated to the
-      // BambuStudio gate.
-      expect(model).toContain('<metadata name="Designer">Gridfinity Layout Tool</metadata>');
-    });
-
-    it('omits Application metadata for single-color exports', () => {
-      const { vertices, normals } = createSingleTriangle();
       const model = strFromU8(
-        unzipSync(build3MFBuffer(vertices, normals, { name: 'plain' }))['3D/3dmodel.model']
+        unzipSync(
+          build3MFBuffer(vertices, normals, {
+            name: 'multi',
+            colorConfig: {
+              materials: [{ color: '#aaaaaa' }, { color: '#ff0000' }],
+              triangleMaterialIndices: [0, 1],
+            },
+          })
+        )['3D/3dmodel.model']
       );
       expect(model).not.toContain('<metadata name="Application">');
       expect(model).not.toContain('BambuStudio:3mfVersion');
+      // Designer metadata is unaffected — that's our human-readable identity.
+      expect(model).toContain('<metadata name="Designer">Gridfinity Layout Tool</metadata>');
     });
 
-    it('multi-object: emits BambuStudio Application metadata when any object has colorConfig', () => {
+    it('multi-object: still does not claim BambuStudio identity even with colored objects', () => {
       const tri = createSingleTriangle();
       const objects = [
         {
@@ -731,23 +732,6 @@ describe('threemfExporter', () => {
       ];
       const model = strFromU8(
         unzipSync(build3MFMultiObjectBuffer(objects, { name: 'multi-bambu' }))['3D/3dmodel.model']
-      );
-      expect(model).toContain('<metadata name="Application">BambuStudio-');
-      expect(model).toContain('<metadata name="BambuStudio:3mfVersion">1</metadata>');
-    });
-
-    it('multi-object: omits Application metadata when no object has colorConfig', () => {
-      const tri = createSingleTriangle();
-      const model = strFromU8(
-        unzipSync(
-          build3MFMultiObjectBuffer(
-            [
-              { vertices: tri.vertices, normals: tri.normals, name: 'a' },
-              { vertices: tri.vertices, normals: tri.normals, name: 'b' },
-            ],
-            { name: 'multi-plain' }
-          )
-        )['3D/3dmodel.model']
       );
       expect(model).not.toContain('<metadata name="Application">');
       expect(model).not.toContain('BambuStudio:3mfVersion');

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -80,11 +80,15 @@ function packageFiles(
     files['Metadata/thumbnail.png'] = thumbnail;
   }
   if (projectSettingsJson) {
-    // Bambu/Orca read this path via `_extract_project_config_from_archive`.
-    // Its mere presence (with any recognized config key) flips Bambu's
-    // `config_loaded.empty()` check, suppressing the "old version, geometry
-    // only" dialog (Plater.cpp:8127). The `filament_colour` payload doubles
-    // as a hint so the slicer's AMS slots open with our zone palette.
+    // OrcaSlicer reads this via `_extract_project_config_from_archive` and
+    // applies `filament_colour` to its AMS slots — so the user opens the
+    // file with the bin's zone palette already pre-filled. BambuStudio
+    // gates the same loader on an "Application=BambuStudio-X.Y.Z" metadata
+    // claim that we deliberately don't make (claiming it caused OrcaSlicer
+    // to reject the file in a version check). Bambu users will see a
+    // dismissible "not from Bambu Lab" dialog and set their AMS palette
+    // manually; paint_color triangle painting still applies because that
+    // lives in the model XML and parses independently of project config.
     files['Metadata/project_settings.config'] = strToU8(projectSettingsJson);
   }
   return zipSync(files, { level: 6 });
@@ -261,12 +265,10 @@ function materialsMatch(
 function buildProjectSettingsConfig(palette: readonly string[]): string {
   return JSON.stringify(
     {
-      // Mirrors BAMBU_COMPAT_APPLICATION's version segment so the JSON
-      // metadata and the Application metadata agree on which "version" we
-      // claim. Bambu's load_from_json reads `version` into a key_values map
-      // but doesn't gate on it, so this is advisory; alignment is for human
-      // and round-trip-tool consistency.
-      version: '01.00.00.00',
+      // Headers are advisory — Bambu's load_from_json stores them in a
+      // key_values map but doesn't gate on them. Generic version is fine
+      // since we no longer claim BambuStudio identity.
+      version: '1.0.0.0',
       name: 'project_settings',
       from: 'Gridfinity Layout Tool',
       filament_colour: palette,
@@ -285,7 +287,7 @@ function buildModelXML(mesh: IndexedMesh, options: ThreeMFOptions): string {
   const objectId = 1;
 
   let xml = openModelElement();
-  xml += buildMetadataXml(options, { bambuCompat: !!colorConfig });
+  xml += buildMetadataXml(options);
   xml += '  <resources>\n';
   xml += buildObjectXml(objectId, options.name, mesh, colorConfig?.triangleMaterialIndices);
   xml += '  </resources>\n';
@@ -335,10 +337,8 @@ function buildMultiObjectModelXML(
     return { ...obj, colorConfig };
   });
 
-  const anyHasColors = resolved.some((obj) => obj.colorConfig !== undefined);
-
   let xml = openModelElement();
-  xml += buildMetadataXml(options, { bambuCompat: anyHasColors });
+  xml += buildMetadataXml(options);
   xml += '  <resources>\n';
 
   const objectIds: number[] = [];
@@ -412,31 +412,10 @@ export const FILAMENT_PAINT_CODES = [
 ] as const;
 const MAX_COLOR_SLOTS = FILAMENT_PAINT_CODES.length;
 
-/**
- * Version string we claim in the `Application` metadata. Must start with
- * "BambuStudio-" to satisfy BambuStudio's gate (bbs_3mf.cpp:1898-1908) that
- * decides whether to load our `project_settings.config` sidecar. Choosing
- * `01.00.00.00` puts us well below any current BambuStudio version so the
- * file_version <= app_version branch is taken — the slicer doesn't warn
- * about a "newer 3mf version", and with config_loaded populated by our
- * filament_colour list the "geometry only" branch is skipped too.
- *
- * OrcaSlicer's classifier also keys on this prefix and reclassifies us
- * from `From_Other` (its silent path) to `From_BBS` — but its warning
- * branch is also gated on config_loaded.empty(), so we stay silent there.
- *
- * PrusaSlicer reads this metadata into a String slot it doesn't act on.
- */
-const BAMBU_COMPAT_APPLICATION = 'BambuStudio-01.00.00.00';
-
-function buildMetadataXml(options: ThreeMFOptions, flags: { bambuCompat: boolean }): string {
+function buildMetadataXml(options: ThreeMFOptions): string {
   let xml = `  <metadata name="Title">${escapeXml(options.name)}</metadata>\n`;
   xml += '  <metadata name="Designer">Gridfinity Layout Tool</metadata>\n';
   xml += `  <metadata name="CreationDate">${new Date().toISOString().split('T')[0]}</metadata>\n`;
-  if (flags.bambuCompat) {
-    xml += `  <metadata name="Application">${BAMBU_COMPAT_APPLICATION}</metadata>\n`;
-    xml += '  <metadata name="BambuStudio:3mfVersion">1</metadata>\n';
-  }
   const ps = options.printSettings;
   if (!ps) return xml;
   // 3MF Core §3.7: custom metadata names without a registered namespace prefix


### PR DESCRIPTION
## Summary

PR #1885's `Application=BambuStudio-01.00.00.00` metadata broke multi-color exports in OrcaSlicer. Users hit a cascade of failures within hours of the merge:

- Bin positioned outside the plate boundary, with an error overlay
- Only a single color displayed instead of the 4-slot palette
- G-code path traveling beyond plate bounds  
- "Relative extruder addressing requires resetting the extruder position at each layer" error on slice

All four symptoms trace to the same root cause: **OrcaSlicer's CLI rejects our claimed version outright** with `File Version 1.0.0.0 not supported by current cli version 2.3.1` (exit code -24). The GUI is more lenient but loads a degraded placeholder — explaining every downstream failure.

## Fix

Drop the `<metadata name="Application">BambuStudio-...</metadata>` claim and the `<metadata name="BambuStudio:3mfVersion">1</metadata>` companion. Keep `Metadata/project_settings.config` (still loads cleanly in Orca and pre-fills the AMS palette).

## Trade-off

OrcaSlicer goes back to classifying our file as `From_Other`:

- ✅ Silent load (no version-check rejection, no dialog)
- ✅ Auto-arrange places the bin sensibly on the plate
- ✅ Multi-color via `paint_color` triangles works fully
- ✅ AMS palette pre-filled from `project_settings.config` — verified via CLI:
  ```
  project filament colors size 2
  project filament 0 original color #aaaaaa
  project filament 1 original color #ff0000
  ```

BambuStudio's `dont_load_config` gate fires again without the BambuStudio identity claim:

- ⚠️ One-time dismissible "the 3mf is not from Bambu Lab, load geometry data and color data only" dialog returns
- ✅ Paint_color triangle painting still applies because it lives in the model XML (parsed independently of project config)
- ⚠️ AMS palette not pre-filled — user sets filament colors manually in Bambu

PrusaSlicer unchanged.

## Test plan

- [x] Targeted tests pass (79)
- [x] OrcaSlicer CLI accepts the file with no version error; loads filament_colour correctly
- [ ] **Manual:** open the exported multi-color 3MF in OrcaSlicer; confirm bin lands on the plate, multi-color displays in the AMS slot palette, slice runs without the relative-extruder error