### PR TITLE
fix(export): pre-fill AMS palette for multi-color 3MFs in BambuStudio

### DIFF
--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -72,7 +72,7 @@ graph TB
 - `worker/generators/patterns/` — pattern system (honeycomb, registry)
 - `worker/generators/scenarios/` — test scenario data by category
 - `export/stlExporter.ts` — STL file export
-- `export/threemfExporter.ts` — 3MF file export
+- `export/threemfExporter.ts` — 3MF file export (see [3MF multi-color compatibility](#3mf-multi-color-compatibility) for the slicer interop notes)
 - `export/validation.ts` — shared mesh data validation
 
 ## Pipeline Stages
@@ -125,3 +125,11 @@ Fast generations → 50ms delay, slow generations → 300ms delay
 ## Generation Timeout
 
 `computeGenerationTimeoutMs(params)` scales the per-request watchdog: 30s base, +15s for hex pattern, +15s when paired with active wall cutouts, +15s per 2u of height over 4u, capped at 90s. Baseplates keep the flat 30s fallback.
+
+## 3MF Multi-color Compatibility
+
+Multi-color exports target three slicers — BambuStudio, OrcaSlicer, PrusaSlicer — with overlapping but conflicting expectations. The exporter (`export/threemfExporter.ts`) handles them via three coordinated mechanisms; touching any one of them risks tripping a different slicer's validator. Verify with the slicer CLIs before merging (see the `feedback_slicer_cli_testing.md` memory).
+
+- **`paint_color` triangle attribute** — the actual per-triangle multi-material encoding. Both OrcaSlicer (`bbs_3mf.cpp` `MMU_SEGMENTATION_ATTR`) and PrusaSlicer (`3mf.cpp:2158`, as a fallback for its own `slic3rpe:mmu_segmentation`) read this. All three slicers explicitly ignore the spec's `pid`/`p1` triangle-color mechanism (`bbs_3mf.cpp:3805-3810`), so the spec-correct `<basematerials>`/`<m:colorgroup>` paths don't work. Slot N maps to `FILAMENT_PAINT_CODES[N+1]` (the slicer's serialized TriangleSelector bit-tree, from OrcaSlicer's `CONST_FILAMENTS` table); slot 0 → `"4"` (filament 1), slot 1 → `"8"`, slot 2 → `"0C"`, etc. Every triangle gets an explicit code so zone-to-AMS-slot mapping doesn't depend on the object's default-extruder setting.
+- **`Metadata/project_settings.config` sidecar** — minimal JSON with `filament_colour` populating the slicer's AMS palette automatically so the user opens the file with the bin's zone colors pre-loaded into slots. Also carries `use_relative_e_distances=1` and a `G92 E0` `layer_change_gcode` to satisfy OrcaSlicer's multi-material slice validation (`Print.cpp:1683-1689`). Bambu users will see these as project overrides applied on import.
+- **`Application=BambuStudio-02.00.00.00` metadata claim** — BambuStudio gates `project_settings.config` loading on this prefix (`bbs_3mf.cpp:1898-1908`); without it the sidecar is silently skipped and Bambu shows a "not from Bambu Lab" dialog. The exact version `02.00.00.00` was empirically chosen as the only value both BambuStudio 2.6.0 and OrcaSlicer 2.3.1 CLIs accept — `01.x.x.x` hits a hidden Orca rejection threshold; `02.06.x.x+` trips its "file newer than CLI" branch. See the `BAMBU_COMPAT_APPLICATION` JSDoc for the full failure-mode table. Only emitted for multi-color exports — single-color exports have no sidecar to gate on.

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -776,7 +776,12 @@ describe('threemfExporter', () => {
       const model = strFromU8(
         unzipSync(build3MFMultiObjectBuffer(objects, { name: 'multi-bambu' }))['3D/3dmodel.model']
       );
-      expect(model).toContain('<metadata name="Application">BambuStudio-');
+      // Pin the safe version range — same regex as the single-object test
+      // so a future bump to e.g. 02.06.x.x doesn't slip through and break
+      // OrcaSlicer's CLI version check.
+      expect(model).toMatch(
+        /<metadata name="Application">BambuStudio-02\.00\.\d+\.\d+<\/metadata>/
+      );
       expect(model).toContain('<metadata name="BambuStudio:3mfVersion">1</metadata>');
     });
 

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -716,18 +716,17 @@ describe('threemfExporter', () => {
       expect(unzipSync(buffer)['Metadata/project_settings.config']).toBeUndefined();
     });
 
-    // We deliberately do NOT claim BambuStudio identity via `<metadata
-    // name="Application">BambuStudio-X.Y.Z</metadata>`. The earlier attempt
-    // backfired: OrcaSlicer's CLI rejected the file outright with
-    // "File Version 1.0.0.0 not supported by current cli version 2.3.1"
-    // (exit -24), and the GUI loaded a degraded placeholder that landed
-    // off-plate, showed as single color, and triggered downstream g-code
-    // path-out-of-bounds and relative-extruder errors. The cost of skipping
-    // the claim is the one-time "the 3mf is not from Bambu Lab, load
-    // geometry data and color data only" dialog in BambuStudio — which is
-    // dismissible and does NOT block paint_color loading (paint_color is on
-    // triangles in the model XML, parsed independently of project config).
-    it('does not claim BambuStudio identity for multi-color exports', () => {
+    // BambuStudio gates `Metadata/project_settings.config` loading on the
+    // `Application` metadata starting with "BambuStudio-X.Y.Z"
+    // (bbs_3mf.cpp:1898-1908). Claim a version Orca won't reject so both
+    // slicers load our sidecar and pre-fill the AMS palette automatically.
+    //
+    // Version choice (`02.00.00.00`) was empirically derived against
+    // OrcaSlicer 2.3.1 and BambuStudio 2.6.0 CLIs: 01.x.x.x → rejected,
+    // 02.06.x.x+ → rejected, 02.00.00.00 → accepted by both. See the
+    // BAMBU_COMPAT_APPLICATION docstring in threemfExporter.ts for the
+    // full failure modes I ruled out.
+    it('claims BambuStudio identity for multi-color exports', () => {
       const { vertices, normals } = createTwoTriangles();
       const model = strFromU8(
         unzipSync(
@@ -740,13 +739,27 @@ describe('threemfExporter', () => {
           })
         )['3D/3dmodel.model']
       );
-      expect(model).not.toContain('<metadata name="Application">');
-      expect(model).not.toContain('BambuStudio:3mfVersion');
-      // Designer metadata is unaffected — that's our human-readable identity.
+      // Must start with "BambuStudio-" per the gate, and stay at 02.00.x.x
+      // or lower so Orca's CLI version check doesn't reject.
+      expect(model).toMatch(
+        /<metadata name="Application">BambuStudio-02\.00\.\d+\.\d+<\/metadata>/
+      );
+      expect(model).toContain('<metadata name="BambuStudio:3mfVersion">1</metadata>');
       expect(model).toContain('<metadata name="Designer">Gridfinity Layout Tool</metadata>');
     });
 
-    it('multi-object: still does not claim BambuStudio identity even with colored objects', () => {
+    it('does NOT claim BambuStudio identity for single-color exports', () => {
+      // No sidecar to gate, so no reason to claim identity. Avoids changing
+      // classification for users who don't need multi-material.
+      const { vertices, normals } = createSingleTriangle();
+      const model = strFromU8(
+        unzipSync(build3MFBuffer(vertices, normals, { name: 'plain' }))['3D/3dmodel.model']
+      );
+      expect(model).not.toContain('<metadata name="Application">');
+      expect(model).not.toContain('BambuStudio:3mfVersion');
+    });
+
+    it('multi-object: claims BambuStudio identity when any object has colorConfig', () => {
       const tri = createSingleTriangle();
       const objects = [
         {
@@ -762,6 +775,23 @@ describe('threemfExporter', () => {
       ];
       const model = strFromU8(
         unzipSync(build3MFMultiObjectBuffer(objects, { name: 'multi-bambu' }))['3D/3dmodel.model']
+      );
+      expect(model).toContain('<metadata name="Application">BambuStudio-');
+      expect(model).toContain('<metadata name="BambuStudio:3mfVersion">1</metadata>');
+    });
+
+    it('multi-object: skips BambuStudio identity when no object has colorConfig', () => {
+      const tri = createSingleTriangle();
+      const model = strFromU8(
+        unzipSync(
+          build3MFMultiObjectBuffer(
+            [
+              { vertices: tri.vertices, normals: tri.normals, name: 'a' },
+              { vertices: tri.vertices, normals: tri.normals, name: 'b' },
+            ],
+            { name: 'multi-plain' }
+          )
+        )['3D/3dmodel.model']
       );
       expect(model).not.toContain('<metadata name="Application">');
       expect(model).not.toContain('BambuStudio:3mfVersion');

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -311,7 +311,7 @@ function buildModelXML(mesh: IndexedMesh, options: ThreeMFOptions): string {
   const objectId = 1;
 
   let xml = openModelElement();
-  xml += buildMetadataXml(options);
+  xml += buildMetadataXml(options, { bambuCompat: !!colorConfig });
   xml += '  <resources>\n';
   xml += buildObjectXml(objectId, options.name, mesh, colorConfig?.triangleMaterialIndices);
   xml += '  </resources>\n';
@@ -361,8 +361,10 @@ function buildMultiObjectModelXML(
     return { ...obj, colorConfig };
   });
 
+  const anyHasColors = resolved.some((obj) => obj.colorConfig !== undefined);
+
   let xml = openModelElement();
-  xml += buildMetadataXml(options);
+  xml += buildMetadataXml(options, { bambuCompat: anyHasColors });
   xml += '  <resources>\n';
 
   const objectIds: number[] = [];
@@ -439,10 +441,42 @@ export const FILAMENT_PAINT_CODES = [
 // One fewer than the table size because we index `[slot + 1]` (slot 0 = filament 1).
 const MAX_COLOR_SLOTS = FILAMENT_PAINT_CODES.length - 1;
 
-function buildMetadataXml(options: ThreeMFOptions): string {
+/**
+ * Version we claim in the `Application` metadata, gated to multi-color
+ * exports. The claim has to start with "BambuStudio-" because BambuStudio's
+ * `dont_load_config` gate at bbs_3mf.cpp:1898-1908 only loads our
+ * `project_settings.config` sidecar when that prefix matches — without it
+ * the AMS palette isn't pre-filled and Bambu shows a "not from Bambu Lab"
+ * dialog.
+ *
+ * Picking the exact version was empirically constrained:
+ *
+ *   - `01.x.x.x` is rejected outright by OrcaSlicer's CLI version check
+ *     (`Version Check: File Version 1.x.x.x not supported by current cli
+ *     version 2.3.1`, exit -24). The check has a hidden minimum beyond the
+ *     maj/min compare in OrcaSlicer.cpp:1589 — I couldn't reproduce the
+ *     reject from reading the source, but it fires reliably for any 1.x.
+ *   - `02.06.x.x` and higher trip Orca 2.3's "file is newer than cli"
+ *     branch and also reject.
+ *   - `02.00.00.00` lands in the sweet spot: Bambu's gate accepts it,
+ *     Orca's version check accepts it, and the file_version stays under
+ *     every Bambu release we'd care about so the slicer doesn't run the
+ *     "translate old project" migration path.
+ *
+ * If beginners are running Orca 1.x (unlikely — it's the 2023 series and
+ * mostly unmaintained) the file will reject. The trade-off is favorable
+ * for the modern install base.
+ */
+const BAMBU_COMPAT_APPLICATION = 'BambuStudio-02.00.00.00';
+
+function buildMetadataXml(options: ThreeMFOptions, flags: { bambuCompat: boolean }): string {
   let xml = `  <metadata name="Title">${escapeXml(options.name)}</metadata>\n`;
   xml += '  <metadata name="Designer">Gridfinity Layout Tool</metadata>\n';
   xml += `  <metadata name="CreationDate">${new Date().toISOString().split('T')[0]}</metadata>\n`;
+  if (flags.bambuCompat) {
+    xml += `  <metadata name="Application">${BAMBU_COMPAT_APPLICATION}</metadata>\n`;
+    xml += '  <metadata name="BambuStudio:3mfVersion">1</metadata>\n';
+  }
   const ps = options.printSettings;
   if (!ps) return xml;
   // 3MF Core §3.7: custom metadata names without a registered namespace prefix

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -80,15 +80,13 @@ function packageFiles(
     files['Metadata/thumbnail.png'] = thumbnail;
   }
   if (projectSettingsJson) {
-    // OrcaSlicer reads this via `_extract_project_config_from_archive` and
-    // applies `filament_colour` to its AMS slots — so the user opens the
-    // file with the bin's zone palette already pre-filled. BambuStudio
-    // gates the same loader on an "Application=BambuStudio-X.Y.Z" metadata
-    // claim that we deliberately don't make (claiming it caused OrcaSlicer
-    // to reject the file in a version check). Bambu users will see a
-    // dismissible "not from Bambu Lab" dialog and set their AMS palette
-    // manually; paint_color triangle painting still applies because that
-    // lives in the model XML and parses independently of project config.
+    // Both OrcaSlicer and BambuStudio read this via
+    // `_extract_project_config_from_archive` and apply `filament_colour` to
+    // their AMS slots, so the user opens the file with the bin's zone
+    // palette already pre-filled. BambuStudio additionally gates the loader
+    // on an `Application=BambuStudio-X.Y.Z` metadata claim — see
+    // BAMBU_COMPAT_APPLICATION below — without which Bambu silently skips
+    // the sidecar and shows a "not from Bambu Lab" dialog instead.
     files['Metadata/project_settings.config'] = strToU8(projectSettingsJson);
   }
   return zipSync(files, { level: 6 });
@@ -266,9 +264,9 @@ function buildProjectSettingsConfig(palette: readonly string[]): string {
   return JSON.stringify(
     {
       // Headers are advisory — Bambu's load_from_json stores them in a
-      // key_values map but doesn't gate on them. Generic version is fine
-      // since we no longer claim BambuStudio identity.
-      version: '1.0.0.0',
+      // key_values map but doesn't gate on them. Aligned with the Application
+      // metadata version (BAMBU_COMPAT_APPLICATION) for human consistency.
+      version: '2.0.0.0',
       name: 'project_settings',
       from: 'Gridfinity Layout Tool',
 


### PR DESCRIPTION
## Summary

Multi-color 3MF exports now open in BambuStudio with the AMS slot palette already populated from the bin's zone colors — no manual filament setup, no "not from Bambu Lab" dialog. OrcaSlicer and PrusaSlicer behavior is unchanged.

## What changed

Add an `<metadata name="Application">BambuStudio-02.00.00.00</metadata>` claim (plus `BambuStudio:3mfVersion=1`) to multi-color exports. BambuStudio gates `Metadata/project_settings.config` loading on this prefix (`bbs_3mf.cpp:1898-1908`); without it, our `filament_colour` palette is silently skipped and Bambu falls back to the user's existing AMS setup. Single-color exports omit the claim — there's no sidecar to gate on, and changing classification of plain exports is unnecessary.

## Why this exact version

`02.00.00.00` is the only version string both slicer CLIs accept. Earlier passes hit two failure modes:

| Version claim | OrcaSlicer 2.3.1 | BambuStudio 2.6.0 |
|---|---|---|
| `01.00.00.00` | rejects (Version Check, exit -24) | accepts |
| `01.10.00.00` | rejects | accepts |
| **`02.00.00.00`** | **accepts** | **accepts** |
| `02.06.00.00` | rejects (file newer than CLI) | accepts |
| `OrcaSlicer-X.Y.Z` | accepts | rejects (gate requires `BambuStudio-` prefix) |

Full failure-mode table and source citations in the `BAMBU_COMPAT_APPLICATION` JSDoc.

## Context for reviewers

This is the final piece of the multi-color 3MF iteration that landed across #1885 (initial paint_color encoding) → #1887 (revert a bad version claim) → #1889 (slice-time `G92 E0` validation) → #1891 (off-by-one collapsing body+lip). Empirically verified end-to-end against both slicer CLIs; the latest commit also addresses Greptile P2 + Copilot review feedback.

## Test plan

- [x] Targeted tests pass (82, includes new identity-claim assertions)
- [x] OrcaSlicer CLI: `load project config file successfully`, no Version Check
- [x] BambuStudio CLI: `load project config file successfully` (not "skipped")
- [ ] **Manual:** open a multi-color export in BambuStudio — AMS palette should match bin zone colors, no "not from Bambu Lab" dialog
- [ ] **Manual:** same file in OrcaSlicer — bin lands on plate, multi-color visible in Paint mode