### PR TITLE
feat(shell): display app version number in sidebar and mobile footer

### DIFF
--- a/scripts/i18n-values-allowlist.json
+++ b/scripts/i18n-values-allowlist.json
@@ -142,6 +142,7 @@
     "sidebar.appName",
     "sidebar.github",
     "sidebar.privacy",
+    "sidebar.version",
     "feedback.cancel",
     "feedback.categoryBug",
     "feedback.categoryFeature",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1933,6 +1933,7 @@
   "share.toast.permissionUpdated": "Berechtigung geändert auf \"{label}\"",
   "share.useShareLinkInstead": "Stattdessen Teilen-Link verwenden",
   "sidebar.appName": "Gridfinity Layout Tool",
+  "sidebar.version": "v{version}",
   "sidebar.bottom": "Unten",
   "sidebar.collapseLeftPanel": "Linkes Panel einklappen",
   "sidebar.collapsePanel": "Panel einklappen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -243,6 +243,7 @@ const en: Record<string, string> = {
   'sidebar.tip': 'Tip',
   'sidebar.github': 'GitHub',
   'sidebar.appName': 'Gridfinity Layout Tool',
+  'sidebar.version': 'v{version}',
   'sidebar.privacy': 'Privacy',
   'sidebar.terms': 'Terms',
   'sidebar.toggleHalfBinMode': 'Toggle half-grid mode',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1933,6 +1933,7 @@
   "share.toast.permissionUpdated": "Permiso actualizado a \"{label}\"",
   "share.useShareLinkInstead": "Usar enlace de compartir en su lugar",
   "sidebar.appName": "Gridfinity Layout Tool",
+  "sidebar.version": "v{version}",
   "sidebar.bottom": "Inferior",
   "sidebar.collapseLeftPanel": "Contraer panel izquierdo",
   "sidebar.collapsePanel": "Contraer panel",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1933,6 +1933,7 @@
   "share.toast.permissionUpdated": "Autorisation modifiée en \"{label}\"",
   "share.useShareLinkInstead": "Utiliser le lien de partage à la place",
   "sidebar.appName": "Gridfinity Layout Tool",
+  "sidebar.version": "v{version}",
   "sidebar.bottom": "Bas",
   "sidebar.collapseLeftPanel": "Réduire le panneau gauche",
   "sidebar.collapsePanel": "Réduire le panneau",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1933,6 +1933,7 @@
   "share.toast.permissionUpdated": "権限を「{label}」に更新しました",
   "share.useShareLinkInstead": "代わりに共有リンクを使用",
   "sidebar.appName": "Gridfinity Layout Tool",
+  "sidebar.version": "v{version}",
   "sidebar.bottom": "下",
   "sidebar.collapseLeftPanel": "左パネルを折りたたむ",
   "sidebar.collapsePanel": "パネルを折りたたむ",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1933,6 +1933,7 @@
   "share.toast.permissionUpdated": "Tilgang oppdatert til \"{label}\"",
   "share.useShareLinkInstead": "Bruk delingslenke i stedet",
   "sidebar.appName": "Gridfinity Layout Tool",
+  "sidebar.version": "v{version}",
   "sidebar.bottom": "Bunn",
   "sidebar.collapseLeftPanel": "Skjul venstre panel",
   "sidebar.collapsePanel": "Skjul panel",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1933,6 +1933,7 @@
   "share.toast.permissionUpdated": "Rechten bijgewerkt naar \"{label}\"",
   "share.useShareLinkInstead": "In plaats daarvan deellink gebruiken",
   "sidebar.appName": "Gridfinity Layout Tool",
+  "sidebar.version": "v{version}",
   "sidebar.bottom": "Onder",
   "sidebar.collapseLeftPanel": "Linker paneel invouwen",
   "sidebar.collapsePanel": "Paneel invouwen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1933,6 +1933,7 @@
   "share.toast.permissionUpdated": "Permissão atualizada para \"{label}\"",
   "share.useShareLinkInstead": "Usar link de compartilhamento",
   "sidebar.appName": "Gridfinity Layout Tool",
