### PR TITLE
refactor(design-system): migrate StorageTab clear-data button to Button

### DIFF
--- a/scripts/design-system-allowlist.txt
+++ b/scripts/design-system-allowlist.txt
@@ -96,4 +96,3 @@ src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsListItem.tsx
 src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.tsx
 src/shell/Modals/HalfGridModeBlockedModal/HalfGridModeBlockedModal.tsx
 src/shell/Modals/SettingsModal/tabs/AppearanceTab/AppearanceTab.tsx
-src/shell/Modals/SettingsModal/tabs/StorageTab/StorageTab.tsx

--- a/src/shell/Modals/SettingsModal/tabs/StorageTab/StorageTab.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/StorageTab/StorageTab.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { CONSTRAINTS } from '@/core/constants';
 import { clearAllAppData } from '@/core/storage/clearAppData';
@@ -182,13 +183,9 @@ function ClearAllDataButton() {
 
   return (
     <>
-      <button
-        type="button"
-        className="px-3 py-1.5 text-sm rounded-md border border-error text-error hover:bg-error/10 transition-colors"
-        onClick={() => setShowConfirm(true)}
-      >
+      <Button type="button" variant="danger" size="sm" onClick={() => setShowConfirm(true)}>
         {t('settings.storage.clearAllData')}
-      </button>
+      </Button>
       <ConfirmDialog
         isOpen={showConfirm}
         title={t('settings.storage.clearAllData')}


### PR DESCRIPTION
## Summary

Allowlist drain. The Storage settings **"Clear all data"** action is a standalone destructive button — migrated to DS `Button variant="danger"` (`type="button"` preserved). Drops `StorageTab.tsx` from the allowlist → **69 entries**.

## Reviewer note
Intentional visual normalization: the bespoke *outline* danger styling becomes the design system's standard *filled* `danger` button — the conventional treatment for a destructive action. Worth a glance on the Vercel preview. Behaviour (opens the existing `ConfirmDialog`) is unchanged; StorageTab tests pass (14).

## Verification
- `check:design-system` ✅ (file clean) · `pnpm lint` ✅ · StorageTab suite ✅ (14).