### PR TITLE
perf(split): render a Manifold draft split on the leading edge

### DIFF
--- a/e2e/bin-designer/split-draft-manifold-visual.spec.ts
+++ b/e2e/bin-designer/split-draft-manifold-visual.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * One-shot visual + perf verification for the Manifold draft split.
+ *
+ * Drives the designer to an oversized (splitting) bin and confirms the split
+ * preview renders, then edits the bin and confirms the preview updates — the
+ * draft (Manifold) path renders on the leading edge while the exact occt-wasm
+ * result computes. Captures screenshots for visual review.
+ *
+ * Run with: `pnpm test:e2e e2e/bin-designer/split-draft-manifold-visual.spec.ts`
+ */
+
+import type { Page } from '@playwright/test';
+import { test, expect } from '../fixtures';
+
+test.use({
+  launchOptions: {
+    args: ['--use-gl=swiftshader', '--enable-webgl', '--ignore-gpu-blocklist'],
+  },
+});
+
+async function waitForGenerationComplete(page: Page): Promise<void> {
+  await expect(page.getByRole('status', { name: /generating mesh/i })).toHaveCount(0, {
+    timeout: 30_000,
+  });
+}
+
+test.describe('Manifold draft split — visual', () => {
+  test('oversized bin renders a split preview that updates on edit', async ({ page }) => {
+    test.setTimeout(180_000);
+    await page.goto('/designer');
+
+    const canvas = page.locator('canvas').first();
+    await expect(canvas).toBeVisible({ timeout: 120_000 });
+    await waitForGenerationComplete(page);
+
+    // Oversize the bin so it must split into pieces (default print bed ≈ 256mm).
+    await page.getByRole('spinbutton', { name: 'Width' }).fill('10');
+    await page.getByRole('spinbutton', { name: 'Width' }).blur();
+
+    // The split options panel only renders once the bin needs splitting — a
+    // proxy that the split preview path is active.
+    await expect(page.getByRole('switch', { name: /wall connectors/i })).toBeVisible({
+      timeout: 15_000,
+    });
+    await waitForGenerationComplete(page);
+
+    const split = await canvas.screenshot({ path: '/tmp/split-draft-1.png' });
+
+    // Edit the bin; the split preview must re-render (draft then exact).
+    await page.getByRole('spinbutton', { name: 'Height' }).fill('6');
+    await page.getByRole('spinbutton', { name: 'Height' }).blur();
+    await waitForGenerationComplete(page);
+
+    const splitEdited = await canvas.screenshot({ path: '/tmp/split-draft-2.png' });
+
+    // The taller bin must produce a visibly different split preview.
+    expect(Buffer.compare(split, splitEdited)).not.toBe(0);
+  });
+});

--- a/e2e/bin-designer/split-draft-manifold-visual.spec.ts
+++ b/e2e/bin-designer/split-draft-manifold-visual.spec.ts
@@ -44,16 +44,22 @@ test.describe('Manifold draft split — visual', () => {
     });
     await waitForGenerationComplete(page);
 
-    const split = await canvas.screenshot({ path: '/tmp/split-draft-1.png' });
+    const split = await canvas.screenshot();
 
     // Edit the bin; the split preview must re-render (draft then exact).
     await page.getByRole('spinbutton', { name: 'Height' }).fill('6');
     await page.getByRole('spinbutton', { name: 'Height' }).blur();
     await waitForGenerationComplete(page);
 
-    const splitEdited = await canvas.screenshot({ path: '/tmp/split-draft-2.png' });
+    const splitEdited = await canvas.screenshot();
 
     // The taller bin must produce a visibly different split preview.
-    expect(Buffer.compare(split, splitEdited)).not.toBe(0);
+    expect(split.equals(splitEdited)).toBe(false);
+
+    await test.info().attach('split-preview.png', { body: split, contentType: 'image/png' });
+    await test.info().attach('split-preview-taller.png', {
+      body: splitEdited,
+      contentType: 'image/png',
+    });
   });
 });

--- a/src/features/bin-designer/hooks/useSplitPreview.test.ts
+++ b/src/features/bin-designer/hooks/useSplitPreview.test.ts
@@ -15,11 +15,14 @@ const mockGenerateSplitPreview = vi.fn();
 const mockDraftGenerateSplitPreview = vi.fn();
 // Null by default → no draft bridge (exact-only), so existing exact-path tests
 // are unaffected. Individual tests set a draft bridge to exercise arbitration.
