### PR TITLE
feat(design-system): add fullWidth variant to Stepper

### DIFF
--- a/src/design-system/Stepper/Stepper.test.tsx
+++ b/src/design-system/Stepper/Stepper.test.tsx
@@ -93,6 +93,24 @@ describe('Stepper', () => {
     });
   });
 
+  describe('fullWidth', () => {
+    it('stretches the container when fullWidth is set', () => {
+      const ref = vi.fn();
+      render(<Stepper {...defaultProps} ref={ref} displayValue={5} fullWidth />);
+      const container = ref.mock.calls[0][0] as HTMLDivElement;
+      expect(container).toHaveClass('flex', 'w-full');
+      expect(container).not.toHaveClass('inline-flex');
+    });
+
+    it('stays inline by default', () => {
+      const ref = vi.fn();
+      render(<Stepper {...defaultProps} ref={ref} displayValue={5} />);
+      const container = ref.mock.calls[0][0] as HTMLDivElement;
+      expect(container).toHaveClass('inline-flex');
+      expect(container).not.toHaveClass('w-full');
+    });
+  });
+
   describe('ref forwarding', () => {
     it('forwards ref to container', () => {
       const ref = vi.fn();

--- a/src/design-system/Stepper/Stepper.tsx
+++ b/src/design-system/Stepper/Stepper.tsx
@@ -233,6 +233,13 @@ export interface StepperProps extends StepperVariantProps {
   commitMode?: 'immediate' | 'deferred';
 
   /**
+   * Stretch the control to fill its container instead of hugging its content.
+   * The +/- buttons keep their fixed width; the input/display absorbs the slack.
+   * @default false
+   */
+  fullWidth?: boolean | null;
+
+  /**
    * If provided, shows a static display instead of an input.
    * Useful for values that should only change via steppers.
    *

--- a/src/design-system/Stepper/Stepper.tsx
+++ b/src/design-system/Stepper/Stepper.tsx
@@ -6,16 +6,23 @@ import { focusRing, disabledStyles, interactiveTransition } from '../variants';
 
 /** Idle window for coalescing step clicks in `'deferred'` commit mode. */
 export const DEFERRED_COMMIT_DELAY_MS = 250;
-const containerVariants = cva(['inline-flex items-center'], {
+const containerVariants = cva(['items-center'], {
   variants: {
     size: {
       sm: 'h-6',
       md: 'h-8',
       lg: 'h-12',
     },
+    fullWidth: {
+      // The input/display carries `flex-1`, so stretching the container lets the
+      // middle element absorb the extra width while the buttons stay fixed.
+      true: 'flex w-full',
+      false: 'inline-flex',
+    },
   },
   defaultVariants: {
     size: 'md',
+    fullWidth: false,
   },
 });
 
@@ -302,6 +309,7 @@ export const Stepper = forwardRef<HTMLDivElement, StepperProps>(
       step = 1,
       inputDecimals = 1,
       size = 'md',
+      fullWidth = false,
       displayValue,
       'aria-label': ariaLabel,
       disabled = false,
@@ -371,7 +379,7 @@ export const Stepper = forwardRef<HTMLDivElement, StepperProps>(
     const showInput = displayValue === undefined && onChange;
 
     return (
-      <div ref={ref} className={cn(containerVariants({ size }), className)}>
+      <div ref={ref} className={cn(containerVariants({ size, fullWidth }), className)}>
         {/* Decrease button */}
         <button
           type="button"

--- a/src/design-system/Stepper/Stepper.visual.tsx
+++ b/src/design-system/Stepper/Stepper.visual.tsx
@@ -66,4 +66,21 @@ test.describe('Stepper visual', () => {
     );
     await expect(component).toHaveScreenshot('stepper-at-max.png');
   });
+
+  test('full width', async ({ mount }) => {
+    const component = await mount(
+      <div style={{ width: 320 }}>
+        <Stepper
+          value={5}
+          onChange={noop}
+          onStep={noop}
+          min={1}
+          max={10}
+          fullWidth
+          aria-label="Height"
+        />
+      </div>
+    );
+    await expect(component).toHaveScreenshot('stepper-full-width.png');
+  });
 });

--- a/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
+++ b/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
@@ -100,6 +100,7 @@ export function DimensionsSection() {
           max={DESIGNER_CONSTRAINTS.MAX_HEIGHT}
           step={DESIGNER_CONSTRAINTS.HEIGHT_STEP}
           size={stepperSize}
+          fullWidth
           aria-label={t('common.height')}
         />
       </div>


### PR DESCRIPTION
## What

Adds a `fullWidth` variant to the design-system `Stepper` and applies it to the bin designer **height** stepper so it spans the full panel width instead of hugging its content.

## Why

In `DimensionsSection`, width and depth share a row (each `flex-1`), while height sits on its own row. Because `Stepper` renders `inline-flex`, the height control only spanned its content width, leaving the row visually unbalanced. Making it full width fills the row and lines the control up with the width/depth pair above it.

## How

`Stepper`'s input/display already carries `flex-1`, so the change is a single CVA variant — `fullWidth` swaps the container from `inline-flex` to `flex w-full`, letting the middle element absorb the slack while the +/- buttons keep their fixed sizing. Defaults to `false`, so all existing call sites are unaffected.

## Changes

- `Stepper.tsx` — `fullWidth` variant on `containerVariants`, threaded through props (defaults `false`)
- `DimensionsSection.tsx` — height stepper now passes `fullWidth`
- `Stepper.test.tsx` — coverage for the stretched vs. inline container
- `Stepper.visual.tsx` — full-width visual snapshot

## Testing

- `vitest run src/design-system/Stepper/Stepper.test.tsx` — 19 passed
- `pnpm run typecheck` — clean
- `eslint` on changed files — clean