### PR TITLE
feat(rightpanel): add nozzle size input to the desktop print list

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1725,6 +1725,7 @@
   "printBedInput.widthAriaLabel": "Druckbett-Breite",
   "rightPanel.binList": "Bin-Liste",
   "rightPanel.binProperties": "Bin-Eigenschaften",
+  "rightPanel.nozzleSizeTooltip": "Düsendurchmesser deines Druckers. Bestimmt die Druckzeitschätzung und skaliert Verbinder geteilter Bins, Wandsperren und Grundplatten-Verbinder, damit sie auf breiteren Düsen druckbar bleiben.",
   "rightPanel.collapsePanel": "Panel einklappen",
   "rightPanel.collapseRightPanel": "Rechtes Panel einklappen",
   "rightPanel.copyBinListAsTsv": "Bin-Liste als TSV kopieren",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -207,6 +207,7 @@
   "rightPanel.filamentMeters": "Estimated filament (meters)",
   "rightPanel.binList": "Bin List",
   "rightPanel.binProperties": "Bin Properties",
+  "rightPanel.nozzleSizeTooltip": "Your printer nozzle diameter. Drives the print-time estimate and scales split connectors, wall locks, and baseplate connectors so they stay printable on wider nozzles.",
   "rightPanel.collapseRightPanel": "Collapse right panel",
   "rightPanel.copyBinListAsTsv": "Copy bin list as TSV",
   "rightPanel.customPropertiesCount": "{count} custom properties",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -265,6 +265,8 @@ const en: Record<string, string> = {
   'rightPanel.filamentMeters': 'Estimated filament (meters)',
   'rightPanel.binList': 'Bin List',
   'rightPanel.binProperties': 'Bin Properties',
+  'rightPanel.nozzleSizeTooltip':
+    'Your printer nozzle diameter. Drives the print-time estimate and scales split connectors, wall locks, and baseplate connectors so they stay printable on wider nozzles.',
   'rightPanel.collapseRightPanel': 'Collapse right panel',
   'rightPanel.copyBinListAsTsv': 'Copy bin list as TSV',
   'rightPanel.customPropertiesCount': '{count} custom properties',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1725,6 +1725,7 @@
   "printBedInput.widthAriaLabel": "Ancho de la cama de impresión",
   "rightPanel.binList": "Lista de Bins",
   "rightPanel.binProperties": "Propiedades de Bin",
+  "rightPanel.nozzleSizeTooltip": "Diámetro de la boquilla de tu impresora. Determina la estimación de tiempo de impresión y escala los conectores de bandejas divididas, los seguros de pared y los conectores de placa base para que sigan siendo imprimibles con boquillas más anchas.",
   "rightPanel.collapsePanel": "Contraer panel",
   "rightPanel.collapseRightPanel": "Contraer panel derecho",
   "rightPanel.copyBinListAsTsv": "Copiar lista de bins como TSV",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1725,6 +1725,7 @@
   "printBedInput.widthAriaLabel": "Largeur du plateau",
   "rightPanel.binList": "Liste des bins",
   "rightPanel.binProperties": "Propriétés des bins",
+  "rightPanel.nozzleSizeTooltip": "Diamètre de la buse de votre imprimante. Détermine l'estimation du temps d'impression et adapte les connecteurs des bacs divisés, les verrous de paroi et les connecteurs de plaque de base pour qu'ils restent imprimables avec des buses plus larges.",
   "rightPanel.collapsePanel": "Réduire le panneau",
   "rightPanel.collapseRightPanel": "Réduire le panneau droit",
   "rightPanel.copyBinListAsTsv": "Copier la liste des bins en TSV",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1725,6 +1725,7 @@
   "printBedInput.widthAriaLabel": "プリントベッドの幅",
   "rightPanel.binList": "ビンリスト",
   "rightPanel.binProperties": "ビンプロパティ",
+  "rightPanel.nozzleSizeTooltip": "プリンターのノズル径。印刷時間の見積もりに使われ、分割ビンのコネクタ、壁ロック、ベースプレートのコネクタを拡大して太いノズルでも印刷できるようにします。",
   "rightPanel.collapsePanel": "パネルを折りたたむ",
   "rightPanel.collapseRightPanel": "右パネルを折りたたむ",
   "rightPanel.copyBinListAsTsv": "ビンリストをTSVとしてコピー",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1725,6 +1725,7 @@
   "printBedInput.widthAriaLabel": "Printbed-bredde",
   "rightPanel.binList": "Bin-liste",
   "rightPanel.binProperties": "Bin-egenskaper",
+  "rightPanel.nozzleSizeTooltip": "Dysediameteren til skriveren din. Bestemmer estimatet for utskriftstid og skalerer koblinger for delte binger, vegglåser og bunnplatekoblinger så de forblir utskrivbare med bredere dyser.",
   "rightPanel.collapsePanel": "Skjul panel",
   "rightPanel.collapseRightPanel": "Skjul høyre panel",
   "rightPanel.copyBinListAsTsv": "Kopier bin-liste som TSV",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1725,6 +1725,7 @@
   "printBedInput.widthAriaLabel": "Printbed-breedte",
   "rightPanel.binList": "Bin lijst",
   "rightPanel.binProperties": "Bin eigenschappen",
+  "rightPanel.nozzleSizeTooltip": "Nozzlediameter van je printer. Bepaalt de printtijdschatting en schaalt connectoren van gesplitste bakken, wandvergrendelingen en grondplaatconnectoren zodat ze met bredere nozzles printbaar blijven.",
   "rightPanel.collapsePanel": "Paneel invouwen",
   "rightPanel.collapseRightPanel": "Rechter paneel invouwen",
   "rightPanel.copyBinListAsTsv": "Bin lijst kopiëren als TSV",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1725,6 +1725,7 @@
   "printBedInput.widthAriaLabel": "Largura da mesa de impressão",
   "rightPanel.binList": "Lista de Bins",
   "rightPanel.binProperties": "Propriedades do Bin",
+  "rightPanel.nozzleSizeTooltip": "Diâmetro do bico da sua impressora. Determina a estimativa de tempo de impressão e escala os conectores de caixas divididas, as travas de parede e os conectores da placa-base para continuarem imprimíveis com bicos mais largos.",
   "rightPanel.collapsePanel": "Recolher painel",
   "rightPanel.collapseRightPanel": "Recolher painel direito",
   "rightPanel.copyBinListAsTsv": "Copiar lista de bins como TSV",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1725,6 +1725,7 @@
   "printBedInput.widthAriaLabel": "Utskriftsbäddens bredd",
   "rightPanel.binList": "Facklista",
   "rightPanel.binProperties": "Fackegenskaper",
+  "rightPanel.nozzleSizeTooltip": "Munstycksdiametern på din skrivare. Styr uppskattningen av utskriftstid och skalar kopplingar för delade lådor, vägglås och bottenplattskopplingar så att de förblir utskrivbara med bredare munstycken.",
   "rightPanel.collapsePanel": "Komprimera panel",
   "rightPanel.collapseRightPanel": "Komprimera höger panel",
   "rightPanel.copyBinListAsTsv": "Kopiera facklista som TSV",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1725,6 +1725,7 @@
   "printBedInput.widthAriaLabel": "Ширина друкарського стола",
   "rightPanel.binList": "Список бінів",
   "rightPanel.binProperties": "Властивості біна",
+  "rightPanel.nozzleSizeTooltip": "Діаметр сопла вашого принтера. Визначає оцінку часу друку та масштабує конектори розділених контейнерів, настінні фіксатори та конектори опорної плити, щоб вони лишалися придатними для друку ширшими соплами.",
   "rightPanel.collapsePanel": "Згорнути панель",
   "rightPanel.collapseRightPanel": "Згорнути праву панель",
   "rightPanel.copyBinListAsTsv": "Копіювати список бінів як TSV",

--- a/src/shell/RightPanel/RightPanel.test.tsx
+++ b/src/shell/RightPanel/RightPanel.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { RightPanel } from '@/shell/RightPanel';
-import { useLayoutStore, useViewStore } from '@/core/store';
+import { useLayoutStore, useViewStore, useSettingsStore } from '@/core/store';
 import { resetAllStores } from '@/test/testUtils';
 import type { UseBinInspectorReturn } from '@/features/bin-inspector';
 import type { UsePrintListReturn } from '@/features/print-export/hooks/usePrintList';
@@ -451,6 +451,24 @@ describe('RightPanel', () => {
       render(<RightPanel />);
 
       expect(screen.getByTestId('print-list-summary')).toBeInTheDocument();
+    });
+
+    it('renders the nozzle size input when rows exist', () => {
+      render(<RightPanel />);
+
+      expect(screen.getByLabelText('Nozzle size')).toBeInTheDocument();
+    });
+
+    it('updates the shared nozzle setting when the input changes', () => {
+      render(<RightPanel />);
+
+      const input = screen.getByLabelText('Nozzle size');
+      // DeferredNumberInput commits on blur; change to a value distinct from the
+      // 0.4mm default so the commit isn't skipped as a no-op.
+      fireEvent.change(input, { target: { value: '0.6' } });
+      fireEvent.blur(input);
+
+      expect(useSettingsStore.getState().settings.printSettings.nozzleSizeMm).toBe(0.6);
     });
 
     it('selects bins when row clicked', () => {

--- a/src/shell/RightPanel/RightPanel.tsx
+++ b/src/shell/RightPanel/RightPanel.tsx
@@ -1,10 +1,14 @@
 import React, { Suspense, useState, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useViewStore } from '@/core/store/view';
+import { useSettingsStore } from '@/core/store/settings';
 import { DEFAULT_CATEGORY_COLOR } from '@/core/constants';
+import { PRINT_SETTINGS_CONSTRAINTS } from '@/shared/printSettings';
 import { exportPrintListTSV } from '@/core/storage';
 import { trackEvent } from '@/shared/analytics/posthog';
 import { ConfirmDialog, CollapsibleSection } from '@/shared/components';
+import { SettingsRow } from '@/shared/components/SettingsRow';
+import { DeferredNumberInput } from '@/shared/components/DeferredNumberInput';
 import { useTranslation } from '@/i18n';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import { lazyWithRetry, namedExport } from '@/shared/utils/lazyWithRetry';
@@ -63,6 +67,13 @@ export function RightPanel() {
 
   // Use the print list hook
   const printList = usePrintList();
+
+  // Shared nozzle size — drives both the print-time estimate and connector scaling.
+  const nozzleSizeMm = useSettingsStore((s) => s.settings.printSettings.nozzleSizeMm);
+  const handleNozzleChange = useCallback((value: number) => {
+    const current = useSettingsStore.getState().settings.printSettings;
+    useSettingsStore.getState().updateSetting('printSettings', { ...current, nozzleSizeMm: value });
+  }, []);
 
   if (collapsed) {
     return (
@@ -511,6 +522,27 @@ export function RightPanel() {
                   )}
                 </div>
 
+                {printList.rows.length > 0 && (
+                  <div className="px-4 py-2 border-t border-stroke-subtle">
+                    <SettingsRow
+                      label={t('settings.nozzleSize')}
+                      htmlFor="rightPanelNozzle"
+                      tooltip={t('rightPanel.nozzleSizeTooltip')}
+                      unit="mm"
+                    >
+                      <DeferredNumberInput
+                        id="rightPanelNozzle"
+                        value={nozzleSizeMm}
+                        onChange={handleNozzleChange}
+                        min={PRINT_SETTINGS_CONSTRAINTS.NOZZLE_SIZE_MIN}
+                        max={PRINT_SETTINGS_CONSTRAINTS.NOZZLE_SIZE_MAX}
+                        step={PRINT_SETTINGS_CONSTRAINTS.NOZZLE_SIZE_STEP}
+                        className="input w-14 py-0.5 px-1 text-xs text-right"
+                        aria-label={t('settings.nozzleSize')}
+                      />
+                    </SettingsRow>
+                  </div>
+                )}
                 {printList.rows.length > 0 && (
                   <PrintListSummary
                     totalBins={printList.totalBins}


### PR DESCRIPTION
## What

Adds the nozzle-size input to the **desktop RightPanel** — the one surface left out of #2080. It lives in the **Bin List** section, between the piece table and the print-time/cost summary it affects.

## Why

#2080 made connectors, wall locks, and baseplate connectors scale with `nozzleSizeMm` and exposed that setting on the bin-designer, baseplate, and mobile dimensions surfaces. The desktop RightPanel was intentionally deferred; this closes that gap so the nozzle is editable from the main layout view too.

## Details

- Bound to the same shared `settings.printSettings.nozzleSizeMm` (editing anywhere updates everywhere — it's a printer property, not per-design).
- `usePrintList` already reads `printSettings` reactively, so editing the nozzle live-updates the print-time estimate; it also feeds the nozzle-aware connector scaling.
- Same `SettingsRow` + `DeferredNumberInput` pattern (0.2–1.0mm, 0.2 step) as the other surfaces.
- i18n tooltip across all 10 locales.

## Verification

- typecheck, lint, i18n all green; 46 RightPanel tests pass.
- Playwright visual check: added a bin, confirmed the "Nozzle size" input renders in the Bin List section (value 0.4mm) between the table and the print summary.