### PR TITLE
fix(labs): re-render feature toggles when flags change

### DIFF
--- a/src/features/labs/components/LabsDrawer/LabsDrawer.reactivity.test.tsx
+++ b/src/features/labs/components/LabsDrawer/LabsDrawer.reactivity.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { LabsDrawer } from './LabsDrawer';
+import { resetAllStores } from '@/test/testUtils';
+import { useLabsStore } from '@/core/store';
+import { getFeature } from '@/core/labs';
+
+// Real store, real FeatureCard, real Switch — this exercises the Zustand
+// subscription path that the heavily-mocked LabsDrawer.test.tsx cannot.
+// Only the unrelated EngineSelector child is stubbed out.
+vi.mock('../EngineSelector', () => ({
+  EngineSelector: () => null,
+  KERNEL_FEATURE_IDS: ['brepkit_kernel'] as const,
+}));
+
+// A real, low-risk, toggleable experimental feature.
+const FEATURE_ID = 'show_generation_perf';
+const FEATURE_NAME = getFeature(FEATURE_ID)?.name ?? '';
+
+describe('LabsDrawer toggle reactivity (regression)', () => {
+  beforeEach(() => {
+    resetAllStores();
+    useLabsStore.setState({ isDrawerOpen: true });
+  });
+
+  it('visually flips the switch when a feature is toggled', () => {
+    render(<LabsDrawer />);
+
+    const article = screen.getByText(FEATURE_NAME).closest('article');
+    expect(article).not.toBeNull();
+    const toggle = within(article as HTMLElement).getByRole('switch');
+
+    // Starts disabled.
+    expect(toggle).not.toBeChecked();
+
+    // Clicking flips the store value...
+    fireEvent.click(toggle);
+    expect(useLabsStore.getState().isFeatureEnabled(FEATURE_ID)).toBe(true);
+
+    // ...and the switch must visually reflect the new state.
+    expect(toggle).toBeChecked();
+  });
+});

--- a/src/features/labs/components/LabsDrawer/LabsDrawer.reactivity.test.tsx
+++ b/src/features/labs/components/LabsDrawer/LabsDrawer.reactivity.test.tsx
@@ -13,9 +13,15 @@ vi.mock('../EngineSelector', () => ({
   KERNEL_FEATURE_IDS: ['brepkit_kernel'] as const,
 }));
 
-// A real, low-risk, toggleable experimental feature.
+// A real, low-risk, toggleable experimental feature. Resolve it up front and
+// fail loudly if it ever disappears from the labs config, rather than letting
+// an empty name silently break the `getByText` lookup below.
 const FEATURE_ID = 'show_generation_perf';
