### PR TITLE
fix(generation): stop path cutouts collapsing to a rectangle on duplicate vertices

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/pathGeometry.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/pathGeometry.test.ts
@@ -167,6 +167,14 @@ describe('flattenPath', () => {
     expect(result.length).toBeGreaterThan(4);
     expect(result[0]).toEqual({ x: 0, y: 0 });
   });
+
+  it('drops consecutive coincident vertices (snap-to-grid duplicate)', () => {
+    const result = flattenPath([pt(0, 0), pt(10, 0), pt(10, 0), pt(5, 10)]);
+    expect(result).toHaveLength(3);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i]).not.toEqual(result[i - 1]);
+    }
+  });
 });
 
 // ─── Triangulation ──────────────────────────────────────────────────────────
@@ -213,6 +221,17 @@ describe('triangulatePath', () => {
       { x: 7, y: 5 },
       { x: 3, y: 7 },
     ]);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.length % 3).toBe(0);
+  });
+
+  // Snap-to-grid (two clicks in one cell) and clampPathToBounds can leave a
+  // duplicate consecutive vertex in a committed path. The zero-length edge
+  // made earclip bail out (empty result → no fill in the cut editor) while the
+  // worker fell back to a bounding-box rectangle. flattenPath now drops the
+  // coincident point so the fill renders the real polygon.
+  it('renders a fill for a path with a duplicate consecutive vertex', () => {
+    const result = triangulatePath(flattenPath([pt(0, 0), pt(10, 0), pt(10, 0), pt(5, 10)]));
     expect(result.length).toBeGreaterThan(0);
     expect(result.length % 3).toBe(0);
   });

--- a/src/features/bin-designer/components/panel/CutoutsSection/pathGeometryBezier.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/pathGeometryBezier.ts
@@ -9,13 +9,10 @@
  */
 
 import type { PathPoint } from '@/features/bin-designer/types';
+import { dropCoincidentPoints } from '@/shared/utils/polyline';
 
 /** Default bezier flattening tolerance in mm */
 const DEFAULT_FLATTEN_TOLERANCE = 0.1;
-
-/** Two points closer than this (mm) collapse to one. Far below the 0.5mm editor
- * snap grid and any printable resolution, so only genuine duplicates merge. */
-const COINCIDENT_POINT_EPSILON = 1e-3;
 
 export interface Point2D {
   readonly x: number;
@@ -153,28 +150,7 @@ export function flattenPath(
     }
   }
 
-  // Drop coincident consecutive vertices. Snap-to-grid (two clicks in one cell)
-  // and clampPathToBounds can leave duplicate points in a committed path; the
-  // zero-length edge makes earclip bail out (empty fill in the cut editor) and
-  // OCCT reject the wire in the worker (cut collapses to a bbox rectangle).
+  // Drop coincident vertices that would otherwise stall earclip triangulation
+  // (see dropCoincidentPoints).
   return dropCoincidentPoints(result, closed);
