### PR TITLE
feat(label-tabs): add adjustable shelf height

### DIFF
--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -52,6 +52,12 @@ const CONSTRAINTS = {
   MAX_LABEL_TAB_DEPTH: 20,
   MIN_LABEL_TAB_WIDTH: 10, // %
   MAX_LABEL_TAB_WIDTH: 100, // %
+  // Label tab height is the Z of the shelf top above the cavity floor (mm).
+  // Static bounds for API payloads — the client's UI uses a dynamic max
+  // tied to the current bin's interior height. Floor (9) = MIN_LABEL_TAB_DEPTH + 1;
+  // ceiling (140) = MAX_HEIGHT * 7mm (heightUnitMm).
+  MIN_LABEL_TAB_HEIGHT: 9,
+  MAX_LABEL_TAB_HEIGHT: 140,
   MAGNET_MIN_DEPTH: 2.0,
   MAGNET_MAX_DEPTH: 4.0,
   MAX_INSERTS: 20,
@@ -496,6 +502,14 @@ function validateLabel(label: unknown): string | null {
       !['left', 'center', 'right'].includes(label.alignment as string)
     ) {
       return 'label.alignment must be "left", "center", or "right"';
+    }
+    // Optional field; absent = anchor shelf at the wall top (legacy behavior).
+    if (
+      label.height !== undefined &&
+      (!isNumber(label.height) ||
+        !inRange(label.height, CONSTRAINTS.MIN_LABEL_TAB_HEIGHT, CONSTRAINTS.MAX_LABEL_TAB_HEIGHT))
+    ) {
+      return `label.height must be ${CONSTRAINTS.MIN_LABEL_TAB_HEIGHT}-${CONSTRAINTS.MAX_LABEL_TAB_HEIGHT}`;
     }
   }
   return null;

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -504,12 +504,20 @@ function validateLabel(label: unknown): string | null {
       return 'label.alignment must be "left", "center", or "right"';
     }
     // Optional field; absent = anchor shelf at the wall top (legacy behavior).
