### PR TITLE
fix(estimates): count label tabs by group, not by column

### DIFF
--- a/src/features/bin-designer/utils/printEstimates.test.ts
+++ b/src/features/bin-designer/utils/printEstimates.test.ts
@@ -289,6 +289,143 @@ describe('printEstimates', () => {
       expect(oneAxis.volumeMm3).toBeLessThan(standard.volumeMm3);
       expect(noSlots.volumeMm3).toBeLessThan(oneAxis.volumeMm3);
     });
+
+    // ─── Label tab counting (issue #1905) ────────────────────────────────
+
+    describe('label tab counting', () => {
+      const enabledLabel = { ...DEFAULT_BIN_PARAMS.label, enabled: true };
+
+      it('merged 2x1 row counts as one tab, not two', () => {
+        // cells=[0,0] → one compartment spanning both columns. The geometry
+        // emits one tab; the estimate must match (regression test for the
+        // old `cols × tabVolume` over-count).
+        const merged: BinParams = {
+          ...DEFAULT_BIN_PARAMS,
+          compartments: { cols: 2, rows: 1, thickness: 1.2, cells: [0, 0] },
+          label: enabledLabel,
+        };
+        const split: BinParams = {
+          ...merged,
+          compartments: { cols: 2, rows: 1, thickness: 1.2, cells: [0, 1] },
+        };
+        const withoutLabel = (p: BinParams) =>
+          estimatePrint({ ...p, label: { ...p.label, enabled: false } }).volumeMm3;
+
+        const mergedLabelVol = estimatePrint(merged).volumeMm3 - withoutLabel(merged);
+        const splitLabelVol = estimatePrint(split).volumeMm3 - withoutLabel(split);
+
+        // Shelf area is identical (one wide shelf vs two half-width shelves),
+        // but the merged version has one support instead of two.
+        expect(mergedLabelVol).toBeLessThan(splitLabelVol);
+      });
+
+      it('accounts for interior-row back walls (1x3 vertical stack)', () => {
+        // 1 col × 3 rows with three compartments → three back walls (two
+        // dividers + outer back), so three tabs. The old `cols × …` formula
+        // billed only 1 tab regardless of row count.
+        const stack: BinParams = {
+          ...DEFAULT_BIN_PARAMS,
+          depth: 3,
+          compartments: { cols: 1, rows: 3, thickness: 1.2, cells: [0, 1, 2] },
+          label: enabledLabel,
+        };
+        const oneTab: BinParams = {
+          ...stack,
+          compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
+        };
+        const labelVol = (p: BinParams) =>
+          estimatePrint(p).volumeMm3 -
+          estimatePrint({ ...p, label: { ...p.label, enabled: false } }).volumeMm3;
+
+        // Three tabs should add roughly 3× the volume of one tab in the same
+        // shell (same cellW, so same per-tab shelf width).
+        expect(labelVol(stack)).toBeGreaterThan(labelVol(oneTab) * 2.5);
+      });
+
+      it('skips tab when back wall is a tilted divider', () => {
+        // dividerOverrides between two compartments makes their shared wall
+        // tilted; the builder skips that tab.
+        const withTilt: BinParams = {
+          ...DEFAULT_BIN_PARAMS,
+          depth: 2,
+          compartments: {
+            cols: 1,
+            rows: 2,
+            thickness: 1.2,
+            cells: [0, 1],
+            dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 5, offsetEnd: -5 }],
+          },
+          label: enabledLabel,
+        };
+        const noTilt: BinParams = {
+          ...withTilt,
+          compartments: { cols: 1, rows: 2, thickness: 1.2, cells: [0, 1] },
+        };
+        const labelVol = (p: BinParams) =>
+          estimatePrint(p).volumeMm3 -
+          estimatePrint({ ...p, label: { ...p.label, enabled: false } }).volumeMm3;
+
+        // Tilt drops one of the two tabs; the remaining outer-back tab still
+        // contributes, so withTilt has roughly half the label contribution.
+        expect(labelVol(withTilt)).toBeLessThan(labelVol(noTilt));
+        expect(labelVol(withTilt)).toBeGreaterThan(0);
+      });
+
+      it("drops front tab when edges='both' would collide", () => {
+        // 1×1 grid where 2·depth + 2·inset > compartmentDepth: front tab
+        // collides with back tab and is silently dropped (only back remains).
+        const tiny: BinParams = {
+          ...DEFAULT_BIN_PARAMS,
+          depth: 1,
+          compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
+          label: { ...enabledLabel, edges: 'both', depth: 18, inset: 2 },
+        };
+        const back: BinParams = {
+          ...tiny,
+          label: { ...tiny.label, edges: 'back' },
+        };
+        const labelVol = (p: BinParams) =>
+          estimatePrint(p).volumeMm3 -
+          estimatePrint({ ...p, label: { ...p.label, enabled: false } }).volumeMm3;
+
+        // With collision, 'both' degrades to the back-only result.
+        expect(labelVol(tiny)).toBeCloseTo(labelVol(back), 0);
+      });
+
+      it('skips tab when depth+inset exceeds compartment depth', () => {
+        // Single-row, single-comp: cellD ≈ 81.6mm. Depth 80 + inset 10 = 90 >
+        // 81.6 → builder skips. Sanity-check no tab volume is added.
+        const skip: BinParams = {
+          ...DEFAULT_BIN_PARAMS,
+          depth: 2,
+          compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
+          label: { ...enabledLabel, depth: 80, inset: 10 },
+        };
+        const skipLabelVol =
+          estimatePrint(skip).volumeMm3 -
+          estimatePrint({ ...skip, label: { ...skip.label, enabled: false } }).volumeMm3;
+        expect(skipLabelVol).toBe(0);
+      });
+
+      it("'both' edges with non-colliding compartment doubles the tab volume", () => {
+        // Large enough compartment that back+front fit without collision.
+        const back: BinParams = {
+          ...DEFAULT_BIN_PARAMS,
+          depth: 4,
+          compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
+          label: { ...enabledLabel, edges: 'back' },
+        };
+        const both: BinParams = {
+          ...back,
+          label: { ...back.label, edges: 'both' },
+        };
+        const labelVol = (p: BinParams) =>
+          estimatePrint(p).volumeMm3 -
+          estimatePrint({ ...p, label: { ...p.label, enabled: false } }).volumeMm3;
+
+        expect(labelVol(both)).toBeGreaterThan(labelVol(back) * 1.8);
+      });
+    });
   });
 
   describe('calculateWallPatternSavings', () => {

--- a/src/features/bin-designer/utils/printEstimates.test.ts
+++ b/src/features/bin-designer/utils/printEstimates.test.ts
@@ -193,7 +193,7 @@ describe('printEstimates', () => {
       expect(highInfill.printTimeMinutes).toBeGreaterThan(baseline.printTimeMinutes);
     });
 
-    it('solid label support uses less volume than bracket', () => {
+    it('solid label support uses more volume than bracket', () => {
       const bracket = estimatePrint({
         ...DEFAULT_BIN_PARAMS,
         label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket' },
@@ -202,9 +202,10 @@ describe('printEstimates', () => {
         ...DEFAULT_BIN_PARAMS,
         label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'solid' },
       });
-      // Solid = 1 triangle per tab, bracket = 2 gussets per tab → bracket uses more
-      expect(solid.volumeMm3).toBeLessThan(bracket.volumeMm3);
-      expect(solid.volumeMm3).toBeGreaterThan(0);
+      // Solid extrudes a triangular prism the full shelf width; bracket only
+      // emits thin gussets spaced ~10mm apart. Solid uses substantially more.
+      expect(solid.volumeMm3).toBeGreaterThan(bracket.volumeMm3);
+      expect(bracket.volumeMm3).toBeGreaterThan(0);
     });
 
     it('lower infill decreases print time', () => {

--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -10,7 +10,7 @@
  * This avoids expensive mesh-based volume integration.
  */
 
-import type { BinParams } from '@/features/bin-designer/types';
+import type { BinParams, LabelTabSupport } from '@/features/bin-designer/types';
 import { GRIDFINITY, STYLE_WALL_THICKNESS } from '@/features/bin-designer/constants/gridfinity';
 import {
   compartmentHasTiltedBackWall,
@@ -258,16 +258,24 @@ function computeDividerVolume(
   // Volume = total wall length × thickness × height
   return totalLength * thickness * dividerH;
 }
+/** Builder constant: max unsupported shelf span between bracket gussets. */
+const BRACKET_GUSSET_SPACING_MM = 10;
+
+interface LabelTabGeom {
+  readonly tabDepth: number;
+  readonly gussetLeg: number;
+  readonly wallThickness: number;
+  readonly dividerThickness: number;
+  readonly widthPercent: number;
+  readonly inset: number;
+  readonly support: LabelTabSupport;
+}
+
 /**
- * Volume of label tabs.
- *
- * Each tab is a horizontal shelf with a support (bracket gussets or a solid
- * triangular prism). To match the geometry produced by `buildTabsAtRow`, we
- * walk every (row, anchor) pair, group consecutive same-compartment cells
- * sharing an edge at that row, and emit one tab per group. Mirroring the
- * builder's skip conditions (tilted anchor wall, depth+inset overrun, and
- * `edges='both'` collision drops) keeps the estimate aligned with what the
- * builder actually generates.
+ * Volume of label tabs, mirroring `labelTabBuilder.buildTabsAtRow`'s
+ * grouping and skip conditions (tilted anchor wall, depth+inset overrun,
+ * `edges='both'` collisions) so the estimate tracks what the builder
+ * actually generates.
  */
 function computeLabelTabVolume(
   params: BinParams,
@@ -275,7 +283,7 @@ function computeLabelTabVolume(
   outerD: number,
   wallThickness: number
 ): number {
-  const { cols, rows } = params.compartments;
+  const { cols, rows, thickness } = params.compartments;
   const { depth: tabDepth, width: widthPercent, support } = params.label;
   const inset = params.label.inset ?? 0;
   const edges = params.label.edges ?? 'back';
@@ -288,17 +296,17 @@ function computeLabelTabVolume(
   // Mirrors the bridge guard in `buildLabelTabsInScope`.
   if (tabDepth >= innerD) return 0;
 
-  // Per-tab support is independent of tab width:
-  // - bracket: two triangular gussets at the edges (interior gussets are
-  //   ignored — they're a second-order correction)
-  // - solid: a triangular prism. We keep the existing approximation that
-  //   scales support by `wallThickness`; the geometry actually extrudes by
-  //   `tabWidth` but that's a separate magnitude issue, not in scope for
-  //   this counting fix.
-  const supportVolumePerTab =
-    support === 'bracket'
-      ? 2 * 0.5 * tabDepth * tabDepth * wallThickness
-      : 0.5 * tabDepth * tabDepth * wallThickness;
+  // `gussetLeg` clamps at 0 so a tabDepth ≤ wallThickness yields shelf-only
+  // volume (no support), matching the builder's guard on degenerate geometry.
+  const geom: LabelTabGeom = {
+    tabDepth,
+    gussetLeg: Math.max(0, tabDepth - wallThickness),
+    wallThickness,
+    dividerThickness: thickness,
+    widthPercent,
+    inset,
+    support,
+  };
 
   const includeBack = edges === 'back' || edges === 'both';
   const includeFront = edges === 'front' || edges === 'both';
@@ -308,42 +316,40 @@ function computeLabelTabVolume(
   let volume = 0;
   for (let row = 0; row < rows; row++) {
     if (includeBack) {
-      volume += sumTabVolumesAtRow(
-        params,
-        row,
-        'back',
-        cellW,
-        cellD,
-        tabDepth,
-        widthPercent,
-        wallThickness,
-        inset,
-        supportVolumePerTab,
-        null
-      );
+      volume += sumTabVolumesAtRow(params, row, 'back', cellW, cellD, geom, null);
     }
     if (includeFront) {
-      volume += sumTabVolumesAtRow(
-        params,
-        row,
-        'front',
-        cellW,
-        cellD,
-        tabDepth,
-        widthPercent,
-        wallThickness,
-        inset,
-        supportVolumePerTab,
-        collidingFrontIds
-      );
+      volume += sumTabVolumesAtRow(params, row, 'front', cellW, cellD, geom, collidingFrontIds);
     }
   }
   return volume;
 }
 
 /**
- * Sum tab volumes anchored on one row's `back` or `front` edge. Mirrors
- * `labelTabBuilder.buildTabsAtRow`'s grouping + skip logic.
+ * Per-tab volume as a function of shelf width. Support depends on style:
+ *   - `solid` / `fillet`: triangular prism extruded the full shelf width.
+ *     Fillet has a concave profile but the over-estimate is small.
+ *   - `bracket`: ~`ceil(tabWidth / BRACKET_GUSSET_SPACING_MM)` gussets,
+ *     each extruded by the divider thickness (within ±1 of the builder).
+ */
+function tabContribution(geom: LabelTabGeom, tabWidth: number): number {
+  if (tabWidth <= 0) return 0;
+  const shelf = geom.tabDepth * tabWidth * geom.wallThickness;
+  if (geom.gussetLeg <= 0) return shelf;
+  const triangleArea = 0.5 * geom.tabDepth * geom.gussetLeg;
+  const support =
+    geom.support === 'bracket'
+      ? Math.max(1, Math.ceil(tabWidth / BRACKET_GUSSET_SPACING_MM)) *
+        triangleArea *
+        geom.dividerThickness
+      : triangleArea * tabWidth;
+  return shelf + support;
+}
+
+/**
+ * Sum tab volumes for one row + anchor edge. Mirrors the grouping and
+ * skip logic of `labelTabBuilder.buildTabsAtRow`, including the
+ * `thickness/2` boundary deduction at real divider walls.
  */
 function sumTabVolumesAtRow(
   params: BinParams,
@@ -351,29 +357,25 @@ function sumTabVolumesAtRow(
   anchor: 'back' | 'front',
   cellW: number,
   cellD: number,
-  tabDepth: number,
-  widthPercent: number,
-  wallThickness: number,
-  inset: number,
-  supportVolumePerTab: number,
+  geom: LabelTabGeom,
   collidingFrontIds: Set<number> | null
 ): number {
-  const { cols, rows, cells } = params.compartments;
+  const { cols, rows, cells, thickness } = params.compartments;
   const isOuterEdgeRow = anchor === 'back' ? row === rows - 1 : row === 0;
   const neighborRowOffset = anchor === 'back' ? 1 : -1;
   const hasTiltedAnchorWall =
     anchor === 'back' ? compartmentHasTiltedBackWall : compartmentHasTiltedFrontWall;
 
+  const cellAt = (c: number): number => cells[row * cols + c];
+  const anchorsTab = (c: number): boolean =>
+    isOuterEdgeRow || cellAt(c) !== cells[(row + neighborRowOffset) * cols + c];
+
   let volume = 0;
   let col = 0;
 
   while (col < cols) {
-    const cellId = cells[row * cols + col];
-    const neighborCellId = isOuterEdgeRow
-      ? undefined
-      : cells[(row + neighborRowOffset) * cols + col];
-    const hasEdge = isOuterEdgeRow || cellId !== neighborCellId;
-    if (!hasEdge) {
+    const cellId = cellAt(col);
+    if (!anchorsTab(col)) {
       col++;
       continue;
     }
@@ -389,28 +391,31 @@ function sumTabVolumesAtRow(
     const bounds = getCompartmentBounds(params.compartments, cellId);
     if (bounds) {
       const compartmentDepth = (bounds.maxRow - bounds.minRow + 1) * cellD;
-      if (tabDepth + inset > compartmentDepth) {
+      if (geom.tabDepth + geom.inset > compartmentDepth) {
         col++;
         continue;
       }
     }
 
-    // Walk consecutive same-cellId columns that all have an edge at this row.
     let groupEnd = col + 1;
-    while (groupEnd < cols) {
-      const gCellId = cells[row * cols + groupEnd];
-      const gNeighborCellId = isOuterEdgeRow
-        ? undefined
-        : cells[(row + neighborRowOffset) * cols + groupEnd];
-      if (gCellId !== cellId || !(isOuterEdgeRow || gCellId !== gNeighborCellId)) break;
+    while (groupEnd < cols && cellAt(groupEnd) === cellId && anchorsTab(groupEnd)) {
       groupEnd++;
     }
 
     const groupCols = groupEnd - col;
-    const tabWidth = (groupCols * cellW * widthPercent) / 100;
-    if (tabWidth > 0) {
-      volume += tabDepth * tabWidth * wallThickness + supportVolumePerTab;
-    }
+    const groupMinCol = col;
+    const groupMaxCol = groupEnd - 1;
+
+    // Deduct half the divider thickness on either side that borders an
+    // actual divider wall (a different compartment). Outer bin walls don't
+    // deduct — the cellW already starts inside the bin wall.
+    const leftDeduction = groupMinCol > 0 && cellAt(groupMinCol - 1) !== cellId ? thickness / 2 : 0;
+    const rightDeduction =
+      groupMaxCol < cols - 1 && cellAt(groupMaxCol + 1) !== cellId ? thickness / 2 : 0;
+    const availableWidth = groupCols * cellW - leftDeduction - rightDeduction;
+    const tabWidth = (availableWidth * geom.widthPercent) / 100;
+
+    volume += tabContribution(geom, tabWidth);
     col = groupEnd;
   }
 
@@ -418,9 +423,9 @@ function sumTabVolumesAtRow(
 }
 
 /**
- * Mirror of `labelTabBuilder.findCollidingFrontCompartments`: when
- * `edges='both'`, identify compartments whose back+front tab pair would
- * collide so we can drop the front tab from the estimate.
+ * For `edges='both'`, identify compartments whose back+front tab pair would
+ * collide so the front tab is dropped from the estimate. Mirror of
+ * `labelTabBuilder.findCollidingFrontCompartments`.
  */
 function findCollidingFrontIds(
   params: BinParams,

--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -12,6 +12,11 @@
 
 import type { BinParams } from '@/features/bin-designer/types';
 import { GRIDFINITY, STYLE_WALL_THICKNESS } from '@/features/bin-designer/constants/gridfinity';
+import {
+  compartmentHasTiltedBackWall,
+  compartmentHasTiltedFrontWall,
+  getCompartmentBounds,
+} from '@/features/bin-designer/utils/compartments';
 import { isFeatureActive } from '@/shared/constraints';
 import {
   PLA_DENSITY,
@@ -130,7 +135,7 @@ function computeBinVolume(params: BinParams): number {
 
   // Label tabs (shelf + support structure)
   if (isFeatureActive(params, 'label')) {
-    volume += computeLabelTabVolume(params, outerW, wallThickness);
+    volume += computeLabelTabVolume(params, outerW, outerD, wallThickness);
   }
 
   // Scoops (remove material from compartment front walls)
@@ -254,43 +259,202 @@ function computeDividerVolume(
   return totalLength * thickness * dividerH;
 }
 /**
- * Volume of label tabs (one per compartment column, per active edge).
+ * Volume of label tabs.
  *
- * Each tab consists of:
- * - Shelf: horizontal plate (depth × width × wallThickness)
- * - Support: bracket gussets or solid triangle underneath
- *
- * Per-edge multiplier: 1 for 'back' or 'front' alone, 2 for 'both' (#1898).
- * Note: this still over-counts merged compartments (uses `cols` rather than
- * walking back-edge groups) — tracked separately, not regressed by this PR.
+ * Each tab is a horizontal shelf with a support (bracket gussets or a solid
+ * triangular prism). To match the geometry produced by `buildTabsAtRow`, we
+ * walk every (row, anchor) pair, group consecutive same-compartment cells
+ * sharing an edge at that row, and emit one tab per group. Mirroring the
+ * builder's skip conditions (tilted anchor wall, depth+inset overrun, and
+ * `edges='both'` collision drops) keeps the estimate aligned with what the
+ * builder actually generates.
  */
-function computeLabelTabVolume(params: BinParams, outerW: number, wallThickness: number): number {
-  const { cols } = params.compartments;
+function computeLabelTabVolume(
+  params: BinParams,
+  outerW: number,
+  outerD: number,
+  wallThickness: number
+): number {
+  const { cols, rows } = params.compartments;
   const { depth: tabDepth, width: widthPercent, support } = params.label;
+  const inset = params.label.inset ?? 0;
+  const edges = params.label.edges ?? 'back';
 
   const innerW = outerW - 2 * wallThickness;
-  const colWidth = innerW / cols;
-  const tabWidth = (colWidth * widthPercent) / 100;
+  const innerD = outerD - 2 * wallThickness;
+  const cellW = innerW / cols;
+  const cellD = innerD / rows;
 
-  // Shelf: horizontal plate
-  const shelfThickness = wallThickness;
-  const shelfVolume = tabDepth * tabWidth * shelfThickness;
+  // Mirrors the bridge guard in `buildLabelTabsInScope`.
+  if (tabDepth >= innerD) return 0;
 
-  // Support structure beneath the shelf
-  let supportVolume: number;
-  if (support === 'bracket') {
-    // Two triangular gussets per tab
-    const gussetSize = tabDepth;
-    supportVolume = 2 * 0.5 * gussetSize * gussetSize * wallThickness;
-  } else {
-    // Solid triangular fill
-    supportVolume = 0.5 * tabDepth * tabDepth * wallThickness;
+  // Per-tab support is independent of tab width:
+  // - bracket: two triangular gussets at the edges (interior gussets are
+  //   ignored — they're a second-order correction)
+  // - solid: a triangular prism. We keep the existing approximation that
+  //   scales support by `wallThickness`; the geometry actually extrudes by
+  //   `tabWidth` but that's a separate magnitude issue, not in scope for
+  //   this counting fix.
+  const supportVolumePerTab =
+    support === 'bracket'
+      ? 2 * 0.5 * tabDepth * tabDepth * wallThickness
+      : 0.5 * tabDepth * tabDepth * wallThickness;
+
+  const includeBack = edges === 'back' || edges === 'both';
+  const includeFront = edges === 'front' || edges === 'both';
+  const collidingFrontIds =
+    edges === 'both' ? findCollidingFrontIds(params, cellD, tabDepth, inset) : null;
+
+  let volume = 0;
+  for (let row = 0; row < rows; row++) {
+    if (includeBack) {
+      volume += sumTabVolumesAtRow(
+        params,
+        row,
+        'back',
+        cellW,
+        cellD,
+        tabDepth,
+        widthPercent,
+        wallThickness,
+        inset,
+        supportVolumePerTab,
+        null
+      );
+    }
+    if (includeFront) {
+      volume += sumTabVolumesAtRow(
+        params,
+        row,
+        'front',
+        cellW,
+        cellD,
+        tabDepth,
+        widthPercent,
+        wallThickness,
+        inset,
+        supportVolumePerTab,
+        collidingFrontIds
+      );
+    }
+  }
+  return volume;
+}
+
+/**
+ * Sum tab volumes anchored on one row's `back` or `front` edge. Mirrors
+ * `labelTabBuilder.buildTabsAtRow`'s grouping + skip logic.
+ */
+function sumTabVolumesAtRow(
+  params: BinParams,
+  row: number,
+  anchor: 'back' | 'front',
+  cellW: number,
+  cellD: number,
+  tabDepth: number,
+  widthPercent: number,
+  wallThickness: number,
+  inset: number,
+  supportVolumePerTab: number,
+  collidingFrontIds: Set<number> | null
+): number {
+  const { cols, rows, cells } = params.compartments;
+  const isOuterEdgeRow = anchor === 'back' ? row === rows - 1 : row === 0;
+  const neighborRowOffset = anchor === 'back' ? 1 : -1;
+  const hasTiltedAnchorWall =
+    anchor === 'back' ? compartmentHasTiltedBackWall : compartmentHasTiltedFrontWall;
+
+  let volume = 0;
+  let col = 0;
+
+  while (col < cols) {
+    const cellId = cells[row * cols + col];
+    const neighborCellId = isOuterEdgeRow
+      ? undefined
+      : cells[(row + neighborRowOffset) * cols + col];
+    const hasEdge = isOuterEdgeRow || cellId !== neighborCellId;
+    if (!hasEdge) {
+      col++;
+      continue;
+    }
+    if (hasTiltedAnchorWall(params.compartments, cellId)) {
+      col++;
+      continue;
+    }
+    if (anchor === 'front' && collidingFrontIds?.has(cellId)) {
+      col++;
+      continue;
+    }
+
+    const bounds = getCompartmentBounds(params.compartments, cellId);
+    if (bounds) {
+      const compartmentDepth = (bounds.maxRow - bounds.minRow + 1) * cellD;
+      if (tabDepth + inset > compartmentDepth) {
+        col++;
+        continue;
+      }
+    }
+
+    // Walk consecutive same-cellId columns that all have an edge at this row.
+    let groupEnd = col + 1;
+    while (groupEnd < cols) {
+      const gCellId = cells[row * cols + groupEnd];
+      const gNeighborCellId = isOuterEdgeRow
+        ? undefined
+        : cells[(row + neighborRowOffset) * cols + groupEnd];
+      if (gCellId !== cellId || !(isOuterEdgeRow || gCellId !== gNeighborCellId)) break;
+      groupEnd++;
+    }
+
+    const groupCols = groupEnd - col;
+    const tabWidth = (groupCols * cellW * widthPercent) / 100;
+    if (tabWidth > 0) {
+      volume += tabDepth * tabWidth * wallThickness + supportVolumePerTab;
+    }
+    col = groupEnd;
   }
 
-  const edges = params.label.edges ?? 'back';
-  const edgeCount = edges === 'both' ? 2 : 1;
+  return volume;
+}
 
-  return cols * edgeCount * (shelfVolume + supportVolume);
+/**
+ * Mirror of `labelTabBuilder.findCollidingFrontCompartments`: when
+ * `edges='both'`, identify compartments whose back+front tab pair would
+ * collide so we can drop the front tab from the estimate.
+ */
+function findCollidingFrontIds(
+  params: BinParams,
+  cellD: number,
+  tabDepth: number,
+  inset: number
+): Set<number> {
+  const { cols, rows, cells } = params.compartments;
+  const colliding = new Set<number>();
+  const visited = new Set<number>();
+
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const cellId = cells[row * cols + col];
+      if (visited.has(cellId)) continue;
+      visited.add(cellId);
+
+      const bounds = getCompartmentBounds(params.compartments, cellId);
+      if (!bounds) continue;
+
+      const hasFrontAnchor =
+        bounds.minRow === 0 || cells[(bounds.minRow - 1) * cols + bounds.minCol] !== cellId;
+      const hasBackAnchor =
+        bounds.maxRow === rows - 1 || cells[(bounds.maxRow + 1) * cols + bounds.minCol] !== cellId;
+      if (!hasBackAnchor || !hasFrontAnchor) continue;
+
+      const compartmentDepth = (bounds.maxRow - bounds.minRow + 1) * cellD;
+      if (2 * tabDepth + 2 * inset > compartmentDepth) {
+        colliding.add(cellId);
+      }
+    }
+  }
+
+  return colliding;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `computeLabelTabVolume` now walks the same row-grouping logic as `labelTabBuilder.buildTabsAtRow`, so merged compartments are counted once and tabs anchored to interior row dividers are no longer missed.
- Skip conditions mirror the builder: tilted anchor wall, per-compartment `depth+inset` overrun, full-shell `tabDepth >= innerD` guard, and `edges='both'` collision drops.
- Signature gains `outerD` so `innerD` is available for the depth/collision checks.

Closes #1905.

## Test plan
- [x] `pnpm run test:run -- src/features/bin-designer/utils/printEstimates.test.ts` — 6 new cases (merged 2x1, 1x3 stack, tilted back wall, `edges='both'` collision drop, depth+inset overrun, non-colliding `'both'` doubles)
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] Full project test run: 11,939 passed, 3 skipped