### PR TITLE
feat(design-system): add 16 primitives and extend dialog compound component

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
       "name": "Total JS (gzip)",
       "path": "dist/assets/*.js",
       "gzip": true,
-      "limit": "1780 kB"
+      "limit": "1800 kB"
     }
   ],
   "dependencies": {

--- a/src/design-system/Alert/Alert.test.tsx
+++ b/src/design-system/Alert/Alert.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { createRef } from 'react';
+import { Alert } from './Alert';
+
+describe('Alert', () => {
+  describe('rendering', () => {
+    it('renders children', () => {
+      render(<Alert intent="info">Keyboard mode active</Alert>);
+      expect(screen.getByText('Keyboard mode active')).toBeInTheDocument();
+    });
+
+    it('renders the title as a bold first line', () => {
+      render(
+        <Alert intent="error" title="Import failed">
+          Invalid file
+        </Alert>
+      );
+      const title = screen.getByText('Import failed');
+      expect(title).toBeInTheDocument();
+      expect(title.className).toContain('font-semibold');
+      expect(title.className).toContain('text-error');
+    });
+
+    it('renders rich children like lists', () => {
+      render(
+        <Alert intent="error" title="Import failed">
+          <ul>
+            <li>Missing drawer size</li>
+            <li>Unknown bin shape</li>
+          </ul>
+        </Alert>
+      );
+      expect(screen.getByRole('list')).toBeInTheDocument();
+      expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    });
+
+    it('renders the icon slot hidden from assistive technology', () => {
+      render(
+        <Alert intent="warning" icon={<svg data-testid="alert-icon" />}>
+          Exceeds print bed
+        </Alert>
+      );
+      const icon = screen.getByTestId('alert-icon');
+      expect(icon).toBeInTheDocument();
+      expect(icon.parentElement).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('merges className with variant classes', () => {
+      render(
+        <Alert intent="info" className="custom-class">
+          Hint
+        </Alert>
+      );
+      const alert = screen.getByRole('status');
+      expect(alert).toHaveClass('custom-class');
+      expect(alert.className).toContain('bg-info-muted');
+    });
+  });
+
+  describe('intent', () => {
+    it.each([
+      ['error', 'bg-error-muted', 'border-error'],
+      ['warning', 'bg-warning-muted', 'border-warning'],
+      ['success', 'bg-success-muted', 'border-success'],
+      ['info', 'bg-info-muted', 'border-info'],
+    ] as const)('applies %s background and border classes', (intent, bg, border) => {
+      render(
+        <Alert intent={intent} data-testid="alert">
+          Message
+        </Alert>
+      );
+      const alert = screen.getByTestId('alert');
+      expect(alert.className).toContain(bg);
+      expect(alert.className).toContain(border);
+    });
+
+    it('uses role alert for error intent', () => {
+      render(<Alert intent="error">Failed</Alert>);
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it.each(['warning', 'success', 'info'] as const)('uses role status for %s intent', (intent) => {
+      render(<Alert intent={intent}>Message</Alert>);
+      expect(screen.getByRole('status')).toBeInTheDocument();
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('size', () => {
+    it('defaults to sm padding and text', () => {
+      render(<Alert intent="info">Hint</Alert>);
+      const alert = screen.getByRole('status');
+      expect(alert).toHaveClass('p-2');
+      expect(alert).toHaveClass('text-xs');
+    });
+
+    it('applies md padding and text', () => {
+      render(
+        <Alert intent="info" size="md">
+          Hint
+        </Alert>
+      );
+      const alert = screen.getByRole('status');
+      expect(alert).toHaveClass('p-3');
+      expect(alert).toHaveClass('text-sm');
+    });
+  });
+
+  describe('dismiss', () => {
+    it('does not render a dismiss button without onDismiss', () => {
+      render(<Alert intent="info">Hint</Alert>);
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('calls onDismiss when the dismiss button is clicked', () => {
+      const onDismiss = vi.fn();
+      render(
+        <Alert intent="info" onDismiss={onDismiss}>
+          Keyboard mode active
+        </Alert>
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses a custom dismissAriaLabel', () => {
+      render(
+        <Alert intent="info" onDismiss={vi.fn()} dismissAriaLabel="Close banner">
+          Hint
+        </Alert>
+      );
+      expect(screen.getByRole('button', { name: 'Close banner' })).toBeInTheDocument();
+    });
+  });
+
+  describe('ref forwarding', () => {
+    it('forwards the ref to the root element', () => {
+      const ref = createRef<HTMLDivElement>();
+      render(
+        <Alert intent="info" ref={ref}>
+          Hint
+        </Alert>
+      );
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+      expect(ref.current).toHaveAttribute('role', 'status');
+    });
+  });
+});

--- a/src/design-system/Alert/Alert.tsx
+++ b/src/design-system/Alert/Alert.tsx
@@ -1,0 +1,152 @@
+import { forwardRef } from 'react';
+import { cva } from 'class-variance-authority';
+import type { ReactNode } from 'react';
+import { cn } from '../cn';
+import { XIcon } from '../Icon';
+import { focusRing, intentBackgrounds, intentText, interactiveTransition } from '../variants';
+
+const alertVariants = cva(['flex items-start gap-2', 'rounded-md border'], {
+  variants: {
+    intent: {
+      error: [intentBackgrounds.error, 'border-error'],
+      warning: [intentBackgrounds.warning, 'border-warning'],
+      success: [intentBackgrounds.success, 'border-success'],
+      info: [intentBackgrounds.info, 'border-info'],
+    },
+    size: {
+      sm: ['p-2', 'text-xs'],
+      md: ['p-3', 'text-sm'],
+    },
+  },
+  defaultVariants: {
+    size: 'sm',
+  },
+});
+
+export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Feedback intent. Maps to muted background, matching border, and
+   * intent-colored title/icon. `error` announces assertively (`role="alert"`),
+   * the rest politely (`role="status"`).
+   */
+  intent: 'error' | 'warning' | 'success' | 'info';
+
+  /**
+   * Bold first line (e.g. 'Import failed').
+   */
+  title?: string;
+
+  /**
+   * Optional leading icon node. Callers supply their own icon; decorative
+   * (hidden from assistive technology).
+   */
+  icon?: ReactNode;
+
+  /**
+   * Body content: text, error lists, key/value grids, inline action buttons,
+   * or kbd chips.
+   */
+  children?: ReactNode;
+
+  /**
+   * Renders a trailing dismiss button. The Alert is controlled — the caller
+   * unmounts it (and owns any auto-dismiss timers).
+   */
+  onDismiss?: () => void;
+
+  /**
+   * Accessible name for the dismiss button.
+   *
+   * @default 'Dismiss'
+   */
+  dismissAriaLabel?: string;
+
+  /**
+   * Density scale: `sm` for inline field-adjacent messages, `md` for dialog
+   * banners.
+   *
+   * @default 'sm'
+   */
+  size?: 'sm' | 'md';
+}
+
+/**
+ * Tone-tinted inline message box for validation errors, warnings, success
+ * confirmations, and status banners.
+ *
+ * @example
+ * <Alert intent="error" title="Import failed">
+ *   <ul className="list-disc pl-4">
+ *     {errors.map((e) => (
+ *       <li key={e}>{e}</li>
+ *     ))}
+ *   </ul>
+ * </Alert>
+ *
+ * @example
+ * <Alert intent="warning" icon={<AlertTriangleIcon size="sm" />}>
+ *   This layout exceeds the print bed.
+ * </Alert>
+ *
+ * @example
+ * <Alert intent="info" size="md" onDismiss={exitKeyboardMode} dismissAriaLabel={t('a11y.dismiss')}>
+ *   Keyboard mode active
+ * </Alert>
+ */
+export const Alert = forwardRef<HTMLDivElement, AlertProps>(
+  (
+    {
+      intent,
+      title,
+      icon,
+      children,
+      onDismiss,
+      dismissAriaLabel = 'Dismiss',
+      size = 'sm',
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <div
+        ref={ref}
+        role={intent === 'error' ? 'alert' : 'status'}
+        className={cn(alertVariants({ intent, size }), className)}
+        {...props}
+      >
+        {icon && (
+          <span className={cn('flex-shrink-0', intentText[intent])} aria-hidden="true">
+            {icon}
+          </span>
+        )}
+
+        <div className="flex-1 min-w-0">
+          {title && <p className={cn('font-semibold', intentText[intent])}>{title}</p>}
+          {children}
+        </div>
+
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label={dismissAriaLabel}
+            className={cn(
+              'flex-shrink-0 -m-1 p-1',
+              'flex items-center justify-center',
+              'rounded',
+              'text-current opacity-60',
+              'hover:opacity-100',
+              interactiveTransition,
+              ...focusRing
+            )}
+          >
+            <XIcon size="xs" />
+          </button>
+        )}
+      </div>
+    );
+  }
+);
+
+Alert.displayName = 'Alert';

--- a/src/design-system/Alert/index.ts
+++ b/src/design-system/Alert/index.ts
@@ -1,0 +1,2 @@
+export { Alert } from './Alert';
+export type { AlertProps } from './Alert';

--- a/src/design-system/Badge/Badge.test.tsx
+++ b/src/design-system/Badge/Badge.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Badge } from './Badge';
+
+describe('Badge', () => {
+  describe('rendering', () => {
+    it('renders children', () => {
+      render(<Badge>Experimental</Badge>);
+      expect(screen.getByText('Experimental')).toBeInTheDocument();
+    });
+
+    it('renders node children alongside text', () => {
+      render(
+        <Badge>
+          <span data-testid="swatch" />
+          Red
+        </Badge>
+      );
+      expect(screen.getByTestId('swatch')).toBeInTheDocument();
+      expect(screen.getByText('Red')).toBeInTheDocument();
+    });
+
+    it('renders as a span with no implicit role', () => {
+      render(<Badge>3</Badge>);
+      expect(screen.getByText('3').tagName).toBe('SPAN');
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('applies className passthrough', () => {
+      render(<Badge className="custom-class">3</Badge>);
+      expect(screen.getByText('3')).toHaveClass('custom-class');
+    });
+
+    it('passes through native span attributes', () => {
+      render(<Badge title="3 staged bins">3</Badge>);
+      expect(screen.getByText('3')).toHaveAttribute('title', '3 staged bins');
+    });
+  });
+
+  describe('tone', () => {
+    it('defaults to neutral', () => {
+      render(<Badge>3</Badge>);
+      expect(screen.getByText('3')).toHaveClass('bg-surface-hover', 'text-content-tertiary');
+    });
+
+    it('applies accent classes', () => {
+      render(<Badge tone="accent">2</Badge>);
+      expect(screen.getByText('2')).toHaveClass('bg-accent', 'text-on-accent');
+    });
+
+    it('applies warning intent classes', () => {
+      render(<Badge tone="warning">Experimental</Badge>);
+      expect(screen.getByText('Experimental')).toHaveClass('bg-warning-muted', 'text-warning');
+    });
+
+    it('applies success intent classes', () => {
+      render(<Badge tone="success">Can edit</Badge>);
+      expect(screen.getByText('Can edit')).toHaveClass('bg-success-muted', 'text-success');
+    });
+
+    it('applies error intent classes', () => {
+      render(<Badge tone="error">Deleted</Badge>);
+      expect(screen.getByText('Deleted')).toHaveClass('bg-error-muted', 'text-error');
+    });
+
+    it('applies info intent classes', () => {
+      render(<Badge tone="info">New</Badge>);
+      expect(screen.getByText('New')).toHaveClass('bg-info-muted', 'text-info');
+    });
+
+    it('applies overlay classes', () => {
+      render(<Badge tone="overlay">4 layers</Badge>);
+      expect(screen.getByText('4 layers')).toHaveClass('bg-black/70', 'text-white');
+    });
+  });
+
+  describe('shape', () => {
+    it('defaults to rounded', () => {
+      render(<Badge>Saved</Badge>);
+      expect(screen.getByText('Saved')).toHaveClass('rounded-md');
+    });
+
+    it('applies pill shape', () => {
+      render(<Badge shape="pill">9+</Badge>);
+      expect(screen.getByText('9+')).toHaveClass('rounded-full');
+    });
+  });
+
+  describe('size', () => {
+    it('defaults to sm', () => {
+      render(<Badge>3</Badge>);
+      expect(screen.getByText('3')).toHaveClass('text-[10px]', 'px-1.5', 'py-0.5');
+    });
+
+    it('applies md size', () => {
+      render(<Badge size="md">3</Badge>);
+      expect(screen.getByText('3')).toHaveClass('text-xs', 'px-2', 'py-0.5');
+    });
+  });
+
+  describe('remove button', () => {
+    it('does not render a remove button without onRemove', () => {
+      render(<Badge>tag</Badge>);
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('renders a remove button with default aria-label', () => {
+      render(<Badge onRemove={vi.fn()}>tag</Badge>);
+      expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+    });
+
+    it('uses removeAriaLabel for the remove button name', () => {
+      render(
+        <Badge onRemove={vi.fn()} removeAriaLabel="Remove tag hardware">
+          hardware
+        </Badge>
+      );
+      expect(screen.getByRole('button', { name: 'Remove tag hardware' })).toBeInTheDocument();
+    });
+
+    it('calls onRemove when the remove button is clicked', () => {
+      const onRemove = vi.fn();
+      render(<Badge onRemove={onRemove}>tag</Badge>);
+      fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+      expect(onRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the remove button as type=button', () => {
+      render(<Badge onRemove={vi.fn()}>tag</Badge>);
+      expect(screen.getByRole('button', { name: 'Remove' })).toHaveAttribute('type', 'button');
+    });
+  });
+
+  describe('ref forwarding', () => {
+    it('forwards ref to the span element', () => {
+      const ref = vi.fn();
+      render(<Badge ref={ref}>3</Badge>);
+      expect(ref).toHaveBeenCalledWith(expect.any(HTMLSpanElement));
+    });
+  });
+});

--- a/src/design-system/Badge/Badge.tsx
+++ b/src/design-system/Badge/Badge.tsx
@@ -1,0 +1,141 @@
+import { forwardRef } from 'react';
+import type { ReactNode } from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '../cn';
+import { focusRing, interactiveTransition, intentBackgrounds, intentText } from '../variants';
+
+const badgeVariants = cva(
+  ['inline-flex items-center gap-1', 'font-medium leading-none whitespace-nowrap'],
+  {
+    variants: {
+      tone: {
+        neutral: ['bg-surface-hover', 'text-content-tertiary'],
+        accent: ['bg-accent', 'text-on-accent'],
+        success: [intentBackgrounds.success, intentText.success],
+        warning: [intentBackgrounds.warning, intentText.warning],
+        error: [intentBackgrounds.error, intentText.error],
+        info: [intentBackgrounds.info, intentText.info],
+        overlay: ['bg-black/70', 'text-white'],
+      },
+      shape: {
+        rounded: 'rounded-md',
+        pill: 'rounded-full',
+      },
+      size: {
+        sm: ['text-[10px]', 'px-1.5', 'py-0.5'],
+        md: ['text-xs', 'px-2', 'py-0.5'],
+      },
+    },
+    defaultVariants: {
+      tone: 'neutral',
+      shape: 'rounded',
+      size: 'sm',
+    },
+  }
+);
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /**
+   * Visual tone of the badge.
+   * - neutral: counts and quiet metadata
+   * - accent: active/selected chips
+   * - success/warning/error/info: feedback and status chips
+   * - overlay: badges layered over thumbnails or imagery
+   *
+   * @default 'neutral'
+   */
+  tone?: 'neutral' | 'accent' | 'success' | 'warning' | 'error' | 'info' | 'overlay';
+
+  /**
+   * Corner shape. 'rounded' for status chips, 'pill' for count and tag pills.
+   *
+   * @default 'rounded'
+   */
+  shape?: 'rounded' | 'pill';
+
+  /**
+   * Text scale and padding.
+   *
+   * @default 'sm'
+   */
+  size?: 'sm' | 'md';
+
+  /**
+   * Renders a trailing remove button inside the chip.
+   */
+  onRemove?: () => void;
+
+  /**
+   * Accessible name for the remove button.
+   *
+   * @default 'Remove'
+   */
+  removeAriaLabel?: string;
+
+  /**
+   * Badge content: text, a count string, or a leading swatch/icon node plus text.
+   */
+  children: ReactNode;
+}
+
+/**
+ * Compact chip for statuses, counts, tags, and overlay labels.
+ *
+ * @example
+ * // Status chip
+ * <Badge tone="warning">Experimental</Badge>
+ *
+ * @example
+ * // Count pill
+ * <Badge shape="pill" title="3 staged bins">3</Badge>
+ *
+ * @example
+ * // Removable tag
+ * <Badge shape="pill" onRemove={() => removeTag(tag)} removeAriaLabel={`Remove ${tag}`}>
+ *   {tag}
+ * </Badge>
+ *
+ * @example
+ * // Overlay badge on a thumbnail
+ * <Badge tone="overlay" size="md">4 layers</Badge>
+ */
+export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
+  (
+    { tone, shape, size, onRemove, removeAriaLabel = 'Remove', className, children, ...props },
+    ref
+  ) => {
+    return (
+      <span ref={ref} className={cn(badgeVariants({ tone, shape, size }), className)} {...props}>
+        {children}
+        {onRemove && (
+          <button
+            type="button"
+            aria-label={removeAriaLabel}
+            onClick={onRemove}
+            className={cn(
+              'rounded-sm p-0.5 opacity-70 hover:opacity-100',
+              interactiveTransition,
+              focusRing
+            )}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="h-2.5 w-2.5"
+              aria-hidden="true"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        )}
+      </span>
+    );
+  }
+);
+
+Badge.displayName = 'Badge';

--- a/src/design-system/Badge/index.ts
+++ b/src/design-system/Badge/index.ts
@@ -1,0 +1,2 @@
+export { Badge } from './Badge';
+export type { BadgeProps } from './Badge';

--- a/src/design-system/Card/Card.test.tsx
+++ b/src/design-system/Card/Card.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Card } from './Card';
+
+describe('Card', () => {
+  describe('rendering', () => {
+    it('renders children in a div by default', () => {
+      render(<Card>Content</Card>);
+      const card = screen.getByText('Content');
+      expect(card.tagName).toBe('DIV');
+    });
+
+    it('applies default surface, border, padding, and radius classes', () => {
+      render(<Card>Content</Card>);
+      expect(screen.getByText('Content')).toHaveClass(
+        'bg-surface-elevated',
+        'border',
+        'border-stroke-subtle',
+        'p-3',
+        'rounded-lg'
+      );
+    });
+
+    it('merges className with caller classes winning conflicts', () => {
+      render(<Card className="p-6 custom-class">Content</Card>);
+      const card = screen.getByText('Content');
+      expect(card).toHaveClass('p-6', 'custom-class');
+      expect(card).not.toHaveClass('p-3');
+    });
+  });
+
+  describe('surface variant', () => {
+    it('applies bg-surface', () => {
+      render(<Card surface="surface">Content</Card>);
+      expect(screen.getByText('Content')).toHaveClass('bg-surface');
+    });
+
+    it('applies bg-surface-secondary', () => {
+      render(<Card surface="secondary">Content</Card>);
+      expect(screen.getByText('Content')).toHaveClass('bg-surface-secondary');
+    });
+  });
+
+  describe('border variant', () => {
+    it('applies border-stroke for default', () => {
+      render(<Card border="default">Content</Card>);
+      expect(screen.getByText('Content')).toHaveClass('border', 'border-stroke');
+    });
+
+    it('applies a 2px dashed border for dashed', () => {
+      render(<Card border="dashed">Content</Card>);
+      expect(screen.getByText('Content')).toHaveClass('border-2', 'border-dashed', 'border-stroke');
+    });
+
+    it('removes the border for none', () => {
+      render(<Card border="none">Content</Card>);
+      const card = screen.getByText('Content');
+      expect(card).toHaveClass('border-none');
+      expect(card).not.toHaveClass('border-stroke-subtle');
+    });
+  });
+
+  describe('padding variant', () => {
+    it('applies p-0 for none', () => {
+      render(<Card padding="none">Content</Card>);
+      expect(screen.getByText('Content')).toHaveClass('p-0');
+    });
+
+    it('applies p-2 for sm', () => {
+      render(<Card padding="sm">Content</Card>);
+      expect(screen.getByText('Content')).toHaveClass('p-2');
+    });
+
+    it('applies p-4 for lg', () => {
+      render(<Card padding="lg">Content</Card>);
+      expect(screen.getByText('Content')).toHaveClass('p-4');
+    });
+  });
+
+  describe('radius variant', () => {
+    it('applies rounded-md', () => {
+      render(<Card radius="md">Content</Card>);
+      expect(screen.getByText('Content')).toHaveClass('rounded-md');
+    });
+
+    it('applies rounded-xl', () => {
+      render(<Card radius="xl">Content</Card>);
+      expect(screen.getByText('Content')).toHaveClass('rounded-xl');
+    });
+  });
+
+  describe('as', () => {
+    it('renders a button with type="button"', () => {
+      render(<Card as="button">Open</Card>);
+      const card = screen.getByRole('button', { name: 'Open' });
+      expect(card.tagName).toBe('BUTTON');
+      expect(card).toHaveAttribute('type', 'button');
+    });
+
+    it('does not set type on non-button elements', () => {
+      render(<Card>Content</Card>);
+      expect(screen.getByText('Content')).not.toHaveAttribute('type');
+    });
+
+    it('renders a list item', () => {
+      render(
+        <ul>
+          <Card as="li">Item</Card>
+        </ul>
+      );
+      expect(screen.getByRole('listitem')).toHaveTextContent('Item');
+    });
+
+    it('renders a section', () => {
+      render(<Card as="section">Content</Card>);
+      expect(screen.getByText('Content').tagName).toBe('SECTION');
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onClick when an interactive button card is clicked', () => {
+      const onClick = vi.fn();
+      render(
+        <Card as="button" interactive onClick={onClick}>
+          Open
+        </Card>
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('applies hover, focus ring, and press classes when interactive', () => {
+      render(<Card interactive>Content</Card>);
+      expect(screen.getByText('Content')).toHaveClass(
+        'hover:bg-surface-hover',
+        'hover:border-stroke',
+        'focus-visible:outline-2',
+        'focus-visible:outline-accent',
+        'active:scale-[0.98]'
+      );
+    });
+
+    it('does not apply interactive classes by default', () => {
+      render(<Card>Content</Card>);
+      const card = screen.getByText('Content');
+      expect(card).not.toHaveClass('hover:bg-surface-hover');
+      expect(card).not.toHaveClass('active:scale-[0.98]');
+    });
+  });
+
+  describe('selected', () => {
+    it('applies the accent border treatment by default', () => {
+      render(<Card selected>Content</Card>);
+      expect(screen.getByText('Content')).toHaveClass('border-accent', 'bg-surface-hover');
+    });
+
+    it('applies the accent rail treatment for selectedStyle="rail"', () => {
+      render(
+        <Card selected selectedStyle="rail">
+          Content
+        </Card>
+      );
+      const card = screen.getByText('Content');
+      expect(card).toHaveClass('border-l-2', 'border-l-accent');
+      expect(card).not.toHaveClass('border-accent');
+    });
+
+    it('does not apply selected classes when not selected', () => {
+      render(<Card selectedStyle="rail">Content</Card>);
+      const card = screen.getByText('Content');
+      expect(card).not.toHaveClass('border-l-accent');
+      expect(card).not.toHaveClass('border-accent');
+    });
+
+    it('passes through caller-provided aria-selected', () => {
+      render(
+        <Card as="li" role="option" selected aria-selected>
+          Item
+        </Card>
+      );
+      expect(screen.getByRole('option')).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('ref forwarding', () => {
+    it('forwards ref to the div element', () => {
+      const ref = vi.fn();
+      render(<Card ref={ref}>Content</Card>);
+      expect(ref).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+    });
+
+    it('forwards ref to the button element', () => {
+      const ref = vi.fn();
+      render(
+        <Card as="button" ref={ref}>
+          Open
+        </Card>
+      );
+      expect(ref).toHaveBeenCalledWith(expect.any(HTMLButtonElement));
+    });
+  });
+});

--- a/src/design-system/Card/Card.tsx
+++ b/src/design-system/Card/Card.tsx
@@ -1,0 +1,160 @@
+import { createElement, forwardRef } from 'react';
+import type { ReactNode } from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '../cn';
+import { activePress, focusRing, interactiveTransition } from '../variants';
+
+const cardVariants = cva('text-left', {
+  variants: {
+    surface: {
+      surface: 'bg-surface',
+      elevated: 'bg-surface-elevated',
+      secondary: 'bg-surface-secondary',
+    },
+    border: {
+      subtle: 'border border-stroke-subtle',
+      default: 'border border-stroke',
+      dashed: 'border-2 border-dashed border-stroke',
+      none: 'border-none',
+    },
+    padding: {
+      none: 'p-0',
+      sm: 'p-2',
+      md: 'p-3',
+      lg: 'p-4',
+    },
+    radius: {
+      md: 'rounded-md',
+      lg: 'rounded-lg',
+      xl: 'rounded-xl',
+    },
+  },
+  defaultVariants: {
+    surface: 'elevated',
+    border: 'subtle',
+    padding: 'md',
+    radius: 'lg',
+  },
+});
+
+export interface CardProps extends React.HTMLAttributes<HTMLElement> {
+  /**
+   * Element to render. Pass 'button' for fully-clickable cards or 'li' for list items.
+   * @default 'div'
+   */
+  as?: 'div' | 'button' | 'li' | 'section';
+
+  /**
+   * Background surface token.
+   * @default 'elevated'
+   */
+  surface?: 'surface' | 'elevated' | 'secondary';
+
+  /**
+   * Border treatment. 'dashed' renders a 2px dashed border for CTA cards.
+   * @default 'subtle'
+   */
+  border?: 'subtle' | 'default' | 'dashed' | 'none';
+
+  /**
+   * Inner padding scale.
+   * @default 'md'
+   */
+  padding?: 'none' | 'sm' | 'md' | 'lg';
+
+  /**
+   * Corner radius scale.
+   * @default 'lg'
+   */
+  radius?: 'md' | 'lg' | 'xl';
+
+  /**
+   * Adds hover, focus ring, and press affordances for clickable cards.
+   */
+  interactive?: boolean;
+
+  /**
+   * Applies the selected accent treatment.
+   */
+  selected?: boolean;
+
+  /**
+   * Selected accent style: 'border' tints the full border, 'rail' draws a left accent rail.
+   * @default 'border'
+   */
+  selectedStyle?: 'border' | 'rail';
+
+  /**
+   * Card content.
+   */
+  children: ReactNode;
+}
+
+/**
+ * Surface container for list items, info boxes, and status cards.
+ *
+ * @example
+ * <Card>Layout details</Card>
+ *
+ * @example
+ * // Fully-clickable card
+ * <Card as="button" interactive onClick={handleOpen}>
+ *   Open layout
+ * </Card>
+ *
+ * @example
+ * // Dashed CTA card
+ * <Card as="button" border="dashed" interactive>
+ *   New layout
+ * </Card>
+ *
+ * @example
+ * // Selected list item with accent rail
+ * <Card as="li" selected selectedStyle="rail">
+ *   Layer 2
+ * </Card>
+ */
+export const Card = forwardRef<HTMLElement, CardProps>(
+  (
+    {
+      as = 'div',
+      surface = 'elevated',
+      border = 'subtle',
+      padding = 'md',
+      radius = 'lg',
+      interactive,
+      selected,
+      selectedStyle = 'border',
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    return createElement(
+      as,
+      {
+        ...props,
+        ref,
+        type: as === 'button' ? 'button' : undefined,
+        className: cn(
+          cardVariants({ surface, border, padding, radius }),
+          interactive && [
+            interactiveTransition,
+            activePress,
+            ...focusRing,
+            'hover:bg-surface-hover hover:border-stroke',
+          ],
+          selected &&
+            (selectedStyle === 'rail'
+              ? 'border-l-2 border-l-accent'
+              : 'border-accent bg-surface-hover'),
+          className
+        ),
+      },
+      children
+    );
+  }
+);
+
+Card.displayName = 'Card';

--- a/src/design-system/Card/index.ts
+++ b/src/design-system/Card/index.ts
@@ -1,0 +1,2 @@
+export { Card } from './Card';
+export type { CardProps } from './Card';

--- a/src/design-system/CheckboxRow/CheckboxRow.test.tsx
+++ b/src/design-system/CheckboxRow/CheckboxRow.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, createEvent } from '@testing-library/react';
+import { CheckboxRow } from './CheckboxRow';
+
+const defaultProps = {
+  label: 'Include labels',
+  checked: false,
+  onChange: vi.fn(),
+};
+
+describe('CheckboxRow', () => {
+  it('renders a checkbox role with the accessible label', () => {
+    render(<CheckboxRow {...defaultProps} />);
+    expect(screen.getByRole('checkbox', { name: 'Include labels' })).toBeInTheDocument();
+  });
+
+  it('reflects checked state via aria-checked', () => {
+    const { rerender } = render(<CheckboxRow {...defaultProps} />);
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-checked', 'false');
+
+    rerender(<CheckboxRow {...defaultProps} checked />);
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('exposes a single accessible checkbox (inner visual is hidden)', () => {
+    render(<CheckboxRow {...defaultProps} />);
+    expect(screen.getAllByRole('checkbox')).toHaveLength(1);
+  });
+
+  it('calls onChange with the toggled value on click', () => {
+    const onChange = vi.fn();
+    render(<CheckboxRow {...defaultProps} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onChange with false when clicking a checked row', () => {
+    const onChange = vi.fn();
+    render(<CheckboxRow {...defaultProps} checked onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it('toggles on Space and prevents default', () => {
+    const onChange = vi.fn();
+    render(<CheckboxRow {...defaultProps} onChange={onChange} />);
+
+    const row = screen.getByRole('checkbox');
+    const event = createEvent.keyDown(row, { key: ' ' });
+    fireEvent(row, event);
+
+    expect(onChange).toHaveBeenCalledWith(true);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('toggles on Enter and prevents default', () => {
+    const onChange = vi.fn();
+    render(<CheckboxRow {...defaultProps} onChange={onChange} />);
+
+    const row = screen.getByRole('checkbox');
+    const event = createEvent.keyDown(row, { key: 'Enter' });
+    fireEvent(row, event);
+
+    expect(onChange).toHaveBeenCalledWith(true);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('ignores other keys', () => {
+    const onChange = vi.fn();
+    render(<CheckboxRow {...defaultProps} onChange={onChange} />);
+
+    fireEvent.keyDown(screen.getByRole('checkbox'), { key: 'a' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('is focusable when enabled', () => {
+    render(<CheckboxRow {...defaultProps} />);
+    expect(screen.getByRole('checkbox')).toHaveAttribute('tabindex', '0');
+  });
+
+  it('does not call onChange when disabled', () => {
+    const onChange = vi.fn();
+    render(<CheckboxRow {...defaultProps} onChange={onChange} disabled />);
+
+    const row = screen.getByRole('checkbox');
+    fireEvent.click(row);
+    fireEvent.keyDown(row, { key: ' ' });
+    fireEvent.keyDown(row, { key: 'Enter' });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('sets aria-disabled and removes from tab order when disabled', () => {
+    render(<CheckboxRow {...defaultProps} disabled />);
+
+    const row = screen.getByRole('checkbox');
+    expect(row).toHaveAttribute('aria-disabled', 'true');
+    expect(row).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('renders the trailing slot', () => {
+    render(<CheckboxRow {...defaultProps} trailing={<span data-testid="count">12</span>} />);
+    expect(screen.getByTestId('count')).toHaveTextContent('12');
+  });
+
+  it('applies indent classes when indent is set', () => {
+    render(<CheckboxRow {...defaultProps} indent />);
+
+    const row = screen.getByRole('checkbox');
+    expect(row).toHaveClass('ml-4', 'border-l', 'border-stroke-subtle', 'pl-3');
+  });
+
+  it('does not apply indent classes by default', () => {
+    render(<CheckboxRow {...defaultProps} />);
+    expect(screen.getByRole('checkbox')).not.toHaveClass('ml-4');
+  });
+
+  it('dims the label when unchecked and brightens it when checked', () => {
+    const { rerender } = render(<CheckboxRow {...defaultProps} />);
+    expect(screen.getByText('Include labels')).toHaveClass('text-content-tertiary');
+
+    rerender(<CheckboxRow {...defaultProps} checked />);
+    expect(screen.getByText('Include labels')).toHaveClass('text-content');
+  });
+
+  it('applies className to the row container', () => {
+    render(<CheckboxRow {...defaultProps} className="custom-class" />);
+    expect(screen.getByRole('checkbox')).toHaveClass('custom-class');
+  });
+
+  it('forwards ref to the row element', () => {
+    const ref = vi.fn();
+    render(<CheckboxRow {...defaultProps} ref={ref} />);
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+  });
+});

--- a/src/design-system/CheckboxRow/CheckboxRow.tsx
+++ b/src/design-system/CheckboxRow/CheckboxRow.tsx
@@ -1,0 +1,142 @@
+import { forwardRef } from 'react';
+import type { KeyboardEvent, ReactNode } from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '../cn';
+import { focusRing, disabledStyles, interactiveTransition } from '../variants';
+import { Checkbox } from '../Checkbox';
+
+const checkboxRowVariants = cva(
+  [
+    'flex items-center justify-between gap-2',
+    'p-1.5 -mx-1.5 rounded-md',
+    'hover:bg-surface-hover',
+    'cursor-pointer select-none',
+    interactiveTransition,
+    ...focusRing,
+    ...disabledStyles,
+  ],
+  {
+    variants: {
+      indent: {
+        true: 'ml-4 border-l border-stroke-subtle pl-3',
+      },
+    },
+    defaultVariants: {
+      indent: false,
+    },
+  }
+);
+
+const labelVariants = cva(['text-sm', 'transition-colors duration-100'], {
+  variants: {
+    checked: {
+      true: 'text-content',
+      false: 'text-content-tertiary',
+    },
+  },
+  defaultVariants: {
+    checked: false,
+  },
+});
+
+export interface CheckboxRowProps {
+  /**
+   * Visible label text for the row.
+   */
+  label: string;
+
+  /**
+   * Whether the row is checked.
+   */
+  checked: boolean;
+
+  /**
+   * Called with the next checked state when the row is toggled.
+   */
+  onChange: (checked: boolean) => void;
+
+  /**
+   * Trailing slot rendered before the checkbox: count Badge, etc.
+   */
+  trailing?: ReactNode;
+
+  /**
+   * Whether the row is disabled.
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * Nested sub-option indent with a left guide border.
+   * @default false
+   */
+  indent?: boolean;
+
+  /**
+   * Additional CSS classes for the row container.
+   */
+  className?: string;
+}
+
+/**
+ * Full-row checkbox: the entire row is the interactive checkbox, with a
+ * hover surface, optional trailing slot, and a display-only Checkbox visual.
+ *
+ * @example
+ * <CheckboxRow
+ *   label="Include labels"
+ *   checked={includeLabels}
+ *   onChange={setIncludeLabels}
+ * />
+ *
+ * @example
+ * // With a trailing count badge
+ * <CheckboxRow
+ *   label="Layer 1"
+ *   checked={selected}
+ *   onChange={setSelected}
+ *   trailing={<Badge>12</Badge>}
+ * />
+ *
+ * @example
+ * // Nested sub-option
+ * <CheckboxRow indent label="Bin notes" checked={withNotes} onChange={setWithNotes} />
+ */
+export const CheckboxRow = forwardRef<HTMLDivElement, CheckboxRowProps>(
+  ({ label, checked, onChange, trailing, disabled = false, indent = false, className }, ref) => {
+    const toggle = () => {
+      if (disabled) {
+        return;
+      }
+      onChange(!checked);
+    };
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault();
+        toggle();
+      }
+    };
+
+    return (
+      <div
+        ref={ref}
+        role="checkbox"
+        aria-checked={checked}
+        aria-disabled={disabled || undefined}
+        tabIndex={disabled ? -1 : 0}
+        onClick={toggle}
+        onKeyDown={handleKeyDown}
+        className={cn(checkboxRowVariants({ indent }), className)}
+      >
+        <span className={labelVariants({ checked })}>{label}</span>
+        <span className="flex items-center gap-2">
+          {trailing}
+          <Checkbox checked={checked} />
+        </span>
+      </div>
+    );
+  }
+);
+
+CheckboxRow.displayName = 'CheckboxRow';

--- a/src/design-system/CheckboxRow/index.ts
+++ b/src/design-system/CheckboxRow/index.ts
@@ -1,0 +1,2 @@
+export { CheckboxRow } from './CheckboxRow';
+export type { CheckboxRowProps } from './CheckboxRow';

--- a/src/design-system/ColorSwatch/ColorSwatch.test.tsx
+++ b/src/design-system/ColorSwatch/ColorSwatch.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ColorSwatch } from './ColorSwatch';
+
+describe('ColorSwatch', () => {
+  it('applies the color as inline background', () => {
+    render(<ColorSwatch color="#ff0000" aria-label="Red" />);
+    expect(screen.getByRole('img', { name: 'Red' })).toHaveStyle({
+      backgroundColor: '#ff0000',
+    });
+  });
+
+  it('falls back to fallbackColor when color is null', () => {
+    render(<ColorSwatch color={null} fallbackColor="#00ff00" aria-label="Hardware" />);
+    expect(screen.getByRole('img', { name: 'Hardware' })).toHaveStyle({
+      backgroundColor: '#00ff00',
+    });
+  });
+
+  it('falls back to fallbackColor when color is undefined', () => {
+    render(<ColorSwatch color={undefined} fallbackColor="#0000ff" aria-label="Screws" />);
+    expect(screen.getByRole('img', { name: 'Screws' })).toHaveStyle({
+      backgroundColor: '#0000ff',
+    });
+  });
+
+  it('renders a neutral placeholder when both color and fallback are absent', () => {
+    render(<ColorSwatch color={null} data-testid="swatch" />);
+    const swatch = screen.getByTestId('swatch');
+    expect(swatch.className).toContain('bg-surface-hover');
+    expect(swatch.style.backgroundColor).toBe('');
+  });
+
+  it('renders as a dot by default', () => {
+    render(<ColorSwatch color="#fff" data-testid="swatch" />);
+    expect(screen.getByTestId('swatch').className).toContain('rounded-full');
+  });
+
+  it('applies square shape classes', () => {
+    render(<ColorSwatch color="#fff" shape="square" data-testid="swatch" />);
+    expect(screen.getByTestId('swatch').className).toContain('rounded-sm');
+  });
+
+  it('applies tile shape classes', () => {
+    render(<ColorSwatch color="#fff" shape="tile" data-testid="swatch" />);
+    expect(screen.getByTestId('swatch').className).toContain('rounded-lg');
+  });
+
+  it('renders at sm size by default', () => {
+    render(<ColorSwatch color="#fff" data-testid="swatch" />);
+    expect(screen.getByTestId('swatch').className).toContain('w-2.5');
+  });
+
+  it.each([
+    ['md', 'w-3.5'],
+    ['lg', 'w-4'],
+    ['xl', 'w-10'],
+  ] as const)('applies %s size classes', (size, expected) => {
+    render(<ColorSwatch color="#fff" size={size} data-testid="swatch" />);
+    expect(screen.getByTestId('swatch').className).toContain(expected);
+  });
+
+  it('exposes role img with accessible name when aria-label is provided', () => {
+    render(<ColorSwatch color="#fff" aria-label="Electronics" />);
+    const swatch = screen.getByRole('img', { name: 'Electronics' });
+    expect(swatch).not.toHaveAttribute('aria-hidden');
+  });
+
+  it('is hidden from assistive tech when aria-label is omitted', () => {
+    render(<ColorSwatch color="#fff" data-testid="swatch" />);
+    const swatch = screen.getByTestId('swatch');
+    expect(swatch).toHaveAttribute('aria-hidden', 'true');
+    expect(swatch).not.toHaveAttribute('role');
+  });
+
+  it('merges className with variant classes', () => {
+    render(<ColorSwatch color="#fff" className="custom-class" data-testid="swatch" />);
+    const swatch = screen.getByTestId('swatch');
+    expect(swatch).toHaveClass('custom-class');
+    expect(swatch.className).toContain('shrink-0');
+  });
+
+  it('merges a custom style with the inline background', () => {
+    render(<ColorSwatch color="#ff0000" style={{ opacity: 0.5 }} data-testid="swatch" />);
+    const swatch = screen.getByTestId('swatch');
+    expect(swatch).toHaveStyle({ backgroundColor: '#ff0000', opacity: 0.5 });
+  });
+
+  it('forwards ref to the span element', () => {
+    const ref = vi.fn();
+    render(<ColorSwatch color="#fff" ref={ref} />);
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLSpanElement));
+  });
+});

--- a/src/design-system/ColorSwatch/ColorSwatch.tsx
+++ b/src/design-system/ColorSwatch/ColorSwatch.tsx
@@ -1,0 +1,99 @@
+import { forwardRef } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../cn';
+
+const colorSwatchVariants = cva(['inline-block', 'shrink-0', 'border', 'border-stroke-subtle'], {
+  variants: {
+    shape: {
+      dot: 'rounded-full',
+      square: 'rounded-sm',
+      tile: 'rounded-lg',
+    },
+    size: {
+      sm: 'w-2.5 h-2.5',
+      md: 'w-3.5 h-3.5',
+      lg: 'w-4 h-4',
+      xl: 'w-10 h-10',
+    },
+  },
+  defaultVariants: {
+    shape: 'dot',
+    size: 'sm',
+  },
+});
+
+type ColorSwatchVariantProps = VariantProps<typeof colorSwatchVariants>;
+
+export interface ColorSwatchProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'color'>, ColorSwatchVariantProps {
+  /**
+   * CSS color. Falls back to `fallbackColor` when undefined/null.
+   */
+  color: string | null | undefined;
+  /**
+   * Fallback color applied when `color` is absent. Callers pass their
+   * domain default (e.g. DEFAULT_CATEGORY_COLOR).
+   *
+   * @default undefined — when both color and fallback are absent, renders a neutral placeholder
+   */
+  fallbackColor?: string;
+  /**
+   * Swatch shape.
+   *
+   * @default 'dot'
+   */
+  shape?: 'dot' | 'square' | 'tile';
+  /**
+   * Swatch size.
+   *
+   * @default 'sm'
+   */
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+  /**
+   * Accessible name when the swatch carries standalone meaning
+   * (exposed as role="img"). Omit when decorative next to visible
+   * text — the swatch is then aria-hidden.
+   */
+  'aria-label'?: string;
+}
+
+/**
+ * Color indicator for categories and other color-coded entities.
+ *
+ * @example
+ * // Decorative dot next to a category name
+ * <ColorSwatch color={category.color} fallbackColor={DEFAULT_CATEGORY_COLOR} />
+ *
+ * @example
+ * // Standalone meaning (accessible name)
+ * <ColorSwatch color={category.color} aria-label={category.name} size="md" />
+ *
+ * @example
+ * // Large tile indicator
+ * <ColorSwatch color={activeColor} shape="tile" size="xl" />
+ */
+export const ColorSwatch = forwardRef<HTMLSpanElement, ColorSwatchProps>(
+  (
+    { color, fallbackColor, shape, size, className, style, 'aria-label': ariaLabel, ...props },
+    ref
+  ) => {
+    const resolvedColor = color ?? fallbackColor;
+    return (
+      <span
+        ref={ref}
+        role={ariaLabel ? 'img' : undefined}
+        aria-label={ariaLabel}
+        aria-hidden={ariaLabel ? undefined : 'true'}
+        className={cn(
+          colorSwatchVariants({ shape, size }),
+          resolvedColor === undefined && 'bg-surface-hover',
+          className
+        )}
+        style={resolvedColor === undefined ? style : { backgroundColor: resolvedColor, ...style }}
+        {...props}
+      />
+    );
+  }
+);
+
+ColorSwatch.displayName = 'ColorSwatch';

--- a/src/design-system/ColorSwatch/index.ts
+++ b/src/design-system/ColorSwatch/index.ts
@@ -1,0 +1,2 @@
+export { ColorSwatch } from './ColorSwatch';
+export type { ColorSwatchProps } from './ColorSwatch';

--- a/src/design-system/CopyButton/CopyButton.test.tsx
+++ b/src/design-system/CopyButton/CopyButton.test.tsx
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { createRef } from 'react';
+import { CopyButton } from './CopyButton';
+
+const writeText = vi.fn<(text: string) => Promise<void>>();
+
+async function clickAndSettle(element: HTMLElement): Promise<void> {
+  await act(async () => {
+    fireEvent.click(element);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  writeText.mockReset().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('CopyButton', () => {
+  describe('copying', () => {
+    it('copies the value to the clipboard', async () => {
+      render(<CopyButton value="hello" aria-label="Copy value" />);
+
+      await clickAndSettle(screen.getByRole('button', { name: 'Copy value' }));
+
+      expect(writeText).toHaveBeenCalledWith('hello');
+    });
+
+    it('resolves a lazy getter at click time', async () => {
+      const getValue = vi.fn(() => 'computed payload');
+      render(<CopyButton value={getValue} aria-label="Copy value" />);
+
+      expect(getValue).not.toHaveBeenCalled();
+      await clickAndSettle(screen.getByRole('button', { name: 'Copy value' }));
+
+      expect(getValue).toHaveBeenCalledTimes(1);
+      expect(writeText).toHaveBeenCalledWith('computed payload');
+    });
+
+    it('calls onCopied after a successful copy', async () => {
+      const onCopied = vi.fn();
+      render(<CopyButton value="hello" aria-label="Copy value" onCopied={onCopied} />);
+
+      await clickAndSettle(screen.getByRole('button', { name: 'Copy value' }));
+
+      expect(onCopied).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not copy when disabled', async () => {
+      render(<CopyButton value="hello" aria-label="Copy value" disabled />);
+
+      await clickAndSettle(screen.getByRole('button', { name: 'Copy value' }));
+
+      expect(writeText).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('copied state', () => {
+    it('shows the copied label and reverts after the timeout', async () => {
+      render(<CopyButton value="hello" aria-label="Copy value" label="Copy" />);
+      const button = screen.getByRole('button', { name: 'Copy value' });
+
+      expect(button).toHaveTextContent('Copy');
+      await clickAndSettle(button);
+      expect(button).toHaveTextContent('Copied');
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+
+      expect(button).not.toHaveTextContent('Copied');
+      expect(button).toHaveTextContent('Copy');
+    });
+
+    it('swaps the icon to a success check while copied', async () => {
+      render(<CopyButton value="hello" aria-label="Copy value" />);
+      const button = screen.getByRole('button', { name: 'Copy value' });
+
+      expect(screen.queryByTestId('copy-button-check-icon')).not.toBeInTheDocument();
+      await clickAndSettle(button);
+
+      const check = screen.getByTestId('copy-button-check-icon');
+      expect(check.closest('svg')?.getAttribute('class')).toContain('text-success');
+    });
+
+    it('respects a custom timeoutMs', async () => {
+      render(<CopyButton value="hello" aria-label="Copy value" label="Copy" timeoutMs={500} />);
+      const button = screen.getByRole('button', { name: 'Copy value' });
+
+      await clickAndSettle(button);
+      expect(button).toHaveTextContent('Copied');
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(button).toHaveTextContent('Copy');
+    });
+
+    it('resets the timer on re-click', async () => {
+      render(<CopyButton value="hello" aria-label="Copy value" label="Copy" />);
+      const button = screen.getByRole('button', { name: 'Copy value' });
+
+      await clickAndSettle(button);
+      act(() => {
+        vi.advanceTimersByTime(1500);
+      });
+      await clickAndSettle(button);
+      act(() => {
+        vi.advanceTimersByTime(1500);
+      });
+
+      expect(button).toHaveTextContent('Copied');
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(button).toHaveTextContent('Copy');
+    });
+
+    it('clears the pending timer on unmount', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { unmount } = render(<CopyButton value="hello" aria-label="Copy value" />);
+
+      await clickAndSettle(screen.getByRole('button', { name: 'Copy value' }));
+      expect(vi.getTimerCount()).toBe(1);
+
+      unmount();
+
+      expect(vi.getTimerCount()).toBe(0);
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('keeps a stable aria-label while copied', async () => {
+      render(<CopyButton value="hello" aria-label="Copy share link" label="Copy" />);
+      const button = screen.getByRole('button', { name: 'Copy share link' });
+
+      await clickAndSettle(button);
+
+      expect(button).toHaveAttribute('aria-label', 'Copy share link');
+    });
+
+    it('announces the copied label via a polite live region', async () => {
+      const { container } = render(
+        <CopyButton value="hello" aria-label="Copy value" copiedLabel="Link copied" />
+      );
+      const liveRegion = container.querySelector('[aria-live="polite"]');
+
+      expect(liveRegion).toHaveTextContent('');
+      await clickAndSettle(screen.getByRole('button', { name: 'Copy value' }));
+      expect(liveRegion).toHaveTextContent('Link copied');
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+
+      expect(liveRegion).toHaveTextContent('');
+    });
+  });
+
+  describe('fallback and failure', () => {
+    it('falls back to execCommand when the clipboard API rejects', async () => {
+      writeText.mockRejectedValue(new Error('not allowed'));
+      const execCommand = vi.fn().mockReturnValue(true);
+      document.execCommand = execCommand;
+      const onCopied = vi.fn();
+      render(<CopyButton value="hello" aria-label="Copy value" label="Copy" onCopied={onCopied} />);
+      const button = screen.getByRole('button', { name: 'Copy value' });
+
+      await clickAndSettle(button);
+
+      expect(execCommand).toHaveBeenCalledWith('copy');
+      expect(onCopied).toHaveBeenCalledTimes(1);
+      expect(button).toHaveTextContent('Copied');
+    });
+
+    it('does not enter the copied state when copy fails entirely', async () => {
+      writeText.mockRejectedValue(new Error('not allowed'));
+      document.execCommand = vi.fn().mockReturnValue(false);
+      const onCopied = vi.fn();
+      render(<CopyButton value="hello" aria-label="Copy value" label="Copy" onCopied={onCopied} />);
+      const button = screen.getByRole('button', { name: 'Copy value' });
+
+      await clickAndSettle(button);
+
+      expect(onCopied).not.toHaveBeenCalled();
+      expect(button).toHaveTextContent('Copy');
+      expect(button).not.toHaveTextContent('Copied');
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+
+      expect(button).toHaveTextContent('Copy');
+      expect(button).not.toHaveTextContent('Copied');
+    });
+  });
+
+  describe('rendering', () => {
+    it('applies className', () => {
+      render(<CopyButton value="hello" aria-label="Copy value" className="custom-class" />);
+      expect(screen.getByRole('button', { name: 'Copy value' })).toHaveClass('custom-class');
+    });
+
+    it('renders icon-only when label is omitted', () => {
+      render(<CopyButton value="hello" aria-label="Copy value" />);
+      expect(screen.getByRole('button', { name: 'Copy value' }).className).toContain(
+        'aspect-square'
+      );
+    });
+
+    it('forwards ref to the button element', () => {
+      const ref = createRef<HTMLButtonElement>();
+      render(<CopyButton ref={ref} value="hello" aria-label="Copy value" />);
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    });
+  });
+});

--- a/src/design-system/CopyButton/CopyButton.tsx
+++ b/src/design-system/CopyButton/CopyButton.tsx
@@ -1,0 +1,225 @@
+import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { cn } from '../cn';
+import { Button } from '../Button';
+import { iconSizes } from '../variants';
+
+function copyViaSelection(text: string): boolean {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- intentional fallback when the Clipboard API is unavailable (non-secure contexts)
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+async function writeClipboardText(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return copyViaSelection(text);
+  }
+}
+
+interface InlineIconProps {
+  className?: string;
+  children: ReactNode;
+}
+
+function InlineIcon({ className, children }: InlineIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export interface CopyButtonProps {
+  /**
+   * Text to copy, or a lazy getter for computed payloads.
+   */
+  value: string | (() => string);
+
+  /**
+   * Accessible name for the button, e.g. 'Copy share link'.
+   * Stays stable while copied; the state change is announced via a live region.
+   */
+  'aria-label': string;
+
+  /**
+   * Visible label next to the icon; omit for icon-only.
+   * @default undefined
+   */
+  label?: string;
+
+  /**
+   * Visible label and announcement while in the copied state.
+   * @default 'Copied'
+   */
+  copiedLabel?: string;
+
+  /**
+   * How long the copied state persists, in milliseconds.
+   * @default 2000
+   */
+  timeoutMs?: number;
+
+  /**
+   * Called after a successful copy.
+   */
+  onCopied?: () => void;
+
+  /**
+   * Visual style passed through to Button.
+   * @default 'secondary'
+   */
+  variant?: 'primary' | 'secondary' | 'ghost';
+
+  /**
+   * Size passed through to Button.
+   * @default 'md'
+   */
+  size?: 'sm' | 'md';
+
+  /**
+   * Disable interaction.
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * Additional classes for the button.
+   */
+  className?: string;
+}
+
+/**
+ * Copy-to-clipboard button with transient success feedback.
+ *
+ * Uses the async Clipboard API with an execCommand fallback for
+ * non-secure contexts. The pending revert timer is cleared on
+ * unmount and on re-click.
+ *
+ * @example
+ * // Icon-only
+ * <CopyButton value={shareUrl} aria-label="Copy share link" />
+ *
+ * @example
+ * // With visible label and toast hookup
+ * <CopyButton
+ *   value={shareUrl}
+ *   aria-label="Copy share link"
+ *   label="Copy"
+ *   copiedLabel="Copied"
+ *   onCopied={() => toast.success('Link copied')}
+ * />
+ *
+ * @example
+ * // Lazy getter for computed payloads
+ * <CopyButton
+ *   value={() => JSON.stringify(exportLayout())}
+ *   aria-label="Copy layout JSON"
+ *   label="Copy JSON"
+ *   variant="ghost"
+ *   size="sm"
+ * />
+ */
+export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
+  (
+    {
+      value,
+      'aria-label': ariaLabel,
+      label,
+      copiedLabel = 'Copied',
+      timeoutMs = 2000,
+      onCopied,
+      variant = 'secondary',
+      size = 'md',
+      disabled,
+      className,
+    },
+    ref
+  ) => {
+    const [copied, setCopied] = useState(false);
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(
+      () => () => {
+        if (timerRef.current !== null) {
+          clearTimeout(timerRef.current);
+        }
+      },
+      []
+    );
+
+    const handleClick = useCallback(async () => {
+      const text = typeof value === 'function' ? value() : value;
+      const succeeded = await writeClipboardText(text);
+      if (!succeeded) {
+        return;
+      }
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+      }
+      setCopied(true);
+      onCopied?.();
+      timerRef.current = setTimeout(() => {
+        setCopied(false);
+        timerRef.current = null;
+      }, timeoutMs);
+    }, [value, onCopied, timeoutMs]);
+
+    return (
+      <Button
+        ref={ref}
+        type="button"
+        variant={variant}
+        size={size}
+        iconOnly={label === undefined}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        className={className}
+        onClick={() => void handleClick()}
+        leftIcon={
+          copied ? (
+            <InlineIcon className={cn(iconSizes[size], 'text-success')}>
+              <polyline points="20 6 9 17 4 12" data-testid="copy-button-check-icon" />
+            </InlineIcon>
+          ) : (
+            <InlineIcon className={iconSizes[size]}>
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </InlineIcon>
+          )
+        }
+      >
+        {label !== undefined && (copied ? copiedLabel : label)}
+        <span aria-live="polite" className="sr-only">
+          {copied ? copiedLabel : ''}
+        </span>
+      </Button>
+    );
+  }
+);
+
+CopyButton.displayName = 'CopyButton';

--- a/src/design-system/CopyButton/CopyField.test.tsx
+++ b/src/design-system/CopyButton/CopyField.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { CopyField } from './CopyField';
+
+const writeText = vi.fn<(text: string) => Promise<void>>();
+
+const defaultProps = {
+  value: 'https://example.com/share/abc123',
+  'aria-label': 'Share link',
+  copyAriaLabel: 'Copy share link',
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  writeText.mockReset().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('CopyField', () => {
+  it('renders a read-only input with the value', () => {
+    render(<CopyField {...defaultProps} />);
+    const input = screen.getByRole('textbox', { name: 'Share link' });
+
+    expect(input).toHaveValue(defaultProps.value);
+    expect(input).toHaveAttribute('readonly');
+  });
+
+  it('selects the full value when the input is clicked', () => {
+    render(<CopyField {...defaultProps} />);
+    const input = screen.getByRole('textbox', { name: 'Share link' });
+
+    fireEvent.click(input);
+
+    expect(input).toHaveProperty('selectionStart', 0);
+    expect(input).toHaveProperty('selectionEnd', defaultProps.value.length);
+  });
+
+  it('copies the value via the copy button', async () => {
+    render(<CopyField {...defaultProps} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Copy share link' }));
+    });
+
+    expect(writeText).toHaveBeenCalledWith(defaultProps.value);
+  });
+
+  it('calls onCopied after a successful copy', async () => {
+    const onCopied = vi.fn();
+    render(<CopyField {...defaultProps} onCopied={onCopied} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Copy share link' }));
+    });
+
+    expect(onCopied).toHaveBeenCalledTimes(1);
+  });
+
+  it('announces a custom copiedLabel', async () => {
+    const { container } = render(<CopyField {...defaultProps} copiedLabel="Link copied" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Copy share link' }));
+    });
+
+    expect(container.querySelector('[aria-live="polite"]')).toHaveTextContent('Link copied');
+  });
+
+  it('renders monospace by default', () => {
+    render(<CopyField {...defaultProps} />);
+    expect(screen.getByRole('textbox', { name: 'Share link' })).toHaveClass('font-mono');
+  });
+
+  it('renders proportional text when mono is false', () => {
+    render(<CopyField {...defaultProps} mono={false} />);
+    expect(screen.getByRole('textbox', { name: 'Share link' })).not.toHaveClass('font-mono');
+  });
+});

--- a/src/design-system/CopyButton/CopyField.tsx
+++ b/src/design-system/CopyButton/CopyField.tsx
@@ -1,0 +1,85 @@
+import { forwardRef } from 'react';
+import { cn } from '../cn';
+import { Input } from '../Input';
+import { CopyButton } from './CopyButton';
+
+export interface CopyFieldProps {
+  /**
+   * Text shown in the read-only field and copied by the button.
+   */
+  value: string;
+
+  /**
+   * Accessible label for the read-only input.
+   */
+  'aria-label': string;
+
+  /**
+   * Accessible name for the copy button.
+   */
+  copyAriaLabel: string;
+
+  /**
+   * Visible label and announcement while in the copied state.
+   * @default 'Copied'
+   */
+  copiedLabel?: string;
+
+  /**
+   * Render the value in a monospace font.
+   * @default true
+   */
+  mono?: boolean;
+
+  /**
+   * Called after a successful copy.
+   */
+  onCopied?: () => void;
+}
+
+/**
+ * Read-only value row with an adjacent copy button.
+ * Clicking the field selects its full contents.
+ *
+ * @example
+ * <CopyField
+ *   value={shareUrl}
+ *   aria-label="Share link"
+ *   copyAriaLabel="Copy share link"
+ * />
+ *
+ * @example
+ * // Non-URL payload without monospace
+ * <CopyField
+ *   value={layoutName}
+ *   aria-label="Layout name"
+ *   copyAriaLabel="Copy layout name"
+ *   mono={false}
+ *   onCopied={() => toast.success('Copied')}
+ * />
+ */
+export const CopyField = forwardRef<HTMLInputElement, CopyFieldProps>(
+  ({ value, 'aria-label': ariaLabel, copyAriaLabel, copiedLabel, mono = true, onCopied }, ref) => {
+    return (
+      <div className="flex items-center gap-2">
+        <Input
+          ref={ref}
+          readOnly
+          value={value}
+          aria-label={ariaLabel}
+          wrapperClassName="min-w-0 flex-1"
+          className={cn(mono && 'font-mono')}
+          onClick={(event) => event.currentTarget.select()}
+        />
+        <CopyButton
+          value={value}
+          aria-label={copyAriaLabel}
+          copiedLabel={copiedLabel}
+          onCopied={onCopied}
+        />
+      </div>
+    );
+  }
+);
+
+CopyField.displayName = 'CopyField';

--- a/src/design-system/CopyButton/index.ts
+++ b/src/design-system/CopyButton/index.ts
@@ -1,0 +1,4 @@
+export { CopyButton } from './CopyButton';
+export type { CopyButtonProps } from './CopyButton';
+export { CopyField } from './CopyField';
+export type { CopyFieldProps } from './CopyField';

--- a/src/design-system/Dialog/Dialog.test.tsx
+++ b/src/design-system/Dialog/Dialog.test.tsx
@@ -672,6 +672,27 @@ describe('Dialog', () => {
       unmount();
       expect(document.body.style.overflow).toBe('');
     });
+
+    it('keeps body locked when concurrent dialogs close in non-LIFO order', () => {
+      const first = render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="First" />
+          <Dialog.Body>First</Dialog.Body>
+        </Dialog.Root>
+      );
+      const second = render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Second" />
+          <Dialog.Body>Second</Dialog.Body>
+        </Dialog.Root>
+      );
+
+      first.unmount();
+      expect(document.body.style.overflow).toBe('hidden');
+
+      second.unmount();
+      expect(document.body.style.overflow).toBe('');
+    });
   });
 });
 

--- a/src/design-system/Dialog/Dialog.test.tsx
+++ b/src/design-system/Dialog/Dialog.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { useRef } from 'react';
 import { Dialog, ConfirmDialog } from './Dialog';
 
 describe('Dialog', () => {
@@ -62,6 +63,129 @@ describe('Dialog', () => {
     });
   });
 
+  describe('sizes', () => {
+    const renderWithSize = (size: 'full' | '2xl' | '3xl' | '4xl' | '5xl') => {
+      const result = render(
+        <Dialog.Root open={true} onClose={vi.fn()} size={size}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      const className = screen.getByRole('dialog').className;
+      result.unmount();
+      return className;
+    };
+
+    it('applies 2xl size classes', () => {
+      expect(renderWithSize('2xl')).toContain('max-w-2xl');
+    });
+
+    it('applies 3xl size classes', () => {
+      expect(renderWithSize('3xl')).toContain('max-w-3xl');
+    });
+
+    it('applies 4xl size classes', () => {
+      const className = renderWithSize('4xl');
+      expect(className).toContain('w-[95vw]');
+      expect(className).toContain('max-w-4xl');
+    });
+
+    it('applies 5xl size classes', () => {
+      const className = renderWithSize('5xl');
+      expect(className).toContain('w-[95vw]');
+      expect(className).toContain('max-w-5xl');
+    });
+
+    it('renders deprecated full size identically to 4xl', () => {
+      expect(renderWithSize('full')).toBe(renderWithSize('4xl'));
+    });
+  });
+
+  describe('height', () => {
+    it('defaults to auto height with max-h cap', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      const className = screen.getByRole('dialog').className;
+      expect(className).toContain('max-h-[90vh]');
+      expect(className).not.toContain('h-[85vh]');
+    });
+
+    it('applies fixed height classes', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()} height="fixed">
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      expect(screen.getByRole('dialog').className).toContain('h-[85vh]');
+    });
+  });
+
+  describe('mobile presentation', () => {
+    it('applies sheet classes and renders the drag handle', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()} mobilePresentation="sheet">
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      const className = screen.getByRole('dialog').className;
+      expect(className).toContain('max-md:rounded-t-2xl');
+      expect(className).toContain('max-md:animate-slide-up');
+      expect(screen.getByTestId('dialog-drag-handle')).toBeInTheDocument();
+    });
+
+    it('does not render the drag handle for dialog presentation', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      expect(screen.queryByTestId('dialog-drag-handle')).not.toBeInTheDocument();
+    });
+
+    it('applies mobile full-screen classes', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()} fullScreen="mobile">
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      const className = screen.getByRole('dialog').className;
+      expect(className).toContain('max-md:h-dvh');
+      expect(className).toContain('max-md:rounded-none');
+    });
+  });
+
+  describe('overlay', () => {
+    it('applies overlayClassName to the overlay', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()} overlayClassName="backdrop-blur-sm">
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      expect(screen.getByTestId('dialog-overlay').className).toContain('backdrop-blur-sm');
+    });
+
+    it('closes on overlay click by default', () => {
+      const onClose = vi.fn();
+      render(
+        <Dialog.Root open={true} onClose={onClose}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      fireEvent.click(screen.getByTestId('dialog-overlay'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('close interactions', () => {
     it('calls onClose when close button clicked', () => {
       const onClose = vi.fn();
@@ -84,6 +208,20 @@ describe('Dialog', () => {
         </Dialog.Root>
       );
       fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose once when Escape is pressed inside the content', () => {
+      const onClose = vi.fn();
+      render(
+        <Dialog.Root open={true} onClose={onClose}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>
+            <input aria-label="Field" />
+          </Dialog.Body>
+        </Dialog.Root>
+      );
+      fireEvent.keyDown(screen.getByLabelText('Field'), { key: 'Escape' });
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
@@ -110,6 +248,339 @@ describe('Dialog', () => {
     });
   });
 
+  describe('dismissable', () => {
+    it('blocks Escape when dismissable is false', () => {
+      const onClose = vi.fn();
+      render(
+        <Dialog.Root open={true} onClose={onClose} dismissable={false}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>
+            <input aria-label="Field" />
+          </Dialog.Body>
+        </Dialog.Root>
+      );
+      fireEvent.keyDown(document, { key: 'Escape' });
+      fireEvent.keyDown(screen.getByLabelText('Field'), { key: 'Escape' });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('blocks overlay click when dismissable is false', () => {
+      const onClose = vi.fn();
+      render(
+        <Dialog.Root open={true} onClose={onClose} dismissable={false}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      fireEvent.click(screen.getByTestId('dialog-overlay'));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('makes the header close button inert when dismissable is false', () => {
+      const onClose = vi.fn();
+      render(
+        <Dialog.Root open={true} onClose={onClose} dismissable={false}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      const closeButton = screen.getByLabelText('Close dialog');
+      expect(closeButton).toBeDisabled();
+      fireEvent.click(closeButton);
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('initial focus', () => {
+    it('focuses the first focusable element by default', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      expect(screen.getByLabelText('Close dialog')).toHaveFocus();
+    });
+
+    it('focuses the container when initialFocus is container', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()} initialFocus="container">
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      expect(screen.getByRole('dialog')).toHaveFocus();
+    });
+
+    it('focuses the referenced element when initialFocus is a ref', () => {
+      function Harness() {
+        const targetRef = useRef<HTMLElement | null>(null);
+        return (
+          <Dialog.Root open={true} onClose={vi.fn()} initialFocus={targetRef}>
+            <Dialog.Header title="Test" />
+            <Dialog.Body>
+              <button>First</button>
+              <button
+                ref={(node) => {
+                  targetRef.current = node;
+                }}
+              >
+                Target
+              </button>
+            </Dialog.Body>
+          </Dialog.Root>
+        );
+      }
+      render(<Harness />);
+      expect(screen.getByText('Target')).toHaveFocus();
+    });
+  });
+
+  describe('keyboard containment', () => {
+    it('stops keydown propagation past the dialog by default', () => {
+      const documentSpy = vi.fn();
+      document.addEventListener('keydown', documentSpy);
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>
+            <input aria-label="Field" />
+          </Dialog.Body>
+        </Dialog.Root>
+      );
+      fireEvent.keyDown(screen.getByLabelText('Field'), { key: 'a' });
+      expect(documentSpy).not.toHaveBeenCalled();
+      document.removeEventListener('keydown', documentSpy);
+    });
+
+    it('lets keydown propagate when containKeyboard is false', () => {
+      const documentSpy = vi.fn();
+      document.addEventListener('keydown', documentSpy);
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()} containKeyboard={false}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>
+            <input aria-label="Field" />
+          </Dialog.Body>
+        </Dialog.Root>
+      );
+      fireEvent.keyDown(screen.getByLabelText('Field'), { key: 'a' });
+      expect(documentSpy).toHaveBeenCalledTimes(1);
+      document.removeEventListener('keydown', documentSpy);
+    });
+  });
+
+  describe('stacking', () => {
+    it('closes only the topmost dialog on Escape', () => {
+      const onCloseOuter = vi.fn();
+      const onCloseInner = vi.fn();
+      render(
+        <>
+          <Dialog.Root open={true} onClose={onCloseOuter}>
+            <Dialog.Header title="Outer" />
+            <Dialog.Body>Outer content</Dialog.Body>
+          </Dialog.Root>
+          <Dialog.Root open={true} onClose={onCloseInner}>
+            <Dialog.Header title="Inner" />
+            <Dialog.Body>Inner content</Dialog.Body>
+          </Dialog.Root>
+        </>
+      );
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onCloseInner).toHaveBeenCalledTimes(1);
+      expect(onCloseOuter).not.toHaveBeenCalled();
+    });
+
+    it('layers stacked dialogs by depth', () => {
+      render(
+        <>
+          <Dialog.Root open={true} onClose={vi.fn()}>
+            <Dialog.Header title="Outer" />
+            <Dialog.Body>Outer content</Dialog.Body>
+          </Dialog.Root>
+          <Dialog.Root open={true} onClose={vi.fn()}>
+            <Dialog.Header title="Inner" />
+            <Dialog.Body>Inner content</Dialog.Body>
+          </Dialog.Root>
+        </>
+      );
+      const overlays = screen.getAllByTestId('dialog-overlay');
+      const dialogs = screen.getAllByRole('dialog');
+      expect(overlays[0].style.zIndex).toBe('50');
+      expect(dialogs[0].style.zIndex).toBe('51');
+      expect(overlays[1].style.zIndex).toBe('52');
+      expect(dialogs[1].style.zIndex).toBe('53');
+    });
+  });
+
+  describe('header parts', () => {
+    it('renders the leading slot', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" leading={<span>Back</span>} />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      expect(screen.getByText('Back')).toBeInTheDocument();
+    });
+
+    it('applies bordered header classes', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" bordered />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      const header = screen.getByText('Test').parentElement?.parentElement;
+      expect(header?.className).toContain('border-b');
+    });
+
+    it('accepts a ReactNode title', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title={<em>Fancy</em>} />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      expect(screen.getByText('Fancy')).toBeInTheDocument();
+    });
+  });
+
+  describe('sub header', () => {
+    it('renders children with the separator row classes', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <Dialog.SubHeader>
+            <span>Tabs go here</span>
+          </Dialog.SubHeader>
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      const subHeader = screen.getByText('Tabs go here').parentElement;
+      expect(subHeader?.className).toContain('border-b');
+      expect(subHeader?.className).toContain('flex-shrink-0');
+    });
+  });
+
+  describe('body parts', () => {
+    it('removes padding with padding none', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body padding="none">Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      const body = screen.getByText('Content');
+      expect(body.className).toContain('p-0');
+      expect(body.className).not.toContain('px-[var(--space-2xl)]');
+    });
+
+    it('becomes an overflow-hidden flex container when scroll is false', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body scroll={false}>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      const body = screen.getByText('Content');
+      expect(body.className).toContain('overflow-hidden');
+      expect(body.className).not.toContain('overflow-y-auto');
+    });
+  });
+
+  describe('split layout', () => {
+    it('renders Split, Sidebar, and Pane structure', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <Dialog.Split>
+            <Dialog.Sidebar>Nav rail</Dialog.Sidebar>
+            <Dialog.Pane>Main pane</Dialog.Pane>
+          </Dialog.Split>
+        </Dialog.Root>
+      );
+      const sidebar = screen.getByText('Nav rail');
+      const pane = screen.getByText('Main pane');
+      const split = sidebar.parentElement;
+      expect(split?.className).toContain('flex');
+      expect(split?.className).toContain('max-md:flex-col');
+      expect(sidebar.className).toContain('w-64');
+      expect(sidebar.className).toContain('border-r');
+      expect(pane.className).toContain('flex-1');
+      expect(pane.className).toContain('overflow-y-auto');
+    });
+
+    it('supports the small sidebar width', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <Dialog.Split>
+            <Dialog.Sidebar width="sm">Nav rail</Dialog.Sidebar>
+            <Dialog.Pane>Main pane</Dialog.Pane>
+          </Dialog.Split>
+        </Dialog.Root>
+      );
+      expect(screen.getByText('Nav rail').className).toContain('w-40');
+    });
+  });
+
+  describe('footer parts', () => {
+    it('defaults to end justification', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+          <Dialog.Footer>
+            <button>Go</button>
+          </Dialog.Footer>
+        </Dialog.Root>
+      );
+      expect(screen.getByText('Go').parentElement?.className).toContain('justify-end');
+    });
+
+    it('supports between justification', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+          <Dialog.Footer justify="between">
+            <button>Go</button>
+          </Dialog.Footer>
+        </Dialog.Root>
+      );
+      expect(screen.getByText('Go').parentElement?.className).toContain('justify-between');
+    });
+
+    it('applies bordered footer classes', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+          <Dialog.Footer bordered>
+            <button>Go</button>
+          </Dialog.Footer>
+        </Dialog.Root>
+      );
+      expect(screen.getByText('Go').parentElement?.className).toContain('border-t');
+    });
+
+    it('renders the leading slot at the start', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+          <Dialog.Footer leading={<span>No layers selected</span>}>
+            <button>Go</button>
+          </Dialog.Footer>
+        </Dialog.Root>
+      );
+      const leading = screen.getByText('No layers selected');
+      expect(leading).toBeInTheDocument();
+      expect(leading.parentElement?.className).toContain('mr-auto');
+    });
+  });
+
   describe('accessibility', () => {
     it('has aria-modal', () => {
       render(
@@ -133,6 +604,52 @@ describe('Dialog', () => {
       expect(labelledBy).toBeTruthy();
       const titleElement = document.getElementById(labelledBy!);
       expect(titleElement?.textContent).toBe('My Title');
+    });
+
+    it('omits aria-labelledby and uses aria-label when no Header title mounts', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()} aria-label="Welcome hero">
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      const dialog = screen.getByRole('dialog', { name: 'Welcome hero' });
+      expect(dialog).not.toHaveAttribute('aria-labelledby');
+      expect(dialog).toHaveAttribute('aria-label', 'Welcome hero');
+    });
+
+    it('prefers the Header title over aria-label', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()} aria-label="Fallback">
+          <Dialog.Header title="Real Title" />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-labelledby');
+      expect(dialog).not.toHaveAttribute('aria-label');
+    });
+
+    it('omits aria-describedby when no Body mounts', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <div>Raw content</div>
+        </Dialog.Root>
+      );
+      expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-describedby');
+    });
+
+    it('sets aria-describedby when a Body mounts', () => {
+      render(
+        <Dialog.Root open={true} onClose={vi.fn()}>
+          <Dialog.Header title="Test" />
+          <Dialog.Body>Content</Dialog.Body>
+        </Dialog.Root>
+      );
+      const dialog = screen.getByRole('dialog');
+      const describedBy = dialog.getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+      expect(document.getElementById(describedBy!)?.textContent).toBe('Content');
     });
 
     it('locks body scroll when open', () => {
@@ -244,5 +761,85 @@ describe('ConfirmDialog', () => {
       />
     );
     expect(container.firstChild).toBeNull();
+  });
+
+  it('disables both buttons and shows busy state when busy', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test"
+        message="Test"
+        busy
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    const confirmButton = screen.getByText('Confirm').closest('button');
+    const cancelButton = screen.getByText('Cancel').closest('button');
+    expect(confirmButton).toBeDisabled();
+    expect(confirmButton).toHaveAttribute('aria-busy', 'true');
+    expect(cancelButton).toBeDisabled();
+  });
+
+  it('is not dismissable while busy', () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test"
+        message="Test"
+        busy
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    fireEvent.click(screen.getByTestId('dialog-overlay'));
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('renders the error line as an alert', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test"
+        message="Test"
+        error="Something went wrong"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong');
+  });
+
+  it('renders the icon in a tinted circle', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test"
+        message="Test"
+        icon={<span data-testid="confirm-icon" />}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    const circle = screen.getByTestId('confirm-icon').parentElement;
+    expect(circle?.className).toContain('rounded-full');
+    expect(circle?.className).toContain('bg-warning-muted');
+  });
+
+  it('tints the icon circle with the error intent when destructive', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test"
+        message="Test"
+        destructive
+        icon={<span data-testid="confirm-icon" />}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('confirm-icon').parentElement?.className).toContain('bg-error-muted');
   });
 });

--- a/src/design-system/Dialog/Dialog.tsx
+++ b/src/design-system/Dialog/Dialog.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useLayoutEffect,
   useRef,
   useCallback,
   useId,
@@ -66,7 +67,9 @@ function subscribeToDialogStack(listener: () => void): () => void {
  * focus-trap behavior so nested dialogs don't fight over keyboard input.
  */
 export function useDialogStack(id: string, active: boolean): { depth: number; isTopmost: boolean } {
-  useEffect(() => {
+  // useLayoutEffect so depth/isTopmost are correct on first paint when
+  // multiple dialogs mount open together.
+  useLayoutEffect(() => {
     if (!active) return;
     registerDialog(id);
     return () => unregisterDialog(id);
@@ -101,7 +104,7 @@ function useDialogContext() {
   }
   return context;
 }
-const overlayVariants = cva(['fixed inset-0 z-50', 'bg-overlay-dark', 'animate-fade-in']);
+const overlayVariants = cva(['fixed inset-0', 'bg-overlay-dark', 'animate-fade-in']);
 
 const contentVariants = cva(
   [
@@ -317,12 +320,17 @@ export function useFocusTrap(
 
 // Body Scroll Lock Hook
 
-export function useBodyScrollLock(isLocked: boolean): void {
-  useEffect(() => {
-    if (!isLocked) return;
+// Reference-counted so concurrent dialogs closing in any order can't restore
+// stale captured styles (non-LIFO close previously unlocked under an open
+// dialog, then re-locked the body permanently).
+let bodyScrollLockCount = 0;
+let bodyScrollOriginalOverflow = '';
+let bodyScrollOriginalPaddingRight = '';
 
-    const originalOverflow = document.body.style.overflow;
-    const originalPaddingRight = document.body.style.paddingRight;
+function acquireBodyScrollLock(): void {
+  if (bodyScrollLockCount === 0) {
+    bodyScrollOriginalOverflow = document.body.style.overflow;
+    bodyScrollOriginalPaddingRight = document.body.style.paddingRight;
 
     // Calculate scrollbar width to prevent layout shift
     const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
@@ -331,11 +339,23 @@ export function useBodyScrollLock(isLocked: boolean): void {
     if (scrollbarWidth > 0) {
       document.body.style.paddingRight = `${scrollbarWidth}px`;
     }
+  }
+  bodyScrollLockCount += 1;
+}
 
-    return () => {
-      document.body.style.overflow = originalOverflow;
-      document.body.style.paddingRight = originalPaddingRight;
-    };
+function releaseBodyScrollLock(): void {
+  bodyScrollLockCount = Math.max(0, bodyScrollLockCount - 1);
+  if (bodyScrollLockCount === 0) {
+    document.body.style.overflow = bodyScrollOriginalOverflow;
+    document.body.style.paddingRight = bodyScrollOriginalPaddingRight;
+  }
+}
+
+export function useBodyScrollLock(isLocked: boolean): void {
+  useEffect(() => {
+    if (!isLocked) return;
+    acquireBodyScrollLock();
+    return releaseBodyScrollLock;
   }, [isLocked]);
 }
 
@@ -663,7 +683,8 @@ function DialogHeader({
 
   const hasTitle = title !== undefined && title !== null;
 
-  useEffect(() => {
+  // useLayoutEffect so aria-labelledby is wired before first paint.
+  useLayoutEffect(() => {
     if (!hasTitle) return;
     return registerTitle();
   }, [hasTitle, registerTitle]);
@@ -734,7 +755,8 @@ export interface DialogBodyProps {
 function DialogBody({ children, className, padding = 'default', scroll = true }: DialogBodyProps) {
   const { descriptionId, registerDescription } = useDialogContext();
 
-  useEffect(() => registerDescription(), [registerDescription]);
+  // useLayoutEffect so aria-describedby is wired before first paint.
+  useLayoutEffect(() => registerDescription(), [registerDescription]);
 
   return (
     <div id={descriptionId} className={cn(bodyVariants({ padding, scroll }), className)}>

--- a/src/design-system/Dialog/Dialog.tsx
+++ b/src/design-system/Dialog/Dialog.tsx
@@ -3,6 +3,8 @@ import {
   useRef,
   useCallback,
   useId,
+  useState,
+  useSyncExternalStore,
   createContext,
   useContext,
   type ReactNode,
@@ -11,8 +13,73 @@ import { createPortal } from 'react-dom';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../cn';
 import { Button } from '../Button';
+import { Alert } from '../Alert';
 import { XIcon } from '../Icon';
-import { focusRing } from '../variants';
+import { focusRing, intentBackgrounds } from '../variants';
+
+// Dialog Stack
+
+const dialogStack: string[] = [];
+const dialogStackListeners = new Set<() => void>();
+
+function emitDialogStackChange() {
+  dialogStackListeners.forEach((listener) => listener());
+}
+
+/**
+ * Registers a dialog as the new topmost entry of the module-level stack.
+ * Exposed so non-Dialog overlays (e.g. BottomSheet) can participate.
+ */
+export function registerDialog(id: string): void {
+  if (!dialogStack.includes(id)) {
+    dialogStack.push(id);
+    emitDialogStackChange();
+  }
+}
+
+/**
+ * Removes a dialog from the module-level stack.
+ */
+export function unregisterDialog(id: string): void {
+  const index = dialogStack.indexOf(id);
+  if (index !== -1) {
+    dialogStack.splice(index, 1);
+    emitDialogStackChange();
+  }
+}
+
+/**
+ * Whether the given dialog is the topmost open dialog.
+ */
+export function isTopmostDialog(id: string): boolean {
+  return dialogStack[dialogStack.length - 1] === id;
+}
+
+function subscribeToDialogStack(listener: () => void): () => void {
+  dialogStackListeners.add(listener);
+  return () => dialogStackListeners.delete(listener);
+}
+
+/**
+ * Registers in the dialog stack while `active`, and returns the live stack
+ * position. `depth` drives z-index layering; `isTopmost` gates Escape and
+ * focus-trap behavior so nested dialogs don't fight over keyboard input.
+ */
+export function useDialogStack(id: string, active: boolean): { depth: number; isTopmost: boolean } {
+  useEffect(() => {
+    if (!active) return;
+    registerDialog(id);
+    return () => unregisterDialog(id);
+  }, [id, active]);
+
+  const index = useSyncExternalStore(subscribeToDialogStack, () => dialogStack.indexOf(id));
+  const stackSize = useSyncExternalStore(subscribeToDialogStack, () => dialogStack.length);
+
+  return {
+    depth: index === -1 ? 0 : index,
+    isTopmost: index !== -1 && index === stackSize - 1,
+  };
+}
 
 // Dialog Context
 
@@ -20,6 +87,9 @@ interface DialogContextValue {
   titleId: string;
   descriptionId: string;
   onClose: () => void;
+  dismissable: boolean;
+  registerTitle: () => () => void;
+  registerDescription: () => () => void;
 }
 
 const DialogContext = createContext<DialogContextValue | null>(null);
@@ -41,7 +111,6 @@ const contentVariants = cva(
     'rounded-[var(--radius-xl)]',
     'shadow-[var(--shadow-xl)]',
     'animate-scale-in',
-    'max-h-[90vh]',
     'overflow-hidden',
     'flex flex-col',
     ...focusRing,
@@ -53,51 +122,157 @@ const contentVariants = cva(
         md: 'w-[90vw] max-w-md',
         lg: 'w-[90vw] max-w-lg',
         xl: 'w-[90vw] max-w-xl',
+        '2xl': 'w-[90vw] max-w-2xl',
+        '3xl': 'w-[90vw] max-w-3xl',
+        '4xl': 'w-[95vw] max-w-4xl',
+        '5xl': 'w-[95vw] max-w-5xl',
         full: 'w-[95vw] max-w-4xl',
+      },
+      height: {
+        auto: 'max-h-[90vh]',
+        fixed: 'h-[85vh] max-h-[90vh]',
       },
       position: {
         center: 'left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2',
         top: 'left-1/2 top-16 -translate-x-1/2',
       },
+      fullScreen: {
+        never: '',
+        mobile: [
+          'max-md:left-0 max-md:top-0',
+          'max-md:translate-x-0 max-md:translate-y-0',
+          'max-md:w-full max-md:max-w-none',
+          'max-md:h-dvh max-md:max-h-none',
+          'max-md:rounded-none max-md:border-0',
+        ],
+      },
+      mobilePresentation: {
+        dialog: '',
+        sheet: [
+          'max-md:left-0 max-md:bottom-0 max-md:top-auto',
+          'max-md:translate-x-0 max-md:translate-y-0',
+          'max-md:w-full max-md:max-w-none',
+          'max-md:rounded-b-none max-md:rounded-t-2xl',
+          'max-md:animate-slide-up',
+        ],
+      },
     },
     defaultVariants: {
       size: 'md',
+      height: 'auto',
       position: 'center',
+      fullScreen: 'never',
+      mobilePresentation: 'dialog',
     },
   }
 );
 
-const headerVariants = cva([
-  'flex items-center justify-between',
-  'px-[var(--space-2xl)] pt-[var(--space-2xl)] pb-2',
+const headerVariants = cva(
+  [
+    'flex items-center justify-between',
+    'px-[var(--space-2xl)] pt-[var(--space-2xl)] pb-2',
+    'flex-shrink-0',
+  ],
+  {
+    variants: {
+      bordered: {
+        true: 'border-b border-stroke-subtle pb-4',
+      },
+    },
+  }
+);
+
+const subHeaderVariants = cva([
+  'px-[var(--space-2xl)] py-3',
+  'border-b border-stroke-subtle',
   'flex-shrink-0',
 ]);
 
-const bodyVariants = cva(['px-[var(--space-2xl)] py-0', 'overflow-y-auto', 'flex-1']);
+const bodyVariants = cva(['flex-1'], {
+  variants: {
+    padding: {
+      default: 'px-[var(--space-2xl)] py-0',
+      none: 'p-0',
+    },
+    scroll: {
+      true: 'overflow-y-auto',
+      false: 'min-h-0 overflow-hidden flex flex-col',
+    },
+  },
+  defaultVariants: {
+    padding: 'default',
+    scroll: true,
+  },
+});
 
-const footerVariants = cva([
-  'flex items-center justify-end gap-3',
-  'px-[var(--space-2xl)] pt-6 pb-[var(--space-2xl)]',
-  'flex-shrink-0',
-]);
+const footerVariants = cva(
+  ['flex items-center gap-3', 'px-[var(--space-2xl)] pt-6 pb-[var(--space-2xl)]', 'flex-shrink-0'],
+  {
+    variants: {
+      justify: {
+        end: 'justify-end',
+        between: 'justify-between',
+      },
+      bordered: {
+        true: 'border-t border-stroke-subtle',
+      },
+    },
+    defaultVariants: {
+      justify: 'end',
+    },
+  }
+);
+
+const splitVariants = cva(['flex flex-row max-md:flex-col', 'flex-1 min-h-0']);
+
+const sidebarVariants = cva(['flex-shrink-0', 'border-r border-stroke-subtle', 'overflow-y-auto'], {
+  variants: {
+    width: {
+      sm: 'w-40',
+      md: 'w-64',
+    },
+  },
+  defaultVariants: {
+    width: 'md',
+  },
+});
+
+const paneVariants = cva(['flex-1', 'overflow-y-auto', 'p-[var(--space-2xl)]']);
 
 // Focus Trap Hook
 
-function useFocusTrap(containerRef: React.RefObject<HTMLElement | null>, isActive: boolean) {
+export type DialogInitialFocus = 'first' | 'container' | React.RefObject<HTMLElement | null>;
+
+const focusableSelector = [
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'a[href]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+/**
+ * Traps Tab focus inside `containerRef` while active and applies initial
+ * focus on activation. Listens on the container (not document) so nested
+ * dialogs and contained keyboard events don't interfere with each other.
+ */
+export function useFocusTrap(
+  containerRef: React.RefObject<HTMLElement | null>,
+  isActive: boolean,
+  initialFocus: DialogInitialFocus = 'first'
+): void {
+  const initialFocusRef = useRef(initialFocus);
+
+  useEffect(() => {
+    initialFocusRef.current = initialFocus;
+  }, [initialFocus]);
+
   useEffect(() => {
     if (!isActive) return;
 
     const container = containerRef.current;
     if (!container) return;
-
-    const focusableSelector = [
-      'button:not([disabled])',
-      'input:not([disabled])',
-      'select:not([disabled])',
-      'textarea:not([disabled])',
-      'a[href]',
-      '[tabindex]:not([tabindex="-1"])',
-    ].join(', ');
 
     const getFocusableElements = () => {
       return Array.from(container.querySelectorAll<HTMLElement>(focusableSelector));
@@ -121,20 +296,28 @@ function useFocusTrap(containerRef: React.RefObject<HTMLElement | null>, isActiv
       }
     };
 
-    // Focus first focusable element
-    const focusable = getFocusableElements();
-    if (focusable.length > 0) {
-      focusable[0].focus();
+    const target = initialFocusRef.current;
+    if (target === 'container') {
+      container.focus();
+    } else if (target !== 'first' && target.current) {
+      target.current.focus();
+    } else {
+      const focusable = getFocusableElements();
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      } else {
+        container.focus();
+      }
     }
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    container.addEventListener('keydown', handleKeyDown);
+    return () => container.removeEventListener('keydown', handleKeyDown);
   }, [containerRef, isActive]);
 }
 
 // Body Scroll Lock Hook
 
-function useBodyScrollLock(isLocked: boolean) {
+export function useBodyScrollLock(isLocked: boolean): void {
   useEffect(() => {
     if (!isLocked) return;
 
@@ -189,19 +372,55 @@ export interface DialogRootProps extends ContentVariantProps {
   closeOnEscape?: boolean;
 
   /**
+   * When false, overlay click, Escape, and the Header close button are all
+   * inert — for busy/async states that must not be interrupted.
+   * @default true
+   */
+  dismissable?: boolean;
+
+  /**
+   * Where focus lands when the dialog opens: the first focusable element,
+   * the dialog container itself, or a specific element ref.
+   * @default 'first'
+   */
+  initialFocus?: DialogInitialFocus;
+
+  /**
+   * Accessible name for headerless dialogs. Used only when no Dialog.Header
+   * title is mounted.
+   */
+  'aria-label'?: string;
+
+  /**
+   * Stops keydown propagation at the dialog boundary so app-level shortcuts
+   * don't fire while the dialog is open.
+   * @default true
+   */
+  containKeyboard?: boolean;
+
+  /**
+   * Additional classes for the overlay element.
+   */
+  overlayClassName?: string;
+
+  /**
    * Additional classes for the content container.
    */
   className?: string;
 }
 
 /**
- * Modal dialog with focus trap and accessibility.
+ * Modal dialog with focus trap, stacking, and accessibility.
  *
  * Use compound components for structure:
  * - Dialog.Root: Container with open/close logic
- * - Dialog.Header: Title and close button
+ * - Dialog.Header: Title, optional leading slot, and close button
+ * - Dialog.SubHeader: Tab bars / search row under the title
  * - Dialog.Body: Main content area (scrollable)
+ * - Dialog.Split / Dialog.Sidebar / Dialog.Pane: Two-column layouts
  * - Dialog.Footer: Action buttons
+ *
+ * `size="full"` is a deprecated alias of `size="4xl"`.
  *
  * @example
  * <Dialog.Root open={isOpen} onClose={() => setIsOpen(false)}>
@@ -220,16 +439,23 @@ export interface DialogRootProps extends ContentVariantProps {
  * </Dialog.Root>
  *
  * @example
- * // Destructive dialog
- * <Dialog.Root open={showDelete} onClose={closeDelete} size="sm">
- *   <Dialog.Header title="Delete Item" />
- *   <Dialog.Body>
- *     This action cannot be undone.
- *   </Dialog.Body>
- *   <Dialog.Footer>
- *     <Button variant="ghost" onClick={closeDelete}>Cancel</Button>
- *     <Button variant="danger" onClick={handleDelete}>Delete</Button>
+ * // Settings-style dialog: stable height, full-screen on mobile, sidebar rail
+ * <Dialog.Root open={open} onClose={close} size="3xl" height="fixed" fullScreen="mobile">
+ *   <Dialog.Header title="Settings" bordered />
+ *   <Dialog.Split>
+ *     <Dialog.Sidebar width="sm">{nav}</Dialog.Sidebar>
+ *     <Dialog.Pane>{content}</Dialog.Pane>
+ *   </Dialog.Split>
+ *   <Dialog.Footer justify="between" bordered leading={legalLinks}>
+ *     <Button onClick={close}>Done</Button>
  *   </Dialog.Footer>
+ * </Dialog.Root>
+ *
+ * @example
+ * // Mobile action sheet
+ * <Dialog.Root open={open} onClose={close} mobilePresentation="sheet">
+ *   <Dialog.Header title="Rename layer" />
+ *   <Dialog.Body>{form}</Dialog.Body>
  * </Dialog.Root>
  */
 function DialogRoot({
@@ -237,16 +463,40 @@ function DialogRoot({
   onClose,
   children,
   size = 'md',
+  height = 'auto',
   position = 'center',
+  fullScreen = 'never',
+  mobilePresentation = 'dialog',
   closeOnOverlayClick = true,
   closeOnEscape = true,
+  dismissable = true,
+  initialFocus = 'first',
+  'aria-label': ariaLabel,
+  containKeyboard = true,
+  overlayClassName,
   className,
 }: DialogRootProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
+  const dialogId = useId();
   const titleId = useId();
   const descriptionId = useId();
+
+  const { depth } = useDialogStack(dialogId, open);
+
+  const [titleRegistrations, setTitleRegistrations] = useState(0);
+  const [descriptionRegistrations, setDescriptionRegistrations] = useState(0);
+
+  const registerTitle = useCallback(() => {
+    setTitleRegistrations((count) => count + 1);
+    return () => setTitleRegistrations((count) => count - 1);
+  }, []);
+
+  const registerDescription = useCallback(() => {
+    setDescriptionRegistrations((count) => count + 1);
+    return () => setDescriptionRegistrations((count) => count - 1);
+  }, []);
 
   // Store the element that had focus before opening
   useEffect(() => {
@@ -262,50 +512,101 @@ function DialogRoot({
     }
   }, [open]);
 
-  // Handle Escape key
+  const canDismiss = dismissable && closeOnEscape;
+
+  // Handle Escape key (document level, for events that never enter the
+  // content — containKeyboard handles in-content Escape before it gets here)
   useEffect(() => {
-    if (!open || !closeOnEscape) return;
+    if (!open || !canDismiss) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        onClose();
-      }
+      if (e.key !== 'Escape' || e.defaultPrevented) return;
+      if (!isTopmostDialog(dialogId)) return;
+      e.preventDefault();
+      onClose();
     };
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [open, closeOnEscape, onClose]);
+  }, [open, canDismiss, onClose, dialogId]);
 
   // Apply focus trap and scroll lock
-  useFocusTrap(contentRef, open);
+  useFocusTrap(contentRef, open, initialFocus);
   useBodyScrollLock(open);
 
   const handleOverlayClick = useCallback(
     (e: React.MouseEvent) => {
-      if (closeOnOverlayClick && e.target === e.currentTarget) {
+      if (dismissable && closeOnOverlayClick && e.target === e.currentTarget) {
         onClose();
       }
     },
-    [closeOnOverlayClick, onClose]
+    [dismissable, closeOnOverlayClick, onClose]
   );
+
+  const handleContentKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!containKeyboard) return;
+      if (e.key === 'Escape' && canDismiss && isTopmostDialog(dialogId)) {
+        e.preventDefault();
+        onClose();
+      }
+      e.stopPropagation();
+    },
+    [containKeyboard, canDismiss, onClose, dialogId]
+  );
+
+  const requestClose = useCallback(() => {
+    if (dismissable) {
+      onClose();
+    }
+  }, [dismissable, onClose]);
 
   if (!open) return null;
 
   return createPortal(
-    <DialogContext.Provider value={{ titleId, descriptionId, onClose }}>
+    <DialogContext.Provider
+      value={{
+        titleId,
+        descriptionId,
+        onClose: requestClose,
+        dismissable,
+        registerTitle,
+        registerDescription,
+      }}
+    >
       {/* Overlay */}
-      <div className={overlayVariants()} onClick={handleOverlayClick} aria-hidden="true" />
+      <div
+        data-testid="dialog-overlay"
+        className={cn(overlayVariants(), overlayClassName)}
+        style={{ zIndex: 50 + depth * 2 }}
+        onClick={handleOverlayClick}
+        aria-hidden="true"
+      />
 
       {/* Content */}
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
       <div
         ref={contentRef}
         role="dialog"
         aria-modal="true"
-        aria-labelledby={titleId}
-        aria-describedby={descriptionId}
-        className={cn(contentVariants({ size, position }), className)}
+        aria-labelledby={titleRegistrations > 0 ? titleId : undefined}
+        aria-label={titleRegistrations > 0 ? undefined : ariaLabel}
+        aria-describedby={descriptionRegistrations > 0 ? descriptionId : undefined}
+        tabIndex={-1}
+        style={{ zIndex: 51 + depth * 2 }}
+        onKeyDown={handleContentKeyDown}
+        className={cn(
+          contentVariants({ size, height, position, fullScreen, mobilePresentation }),
+          className
+        )}
       >
+        {mobilePresentation === 'sheet' && (
+          <div
+            data-testid="dialog-drag-handle"
+            aria-hidden="true"
+            className="mx-auto mt-2 h-1 w-10 flex-shrink-0 rounded-full bg-stroke-subtle md:hidden"
+          />
+        )}
         {children}
       </div>
     </DialogContext.Provider>,
@@ -317,9 +618,20 @@ function DialogRoot({
 
 export interface DialogHeaderProps {
   /**
-   * Dialog title.
+   * Dialog title. When omitted, provide `aria-label` on Dialog.Root.
    */
-  title: string;
+  title?: ReactNode;
+
+  /**
+   * Leading slot before the title (e.g. a back button or icon).
+   */
+  leading?: ReactNode;
+
+  /**
+   * Renders a bottom border under the header.
+   * @default false
+   */
+  bordered?: boolean;
 
   /**
    * Whether to show the close button.
@@ -334,28 +646,49 @@ export interface DialogHeaderProps {
   closeAriaLabel?: string;
 
   /**
-   * Additional content to render in the header.
+   * Trailing actions slot, rendered before the close button.
    */
   children?: ReactNode;
 }
 
 function DialogHeader({
   title,
+  leading,
+  bordered = false,
   showCloseButton = true,
   closeAriaLabel = 'Close dialog',
   children,
 }: DialogHeaderProps) {
-  const { titleId, onClose } = useDialogContext();
+  const { titleId, onClose, dismissable, registerTitle } = useDialogContext();
+
+  const hasTitle = title !== undefined && title !== null;
+
+  useEffect(() => {
+    if (!hasTitle) return;
+    return registerTitle();
+  }, [hasTitle, registerTitle]);
 
   return (
-    <div className={headerVariants()}>
-      <h2 id={titleId} className="text-xl font-semibold text-content">
-        {title}
-      </h2>
+    <div className={headerVariants({ bordered })}>
+      <div className="flex min-w-0 items-center gap-3">
+        {leading}
+        {hasTitle && (
+          <h2 id={titleId} className="text-xl font-semibold text-content">
+            {title}
+          </h2>
+        )}
+      </div>
       <div className="flex items-center gap-2">
         {children}
         {showCloseButton && (
-          <Button iconOnly size="sm" variant="ghost" onClick={onClose} aria-label={closeAriaLabel}>
+          <Button
+            iconOnly
+            size="sm"
+            variant="ghost"
+            onClick={onClose}
+            disabled={!dismissable}
+            aria-label={closeAriaLabel}
+          >
             <XIcon size="sm" />
           </Button>
         )}
@@ -364,21 +697,89 @@ function DialogHeader({
   );
 }
 
+// Dialog SubHeader
+
+export interface DialogSubHeaderProps {
+  /**
+   * Row content, e.g. a tab bar or search input under the title.
+   */
+  children: ReactNode;
+  className?: string;
+}
+
+function DialogSubHeader({ children, className }: DialogSubHeaderProps) {
+  return <div className={cn(subHeaderVariants(), className)}>{children}</div>;
+}
+
 // Dialog Body
 
 export interface DialogBodyProps {
   children: ReactNode;
   className?: string;
+
+  /**
+   * Built-in horizontal padding, or none when the content owns its padding.
+   * @default 'default'
+   */
+  padding?: 'default' | 'none';
+
+  /**
+   * Scrollable body. When false the body becomes an overflow-hidden flex
+   * column so a child (textarea, grid) can flex and scroll itself.
+   * @default true
+   */
+  scroll?: boolean;
 }
 
-function DialogBody({ children, className }: DialogBodyProps) {
-  const { descriptionId } = useDialogContext();
+function DialogBody({ children, className, padding = 'default', scroll = true }: DialogBodyProps) {
+  const { descriptionId, registerDescription } = useDialogContext();
+
+  useEffect(() => registerDescription(), [registerDescription]);
 
   return (
-    <div id={descriptionId} className={cn(bodyVariants(), className)}>
+    <div id={descriptionId} className={cn(bodyVariants({ padding, scroll }), className)}>
       {children}
     </div>
   );
+}
+
+// Dialog Split / Sidebar / Pane
+
+export interface DialogSplitProps {
+  /**
+   * Two-column content, typically a Dialog.Sidebar followed by Dialog.Pane(s).
+   * Stacks vertically below the MD breakpoint.
+   */
+  children: ReactNode;
+  className?: string;
+}
+
+function DialogSplit({ children, className }: DialogSplitProps) {
+  return <div className={cn(splitVariants(), className)}>{children}</div>;
+}
+
+export interface DialogSidebarProps {
+  children: ReactNode;
+  className?: string;
+
+  /**
+   * Rail width.
+   * @default 'md'
+   */
+  width?: 'sm' | 'md';
+}
+
+function DialogSidebar({ children, className, width = 'md' }: DialogSidebarProps) {
+  return <div className={cn(sidebarVariants({ width }), className)}>{children}</div>;
+}
+
+export interface DialogPaneProps {
+  children: ReactNode;
+  className?: string;
+}
+
+function DialogPane({ children, className }: DialogPaneProps) {
+  return <div className={cn(paneVariants(), className)}>{children}</div>;
 }
 
 // Dialog Footer
@@ -386,10 +787,38 @@ function DialogBody({ children, className }: DialogBodyProps) {
 export interface DialogFooterProps {
   children: ReactNode;
   className?: string;
+
+  /**
+   * Horizontal alignment of the footer actions.
+   * @default 'end'
+   */
+  justify?: 'end' | 'between';
+
+  /**
+   * Renders a top border above the footer.
+   * @default false
+   */
+  bordered?: boolean;
+
+  /**
+   * Leading slot pushed to the start (e.g. a warning line or legal links).
+   */
+  leading?: ReactNode;
 }
 
-function DialogFooter({ children, className }: DialogFooterProps) {
-  return <div className={cn(footerVariants(), className)}>{children}</div>;
+function DialogFooter({
+  children,
+  className,
+  justify = 'end',
+  bordered = false,
+  leading,
+}: DialogFooterProps) {
+  return (
+    <div className={cn(footerVariants({ justify, bordered }), className)}>
+      {leading && <div className="mr-auto flex items-center gap-3">{leading}</div>}
+      {children}
+    </div>
+  );
 }
 
 // Compound Component Export
@@ -397,7 +826,11 @@ function DialogFooter({ children, className }: DialogFooterProps) {
 export const Dialog = {
   Root: DialogRoot,
   Header: DialogHeader,
+  SubHeader: DialogSubHeader,
   Body: DialogBody,
+  Split: DialogSplit,
+  Sidebar: DialogSidebar,
+  Pane: DialogPane,
   Footer: DialogFooter,
 };
 
@@ -438,6 +871,23 @@ export interface ConfirmDialogProps {
   destructive?: boolean;
 
   /**
+   * Async-in-flight state: spinner on the confirm button, both buttons and
+   * all dismissal paths disabled.
+   * @default false
+   */
+  busy?: boolean;
+
+  /**
+   * Error line rendered below the message.
+   */
+  error?: string;
+
+  /**
+   * Decorative icon rendered in a tinted circle next to the title.
+   */
+  icon?: ReactNode;
+
+  /**
    * Called when the user confirms.
    */
   onConfirm: () => void;
@@ -461,6 +911,18 @@ export interface ConfirmDialogProps {
  *   onConfirm={handleDelete}
  *   onCancel={() => setShowDelete(false)}
  * />
+ *
+ * @example
+ * <ConfirmDialog
+ *   isOpen={open}
+ *   title="Convert layout"
+ *   message="Bins will be remapped to the half-grid."
+ *   icon={<GridIcon size="md" />}
+ *   busy={isRemediating}
+ *   error={remediationError}
+ *   onConfirm={remediate}
+ *   onCancel={close}
+ * />
  */
 export function ConfirmDialog({
   isOpen,
@@ -469,20 +931,43 @@ export function ConfirmDialog({
   confirmText = 'Confirm',
   cancelText = 'Cancel',
   destructive = false,
+  busy = false,
+  error,
+  icon,
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
   return (
-    <DialogRoot open={isOpen} onClose={onCancel} size="md">
-      <DialogHeader title={title} />
+    <DialogRoot open={isOpen} onClose={onCancel} size="md" dismissable={!busy}>
+      <DialogHeader
+        title={title}
+        leading={
+          icon ? (
+            <div
+              aria-hidden="true"
+              className={cn(
+                'flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full',
+                destructive ? intentBackgrounds.error : intentBackgrounds.warning
+              )}
+            >
+              {icon}
+            </div>
+          ) : undefined
+        }
+      />
       <DialogBody>
         <p className="text-sm text-content-secondary">{message}</p>
+        {error && (
+          <Alert intent="error" className="mt-3">
+            {error}
+          </Alert>
+        )}
       </DialogBody>
       <DialogFooter>
-        <Button variant="ghost" onClick={onCancel}>
+        <Button variant="ghost" onClick={onCancel} disabled={busy}>
           {cancelText}
         </Button>
-        <Button variant={destructive ? 'danger' : 'primary'} onClick={onConfirm}>
+        <Button variant={destructive ? 'danger' : 'primary'} onClick={onConfirm} loading={busy}>
           {confirmText}
         </Button>
       </DialogFooter>

--- a/src/design-system/Dialog/index.ts
+++ b/src/design-system/Dialog/index.ts
@@ -1,8 +1,22 @@
-export { Dialog, ConfirmDialog } from './Dialog';
+export {
+  Dialog,
+  ConfirmDialog,
+  useFocusTrap,
+  useBodyScrollLock,
+  useDialogStack,
+  registerDialog,
+  unregisterDialog,
+  isTopmostDialog,
+} from './Dialog';
 export type {
   DialogProps,
   DialogHeaderProps,
+  DialogSubHeaderProps,
   DialogBodyProps,
+  DialogSplitProps,
+  DialogSidebarProps,
+  DialogPaneProps,
   DialogFooterProps,
+  DialogInitialFocus,
   ConfirmDialogProps,
 } from './Dialog';

--- a/src/design-system/EmptyState/EmptyState.test.tsx
+++ b/src/design-system/EmptyState/EmptyState.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { createRef } from 'react';
+import { EmptyState } from './EmptyState';
+
+describe('EmptyState', () => {
+  describe('rendering', () => {
+    it('renders the title', () => {
+      render(<EmptyState title="No layouts yet" />);
+      expect(screen.getByText('No layouts yet')).toBeInTheDocument();
+    });
+
+    it('renders the description when provided', () => {
+      render(<EmptyState title="No layouts yet" description="Create one to get started" />);
+      expect(screen.getByText('Create one to get started')).toBeInTheDocument();
+    });
+
+    it('does not render an icon container when icon is omitted', () => {
+      render(<EmptyState title="No results" />);
+      expect(screen.queryByTestId('empty-state-icon')).not.toBeInTheDocument();
+    });
+
+    it('renders the icon inside an aria-hidden container', () => {
+      render(<EmptyState title="No results" icon={<svg data-testid="my-icon" />} />);
+      const container = screen.getByTestId('empty-state-icon');
+      expect(container).toHaveAttribute('aria-hidden', 'true');
+      expect(screen.getByTestId('my-icon')).toBeInTheDocument();
+    });
+
+    it('renders the detail slot', () => {
+      render(<EmptyState title="Crashed" detail={<pre>stack trace</pre>} />);
+      expect(screen.getByText('stack trace')).toBeInTheDocument();
+    });
+
+    it('applies className to the container', () => {
+      render(<EmptyState title="No results" className="custom-class" data-testid="empty" />);
+      expect(screen.getByTestId('empty')).toHaveClass('custom-class');
+    });
+  });
+
+  describe('icon styles', () => {
+    it('renders a faded icon without a tinted container for bare style', () => {
+      render(<EmptyState title="No results" icon={<svg />} />);
+      const container = screen.getByTestId('empty-state-icon');
+      expect(container.className).toContain('opacity-50');
+      expect(container.className).not.toContain('bg-surface-elevated');
+    });
+
+    it('renders a rounded square with elevated background for tile style', () => {
+      render(<EmptyState title="No results" icon={<svg />} iconStyle="tile" />);
+      const container = screen.getByTestId('empty-state-icon');
+      expect(container.className).toContain('rounded-xl');
+      expect(container.className).toContain('bg-surface-elevated');
+    });
+
+    it('renders a rounded circle for circle style', () => {
+      render(<EmptyState title="No results" icon={<svg />} iconStyle="circle" />);
+      const container = screen.getByTestId('empty-state-icon');
+      expect(container.className).toContain('rounded-full');
+      expect(container.className).toContain('bg-surface-elevated');
+    });
+  });
+
+  describe('tint', () => {
+    it('applies error tint classes to the icon container', () => {
+      render(<EmptyState title="Crashed" icon={<svg />} iconStyle="circle" tint="error" />);
+      const container = screen.getByTestId('empty-state-icon');
+      expect(container.className).toContain('bg-error-muted');
+      expect(container.className).toContain('text-error');
+    });
+
+    it('applies warning tint classes to the icon container', () => {
+      render(<EmptyState title="Blocked" icon={<svg />} iconStyle="circle" tint="warning" />);
+      const container = screen.getByTestId('empty-state-icon');
+      expect(container.className).toContain('bg-warning-muted');
+      expect(container.className).toContain('text-warning');
+    });
+
+    it('sets role alert when tint is error', () => {
+      render(<EmptyState title="Crashed" tint="error" />);
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('does not set role alert for neutral tint', () => {
+      render(<EmptyState title="No results" />);
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('does not set role alert for warning tint', () => {
+      render(<EmptyState title="Blocked" tint="warning" />);
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('size', () => {
+    it('uses panel spacing and a 12-unit icon at md', () => {
+      render(<EmptyState title="No results" icon={<svg />} data-testid="empty" />);
+      expect(screen.getByTestId('empty').className).toContain('py-8');
+      expect(screen.getByTestId('empty-state-icon').className).toContain('h-12');
+    });
+
+    it('uses full-screen spacing and a 16-unit circle at lg', () => {
+      render(
+        <EmptyState
+          title="Crashed"
+          icon={<svg />}
+          iconStyle="circle"
+          size="lg"
+          data-testid="empty"
+        />
+      );
+      expect(screen.getByTestId('empty').className).toContain('py-12');
+      const container = screen.getByTestId('empty-state-icon');
+      expect(container.className).toContain('h-16');
+      expect(container.className).toContain('w-16');
+    });
+
+    it('scales the title to text-base at lg', () => {
+      render(<EmptyState title="Crashed" size="lg" />);
+      expect(screen.getByText('Crashed').className).toContain('text-base');
+    });
+  });
+
+  describe('actions', () => {
+    it('renders actions and forwards clicks to the handler', () => {
+      const onClick = vi.fn();
+      render(
+        <EmptyState
+          title="No results"
+          actions={
+            <button type="button" onClick={onClick}>
+              Browse all
+            </button>
+          }
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Browse all' }));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders multiple actions in one row', () => {
+      render(
+        <EmptyState
+          title="Crashed"
+          actions={
+            <>
+              <button type="button">Try Again</button>
+              <button type="button">Reload</button>
+            </>
+          }
+        />
+      );
+      const buttons = screen.getAllByRole('button');
+      expect(buttons).toHaveLength(2);
+      expect(buttons[0].parentElement).toBe(buttons[1].parentElement);
+    });
+  });
+
+  describe('ref forwarding', () => {
+    it('forwards the ref to the container element', () => {
+      const ref = createRef<HTMLDivElement>();
+      render(<EmptyState ref={ref} title="No results" />);
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+  });
+});

--- a/src/design-system/EmptyState/EmptyState.tsx
+++ b/src/design-system/EmptyState/EmptyState.tsx
@@ -1,0 +1,223 @@
+import { forwardRef } from 'react';
+import type { ReactNode } from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '../cn';
+import { intentBackgrounds, intentText, sizeText } from '../variants';
+
+const containerVariants = cva(['flex flex-col items-center', 'text-center'], {
+  variants: {
+    size: {
+      md: ['gap-2', 'py-8'],
+      lg: ['gap-3', 'py-12'],
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+const iconVariants = cva(['flex items-center justify-center', 'shrink-0'], {
+  variants: {
+    iconStyle: {
+      bare: 'opacity-50',
+      tile: 'rounded-xl',
+      circle: 'rounded-full',
+    },
+    tint: {
+      neutral: '',
+      error: '',
+      warning: '',
+    },
+    size: {
+      md: 'h-12 w-12',
+      lg: '',
+    },
+  },
+  compoundVariants: [
+    { iconStyle: ['tile', 'circle'], tint: 'neutral', class: 'bg-surface-elevated' },
+    {
+      iconStyle: ['tile', 'circle'],
+      tint: 'error',
+      class: [intentBackgrounds.error, intentText.error],
+    },
+    {
+      iconStyle: ['tile', 'circle'],
+      tint: 'warning',
+      class: [intentBackgrounds.warning, intentText.warning],
+    },
+    { iconStyle: ['bare', 'tile'], size: 'lg', class: 'h-12 w-12' },
+    { iconStyle: 'circle', size: 'lg', class: 'h-16 w-16' },
+  ],
+  defaultVariants: {
+    iconStyle: 'bare',
+    tint: 'neutral',
+    size: 'md',
+  },
+});
+
+const titleVariants = cva(['font-medium text-content-secondary'], {
+  variants: {
+    size: {
+      md: sizeText.md,
+      lg: sizeText.lg,
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+const descriptionVariants = cva(['text-content-tertiary'], {
+  variants: {
+    size: {
+      md: 'text-xs',
+      lg: sizeText.md,
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+export interface EmptyStateProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
+  /**
+   * Icon node. Callers supply their own icon; there is no default.
+   */
+  icon?: ReactNode;
+
+  /**
+   * Visual treatment of the icon.
+   * - bare: faded icon with no container
+   * - tile: icon in a rounded square
+   * - circle: icon in a tinted circle
+   *
+   * @default 'bare'
+   */
+  iconStyle?: 'bare' | 'tile' | 'circle';
+
+  /**
+   * Circle/tile tint.
+   * - neutral: surface-elevated background
+   * - error: error-muted background, error text (sets role="alert")
+   * - warning: warning-muted background, warning text
+   *
+   * @default 'neutral'
+   */
+  tint?: 'neutral' | 'error' | 'warning';
+
+  /**
+   * Primary message.
+   */
+  title: string;
+
+  /**
+   * Secondary hint line.
+   */
+  description?: string;
+
+  /**
+   * CTA slot — callers compose existing Buttons or link-buttons,
+   * rendered in a centered gap row.
+   */
+  actions?: ReactNode;
+
+  /**
+   * Extra detail slot below actions (e.g. an error `<pre>` block).
+   */
+  detail?: ReactNode;
+
+  /**
+   * Overall scale.
+   * - md: panel empty states
+   * - lg: full-screen empty states (larger circle and type)
+   *
+   * @default 'md'
+   */
+  size?: 'md' | 'lg';
+}
+
+/**
+ * Centered icon + heading + secondary message + optional CTA for
+ * no-data panels, empty search results, and error boundaries.
+ *
+ * @example
+ * // No-data panel with CTA
+ * <EmptyState
+ *   icon={<LayoutListIcon />}
+ *   title="No layouts yet"
+ *   description="Create your first layout to get started"
+ *   actions={<Button variant="primary">New Layout</Button>}
+ * />
+ *
+ * @example
+ * // No search results (text-only)
+ * <EmptyState title="No results" description="Try a different search" />
+ *
+ * @example
+ * // Dialog list empty with tiled icon
+ * <EmptyState iconStyle="tile" icon={<SearchIcon />} title="No designs found" />
+ *
+ * @example
+ * // Full-screen error boundary
+ * <EmptyState
+ *   size="lg"
+ *   iconStyle="circle"
+ *   tint="error"
+ *   icon={<AlertTriangleIcon />}
+ *   title="Something went wrong"
+ *   description="The layout failed to render"
+ *   actions={
+ *     <>
+ *       <Button variant="primary" onClick={retry}>Try Again</Button>
+ *       <Button onClick={reload}>Reload</Button>
+ *     </>
+ *   }
+ *   detail={<pre>{error.message}</pre>}
+ * />
+ */
+export const EmptyState = forwardRef<HTMLDivElement, EmptyStateProps>(
+  (
+    {
+      icon,
+      iconStyle,
+      tint = 'neutral',
+      title,
+      description,
+      actions,
+      detail,
+      size,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <div
+        ref={ref}
+        role={tint === 'error' ? 'alert' : undefined}
+        className={cn(containerVariants({ size }), className)}
+        {...props}
+      >
+        {icon !== undefined && icon !== null && (
+          <div
+            aria-hidden="true"
+            data-testid="empty-state-icon"
+            className={cn(iconVariants({ iconStyle, tint, size }))}
+          >
+            {icon}
+          </div>
+        )}
+        <p className={cn(titleVariants({ size }))}>{title}</p>
+        {description !== undefined && (
+          <p className={cn(descriptionVariants({ size }))}>{description}</p>
+        )}
+        {actions !== undefined && actions !== null && (
+          <div className="flex flex-wrap items-center justify-center gap-2">{actions}</div>
+        )}
+        {detail}
+      </div>
+    );
+  }
+);
+
+EmptyState.displayName = 'EmptyState';

--- a/src/design-system/EmptyState/index.ts
+++ b/src/design-system/EmptyState/index.ts
@@ -1,0 +1,2 @@
+export { EmptyState } from './EmptyState';
+export type { EmptyStateProps } from './EmptyState';

--- a/src/design-system/Field/Field.test.tsx
+++ b/src/design-system/Field/Field.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Field } from './Field';
+
+describe('Field', () => {
+  describe('rendering', () => {
+    it('renders the label and children', () => {
+      render(
+        <Field label="Width">
+          <input aria-label="Width value" />
+        </Field>
+      );
+      expect(screen.getByText('Width')).toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    it('applies className to the wrapper', () => {
+      const { container } = render(
+        <Field label="Width" className="custom-class">
+          <input />
+        </Field>
+      );
+      expect(container.firstElementChild).toHaveClass('custom-class');
+    });
+
+    it('forwards ref to the wrapper element', () => {
+      const ref = vi.fn();
+      render(
+        <Field label="Width" ref={ref}>
+          <input />
+        </Field>
+      );
+      expect(ref).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+    });
+  });
+
+  describe('label element', () => {
+    it('renders a <label> associated with the control when htmlFor is given', () => {
+      render(
+        <Field label="Pattern" htmlFor="pattern-select">
+          <select id="pattern-select">
+            <option>Hex</option>
+          </select>
+        </Field>
+      );
+      const caption = screen.getByText('Pattern');
+      expect(caption.tagName).toBe('LABEL');
+      expect(caption).toHaveAttribute('for', 'pattern-select');
+      expect(screen.getByLabelText('Pattern')).toBe(screen.getByRole('combobox'));
+    });
+
+    it('renders a <span> caption when htmlFor is omitted', () => {
+      const { container } = render(
+        <Field label="Divider height">
+          <div role="group" aria-label="Divider height" />
+        </Field>
+      );
+      expect(screen.getByText('Divider height').tagName).toBe('SPAN');
+      expect(container.querySelector('label')).toBeNull();
+    });
+  });
+
+  describe('trailing slot', () => {
+    it('renders trailing content in the caption row', () => {
+      render(
+        <Field label="Width" trailing={<span>42mm</span>}>
+          <input />
+        </Field>
+      );
+      const trailing = screen.getByText('42mm');
+      expect(trailing).toBeInTheDocument();
+      expect(trailing.parentElement).toBe(screen.getByText('Width').parentElement);
+    });
+  });
+
+  describe('hint and error', () => {
+    it('renders the hint below the control', () => {
+      render(
+        <Field label="Size" hint="≥ 40mm (+2mm)">
+          <input />
+        </Field>
+      );
+      const hint = screen.getByText('≥ 40mm (+2mm)');
+      expect(hint).toBeInTheDocument();
+      expect(hint.className).toContain('text-content-tertiary');
+    });
+
+    it('renders the error with error styling', () => {
+      render(
+        <Field label="Name" error="Name is required">
+          <input />
+        </Field>
+      );
+      const error = screen.getByText('Name is required');
+      expect(error).toBeInTheDocument();
+      expect(error.className).toContain('text-error');
+    });
+
+    it('gives the error line an id derived from htmlFor for aria-describedby', () => {
+      render(
+        <Field label="Name" htmlFor="name-input" error="Name is required">
+          <input id="name-input" aria-describedby="name-input-error" />
+        </Field>
+      );
+      const error = screen.getByText('Name is required');
+      expect(error).toHaveAttribute('id', 'name-input-error');
+      expect(screen.getByRole('textbox')).toHaveAccessibleDescription('Name is required');
+    });
+
+    it('does not set an id on the error line without htmlFor', () => {
+      render(
+        <Field label="Name" error="Name is required">
+          <input />
+        </Field>
+      );
+      expect(screen.getByText('Name is required')).not.toHaveAttribute('id');
+    });
+
+    it('shows the error instead of the hint when both are set', () => {
+      render(
+        <Field label="Name" hint="Pick something short" error="Name is required">
+          <input />
+        </Field>
+      );
+      expect(screen.getByText('Name is required')).toBeInTheDocument();
+      expect(screen.queryByText('Pick something short')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('label tone', () => {
+    it('defaults to the tertiary caption tone', () => {
+      render(
+        <Field label="Width">
+          <input />
+        </Field>
+      );
+      const caption = screen.getByText('Width');
+      expect(caption.className).toContain('text-content-tertiary');
+      expect(caption.className).toContain('text-xs');
+      expect(caption.className).not.toContain('font-medium');
+    });
+
+    it('applies the secondary caption tone', () => {
+      render(
+        <Field label="Width" labelTone="secondary">
+          <input />
+        </Field>
+      );
+      const caption = screen.getByText('Width');
+      expect(caption.className).toContain('text-content-secondary');
+      expect(caption.className).toContain('font-medium');
+    });
+  });
+});

--- a/src/design-system/Field/Field.tsx
+++ b/src/design-system/Field/Field.tsx
@@ -1,0 +1,124 @@
+import { forwardRef } from 'react';
+import type { ReactNode } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../cn';
+import { sizeText } from '../variants';
+
+const fieldLabelVariants = cva(sizeText.sm, {
+  variants: {
+    tone: {
+      tertiary: 'text-content-tertiary',
+      secondary: ['text-content-secondary', 'font-medium'],
+    },
+  },
+  defaultVariants: {
+    tone: 'tertiary',
+  },
+});
+
+type FieldLabelVariantProps = VariantProps<typeof fieldLabelVariants>;
+
+export interface FieldProps {
+  /**
+   * Caption text.
+   */
+  label: string;
+
+  /**
+   * When the child is a real input/select/textarea, renders `<label htmlFor>`;
+   * otherwise a `<span>` caption (segment groups, steppers — non-labelable composites).
+   */
+  htmlFor?: string;
+
+  /**
+   * Right-aligned readout in the caption row (live value + unit, e.g. "42mm").
+   */
+  trailing?: ReactNode;
+
+  /**
+   * Help/fit note below the control.
+   */
+  hint?: ReactNode;
+
+  /**
+   * Error note below the control. When `htmlFor` is given, the error line
+   * gets id `${htmlFor}-error` for aria-describedby wiring on the control.
+   */
+  error?: string;
+
+  /**
+   * Caption emphasis.
+   * @default 'tertiary'
+   */
+  labelTone?: NonNullable<FieldLabelVariantProps['tone']>;
+
+  children: ReactNode;
+
+  /**
+   * Additional classes for the wrapper element.
+   */
+  className?: string;
+}
+
+/**
+ * Caption-above-control field wrapper: label row (with optional trailing
+ * readout), the control, and an optional hint or error line below.
+ *
+ * @example
+ * <Field label="Width">
+ *   <StepperControl value={width} onChange={setWidth} />
+ * </Field>
+ *
+ * @example
+ * // Labelable control with native association
+ * <Field label="Pattern" htmlFor="pattern-select">
+ *   <Select id="pattern-select" options={patterns} value={pattern} onChange={setPattern} />
+ * </Field>
+ *
+ * @example
+ * // Live value readout + fit note
+ * <Field label="Compartment size" trailing="42mm" hint="≥ 40mm (+2mm)">
+ *   <Slider value={size} onChange={setSize} aria-label="Compartment size" />
+ * </Field>
+ *
+ * @example
+ * // Error wiring
+ * <Field label="Name" htmlFor="name-input" error="Name is required">
+ *   <Input id="name-input" aria-describedby="name-input-error" />
+ * </Field>
+ */
+export const Field = forwardRef<HTMLDivElement, FieldProps>(
+  ({ label, htmlFor, trailing, hint, error, labelTone = 'tertiary', children, className }, ref) => {
+    const labelClassName = fieldLabelVariants({ tone: labelTone });
+    const errorId = htmlFor ? `${htmlFor}-error` : undefined;
+
+    return (
+      <div ref={ref} className={className}>
+        <div className={cn('flex items-center justify-between', 'mb-1')}>
+          {htmlFor ? (
+            <label htmlFor={htmlFor} className={labelClassName}>
+              {label}
+            </label>
+          ) : (
+            <span className={labelClassName}>{label}</span>
+          )}
+          {trailing}
+        </div>
+
+        {children}
+
+        {hint !== undefined && hint !== null && !error && (
+          <div className={cn('mt-1', sizeText.sm, 'text-content-tertiary')}>{hint}</div>
+        )}
+
+        {error && (
+          <div id={errorId} className={cn('mt-1', sizeText.sm, 'text-error')}>
+            {error}
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+Field.displayName = 'Field';

--- a/src/design-system/Field/index.ts
+++ b/src/design-system/Field/index.ts
@@ -1,0 +1,2 @@
+export { Field } from './Field';
+export type { FieldProps } from './Field';

--- a/src/design-system/IconButton/IconButton.test.tsx
+++ b/src/design-system/IconButton/IconButton.test.tsx
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IconButton } from './IconButton';
+
+const TestIcon = (): React.ReactElement => (
+  <svg data-testid="test-icon" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M6 6l12 12" />
+  </svg>
+);
+
+describe('IconButton', () => {
+  describe('rendering', () => {
+    it('renders a button with the aria-label as its accessible name', () => {
+      render(
+        <IconButton aria-label="Close dialog">
+          <TestIcon />
+        </IconButton>
+      );
+      expect(screen.getByRole('button', { name: 'Close dialog' })).toBeInTheDocument();
+    });
+
+    it('renders the icon children', () => {
+      render(
+        <IconButton aria-label="Close dialog">
+          <TestIcon />
+        </IconButton>
+      );
+      expect(screen.getByTestId('test-icon')).toBeInTheDocument();
+    });
+
+    it('defaults to the ghost variant', () => {
+      render(
+        <IconButton aria-label="Undo">
+          <TestIcon />
+        </IconButton>
+      );
+      expect(screen.getByRole('button').className).toContain('bg-transparent');
+    });
+
+    it('applies secondary variant styling', () => {
+      render(
+        <IconButton aria-label="Swap dimensions" variant="secondary">
+          <TestIcon />
+        </IconButton>
+      );
+      expect(screen.getByRole('button').className).toContain('border-stroke');
+    });
+
+    it('applies dangerGhost hover classes on top of ghost styling', () => {
+      render(
+        <IconButton aria-label="Delete category" variant="dangerGhost">
+          <TestIcon />
+        </IconButton>
+      );
+      const button = screen.getByRole('button');
+      expect(button.className).toContain('bg-transparent');
+      expect(button.className).toContain('hover:text-error');
+      expect(button.className).toContain('hover:bg-error-muted');
+    });
+
+    it('defaults to md size width', () => {
+      render(
+        <IconButton aria-label="Close dialog">
+          <TestIcon />
+        </IconButton>
+      );
+      expect(screen.getByRole('button').className).toContain('w-9');
+    });
+
+    it('applies sm and lg size widths', () => {
+      const { rerender } = render(
+        <IconButton aria-label="Remove tag" size="sm">
+          <TestIcon />
+        </IconButton>
+      );
+      expect(screen.getByRole('button').className).toContain('w-6');
+
+      rerender(
+        <IconButton aria-label="Remove tag" size="lg">
+          <TestIcon />
+        </IconButton>
+      );
+      expect(screen.getByRole('button').className).toContain('w-12');
+    });
+
+    it('enforces the touch target by default and removes it when touchTarget is false', () => {
+      const { rerender } = render(
+        <IconButton aria-label="Align left">
+          <TestIcon />
+        </IconButton>
+      );
+      expect(screen.getByRole('button').className).toContain('min-h-[44px]');
+
+      rerender(
+        <IconButton aria-label="Align left" touchTarget={false}>
+          <TestIcon />
+        </IconButton>
+      );
+      expect(screen.getByRole('button').className).not.toContain('min-h-[44px]');
+    });
+
+    it('merges a custom className', () => {
+      render(
+        <IconButton aria-label="Close dialog" className="custom-class">
+          <TestIcon />
+        </IconButton>
+      );
+      expect(screen.getByRole('button')).toHaveClass('custom-class');
+    });
+
+    it('passes native attributes like title through', () => {
+      render(
+        <IconButton aria-label="Undo" title="Undo (Ctrl+Z)">
+          <TestIcon />
+        </IconButton>
+      );
+      expect(screen.getByRole('button')).toHaveAttribute('title', 'Undo (Ctrl+Z)');
+    });
+  });
+
+  describe('pressed state', () => {
+    it('omits aria-pressed when the pressed prop is not provided', () => {
+      render(
+        <IconButton aria-label="Toggle grid">
+          <TestIcon />
+        </IconButton>
+      );
+      expect(screen.getByRole('button')).not.toHaveAttribute('aria-pressed');
+    });
+
+    it('sets aria-pressed and active styling when pressed is true', () => {
+      render(
+        <IconButton aria-label="Toggle grid" pressed>
+          <TestIcon />
+        </IconButton>
+      );
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute('aria-pressed', 'true');
+      expect(button.className).toContain('bg-surface-active');
+    });
+
+    it('sets aria-pressed false without active styling when pressed is false', () => {
+      render(
+        <IconButton aria-label="Toggle grid" pressed={false}>
+          <TestIcon />
+        </IconButton>
+      );
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute('aria-pressed', 'false');
+      expect(button.className).not.toContain('bg-surface-active');
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onClick when clicked', () => {
+      const onClick = vi.fn();
+      render(
+        <IconButton aria-label="Undo" onClick={onClick}>
+          <TestIcon />
+        </IconButton>
+      );
+      fireEvent.click(screen.getByRole('button'));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClick when disabled', () => {
+      const onClick = vi.fn();
+      render(
+        <IconButton aria-label="Undo" disabled onClick={onClick}>
+          <TestIcon />
+        </IconButton>
+      );
+      fireEvent.click(screen.getByRole('button'));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loading state', () => {
+    it('sets aria-busy and disables the button', () => {
+      render(
+        <IconButton aria-label="Refresh share" loading>
+          <TestIcon />
+        </IconButton>
+      );
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute('aria-busy', 'true');
+      expect(button).toBeDisabled();
+    });
+
+    it('swaps the icon for a spinner', () => {
+      render(
+        <IconButton aria-label="Refresh share" loading>
+          <TestIcon />
+        </IconButton>
+      );
+      expect(screen.getByRole('status')).toBeInTheDocument();
+      expect(screen.queryByTestId('test-icon')).not.toBeInTheDocument();
+    });
+
+    it('does not call onClick while loading', () => {
+      const onClick = vi.fn();
+      render(
+        <IconButton aria-label="Refresh share" loading onClick={onClick}>
+          <TestIcon />
+        </IconButton>
+      );
+      fireEvent.click(screen.getByRole('button'));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ref forwarding', () => {
+    it('forwards the ref to the underlying button element', () => {
+      const ref = vi.fn();
+      render(
+        <IconButton aria-label="Close dialog" ref={ref}>
+          <TestIcon />
+        </IconButton>
+      );
+      expect(ref).toHaveBeenCalledWith(expect.any(HTMLButtonElement));
+    });
+  });
+});

--- a/src/design-system/IconButton/IconButton.tsx
+++ b/src/design-system/IconButton/IconButton.tsx
@@ -1,0 +1,124 @@
+import { forwardRef, type ReactNode } from 'react';
+import { cn } from '../cn';
+import { Button } from '../Button';
+import { Spinner } from '../Spinner';
+
+export interface IconButtonProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  'children' | 'aria-label'
+> {
+  /**
+   * Accessible name for the control. Required because the visible
+   * content is an icon with no text.
+   */
+  'aria-label': string;
+
+  /**
+   * The icon to display — an Icon primitive or inline svg.
+   */
+  children: ReactNode;
+
+  /**
+   * Visual style.
+   * - ghost: transparent until hovered
+   * - secondary: bordered/elevated
+   * - dangerGhost: ghost that turns destructive red on hover
+   * @default 'ghost'
+   */
+  variant?: 'ghost' | 'secondary' | 'dangerGhost';
+
+  /**
+   * Control size: sm (w-6), md (w-9), lg (w-12).
+   * @default 'md'
+   */
+  size?: 'sm' | 'md' | 'lg';
+
+  /**
+   * Toggle state. Emits `aria-pressed` and applies active styling when true.
+   * Omit entirely for non-toggle buttons (no `aria-pressed` attribute).
+   */
+  pressed?: boolean;
+
+  /**
+   * Swaps the icon for a Spinner, disables interaction, and sets `aria-busy`.
+   */
+  loading?: boolean;
+
+  /**
+   * Enforce 44px minimum touch target (Apple HIG).
+   * Defaults to `true`; dense desktop toolbars pass `false`.
+   */
+  touchTarget?: boolean;
+}
+
+/**
+ * Icon-only button for toolbars, panel headers, and inline actions.
+ *
+ * @example
+ * // Dialog close button
+ * <IconButton aria-label="Close dialog">
+ *   <XIcon />
+ * </IconButton>
+ *
+ * @example
+ * // Destructive hover treatment for delete actions
+ * <IconButton aria-label="Delete category" variant="dangerGhost">
+ *   <TrashIcon />
+ * </IconButton>
+ *
+ * @example
+ * // Dense desktop toolbar toggle
+ * <IconButton
+ *   aria-label="Align left"
+ *   size="sm"
+ *   touchTarget={false}
+ *   pressed={alignment === 'left'}
+ * >
+ *   <AlignLeftIcon />
+ * </IconButton>
+ *
+ * @example
+ * // Async action in progress
+ * <IconButton aria-label="Refresh share" loading={isRefreshing}>
+ *   <RefreshIcon />
+ * </IconButton>
+ */
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  (
+    {
+      variant = 'ghost',
+      size = 'md',
+      pressed,
+      loading,
+      touchTarget,
+      className,
+      children,
+      disabled,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <Button
+        ref={ref}
+        iconOnly
+        size={size}
+        variant={variant === 'dangerGhost' ? 'ghost' : variant}
+        touchTarget={touchTarget}
+        disabled={disabled || loading}
+        aria-busy={loading || undefined}
+        aria-pressed={pressed}
+        className={cn(
+          variant === 'dangerGhost' && 'hover:text-error hover:bg-error-muted',
+          pressed && 'bg-surface-active text-content',
+          className
+        )}
+        {...props}
+      >
+        {loading ? <Spinner size="sm" /> : children}
+      </Button>
+    );
+  }
+);
+
+IconButton.displayName = 'IconButton';

--- a/src/design-system/IconButton/index.ts
+++ b/src/design-system/IconButton/index.ts
@@ -1,0 +1,2 @@
+export { IconButton } from './IconButton';
+export type { IconButtonProps } from './IconButton';

--- a/src/design-system/InlineEditText/InlineEditText.test.tsx
+++ b/src/design-system/InlineEditText/InlineEditText.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InlineEditText } from './InlineEditText';
+
+const defaultProps = {
+  value: 'My Layout',
+  onCommit: vi.fn(),
+  'aria-label': 'Rename layout',
+};
+
+describe('InlineEditText', () => {
+  it('renders the value in a display button with title', () => {
+    render(<InlineEditText {...defaultProps} onCommit={vi.fn()} />);
+    const button = screen.getByRole('button', { name: 'Rename layout' });
+    expect(button).toHaveTextContent('My Layout');
+    expect(button).toHaveAttribute('title', 'My Layout');
+  });
+
+  it('enters edit mode on click with the input focused and selected', () => {
+    render(<InlineEditText {...defaultProps} onCommit={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename layout' }));
+    const input = screen.getByRole('textbox', { name: 'Rename layout' });
+    expect(input).toHaveValue('My Layout');
+    expect(input).toHaveFocus();
+    expect((input as HTMLInputElement).selectionStart).toBe(0);
+    expect((input as HTMLInputElement).selectionEnd).toBe('My Layout'.length);
+  });
+
+  it('commits the trimmed value on Enter', () => {
+    const onCommit = vi.fn();
+    render(<InlineEditText {...defaultProps} onCommit={onCommit} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename layout' }));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '  Renamed  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommit).toHaveBeenCalledWith('Renamed');
+    expect(screen.getByRole('button', { name: 'Rename layout' })).toBeInTheDocument();
+  });
+
+  it('commits on blur', () => {
+    const onCommit = vi.fn();
+    render(<InlineEditText {...defaultProps} onCommit={onCommit} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename layout' }));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Blurred' } });
+    fireEvent.blur(input);
+    expect(onCommit).toHaveBeenCalledWith('Blurred');
+    expect(screen.getByRole('button', { name: 'Rename layout' })).toBeInTheDocument();
+  });
+
+  it('reverts on Escape without calling onCommit', () => {
+    const onCommit = vi.fn();
+    render(<InlineEditText {...defaultProps} onCommit={onCommit} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename layout' }));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Discarded' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Rename layout' })).toHaveTextContent('My Layout');
+  });
+
+  it('commits the fallback when the trimmed input is empty', () => {
+    const onCommit = vi.fn();
+    render(<InlineEditText {...defaultProps} onCommit={onCommit} fallback="Untitled layout" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename layout' }));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommit).toHaveBeenCalledWith('Untitled layout');
+  });
+
+  it('reverts to the current value when empty and no fallback is provided', () => {
+    const onCommit = vi.fn();
+    render(<InlineEditText {...defaultProps} onCommit={onCommit} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename layout' }));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Rename layout' })).toHaveTextContent('My Layout');
+  });
+
+  it('does not call onCommit when the value is unchanged', () => {
+    const onCommit = vi.fn();
+    render(<InlineEditText {...defaultProps} onCommit={onCommit} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename layout' }));
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('applies maxLength and placeholder to the input', () => {
+    render(
+      <InlineEditText {...defaultProps} onCommit={vi.fn()} maxLength={50} placeholder="Name" />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Rename layout' }));
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('maxlength', '50');
+    expect(input).toHaveAttribute('placeholder', 'Name');
+  });
+
+  it('enters edit mode on contextmenu when editOnContextMenu is set', () => {
+    render(<InlineEditText {...defaultProps} onCommit={vi.fn()} editOnContextMenu />);
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'Rename layout' }));
+    expect(screen.getByRole('textbox', { name: 'Rename layout' })).toBeInTheDocument();
+  });
+
+  it('ignores contextmenu by default', () => {
+    render(<InlineEditText {...defaultProps} onCommit={vi.fn()} />);
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'Rename layout' }));
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('returns focus to the display button after commit', () => {
+    render(<InlineEditText {...defaultProps} onCommit={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename layout' }));
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+    expect(screen.getByRole('button', { name: 'Rename layout' })).toHaveFocus();
+  });
+
+  it('returns focus to the display button after revert', () => {
+    render(<InlineEditText {...defaultProps} onCommit={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename layout' }));
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    expect(screen.getByRole('button', { name: 'Rename layout' })).toHaveFocus();
+  });
+
+  it('applies displayClassName and inputClassName', () => {
+    render(
+      <InlineEditText
+        {...defaultProps}
+        onCommit={vi.fn()}
+        displayClassName="max-w-[200px]"
+        inputClassName="w-full"
+      />
+    );
+    const button = screen.getByRole('button', { name: 'Rename layout' });
+    expect(button).toHaveClass('max-w-[200px]');
+    fireEvent.click(button);
+    expect(screen.getByRole('textbox')).toHaveClass('w-full');
+  });
+});

--- a/src/design-system/InlineEditText/InlineEditText.test.tsx
+++ b/src/design-system/InlineEditText/InlineEditText.test.tsx
@@ -59,6 +59,29 @@ describe('InlineEditText', () => {
     expect(screen.getByRole('button', { name: 'Rename layout' })).toHaveTextContent('My Layout');
   });
 
+  it('ignores the native blur browsers fire when Escape unmounts the input', () => {
+    const onCommit = vi.fn();
+    render(<InlineEditText {...defaultProps} onCommit={onCommit} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename layout' }));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Discarded' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    fireEvent.blur(input);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('commits again after a revert when editing is re-entered', () => {
+    const onCommit = vi.fn();
+    render(<InlineEditText {...defaultProps} onCommit={onCommit} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename layout' }));
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    fireEvent.click(screen.getByRole('button', { name: 'Rename layout' }));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Second try' } });
+    fireEvent.blur(input);
+    expect(onCommit).toHaveBeenCalledWith('Second try');
+  });
+
   it('commits the fallback when the trimmed input is empty', () => {
     const onCommit = vi.fn();
     render(<InlineEditText {...defaultProps} onCommit={onCommit} fallback="Untitled layout" />);

--- a/src/design-system/InlineEditText/InlineEditText.tsx
+++ b/src/design-system/InlineEditText/InlineEditText.tsx
@@ -94,6 +94,9 @@ export function InlineEditText({
   const inputRef = useRef<HTMLInputElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const restoreFocusRef = useRef(false);
+  // Browsers (not jsdom) fire a native blur when the focused input is removed
+  // from the DOM, so Escape-revert would otherwise commit the stale draft.
+  const revertedRef = useRef(false);
 
   useEffect(() => {
     if (isEditing) {
@@ -107,11 +110,13 @@ export function InlineEditText({
   }, [isEditing]);
 
   const enterEdit = (): void => {
+    revertedRef.current = false;
     setDraft(value);
     setIsEditing(true);
   };
 
   const commit = (): void => {
+    if (revertedRef.current) return;
     const next = draft.trim() || fallback || value;
     if (next !== value) {
       onCommit(next);
@@ -120,6 +125,7 @@ export function InlineEditText({
   };
 
   const revert = (): void => {
+    revertedRef.current = true;
     setDraft(value);
     setIsEditing(false);
   };

--- a/src/design-system/InlineEditText/InlineEditText.tsx
+++ b/src/design-system/InlineEditText/InlineEditText.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '../cn';
+import { activePress, focusRing, interactiveTransition } from '../variants';
+
+export interface InlineEditTextProps {
+  /**
+   * Current text value shown in display mode.
+   */
+  value: string;
+
+  /**
+   * Called with the trimmed committed value (or fallback when trim is empty).
+   * Not called when reverted via Escape or when the value is unchanged.
+   */
+  onCommit: (value: string) => void;
+
+  /**
+   * Committed when the trimmed input is empty.
+   * When omitted, an empty input reverts to the current value.
+   */
+  fallback?: string;
+
+  /**
+   * Maximum input length, applied natively to the edit input.
+   */
+  maxLength?: number;
+
+  /**
+   * Placeholder shown in the edit input.
+   */
+  placeholder?: string;
+
+  /**
+   * Accessible name for the display-mode edit button and the edit input,
+   * e.g. 'Rename layout'.
+   */
+  'aria-label': string;
+
+  /**
+   * Also enter edit mode on contextmenu (mobile long-press path).
+   * @default false
+   */
+  editOnContextMenu?: boolean;
+
+  /**
+   * Additional classes for the display-mode button.
+   */
+  displayClassName?: string;
+
+  /**
+   * Additional classes for the edit-mode input.
+   */
+  inputClassName?: string;
+}
+
+/**
+ * Click-to-edit text for renaming items inline (layout names, category names).
+ * Displays a button until clicked, then swaps to a focused, selected input.
+ * Enter or blur commits, Escape reverts; focus returns to the button afterwards.
+ *
+ * @example
+ * <InlineEditText
+ *   value={layout.name}
+ *   onCommit={setName}
+ *   fallback="Untitled layout"
+ *   maxLength={CONSTRAINTS.NAME_MAX_LENGTH}
+ *   aria-label={t('header.editLayoutName')}
+ * />
+ *
+ * @example
+ * // Mobile long-press entry, custom sizing per surface
+ * <InlineEditText
+ *   value={category.name}
+ *   onCommit={renameCategory}
+ *   editOnContextMenu
+ *   displayClassName="w-full text-center"
+ *   inputClassName="w-full text-center"
+ *   aria-label={t('mobile.categories.renameCategory')}
+ * />
+ */
+export function InlineEditText({
+  value,
+  onCommit,
+  fallback,
+  maxLength,
+  placeholder,
+  'aria-label': ariaLabel,
+  editOnContextMenu = false,
+  displayClassName,
+  inputClassName,
+}: InlineEditTextProps): React.JSX.Element {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const restoreFocusRef = useRef(false);
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+      restoreFocusRef.current = true;
+    } else if (restoreFocusRef.current) {
+      restoreFocusRef.current = false;
+      buttonRef.current?.focus();
+    }
+  }, [isEditing]);
+
+  const enterEdit = (): void => {
+    setDraft(value);
+    setIsEditing(true);
+  };
+
+  const commit = (): void => {
+    const next = draft.trim() || fallback || value;
+    if (next !== value) {
+      onCommit(next);
+    }
+    setIsEditing(false);
+  };
+
+  const revert = (): void => {
+    setDraft(value);
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'Enter') {
+      commit();
+    } else if (e.key === 'Escape') {
+      revert();
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <input
+        ref={inputRef}
+        type="text"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={handleKeyDown}
+        maxLength={maxLength}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        className={cn(
+          'px-3 py-1.5 rounded-md text-sm',
+          interactiveTransition,
+          'bg-surface-elevated border border-accent text-content',
+          'outline-none [box-shadow:0_0_0_3px_var(--color-primary-muted)]',
+          'placeholder:text-content-tertiary',
+          inputClassName
+        )}
+      />
+    );
+  }
+
+  return (
+    <button
+      ref={buttonRef}
+      type="button"
+      onClick={enterEdit}
+      onContextMenu={
+        editOnContextMenu
+          ? (e) => {
+              e.preventDefault();
+              enterEdit();
+            }
+          : undefined
+      }
+      title={value}
+      aria-label={ariaLabel}
+      className={cn(
+        'px-3 py-1.5 text-sm rounded-md truncate',
+        interactiveTransition,
+        activePress,
+        ...focusRing,
+        'text-content-secondary bg-transparent',
+        'hover:bg-surface-hover hover:text-content hover:scale-[1.02]',
+        displayClassName
+      )}
+    >
+      {value}
+    </button>
+  );
+}

--- a/src/design-system/InlineEditText/index.ts
+++ b/src/design-system/InlineEditText/index.ts
@@ -1,0 +1,2 @@
+export { InlineEditText } from './InlineEditText';
+export type { InlineEditTextProps } from './InlineEditText';

--- a/src/design-system/Kbd/Kbd.test.tsx
+++ b/src/design-system/Kbd/Kbd.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { createRef } from 'react';
+import { Kbd } from './Kbd';
+
+describe('Kbd', () => {
+  it('renders a semantic kbd element with its children', () => {
+    render(<Kbd>Enter</Kbd>);
+    const kbd = screen.getByText('Enter');
+    expect(kbd.tagName).toBe('KBD');
+  });
+
+  it('defaults to the neutral tone', () => {
+    render(<Kbd>Esc</Kbd>);
+    const kbd = screen.getByText('Esc');
+    expect(kbd).toHaveClass('bg-surface', 'border-stroke-subtle', 'text-content-secondary');
+    expect(kbd).toHaveClass('font-mono');
+  });
+
+  it('applies info tone classes', () => {
+    render(<Kbd tone="info">⌘Z</Kbd>);
+    const kbd = screen.getByText('⌘Z');
+    expect(kbd).toHaveClass('bg-info/20', 'border-info/30', 'text-info');
+    expect(kbd).not.toHaveClass('font-mono');
+  });
+
+  it('keeps base chip classes on every tone', () => {
+    render(<Kbd tone="info">Shift</Kbd>);
+    const kbd = screen.getByText('Shift');
+    expect(kbd).toHaveClass('inline-block', 'rounded', 'border', 'align-middle');
+  });
+
+  it('merges a custom className with tone classes', () => {
+    render(<Kbd className="custom-class">Tab</Kbd>);
+    const kbd = screen.getByText('Tab');
+    expect(kbd).toHaveClass('custom-class');
+    expect(kbd).toHaveClass('bg-surface');
+  });
+
+  it('forwards its ref to the kbd element', () => {
+    const ref = createRef<HTMLElement>();
+    render(<Kbd ref={ref}>Enter</Kbd>);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current?.tagName).toBe('KBD');
+  });
+
+  it('passes through native HTML attributes and handlers', () => {
+    const onClick = vi.fn();
+    render(
+      <Kbd title="Keyboard shortcut" onClick={onClick}>
+        K
+      </Kbd>
+    );
+    const kbd = screen.getByText('K');
+    expect(kbd).toHaveAttribute('title', 'Keyboard shortcut');
+    fireEvent.click(kbd);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/design-system/Kbd/Kbd.tsx
+++ b/src/design-system/Kbd/Kbd.tsx
@@ -1,0 +1,64 @@
+import { forwardRef } from 'react';
+import { cva } from 'class-variance-authority';
+import type { ReactNode } from 'react';
+import { cn } from '../cn';
+import { intentText } from '../variants';
+
+const kbdVariants = cva(
+  ['inline-block', 'px-1.5 py-0.5', 'rounded border', 'text-[10px] leading-none', 'align-middle'],
+  {
+    variants: {
+      tone: {
+        neutral: ['bg-surface', 'border-stroke-subtle', 'text-content-secondary', 'font-mono'],
+        info: ['bg-info/20', 'border-info/30', intentText.info],
+      },
+    },
+    defaultVariants: {
+      tone: 'neutral',
+    },
+  }
+);
+
+export interface KbdProps extends React.HTMLAttributes<HTMLElement> {
+  /**
+   * Key text: 'Enter', 'Esc', '⌘Z', 'Shift'.
+   */
+  children: ReactNode;
+  /**
+   * Visual tone. `neutral` is a mono chip on surface background;
+   * `info` tints the chip for info-colored banners.
+   *
+   * @default 'neutral'
+   */
+  tone?: 'neutral' | 'info';
+}
+
+/**
+ * Keyboard-key chip rendered as a semantic `<kbd>` element.
+ *
+ * Key sequences are caller compositions of multiple chips plus separators.
+ *
+ * @example
+ * <Kbd>Enter</Kbd>
+ *
+ * @example
+ * // Inside an info banner
+ * <Kbd tone="info">Esc</Kbd>
+ *
+ * @example
+ * // Sequence
+ * <span>
+ *   <Kbd>Ctrl</Kbd> + <Kbd>K</Kbd>
+ * </span>
+ */
+export const Kbd = forwardRef<HTMLElement, KbdProps>(
+  ({ tone = 'neutral', className, children, ...props }, ref) => {
+    return (
+      <kbd ref={ref} className={cn(kbdVariants({ tone }), className)} {...props}>
+        {children}
+      </kbd>
+    );
+  }
+);
+
+Kbd.displayName = 'Kbd';

--- a/src/design-system/Kbd/index.ts
+++ b/src/design-system/Kbd/index.ts
@@ -1,0 +1,2 @@
+export { Kbd } from './Kbd';
+export type { KbdProps } from './Kbd';

--- a/src/design-system/NavRow/NavRow.test.tsx
+++ b/src/design-system/NavRow/NavRow.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { NavRow } from './NavRow';
+
+const defaultProps = {
+  icon: <svg data-testid="leading-icon" />,
+  title: 'Inspiration gallery',
+};
+
+describe('NavRow', () => {
+  describe('rendering', () => {
+    it('renders a button with the title as accessible name', () => {
+      render(<NavRow {...defaultProps} />);
+      expect(screen.getByRole('button', { name: 'Inspiration gallery' })).toBeInTheDocument();
+    });
+
+    it('renders the subtitle when provided', () => {
+      render(<NavRow {...defaultProps} subtitle="Get ideas for your drawer" />);
+      expect(screen.getByText('Get ideas for your drawer')).toBeInTheDocument();
+    });
+
+    it('does not render a subtitle element when omitted', () => {
+      render(<NavRow {...defaultProps} />);
+      expect(screen.queryByText('Get ideas for your drawer')).not.toBeInTheDocument();
+    });
+
+    it('renders the leading icon inside an aria-hidden tile', () => {
+      render(<NavRow {...defaultProps} />);
+      const tile = screen.getByTestId('nav-row-icon-tile');
+      expect(tile).toHaveAttribute('aria-hidden', 'true');
+      expect(tile).toContainElement(screen.getByTestId('leading-icon'));
+      expect(tile.className).toContain('w-10');
+      expect(tile.className).toContain('h-10');
+    });
+
+    it('renders as type="button"', () => {
+      render(<NavRow {...defaultProps} />);
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+    });
+  });
+
+  describe('trailing chevron', () => {
+    it('renders the default aria-hidden chevron', () => {
+      render(<NavRow {...defaultProps} />);
+      expect(screen.getByTestId('nav-row-chevron')).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('omits the chevron when trailing is null', () => {
+      render(<NavRow {...defaultProps} trailing={null} />);
+      expect(screen.queryByTestId('nav-row-chevron')).not.toBeInTheDocument();
+    });
+
+    it('renders a custom trailing node instead of the chevron', () => {
+      render(<NavRow {...defaultProps} trailing={<span data-testid="custom-trailing" />} />);
+      expect(screen.getByTestId('custom-trailing')).toBeInTheDocument();
+      expect(screen.queryByTestId('nav-row-chevron')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('variants', () => {
+    it('applies plain surface classes by default', () => {
+      render(<NavRow {...defaultProps} />);
+      const button = screen.getByRole('button');
+      expect(button.className).toContain('bg-surface-elevated');
+      expect(button.className).toContain('border-stroke-subtle');
+    });
+
+    it('applies promo gradient classes', () => {
+      render(<NavRow {...defaultProps} variant="promo" />);
+      const button = screen.getByRole('button');
+      expect(button.className).toContain('bg-gradient-to-r');
+      expect(button.className).toContain('from-accent/10');
+      expect(button.className).toContain('border-accent/20');
+    });
+
+    it('applies neutral icon tint by default', () => {
+      render(<NavRow {...defaultProps} />);
+      expect(screen.getByTestId('nav-row-icon-tile').className).toContain('bg-surface-elevated');
+    });
+
+    it('applies accent icon tint', () => {
+      render(<NavRow {...defaultProps} iconTint="accent" />);
+      const tile = screen.getByTestId('nav-row-icon-tile');
+      expect(tile.className).toContain('bg-accent/20');
+      expect(tile.className).toContain('text-accent');
+    });
+
+    it('lets iconClassName override the tile tint', () => {
+      render(<NavRow {...defaultProps} iconClassName="bg-purple-500/20 text-purple-500" />);
+      const tile = screen.getByTestId('nav-row-icon-tile');
+      expect(tile.className).toContain('bg-purple-500/20');
+      expect(tile.className).not.toContain('bg-surface-elevated');
+    });
+
+    it('applies the activePress class', () => {
+      render(<NavRow {...defaultProps} />);
+      expect(screen.getByRole('button').className).toContain('active:scale-[0.98]');
+    });
+
+    it('merges className onto the button', () => {
+      render(<NavRow {...defaultProps} className="custom-class" />);
+      expect(screen.getByRole('button')).toHaveClass('custom-class');
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onClick when clicked', () => {
+      const onClick = vi.fn();
+      render(<NavRow {...defaultProps} onClick={onClick} />);
+      fireEvent.click(screen.getByRole('button'));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClick when disabled', () => {
+      const onClick = vi.fn();
+      render(<NavRow {...defaultProps} onClick={onClick} disabled />);
+      fireEvent.click(screen.getByRole('button'));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ref forwarding', () => {
+    it('forwards ref to the button element', () => {
+      const ref = vi.fn();
+      render(<NavRow {...defaultProps} ref={ref} />);
+      expect(ref).toHaveBeenCalledWith(expect.any(HTMLButtonElement));
+    });
+  });
+});

--- a/src/design-system/NavRow/NavRow.tsx
+++ b/src/design-system/NavRow/NavRow.tsx
@@ -1,0 +1,165 @@
+import { forwardRef } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../cn';
+import { focusRing, disabledStyles, interactiveTransition, activePress } from '../variants';
+
+const navRowVariants = cva(
+  [
+    'group w-full flex items-center gap-3 p-3 rounded-lg text-left',
+    interactiveTransition,
+    activePress,
+    ...focusRing,
+    ...disabledStyles,
+  ],
+  {
+    variants: {
+      variant: {
+        plain: ['bg-surface-elevated border border-stroke-subtle', 'hover:bg-surface-hover'],
+        promo: [
+          'bg-gradient-to-r from-accent/10 to-info/10',
+          'hover:from-accent/20 hover:to-info/20',
+          'border border-accent/20',
+        ],
+      },
+    },
+    defaultVariants: {
+      variant: 'plain',
+    },
+  }
+);
+
+type NavRowVariantProps = VariantProps<typeof navRowVariants>;
+
+const iconTints = {
+  neutral: 'bg-surface-elevated',
+  accent: 'bg-accent/20 text-accent',
+} as const;
+
+const defaultChevron = (
+  <svg
+    aria-hidden="true"
+    data-testid="nav-row-chevron"
+    className="w-4 h-4 text-content-tertiary shrink-0 transition-transform group-hover:translate-x-0.5"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+  </svg>
+);
+
+export interface NavRowProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'title'>, NavRowVariantProps {
+  /**
+   * Leading icon node, rendered inside a w-10 h-10 rounded-lg tile.
+   */
+  icon: React.ReactNode;
+
+  /**
+   * Tile tint. Arbitrary tints go via `iconClassName`.
+   * @default 'neutral'
+   */
+  iconTint?: 'neutral' | 'accent';
+
+  /**
+   * Extra classes for the icon tile (e.g. per-option background/text colors).
+   */
+  iconClassName?: string;
+
+  /**
+   * Primary row label.
+   */
+  title: string;
+
+  /**
+   * Secondary line below the title.
+   */
+  subtitle?: string;
+
+  /**
+   * Trailing node. Pass `null` to omit, or a custom node to replace.
+   * @default chevron-right icon
+   */
+  trailing?: React.ReactNode | null;
+
+  /**
+   * Row surface style.
+   * @default 'plain'
+   */
+  variant?: 'plain' | 'promo';
+}
+
+/**
+ * Full-width navigation/CTA row with a leading icon tile, title/subtitle
+ * block, and trailing chevron.
+ *
+ * @example
+ * // Plain settings row
+ * <NavRow icon={<GearIcon />} title="Print settings" subtitle="Nozzle, bed size" onClick={openSettings} />
+ *
+ * @example
+ * // Gradient promo card
+ * <NavRow
+ *   variant="promo"
+ *   iconTint="accent"
+ *   icon={<GridIcon />}
+ *   title="Inspiration gallery"
+ *   subtitle="Get ideas for your drawer"
+ *   onClick={openGallery}
+ * />
+ *
+ * @example
+ * // Custom tile tint, no chevron
+ * <NavRow
+ *   icon={<CloudIcon />}
+ *   iconClassName="bg-purple-500/20 text-purple-500"
+ *   title="Share to cloud"
+ *   trailing={null}
+ *   onClick={shareToCloud}
+ * />
+ */
+export const NavRow = forwardRef<HTMLButtonElement, NavRowProps>(
+  (
+    {
+      icon,
+      iconTint = 'neutral',
+      iconClassName,
+      title,
+      subtitle,
+      trailing,
+      variant,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={cn(navRowVariants({ variant }), className)}
+        {...props}
+      >
+        <span
+          aria-hidden="true"
+          data-testid="nav-row-icon-tile"
+          className={cn(
+            'w-10 h-10 rounded-lg flex items-center justify-center shrink-0',
+            'transition-transform group-hover:scale-105',
+            iconTints[iconTint],
+            iconClassName
+          )}
+        >
+          {icon}
+        </span>
+        <span className="flex-1 min-w-0">
+          <span className="block text-sm font-medium text-content">{title}</span>
+          {subtitle && <span className="block text-xs text-content-tertiary">{subtitle}</span>}
+        </span>
+        {trailing === undefined ? defaultChevron : trailing}
+      </button>
+    );
+  }
+);
+
+NavRow.displayName = 'NavRow';

--- a/src/design-system/NavRow/index.ts
+++ b/src/design-system/NavRow/index.ts
@@ -1,0 +1,2 @@
+export { NavRow } from './NavRow';
+export type { NavRowProps } from './NavRow';

--- a/src/design-system/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/design-system/SegmentedControl/SegmentedControl.test.tsx
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SegmentedControl } from './SegmentedControl';
+import type { SegmentedControlProps } from './SegmentedControl';
+
+type Mode = 'list' | 'grid' | 'table';
+
+const defaultProps: SegmentedControlProps<Mode> = {
+  options: [
+    { value: 'list', label: 'List' },
+    { value: 'grid', label: 'Grid' },
+    { value: 'table', label: 'Table' },
+  ],
+  value: 'list',
+  onChange: () => {},
+  'aria-label': 'View mode',
+};
+
+describe('SegmentedControl', () => {
+  it('renders a radiogroup with the group label and one radio per option', () => {
+    render(<SegmentedControl {...defaultProps} />);
+    expect(screen.getByRole('radiogroup', { name: 'View mode' })).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+    expect(screen.getByRole('radio', { name: 'List' })).toBeInTheDocument();
+  });
+
+  it('marks only the selected option as checked', () => {
+    render(<SegmentedControl {...defaultProps} value="grid" />);
+    expect(screen.getByRole('radio', { name: 'Grid' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: 'List' })).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByRole('radio', { name: 'Table' })).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('gives the selected radio tabindex 0 and the rest -1', () => {
+    render(<SegmentedControl {...defaultProps} value="grid" />);
+    expect(screen.getByRole('radio', { name: 'Grid' })).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('radio', { name: 'List' })).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByRole('radio', { name: 'Table' })).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('calls onChange with the clicked value', () => {
+    const onChange = vi.fn();
+    render(<SegmentedControl {...defaultProps} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('radio', { name: 'Grid' }));
+    expect(onChange).toHaveBeenCalledWith('grid');
+  });
+
+  it('does not call onChange when clicking the already selected option', () => {
+    const onChange = vi.fn();
+    render(<SegmentedControl {...defaultProps} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('radio', { name: 'List' }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('selects the next option on ArrowRight and ArrowDown', () => {
+    const onChange = vi.fn();
+    render(<SegmentedControl {...defaultProps} onChange={onChange} />);
+    const selected = screen.getByRole('radio', { name: 'List' });
+    fireEvent.keyDown(selected, { key: 'ArrowRight' });
+    expect(onChange).toHaveBeenCalledWith('grid');
+    fireEvent.keyDown(selected, { key: 'ArrowDown' });
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('selects the previous option on ArrowLeft and ArrowUp, wrapping at the start', () => {
+    const onChange = vi.fn();
+    render(<SegmentedControl {...defaultProps} onChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'List' }), { key: 'ArrowLeft' });
+    expect(onChange).toHaveBeenCalledWith('table');
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'List' }), { key: 'ArrowUp' });
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('wraps to the first option when pressing ArrowRight on the last', () => {
+    const onChange = vi.fn();
+    render(<SegmentedControl {...defaultProps} value="table" onChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Table' }), { key: 'ArrowRight' });
+    expect(onChange).toHaveBeenCalledWith('list');
+  });
+
+  it('selects the first option on Home and the last on End', () => {
+    const onChange = vi.fn();
+    render(<SegmentedControl {...defaultProps} value="grid" onChange={onChange} />);
+    const selected = screen.getByRole('radio', { name: 'Grid' });
+    fireEvent.keyDown(selected, { key: 'Home' });
+    expect(onChange).toHaveBeenCalledWith('list');
+    fireEvent.keyDown(selected, { key: 'End' });
+    expect(onChange).toHaveBeenCalledWith('table');
+  });
+
+  it('prevents default on navigation keys but not on other keys', () => {
+    render(<SegmentedControl {...defaultProps} />);
+    const selected = screen.getByRole('radio', { name: 'List' });
+    expect(fireEvent.keyDown(selected, { key: 'ArrowRight' })).toBe(false);
+    expect(fireEvent.keyDown(selected, { key: 'Tab' })).toBe(true);
+  });
+
+  it('moves focus to the newly selected segment on arrow navigation', () => {
+    render(<SegmentedControl {...defaultProps} />);
+    const selected = screen.getByRole('radio', { name: 'List' });
+    selected.focus();
+    fireEvent.keyDown(selected, { key: 'ArrowRight' });
+    expect(screen.getByRole('radio', { name: 'Grid' })).toHaveFocus();
+  });
+
+  it('skips disabled segments during arrow navigation', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl
+        {...defaultProps}
+        options={[
+          { value: 'list', label: 'List' },
+          { value: 'grid', label: 'Grid', disabled: true },
+          { value: 'table', label: 'Table' },
+        ]}
+        onChange={onChange}
+      />
+    );
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'List' }), { key: 'ArrowRight' });
+    expect(onChange).toHaveBeenCalledWith('table');
+  });
+
+  it('skips disabled segments for Home and End', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl
+        {...defaultProps}
+        options={[
+          { value: 'list', label: 'List', disabled: true },
+          { value: 'grid', label: 'Grid' },
+          { value: 'table', label: 'Table', disabled: true },
+        ]}
+        value="grid"
+        onChange={onChange}
+      />
+    );
+    const selected = screen.getByRole('radio', { name: 'Grid' });
+    fireEvent.keyDown(selected, { key: 'Home' });
+    fireEvent.keyDown(selected, { key: 'End' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not call onChange when clicking a disabled segment', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl
+        {...defaultProps}
+        options={[
+          { value: 'list', label: 'List' },
+          { value: 'grid', label: 'Grid', disabled: true },
+        ]}
+        onChange={onChange}
+      />
+    );
+    const disabledRadio = screen.getByRole('radio', { name: 'Grid' });
+    expect(disabledRadio).toBeDisabled();
+    fireEvent.click(disabledRadio);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('ignores unrelated keys', () => {
+    const onChange = vi.fn();
+    render(<SegmentedControl {...defaultProps} onChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'List' }), { key: 'a' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('applies the subtle active pill classes by default', () => {
+    render(<SegmentedControl {...defaultProps} />);
+    const selected = screen.getByRole('radio', { name: 'List' });
+    expect(selected.className).toContain('bg-surface-elevated');
+    expect(selected.className).toContain('shadow-sm');
+    expect(screen.getByRole('radio', { name: 'Grid' }).className).toContain(
+      'text-content-tertiary'
+    );
+  });
+
+  it('applies accent active classes when activeStyle is accent', () => {
+    render(<SegmentedControl {...defaultProps} activeStyle="accent" />);
+    const selected = screen.getByRole('radio', { name: 'List' });
+    expect(selected.className).toContain('bg-accent');
+    expect(selected.className).toContain('text-on-accent');
+  });
+
+  it('applies compact text size for size sm', () => {
+    render(<SegmentedControl {...defaultProps} size="sm" />);
+    expect(screen.getByRole('radio', { name: 'List' }).className).toContain('text-[11px]');
+  });
+
+  it('stretches segments equally when fullWidth', () => {
+    render(<SegmentedControl {...defaultProps} fullWidth />);
+    expect(screen.getByRole('radiogroup').className).toContain('w-full');
+    for (const radio of screen.getAllByRole('radio')) {
+      expect(radio.className).toContain('flex-1');
+    }
+  });
+
+  it('applies className to the group container', () => {
+    render(<SegmentedControl {...defaultProps} className="custom-class" />);
+    expect(screen.getByRole('radiogroup')).toHaveClass('custom-class');
+  });
+
+  it('uses per-option aria-label and title for icon-only segments', () => {
+    render(
+      <SegmentedControl
+        {...defaultProps}
+        options={[
+          {
+            value: 'list',
+            label: <svg aria-hidden="true" />,
+            'aria-label': 'List view',
+            title: 'List view',
+          },
+          {
+            value: 'grid',
+            label: <svg aria-hidden="true" />,
+            'aria-label': 'Grid view',
+            title: 'Grid view',
+          },
+        ]}
+      />
+    );
+    expect(screen.getByRole('radio', { name: 'List view' })).toHaveAttribute('title', 'List view');
+    expect(screen.getByRole('radio', { name: 'Grid view' })).toBeInTheDocument();
+  });
+});

--- a/src/design-system/SegmentedControl/SegmentedControl.tsx
+++ b/src/design-system/SegmentedControl/SegmentedControl.tsx
@@ -1,0 +1,272 @@
+import { useCallback, useRef } from 'react';
+import type { KeyboardEvent, ReactNode } from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '../cn';
+import { focusRing, disabledStyles, interactiveTransition } from '../variants';
+
+const groupVariants = cva(['inline-flex rounded-lg bg-surface p-0.5', 'border border-stroke'], {
+  variants: {
+    fullWidth: {
+      true: 'flex w-full',
+    },
+  },
+});
+
+const segmentVariants = cva(
+  [
+    'inline-flex items-center justify-center gap-1.5',
+    'rounded-md font-medium whitespace-nowrap',
+    interactiveTransition,
+    ...focusRing,
+    ...disabledStyles,
+  ],
+  {
+    variants: {
+      size: {
+        sm: ['text-[11px]', 'px-2', 'py-0.5'],
+        md: ['text-xs', 'px-2.5', 'py-1.5'],
+      },
+      activeStyle: {
+        subtle: '',
+        accent: '',
+      },
+      active: {
+        true: '',
+        false: 'text-content-tertiary hover:bg-surface-hover hover:text-content-secondary',
+      },
+      fullWidth: {
+        true: 'flex-1',
+      },
+    },
+    compoundVariants: [
+      {
+        active: true,
+        activeStyle: 'subtle',
+        class: 'bg-surface-elevated text-content shadow-sm',
+      },
+      {
+        active: true,
+        activeStyle: 'accent',
+        class: 'bg-accent text-on-accent',
+      },
+    ],
+    defaultVariants: {
+      size: 'md',
+      activeStyle: 'subtle',
+    },
+  }
+);
+
+export interface SegmentedControlOption<T extends string> {
+  value: T;
+
+  /**
+   * Visible content: text, icon node, or icon+label.
+   */
+  label: ReactNode;
+
+  /**
+   * Accessible name for the segment. Required when label is icon-only.
+   */
+  'aria-label'?: string;
+
+  /**
+   * Tooltip shown on hover.
+   */
+  title?: string;
+
+  /**
+   * Disables this segment; keyboard navigation skips it.
+   */
+  disabled?: boolean;
+}
+
+export interface SegmentedControlProps<T extends string> {
+  /**
+   * Options to render as segments, in order.
+   */
+  options: SegmentedControlOption<T>[];
+
+  /**
+   * Currently selected value.
+   */
+  value: T;
+
+  /**
+   * Called with the newly selected value. Not called when the
+   * selected segment is clicked again.
+   */
+  onChange: (value: T) => void;
+
+  /**
+   * Accessible label for the radiogroup.
+   */
+  'aria-label': string;
+
+  /**
+   * Segment density. 'sm' is compact for dense desktop groups;
+   * 'md' is touch-friendly.
+   * @default 'md'
+   */
+  size?: 'sm' | 'md';
+
+  /**
+   * Active segment treatment: 'subtle' raised neutral pill or
+   * 'accent' filled pill.
+   * @default 'subtle'
+   */
+  activeStyle?: 'subtle' | 'accent';
+
+  /**
+   * Stretch the group and give every segment equal width.
+   * @default false
+   */
+  fullWidth?: boolean;
+
+  className?: string;
+}
+
+function stepEnabledIndex<T extends string>(
+  options: SegmentedControlOption<T>[],
+  from: number,
+  direction: 1 | -1
+): number {
+  const length = options.length;
+  for (let step = 1; step <= length; step++) {
+    const index = (((from + direction * step) % length) + length) % length;
+    if (!options[index].disabled) return index;
+  }
+  return from;
+}
+
+function lastEnabledIndex<T extends string>(options: SegmentedControlOption<T>[]): number {
+  for (let index = options.length - 1; index >= 0; index--) {
+    if (!options[index].disabled) return index;
+  }
+  return -1;
+}
+
+/**
+ * Accessible single-select segmented control. Renders a radiogroup of
+ * joined segments with roving tabindex and full arrow-key navigation
+ * (ArrowLeft/Right/Up/Down cycle, Home/End jump, disabled segments skipped).
+ *
+ * @example
+ * // Text segments
+ * <SegmentedControl
+ *   aria-label="View mode"
+ *   options={[
+ *     { value: 'list', label: 'List' },
+ *     { value: 'grid', label: 'Grid' },
+ *   ]}
+ *   value={mode}
+ *   onChange={setMode}
+ * />
+ *
+ * @example
+ * // Icon-only segments (per-option aria-label required)
+ * <SegmentedControl
+ *   aria-label="Preview mode"
+ *   activeStyle="accent"
+ *   options={[
+ *     { value: 'assembled', label: <CubeIcon />, 'aria-label': 'Assembled' },
+ *     { value: 'exploded', label: <LayersIcon />, 'aria-label': 'Exploded' },
+ *   ]}
+ *   value={previewMode}
+ *   onChange={setPreviewMode}
+ * />
+ *
+ * @example
+ * // Compact, equal-width segments
+ * <SegmentedControl
+ *   aria-label="Divider mode"
+ *   size="sm"
+ *   fullWidth
+ *   options={[
+ *     { value: 'count', label: 'By count' },
+ *     { value: 'size', label: 'By size' },
+ *   ]}
+ *   value={dividerMode}
+ *   onChange={setDividerMode}
+ * />
+ */
+export function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+  'aria-label': ariaLabel,
+  size = 'md',
+  activeStyle = 'subtle',
+  fullWidth = false,
+  className,
+}: SegmentedControlProps<T>) {
+  const groupRef = useRef<HTMLDivElement>(null);
+
+  const selectIndex = useCallback(
+    (index: number) => {
+      const option = options[index];
+      if (option.disabled || option.value === value) return;
+      onChange(option.value);
+      const radios = groupRef.current?.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+      radios?.[index]?.focus();
+    },
+    [options, value, onChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (options.length === 0) return;
+      const currentIndex = options.findIndex((option) => option.value === value);
+      let nextIndex: number;
+
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        nextIndex = stepEnabledIndex(options, currentIndex, 1);
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        nextIndex = stepEnabledIndex(options, currentIndex, -1);
+      } else if (e.key === 'Home') {
+        nextIndex = options.findIndex((option) => !option.disabled);
+      } else if (e.key === 'End') {
+        nextIndex = lastEnabledIndex(options);
+      } else {
+        return;
+      }
+
+      e.preventDefault();
+      if (nextIndex >= 0) selectIndex(nextIndex);
+    },
+    [options, value, selectIndex]
+  );
+
+  return (
+    <div
+      ref={groupRef}
+      role="radiogroup"
+      aria-label={ariaLabel}
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
+      className={cn(groupVariants({ fullWidth }), className)}
+    >
+      {options.map((option) => {
+        const isSelected = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            aria-label={option['aria-label']}
+            title={option.title}
+            disabled={option.disabled}
+            tabIndex={isSelected ? 0 : -1}
+            onClick={() => {
+              if (!isSelected) onChange(option.value);
+            }}
+            className={cn(segmentVariants({ size, activeStyle, active: isSelected, fullWidth }))}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/design-system/SegmentedControl/index.ts
+++ b/src/design-system/SegmentedControl/index.ts
@@ -1,0 +1,2 @@
+export { SegmentedControl } from './SegmentedControl';
+export type { SegmentedControlProps, SegmentedControlOption } from './SegmentedControl';

--- a/src/design-system/Tabs/Tabs.test.tsx
+++ b/src/design-system/Tabs/Tabs.test.tsx
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Tabs, type TabItem } from '.';
+
+type TabId = 'general' | 'display' | 'advanced';
+
+const tabs: TabItem<TabId>[] = [
+  { id: 'general', label: 'General' },
+  { id: 'display', label: 'Display' },
+  { id: 'advanced', label: 'Advanced' },
+];
+
+const defaultProps = {
+  tabs,
+  activeTab: 'general' as TabId,
+  onChange: vi.fn(),
+  'aria-label': 'Settings sections',
+};
+
+describe('Tabs', () => {
+  describe('rendering', () => {
+    it('renders a tablist with the given accessible name', () => {
+      render(<Tabs.List {...defaultProps} />);
+      expect(screen.getByRole('tablist', { name: 'Settings sections' })).toBeInTheDocument();
+    });
+
+    it('renders one tab per item with aria-selected on the active tab', () => {
+      render(<Tabs.List {...defaultProps} activeTab="display" />);
+      expect(screen.getAllByRole('tab')).toHaveLength(3);
+      expect(screen.getByRole('tab', { name: 'Display' })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('tab', { name: 'General' })).toHaveAttribute(
+        'aria-selected',
+        'false'
+      );
+    });
+
+    it('sets aria-orientation horizontal by default', () => {
+      render(<Tabs.List {...defaultProps} />);
+      expect(screen.getByRole('tablist')).toHaveAttribute('aria-orientation', 'horizontal');
+    });
+
+    it('sets aria-orientation vertical for vertical lists', () => {
+      render(<Tabs.List {...defaultProps} orientation="vertical" />);
+      expect(screen.getByRole('tablist')).toHaveAttribute('aria-orientation', 'vertical');
+    });
+
+    it('names icon-only tabs via aria-label', () => {
+      const iconTabs: TabItem<'help'>[] = [
+        { id: 'help', label: <svg aria-hidden="true" />, 'aria-label': 'Help' },
+      ];
+      render(<Tabs.List tabs={iconTabs} activeTab="help" onChange={vi.fn()} aria-label="Topics" />);
+      expect(screen.getByRole('tab', { name: 'Help' })).toBeInTheDocument();
+    });
+
+    it('renders trailing badge content', () => {
+      const badgeTabs: TabItem<TabId>[] = [{ id: 'general', label: 'General', badge: 12 }];
+      render(<Tabs.List {...defaultProps} tabs={badgeTabs} />);
+      expect(screen.getByRole('tab', { name: /General/ })).toHaveTextContent('12');
+    });
+
+    it('disables tabs marked disabled', () => {
+      const withDisabled: TabItem<TabId>[] = [
+        { id: 'general', label: 'General' },
+        { id: 'display', label: 'Display', disabled: true },
+      ];
+      render(<Tabs.List {...defaultProps} tabs={withDisabled} />);
+      expect(screen.getByRole('tab', { name: 'Display' })).toBeDisabled();
+    });
+
+    it('applies className to the tablist', () => {
+      render(<Tabs.List {...defaultProps} className="custom-class" />);
+      expect(screen.getByRole('tablist')).toHaveClass('custom-class');
+    });
+  });
+
+  describe('id wiring', () => {
+    it('wires aria-controls and aria-labelledby between tab and panel', () => {
+      render(
+        <Tabs.Root>
+          <Tabs.List {...defaultProps} />
+          <Tabs.Panel tabId="general" activeTab="general">
+            Content
+          </Tabs.Panel>
+        </Tabs.Root>
+      );
+      const tab = screen.getByRole('tab', { name: 'General' });
+      const panel = screen.getByRole('tabpanel');
+      expect(tab).toHaveAttribute('aria-controls', panel.id);
+      expect(panel).toHaveAttribute('aria-labelledby', tab.id);
+    });
+
+    it('omits aria-controls when used without Tabs.Root', () => {
+      render(<Tabs.List {...defaultProps} />);
+      expect(screen.getByRole('tab', { name: 'General' })).not.toHaveAttribute('aria-controls');
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onChange with the tab id on click', () => {
+      const onChange = vi.fn();
+      render(<Tabs.List {...defaultProps} onChange={onChange} />);
+      fireEvent.click(screen.getByRole('tab', { name: 'Advanced' }));
+      expect(onChange).toHaveBeenCalledWith('advanced');
+    });
+
+    it('does not call onChange when clicking a disabled tab', () => {
+      const onChange = vi.fn();
+      const withDisabled: TabItem<TabId>[] = [
+        { id: 'general', label: 'General' },
+        { id: 'display', label: 'Display', disabled: true },
+      ];
+      render(<Tabs.List {...defaultProps} tabs={withDisabled} onChange={onChange} />);
+      fireEvent.click(screen.getByRole('tab', { name: 'Display' }));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('moves to the next tab with ArrowRight when horizontal', () => {
+      const onChange = vi.fn();
+      render(<Tabs.List {...defaultProps} onChange={onChange} />);
+      fireEvent.keyDown(screen.getByRole('tab', { name: 'General' }), { key: 'ArrowRight' });
+      expect(onChange).toHaveBeenCalledWith('display');
+      expect(screen.getByRole('tab', { name: 'Display' })).toHaveFocus();
+    });
+
+    it('wraps to the last tab with ArrowLeft from the first', () => {
+      const onChange = vi.fn();
+      render(<Tabs.List {...defaultProps} onChange={onChange} />);
+      fireEvent.keyDown(screen.getByRole('tab', { name: 'General' }), { key: 'ArrowLeft' });
+      expect(onChange).toHaveBeenCalledWith('advanced');
+    });
+
+    it('jumps to first and last enabled tabs with Home and End', () => {
+      const onChange = vi.fn();
+      render(<Tabs.List {...defaultProps} activeTab="display" onChange={onChange} />);
+      const tab = screen.getByRole('tab', { name: 'Display' });
+      fireEvent.keyDown(tab, { key: 'End' });
+      expect(onChange).toHaveBeenCalledWith('advanced');
+      fireEvent.keyDown(tab, { key: 'Home' });
+      expect(onChange).toHaveBeenCalledWith('general');
+    });
+
+    it('uses ArrowDown/ArrowUp instead of ArrowRight/ArrowLeft when vertical', () => {
+      const onChange = vi.fn();
+      render(<Tabs.List {...defaultProps} orientation="vertical" onChange={onChange} />);
+      const tab = screen.getByRole('tab', { name: 'General' });
+      fireEvent.keyDown(tab, { key: 'ArrowRight' });
+      expect(onChange).not.toHaveBeenCalled();
+      fireEvent.keyDown(tab, { key: 'ArrowDown' });
+      expect(onChange).toHaveBeenCalledWith('display');
+      fireEvent.keyDown(tab, { key: 'ArrowUp' });
+      expect(onChange).toHaveBeenCalledWith('advanced');
+    });
+
+    it('skips disabled tabs during arrow navigation', () => {
+      const onChange = vi.fn();
+      const withDisabled: TabItem<TabId>[] = [
+        { id: 'general', label: 'General' },
+        { id: 'display', label: 'Display', disabled: true },
+        { id: 'advanced', label: 'Advanced' },
+      ];
+      render(<Tabs.List {...defaultProps} tabs={withDisabled} onChange={onChange} />);
+      fireEvent.keyDown(screen.getByRole('tab', { name: 'General' }), { key: 'ArrowRight' });
+      expect(onChange).toHaveBeenCalledWith('advanced');
+    });
+
+    it('applies roving tabindex with only the active tab focusable', () => {
+      render(<Tabs.List {...defaultProps} activeTab="display" />);
+      expect(screen.getByRole('tab', { name: 'Display' })).toHaveAttribute('tabindex', '0');
+      expect(screen.getByRole('tab', { name: 'General' })).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByRole('tab', { name: 'Advanced' })).toHaveAttribute('tabindex', '-1');
+    });
+  });
+
+  describe('visual variants', () => {
+    it('applies underline classes to the active tab by default', () => {
+      render(<Tabs.List {...defaultProps} />);
+      const active = screen.getByRole('tab', { name: 'General' });
+      expect(active.className).toContain('border-b-2');
+      expect(active.className).toContain('border-accent');
+      expect(active.className).toContain('text-accent');
+    });
+
+    it('applies rail classes to the active tab', () => {
+      render(<Tabs.List {...defaultProps} orientation="vertical" visual="rail" />);
+      const active = screen.getByRole('tab', { name: 'General' });
+      expect(active.className).toContain('border-l-2');
+      expect(active.className).toContain('bg-surface-elevated');
+    });
+
+    it('applies pill classes to the active tab', () => {
+      render(<Tabs.List {...defaultProps} visual="pill" />);
+      const active = screen.getByRole('tab', { name: 'General' });
+      expect(active.className).toContain('rounded-full');
+      expect(active.className).toContain('bg-accent');
+    });
+
+    it('applies flex-1 to tabs when fullWidth', () => {
+      render(<Tabs.List {...defaultProps} visual="pill" fullWidth />);
+      expect(screen.getByRole('tab', { name: 'General' }).className).toContain('flex-1');
+    });
+  });
+
+  describe('panel', () => {
+    it('unmounts the inactive panel by default', () => {
+      render(
+        <Tabs.Root>
+          <Tabs.Panel tabId="display" activeTab="general">
+            Display content
+          </Tabs.Panel>
+        </Tabs.Root>
+      );
+      expect(screen.queryByRole('tabpanel', { hidden: true })).not.toBeInTheDocument();
+    });
+
+    it('keeps the inactive panel mounted and hidden with keepMounted', () => {
+      render(
+        <Tabs.Root>
+          <Tabs.Panel tabId="display" activeTab="general" keepMounted>
+            Display content
+          </Tabs.Panel>
+        </Tabs.Root>
+      );
+      const panel = screen.getByRole('tabpanel', { hidden: true });
+      expect(panel).toHaveAttribute('hidden');
+      expect(panel).toHaveTextContent('Display content');
+    });
+
+    it('sets tabindex 0 when the panel has no focusable content', () => {
+      render(
+        <Tabs.Root>
+          <Tabs.Panel tabId="general" activeTab="general">
+            Plain text
+          </Tabs.Panel>
+        </Tabs.Root>
+      );
+      expect(screen.getByRole('tabpanel')).toHaveAttribute('tabindex', '0');
+    });
+
+    it('omits tabindex when the panel contains focusable content', () => {
+      render(
+        <Tabs.Root>
+          <Tabs.Panel tabId="general" activeTab="general">
+            <button type="button">Action</button>
+          </Tabs.Panel>
+        </Tabs.Root>
+      );
+      expect(screen.getByRole('tabpanel')).not.toHaveAttribute('tabindex');
+    });
+
+    it('applies className to the panel', () => {
+      render(
+        <Tabs.Root>
+          <Tabs.Panel tabId="general" activeTab="general" className="custom-class">
+            Content
+          </Tabs.Panel>
+        </Tabs.Root>
+      );
+      expect(screen.getByRole('tabpanel')).toHaveClass('custom-class');
+    });
+
+    it('throws when used outside Tabs.Root', () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      expect(() =>
+        render(
+          <Tabs.Panel tabId="general" activeTab="general">
+            Content
+          </Tabs.Panel>
+        )
+      ).toThrow('Tabs.Panel must be used within Tabs.Root');
+      consoleError.mockRestore();
+    });
+  });
+});

--- a/src/design-system/Tabs/Tabs.tsx
+++ b/src/design-system/Tabs/Tabs.tsx
@@ -1,0 +1,295 @@
+import { createContext, useCallback, useContext, useId, useRef, type ReactNode } from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '../cn';
+import { disabledStyles, focusRing, interactiveTransition } from '../variants';
+
+interface TabsContextValue {
+  idPrefix: string;
+}
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+export function useTabsContext(): TabsContextValue {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error('Tabs.Panel must be used within Tabs.Root');
+  }
+  return context;
+}
+
+const tabsListVariants = cva(['flex'], {
+  variants: {
+    orientation: {
+      horizontal: 'flex-row items-center overflow-x-auto scrollbar-none',
+      vertical: 'flex-col',
+    },
+    visual: {
+      underline: '',
+      rail: '',
+      pill: 'gap-1',
+    },
+    fullWidth: {
+      true: 'w-full',
+    },
+  },
+  compoundVariants: [
+    { orientation: 'horizontal', visual: 'underline', class: 'border-b border-stroke-subtle' },
+    { orientation: 'vertical', visual: 'rail', class: 'border-r border-stroke-subtle py-2' },
+  ],
+  defaultVariants: {
+    orientation: 'horizontal',
+    visual: 'underline',
+  },
+});
+
+const tabVariants = cva(
+  [
+    'inline-flex items-center gap-1.5',
+    'text-sm whitespace-nowrap flex-shrink-0',
+    interactiveTransition,
+    ...focusRing,
+    ...disabledStyles,
+  ],
+  {
+    variants: {
+      visual: {
+        underline: 'px-3 py-2.5 border-b-2 border-transparent',
+        rail: 'w-full justify-start text-left px-4 py-2 border-l-2 border-transparent',
+        pill: 'justify-center px-4 py-2 rounded-full min-h-[44px]',
+      },
+      active: {
+        true: 'font-medium',
+        false: 'text-content-tertiary hover:text-content-secondary',
+      },
+      fullWidth: {
+        true: 'flex-1 justify-center',
+      },
+    },
+    compoundVariants: [
+      { visual: 'underline', active: true, class: 'text-accent border-accent' },
+      { visual: 'rail', active: true, class: 'bg-surface-elevated text-content border-accent' },
+      { visual: 'rail', active: false, class: 'hover:bg-surface-hover' },
+      { visual: 'pill', active: true, class: 'bg-accent text-on-accent' },
+      { visual: 'pill', active: false, class: 'hover:bg-surface-hover' },
+    ],
+    defaultVariants: {
+      visual: 'underline',
+      active: false,
+    },
+  }
+);
+
+export interface TabsRootProps {
+  /**
+   * Tabs content: a Tabs.List and its Tabs.Panel siblings.
+   */
+  children: ReactNode;
+}
+
+/**
+ * Context provider that wires tab ↔ panel ids (aria-controls / aria-labelledby).
+ * Wrap a Tabs.List together with its Tabs.Panel siblings.
+ *
+ * @example
+ * <Tabs.Root>
+ *   <Tabs.List tabs={tabs} activeTab={tab} onChange={setTab} aria-label="Settings" />
+ *   <Tabs.Panel tabId="general" activeTab={tab}>General settings</Tabs.Panel>
+ *   <Tabs.Panel tabId="display" activeTab={tab}>Display settings</Tabs.Panel>
+ * </Tabs.Root>
+ */
+export function TabsRoot({ children }: TabsRootProps) {
+  const idPrefix = useId();
+  return <TabsContext.Provider value={{ idPrefix }}>{children}</TabsContext.Provider>;
+}
+
+export interface TabItem<T extends string> {
+  /**
+   * Stable tab identifier, passed to onChange.
+   */
+  id: T;
+
+  /**
+   * Tab content: text, icon + label, or icon-only.
+   */
+  label: ReactNode;
+
+  /**
+   * Accessible name for the tab. Required when label is icon-only.
+   */
+  'aria-label'?: string;
+
+  /**
+   * Trailing content such as a count badge.
+   */
+  badge?: ReactNode;
+
+  /**
+   * Whether the tab is disabled. Disabled tabs are skipped by keyboard navigation.
+   */
+  disabled?: boolean;
+}
+
+export interface TabsListProps<T extends string> {
+  /**
+   * Tabs to render, in order.
+   */
+  tabs: TabItem<T>[];
+
+  /**
+   * Id of the currently selected tab.
+   */
+  activeTab: T;
+
+  /**
+   * Called with the tab id when a tab is selected by click or keyboard.
+   */
+  onChange: (id: T) => void;
+
+  /**
+   * Accessible name for the tablist. Pass a translated string.
+   */
+  'aria-label': string;
+
+  /**
+   * @default 'horizontal'. 'vertical' = side rail (e.g. settings on desktop).
+   */
+  orientation?: 'horizontal' | 'vertical';
+
+  /**
+   * @default 'underline'. underline = border-b-2 accent active; rail = border-l-2 +
+   * bg-surface-elevated active, vertical only; pill = rounded solid bg-accent active,
+   * 44px-friendly.
+   */
+  visual?: 'underline' | 'rail' | 'pill';
+
+  /**
+   * flex-1 equal-width tabs.
+   * @default false
+   */
+  fullWidth?: boolean;
+
+  /**
+   * Additional classes for the tablist container.
+   */
+  className?: string;
+}
+
+/**
+ * ARIA tablist with roving tabindex and arrow-key / Home / End navigation.
+ * Selection follows focus. Wrap in Tabs.Root to wire panels via aria-controls;
+ * without a Root the list still works but renders no aria-controls.
+ *
+ * @example
+ * // Underline tabs (default)
+ * <Tabs.List
+ *   tabs={[
+ *     { id: 'layers', label: 'Layers' },
+ *     { id: 'bins', label: 'Bins' },
+ *   ]}
+ *   activeTab={tab}
+ *   onChange={setTab}
+ *   aria-label="Panels"
+ * />
+ *
+ * @example
+ * // Vertical rail (settings sidebar)
+ * <Tabs.List
+ *   tabs={tabs}
+ *   activeTab={tab}
+ *   onChange={setTab}
+ *   aria-label="Settings"
+ *   orientation="vertical"
+ *   visual="rail"
+ * />
+ *
+ * @example
+ * // Equal-width pills with a count badge
+ * <Tabs.List
+ *   tabs={[
+ *     { id: 'all', label: 'All', badge: 12 },
+ *     { id: 'mine', label: 'Mine', badge: 3 },
+ *   ]}
+ *   activeTab={tab}
+ *   onChange={setTab}
+ *   aria-label="Filter"
+ *   visual="pill"
+ *   fullWidth
+ * />
+ */
+export function TabsList<T extends string>({
+  tabs,
+  activeTab,
+  onChange,
+  'aria-label': ariaLabel,
+  orientation = 'horizontal',
+  visual = 'underline',
+  fullWidth = false,
+  className,
+}: TabsListProps<T>) {
+  const context = useContext(TabsContext);
+  const localId = useId();
+  const idPrefix = context?.idPrefix ?? localId;
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const enabled = tabs.map((tab, index) => ({ tab, index })).filter(({ tab }) => !tab.disabled);
+      if (enabled.length === 0) return;
+
+      const nextKey = orientation === 'vertical' ? 'ArrowDown' : 'ArrowRight';
+      const prevKey = orientation === 'vertical' ? 'ArrowUp' : 'ArrowLeft';
+      const currentPos = enabled.findIndex(({ tab }) => tab.id === activeTab);
+
+      let nextPos = -1;
+      if (e.key === nextKey) nextPos = (currentPos + 1) % enabled.length;
+      else if (e.key === prevKey) nextPos = (currentPos - 1 + enabled.length) % enabled.length;
+      else if (e.key === 'Home') nextPos = 0;
+      else if (e.key === 'End') nextPos = enabled.length - 1;
+
+      if (nextPos < 0) return;
+      e.preventDefault();
+
+      const next = enabled[nextPos];
+      onChange(next.tab.id);
+      const buttons = listRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+      buttons?.[next.index]?.focus();
+    },
+    [tabs, activeTab, onChange, orientation]
+  );
+
+  return (
+    <div
+      ref={listRef}
+      role="tablist"
+      tabIndex={-1}
+      aria-label={ariaLabel}
+      aria-orientation={orientation}
+      onKeyDown={handleKeyDown}
+      className={cn(tabsListVariants({ orientation, visual, fullWidth }), className)}
+    >
+      {tabs.map((tab) => {
+        const isActive = tab.id === activeTab;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            id={`${idPrefix}-tab-${tab.id}`}
+            aria-selected={isActive}
+            aria-controls={context ? `${idPrefix}-panel-${tab.id}` : undefined}
+            aria-label={tab['aria-label']}
+            tabIndex={isActive ? 0 : -1}
+            disabled={tab.disabled}
+            onClick={() => onChange(tab.id)}
+            className={cn(tabVariants({ visual, active: isActive, fullWidth }))}
+          >
+            {tab.label}
+            {tab.badge !== undefined && tab.badge !== null && (
+              <span className="text-xs tabular-nums">{tab.badge}</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/design-system/Tabs/TabsPanel.tsx
+++ b/src/design-system/Tabs/TabsPanel.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useTabsContext } from './Tabs';
+
+const FOCUSABLE_SELECTOR = [
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'a[href]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+export interface TabsPanelProps {
+  /**
+   * Id of the tab this panel belongs to.
+   */
+  tabId: string;
+
+  /**
+   * Id of the currently selected tab.
+   */
+  activeTab: string;
+
+  /**
+   * Panel content.
+   */
+  children: ReactNode;
+
+  /**
+   * Additional classes for the panel container.
+   */
+  className?: string;
+
+  /**
+   * Keep the panel mounted but hidden when inactive.
+   * @default false
+   */
+  keepMounted?: boolean;
+}
+
+/**
+ * Content panel wired to a Tabs.List tab. Must be used within Tabs.Root.
+ * Unmounts when inactive unless keepMounted; receives tabIndex={0} only
+ * when its content has no focusable element.
+ *
+ * @example
+ * <Tabs.Panel tabId="general" activeTab={tab}>
+ *   <GeneralSettings />
+ * </Tabs.Panel>
+ *
+ * @example
+ * // Preserve form state across tab switches
+ * <Tabs.Panel tabId="export" activeTab={tab} keepMounted>
+ *   <ExportForm />
+ * </Tabs.Panel>
+ */
+export function TabsPanel({
+  tabId,
+  activeTab,
+  children,
+  className,
+  keepMounted = false,
+}: TabsPanelProps) {
+  const { idPrefix } = useTabsContext();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [hasFocusable, setHasFocusable] = useState(false);
+  const isActive = tabId === activeTab;
+
+  useEffect(() => {
+    const panel = panelRef.current;
+    if (!panel) return;
+    setHasFocusable(panel.querySelector(FOCUSABLE_SELECTOR) !== null);
+  }, [children, isActive]);
+
+  if (!isActive && !keepMounted) return null;
+
+  return (
+    <div
+      ref={panelRef}
+      role="tabpanel"
+      id={`${idPrefix}-panel-${tabId}`}
+      aria-labelledby={`${idPrefix}-tab-${tabId}`}
+      hidden={!isActive}
+      tabIndex={hasFocusable ? undefined : 0}
+      className={className}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/design-system/Tabs/index.ts
+++ b/src/design-system/Tabs/index.ts
@@ -1,0 +1,11 @@
+import { TabsList, TabsRoot } from './Tabs';
+import { TabsPanel } from './TabsPanel';
+
+export const Tabs = {
+  Root: TabsRoot,
+  List: TabsList,
+  Panel: TabsPanel,
+};
+
+export type { TabItem, TabsListProps, TabsRootProps } from './Tabs';
+export type { TabsPanelProps } from './TabsPanel';

--- a/src/design-system/Textarea/Textarea.test.tsx
+++ b/src/design-system/Textarea/Textarea.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Textarea } from './Textarea';
+
+describe('Textarea', () => {
+  describe('rendering', () => {
+    it('renders a textarea element', () => {
+      render(<Textarea aria-label="Notes" />);
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    it('applies placeholder', () => {
+      render(<Textarea placeholder="Paste JSON here" aria-label="Import" />);
+      expect(screen.getByPlaceholderText('Paste JSON here')).toBeInTheDocument();
+    });
+
+    it('forwards native textarea props', () => {
+      render(<Textarea rows={3} readOnly aria-label="Notes" />);
+      const textarea = screen.getByRole('textbox');
+      expect(textarea).toHaveAttribute('rows', '3');
+      expect(textarea).toHaveAttribute('readonly');
+    });
+
+    it('applies className to the textarea', () => {
+      render(<Textarea className="min-h-[200px] flex-1" aria-label="Import" />);
+      expect(screen.getByRole('textbox')).toHaveClass('min-h-[200px]', 'flex-1');
+    });
+  });
+
+  describe('variants', () => {
+    it('applies font-mono when mono', () => {
+      render(<Textarea mono aria-label="Import" />);
+      expect(screen.getByRole('textbox')).toHaveClass('font-mono');
+    });
+
+    it('does not apply font-mono by default', () => {
+      render(<Textarea aria-label="Notes" />);
+      expect(screen.getByRole('textbox')).not.toHaveClass('font-mono');
+    });
+
+    it('applies resize-y by default', () => {
+      render(<Textarea aria-label="Notes" />);
+      expect(screen.getByRole('textbox')).toHaveClass('resize-y');
+    });
+
+    it('applies resize-none when resize is none', () => {
+      render(<Textarea resize="none" aria-label="Import" />);
+      expect(screen.getByRole('textbox')).toHaveClass('resize-none');
+      expect(screen.getByRole('textbox')).not.toHaveClass('resize-y');
+    });
+  });
+
+  describe('selectOnClick', () => {
+    it('selects content on click when selectOnClick', () => {
+      render(<Textarea selectOnClick readOnly value="{}" aria-label="Share data" />);
+      const textarea = screen.getByRole<HTMLTextAreaElement>('textbox');
+      textarea.select = vi.fn();
+      fireEvent.click(textarea);
+      expect(textarea.select).toHaveBeenCalled();
+    });
+
+    it('does not select content on click by default', () => {
+      render(<Textarea readOnly value="{}" aria-label="Share data" />);
+      const textarea = screen.getByRole<HTMLTextAreaElement>('textbox');
+      textarea.select = vi.fn();
+      fireEvent.click(textarea);
+      expect(textarea.select).not.toHaveBeenCalled();
+    });
+
+    it('still calls onClick when selectOnClick', () => {
+      const onClick = vi.fn();
+      render(
+        <Textarea selectOnClick onClick={onClick} readOnly value="{}" aria-label="Share data" />
+      );
+      fireEvent.click(screen.getByRole('textbox'));
+      expect(onClick).toHaveBeenCalled();
+    });
+  });
+
+  describe('character counter', () => {
+    it('renders the counter from value length and maxLength', () => {
+      render(
+        <Textarea showCount maxLength={500} value="hello" onChange={vi.fn()} aria-label="Notes" />
+      );
+      expect(screen.getByText('5/500')).toBeInTheDocument();
+    });
+
+    it('updates the counter when value changes', () => {
+      const { rerender } = render(
+        <Textarea showCount maxLength={500} value="hello" onChange={vi.fn()} aria-label="Notes" />
+      );
+      rerender(
+        <Textarea
+          showCount
+          maxLength={500}
+          value="hello world"
+          onChange={vi.fn()}
+          aria-label="Notes"
+        />
+      );
+      expect(screen.getByText('11/500')).toBeInTheDocument();
+    });
+
+    it('hides the counter from assistive technology', () => {
+      render(
+        <Textarea showCount maxLength={500} value="hi" onChange={vi.fn()} aria-label="Notes" />
+      );
+      expect(screen.getByText('2/500')).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('does not render a counter without showCount', () => {
+      render(<Textarea maxLength={500} value="hello" onChange={vi.fn()} aria-label="Notes" />);
+      expect(screen.queryByText('5/500')).not.toBeInTheDocument();
+    });
+
+    it('does not render a counter without maxLength', () => {
+      render(<Textarea showCount value="hello" onChange={vi.fn()} aria-label="Notes" />);
+      expect(screen.queryByText(/\/\d+$/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('value handling', () => {
+    it('passes maxLength through to the textarea', () => {
+      render(<Textarea maxLength={500} aria-label="Notes" />);
+      expect(screen.getByRole('textbox')).toHaveAttribute('maxlength', '500');
+    });
+
+    it('handles controlled value', () => {
+      render(<Textarea value="hello" onChange={vi.fn()} aria-label="Notes" />);
+      expect(screen.getByRole('textbox')).toHaveValue('hello');
+    });
+
+    it('calls onChange on input', () => {
+      const onChange = vi.fn();
+      render(<Textarea onChange={onChange} aria-label="Notes" />);
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'test' } });
+      expect(onChange).toHaveBeenCalled();
+    });
+  });
+
+  describe('disabled', () => {
+    it('disables the textarea', () => {
+      render(<Textarea disabled aria-label="Notes" />);
+      expect(screen.getByRole('textbox')).toBeDisabled();
+    });
+  });
+
+  describe('ref forwarding', () => {
+    it('forwards ref to the textarea element', () => {
+      const ref = vi.fn();
+      render(<Textarea ref={ref} aria-label="Notes" />);
+      expect(ref).toHaveBeenCalledWith(expect.any(HTMLTextAreaElement));
+    });
+  });
+});

--- a/src/design-system/Textarea/Textarea.tsx
+++ b/src/design-system/Textarea/Textarea.tsx
@@ -1,0 +1,145 @@
+import { forwardRef } from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '../cn';
+import { disabledStyles, focusRing, interactiveTransition } from '../variants';
+
+const textareaVariants = cva(
+  [
+    'w-full',
+    'bg-surface',
+    'border border-stroke',
+    'rounded-md',
+    'p-3',
+    'text-sm text-content',
+    'placeholder:text-content-disabled',
+    interactiveTransition,
+    'hover:border-stroke-strong',
+    ...focusRing,
+    ...disabledStyles,
+  ],
+  {
+    variants: {
+      mono: {
+        true: 'font-mono',
+      },
+      resize: {
+        none: 'resize-none',
+        vertical: 'resize-y',
+      },
+    },
+    defaultVariants: {
+      resize: 'vertical',
+    },
+  }
+);
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  /**
+   * Monospace styling for JSON paste/view areas.
+   * @default false
+   */
+  mono?: boolean;
+
+  /**
+   * Resize behavior. Use 'none' for fixed JSON panes.
+   * @default 'vertical'
+   */
+  resize?: 'none' | 'vertical';
+
+  /**
+   * Select the entire content on click.
+   * Read-only viewer affordance; keyboard select-all keeps working natively.
+   * @default false
+   */
+  selectOnClick?: boolean;
+
+  /**
+   * With maxLength, renders a 'length/maxLength' counter below the textarea.
+   * Requires a controlled value to count.
+   * @default false
+   */
+  showCount?: boolean;
+}
+
+/**
+ * Multi-line text input with consistent styling.
+ *
+ * Label association is the caller's responsibility (pair with a label via htmlFor).
+ *
+ * @example
+ * // Notes field with character counter
+ * <Textarea
+ *   rows={3}
+ *   value={notes}
+ *   onChange={e => setNotes(e.target.value)}
+ *   maxLength={500}
+ *   showCount
+ *   aria-label="Notes"
+ * />
+ *
+ * @example
+ * // Read-only JSON viewer
+ * <Textarea mono readOnly selectOnClick resize="none" value={json} aria-label="Share data" />
+ *
+ * @example
+ * // JSON paste area
+ * <Textarea
+ *   mono
+ *   resize="none"
+ *   className="min-h-[200px] flex-1"
+ *   placeholder="Paste layout JSON here"
+ *   value={input}
+ *   onChange={e => setInput(e.target.value)}
+ * />
+ */
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  (
+    {
+      mono = false,
+      resize = 'vertical',
+      selectOnClick = false,
+      showCount = false,
+      className,
+      onClick,
+      value,
+      maxLength,
+      ...props
+    },
+    ref
+  ) => {
+    const handleClick = (event: React.MouseEvent<HTMLTextAreaElement>): void => {
+      if (selectOnClick) {
+        event.currentTarget.select();
+      }
+      onClick?.(event);
+    };
+
+    const textarea = (
+      <textarea
+        ref={ref}
+        value={value}
+        maxLength={maxLength}
+        onClick={handleClick}
+        className={cn(textareaVariants({ mono, resize }), className)}
+        {...props}
+      />
+    );
+
+    if (!showCount) {
+      return textarea;
+    }
+
+    return (
+      <div className="w-full">
+        {textarea}
+        {maxLength !== undefined && (
+          <div className="text-right text-xs text-content-tertiary" aria-hidden="true">
+            {String(value ?? '').length}/{maxLength}
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+Textarea.displayName = 'Textarea';

--- a/src/design-system/Textarea/index.ts
+++ b/src/design-system/Textarea/index.ts
@@ -1,0 +1,2 @@
+export { Textarea } from './Textarea';
+export type { TextareaProps } from './Textarea';

--- a/src/design-system/Tooltip/Tooltip.test.tsx
+++ b/src/design-system/Tooltip/Tooltip.test.tsx
@@ -20,7 +20,7 @@ describe('Tooltip', () => {
           <button type="button">Trigger</button>
         </Tooltip>
       );
-      expect(screen.getByRole('tooltip')).toHaveClass('invisible', 'opacity-0');
+      expect(screen.getByRole('tooltip')).toHaveClass('opacity-0');
     });
 
     it('renders the shortcut in mono kbd styling', () => {
@@ -77,7 +77,7 @@ describe('Tooltip', () => {
         </Tooltip>
       );
       fireEvent.focus(screen.getByRole('button'));
-      expect(screen.getByRole('tooltip')).toHaveClass('visible', 'opacity-100');
+      expect(screen.getByRole('tooltip')).toHaveClass('opacity-100');
     });
 
     it('hides again when the trigger loses focus', () => {
@@ -89,7 +89,7 @@ describe('Tooltip', () => {
       const button = screen.getByRole('button');
       fireEvent.focus(button);
       fireEvent.blur(button);
-      expect(screen.getByRole('tooltip')).toHaveClass('invisible', 'opacity-0');
+      expect(screen.getByRole('tooltip')).toHaveClass('opacity-0');
     });
 
     it('becomes visible on hover and hides on leave', () => {
@@ -100,9 +100,9 @@ describe('Tooltip', () => {
       );
       const wrapper = screen.getByRole('tooltip').parentElement as HTMLElement;
       fireEvent.mouseEnter(wrapper);
-      expect(screen.getByRole('tooltip')).toHaveClass('visible', 'opacity-100');
+      expect(screen.getByRole('tooltip')).toHaveClass('opacity-100');
       fireEvent.mouseLeave(wrapper);
-      expect(screen.getByRole('tooltip')).toHaveClass('invisible', 'opacity-0');
+      expect(screen.getByRole('tooltip')).toHaveClass('opacity-0');
     });
 
     it('hides on Escape while focused', () => {
@@ -114,7 +114,7 @@ describe('Tooltip', () => {
       const button = screen.getByRole('button');
       fireEvent.focus(button);
       fireEvent.keyDown(button, { key: 'Escape' });
-      expect(screen.getByRole('tooltip')).toHaveClass('invisible', 'opacity-0');
+      expect(screen.getByRole('tooltip')).toHaveClass('opacity-0');
     });
 
     it('can show again after Escape dismissal once focus is lost and regained', () => {
@@ -128,7 +128,7 @@ describe('Tooltip', () => {
       fireEvent.keyDown(button, { key: 'Escape' });
       fireEvent.blur(button);
       fireEvent.focus(button);
-      expect(screen.getByRole('tooltip')).toHaveClass('visible', 'opacity-100');
+      expect(screen.getByRole('tooltip')).toHaveClass('opacity-100');
     });
 
     it('applies the show delay only while visible', () => {
@@ -145,16 +145,30 @@ describe('Tooltip', () => {
   });
 
   describe('accessibility', () => {
-    it('wires aria-describedby on the wrapper to the tooltip id', () => {
+    it('wires aria-describedby on the trigger element to the tooltip id', () => {
       render(
         <Tooltip content="Undo">
           <button type="button">Trigger</button>
         </Tooltip>
       );
       const tooltip = screen.getByRole('tooltip');
-      const wrapper = tooltip.parentElement as HTMLElement;
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
       expect(tooltip.id).not.toBe('');
-      expect(wrapper).toHaveAttribute('aria-describedby', tooltip.id);
+      expect(trigger).toHaveAttribute('aria-describedby', tooltip.id);
+      expect(tooltip.parentElement).not.toHaveAttribute('aria-describedby');
+    });
+
+    it('merges the tooltip id into an existing aria-describedby on the trigger', () => {
+      render(
+        <Tooltip content="Undo">
+          <button type="button" aria-describedby="existing-id">
+            Trigger
+          </button>
+        </Tooltip>
+      );
+      const tooltip = screen.getByRole('tooltip');
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+      expect(trigger).toHaveAttribute('aria-describedby', `existing-id ${tooltip.id}`);
     });
 
     it('works around disabled triggers without blocking them', () => {

--- a/src/design-system/Tooltip/Tooltip.test.tsx
+++ b/src/design-system/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Tooltip } from './Tooltip';
+
+describe('Tooltip', () => {
+  describe('rendering', () => {
+    it('renders children and tooltip content', () => {
+      render(
+        <Tooltip content="Undo">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      expect(screen.getByRole('button', { name: 'Trigger' })).toBeInTheDocument();
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Undo');
+    });
+
+    it('is hidden by default', () => {
+      render(
+        <Tooltip content="Undo">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      expect(screen.getByRole('tooltip')).toHaveClass('invisible', 'opacity-0');
+    });
+
+    it('renders the shortcut in mono kbd styling', () => {
+      render(
+        <Tooltip content="Undo" shortcut="⌘Z">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      const kbd = screen.getByText('⌘Z');
+      expect(kbd.tagName).toBe('KBD');
+      expect(kbd).toHaveClass('font-mono', 'text-content-tertiary');
+    });
+
+    it('omits the kbd element when no shortcut is given', () => {
+      render(
+        <Tooltip content="Undo">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      expect(screen.getByRole('tooltip').querySelector('kbd')).toBeNull();
+    });
+  });
+
+  describe('placement', () => {
+    it('defaults to top placement', () => {
+      render(
+        <Tooltip content="Undo">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      expect(screen.getByRole('tooltip')).toHaveClass('bottom-full');
+    });
+
+    it.each([
+      ['top', 'bottom-full'],
+      ['bottom', 'top-full'],
+      ['left', 'right-full'],
+      ['right', 'left-full'],
+    ] as const)('applies %s placement classes', (placement, expectedClass) => {
+      render(
+        <Tooltip content="Undo" placement={placement}>
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      expect(screen.getByRole('tooltip')).toHaveClass(expectedClass);
+    });
+  });
+
+  describe('interactions', () => {
+    it('becomes visible when the trigger receives focus', () => {
+      render(
+        <Tooltip content="Undo">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      fireEvent.focus(screen.getByRole('button'));
+      expect(screen.getByRole('tooltip')).toHaveClass('visible', 'opacity-100');
+    });
+
+    it('hides again when the trigger loses focus', () => {
+      render(
+        <Tooltip content="Undo">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      const button = screen.getByRole('button');
+      fireEvent.focus(button);
+      fireEvent.blur(button);
+      expect(screen.getByRole('tooltip')).toHaveClass('invisible', 'opacity-0');
+    });
+
+    it('becomes visible on hover and hides on leave', () => {
+      render(
+        <Tooltip content="Undo">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      const wrapper = screen.getByRole('tooltip').parentElement as HTMLElement;
+      fireEvent.mouseEnter(wrapper);
+      expect(screen.getByRole('tooltip')).toHaveClass('visible', 'opacity-100');
+      fireEvent.mouseLeave(wrapper);
+      expect(screen.getByRole('tooltip')).toHaveClass('invisible', 'opacity-0');
+    });
+
+    it('hides on Escape while focused', () => {
+      render(
+        <Tooltip content="Undo">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      const button = screen.getByRole('button');
+      fireEvent.focus(button);
+      fireEvent.keyDown(button, { key: 'Escape' });
+      expect(screen.getByRole('tooltip')).toHaveClass('invisible', 'opacity-0');
+    });
+
+    it('can show again after Escape dismissal once focus is lost and regained', () => {
+      render(
+        <Tooltip content="Undo">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      const button = screen.getByRole('button');
+      fireEvent.focus(button);
+      fireEvent.keyDown(button, { key: 'Escape' });
+      fireEvent.blur(button);
+      fireEvent.focus(button);
+      expect(screen.getByRole('tooltip')).toHaveClass('visible', 'opacity-100');
+    });
+
+    it('applies the show delay only while visible', () => {
+      render(
+        <Tooltip content="Undo" delayMs={500}>
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      const tooltip = screen.getByRole('tooltip');
+      expect(tooltip.getAttribute('style')).toContain('transition-delay: 0ms');
+      fireEvent.focus(screen.getByRole('button'));
+      expect(tooltip.getAttribute('style')).toContain('transition-delay: 500ms');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('wires aria-describedby on the wrapper to the tooltip id', () => {
+      render(
+        <Tooltip content="Undo">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      const tooltip = screen.getByRole('tooltip');
+      const wrapper = tooltip.parentElement as HTMLElement;
+      expect(tooltip.id).not.toBe('');
+      expect(wrapper).toHaveAttribute('aria-describedby', tooltip.id);
+    });
+
+    it('works around disabled triggers without blocking them', () => {
+      render(
+        <Tooltip content="Undo">
+          <button type="button" disabled>
+            Trigger
+          </button>
+        </Tooltip>
+      );
+      expect(screen.getByRole('button')).toBeDisabled();
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    });
+  });
+
+  describe('disabled', () => {
+    it('renders children only when disabled', () => {
+      render(
+        <Tooltip content="Undo" disabled>
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      expect(screen.getByRole('button', { name: 'Trigger' })).toBeInTheDocument();
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/design-system/Tooltip/Tooltip.tsx
+++ b/src/design-system/Tooltip/Tooltip.tsx
@@ -1,0 +1,134 @@
+import { useId, useState } from 'react';
+import type { KeyboardEvent, ReactNode } from 'react';
+import { cn } from '../cn';
+import { interactiveTransition } from '../variants';
+
+type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+const placementClasses: Record<TooltipPlacement, string> = {
+  top: 'bottom-full left-1/2 -translate-x-1/2 mb-1.5',
+  bottom: 'top-full left-1/2 -translate-x-1/2 mt-1.5',
+  left: 'right-full top-1/2 -translate-y-1/2 mr-1.5',
+  right: 'left-full top-1/2 -translate-y-1/2 ml-1.5',
+};
+
+export interface TooltipProps {
+  /**
+   * Tooltip text. Plain string only.
+   */
+  content: string;
+  /**
+   * Optional keyboard-shortcut suffix rendered in mono kbd styling after the content.
+   */
+  shortcut?: string;
+  /**
+   * Side of the trigger the bubble appears on.
+   * @default 'top'
+   */
+  placement?: TooltipPlacement;
+  /**
+   * Delay before the bubble fades in, in milliseconds.
+   * @default 300
+   */
+  delayMs?: number;
+  /**
+   * Render children without a tooltip (for conditional tooltips).
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * Trigger element(s) the tooltip describes.
+   */
+  children: ReactNode;
+}
+
+/**
+ * Accessible replacement for native `title=` attributes.
+ *
+ * Shows on hover and keyboard focus, hides on Escape, and is announced by
+ * screen readers via `role="tooltip"` + `aria-describedby`. Hidden entirely
+ * on touch-only devices. Wraps the trigger in a span so it also works on
+ * disabled buttons.
+ *
+ * @example
+ * <Tooltip content="Undo" shortcut="⌘Z">
+ *   <IconButton aria-label="Undo" icon={<UndoIcon />} />
+ * </Tooltip>
+ *
+ * @example
+ * // Vertical toolbar
+ * <Tooltip content="Rectangle" shortcut="R" placement="right">
+ *   <Button>...</Button>
+ * </Tooltip>
+ *
+ * @example
+ * // Conditional tooltip
+ * <Tooltip content="Switch to draw tool" disabled={isActive}>
+ *   <Button>Draw</Button>
+ * </Tooltip>
+ */
+export function Tooltip({
+  content,
+  shortcut,
+  placement = 'top',
+  delayMs = 300,
+  disabled = false,
+  children,
+}: TooltipProps): ReactNode {
+  const id = useId();
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  if (disabled) {
+    return <>{children}</>;
+  }
+
+  const visible = (hovered || focused) && !dismissed;
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLSpanElement>): void => {
+    if (e.key === 'Escape') {
+      setDismissed(true);
+    }
+  };
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions -- listeners only toggle tooltip visibility; the interactive child keeps its own semantics
+    <span
+      className="relative inline-flex"
+      aria-describedby={id}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => {
+        setHovered(false);
+        setDismissed(false);
+      }}
+      onFocus={() => setFocused(true)}
+      onBlur={() => {
+        setFocused(false);
+        setDismissed(false);
+      }}
+      onKeyDown={handleKeyDown}
+    >
+      {children}
+      <span
+        role="tooltip"
+        id={id}
+        className={cn(
+          'pointer-events-none absolute z-50 whitespace-nowrap',
+          'rounded-md border border-stroke-subtle bg-surface-elevated shadow-lg',
+          'px-2 py-1 text-xs text-content',
+          interactiveTransition,
+          placementClasses[placement],
+          visible ? 'visible opacity-100' : 'invisible opacity-0',
+          '[@media(hover:none)]:hidden'
+        )}
+        style={{ transitionDelay: visible ? `${delayMs}ms` : '0ms' }}
+      >
+        {content}
+        {shortcut !== undefined && (
+          <kbd className="ml-1.5 font-mono text-content-tertiary">{shortcut}</kbd>
+        )}
+      </span>
+    </span>
+  );
+}

--- a/src/design-system/Tooltip/Tooltip.tsx
+++ b/src/design-system/Tooltip/Tooltip.tsx
@@ -1,9 +1,13 @@
-import { useId, useState } from 'react';
-import type { KeyboardEvent, ReactNode } from 'react';
+import { cloneElement, isValidElement, useId, useState } from 'react';
+import type { KeyboardEvent, ReactElement, ReactNode } from 'react';
 import { cn } from '../cn';
 import { interactiveTransition } from '../variants';
 
 type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+function mergeDescribedBy(existing: string | undefined, id: string): string {
+  return existing ? `${existing} ${id}` : id;
+}
 
 const placementClasses: Record<TooltipPlacement, string> = {
   top: 'bottom-full left-1/2 -translate-x-1/2 mb-1.5',
@@ -92,11 +96,23 @@ export function Tooltip({
     }
   };
 
+  // Screen readers compute descriptions from the focused trigger element, not
+  // ancestors, so aria-describedby must live on the child itself.
+  const canAnnotateChild = isValidElement(children);
+  const trigger = canAnnotateChild
+    ? cloneElement(children as ReactElement<{ 'aria-describedby'?: string }>, {
+        'aria-describedby': mergeDescribedBy(
+          (children as ReactElement<{ 'aria-describedby'?: string }>).props['aria-describedby'],
+          id
+        ),
+      })
+    : children;
+
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions -- listeners only toggle tooltip visibility; the interactive child keeps its own semantics
     <span
       className="relative inline-flex"
-      aria-describedby={id}
+      aria-describedby={canAnnotateChild ? undefined : id}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => {
         setHovered(false);
@@ -109,7 +125,7 @@ export function Tooltip({
       }}
       onKeyDown={handleKeyDown}
     >
-      {children}
+      {trigger}
       <span
         role="tooltip"
         id={id}
@@ -119,7 +135,9 @@ export function Tooltip({
           'px-2 py-1 text-xs text-content',
           interactiveTransition,
           placementClasses[placement],
-          visible ? 'visible opacity-100' : 'invisible opacity-0',
+          // opacity-only hiding keeps the description in the accessibility
+          // tree (visibility:hidden would remove it).
+          visible ? 'opacity-100' : 'opacity-0',
           '[@media(hover:none)]:hidden'
         )}
         style={{ transitionDelay: visible ? `${delayMs}ms` : '0ms' }}

--- a/src/design-system/Tooltip/index.ts
+++ b/src/design-system/Tooltip/index.ts
@@ -1,0 +1,2 @@
+export { Tooltip } from './Tooltip';
+export type { TooltipProps } from './Tooltip';

--- a/src/design-system/docs/COMPONENTS.md
+++ b/src/design-system/docs/COMPONENTS.md
@@ -84,6 +84,41 @@ Toggle control for boolean values.
 
 ---
 
+## CheckboxRow
+
+Full-row checkbox: the entire row is the interactive checkbox, with a hover surface, optional trailing slot, and a display-only Checkbox visual.
+
+### Props
+
+| Prop       | Type                         | Default | Description                                       |
+| ---------- | ---------------------------- | ------- | ------------------------------------------------- |
+| `label`    | `string`                     | -       | Visible label text for the row                    |
+| `checked`  | `boolean`                    | -       | Whether the row is checked                        |
+| `onChange` | `(checked: boolean) => void` | -       | Called with the toggled value                     |
+| `trailing` | `ReactNode`                  | -       | Trailing slot before the checkbox (count Badge)   |
+| `disabled` | `boolean`                    | `false` | Disable interaction                               |
+| `indent`   | `boolean`                    | `false` | Nested sub-option indent with a left guide border |
+
+### Examples
+
+```tsx
+// Basic row
+<CheckboxRow label="Include labels" checked={includeLabels} onChange={setIncludeLabels} />
+
+// With a trailing count badge
+<CheckboxRow
+  label="Layer 1"
+  checked={selected}
+  onChange={setSelected}
+  trailing={<Badge>12</Badge>}
+/>
+
+// Nested sub-option
+<CheckboxRow indent label="Bin notes" checked={withNotes} onChange={setWithNotes} />
+```
+
+---
+
 ## Input
 
 Text input with optional icons.
@@ -582,4 +617,90 @@ Base SVG icon component.
 <Icon size="md">
   <path d="M12 2L2 7l10 5 10-5-10-5z" />
 </Icon>
+```
+
+---
+
+## Tabs
+
+ARIA-correct tabbed interface with roving tabindex and keyboard navigation.
+
+### Compound Components
+
+- `Tabs.Root` - Context provider wiring tab/panel ids (aria-controls / aria-labelledby)
+- `Tabs.List` - The tablist of tab buttons
+- `Tabs.Panel` - Content panel for one tab
+
+### Tabs.List Props
+
+| Prop          | Type                              | Default        | Description                                            |
+| ------------- | --------------------------------- | -------------- | ------------------------------------------------------ |
+| `tabs`        | `TabItem<T>[]`                    | **required**   | Tabs to render, in order                               |
+| `activeTab`   | `T`                               | **required**   | Id of the selected tab                                 |
+| `onChange`    | `(id: T) => void`                 | **required**   | Selection handler (click and keyboard)                 |
+| `aria-label`  | `string`                          | **required**   | Accessible name for the tablist                        |
+| `orientation` | `'horizontal' \| 'vertical'`      | `'horizontal'` | Layout and arrow-key axis                              |
+| `visual`      | `'underline' \| 'rail' \| 'pill'` | `'underline'`  | Active style: underline, side rail (vertical), or pill |
+| `fullWidth`   | `boolean`                         | `false`        | flex-1 equal-width tabs                                |
+| `className`   | `string`                          | -              | Additional tablist classes                             |
+
+### TabItem
+
+| Prop         | Type        | Default | Description                               |
+| ------------ | ----------- | ------- | ----------------------------------------- |
+| `id`         | `T`         | -       | Stable tab identifier                     |
+| `label`      | `ReactNode` | -       | Text, icon + label, or icon-only          |
+| `aria-label` | `string`    | -       | Accessible name (required when icon-only) |
+| `badge`      | `ReactNode` | -       | Trailing content such as a count          |
+| `disabled`   | `boolean`   | -       | Disabled tabs are skipped by keyboard nav |
+
+### Tabs.Panel Props
+
+| Prop          | Type      | Default      | Description                           |
+| ------------- | --------- | ------------ | ------------------------------------- |
+| `tabId`       | `string`  | **required** | Id of the tab this panel belongs to   |
+| `activeTab`   | `string`  | **required** | Id of the selected tab                |
+| `keepMounted` | `boolean` | `false`      | Keep mounted but hidden when inactive |
+| `className`   | `string`  | -            | Additional panel classes              |
+
+### Examples
+
+```tsx
+// Underline tabs with panels
+<Tabs.Root>
+  <Tabs.List
+    tabs={[
+      { id: 'general', label: 'General' },
+      { id: 'display', label: 'Display' },
+    ]}
+    activeTab={tab}
+    onChange={setTab}
+    aria-label="Settings"
+  />
+  <Tabs.Panel tabId="general" activeTab={tab}>General settings</Tabs.Panel>
+  <Tabs.Panel tabId="display" activeTab={tab} keepMounted>Display settings</Tabs.Panel>
+</Tabs.Root>
+
+// Vertical rail (settings sidebar)
+<Tabs.List
+  tabs={tabs}
+  activeTab={tab}
+  onChange={setTab}
+  aria-label="Settings"
+  orientation="vertical"
+  visual="rail"
+/>
+
+// Equal-width pills with a count badge
+<Tabs.List
+  tabs={[
+    { id: 'all', label: 'All', badge: 12 },
+    { id: 'mine', label: 'Mine', badge: 3 },
+  ]}
+  activeTab={tab}
+  onChange={setTab}
+  aria-label="Filter"
+  visual="pill"
+  fullWidth
+/>
 ```

--- a/src/design-system/docs/components.json
+++ b/src/design-system/docs/components.json
@@ -97,6 +97,44 @@
         "requirements": ["aria-label or label required"]
       }
     },
+    "CheckboxRow": {
+      "description": "Full-row checkbox with hover surface and trailing slot",
+      "category": "primitive",
+      "file": "CheckboxRow/CheckboxRow.tsx",
+      "props": {
+        "label": {
+          "type": "string",
+          "description": "Visible label text for the row"
+        },
+        "checked": {
+          "type": "boolean",
+          "description": "Whether the row is checked"
+        },
+        "onChange": {
+          "type": "(checked: boolean) => void",
+          "description": "Called with the toggled value"
+        },
+        "trailing": {
+          "type": "ReactNode",
+          "description": "Trailing slot before the checkbox (count Badge, etc.)"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable interaction"
+        },
+        "indent": {
+          "type": "boolean",
+          "default": false,
+          "description": "Nested sub-option indent with left guide border"
+        }
+      },
+      "accessibility": {
+        "role": "checkbox",
+        "keyboardNav": ["Space", "Enter"],
+        "requirements": ["single accessible checkbox; inner visual is aria-hidden"]
+      }
+    },
     "Input": {
       "description": "Text input with optional icons",
       "category": "primitive",
@@ -451,6 +489,59 @@
         "AlertTriangleIcon",
         "InfoIcon"
       ]
+    },
+    "Tabs": {
+      "description": "ARIA tablist with roving tabindex, keyboard navigation, and wired panels",
+      "category": "composite",
+      "file": "Tabs/Tabs.tsx",
+      "compound": true,
+      "subcomponents": ["Tabs.Root", "Tabs.List", "Tabs.Panel"],
+      "props": {
+        "tabs": {
+          "type": "TabItem[]",
+          "required": true,
+          "description": "Tabs to render: id, label, aria-label, badge, disabled"
+        },
+        "activeTab": {
+          "type": "string",
+          "required": true,
+          "description": "Id of the selected tab"
+        },
+        "onChange": {
+          "type": "(id: string) => void",
+          "required": true,
+          "description": "Selection handler for click and keyboard"
+        },
+        "aria-label": {
+          "type": "string",
+          "required": true,
+          "description": "Accessible name for the tablist"
+        },
+        "orientation": {
+          "type": "enum",
+          "values": ["horizontal", "vertical"],
+          "default": "horizontal"
+        },
+        "visual": {
+          "type": "enum",
+          "values": ["underline", "rail", "pill"],
+          "default": "underline"
+        },
+        "fullWidth": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "accessibility": {
+        "role": "tablist",
+        "features": [
+          "roving tabindex",
+          "arrow-key navigation per orientation",
+          "Home/End",
+          "disabled tabs skipped"
+        ],
+        "ariaAttributes": ["aria-orientation", "aria-selected", "aria-controls", "aria-labelledby"]
+      }
     }
   },
   "tokens": {

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -80,6 +80,42 @@ export type { ProgressBarProps } from './ProgressBar';
 export { Slider } from './Slider';
 export type { SliderProps } from './Slider';
 
+// IconButton
+export { IconButton } from './IconButton';
+export type { IconButtonProps } from './IconButton';
+
+// Tooltip
+export { Tooltip } from './Tooltip';
+export type { TooltipProps } from './Tooltip';
+
+// Card
+export { Card } from './Card';
+export type { CardProps } from './Card';
+
+// Badge
+export { Badge } from './Badge';
+export type { BadgeProps } from './Badge';
+
+// SegmentedControl
+export { SegmentedControl } from './SegmentedControl';
+export type { SegmentedControlProps, SegmentedControlOption } from './SegmentedControl';
+
+// Alert
+export { Alert } from './Alert';
+export type { AlertProps } from './Alert';
+
+// Kbd
+export { Kbd } from './Kbd';
+export type { KbdProps } from './Kbd';
+
+// Textarea
+export { Textarea } from './Textarea';
+export type { TextareaProps } from './Textarea';
+
+// ColorSwatch
+export { ColorSwatch } from './ColorSwatch';
+export type { ColorSwatchProps } from './ColorSwatch';
+
 // Composite Components
 
 // Stepper
@@ -90,13 +126,55 @@ export type { StepperProps } from './Stepper';
 export { Collapsible } from './Collapsible';
 export type { CollapsibleProps } from './Collapsible';
 
-// Dialog (compound: Dialog.Root, Dialog.Header, Dialog.Body, Dialog.Footer) + ConfirmDialog
-export { Dialog, ConfirmDialog } from './Dialog';
+// Field
+export { Field } from './Field';
+export type { FieldProps } from './Field';
+
+// EmptyState
+export { EmptyState } from './EmptyState';
+export type { EmptyStateProps } from './EmptyState';
+
+// Tabs (compound: Tabs.Root, Tabs.List, Tabs.Panel)
+export { Tabs } from './Tabs';
+export type { TabItem, TabsListProps, TabsPanelProps, TabsRootProps } from './Tabs';
+
+// CopyButton + CopyField
+export { CopyButton, CopyField } from './CopyButton';
+export type { CopyButtonProps, CopyFieldProps } from './CopyButton';
+
+// NavRow
+export { NavRow } from './NavRow';
+export type { NavRowProps } from './NavRow';
+
+// InlineEditText
+export { InlineEditText } from './InlineEditText';
+export type { InlineEditTextProps } from './InlineEditText';
+
+// CheckboxRow
+export { CheckboxRow } from './CheckboxRow';
+export type { CheckboxRowProps } from './CheckboxRow';
+
+// Dialog (compound: Root, Header, SubHeader, Body, Split, Sidebar, Pane, Footer) + ConfirmDialog + overlay behavior hooks
+export {
+  Dialog,
+  ConfirmDialog,
+  useFocusTrap,
+  useBodyScrollLock,
+  useDialogStack,
+  registerDialog,
+  unregisterDialog,
+  isTopmostDialog,
+} from './Dialog';
 export type {
   DialogProps,
   DialogHeaderProps,
+  DialogSubHeaderProps,
   DialogBodyProps,
+  DialogSplitProps,
+  DialogSidebarProps,
+  DialogPaneProps,
   DialogFooterProps,
+  DialogInitialFocus,
   ConfirmDialogProps,
 } from './Dialog';
 


### PR DESCRIPTION
## Summary

Foundation PR for the design-system migration: every UI built from here on can use one consistent, accessible component set instead of hand-rolled HTML. This PR adds the 16 primitives that recurring app patterns demanded, and extends Dialog so all 17 bespoke modal shells can migrate onto it in a follow-up.

### New primitives (rule of three: 3+ hand-rolled usages each)

| Primitive | Hand-rolled usages found |
|---|---|
| Tooltip | 115 |
| IconButton | 105 |
| Card | 36 |
| Badge | 26 |
| SegmentedControl | 19 |
| Alert | 19 |
| Field | 18 |
| EmptyState | 17 |
| Tabs | 10 |
| Kbd | 6 |
| Textarea / CopyButton / ColorSwatch | 5 each |
| NavRow | 4 |
| InlineEditText / CheckboxRow | 3 each |

Each ships as `src/design-system/<Name>/` with component, behavioral tests, and barrel export, consuming the shared CVA scales from `variants.ts`.

### Dialog extension (backward compatible)

- Size scale through `5xl` (`full` kept as deprecated alias of its current rendering)
- `height='fixed'` for stable-height tabbed/search content (Settings, Help)
- `fullScreen='mobile'` and static `mobilePresentation='sheet'` (gesture-driven BottomSheet intentionally stays separate)
- `dismissable`, `initialFocus`, keyboard containment (app shortcuts no longer fire inside dialogs)
- aria-labelledby/-describedby now only emitted when the matching part mounts (fixes dangling id refs)

All new Root props are optional with defaults reproducing current behavior; every existing call site compiles and renders unchanged.

### Verification

- `pnpm vitest run src/design-system`: 33 files, 525 tests passing
- `pnpm run typecheck` clean, eslint clean (one pre-existing-style max-lines warning on the expanded Dialog.tsx), knip clean

### Part of the design-system migration

Batch 1 of 6. Next: migrate ~100 allowlisted files' raw buttons onto Button/IconButton.