### PR TITLE
fix(baseplate): snap-clip resists pull-apart via seam-side retaining wall

### DIFF
--- a/src/features/generation/worker/generators/baseplateConnectors.ts
+++ b/src/features/generation/worker/generators/baseplateConnectors.ts
@@ -413,13 +413,21 @@ export function buildDovetailKey(totalHeight: number): Shape3D {
 /**
  * Blind snap-clip pocket on one seam side: a narrow throat (top → ledge) over a
  * wider chamber (ledge → floor). The throat passes the leg but blocks the barb;
- * the barb springs into the chamber and catches the ledge. Returned as two
- * stacked cutters (throat, chamber) to subtract from the slab. Mirror of the
- * snap clip's leg cross-section; pocket carries the clearance.
+ * the barb springs into the chamber and catches the ledge.
  *
- * Levels come from the shared `snapClipLevels` so the pocket, the clip, and the
- * seated-clip preview can't drift. Proven standalone with brepjs-verify: at the
- * thin 5mm slab the seated clip clears the pockets with zero interference.
+ * The throat is cut in three Z-bands so a RETAINING WALL is left solid between
+ * the seam and the leg's inner face — the wall the leg bears against to resist
+ * pull-apart (the two seam sides' walls meet at the seam, nesting between the
+ * clip's prongs):
+ *   - bridge recess (top → −BRIDGE_THK): open across the seam so the flush bridge
+ *     clears it,
+ *   - bearing band (−BRIDGE_THK → bearBottomZ): inner edge stops at `bearWallX`,
+ *     leaving the wall solid where the leg root barely flexes,
+ *   - lower throat (bearBottomZ → ledge): open to the seam again so the leg tip
+ *     can still pinch inward to seat the barb.
+ * The chamber below stays open for the sprung barb. Returned as four stacked
+ * cutters. Levels come from the shared `snapClipLevels` so pocket, clip, and
+ * preview can't drift.
  */
 export function makeSnapPocket(
   pt: (wall: number, bp: number) => [number, number],
@@ -430,20 +438,31 @@ export function makeSnapPocket(
 ): Shape3D[] {
   const ext = COPLANAR_MARGIN;
   const ov = COPLANAR_OVERLAP;
+  const br = SNAP_CLIP.BRIDGE_THK;
   const halfL = SNAP_CLIP.LEG_L / 2 + lv.cl;
-  const rect = (depthX: number) =>
-    draw(pt(w + d * ext, bp + halfL))
-      .lineTo(pt(w - d * depthX, bp + halfL))
-      .lineTo(pt(w - d * depthX, bp - halfL))
-      .lineTo(pt(w + d * ext, bp - halfL))
+  // Box from cross-seam depth `innerX`→`outerX` into the piece (innerX = −ext
+  // reaches past the seam = open; innerX = bearWallX leaves the retaining wall).
+  const rect = (innerX: number, outerX: number) =>
+    draw(pt(w - d * innerX, bp + halfL))
+      .lineTo(pt(w - d * outerX, bp + halfL))
+      .lineTo(pt(w - d * outerX, bp - halfL))
+      .lineTo(pt(w - d * innerX, bp - halfL))
       .close();
-  // Throat: from just above the top (Z=+margin) down to the ledge (Z=catchZ).
-  const throat = sketch(rect(lv.throatDepthX), 'XY', ext).extrude(-(ext - lv.catchZ));
-  // Chamber: from just above the ledge down to the pocket floor (sealed).
-  const chamber = sketch(rect(lv.chamberDepthX), 'XY', lv.catchZ + ov).extrude(
+  // Bridge recess: open across the seam for the flush bridge channel.
+  const recess = sketch(rect(-ext, lv.throatDepthX), 'XY', ext).extrude(-(ext + br));
+  // Bearing band: inner wall at bearWallX leaves the retaining wall solid.
+  const bearing = sketch(rect(lv.bearWallX, lv.throatDepthX), 'XY', -br + ov).extrude(
+    lv.bearBottomZ - (-br + ov)
+  );
+  // Lower throat: open to the seam again so the leg tip can flex inward.
+  const lowerThroat = sketch(rect(-ext, lv.throatDepthX), 'XY', lv.bearBottomZ + ov).extrude(
+    lv.catchZ - (lv.bearBottomZ + ov)
+  );
+  // Chamber: ledge → sealed floor, wider outer wall for the sprung barb.
+  const chamber = sketch(rect(-ext, lv.chamberDepthX), 'XY', lv.catchZ + ov).extrude(
     -(lv.catchZ + ov + lv.pocketDepth)
   );
-  return [throat, chamber];
+  return [recess, bearing, lowerThroat, chamber];
 }
 
 /** Per-side gap between the relieved clip and the nominal seated bin foot (mm). */

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.snapClip.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.snapClip.test.ts
@@ -173,16 +173,16 @@ describe('baseplateGenerator — snap-clip connectors (issue #1610)', () => {
   it(
     'clip prints bed-flat with top-bridge corners relieved for the edge sockets',
     () => {
-      // SOCKET_HEIGHT slab (no magnets) = 5mm. The sharp staple is 60.45mm³;
-      // the FDM-balanced edge treatments (slot-root fillets, top chamfer,
-      // slot-mouth fillets) plus relieving the top-bridge corners against the
-      // four neighbouring full-cell bin feet leave ~53.8mm³, and a seated clip
-      // clears bins in the edge sockets flanking each seam (see
-      // snapClipSocketInterference.test.ts).
+      // SOCKET_HEIGHT slab (no magnets) = 5mm. The FDM-balanced edge treatments
+      // (slot-root fillets, top chamfer, slot-mouth fillets) plus relieving the
+      // top-bridge corners against the four neighbouring full-cell bin feet leave
+      // ~46.6mm³ (legs trimmed to LEG_W 0.95 to make room for the retaining wall
+      // while keeping the outer footprint), and a seated clip clears bins in the
+      // edge sockets flanking each seam (see snapClipSocketInterference.test.ts).
       const totalHeight = 5;
       const clip = buildSnapClip(totalHeight, 42);
       const vClip = vol(clip);
-      expect(vClip, 'relieved + filleted clip volume').toBeCloseTo(53.8, 1);
+      expect(vClip, 'relieved + filleted clip volume').toBeCloseTo(46.6, 1);
 
       // Print orientation is a rigid transform — volume is preserved exactly.
       const printClip = buildSnapClipForPrint(totalHeight, 42);

--- a/src/features/generation/worker/generators/snapClipPullApart.test.ts
+++ b/src/features/generation/worker/generators/snapClipPullApart.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+/**
+ * Pull-apart capture — the snap clip's PRIMARY job.
+ *
+ * The clip bridges the seam; for it to resist the two plates being pulled apart,
+ * each leg must be buried in solid plate material on its SEAM side, so that
+ * pulling a plate away from the seam rams that wall into the leg (bearing in
+ * shear) — exactly like a real staple.
+ *
+ * This models one plate (a plain slab with the real seam pocket cut into it) and
+ * the real clip, seats them at a shared seam at x=0, then translates the plate
+ * away from the seam and asserts the clip now blocks it (interference volume
+ * jumps). The pre-fix design cut the pocket OPEN to the seam, so pulling apart
+ * only retreats the walls and the clip blocks nothing — this test fails there.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { measureVolume, translate, intersect, cutAll, draw } from 'brepjs';
+import type { ValidSolid } from 'brepjs';
+import { isOk, unwrap } from '@/core/result';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import { buildSnapClip, makeSnapPocket } from './baseplateConnectors';
+import { snapClipLevels } from './generatorConstants';
+
+const vol = (s: Parameters<typeof measureVolume>[0]): number => {
+  const r = measureVolume(s);
+  if (!isOk(r)) throw new Error('measureVolume failed');
+  return r.value;
+};
+
+const overlap = (a: ValidSolid, b: ValidSolid): number => {
+  const i = intersect(a, b);
+  return isOk(i) ? vol(i.value) : 0;
+};
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+describe('snap-clip pull-apart capture (issue #1610 follow-up)', () => {
+  const GU = 42;
+  const H = 5; // SOCKET_HEIGHT slab, worst case (thinnest viable)
+  const PULL = 0.4; // mm of plate separation to probe (> seated clearance)
+
+  // Right plate: solid body x∈[0,GU] with the seam at x=0 (its left edge is the
+  // join). The real seam pocket is cut from the slab so the bearing geometry is
+  // identical to what the generator produces.
+  function rightPlateWithPocket(): ValidSolid {
+    const lv = snapClipLevels(H, 0);
+    const ptX = (wall: number, bp: number): [number, number] => [wall, bp];
+    const box = draw([0, -GU / 2])
+      .lineTo([GU, -GU / 2])
+      .lineTo([GU, GU / 2])
+      .lineTo([0, GU / 2])
+      .close()
+      .sketchOnPlane('XY', 0)
+      .extrude(-H);
+    const cutters = makeSnapPocket(ptX, 0, 0, -1, lv) as ValidSolid[];
+    const plate = unwrap(cutAll(box as ValidSolid, cutters));
+    cutters.forEach((c) => c.delete());
+    return plate;
+  }
+
+  it('seats with clearance but blocks the plate from being pulled apart', () => {
+    const clip = buildSnapClip(H, GU); // seam at x=0
+
+    // Seated: a clearance fit, so essentially no interference (sub-tolerance
+    // contact from the fillet/corner mismatch between the crisp pocket and the
+    // filleted clip is expected).
+    expect(overlap(clip, rightPlateWithPocket()), 'seated clearance fit').toBeLessThan(0.2);
+
+    // Pulled away from the seam: the clip must now bear against the plate.
+    const pulled = translate(rightPlateWithPocket(), [PULL, 0, 0]);
+    expect(overlap(clip, pulled), 'clip blocks pull-apart').toBeGreaterThan(0.5);
+  }, 60_000);
+});

--- a/src/features/generation/worker/generators/snapClipPullApart.test.ts
+++ b/src/features/generation/worker/generators/snapClipPullApart.test.ts
@@ -15,7 +15,7 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { measureVolume, translate, intersect, cutAll, draw } from 'brepjs';
-import type { ValidSolid } from 'brepjs';
+import type { Shape3D, ValidSolid } from 'brepjs';
 import { isOk, unwrap } from '@/core/result';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 import { buildSnapClip, makeSnapPocket } from './baseplateConnectors';
@@ -29,7 +29,12 @@ const vol = (s: Parameters<typeof measureVolume>[0]): number => {
 
 const overlap = (a: ValidSolid, b: ValidSolid): number => {
   const i = intersect(a, b);
-  return isOk(i) ? vol(i.value) : 0;
+  // Fail loudly rather than returning 0 — a swallowed boolean error would let the
+  // "seated clearance fit" assertion pass spuriously.
+  if (!isOk(i)) throw new Error('intersect failed');
+  const v = vol(i.value);
+  i.value.delete();
+  return v;
 };
 
 beforeAll(async () => {
@@ -57,6 +62,7 @@ describe('snap-clip pull-apart capture (issue #1610 follow-up)', () => {
     const cutters = makeSnapPocket(ptX, 0, 0, -1, lv) as ValidSolid[];
     const plate = unwrap(cutAll(box as ValidSolid, cutters));
     cutters.forEach((c) => c.delete());
+    if ((plate as Shape3D) !== box) box.delete();
     return plate;
   }
 
@@ -66,10 +72,16 @@ describe('snap-clip pull-apart capture (issue #1610 follow-up)', () => {
     // Seated: a clearance fit, so essentially no interference (sub-tolerance
     // contact from the fillet/corner mismatch between the crisp pocket and the
     // filleted clip is expected).
-    expect(overlap(clip, rightPlateWithPocket()), 'seated clearance fit').toBeLessThan(0.2);
+    const seated = rightPlateWithPocket();
+    expect(overlap(clip, seated), 'seated clearance fit').toBeLessThan(0.2);
+    seated.delete();
 
     // Pulled away from the seam: the clip must now bear against the plate.
-    const pulled = translate(rightPlateWithPocket(), [PULL, 0, 0]);
+    const plate = rightPlateWithPocket();
+    const pulled = translate(plate, [PULL, 0, 0]);
+    plate.delete();
     expect(overlap(clip, pulled), 'clip blocks pull-apart').toBeGreaterThan(0.5);
+    pulled.delete();
+    clip.delete();
   }, 60_000);
 });

--- a/src/shared/constants/connectors.ts
+++ b/src/shared/constants/connectors.ts
@@ -90,16 +90,30 @@ export function effectiveClearance(
  * inward past the pocket throat, then splay out so the barbs catch the chamber
  * ledge. Mirror grooves on both seam sides form the blind pockets.
  *
- * Validated standalone via brepjs-verify: clip is a valid solid, and the seated
- * clip clears the pockets with zero interference (fuse-volume == tiles + clip).
+ * Pull-apart resistance: the pocket leaves a solid seam-side WALL intact in the
+ * upper band (the leg root, which barely flexes), so a leg's inner face bears
+ * against it — pulling the plates apart rams that wall into the leg like a real
+ * staple. The lower band stays open to the seam so the leg tip can still pinch
+ * inward to seat the barb. The legs sit `GAP_HALF` off the seam, leaving room for
+ * the wall, with `LEG_W` trimmed to keep the original outer footprint (so the
+ * clip still clears the bin feet in the cells flanking the seam).
+ *
  * The depths below are clamped to the slab height at build time so the snap
  * still seats on a thin baseplate and deepens automatically on taller bases.
  */
 export const SNAP_CLIP = {
-  /** Half-width of the central flex slot (inner leg face sits at ±this). */
-  GAP_HALF: 0.75,
-  /** Leg thickness across the seam (mm). */
-  LEG_W: 1.2,
+  /** Half-width of the central flex slot (inner leg face sits at ±this). Also the
+   *  nominal seam-side wall thickness: the pocket leaves plate solid out to here. */
+  GAP_HALF: 1.0,
+  /** Leg thickness across the seam (mm). Trimmed from the original 1.2 so the
+   *  wider GAP_HALF keeps the same outer face (`GAP_HALF + LEG_W`) and bin clearance. */
+  LEG_W: 0.95,
+  /** Height of the seam-side retaining wall below the bridge (mm) — the band the
+   *  leg's inner face bears against. Tall for a substantial grip, but clamped
+   *  above the catch ledge (never eats the snap) and leaving enough free leg below
+   *  to flex: the leg only deflects in its lower span, so the upper band the wall
+   *  fills barely moves on insertion. */
+  BEAR_DEPTH: 1.2,
   /** Outward barb protrusion past the leg face = engagement depth (mm). */
   BARB_DEPTH: 0.45,
   /** Top bridge thickness; also the flush-recess depth in the slab top (mm). */
@@ -149,6 +163,12 @@ export interface SnapClipLevels {
   readonly throatDepthX: number;
   /** Pocket chamber outer-wall depth into the piece (mm). */
   readonly chamberDepthX: number;
+  /** Seam-side wall depth into the piece in the bearing band (= GAP_HALF − cl);
+   *  the leg's inner face bears against this for pull-apart resistance. */
+  readonly bearWallX: number;
+  /** Bottom Z of the seam-side bearing band (negative), clamped above the catch
+   *  ledge so it never eats the snap. Above this the pocket leaves the wall solid. */
+  readonly bearBottomZ: number;
 }
 
 /**
@@ -181,6 +201,10 @@ export function snapClipLevels(
   const barbTip = legOuter + barbDepth;
   const viable =
     legBottom - SNAP_CLIP.BRIDGE_THK >= SNAP_CLIP.MIN_LEG && catchZ < -SNAP_CLIP.BRIDGE_THK;
+  // Retaining wall: plate left solid out to the leg's inner face (minus clearance)
+  // from the bridge underside down to the bearing-band bottom — clamped above the
+  // catch ledge so it never eats the snap chamber.
+  const bearBottomZ = Math.max(-(SNAP_CLIP.BRIDGE_THK + SNAP_CLIP.BEAR_DEPTH), catchZ);
   return {
     viable,
     cl,
@@ -193,5 +217,7 @@ export function snapClipLevels(
     barbTip,
     throatDepthX: legOuter + cl,
     chamberDepthX: barbTip + cl,
+    bearWallX: SNAP_CLIP.GAP_HALF - cl,
+    bearBottomZ,
   };
 }

--- a/src/shared/constants/connectors.ts
+++ b/src/shared/constants/connectors.ts
@@ -106,7 +106,10 @@ export const SNAP_CLIP = {
    *  nominal seam-side wall thickness: the pocket leaves plate solid out to here. */
   GAP_HALF: 1.0,
   /** Leg thickness across the seam (mm). Trimmed from the original 1.2 so the
-   *  wider GAP_HALF keeps the same outer face (`GAP_HALF + LEG_W`) and bin clearance. */
+   *  wider GAP_HALF keeps the same outer face (`GAP_HALF + LEG_W` = 1.95) at the
+   *  0.4mm baseline, preserving bin clearance. On wider nozzles `scaleFeature`
+   *  floors leg width to 2× the nozzle, so the outer face grows by the GAP_HALF
+   *  increase (~0.25mm) — acceptable on the rarer big-nozzle snap clips. */
   LEG_W: 0.95,
   /** Height of the seam-side retaining wall below the bridge (mm) — the band the
    *  leg's inner face bears against. Tall for a substantial grip, but clamped


### PR DESCRIPTION
## Problem

The snap-clip baseplate connector (`connectorStyle: 'snapClip'`) provided only **vertical (lift-out) retention** — it did nothing to stop the two baseplates from being **pulled apart** across the seam, which is the connector's primary job.

Root cause: the seam pockets were cut *open to the seam*, so every pocket wall that touched a leg sat on the **outer** side and retreated as the plates separated. The barbs catch a horizontal (Z) ledge, which resists the clip lifting out — not the plates spreading. With a clearance fit and nothing on the seam side to bear against, pull-apart resistance was ≈ 0.

## Fix

Leave a solid **retaining wall** between the seam and each leg's inner face, in the upper band just under the bridge (the leg root, which barely flexes). The two seam-sides' walls meet at the seam and **nest between the clip's prongs**, so pulling the plates apart rams the wall into the legs — bearing in shear, like a real staple. The lower band stays open to the seam so the leg tip can still pinch inward to seat the barb.

- **Prongs:** legs spread (`GAP_HALF` 0.75→1.0) and thinned (`LEG_W` 1.2→0.95) to make room for the wall while keeping the **same outer footprint** (legOuter 1.95, barbTip 2.4) — so bin-foot clearance is unchanged.
- **Baseplate pocket:** split into bridge-recess / bearing-band / lower-throat / chamber; the bearing band leaves the wall solid.
- **Clip shape, chamfer, and root fillets are unchanged.**

Bearing-band height (`BEAR_DEPTH` 1.2mm) is clamped above the catch ledge (never eats the snap) and leaves enough free leg below to flex. Wall height vs. snap flex is a tunable trade-off.

## Verification

All brepjs scenario tests green:
- **`snapClipPullApart` (new):** seats with clearance, but pulling a plate off the seam is now blocked by the clip (the fix; was 0mm³ interference, fails on the old geometry).
- Watertight + valid bed-flat print · clears the adjacent bin feet · snap zone intact · catch-ledge backed · nozzle scaling.
- 508 baseplate/sample tests · typecheck + lint clean.

Note: the test proves *geometric* capture; real-world hold is "firm staple," not a hard interlock — a print test is the final confirmation.