### PR TITLE
refactor(design-system): migrate raw buttons to Button/IconButton

### DIFF
--- a/scripts/design-system-allowlist.txt
+++ b/scripts/design-system-allowlist.txt
@@ -15,157 +15,45 @@
 #
 
 # App-level components
-src/App.tsx
-src/shell/Collab/PresenceAvatarBar/PresenceAvatarBar.tsx
-src/shell/Collab/PresenceDropdown/PresenceDropdown.tsx
-src/shell/Collab/PresenceMobileButton/PresenceMobileButton.tsx
-src/shell/ErrorBoundary/ErrorBoundary.tsx
-src/shell/Header/Header.tsx
-src/shell/PanelErrorBoundary/PanelErrorBoundary.tsx
-src/shell/RightPanel/RightPanel.tsx
-src/shell/Sidebar/Sidebar.tsx
-src/shell/STLSearchDropdown/STLSearchDropdown.tsx
 
 # Mobile components
-src/shell/Mobile/BottomNavBar/BottomNavBar.tsx
-src/shell/Mobile/BottomSheet/BottomSheet.tsx
-src/shell/Mobile/MobileCategoriesPanel/MobileCategoriesPanel.tsx
-src/shell/Mobile/MobileGridToolbar/MobileGridToolbar.tsx
-src/shell/Mobile/MobileHeader/MobileHeader.tsx
-src/shell/Mobile/MobileHelpModal/MobileHelpModal.tsx
-src/shell/Mobile/MobileLayersPanel/LayersTab/LayersTab.tsx
-src/shell/Mobile/MobileLayersPanel/TabBar/TabBar.tsx
-src/shell/Mobile/MobileLayersPanel/ToolsTab/ToolsTab.tsx
-src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanel.tsx
-src/shell/Mobile/MobilePrintList/MobilePrintList.tsx
-src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
-src/shell/Mobile/MultiBinContextMenu/MultiBinContextMenu.tsx
 
 # Tablet components
-src/shell/Tablet/TabletPanelTriggers/TabletPanelTriggers.tsx
 
 # Modal components
-src/shell/Modals/BinListModal/BinListDashboard/BinListDashboard.tsx
-src/shell/Modals/BinListModal/BinListFilters/BinListFilters.tsx
-src/shell/Modals/BinListModal/BinListModal.tsx
-src/shell/Modals/BinListModal/BulkActions/BulkActions.tsx
-src/shell/Modals/BinListModal/MobileBinList/MobileBinList.tsx
-src/shell/Modals/HalfBinModeBlockedModal/HalfBinModeBlockedModal.tsx
-src/shell/Modals/HelpModal/HelpModal.tsx
-src/shell/Modals/ImportModal/ImportModal.tsx
-src/shell/Modals/SettingsModal/SettingsModal.tsx
-src/shell/Modals/SettingsModal/TabNavigation/TabNavigation.tsx
-src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
-src/shell/Modals/WelcomeModal/WelcomeModal.tsx
 
 # Bin designer feature
-src/features/bin-designer/components/CartDialog/CartDialog.tsx
-src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
-src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.tsx
-src/features/bin-designer/components/controls/ThicknessSelector/ThicknessSelector.tsx
-src/features/bin-designer/components/DesignActions/DesignActions.tsx
-src/features/bin-designer/components/DesignerPage/DesignerPage.tsx
-src/features/bin-designer/components/DesignImportView/DesignImportView.tsx
-src/features/bin-designer/components/DesignListDialog/DesignListDialog.tsx
-src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
-src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
-src/features/bin-designer/components/panel/FeatureToggle/FeatureToggle.tsx
-src/features/bin-designer/components/panel/InteriorSection/InteriorSection.tsx
-src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
-src/features/bin-designer/components/panel/CutoutsSection/AlignmentToolbar.tsx
-src/features/bin-designer/components/panel/CutoutsSection/CutoutPropertyPanel.tsx
-src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeToolbar.tsx
-src/features/bin-designer/components/panel/CutoutsSection/CutoutContextMenu.tsx
-src/features/bin-designer/components/panel/CutoutsSection/CutoutsSection.tsx
-src/features/bin-designer/components/CutoutWorkspace/InspectorPanel.tsx
 src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.tsx
 src/features/bin-designer/components/panel/WallsSection/PatternSelector.tsx
-src/features/bin-designer/components/preview/PreviewControls/PreviewControls.tsx
-src/features/bin-designer/components/preview/PreviewSkeleton/PreviewSkeleton.tsx
-src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
-src/features/bin-designer/components/ShareDialog/ShareDialog.tsx
-src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.tsx
 
 # Bin inspector feature
-src/features/bin-inspector/components/Inspector/CustomPropertiesEditor/CustomPropertiesEditor.tsx
-src/features/bin-inspector/components/Inspector/MultiBinInspector/MultiBinInspector.tsx
-src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
 
 # Categories feature
-src/features/categories/components/CategoriesPanel/CategoriesPanel.tsx
 
 # Cloud share feature
 src/features/cloud-share/components/CloudShareTab/CloudShareTab.tsx
-src/features/cloud-share/components/ShareButton/ShareButton.tsx
-src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.tsx
-src/features/cloud-share/components/ShareModal/ShareModal.tsx
 
 # Design linking feature
-src/features/design-linking/components/Dialogs/CreateDesignDialog/CreateDesignDialog.tsx
-src/features/design-linking/components/Dialogs/DeleteDesignWarningDialog/DeleteDesignWarningDialog.tsx
-src/features/design-linking/components/Dialogs/LinkDesignDialog/LinkDesignDialog.tsx
-src/features/design-linking/components/Dialogs/SyncDimensionsDialog/SyncDimensionsDialog.tsx
-src/features/design-linking/components/LinkedDesignSection/LinkedDesignSection.tsx
 
 # Grid editor feature
-src/features/grid-editor/components/Grid/GridAxisLabels/GridAxisLabels.tsx
-src/features/grid-editor/components/Grid/GridToolbar/GridToolbar.tsx
-src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
-src/features/grid-editor/components/Grid/QuickLabelPopover/QuickLabelPopover.tsx
 
 # Inspiration gallery feature
-src/features/inspiration-gallery/components/InspirationGallery/InspirationGallery.tsx
-src/features/inspiration-gallery/components/LayoutPreviewOverlay/LayoutPreviewOverlay.tsx
-src/features/inspiration-gallery/components/ThemeFilterPills/ThemeFilterPills.tsx
 
 # Labs feature
-src/features/labs/components/FeatureCard/FeatureCard.tsx
-src/features/labs/components/GraduatedSection/GraduatedSection.tsx
-src/features/labs/components/LabsButton/LabsButton.tsx
-src/features/labs/components/LabsDrawer/LabsDrawer.tsx
 
 # Layers feature
-src/features/layers/components/ActiveLayerPanel/ActiveLayerPanel.tsx
-src/features/layers/components/LayerPanel/LayerPanel.tsx
 
 # Layout library feature
-src/features/layout-library/components/LayoutManagerModal/ImportView/ImportView.tsx
-src/features/layout-library/components/LayoutManagerModal/LayoutActions/LayoutActions.tsx
 src/features/layout-library/components/LayoutManagerModal/LayoutList/LayoutList.tsx
-src/features/layout-library/components/LayoutManagerModal/LayoutManagerModal.tsx
-src/features/layout-library/components/LayoutManagerModal/NewLayoutCard/NewLayoutCard.tsx
-src/features/layout-library/components/LayoutManagerModal/SharedWithMeItem/SharedWithMeItem.tsx
 
 # Name suggestions feature
-src/features/name-suggestions/components/NameFieldHighlight/NameFieldHighlight.tsx
-src/features/name-suggestions/components/SuggestionPopover/SuggestionPopover.tsx
 
 # Print export feature
-src/features/print-export/components/PrintModal/PrintModal.tsx
-src/features/print-export/components/SortOrderConfig/SortOrderConfig.tsx
 
 # Staging feature
-src/features/staging/components/Staging/Staging.tsx
 
 # i18n
-src/i18n/context.tsx
 
 # Shared components
-src/shared/components/CompactNumberInput/CompactNumberInput.tsx
-src/shared/components/BulkIncrementControl/BulkIncrementControl.tsx
-src/shared/components/CollapsibleSection/CollapsibleSection.tsx
-src/shared/components/ConfirmDialog/ConfirmDialog.tsx
-src/shared/components/ContextMenu/ContextMenuItem/ContextMenuItem.tsx
-src/shared/components/ItemListShell/ItemSearch/ItemSearch.tsx
 src/shared/components/ItemListShell/SortDropdown/SortDropdown.tsx
-src/shared/components/LanguageSelector/LanguageSelector.tsx
 src/shared/components/SelectDropdown/SelectDropdown.tsx
-src/shared/components/StepperControl/StepperControl.tsx
-src/shared/components/Toast/Toast.tsx
-src/shared/components/ToolSwitcher/ToolSwitcher.tsx
-src/shared/components/TwoClickDeleteButton/TwoClickDeleteButton.tsx
-src/shared/components/ViewModeToggle/ViewModeToggle.tsx
-src/features/bin-designer/components/DesignListDialog/TagInput/TagInput.tsx
-src/features/bin-designer/components/DesignListDialog/TagFilterBar/TagFilterBar.tsx
-src/features/bin-designer/components/DesignListDialog/BulkActionBar/BulkActionBar.tsx
-src/features/layout-library/components/LayoutQuickSwitch/LayoutQuickSwitch.tsx

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
@@ -21,6 +21,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useSettingsStore } from '@/core/store/settings';
 import { DESIGNER_CONSTRAINTS, WALL_THICKNESS_OPTIONS } from '@/features/bin-designer/constants';
+import { Button } from '@/design-system';
 import { StepperControl } from '@/shared/components/StepperControl';
 import { DeferredNumberInput } from '@/shared/components/DeferredNumberInput';
 import { SnappingSlider } from '../controls/SnappingSlider';
