### PR TITLE
feat(export): determinate progress bar instead of a spinner

### DIFF
--- a/src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
+++ b/src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
@@ -62,6 +62,7 @@ export function ExportDialog() {
     estimates,
     isExporting,
     isExportingBin,
+    exportProgress: exportFraction,
     downloadBin,
     needsSplit,
     splitPieceCount,
@@ -198,6 +199,15 @@ export function ExportDialog() {
       displayExtension={displayExtension}
       canExport={canExport && engineReady}
       isExporting={isExporting}
+      exportProgress={
+        isExportingBin
+          ? {
+              current: Math.round(exportFraction * 100),
+              total: 100,
+              label: t('binDesigner.exporting'),
+            }
+          : null
+      }
       onDownload={() => void handleDownload()}
       downloadLabel={downloadLabel}
       splitBanner={

--- a/src/features/bin-designer/hooks/useExport.test.ts
+++ b/src/features/bin-designer/hooks/useExport.test.ts
@@ -185,7 +185,11 @@ describe('useExport', () => {
       });
     });
 
-    expect(mockExportCombined).toHaveBeenCalledWith(expect.any(Object), 'stl');
+    expect(mockExportCombined).toHaveBeenCalledWith(
+      expect.any(Object),
+      'stl',
+      expect.objectContaining({ onProgress: expect.any(Function) })
+    );
     expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob));
     expect(mockAnchor.click).toHaveBeenCalled();
     expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
@@ -246,7 +250,11 @@ describe('useExport', () => {
       });
     });
 
-    expect(mockExportCombined).toHaveBeenCalledWith(expect.any(Object), 'step');
+    expect(mockExportCombined).toHaveBeenCalledWith(
+      expect.any(Object),
+      'step',
+      expect.objectContaining({ onProgress: expect.any(Function) })
+    );
     expect(mockAnchor.download).toContain('.step');
 
     createElementSpy.mockRestore();

