### PR TITLE
chore(hooks): remove per-edit vitest PostToolUse hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,11 +6,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/post-edit-test.sh",
-            "timeout": 60
-          },
-          {
-            "type": "command",
             "command": ".claude/hooks/use-shallow-check.sh",
             "timeout": 10
           },


### PR DESCRIPTION
## What

Removes the `post-edit-test.sh` entry from the `PostToolUse` (Edit|Write) hooks in `.claude/settings.json`.

## Why

Single-file Vitest cold-start in this repo exceeds the hook's 60s timeout, so **every** `.ts`/`.tsx` edit blocked ~60s waiting on a test run that never completed (killed at the timeout). The work is redundant anyway — affected tests already run at pre-commit and the full suite runs in CI.

The other four PostToolUse hooks (use-shallow, effect-cleanup, auto-format, geometry-sanity) are retained — all run in <2s.