### PR TITLE
fix(bin-designer): wall cutouts now carry through dividers (#1882)

### DIFF
--- a/src/core/store/settings.types.ts
+++ b/src/core/store/settings.types.ts
@@ -189,6 +189,12 @@ export interface UserSettings {
    */
   designListViewMode: 'grid' | 'list';
 
+  /**
+   * Whether the wall-cutouts editor edits all active sides together.
+   * Persisted so unlinking to adjust sides independently survives a reload.
+   */
+  wallCutoutsLinked: boolean;
+
   // Print view preferences
   printViewSettings: PrintViewSettings;
 
@@ -304,6 +310,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   stashMaxHeight: null, // null = use default 33vh
   layoutManagerViewMode: 'grid',
   designListViewMode: 'grid',
+  wallCutoutsLinked: true,
 
   // Print view preferences
   printViewSettings: { ...DEFAULT_PRINT_VIEW_SETTINGS },

--- a/src/features/bin-designer/components/panel/WallCutoutsSection/WallCutoutsSection.test.tsx
+++ b/src/features/bin-designer/components/panel/WallCutoutsSection/WallCutoutsSection.test.tsx
@@ -66,4 +66,29 @@ describe('WallCutoutsSection', () => {
     expect(screen.getByText('Scoop')).toBeDefined();
     expect(screen.getByText('Funnel')).toBeDefined();
   });
+
+  it('shows the density hint on a high-compartment bin with cutouts enabled', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        compartments: { cols: 1, rows: 9, thickness: 1.2, cells: [0, 1, 2, 3, 4, 5, 6, 7, 8] },
+        walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: true },
+      },
+    });
+
+    render(<WallCutoutsSection />);
+    expect(screen.getByText(/stack of slats/)).toBeDefined();
+  });
+
+  it('hides the density hint on a low-compartment bin', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: true },
+      },
+    });
+
+    render(<WallCutoutsSection />);
+    expect(screen.queryByText(/stack of slats/)).toBeNull();
+  });
 });

--- a/src/features/bin-designer/components/panel/WallCutoutsSection/WallCutoutsSection.tsx
+++ b/src/features/bin-designer/components/panel/WallCutoutsSection/WallCutoutsSection.tsx
@@ -252,7 +252,7 @@ function PositionDisclosure({
 
 export function WallCutoutsSection() {
   const { state, handlers, meta, t, STEP } = useWallCutoutsSection();
-  const { walls, activeSides, linked, blocksLid } = state;
+  const { walls, activeSides, linked, blocksLid, showDensityHint } = state;
 
   const sharedSide = activeSides.length > 0 ? activeSides[0] : undefined;
   const hideDepth = walls.shape === 'scoop';
@@ -384,6 +384,13 @@ export function WallCutoutsSection() {
                   </div>
                 ))}
             </>
+          )}
+
+          {/* Density expectation hint (issue #1882) */}
+          {showDensityHint && (
+            <p className="text-xs text-content-tertiary leading-snug">
+              {t('binDesigner.wallCutouts.densityHint')}
+            </p>
           )}
 
           {/* Interior walls */}