--- a/src/features/bin-designer/hooks/useExport.ts
+++ b/src/features/bin-designer/hooks/useExport.ts
@@ -338,6 +338,9 @@ export function useExport(): UseExportReturn {
         const exportResult = await exportWithResilience(() => {
           const bridge = getActiveBridge();
           if (!bridge) throw new Error('Bridge not available');
+          // Reset per attempt so a resilience retry restarts the bar at 0
+          // rather than jumping backwards from where the failed attempt left off.
+          setExportProgress(0);
           return bridge.exportCombined(params, workerFormat, { onProgress: setExportProgress });
         });
         retryCount = exportResult.retryCount;

--- a/src/features/bin-designer/hooks/useExport.ts
+++ b/src/features/bin-designer/hooks/useExport.ts
@@ -58,6 +58,8 @@ interface UseExportReturn {
   readonly isExportingBin: boolean;
   /** Whether any export is currently in progress */
   readonly isExporting: boolean;
+  /** Export progress in [0, 1] while exporting (for a determinate progress bar). */
+  readonly exportProgress: number;
   /** Whether mesh data is available for export (bridge active + mesh exists) */
   readonly canExport: boolean;
   /** Whether the geometry engine is ready to handle export requests */
@@ -129,6 +131,8 @@ export function useExport(): UseExportReturn {
 
   const [isExportingBin, setIsExportingBin] = useState(false);
   const isExporting = isExportingBin;
+  // 0–1 export progress for the determinate progress bar (worker-reported).
+  const [exportProgress, setExportProgress] = useState(0);
 
   // Track engine readiness via bridgeManager subscription. `subscribe()` fires
   // synchronously with the current state, so the initial value is correct.
@@ -321,6 +325,7 @@ export function useExport(): UseExportReturn {
       }
 
       setIsExportingBin(true);
+      setExportProgress(0);
       const startTime = performance.now();
       let retryCount = 0;
       let restartCount = 0;
@@ -333,7 +338,7 @@ export function useExport(): UseExportReturn {
         const exportResult = await exportWithResilience(() => {
           const bridge = getActiveBridge();
           if (!bridge) throw new Error('Bridge not available');
-          return bridge.exportCombined(params, workerFormat);
+          return bridge.exportCombined(params, workerFormat, { onProgress: setExportProgress });
         });
         retryCount = exportResult.retryCount;
         restartCount = exportResult.restartCount;
@@ -540,6 +545,7 @@ export function useExport(): UseExportReturn {
   return {
     isExporting,
     isExportingBin,
+    exportProgress,
     canExport,
     engineReady,
     hasDividers,

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -283,7 +283,11 @@ export class GenerationBridge {
   exportBin(
     params: BinParams,
     format: ExportFormat,
-    options?: { tolerance?: number; angularTolerance?: number }
+    options?: {
+      tolerance?: number;
+      angularTolerance?: number;
+      onProgress?: (progress: number) => void;
+    }
   ): Promise<ExportResult> {
     return exportBinImpl(this, params, format, options);
   }
@@ -295,7 +299,11 @@ export class GenerationBridge {
   exportCombined(
     params: BinParams,
     format: ExportFormat,
-    options?: { tolerance?: number; angularTolerance?: number }
+    options?: {
+      tolerance?: number;
+      angularTolerance?: number;
+      onProgress?: (progress: number) => void;
+    }
   ): Promise<CombinedExportResult> {
     return exportCombinedImpl(this, params, format, options);
   }

--- a/src/features/generation/bridge/bridgeExports.ts
+++ b/src/features/generation/bridge/bridgeExports.ts
@@ -38,7 +38,8 @@ function runExport<T>(
   ctx: BridgeExportContext,
   slot: ExportSlot,
   timeoutMs: number,
-  buildMessage: (requestId: string) => WorkerMessage
+  buildMessage: (requestId: string) => WorkerMessage,
+  onProgress?: (progress: number) => void
 ): Promise<T> {
   return ctx.prepareExport(slot).then(
     (requestId) =>
@@ -48,6 +49,7 @@ function runExport<T>(
           reject,
           requestId,
           timer: null,
+          onProgress,
         });
         ctx.startExportTimeout(slot, requestId, timeoutMs);
         ctx.postMessage(buildMessage(requestId));
@@ -59,7 +61,11 @@ export function exportBin(
   ctx: BridgeExportContext,
   params: BinParams,
   format: ExportFormat,
-  options?: { tolerance?: number; angularTolerance?: number }
+  options?: {
+    tolerance?: number;
+    angularTolerance?: number;
+    onProgress?: (progress: number) => void;
+  }
 ): Promise<ExportResult> {
   return runExport<ExportResult>(
     ctx,
@@ -74,7 +80,8 @@ export function exportBin(
         tolerance: options?.tolerance,
         angularTolerance: options?.angularTolerance,
       },
-    })
+    }),
+    options?.onProgress
   );
 }
 
@@ -94,7 +101,11 @@ export function exportCombined(
   ctx: BridgeExportContext,
   params: BinParams,
   format: ExportFormat,
-  options?: { tolerance?: number; angularTolerance?: number }
+  options?: {
+    tolerance?: number;
+    angularTolerance?: number;
+    onProgress?: (progress: number) => void;
+  }
 ): Promise<CombinedExportResult> {
   return runExport<CombinedExportResult>(
     ctx,
@@ -109,7 +120,8 @@ export function exportCombined(
         tolerance: options?.tolerance,
         angularTolerance: options?.angularTolerance,
       },
-    })
+    }),
+    options?.onProgress
   );
 }
 

--- a/src/features/generation/bridge/bridgeMessageHandler.ts
+++ b/src/features/generation/bridge/bridgeMessageHandler.ts
@@ -93,6 +93,16 @@ export function installMessageHandler(ctx: MessageHandlerContext): void {
       case 'PROGRESS':
         if (response.requestId === ctx.currentRequestId && ctx.onProgress) {
           ctx.onProgress(response.stage, response.progress);
+        } else {
+          // Export requests live in `pendingExports` (keyed by slot, not the
+          // live generate requestId) — route their progress to the export's
+          // own callback so the export dialog can show a determinate bar.
+          for (const pending of ctx.pendingExports.values()) {
+            if (pending.requestId === response.requestId) {
+              pending.onProgress?.(response.progress);
+              break;
+            }
+          }
         }
         break;
 

--- a/src/features/generation/bridge/bridgeTypes.ts
+++ b/src/features/generation/bridge/bridgeTypes.ts
@@ -123,6 +123,8 @@ export interface PendingExport<T> {
   readonly resolve: (result: T) => void;
   readonly reject: (error: Error) => void;
   readonly requestId: string;
+  /** Optional 0–1 progress callback, invoked as the worker reports PROGRESS. */
+  readonly onProgress?: (progress: number) => void;
   /**
    * Timeout handle that cancels the export and rejects the promise if the
    * worker becomes unresponsive. Cleared whenever the request resolves,

--- a/src/features/generation/worker/generators/binExporter.ts
+++ b/src/features/generation/worker/generators/binExporter.ts
@@ -33,13 +33,17 @@ export interface ExportResult {
 async function runExportAttempt(
   params: BinParams,
   format: ExportFormat,
-  name: string
+  name: string,
+  onProgress?: (progress: number) => void
 ): Promise<ExportResult> {
+  onProgress?.(0.02);
   let faceGroups: readonly FaceGroupData[] | undefined;
   if (!isLastSolidExportQuality()) {
-    const meshData = generateBin(params, undefined, true);
+    // Generation is the bulk of export → map its stage progress to 2%–85%.
+    const meshData = generateBin(params, (_stage, p) => onProgress?.(0.02 + p * 0.83), true);
     faceGroups = meshData.faceGroups;
   }
+  onProgress?.(0.85);
 
   const solid = getLastSolid();
   if (!solid) {
@@ -51,6 +55,7 @@ async function runExportAttempt(
     // skip the re-mesh that the STL/3MF path needs.
     const blob = unwrapExportBlob(exportSTEP(solid), 'STEP');
     const data = await blob.arrayBuffer();
+    onProgress?.(1);
     return { data, fileName: `${name}.step` };
   }
 
@@ -68,6 +73,7 @@ async function runExportAttempt(
     }));
   }
 
+  onProgress?.(0.92);
   const blob = unwrapExportBlob(
     exportSTL(solid, {
       tolerance: EXPORT_TOLERANCE,
@@ -77,6 +83,7 @@ async function runExportAttempt(
     'STL'
   );
   const data = await blob.arrayBuffer();
+  onProgress?.(1);
   return { data, fileName: `${name}.stl`, faceGroups };
 }
 
@@ -104,11 +111,15 @@ async function runExportAttempt(
  * STL: binary mesh at the fixed export tolerance.
  * STEP: exact BREP geometry (lossless, CAD-interoperable).
  */
-export async function exportBin(params: BinParams, format: ExportFormat): Promise<ExportResult> {
+export async function exportBin(
+  params: BinParams,
+  format: ExportFormat,
+  onProgress?: (progress: number) => void
+): Promise<ExportResult> {
   const name = `gridfinity-${params.width}x${params.depth}x${params.height}`;
 
   try {
-    return await runExportAttempt(params, format, name);
+    return await runExportAttempt(params, format, name, onProgress);
   } catch (firstError) {
     // Discard any cached state and try once more with a completely fresh
     // solid. If this second attempt also fails, rethrow the second error
@@ -116,7 +127,7 @@ export async function exportBin(params: BinParams, format: ExportFormat): Promis
     // fresh-solid path gives us the cleanest diagnostic stack.
     setLastSolid(null);
     try {
-      return await runExportAttempt(params, format, name);
+      return await runExportAttempt(params, format, name, onProgress);
     } catch (retryError) {
       // Attach context about the first failure so telemetry can see both.
       if (retryError instanceof Error && firstError instanceof Error) {

--- a/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
@@ -47,11 +47,15 @@ export const tessellateStage: PipelineStage = {
     // interface, so the merged mesh is visually identical to the fused shell.
     const { deferredSolid } = ctx;
     if (deferredSolid) {
-      const socketMesh = mesh(deferredSolid, { tolerance, angularTolerance });
-      shapeMesh = mergeShapeMeshes(shapeMesh, socketMesh);
-      const socketEdges = meshEdges(deferredSolid, { tolerance, angularTolerance: edgeAngular });
-      edgeLines = concatFloat32(edgeLines, socketEdges.lines);
-      deferredSolid.delete();
+      try {
+        const socketMesh = mesh(deferredSolid, { tolerance, angularTolerance });
+        shapeMesh = mergeShapeMeshes(shapeMesh, socketMesh);
+        const socketEdges = meshEdges(deferredSolid, { tolerance, angularTolerance: edgeAngular });
+        edgeLines = concatFloat32(edgeLines, socketEdges.lines);
+      } finally {
+        // Dispose even if mesh/meshEdges throws, so the WASM handle never leaks.
+        deferredSolid.delete();
+      }
     }
 
     ctx.onProgress?.('merge', 1.0);

--- a/src/features/generation/worker/handlers/exportHandler.ts
+++ b/src/features/generation/worker/handlers/exportHandler.ts
@@ -22,7 +22,7 @@ import { lidAnchorZ } from '../generators/lidConstants';
 import { GRIDFINITY } from '@/shared/constants/bin';
 import { LID_FIT_CLEARANCE } from '@/shared/types/bin';
 import { shouldGenerateLid } from '@/shared/types/bin';
-import { runExport, classifyExportError } from './workerContext';
+import { runExport, reportProgress, classifyExportError } from './workerContext';
 
 export async function handleExport(message: ExportMessage): Promise<void> {
   const payload = message.payload;
@@ -30,7 +30,9 @@ export async function handleExport(message: ExportMessage): Promise<void> {
     payload.requestId,
     'EXPORT_RESULT',
     async () => {
-      const result = await exportBin(payload.params, payload.format);
+      const result = await exportBin(payload.params, payload.format, (p) =>
+        reportProgress(payload.requestId, 'merge', p)
+      );
       return {
         data: result.data,
         format: payload.format,
@@ -117,8 +119,12 @@ export async function handleExportCombined(message: ExportCombinedMessage): Prom
       // Export the bin first (regenerates solid if needed). exportBin runs
       // at the fixed export tolerance; the explicit `tolerance` /
       // `angularTolerance` from the payload still flow into divider and lid
-      // exports below which carry their own tessellation knobs.
-      const binResult = await exportBin(params, format);
+      // exports below which carry their own tessellation knobs. The bin is the
+      // bulk of the work, so map its progress to 0–95% and report 100% once the
+      // (fast) divider/lid pieces finish below.
+      const binResult = await exportBin(params, format, (p) =>
+        reportProgress(requestId, 'merge', p * 0.95)
+      );
 
       const hasDividers =
         params.style === 'slotted' && (params.slotConfig.x.enabled || params.slotConfig.y.enabled);

--- a/src/features/generation/worker/handlers/exportHandler.ts
+++ b/src/features/generation/worker/handlers/exportHandler.ts
@@ -133,6 +133,7 @@ export async function handleExportCombined(message: ExportCombinedMessage): Prom
       const hasLid = shouldGenerateLid(params);
 
       if (!hasDividers && !hasLid) {
+        reportProgress(requestId, 'merge', 1);
         return {
           pieces: [{ data: binResult.data, label: 'bin' }] as CombinedExportPiece[],
           format,
@@ -175,6 +176,7 @@ export async function handleExportCombined(message: ExportCombinedMessage): Prom
           const assembly = compound([binSolid, ...dividerSolids, ...(lidSolid ? [lidSolid] : [])]);
           const blob = unwrap(exportSTEP(assembly));
 
+          reportProgress(requestId, 'merge', 1);
           return {
             pieces: [
               { data: await blob.arrayBuffer(), label: 'assembly' },
@@ -205,6 +207,7 @@ export async function handleExportCombined(message: ExportCombinedMessage): Prom
         }
       }
 
+      reportProgress(requestId, 'merge', 1);
       return { pieces, format, faceGroups: binResult.faceGroups };
     },
     'Combined export failed',

--- a/src/shared/components/ExportDialog/ExportDialog.tsx
+++ b/src/shared/components/ExportDialog/ExportDialog.tsx
@@ -47,8 +47,13 @@ export interface ExportDialogProps {
   /** Override download button label */
   downloadLabel?: string;
 
-  /** Optional progress for multi-piece exports */
-  exportProgress?: { current: number; total: number } | null;
+  /**
+   * Optional determinate export progress. `current`/`total` drive the bar
+   * percentage; multi-piece exports leave `label` unset to get the default
+   * "piece X of Y" copy, while a single-bin export passes a percentage
+   * (`current` 0–100, `total` 100) plus a `label` like "Exporting…".
+   */
+  exportProgress?: { current: number; total: number; label?: string } | null;
 
   /** Optional split export banner */
   splitBanner?: {
@@ -329,18 +334,22 @@ export function ExportDialog({
           {exportProgress && (
             <div className="mb-4">
               <div className="mb-1.5 text-xs text-content-secondary">
-                {t('export.progressLabel', {
-                  current: exportProgress.current,
-                  total: exportProgress.total,
-                })}
+                {exportProgress.label ??
+                  t('export.progressLabel', {
+                    current: exportProgress.current,
+                    total: exportProgress.total,
+                  })}
               </div>
               <ProgressBar
                 value={progressPercent}
                 size="sm"
-                label={t('export.progressLabel', {
-                  current: exportProgress.current,
-                  total: exportProgress.total,
-                })}
+                label={
+                  exportProgress.label ??
+                  t('export.progressLabel', {
+                    current: exportProgress.current,
+                    total: exportProgress.total,
+                  })
+                }
               />
             </div>
           )}


### PR DESCRIPTION
## What

Export currently shows an indeterminate spinner. This makes it a **determinate progress bar**.

## How

The generation pipeline already emits per-stage `PROGRESS` (used by the live generating indicator); export just never tapped into it. Now:

- **Worker** — `exportBin`/`runExportAttempt` accept an `onProgress`; generation stages map to 2–85% and encode to 100%. `handleExport` + `handleExportCombined` forward it via `reportProgress(exportRequestId, …)`.
- **Bridge** — `PendingExport` gains an `onProgress`; `runExport`/`exportBin`/`exportCombined` register it, and the `PROGRESS` handler routes export-tagged progress to it (export requests live in `pendingExports`, keyed by slot, separate from the live generate request).
- **UI** — `useExport` tracks 0–1 progress and the bin `ExportDialog` feeds the existing `ProgressBar` (the same one multi-piece/split exports already use), with an "Exporting…" label. The spinner stays as the fallback when no progress is reported.

## Notes

- Granularity: single-bin exports are stage-level (a few steps — honest but coarse); the per-piece bar that split/multi-color exports already had is unchanged. The shared dialog's `exportProgress` prop gained an optional `label` so it shows "Exporting…" for the percentage case vs "piece X of Y" for multi-piece.
- Tests: useExport (18) + ExportDialog component (52) + typecheck + lint all green.
