### PR TITLE
fix(export): satisfy OrcaSlicer multi-material slice validation (G92 E0)

### DIFF
--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -600,6 +600,27 @@ describe('threemfExporter', () => {
       expect(config.filament_colour).toEqual(['#aaaaaa', '#ff0000']);
     });
 
+    // Print.cpp:1683-1689 — OrcaSlicer's slice validation rejects
+    // multi-material prints on non-Bambu Marlin printers unless the project
+    // has relative extruder addressing AND a G92 E0 reset in the layer
+    // gcode. Setting both here makes multi-color exports slice on first try
+    // without surfacing the validation error to the user.
+    it('includes multi-material slice requirements (relative E + G92 E0)', () => {
+      const { vertices, normals } = createTwoTriangles();
+      const buffer = build3MFBuffer(vertices, normals, {
+        name: 'mm-slice',
+        colorConfig: {
+          materials: [{ color: '#aaaaaa' }, { color: '#ff0000' }],
+          triangleMaterialIndices: [0, 1],
+        },
+      });
+      const config = JSON.parse(strFromU8(unzipSync(buffer)['Metadata/project_settings.config']));
+      expect(config.use_relative_e_distances).toBe('1');
+      // Must match the regex slicer uses to detect the reset:
+      // ^[ \t]*[gG]92[ \t]*[eE](0(\.0*)?|\.0+)[ \t]*(;.*)?$
+      expect(config.layer_change_gcode).toMatch(/^\s*G92\s*E0\b/);
+    });
+
     it('omits project_settings.config when no colorConfig is provided', () => {
       const { vertices, normals } = createSingleTriangle();
       const buffer = build3MFBuffer(vertices, normals, { name: 'plain' });

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -271,7 +271,31 @@ function buildProjectSettingsConfig(palette: readonly string[]): string {
       version: '1.0.0.0',
       name: 'project_settings',
       from: 'Gridfinity Layout Tool',
+
       filament_colour: palette,
+
+      // Multi-material printing on non-Bambu Marlin-based printers
+      // (OrcaSlicer's `is_BBL_printer() == false` branch in Print.cpp:1679)
+      // imposes two coupled requirements that the user hits as validation
+      // errors during slice:
+      //
+      //   1. Print.cpp:1434 — the wipe tower (needed to clean the nozzle
+      //      between filament swaps) "is currently only supported with
+      //      relative extruder addressing (use_relative_e_distances=1)".
+      //   2. Print.cpp:1683-1689 — relative extruder addressing then
+      //      requires a `G92 E0` reset in `before_layer_change_gcode` or
+      //      `layer_change_gcode`, because "relative extruder addressing
+      //      requires resetting the extruder position at each layer to
+      //      prevent loss of floating point accuracy."
+      //
+      // Set both so multi-color exports slice without surfacing this
+      // validation error to the user. Bambu users skip the check entirely
+      // (Bambu printers have native multi-material handling) so the
+      // settings are harmless there. Users with a custom layer_change_gcode
+      // will see ours override theirs on import — a small price for the
+      // alternative of every multi-color export failing to slice on first try.
+      use_relative_e_distances: '1',
+      layer_change_gcode: 'G92 E0 ; Reset extruder for accurate multi-material\n',
     },
     null,
     2


### PR DESCRIPTION
## Summary

After #1887 fixed the OrcaSlicer rejection, users hit a downstream slice-time validation:

> Relative extruder addressing requires resetting the extruder position at each layer to prevent loss of floating point accuracy. Add "G92 E0" to layer_gcode.

Source: `Print.cpp:1683-1689`. Fires on non-Bambu Marlin printers when `use_relative_e_distances=true` and neither `before_layer_change_gcode` nor `layer_change_gcode` contains a `G92 E0` reset.

## Why we can't dodge it

Relative extruder mode is not optional for multi-material: `Print.cpp:1434` requires it for the wipe tower, which itself is needed to clean the nozzle between filament swaps. So the only valid path is to satisfy both halves of the constraint.

## Fix

Add to `Metadata/project_settings.config`:

```json
"use_relative_e_distances": "1",
"layer_change_gcode": "G92 E0 ; Reset extruder for accurate multi-material\n"
```

Bambu printers bypass this validator entirely (`is_BBL_printer()` guard), so the settings are harmless on Bambu — they just become the project's defaults. Users with a custom `layer_change_gcode` will see ours override theirs on import; acceptable trade vs. every multi-color export failing to slice on first try.

## Test plan

- [x] Targeted tests pass (80, +1 for the new config keys)
- [x] Orca CLI verifies project config loads cleanly, both filament colors applied
- [ ] **Manual:** export a multi-color 3MF, open in OrcaSlicer with a multi-extruder Marlin profile, slice — should complete without the G92 E0 validation error