### PR TITLE
ci(release): retry enabling auto-merge to absorb startup race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,10 @@ jobs:
               echo "Auto-merge enabled on attempt $attempt."
               exit 0
             fi
-            echo "Attempt $attempt failed to enable auto-merge; retrying in 10s..."
-            sleep 10
+            if [ "$attempt" -lt 6 ]; then
+              echo "Attempt $attempt failed to enable auto-merge; retrying in 10s..."
+              sleep 10
+            fi
           done
           echo "::error::Failed to enable auto-merge on PR #$PR_NUMBER after 6 attempts."
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,19 @@ jobs:
         if: steps.release.outputs.pr
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
+        # `gh pr merge --auto` enables auto-merge, but GitHub rejects the call
+        # (`Pull request is in unstable status`) in the brief window before the PR's
+        # required checks register. Retry until they settle so the release isn't
+        # left un-merged by a startup race.
         run: |
-          gh pr merge ${{ fromJSON(steps.release.outputs.pr).number }} \
-            --auto --squash --repo ${{ github.repository }}
+          for attempt in $(seq 1 6); do
+            if gh pr merge "$PR_NUMBER" --auto --squash --repo "$GITHUB_REPOSITORY"; then
+              echo "Auto-merge enabled on attempt $attempt."
+              exit 0
+            fi
+            echo "Attempt $attempt failed to enable auto-merge; retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Failed to enable auto-merge on PR #$PR_NUMBER after 6 attempts."
+          exit 1


### PR DESCRIPTION
## What

Wrap the **Auto-merge Release PR** step's `gh pr merge --auto` call in a bounded retry loop (6 attempts, 10s apart).

## Why

release-please opens the release PR and immediately tries to enable auto-merge. GitHub rejects `enablePullRequestAutoMerge` with `Pull request is in unstable status` during the brief window before the new PR's required checks register. The single-shot call lost that race on #1958 → #1959: the release PR was created and approved but **left un-merged**, and the Release workflow went red on `main` even though all real checks (CI, CodeQL, OSV, smoke) passed.

## How

- Retry the enable until checks settle; succeed on the first attempt that sticks.
- Still **fail the step** if all 6 attempts are exhausted, so a genuinely stuck PR surfaces instead of being silently swallowed.
- Pass the PR number and repo via `env`/built-in `$GITHUB_REPOSITORY` instead of `${{ }}` interpolation in the run body (also removes a minor script-injection surface).

## Verification

- YAML parses; embedded script passes `bash -n`.
- Behavior is a no-op on the happy path (first attempt succeeds → `exit 0`); the loop only engages when the race recurs.