### PR TITLE
feat(shell): unify attribution footer across layout, bin designer, and baseplate

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -28,6 +28,7 @@ import { PrintBedInput } from '@/shared/components/PrintBedInput';
 import { FeatureToggle } from '@/shared/components/FeatureToggle';
 import { SliderInput } from '@/shared/components/SliderInput';
 import { UserDock } from '@/shared/components/UserDock';
+import { AttributionFooter } from '@/shared/components/AttributionFooter/AttributionFooter';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { HelpTargetMarker } from '@/shared/help/HelpTargetMarker';
 import { helpJumpEventName } from '@/shared/help/helpJumpDispatcher';
@@ -523,6 +524,7 @@ export function BaseplatePanel() {
           />
         )}
       </div>
+      <AttributionFooter />
       {cloudSyncEnabled && <UserDock />}
     </div>
   );

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -28,7 +28,7 @@ import { PrintBedInput } from '@/shared/components/PrintBedInput';
 import { FeatureToggle } from '@/shared/components/FeatureToggle';
 import { SliderInput } from '@/shared/components/SliderInput';
 import { UserDock } from '@/shared/components/UserDock';
-import { AttributionFooter } from '@/shared/components/AttributionFooter/AttributionFooter';
+import { AttributionFooter } from '@/shared/components/AttributionFooter';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { HelpTargetMarker } from '@/shared/help/HelpTargetMarker';
 import { helpJumpEventName } from '@/shared/help/helpJumpDispatcher';

--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
@@ -36,6 +36,7 @@ import { useSplitOptionsSection } from '../panel/SplitOptionsSection/useSplitOpt
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { isPartialMask } from '@/shared/utils/cellMask';
 import { UserDock } from '@/shared/components/UserDock';
