### PR TITLE
fix: tighten grid-size stepper and stacked-baseplate preview spacing

### DIFF
--- a/src/features/baseplate/README.md
+++ b/src/features/baseplate/README.md
@@ -33,7 +33,7 @@ graph TB
 - `utils/buildFullParams.ts` — resolves sync mode (drawer dims vs custom width/depth); strips connectors, magnet holes, and corner rounding when stack printing is on
 - `utils/stackPrint.ts` — stack planning (groups → capped physical stacks) + `buildTowerLayers` (bottom plate upright, the rest flipped, all XY-aligned)
 - `utils/stackExport.ts` — bakes a stack into export triangle soup (single material)
-- `utils/stackPreview.ts` — lays the towers out in a centered, roughly-square grid for the 3D preview
+- `utils/stackPreview.ts` — lays the towers out in a centered, roughly-square grid for the 3D preview. `TOWER_GAP_UNITS` (1) is the whole-unit clearance between adjacent towers — one grid unit (~42mm) reads as "separate printed pieces" while keeping every cell on the scene's integer footprint grid
 - `utils/fileNaming.ts` — descriptive/compact/custom filename generation
 - `constants.ts` — MAX_BASEPLATE_DIMENSION (16), EXPLODE_GAP_MM (10), piece color palette
 

--- a/src/features/baseplate/utils/stackPreview.test.ts
+++ b/src/features/baseplate/utils/stackPreview.test.ts
@@ -52,17 +52,17 @@ describe('buildStackPreviewMeshes', () => {
     );
     const b = meshBounds(out.plates.vertices);
     // 2 towers -> 2 cols x 1 row. Cells snap to whole grid units: a 20mm-wide
-    // tower rounds to 1 unit, + TOWER_GAP_UNITS (2) = 3 units → cellW 3*42=126.
-    // Centered cols at ±63; each 20mm tower spans ±10 -> X bounds [-73, 73].
-    expect(b.minX).toBeCloseTo(-73, 4);
-    expect(b.maxX).toBeCloseTo(73, 4);
-    expect(out.widthMm).toBeCloseTo(252, 4);
+    // tower rounds to 1 unit, + TOWER_GAP_UNITS (1) = 2 units → cellW 2*42=84.
+    // Centered cols at ±42; each 20mm tower spans ±10 -> X bounds [-52, 52].
+    expect(b.minX).toBeCloseTo(-52, 4);
+    expect(b.maxX).toBeCloseTo(52, 4);
+    expect(out.widthMm).toBeCloseTo(168, 4);
   });
 
   // Towers tile into a roughly-square grid (cols = ceil(sqrt(n))), centered on
   // origin — a single off-screen row was the "single line" preview bug. Cells
   // snap to whole grid units so towers align to the scene grid: 20×30 plate →
-  // 1×1 units → (1+2)×(1+2) = 3×3 cells = 126×126mm.
+  // 1×1 units → (1+1)×(1+1) = 2×2 cells = 84×84mm.
   describe('grid layout (parameterized)', () => {
     const cases = [
       { towers: 1, cols: 1, rows: 1 },
@@ -80,8 +80,8 @@ describe('buildStackPreviewMeshes', () => {
         0,
         42
       );
-      expect(out.widthMm).toBeCloseTo(cols * 126, 4);
-      expect(out.depthMm).toBeCloseTo(rows * 126, 4);
+      expect(out.widthMm).toBeCloseTo(cols * 84, 4);
+      expect(out.depthMm).toBeCloseTo(rows * 84, 4);
       // Centered on origin in X and Y.
       const b = meshBounds(out.plates.vertices);
       expect(b.minX).toBeCloseTo(-b.maxX, 3);

--- a/src/features/baseplate/utils/stackPreview.ts
+++ b/src/features/baseplate/utils/stackPreview.ts
@@ -15,12 +15,13 @@ import {
 } from './stackPrint';
 
 /**
- * Empty grid units kept around each tower so its cell spans a whole number of
- * grid cells. An even gap (one unit of margin per side) lands the tower's own
- * edges on grid lines, so towers sit squarely on the scene's footprint grid —
- * whether there's one tower or many.
+ * Empty grid units of clearance between towers. Added to each tower's
+ * whole-unit footprint so every cell still spans an integer number of grid
+ * cells (keeping towers on the scene's footprint grid), while one unit of
+ * separation reads clearly as "separate printed pieces" without leaving an
+ * empty grid cell of dead space around each tower.
  */
-const TOWER_GAP_UNITS = 2;
+const TOWER_GAP_UNITS = 1;
 
 export interface StackPreviewTower {
   readonly mesh: StackMeshArrays;

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -331,6 +331,7 @@ export function Sidebar() {
                         max={CONSTRAINTS.GRID_MAX}
                         step={widthStep}
                         size="sm"
+                        fullWidth
                         aria-label={t('sidebar.drawerWidthAria')}
                       />
                     </div>
@@ -349,6 +350,7 @@ export function Sidebar() {
                         max={CONSTRAINTS.GRID_MAX}
                         step={depthStep}
                         size="sm"
+                        fullWidth
                         aria-label={t('sidebar.drawerDepthAria')}
                       />
                     </div>
@@ -365,6 +367,7 @@ export function Sidebar() {
                         min={1}
                         max={CONSTRAINTS.GRID_MAX}
                         size="sm"
+                        fullWidth
                         aria-label={t('sidebar.drawerHeightAria')}
                         displayValue={`${drawer.height}u`}
                       />


### PR DESCRIPTION
Two small visual-spacing fixes.

## 1. Grid Size steppers touching (sidebar)
Regression from the Stepper consolidation (#2127). The old \`StepperControl\` was a block-level \`flex\` that filled each \`grid-cols-3\` track (input \`flex-1\`, no min-width), so \`gap-1.5\` separated the Width/Depth/Height controls. The design-system \`Stepper\` defaults to \`inline-flex\` plus a \`min-w-[34px]\` input floor, so each rendered at natural width inside the fixed track and the gaps visually collapsed.

**Fix:** apply the \`fullWidth\` prop (added in #2136 for exactly this) to all three steppers — container becomes \`flex w-full\`, fills its track, input absorbs slack, gap restored.

## 2. Stacked baseplates too far apart (`/baseplate` preview)
\`TOWER_GAP_UNITS = 2\` padded every tower's cell by 2 grid units → 1 empty grid unit of margin per side → 2 empty grid units between adjacent towers, so a split drawer's plates looked spread far apart. (The vertical air gap is ≤1mm, so it wasn't that.) The "even gap for grid-line registration" rationale doesn't hold — the grid is centered on origin, so even tower counts already sit at half-cell offsets.

**Fix:** reduce \`TOWER_GAP_UNITS\` to \`1\`. One unit of clearance still reads as separate printed pieces, cells stay whole-unit (towers grid-aligned), sprawl halved. Updated the three test expectations (126→84mm cells).

## Testing
- 45 sidebar tests pass
- 11 stackPreview tests pass
- typecheck clean