### PR TITLE
fix(bin-designer): make panel buttons read as buttons

### DIFF
--- a/src/features/bin-designer/components/panel/shared/SideSelector.tsx
+++ b/src/features/bin-designer/components/panel/shared/SideSelector.tsx
@@ -4,13 +4,12 @@
  * Lays the four bin walls out in their physical positions around a center bin
  * glyph — Back on top, Front on the bottom, Left and Right flanking — so the
  * control maps directly onto the bin you're editing instead of an abstract row
- * of L/R/F/B letters. Each side is an independent on/off `switch`; the accent
- * tint (SEGMENT_ACTIVE/INACTIVE) is the "this is on" signal. A side can be
- * disabled (e.g. the back handle while a label tab occupies that wall), in which
- * case it reads as off and shows an explanatory tooltip.
+ * of L/R/F/B letters. Each side is an independent on/off `switch` rendered as a
+ * solid button: a filled accent fill when on, a bordered surface chip when off,
+ * so every side reads unmistakably as a clickable button. A side can be disabled
+ * (e.g. the back handle while a label tab occupies that wall), in which case it
+ * reads as off and shows an explanatory tooltip.
  */
-
-import { SEGMENT_ACTIVE, SEGMENT_INACTIVE } from '@/shared/components/segmentedControlClasses';
 
 /** The four selectable walls, in their physical screen positions. */
 export type Side = 'left' | 'right' | 'front' | 'back';
@@ -40,9 +39,15 @@ const SIDE_CELL: Record<Side, string> = {
 };
 
 const CHIP_BASE =
-  'flex items-center justify-center rounded-md px-2 py-1 text-xs font-medium transition-colors ' +
+  'flex items-center justify-center rounded-md border px-2 py-1 text-xs font-medium transition-colors ' +
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ' +
   'disabled:cursor-not-allowed disabled:opacity-50';
+
+/** Filled accent button when on. */
+const CHIP_ON = 'border-accent bg-accent text-on-accent';
+/** Bordered surface button when off — clearly a button, clearly not selected. */
+const CHIP_OFF =
+  'border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover hover:text-content';
 
 export function SideSelector({ sides, onToggle, ariaLabel }: SideSelectorProps) {
   return (
@@ -61,7 +66,7 @@ export function SideSelector({ sides, onToggle, ariaLabel }: SideSelectorProps) 
             disabled={disabled}
             title={title}
             onClick={() => onToggle(side)}
-            className={`${SIDE_CELL[side]} ${CHIP_BASE} ${isOn ? SEGMENT_ACTIVE : SEGMENT_INACTIVE}`}
+            className={`${SIDE_CELL[side]} ${CHIP_BASE} ${isOn ? CHIP_ON : CHIP_OFF}`}
           >
             {label}
           </button>

--- a/src/shared/components/segmentedControlClasses.test.ts
+++ b/src/shared/components/segmentedControlClasses.test.ts
@@ -49,9 +49,10 @@ describe('getSegmentClass', () => {
     expect(SEGMENT_INACTIVE).toContain('text-content-tertiary');
   });
 
-  it('renders the group container as a recessed track', () => {
+  it('renders the group container as a bordered track (matches ToolSwitcher)', () => {
     expect(SEGMENT_GROUP_CLASS).toContain('flex');
-    expect(SEGMENT_GROUP_CLASS).toContain('bg-surface-tertiary');
+    expect(SEGMENT_GROUP_CLASS).toContain('border');
+    expect(SEGMENT_GROUP_CLASS).toContain('bg-surface');
     expect(SEGMENT_GROUP_CLASS).toContain('rounded-lg');
     expect(SEGMENT_GROUP_CLASS).toContain('p-0.5');
   });

--- a/src/shared/components/segmentedControlClasses.ts
+++ b/src/shared/components/segmentedControlClasses.ts
@@ -6,8 +6,8 @@
  * Two distinct visual systems live here:
  *
  * 1. Single-select segmentation (`SEGMENT_GROUP_CLASS` + `getSegmentClass`):
- *    a recessed track holding segments, where the selected segment is a raised
- *    neutral pill. Matches the design-system `SegmentedControl` so these read
+ *    a bordered track holding segments, where the selected segment is a raised
+ *    neutral pill. Matches the global-nav ToolSwitcher so these read
  *    unmistakably as segmented controls rather than a loose row of chips.
  *
  * 2. Independent boolean toggles (`SEGMENT_ACTIVE` / `SEGMENT_INACTIVE`):
@@ -45,8 +45,13 @@ export const SEGMENT_ACTIVE = 'bg-accent/15 text-accent ring-1 ring-accent/40';
 export const SEGMENT_INACTIVE =
   'text-content-tertiary hover:bg-surface-hover hover:text-content-secondary';
 
-/** Container class for a single-select segment group: the recessed track. */
-export const SEGMENT_GROUP_CLASS = 'flex gap-0.5 rounded-lg bg-surface-tertiary p-0.5';
+/**
+ * Container class for a single-select segment group: a bordered track that
+ * reads unmistakably as a segmented control. Matches the global-nav
+ * ToolSwitcher (bordered `bg-surface` track + raised `bg-surface-elevated`
+ * active pill) so the two look like the same component.
+ */
+export const SEGMENT_GROUP_CLASS = 'flex rounded-lg border border-stroke-subtle bg-surface p-0.5';
 
 const SIZE_CLASS: Record<SegmentSize, string> = {
   icon: 'p-1 text-[11px]',


### PR DESCRIPTION
Follow-up to #2032. That PR unified the wall-cutout and handle panels but regressed button affordance — the segmented controls sat on a borderless track and the spatial side selector's off-state chips rendered as bare text, making it hard to tell what was clickable.

## Fixes

- **Segmented controls now match the global-nav `ToolSwitcher`.** `SEGMENT_GROUP_CLASS` becomes a bordered `bg-surface` track with the active segment raised to `bg-surface-elevated shadow-sm` — the same look as the tool switcher in the header. This applies to every bin-designer segmented control (shape pickers, label-tab edge/alignment/support, thickness selector, cutout inspector selectors), so they all read as real segmented controls.
- **Spatial side selector now uses solid buttons.** Each side is filled accent when on and a bordered surface chip when off, instead of accent-tint-on-transparent — so off sides no longer look like floating text.

## Verification
- typecheck / lint / affected unit tests green
- Playwright visual spot-check of both panels (wall cutouts + handles) confirmed clear button affordance and consistency with the global nav

| Before (#2032) | After |
| --- | --- |
| off sides = bare text; flat borderless segmented track | every side a bordered/filled button; bordered segmented track matching ToolSwitcher |