### PR TITLE
feat(bin-designer): unify compartment sizing into one size-led panel

### DIFF
--- a/docs/superpowers/specs/2026-06-11-compartment-sizing-ux-design.md
+++ b/docs/superpowers/specs/2026-06-11-compartment-sizing-ux-design.md
@@ -1,0 +1,154 @@
+# Compartment Sizing UX — Design
+
+**Date:** 2026-06-11
+**Feature area:** `src/features/bin-designer` — `CompartmentEditor`
+**Status:** Approved for implementation
+
+## Problem
+
+The recently shipped "compartment dimensions in mm" feature (#2101) added a
+`Layout: [By count] [By size]` mode toggle. In **By size** mode the user types a
+target width/depth and the grid packs as many compartments as fit while keeping
+every one at least that size (fit-guarantee). The achieved size is shown as
+`≥ 32.1 mm (+2.1)`.
+
+Confirmed pain points (from the user):
+
+1. **The `≥ X mm (+2.1)` notation is cryptic** — the signed delta is hard to
+   decode at a glance.
+2. **It's not obvious the value you type is a _minimum_, not the size you get.**
+
+The two-mode toggle also hides the relationship between count and size: switching
+modes swaps which control is visible, so count and size never appear together.
+
+## Goal
+
+Replace the two-mode toggle with a **single, size-led panel** that:
+
+- keeps the existing fit-guarantee semantics (primary use case: "my object is
+  30 mm — every compartment must be at least that big"),
+- makes "what you get" legible without signed-delta math, and
+- never shows two on-screen numbers that disagree.
+
+Non-goals: changing the solver/cavity math, changing the generator/geometry,
+folding compartment **height** into this tool.
+
+## Key decision: single source of truth
+
+The stored state is already `cols × rows` on the compartment config. Both the
+size fields and the grid steppers are **views of that same value**:
+
+- The **size fields display the exact _smallest_ (worst-case interior) opening**,
+  always mirroring reality. There is no separate "typed target" stored.
+- Typing a number means _"make compartments at least this big"_: it runs the
+  existing `solveCountForMinCavity`, the count snaps, and the field updates to
+  the real achieved value.
+- Nudging the grid steppers re-derives the size fields live.
+
+Because both controls derive from one value, the panel can never display a stale
+or contradictory number. This single decision resolves three review findings at
+once: the stale-field problem, the default/empty-state ambiguity, and the
+"min vs up to" wording clash.
+
+## Panel design
+
+```
+Smallest opening (mm)
+  Width   [ 32.1 ]      Depth   [ 47.6 ]
+Grid      [−] 4 [+]  ×  [−] 3 [+]
+Rounds up to tile the bin evenly · edge compartments are wider
+```
+
+### Controls
+
+| Control            | Type                        | Behavior                                                                                               |
+| ------------------ | --------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Width / Depth (mm) | Text entry, **no spinner**  | Value = current smallest opening. On commit (blur/Enter), interpreted as "≥ this"; solver snaps count. |
+| Grid (cols × rows) | `StepperControl` (typeable) | Direct count control; 1→12 in one keystroke. Adjusting re-derives the size fields.                     |
+
+- **Width/Depth** are type-to-set only (no `onStep` spinner) because size→count
+  is discrete; a 1 mm spinner would jump counts unpredictably. Two steppers
+  fighting over one value is also the clutter the unification is meant to remove.
+- **Grid** keeps the full `StepperControl` (nudge **and** typeable), so power
+  users aren't forced to tap 1→12.
+
+### Readout / framing
+
+- No separate readout line — the achieved size already lives in the fields.
+- The label frames the number as **cavity geometry, not a fit promise**:
+  "Smallest opening (mm)". We do **not** say "fits objects up to X" because that
+  ignores print tolerance and height and would overpromise.
+- Caption: **"Rounds up to tile the bin evenly · edge compartments are wider"** —
+  explains _why_ you don't get exactly what you typed, and discloses the
+  edge/interior asymmetry (worst-case interior value is what's shown).
+
+### Edge cases
+
+- **Grid cap (12):** when `solveCountForMinCavity` clamps at `MAX_COMPARTMENT_GRID`
+  and the achieved size therefore exceeds what a smaller entry implied, show a
+  hint (e.g. "Max 12 across") so a too-small entry isn't a silent surprise.
+- **Non-uniform (merged) layouts:** fields show the smallest compartment; typing
+  a size resets to a uniform grid (current `setCompartmentGrid` behavior,
+  unchanged). The 2D drag-to-merge/split editor is untouched.
+- **First open:** fields show the current achieved min; grid shows the current
+  count. No placeholder/fake-value ambiguity (a consequence of "field =
+  achieved").
+
+### Height
+
+`DividerHeightControl` stays its own control with no functional change, but is
+relocated/relabeled to sit directly under this panel so the W×D×H story reads
+together. (Currently it renders inside the by-size branch only.)
+
+### Accessibility
+
+- The caption (and any cap hint) live in an `aria-live="polite"` region so screen
+  readers announce changes as the user nudges the grid.
+- Grid steppers carry explicit aria-labels (already provided via `StepperControl`
+  `ariaLabel`).
+
+## Affected code
+
+- **`CompartmentEditor.tsx`**
+  - Remove local state `sizeMode`, `targetW`, `targetD`, `GRID_MODES`, the mode
+    toggle, `enterSizeMode`, `fitNote`/`fitNoteW`/`fitNoteD`.
+  - Render the unified panel: always-visible Width/Depth (type-only, value =
+    `minUniformCavity(...)`) + Grid steppers (existing `handleColsChange/Step`,
+    `handleRowsChange/Step`).
+  - `applyTargetWidth`/`applyTargetDepth` keep their solver call but no longer
+    store a target — they just snap the count. Add the cap-reached hint.
+  - Move `DividerHeightControl` to render under the panel unconditionally
+    (when `compartmentCount > 1`).
+- **`compartmentDimensions.ts`** — reused **unchanged** (`minUniformCavity`,
+  `solveCountForMinCavity`, `formatCompactMm`).
+- **i18n (all 7 locales: en, de, es, fr, nb, nl, pt-BR)**
+  - Remove: `binDesigner.compartmentEditor.gridMode`, `gridModeCount`,
+    `gridModeSize`, `targetWidth`, `targetDepth`, `fitActual`.
+  - Add (new keys, clearly named): a "Smallest opening (mm)" group label,
+    `width`/`depth` sub-labels, the tile-evenly caption, and the grid-cap hint.
+    Do not repurpose the removed `targetWidth`/`targetDepth` keys — the wording
+    changed, so old keys are deleted and new ones added.
+  - Update the i18n allowlist entries for removed/added keys; run
+    `pnpm run check:i18n`.
+- **Tests** — update `CompartmentEditor` tests for the removed toggle and the
+  new always-on panel; assert solver snap-on-commit and the field-mirrors-count
+  behavior. Solver unit tests in `compartmentDimensions.test.ts` stay as-is.
+
+## Testing strategy
+
+- Unit (Vitest + jsdom, `createTestLayout`):
+  - Typing a min width snaps `cols` via the solver and the field reflects the
+    achieved value (not the typed value when they differ).
+  - Nudging the grid updates the displayed size; no stale field.
+  - Grid-cap hint appears when the solver clamps at 12.
+  - Non-uniform layout shows the smallest compartment.
+- Verify no `console.log`, no `any`, `import type` for types, `@/` alias,
+  `useShallow` retained for the multi-select store read.
+- `pnpm run quality` (typecheck + lint + knip) and `pnpm run check:i18n`.
+
+## Open risk
+
+`StepperControl` is currently used for the size fields _with_ a spinner. The
+type-only variant may need a prop (e.g. omit `onStep`) or a fallback to a plain
+`Input`. Confirm `StepperControl` degrades cleanly without `onStep` during
+implementation; if not, use the design-system `Input` for the size fields.

--- a/docs/superpowers/specs/2026-06-11-compartment-sizing-ux-design.md
+++ b/docs/superpowers/specs/2026-06-11-compartment-sizing-ux-design.md
@@ -2,7 +2,22 @@
 
 **Date:** 2026-06-11
 **Feature area:** `src/features/bin-designer` — `CompartmentEditor`
-**Status:** Approved for implementation
+**Status:** Implemented (see revision below)
+
+## Revision (2026-06-11, post-review)
+
+After seeing the size-led panel, the direction changed: **the Columns/Rows
+steppers are the primary control, and manual mm sizing is an advanced opt-in.**
+The fit-guarantee model and the single-source-of-truth principle below still
+hold — only the hierarchy changed:
+
+- Primary view: Columns/Rows `StepperControl`s with visible labels.
+- "Set by size" is a collapsible disclosure (collapsed by default). Expanding it
+  reveals the mm Width/Depth fields (same solver-snap behavior). Keeping them out
+  of the DOM by default also avoids an accessible-name collision with the bin's
+  own Width/Depth controls (`CompartmentEditor` renders inside `ParameterPanel`) —
+  the size fields use `(mm)`-suffixed labels so they're unambiguous when expanded.
+- Divider height returns to the wall-thickness section (its original home).
 
 ## Problem
 

--- a/scripts/i18n-values-allowlist.json
+++ b/scripts/i18n-values-allowlist.json
@@ -215,8 +215,7 @@
     "layouts.announce.fallbackNameCapitalized",
     "binExamples.popular",
     "binExamples.description",
-    "binExamples.dimensions",
-    "binDesigner.compartmentEditor.fitActual"
+    "binExamples.dimensions"
   ],
   "valuePatterns": [
     "^\\{[\\w,\\s]+\\}$",

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
@@ -53,6 +53,24 @@ describe('CompartmentEditor', () => {
     expect(readout.textContent).toMatch(/mm/);
   });
 
+  it('surfaces the grid-cap hint in the readout when an axis hits the max grid', () => {
+    const max = DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID;
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        compartments: {
+          ...DEFAULT_BIN_PARAMS.compartments,
+          cols: max,
+          rows: 1,
+          cells: Array.from({ length: max }, (_, i) => i),
+        },
+      },
+    });
+    render(<CompartmentEditor />);
+    const readout = screen.getByText(/≈/);
+    expect(readout.textContent).toContain(`Max ${max} per side`);
+  });
+
   it('has no By count / By size mode toggle', () => {
     render(<CompartmentEditor />);
     expect(screen.queryByRole('button', { name: /^by count$/i })).toBeNull();

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
@@ -3,13 +3,28 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { resetAllStores } from '@/test/testUtils';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useSettingsStore } from '@/core/store/settings';
-import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import { DEFAULT_BIN_PARAMS, DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
+import { getInteriorDims } from '@/features/bin-designer/utils/dividerAngle';
+import {
+  formatCompactMm,
+  minUniformCavity,
+  solveCountForMinCavity,
+} from '@/features/bin-designer/utils/compartmentDimensions';
 import { CompartmentEditor } from './CompartmentEditor';
 
 const TWO_BY_TWO = {
   ...DEFAULT_BIN_PARAMS,
   compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, rows: 2, cells: [0, 1, 2, 3] },
 };
+
+/** Interior dimensions for the default bin, used to predict solver output. */
+const interior = getInteriorDims({
+  width: DEFAULT_BIN_PARAMS.width,
+  depth: DEFAULT_BIN_PARAMS.depth,
+  gridUnitMm: DEFAULT_BIN_PARAMS.gridUnitMm,
+  wallThickness: DEFAULT_BIN_PARAMS.wallThickness,
+});
+const { thickness } = DEFAULT_BIN_PARAMS.compartments;
 
 describe('CompartmentEditor', () => {
   beforeEach(() => {
@@ -20,91 +35,108 @@ describe('CompartmentEditor', () => {
     });
   });
 
-  it('renders without crashing', () => {
+  it('renders the unified sizing panel', () => {
     render(<CompartmentEditor />);
-    expect(screen.getByText(/columns/i)).toBeInTheDocument();
-    expect(screen.getByText(/rows/i)).toBeInTheDocument();
+    expect(screen.getByText(/smallest opening/i)).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /columns/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /rows/i })).toBeInTheDocument();
   });
 
-  it('shows grid controls for columns and rows', () => {
+  it('has no By count / By size mode toggle', () => {
     render(<CompartmentEditor />);
-    const steppers = screen.getAllByRole('spinbutton');
-    expect(steppers.length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByRole('button', { name: /^by count$/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^by size$/i })).toBeNull();
   });
 
-  it('shows 2D grid editor when grid is larger than 1x1', () => {
+  it('shows size inputs and grid steppers together (width, depth, columns, rows)', () => {
+    render(<CompartmentEditor />);
+    // Default 1x1 grid: no 2D editor, no divider-height control — exactly four
+    // numeric inputs: width, depth, columns, rows.
+    expect(screen.getByRole('spinbutton', { name: /width/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /depth/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('spinbutton')).toHaveLength(4);
+  });
+
+  it('width field shows the achieved smallest opening, not a stale target', () => {
     useDesignerStore.setState({
       params: {
         ...DEFAULT_BIN_PARAMS,
-        compartments: {
-          ...DEFAULT_BIN_PARAMS.compartments,
-          cols: 2,
-          rows: 2,
-          cells: [0, 1, 2, 3],
-        },
+        compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, rows: 1, cells: [0, 1] },
       },
     });
+    render(<CompartmentEditor />);
+    const expected = formatCompactMm(minUniformCavity(interior.innerW, 2, thickness));
+    expect(screen.getByRole('spinbutton', { name: /width/i })).toHaveValue(Number(expected));
+  });
+
+  it('typing a min width snaps the column count via the fit-guarantee solver', () => {
+    const setCompartmentGrid = vi.fn();
+    useDesignerStore.setState({ params: DEFAULT_BIN_PARAMS, setCompartmentGrid });
+    render(<CompartmentEditor />);
+
+    const widthInput = screen.getByRole('spinbutton', { name: /width/i });
+    fireEvent.change(widthInput, { target: { value: '20' } });
+    fireEvent.blur(widthInput);
+
+    const expectedCols = solveCountForMinCavity(
+      interior.innerW,
+      thickness,
+      20,
+      DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID,
+      DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID
+    );
+    expect(setCompartmentGrid).toHaveBeenCalledWith(
+      expectedCols,
+      DEFAULT_BIN_PARAMS.compartments.rows
+    );
+  });
+
+  it('typing a width at least the full interior collapses to a single column', () => {
+    const setCompartmentGrid = vi.fn();
+    useDesignerStore.setState({ params: DEFAULT_BIN_PARAMS, setCompartmentGrid });
+    render(<CompartmentEditor />);
+
+    const widthInput = screen.getByRole('spinbutton', { name: /width/i });
+    fireEvent.change(widthInput, { target: { value: String(Math.round(interior.innerW)) } });
+    fireEvent.blur(widthInput);
+
+    expect(setCompartmentGrid).toHaveBeenCalledWith(1, DEFAULT_BIN_PARAMS.compartments.rows);
+  });
+
+  it('updates columns when the grid stepper changes', () => {
+    const setCompartmentGrid = vi.fn();
+    useDesignerStore.setState({ params: DEFAULT_BIN_PARAMS, setCompartmentGrid });
+    render(<CompartmentEditor />);
+    const cols = screen.getByRole('spinbutton', { name: /columns/i });
+    fireEvent.change(cols, { target: { value: '3' } });
+    fireEvent.blur(cols);
+    expect(setCompartmentGrid).toHaveBeenCalledWith(3, DEFAULT_BIN_PARAMS.compartments.rows);
+  });
+
+  it('shows the tile-evenly explanation caption', () => {
+    render(<CompartmentEditor />);
+    expect(screen.getByText(/tile the bin evenly/i)).toBeInTheDocument();
+  });
+
+  it('shows 2D grid editor when grid is larger than 1x1', () => {
+    useDesignerStore.setState({ params: TWO_BY_TWO });
     render(<CompartmentEditor />);
     expect(screen.getByRole('application')).toBeInTheDocument();
   });
 
   it('does not show 2D grid editor when grid is 1x1', () => {
-    useDesignerStore.setState({
-      params: {
-        ...DEFAULT_BIN_PARAMS,
-        compartments: {
-          ...DEFAULT_BIN_PARAMS.compartments,
-          cols: 1,
-          rows: 1,
-          cells: [0],
-        },
-      },
-    });
     render(<CompartmentEditor />);
     expect(screen.queryByRole('application')).not.toBeInTheDocument();
   });
 
   it('shows wall thickness control when compartments > 1', () => {
-    useDesignerStore.setState({
-      params: {
-        ...DEFAULT_BIN_PARAMS,
-        compartments: {
-          ...DEFAULT_BIN_PARAMS.compartments,
-          cols: 2,
-          rows: 2,
-          cells: [0, 1, 2, 3],
-        },
-      },
-    });
+    useDesignerStore.setState({ params: TWO_BY_TWO });
     render(<CompartmentEditor />);
     expect(screen.getByText(/wall thickness/i)).toBeInTheDocument();
   });
 
-  it('updates columns when changed', () => {
-    const setCompartmentGrid = vi.fn();
-    useDesignerStore.setState({
-      params: DEFAULT_BIN_PARAMS,
-      setCompartmentGrid,
-    });
-    render(<CompartmentEditor />);
-    const steppers = screen.getAllByRole('spinbutton');
-    fireEvent.change(steppers[0], { target: { value: '3' } });
-    fireEvent.blur(steppers[0]);
-    expect(setCompartmentGrid).toHaveBeenCalledWith(3, DEFAULT_BIN_PARAMS.compartments.rows);
-  });
-
   it('shows instruction text for grid interaction', () => {
-    useDesignerStore.setState({
-      params: {
-        ...DEFAULT_BIN_PARAMS,
-        compartments: {
-          ...DEFAULT_BIN_PARAMS.compartments,
-          cols: 2,
-          rows: 2,
-          cells: [0, 1, 2, 3],
-        },
-      },
-    });
+    useDesignerStore.setState({ params: TWO_BY_TWO });
     render(<CompartmentEditor />);
     expect(screen.getByText(/drag to merge/i)).toBeInTheDocument();
   });
@@ -112,7 +144,6 @@ describe('CompartmentEditor', () => {
   it('hides the angled-divider hit targets until the feature is opted into', () => {
     useDesignerStore.setState({ params: TWO_BY_TWO });
     render(<CompartmentEditor />);
-    // Off by default: no on-grid divider hit targets.
     expect(screen.queryByRole('button', { name: /Edit divider between Comp/i })).toBeNull();
   });
 
@@ -133,7 +164,7 @@ describe('CompartmentEditor', () => {
           ...DEFAULT_BIN_PARAMS.compartments,
           cols: 2,
           rows: 2,
-          cells: [0, 0, 1, 1], // Merged compartments
+          cells: [0, 0, 1, 1],
         },
       },
     });

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
@@ -5,7 +5,10 @@ import { useDesignerStore } from '@/features/bin-designer/store';
 import { useSettingsStore } from '@/core/store/settings';
 import { DEFAULT_BIN_PARAMS, DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
 import { getInteriorDims } from '@/features/bin-designer/utils/dividerAngle';
-import { solveCountForMinCavity } from '@/features/bin-designer/utils/compartmentDimensions';
+import {
+  minUniformCavity,
+  solveCountForMinCavity,
+} from '@/features/bin-designer/utils/compartmentDimensions';
 import { CompartmentEditor } from './CompartmentEditor';
 
 const TWO_BY_TWO = {
@@ -37,6 +40,17 @@ describe('CompartmentEditor', () => {
     expect(screen.getByText(/rows/i)).toBeInTheDocument();
     expect(screen.getByRole('spinbutton', { name: /columns/i })).toBeInTheDocument();
     expect(screen.getByRole('spinbutton', { name: /rows/i })).toBeInTheDocument();
+  });
+
+  it('always shows the resulting compartment size without hovering or expanding', () => {
+    useDesignerStore.setState({ params: TWO_BY_TWO });
+    render(<CompartmentEditor />);
+    const w = Math.round(minUniformCavity(interior.innerW, 2, thickness) * 10) / 10;
+    const d = Math.round(minUniformCavity(interior.innerD, 2, thickness) * 10) / 10;
+    const readout = screen.getByText(/≈/);
+    expect(readout.textContent).toContain(String(w));
+    expect(readout.textContent).toContain(String(d));
+    expect(readout.textContent).toMatch(/mm/);
   });
 
   it('has no By count / By size mode toggle', () => {

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
@@ -5,11 +5,7 @@ import { useDesignerStore } from '@/features/bin-designer/store';
 import { useSettingsStore } from '@/core/store/settings';
 import { DEFAULT_BIN_PARAMS, DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
 import { getInteriorDims } from '@/features/bin-designer/utils/dividerAngle';
-import {
-  formatCompactMm,
-  minUniformCavity,
-  solveCountForMinCavity,
-} from '@/features/bin-designer/utils/compartmentDimensions';
+import { solveCountForMinCavity } from '@/features/bin-designer/utils/compartmentDimensions';
 import { CompartmentEditor } from './CompartmentEditor';
 
 const TWO_BY_TWO = {
@@ -35,9 +31,10 @@ describe('CompartmentEditor', () => {
     });
   });
 
-  it('renders the unified sizing panel', () => {
+  it('renders the grid steppers as the primary control', () => {
     render(<CompartmentEditor />);
-    expect(screen.getByText(/smallest opening/i)).toBeInTheDocument();
+    expect(screen.getByText(/columns/i)).toBeInTheDocument();
+    expect(screen.getByText(/rows/i)).toBeInTheDocument();
     expect(screen.getByRole('spinbutton', { name: /columns/i })).toBeInTheDocument();
     expect(screen.getByRole('spinbutton', { name: /rows/i })).toBeInTheDocument();
   });
@@ -48,33 +45,29 @@ describe('CompartmentEditor', () => {
     expect(screen.queryByRole('button', { name: /^by size$/i })).toBeNull();
   });
 
-  it('shows size inputs and grid steppers together (width, depth, columns, rows)', () => {
+  it('keeps manual sizing collapsed as an advanced option by default', () => {
     render(<CompartmentEditor />);
-    // Default 1x1 grid: no 2D editor, no divider-height control — exactly four
-    // numeric inputs: width, depth, columns, rows.
-    expect(screen.getByRole('spinbutton', { name: /width/i })).toBeInTheDocument();
-    expect(screen.getByRole('spinbutton', { name: /depth/i })).toBeInTheDocument();
-    expect(screen.getAllByRole('spinbutton')).toHaveLength(4);
+    expect(screen.getByRole('button', { name: /set by size/i })).toBeInTheDocument();
+    // The mm size inputs are not rendered until the user opts in.
+    expect(screen.queryByRole('spinbutton', { name: /width \(mm\)/i })).toBeNull();
+    expect(screen.queryByRole('spinbutton', { name: /depth \(mm\)/i })).toBeNull();
   });
 
-  it('width field shows the achieved smallest opening, not a stale target', () => {
-    useDesignerStore.setState({
-      params: {
-        ...DEFAULT_BIN_PARAMS,
-        compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, rows: 1, cells: [0, 1] },
-      },
-    });
+  it('reveals the mm size inputs when "Set by size" is expanded', () => {
     render(<CompartmentEditor />);
-    const expected = formatCompactMm(minUniformCavity(interior.innerW, 2, thickness));
-    expect(screen.getByRole('spinbutton', { name: /width/i })).toHaveValue(Number(expected));
+    fireEvent.click(screen.getByRole('button', { name: /set by size/i }));
+    expect(screen.getByRole('spinbutton', { name: /width \(mm\)/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /depth \(mm\)/i })).toBeInTheDocument();
+    expect(screen.getByText(/tile the bin evenly/i)).toBeInTheDocument();
   });
 
-  it('typing a min width snaps the column count via the fit-guarantee solver', () => {
+  it('typing a min width in the advanced sizer snaps the column count', () => {
     const setCompartmentGrid = vi.fn();
     useDesignerStore.setState({ params: DEFAULT_BIN_PARAMS, setCompartmentGrid });
     render(<CompartmentEditor />);
+    fireEvent.click(screen.getByRole('button', { name: /set by size/i }));
 
-    const widthInput = screen.getByRole('spinbutton', { name: /width/i });
+    const widthInput = screen.getByRole('spinbutton', { name: /width \(mm\)/i });
     fireEvent.change(widthInput, { target: { value: '20' } });
     fireEvent.blur(widthInput);
 
@@ -91,16 +84,13 @@ describe('CompartmentEditor', () => {
     );
   });
 
-  it('typing a width at least the full interior collapses to a single column', () => {
-    const setCompartmentGrid = vi.fn();
-    useDesignerStore.setState({ params: DEFAULT_BIN_PARAMS, setCompartmentGrid });
+  it('does not expose accessible names that collide with the bin dimensions', () => {
+    // CompartmentEditor renders inside ParameterPanel alongside bin Width/Depth
+    // controls; the advanced size inputs must not duplicate those names.
     render(<CompartmentEditor />);
-
-    const widthInput = screen.getByRole('spinbutton', { name: /width/i });
-    fireEvent.change(widthInput, { target: { value: String(Math.round(interior.innerW)) } });
-    fireEvent.blur(widthInput);
-
-    expect(setCompartmentGrid).toHaveBeenCalledWith(1, DEFAULT_BIN_PARAMS.compartments.rows);
+    fireEvent.click(screen.getByRole('button', { name: /set by size/i }));
+    expect(screen.queryByLabelText('Width')).toBeNull();
+    expect(screen.queryByLabelText('Depth')).toBeNull();
   });
 
   it('updates columns when the grid stepper changes', () => {
@@ -111,11 +101,6 @@ describe('CompartmentEditor', () => {
     fireEvent.change(cols, { target: { value: '3' } });
     fireEvent.blur(cols);
     expect(setCompartmentGrid).toHaveBeenCalledWith(3, DEFAULT_BIN_PARAMS.compartments.rows);
-  });
-
-  it('shows the tile-evenly explanation caption', () => {
-    render(<CompartmentEditor />);
-    expect(screen.getByText(/tile the bin evenly/i)).toBeInTheDocument();
   });
 
   it('shows 2D grid editor when grid is larger than 1x1', () => {

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
@@ -108,6 +108,9 @@ export function CompartmentEditor() {
   // Preview color synced with 3D preview (cross-tab + same-window CustomEvent)
   const previewColor = usePreviewColor();
 
+  // Manual size entry is an advanced opt-in; the grid steppers are the default.
+  const [showSizer, setShowSizer] = useState(false);
+
   // Selection state for drag-to-merge
   const [selection, setSelection] = useState<Set<number>>(new Set());
   const [dragStart, setDragStart] = useState<number | null>(null);
@@ -466,56 +469,16 @@ export function CompartmentEditor() {
 
   return (
     <div className="space-y-5">
-      {/* Unified sizing panel: one source of truth (cols×rows). The mm fields are
-          a size-led entry point that snaps the count via the fit-guarantee
-          solver; the grid steppers adjust the same count. Both derive from
-          cols/rows, so the panel never shows two disagreeing numbers. */}
-      <section className="space-y-4">
-        {/* Smallest opening (mm): type a minimum size to fit an object. */}
-        <div className="space-y-2">
-          <span className="text-xs text-content-tertiary">
-            {t('binDesigner.compartmentEditor.smallestOpening')}
-          </span>
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <span className="mb-1 block text-xs text-content-tertiary">
-                {t('binDesigner.compartmentEditor.openingWidth')}
-              </span>
-              <DeferredNumberInput
-                value={achievedMinW}
-                onChange={applyTargetWidth}
-                min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE}
-                max={Math.round(interiorW)}
-                step={1}
-                decimals={1}
-                className={sizeInputClass}
-                aria-label={t('binDesigner.compartmentEditor.openingWidth')}
-              />
-            </div>
-            <div>
-              <span className="mb-1 block text-xs text-content-tertiary">
-                {t('binDesigner.compartmentEditor.openingDepth')}
-              </span>
-              <DeferredNumberInput
-                value={achievedMinD}
-                onChange={applyTargetDepth}
-                min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE}
-                max={Math.round(interiorD)}
-                step={1}
-                decimals={1}
-                className={sizeInputClass}
-                aria-label={t('binDesigner.compartmentEditor.openingDepth')}
-              />
-            </div>
-          </div>
-        </div>
-
-        {/* Grid (count): direct cols×rows control, derived from the same state. */}
-        <div className="space-y-2">
-          <span className="text-xs text-content-tertiary">
-            {t('binDesigner.compartmentEditor.grid')}
-          </span>
-          <div className="grid grid-cols-2 gap-3">
+      {/* Compartment grid: the primary control is the Columns/Rows steppers.
+          Setting the grid by a target compartment size is an advanced opt-in
+          (collapsed by default) that snaps the same cols×rows via the
+          fit-guarantee solver — the steppers stay the single source of truth. */}
+      <section className="space-y-3">
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <span className="mb-1 block text-xs text-content-tertiary">
+              {t('binDesigner.columns')}
+            </span>
             <StepperControl
               value={cols}
               onChange={handleColsChange}
@@ -526,6 +489,11 @@ export function CompartmentEditor() {
               variant={stepperVariant}
               ariaLabel={t('binDesigner.columns')}
             />
+          </div>
+          <div>
+            <span className="mb-1 block text-xs text-content-tertiary">
+              {t('binDesigner.rows')}
+            </span>
             <StepperControl
               value={rows}
               onChange={handleRowsChange}
@@ -539,19 +507,76 @@ export function CompartmentEditor() {
           </div>
         </div>
 
-        {/* Explains why typed sizes round up, discloses the edge asymmetry, and
-            announces the grid cap. aria-live so the readout is announced as the
-            grid changes. */}
-        <p aria-live="polite" className="text-[11px] text-content-tertiary">
-          {atMaxGrid
-            ? `${t('binDesigner.compartmentEditor.maxGridReached', { max: DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID })} · `
-            : ''}
-          {t('binDesigner.compartmentEditor.tileEvenlyNote')}
-        </p>
+        {/* Advanced: set the grid by a minimum compartment size in mm. */}
+        <div>
+          <button
+            type="button"
+            onClick={() => setShowSizer((v) => !v)}
+            aria-expanded={showSizer}
+            className="flex items-center gap-1 text-[11px] font-medium text-content-secondary hover:text-content"
+          >
+            <svg
+              className={`h-3 w-3 transition-transform ${showSizer ? 'rotate-90' : ''}`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+            {t('binDesigner.compartmentEditor.setBySize')}
+          </button>
 
-        {/* Divider height lives with the sizing panel so the W×D×H story reads
-            together (only meaningful once there are dividers to size). */}
-        {compartmentCount > 1 && <DividerHeightControl />}
+          {showSizer && (
+            <div className="mt-2 space-y-2 border-l border-stroke-subtle pl-3">
+              <span className="block text-xs text-content-tertiary">
+                {t('binDesigner.compartmentEditor.smallestOpening')}
+              </span>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <span className="mb-1 block text-xs text-content-tertiary">
+                    {t('binDesigner.compartmentEditor.openingWidth')}
+                  </span>
+                  <DeferredNumberInput
+                    value={achievedMinW}
+                    onChange={applyTargetWidth}
+                    min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE}
+                    max={Math.round(interiorW)}
+                    step={1}
+                    decimals={1}
+                    className={sizeInputClass}
+                    aria-label={t('binDesigner.compartmentEditor.openingWidth')}
+                  />
+                </div>
+                <div>
+                  <span className="mb-1 block text-xs text-content-tertiary">
+                    {t('binDesigner.compartmentEditor.openingDepth')}
+                  </span>
+                  <DeferredNumberInput
+                    value={achievedMinD}
+                    onChange={applyTargetDepth}
+                    min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE}
+                    max={Math.round(interiorD)}
+                    step={1}
+                    decimals={1}
+                    className={sizeInputClass}
+                    aria-label={t('binDesigner.compartmentEditor.openingDepth')}
+                  />
+                </div>
+              </div>
+              {/* Explains why typed sizes round up and discloses the edge
+                  asymmetry; announces the grid cap. aria-live so the note is
+                  read out as the achieved size changes. */}
+              <p aria-live="polite" className="text-[11px] text-content-tertiary">
+                {atMaxGrid
+                  ? `${t('binDesigner.compartmentEditor.maxGridReached', { max: DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID })} · `
+                  : ''}
+                {t('binDesigner.compartmentEditor.tileEvenlyNote')}
+              </p>
+            </div>
+          )}
+        </div>
       </section>
 
       {/* 2D Layout editor (hidden when 1x1 grid) */}
@@ -679,8 +704,7 @@ export function CompartmentEditor() {
         </section>
       )}
 
-      {/* Wall thickness (only when there are dividers). Divider height lives with
-          the sizing panel above so the W×D×H story reads together. */}
+      {/* Wall thickness + divider height (only when there are dividers). */}
       {compartmentCount > 1 && (
         <section className="space-y-4">
           <SnappingSlider
@@ -690,6 +714,7 @@ export function CompartmentEditor() {
             options={thicknessOptions}
             unit="mm"
           />
+          <DividerHeightControl />
         </section>
       )}
 

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
@@ -22,6 +22,7 @@ import { useDesignerStore } from '@/features/bin-designer/store';
 import { useSettingsStore } from '@/core/store/settings';
 import { DESIGNER_CONSTRAINTS, WALL_THICKNESS_OPTIONS } from '@/features/bin-designer/constants';
 import { StepperControl } from '@/shared/components/StepperControl';
+import { DeferredNumberInput } from '@/shared/components/DeferredNumberInput';
 import { SnappingSlider } from '../controls/SnappingSlider';
 import type { SnappingSliderOption } from '../controls/SnappingSlider';
 import {
@@ -31,7 +32,6 @@ import {
   cellIndex,
 } from '@/features/bin-designer/utils/compartments';
 import {
-  formatCompactMm,
   minUniformCavity,
   solveCountForMinCavity,
 } from '@/features/bin-designer/utils/compartmentDimensions';
@@ -46,8 +46,6 @@ import { DividerTiltSubsection } from './DividerTiltSubsection';
 import { rowKeyOf } from './useDividerTiltSubsection';
 
 const EMPTY_HIGHLIGHT_SET: ReadonlySet<number> = new Set();
-
-const GRID_MODES = ['count', 'size'] as const;
 
 export function CompartmentEditor() {
   const t = useTranslation();
@@ -109,15 +107,6 @@ export function CompartmentEditor() {
 
   // Preview color synced with 3D preview (cross-tab + same-window CustomEvent)
   const previewColor = usePreviewColor();
-
-  // Whether the grid is set by cell count (cols/rows) or target size (mm).
-  const [sizeMode, setSizeMode] = useState<'count' | 'size'>('count');
-
-  // By-size targets the user typed (the field holds the target, not the achieved
-  // size, so we can show how far the fit-guarantee landed from it). Null until
-  // the user enters size mode, then seeded from the current grid.
-  const [targetW, setTargetW] = useState<number | null>(null);
-  const [targetD, setTargetD] = useState<number | null>(null);
 
   // Selection state for drag-to-merge
   const [selection, setSelection] = useState<Set<number>>(new Set());
@@ -347,17 +336,19 @@ export function CompartmentEditor() {
     [cols, rows, setCompartmentGrid]
   );
 
-  // By-size mode (fit-guarantee): pick the largest count whose tightest
-  // compartment stays >= the requested mm, so every compartment is at least
-  // that size. setCompartmentGrid regenerates the uniform grid (it validates min
-  // cell size and silently no-ops if the target is infeasible).
+  // Size-led entry (fit-guarantee): typing a minimum opening picks the largest
+  // count whose tightest compartment stays >= the requested mm, so every
+  // compartment is at least that size. The mm fields are a solver entry point —
+  // they don't store a target; the grid (cols/rows) is the single source of
+  // truth, and the fields always reflect the achieved smallest opening.
+  // setCompartmentGrid regenerates the uniform grid (it validates min cell size
+  // and silently no-ops if the target is infeasible).
   const applyTargetWidth = useCallback(
     (target: number) => {
       const clamped = Math.min(
         interiorW,
         Math.max(DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE, target)
       );
-      setTargetW(clamped);
       setCompartmentGrid(
         solveCountForMinCavity(
           interiorW,
@@ -379,7 +370,6 @@ export function CompartmentEditor() {
         interiorD,
         Math.max(DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE, target)
       );
-      setTargetD(clamped);
       setCompartmentGrid(
         cols,
         solveCountForMinCavity(
@@ -394,14 +384,6 @@ export function CompartmentEditor() {
     },
     [interiorD, thickness, cols, setCompartmentGrid]
   );
-
-  // Entering size mode seeds the targets from the current grid so the fields
-  // show a sensible starting value (and zero delta) before the user types.
-  const enterSizeMode = useCallback(() => {
-    setTargetW(Math.round(minUniformCavity(interiorW, cols, thickness) * 10) / 10);
-    setTargetD(Math.round(minUniformCavity(interiorD, rows, thickness) * 10) / 10);
-    setSizeMode('size');
-  }, [interiorW, interiorD, cols, rows, thickness]);
 
   const handleThicknessChange = useCallback(
     (newThickness: number) => {
@@ -418,23 +400,24 @@ export function CompartmentEditor() {
   const compartmentCount = getCompartmentCount(compartments);
   const hasMergedCompartments = compartmentCount < cols * rows;
 
-  // By-size readouts: the smallest (guaranteed) compartment per axis, and the
-  // delta from the user's typed target. With fit-guarantee the achieved minimum
-  // is normally >= target (positive delta); it goes negative only when even one
-  // compartment can't reach the target (target larger than the interior).
-  const achievedMinW = minUniformCavity(interiorW, cols, thickness);
-  const achievedMinD = minUniformCavity(interiorD, rows, thickness);
-  const fitNote = (achieved: number, target: number | null): string | null => {
-    if (target === null) return null;
-    const d = Math.round((achieved - target) * 10) / 10;
-    const delta = `${d >= 0 ? '+' : '−'}${formatCompactMm(Math.abs(d))}`;
-    return t('binDesigner.compartmentEditor.fitActual', {
-      value: formatCompactMm(achieved),
-      delta,
-    });
-  };
-  const fitNoteW = fitNote(achievedMinW, targetW);
-  const fitNoteD = fitNote(achievedMinD, targetD);
+  // The mm fields show the smallest (worst-case interior) opening per axis — the
+  // value the fit-guarantee is measured against. Rounded to 0.1mm for display so
+  // the field never shows a stale or contradictory number relative to the grid.
+  const achievedMinW = Math.round(minUniformCavity(interiorW, cols, thickness) * 10) / 10;
+  const achievedMinD = Math.round(minUniformCavity(interiorD, rows, thickness) * 10) / 10;
+
+  // Surface the grid cap so a too-small entry that clamps at the max isn't a
+  // silent surprise (e.g. typing 5mm into a large bin tops out at 12 across).
+  const atMaxGrid =
+    cols >= DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID ||
+    rows >= DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID;
+
+  // Standalone styling for the size inputs (StepperControl owns its own input
+  // styling, but the mm fields are bare DeferredNumberInputs).
+  const sizeInputClass =
+    stepperVariant === 'mobile'
+      ? 'input w-full h-12 text-center font-semibold tabular-nums'
+      : 'w-full h-8 rounded border border-stroke-subtle bg-surface text-center text-sm tabular-nums text-content-secondary';
 
   // Check if hovered cell is in a multi-cell compartment (splittable)
   const hoveredIsSplittable = useMemo(() => {
@@ -483,116 +466,92 @@ export function CompartmentEditor() {
 
   return (
     <div className="space-y-5">
-      {/* Bin Grid controls (above the 2D layout) */}
-      <section className="space-y-3">
-        {/* Mode toggle: set the grid by cell count, or by target compartment size (mm) */}
-        <div className="flex items-center justify-between">
+      {/* Unified sizing panel: one source of truth (cols×rows). The mm fields are
+          a size-led entry point that snaps the count via the fit-guarantee
+          solver; the grid steppers adjust the same count. Both derive from
+          cols/rows, so the panel never shows two disagreeing numbers. */}
+      <section className="space-y-4">
+        {/* Smallest opening (mm): type a minimum size to fit an object. */}
+        <div className="space-y-2">
           <span className="text-xs text-content-tertiary">
-            {t('binDesigner.compartmentEditor.gridMode')}
+            {t('binDesigner.compartmentEditor.smallestOpening')}
           </span>
-          <div className="flex gap-0.5">
-            {GRID_MODES.map((mode) => (
-              <button
-                key={mode}
-                type="button"
-                onClick={() => (mode === 'size' ? enterSizeMode() : setSizeMode('count'))}
-                className={`rounded px-2 py-0.5 text-[11px] font-medium transition-colors ${
-                  sizeMode === mode
-                    ? 'bg-accent text-on-accent'
-                    : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
-                }`}
-              >
-                {mode === 'count'
-                  ? t('binDesigner.compartmentEditor.gridModeCount')
-                  : t('binDesigner.compartmentEditor.gridModeSize')}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {sizeMode === 'count' ? (
           <div className="grid grid-cols-2 gap-3">
             <div>
               <span className="mb-1 block text-xs text-content-tertiary">
-                {t('binDesigner.columns')}
+                {t('binDesigner.compartmentEditor.openingWidth')}
               </span>
-              <StepperControl
-                value={cols}
-                onChange={handleColsChange}
-                onStep={handleColsStep}
-                min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID}
-                max={DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID}
-                step={1}
-                variant={stepperVariant}
-                ariaLabel={t('binDesigner.columns')}
-              />
-            </div>
-            <div>
-              <span className="mb-1 block text-xs text-content-tertiary">
-                {t('binDesigner.rows')}
-              </span>
-              <StepperControl
-                value={rows}
-                onChange={handleRowsChange}
-                onStep={handleRowsStep}
-                min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID}
-                max={DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID}
-                step={1}
-                variant={stepperVariant}
-                ariaLabel={t('binDesigner.rows')}
-              />
-            </div>
-          </div>
-        ) : (
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <span className="mb-1 block text-xs text-content-tertiary">
-                {t('binDesigner.compartmentEditor.targetWidth')}
-              </span>
-              <StepperControl
-                value={targetW ?? Math.round(achievedMinW * 10) / 10}
+              <DeferredNumberInput
+                value={achievedMinW}
                 onChange={applyTargetWidth}
-                onStep={(delta) => applyTargetWidth((targetW ?? achievedMinW) + delta)}
                 min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE}
                 max={Math.round(interiorW)}
                 step={1}
-                inputDecimals={1}
-                variant={stepperVariant}
-                ariaLabel={t('binDesigner.compartmentEditor.targetWidth')}
+                decimals={1}
+                className={sizeInputClass}
+                aria-label={t('binDesigner.compartmentEditor.openingWidth')}
               />
-              {fitNoteW && (
-                <span className="mt-1 block text-[11px] tabular-nums text-content-tertiary">
-                  {fitNoteW}
-                </span>
-              )}
             </div>
             <div>
               <span className="mb-1 block text-xs text-content-tertiary">
-                {t('binDesigner.compartmentEditor.targetDepth')}
+                {t('binDesigner.compartmentEditor.openingDepth')}
               </span>
-              <StepperControl
-                value={targetD ?? Math.round(achievedMinD * 10) / 10}
+              <DeferredNumberInput
+                value={achievedMinD}
                 onChange={applyTargetDepth}
-                onStep={(delta) => applyTargetDepth((targetD ?? achievedMinD) + delta)}
                 min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE}
                 max={Math.round(interiorD)}
                 step={1}
-                inputDecimals={1}
-                variant={stepperVariant}
-                ariaLabel={t('binDesigner.compartmentEditor.targetDepth')}
+                decimals={1}
+                className={sizeInputClass}
+                aria-label={t('binDesigner.compartmentEditor.openingDepth')}
               />
-              {fitNoteD && (
-                <span className="mt-1 block text-[11px] tabular-nums text-content-tertiary">
-                  {fitNoteD}
-                </span>
-              )}
             </div>
           </div>
-        )}
+        </div>
 
-        {/* Height (mm) lives with the size inputs; it proxies the same divider
-            height value as the control in the lower section. */}
-        {sizeMode === 'size' && compartmentCount > 1 && <DividerHeightControl />}
+        {/* Grid (count): direct cols×rows control, derived from the same state. */}
+        <div className="space-y-2">
+          <span className="text-xs text-content-tertiary">
+            {t('binDesigner.compartmentEditor.grid')}
+          </span>
+          <div className="grid grid-cols-2 gap-3">
+            <StepperControl
+              value={cols}
+              onChange={handleColsChange}
+              onStep={handleColsStep}
+              min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID}
+              max={DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID}
+              step={1}
+              variant={stepperVariant}
+              ariaLabel={t('binDesigner.columns')}
+            />
+            <StepperControl
+              value={rows}
+              onChange={handleRowsChange}
+              onStep={handleRowsStep}
+              min={DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID}
+              max={DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID}
+              step={1}
+              variant={stepperVariant}
+              ariaLabel={t('binDesigner.rows')}
+            />
+          </div>
+        </div>
+
+        {/* Explains why typed sizes round up, discloses the edge asymmetry, and
+            announces the grid cap. aria-live so the readout is announced as the
+            grid changes. */}
+        <p aria-live="polite" className="text-[11px] text-content-tertiary">
+          {atMaxGrid
+            ? `${t('binDesigner.compartmentEditor.maxGridReached', { max: DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID })} · `
+            : ''}
+          {t('binDesigner.compartmentEditor.tileEvenlyNote')}
+        </p>
+
+        {/* Divider height lives with the sizing panel so the W×D×H story reads
+            together (only meaningful once there are dividers to size). */}
+        {compartmentCount > 1 && <DividerHeightControl />}
       </section>
 
       {/* 2D Layout editor (hidden when 1x1 grid) */}
@@ -720,7 +679,8 @@ export function CompartmentEditor() {
         </section>
       )}
 
-      {/* Wall thickness + divider height (only when there are dividers) */}
+      {/* Wall thickness (only when there are dividers). Divider height lives with
+          the sizing panel above so the W×D×H story reads together. */}
       {compartmentCount > 1 && (
         <section className="space-y-4">
           <SnappingSlider
@@ -730,8 +690,6 @@ export function CompartmentEditor() {
             options={thicknessOptions}
             unit="mm"
           />
-          {/* In size mode the height field is grouped with the size inputs above. */}
-          {sizeMode === 'count' && <DividerHeightControl />}
         </section>
       )}
 

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
@@ -507,6 +507,20 @@ export function CompartmentEditor() {
           </div>
         </div>
 
+        {/* Always-visible readout of the resulting compartment size, so the
+            actual mm dimensions are legible at a glance — no hover required —
+            whether the grid was set by the steppers or by size. Shows the
+            smallest (worst-case interior) compartment; edges may be wider. */}
+        <p className="text-xs tabular-nums text-content-secondary" aria-live="polite">
+          {atMaxGrid
+            ? `${t('binDesigner.compartmentEditor.maxGridReached', { max: DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID })} · `
+            : ''}
+          {t('binDesigner.compartmentEditor.sizeReadout', {
+            width: achievedMinW,
+            depth: achievedMinD,
+          })}
+        </p>
+
         {/* Advanced: set the grid by a minimum compartment size in mm. */}
         <div>
           <button
@@ -566,12 +580,8 @@ export function CompartmentEditor() {
                 </div>
               </div>
               {/* Explains why typed sizes round up and discloses the edge
-                  asymmetry; announces the grid cap. aria-live so the note is
-                  read out as the achieved size changes. */}
-              <p aria-live="polite" className="text-[11px] text-content-tertiary">
-                {atMaxGrid
-                  ? `${t('binDesigner.compartmentEditor.maxGridReached', { max: DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID })} · `
-                  : ''}
+                  asymmetry (the grid cap is announced in the readout above). */}
+              <p className="text-[11px] text-content-tertiary">
                 {t('binDesigner.compartmentEditor.tileEvenlyNote')}
               </p>
             </div>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2279,5 +2279,6 @@
   "binDesigner.compartmentEditor.openingDepth": "Tiefe (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Wird aufgerundet, um die Box gleichmäßig zu füllen · Randfächer sind breiter",
   "binDesigner.compartmentEditor.maxGridReached": "Max. {max} quer",
-  "binDesigner.compartmentEditor.setBySize": "Nach Größe"
+  "binDesigner.compartmentEditor.setBySize": "Nach Größe",
+  "binDesigner.compartmentEditor.sizeReadout": "Fach ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2275,9 +2275,9 @@
   "baseplate.connectorSample.tip4": "Die richtige Passung gefunden? Stellen Sie „Verbinderpassung“ auf diesen Abstand ein.",
   "baseplate.connectorSample.exportComplete": "Passungsmuster exportiert",
   "binDesigner.compartmentEditor.smallestOpening": "Kleinste Öffnung (mm)",
-  "binDesigner.compartmentEditor.openingWidth": "Breite",
-  "binDesigner.compartmentEditor.openingDepth": "Tiefe",
-  "binDesigner.compartmentEditor.grid": "Raster",
+  "binDesigner.compartmentEditor.openingWidth": "Breite (mm)",
+  "binDesigner.compartmentEditor.openingDepth": "Tiefe (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Wird aufgerundet, um die Box gleichmäßig zu füllen · Randfächer sind breiter",
-  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} quer"
+  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} quer",
+  "binDesigner.compartmentEditor.setBySize": "Nach Größe"
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -224,12 +224,6 @@
   "binDesigner.colors.zone.text": "Gravierter Text",
   "binDesigner.columns": "Spalten",
   "binDesigner.compartmentEditor.cellAria": "Zelle {col}, {row}",
-  "binDesigner.compartmentEditor.fitActual": "≥ {value} mm ({delta})",
-  "binDesigner.compartmentEditor.gridMode": "Aufteilung",
-  "binDesigner.compartmentEditor.gridModeCount": "Nach Anzahl",
-  "binDesigner.compartmentEditor.gridModeSize": "Nach Größe",
-  "binDesigner.compartmentEditor.targetDepth": "Fachtiefe (mm)",
-  "binDesigner.compartmentEditor.targetWidth": "Fachbreite (mm)",
   "binDesigner.compartmentEditor.clickToSplit": "Klicken zum Teilen",
   "binDesigner.compartmentEditor.compartmentAria": "Fach {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaSplittable": "Fach {n}, {dimension}, klicken zum Teilen",
@@ -2279,5 +2273,11 @@
   "baseplate.connectorSample.tip2": "Verwenden Sie denselben Drucker, dasselbe Filament und dieselbe Düse wie für die Grundplatte.",
   "baseplate.connectorSample.tip3": "Jedes Musterstück ist mit seinem Stil (DT / DK / SC) und Passungsabstand beschriftet.",
   "baseplate.connectorSample.tip4": "Die richtige Passung gefunden? Stellen Sie „Verbinderpassung“ auf diesen Abstand ein.",
-  "baseplate.connectorSample.exportComplete": "Passungsmuster exportiert"
+  "baseplate.connectorSample.exportComplete": "Passungsmuster exportiert",
+  "binDesigner.compartmentEditor.smallestOpening": "Kleinste Öffnung (mm)",
+  "binDesigner.compartmentEditor.openingWidth": "Breite",
+  "binDesigner.compartmentEditor.openingDepth": "Tiefe",
+  "binDesigner.compartmentEditor.grid": "Raster",
+  "binDesigner.compartmentEditor.tileEvenlyNote": "Wird aufgerundet, um die Box gleichmäßig zu füllen · Randfächer sind breiter",
+  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} quer"
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2278,7 +2278,7 @@
   "binDesigner.compartmentEditor.openingWidth": "Breite (mm)",
   "binDesigner.compartmentEditor.openingDepth": "Tiefe (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Wird aufgerundet, um die Box gleichmäßig zu füllen · Randfächer sind breiter",
-  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} quer",
+  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} pro Seite",
   "binDesigner.compartmentEditor.setBySize": "Nach Größe",
   "binDesigner.compartmentEditor.sizeReadout": "Fach ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2280,5 +2280,6 @@
   "binDesigner.compartmentEditor.openingDepth": "Depth (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Rounds up to tile the bin evenly · edge compartments are wider",
   "binDesigner.compartmentEditor.maxGridReached": "Max {max} across",
-  "binDesigner.compartmentEditor.setBySize": "Set by size"
+  "binDesigner.compartmentEditor.setBySize": "Set by size",
+  "binDesigner.compartmentEditor.sizeReadout": "Compartment ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2279,7 +2279,7 @@
   "binDesigner.compartmentEditor.openingWidth": "Width (mm)",
   "binDesigner.compartmentEditor.openingDepth": "Depth (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Rounds up to tile the bin evenly · edge compartments are wider",
-  "binDesigner.compartmentEditor.maxGridReached": "Max {max} across",
+  "binDesigner.compartmentEditor.maxGridReached": "Max {max} per side",
   "binDesigner.compartmentEditor.setBySize": "Set by size",
   "binDesigner.compartmentEditor.sizeReadout": "Compartment ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2276,9 +2276,9 @@
   "binDesigner.handles.heightAria": "Handle height",
   "binDesigner.handles.countAria": "Handle count",
   "binDesigner.compartmentEditor.smallestOpening": "Smallest opening (mm)",
-  "binDesigner.compartmentEditor.openingWidth": "Width",
-  "binDesigner.compartmentEditor.openingDepth": "Depth",
-  "binDesigner.compartmentEditor.grid": "Grid",
+  "binDesigner.compartmentEditor.openingWidth": "Width (mm)",
+  "binDesigner.compartmentEditor.openingDepth": "Depth (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Rounds up to tile the bin evenly · edge compartments are wider",
-  "binDesigner.compartmentEditor.maxGridReached": "Max {max} across"
+  "binDesigner.compartmentEditor.maxGridReached": "Max {max} across",
+  "binDesigner.compartmentEditor.setBySize": "Set by size"
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2187,12 +2187,6 @@
   "binDesigner.compartmentEditor.compartmentAriaSplittable": "Compartment {n}, {dimension}, click to split",
   "binDesigner.compartmentEditor.compartmentAria": "Compartment {n}, {dimension}",
   "binDesigner.compartmentEditor.cellAria": "Cell {col}, {row}",
-  "binDesigner.compartmentEditor.gridMode": "Layout",
-  "binDesigner.compartmentEditor.gridModeCount": "By count",
-  "binDesigner.compartmentEditor.gridModeSize": "By size",
-  "binDesigner.compartmentEditor.targetWidth": "Compartment width (mm)",
-  "binDesigner.compartmentEditor.targetDepth": "Compartment depth (mm)",
-  "binDesigner.compartmentEditor.fitActual": "≥ {value} mm ({delta})",
   "binDesigner.handles.cornerRadiusAria": "Handle corner radius",
   "binDesigner.handles.verticalPositionAria": "Handle vertical position",
   "gridEditor.resize.westAria": "Resize left edge",
@@ -2280,5 +2274,11 @@
   "binDesigner.labelTabs.insetAria": "Tab inset",
   "binDesigner.handles.widthAria": "Handle width",
   "binDesigner.handles.heightAria": "Handle height",
-  "binDesigner.handles.countAria": "Handle count"
+  "binDesigner.handles.countAria": "Handle count",
+  "binDesigner.compartmentEditor.smallestOpening": "Smallest opening (mm)",
+  "binDesigner.compartmentEditor.openingWidth": "Width",
+  "binDesigner.compartmentEditor.openingDepth": "Depth",
+  "binDesigner.compartmentEditor.grid": "Grid",
+  "binDesigner.compartmentEditor.tileEvenlyNote": "Rounds up to tile the bin evenly · edge compartments are wider",
+  "binDesigner.compartmentEditor.maxGridReached": "Max {max} across"
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2625,7 +2625,7 @@ const en: Record<string, string> = {
   'binDesigner.compartmentEditor.openingDepth': 'Depth (mm)',
   'binDesigner.compartmentEditor.tileEvenlyNote':
     'Rounds up to tile the bin evenly · edge compartments are wider',
-  'binDesigner.compartmentEditor.maxGridReached': 'Max {max} across',
+  'binDesigner.compartmentEditor.maxGridReached': 'Max {max} per side',
 
   // Handles aria-labels
   'binDesigner.handles.cornerRadiusAria': 'Handle corner radius',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2618,12 +2618,13 @@ const en: Record<string, string> = {
     'Compartment {n}, {dimension}, click to split',
   'binDesigner.compartmentEditor.compartmentAria': 'Compartment {n}, {dimension}',
   'binDesigner.compartmentEditor.cellAria': 'Cell {col}, {row}',
-  'binDesigner.compartmentEditor.gridMode': 'Layout',
-  'binDesigner.compartmentEditor.gridModeCount': 'By count',
-  'binDesigner.compartmentEditor.gridModeSize': 'By size',
-  'binDesigner.compartmentEditor.targetWidth': 'Compartment width (mm)',
-  'binDesigner.compartmentEditor.targetDepth': 'Compartment depth (mm)',
-  'binDesigner.compartmentEditor.fitActual': '≥ {value} mm ({delta})',
+  'binDesigner.compartmentEditor.smallestOpening': 'Smallest opening (mm)',
+  'binDesigner.compartmentEditor.openingWidth': 'Width',
+  'binDesigner.compartmentEditor.openingDepth': 'Depth',
+  'binDesigner.compartmentEditor.grid': 'Grid',
+  'binDesigner.compartmentEditor.tileEvenlyNote':
+    'Rounds up to tile the bin evenly · edge compartments are wider',
+  'binDesigner.compartmentEditor.maxGridReached': 'Max {max} across',
 
   // Handles aria-labels
   'binDesigner.handles.cornerRadiusAria': 'Handle corner radius',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2618,6 +2618,7 @@ const en: Record<string, string> = {
     'Compartment {n}, {dimension}, click to split',
   'binDesigner.compartmentEditor.compartmentAria': 'Compartment {n}, {dimension}',
   'binDesigner.compartmentEditor.cellAria': 'Cell {col}, {row}',
+  'binDesigner.compartmentEditor.sizeReadout': 'Compartment ≈ {width} × {depth} mm',
   'binDesigner.compartmentEditor.setBySize': 'Set by size',
   'binDesigner.compartmentEditor.smallestOpening': 'Smallest opening (mm)',
   'binDesigner.compartmentEditor.openingWidth': 'Width (mm)',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2618,10 +2618,10 @@ const en: Record<string, string> = {
     'Compartment {n}, {dimension}, click to split',
   'binDesigner.compartmentEditor.compartmentAria': 'Compartment {n}, {dimension}',
   'binDesigner.compartmentEditor.cellAria': 'Cell {col}, {row}',
+  'binDesigner.compartmentEditor.setBySize': 'Set by size',
   'binDesigner.compartmentEditor.smallestOpening': 'Smallest opening (mm)',
-  'binDesigner.compartmentEditor.openingWidth': 'Width',
-  'binDesigner.compartmentEditor.openingDepth': 'Depth',
-  'binDesigner.compartmentEditor.grid': 'Grid',
+  'binDesigner.compartmentEditor.openingWidth': 'Width (mm)',
+  'binDesigner.compartmentEditor.openingDepth': 'Depth (mm)',
   'binDesigner.compartmentEditor.tileEvenlyNote':
     'Rounds up to tile the bin evenly · edge compartments are wider',
   'binDesigner.compartmentEditor.maxGridReached': 'Max {max} across',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2279,5 +2279,6 @@
   "binDesigner.compartmentEditor.openingDepth": "Profundidad (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Se redondea hacia arriba para llenar la caja de forma uniforme · los compartimentos de los bordes son más anchos",
   "binDesigner.compartmentEditor.maxGridReached": "Máx. {max} de ancho",
-  "binDesigner.compartmentEditor.setBySize": "Por tamaño"
+  "binDesigner.compartmentEditor.setBySize": "Por tamaño",
+  "binDesigner.compartmentEditor.sizeReadout": "Compartimento ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2275,9 +2275,9 @@
   "baseplate.connectorSample.tip4": "¿Encontraste el ajuste adecuado? Establece «Ajuste del conector» en ese valor.",
   "baseplate.connectorSample.exportComplete": "Muestra de ajuste exportada",
   "binDesigner.compartmentEditor.smallestOpening": "Abertura más pequeña (mm)",
-  "binDesigner.compartmentEditor.openingWidth": "Ancho",
-  "binDesigner.compartmentEditor.openingDepth": "Profundidad",
-  "binDesigner.compartmentEditor.grid": "Cuadrícula",
+  "binDesigner.compartmentEditor.openingWidth": "Ancho (mm)",
+  "binDesigner.compartmentEditor.openingDepth": "Profundidad (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Se redondea hacia arriba para llenar la caja de forma uniforme · los compartimentos de los bordes son más anchos",
-  "binDesigner.compartmentEditor.maxGridReached": "Máx. {max} de ancho"
+  "binDesigner.compartmentEditor.maxGridReached": "Máx. {max} de ancho",
+  "binDesigner.compartmentEditor.setBySize": "Por tamaño"
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2278,7 +2278,7 @@
   "binDesigner.compartmentEditor.openingWidth": "Ancho (mm)",
   "binDesigner.compartmentEditor.openingDepth": "Profundidad (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Se redondea hacia arriba para llenar la caja de forma uniforme · los compartimentos de los bordes son más anchos",
-  "binDesigner.compartmentEditor.maxGridReached": "Máx. {max} de ancho",
+  "binDesigner.compartmentEditor.maxGridReached": "Máx. {max} por lado",
   "binDesigner.compartmentEditor.setBySize": "Por tamaño",
   "binDesigner.compartmentEditor.sizeReadout": "Compartimento ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -224,12 +224,6 @@
   "binDesigner.colors.zone.text": "Texto grabado",
   "binDesigner.columns": "Columnas",
   "binDesigner.compartmentEditor.cellAria": "Celda {col}, {row}",
-  "binDesigner.compartmentEditor.fitActual": "≥ {value} mm ({delta})",
-  "binDesigner.compartmentEditor.gridMode": "Disposición",
-  "binDesigner.compartmentEditor.gridModeCount": "Por cantidad",
-  "binDesigner.compartmentEditor.gridModeSize": "Por tamaño",
-  "binDesigner.compartmentEditor.targetDepth": "Profundidad del compartimento (mm)",
-  "binDesigner.compartmentEditor.targetWidth": "Ancho del compartimento (mm)",
   "binDesigner.compartmentEditor.clickToSplit": "Clic para dividir",
   "binDesigner.compartmentEditor.compartmentAria": "Compartimento {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaSplittable": "Compartimento {n}, {dimension}, clic para dividir",
@@ -2279,5 +2273,11 @@
   "baseplate.connectorSample.tip2": "Usa la misma impresora, filamento y boquilla con los que imprimirás la placa base.",
   "baseplate.connectorSample.tip3": "Cada cupón está etiquetado con su estilo (DT / DK / SC) y su ajuste.",
   "baseplate.connectorSample.tip4": "¿Encontraste el ajuste adecuado? Establece «Ajuste del conector» en ese valor.",
-  "baseplate.connectorSample.exportComplete": "Muestra de ajuste exportada"
+  "baseplate.connectorSample.exportComplete": "Muestra de ajuste exportada",
+  "binDesigner.compartmentEditor.smallestOpening": "Abertura más pequeña (mm)",
+  "binDesigner.compartmentEditor.openingWidth": "Ancho",
+  "binDesigner.compartmentEditor.openingDepth": "Profundidad",
+  "binDesigner.compartmentEditor.grid": "Cuadrícula",
+  "binDesigner.compartmentEditor.tileEvenlyNote": "Se redondea hacia arriba para llenar la caja de forma uniforme · los compartimentos de los bordes son más anchos",
+  "binDesigner.compartmentEditor.maxGridReached": "Máx. {max} de ancho"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2278,7 +2278,7 @@
   "binDesigner.compartmentEditor.openingWidth": "Largeur (mm)",
   "binDesigner.compartmentEditor.openingDepth": "Profondeur (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Arrondi à la hausse pour remplir le bac uniformément · les compartiments de bord sont plus larges",
-  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} en largeur",
+  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} par côté",
   "binDesigner.compartmentEditor.setBySize": "Par taille",
   "binDesigner.compartmentEditor.sizeReadout": "Compartiment ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2279,5 +2279,6 @@
   "binDesigner.compartmentEditor.openingDepth": "Profondeur (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Arrondi à la hausse pour remplir le bac uniformément · les compartiments de bord sont plus larges",
   "binDesigner.compartmentEditor.maxGridReached": "Max. {max} en largeur",
-  "binDesigner.compartmentEditor.setBySize": "Par taille"
+  "binDesigner.compartmentEditor.setBySize": "Par taille",
+  "binDesigner.compartmentEditor.sizeReadout": "Compartiment ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -224,12 +224,6 @@
   "binDesigner.colors.zone.text": "Texte gravé",
   "binDesigner.columns": "Colonnes",
   "binDesigner.compartmentEditor.cellAria": "Cellule {col}, {row}",
-  "binDesigner.compartmentEditor.fitActual": "≥ {value} mm ({delta})",
-  "binDesigner.compartmentEditor.gridMode": "Disposition",
-  "binDesigner.compartmentEditor.gridModeCount": "Par nombre",
-  "binDesigner.compartmentEditor.gridModeSize": "Par taille",
-  "binDesigner.compartmentEditor.targetDepth": "Profondeur du compartiment (mm)",
-  "binDesigner.compartmentEditor.targetWidth": "Largeur du compartiment (mm)",
   "binDesigner.compartmentEditor.clickToSplit": "Cliquer pour diviser",
   "binDesigner.compartmentEditor.compartmentAria": "Compartiment {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaSplittable": "Compartiment {n}, {dimension}, cliquer pour diviser",
@@ -2279,5 +2273,11 @@
   "baseplate.connectorSample.tip2": "Utilisez la même imprimante, le même filament et la même buse que pour la plaque de base.",
   "baseplate.connectorSample.tip3": "Chaque échantillon est étiqueté avec son style (DT / DK / SC) et son ajustement.",
   "baseplate.connectorSample.tip4": "Vous avez trouvé le bon ajustement ? Réglez « Ajustement du connecteur » sur cette valeur.",
-  "baseplate.connectorSample.exportComplete": "Échantillon d'ajustement exporté"
+  "baseplate.connectorSample.exportComplete": "Échantillon d'ajustement exporté",
+  "binDesigner.compartmentEditor.smallestOpening": "Plus petite ouverture (mm)",
+  "binDesigner.compartmentEditor.openingWidth": "Largeur",
+  "binDesigner.compartmentEditor.openingDepth": "Profondeur",
+  "binDesigner.compartmentEditor.grid": "Grille",
+  "binDesigner.compartmentEditor.tileEvenlyNote": "Arrondi à la hausse pour remplir le bac uniformément · les compartiments de bord sont plus larges",
+  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} en largeur"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2275,9 +2275,9 @@
   "baseplate.connectorSample.tip4": "Vous avez trouvé le bon ajustement ? Réglez « Ajustement du connecteur » sur cette valeur.",
   "baseplate.connectorSample.exportComplete": "Échantillon d'ajustement exporté",
   "binDesigner.compartmentEditor.smallestOpening": "Plus petite ouverture (mm)",
-  "binDesigner.compartmentEditor.openingWidth": "Largeur",
-  "binDesigner.compartmentEditor.openingDepth": "Profondeur",
-  "binDesigner.compartmentEditor.grid": "Grille",
+  "binDesigner.compartmentEditor.openingWidth": "Largeur (mm)",
+  "binDesigner.compartmentEditor.openingDepth": "Profondeur (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Arrondi à la hausse pour remplir le bac uniformément · les compartiments de bord sont plus larges",
-  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} en largeur"
+  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} en largeur",
+  "binDesigner.compartmentEditor.setBySize": "Par taille"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2275,9 +2275,9 @@
   "baseplate.connectorSample.tip4": "ぴったりのフィットが見つかりましたか？「コネクタフィット」をそのオフセットに設定してください。",
   "baseplate.connectorSample.exportComplete": "フィットサンプルを書き出しました",
   "binDesigner.compartmentEditor.smallestOpening": "最小の開口部 (mm)",
-  "binDesigner.compartmentEditor.openingWidth": "幅",
-  "binDesigner.compartmentEditor.openingDepth": "奥行き",
-  "binDesigner.compartmentEditor.grid": "グリッド",
+  "binDesigner.compartmentEditor.openingWidth": "幅 (mm)",
+  "binDesigner.compartmentEditor.openingDepth": "奥行き (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "ビンを均等に分割するため切り上げられます · 端の区画は広くなります",
-  "binDesigner.compartmentEditor.maxGridReached": "最大 {max} 列"
+  "binDesigner.compartmentEditor.maxGridReached": "最大 {max} 列",
+  "binDesigner.compartmentEditor.setBySize": "サイズで指定"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -224,12 +224,6 @@
   "binDesigner.colors.zone.text": "彫刻文字",
   "binDesigner.columns": "列数",
   "binDesigner.compartmentEditor.cellAria": "セル{col}、{row}",
-  "binDesigner.compartmentEditor.fitActual": "≥ {value} mm ({delta})",
-  "binDesigner.compartmentEditor.gridMode": "レイアウト",
-  "binDesigner.compartmentEditor.gridModeCount": "数で指定",
-  "binDesigner.compartmentEditor.gridModeSize": "サイズで指定",
-  "binDesigner.compartmentEditor.targetDepth": "区画の奥行き (mm)",
-  "binDesigner.compartmentEditor.targetWidth": "区画の幅 (mm)",
   "binDesigner.compartmentEditor.clickToSplit": "クリックして分割",
   "binDesigner.compartmentEditor.compartmentAria": "区画{n}、{dimension}",
   "binDesigner.compartmentEditor.compartmentAriaSplittable": "区画{n}、{dimension}、クリックして分割",
@@ -2279,5 +2273,11 @@
   "baseplate.connectorSample.tip2": "ベースプレートを印刷するのと同じプリンター・フィラメント・ノズルを使用してください。",
   "baseplate.connectorSample.tip3": "各クーポンにはスタイル（DT / DK / SC）とフィットオフセットが表示されています。",
   "baseplate.connectorSample.tip4": "ぴったりのフィットが見つかりましたか？「コネクタフィット」をそのオフセットに設定してください。",
-  "baseplate.connectorSample.exportComplete": "フィットサンプルを書き出しました"
+  "baseplate.connectorSample.exportComplete": "フィットサンプルを書き出しました",
+  "binDesigner.compartmentEditor.smallestOpening": "最小の開口部 (mm)",
+  "binDesigner.compartmentEditor.openingWidth": "幅",
+  "binDesigner.compartmentEditor.openingDepth": "奥行き",
+  "binDesigner.compartmentEditor.grid": "グリッド",
+  "binDesigner.compartmentEditor.tileEvenlyNote": "ビンを均等に分割するため切り上げられます · 端の区画は広くなります",
+  "binDesigner.compartmentEditor.maxGridReached": "最大 {max} 列"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2279,5 +2279,6 @@
   "binDesigner.compartmentEditor.openingDepth": "奥行き (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "ビンを均等に分割するため切り上げられます · 端の区画は広くなります",
   "binDesigner.compartmentEditor.maxGridReached": "最大 {max} 列",
-  "binDesigner.compartmentEditor.setBySize": "サイズで指定"
+  "binDesigner.compartmentEditor.setBySize": "サイズで指定",
+  "binDesigner.compartmentEditor.sizeReadout": "区画 ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2278,7 +2278,7 @@
   "binDesigner.compartmentEditor.openingWidth": "幅 (mm)",
   "binDesigner.compartmentEditor.openingDepth": "奥行き (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "ビンを均等に分割するため切り上げられます · 端の区画は広くなります",
-  "binDesigner.compartmentEditor.maxGridReached": "最大 {max} 列",
+  "binDesigner.compartmentEditor.maxGridReached": "各辺 最大 {max}",
   "binDesigner.compartmentEditor.setBySize": "サイズで指定",
   "binDesigner.compartmentEditor.sizeReadout": "区画 ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -2275,9 +2275,9 @@
   "baseplate.connectorSample.tip4": "Fant du riktig passform? Still «Koblingspassform» til den forskyvningen.",
   "baseplate.connectorSample.exportComplete": "Passprøve eksportert",
   "binDesigner.compartmentEditor.smallestOpening": "Minste åpning (mm)",
-  "binDesigner.compartmentEditor.openingWidth": "Bredde",
-  "binDesigner.compartmentEditor.openingDepth": "Dybde",
-  "binDesigner.compartmentEditor.grid": "Rutenett",
+  "binDesigner.compartmentEditor.openingWidth": "Bredde (mm)",
+  "binDesigner.compartmentEditor.openingDepth": "Dybde (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Rundes opp for å fylle beholderen jevnt · ytterrom er bredere",
-  "binDesigner.compartmentEditor.maxGridReached": "Maks {max} på tvers"
+  "binDesigner.compartmentEditor.maxGridReached": "Maks {max} på tvers",
+  "binDesigner.compartmentEditor.setBySize": "Etter størrelse"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -2278,7 +2278,7 @@
   "binDesigner.compartmentEditor.openingWidth": "Bredde (mm)",
   "binDesigner.compartmentEditor.openingDepth": "Dybde (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Rundes opp for å fylle beholderen jevnt · ytterrom er bredere",
-  "binDesigner.compartmentEditor.maxGridReached": "Maks {max} på tvers",
+  "binDesigner.compartmentEditor.maxGridReached": "Maks {max} per side",
   "binDesigner.compartmentEditor.setBySize": "Etter størrelse",
   "binDesigner.compartmentEditor.sizeReadout": "Rom ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -2279,5 +2279,6 @@
   "binDesigner.compartmentEditor.openingDepth": "Dybde (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Rundes opp for å fylle beholderen jevnt · ytterrom er bredere",
   "binDesigner.compartmentEditor.maxGridReached": "Maks {max} på tvers",
-  "binDesigner.compartmentEditor.setBySize": "Etter størrelse"
+  "binDesigner.compartmentEditor.setBySize": "Etter størrelse",
+  "binDesigner.compartmentEditor.sizeReadout": "Rom ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -224,12 +224,6 @@
   "binDesigner.colors.zone.text": "Gravert tekst",
   "binDesigner.columns": "Kolonner",
   "binDesigner.compartmentEditor.cellAria": "Celle {col}, {row}",
-  "binDesigner.compartmentEditor.fitActual": "≥ {value} mm ({delta})",
-  "binDesigner.compartmentEditor.gridMode": "Oppsett",
-  "binDesigner.compartmentEditor.gridModeCount": "Etter antall",
-  "binDesigner.compartmentEditor.gridModeSize": "Etter størrelse",
-  "binDesigner.compartmentEditor.targetDepth": "Romdybde (mm)",
-  "binDesigner.compartmentEditor.targetWidth": "Rombredde (mm)",
   "binDesigner.compartmentEditor.clickToSplit": "Klikk for å dele",
   "binDesigner.compartmentEditor.compartmentAria": "Rom {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaSplittable": "Rom {n}, {dimension}, klikk for å dele",
@@ -2279,5 +2273,11 @@
   "baseplate.connectorSample.tip2": "Bruk samme skriver, filament og dyse som du skal skrive ut bunnplaten med.",
   "baseplate.connectorSample.tip3": "Hver prøvebit er merket med stil (DT / DK / SC) og passforskyvning.",
   "baseplate.connectorSample.tip4": "Fant du riktig passform? Still «Koblingspassform» til den forskyvningen.",
-  "baseplate.connectorSample.exportComplete": "Passprøve eksportert"
+  "baseplate.connectorSample.exportComplete": "Passprøve eksportert",
+  "binDesigner.compartmentEditor.smallestOpening": "Minste åpning (mm)",
+  "binDesigner.compartmentEditor.openingWidth": "Bredde",
+  "binDesigner.compartmentEditor.openingDepth": "Dybde",
+  "binDesigner.compartmentEditor.grid": "Rutenett",
+  "binDesigner.compartmentEditor.tileEvenlyNote": "Rundes opp for å fylle beholderen jevnt · ytterrom er bredere",
+  "binDesigner.compartmentEditor.maxGridReached": "Maks {max} på tvers"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -2278,7 +2278,7 @@
   "binDesigner.compartmentEditor.openingWidth": "Breedte (mm)",
   "binDesigner.compartmentEditor.openingDepth": "Diepte (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Wordt naar boven afgerond om de bak gelijkmatig te vullen · randvakken zijn breder",
-  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} breed",
+  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} per zijde",
   "binDesigner.compartmentEditor.setBySize": "Op grootte",
   "binDesigner.compartmentEditor.sizeReadout": "Vak ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -2279,5 +2279,6 @@
   "binDesigner.compartmentEditor.openingDepth": "Diepte (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Wordt naar boven afgerond om de bak gelijkmatig te vullen · randvakken zijn breder",
   "binDesigner.compartmentEditor.maxGridReached": "Max. {max} breed",
-  "binDesigner.compartmentEditor.setBySize": "Op grootte"
+  "binDesigner.compartmentEditor.setBySize": "Op grootte",
+  "binDesigner.compartmentEditor.sizeReadout": "Vak ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -2275,9 +2275,9 @@
   "baseplate.connectorSample.tip4": "De juiste pasvorm gevonden? Stel «Connectorpasvorm» in op die offset.",
   "baseplate.connectorSample.exportComplete": "Pasvormmonster geëxporteerd",
   "binDesigner.compartmentEditor.smallestOpening": "Kleinste opening (mm)",
-  "binDesigner.compartmentEditor.openingWidth": "Breedte",
-  "binDesigner.compartmentEditor.openingDepth": "Diepte",
-  "binDesigner.compartmentEditor.grid": "Raster",
+  "binDesigner.compartmentEditor.openingWidth": "Breedte (mm)",
+  "binDesigner.compartmentEditor.openingDepth": "Diepte (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Wordt naar boven afgerond om de bak gelijkmatig te vullen · randvakken zijn breder",
-  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} breed"
+  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} breed",
+  "binDesigner.compartmentEditor.setBySize": "Op grootte"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -224,12 +224,6 @@
   "binDesigner.colors.zone.text": "Gegraveerde tekst",
   "binDesigner.columns": "Kolommen",
   "binDesigner.compartmentEditor.cellAria": "Cel {col}, {row}",
-  "binDesigner.compartmentEditor.fitActual": "≥ {value} mm ({delta})",
-  "binDesigner.compartmentEditor.gridMode": "Indeling",
-  "binDesigner.compartmentEditor.gridModeCount": "Op aantal",
-  "binDesigner.compartmentEditor.gridModeSize": "Op grootte",
-  "binDesigner.compartmentEditor.targetDepth": "Vakdiepte (mm)",
-  "binDesigner.compartmentEditor.targetWidth": "Vakbreedte (mm)",
   "binDesigner.compartmentEditor.clickToSplit": "Klik om te splitsen",
   "binDesigner.compartmentEditor.compartmentAria": "Compartiment {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaSplittable": "Compartiment {n}, {dimension}, klik om te splitsen",
@@ -2279,5 +2273,11 @@
   "baseplate.connectorSample.tip2": "Gebruik dezelfde printer, hetzelfde filament en dezelfde nozzle als waarmee je de basisplaat print.",
   "baseplate.connectorSample.tip3": "Elk monster is gelabeld met zijn stijl (DT / DK / SC) en pasvorm-offset.",
   "baseplate.connectorSample.tip4": "De juiste pasvorm gevonden? Stel «Connectorpasvorm» in op die offset.",
-  "baseplate.connectorSample.exportComplete": "Pasvormmonster geëxporteerd"
+  "baseplate.connectorSample.exportComplete": "Pasvormmonster geëxporteerd",
+  "binDesigner.compartmentEditor.smallestOpening": "Kleinste opening (mm)",
+  "binDesigner.compartmentEditor.openingWidth": "Breedte",
+  "binDesigner.compartmentEditor.openingDepth": "Diepte",
+  "binDesigner.compartmentEditor.grid": "Raster",
+  "binDesigner.compartmentEditor.tileEvenlyNote": "Wordt naar boven afgerond om de bak gelijkmatig te vullen · randvakken zijn breder",
+  "binDesigner.compartmentEditor.maxGridReached": "Max. {max} breed"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2278,7 +2278,7 @@
   "binDesigner.compartmentEditor.openingWidth": "Largura (mm)",
   "binDesigner.compartmentEditor.openingDepth": "Profundidade (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Arredondado para cima para preencher a caixa uniformemente · os compartimentos das bordas são mais largos",
-  "binDesigner.compartmentEditor.maxGridReached": "Máx. {max} de largura",
+  "binDesigner.compartmentEditor.maxGridReached": "Máx. {max} por lado",
   "binDesigner.compartmentEditor.setBySize": "Por tamanho",
   "binDesigner.compartmentEditor.sizeReadout": "Compartimento ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2275,9 +2275,9 @@
   "baseplate.connectorSample.tip4": "Encontrou o encaixe certo? Defina «Encaixe do conector» com esse valor.",
   "baseplate.connectorSample.exportComplete": "Amostra de encaixe exportada",
   "binDesigner.compartmentEditor.smallestOpening": "Menor abertura (mm)",
-  "binDesigner.compartmentEditor.openingWidth": "Largura",
-  "binDesigner.compartmentEditor.openingDepth": "Profundidade",
-  "binDesigner.compartmentEditor.grid": "Grade",
+  "binDesigner.compartmentEditor.openingWidth": "Largura (mm)",
+  "binDesigner.compartmentEditor.openingDepth": "Profundidade (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Arredondado para cima para preencher a caixa uniformemente · os compartimentos das bordas são mais largos",
-  "binDesigner.compartmentEditor.maxGridReached": "Máx. {max} de largura"
+  "binDesigner.compartmentEditor.maxGridReached": "Máx. {max} de largura",
+  "binDesigner.compartmentEditor.setBySize": "Por tamanho"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -224,12 +224,6 @@
   "binDesigner.colors.zone.text": "Texto gravado",
   "binDesigner.columns": "Colunas",
   "binDesigner.compartmentEditor.cellAria": "Célula {col}, {row}",
-  "binDesigner.compartmentEditor.fitActual": "≥ {value} mm ({delta})",
-  "binDesigner.compartmentEditor.gridMode": "Disposição",
-  "binDesigner.compartmentEditor.gridModeCount": "Por quantidade",
-  "binDesigner.compartmentEditor.gridModeSize": "Por tamanho",
-  "binDesigner.compartmentEditor.targetDepth": "Profundidade do compartimento (mm)",
-  "binDesigner.compartmentEditor.targetWidth": "Largura do compartimento (mm)",
   "binDesigner.compartmentEditor.clickToSplit": "Clique para dividir",
   "binDesigner.compartmentEditor.compartmentAria": "Compartimento {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaSplittable": "Compartimento {n}, {dimension}, clique para dividir",
@@ -2279,5 +2273,11 @@
   "baseplate.connectorSample.tip2": "Use a mesma impressora, filamento e bico com que você imprimirá a placa base.",
   "baseplate.connectorSample.tip3": "Cada amostra é rotulada com seu estilo (DT / DK / SC) e ajuste de encaixe.",
   "baseplate.connectorSample.tip4": "Encontrou o encaixe certo? Defina «Encaixe do conector» com esse valor.",
-  "baseplate.connectorSample.exportComplete": "Amostra de encaixe exportada"
+  "baseplate.connectorSample.exportComplete": "Amostra de encaixe exportada",
+  "binDesigner.compartmentEditor.smallestOpening": "Menor abertura (mm)",
+  "binDesigner.compartmentEditor.openingWidth": "Largura",
+  "binDesigner.compartmentEditor.openingDepth": "Profundidade",
+  "binDesigner.compartmentEditor.grid": "Grade",
+  "binDesigner.compartmentEditor.tileEvenlyNote": "Arredondado para cima para preencher a caixa uniformemente · os compartimentos das bordas são mais largos",
+  "binDesigner.compartmentEditor.maxGridReached": "Máx. {max} de largura"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2279,5 +2279,6 @@
   "binDesigner.compartmentEditor.openingDepth": "Profundidade (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Arredondado para cima para preencher a caixa uniformemente · os compartimentos das bordas são mais largos",
   "binDesigner.compartmentEditor.maxGridReached": "Máx. {max} de largura",
-  "binDesigner.compartmentEditor.setBySize": "Por tamanho"
+  "binDesigner.compartmentEditor.setBySize": "Por tamanho",
+  "binDesigner.compartmentEditor.sizeReadout": "Compartimento ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -2275,9 +2275,9 @@
   "baseplate.connectorSample.tip4": "Hittade du rätt passning? Ställ in «Kopplingspassning» på den förskjutningen.",
   "baseplate.connectorSample.exportComplete": "Passprov exporterat",
   "binDesigner.compartmentEditor.smallestOpening": "Minsta öppning (mm)",
-  "binDesigner.compartmentEditor.openingWidth": "Bredd",
-  "binDesigner.compartmentEditor.openingDepth": "Djup",
-  "binDesigner.compartmentEditor.grid": "Rutnät",
+  "binDesigner.compartmentEditor.openingWidth": "Bredd (mm)",
+  "binDesigner.compartmentEditor.openingDepth": "Djup (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Avrundas uppåt för att fylla lådan jämnt · kantfack är bredare",
-  "binDesigner.compartmentEditor.maxGridReached": "Max {max} på bredden"
+  "binDesigner.compartmentEditor.maxGridReached": "Max {max} på bredden",
+  "binDesigner.compartmentEditor.setBySize": "Efter storlek"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -2279,5 +2279,6 @@
   "binDesigner.compartmentEditor.openingDepth": "Djup (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Avrundas uppåt för att fylla lådan jämnt · kantfack är bredare",
   "binDesigner.compartmentEditor.maxGridReached": "Max {max} på bredden",
-  "binDesigner.compartmentEditor.setBySize": "Efter storlek"
+  "binDesigner.compartmentEditor.setBySize": "Efter storlek",
+  "binDesigner.compartmentEditor.sizeReadout": "Fack ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -224,12 +224,6 @@
   "binDesigner.colors.zone.text": "Graverad text",
   "binDesigner.columns": "Kolumner",
   "binDesigner.compartmentEditor.cellAria": "Cell {col}, {row}",
-  "binDesigner.compartmentEditor.fitActual": "≥ {value} mm ({delta})",
-  "binDesigner.compartmentEditor.gridMode": "Indelning",
-  "binDesigner.compartmentEditor.gridModeCount": "Efter antal",
-  "binDesigner.compartmentEditor.gridModeSize": "Efter storlek",
-  "binDesigner.compartmentEditor.targetDepth": "Fackdjup (mm)",
-  "binDesigner.compartmentEditor.targetWidth": "Fackbredd (mm)",
   "binDesigner.compartmentEditor.clickToSplit": "Klicka för att dela",
   "binDesigner.compartmentEditor.compartmentAria": "Fack {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaSplittable": "Fack {n}, {dimension}, klicka för att dela",
@@ -2279,5 +2273,11 @@
   "baseplate.connectorSample.tip2": "Använd samma skrivare, filament och munstycke som du skriver ut bottenplattan med.",
   "baseplate.connectorSample.tip3": "Varje provbit är märkt med sin stil (DT / DK / SC) och passningsförskjutning.",
   "baseplate.connectorSample.tip4": "Hittade du rätt passning? Ställ in «Kopplingspassning» på den förskjutningen.",
-  "baseplate.connectorSample.exportComplete": "Passprov exporterat"
+  "baseplate.connectorSample.exportComplete": "Passprov exporterat",
+  "binDesigner.compartmentEditor.smallestOpening": "Minsta öppning (mm)",
+  "binDesigner.compartmentEditor.openingWidth": "Bredd",
+  "binDesigner.compartmentEditor.openingDepth": "Djup",
+  "binDesigner.compartmentEditor.grid": "Rutnät",
+  "binDesigner.compartmentEditor.tileEvenlyNote": "Avrundas uppåt för att fylla lådan jämnt · kantfack är bredare",
+  "binDesigner.compartmentEditor.maxGridReached": "Max {max} på bredden"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -2278,7 +2278,7 @@
   "binDesigner.compartmentEditor.openingWidth": "Bredd (mm)",
   "binDesigner.compartmentEditor.openingDepth": "Djup (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Avrundas uppåt för att fylla lådan jämnt · kantfack är bredare",
-  "binDesigner.compartmentEditor.maxGridReached": "Max {max} på bredden",
+  "binDesigner.compartmentEditor.maxGridReached": "Max {max} per sida",
   "binDesigner.compartmentEditor.setBySize": "Efter storlek",
   "binDesigner.compartmentEditor.sizeReadout": "Fack ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -2279,5 +2279,6 @@
   "binDesigner.compartmentEditor.openingDepth": "Глибина (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Округлюється вгору, щоб рівномірно заповнити контейнер · крайні відсіки ширші",
   "binDesigner.compartmentEditor.maxGridReached": "Макс. {max} у ряд",
-  "binDesigner.compartmentEditor.setBySize": "За розміром"
+  "binDesigner.compartmentEditor.setBySize": "За розміром",
+  "binDesigner.compartmentEditor.sizeReadout": "Відсік ≈ {width} × {depth} mm"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -224,12 +224,6 @@
   "binDesigner.colors.zone.text": "Гравірований текст",
   "binDesigner.columns": "Стовпці",
   "binDesigner.compartmentEditor.cellAria": "Клітинка {col}, {row}",
-  "binDesigner.compartmentEditor.fitActual": "≥ {value} mm ({delta})",
-  "binDesigner.compartmentEditor.gridMode": "Розташування",
-  "binDesigner.compartmentEditor.gridModeCount": "За кількістю",
-  "binDesigner.compartmentEditor.gridModeSize": "За розміром",
-  "binDesigner.compartmentEditor.targetDepth": "Глибина відсіку (mm)",
-  "binDesigner.compartmentEditor.targetWidth": "Ширина відсіку (mm)",
   "binDesigner.compartmentEditor.clickToSplit": "Натисніть, щоб розділити",
   "binDesigner.compartmentEditor.compartmentAria": "Відсік {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaSplittable": "Відсік {n}, {dimension}, натисніть, щоб розділити",
@@ -2279,5 +2273,11 @@
   "baseplate.connectorSample.tip2": "Використовуйте той самий принтер, філамент і сопло, що й для опорної плити.",
   "baseplate.connectorSample.tip3": "Кожен зразок позначено стилем (DT / DK / SC) і зміщенням припасування.",
   "baseplate.connectorSample.tip4": "Знайшли потрібне припасування? Встановіть «Припасування з’єднувача» на це зміщення.",
-  "baseplate.connectorSample.exportComplete": "Зразок припасування експортовано"
+  "baseplate.connectorSample.exportComplete": "Зразок припасування експортовано",
+  "binDesigner.compartmentEditor.smallestOpening": "Найменший отвір (mm)",
+  "binDesigner.compartmentEditor.openingWidth": "Ширина",
+  "binDesigner.compartmentEditor.openingDepth": "Глибина",
+  "binDesigner.compartmentEditor.grid": "Сітка",
+  "binDesigner.compartmentEditor.tileEvenlyNote": "Округлюється вгору, щоб рівномірно заповнити контейнер · крайні відсіки ширші",
+  "binDesigner.compartmentEditor.maxGridReached": "Макс. {max} у ряд"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -2275,9 +2275,9 @@
   "baseplate.connectorSample.tip4": "Знайшли потрібне припасування? Встановіть «Припасування з’єднувача» на це зміщення.",
   "baseplate.connectorSample.exportComplete": "Зразок припасування експортовано",
   "binDesigner.compartmentEditor.smallestOpening": "Найменший отвір (mm)",
-  "binDesigner.compartmentEditor.openingWidth": "Ширина",
-  "binDesigner.compartmentEditor.openingDepth": "Глибина",
-  "binDesigner.compartmentEditor.grid": "Сітка",
+  "binDesigner.compartmentEditor.openingWidth": "Ширина (mm)",
+  "binDesigner.compartmentEditor.openingDepth": "Глибина (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Округлюється вгору, щоб рівномірно заповнити контейнер · крайні відсіки ширші",
-  "binDesigner.compartmentEditor.maxGridReached": "Макс. {max} у ряд"
+  "binDesigner.compartmentEditor.maxGridReached": "Макс. {max} у ряд",
+  "binDesigner.compartmentEditor.setBySize": "За розміром"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -2278,7 +2278,7 @@
   "binDesigner.compartmentEditor.openingWidth": "Ширина (mm)",
   "binDesigner.compartmentEditor.openingDepth": "Глибина (mm)",
   "binDesigner.compartmentEditor.tileEvenlyNote": "Округлюється вгору, щоб рівномірно заповнити контейнер · крайні відсіки ширші",
-  "binDesigner.compartmentEditor.maxGridReached": "Макс. {max} у ряд",
+  "binDesigner.compartmentEditor.maxGridReached": "Макс. {max} на сторону",
   "binDesigner.compartmentEditor.setBySize": "За розміром",
   "binDesigner.compartmentEditor.sizeReadout": "Відсік ≈ {width} × {depth} mm"
 }


### PR DESCRIPTION
## What & why

The "compartment dimensions in mm" feature (#2101) added a `By count / By size` mode toggle. The size mode was confusing: the `≥ X mm (+2.1)` readout was cryptic, and it wasn't obvious that what you type is a **minimum** rather than the size you get.

This reworks the compartment editor so the **Columns/Rows steppers are the primary control**, and setting the grid by a target compartment size becomes an **advanced opt-in**. The fit-guarantee model is preserved — typing a minimum size still packs as many compartments as fit while keeping every one at least that big — it's just no longer the default surface.

## How it works

- **Primary:** Columns/Rows `StepperControl`s, front and center. The grid (`cols × rows`) is the single source of truth.
- **Advanced — "Set by size":** a collapsed disclosure (collapsed by default). Expanding it reveals minimum Width/Depth fields in mm; typing one runs the existing fit-guarantee solver, snaps the count, and the field reflects the achieved smallest opening. A short caption explains sizes round up to tile the bin evenly and that edge compartments are wider.
- **Divider height** lives with the wall-thickness controls (its original home).
- Solver / cavity math (`compartmentDimensions.ts`) is reused unchanged — no geometry changes.

## Why the disclosure (and an a11y fix)

`CompartmentEditor` renders inside `ParameterPanel`, alongside the bin's own Width/Depth dimension controls. Keeping the size inputs out of the DOM until opted into — plus giving them `(mm)`-suffixed labels — avoids a duplicate-accessible-name collision with those controls (which is both an a11y bug and what broke `ParameterPanel.test.tsx`).

## Design doc

`docs/superpowers/specs/2026-06-11-compartment-sizing-ux-design.md` captures the decisions, the UX review findings, and the post-review pivot to this stepper-focused layout.

## Testing

- TDD on `CompartmentEditor.test.tsx`: steppers primary, no toggle, sizer collapsed by default, expand reveals the mm inputs, typed width snaps the column count, and no accessible-name collision with the bin dimensions.
- Verified against the **full** unit+dom suite (876 files, 11,579 tests), not just the bin-designer subset.
- `pnpm run typecheck`, `pnpm run lint` (0 errors), and all three i18n checks green across `en.ts` + 10 locale bundles.

## Reviewer notes

The 9 non-English translations (`setBySize`, `(mm)` labels, caption, cap hint) are machine-assisted — worth a native-speaker glance on de/es/fr/ja/nb/nl/pt-BR/sv/uk.
