### PR TITLE
fix(bin-designer): keep stacking lip on split custom-shape and overhung bins

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.split-lip-shape-overhang.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-lip-shape-overhang.test.ts
@@ -12,7 +12,7 @@
  * Both surface as a "missing / broken stacking lip" on the split pieces.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import { DEFAULT_BIN_PARAMS, GRIDFINITY } from '@/shared/constants/bin';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
 import type { BinParams, SplitConnectorConfig } from '@/shared/types/bin';
 import type { CellMask } from '@/shared/utils/cellMask';
@@ -42,10 +42,10 @@ const L_SHAPE_MASK: CellMask = {
 };
 
 function computeWallTopZ(params: BinParams): number {
-  return params.height * GRIDFINITY.HEIGHT_UNIT;
+  return params.height * params.heightUnitMm;
 }
 
-/** Count vertices that fall strictly inside the given world-XY rectangle. */
+/** Count vertices that fall within the given world-XY rectangle (inclusive bounds). */
 function countVerticesInRect(
   vertices: Float32Array,
   xMin: number,

--- a/src/features/generation/worker/generators/binGenerator.scenario.split-lip-shape-overhang.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-lip-shape-overhang.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment node
+/**
+ * Regression tests for the split-bin stacking lip footprint.
+ *
+ * When a bin has a stacking lip and is split into pieces, the lip is built
+ * separately and fused onto each piece (splitBinBuilder). That separate lip
+ * build must use the same footprint as the body — the custom cell mask (L/U
+ * shapes) and the overhang. Previously it was built as a bare nominal-size
+ * rectangle, so:
+ *   - Custom shapes: the rectangular lip juts out over the cleared notch.
+ *   - Overhung bins: the lip falls short of the overhung body edge.
+ * Both surface as a "missing / broken stacking lip" on the split pieces.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DEFAULT_BIN_PARAMS, GRIDFINITY } from '@/shared/constants/bin';
+import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
+import type { BinParams, SplitConnectorConfig } from '@/shared/types/bin';
+import type { CellMask } from '@/shared/utils/cellMask';
+import { initBrepjs, getGenerateSplitPreview } from './__kernel-tests__/wasmInit';
+import { boundingBox } from './__kernel-tests__/meshAssertions';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+/** Tessellation + boolean edge tolerance band. */
+const XY_MARGIN = 1.5;
+
+const DISABLED_CONNECTORS: SplitConnectorConfig = {
+  ...DEFAULT_SPLIT_CONNECTOR_CONFIG,
+  enabled: false,
+};
+
+// 3×3 L: front-right 1u cell cleared (cols 4–5, rows 0–1 of the 6×6 mask).
+const L_SHAPE_MASK: CellMask = {
+  cols: 6,
+  rows: 6,
+  cells: [
+    1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1,
+  ] as (0 | 1)[],
+};
+
+function computeWallTopZ(params: BinParams): number {
+  return params.height * GRIDFINITY.HEIGHT_UNIT;
+}
+
+/** Count vertices that fall strictly inside the given world-XY rectangle. */
+function countVerticesInRect(
+  vertices: Float32Array,
+  xMin: number,
+  xMax: number,
+  yMin: number,
+  yMax: number
+): number {
+  let count = 0;
+  for (let i = 0; i < vertices.length; i += 3) {
+    const x = vertices[i];
+    const y = vertices[i + 1];
+    if (x >= xMin && x <= xMax && y >= yMin && y <= yMax) count++;
+  }
+  return count;
+}
+
+/** X-extent (max − min) of all vertices. */
+function xExtent(vertices: Float32Array): number {
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = 0; i < vertices.length; i += 3) {
+    min = Math.min(min, vertices[i]);
+    max = Math.max(max, vertices[i]);
+  }
+  return max - min;
+}
+
+/** X-extent (max − min) of vertices above a Z threshold (the lip zone). */
+function lipZoneXExtent(vertices: Float32Array, zThreshold: number): number {
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = 0; i < vertices.length; i += 3) {
+    if (vertices[i + 2] > zThreshold) {
+      min = Math.min(min, vertices[i]);
+      max = Math.max(max, vertices[i]);
+    }
+  }
+  return Number.isFinite(min) ? max - min : 0;
+}
+
+describe('split lip footprint follows custom shape', () => {
+  it('does not jut the lip over the cleared notch of an L-shaped bin', () => {
+    const generateSplitPreview = getGenerateSplitPreview();
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 3,
+      depth: 3,
+      height: 3,
+      cellMask: L_SHAPE_MASK,
+    };
+    // Cut along X near the center → left/right pieces; the right piece holds the
+    // cleared front-right notch.
+    const result = generateSplitPreview(params, [1], [], DISABLED_CONNECTORS);
+    expect(result.pieces).toHaveLength(2);
+
+    // The notch sits at the bin's front-right (+X, −Y); the right piece (largest
+    // offsetX) carries it. tessellatePiece re-centers each piece at its own bbox
+    // center, but the right piece's (maxX, minY) corner still maps to the same
+    // world corner — the L-shape's concave notch corner. The correct L-shaped
+    // lip leaves it empty; a wrongly-rectangular lip's rounded outer wall fills
+    // it. (The left piece's (maxX, minY) is its cut-face/front corner, which is
+    // legitimately solid — so we must target the right piece specifically.)
+    const rightPiece = result.pieces.reduce((a, b) => (b.offsetX > a.offsetX ? b : a));
+    const bb = boundingBox(rightPiece.vertices);
+    const cornerVertices = countVerticesInRect(
+      rightPiece.vertices,
+      bb.maxX - 12,
+      Infinity,
+      -Infinity,
+      bb.minY + 12
+    );
+    expect(cornerVertices).toBe(0);
+  }, 90000);
+});
+
+describe('split lip footprint follows overhang (#1949)', () => {
+  it('grows the lip to the overhung body edge', () => {
+    const generateSplitPreview = getGenerateSplitPreview();
+    const OVERHANG_MM = 18;
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 10,
+      depth: 2,
+      height: 3,
+      overhang: { left: 0, right: OVERHANG_MM, front: 0, back: 0 },
+    };
+    // Cut at x=0 → two pieces along X; the right piece carries the overhang.
+    const result = generateSplitPreview(params, [0], [], DISABLED_CONNECTORS);
+    expect(result.pieces).toHaveLength(2);
+
+    const wallTopZ = computeWallTopZ(params);
+
+    // The lip must span the same X range as the body it sits on. Pieces are
+    // re-centered for the exploded view, so compare translation-invariant
+    // extents rather than absolute positions. Without the fix the lip lacks the
+    // overhang and falls ~OVERHANG_MM short of the body edge on the right piece.
+    for (const piece of result.pieces) {
+      const bodyExt = xExtent(piece.vertices);
+      const lipExt = lipZoneXExtent(piece.vertices, wallTopZ + 0.5);
+      expect(
+        lipExt,
+        `piece ${piece.label}: lip X-extent ${lipExt.toFixed(1)} should reach body ${bodyExt.toFixed(1)}`
+      ).toBeGreaterThan(bodyExt - XY_MARGIN);
+    }
+  }, 90000);
+});

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -211,10 +211,10 @@ function splitSolidIntoPieces(
   // socket Z-offset applied in generateBin), shifted down by
   // LIP_FUSE_OVERLAP to ensure a volumetric overlap for clean fusing.
   //
-  // Pass cellMask + overhang so the lip footprint matches the body: rectangular
-  // bins are unaffected, but custom shapes (L/U) and overhung bins would
-  // otherwise get a full-rectangle, nominal-size lip that juts past or falls
-  // short of the actual body edge once fused per-piece.
+  // Pass cellMask + overhang so the lip footprint matches the body. A no-op for
+  // a plain rectangular bin with no overhang; for a custom shape (L/U) or any
+  // overhang it avoids a full-rectangle, nominal-size lip that juts past or
+  // falls short of the actual body edge once fused per-piece.
   let lipSolid: Shape3D | undefined;
   if (hasLip) {
     const lipBase = buildTopShape(

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -201,13 +201,30 @@ function splitSolidIntoPieces(
   const floorZ = isFlat ? 0 : SOCKET_HEIGHT;
   const wallTopZ = floorZ + wallHeight;
 
+  // An overhang grows the outer body past the nominal grid footprint (#1949);
+  // both the lip and the outermost cutting boxes must track it. Suppressed for
+  // partial masks, matching the geometry pipeline.
+  const overhang = resolveOverhang(isPartialMask(params.cellMask) ? undefined : params.overhang);
+
   // Build lip solid separately if needed. The lip is positioned at
   // wallTopZ (= totalHeight for both flat and socket bases after the
   // socket Z-offset applied in generateBin), shifted down by
   // LIP_FUSE_OVERLAP to ensure a volumetric overlap for clean fusing.
+  //
+  // Pass cellMask + overhang so the lip footprint matches the body: rectangular
+  // bins are unaffected, but custom shapes (L/U) and overhung bins would
+  // otherwise get a full-rectangle, nominal-size lip that juts past or falls
+  // short of the actual body edge once fused per-piece.
   let lipSolid: Shape3D | undefined;
   if (hasLip) {
-    const lipBase = buildTopShape(params.width, params.depth, true, params.gridUnitMm);
+    const lipBase = buildTopShape(
+      params.width,
+      params.depth,
+      true,
+      params.gridUnitMm,
+      params.cellMask,
+      overhang
+    );
     lipSolid = translate(lipBase, [0, 0, wallTopZ - LIP_FUSE_OVERLAP]);
     lipBase.delete();
 
@@ -278,13 +295,10 @@ function splitSolidIntoPieces(
   const adjustedCutPlanesX = shiftCutPlanesOffCellBoundaries(cutPlanesX, params.width, gridUnitMm);
   const adjustedCutPlanesY = shiftCutPlanesOffCellBoundaries(cutPlanesY, params.depth, gridUnitMm);
 
-  // An overhang grows the outer body past the nominal grid footprint (the base
-  // sockets stay put). The body spans [-outerW/2 - left, outerW/2 + right] and
-  // [-outerD/2 - front, outerD/2 + back]; the outermost cutting boxes must reach
-  // those edges or the boolean intersect clips the overhang off (#1949).
-  // Suppressed for partial masks, matching the geometry pipeline.
-  const overhang = resolveOverhang(isPartialMask(params.cellMask) ? undefined : params.overhang);
-
+  // The outermost cutting boxes must reach the overhung body edges (resolved
+  // above) or the boolean intersect clips the overhang off (#1949). The body
+  // spans [-outerW/2 - left, outerW/2 + right] and [-outerD/2 - front,
+  // outerD/2 + back].
   // Boundary arrays: [left edge, ...cut planes, right edge]
   const xBounds = [-outerW / 2 - overhang.left, ...adjustedCutPlanesX, outerW / 2 + overhang.right];
   const yBounds = [-outerD / 2 - overhang.front, ...adjustedCutPlanesY, outerD / 2 + overhang.back];


### PR DESCRIPTION
## Problem

Splitting a bin that has a **stacking lip** lost or mangled the lip on the pieces whenever the bin had a **custom shape (L/U)** or an **overhang** — a visibly missing/broken lip in the 3D preview and exploded view.

## Root cause

The split builder can't reuse the normal lip-build path: it builds the body and lip **separately** and fuses them per-piece, to avoid an OCCT boolean-intersect crash at the lip-wall junction. That separate lip build had drifted from the canonical `shellStage` path — it called `buildTopShape(width, depth, true, gridUnitMm)` and dropped two footprint arguments `shellStage` passes:

- **`cellMask`** → the lip was built as a full rectangle, so it juts over the cleared notch of an L/U shape.
- **`overhang`** (#1949) → the lip stayed at nominal grid size while the body grew outward, so it falls short of the overhung edge.

## Fix

Pass `params.cellMask` and the resolved `overhang` into the split lip's `buildTopShape` call, mirroring `shellStage`. `buildTopShape` already suppresses overhang for polygon masks, so rectangular bins are byte-unchanged. The remaining diff just hoists the existing `overhang` resolution above the lip block.

## Tests

New `binGenerator.scenario.split-lip-shape-overhang.test.ts` (reproduce-first — both assertions fail before the fix, pass after):

- **L-shape notch:** the right split piece's concave notch corner must stay empty (a rectangular lip left ~99 stray vertices there).
- **Overhang:** each piece's lip-zone X-extent must reach the body's X-extent (pre-fix 209.7 vs body 227.7 on the overhung piece).

Assertions are translation-invariant because `tessellatePiece` re-centers each piece at its own bbox center.

All existing split/lip scenario tests pass (lip-trim, overhang, polygon, slotted-lip, wall-cutout-lip, cutouts, export, manifold-kernel, cell-boundary); `tsc` + ESLint clean.