-    if (
-      label.height !== undefined &&
-      (!isNumber(label.height) ||
-        !inRange(label.height, CONSTRAINTS.MIN_LABEL_TAB_HEIGHT, CONSTRAINTS.MAX_LABEL_TAB_HEIGHT))
-    ) {
-      return `label.height must be ${CONSTRAINTS.MIN_LABEL_TAB_HEIGHT}-${CONSTRAINTS.MAX_LABEL_TAB_HEIGHT}`;
+    if (label.height !== undefined) {
+      if (
+        !isNumber(label.height) ||
+        !inRange(label.height, CONSTRAINTS.MIN_LABEL_TAB_HEIGHT, CONSTRAINTS.MAX_LABEL_TAB_HEIGHT)
+      ) {
+        return `label.height must be ${CONSTRAINTS.MIN_LABEL_TAB_HEIGHT}-${CONSTRAINTS.MAX_LABEL_TAB_HEIGHT}`;
+      }
+      // Cross-field: gusset needs at least 1mm clearance above the floor,
+      // so the shelf top must sit above the tab depth. Without this guard,
+      // the payload passes range checks but the builder silently drops the
+      // tab — the consumer's design loses geometry with no error signal.
+      if (isNumber(label.depth) && label.height <= label.depth) {
+        return 'label.height must be greater than label.depth';
+      }
     }
   }
   return null;

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
@@ -43,7 +43,7 @@ export function LabelTabsSection() {
       disabledReason={meta.disabledReason}
       valueSummary={meta.summary}
     >
-      {/* Width + Depth steppers side by side */}
+      {/* Width + Depth + Height steppers side by side */}
       <div className="flex items-end gap-2">
         <div className="flex-1 min-w-0">
           <span className="mb-1 block text-xs text-content-tertiary">
@@ -95,13 +95,39 @@ export function LabelTabsSection() {
             ariaLabel="Tab depth"
           />
         </div>
+        <div className="flex-1 min-w-0">
+          <span className="mb-1 block text-xs text-content-tertiary">
+            {t('binDesigner.tabHeight')}
+          </span>
+          <StepperControl
+            value={state.tabHeightMm}
+            onChange={handlers.setTabHeight}
+            onStep={(delta) =>
+              handlers.setTabHeight(
+                Math.min(
+                  state.tabHeightMax,
+                  Math.max(
+                    state.tabHeightMin,
+                    state.tabHeightMm + delta * DESIGNER_CONSTRAINTS.LABEL_TAB_HEIGHT_STEP
+                  )
+                )
+              )
+            }
+            min={state.tabHeightMin}
+            max={state.tabHeightMax}
+            step={DESIGNER_CONSTRAINTS.LABEL_TAB_HEIGHT_STEP}
+            variant="desktop"
+            ariaLabel="Tab height"
+          />
+        </div>
       </div>
 
-      {/* Physical tab dimensions */}
+      {/* Physical tab dimensions — only show H when explicitly set, so unaltered designs stay visually unchanged */}
       <div className="flex items-center gap-1.5 text-xs text-content-tertiary">
         <RulerIcon size="xs" />
         <span className="tabular-nums">
-          {state.tabWidthMm} × {state.label.depth} mm
+          {state.tabWidthMm} × {state.label.depth}
+          {state.heightIsExplicit ? ` × ${state.tabHeightMm}` : ''} mm
         </span>
       </div>
 

--- a/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.test.ts
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.test.ts
@@ -140,6 +140,21 @@ describe('useLabelTabsSection', () => {
       expect(result.current.state.tabHeightMin).toBe(13);
     });
 
+    it('tabHeightMax never exceeds wallHeight even when depth + 1 would', () => {
+      // 3u tall bin → wallHeight = 16mm. depth = 20mm pushes the depth-derived
+      // floor (21) past the ceiling; max must stay at wallHeight and min must
+      // collapse to it so the stepper can't request a Z the builder rejects.
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          label: { ...DEFAULT_BIN_PARAMS.label, depth: 20 },
+        },
+      });
+      const { result } = renderHook(() => useLabelTabsSection());
+      expect(result.current.state.tabHeightMax).toBe(16);
+      expect(result.current.state.tabHeightMin).toBe(16);
+    });
+
     it('setTabDepth clamps explicit height up when depth invalidates it', () => {
       useDesignerStore.setState({
         params: {

--- a/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.test.ts
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.test.ts
@@ -110,4 +110,64 @@ describe('useLabelTabsSection', () => {
     // outerW = 2*42 - 0.5 = 83.5, innerW = 83.5 - 2*1.2 = 81.1, cellW = 81.1
     expect(result.current.state.tabWidthMm).toBeGreaterThan(0);
   });
+
+  describe('tab height', () => {
+    it('heightIsExplicit is false by default and tabHeightMm falls back to wallHeight', () => {
+      const { result } = renderHook(() => useLabelTabsSection());
+      expect(result.current.state.heightIsExplicit).toBe(false);
+      // Default bin: 3u tall × 7mm = 21mm minus 5mm socket = 16mm wallHeight.
+      expect(result.current.state.tabHeightMm).toBe(16);
+    });
+
+    it('setTabHeight writes the explicit value', () => {
+      const { result } = renderHook(() => useLabelTabsSection());
+
+      act(() => {
+        result.current.handlers.setTabHeight(15);
+      });
+
+      expect(useDesignerStore.getState().params.label.height).toBe(15);
+    });
+
+    it('tabHeightMin equals depth + 1 (gusset floor clearance)', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          label: { ...DEFAULT_BIN_PARAMS.label, depth: 12 },
+        },
+      });
+      const { result } = renderHook(() => useLabelTabsSection());
+      expect(result.current.state.tabHeightMin).toBe(13);
+    });
+
+    it('setTabDepth clamps explicit height up when depth invalidates it', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          label: { ...DEFAULT_BIN_PARAMS.label, depth: 10, height: 12 },
+        },
+      });
+      const { result } = renderHook(() => useLabelTabsSection());
+
+      // New depth 15 invalidates height 12 (gusset would have zero clearance).
+      act(() => {
+        result.current.handlers.setTabDepth(15);
+      });
+
+      expect(useDesignerStore.getState().params.label.depth).toBe(15);
+      expect(useDesignerStore.getState().params.label.height).toBe(16);
+    });
+
+    it('setTabDepth leaves height untouched when height is unset (default-at-top)', () => {
+      const { result } = renderHook(() => useLabelTabsSection());
+
+      act(() => {
+        result.current.handlers.setTabDepth(18);
+      });
+
+      expect(useDesignerStore.getState().params.label.depth).toBe(18);
+      // Optional field stays undefined — no migration of legacy designs.
+      expect(useDesignerStore.getState().params.label.height).toBeUndefined();
+    });
+  });
 });

--- a/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.test.ts
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.test.ts
@@ -173,6 +173,27 @@ describe('useLabelTabsSection', () => {
       expect(useDesignerStore.getState().params.label.height).toBe(16);
     });
 
