### PR TITLE
fix(bin-designer): gate angled dividers behind advanced opt-in

### DIFF
--- a/src/core/store/settings.types.ts
+++ b/src/core/store/settings.types.ts
@@ -201,6 +201,15 @@ export interface UserSettings {
    */
   handlesLinked: boolean;
 
+  /**
+   * Whether angled (diagonal) divider editing is exposed in the bin designer.
+   * Off by default — it's an advanced feature, so the editing UI (the tilt list
+   * and the on-grid hit targets) stays hidden until the user opts in. Existing
+   * tilts on a saved design still generate regardless of this flag; only the
+   * editing affordances are gated.
+   */
+  angledDividersEnabled: boolean;
+
   // Print view preferences
   printViewSettings: PrintViewSettings;
 
@@ -318,6 +327,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   designListViewMode: 'grid',
   wallCutoutsLinked: true,
   handlesLinked: true,
+  angledDividersEnabled: false,
 
   // Print view preferences
   printViewSettings: { ...DEFAULT_PRINT_VIEW_SETTINGS },

--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -242,6 +242,15 @@ intersection`, not XOR** — they coincide for 2 members but diverge for
     supersedes it. A monotonic token drops a draft once a newer edit starts or the
     exact for its edit has landed (covers the exact-resolves-before-draft race).
     Drafts skip the undo/redo mesh cache — history holds exact geometry only.
+18. **Angled dividers are an advanced opt-in, gating UI only** — the editing
+    surfaces (the `DividerTiltSubsection` tilt list/inspector and the on-grid
+    `DividerHitTargets` overlay in `CompartmentEditor`) are hidden unless
+    `settings.angledDividersEnabled` is on (default `false`, persisted; toggled
+    inline from the compact header in the Grid Dividers panel). The gate is
+    **UI-only**: `compartments.dividerOverrides` and the worker geometry path are
+    untouched, so a saved design with tilts still renders and exports them while
+    the toggle is off — only editing is hidden (#2044). Toggling off clears the
+    in-flight selection/hover/preview so the canvas overlay drops cleanly.
 
 ## Thumbnail Pipeline
 

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
@@ -2,8 +2,14 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { resetAllStores } from '@/test/testUtils';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { useSettingsStore } from '@/core/store/settings';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import { CompartmentEditor } from './CompartmentEditor';
+
+const TWO_BY_TWO = {
+  ...DEFAULT_BIN_PARAMS,
+  compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, rows: 2, cells: [0, 1, 2, 3] },
+};
 
 describe('CompartmentEditor', () => {
   beforeEach(() => {
@@ -101,6 +107,22 @@ describe('CompartmentEditor', () => {
     });
     render(<CompartmentEditor />);
     expect(screen.getByText(/drag to merge/i)).toBeInTheDocument();
+  });
+
+  it('hides the angled-divider hit targets until the feature is opted into', () => {
+    useDesignerStore.setState({ params: TWO_BY_TWO });
+    render(<CompartmentEditor />);
+    // Off by default: no on-grid divider hit targets.
+    expect(screen.queryByRole('button', { name: /Edit divider between Comp/i })).toBeNull();
+  });
+
+  it('renders the angled-divider hit targets once the feature is enabled', () => {
+    useSettingsStore.getState().updateSetting('angledDividersEnabled', true);
+    useDesignerStore.setState({ params: TWO_BY_TWO });
+    render(<CompartmentEditor />);
+    expect(
+      screen.getAllByRole('button', { name: /Edit divider between Comp/i }).length
+    ).toBeGreaterThan(0);
   });
 
   it('shows reset button when compartments are merged', () => {

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
@@ -19,6 +19,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { useSettingsStore } from '@/core/store/settings';
 import { DESIGNER_CONSTRAINTS, WALL_THICKNESS_OPTIONS } from '@/features/bin-designer/constants';
 import { StepperControl } from '@/shared/components/StepperControl';
 import { SnappingSlider } from '../controls/SnappingSlider';
@@ -81,6 +82,11 @@ export function CompartmentEditor() {
       setHoveredDividerKey: s.setHoveredDividerKey,
     }))
   );
+
+  // Angled dividers are an advanced opt-in (see DividerTiltSubsection). Keep the
+  // on-grid hit-target overlay hidden until the user enables editing so dense
+  // grids stay legible (issue #2044).
+  const angledDividersEnabled = useSettingsStore((s) => s.settings.angledDividersEnabled);
 
   const { innerW: interiorW, innerD: interiorD } = getInteriorDims({
     width,
@@ -505,7 +511,7 @@ export function CompartmentEditor() {
             {/* Divider hit targets: clickable lines above the cells, transparent
                 container with per-line pointer-events so cell drag-merge still
                 works. Hidden during cell-merge drag to keep the surface calm. */}
-            {!isDragging && eligibleDividers.length > 0 && (
+            {!isDragging && angledDividersEnabled && eligibleDividers.length > 0 && (
               <DividerHitTargets
                 compartments={compartments}
                 dividers={eligibleDividers}

--- a/src/features/bin-designer/components/CompartmentEditor/DividerTiltSubsection.test.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/DividerTiltSubsection.test.tsx
@@ -2,8 +2,13 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DividerTiltSubsection } from './DividerTiltSubsection';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { useSettingsStore } from '@/core/store/settings';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import { resetAllStores } from '@/test/testUtils';
+
+const enableAngledDividers = (): void => {
+  useSettingsStore.getState().updateSetting('angledDividersEnabled', true);
+};
 
 describe('DividerTiltSubsection', () => {
   beforeEach(() => {
@@ -12,6 +17,9 @@ describe('DividerTiltSubsection', () => {
       params: DEFAULT_BIN_PARAMS,
       ui: { ...s.ui, selectedDividerKey: null, hoveredDividerKey: null, dividerTiltPreview: null },
     }));
+    // Angled-divider editing is an advanced opt-in (off by default); enable it
+    // so the existing behavioural specs exercise the list/inspector content.
+    enableAngledDividers();
   });
 
   const setGrid = (cols: number, rows: number): void => {
@@ -124,5 +132,50 @@ describe('DividerTiltSubsection', () => {
     render(<DividerTiltSubsection />);
     openInspector();
     expect(screen.queryByText(/removed along tilted dividers/i)).toBeNull();
+  });
+
+  describe('advanced opt-in toggle', () => {
+    const disableAngledDividers = (): void => {
+      useSettingsStore.getState().updateSetting('angledDividersEnabled', false);
+    };
+
+    it('shows the opt-in toggle but hides the editing list when disabled', () => {
+      disableAngledDividers();
+      setGrid(2, 2); // 4 eligible dividers
+      render(<DividerTiltSubsection />);
+      expect(
+        screen.getByRole('switch', { name: /enable diagonal divider editing/i })
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Edit divider between Comp/i })).toBeNull();
+    });
+
+    it('enabling the toggle reveals the divider list and persists the preference', () => {
+      disableAngledDividers();
+      setGrid(2, 2);
+      render(<DividerTiltSubsection />);
+      fireEvent.click(screen.getByRole('switch', { name: /enable diagonal divider editing/i }));
+      expect(useSettingsStore.getState().settings.angledDividersEnabled).toBe(true);
+      expect(screen.getAllByRole('button', { name: /Edit divider between Comp/i })).toHaveLength(4);
+    });
+
+    it('preserves existing tilts when the feature is disabled (render-only, not editable)', () => {
+      setGrid(2, 1);
+      useDesignerStore.getState().setDividerOverride(0, 1, -8, 8);
+      disableAngledDividers();
+      render(<DividerTiltSubsection />);
+      // Editing UI is gone…
+      expect(screen.queryByRole('button', { name: /Edit divider between Comp/i })).toBeNull();
+      // …but the override data survives so the 3D model still generates the tilt.
+      expect(useDesignerStore.getState().params.compartments.dividerOverrides).toHaveLength(1);
+    });
+
+    it('clears any active selection when toggled off', () => {
+      setGrid(2, 1);
+      render(<DividerTiltSubsection />);
+      openInspector();
+      expect(useDesignerStore.getState().ui.selectedDividerKey).not.toBeNull();
+      fireEvent.click(screen.getByRole('switch', { name: /enable diagonal divider editing/i }));
+      expect(useDesignerStore.getState().ui.selectedDividerKey).toBeNull();
+    });
   });
 });

--- a/src/features/bin-designer/components/CompartmentEditor/DividerTiltSubsection.test.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/DividerTiltSubsection.test.tsx
@@ -169,13 +169,24 @@ describe('DividerTiltSubsection', () => {
       expect(useDesignerStore.getState().params.compartments.dividerOverrides).toHaveLength(1);
     });
 
-    it('clears any active selection when toggled off', () => {
+    it('clears active selection, hover, and in-flight preview when toggled off', () => {
       setGrid(2, 1);
       render(<DividerTiltSubsection />);
       openInspector();
+      // Seed every transient divider-UI key so toggling off must clear them all.
+      useDesignerStore.setState((s) => ({
+        ui: {
+          ...s.ui,
+          hoveredDividerKey: '0-1',
+          dividerTiltPreview: { key: '0-1', offsetStart: -5, offsetEnd: 5 },
+        },
+      }));
       expect(useDesignerStore.getState().ui.selectedDividerKey).not.toBeNull();
       fireEvent.click(screen.getByRole('switch', { name: /enable diagonal divider editing/i }));
-      expect(useDesignerStore.getState().ui.selectedDividerKey).toBeNull();
+      const ui = useDesignerStore.getState().ui;
+      expect(ui.selectedDividerKey).toBeNull();
+      expect(ui.hoveredDividerKey).toBeNull();
+      expect(ui.dividerTiltPreview).toBeNull();
     });
   });
 });

--- a/src/features/bin-designer/components/CompartmentEditor/DividerTiltSubsection.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/DividerTiltSubsection.tsx
@@ -2,8 +2,10 @@ import { useRef, useState } from 'react';
 import { ArrowLeftIcon, InfoIcon, RotateCcwIcon } from '@/design-system/Icon';
 import { Popover } from '@/design-system/Popover';
 import { Slider } from '@/design-system/Slider';
+import { Switch } from '@/design-system/Switch';
 import { Collapsible } from '@/design-system/Collapsible';
 import { StepperControl } from '@/shared/components/StepperControl';
+import { useSettingsStore } from '@/core/store/settings';
 import { getCompartmentBounds } from '@/features/bin-designer/utils/compartments';
 import {
   ANGLE_PRESETS_DEG,
@@ -27,30 +29,71 @@ export function DividerTiltSubsection() {
     t,
   } = useDividerTiltSubsection();
 
+  const enabled = useSettingsStore((s) => s.settings.angledDividersEnabled);
+  const updateSetting = useSettingsStore((s) => s.updateSetting);
+
   if (rows.length === 0) return null;
+
+  // Advanced opt-in: angled dividers are off by default so dense grids don't
+  // drown the panel in per-divider rows (see issue #2044). Toggling off also
+  // drops any in-flight selection/hover so the canvas overlay clears cleanly.
+  const toggleEnabled = (): void => {
+    const next = !enabled;
+    updateSetting('angledDividersEnabled', next);
+    if (!next) {
+      handlers.selectDivider(null);
+      handlers.hoverDivider(null);
+    }
+  };
 
   return (
     <div className="mt-3 border-t border-stroke-subtle/40 pt-3">
-      {selectedRow ? (
-        <InspectorView
-          row={selectedRow}
-          compartments={compartments}
-          angleDeg={selectedAngleShift.angleDeg}
-          shiftMm={selectedAngleShift.shiftMm}
-          conflicts={activeConflicts}
-          handlers={handlers}
-          t={t}
-        />
-      ) : (
-        <ListView
-          rows={rows}
-          compartments={compartments}
-          hasAnyOverride={hasAnyOverride}
-          hoveredKey={hoveredKey}
-          handlers={handlers}
-          t={t}
-        />
-      )}
+      <div className={`flex items-center justify-between ${enabled ? 'mb-2' : ''}`}>
+        <div className="flex items-center gap-1.5">
+          <h3 className="text-xs font-medium uppercase tracking-wide text-content-tertiary">
+            {t('binDesigner.angledDividers.title')}
+          </h3>
+          <InfoPopoverButton t={t} />
+        </div>
+        <div className="flex items-center gap-2">
+          {enabled && hasAnyOverride && (
+            <button
+              type="button"
+              onClick={handlers.resetAll}
+              className="text-[11px] font-medium text-accent transition-colors hover:text-accent/80"
+            >
+              {t('binDesigner.angledDividers.resetAll')}
+            </button>
+          )}
+          <Switch
+            checked={enabled}
+            onChange={toggleEnabled}
+            size="sm"
+            aria-label={t('binDesigner.angledDividers.toggleLabel')}
+          />
+        </div>
+      </div>
+
+      {enabled &&
+        (selectedRow ? (
+          <InspectorView
+            row={selectedRow}
+            compartments={compartments}
+            angleDeg={selectedAngleShift.angleDeg}
+            shiftMm={selectedAngleShift.shiftMm}
+            conflicts={activeConflicts}
+            handlers={handlers}
+            t={t}
+          />
+        ) : (
+          <ListView
+            rows={rows}
+            compartments={compartments}
+            hoveredKey={hoveredKey}
+            handlers={handlers}
+            t={t}
+          />
+        ))}
     </div>
   );
 }
@@ -63,45 +106,25 @@ type Conflict = Hook['activeConflicts'][number];
 interface ListViewProps {
   readonly rows: readonly TiltRow[];
   readonly compartments: CompartmentConfig;
-  readonly hasAnyOverride: boolean;
   readonly hoveredKey: string | null;
   readonly handlers: Handlers;
   readonly t: Translate;
 }
 
-function ListView({ rows, compartments, hasAnyOverride, hoveredKey, handlers, t }: ListViewProps) {
+function ListView({ rows, compartments, hoveredKey, handlers, t }: ListViewProps) {
   return (
-    <>
-      <div className="mb-2 flex items-baseline justify-between">
-        <div className="flex items-center gap-1.5">
-          <h3 className="text-xs font-medium uppercase tracking-wide text-content-tertiary">
-            {t('binDesigner.angledDividers.title')}
-          </h3>
-          <InfoPopoverButton t={t} />
-        </div>
-        {hasAnyOverride && (
-          <button
-            type="button"
-            onClick={handlers.resetAll}
-            className="text-[11px] font-medium text-accent transition-colors hover:text-accent/80"
-          >
-            {t('binDesigner.angledDividers.resetAll')}
-          </button>
-        )}
-      </div>
-      <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
-        {rows.map((row) => (
-          <DividerRow
-            key={row.key}
-            row={row}
-            compartments={compartments}
-            isHovered={hoveredKey === row.key}
-            handlers={handlers}
-            t={t}
-          />
-        ))}
-      </div>
-    </>
+    <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
+      {rows.map((row) => (
+        <DividerRow
+          key={row.key}
+          row={row}
+          compartments={compartments}
+          isHovered={hoveredKey === row.key}
+          handlers={handlers}
+          t={t}
+        />
+      ))}
+    </div>
   );
 }
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -147,6 +147,7 @@
   "binDesigner.angledDividers.rowLabel": "Fach {a} ↔ Fach {b}",
   "binDesigner.angledDividers.slotIncompatible": "Schlitze werden auf diagonalen Trennwänden nicht unterstützt – kommt in v2.",
   "binDesigner.angledDividers.title": "Diagonale Trennwände",
+  "binDesigner.angledDividers.toggleLabel": "Bearbeitung diagonaler Trennwände aktivieren",
   "binDesigner.announce.engineLoadError": "Fehler: 3D-Engine konnte nicht geladen werden",
   "binDesigner.announce.generatingMesh": "Bin-Mesh wird generiert",
   "binDesigner.announce.loadingEngine": "3D-Engine wird geladen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1192,6 +1192,7 @@
   "binDesigner.tabEngravedTextPlaceholder": "e.g. SCREWS",
   "binDesigner.tabEngravedTextAriaLabel": "Engraved text for compartment {n}",
   "binDesigner.angledDividers.title": "Diagonal dividers",
+  "binDesigner.angledDividers.toggleLabel": "Enable diagonal divider editing",
   "binDesigner.angledDividers.rowLabel": "Comp {a} ↔ Comp {b}",
   "binDesigner.angledDividers.editRowLabel": "Edit divider between Comp {a} and Comp {b}",
   "binDesigner.angledDividers.resetAll": "Reset all",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1393,6 +1393,7 @@ const en: Record<string, string> = {
   'binDesigner.tabEngravedTextPlaceholder': 'e.g. SCREWS',
   'binDesigner.tabEngravedTextAriaLabel': 'Engraved text for compartment {n}',
   'binDesigner.angledDividers.title': 'Diagonal dividers',
+  'binDesigner.angledDividers.toggleLabel': 'Enable diagonal divider editing',
   'binDesigner.angledDividers.rowLabel': 'Comp {a} ↔ Comp {b}',
   'binDesigner.angledDividers.editRowLabel': 'Edit divider between Comp {a} and Comp {b}',
   'binDesigner.angledDividers.resetAll': 'Reset all',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -147,6 +147,7 @@
   "binDesigner.angledDividers.rowLabel": "Compart. {a} ↔ Compart. {b}",
   "binDesigner.angledDividers.slotIncompatible": "Las ranuras no se admiten en divisores diagonales — disponible en v2.",
   "binDesigner.angledDividers.title": "Divisores diagonales",
+  "binDesigner.angledDividers.toggleLabel": "Activar la edición de divisores diagonales",
   "binDesigner.announce.engineLoadError": "Error: el motor 3D no se pudo cargar",
   "binDesigner.announce.generatingMesh": "Generando malla del bin",
   "binDesigner.announce.loadingEngine": "Cargando motor 3D",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -147,6 +147,7 @@
   "binDesigner.angledDividers.rowLabel": "Comp. {a} ↔ Comp. {b}",
   "binDesigner.angledDividers.slotIncompatible": "Les fentes ne sont pas prises en charge sur les séparateurs diagonaux — à venir dans la v2.",
   "binDesigner.angledDividers.title": "Séparateurs diagonaux",
+  "binDesigner.angledDividers.toggleLabel": "Activer l'édition des séparateurs diagonaux",
   "binDesigner.announce.engineLoadError": "Erreur : impossible de charger le moteur 3D",
   "binDesigner.announce.generatingMesh": "Génération du maillage du bin",
   "binDesigner.announce.loadingEngine": "Chargement du moteur 3D",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -147,6 +147,7 @@
   "binDesigner.angledDividers.rowLabel": "区画{a}↔区画{b}",
   "binDesigner.angledDividers.slotIncompatible": "スロットは斜め仕切り板に対応していません — v2で対応予定です。",
   "binDesigner.angledDividers.title": "斜め仕切り板",
+  "binDesigner.angledDividers.toggleLabel": "斜め仕切り板の編集を有効にする",
   "binDesigner.announce.engineLoadError": "エラー：3Dエンジンの読み込みに失敗しました",
   "binDesigner.announce.generatingMesh": "ビンメッシュを生成中",
   "binDesigner.announce.loadingEngine": "3Dエンジンを読み込み中",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -147,6 +147,7 @@
   "binDesigner.angledDividers.rowLabel": "Rom {a} ↔ Rom {b}",
   "binDesigner.angledDividers.slotIncompatible": "Spor støttes ikke på skrå skillevegger — kommer i v2.",
   "binDesigner.angledDividers.title": "Skrå skillevegger",
+  "binDesigner.angledDividers.toggleLabel": "Slå på redigering av skrå skillevegger",
   "binDesigner.announce.engineLoadError": "Feil: 3D-motoren kunne ikke lastes",
   "binDesigner.announce.generatingMesh": "Genererer bin-mesh",
   "binDesigner.announce.loadingEngine": "Laster 3D-motor",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -147,6 +147,7 @@
   "binDesigner.angledDividers.rowLabel": "Vak {a} ↔ Vak {b}",
   "binDesigner.angledDividers.slotIncompatible": "Sleuven worden niet ondersteund op diagonale scheidingen — komt in v2.",
   "binDesigner.angledDividers.title": "Diagonale scheidingen",
+  "binDesigner.angledDividers.toggleLabel": "Bewerken van diagonale scheidingen inschakelen",
   "binDesigner.announce.engineLoadError": "Fout: kon de 3D-engine niet laden",
   "binDesigner.announce.generatingMesh": "Bin-mesh wordt gegenereerd",
   "binDesigner.announce.loadingEngine": "3D-engine wordt geladen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -147,6 +147,7 @@
   "binDesigner.angledDividers.rowLabel": "Compart. {a} ↔ Compart. {b}",
   "binDesigner.angledDividers.slotIncompatible": "Encaixes não são suportados em divisórias diagonais — em breve na v2.",
   "binDesigner.angledDividers.title": "Divisórias diagonais",
+  "binDesigner.angledDividers.toggleLabel": "Ativar edição de divisórias diagonais",
   "binDesigner.announce.engineLoadError": "Erro: falha ao carregar o motor 3D",
   "binDesigner.announce.generatingMesh": "Gerando malha do bin",
   "binDesigner.announce.loadingEngine": "Carregando motor 3D",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -147,6 +147,7 @@
   "binDesigner.angledDividers.rowLabel": "Fack {a} ↔ Fack {b}",
   "binDesigner.angledDividers.slotIncompatible": "Spår stöds inte på diagonala avdelare — kommer i v2.",
   "binDesigner.angledDividers.title": "Diagonala avdelare",
+  "binDesigner.angledDividers.toggleLabel": "Aktivera redigering av diagonala avdelare",
   "binDesigner.announce.engineLoadError": "Fel: 3D-motorn kunde inte laddas",
   "binDesigner.announce.generatingMesh": "Genererar bin-mesh",
   "binDesigner.announce.loadingEngine": "Laddar 3D-motor",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -147,6 +147,7 @@
   "binDesigner.angledDividers.rowLabel": "Відділ. {a} ↔ Відділ. {b}",
   "binDesigner.angledDividers.slotIncompatible": "Прорізи не підтримуються на діагональних перегородках — у v2.",
   "binDesigner.angledDividers.title": "Діагональні перегородки",
+  "binDesigner.angledDividers.toggleLabel": "Увімкнути редагування діагональних перегородок",
   "binDesigner.announce.engineLoadError": "Помилка: не вдалося завантажити 3D-рушій",
   "binDesigner.announce.generatingMesh": "Створення меша біна",
   "binDesigner.announce.loadingEngine": "Завантаження 3D-рушія",


### PR DESCRIPTION
## Summary

Fixes #2044. Angled/diagonal divider editing was **always-on**, so dense compartment grids flooded the Grid Dividers panel with one row per divider plus on-grid hit-target dots — the cluttered/overflowing UI in the issue (a 1×9 grid produces 8 list rows + 8 dots).

This makes angled dividers an **advanced opt-in**, off by default, toggled inline from the Grid Dividers panel.

## What changed

- **New persisted setting** `angledDividersEnabled` (default `false`), following the existing `wallCutoutsLinked`/`handlesLinked` pattern. Settings merge auto-migrates existing users.
- **`DividerTiltSubsection`** now always shows a compact opt-in header (title + info popover + `Switch`); the tilt list/inspector only render when enabled. Toggling off clears any in-flight selection so the canvas overlay drops cleanly.
- **`CompartmentEditor`** gates the on-grid `DividerHitTargets` overlay on the same setting.
- **i18n**: added `binDesigner.angledDividers.toggleLabel` across all 10 locales (key parity verified).

## Behavior for existing designs

Existing tilts (`compartments.dividerOverrides`) are untouched — the geometry/worker code that generates them is unchanged, so saved designs still render and export their tilts in 3D. Only the **editing** affordances are hidden until the user opts in.

## Testing

- Typecheck, lint, `check:i18n` (all 9 locales at parity) ✅
- Full unit suite: 12867 passed ✅
- Added gating tests: hidden by default, reveals on enable + persists, preserves existing tilts when off, clears selection on toggle-off; plus overlay gating in `CompartmentEditor`.

Closes #2044