### PR TITLE
refactor(design-system): migrate ColorsHintBanner dismiss to IconButton

### DIFF
--- a/scripts/design-system-allowlist.txt
+++ b/scripts/design-system-allowlist.txt
@@ -48,7 +48,6 @@ src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.tsx
 src/features/bin-designer/components/panel/ColorsSection/ColorGroup.tsx
 src/features/bin-designer/components/panel/ColorsSection/ColorPicker.tsx
 src/features/bin-designer/components/panel/ColorsSection/ColorsActionsMenu.tsx
-src/features/bin-designer/components/panel/ColorsSection/ColorsHintBanner.tsx
 src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
 src/features/bin-designer/components/panel/ColorsSection/ColorZoneRow.tsx
 src/features/bin-designer/components/panel/ColorsSection/LipZoneRow.tsx

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsHintBanner.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsHintBanner.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useShallow } from 'zustand/react/shallow';
+import { IconButton } from '@/design-system';
 import { InfoIcon, XIcon } from '@/design-system/Icon';
 import { useSettingsStore } from '@/core/store';
 import { useTranslation } from '@/i18n';
@@ -30,17 +31,19 @@ export function ColorsHintBanner() {
     >
       <InfoIcon size="sm" className="mt-0.5 shrink-0 text-info" />
       <p className="flex-1 leading-snug">{t('binDesigner.colors.firstTimeHint')}</p>
-      <button
-        type="button"
+      <IconButton
+        variant="ghost"
+        size="sm"
+        touchTarget={false}
         onClick={() => {
           updateSettings({ dismissedHints: [...dismissedHints, HINT_ID] });
         }}
-        className="shrink-0 rounded p-0.5 text-content-tertiary hover:bg-surface-hover hover:text-content-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+        className="shrink-0"
         aria-label={t('binDesigner.colors.firstTimeHint.dismiss')}
         title={t('binDesigner.colors.firstTimeHint.dismiss')}
       >
         <XIcon size="sm" />
-      </button>
+      </IconButton>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Allowlist drain — first file in the **icon-dismiss tier**. The colors hint banner's raw `<button>` wrapping an `XIcon` maps cleanly to `IconButton` (`ghost`, `size="sm"`, `touchTarget={false}` to preserve the compact inline footprint that the original `p-0.5` had).

Drops `ColorsHintBanner.tsx` from `design-system-allowlist.txt` — **70 entries remain**.

## Reviewer note
Minor visual normalization (DS `IconButton` ghost hover/focus vs the previous bespoke classes) — worth a glance on the Vercel preview. Behaviour (dismiss → persists in settings) is unchanged; ColorsSection tests pass (50).

## On the rest of the allowlist
A thorough triage shows the remaining 70 are **not** mechanical swaps — most are custom-styled (segmented-group buttons sharing borders, full-width text rows, canvas overlays with `bg-white/20` hover for the 3D view), link buttons (need a DS `link` variant), or `role="radio"/"switch"/"tab"` controls (map to DS `SegmentedControl`/`Switch`/`Tabs`). Those will come as area-grouped PRs, several needing a small design decision or visual verification first.

## Verification
- `check:design-system` ✅ (file now clean) · `pnpm lint` ✅ · ColorsSection suite ✅ (50 passed).