### PR TITLE
fix(deps): bump brepjs 18.66.1 -> 18.66.2 (manifold honeycomb wall-pattern fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/blob": "^2.4.0",
     "arctic": "^3.7.0",
-    "brepjs": "18.66.1",
+    "brepjs": "18.66.2",
     "brepkit-wasm": "^2.101.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^3.7.0
         version: 3.7.0
       brepjs:
-        specifier: 18.66.1
-        version: 18.66.1(brepkit-wasm@2.101.3)(occt-wasm@3.2.2)
+        specifier: 18.66.2
+        version: 18.66.2(brepkit-wasm@2.101.3)(occt-wasm@3.2.2)
       brepkit-wasm:
         specifier: ^2.101.3
         version: 2.101.3
@@ -2574,6 +2574,15 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.60.3':
     resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
     cpu: [arm]
@@ -3434,8 +3443,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  brepjs@18.66.1:
-    resolution: {integrity: sha512-OzyzwENNGj4IoyF3viUOvcgfwvY1K9JqsYAbtMkuNeHbFSPj+ViJR5FYJLpfa3jokOcpXd8QDX/k+pYAHN7MYQ==}
+  brepjs@18.66.2:
+    resolution: {integrity: sha512-jhh6fBHFjjN4eB6K3z/T+eGtrfHi6X33OtZup/7l/0aoPj4vEG8sjY+H/QABc5PL2898757CdN5EPPuDoGz2gA==}
     engines: {node: '>=24'}
     peerDependencies:
       brepjs-manifold: ^0.1.0
@@ -8241,7 +8250,7 @@ snapshots:
 
   '@rollup/plugin-node-resolve@16.0.3(rollup@2.80.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@2.80.0)
+      '@rollup/pluginutils': 5.4.0(rollup@2.80.0)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
@@ -8271,6 +8280,14 @@ snapshots:
       rollup: 2.80.0
 
   '@rollup/pluginutils@5.3.0(rollup@2.80.0)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 2.80.0
+
+  '@rollup/pluginutils@5.4.0(rollup@2.80.0)':
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
@@ -9102,7 +9119,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.66.1(brepkit-wasm@2.101.3)(occt-wasm@3.2.2):
+  brepjs@18.66.2(brepkit-wasm@2.101.3)(occt-wasm@3.2.2):
     dependencies:
       flatbush: 4.5.1
       opentype.js: 1.3.4

--- a/src/features/generation/worker/generators/__kernel-tests__/honeycombManifoldCheck.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/honeycombManifoldCheck.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+/**
+ * Scratch verification (not a CI gate): honeycomb wall pattern must actually
+ * carve the walls on the active kernel. On Manifold this was a silent no-op
+ * (composeTransform degree/radian mismatch + unimplemented makeCompound in
+ * brepjs); plain and honeycomb meshes came back with identical triangles.
+ *
+ * Run per kernel:
+ *   BREPJS_KERNEL=manifold pnpm exec vitest run --config vitest.profile.config.ts honeycombManifoldCheck --reporter=verbose
+ *   pnpm exec vitest run --config vitest.profile.config.ts honeycombManifoldCheck --reporter=verbose
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs, getGenerateBin, getKernelName } from './wasmInit';
+import { buildParams } from './scenarioTypes';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { clearAllCaches } from '../shapeCache';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 120_000);
+
+function minZ(vertices: Float32Array | null): number {
+  if (!vertices) return NaN;
+  let lo = Infinity;
+  for (let i = 2; i < vertices.length; i += 3) lo = Math.min(lo, vertices[i]);
+  return lo;
+}
+
+describe(`honeycomb wall pattern on ${getKernelName()}`, () => {
+  it('carves the walls (triangles change, geometry stays above z=0)', () => {
+    const generateBin = getGenerateBin();
+
+    clearAllCaches();
+    const plain = generateBin(buildParams({ width: 4, depth: 4, height: 8 }));
+
+    clearAllCaches();
+    const honeycomb = generateBin(
+      buildParams({
+        width: 4,
+        depth: 4,
+        height: 8,
+        wallPattern: { ...DEFAULT_BIN_PARAMS.wallPattern, enabled: true, pattern: 'honeycomb' },
+      })
+    );
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[${getKernelName()}] plain tris=${plain.triangleCount} honeycomb tris=${honeycomb.triangleCount} minZ=${minZ(honeycomb.vertices)}`
+    );
+
+    expect(honeycomb.triangleCount).toBeGreaterThan(plain.triangleCount);
+    expect(minZ(honeycomb.vertices)).toBeGreaterThanOrEqual(-0.001);
+  });
+});


### PR DESCRIPTION
## Summary

Honeycomb wall patterns now render in Manifold draft previews (`manifold_preview` Labs flag) instead of silently showing plain walls until the exact result lands.

brepjs 18.66.2 fixes two Manifold-adapter bugs (andymai/brepjs#1236):
1. **Composed transforms treated degrees as radians** — a 90° rotate in `composeTransforms` became a 90-radian one, so `transformCopy`-placed hex prisms landed off-target (same fix applied to `circularPattern` / `transformBatch`).
2. **`makeCompound` was unimplemented** — grouping the placed prisms threw before the cut ran; gridfinity's wall-pattern builder catches and falls back to no pattern, which made the failure silent (output triangles exactly matched a plain bin).

## Changes
- `brepjs` 18.66.1 → 18.66.2 (exact pin per WASM-determinism policy)
- New profile-config regression test `honeycombManifoldCheck.test.ts` (not a CI gate): generates a real honeycomb bin on the active kernel and asserts the walls are carved (`honeycomb tris > plain tris`) with no geometry below z=0

## Verification
- Manifold: plain 14,154 tris → honeycomb 32,232, minZ = 0
- occt-wasm control: plain 7,996 → honeycomb 26,348, minZ = 0
- Full `binGenerator.scenario` suite: 826 passed, zero snapshot drift (18.66.2 is manifold-adapter-only)
- typecheck clean