### PR TITLE
feat(bin-designer): highlight the affected wall when hovering overhang controls

### DIFF
--- a/e2e/bin-designer/overhang-visual.spec.ts
+++ b/e2e/bin-designer/overhang-visual.spec.ts
@@ -99,11 +99,12 @@ test.describe('Bin overhang — visual', () => {
     const hovered = await canvas.screenshot();
     expect(baseline.equals(hovered)).toBe(false);
 
-    // Moving the pointer away clears the highlight.
+    // Moving the pointer away clears the highlight, returning to the baseline.
     await header.hover();
     await page.waitForTimeout(250);
     const cleared = await canvas.screenshot();
     expect(cleared.equals(hovered)).toBe(false);
+    expect(cleared.equals(baseline)).toBe(true);
 
     await test.info().attach('highlight-baseline.png', {
       body: baseline,

--- a/e2e/bin-designer/overhang-visual.spec.ts
+++ b/e2e/bin-designer/overhang-visual.spec.ts
@@ -73,4 +73,42 @@ test.describe('Bin overhang — visual', () => {
     });
     await test.info().attach('overhang-feet.png', { body: afterFeet, contentType: 'image/png' });
   });
+
+  test('hovering an overhang control highlights the matching wall', async ({ page }) => {
+    test.setTimeout(180_000);
+    await page.goto('/designer');
+
+    const canvas = page.locator('canvas').first();
+    await expect(canvas).toBeVisible({ timeout: 120_000 });
+    await waitForGenerationComplete(page);
+
+    const header = page.getByRole('button', { name: /^Overhang/i });
+    await expect(header).toBeVisible({ timeout: 15_000 });
+    await header.click();
+    await expect(header).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.getByText('Left', { exact: true }).first()).toBeVisible();
+
+    // Baseline with the pointer off the panel controls.
+    await header.hover();
+    await page.waitForTimeout(250);
+    const baseline = await canvas.screenshot();
+
+    // Hovering a side control lights up its wall (translucent overlay) even at 0mm.
+    await page.getByText('Left', { exact: true }).first().hover();
+    await page.waitForTimeout(250);
+    const hovered = await canvas.screenshot();
+    expect(baseline.equals(hovered)).toBe(false);
+
+    // Moving the pointer away clears the highlight.
+    await header.hover();
+    await page.waitForTimeout(250);
+    const cleared = await canvas.screenshot();
+    expect(cleared.equals(hovered)).toBe(false);
+
+    await test.info().attach('highlight-baseline.png', {
+      body: baseline,
+      contentType: 'image/png',
+    });
+    await test.info().attach('highlight-hovered.png', { body: hovered, contentType: 'image/png' });
+  });
 });

