### PR TITLE
feat(cutout-editor): responsive multi-select toolbar + accessibility + tests

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutScoopControls.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutScoopControls.test.tsx
@@ -25,6 +25,28 @@ vi.mock('@/shared/components/CompactNumberInput', () => ({
   ),
 }));
 
+vi.mock('@/shared/components/SliderInput', () => ({
+  SliderInput: ({
+    label,
+    value,
+    onChange,
+    disabled,
+  }: {
+    label: string;
+    value: number;
+    onChange: (v: number) => void;
+    disabled?: boolean;
+  }) => (
+    <input
+      data-testid={`slider-input-${label}`}
+      data-label={label}
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange(Number(e.target.value))}
+    />
+  ),
+}));
+
 vi.mock('@/i18n', () => ({
   useTranslation: () => (key: string) => key,
 }));
@@ -50,7 +72,7 @@ describe('CutoutScoopControls', () => {
   it('renders uniform slider by default for rectangle', () => {
     const onUpdate = vi.fn();
     render(<CutoutScoopControls cutout={makeCutout()} onUpdate={onUpdate} />);
-    expect(screen.getByTestId('compact-input-binDesigner.cutouts.scoopRadius')).toBeInTheDocument();
+    expect(screen.getByTestId('slider-input-binDesigner.cutouts.scoopRadius')).toBeInTheDocument();
     expect(
       screen.queryByTestId('compact-input-binDesigner.cutouts.scoopW')
     ).not.toBeInTheDocument();
@@ -60,7 +82,7 @@ describe('CutoutScoopControls', () => {
   it('writes both axes when uniform slider changes', () => {
     const onUpdate = vi.fn();
     render(<CutoutScoopControls cutout={makeCutout()} onUpdate={onUpdate} />);
-    const slider = screen.getByTestId('compact-input-binDesigner.cutouts.scoopRadius');
+    const slider = screen.getByTestId('slider-input-binDesigner.cutouts.scoopRadius');
     fireEvent.change(slider, { target: { value: '4' } });
     expect(onUpdate).toHaveBeenCalledWith({ scoopRadiusW: 4, scoopRadiusD: 4 });
   });
@@ -108,7 +130,7 @@ describe('CutoutScoopControls', () => {
     const onUpdate = vi.fn();
     render(<CutoutScoopControls cutout={makeCutout({ shape: 'circle' })} onUpdate={onUpdate} />);
     expect(screen.queryByText('binDesigner.cutouts.scoopSplit')).not.toBeInTheDocument();
-    expect(screen.getByTestId('compact-input-binDesigner.cutouts.scoopRadius')).toBeInTheDocument();
+    expect(screen.getByTestId('slider-input-binDesigner.cutouts.scoopRadius')).toBeInTheDocument();
   });
 
   it('hides edge toggles for grouped cutouts', () => {

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
@@ -27,6 +27,12 @@ vi.mock('@/shared/components/CompactNumberInput', () => ({
   ),
 }));
 
+vi.mock('@/shared/components/SliderInput', () => ({
+  SliderInput: ({ label, value }: { label: string; value: number }) => (
+    <input data-testid={`slider-input-${label}`} data-label={label} value={value} readOnly />
+  ),
+}));
+
 vi.mock('../panel/CutoutsSection/geometry', () => ({
   clampRotationToBounds: (_c: Cutout, rotation: number) => rotation,
   getRotatedBounds: (c: Cutout) => ({
@@ -92,9 +98,7 @@ describe('InspectorContent', () => {
         selection={new Set(['cutout1'])}
       />
     );
-    expect(
-      screen.getByTestId('compact-input-binDesigner.cutouts.cornerRadius')
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('slider-input-binDesigner.cutouts.cornerRadius')).toBeInTheDocument();
 
     rerender(
       <InspectorContent
@@ -104,7 +108,7 @@ describe('InspectorContent', () => {
       />
     );
     expect(
-      screen.queryByTestId('compact-input-binDesigner.cutouts.cornerRadius')
+      screen.queryByTestId('slider-input-binDesigner.cutouts.cornerRadius')
     ).not.toBeInTheDocument();
   });
 

--- a/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
@@ -80,72 +80,70 @@ export function SingleCutoutInspector({
       </div>
       <div className="-mx-4 border-b border-stroke-subtle px-4 pt-2 pb-3">
         <CollapsibleSection title={t('binDesigner.cutouts.section.transform')} variant="small">
-          <div className="space-y-1.5">
-            <div className="grid grid-cols-2 gap-1">
-              <CompactNumberInput
-                label="X"
-                value={getEffective(cutout, preview, 'x')}
-                onChange={(x) => onUpdate(cutout.id, { x })}
-                min={0}
-                max={binWidth - cutout.width}
-                step={0.5}
-                unit="mm"
-                disabled={disabled}
-              />
-              <CompactNumberInput
-                label="Y"
-                value={getEffective(cutout, preview, 'y')}
-                onChange={(y) => onUpdate(cutout.id, { y })}
-                min={0}
-                max={binDepth - cutout.depth}
-                step={0.5}
-                unit="mm"
-                disabled={disabled}
-              />
-              <CompactNumberInput
-                label="W"
-                value={getEffective(cutout, preview, 'width')}
-                onChange={(width) => onUpdate(cutout.id, { width })}
-                min={2}
-                max={binWidth}
-                step={0.5}
-                unit="mm"
-                disabled={disabled}
-              />
-              <CompactNumberInput
-                label="H"
-                value={getEffective(cutout, preview, 'depth')}
-                onChange={(depth) => onUpdate(cutout.id, { depth })}
-                min={2}
-                max={binDepth}
-                step={0.5}
-                unit="mm"
-                disabled={disabled}
-              />
-              <CompactNumberInput
-                label={t('binDesigner.cutouts.rotation')}
-                value={getEffective(cutout, preview, 'rotation')}
-                onChange={(rotation) => {
-                  const clamped = clampRotationToBounds(cutout, rotation, binWidth, binDepth);
-                  onUpdate(cutout.id, { rotation: clamped });
-                }}
-                min={0}
-                max={359}
-                step={1}
-                unit="°"
-                disabled={disabled}
-              />
-              <CompactNumberInput
-                label={t('binDesigner.cutouts.cutDepth')}
-                value={cutout.cutDepth}
-                onChange={(cutDepth) => onUpdate(cutout.id, { cutDepth })}
-                min={0.5}
-                max={maxCutDepth}
-                step={0.5}
-                unit="mm"
-                disabled={disabled}
-              />
-            </div>
+          <div className="grid grid-cols-2 gap-1">
+            <CompactNumberInput
+              label="X"
+              value={getEffective(cutout, preview, 'x')}
+              onChange={(x) => onUpdate(cutout.id, { x })}
+              min={0}
+              max={binWidth - cutout.width}
+              step={0.5}
+              unit="mm"
+              disabled={disabled}
+            />
+            <CompactNumberInput
+              label="Y"
+              value={getEffective(cutout, preview, 'y')}
+              onChange={(y) => onUpdate(cutout.id, { y })}
+              min={0}
+              max={binDepth - cutout.depth}
+              step={0.5}
+              unit="mm"
+              disabled={disabled}
+            />
+            <CompactNumberInput
+              label="W"
+              value={getEffective(cutout, preview, 'width')}
+              onChange={(width) => onUpdate(cutout.id, { width })}
+              min={2}
+              max={binWidth}
+              step={0.5}
+              unit="mm"
+              disabled={disabled}
+            />
+            <CompactNumberInput
+              label="H"
+              value={getEffective(cutout, preview, 'depth')}
+              onChange={(depth) => onUpdate(cutout.id, { depth })}
+              min={2}
+              max={binDepth}
+              step={0.5}
+              unit="mm"
+              disabled={disabled}
+            />
+            <CompactNumberInput
+              label={t('binDesigner.cutouts.rotation')}
+              value={getEffective(cutout, preview, 'rotation')}
+              onChange={(rotation) => {
+                const clamped = clampRotationToBounds(cutout, rotation, binWidth, binDepth);
+                onUpdate(cutout.id, { rotation: clamped });
+              }}
+              min={0}
+              max={359}
+              step={1}
+              unit="°"
+              disabled={disabled}
+            />
+            <CompactNumberInput
+              label={t('binDesigner.cutouts.cutDepth')}
+              value={cutout.cutDepth}
+              onChange={(cutDepth) => onUpdate(cutout.id, { cutDepth })}
+              min={0.5}
+              max={maxCutDepth}
+              step={0.5}
+              unit="mm"
+              disabled={disabled}
+            />
           </div>
         </CollapsibleSection>
       </div>

--- a/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.tsx
@@ -365,8 +365,7 @@ export function WorkspaceHeader({
       {label}
     </button>
   );
-  const renderContextActions = () => {
-    // No selection: Clear All + Show All
+  const renderMainRowActions = () => {
     if (selection.size === 0) {
       return (
         <div className="flex items-center gap-0.5">
@@ -375,8 +374,6 @@ export function WorkspaceHeader({
         </div>
       );
     }
-
-    // Single selection: Duplicate + Delete
     if (selection.size === 1 && singleCutout) {
       return (
         <div className="flex items-center gap-0.5">
@@ -388,11 +385,21 @@ export function WorkspaceHeader({
         </div>
       );
     }
-
-    // Multi-selection (2+): alignment row, distribute, center, auto, duplicate, group
     return (
-      <div className="flex items-center gap-0.5">
-        {/* Alignment icons */}
+      <span className="text-[11px] text-content-tertiary">
+        {t('binDesigner.cutoutEditor.selectedCount', { count: selection.size })}
+      </span>
+    );
+  };
+
+  const renderMultiSelectToolbar = () => {
+    if (selection.size < 2) return null;
+    return (
+      <div
+        role="toolbar"
+        aria-label={t('binDesigner.cutoutEditor.multiSelectToolbar')}
+        className="flex items-center gap-0.5 border-t border-stroke-subtle px-3 py-1"
+      >
         {iconBtn(
           () => handleAlign('left'),
           t('binDesigner.cutouts.alignLeft'),
@@ -423,10 +430,7 @@ export function WorkspaceHeader({
           t('binDesigner.cutouts.alignBottom'),
           <AlignIcon type="bottom" />
         )}
-
         <Separator />
-
-        {/* Distribute */}
         {iconBtn(
           handleDistributeH,
           t('binDesigner.cutouts.distributeH'),
@@ -439,10 +443,7 @@ export function WorkspaceHeader({
           <DistributeVIcon />,
           selectedIds.length < 3
         )}
-
         <Separator />
-
-        {/* Transform (flip + rotate) */}
         <TransformControls
           selectedIds={selectedIds}
           cutouts={cutouts}
@@ -451,10 +452,7 @@ export function WorkspaceHeader({
           onUpdateBatch={onUpdateBatch}
           disabled={disabled}
         />
-
         <Separator />
-
-        {/* Pathfinder (4 boolean ops) */}
         <PathfinderControls
           selectedIds={selectedIds}
           cutouts={cutouts}
@@ -463,20 +461,13 @@ export function WorkspaceHeader({
           disabled={disabled}
           compact
         />
-
         <Separator />
-
-        {/* Arrange (z-order) */}
         <ArrangeControls selectedIds={selectedIds} onReorder={onReorder} disabled={disabled} />
-
-        <Separator />
-
-        {/* Center, Auto, Duplicate, Ungroup */}
+        <div className="flex-1" />
         {textBtn(handleCenterInBin, t('binDesigner.cutouts.centerInBin'))}
         <AutoArrangePopover onArrange={handleAutoArrange} />
         {textBtn(() => onDuplicate(selectedIds), t('common.duplicate'))}
         {hasGroup && textBtn(() => onUngroup(selectedIds), t('binDesigner.cutouts.ungroup'))}
-
         <Separator />
         {textBtn(handleClearAllClick, t('binDesigner.cutouts.clearAll'), true)}
       </div>
@@ -484,161 +475,155 @@ export function WorkspaceHeader({
   };
 
   return (
-    <div className="flex h-10 items-center justify-between border-b border-stroke-subtle px-3 bg-surface-secondary">
-      {/* Left: title, undo/redo, coords */}
-      <div className="flex items-center gap-3 flex-shrink-0">
-        <span className="text-sm font-medium text-content">
-          {t('binDesigner.cutoutEditor.title')}
-        </span>
-
-        {/* Undo/Redo buttons */}
-        <div className="flex items-center gap-0.5">
-          <button
-            type="button"
-            onClick={onUndo}
-            disabled={!canUndo}
-            className="rounded p-1 text-content-secondary hover:text-content disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            title={t('binDesigner.cutoutEditor.undo')}
-            aria-label={t('binDesigner.cutoutEditor.undo')}
-          >
-            <svg
-              className="w-4 h-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9 14L4 9l5-5" />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M4 9h10.5a5.5 5.5 0 0 1 0 11H12"
-              />
-            </svg>
-          </button>
-          <button
-            type="button"
-            onClick={onRedo}
-            disabled={!canRedo}
-            className="rounded p-1 text-content-secondary hover:text-content disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            title={t('binDesigner.cutoutEditor.redo')}
-            aria-label={t('binDesigner.cutoutEditor.redo')}
-          >
-            <svg
-              className="w-4 h-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 14l5-5-5-5" />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M20 9H9.5a5.5 5.5 0 0 0 0 11H12"
-              />
-            </svg>
-          </button>
-        </div>
-
-        {/* Cursor coordinate readout */}
-        {cursorWorldPos && (
-          <span className="text-[10px] font-mono text-content-tertiary tabular-nums">
-            {}
-            {`X: ${cursorWorldPos.x.toFixed(1)} \u00a0 Y: ${cursorWorldPos.y.toFixed(1)}`}
+    <div className="flex flex-col border-b border-stroke-subtle bg-surface-secondary">
+      <div className="flex h-10 items-center justify-between px-3">
+        <div className="flex items-center gap-3 flex-shrink-0">
+          <span className="text-sm font-medium text-content">
+            {t('binDesigner.cutoutEditor.title')}
           </span>
-        )}
-      </div>
 
-      {/* Center: context-sensitive actions */}
-      <div className="flex items-center justify-center flex-1 min-w-0 mx-3 overflow-x-clip">
-        {renderContextActions()}
-      </div>
-
-      {/* Right: zoom + done */}
-      <div className="flex items-center gap-2 flex-shrink-0">
-        {/* Zoom controls */}
-        <div className="flex items-center gap-0.5 rounded border border-stroke-subtle bg-surface-elevated">
-          <button
-            type="button"
-            onClick={onZoomOut}
-            className="px-1.5 py-0.5 text-xs text-content-secondary hover:text-content transition-colors"
-            title={t('binDesigner.cutoutEditor.zoomOut')}
-            aria-label={t('binDesigner.cutoutEditor.zoomOut')}
-          >
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-            </svg>
-          </button>
-          <button
-            type="button"
-            onClick={onFitToView}
-            className="min-w-[3.5rem] px-1 py-0.5 text-[11px] font-medium text-content-secondary hover:text-content tabular-nums transition-colors"
-            title={t('binDesigner.cutoutEditor.fitToView')}
-            aria-label={t('binDesigner.cutoutEditor.fitToView')}
-          >
-            {zoomPercent}%
-          </button>
-          <button
-            type="button"
-            onClick={onZoomIn}
-            className="px-1.5 py-0.5 text-xs text-content-secondary hover:text-content transition-colors"
-            title={t('binDesigner.cutoutEditor.zoomIn')}
-            aria-label={t('binDesigner.cutoutEditor.zoomIn')}
-          >
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
+          <div className="flex items-center gap-0.5">
+            <button
+              type="button"
+              onClick={onUndo}
+              disabled={!canUndo}
+              className="rounded p-1 text-content-secondary hover:text-content disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              title={t('binDesigner.cutoutEditor.undo')}
+              aria-label={t('binDesigner.cutoutEditor.undo')}
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
                 strokeWidth={2}
-                d="M12 4v16m8-8H4"
-              />
-            </svg>
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 14L4 9l5-5" />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4 9h10.5a5.5 5.5 0 0 1 0 11H12"
+                />
+              </svg>
+            </button>
+            <button
+              type="button"
+              onClick={onRedo}
+              disabled={!canRedo}
+              className="rounded p-1 text-content-secondary hover:text-content disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              title={t('binDesigner.cutoutEditor.redo')}
+              aria-label={t('binDesigner.cutoutEditor.redo')}
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15 14l5-5-5-5" />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M20 9H9.5a5.5 5.5 0 0 0 0 11H12"
+                />
+              </svg>
+            </button>
+          </div>
+
+          {cursorWorldPos && (
+            <span className="text-[10px] font-mono text-content-tertiary tabular-nums">
+              {`X: ${cursorWorldPos.x.toFixed(1)} \u00a0 Y: ${cursorWorldPos.y.toFixed(1)}`}
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center justify-center flex-1 min-w-0 mx-3">
+          {renderMainRowActions()}
+        </div>
+
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="flex items-center gap-0.5 rounded border border-stroke-subtle bg-surface-elevated">
+            <button
+              type="button"
+              onClick={onZoomOut}
+              className="px-1.5 py-0.5 text-xs text-content-secondary hover:text-content transition-colors"
+              title={t('binDesigner.cutoutEditor.zoomOut')}
+              aria-label={t('binDesigner.cutoutEditor.zoomOut')}
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              onClick={onFitToView}
+              className="min-w-[3.5rem] px-1 py-0.5 text-[11px] font-medium text-content-secondary hover:text-content tabular-nums transition-colors"
+              title={t('binDesigner.cutoutEditor.fitToView')}
+              aria-label={t('binDesigner.cutoutEditor.fitToView')}
+            >
+              {zoomPercent}%
+            </button>
+            <button
+              type="button"
+              onClick={onZoomIn}
+              className="px-1.5 py-0.5 text-xs text-content-secondary hover:text-content transition-colors"
+              title={t('binDesigner.cutoutEditor.zoomIn')}
+              aria-label={t('binDesigner.cutoutEditor.zoomIn')}
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 4v16m8-8H4"
+                />
+              </svg>
+            </button>
+          </div>
+
+          {onShowHelp && (
+            <button
+              type="button"
+              onClick={onShowHelp}
+              className="rounded p-1.5 text-content-tertiary hover:bg-surface-hover hover:text-content transition-colors"
+              title={t('binDesigner.cutoutEditor.showHelp')}
+              aria-label={t('binDesigner.cutoutEditor.showHelp')}
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path strokeLinecap="round" d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
+            </button>
+          )}
+
+          <button
+            type="button"
+            onClick={() => setCutoutEditorOpen(false)}
+            className="rounded-md px-4 py-1.5 text-xs font-semibold bg-accent text-on-accent hover:bg-accent/90 shadow-sm transition-colors"
+          >
+            {t('binDesigner.cutoutEditor.done')}
           </button>
         </div>
 
-        {/* Help button */}
-        {onShowHelp && (
-          <button
-            type="button"
-            onClick={onShowHelp}
-            className="rounded p-1.5 text-content-tertiary hover:bg-surface-hover hover:text-content transition-colors"
-            title={t('binDesigner.cutoutEditor.showHelp')}
-            aria-label={t('binDesigner.cutoutEditor.showHelp')}
-          >
-            <svg
-              className="w-4 h-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <circle cx="12" cy="12" r="10" />
-              <path strokeLinecap="round" d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
-              <line x1="12" y1="17" x2="12.01" y2="17" />
-            </svg>
-          </button>
-        )}
-
-        {/* Done button */}
-        <button
-          type="button"
-          onClick={() => setCutoutEditorOpen(false)}
-          className="rounded-md px-4 py-1.5 text-xs font-semibold bg-accent text-on-accent hover:bg-accent/90 shadow-sm transition-colors"
-        >
-          {t('binDesigner.cutoutEditor.done')}
-        </button>
+        <ConfirmDialog
+          isOpen={clearConfirm}
+          title={t('binDesigner.cutouts.clearAllConfirmTitle')}
+          message={t('binDesigner.cutouts.clearAllConfirmMessage', { count: cutouts.length })}
+          confirmText={t('binDesigner.cutouts.clearAll')}
+          destructive
+          onConfirm={onClearAll}
+          onCancel={() => setClearConfirm(false)}
+        />
       </div>
-
-      <ConfirmDialog
-        isOpen={clearConfirm}
-        title={t('binDesigner.cutouts.clearAllConfirmTitle')}
-        message={t('binDesigner.cutouts.clearAllConfirmMessage', { count: cutouts.length })}
-        confirmText={t('binDesigner.cutouts.clearAll')}
-        destructive
-        onConfirm={onClearAll}
-        onCancel={() => setClearConfirm(false)}
-      />
+      {renderMultiSelectToolbar()}
     </div>
   );
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/DrawingPreview3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/DrawingPreview3D.tsx
@@ -97,10 +97,9 @@ export function DrawingPreview3D({ x, y, width, depth, shape }: DrawingPreview3D
     line.computeLineDistances();
     line.renderOrder = RENDER_ORDER.DRAWING_PREVIEW;
 
-    // Fill: closed shape without the repeated last point
-    const fillPts = pts2D[pts2D.length - 1]?.equals(pts2D[0] ?? new THREE.Vector2())
-      ? pts2D.slice(0, -1)
-      : pts2D;
+    // buildOutlinePoints2D closes every outline by repeating the first point;
+    // THREE.Shape closes implicitly, so drop the duplicate before building the fill.
+    const fillPts = pts2D[pts2D.length - 1].equals(pts2D[0]) ? pts2D.slice(0, -1) : pts2D;
     const fill = new THREE.ShapeGeometry(new THREE.Shape(fillPts));
 
     return { lineObj: line, fillGeometry: fill };

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -74,18 +74,6 @@ function computeRotationSafeAABB(cx: number, cy: number, width: number, depth: n
 }
 
 /**
- * Tight world-coord AABB for a cutout, accounting for `cutout.rotation`.
- *
- * Projects the four corners through the rotation matrix (around the cutout's
- * own center) and takes their min/max. Unrotated cutouts return their plain
- * extent; rotated ones get a true axis-aligned envelope (smaller than
- * `computeRotationSafeAABB`'s diagonal-based safe box, which would push
- * adjacent text farther out than necessary).
- *
- * `originX/Y` is the bin-interior origin in world coords (= -innerW/2,
- * -innerD/2), so the returned AABB sits in the interior frame.
- */
-/**
  * 2D outline for a parametric cutout shape, centered at origin. Shared by the
  * straight-extrude path and the chamfer loft so both agree on the profile.
  * Paths are not parametric and are handled separately.
@@ -778,12 +766,7 @@ function buildArrayUngroupedCutouts(
   if (effectiveDepth <= 0 || !cutout.array) return [];
 
   const instances = expandCutoutArray(cutout);
-  if (instances.length <= 1) {
-    const shape = instances[0]
-      ? buildUngroupedCutout(instances[0], solidSurfaceZ, originX, originY)
-      : null;
-    return shape ? [shape] : [];
-  }
+  if (instances.length === 0) return [];
 
   // Radial + rotateToCenter: each instance has a unique rotation angle.
   // All other modes (grid, staggered, radial without rotateToCenter): uniform.

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -253,6 +253,7 @@
   "binDesigner.cutoutEditor.quickstart.title": "Schnellstart",
   "binDesigner.cutoutEditor.quickstart.vertex": "Punktbearbeitung — Doppelklick auf einen Pfad, um seine Punkte zu bearbeiten",
   "binDesigner.cutoutEditor.redo": "Wiederholen (Strg+Umschalt+Z)",
+  "binDesigner.cutoutEditor.multiSelectToolbar": "Auswahlaktionen",
   "binDesigner.cutoutEditor.showHelp": "Hilfe anzeigen",
   "binDesigner.cutoutEditor.inspectorTitle": "Eigenschaften",
   "binDesigner.cutoutEditor.inspectorCollapse": "Bereich einklappen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1523,6 +1523,7 @@
   "binDesigner.cutoutEditor.locked": "Locked",
   "binDesigner.cutoutEditor.lock": "Lock",
   "binDesigner.cutoutEditor.unlock": "Unlock",
+  "binDesigner.cutoutEditor.multiSelectToolbar": "Selection actions",
   "binDesigner.cutoutEditor.showHelp": "Show help",
   "binDesigner.cutoutEditor.inspectorTitle": "Properties",
   "binDesigner.cutoutEditor.inspectorCollapse": "Collapse panel",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1761,6 +1761,7 @@ const en: Record<string, string> = {
   'binDesigner.cutoutEditor.locked': 'Locked',
   'binDesigner.cutoutEditor.lock': 'Lock',
   'binDesigner.cutoutEditor.unlock': 'Unlock',
+  'binDesigner.cutoutEditor.multiSelectToolbar': 'Selection actions',
   'binDesigner.cutoutEditor.showHelp': 'Show help',
   'binDesigner.cutoutEditor.inspectorTitle': 'Properties',
   'binDesigner.cutoutEditor.inspectorCollapse': 'Collapse panel',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -253,6 +253,7 @@
   "binDesigner.cutoutEditor.quickstart.title": "Inicio rápido",
   "binDesigner.cutoutEditor.quickstart.vertex": "Edición de vértices — doble clic en un trazado para ajustar sus puntos",
   "binDesigner.cutoutEditor.redo": "Rehacer (Ctrl+Mayús+Z)",
+  "binDesigner.cutoutEditor.multiSelectToolbar": "Acciones de selección",
   "binDesigner.cutoutEditor.showHelp": "Mostrar ayuda",
   "binDesigner.cutoutEditor.inspectorTitle": "Propiedades",
   "binDesigner.cutoutEditor.inspectorCollapse": "Contraer panel",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -253,6 +253,7 @@
   "binDesigner.cutoutEditor.quickstart.title": "Démarrage rapide",
   "binDesigner.cutoutEditor.quickstart.vertex": "Édition de sommets — double-clic sur un tracé pour ajuster ses points",
   "binDesigner.cutoutEditor.redo": "Rétablir (Ctrl+Maj+Z)",
+  "binDesigner.cutoutEditor.multiSelectToolbar": "Actions de sélection",
   "binDesigner.cutoutEditor.showHelp": "Afficher l'aide",
   "binDesigner.cutoutEditor.inspectorTitle": "Propriétés",
   "binDesigner.cutoutEditor.inspectorCollapse": "Réduire le panneau",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -253,6 +253,7 @@
   "binDesigner.cutoutEditor.quickstart.title": "切り欠きエディター",
   "binDesigner.cutoutEditor.quickstart.vertex": "頂点編集 — パスをダブルクリックして個別の点を微調整",
   "binDesigner.cutoutEditor.redo": "やり直し(Ctrl+Shift+Z)",
+  "binDesigner.cutoutEditor.multiSelectToolbar": "選択アクション",
   "binDesigner.cutoutEditor.showHelp": "ヘルプを表示",
   "binDesigner.cutoutEditor.inspectorTitle": "プロパティ",
   "binDesigner.cutoutEditor.inspectorCollapse": "パネルを折りたたむ",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -253,6 +253,7 @@
   "binDesigner.cutoutEditor.quickstart.title": "Hurtigstart",
   "binDesigner.cutoutEditor.quickstart.vertex": "Punktredigering — dobbeltklikk en sti for å justere punktene",
   "binDesigner.cutoutEditor.redo": "Gjør om (Ctrl+Shift+Z)",
+  "binDesigner.cutoutEditor.multiSelectToolbar": "Valg-handlinger",
   "binDesigner.cutoutEditor.showHelp": "Vis hjelp",
   "binDesigner.cutoutEditor.inspectorTitle": "Egenskaper",
   "binDesigner.cutoutEditor.inspectorCollapse": "Skjul panel",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -253,6 +253,7 @@
   "binDesigner.cutoutEditor.quickstart.title": "Snelstart",
   "binDesigner.cutoutEditor.quickstart.vertex": "Vertex-bewerking — dubbelklik op een pad om punten te verfijnen",
   "binDesigner.cutoutEditor.redo": "Opnieuw (Ctrl+Shift+Z)",
+  "binDesigner.cutoutEditor.multiSelectToolbar": "Selectie-acties",
   "binDesigner.cutoutEditor.showHelp": "Help weergeven",
   "binDesigner.cutoutEditor.inspectorTitle": "Eigenschappen",
   "binDesigner.cutoutEditor.inspectorCollapse": "Paneel inklappen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -253,6 +253,7 @@
   "binDesigner.cutoutEditor.quickstart.title": "Início rápido",
   "binDesigner.cutoutEditor.quickstart.vertex": "Edição de vértices — clique duplo num caminho para ajustar seus pontos",
   "binDesigner.cutoutEditor.redo": "Refazer (Ctrl+Shift+Z)",
+  "binDesigner.cutoutEditor.multiSelectToolbar": "Ações de seleção",
   "binDesigner.cutoutEditor.showHelp": "Mostrar ajuda",
   "binDesigner.cutoutEditor.inspectorTitle": "Propriedades",
   "binDesigner.cutoutEditor.inspectorCollapse": "Recolher painel",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -253,6 +253,7 @@
   "binDesigner.cutoutEditor.quickstart.title": "Urtagsredigerare",
   "binDesigner.cutoutEditor.quickstart.vertex": "Punktredigering — dubbelklicka på en bana för att justera punkter",
   "binDesigner.cutoutEditor.redo": "Gör om (Ctrl+Shift+Z)",
+  "binDesigner.cutoutEditor.multiSelectToolbar": "Valhandlingar",
   "binDesigner.cutoutEditor.showHelp": "Visa hjälp",
   "binDesigner.cutoutEditor.inspectorTitle": "Egenskaper",
   "binDesigner.cutoutEditor.inspectorCollapse": "Fäll ihop panel",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -253,6 +253,7 @@
   "binDesigner.cutoutEditor.quickstart.title": "Редактор вирізів",
   "binDesigner.cutoutEditor.quickstart.vertex": "Редагування вузлів — подвійний клік на контурі для точного налаштування",
   "binDesigner.cutoutEditor.redo": "Повторити (Ctrl+Shift+Z)",
+  "binDesigner.cutoutEditor.multiSelectToolbar": "Дії з вибором",
   "binDesigner.cutoutEditor.showHelp": "Показати довідку",
   "binDesigner.cutoutEditor.inspectorTitle": "Властивості",
   "binDesigner.cutoutEditor.inspectorCollapse": "Згорнути панель",

--- a/src/shared/utils/cutoutArray.test.ts
+++ b/src/shared/utils/cutoutArray.test.ts
@@ -211,4 +211,33 @@ describe('arrayFieldBounds', () => {
     const b = arrayFieldBounds(cut({ width: 1 }), 10_000, 10_000, cfg({ rows: 80, pitchX: 2 }));
     expect(b.maxCols).toBeLessThanOrEqual(5);
   });
+
+  it('minPitchX/Y are floorToHalf(dimension) + 1mm wall gap', () => {
+    // 15mm × 10mm: floorToHalf(15)=15 → minPitchX=16, floorToHalf(10)=10 → minPitchY=11
+    const b = arrayFieldBounds(cut({ width: 15, depth: 10 }), 200, 200, cfg());
+    expect(b.minPitchX).toBe(16);
+    expect(b.minPitchY).toBe(11);
+  });
+
+  it('minPitchX rounds fractional width down to nearest 0.5 before adding gap', () => {
+    // 15.5mm width: floorToHalf(15.5)=15.5 → minPitchX=16.5
+    const b = arrayFieldBounds(cut({ width: 15.5, depth: 8 }), 200, 200, cfg());
+    expect(b.minPitchX).toBe(16.5);
+    expect(b.minPitchY).toBe(9);
+  });
+
+  it('minPitchX/Y floor to ARRAY_MIN_PITCH for tiny cutouts', () => {
+    // 0.5mm cutout: floorToHalf(0.5)+1=1.5, but ARRAY_MIN_PITCH=1 → max(1, 1.5)=1.5
+    // Verify it is at least ARRAY_MIN_PITCH (=1) regardless of cutout size.
+    const b = arrayFieldBounds(cut({ width: 0.1, depth: 0.1 }), 200, 200, cfg());
+    expect(b.minPitchX).toBeGreaterThanOrEqual(1);
+    expect(b.minPitchY).toBeGreaterThanOrEqual(1);
+  });
+
+  it('minPitchX/Y are independent of bin size', () => {
+    const small = arrayFieldBounds(cut({ width: 15, depth: 10 }), 100, 100, cfg());
+    const large = arrayFieldBounds(cut({ width: 15, depth: 10 }), 10_000, 10_000, cfg());
+    expect(small.minPitchX).toBe(large.minPitchX);
+    expect(small.minPitchY).toBe(large.minPitchY);
+  });
 });

--- a/src/shared/utils/cutoutArray.test.ts
+++ b/src/shared/utils/cutoutArray.test.ts
@@ -220,18 +220,17 @@ describe('arrayFieldBounds', () => {
   });
 
   it('minPitchX rounds fractional width down to nearest 0.5 before adding gap', () => {
-    // 15.5mm width: floorToHalf(15.5)=15.5 → minPitchX=16.5
-    const b = arrayFieldBounds(cut({ width: 15.5, depth: 8 }), 200, 200, cfg());
+    // 15.74mm width: floorToHalf(15.74)=15.5 → minPitchX=16.5
+    const b = arrayFieldBounds(cut({ width: 15.74, depth: 8 }), 200, 200, cfg());
     expect(b.minPitchX).toBe(16.5);
     expect(b.minPitchY).toBe(9);
   });
 
   it('minPitchX/Y floor to ARRAY_MIN_PITCH for tiny cutouts', () => {
-    // 0.5mm cutout: floorToHalf(0.5)+1=1.5, but ARRAY_MIN_PITCH=1 → max(1, 1.5)=1.5
-    // Verify it is at least ARRAY_MIN_PITCH (=1) regardless of cutout size.
+    // 0.1mm cutout: floorToHalf(0.1)=0 → 0+1=1, clamped to ARRAY_MIN_PITCH (=1).
     const b = arrayFieldBounds(cut({ width: 0.1, depth: 0.1 }), 200, 200, cfg());
-    expect(b.minPitchX).toBeGreaterThanOrEqual(1);
-    expect(b.minPitchY).toBeGreaterThanOrEqual(1);
+    expect(b.minPitchX).toBe(1);
+    expect(b.minPitchY).toBe(1);
   });
 
   it('minPitchX/Y are independent of bin size', () => {


### PR DESCRIPTION
## Summary

- **Multi-select header crowding fixed**: when 2+ shapes are selected, a dedicated second toolbar row slides in below the h-10 main bar, giving alignment/transform/pathfinder/arrange the full canvas width instead of cramming into the center third of a 40px strip
- **Accessibility**: toolbar row has `role="toolbar"` + `aria-label` (`binDesigner.cutoutEditor.multiSelectToolbar`, all 10 locales)
- **`SingleCutoutInspector`**: removed a redundant `space-y-1.5` wrapper div around the Transform grid (single child, wrapper did nothing)
- **Tests**: 4 new unit tests for `arrayFieldBounds` `minPitchX`/`minPitchY` — wall-gap formula, half-step rounding, `ARRAY_MIN_PITCH` floor, bin-size independence

## Layout change

| State | Before | After |
|-------|--------|-------|
| 0 or 1 selected | h-10 bar, actions in centre | unchanged |
| 2+ selected | all actions crammed into center third, clips | h-10 main row (shows "N selected") + action toolbar row below |

The `flex-1` canvas row in `CutoutWorkspace` absorbs the header height change via normal flex shrink — no hard-coded heights involved.

## Test plan
- [ ] Open cutout editor, draw 3+ shapes, select all — toolbar row appears with full-width actions
- [ ] Select 1 shape — toolbar row disappears, single-select actions appear in main row center
- [ ] Deselect all — main row shows "Clear all"
- [ ] Tab-navigate to toolbar row and verify screen reader announces "Selection actions"
- [ ] `pnpm vitest run src/shared/utils/cutoutArray` — all 23 tests pass