### PR TITLE
feat(bin-designer): add interior divider height control

### DIFF
--- a/api/lib/designerCompartmentValidation.ts
+++ b/api/lib/designerCompartmentValidation.ts
@@ -145,6 +145,17 @@ export function validateCompartments(compartments: unknown): string | null {
       }
     }
   }
+  // Optional global divider height. Either the literal 'auto' or a finite
+  // millimeter value within the bin's possible interior height range. A direct
+  // HTTP POST could otherwise smuggle in NaN/absurd values; the generator
+  // clamps, but reject early to keep payloads honest. Ceiling mirrors the
+  // label-tab cap (MAX_HEIGHT * heightUnitMm = 140mm), the tallest a bin gets.
+  if (compartments.dividerHeight !== undefined) {
+    const h = compartments.dividerHeight;
+    if (h !== 'auto' && (!isNumber(h) || !inRange(h, 0, 140))) {
+      return `compartments.dividerHeight must be 'auto' or a number 0-140`;
+    }
+  }
   // Optional per-divider tilt overrides. Mirrors the client-side
   // `DIVIDER_OFFSET_MAX_MM = 200` cap and the canonical pair ordering rule
   // (compartmentA < compartmentB) so a direct HTTP POST can't smuggle in

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
@@ -36,6 +36,7 @@ import { useResponsive } from '@/shared/hooks/useResponsive';
 import { usePreviewColor } from '@/features/bin-designer/hooks/usePreviewColor';
 import { GridCell, GhostPreview } from './CompartmentEditorParts';
 import { DividerHitTargets } from './DividerHitTargets';
+import { DividerHeightControl } from './DividerHeightControl';
 import { DividerTiltSubsection } from './DividerTiltSubsection';
 import { rowKeyOf } from './useDividerTiltSubsection';
 
@@ -538,9 +539,9 @@ export function CompartmentEditor() {
         </section>
       )}
 
