### PR TITLE
feat(bin-designer): show compartment grid at true bin proportions (fixes stepper overlap)

### DIFF
--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
@@ -141,6 +141,15 @@ describe('CompartmentEditor', () => {
     expect(screen.getByRole('application')).toBeInTheDocument();
   });
 
+  // The grid stacks rows with flex-col-reverse, so content that exceeds the
+  // aspect-ratio box overflows out the *top* — over the steppers above it.
+  // overflow-hidden must clip that spill.
+  it('clips the grid so it cannot overflow onto the controls above', () => {
+    useDesignerStore.setState({ params: TWO_BY_TWO });
+    render(<CompartmentEditor />);
+    expect(screen.getByRole('application')).toHaveClass('overflow-hidden');
+  });
+
   it('does not show 2D grid editor when grid is 1x1', () => {
     render(<CompartmentEditor />);
     expect(screen.queryByRole('application')).not.toBeInTheDocument();

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
@@ -150,6 +150,37 @@ describe('CompartmentEditor', () => {
     expect(screen.getByRole('application')).toHaveClass('overflow-hidden');
   });
 
+  // The grid mirrors the bin's true top-view proportions (no 0.5–2 clamp),
+  // scaled to fit a fixed envelope. The width cap is derived from the height
+  // budget (300px) times the true aspect, which keeps deep bins within budget.
+  it('renders a wide bin at its true proportions, capped by the width envelope', () => {
+    const WIDE = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 210,
+      depth: 42, // 5:1, well past the old 2x clamp
+      compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, rows: 2, cells: [0, 1, 2, 3] },
+    };
+    useDesignerStore.setState({ params: WIDE });
+    render(<CompartmentEditor />);
+    const grid = screen.getByRole('application');
+    expect(grid.style.aspectRatio).toBe('5 / 1');
+    expect(grid.style.maxWidth).toBe('360px'); // min(360, 300*5)
+  });
+
+  it('keeps a deep bin within the height envelope by capping its width', () => {
+    const DEEP = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 42,
+      depth: 210, // 1:5
+      compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, rows: 2, cells: [0, 1, 2, 3] },
+    };
+    useDesignerStore.setState({ params: DEEP });
+    render(<CompartmentEditor />);
+    const grid = screen.getByRole('application');
+    expect(grid.style.aspectRatio).toBe('0.2 / 1');
+    expect(grid.style.maxWidth).toBe('60px'); // min(360, 300*0.2)
+  });
+
   it('does not show 2D grid editor when grid is 1x1', () => {
     render(<CompartmentEditor />);
     expect(screen.queryByRole('application')).not.toBeInTheDocument();

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
@@ -629,7 +629,7 @@ export function CompartmentEditor() {
           </div>
           <div
             ref={gridRef}
-            className="relative mx-auto w-full select-none overflow-hidden rounded-lg border-2 border-stroke-subtle bg-surface-elevated p-2"
+            className="relative mr-auto w-full select-none overflow-hidden rounded-lg border-2 border-stroke-subtle bg-surface-elevated p-2"
             style={{ aspectRatio, maxWidth: `${gridMaxWidthPx}px` }}
             role="application"
             aria-label={`Compartment grid, ${cols} columns by ${rows} rows`}

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
@@ -47,6 +47,10 @@ import { rowKeyOf } from './useDividerTiltSubsection';
 
 const EMPTY_HIGHLIGHT_SET: ReadonlySet<number> = new Set();
 
+// Bounding box the 2D grid is scaled to fit, at the bin's true proportions.
+const GRID_ENVELOPE_W_PX = 360;
+const GRID_ENVELOPE_H_PX = 300;
+
 export function CompartmentEditor() {
   const t = useTranslation();
   const { isMobile } = useResponsive();
@@ -443,8 +447,12 @@ export function CompartmentEditor() {
     return t('binDesigner.compartmentEditor.dragOrClick');
   }, [isDragging, selection.size, selectionAction, hoveredIsSplittable, t]);
 
-  // Compute aspect ratio from bin dimensions, clamped to avoid extreme shapes
-  const aspectRatio = depth > 0 ? Math.min(2, Math.max(0.5, width / depth)) : 1;
+  // Render the grid at the bin's true top-view proportions, scaled to fit a
+  // fixed envelope. Capping width to `MAX_H * aspect` keeps the derived height
+  // within budget while preserving the real shape — so deep bins stay legible
+  // instead of ballooning, and the box never overflows onto the controls above.
+  const aspectRatio = depth > 0 ? width / depth : 1;
+  const gridMaxWidthPx = Math.min(GRID_ENVELOPE_W_PX, GRID_ENVELOPE_H_PX * aspectRatio);
 
   // Build wall thickness options for SnappingSlider
   const thicknessOptions: SnappingSliderOption[] = useMemo(
@@ -621,8 +629,8 @@ export function CompartmentEditor() {
           </div>
           <div
             ref={gridRef}
-            className="relative mx-auto max-w-[360px] select-none overflow-hidden rounded-lg border-2 border-stroke-subtle bg-surface-elevated p-2"
-            style={{ aspectRatio }}
+            className="relative mx-auto w-full select-none overflow-hidden rounded-lg border-2 border-stroke-subtle bg-surface-elevated p-2"
+            style={{ aspectRatio, maxWidth: `${gridMaxWidthPx}px` }}
             role="application"
             aria-label={`Compartment grid, ${cols} columns by ${rows} rows`}
             aria-describedby="compartment-grid-instructions"

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
@@ -621,7 +621,7 @@ export function CompartmentEditor() {
           </div>
           <div
             ref={gridRef}
-            className="relative mx-auto max-w-[360px] select-none rounded-lg border-2 border-stroke-subtle bg-surface-elevated p-2"
+            className="relative mx-auto max-w-[360px] select-none overflow-hidden rounded-lg border-2 border-stroke-subtle bg-surface-elevated p-2"
             style={{ aspectRatio }}
             role="application"
             aria-label={`Compartment grid, ${cols} columns by ${rows} rows`}
@@ -652,7 +652,7 @@ export function CompartmentEditor() {
                 return (
                   <div
                     key={dataRow}
-                    className="grid flex-1"
+                    className="grid min-h-0 min-w-0 flex-1"
                     style={{
                       gridTemplateColumns: `repeat(${cols}, 1fr)`,
                     }}

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditorParts.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditorParts.tsx
@@ -134,7 +134,7 @@ export function GridCell({
 
   return (
     <div
-      className="relative touch-manipulation min-w-[28px] min-h-[28px]"
+      className="relative touch-manipulation min-w-0 min-h-0"
       role="button"
       tabIndex={0}
       aria-label={cellLabel}


### PR DESCRIPTION
## Problem

In the bin designer, the compartment 2D grid could sometimes overlap the columns/rows stepper controls above it. While investigating, two related UX issues surfaced in how the grid is sized.

## Root cause of the overlap

The grid stacks its rows with `flex-col-reverse` so data-row 0 maps to the front of the bin (bottom of the UI), matching the 3D view. The container's height was fixed by a clamped `aspectRatio`, and each cell carried a hard `min-h-[28px]` floor. For a wide bin (aspect clamped to ~2 → box only ~180px tall) with many rows, content exceeded the box — and because `flex-col-reverse` stacks *upward*, the spill escaped out the **top**, onto the steppers.

## What this PR does

**1. Stops the overlap** (commit 1)
- Remove the per-cell `min-w/min-h` floor (→ `min-w-0 min-h-0`) and add `min-h-0 min-w-0` on the flex rows so cells shrink to fit instead of forcing overflow.
- Add `overflow-hidden` on the grid container as a clip guard.

**2. Better UX: show the bin's *true* proportions** (commit 2)
- The old aspect ratio was clamped to `0.5–2`, which (a) lied about the bin's real shape — a 5:1 tray looked identical to a 2:1 — and (b) let deep bins balloon to ~720px tall, dominating the panel.
- Replace it with the true `width/depth` proportion scaled to fit a fixed `360×300` envelope. Capping the box width to `envelopeHeight × aspect` keeps the derived height within budget while preserving the real shape. The grid is now always fully visible, honestly proportioned, responsive, and structurally unable to overflow onto the controls above.

## Tests

- Added regression tests: overflow-clip guard, true (unclamped) aspect ratio for a wide bin, and width-capping that keeps a deep bin within the height envelope.
- `CompartmentEditor.test.tsx` (19) and `CompartmentEditorParts.test.tsx` (6) pass; typecheck + lint clean.