### PR TITLE
fix(cqrs): build mutations over a live commandBus shim to survive chunk-cycle races

### DIFF
--- a/src/shared/contexts/MutationsContext.test.tsx
+++ b/src/shared/contexts/MutationsContext.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { ok } from '@/core/result';
+import { layerId, categoryId, binId } from '@/core/types';
+import type { Bin } from '@/core/types';
+import type { CommandBus } from '@/core/cqrs';
+import type * as CqrsModule from '@/core/cqrs';
+
+// Controls what the mocked `commandBus` binding resolves to. The shim in
+// MutationsContext reads it live on every dispatch, so flipping it mid-test
+// simulates a chunk-cycle/stale-chunk race where the binding resolves late.
+let currentBus: CommandBus | undefined;
+
+const fakeBus: CommandBus = {
+  dispatch: vi.fn(() => ok({ value: binId('bin_fake'), events: [] })),
+  use: vi.fn(),
+  resetMiddleware: vi.fn(),
+};
+
+vi.mock('@/core/cqrs', async (importOriginal) => {
+  const actual = await importOriginal<typeof CqrsModule>();
+  return {
+    ...actual,
+    get commandBus() {
+      return currentBus;
+    },
+  };
+});
+
+// Imported after the mock is registered so the shim closes over the mocked binding.
+const { useMutations } = await import('./MutationsContext');
+
+function makeBin(): Omit<Bin, 'id'> {
+  return {
+    layerId: layerId('layer_1'),
+    x: 0,
+    y: 0,
+    width: 1,
+    depth: 1,
+    height: 3,
+    category: categoryId('cat_1'),
+    label: '',
+    notes: '',
+  };
+}
+
+describe('MutationsContext bus resilience', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentBus = fakeBus;
+  });
+
+  it('routes mutations through the current command bus', () => {
+    const { result } = renderHook(() => useMutations());
+    const res = result.current.addBin(makeBin());
+
+    expect(res.ok).toBe(true);
+    expect(fakeBus.dispatch).toHaveBeenCalledOnce();
+  });
+
+  it('does not permanently break when the bus is undefined at first use (regression #1563/#1466)', () => {
+    // Singleton is first built while the bus binding is still undefined…
+    currentBus = undefined;
+    const { result } = renderHook(() => useMutations());
+
+    // …then the binding resolves (cycle settles / fresh chunk loads).
+    currentBus = fakeBus;
+    const res = result.current.addBin(makeBin());
+
+    expect(res.ok).toBe(true);
+    expect(fakeBus.dispatch).toHaveBeenCalledOnce();
+  });
+
+  it('throws a reload-actionable error when the bus is unavailable', () => {
+    currentBus = undefined;
+    const { result } = renderHook(() => useMutations());
+
+    expect(() => result.current.addBin(makeBin())).toThrow(/stale build/i);
+  });
+});

--- a/src/shared/contexts/MutationsContext.test.tsx
+++ b/src/shared/contexts/MutationsContext.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
 import { ok } from '@/core/result';
 import { layerId, categoryId, binId } from '@/core/types';
 import type { Bin } from '@/core/types';
@@ -27,9 +26,6 @@ vi.mock('@/core/cqrs', async (importOriginal) => {
   };
 });
 
-// Imported after the mock is registered so the shim closes over the mocked binding.
-const { useMutations } = await import('./MutationsContext');
-
 function makeBin(): Omit<Bin, 'id'> {
   return {
     layerId: layerId('layer_1'),
@@ -44,24 +40,38 @@ function makeBin(): Omit<Bin, 'id'> {
   };
 }
 
+// Re-import the module under test (and the renderer) fresh per test so each
+// case rebuilds the module-scoped mutations singleton from scratch — otherwise
+// the first test to build it would mask the "built while bus was undefined"
+// regression scenario. renderHook and useMutations are imported together after
+// the reset so they share the same freshly-evaluated React instance.
+async function freshRender() {
+  vi.resetModules();
+  const [{ renderHook }, { useMutations }] = await Promise.all([
+    import('@testing-library/react'),
+    import('./MutationsContext'),
+  ]);
+  return renderHook(() => useMutations());
+}
+
 describe('MutationsContext bus resilience', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     currentBus = fakeBus;
   });
 