-      {/* Wall thickness (only when there are dividers) */}
+      {/* Wall thickness + divider height (only when there are dividers) */}
       {compartmentCount > 1 && (
-        <section>
+        <section className="space-y-4">
           <SnappingSlider
             label={t('binDesigner.wallThickness')}
             value={thickness}
@@ -548,6 +549,7 @@ export function CompartmentEditor() {
             options={thicknessOptions}
             unit="mm"
           />
+          <DividerHeightControl />
         </section>
       )}
 

--- a/src/features/bin-designer/components/CompartmentEditor/DividerHeightControl.test.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/DividerHeightControl.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { DividerHeightControl } from './DividerHeightControl';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import { resetAllStores } from '@/test/testUtils';
+
+// Default bin wall height: height(6u) × 7mm − socket(4.5mm) = 37.5mm. The
+// stacking lip is off by default, so the full interior (auto) height == 37.5.
+const FULL_HEIGHT = 37.5;
+
+describe('DividerHeightControl', () => {
+  beforeEach(() => {
+    resetAllStores();
+    useDesignerStore.setState(() => ({ params: DEFAULT_BIN_PARAMS }));
+  });
+
+  const dividerHeight = () => useDesignerStore.getState().params.compartments.dividerHeight;
+
+  it('shows the auto label by default', () => {
+    render(<DividerHeightControl />);
+    expect(screen.getByText(/Auto/)).toBeInTheDocument();
+  });
+
+  it('decrementing from auto produces a numeric partial height below full', async () => {
+    render(<DividerHeightControl />);
+    fireEvent.click(screen.getByRole('button', { name: /decrease|minus|−|-/i }));
+
+    // Deferred commit flushes after an idle delay.
+    await waitFor(() => expect(typeof dividerHeight()).toBe('number'));
+    const h = dividerHeight() as number;
+    expect(h).toBeLessThan(FULL_HEIGHT);
+    expect(h).toBeGreaterThanOrEqual(2);
+  });
+
+  it('never commits a height taller than the auto (full interior) value', async () => {
+    useDesignerStore.getState().setCompartmentDividerHeight(10);
+    render(<DividerHeightControl />);
+    const inc = screen.getByRole('button', { name: /increase|plus|\+/i });
+    for (let i = 0; i < 100; i++) fireEvent.click(inc);
+
+    // Driving the stepper past full must snap back to 'auto', never exceed full.
+    await waitFor(() => expect(dividerHeight()).toBeUndefined());
+  });
+});

--- a/src/features/bin-designer/components/CompartmentEditor/DividerHeightControl.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/DividerHeightControl.tsx
@@ -1,0 +1,92 @@
+/**
+ * Global height control for interior compartment dividers.
+ *
+ * Mirrors the slotted-piece height control: a single stepper that toggles
+ * between 'auto' (full interior height) and a numeric millimeter value.
+ * A numeric value produces partial-height dividers that rise from the floor
+ * and stop short of the rim. Effect is visible in the live 3D preview only
+ * (the 2D grid editor is top-down).
+ *
+ * Uses `commitMode="deferred"` so holding/clicking the stepper batches into a
+ * single regeneration — a partial height forces the heavier additive
+ * divider-wall path, so per-tick regen would be costly.
+ */
+
+import { useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
+import { StepperControl } from '@/shared/components/StepperControl';
+import {
+  calculateDividerHeight,
+  resolveCompartmentDividerHeight,
+  MIN_COMPARTMENT_DIVIDER_HEIGHT,
+} from '@/shared/utils/slotMath';
+import { useTranslation } from '@/i18n';
+import { useResponsive } from '@/shared/hooks/useResponsive';
+
+export function DividerHeightControl() {
+  const t = useTranslation();
+  const { isMobile } = useResponsive();
+  const stepperVariant = isMobile ? 'mobile' : 'desktop';
+
+  const { params, setCompartmentDividerHeight } = useDesignerStore(
+    useShallow((s) => ({
+      params: s.params,
+      setCompartmentDividerHeight: s.setCompartmentDividerHeight,
+    }))
+  );
+
+  const { wallHeight } = binDimensions(params);
+  const stackingLip = params.base.stackingLip;
+  const dividerHeight = params.compartments.dividerHeight;
+
+  // Full interior height — the 'auto' value and the numeric upper bound.
+  const maxHeight = useMemo(
+    () => calculateDividerHeight({ height: 'auto' }, wallHeight, stackingLip),
+    [wallHeight, stackingLip]
+  );
+  const maxRounded = Math.round(maxHeight * 10) / 10;
+
+  const isAuto = dividerHeight === undefined || dividerHeight === 'auto';
+  const currentValue = resolveCompartmentDividerHeight(dividerHeight, maxHeight);
+
+  return (
+    <div>
+      <span className="mb-1 block text-xs text-content-tertiary">
+        {t('binDesigner.dividerHeight')}
+      </span>
+      <StepperControl
+        value={currentValue}
+        displayValue={
+          isAuto ? `${t('binDesigner.dividerAutoHeight')} (${maxRounded}mm)` : undefined
+        }
+        onChange={(v) => {
+          const rounded = Math.round(v * 10) / 10;
+          if (rounded >= maxRounded) {
+            setCompartmentDividerHeight('auto');
+          } else {
+            setCompartmentDividerHeight(Math.max(MIN_COMPARTMENT_DIVIDER_HEIGHT, rounded));
+          }
+        }}
+        onStep={(delta) => {
+          // From 'auto', only a downward step is meaningful (already at max).
+          const base = isAuto ? maxHeight : currentValue;
+          if (isAuto && delta > 0) return;
+          const next = Math.round((base + delta) * 10) / 10;
+          if (next >= maxRounded) {
+            setCompartmentDividerHeight('auto');
+          } else {
+            setCompartmentDividerHeight(Math.max(MIN_COMPARTMENT_DIVIDER_HEIGHT, next));
+          }
+        }}
+        min={MIN_COMPARTMENT_DIVIDER_HEIGHT}
+        max={maxRounded}
+        step={1}
+        variant={stepperVariant}
+        commitMode="deferred"
+        ariaLabel={t('binDesigner.dividerHeight')}
+      />
+    </div>
+  );
+}

--- a/src/features/bin-designer/store/designer.scenario.compartments.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.compartments.test.ts
@@ -780,4 +780,39 @@ describe('DesignerStore - compartment actions', () => {
       expect(params.compartments.compartmentTexts).toEqual(['A']);
     });
   });
