### PR TITLE
fix(cutouts): circle cutouts with a chamfer or oval size now cut in 3D

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.snap
@@ -4,7 +4,9 @@ exports[`solid cutouts > 2×2 solid with 3×2 grid array of circles 1`] = `3420`
 
 exports[`solid cutouts > 2×2 solid with chamfered + scooped rectangle cutout 1`] = `3564`;
 
-exports[`solid cutouts > 2×2 solid with chamfered circle cutout 1`] = `2640`;
+exports[`solid cutouts > 2×2 solid with chamfered circle cutout 1`] = `3044`;
+
+exports[`solid cutouts > 2×2 solid with chamfered ellipse cutout 1`] = `3044`;
 
 exports[`solid cutouts > 2×2 solid with chamfered hexagon cutout 1`] = `2622`;
 
@@ -16,7 +18,7 @@ exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `2768`;
 
 exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `2684`;
 
-exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `2532`;
+exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `2796`;
 
 exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2562`;
 

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -15,7 +15,6 @@ import {
   draw,
   drawRoundedRectangle,
   box,
-  drawEllipse,
   cylinder,
   unwrap,
   translate,
@@ -75,9 +74,31 @@ function computeRotationSafeAABB(cx: number, cy: number, width: number, depth: n
 }
 
 /**
- * 2D outline for a parametric cutout shape, centered at origin. Shared by the
- * straight-extrude path and the chamfer loft so both agree on the profile.
- * Paths are not parametric and are handled separately.
+ * Vertex count for the polygonal circle/ellipse approximation.
+ *
+ * brepjs's `drawEllipse` yields a single periodic edge with no vertices. That
+ * breaks two kernel ops: extruding it produces an invalid (non-solid) prism,
+ * and `loftWith({ ruled: true })` has nothing to rule between. In both cases the
+ * resulting shape is dropped by the downstream boolean, so the cut silently
+ * no-ops while the bin stays valid. A fine polygon gives explicit vertices the
+ * extrude and ruled loft both need (the same reason polygon/slot/rectangle cut
+ * fine); 64 sides is visually smooth at print scale.
+ */
+const ELLIPSE_SEGMENTS = 64;
+
+/** Closed fine-polygon approximation of an ellipse (semi-axes rx, ry), centered at origin. */
+function ellipsePolygonDrawing(rx: number, ry: number): Drawing {
+  let pen = draw([rx, 0]);
+  for (let i = 1; i < ELLIPSE_SEGMENTS; i++) {
+    const a = (i / ELLIPSE_SEGMENTS) * Math.PI * 2;
+    pen = pen.lineTo([rx * Math.cos(a), ry * Math.sin(a)]);
+  }
+  return pen.close();
+}
+
+/**
+ * 2D outline for a parametric cutout shape, centered at origin. Used by the
+ * chamfer loft. Paths are not parametric and are handled separately.
  */
 function cutoutProfileDrawing(p: {
   readonly shape: string;
@@ -88,7 +109,7 @@ function cutoutProfileDrawing(p: {
 }): Drawing {
   switch (p.shape) {
     case 'circle':
-      return drawEllipse(p.w / 2, p.d / 2);
+      return ellipsePolygonDrawing(p.w / 2, p.d / 2);
     case 'polygon': {
       const pts = regularPolygonPoints(
         clampPolygonSides(p.sides ?? DEFAULT_POLYGON_SIDES),
@@ -210,9 +231,12 @@ function buildUnrotatedCutoutShape(cutout: {
     case 'circle': {
       const rx = w / 2;
       const ry = d / 2;
+      // True circle → smooth cylinder. Ellipse (rx≠ry) → polygon prism: a
+      // `drawEllipse` extrude produces an invalid solid that the boolean drops,
+      // so the cut silently no-ops (see ELLIPSE_SEGMENTS).
       return Math.abs(rx - ry) < 0.01
         ? cylinder(rx, cutout.cutDepth)
-        : sketch(drawEllipse(rx, ry), 'XY').extrude(cutout.cutDepth);
+        : sketch(ellipsePolygonDrawing(rx, ry), 'XY').extrude(cutout.cutDepth);
     }
     case 'polygon': {
       const pts = regularPolygonPoints(

--- a/src/features/generation/worker/generators/scenarios/solidCutouts.ts
+++ b/src/features/generation/worker/generators/scenarios/solidCutouts.ts
@@ -1,6 +1,23 @@
+import { expect } from 'vitest';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import { defineScenario, makeCutout } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
+
+const SOLID_BASE = { ...DEFAULT_BIN_PARAMS.base, solid: true };
+
+/**
+ * Reusable comparison guard: the cutout MUST actually subtract material.
+ *
+ * Structural-validity (the default scenario assert) can't catch a silent
+ * no-op cut — an uncut bin is still valid. This was the chamfered-circle bug:
+ * the chamfer loft emitted an invalid shell for the periodic ellipse profile,
+ * the boolean dropped it, and the bin came out uncut but valid. A real cut
+ * carves interior walls and so adds triangles over the bare solid bin.
+ */
+const mustCut: ScenarioCase['compareWith'] = {
+  params: { style: 'solid', base: SOLID_BASE, cutouts: [] },
+  assert: (withCut, noCut) => expect(withCut.triangleCount).toBeGreaterThan(noCut.triangleCount),
+};
 
 export const solidCutouts: ScenarioCase[] = [
   defineScenario('solid cutouts', '2\u00d72 solid with rectangle cutout', {
@@ -39,13 +56,30 @@ export const solidCutouts: ScenarioCase[] = [
         makeCutout({ shape: 'polygon', sides: 6, width: 18, depth: 16, chamferWidth: 1.5 }),
       ],
     },
+    compareWith: mustCut,
   }),
   defineScenario('solid cutouts', '2\u00d72 solid with chamfered circle cutout', {
     params: {
       style: 'solid',
       base: { ...DEFAULT_BIN_PARAMS.base, solid: true },
-      cutouts: [makeCutout({ shape: 'circle', width: 20, depth: 20, chamferWidth: 2 })],
+      cutouts: [
+        makeCutout({ shape: 'circle', x: 30, y: 30, width: 20, depth: 20, chamferWidth: 2 }),
+      ],
     },
+    compareWith: mustCut,
+  }),
+  defineScenario('solid cutouts', '2\u00d72 solid with chamfered ellipse cutout', {
+    params: {
+      style: 'solid',
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true },
+      // Width \u2260 depth \u2192 a true ellipse. Same periodic-edge profile as the circle,
+      // so it exercises the polygonal-approximation loft path that replaced the
+      // invalid drawEllipse loft; the cut must still land.
+      cutouts: [
+        makeCutout({ shape: 'circle', x: 26, y: 32, width: 28, depth: 16, chamferWidth: 1.5 }),
+      ],
+    },
+    compareWith: mustCut,
   }),
   defineScenario('solid cutouts', '2\u00d72 solid with chamfered rectangle cutout', {
     params: {
@@ -73,6 +107,7 @@ export const solidCutouts: ScenarioCase[] = [
       // the other shapes \u2014 exercise that loft path explicitly.
       cutouts: [makeCutout({ shape: 'slot', width: 30, depth: 12, chamferWidth: 1.5 })],
     },
+    compareWith: mustCut,
   }),
   defineScenario('solid cutouts', '2\u00d72 solid with slot (stadium) cutout', {
     params: {
@@ -224,6 +259,7 @@ export const solidCutouts: ScenarioCase[] = [
       base: { ...DEFAULT_BIN_PARAMS.base, solid: true },
       cutouts: [makeCutout({ shape: 'circle', width: 20, depth: 30 })],
     },
+    compareWith: mustCut,
   }),
   defineScenario('solid cutouts', '2\u00d72 solid with grouped cutouts', {
     params: {

--- a/src/features/generation/worker/generators/scenarios/solidCutouts.ts
+++ b/src/features/generation/worker/generators/scenarios/solidCutouts.ts
@@ -14,7 +14,7 @@ const SOLID_BASE = { ...DEFAULT_BIN_PARAMS.base, solid: true };
  * the boolean dropped it, and the bin came out uncut but valid. A real cut
  * carves interior walls and so adds triangles over the bare solid bin.
  */
-const mustCut: ScenarioCase['compareWith'] = {
+const mustCut: NonNullable<ScenarioCase['compareWith']> = {
   params: { style: 'solid', base: SOLID_BASE, cutouts: [] },
   assert: (withCut, noCut) => expect(withCut.triangleCount).toBeGreaterThan(noCut.triangleCount),
 };


### PR DESCRIPTION
## What

Drawing a **circle cutout** in the cut editor showed an amber outline in the 3D preview, but the bin stayed solid — no cavity was ever subtracted. This fixes it so drawn circles (and ovals) actually cut.

## Root cause

brepjs's `drawEllipse` yields a single *periodic* edge with no vertices. Two kernel ops choke on that and emit a non-solid shape, which the downstream boolean then silently drops — so the cut no-ops while the bin stays structurally valid (which is why tests didn't catch it):

1. **Entry-chamfer loft** — `loftWith({ ruled: true })` has no vertices to rule between → invalid shell. Every freshly drawn circle gets a default entry chamfer, so **every drawn circle** was affected.
2. **Plain ellipse extrude** — a circle resized so width ≠ depth extrudes to an invalid solid. A second, independent instance of the same failure.

Polygon / slot / rectangle were never affected (their wires have vertices).

## Fix

Approximate the circle/ellipse profile as a 64-side polygon (shared `ellipsePolygonDrawing` helper) in both the chamfer loft and the plain extrude. True circles (`rx == ry`) keep the smooth `cylinder` path. 64 sides is visually smooth at print scale.

## Before / after (3D preview, after deselect)

Before: flat top, no cavity. After: a real chamfered circular cavity is cut. Verified end-to-end in the running app via Playwright.

## Tests

The existing cutout scenarios only asserted *structural validity* — and an uncut bin is still valid, so this whole bug class was invisible. Added `compareWith` "must actually cut" guards (triangle count must exceed the bare solid bin) to:

- chamfered circle, chamfered hexagon, chamfered slot, plain ellipse
- a new **chamfered ellipse** scenario (exercises the width ≠ depth branch)

All 12,956 generator tests pass; typecheck + lint clean.