### PR TITLE
feat(pwa): self-heal stale bundles on refresh/revisit

### DIFF
--- a/src/features/baseplate/hooks/useBaseplateGeneration.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.ts
@@ -30,7 +30,7 @@ import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
 import { bridgeManager, workerPoolManager, createDraftSkipGate } from '@/shared/generation/bridge';
 import type { GenerationBridge } from '@/shared/generation/bridge';
 import type { WorkerPool } from '@/shared/generation/bridge';
-import { captureWasmLoadFailure } from '@/shared/generation/captureWasmLoadFailure';
+import { handleWasmLoadFailure } from '@/shared/generation/captureWasmLoadFailure';
 import {
   trackWasmThreadingStatus,
   trackCachePerformance,
@@ -682,7 +682,7 @@ export function useBaseplateGeneration(): void {
           .getState()
           .addToast(t('baseplate.toast.engineInitFailed', { message }), 'error');
         setWasmStatus('error');
-        captureWasmLoadFailure(e, 'baseplate_preview');
+        handleWasmLoadFailure(e, 'baseplate_preview');
       });
 
     return () => {

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -4,7 +4,7 @@ import { isErr } from '@/core/result';
 import { useDesignerStore } from '../store';
 import { bridgeManager, createDraftSkipGate } from '@/shared/generation/bridge';
 import type { GenerationBridge } from '@/shared/generation/bridge';
-import { captureWasmLoadFailure } from '@/shared/generation/captureWasmLoadFailure';
+import { handleWasmLoadFailure } from '@/shared/generation/captureWasmLoadFailure';
 import { validateCompartmentSizes } from '../utils/validation';
 import {
   trackWasmThreadingStatus,
@@ -243,7 +243,7 @@ export function useGeneration(): void {
       .catch((e: unknown) => {
         if (cancelled) return;
         setWasmStatus('error');
-        captureWasmLoadFailure(e, 'bin_designer_preview');
+        handleWasmLoadFailure(e, 'bin_designer_preview');
       });
 
     // Acquire the best-effort draft-preview bridge in parallel with the exact

--- a/src/shared/generation/captureWasmLoadFailure.test.ts
+++ b/src/shared/generation/captureWasmLoadFailure.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }));
+const { captureException, recoverStaleBundle } = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  recoverStaleBundle: vi.fn(),
+}));
 vi.mock('@/shared/analytics/posthog', () => ({ captureException }));
 vi.mock('@/shared/generation/bridge', () => ({ getActiveKernel: () => 'occt-wasm' }));
+vi.mock('@/shared/pwa/staleRecovery', () => ({ recoverStaleBundle }));
 
