### PR TITLE
fix(baseplate): relieve split dovetail tongues from neighbour sockets

### DIFF
--- a/src/features/generation/worker/generators/baseplateConnectors.ts
+++ b/src/features/generation/worker/generators/baseplateConnectors.ts
@@ -51,8 +51,9 @@ import {
   sketch,
 } from './generatorTypes';
 import type { SnapClipLevels } from '@/shared/constants/connectors';
-import { computeCellBoundariesMm } from './cellDecomposition';
+import { computeCellBoundariesMm, decomposeCells } from './cellDecomposition';
 import { buildSingleCellSocket } from './socketBuilder';
+import { getPocketTemplate } from './baseplatePockets';
 
 /**
  * Half the separation between the tongue and groove of a paired connector,
@@ -64,13 +65,102 @@ import { buildSingleCellSocket } from './socketBuilder';
  */
 const PAIR_HALF_OFFSET = 4;
 
+/** Origin-centred cell spans (centre + size mm) along one grid axis. */
+interface CellSpan {
+  readonly center: number;
+  readonly size: number;
+}
+
+/**
+ * Cell centres + sizes along an axis, origin-centred to match the slab pockets
+ * (which are placed at {@link forEachCell} positions). Honours `fractionalEdge`
+ * so a half-cell at the start shifts the full cells like the pockets do.
+ */
+function cellSpansMm(
+  axisUnits: number,
+  gridUnitMm: number,
+  fractionalEdge: 'start' | 'end' = 'end'
+): CellSpan[] {
+  const cells = decomposeCells(axisUnits);
+  if (fractionalEdge === 'start') cells.reverse();
+  const totalMm = axisUnits * gridUnitMm;
+  const spans: CellSpan[] = [];
+  let pos = 0;
+  for (const u of cells) {
+    const size = u * gridUnitMm;
+    spans.push({ center: pos + size / 2 - totalMm / 2, size });
+    pos += size;
+  }
+  return spans;
+}
+
+/**
+ * Subtract the neighbouring piece's bin sockets from a fused dovetail tongue.
+ *
+ * The gridfinity socket mouth opens to the full cell at the slab top
+ * (`INSET_TOP = 0`), so a flat-topped tongue protruding across the seam pokes
+ * into the open socket where the neighbour's bin foot seats — worst in paired
+ * (`preferIdenticalPieces`) mode, where the tongue is offset `PAIR_HALF_OFFSET`
+ * (= the socket corner radius) onto the fully-open straight edge of the mouth.
+ *
+ * Cutting the actual socket pocket(s) back out of the tongue trims it to the
+ * grid's wall region, so the assembled plate's top matches an un-split plate and
+ * bins seat flush. The tongue keeps its sub-funnel material (the socket recedes
+ * with depth), so the dovetail still locks. Mirrors {@link relieveClipForSockets}.
+ *
+ * The neighbour column lies one full grid unit beyond the seam (`neighborProtrude`);
+ * only sockets the tongue actually reaches (within `reach` of its boundary
+ * position) are subtracted.
+ */
+function relieveTongueForSockets(
+  tongue: Shape3D,
+  bpTongue: number,
+  neighborProtrude: number,
+  protrudeAxis: 'x' | 'y',
+  boundaryCells: readonly CellSpan[],
+  gridUnitMm: number,
+  magnetHoles: boolean,
+  forExport: boolean
+): Shape3D {
+  // Tongue half-width at the tip plus its groove clearance and a small margin —
+  // the boundary-axis reach over which a neighbour socket can touch the tongue.
+  const reach = TONGUE_TIP_HALF + TONGUE_CLEARANCE + 0.5;
+  // Match the slab's pocket depth: through-cut without magnets, blind (socket
+  // region only) with magnets so the tongue keeps its floor/joint material.
+  const throughCut = !magnetHoles;
+  const cutters: ValidSolid[] = [];
+  for (const cell of boundaryCells) {
+    if (cell.center - cell.size / 2 >= bpTongue + reach) continue;
+    if (cell.center + cell.size / 2 <= bpTongue - reach) continue;
+    // Neighbour cell: full grid unit along the protrude axis, this cell's size
+    // along the boundary axis (the grid is continuous across the seam).
+    const pocket =
+      protrudeAxis === 'x'
+        ? getPocketTemplate(gridUnitMm, cell.size, forExport, throughCut)
+        : getPocketTemplate(cell.size, gridUnitMm, forExport, throughCut);
+    const pos: [number, number, number] =
+      protrudeAxis === 'x'
+        ? [neighborProtrude, cell.center, 0]
+        : [cell.center, neighborProtrude, 0];
+    const positioned = translate(pocket, pos);
+    pocket.delete();
+    cutters.push(positioned as ValidSolid);
+  }
+  if (cutters.length === 0) return tongue;
+  const relieved = unwrap(cutAll(tongue as ValidSolid, cutters));
+  for (const c of cutters) c.delete();
+  if (relieved !== tongue) tongue.delete();
+  return relieved;
+}
+
 export function buildConnectors(
   params: BaseplateParams,
   totalHeight: number,
   totalW: number,
   totalD: number,
   slabOffsetX: number,
-  slabOffsetY: number
+  slabOffsetY: number,
+  forExport: boolean = true
 ): { nubs: Shape3D[]; holes: Shape3D[] } {
   const { edges, connectorNubs, invertDovetails, preferIdenticalPieces } = params;
   const tongues: Shape3D[] = [];
@@ -118,6 +208,12 @@ export function buildConnectors(
   const yBoundaries = computeCellBoundariesMm(params.depth, gridUnit, params.fractionalEdgeY);
   const xBoundaries = computeCellBoundariesMm(params.width, gridUnit, params.fractionalEdgeX);
 
+  // Cell layout along each edge's boundary axis — used to subtract the
+  // neighbouring piece's sockets from each tongue (the grid is continuous across
+  // the seam, so the neighbour column shares this piece's boundary-axis cells).
+  const yCellSpans = cellSpansMm(params.depth, gridUnit, params.fractionalEdgeY);
+  const xCellSpans = cellSpansMm(params.width, gridUnit, params.fractionalEdgeX);
+
   type Side = 'left' | 'right' | 'front' | 'back';
 
   /**
@@ -140,6 +236,7 @@ export function buildConnectors(
     maleOffsetSign: -1 | 1;
     wallPos: number;
     boundaries: readonly number[];
+    boundaryCells: readonly CellSpan[];
     protrudeAxis: 'x' | 'y';
     protrudeDir: -1 | 1;
   }> = [
@@ -149,6 +246,7 @@ export function buildConnectors(
       maleOffsetSign: 1,
       wallPos: -halfW + slabOffsetX,
       boundaries: yBoundaries,
+      boundaryCells: yCellSpans,
       protrudeAxis: 'x',
       protrudeDir: -1,
     },
@@ -158,6 +256,7 @@ export function buildConnectors(
       maleOffsetSign: -1,
       wallPos: halfW + slabOffsetX,
       boundaries: yBoundaries,
+      boundaryCells: yCellSpans,
       protrudeAxis: 'x',
       protrudeDir: 1,
     },
@@ -167,6 +266,7 @@ export function buildConnectors(
       maleOffsetSign: -1,
       wallPos: -halfD + slabOffsetY,
       boundaries: xBoundaries,
+      boundaryCells: xCellSpans,
       protrudeAxis: 'y',
       protrudeDir: -1,
     },
@@ -176,10 +276,30 @@ export function buildConnectors(
       maleOffsetSign: 1,
       wallPos: halfD + slabOffsetY,
       boundaries: xBoundaries,
+      boundaryCells: xCellSpans,
       protrudeAxis: 'y',
       protrudeDir: 1,
     },
   ];
+
+  // Trim a freshly-built tongue back to the wall region so it can't poke into
+  // the neighbouring piece's open sockets across the seam (`bpTongue` is the
+  // tongue's centre along the edge's boundary axis).
+  const relieveTongue = (
+    tongue: Shape3D,
+    bpTongue: number,
+    def: (typeof edgeDefs)[number]
+  ): Shape3D =>
+    relieveTongueForSockets(
+      tongue,
+      bpTongue,
+      def.wallPos + def.protrudeDir * (gridUnit / 2),
+      def.protrudeAxis,
+      def.boundaryCells,
+      gridUnit,
+      params.magnetHoles,
+      forExport
+    );
 
   for (const def of edgeDefs) {
     if (edges[def.side] !== 'join' || def.boundaries.length === 0) continue;
@@ -205,10 +325,10 @@ export function buildConnectors(
       } else if (paired) {
         const mBp = bp + def.maleOffsetSign * PAIR_HALF_OFFSET;
         const fBp = bp - def.maleOffsetSign * PAIR_HALF_OFFSET;
-        tongues.push(makeTongue(pt, w, mBp, d, P, bW, tW, totalHeight));
+        tongues.push(relieveTongue(makeTongue(pt, w, mBp, d, P, bW, tW, totalHeight), mBp, def));
         grooves.push(makeGroove(pt, w, fBp, d, P, bW, tW, cl, ext, totalHeight));
       } else if (def.isMale) {
-        tongues.push(makeTongue(pt, w, bp, d, P, bW, tW, totalHeight));
+        tongues.push(relieveTongue(makeTongue(pt, w, bp, d, P, bW, tW, totalHeight), bp, def));
       } else {
         grooves.push(makeGroove(pt, w, bp, d, P, bW, tW, cl, ext, totalHeight));
       }

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -341,7 +341,8 @@ export function buildBaseplateSolid(
     totalW,
     totalD,
     slabOffsetX,
-    slabOffsetY
+    slabOffsetY,
+    forExport
   );
 
   if (nubs.length > 0 || connHoles.length > 0) {

--- a/src/features/generation/worker/generators/dovetailSocketInterference.test.ts
+++ b/src/features/generation/worker/generators/dovetailSocketInterference.test.ts
@@ -24,6 +24,7 @@ import type { BaseplateParams } from '@/shared/types/bin';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 import { buildConnectors } from './baseplateConnectors';
 import { buildSingleCellSocket } from './socketBuilder';
+import { decomposeCells } from './cellDecomposition';
 import { SOCKET_HEIGHT, MAGNET_FLOOR, CLEARANCE } from './generatorConstants';
 
 const vol = (s: Parameters<typeof measureVolume>[0]): number => {
@@ -58,8 +59,10 @@ const defaults = (o: Partial<BaseplateParams> = {}): BaseplateParams => ({
 
 /**
  * Total overlap volume between the fused tongues and the neighbouring piece's
- * bin feet across a left-hand seam. Each neighbour cell sits one grid unit
- * beyond the seam wall (−totalW/2 − GU/2) at every cell-row centre.
+ * bin feet across a left-hand seam. The neighbour column sits one grid unit
+ * beyond the seam wall (−totalW/2 − GU/2); its feet are placed at the real
+ * cell-decomposition centres (so this holds for fractional depths too) and each
+ * foot is sized to its cell (cell − CLEARANCE).
  */
 function tongueFootOverlap(params: BaseplateParams): { overlap: number; tongueVol: number } {
   const GU = params.gridUnitMm;
@@ -69,16 +72,22 @@ function tongueFootOverlap(params: BaseplateParams): { overlap: number; tongueVo
   const { nubs } = buildConnectors(params, totalHeight, totalW, totalD, 0, 0);
   try {
     const tongueVol = nubs.reduce((sum, n) => sum + vol(n), 0);
-    const footSz = GU - CLEARANCE;
-    const rows = Math.round(params.depth);
     const nx = -totalW / 2 - GU / 2;
     let overlap = 0;
-    for (let r = 0; r < rows; r++) {
-      const cy = -totalD / 2 + GU / 2 + r * GU;
-      const foot = translate(buildSingleCellSocket(footSz, footSz), [nx, cy, 0]);
+    let pos = 0;
+    for (const u of decomposeCells(params.depth)) {
+      const sizeMm = u * GU;
+      const cy = pos + sizeMm / 2 - totalD / 2;
+      pos += sizeMm;
+      const socket = buildSingleCellSocket(GU - CLEARANCE, sizeMm - CLEARANCE);
+      const foot = translate(socket, [nx, cy, 0]);
+      socket.delete(); // translate returns a new shape; free the pre-translate one
       for (const tongue of nubs) {
         const i = intersect(tongue, foot);
-        if (isOk(i)) overlap += vol(i.value);
+        if (isOk(i)) {
+          overlap += vol(i.value);
+          i.value.delete();
+        }
       }
       foot.delete();
     }

--- a/src/features/generation/worker/generators/dovetailSocketInterference.test.ts
+++ b/src/features/generation/worker/generators/dovetailSocketInterference.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+/**
+ * A split baseplate's integral dovetail tongues must not poke into the bin
+ * sockets of the neighbouring piece across the seam.
+ *
+ * The gridfinity socket mouth opens to the full cell at the slab top
+ * (`INSET_TOP = 0`). In "prefer identical pieces" (paired) mode the tongue is
+ * offset `PAIR_HALF_OFFSET` (4 mm — exactly the socket corner radius) off the
+ * cell-boundary junction, landing on the fully-open straight edge of the socket
+ * mouth. Un-relieved, each tongue drove ~2.4 mm³ of solid straight into where
+ * the neighbour's bin foot seats, so bins next to a seam wouldn't sit flush
+ * (user report: "dovetails do not follow the shape of the grid … I cut those
+ * small pieces with a knife"). `buildConnectors` now subtracts the neighbouring
+ * sockets from each tongue, mirroring `relieveClipForSockets` for the snap clip.
+ *
+ * The fix is verified by intersecting the fused tongues with the actual
+ * neighbour bin feet (cell − CLEARANCE) and requiring ~zero overlap, while the
+ * tongues keep enough material to still lock the joint.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { measureVolume, translate, intersect } from 'brepjs';
+import { isOk } from '@/core/result';
+import type { BaseplateParams } from '@/shared/types/bin';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import { buildConnectors } from './baseplateConnectors';
+import { buildSingleCellSocket } from './socketBuilder';
+import { SOCKET_HEIGHT, MAGNET_FLOOR, CLEARANCE } from './generatorConstants';
+
+const vol = (s: Parameters<typeof measureVolume>[0]): number => {
+  const r = measureVolume(s);
+  if (!isOk(r)) throw new Error('measureVolume failed');
+  return r.value;
+};
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+const defaults = (o: Partial<BaseplateParams> = {}): BaseplateParams => ({
+  width: 1,
+  depth: 3,
+  gridUnitMm: 42,
+  magnetHoles: false,
+  magnetDiameter: 6.5,
+  magnetDepth: 2.4,
+  paddingLeft: 0,
+  paddingRight: 0,
+  paddingFront: 0,
+  paddingBack: 0,
+  fractionalEdgeX: 'end',
+  fractionalEdgeY: 'end',
+  lightweight: true,
+  connectorNubs: true,
+  // A left join edge → tongues protrude across the seam (−x) into the neighbour.
+  edges: { left: 'join', right: 'exterior', front: 'exterior', back: 'exterior' },
+  ...o,
+});
+
+/**
+ * Total overlap volume between the fused tongues and the neighbouring piece's
+ * bin feet across a left-hand seam. Each neighbour cell sits one grid unit
+ * beyond the seam wall (−totalW/2 − GU/2) at every cell-row centre.
+ */
+function tongueFootOverlap(params: BaseplateParams): { overlap: number; tongueVol: number } {
+  const GU = params.gridUnitMm;
+  const totalHeight = SOCKET_HEIGHT + (params.magnetHoles ? MAGNET_FLOOR + params.magnetDepth : 0);
+  const totalW = params.width * GU;
+  const totalD = params.depth * GU;
+  const { nubs } = buildConnectors(params, totalHeight, totalW, totalD, 0, 0);
+  try {
+    const tongueVol = nubs.reduce((sum, n) => sum + vol(n), 0);
+    const footSz = GU - CLEARANCE;
+    const rows = Math.round(params.depth);
+    const nx = -totalW / 2 - GU / 2;
+    let overlap = 0;
+    for (let r = 0; r < rows; r++) {
+      const cy = -totalD / 2 + GU / 2 + r * GU;
+      const foot = translate(buildSingleCellSocket(footSz, footSz), [nx, cy, 0]);
+      for (const tongue of nubs) {
+        const i = intersect(tongue, foot);
+        if (isOk(i)) overlap += vol(i.value);
+      }
+      foot.delete();
+    }
+    return { overlap, tongueVol };
+  } finally {
+    for (const n of nubs) n.delete();
+  }
+}
+
+describe('integral dovetail tongue vs neighbour edge-socket interference', () => {
+  it('paired-mode tongues do not intrude into the neighbour bin feet', () => {
+    const { overlap, tongueVol } = tongueFootOverlap(defaults({ preferIdenticalPieces: true }));
+    // Un-relieved paired tongues overlapped the feet by ~4.9 mm³ (2 tongues).
+    expect(overlap, 'tongue ∩ neighbour feet').toBeLessThan(0.02);
+    // …while keeping enough material to still lock the joint (was ~34.7 mm³).
+    expect(tongueVol, 'tongues retain locking material').toBeGreaterThan(12);
+  }, 60_000);
+
+  it('plain junction-centred tongues also clear the neighbour bin feet', () => {
+    const { overlap } = tongueFootOverlap(defaults());
+    expect(overlap, 'tongue ∩ neighbour feet').toBeLessThan(0.02);
+  }, 60_000);
+
+  it('magnet-plate paired tongues clear the neighbour bin feet', () => {
+    const { overlap } = tongueFootOverlap(
+      defaults({ magnetHoles: true, preferIdenticalPieces: true })
+    );
+    expect(overlap, 'tongue ∩ neighbour feet').toBeLessThan(0.02);
+  }, 60_000);
+});


### PR DESCRIPTION
## Problem

A user reported that on a **split baseplate**, the dovetail joints "do not completely follow the shape of the grid … bins do not sit completely snug"

## Root cause

In `buildBaseplateSolid`, dovetail **tongues are fused onto the slab edge *after* the socket pockets are carved** (`baseplateGenerator.ts`), as flat-topped full-height prisms. The gridfinity socket mouth opens to the **full cell at the slab top** (`INSET_TOP = 0`), so a tongue protruding across the seam pokes into the neighbouring piece's open socket — exactly where the bin foot seats.

It's worst in **"prefer identical pieces" (paired) mode**: to make opposite-corner pieces share one STL, paired mode offsets each tongue by `PAIR_HALF_OFFSET` (4 mm — *exactly* the socket corner radius), landing it on the fully-open straight edge of the socket mouth.

I measured the intrusion (tongue ∩ neighbour bin foot) before fixing:

| Config | Foot overlap | 
|---|---|
| Plain / inverted / magnet (junction-centred) | **0.0000 mm³** |
| **Paired (`preferIdenticalPieces`)** | **2.44 mm³ / tongue** |
| Paired, depth-3 (2 tongues) | **4.88 mm³** |
| Dovetail key | **0.0000 mm³** |

So the bin-blocking case is the **paired-mode integral tongue**. The plain tongue and the dovetail key only graze the 0.25 mm clearance gap (foot overlap 0), so they're left as-is.

## Fix

`buildConnectors` now subtracts the neighbouring piece's socket pockets from each fused tongue, trimming it back to the grid's wall region — the assembled plate's top then matches an un-split plate and bins seat flush. The tongue keeps its sub-funnel material (the socket recedes with depth), so the dovetail still locks. This mirrors `relieveClipForSockets()`, which already solved the same problem for the snap-clip style.

The relief is surgical: paired-mode foot overlap drops **4.88 → ~0 mm³** while the tongues retain **>80%** of their volume.

## Tests

New `dovetailSocketInterference.test.ts` intersects the fused tongues with the actual neighbour bin feet (cell − CLEARANCE) and requires ~zero overlap, plus an over-cut guard. Watched it fail (paired = 4.88 mm³) before implementing.

- ✅ new interference tests (paired, plain, magnet)
- ✅ full generators suite (127 files / 1489 tests), baseplate-feature + connector suites (487 tests) — no regressions
- ✅ dovetail / dovetailKey / snapClip / split-stress watertight scenarios
- ✅ typecheck, lint, knip