--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.test.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.test.tsx
@@ -183,6 +183,9 @@ vi.mock('three', () => {
     SphereGeometry: function SphereGeometry() {
       return { dispose: vi.fn() };
     },
+    MeshBasicMaterial: function MeshBasicMaterial() {
+      return { dispose: vi.fn() };
+    },
     FrontSide: 0,
     DoubleSide: 2,
   };

--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -41,6 +41,7 @@ import {
   GhostCutouts,
   GhostWallCutouts,
   GhostHandles,
+  OverhangHighlight,
   BinSplitLines,
   SplitBinMeshes,
   type CameraPreset,
@@ -414,6 +415,9 @@ export function PreviewCanvas() {
             <GhostCutouts />
             <GhostWallCutouts />
             <GhostHandles />
+
+            {/* Overhang-section hover highlight — lights up the affected wall */}
+            <OverhangHighlight />
 
             {/* Split lines for oversized bins — hidden when pieces are shown */}
             {!showSplitPieces && <BinSplitLines />}

--- a/src/features/bin-designer/components/panel/OverhangSection/OverhangSection.test.tsx
+++ b/src/features/bin-designer/components/panel/OverhangSection/OverhangSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { OverhangSection } from './OverhangSection';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { DEFAULT_BIN_PARAMS, DEFAULT_UI_STATE } from '@/features/bin-designer/constants';
@@ -28,6 +28,32 @@ describe('OverhangSection', () => {
     });
     render(<OverhangSection />);
     expect(screen.getByText(/L3/)).toBeDefined();
+  });
+
+  it('sets and clears the hovered side on pointer enter/leave', () => {
+    render(<OverhangSection />);
+    // React derives onMouseEnter/Leave from delegated mouseover/mouseout.
+    const left = screen.getByText('Left');
+    fireEvent.mouseOver(left);
+    expect(useDesignerStore.getState().ui.hoveredOverhangSide).toBe('left');
+    fireEvent.mouseOut(left);
+    expect(useDesignerStore.getState().ui.hoveredOverhangSide).toBeNull();
+  });
+
+  it('does not target the feet region when there is no overhang', () => {
+    render(<OverhangSection />);
+    fireEvent.mouseOver(screen.getByText('Feet under overhang'));
+    // Feet toggle is disabled without overhang → hover stays null.
+    expect(useDesignerStore.getState().ui.hoveredOverhangSide).toBeNull();
+  });
+
+  it('targets the feet region when an overhang exists', () => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, overhang: { left: 0, right: 4, front: 0, back: 0 } },
+    });
+    render(<OverhangSection />);
+    fireEvent.mouseOver(screen.getByText('Feet under overhang'));
+    expect(useDesignerStore.getState().ui.hoveredOverhangSide).toBe('feet');
   });
 
   it('disables the controls for custom-shape bins', () => {

--- a/src/features/bin-designer/components/panel/OverhangSection/OverhangSection.tsx
+++ b/src/features/bin-designer/components/panel/OverhangSection/OverhangSection.tsx
@@ -38,19 +38,33 @@ export function OverhangSection() {
       <FeatureGate disabled={state.isCustomShape} reason={meta.disabledReason ?? ''}>
         <div className="space-y-3">
           {sides.map(({ side, label }) => (
-            <SliderInput
+            // Wrapper relays hover + keyboard focus to the 3D wall highlight
+            // without touching the shared SliderInput primitive (onFocus/onBlur
+            // bubble from the inner input).
+            <div
               key={side}
-              label={label}
-              value={state.overhang[side]}
-              onChange={(v) => handlers.setSide(side, v)}
-              min={DESIGNER_CONSTRAINTS.MIN_OVERHANG}
-              max={DESIGNER_CONSTRAINTS.MAX_OVERHANG}
-              step={DESIGNER_CONSTRAINTS.OVERHANG_STEP}
-              unit="mm"
-            />
+              onMouseEnter={() => handlers.setHovered(side)}
+              onMouseLeave={() => handlers.setHovered(null)}
+              onFocus={() => handlers.setHovered(side)}
+              onBlur={() => handlers.setHovered(null)}
+            >
+              <SliderInput
+                label={label}
+                value={state.overhang[side]}
+                onChange={(v) => handlers.setSide(side, v)}
+                min={DESIGNER_CONSTRAINTS.MIN_OVERHANG}
+                max={DESIGNER_CONSTRAINTS.MAX_OVERHANG}
+                step={DESIGNER_CONSTRAINTS.OVERHANG_STEP}
+                unit="mm"
+              />
+            </div>
           ))}
           <div
             className="group flex cursor-pointer items-center justify-between pt-1"
+            onMouseEnter={state.hasOverhang ? () => handlers.setHovered('feet') : undefined}
+            onMouseLeave={state.hasOverhang ? () => handlers.setHovered(null) : undefined}
+            onFocus={state.hasOverhang ? () => handlers.setHovered('feet') : undefined}
+            onBlur={state.hasOverhang ? () => handlers.setHovered(null) : undefined}
             onClick={state.hasOverhang ? handlers.toggleFeet : undefined}
             onKeyDown={(e) => {
               if (state.hasOverhang && (e.key === 'Enter' || e.key === ' ')) {

--- a/src/features/bin-designer/components/panel/OverhangSection/useOverhangSection.ts
+++ b/src/features/bin-designer/components/panel/OverhangSection/useOverhangSection.ts
@@ -10,10 +10,11 @@ const ZERO_OVERHANG: OverhangConfig = { left: 0, right: 0, front: 0, back: 0, fe
 export type OverhangSide = 'left' | 'right' | 'front' | 'back';
 
 export function useOverhangSection() {
-  const { overhang, updateOverhang, isCustomShape } = useDesignerStore(
+  const { overhang, updateOverhang, setHoveredOverhangSide, isCustomShape } = useDesignerStore(
     useShallow((s) => ({
       overhang: s.params.overhang ?? ZERO_OVERHANG,
       updateOverhang: s.updateOverhang,
+      setHoveredOverhangSide: s.setHoveredOverhangSide,
       isCustomShape: isPartialMask(s.params.cellMask),
     }))
   );
@@ -29,6 +30,13 @@ export function useOverhangSection() {
   const toggleFeet = useCallback(() => {
     updateOverhang({ feet: !(overhang.feet ?? false) });
   }, [overhang.feet, updateOverhang]);
+
+  const setHovered = useCallback(
+    (side: OverhangSide | 'feet' | null) => {
+      setHoveredOverhangSide(side);
+    },
+    [setHoveredOverhangSide]
+  );
 
   const total = overhang.left + overhang.right + overhang.front + overhang.back;
 
@@ -50,7 +58,7 @@ export function useOverhangSection() {
 
   return {
     state: { overhang, isCustomShape, feet: overhang.feet ?? false, hasOverhang: total > 0 },
-    handlers: { setSide, toggleFeet },
+    handlers: { setSide, toggleFeet, setHovered },
     meta: { summary, disabledReason },
     t,
   };

--- a/src/features/bin-designer/components/panel/OverhangSection/useOverhangSection.ts
+++ b/src/features/bin-designer/components/panel/OverhangSection/useOverhangSection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useTranslation } from '@/i18n';
@@ -37,6 +37,14 @@ export function useOverhangSection() {
     },
     [setHoveredOverhangSide]
   );
+
+  // Leave/blur handlers can't fire if the section unmounts or gets disabled
+  // (inert custom-shape) mid-hover, which would strand the preview overlay.
+  // Clear the transient highlight on unmount and whenever the section disables.
+  useEffect(() => {
+    if (isCustomShape) setHoveredOverhangSide(null);
+    return () => setHoveredOverhangSide(null);
+  }, [isCustomShape, setHoveredOverhangSide]);
 
   const total = overhang.left + overhang.right + overhang.front + overhang.back;
 

--- a/src/features/bin-designer/components/preview/OverhangHighlight/OverhangHighlight.test.tsx
+++ b/src/features/bin-designer/components/preview/OverhangHighlight/OverhangHighlight.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { DEFAULT_BIN_PARAMS, DEFAULT_UI_STATE } from '@/features/bin-designer/constants';
+import { OverhangHighlight } from './OverhangHighlight';
+
+vi.mock('@react-three/fiber', () => ({
+  useThree: () => ({ invalidate: vi.fn() }),
+}));
+
+vi.mock('three', () => ({
+  DoubleSide: 2,
+  Color: class {
+    constructor(public value?: string) {}
+  },
+  MeshBasicMaterial: class {
+    dispose = vi.fn();
+    constructor(opts: unknown) {
+      Object.assign(this, opts);
+    }
+  },
+}));
+
+describe('OverhangHighlight', () => {
+  beforeEach(() => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS },
+      ui: { ...DEFAULT_UI_STATE },
+    });
+  });
+
+  it('renders nothing when no overhang control is hovered', () => {
+    const { container } = render(<OverhangHighlight />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a single flush face box when a side is hovered at 0mm', () => {
+    useDesignerStore.setState({ ui: { ...DEFAULT_UI_STATE, hoveredOverhangSide: 'right' } });
+    const { container } = render(<OverhangHighlight />);
+    expect(container.querySelectorAll('mesh')).toHaveLength(1);
+  });
+
+  it('renders face + grown band when the hovered side has overhang', () => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, overhang: { left: 0, right: 5, front: 0, back: 0 } },
+      ui: { ...DEFAULT_UI_STATE, hoveredOverhangSide: 'right' },
+    });
+    const { container } = render(<OverhangHighlight />);
+    expect(container.querySelectorAll('mesh')).toHaveLength(2);
+  });
+
+  it('renders nothing for the feet target when there is no overhang', () => {
+    useDesignerStore.setState({ ui: { ...DEFAULT_UI_STATE, hoveredOverhangSide: 'feet' } });
+    const { container } = render(<OverhangHighlight />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the bottom ring for the feet target when overhang exists', () => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, overhang: { left: 3, right: 3, front: 0, back: 0 } },
+      ui: { ...DEFAULT_UI_STATE, hoveredOverhangSide: 'feet' },
+    });
+    const { container } = render(<OverhangHighlight />);
+    expect(container.querySelectorAll('mesh')).toHaveLength(2);
+  });
+});

--- a/src/features/bin-designer/components/preview/OverhangHighlight/OverhangHighlight.tsx
+++ b/src/features/bin-designer/components/preview/OverhangHighlight/OverhangHighlight.tsx
@@ -85,7 +85,7 @@ export function OverhangHighlight() {
     <group renderOrder={3}>
       {boxes.map((box, i) => (
         <mesh
-          key={i}
+          key={`${side}-${i}`}
           position={box.center as [number, number, number]}
           material={material}
           renderOrder={3}

--- a/src/features/bin-designer/components/preview/OverhangHighlight/OverhangHighlight.tsx
+++ b/src/features/bin-designer/components/preview/OverhangHighlight/OverhangHighlight.tsx
@@ -1,0 +1,98 @@
+/**
+ * Translucent wall highlight for the overhang section.
+ *
+ * When an overhang slider (or the feet toggle) is hovered/focused in the panel,
+ * `ui.hoveredOverhangSide` is set and this overlay lights up the matching wall —
+ * a flush face at 0mm, growing into a band as the slider increases — so the user
+ * can see which side a control affects. Mirrors the hoveredColorZone glow path.
+ */
+
+import { useEffect, useMemo } from 'react';
+import * as THREE from 'three';
+import { useThree } from '@react-three/fiber';
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
+import { computeOverhangHighlightBoxes } from './overhangHighlightGeometry';
+
+const HIGHLIGHT_COLOR = '#fbbf24';
+const HIGHLIGHT_OPACITY = 0.3;
+
+const ZERO_OVERHANG = { left: 0, right: 0, front: 0, back: 0 } as const;
+
+export function OverhangHighlight() {
+  const { invalidate } = useThree();
+
+  const { side, width, depth, height, gridUnitMm, heightUnitMm, stackingLip, baseStyle, overhang } =
+    useDesignerStore(
+      useShallow((s) => ({
+        side: s.ui.hoveredOverhangSide,
+        width: s.params.width,
+        depth: s.params.depth,
+        height: s.params.height,
+        gridUnitMm: s.params.gridUnitMm,
+        heightUnitMm: s.params.heightUnitMm,
+        stackingLip: s.params.base.stackingLip,
+        baseStyle: s.params.base.style,
+        overhang: s.params.overhang ?? ZERO_OVERHANG,
+      }))
+    );
+
+  const material = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: new THREE.Color(HIGHLIGHT_COLOR),
+        transparent: true,
+        opacity: HIGHLIGHT_OPACITY,
+        depthWrite: false,
+        side: THREE.DoubleSide,
+      }),
+    []
+  );
+
+  useEffect(() => () => material.dispose(), [material]);
+
+  const boxes = useMemo(() => {
+    if (!side) return [];
+    const outerW = width * gridUnitMm - GRIDFINITY.TOLERANCE;
+    const outerD = depth * gridUnitMm - GRIDFINITY.TOLERANCE;
+    // The overhang's flat bottom sits at the socket top (feet stay put); a flat
+    // base has no socket, so it starts at z=0. Top includes the stacking lip.
+    const wallBottomZ = baseStyle === 'flat' ? 0 : GRIDFINITY.SOCKET_HEIGHT;
+    const wallTopZ = height * heightUnitMm + (stackingLip ? GRIDFINITY.LIP_HEIGHT : 0);
+    return computeOverhangHighlightBoxes(side, {
+      outerW,
+      outerD,
+      wallBottomZ,
+      wallTopZ,
+      overhang: {
+        left: overhang.left,
+        right: overhang.right,
+        front: overhang.front,
+        back: overhang.back,
+      },
+    });
+  }, [side, width, depth, height, gridUnitMm, heightUnitMm, stackingLip, baseStyle, overhang]);
+
+  // frameloop is "demand" — nudge a render whenever the highlight changes or clears.
+  useEffect(() => {
+    invalidate();
+  }, [boxes, invalidate]);
+
+  if (!side || boxes.length === 0) return null;
+
+  return (
+    <group renderOrder={3}>
+      {boxes.map((box, i) => (
+        <mesh
+          key={i}
+          position={box.center as [number, number, number]}
+          material={material}
+          renderOrder={3}
+        >
+          <boxGeometry args={box.size as [number, number, number]} />
+        </mesh>
+      ))}
+    </group>
+  );
+}

--- a/src/features/bin-designer/components/preview/OverhangHighlight/index.ts
+++ b/src/features/bin-designer/components/preview/OverhangHighlight/index.ts
@@ -1,0 +1,1 @@
+export { OverhangHighlight } from './OverhangHighlight';

--- a/src/features/bin-designer/components/preview/OverhangHighlight/overhangHighlightGeometry.test.ts
+++ b/src/features/bin-designer/components/preview/OverhangHighlight/overhangHighlightGeometry.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { computeOverhangHighlightBoxes, type HighlightBox } from './overhangHighlightGeometry';
+
+// Wall region [5, 55] → height 50, mid 30 (socket occupies [0, 5]).
+const BASE = {
+  outerW: 100,
+  outerD: 80,
+  wallBottomZ: 5,
+  wallTopZ: 55,
+  overhang: { left: 0, right: 0, front: 0, back: 0 },
+};
+
+const allFinite = (boxes: HighlightBox[]): boolean =>
+  boxes.every((b) => [...b.center, ...b.size].every((n) => Number.isFinite(n)));
+
+describe('computeOverhangHighlightBoxes', () => {
+  it('emits a flush face sliver at the wall plane when overhang is 0', () => {
+    const boxes = computeOverhangHighlightBoxes('right', BASE);
+    expect(boxes).toHaveLength(1);
+    const [face] = boxes;
+    // Right wall lives at +X = +outerW/2; sliver centered there, spanning full depth + wall height.
+    expect(face.center[0]).toBe(50);
+    expect(face.center[1]).toBe(0);
+    expect(face.center[2]).toBe(30); // mid of [5, 55]
+    expect(face.size[1]).toBe(80);
+    expect(face.size[2]).toBe(50); // wall height, excludes the 5mm socket
+    expect(face.size[0]).toBeGreaterThan(0);
+  });
+
+  it('adds an outward grown band sized to the overhang value', () => {
+    const boxes = computeOverhangHighlightBoxes('right', {
+      ...BASE,
+      overhang: { ...BASE.overhang, right: 6 },
+    });
+    expect(boxes).toHaveLength(2);
+    const band = boxes[1];
+    // Band spans x ∈ [50, 56]: center 53, thickness 6.
+    expect(band.center[0]).toBeCloseTo(53);
+    expect(band.size[0]).toBe(6);
+    expect(band.size[1]).toBe(80);
+    expect(band.size[2]).toBe(50); // matches the wall height
+  });
+
+  it('grows the correct sign per side', () => {
+    const left = computeOverhangHighlightBoxes('left', {
+      ...BASE,
+      overhang: { ...BASE.overhang, left: 4 },
+    })[1];
+    expect(left.center[0]).toBeCloseTo(-52); // outward in -X
+
+    const front = computeOverhangHighlightBoxes('front', {
+      ...BASE,
+      overhang: { ...BASE.overhang, front: 4 },
+    })[1];
+    expect(front.center[1]).toBeCloseTo(-42); // outward in -Y (-outerD/2 - 2)
+
+    const back = computeOverhangHighlightBoxes('back', {
+      ...BASE,
+      overhang: { ...BASE.overhang, back: 4 },
+    })[1];
+    expect(back.center[1]).toBeCloseTo(42); // outward in +Y
+  });
+
+  it('spans from the socket top to the body top including the lip', () => {
+    // Wall region [5, 64.4] (e.g. lip adds height): height 59.4, mid 34.7.
+    const boxes = computeOverhangHighlightBoxes('back', { ...BASE, wallTopZ: 64.4 });
+    expect(boxes[0].center[2]).toBeCloseTo(34.7);
+    expect(boxes[0].size[2]).toBeCloseTo(59.4);
+  });
+
+  it('starts the wall at z=0 for a flat base (no socket)', () => {
+    const boxes = computeOverhangHighlightBoxes('right', {
+      ...BASE,
+      wallBottomZ: 0,
+      wallTopZ: 50,
+    });
+    expect(boxes[0].center[2]).toBe(25);
+    expect(boxes[0].size[2]).toBe(50);
+  });
+
+  describe('feet', () => {
+    it('emits nothing when there is no overhang', () => {
+      expect(computeOverhangHighlightBoxes('feet', BASE)).toHaveLength(0);
+    });
+
+    it('emits one bottom strip per overhanging side, within the socket zone', () => {
+      const boxes = computeOverhangHighlightBoxes('feet', {
+        ...BASE,
+        overhang: { left: 0, right: 5, front: 0, back: 0 },
+      });
+      expect(boxes).toHaveLength(1);
+      const [strip] = boxes;
+      expect(strip.center[0]).toBeCloseTo(52.5); // +outerW/2 + right/2
+      expect(strip.size[1]).toBe(80); // spans full nominal depth
+      expect(strip.size[2]).toBe(5); // fills the socket zone [0, 5]
+      expect(strip.center[2]).toBeCloseTo(2.5);
+    });
+
+    it('adds a corner fill where two adjacent sides overhang', () => {
+      const boxes = computeOverhangHighlightBoxes('feet', {
+        ...BASE,
+        overhang: { left: 0, right: 5, front: 0, back: 3 },
+      });
+      // right strip + back strip + one corner.
+      expect(boxes).toHaveLength(3);
+      const corner = boxes.find((b) => b.center[0] > 50 && b.center[1] > 40);
+      expect(corner).toBeDefined();
+      expect(corner?.size[0]).toBe(5);
+      expect(corner?.size[1]).toBe(3);
+    });
+  });
+
+  it('produces only finite coordinates', () => {
+    const all: HighlightBox[] = [
+      ...computeOverhangHighlightBoxes('left', {
+        ...BASE,
+        overhang: { left: 2, right: 0, front: 0, back: 0 },
+      }),
+      ...computeOverhangHighlightBoxes('feet', {
+        ...BASE,
+        overhang: { left: 2, right: 2, front: 2, back: 2 },
+      }),
+    ];
+    expect(allFinite(all)).toBe(true);
+  });
+});

--- a/src/features/bin-designer/components/preview/OverhangHighlight/overhangHighlightGeometry.ts
+++ b/src/features/bin-designer/components/preview/OverhangHighlight/overhangHighlightGeometry.ts
@@ -1,0 +1,140 @@
+/**
+ * Geometry for the overhang-section hover highlight (see OverhangHighlight).
+ *
+ * Pure box math, kept out of the R3F component so coordinate correctness is
+ * unit-testable without a WebGL context. The bin is centered at the origin in
+ * XY (matching FootprintGrid/BinMesh): `right`/`left` are ∓X walls,
+ * `back`/`front` are ∓Y walls, Z is height with z=0 at the bottom of the feet.
+ *
+ * The wall/overhang region spans `[wallBottomZ, wallTopZ]` — the flat bottom
+ * under the overhang sits at the socket top, so wall sides start above the
+ * feet, not at z=0. The feet ring lives in the socket zone `[0, wallBottomZ]`.
+ */
+
+import type { OverhangHighlightSide } from '@/features/bin-designer/types';
+
+export interface HighlightBox {
+  readonly center: readonly [number, number, number];
+  readonly size: readonly [number, number, number];
+}
+
+export interface OverhangHighlightInput {
+  /** Outer footprint width in mm (X extent), tolerance-adjusted. */
+  readonly outerW: number;
+  /** Outer footprint depth in mm (Y extent), tolerance-adjusted. */
+  readonly outerD: number;
+  /** Z of the overhang region's flat bottom (socket top; 0 for a flat base). */
+  readonly wallBottomZ: number;
+  /** Z of the body top including the stacking lip. */
+  readonly wallTopZ: number;
+  /** Per-side outward overhang in mm. */
+  readonly overhang: {
+    readonly left: number;
+    readonly right: number;
+    readonly front: number;
+    readonly back: number;
+  };
+}
+
+/** Thin sliver that marks a wall face when its overhang is 0mm. */
+const FACE_THICKNESS = 0.4;
+/** Minimum foot-ring slab height when the base is flat (no socket zone). */
+const MIN_FOOT_HEIGHT = 0.6;
+
+/**
+ * Boxes to highlight in the 3D preview for the given overhang control. Wall
+ * sides return a flush face sliver (always, so the wall is identifiable at 0mm)
+ * plus a grown band extending outward by the side's overhang. `feet` returns
+ * the bottom overhang ring affected by the feet toggle.
+ */
+export function computeOverhangHighlightBoxes(
+  side: OverhangHighlightSide,
+  { outerW, outerD, wallBottomZ, wallTopZ, overhang }: OverhangHighlightInput
+): HighlightBox[] {
+  const halfW = outerW / 2;
+  const halfD = outerD / 2;
+
+  if (side === 'feet') {
+    return footRingBoxes(halfW, halfD, wallBottomZ, overhang);
+  }
+
+  const wallH = wallTopZ - wallBottomZ;
+  const midZ = (wallBottomZ + wallTopZ) / 2;
+  const boxes: HighlightBox[] = [];
+  const value = overhang[side];
+
+  switch (side) {
+    case 'right':
+      boxes.push({ center: [halfW, 0, midZ], size: [FACE_THICKNESS, outerD, wallH] });
+      if (value > 0) {
+        boxes.push({ center: [halfW + value / 2, 0, midZ], size: [value, outerD, wallH] });
+      }
+      break;
+    case 'left':
+      boxes.push({ center: [-halfW, 0, midZ], size: [FACE_THICKNESS, outerD, wallH] });
+      if (value > 0) {
+        boxes.push({ center: [-halfW - value / 2, 0, midZ], size: [value, outerD, wallH] });
+      }
+      break;
+    case 'back':
+      boxes.push({ center: [0, halfD, midZ], size: [outerW, FACE_THICKNESS, wallH] });
+      if (value > 0) {
+        boxes.push({ center: [0, halfD + value / 2, midZ], size: [outerW, value, wallH] });
+      }
+      break;
+    case 'front':
+      boxes.push({ center: [0, -halfD, midZ], size: [outerW, FACE_THICKNESS, wallH] });
+      if (value > 0) {
+        boxes.push({ center: [0, -halfD - value / 2, midZ], size: [outerW, value, wallH] });
+      }
+      break;
+  }
+
+  return boxes;
+}
+
+/**
+ * Bottom overhang ring in the socket zone `[0, socketTopZ]`: per-side strips
+ * span the nominal perpendicular extent and corner squares fill the gaps, so
+ * adjacent overhangs never double-cover (translucent overlap would darken the
+ * seam).
+ */
+function footRingBoxes(
+  halfW: number,
+  halfD: number,
+  socketTopZ: number,
+  overhang: OverhangHighlightInput['overhang']
+): HighlightBox[] {
+  const sizeZ = Math.max(socketTopZ, MIN_FOOT_HEIGHT);
+  const z = sizeZ / 2;
+  const { left, right, front, back } = overhang;
+  const boxes: HighlightBox[] = [];
+
+  if (right > 0) {
+    boxes.push({ center: [halfW + right / 2, 0, z], size: [right, 2 * halfD, sizeZ] });
+  }
+  if (left > 0) {
+    boxes.push({ center: [-halfW - left / 2, 0, z], size: [left, 2 * halfD, sizeZ] });
+  }
+  if (back > 0) {
+    boxes.push({ center: [0, halfD + back / 2, z], size: [2 * halfW, back, sizeZ] });
+  }
+  if (front > 0) {
+    boxes.push({ center: [0, -halfD - front / 2, z], size: [2 * halfW, front, sizeZ] });
+  }
+
+  if (right > 0 && back > 0) {
+    boxes.push({ center: [halfW + right / 2, halfD + back / 2, z], size: [right, back, sizeZ] });
+  }
+  if (left > 0 && back > 0) {
+    boxes.push({ center: [-halfW - left / 2, halfD + back / 2, z], size: [left, back, sizeZ] });
+  }
+  if (right > 0 && front > 0) {
+    boxes.push({ center: [halfW + right / 2, -halfD - front / 2, z], size: [right, front, sizeZ] });
+  }
+  if (left > 0 && front > 0) {
+    boxes.push({ center: [-halfW - left / 2, -halfD - front / 2, z], size: [left, front, sizeZ] });
+  }
+
+  return boxes;
+}

--- a/src/features/bin-designer/components/preview/OverhangHighlight/overhangHighlightGeometry.ts
+++ b/src/features/bin-designer/components/preview/OverhangHighlight/overhangHighlightGeometry.ts
@@ -3,8 +3,8 @@
  *
  * Pure box math, kept out of the R3F component so coordinate correctness is
  * unit-testable without a WebGL context. The bin is centered at the origin in
- * XY (matching FootprintGrid/BinMesh): `right`/`left` are ∓X walls,
- * `back`/`front` are ∓Y walls, Z is height with z=0 at the bottom of the feet.
+ * XY (matching FootprintGrid/BinMesh): `left`/`right` are −X/+X walls,
+ * `front`/`back` are −Y/+Y walls, Z is height with z=0 at the bottom of the feet.
  *
  * The wall/overhang region spans `[wallBottomZ, wallTopZ]` — the flat bottom
  * under the overhang sits at the socket top, so wall sides start above the

--- a/src/features/bin-designer/components/preview/index.ts
+++ b/src/features/bin-designer/components/preview/index.ts
@@ -25,5 +25,6 @@ export { GhostDividerPieces } from './GhostDividerPieces/GhostDividerPieces';
 export { GhostCutouts } from './GhostCutouts';
 export { GhostWallCutouts } from './GhostWallCutouts';
 export { GhostHandles } from './GhostHandles';
+export { OverhangHighlight } from './OverhangHighlight';
 export { BinSplitLines } from './BinSplitLines';
 export { SplitBinMeshes } from './SplitBinMeshes/SplitBinMeshes';

--- a/src/features/bin-designer/constants/defaults.ts
+++ b/src/features/bin-designer/constants/defaults.ts
@@ -346,6 +346,7 @@ export const DEFAULT_UI_STATE: DesignerUIState = {
   splitViewMode: 'exploded',
   splitPieceMeshes: [],
   hoveredColorZone: null,
+  hoveredOverhangSide: null,
   colorTool: null,
   swapFirstZone: null,
   pickerOverlay: null,

--- a/src/features/bin-designer/store/slices/uiSlice.ts
+++ b/src/features/bin-designer/store/slices/uiSlice.ts
@@ -12,6 +12,7 @@ import type {
   SplitViewMode,
   SplitPieceMeshEntry,
   DividerTiltPreview,
+  OverhangHighlightSide,
 } from '../../types';
 import type { ColorZone, HoverableZone, LipCorner } from '../../types/featureColors';
 import { LIP_CORNERS, lipCornerZone } from '../../types/featureColors';
@@ -87,6 +88,12 @@ export function createUISlice(set: Set) {
     setHoveredColorZone: (zone: HoverableZone | null) => {
       set((state) => {
         state.ui.hoveredColorZone = zone;
+      });
+    },
+
+    setHoveredOverhangSide: (side: OverhangHighlightSide | null) => {
+      set((state) => {
+        state.ui.hoveredOverhangSide = side;
       });
     },
 

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -410,6 +410,9 @@ export interface OverhangConfig {
   readonly feet?: boolean;
 }
 
+/** Overhang-section hover-highlight target: a wall side or the bottom feet ring. */
+export type OverhangHighlightSide = 'left' | 'right' | 'front' | 'back' | 'feet';
+
 // Wall Pattern Types
 
 /** Supported wall pattern types. Extensible via pattern registry. */
@@ -797,6 +800,8 @@ export interface DesignerUIState {
   readonly splitPieceMeshes: readonly SplitPieceMeshEntry[];
   /** Currently hovered color zone in the panel (for 3D preview glow feedback) */
   readonly hoveredColorZone: HoverableZone | null;
+  /** Overhang control hovered/focused in the panel → 3D wall highlight. Transient. */
+  readonly hoveredOverhangSide: OverhangHighlightSide | null;
   /**
    * Active color tool overlay. `'eyedropper'` lets the user click a zone in
    * the 3D preview to recolor it; `'swap-pick-first'` and `'swap-pick-second'`
@@ -1047,6 +1052,7 @@ export interface DesignerState {
   setSplitViewMode: (mode: SplitViewMode) => void;
   setSplitPieceMeshes: (meshes: readonly SplitPieceMeshEntry[]) => void;
   setHoveredColorZone: (zone: HoverableZone | null) => void;
+  setHoveredOverhangSide: (side: OverhangHighlightSide | null) => void;
   setSelectedDividerKey: (key: string | null) => void;
   setHoveredDividerKey: (key: string | null) => void;
   setDividerTiltPreview: (preview: DividerTiltPreview | null) => void;


### PR DESCRIPTION
## What

Hovering — or keyboard-focusing — an **Overhang** slider in the bin designer now lights up the matching wall in the 3D preview, so it's immediately clear which side each control affects. The highlight is a translucent amber overlay that's flush against the wall at 0 mm and grows outward into a band as the slider increases. Hovering the **Feet under overhang** toggle instead highlights the bottom overhang ring those feet would fill.

Addresses the follow-up request on #1641:

> can you make it so when I hover over a slider it highlights which wall in the model it will extend? … I sometimes get turned around.

## Behavior

- **Triggers:** mouse hover, keyboard focus, and while actively dragging a slider.
- **Always visible:** the wall lights up even at 0 mm (it's an orientation aid), then previews the grown region as the value rises.
- **Vertical extent:** spans the wall + stacking lip, starting at the flat bottom under the overhang (the socket top) rather than down through the feet — matching what overhang actually grows.
- Suppressed for custom-shape bins, where overhang is already disabled.

## Implementation

- Mirrors the existing `hoveredColorZone` glow plumbing: a transient `ui.hoveredOverhangSide` value drives a new `OverhangHighlight` preview component mounted in `PreviewCanvas`.
- Slider rows relay hover/focus via a thin wrapper, leaving the shared `SliderInput` primitive untouched.
- Box geometry lives in a pure, unit-tested helper (coordinate signs, growth direction, full-height span, and the feet ring with corner fills).

## Testing

- Unit: geometry helper, `OverhangHighlight` component, and `OverhangSection` hover wiring.
- Visual: extended `overhang-visual.spec.ts` with a hover-highlight check (passes on Chromium with software WebGL) and spot-checked the rendered overlay for each control.