### PR TITLE
fix(print-export): color the lid by extruder so BambuStudio renders it

### DIFF
--- a/src/features/bin-designer/utils/binDownloadHelpers.test.ts
+++ b/src/features/bin-designer/utils/binDownloadHelpers.test.ts
@@ -143,6 +143,28 @@ describe('binDownloadHelpers — multi-color export gate', () => {
       // multi-color print actually swaps filaments between body and lid.
       expect(objects[1].colorConfig).toBeDefined();
     });
+
+    // discussion #1654: a distinct lid color must resolve to a non-body slot,
+    // otherwise the lid silently exports body-colored. The earlier test only
+    // checked the lid had *a* config, not that it referenced the lid filament.
+    it('lid resolves to a distinct (non-body) material slot when its color diverges', () => {
+      const params: BinParams = {
+        ...paramsWithMultiColor(true),
+        lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true },
+        base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+        featureColors: {
+          ...paramsWithMultiColor(true).featureColors,
+          lid: '#ff0000', // distinct from body (#3b82f6)
+        },
+      };
+      buildMultiObject3MF(pieces, FAKE_FACE_GROUPS, params, 'assembly', PRINT_SETTINGS);
+      const objects = export3MFMultiObjectSpy.mock.calls[0][0] as Array<{
+        colorConfig?: { triangleMaterialIndices: readonly number[] };
+      }>;
+      const lidSlots = objects[1].colorConfig?.triangleMaterialIndices ?? [];
+      expect(lidSlots.length).toBeGreaterThan(0);
+      expect(lidSlots.every((s) => s !== 0)).toBe(true);
+    });
   });
 });
 

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -739,6 +739,50 @@ describe('threemfExporter', () => {
       expect(unzipSync(buffer)['Metadata/project_settings.config']).toBeUndefined();
     });
 
