### PR TITLE
fix(bin-designer): keep scoop and label support inside the rounded bin corners

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.cornerProtrusion.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.cornerProtrusion.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment node
+/**
+ * Regression: geometry must not protrude past its intended footprint.
+ *
+ *  1. Finger scoop ramps are full-width straight prisms with SQUARE corners,
+ *     but the bin cavity has ROUNDED corners (radius BOX_CORNER_RADIUS − wt).
+ *     On thin walls (wt < BOX_CORNER_RADIUS·(1 − 1/√2) ≈ 1.1mm) the scoop's
+ *     square front-outer corner pokes through the rounded outer wall and sticks
+ *     out of the bin. (Mirror of the cavity-cut fix in #1968.)
+ *
+ *  2. A centered, partial-width label tab rounds BOTH free-end front corners of
+ *     the shelf plate, but the gusset/solid/fillet support beneath still runs to
+ *     the full square corner — leaving support "points" poking past the rounded
+ *     shelf on both edges.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+import { assertStructurallyValid } from './__kernel-tests__/meshAssertions';
+import { buildParams } from './__kernel-tests__/scenarioTypes';
+import { GRIDFINITY } from '@/shared/constants/bin';
+import type { BinParams } from '@/shared/types/bin';
+import type { MeshData } from '@/features/generation/bridge/types';
+
+const { GRID_SIZE, HEIGHT_UNIT, TOLERANCE, BOX_CORNER_RADIUS, SOCKET_HEIGHT } = GRIDFINITY;
+
+function gen(over: Partial<BinParams>): MeshData {
+  return getGenerateBin()(buildParams(over), undefined, true);
+}
+
+/** Signed outside-distance of (x,y) from a rounded rectangle centered at origin. <=0 means inside. */
+function outsideRoundedRect(x: number, y: number, w: number, d: number, r: number): number {
+  const ax = Math.abs(x) - (w / 2 - r);
+  const ay = Math.abs(y) - (d / 2 - r);
+  // Both negative → within the straight band; clamp gives the corner distance.
+  const cx = Math.max(ax, 0);
+  const cy = Math.max(ay, 0);
+  return Math.hypot(cx, cy) - r;
+}
+
+describe('corner protrusion regressions', () => {
+  beforeAll(async () => {
+    await initBrepjs();
+  }, 30_000);
+
+  it('thin-wall scoop stays inside the rounded outer footprint', () => {
+    const wt = 0.8; // below the ~1.1mm threshold
+    const m = gen({
+      width: 2,
+      depth: 2,
+      height: 3,
+      wallThickness: wt,
+      scoop: { enabled: true, radius: 'auto' },
+      base: { ...buildParams({}).base, stackingLip: true },
+    });
+    assertStructurallyValid(m, 'thin-wall scoop');
+
+    const outerW = 2 * GRID_SIZE - TOLERANCE;
+    const outerD = 2 * GRID_SIZE - TOLERANCE;
+    const v = m.vertices;
+    let worst = -Infinity;
+    let worstPt: [number, number] | null = null;
+    for (let i = 0; i < v.length; i += 3) {
+      const out = outsideRoundedRect(v[i], v[i + 1], outerW, outerD, BOX_CORNER_RADIUS);
+      if (out > worst) {
+        worst = out;
+        worstPt = [v[i], v[i + 1]];
+      }
+    }
+    // Allow a small tessellation/precision epsilon.
+    expect(
+      worst,
+      `max protrusion ${worst.toFixed(3)}mm past outer footprint at ${JSON.stringify(worstPt)}`
+    ).toBeLessThan(0.05);
+  });
+
+  for (const support of ['bracket', 'solid'] as const) {
+    it(`centered partial-width label (${support}) has no support spikes past rounded shelf`, () => {
+      const wt = 1.2;
+      const widthPct = 50;
+      const tabDepth = 12;
+      const cornerR = 1; // labelTabBuilder shelf corner radius
+
+      const m = gen({
+        width: 1,
+        depth: 1,
+        height: 3,
+        wallThickness: wt,
+        scoop: { enabled: false, radius: 'auto' },
+        base: { ...buildParams({}).base, stackingLip: true },
+        label: {
+          ...buildParams({}).label,
+          enabled: true,
+          support,
+          alignment: 'center',
+          width: widthPct,
+          depth: tabDepth,
+        },
+      });
+      assertStructurallyValid(m, `centered label ${support}`);
+
+      const innerW = GRID_SIZE - TOLERANCE - 2 * wt;
+      const innerD = GRID_SIZE - TOLERANCE - 2 * wt;
+      const tabWidth = (innerW * widthPct) / 100;
+      const tabXStart = -tabWidth / 2; // centered
+      const backY = innerD / 2; // outer back wall (single 1x1 compartment)
+      const frontY = backY - tabDepth; // shelf body extends toward -Y
+      const wallHeight = 3 * HEIGHT_UNIT - SOCKET_HEIGHT;
+      const tabBaseZ = wallHeight - tabDepth + SOCKET_HEIGHT; // gusset bottom (world Z)
+      const tabTopZ = wallHeight + SOCKET_HEIGHT;
+
+      // The two front corners that get rounded. Material in the clipped corner
+      // wedge (inside the square corner box, outside the fillet arc) is a spike.
+      const corners: Array<{ cx: number; cy: number; arcX: number; arcY: number }> = [
+        { cx: tabXStart, cy: frontY, arcX: tabXStart + cornerR, arcY: frontY + cornerR },
+        {
+          cx: tabXStart + tabWidth,
+          cy: frontY,
+          arcX: tabXStart + tabWidth - cornerR,
+          arcY: frontY + cornerR,
+        },
+      ];
+
+      const v = m.vertices;
+      const spikes: Array<[number, number, number]> = [];
+      for (let i = 0; i < v.length; i += 3) {
+        const x = v[i];
+        const y = v[i + 1];
+        const z = v[i + 2];
+        if (z < tabBaseZ + 1 || z > tabTopZ + 0.1) continue; // only within the tab
+        for (const c of corners) {
+          const insideBox =
+            Math.abs(x - c.arcX) <= cornerR + 0.01 &&
+            Math.abs(y - c.arcY) <= cornerR + 0.01 &&
+            // in the square-corner quadrant beyond the arc center
+            (c.cx < c.arcX ? x <= c.arcX : x >= c.arcX) &&
+            y <= c.arcY;
+          if (!insideBox) continue;
+          const distFromArc = Math.hypot(x - c.arcX, y - c.arcY);
+          if (distFromArc > cornerR + 0.1) spikes.push([x, y, z]);
+        }
+      }
+
+      expect(
+        spikes.length,
+        `found ${spikes.length} support-spike vertices, e.g. ${JSON.stringify(spikes[0])}`
+      ).toBe(0);
+    });
+  }
+});

