### PR TITLE
feat(baseplate): connector fit-sample test print

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -34,6 +34,7 @@ import { PaddingSchematic } from './PaddingSchematic';
 import { SplitViewStrip } from './SplitViewStrip';
 import { CornerRadiusControl } from './CornerRadiusControl';
 import { GridDimensionStepper } from './GridDimensionStepper';
+import { ConnectorSampleButton } from './ConnectorSampleButton';
 import { resolveOverTileStatus } from '../../utils/overTileStatus';
 import { PADDING_MAX } from '../PaddingStepper';
 import { Stepper } from '@/design-system/Stepper';
@@ -371,6 +372,7 @@ export function BaseplatePanel() {
                       }
                       label={t('baseplate.preferIdenticalPieces')}
                     />
+                    <ConnectorSampleButton />
                   </>
                 )}
               </>

--- a/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ConnectorSampleButton } from './ConnectorSampleButton';
+import { resetAllStores } from '@/test/testUtils';
 
 vi.mock('@/i18n', () => ({
   useTranslation:
@@ -13,11 +14,13 @@ const downloadSample = vi.fn().mockResolvedValue(true);
 let canExport = true;
 
 vi.mock('../../hooks/useConnectorSampleExport', () => ({
+  CONNECTOR_SAMPLE_BASE_NAME: 'connector-fit-sample',
   useConnectorSampleExport: () => ({ isExporting: false, canExport, downloadSample }),
 }));
 
 describe('ConnectorSampleButton', () => {
   beforeEach(() => {
+    resetAllStores();
     downloadSample.mockClear();
     canExport = true;
   });
@@ -31,12 +34,25 @@ describe('ConnectorSampleButton', () => {
     expect(screen.getByText('baseplate.connectorSample.tip1')).toBeInTheDocument();
   });
 
-  it('triggers a STL sample download from the dialog', async () => {
+  it('triggers a STL sample download with the default name from the dialog', async () => {
     render(<ConnectorSampleButton />);
     fireEvent.click(screen.getByRole('button', { name: 'baseplate.connectorSample.button' }));
     fireEvent.click(screen.getByRole('button', { name: 'export.downloadFormat' }));
 
-    await waitFor(() => expect(downloadSample).toHaveBeenCalledWith('stl'));
+    await waitFor(() => expect(downloadSample).toHaveBeenCalledWith('stl', 'connector-fit-sample'));
+  });
+
+  it('forwards a custom filename to the download', async () => {
+    render(<ConnectorSampleButton />);
+    fireEvent.click(screen.getByRole('button', { name: 'baseplate.connectorSample.button' }));
+    // Switch to custom naming and type a name.
+    fireEvent.click(screen.getByRole('button', { name: 'export.nameStyle.custom' }));
+    fireEvent.change(screen.getByLabelText('export.customFileName'), {
+      target: { value: 'my-card' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'export.downloadFormat' }));
+
+    await waitFor(() => expect(downloadSample).toHaveBeenCalledWith('stl', 'my-card'));
   });
 
   it('disables the trigger when export is unavailable', () => {

--- a/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ConnectorSampleButton } from './ConnectorSampleButton';
+
+vi.mock('@/i18n', () => ({
+  useTranslation:
+    () =>
+    (key: string): string =>
+      key,
+}));
+
+const downloadSample = vi.fn().mockResolvedValue(true);
+let canExport = true;
+
+vi.mock('../../hooks/useConnectorSampleExport', () => ({
+  useConnectorSampleExport: () => ({ isExporting: false, canExport, downloadSample }),
+}));
+
+describe('ConnectorSampleButton', () => {
+  beforeEach(() => {
+    downloadSample.mockClear();
+    canExport = true;
+  });
+
+  it('opens the export dialog with print tips when clicked', () => {
+    render(<ConnectorSampleButton />);
+    fireEvent.click(screen.getByRole('button', { name: 'baseplate.connectorSample.button' }));
+
+    expect(screen.getByText('baseplate.connectorSample.dialogTitle')).toBeInTheDocument();
+    expect(screen.getByText('baseplate.connectorSample.tipsTitle')).toBeInTheDocument();
+    expect(screen.getByText('baseplate.connectorSample.tip1')).toBeInTheDocument();
+  });
+
+  it('triggers a STL sample download from the dialog', async () => {
+    render(<ConnectorSampleButton />);
+    fireEvent.click(screen.getByRole('button', { name: 'baseplate.connectorSample.button' }));
+    fireEvent.click(screen.getByRole('button', { name: 'export.downloadFormat' }));
+
+    await waitFor(() => expect(downloadSample).toHaveBeenCalledWith('stl'));
+  });
+
+  it('disables the trigger when export is unavailable', () => {
+    canExport = false;
+    render(<ConnectorSampleButton />);
+    expect(screen.getByRole('button', { name: 'baseplate.connectorSample.button' })).toBeDisabled();
+  });
+});

--- a/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.tsx
@@ -13,15 +13,10 @@ import { ExportDialog } from '@/shared/components/ExportDialog';
 import { useToastStore } from '@/core/store/toast';
 import { useTranslation } from '@/i18n';
 import { useConnectorSampleExport } from '../../hooks/useConnectorSampleExport';
+import { FORMAT_EXTENSIONS } from '@/shared/generation/exportUtils';
 import type { ExportFileFormat, ExportFileNameConfig } from '@/shared/types/bin';
 
 const SAMPLE_BASE_NAME = 'connector-fit-sample';
-
-const FORMAT_EXTENSIONS: Record<ExportFileFormat, string> = {
-  stl: '.stl',
-  step: '.step',
-  '3mf': '.3mf',
-};
 
 export function ConnectorSampleButton() {
   const t = useTranslation();

--- a/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.tsx
@@ -1,0 +1,110 @@
+/**
+ * "Print fit sample" control for the baseplate connector section.
+ *
+ * Opens the shared ExportDialog to download a one-file calibration tray that
+ * sweeps all three connector styles across a fit-offset ladder, so makers can
+ * dial in the fit that clicks before committing to a full split baseplate.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { Button } from '@/design-system/Button';
+import { LayoutGridIcon } from '@/design-system/Icon';
+import { ExportDialog } from '@/shared/components/ExportDialog';
+import { useToastStore } from '@/core/store/toast';
+import { useTranslation } from '@/i18n';
+import { useConnectorSampleExport } from '../../hooks/useConnectorSampleExport';
+import type { ExportFileFormat, ExportFileNameConfig } from '@/shared/types/bin';
+
+const SAMPLE_BASE_NAME = 'connector-fit-sample';
+
+const FORMAT_EXTENSIONS: Record<ExportFileFormat, string> = {
+  stl: '.stl',
+  step: '.step',
+  '3mf': '.3mf',
+};
+
+export function ConnectorSampleButton() {
+  const t = useTranslation();
+  const { isExporting, canExport, downloadSample } = useConnectorSampleExport();
+
+  const [open, setOpen] = useState(false);
+  const [fileNameConfig, setFileNameConfig] = useState<ExportFileNameConfig>({
+    style: 'descriptive',
+    customName: '',
+    format: 'stl',
+  });
+
+  const activeFormat: ExportFileFormat = fileNameConfig.format ?? 'stl';
+  const displayExtension = FORMAT_EXTENSIONS[activeFormat];
+  const baseName =
+    fileNameConfig.style === 'custom' && fileNameConfig.customName.trim() !== ''
+      ? fileNameConfig.customName.trim()
+      : SAMPLE_BASE_NAME;
+
+  const handleDownload = useCallback(() => {
+    void downloadSample(activeFormat).then((succeeded) => {
+      if (!succeeded) return;
+      useToastStore
+        .getState()
+        .addToast(t('baseplate.connectorSample.exportComplete'), 'success', 3000);
+      setOpen(false);
+    });
+  }, [downloadSample, activeFormat, t]);
+
+  const tips = useMemo(
+    () => [
+      t('baseplate.connectorSample.tip1'),
+      t('baseplate.connectorSample.tip2'),
+      t('baseplate.connectorSample.tip3'),
+      t('baseplate.connectorSample.tip4'),
+    ],
+    [t]
+  );
+
+  return (
+    <>
+      <Button
+        variant="secondary"
+        size="sm"
+        fullWidth
+        leftIcon={<LayoutGridIcon className="h-4 w-4" />}
+        onClick={() => setOpen(true)}
+        disabled={!canExport}
+      >
+        {t('baseplate.connectorSample.button')}
+      </Button>
+
+      <ExportDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        activeFormat={activeFormat}
+        fileNameConfig={fileNameConfig}
+        onFileNameConfigChange={setFileNameConfig}
+        fileName={`${baseName}${displayExtension}`}
+        displayExtension={displayExtension}
+        canExport={canExport}
+        isExporting={isExporting}
+        onDownload={handleDownload}
+        sectionTitle={t('baseplate.connectorSample.dialogTitle')}
+        sectionDescription={t('baseplate.connectorSample.dialogDescription')}
+        extras={
+          <div className="mb-4 rounded-lg border border-stroke-subtle bg-surface p-3">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-content-tertiary">
+              {t('baseplate.connectorSample.tipsTitle')}
+            </h3>
+            <ul className="space-y-1 text-xs text-content-secondary">
+              {tips.map((tip) => (
+                <li key={tip} className="flex gap-2">
+                  <span aria-hidden="true" className="text-content-tertiary">
+                    •
+                  </span>
+                  <span>{tip}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        }
+      />
+    </>
+  );
+}

--- a/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.tsx
@@ -12,11 +12,12 @@ import { LayoutGridIcon } from '@/design-system/Icon';
 import { ExportDialog } from '@/shared/components/ExportDialog';
 import { useToastStore } from '@/core/store/toast';
 import { useTranslation } from '@/i18n';
-import { useConnectorSampleExport } from '../../hooks/useConnectorSampleExport';
+import {
+  useConnectorSampleExport,
+  CONNECTOR_SAMPLE_BASE_NAME,
+} from '../../hooks/useConnectorSampleExport';
 import { FORMAT_EXTENSIONS } from '@/shared/generation/exportUtils';
 import type { ExportFileFormat, ExportFileNameConfig } from '@/shared/types/bin';
-
-const SAMPLE_BASE_NAME = 'connector-fit-sample';
 
 export function ConnectorSampleButton() {
   const t = useTranslation();
@@ -34,17 +35,17 @@ export function ConnectorSampleButton() {
   const baseName =
     fileNameConfig.style === 'custom' && fileNameConfig.customName.trim() !== ''
       ? fileNameConfig.customName.trim()
-      : SAMPLE_BASE_NAME;
+      : CONNECTOR_SAMPLE_BASE_NAME;
 
   const handleDownload = useCallback(() => {
-    void downloadSample(activeFormat).then((succeeded) => {
+    void downloadSample(activeFormat, baseName).then((succeeded) => {
       if (!succeeded) return;
       useToastStore
         .getState()
         .addToast(t('baseplate.connectorSample.exportComplete'), 'success', 3000);
       setOpen(false);
     });
-  }, [downloadSample, activeFormat, t]);
+  }, [downloadSample, activeFormat, baseName, t]);
 
   const tips = useMemo(
     () => [

--- a/src/features/baseplate/hooks/useConnectorSampleExport.test.ts
+++ b/src/features/baseplate/hooks/useConnectorSampleExport.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useConnectorSampleExport } from './useConnectorSampleExport';
+
+vi.mock('@/i18n', () => ({
+  useTranslation:
+    () =>
+    (key: string): string =>
+      key,
+}));
+
+let activeBridge: unknown = null;
+vi.mock('@/shared/generation/bridge', () => ({
+  getActiveBridge: () => activeBridge,
+}));
+
+describe('useConnectorSampleExport', () => {
+  beforeEach(() => {
+    activeBridge = null;
+  });
+
+  it('reports canExport from the active bridge presence', () => {
+    const { result, rerender } = renderHook(() => useConnectorSampleExport());
+    expect(result.current.canExport).toBe(false);
+
+    activeBridge = {};
+    rerender();
+    expect(result.current.canExport).toBe(true);
+  });
+
+  it('refuses to export and surfaces an error when no bridge is ready', async () => {
+    const { result } = renderHook(() => useConnectorSampleExport());
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.downloadSample('stl');
+    });
+    expect(ok).toBe(false);
+  });
+});

--- a/src/features/baseplate/hooks/useConnectorSampleExport.test.ts
+++ b/src/features/baseplate/hooks/useConnectorSampleExport.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useConnectorSampleExport } from './useConnectorSampleExport';
 import { triggerDownload } from '@/shared/generation/exportUtils';
+import { resetAllStores } from '@/test/testUtils';
 
 vi.mock('@/i18n', () => ({
   useTranslation:
@@ -39,6 +40,7 @@ vi.mock('@/shared/generation/export', () => ({
 
 describe('useConnectorSampleExport', () => {
   beforeEach(() => {
+    resetAllStores();
     activeBridge = null;
     vi.mocked(triggerDownload).mockClear();
   });
@@ -77,6 +79,20 @@ describe('useConnectorSampleExport', () => {
     expect(ok).toBe(true);
     expect(exportConnectorSample).toHaveBeenCalledWith(expect.anything(), 'stl');
     expect(triggerDownload).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors a custom base name in the downloaded filename', async () => {
+    const exportConnectorSample = vi
+      .fn()
+      .mockResolvedValue({ data: new ArrayBuffer(8), fileName: 'x.stl' });
+    activeBridge = { exportConnectorSample };
+
+    const { result } = renderHook(() => useConnectorSampleExport());
+    await act(async () => {
+      await result.current.downloadSample('stl', 'my-card');
+    });
+
+    expect(triggerDownload).toHaveBeenCalledWith(expect.anything(), 'my-card.stl');
   });
 
   it('requests STL from the bridge and converts it for 3MF', async () => {

--- a/src/features/baseplate/hooks/useConnectorSampleExport.test.ts
+++ b/src/features/baseplate/hooks/useConnectorSampleExport.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useConnectorSampleExport } from './useConnectorSampleExport';
+import { triggerDownload } from '@/shared/generation/exportUtils';
 
 vi.mock('@/i18n', () => ({
   useTranslation:
@@ -14,9 +15,32 @@ vi.mock('@/shared/generation/bridge', () => ({
   getActiveBridge: () => activeBridge,
 }));
 
+vi.mock('@/shared/generation/exportUtils', () => ({
+  triggerDownload: vi.fn(),
+  FORMAT_MIME_TYPES: { stl: 'model/stl', step: 'model/step', '3mf': 'model/3mf' },
+  FORMAT_EXTENSIONS: { stl: '.stl', step: '.step', '3mf': '.3mf' },
+}));
+
+// 3MF conversion is exercised via lightweight mocks — the STL→mesh→3MF pipeline
+// itself is covered by the parser/export unit tests.
+vi.mock('@/shared/generation/stlParser', async () => {
+  const { ok } = await import('@/core/result');
+  return {
+    parseSTLBinary: () =>
+      ok({
+        vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      }),
+  };
+});
+vi.mock('@/shared/generation/export', () => ({
+  export3MF: () => new Blob(['3mf']),
+}));
+
 describe('useConnectorSampleExport', () => {
   beforeEach(() => {
     activeBridge = null;
+    vi.mocked(triggerDownload).mockClear();
   });
 
   it('reports canExport from the active bridge presence', () => {
@@ -35,5 +59,41 @@ describe('useConnectorSampleExport', () => {
       ok = await result.current.downloadSample('stl');
     });
     expect(ok).toBe(false);
+    expect(triggerDownload).not.toHaveBeenCalled();
+  });
+
+  it('exports STL straight from the bridge', async () => {
+    const exportConnectorSample = vi
+      .fn()
+      .mockResolvedValue({ data: new ArrayBuffer(8), fileName: 'x.stl' });
+    activeBridge = { exportConnectorSample };
+
+    const { result } = renderHook(() => useConnectorSampleExport());
+    let ok = false;
+    await act(async () => {
+      ok = await result.current.downloadSample('stl');
+    });
+
+    expect(ok).toBe(true);
+    expect(exportConnectorSample).toHaveBeenCalledWith(expect.anything(), 'stl');
+    expect(triggerDownload).toHaveBeenCalledTimes(1);
+  });
+
+  it('requests STL from the bridge and converts it for 3MF', async () => {
+    const exportConnectorSample = vi
+      .fn()
+      .mockResolvedValue({ data: new ArrayBuffer(8), fileName: 'x.stl' });
+    activeBridge = { exportConnectorSample };
+
+    const { result } = renderHook(() => useConnectorSampleExport());
+    let ok = false;
+    await act(async () => {
+      ok = await result.current.downloadSample('3mf');
+    });
+
+    expect(ok).toBe(true);
+    // 3MF is synthesized from an STL export, never requested directly.
+    expect(exportConnectorSample).toHaveBeenCalledWith(expect.anything(), 'stl');
+    expect(triggerDownload).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/baseplate/hooks/useConnectorSampleExport.ts
+++ b/src/features/baseplate/hooks/useConnectorSampleExport.ts
@@ -1,0 +1,125 @@
+/**
+ * Hook for exporting the connector fit-sample tray (a calibration card sweeping
+ * all three connector styles across a fit-offset ladder) as STL, STEP, or 3MF.
+ *
+ * Single-file export: the worker compounds every coupon + shared loose part into
+ * one ready-to-slice tray. Independent of the active split/connector selection —
+ * it always sweeps all styles/offsets — but reuses the layout's grid unit and
+ * magnet settings so the coupon height matches the real plate.
+ */
+
+import { useCallback, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useLayoutStore } from '@/core/store/layout';
+import { useSettingsStore } from '@/core/store/settings';
+import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
+import { getActiveBridge } from '@/shared/generation/bridge';
+import { export3MF } from '@/shared/generation/export';
+import { parseSTLBinary } from '@/shared/generation/stlParser';
+import { isErr, getUserMessage } from '@/core/result';
+import { useToastStore } from '@/core/store/toast';
+import { useTranslation } from '@/i18n';
+import { buildFullParams } from '../utils/buildFullParams';
+import { FORMAT_MIME_TYPES, triggerDownload } from '@/shared/generation/exportUtils';
+import type { ExportFileFormat } from '@/shared/types/bin';
+
+const SAMPLE_BASE_NAME = 'connector-fit-sample';
+
+const FORMAT_EXTENSIONS: Record<ExportFileFormat, string> = {
+  stl: '.stl',
+  step: '.step',
+  '3mf': '.3mf',
+};
+
+interface UseConnectorSampleExportReturn {
+  readonly isExporting: boolean;
+  readonly canExport: boolean;
+  readonly downloadSample: (format: ExportFileFormat) => Promise<boolean>;
+}
+
+function convertStlTo3mf(stlData: ArrayBuffer, name: string): Blob {
+  const parseResult = parseSTLBinary(stlData);
+  if (isErr(parseResult)) {
+    throw new Error(getUserMessage(parseResult.error));
+  }
+  const { vertices, normals } = parseResult.value;
+  const printSettings = useSettingsStore.getState().settings.printSettings;
+  return export3MF(vertices, normals, {
+    name,
+    printSettings: {
+      layerHeight: printSettings.layerHeightMm,
+      infillPercent: printSettings.infillPercent,
+      material: 'PLA',
+      supportRequired: false,
+      estimatedMinutes: 0,
+      estimatedGrams: 0,
+    },
+  });
+}
+
+export function useConnectorSampleExport(): UseConnectorSampleExportReturn {
+  const t = useTranslation();
+
+  const {
+    drawerWidth,
+    drawerDepth,
+    gridUnitMm,
+    fractionalEdgeX,
+    fractionalEdgeY,
+    baseplateParams,
+  } = useLayoutStore(
+    useShallow((state) => ({
+      drawerWidth: state.layout.drawer.width,
+      drawerDepth: state.layout.drawer.depth,
+      gridUnitMm: state.layout.gridUnitMm,
+      fractionalEdgeX: state.layout.drawer.fractionalEdgeX ?? 'end',
+      fractionalEdgeY: state.layout.drawer.fractionalEdgeY ?? 'end',
+      baseplateParams: state.layout.baseplateParams ?? DEFAULT_BASEPLATE_PARAMS,
+    }))
+  );
+
+  const [isExporting, setIsExporting] = useState(false);
+  const canExport = getActiveBridge() !== null;
+
+  const downloadSample = useCallback(
+    async (format: ExportFileFormat) => {
+      const bridge = getActiveBridge();
+      if (!bridge) {
+        useToastStore.getState().addToast(t('baseplate.exportNotReady'), 'error');
+        return false;
+      }
+
+      setIsExporting(true);
+      try {
+        const fullParams = buildFullParams(
+          baseplateParams,
+          drawerWidth,
+          drawerDepth,
+          gridUnitMm,
+          fractionalEdgeX,
+          fractionalEdgeY
+        );
+
+        if (format === '3mf') {
+          const stlResult = await bridge.exportConnectorSample(fullParams, 'stl');
+          const blob = convertStlTo3mf(stlResult.data, SAMPLE_BASE_NAME);
+          triggerDownload(blob, `${SAMPLE_BASE_NAME}${FORMAT_EXTENSIONS['3mf']}`);
+        } else {
+          const result = await bridge.exportConnectorSample(fullParams, format);
+          const blob = new Blob([result.data], { type: FORMAT_MIME_TYPES[format] });
+          triggerDownload(blob, `${SAMPLE_BASE_NAME}${FORMAT_EXTENSIONS[format]}`);
+        }
+        return true;
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : 'Export failed';
+        useToastStore.getState().addToast(message, 'error');
+        return false;
+      } finally {
+        setIsExporting(false);
+      }
+    },
+    [t, drawerWidth, drawerDepth, gridUnitMm, fractionalEdgeX, fractionalEdgeY, baseplateParams]
+  );
+
+  return { isExporting, canExport, downloadSample };
+}

--- a/src/features/baseplate/hooks/useConnectorSampleExport.ts
+++ b/src/features/baseplate/hooks/useConnectorSampleExport.ts
@@ -20,16 +20,14 @@ import { isErr, getUserMessage } from '@/core/result';
 import { useToastStore } from '@/core/store/toast';
 import { useTranslation } from '@/i18n';
 import { buildFullParams } from '../utils/buildFullParams';
-import { FORMAT_MIME_TYPES, triggerDownload } from '@/shared/generation/exportUtils';
+import {
+  FORMAT_MIME_TYPES,
+  FORMAT_EXTENSIONS,
+  triggerDownload,
+} from '@/shared/generation/exportUtils';
 import type { ExportFileFormat } from '@/shared/types/bin';
 
 const SAMPLE_BASE_NAME = 'connector-fit-sample';
-
-const FORMAT_EXTENSIONS: Record<ExportFileFormat, string> = {
-  stl: '.stl',
-  step: '.step',
-  '3mf': '.3mf',
-};
 
 interface UseConnectorSampleExportReturn {
   readonly isExporting: boolean;

--- a/src/features/baseplate/hooks/useConnectorSampleExport.ts
+++ b/src/features/baseplate/hooks/useConnectorSampleExport.ts
@@ -27,12 +27,13 @@ import {
 } from '@/shared/generation/exportUtils';
 import type { ExportFileFormat } from '@/shared/types/bin';
 
-const SAMPLE_BASE_NAME = 'connector-fit-sample';
+/** Default download name when the dialog isn't given a custom one. */
+export const CONNECTOR_SAMPLE_BASE_NAME = 'connector-fit-sample';
 
 interface UseConnectorSampleExportReturn {
   readonly isExporting: boolean;
   readonly canExport: boolean;
-  readonly downloadSample: (format: ExportFileFormat) => Promise<boolean>;
+  readonly downloadSample: (format: ExportFileFormat, baseName?: string) => Promise<boolean>;
 }
 
 function convertStlTo3mf(stlData: ArrayBuffer, name: string): Blob {
@@ -80,7 +81,7 @@ export function useConnectorSampleExport(): UseConnectorSampleExportReturn {
   const canExport = getActiveBridge() !== null;
 
   const downloadSample = useCallback(
-    async (format: ExportFileFormat) => {
+    async (format: ExportFileFormat, baseName: string = CONNECTOR_SAMPLE_BASE_NAME) => {
       const bridge = getActiveBridge();
       if (!bridge) {
         useToastStore.getState().addToast(t('baseplate.exportNotReady'), 'error');
@@ -100,12 +101,12 @@ export function useConnectorSampleExport(): UseConnectorSampleExportReturn {
 
         if (format === '3mf') {
           const stlResult = await bridge.exportConnectorSample(fullParams, 'stl');
-          const blob = convertStlTo3mf(stlResult.data, SAMPLE_BASE_NAME);
-          triggerDownload(blob, `${SAMPLE_BASE_NAME}${FORMAT_EXTENSIONS['3mf']}`);
+          const blob = convertStlTo3mf(stlResult.data, baseName);
+          triggerDownload(blob, `${baseName}${FORMAT_EXTENSIONS['3mf']}`);
         } else {
           const result = await bridge.exportConnectorSample(fullParams, format);
           const blob = new Blob([result.data], { type: FORMAT_MIME_TYPES[format] });
-          triggerDownload(blob, `${SAMPLE_BASE_NAME}${FORMAT_EXTENSIONS[format]}`);
+          triggerDownload(blob, `${baseName}${FORMAT_EXTENSIONS[format]}`);
         }
         return true;
       } catch (error: unknown) {

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -55,6 +55,7 @@ import {
   exportSplitBinRange as exportSplitBinRangeImpl,
   exportBaseplate as exportBaseplateImpl,
   exportConnectorKey as exportConnectorKeyImpl,
+  exportConnectorSample as exportConnectorSampleImpl,
 } from './bridgeExports';
 import type { KernelName } from './types';
 
@@ -390,6 +391,14 @@ export class GenerationBridge {
     options?: { tolerance?: number; angularTolerance?: number }
   ): Promise<BaseplateExportResult> {
     return exportConnectorKeyImpl(this, params, format, options);
+  }
+
+  exportConnectorSample(
+    params: BaseplateParams,
+    format: ExportFormat,
+    options?: { tolerance?: number; angularTolerance?: number }
+  ): Promise<BaseplateExportResult> {
+    return exportConnectorSampleImpl(this, params, format, options);
   }
 
   /** Whether the bridge has been destroyed */

--- a/src/features/generation/bridge/bridgeExports.ts
+++ b/src/features/generation/bridge/bridgeExports.ts
@@ -286,3 +286,33 @@ export function exportConnectorKey(
     })
   );
 }
+
+/**
+ * Export the connector fit-sample tray. The tray's work (≈30 coupon booleans +
+ * embossed labels) is fixed regardless of the user's baseplate footprint, so it
+ * uses a fixed generous timeout rather than the footprint-derived budget.
+ */
+const CONNECTOR_SAMPLE_TIMEOUT_MS = 180_000;
+
+export function exportConnectorSample(
+  ctx: BridgeExportContext,
+  params: BaseplateParams,
+  format: ExportFormat,
+  options?: { tolerance?: number; angularTolerance?: number }
+): Promise<BaseplateExportResult> {
+  return runExport<BaseplateExportResult>(
+    ctx,
+    'export',
+    CONNECTOR_SAMPLE_TIMEOUT_MS,
+    (requestId) => ({
+      type: 'EXPORT_CONNECTOR_SAMPLE',
+      payload: {
+        params,
+        requestId,
+        format,
+        tolerance: options?.tolerance,
+        angularTolerance: options?.angularTolerance,
+      },
+    })
+  );
+}

--- a/src/features/generation/bridge/types.ts
+++ b/src/features/generation/bridge/types.ts
@@ -46,6 +46,7 @@ export type WorkerMessage =
   | ExportMessage
   | ExportBaseplateMessage
   | ExportConnectorKeyMessage
+  | ExportConnectorSampleMessage
   | ExportDividersMessage
   | ExportCombinedMessage
   | ExportSplitMessage
@@ -123,6 +124,16 @@ export interface ExportBaseplatePayload {
  */
 export interface ExportConnectorKeyMessage {
   readonly type: 'EXPORT_CONNECTOR_KEY';
+  readonly payload: ExportBaseplatePayload;
+}
+
+/**
+ * Export the connector fit-sample tray (a calibration card sweeping all three
+ * connector styles across a fit-offset ladder). Reuses the BASEPLATE_EXPORT_RESULT
+ * response shape (data + format + fileName) and the ExportBaseplatePayload.
+ */
+export interface ExportConnectorSampleMessage {
+  readonly type: 'EXPORT_CONNECTOR_SAMPLE';
   readonly payload: ExportBaseplatePayload;
 }
 

--- a/src/features/generation/worker/generation.worker.ts
+++ b/src/features/generation/worker/generation.worker.ts
@@ -34,6 +34,7 @@ import {
   handleExport,
   handleExportBaseplate,
   handleExportConnectorKey,
+  handleExportConnectorSample,
   handleExportDividers,
   handleExportCombined,
 } from './handlers/exportHandler';
@@ -123,6 +124,10 @@ self.addEventListener('message', (event: MessageEvent<WorkerMessage>) => {
 
       case 'EXPORT_CONNECTOR_KEY':
         await handleExportConnectorKey(message);
+        break;
+
+      case 'EXPORT_CONNECTOR_SAMPLE':
+        await handleExportConnectorSample(message);
         break;
 
       case 'EXPORT_DIVIDERS':

--- a/src/features/generation/worker/generators/baseplateConnectors.ts
+++ b/src/features/generation/worker/generators/baseplateConnectors.ts
@@ -223,7 +223,7 @@ export function buildConnectors(
  * extended COPLANAR_OVERLAP into the slab so the fuse has shared volume rather
  * than a degenerate coplanar interface at the wall face (issue #1407).
  */
-function makeTongue(
+export function makeTongue(
   pt: (wall: number, bp: number) => [number, number],
   w: number,
   bp: number,
@@ -242,7 +242,7 @@ function makeTongue(
 }
 
 /** Dovetail groove: matching shape + clearance, extended beyond wall and in Z. */
-function makeGroove(
+export function makeGroove(
   pt: (wall: number, bp: number) => [number, number],
   w: number,
   bp: number,
@@ -301,7 +301,7 @@ export function buildDovetailKey(totalHeight: number): Shape3D {
  * seated-clip preview can't drift. Proven standalone with brepjs-verify: at the
  * thin 5mm slab the seated clip clears the pockets with zero interference.
  */
-function makeSnapPocket(
+export function makeSnapPocket(
   pt: (wall: number, bp: number) => [number, number],
   w: number,
   bp: number,

--- a/src/features/generation/worker/generators/connectorSample.scenario.test.ts
+++ b/src/features/generation/worker/generators/connectorSample.scenario.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment node
+/**
+ * Scenario tests for the connector fit-sample tray (calibration card).
+ *
+ * The tray sweeps all three connector styles across a fit-offset ladder, each
+ * cell a mated pair of abstract coupons, plus one shared loose key/clip per
+ * key/clip row. Verified against the real OCCT kernel:
+ *   1. every piece is a valid, positive-volume solid,
+ *   2. the exported STL is watertight (each coupon's groove/pocket + embossed
+ *      label fuse cleanly — no boundary/non-manifold edges) and bed-resting, and
+ *   3. the piece count matches the documented grid (3×5 pairs + 2 loose parts).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { measureVolume } from 'brepjs';
+import type { BaseplateParams } from '@/shared/types/bin';
+import { isOk } from '@/core/result';
+import { parseSTLBinary } from '@/shared/generation/stlParser';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import { buildConnectorSampleTray, exportConnectorSample } from './connectorSample';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+  width: 2,
+  depth: 2,
+  gridUnitMm: 42,
+  magnetHoles: false,
+  magnetDiameter: 6.5,
+  magnetDepth: 2.4,
+  paddingLeft: 0,
+  paddingRight: 0,
+  paddingFront: 0,
+  paddingBack: 0,
+  fractionalEdgeX: 'end',
+  fractionalEdgeY: 'end',
+  ...overrides,
+});
+
+function analyze(stl: ArrayBuffer) {
+  const parsed = parseSTLBinary(stl);
+  if (!isOk(parsed)) throw new Error('STL parse failed');
+  const { vertices } = parsed.value;
+  const triangleCount = vertices.length / 9;
+  const QUANTIZE = 1e4;
+  const vKey = (x: number, y: number, z: number): string =>
+    `${Math.round(x * QUANTIZE)},${Math.round(y * QUANTIZE)},${Math.round(z * QUANTIZE)}`;
+  const eKey = (a: string, b: string): string => (a < b ? `${a}|${b}` : `${b}|${a}`);
+  const edgeCount = new Map<string, number>();
+  let minZ = Infinity,
+    maxZ = -Infinity,
+    hasNaN = false;
+  for (let t = 0; t < triangleCount; t++) {
+    const base = t * 9;
+    const verts: Array<[number, number, number]> = [
+      [vertices[base], vertices[base + 1], vertices[base + 2]],
+      [vertices[base + 3], vertices[base + 4], vertices[base + 5]],
+      [vertices[base + 6], vertices[base + 7], vertices[base + 8]],
+    ];
+    for (const [x, y, z] of verts) {
+      if (Number.isNaN(x) || Number.isNaN(y) || Number.isNaN(z)) hasNaN = true;
+      if (z < minZ) minZ = z;
+      if (z > maxZ) maxZ = z;
+    }
+    const keys = verts.map(([x, y, z]) => vKey(x, y, z));
+    for (let i = 0; i < 3; i++) {
+      const k = eKey(keys[i], keys[(i + 1) % 3]);
+      edgeCount.set(k, (edgeCount.get(k) ?? 0) + 1);
+    }
+  }
+  let nonManifoldEdges = 0;
+  let boundaryEdges = 0;
+  for (const count of edgeCount.values()) {
+    if (count === 1) boundaryEdges++;
+    else if (count > 2) nonManifoldEdges++;
+  }
+  return { triangleCount, nonManifoldEdges, boundaryEdges, minZ, maxZ, hasNaN };
+}
+
+const vol = (s: Parameters<typeof measureVolume>[0]): number => {
+  const r = measureVolume(s);
+  if (!isOk(r)) throw new Error('measureVolume failed');
+  return r.value;
+};
+
+describe('connectorSample — fit-sample tray', () => {
+  const TEST_TIMEOUT_MS = 120_000;
+
+  it(
+    'builds the documented grid of valid, positive-volume pieces',
+    () => {
+      const pieces = buildConnectorSampleTray(defaults());
+      try {
+        // 3 styles × 5 offsets × 2 coupons + 1 key + 1 clip = 32 pieces.
+        expect(pieces).toHaveLength(32);
+        for (const piece of pieces) {
+          const v = vol(piece);
+          expect(Number.isFinite(v)).toBe(true);
+          expect(v).toBeGreaterThan(0);
+        }
+      } finally {
+        for (const p of pieces) p.delete();
+      }
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    'exports a watertight, bed-resting STL tray',
+    async () => {
+      const { data, fileName } = await exportConnectorSample(defaults(), 'stl');
+      const stats = analyze(data);
+      expect(fileName).toBe('connector_fit_sample.stl');
+      expect(stats.hasNaN, 'no NaN vertices').toBe(false);
+      expect(stats.triangleCount, 'non-empty mesh').toBeGreaterThan(0);
+      expect(stats.nonManifoldEdges, 'non-manifold edges').toBe(0);
+      expect(stats.boundaryEdges, 'boundary edges').toBe(0);
+      // Whole tray rests on the bed.
+      expect(stats.minZ, 'rests on bed').toBeCloseTo(0, 1);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    'magnet-hole baseplates produce taller, still-valid coupons',
+    () => {
+      const pieces = buildConnectorSampleTray(defaults({ magnetHoles: true, magnetDepth: 2.4 }));
+      try {
+        expect(pieces).toHaveLength(32);
+        for (const piece of pieces) {
+          expect(vol(piece)).toBeGreaterThan(0);
+        }
+      } finally {
+        for (const p of pieces) p.delete();
+      }
+    },
+    TEST_TIMEOUT_MS
+  );
+});

--- a/src/features/generation/worker/generators/connectorSample.scenario.test.ts
+++ b/src/features/generation/worker/generators/connectorSample.scenario.test.ts
@@ -123,6 +123,16 @@ describe('connectorSample — fit-sample tray', () => {
   );
 
   it(
+    'exports a non-empty STEP tray',
+    async () => {
+      const { data, fileName } = await exportConnectorSample(defaults(), 'step');
+      expect(fileName).toBe('connector_fit_sample.step');
+      expect(data.byteLength).toBeGreaterThan(0);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
     'magnet-hole baseplates produce taller, still-valid coupons',
     () => {
       const pieces = buildConnectorSampleTray(defaults({ magnetHoles: true, magnetDepth: 2.4 }));

--- a/src/features/generation/worker/generators/connectorSample.ts
+++ b/src/features/generation/worker/generators/connectorSample.ts
@@ -1,0 +1,326 @@
+/**
+ * Connector fit-sample tray ("calibration card").
+ *
+ * A single printable tray that lets makers dial in their connector fit before
+ * committing to a full split baseplate. Laid out as a grid:
+ *
+ *   rows  = the three connector styles (dovetail / dovetailKey / snapClip)
+ *   cols  = a fit-offset ladder (-0.10 … +0.10 mm, centered on nominal)
+ *
+ * Each grid cell is a MATED PAIR of small abstract coupons carrying the real
+ * connector profile (reused verbatim from `baseplateConnectors` so the printed
+ * fit matches the real plate — the tolerance lives in the female groove/pocket,
+ * not the surrounding socket, which is why a plain block coupon fits identically
+ * to a full 42 mm cell). Both halves of every pair are embossed with their
+ * style + offset so detached pieces stay identifiable.
+ *
+ * The dovetail KEY and snap CLIP are nominal parts — the offset rides entirely
+ * on the female pocket — so each of those rows ships ONE shared loose part the
+ * maker inserts into each offset's pair to feel the fit, rather than five
+ * redundant copies.
+ *
+ * Pieces are separate, non-fused solids resting on the bed (Z≥0); the export
+ * compounds them into one ready-to-slice file.
+ */
+
+import {
+  draw,
+  fuse,
+  cut,
+  cutAll,
+  translate,
+  compound,
+  mesh,
+  exportSTEP,
+  unwrap,
+  withScope,
+  clone,
+} from 'brepjs';
+import type { Shape3D, ValidSolid, Drawing, DisposalScope } from 'brepjs';
+import type { BaseplateParams } from '@/shared/types/bin';
+import type { ExportFormat } from '../../bridge/types';
+import { sketch } from './meshUtils';
+import {
+  SOCKET_HEIGHT,
+  MAGNET_FLOOR,
+  COPLANAR_MARGIN,
+  TONGUE_PROTRUSION,
+  TONGUE_BASE_HALF,
+  TONGUE_TIP_HALF,
+  TONGUE_CLEARANCE,
+  DOVETAIL_KEY_CLEARANCE,
+  effectiveClearance,
+} from './generatorTypes';
+import { snapClipLevels } from '@/shared/constants/connectors';
+import type { SnapClipLevels } from '@/shared/constants/connectors';
+import {
+  makeTongue,
+  makeGroove,
+  makeSnapPocket,
+  buildDovetailKey,
+  buildSnapClipForPrint,
+} from './baseplateConnectors';
+import { buildTextSolid } from './textBuilder';
+import { buildBaseplateSTL } from './baseplateSTL';
+
+/** Fit-offset ladder swept across the columns, centered on nominal (0). */
+const SAMPLE_OFFSETS: readonly number[] = [-0.1, -0.05, 0, 0.05, 0.1];
+
+interface SampleStyle {
+  readonly key: 'dovetail' | 'dovetailKey' | 'snapClip';
+  /** Short label prefix embossed on each coupon (e.g. "DT"). */
+  readonly abbr: string;
+  /** Whether the row ships a shared loose part (key/clip). */
+  readonly loose: 'key' | 'clip' | null;
+}
+
+const SAMPLE_STYLES: readonly SampleStyle[] = [
+  { key: 'dovetail', abbr: 'DT', loose: null },
+  { key: 'dovetailKey', abbr: 'DK', loose: 'key' },
+  { key: 'snapClip', abbr: 'SC', loose: 'clip' },
+];
+
+// Tray layout (mm). A coupon's long axis is X so the embossed label reads
+// left-to-right; the seam runs along X, so a pair stacks front/back along Y.
+const COUPON_X = 15; // coupon length (label axis)
+const COUPON_Y = 9; // coupon depth (across the seam)
+const COUPON_FILLET = 1.4; // rounded top-view corners — finished look, broken edges
+const SEAM_GAP = 5; // gap between the two coupons of a pair (printed separated)
+const COL_GAP = 7; // gap between offset columns
+const ROW_GAP = 10; // gap between style rows
+const LABEL_DEPTH = 0.6; // emboss height above the top face
+const LABEL_MARGIN = 1.4;
+const LABEL_MIN_FONT = 1.0;
+const LABEL_MAX_FONT = 2.4;
+
+const CELL_Y = 2 * COUPON_Y + SEAM_GAP; // total Y footprint of one mated pair
+const COL_PITCH = COUPON_X + COL_GAP;
+const ROW_PITCH = CELL_Y + ROW_GAP;
+
+/** Map (wall, boundary) → XY point for a seam running along X (protrude on Y). */
+function ptY(wall: number, bp: number): [number, number] {
+  return [bp, wall];
+}
+
+/** Signed fit-offset label, e.g. "+0.05", "-0.10", "0.00". */
+function formatOffset(v: number): string {
+  const s = v.toFixed(2);
+  return v > 0 ? `+${s}` : s;
+}
+
+/** Rounded-rectangle top-view profile centered at (cx, cy). */
+function roundedRect(cx: number, cy: number, w: number, h: number, r: number): Drawing {
+  const x0 = cx - w / 2;
+  const x1 = cx + w / 2;
+  const y0 = cy - h / 2;
+  const y1 = cy + h / 2;
+  return draw([cx, y0])
+    .lineTo([x1, y0])
+    .customCorner(r)
+    .lineTo([x1, y1])
+    .customCorner(r)
+    .lineTo([x0, y1])
+    .customCorner(r)
+    .lineTo([x0, y0])
+    .customCorner(r)
+    .close();
+}
+
+type CouponFeature =
+  | { readonly kind: 'tongue' }
+  | { readonly kind: 'groove'; readonly clearance: number }
+  | { readonly kind: 'pocket'; readonly levels: SnapClipLevels };
+
+/**
+ * Build one labeled coupon at tray position (cx, cy): a rounded slab carrying
+ * the connector feature on its seam-facing wall, embossed with `label`. Built
+ * in the pre-lift frame (top at Z=0, bottom at -totalHeight); the caller lifts
+ * the whole tray onto the bed.
+ */
+function buildCoupon(
+  cx: number,
+  cy: number,
+  totalHeight: number,
+  label: string,
+  wallY: number,
+  d: -1 | 1,
+  feature: CouponFeature
+): Shape3D {
+  return withScope((scope: DisposalScope): Shape3D => {
+    let solid: Shape3D = scope.register(
+      sketch(roundedRect(cx, cy, COUPON_X, COUPON_Y, COUPON_FILLET), 'XY', 0).extrude(-totalHeight)
+    );
+
+    switch (feature.kind) {
+      case 'tongue': {
+        const tongue = scope.register(
+          makeTongue(
+            ptY,
+            wallY,
+            cx,
+            d,
+            TONGUE_PROTRUSION,
+            TONGUE_BASE_HALF,
+            TONGUE_TIP_HALF,
+            totalHeight
+          )
+        );
+        solid = scope.register(unwrap(fuse(solid as ValidSolid, tongue as ValidSolid)));
+        break;
+      }
+      case 'groove': {
+        const groove = scope.register(
+          makeGroove(
+            ptY,
+            wallY,
+            cx,
+            d,
+            TONGUE_PROTRUSION,
+            TONGUE_BASE_HALF,
+            TONGUE_TIP_HALF,
+            feature.clearance,
+            COPLANAR_MARGIN,
+            totalHeight
+          )
+        );
+        solid = scope.register(unwrap(cut(solid as ValidSolid, groove as ValidSolid)));
+        break;
+      }
+      case 'pocket': {
+        const cutters = makeSnapPocket(ptY, wallY, cx, d, feature.levels).map((c) =>
+          scope.register(c)
+        );
+        solid = scope.register(unwrap(cutAll(solid as ValidSolid, cutters as ValidSolid[])));
+        break;
+      }
+    }
+
+    // Emboss the style+offset on the top face (raised letters). Degrades to an
+    // unlabeled coupon if the font isn't loaded or auto-fit can't satisfy the
+    // floor — a single label must never tank the whole tray.
+    const text = buildTextSolid(scope, {
+      text: label,
+      fontFamily: 'jetbrains-mono',
+      mode: 'emboss',
+      availW: COUPON_X,
+      availD: COUPON_Y,
+      centerX: cx,
+      centerY: cy,
+      topZ: 0,
+      depth: LABEL_DEPTH,
+      hostThickness: totalHeight,
+      margin: LABEL_MARGIN,
+      minFontSize: LABEL_MIN_FONT,
+      maxFontSize: LABEL_MAX_FONT,
+    });
+    if (text) {
+      try {
+        solid = scope.register(unwrap(fuse(solid as ValidSolid, text.solid as ValidSolid)));
+      } catch {
+        // keep the unlabeled coupon
+      }
+    }
+
+    return unwrap(clone(solid));
+  });
+}
+
+/**
+ * Build all fit-sample pieces as separate, bed-resting solids. Caller owns the
+ * returned shapes (frees them after compounding).
+ */
+export function buildConnectorSampleTray(params: BaseplateParams): Shape3D[] {
+  const floorDepth = params.magnetHoles ? MAGNET_FLOOR + params.magnetDepth : 0;
+  const totalHeight = SOCKET_HEIGHT + floorDepth;
+  const gridUnitMm = params.gridUnitMm;
+
+  const nRows = SAMPLE_STYLES.length;
+  const nCols = SAMPLE_OFFSETS.length;
+  // Center the grid on the origin (columns 0..nCols include the loose column).
+  const originX = -(nCols * COL_PITCH) / 2;
+  const originY = ((nRows - 1) * ROW_PITCH) / 2;
+
+  const pieces: Shape3D[] = [];
+
+  SAMPLE_STYLES.forEach((style, r) => {
+    const cellY = originY - r * ROW_PITCH;
+    const frontWallY = cellY - SEAM_GAP / 2; // +Y face of the front coupon
+    const backWallY = cellY + SEAM_GAP / 2; // -Y face of the back coupon
+    const frontCenterY = cellY - SEAM_GAP / 2 - COUPON_Y / 2;
+    const backCenterY = cellY + SEAM_GAP / 2 + COUPON_Y / 2;
+
+    SAMPLE_OFFSETS.forEach((offset, c) => {
+      const cx = originX + c * COL_PITCH;
+      const label = `${style.abbr} ${formatOffset(offset)}`;
+
+      let frontFeature: CouponFeature;
+      let backFeature: CouponFeature;
+      if (style.key === 'snapClip') {
+        const levels = snapClipLevels(totalHeight, offset);
+        frontFeature = { kind: 'pocket', levels };
+        backFeature = { kind: 'pocket', levels };
+      } else if (style.key === 'dovetailKey') {
+        const clearance = effectiveClearance(DOVETAIL_KEY_CLEARANCE, offset);
+        frontFeature = { kind: 'groove', clearance };
+        backFeature = { kind: 'groove', clearance };
+      } else {
+        // Integral dovetail: nominal tongue, offset rides on the female groove.
+        frontFeature = { kind: 'tongue' };
+        backFeature = { kind: 'groove', clearance: effectiveClearance(TONGUE_CLEARANCE, offset) };
+      }
+
+      pieces.push(buildCoupon(cx, frontCenterY, totalHeight, label, frontWallY, 1, frontFeature));
+      pieces.push(buildCoupon(cx, backCenterY, totalHeight, label, backWallY, -1, backFeature));
+    });
+
+    // One shared loose part per key/clip row, placed in the column beyond the
+    // ladder. Built at nominal size (the offset is in the pocket), shifted down
+    // into the pre-lift frame so it rests on the bed after the global lift.
+    if (style.loose) {
+      const looseX = originX + nCols * COL_PITCH;
+      const part =
+        style.loose === 'clip'
+          ? buildSnapClipForPrint(totalHeight, gridUnitMm)
+          : buildDovetailKey(totalHeight);
+      const placed = translate(part, [looseX, cellY, -totalHeight]);
+      part.delete();
+      pieces.push(placed);
+    }
+  });
+
+  return pieces;
+}
+
+/** Export the connector fit-sample tray as a single STL or STEP file. */
+export async function exportConnectorSample(
+  params: BaseplateParams,
+  format: ExportFormat,
+  tolerance?: number,
+  angularTolerance?: number
+): Promise<{ data: ArrayBuffer; fileName: string }> {
+  const floorDepth = params.magnetHoles ? MAGNET_FLOOR + params.magnetDepth : 0;
+  const totalHeight = SOCKET_HEIGHT + floorDepth;
+
+  const pieces = buildConnectorSampleTray(params);
+  const tray = compound(pieces);
+  for (const p of pieces) p.delete();
+  // Lift the whole tray so every piece rests on the bed (Z≥0).
+  const lifted = translate(tray, [0, 0, totalHeight]);
+  tray.delete();
+
+  try {
+    const name = 'connector_fit_sample';
+    if (format === 'step') {
+      const blob = unwrap(exportSTEP(lifted));
+      const data = await blob.arrayBuffer();
+      return { data, fileName: `${name}.step` };
+    }
+    const tol = tolerance ?? 0.01;
+    const angTol = angularTolerance ?? 5;
+    const meshResult = mesh(lifted, { tolerance: tol, angularTolerance: angTol });
+    const data = buildBaseplateSTL(meshResult, name);
+    return { data, fileName: `${name}.stl` };
+  } finally {
+    lifted.delete();
+  }
+}

--- a/src/features/generation/worker/generators/connectorSample.ts
+++ b/src/features/generation/worker/generators/connectorSample.ts
@@ -62,15 +62,15 @@ import {
 } from './baseplateConnectors';
 import { buildTextSolid } from './textBuilder';
 import { buildBaseplateSTL } from './baseplateSTL';
+import { sanitizeParams } from './baseplateSlab';
 
 /** Fit-offset ladder swept across the columns, centered on nominal (0). */
 const SAMPLE_OFFSETS: readonly number[] = [-0.1, -0.05, 0, 0.05, 0.1];
 
 interface SampleStyle {
   readonly key: 'dovetail' | 'dovetailKey' | 'snapClip';
-  /** Short label prefix embossed on each coupon (e.g. "DT"). */
   readonly abbr: string;
-  /** Whether the row ships a shared loose part (key/clip). */
+  /** Shared loose part this row ships (inserted into each pair to feel the fit), if any. */
   readonly loose: 'key' | 'clip' | null;
 }
 
@@ -82,18 +82,18 @@ const SAMPLE_STYLES: readonly SampleStyle[] = [
 
 // Tray layout (mm). A coupon's long axis is X so the embossed label reads
 // left-to-right; the seam runs along X, so a pair stacks front/back along Y.
-const COUPON_X = 15; // coupon length (label axis)
-const COUPON_Y = 9; // coupon depth (across the seam)
-const COUPON_FILLET = 1.4; // rounded top-view corners — finished look, broken edges
-const SEAM_GAP = 5; // gap between the two coupons of a pair (printed separated)
-const COL_GAP = 7; // gap between offset columns
-const ROW_GAP = 10; // gap between style rows
-const LABEL_DEPTH = 0.6; // emboss height above the top face
+const COUPON_X = 15;
+const COUPON_Y = 9;
+const COUPON_FILLET = 1.4;
+const SEAM_GAP = 5;
+const COL_GAP = 7;
+const ROW_GAP = 10;
+const LABEL_DEPTH = 0.6;
 const LABEL_MARGIN = 1.4;
 const LABEL_MIN_FONT = 1.0;
 const LABEL_MAX_FONT = 2.4;
 
-const CELL_Y = 2 * COUPON_Y + SEAM_GAP; // total Y footprint of one mated pair
+const CELL_Y = 2 * COUPON_Y + SEAM_GAP;
 const COL_PITCH = COUPON_X + COL_GAP;
 const ROW_PITCH = CELL_Y + ROW_GAP;
 
@@ -108,7 +108,6 @@ function formatOffset(v: number): string {
   return v > 0 ? `+${s}` : s;
 }
 
-/** Rounded-rectangle top-view profile centered at (cx, cy). */
 function roundedRect(cx: number, cy: number, w: number, h: number, r: number): Drawing {
   const x0 = cx - w / 2;
   const x1 = cx + w / 2;
@@ -225,13 +224,21 @@ function buildCoupon(
   });
 }
 
+function couponHeight(params: BaseplateParams): number {
+  const floorDepth = params.magnetHoles ? MAGNET_FLOOR + params.magnetDepth : 0;
+  return SOCKET_HEIGHT + floorDepth;
+}
+
 /**
  * Build all fit-sample pieces as separate, bed-resting solids. Caller owns the
  * returned shapes (frees them after compounding).
  */
-export function buildConnectorSampleTray(params: BaseplateParams): Shape3D[] {
-  const floorDepth = params.magnetHoles ? MAGNET_FLOOR + params.magnetDepth : 0;
-  const totalHeight = SOCKET_HEIGHT + floorDepth;
+export function buildConnectorSampleTray(rawParams: BaseplateParams): Shape3D[] {
+  // Clamp grid unit / magnet depth (and reject non-finite values) the same way
+  // every sibling exporter does — a bad magnetDepth would otherwise make
+  // totalHeight NaN and corrupt every coupon, pocket, and clip.
+  const params = sanitizeParams(rawParams);
+  const totalHeight = couponHeight(params);
   const gridUnitMm = params.gridUnitMm;
 
   const nRows = SAMPLE_STYLES.length;
@@ -293,20 +300,28 @@ export function buildConnectorSampleTray(params: BaseplateParams): Shape3D[] {
 
 /** Export the connector fit-sample tray as a single STL or STEP file. */
 export async function exportConnectorSample(
-  params: BaseplateParams,
+  rawParams: BaseplateParams,
   format: ExportFormat,
   tolerance?: number,
   angularTolerance?: number
 ): Promise<{ data: ArrayBuffer; fileName: string }> {
-  const floorDepth = params.magnetHoles ? MAGNET_FLOOR + params.magnetDepth : 0;
-  const totalHeight = SOCKET_HEIGHT + floorDepth;
+  const params = sanitizeParams(rawParams);
+  const totalHeight = couponHeight(params);
 
+  // Free the individual pieces / tray even if compound or the bed lift throws,
+  // so a boolean failure can't strand 32 solids.
   const pieces = buildConnectorSampleTray(params);
-  const tray = compound(pieces);
+  let lifted: Shape3D;
+  try {
+    const tray = compound(pieces);
+    // Lift the whole tray so every piece rests on the bed (Z≥0).
+    lifted = translate(tray, [0, 0, totalHeight]);
+    tray.delete();
+  } catch (e) {
+    for (const p of pieces) p.delete();
+    throw e;
+  }
   for (const p of pieces) p.delete();
-  // Lift the whole tray so every piece rests on the bed (Z≥0).
-  const lifted = translate(tray, [0, 0, totalHeight]);
-  tray.delete();
 
   try {
     const name = 'connector_fit_sample';

--- a/src/features/generation/worker/handlers/exportHandler.ts
+++ b/src/features/generation/worker/handlers/exportHandler.ts
@@ -7,6 +7,7 @@ import type {
   ExportMessage,
   ExportBaseplateMessage,
   ExportConnectorKeyMessage,
+  ExportConnectorSampleMessage,
   ExportDividersMessage,
   ExportCombinedMessage,
   CombinedExportPiece,
@@ -14,6 +15,7 @@ import type {
 import { exportBin } from '../generators/binGenerator';
 import { getLastSolid } from '../generators/shapeCache';
 import { exportBaseplate, exportConnectorKey } from '../generators/baseplateGenerator';
+import { exportConnectorSample } from '../generators/connectorSample';
 import { exportDividers, exportDividerPiecesSeparately } from '../generators/dividerExport';
 import { buildUniqueDividerPieces } from '../generators/dividerBuilder';
 import { exportLid } from '../generators/lidOrchestrator';
@@ -81,6 +83,28 @@ export async function handleExportConnectorKey(message: ExportConnectorKeyMessag
       return { data: result.data, format: payload.format, fileName: result.fileName };
     },
     'Connector key export failed',
+    (p) => [p.data],
+    classifyExportError
+  );
+}
+
+export async function handleExportConnectorSample(
+  message: ExportConnectorSampleMessage
+): Promise<void> {
+  const payload = message.payload;
+  await runExport(
+    payload.requestId,
+    'BASEPLATE_EXPORT_RESULT',
+    async () => {
+      const result = await exportConnectorSample(
+        payload.params,
+        payload.format,
+        payload.tolerance,
+        payload.angularTolerance
+      );
+      return { data: result.data, format: payload.format, fileName: result.fileName };
+    },
+    'Connector sample export failed',
     (p) => [p.data],
     classifyExportError
   );

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2257,5 +2257,14 @@
   "export.support.downloading": "{fileName} wird heruntergeladen",
   "export.support.pitch": "Dieses Tool ist kostenlos und werbefrei.",
   "export.support.starGithub": "Oder gib ihm einen Stern auf GitHub",
-  "export.complete": "Export abgeschlossen"
+  "export.complete": "Export abgeschlossen",
+  "baseplate.connectorSample.button": "Passungsmuster drucken",
+  "baseplate.connectorSample.dialogTitle": "Verbinder-Passungsmuster",
+  "baseplate.connectorSample.dialogDescription": "Ein kleiner Kalibrierungsdruck aller drei Verbinderstile über eine Reihe von Passungsabständen. Drucken Sie ihn, finden Sie die Passung, die einrastet, und stellen Sie dann „Verbinderpassung“ auf diesen Wert ein, bevor Sie die vollständige Grundplatte drucken.",
+  "baseplate.connectorSample.tipsTitle": "Drucktipps",
+  "baseplate.connectorSample.tip1": "Flach und ohne Stützen drucken.",
+  "baseplate.connectorSample.tip2": "Verwenden Sie denselben Drucker, dasselbe Filament und dieselbe Düse wie für die Grundplatte.",
+  "baseplate.connectorSample.tip3": "Jedes Musterstück ist mit seinem Stil (DT / DK / SC) und Passungsabstand beschriftet.",
+  "baseplate.connectorSample.tip4": "Die richtige Passung gefunden? Stellen Sie „Verbinderpassung“ auf diesen Abstand ein.",
+  "baseplate.connectorSample.exportComplete": "Passungsmuster exportiert"
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2258,5 +2258,14 @@
   "binDesigner.labelTabs.insetAria": "Tab inset",
   "binDesigner.handles.widthAria": "Handle width",
   "binDesigner.handles.heightAria": "Handle height",
-  "binDesigner.handles.countAria": "Handle count"
+  "binDesigner.handles.countAria": "Handle count",
+  "baseplate.connectorSample.button": "Print fit sample",
+  "baseplate.connectorSample.dialogTitle": "Connector fit sample",
+  "baseplate.connectorSample.dialogDescription": "A small calibration print of all three connector styles across a range of fit offsets. Print it, find the fit that clicks, then set Connector fit to that value before printing the full baseplate.",
+  "baseplate.connectorSample.tipsTitle": "Print tips",
+  "baseplate.connectorSample.tip1": "Print flat with no supports.",
+  "baseplate.connectorSample.tip2": "Use the same printer, filament, and nozzle you'll print the baseplate with.",
+  "baseplate.connectorSample.tip3": "Each coupon is labeled with its style (DT / DK / SC) and fit offset.",
+  "baseplate.connectorSample.tip4": "Found the right fit? Set Connector fit to that offset.",
+  "baseplate.connectorSample.exportComplete": "Fit sample exported"
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2067,6 +2067,18 @@ const en: Record<string, string> = {
     'Adjusts the connector gap (mm) to tune fit for your printer and filament. Higher = looser, lower = tighter.',
   'baseplate.dovetails.invert': 'Invert dovetails',
   'baseplate.preferIdenticalPieces': 'Fewer unique parts (rotate to fit)',
+  'baseplate.connectorSample.button': 'Print fit sample',
+  'baseplate.connectorSample.dialogTitle': 'Connector fit sample',
+  'baseplate.connectorSample.dialogDescription':
+    'A small calibration print of all three connector styles across a range of fit offsets. Print it, find the fit that clicks, then set Connector fit to that value before printing the full baseplate.',
+  'baseplate.connectorSample.tipsTitle': 'Print tips',
+  'baseplate.connectorSample.tip1': 'Print flat with no supports.',
+  'baseplate.connectorSample.tip2':
+    "Use the same printer, filament, and nozzle you'll print the baseplate with.",
+  'baseplate.connectorSample.tip3':
+    'Each coupon is labeled with its style (DT / DK / SC) and fit offset.',
+  'baseplate.connectorSample.tip4': 'Found the right fit? Set Connector fit to that offset.',
+  'baseplate.connectorSample.exportComplete': 'Fit sample exported',
   'baseplate.cornerRadius': 'Corner radius',
   'baseplate.cornerRadiusInfo': 'Outer corner radius for fitting in rounded enclosures',
   'baseplate.cornerRadiusTL': 'Top-left',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2257,5 +2257,14 @@
   "export.support.downloading": "{fileName} se está descargando",
   "export.support.pitch": "Esta herramienta es gratuita y sin anuncios.",
   "export.support.starGithub": "O dale una estrella en GitHub",
-  "export.complete": "Exportación completa"
+  "export.complete": "Exportación completa",
+  "baseplate.connectorSample.button": "Imprimir muestra de ajuste",
+  "baseplate.connectorSample.dialogTitle": "Muestra de ajuste del conector",
+  "baseplate.connectorSample.dialogDescription": "Una pequeña impresión de calibración de los tres estilos de conector a lo largo de una serie de ajustes. Imprímela, encuentra el ajuste que encaja y luego establece «Ajuste del conector» en ese valor antes de imprimir la placa base completa.",
+  "baseplate.connectorSample.tipsTitle": "Consejos de impresión",
+  "baseplate.connectorSample.tip1": "Imprime en plano y sin soportes.",
+  "baseplate.connectorSample.tip2": "Usa la misma impresora, filamento y boquilla con los que imprimirás la placa base.",
+  "baseplate.connectorSample.tip3": "Cada cupón está etiquetado con su estilo (DT / DK / SC) y su ajuste.",
+  "baseplate.connectorSample.tip4": "¿Encontraste el ajuste adecuado? Establece «Ajuste del conector» en ese valor.",
+  "baseplate.connectorSample.exportComplete": "Muestra de ajuste exportada"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2257,5 +2257,14 @@
   "export.support.downloading": "Téléchargement de {fileName}",
   "export.support.pitch": "Cet outil est gratuit et sans publicité.",
   "export.support.starGithub": "Ou mettez une étoile sur GitHub",
-  "export.complete": "Export terminé"
+  "export.complete": "Export terminé",
+  "baseplate.connectorSample.button": "Imprimer l'échantillon d'ajustement",
+  "baseplate.connectorSample.dialogTitle": "Échantillon d'ajustement du connecteur",
+  "baseplate.connectorSample.dialogDescription": "Une petite impression de calibrage des trois styles de connecteur sur une plage d'ajustements. Imprimez-la, trouvez l'ajustement qui s'enclenche, puis réglez « Ajustement du connecteur » sur cette valeur avant d'imprimer la plaque de base complète.",
+  "baseplate.connectorSample.tipsTitle": "Conseils d'impression",
+  "baseplate.connectorSample.tip1": "Imprimez à plat, sans supports.",
+  "baseplate.connectorSample.tip2": "Utilisez la même imprimante, le même filament et la même buse que pour la plaque de base.",
+  "baseplate.connectorSample.tip3": "Chaque échantillon est étiqueté avec son style (DT / DK / SC) et son ajustement.",
+  "baseplate.connectorSample.tip4": "Vous avez trouvé le bon ajustement ? Réglez « Ajustement du connecteur » sur cette valeur.",
+  "baseplate.connectorSample.exportComplete": "Échantillon d'ajustement exporté"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2257,5 +2257,14 @@
   "export.support.downloading": "{fileName} をダウンロードしています",
   "export.support.pitch": "このツールは無料・広告なしです。",
   "export.support.starGithub": "または GitHub でスターを付ける",
-  "export.complete": "エクスポート完了"
+  "export.complete": "エクスポート完了",
+  "baseplate.connectorSample.button": "フィットサンプルを印刷",
+  "baseplate.connectorSample.dialogTitle": "コネクタのフィットサンプル",
+  "baseplate.connectorSample.dialogDescription": "3種類すべてのコネクタスタイルを、複数のフィットオフセットにわたって試せる小さなキャリブレーション印刷です。印刷してぴったりはまるフィットを見つけ、ベースプレート全体を印刷する前に「コネクタフィット」をその値に設定してください。",
+  "baseplate.connectorSample.tipsTitle": "印刷のヒント",
+  "baseplate.connectorSample.tip1": "サポートなしで平らに印刷してください。",
+  "baseplate.connectorSample.tip2": "ベースプレートを印刷するのと同じプリンター・フィラメント・ノズルを使用してください。",
+  "baseplate.connectorSample.tip3": "各クーポンにはスタイル（DT / DK / SC）とフィットオフセットが表示されています。",
+  "baseplate.connectorSample.tip4": "ぴったりのフィットが見つかりましたか？「コネクタフィット」をそのオフセットに設定してください。",
+  "baseplate.connectorSample.exportComplete": "フィットサンプルを書き出しました"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -2257,5 +2257,14 @@
   "export.support.downloading": "{fileName} lastes ned",
   "export.support.pitch": "Dette verktøyet er gratis og reklamefritt.",
   "export.support.starGithub": "Eller gi det en stjerne på GitHub",
-  "export.complete": "Eksport fullført"
+  "export.complete": "Eksport fullført",
+  "baseplate.connectorSample.button": "Skriv ut passprøve",
+  "baseplate.connectorSample.dialogTitle": "Passprøve for kobling",
+  "baseplate.connectorSample.dialogDescription": "En liten kalibreringsutskrift av alle tre koblingsstilene over en rekke passforskyvninger. Skriv den ut, finn passformen som klikker, og still deretter «Koblingspassform» til den verdien før du skriver ut hele bunnplaten.",
+  "baseplate.connectorSample.tipsTitle": "Utskriftstips",
+  "baseplate.connectorSample.tip1": "Skriv ut flatt uten støtter.",
+  "baseplate.connectorSample.tip2": "Bruk samme skriver, filament og dyse som du skal skrive ut bunnplaten med.",
+  "baseplate.connectorSample.tip3": "Hver prøvebit er merket med stil (DT / DK / SC) og passforskyvning.",
+  "baseplate.connectorSample.tip4": "Fant du riktig passform? Still «Koblingspassform» til den forskyvningen.",
+  "baseplate.connectorSample.exportComplete": "Passprøve eksportert"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -2257,5 +2257,14 @@
   "export.support.downloading": "{fileName} wordt gedownload",
   "export.support.pitch": "Deze tool is gratis en advertentievrij.",
   "export.support.starGithub": "Of geef het een ster op GitHub",
-  "export.complete": "Export voltooid"
+  "export.complete": "Export voltooid",
+  "baseplate.connectorSample.button": "Pasvormmonster afdrukken",
+  "baseplate.connectorSample.dialogTitle": "Pasvormmonster connector",
+  "baseplate.connectorSample.dialogDescription": "Een kleine kalibratieprint van alle drie de connectorstijlen over een reeks pasvorm-offsets. Print hem, zoek de pasvorm die vastklikt en stel daarna «Connectorpasvorm» in op die waarde voordat je de volledige basisplaat print.",
+  "baseplate.connectorSample.tipsTitle": "Printtips",
+  "baseplate.connectorSample.tip1": "Plat printen, zonder supports.",
+  "baseplate.connectorSample.tip2": "Gebruik dezelfde printer, hetzelfde filament en dezelfde nozzle als waarmee je de basisplaat print.",
+  "baseplate.connectorSample.tip3": "Elk monster is gelabeld met zijn stijl (DT / DK / SC) en pasvorm-offset.",
+  "baseplate.connectorSample.tip4": "De juiste pasvorm gevonden? Stel «Connectorpasvorm» in op die offset.",
+  "baseplate.connectorSample.exportComplete": "Pasvormmonster geëxporteerd"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2257,5 +2257,14 @@
   "export.support.downloading": "{fileName} está sendo baixado",
   "export.support.pitch": "Esta ferramenta é gratuita e sem anúncios.",
   "export.support.starGithub": "Ou dê uma estrela no GitHub",
-  "export.complete": "Exportação concluída"
+  "export.complete": "Exportação concluída",
+  "baseplate.connectorSample.button": "Imprimir amostra de encaixe",
+  "baseplate.connectorSample.dialogTitle": "Amostra de encaixe do conector",
+  "baseplate.connectorSample.dialogDescription": "Uma pequena impressão de calibração dos três estilos de conector ao longo de uma faixa de ajustes de encaixe. Imprima-a, encontre o encaixe que se prende e depois defina «Encaixe do conector» com esse valor antes de imprimir a placa base completa.",
+  "baseplate.connectorSample.tipsTitle": "Dicas de impressão",
+  "baseplate.connectorSample.tip1": "Imprima na horizontal, sem suportes.",
+  "baseplate.connectorSample.tip2": "Use a mesma impressora, filamento e bico com que você imprimirá a placa base.",
+  "baseplate.connectorSample.tip3": "Cada amostra é rotulada com seu estilo (DT / DK / SC) e ajuste de encaixe.",
+  "baseplate.connectorSample.tip4": "Encontrou o encaixe certo? Defina «Encaixe do conector» com esse valor.",
+  "baseplate.connectorSample.exportComplete": "Amostra de encaixe exportada"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -2257,5 +2257,14 @@
   "export.support.downloading": "{fileName} laddas ner",
   "export.support.pitch": "Det här verktyget är gratis och reklamfritt.",
   "export.support.starGithub": "Eller ge det en stjärna på GitHub",
-  "export.complete": "Export klar"
+  "export.complete": "Export klar",
+  "baseplate.connectorSample.button": "Skriv ut passprov",
+  "baseplate.connectorSample.dialogTitle": "Passprov för koppling",
+  "baseplate.connectorSample.dialogDescription": "En liten kalibreringsutskrift av alla tre kopplingsstilar över ett antal passningsförskjutningar. Skriv ut den, hitta passningen som klickar och ställ sedan in «Kopplingspassning» på det värdet innan du skriver ut hela bottenplattan.",
+  "baseplate.connectorSample.tipsTitle": "Utskriftstips",
+  "baseplate.connectorSample.tip1": "Skriv ut platt utan stöd.",
+  "baseplate.connectorSample.tip2": "Använd samma skrivare, filament och munstycke som du skriver ut bottenplattan med.",
+  "baseplate.connectorSample.tip3": "Varje provbit är märkt med sin stil (DT / DK / SC) och passningsförskjutning.",
+  "baseplate.connectorSample.tip4": "Hittade du rätt passning? Ställ in «Kopplingspassning» på den förskjutningen.",
+  "baseplate.connectorSample.exportComplete": "Passprov exporterat"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -2257,5 +2257,14 @@
   "export.support.downloading": "{fileName} завантажується",
   "export.support.pitch": "Цей інструмент безкоштовний і без реклами.",
   "export.support.starGithub": "Або поставте зірку на GitHub",
-  "export.complete": "Експорт завершено"
+  "export.complete": "Експорт завершено",
+  "baseplate.connectorSample.button": "Надрукувати зразок припасування",
+  "baseplate.connectorSample.dialogTitle": "Зразок припасування з’єднувача",
+  "baseplate.connectorSample.dialogDescription": "Невеликий калібрувальний друк усіх трьох стилів з’єднувачів у діапазоні зміщень припасування. Надрукуйте його, знайдіть припасування, яке клацає, а потім встановіть «Припасування з’єднувача» на це значення перед друком усієї опорної плити.",
+  "baseplate.connectorSample.tipsTitle": "Поради щодо друку",
+  "baseplate.connectorSample.tip1": "Друкуйте плоско, без підтримок.",
+  "baseplate.connectorSample.tip2": "Використовуйте той самий принтер, філамент і сопло, що й для опорної плити.",
+  "baseplate.connectorSample.tip3": "Кожен зразок позначено стилем (DT / DK / SC) і зміщенням припасування.",
+  "baseplate.connectorSample.tip4": "Знайшли потрібне припасування? Встановіть «Припасування з’єднувача» на це зміщення.",
+  "baseplate.connectorSample.exportComplete": "Зразок припасування експортовано"
 }

--- a/src/shared/generation/exportUtils.ts
+++ b/src/shared/generation/exportUtils.ts
@@ -13,6 +13,13 @@ export const FORMAT_MIME_TYPES: Record<ExportFileFormat, string> = {
   '3mf': 'application/vnd.ms-package.3dmanufacturing-3dmodel+xml',
 };
 
+/** File extensions for each export format. */
+export const FORMAT_EXTENSIONS: Record<ExportFileFormat, string> = {
+  stl: '.stl',
+  step: '.step',
+  '3mf': '.3mf',
+};
+
 /** Trigger a browser download from a Blob. */
 export function triggerDownload(blob: Blob, fileName: string): void {
   const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## What

Adds a **Print fit sample** button to the baseplate connector section. It exports a single calibration tray — a "fit card" — so makers can dial in their connector tolerance *before* committing to a full split baseplate print.

The tray is a grid:

| | −0.10 | −0.05 | 0.00 | +0.05 | +0.10 |
|---|---|---|---|---|---|
| **Dovetail** | pair | pair | pair | pair | pair |
| **Dovetail key** | pair | pair | pair | pair | pair | + 1 key |
| **Snap clip** | pair | pair | pair | pair | pair | + 1 clip |

- **Rows** = the three connector styles; **columns** = a fit-offset ladder centered on nominal.
- Each cell is a **mated pair** of small abstract coupons carrying the *real* connector profile at the plate's height. Both halves are **embossed** with their style (`DT`/`DK`/`SC`) and offset so detached pieces stay identifiable.
- The dovetail **key** and snap **clip** are nominal parts (the offset rides on the female pocket), so those rows ship **one shared loose part** the maker inserts into each offset's pair — rather than five redundant copies.

Workflow: print it → find the fit that clicks → set **Connector fit** to that offset → print the real baseplate.

## Why

Connector fit is printer/filament-dependent, which is exactly what the existing `connectorFitOffset` control is for — but today there's no cheap way to calibrate it short of reprinting a whole multi-piece baseplate. This makes calibration a ~10g test print.

## How

- New `connectorSample.ts` worker generator builds the tray. Coupon profiles **reuse** the existing `makeTongue` / `makeGroove` / `makeSnapPocket` builders (now exported) so the printed fit is faithful — the tolerance lives in the female groove/pocket, not the surrounding socket, so a plain block coupon fits identically to a real 42 mm cell.
- New `EXPORT_CONNECTOR_SAMPLE` worker path mirrors the existing connector-key export; reuses the `BASEPLATE_EXPORT_RESULT` response.
- UI: button in the connector section (shown when connectors are enabled) → the shared `ExportDialog` (STL / STEP / 3MF) with inline print tips.
- Labels via the existing `buildTextSolid` emboss path; pieces compound into one ready-to-slice, bed-resting file.

## Tests

- `connectorSample.scenario.test.ts` (real OCCT kernel): 32 valid positive-volume pieces, watertight + bed-resting STL (0 boundary / non-manifold edges), and magnet-hole (taller) coupons stay valid.
- Sibling tests for the hook and the dialog button.
- i18n keys added across all 10 locales; `check:i18n` + `check:i18n:values` pass.

## Notes

- Connector controls (and this button) only appear when the baseplate is split, matching the existing connector UI gating.