### PR TITLE
ci: cache pnpm store with restore-keys to fix cold-install stalls

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,43 @@
+name: Setup pnpm + Node
+description: >-
+  Install pnpm, set up Node, restore the pnpm store (with restore-keys so a
+  changed lockfile only downloads the delta instead of a full cold install),
+  and install dependencies with --frozen-lockfile.
+
+inputs:
+  node-version:
+    description: Node.js version to install.
+    required: false
+    default: '24'
+
+runs:
+  using: composite
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+    - name: Setup Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Resolve pnpm store path
+      shell: bash
+      run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+    # Explicit store cache with restore-keys. setup-node's built-in `cache: pnpm`
+    # only restores on an exact lockfile-hash match, so any dependency bump is a
+    # full cold download (~4min stalls observed). The restore-keys fallback
+    # restores the most recent store and pnpm fetches only the changed packages.
+    - name: Cache pnpm store
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ env.PNPM_STORE_PATH }}
+        key: pnpm-store-${{ runner.os }}-node${{ inputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          pnpm-store-${{ runner.os }}-node${{ inputs.node-version }}-
+          pnpm-store-${{ runner.os }}-
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,17 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Setup pnpm + Node and install dependencies
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm run build
@@ -78,17 +71,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Setup pnpm + Node and install dependencies
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Generate artifacts
         # en.json is generated from en.ts at build/dev time and gitignored.
@@ -150,17 +136,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Setup pnpm + Node and install dependencies
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Lint
         id: lint


### PR DESCRIPTION
Follow-up to the split-robustness work: the slowest shard there was 397s, but the step breakdown showed **260s of it was `pnpm install`**, not tests (tests ran in 113s). Root cause: `actions/setup-node`'s built-in `cache: pnpm` only restores on an **exact** `pnpm-lock.yaml` hash match, so any dependency bump (e.g. the recent brepjs/manifold ones) is a full cold download.

## Change

Extract the three identical install blocks (build, test, quality jobs) into a `.github/actions/setup-pnpm` **composite action** that caches the pnpm store explicitly with **`restore-keys`**:

```yaml
key: pnpm-store-${{ runner.os }}-node${{ inputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}
restore-keys: |
  pnpm-store-${{ runner.os }}-node${{ inputs.node-version }}-
  pnpm-store-${{ runner.os }}-
```

On a lockfile change the exact key misses, but `restore-keys` restores the **most recent** store, so `pnpm install` fetches only the changed packages instead of all of them. This turns a ~260s cold install into a near-incremental one.

Bonus: the composite action de-duplicates the install setup across all three jobs (one place to maintain pnpm/Node versions and caching).

## Notes

- `actions/cache` pinned to a commit SHA (v5.0.5), matching the repo's SHA-pinning convention; Dependabot will keep it current.
- No behavior change to what runs — only how dependencies are restored.
- Verification is the CI run on this PR: installs should be fast on a warm cache, and resilient (delta-only) after future lockfile changes.