### PR TITLE
feat: match manifold draft edge lines to occt-wasm

### DIFF
--- a/docs/superpowers/plans/2026-06-05-manifold-draft-edge-lines.md
+++ b/docs/superpowers/plans/2026-06-05-manifold-draft-edge-lines.md
@@ -1,0 +1,932 @@
+# Manifold Draft Edge Lines Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the manifold draft's edge lines look close enough to the occt-wasm final that switching draft→final is hard to notice.
+
+**Architecture:** Replace manifold's full-triangle-wireframe `meshEdges()` with a **dihedral crease-edge extractor** that runs in the generation worker (manifold branch only), so drafts ship clean edges the client renders directly — no more main-thread `EdgesGeometry` per draft tick. A modest bump to the manifold draft's circular tessellation makes curve rims read round, and the bin-designer renderer stops suppressing draft edges and softens the finalize swap with a single fade (no two-layer crossfade).
+
+**Tech Stack:** TypeScript, brepjs (manifold + occt-wasm kernels), Three.js / React Three Fiber, Vitest, Zustand.
+
+**Environment note:** This repo requires **Node 22** for pnpm and the husky pre-commit hooks. Before committing, run `nvm use 22` (default Node 20 breaks pnpm). If a commit's pre-commit hook fails with a `node:sqlite`/pnpm error, you're on the wrong Node version.
+
+**Background (read before starting):** The full design rationale — including why the originally-considered `faceId`/face-boundary approach is broken and why the crossfade was dropped — is in `docs/superpowers/specs/2026-06-05-manifold-draft-edges-design.md`. Read it first.
+
+**Key invariant:** The manifold draft's per-facet circular angle MUST stay below the crease threshold (35°). If a curve's facet step exceeds the threshold, dihedral extraction emits a line at every facet → longitudinal wireframe noise. Task 1 encodes this coupling as a guarded constant.
+
+---
+
+## File Structure
+
+| File                                                                                    | Responsibility                                                                 | Task |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ---- |
+| `src/shared/constants/tessellation.ts` (new)                                            | Shared crease threshold + draft circular angle, with the coupling invariant    | 1    |
+| `src/shared/constants/tessellation.test.ts` (new)                                       | Lock the constants + invariant                                                 | 1    |
+| `src/shared/components/preview/useMeshGeometry.ts` (modify)                             | Use the shared crease constant instead of local literals                       | 1    |
+| `src/features/generation/worker/generators/utils/creaseEdges.ts` (new)                  | Pure dihedral crease-edge extractor (weld → adjacency → threshold)             | 2    |
+| `src/features/generation/worker/generators/utils/creaseEdges.test.ts` (new)             | Unit tests for the extractor                                                   | 2    |
+| `src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts` (modify) | Branch to `creaseEdges` on the build-time (manifold) kernel, for body + socket | 3    |
+| `src/features/bin-designer/components/preview/BinMesh/edgeFade.ts` (new)                | Pure "which fade to start" decision helper                                     | 4    |
+| `src/features/bin-designer/components/preview/BinMesh/edgeFade.test.ts` (new)           | Unit tests for the fade decision                                               | 4    |
+| `src/features/bin-designer/components/preview/BinMesh/BinMesh.tsx` (modify)             | Stop suppressing draft edges; finalize-aware single fade                       | 4    |
+| `src/features/generation/worker/wasmInstantiator.ts` (modify)                           | Bump manifold draft circular angle                                             | 5    |
+
+---
+
+## Task 1: Shared crease/tessellation constants
+
+**Files:**
+
+- Create: `src/shared/constants/tessellation.ts`
+- Test: `src/shared/constants/tessellation.test.ts`
+- Modify: `src/shared/components/preview/useMeshGeometry.ts:19` and `:103`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/shared/constants/tessellation.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { CREASE_ANGLE_DEG, CREASE_ANGLE_RAD, DRAFT_MIN_CIRCULAR_ANGLE_DEG } from './tessellation';
+
+describe('tessellation constants', () => {
+  it('exposes the crease threshold in degrees and radians', () => {
+    expect(CREASE_ANGLE_DEG).toBe(35);
+    expect(CREASE_ANGLE_RAD).toBeCloseTo((35 * Math.PI) / 180, 10);
+  });
+
+  it('keeps the draft circular angle below the crease threshold', () => {
+    // Invariant: a draft facet step at/above the crease angle would make the
+    // worker emit a line at every curve facet (longitudinal wireframe noise).
+    expect(DRAFT_MIN_CIRCULAR_ANGLE_DEG).toBeLessThan(CREASE_ANGLE_DEG);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test:run -- src/shared/constants/tessellation.test.ts`
+Expected: FAIL — cannot resolve `./tessellation`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/shared/constants/tessellation.ts`:
+
+```typescript
+/**
+ * Tessellation / edge constants shared by the generation worker (draft crease
+ * edge extraction) and the client renderer (normal splitting + edge fallback).
+ *
+ * COUPLING: the manifold draft tessellates curves into flat facets. The worker
+ * extracts edges wherever the angle between adjacent face normals exceeds
+ * CREASE_ANGLE_DEG. So the draft's per-facet circular angle MUST stay below
+ * CREASE_ANGLE_DEG — otherwise every curve facet becomes an edge (longitudinal
+ * wireframe noise). Keep DRAFT_MIN_CIRCULAR_ANGLE_DEG comfortably under it.
+ */
+
+/** Dihedral/crease threshold (degrees). Catches lip chamfers (~45°) and curve
+ *  rims (90°) while leaving sub-threshold facets smooth. */
+export const CREASE_ANGLE_DEG = 35;
+
+/** Same threshold in radians (for THREE normal splitting). */
+export const CREASE_ANGLE_RAD = (CREASE_ANGLE_DEG * Math.PI) / 180;
+
+/** Manifold draft min circular angle (degrees per facet). Lower = rounder
+ *  curves, slower draft. MUST stay below CREASE_ANGLE_DEG (see COUPLING). */
+export const DRAFT_MIN_CIRCULAR_ANGLE_DEG = 20;
+
+// Cheap load-time guard so a future edit can't silently reintroduce curve noise.
+if (DRAFT_MIN_CIRCULAR_ANGLE_DEG >= CREASE_ANGLE_DEG) {
+  throw new Error(
+    `DRAFT_MIN_CIRCULAR_ANGLE_DEG (${DRAFT_MIN_CIRCULAR_ANGLE_DEG}) must be < CREASE_ANGLE_DEG (${CREASE_ANGLE_DEG})`
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test:run -- src/shared/constants/tessellation.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Refactor `useMeshGeometry.ts` to use the shared constant**
+
+In `src/shared/components/preview/useMeshGeometry.ts`:
+
+Replace the local constant (line ~19):
+
+```typescript
+const CREASE_ANGLE = (35 * Math.PI) / 180;
+```
+
+with an import at the top of the file (add near the other imports, after line 11):
+
+```typescript
+import { CREASE_ANGLE_DEG, CREASE_ANGLE_RAD } from '@/shared/constants/tessellation';
+```
+
+and update the two usages:
+
+- Line ~70: `toCreasedNormals(geo, CREASE_ANGLE)` → `toCreasedNormals(geo, CREASE_ANGLE_RAD)`
+- Lines ~103-104: replace
+
+```typescript
+const CREASE_ANGLE_DEGREES = 35;
+return new THREE.EdgesGeometry(geometry, CREASE_ANGLE_DEGREES);
+```
+
+with
+
+```typescript
+return new THREE.EdgesGeometry(geometry, CREASE_ANGLE_DEG);
+```
+
+(Delete the now-unused local `CREASE_ANGLE` declaration.)
+
+- [ ] **Step 6: Verify the renderer hook still typechecks and its tests pass**
+
+Run: `pnpm run typecheck`
+Expected: no errors.
+
+Run: `pnpm run test:run -- src/features/bin-designer/components/preview/BinMesh/BinMesh.test.tsx`
+Expected: PASS (existing tests still green — the EdgesGeometry mock ignores the angle arg).
+
+- [ ] **Step 7: Commit**
+
+```bash
+nvm use 22
+git add src/shared/constants/tessellation.ts src/shared/constants/tessellation.test.ts src/shared/components/preview/useMeshGeometry.ts
+git commit -m "feat(tessellation): shared crease-angle constant with draft-angle invariant"
+```
+
+---
+
+## Task 2: Dihedral crease-edge extractor (pure util)
+
+**Files:**
+
+- Create: `src/features/generation/worker/generators/utils/creaseEdges.ts`
+- Test: `src/features/generation/worker/generators/utils/creaseEdges.test.ts`
+
+This is pure array math — no brepjs/WASM, no special vitest environment. It welds vertices by quantized position (manifold can emit split vertices at face boundaries, so index-only adjacency is unsafe), builds an edge→adjacent-triangles map, and emits a segment where adjacent face normals diverge past the threshold (plus naked boundary edges).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/generation/worker/generators/utils/creaseEdges.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { creaseEdges } from './creaseEdges';
+
+/** Count line segments (each segment = 2 points = 6 floats). */
+const segCount = (out: Float32Array): number => out.length / 6;
+
+describe('creaseEdges', () => {
+  it('returns empty for empty input', () => {
+    const out = creaseEdges({ vertices: new Float32Array(0), triangles: new Uint32Array(0) });
+    expect(out.length).toBe(0);
+  });
+
+  it('emits only boundary edges for a flat (coplanar) quad', () => {
+    // Two coplanar triangles sharing the diagonal. The diagonal is coplanar
+    // (no crease) → not emitted; the 4 outer edges are naked boundaries.
+    const vertices = new Float32Array([
+      0,
+      0,
+      0, // 0
+      1,
+      0,
+      0, // 1
+      1,
+      1,
+      0, // 2
+      0,
+      1,
+      0, // 3
+    ]);
+    const triangles = new Uint32Array([0, 1, 2, 0, 2, 3]);
+    const out = creaseEdges({ vertices, triangles });
+    expect(segCount(out)).toBe(4); // 4 boundary edges, shared diagonal suppressed
+  });
+
+  it('emits the ridge of a 90° fold (above threshold)', () => {
+    // Two triangles meeting at a 90° fold along the shared edge (0,0,0)-(1,0,0).
+    const vertices = new Float32Array([
+      0,
+      0,
+      0, // 0  shared
+      1,
+      0,
+      0, // 1  shared
+      0,
+      1,
+      0, // 2  triangle A (in XY plane)
+      0,
+      0,
+      1, // 3  triangle B (in XZ plane)
+    ]);
+    const triangles = new Uint32Array([0, 1, 2, 0, 1, 3]);
+    const out = creaseEdges({ vertices, triangles });
+    // 1 ridge crease + 4 naked boundary edges = 5 segments.
+    expect(segCount(out)).toBe(5);
+  });
+
+  it('does NOT emit a shared edge folded below the threshold', () => {
+    // ~15° fold (< 35°): represents a curve facet that must stay smooth.
+    const angle = (15 * Math.PI) / 180;
+    const vertices = new Float32Array([
+      0,
+      0,
+      0, // 0 shared
+      1,
+      0,
+      0, // 1 shared
+      0,
+      1,
+      0, // 2 triangle A (flat)
+      0,
+      Math.cos(angle),
+      Math.sin(angle), // 3 triangle B tilted 15°
+    ]);
+    const triangles = new Uint32Array([0, 1, 2, 0, 1, 3]);
+    const out = creaseEdges({ vertices, triangles });
+    // Only the 4 boundary edges; the sub-threshold fold is suppressed.
+    expect(segCount(out)).toBe(4);
+  });
+
+  it('detects creases across SPLIT (duplicated-position) vertices', () => {
+    // Manifold may give each triangle its own vertex copies. The shared 90°
+    // ridge must still be found by position-welding, not index identity.
+    const vertices = new Float32Array([
+      // Triangle A: indices 0,1,2
+      0, 0, 0, 1, 0, 0, 0, 1, 0,
+      // Triangle B: indices 3,4,5 — re-uses positions of 0 and 1 as 3 and 4
+      0, 0, 0, 1, 0, 0, 0, 0, 1,
+    ]);
+    const triangles = new Uint32Array([0, 1, 2, 3, 4, 5]);
+    const out = creaseEdges({ vertices, triangles });
+    // After welding, the (0,0,0)-(1,0,0) edge is shared at 90° → 1 ridge,
+    // plus 4 boundary edges = 5.
+    expect(segCount(out)).toBe(5);
+  });
+
+  it('produces finite coordinates only', () => {
+    const vertices = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1]);
+    const triangles = new Uint32Array([0, 1, 2, 0, 1, 3]);
+    const out = creaseEdges({ vertices, triangles });
+    for (const n of out) expect(Number.isFinite(n)).toBe(true);
+  });
+
+  it('emits exactly 12 edges for a unit cube', () => {
+    // 8 corners, 12 triangles (2 per face). Each true cube edge is shared by
+    // two perpendicular faces (90°) → 12 creases; face diagonals are coplanar.
+    const v = new Float32Array([
+      0,
+      0,
+      0, // 0
+      1,
+      0,
+      0, // 1
+      1,
+      1,
+      0, // 2
+      0,
+      1,
+      0, // 3
+      0,
+      0,
+      1, // 4
+      1,
+      0,
+      1, // 5
+      1,
+      1,
+      1, // 6
+      0,
+      1,
+      1, // 7
+    ]);
+    const t = new Uint32Array([
+      0,
+      2,
+      1,
+      0,
+      3,
+      2, // bottom (z=0)
+      4,
+      5,
+      6,
+      4,
+      6,
+      7, // top (z=1)
+      0,
+      1,
+      5,
+      0,
+      5,
+      4, // front (y=0)
+      1,
+      2,
+      6,
+      1,
+      6,
+      5, // right (x=1)
+      2,
+      3,
+      7,
+      2,
+      7,
+      6, // back (y=1)
+      3,
+      0,
+      4,
+      3,
+      4,
+      7, // left (x=0)
+    ]);
+    const out = creaseEdges({ vertices: v, triangles: t });
+    expect(segCount(out)).toBe(12);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test:run -- src/features/generation/worker/generators/utils/creaseEdges.test.ts`
+Expected: FAIL — cannot resolve `./creaseEdges`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/features/generation/worker/generators/utils/creaseEdges.ts`:
+
+```typescript
+/**
+ * Dihedral crease-edge extractor for build-time (manifold) draft meshes.
+ *
+ * Manifold has no B-rep topology and its meshEdges() returns the full triangle
+ * wireframe. This recovers OCCT-style feature edges from the mesh alone:
+ * weld vertices by position (manifold may split them at face boundaries), then
+ * emit a segment wherever two adjacent triangles' face normals diverge past the
+ * crease threshold — plus any naked boundary edge. Sub-threshold folds (curve
+ * facets) stay smooth, so curves render as clean rims, not wireframe.
+ */
+
+import { CREASE_ANGLE_DEG } from '@/shared/constants/tessellation';
+
+export interface CreaseEdgeMesh {
+  readonly vertices: ArrayLike<number>;
+  readonly triangles: ArrayLike<number>;
+}
+
+/** Weld resolution: 1e-4 model units (sub-micron at mm scale). */
+const WELD_SCALE = 1e4;
+
+export function creaseEdges(
+  mesh: CreaseEdgeMesh,
+  thresholdDeg: number = CREASE_ANGLE_DEG
+): Float32Array {
+  const { vertices, triangles } = mesh;
+  const triCount = Math.floor(triangles.length / 3);
+  if (triCount === 0) return new Float32Array(0);
+
+  const vertCount = Math.floor(vertices.length / 3);
+
+  // 1. Weld vertices by quantized position → stable welded id per position.
+  const weld = new Map<string, number>();
+  const remap = new Int32Array(vertCount);
+  const idToVert: number[] = [];
+  const q = (n: number): number => Math.round(n * WELD_SCALE);
+  for (let v = 0; v < vertCount; v++) {
+    const key = `${q(vertices[v * 3])},${q(vertices[v * 3 + 1])},${q(vertices[v * 3 + 2])}`;
+    let id = weld.get(key);
+    if (id === undefined) {
+      id = weld.size;
+      weld.set(key, id);
+      idToVert[id] = v;
+    }
+    remap[v] = id;
+  }
+
+  // 2. Per-triangle face normals from original positions.
+  const faceNormals = new Float32Array(triCount * 3);
+  for (let t = 0; t < triCount; t++) {
+    const a = triangles[t * 3];
+    const b = triangles[t * 3 + 1];
+    const c = triangles[t * 3 + 2];
+    const ax = vertices[a * 3];
+    const ay = vertices[a * 3 + 1];
+    const az = vertices[a * 3 + 2];
+    const ux = vertices[b * 3] - ax;
+    const uy = vertices[b * 3 + 1] - ay;
+    const uz = vertices[b * 3 + 2] - az;
+    const vx = vertices[c * 3] - ax;
+    const vy = vertices[c * 3 + 1] - ay;
+    const vz = vertices[c * 3 + 2] - az;
+    const nx = uy * vz - uz * vy;
+    const ny = uz * vx - ux * vz;
+    const nz = ux * vy - uy * vx;
+    const len = Math.hypot(nx, ny, nz) || 1;
+    faceNormals[t * 3] = nx / len;
+    faceNormals[t * 3 + 1] = ny / len;
+    faceNormals[t * 3 + 2] = nz / len;
+  }
+
+  // 3. Edge (welded id pair) → adjacent triangle indices.
+  const edgeMap = new Map<number, number[]>();
+  const edgeKey = (i: number, j: number): number => {
+    const lo = i < j ? i : j;
+    const hi = i < j ? j : i;
+    return lo * weld.size + hi;
+  };
+  const addEdge = (i: number, j: number, t: number): void => {
+    const key = edgeKey(i, j);
+    const arr = edgeMap.get(key);
+    if (arr) arr.push(t);
+    else edgeMap.set(key, [t]);
+  };
+  for (let t = 0; t < triCount; t++) {
+    const a = remap[triangles[t * 3]];
+    const b = remap[triangles[t * 3 + 1]];
+    const c = remap[triangles[t * 3 + 2]];
+    addEdge(a, b, t);
+    addEdge(b, c, t);
+    addEdge(c, a, t);
+  }
+
+  // 4. Emit creases (dihedral past threshold) and naked boundary edges.
+  const cosThreshold = Math.cos((thresholdDeg * Math.PI) / 180);
+  const size = weld.size;
+  const out: number[] = [];
+  const pushVert = (id: number): void => {
+    const v = idToVert[id];
+    out.push(vertices[v * 3], vertices[v * 3 + 1], vertices[v * 3 + 2]);
+  };
+  for (const [key, tris] of edgeMap) {
+    let emit = false;
+    if (tris.length === 1) {
+      emit = true; // naked boundary edge
+    } else {
+      for (let i = 0; i < tris.length && !emit; i++) {
+        for (let j = i + 1; j < tris.length && !emit; j++) {
+          const ti = tris[i] * 3;
+          const tj = tris[j] * 3;
+          const dot =
+            faceNormals[ti] * faceNormals[tj] +
+            faceNormals[ti + 1] * faceNormals[tj + 1] +
+            faceNormals[ti + 2] * faceNormals[tj + 2];
+          if (dot < cosThreshold) emit = true;
+        }
+      }
+    }
+    if (emit) {
+      pushVert(Math.floor(key / size));
+      pushVert(key % size);
+    }
+  }
+
+  return new Float32Array(out);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test:run -- src/features/generation/worker/generators/utils/creaseEdges.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+nvm use 22
+git add src/features/generation/worker/generators/utils/creaseEdges.ts src/features/generation/worker/generators/utils/creaseEdges.test.ts
+git commit -m "feat(generation): dihedral crease-edge extractor for draft meshes"
+```
+
+---
+
+## Task 3: Wire crease edges into the tessellate stage (manifold only)
+
+**Files:**
+
+- Modify: `src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts`
+
+The OCCT (`extract-time`) path keeps using brepjs `meshEdges` (its native B-rep extractor is better). Only the build-time (manifold) draft swaps to `creaseEdges`, for both the body mesh and the deferred socket mesh.
+
+- [ ] **Step 1: Add imports**
+
+In `tessellateStage.ts`, update the brepjs import (line 11) and add the new imports:
+
+```typescript
+import { mesh, meshEdges, getKernelCapabilities } from 'brepjs';
+```
+
+Add below the existing relative imports (after line 15):
+
+```typescript
+import { creaseEdges } from '../../utils/creaseEdges';
+```
+
+- [ ] **Step 2: Branch the body-edge computation**
+
+Replace the current body-edge block (lines ~37-42):
+
+```typescript
+const edgeAngular = angularTolerance * 0.5;
+let shapeMesh = mesh(solid, { tolerance, angularTolerance });
+let edgeLines: ArrayLike<number> = meshEdges(solid, {
+  tolerance,
+  angularTolerance: edgeAngular,
+}).lines;
+```
+
+with:
+
+```typescript
+const edgeAngular = angularTolerance * 0.5;
+let shapeMesh = mesh(solid, { tolerance, angularTolerance });
+
+// Build-time kernels (manifold draft) have no B-rep topology, so their
+// meshEdges() returns the full triangle wireframe. Recover clean feature
+// edges from the mesh via dihedral crease detection. Extract-time kernels
+// (occt) keep their native analytic edge extractor.
+const buildTime = getKernelCapabilities().tessellationModel === 'build-time';
+let edgeLines: ArrayLike<number> = buildTime
+  ? creaseEdges(shapeMesh)
+  : meshEdges(solid, { tolerance, angularTolerance: edgeAngular }).lines;
+```
+
+- [ ] **Step 3: Branch the socket-edge computation**
+
+Replace the deferred-socket edge line inside the `if (deferredSolid)` block (line ~53):
+
+```typescript
+const socketEdges = meshEdges(deferredSolid, { tolerance, angularTolerance: edgeAngular });
+edgeLines = concatFloat32(edgeLines, socketEdges.lines);
+```
+
+with:
+
+```typescript
+const socketEdges = buildTime
+  ? creaseEdges(socketMesh)
+  : meshEdges(deferredSolid, { tolerance, angularTolerance: edgeAngular }).lines;
+edgeLines = concatFloat32(edgeLines, socketEdges);
+```
+
+Note: `socketMesh` is already computed on the line above (`const socketMesh = mesh(deferredSolid, { tolerance, angularTolerance });`). `concatFloat32` accepts `ArrayLike<number>`, so passing the `creaseEdges` `Float32Array` or the `.lines` array both work.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm run typecheck`
+Expected: no errors. (If brepjs's `getKernelCapabilities` is reported missing, confirm the export with `rg "getKernelCapabilities" node_modules/.pnpm/brepjs@*/node_modules/brepjs/dist/index.d.ts` — it is re-exported from `./kernel/index.js`.)
+
+- [ ] **Step 5: Run the generator scenario tests (occt path must stay green)**
+
+Run: `pnpm run test:run -- src/features/generation/worker/generators/binGenerator.scenario`
+Expected: PASS. These run under the occt kernel (`extract-time`), exercising the unchanged branch — they confirm the refactor didn't disturb the final path. Also verify edge output is non-empty and finite for a representative bin (the scenario assertions already cover geometry sanity; if any edge-specific assertion exists, it should still pass).
+
+- [ ] **Step 6: Commit**
+
+```bash
+nvm use 22
+git add src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
+git commit -m "feat(generation): use crease edges for manifold draft tessellation"
+```
+
+---
+
+## Task 4: Render draft edges + finalize-aware fade (no crossfade)
+
+**Files:**
+
+- Create: `src/features/bin-designer/components/preview/BinMesh/edgeFade.ts`
+- Test: `src/features/bin-designer/components/preview/BinMesh/edgeFade.test.ts`
+- Modify: `src/features/bin-designer/components/preview/BinMesh/BinMesh.tsx`
+
+Two changes: (1) stop suppressing draft edges so the worker's clean crease edges render directly; (2) replace the "edges first appeared" fade trigger with a small decision helper that handles both first-appearance (fade from 0) and the draft→final finalize (gentle fade from a floor, so the already-visible edges never blink to invisible).
+
+- [ ] **Step 1: Write the failing test for the fade decision**
+
+Create `src/features/bin-designer/components/preview/BinMesh/edgeFade.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { nextEdgeFade } from './edgeFade';
+
+describe('nextEdgeFade', () => {
+  it('fades in when edges first appear from nothing', () => {
+    expect(
+      nextEdgeFade({ prevHadEdges: false, hasEdges: true, prevIsDraft: false, isDraft: false })
+    ).toBe('appear');
+  });
+
+  it('gently fades on the draft→final finalize', () => {
+    expect(
+      nextEdgeFade({ prevHadEdges: true, hasEdges: true, prevIsDraft: true, isDraft: false })
+    ).toBe('finalize');
+  });
+
+  it('does nothing on a draft→draft update (edges already present)', () => {
+    expect(
+      nextEdgeFade({ prevHadEdges: true, hasEdges: true, prevIsDraft: true, isDraft: true })
+    ).toBe(null);
+  });
+
+  it('does nothing when edges are unchanged on the final', () => {
+    expect(
+      nextEdgeFade({ prevHadEdges: true, hasEdges: true, prevIsDraft: false, isDraft: false })
+    ).toBe(null);
+  });
+
+  it('does nothing when there are no edges', () => {
+    expect(
+      nextEdgeFade({ prevHadEdges: false, hasEdges: false, prevIsDraft: true, isDraft: false })
+    ).toBe(null);
+  });
+
+  it('treats first appearance as appear even at finalize (covers no-draft first load)', () => {
+    // Labs off: no draft ever; first mesh is final. prevIsDraft was false.
+    expect(
+      nextEdgeFade({ prevHadEdges: false, hasEdges: true, prevIsDraft: false, isDraft: false })
+    ).toBe('appear');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test:run -- src/features/bin-designer/components/preview/BinMesh/edgeFade.test.ts`
+Expected: FAIL — cannot resolve `./edgeFade`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/features/bin-designer/components/preview/BinMesh/edgeFade.ts`:
+
+```typescript
+/**
+ * Decides which edge fade (if any) to start on a render.
+ *
+ * - 'appear'   — edges showed up from nothing (first load, or the first draft
+ *                tick of a new generation). Fade opacity 0 → 1.
+ * - 'finalize' — the draft→final swap, with edges already on screen. Fade from
+ *                a floor → 1 so the near-coincident edges never blink to black.
+ * - null       — no change worth animating (draft→draft, steady final, no edges).
+ */
+export type EdgeFadeKind = 'appear' | 'finalize' | null;
+
+export interface EdgeFadeInput {
+  readonly prevHadEdges: boolean;
+  readonly hasEdges: boolean;
+  readonly prevIsDraft: boolean;
+  readonly isDraft: boolean;
+}
+
+export function nextEdgeFade(input: EdgeFadeInput): EdgeFadeKind {
+  const { prevHadEdges, hasEdges, prevIsDraft, isDraft } = input;
+  if (!hasEdges) return null;
+  if (!prevHadEdges) return 'appear';
+  if (prevIsDraft && !isDraft) return 'finalize';
+  return null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test:run -- src/features/bin-designer/components/preview/BinMesh/edgeFade.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Stop suppressing draft edges in `BinMesh.tsx`**
+
+Replace the `edgeVertices` arg passed to `useMeshGeometry` (lines ~123-126):
+
+```typescript
+    // Manifold drafts have only triangulated mesh edges (not clean B-rep edges),
+    // which render as wireframe noise — suppress them; the exact result restores
+    // real edges when it supersedes the draft.
+    edgeVertices: isDraft ? null : edgeVertices,
+```
+
+with:
+
+```typescript
+    // Drafts now ship clean dihedral crease edges from the worker (see
+    // creaseEdges.ts), so render them directly instead of suppressing and
+    // recomputing EdgesGeometry on the main thread every draft tick.
+    edgeVertices,
+```
+
+- [ ] **Step 6: Replace the fade trigger with the finalize-aware decision**
+
+Add the import near the other local imports (after line 28):
+
+```typescript
+import { nextEdgeFade } from './edgeFade';
+```
+
+Add a floor constant next to `EDGE_FADE_MS` (after line 34):
+
+```typescript
+/** Finalize fade starts from this opacity (not 0) so already-visible draft
+ *  edges never blink to invisible when the final swaps in. */
+const EDGE_FINALIZE_FADE_FLOOR = 0.55;
+```
+
+Replace the fade `useLayoutEffect` (lines ~138-149):
+
+```typescript
+useLayoutEffect(() => {
+  const hasEdges = edgesGeometry !== null;
+  if (hasEdges && !hadEdgesRef.current) {
+    edgeFadeStartRef.current = performance.now();
+    if (edgeMatRef.current) {
+      edgeMatRef.current.transparent = true;
+      edgeMatRef.current.opacity = 0;
+    }
+    invalidate();
+  }
+  hadEdgesRef.current = hasEdges;
+}, [edgesGeometry, invalidate]);
+```
+
+with:
+
+```typescript
+const prevIsDraftRef = useRef(false);
+const fadeFromRef = useRef(0);
+useLayoutEffect(() => {
+  const hasEdges = edgesGeometry !== null;
+  const kind = nextEdgeFade({
+    prevHadEdges: hadEdgesRef.current,
+    hasEdges,
+    prevIsDraft: prevIsDraftRef.current,
+    isDraft,
+  });
+  if (kind !== null) {
+    fadeFromRef.current = kind === 'finalize' ? EDGE_FINALIZE_FADE_FLOOR : 0;
+    edgeFadeStartRef.current = performance.now();
+    if (edgeMatRef.current) {
+      edgeMatRef.current.transparent = true;
+      edgeMatRef.current.opacity = fadeFromRef.current;
+    }
+    invalidate();
+  }
+  hadEdgesRef.current = hasEdges;
+  prevIsDraftRef.current = isDraft;
+}, [edgesGeometry, isDraft, invalidate]);
+```
+
+- [ ] **Step 7: Make the fade loop honor the floor start**
+
+Replace the `useFrame` body (lines ~150-162):
+
+```typescript
+useFrame(() => {
+  const start = edgeFadeStartRef.current;
+  const mat = edgeMatRef.current;
+  if (start === null || !mat) return;
+  const t = Math.min(1, (performance.now() - start) / EDGE_FADE_MS);
+  mat.opacity = t * (2 - t); // ease-out
+  if (t >= 1) {
+    edgeFadeStartRef.current = null;
+    mat.transparent = false;
+    mat.opacity = 1;
+  }
+  invalidate();
+});
+```
+
+with:
+
+```typescript
+useFrame(() => {
+  const start = edgeFadeStartRef.current;
+  const mat = edgeMatRef.current;
+  if (start === null || !mat) return;
+  const t = Math.min(1, (performance.now() - start) / EDGE_FADE_MS);
+  const eased = t * (2 - t); // ease-out
+  const from = fadeFromRef.current;
+  mat.opacity = from + (1 - from) * eased;
+  if (t >= 1) {
+    edgeFadeStartRef.current = null;
+    mat.transparent = false;
+    mat.opacity = 1;
+  }
+  invalidate();
+});
+```
+
+- [ ] **Step 8: Run BinMesh tests + typecheck**
+
+Run: `pnpm run typecheck`
+Expected: no errors.
+
+Run: `pnpm run test:run -- src/features/bin-designer/components/preview/BinMesh/`
+Expected: PASS (existing BinMesh.test.tsx + new edgeFade.test.ts). The existing tests use `edgeVertices: new Float32Array(0)`, which `useMeshGeometry` treats as "no precomputed edges" → EdgesGeometry fallback, so removing the suppression doesn't change their outcome.
+
+- [ ] **Step 9: Commit**
+
+```bash
+nvm use 22
+git add src/features/bin-designer/components/preview/BinMesh/edgeFade.ts src/features/bin-designer/components/preview/BinMesh/edgeFade.test.ts src/features/bin-designer/components/preview/BinMesh/BinMesh.tsx
+git commit -m "feat(bin-designer): render draft crease edges with finalize-aware fade"
+```
+
+---
+
+## Task 5: Bump manifold draft circular tessellation
+
+**Files:**
+
+- Modify: `src/features/generation/worker/wasmInstantiator.ts:155`
+
+Manifold's `setQuality('draft')` sets the per-facet circular angle to 30° (~12-segment circles), which reads as a polygon on curve rims. Drop it to `DRAFT_MIN_CIRCULAR_ANGLE_DEG` (20°, ~18 segments) for rounder rims that still stay below the 35° crease threshold (so no longitudinal noise). This is mostly an empirical/visual change — verified by eye, not a unit test.
+
+- [ ] **Step 1: Add the import**
+
+In `src/features/generation/worker/wasmInstantiator.ts`, add to the imports near the top:
+
+```typescript
+import { DRAFT_MIN_CIRCULAR_ANGLE_DEG } from '@/shared/constants/tessellation';
+```
+
+- [ ] **Step 2: Override the draft circular angle**
+
+Replace line ~155:
+
+```typescript
+getKernel('manifold').setQuality?.('draft');
+```
+
+with:
+
+```typescript
+const manifoldKernel = getKernel('manifold');
+manifoldKernel.setQuality?.('draft');
+// setQuality('draft') sets a 30° min circular angle (~12-gon circles). Tighten
+// it for rounder curve rims, staying below CREASE_ANGLE_DEG so the worker's
+// crease extractor doesn't emit longitudinal facet lines. The raw manifold
+// module is exposed as `.oc`.
+const manifoldModule = (manifoldKernel as { oc?: { setMinCircularAngle?: (deg: number) => void } })
+  .oc;
+manifoldModule?.setMinCircularAngle?.(DRAFT_MIN_CIRCULAR_ANGLE_DEG);
+```
+
+- [ ] **Step 3: Typecheck + wasmInstantiator tests**
+
+Run: `pnpm run typecheck`
+Expected: no errors.
+
+Run: `pnpm run test:run -- src/features/generation/worker/wasmInstantiator.test.ts`
+Expected: PASS. (The test mocks brepjs; `getKernel` returns a mock. The optional-chained `.oc?.setMinCircularAngle?.()` is a no-op when absent, so the mock won't break. If the test asserts exact `getKernel` call shapes and fails, update the mock to return an object with an optional `oc` — do NOT weaken the production guard.)
+
+- [ ] **Step 4: Manual visual verification**
+
+Run: `nvm use 22 && pnpm run dev`
+
+In the bin designer:
+
+1. Create/edit a bin with a **rounded** feature (curved base, scoop, or fillet) and a **cylinder-like** feature if available.
+2. Scrub a parameter (e.g. height) to force rapid draft regeneration, then let it finalize.
+3. Confirm: (a) the **draft** shows clean edges — cap rims/creases present, **no** longitudinal wireframe lines along curves; (b) the **draft→final swap** is hard to notice (no edge pop, no blink); (c) curve rims look acceptably round, not obviously polygonal.
+
+If longitudinal lines appear on curves, the draft angle is at/above the crease threshold — lower `DRAFT_MIN_CIRCULAR_ANGLE_DEG` (e.g. to 15) in `tessellation.ts` and re-check. If drafts feel sluggish during scrubbing, raise it slightly (must stay < 35).
+
+- [ ] **Step 5: Commit**
+
+```bash
+nvm use 22
+git add src/features/generation/worker/wasmInstantiator.ts
+git commit -m "feat(generation): round out manifold draft curve tessellation"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full quality gate**
+
+```bash
+nvm use 22
+pnpm run typecheck
+pnpm run lint
+pnpm run test:run
+```
+
+Expected: all green. Investigate any failure before opening a PR. (Pre-existing `src/design-system/` failures from a missing `class-variance-authority` dep are unrelated to this work — see project notes.)
+
+- [ ] **Open the PR** (main is protected; this branch is `feat/manifold-draft-edge-lines`)
+
+```bash
+git push -u origin feat/manifold-draft-edge-lines
+gh pr create --fill
+```
+
+---
+
+## Notes for the implementer
+
+- **Why dihedral, not face ids:** manifold's `faceGroups.faceId` is per-construction-op (a whole cube = one id), and its true per-face `MeshGL.faceID` repaints curve facets as wireframe. Dihedral crease detection on the welded mesh is the only mesh-only signal that matches OCCT's look. See the spec for the full investigation.
+- **Why no crossfade:** two near-coincident black line sets crossfading produce a mid-fade darkening pulse, z-fighting, and a geometry-disposal hazard (the shared hook disposes the old `edgesGeometry` on dependency change). A single material with a floor-start fade is simpler and looks the same or better.
+- **Tangent fillet edges** that OCCT draws but the mesh can't distinguish from facet boundaries are an accepted, minor difference — not a bug to chase.
+
+```
+
+```

--- a/docs/superpowers/specs/2026-06-05-manifold-draft-edges-design.md
+++ b/docs/superpowers/specs/2026-06-05-manifold-draft-edges-design.md
@@ -1,0 +1,132 @@
+# Design: Match manifold draft edge lines to OCCT
+
+**Date:** 2026-06-05
+**Status:** Approved (pending spec review)
+**Goal:** Make the draft→final geometry swap less noticeable by bringing the manifold
+draft's edge lines closer to the occt-wasm final. Does not need to be perfect — the
+target is "the jump is hard to notice," not pixel-identical edges.
+
+## Background
+
+The bin designer renders two geometry backends:
+
+- **Final / exact** — `occt-wasm` kernel. Edges come from a real B-rep
+  `EdgeMeshExtractor` (clean analytic silhouette/feature curves), transferred to the
+  client as `edgeVertices` and rendered directly.
+- **Draft / preview** — `manifold` kernel in a separate worker. Fast, build-time
+  tessellation. Manifold has **no B-rep topology**.
+
+Both run the same generation pipeline (`binOrchestrator` → `tessellateStage`); only the
+active kernel differs. The draft is best-effort and only exists when the
+`manifold_preview` Labs feature is on (it is graduated/always-on in practice, but the
+no-draft path must still behave).
+
+### Why the current swap is noticeable
+
+- `tessellateStage` calls `meshEdges(solid)`. For manifold this returns the **entire
+  triangle wireframe** (every unique mesh edge), which is noise.
+- `BinMesh` therefore _suppresses_ draft edges (`edgeVertices: isDraft ? null`) and falls
+  back to `THREE.EdgesGeometry(geometry, 35°)` — main-thread crease detection — on **every
+  draft tick**.
+- At finalize, those crease-detected edges are replaced by OCCT's analytic B-rep edges.
+  The two differ in completeness and (on coarse curves) in facet noise, so the swap "pops."
+
+## Investigation findings that shaped this design
+
+1. **`faceGroups.faceId` is the wrong signal.** It maps to manifold's `runOriginalID`,
+   which is **per construction-op**, not per-face. A `Manifold.cube()` is one run → one id
+   for all 6 faces, so "edge where adjacent triangles differ in face id" emits **zero**
+   edges for a closed primitive. The face-id approach is rejected.
+2. **The real per-face id (`MeshGL.faceID`) doesn't help either.** A cylinder side is many
+   non-coplanar facets, each a distinct `faceID` → emitting at faceID boundaries repaints
+   the full curve wireframe. And smooth **tangent fillet edges** are indistinguishable from
+   facet boundaries in mesh-only data — a fundamental limit, not an implementation gap.
+3. **Dihedral crease detection is the correct algorithm** — the same thing
+   `THREE.EdgesGeometry` already does. The dominant lever for matching OCCT on curves is
+   **tessellation fineness + threshold match**, not face ids.
+4. **A two-layer crossfade is over-engineered and slightly harmful** for near-coincident
+   black lines: mid-fade darkening pulse, z-fighting at equal depth, and a geometry-disposal
+   hazard (the shared hook disposes the old `edgesGeometry` on dependency change). A single
+   fade-in is simpler and looks the same or better.
+
+## Approach
+
+Compute clean dihedral crease edges **in the worker** for the manifold path, render them
+directly on the client (no more suppression, no per-tick main-thread `EdgesGeometry`), and
+soften the finalize swap with a single short fade-in.
+
+### Component 1 — Worker: crease-edge extractor (new)
+
+`src/features/generation/worker/generators/utils/creaseEdges.ts`
+
+- Input: `vertices`, `triangles` (and the precomputed per-vertex `normals` if convenient).
+- **Weld vertices by quantized position** so adjacency is robust to manifold's split
+  vertices. Build an edge → adjacent-triangles map.
+- For each shared edge, emit a line segment when the angle between the two adjacent
+  **face normals** exceeds the crease threshold. Also emit naked boundary edges (an edge
+  with a single adjacent triangle).
+- Threshold = the same 35° used by `CREASE_ANGLE` in `useMeshGeometry`, exported as a shared
+  constant so draft edges and the final's normal-split creases stay consistent.
+- Output: `Float32Array` of line-segment vertices — identical format to today's
+  `edgeVertices`, so nothing downstream changes.
+- Unit tests (`creaseEdges.test.ts`): cube → exactly 12 edges; a coarse cylinder above the
+  segment count where facet steps < threshold → 2 cap-rim loops and **no** longitudinal
+  lines; a filleted box → expected rim loops; degenerate/empty input → empty output.
+
+### Component 2 — Worker: branch in `tessellateStage.ts`
+
+- Detect the build-time kernel via `getKernelCapabilities().tessellationModel === 'build-time'`
+  (manifold) vs `'extract-time'` (occt). No dependency on the `workerContext` handler.
+- On the manifold branch, replace `meshEdges(solid)` with `creaseEdges(shapeMesh)`.
+- Apply the same treatment to the **deferred socket** mesh (`ctx.deferredSolid`) and
+  concatenate, exactly as the current `meshEdges` socket path does. Flat bins have no socket.
+- OCCT path is untouched (its native extractor is better).
+
+### Component 3 — Worker: modest draft tessellation bump (tunable)
+
+- Nudge the manifold draft circular-segment / angular tolerance so curved silhouettes keep
+  facet steps under the crease threshold (clean rims, no longitudinal lines). Kept small to
+  protect draft latency; final value tuned by eye. This is the knob that most affects how
+  "OCCT-like" curves read.
+
+### Component 4 — Client: `BinMesh.tsx`
+
+- **Stop suppressing draft edges**: `edgeVertices: isDraft ? null : edgeVertices` →
+  `edgeVertices`. Drafts now render the worker's clean crease edges directly; the main-thread
+  `EdgesGeometry` fallback no longer runs per draft tick.
+- **Transition**: keep a single `<lineSegments>`; repoint its `geometry` on finalize.
+  Replace the current first-appearance fade trigger (which, once drafts have edges, would
+  mis-fire on the first draft tick and leave the final swap un-faded) with a **finalize-edge
+  trigger**: a short (~150–200 ms) single-material fade-in fired only on the `isDraft`
+  true→false transition, reusing the existing `useFrame` + `invalidate()` loop.
+- **No two-layer crossfade.** No retained/cloned geometry.
+- Behavior to preserve: `!wireframe` guard on edges; xray untouched; multicolor untouched;
+  Labs-off (no draft) path falls through to the existing single first-load fade with no
+  spurious finalize animation.
+
+## Edge cases / correctness checklist
+
+- Labs `manifold_preview` off → no draft → `isDraft` stays false → no finalize trigger.
+- New generation starting mid-fade → fade loop must reset cleanly (no zombie/stuck fade).
+- Deferred socket on non-flat bins → crease edges computed and concatenated for it too.
+- Empty/degenerate draft mesh → extractor returns empty, render guards already handle null.
+
+## Testing
+
+- `creaseEdges.test.ts` geometry validation (counts, no-noise-on-curve, no NaN/Infinity,
+  correct coordinate system) per the project's post-generation validation requirement.
+- Existing bin scenario tests must stay green.
+- Manual: scrub bin params and watch draft↔final — the edge set should look continuous, with
+  curves clean at the chosen draft quality.
+
+## Scope
+
+Mostly the manifold branch of the shared `tessellateStage` plus the bin-designer `BinMesh`
+transition. The OCCT/final path and other `useMeshGeometry` consumers are untouched.
+
+## Explicitly out of scope / non-goals
+
+- Pixel-identical edges. Tangent fillet edges that OCCT shows but mesh data can't recover are
+  accepted as a known, minor difference.
+- Any change to the OCCT/final edge pipeline.
+- faceID/face-boundary extraction (rejected — see findings 1–2).

--- a/src/features/bin-designer/components/preview/BinMesh/BinMesh.tsx
+++ b/src/features/bin-designer/components/preview/BinMesh/BinMesh.tsx
@@ -26,12 +26,17 @@ import {
   hoveredMaterialIndices,
 } from '@/features/bin-designer/utils/multiColorGroups';
 import { buildZoneResolver } from '@/features/bin-designer/utils/zoneResolver';
+import { nextEdgeFade } from './edgeFade';
 
 const EDGE_COLOR = '#000000';
 
 /** Edge-overlay fade-in duration after a Manifold draft (edges popping in at
  * full strength is the most jarring part of the draft→exact swap). */
 const EDGE_FADE_MS = 250;
+
+/** Finalize fade starts from this opacity (not 0) so already-visible draft
+ *  edges never blink to invisible when the final swaps in. */
+const EDGE_FINALIZE_FADE_FLOOR = 0.55;
 
 /** Face opacity when xray mode is enabled. Matches brepjs-studio. */
 const XRAY_OPACITY = 0.3;
@@ -120,39 +125,51 @@ export function BinMesh({ wireframe, color, xray = false, onZoneClick }: BinMesh
     vertices,
     normals,
     indices,
-    // Manifold drafts have only triangulated mesh edges (not clean B-rep edges),
-    // which render as wireframe noise — suppress them; the exact result restores
-    // real edges when it supersedes the draft.
-    edgeVertices: isDraft ? null : edgeVertices,
+    // Drafts now ship clean dihedral crease edges from the worker (see
+    // creaseEdges.ts), so render them directly instead of suppressing and
+    // recomputing EdgesGeometry on the main thread every draft tick.
+    edgeVertices,
     faceGroups: multiColorData?.groups,
   });
 
   const coarseGeometry = useCoarseGeometry(coarseLOD);
 
-  // Fade the edge overlay in whenever it (re)appears — Manifold drafts suppress
-  // edges, so this softens the draft→exact swap (and the first load). The
+  // Fade the edge overlay in whenever it (re)appears, and gently fade on the
+  // draft→final swap (already-visible edges never blink to invisible). The
   // canvas renders on demand, so keep invalidating while the fade runs.
   const edgeMatRef = useRef<THREE.LineBasicMaterial>(null);
   const edgeFadeStartRef = useRef<number | null>(null);
   const hadEdgesRef = useRef(false);
+  const prevIsDraftRef = useRef(false);
+  const fadeFromRef = useRef(0);
   useLayoutEffect(() => {
     const hasEdges = edgesGeometry !== null;
-    if (hasEdges && !hadEdgesRef.current) {
+    const kind = nextEdgeFade({
+      prevHadEdges: hadEdgesRef.current,
+      hasEdges,
+      prevIsDraft: prevIsDraftRef.current,
+      isDraft,
+    });
+    if (kind !== null) {
+      fadeFromRef.current = kind === 'finalize' ? EDGE_FINALIZE_FADE_FLOOR : 0;
       edgeFadeStartRef.current = performance.now();
       if (edgeMatRef.current) {
         edgeMatRef.current.transparent = true;
-        edgeMatRef.current.opacity = 0;
+        edgeMatRef.current.opacity = fadeFromRef.current;
       }
       invalidate();
     }
     hadEdgesRef.current = hasEdges;
-  }, [edgesGeometry, invalidate]);
+    prevIsDraftRef.current = isDraft;
+  }, [edgesGeometry, isDraft, invalidate]);
   useFrame(() => {
     const start = edgeFadeStartRef.current;
     const mat = edgeMatRef.current;
     if (start === null || !mat) return;
     const t = Math.min(1, (performance.now() - start) / EDGE_FADE_MS);
-    mat.opacity = t * (2 - t); // ease-out
+    const eased = t * (2 - t); // ease-out
+    const from = fadeFromRef.current;
+    mat.opacity = from + (1 - from) * eased;
     if (t >= 1) {
       edgeFadeStartRef.current = null;
       mat.transparent = false;

--- a/src/features/bin-designer/components/preview/BinMesh/BinMesh.tsx
+++ b/src/features/bin-designer/components/preview/BinMesh/BinMesh.tsx
@@ -174,8 +174,9 @@ export function BinMesh({ wireframe, color, xray = false, onZoneClick }: BinMesh
       edgeFadeStartRef.current = null;
       mat.transparent = false;
       mat.opacity = 1;
+    } else {
+      invalidate();
     }
-    invalidate();
   });
 
   // Allocate one material per zone. Hover state is applied separately via

--- a/src/features/bin-designer/components/preview/BinMesh/edgeFade.test.ts
+++ b/src/features/bin-designer/components/preview/BinMesh/edgeFade.test.ts
@@ -37,4 +37,16 @@ describe('nextEdgeFade', () => {
       nextEdgeFade({ prevHadEdges: false, hasEdges: true, prevIsDraft: false, isDraft: false })
     ).toBe('appear');
   });
+
+  it('fades appear on the first draft tick of a new generation', () => {
+    expect(
+      nextEdgeFade({ prevHadEdges: false, hasEdges: true, prevIsDraft: false, isDraft: true })
+    ).toBe('appear');
+  });
+
+  it('does nothing when edges disappear (mesh cleared)', () => {
+    expect(
+      nextEdgeFade({ prevHadEdges: true, hasEdges: false, prevIsDraft: false, isDraft: false })
+    ).toBe(null);
+  });
 });

--- a/src/features/bin-designer/components/preview/BinMesh/edgeFade.test.ts
+++ b/src/features/bin-designer/components/preview/BinMesh/edgeFade.test.ts
@@ -32,9 +32,11 @@ describe('nextEdgeFade', () => {
     ).toBe(null);
   });
 
-  it('treats first appearance as appear even at finalize (covers no-draft first load)', () => {
+  it('returns appear (not finalize) when edges first appear on the finalize transition', () => {
+    // prevIsDraft was true, but there were no edges yet — first-appearance wins
+    // over the finalize branch, so this fades in from 0 rather than the floor.
     expect(
-      nextEdgeFade({ prevHadEdges: false, hasEdges: true, prevIsDraft: false, isDraft: false })
+      nextEdgeFade({ prevHadEdges: false, hasEdges: true, prevIsDraft: true, isDraft: false })
     ).toBe('appear');
   });
 

--- a/src/features/bin-designer/components/preview/BinMesh/edgeFade.test.ts
+++ b/src/features/bin-designer/components/preview/BinMesh/edgeFade.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { nextEdgeFade } from './edgeFade';
+
+describe('nextEdgeFade', () => {
+  it('fades in when edges first appear from nothing', () => {
+    expect(
+      nextEdgeFade({ prevHadEdges: false, hasEdges: true, prevIsDraft: false, isDraft: false })
+    ).toBe('appear');
+  });
+
+  it('gently fades on the draft→final finalize', () => {
+    expect(
+      nextEdgeFade({ prevHadEdges: true, hasEdges: true, prevIsDraft: true, isDraft: false })
+    ).toBe('finalize');
+  });
+
+  it('does nothing on a draft→draft update (edges already present)', () => {
+    expect(
+      nextEdgeFade({ prevHadEdges: true, hasEdges: true, prevIsDraft: true, isDraft: true })
+    ).toBe(null);
+  });
+
+  it('does nothing when edges are unchanged on the final', () => {
+    expect(
+      nextEdgeFade({ prevHadEdges: true, hasEdges: true, prevIsDraft: false, isDraft: false })
+    ).toBe(null);
+  });
+
+  it('does nothing when there are no edges', () => {
+    expect(
+      nextEdgeFade({ prevHadEdges: false, hasEdges: false, prevIsDraft: true, isDraft: false })
+    ).toBe(null);
+  });
+
+  it('treats first appearance as appear even at finalize (covers no-draft first load)', () => {
+    expect(
+      nextEdgeFade({ prevHadEdges: false, hasEdges: true, prevIsDraft: false, isDraft: false })
+    ).toBe('appear');
+  });
+});

--- a/src/features/bin-designer/components/preview/BinMesh/edgeFade.ts
+++ b/src/features/bin-designer/components/preview/BinMesh/edgeFade.ts
@@ -1,0 +1,25 @@
+/**
+ * Decides which edge fade (if any) to start on a render.
+ *
+ * - 'appear'   — edges showed up from nothing (first load, or the first draft
+ *                tick of a new generation). Fade opacity 0 → 1.
+ * - 'finalize' — the draft→final swap, with edges already on screen. Fade from
+ *                a floor → 1 so the near-coincident edges never blink to black.
+ * - null       — no change worth animating (draft→draft, steady final, no edges).
+ */
+export type EdgeFadeKind = 'appear' | 'finalize' | null;
+
+export interface EdgeFadeInput {
+  readonly prevHadEdges: boolean;
+  readonly hasEdges: boolean;
+  readonly prevIsDraft: boolean;
+  readonly isDraft: boolean;
+}
+
+export function nextEdgeFade(input: EdgeFadeInput): EdgeFadeKind {
+  const { prevHadEdges, hasEdges, prevIsDraft, isDraft } = input;
+  if (!hasEdges) return null;
+  if (!prevHadEdges) return 'appear';
+  if (prevIsDraft && !isDraft) return 'finalize';
+  return null;
+}

--- a/src/features/bin-designer/components/preview/LidMesh/LidMesh.tsx
+++ b/src/features/bin-designer/components/preview/LidMesh/LidMesh.tsx
@@ -62,14 +62,13 @@ interface LidMeshProps {
 export function LidMesh({ color, lidOffsetMm, wireframe = false, xray = false }: LidMeshProps) {
   const { invalidate } = useThree();
 
-  const { lidMesh, lidGroupZ, isDraft } = useDesignerStore(
+  const { lidMesh, lidGroupZ } = useDesignerStore(
     useShallow((s) => {
       const { height, heightUnitMm, base } = s.params;
       const lipTopZ = binLipTopWorldZ(height, heightUnitMm, base.stackingLip);
       const anchorZ = lidAnchorZ(heightUnitMm, LID_FIT_CLEARANCE);
       return {
         lidMesh: s.generation.mesh?.lidMesh ?? null,
-        isDraft: s.generation.isDraft,
         // Mated position: lid local Z = anchorZ aligns with the bin's
         // lip top. The lid group (where local Z=0 lands) is then
         // lipTopZ - anchorZ; anchorZ is negative, so the lid floor sits
@@ -84,8 +83,7 @@ export function LidMesh({ color, lidOffsetMm, wireframe = false, xray = false }:
     vertices: lidMesh?.vertices ?? null,
     normals: lidMesh?.normals ?? null,
     indices: lidMesh?.indices ?? null,
-    // Suppress the noisy triangulated-mesh wireframe on Manifold drafts (see BinMesh).
-    edgeVertices: isDraft ? null : (lidMesh?.edgeVertices ?? null),
+    edgeVertices: lidMesh?.edgeVertices ?? null,
   });
 
   const baseOpacity = opacityForOffset(lidOffsetMm);

--- a/src/features/generation/worker/generators/__kernel-tests__/kernelInit.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/kernelInit.ts
@@ -10,6 +10,8 @@
  * scenario-file import chain.
  */
 
+import { DRAFT_MIN_CIRCULAR_ANGLE_DEG } from '@/shared/constants/tessellation';
+
 /** Initialize brepkit-wasm kernel and register it with brepjs. */
 export async function initBrepkitKernel(): Promise<void> {
   const { registerKernel, BrepkitAdapter } = await import('brepjs');
@@ -64,4 +66,9 @@ export async function initManifoldKernel(): Promise<void> {
   module.setup();
   initFromManifold(module);
   getKernel('manifold').setQuality?.('draft');
+  // Mirror wasmInstantiator: tighten the draft circular angle so test/scenario
+  // runs match production draft curve fidelity (stays below CREASE_ANGLE_DEG).
+  (
+    getKernel('manifold') as { oc?: { setMinCircularAngle?: (deg: number) => void } }
+  ).oc?.setMinCircularAngle?.(DRAFT_MIN_CIRCULAR_ANGLE_DEG);
 }

--- a/src/features/generation/worker/generators/__kernel-tests__/kernelInit.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/kernelInit.ts
@@ -65,10 +65,11 @@ export async function initManifoldKernel(): Promise<void> {
   const module = await ManifoldModule({ wasmBinary } as unknown as { locateFile: () => string });
   module.setup();
   initFromManifold(module);
-  getKernel('manifold').setQuality?.('draft');
+  const manifoldKernel = getKernel('manifold');
+  manifoldKernel.setQuality?.('draft');
   // Mirror wasmInstantiator: tighten the draft circular angle so test/scenario
   // runs match production draft curve fidelity (stays below CREASE_ANGLE_DEG).
   (
-    getKernel('manifold') as { oc?: { setMinCircularAngle?: (deg: number) => void } }
+    manifoldKernel as { oc?: { setMinCircularAngle?: (deg: number) => void } }
   ).oc?.setMinCircularAngle?.(DRAFT_MIN_CIRCULAR_ANGLE_DEG);
 }

--- a/src/features/generation/worker/generators/lidOrchestrator.ts
+++ b/src/features/generation/worker/generators/lidOrchestrator.ts
@@ -6,13 +6,13 @@
  * rejects (lid disabled, no stacking lip, or a blocker is active).
  */
 
-import { mesh, meshEdges, rotate, exportSTL, exportSTEP } from 'brepjs';
+import { mesh, meshEdges, getKernelCapabilities, rotate, exportSTL, exportSTEP } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
 import type { LidMeshData, ExportFormat } from '../../bridge/types';
 import type { ProgressFn } from './generatorTypes';
 import { buildLid } from './lidBuilder';
-import { toIndexedMeshData } from './utils/mesh';
+import { toIndexedMeshData, creaseEdges } from './utils';
 import { computeTessellationTolerances } from './utils/tolerances';
 import { checkCancelled } from './meshUtils';
 import { shouldGenerateLid } from '@/shared/types/bin';
@@ -73,13 +73,13 @@ export function generateLid(
     );
 
     const shapeMesh = mesh(solid, { tolerance, angularTolerance });
-    const edgeMesh = meshEdges(solid, {
-      tolerance,
-      angularTolerance: angularTolerance * 0.5,
-    });
+    const buildTime = getKernelCapabilities().tessellationModel === 'build-time';
+    const edgeLines = buildTime
+      ? creaseEdges(shapeMesh)
+      : meshEdges(solid, { tolerance, angularTolerance: angularTolerance * 0.5 }).lines;
     onProgress?.('merge', 1.0);
 
-    return toIndexedMeshData(shapeMesh, edgeMesh.lines, originToTag);
+    return toIndexedMeshData(shapeMesh, edgeLines, originToTag);
   } finally {
     solid.delete();
   }

--- a/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
@@ -8,9 +8,10 @@
  * tessellation cost. Enable by setting coarseMesh in the return value.
  */
 
-import { mesh, meshEdges } from 'brepjs';
+import { mesh, meshEdges, getKernelCapabilities } from 'brepjs';
 import type { PipelineContext, PipelineStage } from '../types';
 import { toIndexedMeshData, mergeShapeMeshes, concatFloat32 } from '../../utils/mesh';
+import { creaseEdges } from '../../utils';
 import { computeTessellationTolerances } from '../../utils/tolerances';
 import { setLastSolid } from '../../shapeCache';
 
@@ -36,10 +37,15 @@ export const tessellateStage: PipelineStage = {
 
     const edgeAngular = angularTolerance * 0.5;
     let shapeMesh = mesh(solid, { tolerance, angularTolerance });
-    let edgeLines: ArrayLike<number> = meshEdges(solid, {
-      tolerance,
-      angularTolerance: edgeAngular,
-    }).lines;
+
+    // Build-time kernels (manifold draft) have no B-rep topology, so their
+    // meshEdges() returns the full triangle wireframe. Recover clean feature
+    // edges from the mesh via dihedral crease detection. Extract-time kernels
+    // (occt) keep their native analytic edge extractor.
+    const buildTime = getKernelCapabilities().tessellationModel === 'build-time';
+    let edgeLines: ArrayLike<number> = buildTime
+      ? creaseEdges(shapeMesh)
+      : meshEdges(solid, { tolerance, angularTolerance: edgeAngular }).lines;
 
     // Preview path: the base socket is kept out of `solid` to skip the
     // expensive socket↔body fuse. Tessellate it separately and concatenate —
@@ -50,8 +56,10 @@ export const tessellateStage: PipelineStage = {
       try {
         const socketMesh = mesh(deferredSolid, { tolerance, angularTolerance });
         shapeMesh = mergeShapeMeshes(shapeMesh, socketMesh);
-        const socketEdges = meshEdges(deferredSolid, { tolerance, angularTolerance: edgeAngular });
-        edgeLines = concatFloat32(edgeLines, socketEdges.lines);
+        const socketEdges = buildTime
+          ? creaseEdges(socketMesh)
+          : meshEdges(deferredSolid, { tolerance, angularTolerance: edgeAngular }).lines;
+        edgeLines = concatFloat32(edgeLines, socketEdges);
       } finally {
         // Dispose even if mesh/meshEdges throws, so the WASM handle never leaks.
         deferredSolid.delete();

--- a/src/features/generation/worker/generators/utils/creaseEdges.test.ts
+++ b/src/features/generation/worker/generators/utils/creaseEdges.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import { creaseEdges } from './creaseEdges';
+
+/** Count line segments (each segment = 2 points = 6 floats). */
+const segCount = (out: Float32Array): number => out.length / 6;
+
+describe('creaseEdges', () => {
+  it('returns empty for empty input', () => {
+    const out = creaseEdges({ vertices: new Float32Array(0), triangles: new Uint32Array(0) });
+    expect(out.length).toBe(0);
+  });
+
+  it('emits only boundary edges for a flat (coplanar) quad', () => {
+    // Two coplanar triangles sharing the diagonal. The diagonal is coplanar
+    // (no crease) → not emitted; the 4 outer edges are naked boundaries.
+    const vertices = new Float32Array([
+      0,
+      0,
+      0, // 0
+      1,
+      0,
+      0, // 1
+      1,
+      1,
+      0, // 2
+      0,
+      1,
+      0, // 3
+    ]);
+    const triangles = new Uint32Array([0, 1, 2, 0, 2, 3]);
+    const out = creaseEdges({ vertices, triangles });
+    expect(segCount(out)).toBe(4); // 4 boundary edges, shared diagonal suppressed
+  });
+
+  it('emits the ridge of a 90° fold (above threshold)', () => {
+    // Two triangles meeting at a 90° fold along the shared edge (0,0,0)-(1,0,0).
+    const vertices = new Float32Array([
+      0,
+      0,
+      0, // 0  shared
+      1,
+      0,
+      0, // 1  shared
+      0,
+      1,
+      0, // 2  triangle A (in XY plane)
+      0,
+      0,
+      1, // 3  triangle B (in XZ plane)
+    ]);
+    const triangles = new Uint32Array([0, 1, 2, 0, 1, 3]);
+    const out = creaseEdges({ vertices, triangles });
+    // 1 ridge crease + 4 naked boundary edges = 5 segments.
+    expect(segCount(out)).toBe(5);
+  });
+
+  it('does NOT emit a shared edge folded below the threshold', () => {
+    // ~15° fold (< 35°): represents a curve facet that must stay smooth.
+    const angle = (15 * Math.PI) / 180;
+    const vertices = new Float32Array([
+      0,
+      0,
+      0, // 0 shared
+      1,
+      0,
+      0, // 1 shared
+      0,
+      1,
+      0, // 2 triangle A (flat)
+      0,
+      Math.cos(angle),
+      Math.sin(angle), // 3 triangle B tilted 15°
+    ]);
+    const triangles = new Uint32Array([0, 1, 2, 0, 1, 3]);
+    const out = creaseEdges({ vertices, triangles });
+    // Only the 4 boundary edges; the sub-threshold fold is suppressed.
+    expect(segCount(out)).toBe(4);
+  });
+
+  it('detects creases across SPLIT (duplicated-position) vertices', () => {
+    // Manifold may give each triangle its own vertex copies. The shared 90°
+    // ridge must still be found by position-welding, not index identity.
+    const vertices = new Float32Array([
+      // Triangle A: indices 0,1,2
+      0, 0, 0, 1, 0, 0, 0, 1, 0,
+      // Triangle B: indices 3,4,5 — re-uses positions of 0 and 1 as 3 and 4
+      0, 0, 0, 1, 0, 0, 0, 0, 1,
+    ]);
+    const triangles = new Uint32Array([0, 1, 2, 3, 4, 5]);
+    const out = creaseEdges({ vertices, triangles });
+    // After welding, the (0,0,0)-(1,0,0) edge is shared at 90° → 1 ridge,
+    // plus 4 boundary edges = 5.
+    expect(segCount(out)).toBe(5);
+  });
+
+  it('produces finite coordinates only', () => {
+    const vertices = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1]);
+    const triangles = new Uint32Array([0, 1, 2, 0, 1, 3]);
+    const out = creaseEdges({ vertices, triangles });
+    for (const n of out) expect(Number.isFinite(n)).toBe(true);
+  });
+
+  it('emits exactly 12 edges for a unit cube', () => {
+    // 8 corners, 12 triangles (2 per face). Each true cube edge is shared by
+    // two perpendicular faces (90°) → 12 creases; face diagonals are coplanar.
+    const v = new Float32Array([
+      0,
+      0,
+      0, // 0
+      1,
+      0,
+      0, // 1
+      1,
+      1,
+      0, // 2
+      0,
+      1,
+      0, // 3
+      0,
+      0,
+      1, // 4
+      1,
+      0,
+      1, // 5
+      1,
+      1,
+      1, // 6
+      0,
+      1,
+      1, // 7
+    ]);
+    const t = new Uint32Array([
+      0,
+      2,
+      1,
+      0,
+      3,
+      2, // bottom (z=0)
+      4,
+      5,
+      6,
+      4,
+      6,
+      7, // top (z=1)
+      0,
+      1,
+      5,
+      0,
+      5,
+      4, // front (y=0)
+      1,
+      2,
+      6,
+      1,
+      6,
+      5, // right (x=1)
+      2,
+      3,
+      7,
+      2,
+      7,
+      6, // back (y=1)
+      3,
+      0,
+      4,
+      3,
+      4,
+      7, // left (x=0)
+    ]);
+    const out = creaseEdges({ vertices: v, triangles: t });
+    expect(segCount(out)).toBe(12);
+  });
+});

--- a/src/features/generation/worker/generators/utils/creaseEdges.ts
+++ b/src/features/generation/worker/generators/utils/creaseEdges.ts
@@ -1,0 +1,126 @@
+/**
+ * Dihedral crease-edge extractor for build-time (manifold) draft meshes.
+ *
+ * Manifold has no B-rep topology and its meshEdges() returns the full triangle
+ * wireframe. This recovers OCCT-style feature edges from the mesh alone:
+ * weld vertices by position (manifold may split them at face boundaries), then
+ * emit a segment wherever two adjacent triangles' face normals diverge past the
+ * crease threshold — plus any naked boundary edge. Sub-threshold folds (curve
+ * facets) stay smooth, so curves render as clean rims, not wireframe.
+ */
+
+import { CREASE_ANGLE_DEG } from '@/shared/constants/tessellation';
+
+export interface CreaseEdgeMesh {
+  readonly vertices: ArrayLike<number>;
+  readonly triangles: ArrayLike<number>;
+}
+
+/** Weld resolution: 1e-4 model units (sub-micron at mm scale). */
+const WELD_SCALE = 1e4;
+
+export function creaseEdges(
+  mesh: CreaseEdgeMesh,
+  thresholdDeg: number = CREASE_ANGLE_DEG
+): Float32Array {
+  const { vertices, triangles } = mesh;
+  const triCount = Math.floor(triangles.length / 3);
+  if (triCount === 0) return new Float32Array(0);
+
+  const vertCount = Math.floor(vertices.length / 3);
+
+  // 1. Weld vertices by quantized position → stable welded id per position.
+  const weld = new Map<string, number>();
+  const remap = new Int32Array(vertCount);
+  const idToVert: number[] = [];
+  const q = (n: number): number => Math.round(n * WELD_SCALE);
+  for (let v = 0; v < vertCount; v++) {
+    const key = `${q(vertices[v * 3])},${q(vertices[v * 3 + 1])},${q(vertices[v * 3 + 2])}`;
+    let id = weld.get(key);
+    if (id === undefined) {
+      id = weld.size;
+      weld.set(key, id);
+      idToVert[id] = v;
+    }
+    remap[v] = id;
+  }
+
+  // 2. Per-triangle face normals from original positions.
+  const faceNormals = new Float32Array(triCount * 3);
+  for (let t = 0; t < triCount; t++) {
+    const a = triangles[t * 3];
+    const b = triangles[t * 3 + 1];
+    const c = triangles[t * 3 + 2];
+    const ax = vertices[a * 3];
+    const ay = vertices[a * 3 + 1];
+    const az = vertices[a * 3 + 2];
+    const ux = vertices[b * 3] - ax;
+    const uy = vertices[b * 3 + 1] - ay;
+    const uz = vertices[b * 3 + 2] - az;
+    const vx = vertices[c * 3] - ax;
+    const vy = vertices[c * 3 + 1] - ay;
+    const vz = vertices[c * 3 + 2] - az;
+    const nx = uy * vz - uz * vy;
+    const ny = uz * vx - ux * vz;
+    const nz = ux * vy - uy * vx;
+    const len = Math.hypot(nx, ny, nz) || 1;
+    faceNormals[t * 3] = nx / len;
+    faceNormals[t * 3 + 1] = ny / len;
+    faceNormals[t * 3 + 2] = nz / len;
+  }
+
+  // 3. Edge (welded id pair) → adjacent triangle indices.
+  const edgeMap = new Map<number, number[]>();
+  const edgeKey = (i: number, j: number): number => {
+    const lo = i < j ? i : j;
+    const hi = i < j ? j : i;
+    return lo * weld.size + hi;
+  };
+  const addEdge = (i: number, j: number, t: number): void => {
+    const key = edgeKey(i, j);
+    const arr = edgeMap.get(key);
+    if (arr) arr.push(t);
+    else edgeMap.set(key, [t]);
+  };
+  for (let t = 0; t < triCount; t++) {
+    const a = remap[triangles[t * 3]];
+    const b = remap[triangles[t * 3 + 1]];
+    const c = remap[triangles[t * 3 + 2]];
+    addEdge(a, b, t);
+    addEdge(b, c, t);
+    addEdge(c, a, t);
+  }
+
+  // 4. Emit creases (dihedral past threshold) and naked boundary edges.
+  const cosThreshold = Math.cos((thresholdDeg * Math.PI) / 180);
+  const size = weld.size;
+  const out: number[] = [];
+  const pushVert = (id: number): void => {
+    const v = idToVert[id];
+    out.push(vertices[v * 3], vertices[v * 3 + 1], vertices[v * 3 + 2]);
+  };
+  for (const [key, tris] of edgeMap) {
+    let emit = false;
+    if (tris.length === 1) {
+      emit = true; // naked boundary edge
+    } else {
+      for (let i = 0; i < tris.length && !emit; i++) {
+        for (let j = i + 1; j < tris.length && !emit; j++) {
+          const ti = tris[i] * 3;
+          const tj = tris[j] * 3;
+          const dot =
+            faceNormals[ti] * faceNormals[tj] +
+            faceNormals[ti + 1] * faceNormals[tj + 1] +
+            faceNormals[ti + 2] * faceNormals[tj + 2];
+          if (dot < cosThreshold) emit = true;
+        }
+      }
+    }
+    if (emit) {
+      pushVert(Math.floor(key / size));
+      pushVert(key % size);
+    }
+  }
+
+  return new Float32Array(out);
+}

--- a/src/features/generation/worker/generators/utils/creaseEdges.ts
+++ b/src/features/generation/worker/generators/utils/creaseEdges.ts
@@ -70,11 +70,12 @@ export function creaseEdges(
   }
 
   // 3. Edge (welded id pair) → adjacent triangle indices.
+  const size = weld.size;
   const edgeMap = new Map<number, number[]>();
   const edgeKey = (i: number, j: number): number => {
     const lo = i < j ? i : j;
     const hi = i < j ? j : i;
-    return lo * weld.size + hi;
+    return lo * size + hi;
   };
   const addEdge = (i: number, j: number, t: number): void => {
     const key = edgeKey(i, j);
@@ -93,7 +94,6 @@ export function creaseEdges(
 
   // 4. Emit creases (dihedral past threshold) and naked boundary edges.
   const cosThreshold = Math.cos((thresholdDeg * Math.PI) / 180);
-  const size = weld.size;
   const out: number[] = [];
   const pushVert = (id: number): void => {
     const v = idToVert[id];

--- a/src/features/generation/worker/generators/utils/index.ts
+++ b/src/features/generation/worker/generators/utils/index.ts
@@ -7,3 +7,5 @@ export { fuseAllOrNull } from './shapeOps';
 export { toIndexedMeshData } from './mesh';
 export { computeTessellationTolerances } from './tolerances';
 export type { TessellationTolerances } from './tolerances';
+export { creaseEdges } from './creaseEdges';
+export type { CreaseEdgeMesh } from './creaseEdges';

--- a/src/features/generation/worker/wasmInstantiator.test.ts
+++ b/src/features/generation/worker/wasmInstantiator.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { DRAFT_MIN_CIRCULAR_ANGLE_DEG } from '@/shared/constants/tessellation';
+
+// Spy for the manifold kernel's raw-module circular-angle override.
+const mockSetMinCircularAngle = vi.fn();
+
 // Mock all heavy dependencies before importing the module under test
 vi.mock('brepjs', () => ({
   registerKernel: vi.fn(),
@@ -7,7 +12,13 @@ vi.mock('brepjs', () => ({
   OcctWasmAdapter: Object.assign(vi.fn(), { fromKernel: vi.fn(() => ({})) }),
   loadFont: vi.fn(),
   initFromManifold: vi.fn(),
-  getKernel: vi.fn(() => ({ setQuality: vi.fn() })),
+  // Return an object that satisfies both the setQuality call (all kernels) and
+  // the .oc.setMinCircularAngle override (manifold only). Non-manifold paths
+  // never access .oc, so including it here is safe.
+  getKernel: vi.fn(() => ({
+    setQuality: vi.fn(),
+    oc: { setMinCircularAngle: mockSetMinCircularAngle },
+  })),
 }));
 
 // Mock occt-wasm kernel factory
@@ -121,6 +132,7 @@ describe('wasmInstantiator', () => {
       expect(mockManifoldSetup).toHaveBeenCalledTimes(1);
       expect(initFromManifold).toHaveBeenCalledTimes(1);
       expect(getKernel).toHaveBeenCalledWith('manifold');
+      expect(mockSetMinCircularAngle).toHaveBeenCalledWith(DRAFT_MIN_CIRCULAR_ANGLE_DEG);
       expect(result.isThreaded).toBe(false);
       expect(result.hardwareConcurrency).toBeGreaterThan(0);
     });

--- a/src/features/generation/worker/wasmInstantiator.ts
+++ b/src/features/generation/worker/wasmInstantiator.ts
@@ -10,6 +10,7 @@
 
 import { registerKernel, BrepkitAdapter, loadFont, initFromManifold, getKernel } from 'brepjs';
 
+import { DRAFT_MIN_CIRCULAR_ANGLE_DEG } from '@/shared/constants/tessellation';
 import atkinsonFontUrl from './assets/fonts/AtkinsonHyperlegible-Regular.ttf?url';
 import jetbrainsMonoFontUrl from './assets/fonts/JetBrainsMono-Regular.ttf?url';
 import allertaStencilFontUrl from './assets/fonts/AllertaStencil-Regular.ttf?url';
@@ -152,7 +153,16 @@ export async function loadManifold(): Promise<WasmLoadResult> {
   });
   module.setup();
   initFromManifold(module);
-  getKernel('manifold').setQuality?.('draft');
+  const manifoldKernel = getKernel('manifold');
+  manifoldKernel.setQuality?.('draft');
+  // setQuality('draft') sets a 30° min circular angle (~12-gon circles). Tighten
+  // it for rounder curve rims, staying below CREASE_ANGLE_DEG so the worker's
+  // crease extractor doesn't emit longitudinal facet lines. The raw manifold
+  // module is exposed as `.oc`.
+  const manifoldModule = (
+    manifoldKernel as { oc?: { setMinCircularAngle?: (deg: number) => void } }
+  ).oc;
+  manifoldModule?.setMinCircularAngle?.(DRAFT_MIN_CIRCULAR_ANGLE_DEG);
 
   return { isThreaded: false, hardwareConcurrency };
 }

--- a/src/shared/components/preview/useMeshGeometry.ts
+++ b/src/shared/components/preview/useMeshGeometry.ts
@@ -9,14 +9,7 @@ import { useMemo, useEffect } from 'react';
 import * as THREE from 'three';
 import { toCreasedNormals } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import type { CoarseLODData } from '@/shared/types/generation';
-
-/**
- * Crease angle threshold (radians). Edges where adjacent face normals differ
- * by more than this angle get sharp (split) normals; smoother transitions are
- * interpolated. 35° catches the lip chamfer edges (~45°) while preserving
- * smooth shading on gentle curves like scoop ramps and fillets.
- */
-const CREASE_ANGLE = (35 * Math.PI) / 180;
+import { CREASE_ANGLE_DEG, CREASE_ANGLE_RAD } from '@/shared/constants/tessellation';
 
 /** Per-face group defining a material index range within the index buffer */
 export interface MeshFaceGroup {
@@ -67,7 +60,7 @@ export function useMeshGeometry(arrays: MeshArrays): MeshGeometryResult {
       // normals at BREP edges where face normals diverge (e.g. lip chamfer).
       // toCreasedNormals converts to non-indexed internally.
       geo.computeVertexNormals();
-      const creased = toCreasedNormals(geo, CREASE_ANGLE);
+      const creased = toCreasedNormals(geo, CREASE_ANGLE_RAD);
       geo.dispose();
       geo = creased;
     } else {
@@ -100,8 +93,7 @@ export function useMeshGeometry(arrays: MeshArrays): MeshGeometryResult {
     // This gives the direct-mesh preview crisp BREP-style outlines without
     // requiring the generator to author edge geometry by hand.
     if (!geometry) return null;
-    const CREASE_ANGLE_DEGREES = 35;
-    return new THREE.EdgesGeometry(geometry, CREASE_ANGLE_DEGREES);
+    return new THREE.EdgesGeometry(geometry, CREASE_ANGLE_DEG);
   }, [edgeVertices, geometry]);
 
   useEffect(() => {

--- a/src/shared/constants/tessellation.test.ts
+++ b/src/shared/constants/tessellation.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CREASE_ANGLE_DEG, CREASE_ANGLE_RAD, DRAFT_MIN_CIRCULAR_ANGLE_DEG } from './tessellation';
+
+describe('tessellation constants', () => {
+  it('exposes the crease threshold in degrees and radians', () => {
+    expect(CREASE_ANGLE_DEG).toBe(35);
+    expect(CREASE_ANGLE_RAD).toBeCloseTo((35 * Math.PI) / 180, 10);
+  });
+
+  it('keeps the draft circular angle below the crease threshold', () => {
+    // Invariant: a draft facet step at/above the crease angle would make the
+    // worker emit a line at every curve facet (longitudinal wireframe noise).
+    expect(DRAFT_MIN_CIRCULAR_ANGLE_DEG).toBeLessThan(CREASE_ANGLE_DEG);
+  });
+});

--- a/src/shared/constants/tessellation.ts
+++ b/src/shared/constants/tessellation.ts
@@ -19,10 +19,3 @@ export const CREASE_ANGLE_RAD = (CREASE_ANGLE_DEG * Math.PI) / 180;
 /** Manifold draft min circular angle (degrees per facet). Lower = rounder
  *  curves, slower draft. MUST stay below CREASE_ANGLE_DEG (see COUPLING). */
 export const DRAFT_MIN_CIRCULAR_ANGLE_DEG = 20;
-
-// Cheap load-time guard so a future edit can't silently reintroduce curve noise.
-if (DRAFT_MIN_CIRCULAR_ANGLE_DEG >= CREASE_ANGLE_DEG) {
-  throw new Error(
-    `DRAFT_MIN_CIRCULAR_ANGLE_DEG (${DRAFT_MIN_CIRCULAR_ANGLE_DEG}) must be < CREASE_ANGLE_DEG (${CREASE_ANGLE_DEG})`
-  );
-}

--- a/src/shared/constants/tessellation.ts
+++ b/src/shared/constants/tessellation.ts
@@ -1,0 +1,28 @@
+/**
+ * Tessellation / edge constants shared by the generation worker (draft crease
+ * edge extraction) and the client renderer (normal splitting + edge fallback).
+ *
+ * COUPLING: the manifold draft tessellates curves into flat facets. The worker
+ * extracts edges wherever the angle between adjacent face normals exceeds
+ * CREASE_ANGLE_DEG. So the draft's per-facet circular angle MUST stay below
+ * CREASE_ANGLE_DEG — otherwise every curve facet becomes an edge (longitudinal
+ * wireframe noise). Keep DRAFT_MIN_CIRCULAR_ANGLE_DEG comfortably under it.
+ */
+
+/** Dihedral/crease threshold (degrees). Catches lip chamfers (~45°) and curve
+ *  rims (90°) while leaving sub-threshold facets smooth. */
+export const CREASE_ANGLE_DEG = 35;
+
+/** Same threshold in radians (for THREE normal splitting). */
+export const CREASE_ANGLE_RAD = (CREASE_ANGLE_DEG * Math.PI) / 180;
+
+/** Manifold draft min circular angle (degrees per facet). Lower = rounder
+ *  curves, slower draft. MUST stay below CREASE_ANGLE_DEG (see COUPLING). */
+export const DRAFT_MIN_CIRCULAR_ANGLE_DEG = 20;
+
+// Cheap load-time guard so a future edit can't silently reintroduce curve noise.
+if (DRAFT_MIN_CIRCULAR_ANGLE_DEG >= CREASE_ANGLE_DEG) {
+  throw new Error(
+    `DRAFT_MIN_CIRCULAR_ANGLE_DEG (${DRAFT_MIN_CIRCULAR_ANGLE_DEG}) must be < CREASE_ANGLE_DEG (${CREASE_ANGLE_DEG})`
+  );
+}


### PR DESCRIPTION
## Summary

Makes the fast **manifold draft** preview's edge lines look close to the **occt-wasm final**, so the draft→final swap is hard to notice.

Manifold has no B-rep topology — its `meshEdges()` returns the full triangle wireframe (noise), which is why drafts previously **suppressed** edges and recomputed `THREE.EdgesGeometry` on the main thread every tick. This PR recovers OCCT-style feature edges from the manifold mesh via **dihedral crease detection** in the worker, renders them directly, and softens the swap with a single fade.

### How it works
- **`creaseEdges`** (new, pure util): weld vertices by position → build edge→adjacent-triangle adjacency → emit a segment where adjacent face normals diverge past the crease threshold (35°), plus naked boundary edges. Curve facets *below* the threshold stay smooth → clean rims, no wireframe.
- **`tessellateStage` / `lidOrchestrator`**: on the build-time (manifold) kernel use `creaseEdges`; the extract-time (occt) path keeps its native analytic extractor unchanged.
- **`BinMesh` / `LidMesh`**: stop suppressing draft edges; a `nextEdgeFade` decision helper drives a single-material fade (`appear` 0→1, `finalize` 0.55→1 floor so coincident edges never blink). Deliberately **not** a two-layer crossfade.
- **Draft tessellation**: manifold draft min circular angle tightened 30°→20° for rounder rims, kept below the 35° crease threshold (coupling enforced by a unit test).

### Key design decisions (rejected alternatives)
- **Face-id boundary extraction** — rejected: manifold's `runOriginalID` is per-construction-op (a whole cube = one id → zero edges), and the real per-coplanar-face `faceID` repaints curve facets as wireframe.
- **Two-layer crossfade** — rejected: near-coincident black lines produce a mid-fade darkening pulse + z-fighting + geometry-disposal hazards.

Design spec and implementation plan are in `docs/superpowers/`.

## Test plan
- [x] Unit: `creaseEdges` (cube=12 edges, split-vertex weld, sub-threshold suppression, etc.), `nextEdgeFade` transitions, tessellation invariant
- [x] occt path unchanged — bin + lid generator scenario suites green
- [x] Full typecheck + lint clean
- [ ] **Manual visual** (please verify): draft→final swap seamless on a rounded bin; small-radius curves (small base round / corner radius / scoop fillet / holes) have no longitudinal facet lines — if they do, the lever is manifold `setMinCircularEdgeLength`, not the angle; lid-enabled bin matches the body; lip chamfer / wall junctions still show as edges on the draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)