-}
-
-/**
- * Remove consecutive coincident points from a flattened polyline. When
- * `closed`, also drops a trailing point coincident with the first so the
- * implicit closing edge is never zero-length.
- */
-function dropCoincidentPoints(poly: readonly Point2D[], closed: boolean): Point2D[] {
-  const eps2 = COINCIDENT_POINT_EPSILON * COINCIDENT_POINT_EPSILON;
-  const near = (a: Point2D, b: Point2D): boolean => (a.x - b.x) ** 2 + (a.y - b.y) ** 2 <= eps2;
-
-  const out: Point2D[] = [];
-  for (const p of poly) {
-    if (out.length === 0 || !near(out[out.length - 1], p)) out.push({ x: p.x, y: p.y });
-  }
-  if (closed) {
-    while (out.length > 1 && near(out[out.length - 1], out[0])) out.pop();
-  }
-  return out;
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/pathGeometryBezier.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/pathGeometryBezier.ts
@@ -13,6 +13,10 @@ import type { PathPoint } from '@/features/bin-designer/types';
 /** Default bezier flattening tolerance in mm */
 const DEFAULT_FLATTEN_TOLERANCE = 0.1;
 
+/** Two points closer than this (mm) collapse to one. Far below the 0.5mm editor
+ * snap grid and any printable resolution, so only genuine duplicates merge. */
+const COINCIDENT_POINT_EPSILON = 1e-3;
+
 export interface Point2D {
   readonly x: number;
   readonly y: number;
@@ -149,5 +153,28 @@ export function flattenPath(
     }
   }
 
-  return result;
+  // Drop coincident consecutive vertices. Snap-to-grid (two clicks in one cell)
+  // and clampPathToBounds can leave duplicate points in a committed path; the
+  // zero-length edge makes earclip bail out (empty fill in the cut editor) and
+  // OCCT reject the wire in the worker (cut collapses to a bbox rectangle).
+  return dropCoincidentPoints(result, closed);
+}
+
+/**
+ * Remove consecutive coincident points from a flattened polyline. When
+ * `closed`, also drops a trailing point coincident with the first so the
+ * implicit closing edge is never zero-length.
+ */
+function dropCoincidentPoints(poly: readonly Point2D[], closed: boolean): Point2D[] {
+  const eps2 = COINCIDENT_POINT_EPSILON * COINCIDENT_POINT_EPSILON;
+  const near = (a: Point2D, b: Point2D): boolean => (a.x - b.x) ** 2 + (a.y - b.y) ** 2 <= eps2;
+
+  const out: Point2D[] = [];
+  for (const p of poly) {
+    if (out.length === 0 || !near(out[out.length - 1], p)) out.push({ x: p.x, y: p.y });
+  }
+  if (closed) {
+    while (out.length > 1 && near(out[out.length - 1], out[0])) out.pop();
+  }
+  return out;
 }

