### PR TITLE
fix(label-tabs): trim tab corners flush with the bin's rounded outer wall

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.label-corner-overhang.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.label-corner-overhang.test.ts
@@ -6,8 +6,8 @@
  * inner-wall planes, so a full-width tab's square corner sits outside the
  * rounded wall whenever `wt < BOX_CORNER_RADIUS·(1 − 1/√2) ≈ 1.10mm` — i.e.
  * for the 0.4 / 0.6 / 0.8mm wall-thickness presets. Most visible on small
- * bins, where the tab reaches both corners (Reddit report). `clipToOuter
- * Footprint` trims the slivers flush with the wall.
+ * bins, where the tab reaches both corners (Reddit report).
+ * `clipToOuterFootprint` trims the slivers flush with the wall.
  *
  * Footprint is taken from the NO-label bin (the with-label bbox would be
  * inflated by the overhang itself); a self-baseline over the no-label mesh

--- a/src/features/generation/worker/generators/binGenerator.scenario.label-corner-overhang.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.label-corner-overhang.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+/**
+ * Regression: a label tab must not poke past the bin's rounded outer corner.
+ *
+ * The shelf is an axis-aligned rectangle anchored to the nominal flat
+ * inner-wall planes, so a full-width tab's square corner sits outside the
+ * rounded wall whenever `wt < BOX_CORNER_RADIUS·(1 − 1/√2) ≈ 1.10mm` — i.e.
+ * for the 0.4 / 0.6 / 0.8mm wall-thickness presets. Most visible on small
+ * bins, where the tab reaches both corners (Reddit report). `clipToOuter
+ * Footprint` trims the slivers flush with the wall.
+ *
+ * Footprint is taken from the NO-label bin (the with-label bbox would be
+ * inflated by the overhang itself); a self-baseline over the no-label mesh
+ * absorbs corner-radius/tessellation noise so the delta isolates the tab.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DEFAULT_BIN_PARAMS, GRIDFINITY } from '@/shared/constants/bin';
+import type { BinParams } from '@/shared/types/bin';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+import { boundingBox } from './__kernel-tests__/meshAssertions';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+const R = GRIDFINITY.BOX_CORNER_RADIUS; // outer corner radius (mm)
+
+interface Footprint {
+  cx: number;
+  cy: number;
+  halfW: number;
+  halfD: number;
+}
+
+/** Signed distance OUTSIDE the rounded-rect footprint (>0 means poking out). */
+function outsideRoundedRect(x: number, y: number, fp: Footprint): number {
+  const dx = Math.abs(x - fp.cx) - (fp.halfW - R);
+  const dy = Math.abs(y - fp.cy) - (fp.halfD - R);
+  const corner = Math.hypot(Math.max(dx, 0), Math.max(dy, 0)) - R;
+  const edge = Math.min(Math.max(dx, dy), 0);
+  return corner + edge;
+}
+
+function footprintOf(vertices: Float32Array): Footprint {
+  const bb = boundingBox(vertices);
+  return {
+    cx: (bb.minX + bb.maxX) / 2,
+    cy: (bb.minY + bb.maxY) / 2,
+    halfW: (bb.maxX - bb.minX) / 2,
+    halfD: (bb.maxY - bb.minY) / 2,
+  };
+}
+
+function maxOutside(vertices: Float32Array, fp: Footprint): number {
+  let m = 0;
+  for (let i = 0; i < vertices.length; i += 3) {
+    const d = outsideRoundedRect(vertices[i], vertices[i + 1], fp);
+    if (d > m) m = d;
+  }
+  return m;
+}
+
+describe('label tab corner overhang', () => {
+  it('thin-wall 1×1 tab stays within the rounded outer corner', () => {
+    // 0.8mm wall (a UI preset) is below the ~1.10mm overhang threshold; the
+    // unclipped tab pokes ~0.42mm past the corner.
+    const base: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 1,
+      depth: 1,
+      height: 3,
+      wallThickness: 0.8,
+    };
+    const noLabel = getGenerateBin()({ ...base, label: { ...base.label, enabled: false } });
+    const withLabel = getGenerateBin()({ ...base, label: { ...base.label, enabled: true } });
+
+    // Guard against a vacuous pass: the tab must actually be generated.
+    expect(withLabel.triangleCount).toBeGreaterThan(noLabel.triangleCount);
+
+    const fp = footprintOf(noLabel.vertices);
+    const overhang = maxOutside(withLabel.vertices, fp) - maxOutside(noLabel.vertices, fp);
+    expect(overhang).toBeLessThan(0.05);
+  });
+});

