### PR TITLE
fix(generation): bump occt-wasm to 3.3.0 for Safari/iOS engine load

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "ioredis": "^5.11.0",
     "lz-string": "^1.5.0",
     "manifold-3d": "3.5.0",
-    "occt-wasm": "3.2.4",
+    "occt-wasm": "3.3.0",
     "polygon-clipping": "^0.15.7",
     "posthog-js": "^1.376.2",
     "react": "^19.2.6",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "ioredis": "^5.11.0",
     "lz-string": "^1.5.0",
     "manifold-3d": "3.5.0",
-    "occt-wasm": "3.2.2",
+    "occt-wasm": "3.2.4",
     "polygon-clipping": "^0.15.7",
     "posthog-js": "^1.376.2",
     "react": "^19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 3.7.0
       brepjs:
         specifier: 18.66.2
-        version: 18.66.2(brepkit-wasm@2.101.3)(occt-wasm@3.2.2)
+        version: 18.66.2(brepkit-wasm@2.101.3)(occt-wasm@3.3.0)
       brepkit-wasm:
         specifier: ^2.101.3
         version: 2.101.3
@@ -93,8 +93,8 @@ importers:
         specifier: 3.5.0
         version: 3.5.0(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(esbuild-wasm@0.27.7)
       occt-wasm:
-        specifier: 3.2.2
-        version: 3.2.2
+        specifier: 3.3.0
+        version: 3.3.0
       polygon-clipping:
         specifier: ^0.15.7
         version: 0.15.7
@@ -4933,8 +4933,8 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
-  occt-wasm@3.2.2:
-    resolution: {integrity: sha512-capzTfhMUyaLChRs2xHkVaLDGvcrTQGJPCWl7KdFdKEKz7UcLTE/ojzXS3HQu+e6NvUQumheB0sewv89LfHmRg==}
+  occt-wasm@3.3.0:
+    resolution: {integrity: sha512-qlGKZX5W0q1/TSOwEYfRyjas0lC9LrjeHUjC+sRvGc7XWLJT2U0KuvhGuMHuLvtkEIs2ozjLY7VO1rav/tea5g==}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -9119,13 +9119,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.66.2(brepkit-wasm@2.101.3)(occt-wasm@3.2.2):
+  brepjs@18.66.2(brepkit-wasm@2.101.3)(occt-wasm@3.3.0):
     dependencies:
       flatbush: 4.5.1
       opentype.js: 1.3.4
     optionalDependencies:
       brepkit-wasm: 2.101.3
-      occt-wasm: 3.2.2
+      occt-wasm: 3.3.0
 
   brepkit-wasm@2.101.3: {}
 
@@ -10686,7 +10686,7 @@ snapshots:
 
   obug@2.1.1: {}
 
-  occt-wasm@3.2.2:
+  occt-wasm@3.3.0:
     dependencies:
       comlink: 4.4.2
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6852`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `6858`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6788`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `6794`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6924`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `6930`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6924`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `6930`;
 
 exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `6884`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`solid cutouts > 2×2 solid with 3×2 grid array of circles 1`] = `3420`;
 
-exports[`solid cutouts > 2×2 solid with chamfered + scooped rectangle cutout 1`] = `3558`;
+exports[`solid cutouts > 2×2 solid with chamfered + scooped rectangle cutout 1`] = `3564`;
 
-exports[`solid cutouts > 2×2 solid with chamfered circle cutout 1`] = `2638`;
+exports[`solid cutouts > 2×2 solid with chamfered circle cutout 1`] = `2640`;
 
 exports[`solid cutouts > 2×2 solid with chamfered hexagon cutout 1`] = `2622`;
 


### PR DESCRIPTION
## Why

PostHog error tracking surfaced a **100%-Safari / Mobile-Safari cluster** the moment the new engine-load telemetry shipped: `Kernel init failed: WebAssembly.Module doesn't parse … relaxed simd instructions not supported` (28 occ / 21 sessions / 14 users in ~7h). Those WebKit builds can't compile WASM modules containing relaxed-SIMD, so kernel init aborts and the 3D engine fails to load entirely.

Root cause: the `occt-wasm` kernel (default exact kernel) was compiled with `-mrelaxed-simd` (thousands of `f64x2.relaxed_madd`). The manifold draft kernel has none and loads fine — so Safari users likely saw the draft preview, then a dead exact pass.

## What

- Bump `occt-wasm` 3.2.2 → **3.3.0**, which drops relaxed-SIMD (keeps baseline `-msimd128`). Fix shipped in andymai/occt-wasm#148; published 3.3.0 verified relaxed-SIMD-free (0 opcodes via `wasm-opt -S`).
- Re-baseline two scenario snapshots whose triangle counts drift sub-percent from losing relaxed fused-multiply-add:
  - `honeycombJunction`: 4 counts (+6 tris each)
  - `solidCutouts`: 2 counts (+2/+6 tris)

## Verification

- All **826** generation assertions pass against the **published 3.3.0** artifact (snapshots regenerated locally reproduce exactly — geometry is now CPU-deterministic without relaxed-FMA).
- Builder image `ghcr.io/andymai/occt-wasm-builder` rebuilt + pushed (relaxed-SIMD-free OCCT) so the published package is clean end-to-end.

Closes the Safari/iOS engine-load failure ([PostHog issue](https://us.posthog.com/project/284234/error_tracking/019e9d67-86d7-7f23-a4c3-8280581c0f58)).