--- a/src/features/bin-designer/components/panel/WallCutoutsSection/useWallCutoutsSection.test.ts
+++ b/src/features/bin-designer/components/panel/WallCutoutsSection/useWallCutoutsSection.test.ts
@@ -3,12 +3,16 @@ import { renderHook, act } from '@testing-library/react';
 import { useWallCutoutsSection } from './useWallCutoutsSection';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import { useSettingsStore, DEFAULT_SETTINGS } from '@/core/store/settings';
 
 describe('useWallCutoutsSection', () => {
   beforeEach(() => {
     useDesignerStore.setState({
       params: { ...DEFAULT_BIN_PARAMS },
     });
+    // `linked` is a persisted user setting; reset the settings singleton so
+    // state doesn't leak between tests.
+    useSettingsStore.setState({ settings: { ...DEFAULT_SETTINGS } });
   });
 
   it('returns disabled state by default', () => {
@@ -415,5 +419,128 @@ describe('useWallCutoutsSection', () => {
     });
 
     expect(useDesignerStore.getState().params.walls.left.widthMm).toBeNull();
+  });
+
+  describe('interior auto-coupling on enable', () => {
+    it('enables interior with matching dims on a multi-compartment bin', () => {
+      // Feature off, bin has dividers (9 rows), default left/right at 70/50.
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          compartments: { cols: 1, rows: 9, thickness: 1.2, cells: [0, 1, 2, 3, 4, 5, 6, 7, 8] },
+        },
+      });
+
+      const { result } = renderHook(() => useWallCutoutsSection());
+
+      act(() => {
+        result.current.handlers.toggleEnabled();
+      });
+
+      const { walls } = useDesignerStore.getState().params;
+      expect(walls.enabled).toBe(true);
+      expect(walls.interior.enabled).toBe(true);
+      // Copied from the first active outer side (left = 70/50).
+      expect(walls.interior.width).toBe(70);
+      expect(walls.interior.depth).toBe(50);
+    });
+
+    it('does not enable interior on a single-compartment bin', () => {
+      useDesignerStore.setState({ params: { ...DEFAULT_BIN_PARAMS } });
+
+      const { result } = renderHook(() => useWallCutoutsSection());
+
+      act(() => {
+        result.current.handlers.toggleEnabled();
+      });
+
+      const { walls } = useDesignerStore.getState().params;
+      expect(walls.enabled).toBe(true);
+      expect(walls.interior.enabled).toBe(false);
+    });
+
+    it('does not re-enable interior the user already disabled when toggling the feature off', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          compartments: { cols: 1, rows: 9, thickness: 1.2, cells: [0, 1, 2, 3, 4, 5, 6, 7, 8] },
+          walls: {
+            ...DEFAULT_BIN_PARAMS.walls,
+            enabled: true,
+            interior: DEFAULT_BIN_PARAMS.walls.interior,
+          },
+        },
+      });
+
+      const { result } = renderHook(() => useWallCutoutsSection());
+
+      act(() => {
+        result.current.handlers.toggleEnabled(); // disabling — must not touch interior
+      });
+
+      expect(useDesignerStore.getState().params.walls.enabled).toBe(false);
+      expect(useDesignerStore.getState().params.walls.interior.enabled).toBe(false);
+    });
+  });
+
+  describe('linked state persistence', () => {
+    it('persists linked toggle to user settings', () => {
+      const { result } = renderHook(() => useWallCutoutsSection());
+
+      act(() => {
+        result.current.handlers.toggleLinked();
+      });
+
+      expect(useSettingsStore.getState().settings.wallCutoutsLinked).toBe(false);
+    });
+
+    it('reads persisted linked state on a fresh mount', () => {
+      useSettingsStore.setState({
+        settings: { ...DEFAULT_SETTINGS, wallCutoutsLinked: false },
+      });
+
+      const { result } = renderHook(() => useWallCutoutsSection());
+      expect(result.current.state.linked).toBe(false);
+    });
+  });
+
+  describe('density hint', () => {
+    it('flags the hint when cutouts are on and the bin is dense', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          compartments: { cols: 1, rows: 5, thickness: 1.2, cells: [0, 1, 2, 3, 4] },
+          walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: true },
+        },
+      });
+
+      const { result } = renderHook(() => useWallCutoutsSection());
+      expect(result.current.state.showDensityHint).toBe(true);
+    });
+
+    it('does not flag the hint below the density threshold', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          compartments: { cols: 1, rows: 4, thickness: 1.2, cells: [0, 1, 2, 3] },
+          walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: true },
+        },
+      });
+
+      const { result } = renderHook(() => useWallCutoutsSection());
+      expect(result.current.state.showDensityHint).toBe(false);
+    });
+
+    it('does not flag the hint when wall cutouts are disabled', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          compartments: { cols: 1, rows: 9, thickness: 1.2, cells: [0, 1, 2, 3, 4, 5, 6, 7, 8] },
+        },
+      });
+
+      const { result } = renderHook(() => useWallCutoutsSection());
+      expect(result.current.state.showDensityHint).toBe(false);
+    });
   });
 });

--- a/src/features/bin-designer/components/panel/WallCutoutsSection/useWallCutoutsSection.test.ts
+++ b/src/features/bin-designer/components/panel/WallCutoutsSection/useWallCutoutsSection.test.ts
@@ -11,8 +11,10 @@ describe('useWallCutoutsSection', () => {
       params: { ...DEFAULT_BIN_PARAMS },
     });
     // `linked` is a persisted user setting; reset the settings singleton so
-    // state doesn't leak between tests.
+    // state doesn't leak between tests, and clear the localStorage it writes
+    // through so it can't bleed into other test files.
     useSettingsStore.setState({ settings: { ...DEFAULT_SETTINGS } });