--- a/src/features/generation/worker/generators/binGenerator.scenario.path-cutout.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.path-cutout.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+/**
+ * Regression: a pen-tool PATH cutout whose stored points contain a degenerate
+ * (duplicate / zero-length) edge must still cut its real polygon shape — not
+ * silently collapse to a bounding-box rectangle.
+ *
+ * Repro seen in session replays: the path looks right in the 2D cut editor
+ * (the outline stroke is drawn from the bezier flatten regardless of the
+ * degenerate vertex) but the generated bin shows a plain rectangular cavity.
+ *
+ * Root cause: snap-to-grid (two clicks in one grid cell) and clampPathToBounds
+ * can leave two coincident consecutive points in the committed path. The worker
+ * builds a wire with a zero-length edge; OpenCascade rejects it on close()/
+ * extrude(), and buildUnrotatedCutoutShape's `catch` falls back to
+ * `box(width, depth, cutDepth)` — a rectangle the user never drew.
+ *
+ * We probe the geometry by volume: a non-degenerate polygon cut removes less
+ * material than its bounding rectangle, so the path-cut bin must retain
+ * meaningfully MORE volume than the same bin cut with a full-bbox rectangle.
+ * If the path collapses to a rectangle the two volumes are equal.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import type { BinParams, PathPoint } from '@/shared/types/bin';
+import { isOk } from '@/core/result';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { parseSTLBinary } from '@/shared/generation/stlParser';
+import { getPathBounds } from '@/features/bin-designer/components/panel/CutoutsSection/pathGeometry';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import { exportBin } from './binExporter';
+import { clearAllCaches } from './shapeCache';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+beforeEach(() => clearAllCaches());
+
+function corner(x: number, y: number): PathPoint {
+  return { x, y, handleIn: null, handleOut: null, symmetric: true };
+}
+
+function solidBinWithCutout(cutout: BinParams['cutouts'][number]): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    width: 2,
+    depth: 2,
+    base: { ...DEFAULT_BIN_PARAMS.base, solid: true },
+    cutouts: [cutout],
+  };
+}
+
+/** Exact volume of a closed triangle mesh via the divergence theorem. */
+function meshVolume(stl: ArrayBuffer): number {
+  const parsed = parseSTLBinary(stl);
+  if (!isOk(parsed)) throw new Error('STL parse failed');
+  const t = parsed.value.vertices;
+  let v = 0;
+  for (let i = 0; i < t.length; i += 9) {
+    const ax = t[i],
+      ay = t[i + 1],
+      az = t[i + 2];
+    const bx = t[i + 3],
+      by = t[i + 4],
+      bz = t[i + 5];
+    const cx = t[i + 6],
+      cy = t[i + 7],
+      cz = t[i + 8];
+    v += (ax * (by * cz - bz * cy) - ay * (bx * cz - bz * cx) + az * (bx * cy - by * cx)) / 6;
+  }
+  return Math.abs(v);
+}
+
+async function cutVolume(shape: 'path' | 'rectangle', path: PathPoint[]): Promise<number> {
+  const b = getPathBounds(path);
+  const cutout = {
+    id: 'c',
+    shape,
+    ...(shape === 'path' ? { path } : {}),
+    x: b.minX,
+    y: b.minY,
+    width: b.maxX - b.minX,
+    depth: b.maxY - b.minY,
+    cutDepth: 5,
+    rotation: 0,
+    cornerRadius: 0,
+    label: '',
+    groupId: null,
+    scoopRadiusW: 0,
+    scoopRadiusD: 0,
+  } as BinParams['cutouts'][number];
+  const out = await exportBin(solidBinWithCutout(cutout), 'stl');
+  return meshVolume(out.data);
+}
+
+const TIMEOUT = 90_000;
+
+// A convex pentagon with the 3rd vertex duplicated — exactly what snap-to-grid
+// produces when two pen clicks land in the same grid cell.
+const PENTAGON: PathPoint[] = [
+  corner(20, 25),
+  corner(55, 20),
+  corner(62, 50),
+  corner(38, 62),
+  corner(20, 50),
+];
+const PENTAGON_WITH_DUP: PathPoint[] = [
+  PENTAGON[0],
+  PENTAGON[1],
+  PENTAGON[2],
+  PENTAGON[2], // duplicate consecutive vertex (zero-length edge)
+  PENTAGON[3],
+  PENTAGON[4],
+];
+
+describe('path cutout robustness — degenerate vertices must not become a rectangle', () => {
+  it(
+    'a path with a duplicate consecutive vertex cuts the polygon, not its bounding rectangle',
+    async () => {
+      const b = getPathBounds(PENTAGON_WITH_DUP);
+      const bboxVol = (b.maxX - b.minX) * (b.maxY - b.minY) * 5;
+
+      const rectVol = await cutVolume('rectangle', PENTAGON_WITH_DUP);
+      clearAllCaches();
+      const pathVol = await cutVolume('path', PENTAGON_WITH_DUP);
+
+      // A real pentagon cut leaves a large slice of the bbox uncut (corners),
+      // so the path-cut bin keeps clearly more material than the rect-cut bin.
+      // A rectangle fallback would make these equal.
+      expect(pathVol - rectVol).toBeGreaterThan(0.1 * bboxVol);
+    },
+    TIMEOUT
+  );
+});

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -47,6 +47,7 @@ import {
   clampPolygonSides,
 } from '@/shared/utils/cutoutPolygon';
 import { expandCutoutArray } from '@/shared/utils/cutoutArray';
