### PR TITLE
fix(i18n): allowlist nb 'plate' singular

### DIFF
--- a/scripts/i18n-values-allowlist.json
+++ b/scripts/i18n-values-allowlist.json
@@ -2,6 +2,7 @@
   "maxShortValueLength": 3,
   "keys": [
     "baseplate.stackPrint.badge",
+    "baseplate.stackPrint.plates.one",
     "settings.search.inTab",
     "binDesigner.projectionPerspective",
     "baseplate.projectionPerspective",


### PR DESCRIPTION
The squash-merge of #2149 introduced `baseplate.stackPrint.plates.one` whose Norwegian value "{count} plate" is identical to English (Norwegian for 'plate' is the same word). `check:i18n:values` flags it, turning main's Quality check red. Allowlist the key (legitimate same-spelling cognate), matching how `baseplate.stackPrint.badge` is already allowlisted.

Root cause: #2149's pluralization commit was made with `--no-verify`, skipping the pre-commit i18n checks that would have caught this before CI.