### PR TITLE
fix(generation): footprint-aware timeout budget + relax large-bin lip tessellation

### DIFF
--- a/src/features/generation/bridge/generationTimeout.test.ts
+++ b/src/features/generation/bridge/generationTimeout.test.ts
@@ -10,11 +10,15 @@ import {
   BASEPLATE_MAX_TIMEOUT_MS,
   HEX_PATTERN_BONUS_MS,
   HEX_PLUS_CUTOUT_BONUS_MS,
+  HEX_FOOTPRINT_BONUS_MS_PER_CELL,
+  HEX_FOOTPRINT_BONUS_FLOOR_CELLS,
   HEIGHT_BONUS_MS,
   MAX_TIMEOUT_MS,
   computeBaseplateTimeoutMs,
   computeGenerationTimeoutMs,
 } from './generationTimeout';
+
+const HEX_ON = { enabled: true, pattern: 'honeycomb' } as const;
 
 function params(overrides: Partial<BinParams> = {}): BinParams {
   return { ...DEFAULT_BIN_PARAMS, ...overrides };
@@ -111,6 +115,39 @@ describe('computeGenerationTimeoutMs', () => {
     );
   });
 
+  it('grants a footprint bonus to large hex bins, scaled per grid cell above the floor', () => {
+    // 8×8 = 64 cells; 64 - 16 floor = 48 chargeable cells.
+    const t = computeGenerationTimeoutMs(
+      params({ width: 8, depth: 8, height: 3, wallPattern: HEX_ON })
+    );
+    expect(t).toBe(BASE_TIMEOUT_MS + HEX_PATTERN_BONUS_MS + 48 * HEX_FOOTPRINT_BONUS_MS_PER_CELL);
+  });
+
+  it('rounds fractional footprint dimensions up when costing cells', () => {
+    const frac = computeGenerationTimeoutMs(
+      params({ width: 7.5, depth: 8, height: 3, wallPattern: HEX_ON })
+    );
+    const rounded = computeGenerationTimeoutMs(
+      params({ width: 8, depth: 8, height: 3, wallPattern: HEX_ON })
+    );
+    expect(frac).toBe(rounded);
+  });
+
+  it('does not grant a footprint bonus below the cell floor', () => {
+    // 4×4 = 16 cells = exactly the floor → no footprint bonus.
+    const t = computeGenerationTimeoutMs(
+      params({ width: 4, depth: 4, height: 3, wallPattern: HEX_ON })
+    );
+    expect(t).toBe(BASE_TIMEOUT_MS + HEX_PATTERN_BONUS_MS);
+    expect(HEX_FOOTPRINT_BONUS_FLOOR_CELLS).toBe(16);
+  });
+
+  it('does not grant a footprint bonus when the hex pattern is off', () => {
+    // A large plain bin tessellates fast — footprint cost is hex-driven.
+    const t = computeGenerationTimeoutMs(params({ width: 12, depth: 12, height: 3 }));
+    expect(t).toBe(BASE_TIMEOUT_MS);
+  });
+
   it('caps at the maximum timeout', () => {
     const t = computeGenerationTimeoutMs(
       params({
@@ -122,6 +159,13 @@ describe('computeGenerationTimeoutMs', () => {
           front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
         },
       })
+    );
+    expect(t).toBe(MAX_TIMEOUT_MS);
+  });
+
+  it('caps a large-footprint hex bin at the maximum timeout', () => {
+    const t = computeGenerationTimeoutMs(
+      params({ width: 16, depth: 16, height: 6, wallPattern: HEX_ON })
     );
     expect(t).toBe(MAX_TIMEOUT_MS);
   });

--- a/src/features/generation/bridge/generationTimeout.test.ts
+++ b/src/features/generation/bridge/generationTimeout.test.ts
@@ -169,6 +169,24 @@ describe('computeGenerationTimeoutMs', () => {
     );
     expect(t).toBe(MAX_TIMEOUT_MS);
   });
