### PR TITLE
fix(generation): round cavity corners to fix corner gap on thin-walled dividers (#1968)

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.test.ts.snap
@@ -34,21 +34,21 @@ exports[`bin styles > 2×2 standard 1`] = `2812`;
 
 exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1300`;
 
-exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3052`;
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3164`;
 
-exports[`combined features > 2×2 label tabs with merged compartments 1`] = `4332`;
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `4518`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `5352`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `5856`;
 
 exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `18048`;
 
 exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2812`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `2852`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `2988`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `2880`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3016`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `3140`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `3276`;
 
 exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `2918`;
 
@@ -112,17 +112,17 @@ exports[`height > 2×2 height minimum (2u) 1`] = `2812`;
 
 exports[`height > 2×2 height tall (10u) 1`] = `2812`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6572`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6798`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6508`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6734`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6636`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6872`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6636`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6872`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `6676`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `6928`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `6532`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `6784`;
 
 exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `6940`;
 
@@ -162,7 +162,7 @@ exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3304`;
 
 exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4000`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4132`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4596`;
 
 exports[`scoop > 2×2 scoop auto radius 1`] = `4000`;
 

--- a/src/features/generation/worker/generators/binGenerator.scenario.issue-1968.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.issue-1968.test.ts
@@ -181,46 +181,75 @@ const TEST_TIMEOUT_MS = 90_000;
 // under this.
 const NOISE_TOLERANCE = 0.05;
 
+/**
+ * Assert a divider bin keeps its corners intact, using a single-compartment
+ * bin of the same outer dimensions as the control. `dividers` overrides only
+ * the compartment grid (and optionally dividerOverrides) on top of `dims`.
+ */
+async function expectCornersIntact(
+  dims: Partial<BinParams>,
+  dividers: BinParams['compartments']
+): Promise<void> {
+  const control = thinWalledBin({
+    ...dims,
+    compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
+  });
+  const test = thinWalledBin({ ...dims, compartments: dividers });
+  const controlTris = trianglesFromStl((await exportBin(control, 'stl')).data);
+  clearAllCaches();
+  const testTris = trianglesFromStl((await exportBin(test, 'stl')).data);
+  expect(cornerMaterialMissingFraction(controlTris, testTris)).toBeLessThan(NOISE_TOLERANCE);
+}
+
 describe('issue #1968 — corner gap with dividers on thin-walled bins', () => {
   it(
     'single column divider keeps the corners intact (2×2, 0.8mm wall)',
-    async () => {
-      const control = thinWalledBin({
-        width: 2,
-        depth: 2,
-        compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
-      });
-      const withDivider = thinWalledBin({
-        width: 2,
-        depth: 2,
-        compartments: { cols: 2, rows: 1, thickness: 1.2, cells: [0, 1] },
-      });
-      const controlTris = trianglesFromStl((await exportBin(control, 'stl')).data);
-      clearAllCaches();
-      const testTris = trianglesFromStl((await exportBin(withDivider, 'stl')).data);
-      expect(cornerMaterialMissingFraction(controlTris, testTris)).toBeLessThan(NOISE_TOLERANCE);
-    },
+    () =>
+      expectCornersIntact(
+        { width: 2, depth: 2 },
+        { cols: 2, rows: 1, thickness: 1.2, cells: [0, 1] }
+      ),
     TEST_TIMEOUT_MS
   );
 
   it(
     "reporter's config — 2-col × 4-row grid keeps the corners intact (0.8mm wall)",
-    async () => {
-      const control = thinWalledBin({
-        width: 2,
-        depth: 4,
-        compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
-      });
-      const withGrid = thinWalledBin({
-        width: 2,
-        depth: 4,
-        compartments: { cols: 2, rows: 4, thickness: 1.2, cells: [0, 1, 2, 3, 4, 5, 6, 7] },
-      });
-      const controlTris = trianglesFromStl((await exportBin(control, 'stl')).data);
-      clearAllCaches();
-      const testTris = trianglesFromStl((await exportBin(withGrid, 'stl')).data);
-      expect(cornerMaterialMissingFraction(controlTris, testTris)).toBeLessThan(NOISE_TOLERANCE);
-    },
+    () =>
+      expectCornersIntact(
+        { width: 2, depth: 4 },
+        { cols: 2, rows: 4, thickness: 1.2, cells: [0, 1, 2, 3, 4, 5, 6, 7] }
+      ),
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    // Narrow corner cells can't fit the full corner radius, so the cut path
+    // would only partially round them and reopen the gap — these bins must
+    // fall back to the additive path. 8 columns on a 1-wide bin ≈ 5mm cells.
+    'narrow corner cells stay intact via the additive fallback (1×1, 8 cols, 0.8mm wall)',
+    () =>
+      expectCornersIntact(
+        { width: 1, depth: 1 },
+        { cols: 8, rows: 1, thickness: 1.2, cells: [0, 1, 2, 3, 4, 5, 6, 7] }
+      ),
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    // Tilted dividers take the cut path too; exterior corners are never tilted,
+    // so they must still round cleanly.
+    'tilted divider keeps the corners intact (2×4 bin, 1×2 grid, ±20mm tilt, 0.8mm wall)',
+    () =>
+      expectCornersIntact(
+        { width: 2, depth: 4 },
+        {
+          cols: 1,
+          rows: 2,
+          thickness: 1.2,
+          cells: [0, 1],
+          dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: -20, offsetEnd: 20 }],
+        }
+      ),
     TEST_TIMEOUT_MS
   );
 });

--- a/src/features/generation/worker/generators/binGenerator.scenario.issue-1968.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.issue-1968.test.ts
@@ -124,6 +124,16 @@ const SAMPLE_STEP_MM = 0.25;
  */
 function cornerMaterialMissingFraction(control: Float32Array, test: Float32Array): number {
   const b = meshBounds(control);
+  // Corner regions are derived from the control's bounds and reused to probe
+  // the test mesh, so the two must share outer dimensions or the comparison
+  // is meaningless. Fail loudly if a caller passes mismatched bins.
+  const tb = meshBounds(test);
+  const align = SAMPLE_STEP_MM / 2;
+  expect(tb.minX, 'control/test minX must align').toBeCloseTo(b.minX, 1);
+  expect(tb.maxX, 'control/test maxX must align').toBeCloseTo(b.maxX, 1);
+  expect(tb.minY, 'control/test minY must align').toBeCloseTo(b.minY, 1);
+  expect(tb.maxY, 'control/test maxY must align').toBeCloseTo(b.maxY, 1);
+  expect(Math.abs(tb.maxZ - b.maxZ), 'control/test height must align').toBeLessThan(align);
   const z = b.minZ + (b.maxZ - b.minZ) * 0.7; // upper wall band, below the rim
   const cornersX: Array<[number, number]> = [
     [b.minX, 1],

--- a/src/features/generation/worker/generators/binGenerator.scenario.issue-1968.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.issue-1968.test.ts
@@ -1,0 +1,216 @@
+// @vitest-environment node
+/**
+ * Regression test for issue #1968 — gap in corners when column dividers are
+ * added to thin-walled boxes.
+ *
+ * Repro: a bin with a column divider and a wall thickness below
+ * ~1.1mm shows a gap in all four outer corners once the divider is
+ * generated. The corners are intact at the default 1.2mm wall.
+ *
+ * Root cause: the multi-cavity-cut shell path (#1753) subtracts
+ * **sharp-cornered** rectangular cavities from a **rounded** outer box
+ * (BOX_CORNER_RADIUS = 3.75mm). For a corner compartment, the cavity's
+ * sharp corner sits at the bin's inner wall corner. When
+ * `wallThickness < BOX_CORNER_RADIUS · (1 − 1/√2) ≈ 1.098mm`, that sharp
+ * corner pokes *past* the outer rounded arc, so the cut eats through the
+ * outer skin and leaves a notch. The fix rounds each cavity corner that
+ * lies on the bin perimeter with the same radius the single-compartment
+ * hollow shell uses (`BOX_CORNER_RADIUS − wallThickness`), so the cavity
+ * follows the inner wall contour and uniform wall material survives.
+ *
+ * This is invisible to the manifold tests: the over-cut still yields a
+ * watertight solid, just the wrong shape. So we probe the geometry
+ * directly. A single-compartment bin of the same outer dimensions is the
+ * control — its corners are built by the rounded hollow shell and are
+ * always intact. We sample a dense grid of points across all four corner
+ * wall regions; every point that is solid in the control must also be
+ * solid in the divider bin (the divider is interior and never removes
+ * corner material). The corner-gap bug makes ~17% of control-solid corner
+ * points vanish in the divider bin; the fix drops that to tessellation
+ * noise (a couple percent at the wall surfaces).
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import type { BinParams } from '@/shared/types/bin';
+import { isOk } from '@/core/result';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { parseSTLBinary } from '@/shared/generation/stlParser';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import { exportBin } from './binExporter';
+import { clearAllCaches } from './shapeCache';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+beforeEach(() => clearAllCaches());
+
+/** Parse a binary STL into a flat triangle-vertex array (9 floats / triangle). */
+function trianglesFromStl(stl: ArrayBuffer): Float32Array {
+  const parsed = parseSTLBinary(stl);
+  if (!isOk(parsed)) throw new Error('STL parse failed');
+  return parsed.value.vertices;
+}
+
+/**
+ * Point-in-solid test for a closed triangle mesh via vertical (+Z) ray
+ * casting: count triangles directly above `(x, y)` whose XY projection
+ * contains the point; an odd count means the point is inside the solid.
+ */
+function isInsideSolid(tris: Float32Array, x: number, y: number, z: number): boolean {
+  let crossings = 0;
+  for (let i = 0; i < tris.length; i += 9) {
+    const ax = tris[i],
+      ay = tris[i + 1],
+      az = tris[i + 2];
+    const bx = tris[i + 3],
+      by = tris[i + 4],
+      bz = tris[i + 5];
+    const cx = tris[i + 6],
+      cy = tris[i + 7],
+      cz = tris[i + 8];
+
+    // Barycentric containment of (x, y) in the triangle's XY projection.
+    const det = (by - cy) * (ax - cx) + (cx - bx) * (ay - cy);
+    if (Math.abs(det) < 1e-9) continue; // edge-on triangle: no vertical area
+    const l1 = ((by - cy) * (x - cx) + (cx - bx) * (y - cy)) / det;
+    const l2 = ((cy - ay) * (x - cx) + (ax - cx) * (y - cy)) / det;
+    const l3 = 1 - l1 - l2;
+    if (l1 < 0 || l2 < 0 || l3 < 0) continue;
+
+    const zHit = l1 * az + l2 * bz + l3 * cz;
+    if (zHit > z) crossings++;
+  }
+  return crossings % 2 === 1;
+}
+
+interface XYBounds {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+  minZ: number;
+  maxZ: number;
+}
+
+function meshBounds(tris: Float32Array): XYBounds {
+  const b: XYBounds = {
+    minX: Infinity,
+    maxX: -Infinity,
+    minY: Infinity,
+    maxY: -Infinity,
+    minZ: Infinity,
+    maxZ: -Infinity,
+  };
+  for (let i = 0; i < tris.length; i += 3) {
+    b.minX = Math.min(b.minX, tris[i]);
+    b.maxX = Math.max(b.maxX, tris[i]);
+    b.minY = Math.min(b.minY, tris[i + 1]);
+    b.maxY = Math.max(b.maxY, tris[i + 1]);
+    b.minZ = Math.min(b.minZ, tris[i + 2]);
+    b.maxZ = Math.max(b.maxZ, tris[i + 2]);
+  }
+  return b;
+}
+
+const CORNER_SPAN_MM = 6; // size of the square corner region to sample
+const SAMPLE_STEP_MM = 0.25;
+
+/**
+ * Fraction of control-solid corner-wall points that are missing (hollow)
+ * in the test mesh, sampled across all four outer corners at mid-wall
+ * height. Both meshes must share outer dimensions so the corner regions
+ * align. A correct divider bin matches the control to within tessellation
+ * noise; the corner-gap bug leaves a large fraction missing.
+ */
+function cornerMaterialMissingFraction(control: Float32Array, test: Float32Array): number {
+  const b = meshBounds(control);
+  const z = b.minZ + (b.maxZ - b.minZ) * 0.7; // upper wall band, below the rim
+  const cornersX: Array<[number, number]> = [
+    [b.minX, 1],
+    [b.maxX, -1],
+  ];
+  const cornersY: Array<[number, number]> = [
+    [b.minY, 1],
+    [b.maxY, -1],
+  ];
+  let controlSolid = 0;
+  let missing = 0;
+  for (const [baseX, signX] of cornersX) {
+    for (const [baseY, signY] of cornersY) {
+      for (let a = SAMPLE_STEP_MM; a <= CORNER_SPAN_MM; a += SAMPLE_STEP_MM) {
+        for (let c = SAMPLE_STEP_MM; c <= CORNER_SPAN_MM; c += SAMPLE_STEP_MM) {
+          const x = baseX + signX * a;
+          const y = baseY + signY * c;
+          if (!isInsideSolid(control, x, y, z)) continue;
+          controlSolid++;
+          if (!isInsideSolid(test, x, y, z)) missing++;
+        }
+      }
+    }
+  }
+  expect(
+    controlSolid,
+    'control should have solid corner material to compare against'
+  ).toBeGreaterThan(100);
+  return missing / controlSolid;
+}
+
+function thinWalledBin(overrides: Partial<BinParams>): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    wallThickness: 0.8,
+    base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+    scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: false },
+    ...overrides,
+  };
+}
+
+const TEST_TIMEOUT_MS = 90_000;
+// Corner material that may flip between independently tessellated meshes
+// at the wall surfaces. The bug leaves ~17% missing; the fix lands well
+// under this.
+const NOISE_TOLERANCE = 0.05;
+
+describe('issue #1968 — corner gap with dividers on thin-walled bins', () => {
+  it(
+    'single column divider keeps the corners intact (2×2, 0.8mm wall)',
+    async () => {
+      const control = thinWalledBin({
+        width: 2,
+        depth: 2,
+        compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
+      });
+      const withDivider = thinWalledBin({
+        width: 2,
+        depth: 2,
+        compartments: { cols: 2, rows: 1, thickness: 1.2, cells: [0, 1] },
+      });
+      const controlTris = trianglesFromStl((await exportBin(control, 'stl')).data);
+      clearAllCaches();
+      const testTris = trianglesFromStl((await exportBin(withDivider, 'stl')).data);
+      expect(cornerMaterialMissingFraction(controlTris, testTris)).toBeLessThan(NOISE_TOLERANCE);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    "reporter's config — 2-col × 4-row grid keeps the corners intact (0.8mm wall)",
+    async () => {
+      const control = thinWalledBin({
+        width: 2,
+        depth: 4,
+        compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
+      });
+      const withGrid = thinWalledBin({
+        width: 2,
+        depth: 4,
+        compartments: { cols: 2, rows: 4, thickness: 1.2, cells: [0, 1, 2, 3, 4, 5, 6, 7] },
+      });
+      const controlTris = trianglesFromStl((await exportBin(control, 'stl')).data);
+      clearAllCaches();
+      const testTris = trianglesFromStl((await exportBin(withGrid, 'stl')).data);
+      expect(cornerMaterialMissingFraction(controlTris, testTris)).toBeLessThan(NOISE_TOLERANCE);
+    },
+    TEST_TIMEOUT_MS
+  );
+});

--- a/src/features/generation/worker/generators/compartmentBuilder.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.ts
@@ -208,7 +208,10 @@ export function buildCompartmentsCacheKey(params: BinParams): string {
       params.compartments.rows,
       quantize(params.compartments.thickness),
       params.compartments.cells.join(','),
-      stableSerialize(params.compartments.dividerOverrides ?? [])
+      stableSerialize(params.compartments.dividerOverrides ?? []),
+      // Cavity corner rounding depends on wallThickness; include it so this
+      // sub-key stays self-consistent even if used standalone in future.
+      quantize(params.wallThickness)
     )
   );
 }

--- a/src/features/generation/worker/generators/compartmentBuilder.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.ts
@@ -10,6 +10,7 @@ import type { Shape3D, ValidSolid, DisposalScope, Drawing } from 'brepjs';
 import type { BinParams, DividerOverride } from '@/shared/types/bin';
 import { buildCacheKey, compactKey, quantize, stableSerialize } from './cacheKeyUtils';
 import { sketch } from './meshUtils';
+import { BOX_CORNER_RADIUS } from './generatorConstants';
 
 // Re-export for backwards compatibility with existing imports
 export { fuseAllOrNull } from './utils/shapeOps';
@@ -35,6 +36,13 @@ export function hasMultipleCompartments(params: BinParams): boolean {
  * leave `thickness` of wall between them) and aligned flush with the bin's
  * inner wall surface on each exterior boundary.
  *
+ * Corners that sit on the bin perimeter are rounded with the same radius the
+ * single-compartment hollow shell uses (`BOX_CORNER_RADIUS − wallThickness`)
+ * so the cavity follows the rounded inner wall contour. Without this, a sharp
+ * cavity corner pokes past the outer rounded arc on thin-walled bins
+ * (`wallThickness < BOX_CORNER_RADIUS·(1 − 1/√2) ≈ 1.1mm`) and the cut eats
+ * through the outer skin, leaving a gap in the bin's corners (#1968).
+ *
  * Non-rectangular compartments (cells with the same ID forming an L-shape,
  * etc.) are approximated by their bounding box; multi-cavity cut is therefore
  * only safe for compartments that fill their bounding box. Callers should
@@ -46,14 +54,66 @@ export function buildCompartmentCavityDrawings(
   innerD: number
 ): readonly Drawing[] {
   const lookup = buildOverrideLookup(params.compartments.dividerOverrides);
+  // Match the inner footprint radius of the hollow shell (boxBuilder), so a
+  // bin-corner cavity reproduces the same rounded inner corner as a
+  // single-compartment bin.
+  const cornerRadius = Math.max(BOX_CORNER_RADIUS - params.wallThickness, 0);
   const drawings: Drawing[] = [];
   for (const id of new Set(params.compartments.cells)) {
     const corners = cavityCorners(params, innerW, innerD, id, lookup);
     if (!corners) continue;
-    const { bl, br, tr, tl } = corners;
-    drawings.push(draw(bl).lineTo(br).lineTo(tr).lineTo(tl).close());
+    drawings.push(cavityDrawing(corners, cornerRadius));
   }
   return drawings;
+}
+
+/**
+ * Build a cavity drawing, rounding each corner that lies on the bin
+ * perimeter with `cornerRadius` (clamped to the cavity's own dimensions so
+ * the fillet always fits). Interior corners — divider junctions — stay sharp.
+ */
+function cavityDrawing(corners: CavityCorners, cornerRadius: number): Drawing {
+  const { bl, br, tr, tl, exterior } = corners;
+  // The fillet trims `r` from each adjacent edge; cap at half the smaller
+  // span so opposing fillets on the same edge can't overrun each other.
+  const cavW = Math.min(br[0] - bl[0], tr[0] - tl[0]);
+  const cavD = Math.min(tl[1] - bl[1], tr[1] - br[1]);
+  const r = Math.max(0, Math.min(cornerRadius, cavW / 2 - 0.05, cavD / 2 - 0.05));
+  const rBL = exterior.bl ? r : 0;
+  const rBR = exterior.br ? r : 0;
+  const rTR = exterior.tr ? r : 0;
+  const rTL = exterior.tl ? r : 0;
+
+  if (r <= 0.1 || (!rBL && !rBR && !rTR && !rTL)) {
+    return draw(bl).lineTo(br).lineTo(tr).lineTo(tl).close();
+  }
+
+  // Start mid-bottom-edge so close() forms a real edge through BL, letting
+  // customCorner(rBL) apply to it (mirrors buildSlabFootprint in
+  // baseplateSlab.ts). Starting at a corner would make close() degenerate.
+  let pen = draw([(bl[0] + br[0]) / 2, (bl[1] + br[1]) / 2]);
+  pen = pen.lineTo(br);
+  if (rBR > 0) pen = pen.customCorner(rBR);
+  pen = pen.lineTo(tr);
+  if (rTR > 0) pen = pen.customCorner(rTR);
+  pen = pen.lineTo(tl);
+  if (rTL > 0) pen = pen.customCorner(rTL);
+  pen = pen.lineTo(bl);
+  if (rBL > 0) pen = pen.customCorner(rBL);
+  return pen.close();
+}
+
+interface CavityCorners {
+  bl: [number, number];
+  br: [number, number];
+  tr: [number, number];
+  tl: [number, number];
+  /**
+   * Whether each corner sits on the bin perimeter (both adjacent edges are
+   * exterior). Only these corners get rounded; interior corners are divider
+   * junctions and stay sharp.
+   */
+  exterior: { bl: boolean; br: boolean; tr: boolean; tl: boolean };
 }
 
 /**
@@ -69,12 +129,7 @@ function cavityCorners(
   innerD: number,
   id: number,
   lookup: Map<string, DividerOverride>
-): {
-  bl: [number, number];
-  br: [number, number];
-  tr: [number, number];
-  tl: [number, number];
-} | null {
+): CavityCorners | null {
   const { cols, rows, thickness, cells } = params.compartments;
   const bounds = findCompartmentBounds(id, cols, rows, cells);
   if (!bounds) return null;
@@ -90,6 +145,20 @@ function cavityCorners(
   const br: [number, number] = [xMax, yMin];
   const tr: [number, number] = [xMax, yMax];
   const tl: [number, number] = [xMin, yMax];
+  // A corner is on the bin perimeter when both of its edges are exterior:
+  // left edge at minCol===0, right at maxCol===cols-1, front at minRow===0,
+  // back at maxRow===rows-1. Override displacement only touches interior
+  // edges, so exterior corners are never shifted.
+  const left = minCol === 0;
+  const right = maxCol === cols - 1;
+  const front = minRow === 0;
+  const back = maxRow === rows - 1;
+  const exterior = {
+    bl: left && front,
+    br: right && front,
+    tr: right && back,
+    tl: left && back,
+  };
   if (maxCol < cols - 1) {
     const ov = lookup.get(overrideKey(id, cells[minRow * cols + (maxCol + 1)]));
     if (ov) {
@@ -118,7 +187,7 @@ function cavityCorners(
       br[1] += ov.offsetEnd;
     }
   }
-  return { bl, br, tr, tl };
+  return { bl, br, tr, tl, exterior };
 }
 
 /** Whether any divider override is present in the compartment grid. */

--- a/src/features/generation/worker/generators/compartmentBuilder.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.ts
@@ -54,9 +54,6 @@ export function buildCompartmentCavityDrawings(
   innerD: number
 ): readonly Drawing[] {
   const lookup = buildOverrideLookup(params.compartments.dividerOverrides);
-  // Match the inner footprint radius of the hollow shell (boxBuilder), so a
-  // bin-corner cavity reproduces the same rounded inner corner as a
-  // single-compartment bin.
   const cornerRadius = Math.max(BOX_CORNER_RADIUS - params.wallThickness, 0);
   const drawings: Drawing[] = [];
   for (const id of new Set(params.compartments.cells)) {
@@ -74,23 +71,23 @@ export function buildCompartmentCavityDrawings(
  */
 function cavityDrawing(corners: CavityCorners, cornerRadius: number): Drawing {
   const { bl, br, tr, tl, exterior } = corners;
-  // The fillet trims `r` from each adjacent edge; cap at half the smaller
-  // span so opposing fillets on the same edge can't overrun each other.
-  const cavW = Math.min(br[0] - bl[0], tr[0] - tl[0]);
-  const cavD = Math.min(tl[1] - bl[1], tr[1] - br[1]);
+  // Cap the radius at half the smaller span so opposing fillets can't overrun.
+  const { cavW, cavD } = cavitySpan(corners);
   const r = Math.max(0, Math.min(cornerRadius, cavW / 2 - 0.05, cavD / 2 - 0.05));
   const rBL = exterior.bl ? r : 0;
   const rBR = exterior.br ? r : 0;
   const rTR = exterior.tr ? r : 0;
   const rTL = exterior.tl ? r : 0;
 
-  if (r <= 0.1 || (!rBL && !rBR && !rTR && !rTL)) {
+  if (r <= 0.1 || !hasExteriorCorner(exterior)) {
     return draw(bl).lineTo(br).lineTo(tr).lineTo(tl).close();
   }
 
-  // Start mid-bottom-edge so close() forms a real edge through BL, letting
-  // customCorner(rBL) apply to it (mirrors buildSlabFootprint in
+  // Start at the midpoint of BL→BR so close() forms a real edge through BL,
+  // letting customCorner(rBL) apply to it (mirrors buildSlabProfile in
   // baseplateSlab.ts). Starting at a corner would make close() degenerate.
+  // Use the true midpoint (not [mid_x, bl[1]]): an override can tilt the
+  // bottom edge (bl[1] !== br[1]), and the start point must stay on it.
   let pen = draw([(bl[0] + br[0]) / 2, (bl[1] + br[1]) / 2]);
   pen = pen.lineTo(br);
   if (rBR > 0) pen = pen.customCorner(rBR);
@@ -114,6 +111,24 @@ interface CavityCorners {
    * junctions and stay sharp.
    */
   exterior: { bl: boolean; br: boolean; tr: boolean; tl: boolean };
+}
+
+/** Whether any cavity corner sits on the bin perimeter (and so gets rounded). */
+function hasExteriorCorner(exterior: CavityCorners['exterior']): boolean {
+  return exterior.bl || exterior.br || exterior.tr || exterior.tl;
+}
+
+/**
+ * Width and depth of a cavity, taken as the smaller of each pair of opposing
+ * edges so override displacement can't inflate the span used for fillet
+ * clamping or clearance checks.
+ */
+function cavitySpan(corners: CavityCorners): { cavW: number; cavD: number } {
+  const { bl, br, tr, tl } = corners;
+  return {
+    cavW: Math.min(br[0] - bl[0], tr[0] - tl[0]),
+    cavD: Math.min(tl[1] - bl[1], tr[1] - br[1]),
+  };
 }
 
 /**
@@ -145,10 +160,9 @@ function cavityCorners(
   const br: [number, number] = [xMax, yMin];
   const tr: [number, number] = [xMax, yMax];
   const tl: [number, number] = [xMin, yMax];
-  // A corner is on the bin perimeter when both of its edges are exterior:
-  // left edge at minCol===0, right at maxCol===cols-1, front at minRow===0,
-  // back at maxRow===rows-1. Override displacement only touches interior
-  // edges, so exterior corners are never shifted.
+  // A corner is on the bin perimeter when both of its edges are exterior.
+  // Override displacement only touches interior edges, so exterior corners
+  // are never shifted (safe to round).
   const left = minCol === 0;
   const right = maxCol === cols - 1;
   const front = minRow === 0;
@@ -209,8 +223,7 @@ export function buildCompartmentsCacheKey(params: BinParams): string {
       quantize(params.compartments.thickness),
       params.compartments.cells.join(','),
       stableSerialize(params.compartments.dividerOverrides ?? []),
-      // Cavity corner rounding depends on wallThickness; include it so this
-      // sub-key stays self-consistent even if used standalone in future.
+      // Cavity corner rounding depends on wallThickness.
       quantize(params.wallThickness)
     )
   );
@@ -330,6 +343,37 @@ export function compartmentCavitiesAreViable(
     const compD =
       (maxRow - minRow + 1) * cellD - (minRow > 0 ? half : 0) - (maxRow < rows - 1 ? half : 0);
     if (compW < minDim || compD < minDim) return false;
+  }
+  return true;
+}
+
+/**
+ * Whether every bin-perimeter cavity corner can be rounded with the full
+ * inner-shell radius (`BOX_CORNER_RADIUS − wallThickness`). On thin walls a
+ * corner compartment narrower than twice that radius can only be partially
+ * rounded, so its sharp residue still pokes past the outer arc and reopens
+ * the #1968 corner gap — such bins must fall back to the additive-fuse path
+ * (whose rounded hollow shell has no corner gap). Thick-walled bins are
+ * always safe: a sharp cavity corner never reaches past the arc, so cell
+ * size is irrelevant.
+ */
+export function compartmentCornersRoundCleanly(
+  params: BinParams,
+  innerW: number,
+  innerD: number
+): boolean {
+  const targetR = BOX_CORNER_RADIUS - params.wallThickness;
+  // Sharp corners only over-cut below BOX_CORNER_RADIUS·(1 − 1/√2); above
+  // that threshold there is no gap to fix regardless of compartment size.
+  if (targetR <= BOX_CORNER_RADIUS / Math.SQRT2) return true;
+  const need = 2 * targetR;
+  const lookup = buildOverrideLookup(params.compartments.dividerOverrides);
+  for (const id of new Set(params.compartments.cells)) {
+    const corners = cavityCorners(params, innerW, innerD, id, lookup);
+    if (!corners) continue;
+    if (!hasExteriorCorner(corners.exterior)) continue;
+    const { cavW, cavD } = cavitySpan(corners);
+    if (cavW < need || cavD < need) return false;
   }
   return true;
 }

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -18,6 +18,7 @@ import {
   buildCompartmentsCacheKey,
   compartmentCavitiesAreViable,
   compartmentCavitiesAreViableWithOverrides,
+  compartmentCornersRoundCleanly,
   compartmentEdgesAreSinglePair,
   compartmentsAreRectangular,
   hasDividerOverrides,
@@ -88,6 +89,7 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
     hasMultipleCompartments(params) &&
     compartmentsAreRectangular(params) &&
     compartmentCavitiesAreViable(params, innerW, innerD) &&
+    compartmentCornersRoundCleanly(params, innerW, innerD) &&
     overridesAllowCutPath;
 
   // Shell cache key — versioned + quantized for deterministic matching.


### PR DESCRIPTION
Fixes #1968.

## Problem

Adding a column divider to a thin-walled box (wall thickness ≤ ~0.8mm) opens a gap in all four outer corners once the divider is generated. Corners are intact at the default 1.2mm wall.

## Root cause

The multi-cavity-cut shell path (#1753) subtracts **sharp-cornered** rectangular cavities from the bin's **rounded** outer box (`BOX_CORNER_RADIUS = 3.75mm`). For a corner compartment, the cavity's sharp corner sits at the bin's inner wall corner. When

```
wallThickness < BOX_CORNER_RADIUS · (1 − 1/√2) ≈ 1.098mm
```

that sharp corner pokes *past* the outer rounded arc, so the boolean cut eats through the outer skin and leaves a notch in the corner. Above the threshold (incl. the 1.2mm default) the sharp corner stays inside the arc, which is why this went unnoticed.

## Fix

Round each cavity corner that lies on the bin perimeter with the **same radius the single-compartment hollow shell already uses** (`BOX_CORNER_RADIUS − wallThickness`), so the cavity follows the rounded inner wall contour and uniform corner wall material survives. Interior corners (divider junctions) stay sharp. Mirrors the selective-corner-rounding idiom in `baseplateSlab.ts`. The fillet radius is clamped to the cavity's own dimensions so it always fits.

## Tests

- New `binGenerator.scenario.issue-1968.test.ts`: probes geometry directly with point-in-solid ray casting, comparing the divider bin's corner material against a single-compartment control (the bug is invisible to the existing manifold tests — the over-cut still yields a *watertight* solid, just the wrong shape). Before the fix ~17% of control-solid corner points vanish in the divider bin; after, it's within tessellation noise.
- Updated 13 triangle-count snapshots in `binGenerator.scenario.test.ts` (rounded corners add tessellation; all changes are increases).
- Full generation suite green (1250 passed), typecheck + lint clean.