### PR TITLE
fix(print-export): correct filament & print-time estimates (were too high)

### DIFF
--- a/src/features/bin-designer/utils/printEstimates.test.ts
+++ b/src/features/bin-designer/utils/printEstimates.test.ts
@@ -6,7 +6,7 @@ import {
   formatFilament,
 } from '@/features/bin-designer/utils/printEstimates';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
-import { DEFAULT_PRINT_SETTINGS } from '@/shared/printSettings';
+import { DEFAULT_PRINT_SETTINGS, estimateStandardBinVolume } from '@/shared/printSettings';
 import type { BinParams } from '@/features/bin-designer/types';
 
 describe('printEstimates', () => {
@@ -101,12 +101,23 @@ describe('printEstimates', () => {
       expect(large.printTimeMinutes).toBeGreaterThan(small.printTimeMinutes);
     });
 
-    it('volume is reasonable for a 2x2x3 standard bin', () => {
+    it('matches the OCCT-measured solid volume for a 2×2×3 standard bin (±15%)', () => {
+      // Ground truth from the real generator: 2×2×3u solid = 17094 mm³.
+      // The old hollow-box model treated the bottom 7mm as a solid slab and
+      // reported ~67000 mm³ (≈4× too high). The consolidated model reuses the
+      // OCCT-calibrated shared base geometry.
       const est = estimatePrint(DEFAULT_BIN_PARAMS);
-      // A 2x2x3 bin with base socket and lip: should be more material than before
-      // Shell + socket + lip volume between 10,000 and 150,000 mm³
-      expect(est.volumeMm3).toBeGreaterThan(10000);
-      expect(est.volumeMm3).toBeLessThan(150000);
+      expect(est.volumeMm3).toBeGreaterThan(17094 * 0.85);
+      expect(est.volumeMm3).toBeLessThan(17094 * 1.15);
+    });
+
+    it('a plain standard bin matches the shared print-export estimator', () => {
+      // The designer and print-export must agree on the base geometry of an
+      // unfeatured bin (consolidation regression).
+      const designer = estimatePrint(DEFAULT_BIN_PARAMS).volumeMm3;
+      const shared = estimateStandardBinVolume(2, 2, 3);
+      expect(designer).toBeGreaterThan(shared * 0.9);
+      expect(designer).toBeLessThan(shared * 1.1);
     });
 
     it('returns rounded values', () => {
@@ -224,8 +235,10 @@ describe('printEstimates', () => {
         layerHeightMm: 0.1,
         infillPercent: 100,
       });
-      // 0.1mm layers (2×) × 100% infill (1.425×) ≈ 2.85×
-      expect(extreme.printTimeMinutes).toBeGreaterThan(baseline.printTimeMinutes * 2);
+      // The extrusion portion scales by 0.1mm layers (2×) × 100% infill
+      // (1 + 0.003×85 = 1.255×) ≈ 2.5×, but the fixed per-plate overhead is not
+      // scaled, so the total-time ratio for a small bin lands around 1.9×.
+      expect(extreme.printTimeMinutes).toBeGreaterThan(baseline.printTimeMinutes * 1.8);
     });
 
     // ─── Honeycomb wall reduction ─────────────────────────────────────

--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -25,6 +25,7 @@ import {
   MINUTES_PER_METER,
   DEFAULT_PRINT_SETTINGS,
   scalePrintTime,
+  standardBinSolidComponents,
   type PrintSettings,
 } from '@/shared/printSettings';
 import {
@@ -95,14 +96,17 @@ export function formatFilament(meters: number): string {
 /**
  * Computes total material volume analytically from bin parameters.
  *
- * Components:
- * 1. Outer shell (walls + bottom)
- * 2. Base socket (per-cell baseplate interface)
- * 3. Stacking lip (top perimeter profile)
- * 4. Divider walls
- * 5. Corner gussets (solid style)
- * 6. Label tabs (if enabled)
- * 7. Scoops (if enabled, negative — removes material)
+ * The standard bin shell (perimeter walls + floor + base socket feet +
+ * stacking lip) reuses the shared, OCCT-calibrated estimator
+ * (`standardBinSolidComponents`) so the designer and print-export agree on the
+ * base geometry. Feature deltas are layered on top:
+ *   + Divider walls
+ *   + Label tabs
+ *   − Scoops (removes material)
+ *   − Honeycomb wall reduction
+ *
+ * (The previous local hollow-box model treated the bottom 7mm as a solid slab,
+ * over-reporting standard bins by ~3–6×.)
  */
 function computeBinVolume(params: BinParams): number {
   const wallThickness = STYLE_WALL_THICKNESS[params.style] ?? GRIDFINITY.WALL_THICKNESS;
@@ -115,18 +119,16 @@ function computeBinVolume(params: BinParams): number {
   // Base height (7mm dead space: profile + bridge + floor, no cavity here)
   const bottomH = GRIDFINITY.BASE_HEIGHT;
 
-  let volume = 0;
-
-  // Shell volume (outer walls + bottom)
-  volume += computeHollowBoxVolume(outerW, outerD, totalH, wallThickness, bottomH);
-
-  // Base socket (per grid cell, tapered profile that slides onto baseplate)
-  volume += computeBaseSocketVolume(params.width, params.depth, params.gridUnitMm);
-
-  // Stacking lip (sits on top of bin body)
-  if (params.base.stackingLip) {
-    volume += computeStackingLipVolume(outerW, outerD);
-  }
+  // Standard bin shell: walls + floor + base feet (+ lip when enabled),
+  // from the shared OCCT-calibrated model.
+  const shell = standardBinSolidComponents(
+    params.width,
+    params.depth,
+    params.height,
+    params.gridUnitMm,
+    params.heightUnitMm
+  );
+  let volume = shell.walls + shell.base + (params.base.stackingLip ? shell.lip : 0);
 
   // Divider volumes (standard style only — slotted/solid don't use interior dividers)
   if (params.style === 'standard') {
@@ -151,65 +153,6 @@ function computeBinVolume(params: BinParams): number {
 
   // Volume cannot be negative (scoops on tiny bins)
   return Math.max(0, volume);
-}
-/**
- * Volume of a hollow box (outer - inner cavity).
- */
-function computeHollowBoxVolume(
-  w: number,
-  d: number,
-  h: number,
-  wall: number,
-  bottomH: number
-): number {
-  const outerVol = w * d * h;
-  const innerW = w - 2 * wall;
-  const innerD = d - 2 * wall;
-  const innerH = h - bottomH;
-
-  if (innerW <= 0 || innerD <= 0 || innerH <= 0) {
-    return outerVol; // Solid block (walls too thick)
-  }
-
-  return outerVol - innerW * innerD * innerH;
-}
-
-/**
- * Volume of base socket structure (per-cell interface to baseplate).
- *
- * Each full grid cell has a tapered socket (~5mm deep). The socket is a
- * thin-walled shell approximately 3.5mm thick around the cell perimeter.
- * Half-cells share proportional socket volume.
- */
-function computeBaseSocketVolume(
-  widthUnits: number,
-  depthUnits: number,
-  gridUnitMm: number
-): number {
-  // Each 1×1 cell: gridUnitMm×gridUnitMm footprint, socket shell ~3.5mm thick, 5mm deep.
-  // Clamp innerSide to 0 so a tiny gridUnitMm (< 2·shellThickness = 7mm) doesn't
-  // produce a negative socket volume that masks undercounts elsewhere.
-  const shellThickness = 3.5;
-  const outerArea = gridUnitMm * gridUnitMm;
-  const innerSide = Math.max(0, gridUnitMm - 2 * shellThickness);
-  const innerArea = innerSide * innerSide;
-  const shellArea = outerArea - innerArea;
-  const volumePerFullCell = shellArea * GRIDFINITY.SOCKET_HEIGHT;
-
-  // Scale by actual grid area (handles fractional cells like 1.5×2)
-  return volumePerFullCell * widthUnits * depthUnits;
-}
-
-/**
- * Volume of stacking lip (4.4mm tall perimeter profile on top of bin).
- *
- * The lip is a thin-walled band around the bin perimeter. We approximate
- * it as a rectangular ring with average width ~2mm.
- */
-function computeStackingLipVolume(outerW: number, outerD: number): number {
-  const lipThickness = 2; // mm average wall thickness of lip profile
-  const perimeter = 2 * (outerW + outerD);
-  return perimeter * lipThickness * GRIDFINITY.LIP_HEIGHT;
 }
 /**
  * Volume of all divider walls inside the cavity.

--- a/src/features/print-export/hooks/usePrintList.ts
+++ b/src/features/print-export/hooks/usePrintList.ts
@@ -17,6 +17,7 @@ import {
   calcFilamentCost,
   calcSpoolPercentage,
   calcPrintTimeHours,
+  estimatePrintJobs,
   DEFAULT_METERS_PER_KG,
 } from '@/features/print-export/utils/printEstimates';
 import type {
@@ -131,17 +132,30 @@ export function usePrintList(): UsePrintListReturn {
     const totalFilament = Math.round(rows.reduce((sum, r) => sum + r.filament, 0) * 10) / 10;
     const hasAnySplits = rows.some((r) => r.needsSplit);
 
+    // Overhead is per-plate, not per distinct bin type. Estimate plate count
+    // from total bin footprint vs. how many grid cells fit on the bed.
+    const totalFootprintUnits = rows.reduce((sum, r) => sum + r.area * r.binCount, 0);
+    const bedCapacityUnits = maxGridUnits.width * maxGridUnits.depth;
+    const numPrintJobs = estimatePrintJobs(totalFootprintUnits, bedCapacityUnits);
+
     return {
       totalBins,
       totalPieces,
       totalFilament,
       totalCost: calcFilamentCost(totalFilament, config.filamentCostPerKg, config.metersPerKg),
-      totalPrintTimeHours: calcPrintTimeHours(totalFilament, rows.length, printSettings),
+      totalPrintTimeHours: calcPrintTimeHours(totalFilament, numPrintJobs, printSettings),
       spoolEstimate: Math.ceil((totalFilament / config.metersPerKg) * 10) / 10,
       spoolPercentage: calcSpoolPercentage(totalFilament, config.metersPerKg),
       hasAnySplits,
     };
-  }, [rows, config.filamentCostPerKg, config.metersPerKg, printSettings]);
+  }, [
+    rows,
+    config.filamentCostPerKg,
+    config.metersPerKg,
+    printSettings,
+    maxGridUnits.width,
+    maxGridUnits.depth,
+  ]);
 
   const setSort = useCallback((key: PrintListSortKey) => {
     setFilters((f) => ({

--- a/src/features/print-export/utils/printEstimates.test.ts
+++ b/src/features/print-export/utils/printEstimates.test.ts
@@ -13,7 +13,11 @@ import { DEFAULT_PRINT_SETTINGS } from '@/shared/printSettings';
 
 describe('printEstimates', () => {
   describe('estimatePrintJobs (plate count)', () => {
-    it('returns at least 1 job even for a tiny layout', () => {
+    it('returns 0 jobs for an empty layout (no overhead time)', () => {
+      expect(estimatePrintJobs(0, 36)).toBe(0);
+    });
+
+    it('returns at least 1 job for any non-empty layout', () => {
       expect(estimatePrintJobs(1, 36)).toBe(1);
     });
 
@@ -27,16 +31,15 @@ describe('printEstimates', () => {
       expect(estimatePrintJobs(100, 36)).toBe(4);
     });
 
-    it('does NOT scale with the number of distinct bin types (regression: rows.length)', () => {
-      // The same total footprint must yield the same plate count regardless of
-      // how many distinct sizes it is split across.
-      expect(estimatePrintJobs(72, 36)).toBe(estimatePrintJobs(72, 36));
-      // 72 cells / (36 × 0.85 = 30.6) = ceil(2.35) = 3 plates — independent of row count.
+    it('depends only on total footprint, not the number of distinct bin types', () => {
+      // Regression for the old `rows.length` overhead: plate count is a pure
+      // function of total footprint vs bed capacity.
+      // 72 cells / (36 × 0.85 = 30.6) = ceil(2.35) = 3 plates.
       expect(estimatePrintJobs(72, 36)).toBe(3);
     });
 
     it('handles a zero-capacity bed without dividing by zero', () => {
-      expect(estimatePrintJobs(10, 0)).toBeGreaterThanOrEqual(1);
+      expect(estimatePrintJobs(10, 0)).toBe(1);
     });
   });
   describe('calcFilamentCost', () => {

--- a/src/features/print-export/utils/printEstimates.test.ts
+++ b/src/features/print-export/utils/printEstimates.test.ts
@@ -3,6 +3,7 @@ import {
   calcFilamentCost,
   calcSpoolPercentage,
   calcPrintTimeHours,
+  estimatePrintJobs,
   formatPrintTime,
   formatCost,
   DEFAULT_METERS_PER_KG,
@@ -11,6 +12,33 @@ import {
 import { DEFAULT_PRINT_SETTINGS } from '@/shared/printSettings';
 
 describe('printEstimates', () => {
+  describe('estimatePrintJobs (plate count)', () => {
+    it('returns at least 1 job even for a tiny layout', () => {
+      expect(estimatePrintJobs(1, 36)).toBe(1);
+    });
+
+    it('returns 1 job when everything fits on one plate', () => {
+      // 20 grid cells of bins, a 36-cell bed → fits in one plate
+      expect(estimatePrintJobs(20, 36)).toBe(1);
+    });
+
+    it('returns multiple plates when bins exceed one bed', () => {
+      // 100 cells of bins on a 36-cell bed (×0.85 packing ≈ 30.6 usable) → ceil(100/30.6) = 4
+      expect(estimatePrintJobs(100, 36)).toBe(4);
+    });
+
+    it('does NOT scale with the number of distinct bin types (regression: rows.length)', () => {
+      // The same total footprint must yield the same plate count regardless of
+      // how many distinct sizes it is split across.
+      expect(estimatePrintJobs(72, 36)).toBe(estimatePrintJobs(72, 36));
+      // 72 cells / (36 × 0.85 = 30.6) = ceil(2.35) = 3 plates — independent of row count.
+      expect(estimatePrintJobs(72, 36)).toBe(3);
+    });
+
+    it('handles a zero-capacity bed without dividing by zero', () => {
+      expect(estimatePrintJobs(10, 0)).toBeGreaterThanOrEqual(1);
+    });
+  });
   describe('calcFilamentCost', () => {
     it('calculates cost correctly with default values', () => {
       // 330m @ $20/kg = 1kg = $20

--- a/src/features/print-export/utils/printEstimates.ts
+++ b/src/features/print-export/utils/printEstimates.ts
@@ -42,11 +42,43 @@ export function calcSpoolPercentage(
 }
 
 /**
+ * Fraction of the grid-aligned bed area realistically usable for bins once
+ * brim/skirt margins and imperfect packing are accounted for. Gridfinity bins
+ * tile on the grid so packing is efficient, but edges and clearances cost some
+ * capacity.
+ */
+const BED_PACKING_EFFICIENCY = 0.85;
+
+/**
+ * Estimate the number of print plates (jobs) needed for a layout.
+ *
+ * Overhead (bed heating, first layer, cooldown) is incurred once per *plate*,
+ * not once per distinct bin type. This replaces the previous `rows.length`
+ * heuristic, which charged overhead for every unique size/label/category group
+ * and massively inflated time for varied layouts.
+ *
+ * @param totalFootprintUnits - Total bin footprint in grid cells (Σ width×depth×count)
+ * @param bedCapacityUnits - Grid cells that fit on the print bed
+ * @returns Whole number of plates (always ≥ 1)
+ */
+export function estimatePrintJobs(totalFootprintUnits: number, bedCapacityUnits: number): number {
+  const usable = bedCapacityUnits * BED_PACKING_EFFICIENCY;
+  if (usable <= 0 || totalFootprintUnits <= 0) return 1;
+  return Math.max(1, Math.ceil(totalFootprintUnits / usable));
+}
+
+/**
  * Print time estimate based on filament length and number of print jobs.
  *
  * Computes base extrusion time from filament length, scales it via
  * `scalePrintTime` for nozzle/layer/infill settings, then adds
  * per-job overhead (bed heating, first layer, cooling).
+ *
+ * The extrusion rate (`MINUTES_PER_METER`) corresponds to an effective
+ * volumetric throughput of ~11 mm³/s for a 0.4mm-nozzle PLA print (including
+ * perimeters, travel, and acceleration losses) — see `MINUTES_PER_METER` in
+ * `@/shared/printSettings`. `numPrintJobs` should be the estimated plate count
+ * (see `estimatePrintJobs`), not the number of distinct bin types.
  *
  * Returns hours (1 decimal place).
  */

--- a/src/features/print-export/utils/printEstimates.ts
+++ b/src/features/print-export/utils/printEstimates.ts
@@ -62,8 +62,10 @@ const BED_PACKING_EFFICIENCY = 0.85;
  * @returns Whole number of plates (always ≥ 1)
  */
 export function estimatePrintJobs(totalFootprintUnits: number, bedCapacityUnits: number): number {
+  // Nothing to print → no plates (and no overhead time).
+  if (totalFootprintUnits <= 0) return 0;
   const usable = bedCapacityUnits * BED_PACKING_EFFICIENCY;
-  if (usable <= 0 || totalFootprintUnits <= 0) return 1;
+  if (usable <= 0) return 1; // unknown bed capacity → assume a single plate
   return Math.max(1, Math.ceil(totalFootprintUnits / usable));
 }
 

--- a/src/features/print-export/utils/split.test.ts
+++ b/src/features/print-export/utils/split.test.ts
@@ -654,7 +654,7 @@ describe('generatePrintList', () => {
     expect(rows[0].binCount).toBe(2);
   });
 
-  it('uses nozzle size from printSettings for filament estimates', () => {
+  it('filament estimate is independent of nozzle size (bin geometry is fixed)', () => {
     const bins: Bin[] = [
       {
         id: '1',
@@ -677,8 +677,9 @@ describe('generatePrintList', () => {
       ...DEFAULT_PRINT_SETTINGS,
       nozzleSizeMm: 0.6,
     });
-    // 0.6mm nozzle → thicker walls → more filament
-    expect(rows06[0].filament).toBeGreaterThan(rows04[0].filament);
+    // The bin's CAD wall is a fixed spec thickness; nozzle only affects how the
+    // slicer fills it and the print speed, never the part's filament volume.
+    expect(rows06[0].filament).toBe(rows04[0].filament);
   });
 });
 

--- a/src/shared/printSettings/index.test.ts
+++ b/src/shared/printSettings/index.test.ts
@@ -30,7 +30,8 @@ describe('shared printSettings', () => {
       expect(BASELINE_LAYER_HEIGHT).toBe(0.2);
       expect(BASELINE_INFILL).toBe(15);
       expect(OVERHEAD_MINUTES).toBe(16);
-      expect(MINUTES_PER_METER).toBe(3.6);
+      // Derived from ~11 mm³/s effective volumetric flow: 2405 / 11 / 60 ≈ 3.64
+      expect(MINUTES_PER_METER).toBeCloseTo(3.64, 2);
     });
   });
 

--- a/src/shared/printSettings/index.ts
+++ b/src/shared/printSettings/index.ts
@@ -1,15 +1,14 @@
 /**
  * Shared print estimation constants, types, and scaling helpers.
  *
- * Used by both the bin-designer (analytical volume) and print-export
- * (heuristic) estimation systems to ensure consistent defaults and
+ * Used by both the bin-designer and print-export estimators (via
+ * `standardBinSolidComponents`) so they agree on geometry, defaults, and
  * parametric time scaling.
  *
- * Calibrated via least-squares regression on real prints:
- * - Printer: 0.4mm nozzle, 0.2mm layer height, 15% infill
- * - Data: 1×1×3u (2.3m, 24min), 1×2×3u (3.7m, 30min),
- *         2×2×3u (5.6m, 35min), 3×3×3u (9.9m, 52min)
- * - Max error: ~1 min per bin across calibration set
+ * Volume constants are calibrated to ground-truth solid volumes measured from
+ * the real OCCT generator (see `standardBinVolume.ts`). Time constants are
+ * derived from an effective volumetric flow rate (`EFFECTIVE_FLOW_MM3_PER_S`);
+ * absolute print times are printer-speed dependent and approximate.
  */
 /** PLA density in g/cm³ */
 export const PLA_DENSITY = 1.24;
@@ -25,11 +24,27 @@ export const BASELINE_LAYER_HEIGHT = 0.2;
 /** Infill % the time model was calibrated against */
 export const BASELINE_INFILL = 15;
 
-/** Per-job overhead: bed heating, first layer, cooling (minutes) */
+/**
+ * Per-plate overhead: bed heating, slow first layer, and cooldown (minutes).
+ * Incurred once per print plate (see `estimatePrintJobs`), not per bin or per
+ * distinct bin type.
+ */
 export const OVERHEAD_MINUTES = 16;
 
-/** Extrusion rate: extrusion + travel + retractions (minutes per meter) */
-export const MINUTES_PER_METER = 3.6;
+/**
+ * Effective volumetric throughput for a 0.4mm-nozzle PLA print (mm³/s),
+ * averaged over perimeters, solid layers, travel, and acceleration. Typical
+ * quality prints land around 10–12 mm³/s effective; we use 11.
+ */
+export const EFFECTIVE_FLOW_MM3_PER_S = 11;
+
+/**
+ * Extrusion rate (minutes per meter of 1.75mm filament), derived from the
+ * effective volumetric flow rather than hand-tuned:
+ *   1m of filament = FILAMENT_AREA_MM2 × 1000 ≈ 2405 mm³
+ *   minutes/m = 2405 / EFFECTIVE_FLOW_MM3_PER_S / 60 ≈ 3.6
+ */
+export const MINUTES_PER_METER = (FILAMENT_AREA_MM2 * 1000) / EFFECTIVE_FLOW_MM3_PER_S / 60;
 /** User-configurable print settings stored in global preferences. */
 export interface PrintSettings {
   /** Filament cost in USD per kilogram */
@@ -90,5 +105,9 @@ export function scalePrintTime(baseMinutes: number, settings: PrintSettings): nu
   return baseMinutes * nozzleSpeedFactor * layerScale * infillScale;
 }
 export { GRIDFINITY_SPEC, wallThicknessForNozzle } from './gridfinityGeometry';
-export type { StandardBinEstimate } from './standardBinVolume';
-export { estimateStandardBinVolume, estimateStandardBinFilament } from './standardBinVolume';
+export type { StandardBinEstimate, StandardBinComponents } from './standardBinVolume';
+export {
+  estimateStandardBinVolume,
+  estimateStandardBinFilament,
+  standardBinSolidComponents,
+} from './standardBinVolume';

--- a/src/shared/printSettings/standardBinVolume.test.ts
+++ b/src/shared/printSettings/standardBinVolume.test.ts
@@ -5,51 +5,84 @@ import {
 } from '@/shared/printSettings/standardBinVolume';
 import { DEFAULT_PRINT_SETTINGS } from '@/shared/printSettings';
 
+/**
+ * Ground-truth solid volumes (mm³) measured from the REAL OCCT generator via
+ * `measureVolume(getLastSolid())` for standard bins (socket base + stacking
+ * lip, single compartment, default 42mm grid / 7mm height units).
+ *
+ * These replace the previous fabricated "PrusaSlicer calibration" numbers,
+ * which did not match the actual generated geometry (a 1×1×3u bin is 6241mm³
+ * solid ≈ 2.59m, not the 2.3m the old data claimed). The analytical model is
+ * expected to reproduce these within ±10%.
+ *
+ * Reproduce: generate each bin with `generateBin(buildParams({width,depth,height}))`,
+ * read `getLastSolid()`, then `unwrap(measureVolume(solid))`.
+ */
+const OCCT_GROUND_TRUTH: ReadonlyArray<readonly [number, number, number, number]> = [
+  [1, 1, 3, 6241],
+  [1, 2, 3, 10609],
+  [2, 2, 3, 17094],
+  [3, 3, 3, 32180],
+  [1, 1, 6, 10167],
+  [2, 2, 6, 25253],
+  [2, 2, 9, 33413],
+  [1, 1, 2, 4932],
+  [3, 2, 5, 30429],
+  [4, 4, 6, 68127],
+];
+
 describe('standardBinVolume', () => {
-  describe('estimateStandardBinVolume', () => {
-    it('returns positive volume for a 1×1×3u bin', () => {
-      const volume = estimateStandardBinVolume(1, 1, 3);
-      expect(volume).toBeGreaterThan(0);
-    });
+  describe('estimateStandardBinVolume — OCCT ground-truth accuracy (±10%)', () => {
+    for (const [w, d, h, truth] of OCCT_GROUND_TRUTH) {
+      it(`${w}×${d}×${h}u ≈ ${truth}mm³ (real generated solid)`, () => {
+        const volume = estimateStandardBinVolume(w, d, h);
+        expect(volume).toBeGreaterThan(truth * 0.9);
+        expect(volume).toBeLessThan(truth * 1.1);
+      });
+    }
+  });
 
+  describe('estimateStandardBinVolume — invariants', () => {
     it('returns positive volume for fractional bins (0.5×0.5×2u)', () => {
-      const volume = estimateStandardBinVolume(0.5, 0.5, 2);
-      expect(volume).toBeGreaterThan(0);
+      expect(estimateStandardBinVolume(0.5, 0.5, 2)).toBeGreaterThan(0);
     });
 
-    it('is monotonic: larger bins have more volume', () => {
-      const v1x1 = estimateStandardBinVolume(1, 1, 3);
-      const v2x2 = estimateStandardBinVolume(2, 2, 3);
-      const v3x3 = estimateStandardBinVolume(3, 3, 3);
-      expect(v2x2).toBeGreaterThan(v1x1);
-      expect(v3x3).toBeGreaterThan(v2x2);
+    it('is monotonic in footprint and height', () => {
+      expect(estimateStandardBinVolume(2, 2, 3)).toBeGreaterThan(
+        estimateStandardBinVolume(1, 1, 3)
+      );
+      expect(estimateStandardBinVolume(3, 3, 3)).toBeGreaterThan(
+        estimateStandardBinVolume(2, 2, 3)
+      );
+      expect(estimateStandardBinVolume(2, 2, 6)).toBeGreaterThan(
+        estimateStandardBinVolume(2, 2, 3)
+      );
     });
 
-    it('is monotonic: taller bins have more volume', () => {
-      const v3u = estimateStandardBinVolume(2, 2, 3);
-      const v6u = estimateStandardBinVolume(2, 2, 6);
-      expect(v6u).toBeGreaterThan(v3u);
+    it('never returns negative volume for tiny bins', () => {
+      expect(estimateStandardBinVolume(0.5, 0.5, 2)).toBeGreaterThanOrEqual(0);
     });
 
-    it('0.6mm nozzle produces more material than 0.4mm (thicker walls)', () => {
-      const v04 = estimateStandardBinVolume(2, 2, 3, 0.4);
-      const v06 = estimateStandardBinVolume(2, 2, 3, 0.6);
-      expect(v06).toBeGreaterThan(v04);
+    it('socket/base volume scales down with a smaller grid pitch', () => {
+      // Half-pitch (30mm) cells hold materially less base material than 42mm.
+      expect(estimateStandardBinVolume(2, 2, 3, 30)).toBeLessThan(
+        estimateStandardBinVolume(2, 2, 3, 42)
+      );
     });
 
-    it('never returns negative volume', () => {
-      // Tiny bin where walls might exceed interior
-      const volume = estimateStandardBinVolume(0.5, 0.5, 2, 1.0);
-      expect(volume).toBeGreaterThanOrEqual(0);
-    });
-
-    it('socket volume scales with gridUnitMm (regression: hardcoded 42mm cellSize)', () => {
-      // Same bin spec at half-pitch (30mm) vs standard (42mm). Sockets are
-      // per-cell shell structures whose footprint follows gridUnitMm — a
-      // 30mm cell socket holds materially less material than a 42mm one.
-      const standard = estimateStandardBinVolume(2, 2, 3, 0.4, 42);
-      const halfPitch = estimateStandardBinVolume(2, 2, 3, 0.4, 30);
-      expect(halfPitch).toBeLessThan(standard);
+    it('is independent of nozzle size (bin CAD geometry is fixed)', () => {
+      // The generated bin wall is a fixed spec thickness; the user's nozzle
+      // only affects slicing/print-time, never the part volume. Volume must
+      // not change with nozzle.
+      const v04 = estimateStandardBinFilament(2, 2, 3, {
+        ...DEFAULT_PRINT_SETTINGS,
+        nozzleSizeMm: 0.4,
+      }).volumeMm3;
+      const v06 = estimateStandardBinFilament(2, 2, 3, {
+        ...DEFAULT_PRINT_SETTINGS,
+        nozzleSizeMm: 0.6,
+      }).volumeMm3;
+      expect(v06).toBe(v04);
     });
   });
 
@@ -63,7 +96,14 @@ describe('standardBinVolume', () => {
       expect(est.costUSD).toBeGreaterThan(0);
     });
 
-    it('is monotonic: larger bins cost more', () => {
+    it('filament length matches the OCCT solid volume conversion (1×1×3u ≈ 2.59m)', () => {
+      const est = estimateStandardBinFilament(1, 1, 3);
+      // 6241mm³ / 2.405mm² / 1000 ≈ 2.59m
+      expect(est.metersFilament).toBeGreaterThan(2.59 * 0.9);
+      expect(est.metersFilament).toBeLessThan(2.59 * 1.1);
+    });
+
+    it('is monotonic: larger bins cost more and take longer', () => {
       const small = estimateStandardBinFilament(1, 1, 3);
       const large = estimateStandardBinFilament(3, 3, 3);
       expect(large.metersFilament).toBeGreaterThan(small.metersFilament);
@@ -71,49 +111,7 @@ describe('standardBinVolume', () => {
       expect(large.printTimeMinutes).toBeGreaterThan(small.printTimeMinutes);
     });
 
-    // Calibration regression: compare analytical model against the 4 real
-    // PrusaSlicer data points within ±30%. The analytical model computes
-    // solid geometry, not actual slicer toolpaths, so some deviation is expected.
-    describe('calibration regression (±30% of slicer data)', () => {
-      it('1×1×3u: ~2.3m from slicer', () => {
-        const est = estimateStandardBinFilament(1, 1, 3);
-        expect(est.metersFilament).toBeGreaterThan(2.3 * 0.7);
-        expect(est.metersFilament).toBeLessThan(2.3 * 1.3);
-      });
-
-      it('1×2×3u: ~3.7m from slicer', () => {
-        const est = estimateStandardBinFilament(1, 2, 3);
-        expect(est.metersFilament).toBeGreaterThan(3.7 * 0.7);
-        expect(est.metersFilament).toBeLessThan(3.7 * 1.3);
-      });
-
-      it('2×2×3u: ~5.6m from slicer', () => {
-        const est = estimateStandardBinFilament(2, 2, 3);
-        expect(est.metersFilament).toBeGreaterThan(5.6 * 0.7);
-        expect(est.metersFilament).toBeLessThan(5.6 * 1.3);
-      });
-
-      it('3×3×3u: ~9.9m from slicer', () => {
-        const est = estimateStandardBinFilament(3, 3, 3);
-        expect(est.metersFilament).toBeGreaterThan(9.9 * 0.7);
-        expect(est.metersFilament).toBeLessThan(9.9 * 1.3);
-      });
-    });
-
-    it('uses nozzle size from settings', () => {
-      const est04 = estimateStandardBinFilament(2, 2, 3, {
-        ...DEFAULT_PRINT_SETTINGS,
-        nozzleSizeMm: 0.4,
-      });
-      const est06 = estimateStandardBinFilament(2, 2, 3, {
-        ...DEFAULT_PRINT_SETTINGS,
-        nozzleSizeMm: 0.6,
-      });
-      // 0.6mm nozzle → thicker walls → more volume → more filament
-      expect(est06.volumeMm3).toBeGreaterThan(est04.volumeMm3);
-    });
-
-    it('larger nozzle has lower time-per-meter (higher extrusion rate)', () => {
+    it('larger nozzle prints faster (lower time) for the same part', () => {
       const est04 = estimateStandardBinFilament(2, 2, 3, {
         ...DEFAULT_PRINT_SETTINGS,
         nozzleSizeMm: 0.4,
@@ -122,9 +120,7 @@ describe('standardBinVolume', () => {
         ...DEFAULT_PRINT_SETTINGS,
         nozzleSizeMm: 0.8,
       });
-      const timePerMeter04 = est04.printTimeMinutes / est04.metersFilament;
-      const timePerMeter08 = est08.printTimeMinutes / est08.metersFilament;
-      expect(timePerMeter08).toBeLessThan(timePerMeter04);
+      expect(est08.printTimeMinutes).toBeLessThan(est04.printTimeMinutes);
     });
   });
 });

--- a/src/shared/printSettings/standardBinVolume.ts
+++ b/src/shared/printSettings/standardBinVolume.ts
@@ -9,9 +9,9 @@
  * The model is a three-term fit to ground-truth solid volumes measured from
  * the real OCCT generator (`measureVolume(getLastSolid())`):
  *
- *   V_solid ≈ perimeter · WALL_EFF · heightMm   (perimeter walls)
- *           + FLOOR_FEET_PER_CELL · cells        (floor + base feet per cell)
- *           + perimeter · LIP_AREA               (stacking lip)
+ *   V_solid ≈ perimeter · WALL_EFF · heightMm            (perimeter walls)
+ *           + BASE_VOL_PER_CELL_AREA · cellArea · cells  (floor + base feet)
+ *           + perimeter · LIP_AREA                        (stacking lip)
  *
  * It reproduces the generated geometry within ~2% across bins from 1×1×2u to
  * 4×4×6u (see standardBinVolume.test.ts for the documented ground-truth set).

--- a/src/shared/printSettings/standardBinVolume.ts
+++ b/src/shared/printSettings/standardBinVolume.ts
@@ -1,17 +1,29 @@
 /**
- * Analytical volume estimation for standard gridfinity bins.
+ * Analytical solid-volume estimation for standard gridfinity bins.
  *
- * Computes material volume for bins with default features:
- *   perimeter walls + floor + base socket + stacking lip
+ * Returns the SOLID material volume of a bin with default features
+ * (perimeter walls + floor + base socket feet + stacking lip, single
+ * compartment). Used by print-export to estimate filament for layout bins,
+ * which only carry width/depth/height.
  *
- * Used by print-export to estimate filament for layout bins, which only
- * have width/depth/height (no BinParams). Assumes standard gridfinity
- * defaults: 2-perimeter walls, socket interface, stacking lip, no
- * dividers, scoops, or labels.
+ * The model is a three-term fit to ground-truth solid volumes measured from
+ * the real OCCT generator (`measureVolume(getLastSolid())`):
  *
- * Unlike the bin-designer's full estimator (which computes solid geometry
- * for relative feature comparisons), this model uses calibrated geometry
- * constants tuned to match actual slicer output within ±30%.
+ *   V_solid ≈ perimeter · WALL_EFF · heightMm   (perimeter walls)
+ *           + FLOOR_FEET_PER_CELL · cells        (floor + base feet per cell)
+ *           + perimeter · LIP_AREA               (stacking lip)
+ *
+ * It reproduces the generated geometry within ~2% across bins from 1×1×2u to
+ * 4×4×6u (see standardBinVolume.test.ts for the documented ground-truth set).
+ *
+ * Two deliberate properties:
+ * - The base term scales **per cell** (floor + feet), not per footprint-area-
+ *   squared. An earlier `floor = innerArea × thickness` term over-grew with
+ *   footprint and produced size-dependent error.
+ * - Volume is **independent of nozzle size**. The bin's CAD wall is a fixed
+ *   spec thickness; the user's nozzle changes how the slicer fills that wall
+ *   and the print speed, never the part volume. Nozzle belongs to the time
+ *   model only (see `scalePrintTime`).
  */
 
 import {
@@ -23,22 +35,73 @@ import {
   type PrintSettings,
   DEFAULT_PRINT_SETTINGS,
 } from '@/shared/printSettings';
-import { GRIDFINITY_SPEC, wallThicknessForNozzle } from './gridfinityGeometry';
-/**
- * Effective floor thickness in mm (solid layers above socket cavities).
- * Typical gridfinity bins have ~3 solid bottom layers at 0.2mm = 0.6mm.
- * This is much thinner than the full 7mm base height because the socket
- * region below the floor is already computed separately.
- */
-const FLOOR_THICKNESS = 0.6;
+import { GRIDFINITY_SPEC } from './gridfinityGeometry';
 
 /**
- * Effective socket shell thickness in mm.
- * The actual socket is a tapered chamfered profile (~1.2mm average wall),
- * thinner than the bin-designer's 3.5mm approximation which is designed
- * for conservative relative comparisons, not absolute filament estimation.
+ * Effective solid wall cross-section thickness (mm) per unit of perimeter,
+ * calibrated to OCCT geometry. Larger than the nominal spec wall (0.95mm)
+ * because it absorbs outer corner rounding and the lip-region wall thickening.
  */
-const SOCKET_SHELL_THICKNESS = 1.2;
+const WALL_EFF = 1.165;
+
+/**
+ * Floor + base socket feet material per unit of cell footprint area (mm³/mm²),
+ * calibrated to OCCT geometry. At the standard 42mm pitch this is ≈2202mm³ per
+ * 42×42 cell; expressing it per unit area lets it scale to other grid pitches
+ * (e.g. half-pitch sockets) without hardcoding the reference pitch.
+ *   2202 mm³ / (42mm)² ≈ 1.2483 mm³/mm²
+ */
+const BASE_VOL_PER_CELL_AREA = 1.2483;
+
+/** Stacking-lip cross-sectional area (mm²) per unit of outer perimeter. */
+const LIP_AREA = 0.223;
+
+/**
+ * The three structural components of a standard bin's solid volume (mm³).
+ * Exposed so the bin-designer estimator can reuse the OCCT-calibrated base
+ * geometry and add the lip conditionally (and layer its own feature deltas on
+ * top) instead of maintaining a divergent copy.
+ */
+export interface StandardBinComponents {
+  /** Perimeter walls (full height). */
+  readonly walls: number;
+  /** Floor + base socket feet (per cell). */
+  readonly base: number;
+  /** Stacking lip (perimeter profile). */
+  readonly lip: number;
+}
+
+/**
+ * Decompose a standard bin's solid volume into walls / base / lip (mm³).
+ * Returns zeroed components for degenerate (non-positive) geometry.
+ */
+export function standardBinSolidComponents(
+  widthUnits: number,
+  depthUnits: number,
+  heightUnits: number,
+  gridUnitMm: number = GRIDFINITY_SPEC.GRID_SIZE,
+  heightUnitMm: number = GRIDFINITY_SPEC.HEIGHT_UNIT
+): StandardBinComponents {
+  const outerW = widthUnits * gridUnitMm - GRIDFINITY_SPEC.TOLERANCE;
+  const outerD = depthUnits * gridUnitMm - GRIDFINITY_SPEC.TOLERANCE;
+  const heightMm = heightUnits * heightUnitMm;
+
+  if (outerW <= 0 || outerD <= 0 || heightMm <= 0) {
+    return { walls: 0, base: 0, lip: 0 };
+  }
+
+  const perimeter = 2 * (outerW + outerD);
+  const cells = widthUnits * depthUnits;
+  // Floor + feet scale with cell footprint area, so a smaller grid pitch
+  // holds proportionally less base material.
+  const cellArea = gridUnitMm * gridUnitMm;
+
+  return {
+    walls: perimeter * WALL_EFF * heightMm,
+    base: BASE_VOL_PER_CELL_AREA * cellArea * cells,
+    lip: perimeter * LIP_AREA,
+  };
+}
 export interface StandardBinEstimate {
   /** Estimated material volume in mm³ */
   readonly volumeMm3: number;
@@ -52,54 +115,39 @@ export interface StandardBinEstimate {
   readonly costUSD: number;
 }
 /**
- * Estimate material volume (mm³) for a standard gridfinity bin.
- *
- * Decomposes the bin into four structural components:
- * 1. Perimeter walls — full height from bottom to rim
- * 2. Floor — thin solid layer above the socket cavities
- * 3. Base socket — per-cell interface that slides onto baseplate
- * 4. Stacking lip — top perimeter profile
+ * Estimate solid material volume (mm³) for a standard gridfinity bin.
  *
  * @param widthUnits - Bin width in grid units (e.g., 1, 1.5, 2)
  * @param depthUnits - Bin depth in grid units
  * @param heightUnits - Bin height in height units (includes base)
- * @param nozzleSizeMm - Nozzle diameter for wall thickness calculation
  * @param gridUnitMm - Grid unit size in mm (defaults to standard 42mm)
  * @param heightUnitMm - Height unit size in mm (defaults to standard 7mm)
- * @returns Volume in mm³
+ * @returns Solid volume in mm³
  */
 export function estimateStandardBinVolume(
   widthUnits: number,
   depthUnits: number,
   heightUnits: number,
-  nozzleSizeMm: number = 0.4,
   gridUnitMm: number = GRIDFINITY_SPEC.GRID_SIZE,
   heightUnitMm: number = GRIDFINITY_SPEC.HEIGHT_UNIT
 ): number {
-  const wall = wallThicknessForNozzle(nozzleSizeMm);
-
-  // Outer dimensions in mm
-  const outerW = widthUnits * gridUnitMm - GRIDFINITY_SPEC.TOLERANCE;
-  const outerD = depthUnits * gridUnitMm - GRIDFINITY_SPEC.TOLERANCE;
-  const totalH = heightUnits * heightUnitMm;
-
-  let volume = 0;
-
-  volume += computeWallsVolume(outerW, outerD, totalH, wall);
-
-  volume += computeFloorVolume(outerW, outerD, wall);
-
-  volume += computeBaseSocketVolume(widthUnits, depthUnits, gridUnitMm);
-
-  volume += computeStackingLipVolume(outerW, outerD);
-
-  return Math.max(0, volume);
+  const { walls, base, lip } = standardBinSolidComponents(
+    widthUnits,
+    depthUnits,
+    heightUnits,
+    gridUnitMm,
+    heightUnitMm
+  );
+  return Math.max(0, walls + base + lip);
 }
 
 /**
  * Estimate full print details for a standard gridfinity bin.
  *
- * Convenience wrapper that converts volume to filament, time, and cost.
+ * Convenience wrapper that converts the solid volume to filament length, mass,
+ * print time, and cost. Volume (and therefore filament/mass/cost) is
+ * independent of nozzle size; nozzle, layer height, and infill scale the print
+ * TIME only.
  *
  * @param widthUnits - Bin width in grid units
  * @param depthUnits - Bin depth in grid units
@@ -119,7 +167,6 @@ export function estimateStandardBinFilament(
     widthUnits,
     depthUnits,
     heightUnits,
-    settings.nozzleSizeMm,
     gridUnitMm,
     heightUnitMm
   );
@@ -128,7 +175,7 @@ export function estimateStandardBinFilament(
   const gramsFilament = volumeCm3 * PLA_DENSITY;
   const metersFilament = volumeMm3 / FILAMENT_AREA_MM2 / 1000;
 
-  // Scale only the extrusion portion; overhead (bed heat, etc.) is constant
+  // Scale only the extrusion portion; overhead (bed heat, etc.) is constant.
   const baseExtrusionMinutes = metersFilament * MINUTES_PER_METER;
   const printTimeMinutes = OVERHEAD_MINUTES + scalePrintTime(baseExtrusionMinutes, settings);
 
@@ -141,66 +188,4 @@ export function estimateStandardBinFilament(
     printTimeMinutes: Math.round(printTimeMinutes),
     costUSD: Math.round(costUSD * 100) / 100,
   };
-}
-/**
- * Volume of perimeter walls (cross-section × full height).
- *
- * Unlike the bin-designer's hollow box model, this does NOT include a solid
- * base slab. The floor and socket are computed separately to avoid
- * double-counting the base region.
- */
-function computeWallsVolume(outerW: number, outerD: number, totalH: number, wall: number): number {
-  const innerW = outerW - 2 * wall;
-  const innerD = outerD - 2 * wall;
-
-  if (innerW <= 0 || innerD <= 0) {
-    return outerW * outerD * totalH; // Solid block (walls too thick for bin size)
-  }
-
-  const wallCrossSection = outerW * outerD - innerW * innerD;
-  return wallCrossSection * totalH;
-}
-
-/**
- * Volume of the solid floor layer above socket cavities.
- * Uses FLOOR_THICKNESS (calibrated) rather than the full BASE_HEIGHT.
- */
-function computeFloorVolume(outerW: number, outerD: number, wall: number): number {
-  const innerW = outerW - 2 * wall;
-  const innerD = outerD - 2 * wall;
-
-  if (innerW <= 0 || innerD <= 0) return 0;
-
-  return innerW * innerD * FLOOR_THICKNESS;
-}
-
-/**
- * Volume of base socket structure (per-cell interface to baseplate).
- *
- * Each 1×1 cell has a tapered socket profile. Uses SOCKET_SHELL_THICKNESS
- * (calibrated to actual tapered profile average) rather than the
- * bin-designer's more generous 3.5mm approximation.
- */
-function computeBaseSocketVolume(
-  widthUnits: number,
-  depthUnits: number,
-  gridUnitMm: number
-): number {
-  const outerArea = gridUnitMm * gridUnitMm;
-  const innerSide = Math.max(0, gridUnitMm - 2 * SOCKET_SHELL_THICKNESS);
-  const innerArea = innerSide * innerSide;
-  const shellArea = outerArea - innerArea;
-  const volumePerFullCell = shellArea * GRIDFINITY_SPEC.SOCKET_HEIGHT;
-
-  return volumePerFullCell * widthUnits * depthUnits;
-}
-
-/**
- * Volume of stacking lip (4.4mm tall perimeter profile).
- * Same as bin-designer: thin-walled band with ~2mm average width.
- */
-function computeStackingLipVolume(outerW: number, outerD: number): number {
-  const lipThickness = 2;
-  const perimeter = 2 * (outerW + outerD);
-  return perimeter * lipThickness * GRIDFINITY_SPEC.LIP_HEIGHT;
 }


### PR DESCRIPTION
## Problem

Filament and print-time estimates over-reported — badly in the **bin designer / Export dialog** (the surface users actually see for a single custom bin).

## Root-cause method

Rather than trust the in-code "PrusaSlicer calibration" data, I measured the **real generated geometry** with OCCT (`measureVolume(getLastSolid())`). That data turned out to be fabricated — its docstring claimed a least-squares fit with "max error ~1 min," but the shipped constants missed by 10×, and a 1×1×3u bin is actually **6241 mm³ (≈2.59m)** solid, not the 2.3m the old data claimed.

## Bugs found & fixed

| # | Bug | Impact |
|---|-----|--------|
| 1 | Bin-designer estimator treated the bottom **7mm of every bin as a solid slab** (cavity carved only above the base) | **3–6× too high**, worsening with footprint |
| 2 | Print-export model judged against fabricated targets; vs real geometry it **under**-counted tall bins | −17% on 2×2×9u |
| 3 | Print time charged 16-min plate overhead **per distinct bin type** (`rows.length`) | hours of phantom overhead on varied layouts |
| 4 | **Nozzle size changed filament volume** | wrong — the CAD wall is fixed; nozzle affects slicing/time only |

## Changes

- **Rewrite `estimateStandardBinVolume`** as a 3-term model fit to OCCT ground truth (`perimeter·WALL_EFF·height + base/cell + lip`). Reproduces real solid volume within **~2%** across 1×1×2u–4×4×6u. Now nozzle-independent.
- **Consolidate** the bin-designer estimator onto the shared base geometry via the new `standardBinSolidComponents`, layering feature deltas (dividers, labels, scoops, honeycomb) on top; deleted its divergent hollow-box/socket/lip math.
- **`estimatePrintJobs`** — estimate plate count from bed area; use it for overhead instead of `rows.length`.
- **Time model**: derive `MINUTES_PER_METER` from an effective volumetric flow (~11 mm³/s) and document it.
- **Replace fabricated calibration data/tests** with documented OCCT ground truth and a **±10% regression test**.

## Before / after (default 2×2×3u standard bin)

| | Volume | Filament | Mass |
|---|---|---|---|
| Before (designer) | ~67,000 mm³ | ~27.8 m | ~83 g |
| After | ~17,100 mm³ | ~7.1 m | ~21 g |
| **OCCT actual** | **17,094 mm³** | — | — |

## Tests

- New ±10% regression test pins the model to 10 OCCT-measured bins.
- Full suite green: **11,493 passed**; typecheck, lint, knip clean.