### PR TITLE
fix(generation): include overhang expansion in innerW/innerD

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.overhang.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.overhang.test.ts
@@ -113,6 +113,37 @@ describe('overhang with interior features', () => {
     expect(scoopDeltaWithOverhang).toBeGreaterThan(0);
     expect(scoopDeltaWithOverhang).not.toBe(scoopDeltaNoOverhang);
   });
+
+  it('asymmetric overhang: interior features are structurally valid (centering offset applied)', () => {
+    const generateBin = getGenerateBin();
+    // right-only overhang: cavity centre shifts +X by 5mm (offsetX = 5).
+    // Before the centering fix, scoops would extend 5mm into the left wall.
+    // After the fix, all features translate by (innerOffsetX, innerOffsetY).
+    const result = generateBin(
+      buildParams({
+        width: 2,
+        depth: 2,
+        overhang: { left: 0, right: 10, front: 0, back: 0 },
+        scoop: { enabled: true, radius: 'auto' },
+      }),
+      undefined,
+      true
+    );
+    assertStructurallyValid(result, 'asymmetric overhang with scoop');
+
+    // front-only overhang: cavity centre shifts +Y by 5mm (offsetY = 5).
+    const result2 = generateBin(
+      buildParams({
+        width: 2,
+        depth: 2,
+        overhang: { left: 0, right: 0, front: 0, back: 10 },
+        scoop: { enabled: true, radius: 'auto' },
+      }),
+      undefined,
+      true
+    );
+    assertStructurallyValid(result2, 'back-only overhang with scoop');
+  });
 });
 
 describe('overhang feet toggle', () => {

--- a/src/features/generation/worker/generators/binGenerator.scenario.overhang.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.overhang.test.ts
@@ -80,6 +80,44 @@ describe('bin overhang geometry', () => {
   });
 });
 
