### PR TITLE
fix(bin-designer): address divider-height review comments

### DIFF
--- a/src/features/bin-designer/components/CompartmentEditor/DividerHeightControl.test.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/DividerHeightControl.test.tsx
@@ -3,11 +3,18 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { DividerHeightControl } from './DividerHeightControl';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
+import { calculateDividerHeight } from '@/shared/utils/slotMath';
 import { resetAllStores } from '@/test/testUtils';
 
-// Default bin wall height: height(6u) × 7mm − socket(4.5mm) = 37.5mm. The
-// stacking lip is off by default, so the full interior (auto) height == 37.5.
-const FULL_HEIGHT = 37.5;
+// Derive the real "auto" (full interior) height from the defaults using the
+// same helpers the component does, so the assertions actually pin the bound
+// rather than passing against an arbitrarily large constant.
+const FULL_HEIGHT = calculateDividerHeight(
+  { height: 'auto' },
+  binDimensions(DEFAULT_BIN_PARAMS).wallHeight,
+  DEFAULT_BIN_PARAMS.base.stackingLip
+);
 
 describe('DividerHeightControl', () => {
   beforeEach(() => {

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -201,9 +201,12 @@ export interface CompartmentConfig {
    * the floor and are truncated flat; it is clamped to
    * `[MIN_COMPARTMENT_DIVIDER_HEIGHT, interior height]` at generation.
    *
-   * A numeric value also forces the additive divider-wall path (the cut-based
-   * multi-cavity shell can't express a divider that stops short of the rim),
-   * mirroring how `dividerOverrides` already opt out of that path.
+   * A numeric value below the full interior height always forces the additive
+   * divider-wall path (the cut-based multi-cavity shell can't express a divider
+   * that stops short of the rim). This differs from `dividerOverrides`, which
+   * only fall back to the additive path for some layouts; a partial height
+   * always does. A numeric value that clamps up to the full interior height is
+   * treated as full and keeps the cut-path.
    */
   readonly dividerHeight?: number | 'auto';
 }

--- a/src/features/generation/worker/generators/pipeline/context.test.ts
+++ b/src/features/generation/worker/generators/pipeline/context.test.ts
@@ -274,5 +274,14 @@ describe('createInitialContext', () => {
       const ctx = createInitialContext(fourCompartments({ dividerHeight: 'auto' }));
       expect(ctx.dimensions.compartmentsBakedIntoShell).toBe(true);
     });
+
+    it('keeps the cut path when a numeric height clamps up to the full interior height', () => {
+      // No-lip 4x4x3 bin: wallHeight 16 == full interior height. A numeric value
+      // at/above that is effectively full, so it should NOT pay for the slower
+      // additive path or bust the cut-path cache bucket.
+      const ctx = createInitialContext(fourCompartments({ dividerHeight: 999 }));
+      expect(ctx.dimensions.interiorHeight).toBe(16);
+      expect(ctx.dimensions.compartmentsBakedIntoShell).toBe(true);
+    });
   });
 });

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -96,10 +96,16 @@ function deriveDimensions(params: BinParams, _forExport: boolean): BinDimensions
       compartmentCavitiesAreViableWithOverrides(params, innerW, innerD));
   // A partial divider height can't be expressed by the cut-based multi-cavity
   // shell (cut pockets reach the rim, so the leftover divider is always full
-  // height). Fall back to the additive divider-wall path — which builds short
-  // wall boxes from the floor — exactly as tilt overrides already do.
+  // height). A numeric height below the full interior height therefore always
+  // routes to the additive divider-wall path (short wall boxes from the floor).
+  // A numeric value that clamps up to the full interior height is treated as
+  // full so it keeps the faster cut-path. (Contrast tilt overrides, which only
+  // fall back to the additive path for some layouts — see overridesAllowCutPath.)
+  const { dividerHeight } = params.compartments;
   const dividerHeightIsFull =
-    params.compartments.dividerHeight === undefined || params.compartments.dividerHeight === 'auto';
+    dividerHeight === undefined ||
+    dividerHeight === 'auto' ||
+    (typeof dividerHeight === 'number' && dividerHeight >= interiorHeight);
   const compartmentsBakedIntoShell =
     !isSlotted &&
     !solid &&


### PR DESCRIPTION
Follow-up to #2097 addressing the Copilot review comments.

## Changes

1. **Routing (behavioral):** a numeric `dividerHeight` that clamps *up* to the full interior height (e.g. an imported/crafted payload of 999mm) is now treated as full — it keeps the faster cut-path and its cache bucket instead of needlessly taking the additive fuse path. Only a height **strictly below** the full interior height forces the additive walls.
2. **Comment/docstring accuracy:** reworded the routing comment in `context.ts` and the `CompartmentConfig.dividerHeight` docstring. The prior wording said partial height falls back "exactly as tilt overrides do" — but `dividerOverrides` only opt out of the cut-path for *some* layouts, whereas a partial height *always* does.
3. **Test bound:** `DividerHeightControl.test.tsx` now computes the full ("auto") height from `DEFAULT_BIN_PARAMS` via the same helpers the component uses (was hard-coded to 37.5mm, far above the real ~15.3mm, so `h < FULL_HEIGHT` passed trivially).

## Tests

- New routing case: a numeric height ≥ full interior height keeps `compartmentsBakedIntoShell = true`.
- Existing routing/component/resolver tests still green; typecheck + lint clean.