### PR TITLE
fix(generation): retain occt-wasm kernel wrapper to prevent GC use-after-free

### DIFF
--- a/src/features/generation/worker/generators/__kernel-tests__/kernelInit.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/kernelInit.ts
@@ -45,6 +45,17 @@ export async function initBrepkitKernel(): Promise<void> {
 }
 
 /**
+ * Strong references to live `OcctKernel` wrappers. The wrapper owns the raw
+ * Embind kernel and deletes it via a `FinalizationRegistry` when collected,
+ * but `OcctWasmAdapter` only borrows the raw kernel — so without this pin a GC
+ * pass frees the kernel out from under the adapter and the next op throws
+ * "Cannot pass deleted object as a pointer of type OcctKernel*". Mirrors the
+ * worker's `wasmInstantiator.loadOcctWasm` retention. Removable once brepjs's
+ * adapter retains the wrapper itself (andymai/brepjs#1091).
+ */
+const retainedOcctWasmKernels = new Set<unknown>();
+
+/**
  * Initialize occt-wasm kernel and register it with brepjs under id `'occt-wasm'`.
  * Coexists with `'occt'` (brepjs-opencascade) for parity comparisons.
  */
@@ -56,6 +67,9 @@ export async function initOcctWasmKernel(): Promise<void> {
   const wasmPath = join(process.cwd(), 'node_modules/occt-wasm/dist/occt-wasm.wasm');
   const wasmBinary = readFileSync(wasmPath);
   const kernel = await OcctKernel.init({ wasm: wasmBinary });
+  // Pin the wrapper so the FinalizationRegistry can't reclaim the raw kernel
+  // while the adapter is still using it — see `retainedOcctWasmKernels` above.
+  retainedOcctWasmKernels.add(kernel);
   // occt-wasm 3.0's exported types are still narrower than brepjs's expected
   // shape (missing VectorString/getExceptionMessage on the module, IGES/XCAF
   // methods on the raw kernel). All present at runtime — filed upstream.

--- a/src/features/generation/worker/generators/__kernel-tests__/occtWasmKernelLifecycle.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/occtWasmKernelLifecycle.test.ts
@@ -1,0 +1,69 @@
+/**
+ * occt-wasm kernel lifecycle regression.
+ *
+ * occt-wasm's `OcctKernel` wrapper owns the raw Embind kernel and releases it
+ * via a `FinalizationRegistry` when the wrapper is garbage-collected. brepjs's
+ * `OcctWasmAdapter` only borrows the raw kernel + module, so the integrator
+ * (our worker init) MUST keep the wrapper reachable for as long as the adapter
+ * is registered. If the wrapper is dropped, a GC pass fires the finalizer,
+ * `raw.delete()` frees the kernel, and the next generation throws:
+ *
+ *   "Cannot pass deleted object as a pointer of type OcctKernel*"
+ *
+ * This reproduces the production report: the first bin renders, then a later
+ * design change (after enough idle time for a GC) blows up. Requires real
+ * occt-wasm WASM + `--expose-gc`.
+ *
+ * Run:
+ *   pnpm exec vitest run --config vitest.profile.config.ts \
+ *     src/features/generation/worker/generators/__kernel-tests__/occtWasmKernelLifecycle
+ */
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from 'vitest';
+import { withKernel } from 'brepjs';
+import { initOcctWasmKernel, loadGenerateBin } from './dualKernelInit';
+import type { GenerateBinFn } from './dualKernelInit';
+import { buildParams } from './scenarioTypes';
+import { clearAllCaches } from '../shapeCache';
+
+let generateBin: GenerateBinFn;
+
+beforeAll(async () => {
+  await initOcctWasmKernel();
+  generateBin = await loadGenerateBin();
+}, 60_000);
+
+const gen = (gridW: number, gridD: number): void => {
+  withKernel('occt-wasm', () => generateBin(buildParams({ gridW, gridD }), undefined, false));
+};
+
+describe('occt-wasm kernel lifecycle', () => {
+  it.skipIf(!(globalThis as { gc?: () => void }).gc)(
+    'survives a GC pass between generations (wrapper not finalized out from under the adapter)',
+    async () => {
+      const gcFn = (globalThis as { gc: () => void }).gc;
+      const drainGc = async (): Promise<void> => {
+        for (let i = 0; i < 5; i++) {
+          gcFn();
+          // FinalizationRegistry callbacks are scheduled on a later task —
+          // yield the macrotask queue so any pending finalizer actually runs.
+          await new Promise((resolve) => setImmediate(resolve));
+        }
+      };
+
+      // First generation: works, and warms the registered adapter.
+      expect(() => gen(1, 2)).not.toThrow();
+
+      // Drop cached shapes so the next generation must drive the kernel
+      // (not just clone cache hits), then provoke the finalizer.
+      clearAllCaches();
+      await drainGc();
+
+      // Second generation after GC — this is the production "make a change"
+      // step. With the wrapper dropped, the raw kernel is already deleted and
+      // this throws the Embind use-after-free.
+      expect(() => gen(2, 3)).not.toThrow();
+    },
+    120_000
+  );
+});

--- a/src/features/generation/worker/wasmInstantiator.ts
+++ b/src/features/generation/worker/wasmInstantiator.ts
@@ -110,6 +110,19 @@ export async function loadBrepkit(): Promise<WasmLoadResult> {
 }
 
 /**
+ * Strong references to live `OcctKernel` wrappers, held for the worker's
+ * lifetime. The wrapper owns the raw Embind kernel and frees it via a
+ * `FinalizationRegistry` when collected; brepjs's `OcctWasmAdapter` only
+ * borrows the raw kernel, so dropping the wrapper lets GC delete the kernel
+ * out from under the adapter — the next generation then throws "Cannot pass
+ * deleted object as a pointer of type OcctKernel*". Pinning the wrapper here
+ * keeps it reachable; `worker.terminate()` frees the whole WASM heap, so no
+ * explicit disposal is needed. Removable once brepjs's adapter retains the
+ * wrapper itself (andymai/brepjs#1091).
+ */
+const retainedOcctWasmKernels = new Set<unknown>();
+
+/**
  * Load and initialize the occt-wasm geometry kernel.
  *
  * Uses occt-wasm 3.0's public `OcctKernel.init()` and the
@@ -130,6 +143,8 @@ export async function loadOcctWasm(): Promise<WasmLoadResult> {
   ]);
 
   const kernel = await OcctKernel.init({ wasm: occtWasmUrlMod.default });
+  // Pin the wrapper for the worker's lifetime — see `retainedOcctWasmKernels`.
+  retainedOcctWasmKernels.add(kernel);
   // occt-wasm 3.0's exported `OcctWasmModule` still omits `VectorString` /
   // `getExceptionMessage`, and `OcctRawKernel` still omits IGES + XCAF
   // methods that brepjs's interface declares. Both surfaces exist at


### PR DESCRIPTION
## What

Enabling the `occt_wasm_kernel` Labs flag and then editing a design in the bin designer threw:

```
BindingError: Cannot pass deleted object as a pointer of type OcctKernel*
```

The first generation rendered fine; a later change (after enough idle time for a GC) blew up.

## Why

occt-wasm's `OcctKernel` wrapper owns the raw Embind kernel and frees it via a `FinalizationRegistry` when the wrapper is garbage-collected. brepjs's `OcctWasmAdapter` only *borrows* the raw kernel + module — it never holds the wrapper. Our worker init dropped the wrapper the instant `loadOcctWasm()` returned, so the wrapper became GC-eligible while the adapter stayed registered and in use. A GC pass then ran the finalizer, `raw.delete()` freed the kernel, and the next operation passed a dangling `OcctKernel*`.

occt-wasm's own docs spell out the contract we were breaking: *"the adapter must not outlive the `OcctKernel` it was constructed from."*

## Fix

Pin the `OcctKernel` wrapper for the worker's lifetime so the finalizer can't reclaim it while the adapter is live. No explicit disposal needed — `worker.terminate()` already frees the whole WASM heap.

- `wasmInstantiator.ts` — production loader (`loadOcctWasm`)
- `__kernel-tests__/kernelInit.ts` — test-infra mirror (had the identical latent bug)

Both reference [andymai/brepjs#1091](https://github.com/andymai/brepjs/issues/1091) as the trigger to remove the workaround, once the adapter retains the wrapper itself.

## Test

`occtWasmKernelLifecycle.test.ts` warms one generation, forces GC to fire the finalizer, then regenerates. It reproduced the exact error deterministically before the fix and passes after. Gated with `skipIf(!globalThis.gc)`, so it runs under the profile config with `--expose-gc` alongside the other kernel tests:

```
NODE_OPTIONS="--expose-gc" pnpm exec vitest run --config vitest.profile.config.ts \
  src/features/generation/worker/generators/__kernel-tests__/occtWasmKernelLifecycle
```

## Verification

- Regression test: fails on old code with the production error, passes after the fix
- `pnpm run typecheck` clean
- ESLint clean on all touched files
- Existing `occtWasmIsolation` test still passes (no regression from retention)
