### PR TITLE
fix(split-bin): cut stacking lip with wall cutouts

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.split-wall-cutout-lip.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-wall-cutout-lip.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+/**
+ * Scenario tests for wall cutouts on split bins with a stacking lip.
+ *
+ * Verifies that wall cutouts also remove material from the separately-built
+ * stacking lip in split bins. Without the fix, the lip is generated fresh
+ * via buildTopShape() and never receives the wall-cutout cuts, so the lip's
+ * rim stays intact above each cutout — leaving an unsupported overhang where
+ * the wall opening should pass cleanly through the lip too.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
+import type { BinParams, SplitConnectorConfig } from '@/shared/types/bin';
+import { initBrepjs, getGenerateSplitPreview } from './__kernel-tests__/wasmInit';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+const NO_CONNECTORS: SplitConnectorConfig = {
+  ...DEFAULT_SPLIT_CONNECTOR_CONFIG,
+  enabled: false,
+};
+
+/** Count vertices whose Z lies above the wall top (= inside the lip zone). */
+function countLipVertices(vertices: Float32Array, zMin: number): number {
+  let count = 0;
+  for (let i = 0; i < vertices.length; i += 3) {
+    if (vertices[i + 2] >= zMin) count++;
+  }
+  return count;
+}
+
+describe('split bin: wall cutouts must also cut the stacking lip', () => {
+  it('lip carries extra cut geometry when front/back wall cutouts are enabled', () => {
+    const generateSplitPreview = getGenerateSplitPreview();
+
+    const baseParams: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 6,
+      depth: 2,
+      height: 3,
+    };
+
+    const withCutouts: BinParams = {
+      ...baseParams,
+      walls: {
+        ...baseParams.walls,
+        enabled: true,
+        front: {
+          enabled: true,
+          width: 60,
+          depth: 60,
+          alignment: 'center',
+          offset: 0,
+          widthMm: null,
+        },
+        back: {
+          enabled: true,
+          width: 60,
+          depth: 60,
+          alignment: 'center',
+          offset: 0,
+          widthMm: null,
+        },
+      },
+    };
+
+    const cutResult = generateSplitPreview(withCutouts, [0], [], NO_CONNECTORS);
+    const flatResult = generateSplitPreview(baseParams, [0], [], NO_CONNECTORS);
+
+    const wallTopZ = baseParams.height * baseParams.heightUnitMm;
+    const lipZMin = wallTopZ + 0.1;
+
+    expect(cutResult.pieces).toHaveLength(2);
+    expect(flatResult.pieces).toHaveLength(2);
+
+    for (let i = 0; i < cutResult.pieces.length; i++) {
+      const cutLip = countLipVertices(cutResult.pieces[i].vertices, lipZMin);
+      const flatLip = countLipVertices(flatResult.pieces[i].vertices, lipZMin);
+      expect(
+        cutLip,
+        `piece ${cutResult.pieces[i].label}: expected more lip vertices ` +
+          `from wall-cutout cuts (cuts=${cutLip}, flat=${flatLip})`
+      ).toBeGreaterThan(flatLip);
+    }
+  }, 120000);
+});

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -30,6 +30,7 @@ import { getLastSolid, setLastSolid } from './shapeCache';
 import { applySplitConnectors, computeCutFaces } from './splitConnectorBuilder';
 import type { BinGeometryContext } from './splitConnectorBuilder';
 import { buildLipSlotCuts } from './slotBuilder';
+import { buildWallCutoutCuts } from './wallCutoutBuilder';
 import { isAbortError } from './utils/abort';
 
 /** Result of a split export: array of piece buffers with grid labels */
@@ -224,6 +225,33 @@ function splitSolidIntoPieces(
           lipSolid = newLip;
         } finally {
           lipCuts.delete();
+        }
+      }
+    }
+
+    // Same situation for wall cutouts: the body got its wall cutouts via the
+    // normal pipeline on bodyParams (where dim.hasLip=false, so the cutters
+    // only overshoot the wall top by 2mm). The freshly-built lip would
+    // otherwise still seal off the opening that should pass cleanly through
+    // both wall and lip. Pass hasLip=true so the cutters extend through the
+    // full lip zone, then shift them up by floorZ to convert body-local Z
+    // (floor at Z=0) into absolute bin Z (socket bottom at Z=0).
+    if (params.walls.enabled) {
+      const innerW = outerW - 2 * params.wallThickness;
+      const innerD = outerD - 2 * params.wallThickness;
+      const wallCuts = buildWallCutoutCuts(params, innerW, innerD, wallHeight, true);
+      if (wallCuts) {
+        let positioned = wallCuts;
+        if (floorZ !== 0) {
+          positioned = translate(wallCuts, [0, 0, floorZ]);
+          wallCuts.delete();
+        }
+        try {
+          const newLip = unwrap(cut(lipSolid as ValidSolid, positioned as ValidSolid));
+          lipSolid.delete();
+          lipSolid = newLip;
+        } finally {
+          positioned.delete();
         }
       }
     }


### PR DESCRIPTION
## Summary

- Wall cutouts now pass through the stacking lip on split bins. Previously the lip stayed solid above each cutout, blocking what should be a clean opening through the wall and lip.
- Mirrors the existing slotted-bin pattern (`buildLipSlotCuts`): split bins build the body without the lip to dodge an OCCT crash, so any feature that should also cut the lip has to be re-applied to the separately-built lip solid.

## Why the bug existed

`splitBinBuilder.ts` builds the body with `stackingLip: false`, which makes `dim.hasLip=false` in the body pipeline. That collapses `buildWallCutoutCuts`'s `overshoot = (hasLip ? LIP_HEIGHT : 0) + 2` to just 2 mm — body cuts never reach into the lip zone. The lip was then rebuilt fresh via `buildTopShape()` with no cutouts ever applied to it.

## Fix

After the existing `buildLipSlotCuts` block, call `buildWallCutoutCuts(params, innerW, innerD, wallHeight, true)` so the cutters extend through the full lip zone, shift them up by `floorZ` to convert body-local Z to absolute bin Z, then cut the lip.

## Follow-up worth flagging

Other features that pass through both wall and lip (label tabs, handles, wall patterns) likely have the same latent gap — they go through the body-only pipeline and never touch the separately-built lip in split mode.

## Test plan

- [x] New failing scenario test `binGenerator.scenario.split-wall-cutout-lip.test.ts` reproduces the bug (`cuts=112, flat=112` before fix)
- [x] After fix, test asserts lip carries extra cut geometry vs. the no-cutout control
- [x] Full test suite passes (11933 tests)
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` 0 errors
- [ ] Manual: download split-bin STL with wall cutouts + lip enabled and confirm the cut passes through the lip in slicer