### PR TITLE
fix(cutouts): translate path vertices for array instances

### DIFF
--- a/src/shared/utils/cutoutArray.test.ts
+++ b/src/shared/utils/cutoutArray.test.ts
@@ -151,19 +151,28 @@ describe('expandCutoutArray', () => {
       width: 10,
       depth: 10,
       path,
-      array: cfg({ mode: 'grid', cols: 2, rows: 1, pitchX: 30, pitchY: 30 }),
+      array: cfg({ mode: 'grid', cols: 2, rows: 2, pitchX: 30, pitchY: 30 }),
     });
+    // Instance order is row-major: [master, +x, +y, +x+y].
     const out = expandCutoutArray(c);
 
-    // Second instance shifts +30 in x; its path must shift with it.
+    // Instance 1 (col 1, row 0) shifts +30 in x; its path must shift with it.
     expect(out[1].x).toBe(40);
     expect(out[1].path?.map((p) => [p.x, p.y])).toEqual([
       [40, 10],
       [50, 10],
       [45, 20],
     ]);
+    // Instance 2 (col 0, row 1) shifts +30 in y — exercises the Y-axis branch.
+    expect(out[2].y).toBe(40);
+    expect(out[2].path?.map((p) => [p.x, p.y])).toEqual([
+      [10, 40],
+      [20, 40],
+      [15, 50],
+    ]);
     // Relative bezier handles are unchanged by translation.
     expect(out[1].path?.[0].handleOut).toEqual({ dx: 2, dy: 0 });
+    expect(out[2].path?.[0].handleOut).toEqual({ dx: 2, dy: 0 });
     // Master instance keeps the original vertices.
     expect(out[0].path?.map((p) => [p.x, p.y])).toEqual([
       [10, 10],

--- a/src/shared/utils/cutoutArray.test.ts
+++ b/src/shared/utils/cutoutArray.test.ts
@@ -133,6 +133,44 @@ describe('expandCutoutArray', () => {
     const out = expandCutoutArray(c);
     expect(out.map((o) => o.rotation)).toEqual([0, 90, 180, 270]);
   });
+
+  // A path cutout stores absolute vertices; shifting only x/y leaves every
+  // instance's path at the master's location, so the editor renders them all
+  // stacked on the master (and flattening bakes that collapse in). The path
+  // must translate by the same per-instance offset as x/y.
+  it('translates path vertices for non-master instances so the path follows the instance', () => {
+    const path = [
+      { x: 10, y: 10, handleIn: null, handleOut: { dx: 2, dy: 0 }, symmetric: true },
+      { x: 20, y: 10, handleIn: null, handleOut: null, symmetric: true },
+      { x: 15, y: 20, handleIn: null, handleOut: null, symmetric: true },
+    ];
+    const c = master({
+      shape: 'path',
+      x: 10,
+      y: 10,
+      width: 10,
+      depth: 10,
+      path,
+      array: cfg({ mode: 'grid', cols: 2, rows: 1, pitchX: 30, pitchY: 30 }),
+    });
+    const out = expandCutoutArray(c);
+
+    // Second instance shifts +30 in x; its path must shift with it.
+    expect(out[1].x).toBe(40);
+    expect(out[1].path?.map((p) => [p.x, p.y])).toEqual([
+      [40, 10],
+      [50, 10],
+      [45, 20],
+    ]);
+    // Relative bezier handles are unchanged by translation.
+    expect(out[1].path?.[0].handleOut).toEqual({ dx: 2, dy: 0 });
+    // Master instance keeps the original vertices.
+    expect(out[0].path?.map((p) => [p.x, p.y])).toEqual([
+      [10, 10],
+      [20, 10],
+      [15, 20],
+    ]);
+  });
 });
 
 describe('defaultArrayConfig', () => {

--- a/src/shared/utils/cutoutArray.ts
+++ b/src/shared/utils/cutoutArray.ts
@@ -122,6 +122,13 @@ export function expandCutoutArray(cutout: Cutout): Cutout[] {
       x: cx + inst.dx - cutout.width / 2,
       y: cy + inst.dy - cutout.depth / 2,
       rotation: (((cutout.rotation + inst.drot) % 360) + 360) % 360,
+      // Path vertices are absolute, so they must move with the instance —
+      // otherwise editor previews (and flattened arrays) stack every path
+      // instance on the master. Handles are relative offsets and stay as-is.
+      // (The worker rebuilds geometry from the master and ignores this path.)
+      ...(cutout.path
+        ? { path: cutout.path.map((p) => ({ ...p, x: p.x + inst.dx, y: p.y + inst.dy })) }
+        : {}),
     };
   });
 }


### PR DESCRIPTION
## Problem

A **path** (pen-tool) cutout with a parametric **array** rendered all its instances stacked on top of the master in the 2D cut editor, instead of spread across the grid/ring. "Flatten array" baked that collapse into real overlapping cutouts.

Follow-up to #2004 (noted there as a separate out-of-scope bug).

## Root cause

`expandCutoutArray` (`src/shared/utils/cutoutArray.ts`) shifts each non-master instance's `x`/`y`/`rotation` but carried the `path` array verbatim. Path vertices are **absolute** coordinates, so every instance's path stayed at the master's location while its bounding box (`x/y/width/depth`) moved away.

Consumers that read `instance.path` directly therefore collapsed:
- **Editor** — `CutoutArrayMeshes` → `CutoutShapeMesh` → `PathShapeMesh` centers on the path's own bounds, so all instances drew at the master.
- **Flatten array** — `flattenCutoutArray` (`cutoutHelpers.ts`) bakes `expandCutoutArray` output into independent cutouts, persisting the collapse.

The **generation worker** was already correct: `buildArrayUngroupedCutouts` builds geometry once from the *master* and only uses instances for x/y/rotation, so it never read `instance.path`. (This is why the live 3D bin looked fine while the editor preview didn't — a 2D/3D mismatch.)

## Fix

Translate path vertices by the same per-instance offset as `x`/`y`. Relative bezier handles are unaffected. One-line-per-point map in `expandCutoutArray`; the worker is unchanged and stays correct.

## Tests (TDD)

`cutoutArray.test.ts` — a grid array of a path cutout must translate each non-master instance's vertices to follow its position (and leave the master + relative handles untouched). Watched it fail (path stayed at master) before the fix.

## Verification

- `pnpm typecheck` clean, lint clean, all pre-commit gates pass
- `cutoutArray` suite 24/24, `CutoutArrayMeshes` + `cutoutHelpers` suites green
- worker path-cutout scenario still green (worker behavior unchanged)