### PR TITLE
fix(preview): build a fuse-free lip for the Manifold draft

### DIFF
--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -392,6 +392,7 @@ export function buildBinBox(
     return setBoxCache(boxKey, result);
   });
 }
+
 /**
  * Build the stacking lip using a ruled loft + boolean cut.
  *

--- a/src/features/generation/worker/generators/integratedLipBuilder.test.ts
+++ b/src/features/generation/worker/generators/integratedLipBuilder.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment node
+/**
+ * Manifold-KERNEL (draft preview) manifoldness of LIPPED bins (issue #2074).
+ *
+ * The exact occt path builds the stacking lip as a separate solid and fuses it
+ * onto the body; occt's General Fuse dissolves the coincident outer-wall faces.
+ * The Manifold mesh-CSG kernel does NOT — it leaves both coincident surfaces, so
+ * the fused draft has edges shared by >2 triangles (z-fighting) along the
+ * ~2.7mm-tall wall↔lip overlap at the rounded corners. Measured pre-fix:
+ * rectangular ≈ 51, L-shape ≈ 244 non-manifold edges (boundary edges 0 — it's
+ * coincident-face flicker, not holes).
+ *
+ * shellStage now builds the body+lip as a single fuse-free solid on build-time
+ * (mesh) kernels, so the draft is free of those coincident faces. This guard
+ * meshes the draft on the pinned Manifold kernel and asserts the non-manifold
+ * edge count stays at the lipless baseline (≈0).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { BinParams } from '@/shared/types/bin';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { MASK_CELLS_PER_UNIT, type CellMask } from '@/shared/utils/cellMask';
+import { initManifoldKernel } from './__kernel-tests__/kernelInit';
+import { generateBin } from './binGenerator';
+import { clearAllCaches } from './shapeCache';
+
+beforeAll(async () => {
+  await initManifoldKernel();
+}, 30000);
+
+interface EdgeStats {
+  triangleCount: number;
+  nonManifoldEdges: number;
+  boundaryEdges: number;
+}
+
+/**
+ * Count non-manifold (shared by >2 triangles) and boundary (shared by 1) edges
+ * in an indexed mesh. Keys edges by QUANTIZED POSITION, not vertex index —
+ * coincident faces carry distinct vertices at the same spot, so only a position
+ * key exposes the >2 sharing a fuse would leave behind.
+ */
+function analyzeMesh(vertices: Float32Array, indices: Uint32Array): EdgeStats {
+  const Q = 1e3; // 0.001mm — below tessellation noise, above float jitter
+  const vKey = (i: number): string => {
+    const b = i * 3;
+    return `${Math.round(vertices[b] * Q)},${Math.round(vertices[b + 1] * Q)},${Math.round(
+      vertices[b + 2] * Q
+    )}`;
+  };
+  const eKey = (a: string, b: string): string => (a < b ? `${a}|${b}` : `${b}|${a}`);
+
+  const edgeCount = new Map<string, number>();
+  const triangleCount = indices.length / 3;
+  for (let t = 0; t < triangleCount; t++) {
+    const k = [vKey(indices[t * 3]), vKey(indices[t * 3 + 1]), vKey(indices[t * 3 + 2])];
+    for (let i = 0; i < 3; i++) {
+      const e = eKey(k[i], k[(i + 1) % 3]);
+      edgeCount.set(e, (edgeCount.get(e) ?? 0) + 1);
+    }
+  }
+
+  let nonManifoldEdges = 0;
+  let boundaryEdges = 0;
+  for (const count of edgeCount.values()) {
+    if (count === 1) boundaryEdges++;
+    else if (count > 2) nonManifoldEdges++;
+  }
+  return { triangleCount, nonManifoldEdges, boundaryEdges };
+}
+
+describe('Manifold draft — lipped bins are coincidence-free (no fuse z-fighting)', () => {
+  const TIMEOUT = 60_000;
+
+  // Flat base → no socket, so generateBin's preview mesh is the body+lip shell
+  // alone. (The deferred base socket is concatenated as a separate mesh whose
+  // hidden interface with the body is coincident by design — it would mask the
+  // lip signal this guard is about.)
+  function statsFor(params: BinParams, lip: boolean): EdgeStats {
+    clearAllCaches();
+    const mesh = generateBin({
+      ...params,
+      base: { ...params.base, style: 'flat', solid: false, stackingLip: lip },
+    });
+    return analyzeMesh(mesh.vertices, mesh.indices);
+  }
+
+  function expectLipAddsNoCoincidence(params: BinParams, slack: number): void {
+    const base = statsFor(params, false);
+    const lipped = statsFor(params, true);
+    expect(base.boundaryEdges, 'lipless shell is watertight').toBe(0);
+    expect(lipped.boundaryEdges, 'lipped shell is watertight').toBe(0);
+    expect(
+      lipped.nonManifoldEdges,
+      `lipped non-manifold edges ${lipped.nonManifoldEdges} (lipless baseline ${base.nonManifoldEdges})`
+    ).toBeLessThanOrEqual(base.nonManifoldEdges + slack);
+  }
+
+  it(
+    'a rectangular lipped bin has no non-manifold edges (was ~51)',
+    () => {
+      expectLipAddsNoCoincidence({ ...DEFAULT_BIN_PARAMS, width: 2, depth: 2 }, 2);
+    },
+    TIMEOUT
+  );
+
+  it(
+    'a thick-walled lipped bin has no non-manifold edges',
+    () => {
+      expectLipAddsNoCoincidence(
+        { ...DEFAULT_BIN_PARAMS, width: 2, depth: 2, wallThickness: 2.4 },
+        2
+      );
+    },
+    TIMEOUT
+  );
+
+  it(
+    'an L-shaped (polygon) lipped bin has no non-manifold edges (was ~244)',
+    () => {
+      // 2×2 with the top-right quadrant cleared = an L footprint (no hole).
+      const cols = 2 * MASK_CELLS_PER_UNIT;
+      const rows = 2 * MASK_CELLS_PER_UNIT;
+      const cells = new Array<0 | 1>(cols * rows).fill(1);
+      const cutW = Math.floor(cols / 2);
+      const cutD = Math.floor(rows / 2);
+      for (let r = 0; r < cutD; r++) {
+        for (let c = cols - cutW; c < cols; c++) cells[r * cols + c] = 0;
+      }
+      const cellMask: CellMask = { cols, rows, cells };
+      expectLipAddsNoCoincidence({ ...DEFAULT_BIN_PARAMS, width: 2, depth: 2, cellMask }, 4);
+    },
+    TIMEOUT
+  );
+});

