### PR TITLE
fix(export): center bins on the plate when claiming BambuStudio identity

### DIFF
--- a/e2e/bin-designer/multi-color-export.spec.ts
+++ b/e2e/bin-designer/multi-color-export.spec.ts
@@ -39,6 +39,15 @@ test.describe('Bin Designer — multi-color 3MF export', () => {
     const canvas = page.locator('canvas').first();
     await expect(canvas).toBeVisible({ timeout: 30000 });
 
+    // Flip the per-design "Enable multi-color" toggle so the zone color
+    // pickers render. Labs flag alone gates feature *availability*; this
+    // toggle is what activates the multi-color UI for the current bin.
+    const enableMC = page
+      .getByRole('switch', { name: /enable multi-color/i })
+      .or(page.getByLabel(/enable multi-color/i));
+    await enableMC.first().waitFor({ state: 'visible', timeout: 10000 });
+    await enableMC.first().click();
+
     for (const [label, hex] of [
       [/^Body: /i, BODY_HEX],
       [/^Stacking Lip: /i, LIP_HEX],
@@ -86,13 +95,20 @@ test.describe('Bin Designer — multi-color 3MF export', () => {
     const xml = strFromU8(entries['3D/3dmodel.model']);
 
     // Lower-cased: exporter's hex case is not part of the contract.
-    expect(xml.toLowerCase()).toContain(BODY_HEX);
-    expect(xml.toLowerCase()).toContain(LIP_HEX);
-    expect(xml).toMatch(/<basematerials\b/);
-
-    const triangleMatches = xml.match(/<triangle\b[^/]*p1="(\d+)"/g) ?? [];
+    const config = JSON.parse(strFromU8(entries['Metadata/project_settings.config']));
+    expect(config.filament_colour.map((c: string) => c.toLowerCase())).toEqual(
+      expect.arrayContaining([BODY_HEX, LIP_HEX])
+    );
+    expect(xml).toMatch(/<metadata name="Application">BambuStudio-/);
+    const triangleMatches = xml.match(/<triangle\b[^/]*paint_color="([^"]+)"/g) ?? [];
     expect(triangleMatches.length).toBeGreaterThan(0);
-    const distinctP1 = new Set(triangleMatches.map((m) => /p1="(\d+)"/.exec(m)?.[1]));
-    expect(distinctP1.size).toBeGreaterThanOrEqual(2);
+    const distinctCodes = new Set(triangleMatches.map((m) => /paint_color="([^"]+)"/.exec(m)?.[1]));
+    expect(distinctCodes.size).toBeGreaterThanOrEqual(2);
+
+    // Build item must carry a centering transform so the bin opens on the
+    // plate, not at the bed corner (regression introduced when we claimed
+    // BambuStudio identity flipped Orca's auto-arrange off — see
+    // BAMBU_COMPAT_APPLICATION JSDoc in threemfExporter.ts).
+    expect(xml).toMatch(/<item objectid="\d+" transform="1 0 0 0 1 0 0 0 1 [^"]+" \/>/);
   });
 });

--- a/e2e/bin-designer/multi-color-export.spec.ts
+++ b/e2e/bin-designer/multi-color-export.spec.ts
@@ -39,14 +39,19 @@ test.describe('Bin Designer — multi-color 3MF export', () => {
     const canvas = page.locator('canvas').first();
     await expect(canvas).toBeVisible({ timeout: 30000 });
 
-    // Flip the per-design "Enable multi-color" toggle so the zone color
-    // pickers render. Labs flag alone gates feature *availability*; this
-    // toggle is what activates the multi-color UI for the current bin.
+    // Enable the per-design multi-color toggle so the zone color pickers
+    // render. Labs flag alone gates feature *availability*; this toggle is
+    // what activates the multi-color UI for the current bin. Read
+    // `aria-checked` first so a default-on UI in some future release
+    // doesn't get toggled OFF and silently break the rest of the test.
     const enableMC = page
       .getByRole('switch', { name: /enable multi-color/i })
-      .or(page.getByLabel(/enable multi-color/i));
-    await enableMC.first().waitFor({ state: 'visible', timeout: 10000 });
-    await enableMC.first().click();
+      .or(page.getByLabel(/enable multi-color/i))
+      .first();
+    await enableMC.waitFor({ state: 'visible', timeout: 10000 });
+    if ((await enableMC.getAttribute('aria-checked')) !== 'true') {
+      await enableMC.click();
+    }
 
     for (const [label, hex] of [
       [/^Body: /i, BODY_HEX],

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -266,13 +266,18 @@ describe('threemfExporter', () => {
       expect(xml).not.toContain('test <bin>');
     });
 
-    it('includes build section with object reference', () => {
+    it('includes build section with centered object reference', () => {
       const { vertices, normals } = createSingleTriangle();
       const buffer = build3MFBuffer(vertices, normals, { name: 'test' });
       const xml = extractModelXML(buffer);
 
+      // Build item always carries a transform now — the bbox centroid is
+      // translated to PLATE_CENTER_MM so the bin opens centered on the bed
+      // rather than at the world origin (= bed corner). Pre-#1893 this was
+      // unnecessary because OrcaSlicer's From_Other classifier auto-arranged
+      // on import; claiming BambuStudio identity flips need_arrange = false.
       expect(xml).toContain('<build>');
-      expect(xml).toContain('<item objectid="1" />');
+      expect(xml).toMatch(/<item objectid="1" transform="1 0 0 0 1 0 0 0 1 [^"]+" \/>/);
     });
 
     it('formats floating-point vertices with precision', () => {
@@ -1089,13 +1094,93 @@ describe('threemfExporter', () => {
   // Issue #1642 — auto-stack copies in 3MF. The exporter uses 3MF instancing
   // (single object, multiple <item> entries with Z translation) so file size
   // stays constant regardless of copy count.
+  // Pre-#1893 we shipped no Application metadata so OrcaSlicer classified
+  // our file as `From_Other` and auto-arranged on import. Claiming
+  // BambuStudio identity in #1893 flipped need_arrange=false, so the bin
+  // appeared at world origin (bed corner) instead of centered. Centering
+  // via a build-item transform restores the prior visual behavior while
+  // keeping the AMS-palette-loading benefit of the Bambu identity claim.
+  describe('build item centering (positioning regression fix)', () => {
+    it('centers a 42mm gridfinity bin around PLATE_CENTER_MM (128,128)', () => {
+      // Synthesize a 42x42x42mm cube positioned at origin (the gridfinity
+      // worker's default coordinate space). Centroid (21, 21, 21) → expected
+      // translation (128-21, 128-21, -0) = (107, 107, 0).
+      const verts = new Float32Array([
+        0, 0, 0, 42, 0, 0, 42, 42, 0, 0, 0, 42, 42, 0, 42, 42, 42, 42,
+      ]);
+      const normals = new Float32Array(verts.length).fill(0);
+      for (let i = 2; i < normals.length; i += 3) normals[i] = 1;
+      const xml = extractModelXML(build3MFBuffer(verts, normals, { name: 'bin' }));
+      expect(xml).toContain('transform="1 0 0 0 1 0 0 0 1 107 107 0"');
+    });
+
+    it('multi-object: shares a single offset across all items', () => {
+      // Two cubes at offset origins; combined bbox (0,0,0)→(50,50,42),
+      // centroid (25, 25, 21) → translation (103, 103, 0). All build items
+      // share this translation so relative positions are preserved.
+      const cube = (ox: number, oy: number) =>
+        new Float32Array([
+          ox,
+          oy,
+          0,
+          ox + 10,
+          oy,
+          0,
+          ox + 10,
+          oy + 10,
+          0,
+          ox,
+          oy,
+          42,
+          ox + 10,
+          oy,
+          42,
+          ox + 10,
+          oy + 10,
+          42,
+        ]);
+      const normals = new Float32Array(18).fill(0);
+      for (let i = 2; i < normals.length; i += 3) normals[i] = 1;
+      const xml = strFromU8(
+        unzipSync(
+          build3MFMultiObjectBuffer(
+            [
+              { vertices: cube(0, 0), normals, name: 'a' },
+              { vertices: cube(40, 40), normals, name: 'b' },
+            ],
+            { name: 'multi' }
+          )
+        )['3D/3dmodel.model']
+      );
+      const items = xml.match(/<item objectid="\d+" transform="[^"]+"/g) ?? [];
+      expect(items).toHaveLength(2);
+      // Combined centroid X = (0 + 50)/2 = 25; translation x = 128 - 25 = 103.
+      expect(items[0]).toContain('transform="1 0 0 0 1 0 0 0 1 103 103 0"');
+      expect(items[1]).toContain('transform="1 0 0 0 1 0 0 0 1 103 103 0"');
+    });
+
+    it('lifts the bin to z=0 when its mesh has a negative-z baseline', () => {
+      // Synthetic mesh with vertices straddling z=0 (some at -5, some at +5).
+      // Translation z = -bbox.min.z = -(-5) = +5 so the bin sits on the bed.
+      const verts = new Float32Array([0, 0, -5, 1, 0, -5, 0, 1, -5, 0, 0, 5, 1, 0, 5, 0, 1, 5]);
+      const normals = new Float32Array(verts.length).fill(0);
+      for (let i = 2; i < normals.length; i += 3) normals[i] = 1;
+      const xml = extractModelXML(build3MFBuffer(verts, normals, { name: 'lifted' }));
+      // Translation z component must equal -bbox.min.z = 5.
+      expect(xml).toMatch(/transform="1 0 0 0 1 0 0 0 1 \S+ \S+ 5"/);
+    });
+  });
+
   describe('stack option (issue #1642)', () => {
-    it('emits a single <item> when stack is omitted', () => {
+    // The single-triangle test mesh has bbox (0,0,0)→(1,1,0), centroid
+    // (0.5, 0.5, 0). PLATE_CENTER_MM = (128, 128). Translation per stack
+    // copy i is (127.5, 127.5, i * (zHeightMm + spacingMm)).
+    it('emits a single <item> with centering transform when stack is omitted', () => {
       const { vertices, normals } = createSingleTriangle();
       const xml = extractModelXML(build3MFBuffer(vertices, normals, { name: 'test' }));
       const items = xml.match(/<item /g) ?? [];
       expect(items).toHaveLength(1);
-      expect(xml).not.toContain('transform=');
+      expect(xml).toContain('transform="1 0 0 0 1 0 0 0 1 127.5 127.5 0"');
     });
 
     it('emits a single <item> when stack.count is 1', () => {
@@ -1119,9 +1204,10 @@ describe('threemfExporter', () => {
       );
       const items = xml.match(/<item [^/]*\/>/g) ?? [];
       expect(items).toHaveLength(3);
-      expect(items[0]).toContain('transform="1 0 0 0 1 0 0 0 1 0 0 0"');
-      expect(items[1]).toContain('transform="1 0 0 0 1 0 0 0 1 0 0 7"');
-      expect(items[2]).toContain('transform="1 0 0 0 1 0 0 0 1 0 0 14"');
+      // Stack stride adds to the base centering translation's z, not replaces.
+      expect(items[0]).toContain('transform="1 0 0 0 1 0 0 0 1 127.5 127.5 0"');
+      expect(items[1]).toContain('transform="1 0 0 0 1 0 0 0 1 127.5 127.5 7"');
+      expect(items[2]).toContain('transform="1 0 0 0 1 0 0 0 1 127.5 127.5 14"');
     });
 
     it('adds spacingMm to each successive Z stride', () => {
@@ -1133,8 +1219,8 @@ describe('threemfExporter', () => {
         })
       );
       const items = xml.match(/transform="[^"]+"/g) ?? [];
-      expect(items[0]).toBe('transform="1 0 0 0 1 0 0 0 1 0 0 0"');
-      expect(items[1]).toBe('transform="1 0 0 0 1 0 0 0 1 0 0 5.5"');
+      expect(items[0]).toBe('transform="1 0 0 0 1 0 0 0 1 127.5 127.5 0"');
+      expect(items[1]).toBe('transform="1 0 0 0 1 0 0 0 1 127.5 127.5 5.5"');
     });
 
     it('still references a single object even when stacking many copies', () => {

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -384,10 +384,12 @@ function renderBuildItems(
 ): string {
   const count = stack && stack.count > 1 ? Math.floor(stack.count) : 1;
   const stride = (stack?.zHeightMm ?? 0) + (stack?.spacingMm ?? 0);
+  // tx/ty don't change across stack copies — only the Z stride does — so
+  // format them once outside the loop.
+  const tx = formatFloat(offset.x);
+  const ty = formatFloat(offset.y);
   let out = '';
   for (let i = 0; i < count; i++) {
-    const tx = formatFloat(offset.x);
-    const ty = formatFloat(offset.y);
     const tz = formatFloat(offset.z + i * stride);
     out += `    <item objectid="${objectId}" transform="1 0 0 0 1 0 0 0 1 ${tx} ${ty} ${tz}" />\n`;
   }

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -307,6 +307,7 @@ function buildModelXML(mesh: IndexedMesh, options: ThreeMFOptions): string {
   }
 
   const objectId = 1;
+  const offset = centeringTranslation(computeBBox(mesh.vertices));
 
   let xml = openModelElement();
   xml += buildMetadataXml(options, { bambuCompat: !!colorConfig });
@@ -314,29 +315,81 @@ function buildModelXML(mesh: IndexedMesh, options: ThreeMFOptions): string {
   xml += buildObjectXml(objectId, options.name, mesh, colorConfig?.triangleMaterialIndices);
   xml += '  </resources>\n';
   xml += '  <build>\n';
-  xml += renderBuildItems(objectId, options.stack);
+  xml += renderBuildItems(objectId, options.stack, offset);
   xml += '  </build>\n';
   xml += '</model>';
   return xml;
 }
 
 /**
+ * Plate-center coordinates we translate the bin's bbox centroid to so the
+ * file opens centered on the bed. Chosen for the 256×256 mm beds that
+ * BambuStudio A1/X1/P1, Prusa MK4S, and similar most commonly target.
+ * A1 mini (180×180) will see the bin offset 38mm past center — still on
+ * the bed. Pre-#1893 we shipped no Application metadata so OrcaSlicer
+ * classified our file as `From_Other` and auto-arranged on import;
+ * claiming BambuStudio identity flips `need_arrange = false` in the BBS
+ * loader, so we now have to provide the plate position ourselves.
+ */
+const PLATE_CENTER_MM = { x: 128, y: 128 } as const;
+
+interface BBox {
+  readonly min: { x: number; y: number; z: number };
+  readonly max: { x: number; y: number; z: number };
+}
+
+function computeBBox(vertices: readonly (readonly [number, number, number])[]): BBox | null {
+  if (vertices.length === 0) return null;
+  let minX = Infinity,
+    minY = Infinity,
+    minZ = Infinity;
+  let maxX = -Infinity,
+    maxY = -Infinity,
+    maxZ = -Infinity;
+  for (const [x, y, z] of vertices) {
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+    if (z < minZ) minZ = z;
+    if (z > maxZ) maxZ = z;
+  }
+  return { min: { x: minX, y: minY, z: minZ }, max: { x: maxX, y: maxY, z: maxZ } };
+}
+
+/**
+ * Translation that places the bbox centroid at PLATE_CENTER_MM (XY) and
+ * the bottom of the bbox at z=0 (sits on bed). Returns zero for an empty
+ * bbox — let the slicer do whatever it does with an empty mesh.
+ */
+function centeringTranslation(bbox: BBox | null): { x: number; y: number; z: number } {
+  if (!bbox) return { x: 0, y: 0, z: 0 };
+  return {
+    x: PLATE_CENTER_MM.x - (bbox.min.x + bbox.max.x) / 2,
+    y: PLATE_CENTER_MM.y - (bbox.min.y + bbox.max.y) / 2,
+    z: -bbox.min.z,
+  };
+}
+
+/**
  * 3MF transforms are row-major 3×4 (`m11..m13 m21..m23 m31..m33 m41..m43`);
  * the trailing m41/m42/m43 row carries the translation. Stacking is a pure
- * Z translation, so the rotation/scale block stays identity and only m43
- * changes per copy.
+ * Z translation on top of the base centering offset, so the rotation/scale
+ * block stays identity and only m41/m42/m43 vary per copy.
  */
-function renderBuildItems(objectId: number, stack: ThreeMFOptions['stack']): string {
+function renderBuildItems(
+  objectId: number,
+  stack: ThreeMFOptions['stack'],
+  offset: { x: number; y: number; z: number }
+): string {
   const count = stack && stack.count > 1 ? Math.floor(stack.count) : 1;
-  if (count === 1) {
-    return `    <item objectid="${objectId}" />\n`;
-  }
-
   const stride = (stack?.zHeightMm ?? 0) + (stack?.spacingMm ?? 0);
   let out = '';
   for (let i = 0; i < count; i++) {
-    const dz = formatFloat(i * stride);
-    out += `    <item objectid="${objectId}" transform="1 0 0 0 1 0 0 0 1 0 0 ${dz}" />\n`;
+    const tx = formatFloat(offset.x);
+    const ty = formatFloat(offset.y);
+    const tz = formatFloat(offset.z + i * stride);
+    out += `    <item objectid="${objectId}" transform="1 0 0 0 1 0 0 0 1 ${tx} ${ty} ${tz}" />\n`;
   }
   return out;
 }
@@ -361,6 +414,11 @@ function buildMultiObjectModelXML(
 
   const anyHasColors = resolved.some((obj) => obj.colorConfig !== undefined);
 
+  // Single shared offset across all objects so the bin + dividers + lid keep
+  // their relative positions and the assembly lands centered together.
+  const combinedBBox = mergeBBoxes(resolved.map((obj) => computeBBox(obj.mesh.vertices)));
+  const offset = centeringTranslation(combinedBBox);
+
   let xml = openModelElement();
   xml += buildMetadataXml(options, { bambuCompat: anyHasColors });
   xml += '  <resources>\n';
@@ -375,12 +433,39 @@ function buildMultiObjectModelXML(
 
   xml += '  </resources>\n';
   xml += '  <build>\n';
+  const tx = formatFloat(offset.x);
+  const ty = formatFloat(offset.y);
+  const tz = formatFloat(offset.z);
   for (const id of objectIds) {
-    xml += `    <item objectid="${id}" />\n`;
+    xml += `    <item objectid="${id}" transform="1 0 0 0 1 0 0 0 1 ${tx} ${ty} ${tz}" />\n`;
   }
   xml += '  </build>\n';
   xml += '</model>';
   return xml;
+}
+
+function mergeBBoxes(boxes: readonly (BBox | null)[]): BBox | null {
+  let merged: BBox | null = null;
+  for (const b of boxes) {
+    if (!b) continue;
+    if (!merged) {
+      merged = b;
+      continue;
+    }
+    merged = {
+      min: {
+        x: Math.min(merged.min.x, b.min.x),
+        y: Math.min(merged.min.y, b.min.y),
+        z: Math.min(merged.min.z, b.min.z),
+      },
+      max: {
+        x: Math.max(merged.max.x, b.max.x),
+        y: Math.max(merged.max.y, b.max.y),
+        z: Math.max(merged.max.z, b.max.z),
+      },
+    };
+  }
+  return merged;
 }
 
 const CORE_NS = 'http://schemas.microsoft.com/3dmanufacturing/core/2015/02';


### PR DESCRIPTION
## Summary

After #1893 landed, opening a multi-color 3MF in OrcaSlicer/BambuStudio placed the bin at the bed corner (or outside the print volume entirely) and required manual auto-arrange to slice.

## Root cause

Pre-#1893 our exports shipped no `Application` metadata, so OrcaSlicer classified them as `From_Other` and auto-arranged on import. PR #1893 added `Application=BambuStudio-02.00.00.00` to satisfy BambuStudio's `dont_load_config` gate (so the AMS palette is pre-filled with our zone colors). But that classification also flips `need_arrange = false` in the BBS loader — the slicer then trusts our literal coordinates, which put the gridfinity bin's centroid at the world origin (= bed corner).

## Fix

Compute the mesh bbox and emit a build-item transform that:
- Translates the bbox centroid in XY to `PLATE_CENTER_MM = (128, 128)` — chosen for 256×256 mm beds (Bambu A1/X1/P1, Prusa MK4S, most Voron sizes). A1 mini's 180×180 lands the bin 38mm past center but still on the bed.
- Translates the bbox floor to z=0 so the bin sits on the bed regardless of the worker's coordinate baseline.

Multi-object exports share a single offset derived from the combined bbox so the bin + dividers + lid preserve their relative positions. Stacking (issue #1642) composes its per-copy Z stride on top of the base centering offset rather than replacing it.

## Tests

- 4 existing stack tests updated to reflect that every build item now carries a centering transform (single-triangle test mesh centroid (0.5, 0.5, 0) → translation (127.5, 127.5, 0)).
- 3 new positive tests for the centering behavior: 42mm bin → translation (107, 107, 0); multi-object combined-bbox share; z=0 lift for meshes straddling z=0.

## E2E test drive-by

The existing `e2e/bin-designer/multi-color-export.spec.ts` asserted the pre-#1885 `<basematerials>` shape and would fail on `pnpm test:e2e` today. Updated it to (a) click the "Enable multi-color" toggle the current UI requires after the labs flag, (b) assert `paint_color` / `Application=BambuStudio-` / `project_settings.config` / build-item transform — i.e. the live wire format. Surfaced while testing this fix.

## Verified

- 85 unit tests pass (was 82, +3 for centering)
- E2E test produces a real bin with `<item objectid="1" transform="1 0 0 0 1 0 0 0 1 128 128 0" />`
- PrusaSlicer MK3S+MMU3 CLI accepts the file without `--center` and processes through perimeters/infill/supports successfully (gcode export hit an unrelated flatpak SIGSEGV at the final step — same path produced clean output when sliced with manual `--center` before this fix)

## Test plan

- [ ] **Manual:** open a fresh multi-color export in BambuStudio + OrcaSlicer; confirm the bin lands centered on the plate (or at least within the print volume) on first load, without needing auto-arrange
- [ ] **Manual:** confirm a multi-part export (bin + dividers + lid) places all pieces together rather than overlapping at the corner