### PR TITLE
fix: preserve overhang when splitting an oversized bin

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.split-overhang.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-overhang.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+/**
+ * Scenario tests for splitting a bin that has an overhang.
+ *
+ * Regression test for #1949: when a bin with an overhang is also large enough
+ * to need splitting for the print bed, the boolean cut clipped the overhang off
+ * (the cutting bounds were derived from the nominal grid footprint, ignoring the
+ * outward overhang expansion). The overhang must survive the split.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DEFAULT_BIN_PARAMS, GRIDFINITY } from '@/shared/constants/bin';
+import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
+import type { BinParams, SplitConnectorConfig } from '@/shared/types/bin';
+import { initBrepjs, getGenerateSplitPreview } from './__kernel-tests__/wasmInit';
+import { boundingBox, hasNoNaNOrInfinity } from './__kernel-tests__/meshAssertions';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+const SIZE = GRIDFINITY.GRID_SIZE;
+const CLEARANCE = GRIDFINITY.TOLERANCE;
+const OVERHANG_MM = 18;
+/** Tessellation + boolean edge tolerance band. */
+const XY_MARGIN = 1.5;
+
+const DISABLED_CONFIG: SplitConnectorConfig = { ...DEFAULT_SPLIT_CONNECTOR_CONFIG, enabled: false };
+
+/** Largest per-piece width (X extent) across the split result, in mm. */
+function widestPiece(vertsList: Float32Array[]): number {
+  let max = 0;
+  for (const v of vertsList) {
+    expect(hasNoNaNOrInfinity(v)).toBe(true);
+    const bb = boundingBox(v);
+    max = Math.max(max, bb.maxX - bb.minX);
+  }
+  return max;
+}
+
+describe('split preserves overhang (#1949)', () => {
+  it('keeps a right-side overhang when splitting along the same (X) axis', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 10,
+      depth: 2,
+      height: 3,
+      overhang: { left: 0, right: OVERHANG_MM, front: 0, back: 0 },
+    };
+    const generateSplitPreview = getGenerateSplitPreview();
+    // Cut at x=0 → two pieces along X.
+    const result = generateSplitPreview(params, [0], [], DISABLED_CONFIG);
+
+    expect(result.pieces).toHaveLength(2);
+
+    const halfW = (params.width * SIZE - CLEARANCE) / 2;
+    // The right piece spans [0, halfW + overhang]; without the fix it is
+    // clipped at halfW. Its width must include the overhang.
+    const widest = widestPiece(result.pieces.map((p) => p.vertices));
+    expect(widest).toBeGreaterThan(halfW + OVERHANG_MM - XY_MARGIN);
+  }, 90000);
+
+  it('keeps a side overhang when splitting along the perpendicular (Y) axis (#1949 repro)', () => {
+    // 1×7 bin with an 18mm overhang on one side, split across its depth — the
+    // exact reported case. Every depth piece must retain the full X overhang.
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 1,
+      depth: 7,
+      height: 3,
+      overhang: { left: 0, right: OVERHANG_MM, front: 0, back: 0 },
+    };
+    const generateSplitPreview = getGenerateSplitPreview();
+    // Cut at y=0 → two pieces along Y; neither split plane touches the X overhang.
+    const result = generateSplitPreview(params, [], [0], DISABLED_CONFIG);
+
+    expect(result.pieces).toHaveLength(2);
+
+    const outerW = params.width * SIZE - CLEARANCE;
+    for (const piece of result.pieces) {
+      const bb = boundingBox(piece.vertices);
+      const pieceW = bb.maxX - bb.minX;
+      expect(
+        pieceW,
+        `piece ${piece.label} width ${pieceW.toFixed(1)}mm lost the overhang`
+      ).toBeGreaterThan(outerW + OVERHANG_MM - XY_MARGIN);
+    }
+  }, 90000);
+});

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -32,6 +32,8 @@ import type { BinGeometryContext } from './splitConnectorBuilder';
 import { buildLipSlotCuts } from './slotBuilder';
 import { buildWallCutoutCuts } from './wallCutoutBuilder';
 import { isAbortError } from './utils/abort';