-  it('routes mutations through the current command bus', () => {
-    const { result } = renderHook(() => useMutations());
+  it('routes mutations through the current command bus', async () => {
+    const { result } = await freshRender();
     const res = result.current.addBin(makeBin());
 
     expect(res.ok).toBe(true);
     expect(fakeBus.dispatch).toHaveBeenCalledOnce();
   });
 
-  it('does not permanently break when the bus is undefined at first use (regression #1563/#1466)', () => {
+  it('does not permanently break when the bus is undefined at first use (regression #1563/#1466)', async () => {
     // Singleton is first built while the bus binding is still undefined…
     currentBus = undefined;
-    const { result } = renderHook(() => useMutations());
+    const { result } = await freshRender();
 
     // …then the binding resolves (cycle settles / fresh chunk loads).
     currentBus = fakeBus;
@@ -71,9 +81,9 @@ describe('MutationsContext bus resilience', () => {
     expect(fakeBus.dispatch).toHaveBeenCalledOnce();
   });
 
-  it('throws a reload-actionable error when the bus is unavailable', () => {
+  it('throws a reload-actionable error when the bus is unavailable', async () => {
     currentBus = undefined;
-    const { result } = renderHook(() => useMutations());
+    const { result } = await freshRender();
 
     expect(() => result.current.addBin(makeBin())).toThrow(/stale build/i);
   });

--- a/src/shared/contexts/MutationsContext.tsx
+++ b/src/shared/contexts/MutationsContext.tsx
@@ -19,6 +19,7 @@
 import { createContext, useContext, useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { createCqrsMutations, commandBus } from '@/core/cqrs';
+import type { CommandBus } from '@/core/cqrs';
 import type {
   Bin,
   Layer,
@@ -91,12 +92,37 @@ export interface Mutations {
 
 const MutationsContext = createContext<Mutations | null>(null);
 
+// Live indirection over the `commandBus` binding. The mutations adapter is
+// built over this shim, never over a snapshot of `commandBus`, so a transient
+// `undefined` at build time — a chunk-level static-import cycle (#1466/#1563)
+// or a stale chunk that resolves the binding late — can no longer poison the
+// singleton: every dispatch re-reads the current binding. The arrow methods
+// defer the read to call time, which is also why this passes
+// `local/no-init-time-imported-call` (#1566).
+const liveCommandBus: CommandBus = {
+  dispatch(command) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `commandBus` is typed non-nullable but can resolve to `undefined` at runtime under chunk-level import cycles / stale chunks (#1466/#1563); the guard is the whole point of this shim
+    if (!commandBus) {
+      throw new Error(
+        'Command bus unavailable — the app likely loaded a stale build. Reload the page to continue.'
+      );
+    }
+    return commandBus.dispatch(command);
+  },
+  use(middleware) {
+    commandBus.use(middleware);
+  },
+  resetMiddleware() {
+    commandBus.resetMiddleware();
+  },
+};
+
 // Lazy: building at module init would capture `commandBus` before its
 // chunk has evaluated under chunk-level static-import cycles (#1466),
 // so every mutation would close over `undefined` and throw on dispatch.
 let cqrsMutationsSingleton: Mutations | null = null;
 function getCqrsMutations(): Mutations {
-  cqrsMutationsSingleton ??= createCqrsMutations(commandBus);
+  cqrsMutationsSingleton ??= createCqrsMutations(liveCommandBus);
   return cqrsMutationsSingleton;
 }
 

--- a/src/shared/contexts/MutationsContext.tsx
+++ b/src/shared/contexts/MutationsContext.tsx
@@ -92,28 +92,35 @@ export interface Mutations {
 
 const MutationsContext = createContext<Mutations | null>(null);
 
+// Resolve the live `commandBus` binding at call time. `commandBus` is typed
+// non-nullable, but under a chunk-level static-import cycle (#1466/#1563) or a
+// stale chunk it can transiently resolve to `undefined`; surfacing that as an
+// actionable error beats the cryptic native `TypeError`.
+function requireCommandBus(): CommandBus {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- see above: `commandBus` can be undefined at runtime despite its type; the guard is the whole point of this shim
+  if (!commandBus) {
+    throw new Error(
+      'Command bus unavailable — the app likely loaded a stale build. Reload the page to continue.'
+    );
+  }
+  return commandBus;
+}
+
 // Live indirection over the `commandBus` binding. The mutations adapter is
 // built over this shim, never over a snapshot of `commandBus`, so a transient
-// `undefined` at build time — a chunk-level static-import cycle (#1466/#1563)
-// or a stale chunk that resolves the binding late — can no longer poison the
-// singleton: every dispatch re-reads the current binding. The arrow methods
-// defer the read to call time, which is also why this passes
+// `undefined` at build time can no longer poison the singleton: every method
+// re-reads the current binding via `requireCommandBus()`. Reading inside the
+// method bodies (not at init) is also why this passes
 // `local/no-init-time-imported-call` (#1566).
 const liveCommandBus: CommandBus = {
   dispatch(command) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `commandBus` is typed non-nullable but can resolve to `undefined` at runtime under chunk-level import cycles / stale chunks (#1466/#1563); the guard is the whole point of this shim
-    if (!commandBus) {
-      throw new Error(
-        'Command bus unavailable — the app likely loaded a stale build. Reload the page to continue.'
-      );
-    }
-    return commandBus.dispatch(command);
+    return requireCommandBus().dispatch(command);
   },
   use(middleware) {
-    commandBus.use(middleware);
+    requireCommandBus().use(middleware);
   },
   resetMiddleware() {
-    commandBus.resetMiddleware();
+    requireCommandBus().resetMiddleware();
   },
 };
 


### PR DESCRIPTION
## What

Fixes the recurring **\`TypeError: Cannot read properties of undefined (reading 'dispatch')\`** in \`addBin\` — drawing a bin silently breaks for affected users (surfaced again in PostHog error tracking, last seen today on Edge/Windows).

This is the **3rd recurrence** of the chunk-level static-import-cycle / stale-chunk class (#1466, then the lazy-build fix in #1563).

## Why the prior fix wasn't enough

#1563 made the mutations singleton lazy, but \`getCqrsMutations()\` still **snapshotted \`commandBus\` by value** at first read. A race where the binding is briefly \`undefined\` (chunk cycle settling, or a stale chunk that resolves the binding late) poisons the singleton **permanently** — every subsequent mutation closes over \`undefined\` and throws on \`dispatch\`.

## The fix

Build the adapter over a \`liveCommandBus\` shim whose arrow methods **re-read the \`commandBus\` binding on every dispatch** — never a snapshot. The race now self-heals once the binding resolves. When the bus is genuinely unavailable (truly stale chunk), it throws a clear *"stale build — reload the page"* error instead of the cryptic native one, which also improves error-tracking signal.

The object-literal-with-deferred-arrow-read shape is the sanctioned pattern that passes the \`local/no-init-time-imported-call\` ESLint rule added in #1566.

## Tests

New \`MutationsContext.test.tsx\` (3 cases) mocks \`@/core/cqrs\` with a getter-based \`commandBus\` to flip it undefined→defined and proves the singleton no longer poisons.

- ✅ typecheck, eslint clean
- ✅ new tests pass; full suite green

## Also done (out-of-band, no code)

Added two PostHog error-tracking suppression rules scoped tightly by \`\$exception_fingerprint\` for browser-extension noise that was burying real issues: \`Error: undefined\` from the init.ts global handler (232 occ) and \`CustomEvent … isTrusted\` (222 occ).