### PR TITLE
perf(bundle): cut eager initial JS 904→353KB by lazy-loading the 3D + collab stacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
       "path": [
         "dist/assets/main-*.js",
         "dist/assets/react-vendor-*.js",
-        "dist/assets/state-*.js"
+        "dist/assets/state-*.js",
+        "dist/assets/core-foundation-*.js"
       ],
       "gzip": true,
       "limit": "260 kB"

--- a/package.json
+++ b/package.json
@@ -72,10 +72,20 @@
       "limit": "190 kB"
     },
     {
+      "name": "Eager initial JS (gzip)",
+      "path": [
+        "dist/assets/main-*.js",
+        "dist/assets/react-vendor-*.js",
+        "dist/assets/state-*.js"
+      ],
+      "gzip": true,
+      "limit": "260 kB"
+    },
+    {
       "name": "Total JS (gzip)",
       "path": "dist/assets/*.js",
       "gzip": true,
-      "limit": "1800 kB"
+      "limit": "1900 kB"
     }
   ],
   "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,7 +107,7 @@ const CollabProvider = lazyWithRetry(() =>
   import('@/shell/Collab/CollabProvider').then(namedExport('CollabProvider'))
 );
 const BinExampleGallery = lazyWithRetry(() =>
-  import('@/features/bin-designer').then(namedExport('ExampleGallery'))
+  import('@/features/bin-designer/components/ExampleGallery').then(namedExport('ExampleGallery'))
 );
 
 let hasRenderedInitialLayout = false;

--- a/src/features/bin-designer/index.ts
+++ b/src/features/bin-designer/index.ts
@@ -20,18 +20,26 @@ export { useDesignerStore, removeRegistryEntry, upsertRegistryEntry } from './st
 export { loadDesign, deleteDesign, listDesigns, updateDesignParams } from './storage';
 
 // --- Hooks ---
+// Deep paths on purpose: the ./hooks barrel also re-exports useAutoSave /
+// useThumbnailCapture, which import ./utils/thumbnail (full three.js namespace).
+// This module is eagerly imported by App and the sync flows, so going through the
+// barrel would pull three core onto first paint.
+export { useBackgroundThumbnailRegen } from './hooks/useBackgroundThumbnailRegen';
+export { useCustomBins } from './hooks/useCustomBins';
 export {
-  useBackgroundThumbnailRegen,
-  useCustomBins,
   useDesignThumbnail,
   clearThumbnailCache,
   updateThumbnailCache,
-  useBinDefaults,
-} from './hooks';
-export type { UseBinDefaults } from './hooks';
+} from './hooks/useDesignThumbnail';
+export { useBinDefaults } from './hooks/useBinDefaults';
+export type { UseBinDefaults } from './hooks/useBinDefaults';
 
 // --- Utils ---
-export { generateFileName } from './utils';
+// Deep path on purpose: the ./utils barrel re-exports ./thumbnail, which imports
+// the full three.js namespace for offscreen rendering. Pulling the barrel here
+// would drag three core onto first paint (this module is eagerly imported by App
+// and the sync flows). fileNaming is three-free.
+export { generateFileName } from './utils/fileNaming';
 
 // --- Sync ---
 // Exposed for `shared/sync/` to wire into the sync engine without reaching
@@ -39,8 +47,12 @@ export { generateFileName } from './utils';
 export { designAdapter } from './sync/designAdapter';
 
 // --- Components ---
-export { DesignerPage } from './components';
-export { ExampleGallery } from './components/ExampleGallery';
+// Intentionally NOT re-exported here. DesignerPage/ExampleGallery pull in the
+// full three.js + drei + troika 3D stack. This barrel is statically imported by
+// many eager modules (sync flows, design-linking hooks, SettingsModal) for its
+// hooks/types/adapter; re-exporting the 3D components dragged that ~360 kB gzip
+// chunk onto first paint. Consumers must deep-import them via their own paths so
+// they stay behind lazy boundaries.
 
 // --- Help modal integration ---
 export { helpEntries } from './helpEntries';

