### PR TITLE
chore(design-system): remove stale allowlist entries for deleted components

### DIFF
--- a/scripts/design-system-allowlist.txt
+++ b/scripts/design-system-allowlist.txt
@@ -89,8 +89,6 @@ src/shared/components/FeatureToggle/FeatureToggle.tsx
 src/shared/components/FractionalEdgeToggle/FractionalEdgeToggle.tsx
 src/shared/components/HeaderSupportLinks/HeaderSupportLinks.tsx
 src/shared/components/PrintBedInput/PrintBedInput.tsx
-src/shared/components/SegmentedControl/SegmentedControl.tsx
-src/shared/components/SliderInput/SliderInput.tsx
 src/shared/components/StickyGroupHeader/StickyGroupHeader.tsx
 src/shared/components/UserDock/UserDock.tsx
 src/shell/Mobile/BinContextMenu/BinContextMenu.tsx


### PR DESCRIPTION
## Summary

Kicks off the design-system **allowlist drain** by removing two now-dead entries: `SegmentedControl` and `SliderInput` were promoted/moved out of `shared/components` in #2128 and #2129, so their old paths no longer exist.

Allowlist: **73 → 71**. The usage check still passes (171 violations across the remaining 71 files).

## Context — the rest of the drain
The remaining 71 files are heterogeneous and need case-by-case work, not a mechanical sweep. From a first pass:
- **Clean swaps** — icon-dismiss buttons → `IconButton`, plain action/ghost buttons → `Button`.
- **Need a design decision / DS variant** — e.g. outline-`danger` buttons (DS `danger` is filled), underline **link** buttons (no `link` variant yet), custom `role="radio"` pickers.
- **Legitimately custom** — canvas overlays, hit-target layers.

These will land as focused batched PRs (grouped by area: shared/settings, baseplate, bin-designer panels, etc.), each with visual verification per the known button-migration blind spots (emergent height, radius tokens, twMerge bleed).

Trivial, zero-risk first step; no code behavior changes.