+    it('setTabDepth caps height clamp at wallHeightMm (no out-of-range writes)', () => {
+      // 3u tall bin → wallHeight = 16mm. Start with depth=10, height=11.
+      // Setting depth to 16 (= wallHeight) would naively clamp height to 17,
+      // which would exceed wallHeightMm and silently make the builder drop
+      // the tab once depth is reduced again. The cap keeps height ≤ 16.
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          label: { ...DEFAULT_BIN_PARAMS.label, depth: 10, height: 11 },
+        },
+      });
+      const { result } = renderHook(() => useLabelTabsSection());
+
+      act(() => {
+        result.current.handlers.setTabDepth(16);
+      });
+
+      expect(useDesignerStore.getState().params.label.depth).toBe(16);
+      expect(useDesignerStore.getState().params.label.height).toBe(16);
+    });
+
     it('setTabDepth leaves height untouched when height is unset (default-at-top)', () => {
       const { result } = renderHook(() => useLabelTabsSection());
 

--- a/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
@@ -52,7 +52,23 @@ export function useLabelTabsSection() {
 
   const setTabDepth = useCallback(
     (depth: number) => {
-      updateLabel({ depth });
+      // Height (when explicitly set) must stay above `depth` so the gusset
+      // has at least 1mm of clearance above the floor. If raising depth
+      // would invalidate the current height, lift height in lockstep — the
+      // alternative is silently returning no geometry from the builder.
+      const currentHeight = label.height;
+      if (currentHeight !== undefined && currentHeight <= depth) {
+        updateLabel({ depth, height: depth + 1 });
+      } else {
+        updateLabel({ depth });
+      }
+    },
+    [label.height, updateLabel]
+  );
+
+  const setTabHeight = useCallback(
+    (h: number) => {
+      updateLabel({ height: h });
     },
     [updateLabel]
   );
@@ -104,6 +120,23 @@ export function useLabelTabsSection() {
     return Math.round(((availableWidth * label.width) / 100) * 10) / 10;
   }, [params, compartments.cols, compartments.thickness, label.width]);
 
+  // Interior cavity height — dynamic max for the tab-height stepper.
+  // Matches `wallHeight` passed to the geometry builder.
+  const wallHeightMm = useMemo(() => binDimensions(params).wallHeight, [params]);
+
+  // Resolved tab height for display: explicit value when set, otherwise
+  // wall top (the default-when-absent contract from `LabelTabConfig`).
+  const tabHeightMm = label.height ?? wallHeightMm;
+  // Did the user explicitly set height? Controls whether the W×D×H summary
+  // shows the third dimension. Keeps unaltered designs visually unchanged.
+  const heightIsExplicit = label.height !== undefined;
+
+  // Dynamic min/max for the tab-height stepper. The geometry layer
+  // requires `height > depth` for a non-degenerate gusset, so the floor
+  // is `depth + 1`. Ceiling is the interior wall height.
+  const tabHeightMin = label.depth + 1;
+  const tabHeightMax = Math.max(tabHeightMin, wallHeightMm);
+
   const sectionSummary = useMemo(() => {
     if (!label.enabled) return undefined;
     const supportName = t(`binDesigner.tabSupport.${label.support}`);
@@ -146,12 +179,23 @@ export function useLabelTabsSection() {
   }, [compartments, t]);
 
   return {
-    state: { label, textDefaults, isUnavailable, tabWidthMm, compartmentTextRows },
+    state: {
+      label,
+      textDefaults,
+      isUnavailable,
+      tabWidthMm,
+      tabHeightMm,
+      heightIsExplicit,
+      tabHeightMin,
+      tabHeightMax,
+      compartmentTextRows,
+    },
     handlers: {
       toggleLabelTabs,
       setTabSupport,
       setTabDepth,
       setTabWidth,
+      setTabHeight,
       setTabAlignment,
       setCompartmentText,
       setTextFont,

--- a/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
@@ -39,6 +39,11 @@ export function useLabelTabsSection() {
   const tooShort = height <= DESIGNER_CONSTRAINTS.MIN_HEIGHT;
   const isUnavailable = !labelStatus.available || tooShort;
 
+  // Interior cavity height — dynamic max for the tab-height stepper and
+  // the cap for the `setTabDepth` height-clamp. Matches `wallHeight`
+  // passed to the geometry builder.
+  const wallHeightMm = useMemo(() => binDimensions(params).wallHeight, [params]);
+
   const toggleLabelTabs = useCallback(() => {
     updateLabel({ enabled: !label.enabled });
   }, [label.enabled, updateLabel]);
@@ -54,16 +59,21 @@ export function useLabelTabsSection() {
     (depth: number) => {
       // Height (when explicitly set) must stay above `depth` so the gusset
       // has at least 1mm of clearance above the floor. If raising depth
-      // would invalidate the current height, lift height in lockstep — the
-      // alternative is silently returning no geometry from the builder.
+      // would invalidate the current height, lift height in lockstep — and
+      // cap at `wallHeightMm` so we never write a value above the stepper's
+      // own ceiling. Without the cap, pushing depth up to wallHeight on a
+      // short bin would store height = depth + 1 > wallHeight; subsequently
+      // lowering depth wouldn't re-trigger the clamp (`currentHeight <= depth`
+      // is false), and the now-out-of-range height would silently make the
+      // builder drop the tab.
       const currentHeight = label.height;
       if (currentHeight !== undefined && currentHeight <= depth) {
-        updateLabel({ depth, height: depth + 1 });
+        updateLabel({ depth, height: Math.min(depth + 1, wallHeightMm) });
       } else {
         updateLabel({ depth });
       }
     },
-    [label.height, updateLabel]
+    [label.height, updateLabel, wallHeightMm]
   );
 
   const setTabHeight = useCallback(
@@ -119,10 +129,6 @@ export function useLabelTabsSection() {
     }
     return Math.round(((availableWidth * label.width) / 100) * 10) / 10;
   }, [params, compartments.cols, compartments.thickness, label.width]);
-
-  // Interior cavity height — dynamic max for the tab-height stepper.
-  // Matches `wallHeight` passed to the geometry builder.
-  const wallHeightMm = useMemo(() => binDimensions(params).wallHeight, [params]);
 
   // Resolved tab height for display: explicit value when set, otherwise
   // wall top (the default-when-absent contract from `LabelTabConfig`).

--- a/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
@@ -132,10 +132,14 @@ export function useLabelTabsSection() {
   const heightIsExplicit = label.height !== undefined;
 
   // Dynamic min/max for the tab-height stepper. The geometry layer
-  // requires `height > depth` for a non-degenerate gusset, so the floor
-  // is `depth + 1`. Ceiling is the interior wall height.
-  const tabHeightMin = label.depth + 1;
-  const tabHeightMax = Math.max(tabHeightMin, wallHeightMm);
+  // requires `height > depth` for a non-degenerate gusset (floor = depth + 1)
+  // and `height <= wallHeight` (ceiling = interior wall height).
+  // When the depth-derived floor exceeds the wall ceiling (a deep tab in a
+  // short bin), the only valid value is the wall top; collapse min onto max
+  // so the stepper can't request a Z the builder would reject — never let
+  // the stepper expose a max above the actual wall height.
+  const tabHeightMax = wallHeightMm;
+  const tabHeightMin = Math.min(label.depth + 1, tabHeightMax);
 
   const sectionSummary = useMemo(() => {
     if (!label.enabled) return undefined;

--- a/src/features/bin-designer/components/preview/GhostLabelTabs/GhostLabelTabs.tsx
+++ b/src/features/bin-designer/components/preview/GhostLabelTabs/GhostLabelTabs.tsx
@@ -29,6 +29,7 @@ export function GhostLabelTabs() {
     heightUnitMm,
     wallThickness,
     style,
+    baseStyle,
     compartments,
     label,
     generationStatus,
@@ -41,6 +42,7 @@ export function GhostLabelTabs() {
       heightUnitMm: s.params.heightUnitMm,
       wallThickness: s.params.wallThickness,
       style: s.params.style,
+      baseStyle: s.params.base.style,
       compartments: s.params.compartments,
       label: s.params.label,
       generationStatus: s.generation.status,
@@ -53,7 +55,16 @@ export function GhostLabelTabs() {
   const innerW = outerW - 2 * wallThickness;
   const innerD = outerD - 2 * wallThickness;
   const totalH = height * heightUnitMm;
-  const topZ = totalH;
+  // Floor sits at SOCKET_HEIGHT for socketed bins, at z=0 for flat. The wall
+  // top is at totalH in both cases (the socket extends below the floor).
+  // Mirrors `binDimensions`.
+  const wallHeightMm = baseStyle === 'flat' ? totalH : totalH - GRIDFINITY.SOCKET_HEIGHT;
+  const floorZ = baseStyle === 'flat' ? 0 : GRIDFINITY.SOCKET_HEIGHT;
+  // World Z of the shelf TOP. When `label.height` is absent, this matches the
+  // legacy `topZ = totalH` (wall top). With it set, the shelf drops below the
+  // rim — keep the ghost in lockstep with the BREP builder's anchor so the
+  // user sees instant feedback while regeneration is in flight (#1898).
+  const shelfTopWorldZ = floorZ + (label.height ?? wallHeightMm);
 
   const shouldShow =
     label.enabled &&
@@ -225,6 +236,11 @@ export function GhostLabelTabs() {
   if (!geometry || !material) return null;
 
   return (
-    <mesh geometry={geometry} material={material} position={[0, 0, topZ + 0.2]} renderOrder={2} />
+    <mesh
+      geometry={geometry}
+      material={material}
+      position={[0, 0, shelfTopWorldZ + 0.2]}
+      renderOrder={2}
+    />
   );
 }

--- a/src/features/bin-designer/constants/gridfinity.ts
+++ b/src/features/bin-designer/constants/gridfinity.ts
@@ -44,6 +44,14 @@ export const DESIGNER_CONSTRAINTS = {
   MIN_LABEL_TAB_WIDTH: 10, // % of compartment column width
   MAX_LABEL_TAB_WIDTH: 100, // %
   LABEL_TAB_WIDTH_STEP: 5, // %
+  // Tab height is the Z position of the shelf TOP above the cavity floor (mm).
+  // Default (field absent) = wall top. Lowering creates a tuck-under pocket
+  // between the rim and the shelf. The dynamic max is the interior wall
+  // height (computed at render time); the dynamic min is `tabDepth + 1` so
+  // the gusset retains 1mm of clearance above the floor.
+  MIN_LABEL_TAB_HEIGHT: 9, // mm — derived from MIN_LABEL_TAB_DEPTH + 1
+  MAX_LABEL_TAB_HEIGHT: 140, // mm — derived from MAX_HEIGHT (20) * heightUnitMm (7)
+  LABEL_TAB_HEIGHT_STEP: 1, // mm
   MAX_HISTORY: 100, // undo/redo states
   // Wall thickness
   MIN_WALL_THICKNESS: 0.4, // mm (1-wall for 0.4mm nozzle)

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -241,6 +241,18 @@ export interface LabelTabConfig {
   readonly depth: number;
   /** Width of each tab as percentage of compartment column width (1-100) */
   readonly width: number;
+  /**
+   * Z position of the shelf TOP above the cavity floor, in mm. When absent
+   * (default), the shelf anchors to the wall top — identical to the original
+   * label-tab behavior. Lowering this value drops the shelf down, creating a
+   * tuck-under pocket between the stacking rim and the shelf (useful for
+   * keeping springy contents from popping out — see issue #1898).
+   *
+   * Bounds enforced by the UI: `[tabDepth + 1, interiorHeight]`. The geometry
+   * layer also guards against degenerate configs (returns null when the
+   * gusset has no room).
+   */
+  readonly height?: number;
   /** Horizontal alignment within each compartment column */
   readonly alignment: LabelTabAlignment;
   /**

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -146,6 +146,8 @@ exports[`label tabs > 2×2 label disabled 1`] = `2812`;
 
 exports[`label tabs > 2×2 label solid left 1`] = `3380`;
 
+exports[`label tabs > 2×2×6 label dropped (height = 20mm) 1`] = `3280`;
+
 exports[`large bin > 8×8 standard 1`] = `23180`;
 
 exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3304`;

--- a/src/features/generation/worker/generators/labelTabBuilder.test.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.test.ts
@@ -151,6 +151,95 @@ describe('buildLabelTabs', () => {
     });
   });
 
+  describe('tab height (vertical position)', () => {
+    it('omitting height anchors the shelf at the wall top (legacy behavior)', async () => {
+      const { buildLabelTabs } = await import('./labelTabBuilder');
+      const { mesh } = await import('brepjs');
+      const wallHeight = 35;
+      const wt = 1.2;
+      const params = {
+        ...DEFAULT_BIN_PARAMS,
+        // Note: no `height` field → must produce the pre-#1898 geometry.
+        label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket' as const },
+      };
+      const result = buildLabelTabs(params, 80, 80, wallHeight, wt);
+      expect(result).not.toBeNull();
+
+      const tessellated = mesh(result!, { tolerance: 0.1, angularTolerance: 10 });
+      const verts = tessellated.vertices;
+      let maxZ = -Infinity;
+      for (let i = 2; i < verts.length; i += 3) {
+        if (verts[i] > maxZ) maxZ = verts[i];
+      }
+      // Shelf top should reach the wall top.
+      expect(maxZ).toBeCloseTo(wallHeight, 1);
+    });
+
+    it('explicit height drops the shelf below the wall top', async () => {
+      const { buildLabelTabs } = await import('./labelTabBuilder');
+      const { mesh } = await import('brepjs');
+      const wallHeight = 50;
+      const wt = 1.2;
+      const tabDepth = 12;
+      const tabHeight = 20;
+      const params = {
+        ...DEFAULT_BIN_PARAMS,
+        label: {
+          ...DEFAULT_BIN_PARAMS.label,
+          enabled: true,
+          support: 'bracket' as const,
+          depth: tabDepth,
+          height: tabHeight,
+        },
+      };
+      const result = buildLabelTabs(params, 80, 80, wallHeight, wt);
+      expect(result).not.toBeNull();
+
+      const tessellated = mesh(result!, { tolerance: 0.1, angularTolerance: 10 });
+      const verts = tessellated.vertices;
+      let maxZ = -Infinity;
+      let minZ = Infinity;
+      for (let i = 2; i < verts.length; i += 3) {
+        if (verts[i] > maxZ) maxZ = verts[i];
+        if (verts[i] < minZ) minZ = verts[i];
+      }
+      // Shelf top must sit at the requested height, not at the wall top.
+      expect(maxZ).toBeCloseTo(tabHeight, 1);
+      // Gusset bottom = tabHeight - tabDepth = 8mm above the floor.
+      expect(minZ).toBeCloseTo(tabHeight - tabDepth, 1);
+    });
+
+    it('returns null when height exceeds wall height', async () => {
+      const { buildLabelTabs } = await import('./labelTabBuilder');
+      const params = {
+        ...DEFAULT_BIN_PARAMS,
+        label: {
+          ...DEFAULT_BIN_PARAMS.label,
+          enabled: true,
+          height: 50, // > wallHeight
+        },
+      };
+      // wallHeight = 35, height = 50 → invalid.
+      const result = buildLabelTabs(params, 80, 80, 35, 1.2);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when height <= depth (no room for gusset)', async () => {
+      const { buildLabelTabs } = await import('./labelTabBuilder');
+      const params = {
+        ...DEFAULT_BIN_PARAMS,
+        label: {
+          ...DEFAULT_BIN_PARAMS.label,
+          enabled: true,
+          depth: 12,
+          height: 12, // shelfTopZ - tabHeight = 0 → degenerate
+        },
+      };
+      const result = buildLabelTabs(params, 80, 80, 35, 1.2);
+      expect(result).toBeNull();
+    });
+  });
+
   it.each(['solid', 'bracket', 'fillet'] as const)(
     '%s support reaches the front edge of the shelf (no overhang gap)',
     async (support) => {

--- a/src/features/generation/worker/generators/labelTabBuilder.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.ts
@@ -77,12 +77,25 @@ function buildLabelTabsInScope(
   const wt = wallThickness;
   const gt = thickness; // gusset thickness = compartment divider thickness
 
-  // Tab envelope height equals depth (design invariant).
+  // Tab envelope height equals depth (design invariant — the gusset is a
+  // 45° right triangle, so its vertical leg matches its horizontal leg).
   // Gusset height is tabHeight - wt (shelf occupies the top wt).
   const tabHeight = tabDepth;
 
-  // Safety: tab must fit within wall height
+  // `shelfTopZ` is the Z of the shelf TOP above the cavity floor (mm).
+  // When `params.label.height` is undefined, anchor to the wall top — the
+  // original behavior. When explicitly set, place the shelf at that Z so
+  // the user can drop it down to leave a tuck-under pocket above (#1898).
+  // The geometry is built in a local frame (shelf top at Z=tabHeight) and
+  // then translated up by `shelfTopZ - tabHeight`, so the entire
+  // shelf+gusset assembly slides down as a unit.
+  const shelfTopZ = params.label.height ?? wallHeight;
+
+  // Safety: tab must fit within wall height AND between floor and shelfTopZ.
+  // `shelfTopZ - tabHeight` is the Z of the gusset bottom; if it's <= 0 the
+  // gusset would clip the floor.
   if (tabHeight > wallHeight || tabHeight <= 0) return null;
+  if (shelfTopZ > wallHeight || shelfTopZ - tabHeight <= 0) return null;
 
   const cellW = innerW / cols;
   const cellD = innerD / rows;
@@ -255,10 +268,9 @@ function buildLabelTabsInScope(
         shelfThickness: wt,
       });
 
-      // Position: X at alignment offset, Y at compartment back edge, Z at tab base
-      tabSolid = scope.register(
-        translate(tabSolid, [tabXStart, backEdgeY, wallHeight - tabHeight])
-      );
+      // Position: X at alignment offset, Y at compartment back edge,
+      // Z at gusset base (= shelfTopZ - tabHeight).
+      tabSolid = scope.register(translate(tabSolid, [tabXStart, backEdgeY, shelfTopZ - tabHeight]));
 
       allTabs.push(tabSolid);
 

--- a/src/features/generation/worker/generators/scenarios/labelTabs.ts
+++ b/src/features/generation/worker/generators/scenarios/labelTabs.ts
@@ -33,4 +33,18 @@ export const labelTabs: ScenarioCase[] = [
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket', alignment: 'right' },
     },
   }),
+  // Tall bin (6u \u2192 wallHeight \u2248 37mm) so the explicit `height: 20mm` lands
+  // well below the wall top, exercising the dropped-shelf path from #1898.
+  defineScenario('label tabs', '2\u00d72\u00d76 label dropped (height = 20mm)', {
+    params: {
+      height: 6,
+      label: {
+        ...DEFAULT_BIN_PARAMS.label,
+        enabled: true,
+        support: 'bracket',
+        alignment: 'left',
+        height: 20,
+      },
+    },
+  }),
 ];

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -566,6 +566,7 @@
   "binDesigner.tabEngravedText": "Gravierter Text",
   "binDesigner.tabEngravedTextAriaLabel": "Gravierter Text für Fach {n}",
   "binDesigner.tabEngravedTextPlaceholder": "z. B. SCHRAUBEN",
+  "binDesigner.tabHeight": "Halterhöhe",
   "binDesigner.tabSupport": "Stütze",
   "binDesigner.tabSupport.bracket": "Bügel",
   "binDesigner.tabSupport.fillet": "Gebogen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1172,6 +1172,7 @@
   "binDesigner.tabSupport.solid": "Solid",
   "binDesigner.tabDepth": "Tab depth",
   "binDesigner.tabWidth": "Tab width",
+  "binDesigner.tabHeight": "Tab height",
   "binDesigner.tabAlignment": "Tab alignment",
   "binDesigner.alignment.left": "Left",
   "binDesigner.alignment.center": "Center",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1371,6 +1371,7 @@ const en: Record<string, string> = {
   'binDesigner.tabSupport.solid': 'Solid',
   'binDesigner.tabDepth': 'Tab depth',
   'binDesigner.tabWidth': 'Tab width',
+  'binDesigner.tabHeight': 'Tab height',
   'binDesigner.tabAlignment': 'Tab alignment',
   'binDesigner.alignment.left': 'Left',
   'binDesigner.alignment.center': 'Center',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -566,6 +566,7 @@
   "binDesigner.tabEngravedText": "Texto grabado",
   "binDesigner.tabEngravedTextAriaLabel": "Texto grabado para el compartimento {n}",
   "binDesigner.tabEngravedTextPlaceholder": "p. ej. TORNILLOS",
+  "binDesigner.tabHeight": "Altura de pestaña",
   "binDesigner.tabSupport": "Soporte",
   "binDesigner.tabSupport.bracket": "Soporte abierto",
   "binDesigner.tabSupport.fillet": "Curvado",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -566,6 +566,7 @@
   "binDesigner.tabEngravedText": "Texte gravé",
   "binDesigner.tabEngravedTextAriaLabel": "Texte gravé pour le compartiment {n}",
   "binDesigner.tabEngravedTextPlaceholder": "p. ex. VIS",
+  "binDesigner.tabHeight": "Hauteur d'onglet",
   "binDesigner.tabSupport": "Support",
   "binDesigner.tabSupport.bracket": "Étrier",
   "binDesigner.tabSupport.fillet": "Courbé",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -566,6 +566,7 @@
   "binDesigner.tabEngravedText": "彫刻文字",
   "binDesigner.tabEngravedTextAriaLabel": "区画{n}の彫刻文字",
   "binDesigner.tabEngravedTextPlaceholder": "例: SCREWS",
+  "binDesigner.tabHeight": "タブの高さ",
   "binDesigner.tabSupport": "サポート",
   "binDesigner.tabSupport.bracket": "ブラケット",
   "binDesigner.tabSupport.fillet": "曲線状",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -566,6 +566,7 @@
   "binDesigner.tabEngravedText": "Gravert tekst",
   "binDesigner.tabEngravedTextAriaLabel": "Gravert tekst for rom {n}",
   "binDesigner.tabEngravedTextPlaceholder": "f.eks. SKRUER",
+  "binDesigner.tabHeight": "Fanehøyde",
   "binDesigner.tabSupport": "Støtte",
   "binDesigner.tabSupport.bracket": "Brakett",
   "binDesigner.tabSupport.fillet": "Buet",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -566,6 +566,7 @@
   "binDesigner.tabEngravedText": "Gegraveerde tekst",
   "binDesigner.tabEngravedTextAriaLabel": "Gegraveerde tekst voor compartiment {n}",
   "binDesigner.tabEngravedTextPlaceholder": "bijv. SCHROEVEN",
+  "binDesigner.tabHeight": "Tabhoogte",
   "binDesigner.tabSupport": "Steun",
   "binDesigner.tabSupport.bracket": "Beugel",
   "binDesigner.tabSupport.fillet": "Gebogen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -566,6 +566,7 @@
   "binDesigner.tabEngravedText": "Texto gravado",
   "binDesigner.tabEngravedTextAriaLabel": "Texto gravado para o compartimento {n}",
   "binDesigner.tabEngravedTextPlaceholder": "ex. PARAFUSOS",
+  "binDesigner.tabHeight": "Altura da aba",
   "binDesigner.tabSupport": "Suporte",
   "binDesigner.tabSupport.bracket": "Suporte aberto",
   "binDesigner.tabSupport.fillet": "Curvado",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -566,6 +566,7 @@
   "binDesigner.tabEngravedText": "Graverad text",
   "binDesigner.tabEngravedTextAriaLabel": "Graverad text för fack {n}",
   "binDesigner.tabEngravedTextPlaceholder": "t.ex. SKRUVAR",
+  "binDesigner.tabHeight": "Flikhöjd",
   "binDesigner.tabSupport": "Stöd",
   "binDesigner.tabSupport.bracket": "Konsol",
   "binDesigner.tabSupport.fillet": "Kurvad",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -566,6 +566,7 @@
   "binDesigner.tabEngravedText": "Гравірований текст",
   "binDesigner.tabEngravedTextAriaLabel": "Гравірований текст для відсіку {n}",
   "binDesigner.tabEngravedTextPlaceholder": "напр. ГВИНТИ",
+  "binDesigner.tabHeight": "Висота виступу",
   "binDesigner.tabSupport": "Підтримка",
   "binDesigner.tabSupport.bracket": "Кронштейн",
   "binDesigner.tabSupport.fillet": "Закруглена",


### PR DESCRIPTION
## Summary

- Adds an optional **`height`** field to `LabelTabConfig` — the Z position of the shelf top above the cavity floor (mm). Absent = anchor at wall top (legacy behavior, byte-identical output).
- Lowering `height` drops the entire tab assembly (shelf + gusset) down the back wall, leaving a **tuck-under pocket** between the rim and the shelf. Solves #1898 (springy jumper-wire bins where the wires won't stay tucked).
- UI: third stepper joins Width / Depth in the parametric row, labeled "Tab height". Dynamic min = `tabDepth + 1`, dynamic max = interior wall height. `setTabDepth` clamps height upward when needed so the geometry layer doesn't silently render nothing.
- API validation, all 9 locales, and the scenario suite are updated in lockstep.

Closes #1898.

## How the change is contained

- **Type** (`LabelTabConfig.height?: number`) — optional, so existing serialized designs round-trip identically.
- **Builder** — single anchor swap: `shelfTopZ - tabHeight` replaces `wallHeight - tabHeight`. Gussets keep their original size; the assembly slides as a unit.
- **Cache key** — unchanged (`v3`). The existing `stableSerialize(params.label)` already differentiates absent vs. present `height`.
- **API** — new `MIN/MAX_LABEL_TAB_HEIGHT` constants mirror the client; validator rejects out-of-range values when the field is present.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors (only pre-existing warnings)
- [x] `pnpm run check:i18n` — all 8 JSON locales match `en.ts`
- [x] Full vitest suite (855 files / 11901 tests) — passing
- [x] New scenario `2×2×6 label dropped (height = 20mm)` — distinct snapshot from existing label scenarios
- [x] New builder tests — Z position, default-at-top, returns null for invalid configs
- [x] New hook tests — bounds, depth-invalidates-height clamp, no migration of legacy designs
- [ ] Manual: open the bin designer, enable label tabs, drop the height stepper, verify a pocket appears between rim and shelf in the 3D preview