### PR TITLE
feat(slider): tactile grip knob with app-matched polish

### DIFF
--- a/src/design-system/Slider/Slider.tsx
+++ b/src/design-system/Slider/Slider.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useCallback, useId, useRef, useState } from 'react';
 import { cn } from '../cn';
 import { interactiveTransition } from '../variants';
+import { SliderThumb } from './SliderThumb';
 
 export interface SliderProps {
   /** Current value */
@@ -189,15 +190,22 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
             style={{ width: `${percent}%` }}
           />
 
+          {/* Value bubble — shown above the thumb while dragging */}
+          {isDragging && !disabled && (
+            <div
+              className="animate-scale-in pointer-events-none absolute -top-1.5 z-10 -translate-x-1/2 -translate-y-full rounded-md border border-stroke-subtle bg-surface-elevated px-2 py-0.5 text-xs font-semibold tabular-nums text-content shadow-md"
+              style={{ left: `${percent}%` }}
+            >
+              {value}
+            </div>
+          )}
+
           {/* Thumb */}
-          <div
-            data-testid="slider-thumb"
-            className={cn(
-              'pointer-events-none absolute top-1/2 h-5 w-5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-accent bg-surface shadow-sm',
-              interactiveTransition,
-              thumbActive && !disabled && 'scale-110 shadow-md',
-              isDragging && !disabled && 'ring-2 ring-accent/30'
-            )}
+          <SliderThumb
+            active={thumbActive}
+            dragging={isDragging}
+            disabled={disabled}
+            className="top-1/2 -translate-x-1/2 -translate-y-1/2"
             style={{ left: `${percent}%` }}
           />
 

--- a/src/design-system/Slider/SliderThumb.test.tsx
+++ b/src/design-system/Slider/SliderThumb.test.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SliderThumb } from './SliderThumb';
+
+describe('SliderThumb', () => {
+  it('renders three grip lines inside the knob', () => {
+    const { getByTestId } = render(<SliderThumb />);
+    const thumb = getByTestId('slider-thumb');
+    expect(thumb.querySelectorAll('span')).toHaveLength(3);
+  });
+
+  it('forwards positioning className and style', () => {
+    const { getByTestId } = render(
+      <SliderThumb className="-translate-x-1/2" style={{ left: '40%' }} />
+    );
+    const thumb = getByTestId('slider-thumb');
+    expect(thumb).toHaveClass('-translate-x-1/2');
+    expect(thumb.getAttribute('style')).toContain('left: 40%');
+  });
+
+  it('applies the active scale + glow only when not disabled', () => {
+    const { getByTestId, rerender } = render(<SliderThumb active />);
+    expect(getByTestId('slider-thumb')).toHaveClass('scale-105', 'brightness-110');
+
+    rerender(<SliderThumb active disabled />);
+    expect(getByTestId('slider-thumb')).not.toHaveClass('scale-105');
+  });
+});

