### PR TITLE
fix: make print-bed link toggle clearly visible

### DIFF
--- a/src/shared/components/PrintBedInput/PrintBedInput.tsx
+++ b/src/shared/components/PrintBedInput/PrintBedInput.tsx
@@ -79,7 +79,7 @@ export function PrintBedInput({
     ? 'input w-14 py-0.5 px-1 text-xs text-right'
     : 'input w-20 h-10 text-center';
   const iconSize = isCompact ? 'w-3 h-3' : 'w-4 h-4';
-  const btnClass = `flex-shrink-0 rounded text-content-disabled hover:text-content-tertiary transition-colors focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent ${isCompact ? 'p-0.5' : 'p-1'}`;
+  const btnClass = `flex-shrink-0 rounded border border-stroke-subtle text-content-secondary hover:text-content hover:bg-surface-hover hover:border-stroke transition-colors focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent ${isCompact ? 'p-0.5' : 'p-1'}`;
 
   const linkButton = (
     <button


### PR DESCRIPTION
## What

The link/unlink toggle next to the **Print bed** input now stands out as a real control instead of fading into the panel.

In issue #1938, a user wanted separate X and Y bed dimensions — which the link icon already enables — but reported they *"couldn't quite see the link icon clearly"* on their monitor. The icon was painted with `text-content-disabled` (the same gray used for disabled text) and had no border or background, so it read as decoration.

## Change

One-line styling update in `PrintBedInput`:

- **Contrast** — default color `text-content-disabled` → `text-content-secondary`, hover now brightens to primary `text-content`
- **Affordance** — added a subtle `border-stroke-subtle` button shape with `hover:bg-surface-hover` (same understated tokens as the adjacent "Reset" button)

## Before / After

| Linked (square bed) | Unlinked (X × Y) |
| --- | --- |
| `[ 256 ] [⛓] mm` | `[ 256 ] × [ 256 ] [⛓] mm` |

The toggle now has visible bordered chrome and brighter color in both states.

## Verification

- ✅ 7/7 `PrintBedInput` component tests pass
- ✅ `pnpm run typecheck` clean
- ✅ Playwright visual spot check of both linked/unlinked states in the sidebar

Closes #1938