### PR TITLE
fix(baseplate): restore top-down fit-in-view as the default camera

### DIFF
--- a/src/features/baseplate/components/BaseplatePreview/CameraController.test.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/CameraController.test.tsx
@@ -1,31 +1,101 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createRef } from 'react';
+import type { RefObject } from 'react';
+import type { OrbitControls as OrbitControlsType } from 'three-stdlib';
 
 vi.mock('three', () => ({
-  Vector3: vi.fn().mockImplementation(() => ({
-    normalize: vi.fn().mockReturnThis(),
-    multiplyScalar: vi.fn().mockReturnThis(),
-    add: vi.fn().mockReturnThis(),
-    clone: vi.fn().mockReturnThis(),
-    sub: vi.fn().mockReturnThis(),
-    copy: vi.fn(),
-    set: vi.fn(),
-    lerpVectors: vi.fn(),
-  })),
-}));
-
-vi.mock('@react-three/fiber', () => ({
-  useThree: () => ({ invalidate: vi.fn(), camera: { position: { clone: vi.fn() } } }),
-  useFrame: vi.fn(),
+  // Constructable chainable stub — the controller does `new Vector3(...)`.
+  Vector3: class Vector3 {
+    normalize() {
+      return this;
+    }
+    multiplyScalar() {
+      return this;
+    }
+    add() {
+      return this;
+    }
+    clone() {
+      return this;
+    }
+    sub() {
+      return this;
+    }
+    copy() {}
+    set() {}
+    lerpVectors() {}
+  },
+  // Real classes so `instanceof` narrows correctly in the controller.
+  PerspectiveCamera: class PerspectiveCamera {
+    isPerspectiveCamera = true;
+  },
+  OrthographicCamera: class OrthographicCamera {
+    isOrthographicCamera = true;
+  },
 }));
 
 vi.mock('@/shared/printSettings/gridfinityGeometry', () => ({
   GRIDFINITY_SPEC: { SOCKET_HEIGHT: 5 },
 }));
 
+// Hoisted holders so the useThree mock can hand back distinct closure vs. live
+// cameras, mirroring drei's makeDefault swap.
+const cameras = vi.hoisted(() => {
+  const cam = () => ({
+    position: { copy: vi.fn(), clone: vi.fn().mockReturnThis(), distanceTo: vi.fn(() => 100) },
+    up: { set: vi.fn(), copy: vi.fn() },
+    lookAt: vi.fn(),
+    quaternion: { copy: vi.fn() },
+  });
+  return { staleCamera: cam(), liveCamera: cam() };
+});
+
+vi.mock('@react-three/fiber', () => ({
+  // `camera` is the stale closure value (R3F's throwaway initial camera);
+  // `get().camera` is the live default that drei swapped in.
+  useThree: () => ({
+    camera: cameras.staleCamera,
+    invalidate: vi.fn(),
+    size: { height: 600 },
+    get: () => ({ camera: cameras.liveCamera }),
+  }),
+  useFrame: vi.fn(),
+}));
+
 const { CameraController } = await import('./CameraController');
 
