### PR TITLE
fix(generation): raise generation timeout ceiling to 3 min

### DIFF
--- a/src/features/generation/bridge/generationTimeout.test.ts
+++ b/src/features/generation/bridge/generationTimeout.test.ts
@@ -164,8 +164,10 @@ describe('computeGenerationTimeoutMs', () => {
   });
 
   it('caps a large-footprint hex bin at the maximum timeout', () => {
+    // 20×20×20 hex: raw budget (base + hex + 384-cell footprint + 8 height
+    // buckets ≈ 261s) exceeds the 180s ceiling, so it clamps to MAX.
     const t = computeGenerationTimeoutMs(
-      params({ width: 16, depth: 16, height: 6, wallPattern: HEX_ON })
+      params({ width: 20, depth: 20, height: 20, wallPattern: HEX_ON })
     );
     expect(t).toBe(MAX_TIMEOUT_MS);
   });
@@ -295,7 +297,9 @@ describe('computeBaseplateTimeoutMs', () => {
     expect(computeBaseplateTimeoutMs(rest)).toBe(BASE_TIMEOUT_MS + BASEPLATE_LIGHTWEIGHT_BONUS_MS);
   });
 
-  it('has a higher ceiling than bins (dense magnet grids outlast bin pipelines)', () => {
-    expect(BASEPLATE_MAX_TIMEOUT_MS).toBeGreaterThan(MAX_TIMEOUT_MS);
+  it('shares the 3-minute hard ceiling with bins', () => {
+    // Honeycomb bins are now the heaviest pipeline, so baseplates no longer get a
+    // higher ceiling than bins — both clamp at the agreed 3-minute cap.
+    expect(BASEPLATE_MAX_TIMEOUT_MS).toBe(MAX_TIMEOUT_MS);
   });
 });

--- a/src/features/generation/bridge/generationTimeout.ts
+++ b/src/features/generation/bridge/generationTimeout.ts
@@ -57,8 +57,21 @@ export const HEIGHT_BONUS_FLOOR_UNITS = 4;
 /** Height-unit bucket size for bonus steps. */
 export const HEIGHT_BONUS_BUCKET_UNITS = 2;
 
-/** Hard ceiling — protects users from runaway WASM OOM loops. */
-export const MAX_TIMEOUT_MS = 90_000;
+/**
+ * Hard ceiling — protects users from runaway WASM OOM loops while still giving
+ * legitimately complex bins room to finish.
+ *
+ * Raised from 90s to 180s (#timeouts): measured generation of heavy honeycomb
+ * bins runs well past 90s on the single-threaded OCCT pipeline — e.g. a 4×4×8
+ * honeycomb bin's pattern cut alone is ~14s and a tall 6×6×20 is ~3min. The
+ * boolean `pattern_cut` stage is ~82% of total and scales super-linearly, so the
+ * batch cut is already near-optimal and can't be meaningfully parallelized
+ * (splitting the solid forces a recombine that costs more than it saves). Until
+ * the pattern cut itself is optimized, a 3-minute ceiling stops the bulk of
+ * spurious timeouts on bins that would otherwise finish. 3 minutes is the agreed
+ * upper bound on how long a user should wait (with progress + cancel).
+ */
+export const MAX_TIMEOUT_MS = 180_000;
 
 function hasAnyActiveCutoutSide(params: BinParams): boolean {
   const { walls } = params;
@@ -124,12 +137,13 @@ export const BASEPLATE_CONNECTOR_BONUS_MS = 10_000;
 export const BASEPLATE_LIGHTWEIGHT_BONUS_MS = 5_000;
 
 /**
- * Hard ceiling for baseplates. Higher than {@link MAX_TIMEOUT_MS} because
- * dense magnet grids (10u+ with holes) legitimately run longer than any
- * bin shape does — the batched-cut pipeline is serial per batch and OCCT
- * numerical precision work dominates.
+ * Hard ceiling for baseplates. Unified with {@link MAX_TIMEOUT_MS} at the agreed
+ * 3-minute cap: honeycomb bins are now the heaviest pipeline (their pattern cut
+ * can reach ~3min), so baseplates no longer warrant a higher ceiling than bins.
+ * Baseplate raw budgets max out near ~105s anyway (magnet bonus is capped), so
+ * this is a defensive clamp that is effectively never hit.
  */
-export const BASEPLATE_MAX_TIMEOUT_MS = 120_000;
+export const BASEPLATE_MAX_TIMEOUT_MS = 180_000;
 
 /**
  * Compute the timeout budget for a baseplate generation, in milliseconds.


### PR DESCRIPTION
## Problem
Users hit generation timeouts on legitimately complex bins. The hard ceiling was 90s, but heavy honeycomb bins genuinely need longer on the single-threaded OCCT pipeline.

## What I measured
- A **4×4×8 honeycomb** bin's pattern cut alone is **~14s**; a tall **6×6×20** reaches **~3min**.
- The boolean `pattern_cut` stage is **~82% of total** generation time and scales **super-linearly** with the assembled-bin + honeycomb complexity.
- Wall-pattern cuts use a **variable number of per-wall tools** (4 for a rectangle, 6 for an L-shape, more for complex polygons) — and yes, **honeycomb patterns do run on L-shaped/polygon bins**.

## Why not parallelize the cut across workers?
I prototyped and benchmarked it — it doesn't work:
- **tool-split + `intersect` recombine:** correct but **3× slower** (recombining two big carved solids costs ~38s, far more than the ~14s cut it parallelizes).
- **z-slab + `fuse` recombine:** fast-looking but produced **empty/incorrect geometry**.

OCCT boolean cost is super-linear, so the monolithic batch cut is already near-optimal; any split forces a recombine that costs more than it saves.

## This PR
- Raise `MAX_TIMEOUT_MS` **90s → 180s** (3 min — the agreed upper bound on acceptable wait, with progress + cancel).
- Unify `BASEPLATE_MAX_TIMEOUT_MS` at the same 3-min cap (honeycomb bins are now the heaviest pipeline; baseplate raw budgets max ~105s anyway).
- Update `generationTimeout.test.ts` accordingly (22/22 pass).

This stops the bulk of spurious timeouts immediately. A follow-up will investigate optimizing the single-worker pattern cut itself (e.g. cutting the honeycomb into flat wall panels *before* assembly) for a real speedup on the extreme tail.