### PR TITLE
fix(bin-designer): show both print bed dimensions in Physical Units

### DIFF
--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -139,7 +139,15 @@ intersection`, not XOR** — they coincide for 2 members but diverge for
     to identity — a single uniform scalar would distort circles and rotated
     shapes. Path bounds use `getPathBounds` (flattened bezier) so curves that
     bow outward beyond their anchors aren't clipped.
-13. **`BinMesh` multi↔single material switch needs distinct keys** — the
+13. **Physical-units print bed is dual-axis** — the section uses the shared
+    `PrintBedInput`, so width and depth round-trip independently when the
+    link toggle is off. The linked state is encoded by
+    `settings.defaultPrintBedDepth === undefined` (`undefined` = "follow
+    width", not "0" or "missing"). `usePhysicalUnitsSection.handlePrintBedChange`
+    must call the setter with `depth: undefined` when relinking — otherwise
+    a stale depth lingers in localStorage and the bed silently stays
+    non-square on the next load.
+14. **`BinMesh` multi↔single material switch needs distinct keys** — the
     multi-color branch passes `material` as a `<mesh>` **prop** (array of
     `MeshStandardMaterial`), the single-color branch declares the material as
     a `<meshStandardMaterial>` **child**. Without keys, R3F (9.x) reuses the

--- a/src/features/bin-designer/components/panel/PhysicalUnitsSection/PhysicalUnitsSection.test.tsx
+++ b/src/features/bin-designer/components/panel/PhysicalUnitsSection/PhysicalUnitsSection.test.tsx
@@ -19,9 +19,9 @@ describe('PhysicalUnitsSection', () => {
     expect(screen.getByLabelText('Height unit')).toBeInTheDocument();
   });
 
-  it('renders print bed input', () => {
+  it('renders print bed width input (linked by default)', () => {
     render(<PhysicalUnitsSection />);
-    expect(screen.getByLabelText('Print bed')).toBeInTheDocument();
+    expect(screen.getByLabelText('Print bed width')).toBeInTheDocument();
   });
 
   it('expands when a help-jump targets binDesigner:base so the print-bed marker is reachable', () => {

--- a/src/features/bin-designer/components/panel/PhysicalUnitsSection/PhysicalUnitsSection.tsx
+++ b/src/features/bin-designer/components/panel/PhysicalUnitsSection/PhysicalUnitsSection.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react';
 import { CollapsibleSection } from '@/shared/components/CollapsibleSection';
 import { SettingsRow } from '@/shared/components/SettingsRow';
 import { DeferredNumberInput } from '@/shared/components/DeferredNumberInput';
+import { PrintBedInput } from '@/shared/components/PrintBedInput';
 import { helpJumpEventName } from '@/shared/help/helpJumpDispatcher';
 import { usePhysicalUnitsSection } from './usePhysicalUnitsSection';
 
@@ -64,14 +65,11 @@ export function PhysicalUnitsSection() {
           tooltip={t('binDesigner.printBedTooltip')}
           unit="mm"
         >
-          <DeferredNumberInput
-            value={state.printBedSize}
+          <PrintBedInput
+            width={state.printBedSize}
+            depth={state.printBedDepth}
             onChange={handlers.handlePrintBedChange}
-            min={42}
-            max={500}
-            step={10}
-            className="input w-14 py-0.5 px-1 text-xs text-right"
-            aria-label={t('settings.printBed')}
+            variant="compact"
           />
         </SettingsRow>
       </div>

--- a/src/features/bin-designer/components/panel/PhysicalUnitsSection/usePhysicalUnitsSection.test.ts
+++ b/src/features/bin-designer/components/panel/PhysicalUnitsSection/usePhysicalUnitsSection.test.ts
@@ -3,13 +3,11 @@ import { renderHook, act } from '@testing-library/react';
 import { usePhysicalUnitsSection } from './usePhysicalUnitsSection';
 import { useLayoutStore } from '@/core/store/layout';
 import { useSettingsStore } from '@/core/store';
+import { resetAllStores } from '@/test/testUtils';
 
 describe('usePhysicalUnitsSection', () => {
   beforeEach(() => {
-    // Reset layout store to defaults (gridUnitMm: 42, heightUnitMm: 7)
-    const state = useLayoutStore.getState();
-    state.setGridUnitMm(42);
-    state.setHeightUnitMm(7);
+    resetAllStores();
   });
 
   it('returns grid and height unit values from layout store', () => {

--- a/src/features/bin-designer/components/panel/PhysicalUnitsSection/usePhysicalUnitsSection.test.ts
+++ b/src/features/bin-designer/components/panel/PhysicalUnitsSection/usePhysicalUnitsSection.test.ts
@@ -45,13 +45,36 @@ describe('usePhysicalUnitsSection', () => {
     expect(result.current.meta.summary).toBe('42mm grid, 7mm height');
   });
 
-  it('returns print bed size from settings store', () => {
+  it('returns print bed width and depth from settings store', () => {
     const { result } = renderHook(() => usePhysicalUnitsSection());
 
     expect(result.current.state.printBedSize).toBe(256);
+    expect(result.current.state.printBedDepth).toBe(256);
   });
 
-  it('handlePrintBedChange updates settings store', () => {
+  it('printBedDepth falls back to printBedSize when unset (linked)', () => {
+    useSettingsStore.getState().updateSettings({
+      defaultPrintBedSize: 256,
+      defaultPrintBedDepth: undefined,
+    });
+    const { result } = renderHook(() => usePhysicalUnitsSection());
+
+    expect(result.current.state.printBedDepth).toBe(256);
+  });
+
+  it('printBedDepth reflects independent depth when unlinked', () => {
+    useSettingsStore.getState().updateSettings({
+      defaultPrintBedSize: 256,
+      defaultPrintBedDepth: 180,
+    });
+    const { result } = renderHook(() => usePhysicalUnitsSection());
+
+    expect(result.current.state.printBedSize).toBe(256);
+    expect(result.current.state.printBedDepth).toBe(180);
+  });
+
+  it('handlePrintBedChange with single arg clears depth (linked)', () => {
+    useSettingsStore.getState().updateSettings({ defaultPrintBedDepth: 180 });
     const { result } = renderHook(() => usePhysicalUnitsSection());
 
     act(() => {
@@ -59,19 +82,33 @@ describe('usePhysicalUnitsSection', () => {
     });
 
     expect(useSettingsStore.getState().settings.defaultPrintBedSize).toBe(300);
+    expect(useSettingsStore.getState().settings.defaultPrintBedDepth).toBeUndefined();
   });
 
-  it('handlePrintBedChange clamps to valid range', () => {
+  it('handlePrintBedChange with both args stores independent depth', () => {
     const { result } = renderHook(() => usePhysicalUnitsSection());
 
     act(() => {
-      result.current.handlers.handlePrintBedChange(10);
+      result.current.handlers.handlePrintBedChange(300, 180);
+    });
+
+    expect(useSettingsStore.getState().settings.defaultPrintBedSize).toBe(300);
+    expect(useSettingsStore.getState().settings.defaultPrintBedDepth).toBe(180);
+  });
+
+  it('handlePrintBedChange clamps both dimensions to valid range', () => {
+    const { result } = renderHook(() => usePhysicalUnitsSection());
+
+    act(() => {
+      result.current.handlers.handlePrintBedChange(10, 999);
     });
     expect(useSettingsStore.getState().settings.defaultPrintBedSize).toBe(42);
+    expect(useSettingsStore.getState().settings.defaultPrintBedDepth).toBe(500);
 
     act(() => {
       result.current.handlers.handlePrintBedChange(999);
     });
     expect(useSettingsStore.getState().settings.defaultPrintBedSize).toBe(500);
+    expect(useSettingsStore.getState().settings.defaultPrintBedDepth).toBeUndefined();
   });
 });

--- a/src/features/bin-designer/components/panel/PhysicalUnitsSection/usePhysicalUnitsSection.ts
+++ b/src/features/bin-designer/components/panel/PhysicalUnitsSection/usePhysicalUnitsSection.ts
@@ -12,10 +12,11 @@ export function usePhysicalUnitsSection() {
       heightUnitMm: s.layout.heightUnitMm,
     }))
   );
-  const { printBedSize, updateSetting } = useSettingsStore(
+  const { printBedSize, printBedDepth, updateSettings } = useSettingsStore(
     useShallow((s) => ({
       printBedSize: s.settings.defaultPrintBedSize,
-      updateSetting: s.updateSetting,
+      printBedDepth: s.settings.defaultPrintBedDepth ?? s.settings.defaultPrintBedSize,
+      updateSettings: s.updateSettings,
     }))
   );
   const t = useTranslation();
@@ -29,10 +30,15 @@ export function usePhysicalUnitsSection() {
   }, []);
 
   const handlePrintBedChange = useCallback(
-    (value: number) => {
-      updateSetting('defaultPrintBedSize', Math.max(42, Math.min(500, value)));
+    (width: number, depth?: number) => {
+      const clampedWidth = Math.max(42, Math.min(500, width));
+      const clampedDepth = depth === undefined ? undefined : Math.max(42, Math.min(500, depth));
+      updateSettings({
+        defaultPrintBedSize: clampedWidth,
+        defaultPrintBedDepth: clampedDepth,
+      });
     },
-    [updateSetting]
+    [updateSettings]
   );
 
   const meta: SectionMeta = useMemo(
@@ -41,7 +47,7 @@ export function usePhysicalUnitsSection() {
   );
 
   return {
-    state: { gridUnitMm, heightUnitMm, printBedSize },
+    state: { gridUnitMm, heightUnitMm, printBedSize, printBedDepth },
     handlers: { handleGridUnitChange, handleHeightUnitChange, handlePrintBedChange },
     meta,
     t,


### PR DESCRIPTION
## Summary

- The Bin Designer's **Physical Units** section only exposed a single value for the print bed, so users with non-square beds (e.g. Bambu A1) couldn't see or edit the second dimension — even though settings already store `defaultPrintBedDepth` and the main app sidebar uses the dual-input `PrintBedInput` component.
- Swapped the lone `DeferredNumberInput` for `PrintBedInput` so the bin designer matches the sidebar: linked single-input by default, link/unlink toggle, independent width × depth when unlinked.

## Test plan

- [x] `pnpm vitest run src/features/bin-designer/components/panel/PhysicalUnitsSection/` — 13/13 pass
- [x] `pnpm run typecheck` clean
- [x] Full suite previously triggered: 11,936 tests pass
- [ ] Manual: open a bin in the designer, expand Physical Units, confirm Print bed renders as `W × D` with a link toggle; unlink, change depth, reload — depth persists; relink — depth clears back to width

Fixes #1906