+
+  it('clamps non-finite or invalid dimensions into the supported range', () => {
+    // Mid-edit UI state can transiently present NaN/negative dims. setTimeout(NaN)
+    // coerces to 0ms and would cancel generation immediately, so the budget must
+    // stay finite and ≥ BASE regardless of input.
+    const cases = [
+      params({ width: Number.NaN, depth: 8, height: 6, wallPattern: HEX_ON }),
+      params({ width: 8, depth: Number.POSITIVE_INFINITY, height: 6, wallPattern: HEX_ON }),
+      params({ width: -4, depth: 8, height: 6, wallPattern: HEX_ON }),
+      params({ width: 8, depth: 8, height: Number.NaN, wallPattern: HEX_ON }),
+    ];
+    for (const p of cases) {
+      const t = computeGenerationTimeoutMs(p);
+      expect(Number.isFinite(t)).toBe(true);
+      expect(t).toBeGreaterThanOrEqual(BASE_TIMEOUT_MS);
+      expect(t).toBeLessThanOrEqual(MAX_TIMEOUT_MS);
+    }
+  });
 });
 
 describe('computeBaseplateTimeoutMs', () => {

--- a/src/features/generation/bridge/generationTimeout.ts
+++ b/src/features/generation/bridge/generationTimeout.ts
@@ -78,6 +78,15 @@ function hasAnyActiveCutoutSide(params: BinParams): boolean {
  * Clamped to `[BASE_TIMEOUT_MS, MAX_TIMEOUT_MS]`.
  */
 export function computeGenerationTimeoutMs(params: BinParams): number {
+  // Defensive against transient bad inputs — mid-edit UI state can briefly
+  // present NaN/negative dimensions. setTimeout(NaN) coerces to 0ms, which would
+  // cancel the request before the worker can run. Floor bad dims to 0 (no
+  // footprint/height bonus) and clamp the result below. Mirrors
+  // computeBaseplateTimeoutMs.
+  const safeWidth = Number.isFinite(params.width) && params.width > 0 ? params.width : 0;
+  const safeDepth = Number.isFinite(params.depth) && params.depth > 0 ? params.depth : 0;
+  const safeHeight = Number.isFinite(params.height) && params.height > 0 ? params.height : 0;
+
   let timeout = BASE_TIMEOUT_MS;
 
   const hasHexPattern = params.wallPattern.enabled;
@@ -87,17 +96,19 @@ export function computeGenerationTimeoutMs(params: BinParams): number {
       timeout += HEX_PLUS_CUTOUT_BONUS_MS;
     }
     // Round fractional grids up — a partial cell still carries a full cell's
-    // worth of hex tessellation along that edge.
-    const cells = Math.ceil(params.width) * Math.ceil(params.depth);
+    // worth of hex pattern-cut work along that edge.
+    const cells = Math.ceil(safeWidth) * Math.ceil(safeDepth);
     const chargeableCells = Math.max(0, cells - HEX_FOOTPRINT_BONUS_FLOOR_CELLS);
     timeout += chargeableCells * HEX_FOOTPRINT_BONUS_MS_PER_CELL;
   }
 
-  const heightOverFloor = Math.max(0, params.height - HEIGHT_BONUS_FLOOR_UNITS);
+  const heightOverFloor = Math.max(0, safeHeight - HEIGHT_BONUS_FLOOR_UNITS);
   const heightBuckets = Math.floor(heightOverFloor / HEIGHT_BONUS_BUCKET_UNITS);
   timeout += heightBuckets * HEIGHT_BONUS_MS;
 
-  return Math.min(MAX_TIMEOUT_MS, timeout);
+  // Clamp to [BASE, MAX] — the guards above keep `timeout` finite, and this
+  // makes the documented contract self-enforcing.
+  return Math.max(BASE_TIMEOUT_MS, Math.min(MAX_TIMEOUT_MS, timeout));
 }
 
 /** Per-cell cost of magnet-hole boolean subtractions, in ms. */

--- a/src/features/generation/bridge/generationTimeout.ts
+++ b/src/features/generation/bridge/generationTimeout.ts
@@ -22,6 +22,26 @@ export const HEX_PATTERN_BONUS_MS = 15_000;
 export const HEX_PLUS_CUTOUT_BONUS_MS = 15_000;
 
 /**
+ * Extra time per grid cell of footprint (width × depth) above the floor, granted
+ * only when the hex pattern is enabled.
+ *
+ * The hex-pattern boolean cut (subtracting hundreds of hex prisms from the bin)
+ * is the generation bottleneck, and its cost scales with wall *area*, not just
+ * height — yet the other bonuses key off height and feature flags alone. A wide,
+ * short hex bin (e.g. 16×16×4) therefore used to get only the base + hex budget
+ * while legitimately needing far longer, and timed out mid-generation. This term
+ * restores the missing area dimension. Gated on hex because a plain large bin
+ * has no pattern cut and finishes quickly.
+ */
+export const HEX_FOOTPRINT_BONUS_MS_PER_CELL = 250;
+
+/**
+ * Footprint (in whole grid cells) below which no footprint bonus accrues — the
+ * base budget already covers normal-sized bins. 16 = a 4×4 grid.
+ */
+export const HEX_FOOTPRINT_BONUS_FLOOR_CELLS = 16;
+
+/**
  * Bonus per 2 height units above the reference height.
  *
  * Applied **unconditionally** (not gated on the hex pattern) because tessellation
@@ -66,6 +86,11 @@ export function computeGenerationTimeoutMs(params: BinParams): number {
     if (hasAnyActiveCutoutSide(params)) {
       timeout += HEX_PLUS_CUTOUT_BONUS_MS;
     }
+    // Round fractional grids up — a partial cell still carries a full cell's
+    // worth of hex tessellation along that edge.
+    const cells = Math.ceil(params.width) * Math.ceil(params.depth);
+    const chargeableCells = Math.max(0, cells - HEX_FOOTPRINT_BONUS_FLOOR_CELLS);
+    timeout += chargeableCells * HEX_FOOTPRINT_BONUS_MS_PER_CELL;
   }
 
   const heightOverFloor = Math.max(0, params.height - HEIGHT_BONUS_FLOOR_UNITS);

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.exportAndLarge.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.exportAndLarge.test.ts.snap
@@ -4,4 +4,4 @@ exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2604`;
 
 exports[`export mode > 2×2 default params (forExport=true) 1`] = `5276`;
 
-exports[`large bin > 8×8 standard 1`] = `22924`;
+exports[`large bin > 8×8 standard 1`] = `22308`;

--- a/src/features/generation/worker/generators/utils/tolerances.test.ts
+++ b/src/features/generation/worker/generators/utils/tolerances.test.ts
@@ -25,8 +25,10 @@ describe('computeTessellationTolerances', () => {
 
   it('relaxes the lip tolerance on large bins instead of pinning it at 0.06', () => {
     // Regression: the lip branch used to clamp at 0.06 for ANY size, so a
-    // 16-grid bin (~672mm) was tessellated at near-export fidelity in preview,
-    // exploding the hex-wall triangle count and timing out generation.
+    // 16-grid bin (~672mm) was meshed at near-export fidelity in preview,
+    // bloating the preview triangle count (memory/transfer/GPU weight). This
+    // does not drive the generation timeout — the hex boolean cut does — but a
+    // lighter preview mesh is worth it on large bins.
     const small = computeTessellationTolerances(false, true, 100).tolerance;
     const large = computeTessellationTolerances(false, true, 672).tolerance;
     expect(large).toBeGreaterThan(0.06);

--- a/src/features/generation/worker/generators/utils/tolerances.test.ts
+++ b/src/features/generation/worker/generators/utils/tolerances.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EXPORT_TOLERANCE,
+  EXPORT_ANGULAR_TOLERANCE,
+  computeTessellationTolerances,
+} from './tolerances';
+
+describe('computeTessellationTolerances', () => {
+  it('uses fine export tolerance regardless of size or lip', () => {
+    for (const maxDimension of [50, 200, 700]) {
+      for (const hasLip of [true, false]) {
+        expect(computeTessellationTolerances(true, hasLip, maxDimension)).toEqual({
+          tolerance: EXPORT_TOLERANCE,
+          angularTolerance: EXPORT_ANGULAR_TOLERANCE,
+        });
+      }
+    }
+  });
+
+  it('keeps a small lipped bin crisp (fine tolerance, tight angular)', () => {
+    const { tolerance, angularTolerance } = computeTessellationTolerances(false, true, 100);
+    expect(tolerance).toBeLessThanOrEqual(0.06);
+    expect(angularTolerance).toBe(8);
+  });
+
+  it('relaxes the lip tolerance on large bins instead of pinning it at 0.06', () => {
+    // Regression: the lip branch used to clamp at 0.06 for ANY size, so a
+    // 16-grid bin (~672mm) was tessellated at near-export fidelity in preview,
+    // exploding the hex-wall triangle count and timing out generation.
+    const small = computeTessellationTolerances(false, true, 100).tolerance;
+    const large = computeTessellationTolerances(false, true, 672).tolerance;
+    expect(large).toBeGreaterThan(0.06);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it('caps the large lipped-bin tolerance so the chamfer stays acceptable', () => {
+    const large = computeTessellationTolerances(false, true, 2000).tolerance;
+    expect(large).toBeLessThanOrEqual(0.15);
+  });
+
+  it('loosens the angular tolerance on large lipped bins', () => {
+    expect(computeTessellationTolerances(false, true, 672).angularTolerance).toBeGreaterThan(8);
+  });
+
+  it('uses the moderate tier for small lip-less bins (≤200mm)', () => {
+    const { tolerance, angularTolerance } = computeTessellationTolerances(false, false, 150);
+    expect(tolerance).toBeGreaterThanOrEqual(0.08);
+    expect(tolerance).toBeLessThanOrEqual(0.2);
+    expect(angularTolerance).toBe(10);
+  });
+
+  it('uses the coarse tier for large lip-less bins (>200mm)', () => {
+    const { tolerance, angularTolerance } = computeTessellationTolerances(false, false, 600);
+    expect(tolerance).toBeGreaterThanOrEqual(0.15);
+    expect(tolerance).toBeLessThanOrEqual(0.5);
+    expect(angularTolerance).toBe(15);
+  });
+});

--- a/src/features/generation/worker/generators/utils/tolerances.ts
+++ b/src/features/generation/worker/generators/utils/tolerances.ts
@@ -25,7 +25,10 @@ export const EXPORT_ANGULAR_TOLERANCE = 5;
  *
  * Quality tiers:
  * - Export: fine (0.01mm) for STL/STEP accuracy
- * - Lip bins: tight to preserve chamfer profile at corner junctions
+ * - Lip bins: tight to preserve chamfer profile at corner junctions, but
+ *   relaxed on large bins so a giant hex-riddled wall isn't meshed at
+ *   near-export fidelity just to keep a 2.6mm rim chamfer smooth — cutting the
+ *   preview mesh weight (memory/transfer/GPU), not the generation time itself
  * - Small bins (≤200mm): moderate quality
  * - Large bins (>200mm): coarser for preview speed
  */
@@ -38,9 +41,15 @@ export function computeTessellationTolerances(
     return { tolerance: EXPORT_TOLERANCE, angularTolerance: EXPORT_ANGULAR_TOLERANCE };
   }
   if (hasLip) {
+    // The chamfer needs fine tessellation, but only at the rim — pinning the
+    // whole solid at a flat 0.06 ceiling bloated the preview triangle count on
+    // large hex bins (wall area, not the lip, dominates the face count). Let the
+    // tolerance grow with size, capped at 0.15mm (the coarse tier's floor) so the
+    // chamfer stays acceptable while large walls shed triangles. Normal bins
+    // (<300mm) are unaffected: maxDimension/5000 stays ≤0.06 below that.
     return {
-      tolerance: Math.min(0.06, Math.max(0.03, maxDimension / 5000)),
-      angularTolerance: 8,
+      tolerance: Math.min(0.15, Math.max(0.03, maxDimension / 5000)),
+      angularTolerance: maxDimension > 200 ? 12 : 8,
     };
   }
   if (maxDimension <= 200) {


### PR DESCRIPTION
## Problem

Large-footprint hex-wall bins time out in the **live preview** (reported with "hex walls + removable dividers"). Removable dividers (`slotted` style) were a red herring — slots *disable* the hex pattern on slotted walls, so they make hex bins faster, not slower.

Root cause, established by reproduction + per-stage instrumentation:

- The hot path is the **boolean `pattern_cut`** (subtracting hundreds of hex prisms from the bin) — ~16s of a ~26s generation on a 16×16×6 bin. Its cost scales with wall **area**.
- `computeGenerationTimeoutMs` budgeted for hex, cutouts, and height — **never footprint**. A wide bin got only 45–60s while legitimately needing more; the browser's slower single-threaded WASM pushed it past the budget → timeout.

> Note: the pipeline runner emits progress *before* each stage, so the `merge@0.8` spike is actually the preceding `boolean` stage — tessellation is only ~1.5s. Easy to mis-attribute.

## Changes

1. **`generationTimeout.ts`** — footprint-aware budget: `+250ms` per grid cell above a 4×4 floor, gated on hex (a plain large bin has no pattern cut and finishes fast). Large hex bins now reach the 90s cap; normal bins unchanged.
2. **`tolerances.ts`** — the `hasLip` branch clamped tessellation at `0.06mm` for *any* size, over-meshing large lipped bins at near-export fidelity. Now relaxes with size (cap `0.15mm`, angular `8→12` above 200mm), cutting preview mesh weight ~29% on large bins. This lightens preview memory/transfer/GPU; it does **not** change generation time (the boolean dominates) — the budget fix is what resolves the timeout.

## Testing

- New `tolerances.test.ts` + extended `generationTimeout.test.ts` (TDD, red→green).
- Full bin scenario suite passes in isolation; one deliberate snapshot updated (`8×8 standard`, 22924→22308, validated). Export (STL) fidelity is unchanged.