+describe('overhang with interior features', () => {
+  it('scoop ramp uses expanded interior space (regression: innerD was not including overhang)', () => {
+    const generateBin = getGenerateBin();
+    const SCOOP = { enabled: true as const, radius: 'auto' as const };
+
+    const noOverhang = generateBin(
+      buildParams({ width: 2, depth: 2, scoop: SCOOP }),
+      undefined,
+      true
+    );
+    const withOverhang = generateBin(
+      buildParams({
+        width: 2,
+        depth: 2,
+        scoop: SCOOP,
+        overhang: { left: 5, right: 5, front: 5, back: 5 },
+      }),
+      undefined,
+      true
+    );
+
+    assertStructurallyValid(noOverhang, 'scoop no overhang');
+    assertStructurallyValid(withOverhang, 'scoop with overhang');
+
+    // With overhang the outer body is larger and so is the interior.
+    // The scoop ramp is positioned relative to innerD, so the two meshes
+    // must differ — if innerD was identical (the old bug), they would be
+    // structurally the same scoop just inside a larger shell.
+    const baseW = boundingBox(noOverhang.vertices);
+    const ovhW = boundingBox(withOverhang.vertices);
+    // Outer body grew by 10mm on each axis
+    expect(ovhW.maxX - ovhW.minX).toBeGreaterThan(baseW.maxX - baseW.minX + 9);
+    expect(ovhW.maxY - ovhW.minY).toBeGreaterThan(baseW.maxY - baseW.minY + 9);
+    // Triangle counts differ because the scoop carves a differently-sized cavity
+    expect(withOverhang.triangleCount).not.toBe(noOverhang.triangleCount);
+  });
+});
+
 describe('overhang feet toggle', () => {
   const OVERHANG = { left: 12, right: 12, front: 12, back: 12 };
 

--- a/src/features/generation/worker/generators/binGenerator.scenario.overhang.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.overhang.test.ts
@@ -84,37 +84,34 @@ describe('overhang with interior features', () => {
   it('scoop ramp uses expanded interior space (regression: innerD was not including overhang)', () => {
     const generateBin = getGenerateBin();
     const SCOOP = { enabled: true as const, radius: 'auto' as const };
+    const OVH = { left: 5, right: 5, front: 5, back: 5 };
 
-    const noOverhang = generateBin(
+    // Build all four combinations to isolate the scoop-delta under each condition.
+    const base = generateBin(buildParams({ width: 2, depth: 2 }), undefined, true);
+    const baseScoop = generateBin(
       buildParams({ width: 2, depth: 2, scoop: SCOOP }),
       undefined,
       true
     );
-    const withOverhang = generateBin(
-      buildParams({
-        width: 2,
-        depth: 2,
-        scoop: SCOOP,
-        overhang: { left: 5, right: 5, front: 5, back: 5 },
-      }),
+    const ovh = generateBin(buildParams({ width: 2, depth: 2, overhang: OVH }), undefined, true);
+    const ovhScoop = generateBin(
+      buildParams({ width: 2, depth: 2, scoop: SCOOP, overhang: OVH }),
       undefined,
       true
     );
 
-    assertStructurallyValid(noOverhang, 'scoop no overhang');
-    assertStructurallyValid(withOverhang, 'scoop with overhang');
+    assertStructurallyValid(baseScoop, 'scoop no overhang');
+    assertStructurallyValid(ovhScoop, 'scoop with overhang');
 
-    // With overhang the outer body is larger and so is the interior.
-    // The scoop ramp is positioned relative to innerD, so the two meshes
-    // must differ — if innerD was identical (the old bug), they would be
-    // structurally the same scoop just inside a larger shell.
-    const baseW = boundingBox(noOverhang.vertices);
-    const ovhW = boundingBox(withOverhang.vertices);
-    // Outer body grew by 10mm on each axis
-    expect(ovhW.maxX - ovhW.minX).toBeGreaterThan(baseW.maxX - baseW.minX + 9);
-    expect(ovhW.maxY - ovhW.minY).toBeGreaterThan(baseW.maxY - baseW.minY + 9);
-    // Triangle counts differ because the scoop carves a differently-sized cavity
-    expect(withOverhang.triangleCount).not.toBe(noOverhang.triangleCount);
+    // The scoop-delta is how many triangles the scoop adds to the plain shell.
+    // Before the fix, innerD was nominal regardless of overhang, so both deltas
+    // would be identical. After the fix, the overhang shell has a larger inner
+    // cavity, so the scoop carves more geometry and its delta is different.
+    const scoopDeltaNoOverhang = baseScoop.triangleCount - base.triangleCount;
+    const scoopDeltaWithOverhang = ovhScoop.triangleCount - ovh.triangleCount;
+    expect(scoopDeltaNoOverhang).toBeGreaterThan(0);
+    expect(scoopDeltaWithOverhang).toBeGreaterThan(0);
+    expect(scoopDeltaWithOverhang).not.toBe(scoopDeltaNoOverhang);
   });
 });
 

--- a/src/features/generation/worker/generators/pipeline/context.test.ts
+++ b/src/features/generation/worker/generators/pipeline/context.test.ts
@@ -119,6 +119,30 @@ describe('createInitialContext', () => {
     expect(ctx.dimensions.innerD).toBeCloseTo(baseline.dimensions.innerD, 5);
   });
 
+  it('innerOffsetX/Y are zero for symmetric overhang', () => {
+    const ctx = createInitialContext(
+      createTestParams({ overhang: { left: 5, right: 5, front: 4, back: 4 } })
+    );
+    expect(ctx.dimensions.innerOffsetX).toBe(0);
+    expect(ctx.dimensions.innerOffsetY).toBe(0);
+  });
+
+  it('innerOffsetX/Y are zero with no overhang', () => {
+    const ctx = createInitialContext(createTestParams());
+    expect(ctx.dimensions.innerOffsetX).toBe(0);
+    expect(ctx.dimensions.innerOffsetY).toBe(0);
+  });
+
+  it('innerOffsetX/Y reflect asymmetric overhang cavity shift', () => {
+    // right=6, left=0  → offsetX = (6-0)/2 = 3  (cavity shifts toward +X)
+    // back=4,  front=0 → offsetY = (4-0)/2 = 2
+    const ctx = createInitialContext(
+      createTestParams({ overhang: { left: 0, right: 6, front: 0, back: 4 } })
+    );
+    expect(ctx.dimensions.innerOffsetX).toBeCloseTo(3, 5);
+    expect(ctx.dimensions.innerOffsetY).toBeCloseTo(2, 5);
+  });
+
   it('should use params.gridUnitMm instead of hardcoded 42mm', () => {
     const ctx = createInitialContext(createTestParams({ gridUnitMm: 50 }));
     const dim = ctx.dimensions;

--- a/src/features/generation/worker/generators/pipeline/context.test.ts
+++ b/src/features/generation/worker/generators/pipeline/context.test.ts
@@ -92,6 +92,33 @@ describe('createInitialContext', () => {
     expect(ctx.originToTag.size).toBe(0);
   });
 
+  it('includes overhang expansion in innerW/innerD', () => {
+    const noOverhang = createInitialContext(createTestParams({ width: 2, depth: 2 }));
+    const withOverhang = createInitialContext(
+      createTestParams({
+        width: 2,
+        depth: 2,
+        overhang: { left: 5, right: 5, front: 4, back: 4 },
+      })
+    );
+    // outerW stays nominal (socket footprint unchanged)
+    expect(withOverhang.dimensions.outerW).toBeCloseTo(noOverhang.dimensions.outerW);
+    // innerW must grow by addW (10mm) so interior features use the full space
+    expect(withOverhang.dimensions.innerW).toBeCloseTo(noOverhang.dimensions.innerW + 10, 5);
+    expect(withOverhang.dimensions.innerD).toBeCloseTo(noOverhang.dimensions.innerD + 8, 5);
+  });
+
+  it('innerW/innerD are unchanged with zero overhang', () => {
+    const ctx = createInitialContext(
+      createTestParams({
+        overhang: { left: 0, right: 0, front: 0, back: 0 },
+      })
+    );
+    const baseline = createInitialContext(createTestParams());
+    expect(ctx.dimensions.innerW).toBeCloseTo(baseline.dimensions.innerW, 5);
+    expect(ctx.dimensions.innerD).toBeCloseTo(baseline.dimensions.innerD, 5);
+  });
+
   it('should use params.gridUnitMm instead of hardcoded 42mm', () => {
     const ctx = createInitialContext(createTestParams({ gridUnitMm: 50 }));
     const dim = ctx.dimensions;

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -63,13 +63,8 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
 
   const innerW = outerW + (ovhExp?.addW ?? 0) - 2 * params.wallThickness;
   const innerD = outerD + (ovhExp?.addD ?? 0) - 2 * params.wallThickness;
-  // NOTE: for symmetric overhang (left=right, front=back) ovhExp.offsetX/Y = 0 and
-  // all interior features remain correctly centred at the origin. For *asymmetric*
-  // overhang the cavity centre shifts by (offsetX, offsetY) in boxBuilder, but
-  // feature builders still place geometry at the origin, so they will be slightly
-  // off-centre. The error equals |offsetX| = |(right-left)/2| — small in practice
-  // and bounded by half the asymmetry. A follow-up should carry innerOffsetX/Y
-  // through BinDimensions and shift feature builder origins accordingly.
+  const innerOffsetX = ovhExp?.offsetX ?? 0;
+  const innerOffsetY = ovhExp?.offsetY ?? 0;
   const isSlotted = params.style === 'slotted';
 
   const withMagnet =
@@ -159,6 +154,8 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
     withScrew,
     compartmentsBakedIntoShell,
     overhang,
+    innerOffsetX,
+    innerOffsetY,
   };
 }
 

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -63,6 +63,13 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
 
   const innerW = outerW + (ovhExp?.addW ?? 0) - 2 * params.wallThickness;
   const innerD = outerD + (ovhExp?.addD ?? 0) - 2 * params.wallThickness;
+  // NOTE: for symmetric overhang (left=right, front=back) ovhExp.offsetX/Y = 0 and
+  // all interior features remain correctly centred at the origin. For *asymmetric*
+  // overhang the cavity centre shifts by (offsetX, offsetY) in boxBuilder, but
+  // feature builders still place geometry at the origin, so they will be slightly
+  // off-centre. The error equals |offsetX| = |(right-left)/2| — small in practice
+  // and bounded by half the asymmetry. A follow-up should carry innerOffsetX/Y
+  // through BinDimensions and shift feature builder origins accordingly.
   const isSlotted = params.style === 'slotted';
 
   const withMagnet =

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -30,7 +30,7 @@ import type { ProgressFn } from '../meshUtils';
 import { buildCacheKey, quantize, compactKey } from '../cacheKeyUtils';
 import type { BinDimensions, PipelineContext } from './types';
 import type { PerfCollector } from './perfCollector';
-import { resolveOverhang, overhangKey } from '../overhang';
+import { resolveOverhang, overhangKey, hasOverhang, overhangExpansion } from '../overhang';
 
 /** Derive all dimensions from bin parameters. */
 function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions {
@@ -51,8 +51,18 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
   const gridUnit = params.gridUnitMm ?? SIZE;
   const outerW = params.width * gridUnit - CLEARANCE;
   const outerD = params.depth * gridUnit - CLEARANCE;
-  const innerW = outerW - 2 * params.wallThickness;
-  const innerD = outerD - 2 * params.wallThickness;
+
+  // Resolve overhang before innerW/innerD so interior features (compartments,
+  // scoops, label tabs, etc.) see the actual available space. The box shell
+  // expands in lockstep with the overhang, so innerW/innerD must include the
+  // per-side addW/addD expansion.
+  // Overhang is suppressed for polygon masks (the mask defines its own footprint).
+  const { cellMask } = params;
+  const overhang = resolveOverhang(isPartialMask(cellMask) ? undefined : params.overhang);
+  const ovhExp = hasOverhang(overhang) ? overhangExpansion(overhang) : null;
+
+  const innerW = outerW + (ovhExp?.addW ?? 0) - 2 * params.wallThickness;
+  const innerD = outerD + (ovhExp?.addD ?? 0) - 2 * params.wallThickness;
   const isSlotted = params.style === 'slotted';
 
   const withMagnet =
@@ -97,13 +107,9 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
   // rectangular bins continue to share the existing cache bucket. The
   // compartments segment is "none" unless the bin uses the multi-cavity
   // cut path, so single-compartment bins keep their existing cache bucket.
-  const { cellMask } = params;
   const maskKeySegment = isPartialMask(cellMask) ? hashMask(cellMask) : 'rect';
   const compartmentsKey = compartmentsBakedIntoShell ? buildCompartmentsCacheKey(params) : 'none';
 
-  // Overhang is a rectangle-path feature in v1: a custom-shape mask defines its
-  // own exact footprint, so suppress overhang when a partial mask is present.
-  const overhang = resolveOverhang(isPartialMask(cellMask) ? undefined : params.overhang);
   const shellKey = compactKey(
     buildCacheKey(
       'v6',

--- a/src/features/generation/worker/generators/pipeline/featureRunner.ts
+++ b/src/features/generation/worker/generators/pipeline/featureRunner.ts
@@ -14,7 +14,7 @@
  * - One clone per path — never two
  */
 
-import { clone, unwrap } from 'brepjs';
+import { clone, translate, unwrap } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import type { PipelineContext } from './types';
 import type { FeatureBuilder } from './featureBuilder';
@@ -73,6 +73,14 @@ export function runFeatureBuilders(
     }
 
     if (shape) {
+      // Apply asymmetric-overhang cavity offset before tagging so
+      // collectOrigins maps the face IDs of the final, positioned shape.
+      const { innerOffsetX, innerOffsetY } = ctx.dimensions;
+      if (innerOffsetX !== 0 || innerOffsetY !== 0) {
+        const old = shape;
+        shape = translate(old, [innerOffsetX, innerOffsetY, 0]);
+        old.delete();
+      }
       // `clone()` drops the face-origin WeakMap (shellCache uses
       // `translate([0,0,0])` for that reason), but here it's safe because
       // `collectOrigins` re-tags the freshly cloned shape on every

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -12,6 +12,7 @@
  * for the subsequent boolean stage.
  */
 
+import { translate } from 'brepjs';
 import { isPartialMask } from '@/shared/utils/cellMask';
 import type { PipelineContext, PipelineStage } from '../types';
 import { buildCutoutCuts } from '../../featureBuilder';
@@ -42,7 +43,14 @@ export const featuresStage: PipelineStage = {
       // booleanStage early-returns when ctx.solid is null; building tools
       // we'd never apply would just leak their WASM shapes.
       if (!ctx.solid) return ctx;
-      const cutoutTools = buildCutoutCuts(params, dim.innerW, dim.innerD, dim.wallHeight);
+      const rawTools = buildCutoutCuts(params, dim.innerW, dim.innerD, dim.wallHeight);
+      const { innerOffsetX, innerOffsetY } = dim;
+      const cutoutTools = rawTools.map((tool) => {
+        if (innerOffsetX === 0 && innerOffsetY === 0) return tool;
+        const shifted = translate(tool, [innerOffsetX, innerOffsetY, 0]);
+        tool.delete();
+        return shifted;
+      });
       for (const tool of cutoutTools) {
         collectOrigins(tool, FeatureTag.CUTOUT, originToTag);
       }

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -51,9 +51,15 @@ export const shellStage: PipelineStage = {
     // path will be taken (rectangular bin + non-solid + rectangular comps).
     // The cache key in `dim.shellKey` already discriminates on the comp grid
     // so we can safely pass `undefined` for the default path.
-    const compartmentCavityDrawings = dim.compartmentsBakedIntoShell
+    const rawCavityDrawings = dim.compartmentsBakedIntoShell
       ? buildCompartmentCavityDrawings(params, dim.innerW, dim.innerD)
       : undefined;
+    // For asymmetric overhang the inner cavity centre is at (innerOffsetX, innerOffsetY);
+    // shift the cavity drawings so they cut the correct region of the box body.
+    const compartmentCavityDrawings =
+      rawCavityDrawings && (dim.innerOffsetX !== 0 || dim.innerOffsetY !== 0)
+        ? rawCavityDrawings.map((d) => d.translate(dim.innerOffsetX, dim.innerOffsetY))
+        : rawCavityDrawings;
     const compartmentCavityKey = dim.compartmentsBakedIntoShell
       ? buildCompartmentsCacheKey(params)
       : undefined;

--- a/src/features/generation/worker/generators/pipeline/types.ts
+++ b/src/features/generation/worker/generators/pipeline/types.ts
@@ -49,6 +49,15 @@ export interface BinDimensions {
    * these amounts; the base sockets stay at the nominal footprint.
    */
   readonly overhang: ResolvedOverhang;
+  /**
+   * X shift of the inner cavity centre relative to the bin origin, in mm.
+   * Equal to `(overhang.right - overhang.left) / 2`. Zero for symmetric or
+   * absent overhang. All interior feature builders translate their geometry
+   * by `(innerOffsetX, innerOffsetY)` so features stay centred in the cavity.
+   */
+  readonly innerOffsetX: number;
+  /** Y shift of the inner cavity centre — `(overhang.back - overhang.front) / 2`. */
+  readonly innerOffsetY: number;
 }
 
 /** Immutable context threaded through pipeline stages. */

--- a/src/features/generation/worker/generators/wallPatternBuilder.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.ts
@@ -14,7 +14,7 @@
  *   - `wallPatternClips`     — cutout/handle/ramp clipping passes
  */
 
-import { drawPolysides, unwrap, clone } from 'brepjs';
+import { drawPolysides, unwrap, clone, translate } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import type { PipelineContext } from './pipeline/types';
 import { LIP_HEIGHT, LIP_TAPER_WIDTH } from './generatorConstants';
@@ -66,7 +66,7 @@ import { buildClippedWallPattern } from './wallPatternCompound';
  */
 export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
   const { params, dimensions: dim, signal, originToTag, perfCollector } = ctx;
-  const { innerW, innerD, interiorHeight, hasLip } = dim;
+  const { innerW, innerD, interiorHeight, hasLip, innerOffsetX, innerOffsetY } = dim;
   const patternCutTargets: Shape3D[] = [];
 
   const patternResult = getPatternDescriptors(params, innerW, innerD, interiorHeight);
@@ -372,6 +372,11 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
       perfCollector.addHexCenters(wall.centers.length);
     }
     if (shape) {
+      if (innerOffsetX !== 0 || innerOffsetY !== 0) {
+        const old = shape;
+        shape = translate(old, [innerOffsetX, innerOffsetY, 0]);
+        old.delete();
+      }
       collectOrigins(shape, FeatureTag.WALL_PATTERN, originToTag);
       patternCutTargets.push(shape);
     }


### PR DESCRIPTION
## Summary

- `innerW` and `innerD` in `deriveDimensions` (pipeline context) were computed from nominal outer dimensions, without the per-side overhang expansion
- `boxBuilder` already added the expansion to its inner footprint, so the physical shell cavity was larger than what all interior feature builders (compartments, scoops, label tabs, wall patterns, handles, inserts) thought was available
- Interior features were therefore constrained to the smaller nominal space and didn't use the room created by the overhang

## Fix

Resolve overhang before computing `innerW`/`innerD` and include `addW`/`addD` from the overhang expansion:

```ts
// Before
const innerW = outerW - 2 * params.wallThickness;

// After
const overhang = resolveOverhang(...);
const ovhExp = hasOverhang(overhang) ? overhangExpansion(overhang) : null;
const innerW = outerW + (ovhExp?.addW ?? 0) - 2 * params.wallThickness;
```

No-overhang bins are unaffected (`addW` / `addD` = 0). Polygon-mask bins are also unaffected (overhang is already suppressed for them). The duplicate overhang resolution that appeared later in `deriveDimensions` is removed.

## Test plan

- [x] `context.test.ts` — new unit tests verify `innerW`/`innerD` grow by `addW`/`addD` with overhang and are unchanged with zero overhang
- [x] `binGenerator.scenario.overhang.test.ts` — new geometry regression test builds a bin with overhang + scoop, asserts structural validity and that the mesh differs from the no-overhang counterpart (confirming scoop uses the expanded interior)
- [x] All 6 overhang scenario tests pass
- [x] All 14 context unit tests pass
- [x] TypeScript and ESLint clean