### PR TITLE
feat(baseplate): make padding alignment control self-explanatory

### DIFF
--- a/src/features/baseplate/README.md
+++ b/src/features/baseplate/README.md
@@ -41,6 +41,7 @@ graph TB
 - **Epoch detection**: rapid param changes bump an epoch counter; stale in-flight results (direct or BREP) are discarded
 - **Ephemeral store**: `baseplatePageStore` resets on unmount; persistent params live in layout store
 - **`preferIdenticalPieces` (opt-in, gated behind `connectorNubs`)**: palindromic chunk sizes + doubled (M+F) dovetail connectors + canonical-edge fingerprinting let opposite-corner pieces share one generated mesh. Each placement gets a `placementRotationDeg` (0 or 180); the 3D preview rotates the canonical mesh around the piece center and the print guide annotates rotated positions with "(rotate 180°)"
+- **Padding anchor pad**: `PaddingSchematic` frames four mm steppers around a central `PaddingAnchor` 3×3 pad. Each outer cell is a directional arrow (a single `ArrowLeftIcon` rotated in 45° steps via `ARROW_ROTATION`) pointing at the drawer corner/edge it anchors to; the center cell is a target glyph. Picking a cell redistributes total padding through `computeAnchoredPaddings`; editing any stepper flips the anchor to `custom`, surfaced as a caption
 
 ## Gotchas
 

--- a/src/features/baseplate/components/BaseplatePanel/PaddingSchematic.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/PaddingSchematic.test.tsx
@@ -169,6 +169,26 @@ describe('PaddingSchematic', () => {
     expect(screen.queryByLabelText('baseplate.paddingAnchor.clampedWarning')).toBeNull();
   });
 
