### PR TITLE
ci: shard PR unit tests across 4 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,10 @@ jobs:
           project-id: ${{ secrets.POSTHOG_PROJECT_ID }}
           api-key: ${{ secrets.POSTHOG_API_KEY }}
 
-  # PRs: Sharded test suite without coverage (fast feedback, 2 parallel runners)
+  # PRs: Sharded test suite without coverage (fast feedback, 4 parallel runners).
+  #   Vitest assigns files to shards by hashing the file path, so the heavy
+  #   brepjs/WASM generator tests scatter unevenly; 4 shards keeps the slowest
+  #   shard well below the ~10min a 2-way split produced.
   # Main: Full test suite with coverage thresholds (regression guard, single runner)
   test:
     name: Unit Tests (${{ matrix.shard }})
@@ -65,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ github.event_name == 'pull_request' && fromJSON('["1/2", "2/2"]') || fromJSON('["1/1"]') }}
+        shard: ${{ github.event_name == 'pull_request' && fromJSON('["1/4", "2/4", "3/4", "4/4"]') || fromJSON('["1/1"]') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Problem

PR unit tests run in **2 shards**, but Vitest assigns files to shards by **hashing the file path, not by duration** (`BaseSequencer.shard` → sha1(path) → sort → contiguous slice). The ~40 brepjs/OpenCascade WASM generator scenario tests in `src/features/generation/worker/generators/` dominate runtime and scatter unevenly, so the shards are badly imbalanced:

| Recent run | Shard 1/2 | Shard 2/2 |
|---|---|---|
| feat/manifold-preview-kernel | ~300s | **~640s** |
| feat/manifold-preview-kernel | ~315s | **~634s** |

Wall time = the slow shard ≈ **~10.5 min**, while the other finishes in ~5 min and idles. (`300 + 640 ≈ 965s`, matching `main`'s single-shard run.)

Per-step timing confirms it's pure test execution — checkout/install/node-setup total only ~22s thanks to the pnpm cache.

## Change

Bump the PR matrix from 2 → **4 shards** (one line). With ~16 min of total compute, a 4-way split puts the slowest shard around **240–340s** (incl. ~22s setup) — roughly halving worst-case wall time. Setup overhead is negligible, so the 2 extra runners cost little. `main` still runs a single shard with coverage thresholds.

## Safety

- Branch ruleset `protection` requires only **Conventional Commit** and **Build** — not the `Unit Tests (n/2)` check names — so renaming the shards doesn't orphan a required check.
- No other workflow/config references the shard count.

## Follow-ups (not done here)

If hash variance still leaves an unlucky slow shard, the deterministic next step is isolating the WASM generator suite into its own job. Bigger lever (more effort): amortize OpenCascade WASM init across files.