+import { AttributionFooter } from '@/shared/components/AttributionFooter/AttributionFooter';
 import { helpJumpEventName } from '@/shared/help/helpJumpDispatcher';
 
 export function ParameterPanel() {
@@ -220,44 +221,7 @@ export function ParameterPanel() {
           </button>
         </div>
 
-        {/* Attribution */}
-        <div className="px-4 py-4 text-content-disabled text-[10px] leading-relaxed">
-          {t('sidebar.gridfinityBy')}{' '}
-          <a
-            href="https://www.youtube.com/c/ZackFreedman"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-content-tertiary hover:underline"
-          >
-            Zack Freedman
-          </a>
-          <br />
-          {t('sidebar.toolBy')}{' '}
-          <a
-            href="https://www.linkedin.com/in/andyhmai/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-content-tertiary hover:underline"
-          >
-            Andy Aragon
-          </a>{' '}
-          ·{' '}
-          <a
-            href="https://ko-fi.com/andyaragon"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent hover:underline"
-          >
-            <svg
-              className="w-3 h-3 inline-block align-text-bottom mr-0.5"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-            </svg>
-            {t('sidebar.tip')}
-          </a>
-        </div>
+        <AttributionFooter />
       </div>
       {cloudSyncEnabled && <UserDock />}
     </div>

--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
@@ -36,7 +36,7 @@ import { useSplitOptionsSection } from '../panel/SplitOptionsSection/useSplitOpt
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { isPartialMask } from '@/shared/utils/cellMask';
 import { UserDock } from '@/shared/components/UserDock';
-import { AttributionFooter } from '@/shared/components/AttributionFooter/AttributionFooter';
+import { AttributionFooter } from '@/shared/components/AttributionFooter';
 import { helpJumpEventName } from '@/shared/help/helpJumpDispatcher';
 
 export function ParameterPanel() {

--- a/src/shared/components/AttributionFooter/AttributionFooter.test.tsx
+++ b/src/shared/components/AttributionFooter/AttributionFooter.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AttributionFooter } from './AttributionFooter';
+
+describe('AttributionFooter', () => {
+  it('renders app name and version link', () => {
+    render(<AttributionFooter />);
+    expect(screen.getByText('Gridfinity Layout Tool')).toBeInTheDocument();
+    const versionLink = screen.getByRole('link', { name: /v\d+\.\d+\.\d+/ });
+    expect(versionLink).toHaveAttribute('href', expect.stringContaining('releases/tag/'));
+  });
+
+  it('renders attribution links', () => {
+    render(<AttributionFooter />);
+    expect(screen.getByRole('link', { name: /Zack Freedman/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Andy Aragon/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /GitHub/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Privacy/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Terms/ })).toBeInTheDocument();
+  });
+
+  it('opens all external links in a new tab', () => {
+    render(<AttributionFooter />);
+    const externalLinks = screen.getAllByRole('link');
+    externalLinks.forEach((link) => {
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+  });
+});

--- a/src/shared/components/AttributionFooter/AttributionFooter.tsx
+++ b/src/shared/components/AttributionFooter/AttributionFooter.tsx
@@ -1,0 +1,85 @@
+import { ICON_PATHS } from '@/shared/constants/iconPaths';
+import { useTranslation } from '@/i18n';
+
+export function AttributionFooter() {
+  const t = useTranslation();
+  return (
+    <div className="px-4 py-4 border-t border-stroke-subtle text-content-disabled text-[10px] leading-relaxed">
+      <div className="text-content-secondary text-[11px] font-semibold mb-1 flex items-baseline gap-1.5">
+        {t('sidebar.appName')}
+        <a
+          href={`https://github.com/andymai/gridfinity-layout-tool/releases/tag/v${__APP_VERSION__}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[10px] font-normal text-content-disabled hover:text-content-tertiary hover:underline"
+        >
+          {t('sidebar.version', { version: __APP_VERSION__ })}
+        </a>
+      </div>
+      {t('sidebar.gridfinityBy')}{' '}
+      <a
+        href="https://www.youtube.com/c/ZackFreedman"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-content-tertiary hover:underline"
+      >
+        Zack Freedman
+      </a>
+      <br />
+      {t('sidebar.toolBy')}{' '}
+      <a
+        href="https://www.linkedin.com/in/andyhmai/"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-content-tertiary hover:underline"
+      >
+        Andy Aragon
+      </a>{' '}
+      ·{' '}
+      <a
+        href="https://ko-fi.com/andyaragon"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-accent hover:underline"
+      >
+        <svg
+          className="w-3 h-3 inline-block align-text-bottom mr-0.5"
+          fill="currentColor"
+          viewBox="0 0 24 24"
+        >
+          {ICON_PATHS.heart.map((d) => (
+            <path key={d} d={d} />
+          ))}
+        </svg>
+        {t('sidebar.tip')}
+      </a>{' '}
+      ·{' '}
+      <a
+        href="https://github.com/andymai/gridfinity-layout-tool"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-content-tertiary hover:underline"
+      >
+        {t('sidebar.github')}
+      </a>{' '}
+      ·{' '}
+      <a
+        href="/privacy"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-content-tertiary hover:underline"
+      >
+        {t('sidebar.privacy')}
+      </a>{' '}
+      ·{' '}
+      <a
+        href="/terms"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-content-tertiary hover:underline"
+      >
+        {t('sidebar.terms')}
+      </a>
+    </div>
+  );
+}

--- a/src/shared/components/AttributionFooter/index.ts
+++ b/src/shared/components/AttributionFooter/index.ts
@@ -1,0 +1,1 @@
+export { AttributionFooter } from './AttributionFooter';

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -1,6 +1,7 @@
 // Shared UI Components
 // Reusable UI primitives with no domain coupling
 
+export { AttributionFooter } from './AttributionFooter/AttributionFooter';
 export { Checkbox } from './Checkbox';
 export { CollapsibleSection } from './CollapsibleSection';
 export { ConfirmDialog } from './ConfirmDialog';

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -1,7 +1,7 @@
 // Shared UI Components
 // Reusable UI primitives with no domain coupling
 
-export { AttributionFooter } from './AttributionFooter/AttributionFooter';
+export { AttributionFooter } from './AttributionFooter';
 export { Checkbox } from './Checkbox';
 export { CollapsibleSection } from './CollapsibleSection';
 export { ConfirmDialog } from './ConfirmDialog';

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -19,7 +19,7 @@ import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { Checkbox } from '@/shared/components/Checkbox';
 import { SettingsRow } from '@/shared/components/SettingsRow';
 import { UserDock } from '@/shared/components/UserDock';
-import { AttributionFooter } from '@/shared/components/AttributionFooter/AttributionFooter';
+import { AttributionFooter } from '@/shared/components/AttributionFooter';
 import { lazyWithRetry, namedExport } from '@/shared/utils/lazyWithRetry';
 import { useTranslation } from '@/i18n';
 import { useOnboarding } from '@/features/onboarding';

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -19,6 +19,7 @@ import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { Checkbox } from '@/shared/components/Checkbox';
 import { SettingsRow } from '@/shared/components/SettingsRow';
 import { UserDock } from '@/shared/components/UserDock';
+import { AttributionFooter } from '@/shared/components/AttributionFooter/AttributionFooter';
 import { lazyWithRetry, namedExport } from '@/shared/utils/lazyWithRetry';
 import { useTranslation } from '@/i18n';
 import { useOnboarding } from '@/features/onboarding';
@@ -528,13 +529,15 @@ export function Sidebar() {
                 link equity from the SPA to /what-is-gridfinity et al. (which had zero
                 inbound links from the SPA before this section existed). */}
             <div className="px-4 py-4 border-t border-stroke-subtle">
-              <h2 className="text-xs leading-none font-semibold text-content-tertiary uppercase tracking-wider mb-2">
+              <h2 className="text-xs leading-none font-semibold text-content-tertiary mb-2">
                 {t('sidebar.learn')}
               </h2>
               <ul className="text-[11px] leading-relaxed space-y-1">
                 <li>
                   <a
                     href="/what-is-gridfinity"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="text-content-tertiary hover:text-content hover:underline"
                   >
                     {t('sidebar.learn.whatIs')}
@@ -543,6 +546,8 @@ export function Sidebar() {
                 <li>
                   <a
                     href="/guide"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="text-content-tertiary hover:text-content hover:underline"
                   >
                     {t('sidebar.learn.guide')}
@@ -551,6 +556,8 @@ export function Sidebar() {
                 <li>
                   <a
                     href="/gridfinity-bin-generator"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="text-content-tertiary hover:text-content hover:underline"
                   >
                     {t('sidebar.learn.binGenerator')}
@@ -559,6 +566,8 @@ export function Sidebar() {
                 <li>
                   <a
                     href="/gridfinity-baseplate-generator"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="text-content-tertiary hover:text-content hover:underline"
                   >
                     {t('sidebar.learn.baseplateGenerator')}
@@ -567,6 +576,8 @@ export function Sidebar() {
                 <li>
                   <a
                     href="/gridfinity-sizes"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="text-content-tertiary hover:text-content hover:underline"
                   >
                     {t('sidebar.learn.sizes')}
@@ -575,84 +586,7 @@ export function Sidebar() {
               </ul>
             </div>
 
-            {/* Attribution */}
-            <div className="px-4 py-4 border-t border-stroke-subtle text-content-disabled text-[10px] leading-relaxed">
-              <div className="text-content-secondary text-[11px] font-semibold mb-1 flex items-baseline gap-1.5">
-                {t('sidebar.appName')}
-                <a
-                  href={`https://github.com/andymai/gridfinity-layout-tool/releases/tag/v${__APP_VERSION__}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-[10px] font-normal text-content-disabled hover:text-content-tertiary hover:underline"
-                >
-                  {t('sidebar.version', { version: __APP_VERSION__ })}
-                </a>
-              </div>
-              {t('sidebar.gridfinityBy')}{' '}
-              <a
-                href="https://www.youtube.com/c/ZackFreedman"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-content-tertiary hover:underline"
-              >
-                Zack Freedman
-              </a>
-              <br />
-              {t('sidebar.toolBy')}{' '}
-              <a
-                href="https://www.linkedin.com/in/andyhmai/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-content-tertiary hover:underline"
-              >
-                Andy Aragon
-              </a>{' '}
-              ·{' '}
-              <a
-                href="https://ko-fi.com/andyaragon"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-accent hover:underline"
-              >
-                <svg
-                  className="w-3 h-3 inline-block align-text-bottom mr-0.5"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  {ICON_PATHS.heart.map((d) => (
-                    <path key={d} d={d} />
-                  ))}
-                </svg>
-                {t('sidebar.tip')}
-              </a>{' '}
-              ·{' '}
-              <a
-                href="https://github.com/andymai/gridfinity-layout-tool"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-content-tertiary hover:underline"
-              >
-                {t('sidebar.github')}
-              </a>{' '}
-              ·{' '}
-              <a
-                href="/privacy"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-content-tertiary hover:underline"
-              >
-                {t('sidebar.privacy')}
-              </a>{' '}
-              ·{' '}
-              <a
-                href="/terms"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-content-tertiary hover:underline"
-              >
-                {t('sidebar.terms')}
-              </a>
-            </div>
+            <AttributionFooter />
           </div>
           {cloudSyncEnabled && (
             <UserDock


### PR DESCRIPTION
## Summary

- Extracts a shared `AttributionFooter` component (app name + version badge + full attribution + links) used by all three tools
- Replaces the incomplete inline attribution block in the bin designer `ParameterPanel` — it was missing GitHub, Privacy, and Terms links
- Adds `AttributionFooter` to `BaseplatePanel` which had no attribution at all
- Replaces the inline block in `Sidebar` — now a single source of truth
- Fixes the Learn section heading: removes `uppercase tracking-wider` per UX feedback
- Fixes Learn links: adds `target="_blank"` so content pages open in a new tab without navigating away from the SPA

## Test plan

- [ ] Verify attribution footer (app name, version, all links) appears in layout sidebar, bin designer panel, and baseplate panel
- [ ] Click version badge — should open GitHub Releases in a new tab
- [ ] Verify Learn heading is no longer all-caps
- [ ] Click Learn links — should open content pages in a new tab without leaving the app