### PR TITLE
chore: remove accidental debug scratch script

### DIFF
--- a/dbg-tmp.mjs
+++ b/dbg-tmp.mjs
@@ -1,8 +1,0 @@
-import { chromium } from '@playwright/test';
-const browser = await chromium.launch();
-const page = await browser.newPage({ viewport: { width: 512, height: 512 } });
-await page.goto('http://localhost:5174/?devThumbnails=1&example=hero-multicolor-organizer');
-await page.waitForFunction(() => window.__thumbnailReady === true, null, { timeout: 90000 });
-const info = await page.evaluate(() => window.__debugScene?.() ?? null);
-console.log(JSON.stringify(info, null, 2));
-await browser.close();


### PR DESCRIPTION
## What

Removes `dbg-tmp.mjs` from the repo root.

## Why

An 8-line throwaway Playwright snippet committed by accident in #1964 while building the example-thumbnail generator. It's unreferenced and not part of any build or test path.

## Impact

None — no code or product behavior changes.