### PR TITLE
feat(bin-designer): unify wall-cutout and handle panel UI

### DIFF
--- a/src/core/store/settings.types.ts
+++ b/src/core/store/settings.types.ts
@@ -195,6 +195,12 @@ export interface UserSettings {
    */
   wallCutoutsLinked: boolean;
 
+  /**
+   * Whether the handles editor edits all active sides together.
+   * Persisted so unlinking to adjust sides independently survives a reload.
+   */
+  handlesLinked: boolean;
+
   // Print view preferences
   printViewSettings: PrintViewSettings;
 
@@ -311,6 +317,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   layoutManagerViewMode: 'grid',
   designListViewMode: 'grid',
   wallCutoutsLinked: true,
+  handlesLinked: true,
 
   // Print view preferences
   printViewSettings: { ...DEFAULT_PRINT_VIEW_SETTINGS },

--- a/src/features/bin-designer/components/panel/HandleSection/HandleSection.tsx
+++ b/src/features/bin-designer/components/panel/HandleSection/HandleSection.tsx
@@ -45,14 +45,14 @@ export function HandleSection() {
   } = state;
 
   const sideStates: SideState[] = HANDLE_SIDES.map((side) => {
+    // The back handle is blocked while a label tab occupies that wall.
+    // SideSelector renders a disabled side as off, so the stored `enabled`
+    // flag can pass through unchanged.
     const isDisabled = side === 'back' && isBackDisabled;
-    // A disabled side is functionally off (generation skips back handles while a
-    // label tab is active), so present it as off even if its stored `enabled`
-    // flag is still true — otherwise the blocked side reads as "on".
     return {
       side,
       label: t(`binDesigner.handles.${side}`),
-      active: handles[side].enabled && !isDisabled,
+      active: handles[side].enabled,
       disabled: isDisabled,
       title: isDisabled ? t('binDesigner.handles.backDisabledByLabelTab') : undefined,
     };

--- a/src/features/bin-designer/components/panel/HandleSection/HandleSection.tsx
+++ b/src/features/bin-designer/components/panel/HandleSection/HandleSection.tsx
@@ -1,23 +1,26 @@
 /**
  * Handle section: through-hole grip cutouts in bin walls.
  *
- * Controls: master toggle, shape selector, side chip toggles,
- * linked/independent mode, width/height/corner-radius/vertical position steppers,
- * count stepper, chamfer toggle, interior walls toggle.
+ * Controls: master toggle, shape picker, spatial side selector, linked/independent
+ * mode, width/height/corner-radius steppers, collapsible vertical-position + count,
+ * chamfer toggle, interior walls toggle. Shares its selectors, steppers, and
+ * disclosure with the wall-cutout section via panel/shared so the two panels read
+ * identically.
  */
 
 import { FeatureToggle } from '../FeatureToggle';
-import { StepperControl } from '@/shared/components/StepperControl';
 import {
-  getSegmentClass,
-  SEGMENT_GROUP_CLASS,
-  SEGMENT_ACTIVE,
-  SEGMENT_INACTIVE,
-} from '@/shared/components/segmentedControlClasses';
+  ShapePicker,
+  SideSelector,
+  StepperField,
+  AdvancedDisclosure,
+  LinkIcon,
+  type SideState,
+} from '../shared';
 import { RulerIcon } from '@/design-system/Icon';
 import { DESIGNER_CONSTRAINTS } from '../../../constants';
 import { useHandleSection, HANDLE_SIDES } from './useHandleSection';
-import type { HandleCutoutShape } from '@/features/bin-designer/types';
+import type { HandleCutoutShape, HandleWallSide } from '@/features/bin-designer/types';
 
 const C = DESIGNER_CONSTRAINTS;
 
@@ -27,52 +30,7 @@ const SHAPE_OPTIONS: readonly { value: HandleCutoutShape; labelKey: string }[] =
   { value: 'scoop', labelKey: 'binDesigner.handles.shape.scoop' },
 ];
 
-/** Inline SVG chain-link icon (12x12). */
-function LinkIcon({ linked }: { linked: boolean }) {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="flex-shrink-0"
-    >
-      {linked ? (
-        <>
-          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-        </>
-      ) : (
-        <>
-          <path d="M18.84 12.25l1.72-1.71a5 5 0 0 0-7.07-7.07l-3 3a5 5 0 0 0 .12 7.19" />
-          <path d="M5.16 11.75l-1.72 1.71a5 5 0 0 0 7.07 7.07l3-3a5 5 0 0 0-.12-7.19" />
-          <line x1="2" y1="2" x2="22" y2="22" />
-        </>
-      )}
-    </svg>
-  );
-}
-
-/**
- * Side chip base dimensions. Matches the shape selector's segment pills
- * (px-2 py-1 text-xs rounded-md) so both rails read identically, but the
- * sides are independent on/off toggles — they use the accent-tint
- * SEGMENT_ACTIVE/SEGMENT_INACTIVE treatment instead of the single-select
- * raised pill (getSegmentClass).
- */
-const SIDE_CHIP_BASE =
-  'flex items-center justify-center rounded-md px-2 py-1 text-xs font-medium transition-colors ' +
-  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ' +
-  'disabled:cursor-not-allowed disabled:opacity-50';
-
-/** Side chip button class based on state. */
-function sideChipClass(isActive: boolean): string {
-  return `${SIDE_CHIP_BASE} ${isActive ? SEGMENT_ACTIVE : SEGMENT_INACTIVE}`;
-}
+const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
 
 export function HandleSection() {
   const { state, handlers, meta, t } = useHandleSection();
@@ -86,6 +44,71 @@ export function HandleSection() {
     activeSides,
   } = state;
 
+  const sideStates: SideState[] = HANDLE_SIDES.map((side) => {
+    const isDisabled = side === 'back' && isBackDisabled;
+    // A disabled side is functionally off (generation skips back handles while a
+    // label tab is active), so present it as off even if its stored `enabled`
+    // flag is still true — otherwise the blocked side reads as "on".
+    return {
+      side,
+      label: t(`binDesigner.handles.${side}`),
+      active: handles[side].enabled && !isDisabled,
+      disabled: isDisabled,
+      title: isDisabled ? t('binDesigner.handles.backDisabledByLabelTab') : undefined,
+    };
+  });
+
+  /** Width (%) + height (mm) steppers for a single side or the shared config. */
+  const renderSizeRow = (side: HandleWallSide | null) => {
+    const width = side ? (handles[side].width ?? handles.width) : handles.width;
+    const height = side ? (handles[side].height ?? handles.height) : handles.height;
+    const setWidth = side ? (v: number) => handlers.setSideWidth(side, v) : handlers.setWidth;
+    const setHeight = side ? (v: number) => handlers.setSideHeight(side, v) : handlers.setHeight;
+
+    return (
+      <div className="flex items-end gap-2">
+        <StepperField
+          label={t('binDesigner.handles.width')}
+          unit="%"
+          value={width}
+          onChange={setWidth}
+          onStep={(delta) =>
+            setWidth(
+              clamp(width + delta * C.HANDLE_WIDTH_STEP, C.MIN_HANDLE_WIDTH, C.MAX_HANDLE_WIDTH)
+            )
+          }
+          min={C.MIN_HANDLE_WIDTH}
+          max={C.MAX_HANDLE_WIDTH}
+          step={C.HANDLE_WIDTH_STEP}
+          variant="desktop"
+          ariaLabel={side ? `${side} handle width` : t('binDesigner.handles.widthAria')}
+        />
+        <StepperField
+          label={t('binDesigner.handles.height')}
+          unit="mm"
+          value={height}
+          onChange={setHeight}
+          onStep={(delta) =>
+            setHeight(
+              clamp(height + delta * C.HANDLE_HEIGHT_STEP, C.MIN_HANDLE_HEIGHT, C.MAX_HANDLE_HEIGHT)
+            )
+          }
+          min={C.MIN_HANDLE_HEIGHT}
+          max={C.MAX_HANDLE_HEIGHT}
+          step={C.HANDLE_HEIGHT_STEP}
+          variant="desktop"
+          ariaLabel={side ? `${side} handle height` : t('binDesigner.handles.heightAria')}
+        />
+      </div>
+    );
+  };
+
+  const vpPercent = Math.round(handles.verticalPosition * 100);
+  const advancedSummary = `${vpPercent}%${handles.count > 1 ? ` ×${handles.count}` : ''}`;
+  // Auto-expand the advanced controls when the user has moved off the defaults
+  // (vertical position 0.7, single handle), so customizations are never hidden.
+  const advancedForceOpen = handles.verticalPosition !== 0.7 || handles.count !== 1;
+
   return (
     <FeatureToggle
       label={t('binDesigner.handles')}
@@ -95,54 +118,20 @@ export function HandleSection() {
       valueSummary={meta.summary}
       primaryControls={
         <div className="space-y-3">
-          {/* Shape selector */}
-          <div
-            role="group"
-            aria-label={t('binDesigner.handles.shape')}
-            className={SEGMENT_GROUP_CLASS}
-          >
-            {SHAPE_OPTIONS.map(({ value, labelKey }) => {
-              const isActive = handles.shape === value;
-              return (
-                <button
-                  key={value}
-                  type="button"
-                  aria-pressed={isActive}
-                  onClick={() => handlers.setShape(value)}
-                  className={`flex-1 ${getSegmentClass(isActive)}`}
-                >
-                  {t(labelKey)}
-                </button>
-              );
-            })}
-          </div>
+          {/* Shape picker */}
+          <ShapePicker
+            options={SHAPE_OPTIONS.map(({ value, labelKey }) => ({ value, label: t(labelKey) }))}
+            value={handles.shape}
+            onChange={handlers.setShape}
+            ariaLabel={t('binDesigner.handles.shape')}
+          />
 
-          {/* Side toggle chips — same order as WallCutoutsSection: L R F B */}
-          <div className={SEGMENT_GROUP_CLASS}>
-            {HANDLE_SIDES.map((side) => {
-              const isDisabled = side === 'back' && isBackDisabled;
-              // A disabled side is functionally off (generation skips back
-              // handles while a label tab is active), so present it as off —
-              // neutral styling + aria-checked=false — even if its stored
-              // `enabled` flag is still true. Otherwise the blocked chip reads
-              // as "on" (accent tint), implying the setting is still in effect.
-              const effectiveActive = handles[side].enabled && !isDisabled;
-              return (
-                <button
-                  key={side}
-                  type="button"
-                  role="switch"
-                  aria-checked={effectiveActive}
-                  disabled={isDisabled}
-                  title={isDisabled ? t('binDesigner.handles.backDisabledByLabelTab') : undefined}
-                  onClick={() => handlers.toggleSide(side)}
-                  className={`flex-1 ${sideChipClass(effectiveActive)}`}
-                >
-                  {t(`binDesigner.handles.${side}`)}
-                </button>
-              );
-            })}
-          </div>
+          {/* Spatial side selector */}
+          <SideSelector
+            sides={sideStates}
+            onToggle={(side) => handlers.toggleSide(side)}
+            ariaLabel={t('binDesigner.handles.sides')}
+          />
 
           {/* Controls — shown when at least one side is active */}
           {activeSides.length > 0 && (
@@ -166,60 +155,7 @@ export function HandleSection() {
               {/* Shared controls (linked mode) */}
               {linked && (
                 <>
-                  <div className="flex items-end gap-2">
-                    <div className="flex-1 min-w-0">
-                      <span className="mb-1 block text-xs text-content-tertiary">
-                        {}
-                        {t('binDesigner.handles.width')} {'(%)'}
-                      </span>
-                      <StepperControl
-                        value={handles.width}
-                        onChange={handlers.setWidth}
-                        onStep={(delta) =>
-                          handlers.setWidth(
-                            Math.min(
-                              C.MAX_HANDLE_WIDTH,
-                              Math.max(
-                                C.MIN_HANDLE_WIDTH,
-                                handles.width + delta * C.HANDLE_WIDTH_STEP
-                              )
-                            )
-                          )
-                        }
-                        min={C.MIN_HANDLE_WIDTH}
-                        max={C.MAX_HANDLE_WIDTH}
-                        step={C.HANDLE_WIDTH_STEP}
-                        variant="desktop"
-                        ariaLabel={t('binDesigner.handles.widthAria')}
-                      />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <span className="mb-1 block text-xs text-content-tertiary">
-                        {}
-                        {t('binDesigner.handles.height')} {'(mm)'}
-                      </span>
-                      <StepperControl
-                        value={handles.height}
-                        onChange={handlers.setHeight}
-                        onStep={(delta) =>
-                          handlers.setHeight(
-                            Math.min(
-                              C.MAX_HANDLE_HEIGHT,
-                              Math.max(
-                                C.MIN_HANDLE_HEIGHT,
-                                handles.height + delta * C.HANDLE_HEIGHT_STEP
-                              )
-                            )
-                          )
-                        }
-                        min={C.MIN_HANDLE_HEIGHT}
-                        max={C.MAX_HANDLE_HEIGHT}
-                        step={C.HANDLE_HEIGHT_STEP}
-                        variant="desktop"
-                        ariaLabel={t('binDesigner.handles.heightAria')}
-                      />
-                    </div>
-                  </div>
+                  {renderSizeRow(null)}
 
                   {/* Physical dimensions readout — hidden on custom shapes
                       where the actual span is a polygon edge, not the AABB. */}
@@ -235,32 +171,26 @@ export function HandleSection() {
                   {/* Corner radius — only for rectangle */}
                   {showCornerRadius && (
                     <div className="flex items-end gap-2">
-                      <div className="flex-1 min-w-0">
-                        <span className="mb-1 block text-xs text-content-tertiary">
-                          {}
-                          {t('binDesigner.handles.cornerRadius')} {'(mm)'}
-                        </span>
-                        <StepperControl
-                          value={handles.cornerRadius}
-                          onChange={handlers.setCornerRadius}
-                          onStep={(delta) =>
-                            handlers.setCornerRadius(
-                              Math.min(
-                                C.MAX_HANDLE_CORNER_RADIUS,
-                                Math.max(
-                                  C.MIN_HANDLE_CORNER_RADIUS,
-                                  handles.cornerRadius + delta * C.HANDLE_CORNER_RADIUS_STEP
-                                )
-                              )
+                      <StepperField
+                        label={t('binDesigner.handles.cornerRadius')}
+                        unit="mm"
+                        value={handles.cornerRadius}
+                        onChange={handlers.setCornerRadius}
+                        onStep={(delta) =>
+                          handlers.setCornerRadius(
+                            clamp(
+                              handles.cornerRadius + delta * C.HANDLE_CORNER_RADIUS_STEP,
+                              C.MIN_HANDLE_CORNER_RADIUS,
+                              C.MAX_HANDLE_CORNER_RADIUS
                             )
-                          }
-                          min={C.MIN_HANDLE_CORNER_RADIUS}
-                          max={C.MAX_HANDLE_CORNER_RADIUS}
-                          step={C.HANDLE_CORNER_RADIUS_STEP}
-                          variant="desktop"
-                          ariaLabel={t('binDesigner.handles.cornerRadiusAria')}
-                        />
-                      </div>
+                          )
+                        }
+                        min={C.MIN_HANDLE_CORNER_RADIUS}
+                        max={C.MAX_HANDLE_CORNER_RADIUS}
+                        step={C.HANDLE_CORNER_RADIUS_STEP}
+                        variant="desktop"
+                        ariaLabel={t('binDesigner.handles.cornerRadiusAria')}
+                      />
                     </div>
                   )}
                 </>
@@ -272,88 +202,32 @@ export function HandleSection() {
                   (s) => handles[s].enabled && !(s === 'back' && isBackDisabled)
                 ).map((side) => (
                   <div key={side} className="space-y-2">
-                    <label className="text-xs font-medium text-content-secondary block">
+                    <label className="block text-xs font-medium text-content-secondary">
                       {t(`binDesigner.handles.${side}`)}
                     </label>
-                    <div className="flex items-end gap-2">
-                      <div className="flex-1 min-w-0">
-                        <span className="mb-1 block text-xs text-content-tertiary">
-                          {}
-                          {t('binDesigner.handles.width')} {'(%)'}
-                        </span>
-                        <StepperControl
-                          value={handles[side].width ?? handles.width}
-                          onChange={(v) => handlers.setSideWidth(side, v)}
-                          onStep={(delta) =>
-                            handlers.setSideWidth(
-                              side,
-                              Math.min(
-                                C.MAX_HANDLE_WIDTH,
-                                Math.max(
-                                  C.MIN_HANDLE_WIDTH,
-                                  (handles[side].width ?? handles.width) +
-                                    delta * C.HANDLE_WIDTH_STEP
-                                )
-                              )
-                            )
-                          }
-                          min={C.MIN_HANDLE_WIDTH}
-                          max={C.MAX_HANDLE_WIDTH}
-                          step={C.HANDLE_WIDTH_STEP}
-                          variant="desktop"
-                          ariaLabel={`${side} handle width`}
-                        />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <span className="mb-1 block text-xs text-content-tertiary">
-                          {}
-                          {t('binDesigner.handles.height')} {'(mm)'}
-                        </span>
-                        <StepperControl
-                          value={handles[side].height ?? handles.height}
-                          onChange={(v) => handlers.setSideHeight(side, v)}
-                          onStep={(delta) =>
-                            handlers.setSideHeight(
-                              side,
-                              Math.min(
-                                C.MAX_HANDLE_HEIGHT,
-                                Math.max(
-                                  C.MIN_HANDLE_HEIGHT,
-                                  (handles[side].height ?? handles.height) +
-                                    delta * C.HANDLE_HEIGHT_STEP
-                                )
-                              )
-                            )
-                          }
-                          min={C.MIN_HANDLE_HEIGHT}
-                          max={C.MAX_HANDLE_HEIGHT}
-                          step={C.HANDLE_HEIGHT_STEP}
-                          variant="desktop"
-                          ariaLabel={`${side} handle height`}
-                        />
-                      </div>
-                    </div>
+                    {renderSizeRow(side)}
                   </div>
                 ))}
 
-              {/* Global controls: vertical position + count (always visible, not per-side) */}
-              <div className="flex items-end gap-2">
-                {/* Vertical position */}
-                <div className="flex-1 min-w-0">
-                  <span className="mb-1 block text-xs text-content-tertiary">
-                    {}
-                    {t('binDesigner.handles.verticalPosition')} {'(%)'}
-                  </span>
-                  <StepperControl
-                    value={Math.round(handles.verticalPosition * 100)}
+              {/* Advanced: vertical position + count, collapsible */}
+              <AdvancedDisclosure
+                label={`${t('binDesigner.handles.verticalPosition')}:`}
+                summary={advancedSummary}
+                forceOpen={advancedForceOpen}
+              >
+                <div className="flex items-end gap-2">
+                  <StepperField
+                    label={t('binDesigner.handles.verticalPosition')}
+                    unit="%"
+                    value={vpPercent}
                     onChange={(v) => handlers.setVerticalPosition(v / 100)}
                     onStep={(delta) => {
                       const step = C.HANDLE_VERTICAL_POSITION_STEP * 100;
-                      const current = Math.round(handles.verticalPosition * 100);
                       handlers.setVerticalPosition(
-                        Math.min(
-                          C.MAX_HANDLE_VERTICAL_POSITION,
-                          Math.max(C.MIN_HANDLE_VERTICAL_POSITION, (current + delta * step) / 100)
+                        clamp(
+                          (vpPercent + delta * step) / 100,
+                          C.MIN_HANDLE_VERTICAL_POSITION,
+                          C.MAX_HANDLE_VERTICAL_POSITION
                         )
                       );
                     }}
@@ -363,22 +237,13 @@ export function HandleSection() {
                     variant="desktop"
                     ariaLabel={t('binDesigner.handles.verticalPositionAria')}
                   />
-                </div>
-
-                {/* Count stepper — shares row with vertical position */}
-                <div className="flex-1 min-w-0">
-                  <span className="mb-1 block text-xs text-content-tertiary">
-                    {t('binDesigner.handles.count')}
-                  </span>
-                  <StepperControl
+                  <StepperField
+                    label={t('binDesigner.handles.count')}
                     value={handles.count}
                     onChange={handlers.setCount}
                     onStep={(delta) =>
                       handlers.setCount(
-                        Math.min(
-                          C.MAX_HANDLE_COUNT,
-                          Math.max(C.MIN_HANDLE_COUNT, handles.count + delta)
-                        )
+                        clamp(handles.count + delta, C.MIN_HANDLE_COUNT, C.MAX_HANDLE_COUNT)
                       )
                     }
                     min={C.MIN_HANDLE_COUNT}
@@ -388,39 +253,39 @@ export function HandleSection() {
                     ariaLabel={t('binDesigner.handles.countAria')}
                   />
                 </div>
-              </div>
+              </AdvancedDisclosure>
 
               {/* Behavior toggles — separated visually */}
-              <div className="border-t border-stroke-subtle/50 pt-2 space-y-2">
-                <label className="flex items-center gap-2 text-xs text-content-secondary cursor-pointer">
+              <div className="space-y-2 border-t border-stroke-subtle/50 pt-2">
+                <label className="flex cursor-pointer items-center gap-2 text-xs text-content-secondary">
                   <input
                     type="checkbox"
                     checked={handles.chamfer}
                     onChange={handlers.toggleChamfer}
-                    className="rounded border-stroke-subtle text-accent focus:ring-accent h-3.5 w-3.5"
+                    className="h-3.5 w-3.5 rounded border-stroke-subtle text-accent focus:ring-accent"
                   />
                   {t('binDesigner.handles.chamfer')}
                 </label>
 
                 {hasCompartments && (
-                  <label className="flex items-center gap-2 text-xs text-content-secondary cursor-pointer">
+                  <label className="flex cursor-pointer items-center gap-2 text-xs text-content-secondary">
                     <input
                       type="checkbox"
                       checked={handles.interior}
                       onChange={handlers.toggleInterior}
-                      className="rounded border-stroke-subtle text-accent focus:ring-accent h-3.5 w-3.5"
+                      className="h-3.5 w-3.5 rounded border-stroke-subtle text-accent focus:ring-accent"
                     />
                     {t('binDesigner.handles.interior')}
                   </label>
                 )}
               </div>
+
+              {/* FDM support note — contextual to active handles */}
+              <p className="text-[11px] text-content-tertiary">
+                {t('binDesigner.handles.supportNote')}
+              </p>
             </>
           )}
-
-          {/* FDM support note */}
-          <p className="text-[11px] text-content-tertiary">
-            {t('binDesigner.handles.supportNote')}
-          </p>
         </div>
       }
     />

--- a/src/features/bin-designer/components/panel/HandleSection/useHandleSection.test.ts
+++ b/src/features/bin-designer/components/panel/HandleSection/useHandleSection.test.ts
@@ -3,12 +3,18 @@ import { renderHook, act } from '@testing-library/react';
 import { useHandleSection } from './useHandleSection';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import { useSettingsStore, DEFAULT_SETTINGS } from '@/core/store/settings';
 
 describe('useHandleSection', () => {
   beforeEach(() => {
     useDesignerStore.setState({
       params: { ...DEFAULT_BIN_PARAMS },
     });
+    // `linked` is a persisted user setting; reset the settings singleton so
+    // state doesn't leak between tests, and clear the localStorage it writes
+    // through so it can't bleed into other test files.
+    useSettingsStore.setState({ settings: { ...DEFAULT_SETTINGS } });
+    localStorage.clear();
   });
 
   it('returns disabled state by default', () => {
@@ -216,6 +222,33 @@ describe('useHandleSection', () => {
 
     const { result } = renderHook(() => useHandleSection());
     expect(result.current.state.handleWidthMm).toBeNull();
+  });
+
+  describe('linked state persistence', () => {
+    it('starts in linked mode by default', () => {
+      const { result } = renderHook(() => useHandleSection());
+      expect(result.current.state.linked).toBe(true);
+    });
+
+    it('persists linked toggle to user settings', () => {
+      const { result } = renderHook(() => useHandleSection());
+
+      act(() => {
+        result.current.handlers.toggleLinked();
+      });
+
+      expect(result.current.state.linked).toBe(false);
+      expect(useSettingsStore.getState().settings.handlesLinked).toBe(false);
+    });
+
+    it('reads persisted linked state on a fresh mount', () => {
+      useSettingsStore.setState({
+        settings: { ...DEFAULT_SETTINGS, handlesLinked: false },
+      });
+
+      const { result } = renderHook(() => useHandleSection());
+      expect(result.current.state.linked).toBe(false);
+    });
   });
 
   it('hides Interior toggle on polygon bins even when compartments exist', () => {

--- a/src/features/bin-designer/components/panel/HandleSection/useHandleSection.ts
+++ b/src/features/bin-designer/components/panel/HandleSection/useHandleSection.ts
@@ -1,6 +1,7 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { useSettingsStore } from '@/core/store/settings';
 import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
 import { useTranslation } from '@/i18n';
 import { getFeatureStatus } from '@/shared/constraints';
@@ -22,7 +23,12 @@ export function useHandleSection() {
     }))
   );
   const t = useTranslation();
-  const [linked, setLinked] = useState(true);
+  const { linked, updateSetting } = useSettingsStore(
+    useShallow((s) => ({
+      linked: s.settings.handlesLinked,
+      updateSetting: s.updateSetting,
+    }))
+  );
 
   const featureStatus = getFeatureStatus(params, 'handles');
   const isUnavailable = !featureStatus.available;
@@ -91,7 +97,10 @@ export function useHandleSection() {
     () => updateHandles({ interior: !handles.interior }),
     [handles.interior, updateHandles]
   );
-  const toggleLinked = useCallback(() => setLinked((prev) => !prev), []);
+  const toggleLinked = useCallback(
+    () => updateSetting('handlesLinked', !linked),
+    [updateSetting, linked]
+  );
 
   // Per-side setters
   const setSideWidth = useCallback(

--- a/src/features/bin-designer/components/panel/WallCutoutsSection/WallCutoutsSection.tsx
+++ b/src/features/bin-designer/components/panel/WallCutoutsSection/WallCutoutsSection.tsx
@@ -1,13 +1,21 @@
 /**
  * Wall cutouts section: U-shaped notches from the top of bin walls.
  *
- * Controls: master toggle, shape selector, side toggle chips, linked/independent mode,
- * span/height steppers with %/mm toggle, collapsible position controls (alignment + offset).
+ * Controls: master toggle, shape picker, spatial side selector, linked/independent
+ * mode, span/height steppers with %/mm toggle, collapsible position controls
+ * (alignment + offset). Shares its selectors, steppers, and disclosure with the
+ * handle section via panel/shared so the two panels read identically.
  */
 
-import { useState } from 'react';
 import { FeatureToggle } from '../FeatureToggle';
-import { StepperControl } from '@/shared/components/StepperControl';
+import {
+  ShapePicker,
+  SideSelector,
+  StepperField,
+  AdvancedDisclosure,
+  LinkIcon,
+  type SideState,
+} from '../shared';
 import { useWallCutoutsSection } from './useWallCutoutsSection';
 import type {
   WallSide,
@@ -17,7 +25,7 @@ import type {
 } from '@/features/bin-designer/types';
 
 const SIDE_ORDER: readonly Exclude<WallSide, 'interior'>[] = ['left', 'right', 'front', 'back'];
-const ALIGNMENT_OPTIONS: LabelTabAlignment[] = ['left', 'center', 'right'];
+const ALIGNMENT_OPTIONS: readonly LabelTabAlignment[] = ['left', 'center', 'right'];
 const OFFSET_STEP = 1;
 
 const SHAPE_OPTIONS: readonly { value: WallCutoutShape; labelKey: string }[] = [
@@ -26,61 +34,12 @@ const SHAPE_OPTIONS: readonly { value: WallCutoutShape; labelKey: string }[] = [
   { value: 'funnel', labelKey: 'binDesigner.wallCutouts.shape.funnel' },
 ];
 
-/** Inline SVG chain-link icon (12×12). */
-function LinkIcon({ linked }: { linked: boolean }) {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="flex-shrink-0"
-    >
-      {linked ? (
-        <>
-          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-        </>
-      ) : (
-        <>
-          <path d="M18.84 12.25l1.72-1.71a5 5 0 0 0-7.07-7.07l-3 3a5 5 0 0 0 .12 7.19" />
-          <path d="M5.16 11.75l-1.72 1.71a5 5 0 0 0 7.07 7.07l3-3a5 5 0 0 0-.12-7.19" />
-          <line x1="2" y1="2" x2="22" y2="22" />
-        </>
-      )}
-    </svg>
-  );
-}
-
-/** Inline SVG chevron (8×8). */
-function ChevronIcon({ open }: { open: boolean }) {
-  return (
-    <svg
-      width="8"
-      height="8"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="3"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={`flex-shrink-0 transition-transform ${open ? 'rotate-90' : ''}`}
-    >
-      <polyline points="9 18 15 12 9 6" />
-    </svg>
-  );
-}
-
-/** Whether a cutout has non-default positioning (worth showing in collapsed label). */
+/** Whether a cutout has non-default positioning (worth auto-expanding to show). */
 function hasCustomPosition(cfg: WallCutout): boolean {
   return cfg.alignment !== 'center' || cfg.offset !== 0;
 }
 
-/** Span + height steppers on one row, with optional %/mm toggle on the span. */
+/** Span + height steppers on one row, with a %/mm unit toggle on the span. */
 function SizeControls({
   side,
   cfg,
@@ -98,75 +57,68 @@ function SizeControls({
   heightLabel: string;
   step: number;
 }) {
+  const widthMm = cfg.widthMm ?? 1;
   const isMmMode = cfg.widthMm !== null;
 
   return (
     <div className="flex items-end gap-2">
-      {/* Span stepper */}
-      <div className="flex-1 min-w-0">
-        <span className="mb-1 block text-xs text-content-tertiary">{spanLabel}</span>
-        {isMmMode ? (
-          <StepperControl
-            value={cfg.widthMm}
-            onChange={(v) => handlers.setSideWidthMm(side, Math.max(1, v))}
-            onStep={(delta) =>
-              handlers.setSideWidthMm(side, Math.max(1, (cfg.widthMm as number) + delta))
-            }
-            min={1}
-            max={500}
-            step={1}
-            variant="desktop"
-            ariaLabel="Span mm"
-            commitMode="deferred"
-          />
-        ) : (
-          <StepperControl
-            value={cfg.width}
-            onChange={(v) => handlers.setSideWidth(side, v)}
-            onStep={(delta) =>
-              handlers.setSideWidth(side, Math.max(0, Math.min(100, cfg.width + delta * step)))
-            }
-            min={0}
-            max={100}
-            step={step}
-            variant="desktop"
-            ariaLabel="Span %"
-            commitMode="deferred"
-          />
-        )}
-      </div>
+      {isMmMode ? (
+        <StepperField
+          label={spanLabel}
+          unit="mm"
+          value={widthMm}
+          onChange={(v) => handlers.setSideWidthMm(side, Math.max(1, v))}
+          onStep={(delta) => handlers.setSideWidthMm(side, Math.max(1, widthMm + delta))}
+          min={1}
+          max={500}
+          step={1}
+          variant="desktop"
+          ariaLabel="Span mm"
+          commitMode="deferred"
+        />
+      ) : (
+        <StepperField
+          label={spanLabel}
+          unit="%"
+          value={cfg.width}
+          onChange={(v) => handlers.setSideWidth(side, v)}
+          onStep={(delta) =>
+            handlers.setSideWidth(side, Math.max(0, Math.min(100, cfg.width + delta * step)))
+          }
+          min={0}
+          max={100}
+          step={step}
+          variant="desktop"
+          ariaLabel="Span %"
+          commitMode="deferred"
+        />
+      )}
 
-      {/* %/mm toggle */}
+      {/* %/mm unit toggle for the span */}
       <button
         type="button"
         onClick={() => handlers.setSideWidthMm(side, isMmMode ? null : 30)}
-        className={`shrink-0 rounded px-1.5 py-1 text-xs font-medium transition-colors ${
-          isMmMode
-            ? 'bg-accent text-on-accent'
-            : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
-        }`}
+        className="shrink-0 rounded-md border border-stroke-subtle bg-surface-elevated px-1.5 py-1 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-hover"
       >
         {isMmMode ? 'mm' : '%'}
       </button>
 
-      {/* Height stepper */}
       {!hideDepth && (
-        <div className="flex-1 min-w-0">
-          <span className="mb-1 block text-xs text-content-tertiary">{heightLabel}</span>
-          <StepperControl
-            value={cfg.depth}
-            onChange={(v) => handlers.setSideDepth(side, v)}
-            onStep={(delta) =>
-              handlers.setSideDepth(side, Math.max(0, Math.min(100, cfg.depth + delta * step)))
-            }
-            min={0}
-            max={100}
-            step={step}
-            variant="desktop"
-            ariaLabel="Height %"
-            commitMode="deferred"
-          />
-        </div>
+        <StepperField
+          label={heightLabel}
+          unit="%"
+          value={cfg.depth}
+          onChange={(v) => handlers.setSideDepth(side, v)}
+          onStep={(delta) =>
+            handlers.setSideDepth(side, Math.max(0, Math.min(100, cfg.depth + delta * step)))
+          }
+          min={0}
+          max={100}
+          step={step}
+          variant="desktop"
+          ariaLabel="Height %"
+          commitMode="deferred"
+        />
       )}
     </div>
   );
@@ -185,68 +137,45 @@ function PositionDisclosure({
   t: (key: string) => string;
 }) {
   const isCustom = hasCustomPosition(cfg);
-  const [manualOpen, setManualOpen] = useState(false);
-  const isOpen = manualOpen || isCustom;
-
   const alignmentLabel = t(`binDesigner.alignment.${cfg.alignment}`);
   const summary = isCustom
     ? `${alignmentLabel}${cfg.offset !== 0 ? ` ${cfg.offset > 0 ? '+' : ''}${cfg.offset}mm` : ''}`
     : alignmentLabel;
 
   return (
-    <div>
-      <button
-        type="button"
-        onClick={() => setManualOpen((prev) => !prev)}
-        className="flex items-center gap-1.5 text-xs text-content-tertiary hover:text-content-secondary transition-colors"
-      >
-        <ChevronIcon open={isOpen} />
-        <span>{t('binDesigner.wallCutouts.position')}:</span>
-        <span className="text-content-secondary font-medium">{summary}</span>
-      </button>
+    <AdvancedDisclosure
+      label={`${t('binDesigner.wallCutouts.position')}:`}
+      summary={summary}
+      forceOpen={isCustom}
+    >
+      <ShapePicker
+        options={ALIGNMENT_OPTIONS.map((value) => ({
+          value,
+          label: t(`binDesigner.alignment.${value}`),
+        }))}
+        value={cfg.alignment}
+        onChange={(value) => handlers.setSideAlignment(side, value)}
+        ariaLabel={t('binDesigner.wallCutouts.position')}
+      />
 
-      {isOpen && (
-        <div className="mt-2 space-y-2 ml-3.5">
-          {/* Alignment picker */}
-          <div className="flex gap-1">
-            {ALIGNMENT_OPTIONS.map((option) => (
-              <button
-                key={option}
-                type="button"
-                onClick={() => handlers.setSideAlignment(side, option)}
-                className={`flex-1 rounded px-2 py-1 text-xs font-medium transition-colors ${
-                  cfg.alignment === option
-                    ? 'bg-accent text-on-accent'
-                    : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
-                }`}
-              >
-                {t(`binDesigner.alignment.${option}`)}
-              </button>
-            ))}
-          </div>
-
-          {/* Offset stepper */}
-          {(cfg.alignment !== 'center' || cfg.offset !== 0) && (
-            <div>
-              <span className="mb-1 block text-xs text-content-tertiary">
-                {t('binDesigner.wallCutouts.offset')}
-              </span>
-              <StepperControl
-                value={cfg.offset}
-                onChange={(v) => handlers.setSideOffset(side, v)}
-                onStep={(delta) => handlers.setSideOffset(side, cfg.offset + delta * OFFSET_STEP)}
-                min={-50}
-                max={50}
-                step={OFFSET_STEP}
-                variant="desktop"
-                ariaLabel="Offset mm"
-                commitMode="deferred"
-              />
-            </div>
-          )}
+      {(cfg.alignment !== 'center' || cfg.offset !== 0) && (
+        <div className="flex">
+          <StepperField
+            label={t('binDesigner.wallCutouts.offset')}
+            unit="mm"
+            value={cfg.offset}
+            onChange={(v) => handlers.setSideOffset(side, v)}
+            onStep={(delta) => handlers.setSideOffset(side, cfg.offset + delta * OFFSET_STEP)}
+            min={-50}
+            max={50}
+            step={OFFSET_STEP}
+            variant="desktop"
+            ariaLabel="Offset mm"
+            commitMode="deferred"
+          />
         </div>
       )}
-    </div>
+    </AdvancedDisclosure>
   );
 }
 
@@ -256,6 +185,12 @@ export function WallCutoutsSection() {
 
   const sharedSide = activeSides.length > 0 ? activeSides[0] : undefined;
   const hideDepth = walls.shape === 'scoop';
+
+  const sideStates: SideState[] = SIDE_ORDER.map((side) => ({
+    side,
+    label: t(`binDesigner.wallCutouts.${side}`),
+    active: walls[side].enabled,
+  }));
 
   return (
     <FeatureToggle
@@ -279,49 +214,20 @@ export function WallCutoutsSection() {
       }
       primaryControls={
         <div className="space-y-3">
-          {/* Shape selector */}
-          <div className="flex gap-1">
-            {SHAPE_OPTIONS.map(({ value, labelKey }) => {
-              const isActive = walls.shape === value;
-              return (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => handlers.setShape(value)}
-                  className={`flex-1 rounded px-2 py-1 text-xs font-medium transition-colors ${
-                    isActive
-                      ? 'bg-accent text-on-accent'
-                      : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
-                  }`}
-                >
-                  {t(labelKey)}
-                </button>
-              );
-            })}
-          </div>
+          {/* Shape picker */}
+          <ShapePicker
+            options={SHAPE_OPTIONS.map(({ value, labelKey }) => ({ value, label: t(labelKey) }))}
+            value={walls.shape}
+            onChange={handlers.setShape}
+            ariaLabel={t('binDesigner.wallCutouts')}
+          />
 
-          {/* Side toggle chips */}
-          <div className="flex gap-1">
-            {SIDE_ORDER.map((side) => {
-              const isActive = walls[side].enabled;
-              return (
-                <button
-                  key={side}
-                  type="button"
-                  role="switch"
-                  aria-checked={isActive}
-                  onClick={() => handlers.toggleSide(side)}
-                  className={`flex-1 rounded px-2 py-1 text-xs font-medium transition-colors ${
-                    isActive
-                      ? 'bg-accent text-on-accent'
-                      : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
-                  }`}
-                >
-                  {t(`binDesigner.wallCutouts.${side}`)}
-                </button>
-              );
-            })}
-          </div>
+          {/* Spatial side selector */}
+          <SideSelector
+            sides={sideStates}
+            onToggle={(side) => handlers.toggleSide(side)}
+            ariaLabel={t('binDesigner.wallCutouts')}
+          />
 
           {/* Controls — shown when at least one side is active */}
           {activeSides.length > 0 && (
@@ -368,7 +274,7 @@ export function WallCutoutsSection() {
               {!linked &&
                 SIDE_ORDER.filter((side) => walls[side].enabled).map((side) => (
                   <div key={side} className="space-y-2">
-                    <label className="text-xs font-medium text-content-secondary block">
+                    <label className="block text-xs font-medium text-content-secondary">
                       {t(`binDesigner.wallCutouts.${side}`)}
                     </label>
                     <SizeControls
@@ -386,26 +292,26 @@ export function WallCutoutsSection() {
             </>
           )}
 
-          {/* Density expectation hint (issue #1882) */}
+          {/* Density expectation hint (issue #1882) — contextual */}
           {showDensityHint && (
-            <p className="text-xs text-content-tertiary leading-snug">
+            <p className="text-xs leading-snug text-content-tertiary">
               {t('binDesigner.wallCutouts.densityHint')}
             </p>
           )}
 
           {/* Interior walls */}
           <div className="border-t border-stroke-subtle/50 pt-2">
-            <label className="flex items-center gap-2 text-xs text-content-secondary cursor-pointer">
+            <label className="flex cursor-pointer items-center gap-2 text-xs text-content-secondary">
               <input
                 type="checkbox"
                 checked={walls.interior.enabled}
                 onChange={() => handlers.toggleSide('interior')}
-                className="rounded border-stroke-subtle text-accent focus:ring-accent h-3.5 w-3.5"
+                className="h-3.5 w-3.5 rounded border-stroke-subtle text-accent focus:ring-accent"
               />
               {t('binDesigner.wallCutouts.interior')}
             </label>
             {walls.interior.enabled && !linked && (
-              <div className="mt-2 ml-6">
+              <div className="ml-6 mt-2">
                 <SizeControls
                   side="interior"
                   cfg={walls.interior}

--- a/src/features/bin-designer/components/panel/shared/AdvancedDisclosure.test.tsx
+++ b/src/features/bin-designer/components/panel/shared/AdvancedDisclosure.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AdvancedDisclosure } from './AdvancedDisclosure';
+
+describe('AdvancedDisclosure', () => {
+  it('hides children until expanded', () => {
+    render(
+      <AdvancedDisclosure label="Position">
+        <div>secret</div>
+      </AdvancedDisclosure>
+    );
+    expect(screen.queryByText('secret')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /Position/ }));
+    expect(screen.getByText('secret')).toBeDefined();
+  });
+
+  it('stays open when forceOpen is set', () => {
+    render(
+      <AdvancedDisclosure label="Position" forceOpen summary="Left +2mm">
+        <div>secret</div>
+      </AdvancedDisclosure>
+    );
+    expect(screen.getByText('secret')).toBeDefined();
+    expect(screen.getByText('Left +2mm')).toBeDefined();
+  });
+});

--- a/src/features/bin-designer/components/panel/shared/AdvancedDisclosure.tsx
+++ b/src/features/bin-designer/components/panel/shared/AdvancedDisclosure.tsx
@@ -1,0 +1,45 @@
+/**
+ * Collapsible "advanced controls" disclosure shared by feature panels. Folds
+ * secondary controls (cutout position/offset, handle vertical-position/count)
+ * behind a chevron summary so panels stay short, and auto-expands when the
+ * values are non-default (`forceOpen`) so customizations are never hidden.
+ */
+
+import { useState, type ReactNode } from 'react';
+import { ChevronIcon } from './icons';
+
+interface AdvancedDisclosureProps {
+  label: string;
+  /** Compact summary of the current values, shown next to the label. */
+  summary?: string;
+  /** Keep open regardless of manual state (values differ from default). */
+  forceOpen?: boolean;
+  children: ReactNode;
+}
+
+export function AdvancedDisclosure({
+  label,
+  summary,
+  forceOpen = false,
+  children,
+}: AdvancedDisclosureProps) {
+  const [manualOpen, setManualOpen] = useState(false);
+  const isOpen = manualOpen || forceOpen;
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setManualOpen((prev) => !prev)}
+        aria-expanded={isOpen}
+        className="flex items-center gap-1.5 text-xs text-content-tertiary transition-colors hover:text-content-secondary"
+      >
+        <ChevronIcon open={isOpen} />
+        <span>{label}</span>
+        {summary && <span className="font-medium text-content-secondary">{summary}</span>}
+      </button>
+
+      {isOpen && <div className="ml-3.5 mt-2 space-y-2">{children}</div>}
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/panel/shared/ShapePicker.test.tsx
+++ b/src/features/bin-designer/components/panel/shared/ShapePicker.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ShapePicker } from './ShapePicker';
+
+const OPTIONS = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Beta' },
+] as const;
+
+describe('ShapePicker', () => {
+  it('marks the selected option as pressed', () => {
+    render(<ShapePicker options={OPTIONS} value="b" onChange={() => {}} ariaLabel="Shape" />);
+    expect(screen.getByRole('button', { name: 'Beta' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('button', { name: 'Alpha' }).getAttribute('aria-pressed')).toBe(
+      'false'
+    );
+  });
+
+  it('calls onChange with the clicked value', () => {
+    const onChange = vi.fn();
+    render(<ShapePicker options={OPTIONS} value="a" onChange={onChange} ariaLabel="Shape" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Beta' }));
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+});

--- a/src/features/bin-designer/components/panel/shared/ShapePicker.tsx
+++ b/src/features/bin-designer/components/panel/shared/ShapePicker.tsx
@@ -1,0 +1,47 @@
+/**
+ * Single-select shape picker shared by feature panels (wall cutouts, handles).
+ *
+ * Renders the design-system segmented control: a recessed track whose selected
+ * segment lifts into a raised neutral pill. Pulls its visual treatment from
+ * `segmentedControlClasses` so every feature panel's shape rail reads identically.
+ */
+
+import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
+
+export interface ShapeOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface ShapePickerProps<T extends string> {
+  options: ReadonlyArray<ShapeOption<T>>;
+  value: T;
+  onChange: (value: T) => void;
+  ariaLabel: string;
+}
+
+export function ShapePicker<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+}: ShapePickerProps<T>) {
+  return (
+    <div role="group" aria-label={ariaLabel} className={SEGMENT_GROUP_CLASS}>
+      {options.map((opt) => {
+        const isActive = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            aria-pressed={isActive}
+            onClick={() => onChange(opt.value)}
+            className={`flex-1 ${getSegmentClass(isActive)}`}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/panel/shared/SideSelector.test.tsx
+++ b/src/features/bin-designer/components/panel/shared/SideSelector.test.tsx
@@ -25,6 +25,18 @@ describe('SideSelector', () => {
     expect(back.getAttribute('title')).toBe('Blocked');
   });
 
+  it('forces a disabled side to read as off even when active is passed true', () => {
+    const sides: SideState[] = [
+      { side: 'left', label: 'Left', active: false },
+      { side: 'right', label: 'Right', active: false },
+      { side: 'front', label: 'Front', active: false },
+      // Stored as active, but blocked — must announce as off.
+      { side: 'back', label: 'Back', active: true, disabled: true },
+    ];
+    render(<SideSelector sides={sides} onToggle={() => {}} ariaLabel="Sides" />);
+    expect(screen.getByRole('switch', { name: 'Back' }).getAttribute('aria-checked')).toBe('false');
+  });
+
   it('toggles a side on click', () => {
     const onToggle = vi.fn();
     render(<SideSelector sides={SIDES} onToggle={onToggle} ariaLabel="Sides" />);

--- a/src/features/bin-designer/components/panel/shared/SideSelector.test.tsx
+++ b/src/features/bin-designer/components/panel/shared/SideSelector.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SideSelector, type SideState } from './SideSelector';
+
+const SIDES: SideState[] = [
+  { side: 'left', label: 'Left', active: true },
+  { side: 'right', label: 'Right', active: false },
+  { side: 'front', label: 'Front', active: false },
+  { side: 'back', label: 'Back', active: false, disabled: true, title: 'Blocked' },
+];
+
+describe('SideSelector', () => {
+  it('renders each side as a switch reflecting its active state', () => {
+    render(<SideSelector sides={SIDES} onToggle={() => {}} ariaLabel="Sides" />);
+    expect(screen.getByRole('switch', { name: 'Left' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('switch', { name: 'Right' }).getAttribute('aria-checked')).toBe(
+      'false'
+    );
+  });
+
+  it('disables a side and exposes its tooltip', () => {
+    render(<SideSelector sides={SIDES} onToggle={() => {}} ariaLabel="Sides" />);
+    const back = screen.getByRole('switch', { name: 'Back' });
+    expect((back as HTMLButtonElement).disabled).toBe(true);
+    expect(back.getAttribute('title')).toBe('Blocked');
+  });
+
+  it('toggles a side on click', () => {
+    const onToggle = vi.fn();
+    render(<SideSelector sides={SIDES} onToggle={onToggle} ariaLabel="Sides" />);
+    fireEvent.click(screen.getByRole('switch', { name: 'Right' }));
+    expect(onToggle).toHaveBeenCalledWith('right');
+  });
+});

--- a/src/features/bin-designer/components/panel/shared/SideSelector.tsx
+++ b/src/features/bin-designer/components/panel/shared/SideSelector.tsx
@@ -47,20 +47,26 @@ const CHIP_BASE =
 export function SideSelector({ sides, onToggle, ariaLabel }: SideSelectorProps) {
   return (
     <div role="group" aria-label={ariaLabel} className="grid grid-cols-3 grid-rows-3 gap-1">
-      {sides.map(({ side, label, active, disabled, title }) => (
-        <button
-          key={side}
-          type="button"
-          role="switch"
-          aria-checked={active}
-          disabled={disabled}
-          title={title}
-          onClick={() => onToggle(side)}
-          className={`${SIDE_CELL[side]} ${CHIP_BASE} ${active ? SEGMENT_ACTIVE : SEGMENT_INACTIVE}`}
-        >
-          {label}
-        </button>
-      ))}
+      {sides.map(({ side, label, active, disabled, title }) => {
+        // A disabled side always reads as off — both visually and for ARIA —
+        // regardless of the `active` the caller passes, so a blocked side can
+        // never appear enabled.
+        const isOn = active && !disabled;
+        return (
+          <button
+            key={side}
+            type="button"
+            role="switch"
+            aria-checked={isOn}
+            disabled={disabled}
+            title={title}
+            onClick={() => onToggle(side)}
+            className={`${SIDE_CELL[side]} ${CHIP_BASE} ${isOn ? SEGMENT_ACTIVE : SEGMENT_INACTIVE}`}
+          >
+            {label}
+          </button>
+        );
+      })}
 
       {/* Center bin glyph — grounds the four sides in physical space. */}
       <div aria-hidden className="col-start-2 row-start-2 flex items-center justify-center">

--- a/src/features/bin-designer/components/panel/shared/SideSelector.tsx
+++ b/src/features/bin-designer/components/panel/shared/SideSelector.tsx
@@ -1,0 +1,71 @@
+/**
+ * Spatial side selector shared by feature panels (wall cutouts, handles).
+ *
+ * Lays the four bin walls out in their physical positions around a center bin
+ * glyph — Back on top, Front on the bottom, Left and Right flanking — so the
+ * control maps directly onto the bin you're editing instead of an abstract row
+ * of L/R/F/B letters. Each side is an independent on/off `switch`; the accent
+ * tint (SEGMENT_ACTIVE/INACTIVE) is the "this is on" signal. A side can be
+ * disabled (e.g. the back handle while a label tab occupies that wall), in which
+ * case it reads as off and shows an explanatory tooltip.
+ */
+
+import { SEGMENT_ACTIVE, SEGMENT_INACTIVE } from '@/shared/components/segmentedControlClasses';
+
+/** The four selectable walls, in their physical screen positions. */
+export type Side = 'left' | 'right' | 'front' | 'back';
+
+export interface SideState {
+  side: Side;
+  label: string;
+  active: boolean;
+  disabled?: boolean;
+  /** Tooltip shown on hover (e.g. why a side is disabled). */
+  title?: string;
+}
+
+interface SideSelectorProps {
+  /** All four sides; order is irrelevant — placement is spatial. */
+  sides: ReadonlyArray<SideState>;
+  onToggle: (side: Side) => void;
+  ariaLabel: string;
+}
+
+/** Grid placement per side around the center bin glyph. */
+const SIDE_CELL: Record<Side, string> = {
+  back: 'col-start-2 row-start-1',
+  left: 'col-start-1 row-start-2',
+  right: 'col-start-3 row-start-2',
+  front: 'col-start-2 row-start-3',
+};
+
+const CHIP_BASE =
+  'flex items-center justify-center rounded-md px-2 py-1 text-xs font-medium transition-colors ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ' +
+  'disabled:cursor-not-allowed disabled:opacity-50';
+
+export function SideSelector({ sides, onToggle, ariaLabel }: SideSelectorProps) {
+  return (
+    <div role="group" aria-label={ariaLabel} className="grid grid-cols-3 grid-rows-3 gap-1">
+      {sides.map(({ side, label, active, disabled, title }) => (
+        <button
+          key={side}
+          type="button"
+          role="switch"
+          aria-checked={active}
+          disabled={disabled}
+          title={title}
+          onClick={() => onToggle(side)}
+          className={`${SIDE_CELL[side]} ${CHIP_BASE} ${active ? SEGMENT_ACTIVE : SEGMENT_INACTIVE}`}
+        >
+          {label}
+        </button>
+      ))}
+
+      {/* Center bin glyph — grounds the four sides in physical space. */}
+      <div aria-hidden className="col-start-2 row-start-2 flex items-center justify-center">
+        <div className="h-5 w-7 rounded-sm border border-stroke-subtle bg-surface-tertiary" />
+      </div>
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/panel/shared/StepperField.test.tsx
+++ b/src/features/bin-designer/components/panel/shared/StepperField.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StepperField } from './StepperField';
+
+describe('StepperField', () => {
+  it('renders the label with an inline unit', () => {
+    render(
+      <StepperField
+        label="Height"
+        unit="mm"
+        value={5}
+        onStep={() => {}}
+        min={0}
+        max={10}
+        ariaLabel="Height"
+      />
+    );
+    expect(screen.getByText('Height')).toBeDefined();
+    expect(screen.getByText('(mm)')).toBeDefined();
+  });
+
+  it('omits the unit suffix when no unit is given', () => {
+    render(
+      <StepperField label="Count" value={1} onStep={() => {}} min={1} max={5} ariaLabel="Count" />
+    );
+    expect(screen.getByText('Count')).toBeDefined();
+    expect(screen.queryByText(/\(/)).toBeNull();
+  });
+});

--- a/src/features/bin-designer/components/panel/shared/StepperField.tsx
+++ b/src/features/bin-designer/components/panel/shared/StepperField.tsx
@@ -1,0 +1,27 @@
+/**
+ * Labelled stepper field shared by feature panels. Standardizes the label +
+ * inline-unit treatment (e.g. "Height (mm)") above a StepperControl so every
+ * numeric field across the bin-designer panels reads identically and is
+ * self-documenting about its unit.
+ */
+
+import type { ComponentProps } from 'react';
+import { StepperControl } from '@/shared/components/StepperControl';
+
+type StepperFieldProps = ComponentProps<typeof StepperControl> & {
+  label: string;
+  /** Unit rendered inline in the label, e.g. '%' or 'mm'. */
+  unit?: string;
+};
+
+export function StepperField({ label, unit, ...stepper }: StepperFieldProps) {
+  return (
+    <div className="min-w-0 flex-1">
+      <span className="mb-1 block text-xs text-content-tertiary">
+        {label}
+        {unit ? <span className="text-content-tertiary/70">{` (${unit})`}</span> : null}
+      </span>
+      <StepperControl {...stepper} />
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/panel/shared/icons.test.tsx
+++ b/src/features/bin-designer/components/panel/shared/icons.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { LinkIcon, ChevronIcon } from './icons';
+
+describe('panel icons', () => {
+  it('rotates the chevron when open', () => {
+    const { container } = render(<ChevronIcon open />);
+    expect(container.querySelector('svg')?.getAttribute('class')).toContain('rotate-90');
+  });
+
+  it('renders the link icon in both states', () => {
+    const linked = render(<LinkIcon linked />);
+    expect(linked.container.querySelector('svg')).not.toBeNull();
+    const unlinked = render(<LinkIcon linked={false} />);
+    // Broken-link state adds the strike-through line.
+    expect(unlinked.container.querySelector('line')).not.toBeNull();
+  });
+});

--- a/src/features/bin-designer/components/panel/shared/icons.tsx
+++ b/src/features/bin-designer/components/panel/shared/icons.tsx
@@ -1,0 +1,55 @@
+/**
+ * Shared inline icons for bin-designer feature panels, so the wall-cutout and
+ * handle sections (and any future feature section) render identical glyphs.
+ */
+
+/** Chain-link icon (12×12) — toggles between linked and broken-link states. */
+export function LinkIcon({ linked }: { linked: boolean }) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="flex-shrink-0"
+      aria-hidden
+    >
+      {linked ? (
+        <>
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+        </>
+      ) : (
+        <>
+          <path d="M18.84 12.25l1.72-1.71a5 5 0 0 0-7.07-7.07l-3 3a5 5 0 0 0 .12 7.19" />
+          <path d="M5.16 11.75l-1.72 1.71a5 5 0 0 0 7.07 7.07l3-3a5 5 0 0 0-.12-7.19" />
+          <line x1="2" y1="2" x2="22" y2="22" />
+        </>
+      )}
+    </svg>
+  );
+}
+
+/** Chevron icon (8×8) — rotates 90° to point down when open. */
+export function ChevronIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="8"
+      height="8"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`flex-shrink-0 transition-transform ${open ? 'rotate-90' : ''}`}
+      aria-hidden
+    >
+      <polyline points="9 18 15 12 9 6" />
+    </svg>
+  );
+}

--- a/src/features/bin-designer/components/panel/shared/index.ts
+++ b/src/features/bin-designer/components/panel/shared/index.ts
@@ -1,0 +1,5 @@
+export { ShapePicker, type ShapeOption } from './ShapePicker';
+export { SideSelector, type Side, type SideState } from './SideSelector';
+export { StepperField } from './StepperField';
+export { AdvancedDisclosure } from './AdvancedDisclosure';
+export { LinkIcon, ChevronIcon } from './icons';


### PR DESCRIPTION
## What & why

The wall-cutout and handle panels in the bin designer had drifted apart visually — the handle panel was recently modernized to the design-system segmented-control look, while the wall-cutout panel still used older hand-rolled buttons. This brings both to one shared standard and does a UX polish pass.

Both panels now render from a single set of shared primitives, so they read identically and can't drift apart again.

## Changes

**New shared primitives** (`src/features/bin-designer/components/panel/shared/`, each with sibling tests):
- **`ShapePicker`** — design-system segmented control (recessed track + raised pill); replaces the wall-cutout panel's custom buttons
- **`SideSelector`** — new **spatial cross** layout: Back top, Left/Right flanking a center bin glyph, Front bottom — replaces the abstract flat L/R/F/B row. Supports per-side disabled state (e.g. the back handle while a label tab occupies that wall)
- **`StepperField`** — standardized label with inline unit, e.g. `Height (mm)` / `Span (%)`
- **`AdvancedDisclosure`** — collapsible secondary controls (cutout position/offset; handle vertical-position/count), auto-expanding when values are non-default
- shared `LinkIcon` / `ChevronIcon` (previously duplicated per panel)

**Behavior parity**
- Handle linked-state now persists across sessions via a new `handlesLinked` setting (was ephemeral `useState`), matching the wall-cutout panel
- Help text shown contextually rather than always-on

## Verification
- `typecheck`, `lint`, `check:i18n` (all locales) green
- Full Vitest suite passes (incl. new primitive tests)
- Playwright visual spot-check confirmed both panels render with identical layout

Handle-specific controls (physical-dimension readout, corner radius, chamfer, support note) are genuine functional differences and were intentionally preserved.