--- a/src/features/generation/worker/generators/labelTabBuilder.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.ts
@@ -193,6 +193,12 @@ function clipToOuterFootprint(
   dims: TabBuildDimensions
 ): Shape3D {
   const { innerW, innerD, wallThickness, shelfTopZ, tabHeight } = dims;
+
+  // A tab corner can only poke past the rounded outer corner when
+  // wt < R·(1 − 1/√2); at or above that the intersect is a guaranteed no-op,
+  // so skip the boolean for the common (default 1.2mm) wall.
+  if (wallThickness >= BOX_CORNER_RADIUS * (1 - Math.SQRT1_2)) return tabs;
+
   const outerW = innerW + 2 * wallThickness;
   const outerD = innerD + 2 * wallThickness;
   try {

--- a/src/features/generation/worker/generators/labelTabBuilder.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.ts
@@ -5,8 +5,20 @@
  * at the back edge of each compartment.
  */
 
-import { draw, unwrap, fuseAll, fuse, cut, intersect, translate, withScope, clone } from 'brepjs';
+import {
+  draw,
+  drawRoundedRectangle,
+  unwrap,
+  fuseAll,
+  fuse,
+  cut,
+  intersect,
+  translate,
+  withScope,
+  clone,
+} from 'brepjs';
 import type { Shape3D, ValidSolid, Drawing, DisposalScope } from 'brepjs';
+import { BOX_CORNER_RADIUS } from './generatorConstants';
 import type { BinParams, TextStyleDefaults, TextStyleOverride } from '@/shared/types/bin';
 import {
   compartmentHasTiltedBackWall,
@@ -152,8 +164,49 @@ function buildLabelTabsInScope(
   }
 
   if (allTabs.length === 0) return null;
-  if (allTabs.length === 1) return allTabs[0]; // already scope-registered
-  return scope.register(unwrap(fuseAll(allTabs as ValidSolid[])));
+  const assembled =
+    allTabs.length === 1
+      ? allTabs[0] // already scope-registered
+      : scope.register(unwrap(fuseAll(allTabs as ValidSolid[])));
+
+  return clipToOuterFootprint(scope, assembled, dims);
+}
+
+/**
+ * Clip the assembled tabs to the bin's outer rounded-corner footprint.
+ *
+ * Tabs are axis-aligned rectangles anchored to the nominal flat inner-wall
+ * planes, so a wall-touching corner can poke past the bin's rounded outer
+ * corner. This happens when `wt < BOX_CORNER_RADIUS·(1 − 1/√2) ≈ 1.10mm`:
+ * the square corner sits outside the rounded wall and juts into open air.
+ * It's most visible on small bins, where a full-width tab reaches both
+ * corners and the fixed-size poke is a large fraction of the short wall.
+ *
+ * Intersecting with a prism of the outer footprint trims those slivers flush
+ * with the wall. It's a no-op for thicker walls and for interior-divider tabs
+ * that never reach the perimeter. Best-effort: keep the un-clipped tabs if the
+ * boolean throws (mirrors the per-tab support/text fallbacks above).
+ */
+function clipToOuterFootprint(
+  scope: DisposalScope,
+  tabs: Shape3D,
+  dims: TabBuildDimensions
+): Shape3D {
+  const { innerW, innerD, wallThickness, shelfTopZ, tabHeight } = dims;
+  const outerW = innerW + 2 * wallThickness;
+  const outerD = innerD + 2 * wallThickness;
+  try {
+    const footprint = scope.register(
+      sketch(
+        drawRoundedRectangle(outerW, outerD, BOX_CORNER_RADIUS),
+        'XY',
+        shelfTopZ - tabHeight - 0.1
+      ).extrude(tabHeight + 0.2)
+    );
+    return scope.register(unwrap(intersect(tabs as ValidSolid, footprint as ValidSolid)));
+  } catch {
+    return tabs;
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

On bins with thin walls, a label tab's square corner pokes out past the bin's **rounded** outer corner — a visible ledge "sticking out of the wall." Most noticeable on small (e.g. 1×1) bins where a full-width tab reaches into both rounded corners. (Reported on Reddit.)

## Root cause

The shelf is built as an axis-aligned rectangle anchored to the *nominal flat* inner-wall planes (`±innerW/2`), but the bin's outer corner is rounded (`BOX_CORNER_RADIUS = 3.75mm`). The square corner sits outside the rounded wall whenever:

```
wt < BOX_CORNER_RADIUS · (1 − 1/√2) ≈ 1.10mm
```

i.e. the **0.4 / 0.6 / 0.8mm** wall-thickness presets. The 1.2mm default is just above the threshold, so it isn't always visible. Measured **0.42mm** overhang at wt=0.8 on a 1×1 bin.

## Fix

`clipToOuterFootprint()` intersects the assembled tabs with a prism of the bin's outer rounded-rect footprint, trimming any wall-touching corner flush with the wall. It is a **no-op** for thicker walls and for interior-divider tabs that never reach the perimeter.

## Verification

- New regression test (`binGenerator.scenario.label-corner-overhang.test.ts`): builds the real mesh and asserts the label tab stays within the bin's outer footprint (overhang 0.42mm → ~0), with a guard that the tab is actually generated.
- Existing label-tab scenario snapshots **unchanged** (confirms the clip is a true no-op on the default thick walls).
- `tsc` + `eslint` clean.
