### PR TITLE
refactor(design-system): begin draining allowlist (clean swaps + policy)

### DIFF
--- a/scripts/design-system-allowlist.txt
+++ b/scripts/design-system-allowlist.txt
@@ -14,6 +14,17 @@
 #
 # Import design system components:
 #   import { Button, Checkbox, Select, Input } from '@/design-system';
+#
+# Migration policy (clean swaps only): migrate raw buttons that map directly
+# to <Button>/<IconButton> while preserving exact appearance. Most remaining
+# entries are intentionally raw — bespoke controls that do NOT map cleanly:
+# segmented controls / connected toolbars / pills with an active bg-accent
+# state, role=radio|tab grids with roving tabindex, custom toggle switches,
+# sliders, color-swatch grids, and connected steppers. Forcing these into
+# Button/IconButton breaks a11y semantics (e.g. aria-pressed on a radio) or
+# needs many className overrides for no visual gain. Adopt the DS
+# SegmentedControl/primitive for those in a dedicated effort rather than a
+# button-by-button swap.
 
 src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
 src/features/baseplate/components/BaseplatePanel/EditableDimensions.tsx
@@ -81,12 +92,10 @@ src/shared/components/SegmentedControl/SegmentedControl.tsx
 src/shared/components/SliderInput/SliderInput.tsx
 src/shared/components/StickyGroupHeader/StickyGroupHeader.tsx
 src/shared/components/UserDock/UserDock.tsx
-src/shell/InitErrorFallback/InitErrorFallback.tsx
 src/shell/Mobile/BinContextMenu/BinContextMenu.tsx
 src/shell/Mobile/MobileLayoutsPanel/MobileCloudSharePanel.tsx
 src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsListItem.tsx
 src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.tsx
 src/shell/Modals/HalfGridModeBlockedModal/HalfGridModeBlockedModal.tsx
-src/shell/Modals/HelpModal/HelpSearchResultRow.tsx
 src/shell/Modals/SettingsModal/tabs/AppearanceTab/AppearanceTab.tsx
 src/shell/Modals/SettingsModal/tabs/StorageTab/StorageTab.tsx

--- a/scripts/design-system-allowlist.txt
+++ b/scripts/design-system-allowlist.txt
@@ -21,8 +21,9 @@
 # segmented controls / connected toolbars / pills with an active bg-accent
 # state, role=radio|tab grids with roving tabindex, custom toggle switches,
 # sliders, color-swatch grids, and connected steppers. Forcing these into
-# Button/IconButton breaks a11y semantics (e.g. aria-pressed on a radio) or
-# needs many className overrides for no visual gain. Adopt the DS
+# Button/IconButton breaks a11y semantics (e.g. IconButton emits aria-pressed
+# where a role=radio needs aria-checked) or needs many className overrides for
+# no visual gain. Adopt the DS
 # SegmentedControl/primitive for those in a dedicated effort rather than a
 # button-by-button swap.
 

--- a/src/shell/InitErrorFallback/InitErrorFallback.tsx
+++ b/src/shell/InitErrorFallback/InitErrorFallback.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable i18next/no-literal-string -- Catastrophic fallback; i18n may not be available */
 
+import { Button } from '@/design-system';
+
 /** Shown when IndexedDB initialization fails and the app cannot load saved data. */
 export function InitErrorFallback({ error }: { error: Error }) {
   return (
@@ -29,9 +31,9 @@ export function InitErrorFallback({ error }: { error: Error }) {
         <pre className="text-left text-xs rounded-lg p-3 mb-4 overflow-auto max-h-24 text-error bg-surface-elevated border border-stroke-subtle">
           {error.message}
         </pre>
-        <button onClick={() => window.location.reload()} className="btn btn-primary">
+        <Button variant="primary" onClick={() => window.location.reload()}>
           Reload
-        </button>
+        </Button>
         <p className="text-xs text-content-tertiary mt-4">
           If reloading doesn&rsquo;t help, your browser&rsquo;s stored data for this site may be
           corrupted. You can clear it from your browser&rsquo;s site settings to recover. That

--- a/src/shell/Modals/HelpModal/HelpSearchResultRow.tsx
+++ b/src/shell/Modals/HelpModal/HelpSearchResultRow.tsx
@@ -4,6 +4,7 @@
  * "Go to" deep-link button; tips render description-only.
  */
 
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import type { HelpEntry } from '@/shared/help/helpEntry';
 import { KeyboardKey } from './HelpModalSections';
@@ -46,16 +47,16 @@ export function HelpSearchResultRow({
       {entry.kind === 'shortcut' ? (
         <ShortcutKeyCaps entry={entry} modifierKey={modifierKey} />
       ) : entry.kind === 'feature' && showJumpButton ? (
-        <button
-          type="button"
-          className="btn btn-secondary btn-sm shrink-0"
+        <Button
+          variant="secondary"
+          className="shrink-0"
           onClick={() => {
             onJump();
             void jumpToHelpTarget(entry.target);
           }}
         >
           {t('help.goTo')}
-        </button>
+        </Button>
       ) : null}
     </div>
   );

--- a/src/shell/Modals/HelpModal/HelpSearchResultRow.tsx
+++ b/src/shell/Modals/HelpModal/HelpSearchResultRow.tsx
@@ -48,6 +48,7 @@ export function HelpSearchResultRow({
         <ShortcutKeyCaps entry={entry} modifierKey={modifierKey} />
       ) : entry.kind === 'feature' && showJumpButton ? (
         <Button
+          type="button"
           variant="secondary"
           className="shrink-0"
           onClick={() => {


### PR DESCRIPTION
## Summary

First step of draining the 75-file grandfathered design-system allowlist, using the **"clean swaps only"** strategy: migrate raw buttons that map *directly* to the DS primitives while preserving exact appearance, and **document why the rest stay raw**.

### Migrated (exact `.btn` → Button, zero drift)
- **InitErrorFallback**: `btn btn-primary` → `Button variant="primary"` (`.btn` ≡ Button md)
- **HelpSearchResultRow**: `btn btn-secondary btn-sm` → `Button variant="secondary"`. Note: `.btn-sm` is **undefined in CSS** (a no-op class), so the button actually rendered at **md** — mapping to `size="sm"` would have shrunk it. Mapped to md to preserve appearance.

Allowlist: 75 → 73 entries.

### Documented the rest (policy)
Classified all 75 files. ~19 are FULLY_CLEAN (queued for follow-up clean-swap PRs); the **majority are bespoke controls** that don't map cleanly: segmented controls / connected toolbars with active `bg-accent` state, `role=radio|tab` grids with roving tabindex, custom toggle switches, sliders, color-swatch grids, connected steppers. Forcing those into Button/IconButton would break a11y (e.g. `aria-pressed` on a radio) or need many overrides for no visual gain. The allowlist header now documents this policy and recommends adopting the DS `SegmentedControl` for those in a dedicated effort.

## Testing
- `tsc`, eslint, all gates green (incl. the enabled `check:design-system`)
- Verified `.btn`/`.btn-sm` against `index.css` before mapping (caught the `btn-sm` no-op)