### PR TITLE
fix(stepper): stretch solo steppers to full width

### DIFF
--- a/src/features/bin-designer/components/CompartmentEditor/DividerHeightControl.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/DividerHeightControl.tsx
@@ -85,6 +85,7 @@ export function DividerHeightControl() {
         step={1}
         size={stepperSize}
         commitMode="deferred"
+        fullWidth
         aria-label={t('binDesigner.dividerHeight')}
       />
     </div>

--- a/src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.tsx
+++ b/src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.tsx
@@ -184,6 +184,7 @@ export function SlotConfigurator() {
           max={DESIGNER_CONSTRAINTS.MAX_SLOT_PITCH}
           step={DESIGNER_CONSTRAINTS.SLOT_PITCH_STEP}
           size="md"
+          fullWidth
           aria-label={t('binDesigner.slotSpacing')}
         />
       </div>
@@ -230,6 +231,7 @@ export function SlotConfigurator() {
           max={maxHeightRounded}
           step={1}
           size="md"
+          fullWidth
           aria-label={t('binDesigner.dividerHeight')}
         />
       </div>

--- a/src/features/bin-designer/components/panel/ScoopSection/ScoopSection.tsx
+++ b/src/features/bin-designer/components/panel/ScoopSection/ScoopSection.tsx
@@ -53,6 +53,7 @@ export function ScoopSection() {
             max={DESIGNER_CONSTRAINTS.MAX_SCOOP_RADIUS}
             step={DESIGNER_CONSTRAINTS.SCOOP_RADIUS_STEP}
             size="md"
+            fullWidth
             aria-label={t('binDesigner.scoop.radiusAria')}
           />
         )}

--- a/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
+++ b/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
@@ -124,6 +124,7 @@ export function MobileSettingsPanel() {
             min={1}
             max={CONSTRAINTS.GRID_MAX}
             size="lg"
+            fullWidth
             aria-label={t('sidebar.drawerHeightAria')}
             displayValue={`${drawer.height}u`}
           />


### PR DESCRIPTION
## What

Solo stepper controls that sit alone in a full-width section were rendering as `inline-flex` (hugging the left edge), leaving dead space to their right. Add the `fullWidth` prop to those 5 steppers so the number field absorbs the slack while the +/− buttons keep their fixed width.

This matches the existing precedent — `DimensionsSection`'s height stepper already uses `fullWidth`; every other solo stepper had missed it.

## Changes

| File | Control |
| ---- | ------- |
| `MobileSettingsPanel.tsx` | Drawer height |
| `SlotConfigurator.tsx` | Slot spacing |
| `SlotConfigurator.tsx` | Divider piece height |
| `DividerHeightControl.tsx` | Compartment divider height |
| `ScoopSection.tsx` | Scoop radius |

## Scope notes

Intentionally left alone:
- Paired `flex-1` width/depth rows — split a row two-up, stay filled.
- Compact `grid-cols-3` triplets (Sidebar grid size, Defaults tab) — `size="sm"`, negligible slack.
- `justify-between` rows (cutout array/fit, divider tilt) — label fills the left, stepper sits flush right.

## Risk

Purely presentational. `fullWidth` only flips the container from `inline-flex` to `flex w-full`; no logic or layout math elsewhere changes. Typecheck passes.