+    localStorage.clear();
   });
 
   it('returns disabled state by default', () => {
@@ -457,6 +459,33 @@ describe('useWallCutoutsSection', () => {
       const { walls } = useDesignerStore.getState().params;
       expect(walls.enabled).toBe(true);
       expect(walls.interior.enabled).toBe(false);
+    });
+
+    it('does not resurrect interior the user explicitly disabled across a feature off/on cycle', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          compartments: { cols: 1, rows: 9, thickness: 1.2, cells: [0, 1, 2, 3, 4, 5, 6, 7, 8] },
+        },
+      });
+
+      const { result } = renderHook(() => useWallCutoutsSection());
+
+      // Enable cutouts → interior auto-on.
+      act(() => result.current.handlers.toggleEnabled());
+      expect(useDesignerStore.getState().params.walls.interior.enabled).toBe(true);
+
+      // User explicitly turns interior off.
+      act(() => result.current.handlers.toggleSide('interior'));
+      expect(useDesignerStore.getState().params.walls.interior.enabled).toBe(false);
+
+      // Toggle the whole feature off, then back on.
+      act(() => result.current.handlers.toggleEnabled());
+      act(() => result.current.handlers.toggleEnabled());
+
+      // Interior must stay off — the auto-coupling must not override the
+      // user's explicit choice.
+      expect(useDesignerStore.getState().params.walls.interior.enabled).toBe(false);
     });
 
     it('does not re-enable interior the user already disabled when toggling the feature off', () => {

--- a/src/features/bin-designer/components/panel/WallCutoutsSection/useWallCutoutsSection.ts
+++ b/src/features/bin-designer/components/panel/WallCutoutsSection/useWallCutoutsSection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useSettingsStore } from '@/core/store/settings';
@@ -36,8 +36,16 @@ export function useWallCutoutsSection() {
     }))
   );
   const t = useTranslation();
-  const linked = useSettingsStore((s) => s.settings.wallCutoutsLinked);
-  const updateSetting = useSettingsStore((s) => s.updateSetting);
+  const { linked, updateSetting } = useSettingsStore(
+    useShallow((s) => ({
+      linked: s.settings.wallCutoutsLinked,
+      updateSetting: s.updateSetting,
+    }))
+  );
+
+  // True once the user has made an explicit interior choice this session, so
+  // the auto-coupling below won't resurrect an interior they turned off.
+  const interiorUserSet = useRef(false);
 
   const featureStatus = getFeatureStatus(params, 'wallCutouts');
   const isUnavailable = !featureStatus.available;
@@ -57,10 +65,10 @@ export function useWallCutoutsSection() {
     }
     // Enabling on a multi-compartment bin: also cut the interior dividers so
     // the opening carries through the bin instead of leaving full-height
-    // dividers behind notched outer walls (issue #1882). One-time on enable —
-    // if the user later turns interior off, it stays off.
+    // dividers behind notched outer walls (issue #1882). Skipped once the user
+    // has made an explicit interior choice, so turning it off stays off.
     const hasDividers = params.compartments.cols > 1 || params.compartments.rows > 1;