--- a/src/features/generation/worker/generators/integratedLipBuilder.ts
+++ b/src/features/generation/worker/generators/integratedLipBuilder.ts
@@ -1,0 +1,145 @@
+/**
+ * Draft-only body + stacking lip as a SINGLE fuse-free solid (issue #2074).
+ *
+ * The exact (occt) path builds a separate lip solid and `fuse`s it onto the
+ * body; occt's General Fuse dissolves the coincident outer-wall faces cleanly.
+ * Mesh kernels (the Manifold draft preview) do NOT dissolve exactly-coincident
+ * faces, so the fused draft z-fights along the ~2.7mm-tall wall↔lip overlap at
+ * the rounded corners. This builds the same geometry WITHOUT a fuse, so there
+ * is no coincident face to fight.
+ *
+ * @module
+ */
+
+import { drawRoundedRectangle, unwrap, cut, withScope } from 'brepjs';
+import type { Shape3D, Sketch, DisposalScope, Drawing } from 'brepjs';
+import {
+  SIZE,
+  CLEARANCE,
+  BOX_CORNER_RADIUS,
+  LIP_SMALL_TAPER,
+  LIP_VERTICAL_PART,
+  LIP_BIG_TAPER,
+  LIP_HEIGHT,
+  LIP_TAPER_WIDTH,
+  LIP_OVERLAP,
+  sketch,
+} from './generatorTypes';
+import { isPartialMask, type CellMask } from '@/shared/utils/cellMask';
+import { hasOverhang, overhangExpansion, type ResolvedOverhang } from './overhang';
+import { buildMaskDrawing, buildMaskDrawingInset } from './maskPolygon';
+
+function translateDrawing(d: Drawing, offX: number, offY: number): Drawing {
+  return offX !== 0 || offY !== 0 ? d.translate(offX, offY) : d;
+}
+
+/**
+ * Build the body + stacking lip as a single solid for mesh (build-time) draft
+ * kernels: one outer prism spanning floor→lip peak, with the bin cavity and the
+ * lip's inner taper removed as ONE boolean CUT. A cut leaves no coincident
+ * exterior faces, so the wall↔lip overlap an exact-kernel fuse would z-fight on
+ * simply does not exist.
+ *
+ * The single inner cut tool is a ruled loft of the lip's inner profile
+ * (mirroring `buildTopShapeLoft`) extended down to the cavity floor. Below the
+ * wall top the lip insets are clamped to `>= wallThickness` so the cut never
+ * eats into the wall (where the fused body wall would otherwise win); above the
+ * wall top the raw profile tapers to the knife edge.
+ *
+ * Draft-path only — the exported geometry stays on the fused occt path, so this
+ * cannot reintroduce the flush wall↔lip seam (#1314). The caller restricts it
+ * to the common case (non-solid, rectangular or solid-polygon footprint, no
+ * O-holes, no baked compartments) and falls back to the fuse otherwise.
+ */
+export function buildBinBoxWithLip(
+  gridW: number,
+  gridD: number,
+  wallHeight: number,
+  wallThickness: number,
+  gridUnitMm: number = SIZE,
+  cellMask?: CellMask,
+  overhang?: ResolvedOverhang
+): Shape3D {
+  const polygon = isPartialMask(cellMask);
+  const ov = polygon ? undefined : overhang;
+  const exp = ov && hasOverhang(ov) ? overhangExpansion(ov) : null;
+
+  const outerW = gridW * gridUnitMm - CLEARANCE + (exp?.addW ?? 0);
+  const outerD = gridD * gridUnitMm - CLEARANCE + (exp?.addD ?? 0);
+  const offX = exp?.offsetX ?? 0;
+  const offY = exp?.offsetY ?? 0;
+  const wt = wallThickness;
+
+  // Lip inner-profile insets (mirror buildTopShapeLoft's INNER_* values).
+  const INNER_ANGLE = 1.2; // LIP_EXTENSION
+  const INNER_BASE = LIP_TAPER_WIDTH; // 2.6
+  const INNER_MID = LIP_BIG_TAPER; // 1.9
+
+  // Lip profile breakpoints in GLOBAL Z. The lip base sits LIP_OVERLAP below the
+  // wall top; the angled support runs LIP_TAPER_WIDTH below that, alongside the
+  // upper wall (this is the coincident region the fuse z-fights on).
+  const lipBaseZ = wallHeight - LIP_OVERLAP;
+  const zAngleBottom = lipBaseZ - LIP_TAPER_WIDTH;
+  const zExt = lipBaseZ - 1.2;
+  const zTaper1 = lipBaseZ + LIP_SMALL_TAPER;
+  const zVert = lipBaseZ + LIP_SMALL_TAPER + LIP_VERTICAL_PART;
+  const zPeak = lipBaseZ + LIP_HEIGHT;
+
+  // Below the wall top the body wall is the visible interior, so the lip cut
+  // must not reach past it — clamp the inset to at least the wall thickness.
+  // Above the wall top there is no wall, so the raw profile (down to 0 at the
+  // peak) is used to keep the knife edge.
+  const clampedInset = (z: number, inset: number): number =>
+    z <= wallHeight + 1e-6 ? Math.max(wt, inset) : inset;
+
+  const insetDrawing = (inset: number): Drawing => {
+    if (polygon) {
+      return inset === 0
+        ? buildMaskDrawing(cellMask, gridUnitMm)
+        : buildMaskDrawingInset(cellMask, gridUnitMm, inset);
+    }
+    const w = outerW - 2 * inset;
+    const d = outerD - 2 * inset;
+    const r = Math.max(BOX_CORNER_RADIUS - inset, 0.1);
+    return translateDrawing(drawRoundedRectangle(w, d, r), offX, offY);
+  };
+
+  const sectionAt = (z: number, inset: number): Sketch =>
+    insetDrawing(inset).sketchOnPlane('XY', z) as Sketch;
+
+  const makeOuterFootprint = (): Drawing =>
+    polygon
+      ? buildMaskDrawing(cellMask, gridUnitMm)
+      : translateDrawing(drawRoundedRectangle(outerW, outerD, BOX_CORNER_RADIUS), offX, offY);
+
+  // The lip taper overshoots the peak so the cut tool exits cleanly THROUGH the
+  // prism top instead of capping flush with it (a flush cap would itself leave a
+  // coincident horizontal face). The residual top rim is sub-printable-layer thin.
+  const OVERSHOOT = 0.1;
+  // Distinct-Z gap between the vertical-wall top and the overhang foot so the
+  // corner is sharp without two sections sharing a Z (which degenerates the loft).
+  const FOOT = 0.05;
+
+  return withScope((scope: DisposalScope) => {
+    // Single outer prism: footprint extruded from the floor up to the lip peak.
+    // The body wall and lip outer share this one face — no coincidence to fight.
+    const outer = sketch(makeOuterFootprint()).extrude(zPeak);
+
+    // ONE inner cut tool: the straight bin cavity flowing into the lip's inner
+    // taper, as a single ruled loft. A single tool means there is no
+    // second-tool junction plane to leave a coincident face.
+    const innerSections: Sketch[] = [
+      sectionAt(wallThickness, wt),
+      sectionAt(zAngleBottom, wt),
+      sectionAt(zAngleBottom + FOOT, clampedInset(zAngleBottom + FOOT, INNER_ANGLE)),
+      sectionAt(zExt, clampedInset(zExt, INNER_BASE)),
+      sectionAt(lipBaseZ, clampedInset(lipBaseZ, INNER_BASE)),
+      sectionAt(zTaper1, clampedInset(zTaper1, INNER_MID)),
+      sectionAt(zVert, clampedInset(zVert, INNER_MID)),
+      sectionAt(zPeak + OVERSHOOT, 0),
+    ];
+    const [innerFirst, ...innerRest] = innerSections;
+    const innerCut = scope.register(innerFirst.loftWith(innerRest, { ruled: true }));
+    return unwrap(cut(outer, innerCut));
+  });
+}

