### PR TITLE
fix(baseplate): fix stack preview dark background + letterboxing

### DIFF
--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
@@ -195,7 +195,12 @@ export function BaseplatePreview({
       ? Math.max(baseMaxOrbitDistance, stackBounds.heightMm * 4, stackBounds.widthMm * 3)
       : baseMaxOrbitDistance;
 
-  const hasAnyMesh = isSplit ? hasSplitMeshes : hasMesh;
+  // In stack mode the canvas renders StackedBaseplateMeshes instead of
+  // BaseplateMesh/SplitBaseplateMeshes. Gate visibility on stackBounds so
+  // the canvas only becomes opaque once the tower preview has been built and
+  // its dimensions reported — otherwise the gradient background shows through
+  // while StackedBaseplateMeshes is still constructing or returns null.
+  const hasAnyMesh = stackEnabled ? stackBounds !== null : isSplit ? hasSplitMeshes : hasMesh;
   const hasError = wasmStatus === 'error' || generationStatus === 'error';
   const isWasmLoading = !hasError && wasmStatus !== 'ready';
   const isGenerating = generationStatus === 'generating';
@@ -289,6 +294,8 @@ export function BaseplatePreview({
                   paddingRight={paddingRight}
                   paddingFront={paddingFront}
                   paddingBack={paddingBack}
+                  stackEnabled={stackEnabled}
+                  stackBounds={stackBounds}
                 />
 
                 {stackPrint && stackEnabled ? (

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
@@ -8,7 +8,7 @@
  * The slab extends asymmetrically when padding differs per side.
  */
 
-import { useRef, useCallback, useMemo, useState } from 'react';
+import { useRef, useCallback, useEffect, useMemo, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import { useShallow } from 'zustand/react/shallow';
@@ -170,6 +170,10 @@ export function BaseplatePreview({
     (b: { widthMm: number; depthMm: number; heightMm: number }) => setStackBounds(b),
     []
   );
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing opacity gate to stackEnabled toggle; stale bounds cause a dark-flash on re-entry
+    if (!stackEnabled) setStackBounds(null);
+  }, [stackEnabled]);
   const targetZ = stackEnabled && stackBounds ? stackBounds.heightMm / 2 : totalH / 2;
 
   const baseMaxOrbitDistance = useMemo(

--- a/src/features/baseplate/components/BaseplatePreview/CameraController.test.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/CameraController.test.tsx
@@ -70,7 +70,7 @@ vi.mock('@react-three/fiber', () => ({
   useThree: () => ({
     camera: mocks.staleCamera,
     invalidate: vi.fn(),
-    size: { height: 600 },
+    size: { width: 800, height: 600 },
     get: () => ({ camera: mocks.liveCamera }),
   }),
   useFrame: vi.fn(),
@@ -78,20 +78,29 @@ vi.mock('@react-three/fiber', () => ({
 
 const { CameraController } = await import('./CameraController');
 
-function renderController() {
+function renderController(
+  overrides: Partial<{
+    width: number;
+    depth: number;
+    stackEnabled: boolean;
+    stackBounds: { widthMm: number; depthMm: number; heightMm: number } | null;
+  }> = {}
+) {
   const controlsRef: RefObject<OrbitControlsType | null> = createRef<OrbitControlsType>();
   const invalidateRef: RefObject<(() => void) | null> = createRef<() => void>();
   return render(
     <CameraController
       controlsRef={controlsRef}
       invalidateRef={invalidateRef}
-      width={5}
-      depth={5}
+      width={overrides.width ?? 5}
+      depth={overrides.depth ?? 5}
       gridUnitMm={42}
       paddingLeft={0}
       paddingRight={0}
       paddingFront={0}
       paddingBack={0}
+      stackEnabled={overrides.stackEnabled}
+      stackBounds={overrides.stackBounds}
     />
   );
 }
@@ -120,5 +129,18 @@ describe('CameraController', () => {
 
     expect(mocks.liveCamera.updateProjectionMatrix).toHaveBeenCalled();
     expect(mocks.staleCamera.updateProjectionMatrix).not.toHaveBeenCalled();
+  });
+
+  it('accepts stackEnabled and stackBounds props without throwing', () => {
+    expect(() =>
+      renderController({
+        stackEnabled: true,
+        stackBounds: { widthMm: 200, depthMm: 200, heightMm: 80 },
+      })
+    ).not.toThrow();
+  });
+
+  it('renders without stack props (backward compat defaults)', () => {
+    expect(() => renderController()).not.toThrow();
   });
 });

--- a/src/features/baseplate/components/BaseplatePreview/CameraController.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/CameraController.tsx
@@ -10,6 +10,7 @@ import {
   CAMERA_PRESETS,
   easeOutCubic,
   calculateIdealDistance,
+  calculateStackIdealDistance,
   calculateMaxOrbitDistance,
   calculateFarPlane,
 } from './cameraUtils';
@@ -40,6 +41,8 @@ export function CameraController({
   paddingRight,
   paddingFront,
   paddingBack,
+  stackEnabled = false,
+  stackBounds = null,
 }: {
   controlsRef: RefObject<OrbitControlsType | null>;
   invalidateRef: RefObject<(() => void) | null>;
@@ -50,6 +53,8 @@ export function CameraController({
   paddingRight: number;
   paddingFront: number;
   paddingBack: number;
+  stackEnabled?: boolean;
+  stackBounds?: { widthMm: number; depthMm: number; heightMm: number } | null;
 }) {
   const { camera, invalidate, size, get } = useThree();
   const initializedRef = useRef(false);
@@ -60,22 +65,43 @@ export function CameraController({
   }, [invalidate, invalidateRef]);
 
   const fov = 45;
-  const totalH = GRIDFINITY_SPEC.SOCKET_HEIGHT;
+  const aspect = size.width > 0 && size.height > 0 ? size.width / size.height : 1;
+
+  const stackActive = stackEnabled && stackBounds !== null && (stackBounds?.heightMm ?? 0) > 0;
+  const totalH = stackActive && stackBounds ? stackBounds.heightMm : GRIDFINITY_SPEC.SOCKET_HEIGHT;
   const binCenter = useMemo(() => new THREE.Vector3(0, 0, totalH / 2), [totalH]);
-  const idealDistance = useMemo(
-    () =>
-      calculateIdealDistance(
-        width,
-        depth,
-        gridUnitMm,
-        paddingLeft,
-        paddingRight,
-        paddingFront,
-        paddingBack,
+  const idealDistance = useMemo(() => {
+    if (stackActive && stackBounds) {
+      return calculateStackIdealDistance(
+        stackBounds.widthMm,
+        stackBounds.depthMm,
+        stackBounds.heightMm,
         fov
-      ),
-    [width, depth, gridUnitMm, paddingLeft, paddingRight, paddingFront, paddingBack]
-  );
+      );
+    }
+    return calculateIdealDistance(
+      width,
+      depth,
+      gridUnitMm,
+      paddingLeft,
+      paddingRight,
+      paddingFront,
+      paddingBack,
+      fov,
+      aspect
+    );
+  }, [
+    width,
+    depth,
+    gridUnitMm,
+    paddingLeft,
+    paddingRight,
+    paddingFront,
+    paddingBack,
+    aspect,
+    stackActive,
+    stackBounds,
+  ]);
 
   // Keep the far plane ahead of the user's zoom-out range. Without this,
   // the geometry's farthest corner clips off-screen at maximum zoom for

--- a/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.test.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.test.tsx
@@ -25,7 +25,18 @@ vi.mock('@/core/store/settings', () => ({
     selector({ settings: { printSettings: { nozzleSizeMm: 0.4, maxPrintHeightMm: 250 } } }),
 }));
 
-const pageState = { tiling: null, generation: { mesh: null }, pieceMeshes: [] };
+const pageState: {
+  tiling: null;
+  generation: {
+    mesh: {
+      vertices: Float32Array | null;
+      normals: Float32Array | null;
+      indices: Uint32Array | null;
+      edgeVertices: Float32Array | null;
+    } | null;
+  };
+  pieceMeshes: unknown[];
+} = { tiling: null, generation: { mesh: null }, pieceMeshes: [] };
 vi.mock('../../store/baseplatePageStore', () => ({
   useBaseplatePageStore: (selector: (s: unknown) => unknown) => selector(pageState),
 }));
@@ -40,5 +51,27 @@ describe('StackedBaseplateMeshes', () => {
       <StackedBaseplateMeshes stack={stack} color="#ffffff" separationMm={0} />
     );
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('calls onBounds when mesh has null normals (defensive toMeshArrays)', () => {
+    // Direct-mesh previews always carry normals from MeshData, but the type
+    // allows null. toMeshArrays must not reject on null normals — otherwise
+    // towers stays empty, onBounds never fires, and the canvas stays dark.
+    pageState.generation.mesh = {
+      vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      normals: null,
+      indices: new Uint32Array([0, 1, 2]),
+      edgeVertices: new Float32Array(0),
+    };
+    const onBounds = vi.fn();
+    render(
+      <StackedBaseplateMeshes stack={stack} color="#ffffff" separationMm={0} onBounds={onBounds} />
+    );
+    // Stack is built (1 copy) → onBounds fires with valid dimensions.
+    expect(onBounds).toHaveBeenCalledWith(
+      expect.objectContaining({ widthMm: expect.any(Number), heightMm: expect.any(Number) })
+    );
+    // Restore
+    pageState.generation.mesh = null;
   });
 });

--- a/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.tsx
@@ -39,10 +39,12 @@ function toMeshArrays(mesh: {
   indices: Uint32Array | null;
   edgeVertices: Float32Array | null;
 }): StackMeshArrays | null {
-  if (!mesh.vertices || !mesh.normals || !mesh.indices) return null;
+  if (!mesh.vertices || !mesh.indices) return null;
   return {
     vertices: mesh.vertices,
-    normals: mesh.normals,
+    // null normals → empty array; stack transform is a no-op on zero elements,
+    // and useMeshGeometry falls back to flat shading when normals.length === 0.
+    normals: mesh.normals ?? new Float32Array(0),
     indices: mesh.indices,
     edgeVertices: mesh.edgeVertices ?? new Float32Array(0),
   };

--- a/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.tsx
@@ -23,6 +23,7 @@ import { buildStackPreviewMeshes, type StackPreviewTower } from '../../utils/sta
 import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 
 const EMPTY_GEO = { vertices: null, normals: null, indices: null, edgeVertices: null } as const;
+const EMPTY_F32 = new Float32Array(0);
 
 interface StackedBaseplateMeshesProps {
   readonly stack: StackPrintParams;
@@ -44,9 +45,9 @@ function toMeshArrays(mesh: {
     vertices: mesh.vertices,
     // null normals → empty array; stack transform is a no-op on zero elements,
     // and useMeshGeometry falls back to flat shading when normals.length === 0.
-    normals: mesh.normals ?? new Float32Array(0),
+    normals: mesh.normals ?? EMPTY_F32,
     indices: mesh.indices,
-    edgeVertices: mesh.edgeVertices ?? new Float32Array(0),
+    edgeVertices: mesh.edgeVertices ?? EMPTY_F32,
   };
 }
 

--- a/src/features/baseplate/components/BaseplatePreview/cameraUtils.test.ts
+++ b/src/features/baseplate/components/BaseplatePreview/cameraUtils.test.ts
@@ -153,7 +153,7 @@ describe('cameraUtils', () => {
       const max = calculateMaxOrbitDistance(ideal);
       const far = calculateFarPlane(max);
 
-      // Bounding sphere of the baseplate (slab + socket height).
+      // Bounding sphere of the baseplate footprint (width only, height not framed).
       const halfW = (50 * 42 + 100 + 100) / 2;
       const boundingRadius = Math.sqrt(2 * halfW * halfW);
 

--- a/src/features/baseplate/components/BaseplatePreview/cameraUtils.test.ts
+++ b/src/features/baseplate/components/BaseplatePreview/cameraUtils.test.ts
@@ -1,12 +1,9 @@
-import { describe, it, expect, vi } from 'vitest';
-
-vi.mock('@/shared/printSettings/gridfinityGeometry', () => ({
-  GRIDFINITY_SPEC: { SOCKET_HEIGHT: 5 },
-}));
+import { describe, it, expect } from 'vitest';
 
 const {
   easeOutCubic,
   calculateIdealDistance,
+  calculateStackIdealDistance,
   calculateMaxOrbitDistance,
   calculateFarPlane,
   CAMERA_PRESETS,
@@ -49,6 +46,63 @@ describe('cameraUtils', () => {
       const noPad = calculateIdealDistance(4, 4, 42, 0, 0, 0, 0, 45);
       const withPad = calculateIdealDistance(4, 4, 42, 10, 10, 10, 10, 45);
       expect(withPad).toBeGreaterThan(noPad);
+    });
+
+    it('pulls camera closer for a wide plate in a landscape viewport', () => {
+      // For a width-dominant plate (outerW >> outerD), the width constraint
+      // drives idealDistance. A landscape viewport (aspect > 1) can fit that
+      // width with the camera sitting closer; the distance must be smaller than
+      // in a square viewport where the full diagonal is the limiting factor.
+      const square = calculateIdealDistance(8, 2, 42, 0, 0, 0, 0, 45, 1.0);
+      const wide = calculateIdealDistance(8, 2, 42, 0, 0, 0, 0, 45, 1.5);
+      expect(wide).toBeLessThan(square);
+    });
+
+    it('frames a wide plate without letterboxing in a landscape viewport', () => {
+      // Regression: a 10×2 plate in a 1.5:1 viewport used to be framed by the
+      // bounding-sphere diagonal, leaving the plate occupying only ~12% of
+      // viewport height. With aspect-aware framing the width constraint drives
+      // the distance and the plate fills FRAME_FILL of the narrower viewport axis.
+      const fov = 45;
+      const aspect = 1.5;
+      const dist = calculateIdealDistance(10, 2, 42, 0, 0, 0, 0, fov, aspect);
+      const halfFovTan = Math.tan((fov / 2) * (Math.PI / 180));
+      const outerW = 10 * 42;
+      const outerD = 2 * 42;
+      const halfVisibleW = dist * halfFovTan * aspect;
+      const halfVisibleH = dist * halfFovTan;
+      // Both plate dimensions must fit inside the framed viewport.
+      expect(outerW / 2).toBeLessThanOrEqual(halfVisibleW + 0.01);
+      expect(outerD / 2).toBeLessThanOrEqual(halfVisibleH + 0.01);
+      // Width drives the framing, so it fills exactly FRAME_FILL of the
+      // visible width (within floating-point tolerance).
+      expect(outerW / 2 / halfVisibleW).toBeCloseTo(FRAME_FILL, 5);
+    });
+  });
+
+  describe('calculateStackIdealDistance', () => {
+    it('returns a positive distance', () => {
+      expect(calculateStackIdealDistance(200, 200, 50, 45)).toBeGreaterThan(0);
+    });
+
+    it('increases with taller stacks', () => {
+      const short = calculateStackIdealDistance(200, 200, 20, 45);
+      const tall = calculateStackIdealDistance(200, 200, 100, 45);
+      expect(tall).toBeGreaterThan(short);
+    });
+
+    it('accounts for height so tall stacks fit in the view', () => {
+      const heightMm = 100;
+      const widthMm = 200;
+      const depthMm = 200;
+      const fov = 45;
+      const dist = calculateStackIdealDistance(widthMm, depthMm, heightMm, fov);
+      // Bounding sphere must fit inside the FOV at this distance.
+      const boundingRadius = Math.sqrt(
+        (widthMm / 2) ** 2 + (depthMm / 2) ** 2 + (heightMm / 2) ** 2
+      );
+      const halfFovRad = (fov / 2) * (Math.PI / 180);
+      expect(dist * Math.sin(halfFovRad)).toBeCloseTo(boundingRadius / FRAME_FILL, 3);
     });
   });
 

--- a/src/features/baseplate/components/BaseplatePreview/cameraUtils.ts
+++ b/src/features/baseplate/components/BaseplatePreview/cameraUtils.ts
@@ -1,5 +1,3 @@
-import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
-
 export type CameraPreset = 'front' | 'side' | 'top' | 'isometric';
 
 /** Camera positions for each preset (eye position looking toward center) */
@@ -29,6 +27,13 @@ export function easeOutCubic(t: number): number {
 
 /**
  * Calculate ideal camera distance to frame the baseplate including padding.
+ *
+ * Uses per-axis projection framing (not bounding sphere) so the camera
+ * accounts for the viewport aspect ratio — preventing wide plates from
+ * appearing as a thin letterboxed strip in landscape viewports.
+ *
+ * `aspect` defaults to 1 when called outside the Canvas context (e.g. for
+ * orbit-distance caps where the exact aspect doesn't matter).
  */
 export function calculateIdealDistance(
   width: number,
@@ -38,17 +43,32 @@ export function calculateIdealDistance(
   paddingRight: number,
   paddingFront: number,
   paddingBack: number,
-  fov: number
+  fov: number,
+  aspect = 1
 ): number {
   const outerW = width * gridUnitMm + paddingLeft + paddingRight;
   const outerD = depth * gridUnitMm + paddingFront + paddingBack;
-  const totalH = GRIDFINITY_SPEC.SOCKET_HEIGHT;
 
-  const halfW = outerW / 2;
-  const halfD = outerD / 2;
-  const halfH = totalH / 2;
+  const halfFovTan = Math.tan((fov / 2) * (Math.PI / 180));
+  const dForWidth = outerW / 2 / (halfFovTan * aspect * FRAME_FILL);
+  const dForDepth = outerD / 2 / (halfFovTan * FRAME_FILL);
+  return Math.max(dForWidth, dForDepth);
+}
+
+/**
+ * Ideal camera distance for a 3D stack-print tower layout using bounding-sphere
+ * framing. Appropriate for 3D geometry (unlike the top-down plate framing above).
+ */
+export function calculateStackIdealDistance(
+  widthMm: number,
+  depthMm: number,
+  heightMm: number,
+  fov: number
+): number {
+  const halfW = widthMm / 2;
+  const halfD = depthMm / 2;
+  const halfH = heightMm / 2;
   const boundingRadius = Math.sqrt(halfW * halfW + halfD * halfD + halfH * halfH);
-
   const halfFovRad = (fov / 2) * (Math.PI / 180);
   return (boundingRadius / Math.sin(halfFovRad)) * (1 / FRAME_FILL);
 }

--- a/src/features/baseplate/components/BaseplatePreview/useBaseplatePresetTransition.ts
+++ b/src/features/baseplate/components/BaseplatePreview/useBaseplatePresetTransition.ts
@@ -38,6 +38,8 @@ export function useBaseplatePresetTransition(
       const fov = 45;
       const totalH = GRIDFINITY_SPEC.SOCKET_HEIGHT;
       const binCenter = new THREE.Vector3(0, 0, totalH / 2);
+      const aspect =
+        camera instanceof THREE.PerspectiveCamera && camera.aspect > 0 ? camera.aspect : 1;
       const idealDistance = calculateIdealDistance(
         width,
         depth,
@@ -46,7 +48,8 @@ export function useBaseplatePresetTransition(
         paddingRight,
         paddingFront,
         paddingBack,
-        fov
+        fov,
+        aspect
       );
 
       const direction = new THREE.Vector3(...CAMERA_PRESETS[preset]).normalize();


### PR DESCRIPTION
## Summary

- **Stack mode dark background**: `hasAnyMesh` previously gated canvas visibility on `hasMesh`/`hasSplitMeshes` (single/split-plate metrics) even when the canvas was rendering `StackedBaseplateMeshes`. If the tower preview hadn't built yet or returned null, the canvas was visible but showing only the gradient background. Fix: gate on `stackBounds !== null` — set by `StackedBaseplateMeshes.onBounds` only after a valid tower preview is constructed. The canvas renders silently at `opacity-0` while the preview builds, so the transition is imperceptible.
- **Letterboxing on wide baseplates**: `calculateIdealDistance` used bounding-sphere framing, placing a 10×2 plate at the same camera distance as a 10×10 one. Replaced with per-axis projection framing that respects the viewport aspect ratio.
- **Stack camera framing**: Added `calculateStackIdealDistance` (bounding-sphere, appropriate for 3D tower geometry) and wired it through `CameraController` when `stackBounds` are present.
- **Defensive `toMeshArrays`**: No longer rejects meshes with null normals — passes `Float32Array(0)` so the existing `flatShading` fallback in `useMeshGeometry` handles it.

## Test plan

- [ ] Enable stack mode on a non-split baseplate — preview appears (no dark bg)
- [ ] Enable stack mode on a split baseplate — preview appears (no dark bg)  
- [ ] Wide plate (e.g. 10×2) fills the viewport width, not letterboxed
- [ ] Stack with many copies frames all towers in view
- [ ] Toggling stack mode off restores normal single/split preview