+  it('shows the "Custom" caption only when the anchor is custom', () => {
+    const { rerender } = render(
+      <PaddingSchematic
+        baseplateParams={{ ...DEFAULT_BASEPLATE_PARAMS, paddingAnchor: 'custom' }}
+        updateParam={vi.fn()}
+        updateParams={vi.fn()}
+      />
+    );
+    expect(screen.getByText('baseplate.paddingAnchor.custom')).toBeInTheDocument();
+
+    rerender(
+      <PaddingSchematic
+        baseplateParams={{ ...DEFAULT_BASEPLATE_PARAMS, paddingAnchor: 'tl' }}
+        updateParam={vi.fn()}
+        updateParams={vi.fn()}
+      />
+    );
+    expect(screen.queryByText('baseplate.paddingAnchor.custom')).toBeNull();
+  });
+
   it('does not touch paddingAnchor when already custom (uses single-key update)', () => {
     const updateParam = vi.fn();
     const updateParams = vi.fn();

--- a/src/features/baseplate/components/BaseplatePanel/PaddingSchematic.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/PaddingSchematic.tsx
@@ -76,12 +76,20 @@ export function PaddingSchematic({
           value={baseplateParams.paddingLeft}
           onChange={(v) => handlePaddingChange('paddingLeft', v)}
         />
-        <div className="flex-1 min-h-16 rounded border border-dashed border-stroke-subtle bg-surface-secondary/50">
-          <PaddingAnchor
-            value={anchor}
-            onChange={handleAnchorChange}
-            showClampWarning={showClampWarning}
-          />
+        <div className="flex min-h-16 flex-1 flex-col rounded-md border border-stroke-subtle bg-surface-secondary/50">
+          <div className="flex-1">
+            <PaddingAnchor
+              value={anchor}
+              onChange={handleAnchorChange}
+              showClampWarning={showClampWarning}
+            />
+          </div>
+          <div
+            aria-live="polite"
+            className="flex h-4 items-center justify-center text-[10px] leading-none text-content-tertiary"
+          >
+            {anchor === 'custom' ? t('baseplate.paddingAnchor.custom') : ''}
+          </div>
         </div>
         <PaddingStepper
           orientation="vertical"

--- a/src/features/baseplate/components/BaseplatePanel/PaddingSchematic.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/PaddingSchematic.tsx
@@ -85,10 +85,14 @@ export function PaddingSchematic({
             />
           </div>
           <div
+            role="status"
             aria-live="polite"
+            aria-atomic
             className="flex h-4 items-center justify-center text-[10px] leading-none text-content-tertiary"
           >
-            {anchor === 'custom' ? t('baseplate.paddingAnchor.custom') : ''}
+            {/* Non-breaking space (not '') keeps the row height without making the
+                live region announce a blank update when the anchor leaves custom. */}
+            {anchor === 'custom' ? t('baseplate.paddingAnchor.custom') : ' '}
           </div>
         </div>
         <PaddingStepper

--- a/src/features/baseplate/components/PaddingAnchor/PaddingAnchor.test.tsx
+++ b/src/features/baseplate/components/PaddingAnchor/PaddingAnchor.test.tsx
@@ -76,6 +76,42 @@ describe('PaddingAnchor', () => {
     }
   });
 
+  it('renders a directional arrow rotated toward each edge/corner cell', () => {
+    render(<PaddingAnchor value="custom" onChange={vi.fn()} />);
+    const cases: Array<[string, string]> = [
+      ['tl', 'rotate-45'],
+      ['tc', 'rotate-90'],
+      ['ml', 'rotate-0'],
+      ['mr', 'rotate-180'],
+      ['br', 'rotate-[225deg]'],
+    ];
+    for (const [anchor, rotation] of cases) {
+      const svg = screen.getByLabelText(`baseplate.paddingAnchor.${anchor}`).querySelector('svg');
+      expect(svg).not.toBeNull();
+      expect(svg).toHaveClass(rotation);
+    }
+  });
+
+  it('renders the center cell as a target glyph rather than an arrow', () => {
+    render(<PaddingAnchor value="custom" onChange={vi.fn()} />);
+    const center = screen.getByLabelText('baseplate.paddingAnchor.c');
+    expect(center.querySelector('svg')).toBeNull();
+    expect(center.querySelector('span.rounded-full')).not.toBeNull();
+  });
+
+  it('gives the selected cell a filled tile', () => {
+    render(<PaddingAnchor value="tr" onChange={vi.fn()} />);
+    expect(screen.getByLabelText('baseplate.paddingAnchor.tr')).toHaveClass('bg-content');
+  });
+
+  it('exposes a hover tooltip mirroring each cell label', () => {
+    render(<PaddingAnchor value="custom" onChange={vi.fn()} />);
+    expect(screen.getByLabelText('baseplate.paddingAnchor.bl')).toHaveAttribute(
+      'title',
+      'baseplate.paddingAnchor.bl'
+    );
+  });
+
   it('shows clamp warning badge only when showClampWarning is true', () => {
     const { rerender } = render(
       <PaddingAnchor value="tl" onChange={vi.fn()} showClampWarning={false} />

--- a/src/features/baseplate/components/PaddingAnchor/PaddingAnchor.tsx
+++ b/src/features/baseplate/components/PaddingAnchor/PaddingAnchor.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef, type KeyboardEvent } from 'react';
 import { cn } from '@/design-system/cn';
-import { AlertTriangleIcon } from '@/design-system/Icon';
+import { AlertTriangleIcon, ArrowLeftIcon } from '@/design-system/Icon';
 import { focusRing, interactiveTransition } from '@/design-system/variants';
 import { useTranslation } from '@/i18n';
 import type { PaddingAnchor as PaddingAnchorValue } from '@/core/types';
@@ -24,6 +24,22 @@ const ARROW_DELTAS: Record<string, readonly [number, number] | undefined> = {
   ArrowDown: [0, 1],
 };
 
+// ArrowLeftIcon points left (west). Rotating it clockwise by these amounts aims
+// each cell's arrow at the drawer corner/edge that anchor snaps the baseplate to.
+// `null` marks the center cell, which renders a target glyph instead of an arrow.
+// Classes are spelled out literally so Tailwind's JIT emits the arbitrary rotations.
+const ARROW_ROTATION: Record<ConcreteAnchor, string | null> = {
+  tl: 'rotate-45',
+  tc: 'rotate-90',
+  tr: 'rotate-[135deg]',
+  ml: 'rotate-0',
+  c: null,
+  mr: 'rotate-180',
+  bl: 'rotate-[315deg]',
+  bc: 'rotate-[270deg]',
+  br: 'rotate-[225deg]',
+};
+
 function clampToGrid(v: number): number {
   return Math.max(0, Math.min(2, v));
 }
@@ -41,6 +57,18 @@ const FIRST_ANCHOR: ConcreteAnchor = 'tl';
 function rovingTabIndex(anchor: ConcreteAnchor, value: PaddingAnchorValue): 0 | -1 {
   if (value === 'custom') return anchor === FIRST_ANCHOR ? 0 : -1;
   return anchor === value ? 0 : -1;
+}
+
+function CellGlyph({ anchor }: { readonly anchor: ConcreteAnchor }) {
+  const rotation = ARROW_ROTATION[anchor];
+  if (rotation === null) {
+    return (
+      <span className="flex h-2 w-2 items-center justify-center rounded-full border border-current">
+        <span className="h-0.5 w-0.5 rounded-full bg-current" />
+      </span>
+    );
+  }
+  return <ArrowLeftIcon size="sm" className={cn('h-3 w-3', rotation)} strokeWidth={2.25} />;
 }
 
 export function PaddingAnchor({
@@ -77,6 +105,7 @@ export function PaddingAnchor({
     >
       {ANCHORS.map((anchor) => {
         const selected = value === anchor;
+        const cellLabel = t(`baseplate.paddingAnchor.${anchor}`);
         return (
           <button
             key={anchor}
@@ -87,21 +116,24 @@ export function PaddingAnchor({
             type="button"
             role="radio"
             aria-checked={selected}
-            aria-label={t(`baseplate.paddingAnchor.${anchor}`)}
+            aria-label={cellLabel}
+            title={cellLabel}
             tabIndex={rovingTabIndex(anchor, value)}
             disabled={disabled}
             onClick={() => onChange(anchor)}
             onKeyDown={(e) => handleKeyDown(anchor, e)}
             className={cn(
-              'flex h-3.5 w-3.5 items-center justify-center rounded-full border',
+              'flex h-5 w-5 items-center justify-center rounded-md border',
               selected
-                ? 'border-content bg-content'
-                : 'border-stroke-subtle bg-surface-elevated hover:border-content-secondary hover:bg-surface-hover',
+                ? 'border-content bg-content text-surface'
+                : 'border-transparent text-content-tertiary hover:border-stroke-subtle hover:bg-surface-hover hover:text-content-secondary',
               'disabled:cursor-not-allowed disabled:opacity-50',
               interactiveTransition,
               ...focusRing
             )}
-          />
+          >
+            <CellGlyph anchor={anchor} />
+          </button>
         );
       })}
       {showClampWarning && (

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -88,6 +88,7 @@
   "baseplate.paddingAnchor.bc": "Bins vorne mittig verankern",
   "baseplate.paddingAnchor.bl": "Bins vorne-links verankern",
   "baseplate.paddingAnchor.br": "Bins vorne-rechts verankern",
+  "baseplate.paddingAnchor.custom": "Benutzerdefiniert",
   "baseplate.paddingAnchor.c": "Bins zentrieren",
   "baseplate.paddingAnchor.clampedWarning": "Padding wurde auf den zulässigen Bereich begrenzt; die Bin-Position passt möglicherweise nicht genau zur gewählten Verankerung.",
   "baseplate.paddingAnchor.label": "Padding-Verankerung",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1697,6 +1697,7 @@
   "baseplate.paddingAnchor.bl": "Anchor bins front-left",
   "baseplate.paddingAnchor.bc": "Anchor bins front-center",
   "baseplate.paddingAnchor.br": "Anchor bins front-right",
+  "baseplate.paddingAnchor.custom": "Custom",
   "baseplate.paddingAnchor.clampedWarning": "Padding was clamped to the allowed range; the bin position may not match the selected anchor exactly.",
   "baseplate.editDimensions": "Edit baseplate dimensions",
   "baseplate.inclPadding": "incl. padding",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1959,6 +1959,7 @@ const en: Record<string, string> = {
   'baseplate.paddingAnchor.bl': 'Anchor bins front-left',
   'baseplate.paddingAnchor.bc': 'Anchor bins front-center',
   'baseplate.paddingAnchor.br': 'Anchor bins front-right',
+  'baseplate.paddingAnchor.custom': 'Custom',
   'baseplate.paddingAnchor.clampedWarning':
     'Padding was clamped to the allowed range; the bin position may not match the selected anchor exactly.',
   'baseplate.editDimensions': 'Edit baseplate dimensions',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -88,6 +88,7 @@
   "baseplate.paddingAnchor.bc": "Anclar bins frente-centro",
   "baseplate.paddingAnchor.bl": "Anclar bins frente-izquierda",
   "baseplate.paddingAnchor.br": "Anclar bins frente-derecha",
+  "baseplate.paddingAnchor.custom": "Personalizado",
   "baseplate.paddingAnchor.c": "Centrar bins",
   "baseplate.paddingAnchor.clampedWarning": "El relleno se limitó al rango permitido; la posición de los bins puede no coincidir exactamente con el anclaje seleccionado.",
   "baseplate.paddingAnchor.label": "Anclaje de relleno",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -88,6 +88,7 @@
   "baseplate.paddingAnchor.bc": "Ancrer les bacs avant-centre",
   "baseplate.paddingAnchor.bl": "Ancrer les bacs avant-gauche",
   "baseplate.paddingAnchor.br": "Ancrer les bacs avant-droite",
+  "baseplate.paddingAnchor.custom": "Personnalisé",
   "baseplate.paddingAnchor.c": "Centrer les bacs",
   "baseplate.paddingAnchor.clampedWarning": "La marge a été limitée à la plage autorisée ; la position des bacs peut ne pas correspondre exactement à l'ancrage sélectionné.",
   "baseplate.paddingAnchor.label": "Ancrage de marge",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -88,6 +88,7 @@
   "baseplate.paddingAnchor.bc": "ビンを手前中央に配置",
   "baseplate.paddingAnchor.bl": "ビンを手前左に配置",
   "baseplate.paddingAnchor.br": "ビンを手前右に配置",
+  "baseplate.paddingAnchor.custom": "カスタム",
   "baseplate.paddingAnchor.c": "ビンを中央に配置",
   "baseplate.paddingAnchor.clampedWarning": "余白が許容範囲に丸められました。ビンの位置が選択したアンカーと正確に一致しない場合があります。",
   "baseplate.paddingAnchor.label": "余白アンカー",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -88,6 +88,7 @@
   "baseplate.paddingAnchor.bc": "Forankre bins foran-midten",
   "baseplate.paddingAnchor.bl": "Forankre bins foran-venstre",
   "baseplate.paddingAnchor.br": "Forankre bins foran-høyre",
+  "baseplate.paddingAnchor.custom": "Egendefinert",
   "baseplate.paddingAnchor.c": "Sentrer bins",
   "baseplate.paddingAnchor.clampedWarning": "Polstringen ble begrenset til tillatt område; bin-posisjonen samsvarer kanskje ikke nøyaktig med det valgte ankeret.",
   "baseplate.paddingAnchor.label": "Polstringsanker",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -88,6 +88,7 @@
   "baseplate.paddingAnchor.bc": "Bins voor-midden verankeren",
   "baseplate.paddingAnchor.bl": "Bins voor-links verankeren",
   "baseplate.paddingAnchor.br": "Bins voor-rechts verankeren",
+  "baseplate.paddingAnchor.custom": "Aangepast",
   "baseplate.paddingAnchor.c": "Bins centreren",
   "baseplate.paddingAnchor.clampedWarning": "De vulling is beperkt tot het toegestane bereik; de positie van de bins komt mogelijk niet exact overeen met het gekozen anker.",
   "baseplate.paddingAnchor.label": "Vullingsanker",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -88,6 +88,7 @@
   "baseplate.paddingAnchor.bc": "Ancorar bins frente-centro",
   "baseplate.paddingAnchor.bl": "Ancorar bins frente-esquerda",
   "baseplate.paddingAnchor.br": "Ancorar bins frente-direita",
+  "baseplate.paddingAnchor.custom": "Personalizado",
   "baseplate.paddingAnchor.c": "Centralizar bins",
   "baseplate.paddingAnchor.clampedWarning": "O preenchimento foi limitado ao intervalo permitido; a posição dos bins pode não corresponder exatamente à âncora selecionada.",
   "baseplate.paddingAnchor.label": "Âncora de preenchimento",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -88,6 +88,7 @@
   "baseplate.paddingAnchor.bc": "Förankra bins fram-mitten",
   "baseplate.paddingAnchor.bl": "Förankra bins fram-vänster",
   "baseplate.paddingAnchor.br": "Förankra bins fram-höger",
+  "baseplate.paddingAnchor.custom": "Anpassad",
   "baseplate.paddingAnchor.c": "Centrera bins",
   "baseplate.paddingAnchor.clampedWarning": "Utfyllnaden begränsades till tillåtet intervall; bin-positionen matchar kanske inte exakt den valda förankringen.",
   "baseplate.paddingAnchor.label": "Utfyllnadsförankring",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -88,6 +88,7 @@
   "baseplate.paddingAnchor.bc": "Прив'язати бункери до передньої центральної",
   "baseplate.paddingAnchor.bl": "Прив'язати бункери до передньої лівої",
   "baseplate.paddingAnchor.br": "Прив'язати бункери до передньої правої",
+  "baseplate.paddingAnchor.custom": "Власні",
   "baseplate.paddingAnchor.c": "Центрувати бункери",
   "baseplate.paddingAnchor.clampedWarning": "Відступ було обмежено допустимим діапазоном; положення бункерів може не точно відповідати обраній прив'язці.",
   "baseplate.paddingAnchor.label": "Прив'язка відступів",


### PR DESCRIPTION
## What & why

The padding alignment control in the baseplate generator was a 3×3 grid of bare dots. It anchors the baseplate to a corner/edge of the drawer (redistributing leftover padding), but nothing about nine identical dots communicated that — so people didn't know what it did.

This restyles it into a **directional alignment pad**:

- Each outer cell shows an **arrow pointing toward the drawer corner/edge** it anchors to (top-left cell → up-left arrow).
- The **center cell** shows a target glyph meaning "centered".
- The **active anchor** gets a filled tile.
- Editing a padding stepper manually now surfaces a small **"Custom"** caption (the anchor is overridden).
- Each cell gains a **hover tooltip** ("Anchor bins back-left", etc.).
- The container border firmed up (dashed → subtle solid) so the schematic reads as one intentional control.

## Unchanged

Anchor redistribution math, the custom-flip on manual edit, the clamp warning, keyboard roving-tabindex navigation, and radiogroup/radio accessibility semantics are all untouched.

## Implementation note

The design system only ships a left arrow, so rather than add eight new icon files, the eight directions are produced by rotating a single `ArrowLeftIcon` in 45° steps — every arrow keeps the system's stroke weight.

## Verification

- `PaddingAnchor` + `PaddingSchematic` unit tests pass (added coverage for arrow rotations, center glyph, selected tile, tooltips, and the Custom caption)
- typecheck, eslint (changed files), and all i18n checks (keys / interpolation / values — new `baseplate.paddingAnchor.custom` key added + translated across all locales)
- Playwright visual spot-check of all four states (default, corner-selected, center, custom)