### PR TITLE
fix(bin-designer): stop 3D preview crashing when the browser auto-translates

### DIFF
--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -321,6 +321,11 @@ export function PreviewCanvas() {
       onPointerDown={onDoubleTapPointerDown}
       onPointerUp={onDoubleTapPointerUp}
       onPointerCancel={onDoubleTapPointerCancel}
+      // Page translators rewrap the frequently-updated overlay/status text
+      // below, desyncing React's DOM and crashing the reconciler. This is a
+      // 3D tool surface (icons + live status), so opting it out of translation
+      // costs nothing and keeps the canvas subtree stable.
+      translate="no"
     >
       {/* ARIA live region for status announcements */}
       <div aria-live="polite" aria-atomic="true" className="sr-only">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,6 +25,12 @@ import {
 import { connectDesignLinking } from '@/features/design-linking/subscribers';
 import { InitErrorFallback } from '@/shell/InitErrorFallback';
 import { isSmokeMode } from '@/shared/utils/smokeMode';
+import { installTranslationDomGuard } from '@/shared/utils/translationDomGuard';
+
+// Browser page-translation rewraps text nodes under React, which otherwise
+// crashes the reconciler with insertBefore/removeChild NotFoundError. Install
+// the guard before any DOM is created so every boot path is covered.
+installTranslationDomGuard();
 
 // Smoke mode (?smoke=1) boots a synthetic fixture and reports back to a parent listener.
 // Must short-circuit ahead of www-migration paths, which would otherwise reload/redirect

--- a/src/shared/utils/translationDomGuard.test.ts
+++ b/src/shared/utils/translationDomGuard.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { installTranslationDomGuard } from './translationDomGuard';
+
+const originalRemoveChild = Node.prototype.removeChild;
+const originalInsertBefore = Node.prototype.insertBefore;
+
+describe('installTranslationDomGuard', () => {
+  // The guard patches the prototype once and is idempotent, so install for the
+  // whole file and restore at the end rather than per-test.
+  beforeAll(() => {
+    installTranslationDomGuard();
+  });
+
+  afterAll(() => {
+    Node.prototype.removeChild = originalRemoveChild;
+    Node.prototype.insertBefore = originalInsertBefore;
+  });
+
+  it('still removes a real child node', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+    parent.appendChild(child);
+
+    expect(parent.removeChild(child)).toBe(child);
+    expect(parent.contains(child)).toBe(false);
+  });
+
+  it('no-ops instead of throwing when removing a node from the wrong parent', () => {
+    const parent = document.createElement('div');
+    const otherParent = document.createElement('div');
+    const child = document.createElement('span');
+    otherParent.appendChild(child);
+
+    // Without the guard this throws NotFoundError (the Translate crash).
+    expect(() => parent.removeChild(child)).not.toThrow();
+    expect(parent.removeChild(child)).toBe(child);
+    // The node stays where it actually lives.
+    expect(otherParent.contains(child)).toBe(true);
+  });
+
+  it('still inserts before a real reference node', () => {
+    const parent = document.createElement('div');
+    const ref = document.createElement('span');
+    const inserted = document.createElement('b');
+    parent.appendChild(ref);
+
+    expect(parent.insertBefore(inserted, ref)).toBe(inserted);
+    expect(parent.firstChild).toBe(inserted);
+  });
+
+  it('appends when reference node is null', () => {
+    const parent = document.createElement('div');
+    const inserted = document.createElement('b');
+
+    expect(parent.insertBefore(inserted, null)).toBe(inserted);
+    expect(parent.firstChild).toBe(inserted);
+  });
+
+  it('no-ops instead of throwing when reference node has a different parent', () => {
+    const parent = document.createElement('div');
+    const otherParent = document.createElement('div');
+    const ref = document.createElement('span');
+    const inserted = document.createElement('b');
+    otherParent.appendChild(ref);
+
+    expect(() => parent.insertBefore(inserted, ref)).not.toThrow();
+    expect(parent.insertBefore(inserted, ref)).toBe(inserted);
+    // Nothing was inserted into the wrong parent.
+    expect(parent.contains(inserted)).toBe(false);
+  });
+});

--- a/src/shared/utils/translationDomGuard.test.ts
+++ b/src/shared/utils/translationDomGuard.test.ts
@@ -15,6 +15,18 @@ describe('installTranslationDomGuard', () => {
   afterAll(() => {
     Node.prototype.removeChild = originalRemoveChild;
     Node.prototype.insertBefore = originalInsertBefore;
+    // Drop the prototype brand so the guard can be re-installed by other files.
+    Reflect.deleteProperty(Node.prototype, '__translationDomGuardInstalled__');
+  });
+
+  it('is idempotent — a second install does not re-wrap the methods', () => {
+    const patchedRemove = Node.prototype.removeChild;
+    const patchedInsert = Node.prototype.insertBefore;
+
+    installTranslationDomGuard();
+
+    expect(Node.prototype.removeChild).toBe(patchedRemove);
+    expect(Node.prototype.insertBefore).toBe(patchedInsert);
   });
 
   it('still removes a real child node', () => {

--- a/src/shared/utils/translationDomGuard.ts
+++ b/src/shared/utils/translationDomGuard.ts
@@ -1,0 +1,43 @@
+/**
+ * Browser page-translation (Chrome's built-in translate, Google Translate,
+ * some extensions) rewraps text nodes in `<font>` elements directly in the
+ * live DOM. This desyncs React's virtual DOM from the real tree, so React's
+ * commit phase later calls `insertBefore`/`removeChild` against a node the
+ * translator already relocated — throwing
+ * `NotFoundError: Failed to execute 'insertBefore' on 'Node'` mid-render.
+ *
+ * Guarding the two mutation methods so a cross-parent call degrades to a
+ * no-op (instead of throwing) keeps the subtree alive. The translated text is
+ * already where the translator put it, so skipping React's redundant move is
+ * visually harmless. See facebook/react#11538.
+ */
+
+let installed = false;
+
+export function installTranslationDomGuard(): void {
+  if (installed) return;
+  if (typeof Node !== 'function') return;
+  installed = true;
+
+  // eslint-disable-next-line @typescript-eslint/unbound-method -- intentional: invoked via .call(this, …) below
+  const originalRemoveChild = Node.prototype.removeChild;
+  Node.prototype.removeChild = function removeChild<T extends Node>(this: Node, child: T): T {
+    if (child.parentNode !== this) {
+      return child;
+    }
+    return originalRemoveChild.call(this, child) as T;
+  };
+
+  // eslint-disable-next-line @typescript-eslint/unbound-method -- intentional: invoked via .call(this, …) below
+  const originalInsertBefore = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function insertBefore<T extends Node>(
+    this: Node,
+    newNode: T,
+    referenceNode: Node | null
+  ): T {
+    if (referenceNode && referenceNode.parentNode !== this) {
+      return newNode;
+    }
+    return originalInsertBefore.call(this, newNode, referenceNode) as T;
+  };
+}

--- a/src/shared/utils/translationDomGuard.ts
+++ b/src/shared/utils/translationDomGuard.ts
@@ -12,12 +12,22 @@
  * visually harmless. See facebook/react#11538.
  */
 
-let installed = false;
+// Branding the prototype (not a module-level boolean) ties the
+// idempotency check to the same global object the patch mutates. A module
+// re-evaluation (e.g. vi.resetModules()) can't then desync a fresh "installed"
+// flag from the already-patched prototype and double-wrap the methods.
+const GUARD_FLAG = '__translationDomGuardInstalled__';
 
 export function installTranslationDomGuard(): void {
-  if (installed) return;
   if (typeof Node !== 'function') return;
-  installed = true;
+
+  const proto = Node.prototype as unknown as Record<string, unknown>;
+  if (proto[GUARD_FLAG]) return;
+  Object.defineProperty(proto, GUARD_FLAG, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
 
   // eslint-disable-next-line @typescript-eslint/unbound-method -- intentional: invoked via .call(this, …) below
   const originalRemoveChild = Node.prototype.removeChild;


### PR DESCRIPTION
## What

Non-English visitors hit a `NotFoundError: Failed to execute 'insertBefore' on 'Node'` that collapses the bin designer's 3D preview to its "Retry" error panel — most visibly while exporting a bin (notably one with a stacking lid).

## Root cause

It's **not** the export pipeline — exports succeed every time. It's browser page-translation desyncing React:

- Visitors whose browser language isn't one of our 7 locales (en/de/es/fr/nb/nl/pt-BR) land on the English UI and accept Chrome's auto-translate. Google Translate rewraps text nodes in `<font>` tags.
- That desyncs React's virtual DOM, so the reconciler later calls `insertBefore`/`removeChild` against a node the translator already moved → `NotFoundError` mid-render.
- The 3D-preview `PanelErrorBoundary` catches it (`$exception` + `3d_render_error`), so the app survives but the live preview drops to the Retry panel.
- A stacking lid renders extra conditional overlay nodes (`LidMesh`, `LidGuideLine`, `LidExplodeSlider`, the live `aria-live` status text), widening the export-time re-render window — hence the correlation.

**PostHog confirms 100% of affected users are non-English** (`zh-CN`, `ru-RU`, `ru`, `ja`, `it`) across all three issues; ~14 occurrences / ~9 users over ~12 days, still active.

## Fix

- **Global guard** (`src/shared/utils/translationDomGuard.ts`): patches `Node.prototype.insertBefore`/`removeChild` to no-op on cross-parent calls instead of throwing. The translated text is already where the translator put it, so skipping React's redundant move is visually harmless. Installed in `main.tsx` before first paint so every boot path is covered. (See facebook/react#11538.)
- **`translate="no"`** on the 3D-preview root so translators never touch its volatile React-managed overlay/status text in the first place.

## Testing

- New `translationDomGuard.test.ts` — 5/5 pass (real removals/inserts still work; cross-parent calls no-op instead of throwing).
- `PreviewCanvas` 13/13, `typecheck`, `eslint` (touched files) all green.

## Follow-up (not in this PR)

Adding `zh-CN`, `ru`, `ja`, `it` to i18n would stop these users landing on English at all — addressing the demand for translation rather than just hardening against it.