+
+  describe('setCompartmentDividerHeight', () => {
+    it('stores a numeric height on the compartments config', () => {
+      const { setCompartmentDividerHeight } = useDesignerStore.getState();
+      setCompartmentDividerHeight(12);
+      expect(useDesignerStore.getState().params.compartments.dividerHeight).toBe(12);
+    });
+
+    it("omits the field entirely when set to 'auto' (tidy persisted JSON)", () => {
+      const { setCompartmentDividerHeight } = useDesignerStore.getState();
+      setCompartmentDividerHeight(12);
+      setCompartmentDividerHeight('auto');
+      expect(useDesignerStore.getState().params.compartments).not.toHaveProperty('dividerHeight');
+    });
+
+    it('pushes a history entry on a real change', () => {
+      const { setCompartmentDividerHeight } = useDesignerStore.getState();
+      setCompartmentDividerHeight(10);
+      expect(useDesignerStore.getState().history.past).toHaveLength(1);
+    });
+
+    it('is a no-op when the value is unchanged (no history spam)', () => {
+      const { setCompartmentDividerHeight } = useDesignerStore.getState();
+      setCompartmentDividerHeight(10);
+      setCompartmentDividerHeight(10);
+      expect(useDesignerStore.getState().history.past).toHaveLength(1);
+    });
+
+    it("treats undefined and 'auto' as the same state (no redundant history)", () => {
+      // Default has no dividerHeight (== auto); setting 'auto' must not record.
+      const { setCompartmentDividerHeight } = useDesignerStore.getState();
+      setCompartmentDividerHeight('auto');
+      expect(useDesignerStore.getState().history.past).toHaveLength(0);
+    });
+  });
 });

--- a/src/features/bin-designer/store/slices/paramSlice.ts
+++ b/src/features/bin-designer/store/slices/paramSlice.ts
@@ -400,6 +400,27 @@ export function createParamSlice(set: Set, get: Get) {
       });
     },
 
+    setCompartmentDividerHeight: (height: number | 'auto') => {
+      const { params } = get();
+      const prev = params.compartments.dividerHeight;
+      // No-op guard: the stepper fires on every tick; an unchanged value must
+      // not push a history entry. Treat undefined and 'auto' as the same state.
+      const prevIsAuto = prev === undefined || prev === 'auto';
+      if (height === 'auto' ? prevIsAuto : prev === height) return;
+
+      set((state) => {
+        pushHistoryEntry(state);
+        if (height === 'auto') {
+          // Omit the field entirely so persisted JSON stays tidy and the bin
+          // shares the full-height cache bucket / cut-path geometry.
+          const { dividerHeight: _drop, ...rest } = state.params.compartments;
+          state.params.compartments = rest;
+        } else {
+          state.params.compartments = { ...state.params.compartments, dividerHeight: height };
+        }
+      });
+    },
+
     setTextDefaults: (partial: Partial<TextStyleDefaults>) => {
       set((state) => {
         pushHistoryEntry(state);

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -194,6 +194,18 @@ export interface CompartmentConfig {
    * `remapDividerOverrides` on any cell mutation that renumbers IDs.
    */
   readonly dividerOverrides?: DividerOverride[];
+  /**
+   * Optional global height (mm) for the interior divider walls. `'auto'` or
+   * omitted means full interior height (below the lip taper) — the historical
+   * behavior. A numeric value produces partial-height dividers that rise from
+   * the floor and are truncated flat; it is clamped to
+   * `[MIN_COMPARTMENT_DIVIDER_HEIGHT, interior height]` at generation.
+   *
+   * A numeric value also forces the additive divider-wall path (the cut-based
+   * multi-cavity shell can't express a divider that stops short of the rim),
+   * mirroring how `dividerOverrides` already opt out of that path.
+   */
+  readonly dividerHeight?: number | 'auto';
 }
 
 /**
@@ -885,6 +897,8 @@ export interface DesignerState {
   splitCompartment: (compartmentId: number) => void;
   resetCompartments: () => void;
   setCompartmentText: (compartmentId: number, text: string) => void;
+  /** Set the global interior divider height in mm, or 'auto' for full height. */
+  setCompartmentDividerHeight: (height: number | 'auto') => void;
 
   // Angled-divider override actions
   setDividerOverride: (

--- a/src/features/generation/worker/generators/compartmentBuilder.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.ts
@@ -11,6 +11,7 @@ import type { BinParams, DividerOverride } from '@/shared/types/bin';
 import { buildCacheKey, compactKey, quantize, stableSerialize } from './cacheKeyUtils';
 import { sketch } from './meshUtils';
 import { BOX_CORNER_RADIUS } from './generatorConstants';
+import { resolveCompartmentDividerHeight } from '@/shared/utils/slotMath';
 
 // Re-export for backwards compatibility with existing imports
 export { fuseAllOrNull } from './utils/shapeOps';
@@ -703,7 +704,10 @@ export const compartmentWallsFeature: FeatureBuilder = {
         params.compartments.rows,
         quantize(params.compartments.thickness),
         params.compartments.cells.join(','),
-        stableSerialize(params.compartments.dividerOverrides ?? [])
+        stableSerialize(params.compartments.dividerOverrides ?? []),
+        quantize(
+          resolveCompartmentDividerHeight(params.compartments.dividerHeight, dim.interiorHeight)
+        )
       )
     );
   },
@@ -712,7 +716,10 @@ export const compartmentWallsFeature: FeatureBuilder = {
       ctx.params,
       ctx.dimensions.innerW,
       ctx.dimensions.innerD,
-      ctx.dimensions.interiorHeight
+      resolveCompartmentDividerHeight(
+        ctx.params.compartments.dividerHeight,
+        ctx.dimensions.interiorHeight
+      )
     );
     return result ? [result] : null;
   },

--- a/src/features/generation/worker/generators/pipeline/context.test.ts
+++ b/src/features/generation/worker/generators/pipeline/context.test.ts
@@ -249,4 +249,30 @@ describe('createInitialContext', () => {
       expect(ctx.dimensions.halfSockets).toBe(false);
     });
   });