-    if (hasDividers && !walls.interior.enabled) {
+    if (hasDividers && !walls.interior.enabled && !interiorUserSet.current) {
       const source = OUTER_SIDES.map((s) => walls[s]).find((c) => c.enabled);
       updateWalls({
         enabled: true,
@@ -80,6 +88,8 @@ export function useWallCutoutsSection() {
 
   const toggleSide = useCallback(
     (side: WallSide) => {
+      // An explicit interior toggle opts out of the auto-coupling above.
+      if (side === 'interior') interiorUserSet.current = true;
       const current = walls[side];
       if (current.enabled) {
         updateWallSide(side, DISABLED_WALL_CUTOUT);
@@ -181,9 +191,11 @@ export function useWallCutoutsSection() {
   // a quiet expectation hint rather than changing geometry (issue #1882).
   const showDensityHint = useMemo(() => {
     if (!walls.enabled || activeSides.length === 0) return false;
-    const { cols, rows } = params.compartments;
-    return cols >= DENSITY_HINT_THRESHOLD || rows >= DENSITY_HINT_THRESHOLD;
-  }, [walls.enabled, activeSides.length, params.compartments]);
+    return (
+      params.compartments.cols >= DENSITY_HINT_THRESHOLD ||
+      params.compartments.rows >= DENSITY_HINT_THRESHOLD
+    );
+  }, [walls.enabled, activeSides.length, params.compartments.cols, params.compartments.rows]);
 
   const disabledReason = featureStatus.reason ? t(featureStatus.reason) : undefined;
 

--- a/src/features/bin-designer/components/panel/WallCutoutsSection/useWallCutoutsSection.ts
+++ b/src/features/bin-designer/components/panel/WallCutoutsSection/useWallCutoutsSection.ts
@@ -1,6 +1,7 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { useSettingsStore } from '@/core/store/settings';
 import { useTranslation } from '@/i18n';
 import { getFeatureStatus } from '@/shared/constraints';
 import { isLidBlockedBySection } from '@/features/bin-designer/utils/lidCompatibility';
@@ -14,9 +15,16 @@ import { DISABLED_WALL_CUTOUT } from '@/features/bin-designer/constants/defaults
 import type { SectionMeta } from '../types';
 
 const ALL_SIDES: readonly WallSide[] = ['front', 'back', 'left', 'right', 'interior'];
+const OUTER_SIDES: readonly WallSide[] = ['front', 'back', 'left', 'right'];
 const STEP = 5;
 const DEFAULT_SPAN = 70;
 const DEFAULT_HEIGHT = 50;
+
+/**
+ * Compartment count at or above which wall cutouts read as a stack of slats.
+ * Drives the expectation hint (issue #1882) rather than any geometry change.
+ */
+const DENSITY_HINT_THRESHOLD = 5;
 
 export function useWallCutoutsSection() {
   const { walls, updateWalls, updateWallSide, params } = useDesignerStore(
@@ -28,7 +36,8 @@ export function useWallCutoutsSection() {
     }))
   );
   const t = useTranslation();
-  const [linked, setLinked] = useState(true);
+  const linked = useSettingsStore((s) => s.settings.wallCutoutsLinked);
+  const updateSetting = useSettingsStore((s) => s.updateSetting);
 
   const featureStatus = getFeatureStatus(params, 'wallCutouts');
   const isUnavailable = !featureStatus.available;
@@ -42,8 +51,32 @@ export function useWallCutoutsSection() {
   }, [walls]);
 
   const toggleEnabled = useCallback(() => {
-    updateWalls({ enabled: !walls.enabled });
-  }, [walls.enabled, updateWalls]);
+    if (walls.enabled) {
+      updateWalls({ enabled: false });
+      return;
+    }
+    // Enabling on a multi-compartment bin: also cut the interior dividers so
+    // the opening carries through the bin instead of leaving full-height
+    // dividers behind notched outer walls (issue #1882). One-time on enable —
+    // if the user later turns interior off, it stays off.
+    const hasDividers = params.compartments.cols > 1 || params.compartments.rows > 1;
+    if (hasDividers && !walls.interior.enabled) {
+      const source = OUTER_SIDES.map((s) => walls[s]).find((c) => c.enabled);
+      updateWalls({
+        enabled: true,
+        interior: {
+          enabled: true,
+          width: source?.width ?? DEFAULT_SPAN,
+          depth: source?.depth ?? DEFAULT_HEIGHT,
+          alignment: source?.alignment ?? 'center',
+          offset: source?.offset ?? 0,
+          widthMm: source?.widthMm ?? null,
+        },
+      });
+      return;
+    }
+    updateWalls({ enabled: true });
+  }, [walls, updateWalls, params.compartments]);
 
   const toggleSide = useCallback(
     (side: WallSide) => {
@@ -101,8 +134,8 @@ export function useWallCutoutsSection() {
   );
 
   const toggleLinked = useCallback(() => {
-    setLinked((prev) => !prev);
-  }, []);
+    updateSetting('wallCutoutsLinked', !linked);
+  }, [updateSetting, linked]);
 
   const setShape = useCallback(
     (shape: WallCutoutShape) => {
@@ -144,6 +177,14 @@ export function useWallCutoutsSection() {
     });
   }, [walls, activeSides, t]);
 
+  // Dense bins render wall cutouts as a stack of slats no matter what — surface
+  // a quiet expectation hint rather than changing geometry (issue #1882).
+  const showDensityHint = useMemo(() => {
+    if (!walls.enabled || activeSides.length === 0) return false;
+    const { cols, rows } = params.compartments;
+    return cols >= DENSITY_HINT_THRESHOLD || rows >= DENSITY_HINT_THRESHOLD;
+  }, [walls.enabled, activeSides.length, params.compartments]);
+
   const disabledReason = featureStatus.reason ? t(featureStatus.reason) : undefined;
 
   // True when the user's wall-cutout config is blocking the click-lock
@@ -161,7 +202,7 @@ export function useWallCutoutsSection() {
   );
 
   return {
-    state: { walls, activeSides, linked, blocksLid },
+    state: { walls, activeSides, linked, blocksLid, showDensityHint },
     handlers: {
       toggleEnabled,
       toggleSide,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -668,6 +668,7 @@
   "binDesigner.touchGestureHints": "Touch-Gesten-Hinweise",
   "binDesigner.wallCutouts": "Wandausschnitte",
   "binDesigner.wallCutouts.back": "Hinten",
+  "binDesigner.wallCutouts.densityHint": "Viele Fächer lassen Wandausschnitte wie einen Stapel Lamellen aussehen — Innenausschnitte führen die Öffnung durch jede Trennwand.",
   "binDesigner.wallCutouts.front": "Vorne",
   "binDesigner.wallCutouts.height": "Höhe",
   "binDesigner.wallCutouts.independent": "Unabhängig",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1511,6 +1511,7 @@
   "binDesigner.wallCutouts.offset": "Offset",
   "binDesigner.wallCutouts.widthUnit.percent": "%",
   "binDesigner.wallCutouts.widthUnit.mm": "mm",
+  "binDesigner.wallCutouts.densityHint": "Many compartments make wall cutouts look like a stack of slats — interior cutouts carry the opening through each divider.",
   "binDesigner.handles": "Handles",
   "binDesigner.handles.enable": "Enable handles",
   "binDesigner.handles.sides": "Sides",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1752,6 +1752,8 @@ const en: Record<string, string> = {
   'binDesigner.wallCutouts.offset': 'Offset',
   'binDesigner.wallCutouts.widthUnit.percent': '%',
   'binDesigner.wallCutouts.widthUnit.mm': 'mm',
+  'binDesigner.wallCutouts.densityHint':
+    'Many compartments make wall cutouts look like a stack of slats — interior cutouts carry the opening through each divider.',
   'binDesigner.handles': 'Handles',
   'binDesigner.handles.enable': 'Enable handles',
   'binDesigner.handles.sides': 'Sides',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -668,6 +668,7 @@
   "binDesigner.touchGestureHints": "Indicaciones de gestos táctiles",
   "binDesigner.wallCutouts": "Recortes de pared",
   "binDesigner.wallCutouts.back": "Trasera",
+  "binDesigner.wallCutouts.densityHint": "Muchos compartimentos hacen que los recortes de pared parezcan una pila de láminas — los recortes interiores prolongan la abertura a través de cada divisor.",
   "binDesigner.wallCutouts.front": "Frontal",
   "binDesigner.wallCutouts.height": "Altura",
   "binDesigner.wallCutouts.independent": "Independiente",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -668,6 +668,7 @@
   "binDesigner.touchGestureHints": "Indications de gestes tactiles",
   "binDesigner.wallCutouts": "Découpes de paroi",
   "binDesigner.wallCutouts.back": "Arrière",
+  "binDesigner.wallCutouts.densityHint": "De nombreux compartiments font ressembler les découpes de paroi à un empilement de lamelles — les découpes intérieures prolongent l'ouverture à travers chaque séparation.",
   "binDesigner.wallCutouts.front": "Avant",
   "binDesigner.wallCutouts.height": "Hauteur",
   "binDesigner.wallCutouts.independent": "Indépendant",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -668,6 +668,7 @@
   "binDesigner.touchGestureHints": "タッチジェスチャーヒント",
   "binDesigner.wallCutouts": "壁の切り欠き",
   "binDesigner.wallCutouts.back": "奥",
+  "binDesigner.wallCutouts.densityHint": "仕切りが多いと壁の切り欠きが薄板を重ねたように見えます。内部の切り欠きを使うと開口部が各仕切りを貫通します。",
   "binDesigner.wallCutouts.front": "手前",
   "binDesigner.wallCutouts.height": "高さ",
   "binDesigner.wallCutouts.independent": "個別",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -668,6 +668,7 @@
   "binDesigner.touchGestureHints": "Berøringsbevegelsehintet",
   "binDesigner.wallCutouts": "Veggutskjæringer",
   "binDesigner.wallCutouts.back": "Bak",
+  "binDesigner.wallCutouts.densityHint": "Mange rom får veggutskjæringer til å se ut som en stabel med lameller — innvendige utskjæringer fører åpningen gjennom hver skillevegg.",
   "binDesigner.wallCutouts.front": "Foran",
   "binDesigner.wallCutouts.height": "Høyde",
   "binDesigner.wallCutouts.independent": "Uavhengig",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -668,6 +668,7 @@
   "binDesigner.touchGestureHints": "Aanraakgebaren tips",
   "binDesigner.wallCutouts": "Wanduitsparingen",
   "binDesigner.wallCutouts.back": "Achter",
+  "binDesigner.wallCutouts.densityHint": "Veel vakken laten muuruitsparingen op een stapel latten lijken — binnenuitsparingen trekken de opening door elke scheidingswand.",
   "binDesigner.wallCutouts.front": "Voor",
   "binDesigner.wallCutouts.height": "Hoogte",
   "binDesigner.wallCutouts.independent": "Onafhankelijk",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -668,6 +668,7 @@
   "binDesigner.touchGestureHints": "Dicas de gestos de toque",
   "binDesigner.wallCutouts": "Recortes de parede",
   "binDesigner.wallCutouts.back": "Traseira",
+  "binDesigner.wallCutouts.densityHint": "Muitos compartimentos fazem os recortes de parede parecerem uma pilha de ripas — recortes internos levam a abertura através de cada divisória.",
   "binDesigner.wallCutouts.front": "Frontal",
   "binDesigner.wallCutouts.height": "Altura",
   "binDesigner.wallCutouts.independent": "Independente",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -668,6 +668,7 @@
   "binDesigner.touchGestureHints": "Tips för pekgester",
   "binDesigner.wallCutouts": "Väggurtag",
   "binDesigner.wallCutouts.back": "Bak",
+  "binDesigner.wallCutouts.densityHint": "Många fack får väggurtagen att se ut som en trave lameller — inre urtag för öppningen genom varje mellanvägg.",
   "binDesigner.wallCutouts.front": "Fram",
   "binDesigner.wallCutouts.height": "Höjd",
   "binDesigner.wallCutouts.independent": "Oberoende",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -668,6 +668,7 @@
   "binDesigner.touchGestureHints": "Підказки сенсорних жестів",
   "binDesigner.wallCutouts": "Вирізи в стінах",
   "binDesigner.wallCutouts.back": "Ззаду",
+  "binDesigner.wallCutouts.densityHint": "Багато відсіків роблять вирізи у стінках схожими на стос пластин — внутрішні вирізи продовжують отвір крізь кожну перегородку.",
   "binDesigner.wallCutouts.front": "Спереду",
   "binDesigner.wallCutouts.height": "Висота",
   "binDesigner.wallCutouts.independent": "Незалежні",


### PR DESCRIPTION
## Summary

Reported in #1882: adding wall cutouts to a bin with many rows produced a "strange" result that looked like a stack of disconnected slats. Investigation confirmed the **generator geometry was already correct** — it cuts exactly the walls that are enabled. The real problem was UX: enabling cutouts notched only the outer walls and left every interior divider full-height, so the opening never carried *through* the bin, and the link/unlink controls silently reset.

This is an expectation fix, not a geometry change.

## What changed

- **Interior cutouts auto-enable** when you turn on wall cutouts on a multi-compartment bin, so the opening passes through the dividers instead of stopping at the outer walls. It's a one-time coupling on enable and remains a normal toggle — switch it off and it stays off.
- **Linked/independent state now persists** as a user setting (`wallCutoutsLinked`). Unlinking to adjust sides separately no longer snaps back and re-unifies your values after a reload.
- **A quiet hint** appears in the Wall Cutouts panel on high compartment counts (rows or cols ≥ 5), explaining that the slatted look is expected at that density. Translated into all 10 locales.

## Test plan

- [x] `useWallCutoutsSection` unit tests: interior coupling (multi vs. single compartment), link-state persistence, density-hint flag
- [x] `WallCutoutsSection` component tests: hint shows on dense bins, hidden otherwise
- [x] Settings store tests pass with the new field
- [x] Browser spot-check: 9-row bin → enabling cutouts auto-checks Interior walls and shows the hint
- [x] `typecheck`, `lint`, and all four i18n checks (keys/values/interpolation/unused) green