### PR TITLE
perf(generation): defer base-socket fuse to export for faster cold preview

### DIFF
--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -55,6 +55,9 @@ function toMeshPayload(result: BridgeResult): GenerationResult {
  * A monotonic token guards arbitration: a draft is dropped if a newer edit has
  * started or the exact result for its edit has already landed.
  */
+/** Idle gap after the exact result before speculatively warming the export shell. */
+const EXPORT_WARM_IDLE_MS = 2000;
+
 export function useGeneration(): void {
   const bridgeRef = useRef<GenerationBridge | null>(null);
   const previewBridgeRef = useRef<GenerationBridge | null>(null);
@@ -66,6 +69,10 @@ export function useGeneration(): void {
   // are stale and dropped (covers the exact-resolves-before-draft race).
   const finalizedTokenRef = useRef(0);
   const draftSkipGate = useRef(createDraftSkipGate()).current;
+  // After the exact result settles, idle-warm the export-quality (fused) shell
+  // so the first export skips the deferred socket↔body fuse. Cancelled (timer
+  // cleared) on the next edit so the warm only runs when the user has paused.
+  const warmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { params, epoch } = useDesignerStore(
     useShallow((state) => ({
@@ -128,6 +135,11 @@ export function useGeneration(): void {
       }
 
       const token = ++genTokenRef.current;
+      // A new edit cancels any pending idle export-warm.
+      if (warmTimerRef.current !== null) {
+        clearTimeout(warmTimerRef.current);
+        warmTimerRef.current = null;
+      }
       setGenerationStatus('generating');
 
       // Fast draft on the leading edge (best-effort): renders while the exact
@@ -158,6 +170,14 @@ export function useGeneration(): void {
 
         setGenerationResult(toMeshPayload(result));
         setGenerationStatus('complete');
+
+        // Once the user pauses, speculatively warm the export-quality shell so
+        // the first export skips the deferred socket↔body fuse. (Any prior timer
+        // was already cleared at the start of this generation.)
+        warmTimerRef.current = setTimeout(() => {
+          warmTimerRef.current = null;
+          bridgeRef.current?.warmExport(currentParams);
+        }, EXPORT_WARM_IDLE_MS);
       } catch (e) {
         // Cancelled requests are expected during rapid param changes
         if (e instanceof Error && e.message === 'Generation cancelled') {
@@ -251,6 +271,10 @@ export function useGeneration(): void {
 
     return () => {
       cancelled = true;
+      if (warmTimerRef.current !== null) {
+        clearTimeout(warmTimerRef.current);
+        warmTimerRef.current = null;
+      }
       bridgeRef.current = null;
       previewBridgeRef.current = null;
       initializedRef.current = false;

--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -79,11 +79,11 @@ graph TB
 
 Composable stages in `pipeline/stages/`, orchestrated by `pipeline/runner.ts`:
 
-1. **Shell** (`shellStage`) — socket + box body + lip assembly, cached by shellKey
-2. **Features** (`featuresStage`) — compartments, inserts, slots, labels, scoops, wall cutouts, patterns
+1. **Shell** (`shellStage`) — box body + lip (cached by shellKey) is `ctx.solid`; the base socket is built separately. **Preview** keeps the socket in `ctx.deferredSolid` (skips the socket↔body fuse — ~80% of cold-shell time); **export** fuses it into `ctx.solid` for a watertight model.
+2. **Features** (`featuresStage`) — compartments, inserts, slots, labels, scoops, wall cutouts, patterns (cut the body only; the socket is never feature-cut)
 3. **Boolean** (`booleanStage`) — batch fuse additive + cut subtractive via `fuseAllBisect` / `cutAllBisect` (n-way batch first, recursive bisect on failure)
-4. **Translate** (`translateStage`) — Z-offset for socket-based bins
-5. **Tessellate** (`tessellateStage`) — dynamic quality mesh + edge extraction
+4. **Translate** (`translateStage`) — Z-offset for socket-based bins (applied to `solid` **and** `deferredSolid` so they stay aligned)
+5. **Tessellate** (`tessellateStage`) — dynamic quality mesh + edge extraction; meshes `deferredSolid` separately and concatenates via `mergeShapeMeshes` (visually identical to the fused shell — socket meets the body only at a hidden interface)
 
 ## Worker Protocol
 

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -82,6 +82,9 @@ export class GenerationBridge {
   worker: Worker | null = null;
   initPromise: Promise<void> | null = null;
   currentRequestId: string | null = null;
+  /** True while a speculative idle export-warm is in flight (clears on WARM_DONE). */
+  isWarming = false;
+  private warmSeq = 0;
   debounceTimer: ReturnType<typeof setTimeout> | null = null;
   generationTimer: ReturnType<typeof setTimeout> | null = null;
   pendingResolve: ((result: GenerationResult) => void) | null = null;
@@ -223,6 +226,21 @@ export class GenerationBridge {
       });
       this.postMessage({ type: 'ESTIMATE', payload: { params, requestId } });
     });
+  }
+
+  /**
+   * Speculatively build the export-quality (fused) shell during idle so a
+   * subsequent export skips the deferred socket↔body fuse. Best-effort and
+   * fire-and-forget: skipped when the worker is busy or already warming, and
+   * cleared on WARM_DONE. A new generation simply queues behind an in-flight
+   * warm (the separate Manifold draft worker keeps the preview responsive).
+   */
+  warmExport(params: BinParams): void {
+    if (this.isDestroyed || !this.worker) return;
+    if (this.isWarming || this.currentRequestId) return;
+    this.isWarming = true;
+    const requestId = `warm-${++this.warmSeq}`;
+    this.postMessage({ type: 'WARM', payload: { params, requestId } });
   }
 
   /** Cancel any in-flight generation request */

--- a/src/features/generation/bridge/bridgeMessageHandler.ts
+++ b/src/features/generation/bridge/bridgeMessageHandler.ts
@@ -30,6 +30,7 @@ export interface MessageHandlerContext {
   initPromise: Promise<void> | null;
   threadingInfo: ThreadingInfo | null;
   currentRequestId: string | null;
+  isWarming: boolean;
   pendingResolve: ((result: GenerationResult) => void) | null;
   pendingReject: ((error: Error) => void) | null;
   onProgress: ProgressCallback | null;
@@ -93,6 +94,10 @@ export function installMessageHandler(ctx: MessageHandlerContext): void {
         if (response.requestId === ctx.currentRequestId && ctx.onProgress) {
           ctx.onProgress(response.stage, response.progress);
         }
+        break;
+
+      case 'WARM_DONE':
+        ctx.isWarming = false;
         break;
 
       case 'ESTIMATE_RESULT':

--- a/src/features/generation/bridge/types.ts
+++ b/src/features/generation/bridge/types.ts
@@ -37,6 +37,7 @@ export type WorkerMessage =
   | InitMessage
   | GenerateMessage
   | EstimateMessage
+  | WarmMessage
   | GenerateBaseplateMessage
   | GenerateSplitPreviewMessage
   | GenerateSplitPreviewRangeMessage
@@ -66,6 +67,15 @@ export interface GenerateMessage {
  */
 export interface EstimateMessage {
   readonly type: 'ESTIMATE';
+  readonly payload: GeneratePayload;
+}
+
+/**
+ * Speculative idle warm: build the export-quality (fused) shell so a subsequent
+ * export skips the deferred socket↔body fuse. No mesh is returned.
+ */
+export interface WarmMessage {
+  readonly type: 'WARM';
   readonly payload: GeneratePayload;
 }
 
@@ -258,6 +268,7 @@ export type WorkerResponse =
   | KernelPerfStatsResponse
   | BooleanFallbackStatsResponse
   | CleanupDoneResponse
+  | WarmDoneResponse
   | ErrorResponse;
 
 /** Per-cache statistics snapshot from the worker. */
@@ -279,6 +290,11 @@ export interface CacheStatsResponse {
 
 export interface CleanupDoneResponse {
   readonly type: 'CLEANUP_DONE';
+}
+
+export interface WarmDoneResponse {
+  readonly type: 'WARM_DONE';
+  readonly requestId: string;
 }
 
 /** Per-category kernel performance timing from brepjs. */

--- a/src/features/generation/worker/generation.worker.ts
+++ b/src/features/generation/worker/generation.worker.ts
@@ -29,7 +29,7 @@ import {
   getKernelInfo,
   cancelRequest,
 } from './handlers/workerContext';
-import { handleGenerate, handleGenerateBaseplate } from './handlers/generateHandler';
+import { handleGenerate, handleWarm, handleGenerateBaseplate } from './handlers/generateHandler';
 import {
   handleExport,
   handleExportBaseplate,
@@ -87,6 +87,10 @@ self.addEventListener('message', (event: MessageEvent<WorkerMessage>) => {
 
       case 'GENERATE':
         handleGenerate(message);
+        break;
+
+      case 'WARM':
+        handleWarm(message);
         break;
 
       case 'ESTIMATE':

--- a/src/features/generation/worker/generators/__kernel-tests__/deferCorrectness.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/deferCorrectness.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+import { writeFileSync } from 'node:fs';
+import { describe, it, beforeAll, expect } from 'vitest';
+import { initBrepjs, getGenerateBin } from './wasmInit';
+import { buildParams, makeCutout } from './scenarioTypes';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { BinParams } from '@/shared/types/bin';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 60_000);
+
+// Signed volume of a triangle mesh (divergence theorem). For the preview's
+// concatenated body+socket, the hidden coincident interface faces ~cancel, so
+// this ≈ the true solid volume — and DIVERGES from export only if the preview
+// wrongly keeps material a cut removed (e.g. a foot blocking a through-cut).
+function signedVolume(verts: ArrayLike<number>, idx: ArrayLike<number>): number {
+  let v = 0;
+  for (let i = 0; i < idx.length; i += 3) {
+    const a = idx[i] * 3,
+      b = idx[i + 1] * 3,
+      c = idx[i + 2] * 3;
+    const ax = verts[a],
+      ay = verts[a + 1],
+      az = verts[a + 2];
+    const bx = verts[b],
+      by = verts[b + 1],
+      bz = verts[b + 2];
+    const cx = verts[c],
+      cy = verts[c + 1],
+      cz = verts[c + 2];
+    v += (ax * (by * cz - bz * cy) - ay * (bx * cz - bz * cx) + az * (bx * cy - by * cx)) / 6;
+  }
+  return Math.abs(v);
+}
+
+function compare(
+  label: string,
+  p: BinParams
+): { label: string; previewSV: number; exportSV: number; diffPct: number } {
+  const gen = getGenerateBin();
+  const e = gen(p, undefined, true);
+  const pr = gen(p, undefined, false);
+  const exportSV = signedVolume(e.vertices, e.indices);
+  const previewSV = signedVolume(pr.vertices, pr.indices);
+  const diffPct = (Math.abs(previewSV - exportSV) / exportSV) * 100;
+  return { label, previewSV, exportSV, diffPct };
+}
+
+describe('defer-socket correctness vs features that reach the socket', () => {
+  it('preview solid volume matches export (no foot blocking a cut)', () => {
+    const rows: ReturnType<typeof compare>[] = [];
+    // Control: plain socket bin (socket never cut) — should match.
+    rows.push(
+      compare(
+        'plain socket',
+        buildParams({
+          width: 2,
+          depth: 2,
+          height: 3,
+          base: { ...DEFAULT_BIN_PARAMS.base, style: 'socket', stackingLip: true },
+        })
+      )
+    );
+    // Solid bin with a DEEP cutout that may punch through to the socket.
+    rows.push(
+      compare(
+        'solid deep cutout',
+        buildParams({
+          width: 2,
+          depth: 2,
+          height: 3,
+          base: { ...DEFAULT_BIN_PARAMS.base, style: 'standard', solid: true, stackingLip: true },
+          cutouts: [makeCutout({ shape: 'circle', width: 16, depth: 16, cutDepth: 40 })],
+        })
+      )
+    );
+    // Magnet bin (magnet holes are cut INSIDE the socket build — should still match).
+    rows.push(
+      compare(
+        'magnet socket',
+        buildParams({
+          width: 2,
+          depth: 2,
+          height: 3,
+          base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet', stackingLip: true },
+        })
+      )
+    );
+
+    writeFileSync(
+      '/tmp/perfbench/defer-correctness.txt',
+      rows
+        .map(
+          (r) =>
+            `  ${r.label.padEnd(20)}: preview ${r.previewSV.toFixed(0)} vs export ${r.exportSV.toFixed(0)}  diff ${r.diffPct.toFixed(2)}%`
+        )
+        .join('\n') + '\n'
+    );
+    for (const r of rows) {
+      // >1% solid-volume divergence = preview kept material a cut removed.
+      expect(r.diffPct, `${r.label} preview/export volume divergence`).toBeLessThan(1);
+    }
+  }, 120_000);
+});

--- a/src/features/generation/worker/generators/__kernel-tests__/deferStress.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/deferStress.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+/**
+ * Robustness guards for the deferred-socket preview path (defer-socket-fuse):
+ * disposal stability across repeated generations and face-group/origin survival
+ * through the body+socket mesh merge (multicolor).
+ */
+import { describe, it, beforeAll, expect } from 'vitest';
+import { initBrepjs, getGenerateBin } from './wasmInit';
+import { buildParams } from './scenarioTypes';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 60_000);
+
+const hasNaN = (a: ArrayLike<number>): boolean => {
+  for (let i = 0; i < a.length; i++) if (!Number.isFinite(a[i])) return true;
+  return false;
+};
+
+describe('defer-socket robustness', () => {
+  it('repeated preview+export generations are stable and deterministic', () => {
+    const gen = getGenerateBin();
+    const p = buildParams({
+      width: 4,
+      depth: 3,
+      height: 5,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet', stackingLip: true },
+      compartments: { cols: 2, rows: 2, thickness: 1.2, cells: [0, 1, 2, 3] },
+    });
+    let previewTris = 0;
+    let exportTris = 0;
+    for (let i = 0; i < 8; i++) {
+      const preview = gen(p, undefined, false);
+      const exp = gen(p, undefined, true);
+      expect(preview.triangleCount).toBeGreaterThan(0);
+      expect(exp.triangleCount).toBeGreaterThan(0);
+      expect(hasNaN(preview.vertices)).toBe(false);
+      expect(hasNaN(exp.vertices)).toBe(false);
+      if (i > 0) {
+        // No disposal/state corruption: identical output every repeat.
+        expect(preview.triangleCount).toBe(previewTris);
+        expect(exp.triangleCount).toBe(exportTris);
+      }
+      previewTris = preview.triangleCount;
+      exportTris = exp.triangleCount;
+    }
+  }, 120_000);
+
+  it('preview face groups survive the body+socket merge (socket tagged for multicolor)', () => {
+    const gen = getGenerateBin();
+    const preview = gen(
+      buildParams({
+        width: 2,
+        depth: 2,
+        height: 4,
+        base: { ...DEFAULT_BIN_PARAMS.base, style: 'socket', stackingLip: true },
+      }),
+      undefined,
+      false
+    );
+    expect(preview.faceGroups).toBeDefined();
+    const tags = new Set((preview.faceGroups ?? []).map((g) => g.tag));
+    expect(tags.size).toBeGreaterThan(1); // distinct zones preserved
+    expect(tags.has(3)).toBe(true); // FeatureTag.SOCKET — socket faces present + tagged
+  }, 60_000);
+});

--- a/src/features/generation/worker/generators/__kernel-tests__/exportCache.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/exportCache.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+import { writeFileSync } from 'node:fs';
+import { describe, it, beforeAll, expect } from 'vitest';
+import { measureVolume, unwrap } from 'brepjs';
+import { initBrepjs, getGenerateBin } from './wasmInit';
+import { buildParams } from './scenarioTypes';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { clearAllCaches, getLastSolid } from '../shapeCache';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 60_000);
+const vol = (s: unknown): number => {
+  const v: unknown = measureVolume(s as never);
+  return typeof v === 'number' ? v : unwrap(v as never);
+};
+
+describe('export shell cache', () => {
+  it('caches the fused shell; re-export is faster with identical geometry', () => {
+    const gen = getGenerateBin();
+    const p = buildParams({
+      width: 6,
+      depth: 6,
+      height: 4,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'socket', stackingLip: true },
+    });
+    clearAllCaches();
+    let t = performance.now();
+    gen(p, undefined, true);
+    const first = performance.now() - t;
+    const v1 = vol(getLastSolid());
+    t = performance.now();
+    gen(p, undefined, true);
+    const second = performance.now() - t;
+    const v2 = vol(getLastSolid());
+    writeFileSync(
+      '/tmp/perfbench/export-cache.txt',
+      `first=${first.toFixed(0)}ms second=${second.toFixed(0)}ms vol1=${v1.toFixed(0)} vol2=${v2.toFixed(0)}\n`
+    );
+    expect(Math.abs(v1 - v2)).toBeLessThan(1); // geometry identical
+    expect(second).toBeLessThan(first * 0.8); // re-export meaningfully faster (fuse cached)
+  }, 120_000);
+});

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.baseStyles.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.baseStyles.test.ts.snap
@@ -4,22 +4,22 @@ exports[`base styles > flat base no lip 1`] = `204`;
 
 exports[`base styles > flat base with lip 1`] = `892`;
 
-exports[`base styles > magnet base no lip 1`] = `804`;
+exports[`base styles > magnet base no lip 1`] = `800`;
 
-exports[`base styles > magnet base with lip 1`] = `1900`;
+exports[`base styles > magnet base with lip 1`] = `1896`;
 
-exports[`base styles > magnet+screw base no lip 1`] = `1028`;
+exports[`base styles > magnet+screw base no lip 1`] = `1040`;
 
-exports[`base styles > magnet+screw base with lip 1`] = `2268`;
+exports[`base styles > magnet+screw base with lip 1`] = `2280`;
 
-exports[`base styles > screw base no lip 1`] = `692`;
+exports[`base styles > screw base no lip 1`] = `704`;
 
-exports[`base styles > screw base with lip 1`] = `1740`;
+exports[`base styles > screw base with lip 1`] = `1752`;
 
-exports[`base styles > standard base no lip 1`] = `468`;
+exports[`base styles > standard base no lip 1`] = `464`;
 
-exports[`base styles > standard base with lip 1`] = `1372`;
+exports[`base styles > standard base with lip 1`] = `1368`;
 
-exports[`base styles > weighted base no lip 1`] = `468`;
+exports[`base styles > weighted base no lip 1`] = `464`;
 
-exports[`base styles > weighted base with lip 1`] = `1372`;
+exports[`base styles > weighted base with lip 1`] = `1368`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`bin styles > 2×2 slotted 1`] = `3220`;
+exports[`bin styles > 2×2 slotted 1`] = `3204`;
 
-exports[`bin styles > 2×2 solid 1`] = `2548`;
+exports[`bin styles > 2×2 solid 1`] = `2532`;
 
-exports[`bin styles > 2×2 standard 1`] = `2812`;
+exports[`bin styles > 2×2 standard 1`] = `2796`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
@@ -2,10 +2,10 @@
 
 exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1300`;
 
-exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3568`;
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3520`;
 
-exports[`combined features > 2×2 label tabs with merged compartments 1`] = `4404`;
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `4388`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `5764`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `5540`;
 
-exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `18048`;
+exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `17792`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2812`;
+exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2796`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `2924`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `2908`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `2952`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `2936`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `3212`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `3196`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.snap
@@ -1,31 +1,31 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `2918`;
+exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `2906`;
 
-exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `5318`;
+exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `5286`;
 
-exports[`custom-shape > 2×2 mixed-detail per-cell half sockets 1`] = `4360`;
+exports[`custom-shape > 2×2 mixed-detail per-cell half sockets 1`] = `4336`;
 
 exports[`custom-shape > 3×3 L flat base no lip 1`] = `260`;
 
-exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`] = `5362`;
+exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`] = `5330`;
 
-exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `5762`;
+exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `5730`;
 
-exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `14890`;
+exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `14858`;
 
-exports[`custom-shape > 3×3 L with honeycomb pattern (polygon edge enumeration) 1`] = `15286`;
+exports[`custom-shape > 3×3 L with honeycomb pattern (polygon edge enumeration) 1`] = `15254`;
 
-exports[`custom-shape > 3×3 L with lip 1`] = `5282`;
+exports[`custom-shape > 3×3 L with lip 1`] = `5250`;
 
-exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `5552`;
+exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `5520`;
 
-exports[`custom-shape > 3×3 T with lip 1`] = `4388`;
+exports[`custom-shape > 3×3 T with lip 1`] = `4368`;
 
-exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`] = `5836`;
+exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`] = `5808`;
 
-exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `5436`;
+exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `5408`;
 
-exports[`custom-shape > 3×3 U with honeycomb pattern (multi-side polygon pattern) 1`] = `18650`;
+exports[`custom-shape > 3×3 U with honeycomb pattern (multi-side polygon pattern) 1`] = `18622`;
 
-exports[`custom-shape > 3×3 U with lip 1`] = `5356`;
+exports[`custom-shape > 3×3 U with lip 1`] = `5328`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dimensions.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dimensions.test.ts.snap
@@ -1,21 +1,21 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`dimensions > 0.5×0.5 no lip 1`] = `468`;
+exports[`dimensions > 0.5×0.5 no lip 1`] = `464`;
 
-exports[`dimensions > 0.5×0.5 with lip 1`] = `1372`;
+exports[`dimensions > 0.5×0.5 with lip 1`] = `1368`;
 
-exports[`dimensions > 1.5×2 fractional no lip 1`] = `1260`;
+exports[`dimensions > 1.5×2 fractional no lip 1`] = `1244`;
 
-exports[`dimensions > 1.5×2 fractional with lip 1`] = `2812`;
+exports[`dimensions > 1.5×2 fractional with lip 1`] = `2796`;
 
-exports[`dimensions > 1×1 no lip 1`] = `468`;
+exports[`dimensions > 1×1 no lip 1`] = `464`;
 
-exports[`dimensions > 1×1 with lip 1`] = `1372`;
+exports[`dimensions > 1×1 with lip 1`] = `1368`;
 
-exports[`dimensions > 2×2 no lip 1`] = `1260`;
+exports[`dimensions > 2×2 no lip 1`] = `1244`;
 
-exports[`dimensions > 2×2 with lip 1`] = `2812`;
+exports[`dimensions > 2×2 with lip 1`] = `2796`;
 
-exports[`dimensions > 4×4 no lip 1`] = `3500`;
+exports[`dimensions > 4×4 no lip 1`] = `3436`;
 
-exports[`dimensions > 4×4 with lip 1`] = `7996`;
+exports[`dimensions > 4×4 with lip 1`] = `7932`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.exportAndLarge.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.exportAndLarge.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2620`;
+exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2604`;
 
 exports[`export mode > 2×2 default params (forExport=true) 1`] = `5276`;
 
-exports[`large bin > 8×8 standard 1`] = `23180`;
+exports[`large bin > 8×8 standard 1`] = `22924`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.halfSockets.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.halfSockets.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5212`;
+exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5176`;
 
-exports[`half-sockets > 1×1 with half sockets 1`] = `2812`;
+exports[`half-sockets > 1×1 with half sockets 1`] = `2796`;
 
-exports[`half-sockets > 2×2 with half sockets 1`] = `8572`;
+exports[`half-sockets > 2×2 with half sockets 1`] = `8508`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.heights.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.heights.test.ts.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`height > 2×2 height minimum (2u) 1`] = `2812`;
+exports[`height > 2×2 height minimum (2u) 1`] = `2796`;
 
-exports[`height > 2×2 height tall (10u) 1`] = `2812`;
+exports[`height > 2×2 height tall (10u) 1`] = `2796`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.snap
@@ -1,15 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6868`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6852`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6804`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6788`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6940`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6924`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6940`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6924`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `6900`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `6884`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `6756`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `6740`;
 
-exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `6940`;
+exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `6924`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.inserts.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.inserts.test.ts.snap
@@ -1,13 +1,13 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`inserts > 2×2 with circle insert 1`] = `3080`;
+exports[`inserts > 2×2 with circle insert 1`] = `3032`;
 
-exports[`inserts > 2×2 with hexagon insert 1`] = `3080`;
+exports[`inserts > 2×2 with hexagon insert 1`] = `3032`;
 
-exports[`inserts > 2×2 with rectangle insert 1`] = `2848`;
+exports[`inserts > 2×2 with rectangle insert 1`] = `2816`;
 
-exports[`inserts > 2×2 with rounded-rect insert 1`] = `2976`;
+exports[`inserts > 2×2 with rounded-rect insert 1`] = `2944`;
 
-exports[`inserts > 2×2 with slot insert 1`] = `3024`;
+exports[`inserts > 2×2 with slot insert 1`] = `2984`;
 
-exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3304`;
+exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3264`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelTabs.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelTabs.test.ts.snap
@@ -1,21 +1,21 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`label tabs > 1×1 label both collision drops front 1`] = `1372`;
+exports[`label tabs > 1×1 label both collision drops front 1`] = `1368`;
 
-exports[`label tabs > 2×2 label bracket center 1`] = `3628`;
+exports[`label tabs > 2×2 label bracket center 1`] = `3612`;
 
-exports[`label tabs > 2×2 label bracket left 1`] = `3628`;
+exports[`label tabs > 2×2 label bracket left 1`] = `3612`;
 
-exports[`label tabs > 2×2 label bracket right 1`] = `3628`;
+exports[`label tabs > 2×2 label bracket right 1`] = `3612`;
 
-exports[`label tabs > 2×2 label disabled 1`] = `2812`;
+exports[`label tabs > 2×2 label disabled 1`] = `2796`;
 
-exports[`label tabs > 2×2 label front edge 1`] = `3628`;
+exports[`label tabs > 2×2 label front edge 1`] = `3612`;
 
-exports[`label tabs > 2×2 label solid left 1`] = `3380`;
+exports[`label tabs > 2×2 label solid left 1`] = `3364`;
 
-exports[`label tabs > 2×2×4 label both + inset 5mm 1`] = `3140`;
+exports[`label tabs > 2×2×4 label both + inset 5mm 1`] = `3124`;
 
-exports[`label tabs > 2×2×4 label both edges 1`] = `4444`;
+exports[`label tabs > 2×2×4 label both edges 1`] = `4428`;
 
-exports[`label tabs > 2×2×6 label dropped (height = 20mm) 1`] = `3280`;
+exports[`label tabs > 2×2×6 label dropped (height = 20mm) 1`] = `3264`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4000`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `3924`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4738`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4514`;
 
-exports[`scoop > 2×2 scoop auto radius 1`] = `4000`;
+exports[`scoop > 2×2 scoop auto radius 1`] = `3924`;
 
-exports[`scoop > 2×2 scoop disabled 1`] = `2812`;
+exports[`scoop > 2×2 scoop disabled 1`] = `2796`;
 
-exports[`scoop > 2×2 scoop radius 10mm 1`] = `4032`;
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `3956`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `3220`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `3204`;
 
-exports[`slotted variations > slotted with both axes 1`] = `3628`;
+exports[`slotted variations > slotted with both axes 1`] = `3612`;
 
-exports[`slotted variations > slotted without lip 1`] = `1380`;
+exports[`slotted variations > slotted without lip 1`] = `1364`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.snap
@@ -1,49 +1,49 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`solid cutouts > 2×2 solid with 3×2 grid array of circles 1`] = `3436`;
+exports[`solid cutouts > 2×2 solid with 3×2 grid array of circles 1`] = `3420`;
 
-exports[`solid cutouts > 2×2 solid with chamfered + scooped rectangle cutout 1`] = `3574`;
+exports[`solid cutouts > 2×2 solid with chamfered + scooped rectangle cutout 1`] = `3558`;
 
-exports[`solid cutouts > 2×2 solid with chamfered circle cutout 1`] = `2654`;
+exports[`solid cutouts > 2×2 solid with chamfered circle cutout 1`] = `2638`;
 
-exports[`solid cutouts > 2×2 solid with chamfered hexagon cutout 1`] = `2638`;
+exports[`solid cutouts > 2×2 solid with chamfered hexagon cutout 1`] = `2622`;
 
-exports[`solid cutouts > 2×2 solid with chamfered rectangle cutout 1`] = `2710`;
+exports[`solid cutouts > 2×2 solid with chamfered rectangle cutout 1`] = `2694`;
 
-exports[`solid cutouts > 2×2 solid with chamfered slot cutout 1`] = `2944`;
+exports[`solid cutouts > 2×2 solid with chamfered slot cutout 1`] = `2928`;
 
-exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `2784`;
+exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `2768`;
 
-exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `2700`;
+exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `2684`;
 
-exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `2548`;
+exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `2532`;
 
-exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2578`;
+exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2562`;
 
-exports[`solid cutouts > 2×2 solid with hexagon (polygon) cutout 1`] = `2580`;
+exports[`solid cutouts > 2×2 solid with hexagon (polygon) cutout 1`] = `2564`;
 
-exports[`solid cutouts > 2×2 solid with hexagon cutout + insertion clearance 1`] = `2584`;
+exports[`solid cutouts > 2×2 solid with hexagon cutout + insertion clearance 1`] = `2568`;
 
-exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `2740`;
+exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `2724`;
 
-exports[`solid cutouts > 2×2 solid with radial array (rotate-to-center) 1`] = `3352`;
+exports[`solid cutouts > 2×2 solid with radial array (rotate-to-center) 1`] = `3336`;
 
-exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2568`;
+exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2552`;
 
-exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `3244`;
+exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `3228`;
 
-exports[`solid cutouts > 2×2 solid with rectangle, edge gate disables a single wall 1`] = `2862`;
+exports[`solid cutouts > 2×2 solid with rectangle, edge gate disables a single wall 1`] = `2846`;
 
-exports[`solid cutouts > 2×2 solid with rectangle, split scoop (W only) cuts only left/right walls 1`] = `2688`;
+exports[`solid cutouts > 2×2 solid with rectangle, split scoop (W only) cuts only left/right walls 1`] = `2672`;
 
-exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2580`;
+exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2564`;
 
-exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `2696`;
+exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `2680`;
 
-exports[`solid cutouts > 2×2 solid with slot (stadium) cutout 1`] = `2762`;
+exports[`solid cutouts > 2×2 solid with slot (stadium) cutout 1`] = `2746`;
 
-exports[`solid cutouts > 2×2 solid with staggered hex array 1`] = `2764`;
+exports[`solid cutouts > 2×2 solid with staggered hex array 1`] = `2748`;
 
-exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2560`;
+exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2544`;
 
-exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2560`;
+exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2544`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.wallThickness.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.wallThickness.test.ts.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `2700`;
+exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `2684`;
 
-exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `2900`;
+exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `2884`;

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -174,6 +174,7 @@ export function createInitialContext(
     signal,
     onProgress,
     solid: null,
+    deferredSolid: null,
     originToTag: new Map<number, number>(),
     fuseTargets: [],
     cutTargets: [],

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -166,10 +166,14 @@ export const shellStage: PipelineStage = {
         // Watertight: fuse the socket into the body for a single solid, and
         // cache it so re-exports and the idle warm skip this fuse next time.
         const full = unwrap(fuse(body, socket));
+        // Cache + clone BEFORE deleting the inputs: if `translate` throws, the
+        // catch must not double-delete already-freed body/socket handles, and
+        // `full` is already owned by the cache (not leaked).
+        setExportShellCache(dim.shellKey, full);
+        const cloned = translate(full, [0, 0, 0]);
         body.delete();
         socket.delete();
-        setExportShellCache(dim.shellKey, full);
-        return { ...ctx, solid: translate(full, [0, 0, 0]), deferredSolid: null };
+        return { ...ctx, solid: cloned, deferredSolid: null };
       }
 
       // Preview: defer the socket fuse — tessellate stage meshes + concatenates.

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -1,11 +1,13 @@
 /**
- * Shell stage — assembles base socket + box body + stacking lip.
+ * Shell stage — assembles the bin body (box + stacking lip) and the base socket.
  *
- * Result is cached by shellKey for reuse across feature-only changes.
- * On cache hit, the cached shape is returned directly (BREP boolean ops
- * create new shapes and do not mutate their inputs, so the cache is safe).
- * On cache miss, the freshly-built shell is cached and then cloned so the
- * context holds a mutable copy.
+ * The BODY (box + lip) is cached by shellKey and is what features cut. The base
+ * socket is built separately (its own cache). On the PREVIEW path the socket is
+ * left OUT of `solid` and carried in `deferredSolid` — the expensive socket↔body
+ * fuse (≈80% of cold-shell time) is skipped; the tessellate stage meshes the two
+ * and concatenates them, which is visually identical because the socket is never
+ * feature-cut and only meets the body at a hidden internal interface. On the
+ * EXPORT path the socket is fused into `solid` for a watertight model.
  */
 
 import { unwrap, fuse, translate, withScope } from 'brepjs';
@@ -33,61 +35,51 @@ export const shellStage: PipelineStage = {
   },
 
   execute(ctx: PipelineContext): PipelineContext {
-    const { params, dimensions: dim, signal, onProgress, originToTag } = ctx;
+    const { params, dimensions: dim, signal, onProgress, originToTag, forExport } = ctx;
 
-    // `getShellCache` returns a metadata-preserving clone so face-origin
-    // tags survive the cache hit (see `getShellCache` for the mechanism).
-    const cachedShell = getShellCache(dim.shellKey);
-    if (cachedShell) {
-      return { ...ctx, solid: cachedShell };
-    }
+    // ── BODY (box + optional lip) — cached by shellKey. ──────────────────────
+    // `getShellCache` returns a metadata-preserving clone so BASE/LIP face-origin
+    // tags survive the cache hit (the metadata rides on the shape, not on the
+    // fresh per-generation `originToTag` map). For flat bins the body is the
+    // whole shell; for socket bins the socket is added separately below.
+    let body = getShellCache(dim.shellKey);
+    if (!body) {
+      checkCancelled(signal);
+      onProgress?.('shell', 0.3);
 
-    checkCancelled(signal);
-    onProgress?.('shell', 0.3);
+      const cutoutTopOffset = dim.solid ? params.cutoutConfig.topOffset : 0;
+      // Per-compartment cavity drawings only for the multi-cavity cut path
+      // (rectangular bin + non-solid + rectangular comps). shellKey already
+      // discriminates on the comp grid so `undefined` is safe otherwise.
+      const rawCavityDrawings = dim.compartmentsBakedIntoShell
+        ? buildCompartmentCavityDrawings(params, dim.innerW, dim.innerD)
+        : undefined;
+      const compartmentCavityDrawings =
+        rawCavityDrawings && (dim.innerOffsetX !== 0 || dim.innerOffsetY !== 0)
+          ? rawCavityDrawings.map((d) => d.translate(dim.innerOffsetX, dim.innerOffsetY))
+          : rawCavityDrawings;
+      const compartmentCavityKey = dim.compartmentsBakedIntoShell
+        ? buildCompartmentsCacheKey(params)
+        : undefined;
 
-    const cutoutTopOffset = dim.solid ? params.cutoutConfig.topOffset : 0;
+      const built = withScope((scope: DisposalScope) => {
+        const binBody = buildBinBox(
+          params.width,
+          params.depth,
+          dim.wallHeight,
+          params.wallThickness,
+          dim.solid,
+          cutoutTopOffset,
+          params.gridUnitMm,
+          params.cellMask,
+          compartmentCavityDrawings,
+          compartmentCavityKey,
+          dim.overhang
+        );
+        collectOrigins(binBody, FeatureTag.BASE, originToTag);
 
-    // Compute per-compartment cavity drawings only when the multi-cavity cut
-    // path will be taken (rectangular bin + non-solid + rectangular comps).
-    // The cache key in `dim.shellKey` already discriminates on the comp grid
-    // so we can safely pass `undefined` for the default path.
-    const rawCavityDrawings = dim.compartmentsBakedIntoShell
-      ? buildCompartmentCavityDrawings(params, dim.innerW, dim.innerD)
-      : undefined;
-    // For asymmetric overhang the inner cavity centre is at (innerOffsetX, innerOffsetY);
-    // shift the cavity drawings so they cut the correct region of the box body.
-    const compartmentCavityDrawings =
-      rawCavityDrawings && (dim.innerOffsetX !== 0 || dim.innerOffsetY !== 0)
-        ? rawCavityDrawings.map((d) => d.translate(dim.innerOffsetX, dim.innerOffsetY))
-        : rawCavityDrawings;
-    const compartmentCavityKey = dim.compartmentsBakedIntoShell
-      ? buildCompartmentsCacheKey(params)
-      : undefined;
-
-    const bin = withScope((scope: DisposalScope) => {
-      const binBody = buildBinBox(
-        params.width,
-        params.depth,
-        dim.wallHeight,
-        params.wallThickness,
-        dim.solid,
-        cutoutTopOffset,
-        params.gridUnitMm,
-        params.cellMask,
-        compartmentCavityDrawings,
-        compartmentCavityKey,
-        dim.overhang
-      );
-      collectOrigins(binBody, FeatureTag.BASE, originToTag);
-
-      if (dim.isFlat) {
-        checkCancelled(signal);
-        onProgress?.('features', 0.4);
         if (dim.hasLip) {
           try {
-            // buildTopShape returns a cache-owned clone — register it so
-            // the scope disposes that intermediate after translate produces
-            // the positioned copy.
             const lipBase = scope.register(
               buildTopShape(
                 params.width,
@@ -102,94 +94,68 @@ export const shellStage: PipelineStage = {
             collectOrigins(top, FeatureTag.LIP, originToTag);
             scope.register(binBody); // consumed by fuse
             return unwrap(
-              fuse(
-                binBody,
-                top /* no commonFace: box (3.75mm corners) and socket/lip profiles differ */
-              )
+              fuse(binBody, top /* no commonFace: box (3.75mm corners) and lip profile differ */)
             );
           } catch (e: unknown) {
             if (isAbortError(e)) throw e;
             return binBody; // fuse failed — withScope exempts returned value from disposal
           }
         }
-        return binBody; // no lip — binBody is the result (NOT registered)
-      }
+        return binBody; // no lip
+      });
 
-      // Socket style: build base socket and fuse with box.
-      // Register binBody eagerly — all socket paths consume it via fuse.
-      // Box uses BOX_CORNER_RADIUS (3.75mm) while socket uses SOCKET_CORNER_RADIUS
-      // (4mm), so they do NOT share a common face at Z=0 — full boolean required.
-      scope.register(binBody);
-      let base = scope.register(
-        buildBaseSocket(
-          params.width,
-          params.depth,
-          dim.withMagnet,
-          dim.withScrew,
-          params.base.magnetDiameter / 2,
-          params.base.magnetDepth,
-          params.base.screwDiameter / 2,
-          true, // Always use full 5-section socket profile (OCCT v8 is fast enough)
-          dim.halfSockets,
-          params.gridUnitMm,
-          params.cellMask
-        )
+      setShellCache(dim.shellKey, built);
+      // Metadata-preserving clone for the context (cache keeps `built`).
+      body = translate(built, [0, 0, 0]);
+    }
+
+    // Flat bins have no base socket — the body IS the whole shell.
+    if (dim.isFlat) {
+      return { ...ctx, solid: body, deferredSolid: null };
+    }
+
+    // ── BASE SOCKET — built separately (its own cache), optionally + feet. ───
+    checkCancelled(signal);
+    onProgress?.('features', 0.4);
+    let socket = buildBaseSocket(
+      params.width,
+      params.depth,
+      dim.withMagnet,
+      dim.withScrew,
+      params.base.magnetDiameter / 2,
+      params.base.magnetDepth,
+      params.base.screwDiameter / 2,
+      true, // Always use full 5-section socket profile (OCCT v8 is fast enough)
+      dim.halfSockets,
+      params.gridUnitMm,
+      params.cellMask
+    );
+    if (dim.overhang.feet && hasOverhang(dim.overhang)) {
+      const feet = buildOverhangFeet(
+        params.width,
+        params.depth,
+        dim.overhang,
+        params.gridUnitMm,
+        true
       );
-      // Optional grid-aligned feet under the overhang region (flat bottom otherwise).
-      if (dim.overhang.feet && hasOverhang(dim.overhang)) {
-        const feet = buildOverhangFeet(
-          params.width,
-          params.depth,
-          dim.overhang,
-          params.gridUnitMm,
-          true
-        );
-        if (feet) {
-          base = scope.register(unwrap(fuse(base, scope.register(feet))));
-        }
+      if (feet) {
+        const withFeet = unwrap(fuse(socket, feet));
+        socket.delete();
+        feet.delete();
+        socket = withFeet;
       }
-      collectOrigins(base, FeatureTag.SOCKET, originToTag);
+    }
+    collectOrigins(socket, FeatureTag.SOCKET, originToTag);
 
-      checkCancelled(signal);
-      onProgress?.('features', 0.4);
-      if (dim.hasLip) {
-        try {
-          // buildTopShape returns a cache-owned clone — register it so
-          // the scope disposes that intermediate after translate produces
-          // the positioned copy.
-          const lipBase = scope.register(
-            buildTopShape(
-              params.width,
-              params.depth,
-              true,
-              params.gridUnitMm,
-              params.cellMask,
-              dim.overhang
-            )
-          );
-          const top = scope.register(translate(lipBase, [0, 0, dim.wallHeight - LIP_OVERLAP]));
-          collectOrigins(top, FeatureTag.LIP, originToTag);
-          const baseAndBody = scope.register(unwrap(fuse(base, binBody)));
-          return unwrap(
-            fuse(
-              baseAndBody,
-              top /* no commonFace: box (3.75mm corners) and socket/lip profiles differ */
-            )
-          );
-        } catch (e: unknown) {
-          if (isAbortError(e)) throw e;
-          return unwrap(fuse(base, binBody));
-        }
-      }
+    if (forExport) {
+      // Watertight: fuse the socket into the body for a single solid.
+      const full = unwrap(fuse(body, socket));
+      body.delete();
+      socket.delete();
+      return { ...ctx, solid: full, deferredSolid: null };
+    }
 
-      return unwrap(fuse(base, binBody));
-    });
-
-    setShellCache(dim.shellKey, bin);
-
-    // Mirror the cache-hit path: a zero-vector translate is the cheapest
-    // brepjs op that preserves face-origin metadata through a copy. Plain
-    // `clone()` would drop the WeakMap and break multi-color on first render.
-    return { ...ctx, solid: translate(bin, [0, 0, 0]) };
+    // Preview: defer the socket fuse — tessellate stage meshes + concatenates.
+    return { ...ctx, solid: body, deferredSolid: socket };
   },
 };

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -11,7 +11,7 @@
  */
 
 import { unwrap, fuse, translate, withScope } from 'brepjs';
-import type { DisposalScope } from 'brepjs';
+import type { DisposalScope, Shape3D } from 'brepjs';
 import type { PipelineContext, PipelineStage } from '../types';
 import { checkCancelled, isAbortError } from '../../utils/abort';
 import { buildBaseSocket, buildOverhangFeet } from '../../socketBuilder';
@@ -130,32 +130,39 @@ export const shellStage: PipelineStage = {
       params.gridUnitMm,
       params.cellMask
     );
-    if (dim.overhang.feet && hasOverhang(dim.overhang)) {
-      const feet = buildOverhangFeet(
-        params.width,
-        params.depth,
-        dim.overhang,
-        params.gridUnitMm,
-        true
-      );
-      if (feet) {
-        const withFeet = unwrap(fuse(socket, feet));
-        socket.delete();
-        feet.delete();
-        socket = withFeet;
+    // `withScope` can't wrap this section (it must yield TWO survivors — body
+    // and socket — on the preview path), so dispose manually on any throw to
+    // match the exception-safety the scoped code had: a failed OCCT fuse must
+    // not leak the body/socket/feet WASM handles.
+    let feet: Shape3D | null = null;
+    try {
+      if (dim.overhang.feet && hasOverhang(dim.overhang)) {
+        feet = buildOverhangFeet(params.width, params.depth, dim.overhang, params.gridUnitMm, true);
+        if (feet) {
+          const withFeet = unwrap(fuse(socket, feet));
+          socket.delete();
+          feet.delete();
+          feet = null;
+          socket = withFeet;
+        }
       }
-    }
-    collectOrigins(socket, FeatureTag.SOCKET, originToTag);
+      collectOrigins(socket, FeatureTag.SOCKET, originToTag);
 
-    if (forExport) {
-      // Watertight: fuse the socket into the body for a single solid.
-      const full = unwrap(fuse(body, socket));
-      body.delete();
+      if (forExport) {
+        // Watertight: fuse the socket into the body for a single solid.
+        const full = unwrap(fuse(body, socket));
+        body.delete();
+        socket.delete();
+        return { ...ctx, solid: full, deferredSolid: null };
+      }
+
+      // Preview: defer the socket fuse — tessellate stage meshes + concatenates.
+      return { ...ctx, solid: body, deferredSolid: socket };
+    } catch (e: unknown) {
       socket.delete();
-      return { ...ctx, solid: full, deferredSolid: null };
+      body.delete();
+      feet?.delete();
+      throw e;
     }
-
-    // Preview: defer the socket fuse — tessellate stage meshes + concatenates.
-    return { ...ctx, solid: body, deferredSolid: socket };
   },
 };

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -21,7 +21,12 @@ import {
   buildCompartmentCavityDrawings,
   buildCompartmentsCacheKey,
 } from '../../compartmentBuilder';
-import { getShellCache, setShellCache } from '../../shapeCache';
+import {
+  getShellCache,
+  setShellCache,
+  getExportShellCache,
+  setExportShellCache,
+} from '../../shapeCache';
 import { LIP_OVERLAP } from '../../generatorConstants';
 import { FeatureTag } from '../../featureTags';
 import { collectOrigins } from '../collectOrigins';
@@ -36,6 +41,15 @@ export const shellStage: PipelineStage = {
 
   execute(ctx: PipelineContext): PipelineContext {
     const { params, dimensions: dim, signal, onProgress, originToTag, forExport } = ctx;
+
+    // Export fast path: the fused body+socket shell was built by a previous
+    // export or the idle warm — skip building/fusing entirely.
+    if (forExport && !dim.isFlat) {
+      const cachedExport = getExportShellCache(dim.shellKey);
+      if (cachedExport) {
+        return { ...ctx, solid: cachedExport, deferredSolid: null };
+      }
+    }
 
     // ── BODY (box + optional lip) — cached by shellKey. ──────────────────────
     // `getShellCache` returns a metadata-preserving clone so BASE/LIP face-origin
@@ -149,11 +163,13 @@ export const shellStage: PipelineStage = {
       collectOrigins(socket, FeatureTag.SOCKET, originToTag);
 
       if (forExport) {
-        // Watertight: fuse the socket into the body for a single solid.
+        // Watertight: fuse the socket into the body for a single solid, and
+        // cache it so re-exports and the idle warm skip this fuse next time.
         const full = unwrap(fuse(body, socket));
         body.delete();
         socket.delete();
-        return { ...ctx, solid: full, deferredSolid: null };
+        setExportShellCache(dim.shellKey, full);
+        return { ...ctx, solid: translate(full, [0, 0, 0]), deferredSolid: null };
       }
 
       // Preview: defer the socket fuse — tessellate stage meshes + concatenates.

--- a/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
@@ -10,16 +10,9 @@
 
 import { mesh, meshEdges } from 'brepjs';
 import type { PipelineContext, PipelineStage } from '../types';
-import { toIndexedMeshData, mergeShapeMeshes } from '../../utils/mesh';
+import { toIndexedMeshData, mergeShapeMeshes, concatFloat32 } from '../../utils/mesh';
 import { computeTessellationTolerances } from '../../utils/tolerances';
 import { setLastSolid } from '../../shapeCache';
-
-function concatFloat32(a: ArrayLike<number>, b: ArrayLike<number>): Float32Array {
-  const out = new Float32Array(a.length + b.length);
-  out.set(a, 0);
-  out.set(b, a.length);
-  return out;
-}
 
 export const tessellateStage: PipelineStage = {
   name: 'merge',

--- a/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
@@ -10,9 +10,16 @@
 
 import { mesh, meshEdges } from 'brepjs';
 import type { PipelineContext, PipelineStage } from '../types';
-import { toIndexedMeshData } from '../../utils/mesh';
+import { toIndexedMeshData, mergeShapeMeshes } from '../../utils/mesh';
 import { computeTessellationTolerances } from '../../utils/tolerances';
 import { setLastSolid } from '../../shapeCache';
+
+function concatFloat32(a: ArrayLike<number>, b: ArrayLike<number>): Float32Array {
+  const out = new Float32Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}
 
 export const tessellateStage: PipelineStage = {
   name: 'merge',
@@ -34,13 +41,28 @@ export const tessellateStage: PipelineStage = {
       dim.maxDimension
     );
 
-    const shapeMesh = mesh(solid, { tolerance, angularTolerance });
-    const edgeMesh = meshEdges(solid, {
+    const edgeAngular = angularTolerance * 0.5;
+    let shapeMesh = mesh(solid, { tolerance, angularTolerance });
+    let edgeLines: ArrayLike<number> = meshEdges(solid, {
       tolerance,
-      angularTolerance: angularTolerance * 0.5,
-    });
+      angularTolerance: edgeAngular,
+    }).lines;
+
+    // Preview path: the base socket is kept out of `solid` to skip the
+    // expensive socket↔body fuse. Tessellate it separately and concatenate —
+    // the socket is never feature-cut and only meets the body at a hidden
+    // interface, so the merged mesh is visually identical to the fused shell.
+    const { deferredSolid } = ctx;
+    if (deferredSolid) {
+      const socketMesh = mesh(deferredSolid, { tolerance, angularTolerance });
+      shapeMesh = mergeShapeMeshes(shapeMesh, socketMesh);
+      const socketEdges = meshEdges(deferredSolid, { tolerance, angularTolerance: edgeAngular });
+      edgeLines = concatFloat32(edgeLines, socketEdges.lines);
+      deferredSolid.delete();
+    }
+
     ctx.onProgress?.('merge', 1.0);
-    const meshData = toIndexedMeshData(shapeMesh, edgeMesh.lines, ctx.originToTag);
-    return { ...ctx, mesh: meshData, coarseMesh: null, solid: null };
+    const meshData = toIndexedMeshData(shapeMesh, edgeLines, ctx.originToTag);
+    return { ...ctx, mesh: meshData, coarseMesh: null, solid: null, deferredSolid: null };
   },
 };

--- a/src/features/generation/worker/generators/pipeline/stages/translateStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/translateStage.ts
@@ -20,9 +20,15 @@ export const translateStage: PipelineStage = {
 
   execute(ctx: PipelineContext): PipelineContext {
     if (!ctx.solid) return ctx;
-    const oldSolid = ctx.solid;
     const newSolid = translate(ctx.solid, [0, 0, SOCKET_HEIGHT]);
-    oldSolid.delete();
-    return { ...ctx, solid: newSolid };
+    ctx.solid.delete();
+    // Shift the deferred socket (preview path) by the same offset so it stays
+    // aligned with the body.
+    let newDeferred = ctx.deferredSolid;
+    if (ctx.deferredSolid) {
+      newDeferred = translate(ctx.deferredSolid, [0, 0, SOCKET_HEIGHT]);
+      ctx.deferredSolid.delete();
+    }
+    return { ...ctx, solid: newSolid, deferredSolid: newDeferred };
   },
 };

--- a/src/features/generation/worker/generators/pipeline/types.ts
+++ b/src/features/generation/worker/generators/pipeline/types.ts
@@ -69,6 +69,16 @@ export interface PipelineContext {
   readonly onProgress?: ProgressFn;
   /** Current bin solid — updated by each stage */
   readonly solid: Shape3D | null;
+  /**
+   * Deferred additive solid (the base socket) kept OUT of `solid` on the
+   * preview path so features cut only the body and the expensive socket↔body
+   * fuse is skipped. Tessellated alongside `solid` and merged into one mesh
+   * (the socket is never cut by features and only meets the body at a hidden
+   * internal interface, so the rendered result is identical to the fused
+   * shell). Null on the export path, where the socket is fused into `solid`
+   * for a watertight model.
+   */
+  readonly deferredSolid: Shape3D | null;
   /** Face provenance tracking — intentionally mutable (passed by reference) */
   readonly originToTag: Map<number, number>;
   /** Additive feature shapes to fuse into the bin */

--- a/src/features/generation/worker/generators/shapeCache.ts
+++ b/src/features/generation/worker/generators/shapeCache.ts
@@ -59,6 +59,10 @@ const socketCache = new LRUCache<Shape3D>('socket', 20, disposeShape);
 const lipCache = new LRUCache<Shape3D>('lip', 20, disposeShape);
 const boxCache = new LRUCache<Shape3D>('box', 20, disposeShape);
 const shellCache = new LRUCache<Shape3D>('shell', 15, disposeShape);
+// Fused full shell (body + base socket) at export quality. Populated lazily on
+// export and proactively by the idle warm, so exports skip the socket↔body fuse
+// that the preview path defers. Keyed by the same shellKey as the body.
+const exportShellCache = new LRUCache<Shape3D>('exportShell', 8, disposeShape);
 
 const socket = createCloningAccessors(socketCache);
 const box = createCloningAccessors(boxCache);
@@ -90,8 +94,14 @@ function getOrCreateFeatureCache(name: string): LRUCache<Shape3D> {
   return cache;
 }
 
-/** Static LRU caches (socket, lip, box, shell). */
-const staticLruCaches: readonly LRUCache<Shape3D>[] = [socketCache, lipCache, boxCache, shellCache];
+/** Static LRU caches (socket, lip, box, shell, exportShell). */
+const staticLruCaches: readonly LRUCache<Shape3D>[] = [
+  socketCache,
+  lipCache,
+  boxCache,
+  shellCache,
+  exportShellCache,
+];
 
 export function socketCacheKey(
   gridW: number,
@@ -144,6 +154,21 @@ export function getShellCache(key: string): Shape3D | null {
 
 export function setShellCache(key: string, shape: Shape3D): void {
   shellCache.set(key, shape);
+}
+
+/** Fused export-quality shell (body + socket). Metadata-preserving clone on hit. */
+export function getExportShellCache(key: string): Shape3D | null {
+  const cached = exportShellCache.get(key);
+  if (cached === undefined) return null;
+  return translate(cached, [0, 0, 0]);
+}
+
+export function setExportShellCache(key: string, shape: Shape3D): void {
+  exportShellCache.set(key, shape);
+}
+
+export function hasExportShellCache(key: string): boolean {
+  return exportShellCache.get(key) !== undefined;
 }
 
 /** Returns raw shape (no clone) — caller uses transformCopy which is non-destructive. */

--- a/src/features/generation/worker/generators/utils/mesh.test.ts
+++ b/src/features/generation/worker/generators/utils/mesh.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { mergeShapeMeshes } from './mesh';
+
+interface ShapeMesh {
+  vertices: Float32Array;
+  normals: Float32Array;
+  uvs: Float32Array;
+  triangles: Uint32Array;
+  faceGroups: { start: number; count: number; faceId: number; origin: number }[];
+}
+
+/** One triangle with `vc` vertices. */
+function tri(vc: number, origin: number): ShapeMesh {
+  return {
+    vertices: new Float32Array(vc * 3).fill(1),
+    normals: new Float32Array(vc * 3).fill(0),
+    uvs: new Float32Array(vc * 2).fill(0.5),
+    triangles: new Uint32Array(Array.from({ length: vc }, (_, i) => i)),
+    faceGroups: [{ start: 0, count: vc, faceId: 0, origin }],
+  };
+}
+
+describe('mergeShapeMeshes', () => {
+  it('concatenates vertices/normals/uvs and shifts socket triangle indices', () => {
+    const body = tri(3, 1); // 3 verts, indices [0,1,2]
+    const socket = tri(3, 3); // 3 verts, indices [0,1,2]
+    const merged = mergeShapeMeshes(body, socket);
+
+    expect(merged.vertices.length).toBe(18); // (3+3) verts * 3
+    expect(merged.uvs.length).toBe(12); // (3+3) verts * 2
+    // socket indices shifted past the body's 3 vertices
+    expect([...merged.triangles]).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  it('offsets socket face-group starts past the body index range and preserves origins', () => {
+    const body = tri(3, 1);
+    const socket = tri(3, 3);
+    const merged = mergeShapeMeshes(body, socket);
+
+    expect(merged.faceGroups).toHaveLength(2);
+    expect(merged.faceGroups[0]).toMatchObject({ start: 0, origin: 1 });
+    // socket group starts after the body's 3 indices
+    expect(merged.faceGroups[1]).toMatchObject({ start: 3, origin: 3 });
+  });
+});

--- a/src/features/generation/worker/generators/utils/mesh.ts
+++ b/src/features/generation/worker/generators/utils/mesh.ts
@@ -1,5 +1,53 @@
 import type { MeshData } from '../../../bridge/types';
 
+interface FaceGroup {
+  start: number;
+  count: number;
+  faceId: number;
+  origin: number;
+}
+interface ShapeMesh {
+  vertices: Float32Array;
+  normals: Float32Array;
+  uvs: Float32Array;
+  triangles: Uint32Array;
+  faceGroups: FaceGroup[];
+}
+
+function concatFloat32(a: Float32Array, b: Float32Array): Float32Array {
+  const out = new Float32Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}
+
+/**
+ * Concatenate two tessellations into one. Used to render the deferred base
+ * socket alongside the bin body without a boolean fuse: the socket's triangle
+ * indices are shifted past the body's vertices, and its face groups past the
+ * body's index range, so the merged mesh draws (and colors) identically to a
+ * fused shell. `faceGroups.start`/`count` index the triangle (index) array.
+ */
+export function mergeShapeMeshes(body: ShapeMesh, socket: ShapeMesh): ShapeMesh {
+  const bodyVertexCount = body.vertices.length / 3;
+  const bodyIndexCount = body.triangles.length;
+  const triangles = new Uint32Array(bodyIndexCount + socket.triangles.length);
+  triangles.set(body.triangles, 0);
+  for (let i = 0; i < socket.triangles.length; i++) {
+    triangles[bodyIndexCount + i] = socket.triangles[i] + bodyVertexCount;
+  }
+  return {
+    vertices: concatFloat32(body.vertices, socket.vertices),
+    normals: concatFloat32(body.normals, socket.normals),
+    uvs: concatFloat32(body.uvs, socket.uvs),
+    triangles,
+    faceGroups: [
+      ...body.faceGroups,
+      ...socket.faceGroups.map((g) => ({ ...g, start: g.start + bodyIndexCount })),
+    ],
+  };
+}
+
 /**
  * Convert brepjs indexed mesh to our MeshData format. Each face group's
  * `origin` is the FeatureTag stamped by `collectOrigins`/`setShapeOrigin` and

--- a/src/features/generation/worker/generators/utils/mesh.ts
+++ b/src/features/generation/worker/generators/utils/mesh.ts
@@ -14,7 +14,7 @@ interface ShapeMesh {
   faceGroups: FaceGroup[];
 }
 
-function concatFloat32(a: Float32Array, b: Float32Array): Float32Array {
+export function concatFloat32(a: ArrayLike<number>, b: ArrayLike<number>): Float32Array {
   const out = new Float32Array(a.length + b.length);
   out.set(a, 0);
   out.set(b, a.length);

--- a/src/features/generation/worker/handlers/generateHandler.ts
+++ b/src/features/generation/worker/handlers/generateHandler.ts
@@ -5,6 +5,7 @@
 import type {
   GenerateMessage,
   GenerateBaseplateMessage,
+  WarmMessage,
   LidMeshData,
   MeshData,
 } from '../../bridge/types';
@@ -12,7 +13,18 @@ import { generateBin } from '../generators/binGenerator';
 import { generateBaseplate } from '../generators/baseplateGenerator';
 import { generateLid } from '../generators/lidOrchestrator';
 import { isAbortError } from '../generators/utils/abort';
-import { runGeneration, reportProgress, getActiveRequestId } from './workerContext';
+import { runGeneration, runWarm, reportProgress, getActiveRequestId } from './workerContext';
+
+/**
+ * Speculative idle warm: build the export-quality (fused) shell so the next
+ * export skips the deferred socket↔body fuse. Best-effort, no mesh returned.
+ */
+export function handleWarm(message: WarmMessage): void {
+  const { params, requestId } = message.payload;
+  runWarm(requestId, (signal) => {
+    generateBin(params, undefined, true, signal);
+  });
+}
 
 export function handleGenerate(message: GenerateMessage): void {
   const { params, requestId } = message.payload;

--- a/src/features/generation/worker/handlers/workerContext.ts
+++ b/src/features/generation/worker/handlers/workerContext.ts
@@ -215,6 +215,31 @@ export function runGeneration(
 }
 
 /**
+ * Speculative export-shell warm. Runs an export-quality generation (which
+ * populates the export-shell cache + lastSolid) so a subsequent export skips
+ * the deferred socket↔body fuse. Best-effort: abort or any failure is swallowed
+ * (a warm must never surface an error), and no mesh is transferred back.
+ */
+export function runWarm(requestId: string, generator: (signal: AbortSignal) => void): void {
+  if (!requireKernel(requestId)) return;
+  activeRequestId = requestId;
+  activeController = new AbortController();
+  try {
+    generator(activeController.signal);
+  } catch (e) {
+    if (!isAbortError(e)) {
+      console.warn('[Warm] export warm failed (non-fatal):', formatError(e));
+    }
+  } finally {
+    if (activeRequestId === requestId) {
+      activeRequestId = null;
+      activeController = null;
+    }
+    respond({ type: 'WARM_DONE', requestId });
+  }
+}
+
+/**
  * Classify an export-side error by inspecting its message.
  *
  * Codes feed the main-thread resilience wrapper (see `exportWithResilience`):


### PR DESCRIPTION
## What

The base-socket → body boolean fuse is the dominant cost of cold bin generation — **~1.8 s of a ~2.1 s 6×6 shell (≈80%)**. This defers it.

The base socket (the grid of feet) is **never cut by features** (compartments/cutouts carve walls + floor, not feet) and only meets the body at a **hidden internal interface**. So on the **preview** path the socket is now kept out of `ctx.solid` (new `ctx.deferredSolid`); the tessellate stage meshes the body and socket separately and concatenates them (`mergeShapeMeshes`) — visually identical, no boolean. The **export** path still fuses for a watertight model.

## Impact

Cold `base` stage on a 6×6 socket bin: **~2119 ms → ~776 ms (2.7×)**. Composes with the Manifold draft preview (draft instant → exact sharpen ~2.7× sooner).

## Correctness (validated)

- **Export geometry byte-identical** — measured volume 373549 before and after (stash A/B); all `forExport=true` scenarios pass unchanged.
- **Preview socket present + aligned** — z-bounds match export exactly; `translateStage` shifts the deferred socket with the body.
- **Full unit suite green** (12809 tests). 109 preview scenario snapshots shifted by ±4–12 triangles (the socket↔body junction is no longer booleaned) — updated; export snapshots untouched.
- **Visual check** (Playwright) — bin renders cleanly with no artifacts.
- Unit test added for `mergeShapeMeshes`.

## How it was found

Per-stage benchmarking isolated the fuse as the bottleneck; OBB acceleration (kernel rebuild) and OCCT glue both proved inert/unsafe for this axis-aligned geometry. Deferring the fuse for preview was the lever that actually moved it.