### PR TITLE
chore(cutouts): dedupe path vertices at source + reconcile MIN_PATH_POINTS docs

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathDrawingHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathDrawingHandler.ts
@@ -4,7 +4,7 @@
  * Manages multi-click path creation with bezier handle support.
  * Each click adds a corner point; dragging after click creates
  * symmetric bezier handles. Closing the path (clicking near the
- * first point with 3+ points) commits the shape.
+ * first point with MIN_PATH_POINTS+ points) commits the shape.
  */
 
 import type { PathPoint } from '@/features/bin-designer/types';
@@ -56,7 +56,7 @@ export interface PathDrawingSetters {
  *
  * - First click (no existing mode): creates the first corner point and
  *   transitions to path-drawing mode.
- * - Subsequent clicks: if near the first point (and 3+ points exist),
+ * - Subsequent clicks: if near the first point (and MIN_PATH_POINTS+ exist),
  *   closes and commits the path. Otherwise appends a new corner point.
  * - Shift key constrains the new point angle to 45-degree increments
  *   relative to the last point.
@@ -270,7 +270,7 @@ export function handlePathDrawingPointerUp(
  * Start repositioning an existing vertex during path drawing.
  *
  * Called when the user clicks on a vertex dot in the drawing preview.
- * If the click is on the first vertex with 3+ points, closes the path instead.
+ * If the click is on the first vertex with MIN_PATH_POINTS+ points, closes the path instead.
  */
 export function handlePathDrawingVertexDown(
   mode: PathDrawingMode,

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathEditHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathEditHandler.ts
@@ -248,7 +248,7 @@ export function handleVertexEditPointerUp(
 /**
  * Handle keydown events during vertex editing.
  *
- * - Delete/Backspace: remove the selected vertex (if 3+ points remain)
+ * - Delete/Backspace: remove the selected vertex (down to MIN_PATH_POINTS anchors)
  * - Escape: exit vertex editing mode
  */
 export function handleVertexEditKeyDown(
@@ -266,7 +266,7 @@ export function handleVertexEditKeyDown(
       if (mode.selectedPointIndex === null) return;
 
       const updated = removePoint(path, mode.selectedPointIndex);
-      if (!updated) return; // fewer than 3 points would remain
+      if (!updated) return; // would drop below MIN_PATH_POINTS anchors
 
       event.preventDefault();
       setters.onUpdate(cutout.id, pathBoundsUpdate(updated));

--- a/src/features/bin-designer/components/panel/CutoutsSection/pathGeometry.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/pathGeometry.ts
@@ -76,7 +76,8 @@ export function insertPoint(
   return result;
 }
 
-/** Remove a point from a path at the given index. Requires 3+ points to remain. */
+/** Remove a point from a path at the given index. Won't drop below
+ * MIN_PATH_POINTS anchors (returns null instead). */
 export function removePoint(points: readonly PathPoint[], index: number): PathPoint[] | null {
   if (points.length <= MIN_PATH_POINTS) return null;
   const result = [...points];

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgConvertShapes.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgConvertShapes.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import type { PathPoint } from '@/features/bin-designer/types';
+import { pathPointsToSpec } from './svgConvertShapes';
+
+const pt = (x: number, y: number): PathPoint => ({
+  x,
+  y,
+  handleIn: null,
+  handleOut: null,
+  symmetric: false,
+});
+
+describe('pathPointsToSpec — path data hygiene', () => {
+  // SVG <polygon>/<polyline> commonly repeat the first vertex to close the
+  // shape; that trailing duplicate is a zero-length edge. Strip it at import
+  // so stored path data is canonical (not just deduped at render time).
+  it('drops a trailing vertex coincident with the first', () => {
+    const spec = pathPointsToSpec([pt(0, 0), pt(10, 0), pt(5, 10), pt(0, 0)]);
+    expect(spec?.path?.map((p) => [p.x, p.y])).toEqual([
+      [0, 0],
+      [10, 0],
+      [5, 10],
+    ]);
+  });
+
+  it('drops duplicate consecutive vertices', () => {
+    const spec = pathPointsToSpec([pt(0, 0), pt(10, 0), pt(10, 0), pt(5, 10)]);
+    expect(spec?.path?.map((p) => [p.x, p.y])).toEqual([
+      [0, 0],
+      [10, 0],
+      [5, 10],
+    ]);
+  });
+
+  it('leaves a clean polygon untouched', () => {
+    const spec = pathPointsToSpec([pt(0, 0), pt(10, 0), pt(5, 10)]);
+    expect(spec?.path).toHaveLength(3);
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgConvertShapes.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgConvertShapes.ts
@@ -16,6 +16,7 @@ import type { Matrix } from './svgTransform';
 import type { ViewBox } from './types';
 import { applyMatrix, isIdentityOrTranslate, transformPoint } from './svgTransform';
 import { getPathBounds } from '../pathGeometry';
+import { dropCoincidentPoints } from '@/shared/utils/polyline';
 
 export function wrapSingle(spec: ParsedCutoutSpec | null): ParsedCutoutSpec[] | null {
   return spec ? [spec] : null;
@@ -79,9 +80,13 @@ export function pointsToPathSpec(
  * flattens the curve, matching what the renderer / vertex editor compute.
  */
 export function pathPointsToSpec(pathPoints: PathPoint[]): ParsedCutoutSpec | null {
-  if (pathPoints.length < 2) return null;
+  // SVG closes shapes by repeating the first vertex, and source art often has
+  // duplicate/near-duplicate anchors; strip them so stored path data is
+  // canonical instead of relying solely on render-time dedup.
+  const cleaned = dropCoincidentPoints(pathPoints);
+  if (cleaned.length < 2) return null;
 
-  const { minX, minY, maxX, maxY } = getPathBounds(pathPoints);
+  const { minX, minY, maxX, maxY } = getPathBounds(cleaned);
   const width = maxX - minX;
   const depth = maxY - minY;
 
@@ -95,7 +100,7 @@ export function pathPointsToSpec(pathPoints: PathPoint[]): ParsedCutoutSpec | nu
     depth,
     cornerRadius: 0,
     rotation: 0,
-    path: pathPoints,
+    path: cleaned,
   };
 }
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPathTool.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPathTool.ts
@@ -20,10 +20,12 @@ import {
 import type { PathDrawingPreviewState, SegmentHoverInfo } from './handlers';
 import {
   CLOSE_SNAP_THRESHOLD,
+  MIN_PATH_POINTS,
   clampPathToBounds,
   getPathBounds,
   isSelfIntersecting,
 } from './pathGeometry';
+import { dropCoincidentPoints } from '@/shared/utils/polyline';
 import { rectFitsInMask, type MaskCellSize } from './maskFit';
 import { createDefaultCutout } from './cutoutHelpers';
 import type { InteractionMode, PreviewMap } from './cutoutInteractionTypes';
@@ -81,8 +83,18 @@ export function useCutoutPathTool({
   /** Commit a closed path as a new cutout. */
   const commitPath = useCallback(
     (points: readonly PathPoint[]) => {
-      // Clamp to bin bounds so cutout never extends outside the bin surface
-      const clamped = clampPathToBounds(points, binWidth, binDepth);
+      // Clamp to bin bounds so cutout never extends outside the bin surface,
+      // then drop coincident anchors. Clamping two points onto the same edge
+      // (and snap-to-grid) can leave a zero-length edge; storing the deduped
+      // path keeps the data canonical rather than relying on render-time dedup.
+      const clamped = dropCoincidentPoints(clampPathToBounds(points, binWidth, binDepth));
+
+      // Degenerate after dedup (e.g. all anchors coincident) — nothing to cut.
+      if (clamped.length < MIN_PATH_POINTS) {
+        setPathDrawingPreview(null);
+        setMode({ type: 'idle' });
+        return;
+      }
 
       // Reject self-intersecting paths that would produce invalid 3D geometry
       if (isSelfIntersecting(clamped)) {

--- a/src/features/bin-designer/types/cutout.ts
+++ b/src/features/bin-designer/types/cutout.ts
@@ -152,7 +152,13 @@ export const DEFAULT_SCOOP_EDGES: CutoutScoopEdges = {
   back: true,
 };
 
-/** Minimum number of anchor points required to form a closed path shape */
+/**
+ * Minimum number of *anchor* points to form a closed path. Two is enough
+ * because a 2-anchor path with bezier handles closes into a curve (a lens).
+ * The separate *geometric* minimum — ≥3 distinct flattened points for a
+ * fillable/printable area — is enforced on the flattened polyline by the
+ * renderer (`MIN_POLYLINE_POINTS`) and the worker, not here.
+ */
 export const MIN_PATH_POINTS = 2;
 
 /** A vertex in a bezier path with optional control handles */


### PR DESCRIPTION
Two path-data-hygiene follow-ups flagged during #2004 / #2006.

## 1. Source-side dedup of coincident path vertices

#2004 strips duplicate/zero-length path vertices at *render time* (editor flatten + worker), which fixes already-saved layouts. This adds dedup at the **write** sites too, so newly stored path data is canonical instead of relying solely on consumer-side cleanup:

- **SVG import** (`pathPointsToSpec`) — SVG `<polygon>`/`<polyline>` repeat the first vertex to close the shape; that trailing point is a zero-length edge. Strip it (and any duplicate anchors) on import. Otherwise the vertex editor shows a redundant vertex stacked on the first.
- **Pen commit** (`commitPath`) — dedupe *after* `clampPathToBounds` (clamping two points onto the same bin edge, and snap-to-grid, can create coincident anchors), and bail to idle if the path is degenerate (all anchors coincident).

Vertex-edit (`pathBoundsUpdate`) is deliberately **left alone** — deduping mid-edit would desync the selected-vertex index for marginal gain, and render-time dedup already covers it.

Uses the shared `dropCoincidentPoints` from #2004 (generic, reference-preserving) — no new dedup logic.

## 2. Reconcile MIN_PATH_POINTS docs

The constant is `2` (two anchors + bezier handles form a closed lens), but several comments claimed "3+ points". Updated the comments and documented that the **geometric** minimum — ≥3 distinct *flattened* points for a fillable/printable area — is enforced separately on the polyline (`MIN_POLYLINE_POINTS` / worker), not on anchor count. No behavior change.

## Tests
- `svgConvertShapes.test.ts` (new) — `pathPointsToSpec` drops a trailing-coincident-with-first vertex and duplicate consecutive vertices, leaves a clean polygon untouched. TDD: watched the two dedup cases fail before the fix.
- Pen-commit dedup reuses the already-unit-tested `dropCoincidentPoints` (`polyline.test.ts`); the SVG test exercises the same helper end-to-end at a real write site.

## Verification
- `pnpm typecheck` clean, lint clean, knip clean, all pre-commit gates pass
- SVG-import + CutoutsSection unit suites: 531/531 green