--- a/src/features/generation/worker/generators/labelTabBuilder.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.ts
@@ -5,7 +5,7 @@
  * at the back edge of each compartment.
  */
 
-import { draw, unwrap, fuseAll, fuse, cut, translate, withScope, clone } from 'brepjs';
+import { draw, unwrap, fuseAll, fuse, cut, intersect, translate, withScope, clone } from 'brepjs';
 import type { Shape3D, ValidSolid, Drawing, DisposalScope } from 'brepjs';
 import type { BinParams, TextStyleDefaults, TextStyleOverride } from '@/shared/types/bin';
 import {
@@ -355,11 +355,17 @@ function buildTabsAtRow(
     // back-anchor, positive Y for front-anchor).
     const cornerR = 1; // mm
     const depthExtent = depthSign * tabDepth;
-    let pen = draw([0, 0]).lineTo([tabWidth, 0]).lineTo([tabWidth, depthExtent]);
-    if (!touchesRight) pen = pen.customCorner(cornerR);
-    pen = pen.lineTo([0, depthExtent]);
-    if (!touchesLeft) pen = pen.customCorner(cornerR);
-    const shelf = scope.register(sketch(pen.close(), 'XY', tabHeight - wt).extrude(wt));
+    // Shelf/footprint outline: rounded front corners on free (non-wall) ends.
+    // Built fresh each call so it can be sketched independently for the shelf
+    // plate and (below) the full-height support clip.
+    const buildOutline = (): Drawing => {
+      let p = draw([0, 0]).lineTo([tabWidth, 0]).lineTo([tabWidth, depthExtent]);
+      if (!touchesRight) p = p.customCorner(cornerR);
+      p = p.lineTo([0, depthExtent]);
+      if (!touchesLeft) p = p.customCorner(cornerR);
+      return p.close();
+    };
+    const shelf = scope.register(sketch(buildOutline(), 'XY', tabHeight - wt).extrude(wt));
 
     // -- Gussets: 45deg triangular supports under the shelf --
     // Free ends get edge gussets for structural support.
@@ -417,6 +423,21 @@ function buildTabsAtRow(
 
         const fusedGussets = scope.register(unwrap(fuseAll(gussetShapes as ValidSolid[])));
         tabSolid = scope.register(unwrap(fuse(tabSolid as ValidSolid, fusedGussets)));
+      }
+
+      // The shelf plate rounds its free-end front corners, but the support
+      // (solid prism / fillet / edge gussets) runs to the full square corner —
+      // poking "points" past the rounded shelf on partial-width and centered
+      // tabs. Clip the support to the shelf footprint (full tab height) so it
+      // can never exceed the plate outline. Only free ends are rounded, so
+      // skip the boolean when both ends sit flush against a wall.
+      if (!touchesLeft || !touchesRight) {
+        const footprint = scope.register(
+          sketch(buildOutline(), 'XY', -0.1).extrude(tabHeight + 0.2)
+        );
+        tabSolid = scope.register(
+          unwrap(intersect(tabSolid as ValidSolid, footprint as ValidSolid))
+        );
       }
     }
 

--- a/src/features/generation/worker/generators/labelTabBuilder.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.ts
@@ -432,12 +432,17 @@ function buildTabsAtRow(
       // can never exceed the plate outline. Only free ends are rounded, so
       // skip the boolean when both ends sit flush against a wall.
       if (!touchesLeft || !touchesRight) {
-        const footprint = scope.register(
-          sketch(buildOutline(), 'XY', -0.1).extrude(tabHeight + 0.2)
-        );
-        tabSolid = scope.register(
-          unwrap(intersect(tabSolid as ValidSolid, footprint as ValidSolid))
-        );
+        try {
+          const footprint = scope.register(
+            sketch(buildOutline(), 'XY', -0.1).extrude(tabHeight + 0.2)
+          );
+          tabSolid = scope.register(
+            unwrap(intersect(tabSolid as ValidSolid, footprint as ValidSolid))
+          );
+        } catch {
+          // Best-effort cosmetic clip (mirrors the text-boolean fallback
+          // below): keep the un-clipped support rather than fail the tab build.
+        }
       }
     }
 

--- a/src/features/generation/worker/generators/scoopRampBuilder.ts
+++ b/src/features/generation/worker/generators/scoopRampBuilder.ts
@@ -5,7 +5,16 @@
  * to help slide items out of the bin.
  */
 
-import { draw, translate, withScope, clone, unwrap, fuseAll } from 'brepjs';
+import {
+  draw,
+  drawRoundedRectangle,
+  translate,
+  withScope,
+  clone,
+  unwrap,
+  fuseAll,
+  intersect,
+} from 'brepjs';
 import type { Shape3D, ValidSolid, DisposalScope } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
 import { sketch } from './meshUtils';
@@ -14,7 +23,7 @@ import {
   computeLipOffset,
   computeInteriorHeight,
 } from '@/shared/utils/scoopCalculations';
-import { LIP_SMALL_TAPER, LIP_TAPER_WIDTH } from './generatorConstants';
+import { LIP_SMALL_TAPER, LIP_TAPER_WIDTH, BOX_CORNER_RADIUS } from './generatorConstants';
 import { findCompartmentBounds } from './compartmentBuilder';
 import { compartmentHasTiltedEdge } from '@/shared/types/bin';
 /**
@@ -169,8 +178,28 @@ function buildScoopRampsInScope(
 
   // Inline fuse so the fused handle is registered in scope.
   if (scoopShapes.length === 0) return null;
-  if (scoopShapes.length === 1) return scoopShapes[0]; // already scope-registered
-  return scope.register(unwrap(fuseAll(scoopShapes as ValidSolid[])));
+  const fused =
+    scoopShapes.length === 1
+      ? scoopShapes[0] // already scope-registered
+      : scope.register(unwrap(fuseAll(scoopShapes as ValidSolid[])));
+
+  // Thin-walled bins round the inner cavity corners to radius
+  // (BOX_CORNER_RADIUS − wallThickness), but the scoop is a straight full-width
+  // prism with SQUARE corners. At the bin's front-outer corners those square
+  // corners poke through the rounded outer wall and stick out of the bin. Below
+  // the geometric threshold wallThickness < BOX_CORNER_RADIUS·(1 − 1/√2) the
+  // square corner overshoots the outer arc (same condition the cavity cut
+  // guards in compartmentBuilder, #1968). Clip the scoop to the rounded inner
+  // footprint so its corners follow the wall; skip the boolean above the
+  // threshold where there is nothing to trim.
+  if (wallThickness < BOX_CORNER_RADIUS * (1 - Math.SQRT1_2)) {
+    const cavityCornerR = Math.max(BOX_CORNER_RADIUS - wallThickness, 0.1);
+    const footprint = scope.register(
+      sketch(drawRoundedRectangle(innerW, innerD, cavityCornerR), 'XY', -1).extrude(wallHeight + 2)
+    );
+    return scope.register(unwrap(intersect(fused as ValidSolid, footprint as ValidSolid)));
+  }
+  return fused;
 }
 
 // --- FeatureBuilder protocol ---

--- a/src/features/generation/worker/generators/scoopRampBuilder.ts
+++ b/src/features/generation/worker/generators/scoopRampBuilder.ts
@@ -193,11 +193,20 @@ function buildScoopRampsInScope(
   // footprint so its corners follow the wall; skip the boolean above the
   // threshold where there is nothing to trim.
   if (wallThickness < BOX_CORNER_RADIUS * (1 - Math.SQRT1_2)) {
-    const cavityCornerR = Math.max(BOX_CORNER_RADIUS - wallThickness, 0.1);
-    const footprint = scope.register(
-      sketch(drawRoundedRectangle(innerW, innerD, cavityCornerR), 'XY', -1).extrude(wallHeight + 2)
-    );
-    return scope.register(unwrap(intersect(fused as ValidSolid, footprint as ValidSolid)));
+    try {
+      const cavityCornerR = Math.max(BOX_CORNER_RADIUS - wallThickness, 0.1);
+      const footprint = scope.register(
+        sketch(drawRoundedRectangle(innerW, innerD, cavityCornerR), 'XY', -1).extrude(
+          wallHeight + 2
+        )
+      );
+      return scope.register(unwrap(intersect(fused as ValidSolid, footprint as ValidSolid)));
+    } catch {
+      // The clip only trims a sub-mm corner overshoot — best-effort, like the
+      // other booleans here. A kernel failure must not sink the whole bin
+      // build, so fall back to the un-clipped scoop.
+      return fused;
+    }
   }
   return fused;
 }


### PR DESCRIPTION
## Problem

Two square-cornered features poked past the bin's **rounded** corners (reported from the bin designer):

| | |
|---|---|
| **Finger scoop** | A full-width straight prism with square corners overshoots the rounded outer wall and sticks out of the bin at the front-outer corners, once `wallThickness < BOX_CORNER_RADIUS·(1 − 1/√2) ≈ 1.1mm` (the thin-wall options below the 1.2mm default). |
| **Label tab support** | The shelf plate rounds its free-end front corners, but the gusset/solid/fillet support still ran to the full square corner — leaving "points" sticking out on centered/partial-width tabs. |

Both are the same class of bug as the compartment **cavity cut** fixed in #1968 (square geometry vs. the rounded `BOX_CORNER_RADIUS − wt` inner contour).

## Fix

- **`scoopRampBuilder.ts`** — clip the fused scoop to a rounded-rectangle inner footprint, guarded by the `< 1.1mm` threshold so the boolean is skipped entirely on normal walls (no perf impact on the default path).
- **`labelTabBuilder.ts`** — clip the support to the shelf outline (full tab height) via `intersect`, only when a free end exists. Preserves the rounded-shelf look while trimming the overhang.

## Tests

- New `binGenerator.scenario.cornerProtrusion.test.ts` — written first, confirmed **failing** on current code (scoop: 0.42mm protrusion; label: 6 spike vertices), now passing. Asserts vertex containment within the intended rounded footprint.
- No snapshot churn: scoops/labels/wallThickness/combinedFeatures (54) pass unchanged — fixes only touch the buggy configs.
- export-integrity (357) passes → clip booleans stay manifold/hole-free.
- typecheck + eslint + prettier clean.

## Known limitation

`GhostScoops.tsx` (the transient translucent preview during regeneration) still draws a square-cornered arc strip, so it may briefly show the poke before the real geometry lands. The real/exported geometry is correct.