### PR TITLE
style(bin-designer): unify segmented controls into one consistent style

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutScoopControls.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutScoopControls.tsx
@@ -16,6 +16,7 @@ import type { Cutout, CutoutScoopEdges } from '@/features/bin-designer/types';
 import { DEFAULT_SCOOP_EDGES } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
 import { SliderInput } from '@/features/bin-designer/components/controls/SliderInput';
+import { SEGMENT_ACTIVE, SEGMENT_INACTIVE } from '@/shared/components/segmentedControlClasses';
 
 interface CutoutScoopControlsProps {
   readonly cutout: Cutout;
@@ -194,11 +195,9 @@ function EdgeChip({ label, ariaLabel, on, disabled, onToggle }: EdgeChipProps) {
       disabled={disabled}
       aria-label={ariaLabel}
       aria-pressed={on}
-      className={`h-5 min-w-[20px] rounded text-[10px] font-medium transition-colors px-1 ${
-        on
-          ? 'bg-accent/15 text-accent hover:bg-accent/25'
-          : 'bg-surface-subtle text-content-tertiary hover:bg-surface-subtle/70'
-      } disabled:opacity-50 disabled:cursor-not-allowed`}
+      className={`h-5 min-w-[20px] rounded px-1 text-[10px] font-medium leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset disabled:cursor-not-allowed disabled:opacity-50 ${
+        on ? SEGMENT_ACTIVE : SEGMENT_INACTIVE
+      }`}
     >
       {label}
     </button>

--- a/src/features/bin-designer/components/CutoutWorkspace/FloatingInspector.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/FloatingInspector.tsx
@@ -13,6 +13,7 @@ import { TEXT_MAX_LENGTH } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
 import { SliderInput } from '@/features/bin-designer/components/controls/SliderInput';
 import { CompactNumberInput } from '@/shared/components/CompactNumberInput';
+import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
 import { clampRotationToBounds, getRotatedBounds } from '../panel/CutoutsSection/geometry';
 import { CutoutScoopControls } from './CutoutScoopControls';
 import { Checkbox, Input } from '@/design-system';
@@ -494,7 +495,11 @@ function CutoutEngraveLabelControls({
             <span className="mb-1 block text-[10px] uppercase tracking-wide text-content-tertiary">
               {t('binDesigner.cutoutTextSide')}
             </span>
-            <div role="group" aria-label={t('binDesigner.cutoutTextSide')} className="flex gap-1">
+            <div
+              role="group"
+              aria-label={t('binDesigner.cutoutTextSide')}
+              className={SEGMENT_GROUP_CLASS}
+            >
               {SIDE_OPTIONS.map(({ side: opt, glyph }) => (
                 <button
                   key={opt}
@@ -504,11 +509,7 @@ function CutoutEngraveLabelControls({
                   aria-pressed={side === opt}
                   aria-label={t(`binDesigner.cutoutTextSide.${opt}`)}
                   title={t(`binDesigner.cutoutTextSide.${opt}`)}
-                  className={`flex-1 rounded px-2 py-1 text-xs font-medium leading-none transition-colors ${
-                    side === opt
-                      ? 'bg-accent text-on-accent'
-                      : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
-                  }`}
+                  className={`flex-1 leading-none ${getSegmentClass(side === opt)}`}
                 >
                   {glyph}
                 </button>

--- a/src/features/bin-designer/components/controls/ThicknessSelector/ThicknessSelector.tsx
+++ b/src/features/bin-designer/components/controls/ThicknessSelector/ThicknessSelector.tsx
@@ -7,6 +7,7 @@
 
 import { useCallback, useRef } from 'react';
 import { WALL_THICKNESS_OPTIONS } from '@/features/bin-designer/constants';
+import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
 
 interface ThicknessSelectorProps {
   /** Display label */
@@ -66,7 +67,7 @@ export function ThicknessSelector({
       </div>
       <div
         ref={groupRef}
-        className="flex gap-1"
+        className={SEGMENT_GROUP_CLASS}
         role="radiogroup"
         aria-label={label}
         tabIndex={-1}
@@ -84,11 +85,7 @@ export function ThicknessSelector({
               aria-label={`${option}mm`}
               disabled={disabled}
               onClick={() => onChange(option)}
-              className={`flex-1 rounded-md px-1 py-1.5 text-xs font-medium tabular-nums transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
-                isActive
-                  ? 'bg-accent text-on-accent shadow-sm'
-                  : 'bg-surface-secondary text-content-secondary hover:bg-surface-tertiary'
-              } disabled:cursor-not-allowed`}
+              className={`flex-1 tabular-nums ${getSegmentClass(isActive)}`}
             >
               {option}
             </button>

--- a/src/features/bin-designer/components/controls/ThicknessSelector/ThicknessSelector.tsx
+++ b/src/features/bin-designer/components/controls/ThicknessSelector/ThicknessSelector.tsx
@@ -60,8 +60,8 @@ export function ThicknessSelector({
   );
 
   return (
-    <div className={disabled ? 'opacity-50' : ''}>
-      <div className="mb-2 flex items-center justify-between">
+    <div>
+      <div className={`mb-2 flex items-center justify-between ${disabled ? 'opacity-50' : ''}`}>
         <span className="text-xs font-medium text-content-secondary">{label}</span>
         <span className="text-xs tabular-nums text-content-tertiary">{value} mm</span>
       </div>

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
@@ -24,6 +24,7 @@ import type { ColorZone, FeatureColorConfig } from '@/features/bin-designer/type
 import type { SavedColorPalette } from '@/core/store/settings.types';
 import { useTranslation } from '@/i18n';
 import { PipetteIcon } from '@/design-system/Icon';
+import { SEGMENT_ACTIVE, SEGMENT_INACTIVE } from '@/shared/components/segmentedControlClasses';
 import { useSwapZoneWithToast } from '@/features/bin-designer/hooks/useSwapZoneWithToast';
 import { ColorZoneRow } from './ColorZoneRow';
 import { ColorGroup } from './ColorGroup';
@@ -246,10 +247,8 @@ export function ColorsSection() {
               aria-pressed={colorTool === 'eyedropper'}
               aria-label={t('binDesigner.colors.eyedropper.enter')}
               title={t('binDesigner.colors.eyedropper.enter')}
-              className={`flex h-6 w-6 items-center justify-center rounded transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent ${
-                colorTool === 'eyedropper'
-                  ? 'bg-accent text-on-accent'
-                  : 'text-content-tertiary hover:bg-surface-hover hover:text-content-secondary'
+              className={`flex h-6 w-6 items-center justify-center rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ${
+                colorTool === 'eyedropper' ? SEGMENT_ACTIVE : SEGMENT_INACTIVE
               }`}
             >
               <PipetteIcon size="sm" />

--- a/src/features/bin-designer/components/panel/CutoutsSection/ArrangeControls.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/ArrangeControls.tsx
@@ -7,6 +7,7 @@
 
 import type { ReorderDirection } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
+import { getSegmentClass } from '@/shared/components/segmentedControlClasses';
 
 interface ArrangeControlsProps {
   readonly selectedIds: readonly string[];
@@ -26,7 +27,7 @@ export function ArrangeControls({
   const btn = (direction: ReorderDirection, label: string, content: React.ReactNode) => (
     <button
       type="button"
-      className="rounded p-1 text-content-tertiary hover:bg-surface-hover hover:text-content transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      className={getSegmentClass(false, { size: 'icon' })}
       onClick={() => onReorder(selectedIds, direction)}
       title={label}
       aria-label={label}

--- a/src/features/bin-designer/components/panel/CutoutsSection/PathfinderControls.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/PathfinderControls.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from '@/i18n';
 import { useToastStore } from '@/core/store/toast';
 import { applyGroupOp } from './booleanGeometry';
 import { resolveActiveOp } from './pathfinderHelpers';
+import { getSegmentClass } from '@/shared/components/segmentedControlClasses';
 
 interface PathfinderControlsProps {
   readonly selectedIds: readonly string[];
@@ -160,11 +161,7 @@ export function PathfinderControls({
           <button
             key={op}
             type="button"
-            className={`flex items-center gap-1 rounded px-1.5 py-1 text-[11px] transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
-              isActive
-                ? 'bg-accent/15 text-accent ring-1 ring-accent/40'
-                : 'text-content-tertiary hover:bg-surface-hover hover:text-content'
-            }`}
+            className={getSegmentClass(isActive, { size: 'sm' })}
             onClick={() => handleClick(op)}
             disabled={allDisabled}
             title={label}

--- a/src/features/bin-designer/components/panel/CutoutsSection/TransformControls.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/TransformControls.tsx
@@ -15,6 +15,7 @@ import type { Cutout } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
 import { flipSelectionHorizontal, flipSelectionVertical } from './geometryFlips';
 import { buildGroupRotationUpdates } from './pathfinderHelpers';
+import { getSegmentClass } from '@/shared/components/segmentedControlClasses';
 
 interface TransformControlsProps {
   readonly selectedIds: readonly string[];
@@ -58,7 +59,7 @@ export function TransformControls({
   const btn = (onClick: () => void, label: string, content: React.ReactNode) => (
     <button
       type="button"
-      className="rounded p-1 text-content-tertiary hover:bg-surface-hover hover:text-content transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      className={getSegmentClass(false, { size: 'icon' })}
       onClick={onClick}
       title={label}
       aria-label={label}

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.test.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.test.tsx
@@ -34,4 +34,24 @@ describe('LabelTabsSection', () => {
     fireEvent.change(input, { target: { value: 'SCREWS' } });
     expect(useDesignerStore.getState().params.compartments.compartmentTexts).toEqual(['SCREWS']);
   });
+
+  it('exposes aria-pressed on the support picker reflecting the active option', () => {
+    render(<LabelTabsSection />);
+    // The pickers live inside the collapsed "Customize" disclosure.
+    fireEvent.click(screen.getByRole('button', { name: 'Customize' }));
+    // Default support is 'bracket'.
+    expect(screen.getByRole('button', { name: 'Bracket', pressed: true })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Solid', pressed: false })).toBeInTheDocument();
+  });
+
+  it('exposes aria-pressed on the alignment picker when it is visible', () => {
+    // Alignment is hidden at full width; shrink the tab so the picker renders.
+    useDesignerStore.setState((s) => ({
+      params: { ...s.params, label: { ...s.params.label, width: 50, alignment: 'center' } },
+    }));
+    render(<LabelTabsSection />);
+    fireEvent.click(screen.getByRole('button', { name: 'Customize' }));
+    expect(screen.getByRole('button', { name: 'Center', pressed: true })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Left', pressed: false })).toBeInTheDocument();
+  });
 });

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
@@ -7,6 +7,7 @@
 
 import { FeatureToggle } from '../FeatureToggle';
 import { StepperControl } from '@/shared/components/StepperControl';
+import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
 import { Input, Select, InfoIcon } from '@/design-system';
 import type { SelectOption } from '@/design-system';
 import { RulerIcon } from '@/design-system/Icon';
@@ -56,7 +57,7 @@ export function LabelTabsSection() {
         <span className="text-xs font-medium text-content-secondary mb-1 block">
           {t('binDesigner.tabEdges')}
         </span>
-        <div role="group" aria-label={t('binDesigner.tabEdges')} className="flex gap-1">
+        <div role="group" aria-label={t('binDesigner.tabEdges')} className={SEGMENT_GROUP_CLASS}>
           {EDGES_OPTIONS.map((option) => {
             const current = state.label.edges ?? 'back';
             return (
@@ -65,11 +66,7 @@ export function LabelTabsSection() {
                 type="button"
                 onClick={() => handlers.setTabEdges(option)}
                 aria-pressed={current === option}
-                className={`flex-1 rounded px-2 py-1 text-xs font-medium transition-colors ${
-                  current === option
-                    ? 'bg-accent text-on-accent'
-                    : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
-                }`}
+                className={`flex-1 ${getSegmentClass(current === option)}`}
               >
                 {t(`binDesigner.tabEdges.${option}`)}
               </button>
@@ -216,17 +213,18 @@ export function LabelTabsSection() {
               <InfoIcon size="xs" className="text-content-tertiary" />
             </span>
           </span>
-          <div role="group" aria-label={t('binDesigner.tabAlignment')} className="flex gap-1">
+          <div
+            role="group"
+            aria-label={t('binDesigner.tabAlignment')}
+            className={SEGMENT_GROUP_CLASS}
+          >
             {ALIGNMENT_OPTIONS.map((option) => (
               <button
                 key={option}
                 type="button"
                 onClick={() => handlers.setTabAlignment(option)}
-                className={`flex-1 rounded px-2 py-1 text-xs font-medium transition-colors ${
-                  state.label.alignment === option
-                    ? 'bg-accent text-on-accent'
-                    : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
-                }`}
+                aria-pressed={state.label.alignment === option}
+                className={`flex-1 ${getSegmentClass(state.label.alignment === option)}`}
               >
                 {t(`binDesigner.alignment.${option}`)}
               </button>
@@ -240,17 +238,14 @@ export function LabelTabsSection() {
         <span className="text-xs font-medium text-content-secondary mb-1 block">
           {t('binDesigner.tabSupport')}
         </span>
-        <div role="group" aria-label={t('binDesigner.tabSupport')} className="flex gap-1">
+        <div role="group" aria-label={t('binDesigner.tabSupport')} className={SEGMENT_GROUP_CLASS}>
           {SUPPORT_OPTIONS.map((option) => (
             <button
               key={option}
               type="button"
               onClick={() => handlers.setTabSupport(option)}
-              className={`flex-1 rounded px-2 py-1 text-xs font-medium transition-colors ${
-                state.label.support === option
-                  ? 'bg-accent text-on-accent'
-                  : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
-              }`}
+              aria-pressed={state.label.support === option}
+              className={`flex-1 ${getSegmentClass(state.label.support === option)}`}
             >
               {t(`binDesigner.tabSupport.${option}`)}
             </button>
@@ -273,18 +268,18 @@ export function LabelTabsSection() {
             <span className="mb-1 block text-xs text-content-tertiary">
               {t('binDesigner.textMode')}
             </span>
-            <div role="group" aria-label={t('binDesigner.textMode')} className="flex gap-1">
+            <div
+              role="group"
+              aria-label={t('binDesigner.textMode')}
+              className={SEGMENT_GROUP_CLASS}
+            >
               {MODE_OPTIONS.map((option) => (
                 <button
                   key={option}
                   type="button"
                   onClick={() => handlers.setTextMode(option)}
                   aria-pressed={state.textDefaults.mode === option}
-                  className={`flex-1 rounded px-2 py-1 text-xs font-medium transition-colors ${
-                    state.textDefaults.mode === option
-                      ? 'bg-accent text-on-accent'
-                      : 'border border-stroke-subtle bg-surface text-content-secondary hover:bg-surface-hover'
-                  }`}
+                  className={`flex-1 ${getSegmentClass(state.textDefaults.mode === option)}`}
                 >
                   {t(`binDesigner.textMode.${option}`)}
                 </button>

--- a/src/shared/components/segmentedControlClasses.test.ts
+++ b/src/shared/components/segmentedControlClasses.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSegmentClass,
+  SEGMENT_ACTIVE,
+  SEGMENT_INACTIVE,
+  SEGMENT_GROUP_CLASS,
+} from './segmentedControlClasses';
+
+describe('getSegmentClass', () => {
+  it('applies the accent tint + ring when active', () => {
+    const cls = getSegmentClass(true);
+    expect(cls).toContain('bg-accent/15');
+    expect(cls).toContain('text-accent');
+    expect(cls).toContain('ring-1');
+    expect(cls).toContain('ring-accent/40');
+  });
+
+  it('applies the quiet inactive treatment when not active', () => {
+    const cls = getSegmentClass(false);
+    expect(cls).toContain('text-content-tertiary');
+    expect(cls).toContain('hover:bg-surface-hover');
+    expect(cls).not.toContain('bg-accent/15');
+  });
+
+  it('uses compact sizing for sm and default sizing for md', () => {
+    expect(getSegmentClass(false, { size: 'sm' })).toContain('text-[11px]');
+    expect(getSegmentClass(false, { size: 'md' })).toContain('text-xs');
+    expect(getSegmentClass(false)).toContain('text-xs');
+  });
+
+  it('uses square padding for the icon size', () => {
+    const cls = getSegmentClass(false, { size: 'icon' });
+    expect(cls).toContain('p-1');
+    expect(cls).not.toContain('px-1.5');
+    expect(cls).not.toContain('px-2');
+  });
+
+  it('always includes focus-visible and disabled affordances', () => {
+    const cls = getSegmentClass(false);
+    expect(cls).toContain('focus-visible:ring-accent');
+    expect(cls).toContain('disabled:opacity-50');
+    expect(cls).toContain('disabled:cursor-not-allowed');
+  });
+
+  it('exposes color fragments and a group container class for bespoke call sites', () => {
+    expect(SEGMENT_ACTIVE).toContain('bg-accent/15');
+    expect(SEGMENT_INACTIVE).toContain('text-content-tertiary');
+    expect(SEGMENT_GROUP_CLASS).toContain('flex');
+  });
+});

--- a/src/shared/components/segmentedControlClasses.ts
+++ b/src/shared/components/segmentedControlClasses.ts
@@ -1,0 +1,44 @@
+/**
+ * Single source of truth for segmented-control button styling across the
+ * bin designer. Controls keep their own structure and ARIA semantics but
+ * pull their visual treatment from here so the look can't drift.
+ *
+ * Active state is a subtle accent tint with a crisp ring.
+ *
+ * Exception: PreviewControls (the toolbar floating over the 3D viewport)
+ * deliberately keeps its own solid accent fill and toolbar-specific sizing
+ * for contrast against arbitrary camera backgrounds, so it does not consume
+ * this helper.
+ */
+
+export type SegmentSize = 'icon' | 'sm' | 'md';
+
+const SEGMENT_BASE =
+  'flex items-center justify-center gap-1.5 font-medium rounded-md transition-colors ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ' +
+  'disabled:opacity-50 disabled:cursor-not-allowed';
+
+/** Color fragments — exported for bespoke-sized chips that supply their own dimensions. */
+export const SEGMENT_ACTIVE = 'bg-accent/15 text-accent ring-1 ring-accent/40';
+export const SEGMENT_INACTIVE =
+  'text-content-tertiary hover:bg-surface-hover hover:text-content-secondary';
+
+/** Container class for a horizontal segment group. */
+export const SEGMENT_GROUP_CLASS = 'flex gap-1';
+
+const SIZE_CLASS: Record<SegmentSize, string> = {
+  icon: 'p-1 text-[11px]',
+  sm: 'px-1.5 py-1 text-[11px]',
+  md: 'px-2 py-1 text-xs',
+};
+
+interface SegmentOptions {
+  /** `md` = sidebar pickers (default); `sm` = compact label strips; `icon` = square icon-only buttons. */
+  size?: SegmentSize;
+}
+
+export function getSegmentClass(isActive: boolean, opts: SegmentOptions = {}): string {
+  const { size = 'md' } = opts;
+  const state = isActive ? SEGMENT_ACTIVE : SEGMENT_INACTIVE;
+  return `${SEGMENT_BASE} ${SIZE_CLASS[size]} ${state}`;
+}


### PR DESCRIPTION
## What & why

The bin designer's toggle/segmented controls had drifted into **three** competing "active" treatments (solid accent fill, subtle tint, elevated pill), **two** focus idioms, and inconsistent inactive states (some bordered, some filled, some transparent). This made the panels feel visually noisy and inconsistent.

This PR converges them all on one quiet **accent-tint** language, backed by a small shared class helper so the look can't drift again.

| Before | After |
|---|---|
| `ThicknessSelector` solid fill, `LabelTabsSection` bordered segments, `PathfinderControls` tint, scoop edges tint-no-ring, etc. | Every picker: `bg-accent/15 text-accent ring-1 ring-accent/40` active, quiet `text-content-tertiary` inactive, one standardized focus-visible ring |

## Changes

- **New** `src/shared/components/segmentedControlClasses.ts` — single source of truth: `getSegmentClass(isActive, { size })` plus `SEGMENT_ACTIVE`/`SEGMENT_INACTIVE` fragments and `SEGMENT_GROUP_CLASS`. Sizes: `icon` (square), `sm` (compact strips), `md` (sidebar pickers).
- Converted to the shared tint: `ThicknessSelector`, `LabelTabsSection` (edges / alignment / support / text-mode), `FloatingInspector` text-side picker, `PathfinderControls`, the scoop `EdgeChip`, and the `ColorsSection` eyedropper toggle.
- `TransformControls` / `ArrangeControls` (icon-only action strips) gain a consistent focus-visible ring while keeping their square shape.
- **a11y:** added the missing `aria-pressed` to the alignment + support pickers (their siblings already had it).

## Deliberately left alone

- **PreviewControls** and the **canvas eyedropper** keep their solid accent fill — they float over the 3D viewport where the subtle tint reads weakly against arbitrary camera backgrounds.
- **ToolSwitcher** excluded — it's app-level navigation (Layout/Bins/Baseplate) and intentionally uses the neutral iOS-pill style.

## Verification

- `pnpm run typecheck`, `pnpm run quality` (knip clean, 0 lint errors)
- Full test suite green; added a unit test for `getSegmentClass` and tests asserting the new `aria-pressed`
- Playwright visual spot check of the label-tabs pickers — tint + ring reads clearly as selected against the dark panel