### PR TITLE
fix(export): recover STL exports that OCCT's writer rejects

### DIFF
--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -50,6 +50,7 @@ graph TB
 - `worker/generators/featureBuilder.ts` — barrel re-export of all builder modules
 - `worker/generators/dividerBuilder.ts` — divider piece generation
 - `worker/generators/dividerExport.ts` — standalone divider STL export
+- `worker/generators/utils/stlMeshFallback.ts` — `exportSolidToStl`: OCCT-primary STL writer with a mesh-based fallback for topologies OCCT's `StlAPI.Write` rejects but `mesh()` triangulates (the `STL_EXPORT_FAILED` class, #1760/#1850). Used by bin/divider/lid exporters; OCCT stays primary so success is byte-identical and 3MF faceGroups stay aligned
 - `worker/generators/wallPatterns.ts` — hexgrid/slot patterns
 - `worker/generators/slotBuilder.ts` — wall slot cutout geometry
 - `worker/generators/splitConnectorBuilder.ts` — split-piece joints: floor scarf lap + optional press-together wall-locking keys (#1869)

--- a/src/features/generation/worker/generators/binExporter.ts
+++ b/src/features/generation/worker/generators/binExporter.ts
@@ -2,7 +2,7 @@
  * Bin export — converts the last generated solid to STL or STEP format.
  */
 
-import { exportSTL, exportSTEP, mesh } from 'brepjs';
+import { exportSTEP, mesh } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
 import type { ExportFormat, FaceGroupData } from '../../bridge/types';
 
@@ -11,6 +11,7 @@ import { FeatureTag } from './featureTags';
 import { getLastSolid, isLastSolidExportQuality, setLastSolid } from './shapeCache';
 import { EXPORT_ANGULAR_TOLERANCE, EXPORT_TOLERANCE } from './utils/tolerances';
 import { unwrapExportBlob } from './utils/exportUnwrap';
+import { exportSolidToStl } from './utils/stlMeshFallback';
 
 /** Export result with binary data and suggested file name. */
 export interface ExportResult {
@@ -74,15 +75,9 @@ async function runExportAttempt(
   }
 
   onProgress?.(0.92);
-  const blob = unwrapExportBlob(
-    exportSTL(solid, {
-      tolerance: EXPORT_TOLERANCE,
-      angularTolerance: EXPORT_ANGULAR_TOLERANCE,
-      binary: true,
-    }),
-    'STL'
-  );
-  const data = await blob.arrayBuffer();
+  // `faceGroups` above indexes into the same mesh() tessellation the fallback
+  // writes from, so 3MF material alignment survives an OCCT-writer failure.
+  const data = await exportSolidToStl(solid, name, EXPORT_TOLERANCE, EXPORT_ANGULAR_TOLERANCE);
   onProgress?.(1);
   return { data, fileName: `${name}.stl`, faceGroups };
 }

--- a/src/features/generation/worker/generators/dividerExport.ts
+++ b/src/features/generation/worker/generators/dividerExport.ts
@@ -6,12 +6,13 @@
  * in their slicer as needed.
  */
 
-import { unwrap, fuse, exportSTL, exportSTEP } from 'brepjs';
+import { unwrap, fuse, exportSTEP } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
 import type { ExportFormat, CombinedExportPiece } from '../../bridge/types';
 import { GRIDFINITY } from '@/shared/constants/bin';
 import { buildUniqueDividerPieces } from './dividerBuilder';
 import { unwrapExportBlob } from './utils/exportUnwrap';
+import { exportSolidToStl } from './utils/stlMeshFallback';
 
 const CLEARANCE = GRIDFINITY.TOLERANCE;
 const SOCKET_HEIGHT = GRIDFINITY.SOCKET_HEIGHT;
@@ -62,17 +63,8 @@ export async function exportDividers(
       nextPieceToFree = i + 1;
     }
 
-    const blob = unwrapExportBlob(
-      exportSTL(combined, {
-        tolerance: 0.01,
-        angularTolerance: 5,
-        binary: true,
-      }),
-      'STL'
-    );
-    const data = await blob.arrayBuffer();
-
     const name = `gridfinity-${params.width}x${params.depth}-divider`;
+    const data = await exportSolidToStl(combined, name, 0.01, 5);
     return { data, fileName: `${name}.stl` };
   } finally {
     combined.delete();
@@ -122,11 +114,8 @@ export async function exportDividerPiecesSeparately(
         const blob = unwrapExportBlob(exportSTEP(pieces[i]), 'STEP');
         results.push({ data: await blob.arrayBuffer(), label: labels[i] });
       } else {
-        const blob = unwrapExportBlob(
-          exportSTL(pieces[i], { tolerance, angularTolerance, binary: true }),
-          'STL'
-        );
-        results.push({ data: await blob.arrayBuffer(), label: labels[i] });
+        const data = await exportSolidToStl(pieces[i], labels[i], tolerance, angularTolerance);
+        results.push({ data, label: labels[i] });
       }
     }
   } finally {

--- a/src/features/generation/worker/generators/lidOrchestrator.ts
+++ b/src/features/generation/worker/generators/lidOrchestrator.ts
@@ -6,7 +6,7 @@
  * rejects (lid disabled, no stacking lip, or a blocker is active).
  */
 
-import { mesh, meshEdges, getKernelCapabilities, rotate, exportSTL, exportSTEP } from 'brepjs';
+import { mesh, meshEdges, getKernelCapabilities, rotate, exportSTEP } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
 import type { LidMeshData, ExportFormat } from '../../bridge/types';
@@ -17,6 +17,7 @@ import { computeTessellationTolerances } from './utils/tolerances';
 import { checkCancelled } from './meshUtils';
 import { shouldGenerateLid } from '@/shared/types/bin';
 import { unwrapExportBlob } from './utils/exportUnwrap';
+import { exportSolidToStl } from './utils/stlMeshFallback';
 
 /**
  * Rotate the lid 180° around the X axis so the floor's outer surface
@@ -125,15 +126,7 @@ export async function exportLid(
       return { data, fileName: `${name}.step` };
     }
 
-    const blob = unwrapExportBlob(
-      exportSTL(solid, {
-        tolerance,
-        angularTolerance,
-        binary: true,
-      }),
-      'STL'
-    );
-    const data = await blob.arrayBuffer();
+    const data = await exportSolidToStl(solid, name, tolerance, angularTolerance);
     return { data, fileName: `${name}.stl` };
   } finally {
     solid.delete();

--- a/src/features/generation/worker/generators/utils/stlMeshFallback.test.ts
+++ b/src/features/generation/worker/generators/utils/stlMeshFallback.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+/**
+ * The mesh-based STL fallback must produce a valid, parseable binary STL from
+ * a real generated solid — this is the path the single-piece exporter falls
+ * back to when OCCT's `StlAPI.Write` rejects an otherwise-meshable topology
+ * (production `STL_EXPORT_FAILED` failures, #1760 / #1850 family).
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { BinParams } from '@/shared/types/bin';
+import { initBrepjs, getGenerateBin } from '../__kernel-tests__/wasmInit';
+import { getLastSolid, clearAllCaches } from '../shapeCache';
+import { EXPORT_ANGULAR_TOLERANCE, EXPORT_TOLERANCE } from './tolerances';
+import { parseSTLBinary } from '@/shared/generation/stlParser';
+import { hasNoNaNOrInfinity } from '../__kernel-tests__/meshAssertions';
+import { isOk } from '@/core/result';
+import { exportSolidMeshToStl } from './stlMeshFallback';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+beforeEach(() => clearAllCaches());
+
+function scoopBin(w: number, d: number, h: number): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    width: w,
+    depth: d,
+    height: h,
+    compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
+    scoop: { enabled: true, radius: 'auto' },
+  };
+}
+
+describe('exportSolidMeshToStl', () => {
+  it('writes a valid binary STL from a real generated solid', () => {
+    const generateBin = getGenerateBin();
+    generateBin(scoopBin(2, 3, 6), undefined, true);
+    const solid = getLastSolid();
+    expect(solid, 'generateBin should populate the cached solid').not.toBeNull();
+    if (!solid) throw new Error('unreachable');
+
+    const data = exportSolidMeshToStl(
+      solid,
+      'fallback-test',
+      EXPORT_TOLERANCE,
+      EXPORT_ANGULAR_TOLERANCE
+    );
+
+    const parsed = parseSTLBinary(data);
+    expect(isOk(parsed), 'fallback STL should parse').toBe(true);
+    if (!isOk(parsed)) throw new Error('unreachable');
+    const { vertices } = parsed.value;
+    expect(vertices.length, 'STL should contain triangles').toBeGreaterThan(0);
+    expect(vertices.length % 9, 'vertices must form whole triangles').toBe(0);
+    expect(hasNoNaNOrInfinity(vertices), 'STL vertices must be finite').toBe(true);
+  });
+
+  it('writes triangles matching the meshed solid, not OCCT, so it succeeds whenever the preview does', () => {
+    const generateBin = getGenerateBin();
+    generateBin(scoopBin(3, 5, 9), undefined, true);
+    const solid = getLastSolid();
+    if (!solid) throw new Error('generateBin should populate the cached solid');
+
+    const data = exportSolidMeshToStl(
+      solid,
+      'fallback-tall',
+      EXPORT_TOLERANCE,
+      EXPORT_ANGULAR_TOLERANCE
+    );
+    const parsed = parseSTLBinary(data);
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) throw new Error('unreachable');
+    expect(parsed.value.vertices.length / 9).toBeGreaterThan(100);
+  });
+});

--- a/src/features/generation/worker/generators/utils/stlMeshFallback.test.ts
+++ b/src/features/generation/worker/generators/utils/stlMeshFallback.test.ts
@@ -6,6 +6,7 @@
  * (production `STL_EXPORT_FAILED` failures, #1760 / #1850 family).
  */
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { mesh } from 'brepjs';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import type { BinParams } from '@/shared/types/bin';
 import { initBrepjs, getGenerateBin } from '../__kernel-tests__/wasmInit';
@@ -57,7 +58,7 @@ describe('exportSolidMeshToStl', () => {
     expect(hasNoNaNOrInfinity(vertices), 'STL vertices must be finite').toBe(true);
   });
 
-  it('writes triangles matching the meshed solid, not OCCT, so it succeeds whenever the preview does', () => {
+  it('writes exactly the meshed triangles, not OCCT, so it succeeds whenever the preview does', () => {
     const generateBin = getGenerateBin();
     generateBin(scoopBin(3, 5, 9), undefined, true);
     const solid = getLastSolid();
@@ -72,6 +73,16 @@ describe('exportSolidMeshToStl', () => {
     const parsed = parseSTLBinary(data);
     expect(isOk(parsed)).toBe(true);
     if (!isOk(parsed)) throw new Error('unreachable');
-    expect(parsed.value.vertices.length / 9).toBeGreaterThan(100);
+
+    // The STL must contain exactly the triangles mesh() produced — that's what
+    // makes the fallback succeed whenever the preview (also mesh()-driven) does.
+    const m = mesh(solid, {
+      tolerance: EXPORT_TOLERANCE,
+      angularTolerance: EXPORT_ANGULAR_TOLERANCE,
+      cache: true,
+    });
+    const meshTriangleCount = m.triangles.length / 3;
+    expect(meshTriangleCount).toBeGreaterThan(100);
+    expect(parsed.value.vertices.length / 9).toBe(meshTriangleCount);
   });
 });

--- a/src/features/generation/worker/generators/utils/stlMeshFallback.ts
+++ b/src/features/generation/worker/generators/utils/stlMeshFallback.ts
@@ -31,7 +31,7 @@ export function exportSolidMeshToStl(
   tolerance: number,
   angularTolerance: number
 ): ArrayBuffer {
-  const m = mesh(solid, { tolerance, angularTolerance });
+  const m = mesh(solid, { tolerance, angularTolerance, cache: true });
   const vertices = m.vertices instanceof Float32Array ? m.vertices : new Float32Array(m.vertices);
   const normals = m.normals instanceof Float32Array ? m.normals : new Float32Array(m.normals);
   const indices = m.triangles instanceof Uint32Array ? m.triangles : new Uint32Array(m.triangles);
@@ -63,7 +63,16 @@ export async function exportSolidToStl(
   } catch (occtStlError) {
     try {
       return exportSolidMeshToStl(solid, name, tolerance, angularTolerance);
-    } catch {
+    } catch (meshFallbackError) {
+      // Both writers failed — the geometry is genuinely unexportable. Rethrow
+      // OCCT's error (its message carries the user-facing actionable hint, and
+      // its `cause` the structured BrepError), but record the fallback failure
+      // on a separate property so telemetry can tell "OCCT failed, fallback
+      // also failed" apart from "OCCT failed, fallback succeeded".
+      if (occtStlError instanceof Error) {
+        (occtStlError as Error & { meshFallbackCause?: unknown }).meshFallbackCause =
+          meshFallbackError;
+      }
       throw occtStlError;
     }
   }

--- a/src/features/generation/worker/generators/utils/stlMeshFallback.ts
+++ b/src/features/generation/worker/generators/utils/stlMeshFallback.ts
@@ -1,0 +1,70 @@
+/**
+ * Mesh-based STL serialization — a fallback for OCCT's `StlAPI.Write`.
+ *
+ * OCCT's STL writer silently rejects some valid-but-tricky topologies that
+ * `mesh()` triangulates cleanly (scoop ramp + tall walls #1760, scoop cusp
+ * rims #1850, and assorted user feature combinations that surface in
+ * production as `STL_EXPORT_FAILED`). Writing STL ourselves from the meshed
+ * triangle buffer removes the dependency on OCCT's writer: it runs on the
+ * exact same triangles the preview already renders cleanly, so it succeeds
+ * whenever the preview does.
+ *
+ * The split-bin export path (`splitBinBuilder`) has bypassed OCCT this way
+ * since #1760; this shares that proven path with the single-piece exporter.
+ */
+
+import { mesh, exportSTL } from 'brepjs';
+import type { Shape3D } from 'brepjs';
+import { buildSTLBufferFromIndexed } from '@/features/generation/export/stlExporter';
+import { unwrapExportBlob } from './exportUnwrap';
+
+/**
+ * Tessellate `solid` and serialize it to a binary STL ArrayBuffer, bypassing
+ * OCCT's STL writer entirely.
+ *
+ * Tolerances must match the caller's so the triangles (and any parallel
+ * `faceGroups` derived from the same `mesh()` call) line up.
+ */
+export function exportSolidMeshToStl(
+  solid: Shape3D,
+  name: string,
+  tolerance: number,
+  angularTolerance: number
+): ArrayBuffer {
+  const m = mesh(solid, { tolerance, angularTolerance });
+  const vertices = m.vertices instanceof Float32Array ? m.vertices : new Float32Array(m.vertices);
+  const normals = m.normals instanceof Float32Array ? m.normals : new Float32Array(m.normals);
+  const indices = m.triangles instanceof Uint32Array ? m.triangles : new Uint32Array(m.triangles);
+  return buildSTLBufferFromIndexed(vertices, normals, indices, name);
+}
+
+/**
+ * Export `solid` to a binary STL ArrayBuffer, trying OCCT's writer first and
+ * falling back to the meshed-triangle writer when OCCT rejects the geometry.
+ *
+ * OCCT stays primary so successful exports remain byte-identical (and 3MF
+ * face-group alignment, which depends on OCCT's tessellation cache, is
+ * preserved). The fallback only runs on failure, recovering exports that would
+ * otherwise hard-fail with `STL_EXPORT_FAILED`. If meshing also fails, the
+ * geometry is genuinely unexportable; rethrow OCCT's actionable error.
+ */
+export async function exportSolidToStl(
+  solid: Shape3D,
+  name: string,
+  tolerance: number,
+  angularTolerance: number
+): Promise<ArrayBuffer> {
+  try {
+    const blob = unwrapExportBlob(
+      exportSTL(solid, { tolerance, angularTolerance, binary: true }),
+      'STL'
+    );
+    return await blob.arrayBuffer();
+  } catch (occtStlError) {
+    try {
+      return exportSolidMeshToStl(solid, name, tolerance, angularTolerance);
+    } catch {
+      throw occtStlError;
+    }
+  }
+}


### PR DESCRIPTION
## What

Some bin designs render a clean 3D preview but **fail to export**, hard-stopping with `Combined export failed: STL_EXPORT_FAILED: Failed to write STL file`. Production telemetry shows this hitting **15 users / 142 occurrences** over the last 30 days — the highest occurrence count of any real (non-extension) error, on the app's core export path.

This PR makes every STL export path recover from those failures, so **whenever the preview renders, export now succeeds**.

## Why it happens

OCCT's `StlAPI.Write` silently rejects certain valid-but-tricky topologies that `mesh()` triangulates cleanly — scoop ramp + tall walls (#1760), scoop cusp rims (#1850), and assorted user feature combinations. The error is deterministic for the affected geometry, so the existing regenerate-and-retry-once strategy can't help: retrying the same BREP→STL writer fails the same way.

## The fix

The **split-bin** exporter has bypassed OCCT since #1760 by writing STL from the meshed triangle buffer (`mesh()` → `buildSTLBufferFromIndexed`). This shares that proven path with the exporters that never got it — **single bin, combined (bin + dividers + lid), standalone dividers, and lid** — via a new `exportSolidToStl` helper that:

- keeps OCCT's writer **primary**, so successful exports stay byte-identical and 3MF face-group alignment (which rides OCCT's tessellation cache) is preserved;
- falls back to the mesh writer **only on failure**, using the exact triangles the preview already renders;
- rethrows OCCT's actionable error if meshing also fails (geometry genuinely unexportable).

## Tests

- New `stlMeshFallback.test.ts` exercises the fallback against real generated solids (real kernel, no mocks) and asserts a valid, parseable, finite binary STL.
- Existing export suites (binExporter, combined features, export-integrity, issue-1850, lid, dividers, exportCache) all pass — 426 tests green across the touched paths.