+function renderController() {
+  const controlsRef: RefObject<OrbitControlsType | null> = createRef<OrbitControlsType>();
+  const invalidateRef: RefObject<(() => void) | null> = createRef<() => void>();
+  return render(
+    <CameraController
+      controlsRef={controlsRef}
+      invalidateRef={invalidateRef}
+      width={5}
+      depth={5}
+      gridUnitMm={42}
+      paddingLeft={0}
+      paddingRight={0}
+      paddingFront={0}
+      paddingBack={0}
+    />
+  );
+}
+
 describe('CameraController', () => {
-  it('exports a component function', () => {
-    expect(typeof CameraController).toBe('function');
+  beforeEach(() => {
+    cameras.staleCamera.position.copy.mockClear();
+    cameras.liveCamera.position.copy.mockClear();
+  });
+
+  it('frames the live default camera, not the stale closure camera', () => {
+    renderController();
+
+    // Regression (#1870 camera-rig handoff): drei's makeDefault swaps the real
+    // camera in via a layout effect, so the closure here still points at R3F's
+    // throwaway initial camera. Framing must target the live default.
+    expect(cameras.liveCamera.position.copy).toHaveBeenCalled();
+    expect(cameras.staleCamera.position.copy).not.toHaveBeenCalled();
   });
 });

--- a/src/features/baseplate/components/BaseplatePreview/CameraController.test.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/CameraController.test.tsx
@@ -4,9 +4,11 @@ import { createRef } from 'react';
 import type { RefObject } from 'react';
 import type { OrbitControls as OrbitControlsType } from 'three-stdlib';
 
-vi.mock('three', () => ({
-  // Constructable chainable stub — the controller does `new Vector3(...)`.
-  Vector3: class Vector3 {
+// Shared between the `three` mock and the camera instances so `instanceof
+// PerspectiveCamera` narrows correctly inside the controller (the far-plane
+// effect early-returns for non-perspective cameras).
+const mocks = vi.hoisted(() => {
+  class Vector3 {
     normalize() {
       return this;
     }
@@ -25,40 +27,51 @@ vi.mock('three', () => ({
     copy() {}
     set() {}
     lerpVectors() {}
-  },
-  // Real classes so `instanceof` narrows correctly in the controller.
-  PerspectiveCamera: class PerspectiveCamera {
+  }
+  class PerspectiveCamera {
     isPerspectiveCamera = true;
-  },
-  OrthographicCamera: class OrthographicCamera {
+    far = 0;
+    position = {
+      copy: vi.fn(),
+      clone: vi.fn().mockReturnThis(),
+      sub: vi.fn().mockReturnThis(),
+      distanceTo: vi.fn(() => 100),
+    };
+    up = { set: vi.fn(), copy: vi.fn() };
+    quaternion = { copy: vi.fn() };
+    lookAt = vi.fn();
+    updateProjectionMatrix = vi.fn();
+  }
+  class OrthographicCamera {
     isOrthographicCamera = true;
-  },
+  }
+  return {
+    Vector3,
+    PerspectiveCamera,
+    OrthographicCamera,
+    // `staleCamera` is the closure value (R3F's throwaway initial camera);
+    // `liveCamera` is the default drei swapped in via makeDefault.
+    staleCamera: new PerspectiveCamera(),
+    liveCamera: new PerspectiveCamera(),
+  };
+});
+
+vi.mock('three', () => ({
+  Vector3: mocks.Vector3,
+  PerspectiveCamera: mocks.PerspectiveCamera,
+  OrthographicCamera: mocks.OrthographicCamera,
 }));
 
 vi.mock('@/shared/printSettings/gridfinityGeometry', () => ({
   GRIDFINITY_SPEC: { SOCKET_HEIGHT: 5 },
 }));
 
-// Hoisted holders so the useThree mock can hand back distinct closure vs. live
-// cameras, mirroring drei's makeDefault swap.
-const cameras = vi.hoisted(() => {
-  const cam = () => ({
-    position: { copy: vi.fn(), clone: vi.fn().mockReturnThis(), distanceTo: vi.fn(() => 100) },
-    up: { set: vi.fn(), copy: vi.fn() },
-    lookAt: vi.fn(),
-    quaternion: { copy: vi.fn() },
-  });
-  return { staleCamera: cam(), liveCamera: cam() };
-});
-
 vi.mock('@react-three/fiber', () => ({
-  // `camera` is the stale closure value (R3F's throwaway initial camera);
-  // `get().camera` is the live default that drei swapped in.
   useThree: () => ({
-    camera: cameras.staleCamera,
+    camera: mocks.staleCamera,
     invalidate: vi.fn(),
     size: { height: 600 },
-    get: () => ({ camera: cameras.liveCamera }),
+    get: () => ({ camera: mocks.liveCamera }),
   }),
   useFrame: vi.fn(),
 }));
@@ -85,17 +98,27 @@ function renderController() {
 
 describe('CameraController', () => {
   beforeEach(() => {
-    cameras.staleCamera.position.copy.mockClear();
-    cameras.liveCamera.position.copy.mockClear();
+    mocks.staleCamera.position.copy.mockClear();
+    mocks.liveCamera.position.copy.mockClear();
+    mocks.staleCamera.updateProjectionMatrix.mockClear();
+    mocks.liveCamera.updateProjectionMatrix.mockClear();
   });
 
+  // Regression (#1870 camera-rig handoff): drei's makeDefault swaps the real
+  // camera in via a layout effect, so the closure still points at R3F's
+  // throwaway initial camera when the passive effects run. Both the framing
+  // and the far-plane effects must target the live default camera instead.
   it('frames the live default camera, not the stale closure camera', () => {
     renderController();
 
-    // Regression (#1870 camera-rig handoff): drei's makeDefault swaps the real
-    // camera in via a layout effect, so the closure here still points at R3F's
-    // throwaway initial camera. Framing must target the live default.
-    expect(cameras.liveCamera.position.copy).toHaveBeenCalled();
-    expect(cameras.staleCamera.position.copy).not.toHaveBeenCalled();
+    expect(mocks.liveCamera.position.copy).toHaveBeenCalled();
+    expect(mocks.staleCamera.position.copy).not.toHaveBeenCalled();
+  });
+
+  it('sets the far plane on the live default camera, not the stale closure camera', () => {
+    renderController();
+
+    expect(mocks.liveCamera.updateProjectionMatrix).toHaveBeenCalled();
+    expect(mocks.staleCamera.updateProjectionMatrix).not.toHaveBeenCalled();
   });
 });

--- a/src/features/baseplate/components/BaseplatePreview/CameraController.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/CameraController.tsx
@@ -81,10 +81,14 @@ export function CameraController({
   // the geometry's farthest corner clips off-screen at maximum zoom for
   // large baseplates (50×50 + 100mm padding pushes the corner past 21m).
   useEffect(() => {
+    // Same live-camera read as the framing init below: on first mount the
+    // `camera` closure is still R3F's throwaway default, so setting far on it
+    // leaves the real camera at its seed far value (large baseplates clip for
+    // one frame). `camera` stays in the deps so a projection swap re-runs this.
     const targetFar = calculateFarPlane(calculateMaxOrbitDistance(idealDistance));
-    setCameraFar(camera, targetFar);
+    setCameraFar(get().camera, targetFar);
     invalidate();
-  }, [camera, idealDistance, invalidate]);
+  }, [camera, idealDistance, invalidate, get]);
 
   const animRef = useRef<{
     startPos: THREE.Vector3;

--- a/src/features/baseplate/components/BaseplatePreview/CameraController.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/CameraController.tsx
@@ -51,7 +51,7 @@ export function CameraController({
   paddingFront: number;
   paddingBack: number;
 }) {
-  const { camera, invalidate, size } = useThree();
+  const { camera, invalidate, size, get } = useThree();
   const initializedRef = useRef(false);
 
   // Expose invalidate to hooks outside Canvas context
@@ -102,12 +102,18 @@ export function CameraController({
 
   useEffect(() => {
     if (!initializedRef.current) {
+      // Read the live default camera, not the closure value. drei's
+      // makeDefault swaps the real camera in during a layout effect that only
+      // takes hold on the *next* render, so the closure here still points at
+      // R3F's throwaway initial camera. Framing that one would latch
+      // initializedRef and leave the real camera stuck at its seed position.
+      const activeCamera = get().camera;
       const direction = new THREE.Vector3(...CAMERA_PRESETS.top).normalize();
-      camera.position.copy(direction.multiplyScalar(idealDistance).add(binCenter));
-      camera.up.set(0, 0, 1);
-      camera.lookAt(binCenter);
-      if (camera instanceof OrthographicCamera && size.height > 0) {
-        setOrthoZoom(camera, distanceToOrthoZoom(idealDistance, fov, size.height));
+      activeCamera.position.copy(direction.multiplyScalar(idealDistance).add(binCenter));
+      activeCamera.up.set(0, 0, 1);
+      activeCamera.lookAt(binCenter);
+      if (activeCamera instanceof OrthographicCamera && size.height > 0) {
+        setOrthoZoom(activeCamera, distanceToOrthoZoom(idealDistance, fov, size.height));
       }
       if (controlsRef.current) {
         controlsRef.current.target.copy(binCenter);
@@ -144,7 +150,7 @@ export function CameraController({
     }
 
     prevDistanceRef.current = idealDistance;
-  }, [idealDistance, binCenter, camera, controlsRef, fov, size.height]);
+  }, [idealDistance, binCenter, camera, controlsRef, fov, size.height, get]);
 
   useEffect(() => {
     if (controlsRef.current && initializedRef.current) {


### PR DESCRIPTION
## What

The default baseplate preview opened **zoomed-in at a 3/4 angle** instead of the top-down, fit-in-view framing it used to show. This restores the expected default: the whole baseplate framed top-down on open.

| Before | After |
| --- | --- |
| Zoomed-in 3/4 perspective, grid receding into the distance | Top-down, baseplate fitted in view |

## Why

The camera-rig refactor (#1870 / #1877) replaced the single Canvas camera with a dual perspective/orthographic rig that swaps the real camera in via drei's `makeDefault` — a **layout effect** that only takes hold on the next render.

`CameraController` frames the camera in a **passive effect**, whose closure still held R3F's throwaway initial camera from the first render. It framed that throwaway, latched `initializedRef`, and the real camera arrived too late to be framed — left stuck at its seed position `[100, -100, 80]`.

## Fix

Read the **live** default camera from the R3F store (`get().camera`) inside the init effect instead of the stale closure value. By the time the passive effect runs, drei has already set the real camera as default. Framing still runs once, so projection toggles stay handled by `CameraRig`.

## Testing

- Added a regression test that asserts the live default camera is framed and the stale closure camera is not. Verified it fails on the pre-fix code and passes with the fix.
- `pnpm run typecheck`, ESLint, and all BaseplatePreview tests pass.
- Manual visual check (Playwright): default view now opens top-down and fitted.