### PR TITLE
feat(cutouts): number-first inspector controls + hardware-size chips

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutScoopControls.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutScoopControls.test.tsx
@@ -3,8 +3,8 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { CutoutScoopControls } from './CutoutScoopControls';
 import type { Cutout } from '@/features/bin-designer/types';
 
-vi.mock('@/features/bin-designer/components/controls/SliderInput', () => ({
-  SliderInput: ({
+vi.mock('@/shared/components/CompactNumberInput', () => ({
+  CompactNumberInput: ({
     label,
     value,
     onChange,
@@ -16,7 +16,7 @@ vi.mock('@/features/bin-designer/components/controls/SliderInput', () => ({
     disabled?: boolean;
   }) => (
     <input
-      data-testid={`slider-input-${label}`}
+      data-testid={`compact-input-${label}`}
       data-label={label}
       value={value}
       disabled={disabled}
@@ -50,15 +50,17 @@ describe('CutoutScoopControls', () => {
   it('renders uniform slider by default for rectangle', () => {
     const onUpdate = vi.fn();
     render(<CutoutScoopControls cutout={makeCutout()} onUpdate={onUpdate} />);
-    expect(screen.getByTestId('slider-input-binDesigner.cutouts.scoopRadius')).toBeInTheDocument();
-    expect(screen.queryByTestId('slider-input-binDesigner.cutouts.scoopW')).not.toBeInTheDocument();
+    expect(screen.getByTestId('compact-input-binDesigner.cutouts.scoopRadius')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('compact-input-binDesigner.cutouts.scoopW')
+    ).not.toBeInTheDocument();
     expect(screen.getByText('binDesigner.cutouts.scoopSplit')).toBeInTheDocument();
   });
 
   it('writes both axes when uniform slider changes', () => {
     const onUpdate = vi.fn();
     render(<CutoutScoopControls cutout={makeCutout()} onUpdate={onUpdate} />);
-    const slider = screen.getByTestId('slider-input-binDesigner.cutouts.scoopRadius');
+    const slider = screen.getByTestId('compact-input-binDesigner.cutouts.scoopRadius');
     fireEvent.change(slider, { target: { value: '4' } });
     expect(onUpdate).toHaveBeenCalledWith({ scoopRadiusW: 4, scoopRadiusD: 4 });
   });
@@ -67,8 +69,8 @@ describe('CutoutScoopControls', () => {
     const onUpdate = vi.fn();
     render(<CutoutScoopControls cutout={makeCutout()} onUpdate={onUpdate} />);
     fireEvent.click(screen.getByText('binDesigner.cutouts.scoopSplit'));
-    expect(screen.getByTestId('slider-input-binDesigner.cutouts.scoopW')).toBeInTheDocument();
-    expect(screen.getByTestId('slider-input-binDesigner.cutouts.scoopD')).toBeInTheDocument();
+    expect(screen.getByTestId('compact-input-binDesigner.cutouts.scoopW')).toBeInTheDocument();
+    expect(screen.getByTestId('compact-input-binDesigner.cutouts.scoopD')).toBeInTheDocument();
     expect(screen.getByText('binDesigner.cutouts.scoopEdgeLeft')).toBeInTheDocument();
     expect(screen.getByText('binDesigner.cutouts.scoopEdgeRight')).toBeInTheDocument();
     expect(screen.getByText('binDesigner.cutouts.scoopEdgeFront')).toBeInTheDocument();
@@ -83,7 +85,7 @@ describe('CutoutScoopControls', () => {
         onUpdate={onUpdate}
       />
     );
-    expect(screen.getByTestId('slider-input-binDesigner.cutouts.scoopW')).toBeInTheDocument();
+    expect(screen.getByTestId('compact-input-binDesigner.cutouts.scoopW')).toBeInTheDocument();
   });
 
   it('toggling an edge writes the patch with that edge flipped', () => {
@@ -106,7 +108,7 @@ describe('CutoutScoopControls', () => {
     const onUpdate = vi.fn();
     render(<CutoutScoopControls cutout={makeCutout({ shape: 'circle' })} onUpdate={onUpdate} />);
     expect(screen.queryByText('binDesigner.cutouts.scoopSplit')).not.toBeInTheDocument();
-    expect(screen.getByTestId('slider-input-binDesigner.cutouts.scoopRadius')).toBeInTheDocument();
+    expect(screen.getByTestId('compact-input-binDesigner.cutouts.scoopRadius')).toBeInTheDocument();
   });
 
   it('hides edge toggles for grouped cutouts', () => {

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutScoopControls.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutScoopControls.tsx
@@ -15,7 +15,7 @@ import { useState } from 'react';
 import type { Cutout, CutoutScoopEdges } from '@/features/bin-designer/types';
 import { DEFAULT_SCOOP_EDGES } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
-import { SliderInput } from '@/features/bin-designer/components/controls/SliderInput';
+import { CompactNumberInput } from '@/shared/components/CompactNumberInput';
 import { SEGMENT_ACTIVE, SEGMENT_INACTIVE } from '@/shared/components/segmentedControlClasses';
 
 interface CutoutScoopControlsProps {
@@ -71,7 +71,7 @@ export function CutoutScoopControls({
   if (!supportsSplit || !expanded) {
     return (
       <div className="space-y-1">
-        <SliderInput
+        <CompactNumberInput
           label={t('binDesigner.cutouts.scoopRadius')}
           value={uniformValue}
           onChange={handleUniformChange}
@@ -120,26 +120,28 @@ export function CutoutScoopControls({
           {t('binDesigner.cutouts.scoopUniform')}
         </button>
       </div>
-      <SliderInput
-        label={t('binDesigner.cutouts.scoopW')}
-        value={radiusW}
-        onChange={(scoopRadiusW) => onUpdate({ scoopRadiusW })}
-        min={0}
-        max={maxScoop}
-        step={0.5}
-        unit="mm"
-        disabled={disabled}
-      />
-      <SliderInput
-        label={t('binDesigner.cutouts.scoopD')}
-        value={radiusD}
-        onChange={(scoopRadiusD) => onUpdate({ scoopRadiusD })}
-        min={0}
-        max={maxScoop}
-        step={0.5}
-        unit="mm"
-        disabled={disabled}
-      />
+      <div className="grid grid-cols-2 gap-1">
+        <CompactNumberInput
+          label={t('binDesigner.cutouts.scoopW')}
+          value={radiusW}
+          onChange={(scoopRadiusW) => onUpdate({ scoopRadiusW })}
+          min={0}
+          max={maxScoop}
+          step={0.5}
+          unit="mm"
+          disabled={disabled}
+        />
+        <CompactNumberInput
+          label={t('binDesigner.cutouts.scoopD')}
+          value={radiusD}
+          onChange={(scoopRadiusD) => onUpdate({ scoopRadiusD })}
+          min={0}
+          max={maxScoop}
+          step={0.5}
+          unit="mm"
+          disabled={disabled}
+        />
+      </div>
       {supportsEdges && (
         <div className="flex items-center gap-1 pt-0.5">
           <span className="text-[10px] text-content-tertiary mr-1">

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
@@ -13,12 +13,6 @@ vi.mock('@/shared/components/CompactNumberInput', () => ({
   ),
 }));
 
-vi.mock('@/features/bin-designer/components/controls/SliderInput', () => ({
-  SliderInput: ({ label, value }: { label: string; value: number }) => (
-    <input data-testid={`slider-input-${label}`} data-label={label} value={value} readOnly />
-  ),
-}));
-
 vi.mock('../panel/CutoutsSection/geometry', () => ({
   clampRotationToBounds: (_c: Cutout, rotation: number) => rotation,
   getRotatedBounds: (c: Cutout) => ({
@@ -72,8 +66,8 @@ describe('InspectorContent', () => {
     expect(screen.getByTestId('compact-input-Y')).toBeInTheDocument();
     expect(screen.getByTestId('compact-input-W')).toBeInTheDocument();
     expect(screen.getByTestId('compact-input-H')).toBeInTheDocument();
-    expect(screen.getByTestId('slider-input-binDesigner.cutouts.rotation')).toBeInTheDocument();
-    expect(screen.getByTestId('slider-input-binDesigner.cutouts.cutDepth')).toBeInTheDocument();
+    expect(screen.getByTestId('compact-input-binDesigner.cutouts.rotation')).toBeInTheDocument();
+    expect(screen.getByTestId('compact-input-binDesigner.cutouts.cutDepth')).toBeInTheDocument();
   });
 
   it('shows the corner-radius slider only for rectangles', () => {
@@ -84,7 +78,9 @@ describe('InspectorContent', () => {
         selection={new Set(['cutout1'])}
       />
     );
-    expect(screen.getByTestId('slider-input-binDesigner.cutouts.cornerRadius')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('compact-input-binDesigner.cutouts.cornerRadius')
+    ).toBeInTheDocument();
 
     rerender(
       <InspectorContent
@@ -94,7 +90,7 @@ describe('InspectorContent', () => {
       />
     );
     expect(
-      screen.queryByTestId('slider-input-binDesigner.cutouts.cornerRadius')
+      screen.queryByTestId('compact-input-binDesigner.cutouts.cornerRadius')
     ).not.toBeInTheDocument();
   });
 
@@ -109,8 +105,8 @@ describe('InspectorContent', () => {
         onUpdateBatch={vi.fn()}
       />
     );
-    expect(screen.getByTestId('slider-input-binDesigner.cutouts.rotation')).toBeInTheDocument();
-    expect(screen.getByTestId('slider-input-binDesigner.cutouts.cutDepth')).toBeInTheDocument();
+    expect(screen.getByTestId('compact-input-binDesigner.cutouts.rotation')).toBeInTheDocument();
+    expect(screen.getByTestId('compact-input-binDesigner.cutouts.cutDepth')).toBeInTheDocument();
     // X/Y/W/H are single-selection only
     expect(screen.queryByTestId('compact-input-X')).not.toBeInTheDocument();
   });

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
@@ -8,7 +8,7 @@
 import { useMemo } from 'react';
 import type { Cutout } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
-import { SliderInput } from '@/features/bin-designer/components/controls/SliderInput';
+import { CompactNumberInput } from '@/shared/components/CompactNumberInput';
 import type { FitCue } from '../panel/CutoutsSection/cutoutSectionVisibility';
 import { SingleCutoutInspector } from './SingleCutoutInspector';
 
@@ -137,8 +137,8 @@ export function InspectorContent({
           <div className="text-[10px] font-medium text-content-secondary">
             {selectedCutouts.length} {t('binDesigner.cutoutEditor.actions').toLowerCase()}
           </div>
-          <div className="space-y-0.5">
-            <SliderInput
+          <div className="grid grid-cols-2 gap-1">
+            <CompactNumberInput
               label={t('binDesigner.cutouts.rotation')}
               value={sharedRotation ?? 0}
               onChange={(rotation) => handleBatchUpdate('rotation', rotation)}
@@ -148,7 +148,7 @@ export function InspectorContent({
               unit="°"
               disabled={disabled}
             />
-            <SliderInput
+            <CompactNumberInput
               label={t('binDesigner.cutouts.cutDepth')}
               value={sharedCutDepth ?? 5}
               onChange={(cutDepth) => handleBatchUpdate('cutDepth', cutDepth)}
@@ -158,7 +158,7 @@ export function InspectorContent({
               unit="mm"
               disabled={disabled}
             />
-            <SliderInput
+            <CompactNumberInput
               label={t('binDesigner.cutouts.scoopW')}
               value={sharedScoopRadiusW ?? 0}
               onChange={(scoopRadiusW) => handleScoopAxisBatch('scoopRadiusW', scoopRadiusW)}
@@ -168,7 +168,7 @@ export function InspectorContent({
               unit="mm"
               disabled={disabled}
             />
-            <SliderInput
+            <CompactNumberInput
               label={t('binDesigner.cutouts.scoopD')}
               value={sharedScoopRadiusD ?? 0}
               onChange={(scoopRadiusD) => handleScoopAxisBatch('scoopRadiusD', scoopRadiusD)}

--- a/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
@@ -7,7 +7,6 @@
 import type { Cutout, CutoutTextSide } from '@/features/bin-designer/types';
 import { TEXT_MAX_LENGTH } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
-import { SliderInput } from '@/features/bin-designer/components/controls/SliderInput';
 import { CompactNumberInput } from '@/shared/components/CompactNumberInput';
 import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
 import { clampRotationToBounds } from '../panel/CutoutsSection/geometry';
@@ -116,37 +115,37 @@ export function SingleCutoutInspector({
               unit="mm"
               disabled={disabled}
             />
+            <CompactNumberInput
+              label={t('binDesigner.cutouts.rotation')}
+              value={getEffective(cutout, preview, 'rotation')}
+              onChange={(rotation) => {
+                const clamped = clampRotationToBounds(cutout, rotation, binWidth, binDepth);
+                onUpdate(cutout.id, { rotation: clamped });
+              }}
+              min={0}
+              max={359}
+              step={1}
+              unit="°"
+              disabled={disabled}
+            />
+            <CompactNumberInput
+              label={t('binDesigner.cutouts.cutDepth')}
+              value={cutout.cutDepth}
+              onChange={(cutDepth) => onUpdate(cutout.id, { cutDepth })}
+              min={0.5}
+              max={maxCutDepth}
+              step={0.5}
+              unit="mm"
+              disabled={disabled}
+            />
           </div>
-          <SliderInput
-            label={t('binDesigner.cutouts.rotation')}
-            value={getEffective(cutout, preview, 'rotation')}
-            onChange={(rotation) => {
-              const clamped = clampRotationToBounds(cutout, rotation, binWidth, binDepth);
-              onUpdate(cutout.id, { rotation: clamped });
-            }}
-            min={0}
-            max={359}
-            step={1}
-            unit="°"
-            disabled={disabled}
-          />
-          <SliderInput
-            label={t('binDesigner.cutouts.cutDepth')}
-            value={cutout.cutDepth}
-            onChange={(cutDepth) => onUpdate(cutout.id, { cutDepth })}
-            min={0.5}
-            max={maxCutDepth}
-            step={0.5}
-            unit="mm"
-            disabled={disabled}
-          />
         </div>
       </CollapsibleSection>
 
       <CollapsibleSection title={t('binDesigner.cutouts.section.shape')} variant="small">
         <div className="space-y-1.5">
           {cutout.shape === 'rectangle' && (
-            <SliderInput
+            <CompactNumberInput
               label={t('binDesigner.cutouts.cornerRadius')}
               value={cutout.cornerRadius}
               onChange={(cornerRadius) => onUpdate(cutout.id, { cornerRadius })}

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutFitControls.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutFitControls.tsx
@@ -14,7 +14,7 @@ import {
   MAX_CUTOUT_CHAMFER,
 } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
-import { SliderInput } from '../../controls/SliderInput';
+import { CompactNumberInput } from '@/shared/components/CompactNumberInput';
 import type { FitCue } from './cutoutSectionVisibility';
 
 interface CutoutFitControlsProps {
@@ -50,7 +50,7 @@ export function CutoutFitControls({
     <div className="space-y-1.5">
       {isClearanceShape && (
         <div {...cueProps('clearance')}>
-          <SliderInput
+          <CompactNumberInput
             label={t('binDesigner.cutouts.clearance')}
             value={cutout.clearance ?? 0}
             onChange={(clearance) => onUpdate({ clearance })}
@@ -66,7 +66,7 @@ export function CutoutFitControls({
 
       {isChamferShape && maxChamfer > 0 && (
         <div {...cueProps('chamfer')}>
-          <SliderInput
+          <CompactNumberInput
             label={t('binDesigner.cutouts.chamfer')}
             value={Math.min(cutout.chamferWidth ?? 0, maxChamfer)}
             onChange={(chamferWidth) => onUpdate({ chamferWidth })}

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutPresetChips.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutPresetChips.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CutoutPresetChips } from './CutoutPresetChips';
+import type { CutoutSizePreset } from './cutoutShapePresets';
+
+vi.mock('@/i18n', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+// Stub the "More…" dropdown so we can assert overflow presets are routed there.
+vi.mock('./CutoutPresetMenu', () => ({
+  CutoutPresetMenu: ({ presets }: { presets: readonly CutoutSizePreset[] }) => (
+    <div data-testid="more-menu" data-count={presets.length} />
+  ),
+}));
+
+const PRESETS: CutoutSizePreset[] = [
+  { id: 'a', label: '1/4" hex bit (6.35mm)', mm: 6.35 },
+  { id: 'b', label: 'Allen 2mm', mm: 2 },
+  { id: 'c', label: 'Allen 3mm', mm: 3 },
+  { id: 'd', label: 'Allen 4mm', mm: 4 },
+];
+
+describe('CutoutPresetChips', () => {
+  it('renders the first N presets as chips and routes the rest to the More menu', () => {
+    render(<CutoutPresetChips presets={PRESETS} onPick={vi.fn()} maxChips={2} />);
+    // Two chips, labelled by full spec for a11y.
+    expect(screen.getByRole('button', { name: '1/4" hex bit (6.35mm)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Allen 2mm' })).toBeInTheDocument();
+    // Remaining 2 presets live in the More menu.
+    const more = screen.getByTestId('more-menu');
+    expect(more).toHaveAttribute('data-count', '2');
+  });
+
+  it('shortens the chip label to the spec fraction or the mm value', () => {
+    render(<CutoutPresetChips presets={PRESETS} onPick={vi.fn()} maxChips={2} />);
+    expect(screen.getByText('1/4"')).toBeInTheDocument(); // fraction token
+    expect(screen.getByText('2')).toBeInTheDocument(); // mm fallback
+  });
+
+  it('calls onPick with the preset mm when a chip is clicked', () => {
+    const onPick = vi.fn();
+    render(<CutoutPresetChips presets={PRESETS} onPick={onPick} maxChips={2} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Allen 2mm' }));
+    expect(onPick).toHaveBeenCalledWith(2);
+  });
+
+  it('marks the active chip as pressed', () => {
+    render(<CutoutPresetChips presets={PRESETS} onPick={vi.fn()} maxChips={3} activeMm={3} />);
+    expect(screen.getByRole('button', { name: 'Allen 3mm' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByRole('button', { name: 'Allen 2mm' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('omits the More menu when all presets fit as chips', () => {
+    render(<CutoutPresetChips presets={PRESETS} onPick={vi.fn()} maxChips={4} />);
+    expect(screen.queryByTestId('more-menu')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutPresetChips.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutPresetChips.tsx
@@ -1,0 +1,83 @@
+/**
+ * Quick-pick hardware-size chips — the fast path for bit/socket organizers.
+ *
+ * Shows the most common spec sizes as one-tap chips (the active size is
+ * highlighted), with the full catalog tucked behind a "More…" dropdown
+ * (reusing CutoutPresetMenu). Replaces the dropdown-only picker so the
+ * dominant use case (drop a 6mm hex, a 1/4" drive) is a single click.
+ */
+
+import { useTranslation } from '@/i18n';
+import { cn } from '@/design-system/cn';
+import type { CutoutSizePreset } from './cutoutShapePresets';
+import { CutoutPresetMenu } from './CutoutPresetMenu';
+
+interface CutoutPresetChipsProps {
+  readonly presets: readonly CutoutSizePreset[];
+  readonly onPick: (mm: number) => void;
+  /** Currently applied nominal size (mm), used to highlight the matching chip. */
+  readonly activeMm?: number;
+  readonly disabled?: boolean;
+  /** Number of presets surfaced as chips; the rest live in the "More…" menu. */
+  readonly maxChips?: number;
+}
+
+/** Compact chip label — the spec's leading token, e.g. `1/4"` or `6`. */
+function chipLabel(preset: CutoutSizePreset): string {
+  const fraction = preset.label.match(/^\d+\/\d+"/);
+  if (fraction) return fraction[0];
+  return String(preset.mm);
+}
+
+export function CutoutPresetChips({
+  presets,
+  onPick,
+  activeMm,
+  disabled = false,
+  maxChips = 6,
+}: CutoutPresetChipsProps) {
+  const t = useTranslation();
+  const quick = presets.slice(0, maxChips);
+  const rest = presets.slice(maxChips);
+
+  return (
+    <div className="space-y-1">
+      <span className="block text-[10px] uppercase tracking-wide text-content-tertiary">
+        {t('binDesigner.cutouts.sizePreset')}
+      </span>
+      <div className="flex flex-wrap gap-1">
+        {quick.map((preset) => {
+          const active = activeMm !== undefined && Math.abs(activeMm - preset.mm) < 0.01;
+          return (
+            <button
+              key={preset.id}
+              type="button"
+              disabled={disabled}
+              onClick={() => onPick(preset.mm)}
+              title={preset.label}
+              aria-pressed={active}
+              aria-label={preset.label}
+              className={cn(
+                'rounded border px-1.5 py-0.5 text-[11px] tabular-nums transition-colors',
+                active
+                  ? 'border-accent bg-accent/15 text-accent'
+                  : 'border-stroke-subtle bg-surface-elevated text-content-secondary hover:border-accent/50 hover:text-content',
+                disabled && 'cursor-not-allowed opacity-50'
+              )}
+            >
+              {chipLabel(preset)}
+            </button>
+          );
+        })}
+      </div>
+      {rest.length > 0 && (
+        <CutoutPresetMenu
+          presets={rest}
+          label={t('binDesigner.cutouts.sizePresetMore')}
+          onPick={onPick}
+          disabled={disabled}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeControls.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeControls.test.tsx
@@ -46,12 +46,12 @@ describe('CutoutShapeControls', () => {
     renderControls(makeCutout({ shape: 'polygon', sides: 6 }));
     expect(screen.getByText('binDesigner.cutouts.sides')).toBeInTheDocument();
     expect(screen.getByText('binDesigner.cutouts.acrossFlats')).toBeInTheDocument();
-    expect(screen.getByLabelText('binDesigner.cutouts.sizePreset')).toBeInTheDocument();
+    expect(screen.getByText('binDesigner.cutouts.sizePreset')).toBeInTheDocument();
   });
 
   it('shows only a preset menu for a circle (no sides)', () => {
     renderControls(makeCutout({ shape: 'circle' }));
-    expect(screen.getByLabelText('binDesigner.cutouts.sizePreset')).toBeInTheDocument();
+    expect(screen.getByText('binDesigner.cutouts.sizePreset')).toBeInTheDocument();
     expect(screen.queryByText('binDesigner.cutouts.sides')).not.toBeInTheDocument();
   });
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeControls.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeControls.tsx
@@ -19,10 +19,11 @@ import {
   maxAcrossFlats,
 } from '@/shared/utils/cutoutPolygon';
 import { useTranslation } from '@/i18n';
-import { SliderInput } from '../../controls/SliderInput';
+import { Stepper } from '@/design-system';
+import { CompactNumberInput } from '@/shared/components/CompactNumberInput';
 import { resizeKeepingCenter } from './cutoutHelpers';
 import { HEX_ACROSS_FLATS_PRESETS, CIRCLE_DIAMETER_PRESETS } from './cutoutShapePresets';
-import { CutoutPresetMenu } from './CutoutPresetMenu';
+import { CutoutPresetChips } from './CutoutPresetChips';
 
 interface CutoutShapeControlsProps {
   readonly cutout: Cutout;
@@ -74,16 +75,26 @@ export function CutoutShapeControls({
   if (cutout.shape === 'polygon') {
     return (
       <div className="space-y-1.5">
-        <SliderInput
-          label={t('binDesigner.cutouts.sides')}
-          value={sides}
-          onChange={(s) => applyAcrossFlats(acrossFlatsFromBox(s, cutout.depth), s)}
-          min={MIN_POLYGON_SIDES}
-          max={MAX_POLYGON_SIDES}
-          step={1}
-          disabled={disabled}
-        />
-        <SliderInput
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-xs font-medium text-content-secondary">
+            {t('binDesigner.cutouts.sides')}
+          </span>
+          <Stepper
+            value={sides}
+            onChange={(s) => applyAcrossFlats(acrossFlatsFromBox(s, cutout.depth), s)}
+            onStep={(delta) => {
+              const next = Math.max(MIN_POLYGON_SIDES, Math.min(MAX_POLYGON_SIDES, sides + delta));
+              applyAcrossFlats(acrossFlatsFromBox(next, cutout.depth), next);
+            }}
+            min={MIN_POLYGON_SIDES}
+            max={MAX_POLYGON_SIDES}
+            step={1}
+            size="sm"
+            disabled={disabled}
+            aria-label={t('binDesigner.cutouts.sides')}
+          />
+        </div>
+        <CompactNumberInput
           label={t('binDesigner.cutouts.acrossFlats')}
           value={acrossFlatsFromBox(sides, cutout.depth)}
           onChange={(af) => applyAcrossFlats(af)}
@@ -95,9 +106,9 @@ export function CutoutShapeControls({
           disabled={disabled}
           highlight={flashSize}
         />
-        <CutoutPresetMenu
+        <CutoutPresetChips
           presets={HEX_ACROSS_FLATS_PRESETS}
-          label={t('binDesigner.cutouts.sizePreset')}
+          activeMm={acrossFlatsFromBox(sides, cutout.depth)}
           onPick={(mm) => {
             applyAcrossFlats(mm);
             flash();
@@ -110,9 +121,9 @@ export function CutoutShapeControls({
 
   if (cutout.shape === 'circle') {
     return (
-      <CutoutPresetMenu
+      <CutoutPresetChips
         presets={CIRCLE_DIAMETER_PRESETS}
-        label={t('binDesigner.cutouts.sizePreset')}
+        activeMm={cutout.width}
         onPick={applyDiameter}
         disabled={disabled}
       />

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -283,6 +283,7 @@
   "binDesigner.cutouts.fitNone": "Keine Passungszugabe",
   "binDesigner.cutouts.shapeName.path": "Pfad",
   "binDesigner.cutouts.sizePreset": "Normgrößen",
+  "binDesigner.cutouts.sizePresetMore": "Weitere Größen…",
   "binDesigner.cutouts.clearance": "Spiel",
   "binDesigner.cutouts.clearanceInfo": "Zusätzliche Größe, damit Teile hineinpassen",
   "binDesigner.cutouts.chamfer": "Einführfase",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1409,6 +1409,7 @@
   "binDesigner.cutouts.acrossFlats": "Across flats",
   "binDesigner.cutouts.acrossFlatsInfo": "Flat-to-flat width — matches hex bit / Allen specs",
   "binDesigner.cutouts.sizePreset": "Hardware sizes",
+  "binDesigner.cutouts.sizePresetMore": "More sizes…",
   "binDesigner.cutouts.fitNone": "No fit allowance",
   "binDesigner.cutouts.shapeName.path": "Path",
   "binDesigner.cutouts.clearance": "Clearance",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1646,6 +1646,7 @@ const en: Record<string, string> = {
   'binDesigner.cutouts.acrossFlats': 'Across flats',
   'binDesigner.cutouts.acrossFlatsInfo': 'Flat-to-flat width — matches hex bit / Allen specs',
   'binDesigner.cutouts.sizePreset': 'Hardware sizes',
+  'binDesigner.cutouts.sizePresetMore': 'More sizes…',
   'binDesigner.cutouts.fitNone': 'No fit allowance',
   'binDesigner.cutouts.shapeName.path': 'Path',
   'binDesigner.cutouts.clearance': 'Clearance',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -283,6 +283,7 @@
   "binDesigner.cutouts.fitNone": "Sin holgura de ajuste",
   "binDesigner.cutouts.shapeName.path": "Trazado",
   "binDesigner.cutouts.sizePreset": "Tamaños estándar",
+  "binDesigner.cutouts.sizePresetMore": "Más tamaños…",
   "binDesigner.cutouts.clearance": "Holgura",
   "binDesigner.cutouts.clearanceInfo": "Tamaño extra para que las piezas entren",
   "binDesigner.cutouts.chamfer": "Bisel de entrada",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -283,6 +283,7 @@
   "binDesigner.cutouts.fitNone": "Aucune marge d'ajustement",
   "binDesigner.cutouts.shapeName.path": "Tracé",
   "binDesigner.cutouts.sizePreset": "Tailles standard",
+  "binDesigner.cutouts.sizePresetMore": "Plus de tailles…",
   "binDesigner.cutouts.clearance": "Jeu",
   "binDesigner.cutouts.clearanceInfo": "Marge ajoutée pour que les pièces entrent",
   "binDesigner.cutouts.chamfer": "Chanfrein d'entrée",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -283,6 +283,7 @@
   "binDesigner.cutouts.fitNone": "はめあい代なし",
   "binDesigner.cutouts.shapeName.path": "パス",
   "binDesigner.cutouts.sizePreset": "規格サイズ",
+  "binDesigner.cutouts.sizePresetMore": "その他のサイズ…",
   "binDesigner.cutouts.clearance": "クリアランス",
   "binDesigner.cutouts.clearanceInfo": "部品が入るように追加する余裕",
   "binDesigner.cutouts.chamfer": "入口面取り",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -283,6 +283,7 @@
   "binDesigner.cutouts.fitNone": "Ingen passklaring",
   "binDesigner.cutouts.shapeName.path": "Bane",
   "binDesigner.cutouts.sizePreset": "Standardstørrelser",
+  "binDesigner.cutouts.sizePresetMore": "Flere størrelser…",
   "binDesigner.cutouts.clearance": "Klaring",
   "binDesigner.cutouts.clearanceInfo": "Ekstra størrelse så deler passer",
   "binDesigner.cutouts.chamfer": "Innføringsfas",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -283,6 +283,7 @@
   "binDesigner.cutouts.fitNone": "Geen pasruimte",
   "binDesigner.cutouts.shapeName.path": "Pad",
   "binDesigner.cutouts.sizePreset": "Standaardmaten",
+  "binDesigner.cutouts.sizePresetMore": "Meer maten…",
   "binDesigner.cutouts.clearance": "Speling",
   "binDesigner.cutouts.clearanceInfo": "Extra ruimte zodat onderdelen passen",
   "binDesigner.cutouts.chamfer": "Invoerafschuining",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -283,6 +283,7 @@
   "binDesigner.cutouts.fitNone": "Sem folga de encaixe",
   "binDesigner.cutouts.shapeName.path": "Caminho",
   "binDesigner.cutouts.sizePreset": "Tamanhos padrão",
+  "binDesigner.cutouts.sizePresetMore": "Mais tamanhos…",
   "binDesigner.cutouts.clearance": "Folga",
   "binDesigner.cutouts.clearanceInfo": "Tamanho extra para as peças encaixarem",
   "binDesigner.cutouts.chamfer": "Chanfro de entrada",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -283,6 +283,7 @@
   "binDesigner.cutouts.fitNone": "Ingen passtolerans",
   "binDesigner.cutouts.shapeName.path": "Bana",
   "binDesigner.cutouts.sizePreset": "Standardstorlekar",
+  "binDesigner.cutouts.sizePresetMore": "Fler storlekar…",
   "binDesigner.cutouts.clearance": "Spelrum",
   "binDesigner.cutouts.clearanceInfo": "Extra storlek så att delar passar",
   "binDesigner.cutouts.chamfer": "Insticksfas",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -283,6 +283,7 @@
   "binDesigner.cutouts.fitNone": "Без припуску на підгін",
   "binDesigner.cutouts.shapeName.path": "Контур",
   "binDesigner.cutouts.sizePreset": "Стандартні розміри",
+  "binDesigner.cutouts.sizePresetMore": "Більше розмірів…",
   "binDesigner.cutouts.clearance": "Зазор",
   "binDesigner.cutouts.clearanceInfo": "Додатковий розмір, щоб деталі входили",
   "binDesigner.cutouts.chamfer": "Вхідна фаска",

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
@@ -216,4 +216,45 @@ describe('CompactNumberInput', () => {
     // Component exits edit mode but doesn't call onChange with invalid value
     await waitFor(() => expect(screen.queryByRole('textbox')).not.toBeInTheDocument());
   });
+
+  it('applies a fine step with Alt+ArrowUp', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<CompactNumberInput label="X" value={10} onChange={onChange} step={1} />);
+
+    await user.click(screen.getByRole('button'));
+    await user.keyboard('{Alt>}{ArrowUp}{/Alt}');
+
+    expect(onChange).toHaveBeenCalledWith(10.1);
+  });
+
+  it('exposes a slider role on the draggable label', () => {
+    render(<CompactNumberInput label="X" value={10} onChange={vi.fn()} min={0} max={50} />);
+    const slider = screen.getByRole('slider', { name: 'X' });
+    expect(slider).toHaveAttribute('aria-valuenow', '10');
+    expect(slider).toHaveAttribute('aria-valuemax', '50');
+  });
+
+  it('scrubs the value when dragging the label horizontally', () => {
+    const onChange = vi.fn();
+    render(<CompactNumberInput label="X" value={10} onChange={onChange} step={1} />);
+
+    const slider = screen.getByRole('slider', { name: 'X' });
+    fireEvent.pointerDown(slider, { clientX: 100 });
+    fireEvent.pointerMove(document, { clientX: 118 }); // +18px → 3 steps
+    expect(onChange).toHaveBeenLastCalledWith(13);
+    fireEvent.pointerUp(document);
+  });
+
+  it('does not enter edit mode after a scrub drag', () => {
+    const onChange = vi.fn();
+    render(<CompactNumberInput label="X" value={10} onChange={onChange} step={1} />);
+
+    const slider = screen.getByRole('slider', { name: 'X' });
+    fireEvent.pointerDown(slider, { clientX: 100 });
+    fireEvent.pointerMove(document, { clientX: 130 });
+    fireEvent.pointerUp(document);
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
 });

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
@@ -1,11 +1,14 @@
 /**
- * Figma-style compact number input.
+ * Figma-style compact, number-first input.
  *
- * Features: label on left, editable value on right, arrow key increment,
- * shift+arrow for 10x step, enter to commit, escape to revert.
+ * Number is primary: click the value to type an exact number, drag the label
+ * to scrub coarsely, or use arrow keys to nudge. Modifiers apply to both scrub
+ * and arrows — Shift = ×10 step, Alt = fine (÷10) step. Enter commits, Escape
+ * reverts.
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
+import { cn } from '@/design-system/cn';
 
 interface CompactNumberInputProps {
   readonly label: string;
@@ -16,6 +19,22 @@ interface CompactNumberInputProps {
   readonly step?: number;
   readonly unit?: string;
   readonly disabled?: boolean;
+  /** Tooltip hint surfaced on hover/focus (the slider's inline `info`, compacted). */
+  readonly info?: string;
+  /** Transient emphasis ring — flashed when a preset sets this value. */
+  readonly highlight?: boolean;
+}
+
+/** Pixels of horizontal drag per step increment while scrubbing. */
+const PIXELS_PER_STEP = 6;
+/** Movement past this (px) turns a label press into a scrub instead of a click. */
+const SCRUB_THRESHOLD = 3;
+
+/** Step size for the current modifier keys: Shift = ×10, Alt = fine (÷10). */
+function effectiveStep(step: number, e: { shiftKey: boolean; altKey: boolean }): number {
+  if (e.shiftKey) return step * 10;
+  if (e.altKey) return step / 10;
+  return step;
 }
 
 export function CompactNumberInput({
@@ -27,9 +46,12 @@ export function CompactNumberInput({
   step = 0.5,
   unit,
   disabled = false,
+  info,
+  highlight = false,
 }: CompactNumberInputProps) {
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
+  const [scrubbing, setScrubbing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const clamp = useCallback((v: number) => Math.max(min, Math.min(max, v)), [min, max]);
@@ -39,7 +61,10 @@ export function CompactNumberInput({
     return rounded % 1 === 0 ? rounded.toFixed(0) : rounded.toString();
   }, []);
 
-  const handleClick = useCallback(() => {
+  /** Round to 2dp to keep accumulated scrub/nudge deltas free of float noise. */
+  const tidy = useCallback((v: number) => Math.round(v * 100) / 100, []);
+
+  const startEditing = useCallback(() => {
     if (disabled) return;
     setEditValue(formatValue(value));
     setEditing(true);
@@ -55,9 +80,7 @@ export function CompactNumberInput({
   const commit = useCallback(
     (raw: string) => {
       const parsed = parseFloat(raw);
-      if (!isNaN(parsed)) {
-        onChange(clamp(parsed));
-      }
+      if (!isNaN(parsed)) onChange(clamp(parsed));
       setEditing(false);
     },
     [onChange, clamp]
@@ -69,33 +92,72 @@ export function CompactNumberInput({
         commit(editValue);
       } else if (e.key === 'Escape') {
         setEditing(false);
-      } else if (e.key === 'ArrowUp') {
+      } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
         e.preventDefault();
-        const increment = e.shiftKey ? step * 10 : step;
-        const newVal = clamp(value + increment);
-        onChange(newVal);
-        setEditValue(formatValue(newVal));
-      } else if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        const decrement = e.shiftKey ? step * 10 : step;
-        const newVal = clamp(value - decrement);
-        onChange(newVal);
-        setEditValue(formatValue(newVal));
+        const delta = effectiveStep(step, e) * (e.key === 'ArrowUp' ? 1 : -1);
+        const next = clamp(tidy(value + delta));
+        onChange(next);
+        setEditValue(formatValue(next));
       }
     },
-    [editValue, commit, value, step, clamp, onChange, formatValue]
+    [editValue, commit, value, clamp, onChange, formatValue, tidy, step]
+  );
+
+  const handleScrubStart = useCallback(
+    (e: React.PointerEvent) => {
+      if (disabled || editing) return;
+      e.preventDefault();
+      const startX = e.clientX;
+      const startValue = value;
+      let moved = false;
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        const dx = moveEvent.clientX - startX;
+        if (!moved && Math.abs(dx) > SCRUB_THRESHOLD) {
+          moved = true;
+          setScrubbing(true);
+        }
+        if (!moved) return;
+        const steps = Math.round(dx / PIXELS_PER_STEP);
+        const next = clamp(tidy(startValue + steps * effectiveStep(step, moveEvent)));
+        onChange(next);
+      };
+
+      const handleUp = () => {
+        document.removeEventListener('pointermove', handleMove);
+        document.removeEventListener('pointerup', handleUp);
+        setScrubbing(false);
+        if (!moved) startEditing();
+      };
+
+      document.addEventListener('pointermove', handleMove);
+      document.addEventListener('pointerup', handleUp);
+    },
+    [disabled, editing, value, clamp, onChange, tidy, startEditing, step]
   );
 
   return (
-    <button
-      type="button"
-      className={`flex items-center rounded border border-stroke-subtle bg-surface-elevated h-7 text-left ${
-        disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-text'
-      }`}
-      onClick={handleClick}
-      disabled={disabled}
+    <div
+      className={cn(
+        'flex h-7 items-center rounded border border-stroke-subtle bg-surface-elevated text-left transition-[box-shadow] duration-500',
+        disabled && 'cursor-not-allowed opacity-50',
+        highlight && 'ring-2 ring-accent/70'
+      )}
+      title={info}
     >
-      <span className="px-1.5 text-[10px] text-content-tertiary select-none leading-none min-w-[1.5rem]">
+      <span
+        className={cn(
+          'select-none px-1.5 text-[10px] leading-none text-content-tertiary',
+          !disabled && 'cursor-ew-resize',
+          'min-w-[1.5rem]'
+        )}
+        onPointerDown={handleScrubStart}
+        role="slider"
+        aria-label={label}
+        aria-valuenow={value}
+        aria-valuemin={min}
+        aria-valuemax={max === Infinity ? undefined : max}
+      >
         {label}
       </span>
       {editing ? (
@@ -107,15 +169,26 @@ export function CompactNumberInput({
           onChange={(e) => setEditValue(e.target.value)}
           onBlur={() => commit(editValue)}
           onKeyDown={handleKeyDown}
-          className="flex-1 min-w-0 bg-transparent text-right text-xs text-content pr-1 outline-none"
+          className="min-w-0 flex-1 bg-transparent pr-1 text-right text-xs text-content outline-none"
           disabled={disabled}
+          aria-label={label}
         />
       ) : (
-        <span className="flex-1 text-right text-xs text-content pr-1 tabular-nums select-none">
+        <button
+          type="button"
+          onClick={startEditing}
+          disabled={disabled}
+          className={cn(
+            'min-w-0 flex-1 select-none pr-1 text-right text-xs tabular-nums text-content outline-none',
+            !disabled && 'cursor-text',
+            scrubbing && 'text-accent'
+          )}
+          aria-label={`${label}: ${formatValue(value)}${unit ? ` ${unit}` : ''}`}
+        >
           {formatValue(value)}
-        </span>
+        </button>
       )}
-      {unit && <span className="pr-1.5 text-[10px] text-content-disabled select-none">{unit}</span>}
-    </button>
+      {unit && <span className="select-none pr-1.5 text-[10px] text-content-disabled">{unit}</span>}
+    </div>
   );
 }


### PR DESCRIPTION
## What

Second PR of the cutout-editor overhaul. Replaces the inspector's sliders with **number-first controls** and promotes hardware presets to **quick-pick chips**.

> Stacked on #1993 — review/merge that first. The base branch is `feat/cutout-inspector-dock`.

## Why

The sliders made precise values fiddly — their knobs jammed at the left of the track (visible in the original screenshot where Sides/Across-flats/Scoop/Clearance all sat at min). A bit/socket organizer is all about exact spec sizes, so the number should be primary.

## How

- **`CompactNumberInput`** (already the X/Y/W/H control) gains:
  - **drag-scrub** — drag the label to adjust coarsely (cursor `ew-resize`)
  - **modifiers** — `Shift` = ×10 step, `Alt` = fine (÷10), on both scrub and arrow keys
  - **step-snapping** + click-to-type-exact (kept)
  - It now drives rotation, cut depth, corner radius, scoop W/D, clearance, and chamfer too — laid out in tidy 2-col grids.
- **Polygon sides** → design-system `Stepper` (discrete +/−), which fits a small integer range far better than a slider.
- **Hardware presets** → `CutoutPresetChips`: one-tap chips for the common sizes (active size highlighted), full catalog behind a **"More…"** dropdown (reuses `CutoutPresetMenu`).

These controls are shared with the sidebar `CutoutPropertyPanel`, so the improvement lands there too.

## Verification

- `typecheck` + lint clean; 40 unit tests pass (23 `CompactNumberInput` incl. new scrub/Alt-fine/slider-role coverage, preset chips, updated scoop/shape/inspector tests)
- Playwright spot-check of a polygon selection: Stepper for Sides, compact number fields, and hardware chips all render correctly in the docked panel
- i18n: `sizePresetMore` key added across all 9 locales