### PR TITLE
fix(sidebar): non-sticky footer, trim attribution, and dev content-route parity

### DIFF
--- a/scripts/vite-plugin-content-routes.ts
+++ b/scripts/vite-plugin-content-routes.ts
@@ -1,0 +1,59 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import type { Plugin } from 'vite';
+
+// Mirror of vercel.json's content rewrites. The prod CDN serves the generated
+// public/<slug>/index.html for these extensionless paths, but Vite's dev server
+// has no equivalent — the SPA history fallback swallows them and returns the app
+// shell instead. This dev-only middleware reproduces the rewrite so the Learn
+// links resolve to the same static pages locally as they do in production.
+const PUBLIC_DIR = fileURLToPath(new URL('../public', import.meta.url));
+
+const SLUGS = [
+  'what-is-gridfinity',
+  'guide',
+  'privacy',
+  'terms',
+  'gridfinity-bin-generator',
+  'gridfinity-baseplate-generator',
+  'gridfinity-sizes',
+];
+
+// privacy/terms are English-only in prod (omitted from the localized rewrite).
+const LOCALIZED_SLUGS = SLUGS.filter((s) => s !== 'privacy' && s !== 'terms');
+const LOCALES = ['de', 'fr', 'es', 'pt-BR', 'nl', 'sv', 'nb', 'uk'];
+
+const ROUTE = new RegExp(`^/(${SLUGS.join('|')})/?$`);
+const LOCALIZED_ROUTE = new RegExp(`^/(${LOCALES.join('|')})/(${LOCALIZED_SLUGS.join('|')})/?$`);
+
+export function contentRoutesPlugin(): Plugin {
+  return {
+    name: 'content-routes-dev',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const pathname = (req.url ?? '').split('?')[0];
+
+        let file: string | null = null;
+        const plain = ROUTE.exec(pathname);
+        if (plain) {
+          file = path.join(PUBLIC_DIR, plain[1], 'index.html');
+        } else {
+          const localized = LOCALIZED_ROUTE.exec(pathname);
+          if (localized) {
+            file = path.join(PUBLIC_DIR, localized[1], localized[2], 'index.html');
+          }
+        }
+
+        if (!file || !existsSync(file)) {
+          next();
+          return;
+        }
+
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        res.end(readFileSync(file));
+      });
+    },
+  };
+}

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -665,8 +665,9 @@ export function BaseplatePanel() {
             printBedSize={printBedSize}
           />
         )}
+
+        <AttributionFooter />
       </div>
-      <AttributionFooter />
       {cloudSyncEnabled && <UserDock />}
     </div>
   );

--- a/src/shared/components/AttributionFooter/AttributionFooter.test.tsx
+++ b/src/shared/components/AttributionFooter/AttributionFooter.test.tsx
@@ -17,7 +17,6 @@ describe('AttributionFooter', () => {
     render(<AttributionFooter />);
     expect(screen.getByRole('link', { name: /Zack Freedman/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Andy Aragon/ })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /GitHub/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Privacy/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Terms/ })).toBeInTheDocument();
   });

--- a/src/shared/components/AttributionFooter/AttributionFooter.tsx
+++ b/src/shared/components/AttributionFooter/AttributionFooter.tsx
@@ -55,15 +55,6 @@ export function AttributionFooter() {
       </a>{' '}
       ·{' '}
       <a
-        href="https://github.com/andymai/gridfinity-layout-tool"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-content-tertiary hover:underline"
-      >
-        {t('sidebar.github')}
-      </a>{' '}
-      ·{' '}
-      <a
         href="/privacy"
         target="_blank"
         rel="noopener noreferrer"

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -472,11 +472,6 @@ export function Sidebar() {
                         className="input w-14 py-0.5 px-1 text-xs text-right"
                       />
                     </SettingsRow>
-                    <p className="text-[10px] text-content-tertiary mt-0.5">
-                      {t('settings.gridfinityStandardMm', {
-                        value: CONSTRAINTS.GRID_UNIT_MM_DEFAULT,
-                      })}
-                    </p>
                   </div>
                   <div data-help-target="height-unit">
                     <SettingsRow
@@ -494,11 +489,6 @@ export function Sidebar() {
                         className="input w-14 py-0.5 px-1 text-xs text-right"
                       />
                     </SettingsRow>
-                    <p className="text-[10px] text-content-tertiary mt-0.5">
-                      {t('settings.gridfinityStandardMm', {
-                        value: CONSTRAINTS.HEIGHT_UNIT_MM_DEFAULT,
-                      })}
-                    </p>
                   </div>
                   <div data-help-target="print-bed-size">
                     <SettingsRow

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import wasm from 'vite-plugin-wasm';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { fileURLToPath, URL } from 'node:url';
 import { versionPlugin } from './scripts/vite-plugin-version';
+import { contentRoutesPlugin } from './scripts/vite-plugin-content-routes';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -44,6 +45,7 @@ export default defineConfig({
     react(),
     tailwindcss(),
     versionPlugin(),
+    contentRoutesPlugin(),
     VitePWA({
       // 'prompt' so the smoke gate (src/shared/pwa/smokeGate.ts) controls activation.
       // With 'autoUpdate' the new SW would auto-skip-waiting on install, defeating the gate.


### PR DESCRIPTION
## Summary

Three small, related sidebar/footer cleanups plus a dev-server fix surfaced while working on them.

### Footer
- **Non-sticky footer everywhere.** `AttributionFooter` now lives inside each panel's `overflow-y-auto` scroll region (baseplate, main sidebar, and bin-designer) so it scrolls with content instead of pinning to the bottom. Previously baseplate pinned it; now all panels behave the same. `UserDock` (the account dock) is unchanged — it stays pinned as before.
- **Removed the standalone GitHub link** from `AttributionFooter` (the version label still links to the GitHub releases page).
- **Removed the "Standard Gridfinity: Nmm" helper text** under the Grid unit / Height unit inputs in the desktop Physical units panel.

### Dev tooling
- **`vite-plugin-content-routes`** — a dev-only middleware that mirrors the production `vercel.json` content rewrites. Vite's dev server doesn't honor `vercel.json`, so extensionless Learn links (`/what-is-gridfinity`, `/guide`, `/gridfinity-bin-generator`, `/gridfinity-baseplate-generator`, `/gridfinity-sizes`, `/privacy`, `/terms`, plus locale-prefixed variants) fell through the SPA history fallback to the app shell instead of serving the generated `public/<slug>/index.html`. They worked in production but 404'd/served-the-app locally. Now they resolve identically in dev.

## Verification
- `pnpm run typecheck` clean.
- ESLint clean on changed files.
- Verified locally on the dev server: `/what-is-gridfinity`, `/guide`, `/gridfinity-sizes`, and `/de/guide` now serve the correct landing-page HTML; app routes like `/designer` still fall through to the SPA shell.
- Confirmed production was already serving these correctly (HTTP 200 + real content), so no `vercel.json` change was needed.

## Notes
The `settings.gridfinityStandardMm` and `sidebar.github` i18n keys remain in use elsewhere (mobile settings panel, settings modal, mobile header), so nothing is orphaned.