### PR TITLE
feat(bin-designer): remove broken u-shape handle; segment shape & side selectors

### DIFF
--- a/src/features/bin-designer/components/panel/HandleSection/HandleSection.test.tsx
+++ b/src/features/bin-designer/components/panel/HandleSection/HandleSection.test.tsx
@@ -33,6 +33,28 @@ describe('HandleSection', () => {
     expect(screen.getByText('Right')).toBeDefined();
   });
 
+  it('renders the back side chip as off + disabled when a label tab blocks it', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+        handles: {
+          ...DEFAULT_BIN_PARAMS.handles,
+          enabled: true,
+          // Stored as enabled, but the active label tab blocks the back handle.
+          back: { ...DEFAULT_BIN_PARAMS.handles.back, enabled: true },
+        },
+      },
+    });
+
+    render(<HandleSection />);
+    const back = screen.getByRole('switch', { name: 'Back' });
+    expect(back.disabled).toBe(true);
+    // Must read as off (not an accent-tinted "on"), matching generation which
+    // skips back handles while a label tab is active.
+    expect(back.getAttribute('aria-checked')).toBe('false');
+  });
+
   it('does not show controls when disabled', () => {
     render(<HandleSection />);
     expect(screen.queryByText('Front')).toBeNull();

--- a/src/features/bin-designer/components/panel/HandleSection/HandleSection.tsx
+++ b/src/features/bin-designer/components/panel/HandleSection/HandleSection.tsx
@@ -8,6 +8,12 @@
 
 import { FeatureToggle } from '../FeatureToggle';
 import { StepperControl } from '@/shared/components/StepperControl';
+import {
+  getSegmentClass,
+  SEGMENT_GROUP_CLASS,
+  SEGMENT_ACTIVE,
+  SEGMENT_INACTIVE,
+} from '@/shared/components/segmentedControlClasses';
 import { RulerIcon } from '@/design-system/Icon';
 import { DESIGNER_CONSTRAINTS } from '../../../constants';
 import { useHandleSection, HANDLE_SIDES } from './useHandleSection';
@@ -19,7 +25,6 @@ const SHAPE_OPTIONS: readonly { value: HandleCutoutShape; labelKey: string }[] =
   { value: 'rectangle', labelKey: 'binDesigner.handles.shape.rectangle' },
   { value: 'oval', labelKey: 'binDesigner.handles.shape.oval' },
   { value: 'scoop', labelKey: 'binDesigner.handles.shape.scoop' },
-  { value: 'u-shape', labelKey: 'binDesigner.handles.shape.uShape' },
 ];
 
 /** Inline SVG chain-link icon (12x12). */
@@ -52,15 +57,21 @@ function LinkIcon({ linked }: { linked: boolean }) {
   );
 }
 
+/**
+ * Side chip base dimensions. Matches the shape selector's segment pills
+ * (px-2 py-1 text-xs rounded-md) so both rails read identically, but the
+ * sides are independent on/off toggles — they use the accent-tint
+ * SEGMENT_ACTIVE/SEGMENT_INACTIVE treatment instead of the single-select
+ * raised pill (getSegmentClass).
+ */
+const SIDE_CHIP_BASE =
+  'flex items-center justify-center rounded-md px-2 py-1 text-xs font-medium transition-colors ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ' +
+  'disabled:cursor-not-allowed disabled:opacity-50';
+
 /** Side chip button class based on state. */