+
+  describe('partial divider height routing', () => {
+    const fourCompartments = (overrides?: Partial<BinParams['compartments']>) =>
+      createTestParams({
+        width: 4,
+        depth: 4,
+        compartments: { cols: 2, rows: 2, thickness: 1.2, cells: [0, 1, 2, 3], ...overrides },
+      });
+
+    it('bakes rectangular compartments into the shell at full (auto) height', () => {
+      const ctx = createInitialContext(fourCompartments());
+      expect(ctx.dimensions.compartmentsBakedIntoShell).toBe(true);
+    });
+
+    it('routes a numeric (partial) divider height to the additive wall path', () => {
+      // The cut-based shell can't express a divider that stops short of the
+      // rim, so a partial height must disable the bake-into-shell path.
+      const ctx = createInitialContext(fourCompartments({ dividerHeight: 8 }));
+      expect(ctx.dimensions.compartmentsBakedIntoShell).toBe(false);
+    });
+
+    it("keeps the cut path for an explicit 'auto' divider height", () => {
+      const ctx = createInitialContext(fourCompartments({ dividerHeight: 'auto' }));
+      expect(ctx.dimensions.compartmentsBakedIntoShell).toBe(true);
+    });
+  });
 });

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -94,6 +94,12 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
     !hasDividerOverrides(params) ||
     (compartmentEdgesAreSinglePair(params) &&
       compartmentCavitiesAreViableWithOverrides(params, innerW, innerD));
+  // A partial divider height can't be expressed by the cut-based multi-cavity
+  // shell (cut pockets reach the rim, so the leftover divider is always full
+  // height). Fall back to the additive divider-wall path — which builds short
+  // wall boxes from the floor — exactly as tilt overrides already do.
+  const dividerHeightIsFull =
+    params.compartments.dividerHeight === undefined || params.compartments.dividerHeight === 'auto';
   const compartmentsBakedIntoShell =
     !isSlotted &&
     !solid &&
@@ -102,7 +108,8 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
     compartmentsAreRectangular(params) &&
     compartmentCavitiesAreViable(params, innerW, innerD) &&
     compartmentCornersRoundCleanly(params, innerW, innerD) &&
-    overridesAllowCutPath;
+    overridesAllowCutPath &&
+    dividerHeightIsFull;
 
   // Shell cache key — versioned + quantized for deterministic matching.
   // Mask hash is included only when the mask triggers the polygon path so