+import { resolveOverhang } from './overhang';
+import { isPartialMask } from '@/shared/utils/cellMask';
 
 /** Result of a split export: array of piece buffers with grid labels */
 export interface SplitExportResult {
@@ -268,9 +270,16 @@ function splitSolidIntoPieces(
   const adjustedCutPlanesX = shiftCutPlanesOffCellBoundaries(cutPlanesX, params.width, gridUnitMm);
   const adjustedCutPlanesY = shiftCutPlanesOffCellBoundaries(cutPlanesY, params.depth, gridUnitMm);
 
+  // An overhang grows the outer body past the nominal grid footprint (the base
+  // sockets stay put). The body spans [-outerW/2 - left, outerW/2 + right] and
+  // [-outerD/2 - front, outerD/2 + back]; the outermost cutting boxes must reach
+  // those edges or the boolean intersect clips the overhang off (#1949).
+  // Suppressed for partial masks, matching the geometry pipeline.
+  const overhang = resolveOverhang(isPartialMask(params.cellMask) ? undefined : params.overhang);
+
   // Boundary arrays: [left edge, ...cut planes, right edge]
-  const xBounds = [-outerW / 2, ...adjustedCutPlanesX, outerW / 2];
-  const yBounds = [-outerD / 2, ...adjustedCutPlanesY, outerD / 2];
+  const xBounds = [-outerW / 2 - overhang.left, ...adjustedCutPlanesX, outerW / 2 + overhang.right];
+  const yBounds = [-outerD / 2 - overhang.front, ...adjustedCutPlanesY, outerD / 2 + overhang.back];
 
   // Outer edges of the cutting box are expanded by this margin to avoid
   // coplanar faces with bin geometry, which cause OCCT booleans to


### PR DESCRIPTION
## Summary

Fixes #1949 — a bin with an overhang loses the overhang when it's also large enough to need splitting for the print bed. When no split is needed, the overhang is fine.

## Root cause

`splitSolidIntoPieces` derived the cutting bounds from the **nominal grid footprint** only:

```ts
const outerW = params.width * gridUnitMm - CLEARANCE; // ignores overhang
const xBounds = [-outerW / 2, ...cutPlanesX, outerW / 2];
```

An overhang grows the outer body past that footprint — the body actually spans `[-outerW/2 - left, outerW/2 + right]` (and `front`/`back` in Y), while the base sockets stay at the nominal footprint. The outermost cutting box only reached `±outerW/2 + 1mm`, so the boolean `intersect` that carves each piece **clipped the overhang off**. It only manifested when a split occurred, exactly matching the report.

## Fix

Extend the outermost cutting bounds by the resolved per-side overhang so the cutting boxes reach the real body edges:

```ts
const overhang = resolveOverhang(isPartialMask(params.cellMask) ? undefined : params.overhang);
const xBounds = [-outerW / 2 - overhang.left, ...cutPlanesX, outerW / 2 + overhang.right];
const yBounds = [-outerD / 2 - overhang.front, ...cutPlanesY, outerD / 2 + overhang.back];
```

This mirrors the geometry pipeline's own overhang resolution (including the partial-mask suppression). When there's no overhang, `resolveOverhang` returns all-zero and the bounds are unchanged — no behavior change for existing bins.

## Testing

- New regression scenario `binGenerator.scenario.split-overhang.test.ts` (real OCCT kernel), including the exact reported 1×7 + 18mm-overhang case split across its depth. Both cases **failed before** the fix (piece widths came back at the nominal footprint) and pass after.
- Re-ran the split + overhang/fractional-feet scenario suite (8 files, 78 tests) — all pass, no regression.
- `typecheck` clean; `lint` 0 errors.