-import { captureWasmLoadFailure } from './captureWasmLoadFailure';
+import { captureWasmLoadFailure, handleWasmLoadFailure } from './captureWasmLoadFailure';
 
 describe('captureWasmLoadFailure', () => {
-  beforeEach(() => captureException.mockClear());
+  beforeEach(() => {
+    captureException.mockClear();
+    recoverStaleBundle.mockClear();
+  });
 
   it('captures with surface, kernel, and a stale_asset=true flag for cache failures', () => {
     const err = new Error('Worker failed to initialize: script failed to load');
@@ -36,5 +43,29 @@ describe('captureWasmLoadFailure', () => {
     const [arg] = captureException.mock.calls[0];
     expect(arg).toBeInstanceOf(Error);
     expect((arg as Error).message).toBe('boom');
+  });
+});
+
+describe('handleWasmLoadFailure', () => {
+  beforeEach(() => {
+    captureException.mockClear();
+    recoverStaleBundle.mockClear();
+  });
+
+  it('captures and self-heals on a stale-bundle error', () => {
+    handleWasmLoadFailure(
+      new Error('CompileError: relaxed simd instructions not supported'),
+      'bin_designer_preview'
+    );
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(recoverStaleBundle).toHaveBeenCalledWith('wasm_load_failure:bin_designer_preview');
+  });
+
+  it('captures but does not recover on a genuine (non-stale) error', () => {
+    handleWasmLoadFailure(new Error('out of memory'), 'baseplate_preview');
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(recoverStaleBundle).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/generation/captureWasmLoadFailure.ts
+++ b/src/shared/generation/captureWasmLoadFailure.ts
@@ -14,10 +14,9 @@ import { getActiveKernel } from '@/shared/generation/bridge';
 import { recoverStaleBundle } from '@/shared/pwa/staleRecovery';
 import { isStaleAssetError } from './wasmLoadError';
 
-export function captureWasmLoadFailure(
-  error: unknown,
-  surface: 'bin_designer_preview' | 'baseplate_preview'
-): void {
+type WasmLoadSurface = 'bin_designer_preview' | 'baseplate_preview';
+
+export function captureWasmLoadFailure(error: unknown, surface: WasmLoadSurface): void {
   captureException(error instanceof Error ? error : new Error(String(error)), {
     surface,
     kernel: getActiveKernel(),
@@ -32,10 +31,7 @@ export function captureWasmLoadFailure(
  * returning user on an old bundle recovers on the spot instead of staring at a
  * dead "Failed to load 3D engine" state.
  */
-export function handleWasmLoadFailure(
-  error: unknown,
-  surface: 'bin_designer_preview' | 'baseplate_preview'
-): void {
+export function handleWasmLoadFailure(error: unknown, surface: WasmLoadSurface): void {
   captureWasmLoadFailure(error, surface);
   if (isStaleAssetError(error)) {
     void recoverStaleBundle(`wasm_load_failure:${surface}`);

--- a/src/shared/generation/captureWasmLoadFailure.ts
+++ b/src/shared/generation/captureWasmLoadFailure.ts
@@ -11,6 +11,7 @@
 
 import { captureException } from '@/shared/analytics/posthog';
 import { getActiveKernel } from '@/shared/generation/bridge';
+import { recoverStaleBundle } from '@/shared/pwa/staleRecovery';
 import { isStaleAssetError } from './wasmLoadError';
 
 export function captureWasmLoadFailure(
@@ -22,4 +23,21 @@ export function captureWasmLoadFailure(
     kernel: getActiveKernel(),
     stale_asset: isStaleAssetError(error),
   });
+}
+
+/**
+ * Report a kernel load failure and, when it looks like a stale cached bundle,
+ * self-heal: drop the stale caches + service worker and hard-reload to the
+ * latest build (once per session). Use this from the preview load paths so a
+ * returning user on an old bundle recovers on the spot instead of staring at a
+ * dead "Failed to load 3D engine" state.
+ */
+export function handleWasmLoadFailure(
+  error: unknown,
+  surface: 'bin_designer_preview' | 'baseplate_preview'
+): void {
+  captureWasmLoadFailure(error, surface);
+  if (isStaleAssetError(error)) {
+    void recoverStaleBundle(`wasm_load_failure:${surface}`);
+  }
 }

--- a/src/shared/generation/wasmLoadError.test.ts
+++ b/src/shared/generation/wasmLoadError.test.ts
@@ -29,6 +29,17 @@ describe('isStaleAssetError', () => {
     ).toBe(true);
   });
 
+  it('flags the relaxed-SIMD compile failure from a stale cached bundle', () => {
+    expect(
+      isStaleAssetError(
+        new Error(
+          "Kernel init failed: Aborted(CompileError: WebAssembly.Module doesn't parse at byte 301: " +
+            'relaxed simd instructions not supported, in function at index 219).'
+        )
+      )
+    ).toBe(true);
+  });
+
   it('does not flag unrelated generation errors', () => {
     expect(isStaleAssetError(new Error('Split export range failed: STL_EXPORT_FAILED'))).toBe(
       false

--- a/src/shared/generation/wasmLoadError.ts
+++ b/src/shared/generation/wasmLoadError.ts
@@ -17,6 +17,11 @@ const STALE_ASSET_SIGNATURES = [
   'script failed to load',
   'Failed to fetch dynamically imported module',
   'WASM fetch failed',
+  // A cached old bundle running on a browser that can't compile an instruction
+  // the old build used (e.g. relaxed-SIMD on some Safari/iOS WebKit). Current
+  // builds no longer emit it, so seeing it means the client is on stale cached
+  // code — recoverable by fetching the latest bundle.
+  'relaxed simd instructions not supported',
 ] as const;
 
 export function isStaleAssetError(error: unknown): boolean {

--- a/src/shared/hooks/usePWAUpdate.test.ts
+++ b/src/shared/hooks/usePWAUpdate.test.ts
@@ -36,6 +36,9 @@ vi.mock('@/shared/pwa/iosBypass', () => ({
 vi.mock('@/shared/pwa/smokeGate', () => ({
   runUpdateSmokeTest: vi.fn(),
 }));
+vi.mock('@/shared/pwa/bootVersionCheck', () => ({
+  checkBootVersionFreshness: vi.fn().mockResolvedValue(undefined),
+}));
 
 // Mock the virtual:pwa-register/react module
 vi.mock('virtual:pwa-register/react', () => ({

--- a/src/shared/hooks/usePWAUpdate.ts
+++ b/src/shared/hooks/usePWAUpdate.ts
@@ -17,6 +17,7 @@ import { useTranslation } from '@/i18n';
 import { isSmokeMode } from '@/shared/utils/smokeMode';
 import { runUpdateSmokeTest, type SmokeGateResult } from '@/shared/pwa/smokeGate';
 import { checkBootVersionFreshness } from '@/shared/pwa/bootVersionCheck';
+import { PRECACHE_PREFIX } from '@/shared/pwa/cacheNames';
 import { getSmokeGateFlag } from '@/shared/pwa/featureFlag';
 import { isIosStandalonePwa } from '@/shared/pwa/iosBypass';
 import {
@@ -33,9 +34,6 @@ import { getPosthogInstance } from '@/shared/analytics/posthog/init';
  * smoke run while one is already in flight. Reset by `gatedUpdate()` on exit.
  */
 let smokeInProgress = false;
-
-/** Cache name prefix used by Workbox precache (matches `cacheId: 'gridfinity-v1'`). */
-const PRECACHE_PREFIX = 'gridfinity-v1-precache-';
 
 async function clearPrecaches(): Promise<void> {
   try {

--- a/src/shared/hooks/usePWAUpdate.ts
+++ b/src/shared/hooks/usePWAUpdate.ts
@@ -16,6 +16,7 @@ import type { BinId } from '@/core/types';
 import { useTranslation } from '@/i18n';
 import { isSmokeMode } from '@/shared/utils/smokeMode';
 import { runUpdateSmokeTest, type SmokeGateResult } from '@/shared/pwa/smokeGate';
+import { checkBootVersionFreshness } from '@/shared/pwa/bootVersionCheck';
 import { getSmokeGateFlag } from '@/shared/pwa/featureFlag';
 import { isIosStandalonePwa } from '@/shared/pwa/iosBypass';
 import {
@@ -517,6 +518,15 @@ export function usePWAUpdate(): void {
   useEffect(() => {
     if (skipRegistration) return;
     return startActivityTracking();
+  }, [skipRegistration]);
+
+  // Boot freshness check: the SW can serve a stale precached shell, so the
+  // running bundle may be behind the live deploy. Compare /version.json's gitSha
+  // to this build's and self-heal before the user hits a load failure. One-shot
+  // per session (recoverStaleBundle is guarded), complements the SW polling.
+  useEffect(() => {
+    if (skipRegistration) return;
+    void checkBootVersionFreshness();
   }, [skipRegistration]);
 
   // Apply an available update without interrupting active work.

--- a/src/shared/pwa/bootVersionCheck.test.ts
+++ b/src/shared/pwa/bootVersionCheck.test.ts
@@ -63,6 +63,12 @@ describe('checkBootVersionFreshness', () => {
     expect(recoverStaleBundle).not.toHaveBeenCalled();
   });
 
+  it('no-ops on a non-200 version.json response', async () => {
+    mockVersionFetch({ version: '9.9.9', gitSha: 'newer-sha', buildTime: 'x' }, false);
+    await checkBootVersionFreshness();
+    expect(recoverStaleBundle).not.toHaveBeenCalled();
+  });
+
   it('no-ops when the deployed gitSha is unknown', async () => {
     mockVersionFetch({ version: '9.9.9', gitSha: 'unknown', buildTime: 'x' });
     await checkBootVersionFreshness();

--- a/src/shared/pwa/bootVersionCheck.test.ts
+++ b/src/shared/pwa/bootVersionCheck.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { checkBootVersionFreshness } from './bootVersionCheck';
+
+const { recoverStaleBundle, isSmokeMode } = vi.hoisted(() => ({
+  recoverStaleBundle: vi.fn(),
+  isSmokeMode: vi.fn(() => false),
+}));
+vi.mock('./staleRecovery', () => ({ recoverStaleBundle }));
+vi.mock('@/shared/utils/smokeMode', () => ({ isSmokeMode }));
+
+// vitest.config defines __GIT_SHA__ === 'test-sha' as the running bundle's SHA.
+function mockVersionFetch(payload: unknown, ok = true): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      json: () => Promise.resolve(payload),
+    })
+  );
+}
+
+beforeEach(() => {
+  recoverStaleBundle.mockClear();
+  isSmokeMode.mockReturnValue(false);
+  vi.stubGlobal('navigator', { onLine: true });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('checkBootVersionFreshness', () => {
+  it('recovers when the deployed gitSha differs from the running bundle', async () => {
+    mockVersionFetch({ version: '9.9.9', gitSha: 'newer-sha', buildTime: 'x' });
+    await checkBootVersionFreshness();
+    expect(recoverStaleBundle).toHaveBeenCalledWith('boot_version_mismatch');
+  });
+
+  it('does nothing when the deployed gitSha matches', async () => {
+    mockVersionFetch({ version: '0.0.0-test', gitSha: 'test-sha', buildTime: 'x' });
+    await checkBootVersionFreshness();
+    expect(recoverStaleBundle).not.toHaveBeenCalled();
+  });
+
+  it('no-ops in smoke mode (never reload inside the gate iframe)', async () => {
+    isSmokeMode.mockReturnValue(true);
+    mockVersionFetch({ version: '9.9.9', gitSha: 'newer-sha', buildTime: 'x' });
+    await checkBootVersionFreshness();
+    expect(recoverStaleBundle).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when offline', async () => {
+    vi.stubGlobal('navigator', { onLine: false });
+    mockVersionFetch({ version: '9.9.9', gitSha: 'newer-sha', buildTime: 'x' });
+    await checkBootVersionFreshness();
+    expect(recoverStaleBundle).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when version.json is unreachable (dev / network error)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('404')));
+    await checkBootVersionFreshness();
+    expect(recoverStaleBundle).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when the deployed gitSha is unknown', async () => {
+    mockVersionFetch({ version: '9.9.9', gitSha: 'unknown', buildTime: 'x' });
+    await checkBootVersionFreshness();
+    expect(recoverStaleBundle).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/pwa/bootVersionCheck.ts
+++ b/src/shared/pwa/bootVersionCheck.ts
@@ -1,0 +1,45 @@
+/**
+ * Proactive stale-bundle check at app boot.
+ *
+ * The service worker can keep serving an old precached shell after a deploy, so
+ * the running bundle may be behind what's live. `version.json` is globIgnored
+ * from the precache (always network-fresh) and reports the deployed build's git
+ * SHA. If it disagrees with this bundle's compile-time `__GIT_SHA__`, we're
+ * stale — self-heal to the latest build before the user hits a failure.
+ *
+ * Conservative by design: no-ops in dev/smoke, offline, when either SHA is
+ * unknown, or on any fetch error. Recovery itself is one-shot per session.
+ */
+
+import { isSmokeMode } from '@/shared/utils/smokeMode';
+import { recoverStaleBundle } from './staleRecovery';
+
+interface VersionPayload {
+  version: string;
+  gitSha: string;
+  buildTime: string;
+}
+
+export async function checkBootVersionFreshness(): Promise<void> {
+  // Never self-reload inside the smoke iframe — it would abort the gate's probe.
+  if (isSmokeMode()) return;
+  if (typeof navigator !== 'undefined' && !navigator.onLine) return;
+  // Builds without git info can't be compared (tarball/detached builds).
+  if (__GIT_SHA__ === 'unknown') return;
+
+  let payload: VersionPayload;
+  try {
+    const res = await fetch('/version.json', { cache: 'reload' });
+    if (!res.ok) return;
+    payload = (await res.json()) as VersionPayload;
+  } catch {
+    // Offline / dev (no version.json) / network blip — nothing to do.
+    return;
+  }
+
+  if (!payload.gitSha || payload.gitSha === 'unknown') return;
+
+  if (payload.gitSha !== __GIT_SHA__) {
+    void recoverStaleBundle('boot_version_mismatch');
+  }
+}

--- a/src/shared/pwa/cacheNames.ts
+++ b/src/shared/pwa/cacheNames.ts
@@ -1,0 +1,8 @@
+/**
+ * Workbox cache names, shared so the SW-update path (`usePWAUpdate`) and the
+ * stale-recovery path can't drift. `PRECACHE_PREFIX` must track `workbox.cacheId`
+ * ('gridfinity-v1') + Workbox's '-precache-' suffix; `WASM_CACHE` must match the
+ * wasm `runtimeCaching` cacheName — both in vite.config.ts.
+ */
+export const PRECACHE_PREFIX = 'gridfinity-v1-precache-';
+export const WASM_CACHE = 'wasm-binaries';

--- a/src/shared/pwa/staleRecovery.test.ts
+++ b/src/shared/pwa/staleRecovery.test.ts
@@ -11,6 +11,8 @@ const reload = vi.fn();
 const cacheDelete = vi.fn().mockResolvedValue(true);
 const unregister = vi.fn().mockResolvedValue(true);
 
+const realLocation = window.location;
+
 beforeEach(() => {
   sessionStorage.clear();
   capture.mockClear();
@@ -18,9 +20,11 @@ beforeEach(() => {
   cacheDelete.mockClear();
   unregister.mockClear();
 
+  // Preserve the real Location shape (href/origin/...) and override only reload,
+  // so code reading other fields still works.
   Object.defineProperty(window, 'location', {
     configurable: true,
-    value: { reload },
+    value: { ...realLocation, href: realLocation.href, origin: realLocation.origin, reload },
   });
 
   vi.stubGlobal('caches', {
@@ -39,6 +43,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  Object.defineProperty(window, 'location', { configurable: true, value: realLocation });
   vi.unstubAllGlobals();
 });
 

--- a/src/shared/pwa/staleRecovery.test.ts
+++ b/src/shared/pwa/staleRecovery.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { recoverStaleBundle, STALE_RECOVERY_FLAG } from './staleRecovery';
+
+const capture = vi.fn();
+vi.mock('@/shared/analytics/posthog/init', () => ({
+  getPosthogInstance: () => ({ capture }),
+}));
+
+const reload = vi.fn();
+const cacheDelete = vi.fn().mockResolvedValue(true);
+const unregister = vi.fn().mockResolvedValue(true);
+
+beforeEach(() => {
+  sessionStorage.clear();
+  capture.mockClear();
+  reload.mockClear();
+  cacheDelete.mockClear();
+  unregister.mockClear();
+
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { reload },
+  });
+
+  vi.stubGlobal('caches', {
+    keys: vi
+      .fn()
+      .mockResolvedValue(['gridfinity-v1-precache-abc', 'wasm-binaries', 'shared-layouts']),
+    delete: cacheDelete,
+  });
+
+  vi.stubGlobal('navigator', {
+    onLine: true,
+    serviceWorker: {
+      getRegistrations: vi.fn().mockResolvedValue([{ unregister }, { unregister }]),
+    },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('recoverStaleBundle', () => {
+  it('clears precache + wasm caches, unregisters SWs, and reloads', async () => {
+    const started = await recoverStaleBundle('wasm_load_failure');
+
+    expect(started).toBe(true);
+    // Drops the precache and wasm caches, leaves unrelated caches (shared-layouts) alone.
+    expect(cacheDelete).toHaveBeenCalledWith('gridfinity-v1-precache-abc');
+    expect(cacheDelete).toHaveBeenCalledWith('wasm-binaries');
+    expect(cacheDelete).not.toHaveBeenCalledWith('shared-layouts');
+    expect(unregister).toHaveBeenCalledTimes(2);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures a telemetry event with the reason', async () => {
+    await recoverStaleBundle('boot_version_mismatch');
+    expect(capture).toHaveBeenCalledWith(
+      'pwa_stale_recovery',
+      expect.objectContaining({ reason: 'boot_version_mismatch' })
+    );
+  });
+
+  it('recovers at most once per session (guards against reload loops)', async () => {
+    expect(await recoverStaleBundle('first')).toBe(true);
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    const second = await recoverStaleBundle('second');
+    expect(second).toBe(false);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(STALE_RECOVERY_FLAG)).not.toBeNull();
+  });
+});

--- a/src/shared/pwa/staleRecovery.ts
+++ b/src/shared/pwa/staleRecovery.ts
@@ -1,0 +1,94 @@
+/**
+ * One-shot self-heal for a client stuck on a stale cached bundle.
+ *
+ * The PWA's normal updater (`usePWAUpdate`) fixes the *next* load: a returning
+ * user is served the old precached shell + old runtime-cached wasm, so the
+ * current page can fail (e.g. kernel init) before any update applies. This
+ * recovers the *current* visit: drop the precache + wasm caches, unregister the
+ * service worker (so the reload bypasses it and fetches the latest from the
+ * network), then hard-reload.
+ *
+ * Guarded by a per-session flag so a genuinely broken new bundle can't loop:
+ * we recover at most once per tab session.
+ */
+
+import { getPosthogInstance } from '@/shared/analytics/posthog/init';
+
+/** sessionStorage key — set once a recovery has been attempted this tab session. */
+export const STALE_RECOVERY_FLAG = 'pwa-stale-recovery-done';
+
+/** Caches to drop: the Workbox precache (shell) and the runtime wasm cache. */
+const PRECACHE_PREFIX = 'gridfinity-v1-precache-';
+const WASM_CACHE = 'wasm-binaries';
+
+function alreadyRecovered(): boolean {
+  try {
+    return sessionStorage.getItem(STALE_RECOVERY_FLAG) !== null;
+  } catch {
+    return false;
+  }
+}
+
+function markRecovered(): void {
+  try {
+    sessionStorage.setItem(STALE_RECOVERY_FLAG, Date.now().toString());
+  } catch {
+    // best-effort — if storage is unavailable we accept the small loop risk
+  }
+}
+
+async function clearStaleCaches(): Promise<void> {
+  if (typeof caches === 'undefined') return;
+  try {
+    const keys = await caches.keys();
+    await Promise.all(
+      keys
+        .filter((k) => k.startsWith(PRECACHE_PREFIX) || k === WASM_CACHE)
+        .map((k) => caches.delete(k))
+    );
+  } catch {
+    // best-effort
+  }
+}
+
+async function unregisterServiceWorkers(): Promise<void> {
+  if (typeof navigator === 'undefined') return;
+  // `navigator.serviceWorker` is typed as always-present but is genuinely
+  // undefined in insecure contexts / unsupported browsers.
+  const swContainer = navigator.serviceWorker as ServiceWorkerContainer | undefined;
+  if (!swContainer) return;
+  try {
+    const regs = await swContainer.getRegistrations();
+    await Promise.all(regs.map((r) => r.unregister()));
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Attempt a one-time stale-bundle recovery. Returns true if a recovery was
+ * started (caches cleared + reload triggered), false if it was skipped because
+ * one already ran this session.
+ */
+export async function recoverStaleBundle(reason: string): Promise<boolean> {
+  if (alreadyRecovered()) return false;
+  markRecovered();
+
+  try {
+    getPosthogInstance()?.capture('pwa_stale_recovery', {
+      reason,
+      from_version: __APP_VERSION__,
+      from_sha: __GIT_SHA__,
+    });
+  } catch {
+    // never let telemetry block recovery
+  }
+
+  await clearStaleCaches();
+  await unregisterServiceWorkers();
+
+  // Hard reload — with the SW unregistered and caches cleared, this fetches the
+  // latest shell + assets from the network.
+  window.location.reload();
+  return true;
+}

--- a/src/shared/pwa/staleRecovery.ts
+++ b/src/shared/pwa/staleRecovery.ts
@@ -13,13 +13,10 @@
  */
 
 import { getPosthogInstance } from '@/shared/analytics/posthog/init';
+import { PRECACHE_PREFIX, WASM_CACHE } from './cacheNames';
 
 /** sessionStorage key — set once a recovery has been attempted this tab session. */
 export const STALE_RECOVERY_FLAG = 'pwa-stale-recovery-done';
-
-/** Caches to drop: the Workbox precache (shell) and the runtime wasm cache. */
-const PRECACHE_PREFIX = 'gridfinity-v1-precache-';
-const WASM_CACHE = 'wasm-binaries';
 
 function alreadyRecovered(): boolean {
   try {
@@ -87,8 +84,6 @@ export async function recoverStaleBundle(reason: string): Promise<boolean> {
   await clearStaleCaches();
   await unregisterServiceWorkers();
 
-  // Hard reload — with the SW unregistered and caches cleared, this fetches the
-  // latest shell + assets from the network.
   window.location.reload();
   return true;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -44,6 +44,13 @@ const generatorIncludes = ['src/features/generation/worker/generators/**/*.test.
 
 export default defineConfig({
   plugins: [react()],
+  // Build-time version constants (provided by versionPlugin in the real build).
+  // Defined here so PWA modules that reference them are testable under Vitest.
+  define: {
+    __APP_VERSION__: JSON.stringify('0.0.0-test'),
+    __GIT_SHA__: JSON.stringify('test-sha'),
+    __BUILD_TIME__: JSON.stringify('1970-01-01T00:00:00.000Z'),
+  },
   test: {
     globals: true,
     testTimeout: 30000,


### PR DESCRIPTION
## Why

After the Safari/iOS relaxed-SIMD fix (occt-wasm 3.3.0, #2045), PostHog still showed a residual tail of kernel-load failures from clients on the **old cached bundle**: the relaxed-SIMD compile error from fully-cached Safari clients, and a 404 on the now-removed wasm hash from partially-updated clients.

Root cause: the SW serves a returning user the **old precached shell + old runtime-cached wasm**, so the current page can fail at kernel init *before* the existing updater (`usePWAUpdate`) applies on the next load. The updater fixes the *next* visit; the current one still breaks.

## What

Two complementary recoveries (chosen over a NetworkFirst-shell change to preserve the smoke-gate's "keep open tabs on the old SW" design):

1. **Self-heal on load failure** — when the kernel fails with a stale-bundle signature, `recoverStaleBundle()` drops the precache + wasm caches, unregisters the SW, and hard-reloads to the latest build. One-shot per session (sessionStorage-guarded) so a genuinely broken new bundle can't loop. Wired via `handleWasmLoadFailure` in the bin-designer + baseplate preview paths.
2. **Boot-time version check** — `checkBootVersionFreshness()` compares `/version.json`'s `gitSha` (network-fresh; globIgnored from precache) to this build's `__GIT_SHA__` on startup and self-heals on mismatch, *before* the user hits a failure. No-ops in dev/smoke, offline, or when either SHA is unknown.

Also:
- Adds `relaxed simd instructions not supported` to the stale-asset classifier (`isStaleAssetError`).
- Provides the `__APP_VERSION__` / `__GIT_SHA__` / `__BUILD_TIME__` defines to Vitest so the PWA modules are testable.

## Tests

New/updated: `staleRecovery`, `bootVersionCheck`, `wasmLoadError`, `captureWasmLoadFailure`, `usePWAUpdate` — 50 tests pass. Recovery is verified to clear only the precache + wasm caches (not unrelated caches), unregister SWs, reload, capture telemetry, and guard against reload loops.

## Telemetry

Emits `pwa_stale_recovery` (with `reason`, `from_version`, `from_sha`) so we can watch recovery frequency and confirm the residual tail subsides.