--- a/src/shared/utils/slotMath.test.ts
+++ b/src/shared/utils/slotMath.test.ts
@@ -4,6 +4,8 @@ import {
   calculateDividerHeight,
   calculateDividerLength,
   getEffectiveSlotDimensions,
+  resolveCompartmentDividerHeight,
+  MIN_COMPARTMENT_DIVIDER_HEIGHT,
 } from './slotMath';
 
 describe('calculateSlotPositions', () => {
@@ -79,6 +81,34 @@ describe('calculateDividerHeight', () => {
   it('returns explicit height regardless of lip', () => {
     expect(calculateDividerHeight({ height: 15 }, 30, true)).toBe(15);
     expect(calculateDividerHeight({ height: 15 }, 30, false)).toBe(15);
+  });
+});
+
+describe('resolveCompartmentDividerHeight', () => {
+  it('returns full interior height when undefined (default)', () => {
+    expect(resolveCompartmentDividerHeight(undefined, 30)).toBe(30);
+  });
+
+  it("returns full interior height when 'auto'", () => {
+    expect(resolveCompartmentDividerHeight('auto', 30)).toBe(30);
+  });
+
+  it('passes through an in-range numeric height', () => {
+    expect(resolveCompartmentDividerHeight(12, 30)).toBe(12);
+  });
+
+  it('clamps below the minimum up to MIN_COMPARTMENT_DIVIDER_HEIGHT', () => {
+    expect(resolveCompartmentDividerHeight(0.5, 30)).toBe(MIN_COMPARTMENT_DIVIDER_HEIGHT);
+    expect(resolveCompartmentDividerHeight(-5, 30)).toBe(MIN_COMPARTMENT_DIVIDER_HEIGHT);
+  });
+
+  it('clamps above the interior height down to the interior height', () => {
+    expect(resolveCompartmentDividerHeight(100, 30)).toBe(30);
+  });
+
+  it('never exceeds interior height even when min would push past it', () => {
+    // Degenerate tiny bin: interior height below the printable minimum.
+    expect(resolveCompartmentDividerHeight(5, 1)).toBe(1);
   });
 });
 

--- a/src/shared/utils/slotMath.ts
+++ b/src/shared/utils/slotMath.ts
@@ -75,6 +75,28 @@ export function calculateDividerHeight(
 }
 
 /**
+ * Minimum interior compartment-divider height in mm. Below this a partial
+ * divider becomes a barely-printable sliver, so numeric heights clamp up to it.
+ */
+export const MIN_COMPARTMENT_DIVIDER_HEIGHT = 2;
+
+/**
+ * Resolve the effective interior compartment-divider height in mm.
+ *
+ * `'auto'`/undefined → the full interior height (the historical full-height
+ * divider). A numeric value is clamped to
+ * `[MIN_COMPARTMENT_DIVIDER_HEIGHT, interiorHeight]` so dividers stay printable
+ * and never poke above the rim.
+ */
+export function resolveCompartmentDividerHeight(
+  dividerHeight: number | 'auto' | undefined,
+  interiorHeight: number
+): number {
+  if (dividerHeight === undefined || dividerHeight === 'auto') return interiorHeight;
+  return Math.min(interiorHeight, Math.max(MIN_COMPARTMENT_DIVIDER_HEIGHT, dividerHeight));
+}
+
+/**
  * Calculate the divider length for a given axis.
  *
  * The divider spans the interior dimension plus tab engagement on each side.


### PR DESCRIPTION
## What

Adds a control in the bin designer to set the **height of the interior compartment dividers**. Dividers can now rise partway up the bin (a low-walled tray that keeps contents visible/reachable) instead of always reaching the rim.

The control lives in the **Compartment editor** section: a single stepper that toggles between **Auto** (full interior height) and a numeric millimeter value. Effect shows live in the 3D preview.

## Behavior

- **Default is unchanged.** `'auto'` (the default) produces byte-identical geometry to before and shares the same shell cache bucket — zero impact on existing designs.
- A **numeric height** routes generation to the additive divider-wall path, because the cut-based multi-cavity shell can't express a divider that stops short of the rim. This mirrors how angled (tilt) dividers already opt out of the cut path.
- Walls **rise from the floor** and are **truncated flat**. Applies to straight *and* tilted dividers.
- Height is **clamped to `[2mm, full interior height]`** — a partial divider can never exceed the Auto value or print as an unviable sliver.

## Performance

- Default path is byte-identical (same cache bucket), so no cost for the common case.
- The stepper uses **deferred commit**, so rapid steps batch into a single regeneration rather than one per click.
- Only an explicit partial height pays for the additive path (the same one tilted dividers already use), and it's memoized by the per-feature cache.

## Tests

- `resolveCompartmentDividerHeight` unit tests (auto passthrough, min/max clamping, never-exceeds-interior).
- Routing tests: partial height disables `compartmentsBakedIntoShell`; `'auto'` keeps the cut path.
- Store action tests (numeric store, `'auto'` omits the field, history no-op guards).
- Component tests (auto label, decrement produces partial height, +100 steps snaps back to auto — never exceeds full).
- Full suite green (typecheck, lint, i18n parity, module boundaries).