--- a/src/features/generation/worker/generators/integratedLipBuilder.ts
+++ b/src/features/generation/worker/generators/integratedLipBuilder.ts
@@ -71,7 +71,8 @@ export function buildBinBoxWithLip(
   const wt = wallThickness;
 
   // Lip inner-profile insets (mirror buildTopShapeLoft's INNER_* values).
-  const INNER_ANGLE = 1.2; // LIP_EXTENSION
+  const LIP_EXTENSION = 1.2; // overhang depth = angled-support inset at its base
+  const INNER_ANGLE = LIP_EXTENSION;
   const INNER_BASE = LIP_TAPER_WIDTH; // 2.6
   const INNER_MID = LIP_BIG_TAPER; // 1.9
 
@@ -80,7 +81,7 @@ export function buildBinBoxWithLip(
   // upper wall (this is the coincident region the fuse z-fights on).
   const lipBaseZ = wallHeight - LIP_OVERLAP;
   const zAngleBottom = lipBaseZ - LIP_TAPER_WIDTH;
-  const zExt = lipBaseZ - 1.2;
+  const zExt = lipBaseZ - LIP_EXTENSION;
   const zTaper1 = lipBaseZ + LIP_SMALL_TAPER;
   const zVert = lipBaseZ + LIP_SMALL_TAPER + LIP_VERTICAL_PART;
   const zPeak = lipBaseZ + LIP_HEIGHT;
@@ -123,7 +124,8 @@ export function buildBinBoxWithLip(
   return withScope((scope: DisposalScope) => {
     // Single outer prism: footprint extruded from the floor up to the lip peak.
     // The body wall and lip outer share this one face — no coincidence to fight.
-    const outer = sketch(makeOuterFootprint()).extrude(zPeak);
+    // Registered so the scope disposes it; `cut` does not consume its inputs.
+    const outer = scope.register(sketch(makeOuterFootprint()).extrude(zPeak));
 
     // ONE inner cut tool: the straight bin cavity flowing into the lip's inner
     // taper, as a single ruled loft. A single tool means there is no

--- a/src/features/generation/worker/generators/maskPolygon.ts
+++ b/src/features/generation/worker/generators/maskPolygon.ts
@@ -220,6 +220,14 @@ export function buildMaskDrawingAtInset(
 }
 
 /**
+ * Whether the mask encloses any empty cells (O-shape interiors). `maskToPolygon`
+ * returns the outer perimeter as loop 0 and one loop per enclosed hole.
+ */
+export function maskHasHoles(mask: CellMask): boolean {
+  return maskToPolygon(mask).length > 1;
+}
+
+/**
  * Build one Drawing per inner hole in the mask. Each drawing represents
  * the cavity region in CCW orientation, grown outward from the nominal
  * hole boundary by `insetMm` so the extruded cut carries clearance on

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -10,12 +10,14 @@
  * EXPORT path the socket is fused into `solid` for a watertight model.
  */
 
-import { unwrap, fuse, translate, withScope } from 'brepjs';
+import { unwrap, fuse, translate, withScope, getKernelCapabilities } from 'brepjs';
 import type { DisposalScope, Shape3D } from 'brepjs';
 import type { PipelineContext, PipelineStage } from '../types';
 import { checkCancelled, isAbortError } from '../../utils/abort';
 import { buildBaseSocket, buildOverhangFeet } from '../../socketBuilder';
 import { buildBinBox, buildTopShape } from '../../boxBuilder';
+import { buildBinBoxWithLip } from '../../integratedLipBuilder';
+import { maskHasHoles } from '../../maskPolygon';
 import { hasOverhang } from '../../overhang';
 import {
   buildCompartmentCavityDrawings,
@@ -76,7 +78,40 @@ export const shellStage: PipelineStage = {
         ? buildCompartmentsCacheKey(params)
         : undefined;
 
+      // Mesh kernels (the Manifold draft) leave the body↔lip fuse's coincident
+      // outer-wall faces undissolved → z-fighting at the rounded corners (#2074).
+      // Build the body+lip as a single fuse-free solid instead, but only for the
+      // common case the integrated builder covers; everything else keeps the
+      // exact-faithful fuse below. Draft-only: the export path is an exact kernel.
+      const integratedLip =
+        dim.hasLip &&
+        !dim.solid &&
+        !dim.compartmentsBakedIntoShell &&
+        getKernelCapabilities().tessellationModel === 'build-time' &&
+        !(params.cellMask && maskHasHoles(params.cellMask));
+
       const built = withScope((scope: DisposalScope) => {
+        if (integratedLip) {
+          try {
+            const integrated = buildBinBoxWithLip(
+              params.width,
+              params.depth,
+              dim.wallHeight,
+              params.wallThickness,
+              params.gridUnitMm,
+              params.cellMask,
+              dim.overhang
+            );
+            // One solid: the lip is not a separable origin here, so the whole
+            // body carries the BASE tag (the exact path preserves the LIP tag).
+            collectOrigins(integrated, FeatureTag.BASE, originToTag);
+            return integrated;
+          } catch (e: unknown) {
+            if (isAbortError(e)) throw e;
+            // Integrated build failed — fall through to the fuse path.
+          }
+        }
+
         const binBody = buildBinBox(
           params.width,
           params.depth,


### PR DESCRIPTION
## What

Lipped bins no longer flicker (z-fight) at the rounded corners during the fast **draft preview**. The lip rim now renders clean and continuous from the first draft frame through the exact result.

Closes #2074.

## Why

The exact (occt) kernel builds the stacking lip as a separate solid and *fuses* it onto the bin body; its General Fuse dissolves the coincident outer-wall faces cleanly. The Manifold mesh-CSG kernel that powers the draft preview does **not** dissolve exactly-coincident faces — so every lipped bin's draft z-fought along the ~2.7mm-tall wall↔lip overlap at the corners (measured: rectangular ≈ 51, L-shape ≈ 244 non-manifold edges; boundary edges 0 — coincident-face flicker, not holes).

## How

On build-time (mesh) draft kernels, `shellStage` now builds the body+lip as a **single fuse-free solid**: one outer prism spanning floor→lip-peak, with the bin cavity and the lip's inner taper removed as one ruled-loft **cut**. A cut leaves no coincident exterior faces, so there is nothing to z-fight. The cut tool overshoots the peak (so it exits through the prism top rather than capping flush with it) and clamps the lip inset to `≥ wallThickness` below the wall top (so it never eats into the wall).

This is **draft-path only** — the export/exact path stays on the fused occt kernel, so the flush wall↔lip junction (#1314) and exported STL/3MF are untouched. The integrated builder covers the common case (non-solid, rectangular or solid-polygon footprint, no O-holes, no baked compartments); everything else keeps the existing fuse.

## Verification

- New sibling test pins the Manifold kernel and asserts non-manifold edges stay at the lipless baseline (≈0) for rectangular, thick-walled, and L-shaped lipped bins — was 51 / 244, now 0.
- Probed clean (0 non-manifold, watertight) across thin/thick walls, fractional sizes, large bins, and 1u-tall bins where the lip towers over a short wall.
- All 832 occt generation scenario tests pass (export geometry unchanged).
- Visual spot-check in the bin designer: the draft frame ("Generating surfaces") renders the lip rim cleanly with no corner artifacts.

## Known limitation

The integrated draft solid is one solid, so it carries a single `BASE` face-origin tag (no separate `LIP` tag). The exact result, which preserves the `LIP` tag, supersedes the draft within ~1.5s — so a custom-painted lip shows body-colored only during the transient draft.