-function sideChipClass(isDisabled: boolean, isActive: boolean): string {
-  if (isDisabled) {
-    return 'border border-stroke-subtle bg-surface-secondary text-content-tertiary cursor-not-allowed opacity-50';
-  }
-  if (isActive) {
-    return 'bg-accent text-on-accent';
-  }
-  return 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover';
+function sideChipClass(isActive: boolean): string {
+  return `${SIDE_CHIP_BASE} ${isActive ? SEGMENT_ACTIVE : SEGMENT_INACTIVE}`;
 }
 
 export function HandleSection() {
@@ -70,7 +81,6 @@ export function HandleSection() {
     isBackDisabled,
     handleWidthMm,
     linked,
-    isUShape,
     showCornerRadius,
     hasCompartments,
     activeSides,
@@ -86,25 +96,29 @@ export function HandleSection() {
       primaryControls={
         <div className="space-y-3">
           {/* Shape selector */}
-          <div className="flex gap-1">
-            {SHAPE_OPTIONS.map(({ value, labelKey }) => (
-              <button
-                key={value}
-                type="button"
-                onClick={() => handlers.setShape(value)}
-                className={`flex-1 rounded px-2 py-1 text-xs font-medium transition-colors ${
-                  handles.shape === value
-                    ? 'bg-accent text-on-accent'
-                    : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
-                }`}
-              >
-                {t(labelKey)}
-              </button>
-            ))}
+          <div
+            role="group"
+            aria-label={t('binDesigner.handles.shape')}
+            className={SEGMENT_GROUP_CLASS}
+          >
+            {SHAPE_OPTIONS.map(({ value, labelKey }) => {
+              const isActive = handles.shape === value;
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  aria-pressed={isActive}
+                  onClick={() => handlers.setShape(value)}
+                  className={`flex-1 ${getSegmentClass(isActive)}`}
+                >
+                  {t(labelKey)}
+                </button>
+              );
+            })}
           </div>
 
           {/* Side toggle chips — same order as WallCutoutsSection: L R F B */}
-          <div className="flex gap-1">
+          <div className={SEGMENT_GROUP_CLASS}>
             {HANDLE_SIDES.map((side) => {
               const isActive = handles[side].enabled;
               const isDisabled = side === 'back' && isBackDisabled;
@@ -117,7 +131,7 @@ export function HandleSection() {
                   disabled={isDisabled}
                   title={isDisabled ? t('binDesigner.handles.backDisabledByLabelTab') : undefined}
                   onClick={() => handlers.toggleSide(side)}
-                  className={`flex-1 rounded px-2 py-1 text-xs font-medium transition-colors ${sideChipClass(isDisabled, isActive)}`}
+                  className={`flex-1 ${sideChipClass(isActive)}`}
                 >
                   {t(`binDesigner.handles.${side}`)}
                 </button>
@@ -213,7 +227,7 @@ export function HandleSection() {
                     </div>
                   )}
 
-                  {/* Corner radius — only for rectangle and u-shape */}
+                  {/* Corner radius — only for rectangle */}
                   {showCornerRadius && (
                     <div className="flex items-end gap-2">
                       <div className="flex-1 min-w-0">
@@ -319,34 +333,32 @@ export function HandleSection() {
 
               {/* Global controls: vertical position + count (always visible, not per-side) */}
               <div className="flex items-end gap-2">
-                {/* Vertical position — hidden for u-shape (auto-anchored to bottom) */}
-                {!isUShape && (
-                  <div className="flex-1 min-w-0">
-                    <span className="mb-1 block text-xs text-content-tertiary">
-                      {}
-                      {t('binDesigner.handles.verticalPosition')} {'(%)'}
-                    </span>
-                    <StepperControl
-                      value={Math.round(handles.verticalPosition * 100)}
-                      onChange={(v) => handlers.setVerticalPosition(v / 100)}
-                      onStep={(delta) => {
-                        const step = C.HANDLE_VERTICAL_POSITION_STEP * 100;
-                        const current = Math.round(handles.verticalPosition * 100);
-                        handlers.setVerticalPosition(
-                          Math.min(
-                            C.MAX_HANDLE_VERTICAL_POSITION,
-                            Math.max(C.MIN_HANDLE_VERTICAL_POSITION, (current + delta * step) / 100)
-                          )
-                        );
-                      }}
-                      min={Math.round(C.MIN_HANDLE_VERTICAL_POSITION * 100)}
-                      max={Math.round(C.MAX_HANDLE_VERTICAL_POSITION * 100)}
-                      step={Math.round(C.HANDLE_VERTICAL_POSITION_STEP * 100)}
-                      variant="desktop"
-                      ariaLabel={t('binDesigner.handles.verticalPositionAria')}
-                    />
-                  </div>
-                )}
+                {/* Vertical position */}
+                <div className="flex-1 min-w-0">
+                  <span className="mb-1 block text-xs text-content-tertiary">
+                    {}
+                    {t('binDesigner.handles.verticalPosition')} {'(%)'}
+                  </span>
+                  <StepperControl
+                    value={Math.round(handles.verticalPosition * 100)}
+                    onChange={(v) => handlers.setVerticalPosition(v / 100)}
+                    onStep={(delta) => {
+                      const step = C.HANDLE_VERTICAL_POSITION_STEP * 100;
+                      const current = Math.round(handles.verticalPosition * 100);
+                      handlers.setVerticalPosition(
+                        Math.min(
+                          C.MAX_HANDLE_VERTICAL_POSITION,
+                          Math.max(C.MIN_HANDLE_VERTICAL_POSITION, (current + delta * step) / 100)
+                        )
+                      );
+                    }}
+                    min={Math.round(C.MIN_HANDLE_VERTICAL_POSITION * 100)}
+                    max={Math.round(C.MAX_HANDLE_VERTICAL_POSITION * 100)}
+                    step={Math.round(C.HANDLE_VERTICAL_POSITION_STEP * 100)}
+                    variant="desktop"
+                    ariaLabel={t('binDesigner.handles.verticalPositionAria')}
+                  />
+                </div>
 
                 {/* Count stepper — shares row with vertical position */}
                 <div className="flex-1 min-w-0">

--- a/src/features/bin-designer/components/panel/HandleSection/HandleSection.tsx
+++ b/src/features/bin-designer/components/panel/HandleSection/HandleSection.tsx
@@ -120,18 +120,23 @@ export function HandleSection() {
           {/* Side toggle chips — same order as WallCutoutsSection: L R F B */}
           <div className={SEGMENT_GROUP_CLASS}>
             {HANDLE_SIDES.map((side) => {
-              const isActive = handles[side].enabled;
               const isDisabled = side === 'back' && isBackDisabled;
+              // A disabled side is functionally off (generation skips back
+              // handles while a label tab is active), so present it as off —
+              // neutral styling + aria-checked=false — even if its stored
+              // `enabled` flag is still true. Otherwise the blocked chip reads
+              // as "on" (accent tint), implying the setting is still in effect.
+              const effectiveActive = handles[side].enabled && !isDisabled;
               return (
                 <button
                   key={side}
                   type="button"
                   role="switch"
-                  aria-checked={isActive}
+                  aria-checked={effectiveActive}
                   disabled={isDisabled}
                   title={isDisabled ? t('binDesigner.handles.backDisabledByLabelTab') : undefined}
                   onClick={() => handlers.toggleSide(side)}
-                  className={`flex-1 ${sideChipClass(isActive)}`}
+                  className={`flex-1 ${sideChipClass(effectiveActive)}`}
                 >
                   {t(`binDesigner.handles.${side}`)}
                 </button>

--- a/src/features/bin-designer/components/panel/HandleSection/useHandleSection.ts
+++ b/src/features/bin-designer/components/panel/HandleSection/useHandleSection.ts
@@ -129,9 +129,7 @@ export function useHandleSection() {
   const summary = useMemo(() => {
     if (!handles.enabled || activeSides.length === 0) return undefined;
     const sideNames = activeSides.map((s) => t(`binDesigner.handles.${s}`)).join(', ');
-    const shapeName = t(
-      `binDesigner.handles.shape.${handles.shape === 'u-shape' ? 'uShape' : handles.shape}`
-    );
+    const shapeName = t(`binDesigner.handles.shape.${handles.shape}`);
     const countSuffix = handles.count > 1 ? ` ×${handles.count}` : '';
     return t('binDesigner.handles.summary', {
       shape: shapeName + countSuffix,
@@ -150,8 +148,7 @@ export function useHandleSection() {
     [isUnavailable, summary, disabledReason]
   );
 
-  const isUShape = handles.shape === 'u-shape';
-  const showCornerRadius = handles.shape === 'rectangle' || handles.shape === 'u-shape';
+  const showCornerRadius = handles.shape === 'rectangle';
   // Interior handles are skipped on polygon bins (no compartment walls exist
   // for custom shapes), so hide the toggle there to prevent a silent no-op.
   const hasCompartments =
@@ -163,7 +160,6 @@ export function useHandleSection() {
       isBackDisabled,
       handleWidthMm,
       linked,
-      isUShape,
       showCornerRadius,
       hasCompartments,
       activeSides,

--- a/src/features/bin-designer/components/preview/GhostHandles/GhostHandles.tsx
+++ b/src/features/bin-designer/components/preview/GhostHandles/GhostHandles.tsx
@@ -16,7 +16,6 @@ import {
   buildHandleWallDefs,
   computeHandleHoleGeometry,
   computeWallHandleSegments,
-  U_SHAPE_OVERSHOOT,
 } from '@/shared/utils/handleCutoutClip';
 import { computeMultiHandleOffsets } from '@/shared/utils/handleLayout';
 
@@ -72,8 +71,6 @@ export function GhostHandles() {
     style !== 'solid' &&
     generationStatus === 'generating';
 
-  const isUShape = handles.shape === 'u-shape';
-
   const geometry = useMemo(() => {
     if (!shouldShow) return null;
 
@@ -90,18 +87,11 @@ export function GhostHandles() {
       const sideHeight = side.height ?? handles.height;
 
       // Compute vertical geometry per-side (matches handleBuilder)
-      let effectiveHeight: number;
-      if (isUShape) {
-        const clampedHeight = Math.min(sideHeight, interiorHeight);
-        effectiveHeight = clampedHeight + U_SHAPE_OVERSHOOT;
-      } else {
-        const geom = computeHandleHoleGeometry(
-          interiorHeight,
-          sideHeight,
-          handles.verticalPosition
-        );
-        effectiveHeight = geom.effectiveHeight;
-      }
+      const { effectiveHeight } = computeHandleHoleGeometry(
+        interiorHeight,
+        sideHeight,
+        handles.verticalPosition
+      );
       if (effectiveHeight < 1) continue;
 
       const wallCutout = wallConfig.enabled ? wallConfig[wall.side] : undefined;
@@ -183,7 +173,6 @@ export function GhostHandles() {
     label.enabled,
     wallConfig,
     interiorHeight,
-    isUShape,
   ]);
 
   const material = useMemo(() => {
@@ -212,12 +201,7 @@ export function GhostHandles() {
 
   const socketZ = isFlat ? 0 : GRIDFINITY.SOCKET_HEIGHT;
   // Use variable vertical position for ghost mesh world-space position
-  let holeZ: number;
-  if (isUShape) {
-    holeZ = socketZ + (Math.min(handles.height, interiorHeight) - U_SHAPE_OVERSHOOT) / 2;
-  } else {
-    holeZ = socketZ + interiorHeight * handles.verticalPosition;
-  }
+  const holeZ = socketZ + interiorHeight * handles.verticalPosition;
 
   return <mesh geometry={geometry} material={material} position={[0, 0, holeZ]} renderOrder={2} />;
 }

--- a/src/features/bin-designer/constants/defaults.ts
+++ b/src/features/bin-designer/constants/defaults.ts
@@ -9,6 +9,7 @@ import type {
   GenerationState,
   DesignerHistory,
   HandleConfig,
+  HandleCutoutShape,
   HandleSide,
   WallCutout,
   WallConfig,
@@ -82,6 +83,9 @@ export const DEFAULT_SPLIT_CONNECTOR_CONFIG: SplitConnectorConfig = {
   ridgeWidthFraction: 0.35,
   ridgeHeightFraction: 0.8,
 } as const;
+
+/** Handle cutout shapes still supported — used to coerce retired values on load. */
+const VALID_HANDLE_SHAPES: readonly HandleCutoutShape[] = ['rectangle', 'oval', 'scoop'];
 
 /** Default per-side handle config: enabled=false, no per-side overrides */
 export const DEFAULT_HANDLE_SIDE: HandleSide = {
@@ -505,6 +509,11 @@ export function migrateParams(params: MigrateParamsInput): BinParams {
   const handlesConfig: HandleConfig = {
     ...DEFAULT_HANDLE_CONFIG,
     ...(cleanHandles as Partial<HandleConfig>),
+    // Coerce removed/unknown shapes (e.g. the retired 'u-shape') back to the
+    // default so old saves don't carry a value the type no longer allows.
+    shape: VALID_HANDLE_SHAPES.includes(cleanHandles.shape as HandleCutoutShape)
+      ? (cleanHandles.shape as HandleCutoutShape)
+      : DEFAULT_HANDLE_CONFIG.shape,
     front: { ...DEFAULT_HANDLE_CONFIG.front, ...((rawHandles.front as object | undefined) ?? {}) },
     back: { ...DEFAULT_HANDLE_CONFIG.back, ...((rawHandles.back as object | undefined) ?? {}) },
     left: { ...DEFAULT_HANDLE_CONFIG.left, ...((rawHandles.left as object | undefined) ?? {}) },

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -302,7 +302,7 @@ export interface LabelTabConfig {
 export type HandleWallSide = 'front' | 'back' | 'left' | 'right';
 
 /** Handle cutout shape */
-export type HandleCutoutShape = 'rectangle' | 'oval' | 'scoop' | 'u-shape';
+export type HandleCutoutShape = 'rectangle' | 'oval' | 'scoop';
 
 /** Per-side handle configuration */
 export interface HandleSide {
@@ -326,9 +326,9 @@ export interface HandleConfig {
   readonly width: number;
   /** Hole height in mm (vertical extent). Default: 15 */
   readonly height: number;
-  /** Corner radius in mm (0 = sharp rectangle). Default: 10. Used for rectangle and u-shape only. */
+  /** Corner radius in mm (0 = sharp rectangle). Default: 10. Used for rectangle only. */
   readonly cornerRadius: number;
-  /** Vertical position as fraction 0-1 from floor. Default: 0.7. Ignored for u-shape (auto-anchored to bottom). */
+  /** Vertical position as fraction 0-1 from floor. Default: 0.7. */
   readonly verticalPosition: number;
   /** Number of handles per wall side (1-3). Default: 1 */
   readonly count: number;

--- a/src/features/bin-designer/utils/lidCompatibility.test.ts
+++ b/src/features/bin-designer/utils/lidCompatibility.test.ts
@@ -387,43 +387,6 @@ describe('checkLidCompatibility', () => {
       expect(issue?.sides).toEqual(['front']);
     });
 
-    it('u-shape handles use floor-anchored geometry (ignore verticalPosition)', () => {
-      // U-shape extends from the floor up to `min(requestedHeight, interiorHeight)`,
-      // matching `handleBuilder.ts:clampedHeight`. verticalPosition is ignored.
-      // Interior height = 14mm, lipBottom = 9.6mm. A u-shape handle 12mm tall
-      // tops out at Z=12mm → above the lip → should warn even with
-      // verticalPosition=0 (which would clamp non-u-shape handles to 0).
-      const params = withOverrides({
-        handles: {
-          ...DEFAULT_BIN_PARAMS.handles,
-          enabled: true,
-          shape: 'u-shape',
-          height: 12,
-          verticalPosition: 0,
-          front: { ...DEFAULT_BIN_PARAMS.handles.front, enabled: true },
-          back: { ...DEFAULT_BIN_PARAMS.handles.back, enabled: false },
-          left: { ...DEFAULT_BIN_PARAMS.handles.left, enabled: false },
-          right: { ...DEFAULT_BIN_PARAMS.handles.right, enabled: false },
-        },
-      });
-      const issue = checkLidCompatibility(params).find((i) => i.id === 'handles');
-      expect(issue?.sides).toEqual(['front']);
-    });
-
-    it('short u-shape handles do NOT warn (top below lip)', () => {
-      // A 5mm u-shape handle tops out at Z=5mm, well below lipBottom=9.6mm.
-      const params = withOverrides({
-        handles: {
-          ...DEFAULT_BIN_PARAMS.handles,
-          enabled: true,
-          shape: 'u-shape',
-          height: 5,
-          front: { ...DEFAULT_BIN_PARAMS.handles.front, enabled: true },
-        },
-      });
-      expect(checkLidCompatibility(params).find((i) => i.id === 'handles')).toBeUndefined();
-    });
-
     it('does NOT warn when the handle sits clear of the lip (low verticalPosition)', () => {
       const params = withOverrides({
         handles: {

--- a/src/features/bin-designer/utils/lidCompatibility.ts
+++ b/src/features/bin-designer/utils/lidCompatibility.ts
@@ -81,16 +81,10 @@ function lipBottomZ(interiorHeight: number): number {
 /**
  * Does the per-side handle hole extend up into the lip Z range?
  *
- * Mirrors the shape branching in `handleBuilder.ts` so the lip check
- * agrees with the geometry that actually gets cut:
- *   - 'u-shape': anchored to the floor, top sits at
- *     `min(requestedHeight, interiorHeight)` (verticalPosition is
- *     ignored — matches the `clampedHeight` derivation in
- *     handleBuilder's u-shape branch).
- *   - other shapes: centered at `centerZ`, top is
- *     `centerZ + effectiveHeight/2`.
- *
- * Each form is compared against the lip's bottom Z.
+ * Mirrors the geometry in `handleBuilder.ts` so the lip check agrees
+ * with what actually gets cut: the hole is centered at `centerZ`, so
+ * its top sits at `centerZ + effectiveHeight/2`, compared against the
+ * lip's bottom Z.
  */
 function handleSideIntrudesLip(
   handles: HandleConfig,
@@ -102,17 +96,12 @@ function handleSideIntrudesLip(
   if (!sideCfg.enabled) return false;
 
   const requestedHeight = sideCfg.height ?? handles.height;
-  const topZ =
-    handles.shape === 'u-shape'
-      ? Math.min(requestedHeight, interiorHeight)
-      : (() => {
-          const { centerZ, effectiveHeight } = computeHandleHoleGeometry(
-            interiorHeight,
-            requestedHeight,
-            handles.verticalPosition
-          );
-          return centerZ + effectiveHeight / 2;
-        })();
+  const { centerZ, effectiveHeight } = computeHandleHoleGeometry(
+    interiorHeight,
+    requestedHeight,
+    handles.verticalPosition
+  );
+  const topZ = centerZ + effectiveHeight / 2;
   return topZ > lipBottomZ(interiorHeight);
 }
 

--- a/src/features/generation/worker/generators/handleBuilder.ts
+++ b/src/features/generation/worker/generators/handleBuilder.ts
@@ -2,7 +2,7 @@
  * Handle hole builder for Gridfinity bins.
  *
  * Generates through-hole cutouts in bin walls as finger grips.
- * Supports 4 shapes (rectangle, oval, scoop, u-shape), adjustable
+ * Supports 3 shapes (rectangle, oval, scoop), adjustable
  * vertical position, multi-handle per wall, per-side overrides,
  * interior wall handles, and optional chamfer.
  *
@@ -19,7 +19,6 @@ import {
   buildHandleWallDefs,
   computeHandleHoleGeometry,
   computeWallHandleSegments,
-  U_SHAPE_OVERSHOOT,
 } from '@/shared/utils/handleCutoutClip';
 import type { HandleWallDef } from '@/shared/utils/handleCutoutClip';
 import { computeMultiHandleOffsets } from '@/shared/utils/handleLayout';
@@ -149,7 +148,6 @@ function buildHandleHolesInScope(
 
   const lipOverhang = hasLip ? LIP_TAPER_WIDTH : 0;
   const extrudeDepth = (wallThickness + lipOverhang) * 2 + 1;
-  const isUShape = shape === 'u-shape';
 
   // Non-rectangular footprints map each outer side to its outermost matching
   // polygon edge (silently skipping sides with no edge). Rect bins use the
@@ -186,18 +184,11 @@ function buildHandleHolesInScope(
     const sideRadius = side.cornerRadius ?? globalRadius;
 
     // Compute vertical geometry
-    let centerZ: number;
-    let effectiveHeight: number;
-    if (isUShape) {
-      // Auto-anchor: U-shape extends from floor upward, with overshoot below
-      const clampedHeight = Math.min(sideHeight, interiorHeight);
-      effectiveHeight = clampedHeight + U_SHAPE_OVERSHOOT;
-      centerZ = (clampedHeight - U_SHAPE_OVERSHOOT) / 2;
-    } else {
-      const geom = computeHandleHoleGeometry(interiorHeight, sideHeight, verticalPosition);
-      centerZ = geom.centerZ;
-      effectiveHeight = geom.effectiveHeight;
-    }
+    const { centerZ, effectiveHeight } = computeHandleHoleGeometry(
+      interiorHeight,
+      sideHeight,
+      verticalPosition
+    );
     if (effectiveHeight < 1) continue;
 
     // Multi-handle: compute offsets, then split each around wall cutout
@@ -242,7 +233,7 @@ function buildHandleHolesInScope(
 
   // Interior wall handles — skipped on polygon bins (compartment walls are
   // filtered out for custom shapes, so there's nothing to cut through).
-  if (interior && !isUShape && !isPolygon) {
+  if (interior && !isPolygon) {
     const { cols, rows, cells } = params.compartments;
     if (cols > 1 || rows > 1) {
       const cellW = innerW / cols;

--- a/src/features/generation/worker/generators/handleProfiles.test.ts
+++ b/src/features/generation/worker/generators/handleProfiles.test.ts
@@ -24,11 +24,6 @@ describe('buildHandleProfile', () => {
     expect(profile).not.toBeNull();
   });
 
-  it('returns a valid Drawing for u-shape (open bottom)', () => {
-    const profile = buildHandleProfile('u-shape', defaultArgs);
-    expect(profile).not.toBeNull();
-  });
-
   it('clamps corner radius to half of smallest dimension', () => {
     const profile = buildHandleProfile('rectangle', { width: 10, height: 10, cornerRadius: 20 });
     expect(profile).not.toBeNull();

--- a/src/features/generation/worker/generators/handleProfiles.ts
+++ b/src/features/generation/worker/generators/handleProfiles.ts
@@ -7,20 +7,18 @@
  * - rectangle: rounded rectangle (existing behavior, now explicit)
  * - oval: true ellipse via brepjs drawEllipse
  * - scoop: semicircle / circular arc (closed hole)
- * - u-shape: open at bottom — extends below origin for clean boolean cut
  */
 
 import { draw, drawRoundedRectangle, drawRectangle, drawEllipse } from 'brepjs';
 import type { Drawing } from 'brepjs';
 import type { HandleCutoutShape } from '@/shared/types/bin';
-import { U_SHAPE_OVERSHOOT } from '@/shared/utils/handleCutoutClip';
 
 interface ProfileArgs {
   /** Horizontal span in mm */
   readonly width: number;
   /** Vertical extent in mm */
   readonly height: number;
-  /** Corner radius in mm (used for rectangle and u-shape) */
+  /** Corner radius in mm (used for rectangle) */
   readonly cornerRadius: number;
 }
 
@@ -38,8 +36,6 @@ export function buildHandleProfile(shape: HandleCutoutShape, args: ProfileArgs):
       return buildOvalProfile(width, height);
     case 'scoop':
       return buildScoopProfile(width, height);
-    case 'u-shape':
-      return buildUShapeProfile(width, height, cornerRadius);
     default:
       return buildRectangleProfile(width, height, cornerRadius);
   }
@@ -61,27 +57,4 @@ function buildScoopProfile(w: number, h: number): Drawing {
   const hh = h / 2;
   const sagitta = Math.min(hw, hh);
   return draw([-hw, hh]).lineTo([hw, hh]).lineTo([hw, 0]).sagittaArc(-w, 0, sagitta).close();
-}
-
-function buildUShapeProfile(w: number, h: number, r: number): Drawing {
-  // Open-bottom U: extends below origin by U_SHAPE_OVERSHOOT for clean boolean.
-  // Rounded top corners, straight sides, open (below floor) bottom.
-  const hw = w / 2;
-  const totalH = h + U_SHAPE_OVERSHOOT;
-  const topY = totalH / 2;
-  const bottomY = -totalH / 2;
-  const safeR = Math.max(0, Math.min(r, w / 2 - 0.01, h / 4 - 0.01));
-
-  if (safeR > 0.1) {
-    return draw([-hw, bottomY])
-      .lineTo([-hw, topY - safeR])
-      .customCorner(safeR)
-      .lineTo([hw - safeR, topY])
-      .customCorner(safeR)
-      .lineTo([hw, bottomY])
-      .close();
-  }
-
-  // Shift center to account for asymmetric overshoot
-  return drawRectangle(w, totalH);
 }

--- a/src/features/generation/worker/generators/scenarios/handles.ts
+++ b/src/features/generation/worker/generators/scenarios/handles.ts
@@ -195,22 +195,6 @@ export const handles: ScenarioCase[] = [
     },
     timeout: 60_000,
   }),
-  defineScenario('handles', 'u-shape handles auto-anchored to floor', {
-    assert: 'structural',
-    params: {
-      width: 2,
-      depth: 2,
-      height: 5,
-      handles: {
-        ...DEFAULT_BIN_PARAMS.handles,
-        enabled: true,
-        shape: 'u-shape',
-        front: ENABLED_SIDE,
-        left: ENABLED_SIDE,
-      },
-    },
-    timeout: 60_000,
-  }),
   defineScenario('handles', 'multi-handle count=2 on wide bin', {
     assert: 'structural',
     params: {

--- a/src/features/generation/worker/generators/wallPatternBuilder.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.ts
@@ -43,7 +43,6 @@ import {
   buildHandleWallDefs,
   computeHandleHoleGeometry,
   computeWallHandleSegments,
-  U_SHAPE_OVERSHOOT,
 } from '@/shared/utils/handleCutoutClip';
 import type { HandleSegment, HandleWallDef } from '@/shared/utils/handleCutoutClip';
 import { computeMultiHandleOffsets } from '@/shared/utils/handleLayout';
@@ -197,26 +196,12 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
       params.handles[wall.side]?.enabled &&
       !(wall.side === 'back' && params.label.enabled)
     ) {
-      const isUShape = params.handles.shape === 'u-shape';
       const side = params.handles[wall.side];
       const sideHeight = side.height ?? params.handles.height;
       const sideWidth = side.width ?? params.handles.width;
 
-      let handleCenterZ: number;
-      let handleEffHeight: number;
-      if (isUShape) {
-        const clampedHeight = Math.min(sideHeight, interiorHeight);
-        handleEffHeight = clampedHeight + U_SHAPE_OVERSHOOT;
-        handleCenterZ = (clampedHeight - U_SHAPE_OVERSHOOT) / 2;
-      } else {
-        const geom = computeHandleHoleGeometry(
-          interiorHeight,
-          sideHeight,
-          params.handles.verticalPosition
-        );
-        handleCenterZ = geom.centerZ;
-        handleEffHeight = geom.effectiveHeight;
-      }
+      const { centerZ: handleCenterZ, effectiveHeight: handleEffHeight } =
+        computeHandleHoleGeometry(interiorHeight, sideHeight, params.handles.verticalPosition);
 
       if (handleEffHeight >= 1) {
         const handleCutoutCfg = params.walls.enabled ? params.walls[wall.side] : undefined;

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -491,7 +491,6 @@
   "binDesigner.handles.shape.oval": "Oval",
   "binDesigner.handles.shape.rectangle": "Rechteck",
   "binDesigner.handles.shape.scoop": "Schaufel",
-  "binDesigner.handles.shape.uShape": "U-Form",
   "binDesigner.handles.sides": "Seiten",
   "binDesigner.handles.summary": "{shape} {sides}: {height}mm",
   "binDesigner.handles.supportNote": "Breite Löcher erfordern möglicherweise Stützstrukturen beim Drucken",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1587,7 +1587,6 @@
   "binDesigner.handles.shape.rectangle": "Rectangle",
   "binDesigner.handles.shape.oval": "Oval",
   "binDesigner.handles.shape.scoop": "Scoop",
-  "binDesigner.handles.shape.uShape": "U-Shape",
   "binDesigner.handles.verticalPosition": "Vertical position",
   "binDesigner.handles.count": "Count",
   "binDesigner.handles.chamfer": "Chamfer edges",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1832,7 +1832,6 @@ const en: Record<string, string> = {
   'binDesigner.handles.shape.rectangle': 'Rectangle',
   'binDesigner.handles.shape.oval': 'Oval',
   'binDesigner.handles.shape.scoop': 'Scoop',
-  'binDesigner.handles.shape.uShape': 'U-Shape',
   'binDesigner.handles.verticalPosition': 'Vertical position',
   'binDesigner.handles.count': 'Count',
   'binDesigner.handles.chamfer': 'Chamfer edges',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -491,7 +491,6 @@
   "binDesigner.handles.shape.oval": "Óvalo",
   "binDesigner.handles.shape.rectangle": "Rectángulo",
   "binDesigner.handles.shape.scoop": "Cuchara",
-  "binDesigner.handles.shape.uShape": "U",
   "binDesigner.handles.sides": "Lados",
   "binDesigner.handles.summary": "{shape} {sides}: {height}mm",
   "binDesigner.handles.supportNote": "Los agujeros anchos pueden requerir soportes al imprimir",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -491,7 +491,6 @@
   "binDesigner.handles.shape.oval": "Ovale",
   "binDesigner.handles.shape.rectangle": "Rectangle",
   "binDesigner.handles.shape.scoop": "Cuillère",
-  "binDesigner.handles.shape.uShape": "U",
   "binDesigner.handles.sides": "Côtés",
   "binDesigner.handles.summary": "{shape} {sides}: {height}mm",
   "binDesigner.handles.supportNote": "Les trous larges peuvent nécessiter des supports lors de l'impression",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -491,7 +491,6 @@
   "binDesigner.handles.shape.oval": "楕円",
   "binDesigner.handles.shape.rectangle": "長方形",
   "binDesigner.handles.shape.scoop": "スクープ",
-  "binDesigner.handles.shape.uShape": "U字",
   "binDesigner.handles.sides": "辺",
   "binDesigner.handles.summary": "{shape} {sides}: {height}mm",
   "binDesigner.handles.supportNote": "広い穴は印刷時にサポートが必要な場合があります",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -491,7 +491,6 @@
   "binDesigner.handles.shape.oval": "Oval",
   "binDesigner.handles.shape.rectangle": "Rektangel",
   "binDesigner.handles.shape.scoop": "Skje",
-  "binDesigner.handles.shape.uShape": "U-form",
   "binDesigner.handles.sides": "Sider",
   "binDesigner.handles.summary": "{shape} {sides}: {height}mm",
   "binDesigner.handles.supportNote": "Brede hull kan kreve støttestrukturer ved utskrift",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -491,7 +491,6 @@
   "binDesigner.handles.shape.oval": "Ovaal",
   "binDesigner.handles.shape.rectangle": "Rechthoek",
   "binDesigner.handles.shape.scoop": "Schep",
-  "binDesigner.handles.shape.uShape": "U-vorm",
   "binDesigner.handles.sides": "Zijden",
   "binDesigner.handles.summary": "{shape} {sides}: {height}mm",
   "binDesigner.handles.supportNote": "Brede gaten hebben mogelijk ondersteuning nodig bij het printen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -491,7 +491,6 @@
   "binDesigner.handles.shape.oval": "Oval",
   "binDesigner.handles.shape.rectangle": "Retângulo",
   "binDesigner.handles.shape.scoop": "Concha",
-  "binDesigner.handles.shape.uShape": "U",
   "binDesigner.handles.sides": "Lados",
   "binDesigner.handles.summary": "{shape} {sides}: {height}mm",
   "binDesigner.handles.supportNote": "Furos largos podem precisar de suportes na impressão",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -491,7 +491,6 @@
   "binDesigner.handles.shape.oval": "Oval",
   "binDesigner.handles.shape.rectangle": "Rektangel",
   "binDesigner.handles.shape.scoop": "Skopa",
-  "binDesigner.handles.shape.uShape": "U-form",
   "binDesigner.handles.sides": "Sidor",
   "binDesigner.handles.summary": "{shape} {sides}: {height}mm",
   "binDesigner.handles.supportNote": "Breda hål kan kräva stöd vid utskrift",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -491,7 +491,6 @@
   "binDesigner.handles.shape.oval": "Овал",
   "binDesigner.handles.shape.rectangle": "Прямокутник",
   "binDesigner.handles.shape.scoop": "Захват",
-  "binDesigner.handles.shape.uShape": "U-форма",
   "binDesigner.handles.sides": "Сторони",
   "binDesigner.handles.summary": "{shape} {sides}: {height}мм",
   "binDesigner.handles.supportNote": "Широкі отвори можуть потребувати підпор під час друку",

--- a/src/shared/utils/handleCutoutClip.ts
+++ b/src/shared/utils/handleCutoutClip.ts
@@ -35,8 +35,6 @@ export interface HandleWallDef {
 
 /** Default vertical center of handle hole as fraction of interior height (from floor). */
 export const DEFAULT_VERTICAL_POSITION = 0.7;
-/** U-shape floor overshoot for clean boolean cut (mm). */
-export const U_SHAPE_OVERSHOOT = 5;
 /** Clearance gap between handle edge and cutout edge (mm). */
 export const CUTOUT_CLEARANCE = 1.0;
 /** Minimum handle segment width to generate (mm). */


### PR DESCRIPTION
## Summary

The **u-shape** handle cutout produced broken geometry, so this PR removes it entirely and restyles the handle shape/side pickers as segmented rail controls.

### Remove u-shape handle
- Drop `'u-shape'` from `HandleCutoutShape` and every branch that special-cased it: `handleProfiles`, `handleBuilder`, `wallPatternBuilder` (hex-pattern clip), `GhostHandles` preview, and `lidCompatibility` lip-intrusion check. All shapes now use the shared `computeHandleHoleGeometry` path.
- **Migration**: persisted designs with `handles.shape === 'u-shape'` are coerced to `'rectangle'` on load (`migrateParams` + new `VALID_HANDLE_SHAPES`), mirroring the existing wall-cutout shape coercion.
- Remove the now-orphaned `U_SHAPE_OVERSHOOT` constant.
- Remove `binDesigner.handles.shape.uShape` from `en.ts` and all 9 locale JSONs.
- Remove the u-shape generator scenario and the u-shape unit tests (`handleProfiles`, `lidCompatibility`).

> Wall-cutout u-shape (`WallCutoutShape`) is a **separate** feature and is intentionally left untouched.

### Segmented rail selectors
- Handle **shape** picker (rectangle/oval/scoop) → `SEGMENT_GROUP_CLASS` rail + `getSegmentClass` raised pills (single-select), matching `LabelTabsSection`.
- Handle **side** toggles (L/R/F/B) → same rail container, but with the `SEGMENT_ACTIVE`/`SEGMENT_INACTIVE` accent-tint treatment since they're independent multi-select toggles (a raised pill would wrongly imply a single choice).

## Testing
- `pnpm typecheck` — clean
- `pnpm check:i18n` — all 9 locales match (2256 keys)
- `pnpm lint` — clean on changed files
- Full Vitest suite — **12804 passed, 7 skipped, 0 failed** (incl. WASM generator scenarios)