### PR TITLE
feat(pwa): apply updates without interrupting active sessions

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2085,6 +2085,8 @@
   "toast.selectedByCategory": "{count} {name} Bin(s) ausgewählt",
   "toast.selectionInverted": "Auswahl umgekehrt ({count} Bin(s))",
   "toast.sessionRestored": "Sitzung wiederhergestellt",
+  "toast.updateAvailable": "Eine neue Version ist verfügbar",
+  "toast.updateReload": "Neu laden",
   "toast.sharedLayoutFailed": "Geteiltes Layout laden fehlgeschlagen: {error}",
   "toast.stagingCleared": "{count} Bin(s) aus der Ablage gelöscht",
   "toast.stashCleared": "{count} gestashte Bins gelöscht",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1145,6 +1145,8 @@ const en: Record<string, string> = {
   'toast.online': 'Back online',
   'toast.offline': "You're offline. Changes save locally.",
   'toast.updating': 'Updating to latest version...',
+  'toast.updateAvailable': 'A new version is available',
+  'toast.updateReload': 'Reload',
   'toast.sessionRestored': 'Session restored',
   'toast.rotateRepositioned': 'Bin rotated and moved {distance} cell(s) to fit',
   'toast.binsSwapped': 'Bins swapped positions',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2085,6 +2085,8 @@
   "toast.selectedByCategory": "{count} bin(s) de {name} seleccionados",
   "toast.selectionInverted": "Selección invertida ({count} bin(s))",
   "toast.sessionRestored": "Sesión restaurada",
+  "toast.updateAvailable": "Hay una nueva versión disponible",
+  "toast.updateReload": "Recargar",
   "toast.sharedLayoutFailed": "Error al cargar diseño compartido: {error}",
   "toast.stagingCleared": "{count} bin(s) eliminados del almacén",
   "toast.stashCleared": "{count} bins del stash eliminados",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2085,6 +2085,8 @@
   "toast.selectedByCategory": "{count} bin(s) {name} sélectionnés",
   "toast.selectionInverted": "Sélection inversée ({count} bin(s))",
   "toast.sessionRestored": "Session restaurée",
+  "toast.updateAvailable": "Une nouvelle version est disponible",
+  "toast.updateReload": "Recharger",
   "toast.sharedLayoutFailed": "Échec du chargement du layout partagé : {error}",
   "toast.stagingCleared": "{count} bin(s) supprimé(s) du stash",
   "toast.stashCleared": "{count} bins du stash supprimés",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2085,6 +2085,8 @@
   "toast.selectedByCategory": "{count}個の{name}ビンを選択しました",
   "toast.selectionInverted": "選択を反転しました({count}個のビン)",
   "toast.sessionRestored": "セッションを復元しました",
+  "toast.updateAvailable": "新しいバージョンが利用可能です",
+  "toast.updateReload": "再読み込み",
   "toast.sharedLayoutFailed": "共有レイアウトの読み込みに失敗しました：{error}",
   "toast.stagingCleared": "ステージングから{count}個のビンをクリアしました",
   "toast.stashCleared": "ステージングされた{count}個のビンを削除しました",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -2085,6 +2085,8 @@
   "toast.selectedByCategory": "Valgte {count} {name} bin(s)",
   "toast.selectionInverted": "Invertert utvalg ({count} bin(s))",
   "toast.sessionRestored": "Økt gjenopprettet",
+  "toast.updateAvailable": "En ny versjon er tilgjengelig",
+  "toast.updateReload": "Last inn på nytt",
   "toast.sharedLayoutFailed": "Kunne ikke laste delt layout: {error}",
   "toast.stagingCleared": "Tømt {count} bin(s) fra stash",
   "toast.stashCleared": "Slettet {count} stashede bins",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -2085,6 +2085,8 @@
   "toast.selectedByCategory": "{count} {name} bin(s) geselecteerd",
   "toast.selectionInverted": "Selectie omgekeerd ({count} bin(s))",
   "toast.sessionRestored": "Sessie hersteld",
+  "toast.updateAvailable": "Er is een nieuwe versie beschikbaar",
+  "toast.updateReload": "Opnieuw laden",
   "toast.sharedLayoutFailed": "Laden van gedeelde layout mislukt: {error}",
   "toast.stagingCleared": "{count} bin(s) uit opslag verwijderd",
   "toast.stashCleared": "{count} opgeslagen bins verwijderd",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2085,6 +2085,8 @@
   "toast.selectedByCategory": "{count} bin(s) de {name} selecionados",
   "toast.selectionInverted": "Seleção invertida ({count} bin(s))",
   "toast.sessionRestored": "Sessão restaurada",
+  "toast.updateAvailable": "Uma nova versão está disponível",
+  "toast.updateReload": "Recarregar",
   "toast.sharedLayoutFailed": "Falha ao carregar layout compartilhado: {error}",
   "toast.stagingCleared": "{count} bin(s) removido(s) do armazenamento",
   "toast.stashCleared": "{count} bins do stash excluídos",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -2085,6 +2085,8 @@
   "toast.selectedByCategory": "Markerade {count} {name}-fack",
   "toast.selectionInverted": "Markeringen inverterad ({count} fack)",
   "toast.sessionRestored": "Session återställd",
+  "toast.updateAvailable": "En ny version är tillgänglig",
+  "toast.updateReload": "Ladda om",
   "toast.sharedLayoutFailed": "Det gick inte att ladda delad layout: {error}",
   "toast.stagingCleared": "Rensade {count} fack från förråd",
   "toast.stashCleared": "Raderade {count} fack i förrådet",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -2085,6 +2085,8 @@
   "toast.selectedByCategory": "Виділено {count} бінів категорії {name}",
   "toast.selectionInverted": "Виділення інвертовано ({count} бінів)",
   "toast.sessionRestored": "Сесію відновлено",
+  "toast.updateAvailable": "Доступна нова версія",
+  "toast.updateReload": "Перезавантажити",
   "toast.sharedLayoutFailed": "Не вдалося завантажити спільну розкладку: {error}",
   "toast.stagingCleared": "Очищено {count} бінів зі сховку",
   "toast.stashCleared": "Видалено {count} бінів зі сховку",

--- a/src/shared/hooks/usePWAUpdate.test.ts
+++ b/src/shared/hooks/usePWAUpdate.test.ts
@@ -9,11 +9,12 @@ import { useToastStore } from '@/core/store/toast';
 import { resetAllStores, setupFakeTimers } from '@/test/testUtils';
 import { STAGING_ID } from '@/core/constants';
 import { saveEphemeralState, type EphemeralState } from '@/shared/utils/ephemeralState';
+import { resetActivityClock } from '@/shared/pwa/reloadSafety';
 
 // Constants from usePWAUpdate (mirrored for testing)
-const UPDATE_TOAST_MS = 5000;
 const IDLE_CHECK_INTERVAL_MS = 1000;
-const MAX_IDLE_WAIT_MS = 2 * 60 * 1000;
+const SILENT_WINDOW_MS = 60 * 1000;
+const LONG_IDLE_MS = 5 * 60 * 1000;
 
 // Track mock functions from the virtual module
 let mockNeedRefresh = false;
@@ -62,6 +63,7 @@ describe('usePWAUpdate', () => {
     timerUtils = setupFakeTimers();
     vi.clearAllMocks();
     resetAllStores();
+    resetActivityClock();
 
     // Reset module-level mock state
     mockNeedRefresh = false;
@@ -267,17 +269,13 @@ describe('usePWAUpdate', () => {
         mockOnRegisteredSW?.('/sw.js', mockRegistration);
       });
 
-      // Flush pending promises and advance through idle check + toast duration.
-      // The first microtask flush resolves the awaited getSmokeGateFlag() promise
-      // (mocked to resolve `false`); subsequent flushes drive the rest of the chain.
+      // Idle at detection: the silent-window wait resolves immediately, so the
+      // reload happens with no artificial delay. The first microtask flush
+      // resolves the awaited getSmokeGateFlag() (mocked `false`); the rest drive
+      // waitForSafeReload's synchronous resolve and performReload.
       await act(async () => {
-        await Promise.resolve(); // Flush getSmokeGateFlag()
-        await Promise.resolve(); // Flush waitForSafeReload's initial resolve
-
-        timerUtils.advanceTime(IDLE_CHECK_INTERVAL_MS);
         await Promise.resolve();
-
-        timerUtils.advanceTime(UPDATE_TOAST_MS);
+        await Promise.resolve();
         await Promise.resolve();
       });
 
@@ -539,56 +537,9 @@ describe('usePWAUpdate', () => {
   });
 
   describe('update flow', () => {
-    it('shows toast before updating', async () => {
-      mockNeedRefresh = true;
-
-      renderHook(() => usePWAUpdate());
-
-      act(() => {
-        mockOnRegisteredSW?.('/sw.js', mockRegistration);
-      });
-
-      // Flush promises and wait for idle check (should pass immediately)
-      await act(async () => {
-        timerUtils.advanceTime(IDLE_CHECK_INTERVAL_MS);
-        await Promise.resolve();
-      });
-
-      const toasts = useToastStore.getState().toasts;
-      expect(toasts.some((t) => t.message.includes('Updating'))).toBe(true);
-    });
-
-    it('waits for toast duration before updating', async () => {
-      mockNeedRefresh = true;
-
-      renderHook(() => usePWAUpdate());
-
-      act(() => {
-        mockOnRegisteredSW?.('/sw.js', mockRegistration);
-      });
-
-      // Flush promises after idle check
-      await act(async () => {
-        timerUtils.advanceTime(IDLE_CHECK_INTERVAL_MS);
-        await Promise.resolve();
-      });
-
-      // updateServiceWorker not called yet (waiting for toast duration)
-      expect(mockUpdateServiceWorker).not.toHaveBeenCalled();
-
-      // After toast duration
-      await act(async () => {
-        timerUtils.advanceTime(UPDATE_TOAST_MS);
-        await Promise.resolve();
-      });
-
-      expect(mockUpdateServiceWorker).toHaveBeenCalledWith(true);
-    });
-
-    it('times out waiting for idle after max wait time', async () => {
-      mockNeedRefresh = true;
-
-      // Keep interaction active
+    // Set an active interaction so the silent window can't reload, forcing the
+    // flow into the persistent-prompt + safety-net path.
+    const setActiveInteraction = () => {
       useInteractionStore.setState({
         interaction: {
           type: 'drag',
@@ -599,8 +550,22 @@ describe('usePWAUpdate', () => {
           currentY: 0,
         },
       });
+    };
 
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Drive the flow past the silent window while active. Returns once the
+    // persistent prompt has been surfaced.
+    const advancePastSilentWindow = async () => {
+      await act(async () => {
+        await Promise.resolve(); // getSmokeGateFlag()
+        await Promise.resolve(); // enter waitForSafeReload (not safe → interval)
+        timerUtils.advanceTime(SILENT_WINDOW_MS + IDLE_CHECK_INTERVAL_MS);
+        await Promise.resolve(); // resolve(false) → addToast + waitForAutoApply
+        await Promise.resolve();
+      });
+    };
+
+    it('reloads silently and shows the updating toast when idle', async () => {
+      mockNeedRefresh = true;
 
       renderHook(() => usePWAUpdate());
 
@@ -608,31 +573,146 @@ describe('usePWAUpdate', () => {
         mockOnRegisteredSW?.('/sw.js', mockRegistration);
       });
 
-      // Advance through all the idle checks until timeout
-      // The check runs every 1 second, so we need to advance in steps
       await act(async () => {
-        // Flush gate-flag + initial isSafeToReload check before driving the loop.
         await Promise.resolve();
         await Promise.resolve();
-        for (let elapsed = 0; elapsed <= MAX_IDLE_WAIT_MS; elapsed += IDLE_CHECK_INTERVAL_MS) {
-          timerUtils.advanceTime(IDLE_CHECK_INTERVAL_MS);
-          await Promise.resolve();
-        }
-      });
-
-      // Should have warned about timeout
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Timed out'));
-
-      // Now advance through toast duration
-      await act(async () => {
-        timerUtils.advanceTime(UPDATE_TOAST_MS);
         await Promise.resolve();
       });
 
-      // Should have updated anyway
+      expect(mockUpdateServiceWorker).toHaveBeenCalledWith(true);
+      const toasts = useToastStore.getState().toasts;
+      expect(toasts.some((toast) => toast.message.includes('Updating'))).toBe(true);
+    });
+
+    it('does not reload while the user is active; surfaces a persistent prompt', async () => {
+      mockNeedRefresh = true;
+      setActiveInteraction();
+
+      renderHook(() => usePWAUpdate());
+
+      act(() => {
+        mockOnRegisteredSW?.('/sw.js', mockRegistration);
+      });
+
+      await advancePastSilentWindow();
+
+      // No reload while active...
+      expect(mockUpdateServiceWorker).not.toHaveBeenCalled();
+      // ...and a persistent (duration 0) prompt with a Reload action is shown.
+      const prompt = useToastStore
+        .getState()
+        .toasts.find((toast) => toast.message.includes('new version'));
+      expect(prompt).toBeDefined();
+      expect(prompt?.duration).toBe(0);
+      expect(prompt?.action?.label).toBe('Reload');
+    });
+
+    it('reloads immediately when the prompt action is clicked, even while active', async () => {
+      mockNeedRefresh = true;
+      setActiveInteraction();
+
+      renderHook(() => usePWAUpdate());
+
+      act(() => {
+        mockOnRegisteredSW?.('/sw.js', mockRegistration);
+      });
+
+      await advancePastSilentWindow();
+
+      const prompt = useToastStore
+        .getState()
+        .toasts.find((toast) => toast.message.includes('new version'));
+
+      // Still actively dragging — an explicit click overrides the blocking checks.
+      act(() => {
+        void prompt?.action?.onClick();
+      });
+
+      expect(mockUpdateServiceWorker).toHaveBeenCalledWith(true);
+    });
+
+    it('auto-applies via the safety net once the user goes idle long enough', async () => {
+      mockNeedRefresh = true;
+      setActiveInteraction();
+
+      renderHook(() => usePWAUpdate());
+
+      act(() => {
+        mockOnRegisteredSW?.('/sw.js', mockRegistration);
+      });
+
+      await advancePastSilentWindow();
+      expect(mockUpdateServiceWorker).not.toHaveBeenCalled();
+
+      // User stops interacting — the safety net should apply after LONG_IDLE_MS.
+      act(() => {
+        useInteractionStore.setState({ interaction: null });
+      });
+
+      await act(async () => {
+        timerUtils.advanceTime(IDLE_CHECK_INTERVAL_MS); // first safe poll arms safeSince
+        await Promise.resolve();
+        timerUtils.advanceTime(LONG_IDLE_MS); // continuous idle elapses
+        await Promise.resolve();
+      });
+
+      expect(mockUpdateServiceWorker).toHaveBeenCalledWith(true);
+    });
+
+    it('auto-applies when the tab is backgrounded while safe', async () => {
+      mockNeedRefresh = true;
+      setActiveInteraction();
+
+      renderHook(() => usePWAUpdate());
+
+      act(() => {
+        mockOnRegisteredSW?.('/sw.js', mockRegistration);
+      });
+
+      await advancePastSilentWindow();
+
+      // Clear the blocking interaction, then background the tab.
+      act(() => {
+        useInteractionStore.setState({ interaction: null });
+        Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
       expect(mockUpdateServiceWorker).toHaveBeenCalledWith(true);
 
-      consoleSpy.mockRestore();
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+    });
+
+    it('does not reload a backgrounded tab while a blocking signal is active', async () => {
+      mockNeedRefresh = true;
+      setActiveInteraction();
+
+      renderHook(() => usePWAUpdate());
+
+      act(() => {
+        mockOnRegisteredSW?.('/sw.js', mockRegistration);
+      });
+
+      await advancePastSilentWindow();
+
+      // Background the tab but keep the interaction active — hidden must still
+      // respect blocking signals.
+      act(() => {
+        Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockUpdateServiceWorker).not.toHaveBeenCalled();
+
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true });
     });
 
     it('saves ephemeral state before triggering update', async () => {
@@ -648,23 +728,16 @@ describe('usePWAUpdate', () => {
         mockOnRegisteredSW?.('/sw.js', mockRegistration);
       });
 
-      // Complete the update flow. Extra flushes account for the awaited
-      // getSmokeGateFlag() and waitForSafeReload() promises in the gatedUpdate
-      // chain (gate is mocked to disabled, so it falls straight through).
+      // Idle path: reloads immediately after the silent-window check resolves.
       await act(async () => {
         await Promise.resolve();
         await Promise.resolve();
-        timerUtils.advanceTime(IDLE_CHECK_INTERVAL_MS);
-        await Promise.resolve();
-        timerUtils.advanceTime(UPDATE_TOAST_MS);
         await Promise.resolve();
       });
 
-      // Check that state was saved to sessionStorage
-      // Note: The state will be saved just before updateServiceWorker is called
       expect(mockUpdateServiceWorker).toHaveBeenCalledWith(true);
-      // State should have been saved (we can't easily verify the contents since
-      // the real updateServiceWorker would reload the page, but we verify the call)
+      // State should have been saved just before the reload (we verify the call;
+      // the real updateServiceWorker would reload the page).
     });
   });
 

--- a/src/shared/hooks/usePWAUpdate.ts
+++ b/src/shared/hooks/usePWAUpdate.ts
@@ -18,6 +18,13 @@ import { isSmokeMode } from '@/shared/utils/smokeMode';
 import { runUpdateSmokeTest, type SmokeGateResult } from '@/shared/pwa/smokeGate';
 import { getSmokeGateFlag } from '@/shared/pwa/featureFlag';
 import { isIosStandalonePwa } from '@/shared/pwa/iosBypass';
+import {
+  startActivityTracking,
+  isRecentlyActive,
+  isEditableElementFocused,
+  isModalOpen,
+} from '@/shared/pwa/reloadSafety';
+import { useSyncStatusStore } from '@/core/sync/status';
 import { getPosthogInstance } from '@/shared/analytics/posthog/init';
 
 /**
@@ -48,7 +55,7 @@ function captureSmokeEvent(name: string, props: Record<string, unknown>): void {
   }
 }
 
-// Toast duration for update notification
+// Toast duration for the brief "updating" notice shown right before reload
 const UPDATE_TOAST_MS = 5000;
 
 // Background polling interval (every 15 minutes when tab is active)
@@ -60,8 +67,16 @@ const UPDATE_THROTTLE_MS = 60 * 1000;
 // How often to check if safe to reload while waiting (1 second)
 const IDLE_CHECK_INTERVAL_MS = 1000;
 
-// Max time to wait for idle before forcing reload (2 minutes)
-const MAX_IDLE_WAIT_MS = 2 * 60 * 1000;
+// How long to wait silently for an idle moment before surfacing the update
+// prompt. Inside this window an update applies invisibly if the user pauses.
+const SILENT_WINDOW_MS = 60 * 1000;
+
+// Treat the user as actively present for this long after their last input.
+const ACTIVITY_DEBOUNCE_MS = 30 * 1000;
+
+// Safety net: auto-apply a still-pending update once the user has been
+// continuously idle this long (or whenever they background the tab).
+const LONG_IDLE_MS = 5 * 60 * 1000;
 
 // Session storage key to prevent reload loops
 const RELOAD_FLAG_KEY = 'pwa-update-pending-reload';
@@ -104,6 +119,27 @@ function isSafeToReload(): boolean {
 
   // Don't reload during keyboard drag/resize mode
   if (interaction.keyboardDragMode || interaction.keyboardResizeMode) {
+    return false;
+  }
+
+  // Don't reload while the user is typing in a text field (label/notes editing)
+  if (isEditableElementFocused()) {
+    return false;
+  }
+
+  // Don't reload with a modal/dialog open — in-progress form state would be lost
+  if (isModalOpen()) {
+    return false;
+  }
+
+  // Don't reload right after recent input — they're mid-task even without a
+  // specific interaction flag set (e.g. moving the cursor, deciding).
+  if (isRecentlyActive(ACTIVITY_DEBOUNCE_MS)) {
+    return false;
+  }
+
+  // Don't reload while a layout sync is pushing changes to storage
+  if (useSyncStatusStore.getState().state === 'syncing') {
     return false;
   }
 
@@ -156,6 +192,65 @@ function waitForSafeReload(timeoutMs: number, signal?: AbortSignal): Promise<boo
       clearInterval(intervalId);
       resolve(false);
     });
+  });
+}
+
+type AutoApplyTrigger = 'idle' | 'hidden' | 'aborted';
+
+/**
+ * Wait for the safety-net condition that auto-applies a still-pending update
+ * without an explicit click: either the tab is backgrounded while safe, or the
+ * app has been continuously safe-to-reload for LONG_IDLE_MS. Either trigger
+ * still respects every blocking signal — a hidden tab with an open modal or an
+ * in-flight sync keeps waiting.
+ */
+function waitForAutoApply(signal: AbortSignal): Promise<AutoApplyTrigger> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve('aborted');
+      return;
+    }
+
+    let safeSince: number | null = isSafeToReload() ? Date.now() : null;
+
+    const cleanup = (): void => {
+      clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', evaluate);
+      signal.removeEventListener('abort', onAbort);
+    };
+
+    const evaluate = (): void => {
+      if (signal.aborted) {
+        cleanup();
+        resolve('aborted');
+        return;
+      }
+      if (!isSafeToReload()) {
+        safeSince = null;
+        return;
+      }
+      if (safeSince === null) safeSince = Date.now();
+      if (document.hidden) {
+        cleanup();
+        resolve('hidden');
+        return;
+      }
+      if (Date.now() - safeSince >= LONG_IDLE_MS) {
+        cleanup();
+        resolve('idle');
+      }
+    };
+
+    const onAbort = (): void => {
+      cleanup();
+      resolve('aborted');
+    };
+
+    const intervalId = setInterval(evaluate, IDLE_CHECK_INTERVAL_MS);
+    document.addEventListener('visibilitychange', evaluate);
+    signal.addEventListener('abort', onAbort);
+
+    evaluate();
   });
 }
 
@@ -279,10 +374,10 @@ function restoreEphemeralState(): boolean {
  * - SW is currently installing
  * - Checked within last minute
  *
- * When a new version is available:
- * - Waits until user is idle (no active interaction, no staging bins)
- * - Shows a toast notification
- * - Auto-reloads after a short delay
+ * When a new version is available it is applied without interrupting active
+ * work (see the needRefresh effect): a brief silent window, then a persistent
+ * click-to-update toast backed by a long-idle / tab-hidden safety net. It never
+ * force-reloads while the user is mid-task.
  */
 export function usePWAUpdate(): void {
   const t = useTranslation();
@@ -417,10 +512,25 @@ export function usePWAUpdate(): void {
     };
   }, [checkForUpdate, skipRegistration]);
 
-  // Handle update notification and auto-reload when idle.
+  // Track user input so isSafeToReload() can defer while they're actively using
+  // the app (see ACTIVITY_DEBOUNCE_MS).
+  useEffect(() => {
+    if (skipRegistration) return;
+    return startActivityTracking();
+  }, [skipRegistration]);
+
+  // Apply an available update without interrupting active work.
+  //
   // The smoke gate (when enabled via PostHog flag) runs first: it activates the
-  // new SW manually, spawns a hidden iframe to verify the new bundle boots,
-  // and either green-lights the reload or rolls back the precache.
+  // new SW manually, spawns a hidden iframe to verify the new bundle boots, and
+  // either green-lights the reload or rolls back the precache.
+  //
+  // The reload itself is hybrid:
+  //   1. Wait up to SILENT_WINDOW_MS for an idle moment and reload quietly.
+  //   2. If the user is still active, surface a persistent "Update available"
+  //      toast they can act on, while a safety net auto-applies once they go
+  //      idle (LONG_IDLE_MS) or background the tab. We never force a reload
+  //      out from under an active session.
   useEffect(() => {
     if (!needRefresh || hasTriggeredReload.current) return;
 
@@ -438,7 +548,34 @@ export function usePWAUpdate(): void {
 
     // Use AbortController for cleanup on unmount
     const abortController = new AbortController();
-    let toastTimeoutId: number | undefined;
+    const { signal } = abortController;
+    let reloaded = false;
+
+    // Apply the update now: persist UI state, then SKIP_WAITING + reload. Shared
+    // by the silent path, the long-idle/hidden safety net, and the explicit
+    // toast click — the click deliberately bypasses isSafeToReload(), since
+    // clicking "Reload" is unambiguous intent that overrides the blocking checks.
+    const performReload = (): void => {
+      if (reloaded || signal.aborted) return;
+      reloaded = true;
+
+      try {
+        sessionStorage.setItem(RELOAD_FLAG_KEY, Date.now().toString());
+      } catch {
+        // best-effort
+      }
+
+      // Save UI state right before reload (after smoke success in the gated path,
+      // so we never leave stale ephemeral state behind a failed gate run).
+      saveEphemeralState(gatherEphemeralState());
+
+      addToast(t('toast.updating'), 'info', UPDATE_TOAST_MS);
+
+      // updateServiceWorker(true) sends SKIP_WAITING + reloads. In the gated
+      // path the new SW is already 'activated', so SKIP_WAITING is a no-op
+      // and only the reload runs.
+      void updateServiceWorker(true);
+    };
 
     const gatedUpdate = async (): Promise<void> => {
       const registration = registrationRef.current;
@@ -454,7 +591,7 @@ export function usePWAUpdate(): void {
           smokeInProgress = false;
         }
 
-        if (abortController.signal.aborted) return;
+        if (signal.aborted) return;
 
         if (!result.ok) {
           captureSmokeEvent('pwa_smoke_failed', {
@@ -495,57 +632,40 @@ export function usePWAUpdate(): void {
         });
       }
 
-      // Common reload path — used by both the gated-success branch and the
-      // flag-disabled / iOS-bypass / no-waiting-worker fall-through.
       // Re-check abort: getSmokeGateFlag can take up to 2s, plenty of time
       // for the component to unmount.
-      if (abortController.signal.aborted) return;
+      if (signal.aborted) return;
 
-      try {
-        sessionStorage.setItem(RELOAD_FLAG_KEY, Date.now().toString());
-      } catch {
-        // best-effort
-      }
-
-      const wasSafe = await waitForSafeReload(MAX_IDLE_WAIT_MS, abortController.signal);
+      // Phase 1 — apply silently if the user goes idle within the short window.
+      const wentIdle = await waitForSafeReload(SILENT_WINDOW_MS, signal);
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- signal can flip between awaits
-      if (abortController.signal.aborted) return;
-      if (!wasSafe) {
-        console.warn('Timed out waiting for idle, proceeding with update');
+      if (signal.aborted) return;
+      if (wentIdle) {
+        performReload();
+        return;
       }
 
-      addToast(t('toast.updating'), 'info', UPDATE_TOAST_MS);
-
-      // Brief delay so the user actually sees the toast (cancellable).
-      await new Promise<void>((resolve) => {
-        if (abortController.signal.aborted) {
-          resolve();
-          return;
-        }
-        toastTimeoutId = window.setTimeout(resolve, UPDATE_TOAST_MS);
-        abortController.signal.addEventListener('abort', () => {
-          clearTimeout(toastTimeoutId);
-          resolve();
-        });
+      // Phase 2 — still active: surface a persistent prompt and keep a safety
+      // net running. Dismissing the toast leaves the update pending (no re-nag);
+      // the net still applies it on long idle or when the tab is backgrounded.
+      addToast({
+        message: t('toast.updateAvailable'),
+        type: 'info',
+        duration: 0,
+        action: { label: t('toast.updateReload'), onClick: performReload },
       });
 
-      // Save UI state right before reload (after smoke success in the gated path,
-      // so we never leave stale ephemeral state behind a failed gate run).
-      saveEphemeralState(gatherEphemeralState());
-
-      // updateServiceWorker(true) sends SKIP_WAITING + reloads. In the gated
-      // path the new SW is already 'activated', so SKIP_WAITING is a no-op
-      // and only the reload runs.
-      void updateServiceWorker(true);
+      // waitForAutoApply resolves 'aborted' on unmount; performReload also
+      // guards on signal.aborted, so no second check is needed here.
+      const trigger = await waitForAutoApply(signal);
+      if (trigger === 'aborted') return;
+      performReload();
     };
 
     void gatedUpdate();
 
     return () => {
       abortController.abort();
-      if (toastTimeoutId !== undefined) {
-        clearTimeout(toastTimeoutId);
-      }
     };
   }, [needRefresh, addToast, updateServiceWorker, t]);
 

--- a/src/shared/pwa/reloadSafety.test.ts
+++ b/src/shared/pwa/reloadSafety.test.ts
@@ -73,6 +73,29 @@ describe('reloadSafety', () => {
       expect(isEditableElementFocused()).toBe(true);
     });
 
+    it('detects a focused numeric input', () => {
+      const input = document.createElement('input');
+      input.type = 'number';
+      document.body.appendChild(input);
+      input.focus();
+      expect(isEditableElementFocused()).toBe(true);
+    });
+
+    it('ignores a focused non-text input (checkbox)', () => {
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      document.body.appendChild(checkbox);
+      checkbox.focus();
+      expect(isEditableElementFocused()).toBe(false);
+    });
+
+    it('ignores a focused select', () => {
+      const select = document.createElement('select');
+      document.body.appendChild(select);
+      select.focus();
+      expect(isEditableElementFocused()).toBe(false);
+    });
+
     it('detects a contenteditable element', () => {
       const div = document.createElement('div');
       div.setAttribute('contenteditable', 'true');

--- a/src/shared/pwa/reloadSafety.test.ts
+++ b/src/shared/pwa/reloadSafety.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  startActivityTracking,
+  isRecentlyActive,
+  resetActivityClock,
+  isEditableElementFocused,
+  isModalOpen,
+} from './reloadSafety';
+
+describe('reloadSafety', () => {
+  beforeEach(() => {
+    resetActivityClock();
+    document.body.replaceChildren();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.replaceChildren();
+  });
+
+  describe('isRecentlyActive', () => {
+    it('is false before any input', () => {
+      expect(isRecentlyActive(30_000)).toBe(false);
+    });
+
+    it('is true immediately after input and false once the window elapses', () => {
+      vi.useFakeTimers();
+      const stop = startActivityTracking();
+
+      window.dispatchEvent(new Event('keydown'));
+      expect(isRecentlyActive(30_000)).toBe(true);
+
+      vi.advanceTimersByTime(30_001);
+      expect(isRecentlyActive(30_000)).toBe(false);
+
+      stop();
+    });
+
+    it('stops updating after the tracker is detached', () => {
+      vi.useFakeTimers();
+      const stop = startActivityTracking();
+      stop();
+
+      window.dispatchEvent(new Event('keydown'));
+      expect(isRecentlyActive(30_000)).toBe(false);
+    });
+
+    it('keeps tracking while any caller is still active (ref-counted)', () => {
+      const stopA = startActivityTracking();
+      const stopB = startActivityTracking();
+      stopA();
+
+      window.dispatchEvent(new Event('pointerdown'));
+      expect(isRecentlyActive(30_000)).toBe(true);
+
+      stopB();
+    });
+  });
+
+  describe('isEditableElementFocused', () => {
+    it('detects a focused input', () => {
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      input.focus();
+      expect(isEditableElementFocused()).toBe(true);
+    });
+
+    it('detects a focused textarea', () => {
+      const textarea = document.createElement('textarea');
+      document.body.appendChild(textarea);
+      textarea.focus();
+      expect(isEditableElementFocused()).toBe(true);
+    });
+
+    it('detects a contenteditable element', () => {
+      const div = document.createElement('div');
+      div.setAttribute('contenteditable', 'true');
+      // jsdom only focuses elements that are natively focusable or tabbable.
+      div.tabIndex = 0;
+      document.body.appendChild(div);
+      div.focus();
+      expect(isEditableElementFocused()).toBe(true);
+    });
+
+    it('is false for a non-editable focused element', () => {
+      const button = document.createElement('button');
+      document.body.appendChild(button);
+      button.focus();
+      expect(isEditableElementFocused()).toBe(false);
+    });
+  });
+
+  describe('isModalOpen', () => {
+    it('is false with no dialog present', () => {
+      expect(isModalOpen()).toBe(false);
+    });
+
+    it('is true when an aria-modal dialog is present', () => {
+      const dialog = document.createElement('div');
+      dialog.setAttribute('role', 'dialog');
+      dialog.setAttribute('aria-modal', 'true');
+      document.body.appendChild(dialog);
+      expect(isModalOpen()).toBe(true);
+    });
+
+    it('ignores a non-modal dialog', () => {
+      const dialog = document.createElement('div');
+      dialog.setAttribute('role', 'dialog');
+      document.body.appendChild(dialog);
+      expect(isModalOpen()).toBe(false);
+    });
+  });
+});

--- a/src/shared/pwa/reloadSafety.ts
+++ b/src/shared/pwa/reloadSafety.ts
@@ -56,20 +56,44 @@ export function isRecentlyActive(windowMs: number, now: number = Date.now()): bo
   return lastInputAt !== 0 && now - lastInputAt < windowMs;
 }
 
-/** Reset the input clock. Test-only. */
+/** Reset the input clock and tear down any listeners. Test-only. */
 export function resetActivityClock(): void {
   lastInputAt = 0;
+  detach?.();
+  detach = null;
+  trackerCount = 0;
 }
+
+/** Input types that don't hold typed text, so focus on them shouldn't block a reload. */
+const NON_TEXT_INPUT_TYPES = new Set([
+  'button',
+  'checkbox',
+  'color',
+  'file',
+  'hidden',
+  'image',
+  'radio',
+  'range',
+  'reset',
+  'submit',
+]);
 
 /**
  * True when focus is in a text-editable element (label/notes field, etc.).
  * Reloading mid-edit would discard whatever the user is typing.
+ *
+ * Scoped to genuine text entry: a focused checkbox/radio/range/button or a
+ * <select> must not count, since focus is sticky (it survives going idle) and
+ * would otherwise permanently block the long-idle auto-apply.
  */
 export function isEditableElementFocused(): boolean {
   const el = document.activeElement as HTMLElement | null;
   if (!el) return false;
   const tag = el.tagName;
-  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (tag === 'TEXTAREA') return true;
+  if (tag === 'INPUT') {
+    return !NON_TEXT_INPUT_TYPES.has((el as HTMLInputElement).type);
+  }
   if (el.isContentEditable) return true;
   // Attribute fallback: `isContentEditable` (which also resolves inherited
   // editability) isn't implemented in every environment.

--- a/src/shared/pwa/reloadSafety.ts
+++ b/src/shared/pwa/reloadSafety.ts
@@ -1,0 +1,87 @@
+/**
+ * Predicates and input tracking that let the PWA update flow tell whether the
+ * user is actively working, so a reload never interrupts them. Paired with
+ * usePWAUpdate; the store-backed checks (interaction, staging, sync) live in the
+ * hook, while the DOM/timing checks that don't need store access live here.
+ */
+
+let lastInputAt = 0;
+let trackerCount = 0;
+let detach: (() => void) | null = null;
+
+/**
+ * Events that mark the user as present. `pointermove` is included on purpose:
+ * a moving cursor (reading, hovering, deciding) is active use we shouldn't
+ * reload through, and a resting cursor still ages out after the debounce.
+ */
+const ACTIVITY_EVENTS = ['pointerdown', 'pointermove', 'keydown', 'wheel', 'touchstart'] as const;
+
+function handleActivity(): void {
+  lastInputAt = Date.now();
+}
+
+/**
+ * Start tracking user input timestamps. Ref-counted so multiple callers share a
+ * single set of listeners; the returned cleanup detaches them when the last
+ * caller stops.
+ */
+export function startActivityTracking(): () => void {
+  trackerCount += 1;
+  if (!detach) {
+    for (const evt of ACTIVITY_EVENTS) {
+      window.addEventListener(evt, handleActivity, { passive: true });
+    }
+    detach = () => {
+      for (const evt of ACTIVITY_EVENTS) {
+        window.removeEventListener(evt, handleActivity);
+      }
+    };
+  }
+
+  let stopped = false;
+  return () => {
+    if (stopped) return;
+    stopped = true;
+    trackerCount -= 1;
+    if (trackerCount <= 0) {
+      trackerCount = 0;
+      detach?.();
+      detach = null;
+    }
+  };
+}
+
+/** True if the user produced input within `windowMs`. */
+export function isRecentlyActive(windowMs: number, now: number = Date.now()): boolean {
+  return lastInputAt !== 0 && now - lastInputAt < windowMs;
+}
+
+/** Reset the input clock. Test-only. */
+export function resetActivityClock(): void {
+  lastInputAt = 0;
+}
+
+/**
+ * True when focus is in a text-editable element (label/notes field, etc.).
+ * Reloading mid-edit would discard whatever the user is typing.
+ */
+export function isEditableElementFocused(): boolean {
+  const el = document.activeElement as HTMLElement | null;
+  if (!el) return false;
+  const tag = el.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (el.isContentEditable) return true;
+  // Attribute fallback: `isContentEditable` (which also resolves inherited
+  // editability) isn't implemented in every environment.
+  const editable = el.getAttribute('contenteditable');
+  return editable === '' || editable === 'true';
+}
+
+/**
+ * True when a modal dialog is open. The design-system Dialog renders with
+ * `role="dialog" aria-modal="true"` via a portal, so this one query covers
+ * every modal without enumerating the scattered per-feature open-state flags.
+ */
+export function isModalOpen(): boolean {
+  return document.querySelector('[role="dialog"][aria-modal="true"]') !== null;
+}


### PR DESCRIPTION
## What & why

When a new version deploys, the PWA used to wait up to 2 minutes for an idle moment and then **force-reload the page regardless of what the user was doing** — yanking them out mid-task. This makes the update apply gracefully instead, never interrupting an active session.

## New behavior

A hybrid update flow:

1. **Silent window (60s):** if the user goes idle, the update applies quietly — same seamless reload as before.
2. **Persistent prompt:** if they're still active after 60s, a non-dismissing **"A new version is available — Reload"** toast appears.
3. **Safety net:** the update auto-applies anyway after **5 min of continuous idle** *or* when the **tab is backgrounded** — both still respecting every blocking signal.
4. **Explicit click** reloads immediately (overrides the blocking checks). **Dismissing** the toast leaves the update pending with no re-nag.

## Wider "active session" detection

Reloads now also defer while the user is:
- typing in a text field (label/notes editing)
- in any open modal/dialog
- recently active (input within the last 30s)
- mid cloud/device sync (`syncing` state)

…on top of the existing checks (drag/resize/draw/paint, staging bins, expanded 3D preview, context menu, quick-label popover, keyboard drag/resize modes). Modal detection uses the shared `aria-modal` DOM marker rather than enumerating per-feature open-state flags, so it covers every dialog automatically.

The smoke-test gate and ephemeral UI-state save/restore are preserved unchanged.

## Implementation

- **`src/shared/pwa/reloadSafety.ts`** (new) — input-activity tracker + `isEditableElementFocused` / `isModalOpen` / `isRecentlyActive` predicates.
- **`src/shared/hooks/usePWAUpdate.ts`** — hybrid flow + `waitForAutoApply` safety net; extended `isSafeToReload`; removed the 2-min force timeout.
- **i18n** — `toast.updateAvailable` + `toast.updateReload` across all 10 locales.

## Testing

- `reloadSafety` + `usePWAUpdate`: 40/40 pass (silent reload, persistent prompt, click override, long-idle + tab-hidden auto-apply, hidden-while-busy deferral).
- typecheck, eslint, knip, and all 4 i18n checks clean.

> Note: the prompt was not visually verified in Playwright — triggering it requires simulating a real service-worker update, which isn't reproducible in a normal dev session. The toast reuses the existing action-button UI, so there's no new visual surface.