### PR TITLE
fix(vite): exclude occt-wasm from optimizeDeps pre-bundling

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
   },
   optimizeDeps: {
     // Exclude WASM module from Vite's dependency pre-bundling
-    exclude: ['brepjs-opencascade', 'brepkit-wasm'],
+    exclude: ['brepjs-opencascade', 'brepkit-wasm', 'occt-wasm'],
   },
   worker: {
     format: 'es',


### PR DESCRIPTION
## Summary

Aligns the three geometry kernels so the occt-wasm Labs flag isn't a stale-cache footgun: `brepjs-opencascade` and `brepkit-wasm` are excluded from `optimizeDeps`, but `occt-wasm` was missing despite using the identical loader pattern.

`OcctKernel.init` does `await import("./occt-wasm.js")` to fetch the Emscripten module. Without the exclusion, esbuild pre-bundles it and rewrites the dynamic import to a hashed sibling in `node_modules/.vite/deps/`. It works today, but a stale `.vite/deps/` after a version bump can leave the rewritten target dangling and the kernel silently fails to instantiate.

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `pnpm run build` clean
- [x] Dev (`rm -rf node_modules/.vite && pnpm dev`) — `/designer` with `occt_wasm_kernel: true` sends `INIT_READY {kernel:"occt-wasm"}` and completes a `MESH_RESULT`
- [x] Prod (`pnpm preview`) — same behavior, three occt-wasm assets serve 200
- [ ] CI green
- [ ] Greptile review