### PR TITLE
ci(release): guard fromJSON against empty release-please output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,9 @@ jobs:
         if: steps.release.outputs.pr
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
+          # Guard fromJSON: when no release PR is created the output is empty and
+          # fromJSON('') errors at template-eval time even though `if:` skips the step.
+          PR_NUMBER: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).number }}
         # `gh pr merge --auto` enables auto-merge, but GitHub rejects the call
         # (`Pull request is in unstable status`) in the brief window before the PR's
         # required checks register. Retry until they settle so the release isn't


### PR DESCRIPTION
## What

Short-circuit-guard the `PR_NUMBER` env expression so `fromJSON` is only called when release-please actually produced a release PR.

## Why (regression from #1960)

#1960 moved the PR number into an `env:` var for injection hygiene. That has a side effect: `env:` expressions are evaluated at template-eval time, **before** the step's `if:` gate skips it. On any push that produces **no release PR** (e.g. a `ci:` commit that triggers no version bump), `steps.release.outputs.pr` is empty and `fromJSON('')` throws:

```
The template is not valid. release.yml (Line: 45): Error reading JToken from JsonReader.
```

This failed the Release workflow on the merge commit of #1960 itself (run 26725513177) and would fail on every non-release push. The original code dodged this because the `fromJSON` lived in the lazily-evaluated `run:` block.

## Fix

```yaml
PR_NUMBER: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).number }}
```

The `&&` short-circuits on the empty output, so `fromJSON` is never reached when there's no PR. The retry-loop hardening from #1960 is unchanged.

## Verification

- YAML parses; the no-PR path now yields an empty `PR_NUMBER` instead of erroring, and the step stays gated by `if: steps.release.outputs.pr`.