### PR TITLE
ci: add Unit Tests Complete aggregate gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,27 @@ jobs:
           path: coverage/
           retention-days: 5
 
+  # Single stable gate that passes only if every Unit Tests shard passed.
+  # Branch protection requires this one context instead of the individual
+  # shard names, so shard/group counts can change without updating the ruleset.
+  # always() so it still runs (and fails) when a shard fails; skipped for
+  # release-please PRs in lockstep with the test job above.
+  test-gate:
+    name: Unit Tests Complete
+    needs: [test]
+    if: ${{ always() && !startsWith(github.head_ref, 'release-please--') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all unit-test shards passed
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          if [ "$TEST_RESULT" != "success" ]; then
+            echo "Unit test shards did not all pass (result: $TEST_RESULT)"
+            exit 1
+          fi
+          echo "All unit-test shards passed."
+
   # PRs + main: Lint, i18n, module boundaries, union exhaustiveness
   # All checks run to completion so every failure is visible in one pass
   quality:


### PR DESCRIPTION
Hardening follow-up to #2016/#2017.

## Problem

Branch protection requires each individual Unit Tests **shard** context (`Unit Tests (generators 1/3)` … `Unit Tests (core 3/3)`). During this work the shard names changed four times (`2/2` → `4/4` → group names → `core n/3`), and every change would have silently blocked merges until the ruleset was hand-edited to match.

## Change

Add a `test-gate` job that `needs: [test]` and passes only if **every** shard succeeded, surfaced as a single stable check: **`Unit Tests Complete`**.

- `if: always() && !release-please` — runs even when a shard fails (so it can report failure and block merge), and skips for release-please PRs in lockstep with the test job.
- Reads `needs.test.result` via an env var (no expression injection into the shell).

Branch protection can then require just `Unit Tests Complete` instead of the N shard names — so shard/group counts can change freely without touching the ruleset.

## Follow-up (manual, after merge)

Swap the `protection` ruleset's required checks from the 6 shard contexts to the single `Unit Tests Complete` context (keeping Build + Conventional Commit).