### PR TITLE
fix(generation): surface 3D engine load failures and restore kernel-perf metric

### DIFF
--- a/src/features/baseplate/hooks/useBaseplateGeneration.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.ts
@@ -30,6 +30,7 @@ import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
 import { bridgeManager, workerPoolManager, createDraftSkipGate } from '@/shared/generation/bridge';
 import type { GenerationBridge } from '@/shared/generation/bridge';
 import type { WorkerPool } from '@/shared/generation/bridge';
+import { captureWasmLoadFailure } from '@/shared/generation/captureWasmLoadFailure';
 import {
   trackWasmThreadingStatus,
   trackCachePerformance,
@@ -681,6 +682,7 @@ export function useBaseplateGeneration(): void {
           .getState()
           .addToast(t('baseplate.toast.engineInitFailed', { message }), 'error');
         setWasmStatus('error');
+        captureWasmLoadFailure(e, 'baseplate_preview');
       });
 
     return () => {

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -4,6 +4,7 @@ import { isErr } from '@/core/result';
 import { useDesignerStore } from '../store';
 import { bridgeManager, createDraftSkipGate } from '@/shared/generation/bridge';
 import type { GenerationBridge } from '@/shared/generation/bridge';
+import { captureWasmLoadFailure } from '@/shared/generation/captureWasmLoadFailure';
 import { validateCompartmentSizes } from '../utils/validation';
 import {
   trackWasmThreadingStatus,
@@ -239,8 +240,10 @@ export function useGeneration(): void {
         prevEpochRef.current = currentState.generation.epoch;
         void runGeneration(currentState.params);
       })
-      .catch((_e: unknown) => {
-        if (!cancelled) setWasmStatus('error');
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setWasmStatus('error');
+        captureWasmLoadFailure(e, 'bin_designer_preview');
       });
 
     // Acquire the best-effort draft-preview bridge in parallel with the exact

--- a/src/features/generation/bridge/BridgeManager.ts
+++ b/src/features/generation/bridge/BridgeManager.ts
@@ -228,3 +228,12 @@ function resolveKernel(): KernelName {
   if (labs.isFeatureEnabled('brepkit_kernel')) return 'brepkit';
   return 'occt-wasm';
 }
+
+/**
+ * The kernel the exact bridge would load right now. Exposed so callers can
+ * attribute a load failure to a specific kernel in telemetry (a failed bridge
+ * never exists to query, so the resolved choice is the only signal).
+ */
+export function getActiveKernel(): KernelName {
+  return resolveKernel();
+}

--- a/src/features/generation/bridge/index.ts
+++ b/src/features/generation/bridge/index.ts
@@ -10,7 +10,7 @@ export type {
   DividersExportResult,
 } from './GenerationBridge';
 export { getActiveBridge } from './bridgeRef';
-export { bridgeManager } from './BridgeManager';
+export { bridgeManager, getActiveKernel } from './BridgeManager';
 export { WorkerPool } from './WorkerPool';
 export { WorkerPoolManager, workerPoolManager } from './WorkerPoolManager';
 export type {

--- a/src/features/generation/worker/handlers/stageStats.test.ts
+++ b/src/features/generation/worker/handlers/stageStats.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { stageStats } from './stageStats';
+import type { PerfSnapshot } from '../../bridge/types';
+
+function snapshot(stages: { name: string; ms: number }[]): PerfSnapshot {
+  return {
+    totalMs: stages.reduce((s, e) => s + e.ms, 0),
+    stages,
+    featureBuilders: [],
+    wallPatternSubsteps: [],
+    hexCenterCount: 0,
+    patternCutToolCount: 0,
+  };
+}
+
+describe('stageStats', () => {
+  it('prefixes each stage with stage_ and counts one occurrence', () => {
+    expect(
+      stageStats(
+        snapshot([
+          { name: 'base', ms: 100 },
+          { name: 'features', ms: 50 },
+        ])
+      )
+    ).toEqual({
+      stage_base: { totalMs: 100, count: 1 },
+      stage_features: { totalMs: 50, count: 1 },
+    });
+  });
+
+  it('accumulates stages that share a name (translate + tessellate both report as merge)', () => {
+    // Regression guard: overwriting per key would drop the translate timing.
+    expect(
+      stageStats(
+        snapshot([
+          { name: 'merge', ms: 30 }, // translateStage
+          { name: 'merge', ms: 70 }, // tessellateStage
+        ])
+      )
+    ).toEqual({ stage_merge: { totalMs: 100, count: 2 } });
+  });
+
+  it('returns an empty object for a snapshot with no stages', () => {
+    expect(stageStats(snapshot([]))).toEqual({});
+  });
+});

--- a/src/features/generation/worker/handlers/stageStats.ts
+++ b/src/features/generation/worker/handlers/stageStats.ts
@@ -1,0 +1,27 @@
+import type { PerfSnapshot } from '../../bridge/types';
+
+/**
+ * Convert pipeline stage timings into the kernel-perf stats shape, namespaced
+ * with a `stage_` prefix so they never collide with brepjs's op categories.
+ *
+ * Stage names are not unique: translateStage and tessellateStage both report as
+ * `'merge'` (they share the `'merge'` progress phase), so two entries collapse
+ * into `stage_merge` with `count: 2`. The accumulation is required — overwriting
+ * per key would silently drop the translate timing.
+ */
+export function stageStats(
+  snapshot: PerfSnapshot
+): Record<string, { totalMs: number; count: number }> {
+  const acc = new Map<string, { totalMs: number; count: number }>();
+  for (const { name, ms } of snapshot.stages) {
+    const key = `stage_${name}`;
+    const prev = acc.get(key);
+    if (prev) {
+      prev.totalMs += ms;
+      prev.count += 1;
+    } else {
+      acc.set(key, { totalMs: ms, count: 1 });
+    }
+  }
+  return Object.fromEntries(acc);
+}

--- a/src/features/generation/worker/handlers/workerContext.ts
+++ b/src/features/generation/worker/handlers/workerContext.ts
@@ -7,13 +7,8 @@
  */
 
 import { getPerformanceStats, resetPerformanceStats } from 'brepjs';
-import type {
-  WorkerResponse,
-  MeshData,
-  KernelName,
-  ExportErrorCode,
-  PerfSnapshot,
-} from '../../bridge/types';
+import type { WorkerResponse, MeshData, KernelName, ExportErrorCode } from '../../bridge/types';
+import { stageStats } from './stageStats';
 import { getAllShapeCacheStats, resetAllShapeCacheStats } from '../generators/shapeCache';
 import { getBaseplateCacheStats, resetBaseplateCacheStats } from '../generators/baseplateGenerator';
 import {
@@ -35,26 +30,6 @@ let hardwareConcurrency = 4;
 /** Post a typed response to the main thread */
 export function respond(response: WorkerResponse): void {
   self.postMessage(response);
-}
-
-/**
- * Convert pipeline stage timings into the kernel-perf stats shape, namespaced
- * with a `stage_` prefix so they never collide with brepjs's op categories.
- * Each stage is recorded once per generation, so `count` tallies occurrences.
- */
-function stageStats(snapshot: PerfSnapshot): Record<string, { totalMs: number; count: number }> {
-  const acc = new Map<string, { totalMs: number; count: number }>();
-  for (const { name, ms } of snapshot.stages) {
-    const key = `stage_${name}`;
-    const prev = acc.get(key);
-    if (prev) {
-      prev.totalMs += ms;
-      prev.count += 1;
-    } else {
-      acc.set(key, { totalMs: ms, count: 1 });
-    }
-  }
-  return Object.fromEntries(acc);
 }
 
 /** Post a progress update */

--- a/src/features/generation/worker/handlers/workerContext.ts
+++ b/src/features/generation/worker/handlers/workerContext.ts
@@ -7,7 +7,13 @@
  */
 
 import { getPerformanceStats, resetPerformanceStats } from 'brepjs';
-import type { WorkerResponse, MeshData, KernelName, ExportErrorCode } from '../../bridge/types';
+import type {
+  WorkerResponse,
+  MeshData,
+  KernelName,
+  ExportErrorCode,
+  PerfSnapshot,
+} from '../../bridge/types';
 import { getAllShapeCacheStats, resetAllShapeCacheStats } from '../generators/shapeCache';
 import { getBaseplateCacheStats, resetBaseplateCacheStats } from '../generators/baseplateGenerator';
 import {
@@ -29,6 +35,26 @@ let hardwareConcurrency = 4;
 /** Post a typed response to the main thread */
 export function respond(response: WorkerResponse): void {
   self.postMessage(response);
+}
+
+/**
+ * Convert pipeline stage timings into the kernel-perf stats shape, namespaced
+ * with a `stage_` prefix so they never collide with brepjs's op categories.
+ * Each stage is recorded once per generation, so `count` tallies occurrences.
+ */
+function stageStats(snapshot: PerfSnapshot): Record<string, { totalMs: number; count: number }> {
+  const acc = new Map<string, { totalMs: number; count: number }>();
+  for (const { name, ms } of snapshot.stages) {
+    const key = `stage_${name}`;
+    const prev = acc.get(key);
+    if (prev) {
+      prev.totalMs += ms;
+      prev.count += 1;
+    } else {
+      acc.set(key, { totalMs: ms, count: 1 });
+    }
+  }
+  return Object.fromEntries(acc);
 }
 
 /** Post a progress update */
@@ -101,9 +127,15 @@ export function runGeneration(
     if (activeRequestId !== requestId) return;
 
     const timingMs = performance.now() - startTime;
-    const kernelPerfStats = getPerformanceStats();
     const perfSnapshot = perfCollector.snapshot(timingMs);
     recordCompletedGeneration(perfSnapshot);
+    // brepjs's perf categories are populated only by the legacy opencascade
+    // adapter. occt-wasm (the default kernel) routes booleans through its C++
+    // BooleanPipeline and doesn't instrument mesh timing, so getPerformanceStats
+    // returns all-zero counts and `generation_kernel_perf` would never fire
+    // (its emit guard drops zero-count categories). Fold in the kernel-agnostic
+    // pipeline stage timings so the metric survives any kernel.
+    const kernelPerfStats = { ...getPerformanceStats(), ...stageStats(perfSnapshot) };
 
     const maybeCopy = <T extends Float32Array | Uint32Array>(buf: T): T =>
       (copyBuffers ? buf.slice() : buf) as T;

--- a/src/shared/generation/bridge.ts
+++ b/src/shared/generation/bridge.ts
@@ -6,7 +6,7 @@
  * the bridge without a cross-feature import violation.
  */
 export { GenerationBridge } from '@/features/generation/bridge';
-export { getActiveBridge, bridgeManager } from '@/features/generation/bridge';
+export { getActiveBridge, bridgeManager, getActiveKernel } from '@/features/generation/bridge';
 export { WorkerPool, workerPoolManager } from '@/features/generation/bridge';
 export {
   FAST_EXACT_SKIP_MS,

--- a/src/shared/generation/captureWasmLoadFailure.test.ts
+++ b/src/shared/generation/captureWasmLoadFailure.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }));
+vi.mock('@/shared/analytics/posthog', () => ({ captureException }));
+vi.mock('@/shared/generation/bridge', () => ({ getActiveKernel: () => 'occt-wasm' }));
+
+import { captureWasmLoadFailure } from './captureWasmLoadFailure';
+
+describe('captureWasmLoadFailure', () => {
+  beforeEach(() => captureException.mockClear());
+
+  it('captures with surface, kernel, and a stale_asset=true flag for cache failures', () => {
+    const err = new Error('Worker failed to initialize: script failed to load');
+    captureWasmLoadFailure(err, 'bin_designer_preview');
+
+    expect(captureException).toHaveBeenCalledWith(err, {
+      surface: 'bin_designer_preview',
+      kernel: 'occt-wasm',
+      stale_asset: true,
+    });
+  });
+
+  it('flags genuine (non-stale) load errors with stale_asset=false', () => {
+    captureWasmLoadFailure(new Error('out of memory'), 'baseplate_preview');
+
+    expect(captureException).toHaveBeenCalledWith(expect.any(Error), {
+      surface: 'baseplate_preview',
+      kernel: 'occt-wasm',
+      stale_asset: false,
+    });
+  });
+
+  it('wraps non-Error throwables', () => {
+    captureWasmLoadFailure('boom', 'bin_designer_preview');
+
+    const [arg] = captureException.mock.calls[0];
+    expect(arg).toBeInstanceOf(Error);
+    expect((arg as Error).message).toBe('boom');
+  });
+});

--- a/src/shared/generation/captureWasmLoadFailure.ts
+++ b/src/shared/generation/captureWasmLoadFailure.ts
@@ -1,0 +1,25 @@
+/**
+ * Report a geometry-kernel (WASM) load failure to error tracking.
+ *
+ * Both the bin-designer and baseplate preview paths drive the user-visible
+ * "Failed to load 3D engine" state but historically swallowed the underlying
+ * error, so these failures were invisible to error tracking and only showed in
+ * session replay. This centralizes the capture with the kernel name and a
+ * stale-asset flag so the self-healing cache class can be split from genuine
+ * load regressions.
+ */
+
+import { captureException } from '@/shared/analytics/posthog';
+import { getActiveKernel } from '@/shared/generation/bridge';
+import { isStaleAssetError } from './wasmLoadError';
+
+export function captureWasmLoadFailure(
+  error: unknown,
+  surface: 'bin_designer_preview' | 'baseplate_preview'
+): void {
+  captureException(error instanceof Error ? error : new Error(String(error)), {
+    surface,
+    kernel: getActiveKernel(),
+    stale_asset: isStaleAssetError(error),
+  });
+}

--- a/src/shared/generation/wasmLoadError.test.ts
+++ b/src/shared/generation/wasmLoadError.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { isStaleAssetError } from './wasmLoadError';
+
+describe('isStaleAssetError', () => {
+  it('flags the fetchWasmBinary stale-asset message', () => {
+    const err = new Error(
+      'OCCT WASM asset returned text/html, not a WebAssembly binary (/assets/occt.wasm). ' +
+        'A stale cache or service worker is likely serving a missing asset — hard-reload the page.'
+    );
+    expect(isStaleAssetError(err)).toBe(true);
+  });
+
+  it('flags the worker bootstrap script-load failure', () => {
+    const err = new Error(
+      'Worker failed to initialize: script failed to load (possible network error, CSP restriction, or unsupported browser)'
+    );
+    expect(isStaleAssetError(err)).toBe(true);
+  });
+
+  it('flags the raw Emscripten CompileError magic-byte message', () => {
+    expect(isStaleAssetError(new Error("CompileError: ... doesn't start with '\\0asm'"))).toBe(
+      true
+    );
+  });
+
+  it('flags a failed dynamic chunk import', () => {
+    expect(
+      isStaleAssetError(new Error('Failed to fetch dynamically imported module: /assets/occt-x.js'))
+    ).toBe(true);
+  });
+
+  it('does not flag unrelated generation errors', () => {
+    expect(isStaleAssetError(new Error('Split export range failed: STL_EXPORT_FAILED'))).toBe(
+      false
+    );
+  });
+
+  it('handles non-Error values without throwing', () => {
+    expect(isStaleAssetError('script failed to load')).toBe(true);
+    expect(isStaleAssetError(undefined)).toBe(false);
+  });
+});

--- a/src/shared/generation/wasmLoadError.ts
+++ b/src/shared/generation/wasmLoadError.ts
@@ -1,0 +1,25 @@
+/**
+ * Classify geometry-kernel (WASM) load failures for telemetry.
+ *
+ * The dominant real-world failure is not a code bug: a stale service worker or
+ * browser cache serves index.html for a hashed .wasm/chunk URL that no longer
+ * exists after a redeploy, so the worker bootstrap or `fetchWasmBinary` aborts.
+ * It self-heals on a hard reload. Flagging it lets dashboards separate that
+ * self-healing cache class from genuine load regressions — without the flag the
+ * two are indistinguishable, and the cache class is invisible because the
+ * affected code paths historically swallowed the error.
+ */
+
+const STALE_ASSET_SIGNATURES = [
+  'not a WebAssembly binary',
+  'stale cache or service worker',
+  "doesn't start with",
+  'script failed to load',
+  'Failed to fetch dynamically imported module',
+  'WASM fetch failed',
+] as const;
+
+export function isStaleAssetError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return STALE_ASSET_SIGNATURES.some((sig) => message.includes(sig));
+}


### PR DESCRIPTION
## Why

Users were hitting "Failed to load 3D engine" errors visible in session replay, with nothing in error-tracking to corroborate. Investigation (PostHog error-tracking + trends across the 06-05 deploy cluster) found **no aggregate engine-load regression** — `wasm_threading_status` (load success), `generation_cache_stats`, and `bin_export_succeeded` are all flat across the deploy boundary. The replay-only impression came from two real-but-separate problems:

1. **Engine-load failures were invisible to error tracking.** Both preview paths drove the user-visible "Failed to load 3D engine" state but never captured the error — `useGeneration.ts` swallowed it (`_e`), `useBaseplateGeneration.ts` only toasted. So failures (dominated by the chronic stale-service-worker / missing-chunk class) surfaced **only** in session replay, with no dashboard to calibrate against.

2. **`generation_kernel_perf` went dark on 06-03** (~168 → ~20/day). Not user-facing: brepjs only instruments `perfTimer` in its legacy opencascade adapter, not `occtWasm/*`. Once occt-wasm became the worker kernel (#1970/#1992), `getPerformanceStats()` returned all-zero counts and the `count > 0` emit guard suppressed the event.

## What

- **`wasmLoadError.ts`** — pure `isStaleAssetError()` classifier (stale-cache vs genuine failure).
- **`captureWasmLoadFailure.ts`** — centralizes `captureException` with `surface`, `kernel`, and a `stale_asset` flag; wired into both preview load-failure paths.
- **`stageStats.ts` + `workerContext.ts`** — folds the kernel-agnostic `PerfCollector` stage timings into `KERNEL_PERF_STATS` as `stage_*` keys, so the metric fires regardless of kernel.
- Exposed `getActiveKernel()` so a failed bridge (which never exists to query) can still be attributed.

## Dashboard note

For occt-wasm, brepjs op-category props (`loft_ms`, `extrude_ms`, `fillet_ms`, `mesh_ms`, `edge_mesh_ms`) are dead — switch `generation_kernel_perf` queries to the `stage_*_ms` series: `stage_base_ms`, `stage_features_ms`, `stage_boolean_ms`, and `stage_merge_ms`.

`stage_merge_ms` aggregates the translate + tessellate stages (both report under the shared `'merge'` progress phase, so `stage_merge_count` is 2). There is no separate `stage_tessellate_ms`.

## Testing

- New sibling tests: `wasmLoadError.test.ts`, `captureWasmLoadFailure.test.ts`, `stageStats.test.ts` (the last locks in the merge-collision accumulation).
- Typecheck + ESLint clean; affected hook and `kernelPerfStats` tests pass.