+    // discussion #1654: a uniform-color secondary object (the lid) ships every
+    // triangle with one paint_color code, but BambuStudio colors a whole
+    // object by its assigned extruder — with none assigned it defaults to
+    // extruder 1 (body), so the lid renders body-colored despite correct
+    // paint_color. Emitting model_settings.config with each object's dominant
+    // slot as its base extruder lets BBS color uniform objects natively.
+    it('multi-object: assigns per-object base extruder in model_settings.config', () => {
+      const tri = createSingleTriangle();
+      const shared = [{ color: '#d4d8dc' }, { color: '#ff0000' }];
+      const objects = [
+        {
+          vertices: tri.vertices,
+          normals: tri.normals,
+          name: 'Bin 2x2x3',
+          colorConfig: { materials: shared, triangleMaterialIndices: [0] },
+        },
+        {
+          vertices: tri.vertices,
+          normals: tri.normals,
+          name: 'Lid 2x2x3',
+          colorConfig: { materials: shared, triangleMaterialIndices: [1] },
+        },
+      ];
+      const files = unzipSync(build3MFMultiObjectBuffer(objects, { name: 'multi' }));
+      const cfg = files['Metadata/model_settings.config'];
+      expect(cfg).toBeDefined();
+      const xml = strFromU8(cfg);
+      // Bin (object 1) → body extruder 1; Lid (object 2) → its filament (slot 1 → extruder 2).
+      expect(xml).toMatch(/<object id="1">[\s\S]*?key="extruder" value="1"[\s\S]*?<\/object>/);
+      expect(xml).toMatch(/<object id="2">[\s\S]*?key="extruder" value="2"[\s\S]*?<\/object>/);
+    });
+
+    it('multi-object: omits model_settings.config when no object has a colorConfig', () => {
+      const tri = createSingleTriangle();
+      const buffer = build3MFMultiObjectBuffer(
+        [
+          { vertices: tri.vertices, normals: tri.normals, name: 'a' },
+          { vertices: tri.vertices, normals: tri.normals, name: 'b' },
+        ],
+        { name: 'multi-plain' }
+      );
+      expect(unzipSync(buffer)['Metadata/model_settings.config']).toBeUndefined();
+    });
+
     // BambuStudio gates `Metadata/project_settings.config` loading on the
     // `Application` metadata starting with "BambuStudio-X.Y.Z"
     // (bbs_3mf.cpp:1898-1908). Claim a version Orca won't reject so both

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -68,7 +68,8 @@ export function export3MFMultiObject(
 function packageFiles(
   modelXml: string,
   thumbnail: Uint8Array | undefined,
-  projectSettingsJson: string | undefined
+  projectSettingsJson: string | undefined,
+  modelSettingsXml?: string
 ): Uint8Array {
   const hasThumbnail = !!thumbnail;
   const files: Record<string, Uint8Array> = {
@@ -78,6 +79,13 @@ function packageFiles(
   };
   if (thumbnail) {
     files['Metadata/thumbnail.png'] = thumbnail;
+  }
+  if (modelSettingsXml) {
+    // BambuStudio/OrcaSlicer read per-object settings (including the base
+    // `extruder` assignment) from this sidecar. It's what colors a whole
+    // uniform secondary object — the lid — by filament; `paint_color` alone
+    // leaves it on the default extruder (body). See `buildModelSettingsConfig`.
+    files['Metadata/model_settings.config'] = strToU8(modelSettingsXml);
   }
   if (projectSettingsJson) {
     // Both OrcaSlicer and BambuStudio read this via
@@ -110,7 +118,8 @@ export function build3MFMultiObjectBuffer(
   return packageFiles(
     buildMultiObjectModelXML(meshes, options),
     options.thumbnail,
-    palette && buildProjectSettingsConfig(palette)
+    palette && buildProjectSettingsConfig(palette),
+    buildModelSettingsConfig(meshes)
   );
 }
 
@@ -459,6 +468,63 @@ function buildMultiObjectModelXML(
   xml += '  </build>\n';
   xml += '</model>';
   return xml;
+}
+
+/**
+ * Most frequent material slot across a triangle→slot list. For a uniform
+ * object (lid, divider) that's its single slot; for the multi-zone bin it's
+ * the body, which is the right base extruder since per-triangle `paint_color`
+ * overrides the rest. Ties resolve to the lower slot index, so a bin with no
+ * dominant zone falls back to body (slot 0) rather than an arbitrary feature.
+ */
+function dominantSlot(triangleMaterialIndices: readonly number[]): number {
+  const counts = new Map<number, number>();
+  for (const slot of triangleMaterialIndices) {
+    counts.set(slot, (counts.get(slot) ?? 0) + 1);
+  }
+  let best = 0;
+  let bestCount = -1;
+  for (const [slot, n] of counts) {
+    if (n > bestCount || (n === bestCount && slot < best)) {
+      bestCount = n;
+      best = slot;
+    }
+  }
+  return best;
+}
+
+/**
+ * Per-object settings sidecar (`Metadata/model_settings.config`) assigning
+ * each colored object its base `extruder` = dominant slot + 1 (slicers are
+ * 1-based, matching the `paint_color` slot→filament mapping). BambuStudio and
+ * OrcaSlicer color a whole object by this extruder; without it every object
+ * defaults to extruder 1 (body), so a uniform secondary object like the lid
+ * renders body-colored even though its triangles carry the correct
+ * `paint_color` (discussion #1654). Purely additive — slicers that ignore the
+ * sidecar fall back to today's paint_color-only behavior, so it can't regress
+ * the already-working multi-zone bin.
+ *
+ * Returns undefined when no object carries colors (single-color assemblies
+ * need no extruder overrides).
+ */
+function buildModelSettingsConfig(
+  meshes: readonly { name: string; colorConfig?: ThreeMFColorConfig }[]
+): string | undefined {
+  const entries: string[] = [];
+  meshes.forEach((m, i) => {
+    const colorConfig = activeColorConfig(m.colorConfig);
+    if (!colorConfig) return;
+    const extruder = dominantSlot(colorConfig.triangleMaterialIndices) + 1;
+    const objectId = i + 1;
+    entries.push(
+      `  <object id="${objectId}">\n` +
+        `    <metadata key="name" value="${escapeXml(m.name)}"/>\n` +
+        `    <metadata key="extruder" value="${extruder}"/>\n` +
+        `  </object>\n`
+    );
+  });
+  if (entries.length === 0) return undefined;
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<config>\n${entries.join('')}</config>\n`;
 }
 
 function mergeBBoxes(boxes: readonly (BBox | null)[]): BBox | null {


### PR DESCRIPTION
Addresses the "Lid isn't getting colour" report from discussion #1654.

## Root cause
The multi-color 3MF assigned color **only** via per-triangle `paint_color`. BambuStudio colors a whole object by its **assigned extruder**, and with none assigned every object defaults to extruder 1 (body). A uniform secondary object like the lid therefore renders body-colored even though its triangles carry the correct `paint_color`.

Verified the export data itself is correct — the lid object's triangles are all painted with the lid's distinct filament and the lid color is present in the palette:

```
OBJECT "Lid": paint codes [0C]   (filament 3)
filament_colour: ["#d4d8dc", "#22c55e", "#ff0000"]
```

So this is a slicer-interpretation gap, not a data bug.

## Fix
Emit `Metadata/model_settings.config` assigning each colored object its base `extruder` = dominant material slot + 1 (bin → body, lid/dividers → their own filament). BambuStudio/OrcaSlicer then color uniform objects natively.

The sidecar is **purely additive**: slicers that ignore it keep today's `paint_color`-only behavior, so the already-working multi-zone bin cannot regress. Ties in the dominant-slot calc resolve to the lower slot (body), so a bin with no dominant zone still bases on body.

## Tests
- New: `model_settings.config` assigns per-object base extruder (bin→1, lid→2); omitted when no object is colored.
- Closes a gap in the existing lid test, which checked the lid had *a* color config but not that a distinct lid color resolves to a non-body slot.

## Needs slicer verification
The extruder-assignment behavior can only be fully confirmed in BambuStudio. Exported-file structure and all unit tests pass; a real multi-color bin+lid export should now show the lid in its own color in BBS.