### PR TITLE
fix: pin acceleration to silence Orca + sync server caps with #1873

### DIFF
--- a/api/lib/designerValidation.test.ts
+++ b/api/lib/designerValidation.test.ts
@@ -95,9 +95,16 @@ describe('validateDesignerShare', () => {
 
     it('rejects width above maximum', () => {
       const payload = validPayload();
-      payload.params.width = 10;
+      payload.params.width = 17;
       const result = validateDesignerShare(payload, JSON.stringify(payload).length);
       expect(result.valid).toBe(false);
+    });
+
+    it('accepts width at the 16 boundary (matches client MAX_DIMENSION)', () => {
+      const payload = validPayload();
+      payload.params.width = 16;
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(true);
     });
 
     it('rejects height below minimum', () => {
@@ -173,6 +180,15 @@ describe('validateDesignerShare', () => {
       payload.params.compartments.cols = 15;
       const result = validateDesignerShare(payload, JSON.stringify(payload).length);
       expect(result.valid).toBe(false);
+    });
+
+    it('accepts cols at the 12 boundary (client cap raised in #1873)', () => {
+      const payload = validPayload();
+      payload.params.compartments.cols = 12;
+      payload.params.compartments.rows = 12;
+      payload.params.compartments.cells = Array.from({ length: 144 }, (_, i) => i);
+      const result = validateDesignerShare(payload, JSON.stringify(payload).length);
+      expect(result.valid).toBe(true);
     });
 
     it('rejects compartment thickness out of range', () => {

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -34,18 +34,19 @@ const VALID_ROTATIONS = [0, 90, 180, 270] as const;
 const VALID_TEXT_FONTS = ['atkinson', 'jetbrains-mono', 'allerta-stencil'] as const;
 const VALID_TEXT_MODES = ['engrave', 'emboss', 'through-cut'] as const;
 
-// Constraints (server-side copies of client DESIGNER_CONSTRAINTS)
+// Constraints (server-side copies of client DESIGNER_CONSTRAINTS in
+// src/features/bin-designer/constants/gridfinity.ts — keep in sync).
 const CONSTRAINTS = {
   MIN_DIMENSION: 0.5,
-  MAX_DIMENSION: 8,
+  MAX_DIMENSION: 16,
   MIN_HEIGHT: 2,
   MAX_HEIGHT: 20,
   MAX_DIVIDERS: 10,
   MIN_DIVIDER_THICKNESS: 0.8,
-  MAX_DIVIDER_THICKNESS: 2.0,
+  MAX_DIVIDER_THICKNESS: 2.4,
   MIN_COMPARTMENT_GRID: 1,
-  MAX_COMPARTMENT_GRID: 8,
-  MIN_COMPARTMENT_THICKNESS: 0.8,
+  MAX_COMPARTMENT_GRID: 12,
+  MIN_COMPARTMENT_THICKNESS: 0.4,
   MAX_COMPARTMENT_THICKNESS: 2.4,
   MIN_LABEL_TAB_DEPTH: 8,
   MAX_LABEL_TAB_DEPTH: 20,

--- a/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.test.tsx
@@ -155,7 +155,6 @@ describe('WorkspaceHeader', () => {
     expect(screen.getByTitle('binDesigner.cutouts.alignLeft')).toBeInTheDocument();
     expect(screen.getByTitle('binDesigner.cutouts.alignRight')).toBeInTheDocument();
     expect(screen.getByText('binDesigner.cutouts.centerInBin')).toBeInTheDocument();
-    // Pathfinder Unite replaces the legacy "Combine" button.
     expect(screen.getByTitle('binDesigner.cutouts.pathfinder.union')).toBeInTheDocument();
   });
 });

--- a/src/features/bin-designer/utils/designJson.test.ts
+++ b/src/features/bin-designer/utils/designJson.test.ts
@@ -327,7 +327,7 @@ describe('validateBinParams', () => {
   it('should validate compartments.rows range', () => {
     const result = validateBinParams({
       ...DEFAULT_BIN_PARAMS,
-      compartments: { cols: 1, rows: 10, thickness: 1.2, cells: [] },
+      compartments: { cols: 1, rows: 13, thickness: 1.2, cells: [] },
     });
 
     expect(result.valid).toBe(false);

--- a/src/features/bin-designer/utils/designJson.ts
+++ b/src/features/bin-designer/utils/designJson.ts
@@ -6,6 +6,7 @@
  */
 
 import type { BinParams } from '../types';
+import { DESIGNER_CONSTRAINTS } from '../constants/gridfinity';
 import { migrateParams } from '../constants/defaults';
 import { sanitizeFileName } from './fileNaming';
 
@@ -261,21 +262,26 @@ export function validateBinParams(params: unknown): ValidateBinParamsResult {
   } else {
     const comp = p.compartments as Record<string, unknown>;
 
+    const { MIN_COMPARTMENT_GRID, MAX_COMPARTMENT_GRID } = DESIGNER_CONSTRAINTS;
     if (
       typeof comp.cols !== 'number' ||
       !Number.isInteger(comp.cols) ||
-      comp.cols < 1 ||
-      comp.cols > 8
+      comp.cols < MIN_COMPARTMENT_GRID ||
+      comp.cols > MAX_COMPARTMENT_GRID
     ) {
-      errors.push('compartments.cols must be an integer between 1 and 8');
+      errors.push(
+        `compartments.cols must be an integer between ${MIN_COMPARTMENT_GRID} and ${MAX_COMPARTMENT_GRID}`
+      );
     }
     if (
       typeof comp.rows !== 'number' ||
       !Number.isInteger(comp.rows) ||
-      comp.rows < 1 ||
-      comp.rows > 8
+      comp.rows < MIN_COMPARTMENT_GRID ||
+      comp.rows > MAX_COMPARTMENT_GRID
     ) {
-      errors.push('compartments.rows must be an integer between 1 and 8');
+      errors.push(
+        `compartments.rows must be an integer between ${MIN_COMPARTMENT_GRID} and ${MAX_COMPARTMENT_GRID}`
+      );
     }
     if (!Array.isArray(comp.cells)) {
       errors.push('compartments.cells must be an array');

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -635,6 +635,24 @@ describe('threemfExporter', () => {
       expect(config.layer_change_gcode).toMatch(/^\s*G92\s*E0\b/);
     });
 
+    // Pin acceleration to "use machine default" so Orca doesn't inherit
+    // Bambu's profile defaults (via our BambuStudio identity claim) and
+    // surface a false-positive comparison warning when the inherited travel
+    // value exceeds the user's printer's machine_max_acceleration_extruding.
+    it('pins acceleration to machine defaults to silence Orca comparison warning', () => {
+      const { vertices, normals } = createTwoTriangles();
+      const buffer = build3MFBuffer(vertices, normals, {
+        name: 'accel',
+        colorConfig: {
+          materials: [{ color: '#aaaaaa' }, { color: '#ff0000' }],
+          triangleMaterialIndices: [0, 1],
+        },
+      });
+      const config = JSON.parse(strFromU8(unzipSync(buffer)['Metadata/project_settings.config']));
+      expect(config.default_acceleration).toBe('0');
+      expect(config.travel_acceleration).toBe('0');
+    });
+
     it('omits project_settings.config when no colorConfig is provided', () => {
       const { vertices, normals } = createSingleTriangle();
       const buffer = build3MFBuffer(vertices, normals, { name: 'plain' });

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -294,6 +294,21 @@ function buildProjectSettingsConfig(palette: readonly string[]): string {
       // alternative of every multi-color export failing to slice on first try.
       use_relative_e_distances: '1',
       layer_change_gcode: 'G92 E0 ; Reset extruder for accurate multi-material\n',
+
+      // Defer all acceleration values to the user's printer profile rather
+      // than inheriting whatever Bambu defaults Orca picks up from our
+      // BambuStudio identity claim. Without these, Orca's GCodeWriter caps
+      // travel acceleration against `machine_max_acceleration_extruding` and
+      // surfaces a comparison warning when the inherited Bambu travel value
+      // exceeds the user's printer's extruding limit (a near-certain
+      // mismatch on Marlin/Klipper printers with conservative max accels).
+      // Setting `default_acceleration=0` is the canonical "use machine
+      // default" signal — Orca's `have_default_acceleration =
+      // default_acceleration > 0` gate (slic3r/GUI/ConfigManipulation.cpp)
+      // then hides every per-feature acceleration override in the loaded
+      // config, so the warning never fires.
+      default_acceleration: '0',
+      travel_acceleration: '0',
     },
     null,
     2


### PR DESCRIPTION
## Summary

Two unrelated fixes bundled — both are downstream cleanup of recent PR clusters.

### 1. Orca acceleration warning silenced
When opening our 3MFs, OrcaSlicer was surfacing a *travel acceleration > print acceleration* warning. Root cause: under our `BambuStudio-02.00.00.00` identity claim, Orca inherits Bambu profile defaults whose `travel_acceleration` typically exceeds non-Bambu printers' `machine_max_acceleration_extruding`.

Pin `default_acceleration: '0'` and `travel_acceleration: '0'` in `Metadata/project_settings.config`. Zero is Orca's "use machine default" signal — `ConfigManipulation.cpp` gates the per-feature acceleration UI on `default_acceleration > 0`, so a zero value hides every override and the slicer falls back to the printer's own limits. The comparison warning never fires.

### 2. Server validator drift — cloud shares of 9–12 row designs were 400-rejected
PR #1873 raised client `MAX_COMPARTMENT_GRID` from 8 to 12 but left the server validator (`api/lib/designerValidation.ts`) and a separate client-side JSON validator (`designJson.ts`) at the old cap. Same drift on three other constants:

| Constant | Client | Server (before) | Server (after) |
|---|---|---|---|
| `MAX_DIMENSION` | 16 | 8 | **16** |
| `MAX_COMPARTMENT_GRID` | 12 | 8 | **12** |
| `MAX_DIVIDER_THICKNESS` | 2.4 | 2.0 | **2.4** |
| `MIN_COMPARTMENT_THICKNESS` | 0.4 | 0.8 | **0.4** |

`designJson.ts` now imports from `DESIGNER_CONSTRAINTS` instead of hardcoding numbers, so client-side drift can't recur there. The server is still a manual copy (no cross-module import path between `api/` and `src/`) but the comment now points at the client as source of truth.

Also drops a one-line change-narration comment in `WorkspaceHeader.test.tsx`.

## Test plan
- [x] `pnpm exec vitest run` on affected files — 190 passing
- [x] `pnpm exec tsc --noEmit` — clean
- [x] ESLint on changed files — no new warnings
- [x] Pre-commit hooks (module boundaries / i18n keys / i18n values / i18n interpolation / exhaustiveness / component structure / missing tests) — all green
- [x] New regression tests: server accepts `cols=12, rows=12`; server accepts `width=16`; multi-color sidecar pins `default_acceleration='0'` and `travel_acceleration='0'`
- [ ] Manual: open exported 3MF in OrcaSlicer, confirm the acceleration warning is gone