-const FEATURE_NAME = getFeature(FEATURE_ID)?.name ?? '';
+const FEATURE = getFeature(FEATURE_ID);
+if (!FEATURE) {
+  throw new Error(`Labs feature "${FEATURE_ID}" no longer exists; update this regression test`);
+}
+const FEATURE_NAME = FEATURE.name;
 
 describe('LabsDrawer toggle reactivity (regression)', () => {
   beforeEach(() => {

--- a/src/features/labs/components/LabsDrawer/LabsDrawer.test.tsx
+++ b/src/features/labs/components/LabsDrawer/LabsDrawer.test.tsx
@@ -69,12 +69,18 @@ vi.mock('@/i18n', () => ({
   useTranslation: () => (key: string) => key,
 }));
 
-function mockLabsStore(overrides: { isDrawerOpen?: boolean; closeDrawer?: () => void } = {}) {
+function mockLabsStore(
+  overrides: {
+    isDrawerOpen?: boolean;
+    closeDrawer?: () => void;
+    enabledFeatures?: Record<string, boolean>;
+  } = {}
+) {
   const state = {
     isDrawerOpen: overrides.isDrawerOpen ?? true,
     closeDrawer: overrides.closeDrawer ?? vi.fn(),
     toggleFeature: vi.fn(),
-    isFeatureEnabled: vi.fn(() => false),
+    preferences: { enabledFeatures: overrides.enabledFeatures ?? {} },
   };
   vi.mocked(useLabsStore).mockImplementation((selector) => (selector ? selector(state) : state));
   return state;

--- a/src/features/labs/components/LabsDrawer/LabsDrawer.tsx
+++ b/src/features/labs/components/LabsDrawer/LabsDrawer.tsx
@@ -10,12 +10,16 @@ import { useTranslation } from '@/i18n';
 
 export function LabsDrawer() {
   const t = useTranslation();
-  const { isOpen, closeDrawer, toggleFeature, isFeatureEnabled } = useLabsStore(
+  // Subscribe to `enabledFeatures` (a fresh object on every toggle) — not the
+  // stable `isFeatureEnabled` reference — so the switches re-render when a flag
+  // flips. The drawer only renders toggleable (experimental/preview) features,
+  // for which enabled state is exactly `enabledFeatures[id]`.
+  const { isOpen, closeDrawer, toggleFeature, enabledFeatures } = useLabsStore(
     useShallow((state) => ({
       isOpen: state.isDrawerOpen,
       closeDrawer: state.closeDrawer,
       toggleFeature: state.toggleFeature,
-      isFeatureEnabled: state.isFeatureEnabled,
+      enabledFeatures: state.preferences.enabledFeatures,
     }))
   );
 
@@ -96,7 +100,7 @@ export function LabsDrawer() {
                   <FeatureCard
                     key={feature.id}
                     feature={feature}
-                    isEnabled={isFeatureEnabled(feature.id as FeatureId)}
+                    isEnabled={enabledFeatures[feature.id as FeatureId] ?? false}
                     onToggle={() => toggleFeature(feature.id as FeatureId)}
                   />
                 ))}

--- a/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.test.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { LabsTab } from './LabsTab';
 
 const mockToggleFeature = vi.hoisted(() => vi.fn());
-const mockIsFeatureEnabled = vi.hoisted(() => vi.fn(() => true));
+const mockEnabledFeatures = vi.hoisted((): Record<string, boolean> => ({ binDesigner: true }));
 const mockFeatures = vi.hoisted(() => ({
   toggleable: [
     {
@@ -26,7 +26,7 @@ vi.mock('@/core/store', () => ({
   useLabsStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
       toggleFeature: mockToggleFeature,
-      isFeatureEnabled: mockIsFeatureEnabled,
+      preferences: { enabledFeatures: mockEnabledFeatures },
     }),
 }));
 
@@ -81,7 +81,7 @@ describe('LabsTab', () => {
   });
 
   it('FeatureCard receives correct isEnabled and onToggle props', () => {
-    mockIsFeatureEnabled.mockReturnValue(true);
+    mockEnabledFeatures.binDesigner = true;
     render(<LabsTab />);
     const card = screen.getByTestId('feature-card');
     expect(card).toHaveAttribute('data-enabled', 'true');

--- a/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.tsx
@@ -14,10 +14,14 @@ import { useTranslation } from '@/i18n';
 export function LabsTab() {
   const t = useTranslation();
 
-  const { toggleFeature, isFeatureEnabled } = useLabsStore(
+  // Subscribe to `enabledFeatures` (a fresh object on every toggle) — not the
+  // stable `isFeatureEnabled` reference — so the switches re-render when a flag
+  // flips. The tab only renders toggleable (experimental/preview) features,
+  // for which enabled state is exactly `enabledFeatures[id]`.
+  const { toggleFeature, enabledFeatures } = useLabsStore(
     useShallow((state) => ({
       toggleFeature: state.toggleFeature,
-      isFeatureEnabled: state.isFeatureEnabled,
+      enabledFeatures: state.preferences.enabledFeatures,
     }))
   );
 
@@ -45,7 +49,7 @@ export function LabsTab() {
               <FeatureCard
                 key={feature.id}
                 feature={feature}
-                isEnabled={isFeatureEnabled(feature.id as FeatureId)}
+                isEnabled={enabledFeatures[feature.id as FeatureId] ?? false}
                 onToggle={() => toggleFeature(feature.id as FeatureId)}
               />
             ))}


### PR DESCRIPTION
## Problem

The toggle switches in **Labs** (both the Labs drawer and **Settings → Labs** tab) did not visually flip when clicked, even though the underlying feature flag actually toggled (and persisted to localStorage).

## Root cause

Both surfaces selected the **stable `isFeatureEnabled` function reference** (plus `isDrawerOpen`) from the Zustand store via `useShallow`, then called `isFeatureEnabled(feature.id)` in JSX:

```ts
useShallow((state) => ({ ..., isFeatureEnabled: state.isFeatureEnabled }))
```

That reference never changes and the selector never reads `state.preferences`. So after a toggle, the selected slice is shallow-**equal** → Zustand skips the re-render → the `Switch`'s `checked` prop is never recomputed. The feature "works" (store + other subscribed consumers update correctly); only the toggle's own UI is stale — a subscribe-vs-mutate mismatch.

## Fix

Subscribe to `state.preferences.enabledFeatures` (a fresh object on every toggle) and read enabled state directly from it — matching the working pattern already used in `LabsButton`/`EngineSelector`. Both surfaces only render `experimental`/`preview` features, for which `enabledFeatures[id] ?? false` is equivalent to the old `isFeatureEnabled(id)`.

## Tests

- **New** `LabsDrawer.reactivity.test.tsx` uses the **real** store + real `FeatureCard`/`Switch` and asserts the switch visually flips on click. The pre-existing tests fully mock `@/core/store`, so they could never reproduce a re-render/subscription defect — this is why the bug shipped despite coverage.
- Updated the two existing mocked tests for the new selector shape.

All 68 labs/LabsTab tests pass; typecheck and lint clean.