### PR TITLE
fix(split): clean split draft preview edges and skip redundant drafts

### DIFF
--- a/src/features/bin-designer/hooks/useSplitPreview.test.ts
+++ b/src/features/bin-designer/hooks/useSplitPreview.test.ts
@@ -13,6 +13,11 @@ import {
 
 const mockGenerateSplitPreview = vi.fn();
 const mockDraftGenerateSplitPreview = vi.fn();
+// Exact-build time estimate consulted by the draft-skip gate. null = no
+// history / worker busy → treated as slow → draft proceeds (the default, so
+// existing draft tests are unaffected). A test can resolve a fast value to
+// exercise the skip path.
+const mockEstimateGenerate = vi.fn<() => Promise<number | null>>(() => Promise.resolve(null));
 // Null by default → no draft bridge (exact-only), so existing exact-path tests
 // are unaffected. Individual tests set a draft bridge to exercise arbitration.
 type PreviewBridge = {
@@ -27,7 +32,10 @@ let acquirePreviewImpl: () => Promise<PreviewBridge> = () => Promise.resolve(moc
 vi.mock('@/shared/generation/bridge', () => ({
   getActiveBridge: () => ({
     generateSplitPreview: mockGenerateSplitPreview,
+    estimateGenerate: mockEstimateGenerate,
+    isDestroyed: false,
   }),
+  createDraftSkipGate: () => () => 1000,
   workerPoolManager: {
     get: () => null,
     acquire: () => Promise.reject(new Error('No pool in test')),
@@ -44,6 +52,10 @@ vi.mock('@/shared/generation/bridge', () => ({
 /** Flush pending microtasks so async effects resolve. */
 async function flush(): Promise<void> {
   await act(async () => {
+    // Several microtask cycles: the draft path awaits the exact-build estimate
+    // before dispatching, then awaits the split result — each is its own hop.
+    await Promise.resolve();
+    await Promise.resolve();
     await Promise.resolve();
   });
 }
@@ -132,6 +144,7 @@ describe('useSplitPreview', () => {
     resetStores();
     mockGenerateSplitPreview.mockResolvedValue(makeSplitResult(2));
     mockDraftGenerateSplitPreview.mockResolvedValue(makeSplitResult(2));
+    mockEstimateGenerate.mockResolvedValue(null); // slow by default → draft proceeds
     mockPreviewBridge = null; // exact-only unless a test opts into the draft bridge
     acquirePreviewImpl = () => Promise.resolve(mockPreviewBridge);
   });
@@ -337,6 +350,20 @@ describe('useSplitPreview', () => {
     expect(mockDraftGenerateSplitPreview).toHaveBeenCalledTimes(1);
     expect(mockGenerateSplitPreview).not.toHaveBeenCalled();
     expect(useDesignerStore.getState().ui.splitPieceMeshes).toHaveLength(2);
+  });
+
+  it('skips the draft when the exact build is predicted faster than the gate', async () => {
+    enableDraftBridge();
+    // Exact predicted at 50ms — under the 1000ms gate, so the draft would just
+    // flicker before the exact lands. The gate suppresses it.
+    mockEstimateGenerate.mockResolvedValue(50);
+    mockDraftGenerateSplitPreview.mockResolvedValue(makeSplitResult(2));
+    setOversizedExplodedState({ generationStatus: 'generating' });
+
+    renderHook(() => useSplitPreview());
+    await flush();
+
+    expect(mockDraftGenerateSplitPreview).not.toHaveBeenCalled();
   });
 
   it('exact result supersedes the draft once main generation completes', async () => {

--- a/src/features/bin-designer/hooks/useSplitPreview.ts
+++ b/src/features/bin-designer/hooks/useSplitPreview.ts
@@ -23,7 +23,12 @@ import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useSettingsStore } from '@/core/store/settings';
 import { calcMaxGridUnits } from '@/core/constants';
-import { getActiveBridge, workerPoolManager, bridgeManager } from '@/shared/generation/bridge';
+import {
+  getActiveBridge,
+  workerPoolManager,
+  bridgeManager,
+  createDraftSkipGate,
+} from '@/shared/generation/bridge';
 import type { GenerationBridge, SplitPreviewResult } from '@/shared/generation/bridge';
 import { getSplitPieceCount, getSplitPlanePositionsMm } from '@/shared/utils/splitPositions';
 import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
@@ -92,6 +97,10 @@ export function useSplitPreview(): void {
   const finalizedTokenRef = useRef(0);
   const prevStatusRef = useRef(generationStatus);
   const previewBridgeRef = useRef<GenerationBridge | null>(null);
+  // Shared with useGeneration's bin draft: returns the current skip threshold
+  // (FAST_EXACT_SKIP_MS, tightened to BURST_EXACT_SKIP_MS mid-scrub). Read
+  // `.current` inside the effect, never during render.
+  const draftSkipGateRef = useRef(createDraftSkipGate());
   // Flips true once the Manifold bridge is acquired so the draft effect re-runs
   // and dispatches a draft for the current params (the bridge usually resolves
   // after the first render, so the initial edit would otherwise miss its draft).
@@ -147,16 +156,38 @@ export function useSplitPreview(): void {
     if (token <= finalizedTokenRef.current) return;
     const { cutPlanesX, cutPlanesY, splitConnectorConfig } = computeSplitInputs(params, maxGrid);
 
-    void preview
-      .generateSplitPreview(params, cutPlanesX, cutPlanesY, { splitConnectorConfig })
-      .then((result) => {
-        // Dropped if a newer edit started or this edit's exact result landed.
+    const dispatchDraft = (): void => {
+      void preview
+        .generateSplitPreview(params, cutPlanesX, cutPlanesY, { splitConnectorConfig })
+        .then((result) => {
+          // Dropped if a newer edit started or this edit's exact result landed.
+          if (token !== genTokenRef.current || token <= finalizedTokenRef.current) return;
+          useDesignerStore.getState().setSplitPieceMeshes(toMeshEntries(result));
+        })
+        .catch(() => {
+          // Draft failure is non-fatal — the exact path still runs.
+        });
+    };
+
+    // Skip the draft when the exact pipeline is predicted to finish faster than
+    // the gate's threshold — a draft replaced almost immediately is just
+    // flicker, and the threshold tightens during a scrub (see draftPolicy).
+    // The estimate covers the exact bin build; the split cut runs on top, so the
+    // true exact-split time is at least this. Split bins exceed the print bed
+    // (large), so in practice this rarely skips — matching the bin draft's
+    // behavior for consistency. null (no history / worker busy mid-generation /
+    // timeout) means slow, so the draft proceeds.
+    const skipBelowMs = draftSkipGateRef.current();
+    const exact = getActiveBridge();
+    if (exact && !exact.isDestroyed) {
+      void exact.estimateGenerate(params).then((predictedMs) => {
+        if (predictedMs !== null && predictedMs < skipBelowMs) return;
         if (token !== genTokenRef.current || token <= finalizedTokenRef.current) return;
-        useDesignerStore.getState().setSplitPieceMeshes(toMeshEntries(result));
-      })
-      .catch(() => {
-        // Draft failure is non-fatal — the exact path still runs.
+        dispatchDraft();
       });
+    } else {
+      dispatchDraft();
+    }
   }, [needsSplit, params, maxGrid, previewReady]);
 
   // Exact path: runs after the main bin generation finishes so the worker's

--- a/src/features/generation/worker/generators/splitBinBuilder.scenario.manifold-kernel.test.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.scenario.manifold-kernel.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+/**
+ * Manifold-KERNEL (draft preview) edge fidelity for split-bin pieces.
+ *
+ * The bin designer's split preview runs on the Manifold mesh-CSG kernel, which
+ * has no B-rep topology — so `meshEdges()` returns the FULL triangle wireframe
+ * (~1.5 edges per triangle), not feature edges. Rendered, that paints every
+ * facet of the freshly-cut faces and curved socket walls as wireframe noise.
+ *
+ * `tessellatePiece` recovers clean feature edges via dihedral crease detection
+ * for build-time kernels (mirroring the whole-bin `tessellateStage`). This
+ * guard asserts the recovered edge set is feature edges — far fewer segments
+ * than a full wireframe — so a regression back to `meshEdges()` is caught.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { BinParams } from '@/shared/types/bin';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
+import { initManifoldKernel } from './__kernel-tests__/kernelInit';
+import { generateSplitPreview } from './binGenerator';
+import { clearAllCaches } from './shapeCache';
+
+beforeAll(async () => {
+  await initManifoldKernel();
+}, 30000);
+
+describe('Manifold split draft — pieces render feature edges, not full wireframe', () => {
+  const TIMEOUT = 60_000;
+
+  function check(label: string, params: BinParams): void {
+    clearAllCaches();
+    const res = generateSplitPreview(params, [0], [], DEFAULT_SPLIT_CONNECTOR_CONFIG);
+    expect(res.pieces.length, `${label}: two pieces`).toBe(2);
+    for (const piece of res.pieces) {
+      const edgeSegments = piece.edgeVertices.length / 6;
+      const triangleCount = piece.indices.length / 3;
+      expect(edgeSegments, `${label}/${piece.label}: has edges`).toBeGreaterThan(0);
+      // A full triangle wireframe has ~1.5 edge segments per triangle. Feature
+      // edges are a small fraction of that. Assert well under 1.0× triangles —
+      // the pre-fix meshEdges() wireframe was ~1.5× (and failed this).
+      expect(
+        edgeSegments,
+        `${label}/${piece.label}: feature edges (${edgeSegments}), not full wireframe (~${Math.round(
+          triangleCount * 1.5
+        )})`
+      ).toBeLessThan(triangleCount);
+    }
+  }
+
+  it(
+    'a plain 4×2 bin split along X has clean piece edges',
+    () => {
+      check('4×2 plain', { ...DEFAULT_BIN_PARAMS, width: 4, depth: 2 });
+    },
+    TIMEOUT
+  );
+
+  it(
+    'a 4×2 bin with compartments split along X has clean piece edges',
+    () => {
+      check('4×2 +comp', {
+        ...DEFAULT_BIN_PARAMS,
+        width: 4,
+        depth: 2,
+        compartments: { cols: 4, rows: 2, cells: [0, 1, 2, 3, 4, 5, 6, 7], thickness: 1.2 },
+      });
+    },
+    TIMEOUT
+  );
+});

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -16,6 +16,7 @@ import {
   getBounds,
   mesh,
   meshEdges,
+  getKernelCapabilities,
 } from 'brepjs';
 import type { Shape3D, ValidSolid } from 'brepjs';
 import type { BinParams, SplitConnectorConfig } from '@/shared/types/bin';
@@ -24,6 +25,7 @@ import { SIZE, CLEARANCE, SOCKET_HEIGHT } from './generatorTypes';
 import { buildSTLBufferFromIndexed } from '@/features/generation/export/stlExporter';
 import { LIP_HEIGHT, LIP_TAPER_WIDTH } from './generatorConstants';
 import { toIndexedMeshData } from './utils/mesh';
+import { creaseEdges } from './utils';
 import { buildTopShape } from './boxBuilder';
 import { generateBin } from './binOrchestrator';
 import { getLastSolid, setLastSolid } from './shapeCache';
@@ -523,12 +525,20 @@ function tessellatePiece(
       tolerance: PREVIEW_TOLERANCE,
       angularTolerance: PREVIEW_ANGULAR_TOLERANCE,
     });
-    const edgeMesh = meshEdges(centeredPiece, {
-      tolerance: PREVIEW_TOLERANCE,
-      angularTolerance: PREVIEW_ANGULAR_TOLERANCE * 0.5,
-    });
+    // Build-time kernels (manifold draft) have no B-rep topology, so
+    // `meshEdges()` returns the full triangle wireframe — every facet line,
+    // not feature edges. That paints the freshly-cut faces and curved socket
+    // walls as wireframe noise. Recover clean feature edges from the mesh via
+    // dihedral crease detection, mirroring `tessellateStage` for whole bins.
+    const buildTime = getKernelCapabilities().tessellationModel === 'build-time';
+    const edgeLines = buildTime
+      ? creaseEdges(shapeMesh)
+      : meshEdges(centeredPiece, {
+          tolerance: PREVIEW_TOLERANCE,
+          angularTolerance: PREVIEW_ANGULAR_TOLERANCE * 0.5,
+        }).lines;
     centeredPiece.delete();
-    meshData = toIndexedMeshData(shapeMesh, edgeMesh.lines);
+    meshData = toIndexedMeshData(shapeMesh, edgeLines);
   } finally {
     pieceSolid.delete();
   }

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -521,24 +521,29 @@ function tessellatePiece(
   let meshData;
   try {
     const centeredPiece = translate(pieceSolid, [-pieceCenterX, -pieceCenterY, 0]);
-    const shapeMesh = mesh(centeredPiece, {
-      tolerance: PREVIEW_TOLERANCE,
-      angularTolerance: PREVIEW_ANGULAR_TOLERANCE,
-    });
-    // Build-time kernels (manifold draft) have no B-rep topology, so
-    // `meshEdges()` returns the full triangle wireframe — every facet line,
-    // not feature edges. That paints the freshly-cut faces and curved socket
-    // walls as wireframe noise. Recover clean feature edges from the mesh via
-    // dihedral crease detection, mirroring `tessellateStage` for whole bins.
-    const buildTime = getKernelCapabilities().tessellationModel === 'build-time';
-    const edgeLines = buildTime
-      ? creaseEdges(shapeMesh)
-      : meshEdges(centeredPiece, {
-          tolerance: PREVIEW_TOLERANCE,
-          angularTolerance: PREVIEW_ANGULAR_TOLERANCE * 0.5,
-        }).lines;
-    centeredPiece.delete();
-    meshData = toIndexedMeshData(shapeMesh, edgeLines);
+    // Dispose centeredPiece in a finally so a throw in mesh()/meshEdges()/
+    // creaseEdges() doesn't leak the translated WASM handle.
+    try {
+      const shapeMesh = mesh(centeredPiece, {
+        tolerance: PREVIEW_TOLERANCE,
+        angularTolerance: PREVIEW_ANGULAR_TOLERANCE,
+      });
+      // Build-time kernels (manifold draft) have no B-rep topology, so
+      // `meshEdges()` returns the full triangle wireframe — every facet line,
+      // not feature edges. That paints the freshly-cut faces and curved socket
+      // walls as wireframe noise. Recover clean feature edges from the mesh via
+      // dihedral crease detection, mirroring `tessellateStage` for whole bins.
+      const buildTime = getKernelCapabilities().tessellationModel === 'build-time';
+      const edgeLines = buildTime
+        ? creaseEdges(shapeMesh)
+        : meshEdges(centeredPiece, {
+            tolerance: PREVIEW_TOLERANCE,
+            angularTolerance: PREVIEW_ANGULAR_TOLERANCE * 0.5,
+          }).lines;
+      meshData = toIndexedMeshData(shapeMesh, edgeLines);
+    } finally {
+      centeredPiece.delete();
+    }
   } finally {
     pieceSolid.delete();
   }


### PR DESCRIPTION
## What & why

Two refinements to the **split-bin draft preview** (the fast Manifold render shown while the exact occt geometry computes):

### 1. Clean cut-face edges (no more wireframe noise)
Split pieces rendered every triangle facet of the freshly-cut faces and curved sockets as wireframe lines. `tessellatePiece` called `meshEdges()` unconditionally — but on the build-time **Manifold** kernel that returns the *full triangle wireframe* (no B-rep topology to extract feature edges from). The whole-bin `tessellateStage` already solved this by switching to `creaseEdges()` (dihedral feature-edge recovery) for build-time kernels; the split path never got that switch.

**Result:** Manifold edge count per piece drops from **~6190 (full wireframe) → ~2030 feature edges**, matching occt's ~1920. The occt (exact) path is unchanged.

### 2. Honor the draft-skip gate
`useSplitPreview` dispatched a Manifold split draft on *every* edit, even when the exact result was about to land — unlike the bin draft (`useGeneration`), which gates on the worker's cache-aware estimate. Split drafts now reuse the same `createDraftSkipGate()` + `estimateGenerate()` gate (`FAST_EXACT_SKIP_MS` / `BURST_EXACT_SKIP_MS`, unchanged). Split bins are large (they exceed the print bed), so in practice this rarely skips — it's about consistency and avoiding flicker on the cheap cases.

## Verification
- New Manifold-kernel-pinned guard (`splitBinBuilder.scenario.manifold-kernel.test.ts`) asserts pieces render feature edges, not a full wireframe — **fails without the fix**.
- New `useSplitPreview` test covers the skip path; bridge mock updated.
- typecheck ✓, lint ✓, 22 split scenario tests ✓, 17 `useSplitPreview` tests ✓.

## Not in this PR
The custom-shape "non-manifold corner artifact" turned out to be the **stacking-lip fuse on the Manifold kernel** (coincident lip↔body corner faces the union doesn't dissolve), general to all lipped bins — being addressed upstream in brepjs separately.