### PR TITLE
fix(export): watertight STL for scoop, magnet+feature, chamfer, and handle bins (#2085)

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`solid cutouts > 2×2 solid with 3×2 grid array of circles 1`] = `3420`;
 
-exports[`solid cutouts > 2×2 solid with chamfered + scooped rectangle cutout 1`] = `3564`;
+exports[`solid cutouts > 2×2 solid with chamfered + scooped rectangle cutout 1`] = `2904`;
 
 exports[`solid cutouts > 2×2 solid with chamfered circle cutout 1`] = `3044`;
 
@@ -10,7 +10,7 @@ exports[`solid cutouts > 2×2 solid with chamfered ellipse cutout 1`] = `3044`;
 
 exports[`solid cutouts > 2×2 solid with chamfered hexagon cutout 1`] = `2622`;
 
-exports[`solid cutouts > 2×2 solid with chamfered rectangle cutout 1`] = `2694`;
+exports[`solid cutouts > 2×2 solid with chamfered rectangle cutout 1`] = `2660`;
 
 exports[`solid cutouts > 2×2 solid with chamfered slot cutout 1`] = `2928`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.snap
@@ -32,11 +32,11 @@ exports[`solid cutouts > 2×2 solid with radial array (rotate-to-center) 1`] = `
 
 exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2552`;
 
-exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `3228`;
+exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `2624`;
 
-exports[`solid cutouts > 2×2 solid with rectangle, edge gate disables a single wall 1`] = `2846`;
+exports[`solid cutouts > 2×2 solid with rectangle, edge gate disables a single wall 1`] = `2612`;
 
