### PR TITLE
chore(deps): drop expired cooldown excludes

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,11 +20,6 @@ minimumReleaseAgeExclude:
   - '@vercel/*'
   - '@protobufjs/*'
   - protobufjs
-  # TODO: remove after 2026-05-26 once these have aged past the 7-day window.
-  - dompurify
-  - lru-cache
-  - preact
-  - tsx
   # esbuild 0.28.1 (2026-06-11) is the first version patched against
   # GHSA-gv7w-rqvm-qjhr and GHSA-g7r4-m6w7-qqqr; allow it (and its native
   # binary packages) through before the 7-day window elapses.


### PR DESCRIPTION
## Why

`dompurify`, `lru-cache`, `preact`, and `tsx` were temporarily added to `minimumReleaseAgeExclude` with a `TODO: remove after 2026-05-26`. That window elapsed ~18 days ago.

## What

Removes those four entries (and the stale TODO comment). Their pinned versions are now well past the 7-day cooldown, so re-subjecting them to it is resolution-neutral — `pnpm install` produces **no lockfile change**.

The esbuild / `@esbuild/*` exclude (TODO 2026-06-18) stays; that window hasn't elapsed yet.

## Verification

- `pnpm install --lockfile-only` → clean, no cooldown errors, lockfile unchanged