### PR TITLE
fix(shell): simplify version badge link to /releases

### DIFF
--- a/src/shared/components/AttributionFooter/AttributionFooter.test.tsx
+++ b/src/shared/components/AttributionFooter/AttributionFooter.test.tsx
@@ -7,7 +7,10 @@ describe('AttributionFooter', () => {
     render(<AttributionFooter />);
     expect(screen.getByText('Gridfinity Layout Tool')).toBeInTheDocument();
     const versionLink = screen.getByRole('link', { name: /v\d+\.\d+\.\d+/ });
-    expect(versionLink).toHaveAttribute('href', expect.stringContaining('releases/tag/'));
+    expect(versionLink).toHaveAttribute(
+      'href',
+      'https://github.com/andymai/gridfinity-layout-tool/releases'
+    );
   });
 
   it('renders attribution links', () => {

--- a/src/shared/components/AttributionFooter/AttributionFooter.tsx
+++ b/src/shared/components/AttributionFooter/AttributionFooter.tsx
@@ -8,7 +8,7 @@ export function AttributionFooter() {
       <div className="text-content-secondary text-[11px] font-semibold mb-1 flex items-baseline gap-1.5">
         {t('sidebar.appName')}
         <a
-          href={`https://github.com/andymai/gridfinity-layout-tool/releases/tag/v${__APP_VERSION__}`}
+          href="https://github.com/andymai/gridfinity-layout-tool/releases"
           target="_blank"
           rel="noopener noreferrer"
           className="text-[10px] font-normal text-content-disabled hover:text-content-tertiary hover:underline"


### PR DESCRIPTION
Changes version badge href from `/releases/tag/v{version}` to `/releases` so users land on the full releases list rather than a specific tag.