### PR TITLE
fix(bin-designer): make overhang, multi-color & lid feature toggles; sidebar polish

### DIFF
--- a/src/design-system/Stepper/Stepper.tsx
+++ b/src/design-system/Stepper/Stepper.tsx
@@ -76,9 +76,9 @@ const inputVariants = cva(
   {
     variants: {
       size: {
-        sm: 'text-xs min-w-[40px]',
-        md: 'text-sm min-w-[48px]',
-        lg: 'text-base font-semibold min-w-[64px] border-stroke',
+        sm: 'text-xs min-w-[34px]',
+        md: 'text-sm min-w-[38px]',
+        lg: 'text-base font-semibold min-w-[48px] border-stroke',
       },
     },
     defaultVariants: {
@@ -100,9 +100,9 @@ const displayVariants = cva(
   {
     variants: {
       size: {
-        sm: 'text-xs text-content-secondary min-w-[40px]',
-        md: 'text-sm text-content-secondary min-w-[48px]',
-        lg: 'text-base font-semibold text-content min-w-[64px] border-stroke',
+        sm: 'text-xs text-content-secondary min-w-[34px]',
+        md: 'text-sm text-content-secondary min-w-[38px]',
+        lg: 'text-base font-semibold text-content min-w-[48px] border-stroke',
       },
     },
     defaultVariants: {

--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.test.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.test.tsx
@@ -90,10 +90,8 @@ describe('ParameterPanel', () => {
   it('shows mm info for dimensions', () => {
     render(<ParameterPanel />);
 
-    // Default width=2, depth=2, height=3 shows combined dimensions
-    // Format: "84 × 84 × 21 mm" (using gridUnitMm=42, heightUnitMm=7).
-    // Appears in both the section body and the always-visible header summary.
-    expect(screen.getAllByText(/84\s*×\s*84\s*×\s*21\s*mm/)).toHaveLength(2);
+    // 84 × 84 × 21 mm = width 2 / depth 2 / height 3 at gridUnitMm 42, heightUnitMm 7.
+    expect(screen.getByText(/84\s*×\s*84\s*×\s*21\s*mm/)).toBeInTheDocument();
   });
 
   it('swap button swaps width and depth values', () => {

--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
@@ -24,6 +24,7 @@ import { LidSection } from '../panel/LidSection';
 import { PhysicalUnitsSection } from '../panel/PhysicalUnitsSection';
 import { SplitOptionsSection } from '../panel/SplitOptionsSection';
 import { StickyGroupHeader } from '../panel/StickyGroupHeader';
+import { PanelSection } from '../panel/PanelSection';
 import { ColorsSection } from '../panel/ColorsSection';
 import { FeatureGate } from '../panel/FeatureGate';
 import { SetDefaultFooter } from '../panel/SetDefaultFooter';
@@ -90,41 +91,37 @@ export function ParameterPanel() {
           onExpandedChange={setShapeExpanded}
           summary={shapeSummary}
         >
-          <div
-            data-help-target="bd-dimensions"
-            className="px-4 py-4 border-b border-stroke-subtle/50"
-          >
-            <DimensionsSection />
-          </div>
-          <div
-            data-help-target="bd-overhang"
-            className="px-4 py-4 border-b border-stroke-subtle/50"
-          >
-            {/* Advanced drawer-fit control next to the dimensions; collapsed by
-                default and gated off internally for custom-shape (mask) bins. */}
-            <OverhangSection />
-          </div>
-          <div data-help-target="bd-shape" className="px-4 py-4 border-b border-stroke-subtle/50">
-            <ShapeSection />
-          </div>
-          {needsSplit && (
-            <div className="px-4 py-4 border-b border-stroke-subtle/50">
-              {/* Splits work for any footprint — axis-aligned cut planes
-                  intersect the polygon naturally. Pieces may be irregular
-                  but each has positive volume; tested in the polygon
-                  scenario suite. */}
-              <SplitOptionsSection />
-            </div>
-          )}
-          <div data-help-target="bd-walls" className="px-4 py-4 border-b border-stroke-subtle/50">
-            {/* Wall thickness works for any footprint; pattern/cutouts/handle
-                gate themselves inside WallsSection. */}
-            <WallsSection />
-          </div>
-          <div data-help-target="bd-lid" className="px-4 py-4">
-            {/* Lid is a companion piece auto-fit to the bin's lip. Internally
-                gated when params.base.stackingLip is off (lid mates with lip). */}
-            <LidSection />
+          <div className="divide-y divide-stroke-subtle/50">
+            <PanelSection helpTarget="bd-dimensions">
+              <DimensionsSection />
+            </PanelSection>
+            <PanelSection helpTarget="bd-overhang">
+              {/* Advanced drawer-fit control next to the dimensions; collapsed by
+                  default and gated off internally for custom-shape (mask) bins. */}
+              <OverhangSection />
+            </PanelSection>
+            <PanelSection helpTarget="bd-shape">
+              <ShapeSection />
+            </PanelSection>
+            {needsSplit && (
+              <PanelSection>
+                {/* Splits work for any footprint — axis-aligned cut planes
+                    intersect the polygon naturally. Pieces may be irregular
+                    but each has positive volume; tested in the polygon
+                    scenario suite. */}
+                <SplitOptionsSection />
+              </PanelSection>
+            )}
+            <PanelSection helpTarget="bd-walls">
+              {/* Wall thickness works for any footprint; pattern/cutouts/handle
+                  gate themselves inside WallsSection. */}
+              <WallsSection />
+            </PanelSection>
+            <PanelSection helpTarget="bd-lid">
+              {/* Lid is a companion piece auto-fit to the bin's lip. Internally
+                  gated when params.base.stackingLip is off (lid mates with lip). */}
+              <LidSection />
+            </PanelSection>
           </div>
         </StickyGroupHeader>
 
@@ -135,9 +132,9 @@ export function ParameterPanel() {
           onExpandedChange={setColorsExpanded}
           badge={t('binDesigner.multiColor.experimental')}
         >
-          <div data-help-target="bd-colors" className="px-4 py-4">
+          <PanelSection helpTarget="bd-colors">
             <ColorsSection />
-          </div>
+          </PanelSection>
         </StickyGroupHeader>
 
         {/* Interior group */}
@@ -147,25 +144,24 @@ export function ParameterPanel() {
           onExpandedChange={setInteriorExpanded}
           summary={interiorSummary}
         >
-          <div data-help-target="bd-interior" className="px-4 py-4">
-            {/* Per-mode gating lives inside InteriorSection: Solid (cutouts) stays
-                interactive on custom shapes; Standard/Slotted remain gated. */}
-            <InteriorSection />
-          </div>
-          {showLabelTabs && (
-            <div
-              data-help-target="bd-label-tabs"
-              className="px-4 py-4 border-t border-stroke-subtle/50"
-            >
+          <div className="divide-y divide-stroke-subtle/50">
+            <PanelSection helpTarget="bd-interior">
+              {/* Per-mode gating lives inside InteriorSection: Solid (cutouts) stays
+                  interactive on custom shapes; Standard/Slotted remain gated. */}
+              <InteriorSection />
+            </PanelSection>
+            {showLabelTabs && (
+              <PanelSection helpTarget="bd-label-tabs">
+                <FeatureGate disabled={isCustomShape} reason={customShapeReason}>
+                  <LabelTabsSection />
+                </FeatureGate>
+              </PanelSection>
+            )}
+            <PanelSection helpTarget="bd-scoop">
               <FeatureGate disabled={isCustomShape} reason={customShapeReason}>
-                <LabelTabsSection />
+                <ScoopSection />
               </FeatureGate>
-            </div>
-          )}
-          <div data-help-target="bd-scoop" className="px-4 py-4 border-t border-stroke-subtle/50">
-            <FeatureGate disabled={isCustomShape} reason={customShapeReason}>
-              <ScoopSection />
-            </FeatureGate>
+            </PanelSection>
           </div>
         </StickyGroupHeader>
 
@@ -176,16 +172,18 @@ export function ParameterPanel() {
           onExpandedChange={setBaseExpanded}
           summary={baseSummary}
         >
-          <div data-help-target="bd-base" className="px-4 py-4 border-b border-stroke-subtle/50">
-            <BaseSection />
-          </div>
-          <div data-help-target="bd-physical-units" className="px-4 py-4">
-            <PhysicalUnitsSection />
+          <div className="divide-y divide-stroke-subtle/50">
+            <PanelSection helpTarget="bd-base">
+              <BaseSection />
+            </PanelSection>
+            <PanelSection helpTarget="bd-physical-units">
+              <PhysicalUnitsSection />
+            </PanelSection>
           </div>
         </StickyGroupHeader>
 
         {/* Design Showcase entry — opens the bin-example gallery (below Physical Units) */}
-        <div className="px-4 py-4 border-b border-stroke-subtle">
+        <div className="px-4 py-3 border-b border-stroke-subtle">
           <button
             onClick={openExampleGallery}
             className="w-full flex items-center gap-3 text-left p-3 rounded-lg bg-gradient-to-r from-accent/10 to-info/10 hover:from-accent/20 hover:to-info/20 border border-accent/20 transition-all group"

--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
@@ -60,14 +60,12 @@ export function ParameterPanel() {
   // Group expansion state — controlled so help-modal deep-links can force a
   // section open before the dispatcher scrolls and pulses its target.
   const [shapeExpanded, setShapeExpanded] = useState(true);
-  const [colorsExpanded, setColorsExpanded] = useState(true);
   const [interiorExpanded, setInteriorExpanded] = useState(true);
   const [baseExpanded, setBaseExpanded] = useState(true);
 
   useEffect(() => {
     const handlers: Record<string, () => void> = {
       [helpJumpEventName('binDesigner:shape')]: () => setShapeExpanded(true),
-      [helpJumpEventName('binDesigner:colors')]: () => setColorsExpanded(true),
       [helpJumpEventName('binDesigner:interior')]: () => setInteriorExpanded(true),
       [helpJumpEventName('binDesigner:base')]: () => setBaseExpanded(true),
     };
@@ -113,28 +111,12 @@ export function ParameterPanel() {
               </PanelSection>
             )}
             <PanelSection helpTarget="bd-walls">
-              {/* Wall thickness works for any footprint; pattern/cutouts/handle
-                  gate themselves inside WallsSection. */}
               <WallsSection />
-            </PanelSection>
-            <PanelSection helpTarget="bd-lid">
-              {/* Lid is a companion piece auto-fit to the bin's lip. Internally
-                  gated when params.base.stackingLip is off (lid mates with lip). */}
-              <LidSection />
+              <div data-help-target="bd-lid" className="mt-4">
+                <LidSection />
+              </div>
             </PanelSection>
           </div>
-        </StickyGroupHeader>
-
-        {/* Multi-Color group — between Shape and Interior */}
-        <StickyGroupHeader
-          title={t('binDesigner.group.colors')}
-          expanded={colorsExpanded}
-          onExpandedChange={setColorsExpanded}
-          badge={t('binDesigner.multiColor.experimental')}
-        >
-          <PanelSection helpTarget="bd-colors">
-            <ColorsSection />
-          </PanelSection>
         </StickyGroupHeader>
 
         {/* Interior group */}
@@ -175,6 +157,9 @@ export function ParameterPanel() {
           <div className="divide-y divide-stroke-subtle/50">
             <PanelSection helpTarget="bd-base">
               <BaseSection />
+            </PanelSection>
+            <PanelSection helpTarget="bd-colors">
+              <ColorsSection />
             </PanelSection>
             <PanelSection helpTarget="bd-physical-units">
               <PhysicalUnitsSection />

--- a/src/features/bin-designer/components/ParameterPanel/useShapeGroupSummary.ts
+++ b/src/features/bin-designer/components/ParameterPanel/useShapeGroupSummary.ts
@@ -4,22 +4,16 @@ import { useDesignerStore } from '@/features/bin-designer/store';
 
 /** Read-only summary for the Shape group when collapsed. */
 export function useShapeGroupSummary(): string {
-  const { width, depth, height, gridUnitMm, heightUnitMm, wallThickness } = useDesignerStore(
+  const { width, depth, height, wallThickness } = useDesignerStore(
     useShallow((s) => ({
       width: s.params.width,
       depth: s.params.depth,
       height: s.params.height,
-      gridUnitMm: s.params.gridUnitMm,
-      heightUnitMm: s.params.heightUnitMm,
       wallThickness: s.params.wallThickness,
     }))
   );
 
   return useMemo(() => {
-    const widthMm = (width * gridUnitMm).toFixed(0);
-    const depthMm = (depth * gridUnitMm).toFixed(0);
-    const heightMm = (height * heightUnitMm).toFixed(0);
-
-    return `${width}\u00d7${depth}\u00d7${height}u (${widthMm}\u00d7${depthMm}\u00d7${heightMm}mm) \u00b7 ${wallThickness}mm walls`;
-  }, [width, depth, height, gridUnitMm, heightUnitMm, wallThickness]);
+    return `${width}\u00d7${depth}\u00d7${height}u \u00b7 ${wallThickness}mm walls`;
+  }, [width, depth, height, wallThickness]);
 }

--- a/src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.tsx
+++ b/src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.tsx
@@ -194,7 +194,7 @@ export function SnappingSlider({
     <div className={disabled ? 'opacity-50' : ''}>
       {/* Label row with prominent value */}
       <div className="mb-3 flex items-center justify-between">
-        <label htmlFor={id} className="text-xs font-medium text-content-secondary">
+        <label htmlFor={id} className="text-xs text-content-secondary">
           {label}
         </label>
         <span

--- a/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
@@ -18,7 +18,7 @@ export function BaseSection() {
   const t = useTranslation();
 
   return (
-    <div className="space-y-1">
+    <div className="space-y-3">
       <FeatureToggle
         label="Stacking lip"
         checked={state.base.stackingLip}

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
@@ -26,6 +26,7 @@ import { useTranslation } from '@/i18n';
 import { PipetteIcon } from '@/design-system/Icon';
 import { SEGMENT_ACTIVE, SEGMENT_INACTIVE } from '@/shared/components/segmentedControlClasses';
 import { useSwapZoneWithToast } from '@/features/bin-designer/hooks/useSwapZoneWithToast';
+import { FeatureToggle } from '../FeatureToggle';
 import { ColorZoneRow } from './ColorZoneRow';
 import { ColorGroup } from './ColorGroup';
 import { ColorsHintBanner } from './ColorsHintBanner';
@@ -229,166 +230,152 @@ export function ColorsSection() {
     [startTransaction, commitTransaction, updateFeatureColors]
   );
 
-  const enableLabel = t('binDesigner.multiColor.enableLabel');
   const handleToggleMultiColor = useCallback(() => {
     updateFeatureColors({ enabled: !multiColorEnabled });
   }, [multiColorEnabled, updateFeatureColors]);
 
   return (
     <div className="space-y-2">
-      {/* Top toggle row — gates the zone editor below */}
-      <div className="flex items-center justify-between py-1.5">
-        <span className="text-xs text-content-secondary">{enableLabel}</span>
-        <div className="flex items-center gap-2">
-          {multiColorEnabled && (
-            <button
-              type="button"
-              onClick={() => setColorTool(colorTool === 'eyedropper' ? null : 'eyedropper')}
-              aria-pressed={colorTool === 'eyedropper'}
-              aria-label={t('binDesigner.colors.eyedropper.enter')}
-              title={t('binDesigner.colors.eyedropper.enter')}
-              className={`flex h-6 w-6 items-center justify-center rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ${
-                colorTool === 'eyedropper' ? SEGMENT_ACTIVE : SEGMENT_INACTIVE
-              }`}
-            >
-              <PipetteIcon size="sm" />
-            </button>
-          )}
-          {multiColorEnabled && (
-            <ColorsActionsMenu
-              featureColors={featureColors}
-              onMatchAllToBody={handleMatchAllToBody}
-              onApplyPalette={handleApplyPalette}
-            />
-          )}
-          <button
-            type="button"
-            role="switch"
-            aria-checked={multiColorEnabled}
-            aria-label={enableLabel}
-            onClick={handleToggleMultiColor}
-            className={`relative inline-flex h-7 w-12 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
-              multiColorEnabled ? 'bg-accent' : 'bg-stroke-subtle'
-            }`}
-          >
-            <span
-              className={`inline-block h-5 w-5 transform rounded-full bg-white shadow-sm transition-transform ${
-                multiColorEnabled ? 'translate-x-6' : 'translate-x-0.5'
-              }`}
-            />
-          </button>
-        </div>
-      </div>
+      <FeatureToggle
+        label={t('binDesigner.group.colors')}
+        checked={multiColorEnabled}
+        onChange={handleToggleMultiColor}
+        badge={
+          <span className="rounded bg-warning-muted px-1.5 py-0.5 text-[10px] font-medium text-warning">
+            {t('binDesigner.multiColor.experimental')}
+          </span>
+        }
+        primaryControls={
+          <>
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setColorTool(colorTool === 'eyedropper' ? null : 'eyedropper')}
+                aria-pressed={colorTool === 'eyedropper'}
+                aria-label={t('binDesigner.colors.eyedropper.enter')}
+                title={t('binDesigner.colors.eyedropper.enter')}
+                className={`flex h-6 w-6 items-center justify-center rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ${
+                  colorTool === 'eyedropper' ? SEGMENT_ACTIVE : SEGMENT_INACTIVE
+                }`}
+              >
+                <PipetteIcon size="sm" />
+              </button>
+              <ColorsActionsMenu
+                featureColors={featureColors}
+                onMatchAllToBody={handleMatchAllToBody}
+                onApplyPalette={handleApplyPalette}
+              />
+            </div>
 
+            <ColorsHintBanner />
+
+            <ColorGroup title={t('binDesigner.colors.group.exterior')}>
+              {renderZone(
+                'body',
+                t('binDesigner.colors.body'),
+                featureColors.body,
+                DEFAULT_FEATURE_COLOR_CONFIG.body,
+                (hex) => updateFeatureColors({ body: hex })
+              )}
+              {hasLip && (
+                // Lip uses the umbrella 'lip' hover target so the whole lip
+                // glows on row hover. The picker writes the chosen hex into
+                // all four corner slots — the per-corner schema stays valid
+                // and the per-corner UI can be restored without a migration.
+                <ColorZoneRow
+                  zone="lip"
+                  label={t('binDesigner.colors.lip')}
+                  color={lipColor}
+                  defaultColor={DEFAULT_FEATURE_COLOR_CONFIG.lip.frontLeft}
+                  otherColors={buildOtherColors('lip:frontLeft', colorsByZone)}
+                  bodyColor={featureColors.body}
+                  recentColors={recentColors}
+                  onChange={(hex) => {
+                    remember(hex);
+                    updateFeatureColors({
+                      lip: {
+                        frontLeft: hex,
+                        frontRight: hex,
+                        backRight: hex,
+                        backLeft: hex,
+                      },
+                    });
+                  }}
+                  onHover={setHoveredColorZone}
+                  onGestureStart={startTransaction}
+                  onGestureEnd={commitTransaction}
+                  // During swap mode, route the lip click into the state machine
+                  // through `lip:frontLeft` — the canonical representative for
+                  // the now-single-color lip (mirror-on-write means picking any
+                  // corner spreads to all four). Without this override the row
+                  // would open the picker mid-swap.
+                  onClickOverride={
+                    swapActive ? () => swapZoneWithToast('lip:frontLeft') : undefined
+                  }
+                />
+              )}
+              {hasBase &&
+                renderZone(
+                  'base',
+                  t('binDesigner.colors.base'),
+                  featureColors.base,
+                  DEFAULT_FEATURE_COLOR_CONFIG.base,
+                  (hex) => updateFeatureColors({ base: hex })
+                )}
+            </ColorGroup>
+
+            <ColorGroup
+              title={t('binDesigner.colors.group.interior')}
+              visible={hasScoop || hasDividers}
+              growthTick={interiorGrowthTick}
+            >
+              {hasScoop &&
+                renderZone(
+                  'scoop',
+                  t('binDesigner.colors.scoop'),
+                  featureColors.scoop,
+                  DEFAULT_FEATURE_COLOR_CONFIG.scoop,
+                  (hex) => updateFeatureColors({ scoop: hex })
+                )}
+              {hasDividers &&
+                renderZone(
+                  'dividers',
+                  t('binDesigner.colors.dividers'),
+                  featureColors.dividers,
+                  DEFAULT_FEATURE_COLOR_CONFIG.dividers,
+                  (hex) => updateFeatureColors({ dividers: hex })
+                )}
+            </ColorGroup>
+
+            <ColorGroup
+              title={t('binDesigner.colors.group.addons')}
+              visible={hasLabelTabs || hasLid}
+              growthTick={addonsGrowthTick}
+            >
+              {hasLabelTabs &&
+                renderZone(
+                  'labelTab',
+                  t('binDesigner.colors.labelTab'),
+                  featureColors.labelTab,
+                  DEFAULT_FEATURE_COLOR_CONFIG.labelTab,
+                  (hex) => updateFeatureColors({ labelTab: hex })
+                )}
+              {hasLid &&
+                renderZone(
+                  'lid',
+                  t('binDesigner.colors.lid'),
+                  featureColors.lid,
+                  DEFAULT_FEATURE_COLOR_CONFIG.lid,
+                  (hex) => updateFeatureColors({ lid: hex })
+                )}
+            </ColorGroup>
+          </>
+        }
+      />
       {!multiColorEnabled && (
         <p className="text-[11px] text-content-tertiary leading-snug">
           {t('binDesigner.multiColor.enableHint')}
         </p>
-      )}
-
-      {multiColorEnabled && (
-        <>
-          <ColorsHintBanner />
-
-          <ColorGroup title={t('binDesigner.colors.group.exterior')}>
-            {renderZone(
-              'body',
-              t('binDesigner.colors.body'),
-              featureColors.body,
-              DEFAULT_FEATURE_COLOR_CONFIG.body,
-              (hex) => updateFeatureColors({ body: hex })
-            )}
-            {hasLip && (
-              // Lip uses the umbrella 'lip' hover target so the whole lip
-              // glows on row hover. The picker writes the chosen hex into
-              // all four corner slots — the per-corner schema stays valid
-              // and the per-corner UI can be restored without a migration.
-              <ColorZoneRow
-                zone="lip"
-                label={t('binDesigner.colors.lip')}
-                color={lipColor}
-                defaultColor={DEFAULT_FEATURE_COLOR_CONFIG.lip.frontLeft}
-                otherColors={buildOtherColors('lip:frontLeft', colorsByZone)}
-                bodyColor={featureColors.body}
-                recentColors={recentColors}
-                onChange={(hex) => {
-                  remember(hex);
-                  updateFeatureColors({
-                    lip: {
-                      frontLeft: hex,
-                      frontRight: hex,
-                      backRight: hex,
-                      backLeft: hex,
-                    },
-                  });
-                }}
-                onHover={setHoveredColorZone}
-                onGestureStart={startTransaction}
-                onGestureEnd={commitTransaction}
-                // During swap mode, route the lip click into the state machine
-                // through `lip:frontLeft` — the canonical representative for
-                // the now-single-color lip (mirror-on-write means picking any
-                // corner spreads to all four). Without this override the row
-                // would open the picker mid-swap.
-                onClickOverride={swapActive ? () => swapZoneWithToast('lip:frontLeft') : undefined}
-              />
-            )}
-            {hasBase &&
-              renderZone(
-                'base',
-                t('binDesigner.colors.base'),
-                featureColors.base,
-                DEFAULT_FEATURE_COLOR_CONFIG.base,
-                (hex) => updateFeatureColors({ base: hex })
-              )}
-          </ColorGroup>
-
-          <ColorGroup
-            title={t('binDesigner.colors.group.interior')}
-            visible={hasScoop || hasDividers}
-            growthTick={interiorGrowthTick}
-          >
-            {hasScoop &&
-              renderZone(
-                'scoop',
-                t('binDesigner.colors.scoop'),
-                featureColors.scoop,
-                DEFAULT_FEATURE_COLOR_CONFIG.scoop,
-                (hex) => updateFeatureColors({ scoop: hex })
-              )}
-            {hasDividers &&
-              renderZone(
-                'dividers',
-                t('binDesigner.colors.dividers'),
-                featureColors.dividers,
-                DEFAULT_FEATURE_COLOR_CONFIG.dividers,
-                (hex) => updateFeatureColors({ dividers: hex })
-              )}
-          </ColorGroup>
-
-          <ColorGroup
-            title={t('binDesigner.colors.group.addons')}
-            visible={hasLabelTabs || hasLid}
-            growthTick={addonsGrowthTick}
-          >
-            {hasLabelTabs &&
-              renderZone(
-                'labelTab',
-                t('binDesigner.colors.labelTab'),
-                featureColors.labelTab,
-                DEFAULT_FEATURE_COLOR_CONFIG.labelTab,
-                (hex) => updateFeatureColors({ labelTab: hex })
-              )}
-            {hasLid &&
-              renderZone(
-                'lid',
-                t('binDesigner.colors.lid'),
-                featureColors.lid,
-                DEFAULT_FEATURE_COLOR_CONFIG.lid,
-                (hex) => updateFeatureColors({ lid: hex })
-              )}
-          </ColorGroup>
-        </>
       )}
     </div>
   );

--- a/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
+++ b/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
@@ -67,7 +67,7 @@ export function DimensionsSection() {
       </div>
 
       {/* Physical dimensions display */}
-      <div className="flex items-center gap-1.5 text-xs text-content-tertiary">
+      <div className="flex items-center justify-center gap-1.5 text-xs text-content-tertiary">
         <RulerIcon size="xs" />
         <span className="tabular-nums">
           {state.widthMm.toFixed(0)} × {state.depthMm.toFixed(0)} × {state.heightMm.toFixed(0)} mm

--- a/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
+++ b/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
@@ -8,7 +8,7 @@
 
 import { DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
 import { Checkbox, IconButton, Stepper } from '@/design-system';
-import { RulerIcon } from '@/design-system/Icon';
+import { ArrowLeftRightIcon, RulerIcon } from '@/design-system/Icon';
 import { useResponsive } from '@/shared/hooks/useResponsive';
 import { useDimensionsSection } from './useDimensionsSection';
 
@@ -21,9 +21,9 @@ export function DimensionsSection() {
   return (
     <div className="space-y-3">
       {/* Width and Depth on same row with swap button */}
-      <div className="flex items-end gap-2">
+      <div className="flex items-end justify-center gap-2">
         {/* Width */}
-        <div className="flex-1 min-w-0">
+        <div className="flex flex-col">
           <span className="mb-1 block text-xs text-content-tertiary">{t('common.width')}</span>
           <Stepper
             value={state.width}
@@ -47,23 +47,11 @@ export function DimensionsSection() {
           title={t('inspector.swapDimensions')}
           aria-label={t('inspector.swapWidthAndDepth')}
         >
-          <svg
-            className="h-3 w-3"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2.5}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
-            />
-          </svg>
+          <ArrowLeftRightIcon size={isMobile ? 'md' : 'xs'} />
         </IconButton>
 
         {/* Depth */}
-        <div className="flex-1 min-w-0">
+        <div className="flex flex-col">
           <span className="mb-1 block text-xs text-content-tertiary">{t('common.depth')}</span>
           <Stepper
             value={state.depth}
@@ -107,7 +95,7 @@ export function DimensionsSection() {
 
       {/* Half-bin mode toggle */}
       <div
-        className="group flex items-center justify-between pt-2 cursor-pointer rounded-md px-1 -mx-1 py-1 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none"
+        className="group flex items-center justify-between cursor-pointer rounded-md px-1 -mx-1 py-1 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none"
         onClick={handlers.toggleHalfGridMode}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {

--- a/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
+++ b/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
@@ -77,11 +77,6 @@ export function LidSection() {
       onChange={handlers.toggleEnabled}
       disabledReason={state.disabledReason}
       valueSummary={state.valueSummary}
-      badge={
-        <span className="rounded bg-warning-muted px-1.5 py-0.5 text-[10px] font-medium text-warning">
-          {t('settings.experimental')}
-        </span>
-      }
     >
       {/* Print-time hint — the mating cavity and click rails are
           downward-facing overhangs that need supports for a clean print. */}

--- a/src/features/bin-designer/components/panel/OverhangSection/OverhangSection.test.tsx
+++ b/src/features/bin-designer/components/panel/OverhangSection/OverhangSection.test.tsx
@@ -14,6 +14,12 @@ describe('OverhangSection', () => {
   });
 
   it('renders the four per-side controls', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        overhang: { left: 0, right: 0, front: 0, back: 0, enabled: true },
+      },
+    });
     render(<OverhangSection />);
     expect(screen.getByText('Overhang')).toBeDefined();
     expect(screen.getByText('Left')).toBeDefined();
@@ -22,15 +28,22 @@ describe('OverhangSection', () => {
     expect(screen.getByText('Back')).toBeDefined();
   });
 
-  it('shows a summary once a side has a non-zero overhang', () => {
+  it('treats a legacy non-zero overhang as enabled and reveals the controls', () => {
     useDesignerStore.setState({
       params: { ...DEFAULT_BIN_PARAMS, overhang: { left: 3, right: 0, front: 0, back: 2 } },
     });
     render(<OverhangSection />);
-    expect(screen.getByText(/L3/)).toBeDefined();
+    expect(screen.getByText('Left')).toBeDefined();
+    expect(screen.getByText('Back')).toBeDefined();
   });
 
   it('sets and clears the hovered side on pointer enter/leave', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        overhang: { left: 0, right: 0, front: 0, back: 0, enabled: true },
+      },
+    });
     render(<OverhangSection />);
     // React derives onMouseEnter/Leave from delegated mouseover/mouseout.
     const left = screen.getByText('Left');
@@ -41,6 +54,12 @@ describe('OverhangSection', () => {
   });
 
   it('does not target the feet region when there is no overhang', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        overhang: { left: 0, right: 0, front: 0, back: 0, enabled: true },
+      },
+    });
     render(<OverhangSection />);
     fireEvent.mouseOver(screen.getByText('Feet under overhang'));
     // Feet toggle is disabled without overhang → hover stays null.
@@ -67,7 +86,6 @@ describe('OverhangSection', () => {
       params: { ...DEFAULT_BIN_PARAMS, width: 2, depth: 2, cellMask: mask },
     });
     render(<OverhangSection />);
-    const gate = document.querySelector('[aria-disabled="true"]');
-    expect(gate).not.toBeNull();
+    expect(screen.getByRole('switch')).toBeDisabled();
   });
 });

--- a/src/features/bin-designer/components/panel/OverhangSection/OverhangSection.tsx
+++ b/src/features/bin-designer/components/panel/OverhangSection/OverhangSection.tsx
@@ -26,11 +26,10 @@ export function OverhangSection() {
   return (
     <Collapsible
       title={t('binDesigner.overhang.title')}
-      size="sm"
       defaultExpanded={false}
       summary={meta.summary}
     >
-      <p className="mb-3 mt-1 text-[11px] leading-relaxed text-content-tertiary">
+      <p className="mb-3 text-[11px] leading-relaxed text-content-tertiary">
         {t('binDesigner.overhang.hint')}
       </p>
       <FeatureGate disabled={state.isCustomShape} reason={meta.disabledReason ?? ''}>

--- a/src/features/bin-designer/components/panel/OverhangSection/OverhangSection.tsx
+++ b/src/features/bin-designer/components/panel/OverhangSection/OverhangSection.tsx
@@ -3,14 +3,14 @@
  *
  * Grows the bin walls + stacking lip outward to fill the centering gap a
  * non-integral grid leaves in a drawer. Feet stay at the nominal footprint
- * (flat bottom under the overhang) unless the feet toggle is enabled.
- * Collapsed by default — a niche/advanced control. Suppressed for custom-shape
- * bins.
+ * (flat bottom under the overhang) unless the feet toggle is enabled. A feature
+ * toggle gates the per-side controls; per-side values are retained while off.
+ * Suppressed for custom-shape bins.
  */
 
-import { Checkbox, Collapsible, SliderInput } from '@/design-system';
+import { Checkbox, SliderInput } from '@/design-system';
 import { DESIGNER_CONSTRAINTS } from '../../../constants';
-import { FeatureGate } from '../FeatureGate';
+import { FeatureToggle } from '../FeatureToggle';
 import { useOverhangSection, type OverhangSide } from './useOverhangSection';
 
 export function OverhangSection() {
@@ -24,16 +24,16 @@ export function OverhangSection() {
   ];
 
   return (
-    <Collapsible
-      title={t('binDesigner.overhang.title')}
-      defaultExpanded={false}
-      summary={meta.summary}
-    >
-      <p className="mb-3 text-[11px] leading-relaxed text-content-tertiary">
-        {t('binDesigner.overhang.hint')}
-      </p>
-      <FeatureGate disabled={state.isCustomShape} reason={meta.disabledReason ?? ''}>
-        <div className="space-y-3">
+    <FeatureToggle
+      label={t('binDesigner.overhang.title')}
+      checked={state.enabled}
+      onChange={handlers.toggle}
+      disabledReason={meta.disabledReason}
+      primaryControls={
+        <>
+          <p className="text-[11px] leading-relaxed text-content-tertiary">
+            {t('binDesigner.overhang.hint')}
+          </p>
           {sides.map(({ side, label }) => (
             // Wrapper relays hover + keyboard focus to the 3D wall highlight
             // without touching the shared SliderInput primitive (onFocus/onBlur
@@ -57,7 +57,7 @@ export function OverhangSection() {
             </div>
           ))}
           <div
-            className="group flex cursor-pointer items-center justify-between pt-1"
+            className="group flex cursor-pointer items-center justify-between"
             onMouseEnter={state.hasOverhang ? () => handlers.setHovered('feet') : undefined}
             onMouseLeave={state.hasOverhang ? () => handlers.setHovered(null) : undefined}
             onFocus={state.hasOverhang ? () => handlers.setHovered('feet') : undefined}
@@ -85,8 +85,8 @@ export function OverhangSection() {
           <p className="text-[11px] leading-relaxed text-content-tertiary">
             {t('binDesigner.overhang.feetHint')}
           </p>
-        </div>
-      </FeatureGate>
-    </Collapsible>
+        </>
+      }
+    />
   );
 }

--- a/src/features/bin-designer/components/panel/OverhangSection/useOverhangSection.ts
+++ b/src/features/bin-designer/components/panel/OverhangSection/useOverhangSection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useTranslation } from '@/i18n';
@@ -47,27 +47,21 @@ export function useOverhangSection() {
   }, [isCustomShape, setHoveredOverhangSide]);
 
   const total = overhang.left + overhang.right + overhang.front + overhang.back;
+  const hasOverhang = total > 0;
+  const enabled = overhang.enabled ?? hasOverhang;
 
-  const summary = useMemo(() => {
-    if (isCustomShape || total <= 0) return undefined;
-    // Compact axis-code chip (only non-zero sides), e.g. "L3 B2 mm". The codes
-    // L/R/F/B + mm are glanceable, not translatable prose.
-    const parts: string[] = [];
-    if (overhang.left > 0) parts.push(`L${overhang.left}`);
-    if (overhang.right > 0) parts.push(`R${overhang.right}`);
-    if (overhang.front > 0) parts.push(`F${overhang.front}`);
-    if (overhang.back > 0) parts.push(`B${overhang.back}`);
-    return `${parts.join(' ')} mm`;
-  }, [isCustomShape, total, overhang]);
+  const toggle = useCallback(() => {
+    updateOverhang({ enabled: !enabled });
+  }, [enabled, updateOverhang]);
 
   // Overhang is suppressed for custom-shape (mask) bins in the generator, so
   // surface that as a disabled state rather than silently ignoring input.
   const disabledReason = isCustomShape ? t('binDesigner.shape.custom.hint') : undefined;
 
   return {
-    state: { overhang, isCustomShape, feet: overhang.feet ?? false, hasOverhang: total > 0 },
-    handlers: { setSide, toggleFeet, setHovered },
-    meta: { summary, disabledReason },
+    state: { overhang, isCustomShape, feet: overhang.feet ?? false, hasOverhang, enabled },
+    handlers: { setSide, toggleFeet, setHovered, toggle },
+    meta: { disabledReason },
     t,
   };
 }

--- a/src/features/bin-designer/components/panel/PanelSection/PanelSection.test.tsx
+++ b/src/features/bin-designer/components/panel/PanelSection/PanelSection.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PanelSection } from './PanelSection';
+
+describe('PanelSection', () => {
+  it('renders its children', () => {
+    render(
+      <PanelSection>
+        <span>contents</span>
+      </PanelSection>
+    );
+    expect(screen.getByText('contents')).toBeInTheDocument();
+  });
+
+  it('exposes the help-jump anchor', () => {
+    const { container } = render(<PanelSection helpTarget="bd-thing">x</PanelSection>);
+    expect(container.querySelector('[data-help-target="bd-thing"]')).not.toBeNull();
+  });
+
+  it('owns the section padding and never draws its own divider', () => {
+    const { container } = render(<PanelSection>x</PanelSection>);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.className).toContain('px-4');
+    expect(el.className).toContain('py-3');
+    expect(el.className).not.toMatch(/border/);
+  });
+
+  it('appends a caller className onto the base padding', () => {
+    const { container } = render(<PanelSection className="border-t">x</PanelSection>);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.className).toContain('px-4');
+    expect(el.className).toContain('border-t');
+  });
+});

--- a/src/features/bin-designer/components/panel/PanelSection/PanelSection.tsx
+++ b/src/features/bin-designer/components/panel/PanelSection/PanelSection.tsx
@@ -1,0 +1,25 @@
+/**
+ * Uniform padding wrapper for a bin-designer sidebar section.
+ *
+ * Owns a section's leading (`px-4 py-3`) so sections don't each reinvent it.
+ * Section dividers are drawn by the parent group via `divide-y`, never here —
+ * one divider system keeps stacked hairlines from forming at seams.
+ */
+
+import type { ReactNode } from 'react';
+import { cn } from '@/design-system/cn';
+
+interface PanelSectionProps {
+  children: ReactNode;
+  /** Help-jump anchor consumed by the help dispatcher (`data-help-target`). */
+  helpTarget?: string;
+  className?: string;
+}
+
+export function PanelSection({ children, helpTarget, className }: PanelSectionProps) {
+  return (
+    <div data-help-target={helpTarget} className={cn('px-4 py-3', className)}>
+      {children}
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/panel/PanelSection/index.ts
+++ b/src/features/bin-designer/components/panel/PanelSection/index.ts
@@ -1,0 +1,1 @@
+export * from './PanelSection';

--- a/src/features/bin-designer/components/panel/SetDefaultFooter/SetDefaultFooter.tsx
+++ b/src/features/bin-designer/components/panel/SetDefaultFooter/SetDefaultFooter.tsx
@@ -16,7 +16,7 @@ export function SetDefaultFooter() {
   const { hasCustomDefault, setCurrentAsDefault } = useBinDefaults();
 
   return (
-    <div className="px-4 py-3 border-b border-stroke-subtle">
+    <div className="px-4 py-3">
       <button
         type="button"
         onClick={setCurrentAsDefault}

--- a/src/features/bin-designer/components/panel/ShapeSection/ShapeSection.tsx
+++ b/src/features/bin-designer/components/panel/ShapeSection/ShapeSection.tsx
@@ -30,11 +30,6 @@ export function ShapeSection() {
       label={t('binDesigner.shape.customShape')}
       checked={state.editingEnabled}
       onChange={handlers.toggleEditingEnabled}
-      badge={
-        <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-warning-muted text-warning">
-          {t('settings.experimental')}
-        </span>
-      }
       primaryControls={
         <div className="space-y-3">
           <div className="flex flex-wrap items-center gap-2">

--- a/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
@@ -30,25 +30,19 @@ export function WallsSection() {
         unit="mm"
         tip={t('binDesigner.wallThickness.nozzleTip')}
       />
-      <div className="space-y-4">
-        <div className="pt-3 border-t border-stroke-subtle/50">
-          <PatternSelector
-            selectedPattern={state.patternEnabled ? state.pattern : null}
-            onChange={handlers.handlePatternChange}
-            disabled={state.patternDisabled}
-            disabledReason={state.patternDisabledReason}
-          />
-          {state.patternPartialNote && state.patternEnabled && (
-            <p className="text-[11px] text-content-tertiary mt-1">{state.patternPartialNote}</p>
-          )}
-        </div>
-        <div className="pt-3 border-t border-stroke-subtle/50">
-          <WallCutoutsSection />
-        </div>
-        <div className="pt-3 border-t border-stroke-subtle/50">
-          <HandleSection />
-        </div>
+      <div>
+        <PatternSelector
+          selectedPattern={state.patternEnabled ? state.pattern : null}
+          onChange={handlers.handlePatternChange}
+          disabled={state.patternDisabled}
+          disabledReason={state.patternDisabledReason}
+        />
+        {state.patternPartialNote && state.patternEnabled && (
+          <p className="text-[11px] text-content-tertiary mt-1">{state.patternPartialNote}</p>
+        )}
       </div>
+      <WallCutoutsSection />
+      <HandleSection />
     </div>
   );
 }

--- a/src/features/bin-designer/helpEntries.ts
+++ b/src/features/bin-designer/helpEntries.ts
@@ -5,9 +5,8 @@
  *
  * Each target.surface is one of:
  *   - 'binDesigner:shape'    — Shape group (dimensions, shape, walls, lid)
- *   - 'binDesigner:colors'   — Multi-color group
  *   - 'binDesigner:interior' — Interior dividers, label tabs, scoop
- *   - 'binDesigner:base'     — Base attachments, physical units
+ *   - 'binDesigner:base'     — Base attachments, multi-color, physical units
  *
  * The ParameterPanel listens for `help-jump:binDesigner:*` events and
  * expands the corresponding StickyGroupHeader before the dispatcher
@@ -65,7 +64,7 @@ export const helpEntries: FeatureHelpEntry[] = [
     keywordsKey: 'help.target.binDesigner.colors.keywords',
     category: 'colors',
     routes: ['designer'],
-    target: { surface: 'binDesigner:colors', controlId: 'bd-colors' },
+    target: { surface: 'binDesigner:base', controlId: 'bd-colors' },
   },
   {
     id: 'feature/bin-designer/interior',

--- a/src/features/bin-designer/store/slices/paramSlice.ts
+++ b/src/features/bin-designer/store/slices/paramSlice.ts
@@ -179,6 +179,7 @@ export function createParamSlice(set: Set, get: Get) {
           front: Math.max(0, next.front),
           back: Math.max(0, next.back),
           feet: next.feet ?? false,
+          ...(next.enabled !== undefined ? { enabled: next.enabled } : {}),
         };
       });
     },

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -413,6 +413,8 @@ export interface WallConfig {
  * `front`/`back` are -Y/+Y.
  */
 export interface OverhangConfig {
+  /** Absent (legacy designs) → enabled is inferred from any non-zero side. */
+  readonly enabled?: boolean;
   readonly left: number;
   readonly right: number;
   readonly front: number;

--- a/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
+++ b/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 import { CONSTRAINTS, DEFAULT_CATEGORY_COLOR, STAGING_ID } from '@/core/constants';
 import { Button, IconButton, Select, Stepper, XIcon } from '@/design-system';
-import { RulerIcon } from '@/design-system/Icon';
+import { ArrowLeftRightIcon, RulerIcon } from '@/design-system/Icon';
 import { useHalfGridModeStore } from '@/core/store/halfGridMode';
 import { getBinLocationContext } from '@/shared/utils/binLocation';
 import type { UseBinInspectorReturn } from '@/features/bin-inspector/hooks/useBinInspector';
@@ -92,9 +92,9 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
 
       <div className="space-y-4">
         {/* Size inputs with flip button between */}
-        <div className="flex items-end gap-2">
+        <div className="flex items-end justify-center gap-2">
           {/* Width control */}
-          <div className="flex-1">
+          <div className="flex flex-col">
             <label className={`block ${labelSize} text-content-tertiary`}>
               {t('common.width')}
             </label>
@@ -125,23 +125,11 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
             title={t('inspector.swapDimensions')}
             aria-label={t('inspector.swapWidthAndDepth')}
           >
-            <svg
-              className={isMobile ? 'w-5 h-5' : 'w-3 h-3'}
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={isMobile ? 2 : 2.5}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
-              />
-            </svg>
+            <ArrowLeftRightIcon size={isMobile ? 'md' : 'xs'} />
           </IconButton>
 
           {/* Depth control */}
-          <div className="flex-1">
+          <div className="flex flex-col">
             <label className={`block ${labelSize} text-content-tertiary`}>
               {t('common.depth')}
             </label>

--- a/src/features/generation/worker/generators/overhang.test.ts
+++ b/src/features/generation/worker/generators/overhang.test.ts
@@ -26,6 +26,20 @@ describe('resolveOverhang', () => {
     expect(resolveOverhang({ left: 5, right: 0, front: 0, back: 0, feet: true }).feet).toBe(true);
     expect(resolveOverhang({ left: 5, right: 0, front: 0, back: 0 }).feet).toBe(false);
   });
+
+  it('returns zero when explicitly disabled, retaining nothing in the resolved value', () => {
+    expect(resolveOverhang({ left: 5, right: 5, front: 5, back: 5, enabled: false })).toEqual({
+      left: 0,
+      right: 0,
+      front: 0,
+      back: 0,
+      feet: false,
+    });
+  });
+
+  it('applies per-side values when enabled is omitted (legacy configs)', () => {
+    expect(resolveOverhang({ left: 3, right: 0, front: 0, back: 0 }).left).toBe(3);
+  });
 });
 
 describe('hasOverhang', () => {

--- a/src/features/generation/worker/generators/overhang.ts
+++ b/src/features/generation/worker/generators/overhang.ts
@@ -44,6 +44,7 @@ export interface OverhangExpansion {
 /** Clamp an `OverhangConfig` to outward-only values; absent → all zero. */
 export function resolveOverhang(overhang: OverhangConfig | undefined): ResolvedOverhang {
   if (!overhang) return ZERO;
+  if (overhang.enabled === false) return ZERO;
   return {
     left: Math.max(0, overhang.left),
     right: Math.max(0, overhang.right),

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -581,7 +581,6 @@
   "binDesigner.loadingSharedDesign": "Geteiltes Design wird geladen",
   "binDesigner.moreActionsForDesign": "Weitere Aktionen für {name}",
   "binDesigner.multiColor.enableHint": "Weise verschiedenen Bin-Teilen unterschiedliche Filamente zu und exportiere eine mehrfarbige 3MF-Datei.",
-  "binDesigner.multiColor.enableLabel": "Mehrfarbig aktivieren",
   "binDesigner.multiColor.experimental": "Experimentell",
   "binDesigner.newDesign": "Neues Design",
   "binDesigner.newDesignConfirm": "Neues Design starten? Dein aktuelles Design wird gespeichert und kann später geladen werden.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1571,7 +1571,6 @@ const en: Record<string, string> = {
   'binDesigner.group.base': 'Base',
   'binDesigner.group.colors': 'Multi-Color',
   'binDesigner.multiColor.experimental': 'Experimental',
-  'binDesigner.multiColor.enableLabel': 'Enable multi-color',
   'binDesigner.multiColor.enableHint':
     'Assign different filaments to bin parts and export a multi-color 3MF.',
   'binDesigner.colors.body': 'Body',
@@ -1939,7 +1938,7 @@ const en: Record<string, string> = {
     'Start a new design? Your current design is saved and can be loaded later.',
   'binDesigner.newDesignCreated': 'New design created',
   'binDesigner.moreOptions': 'More options',
-  'binDesigner.setAsDefault': 'Set current settings as default for new bins',
+  'binDesigner.setAsDefault': 'Set as default for new bins',
   'binDesigner.savedAsDefault': 'Saved as the default for new bins',
   'binDesigner.resetFactoryDefaults': 'Reset to factory defaults',
   'binDesigner.factoryDefaultsRestored': 'Factory defaults restored',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -581,7 +581,6 @@
   "binDesigner.loadingSharedDesign": "Cargando diseño compartido",
   "binDesigner.moreActionsForDesign": "Más acciones para {name}",
   "binDesigner.multiColor.enableHint": "Asigna diferentes filamentos a las partes del bin y exporta un 3MF multicolor.",
-  "binDesigner.multiColor.enableLabel": "Activar multicolor",
   "binDesigner.multiColor.experimental": "Experimental",
   "binDesigner.newDesign": "Nuevo Diseño",
   "binDesigner.newDesignConfirm": "¿Iniciar un nuevo diseño? Tu diseño actual se guarda y se puede cargar más tarde.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -581,7 +581,6 @@
   "binDesigner.loadingSharedDesign": "Chargement du design partagé",
   "binDesigner.moreActionsForDesign": "Plus d'actions pour {name}",
   "binDesigner.multiColor.enableHint": "Assignez différents filaments aux pièces du bac et exportez un 3MF multicolore.",
-  "binDesigner.multiColor.enableLabel": "Activer le multicolore",
   "binDesigner.multiColor.experimental": "Expérimental",
   "binDesigner.newDesign": "Nouveau Design",
   "binDesigner.newDesignConfirm": "Commencer un nouveau design ? Votre design actuel est sauvegardé et peut être chargé ultérieurement.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -581,7 +581,6 @@
   "binDesigner.loadingSharedDesign": "共有デザインを読み込み中",
   "binDesigner.moreActionsForDesign": "{name}のその他の操作",
   "binDesigner.multiColor.enableHint": "ビンの各パーツに異なるフィラメントを割り当てて、マルチカラー3MFをエクスポートします。",
-  "binDesigner.multiColor.enableLabel": "マルチカラーを有効化",
   "binDesigner.multiColor.experimental": "試験的",
   "binDesigner.newDesign": "新しいデザイン",
   "binDesigner.newDesignConfirm": "新しいデザインを開始しますか?現在のデザインは保存され、後で読み込み可能です。",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -581,7 +581,6 @@
   "binDesigner.loadingSharedDesign": "Laster delt design",
   "binDesigner.moreActionsForDesign": "Flere handlinger for {name}",
   "binDesigner.multiColor.enableHint": "Tildel ulike filamenter til delene av bingen og eksporter en flerfarget 3MF-fil.",
-  "binDesigner.multiColor.enableLabel": "Aktiver flerfarget",
   "binDesigner.multiColor.experimental": "Eksperimentell",
   "binDesigner.newDesign": "Nytt design",
   "binDesigner.newDesignConfirm": "Starte et nytt design? Det nåværende designet ditt er lagret og kan lastes inn igjen senere.",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -581,7 +581,6 @@
   "binDesigner.loadingSharedDesign": "Gedeeld design laden",
   "binDesigner.moreActionsForDesign": "Meer acties voor {name}",
   "binDesigner.multiColor.enableHint": "Wijs verschillende filamenten toe aan bakonderdelen en exporteer een meerkleurig 3MF-bestand.",
-  "binDesigner.multiColor.enableLabel": "Meerkleurig inschakelen",
   "binDesigner.multiColor.experimental": "Experimenteel",
   "binDesigner.newDesign": "Nieuw design",
   "binDesigner.newDesignConfirm": "Een nieuw ontwerp starten? Je huidige ontwerp is opgeslagen en kan later worden geladen.",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -581,7 +581,6 @@
   "binDesigner.loadingSharedDesign": "Carregando design compartilhado",
   "binDesigner.moreActionsForDesign": "Mais ações para {name}",
   "binDesigner.multiColor.enableHint": "Atribua diferentes filamentos às partes do compartimento e exporte um 3MF multicolorido.",
-  "binDesigner.multiColor.enableLabel": "Ativar multicolorido",
   "binDesigner.multiColor.experimental": "Experimental",
   "binDesigner.newDesign": "Novo Design",
   "binDesigner.newDesignConfirm": "Iniciar um novo design? Seu design atual está salvo e pode ser carregado mais tarde.",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -581,7 +581,6 @@
   "binDesigner.loadingSharedDesign": "Laddar delad design",
   "binDesigner.moreActionsForDesign": "Fler åtgärder för {name}",
   "binDesigner.multiColor.enableHint": "Tilldela olika filament till bin-delar och exportera en flerfärgad 3MF-fil.",
-  "binDesigner.multiColor.enableLabel": "Aktivera flerfärgad",
   "binDesigner.multiColor.experimental": "Experimentell",
   "binDesigner.newDesign": "Ny design",
   "binDesigner.newDesignConfirm": "Starta en ny design? Din nuvarande design är sparad och kan laddas senare.",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -581,7 +581,6 @@
   "binDesigner.loadingSharedDesign": "Завантаження спільного дизайну",
   "binDesigner.moreActionsForDesign": "Більше дій для {name}",
   "binDesigner.multiColor.enableHint": "Призначте різні філаменти для частин контейнера і експортуйте багатоколірний файл 3MF.",
-  "binDesigner.multiColor.enableLabel": "Увімкнути багатоколірний режим",
   "binDesigner.multiColor.experimental": "Експериментальний",
   "binDesigner.newDesign": "Новий дизайн",
   "binDesigner.newDesignConfirm": "Почати новий дизайн? Ваш поточний дизайн збережено й може бути завантажений пізніше.",

--- a/src/shared/components/FeatureToggle/FeatureToggle.tsx
+++ b/src/shared/components/FeatureToggle/FeatureToggle.tsx
@@ -53,8 +53,10 @@ export function FeatureToggle({
 
   return (
     <div>
-      {/* Toggle row */}
-      <div className="flex items-center justify-between py-1.5">
+      {/* Toggle row — vertical rhythm is owned by the parent container
+          (PanelSection leading / a stacking `space-y`), not this row, so a
+          toggle never adds padding on top of an already-padded section. */}
+      <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span className="text-xs text-content-secondary">{label}</span>
           {!disabledReason && comingSoon && (


### PR DESCRIPTION
## Summary

Sidebar polish pass for the bin designer — standardizes feature controls on the shared `FeatureToggle` pattern and tightens the typographic/spacing rhythm.

### Feature toggles
- **Overhang**: `Collapsible` → `FeatureToggle`. Adds an explicit `enabled` flag to `OverhangConfig` so per-side values are retained while the feature is off (mirrors how Scoop keeps its radius); `resolveOverhang` returns zero when `enabled === false`, and legacy designs (no flag) still infer enablement from any non-zero side.
- **Multi-color**: dissolved the redundant "Multi-Color" group panel (the panel wrapped a toggle that did the same job) into a standalone `FeatureToggle`. Moved it into the **Base** group between Base and Physical Units, dropped "Enable" from the title, and restyled its Experimental badge to match the former custom-shape badge.
- **Lid**: folded into the Walls section so it's no longer its own bordered block.

### Visual polish
- Removed the Experimental badges from Custom shape and Lid (Multi-color keeps the now-warning-styled one).
- Un-bolded the wall-thickness `SnappingSlider` label to match feature-toggle titles (also normalizes the Lid/Compartment sliders).
- Dropped the `(…mm)` figures from the Shape group header summary.
- Centered the physical-dimension readout under the width/depth steppers.
- Shortened "Set as default for new bins" so it fits on one line at normal size.

### i18n
- Removed the orphaned `binDesigner.multiColor.enableLabel` from `en.ts` + all 9 locale JSONs (the toggle label now reuses `binDesigner.group.colors` = "Multi-Color", already translated everywhere). Regenerated `en.json`.

## Test plan
- `pnpm typecheck` ✅
- `pnpm lint` (changed files) ✅
- `check:i18n`, `check:i18n:unused`, `check:i18n:values`, `check:i18n:interpolation` ✅
- Affected unit tests green (Overhang, Multi-color, ParameterPanel, Dimensions, Shape, Lid, SetDefaultFooter, overhang generator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)