### PR TITLE
fix(bin-designer): allow fractional magnet depth input

### DIFF
--- a/src/features/bin-designer/constants/defaults.test.ts
+++ b/src/features/bin-designer/constants/defaults.test.ts
@@ -767,3 +767,29 @@ describe('GRIDFINITY constants', () => {
     expect(GRIDFINITY.MAGNET_DEPTH).toBeGreaterThan(0);
   });
 });
+
+describe('DESIGNER_CONSTRAINTS magnet depth step', () => {
+  it('MAGNET_HEIGHT_STEP is 0.1mm to allow fractional input', () => {
+    expect(DESIGNER_CONSTRAINTS.MAGNET_HEIGHT_STEP).toBe(0.1);
+  });
+
+  it('validateBinParams rejects magnetDepth not on 0.1mm grid', () => {
+    const params = {
+      ...DEFAULT_BIN_PARAMS,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet' as const, magnetDepth: 2.25 },
+    };
+    const result = validateBinParams(params);
+    expect(result).toMatchObject({ ok: false });
+    if (!result.ok) {
+      expect(result.error.code).toBe('MAGNET_HEIGHT_INVALID_STEP');
+    }
+  });
+
+  it('validateBinParams accepts fractional magnetDepth on 0.1mm grid', () => {
+    const params = {
+      ...DEFAULT_BIN_PARAMS,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet' as const, magnetDepth: 2.3 },
+    };
+    expectOk(validateBinParams(params));
+  });
+});

--- a/src/features/bin-designer/constants/gridfinity.ts
+++ b/src/features/bin-designer/constants/gridfinity.ts
@@ -73,7 +73,7 @@ export const DESIGNER_CONSTRAINTS = {
   MAGNET_DIAMETER_STEP: 0.1, // mm
   MIN_MAGNET_HEIGHT: 1.0, // mm
   MAX_MAGNET_HEIGHT: 4.0, // mm
-  MAGNET_HEIGHT_STEP: 0.5, // mm
+  MAGNET_HEIGHT_STEP: 0.1, // mm
   // Screw holes (diameter in UI and store)
   MIN_SCREW_DIAMETER: 2.0, // mm
   MAX_SCREW_DIAMETER: 6.0, // mm

--- a/src/features/bin-designer/utils/validation.ts
+++ b/src/features/bin-designer/utils/validation.ts
@@ -126,6 +126,13 @@ export function validateBinParams(params: BinParams): Result<BinParams, Designer
         field: 'base.magnetDepth',
       });
     }
+    if (!isValidStep(params.base.magnetDepth, DESIGNER_CONSTRAINTS.MAGNET_HEIGHT_STEP)) {
+      return err({
+        code: 'MAGNET_HEIGHT_INVALID_STEP',
+        message: `Magnet depth must be in ${DESIGNER_CONSTRAINTS.MAGNET_HEIGHT_STEP}mm increments`,
+        field: 'base.magnetDepth',
+      });
+    }
   }
 
   // Screw dimension check (only when screw is enabled)


### PR DESCRIPTION
## Summary

- Users typing a fractional magnet depth (e.g. `2.3mm`) in the bin designer had their value silently snapped to the nearest 0.5mm step, making it impossible to set values like `2.1` or `2.7`
- Root cause: `MAGNET_HEIGHT_STEP` was `0.5mm` — the `SliderInput` uses this constant to snap typed values on commit
- Fixed by changing the step to `0.1mm`, matching the magnet diameter step and the baseplate panel's existing behaviour

## Changes

- `gridfinity.ts`: `MAGNET_HEIGHT_STEP` `0.5` → `0.1`
- `validation.ts`: adds `isValidStep` check for `magnetDepth` (consistent with width/depth validation)
- `defaults.test.ts`: pins the step value and asserts fractional depth accepts/rejects correctly