@@ -523,11 +524,12 @@ export function CompartmentEditor() {
 
         {/* Advanced: set the grid by a minimum compartment size in mm. */}
         <div>
-          <button
+          <Button
             type="button"
+            variant="ghost"
             onClick={() => setShowSizer((v) => !v)}
             aria-expanded={showSizer}
-            className="flex items-center gap-1 text-[11px] font-medium text-content-secondary hover:text-content"
+            className="flex items-center gap-1 rounded-none px-0 py-0 hover:bg-transparent text-[11px] font-medium text-content-secondary hover:text-content"
           >
             <svg
               className={`h-3 w-3 transition-transform ${showSizer ? 'rotate-90' : ''}`}
@@ -540,7 +542,7 @@ export function CompartmentEditor() {
               <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
             </svg>
             {t('binDesigner.compartmentEditor.setBySize')}
-          </button>
+          </Button>
 
           {showSizer && (
             <div className="mt-2 space-y-2 border-l border-stroke-subtle pl-3">
@@ -607,14 +609,15 @@ export function CompartmentEditor() {
               {instructionText}
             </p>
             {hasMergedCompartments && (
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 onClick={handleReset}
-                className="text-[11px] font-medium text-accent hover:text-accent/80 transition-colors"
+                className="rounded-none px-0 py-0 hover:bg-transparent text-[11px] font-medium text-accent hover:text-accent/80 transition-colors"
                 aria-label={t('binDesigner.resetCompartmentLayoutToUniformGrid')}
               >
                 {t('common.reset')}
-              </button>
+              </Button>
             )}
           </div>
           <div

--- a/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.tsx
@@ -9,6 +9,7 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import type { Cutout, GroupOp, ReorderDirection } from '@/features/bin-designer/types';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { Button, IconButton } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog/ConfirmDialog';
 import {
@@ -141,14 +142,17 @@ function AutoArrangePopover({
 
   return (
     <div ref={popoverRef} className="relative">
-      <button
+      <Button
         type="button"
-        className="rounded p-1 text-[11px] text-content-secondary hover:bg-surface-hover hover:text-content transition-colors"
+        variant="ghost"
+        size="sm"
+        touchTarget={false}
+        className="text-[11px] text-content-secondary"
         onClick={() => setOpen(!open)}
         title={t('binDesigner.cutouts.autoArrange')}
       >
         {t('binDesigner.cutouts.autoArrange')}
-      </button>
+      </Button>
       {open && (
         <div className="absolute top-full left-0 z-50 mt-1 rounded-lg border border-stroke-subtle bg-surface-elevated p-2 shadow-lg">
           <div className="flex flex-col gap-1.5">
@@ -166,16 +170,19 @@ function AutoArrangePopover({
                 />
                 mm
               </label>
-              <button
+              <Button
                 type="button"
-                className="rounded bg-accent px-2 py-0.5 text-[11px] font-medium text-on-accent hover:bg-accent/90 transition-colors"
+                variant="primary"
+                size="sm"
+                touchTarget={false}
+                className="text-[11px]"
                 onClick={() => {
                   onArrange(gap, staggered);
                   setOpen(false);
                 }}
               >
                 {t('binDesigner.cutouts.autoArrange')}
-              </button>
+              </Button>
             </div>
             <label className="flex items-center gap-1.5 text-[11px] text-content-tertiary cursor-pointer">
               <input
@@ -339,31 +346,36 @@ export function WorkspaceHeader({
     icon: React.ReactNode,
     isDisabled = false
   ) => (
-    <button
+    <IconButton
       type="button"
-      className="rounded p-1 text-content-tertiary hover:bg-surface-hover hover:text-content transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      size="sm"
+      touchTarget={false}
+      className="text-content-tertiary"
       onClick={onClick}
       title={title}
       aria-label={title}
       disabled={isDisabled || disabled}
     >
       {icon}
-    </button>
+    </IconButton>
   );
 
   const textBtn = (onClick: () => void, label: string, danger = false, isDisabled = false) => (
-    <button
+    <Button
       type="button"
-      className={`rounded px-2 py-0.5 text-[11px] transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+      variant={danger ? 'danger' : 'ghost'}
+      size="sm"
+      touchTarget={false}
+      className={
         danger
-          ? 'text-red-400 hover:bg-red-500/10'
-          : 'text-content-secondary hover:bg-surface-hover hover:text-content'
-      }`}
+          ? 'text-[11px] text-red-400 bg-transparent hover:bg-red-500/10'
+          : 'text-[11px] text-content-secondary'
+      }
       onClick={onClick}
       disabled={isDisabled || disabled}
     >
       {label}
-    </button>
+    </Button>
   );
   const renderMainRowActions = () => {
     if (selection.size === 0) {
@@ -483,11 +495,13 @@ export function WorkspaceHeader({
           </span>
 
           <div className="flex items-center gap-0.5">
-            <button
+            <IconButton
               type="button"
+              size="sm"
+              touchTarget={false}
+              className="text-content-secondary"
               onClick={onUndo}
               disabled={!canUndo}
-              className="rounded p-1 text-content-secondary hover:text-content disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               title={t('binDesigner.cutoutEditor.undo')}
               aria-label={t('binDesigner.cutoutEditor.undo')}
             >
@@ -505,12 +519,14 @@ export function WorkspaceHeader({
                   d="M4 9h10.5a5.5 5.5 0 0 1 0 11H12"
                 />
               </svg>
-            </button>
-            <button
+            </IconButton>
+            <IconButton
               type="button"
+              size="sm"
+              touchTarget={false}
+              className="text-content-secondary"
               onClick={onRedo}
               disabled={!canRedo}
-              className="rounded p-1 text-content-secondary hover:text-content disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               title={t('binDesigner.cutoutEditor.redo')}
               aria-label={t('binDesigner.cutoutEditor.redo')}
             >
@@ -528,7 +544,7 @@ export function WorkspaceHeader({
                   d="M20 9H9.5a5.5 5.5 0 0 0 0 11H12"
                 />
               </svg>
-            </button>
+            </IconButton>
           </div>
 
           {cursorWorldPos && (
@@ -544,30 +560,37 @@ export function WorkspaceHeader({
 
         <div className="flex items-center gap-2 flex-shrink-0">
           <div className="flex items-center gap-0.5 rounded border border-stroke-subtle bg-surface-elevated">
-            <button
+            <IconButton
               type="button"
+              size="sm"
+              touchTarget={false}
+              className="text-content-secondary"
               onClick={onZoomOut}
-              className="px-1.5 py-0.5 text-xs text-content-secondary hover:text-content transition-colors"
               title={t('binDesigner.cutoutEditor.zoomOut')}
               aria-label={t('binDesigner.cutoutEditor.zoomOut')}
             >
               <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
               </svg>
-            </button>
-            <button
+            </IconButton>
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
+              touchTarget={false}
+              className="min-w-[3.5rem] px-1 text-[11px] text-content-secondary tabular-nums"
               onClick={onFitToView}
-              className="min-w-[3.5rem] px-1 py-0.5 text-[11px] font-medium text-content-secondary hover:text-content tabular-nums transition-colors"
               title={t('binDesigner.cutoutEditor.fitToView')}
               aria-label={t('binDesigner.cutoutEditor.fitToView')}
             >
               {zoomPercent}%
-            </button>
-            <button
+            </Button>
+            <IconButton
               type="button"
+              size="sm"
+              touchTarget={false}
+              className="text-content-secondary"
               onClick={onZoomIn}
-              className="px-1.5 py-0.5 text-xs text-content-secondary hover:text-content transition-colors"
               title={t('binDesigner.cutoutEditor.zoomIn')}
               aria-label={t('binDesigner.cutoutEditor.zoomIn')}
             >
@@ -579,14 +602,16 @@ export function WorkspaceHeader({
                   d="M12 4v16m8-8H4"
                 />
               </svg>
-            </button>
+            </IconButton>
           </div>
 
           {onShowHelp && (
-            <button
+            <IconButton
               type="button"
+              size="sm"
+              touchTarget={false}
+              className="text-content-tertiary"
               onClick={onShowHelp}
-              className="rounded p-1.5 text-content-tertiary hover:bg-surface-hover hover:text-content transition-colors"
               title={t('binDesigner.cutoutEditor.showHelp')}
               aria-label={t('binDesigner.cutoutEditor.showHelp')}
             >
@@ -601,16 +626,19 @@ export function WorkspaceHeader({
                 <path strokeLinecap="round" d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
                 <line x1="12" y1="17" x2="12.01" y2="17" />
               </svg>
-            </button>
+            </IconButton>
           )}
 
-          <button
+          <Button
             type="button"
+            variant="primary"
+            size="sm"
+            touchTarget={false}
+            className="px-4 font-semibold"
             onClick={() => setCutoutEditorOpen(false)}
-            className="rounded-md px-4 py-1.5 text-xs font-semibold bg-accent text-on-accent hover:bg-accent/90 shadow-sm transition-colors"
           >
             {t('binDesigner.cutoutEditor.done')}
-          </button>
+          </Button>
         </div>
 
         <ConfirmDialog

--- a/src/features/bin-designer/components/DesignActions/DesignActions.tsx
+++ b/src/features/bin-designer/components/DesignActions/DesignActions.tsx
@@ -269,7 +269,7 @@ export function DesignActions({
               onClick={handleDelete}
               className={`
                 w-full px-3 py-2.5 justify-start text-left text-sm flex flex-col gap-0.5 transition-colors
-                ${isConfirmingDelete ? 'bg-danger text-on-dark hover:bg-danger' : 'text-danger hover:bg-surface'}
+                ${isConfirmingDelete ? 'bg-danger text-on-dark hover:bg-danger' : 'text-danger hover:bg-surface hover:text-danger'}
               `}
             >
               <span className="flex items-center gap-2">

--- a/src/features/bin-designer/components/DesignActions/DesignActions.tsx
+++ b/src/features/bin-designer/components/DesignActions/DesignActions.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from '@/i18n';
+import { Button, IconButton } from '@/design-system';
 import { useTwoClickDelete } from '@/shared/components';
 import type { SavedDesign } from '../../types';
 
@@ -102,11 +103,13 @@ export function DesignActions({
 
   return (
     <div className="relative" role="presentation" onClick={(e) => e.stopPropagation()}>
-      <button
+      <IconButton
         ref={menuButtonRef}
+        size="sm"
+        touchTarget={false}
         onClick={handleMenuToggle}
         className={`
-          p-1.5 rounded transition-colors
+          h-auto w-auto p-1.5 rounded transition-colors
           ${
             isMenuOpen
               ? 'bg-surface text-content'
@@ -120,7 +123,7 @@ export function DesignActions({
         <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
         </svg>
-      </button>
+      </IconButton>
 
       {isMenuOpen &&
         createPortal(
@@ -132,10 +135,12 @@ export function DesignActions({
           >
             {/* Load (only if not active) */}
             {!isActive && (
-              <button
+              <Button
+                variant="ghost"
+                fullWidth
                 role="menuitem"
                 onClick={handleAction(onLoad)}
-                className="w-full px-3 py-2.5 text-left text-sm text-content hover:bg-surface flex items-center gap-2"
+                className="w-full px-3 py-2.5 justify-start text-left text-sm text-content hover:bg-surface flex items-center gap-2"
               >
                 <svg
                   className="w-4 h-4 text-content-secondary"
@@ -152,14 +157,16 @@ export function DesignActions({
                   />
                 </svg>
                 {t('binDesigner.load')}
-              </button>
+              </Button>
             )}
 
             {/* Download JSON */}
-            <button
+            <Button
+              variant="ghost"
+              fullWidth
               role="menuitem"
               onClick={handleAction(onDownloadJSON)}
-              className="w-full px-3 py-2.5 text-left text-sm text-content hover:bg-surface flex items-center gap-2"
+              className="w-full px-3 py-2.5 justify-start text-left text-sm text-content hover:bg-surface flex items-center gap-2"
             >
               <svg
                 className="w-4 h-4 text-content-secondary"
@@ -176,13 +183,15 @@ export function DesignActions({
                 />
               </svg>
               {t('binDesigner.downloadJSON')}
-            </button>
+            </Button>
 
             {/* Rename */}
-            <button
+            <Button
+              variant="ghost"
+              fullWidth
               role="menuitem"
               onClick={handleAction(onRename)}
-              className="w-full px-3 py-2.5 text-left text-sm text-content hover:bg-surface flex items-center gap-2"
+              className="w-full px-3 py-2.5 justify-start text-left text-sm text-content hover:bg-surface flex items-center gap-2"
             >
               <svg
                 className="w-4 h-4 text-content-secondary"
@@ -199,13 +208,15 @@ export function DesignActions({
                 />
               </svg>
               {t('common.rename')}
-            </button>
+            </Button>
 
             {/* Edit tags */}
-            <button
+            <Button
+              variant="ghost"
+              fullWidth
               role="menuitem"
               onClick={handleAction(onEditTags)}
-              className="w-full px-3 py-2.5 text-left text-sm text-content hover:bg-surface flex items-center gap-2"
+              className="w-full px-3 py-2.5 justify-start text-left text-sm text-content hover:bg-surface flex items-center gap-2"
             >
               <svg
                 className="w-4 h-4 text-content-secondary"
@@ -222,13 +233,15 @@ export function DesignActions({
                 />
               </svg>
               {t('binDesigner.tags.editAction')}
-            </button>
+            </Button>
 
             {/* Duplicate */}
-            <button
+            <Button
+              variant="ghost"
+              fullWidth
               role="menuitem"
               onClick={handleAction(onDuplicate)}
-              className="w-full px-3 py-2.5 text-left text-sm text-content hover:bg-surface flex items-center gap-2"
+              className="w-full px-3 py-2.5 justify-start text-left text-sm text-content hover:bg-surface flex items-center gap-2"
             >
               <svg
                 className="w-4 h-4 text-content-secondary"
@@ -245,16 +258,18 @@ export function DesignActions({
                 />
               </svg>
               {t('common.duplicate')}
-            </button>
+            </Button>
 
             {/* Delete */}
             <div className="border-t border-stroke my-1" />
-            <button
+            <Button
+              variant="ghost"
+              fullWidth
               role="menuitem"
               onClick={handleDelete}
               className={`
-                w-full px-3 py-2.5 text-left text-sm flex flex-col gap-0.5 transition-colors
-                ${isConfirmingDelete ? 'bg-danger text-on-dark' : 'text-danger hover:bg-surface'}
+                w-full px-3 py-2.5 justify-start text-left text-sm flex flex-col gap-0.5 transition-colors
+                ${isConfirmingDelete ? 'bg-danger text-on-dark hover:bg-danger' : 'text-danger hover:bg-surface'}
               `}
             >
               <span className="flex items-center gap-2">
@@ -274,7 +289,7 @@ export function DesignActions({
                 </svg>
                 {isConfirmingDelete ? t('binDesigner.confirmDelete') : t('common.delete')}
               </span>
-            </button>
+            </Button>
           </div>,
           document.body
         )}

--- a/src/features/bin-designer/components/DesignActions/DesignActions.tsx
+++ b/src/features/bin-designer/components/DesignActions/DesignActions.tsx
@@ -263,13 +263,13 @@ export function DesignActions({
             {/* Delete */}
             <div className="border-t border-stroke my-1" />
             <Button
-              variant="ghost"
+              variant={isConfirmingDelete ? 'danger' : 'ghost'}
               fullWidth
               role="menuitem"
               onClick={handleDelete}
               className={`
                 w-full px-3 py-2.5 justify-start text-left text-sm flex flex-col gap-0.5 transition-colors
-                ${isConfirmingDelete ? 'bg-danger text-on-dark hover:bg-danger' : 'text-danger hover:bg-surface hover:text-danger'}
+                ${isConfirmingDelete ? '' : 'text-danger hover:bg-surface hover:text-danger'}
               `}
             >
               <span className="flex items-center gap-2">

--- a/src/features/bin-designer/components/DesignImportView/DesignImportView.tsx
+++ b/src/features/bin-designer/components/DesignImportView/DesignImportView.tsx
@@ -10,6 +10,7 @@ import type { ChangeEvent, DragEvent } from 'react';
 import { parseDesignJSON } from '@/features/bin-designer/utils/designJson';
 import type { BinParams } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
+import { Button } from '@/design-system';
 
 interface DesignImportViewProps {
   onImport: (design: { name: string; params: BinParams }) => void;
@@ -177,12 +178,13 @@ export function DesignImportView({ onImport, onCancel }: DesignImportViewProps) 
           {isDragging ? t('layouts.dropFileHere') : t('binDesigner.dragDropDesignJson')}
         </p>
         <p className="text-content-tertiary text-sm mb-4">{t('layouts.or')}</p>
-        <button
+        <Button
+          variant="secondary"
           onClick={() => fileInputRef.current?.click()}
           className="px-4 py-2 bg-surface-secondary hover:bg-surface border border-stroke text-content text-sm rounded-lg transition-colors"
         >
           {t('layouts.browseFiles')}
-        </button>
+        </Button>
       </div>
 
       {/* Divider */}
@@ -199,12 +201,13 @@ export function DesignImportView({ onImport, onCancel }: DesignImportViewProps) 
             {t('binDesigner.designJson')}
           </label>
           {jsonText && (
-            <button
+            <Button
+              variant="ghost"
               onClick={handleClear}
-              className="text-xs text-content-tertiary hover:text-content"
+              className="rounded-none px-0 py-0 hover:bg-transparent text-xs text-content-tertiary hover:text-content"
             >
               {t('common.clear')}
-            </button>
+            </Button>
           )}
         </div>
         <textarea
@@ -266,19 +269,21 @@ export function DesignImportView({ onImport, onCancel }: DesignImportViewProps) 
 
       {/* Action Buttons */}
       <div className="flex gap-3 pt-4 border-t border-stroke">
-        <button
+        <Button
+          variant="primary"
           onClick={handleImport}
           disabled={!validDesign}
           className="flex-1 py-2.5 px-4 bg-accent hover:bg-accent/90 disabled:hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed text-on-dark rounded-lg transition-colors text-sm font-medium"
         >
           {t('binDesigner.importAndLoad')}
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="secondary"
           onClick={onCancel}
           className="py-2.5 px-4 bg-surface-secondary hover:bg-surface border border-stroke text-content rounded-lg transition-colors text-sm"
         >
           {t('common.cancel')}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/features/bin-designer/components/DesignListDialog/BulkActionBar/BulkActionBar.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/BulkActionBar/BulkActionBar.tsx
@@ -27,13 +27,14 @@ export function BulkActionBar({
       <span className="text-sm font-medium text-content">
         {t('binDesigner.bulk.selected', { count })}
       </span>
-      <button
+      <Button
         type="button"
+        variant="ghost"
         onClick={onSelectAll}
-        className="text-xs font-medium text-accent hover:underline"
+        className="rounded-none px-0 py-0 hover:bg-transparent text-xs font-medium text-accent hover:underline"
       >
         {t('binDesigner.bulk.selectAll')}
-      </button>
+      </Button>
       <div className="ml-auto flex items-center gap-2">
         <Button variant="secondary" size="sm" onClick={onTag} disabled={none}>
           {t('binDesigner.bulk.tag')}

--- a/src/features/bin-designer/components/DesignListDialog/DesignListDialog.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListDialog.tsx
@@ -16,7 +16,7 @@ import {
   saveDesign,
   updateDesignTags,
 } from '@/features/bin-designer/storage/DesignerStorage';
-import { Menu } from '@/design-system';
+import { Menu, Button, IconButton, XIcon, PlusIcon } from '@/design-system';
 import { useBinDefaults } from '../../hooks';
 import { collectTags, filterByTags, toggleTag } from '@/features/bin-designer/utils/tagFilter';
 import { normalizeTags, tagsEqual } from '@/features/bin-designer/utils/tags';
@@ -533,29 +533,34 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
           <h2 className="text-lg font-semibold text-content">{t('binDesigner.savedDesigns')}</h2>
           <div className="flex flex-wrap items-center gap-2">
             {!showImport && designs.length > 0 && !selection.active && (
-              <button
+              <Button
+                variant="secondary"
                 onClick={() => selection.enter()}
                 className="rounded-md bg-surface-secondary px-3 py-1.5 text-sm font-medium text-content border border-stroke transition-colors hover:bg-surface-hover"
               >
                 {t('binDesigner.select')}
-              </button>
+              </Button>
             )}
-            <button
+            <Button
+              variant="secondary"
               onClick={() => setShowImport(true)}
               className="rounded-md bg-surface-secondary px-3 py-1.5 text-sm font-medium text-content border border-stroke transition-colors hover:bg-surface-hover"
             >
               {t('common.import')}
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="primary"
               onClick={handleNewDesign}
               className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-hover"
             >
               {t('binDesigner.newDesign')}
-            </button>
-            <button
+            </Button>
+            <IconButton
               type="button"
+              size="md"
+              touchTarget={false}
               onClick={handleOpenOptionsMenu}
-              className="relative rounded-md p-1.5 text-content-secondary border border-stroke transition-colors hover:bg-surface-hover hover:text-content"
+              className="relative h-auto w-auto rounded-md p-1.5 text-content-secondary border border-stroke transition-colors hover:bg-surface-hover hover:text-content"
               aria-label={
                 customDefaultActive
                   ? `${t('binDesigner.moreOptions')} — ${t('binDesigner.customDefaultActive')}`
@@ -585,27 +590,16 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
                   aria-hidden="true"
                 />
               )}
-            </button>
-            <button
+            </IconButton>
+            <IconButton
+              size="sm"
+              touchTarget={false}
               onClick={onClose}
-              className="rounded-md p-1 text-content-secondary hover:bg-surface-hover hover:text-content"
+              className="h-auto w-auto rounded-md p-1 text-content-secondary hover:bg-surface-hover hover:text-content"
               aria-label={t('common.close')}
             >
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            </button>
+              <XIcon className="h-5 w-5" />
+            </IconButton>
           </div>
         </div>
 
@@ -652,26 +646,14 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
               <p className="mt-1 text-xs text-content-disabled">
                 {t('binDesigner.changesAreSavedAutomaticallyAsYouDe')}
               </p>
-              <button
+              <Button
+                variant="primary"
                 onClick={handleNewDesign}
                 className="mt-4 inline-flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-hover"
+                leftIcon={<PlusIcon className="h-4 w-4" />}
               >
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 4v16m8-8H4"
-                  />
-                </svg>
                 {t('binDesigner.startANewDesign')}
-              </button>
+              </Button>
             </div>
           ) : (
             <ItemListShell

--- a/src/features/bin-designer/components/DesignListDialog/TagFilterBar/TagFilterBar.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/TagFilterBar/TagFilterBar.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from '@/i18n';
+import { Button } from '@/design-system';
 
 interface TagFilterBarProps {
   allTags: readonly string[];
@@ -23,30 +24,32 @@ export function TagFilterBar({ allTags, activeTags, onToggle, onClear }: TagFilt
       {allTags.map((tag) => {
         const isActive = activeSet.has(tag.toLowerCase());
         return (
-          <button
+          <Button
             key={tag}
             type="button"
+            variant="ghost"
             onClick={() => onToggle(tag)}
             aria-pressed={isActive}
             className={`max-w-[10rem] truncate rounded-full border px-2.5 py-1 text-xs font-medium transition-colors ${
               isActive
-                ? 'border-accent bg-accent text-on-accent'
+                ? 'border-accent bg-accent text-on-accent hover:bg-accent'
                 : 'border-stroke bg-surface text-content-secondary hover:bg-surface-hover'
             }`}
             title={tag}
           >
             {tag}
-          </button>
+          </Button>
         );
       })}
       {activeTags.length > 0 && (
-        <button
+        <Button
           type="button"
+          variant="ghost"
           onClick={onClear}
-          className="rounded-full px-2 py-1 text-xs font-medium text-content-tertiary hover:text-content"
+          className="rounded-full px-2 py-1 hover:bg-transparent text-xs font-medium text-content-tertiary hover:text-content"
         >
           {t('binDesigner.tags.clearFilter')}
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/src/features/bin-designer/components/DesignListDialog/TagInput/TagInput.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/TagInput/TagInput.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import type { KeyboardEvent } from 'react';
 import { useTranslation } from '@/i18n';
-import { Input } from '@/design-system';
+import { Input, IconButton, XIcon } from '@/design-system';
 import { MAX_TAGS, normalizeTags } from '@/features/bin-designer/utils/tags';
 
 interface TagInputProps {
@@ -52,27 +52,16 @@ export function TagInput({ value, onChange }: TagInputProps) {
                 <span className="max-w-[10rem] truncate" title={tag}>
                   {tag}
                 </span>
-                <button
+                <IconButton
                   type="button"
+                  size="sm"
+                  touchTarget={false}
                   onClick={() => removeTag(tag)}
-                  className="rounded-full p-0.5 text-content-tertiary hover:bg-surface hover:text-content"
+                  className="h-auto w-auto rounded-full p-0.5 text-content-tertiary hover:bg-surface hover:text-content"
                   aria-label={t('binDesigner.tags.remove', { tag })}
                 >
-                  <svg
-                    className="h-3 w-3"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
+                  <XIcon className="h-3 w-3" />
+                </IconButton>
               </span>
             </li>
           ))}

--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -65,6 +65,7 @@ import { detectWebGL, WebGLFallback, WebGLErrorBoundary } from '@/shared/webgl';
 import { ColorToolOverlay } from './ColorToolOverlay';
 import type { ColorZone } from '@/features/bin-designer/types/featureColors';
 import { PipetteIcon } from '@/design-system/Icon';
+import { IconButton } from '@/design-system';
 import { useSwapZoneWithToast } from '../../hooks/useSwapZoneWithToast';
 
 const PREVIEW_COLOR_KEY = 'gridfinity-designer-preview-color';
@@ -521,8 +522,9 @@ export function PreviewCanvas({ hideChrome = false }: PreviewCanvasProps = {}) {
               button is paired with one in the Colors panel header; both
               enter eyedropper mode. */}
           {!hideChrome && showColors && (
-            <button
+            <IconButton
               type="button"
+              touchTarget={false}
               onClick={() => setColorTool(colorTool === 'eyedropper' ? null : 'eyedropper')}
               className={`absolute bottom-3 left-3 z-20 inline-flex h-9 w-9 items-center justify-center rounded-full border shadow-md backdrop-blur transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                 colorTool === 'eyedropper'
@@ -534,7 +536,7 @@ export function PreviewCanvas({ hideChrome = false }: PreviewCanvasProps = {}) {
               title={t('binDesigner.colors.eyedropper.enter')}
             >
               <PipetteIcon size="sm" />
-            </button>
+            </IconButton>
           )}
 
           {/* Banner + click-anchored picker — rendered above canvas. The

--- a/src/features/bin-designer/components/ShareDialog/ShareDialog.tsx
+++ b/src/features/bin-designer/components/ShareDialog/ShareDialog.tsx
@@ -13,6 +13,7 @@ import { migrateParams } from '@/features/bin-designer/constants/defaults';
 import { useFocusTrap } from '@/shared/hooks/useFocusTrap';
 import { useToastStore } from '@/core/store/toast';
 import { useTranslation } from '@/i18n';
+import { Button, IconButton, XIcon, CheckIcon } from '@/design-system';
 
 interface ShareDialogProps {
   open: boolean;
@@ -128,26 +129,15 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
         {/* Header */}
         <div className="mb-5 flex items-center justify-between">
           <h2 className="text-lg font-semibold text-content">{t('binDesigner.shareDesign')}</h2>
-          <button
+          <IconButton
+            size="sm"
+            touchTarget={false}
             onClick={onClose}
-            className="rounded-md p-1 text-content-secondary hover:bg-surface-hover hover:text-content"
+            className="h-auto w-auto rounded-md p-1 text-content-secondary hover:bg-surface-hover hover:text-content"
             aria-label={t('common.close')}
           >
-            <svg
-              className="h-5 w-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
+            <XIcon className="h-5 w-5" />
+          </IconButton>
         </div>
 
         {/* Share section */}
@@ -159,26 +149,29 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
             </p>
 
             {status === 'idle' && (
-              <button
+              <Button
+                fullWidth
                 onClick={handleShare}
-                className="flex w-full items-center justify-center gap-2 rounded-md bg-info px-4 py-2 text-sm font-medium text-white transition-colors hover:brightness-110"
+                className="flex w-full items-center justify-center gap-2 rounded-md bg-info px-4 py-2 text-sm font-medium text-white transition-colors hover:brightness-110 hover:bg-info"
+                leftIcon={
+                  <svg
+                    className="h-4 w-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+                    />
+                  </svg>
+                }
               >
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
-                  />
-                </svg>
                 {t('binDesigner.createShareLink')}
-              </button>
+              </Button>
             )}
 
             {status === 'sharing' && (
@@ -219,26 +212,14 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
                     aria-label={t('binDesigner.shareUrl')}
                     onClick={(e) => (e.target as HTMLInputElement).select()}
                   />
-                  <button
+                  <Button
+                    variant="secondary"
                     onClick={handleCopy}
                     className="flex items-center gap-1 rounded-md bg-surface-secondary px-3 py-2 text-xs font-medium text-content transition-colors hover:bg-surface-hover"
                   >
                     {copied ? (
                       <>
-                        <svg
-                          className="h-4 w-4 text-green-500"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                          aria-hidden="true"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M5 13l4 4L19 7"
-                          />
-                        </svg>
+                        <CheckIcon className="h-4 w-4 text-green-500" />
                         {t('binDesigner.copied')}
                       </>
                     ) : (
@@ -260,7 +241,7 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
                         {t('common.copy')}
                       </>
                     )}
-                  </button>
+                  </Button>
                 </div>
                 <p className="text-[10px] text-content-tertiary">
                   This link is permanent. Anyone with the link can load this design.
@@ -293,13 +274,14 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
                   if (e.key === 'Enter') void handleLoad();
                 }}
               />
-              <button
+              <Button
+                variant="secondary"
                 onClick={handleLoad}
                 disabled={!loadInput.trim() || status === 'loading'}
                 className="rounded-md bg-surface-secondary px-3 py-2 text-xs font-medium text-content transition-colors hover:bg-surface-hover disabled:opacity-50"
               >
                 {status === 'loading' ? t('binDesigner.loading') : t('binDesigner.load')}
-              </button>
+              </Button>
             </div>
           </div>
 

--- a/src/features/bin-designer/components/ShareDialog/ShareDialog.tsx
+++ b/src/features/bin-designer/components/ShareDialog/ShareDialog.tsx
@@ -151,8 +151,9 @@ export function ShareDialog({ open, onClose }: ShareDialogProps) {
             {status === 'idle' && (
               <Button
                 fullWidth
+                variant="ghost"
                 onClick={handleShare}
-                className="flex w-full items-center justify-center gap-2 rounded-md bg-info px-4 py-2 text-sm font-medium text-white transition-colors hover:brightness-110 hover:bg-info"
+                className="flex w-full items-center justify-center gap-2 rounded-md bg-info px-4 py-2 text-sm font-medium text-white transition-colors hover:brightness-110 hover:bg-info hover:text-white"
                 leftIcon={
                   <svg
                     className="h-4 w-4"

--- a/src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.tsx
+++ b/src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.tsx
@@ -12,6 +12,7 @@ import { useDesignerStore } from '@/features/bin-designer/store';
 import { DESIGNER_CONSTRAINTS, GRIDFINITY } from '@/features/bin-designer/constants';
 import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
 import { StepperControl } from '@/shared/components/StepperControl';
+import { Button } from '@/design-system';
 import { RulerIcon } from '@/design-system/Icon';
 import {
   calculateSlotPositions,
@@ -143,20 +144,21 @@ export function SlotConfigurator() {
         <span className="text-xs text-content-tertiary">{t('binDesigner.slotDirection')}</span>
         <div className="flex gap-0.5">
           {directions.map((direction) => (
-            <button
+            <Button
               key={direction}
               type="button"
+              variant="ghost"
               onClick={() => setDirection(direction)}
               className={`rounded px-2 py-0.5 text-[11px] font-medium transition-colors ${
                 activeDirection === direction
-                  ? 'bg-accent text-on-accent'
+                  ? 'bg-accent text-on-accent hover:bg-accent'
                   : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
               }`}
             >
               {direction === 'vertical'
                 ? t('binDesigner.slotVertical')
                 : t('binDesigner.slotHorizontal')}
-            </button>
+            </Button>
           ))}
         </div>
       </div>

--- a/src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.tsx
+++ b/src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.tsx
@@ -11,6 +11,7 @@
 
 import { useId, useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from '@/i18n';
+import { Button } from '@/design-system';
 import { SliderThumb } from '@/design-system/Slider';
 
 export interface SnappingSliderOption {
@@ -296,19 +297,20 @@ export function SnappingSlider({
             const showLabel = KEY_VALUES.has(option.value) || isActive;
             if (!showLabel) return null;
             return (
-              <button
+              <Button
                 key={option.value}
                 type="button"
+                variant="ghost"
                 onClick={() => handleTickClick(option.value)}
                 disabled={disabled}
-                className={`absolute -translate-x-1/2 min-h-[36px] flex items-end pb-0.5 text-[11px] tabular-nums transition-colors ${
+                className={`absolute -translate-x-1/2 min-h-[36px] flex items-end pb-0.5 rounded-none px-0 hover:bg-transparent text-[11px] tabular-nums transition-colors ${
                   disabled ? 'cursor-not-allowed' : 'cursor-pointer hover:text-content'
                 } ${isActive ? 'font-semibold text-accent' : 'text-content-tertiary'}`}
                 style={{ left: `${getPosition(option.value)}%` }}
                 aria-label={t('snappingSlider.select', { value: option.value, unit })}
               >
                 {option.value}
-              </button>
+              </Button>
             );
           })}
         </div>

--- a/src/features/bin-designer/components/controls/ThicknessSelector/ThicknessSelector.tsx
+++ b/src/features/bin-designer/components/controls/ThicknessSelector/ThicknessSelector.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useCallback, useRef } from 'react';
+import { Button } from '@/design-system';
 import { WALL_THICKNESS_OPTIONS } from '@/features/bin-designer/constants';
 import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
 
@@ -76,9 +77,10 @@ export function ThicknessSelector({
         {WALL_THICKNESS_OPTIONS.map((option) => {
           const isActive = Math.abs(option - value) < 0.001;
           return (
-            <button
+            <Button
               key={option}
               type="button"
+              variant="ghost"
               role="radio"
               tabIndex={isActive ? 0 : -1}
               aria-checked={isActive}
@@ -88,7 +90,7 @@ export function ThicknessSelector({
               className={`flex-1 tabular-nums ${getSegmentClass(isActive)}`}
             >
               {option}
-            </button>
+            </Button>
           );
         })}
       </div>

--- a/src/features/bin-designer/components/panel/CutoutsSection/AlignmentToolbar.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/AlignmentToolbar.tsx
@@ -7,6 +7,7 @@
 
 import { useState } from 'react';
 import type { Cutout, GroupOp, ReorderDirection } from '@/features/bin-designer/types';
+import { Button, IconButton } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import {
   computeBounds,
@@ -214,15 +215,17 @@ export function AlignmentToolbar({
   };
 
   const alignButton = (type: AlignType, label: string) => (
-    <button
+    <IconButton
       type="button"
-      className="rounded p-1.5 text-content-tertiary hover:bg-surface-hover hover:text-content transition-colors"
+      size="sm"
+      touchTarget={false}
+      className="text-content-tertiary"
       onClick={() => handleAlign(type)}
       title={label}
       aria-label={label}
     >
       <AlignIcon type={type} />
-    </button>
+    </IconButton>
   );
 
   return (
@@ -243,57 +246,70 @@ export function AlignmentToolbar({
 
       {/* Distribution buttons */}
       <div className="flex gap-2">
-        <button
+        <Button
           type="button"
-          className="flex items-center gap-1.5 rounded border border-stroke-subtle bg-surface-elevated px-2 py-1 text-xs text-content-secondary hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          variant="secondary"
+          size="sm"
+          touchTarget={false}
+          className="text-content-secondary"
+          leftIcon={
+            <svg
+              className="h-3.5 w-3.5"
+              viewBox="0 0 14 14"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            >
+              <line x1="1" y1="1" x2="1" y2="13" />
+              <line x1="7" y1="3" x2="7" y2="11" />
+              <line x1="13" y1="1" x2="13" y2="13" />
+            </svg>
+          }
           onClick={handleDistributeH}
           disabled={selectedIds.length < 3}
           title={t('binDesigner.cutouts.distributeH')}
         >
-          <svg
-            className="h-3.5 w-3.5"
-            viewBox="0 0 14 14"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-          >
-            <line x1="1" y1="1" x2="1" y2="13" />
-            <line x1="7" y1="3" x2="7" y2="11" />
-            <line x1="13" y1="1" x2="13" y2="13" />
-          </svg>
           {t('binDesigner.cutouts.distributeH')}
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
-          className="flex items-center gap-1.5 rounded border border-stroke-subtle bg-surface-elevated px-2 py-1 text-xs text-content-secondary hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          variant="secondary"
+          size="sm"
+          touchTarget={false}
+          className="text-content-secondary"
+          leftIcon={
+            <svg
+              className="h-3.5 w-3.5"
+              viewBox="0 0 14 14"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            >
+              <line x1="1" y1="1" x2="13" y2="1" />
+              <line x1="3" y1="7" x2="11" y2="7" />
+              <line x1="1" y1="13" x2="13" y2="13" />
+            </svg>
+          }
           onClick={handleDistributeV}
           disabled={selectedIds.length < 3}
           title={t('binDesigner.cutouts.distributeV')}
         >
-          <svg
-            className="h-3.5 w-3.5"
-            viewBox="0 0 14 14"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-          >
-            <line x1="1" y1="1" x2="13" y2="1" />
-            <line x1="3" y1="7" x2="11" y2="7" />
-            <line x1="1" y1="13" x2="13" y2="13" />
-          </svg>
           {t('binDesigner.cutouts.distributeV')}
-        </button>
+        </Button>
       </div>
 
       {/* Auto-arrange */}
       <div className="flex items-center gap-2">
-        <button
+        <Button
           type="button"
-          className="rounded border border-stroke-subtle bg-surface-elevated px-2 py-1 text-xs text-content-secondary hover:bg-surface-hover transition-colors"
+          variant="secondary"
+          size="sm"
+          touchTarget={false}
+          className="text-content-secondary"
           onClick={handleAutoArrange}
         >
           {t('binDesigner.cutouts.autoArrange')}
-        </button>
+        </Button>
         <label className="flex items-center gap-1 text-[11px] text-content-tertiary">
           {t('binDesigner.cutouts.gap')}
           <input
@@ -346,28 +362,37 @@ export function AlignmentToolbar({
 
       {/* Actions */}
       <div className="flex flex-wrap gap-2">
-        <button
+        <Button
           type="button"
-          className="rounded border border-stroke-subtle bg-surface-elevated px-2 py-1 text-xs text-content-secondary hover:bg-surface-hover transition-colors"
+          variant="secondary"
+          size="sm"
+          touchTarget={false}
+          className="text-content-secondary"
           onClick={handleCenterInBin}
         >
           {t('binDesigner.cutouts.centerInBin')}
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
-          className="rounded border border-stroke-subtle bg-surface-elevated px-2 py-1 text-xs text-content-secondary hover:bg-surface-hover transition-colors"
+          variant="secondary"
+          size="sm"
+          touchTarget={false}
+          className="text-content-secondary"
           onClick={() => onDuplicate(selectedIds)}
         >
           {t('common.duplicate')}
-        </button>
+        </Button>
         {hasGroup && (
-          <button
+          <Button
             type="button"
-            className="rounded border border-stroke-subtle bg-surface-elevated px-2 py-1 text-xs text-content-secondary hover:bg-surface-hover transition-colors"
+            variant="secondary"
+            size="sm"
+            touchTarget={false}
+            className="text-content-secondary"
             onClick={() => onUngroup(selectedIds)}
           >
             {t('binDesigner.cutouts.ungroup')}
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutContextMenu.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutContextMenu.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useCallback } from 'react';
+import { Button } from '@/design-system';
 import { ShortcutBadge } from '@/shared/components/ShortcutBadge/ShortcutBadge';
 
 export interface ContextMenuAction {
@@ -67,11 +68,15 @@ export function CutoutContextMenu({ x, y, actions, onClose }: CutoutContextMenuP
       >
         {actions.map((action, index) => (
           <div key={index}>
-            <button
+            <Button
               type="button"
-              className={`w-full flex items-center justify-between gap-4 px-3 py-1.5 text-xs transition-colors ${
+              variant="ghost"
+              size="sm"
+              fullWidth
+              touchTarget={false}
+              className={`justify-between gap-4 rounded-none px-3 py-1.5 ${
                 action.disabled
-                  ? 'text-content-tertiary cursor-not-allowed opacity-50'
+                  ? 'text-content-tertiary'
                   : action.danger
                     ? 'text-red-400 hover:text-red-300 hover:bg-surface-hover'
                     : 'text-content-secondary hover:bg-surface-hover hover:text-content'
@@ -88,7 +93,7 @@ export function CutoutContextMenu({ x, y, actions, onClose }: CutoutContextMenuP
                   className="opacity-60"
                 />
               )}
-            </button>
+            </Button>
             {action.dividerAfter && <div className="border-t border-stroke-subtle my-1" />}
           </div>
         ))}

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutPropertyPanel.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutPropertyPanel.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { Cutout } from '@/features/bin-designer/types';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { SliderInput } from '../../controls/SliderInput';
 import { clampRotationToBounds, flipCutoutHorizontal, flipCutoutVertical } from './geometry';
@@ -201,67 +202,83 @@ export function CutoutPropertyPanel({
 
       <div className="space-y-2">
         <div className="flex gap-1.5 pt-1">
-          <button
+          <Button
             type="button"
-            className="flex items-center gap-1 rounded border border-stroke-subtle bg-surface-elevated px-2 py-1 text-xs text-content-secondary hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            variant="secondary"
+            size="sm"
+            touchTarget={false}
+            className="text-content-secondary"
+            leftIcon={
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 14 14"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M7 1v12M3 4l-2 3 2 3M11 4l2 3-2 3" />
+              </svg>
+            }
             onClick={() => onUpdate(cutout.id, flipCutoutHorizontal(cutout))}
             disabled={disabled || cutout.locked}
             title={t('binDesigner.cutouts.flipHorizontal')}
           >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 14 14"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M7 1v12M3 4l-2 3 2 3M11 4l2 3-2 3" />
-            </svg>
             {t('binDesigner.cutouts.flipHorizontal')}
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
-            className="flex items-center gap-1 rounded border border-stroke-subtle bg-surface-elevated px-2 py-1 text-xs text-content-secondary hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            variant="secondary"
+            size="sm"
+            touchTarget={false}
+            className="text-content-secondary"
+            leftIcon={
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 14 14"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M1 7h12M4 3L7 1l3 2M4 11l3 2 3-2" />
+              </svg>
+            }
             onClick={() => onUpdate(cutout.id, flipCutoutVertical(cutout))}
             disabled={disabled || cutout.locked}
             title={t('binDesigner.cutouts.flipVertical')}
           >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 14 14"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M1 7h12M4 3L7 1l3 2M4 11l3 2 3-2" />
-            </svg>
             {t('binDesigner.cutouts.flipVertical')}
-          </button>
+          </Button>
         </div>
 
         <div className="flex gap-2">
-          <button
+          <Button
             type="button"
-            className="flex-1 rounded border border-stroke-subtle bg-surface-elevated px-2 py-1 text-xs text-content-secondary hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            variant="secondary"
+            size="sm"
+            fullWidth
+            touchTarget={false}
+            className="flex-1 text-content-secondary"
             onClick={() => onDuplicate([cutout.id])}
             disabled={disabled}
           >
             {t('common.duplicate')}
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
-            className="rounded border border-red-500/30 bg-surface-elevated px-2 py-1 text-xs text-red-400 hover:bg-red-500/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            variant="danger"
+            size="sm"
+            touchTarget={false}
             onClick={() => onRemove(cutout.id)}
             disabled={disabled}
           >
             {t('common.delete')}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeToolbar.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeToolbar.tsx
@@ -8,6 +8,7 @@
 import type { ReactNode } from 'react';
 import type { CutoutShape } from '@/features/bin-designer/types';
 import type { InteractionMode } from './useCutoutInteraction';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 /** Styled tooltip wrapper for vertical toolbar buttons */
@@ -112,8 +113,10 @@ export function CutoutShapeToolbar({
       {wrap(
         t('binDesigner.cutouts.pointerTool'),
         'V',
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          touchTarget={false}
           className={`${btnBase} ${isPointerActive ? btnActive : btnInactive}`}
           onClick={() => onSelectShape({ type: 'idle' })}
           aria-label={t('binDesigner.cutouts.pointerTool')}
@@ -129,14 +132,16 @@ export function CutoutShapeToolbar({
             <path d="M3 1l8 5.5-3.5.5L5 11z" />
           </svg>
           {!vertical && t('binDesigner.cutouts.pointerTool')}
-        </button>
+        </Button>
       )}
 
       {wrap(
         t('binDesigner.cutouts.addRectangle'),
         'R',
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          touchTarget={false}
           className={`${btnBase} ${activeShape === 'rectangle' ? btnActive : btnInactive}`}
           onClick={() => handleClick('rectangle')}
           aria-label={t('binDesigner.cutouts.addRectangle')}
@@ -152,15 +157,17 @@ export function CutoutShapeToolbar({
             <rect x="1" y="2" width="12" height="10" rx="1" />
           </svg>
           {!vertical && t('binDesigner.cutouts.addRectangle')}
-        </button>
+        </Button>
       )}
 
       {/* eslint-disable i18next/no-literal-string -- shortcut key identifiers, not translatable */}
       {wrap(
         t('binDesigner.cutouts.addCircle'),
         'C',
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          touchTarget={false}
           className={`${btnBase} ${activeShape === 'circle' ? btnActive : btnInactive}`}
           onClick={() => handleClick('circle')}
           aria-label={t('binDesigner.cutouts.addCircle')}
@@ -176,14 +183,16 @@ export function CutoutShapeToolbar({
             <circle cx="7" cy="7" r="5.5" />
           </svg>
           {!vertical && t('binDesigner.cutouts.addCircle')}
-        </button>
+        </Button>
       )}
 
       {wrap(
         t('binDesigner.cutouts.addPolygon'),
         'G',
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          touchTarget={false}
           className={`${btnBase} ${activeShape === 'polygon' ? btnActive : btnInactive}`}
           onClick={() => handleClick('polygon')}
           aria-label={t('binDesigner.cutouts.addPolygon')}
@@ -201,14 +210,16 @@ export function CutoutShapeToolbar({
             <path d="M3.5 1.5h7L13 7l-2.5 5.5h-7L1 7z" />
           </svg>
           {!vertical && t('binDesigner.cutouts.addPolygon')}
-        </button>
+        </Button>
       )}
 
       {wrap(
         t('binDesigner.cutouts.addSlot'),
         'S',
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          touchTarget={false}
           className={`${btnBase} ${activeShape === 'slot' ? btnActive : btnInactive}`}
           onClick={() => handleClick('slot')}
           aria-label={t('binDesigner.cutouts.addSlot')}
@@ -225,14 +236,16 @@ export function CutoutShapeToolbar({
             <rect x="1" y="4" width="12" height="6" rx="3" />
           </svg>
           {!vertical && t('binDesigner.cutouts.addSlot')}
-        </button>
+        </Button>
       )}
 
       {wrap(
         t('binDesigner.cutouts.penTool'),
         'P',
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          touchTarget={false}
           className={`${btnBase} ${activeShape === 'path' ? btnActive : btnInactive}`}
           onClick={() => handleClick('path')}
           aria-label={t('binDesigner.cutouts.penTool')}
@@ -260,15 +273,17 @@ export function CutoutShapeToolbar({
             <circle cx="9" cy="12" r="1" fill="none" strokeWidth="1" />
           </svg>
           {!vertical && t('binDesigner.cutouts.penTool')}
-        </button>
+        </Button>
       )}
 
       {onImportSvg &&
         wrap(
           t('binDesigner.cutouts.importSvg'),
           'I',
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            touchTarget={false}
             className={`${btnBase} ${btnInactive}`}
             onClick={onImportSvg}
             aria-label={t('binDesigner.cutouts.importSvg')}
@@ -290,7 +305,7 @@ export function CutoutShapeToolbar({
               <path d="M2 9v2.5a1 1 0 001 1h8a1 1 0 001-1V9" />
             </svg>
             {!vertical && t('binDesigner.cutouts.importSvg')}
-          </button>
+          </Button>
         )}
 
       <div
@@ -302,8 +317,10 @@ export function CutoutShapeToolbar({
       {wrap(
         t('binDesigner.cutouts.rulerTool'),
         'M',
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          touchTarget={false}
           className={`${btnBase} ${isRulerActive ? btnActive : btnInactive}`}
           onClick={() => onSelectShape(isRulerActive ? { type: 'idle' } : { type: 'ruler-ready' })}
           aria-label={t('binDesigner.cutouts.rulerTool')}
@@ -323,7 +340,7 @@ export function CutoutShapeToolbar({
             <line x1="12.5" y1="5" x2="12.5" y2="9" />
           </svg>
           {!vertical && t('binDesigner.cutouts.rulerTool')}
-        </button>
+        </Button>
       )}
       {/* eslint-enable i18next/no-literal-string */}
 
@@ -333,8 +350,10 @@ export function CutoutShapeToolbar({
         }
       />
 
-      <button
+      <Button
         type="button"
+        variant="ghost"
+        touchTarget={false}
         className={`${btnBase} ${snapEnabled ? btnActive : btnInactive}`}
         onClick={() => onSnapToggle(!snapEnabled)}
         title={t('binDesigner.cutouts.snapToGrid')}
@@ -349,11 +368,13 @@ export function CutoutShapeToolbar({
           <path d="M1 1h4v4H1zM9 1h4v4H9zM1 9h4v4H1zM9 9h4v4H9z" />
         </svg>
         {!vertical && t('binDesigner.cutouts.snapToGrid')}
-      </button>
+      </Button>
 
       {snapEnabled && (
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          touchTarget={false}
           className={`${btnBase} ${btnInactive}`}
           onClick={handleGridSizeCycle}
           title={`${t('binDesigner.gridSize')}: ${gridSize}mm`}
@@ -361,7 +382,7 @@ export function CutoutShapeToolbar({
           <span className={vertical ? 'text-[10px] font-mono' : 'text-xs font-mono'}>
             {gridSize}mm
           </span>
-        </button>
+        </Button>
       )}
 
       {activeShape !== null && !vertical && (

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutsSection.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutsSection.test.tsx
@@ -123,9 +123,9 @@ describe('CutoutsSection', () => {
     render(<CutoutsSection />);
     fireEvent.click(screen.getByText('binDesigner.cutouts.clearAll'));
 
-    // Click the confirm button in the dialog (the one with btn-danger class)
+    // Click the confirm button in the dialog (the one with danger variant)
     const dialog = screen.getByRole('dialog');
-    const confirmBtn = dialog.querySelector('button.btn-danger');
+    const confirmBtn = dialog.querySelector('button.to-danger');
     expect(confirmBtn).not.toBeNull();
     fireEvent.click(confirmBtn!);
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutsSection.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutsSection.tsx
@@ -8,6 +8,7 @@
 import { useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog/ConfirmDialog';
 import { CutoutEditor } from './CutoutEditor';
@@ -36,13 +37,17 @@ export function CutoutsSection() {
       <CutoutEditor />
 
       {cutoutCount > 0 && (
-        <button
+        <Button
           type="button"
-          className="w-full rounded border border-stroke-subtle bg-surface-elevated px-2 py-1 text-xs text-content-tertiary hover:bg-surface-hover hover:text-content transition-colors"
+          variant="ghost"
+          size="sm"
+          fullWidth
+          touchTarget={false}
+          className="rounded border border-stroke-subtle bg-surface-elevated px-2 py-1 text-xs text-content-tertiary hover:bg-surface-hover hover:text-content"
           onClick={() => setClearConfirm(true)}
         >
           {t('binDesigner.cutouts.clearAll')}
-        </button>
+        </Button>
       )}
 
       <ConfirmDialog

--- a/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
+++ b/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
@@ -8,6 +8,7 @@
 
 import { DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
 import { StepperControl } from '@/shared/components/StepperControl';
+import { IconButton } from '@/design-system';
 import { RulerIcon } from '@/design-system/Icon';
 import { Checkbox } from '@/shared/components/Checkbox';
 import { useResponsive } from '@/shared/hooks/useResponsive';
@@ -38,10 +39,12 @@ export function DimensionsSection() {
         </div>
 
         {/* Swap button */}
-        <button
+        <IconButton
           type="button"
+          variant="secondary"
+          touchTarget={false}
           onClick={handlers.handleSwapDimensions}
-          className={`flex ${isMobile ? 'h-12 w-12' : 'h-8 w-8'} flex-shrink-0 items-center justify-center rounded border border-stroke-subtle bg-surface-elevated text-content-tertiary transition-colors hover:bg-surface-hover hover:text-content`}
+          className={`${isMobile ? 'h-12 w-12' : 'h-8 w-8'} flex-shrink-0 text-content-tertiary`}
           title={t('inspector.swapDimensions')}
           aria-label={t('inspector.swapWidthAndDepth')}
         >
@@ -58,7 +61,7 @@ export function DimensionsSection() {
               d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
             />
           </svg>
-        </button>
+        </IconButton>
 
         {/* Depth */}
         <div className="flex-1 min-w-0">

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
@@ -8,7 +8,7 @@
 import { FeatureToggle } from '../FeatureToggle';
 import { StepperControl } from '@/shared/components/StepperControl';
 import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
-import { Input, Select, InfoIcon } from '@/design-system';
+import { Button, Input, Select, InfoIcon } from '@/design-system';
 import type { SelectOption } from '@/design-system';
 import { RulerIcon } from '@/design-system/Icon';
 import { DESIGNER_CONSTRAINTS } from '../../../constants';
@@ -61,15 +61,17 @@ export function LabelTabsSection() {
           {EDGES_OPTIONS.map((option) => {
             const current = state.label.edges ?? 'back';
             return (
-              <button
+              <Button
                 key={option}
                 type="button"
+                variant="ghost"
+                touchTarget={false}
                 onClick={() => handlers.setTabEdges(option)}
                 aria-pressed={current === option}
                 className={`flex-1 ${getSegmentClass(current === option)}`}
               >
                 {t(`binDesigner.tabEdges.${option}`)}
-              </button>
+              </Button>
             );
           })}
         </div>
@@ -77,13 +79,16 @@ export function LabelTabsSection() {
           <div className="mt-1 flex items-start gap-2 text-xs text-warning">
             <InfoIcon size="xs" className="mt-0.5 shrink-0" />
             <span className="flex-1">{t('binDesigner.tabBothCollisionWarning')}</span>
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
+              touchTarget={false}
               onClick={handlers.autoFixDimensions}
-              className="shrink-0 font-medium text-accent hover:text-accent/80 transition-colors"
+              className="shrink-0 px-0 font-medium text-accent hover:bg-transparent hover:text-accent/80"
             >
               {t('binDesigner.tabAutoFix')}
-            </button>
+            </Button>
           </div>
         )}
       </div>
@@ -219,15 +224,17 @@ export function LabelTabsSection() {
             className={SEGMENT_GROUP_CLASS}
           >
             {ALIGNMENT_OPTIONS.map((option) => (
-              <button
+              <Button
                 key={option}
                 type="button"
+                variant="ghost"
+                touchTarget={false}
                 onClick={() => handlers.setTabAlignment(option)}
                 aria-pressed={state.label.alignment === option}
                 className={`flex-1 ${getSegmentClass(state.label.alignment === option)}`}
               >
                 {t(`binDesigner.alignment.${option}`)}
-              </button>
+              </Button>
             ))}
           </div>
         </div>
@@ -240,15 +247,17 @@ export function LabelTabsSection() {
         </span>
         <div role="group" aria-label={t('binDesigner.tabSupport')} className={SEGMENT_GROUP_CLASS}>
           {SUPPORT_OPTIONS.map((option) => (
-            <button
+            <Button
               key={option}
               type="button"
+              variant="ghost"
+              touchTarget={false}
               onClick={() => handlers.setTabSupport(option)}
               aria-pressed={state.label.support === option}
               className={`flex-1 ${getSegmentClass(state.label.support === option)}`}
             >
               {t(`binDesigner.tabSupport.${option}`)}
-            </button>
+            </Button>
           ))}
         </div>
       </div>
@@ -274,15 +283,17 @@ export function LabelTabsSection() {
               className={SEGMENT_GROUP_CLASS}
             >
               {MODE_OPTIONS.map((option) => (
-                <button
+                <Button
                   key={option}
                   type="button"
+                  variant="ghost"
+                  touchTarget={false}
                   onClick={() => handlers.setTextMode(option)}
                   aria-pressed={state.textDefaults.mode === option}
                   className={`flex-1 ${getSegmentClass(state.textDefaults.mode === option)}`}
                 >
                   {t(`binDesigner.textMode.${option}`)}
-                </button>
+                </Button>
               ))}
             </div>
             {state.textDefaults.mode === 'through-cut' && (

--- a/src/features/bin-designer/components/preview/PreviewControls/PreviewControls.tsx
+++ b/src/features/bin-designer/components/preview/PreviewControls/PreviewControls.tsx
@@ -6,6 +6,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import type { ReactNode } from 'react';
 import { useTranslation } from '@/i18n';
+import { Button, IconButton } from '@/design-system';
 import { CATEGORY_COLOR_PALETTE } from '@/core/constants';
 import { useResponsive } from '@/shared/hooks/useResponsive';
 import {
@@ -85,11 +86,12 @@ function ColorPickerContent({
   return (
     <div className="grid grid-cols-7 gap-1.5">
       {CATEGORY_COLOR_PALETTE.map(({ color, nameKey }) => (
-        <button
+        <Button
           key={color}
           type="button"
+          variant="ghost"
           onClick={() => onColorSelect(color)}
-          className={`rounded-md p-0.5 transition-colors hover:bg-surface-hover focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:outline-none ${
+          className={`h-auto w-auto rounded-md p-0.5 transition-colors hover:bg-surface-hover focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:outline-none ${
             previewColor === color ? 'ring-2 ring-accent bg-surface-hover' : ''
           }`}
           aria-label={t('colors.colorAriaLabel', { name: t(nameKey) })}
@@ -102,7 +104,7 @@ function ColorPickerContent({
             }`}
             style={{ backgroundColor: color }}
           />
-        </button>
+        </Button>
       ))}
     </div>
   );
@@ -178,13 +180,16 @@ export function PreviewControls({
               const Icon = VIEW_MODE_ICONS[mode];
               const isActive = splitViewMode === mode;
               return (
-                <button
+                <Button
                   key={mode}
                   type="button"
+                  variant="ghost"
+                  size="sm"
+                  touchTarget={false}
                   onClick={() => onSplitViewModeChange(mode)}
-                  className={`flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
+                  className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors min-h-[28px] touch-manipulation ${
                     isActive
-                      ? 'bg-accent text-on-accent'
+                      ? 'bg-accent text-on-accent hover:bg-accent'
                       : 'text-content-secondary hover:bg-surface-hover hover:text-content'
                   }`}
                   aria-pressed={isActive}
@@ -195,7 +200,7 @@ export function PreviewControls({
                       ? t('binDesigner.splitAssembled')
                       : t('binDesigner.splitExploded')}
                   </span>
-                </button>
+                </Button>
               );
             })}
           </div>
@@ -207,13 +212,16 @@ export function PreviewControls({
             const Icon = PRESET_ICONS[key];
             const isActive = activePreset === key;
             return (
-              <button
+              <Button
                 key={key}
                 type="button"
+                variant="ghost"
+                size="sm"
+                touchTarget={false}
                 onClick={() => onCameraPreset(key)}
-                className={`flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
+                className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors min-h-[28px] touch-manipulation ${
                   isActive
-                    ? 'bg-accent text-on-accent'
+                    ? 'bg-accent text-on-accent hover:bg-accent'
                     : 'text-content-secondary hover:bg-surface-hover hover:text-content'
                 }`}
                 title={`${label} view (${shortcut})`}
@@ -227,7 +235,7 @@ export function PreviewControls({
                 >
                   {shortcut}
                 </kbd>
-              </button>
+              </Button>
             );
           })}
 
@@ -235,24 +243,30 @@ export function PreviewControls({
           <div className="w-px h-5 bg-stroke-subtle/50" />
 
           {/* Reset button */}
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
+            touchTarget={false}
             onClick={onResetView}
-            className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
+            className="flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content min-h-[28px] touch-manipulation"
             title={t('binDesigner.resetView')}
             aria-label={t('binDesigner.resetCameraViewKeyboardShortcutR')}
           >
             <IconReset />
             <span>{t('common.reset')}</span>
-          </button>
+          </Button>
 
           {/* Wireframe toggle */}
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
+            touchTarget={false}
             onClick={onWireframeToggle}
-            className={`flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
+            className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors min-h-[28px] touch-manipulation ${
               wireframe
-                ? 'bg-accent text-on-accent'
+                ? 'bg-accent text-on-accent hover:bg-accent'
                 : 'text-content-secondary hover:bg-surface-hover hover:text-content'
             }`}
             title={t('binDesigner.toggleWireframe')}
@@ -261,15 +275,18 @@ export function PreviewControls({
           >
             <IconWireframe />
             <span>{t('binDesigner.wire')}</span>
-          </button>
+          </Button>
 
           {/* X-ray toggle */}
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
+            touchTarget={false}
             onClick={onXrayToggle}
-            className={`flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
+            className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors min-h-[28px] touch-manipulation ${
               xray
-                ? 'bg-accent text-on-accent'
+                ? 'bg-accent text-on-accent hover:bg-accent'
                 : 'text-content-secondary hover:bg-surface-hover hover:text-content'
             }`}
             title={t('binDesigner.toggleXray')}
@@ -278,13 +295,16 @@ export function PreviewControls({
           >
             <IconXray />
             <span>{t('binDesigner.xray')}</span>
-          </button>
+          </Button>
 
           {/* Projection toggle (perspective ↔ orthographic) */}
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
+            touchTarget={false}
             onClick={onProjectionToggle}
-            className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
+            className="flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content min-h-[28px] touch-manipulation"
             title={t('binDesigner.toggleProjection')}
             aria-label={t('binDesigner.toggleProjectionKeyboardShortcut')}
             aria-pressed={projection === 'orthographic'}
@@ -295,7 +315,7 @@ export function PreviewControls({
                 ? t('binDesigner.projectionPerspective')
                 : t('binDesigner.projectionOrthographic')}
             </span>
-          </button>
+          </Button>
 
           {/* Color picker (hidden in multi-color mode) */}
           {!hideColorPicker && (
@@ -304,10 +324,13 @@ export function PreviewControls({
               <div className="w-px h-5 bg-stroke-subtle/50" />
 
               {/* Color picker button */}
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="sm"
+                touchTarget={false}
                 onClick={() => setColorPickerOpen((v) => !v)}
-                className="flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
+                className="flex items-center gap-1.5 rounded-none px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content min-h-[28px] touch-manipulation"
                 title={t('binDesigner.changePreviewColor')}
                 aria-label={t('binDesigner.changePreviewColor')}
                 aria-expanded={colorPickerOpen}
@@ -317,7 +340,7 @@ export function PreviewControls({
                   style={{ backgroundColor: previewColor }}
                 />
                 <span>{t('common.color')}</span>
-              </button>
+              </Button>
             </>
           )}
         </div>
@@ -343,13 +366,15 @@ export function PreviewControls({
               const Icon = VIEW_MODE_ICONS[mode];
               const isActive = splitViewMode === mode;
               return (
-                <button
+                <Button
                   key={mode}
                   type="button"
+                  variant="ghost"
+                  touchTarget={false}
                   onClick={() => onSplitViewModeChange(mode)}
-                  className={`flex items-center justify-center gap-1 min-w-[44px] min-h-[44px] px-3 py-2 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
+                  className={`flex items-center justify-center gap-1 rounded-none min-w-[44px] min-h-[44px] px-3 py-2 text-[11px] font-medium transition-colors touch-manipulation ${
                     isActive
-                      ? 'bg-accent text-on-accent'
+                      ? 'bg-accent text-on-accent hover:bg-accent'
                       : 'text-content-secondary hover:bg-surface-hover hover:text-content'
                   }`}
                   aria-pressed={isActive}
@@ -360,7 +385,7 @@ export function PreviewControls({
                       ? t('binDesigner.splitAssembled')
                       : t('binDesigner.splitExploded')}
                   </span>
-                </button>
+                </Button>
               );
             })}
           </div>
@@ -371,21 +396,22 @@ export function PreviewControls({
             const Icon = PRESET_ICONS[key];
             const isActive = activePreset === key;
             return (
-              <button
+              <IconButton
                 key={key}
                 type="button"
+                touchTarget={false}
+                pressed={isActive}
                 onClick={() => onCameraPreset(key)}
-                className={`flex items-center justify-center min-w-[44px] min-h-[44px] p-2 transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
+                className={`flex items-center justify-center rounded-none min-w-[44px] min-h-[44px] p-2 transition-colors touch-manipulation ${
                   isActive
-                    ? 'bg-accent text-on-accent'
+                    ? 'bg-accent text-on-accent hover:bg-accent'
                     : 'text-content-secondary hover:bg-surface-hover hover:text-content'
                 }`}
                 title={`${label} view (${shortcut})`}
                 aria-label={`${label} camera view`}
-                aria-pressed={isActive}
               >
                 <Icon />
-              </button>
+              </IconButton>
             );
           })}
 
@@ -393,59 +419,63 @@ export function PreviewControls({
           <div className="w-px h-5 bg-stroke-subtle/50" />
 
           {/* Reset */}
-          <button
+          <IconButton
             type="button"
+            touchTarget={false}
             onClick={onResetView}
-            className="flex items-center justify-center min-w-[44px] min-h-[44px] p-2 text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation"
+            className="flex items-center justify-center rounded-none min-w-[44px] min-h-[44px] p-2 text-content-secondary transition-colors hover:bg-surface-hover hover:text-content touch-manipulation"
             title={t('binDesigner.resetView')}
             aria-label={t('binDesigner.resetCameraViewKeyboardShortcutR')}
           >
             <IconReset />
-          </button>
+          </IconButton>
 
           {/* Wireframe */}
-          <button
+          <IconButton
             type="button"
+            touchTarget={false}
+            pressed={wireframe}
             onClick={onWireframeToggle}
-            className={`flex items-center justify-center min-w-[44px] min-h-[44px] p-2 transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
+            className={`flex items-center justify-center rounded-none min-w-[44px] min-h-[44px] p-2 transition-colors touch-manipulation ${
               wireframe
-                ? 'bg-accent text-on-accent'
+                ? 'bg-accent text-on-accent hover:bg-accent'
                 : 'text-content-secondary hover:bg-surface-hover hover:text-content'
             }`}
             title={t('binDesigner.toggleWireframe')}
             aria-label={t('binDesigner.toggleWireframeModeKeyboardShortcut')}
-            aria-pressed={wireframe}
           >
             <IconWireframe />
-          </button>
+          </IconButton>
 
           {/* X-ray */}
-          <button
+          <IconButton
             type="button"
+            touchTarget={false}
+            pressed={xray}
             onClick={onXrayToggle}
-            className={`flex items-center justify-center min-w-[44px] min-h-[44px] p-2 transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
+            className={`flex items-center justify-center rounded-none min-w-[44px] min-h-[44px] p-2 transition-colors touch-manipulation ${
               xray
-                ? 'bg-accent text-on-accent'
+                ? 'bg-accent text-on-accent hover:bg-accent'
                 : 'text-content-secondary hover:bg-surface-hover hover:text-content'
             }`}
             title={t('binDesigner.toggleXray')}
             aria-label={t('binDesigner.toggleXrayKeyboardShortcut')}
-            aria-pressed={xray}
           >
             <IconXray />
-          </button>
+          </IconButton>
 
           {/* Projection toggle */}
-          <button
+          <IconButton
             type="button"
+            touchTarget={false}
+            pressed={projection === 'orthographic'}
             onClick={onProjectionToggle}
-            className="flex items-center justify-center min-w-[44px] min-h-[44px] p-2 text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation"
+            className="flex items-center justify-center rounded-none min-w-[44px] min-h-[44px] p-2 text-content-secondary transition-colors hover:bg-surface-hover hover:text-content touch-manipulation"
             title={t('binDesigner.toggleProjection')}
             aria-label={t('binDesigner.toggleProjectionKeyboardShortcut')}
-            aria-pressed={projection === 'orthographic'}
           >
             {projection === 'perspective' ? <IconPerspective /> : <IconOrthographic />}
-          </button>
+          </IconButton>
 
           {/* Color picker (hidden in multi-color mode) */}
           {!hideColorPicker && (
@@ -454,10 +484,11 @@ export function PreviewControls({
               <div className="flex-1" />
 
               {/* Color picker */}
-              <button
+              <IconButton
                 type="button"
+                touchTarget={false}
                 onClick={() => setColorPickerOpen((v) => !v)}
-                className="flex items-center justify-center min-w-[44px] min-h-[44px] p-2 text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation"
+                className="flex items-center justify-center rounded-none min-w-[44px] min-h-[44px] p-2 text-content-secondary transition-colors hover:bg-surface-hover hover:text-content touch-manipulation"
                 title={t('binDesigner.changePreviewColor')}
                 aria-label={t('binDesigner.changePreviewColor')}
                 aria-expanded={colorPickerOpen}
@@ -466,7 +497,7 @@ export function PreviewControls({
                   className="inline-block h-4 w-4 rounded border border-stroke-subtle/50"
                   style={{ backgroundColor: previewColor }}
                 />
-              </button>
+              </IconButton>
             </>
           )}
         </div>

--- a/src/features/bin-designer/components/preview/PreviewSkeleton/PreviewSkeleton.tsx
+++ b/src/features/bin-designer/components/preview/PreviewSkeleton/PreviewSkeleton.tsx
@@ -6,6 +6,7 @@
 
 import type { WasmStatus, GenerationStatus } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
+import { Button } from '@/design-system';
 
 interface PreviewSkeletonProps {
   wasmStatus: WasmStatus;
@@ -99,50 +100,56 @@ export function PreviewSkeleton({
         {isError && (onRetry || (onRevert && canRevert)) && (
           <div className="mt-3 flex items-center justify-center gap-2">
             {onRetry && (
-              <button
+              <Button
+                variant="secondary"
                 onClick={onRetry}
                 className="inline-flex items-center gap-1.5 rounded-md bg-surface-elevated px-3 py-1.5 text-xs font-medium text-content-secondary shadow-sm transition-colors hover:bg-surface-hover hover:text-content"
                 aria-label={t('binDesigner.retryLoading')}
+                leftIcon={
+                  <svg
+                    className="h-3.5 w-3.5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                    />
+                  </svg>
+                }
               >
-                <svg
-                  className="h-3.5 w-3.5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-                  />
-                </svg>
                 {t('binDesigner.retry')}
-              </button>
+              </Button>
             )}
             {onRevert && canRevert && generationStatus === 'error' && (
-              <button
+              <Button
+                variant="secondary"
                 onClick={onRevert}
                 className="inline-flex items-center gap-1.5 rounded-md bg-surface-elevated px-3 py-1.5 text-xs font-medium text-content-secondary shadow-sm transition-colors hover:bg-surface-hover hover:text-content"
                 aria-label={t('binDesigner.revertToWorking')}
+                leftIcon={
+                  <svg
+                    className="h-3.5 w-3.5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"
+                    />
+                  </svg>
+                }
               >
-                <svg
-                  className="h-3.5 w-3.5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"
-                  />
-                </svg>
                 {t('binDesigner.revertToWorking')}
-              </button>
+              </Button>
             )}
           </div>
         )}

--- a/src/features/bin-inspector/components/Inspector/CustomPropertiesEditor/CustomPropertiesEditor.tsx
+++ b/src/features/bin-inspector/components/Inspector/CustomPropertiesEditor/CustomPropertiesEditor.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { CONSTRAINTS, RESERVED_PROPERTY_KEYS } from '@/core/constants';
+import { Button, IconButton, XIcon } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 interface CustomPropertiesEditorProps {
@@ -133,11 +134,12 @@ export function CustomPropertiesEditor({
             : t('inspector.customProperties')}
         </label>
         {!isAdding && (
-          <button
+          <Button
+            variant="ghost"
             type="button"
             onClick={() => setIsAdding(true)}
             disabled={atMaxProperties}
-            className="text-xs text-accent hover:text-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="text-xs text-accent hover:text-accent-hover px-0 py-0 hover:bg-transparent"
             aria-label={t('inspector.addCustomProperty')}
             title={
               atMaxProperties
@@ -148,7 +150,7 @@ export function CustomPropertiesEditor({
             }
           >
             {t('inspector.add')}
-          </button>
+          </Button>
         )}
       </div>
 
@@ -159,27 +161,18 @@ export function CustomPropertiesEditor({
             <div key={key}>
               <div className="flex items-center gap-2 mb-1">
                 <label className="text-xs text-content-secondary flex-shrink-0">{key}</label>
-                <button
+                <IconButton
+                  variant="dangerGhost"
+                  size="sm"
+                  touchTarget={false}
                   type="button"
                   onClick={() => handleDelete(key)}
-                  className="ml-auto p-1 text-content-tertiary hover:text-error transition-colors"
+                  className="ml-auto text-content-tertiary"
                   title={t('inspector.customProps.deleteProperty')}
                   aria-label={`Delete ${key}`}
                 >
-                  <svg
-                    className="w-3.5 h-3.5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
+                  <XIcon className="w-3.5 h-3.5" />
+                </IconButton>
               </div>
               <input
                 type="text"
@@ -237,21 +230,23 @@ export function CustomPropertiesEditor({
             </div>
           )}
           <div className="flex gap-2">
-            <button
+            <Button
+              variant="primary"
               type="button"
               onClick={handleAdd}
               disabled={!newKey.trim() || !newValue.trim()}
-              className={`btn btn-primary flex-1 ${isMobile ? 'h-10' : 'h-8'}`}
+              className={`flex-1 ${isMobile ? 'h-10' : 'h-8'}`}
             >
               {t('common.add')}
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="ghost"
               type="button"
               onClick={handleCancelAdd}
-              className={`btn btn-ghost flex-1 ${isMobile ? 'h-10' : 'h-8'}`}
+              className={`flex-1 ${isMobile ? 'h-10' : 'h-8'}`}
             >
               {t('common.cancel')}
-            </button>
+            </Button>
           </div>
         </div>
       )}
@@ -270,15 +265,16 @@ export function CustomPropertiesEditor({
           </div>
           <div className="flex flex-wrap gap-1.5">
             {availableSuggestions.slice(0, 6).map((key) => (
-              <button
+              <Button
                 key={key}
+                variant="secondary"
                 type="button"
                 onClick={() => handleQuickAdd(key)}
-                className="text-xs px-2 py-1 rounded bg-surface-secondary hover:bg-surface-elevated text-content-secondary hover:text-content transition-colors border border-stroke-subtle"
+                className="text-xs px-2 py-1 text-content-secondary hover:text-content"
                 title={t('inspector.addProperty', { key })}
               >
                 {t('inspector.addPrefix', { key })}
-              </button>
+              </Button>
             ))}
             {availableSuggestions.length > 6 && (
               <span className="text-xs text-content-disabled px-1 py-1">

--- a/src/features/bin-inspector/components/Inspector/MultiBinInspector/MultiBinInspector.tsx
+++ b/src/features/bin-inspector/components/Inspector/MultiBinInspector/MultiBinInspector.tsx
@@ -5,6 +5,7 @@ import type { UseBinInspectorReturn } from '@/features/bin-inspector/hooks/useBi
 import type { Layer } from '@/core/types';
 import { SelectDropdown } from '@/shared/components/SelectDropdown';
 import { BulkIncrementControl } from '@/shared/components/BulkIncrementControl';
+import { Button, IconButton, XIcon } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 interface MultiBinInspectorProps {
@@ -120,21 +121,16 @@ export function MultiBinInspector({ inspector, variant, onClose }: MultiBinInspe
         </div>
         <h2 className="flex-1 text-lg font-semibold text-content">{t('inspector.binsSelected')}</h2>
         {onClose && (
-          <button
+          <IconButton
+            size="sm"
+            touchTarget={false}
             type="button"
             onClick={onClose}
-            className="btn btn-ghost w-7 h-7 p-0 min-w-0 min-h-0"
+            className="w-7 h-7"
             aria-label={t('inspector.deselectAllBins')}
           >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
+            <XIcon className="w-4 h-4" />
+          </IconButton>
         )}
       </div>
 
@@ -223,13 +219,14 @@ export function MultiBinInspector({ inspector, variant, onClose }: MultiBinInspe
               {t('inspector.customProperties')}
             </label>
             {!showPropertyForm && (
-              <button
+              <Button
+                variant="ghost"
                 type="button"
                 onClick={() => setShowPropertyForm(true)}
-                className="text-xs text-accent hover:text-accent-hover transition-colors"
+                className="text-xs text-accent hover:text-accent-hover px-0 py-0 hover:bg-transparent"
               >
                 {t('inspector.setProperty')}
-              </button>
+              </Button>
             )}
           </div>
           {showPropertyForm ? (
@@ -267,7 +264,8 @@ export function MultiBinInspector({ inspector, variant, onClose }: MultiBinInspe
                 aria-label={t('inspector.propertyValue')}
               />
               <div className="flex gap-2">
-                <button
+                <Button
+                  variant="primary"
                   type="button"
                   onClick={() => {
                     if (propertyKey.trim()) {
@@ -278,21 +276,22 @@ export function MultiBinInspector({ inspector, variant, onClose }: MultiBinInspe
                     }
                   }}
                   disabled={!propertyKey.trim()}
-                  className={`btn btn-primary flex-1 ${isMobile ? 'h-10' : 'h-8'}`}
+                  className={`flex-1 ${isMobile ? 'h-10' : 'h-8'}`}
                 >
                   {t('inspector.setOnAll')}
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant="ghost"
                   type="button"
                   onClick={() => {
                     setPropertyKey('');
                     setPropertyValue('');
                     setShowPropertyForm(false);
                   }}
-                  className={`btn btn-ghost flex-1 ${isMobile ? 'h-10' : 'h-8'}`}
+                  className={`flex-1 ${isMobile ? 'h-10' : 'h-8'}`}
                 >
                   {t('common.cancel')}
-                </button>
+                </Button>
               </div>
             </div>
           ) : (
@@ -305,21 +304,23 @@ export function MultiBinInspector({ inspector, variant, onClose }: MultiBinInspe
         {/* Actions */}
         <div className="flex gap-2">
           {canMoveToStaging && (
-            <button
+            <Button
+              variant="secondary"
               type="button"
               onClick={moveToStaging}
-              className={`btn btn-secondary flex-1 ${isMobile ? 'h-12' : ''}`}
+              className={`flex-1 ${isMobile ? 'h-12' : ''}`}
             >
               {t('inspector.toStash')}
-            </button>
+            </Button>
           )}
-          <button
+          <Button
+            variant="danger"
             type="button"
             onClick={requestDelete}
-            className={`btn btn-danger flex-1 ${isMobile ? 'h-12' : ''}`}
+            className={`flex-1 ${isMobile ? 'h-12' : ''}`}
           >
             {t('inspector.deleteAll')}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
+++ b/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
@@ -114,13 +114,15 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
 
           {/* Flip button */}
           <IconButton
-            variant="secondary"
+            variant={isMobile ? 'secondary' : 'ghost'}
             size={isMobile ? 'lg' : 'sm'}
             touchTarget={isMobile}
             type="button"
             onClick={rotateBin}
             className={
-              isMobile ? 'w-12 h-12 flex-shrink-0' : 'flex-shrink-0 h-8 w-8 text-content-tertiary'
+              isMobile
+                ? 'w-12 h-12 flex-shrink-0'
+                : 'flex-shrink-0 h-8 w-8 rounded-sm border border-stroke-subtle bg-surface-elevated text-content-tertiary hover:bg-surface-hover hover:text-content'
             }
             title={t('inspector.swapDimensions')}
             aria-label={t('inspector.swapWidthAndDepth')}

--- a/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
+++ b/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import { CONSTRAINTS, DEFAULT_CATEGORY_COLOR, STAGING_ID } from '@/core/constants';
+import { Button, IconButton, XIcon } from '@/design-system';
 import { RulerIcon } from '@/design-system/Icon';
 import { useHalfGridModeStore } from '@/core/store/halfGridMode';
 import { getBinLocationContext } from '@/shared/utils/binLocation';
@@ -78,21 +79,16 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
           {t('inspector.bin', { width: formatDim(bin.width), depth: formatDim(bin.depth) })}
         </h2>
         {onClose && (
-          <button
+          <IconButton
+            size="sm"
+            touchTarget={false}
             type="button"
             onClick={onClose}
-            className="btn btn-ghost w-7 h-7 p-0 min-w-0 min-h-0"
+            className="w-7 h-7"
             aria-label={t('inspector.deselectBin')}
           >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
+            <XIcon className="w-4 h-4" />
+          </IconButton>
         )}
       </div>
 
@@ -117,13 +113,14 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
           </div>
 
           {/* Flip button */}
-          <button
+          <IconButton
+            variant="secondary"
+            size={isMobile ? 'lg' : 'sm'}
+            touchTarget={isMobile}
             type="button"
             onClick={rotateBin}
             className={
-              isMobile
-                ? 'btn btn-secondary w-12 h-12 p-0 flex-shrink-0'
-                : 'flex-shrink-0 h-8 w-8 flex items-center justify-center rounded border border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover transition-colors'
+              isMobile ? 'w-12 h-12 flex-shrink-0' : 'flex-shrink-0 h-8 w-8 text-content-tertiary'
             }
             title={t('inspector.swapDimensions')}
             aria-label={t('inspector.swapWidthAndDepth')}
@@ -141,7 +138,7 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
                 d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
               />
             </svg>
-          </button>
+          </IconButton>
 
           {/* Depth control */}
           <div className="flex-1">
@@ -346,21 +343,23 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
         {/* Actions */}
         <div className="flex gap-2">
           {canMoveToStaging && (
-            <button
+            <Button
+              variant="secondary"
               type="button"
               onClick={moveToStaging}
-              className={`btn btn-secondary flex-1 ${isMobile ? 'h-12' : ''}`}
+              className={`flex-1 ${isMobile ? 'h-12' : ''}`}
             >
               {t('inspector.toStash')}
-            </button>
+            </Button>
           )}
-          <button
+          <Button
+            variant="danger"
             type="button"
             onClick={requestDelete}
-            className={`btn btn-danger flex-1 ${isMobile ? 'h-12' : ''}`}
+            className={`flex-1 ${isMobile ? 'h-12' : ''}`}
           >
             {t('common.delete')}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/features/categories/components/CategoriesPanel/CategoriesPanel.tsx
+++ b/src/features/categories/components/CategoriesPanel/CategoriesPanel.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from '@/i18n';
 import { categoryId as toCategoryId } from '@/core/types';
 import type { CategoryId } from '@/core/types';
 import { batch } from '@/core/cqrs';
+import { Button, IconButton, PlusIcon, XIcon } from '@/design-system';
 
 interface ColorPaletteGridProps {
   selectedColor: string;
@@ -28,19 +29,26 @@ function ColorPaletteGrid({ selectedColor, onColorSelect, t }: ColorPaletteGridP
       {CATEGORY_COLOR_PALETTE.map(({ color, nameKey }) => {
         const name = t(nameKey);
         return (
-          <button
+          <IconButton
             key={color}
+            size="sm"
+            touchTarget={false}
             onClick={() => onColorSelect(color)}
-            className="w-6 h-6 rounded transition-all duration-150 hover:scale-110 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-accent"
+            className="w-6 h-6 hover:scale-110 hover:bg-transparent"
             style={{
-              backgroundColor: color,
               boxShadow:
                 selectedColor === color ? '0 0 0 2px var(--color-primary)' : 'var(--shadow-sm)',
             }}
             title={name}
             aria-label={t('categories.setColorTo', { name })}
-            aria-pressed={selectedColor === color}
-          />
+            pressed={selectedColor === color}
+          >
+            <span
+              className="block w-full h-full rounded"
+              style={{ backgroundColor: color }}
+              aria-hidden="true"
+            />
+          </IconButton>
         );
       })}
     </div>
@@ -234,13 +242,14 @@ export function CategoriesPanel() {
 
   const actionButtons = (
     <div className="flex items-center gap-1">
-      <button
+      <IconButton
+        size="sm"
+        touchTarget={false}
         onClick={() => setShowSaveCategoriesConfirm(true)}
-        className="btn btn-ghost w-7 h-7 p-0 min-w-0 min-h-0"
+        className="w-7 h-7"
         title={t('categories.saveAsDefaultsTitle')}
         aria-label={t('categories.saveAsDefaults')}
       >
-        {/* Pin icon */}
         <svg
           className="w-4 h-4"
           viewBox="0 0 24 24"
@@ -250,18 +259,18 @@ export function CategoriesPanel() {
         >
           <path d="M12 17v5M9 3h6v2l-1 1v4l3 3v2H7v-2l3-3V6L9 5V3z" />
         </svg>
-      </button>
-      <button
+      </IconButton>
+      <IconButton
+        size="sm"
+        touchTarget={false}
         onClick={handleAddCategory}
         disabled={!canAddCategory}
-        className="btn btn-ghost w-7 h-7 p-0 min-w-0 min-h-0"
+        className="w-7 h-7"
         title={t('categories.addCategory')}
         aria-label={t('categories.addCategory')}
       >
-        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-        </svg>
-      </button>
+        <PlusIcon className="w-4 h-4" />
+      </IconButton>
     </div>
   );
 
@@ -318,21 +327,24 @@ export function CategoriesPanel() {
                     <div className="flex items-center justify-between text-xs text-content-tertiary mt-0.5">
                       <span>{t('categories.clickOutsideToClose')}</span>
                       {canDelete && (
-                        <button
+                        <Button
+                          variant="ghost"
                           onClick={(e) => handleDeleteCategory(category.id, category.name, e)}
-                          className="text-content-tertiary hover:text-error transition-colors"
+                          className="text-content-tertiary hover:text-error px-0 py-0 hover:bg-transparent"
                           aria-label={t('categories.deleteCategory')}
                         >
                           {t('common.delete')}
-                        </button>
+                        </Button>
                       )}
                     </div>
                   </div>
                 ) : (
                   <>
                     {/* Color swatch with checkmark overlay - click to open quick color picker */}
-                    <button
-                      className="relative w-5 h-5 rounded flex-shrink-0 shadow-sm transition-all duration-150 hover:scale-110 hover:ring-2 hover:ring-accent/50 focus-visible:ring-2 focus-visible:ring-accent"
+                    <IconButton
+                      size="sm"
+                      touchTarget={false}
+                      className="relative w-5 h-5 flex-shrink-0 shadow-sm hover:scale-110 hover:ring-2 hover:ring-accent/50 hover:bg-transparent"
                       style={{ backgroundColor: category.color }}
                       onClick={(e) => {
                         e.stopPropagation();
@@ -360,7 +372,7 @@ export function CategoriesPanel() {
                           />
                         </svg>
                       )}
-                    </button>
+                    </IconButton>
 
                     {colorPickerId === category.id && (
                       <div
@@ -380,8 +392,9 @@ export function CategoriesPanel() {
                       </div>
                     )}
                     {/* Category name - click to select, double-click to edit */}
-                    <button
-                      className="flex-1 min-w-0 text-left"
+                    <Button
+                      variant="ghost"
+                      className="flex-1 min-w-0 text-left justify-start px-0 py-0 hover:bg-transparent"
                       onClick={(e) => {
                         e.stopPropagation();
                         handleCategorySelect(category.id, category.name);
@@ -409,15 +422,17 @@ export function CategoriesPanel() {
                       }
                     >
                       <span className="text-sm truncate text-content block">{category.name}</span>
-                    </button>
+                    </Button>
                     {/* Edit button - appears on hover */}
-                    <button
+                    <IconButton
+                      size="sm"
+                      touchTarget={false}
                       onClick={(e) => {
                         e.stopPropagation();
                         setColorPickerId(null);
                         setEditingId(category.id);
                       }}
-                      className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-1.5 -my-1 rounded hover:bg-surface-elevated transition-opacity flex-shrink-0 focus-visible:ring-2 focus-visible:ring-accent"
+                      className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 -my-1 flex-shrink-0"
                       title={t('categories.editCategory')}
                       aria-label={t('categories.editCategoryAria', { name: category.name })}
                     >
@@ -434,29 +449,20 @@ export function CategoriesPanel() {
                           d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
                         />
                       </svg>
-                    </button>
+                    </IconButton>
                     {/* Delete button - appears on hover for unused categories */}
                     {canDelete && (
-                      <button
+                      <IconButton
+                        variant="dangerGhost"
+                        size="sm"
+                        touchTarget={false}
                         onClick={(e) => handleDeleteCategory(category.id, category.name, e)}
-                        className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-1.5 -my-1 rounded text-content-tertiary hover:text-error hover:bg-error/10 transition-all flex-shrink-0 focus-visible:ring-2 focus-visible:ring-accent"
+                        className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 -my-1 text-content-tertiary flex-shrink-0"
                         title={t('categories.deleteCategory')}
                         aria-label={t('categories.deleteCategoryAria', { name: category.name })}
                       >
-                        <svg
-                          className="w-3.5 h-3.5"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M6 18L18 6M6 6l12 12"
-                          />
-                        </svg>
-                      </button>
+                        <XIcon className="w-3.5 h-3.5" />
+                      </IconButton>
                     )}
                     {/* Bin count badge - only rendered when category has bins */}
                     {binCount > 0 && (

--- a/src/features/categories/components/CategoriesPanel/CategoriesPanel.tsx
+++ b/src/features/categories/components/CategoriesPanel/CategoriesPanel.tsx
@@ -344,7 +344,7 @@ export function CategoriesPanel() {
                     <IconButton
                       size="sm"
                       touchTarget={false}
-                      className="relative w-5 h-5 flex-shrink-0 shadow-sm hover:scale-110 hover:ring-2 hover:ring-accent/50 hover:bg-transparent"
+                      className="relative w-5 h-5 rounded flex-shrink-0 shadow-sm hover:scale-110 hover:ring-2 hover:ring-accent/50 hover:bg-transparent"
                       style={{ backgroundColor: category.color }}
                       onClick={(e) => {
                         e.stopPropagation();

--- a/src/features/cloud-share/components/CloudShareTab/CloudShareTab.tsx
+++ b/src/features/cloud-share/components/CloudShareTab/CloudShareTab.tsx
@@ -7,6 +7,7 @@ import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from '@/i18n';
 import { useCloudShare } from '@/features/cloud-share/hooks/useCloudShare';
 import { formatShareDate } from '@/features/cloud-share/utils/cloudShare';
+import { Button } from '@/design-system';
 import type { SharePermission } from '@/core/types';
 
 interface CloudShareTabProps {
@@ -108,9 +109,9 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
           </select>
         </div>
 
-        <button onClick={handleShare} className="btn btn-primary w-full">
+        <Button variant="primary" fullWidth onClick={handleShare}>
           {t('share.cloud.publish')}
-        </button>
+        </Button>
 
         <div className="text-xs text-content-tertiary border-t border-stroke-subtle pt-3 mt-3">
           Note: Cloud shares are snapshots. Changes you make locally won't affect the shared
@@ -136,9 +137,9 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
         </div>
 
         <div className="flex gap-2">
-          <button onClick={handleCopyUrl} className="btn btn-primary flex-1">
+          <Button variant="primary" onClick={handleCopyUrl} className="flex-1">
             {urlCopied ? t('share.cloud.linkCopied') : t('share.cloud.copyLink')}
-          </button>
+          </Button>
           <select
             value={localPermission}
             onChange={(e) => handlePermissionChange(e.target.value as SharePermission)}
@@ -150,12 +151,13 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
           </select>
         </div>
 
-        <button
+        <Button
+          variant="ghost"
           onClick={() => setShowDeleteConfirm(true)}
-          className="text-sm text-content-tertiary hover:text-error transition-colors"
+          className="px-0 py-0 hover:bg-transparent text-content-tertiary hover:text-error"
         >
           {t('share.cloud.unpublish')}
-        </button>
+        </Button>
 
         {showDeleteConfirm && (
           <div className="bg-error/10 border border-error/30 rounded-lg p-3 space-y-2">
@@ -163,15 +165,12 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
               Are you sure you want to delete this share? The link will stop working.
             </p>
             <div className="flex gap-2">
-              <button
-                onClick={handleDelete}
-                className="btn btn-secondary text-error border-error hover:bg-error hover:text-white"
-              >
+              <Button variant="danger" onClick={handleDelete}>
                 {t('common.delete')}
-              </button>
-              <button onClick={() => setShowDeleteConfirm(false)} className="btn btn-secondary">
+              </Button>
+              <Button variant="secondary" onClick={() => setShowDeleteConfirm(false)}>
                 {t('common.cancel')}
-              </button>
+              </Button>
             </div>
           </div>
         )}
@@ -242,9 +241,9 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
               onClick={() => urlInputRef.current?.select()}
               className="flex-1 bg-surface text-content p-3 rounded font-mono text-sm"
             />
-            <button onClick={handleCopyUrl} className="btn btn-primary px-4">
+            <Button variant="primary" onClick={handleCopyUrl}>
               {urlCopied ? t('share.cloud.linkCopied') : t('common.copy')}
-            </button>
+            </Button>
           </div>
         </div>
 
@@ -253,12 +252,12 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
         </div>
 
         <div className="flex gap-3 pt-2">
-          <button onClick={onClose} className="btn btn-primary">
+          <Button variant="primary" onClick={onClose}>
             {t('common.done')}
-          </button>
-          <button onClick={reset} className="btn btn-secondary">
+          </Button>
+          <Button variant="secondary" onClick={reset}>
             {t('share.shareAnother')}
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -283,12 +282,12 @@ export function CloudShareTab({ layoutId, onClose, onSwitchToUrlTab }: CloudShar
         <p className="text-sm text-content-secondary">{error.message}</p>
 
         <div className="flex gap-3">
-          <button onClick={reset} className="btn btn-primary">
+          <Button variant="primary" onClick={reset}>
             {t('error.tryAgain')}
-          </button>
-          <button onClick={onSwitchToUrlTab} className="btn btn-secondary">
+          </Button>
+          <Button variant="secondary" onClick={onSwitchToUrlTab}>
             {t('share.useShareLinkInstead')}
-          </button>
+          </Button>
         </div>
       </div>
     );

--- a/src/features/cloud-share/components/ShareButton/ShareButton.tsx
+++ b/src/features/cloud-share/components/ShareButton/ShareButton.tsx
@@ -3,6 +3,7 @@ import { useSharedPreviewStore, useSharePopoverStore } from '@/core/store';
 import { useCloudShare } from '@/features/cloud-share/hooks/useCloudShare';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { useTranslation } from '@/i18n';
+import { Button } from '@/design-system';
 import { SharePopover } from './SharePopover';
 
 /**
@@ -35,38 +36,35 @@ export function ShareButton() {
 
   return (
     <>
-      <button
+      <Button
         ref={buttonRef}
+        variant={showSharedIndicator ? 'secondary' : 'primary'}
         onClick={togglePopover}
-        className={`btn px-4 py-1.5 text-sm font-medium flex items-center gap-2 ${
-          showSharedIndicator ? 'btn-secondary' : 'btn-primary'
-        }`}
-        aria-haspopup="true"
-        aria-expanded={isPopoverOpen}
-        title={showSharedIndicator ? t('share.button.manageShare') : t('share.button.shareLayout')}
-      >
-        {isLoading ? (
-          <svg
-            className="w-4 h-4 animate-spin motion-reduce:animate-none"
-            viewBox="0 0 24 24"
-            fill="none"
-          >
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            />
-          </svg>
-        ) : showSharedIndicator ? (
-          <div className="relative">
+        loading={isLoading}
+        leftIcon={
+          showSharedIndicator ? (
+            <div className="relative">
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+                />
+              </svg>
+              <svg
+                className="w-2.5 h-2.5 absolute -top-1 -right-1 text-success"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </div>
+          ) : (
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path
                 strokeLinecap="round"
@@ -75,30 +73,14 @@ export function ShareButton() {
                 d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
               />
             </svg>
-            <svg
-              className="w-2.5 h-2.5 absolute -top-1 -right-1 text-success"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-            >
-              <path
-                fillRule="evenodd"
-                d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </div>
-        ) : (
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
-            />
-          </svg>
-        )}
+          )
+        }
+        aria-haspopup="true"
+        aria-expanded={isPopoverOpen}
+        title={showSharedIndicator ? t('share.button.manageShare') : t('share.button.shareLayout')}
+      >
         {showSharedIndicator ? t('share.button.shared') : t('common.share')}
-      </button>
+      </Button>
 
       {isPopoverOpen && <SharePopover buttonRef={buttonRef} cloudShare={cloudShare} />}
     </>

--- a/src/features/cloud-share/components/ShareModal/ShareModal.tsx
+++ b/src/features/cloud-share/components/ShareModal/ShareModal.tsx
@@ -11,6 +11,7 @@ import { trackEvent } from '@/shared/analytics/posthog';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
 import { useTranslation } from '@/i18n';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
+import { Button, IconButton, XIcon } from '@/design-system';
 import { CloudShareTab } from '../CloudShareTab';
 
 interface ShareModalProps {
@@ -124,78 +125,73 @@ function ShareModalContent({ onClose, layoutId }: { onClose: () => void; layoutI
           <h2 id="share-modal-title" className="text-2xl font-bold text-content">
             {t('share.title')}
           </h2>
-          <button
+          <IconButton
             onClick={onClose}
-            className="p-2 -m-2 rounded-md text-content-tertiary hover:text-content hover:bg-surface-hover transition-colors"
+            touchTarget={false}
+            className="-m-2 text-content-tertiary hover:text-content"
             aria-label={t('common.close')}
           >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path d="M6 18L18 6M6 6l12 12"></path>
-            </svg>
-          </button>
+            <XIcon size="md" />
+          </IconButton>
         </div>
 
         {/* Tab selector */}
         <div className="flex gap-1 mb-4 bg-surface rounded-lg p-1" role="tablist">
           {/* Cloud tab hidden when collaborative_editing is enabled (uses ShareButton instead) */}
           {!isCollabEnabled && (
-            <button
+            <Button
+              variant="ghost"
               role="tab"
               aria-selected={activeTab === 'cloud'}
               onClick={() => handleTabChange('cloud')}
-              className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors ${
+              className={`flex-1 hover:bg-transparent ${
                 activeTab === 'cloud'
                   ? 'bg-accent text-on-dark'
                   : 'text-content-secondary hover:text-content hover:bg-surface-hover'
               }`}
             >
               {t('share.tabs.cloud')}
-            </button>
+            </Button>
           )}
-          <button
+          <Button
+            variant="ghost"
             role="tab"
             aria-selected={activeTab === 'url'}
             onClick={() => handleTabChange('url')}
-            className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors ${
+            className={`flex-1 hover:bg-transparent ${
               activeTab === 'url'
                 ? 'bg-accent text-on-dark'
                 : 'text-content-secondary hover:text-content hover:bg-surface-hover'
             }`}
           >
             {t('share.tabs.link')}
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="ghost"
             role="tab"
             aria-selected={activeTab === 'file'}
             onClick={() => handleTabChange('file')}
-            className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors ${
+            className={`flex-1 hover:bg-transparent ${
               activeTab === 'file'
                 ? 'bg-accent text-on-dark'
                 : 'text-content-secondary hover:text-content hover:bg-surface-hover'
             }`}
           >
             {t('share.tabs.file')}
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="ghost"
             role="tab"
             aria-selected={activeTab === 'json'}
             onClick={() => handleTabChange('json')}
-            className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors ${
+            className={`flex-1 hover:bg-transparent ${
               activeTab === 'json'
                 ? 'bg-accent text-on-dark'
                 : 'text-content-secondary hover:text-content hover:bg-surface-hover'
             }`}
           >
             {t('share.tabs.json')}
-          </button>
+          </Button>
         </div>
 
         {/* Tab content */}
@@ -221,9 +217,9 @@ function ShareModalContent({ onClose, layoutId }: { onClose: () => void; layoutI
                   onClick={() => urlInputRef.current?.select()}
                   className="flex-1 bg-surface text-content p-3 rounded font-mono text-sm"
                 />
-                <button onClick={handleCopyURL} className="btn btn-primary px-4">
+                <Button variant="primary" onClick={handleCopyURL}>
                   {copied ? t('common.copied') : t('common.copy')}
-                </button>
+                </Button>
               </div>
               <div className="text-xs text-content-tertiary">{t('share.link.longUrlNote')}</div>
             </div>
@@ -261,9 +257,9 @@ function ShareModalContent({ onClose, layoutId }: { onClose: () => void; layoutI
                       })}
                     </div>
                   </div>
-                  <button onClick={handleDownload} className="btn btn-primary">
+                  <Button variant="primary" onClick={handleDownload}>
                     {t('common.download')}
-                  </button>
+                  </Button>
                 </div>
               </div>
             </div>
@@ -279,9 +275,9 @@ function ShareModalContent({ onClose, layoutId }: { onClose: () => void; layoutI
                 onClick={() => jsonTextareaRef.current?.select()}
                 className="flex-1 bg-surface text-content p-3 rounded font-mono text-xs resize-none min-h-[200px]"
               />
-              <button onClick={handleCopyJSON} className="btn btn-primary self-start">
+              <Button variant="primary" onClick={handleCopyJSON} className="self-start">
                 {copied ? t('share.json.copied') : t('share.json.copy')}
-              </button>
+              </Button>
             </div>
           )}
         </div>

--- a/src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.test.tsx
+++ b/src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.test.tsx
@@ -330,9 +330,9 @@ describe('SharedLayoutBanner', () => {
 
       // Click discard to show dialog
       fireEvent.click(screen.getByRole('button', { name: /Discard/i }));
-      // Confirm in dialog (the btn-danger button inside the dialog)
+      // Confirm in dialog (the danger-variant button inside the dialog)
       const dialog = screen.getByRole('dialog');
-      const confirmButton = dialog.querySelector('.btn-danger') as HTMLElement;
+      const confirmButton = dialog.querySelector('.to-danger') as HTMLElement;
       fireEvent.click(confirmButton);
 
       await waitFor(() => {
@@ -347,7 +347,7 @@ describe('SharedLayoutBanner', () => {
       fireEvent.click(screen.getByRole('button', { name: /Discard/i }));
       // Confirm in dialog
       const dialog = screen.getByRole('dialog');
-      const confirmButton = dialog.querySelector('.btn-danger') as HTMLElement;
+      const confirmButton = dialog.querySelector('.to-danger') as HTMLElement;
       fireEvent.click(confirmButton);
 
       await waitFor(() => {
@@ -364,7 +364,7 @@ describe('SharedLayoutBanner', () => {
       fireEvent.click(screen.getByRole('button', { name: /Discard/i }));
       // Confirm in dialog
       const dialog = screen.getByRole('dialog');
-      const confirmButton = dialog.querySelector('.btn-danger') as HTMLElement;
+      const confirmButton = dialog.querySelector('.to-danger') as HTMLElement;
       fireEvent.click(confirmButton);
 
       // Check that layout store was updated (handleDiscard is async)

--- a/src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.tsx
+++ b/src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.tsx
@@ -178,7 +178,7 @@ export function SharedLayoutBanner() {
         <Button
           variant="ghost"
           onClick={() => setShowDiscardConfirm(true)}
-          className="px-3 bg-on-accent/15 hover:bg-on-accent/25"
+          className="px-3 bg-on-accent/15 hover:bg-on-accent/25 text-on-accent hover:text-on-accent"
         >
           {t('share.banner.discardConfirm')}
         </Button>

--- a/src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.tsx
+++ b/src/features/cloud-share/components/SharedLayoutBanner/SharedLayoutBanner.tsx
@@ -13,6 +13,7 @@ import { useResultToast } from '@/shared/hooks';
 import { layoutId as toLayoutId } from '@/core/types';
 import { ConfirmDialog } from '@/shared/components';
 import { useCollabMode } from '@/shared/hooks/useCollabMode';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 /**
@@ -167,18 +168,20 @@ export function SharedLayoutBanner() {
       </div>
 
       <div className="flex items-center gap-2">
-        <button
+        <Button
+          variant="ghost"
           onClick={handleSave}
-          className="px-3 py-1.5 text-sm font-medium rounded-md bg-surface text-content hover:bg-surface-hover transition-colors"
+          className="px-3 bg-surface text-content hover:bg-surface-hover"
         >
           {t('share.banner.saveToMyLayouts')}
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="ghost"
           onClick={() => setShowDiscardConfirm(true)}
-          className="px-3 py-1.5 text-sm font-medium rounded-md bg-on-accent/15 hover:bg-on-accent/25 transition-colors"
+          className="px-3 bg-on-accent/15 hover:bg-on-accent/25"
         >
           {t('share.banner.discardConfirm')}
-        </button>
+        </Button>
       </div>
 
       <ConfirmDialog

--- a/src/features/design-linking/components/Dialogs/CreateDesignDialog/CreateDesignDialog.tsx
+++ b/src/features/design-linking/components/Dialogs/CreateDesignDialog/CreateDesignDialog.tsx
@@ -11,6 +11,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useLinkingStore } from '../../../store';
 import { useBinLinking } from '../../../hooks';
 import { formatDimensions } from '../../../domain';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 export function CreateDesignDialog() {
@@ -135,14 +136,15 @@ export function CreateDesignDialog() {
                 autoFocus
               />
               {binLabel && (
-                <button
+                <Button
+                  variant="secondary"
                   type="button"
                   onClick={handleUseBinLabel}
-                  className="btn btn-secondary text-sm whitespace-nowrap focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1 focus:ring-offset-surface-secondary"
+                  className="whitespace-nowrap"
                   title={t('designLinking.createDialog.useLabelTooltip', { label: binLabel })}
                 >
                   {t('designLinking.createDialog.useLabel')}
-                </button>
+                </Button>
               )}
             </div>
           </div>
@@ -163,20 +165,12 @@ export function CreateDesignDialog() {
 
           {/* Actions */}
           <div className="flex gap-2 justify-end">
-            <button
-              type="button"
-              onClick={handleCancel}
-              className="btn btn-secondary h-8 text-sm px-3 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1 focus:ring-offset-surface-secondary"
-            >
+            <Button variant="secondary" type="button" onClick={handleCancel}>
               {t('common.cancel')}
-            </button>
-            <button
-              type="submit"
-              className="btn btn-primary h-8 text-sm px-3 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1 focus:ring-offset-surface-secondary"
-              disabled={!name.trim()}
-            >
+            </Button>
+            <Button variant="primary" type="submit" disabled={!name.trim()}>
               {t('designLinking.createDialog.create')}
-            </button>
+            </Button>
           </div>
         </form>
       </div>

--- a/src/features/design-linking/components/Dialogs/DeleteDesignWarningDialog/DeleteDesignWarningDialog.tsx
+++ b/src/features/design-linking/components/Dialogs/DeleteDesignWarningDialog/DeleteDesignWarningDialog.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useShallow } from 'zustand/react/shallow';
 import { useLinkingStore } from '../../../store';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 export function DeleteDesignWarningDialog() {
@@ -117,19 +118,12 @@ export function DeleteDesignWarningDialog() {
 
         {/* Actions */}
         <div className="flex gap-2 justify-end">
-          <button
-            ref={cancelButtonRef}
-            onClick={handleCancel}
-            className="btn btn-secondary h-8 text-sm px-3 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1 focus:ring-offset-surface-secondary"
-          >
+          <Button ref={cancelButtonRef} variant="secondary" onClick={handleCancel}>
             {t('common.cancel')}
-          </button>
-          <button
-            onClick={handleConfirm}
-            className="btn btn-danger h-8 text-sm px-3 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1 focus:ring-offset-surface-secondary"
-          >
+          </Button>
+          <Button variant="danger" onClick={handleConfirm}>
             {t('designLinking.deleteWarning.confirm')}
-          </button>
+          </Button>
         </div>
       </div>
     </div>,

--- a/src/features/design-linking/components/Dialogs/LinkDesignDialog/LinkDesignDialog.tsx
+++ b/src/features/design-linking/components/Dialogs/LinkDesignDialog/LinkDesignDialog.tsx
@@ -12,6 +12,7 @@ import { listDesigns, type SavedDesign } from '@/features/bin-designer';
 import { useShallow } from 'zustand/react/shallow';
 import { useLinkingStore } from '../../../store';
 import { useBinLinking } from '../../../hooks';
+import { Button, IconButton, XIcon } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 export function LinkDesignDialog() {
@@ -143,26 +144,14 @@ export function LinkDesignDialog() {
               {t('designLinking.linkDialog.footprint', { width, depth })}
             </p>
           </div>
-          <button
+          <IconButton
             onClick={handleCancel}
-            className="rounded-md p-1.5 text-content-secondary hover:bg-surface-hover hover:text-content transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1 focus:ring-offset-surface-secondary"
+            touchTarget={false}
+            className="text-content-secondary hover:text-content"
             aria-label={t('common.close')}
           >
-            <svg
-              className="h-5 w-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
+            <XIcon size="md" />
+          </IconButton>
         </div>
 
         {/* Search input - shown when enough designs */}
@@ -191,20 +180,15 @@ export function LinkDesignDialog() {
                 className="w-full pl-8 pr-3 py-1.5 text-sm bg-surface border border-stroke rounded-md transition-colors"
               />
               {searchQuery && (
-                <button
+                <IconButton
                   onClick={() => setSearchQuery('')}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 text-content-tertiary hover:text-content transition-colors"
+                  size="sm"
+                  touchTarget={false}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-content-tertiary hover:text-content"
                   aria-label={t('common.clear')}
                 >
-                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
+                  <XIcon size="sm" />
+                </IconButton>
               )}
             </div>
           </div>
@@ -305,9 +289,10 @@ export function LinkDesignDialog() {
 
                 return (
                   <li key={design.id}>
-                    <button
+                    <Button
+                      variant="ghost"
                       onClick={() => handleSelect(design)}
-                      className="w-full flex items-center gap-3 rounded-lg border border-stroke-subtle px-3 py-2 transition-colors hover:bg-surface-hover hover:border-stroke text-left focus:outline-none focus:ring-2 focus:ring-accent focus:ring-inset"
+                      className="w-full flex items-center justify-start gap-3 rounded-lg border border-stroke-subtle px-3 py-2 hover:bg-surface-hover hover:border-stroke text-left font-normal"
                     >
                       {/* Thumbnail */}
                       <div className="w-12 h-12 rounded-md overflow-hidden bg-surface-elevated flex-shrink-0 relative">
@@ -372,7 +357,7 @@ export function LinkDesignDialog() {
                           d="M9 5l7 7-7 7"
                         />
                       </svg>
-                    </button>
+                    </Button>
                   </li>
                 );
               })}
@@ -382,9 +367,9 @@ export function LinkDesignDialog() {
 
         {/* Footer - compact */}
         <div className="flex justify-end gap-2 border-t border-stroke-subtle px-4 py-3 flex-shrink-0">
-          <button onClick={handleCancel} className="btn btn-secondary h-8 text-sm px-3">
+          <Button variant="secondary" onClick={handleCancel}>
             {t('common.cancel')}
-          </button>
+          </Button>
         </div>
       </div>
     </div>,

--- a/src/features/design-linking/components/Dialogs/SyncDimensionsDialog/SyncDimensionsDialog.tsx
+++ b/src/features/design-linking/components/Dialogs/SyncDimensionsDialog/SyncDimensionsDialog.tsx
@@ -10,6 +10,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useLinkingStore } from '../../../store';
 import { useBinLinking } from '../../../hooks';
 import { formatDimensions } from '../../../domain';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 export function SyncDimensionsDialog() {
@@ -155,18 +156,12 @@ export function SyncDimensionsDialog() {
 
         {/* Actions */}
         <div className="flex gap-2 justify-end">
-          <button
-            onClick={handleCancel}
-            className="btn btn-secondary h-8 text-sm px-3 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1 focus:ring-offset-surface-secondary"
-          >
+          <Button variant="secondary" onClick={handleCancel}>
             {t('common.cancel')}
-          </button>
-          <button
-            onClick={() => void handleSync()}
-            className="btn btn-primary h-8 text-sm px-3 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1 focus:ring-offset-surface-secondary"
-          >
+          </Button>
+          <Button variant="primary" onClick={() => void handleSync()}>
             {t('designLinking.syncDialog.sync')}
-          </button>
+          </Button>
         </div>
       </div>
     </div>,

--- a/src/features/design-linking/components/LinkedDesignSection/LinkedDesignSection.tsx
+++ b/src/features/design-linking/components/LinkedDesignSection/LinkedDesignSection.tsx
@@ -12,6 +12,7 @@ import { useLinkedDesign, useBinLinking, useQuickExport } from '../../hooks';
 import { useLinkingStore } from '../../store';
 import { ConfirmDialog } from '@/shared/components';
 import { useDesignThumbnail } from '@/features/bin-designer';
+import { Button, IconButton, PlusIcon } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import type { Bin } from '@/core/types';
 
@@ -113,35 +114,32 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
           </span>
         </div>
         <div className="flex gap-2">
-          <button
+          <Button
+            variant="secondary"
             onClick={() => showCreateDesignDialog(bin.id)}
-            className={`btn btn-secondary flex-1 ${buttonHeight} flex items-center justify-center gap-2 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1 focus:ring-offset-surface-secondary`}
+            leftIcon={<PlusIcon size="sm" />}
+            className={`flex-1 ${buttonHeight}`}
           >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 6v6m0 0v6m0-6h6m-6 0H6"
-              />
-            </svg>
             {t('designLinking.inspector.createDesign')}
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="secondary"
             onClick={() => showLinkDesignDialog(bin.id, bin.width, bin.depth, bin.height)}
-            className={`btn btn-secondary flex-1 ${buttonHeight} flex items-center justify-center gap-2 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1 focus:ring-offset-surface-secondary`}
+            className={`flex-1 ${buttonHeight}`}
             title={t('designLinking.inspector.linkExistingTooltip')}
+            leftIcon={
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+                />
+              </svg>
+            }
           >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-              />
-            </svg>
             {t('designLinking.inspector.linkExisting')}
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -178,12 +176,14 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
               {t('designLinking.inspector.designDeleted')}
             </span>
           </div>
-          <button
+          <Button
+            variant="secondary"
+            fullWidth
             onClick={() => unlinkBin(bin.id)}
-            className={`btn btn-secondary w-full ${buttonHeight} text-sm`}
+            className={buttonHeight}
           >
             {t('designLinking.inspector.unlink')}
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -209,9 +209,10 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
 
       <div className="flex items-center gap-3">
         {/* Thumbnail with link indicator */}
-        <button
+        <Button
+          variant="ghost"
           onClick={handleThumbnailClick}
-          className={`${thumbSize} flex-shrink-0 rounded-md overflow-hidden relative hover:ring-2 hover:ring-accent/50 transition-all focus:outline-none focus:ring-2 focus:ring-accent`}
+          className={`${thumbSize} flex-shrink-0 p-0 rounded-md overflow-hidden relative block hover:bg-transparent hover:ring-2 hover:ring-accent/50`}
           title={t('designLinking.inspector.clickToEdit')}
         >
           {thumbnail ? (
@@ -249,7 +250,7 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
               />
             </svg>
           </div>
-        </button>
+        </Button>
 
         {/* Name and dimensions */}
         <div className="flex-1 min-w-0">
@@ -263,44 +264,32 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
       {/* Action buttons - icon + label */}
       <div className="flex items-center gap-2">
         {/* Edit button with label */}
-        <button
+        <Button
+          variant="secondary"
           onClick={() => editLinkedDesign(linkedDesign.id)}
-          className={`btn btn-secondary flex-1 ${actionButtonClass} flex items-center justify-center gap-1.5 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1 focus:ring-offset-surface-secondary`}
-        >
-          <svg className={iconSize} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
-            />
-          </svg>
-          {t('designLinking.inspector.editDesign')}
-        </button>
-
-        {/* Export button with label */}
-        <button
-          onClick={handleExport}
-          disabled={isExporting}
-          className={`btn btn-secondary flex-1 ${actionButtonClass} flex items-center justify-center gap-1.5 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1 focus:ring-offset-surface-secondary`}
-        >
-          {isExporting ? (
-            <svg className={`${iconSize} animate-spin`} fill="none" viewBox="0 0 24 24">
-              <circle
-                className="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                strokeWidth="4"
-              />
+          className={`flex-1 ${actionButtonClass}`}
+          leftIcon={
+            <svg className={iconSize} fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path
-                className="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
               />
             </svg>
-          ) : (
+          }
+        >
+          {t('designLinking.inspector.editDesign')}
+        </Button>
+
+        {/* Export button with label */}
+        <Button
+          variant="secondary"
+          onClick={handleExport}
+          disabled={isExporting}
+          loading={isExporting}
+          className={`flex-1 ${actionButtonClass}`}
+          leftIcon={
             <svg className={iconSize} fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path
                 strokeLinecap="round"
@@ -309,19 +298,23 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
                 d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
               />
             </svg>
-          )}
+          }
+        >
           {t('common.export')}
-        </button>
+        </Button>
 
         {/* Overflow menu button */}
         <div className="relative">
-          <button
+          <IconButton
             ref={menuButtonRef}
+            variant="secondary"
             onClick={() => setMenuOpen(!menuOpen)}
-            className={`btn btn-secondary ${isMobile ? 'h-9 w-9' : 'h-7 w-7'} p-0 flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1 focus:ring-offset-surface-secondary`}
+            touchTarget={false}
+            className={isMobile ? 'h-9 w-9' : 'h-7 w-7'}
             title={t('common.moreOptions')}
             aria-haspopup="true"
             aria-expanded={menuOpen}
+            aria-label={t('common.moreOptions')}
           >
             <svg className={iconSize} fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path
@@ -331,7 +324,7 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
                 d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"
               />
             </svg>
-          </button>
+          </IconButton>
 
           {/* Dropdown menu */}
           {menuOpen && (
@@ -340,9 +333,10 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
               className="absolute right-0 mt-1 w-40 py-1 bg-surface-secondary border border-stroke rounded-lg shadow-lg z-10"
               role="menu"
             >
-              <button
+              <Button
+                variant="ghost"
                 onClick={handleUnlink}
-                className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface-hover flex items-center gap-2 transition-colors"
+                className="w-full justify-start rounded-none px-3 py-2 text-left text-sm font-normal text-content hover:bg-surface-hover"
                 role="menuitem"
               >
                 <svg
@@ -365,10 +359,11 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
                   />
                 </svg>
                 {t('designLinking.inspector.unlink')}
-              </button>
-              <button
+              </Button>
+              <Button
+                variant="ghost"
                 onClick={handleDelete}
-                className="w-full px-3 py-2 text-left text-sm text-status-error hover:bg-surface-hover flex items-center gap-2 transition-colors"
+                className="w-full justify-start rounded-none px-3 py-2 text-left text-sm font-normal text-status-error hover:bg-surface-hover"
                 role="menuitem"
               >
                 <svg
@@ -385,7 +380,7 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
                   />
                 </svg>
                 {t('designLinking.inspector.deleteDesign')}
-              </button>
+              </Button>
             </div>
           )}
         </div>

--- a/src/features/grid-editor/components/Grid/GridAxisLabels/GridAxisLabels.tsx
+++ b/src/features/grid-editor/components/Grid/GridAxisLabels/GridAxisLabels.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { Button } from '@/design-system';
 import { useViewStore } from '@/core/store/view';
 import type { GridAxisLabelsState } from '@/features/grid-editor/hooks/useGridAxisLabels';
 
@@ -85,10 +86,12 @@ export const RowLabels = memo(function RowLabels({
         const label = typeof num === 'number' && num % 1 !== 0 ? num.toFixed(1) : num;
 
         return (
-          <button
+          <Button
+            variant="ghost"
             key={`row-${num}`}
             type="button"
-            className="group flex items-center justify-center select-none transition-colors font-medium text-content-tertiary tabular-nums bg-transparent border-0 cursor-pointer hover:text-content"
+            touchTarget={false}
+            className="group select-none rounded-none font-medium text-content-tertiary tabular-nums hover:bg-transparent hover:text-content cursor-pointer"
             style={{
               width: labelWidth,
               height: rowHeight,
@@ -104,7 +107,7 @@ export const RowLabels = memo(function RowLabels({
             aria-label={`Select bins in row ${label}`}
           >
             {labelFontSize > 0 && label}
-          </button>
+          </Button>
         );
       })}
     </div>
@@ -160,10 +163,12 @@ export const ColumnLabels = memo(function ColumnLabels({
         const label = typeof num === 'number' && num % 1 !== 0 ? num.toFixed(1) : num;
 
         return (
-          <button
+          <Button
+            variant="ghost"
             key={`col-${num}`}
             type="button"
-            className="group flex items-center justify-center select-none transition-colors font-medium text-content-tertiary tabular-nums bg-transparent border-0 cursor-pointer hover:text-content"
+            touchTarget={false}
+            className="group select-none rounded-none font-medium text-content-tertiary tabular-nums hover:bg-transparent hover:text-content cursor-pointer"
             style={{
               width: colWidth,
               height: columnLabelHeight,
@@ -179,7 +184,7 @@ export const ColumnLabels = memo(function ColumnLabels({
             aria-label={`Select bins in column ${label}`}
           >
             {labelFontSize > 0 && label}
-          </button>
+          </Button>
         );
       })}
     </div>

--- a/src/features/grid-editor/components/Grid/GridToolbar/GridToolbar.test.tsx
+++ b/src/features/grid-editor/components/Grid/GridToolbar/GridToolbar.test.tsx
@@ -311,7 +311,7 @@ describe('GridToolbar', () => {
 
       const cubeIcon = container.querySelector('path[d*="M21 8a2 2 0"]');
       const button = cubeIcon?.closest('button');
-      expect(button).toHaveClass('btn-primary');
+      expect(button).toHaveClass('text-on-accent');
     });
 
     it('applies ghost button styling when preview is hidden', () => {
@@ -321,7 +321,7 @@ describe('GridToolbar', () => {
 
       const cubeIcon = container.querySelector('path[d*="M21 8a2 2 0"]');
       const button = cubeIcon?.closest('button');
-      expect(button).toHaveClass('btn-ghost');
+      expect(button).toHaveClass('bg-transparent');
     });
   });
 

--- a/src/features/grid-editor/components/Grid/GridToolbar/GridToolbar.tsx
+++ b/src/features/grid-editor/components/Grid/GridToolbar/GridToolbar.tsx
@@ -3,6 +3,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useViewStore } from '@/core/store/view';
 import { useInteractionStore } from '@/core/store/interaction';
 import { Checkbox } from '@/shared/components/Checkbox';
+import { Button, IconButton, ChevronDownIcon, MinusIcon, PlusIcon, XIcon } from '@/design-system';
 import { trackEvent } from '@/shared/analytics/posthog';
 import { useTranslation } from '@/i18n';
 import type { Layer } from '@/core/types';
@@ -98,30 +99,17 @@ export const GridToolbar = memo(function GridToolbar({
       {/* Left: Layer indicator + Paint mode */}
       <div className="flex items-center gap-3">
         {layers.length > 1 && activeLayer && (
-          <button
+          <Button
+            variant="secondary"
             onClick={() => leftPanelCollapsed && toggleLeftPanel()}
-            className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-surface-elevated border border-stroke-subtle transition-colors hover:bg-surface-hover"
+            className="gap-2 px-3 py-1.5"
             title={leftPanelCollapsed ? t('toolbar.showLayersPanel') : activeLayer.name}
           >
             <div className="w-2 h-2 rounded-full bg-accent" />
             <span className="text-sm font-medium">{activeLayer.name}</span>
             <span className="text-xs text-content-tertiary">{activeLayer.height}u</span>
-            {leftPanelCollapsed && (
-              <svg
-                className="w-3 h-3 text-content-tertiary"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M19 9l-7 7-7-7"
-                />
-              </svg>
-            )}
-          </button>
+            {leftPanelCollapsed && <ChevronDownIcon className="w-3 h-3 text-content-tertiary" />}
+          </Button>
         )}
 
         {/* Keyboard drag mode indicator */}
@@ -152,22 +140,16 @@ export const GridToolbar = memo(function GridToolbar({
                 Enter
               </kbd>
               <span className="text-xs text-info/60">{t('toolbar.toPlace')}</span>
-              <button
+              <IconButton
+                size="sm"
+                touchTarget={false}
                 onClick={() => setKeyboardDragMode(false)}
-                className="text-info hover:text-info/70 transition-colors p-1.5 ml-1 rounded hover:bg-info/10"
+                className="text-info hover:text-info/70 hover:bg-info/10 ml-1"
                 aria-label={t('toolbar.exitMoveMode')}
                 title={t('toolbar.exitMoveModeEsc')}
               >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
+                <XIcon className="w-4 h-4" />
+              </IconButton>
             </div>
           </div>
         )}
@@ -200,22 +182,16 @@ export const GridToolbar = memo(function GridToolbar({
                 Enter
               </kbd>
               <span className="text-xs text-info/60">{t('toolbar.toApply')}</span>
-              <button
+              <IconButton
+                size="sm"
+                touchTarget={false}
                 onClick={() => setKeyboardResizeMode(false)}
-                className="text-info hover:text-info/70 transition-colors p-1.5 ml-1 rounded hover:bg-info/10"
+                className="text-info hover:text-info/70 hover:bg-info/10 ml-1"
                 aria-label={t('toolbar.exitResizeMode')}
                 title={t('toolbar.exitResizeModeEsc')}
               >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
+                <XIcon className="w-4 h-4" />
+              </IconButton>
             </div>
           </div>
         )}
@@ -252,55 +228,50 @@ export const GridToolbar = memo(function GridToolbar({
           role="group"
           aria-label={t('toolbar.zoomControls')}
         >
-          <button
+          <IconButton
+            size="sm"
+            touchTarget={false}
             onClick={zoomOut}
             disabled={!canZoomOut}
-            className="btn btn-ghost p-1.5"
             aria-label={t('toolbar.zoomOut')}
             title={t('toolbar.zoomOutKey')}
           >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-            </svg>
-          </button>
+            <MinusIcon className="w-4 h-4" />
+          </IconButton>
           <span className="min-w-[44px] text-center text-sm text-content-secondary tabular-nums">
             {Math.round(zoom * 100)}%
           </span>
-          <button
+          <IconButton
+            size="sm"
+            touchTarget={false}
             onClick={zoomIn}
             disabled={!canZoomIn}
-            className="btn btn-ghost p-1.5"
             aria-label={t('toolbar.zoomIn')}
             title={t('toolbar.zoomInKey')}
           >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 4v16m8-8H4"
-              />
-            </svg>
-          </button>
-          <button
+            <PlusIcon className="w-4 h-4" />
+          </IconButton>
+          <Button
+            variant="ghost"
             onClick={fitToScreen}
-            className="btn btn-ghost px-2.5 py-1.5 text-sm"
+            className="px-2.5 py-1.5 text-sm"
             aria-label={t('toolbar.fitGridToScreen')}
             title={t('toolbar.fitToScreen')}
           >
             {t('toolbar.fit')}
-          </button>
+          </Button>
         </div>
 
         {/* 3D Preview toggle */}
-        <button
+        <Button
+          variant={showIsometricPreview ? 'primary' : 'ghost'}
           onClick={() => {
             if (!showIsometricPreview) {
               trackEvent('ui.featureUsed', { feature: '3d_preview' });
             }
             toggleIsometricPreview();
           }}
-          className={`btn ${showIsometricPreview ? 'btn-primary' : 'btn-ghost'} px-2.5 py-1.5 flex items-center gap-1.5`}
+          className="px-2.5 py-1.5 gap-1.5"
           aria-label={t(showIsometricPreview ? 'toolbar.hide3dPreview' : 'toolbar.show3dPreview')}
           title={t(showIsometricPreview ? 'toolbar.hide3dPreview' : 'toolbar.show3dPreview')}
         >
@@ -318,14 +289,16 @@ export const GridToolbar = memo(function GridToolbar({
             <path d="M12 22V12" />
           </svg>
           {!isNarrowToolbar && <span className="text-sm">{t('toolbar.3dView')}</span>}
-        </button>
+        </Button>
 
         {/* Overflow menu button - only when narrow */}
         {isNarrowToolbar && layers.length > 1 && (
           <div className="relative" ref={overflowMenuRef}>
-            <button
+            <IconButton
+              size="sm"
+              touchTarget={false}
+              variant={overflowMenuOpen ? 'secondary' : 'ghost'}
               onClick={() => setOverflowMenuOpen(!overflowMenuOpen)}
-              className={`btn ${overflowMenuOpen ? 'btn-primary' : 'btn-ghost'} p-1.5`}
               aria-label={t('common.moreOptions')}
               aria-expanded={overflowMenuOpen}
               aria-haspopup="menu"
@@ -339,7 +312,7 @@ export const GridToolbar = memo(function GridToolbar({
                   d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"
                 />
               </svg>
-            </button>
+            </IconButton>
 
             {/* Overflow dropdown */}
             {overflowMenuOpen && (

--- a/src/features/grid-editor/components/Grid/GridToolbar/GridToolbar.tsx
+++ b/src/features/grid-editor/components/Grid/GridToolbar/GridToolbar.tsx
@@ -94,7 +94,7 @@ export const GridToolbar = memo(function GridToolbar({
     <div
       data-grid-toolbar
       ref={toolbarRef}
-      className="flex items-center justify-between px-4 py-[7.5px] bg-surface-secondary border-b border-stroke-subtle"
+      className="flex items-center justify-between px-4 h-[47px] bg-surface-secondary border-b border-stroke-subtle"
     >
       {/* Left: Layer indicator + Paint mode */}
       <div className="flex items-center gap-3">

--- a/src/features/grid-editor/components/Grid/QuickLabelPopover/QuickLabelPopover.tsx
+++ b/src/features/grid-editor/components/Grid/QuickLabelPopover/QuickLabelPopover.tsx
@@ -7,6 +7,7 @@ import { mlTracking } from '@/shared/analytics/useMLTracking';
 import { useTranslation } from '@/i18n';
 import { batch } from '@/core/cqrs';
 import { trackEvent } from '@/shared/analytics/posthog';
+import { IconButton, XIcon } from '@/design-system';
 
 /**
  * Small popover that appears near a bin for quick label editing.
@@ -152,21 +153,16 @@ function QuickLabelPopoverInner({ binId }: { binId: string }) {
               style={{ minWidth: '200px' }}
             />
             {value && (
-              <button
+              <IconButton
+                size="sm"
+                touchTarget={false}
                 type="button"
                 onClick={handleClear}
-                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded text-content-tertiary hover:text-content hover:bg-surface-hover transition-colors"
+                className="absolute right-2 top-1/2 -translate-y-1/2"
                 aria-label={t('common.clear')}
               >
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
+                <XIcon className="w-4 h-4" />
+              </IconButton>
             )}
           </div>
 

--- a/src/features/inspiration-gallery/components/InspirationGallery/InspirationGallery.tsx
+++ b/src/features/inspiration-gallery/components/InspirationGallery/InspirationGallery.tsx
@@ -19,6 +19,7 @@ import type { InspirationLayout, InspirationTheme } from '../../types';
 import { ThemeFilterPills } from '../ThemeFilterPills';
 import { LayoutCard } from '../LayoutCard';
 import { LayoutPreviewOverlay } from '../LayoutPreviewOverlay';
+import { Button, IconButton, XIcon } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 interface InspirationGalleryProps {
@@ -329,23 +330,15 @@ function InspirationGalleryContent({ onClose }: { onClose: () => void }) {
                   />
                 </div>
               )}
-              <button
+              <IconButton
                 ref={closeButtonRef}
                 onClick={() =>
                   handleCloseGallery(templateApplied ? 'applied_template' : 'dismissed')
                 }
-                className="p-1.5 text-content-secondary hover:text-content hover:bg-surface rounded-lg transition-colors"
                 aria-label={t('common.close')}
               >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
+                <XIcon className="w-5 h-5" />
+              </IconButton>
             </div>
           </div>
           {/* Filter row */}
@@ -400,12 +393,14 @@ function InspirationGalleryContent({ onClose }: { onClose: () => void }) {
                 />
               </svg>
               <p className="text-content-secondary mb-2">{t('gallery.empty')}</p>
-              <button
+              <Button
+                variant="ghost"
+                size="sm"
                 onClick={() => setSelectedTheme('all')}
-                className="text-sm text-accent hover:underline"
+                className="px-0 text-accent hover:bg-transparent hover:underline"
               >
                 {t('gallery.browseAllLayouts')}
-              </button>
+              </Button>
             </div>
           )}
         </div>

--- a/src/features/inspiration-gallery/components/LayoutPreviewOverlay/LayoutPreviewOverlay.tsx
+++ b/src/features/inspiration-gallery/components/LayoutPreviewOverlay/LayoutPreviewOverlay.tsx
@@ -5,6 +5,7 @@ import { LayoutThumbnailWithLabels } from '../LayoutThumbnailWithLabels';
 import { THEME_CONFIG } from '../../types';
 import { INSPIRATION_LAYOUTS } from '../../data';
 import type { InspirationLayout } from '../../types';
+import { Button, IconButton, ArrowLeftIcon } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 interface LayoutPreviewOverlayProps {
@@ -92,21 +93,13 @@ export function LayoutPreviewOverlay({
         {/* Header */}
         <div className="flex items-center justify-between p-4 md:p-6 border-b border-stroke-subtle shrink-0">
           <div className="flex items-center gap-3">
-            <button
+            <IconButton
               ref={closeButtonRef}
               onClick={onClose}
-              className="p-2 text-content-secondary hover:text-content hover:bg-surface rounded-lg transition-colors"
               aria-label={t('gallery.backToGallery')}
             >
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M10 19l-7-7m0 0l7-7m-7 7h18"
-                />
-              </svg>
-            </button>
+              <ArrowLeftIcon className="w-5 h-5" />
+            </IconButton>
             <h2 id="preview-title" className="text-lg md:text-xl font-bold text-content">
               {name}
             </h2>
@@ -196,10 +189,11 @@ export function LayoutPreviewOverlay({
                 </h3>
                 <div className="flex gap-2">
                   {relatedLayouts.map((related) => (
-                    <button
+                    <Button
                       key={related.id}
+                      variant="ghost"
                       onClick={() => onSelectRelated(related)}
-                      className="flex-1 p-2 rounded-lg bg-surface hover:bg-surface-hover border border-stroke-subtle hover:border-stroke transition-colors text-left"
+                      className="flex-1 flex-col items-stretch p-2 rounded-lg bg-surface hover:bg-surface-hover border border-stroke-subtle hover:border-stroke text-left"
                     >
                       <div className="aspect-[3/4] bg-surface-secondary rounded mb-1.5 flex items-center justify-center overflow-hidden p-1">
                         <LayoutThumbnailWithLabels
@@ -218,7 +212,7 @@ export function LayoutPreviewOverlay({
                         {related.metrics.binCount}
                         {t('gallery.bins')}
                       </div>
-                    </button>
+                    </Button>
                   ))}
                 </div>
               </div>
@@ -232,38 +226,14 @@ export function LayoutPreviewOverlay({
             <p className="text-sm text-content-secondary">
               {t('gallery.useAsAStartingPointCustomizeToFitYo')}
             </p>
-            <button
+            <Button
+              variant="primary"
+              loading={isImporting}
               onClick={onUseLayout}
-              disabled={isImporting}
-              className="btn btn-primary px-6 shrink-0"
+              className="px-6 shrink-0"
             >
-              {isImporting ? (
-                <>
-                  <svg
-                    className="animate-spin motion-reduce:animate-none -ml-1 mr-2 h-4 w-4"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    />
-                  </svg>
-                  Adding...
-                </>
-              ) : (
-                t('gallery.useAsStartingPoint')
-              )}
-            </button>
+              {isImporting ? 'Adding...' : t('gallery.useAsStartingPoint')}
+            </Button>
           </div>
         </div>
       </div>

--- a/src/features/inspiration-gallery/components/ThemeFilterPills/ThemeFilterPills.tsx
+++ b/src/features/inspiration-gallery/components/ThemeFilterPills/ThemeFilterPills.tsx
@@ -1,5 +1,6 @@
 import { THEME_CONFIG } from '../../types';
 import type { InspirationTheme } from '../../types';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 interface ThemeFilterPillsProps {
@@ -34,18 +35,18 @@ export function ThemeFilterPills({
         const count = themeCounts[theme];
 
         return (
-          <button
+          <Button
+            variant="ghost"
             type="button"
             key={theme}
             role="tab"
             aria-selected={isSelected}
             onClick={() => onThemeChange(theme)}
             className={`
-              flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium
-              transition-all duration-150 whitespace-nowrap
+              gap-1.5 px-3 py-1.5 rounded-full whitespace-nowrap
               ${
                 isSelected
-                  ? 'bg-accent text-on-dark shadow-sm'
+                  ? 'bg-accent text-on-dark shadow-sm hover:bg-accent'
                   : 'bg-surface text-content-secondary hover:text-content hover:bg-surface-hover'
               }
             `}
@@ -72,7 +73,7 @@ export function ThemeFilterPills({
             >
               {count}
             </span>
-          </button>
+          </Button>
         );
       })}
     </div>

--- a/src/features/labs/components/GraduatedSection/GraduatedSection.tsx
+++ b/src/features/labs/components/GraduatedSection/GraduatedSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { FeatureFlag } from '@/core/labs';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 interface GraduatedSectionProps {
@@ -14,16 +15,18 @@ export function GraduatedSection({ features }: GraduatedSectionProps) {
 
   return (
     <section className="mt-6 pt-4 border-t border-dashed border-stroke-subtle">
-      <button
+      <Button
+        variant="ghost"
+        fullWidth
         onClick={() => setIsExpanded(!isExpanded)}
-        className="flex items-center gap-2 w-full text-left text-sm font-medium text-content-secondary hover:text-content transition-colors"
+        className="justify-start gap-2 px-0 text-left text-sm font-medium text-content-secondary hover:bg-transparent"
         aria-expanded={isExpanded}
       >
         <ChevronIcon
           className={`w-4 h-4 transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
         />
         <span>{t('labs.whatsNew', { count: features.length })}</span>
-      </button>
+      </Button>
 
       {isExpanded && (
         <div className="mt-3 space-y-2">

--- a/src/features/labs/components/LabsButton/LabsButton.tsx
+++ b/src/features/labs/components/LabsButton/LabsButton.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useLabsStore } from '@/core/store';
 import { getFeature } from '@/core/labs';
+import { Button } from '@/design-system';
 import { SparklesIcon } from '../icons';
 import { useTranslation } from '@/i18n';
 
@@ -18,9 +19,11 @@ export function LabsButton() {
   }, [enabledFeatures]);
 
   return (
-    <button
+    <Button
+      variant="ghost"
+      fullWidth
       onClick={openDrawer}
-      className="flex items-center gap-2 w-full px-3 py-2 text-content-secondary hover:text-content hover:bg-surface-hover rounded-md transition-colors"
+      className="justify-start gap-2 px-3 py-2 font-normal text-content-secondary"
       aria-label={`Open Labs experimental features${enabledCount > 0 ? `, ${enabledCount} enabled` : ''}`}
     >
       <SparklesIcon className="w-[18px] h-[18px] flex-shrink-0" />
@@ -33,6 +36,6 @@ export function LabsButton() {
           {enabledCount > 9 ? t('common.overflowCount') : enabledCount}
         </span>
       )}
-    </button>
+    </Button>
   );
 }

--- a/src/features/labs/components/LabsDrawer/LabsDrawer.tsx
+++ b/src/features/labs/components/LabsDrawer/LabsDrawer.tsx
@@ -6,6 +6,7 @@ import { EngineSelector, KERNEL_FEATURE_IDS } from '../EngineSelector';
 import { FeatureCard } from '../FeatureCard';
 import { GraduatedSection } from '../GraduatedSection';
 import { SparklesIcon, CloseIcon } from '../icons';
+import { IconButton } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 export function LabsDrawer() {
@@ -75,14 +76,14 @@ export function LabsDrawer() {
               <SparklesIcon className="w-5 h-5 text-accent" />
               <h2 className="text-lg font-semibold text-content">{t('labs.labs')}</h2>
             </div>
-            <button
+            <IconButton
               ref={closeButtonRef}
               onClick={closeDrawer}
-              className="p-2 -mr-2 rounded-md text-content-secondary hover:text-content hover:bg-surface-hover transition-colors"
+              className="-mr-2"
               aria-label={t('labs.closeLabs')}
             >
               <CloseIcon className="w-5 h-5" />
-            </button>
+            </IconButton>
           </header>
 
           <div className="flex-1 overflow-y-auto scrollbar-thin p-6">

--- a/src/features/layers/components/ActiveLayerPanel/ActiveLayerPanel.tsx
+++ b/src/features/layers/components/ActiveLayerPanel/ActiveLayerPanel.tsx
@@ -11,6 +11,7 @@ import { gridUnits } from '@/core/types';
 import { getLayerBins } from '@/shared/utils';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { SizeSelectorPopover } from './SizeSelectorPopover';
 import { batch } from '@/core/cqrs';
@@ -130,13 +131,13 @@ export function ActiveLayerPanel() {
       {/* Compact toolbar — 3 full-width rows */}
       <div className="flex flex-col gap-1.5">
         {/* Row 1: Size selector */}
-        <button
+        <Button
           ref={sizeButtonRef}
+          variant="secondary"
+          fullWidth
           onClick={handleSizeButtonClick}
-          className={`btn w-full justify-center text-sm h-8 gap-1.5 ${
-            paintSize
-              ? 'bg-accent/15 border-accent/60 text-accent hover:bg-accent/25'
-              : 'btn-secondary'
+          className={`text-sm h-8 gap-1.5 ${
+            paintSize ? 'bg-accent/15 border-accent/60 text-accent hover:bg-accent/25' : ''
           }`}
           title={
             paintSize
@@ -165,7 +166,7 @@ export function ActiveLayerPanel() {
           >
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
           </svg>
-        </button>
+        </Button>
 
         {/* Status strip: makes paint mode unmistakable while a size is loaded */}
         {paintSize && (
@@ -192,19 +193,23 @@ export function ActiveLayerPanel() {
 
         {/* Row 2: Fill — shows "Fill with NxN" when size selected, "Fill gaps" otherwise */}
         {paintSize ? (
-          <button
+          <Button
+            variant="primary"
+            fullWidth
             onClick={handleFill}
-            className="btn btn-primary w-full justify-center text-sm h-8"
+            className="text-sm h-8"
             title={t('layers.fillTitle', { width: paintSize.width, depth: paintSize.depth })}
           >
             {t('layers.fillWith')}
             {paintSize.width}×{paintSize.depth}
-          </button>
+          </Button>
         ) : (
-          <button
+          <Button
+            variant="secondary"
+            fullWidth
             onClick={handleFillGaps}
             disabled={emptyCells === 0}
-            className="btn btn-secondary w-full justify-center text-sm h-8 gap-1.5"
+            className="text-sm h-8 gap-1.5"
             title={
               emptyCells > 0
                 ? t('layers.fillGapsTitle', { count: emptyCells })
@@ -220,14 +225,16 @@ export function ActiveLayerPanel() {
               />
             </svg>
             {emptyCells > 0 ? t('layers.fillGaps', { count: emptyCells }) : t('layers.noGaps')}
-          </button>
+          </Button>
         )}
 
         {/* Row 3: Clear layer */}
-        <button
+        <Button
+          variant="ghost"
+          fullWidth
           onClick={() => setShowClearConfirm(true)}
           disabled={layerBins.length === 0}
-          className="btn btn-ghost w-full justify-center text-sm h-8 gap-1.5 text-error hover:bg-error/10"
+          className="text-sm h-8 gap-1.5 text-error hover:bg-error/10"
           title={
             layerBins.length > 0
               ? t('layers.clearBinsTitle', { count: layerBins.length })
@@ -245,7 +252,7 @@ export function ActiveLayerPanel() {
           {layerBins.length > 0
             ? t('layers.clearBins', { count: layerBins.length })
             : t('layers.noBins')}
-        </button>
+        </Button>
       </div>
 
       {/* Size selector popover */}

--- a/src/features/layers/components/ActiveLayerPanel/ActiveLayerPanel.tsx
+++ b/src/features/layers/components/ActiveLayerPanel/ActiveLayerPanel.tsx
@@ -234,7 +234,7 @@ export function ActiveLayerPanel() {
           fullWidth
           onClick={() => setShowClearConfirm(true)}
           disabled={layerBins.length === 0}
-          className="text-sm h-8 gap-1.5 text-error hover:bg-error/10"
+          className="text-sm h-8 gap-1.5 text-error hover:bg-error/10 hover:text-error"
           title={
             layerBins.length > 0
               ? t('layers.clearBinsTitle', { count: layerBins.length })

--- a/src/features/layers/components/ActiveLayerPanel/ActiveLayerPanel.tsx
+++ b/src/features/layers/components/ActiveLayerPanel/ActiveLayerPanel.tsx
@@ -133,11 +133,11 @@ export function ActiveLayerPanel() {
         {/* Row 1: Size selector */}
         <Button
           ref={sizeButtonRef}
-          variant="secondary"
+          variant={paintSize ? 'ghost' : 'secondary'}
           fullWidth
           onClick={handleSizeButtonClick}
           className={`text-sm h-8 gap-1.5 ${
-            paintSize ? 'bg-accent/15 border-accent/60 text-accent hover:bg-accent/25' : ''
+            paintSize ? 'bg-accent/15 border border-accent/60 text-accent hover:bg-accent/25' : ''
           }`}
           title={
             paintSize

--- a/src/features/layers/components/LayerPanel/LayerPanel.tsx
+++ b/src/features/layers/components/LayerPanel/LayerPanel.tsx
@@ -8,6 +8,7 @@ import { getGridBins, getLayerBins } from '@/shared/utils';
 import { getDisplayLayers } from '@/shared/utils/collision';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { CollapsibleSection } from '@/shared/components/CollapsibleSection';
+import { IconButton, PlusIcon } from '@/design-system';
 import { isOk, isErr } from '@/core/result';
 import { useToastStore } from '@/core/store';
 import { useResultToast } from '@/shared/hooks';
@@ -181,17 +182,17 @@ export function LayerPanel() {
   };
 
   const addLayerButton = (
-    <button
+    <IconButton
+      size="sm"
+      touchTarget={false}
       onClick={handleAddLayer}
       disabled={!canAddLayer}
-      className="btn btn-ghost w-7 h-7 p-0 min-w-0 min-h-0"
+      className="w-7 h-7"
       title={getAddLayerTitle()}
       aria-label={t('layers.addNewLayer')}
     >
-      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-      </svg>
-    </button>
+      <PlusIcon className="w-4 h-4" />
+    </IconButton>
   );
 
   return (

--- a/src/features/layout-library/components/LayoutManagerModal/ImportView/ImportView.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/ImportView/ImportView.tsx
@@ -5,6 +5,7 @@ import { decodeLayoutFromURL, isArchiveFormat } from '@/core/storage';
 import type { Layout } from '@/core/types';
 import type { LayoutArchive } from '@/core/storage';
 import { useTranslation } from '@/i18n';
+import { Button } from '@/design-system';
 
 interface ImportViewProps {
   onImport: (layout: Layout) => void;
@@ -258,12 +259,9 @@ export function ImportView({ onImport, onImportArchive, onCancel }: ImportViewPr
           {isDragging ? t('layouts.dropFileHere') : t('layouts.dragDropJson')}
         </p>
         <p className="text-content-tertiary text-sm mb-4">{t('layouts.or')}</p>
-        <button
-          onClick={() => fileInputRef.current?.click()}
-          className="px-4 py-2 bg-surface-secondary hover:bg-surface border border-stroke text-content text-sm rounded-lg transition-colors"
-        >
+        <Button variant="secondary" onClick={() => fileInputRef.current?.click()}>
           {t('layouts.browseFiles')}
-        </button>
+        </Button>
       </div>
 
       {/* Divider */}
@@ -280,12 +278,14 @@ export function ImportView({ onImport, onImportArchive, onCancel }: ImportViewPr
             {t('layouts.layoutJson')}
           </label>
           {jsonText && (
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={handleClear}
-              className="text-xs text-content-tertiary hover:text-content"
+              className="h-auto px-0 py-0 text-content-tertiary hover:bg-transparent hover:text-content"
             >
               {t('common.clear')}
-            </button>
+            </Button>
           )}
         </div>
         <textarea
@@ -377,28 +377,27 @@ export function ImportView({ onImport, onImportArchive, onCancel }: ImportViewPr
       {/* Action Buttons */}
       <div className="flex gap-3 pt-4 border-t border-stroke">
         {validArchive ? (
-          <button
+          <Button
+            variant="primary"
             onClick={handleImportArchive}
             disabled={!onImportArchive}
-            className="flex-1 py-2.5 px-4 bg-accent hover:bg-accent/90 disabled:hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed text-on-dark rounded-lg transition-colors text-sm font-medium"
+            className="flex-1"
           >
             {t('layouts.importAll', { count: validArchive.layouts.length })}
-          </button>
+          </Button>
         ) : (
-          <button
+          <Button
+            variant="primary"
             onClick={handleImport}
             disabled={!validLayout}
-            className="flex-1 py-2.5 px-4 bg-accent hover:bg-accent/90 disabled:hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed text-on-dark rounded-lg transition-colors text-sm font-medium"
+            className="flex-1"
           >
             {t('layouts.importLayout')}
-          </button>
+          </Button>
         )}
-        <button
-          onClick={onCancel}
-          className="py-2.5 px-4 bg-surface-secondary hover:bg-surface border border-stroke text-content rounded-lg transition-colors text-sm"
-        >
+        <Button variant="secondary" onClick={onCancel}>
           {t('common.cancel')}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/features/layout-library/components/LayoutManagerModal/LayoutActions/LayoutActions.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutActions/LayoutActions.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import type { LayoutEntry } from '@/core/types';
 import { useTranslation } from '@/i18n';
 import { useTwoClickDelete } from '@/shared/components';
+import { Button, IconButton } from '@/design-system';
 
 interface LayoutActionsProps {
   entry: LayoutEntry;
@@ -105,9 +106,11 @@ export function LayoutActions({
       onClick={(e) => e.stopPropagation()}
     >
       {/* Download Button */}
-      <button
+      <IconButton
+        size="sm"
+        touchTarget={false}
         onClick={handleAction(onDownload)}
-        className="p-1.5 rounded text-content-tertiary hover:text-content hover:bg-surface transition-colors"
+        className="text-content-tertiary hover:bg-surface hover:text-content"
         title={t('common.download')}
         aria-label={`${t('common.download')} ${entry.name}`}
       >
@@ -125,21 +128,17 @@ export function LayoutActions({
             d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
           />
         </svg>
-      </button>
+      </IconButton>
 
       {/* Overflow Menu Button */}
       <div className="relative">
-        <button
+        <IconButton
           ref={menuButtonRef}
+          size="sm"
+          touchTarget={false}
+          pressed={isMenuOpen}
           onClick={handleMenuToggle}
-          className={`
-            p-1.5 rounded transition-colors
-            ${
-              isMenuOpen
-                ? 'bg-surface text-content'
-                : 'text-content-tertiary hover:text-content hover:bg-surface'
-            }
-          `}
+          className="text-content-tertiary hover:bg-surface hover:text-content"
           aria-label={`More actions for ${entry.name}`}
           aria-expanded={isMenuOpen}
           aria-haspopup="menu"
@@ -147,7 +146,7 @@ export function LayoutActions({
           <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
           </svg>
-        </button>
+        </IconButton>
 
         {/* Dropdown Menu - rendered via portal to escape modal's transform */}
         {isMenuOpen &&
@@ -158,10 +157,12 @@ export function LayoutActions({
               style={menuStyle}
               className="w-40 bg-surface-elevated border border-stroke rounded-lg shadow-lg py-1 z-50"
             >
-              <button
+              <Button
+                variant="ghost"
+                fullWidth
                 role="menuitem"
                 onClick={handleAction(onRename)}
-                className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface flex items-center gap-2"
+                className="justify-start rounded-none px-3 py-2 text-left text-sm font-normal text-content hover:bg-surface"
               >
                 <svg
                   className="w-4 h-4 text-content-secondary"
@@ -178,11 +179,13 @@ export function LayoutActions({
                   />
                 </svg>
                 {t('common.rename')}
-              </button>
-              <button
+              </Button>
+              <Button
+                variant="ghost"
+                fullWidth
                 role="menuitem"
                 onClick={handleAction(onDuplicate)}
-                className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface flex items-center gap-2"
+                className="justify-start rounded-none px-3 py-2 text-left text-sm font-normal text-content hover:bg-surface"
               >
                 <svg
                   className="w-4 h-4 text-content-secondary"
@@ -199,12 +202,14 @@ export function LayoutActions({
                   />
                 </svg>
                 {t('common.duplicate')}
-              </button>
+              </Button>
               {/* Copy Link */}
-              <button
+              <Button
+                variant="ghost"
+                fullWidth
                 role="menuitem"
                 onClick={handleAction(onCopyLink)}
-                className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface flex items-center gap-2"
+                className="justify-start rounded-none px-3 py-2 text-left text-sm font-normal text-content hover:bg-surface"
               >
                 <svg
                   className="w-4 h-4 text-content-secondary"
@@ -221,18 +226,20 @@ export function LayoutActions({
                   />
                 </svg>
                 {t('share.copyLink')}
-              </button>
+              </Button>
               {!isOnlyLayout && (
                 <>
                   <div className="border-t border-stroke my-1" />
-                  <button
+                  <Button
+                    variant="ghost"
+                    fullWidth
                     role="menuitem"
                     onClick={handleDelete}
                     className={`
-                      w-full px-3 py-2 text-left text-sm flex flex-col gap-0.5 transition-colors
+                      flex-col items-start gap-0.5 rounded-none px-3 py-2 text-left text-sm font-normal
                       ${
                         isConfirmingDelete
-                          ? 'bg-danger text-on-dark'
+                          ? 'bg-danger text-on-dark hover:bg-danger'
                           : 'text-danger hover:bg-surface'
                       }
                     `}
@@ -259,7 +266,7 @@ export function LayoutActions({
                         {t('layouts.binsWillBeDeleted', { count: entry.preview.binCount })}
                       </span>
                     )}
-                  </button>
+                  </Button>
                 </>
               )}
             </div>,

--- a/src/features/layout-library/components/LayoutManagerModal/LayoutActions/LayoutActions.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutActions/LayoutActions.tsx
@@ -240,7 +240,7 @@ export function LayoutActions({
                       ${
                         isConfirmingDelete
                           ? 'bg-danger text-on-dark hover:bg-danger'
-                          : 'text-danger hover:bg-surface'
+                          : 'text-danger hover:bg-surface hover:text-danger'
                       }
                     `}
                   >

--- a/src/features/layout-library/components/LayoutManagerModal/LayoutList/LayoutList.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutList/LayoutList.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from '@/i18n';
 import { ViewModeToggle } from '../ViewModeToggle';
 import type { ViewMode } from '../ViewModeToggle';
 import type { SortOption } from '../index';
+import { IconButton, XIcon } from '@/design-system';
 
 /** Threshold for showing search bar */
 const SEARCH_THRESHOLD = 6;
@@ -259,26 +260,15 @@ export function LayoutList({
               aria-label={t('layouts.searchLayouts')}
             />
             {searchQuery && (
-              <button
+              <IconButton
+                size="sm"
+                touchTarget={false}
                 onClick={() => handleSearchChange('')}
-                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-content-tertiary hover:text-content"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-content-tertiary hover:bg-transparent hover:text-content"
                 aria-label={t('layouts.clearSearch')}
               >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
+                <XIcon className="w-4 h-4" />
+              </IconButton>
             )}
           </div>
         )}

--- a/src/features/layout-library/components/LayoutManagerModal/LayoutManagerModal.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutManagerModal.tsx
@@ -15,6 +15,7 @@ import { downloadArchive, importArchive } from '@/core/storage';
 import { isOk } from '@/core/result';
 import { useTranslation } from '@/i18n';
 import { useToastStore } from '@/core/store/toast';
+import { Button, IconButton, ArrowLeftIcon, XIcon } from '@/design-system';
 
 export type SortOption = 'recent' | 'name' | 'size' | 'binCount';
 
@@ -271,26 +272,15 @@ function LayoutManagerModalContent({
         <div className="flex justify-between items-center border-b border-stroke-subtle px-6 py-4">
           <div className="flex items-center gap-3">
             {activeTab === 'import' && (
-              <button
+              <IconButton
+                size="sm"
+                touchTarget={false}
                 onClick={() => setActiveTab('layouts')}
-                className="p-1 text-content-secondary hover:text-content transition-colors rounded hover:bg-surface"
+                className="text-content-secondary hover:bg-surface hover:text-content"
                 aria-label={t('layouts.backToLayouts')}
               >
-                <svg
-                  className="w-5 h-5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M15 19l-7-7 7-7"
-                  />
-                </svg>
-              </button>
+                <ArrowLeftIcon className="w-5 h-5" />
+              </IconButton>
             )}
             <h2 id="layout-manager-title" className="text-2xl font-bold text-content">
               {activeTab === 'layouts' ? t('layouts.layouts') : t('common.import')}
@@ -299,46 +289,36 @@ function LayoutManagerModalContent({
           <div className="flex items-center gap-2">
             {activeTab === 'layouts' && (
               <>
-                <button
+                <Button
+                  variant="secondary"
                   onClick={handleExportAll}
                   disabled={isExporting}
-                  className="rounded-md border border-stroke bg-surface px-3 py-1.5 text-sm font-medium text-content transition-colors hover:bg-surface-hover disabled:opacity-50"
+                  className="px-3 py-1.5 text-sm"
                 >
                   {isExporting ? t('common.exporting') : t('layouts.exportAll')}
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant="secondary"
                   onClick={() => setActiveTab('import')}
-                  className="rounded-md border border-stroke bg-surface px-3 py-1.5 text-sm font-medium text-content transition-colors hover:bg-surface-hover"
+                  className="px-3 py-1.5 text-sm"
                 >
                   {t('common.import')}
-                </button>
-                <button
-                  onClick={handleCreate}
-                  className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-hover"
-                >
+                </Button>
+                <Button variant="primary" onClick={handleCreate} className="px-3 py-1.5 text-sm">
                   {t('layouts.newLayout')}
-                </button>
+                </Button>
               </>
             )}
-            <button
+            <IconButton
               ref={closeButtonRef}
+              size="sm"
+              touchTarget={false}
               onClick={onClose}
-              className="p-1 text-content-secondary hover:text-content transition-colors rounded hover:bg-surface"
+              className="text-content-secondary hover:bg-surface hover:text-content"
               aria-label={t('layouts.closeLayoutsDialog')}
             >
-              <svg
-                className="w-6 h-6"
-                fill="none"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                aria-hidden="true"
-              >
-                <path d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
+              <XIcon className="w-6 h-6" />
+            </IconButton>
           </div>
         </div>
 

--- a/src/features/layout-library/components/LayoutManagerModal/LayoutManagerModal.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutManagerModal.tsx
@@ -317,7 +317,7 @@ function LayoutManagerModalContent({
               className="text-content-secondary hover:bg-surface hover:text-content"
               aria-label={t('layouts.closeLayoutsDialog')}
             >
-              <XIcon className="w-6 h-6" />
+              <XIcon className="w-5 h-5" />
             </IconButton>
           </div>
         </div>

--- a/src/features/layout-library/components/LayoutManagerModal/NewLayoutCard/NewLayoutCard.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/NewLayoutCard/NewLayoutCard.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from '@/i18n';
+import { Button } from '@/design-system';
 
 interface NewLayoutCardProps {
   onCreate: () => void;
@@ -12,13 +13,13 @@ export function NewLayoutCard({ onCreate }: NewLayoutCardProps) {
   const t = useTranslation();
 
   return (
-    <button
+    <Button
+      variant="ghost"
       onClick={onCreate}
       className="
-        group w-full text-left bg-surface-secondary rounded-lg p-2
-        border-2 border-dashed border-stroke
+        group block h-auto w-full text-left bg-surface-secondary rounded-lg p-2
+        border-2 border-dashed border-stroke font-normal
         hover:border-accent hover:bg-surface-tertiary
-        transition-colors cursor-pointer
         focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
       "
       aria-label={t('layouts.newLayout')}
@@ -53,6 +54,6 @@ export function NewLayoutCard({ onCreate }: NewLayoutCardProps) {
 
       {/* Placeholder for action buttons row - matches LayoutGridItem height */}
       <div className="mt-1.5 h-8" aria-hidden="true" />
-    </button>
+    </Button>
   );
 }

--- a/src/features/layout-library/components/LayoutManagerModal/SharedWithMeItem/SharedWithMeItem.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/SharedWithMeItem/SharedWithMeItem.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import type { SharedWithMeEntry } from '@/core/types';
 import { LayoutThumbnail } from '@/shell/LayoutThumbnail';
 import { useTranslation, useFormatting } from '@/i18n';
+import { IconButton } from '@/design-system';
 
 interface SharedWithMeItemProps {
   entry: SharedWithMeEntry;
@@ -131,62 +132,38 @@ export function SharedWithMeItem({
         {/* Action Buttons */}
         <div className="flex-shrink-0 flex items-center gap-1">
           {/* Open button */}
-          <button
+          <IconButton
+            size="sm"
+            touchTarget={false}
+            loading={isLoading}
             onClick={(e) => {
               e.stopPropagation();
               onOpen();
             }}
             disabled={isLoading || isDeleted}
-            className={`
-              p-2 rounded transition-colors
-              ${
-                isLoading || isDeleted
-                  ? 'text-content-tertiary cursor-not-allowed'
-                  : 'text-content-secondary hover:text-content hover:bg-surface'
-              }
-            `}
+            className="text-content-secondary hover:bg-surface hover:text-content disabled:text-content-tertiary"
             title={isDeleted ? t('layouts.layoutDeleted') : t('layouts.openLayout')}
             aria-label={isDeleted ? t('layouts.layoutDeleted') : t('layouts.openLayout')}
           >
-            {isLoading ? (
-              <svg
-                className="w-4 h-4 animate-spin motion-reduce:animate-none"
-                viewBox="0 0 24 24"
-                fill="none"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                />
-              </svg>
-            ) : (
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                />
-              </svg>
-            )}
-          </button>
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+              />
+            </svg>
+          </IconButton>
 
           {/* Remove button */}
-          <button
+          <IconButton
+            size="sm"
+            touchTarget={false}
             onClick={(e) => {
               e.stopPropagation();
               onRemove();
             }}
-            className="p-2 rounded text-content-secondary hover:text-error hover:bg-surface transition-colors"
+            className="text-content-secondary hover:bg-surface hover:text-error"
             title={t('layouts.removeFromList')}
             aria-label={t('layouts.removeFromList')}
           >
@@ -198,7 +175,7 @@ export function SharedWithMeItem({
                 d="M6 18L18 6M6 6l12 12"
               />
             </svg>
-          </button>
+          </IconButton>
         </div>
       </div>
     </div>

--- a/src/features/layout-library/components/LayoutQuickSwitch/LayoutQuickSwitch.tsx
+++ b/src/features/layout-library/components/LayoutQuickSwitch/LayoutQuickSwitch.tsx
@@ -7,6 +7,7 @@ import { LayoutThumbnail } from '@/shell/LayoutThumbnail';
 import type { LayoutPreview } from '@/core/types';
 import { layoutId } from '@/core/types';
 import { useTranslation } from '@/i18n';
+import { Button } from '@/design-system';
 
 interface LayoutQuickSwitchProps {
   onManage: () => void;
@@ -60,7 +61,7 @@ function Thumb({ preview, size, className }: ThumbProps) {
 }
 
 const MENU_ITEM_CLASS =
-  'flex w-full items-center gap-2 px-2.5 py-2 text-left text-sm text-content-secondary transition-colors hover:bg-surface-hover hover:text-content';
+  'w-full justify-start gap-2 rounded-none px-2.5 py-2 text-left text-sm font-normal text-content-secondary hover:bg-surface-hover hover:text-content';
 
 interface MenuActionProps {
   onClick: () => void;
@@ -69,9 +70,9 @@ interface MenuActionProps {
 
 function MenuAction({ onClick, children }: MenuActionProps) {
   return (
-    <button role="menuitem" onClick={onClick} className={MENU_ITEM_CLASS}>
+    <Button variant="ghost" fullWidth role="menuitem" onClick={onClick} className={MENU_ITEM_CLASS}>
       {children}
-    </button>
+    </Button>
   );
 }
 
@@ -126,16 +127,17 @@ export function LayoutQuickSwitch({ onManage }: LayoutQuickSwitchProps) {
 
   return (
     <div ref={containerRef} className="relative">
-      <button
+      <Button
+        variant="ghost"
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-1.5 rounded-md px-1.5 py-1 text-content-secondary transition-colors hover:bg-surface-hover hover:text-content"
+        className="h-auto gap-1.5 px-1.5 py-1 text-content-secondary hover:bg-surface-hover hover:text-content"
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={t('header.switchLayout', { name: triggerName })}
       >
         <Thumb preview={triggerPreview} size={30} className="h-6 w-8" />
         <Icon name="chevron" className="h-3.5 w-3.5" />
-      </button>
+      </Button>
 
       {open && (
         <div
@@ -145,12 +147,14 @@ export function LayoutQuickSwitch({ onManage }: LayoutQuickSwitchProps) {
           {library.entries.map((entry) => {
             const isActive = entry.id === activeLayoutId;
             return (
-              <button
+              <Button
                 key={entry.id}
+                variant="ghost"
+                fullWidth
                 role="menuitem"
                 aria-current={isActive ? 'true' : undefined}
                 onClick={() => void handleSwitch(entry.id)}
-                className={`flex w-full items-center gap-2.5 px-2.5 py-2 text-left text-sm transition-colors hover:bg-surface-hover ${
+                className={`justify-start gap-2.5 rounded-none px-2.5 py-2 text-left text-sm font-normal hover:bg-surface-hover ${
                   isActive ? 'text-content' : 'text-content-secondary'
                 }`}
               >
@@ -159,7 +163,7 @@ export function LayoutQuickSwitch({ onManage }: LayoutQuickSwitchProps) {
                   {entry.name}
                 </span>
                 {isActive && <Icon name="check" className="h-4 w-4 flex-shrink-0 text-accent" />}
-              </button>
+              </Button>
             );
           })}
 

--- a/src/features/print-export/components/PrintModal/PrintModal.tsx
+++ b/src/features/print-export/components/PrintModal/PrintModal.tsx
@@ -12,6 +12,7 @@ import type { LayerId } from '@/core/types';
 import { PrintLayout } from '../PrintLayout';
 import { SortOrderConfig } from '../SortOrderConfig';
 import { Checkbox } from '@/shared/components/Checkbox';
+import { Button, IconButton, XIcon } from '@/design-system';
 import { getBinCountByLayer } from '@/features/print-export/utils/printLayout';
 import { getDisplayLayers } from '@/shared/utils';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
@@ -231,20 +232,9 @@ export function PrintModal({ isOpen, onClose }: PrintModalProps) {
             <h2 id="print-modal-title" style={STYLES.title}>
               {t('print.title')}
             </h2>
-            <button
-              onClick={onClose}
-              className="btn btn-ghost btn-icon"
-              aria-label={t('common.close')}
-            >
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            </button>
+            <IconButton onClick={onClose} aria-label={t('common.close')}>
+              <XIcon className="w-5 h-5" />
+            </IconButton>
           </div>
 
           {/* Content */}
@@ -256,13 +246,15 @@ export function PrintModal({ isOpen, onClose }: PrintModalProps) {
                 <div className="flex items-center justify-between mb-3">
                   <h3 style={STYLES.sectionHeader}>{t('common.layers')}</h3>
                   {layout.layers.length > 1 && (
-                    <button
+                    <Button
+                      variant="ghost"
+                      size="sm"
                       onClick={selectAllLayers}
-                      className="text-xs text-accent hover:underline"
+                      className="h-auto px-0 py-0 text-xs text-accent hover:bg-transparent hover:underline"
                       disabled={allLayersSelected}
                     >
                       {t('common.all')}
-                    </button>
+                    </Button>
                   )}
                 </div>
                 <div className="space-y-2">
@@ -409,17 +401,18 @@ export function PrintModal({ isOpen, onClose }: PrintModalProps) {
                   </div>
                   <div className="flex gap-1">
                     {ORIENTATION_OPTIONS.map((o) => (
-                      <button
+                      <Button
                         key={o}
+                        variant="ghost"
                         onClick={() => updatePrintSetting('orientation', o)}
-                        className={`flex-1 text-xs py-1.5 px-2 rounded-md transition-colors ${
+                        className={`h-auto flex-1 rounded-md px-2 py-1.5 text-xs ${
                           printViewSettings.orientation === o
-                            ? 'bg-accent text-white font-medium'
+                            ? 'bg-accent font-medium text-white hover:bg-accent'
                             : 'bg-surface-hover text-content-secondary hover:text-content'
                         }`}
                       >
                         {t(`print.${o}`)}
-                      </button>
+                      </Button>
                     ))}
                   </div>
                   <div className="mt-2">
@@ -469,24 +462,26 @@ export function PrintModal({ isOpen, onClose }: PrintModalProps) {
                 {t('print.selectAtLeastOneLayerToPrint')}
               </span>
             )}
-            <button onClick={onClose} className="btn btn-secondary">
+            <Button variant="secondary" onClick={onClose}>
               {t('common.cancel')}
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="primary"
               onClick={() => window.print()}
               disabled={noLayersSelected}
-              className="btn btn-primary flex items-center gap-2"
+              leftIcon={
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
+                  />
+                </svg>
+              }
             >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
-                />
-              </svg>
               {t('print.printNow')}
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/src/features/print-export/components/SortOrderConfig/SortOrderConfig.tsx
+++ b/src/features/print-export/components/SortOrderConfig/SortOrderConfig.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import { Checkbox } from '@/shared/components/Checkbox';
 import type { BinListSortOrder, SortFieldConfig, BinSortField } from '@/core/store/settings';
 import { useTranslation } from '@/i18n';
+import { IconButton } from '@/design-system';
 
 /**
  * Maps sort fields to their translation keys.
@@ -224,11 +225,13 @@ function SortFieldItem({
 
       {/* Up/Down buttons for accessibility */}
       <div className="flex gap-0.5">
-        <button
+        <IconButton
           type="button"
+          size="sm"
+          touchTarget={false}
           onClick={onMoveUp}
           disabled={isFirst}
-          className="p-1.5 rounded text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="text-content-tertiary hover:bg-surface-hover hover:text-content"
           title={t('print.sort.moveUp')}
           aria-label={t('print.sort.moveFieldUp', { field: t(SORT_FIELD_KEYS[config.field]) })}
         >
@@ -241,12 +244,14 @@ function SortFieldItem({
           >
             <path d="M18 15l-6-6-6 6" />
           </svg>
-        </button>
-        <button
+        </IconButton>
+        <IconButton
           type="button"
+          size="sm"
+          touchTarget={false}
           onClick={onMoveDown}
           disabled={isLast}
-          className="p-1.5 rounded text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="text-content-tertiary hover:bg-surface-hover hover:text-content"
           title={t('print.sort.moveDown')}
           aria-label={t('print.sort.moveFieldDown', { field: t(SORT_FIELD_KEYS[config.field]) })}
         >
@@ -259,7 +264,7 @@ function SortFieldItem({
           >
             <path d="M6 9l6 6 6-6" />
           </svg>
-        </button>
+        </IconButton>
       </div>
     </div>
   );

--- a/src/features/staging/components/Staging/Staging.tsx
+++ b/src/features/staging/components/Staging/Staging.tsx
@@ -12,6 +12,7 @@ import { useResponsive } from '@/shared/hooks';
 import { BASE_CELL_SIZE, DEFAULT_CATEGORY_COLOR } from '@/core/constants';
 import { getStagingBins } from '@/shared/utils';
 import { ConfirmDialog } from '@/shared/components';
+import { Button } from '@/design-system';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
 import { useTranslation } from '@/i18n';
 import type { BinId } from '@/core/types';
@@ -460,9 +461,10 @@ export function Staging() {
 
       {/* Header with collapse toggle */}
       <div className="flex items-center justify-between px-4 pt-2 pb-2">
-        <button
+        <Button
           type="button"
-          className="flex items-center gap-2 bg-transparent rounded hover:opacity-80 transition-opacity focus-visible:ring-2 focus-visible:ring-accent"
+          variant="ghost"
+          className="h-auto gap-2 rounded bg-transparent px-0 py-0 font-normal transition-opacity hover:bg-transparent hover:opacity-80"
           onClick={handleToggleExpand}
           aria-expanded={isExpanded}
           aria-controls="staging-stash-panel"
@@ -493,22 +495,25 @@ export function Staging() {
           <span className="px-1.5 py-0.5 rounded text-xs bg-surface-hover text-content-tertiary">
             {t('staging.binCount', { count: stagingBins.length })}
           </span>
-        </button>
+        </Button>
 
-        <button
+        <Button
+          variant="ghost"
           onClick={() => setShowClearConfirm(true)}
-          className="btn btn-ghost flex items-center gap-1.5 px-2 py-1.5 text-xs text-content-tertiary"
+          className="h-auto gap-1.5 px-2 py-1.5 text-xs font-normal text-content-tertiary"
+          leftIcon={
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+          }
         >
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-            />
-          </svg>
           {t('staging.clearAll')}
-        </button>
+        </Button>
       </div>
 
       {/* Collapsible staging grid content */}

--- a/src/i18n/context.tsx
+++ b/src/i18n/context.tsx
@@ -285,7 +285,7 @@ export function LocaleProvider({ children, initialLocale, onLocaleChange }: Loca
  * @example
  * ```tsx
  * const t = useTranslation();
- * return <button>{t('common.save')}</button>;
+ * return <span>{t('common.save')}</span>;
  * ```
  */
 export function useTranslation(): TFunction {

--- a/src/shared/components/BulkIncrementControl/BulkIncrementControl.tsx
+++ b/src/shared/components/BulkIncrementControl/BulkIncrementControl.tsx
@@ -40,7 +40,7 @@ export function BulkIncrementControl({
         disabled={decreaseDisabled}
         aria-label={`Decrease ${ariaLabelPrefix}`}
       >
-        <MinusIcon />
+        <MinusIcon size="sm" />
       </IconButton>
       <span className={`flex-1 text-center font-semibold ${valueSize} text-content`}>
         {displayValue}
@@ -52,7 +52,7 @@ export function BulkIncrementControl({
         disabled={increaseDisabled}
         aria-label={`Increase ${ariaLabelPrefix}`}
       >
-        <PlusIcon />
+        <PlusIcon size="sm" />
       </IconButton>
     </div>
   );

--- a/src/shared/components/BulkIncrementControl/BulkIncrementControl.tsx
+++ b/src/shared/components/BulkIncrementControl/BulkIncrementControl.tsx
@@ -1,3 +1,5 @@
+import { IconButton, MinusIcon, PlusIcon } from '@/design-system';
+
 interface BulkIncrementControlProps {
   /** Display value (can include range like "3–5u" or single value like "4u") */
   displayValue: string;
@@ -26,39 +28,32 @@ export function BulkIncrementControl({
   variant = 'desktop',
 }: BulkIncrementControlProps) {
   const isMobile = variant === 'mobile';
-
-  // Button sizing for mobile vs desktop
-  const btnSize = isMobile ? 'w-12 h-12' : 'w-10 h-10';
-  const btnMinSize = isMobile ? 'min-w-[48px] min-h-[48px]' : 'min-w-[40px] min-h-[40px]';
+  const btnSize = isMobile ? 'lg' : 'md';
   const valueSize = isMobile ? 'text-xl' : 'text-lg';
 
   return (
     <div className="flex items-center gap-2">
-      <button
-        type="button"
+      <IconButton
+        variant="secondary"
+        size={btnSize}
         onClick={() => onStep(-1)}
         disabled={decreaseDisabled}
-        className={`btn btn-secondary ${btnSize} p-0 ${btnMinSize}`}
         aria-label={`Decrease ${ariaLabelPrefix}`}
       >
-        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-        </svg>
-      </button>
+        <MinusIcon />
+      </IconButton>
       <span className={`flex-1 text-center font-semibold ${valueSize} text-content`}>
         {displayValue}
       </span>
-      <button
-        type="button"
+      <IconButton
+        variant="secondary"
+        size={btnSize}
         onClick={() => onStep(1)}
         disabled={increaseDisabled}
-        className={`btn btn-secondary ${btnSize} p-0 ${btnMinSize}`}
         aria-label={`Increase ${ariaLabelPrefix}`}
       >
-        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-        </svg>
-      </button>
+        <PlusIcon />
+      </IconButton>
     </div>
   );
 }

--- a/src/shared/components/BulkIncrementControl/BulkIncrementControl.tsx
+++ b/src/shared/components/BulkIncrementControl/BulkIncrementControl.tsx
@@ -36,6 +36,8 @@ export function BulkIncrementControl({
       <IconButton
         variant="secondary"
         size={btnSize}
+        touchTarget={false}
+        className={isMobile ? undefined : 'h-10 w-10'}
         onClick={() => onStep(-1)}
         disabled={decreaseDisabled}
         aria-label={`Decrease ${ariaLabelPrefix}`}
@@ -48,6 +50,8 @@ export function BulkIncrementControl({
       <IconButton
         variant="secondary"
         size={btnSize}
+        touchTarget={false}
+        className={isMobile ? undefined : 'h-10 w-10'}
         onClick={() => onStep(1)}
         disabled={increaseDisabled}
         aria-label={`Increase ${ariaLabelPrefix}`}

--- a/src/shared/components/CollapsibleSection/CollapsibleSection.tsx
+++ b/src/shared/components/CollapsibleSection/CollapsibleSection.tsx
@@ -1,4 +1,5 @@
 import { useState, useId, type ReactNode } from 'react';
+import { Button } from '@/design-system';
 
 interface CollapsibleSectionProps {
   /** Section title */
@@ -62,15 +63,15 @@ export function CollapsibleSection({
   return (
     <div>
       <div className="flex items-center justify-between">
-        <button
-          type="button"
-          className="flex items-center gap-2 bg-transparent rounded hover:opacity-80 transition-opacity focus-visible:ring-2 focus-visible:ring-accent"
+        <Button
+          variant="ghost"
           onClick={() => {
             setHasToggled(true);
             setExpanded(!expanded);
           }}
           aria-expanded={expanded}
           aria-controls={contentId}
+          className="justify-start gap-2 rounded px-0 py-0 font-normal hover:bg-transparent hover:opacity-80"
         >
           <svg
             className={`w-3.5 h-3.5 transition-transform duration-200 text-content-tertiary ${expanded ? 'rotate-0' : '-rotate-90'}`}
@@ -83,7 +84,7 @@ export function CollapsibleSection({
           {icon && <span className="flex-shrink-0 text-content-tertiary">{icon}</span>}
           <span className={headerClass}>{title}</span>
           {badge}
-        </button>
+        </Button>
         {actions}
       </div>
       {summary && !expanded && (

--- a/src/shared/components/CollapsibleSection/CollapsibleSection.tsx
+++ b/src/shared/components/CollapsibleSection/CollapsibleSection.tsx
@@ -64,6 +64,7 @@ export function CollapsibleSection({
     <div>
       <div className="flex items-center justify-between">
         <Button
+          type="button"
           variant="ghost"
           onClick={() => {
             setHasToggled(true);

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
+import { Button } from '@/design-system';
 import { cn } from '@/design-system/cn';
 
 interface CompactNumberInputProps {
@@ -186,12 +187,13 @@ export function CompactNumberInput({
           aria-label={label}
         />
       ) : (
-        <button
+        <Button
+          variant="ghost"
           type="button"
           onClick={startEditing}
           disabled={disabled}
           className={cn(
-            'min-w-0 flex-1 select-none pr-1 text-right text-xs tabular-nums outline-none',
+            'h-full min-w-0 flex-1 select-none justify-end rounded-none px-0 pr-1 py-0 text-right text-xs font-normal tabular-nums hover:bg-transparent',
             indeterminate ? 'text-content-tertiary' : 'text-content',
             !disabled && 'cursor-text',
             scrubbing && 'text-accent'
@@ -203,7 +205,7 @@ export function CompactNumberInput({
           }
         >
           {indeterminate ? MIXED_GLYPH : formatValue(value)}
-        </button>
+        </Button>
       )}
       {unit && <span className="select-none pr-1.5 text-[10px] text-content-disabled">{unit}</span>}
     </div>

--- a/src/shared/components/ConfirmDialog/ConfirmDialog.test.tsx
+++ b/src/shared/components/ConfirmDialog/ConfirmDialog.test.tsx
@@ -52,13 +52,13 @@ describe('ConfirmDialog', () => {
     it('applies destructive styling when destructive prop is true', () => {
       render(<ConfirmDialog {...defaultProps} destructive />);
       const confirmButton = screen.getByText('Confirm');
-      expect(confirmButton.className).toContain('btn-danger');
+      expect(confirmButton.className).toContain('to-danger');
     });
 
     it('applies primary styling when not destructive', () => {
       render(<ConfirmDialog {...defaultProps} />);
       const confirmButton = screen.getByText('Confirm');
-      expect(confirmButton.className).toContain('btn-primary');
+      expect(confirmButton.className).toContain('to-accent');
     });
   });
 

--- a/src/shared/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/shared/components/ConfirmDialog/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
+import { Button } from '@/design-system';
 
 interface ConfirmDialogProps {
   isOpen: boolean;
@@ -114,18 +115,18 @@ export function ConfirmDialog({
         </p>
 
         <div className="flex gap-3 justify-end">
-          <button ref={cancelButtonRef} onClick={onCancel} className="btn btn-secondary">
+          <Button ref={cancelButtonRef} variant="secondary" onClick={onCancel}>
             {cancelText}
-          </button>
-          <button
+          </Button>
+          <Button
+            variant={destructive ? 'danger' : 'primary'}
             onClick={() => {
               onConfirm();
               onCancel();
             }}
-            className={`btn ${destructive ? 'btn-danger' : 'btn-primary'}`}
           >
             {confirmText}
-          </button>
+          </Button>
         </div>
       </div>
     </div>,

--- a/src/shared/components/ContextMenu/ContextMenuItem/ContextMenuItem.test.tsx
+++ b/src/shared/components/ContextMenu/ContextMenuItem/ContextMenuItem.test.tsx
@@ -38,7 +38,7 @@ describe('ContextMenuItem', () => {
     render(<ContextMenuItem icon={mockIcon} label="Disabled" onClick={vi.fn()} disabled />);
     const button = screen.getByRole('menuitem');
     expect(button).toBeDisabled();
-    expect(button).toHaveClass('opacity-50');
+    expect(button).toHaveClass('disabled:opacity-50');
   });
 
   it('does not call onClick when disabled', () => {

--- a/src/shared/components/ContextMenu/ContextMenuItem/ContextMenuItem.test.tsx
+++ b/src/shared/components/ContextMenu/ContextMenuItem/ContextMenuItem.test.tsx
@@ -36,9 +36,12 @@ describe('ContextMenuItem', () => {
 
   it('is disabled when disabled prop is true', () => {
     render(<ContextMenuItem icon={mockIcon} label="Disabled" onClick={vi.fn()} disabled />);
-    const button = screen.getByRole('menuitem');
-    expect(button).toBeDisabled();
-    expect(button).toHaveClass('disabled:opacity-50');
+    expect(screen.getByRole('menuitem')).toBeDisabled();
+  });
+
+  it('is enabled by default', () => {
+    render(<ContextMenuItem icon={mockIcon} label="Enabled" onClick={vi.fn()} />);
+    expect(screen.getByRole('menuitem')).toBeEnabled();
   });
 
   it('does not call onClick when disabled', () => {

--- a/src/shared/components/ContextMenu/ContextMenuItem/ContextMenuItem.tsx
+++ b/src/shared/components/ContextMenu/ContextMenuItem/ContextMenuItem.tsx
@@ -1,3 +1,5 @@
+import { Button, cn } from '@/design-system';
+
 interface ContextMenuItemProps {
   /** Icon element to display (SVG) */
   icon: React.ReactNode;
@@ -31,16 +33,19 @@ export function ContextMenuItem({
   disabled = false,
 }: ContextMenuItemProps) {
   return (
-    <button
+    <Button
+      variant="ghost"
+      fullWidth
       role="menuitem"
       onClick={onClick}
       disabled={disabled}
-      className={`w-full px-4 py-3 flex items-center gap-3 transition-colors focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent ${
-        destructive ? 'text-error hover:bg-surface-hover' : 'text-content hover:bg-surface-hover'
-      } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+      className={cn(
+        'justify-start gap-3 rounded-none px-4 py-3 font-normal',
+        destructive ? 'text-error' : 'text-content'
+      )}
     >
-      <div className={`w-5 h-5 ${destructive ? '' : 'text-content-tertiary'}`}>{icon}</div>
+      <div className={cn('w-5 h-5', !destructive && 'text-content-tertiary')}>{icon}</div>
       {label}
-    </button>
+    </Button>
   );
 }

--- a/src/shared/components/ContextMenu/ContextMenuItem/ContextMenuItem.tsx
+++ b/src/shared/components/ContextMenu/ContextMenuItem/ContextMenuItem.tsx
@@ -41,7 +41,7 @@ export function ContextMenuItem({
       disabled={disabled}
       className={cn(
         'justify-start gap-3 rounded-none px-4 py-3 font-normal',
-        destructive ? 'text-error' : 'text-content'
+        destructive ? 'text-error hover:text-error' : 'text-content'
       )}
     >
       <div className={cn('w-5 h-5', !destructive && 'text-content-tertiary')}>{icon}</div>

--- a/src/shared/components/ItemListShell/ItemSearch/ItemSearch.tsx
+++ b/src/shared/components/ItemListShell/ItemSearch/ItemSearch.tsx
@@ -54,7 +54,7 @@ export function ItemSearch({
           aria-label={clearAriaLabel}
           className="absolute right-2 top-1/2 -translate-y-1/2"
         >
-          <XIcon />
+          <XIcon size="sm" />
         </IconButton>
       )}
     </div>

--- a/src/shared/components/ItemListShell/ItemSearch/ItemSearch.tsx
+++ b/src/shared/components/ItemListShell/ItemSearch/ItemSearch.tsx
@@ -1,3 +1,4 @@
+import { IconButton, XIcon } from '@/design-system';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 
 interface ItemSearchProps {
@@ -44,24 +45,17 @@ export function ItemSearch({
         aria-label={ariaLabel}
       />
       {value && (
-        <button
-          onClick={() => onChange('')}
-          className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-content-tertiary hover:text-content transition-colors"
-          aria-label={clearAriaLabel}
+        <IconButton
           type="button"
+          variant="ghost"
+          size="sm"
+          touchTarget={false}
+          onClick={() => onChange('')}
+          aria-label={clearAriaLabel}
+          className="absolute right-2 top-1/2 -translate-y-1/2"
         >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            aria-hidden="true"
-          >
-            {ICON_PATHS.close.map((d) => (
-              <path key={d} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
-            ))}
-          </svg>
-        </button>
+          <XIcon />
+        </IconButton>
       )}
     </div>
   );

--- a/src/shared/components/LanguageSelector/LanguageSelector.tsx
+++ b/src/shared/components/LanguageSelector/LanguageSelector.tsx
@@ -93,7 +93,7 @@ export function LanguageSelector() {
         variant="ghost"
         size="sm"
         onClick={() => setIsOpen(!isOpen)}
-        className="gap-1 px-2 text-content-secondary hover:text-content"
+        className="gap-1 px-2 text-sm text-content-secondary hover:text-content"
         title={t('header.changeLanguage')}
         aria-label={t('header.changeLanguage')}
         aria-expanded={isOpen}

--- a/src/shared/components/LanguageSelector/LanguageSelector.tsx
+++ b/src/shared/components/LanguageSelector/LanguageSelector.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useRef, useEffect } from 'react';
+import { Button, cn } from '@/design-system';
 import { useLocale, SUPPORTED_LOCALES, useTranslation } from '@/i18n';
 import type { Locale } from '@/i18n';
 import { useSettingsStore } from '@/core/store';
@@ -87,10 +88,12 @@ export function LanguageSelector() {
 
   return (
     <div className="relative">
-      <button
+      <Button
         ref={buttonRef}
+        variant="ghost"
+        size="sm"
         onClick={() => setIsOpen(!isOpen)}
-        className="btn btn-ghost px-2 py-1.5 text-sm gap-1 text-content-secondary hover:text-content flex items-center"
+        className="gap-1 px-2 text-content-secondary hover:text-content"
         title={t('header.changeLanguage')}
         aria-label={t('header.changeLanguage')}
         aria-expanded={isOpen}
@@ -108,7 +111,7 @@ export function LanguageSelector() {
         >
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
-      </button>
+      </Button>
 
       {isOpen && (
         <div
@@ -120,14 +123,15 @@ export function LanguageSelector() {
           {SUPPORTED_LOCALES.map((loc) => {
             const isSelected = locale === loc.code;
             return (
-              <button
+              <Button
                 key={loc.code}
+                variant="ghost"
+                fullWidth
                 onClick={() => handleLocaleSelect(loc.code)}
-                className={`w-full px-3 py-2 text-sm text-left flex items-center justify-between gap-2 transition-colors ${
-                  isSelected
-                    ? 'bg-accent/10 text-accent'
-                    : 'text-content-secondary hover:bg-surface-hover hover:text-content'
-                }`}
+                className={cn(
+                  'justify-between gap-2 rounded-none px-3 py-2 text-sm font-normal',
+                  isSelected ? 'bg-accent/10 text-accent' : 'text-content-secondary'
+                )}
                 role="option"
                 aria-selected={isSelected}
               >
@@ -139,7 +143,7 @@ export function LanguageSelector() {
                   <span>{loc.nativeName}</span>
                 </div>
                 {isSelected && <CheckIcon className="w-4 h-4 text-accent flex-shrink-0" />}
-              </button>
+              </Button>
             );
           })}
         </div>

--- a/src/shared/components/StepperControl/StepperControl.tsx
+++ b/src/shared/components/StepperControl/StepperControl.tsx
@@ -212,11 +212,11 @@ export function StepperControl({
 
   const decreaseButtonClass = isMobile
     ? `${buttonBaseClass} rounded-r-none`
-    : `${buttonBaseClass} rounded-l border-r-0`;
+    : `${buttonBaseClass} rounded-l rounded-r-none border-r-0`;
 
   const increaseButtonClass = isMobile
     ? `${buttonBaseClass} rounded-l-none`
-    : `${buttonBaseClass} rounded-r border-l-0`;
+    : `${buttonBaseClass} rounded-r rounded-l-none border-l-0`;
 
   // Container height
   const heightClass = isCompact ? 'h-6' : isMobile ? '' : 'h-8';

--- a/src/shared/components/StepperControl/StepperControl.tsx
+++ b/src/shared/components/StepperControl/StepperControl.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
+import { Button } from '@/design-system';
 import { DeferredNumberInput } from '@/shared/components/DeferredNumberInput';
 
 /**
@@ -201,9 +202,12 @@ export function StepperControl({
   const decreaseDisabled = disabled || optimisticValue <= min;
   const increaseDisabled = disabled || optimisticValue >= max;
 
-  // Button styles based on variant
+  // Button styles based on variant. The mobile `secondary` variant supplies the
+  // filled look; desktop/compact use `ghost` and override bg/border via these
+  // classes so the +/- buttons keep their connected, border-sharing appearance.
+  const buttonVariant = isMobile ? 'secondary' : 'ghost';
   const buttonBaseClass = isMobile
-    ? 'btn btn-secondary w-12 h-12 p-0'
+    ? 'w-12 h-12 p-0'
     : `h-full ${isCompact ? 'px-1' : 'px-2'} border border-stroke-subtle bg-surface-elevated text-content-tertiary hover:text-content hover:bg-surface-hover disabled:opacity-50 transition-colors`;
 
   const decreaseButtonClass = isMobile
@@ -232,7 +236,8 @@ export function StepperControl({
   return (
     <div className={`flex items-center ${heightClass} ${className}`}>
       {/* Decrease button */}
-      <button
+      <Button
+        variant={buttonVariant}
         type="button"
         onClick={() => handleStep(-1)}
         disabled={decreaseDisabled}
@@ -240,7 +245,7 @@ export function StepperControl({
         aria-label={`Decrease ${ariaLabel}`}
       >
         <MinusIcon size={iconSize} />
-      </button>
+      </Button>
 
       {/* Input or display */}
       {displayValue !== undefined ? (
@@ -265,7 +270,8 @@ export function StepperControl({
       )}
 
       {/* Increase button */}
-      <button
+      <Button
+        variant={buttonVariant}
         type="button"
         onClick={() => handleStep(1)}
         disabled={increaseDisabled}
@@ -273,7 +279,7 @@ export function StepperControl({
         aria-label={`Increase ${ariaLabel}`}
       >
         <PlusIcon size={iconSize} />
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/shared/components/Toast/Toast.tsx
+++ b/src/shared/components/Toast/Toast.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
+import { Button, IconButton } from '@/design-system';
 import type { Toast, ToastType } from '@/core/store/toast';
 import { useToastStore } from '@/core/store/toast';
 import { useResponsive } from '@/shared/hooks';
@@ -167,38 +168,43 @@ function ToastItem({ toast, position, onRemove }: ToastItemProps) {
         <div className="text-sm leading-relaxed whitespace-pre-wrap pr-1">{toast.message}</div>
         {toast.action && (
           <div className="mt-2 flex items-center gap-3">
-            <button
+            <Button
+              variant="ghost"
               onClick={() => {
                 void toast.action?.onClick();
                 handleDismiss();
               }}
-              className="text-sm font-medium underline underline-offset-2 opacity-90 hover:opacity-100 transition-opacity"
+              className="h-auto rounded-none px-0 py-0 text-sm font-medium underline underline-offset-2 opacity-90 hover:bg-transparent hover:text-current hover:opacity-100"
             >
               {toast.action.label}
-            </button>
+            </Button>
             {toast.secondaryAction && (
-              <button
+              <Button
+                variant="ghost"
                 onClick={() => {
                   void toast.secondaryAction?.onClick();
                   handleDismiss();
                 }}
-                className="text-sm font-medium underline underline-offset-2 opacity-75 hover:opacity-100 transition-opacity"
+                className="h-auto rounded-none px-0 py-0 text-sm font-medium underline underline-offset-2 opacity-75 hover:bg-transparent hover:text-current hover:opacity-100"
               >
                 {toast.secondaryAction.label}
-              </button>
+              </Button>
             )}
           </div>
         )}
       </div>
 
       {/* Close button */}
-      <button
+      <IconButton
+        variant="ghost"
+        size="sm"
+        touchTarget={false}
         onClick={handleDismiss}
-        className="absolute top-1/2 -translate-y-1/2 right-1 p-2 flex items-center justify-center rounded-md text-current opacity-60 hover:opacity-100 hover:bg-white/10 transition-all focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:opacity-100"
+        className="absolute top-1/2 right-1 -translate-y-1/2 p-2 text-current opacity-60 hover:bg-white/10 hover:text-current hover:opacity-100 focus-visible:opacity-100"
         aria-label={t('toast.dismissNotification')}
       >
         <CloseIcon />
-      </button>
+      </IconButton>
 
       {/* Progress bar */}
       {toast.duration > 0 && (

--- a/src/shared/components/Toast/Toast.tsx
+++ b/src/shared/components/Toast/Toast.tsx
@@ -174,7 +174,7 @@ function ToastItem({ toast, position, onRemove }: ToastItemProps) {
                 void toast.action?.onClick();
                 handleDismiss();
               }}
-              className="h-auto rounded-none px-0 py-0 text-sm font-medium underline underline-offset-2 opacity-90 hover:bg-transparent hover:text-current hover:opacity-100"
+              className="h-auto rounded-none px-0 py-0 text-sm font-medium text-current underline underline-offset-2 opacity-90 hover:bg-transparent hover:text-current hover:opacity-100"
             >
               {toast.action.label}
             </Button>
@@ -185,7 +185,7 @@ function ToastItem({ toast, position, onRemove }: ToastItemProps) {
                   void toast.secondaryAction?.onClick();
                   handleDismiss();
                 }}
-                className="h-auto rounded-none px-0 py-0 text-sm font-medium underline underline-offset-2 opacity-75 hover:bg-transparent hover:text-current hover:opacity-100"
+                className="h-auto rounded-none px-0 py-0 text-sm font-medium text-current underline underline-offset-2 opacity-75 hover:bg-transparent hover:text-current hover:opacity-100"
               >
                 {toast.secondaryAction.label}
               </Button>

--- a/src/shared/components/ToolSwitcher/ToolSwitcher.tsx
+++ b/src/shared/components/ToolSwitcher/ToolSwitcher.tsx
@@ -2,6 +2,7 @@
  * Segmented control for switching between Layout, Bins, and Baseplate Generator.
  */
 
+import { Button } from '@/design-system';
 import { useDesignerRouting } from '@/shared/hooks/useDesignerRouting';
 import { useBaseplateRouting } from '@/shared/hooks/useBaseplateRouting';
 import { useTranslation } from '@/i18n';
@@ -101,8 +102,9 @@ export function ToolSwitcher({ compact = false, iconOnly = false }: ToolSwitcher
         aria-label={t('toolSwitcher.activeTool')}
       >
         {TOOLS.map(({ id, labelKey, switchKey, iconPaths }) => (
-          <button
+          <Button
             key={id}
+            variant="ghost"
             role="tab"
             aria-selected={activeTool === id}
             aria-label={t(labelKey)}
@@ -116,7 +118,7 @@ export function ToolSwitcher({ compact = false, iconOnly = false }: ToolSwitcher
               ))}
             </svg>
             {!iconOnly && t(labelKey)}
-          </button>
+          </Button>
         ))}
       </div>
     </div>

--- a/src/shared/components/TwoClickDeleteButton/TwoClickDeleteButton.tsx
+++ b/src/shared/components/TwoClickDeleteButton/TwoClickDeleteButton.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { Button, cn } from '@/design-system';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 
 interface TwoClickDeleteButtonProps {
@@ -83,19 +84,22 @@ export function TwoClickDeleteButton({
     [disabled, isConfirming, onDelete]
   );
 
-  const baseStyles = 'w-full px-3 py-2 text-left text-sm flex flex-col gap-0.5 transition-colors';
-  const stateStyles = effectiveConfirming
-    ? 'bg-danger text-on-dark'
-    : 'text-danger hover:bg-surface disabled:opacity-50 disabled:cursor-not-allowed';
+  const stateStyles = effectiveConfirming ? 'text-on-dark' : 'text-danger hover:bg-surface';
 
   return (
-    <button
+    <Button
       ref={buttonRef}
+      variant={effectiveConfirming ? 'danger' : 'ghost'}
+      fullWidth
       type="button"
       role="menuitem"
       onClick={handleClick}
       disabled={disabled}
-      className={`${baseStyles} ${stateStyles} ${className}`}
+      className={cn(
+        'flex-col items-start justify-start gap-0.5 rounded-none px-3 py-2 text-left text-sm font-normal',
+        stateStyles,
+        className
+      )}
     >
       <span className="flex items-center gap-2">
         <svg
@@ -114,6 +118,6 @@ export function TwoClickDeleteButton({
       {effectiveConfirming && confirmSubtext && (
         <span className="text-xs opacity-70 ml-6">{confirmSubtext}</span>
       )}
-    </button>
+    </Button>
   );
 }

--- a/src/shared/components/TwoClickDeleteButton/TwoClickDeleteButton.tsx
+++ b/src/shared/components/TwoClickDeleteButton/TwoClickDeleteButton.tsx
@@ -84,7 +84,9 @@ export function TwoClickDeleteButton({
     [disabled, isConfirming, onDelete]
   );
 
-  const stateStyles = effectiveConfirming ? 'text-on-dark' : 'text-danger hover:bg-surface';
+  const stateStyles = effectiveConfirming
+    ? 'text-on-dark'
+    : 'text-danger hover:bg-surface hover:text-danger';
 
   return (
     <Button

--- a/src/shared/components/ViewModeToggle/ViewModeToggle.tsx
+++ b/src/shared/components/ViewModeToggle/ViewModeToggle.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { IconButton } from '@/design-system';
 
 export type ViewMode = 'list' | 'grid';
 
@@ -44,12 +45,10 @@ export function ViewModeToggle({
     [onChange]
   );
 
-  const buttonClass = (isSelected: boolean): string =>
-    `p-1.5 rounded-md transition-colors leading-none ${
-      isSelected
-        ? 'bg-accent text-on-dark'
-        : 'text-content-secondary hover:text-content hover:bg-surface-secondary'
-    }`;
+  const selectedClass = (isSelected: boolean): string =>
+    isSelected
+      ? 'bg-accent text-on-dark'
+      : 'text-content-secondary hover:text-content hover:bg-surface-secondary';
 
   return (
     <div
@@ -59,13 +58,16 @@ export function ViewModeToggle({
       aria-label={ariaLabel}
       onKeyDown={handleKeyDown}
     >
-      <button
+      <IconButton
         type="button"
+        variant="ghost"
+        size="sm"
+        touchTarget={false}
         role="radio"
         aria-checked={value === 'list'}
         tabIndex={value === 'list' ? 0 : -1}
         onClick={() => onChange('list')}
-        className={buttonClass(value === 'list')}
+        className={selectedClass(value === 'list')}
         aria-label={listLabel}
         title={listLabel}
       >
@@ -83,14 +85,17 @@ export function ViewModeToggle({
             d="M4 6h16M4 10h16M4 14h16M4 18h16"
           />
         </svg>
-      </button>
-      <button
+      </IconButton>
+      <IconButton
         type="button"
+        variant="ghost"
+        size="sm"
+        touchTarget={false}
         role="radio"
         aria-checked={value === 'grid'}
         tabIndex={value === 'grid' ? 0 : -1}
         onClick={() => onChange('grid')}
-        className={buttonClass(value === 'grid')}
+        className={selectedClass(value === 'grid')}
         aria-label={gridLabel}
         title={gridLabel}
       >
@@ -108,7 +113,7 @@ export function ViewModeToggle({
             d="M4 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM14 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM4 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1v-4zM14 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z"
           />
         </svg>
-      </button>
+      </IconButton>
     </div>
   );
 }

--- a/src/shell/Collab/PresenceAvatarBar/PresenceAvatarBar.tsx
+++ b/src/shell/Collab/PresenceAvatarBar/PresenceAvatarBar.tsx
@@ -8,6 +8,7 @@
 
 import { useState, useRef } from 'react';
 import type { Participant, ConnectionStatus } from '@/shared/hooks/usePresence';
+import { Button } from '@/design-system';
 import { PresenceAvatar } from '../PresenceAvatar';
 import { ConnectionIndicator } from '../ConnectionIndicator';
 import { PresenceDropdown } from '../PresenceDropdown';
@@ -65,23 +66,17 @@ export function PresenceAvatarBar({
         </div>
 
         {/* Overflow button or click target */}
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           onClick={() => setIsDropdownOpen((prev) => !prev)}
-          className={`
-            ml-1 px-2 py-1 rounded-md text-xs font-medium
-            transition-colors
-            ${
-              isDropdownOpen
-                ? 'bg-surface-hover text-content'
-                : 'text-content-secondary hover:text-content hover:bg-surface-hover'
-            }
-          `.trim()}
+          className={`ml-1 ${isDropdownOpen ? 'bg-surface-hover text-content' : ''}`.trim()}
           aria-expanded={isDropdownOpen}
           aria-haspopup="dialog"
           title={`${participants.length} collaborators - click to see all`}
         >
           {hasOverflow ? `+${overflowCount} more` : `${participants.length}`}
-        </button>
+        </Button>
       </div>
 
       {/* Dropdown */}

--- a/src/shell/Collab/PresenceDropdown/PresenceDropdown.tsx
+++ b/src/shell/Collab/PresenceDropdown/PresenceDropdown.tsx
@@ -9,6 +9,7 @@ import { useRef, useEffect, useLayoutEffect, useCallback, useState } from 'react
 import type { Participant, ConnectionStatus } from '@/shared/hooks/usePresence';
 import { PresenceAvatarList } from '../PresenceAvatarList';
 import { ConnectionIndicator } from '../ConnectionIndicator';
+import { IconButton, XIcon } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 /** Minimum distance from viewport edge */
@@ -164,20 +165,15 @@ export function PresenceDropdown({
           </span>
           <ConnectionIndicator status={status} size="sm" />
         </div>
-        <button
+        <IconButton
+          size="sm"
+          touchTarget={false}
           onClick={onClose}
-          className="text-content-tertiary hover:text-content transition-colors p-1 -m-1"
+          className="-m-1 text-content-tertiary"
           aria-label={t('common.close')}
         >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
+          <XIcon size="sm" />
+        </IconButton>
       </div>
 
       {/* Participant list */}

--- a/src/shell/Collab/PresenceMobileButton/PresenceMobileButton.tsx
+++ b/src/shell/Collab/PresenceMobileButton/PresenceMobileButton.tsx
@@ -7,6 +7,7 @@
  */
 
 import type { ConnectionStatus } from '@/shared/hooks/usePresence';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 const PEOPLE_EMOJI = '👥';
@@ -34,28 +35,21 @@ export function PresenceMobileButton({
 }: PresenceMobileButtonProps) {
   const t = useTranslation();
   return (
-    <button
+    <Button
+      variant="ghost"
+      size="sm"
       onClick={onPress}
-      className={`
-        flex items-center gap-1.5 px-2 py-1
-        rounded-md text-sm font-medium
-        text-content-secondary hover:text-content
-        hover:bg-surface-hover transition-colors
-        ${className}
-      `.trim()}
+      className={`gap-1.5 ${className}`.trim()}
       aria-label={t('collab.mobileButton.ariaLabel', { count: participantCount })}
       title={t('collab.mobileButton.title', { count: participantCount })}
     >
-      {/* People emoji */}
       <span className="text-base" aria-hidden="true">
         {PEOPLE_EMOJI}
       </span>
 
-      {/* Count */}
       <span>{participantCount}</span>
 
-      {/* Connection indicator */}
       <ConnectionIndicator status={status} size="sm" />
-    </button>
+    </Button>
   );
 }

--- a/src/shell/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/shell/ErrorBoundary/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 import type { ErrorInfo, ReactNode } from 'react';
+import { Button } from '@/design-system';
 import { captureException, track3DRenderError } from '@/shared/analytics/posthog';
 import { downloadArchive } from '@/core/storage';
 import { useLibraryStore } from '@/core/store/library';
@@ -116,21 +117,21 @@ export class ErrorBoundary extends Component<Props, State> {
             )}
             {/* eslint-disable i18next/no-literal-string -- translation keys */}
             <div className="flex flex-wrap gap-3 justify-center">
-              <button onClick={this.handleReset} className="btn btn-secondary">
+              <Button variant="secondary" onClick={this.handleReset}>
                 {getStaticTranslation('errorBoundary.tryAgain')}
-              </button>
+              </Button>
               {canUndo && (
-                <button onClick={this.handleUndo} className="btn btn-secondary">
+                <Button variant="secondary" onClick={this.handleUndo}>
                   {getStaticTranslation('errorBoundary.undoLastChange')}
-                </button>
+                </Button>
               )}
-              <button
+              <Button
+                variant="primary"
                 onClick={this.handleDownloadBackup}
-                className="btn btn-primary"
                 disabled={backupState === 'working'}
               >
                 {getStaticTranslation('errorBoundary.downloadBackup')}
-              </button>
+              </Button>
             </div>
             {backupState === 'done' && (
               <p className="text-sm text-success mt-4">

--- a/src/shell/Header/Header.tsx
+++ b/src/shell/Header/Header.tsx
@@ -127,7 +127,7 @@ export function Header({ saveStatus }: HeaderProps) {
             variant="ghost"
             size="sm"
             onClick={handleNameClick}
-            className={`hover:scale-[1.02] ${activePress} text-content-secondary truncate max-w-[200px]`}
+            className={`px-3 py-1.5 h-auto text-sm hover:scale-[1.02] ${activePress} text-content-secondary truncate max-w-[200px]`}
             title={t('header.editLayoutName')}
           >
             {layout.name}
@@ -141,7 +141,7 @@ export function Header({ saveStatus }: HeaderProps) {
           variant="ghost"
           size="sm"
           onClick={() => setPrintModalOpen(true)}
-          className={`gap-1.5 ${activePress} text-content-secondary`}
+          className={`px-2 py-1.5 h-auto text-sm gap-1.5 ${activePress} text-content-secondary`}
           title={t('header.printLayout')}
           aria-label={t('header.printLayout')}
           leftIcon={

--- a/src/shell/Header/Header.tsx
+++ b/src/shell/Header/Header.tsx
@@ -221,6 +221,7 @@ export function Header({ saveStatus }: HeaderProps) {
         <div className="flex items-center">
           <IconButton
             size="sm"
+            touchTarget={false}
             onClick={undo}
             disabled={!canUndo}
             title={t('header.undoAction', { mod: modKey })}
@@ -237,6 +238,7 @@ export function Header({ saveStatus }: HeaderProps) {
           </IconButton>
           <IconButton
             size="sm"
+            touchTarget={false}
             onClick={redo}
             disabled={!canRedo}
             title={t('header.redoAction', { mod: modKey })}

--- a/src/shell/Header/Header.tsx
+++ b/src/shell/Header/Header.tsx
@@ -7,7 +7,7 @@ import { useResponsive } from '@/shared/hooks';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { useCollabMode } from '@/shared/hooks/useCollabMode';
 import { CONSTRAINTS } from '@/core/constants';
-import { activePress } from '@/design-system';
+import { activePress, Button, IconButton } from '@/design-system';
 import { lazyWithRetry, namedExport } from '@/shared/utils/lazyWithRetry';
 import { ShareButton } from '@/features/cloud-share/components/ShareButton';
 import { ShareModal } from '@/features/cloud-share/components/ShareModal';
@@ -123,34 +123,40 @@ export function Header({ saveStatus }: HeaderProps) {
             }}
           />
         ) : (
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={handleNameClick}
-            className={`px-3 py-1.5 text-sm rounded-md transition-all hover:scale-[1.02] ${activePress} text-content-secondary bg-transparent hover:bg-surface-hover hover:text-content truncate max-w-[200px]`}
+            className={`hover:scale-[1.02] ${activePress} text-content-secondary truncate max-w-[200px]`}
             title={t('header.editLayoutName')}
           >
             {layout.name}
-          </button>
+          </Button>
         )}
 
         <LayoutQuickSwitch onManage={() => setShowLayoutManager(true)} />
 
         {/* Print Button */}
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           onClick={() => setPrintModalOpen(true)}
-          className={`px-2 py-1.5 text-sm leading-none rounded-md transition-all ${activePress} text-content-secondary bg-transparent hover:bg-surface-hover hover:text-content flex items-center gap-1.5`}
+          className={`gap-1.5 ${activePress} text-content-secondary`}
           title={t('header.printLayout')}
           aria-label={t('header.printLayout')}
+          leftIcon={
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
+              />
+            </svg>
+          }
         >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
-            />
-          </svg>
           {!isTablet && <span className="hidden sm:inline">{t('header.print')}</span>}
-        </button>
+        </Button>
       </div>
 
       <div className="flex items-center gap-1 flex-shrink-0">
@@ -213,10 +219,10 @@ export function Header({ saveStatus }: HeaderProps) {
 
         {/* Undo/Redo buttons */}
         <div className="flex items-center">
-          <button
+          <IconButton
+            size="sm"
             onClick={undo}
             disabled={!canUndo}
-            className="btn btn-ghost btn-icon"
             title={t('header.undoAction', { mod: modKey })}
             aria-label={t('header.undo', { mod: modKey })}
           >
@@ -228,11 +234,11 @@ export function Header({ saveStatus }: HeaderProps) {
                 d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"
               />
             </svg>
-          </button>
-          <button
+          </IconButton>
+          <IconButton
+            size="sm"
             onClick={redo}
             disabled={!canRedo}
-            className="btn btn-ghost btn-icon"
             title={t('header.redoAction', { mod: modKey })}
             aria-label={t('header.redo', { mod: modKey })}
           >
@@ -244,7 +250,7 @@ export function Header({ saveStatus }: HeaderProps) {
                 d="M21 10h-10a8 8 0 00-8 8v2M21 10l-6 6m6-6l-6-6"
               />
             </svg>
-          </button>
+          </IconButton>
         </div>
 
         {/* Share button and presence avatars (only visible when collaborative_editing flag is enabled) */}

--- a/src/shell/Mobile/BottomNavBar/BottomNavBar.tsx
+++ b/src/shell/Mobile/BottomNavBar/BottomNavBar.tsx
@@ -1,4 +1,5 @@
 import { useMobileStore } from '@/core/store';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 interface NavItem {
@@ -99,10 +100,11 @@ export function BottomNavBar() {
         const isActive = activeMobilePanel === item.id;
         const label = getLabel(item.id);
         return (
-          <button
+          <Button
             key={item.id}
+            variant="ghost"
             onClick={() => toggleMobilePanel(item.id)}
-            className="flex-1 flex flex-col items-center justify-center gap-0.5 transition-colors"
+            className="flex-1 flex flex-col items-center justify-center gap-0.5 rounded-none hover:bg-transparent"
             style={{
               color: isActive ? 'var(--color-primary)' : 'var(--text-tertiary)',
               backgroundColor: isActive ? 'var(--bg-hover)' : 'transparent',
@@ -112,7 +114,7 @@ export function BottomNavBar() {
           >
             {item.icon}
             <span className="text-xs">{label}</span>
-          </button>
+          </Button>
         );
       })}
     </nav>

--- a/src/shell/Mobile/BottomSheet/BottomSheet.tsx
+++ b/src/shell/Mobile/BottomSheet/BottomSheet.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { useMobileStore } from '@/core/store';
+import { IconButton, XIcon } from '@/design-system';
 import { useResponsive } from '@/shared/hooks';
 import { useTranslation } from '@/i18n';
 
@@ -221,20 +222,9 @@ export function BottomSheet({ children, title }: BottomSheetProps) {
           {/* Title row */}
           <div className="w-full flex items-center justify-between px-4">
             <h2 className="text-base font-medium text-content">{title}</h2>
-            <button
-              onClick={closeMobilePanel}
-              className="btn btn-ghost btn-icon"
-              aria-label={t('mobile.bottomSheet.closePanel')}
-            >
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            </button>
+            <IconButton onClick={closeMobilePanel} aria-label={t('mobile.bottomSheet.closePanel')}>
+              <XIcon />
+            </IconButton>
           </div>
         </div>
 

--- a/src/shell/Mobile/MobileCategoriesPanel/MobileCategoriesPanel.tsx
+++ b/src/shell/Mobile/MobileCategoriesPanel/MobileCategoriesPanel.tsx
@@ -8,6 +8,7 @@ import type { CategoryId } from '@/core/types';
 import { CONSTRAINTS, DEFAULT_CATEGORY_COLOR, CATEGORY_COLOR_PALETTE } from '@/core/constants';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { isOk } from '@/core/result';
+import { Button, IconButton, PlusIcon } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { batch } from '@/core/cqrs';
 
@@ -160,8 +161,9 @@ export function MobileCategoriesPanel() {
                   {/* Color grid */}
                   <div className="grid grid-cols-6 gap-2">
                     {CATEGORY_COLOR_PALETTE.map(({ color, nameKey }) => (
-                      <button
+                      <IconButton
                         key={color}
+                        size="lg"
                         onClick={() => handleUpdateColor(category.id, color)}
                         className="w-10 h-10 rounded-lg transition-transform active:scale-95"
                         style={{
@@ -172,27 +174,38 @@ export function MobileCategoriesPanel() {
                               : 'var(--shadow-sm)',
                         }}
                         aria-label={t(nameKey)}
-                      />
+                      >
+                        <span />
+                      </IconButton>
                     ))}
                   </div>
 
                   {/* Actions */}
                   <div className="flex gap-2 pt-2">
-                    <button
+                    <Button
+                      variant={canDelete ? 'danger' : 'secondary'}
+                      fullWidth
                       onClick={() => handleDelete(category.id, category.name)}
-                      className={`btn flex-1 ${canDelete ? 'btn-danger' : 'btn-secondary opacity-50'}`}
+                      className={`flex-1 ${canDelete ? '' : 'opacity-50'}`}
                     >
                       {t('common.delete')}
                       {binCount > 0 ? ` (${binCount} bins)` : ''}
-                    </button>
-                    <button onClick={() => setEditingId(null)} className="btn btn-secondary flex-1">
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      fullWidth
+                      onClick={() => setEditingId(null)}
+                      className="flex-1"
+                    >
                       {t('common.done')}
-                    </button>
+                    </Button>
                   </div>
                 </div>
               ) : (
-                <button
-                  className="w-full p-4 flex items-center gap-3"
+                <Button
+                  variant="ghost"
+                  fullWidth
+                  className="p-4 flex items-center gap-3 justify-start rounded-none hover:bg-transparent"
                   onClick={() => handleSelectCategory(category.id, category.name)}
                   aria-label={
                     selectedBinIds.length > 0
@@ -220,12 +233,13 @@ export function MobileCategoriesPanel() {
                       {t('layouts.active')}
                     </span>
                   )}
-                  <button
+                  <IconButton
+                    size="lg"
                     onClick={(e) => {
                       e.stopPropagation();
                       setEditingId(category.id);
                     }}
-                    className="btn btn-ghost w-10 h-10 p-0"
+                    className="w-10 h-10"
                     aria-label={t('categories.editCategory')}
                   >
                     <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -236,8 +250,8 @@ export function MobileCategoriesPanel() {
                         d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
                       />
                     </svg>
-                  </button>
-                </button>
+                  </IconButton>
+                </Button>
               )}
             </div>
           );
@@ -245,16 +259,16 @@ export function MobileCategoriesPanel() {
       </div>
 
       {/* Add category button */}
-      <button
+      <Button
+        variant="primary"
+        fullWidth
         onClick={handleAddCategory}
         disabled={!canAddCategory}
-        className="btn btn-primary w-full mt-4"
+        className="mt-4"
+        leftIcon={<PlusIcon />}
       >
-        <svg className="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-        </svg>
         {t('categories.addCategory')}
-      </button>
+      </Button>
 
       <ConfirmDialog
         isOpen={deleteConfirm !== null}

--- a/src/shell/Mobile/MobileCategoriesPanel/MobileCategoriesPanel.tsx
+++ b/src/shell/Mobile/MobileCategoriesPanel/MobileCategoriesPanel.tsx
@@ -164,6 +164,7 @@ export function MobileCategoriesPanel() {
                       <IconButton
                         key={color}
                         size="lg"
+                        touchTarget={false}
                         onClick={() => handleUpdateColor(category.id, color)}
                         className="w-10 h-10 rounded-lg transition-transform active:scale-95"
                         style={{

--- a/src/shell/Mobile/MobileGridToolbar/MobileGridToolbar.tsx
+++ b/src/shell/Mobile/MobileGridToolbar/MobileGridToolbar.tsx
@@ -96,10 +96,11 @@ export function MobileGridToolbar({ onFitToScreen }: MobileGridToolbarProps) {
       {/* Right: Baseplate + 3D preview + Zoom controls */}
       <div className="flex items-center gap-1 flex-shrink-0">
         {/* 3D Preview toggle */}
-        <IconButton
-          variant="secondary"
+        <Button
+          iconOnly
+          variant={showIsometricPreview ? 'primary' : 'secondary'}
           size="lg"
-          pressed={showIsometricPreview}
+          aria-pressed={showIsometricPreview}
           onClick={toggleIsometricPreview}
           className="w-10 h-10"
           aria-label={
@@ -115,7 +116,7 @@ export function MobileGridToolbar({ onFitToScreen }: MobileGridToolbarProps) {
               d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
             />
           </svg>
-        </IconButton>
+        </Button>
         <IconButton
           variant="secondary"
           size="lg"

--- a/src/shell/Mobile/MobileGridToolbar/MobileGridToolbar.tsx
+++ b/src/shell/Mobile/MobileGridToolbar/MobileGridToolbar.tsx
@@ -2,6 +2,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
 import { useViewStore, useSelectionStore, useInteractionStore, useMobileStore } from '@/core/store';
 import { CONSTRAINTS } from '@/core/constants';
+import { Button, IconButton, PlusIcon, MinusIcon } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 interface MobileGridToolbarProps {
@@ -44,9 +45,10 @@ export function MobileGridToolbar({ onFitToScreen }: MobileGridToolbarProps) {
   return (
     <div className="flex items-center justify-between px-3 py-2 flex-shrink-0 bg-surface-secondary border-b border-stroke-subtle gap-2 overflow-x-auto">
       {/* Left: Layer indicator (tappable) */}
-      <button
+      <Button
+        variant="secondary"
         onClick={() => toggleMobilePanel('layers')}
-        className="flex items-center gap-2 px-3 py-2 rounded-lg transition-colors bg-surface-elevated border border-stroke-subtle"
+        className="flex items-center gap-2 px-3 py-2 rounded-lg bg-surface-elevated border border-stroke-subtle"
       >
         <div className="w-2 h-2 rounded-full flex-shrink-0 bg-accent" />
         <span className="font-medium truncate max-w-[80px] text-sm text-content">
@@ -60,13 +62,14 @@ export function MobileGridToolbar({ onFitToScreen }: MobileGridToolbarProps) {
         >
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
-      </button>
+      </Button>
 
       {/* Center: Paint mode indicator (if active) */}
       {paintSize && (
-        <button
+        <Button
+          variant="ghost"
           onClick={() => setPaintSize(null)}
-          className="flex items-center gap-1.5 px-2 py-1 rounded-md border border-accent text-accent text-xs font-medium"
+          className="flex items-center gap-1.5 px-2 py-1 rounded-md border border-accent text-accent text-xs"
           style={{ backgroundColor: 'var(--color-primary-muted)' }}
           aria-label={t('toolbar.exitPaintMode')}
         >
@@ -87,15 +90,18 @@ export function MobileGridToolbar({ onFitToScreen }: MobileGridToolbarProps) {
               d="M6 18L18 6M6 6l12 12"
             />
           </svg>
-        </button>
+        </Button>
       )}
 
       {/* Right: Baseplate + 3D preview + Zoom controls */}
       <div className="flex items-center gap-1 flex-shrink-0">
         {/* 3D Preview toggle */}
-        <button
+        <IconButton
+          variant="secondary"
+          size="lg"
+          pressed={showIsometricPreview}
           onClick={toggleIsometricPreview}
-          className={`btn ${showIsometricPreview ? 'btn-primary' : 'btn-secondary'} w-10 h-10 p-0`}
+          className="w-10 h-10"
           aria-label={
             showIsometricPreview ? t('toolbar.hide3dPreview') : t('toolbar.show3dPreview')
           }
@@ -109,34 +115,35 @@ export function MobileGridToolbar({ onFitToScreen }: MobileGridToolbarProps) {
               d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
             />
           </svg>
-        </button>
-        <button
+        </IconButton>
+        <IconButton
+          variant="secondary"
+          size="lg"
           onClick={zoomOut}
           disabled={!canZoomOut}
-          className="btn btn-secondary w-10 h-10 p-0"
+          className="w-10 h-10"
           aria-label={t('toolbar.zoomOut')}
         >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-          </svg>
-        </button>
-        <button
+          <MinusIcon />
+        </IconButton>
+        <Button
+          variant="secondary"
           onClick={onFitToScreen}
-          className="btn btn-secondary px-3 h-10"
+          className="px-3 h-10"
           aria-label={t('toolbar.fitToScreen')}
         >
           <span className="text-sm font-medium">{Math.round(zoom * 100)}%</span>
-        </button>
-        <button
+        </Button>
+        <IconButton
+          variant="secondary"
+          size="lg"
           onClick={zoomIn}
           disabled={!canZoomIn}
-          className="btn btn-secondary w-10 h-10 p-0"
+          className="w-10 h-10"
           aria-label={t('toolbar.zoomIn')}
         >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-        </button>
+          <PlusIcon />
+        </IconButton>
       </div>
     </div>
   );

--- a/src/shell/Mobile/MobileHeader/MobileHeader.tsx
+++ b/src/shell/Mobile/MobileHeader/MobileHeader.tsx
@@ -7,6 +7,7 @@ import { useCollabMode } from '@/shared/hooks/useCollabMode';
 import { CONSTRAINTS } from '@/core/constants';
 import { PresenceAvatars } from '@/shell/Collab';
 import type { SaveStatus } from '@/shared/hooks';
+import { Button, IconButton } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import { ToolSwitcher } from '@/shared/components/ToolSwitcher';
@@ -118,13 +119,15 @@ export function MobileHeader({ onMenuClick, saveStatus }: MobileHeaderProps) {
               className="w-full px-2 py-1 rounded text-sm text-center bg-surface-elevated border border-accent text-content"
             />
           ) : (
-            <button
+            <Button
+              variant="ghost"
+              fullWidth
               onClick={() => toggleMobilePanel('layouts')}
               onContextMenu={(e) => {
                 e.preventDefault();
                 handleNameClick();
               }}
-              className="w-full text-sm truncate py-1 rounded transition-colors text-content flex items-center justify-center gap-1"
+              className="text-sm truncate py-1 rounded text-content flex items-center justify-center gap-1 hover:bg-transparent"
               aria-label={t('mobile.header.openLayoutsPanel')}
             >
               <span className="truncate">{layout.name}</span>
@@ -141,7 +144,7 @@ export function MobileHeader({ onMenuClick, saveStatus }: MobileHeaderProps) {
                   d="M19 9l-7 7-7-7"
                 />
               </svg>
-            </button>
+            </Button>
           )}
         </div>
 
@@ -175,10 +178,9 @@ export function MobileHeader({ onMenuClick, saveStatus }: MobileHeaderProps) {
               </svg>
             </div>
           )}
-          <button
+          <IconButton
             onClick={undo}
             disabled={!canUndo}
-            className="btn btn-ghost btn-icon"
             aria-label={canUndo ? t('common.undo') : t('mobile.header.nothingToUndo')}
           >
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -189,11 +191,10 @@ export function MobileHeader({ onMenuClick, saveStatus }: MobileHeaderProps) {
                 d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"
               />
             </svg>
-          </button>
-          <button
+          </IconButton>
+          <IconButton
             onClick={redo}
             disabled={!canRedo}
-            className="btn btn-ghost btn-icon"
             aria-label={canRedo ? t('common.redo') : t('mobile.header.nothingToRedo')}
           >
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -204,10 +205,9 @@ export function MobileHeader({ onMenuClick, saveStatus }: MobileHeaderProps) {
                 d="M21 10h-10a8 8 0 00-8 8v2M21 10l-6 6m6-6l-6-6"
               />
             </svg>
-          </button>
-          <button
+          </IconButton>
+          <IconButton
             onClick={onMenuClick}
-            className="btn btn-ghost btn-icon"
             aria-label={t('sidebar.openSettings')}
             title={t('mobile.settings')}
           >
@@ -216,7 +216,7 @@ export function MobileHeader({ onMenuClick, saveStatus }: MobileHeaderProps) {
                 <path key={d} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
               ))}
             </svg>
-          </button>
+          </IconButton>
         </div>
       </header>
     </div>

--- a/src/shell/Mobile/MobileHelpModal/MobileHelpModal.tsx
+++ b/src/shell/Mobile/MobileHelpModal/MobileHelpModal.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { IconButton, XIcon } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import { getAllHelpEntries } from '@/shell/Modals/HelpModal/helpEntryAggregator';
@@ -122,20 +123,14 @@ export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
             <h2 id="mobile-help-title" style={STYLES.title}>
               {t('mobile.help')}
             </h2>
-            <button
+            <IconButton
+              size="lg"
               onClick={handleClose}
-              className="btn btn-ghost w-10 h-10 p-0"
+              className="w-10 h-10"
               aria-label={t('common.close')}
             >
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            </button>
+              <XIcon />
+            </IconButton>
           </div>
 
           {/* Search */}
@@ -161,9 +156,11 @@ export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
               className="w-full pl-9 pr-9 py-2 text-sm rounded-md bg-surface border border-stroke-subtle text-content placeholder:text-content-tertiary"
             />
             {searchQuery && (
-              <button
+              <IconButton
+                size="sm"
+                touchTarget={false}
                 onClick={() => setSearchQuery('')}
-                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded text-content-tertiary hover:text-content"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-content-tertiary hover:text-content"
                 aria-label={t('layouts.clearSearch')}
               >
                 <svg
@@ -184,7 +181,7 @@ export function MobileHelpModal({ isOpen, onClose }: MobileHelpModalProps) {
                     />
                   ))}
                 </svg>
-              </button>
+              </IconButton>
             )}
           </div>
 

--- a/src/shell/Mobile/MobileLayersPanel/LayersTab/LayersTab.tsx
+++ b/src/shell/Mobile/MobileLayersPanel/LayersTab/LayersTab.tsx
@@ -13,6 +13,7 @@ import { isOk, isErr, getUserMessage } from '@/core/result';
 import { useToastStore } from '@/core/store/toast';
 import { useResultToast } from '@/shared/hooks';
 import { useTranslation } from '@/i18n';
+import { Button, IconButton, PlusIcon, MinusIcon } from '@/design-system';
 import { calculateLayerAutoExpansion } from '@/features/layers/utils/layerAutoExpansion';
 import { batch } from '@/core/cqrs';
 
@@ -268,8 +269,10 @@ export function LayersTab() {
               }`}
             >
               {/* Layer info - tappable to select */}
-              <button
-                className="flex-1 min-w-0 text-left py-1"
+              <Button
+                variant="ghost"
+                touchTarget={false}
+                className="flex-1 min-w-0 flex-col items-start text-left py-1 px-0 hover:bg-transparent"
                 onClick={() => handleSelectLayer(layer.id)}
               >
                 <span
@@ -289,54 +292,43 @@ export function LayersTab() {
                   {t('mobile.layers.binCount', { count: binCount })}
                   {hasMultipleLayers ? ` · ${layerCoverage}%` : ''}
                 </span>
-              </button>
+              </Button>
 
               {/* Height control - compact */}
               <div className="flex items-center gap-1">
-                <button
+                <IconButton
+                  size="lg"
                   onClick={() => handleHeightChange(layer.id, -1)}
                   disabled={layer.height <= CONSTRAINTS.MIN_LAYER_HEIGHT}
-                  className="w-10 h-10 flex items-center justify-center rounded-md text-content-tertiary active:bg-surface-hover disabled:opacity-50 transition-colors"
+                  className="w-10 h-10 text-content-tertiary active:bg-surface-hover"
                   aria-label={t('layers.decreaseHeight', { name: layer.name })}
                 >
-                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M20 12H4"
-                    />
-                  </svg>
-                </button>
+                  <MinusIcon size="sm" />
+                </IconButton>
                 <span
                   className="text-center text-xs font-medium text-content-secondary tabular-nums whitespace-nowrap min-w-[2ch]"
                   title={t('layers.heightTooltip')}
                 >
                   {layer.height}u
                 </span>
-                <button
+                <IconButton
+                  size="lg"
                   onClick={() => handleHeightChange(layer.id, 1)}
-                  className="w-10 h-10 flex items-center justify-center rounded-md text-content-tertiary active:bg-surface-hover transition-colors"
+                  className="w-10 h-10 text-content-tertiary active:bg-surface-hover"
                   aria-label={t('layers.increaseHeight', { name: layer.name })}
                 >
-                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M12 4v16m8-8H4"
-                    />
-                  </svg>
-                </button>
+                  <PlusIcon size="sm" />
+                </IconButton>
               </div>
 
               {/* Reorder buttons - only for active layer when multiple layers */}
               {isActive && hasMultipleLayers && (
                 <div className="flex items-center">
-                  <button
+                  <IconButton
+                    touchTarget={false}
                     onClick={() => handleMoveLayer(displayIndex, 'up')}
                     disabled={displayIndex === 0}
-                    className="w-8 h-8 flex items-center justify-center text-content-tertiary hover:text-content disabled:opacity-50 transition-colors"
+                    className="w-8 h-8 text-content-tertiary hover:text-content"
                     aria-label={t('mobile.moveLayerUp')}
                   >
                     <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -347,11 +339,12 @@ export function LayersTab() {
                         d="M5 15l7-7 7 7"
                       />
                     </svg>
-                  </button>
-                  <button
+                  </IconButton>
+                  <IconButton
+                    touchTarget={false}
                     onClick={() => handleMoveLayer(displayIndex, 'down')}
                     disabled={displayIndex === layers.length - 1}
-                    className="w-8 h-8 flex items-center justify-center text-content-tertiary hover:text-content disabled:opacity-50 transition-colors"
+                    className="w-8 h-8 text-content-tertiary hover:text-content"
                     aria-label={t('mobile.moveLayerDown')}
                   >
                     <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -362,15 +355,17 @@ export function LayersTab() {
                         d="M19 9l-7 7-7-7"
                       />
                     </svg>
-                  </button>
+                  </IconButton>
                 </div>
               )}
 
               {/* Delete */}
               {layers.length > 1 && (
-                <button
+                <IconButton
+                  touchTarget={false}
+                  variant="dangerGhost"
                   onClick={() => handleDeleteLayer(layer.id)}
-                  className="w-8 h-8 flex items-center justify-center text-content-tertiary hover:text-error transition-colors"
+                  className="w-8 h-8 text-content-tertiary"
                   aria-label={t('mobile.deleteLayer')}
                 >
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -381,7 +376,7 @@ export function LayersTab() {
                       d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
                     />
                   </svg>
-                </button>
+                </IconButton>
               )}
             </div>
           );
@@ -417,12 +412,15 @@ export function LayersTab() {
       </div>
 
       {/* Add layer button */}
-      <button onClick={handleAddLayer} disabled={!canAddLayer} className="btn btn-primary w-full">
-        <svg className="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-        </svg>
+      <Button
+        variant="primary"
+        fullWidth
+        onClick={handleAddLayer}
+        disabled={!canAddLayer}
+        leftIcon={<PlusIcon />}
+      >
         {t('layers.addLayer')}
-      </button>
+      </Button>
 
       <ConfirmDialog
         isOpen={deleteLayerId !== null}
@@ -478,22 +476,26 @@ export function LayersTab() {
                 autoFocus
               />
               <div className="flex gap-2 mt-4">
-                <button
+                <Button
+                  variant="secondary"
+                  fullWidth
                   onClick={() => {
                     setRenameLayerId(null);
                     setRenameValue('');
                   }}
-                  className="flex-1 py-3 text-content-secondary font-medium bg-surface rounded-lg"
+                  className="flex-1 py-3 text-content-secondary bg-surface rounded-lg"
                 >
                   {t('common.cancel')}
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant="primary"
+                  fullWidth
                   onClick={handleRenameConfirm}
                   disabled={!renameValue.trim()}
-                  className="flex-1 py-3 text-on-dark font-medium bg-accent rounded-lg disabled:opacity-50"
+                  className="flex-1 py-3 text-on-dark bg-accent rounded-lg disabled:opacity-50"
                 >
                   {t('common.rename')}
-                </button>
+                </Button>
               </div>
             </div>
           </div>,

--- a/src/shell/Mobile/MobileLayersPanel/TabBar/TabBar.tsx
+++ b/src/shell/Mobile/MobileLayersPanel/TabBar/TabBar.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@/design-system';
+
 /**
  * Reusable tab bar component for mobile panels.
  * Touch-optimized with 44px minimum touch targets.
@@ -20,19 +22,21 @@ export function TabBar<T extends TabId>({ tabs, activeTab, onChange }: TabBarPro
   return (
     <div className="flex gap-1 mb-4 bg-surface rounded-lg p-1" role="tablist">
       {tabs.map((tab) => (
-        <button
+        <Button
           key={tab.id}
+          variant="ghost"
+          fullWidth
           role="tab"
           aria-selected={activeTab === tab.id}
           onClick={() => onChange(tab.id as T)}
-          className={`flex-1 py-3 px-4 rounded-md text-sm font-medium transition-colors min-h-[44px] ${
+          className={`flex-1 py-3 px-4 rounded-md min-h-[44px] ${
             activeTab === tab.id
-              ? 'bg-accent text-on-dark'
+              ? 'bg-accent text-on-dark hover:bg-accent'
               : 'text-content-secondary hover:text-content hover:bg-surface-hover'
           }`}
         >
           {tab.label}
-        </button>
+        </Button>
       ))}
     </div>
   );

--- a/src/shell/Mobile/MobileLayersPanel/ToolsTab/ToolsTab.tsx
+++ b/src/shell/Mobile/MobileLayersPanel/ToolsTab/ToolsTab.tsx
@@ -256,7 +256,7 @@ export function ToolsTab() {
           fullWidth
           onClick={() => setShowClearConfirm(true)}
           disabled={layerBins.length === 0}
-          className="h-11 justify-center text-error hover:bg-error/10"
+          className="h-11 justify-center text-error hover:bg-error/10 hover:text-error"
           leftIcon={
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path

--- a/src/shell/Mobile/MobileLayersPanel/ToolsTab/ToolsTab.tsx
+++ b/src/shell/Mobile/MobileLayersPanel/ToolsTab/ToolsTab.tsx
@@ -12,6 +12,7 @@ import { useMutations } from '@/shared/contexts';
 import { useToastStore } from '@/core/store/toast';
 import { getLayerBins } from '@/shared/utils';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 // Square sizes (matching desktop ActiveLayerPanel)
@@ -136,11 +137,12 @@ export function ToolsTab() {
     const previewHeight = d * 5;
 
     return (
-      <button
+      <Button
+        variant="ghost"
         onClick={() => togglePaintSize({ width: w, depth: d })}
-        className={`flex flex-col items-center justify-end gap-1 min-h-[56px] p-2 rounded transition-colors ${
+        className={`flex flex-col items-center justify-end gap-1 min-h-[56px] p-2 rounded ${
           isActive
-            ? 'bg-accent/20 ring-2 ring-accent'
+            ? 'bg-accent/20 ring-2 ring-accent hover:bg-accent/20'
             : 'bg-surface-elevated hover:bg-surface-hover'
         }`}
         aria-label={t('mobile.tools.selectForPaint', {
@@ -162,7 +164,7 @@ export function ToolsTab() {
         >
           {w}×{d}
         </span>
-      </button>
+      </Button>
     );
   };
 
@@ -186,9 +188,11 @@ export function ToolsTab() {
         <span className="text-xs text-content-tertiary uppercase tracking-wide">
           {t('layers.rectangles')}
         </span>
-        <button
+        <Button
+          variant="ghost"
+          touchTarget={false}
           onClick={() => setRotated(!rotated)}
-          className="text-xs text-content-tertiary hover:text-content flex items-center gap-1.5 px-2 py-1 rounded transition-colors"
+          className="text-xs text-content-tertiary hover:text-content flex items-center gap-1.5 px-2 py-1 rounded"
           aria-label={t(rotated ? 'mobile.tools.switchToWide' : 'mobile.tools.switchToTall')}
         >
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -200,7 +204,7 @@ export function ToolsTab() {
             />
           </svg>
           {t(rotated ? 'layers.tall' : 'layers.wide')}
-        </button>
+        </Button>
       </div>
       <div className="grid grid-cols-5 gap-2">
         {RECTANGLE_SIZES.map(({ w, d }) => {
@@ -213,51 +217,61 @@ export function ToolsTab() {
       <div className="mt-6 space-y-2">
         {/* Fill with selected size (conditional) */}
         {paintSize && (
-          <button
+          <Button
+            variant="primary"
+            fullWidth
             onClick={() => handleFill(paintSize.width, paintSize.depth)}
-            className="btn btn-primary w-full h-11 justify-center"
+            className="h-11 justify-center"
           >
             {t('mobile.tools.fillWithSize', { width: paintSize.width, depth: paintSize.depth })}
-          </button>
+          </Button>
         )}
 
         {/* Fill Gaps */}
-        <button
+        <Button
+          variant="secondary"
+          fullWidth
           onClick={handleFillGaps}
           disabled={emptyCells === 0}
-          className="btn btn-secondary w-full h-11 justify-center"
+          className="h-11 justify-center"
+          leftIcon={
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"
+              />
+            </svg>
+          }
         >
-          <svg className="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"
-            />
-          </svg>
           {emptyCells > 0
             ? t('mobile.tools.fillGaps', { count: emptyCells })
             : t('mobile.tools.noGaps')}
-        </button>
+        </Button>
 
         {/* Clear Layer */}
-        <button
+        <Button
+          variant="ghost"
+          fullWidth
           onClick={() => setShowClearConfirm(true)}
           disabled={layerBins.length === 0}
-          className="btn btn-ghost w-full h-11 justify-center text-error hover:bg-error/10"
+          className="h-11 justify-center text-error hover:bg-error/10"
+          leftIcon={
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+          }
         >
-          <svg className="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-            />
-          </svg>
           {layerBins.length > 0
             ? t('mobile.tools.clearBins', { count: layerBins.length })
             : t('mobile.tools.noBins')}
-        </button>
+        </Button>
       </div>
 
       {/* Clear confirmation dialog */}

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanel.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanel.tsx
@@ -23,6 +23,7 @@ import type { Layout } from '@/core/types';
 import { layoutId } from '@/core/types';
 import { isOk } from '@/core/result';
 import { useTranslation, useFormatting } from '@/i18n';
+import { Button } from '@/design-system';
 import { SvgIcon, ActionSheet, ShareOptionButton, ICON_PATHS } from './MobileLayoutsPanelParts';
 import { LayoutListItem, findEntry } from './MobileLayoutsListItem';
 import { MobileCloudSharePanel } from './MobileCloudSharePanel';
@@ -291,9 +292,11 @@ export function MobileLayoutsPanel() {
         ))}
       </div>
 
-      <button
+      <Button
+        variant="ghost"
+        fullWidth
         onClick={() => setShowInspirationGallery(true)}
-        className="w-full flex items-center gap-3 mt-4 p-3 rounded-xl bg-gradient-to-r from-accent/10 to-purple-500/10 border border-accent/20 active:scale-[0.98] transition-transform"
+        className="flex items-center gap-3 mt-4 p-3 rounded-xl bg-gradient-to-r from-accent/10 to-purple-500/10 border border-accent/20 active:scale-[0.98] hover:bg-gradient-to-r"
       >
         <div className="w-10 h-10 rounded-lg bg-accent/20 flex items-center justify-center shrink-0">
           <SvgIcon path={ICON_PATHS.grid} className="w-5 h-5 text-accent" />
@@ -305,12 +308,17 @@ export function MobileLayoutsPanel() {
           </div>
         </div>
         <SvgIcon path={ICON_PATHS.chevronRight} className="w-4 h-4 text-content-tertiary" />
-      </button>
+      </Button>
 
-      <button onClick={handleCreateNew} className="btn btn-secondary w-full mt-3 h-12">
-        <SvgIcon path={ICON_PATHS.plus} className="w-5 h-5 mr-2" />
+      <Button
+        variant="secondary"
+        fullWidth
+        onClick={handleCreateNew}
+        className="mt-3 h-12"
+        leftIcon={<SvgIcon path={ICON_PATHS.plus} className="w-5 h-5" />}
+      >
         {t('layouts.newLayout')}
-      </button>
+      </Button>
 
       <ConfirmDialog
         isOpen={deleteLayoutId !== null}
@@ -351,12 +359,14 @@ export function MobileLayoutsPanel() {
               description={t('share.file.saveAsFile')}
             />
           </div>
-          <button
+          <Button
+            variant="ghost"
+            fullWidth
             onClick={() => setShareMenuId(null)}
-            className="w-full mt-4 py-3 text-content-secondary font-medium"
+            className="mt-4 py-3 text-content-secondary hover:bg-transparent"
           >
             {t('common.cancel')}
-          </button>
+          </Button>
         </ActionSheet>
       )}
 
@@ -384,19 +394,23 @@ export function MobileLayoutsPanel() {
             autoFocus
           />
           <div className="flex gap-2 mt-4">
-            <button
+            <Button
+              variant="secondary"
+              fullWidth
               onClick={dismissRename}
-              className="flex-1 py-3 text-content-secondary font-medium bg-surface rounded-lg"
+              className="flex-1 py-3 text-content-secondary bg-surface rounded-lg"
             >
               {t('common.cancel')}
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="primary"
+              fullWidth
               onClick={handleRenameConfirm}
               disabled={!renameValue.trim()}
-              className="flex-1 py-3 text-on-dark font-medium bg-accent rounded-lg disabled:opacity-50"
+              className="flex-1 py-3 text-on-dark bg-accent rounded-lg disabled:opacity-50"
             >
               {t('common.rename')}
-            </button>
+            </Button>
           </div>
         </ActionSheet>
       )}

--- a/src/shell/Mobile/MobilePrintList/MobilePrintList.tsx
+++ b/src/shell/Mobile/MobilePrintList/MobilePrintList.tsx
@@ -5,6 +5,7 @@ import { usePrintList } from '@/features/print-export/hooks/usePrintList';
 import { useLayoutStore } from '@/core/store';
 import { PrintListSummary, PrintListEmpty } from '@/features/print-export/components';
 import { SplitPreview } from '@/shell/Print/SplitPreview';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 const OVERFLOW_PREFIX = '+';
@@ -48,7 +49,7 @@ export function MobilePrintList() {
         </span>
         <div className="flex items-center gap-2">
           {/* Copy button */}
-          <button onClick={handleCopy} className="btn btn-ghost btn-sm gap-1.5">
+          <Button variant="ghost" size="sm" onClick={handleCopy} className="gap-1.5">
             {copyFeedback ? (
               <>
                 <svg
@@ -79,7 +80,7 @@ export function MobilePrintList() {
                 {t('common.copy')}
               </>
             )}
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
+++ b/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
@@ -16,6 +16,7 @@ import { SettingsRow } from '@/shared/components/SettingsRow';
 import { LoadingFallback } from '@/shared/components/LoadingFallback';
 import { lazyWithRetry, namedExport } from '@/shared/utils/lazyWithRetry';
 import { useTranslation } from '@/i18n';
+import { Button } from '@/design-system';
 import { UserDock } from '@/shared/components/UserDock';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import type { SettingsTabId } from '@/shell/Modals/SettingsModal/types';
@@ -232,17 +233,19 @@ export function MobileSettingsPanel() {
             </p>
           </div>
 
-          <button
+          <Button
             type="button"
+            variant="secondary"
+            fullWidth
             onClick={resetGridfinityStandard}
             disabled={
               gridUnitMm === CONSTRAINTS.GRID_UNIT_MM_DEFAULT &&
               heightUnitMm === CONSTRAINTS.HEIGHT_UNIT_MM_DEFAULT
             }
-            className="w-full text-sm py-2 px-3 rounded-lg text-content-secondary hover:text-content hover:bg-surface-hover border border-stroke-subtle transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-content-secondary disabled:hover:bg-transparent"
+            className="text-sm py-2 px-3 rounded-lg text-content-secondary hover:text-content hover:bg-surface-hover border border-stroke-subtle disabled:cursor-not-allowed disabled:hover:text-content-secondary disabled:hover:bg-transparent"
           >
             {t('settings.resetGridfinityStandard')}
-          </button>
+          </Button>
 
           <div className="text-sm text-right text-content-disabled">
             {t('mobile.settings.maxBinSize')}
@@ -253,9 +256,11 @@ export function MobileSettingsPanel() {
 
       {/* App Settings Link */}
       <section>
-        <button
+        <Button
+          variant="ghost"
+          fullWidth
           onClick={() => openSettingsModal()}
-          className="w-full flex items-center justify-between px-4 py-3 bg-surface-elevated rounded-lg hover:bg-surface-hover transition-colors"
+          className="flex items-center justify-between px-4 py-3 bg-surface-elevated rounded-lg hover:bg-surface-hover"
         >
           <div className="flex items-center gap-3">
             <svg
@@ -291,7 +296,7 @@ export function MobileSettingsPanel() {
           >
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
           </svg>
-        </button>
+        </Button>
       </section>
 
       {/* Info */}

--- a/src/shell/Mobile/MultiBinContextMenu/MultiBinContextMenu.tsx
+++ b/src/shell/Mobile/MultiBinContextMenu/MultiBinContextMenu.tsx
@@ -13,6 +13,7 @@ import { splitBinsByLocation } from '@/shared/utils';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
 import { findBinsByIds } from '@/shared/utils/entity';
 import type { BinId, CategoryId, GridUnits, LayerId } from '@/core/types';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 interface MultiBinContextMenuProps {
@@ -143,9 +144,11 @@ export function MultiBinContextMenu({
       <div className="py-1">
         {/* Change Category */}
         <div>
-          <button
+          <Button
+            variant="ghost"
+            fullWidth
             onClick={() => setShowCategoryPicker(!showCategoryPicker)}
-            className="w-full px-4 py-3 flex items-center justify-between transition-colors text-content hover:bg-surface-hover"
+            className="px-4 py-3 flex items-center justify-between rounded-none text-content hover:bg-surface-hover"
           >
             <div className="flex items-center gap-3">
               <svg
@@ -176,18 +179,20 @@ export function MultiBinContextMenu({
                 d="M19 9l-7 7-7-7"
               />
             </svg>
-          </button>
+          </Button>
           {showCategoryPicker && (
             <div className="px-2 py-1 bg-surface-secondary">
               {layout.categories.map((category) => (
-                <button
+                <Button
                   key={category.id}
+                  variant="ghost"
+                  fullWidth
                   onClick={() => handleChangeCategory(category.id)}
-                  className="w-full px-3 py-2 flex items-center gap-2 rounded transition-colors hover:bg-surface-hover"
+                  className="px-3 py-2 flex items-center justify-start gap-2 rounded hover:bg-surface-hover"
                 >
                   <div className="w-4 h-4 rounded-sm" style={{ backgroundColor: category.color }} />
                   <span className="text-sm text-content">{category.name}</span>
-                </button>
+                </Button>
               ))}
             </div>
           )}
@@ -196,9 +201,11 @@ export function MultiBinContextMenu({
         {/* Move All to Layer */}
         {canMoveToLayer && (
           <div>
-            <button
+            <Button
+              variant="ghost"
+              fullWidth
               onClick={() => setShowLayerPicker(!showLayerPicker)}
-              className="w-full px-4 py-3 flex items-center justify-between transition-colors text-content hover:bg-surface-hover"
+              className="px-4 py-3 flex items-center justify-between rounded-none text-content hover:bg-surface-hover"
             >
               <div className="flex items-center gap-3">
                 <svg
@@ -229,20 +236,22 @@ export function MultiBinContextMenu({
                   d="M19 9l-7 7-7-7"
                 />
               </svg>
-            </button>
+            </Button>
             {showLayerPicker && (
               <div className="px-2 py-1 bg-surface-secondary">
                 {layout.layers.map((layer) => (
-                  <button
+                  <Button
                     key={layer.id}
+                    variant="ghost"
+                    fullWidth
                     onClick={() => handleMoveToLayer(layer.id)}
-                    className="w-full px-3 py-2 text-left rounded transition-colors hover:bg-surface-hover"
+                    className="px-3 py-2 flex-col items-start text-left rounded hover:bg-surface-hover"
                   >
                     <div className="text-sm text-content">{layer.name}</div>
                     <div className="text-xs text-content-tertiary">
                       {t('mobile.contextMenu.minHeight', { height: layer.height })}
                     </div>
-                  </button>
+                  </Button>
                 ))}
               </div>
             )}

--- a/src/shell/Modals/HelpModal/HelpModal.tsx
+++ b/src/shell/Modals/HelpModal/HelpModal.tsx
@@ -9,6 +9,7 @@
 
 import { useEffect, useState, useMemo } from 'react';
 import { useTranslation } from '@/i18n';
+import { Button, IconButton, XIcon } from '@/design-system';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import { STYLES, getModifierKey } from './helpModalStyles';
 import { SHORTCUT_CATEGORIES } from './helpModalShortcutData';
@@ -109,50 +110,37 @@ export function HelpModal({ isOpen, onClose, isTablet = false }: HelpModalProps)
             <h2 id="help-title" style={STYLES.title}>
               {t('help.title')}
             </h2>
-            <button
-              onClick={onClose}
-              className="btn btn-ghost btn-icon"
-              style={STYLES.buttonCompact}
-              aria-label={t('common.close')}
-            >
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                {ICON_PATHS.close.map((d) => (
-                  <path
-                    key={d}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d={d}
-                  />
-                ))}
-              </svg>
-            </button>
+            <IconButton onClick={onClose} touchTarget={false} aria-label={t('common.close')}>
+              <XIcon size="md" />
+            </IconButton>
           </div>
 
           {/* Tab bar and search */}
           <div className="px-6 py-3 border-b border-stroke-subtle flex items-center gap-4">
             {!isSearching && (
               <div className="flex gap-1">
-                <button
+                <Button
+                  variant="ghost"
                   onClick={() => setActiveTab('shortcuts')}
-                  className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent ${
+                  className={`px-3 py-1.5 text-sm font-medium ${
                     activeTab === 'shortcuts'
-                      ? 'bg-accent/20 text-accent'
+                      ? 'bg-accent/20 text-accent hover:bg-accent/20 hover:text-accent'
                       : 'text-content-secondary hover:text-content hover:bg-surface-hover'
                   }`}
                 >
                   {t('help.shortcuts')}
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant="ghost"
                   onClick={() => setActiveTab('tips')}
-                  className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent ${
+                  className={`px-3 py-1.5 text-sm font-medium ${
                     activeTab === 'tips'
-                      ? 'bg-accent/20 text-accent'
+                      ? 'bg-accent/20 text-accent hover:bg-accent/20 hover:text-accent'
                       : 'text-content-secondary hover:text-content hover:bg-surface-hover'
                   }`}
                 >
                   {t('help.tipsInfo')}
-                </button>
+                </Button>
               </div>
             )}
 
@@ -182,23 +170,15 @@ export function HelpModal({ isOpen, onClose, isTablet = false }: HelpModalProps)
                   className="w-full pl-9 pr-3 py-1.5 text-sm rounded-md bg-surface border border-stroke-subtle text-content placeholder:text-content-tertiary"
                 />
                 {searchQuery && (
-                  <button
+                  <IconButton
                     onClick={() => setSearchQuery('')}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded text-content-tertiary hover:text-content focus-visible:ring-2 focus-visible:ring-accent"
+                    size="sm"
+                    touchTarget={false}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-content-tertiary hover:text-content"
                     aria-label={t('layouts.clearSearch')}
                   >
-                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      {ICON_PATHS.close.map((d) => (
-                        <path
-                          key={d}
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d={d}
-                        />
-                      ))}
-                    </svg>
-                  </button>
+                    <XIcon size="sm" />
+                  </IconButton>
                 )}
               </div>
             </div>
@@ -303,9 +283,9 @@ function SearchResultsList({
     return (
       <div className="text-center py-10 px-4 space-y-4">
         <p className="text-content-tertiary text-sm">{t('help.noResultsFor', { query })}</p>
-        <button type="button" onClick={openCommandPalette} className="btn btn-secondary btn-sm">
+        <Button type="button" variant="secondary" size="sm" onClick={openCommandPalette}>
           {t('help.openCommandPaletteWithQuery')}
-        </button>
+        </Button>
       </div>
     );
   }

--- a/src/shell/Modals/ImportModal/ImportModal.tsx
+++ b/src/shell/Modals/ImportModal/ImportModal.tsx
@@ -3,6 +3,7 @@ import type { ChangeEvent } from 'react';
 import { validateImport } from '@/shared/utils/validation';
 import { decodeLayoutFromURL } from '@/core/storage';
 import type { Layout } from '@/core/types';
+import { Button, IconButton, XIcon } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 interface ImportModalProps {
@@ -152,23 +153,14 @@ function ImportModalContent({ onClose, onImport }: Omit<ImportModalProps, 'isOpe
             <h2 id="import-modal-title" className="text-2xl font-bold text-content">
               {t('layouts.import.title')}
             </h2>
-            <button
+            <IconButton
               onClick={onClose}
-              className="p-2 -m-2 rounded-md text-content-tertiary hover:text-content hover:bg-surface-hover transition-colors"
+              touchTarget={false}
+              className="-m-2 text-content-tertiary hover:text-content"
               aria-label={t('layouts.import.closeImportDialog')}
             >
-              <svg
-                className="w-5 h-5"
-                fill="none"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path d="M6 18L18 6M6 6l12 12"></path>
-              </svg>
-            </button>
+              <XIcon size="md" />
+            </IconButton>
           </div>
 
           <div className="flex-1 flex flex-col gap-4 overflow-hidden">
@@ -182,12 +174,9 @@ function ImportModalContent({ onClose, onImport }: Omit<ImportModalProps, 'isOpe
                 className="hidden"
                 aria-label={t('layouts.import.selectJsonFileToImport')}
               />
-              <button
-                onClick={() => fileInputRef.current?.click()}
-                className="px-4 py-2 bg-surface-hover hover:bg-surface-active text-content rounded transition-colors"
-              >
+              <Button variant="secondary" onClick={() => fileInputRef.current?.click()}>
                 {t('layouts.import.browseFiles')}
-              </button>
+              </Button>
             </div>
 
             {/* Textarea */}
@@ -240,16 +229,16 @@ function ImportModalContent({ onClose, onImport }: Omit<ImportModalProps, 'isOpe
 
           {/* Action Buttons */}
           <div className="flex gap-3 mt-6">
-            <button
+            <Button
+              variant="primary"
               onClick={handleImport}
               disabled={!!errors.length || !jsonText.trim()}
-              className="btn btn-primary"
             >
               {t('common.import')}
-            </button>
-            <button onClick={onClose} className="btn btn-secondary">
+            </Button>
+            <Button variant="secondary" onClick={onClose}>
               {t('common.cancel')}
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/src/shell/Modals/SettingsModal/SettingsModal.tsx
+++ b/src/shell/Modals/SettingsModal/SettingsModal.tsx
@@ -16,7 +16,7 @@ import { IntegrationsTab } from './tabs/IntegrationsTab/IntegrationsTab';
 import { PrivacyTab } from './tabs/PrivacyTab/PrivacyTab';
 import { StorageTab } from './tabs/StorageTab/StorageTab';
 import { LabsTab } from './tabs/LabsTab/LabsTab';
-import { ICON_PATHS } from '@/shared/constants/iconPaths';
+import { Button, IconButton, XIcon } from '@/design-system';
 import type { SettingsModalProps, SettingsTabId } from './types';
 
 const STYLES = {
@@ -123,25 +123,14 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
             <h2 id="settings-title" style={STYLES.title}>
               {t('settings.title')}
             </h2>
-            <button
+            <IconButton
               ref={closeButtonRef}
               onClick={onClose}
-              className="btn btn-ghost btn-icon"
-              style={{ minWidth: 'auto', minHeight: 'auto' }}
+              touchTarget={false}
               aria-label={t('common.close')}
             >
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                {ICON_PATHS.close.map((d) => (
-                  <path
-                    key={d}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d={d}
-                  />
-                ))}
-              </svg>
-            </button>
+              <XIcon size="md" />
+            </IconButton>
           </div>
 
           {/* Tab layout */}
@@ -162,22 +151,24 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
           {/* Footer */}
           <div className="flex items-center justify-between px-6 py-3 border-t border-stroke-subtle text-xs">
             <div className="text-content-tertiary space-x-3">
-              <button
+              <Button
+                variant="ghost"
                 onClick={() => setShowResetConfirm(true)}
-                className="hover:text-content transition-colors"
+                className="h-auto p-0 text-xs font-normal hover:bg-transparent hover:text-content"
               >
                 {t('settings.resetTabDefaults')}
-              </button>
+              </Button>
               <span className="text-content-disabled">·</span>
-              <button
+              <Button
+                variant="ghost"
                 onClick={() => {
                   resetOnboarding();
                   addToast(t('toast.onboardingReset'), 'info');
                 }}
-                className="hover:text-content transition-colors"
+                className="h-auto p-0 text-xs font-normal hover:bg-transparent hover:text-content"
               >
                 {t('settings.resetOnboarding')}
-              </button>
+              </Button>
             </div>
             <div className="text-content-disabled space-x-3">
               <a

--- a/src/shell/Modals/SettingsModal/TabNavigation/TabNavigation.tsx
+++ b/src/shell/Modals/SettingsModal/TabNavigation/TabNavigation.tsx
@@ -1,4 +1,5 @@
 import { useRef, useCallback } from 'react';
+import { Button } from '@/design-system';
 import { useResponsive } from '@/shared/hooks';
 import { useTranslation } from '@/i18n';
 import { TAB_DEFINITIONS } from '../tabDefinitions';
@@ -55,23 +56,24 @@ export function TabNavigation({ activeTab, onTabChange }: TabNavigationProps) {
           const Icon = tab.icon;
           const isActive = activeTab === tab.id;
           return (
-            <button
+            <Button
               key={tab.id}
+              variant="ghost"
               tabIndex={isActive ? 0 : -1}
               role="tab"
               aria-selected={isActive}
               aria-controls={`settings-tabpanel-${tab.id}`}
               id={`settings-tab-${tab.id}`}
               onClick={() => onTabChange(tab.id)}
-              className={`flex items-center gap-1.5 px-3 py-2.5 text-sm whitespace-nowrap transition-colors flex-shrink-0 ${
+              className={`gap-1.5 rounded-none px-3 py-2.5 text-sm whitespace-nowrap flex-shrink-0 ${
                 isActive
-                  ? 'text-accent border-b-2 border-accent font-medium'
-                  : 'text-content-tertiary hover:text-content-secondary'
+                  ? 'text-accent border-b-2 border-accent font-medium hover:bg-transparent hover:text-accent'
+                  : 'text-content-tertiary hover:bg-transparent hover:text-content-secondary'
               }`}
             >
               <Icon className="w-5 h-5" />
               <span>{t(tab.labelKey)}</span>
-            </button>
+            </Button>
           );
         })}
       </div>
@@ -92,23 +94,25 @@ export function TabNavigation({ activeTab, onTabChange }: TabNavigationProps) {
         const Icon = tab.icon;
         const isActive = activeTab === tab.id;
         return (
-          <button
+          <Button
             key={tab.id}
+            variant="ghost"
+            fullWidth
             tabIndex={isActive ? 0 : -1}
             role="tab"
             aria-selected={isActive}
             aria-controls={`settings-tabpanel-${tab.id}`}
             id={`settings-tab-${tab.id}`}
             onClick={() => onTabChange(tab.id)}
-            className={`w-full flex items-center gap-2 px-4 py-2 text-sm text-left transition-colors ${
+            className={`justify-start gap-2 rounded-none px-4 py-2 text-sm font-normal ${
               isActive
-                ? 'bg-surface-elevated text-content font-medium border-l-2 border-accent'
+                ? 'bg-surface-elevated text-content font-medium border-l-2 border-accent hover:bg-surface-elevated hover:text-content'
                 : 'text-content-tertiary hover:text-content-secondary hover:bg-surface-hover'
             }`}
           >
             <Icon className="w-5 h-5 flex-shrink-0" />
             <span>{t(tab.labelKey)}</span>
-          </button>
+          </Button>
         );
       })}
     </div>

--- a/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
@@ -12,6 +12,7 @@ import { SettingsRow } from '@/shared/components/SettingsRow';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { useDrawerSettings } from '@/shared/hooks/useDrawerSettings';
 import { useBinDefaults } from '@/features/bin-designer';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 export function DefaultsTab() {
@@ -209,12 +210,14 @@ export function DefaultsTab() {
         </div>
 
         {/* Copy from current layout */}
-        <button
+        <Button
+          variant="ghost"
+          fullWidth
           onClick={() => setShowCopyConfirm(true)}
-          className="w-full mt-4 text-sm py-2 px-3 rounded-lg bg-surface-elevated hover:bg-surface-hover text-content-secondary hover:text-content border border-stroke-subtle transition-colors"
+          className="mt-4 text-sm py-2 px-3 rounded-lg bg-surface-elevated hover:bg-surface-hover text-content-secondary hover:text-content border border-stroke-subtle"
         >
           {t('settings.copyFromCurrentLayout')}
-        </button>
+        </Button>
       </section>
 
       {/* Divider */}
@@ -346,19 +349,21 @@ export function DefaultsTab() {
           </div>
         </div>
         <div className="flex gap-2">
-          <button
+          <Button
+            variant="ghost"
             onClick={() => setShowSaveCategoriesConfirm(true)}
-            className="flex-1 text-sm py-2 px-3 rounded-lg bg-surface-elevated hover:bg-surface-hover text-content-secondary hover:text-content border border-stroke-subtle transition-colors"
+            className="flex-1 text-sm py-2 px-3 rounded-lg bg-surface-elevated hover:bg-surface-hover text-content-secondary hover:text-content border border-stroke-subtle"
           >
             {t('settings.saveCategoriesAsDefaults')}
-          </button>
+          </Button>
           {hasCustomCategoryDefaults && (
-            <button
+            <Button
+              variant="ghost"
               onClick={() => updateSetting('defaultCategories', null)}
-              className="text-sm py-2 px-3 rounded-lg text-content-tertiary hover:text-content hover:bg-surface-hover border border-stroke-subtle transition-colors"
+              className="text-sm py-2 px-3 rounded-lg text-content-tertiary hover:text-content hover:bg-surface-hover border border-stroke-subtle"
             >
               {t('settings.resetToBuiltIn')}
-            </button>
+            </Button>
           )}
         </div>
       </section>
@@ -385,12 +390,13 @@ export function DefaultsTab() {
           </div>
         </div>
         {hasCustomBinDefault && (
-          <button
+          <Button
+            variant="ghost"
             onClick={resetBinDefault}
-            className="text-sm py-2 px-3 rounded-lg text-content-tertiary hover:text-content hover:bg-surface-hover border border-stroke-subtle transition-colors"
+            className="text-sm py-2 px-3 rounded-lg text-content-tertiary hover:text-content hover:bg-surface-hover border border-stroke-subtle"
           >
             {t('binDesigner.resetFactoryDefaults')}
-          </button>
+          </Button>
         )}
       </section>
 

--- a/src/shell/Modals/WelcomeModal/WelcomeModal.tsx
+++ b/src/shell/Modals/WelcomeModal/WelcomeModal.tsx
@@ -7,6 +7,7 @@ import { isOk } from '@/core/result';
 import { layoutId } from '@/core/types';
 import { trackEvent } from '@/shared/analytics/posthog';
 import { useResponsive } from '@/shared/hooks';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { INSPIRATION_LAYOUTS } from '@/features/inspiration-gallery/data';
 import { LayoutThumbnailWithLabels } from '@/features/inspiration-gallery/components/LayoutThumbnailWithLabels';
@@ -200,15 +201,16 @@ function WelcomeModalContent({ onClose }: { onClose: (method: 'template' | 'blan
             <p className="text-sm text-content-secondary mb-8 max-w-xs">
               {t('onboarding.welcome.desktopNudge')}
             </p>
-            <button
+            <Button
+              variant="primary"
               onClick={() => onClose('blank')}
-              className="btn btn-primary px-8 py-2.5 text-sm font-semibold rounded-lg"
+              className="px-8 py-2.5 text-sm font-semibold rounded-lg"
               disabled={isImporting}
               // eslint-disable-next-line jsx-a11y/no-autofocus -- Intentional autofocus for modal/dialog UX
               autoFocus
             >
               {t('onboarding.welcome.startDesigning')}
-            </button>
+            </Button>
           </div>
         ) : (
           /* Desktop — hero + template showcase (unchanged) */
@@ -221,15 +223,16 @@ function WelcomeModalContent({ onClose }: { onClose: (method: 'template' | 'blan
               <p className="text-sm text-content-secondary mb-6">
                 {t('onboarding.welcome.subtitle')}
               </p>
-              <button
+              <Button
+                variant="primary"
                 onClick={() => onClose('blank')}
-                className="btn btn-primary px-8 py-2.5 text-sm font-semibold rounded-lg"
+                className="px-8 py-2.5 text-sm font-semibold rounded-lg"
                 disabled={isImporting}
                 // eslint-disable-next-line jsx-a11y/no-autofocus -- Intentional autofocus for modal/dialog UX
                 autoFocus
               >
                 {t('onboarding.welcome.startBlank')}
-              </button>
+              </Button>
             </div>
 
             {/* Showcase — "here's what people build" */}

--- a/src/shell/PanelErrorBoundary/PanelErrorBoundary.tsx
+++ b/src/shell/PanelErrorBoundary/PanelErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 import type { ReactNode } from 'react';
+import { Button } from '@/design-system';
 import { captureException, track3DRenderError } from '@/shared/analytics/posthog';
 
 // Error boundary strings as constants (class components cannot use hooks)
@@ -84,12 +85,9 @@ export class PanelErrorBoundary extends Component<Props, State> {
               {this.state.error.message}
             </p>
           )}
-          <button
-            onClick={this.handleRetry}
-            className="px-3 py-1.5 text-xs font-medium bg-surface-secondary hover:bg-surface-elevated rounded transition-colors"
-          >
+          <Button variant="secondary" size="sm" onClick={this.handleRetry}>
             {RETRY_LABEL}
-          </button>
+          </Button>
         </div>
       );
     }

--- a/src/shell/RightPanel/RightPanel.test.tsx
+++ b/src/shell/RightPanel/RightPanel.test.tsx
@@ -780,7 +780,7 @@ describe('RightPanel', () => {
       const { container } = render(<RightPanel />);
 
       // Shadow class is on the header wrapper (parent of the tab bar)
-      const headerWrapper = container.querySelector('[class*="flex flex-col border-b"]');
+      const headerWrapper = container.querySelector('[class*="flex flex-col"][class*="border-b"]');
       expect(headerWrapper).not.toHaveClass('shadow-elevated');
     });
 
@@ -794,7 +794,7 @@ describe('RightPanel', () => {
       }
 
       // Shadow class is on the header wrapper (parent of the tab bar)
-      const headerWrapper = container.querySelector('[class*="flex flex-col border-b"]');
+      const headerWrapper = container.querySelector('[class*="flex flex-col"][class*="border-b"]');
       expect(headerWrapper?.className).toContain('shadow');
     });
   });

--- a/src/shell/RightPanel/RightPanel.tsx
+++ b/src/shell/RightPanel/RightPanel.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_CATEGORY_COLOR } from '@/core/constants';
 import { PRINT_SETTINGS_CONSTRAINTS } from '@/shared/printSettings';
 import { exportPrintListTSV } from '@/core/storage';
 import { trackEvent } from '@/shared/analytics/posthog';
+import { Button, IconButton } from '@/design-system';
 import { ConfirmDialog, CollapsibleSection } from '@/shared/components';
 import { SettingsRow } from '@/shared/components/SettingsRow';
 import { DeferredNumberInput } from '@/shared/components/DeferredNumberInput';
@@ -83,9 +84,9 @@ export function RightPanel() {
         style={{ width: '48px' }}
       >
         <div className="flex flex-col items-center py-2">
-          <button
+          <IconButton
+            size="sm"
             onClick={toggle}
-            className="btn btn-ghost btn-icon"
             title={t('rightPanel.expandPanel')}
             aria-label={t('rightPanel.expandRightPanel')}
           >
@@ -94,16 +95,17 @@ export function RightPanel() {
                 <path key={d} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
               ))}
             </svg>
-          </button>
+          </IconButton>
         </div>
       </aside>
     );
   }
 
   const collapseButton = (
-    <button
+    <IconButton
+      size="sm"
       onClick={toggle}
-      className="flex-shrink-0 p-2 rounded-md transition-colors text-content-tertiary hover:bg-surface-hover hover:text-content"
+      className="flex-shrink-0 text-content-tertiary"
       title={t('rightPanel.collapsePanel')}
       aria-label={t('rightPanel.collapseRightPanel')}
     >
@@ -112,7 +114,7 @@ export function RightPanel() {
           <path key={d} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
         ))}
       </svg>
-    </button>
+    </IconButton>
   );
 
   return (
@@ -130,12 +132,14 @@ export function RightPanel() {
         <div className="flex items-center gap-3 px-4 py-2">
           {collapseButton}
           <div className="flex gap-1" role="tablist">
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               id="tab-inspector"
               role="tab"
               aria-selected={activeTab === 'inspector'}
               aria-controls="tabpanel-inspector"
-              className={`text-xs font-semibold uppercase tracking-wider px-2 py-1 rounded transition-colors ${
+              className={`font-semibold uppercase tracking-wider rounded hover:bg-transparent ${
                 activeTab === 'inspector'
                   ? 'text-accent bg-accent-muted'
                   : 'text-content-tertiary hover:text-content-secondary'
@@ -143,13 +147,15 @@ export function RightPanel() {
               onClick={() => setActiveTab('inspector')}
             >
               {t('rightPanel.inspector')}
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
               id="tab-history"
               role="tab"
               aria-selected={activeTab === 'history'}
               aria-controls="tabpanel-history"
-              className={`text-xs font-semibold uppercase tracking-wider px-2 py-1 rounded transition-colors ${
+              className={`font-semibold uppercase tracking-wider rounded hover:bg-transparent ${
                 activeTab === 'history'
                   ? 'text-accent bg-accent-muted'
                   : 'text-content-tertiary hover:text-content-secondary'
@@ -157,7 +163,7 @@ export function RightPanel() {
               onClick={() => setActiveTab('history')}
             >
               {t('rightPanel.historyTab')}
-            </button>
+            </Button>
           </div>
         </div>
       </div>
@@ -219,8 +225,9 @@ export function RightPanel() {
               <div
                 className={`flex items-center justify-between px-4 py-3 ${printListExpanded ? 'border-b border-stroke-subtle' : ''}`}
               >
-                <button
-                  className="flex items-center gap-2 transition-colors bg-transparent"
+                <Button
+                  variant="ghost"
+                  className="gap-2 px-0 py-0 bg-transparent hover:bg-transparent"
                   onClick={() => setPrintListExpanded(!printListExpanded)}
                   aria-expanded={printListExpanded}
                 >
@@ -241,11 +248,12 @@ export function RightPanel() {
                   {printList.rows.length > 0 && (
                     <span className="badge badge-info">{printList.totalBins}</span>
                   )}
-                </button>
+                </Button>
                 {printList.rows.length > 0 && (
                   <div className="flex items-center gap-1">
                     {/* Copy button */}
-                    <button
+                    <IconButton
+                      size="sm"
                       onClick={(e) => {
                         e.stopPropagation();
                         const tsv = exportPrintListTSV(printList.rows, {
@@ -257,7 +265,6 @@ export function RightPanel() {
                         trackEvent('ui.layoutExported', { format: 'tsv' });
                         setTimeout(() => setCopyFeedback(false), 2000);
                       }}
-                      className="btn btn-ghost p-1.5 min-w-0 min-h-0"
                       title={t('rightPanel.copyTSV')}
                       aria-label={t('rightPanel.copyBinListAsTsv')}
                     >
@@ -296,7 +303,7 @@ export function RightPanel() {
                           ))}
                         </svg>
                       )}
-                    </button>
+                    </IconButton>
                   </div>
                 )}
               </div>

--- a/src/shell/RightPanel/RightPanel.tsx
+++ b/src/shell/RightPanel/RightPanel.tsx
@@ -107,7 +107,7 @@ export function RightPanel() {
       size="sm"
       touchTarget={false}
       onClick={toggle}
-      className="flex-shrink-0 text-content-tertiary"
+      className="flex-shrink-0 h-8 w-8 text-content-tertiary"
       title={t('rightPanel.collapsePanel')}
       aria-label={t('rightPanel.collapseRightPanel')}
     >
@@ -131,7 +131,7 @@ export function RightPanel() {
           isScrolled ? 'shadow-elevated' : ''
         }`}
       >
-        <div className="flex items-center gap-3 px-4 py-2">
+        <div className="flex items-center gap-3 px-4 py-[7.5px]">
           {collapseButton}
           <div className="flex gap-1" role="tablist">
             <Button

--- a/src/shell/RightPanel/RightPanel.tsx
+++ b/src/shell/RightPanel/RightPanel.tsx
@@ -127,11 +127,11 @@ export function RightPanel() {
     >
       {/* Header with tabs */}
       <div
-        className={`flex flex-col border-b border-stroke-subtle transition-shadow duration-200 ${
+        className={`flex flex-col h-[47px] border-b border-stroke-subtle transition-shadow duration-200 ${
           isScrolled ? 'shadow-elevated' : ''
         }`}
       >
-        <div className="flex items-center gap-3 px-4 py-[7.5px]">
+        <div className="flex items-center gap-3 px-4 h-full">
           {collapseButton}
           <div className="flex gap-1" role="tablist">
             <Button

--- a/src/shell/RightPanel/RightPanel.tsx
+++ b/src/shell/RightPanel/RightPanel.tsx
@@ -86,6 +86,7 @@ export function RightPanel() {
         <div className="flex flex-col items-center py-2">
           <IconButton
             size="sm"
+            touchTarget={false}
             onClick={toggle}
             title={t('rightPanel.expandPanel')}
             aria-label={t('rightPanel.expandRightPanel')}
@@ -104,6 +105,7 @@ export function RightPanel() {
   const collapseButton = (
     <IconButton
       size="sm"
+      touchTarget={false}
       onClick={toggle}
       className="flex-shrink-0 text-content-tertiary"
       title={t('rightPanel.collapsePanel')}
@@ -254,6 +256,7 @@ export function RightPanel() {
                     {/* Copy button */}
                     <IconButton
                       size="sm"
+                      touchTarget={false}
                       onClick={(e) => {
                         e.stopPropagation();
                         const tsv = exportPrintListTSV(printList.rows, {

--- a/src/shell/STLSearchDropdown/STLSearchDropdown.tsx
+++ b/src/shell/STLSearchDropdown/STLSearchDropdown.tsx
@@ -4,6 +4,7 @@ import { useSettingsStore } from '@/core/store';
 import { useContextMenu } from '@/shared/hooks/useContextMenu';
 import { useTranslation } from '@/i18n';
 import { ContextMenuContainer, ContextMenuItem } from '@/shared/components/ContextMenu';
+import { Button, IconButton } from '@/design-system';
 import { openSTLSearch, formatDimension } from '@/shared/utils/stlSearch';
 import type { STLSearchSite } from '@/core/store/settings';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
@@ -145,47 +146,54 @@ export function STLSearchDropdown({
     <>
       {/* Trigger button */}
       {variant === 'button' && (
-        <button
+        <Button
           ref={triggerRef}
+          variant="ghost"
+          size="sm"
           type="button"
           onClick={handleClick}
-          className={`btn btn-ghost gap-1.5 text-content-secondary hover:text-content ${className}`}
+          className={`gap-1.5 text-content-secondary ${className}`}
           aria-label={t('stlSearch.searchFor', {
             width: formatDimension(width),
             depth: formatDimension(depth),
           })}
           aria-expanded={isSingleSite ? undefined : isOpen}
           aria-haspopup={isSingleSite ? undefined : 'menu'}
+          leftIcon={<SearchIcon className="w-4 h-4" />}
+          rightIcon={
+            !isSingleSite ? <ChevronIcon className="w-3 h-3" isOpen={isOpen} /> : undefined
+          }
         >
-          <SearchIcon className="w-4 h-4" />
           {isSingleSite
             ? t('stlSearch.findOnSite', { site: enabledSites[0].name })
             : t('stlSearch.findSTL')}
-          {!isSingleSite && <ChevronIcon className="w-3 h-3" isOpen={isOpen} />}
-        </button>
+        </Button>
       )}
 
       {variant === 'icon' && (
-        <button
+        <IconButton
           ref={triggerRef}
+          size="sm"
           type="button"
           onClick={handleClick}
-          className={`btn btn-ghost p-1.5 text-content-tertiary hover:text-content ${className}`}
+          className={`text-content-tertiary ${className}`}
           aria-label={iconTooltip}
           aria-expanded={isSingleSite ? undefined : isOpen}
           aria-haspopup={isSingleSite ? undefined : 'menu'}
           title={iconTooltip}
         >
           <SearchIcon className="w-4 h-4" />
-        </button>
+        </IconButton>
       )}
 
       {variant === 'menu-item' && (
-        <button
+        <Button
           ref={triggerRef}
+          variant="ghost"
+          fullWidth
           type="button"
           onClick={handleClick}
-          className={`w-full px-4 py-3 flex items-center gap-3 text-content hover:bg-surface-hover ${className}`}
+          className={`justify-start px-4 py-3 gap-3 rounded-none text-content hover:bg-surface-hover ${className}`}
           aria-label={t('stlSearch.searchFor', {
             width: formatDimension(width),
             depth: formatDimension(depth),
@@ -202,7 +210,7 @@ export function STLSearchDropdown({
           {!isSingleSite && (
             <ChevronRightIcon className="w-4 h-4 text-content-tertiary flex-shrink-0" />
           )}
-        </button>
+        </Button>
       )}
 
       {/* Dropdown menu - portaled to escape BottomSheet transforms on mobile */}

--- a/src/shell/STLSearchDropdown/STLSearchDropdown.tsx
+++ b/src/shell/STLSearchDropdown/STLSearchDropdown.tsx
@@ -174,6 +174,7 @@ export function STLSearchDropdown({
         <IconButton
           ref={triggerRef}
           size="sm"
+          touchTarget={false}
           type="button"
           onClick={handleClick}
           className={`text-content-tertiary ${className}`}

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -181,7 +181,7 @@ export function Sidebar() {
         // Expanded state
         <div className="flex flex-col h-full animate-fade-in">
           <div
-            className={`flex items-center gap-3 px-4 py-2 border-b border-stroke-subtle transition-shadow duration-200 ${
+            className={`flex items-center gap-3 px-4 py-[7.5px] border-b border-stroke-subtle transition-shadow duration-200 ${
               isScrolled ? 'shadow-elevated' : ''
             }`}
           >
@@ -192,7 +192,7 @@ export function Sidebar() {
               size="sm"
               touchTarget={false}
               onClick={() => setShowSettingsModal(true)}
-              className="text-content-tertiary"
+              className="h-8 w-8 text-content-tertiary"
               title={t('sidebar.settings')}
               aria-label={t('sidebar.openSettings')}
             >
@@ -212,7 +212,7 @@ export function Sidebar() {
               size="sm"
               touchTarget={false}
               onClick={toggle}
-              className="text-content-tertiary"
+              className="h-8 w-8 text-content-tertiary"
               title={t('sidebar.collapsePanel')}
               aria-label={t('sidebar.collapseLeftPanel')}
             >

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -181,7 +181,7 @@ export function Sidebar() {
         // Expanded state
         <div className="flex flex-col h-full animate-fade-in">
           <div
-            className={`flex items-center gap-3 px-4 py-[7.5px] border-b border-stroke-subtle transition-shadow duration-200 ${
+            className={`flex items-center gap-3 px-4 h-[47px] border-b border-stroke-subtle transition-shadow duration-200 ${
               isScrolled ? 'shadow-elevated' : ''
             }`}
           >

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -160,6 +160,7 @@ export function Sidebar() {
         <div className="flex flex-col items-center h-full py-2">
           <IconButton
             size="sm"
+            touchTarget={false}
             onClick={toggle}
             title={t('sidebar.expandPanel')}
             aria-label={t('sidebar.expandLeftPanel')}
@@ -189,6 +190,7 @@ export function Sidebar() {
             </h2>
             <IconButton
               size="sm"
+              touchTarget={false}
               onClick={() => setShowSettingsModal(true)}
               className="text-content-tertiary"
               title={t('sidebar.settings')}
@@ -208,6 +210,7 @@ export function Sidebar() {
             </IconButton>
             <IconButton
               size="sm"
+              touchTarget={false}
               onClick={toggle}
               className="text-content-tertiary"
               title={t('sidebar.collapsePanel')}

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -3,6 +3,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useViewStore } from '@/core/store/view';
 import { useDrawerSettings } from '@/shared/hooks/useDrawerSettings';
 import { CONSTRAINTS } from '@/core/constants';
+import { Button, IconButton } from '@/design-system';
 import { RulerIcon } from '@/design-system/Icon';
 import type { SettingsTabId } from '@/shell/Modals/SettingsModal/types';
 import { ActiveLayerPanel } from '@/features/layers/components/ActiveLayerPanel';
@@ -157,9 +158,9 @@ export function Sidebar() {
       {collapsed ? (
         // Collapsed state - expand button at top, UserDock pinned at bottom
         <div className="flex flex-col items-center h-full py-2">
-          <button
+          <IconButton
+            size="sm"
             onClick={toggle}
-            className="btn btn-ghost btn-icon"
             title={t('sidebar.expandPanel')}
             aria-label={t('sidebar.expandLeftPanel')}
           >
@@ -168,7 +169,7 @@ export function Sidebar() {
                 <path key={d} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
               ))}
             </svg>
-          </button>
+          </IconButton>
           {cloudSyncEnabled && (
             <div className="mt-auto w-full">
               <UserDock variant="compact" />
@@ -186,9 +187,10 @@ export function Sidebar() {
             <h2 className="flex-1 text-xs leading-none font-semibold text-content-tertiary uppercase tracking-wider">
               {t('sidebar.tools')}
             </h2>
-            <button
+            <IconButton
+              size="sm"
               onClick={() => setShowSettingsModal(true)}
-              className="p-2 rounded-md transition-colors text-content-tertiary hover:bg-surface-hover hover:text-content"
+              className="text-content-tertiary"
               title={t('sidebar.settings')}
               aria-label={t('sidebar.openSettings')}
             >
@@ -203,10 +205,11 @@ export function Sidebar() {
                   />
                 ))}
               </svg>
-            </button>
-            <button
+            </IconButton>
+            <IconButton
+              size="sm"
               onClick={toggle}
-              className="p-2 rounded-md transition-colors text-content-tertiary hover:bg-surface-hover hover:text-content"
+              className="text-content-tertiary"
               title={t('sidebar.collapsePanel')}
               aria-label={t('sidebar.collapseLeftPanel')}
             >
@@ -221,7 +224,7 @@ export function Sidebar() {
                   />
                 ))}
               </svg>
-            </button>
+            </IconButton>
           </div>
           <div
             ref={scrollRef}
@@ -248,12 +251,14 @@ export function Sidebar() {
 
             {/* Inspiration Gallery - Prominent placement */}
             <div className="px-4 py-4 border-b border-stroke-subtle">
-              <button
+              <Button
+                variant="ghost"
+                fullWidth
                 onClick={() => {
                   setShowInspirationGallery(true);
                   if (shouldPulseGallery) dismissGalleryPulse();
                 }}
-                className={`w-full flex items-center gap-3 text-left p-3 rounded-lg bg-gradient-to-r from-accent/10 to-info/10 hover:from-accent/20 hover:to-info/20 border border-accent/20 transition-all group ${shouldPulseGallery ? 'animate-gallery-pulse' : ''}`}
+                className={`justify-start gap-3 text-left p-3 rounded-lg bg-gradient-to-r from-accent/10 to-info/10 hover:from-accent/20 hover:to-info/20 border border-accent/20 group ${shouldPulseGallery ? 'animate-gallery-pulse' : ''}`}
               >
                 <div className="w-10 h-10 rounded-lg bg-accent/20 flex items-center justify-center group-hover:scale-105 transition-transform">
                   <svg
@@ -297,7 +302,7 @@ export function Sidebar() {
                     />
                   ))}
                 </svg>
-              </button>
+              </Button>
             </div>
 
             {/* Grid Size */}
@@ -511,17 +516,19 @@ export function Sidebar() {
                       />
                     </SettingsRow>
                   </div>
-                  <button
+                  <Button
+                    variant="secondary"
+                    fullWidth
                     type="button"
                     onClick={resetGridfinityStandard}
                     disabled={
                       gridUnitMm === CONSTRAINTS.GRID_UNIT_MM_DEFAULT &&
                       heightUnitMm === CONSTRAINTS.HEIGHT_UNIT_MM_DEFAULT
                     }
-                    className="w-full text-[11px] py-1.5 px-2 mt-1 rounded text-content-tertiary hover:text-content hover:bg-surface-hover border border-stroke-subtle transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-content-tertiary disabled:hover:bg-transparent"
+                    className="text-[11px] py-1.5 px-2 mt-1 text-content-tertiary hover:text-content"
                   >
                     {t('settings.resetGridfinityStandard')}
-                  </button>
+                  </Button>
                 </div>
               </CollapsibleSection>
             </div>

--- a/src/shell/Tablet/TabletPanelTriggers/TabletPanelTriggers.tsx
+++ b/src/shell/Tablet/TabletPanelTriggers/TabletPanelTriggers.tsx
@@ -1,3 +1,4 @@
+import { IconButton } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 interface TabletPanelTriggersProps {
@@ -23,9 +24,10 @@ export function TabletPanelTriggers({
     <>
       {/* Left panel trigger - top-left corner */}
       {!leftPanelOpen && (
-        <button
+        <IconButton
+          size="lg"
           onClick={onOpenLeftPanel}
-          className="fixed top-16 left-4 z-30 flex items-center justify-center w-12 h-12 rounded-full shadow-lg transition-all duration-300 hover:scale-110 active:scale-95"
+          className="fixed top-16 left-4 z-30 rounded-full shadow-lg transition-all duration-300 hover:scale-110 active:scale-95"
           style={{
             background: 'var(--color-surface-elevated)',
             border: '1px solid var(--border-default)',
@@ -49,14 +51,15 @@ export function TabletPanelTriggers({
               d="M4 5h16M4 12h16m-7 7h7"
             />
           </svg>
-        </button>
+        </IconButton>
       )}
 
       {/* Right panel trigger - top-right corner */}
       {!rightPanelOpen && (
-        <button
+        <IconButton
+          size="lg"
           onClick={onOpenRightPanel}
-          className="fixed top-16 right-4 z-30 flex items-center justify-center w-12 h-12 rounded-full shadow-lg transition-all duration-300 hover:scale-110 active:scale-95"
+          className="fixed top-16 right-4 z-30 rounded-full shadow-lg transition-all duration-300 hover:scale-110 active:scale-95"
           style={{
             background: 'var(--color-surface-elevated)',
             border: '1px solid var(--border-default)',
@@ -80,7 +83,7 @@ export function TabletPanelTriggers({
               d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
             />
           </svg>
-        </button>
+        </IconButton>
       )}
     </>
   );


### PR DESCRIPTION
## Summary

Every raw `<button>` in the app now renders through the design-system `Button`/`IconButton` primitives, so focus rings, disabled handling, press feedback, and touch targets are uniform across the whole UI. **98 files migrated, 112 files drained from the allowlist.**

Batch 2 of 6 in the design-system migration (foundation primitives landed in #2111).

## What changed

- **Icon-only controls → `IconButton`** with a required `aria-label` (reusing existing `title`/`t()` text — no new i18n keys). Dense desktop toolbars opt out of the 44px touch target via `touchTarget={false}`; mobile keeps it.
- **Text actions → `Button`** with the matching variant: `ghost` (transparent/hover-only), `secondary` (bordered neutral), `primary` (accent CTA), `danger` (destructive). Async submit buttons use the `loading` prop instead of hand-rolled inline spinner SVGs.
- **Menu rows, tabs, segmented controls, disclosure headers, and connected steppers** keep their bespoke layout via `className` (cn/tailwind-merge lets the override win over the primitive's base) while gaining the primitive's uniform `<button>` semantics and focus/disabled behavior.
- Stale `btn-*` class assertions in 5 sibling tests updated to query the design-system variant classes.

## Scope boundary

The 6 files still on the allowlist hold only raw `<select>`/checkbox controls — deferred to the inputs batch (batch 3). Modal/dialog **shells** are untouched here; only the buttons inside them were converted.

## Verification

- `tsc -b` clean, ESLint clean on all 98 changed files, `check:design-system` reports **zero** raw-button violations repo-wide.
- Full test suite for every touched area green (6016 tests); the 5 tests asserting old `btn-*` classes were updated.
- Playwright visual spot check on desktop (1440px) and mobile (390px) viewports — header, tools, layers/grid steppers, category swatches, and bottom nav all render identically to baseline; no console/page errors (only unrelated local Liveblocks WS noise).

Net **−36 lines** despite touching ~100 files (bespoke button class soup replaced by primitive props).