--- a/src/features/bin-designer/utils/cameraFraming.test.ts
+++ b/src/features/bin-designer/utils/cameraFraming.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest';
-import { Vector3 } from 'three';
 import {
   ISOMETRIC_DIRECTION,
   FRAME_FILL,
@@ -9,9 +8,9 @@ import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 
 describe('cameraFraming', () => {
   describe('ISOMETRIC_DIRECTION', () => {
-    it('is a normalized Vector3 with length approximately 1', () => {
-      expect(ISOMETRIC_DIRECTION).toBeInstanceOf(Vector3);
-      const length = ISOMETRIC_DIRECTION.length();
+    it('is a normalized direction with length approximately 1', () => {
+      const { x, y, z } = ISOMETRIC_DIRECTION;
+      const length = Math.hypot(x, y, z);
       expect(length).toBeCloseTo(1, 10);
     });
 

--- a/src/features/bin-designer/utils/cameraFraming.ts
+++ b/src/features/bin-designer/utils/cameraFraming.ts
@@ -5,11 +5,21 @@
  * offscreen regenerator (thumbnailRegenerator.ts).
  */
 
-import { Vector3 } from 'three';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 
-/** Standard isometric direction (matches PreviewCanvas.CAMERA_PRESETS.isometric) */
-export const ISOMETRIC_DIRECTION = new Vector3(0.6, -0.6, 0.5).normalize();
+/**
+ * Standard isometric camera direction (matches PreviewCanvas.CAMERA_PRESETS.isometric),
+ * as a normalized {x,y,z}. Kept three-free (a plain object, not a THREE.Vector3) so
+ * this module — pulled by the eagerly-reachable thumbnail regenerator — doesn't drag
+ * three core onto first paint. Construct a Vector3 from it at the (three-loaded) call site.
+ */
+export const ISOMETRIC_DIRECTION: Readonly<{ x: number; y: number; z: number }> = (() => {
+  const x = 0.6;
+  const y = -0.6;
+  const z = 0.5;
+  const len = Math.hypot(x, y, z);
+  return { x: x / len, y: y / len, z: z / len };
+})();
 
 /** How much of the viewport the bin should fill (matches PreviewCanvas.FRAME_FILL) */
 export const FRAME_FILL = 0.65;

--- a/src/features/bin-designer/utils/thumbnail.ts
+++ b/src/features/bin-designer/utils/thumbnail.ts
@@ -423,7 +423,13 @@ export function captureThumbnailAtPreset(
     const savedQuaternion = previewCamera.quaternion.clone();
 
     // Move to isometric preset
-    const targetPosition = ISOMETRIC_DIRECTION.clone().multiplyScalar(idealDistance).add(binCenter);
+    const targetPosition = new Vector3(
+      ISOMETRIC_DIRECTION.x,
+      ISOMETRIC_DIRECTION.y,
+      ISOMETRIC_DIRECTION.z
+    )
+      .multiplyScalar(idealDistance)
+      .add(binCenter);
     previewCamera.position.copy(targetPosition);
     previewCamera.up.set(0, 0, 1);
     previewCamera.lookAt(binCenter);

--- a/src/features/bin-designer/utils/thumbnailRegenerator.ts
+++ b/src/features/bin-designer/utils/thumbnailRegenerator.ts
@@ -9,7 +9,7 @@
  * if one is active) and releases it when done.
  */
 
-import * as THREE from 'three';
+import type { WebGLRenderer, BufferGeometry, MeshStandardMaterial } from 'three';
 import { bridgeManager } from '@/shared/generation/bridge';
 import type { BinParams } from '@/features/bin-designer/types';
 import { LID_FIT_CLEARANCE } from '@/features/bin-designer/types';
@@ -48,7 +48,10 @@ export async function regenerateThumbnail(
   options: RegenerateOptions = {}
 ): Promise<string | null> {
   const { signal, color = DEFAULT_COLOR } = options;
-  let renderer: THREE.WebGLRenderer | null = null;
+  // three is loaded on demand: this offscreen renderer only runs during background
+  // thumbnail regeneration (idle time), so three core stays out of the eager bundle.
+  const THREE = await import('three');
+  let renderer: WebGLRenderer | null = null;
   // Track whether `acquire()` actually returned before incrementing the
   // bridge's ref-count obligation on our side. BridgeManager.acquire()
   // decrements its own refCount on init failure, so a blanket `release()`
@@ -83,7 +86,7 @@ export async function regenerateThumbnail(
     }
 
     // Build edge geometry from pre-computed BREP edges (from worker)
-    let edgesGeometry: THREE.BufferGeometry | null = null;
+    let edgesGeometry: BufferGeometry | null = null;
     if (edgeVertices.length > 0) {
       edgesGeometry = new THREE.BufferGeometry();
       edgesGeometry.setAttribute('position', new THREE.Float32BufferAttribute(edgeVertices, 3));
@@ -91,8 +94,8 @@ export async function regenerateThumbnail(
 
     // Lid mesh + edges (rendered at closed position when params.lid.enabled
     // and the worker produced a lid). Matches LidMesh.tsx's mated formula.
-    let lidGeometry: THREE.BufferGeometry | null = null;
-    let lidEdgesGeometry: THREE.BufferGeometry | null = null;
+    let lidGeometry: BufferGeometry | null = null;
+    let lidEdgesGeometry: BufferGeometry | null = null;
     const lidGroupZ =
       lidMesh && params.lid.enabled && params.base.stackingLip
         ? binLipTopWorldZ(params.height, params.heightUnitMm, params.base.stackingLip) -
@@ -176,7 +179,7 @@ export async function regenerateThumbnail(
     // Lid mesh rendered at its closed/mated position (lidOffsetMm = 0). Opaque
     // here — there's no exploded-view affordance in a thumbnail, so the lid
     // simply hides the cavity it sits over.
-    let lidMaterial: THREE.MeshStandardMaterial | null = null;
+    let lidMaterial: MeshStandardMaterial | null = null;
     if (lidGeometry && lidGroupZ !== null) {
       lidMaterial = new THREE.MeshStandardMaterial({
         color,
@@ -218,7 +221,13 @@ export async function regenerateThumbnail(
       heightUnitMm
     );
 
-    const cameraPos = ISOMETRIC_DIRECTION.clone().multiplyScalar(idealDistance).add(binCenter);
+    const cameraPos = new THREE.Vector3(
+      ISOMETRIC_DIRECTION.x,
+      ISOMETRIC_DIRECTION.y,
+      ISOMETRIC_DIRECTION.z
+    )
+      .multiplyScalar(idealDistance)
+      .add(binCenter);
     camera.position.copy(cameraPos);
     camera.lookAt(binCenter);
     camera.updateProjectionMatrix();

--- a/src/features/grid-editor/components/Grid/Grid.tsx
+++ b/src/features/grid-editor/components/Grid/Grid.tsx
@@ -29,7 +29,6 @@ import { RowLabels, ColumnLabels } from './GridAxisLabels';
 import { DrawerResizeHandles } from './DrawerResizeHandles';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { PanelErrorBoundary } from '@/shell/PanelErrorBoundary';
-import { CollabCursors, CollabGhosts, CollabSelectionRings } from '@/shell/Collab';
 import { useCollabMode } from '@/shared/hooks/useCollabMode';
 import { useCollabPresence } from '@/shared/hooks/useCollabPresence';
 import { useTranslation } from '@/i18n';
@@ -42,6 +41,18 @@ const IsometricPreview = lazyWithRetry(() =>
 // Lazy load mobile toolbar (only used on mobile)
 const MobileGridToolbar = lazyWithRetry(() =>
   import('@/shell/Mobile').then(namedExport('MobileGridToolbar'))
+);
+
+// Collab overlays pull the Liveblocks client; collaboration is opt-in, so load
+// them only when a session is active instead of in the eager Grid bundle.
+const CollabCursors = lazyWithRetry(() =>
+  import('@/shell/Collab/CollabCursors').then(namedExport('CollabCursors'))
+);
+const CollabGhosts = lazyWithRetry(() =>
+  import('@/shell/Collab/CollabGhosts').then(namedExport('CollabGhosts'))
+);
+const CollabSelectionRings = lazyWithRetry(() =>
+  import('@/shell/Collab/CollabSelectionRings').then(namedExport('CollabSelectionRings'))
 );
 
 /**
@@ -370,12 +381,15 @@ export function Grid({ shouldShowDrawTutorial = false }: GridProps) {
                     onStartResize={startResize}
                   />
                   <Overlay cellSize={cellSize} gap={gap} />
-                  {/* Collaborative selection rings - shows bins selected by other users */}
-                  {isCollaborative && <CollabSelectionRings />}
-                  {/* Collaborative ghosts overlay - shows other users' operations */}
-                  {isCollaborative && <CollabGhosts />}
-                  {/* Collaborative cursors overlay - shows other users' cursors */}
-                  {isCollaborative && <CollabCursors />}
+                  {/* Collaborative overlays — selection rings, operation ghosts, and
+                      remote cursors. Lazy-loaded with the Liveblocks client. */}
+                  {isCollaborative && (
+                    <Suspense fallback={null}>
+                      <CollabSelectionRings />
+                      <CollabGhosts />
+                      <CollabCursors />
+                    </Suspense>
+                  )}
 
                   {/* Empty state overlay */}
                   {isEmpty &&

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -16,7 +16,11 @@ export { useGridTemplate } from './useGridTemplate';
 export type { GridTemplateState, UseGridTemplateOptions } from './useGridTemplate';
 export { useDrawerSettings } from './useDrawerSettings';
 export type { UseDrawerSettingsReturn } from './useDrawerSettings';
-export { useBinGeometry, createBinGeometry } from './useBinGeometry';
+// useBinGeometry / createBinGeometry import the full `three` namespace and are
+// only used inside the lazy IsometricPreview 3D subtree (via deep imports). Not
+// re-exported here: this barrel is eagerly imported (layout-library → App), so a
+// re-export would pull three core onto first paint. Deep-import them at the 3D
+// call sites instead.
 export { useLayoutSwitcher } from './useLayoutSwitcher';
 export { useSelectionActions } from './useSelectionActions';
 export { useAlignBins } from './useAlignBins';
@@ -47,5 +51,7 @@ export { useCollabMode, getCollabMode } from './useCollabMode';
 export type { CollabModeState } from './useCollabMode';
 export { useCollabPresence } from './useCollabPresence';
 export type { CollabPresenceActions } from './useCollabPresence';
-export { useCollabSync } from './useCollabSync';
-export { useCollabLayout, useCollabLayoutSelector } from './useCollabLayout';
+// useCollabSync / useCollabLayout import the Liveblocks client (@/liveblocks.config)
+// at module load. This barrel is statically imported by eager code (layout-library
+// → App), so re-exporting them pulled the ~63 kB Liveblocks chunk onto first paint.
+// They're only used inside the lazy CollabProvider subtree — deep-import them there.

--- a/src/shell/Collab/ParticipantsPanel/ParticipantsPanel.tsx
+++ b/src/shell/Collab/ParticipantsPanel/ParticipantsPanel.tsx
@@ -1,0 +1,29 @@
+import { usePresence } from '@/shared/hooks/usePresence';
+import { useCollabMode } from '@/shared/hooks/useCollabMode';
+import { useTranslation } from '@/i18n';
+import { PresenceAvatarList } from '@/shell/Collab/PresenceAvatarList';
+
+/**
+ * Participants panel content that safely calls usePresence().
+ *
+ * Lives in its own module (not inline in MobileLayout) so it can be lazy-loaded:
+ * usePresence + PresenceAvatarList pull the Liveblocks client, and collaboration
+ * is opt-in. Only mounted when in collaborative mode (inside RoomProvider).
+ */
+export function ParticipantsPanel() {
+  const t = useTranslation();
+  const { isCollaborative } = useCollabMode();
+  const { participants } = usePresence();
+
+  // Safety check - should not reach here if not collaborative,
+  // but guard just in case
+  if (!isCollaborative) {
+    return (
+      <div className="px-4 py-8 text-center text-content-secondary text-sm">
+        {t('layout.collaborativeEditingIsNotActive')}
+      </div>
+    );
+  }
+
+  return <PresenceAvatarList participants={participants} className="px-2" />;
+}

--- a/src/shell/Collab/ParticipantsPanel/index.ts
+++ b/src/shell/Collab/ParticipantsPanel/index.ts
@@ -1,0 +1,1 @@
+export * from './ParticipantsPanel';

--- a/src/shell/Header/Header.tsx
+++ b/src/shell/Header/Header.tsx
@@ -13,7 +13,6 @@ import { ShareButton } from '@/features/cloud-share/components/ShareButton';
 import { ShareModal } from '@/features/cloud-share/components/ShareModal';
 import { ToolSwitcher } from '@/shared/components/ToolSwitcher';
 import { LayoutQuickSwitch } from '@/features/layout-library';
-import { PresenceAvatars } from '../Collab';
 import { HeaderSupportLinks } from '@/shared/components/HeaderSupportLinks';
 import { useTranslation } from '@/i18n';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
@@ -29,6 +28,12 @@ const LayoutManagerModal = lazyWithRetry(() =>
 );
 const PrintModal = lazyWithRetry(() =>
   import('@/features/print-export/components/PrintModal').then(namedExport('PrintModal'))
+);
+// Presence avatars pull the Liveblocks client. Collaboration is opt-in (off by
+// default), so keep it out of the eager Header bundle — load only when a collab
+// session is actually active.
+const PresenceAvatars = lazyWithRetry(() =>
+  import('../Collab/PresenceAvatars').then(namedExport('PresenceAvatars'))
 );
 
 interface HeaderProps {
@@ -259,7 +264,11 @@ export function Header({ saveStatus }: HeaderProps) {
         {isCollabEnabled && <div className="w-px h-6 bg-stroke-subtle mx-2" />}
         <ShareButton />
         {/* Only render PresenceAvatars when actually in collab mode (inside RoomProvider) */}
-        {isCollabEnabled && isCollaborative && <PresenceAvatars className="ml-2" />}
+        {isCollabEnabled && isCollaborative && (
+          <Suspense fallback={null}>
+            <PresenceAvatars className="ml-2" />
+          </Suspense>
+        )}
         {isCollabEnabled && <div className="w-px h-6 bg-stroke-subtle mx-2" />}
 
         {/* Divider before external links (only when collab is disabled) */}

--- a/src/shell/Mobile/MobileHeader/MobileHeader.tsx
+++ b/src/shell/Mobile/MobileHeader/MobileHeader.tsx
@@ -1,16 +1,21 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, Suspense } from 'react';
 import { useLayoutStore } from '@/core/store/layout';
 import { useMobileStore } from '@/core/store';
 import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
 import { useMutations } from '@/shared/contexts';
 import { useCollabMode } from '@/shared/hooks/useCollabMode';
 import { CONSTRAINTS } from '@/core/constants';
-import { PresenceAvatars } from '@/shell/Collab';
+import { lazyWithRetry, namedExport } from '@/shared/utils/lazyWithRetry';
 import type { SaveStatus } from '@/shared/hooks';
 import { Button, IconButton } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import { ToolSwitcher } from '@/shared/components/ToolSwitcher';
+
+// Lazy: presence avatars pull the Liveblocks client; collab is opt-in.
+const PresenceAvatars = lazyWithRetry(() =>
+  import('@/shell/Collab/PresenceAvatars').then(namedExport('PresenceAvatars'))
+);
 
 interface MobileHeaderProps {
   onMenuClick: () => void;
@@ -151,7 +156,11 @@ export function MobileHeader({ onMenuClick, saveStatus }: MobileHeaderProps) {
         {/* Right: Save status + Undo/Redo + Settings */}
         <div className="flex items-center gap-1 flex-shrink-0">
           {/* Presence indicator (only when actually in collaborative mode, inside RoomProvider) */}
-          {isCollaborative && <PresenceAvatars />}
+          {isCollaborative && (
+            <Suspense fallback={null}>
+              <PresenceAvatars />
+            </Suspense>
+          )}
 
           {/* Save status indicator (icon only on mobile) */}
           {saveStatus !== 'idle' && (

--- a/src/shell/layouts/MobileLayout.tsx
+++ b/src/shell/layouts/MobileLayout.tsx
@@ -20,6 +20,8 @@ import {
   MobileLayoutsPanel,
   BinContextMenuWrapper,
 } from '@/shell/Mobile';
+import type { SaveStatus } from '@/shared/hooks';
+import { useOnboarding } from '@/features/onboarding';
 
 // Lazy load design-linking dialogs
 const DesignLinkingDialogs = lazyWithRetry(() =>
@@ -31,9 +33,6 @@ const DesignLinkingDialogs = lazyWithRetry(() =>
 const ParticipantsPanel = lazyWithRetry(() =>
   import('@/shell/Collab/ParticipantsPanel').then(namedExport('ParticipantsPanel'))
 );
-import type { SaveStatus } from '@/shared/hooks';
-import { useOnboarding } from '@/features/onboarding';
-
 // Lazy load mobile help modal (with retry for chunk load failures)
 const MobileHelpModal = lazyWithRetry(() =>
   import('@/shell/Mobile/MobileHelpModal').then(namedExport('MobileHelpModal'))

--- a/src/shell/layouts/MobileLayout.tsx
+++ b/src/shell/layouts/MobileLayout.tsx
@@ -20,7 +20,6 @@ import {
   MobileLayoutsPanel,
   BinContextMenuWrapper,
 } from '@/shell/Mobile';
-import { PresenceAvatarList } from '@/shell/Collab';
 
 // Lazy load design-linking dialogs
 const DesignLinkingDialogs = lazyWithRetry(() =>
@@ -28,10 +27,11 @@ const DesignLinkingDialogs = lazyWithRetry(() =>
     namedExport('DesignLinkingDialogs')
   )
 );
-import { usePresence } from '@/shared/hooks/usePresence';
-import { useCollabMode } from '@/shared/hooks/useCollabMode';
+// Participants panel pulls the Liveblocks client (usePresence); collab is opt-in.
+const ParticipantsPanel = lazyWithRetry(() =>
+  import('@/shell/Collab/ParticipantsPanel').then(namedExport('ParticipantsPanel'))
+);
 import type { SaveStatus } from '@/shared/hooks';
-import { useTranslation } from '@/i18n';
 import { useOnboarding } from '@/features/onboarding';
 
 // Lazy load mobile help modal (with retry for chunk load failures)
@@ -112,28 +112,6 @@ export function MobileLayout({
 }
 
 /**
- * Participants panel content that safely calls usePresence().
- * Only mounted when in collaborative mode (inside RoomProvider).
- */
-function ParticipantsPanel() {
-  const t = useTranslation();
-  const { isCollaborative } = useCollabMode();
-  const { participants } = usePresence();
-
-  // Safety check - should not reach here if not collaborative,
-  // but guard just in case
-  if (!isCollaborative) {
-    return (
-      <div className="px-4 py-8 text-center text-content-secondary text-sm">
-        {t('layout.collaborativeEditingIsNotActive')}
-      </div>
-    );
-  }
-
-  return <PresenceAvatarList participants={participants} className="px-2" />;
-}
-
-/**
  * Mobile panel content based on active panel type.
  */
 function MobilePanelContent({ panel }: { panel: string }) {
@@ -152,7 +130,11 @@ function MobilePanelContent({ panel }: { panel: string }) {
       case 'layouts':
         return <MobileLayoutsPanel />;
       case 'participants':
-        return <ParticipantsPanel />;
+        return (
+          <Suspense fallback={null}>
+            <ParticipantsPanel />
+          </Suspense>
+        );
       default:
         return null;
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -213,43 +213,56 @@ export default defineConfig({
           // Default Vite chunk naming
           return 'assets/[name]-[hash].js';
         },
-        // Use function-based manualChunks for more reliable splitting
-        manualChunks(id) {
-          // Pin foundational constants/types into a dedicated leaf chunk that
-          // imports nothing from other app chunks. Many modules read these at
-          // module-init time (Zod schemas, store creators, etc); keeping them
-          // in a leaf chunk guarantees they are fully evaluated before any
-          // dependent chunk runs, eliminating chunk-level static-import cycles
-          // that would otherwise leave imported bindings undefined. See #1466.
-          if (
-            id.endsWith('/src/core/constants.ts') ||
-            id.endsWith('/src/core/types.ts') ||
-            id.includes('packages/branded-types/src/')
-          ) {
-            return 'core-foundation';
-          }
-          // Three.js ecosystem - only loaded when 3D preview is used
-          if (id.includes('node_modules/three/')) {
-            return 'three';
-          }
-          if (id.includes('node_modules/@react-three/')) {
-            return 'react-three';
-          }
-          // Liveblocks - only loaded when collaborative editing is used (Labs feature)
-          if (id.includes('node_modules/@liveblocks/')) {
-            return 'liveblocks';
-          }
-          // State management
-          if (id.includes('node_modules/zustand/') || id.includes('node_modules/immer/')) {
-            return 'state';
-          }
-          // Core React runtime - split out for better caching
-          if (id.includes('node_modules/react-dom/') || id.includes('node_modules/react/')) {
-            return 'react-vendor';
-          }
-          // Note: posthog-js is dynamically imported in src/shared/analytics/posthog.ts
-          // so it automatically gets its own chunk without needing manualChunks config
+        // Rolldown's native chunking API. The Rollup-compat `manualChunks`
+        // function only hints at names — Rolldown still co-located the shared
+        // eager react-dom with the lazy three.js/drei stack, forcing the whole
+        // ~360 kB 3D chunk onto first paint. `advancedChunks` groups are honored
+        // deterministically: react-vendor (eager) is split from the 3D rendering
+        // libs (lazy), and three core is its own lazy chunk. Higher priority wins.
+        advancedChunks: {
+          groups: [
+            // Pin foundational constants/types into a leaf chunk that imports
+            // nothing from other app chunks. Many modules read these at module-init
+            // time (Zod schemas, store creators), so a leaf chunk guarantees they
+            // evaluate before dependents — avoiding chunk-level static-import cycles
+            // that leave imported bindings undefined. See #1466.
+            {
+              name: 'core-foundation',
+              priority: 100,
+              test: (id: string) =>
+                id.endsWith('/src/core/constants.ts') ||
+                id.endsWith('/src/core/types.ts') ||
+                id.includes('packages/branded-types/src/'),
+            },
+            // Core React runtime — eager, shared by every UI chunk. HIGHEST vendor
+            // priority so the shared react-dom is pinned here and NOT absorbed into
+            // the lazy 3D chunk (which would force the whole 3D stack onto first
+            // paint, since every UI chunk needs react-dom).
+            {
+              name: 'react-vendor',
+              priority: 95,
+              test: /[\\/]node_modules[\\/](?:react|react-dom|scheduler|use-sync-external-store|react-reconciler)[\\/]/,
+            },
+            // State management — eager. Priority ABOVE three-render because drei
+            // also depends on zustand; without this, the shared zustand module gets
+            // placed in the 3D chunk and the eager app stores then import it from
+            // there, dragging three-render onto first paint.
+            { name: 'state', priority: 92, test: /[\\/]node_modules[\\/](?:zustand|immer)[\\/]/ },
+            // 3D stack (three core + fiber/drei/troika/three-stdlib) — only loaded
+            // when a 3D preview mounts. three core and the renderers are always
+            // loaded together, so keeping them in ONE chunk avoids duplicating
+            // three's modules across two lazy chunks.
+            {
+              name: 'three-render',
+              priority: 90,
+              test: /[\\/]node_modules[\\/](?:three[\\/]|@react-three[\\/]|three-stdlib[\\/]|troika-[^\\/]+[\\/]|bidi-js[\\/]|webgl-sdf-generator[\\/]|maath[\\/]|meshline[\\/]|camera-controls[\\/]|stats\.js[\\/]|stats-gl[\\/]|suspend-react[\\/]|its-fine[\\/]|react-use-measure[\\/]|tunnel-rat[\\/]|@use-gesture[\\/]|potpack[\\/])/,
+            },
+            // Liveblocks — only loaded when collaborative editing is active (Labs).
+            { name: 'liveblocks', priority: 80, test: /[\\/]node_modules[\\/]@liveblocks[\\/]/ },
+          ],
         },
+        // Note: posthog-js is dynamically imported in src/shared/analytics/posthog.ts
+        // so it automatically gets its own chunk without needing chunk config.
       },
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -217,8 +217,8 @@ export default defineConfig({
         // function only hints at names — Rolldown still co-located the shared
         // eager react-dom with the lazy three.js/drei stack, forcing the whole
         // ~360 kB 3D chunk onto first paint. `advancedChunks` groups are honored
-        // deterministically: react-vendor (eager) is split from the 3D rendering
-        // libs (lazy), and three core is its own lazy chunk. Higher priority wins.
+        // deterministically: react-vendor (eager) is split from the lazy 3D stack
+        // (three core + renderers, grouped together). Higher priority wins.
         advancedChunks: {
           groups: [
             // Pin foundational constants/types into a leaf chunk that imports


### PR DESCRIPTION
## What & why

The three.js + drei rendering stack (**358 KB gzip**), the Liveblocks collab client (**63 KB**), and the bin example gallery (**48 KB**) were all downloading on **first paint** for every user — despite each having a lazy boundary. They leaked into the eager critical path through barrel re-exports, a static `three` import in the offscreen thumbnail regenerator, and presence UI statically wired into the always-on Header/Grid.

**Eager initial JS: 904 → 353 KB gzip (−551 KB, −61%).**

## How

- **Barrel re-export leaks** — `@/features/bin-designer` and `@/shared/hooks` barrels (imported by eager App / sync flows / design-linking) re-exported heavy components/hooks, dragging three+drei+Liveblocks eager. Dropped the heavy re-exports; deep-imported the light symbols.
- **Deferred `three`** in `thumbnailRegenerator` via `await import('three')` (the fn is already async, runs on idle); made `cameraFraming` three-free.
- **Lazy-loaded the opt-in collab/presence UI** (`PresenceAvatars`, `CollabCursors/Ghosts/SelectionRings`, `ParticipantsPanel`) behind `Suspense` at its 4 always-on mount sites. Collab is off by default, so this ships zero Liveblocks to most users.
- **Chunking** — switched `manualChunks` → Rolldown `advancedChunks`. The Rollup-compat `manualChunks` *function* was being ignored for shared vendors, gluing react-dom + three + drei into one eager mega-chunk (every UI chunk imported it just to get react-dom). Priority-pinned groups now keep `react-vendor` / `state` eager and the 3D + Liveblocks stacks lazy. Key subtlety: **zustand must outrank `three-render`** (drei depends on zustand) or the shared module anchors the whole 3D chunk eager.
- **size-limit** — added an "Eager initial JS" budget (260 KB) to lock the win; bumped Total 1800 → 1900 KB to cover ~40 KB of finer-splitting overhead.

## Trade-off

Total JS rose ~40 KB (+2%, amortized/cached across the app lifetime) — the cost of finer code-splitting. The metric users actually feel (first-paint JS) dropped 61%.

## Verification

- ✅ typecheck, eslint (changed files), module-boundaries, component-structure
- ✅ 447 unit tests pass
- ✅ size-limit green — main **88 KB** (limit 190), eager-init **152 KB** (limit 260), total **1.84 MB** (limit 1.9)
- ✅ Runtime boot smoke (production build, headless): app mounts cleanly with **no chunk-init cycle**; `three-render` and `liveblocks` confirmed **absent from first paint** and lazy-load on demand (3D toggle pulls `three-render`)

## Note on localization

Investigated per a side request — locales are **not** a bundle lever: already lazy per-locale (only the active one ships), only 1–6 % of values match English, 1.4 % identical across all locales, and English isn't eagerly bundled.