+  "sidebar.version": "v{version}",
   "sidebar.bottom": "Embaixo",
   "sidebar.collapseLeftPanel": "Recolher painel esquerdo",
   "sidebar.collapsePanel": "Recolher painel",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1933,6 +1933,7 @@
   "share.toast.permissionUpdated": "Behörighet uppdaterad till \"{label}\"",
   "share.useShareLinkInstead": "Använd delningslänk istället",
   "sidebar.appName": "Gridfinity Layout Tool",
+  "sidebar.version": "v{version}",
   "sidebar.bottom": "Nederkant",
   "sidebar.collapseLeftPanel": "Komprimera vänster panel",
   "sidebar.collapsePanel": "Komprimera panel",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1933,6 +1933,7 @@
   "share.toast.permissionUpdated": "Дозвіл оновлено на \"{label}\"",
   "share.useShareLinkInstead": "Скористайтесь натомість посиланням",
   "sidebar.appName": "Gridfinity Layout Tool",
+  "sidebar.version": "v{version}",
   "sidebar.bottom": "Низ",
   "sidebar.collapseLeftPanel": "Згорнути ліву панель",
   "sidebar.collapsePanel": "Згорнути панель",

--- a/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
+++ b/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
@@ -296,6 +296,19 @@ export function MobileSettingsPanel() {
 
       {/* Info */}
       <section className="pt-4 text-center border-t border-stroke-subtle">
+        <div className="flex items-baseline justify-center gap-1.5 mb-2">
+          <span className="text-xs font-semibold text-content-secondary">
+            {t('sidebar.appName')}
+          </span>
+          <a
+            href={`https://github.com/andymai/gridfinity-layout-tool/releases/tag/v${__APP_VERSION__}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[10px] text-content-disabled hover:text-content-tertiary hover:underline"
+          >
+            {t('sidebar.version', { version: __APP_VERSION__ })}
+          </a>
+        </div>
         <div className="text-xs text-content-disabled leading-relaxed">
           <a
             href="https://www.youtube.com/c/ZackFreedman"

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -577,8 +577,16 @@ export function Sidebar() {
 
             {/* Attribution */}
             <div className="px-4 py-4 border-t border-stroke-subtle text-content-disabled text-[10px] leading-relaxed">
-              <div className="text-content-secondary text-[11px] font-semibold mb-1">
+              <div className="text-content-secondary text-[11px] font-semibold mb-1 flex items-baseline gap-1.5">
                 {t('sidebar.appName')}
+                <a
+                  href={`https://github.com/andymai/gridfinity-layout-tool/releases/tag/v${__APP_VERSION__}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[10px] font-normal text-content-disabled hover:text-content-tertiary hover:underline"
+                >
+                  {t('sidebar.version', { version: __APP_VERSION__ })}
+                </a>
               </div>
               {t('sidebar.gridfinityBy')}{' '}
               <a


### PR DESCRIPTION
## Summary

- Adds `v{version}` badge inline with the "Gridfinity Layout Tool" heading in the desktop sidebar attribution block
- Adds an app name + version heading above the attribution text in the mobile settings panel footer
- Version badge links to the corresponding GitHub Releases tag for that version
- `sidebar.version` i18n key added to all 10 locales and the values allowlist (version format is universal)

Closes #2087

## Test plan

- [ ] Open the app on desktop — check sidebar footer shows e.g. `Gridfinity Layout Tool  v4.155.0`
- [ ] Click the version badge — should open the GitHub Releases page for that tag
- [ ] Open the mobile settings panel — check the same version heading appears above the attribution text
- [ ] Verify TypeScript passes (`pnpm run typecheck`) and all i18n checks pass (enforced by pre-commit hooks)