-exports[`solid cutouts > 2×2 solid with rectangle, split scoop (W only) cuts only left/right walls 1`] = `2672`;
+exports[`solid cutouts > 2×2 solid with rectangle, split scoop (W only) cuts only left/right walls 1`] = `2616`;
 
 exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2564`;
 

--- a/src/features/generation/worker/generators/binGenerator.scenario.export-integrity.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.export-integrity.test.ts
@@ -82,20 +82,17 @@ function analyze(stl: ArrayBuffer, label: string): ManifoldStats {
 }
 
 /**
- * Scenarios whose exported STL is still non-manifold after the interior-void-
- * shell repair (`keepOuterShell`) and the scoop-fillet vertical-edge fix
- * (`findBottomEdges` now selects only flat bottom-plane edges, GH #2085). The
- * remainder split across distinct root causes — magnet/screw+feature combos
- * with an open/residually-non-manifold outer shell, the through-wall handle
- * cut, the entry-chamfer loft, and single-shell pinch edges where two solid
- * regions kiss along one edge (XOR, touching inserts). Un-skip each as its root
- * cause is fixed. Keyed by `${category} › ${name}`.
+ * Scenarios whose exported STL is still non-manifold after three GH #2085
+ * repairs: the interior-void-shell collapse (`keepOuterShell`), the scoop-fillet
+ * vertical-edge fix (`findBottomEdges` selects only flat bottom-plane edges), and
+ * the deferred-socket export fuse (the base socket is fused after features, so
+ * additive feature fuses run on the socket-less body — see shellStage). The
+ * remainder split across distinct root causes — the through-wall handle cut, the
+ * entry-chamfer loft, and single-shell pinch edges where two solid regions kiss
+ * along one edge (XOR, touching inserts). Un-skip each as its root cause is
+ * fixed. Keyed by `${category} › ${name}`.
  */
 const QUARANTINED_NON_MANIFOLD = new Set<string>([
-  'combined features › 4×4 magnet + label bracket + half-sockets',
-  'permutation matrix › 3×3 magnet+screw base + scoop + label + lip',
-  'permutation matrix › 4×4 magnet + compartments + scoop + label (mega)',
-  'regressions › #canary lip + scoop + compartments + magnet base + tall',
   'handles › oval shape handles on front wall',
   'multiple inserts › 2×2 with 2 circle inserts',
   'pathfinder › exclude group: XOR keeps non-overlapping regions',

--- a/src/features/generation/worker/generators/binGenerator.scenario.export-integrity.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.export-integrity.test.ts
@@ -83,11 +83,13 @@ function analyze(stl: ArrayBuffer, label: string): ManifoldStats {
 
 /**
  * Scenarios whose exported STL is still non-manifold after the interior-void-
- * shell repair (`keepOuterShell`). They split across three further root causes
- * — magnet/screw+feature combos with an open/residually-non-manifold outer
- * shell, the through-wall handle cut, and single-shell pinch edges (XOR,
- * touching inserts, solid-cutout scoops). Tracked in GH #2085; un-skip each as
- * its root cause is fixed. Keyed by `${category} › ${name}`.
+ * shell repair (`keepOuterShell`) and the scoop-fillet vertical-edge fix
+ * (`findBottomEdges` now selects only flat bottom-plane edges, GH #2085). The
+ * remainder split across distinct root causes — magnet/screw+feature combos
+ * with an open/residually-non-manifold outer shell, the through-wall handle
+ * cut, the entry-chamfer loft, and single-shell pinch edges where two solid
+ * regions kiss along one edge (XOR, touching inserts). Un-skip each as its root
+ * cause is fixed. Keyed by `${category} › ${name}`.
  */
 const QUARANTINED_NON_MANIFOLD = new Set<string>([
   'combined features › 4×4 magnet + label bracket + half-sockets',
@@ -97,9 +99,6 @@ const QUARANTINED_NON_MANIFOLD = new Set<string>([
   'handles › oval shape handles on front wall',
   'multiple inserts › 2×2 with 2 circle inserts',
   'pathfinder › exclude group: XOR keeps non-overlapping regions',
-  'solid cutouts › 2×2 solid with rectangle, edge gate disables a single wall',
-  'solid cutouts › 2×2 solid with rectangle with scoop cutout',
-  'solid+cutout matrix › solid + grouped cutouts with scoop at 45°',
   'solid cutouts › 2×2 solid with chamfered + scooped rectangle cutout',
 ]);
 

--- a/src/features/generation/worker/generators/binGenerator.scenario.export-integrity.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.export-integrity.test.ts
@@ -82,21 +82,22 @@ function analyze(stl: ArrayBuffer, label: string): ManifoldStats {
 }
 
 /**
- * Scenarios whose exported STL is still non-manifold after three GH #2085
- * repairs: the interior-void-shell collapse (`keepOuterShell`), the scoop-fillet
- * vertical-edge fix (`findBottomEdges` selects only flat bottom-plane edges), and
- * the deferred-socket export fuse (the base socket is fused after features, so
- * additive feature fuses run on the socket-less body — see shellStage). The
- * remainder split across distinct root causes — the through-wall handle cut, the
- * entry-chamfer loft, and single-shell pinch edges where two solid regions kiss
- * along one edge (XOR, touching inserts). Un-skip each as its root cause is
- * fixed. Keyed by `${category} › ${name}`.
+ * Scenarios whose exported STL is still non-manifold after the GH #2085 repairs
+ * (interior-void-shell collapse, the scoop-fillet flat-bottom-edge selector, the
+ * sharp-corner chamfer profile, and the deferred-socket export fuse — see
+ * `keepOuterShell`, `findBottomEdges`, `cutoutProfileDrawing`, and shellStage).
+ *
+ * The two left are not boolean artifacts but a genuine geometry pathology: two
+ * cavity cuts placed exactly tangent leave a zero-thickness knife-edge pinch in
+ * the wall between them (a single non-manifold edge along the contact line). A
+ * watertight mesh can't represent a measure-zero contact, so these can only be
+ * made manifold by perturbing the design (overlapping or separating the
+ * cavities) — a product decision, not a generation bug. Keyed by
+ * `${category} › ${name}`.
  */
 const QUARANTINED_NON_MANIFOLD = new Set<string>([
-  'handles › oval shape handles on front wall',
   'multiple inserts › 2×2 with 2 circle inserts',
   'pathfinder › exclude group: XOR keeps non-overlapping regions',
-  'solid cutouts › 2×2 solid with chamfered + scooped rectangle cutout',
 ]);
 
 describe('export integrity: full scenario matrix → binary STL', () => {

--- a/src/features/generation/worker/generators/cutoutBuilder.test.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.test.ts
@@ -28,7 +28,9 @@ describe('findBottomEdges', () => {
       expect(edges.length).toBe(4);
       for (const e of edges) {
         const b = getBounds(e);
-        // Every selected edge lies in the z≈0 plane — no vertical edge leaks in.
+        // Every selected edge lies fully in the z≈0 plane — no vertical edge
+        // (which spans up to the top) leaks in, in either direction.
+        expect(b.zMin).toBeGreaterThanOrEqual(-0.1);
         expect(b.zMax).toBeLessThanOrEqual(0.1);
       }
     } finally {

--- a/src/features/generation/worker/generators/cutoutBuilder.test.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment node
+/**
+ * Real-kernel tests for `findBottomEdges` — the scoop-fillet edge selector.
+ *
+ * Regression for GH #2085: the selector must return only edges that lie flat in
+ * the bottom plane, never a box's vertical corner edges. Filleting a vertical
+ * edge rounds the cutout corner all the way to the top rim and leaves a
+ * degenerate single-face sliver there, which exports as a non-manifold STL edge.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { box, getBounds } from 'brepjs';
+import { findBottomEdges } from './cutoutBuilder';
+
+beforeAll(async () => {
+  const { initBrepjs } = await import('./__kernel-tests__/wasmInit');
+  await initBrepjs();
+}, 60_000);
+
+describe('findBottomEdges', () => {
+  it('selects only the flat bottom edges, excluding vertical corner edges', () => {
+    // 20×20×10 box centered so its bottom face sits at z=0.
+    const solid = box(20, 20, 10, { at: [0, 0, 5] });
+    try {
+      const edges = findBottomEdges(solid, 0, { minX: -10, minY: -10, maxX: 10, maxY: 10 });
+
+      // A sharp box has exactly four bottom edges; the four verticals (zMax=10)
+      // and four top edges (zMin=10) must be excluded.
+      expect(edges.length).toBe(4);
+      for (const e of edges) {
+        const b = getBounds(e);
+        // Every selected edge lies in the z≈0 plane — no vertical edge leaks in.
+        expect(b.zMax).toBeLessThanOrEqual(0.1);
+      }
+    } finally {
+      solid.delete();
+    }
+  }, 60_000);
+});

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -128,9 +128,18 @@ function cutoutProfileDrawing(p: {
       return drawRoundedRectangle(p.w, p.d, Math.max(0.01, slotCornerRadius(p.w, p.d) - 0.01));
     case 'rectangle':
     default: {
+      // Sharp corners when no radius is requested. A 0.01mm "rounded" corner is
+      // a near-degenerate arc; lofting it leaves a pinched corner seam that a
+      // later scoop fillet corrupts into open sliver faces at the flared rim
+      // (GH #2085). A true four-line rectangle gives the loft clean corner edges
+      // the fillet blends cleanly, exactly like the non-chamfered box path.
+      if (p.cornerRadius <= 0) {
+        const hw = p.w / 2;
+        const hd = p.d / 2;
+        return draw([-hw, -hd]).lineTo([hw, -hd]).lineTo([hw, hd]).lineTo([-hw, hd]).close();
+      }
       const maxCR = Math.min(p.w, p.d) / 2 - 0.01;
-      const r = p.cornerRadius > 0 ? Math.min(p.cornerRadius, maxCR) : 0.01;
-      return drawRoundedRectangle(p.w, p.d, Math.max(0.01, r));
+      return drawRoundedRectangle(p.w, p.d, Math.min(p.cornerRadius, maxCR));
     }
   }
 }

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -423,7 +423,20 @@ function polylineSelfIntersects(poly: readonly { x: number; y: number }[]): bool
   }
   return false;
 }
-/** Find edges near a target Z height within XY bounds, with tolerance margins. */
+/**
+ * Find the bottom-plane edges within XY bounds — the edges a scoop fillet should
+ * round.
+ *
+ * Selects edges that lie *flat* in the z≈zTarget plane (the cutout floor), not
+ * merely edges that touch it. A box's four vertical corner edges have
+ * `zMin = zTarget` but span the full cut depth; the older "z range overlaps
+ * zTarget" test picked them up, so the scoop fillet rounded the corners all the
+ * way to the top rim. That left a degenerate sliver face where the rounded
+ * vertical surface met the sharp top edges — an open (single-face) edge that
+ * survives as a non-manifold edge in the exported STL (GH #2085). Requiring the
+ * whole edge to sit in the bottom plane keeps verticals sharp and scoops only
+ * the floor ring, as intended.
+ */
 export function findBottomEdges(
   shape: Shape3D,
   zTarget: number,
@@ -433,12 +446,12 @@ export function findBottomEdges(
   return edgeFinder()
     .when((e) => {
       const bounds = getBounds(e);
-      const zOverlaps = bounds.zMin <= zTarget + 0.1 && bounds.zMax >= zTarget - 0.1;
+      const inBottomPlane = bounds.zMin >= zTarget - 0.1 && bounds.zMax <= zTarget + 0.1;
       const xOverlaps =
         bounds.xMax >= xyBounds.minX - margin && bounds.xMin <= xyBounds.maxX + margin;
       const yOverlaps =
         bounds.yMax >= xyBounds.minY - margin && bounds.yMin <= xyBounds.maxY + margin;
-      return zOverlaps && xOverlaps && yOverlaps;
+      return inBottomPlane && xOverlaps && yOverlaps;
     })
     .findAll(shape);
 }

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -2,12 +2,14 @@
  * Shell stage — assembles the bin body (box + stacking lip) and the base socket.
  *
  * The BODY (box + lip) is cached by shellKey and is what features cut. The base
- * socket is built separately (its own cache). On the PREVIEW path the socket is
- * left OUT of `solid` and carried in `deferredSolid` — the expensive socket↔body
- * fuse (≈80% of cold-shell time) is skipped; the tessellate stage meshes the two
- * and concatenates them, which is visually identical because the socket is never
- * feature-cut and only meets the body at a hidden internal interface. On the
- * EXPORT path the socket is fused into `solid` for a watertight model.
+ * socket is built separately (its own cache) and left OUT of `solid` on BOTH
+ * paths — carried in `deferredSolid` so feature fuses/cuts run on the simpler
+ * socket-less body. The tessellate stage then resolves it: PREVIEW meshes the
+ * body and socket separately and concatenates (skips the ≈80%-of-cold-shell
+ * socket↔body fuse), while EXPORT fuses the socket into the featured body for a
+ * single watertight solid. Deferring past features — not just past the body —
+ * also keeps additive feature fuses off the socket-laden body, which otherwise
+ * went non-manifold (GH #2085); see the socket-deferral note below.
  */
 
 import { unwrap, fuse, translate, withScope, getKernelCapabilities } from 'brepjs';
@@ -23,12 +25,7 @@ import {
   buildCompartmentCavityDrawings,
   buildCompartmentsCacheKey,
 } from '../../compartmentBuilder';
-import {
-  getShellCache,
-  setShellCache,
-  getExportShellCache,
-  setExportShellCache,
-} from '../../shapeCache';
+import { getShellCache, setShellCache } from '../../shapeCache';
 import { LIP_OVERLAP } from '../../generatorConstants';
 import { FeatureTag } from '../../featureTags';
 import { collectOrigins } from '../collectOrigins';
@@ -42,16 +39,7 @@ export const shellStage: PipelineStage = {
   },
 
   execute(ctx: PipelineContext): PipelineContext {
-    const { params, dimensions: dim, signal, onProgress, originToTag, forExport } = ctx;
-
-    // Export fast path: the fused body+socket shell was built by a previous
-    // export or the idle warm — skip building/fusing entirely.
-    if (forExport && !dim.isFlat) {
-      const cachedExport = getExportShellCache(dim.shellKey);
-      if (cachedExport) {
-        return { ...ctx, solid: cachedExport, deferredSolid: null };
-      }
-    }
+    const { params, dimensions: dim, signal, onProgress, originToTag } = ctx;
 
     // ── BODY (box + optional lip) — cached by shellKey. ──────────────────────
     // `getShellCache` returns a metadata-preserving clone so BASE/LIP face-origin
@@ -197,21 +185,18 @@ export const shellStage: PipelineStage = {
       }
       collectOrigins(socket, FeatureTag.SOCKET, originToTag);
 
-      if (forExport) {
-        // Watertight: fuse the socket into the body for a single solid, and
-        // cache it so re-exports and the idle warm skip this fuse next time.
-        const full = unwrap(fuse(body, socket));
-        // Cache + clone BEFORE deleting the inputs: if `translate` throws, the
-        // catch must not double-delete already-freed body/socket handles, and
-        // `full` is already owned by the cache (not leaked).
-        setExportShellCache(dim.shellKey, full);
-        const cloned = translate(full, [0, 0, 0]);
-        body.delete();
-        socket.delete();
-        return { ...ctx, solid: cloned, deferredSolid: null };
-      }
-
-      // Preview: defer the socket fuse — tessellate stage meshes + concatenates.
+      // Defer the socket on BOTH paths. Preview meshes it separately (skips the
+      // fuse); export fuses it in at the tessellate stage, AFTER features.
+      //
+      // Fusing the socket here (before features) made additive feature fuses —
+      // the label-bracket especially — go non-manifold: OCCT's fuse of the
+      // bracket onto a socket-laden body left T-junction (faces=3) edges far
+      // from the interface, so the exported STL was not watertight (GH #2085).
+      // The same bracket fuses cleanly onto the socket-less body, so deferring
+      // the socket to last keeps every feature fuse on a simpler solid and the
+      // final socket fuse (onto the featured body) stays manifold. The socket is
+      // never feature-cut — it only meets the body at the hidden floor interface
+      // — so order is geometrically equivalent, just numerically robust.
       return { ...ctx, solid: body, deferredSolid: socket };
     } catch (e: unknown) {
       socket.delete();

--- a/src/features/generation/worker/generators/pipeline/stages/tessellateStage.test.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/tessellateStage.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment node
+/**
+ * Real-kernel regression for the deferred-socket export fuse (GH #2085).
+ *
+ * The base socket is fused into the body at the tessellate stage, AFTER feature
+ * fuses, so additive features (the label bracket especially) fuse onto the
+ * socket-less body. Fusing the socket first made the bracket fuse emit
+ * non-manifold T-junction edges, so the exported STL was not watertight. These
+ * combos (magnet base + label bracket, magnet + floor features) must now export
+ * as a single watertight shell.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { isOk } from '@/core/result';
+import { parseSTLBinary } from '@/shared/generation/stlParser';
+import { buildParams } from '../../__kernel-tests__/scenarioTypes';
+import { setLastSolid, getLastSolid } from '../../shapeCache';
+import { exportSolidToStl } from '../../utils/stlMeshFallback';
+import { EXPORT_ANGULAR_TOLERANCE, EXPORT_TOLERANCE } from '../../utils/tolerances';
+import type { BinParams } from '@/shared/types/bin';
+import type * as BinOrchestratorModule from '../../binOrchestrator';
+
+let generateBin: typeof BinOrchestratorModule.generateBin;
+
+beforeAll(async () => {
+  const { initBrepjs } = await import('../../__kernel-tests__/wasmInit');
+  await initBrepjs();
+  generateBin = (await import('../../binOrchestrator')).generateBin;
+}, 60_000);
+
+/** Count STL edges shared by >2 triangles (non-manifold) and by exactly 1 (boundary). */
+async function exportDefects(
+  overrides: Partial<BinParams>
+): Promise<{ nonManifold: number; boundary: number; triangles: number }> {
+  setLastSolid(null);
+  generateBin(buildParams(overrides), undefined, true);
+  const solid = getLastSolid();
+  if (!solid) throw new Error('no solid');
+  const data = await exportSolidToStl(solid, 'x', EXPORT_TOLERANCE, EXPORT_ANGULAR_TOLERANCE);
+  const parsed = parseSTLBinary(data);
+  if (!isOk(parsed)) throw new Error('STL parse failed');
+  const { vertices } = parsed.value;
+  const triangles = vertices.length / 9;
+  const Q = 1e4;
+  const vKey = (x: number, y: number, z: number): string =>
+    `${Math.round(x * Q)},${Math.round(y * Q)},${Math.round(z * Q)}`;
+  const eKey = (a: string, b: string): string => (a < b ? `${a}|${b}` : `${b}|${a}`);
+  const edgeCount = new Map<string, number>();
+  for (let t = 0; t < triangles; t++) {
+    const o = t * 9;
+    const keys = [
+      vKey(vertices[o], vertices[o + 1], vertices[o + 2]),
+      vKey(vertices[o + 3], vertices[o + 4], vertices[o + 5]),
+      vKey(vertices[o + 6], vertices[o + 7], vertices[o + 8]),
+    ];
+    for (let i = 0; i < 3; i++) {
+      const k = eKey(keys[i], keys[(i + 1) % 3]);
+      edgeCount.set(k, (edgeCount.get(k) ?? 0) + 1);
+    }
+  }
+  let nonManifold = 0;
+  let boundary = 0;
+  for (const c of edgeCount.values()) {
+    if (c > 2) nonManifold++;
+    else if (c === 1) boundary++;
+  }
+  return { nonManifold, boundary, triangles };
+}
+
+const magnet = { ...DEFAULT_BIN_PARAMS.base, style: 'magnet' as const, stackingLip: false };
+const bracket = { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket' as const };
+
+describe('deferred-socket export fuse → watertight', () => {
+  it('magnet base + label bracket exports watertight', async () => {
+    const d = await exportDefects({ width: 2, depth: 2, base: magnet, label: bracket });
+    expect(d.triangles).toBeGreaterThan(0);
+    expect(d.nonManifold).toBe(0);
+    expect(d.boundary).toBe(0);
+  }, 60_000);
+
+  it('magnet base alone stays watertight (no regression)', async () => {
+    const d = await exportDefects({ width: 2, depth: 2, base: magnet });
+    expect(d.nonManifold).toBe(0);
+    expect(d.boundary).toBe(0);
+  }, 60_000);
+});

--- a/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
@@ -8,7 +8,7 @@
  * tessellation cost. Enable by setting coarseMesh in the return value.
  */
 
-import { mesh, meshEdges, getKernelCapabilities } from 'brepjs';
+import { mesh, meshEdges, getKernelCapabilities, unwrap, fuse } from 'brepjs';
 import type { PipelineContext, PipelineStage } from '../types';
 import { toIndexedMeshData, mergeShapeMeshes, concatFloat32 } from '../../utils/mesh';
 import { creaseEdges } from '../../utils';
@@ -25,8 +25,28 @@ export const tessellateStage: PipelineStage = {
   },
 
   execute(ctx: PipelineContext): PipelineContext {
-    const { solid: rawSolid, dimensions: dim, forExport } = ctx;
+    let rawSolid = ctx.solid;
+    const { dimensions: dim, forExport } = ctx;
     if (!rawSolid) return ctx;
+
+    // EXPORT: fuse the deferred base socket into the featured body for a single
+    // watertight solid. The socket is deferred past the feature stage (see
+    // shellStage) so feature fuses run on the socket-less body — fusing it
+    // earlier made additive features like the label bracket non-manifold
+    // (GH #2085). On failure, leave the socket deferred so the separate-mesh
+    // path below still produces a complete (if seam-split) export rather than
+    // throwing. PREVIEW keeps the socket deferred and meshes it separately.
+    if (forExport && ctx.deferredSolid) {
+      try {
+        const fused = unwrap(fuse(rawSolid, ctx.deferredSolid));
+        rawSolid.delete();
+        ctx.deferredSolid.delete();
+        rawSolid = fused;
+        ctx = { ...ctx, solid: fused, deferredSolid: null };
+      } catch {
+        // Fuse failed — fall through with the socket still deferred.
+      }
+    }
 
     // Additive feature fuses can leave interior void shells inside an otherwise
     // valid export solid; STL tessellates them as doubled (non-manifold) faces.
@@ -56,10 +76,11 @@ export const tessellateStage: PipelineStage = {
       ? creaseEdges(shapeMesh)
       : meshEdges(solid, { tolerance, angularTolerance: edgeAngular }).lines;
 
-    // Preview path: the base socket is kept out of `solid` to skip the
-    // expensive socket↔body fuse. Tessellate it separately and concatenate —
-    // the socket is never feature-cut and only meets the body at a hidden
-    // interface, so the merged mesh is visually identical to the fused shell.
+    // Socket still deferred — the preview path (which skips the expensive
+    // socket↔body fuse) or an export whose fuse failed above. Tessellate it
+    // separately and concatenate: the socket is never feature-cut and only
+    // meets the body at a hidden interface, so the merged mesh is visually
+    // identical to the fused shell (though not watertight at the seam).
     const { deferredSolid } = ctx;
     if (deferredSolid) {
       try {

--- a/src/features/generation/worker/generators/shapeCache.ts
+++ b/src/features/generation/worker/generators/shapeCache.ts
@@ -59,10 +59,6 @@ const socketCache = new LRUCache<Shape3D>('socket', 20, disposeShape);
 const lipCache = new LRUCache<Shape3D>('lip', 20, disposeShape);
 const boxCache = new LRUCache<Shape3D>('box', 20, disposeShape);
 const shellCache = new LRUCache<Shape3D>('shell', 15, disposeShape);
-// Fused full shell (body + base socket) at export quality. Populated lazily on
-// export and proactively by the idle warm, so exports skip the socket↔body fuse
-// that the preview path defers. Keyed by the same shellKey as the body.
-const exportShellCache = new LRUCache<Shape3D>('exportShell', 8, disposeShape);
 
 const socket = createCloningAccessors(socketCache);
 const box = createCloningAccessors(boxCache);
@@ -94,14 +90,8 @@ function getOrCreateFeatureCache(name: string): LRUCache<Shape3D> {
   return cache;
 }
 
-/** Static LRU caches (socket, lip, box, shell, exportShell). */
-const staticLruCaches: readonly LRUCache<Shape3D>[] = [
-  socketCache,
-  lipCache,
-  boxCache,
-  shellCache,
-  exportShellCache,
-];
+/** Static LRU caches (socket, lip, box, shell). */
+const staticLruCaches: readonly LRUCache<Shape3D>[] = [socketCache, lipCache, boxCache, shellCache];
 
 export function socketCacheKey(
   gridW: number,
@@ -154,21 +144,6 @@ export function getShellCache(key: string): Shape3D | null {
 
 export function setShellCache(key: string, shape: Shape3D): void {
   shellCache.set(key, shape);
-}
-
-/** Fused export-quality shell (body + socket). Metadata-preserving clone on hit. */
-export function getExportShellCache(key: string): Shape3D | null {
-  const cached = exportShellCache.get(key);
-  if (cached === undefined) return null;
-  return translate(cached, [0, 0, 0]);
-}
-
-export function setExportShellCache(key: string, shape: Shape3D): void {
-  exportShellCache.set(key, shape);
-}
-
-export function hasExportShellCache(key: string): boolean {
-  return exportShellCache.get(key) !== undefined;
 }
 
 /** Returns raw shape (no clone) — caller uses transformCopy which is non-destructive. */


### PR DESCRIPTION
Four independent root-cause fixes from the #2085 quarantine. Together they take the export-integrity matrix from **346 → 352 passing** (11 → 2 skipped), with no regressions across the full scenario suite (831 passed).

---

## 1. Scoop-cutout corner cracks (3)
`findBottomEdges` selected a box's vertical corner edges (their `zMin` sits at the floor), so the scoop fillet rounded the corners the full height and left single-face slivers where the rounded surface met the sharp top rim. Fix: require the whole edge to lie in the bottom plane.

## 2. Magnet/screw + feature bins (4)
The base socket was fused into the body **before** features. Fusing additive features (label bracket, scoop, compartments) onto the socket-laden body made OCCT emit hundreds–thousands of non-manifold T-junctions. Fix: **defer the socket fuse past the feature stage** — features fuse onto the socket-less body; the socket is fused in last at the tessellate stage. The socket is never feature-cut, so the order is geometrically equivalent. Triangle counts preserved (vs `fuseAllBisect`, which reaches watertightness by filling the magnet holes — rejected).

## 3. Through-wall handle (1)
Fixed for free by #2 — the handle cut now runs on the socket-less body, so the 10-shell open boundary collapses to one watertight shell.

## 4. Chamfer + scoop (1)
The entry-chamfer loft built its rectangle profile with a 0.01mm "rounded" corner; that near-degenerate arc lofts into a pinched seam that the scoop fillet corrupts into open slivers at the flared rim. Fix: a true four-line sharp rectangle when no radius is requested, giving the loft clean corner edges (like the non-chamfered box path).

---

## Still quarantined (2 — a geometry pathology, not a bug)
`2×2 with 2 circle inserts` and `XOR keeps non-overlapping regions`: two cavity cuts placed exactly tangent leave a zero-thickness knife-edge pinch in the wall between them. A watertight mesh can't represent a measure-zero contact, so these can only be made manifold by perturbing the design (overlapping or separating the cavities) — a product decision. Left skipped with an explanatory note.

## Verification
- Export-integrity matrix: **352 passed / 2 skipped**, no regressions
- Full scenario suite: **831 passed / 2 skipped**, snapshots updated only for the directly-affected scoop/chamfer cutouts (counts dropped — the removed triangles are the spurious doubled/sliver faces)
- New `tessellateStage.test.ts` (magnet+bracket → watertight) and `cutoutBuilder.test.ts` (bottom-edge selector)
- typecheck + lint + knip clean

Refs #2085