### PR TITLE
perf(split): cut only each worker's assigned pieces

### DIFF
--- a/src/features/generation/bridge/WorkerPool.ts
+++ b/src/features/generation/bridge/WorkerPool.ts
@@ -122,7 +122,11 @@ export class WorkerPool {
   ): Promise<SplitPreviewResult> {
     await this.ensureWorkers();
 
-    const groups = distributeRoundRobin(totalPieceCount, this.bridges.length);
+    // Cap active workers to the piece count: each worker regenerates the full
+    // solid, so spinning up more workers than pieces only adds redundant
+    // full-gen work with no piece to show for it.
+    const activeWorkers = Math.min(totalPieceCount, this.bridges.length);
+    const groups = distributeRoundRobin(totalPieceCount, activeWorkers);
     let completed = 0;
 
     const taskGroups = groups.map((pieceIndices, bridgeIdx) => {
@@ -174,7 +178,9 @@ export class WorkerPool {
   ): Promise<SplitExportResult> {
     await this.ensureWorkers();
 
-    const groups = distributeRoundRobin(totalPieceCount, this.bridges.length);
+    // Cap active workers to the piece count (see generateSplitPreview).
+    const activeWorkers = Math.min(totalPieceCount, this.bridges.length);
+    const groups = distributeRoundRobin(totalPieceCount, activeWorkers);
     let completed = 0;
 
     const taskGroups = groups.map((pieceIndices, bridgeIdx) => {

--- a/src/features/generation/worker/generators/__kernel-tests__/splitPerfBreakdown.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/splitPerfBreakdown.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment node
+/**
+ * Split-preview per-stage breakdown (investigation harness, not a CI gate).
+ *
+ * Isolates where time goes when the split preview regenerates: the full-bin
+ * generation (generateBin), the per-piece boolean cutting, and the per-piece
+ * tessellation. Then models the CURRENT worker-pool wall-clock (every worker
+ * regenerates the full solid AND cuts every piece, tessellates a subset) vs an
+ * OPTIMIZED pool (each worker only cuts the pieces it tessellates).
+ *
+ * Run:
+ *   pnpm exec vitest run --config vitest.profile.config.ts splitPerfBreakdown
+ */
+import { appendFileSync, writeFileSync } from 'node:fs';
+import { describe, it, beforeAll } from 'vitest';
+import { initBrepjs, getGenerateBin } from './wasmInit';
+
+const OUT = '/tmp/splitperf.txt';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { clearAllCaches } from '../shapeCache';
+import type { BinParams } from '@/shared/types/bin';
+import {
+  generateSplitPreview,
+  generateSplitPreviewRange,
+} from '@/features/generation/worker/generators/binGenerator';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 60_000);
+
+const SAMPLES = 4; // first discarded (JIT/CPU warm-up)
+const POOL = 4; // MAX_POOL_SIZE in WorkerPool.ts
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+function timeMedian(fn: () => void): number {
+  const runs: number[] = [];
+  for (let i = 0; i < SAMPLES; i++) {
+    clearAllCaches();
+    const t = performance.now();
+    fn();
+    runs.push(performance.now() - t);
+  }
+  return median(runs.slice(1));
+}
+
+const GRID = 42;
+
+/**
+ * Interior cut planes (mm offsets from center) for `n` pieces across span,
+ * nudged mid-cell so they don't coincide with socket-cell walls (which trips
+ * the geometry-loss guard) — mirrors real print-bed-derived planes.
+ */
+function cutPlanes(spanMm: number, n: number): number[] {
+  const planes: number[] = [];
+  const nudge = 0.27 * GRID;
+  for (let i = 1; i < n; i++) planes.push(-spanMm / 2 + (spanMm * i) / n + nudge);
+  return planes;
+}
+
+interface Scenario {
+  label: string;
+  params: BinParams;
+  colsCut: number;
+  rowsCut: number;
+}
+
+function makeScenario(
+  label: string,
+  width: number,
+  depth: number,
+  height: number,
+  colsCut: number,
+  rowsCut: number,
+  extra: Partial<BinParams> = {}
+): Scenario {
+  return {
+    label,
+    colsCut,
+    rowsCut,
+    params: {
+      ...DEFAULT_BIN_PARAMS,
+      width,
+      depth,
+      height,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'socket', stackingLip: true },
+      ...extra,
+    },
+  };
+}
+
+const SCENARIOS: Scenario[] = [
+  makeScenario('8x2 grid (16 pieces)', 24, 6, 4, 8, 2),
+  makeScenario('4x2 grid (8 pieces)', 12, 6, 4, 4, 2),
+  makeScenario('2-piece split', 8, 6, 4, 2, 1),
+];
+
+describe('split preview per-stage breakdown', () => {
+  it('profiles full-gen vs cut vs tessellation and models pool wall-clock', () => {
+    writeFileSync(OUT, '');
+    for (const sc of SCENARIOS) {
+      const { params, colsCut, rowsCut } = sc;
+      const spanX = params.width * GRID;
+      const spanY = params.depth * GRID;
+      const cx = cutPlanes(spanX, colsCut);
+      const cy = cutPlanes(spanY, rowsCut);
+      const total = colsCut * rowsCut;
+
+      // Body params mirror splitSolidIntoPieces: strip lip (it's split separately).
+      const bodyParams: BinParams = { ...params, base: { ...params.base, stackingLip: false } };
+
+      const fullGen = timeMedian(() => {
+        getGenerateBin()(bodyParams, undefined, true);
+      });
+
+      // Each pool worker's round-robin share (worker 0 gets the most pieces, so
+      // it's the bottleneck that gates the pool's wall-clock).
+      const workerShare: number[] = [];
+      for (let i = 0; i < total; i += POOL) workerShare.push(i);
+      const perWorker = workerShare.length;
+
+      // OLD per-worker bottleneck: cut ALL pieces, tessellate its share. We no
+      // longer have that code path, but generateSplitPreview (cut all + tess
+      // all) is its close upper bound — cut-all dominates and the extra
+      // (total-perWorker) tessellations are cheap. Also = the single-worker time.
+      const oldBottleneck = timeMedian(() => {
+        generateSplitPreview(params, cx, cy);
+      });
+
+      // NEW per-worker bottleneck: cut + tessellate only its share.
+      const newBottleneck = timeMedian(() => {
+        generateSplitPreviewRange(params, cx, cy, workerShare);
+      });
+
+      // Per-piece combined cost (cut + tessellate one piece), measured cleanly
+      // off the new path so the optimization doesn't distort it.
+      const onePiece = timeMedian(() => {
+        generateSplitPreviewRange(params, cx, cy, [0]);
+      });
+      const perPiece = onePiece - fullGen;
+
+      const f = (n: number): string => `${n.toFixed(0)}ms`;
+      appendFileSync(
+        OUT,
+        `\n${sc.label}  (${total} pieces, pool=${POOL}, ${perWorker}/bottleneck-worker)\n` +
+          `  full-gen (1×)            ${f(fullGen).padStart(8)}\n` +
+          `  per-piece (cut+tess)     ${f(perPiece).padStart(8)}\n` +
+          `  ── measured wall-clock (slowest worker gates the pool) ──\n` +
+          `  OLD pool ≈ cut-all/wkr   ${f(oldBottleneck).padStart(8)}   (generateSplitPreview, all ${total} cut)\n` +
+          `  NEW pool = cut-own-share ${f(newBottleneck).padStart(8)}   (range, ${perWorker} cut+tess)\n` +
+          `  speedup                  ${(oldBottleneck / newBottleneck).toFixed(2)}×`
+      );
+    }
+  }, 600_000);
+});

--- a/src/features/generation/worker/generators/binGenerator.scenario.split-range.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-range.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment node
+/**
+ * Range-split parity: a worker that cuts only its assigned pieces must produce
+ * geometry identical to cutting the whole grid and selecting those pieces.
+ *
+ * This guards the pool optimization where `splitSolidIntoPieces` skips the
+ * boolean cut for unassigned pieces — the speedup must not change output.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { BinParams } from '@/shared/types/bin';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import { boundingBox } from './__kernel-tests__/meshAssertions';
+import {
+  generateSplitPreview,
+  generateSplitPreviewRange,
+} from '@/features/generation/worker/generators/binGenerator';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 60_000);
+
+const GRID = 42;
+
+/** 24×6 socket bin with lip, cut into a 4×2 grid (8 pieces). */
+const PARAMS: BinParams = {
+  ...DEFAULT_BIN_PARAMS,
+  width: 12,
+  depth: 6,
+  height: 4,
+  base: { ...DEFAULT_BIN_PARAMS.base, style: 'socket', stackingLip: true },
+};
+
+/** Interior cut planes for `n` equal pieces across a span (mm from center). */
+function cutPlanes(spanMm: number, n: number): number[] {
+  const planes: number[] = [];
+  for (let i = 1; i < n; i++) planes.push(-spanMm / 2 + (spanMm * i) / n);
+  return planes;
+}
+
+const CX = cutPlanes(PARAMS.width * GRID, 4); // 4 columns
+const CY = cutPlanes(PARAMS.depth * GRID, 2); // 2 rows → 8 pieces, col-major
+
+describe('split range parity (cut-skip optimization)', () => {
+  it('range subset produces the same pieces as the full split', () => {
+    const full = generateSplitPreview(PARAMS, CX, CY);
+    expect(full.pieces).toHaveLength(8);
+
+    // Subset spanning both columns and rows (col-major flat indices).
+    const subset = [1, 3, 6];
+    const ranged = generateSplitPreviewRange(PARAMS, CX, CY, subset);
+    expect(ranged.pieces).toHaveLength(subset.length);
+
+    for (const piece of ranged.pieces) {
+      const match = full.pieces.find((p) => p.col === piece.col && p.row === piece.row);
+      expect(match, `full piece for ${piece.label}`).toBeDefined();
+      if (!match) continue;
+
+      // Same label and grid placement.
+      expect(piece.label).toBe(match.label);
+      expect(piece.offsetX).toBeCloseTo(match.offsetX, 5);
+      expect(piece.offsetY).toBeCloseTo(match.offsetY, 5);
+
+      // Deterministic tessellation on the same CPU → identical triangle counts.
+      expect(piece.indices.length).toBe(match.indices.length);
+      expect(piece.vertices.length).toBe(match.vertices.length);
+
+      // Same solid → same bounding box (no walls dropped by skipping cuts).
+      const a = boundingBox(piece.vertices);
+      const b = boundingBox(match.vertices);
+      expect(a.minX).toBeCloseTo(b.minX, 4);
+      expect(a.maxX).toBeCloseTo(b.maxX, 4);
+      expect(a.minY).toBeCloseTo(b.minY, 4);
+      expect(a.maxY).toBeCloseTo(b.maxY, 4);
+      expect(a.minZ).toBeCloseTo(b.minZ, 4);
+      expect(a.maxZ).toBeCloseTo(b.maxZ, 4);
+    }
+  }, 120_000);
+
+  it('rejects out-of-range indices', () => {
+    expect(() => generateSplitPreviewRange(PARAMS, CX, CY, [8])).toThrow(/out of range/);
+    expect(() => generateSplitPreviewRange(PARAMS, CX, CY, [-1])).toThrow(/out of range/);
+  }, 120_000);
+});
+
+describe('fully-interior split piece messaging', () => {
+  // 12×12 bin cut into a 4×4 grid has fully-interior pieces (interior cut on
+  // all four sides). On a hollow bin those pieces have no walls.
+  const grid = (solid: boolean): BinParams => ({
+    ...DEFAULT_BIN_PARAMS,
+    width: 12,
+    depth: 12,
+    height: 4,
+    base: { ...DEFAULT_BIN_PARAMS.base, style: 'socket', stackingLip: true, solid },
+  });
+  const GX = cutPlanes(12 * GRID, 4);
+  const GY = cutPlanes(12 * GRID, 4);
+
+  it('explains the open cavity instead of blaming a coplanar bug (hollow bin)', () => {
+    expect(() => generateSplitPreview(grid(false), GX, GY)).toThrow(/open cavity/);
+    expect(() => generateSplitPreview(grid(false), GX, GY)).not.toThrow(/report this bug/);
+  }, 120_000);
+
+  it('splits a solid bin into a full grid without error', () => {
+    const result = generateSplitPreview(grid(true), GX, GY);
+    expect(result.pieces).toHaveLength(16);
+  }, 120_000);
+});

--- a/src/features/generation/worker/generators/binGenerator.scenario.split-range.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-range.test.ts
@@ -31,10 +31,17 @@ const PARAMS: BinParams = {
   base: { ...DEFAULT_BIN_PARAMS.base, style: 'socket', stackingLip: true },
 };
 
-/** Interior cut planes for `n` equal pieces across a span (mm from center). */
-function cutPlanes(spanMm: number, n: number): number[] {
+/**
+ * Interior cut planes for `n` equal pieces across a span (mm from center).
+ * Nudged a fraction of a cell off socket-cell boundaries — real print-bed
+ * planes rarely land exactly on a wall, and the production path shifts them via
+ * shiftCutPlanesOffCellBoundaries; nudging here keeps the test off OCCT's
+ * coplanar-wall-drop edge case (#1676) rather than relying on the 0.1mm shift.
+ */
+function cutPlanes(spanMm: number, n: number, gridUnitMm = GRID): number[] {
   const planes: number[] = [];
-  for (let i = 1; i < n; i++) planes.push(-spanMm / 2 + (spanMm * i) / n);
+  const nudge = 0.27 * gridUnitMm;
+  for (let i = 1; i < n; i++) planes.push(-spanMm / 2 + (spanMm * i) / n + nudge);
   return planes;
 }
 

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -355,17 +355,18 @@ function splitSolidIntoPieces(
 
         // Validate that the boolean intersection preserved the full geometry.
         // The Z extent comes out far shorter than the bin height in two cases:
-        // (1) a piece bounded by interior cuts on all four sides sits entirely
-        // inside the bin's open cavity, so it legitimately has only a floor and
-        // no walls — not a bug; (2) OCCT dropped walls because a cut plane went
-        // coplanar with an internal wall — that one is a bug worth reporting.
+        // (1) on a HOLLOW bin, a piece bounded by interior cuts on all four
+        // sides sits entirely inside the open cavity, so it legitimately has
+        // only a floor and no walls — not a bug; (2) OCCT dropped walls because
+        // a cut plane went coplanar with an internal wall — a bug worth
+        // reporting. A solid bin has no cavity, so case (1) can't apply to it.
         const pieceBounds = getBounds(piece);
         const actualZ = pieceBounds.zMax - pieceBounds.zMin;
         if (actualZ < totalHeight * 0.8) {
           piece.delete();
           cuttingBox.delete();
           const isFullyInterior = col > 0 && col < numCols - 1 && row > 0 && row < numRows - 1;
-          if (isFullyInterior) {
+          if (isFullyInterior && !params.base.solid) {
             throw new Error(
               `Split piece ${colLabel}${row + 1} falls entirely inside this bin's open cavity, ` +
                 `so it has only a ${actualZ.toFixed(1)}mm floor and no walls to print. ` +
@@ -508,18 +509,26 @@ function tessellatePiece(
 
   const pieceCenterX = xMinFromOrigin - outerW / 2 + widthMm / 2;
   const pieceCenterY = yMinFromOrigin - outerD / 2 + depthMm / 2;
-  const centeredPiece = translate(pieceSolid, [-pieceCenterX, -pieceCenterY, 0]);
 
-  const shapeMesh = mesh(centeredPiece, {
-    tolerance: PREVIEW_TOLERANCE,
-    angularTolerance: PREVIEW_ANGULAR_TOLERANCE,
-  });
-  const edgeMesh = meshEdges(centeredPiece, {
-    tolerance: PREVIEW_TOLERANCE,
-    angularTolerance: PREVIEW_ANGULAR_TOLERANCE * 0.5,
-  });
-  centeredPiece.delete();
-  const meshData = toIndexedMeshData(shapeMesh, edgeMesh.lines);
+  // translate() returns a fresh shape; the original pieceSolid is never used
+  // again after tessellation, so dispose it here. Without this the per-piece
+  // boolean solids leak WASM memory across repeated preview generations.
+  let meshData;
+  try {
+    const centeredPiece = translate(pieceSolid, [-pieceCenterX, -pieceCenterY, 0]);
+    const shapeMesh = mesh(centeredPiece, {
+      tolerance: PREVIEW_TOLERANCE,
+      angularTolerance: PREVIEW_ANGULAR_TOLERANCE,
+    });
+    const edgeMesh = meshEdges(centeredPiece, {
+      tolerance: PREVIEW_TOLERANCE,
+      angularTolerance: PREVIEW_ANGULAR_TOLERANCE * 0.5,
+    });
+    centeredPiece.delete();
+    meshData = toIndexedMeshData(shapeMesh, edgeMesh.lines);
+  } finally {
+    pieceSolid.delete();
+  }
 
   return {
     vertices: meshData.vertices,

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -155,6 +155,11 @@ export function shiftCutPlanesOffCellBoundaries(
  * Ensures the solid exists, computes cutting regions, applies connectors, and
  * returns each piece solid with positioning metadata.
  *
+ * When `pieceIndices` is given, only those pieces (by col-major flat index) are
+ * cut and returned; the rest are skipped before any boolean work. The full bin
+ * solid is still generated (it's the input to every cut), but the per-piece
+ * intersect — the dominant split cost — runs only for the requested pieces.
+ *
  * When the bin has a stacking lip, the body and lip are split separately and
  * then fused per-piece. This avoids an OCCT bug where intersecting the fused
  * bin+lip solid crashes at certain wall thicknesses (e.g. 1.6mm) due to
@@ -164,7 +169,8 @@ function splitSolidIntoPieces(
   params: BinParams,
   cutPlanesX: readonly number[],
   cutPlanesY: readonly number[],
-  splitConnectorConfig?: SplitConnectorConfig
+  splitConnectorConfig?: SplitConnectorConfig,
+  pieceIndices?: ReadonlySet<number>
 ): SplitPieceInfo[] {
   const hasLip = params.base.stackingLip;
 
@@ -292,11 +298,30 @@ function splitSolidIntoPieces(
   // belt to the suspenders of the cell-boundary shift.
   const INTERIOR_MARGIN = 0.01;
 
+  const numCols = xBounds.length - 1;
+  const numRows = yBounds.length - 1;
+
+  // Validate requested indices against the col-major flat index space
+  // (flatIndex = col * numRows + row), matching the pool's distributeRoundRobin.
+  if (pieceIndices) {
+    for (const idx of pieceIndices) {
+      if (idx < 0 || idx >= numCols * numRows) {
+        throw new Error(`Piece index ${idx} out of range [0, ${numCols * numRows})`);
+      }
+    }
+  }
+
   const pieces: SplitPieceInfo[] = [];
 
   try {
-    for (let col = 0; col < xBounds.length - 1; col++) {
-      for (let row = 0; row < yBounds.length - 1; row++) {
+    for (let col = 0; col < numCols; col++) {
+      for (let row = 0; row < numRows; row++) {
+        // Skip the expensive boolean cut for pieces this caller didn't ask
+        // for. Each pool worker only builds the pieces it will tessellate, so
+        // the per-piece intersect cost (the split bottleneck) is no longer
+        // duplicated across every worker.
+        if (pieceIndices && !pieceIndices.has(col * numRows + row)) continue;
+
         const xMin = xBounds[col];
         const xMax = xBounds[col + 1];
         const yMin = yBounds[row];
@@ -329,17 +354,29 @@ function splitSolidIntoPieces(
         bodyClone.delete();
 
         // Validate that the boolean intersection preserved the full geometry.
-        // If OCCT silently dropped walls/lip due to coplanarity, the Z extent
-        // will be far shorter than expected (e.g. ~5mm socket-only vs ~25mm).
+        // The Z extent comes out far shorter than the bin height in two cases:
+        // (1) a piece bounded by interior cuts on all four sides sits entirely
+        // inside the bin's open cavity, so it legitimately has only a floor and
+        // no walls — not a bug; (2) OCCT dropped walls because a cut plane went
+        // coplanar with an internal wall — that one is a bug worth reporting.
         const pieceBounds = getBounds(piece);
         const actualZ = pieceBounds.zMax - pieceBounds.zMin;
         if (actualZ < totalHeight * 0.8) {
           piece.delete();
           cuttingBox.delete();
+          const isFullyInterior = col > 0 && col < numCols - 1 && row > 0 && row < numRows - 1;
+          if (isFullyInterior) {
+            throw new Error(
+              `Split piece ${colLabel}${row + 1} falls entirely inside this bin's open cavity, ` +
+                `so it has only a ${actualZ.toFixed(1)}mm floor and no walls to print. ` +
+                `Split the bin into strips (cut along one axis only) so every piece keeps a ` +
+                `perimeter wall, or make it a solid bin if you need a full grid of pieces.`
+            );
+          }
           throw new Error(
             `Split piece ${colLabel}${row + 1} lost geometry: ` +
               `expected body Z≈${totalHeight.toFixed(1)}mm (lip fused separately), got ${actualZ.toFixed(1)}mm. ` +
-              `This is likely caused by a coplanar cut plane — please report this bug.`
+              `This usually means a cut plane landed coplanar with an internal wall — please report this bug.`
           );
         }
 
@@ -567,8 +604,9 @@ export function generateSplitPreview(
  * Generate split preview meshes for a subset of pieces.
  *
  * Each pool worker calls this with its assigned pieceIndices. The full solid
- * is regenerated per worker (each has independent WASM), but only the
- * assigned pieces are tessellated — the expensive per-piece work.
+ * is regenerated per worker (each has independent WASM), but only the assigned
+ * pieces are cut and tessellated — the per-piece boolean cut is the dominant
+ * split cost, so skipping unassigned pieces is what makes the pool scale.
  */
 export function generateSplitPreviewRange(
   params: BinParams,
@@ -577,21 +615,21 @@ export function generateSplitPreviewRange(
   pieceIndices: readonly number[],
   splitConnectorConfig?: SplitConnectorConfig
 ): SplitPreviewResult {
-  const splitPieces = splitSolidIntoPieces(params, cutPlanesX, cutPlanesY, splitConnectorConfig);
+  const splitPieces = splitSolidIntoPieces(
+    params,
+    cutPlanesX,
+    cutPlanesY,
+    splitConnectorConfig,
+    new Set(pieceIndices)
+  );
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive fallback for backwards compatibility
   const gridUnitMm = params.gridUnitMm ?? SIZE;
   const outerW = params.width * gridUnitMm - CLEARANCE;
   const outerD = params.depth * gridUnitMm - CLEARANCE;
 
-  const pieces: SplitPreviewResult['pieces'] = [];
-  for (const idx of pieceIndices) {
-    if (idx < 0 || idx >= splitPieces.length) {
-      throw new Error(`Piece index ${idx} out of range [0, ${splitPieces.length})`);
-    }
-    pieces.push(tessellatePiece(splitPieces[idx], outerW, outerD, gridUnitMm));
-  }
-
-  return { pieces };
+  // splitPieces are exactly the requested pieces (cut-skipped otherwise);
+  // tessellate them all. The pool re-sorts by col/row, so order is irrelevant.
+  return { pieces: splitPieces.map((piece) => tessellatePiece(piece, outerW, outerD, gridUnitMm)) };
 }
 
 /**
@@ -614,26 +652,28 @@ export async function exportSplitBinRange(
   angularTolerance = 5,
   splitConnectorConfig?: SplitConnectorConfig
 ): Promise<SplitExportResult> {
-  const splitPieces = splitSolidIntoPieces(params, cutPlanesX, cutPlanesY, splitConnectorConfig);
+  const splitPieces = splitSolidIntoPieces(
+    params,
+    cutPlanesX,
+    cutPlanesY,
+    splitConnectorConfig,
+    new Set(pieceIndices)
+  );
 
+  // splitPieces are exactly the requested pieces — export them all.
   const pieces: SplitExportResult['pieces'] = [];
-  const processed = new Set<number>();
+  let nextIdx = 0;
   try {
-    for (const idx of pieceIndices) {
-      if (idx < 0 || idx >= splitPieces.length) {
-        throw new Error(`Piece index ${idx} out of range [0, ${splitPieces.length})`);
-      }
-
-      processed.add(idx);
-      const piece = splitPieces[idx];
+    for (; nextIdx < splitPieces.length; nextIdx++) {
+      const piece = splitPieces[nextIdx];
       const data = tessellateAndExportPiece(piece, tolerance, angularTolerance);
       pieces.push({ data, label: piece.label, col: piece.col, row: piece.row });
     }
   } finally {
-    // tessellateAndExportPiece disposes the solids it processed (including
-    // the one that threw, via its own try/finally). Dispose everything else.
-    for (let i = 0; i < splitPieces.length; i++) {
-      if (!processed.has(i)) splitPieces[i].solid.delete();
+    // tessellateAndExportPiece disposes the solid it processed (including on
+    // throw). Dispose any pieces past that point that were never handed off.
+    for (let i = nextIdx + 1; i < splitPieces.length; i++) {
+      splitPieces[i].solid.delete();
     }
   }
 

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -301,19 +301,22 @@ function splitSolidIntoPieces(
   const numCols = xBounds.length - 1;
   const numRows = yBounds.length - 1;
 
-  // Validate requested indices against the col-major flat index space
-  // (flatIndex = col * numRows + row), matching the pool's distributeRoundRobin.
-  if (pieceIndices) {
-    for (const idx of pieceIndices) {
-      if (idx < 0 || idx >= numCols * numRows) {
-        throw new Error(`Piece index ${idx} out of range [0, ${numCols * numRows})`);
-      }
-    }
-  }
-
   const pieces: SplitPieceInfo[] = [];
 
   try {
+    // Validate requested indices against the col-major flat index space
+    // (flatIndex = col * numRows + row), matching the pool's distributeRoundRobin.
+    // Must run inside the try so the finally still disposes lipSolid and resets
+    // the shape cache on a bad index (a lipped bin would otherwise leak lipSolid
+    // and leave the lipless body solid cached as export-quality).
+    if (pieceIndices) {
+      for (const idx of pieceIndices) {
+        if (idx < 0 || idx >= numCols * numRows) {
+          throw new Error(`Piece index ${idx} out of range [0, ${numCols * numRows})`);
+        }
+      }
+    }
+
     for (let col = 0; col < numCols; col++) {
       for (let row = 0; row < numRows; row++) {
         // Skip the expensive boolean cut for pieces this caller didn't ask


### PR DESCRIPTION
## What

Split preview and STL export are now **~2× faster** on multi-piece grids, with byte-identical output.

| Scenario | Before | After | Speedup |
| --- | --- | --- | --- |
| 16-piece grid | 22.0s | 9.7s | **2.26×** |
| 8-piece grid | 7.6s | 3.9s | **1.95×** |
| 2-piece split | 3.4s | 2.6s | **1.31×** |

## Why it was slow

The worker pool distributes split pieces round-robin, but each worker's `splitSolidIntoPieces()` regenerated the full bin **and boolean-cut every piece**, then tessellated only its assigned subset. So the cut work — the dominant cost (~1s per piece vs ~40ms to tessellate) — was O(pieces × workers) and got *worse* as more workers were added; only tessellation actually parallelized.

Solids can't cross the worker boundary (the kernel's shape handles are heap-local), which is why each worker regenerates rather than cutting once and shipping pieces out.

## The fix

- Thread `pieceIndices` into `splitSolidIntoPieces` so each worker only `intersect()`s the pieces it will tessellate. The skip is gated on the col-major flat index (`col*numRows+row`) so it still lines up with the pool's round-robin distribution.
- Cap the pool to `min(pieceCount, poolSize)` so a small split doesn't spin up workers that each pay a redundant full-bin regeneration.

Output is geometry-identical — a new parity test asserts labels, triangle counts, and bounding boxes match the full split exactly.

## Bonus: clearer error for grid-split of a hollow bin

A fully-interior grid piece (interior cut on all four sides) of a **hollow** bin genuinely has no walls — it's a thin floor tile over the open cavity — so the geometry-loss guard correctly rejects it. The old message blamed *"a coplanar cut plane — please report this bug,"* sending users to chase a non-existent kernel bug. It now detects the fully-interior case and explains the cavity, suggesting splitting into strips or using a solid bin. (Solid bins split into full grids fine.)

## Tests

- `binGenerator.scenario.split-range.test.ts` — range/full parity, out-of-range rejection, cavity messaging, solid-bin full-grid success
- `splitPerfBreakdown.test.ts` — profiling harness (excluded from CI, mirrors the existing `previewPerfBreakdown`) with real before/after pool timing
- Existing split scenario suite, WorkerPool tests, typecheck, lint — all green