-let mockPreviewBridge: {
+type PreviewBridge = {
   generateSplitPreview: typeof mockDraftGenerateSplitPreview;
   isDestroyed: boolean;
-} | null = null;
+} | null;
+let mockPreviewBridge: PreviewBridge = null;
 const mockReleasePreview = vi.fn();
+// Overridable so a test can defer the bridge acquire (simulate a late load).
+let acquirePreviewImpl: () => Promise<PreviewBridge> = () => Promise.resolve(mockPreviewBridge);
 
 vi.mock('@/shared/generation/bridge', () => ({
   getActiveBridge: () => ({
@@ -31,7 +34,7 @@ vi.mock('@/shared/generation/bridge', () => ({
     release: () => {},
   },
   bridgeManager: {
-    acquirePreview: () => Promise.resolve(mockPreviewBridge),
+    acquirePreview: () => acquirePreviewImpl(),
     releasePreview: () => mockReleasePreview(),
   },
 }));
@@ -130,6 +133,7 @@ describe('useSplitPreview', () => {
     mockGenerateSplitPreview.mockResolvedValue(makeSplitResult(2));
     mockDraftGenerateSplitPreview.mockResolvedValue(makeSplitResult(2));
     mockPreviewBridge = null; // exact-only unless a test opts into the draft bridge
+    acquirePreviewImpl = () => Promise.resolve(mockPreviewBridge);
   });
 
   afterEach(() => {
@@ -378,6 +382,39 @@ describe('useSplitPreview', () => {
       resolveDraft(makeSplitResult(2));
       await Promise.resolve();
     });
+    expect(useDesignerStore.getState().ui.splitPieceMeshes).toHaveLength(4);
+  });
+
+  it('does NOT downgrade the exact result when the draft bridge loads late', async () => {
+    // The bridge resolves only when we call it — simulating Manifold loading
+    // after the exact split has already finalized for this edit.
+    let resolveAcquire: (b: PreviewBridge) => void = () => {};
+    acquirePreviewImpl = () =>
+      new Promise<PreviewBridge>((res) => {
+        resolveAcquire = res;
+      });
+    mockGenerateSplitPreview.mockResolvedValue(makeSplitResult(4));
+    mockDraftGenerateSplitPreview.mockResolvedValue(makeSplitResult(2));
+    setOversizedExplodedState({ generationStatus: 'generating' });
+
+    const { rerender } = renderHook(() => useSplitPreview());
+    completeMainGeneration();
+    rerender();
+    await flush(); // exact lands (4 pieces) and finalizes — no draft bridge yet
+    expect(useDesignerStore.getState().ui.splitPieceMeshes).toHaveLength(4);
+
+    // Bridge finishes loading now (late). The previewReady re-fire must NOT
+    // dispatch a draft for the already-finalized edit, nor overwrite the exact.
+    await act(async () => {
+      resolveAcquire({
+        generateSplitPreview: mockDraftGenerateSplitPreview,
+        isDestroyed: false,
+      });
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(mockDraftGenerateSplitPreview).not.toHaveBeenCalled();
     expect(useDesignerStore.getState().ui.splitPieceMeshes).toHaveLength(4);
   });
 

--- a/src/features/bin-designer/hooks/useSplitPreview.test.ts
+++ b/src/features/bin-designer/hooks/useSplitPreview.test.ts
@@ -12,6 +12,14 @@ import {
 // ── Bridge mock ──────────────────────────────────────────────────────────────
 
 const mockGenerateSplitPreview = vi.fn();
+const mockDraftGenerateSplitPreview = vi.fn();
+// Null by default → no draft bridge (exact-only), so existing exact-path tests
+// are unaffected. Individual tests set a draft bridge to exercise arbitration.
+let mockPreviewBridge: {
+  generateSplitPreview: typeof mockDraftGenerateSplitPreview;
+  isDestroyed: boolean;
+} | null = null;
+const mockReleasePreview = vi.fn();
 
 vi.mock('@/shared/generation/bridge', () => ({
   getActiveBridge: () => ({
@@ -21,6 +29,10 @@ vi.mock('@/shared/generation/bridge', () => ({
     get: () => null,
     acquire: () => Promise.reject(new Error('No pool in test')),
     release: () => {},
+  },
+  bridgeManager: {
+    acquirePreview: () => Promise.resolve(mockPreviewBridge),
+    releasePreview: () => mockReleasePreview(),
   },
 }));
 
@@ -116,6 +128,8 @@ describe('useSplitPreview', () => {
     vi.clearAllMocks();
     resetStores();
     mockGenerateSplitPreview.mockResolvedValue(makeSplitResult(2));
+    mockDraftGenerateSplitPreview.mockResolvedValue(makeSplitResult(2));
+    mockPreviewBridge = null; // exact-only unless a test opts into the draft bridge
   });
 
   afterEach(() => {
@@ -294,6 +308,77 @@ describe('useSplitPreview', () => {
     const afterFirst = useDesignerStore.getState().ui.splitPieceMeshes;
 
     expect(afterFirst).toHaveLength(afterSecond.length);
+  });
+
+  // ── Manifold draft path ─────────────────────────────────────────────────
+
+  /** Enable the draft (Manifold) preview bridge for a test. */
+  function enableDraftBridge() {
+    mockPreviewBridge = {
+      generateSplitPreview: mockDraftGenerateSplitPreview,
+      isDestroyed: false,
+    };
+  }
+
+  it('renders a draft split before the exact generation completes', async () => {
+    enableDraftBridge();
+    mockDraftGenerateSplitPreview.mockResolvedValue(makeSplitResult(2));
+    // Status stays 'generating' — the exact path is gated on completion, so any
+    // meshes here come from the draft.
+    setOversizedExplodedState({ generationStatus: 'generating' });
+
+    renderHook(() => useSplitPreview());
+    await flush();
+
+    expect(mockDraftGenerateSplitPreview).toHaveBeenCalledTimes(1);
+    expect(mockGenerateSplitPreview).not.toHaveBeenCalled();
+    expect(useDesignerStore.getState().ui.splitPieceMeshes).toHaveLength(2);
+  });
+
+  it('exact result supersedes the draft once main generation completes', async () => {
+    enableDraftBridge();
+    mockDraftGenerateSplitPreview.mockResolvedValue(makeSplitResult(2));
+    mockGenerateSplitPreview.mockResolvedValue(makeSplitResult(4));
+    setOversizedExplodedState({ generationStatus: 'generating' });
+
+    const { rerender } = renderHook(() => useSplitPreview());
+    await flush(); // draft lands (2 pieces)
+    expect(useDesignerStore.getState().ui.splitPieceMeshes).toHaveLength(2);
+
+    completeMainGeneration();
+    rerender();
+    await flush(); // exact lands (4 pieces), superseding the draft
+
+    expect(mockGenerateSplitPreview).toHaveBeenCalledTimes(1);
+    expect(useDesignerStore.getState().ui.splitPieceMeshes).toHaveLength(4);
+  });
+
+  it('drops a slow draft that resolves after the exact result finalized', async () => {
+    enableDraftBridge();
+    // Draft resolves manually, after the exact result.
+    let resolveDraft: (r: ReturnType<typeof makeSplitResult>) => void = () => {};
+    mockDraftGenerateSplitPreview.mockReturnValue(
+      new Promise((res) => {
+        resolveDraft = res;
+      })
+    );
+    mockGenerateSplitPreview.mockResolvedValue(makeSplitResult(4));
+    setOversizedExplodedState({ generationStatus: 'generating' });
+
+    const { rerender } = renderHook(() => useSplitPreview());
+    await flush();
+
+    completeMainGeneration();
+    rerender();
+    await flush(); // exact lands (4 pieces) and finalizes the token
+    expect(useDesignerStore.getState().ui.splitPieceMeshes).toHaveLength(4);
+
+    // The stale draft resolves late — must NOT clobber the exact result.
+    await act(async () => {
+      resolveDraft(makeSplitResult(2));
+      await Promise.resolve();
+    });
+    expect(useDesignerStore.getState().ui.splitPieceMeshes).toHaveLength(4);
   });
 
   // ── Switching between modes preserves meshes ────────────────────────────

--- a/src/features/bin-designer/hooks/useSplitPreview.ts
+++ b/src/features/bin-designer/hooks/useSplitPreview.ts
@@ -1,27 +1,61 @@
 /**
  * Drives split bin piece mesh generation for the 3D preview.
  *
- * Waits for the main bin generation to complete (generating → complete
- * transition) before generating split pieces, so the worker's cached
- * solid matches the current params. Without this gating, a param change
- * would trigger an immediate split preview against the stale solid,
- * producing mismatched geometry that flashes before the correct version.
+ * Two paths feed the same `splitPieceMeshes` slot, arbitrated by a monotonic
+ * token so the most recent edit always wins:
  *
- * When a worker pool is available, distributes piece processing across
- * multiple workers in parallel. Falls back to the single bridge otherwise.
+ * 1. **Draft (Manifold)** — fires immediately on each edit via the separate
+ *    Manifold preview bridge (~7× faster than occt-wasm), so the split pieces
+ *    appear in a few hundred ms instead of waiting for the full exact pipeline.
+ * 2. **Exact (occt-wasm)** — runs after the main bin generation completes, so
+ *    the worker's cached solid matches the current params, and supersedes the
+ *    draft. Distributes pieces across the worker pool when available.
+ *
+ * A draft is dropped if a newer edit has started (`token !== genToken`) or the
+ * exact result for its edit already landed (`token <= finalizedToken`). The
+ * exact result records its token as finalized so a slow draft can't clobber it.
  *
  * Clears meshes when the bin no longer needs splitting.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useSettingsStore } from '@/core/store/settings';
 import { calcMaxGridUnits } from '@/core/constants';
-import { getActiveBridge, workerPoolManager } from '@/shared/generation/bridge';
+import { getActiveBridge, workerPoolManager, bridgeManager } from '@/shared/generation/bridge';
+import type { GenerationBridge, SplitPreviewResult } from '@/shared/generation/bridge';
 import { getSplitPieceCount, getSplitPlanePositionsMm } from '@/shared/utils/splitPositions';
 import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
+import type { BinParams } from '@/shared/types/bin';
 import type { SplitPieceMeshEntry } from '../types';
+
+interface SplitInputs {
+  readonly cutPlanesX: number[];
+  readonly cutPlanesY: number[];
+  readonly totalPieceCount: number;
+  readonly splitConnectorConfig: BinParams['splitConnectors'];
+}
+
+function computeSplitInputs(
+  params: BinParams,
+  maxGrid: { width: number; depth: number }
+): SplitInputs {
+  return {
+    cutPlanesX: getSplitPlanePositionsMm(params.width, maxGrid.width, params.gridUnitMm),
+    cutPlanesY: getSplitPlanePositionsMm(params.depth, maxGrid.depth, params.gridUnitMm),
+    totalPieceCount: getSplitPieceCount(params.width, params.depth, maxGrid.width, maxGrid.depth),
+    splitConnectorConfig: params.splitConnectors ?? DEFAULT_SPLIT_CONNECTOR_CONFIG,
+  };
+}
+
+/** Convert a worker SplitPreviewResult into the store's mesh-entry shape. */
+function toMeshEntries(result: SplitPreviewResult): SplitPieceMeshEntry[] {
+  return result.pieces.map(({ vertices, normals, indices, edgeVertices, ...metadata }) => ({
+    ...metadata,
+    mesh: { vertices, normals, indices, edgeVertices },
+  }));
+}
 
 export function useSplitPreview(): void {
   const { generationStatus, params } = useDesignerStore(
@@ -43,9 +77,70 @@ export function useSplitPreview(): void {
   const maxGrid = calcMaxGridUnits(defaultPrintBedSize, params.gridUnitMm, defaultPrintBedDepth);
   const needsSplit = params.width > maxGrid.width || params.depth > maxGrid.depth;
 
-  const requestIdRef = useRef(0);
+  // Monotonic per-edit token; the most recent dispatch wins. finalizedToken is
+  // the highest token whose EXACT result has been applied — drafts at or below
+  // it are stale (covers the exact-resolves-before-draft race).
+  const genTokenRef = useRef(0);
+  const finalizedTokenRef = useRef(0);
   const prevStatusRef = useRef(generationStatus);
+  const previewBridgeRef = useRef<GenerationBridge | null>(null);
+  // Flips true once the Manifold bridge is acquired so the draft effect re-runs
+  // and dispatches a draft for the current params (the bridge usually resolves
+  // after the first render, so the initial edit would otherwise miss its draft).
+  const [previewReady, setPreviewReady] = useState(false);
 
+  // Acquire the Manifold draft-preview bridge (null when the flag is off or the
+  // kernel fails to load — never fatal; the exact path still runs).
+  useEffect(() => {
+    let acquired = false;
+    let cancelled = false;
+    void bridgeManager
+      .acquirePreview()
+      .then((preview) => {
+        if (cancelled) {
+          if (preview) bridgeManager.releasePreview();
+          return;
+        }
+        if (!preview) return;
+        previewBridgeRef.current = preview;
+        acquired = true;
+        setPreviewReady(true);
+      })
+      .catch(() => {
+        // Draft preview unavailable; exact-only split proceeds.
+      });
+    return () => {
+      cancelled = true;
+      previewBridgeRef.current = null;
+      setPreviewReady(false);
+      if (acquired) bridgeManager.releasePreview();
+    };
+  }, []);
+
+  // Draft path: render a fast Manifold split on the leading edge of each edit,
+  // without waiting for the exact main generation to finish.
+  useEffect(() => {
+    if (!needsSplit) return;
+    const preview = previewBridgeRef.current;
+    if (!preview || preview.isDestroyed) return;
+
+    const token = ++genTokenRef.current;
+    const { cutPlanesX, cutPlanesY, splitConnectorConfig } = computeSplitInputs(params, maxGrid);
+
+    void preview
+      .generateSplitPreview(params, cutPlanesX, cutPlanesY, { splitConnectorConfig })
+      .then((result) => {
+        // Dropped if a newer edit started or this edit's exact result landed.
+        if (token !== genTokenRef.current || token <= finalizedTokenRef.current) return;
+        useDesignerStore.getState().setSplitPieceMeshes(toMeshEntries(result));
+      })
+      .catch(() => {
+        // Draft failure is non-fatal — the exact path still runs.
+      });
+  }, [needsSplit, params, maxGrid, previewReady]);
+
+  // Exact path: runs after the main bin generation finishes so the worker's
+  // cached solid matches the current params, then supersedes the draft.
   useEffect(() => {
     const prevStatus = prevStatusRef.current;
     prevStatusRef.current = generationStatus;
@@ -58,8 +153,6 @@ export function useSplitPreview(): void {
       return;
     }
 
-    // Only generate split preview after the main bin generation finishes.
-    // This ensures the worker's cached solid matches the current params.
     // On first load, 'idle' → 'complete' counts as a valid transition.
     const justCompleted =
       generationStatus === 'complete' && (prevStatus === 'generating' || prevStatus === 'idle');
@@ -69,15 +162,14 @@ export function useSplitPreview(): void {
     const bridge = getActiveBridge();
     if (!bridge) return;
 
-    const requestId = ++requestIdRef.current;
-    const cutPlanesX = getSplitPlanePositionsMm(params.width, maxGrid.width, params.gridUnitMm);
-    const cutPlanesY = getSplitPlanePositionsMm(params.depth, maxGrid.depth, params.gridUnitMm);
-    const connectorConfig = params.splitConnectors ?? DEFAULT_SPLIT_CONNECTOR_CONFIG;
-    const totalPieceCount = getSplitPieceCount(
-      params.width,
-      params.depth,
-      maxGrid.width,
-      maxGrid.depth
+    // Claim a fresh token so a stale exact (from a superseded edit) can't
+    // overwrite a newer one, and finalize it on success so a slow draft for an
+    // earlier edit is dropped. Bumping past any in-flight draft for this same
+    // edit is fine — by justCompleted the draft has already served its purpose.
+    const token = ++genTokenRef.current;
+    const { cutPlanesX, cutPlanesY, totalPieceCount, splitConnectorConfig } = computeSplitInputs(
+      params,
+      maxGrid
     );
 
     // Try to acquire the pool for parallel generation, fall back to single bridge.
@@ -89,33 +181,26 @@ export function useSplitPreview(): void {
         if (pool.size <= 1) {
           workerPoolManager.release();
           return bridge.generateSplitPreview(params, cutPlanesX, cutPlanesY, {
-            splitConnectorConfig: connectorConfig,
+            splitConnectorConfig,
           });
         }
         usingPool = true;
         return pool.generateSplitPreview(params, cutPlanesX, cutPlanesY, totalPieceCount, {
-          splitConnectorConfig: connectorConfig,
+          splitConnectorConfig,
         });
       })
       .catch(() =>
         // Pool unavailable — fall back to single bridge
         bridge.generateSplitPreview(params, cutPlanesX, cutPlanesY, {
-          splitConnectorConfig: connectorConfig,
+          splitConnectorConfig,
         })
       );
 
     resultPromise
       .then((result) => {
-        if (requestIdRef.current !== requestId) return;
-
-        const entries: SplitPieceMeshEntry[] = result.pieces.map(
-          ({ vertices, normals, indices, edgeVertices, ...metadata }) => ({
-            ...metadata,
-            mesh: { vertices, normals, indices, edgeVertices },
-          })
-        );
-
-        useDesignerStore.getState().setSplitPieceMeshes(entries);
+        if (token !== genTokenRef.current) return;
+        finalizedTokenRef.current = token;
+        useDesignerStore.getState().setSplitPieceMeshes(toMeshEntries(result));
       })
       .catch(() => {
         // Silently ignore errors (e.g., superseded requests)

--- a/src/features/bin-designer/hooks/useSplitPreview.ts
+++ b/src/features/bin-designer/hooks/useSplitPreview.ts
@@ -18,7 +18,7 @@
  * Clears meshes when the bin no longer needs splitting.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useSettingsStore } from '@/core/store/settings';
@@ -73,13 +73,21 @@ export function useSplitPreview(): void {
   );
 
   // Use params.gridUnitMm (the bin's actual grid unit) rather than
-  // defaultGridUnitMm from settings, which may be stale
-  const maxGrid = calcMaxGridUnits(defaultPrintBedSize, params.gridUnitMm, defaultPrintBedDepth);
+  // defaultGridUnitMm from settings, which may be stale. Memoized on its
+  // primitive inputs so it's stable across renders — otherwise a fresh object
+  // each render would re-run the effects (and re-dispatch split work) below.
+  const maxGrid = useMemo(
+    () => calcMaxGridUnits(defaultPrintBedSize, params.gridUnitMm, defaultPrintBedDepth),
+    [defaultPrintBedSize, params.gridUnitMm, defaultPrintBedDepth]
+  );
   const needsSplit = params.width > maxGrid.width || params.depth > maxGrid.depth;
 
-  // Monotonic per-edit token; the most recent dispatch wins. finalizedToken is
-  // the highest token whose EXACT result has been applied — drafts at or below
-  // it are stale (covers the exact-resolves-before-draft race).
+  // Monotonic per-EDIT token, bumped only when params/maxGrid change (below) —
+  // never by draft dispatch or bridge readiness. Both the draft and exact paths
+  // read the current edit's token, so a draft that arrives after the exact
+  // result for the SAME edit (token <= finalizedToken) is dropped rather than
+  // downgrading the preview. finalizedToken is the highest token whose EXACT
+  // result has been applied.
   const genTokenRef = useRef(0);
   const finalizedTokenRef = useRef(0);
   const prevStatusRef = useRef(generationStatus);
@@ -117,6 +125,15 @@ export function useSplitPreview(): void {
     };
   }, []);
 
+  // Bump the per-edit token whenever the edit identity changes. Declared before
+  // the draft/exact effects so they read the already-incremented token on the
+  // same render. The draft effect also re-runs on previewReady (late bridge
+  // acquire) WITHOUT bumping, so a draft for an already-finalized edit is
+  // correctly dropped instead of overwriting the exact result.
+  useEffect(() => {
+    genTokenRef.current += 1;
+  }, [params, maxGrid]);
+
   // Draft path: render a fast Manifold split on the leading edge of each edit,
   // without waiting for the exact main generation to finish.
   useEffect(() => {
@@ -124,7 +141,10 @@ export function useSplitPreview(): void {
     const preview = previewBridgeRef.current;
     if (!preview || preview.isDestroyed) return;
 
-    const token = ++genTokenRef.current;
+    // Read (don't bump) the current edit's token. Skip entirely if the exact
+    // result for this edit already landed — a late draft must not downgrade it.
+    const token = genTokenRef.current;
+    if (token <= finalizedTokenRef.current) return;
     const { cutPlanesX, cutPlanesY, splitConnectorConfig } = computeSplitInputs(params, maxGrid);
 
     void preview
@@ -162,11 +182,11 @@ export function useSplitPreview(): void {
     const bridge = getActiveBridge();
     if (!bridge) return;
 
-    // Claim a fresh token so a stale exact (from a superseded edit) can't
-    // overwrite a newer one, and finalize it on success so a slow draft for an
-    // earlier edit is dropped. Bumping past any in-flight draft for this same
-    // edit is fine — by justCompleted the draft has already served its purpose.
-    const token = ++genTokenRef.current;
+    // Read the current edit's token (bumped by the edit effect above, shared
+    // with the draft). On success we finalize it so a slow draft for this edit
+    // is dropped; if a newer edit arrives mid-flight, token !== genToken drops
+    // this stale exact.
+    const token = genTokenRef.current;
     const { cutPlanesX, cutPlanesY, totalPieceCount, splitConnectorConfig } = computeSplitInputs(
       params,
       maxGrid

--- a/src/shared/generation/bridge.ts
+++ b/src/shared/generation/bridge.ts
@@ -23,6 +23,7 @@ export type {
 } from '@/features/generation/bridge/types';
 export type {
   SplitExportResult,
+  SplitPreviewResult,
   GenerationResult,
   BaseplateExportResult,
   CombinedExportResult,


### PR DESCRIPTION
## What

Splitting an oversized bin now shows its pieces **almost immediately** instead of waiting seconds for the full exact pipeline. A fast Manifold **draft** split renders on the leading edge of each edit, and the exact occt-wasm result supersedes it when ready.

Builds on #2069 (which made the exact split ~2× faster by removing the per-worker cut redundancy). This PR attacks the *remaining* cost — the split preview was exact-only and never used the Manifold draft path the single-bin preview already has.

## Why it was slow

`useSplitPreview` waited for the main bin generation to finish, then ran the full occt-wasm split (full-bin regen + per-piece boolean cuts) before any pieces appeared. The single-bin designer preview already renders a Manifold draft while occt computes — the split path was simply never wired to it.

## Measured

Running the split path under the Manifold kernel end-to-end (valid geometry, no NaN):

| Case | Manifold draft | occt-wasm exact | Speedup |
| --- | --- | --- | --- |
| socket+lip 8×2 | **334ms** | 2425ms | **7.3×** |
| flat no-lip 12×2 | **12ms** | 84ms | **7×** |

## How

- `useSplitPreview.ts`: fire `previewBridge.generateSplitPreview` (Manifold) immediately on each edit; the exact occt split (pool or single bridge) still runs after main generation completes and supersedes the draft.
- Token arbitration mirrors the single-bin draft→exact path (`genToken`/`finalizedToken`): a draft is dropped if a newer edit started or the exact result for its edit already landed; the exact result finalizes its token so a slow draft can't clobber it.
- A `previewReady` flag re-fires the draft once the Manifold bridge finishes loading (it usually resolves after the first render), so the initial edit doesn't miss its draft.
- Exposes `SplitPreviewResult` on the `@/shared/generation/bridge` facade.

## Tests

- `useSplitPreview.test.ts` — 15 tests: the 12 existing exact-path tests plus draft-renders-first, exact-supersedes-draft, and stale-draft-dropped.
- `split-draft-manifold-visual.spec.ts` — one-shot Playwright visual (oversized bin renders a split preview that updates on edit).

## ⚠️ Visual verification needed

I could **not** render the 3D preview in my sandbox — occt-wasm + WebGL don't initialize headless there (the preview hangs at "Generating mesh…", no canvas). The kernel-level perf and the hook→store integration are verified, but the actual pixel render is not. **Please check the Vercel preview** (oversize a bin so it splits, then edit it) to confirm the draft renders and feels fast before merge. Not arming auto-merge.