+import { dropCoincidentPoints } from '@/shared/utils/polyline';
 import { cutoutLabelPlacement } from '@/shared/utils/cutoutLabel';
 import { combineGroupSolids } from './cutoutGroupOps';
 import {
@@ -306,11 +307,9 @@ function buildPathCutoutShape(cutout: {
   const path = cutout.path;
   if (!path || path.length < MIN_PATH_POINTS) return fallbackRect();
 
-  // Flatten bezier path to polyline, then drop coincident points. Snap-to-grid
-  // (two clicks in one grid cell) and clampPathToBounds can leave duplicate
-  // consecutive vertices in the committed path; the zero-length edge they
-  // produce makes OCCT reject close()/extrude(), collapsing the whole cut to
-  // the bounding-box rectangle fallback. Need 3+ distinct points for a wire.
+  // Flatten bezier path to polyline, dropping coincident vertices that would
+  // collapse the wire to the bbox fallback (see dropCoincidentPoints). Need 3+
+  // distinct points for a closed wire.
   const polyline = dropCoincidentPoints(flattenPathToPolyline(path));
   if (polyline.length < 3) return fallbackRect();
 
@@ -331,33 +330,6 @@ function buildPathCutoutShape(cutout: {
   const wire = pen.close();
 
   return sketch(wire, 'XY').extrude(cutout.cutDepth);
-}
-
-/** Two points closer than this (mm) are treated as the same vertex. Far below
- * any printable resolution and the 0.5mm editor snap grid, so it only ever
- * collapses genuine duplicates, never distinct geometry. */
-const COINCIDENT_POINT_EPSILON = 1e-3;
-
-/**
- * Drop consecutive coincident points from a closed polyline, including a
- * trailing point that coincides with the first (the wrap-around closing edge).
- * Each removed point would otherwise become a zero-length edge that OCCT
- * rejects, forcing the path cut to fall back to a bounding-box rectangle.
- */
-function dropCoincidentPoints(
-  poly: readonly { x: number; y: number }[]
-): Array<{ x: number; y: number }> {
-  const eps2 = COINCIDENT_POINT_EPSILON * COINCIDENT_POINT_EPSILON;
-  const near = (a: { x: number; y: number }, b: { x: number; y: number }): boolean =>
-    (a.x - b.x) ** 2 + (a.y - b.y) ** 2 <= eps2;
-
-  const out: Array<{ x: number; y: number }> = [];
-  for (const p of poly) {
-    if (out.length === 0 || !near(out[out.length - 1], p)) out.push({ x: p.x, y: p.y });
-  }
-  // Closing edge: the last point must differ from the first too.
-  while (out.length > 1 && near(out[out.length - 1], out[0])) out.pop();
-  return out;
 }
 
 /** Flatten a closed bezier path to an open polyline for 3D generation.

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -306,8 +306,12 @@ function buildPathCutoutShape(cutout: {
   const path = cutout.path;
   if (!path || path.length < MIN_PATH_POINTS) return fallbackRect();
 
-  // Flatten bezier path to polyline — need 3+ flattened points for a closed wire
-  const polyline = flattenPathToPolyline(path);
+  // Flatten bezier path to polyline, then drop coincident points. Snap-to-grid
+  // (two clicks in one grid cell) and clampPathToBounds can leave duplicate
+  // consecutive vertices in the committed path; the zero-length edge they
+  // produce makes OCCT reject close()/extrude(), collapsing the whole cut to
+  // the bounding-box rectangle fallback. Need 3+ distinct points for a wire.
+  const polyline = dropCoincidentPoints(flattenPathToPolyline(path));
   if (polyline.length < 3) return fallbackRect();
 
   // Reject self-intersecting polylines that would produce invalid 3D geometry
@@ -327,6 +331,33 @@ function buildPathCutoutShape(cutout: {
   const wire = pen.close();
 
   return sketch(wire, 'XY').extrude(cutout.cutDepth);
+}
+
+/** Two points closer than this (mm) are treated as the same vertex. Far below
+ * any printable resolution and the 0.5mm editor snap grid, so it only ever
+ * collapses genuine duplicates, never distinct geometry. */
+const COINCIDENT_POINT_EPSILON = 1e-3;
+
+/**
+ * Drop consecutive coincident points from a closed polyline, including a
+ * trailing point that coincides with the first (the wrap-around closing edge).
+ * Each removed point would otherwise become a zero-length edge that OCCT
+ * rejects, forcing the path cut to fall back to a bounding-box rectangle.
+ */
+function dropCoincidentPoints(
+  poly: readonly { x: number; y: number }[]
+): Array<{ x: number; y: number }> {
+  const eps2 = COINCIDENT_POINT_EPSILON * COINCIDENT_POINT_EPSILON;
+  const near = (a: { x: number; y: number }, b: { x: number; y: number }): boolean =>
+    (a.x - b.x) ** 2 + (a.y - b.y) ** 2 <= eps2;
+
+  const out: Array<{ x: number; y: number }> = [];
+  for (const p of poly) {
+    if (out.length === 0 || !near(out[out.length - 1], p)) out.push({ x: p.x, y: p.y });
+  }
+  // Closing edge: the last point must differ from the first too.
+  while (out.length > 1 && near(out[out.length - 1], out[0])) out.pop();
+  return out;
 }
 
 /** Flatten a closed bezier path to an open polyline for 3D generation.

--- a/src/shared/utils/polyline.test.ts
+++ b/src/shared/utils/polyline.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { dropCoincidentPoints, COINCIDENT_POINT_EPSILON } from './polyline';
+
+const p = (x: number, y: number): { x: number; y: number } => ({ x, y });
+
+describe('dropCoincidentPoints', () => {
+  it('removes a duplicate consecutive vertex (snap-to-grid duplicate)', () => {
+    const result = dropCoincidentPoints([p(0, 0), p(10, 0), p(10, 0), p(5, 10)]);
+    expect(result).toEqual([p(0, 0), p(10, 0), p(5, 10)]);
+  });
+
+  it('keeps collinear-but-distinct points (does not over-collapse)', () => {
+    const result = dropCoincidentPoints([p(0, 0), p(5, 0), p(10, 0), p(0, 10)]);
+    expect(result).toHaveLength(4);
+  });
+
+  it('drops a trailing point coincident with the first when closed', () => {
+    const result = dropCoincidentPoints([p(0, 0), p(10, 0), p(5, 10), p(0, 0)], true);
+    expect(result).toEqual([p(0, 0), p(10, 0), p(5, 10)]);
+  });
+
+  it('drops a whole trailing run coincident with the first when closed', () => {
+    const result = dropCoincidentPoints([p(0, 0), p(10, 0), p(5, 10), p(0, 0), p(0, 0)], true);
+    expect(result).toEqual([p(0, 0), p(10, 0), p(5, 10)]);
+  });
+
+  it('keeps a first/last coincidence when open (closed=false)', () => {
+    // An open polyline (e.g. the in-progress drawing preview) has no implicit
+    // closing edge, so a first==last point is meaningful and must be kept.
+    const result = dropCoincidentPoints([p(0, 0), p(10, 0), p(0, 0)], false);
+    expect(result).toEqual([p(0, 0), p(10, 0), p(0, 0)]);
+  });
+
+  it('collapses an all-coincident path to a single point', () => {
+    const result = dropCoincidentPoints([p(3, 3), p(3, 3), p(3, 3)]);
+    expect(result).toEqual([p(3, 3)]);
+  });
+
+  it('merges points within epsilon and keeps points just beyond it', () => {
+    const within = dropCoincidentPoints([p(0, 0), p(COINCIDENT_POINT_EPSILON / 2, 0), p(5, 5)]);
+    expect(within).toHaveLength(2);
+    const beyond = dropCoincidentPoints([p(0, 0), p(COINCIDENT_POINT_EPSILON * 10, 0), p(5, 5)]);
+    expect(beyond).toHaveLength(3);
+  });
+
+  it('returns references to the original point objects (no allocation, no mutation)', () => {
+    const input = [p(0, 0), p(10, 0), p(5, 10)];
+    const result = dropCoincidentPoints(input);
+    expect(result[0]).toBe(input[0]);
+    expect(input).toHaveLength(3);
+  });
+
+  it('handles empty and single-point input', () => {
+    expect(dropCoincidentPoints([])).toEqual([]);
+    expect(dropCoincidentPoints([p(1, 2)])).toEqual([p(1, 2)]);
+  });
+});

--- a/src/shared/utils/polyline.ts
+++ b/src/shared/utils/polyline.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared polyline helpers used by both the 2D cut editor and the generation
+ * worker. Kept in `shared/` so the two flatteners (the editor's adaptive
+ * `flattenPath` and the worker's fixed-step `flattenPathToPolyline`) enforce
+ * the same degenerate-vertex invariant from one canonical source.
+ */
+
+/** Two points closer than this (mm) are treated as the same vertex. Far below
+ * the 0.5mm editor snap grid and any printable resolution, so it only ever
+ * collapses genuine duplicates — never distinct (e.g. collinear) geometry. */
+export const COINCIDENT_POINT_EPSILON = 1e-3;
+
+/**
+ * Drop coincident consecutive points from a flattened polyline. When `closed`
+ * (the default), also drops a trailing run of points coincident with the first
+ * so the implicit closing edge is never zero-length.
+ *
+ * Snap-to-grid (two clicks in one grid cell) and `clampPathToBounds` can leave
+ * duplicate points in a committed path. The zero-length edge they produce makes
+ * earclip triangulation bail out (empty fill in the editor) and OpenCascade
+ * reject the wire in the worker (the cut collapses to a bounding-box rectangle).
+ *
+ * Returns references to the original point objects (never mutates input).
+ */
+export function dropCoincidentPoints<T extends { readonly x: number; readonly y: number }>(
+  poly: readonly T[],
+  closed = true
+): T[] {
+  const eps2 = COINCIDENT_POINT_EPSILON * COINCIDENT_POINT_EPSILON;
+  const near = (a: T, b: T): boolean => (a.x - b.x) ** 2 + (a.y - b.y) ** 2 <= eps2;
+
+  const out: T[] = [];
+  for (const p of poly) {
+    if (out.length === 0 || !near(out[out.length - 1], p)) out.push(p);
+  }
+  if (closed) {
+    while (out.length > 1 && near(out[out.length - 1], out[0])) out.pop();
+  }
+  return out;
+}


### PR DESCRIPTION
## Problem

A pen-tool **path** cutout could look correct in the 2D cut editor yet render as a plain **rectangular** cavity in the generated 3D bin (seen in session replays).

## Root cause

Snap-to-grid (two clicks in one grid cell) and `clampPathToBounds` can leave **duplicate consecutive vertices** in a committed path. The zero-length edge they produce breaks two layers independently:

- **Worker** (`cutoutBuilder.ts`): OpenCascade rejects `close()`/`extrude()`, so the `catch` in `buildUnrotatedCutoutShape` falls back to `box(width, depth, cutDepth)` — a bounding-box rectangle. (`polylineSelfIntersects` misses zero-length edges — they read as "parallel".)
- **Editor** (`flattenPath` → `triangulatePath`): earclip returns 0 triangles → no fill renders (only the outline stroke, which is why it "looked correct").

Rotation centers were verified to stay synced across editor/preview/worker, and the `path` field survives serialization — those were ruled out empirically before landing on this.

## Fix

Both bezier flatteners now drop coincident consecutive points (and a wrap-around closing duplicate), `COINCIDENT_POINT_EPSILON = 1e-3` mm — far below the 0.5 mm snap grid, so only genuine duplicates merge:

- `cutoutBuilder.ts`: `dropCoincidentPoints` on the flattened polyline before building the wire.
- `pathGeometryBezier.flattenPath`: dedup before triangulation / bounds / self-intersection / outline.

## Tests (TDD — written first, watched fail, then pass)

- `binGenerator.scenario.path-cutout.test.ts` — real brepjs generator; a duplicate-vertex path must keep more volume than its bounding rectangle (was `0 > 882` → rectangle; now passes).
- `pathGeometry.test.ts` — `flattenPath` drops duplicates; `triangulatePath` renders a fill for a duplicate-vertex path.

## Verification

- `pnpm typecheck` clean, lint clean
- CutoutsSection unit suite **519/519**
- Bin scenario snapshots **354/354** (zero drift — clean paths unaffected)

## Out of scope (follow-ups noted, not fixed here)

- `expandCutoutArray` shifts instance `x/y` but never translates `path` points, so array-path instances collapse onto the master (editor + worker agree, both wrong).
- `MIN_PATH_POINTS = 2` despite doc comments saying "3+ points".