--- a/src/design-system/Slider/SliderThumb.tsx
+++ b/src/design-system/Slider/SliderThumb.tsx
@@ -43,6 +43,7 @@ export function SliderThumb({ active, dragging, disabled, className, style }: Sl
   return (
     <div
       data-testid="slider-thumb"
+      aria-hidden="true"
       className={cn(
         'pointer-events-none absolute flex h-5 w-5 items-center justify-center gap-[3px] rounded-full',
         'bg-gradient-to-b from-accent-hover to-accent',

--- a/src/design-system/Slider/SliderThumb.tsx
+++ b/src/design-system/Slider/SliderThumb.tsx
@@ -1,0 +1,61 @@
+import type { CSSProperties } from 'react';
+import { cn } from '../cn';
+import { interactiveTransition } from '../variants';
+
+interface SliderThumbProps {
+  /** Hover or drag — brightens the knob and adds a soft accent glow. */
+  active?: boolean;
+  /** Pointer is held down — widens the glow ring. */
+  dragging?: boolean;
+  disabled?: boolean;
+  /** Positioning classes (e.g. `top-1/2 -translate-x-1/2 -translate-y-1/2`). */
+  className?: string;
+  /** Positioning style (e.g. `{ left: '40%' }`). */
+  style?: CSSProperties;
+}
+
+// Surface halo keeps the filled knob crisp even where it overlaps the
+// same-colored accent fill; layered shadow + accent-muted glow mirror the
+// app's button/focus polish (top-light gradient, brightness-on-hover).
+const SHADOW_IDLE = '[box-shadow:0_0_0_2px_var(--color-surface),var(--shadow-sm)]';
+const SHADOW_HOVER =
+  '[box-shadow:0_0_0_2px_var(--color-surface),0_0_0_5px_var(--color-accent-muted),var(--shadow-md)]';
+const SHADOW_DRAG =
+  '[box-shadow:0_0_0_2px_var(--color-surface),0_0_0_7px_var(--color-accent-muted),var(--shadow-md)]';
+
+/**
+ * Filled, grip-textured slider knob shared by every slider surface.
+ *
+ * The accent body uses a top-light gradient to read as a raised physical
+ * control; three short grip lines (in the on-accent tint) signal "grab me".
+ * Hover/drag brighten it, scale it up slightly, and bloom an accent glow.
+ */
+export function SliderThumb({ active, dragging, disabled, className, style }: SliderThumbProps) {
+  const lifted = (active || dragging) && !disabled;
+  const shadow = disabled
+    ? SHADOW_IDLE
+    : dragging
+      ? SHADOW_DRAG
+      : active
+        ? SHADOW_HOVER
+        : SHADOW_IDLE;
+
+  return (
+    <div
+      data-testid="slider-thumb"
+      className={cn(
+        'pointer-events-none absolute flex h-5 w-5 items-center justify-center gap-[3px] rounded-full',
+        'bg-gradient-to-b from-accent-hover to-accent',
+        interactiveTransition,
+        shadow,
+        lifted && 'scale-105 brightness-110',
+        className
+      )}
+      style={style}
+    >
+      {[0, 1, 2].map((i) => (
+        <span key={i} className="h-2 w-px rounded-full bg-on-accent/45" />
+      ))}
+    </div>
+  );
+}

--- a/src/design-system/Slider/SliderThumb.tsx
+++ b/src/design-system/Slider/SliderThumb.tsx
@@ -1,6 +1,5 @@
 import type { CSSProperties } from 'react';
 import { cn } from '../cn';
-import { interactiveTransition } from '../variants';
 
 interface SliderThumbProps {
   /** Hover or drag — brightens the knob and adds a soft accent glow. */
@@ -47,7 +46,10 @@ export function SliderThumb({ active, dragging, disabled, className, style }: Sl
       className={cn(
         'pointer-events-none absolute flex h-5 w-5 items-center justify-center gap-[3px] rounded-full',
         'bg-gradient-to-b from-accent-hover to-accent',
-        interactiveTransition,
+        // Transition only the visual state — NOT position. The thumb is placed
+        // via an inline `left`/`bottom`; animating it would make the knob lag
+        // behind the pointer during a drag.
+        'transition-[box-shadow,transform,filter] duration-100 ease-out',
         shadow,
         lifted && 'scale-105 brightness-110',
         className

--- a/src/design-system/Slider/index.ts
+++ b/src/design-system/Slider/index.ts
@@ -1,2 +1,3 @@
 export { Slider } from './Slider';
 export type { SliderProps } from './Slider';
+export { SliderThumb } from './SliderThumb';

--- a/src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.tsx
+++ b/src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.tsx
@@ -11,6 +11,7 @@
 
 import { useId, useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from '@/i18n';
+import { SliderThumb } from '@/design-system/Slider';
 
 export interface SnappingSliderOption {
   /** The numeric value */
@@ -281,10 +282,10 @@ export function SnappingSlider({
           />
 
           {/* Visual thumb - larger for touch, follows drag smoothly */}
-          <div
-            className={`pointer-events-none absolute top-1/2 h-5 w-5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-accent bg-surface shadow-md transition-transform ${
-              isDragging ? 'scale-110' : ''
-            }`}
+          <SliderThumb
+            active={isDragging}
+            dragging={isDragging}
+            className="top-1/2 -translate-x-1/2 -translate-y-1/2"
             style={{ left: `${getPosition(thumbPosition)}%` }}
           />
         </div>

--- a/src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.tsx
+++ b/src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.tsx
@@ -283,7 +283,6 @@ export function SnappingSlider({
 
           {/* Visual thumb - larger for touch, follows drag smoothly */}
           <SliderThumb
-            active={isDragging}
             dragging={isDragging}
             className="top-1/2 -translate-x-1/2 -translate-y-1/2"
             style={{ left: `${getPosition(thumbPosition)}%` }}

--- a/src/features/bin-designer/components/preview/LidExplodeSlider/LidExplodeSlider.tsx
+++ b/src/features/bin-designer/components/preview/LidExplodeSlider/LidExplodeSlider.tsx
@@ -15,6 +15,7 @@ import { useCallback, useId, useRef, useState } from 'react';
 import { useTranslation } from '@/i18n';
 import { cn } from '@/design-system/cn';
 import { interactiveTransition } from '@/design-system/variants';
+import { SliderThumb } from '@/design-system/Slider';
 
 /**
  * Slider range in mm. Closed position is exactly the lid's mated
@@ -147,15 +148,21 @@ export function LidExplodeSlider({ value, onChange }: LidExplodeSliderProps) {
           style={{ height: `${percent}%` }}
         />
 
+        {/* Value bubble — shown beside the thumb while dragging. */}
+        {isDragging && (
+          <div
+            className="animate-scale-in pointer-events-none absolute right-full z-10 mr-1.5 translate-y-1/2 rounded-md border border-stroke-subtle bg-surface-elevated px-2 py-0.5 text-xs font-semibold tabular-nums text-content shadow-md"
+            style={{ bottom: `${percent}%` }}
+          >
+            {value}
+          </div>
+        )}
+
         {/* Thumb — `bottom: percent%` so 0% sits at the closed end, 100% at open. */}
-        <div
-          data-testid="slider-thumb"
-          className={cn(
-            'pointer-events-none absolute left-1/2 h-5 w-5 -translate-x-1/2 translate-y-1/2 rounded-full border-2 border-accent bg-surface shadow-sm',
-            interactiveTransition,
-            thumbActive && 'scale-110 shadow-md',
-            isDragging && 'ring-2 ring-accent/30'
-          )}
+        <SliderThumb
+          active={thumbActive}
+          dragging={isDragging}
+          className="left-1/2 -translate-x-1/2 translate-y-1/2"
           style={{ bottom: `${percent}%` }}
         />
 

--- a/src/index.css
+++ b/src/index.css
@@ -589,30 +589,68 @@ input[type='range']::-moz-range-track {
   height: 4px;
 }
 
+/* Filled, grip-textured knob matching the design-system SliderThumb. The
+   repeating-linear-gradient fakes three grip lines (pseudo-elements can't hold
+   child nodes); the linear-gradient gives the raised top-light body. The
+   2px surface halo keeps the knob crisp where it overlaps the accent fill. */
 input[type='range']::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  background: var(--color-accent);
+  height: 18px;
+  width: 18px;
   border-radius: 50%;
-  height: 14px;
-  width: 14px;
-  margin-top: -5px;
+  background:
+    repeating-linear-gradient(
+        90deg,
+        transparent 0 5px,
+        color-mix(in srgb, var(--text-on-accent) 45%, transparent) 5px 6px,
+        transparent 6px 8px
+      )
+      center / 9px 8px no-repeat,
+    linear-gradient(to bottom, var(--color-accent-hover), var(--color-accent));
+  box-shadow:
+    0 0 0 2px var(--color-surface),
+    var(--shadow-sm);
+  margin-top: -7px;
+  transition: all var(--transition-fast);
 }
 
 input[type='range']::-moz-range-thumb {
-  background: var(--color-accent);
+  height: 18px;
+  width: 18px;
   border: none;
   border-radius: 50%;
-  height: 14px;
-  width: 14px;
+  background:
+    repeating-linear-gradient(
+        90deg,
+        transparent 0 5px,
+        color-mix(in srgb, var(--text-on-accent) 45%, transparent) 5px 6px,
+        transparent 6px 8px
+      )
+      center / 9px 8px no-repeat,
+    linear-gradient(to bottom, var(--color-accent-hover), var(--color-accent));
+  box-shadow:
+    0 0 0 2px var(--color-surface),
+    var(--shadow-sm);
+  transition: all var(--transition-fast);
 }
 
 input[type='range']:hover::-webkit-slider-thumb {
-  background: var(--color-accent-hover);
+  transform: scale(1.05);
+  filter: brightness(1.1);
+  box-shadow:
+    0 0 0 2px var(--color-surface),
+    0 0 0 5px var(--color-accent-muted),
+    var(--shadow-md);
 }
 
 input[type='range']:hover::-moz-range-thumb {
-  background: var(--color-accent-hover);
+  transform: scale(1.05);
+  filter: brightness(1.1);
+  box-shadow:
+    0 0 0 2px var(--color-surface),
+    0 0 0 5px var(--color-accent-muted),
+    var(--shadow-md);
 }
 
 /* ===========================================

--- a/src/index.css
+++ b/src/index.css
@@ -612,7 +612,11 @@ input[type='range']::-webkit-slider-thumb {
     0 0 0 2px var(--color-surface),
     var(--shadow-sm);
   margin-top: -7px;
-  transition: all var(--transition-fast);
+  /* Visual state only — animating position would lag the knob behind drags. */
+  transition:
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast),
+    filter var(--transition-fast);
 }
 
 input[type='range']::-moz-range-thumb {
@@ -632,7 +636,10 @@ input[type='range']::-moz-range-thumb {
   box-shadow:
     0 0 0 2px var(--color-surface),
     var(--shadow-sm);
-  transition: all var(--transition-fast);
+  transition:
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast),
+    filter var(--transition-fast);
 }
 
 input[type='range']:hover::-webkit-slider-thumb {


### PR DESCRIPTION
## What

Replaces the plain hollow-ring slider thumb with a **filled, grip-textured knob** that matches the rest of the app's visual polish — applied across every slider surface.

| Before | After |
| --- | --- |
| Flat hollow ring (surface center + thin accent border) | Filled accent knob with three grip lines, surface halo, depth shadow, and hover/drag glow |

## Where

- **`design-system/Slider/SliderThumb.tsx`** (new) — one shared presentational knob, exported from the Slider barrel.
- **`Slider`** primitive (powers app-wide `SliderInput`) — uses `SliderThumb` + adds a drag value bubble.
- **`SnappingSlider`** and **`LidExplodeSlider`** — adopt the same knob (LidExplode also gets a drag value bubble; SnappingSlider keeps its existing live value badge).
- **`index.css`** — native `input[type=range]` thumb restyled to match (grip lines faked via `repeating-linear-gradient`, surface halo, brightness + glow on hover).

## Polish details (matched to existing components)

- **Top-light accent gradient** (`from-accent-hover to-accent`) — same DNA as the primary button.
- **Surface halo** via layered `box-shadow` — keeps the filled knob crisp where it overlaps the same-colored accent fill (the filled portion of the track), and reuses the app's `0 0 0 Npx` ring vocabulary.
- **`brightness-110` + `accent-muted` glow + gentle `scale-105`** on hover/drag — mirrors the button/focus treatment.
- **Value bubble** styled like the app's floating surfaces (elevated surface, `stroke-subtle` border, `shadow-md`, `animate-scale-in`).
- Grip lines drawn in the `on-accent` tint so they read as knurling on the amber body.

## Testing

- New `SliderThumb.test.tsx`; `Slider` / `SnappingSlider` / `LidExplodeSlider` tests green (43 passing across the 4 files).
- typecheck + lint clean.
- Visually verified in `/designer` (knob detail, surface halo, and lifted drag glow over the filled track).