### PR TITLE
fix(export): off-by-one collapsed body+lip onto the same AMS slot

### DIFF
--- a/src/features/bin-designer/utils/multicolorRoundTrip.test.ts
+++ b/src/features/bin-designer/utils/multicolorRoundTrip.test.ts
@@ -89,14 +89,18 @@ async function blobToModelXml(blob: Blob): Promise<string> {
 
 /**
  * Decode a paint_color attribute back to a material slot index using the
- * live FILAMENT_PAINT_CODES from the exporter — keeping the test pinned to
- * the same table the production code emits.
+ * live FILAMENT_PAINT_CODES from the exporter. The exporter maps slot N to
+ * `FILAMENT_PAINT_CODES[N + 1]` so decoding subtracts 1 to recover the slot.
+ * `code === undefined` (no paint_color attribute) shouldn't appear in any
+ * colored export — colorConfig'd objects emit paint_color on every triangle.
  */
 function slotFromCode(code: string | undefined): number {
-  if (code === undefined) return 0; // missing attribute → slot 0 (body)
+  if (code === undefined) {
+    throw new Error('paint_color missing on triangle of a colored export — expected explicit code');
+  }
   const idx = FILAMENT_PAINT_CODES.indexOf(code as (typeof FILAMENT_PAINT_CODES)[number]);
-  if (idx < 0) throw new Error(`unknown paint_color code: ${code}`);
-  return idx;
+  if (idx <= 0) throw new Error(`unknown paint_color code: ${code}`);
+  return idx - 1;
 }
 
 /** Material slot per triangle in document order. */

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -410,7 +410,7 @@ describe('threemfExporter', () => {
   // multi-material assignment. The encoding string for each filament slot is the
   // serialized TriangleSelector bit-tree, lifted from OrcaSlicer Model.cpp:52.
   describe('multi-color paint_color', () => {
-    it('emits paint_color on triangles whose material index ≠ 0', () => {
+    it('emits explicit paint_color on every triangle (slot N → filament N+1)', () => {
       const { vertices, normals } = createTwoTriangles();
       const buffer = build3MFBuffer(vertices, normals, {
         name: 'color-test',
@@ -421,11 +421,17 @@ describe('threemfExporter', () => {
       });
       const model = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
 
-      // Slot 0 → no paint_color attribute (triangle inherits default extruder)
-      expect(model).toMatch(/<triangle v1="\d+" v2="\d+" v3="\d+" \/>/);
-      // Slot 1 → paint_color="4" per CONST_FILAMENTS[1]
+      // Slot 0 (body) → filament 1 → CONST_FILAMENTS[1] = "4".
+      // Slot 1 → filament 2 → CONST_FILAMENTS[2] = "8".
+      // Both explicit so body and lip land on DIFFERENT AMS slots — the
+      // alternative (omitting the attribute for slot 0) lets body collapse
+      // onto whatever the object's default extruder is, which is also
+      // typically filament 1, making slot-1 paint_color="4" indistinguishable.
       expect(model).toMatch(/<triangle v1="\d+" v2="\d+" v3="\d+" paint_color="4" \/>/);
-      // No legacy artifacts from the old colorgroup approach
+      expect(model).toMatch(/<triangle v1="\d+" v2="\d+" v3="\d+" paint_color="8" \/>/);
+      // No triangle ships without paint_color when a colorConfig is present.
+      expect(model).not.toMatch(/<triangle v1="\d+" v2="\d+" v3="\d+" \/>/);
+      // No legacy artifacts from the old colorgroup approach.
       expect(model).not.toContain('pid=');
       expect(model).not.toContain('p1=');
       expect(model).not.toContain('m:colorgroup');
@@ -433,9 +439,9 @@ describe('threemfExporter', () => {
       expect(model).not.toContain('requiredextensions=');
     });
 
-    it('emits the correct paint_color code for each filament slot', () => {
-      // Build a 4-triangle mesh, one triangle per material slot, to exercise
-      // every entry of FILAMENT_PAINT_CODES that's likely to ship in a bin.
+    it('emits the correct paint_color code for each material slot', () => {
+      // 4 triangles, one per slot, exercises the +1 shift in
+      // FILAMENT_PAINT_CODES[slot + 1] across the slots a typical bin uses.
       const verts = new Float32Array(4 * 9);
       for (let i = 0; i < 4; i++) {
         const base = i * 9;
@@ -459,12 +465,14 @@ describe('threemfExporter', () => {
       });
       const model = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
 
-      // Slot 0 → no attribute; Slots 1..3 → "4", "8", "0C" per CONST_FILAMENTS
+      // Slots 0..3 → filaments 1..4 → "4", "8", "0C", "1C".
       const codes = model.match(/paint_color="([^"]+)"/g) ?? [];
-      expect(codes).toContain('paint_color="4"');
-      expect(codes).toContain('paint_color="8"');
-      expect(codes).toContain('paint_color="0C"');
-      expect(codes).toHaveLength(3);
+      expect(codes).toEqual([
+        'paint_color="4"',
+        'paint_color="8"',
+        'paint_color="0C"',
+        'paint_color="1C"',
+      ]);
     });
 
     it('omits paint_color and namespace when colorConfig is absent', () => {
@@ -519,9 +527,10 @@ describe('threemfExporter', () => {
 
     it('throws when materials count exceeds the slicer filament cap', () => {
       const { vertices, normals } = createSingleTriangle();
-      // FILAMENT_PAINT_CODES has 17 entries (slots 0..16); 18 is the first
-      // count that lacks a code.
-      const tooMany = Array.from({ length: 18 }, (_, i) => ({
+      // Slot N maps to FILAMENT_PAINT_CODES[N+1]; the table has 17 entries
+      // so the highest valid slot is 15 (→ index 16 = "DC"). 17 slots
+      // (highest = 16, index 17) is the first count without a code.
+      const tooMany = Array.from({ length: 17 }, (_, i) => ({
         color: `#${i.toString(16).padStart(2, '0').repeat(3)}`,
       }));
       expect(() =>
@@ -813,8 +822,8 @@ describe('threemfExporter', () => {
       expect(model).toContain('object id="2"');
       expect(model).toContain('objectid="1"');
       expect(model).toContain('objectid="2"');
-      // Material index 1 → filament 1 → "4"
-      expect(model).toContain('paint_color="4"');
+      // Material slot 1 → filament 2 → "8" (slot N maps to FILAMENT_PAINT_CODES[N+1])
+      expect(model).toContain('paint_color="8"');
       expect(model).not.toContain('m:colorgroup');
       expect(model).not.toContain('xmlns:m=');
     });

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -600,6 +600,27 @@ describe('threemfExporter', () => {
       expect(config.filament_colour).toEqual(['#aaaaaa', '#ff0000']);
     });
 
+    // Print.cpp:1683-1689 — OrcaSlicer's slice validation rejects
+    // multi-material prints on non-Bambu Marlin printers unless the project
+    // has relative extruder addressing AND a G92 E0 reset in the layer
+    // gcode. Setting both here makes multi-color exports slice on first try
+    // without surfacing the validation error to the user.
+    it('includes multi-material slice requirements (relative E + G92 E0)', () => {
+      const { vertices, normals } = createTwoTriangles();
+      const buffer = build3MFBuffer(vertices, normals, {
+        name: 'mm-slice',
+        colorConfig: {
+          materials: [{ color: '#aaaaaa' }, { color: '#ff0000' }],
+          triangleMaterialIndices: [0, 1],
+        },
+      });
+      const config = JSON.parse(strFromU8(unzipSync(buffer)['Metadata/project_settings.config']));
+      expect(config.use_relative_e_distances).toBe('1');
+      // Must match the regex slicer uses to detect the reset:
+      // ^[ \t]*[gG]92[ \t]*[eE](0(\.0*)?|\.0+)[ \t]*(;.*)?$
+      expect(config.layer_change_gcode).toMatch(/^\s*G92\s*E0\b/);
+    });
+
     it('omits project_settings.config when no colorConfig is provided', () => {
       const { vertices, normals } = createSingleTriangle();
       const buffer = build3MFBuffer(vertices, normals, { name: 'plain' });

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -271,7 +271,31 @@ function buildProjectSettingsConfig(palette: readonly string[]): string {
       version: '1.0.0.0',
       name: 'project_settings',
       from: 'Gridfinity Layout Tool',
+
       filament_colour: palette,
+
+      // Multi-material printing on non-Bambu Marlin-based printers
+      // (OrcaSlicer's `is_BBL_printer() == false` branch in Print.cpp:1679)
+      // imposes two coupled requirements that the user hits as validation
+      // errors during slice:
+      //
+      //   1. Print.cpp:1434 — the wipe tower (needed to clean the nozzle
+      //      between filament swaps) "is currently only supported with
+      //      relative extruder addressing (use_relative_e_distances=1)".
+      //   2. Print.cpp:1683-1689 — relative extruder addressing then
+      //      requires a `G92 E0` reset in `before_layer_change_gcode` or
+      //      `layer_change_gcode`, because "relative extruder addressing
+      //      requires resetting the extruder position at each layer to
+      //      prevent loss of floating point accuracy."
+      //
+      // Set both so multi-color exports slice without surfacing this
+      // validation error to the user. Bambu users skip the check entirely
+      // (Bambu printers have native multi-material handling) so the
+      // settings are harmless there. Users with a custom layer_change_gcode
+      // will see ours override theirs on import — a small price for the
+      // alternative of every multi-color export failing to slice on first try.
+      use_relative_e_distances: '1',
+      layer_change_gcode: 'G92 E0 ; Reset extruder for accurate multi-material\n',
     },
     null,
     2

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -390,20 +390,22 @@ function openModelElement(): string {
 }
 
 /**
- * Per-slot paint_color encoding table, lifted verbatim from OrcaSlicer's
- * `CONST_FILAMENTS` (libslic3r/Model.cpp). Indexed by the exporter's material
- * slot number, not by slicer filament number:
+ * Per-filament paint_color encoding table, lifted verbatim from OrcaSlicer's
+ * `CONST_FILAMENTS` (libslic3r/Model.cpp). Index N is the bit-tree code for
+ * filament N (1-based) in the slicer's AMS / extruder list:
  *
- *   - Index 0 → `""` (empty). Caller omits the attribute entirely so the
- *     triangle inherits the object's default extruder. The body color is
- *     always slot 0, so most triangles emit no paint_color.
- *   - Index 1 → `"4"`, the bit-tree encoding for filament 1 in the slicer.
- *   - Index 2 → `"8"`, filament 2. ...
- *   - Index N → CONST_FILAMENTS[N], filament N.
+ *   - Index 0 → `""` (no filament; means "no override / default extruder").
+ *     Not used by our exporter — every triangle gets an explicit code so
+ *     zone-to-filament mapping doesn't depend on the object's default
+ *     extruder setting.
+ *   - Index 1 → `"4"`, filament 1.
+ *   - Index 2 → `"8"`, filament 2.
+ *   - Index 3 → `"0C"`, filament 3. ...
  *
- * The off-by-one between "our slot" and "slicer filament" is intentional:
- * slot 0 is special-cased to mean "no override" so a single-color export
- * needs zero attribute writes and zero AMS slots claimed.
+ * Exporter mapping: material slot N (our 0-based slot index in
+ * `colorConfig.materials`) → filament N+1 (slicer 1-based) →
+ * `FILAMENT_PAINT_CODES[N+1]`. So slot 0 (body) → `"4"` (filament 1),
+ * slot 1 → `"8"` (filament 2), etc.
  *
  * PrusaSlicer reads the same `paint_color` attribute (3mf.cpp:2158) as a
  * fallback for its own `slic3rpe:mmu_segmentation`, so one emission path
@@ -412,7 +414,7 @@ function openModelElement(): string {
  * comment lines 3805–3810) and treats each colorgroup as a single object
  * color, not a multi-slot palette.
  *
- * Exported so test code can decode `paint_color` back to slot indices
+ * Exported so test code can decode `paint_color` back to filament indices
  * without maintaining a duplicate copy of the table.
  */
 export const FILAMENT_PAINT_CODES = [
@@ -434,7 +436,8 @@ export const FILAMENT_PAINT_CODES = [
   'CC',
   'DC',
 ] as const;
-const MAX_COLOR_SLOTS = FILAMENT_PAINT_CODES.length;
+// One fewer than the table size because we index `[slot + 1]` (slot 0 = filament 1).
+const MAX_COLOR_SLOTS = FILAMENT_PAINT_CODES.length - 1;
 
 function buildMetadataXml(options: ThreeMFOptions): string {
   let xml = `  <metadata name="Title">${escapeXml(options.name)}</metadata>\n`;
@@ -474,13 +477,18 @@ function buildObjectXml(
   if (triangleMaterialIndices) {
     for (let i = 0; i < mesh.triangles.length; i++) {
       const [v1, v2, v3] = mesh.triangles[i];
-      // Slot 0 (body) maps to filament 0 = "" = no paint_color attribute, so
-      // the triangle inherits the object's default extruder. Slots 1..N map
-      // to filaments 1..N with their matching bit-tree code.
-      const code = FILAMENT_PAINT_CODES[triangleMaterialIndices[i]];
-      xml += code
-        ? `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" paint_color="${code}" />\n`
-        : `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />\n`;
+      // Map material slot N to filament N+1 in the slicer (1-based) so each
+      // zone lands on its own AMS slot — slot 0 → "4" (filament 1, body),
+      // slot 1 → "8" (filament 2, lip), slot 2 → "0C" (filament 3), etc.
+      // Earlier passes omitted paint_color for slot 0 intending to fall
+      // through to the object's default extruder, but the default IS filament
+      // 1, so body (no attribute) and lip (paint_color="4" = filament 1)
+      // collapsed onto the same physical filament — making 4-zone exports
+      // appear as 2 colors in the slicer. Explicit attribute for every
+      // triangle decouples zone-to-filament mapping from the default-extruder
+      // setting, which the user can re-set per object without color drift.
+      const code = FILAMENT_PAINT_CODES[triangleMaterialIndices[i] + 1];
+      xml += `          <triangle v1="${v1}" v2="${v2}" v3="${v3}" paint_color="${code}" />\n`;
     }
   } else {
     for (const [v1, v2, v3] of mesh.triangles) {


### PR DESCRIPTION
## Summary

Direct cause of the "I only see one color in Bambu" symptom users hit after #1887 + #1889 landed. Body and the first-after-body zone were both rendering on filament 1, so a 4-zone bin appeared with at most 2 distinct colors.

## The bug

Previous mapping: slot N → `FILAMENT_PAINT_CODES[N]`, with slot 0 (body) emitting **no** `paint_color` attribute so the triangle would inherit the object's default extruder. The default extruder is filament 1, so body triangles rendered on filament 1.

But slot 1 (the first non-body zone) emitted `paint_color="4"` — and `"4"` in OrcaSlicer's `CONST_FILAMENTS` encoding ALSO means filament 1. Body and lip both landed on the same physical AMS slot.

## Fix

Explicit `paint_color` on **every** triangle, mapping slot N → `FILAMENT_PAINT_CODES[N + 1]`:

| Material slot | paint_color | Filament |
|---|---|---|
| 0 (body) | `"4"` | 1 |
| 1 (lip) | `"8"` | 2 |
| 2 (base) | `"0C"` | 3 |
| 3 (text) | `"1C"` | 4 |
| ... | ... | ... |

Each zone now lands on its own AMS slot regardless of the object's default-extruder setting. Cap adjusted: `MAX_COLOR_SLOTS = FILAMENT_PAINT_CODES.length - 1 = 16` (the table is 17 entries; we never index past `[slot + 1] = [16]`).

## Test plan

- [x] Targeted tests pass (80, including a new explicit assertion that slots 0..3 emit codes `"4"`, `"8"`, `"0C"`, `"1C"` in that order)
- [x] Smoke-rendered a 4-color bin and confirmed each zone has a distinct `paint_color` code in the XML
- [ ] **Manual:** export a multi-color bin with ≥3 distinct zone colors, open in OrcaSlicer/BambuStudio, confirm 3+ distinct colors appear in the AMS palette (rather than the current 1–2)

## Note on the "is this overcomplicated?" question

Yes, and I'll address it candidly in the next response. Short version: the format genuinely is this fragmented (each slicer has its own per-triangle painting attribute, no spec agreement), but a lot of the layered fixes are us *automating* slicer-side setup that users could do manually. If you want, I can revert the `project_settings.config` and `use_relative_e_distances` automation in a follow-up and ship just the paint_color primitive — fewer surprises, more user setup.