### PR TITLE
feat(export): grant exports a far higher timeout ceiling

### DIFF
--- a/src/features/generation/bridge/GenerationBridge.test.ts
+++ b/src/features/generation/bridge/GenerationBridge.test.ts
@@ -440,8 +440,9 @@ describe('GenerationBridge', () => {
       ) as { payload: { requestId: string } };
       expect(exportMsg).toBeDefined();
 
-      // Default bin timeout is at least BASE (30s); advance well past it.
-      await vi.advanceTimersByTimeAsync(120_000);
+      // Export timeout is the complexity budget (BASE 30s for a default bin)
+      // scaled by EXPORT_TIMEOUT_MULTIPLIER (×4 = 120s); advance well past it.
+      await vi.advanceTimersByTimeAsync(180_000);
 
       const result = await settled;
       expect(result).toBeInstanceOf(Error);

--- a/src/features/generation/bridge/bridgeExports.ts
+++ b/src/features/generation/bridge/bridgeExports.ts
@@ -10,7 +10,11 @@
 
 import type { BinParams, BaseplateParams, SplitConnectorConfig } from '@/shared/types/bin';
 import type { WorkerMessage, ExportFormat } from './types';
-import { computeBaseplateTimeoutMs, computeGenerationTimeoutMs } from './generationTimeout';
+import {
+  computeBaseplateExportTimeoutMs,
+  computeExportTimeoutMs,
+  EXPORT_MAX_TIMEOUT_MS,
+} from './generationTimeout';
 import type {
   ExportResult,
   DividersExportResult,
@@ -70,7 +74,7 @@ export function exportBin(
   return runExport<ExportResult>(
     ctx,
     'export',
-    computeGenerationTimeoutMs(params),
+    computeExportTimeoutMs(params),
     (requestId) => ({
       type: 'EXPORT',
       payload: {
@@ -92,7 +96,7 @@ export function exportDividers(
   return runExport<DividersExportResult>(
     ctx,
     'dividers',
-    computeGenerationTimeoutMs(params),
+    computeExportTimeoutMs(params),
     (requestId) => ({ type: 'EXPORT_DIVIDERS', payload: { params, requestId } })
   );
 }
@@ -110,7 +114,7 @@ export function exportCombined(
   return runExport<CombinedExportResult>(
     ctx,
     'combined',
-    computeGenerationTimeoutMs(params),
+    computeExportTimeoutMs(params),
     (requestId) => ({
       type: 'EXPORT_COMBINED',
       payload: {
@@ -139,7 +143,7 @@ export function exportSplitBin(
   return runExport<SplitExportResult>(
     ctx,
     'split',
-    computeGenerationTimeoutMs(params),
+    computeExportTimeoutMs(params),
     (requestId) => ({
       type: 'EXPORT_SPLIT',
       payload: {
@@ -165,7 +169,7 @@ export function generateSplitPreview(
   return runExport<SplitPreviewResult>(
     ctx,
     'splitPreview',
-    computeGenerationTimeoutMs(params),
+    computeExportTimeoutMs(params),
     (requestId) => ({
       type: 'GENERATE_SPLIT_PREVIEW',
       payload: {
@@ -190,7 +194,7 @@ export function generateSplitPreviewRange(
   return runExport<SplitPreviewResult>(
     ctx,
     'splitPreview',
-    computeGenerationTimeoutMs(params),
+    computeExportTimeoutMs(params),
     (requestId) => ({
       type: 'GENERATE_SPLIT_PREVIEW_RANGE',
       payload: {
@@ -220,7 +224,7 @@ export function exportSplitBinRange(
   return runExport<SplitExportResult>(
     ctx,
     'split',
-    computeGenerationTimeoutMs(params),
+    computeExportTimeoutMs(params),
     (requestId) => ({
       type: 'EXPORT_SPLIT_RANGE',
       payload: {
@@ -246,7 +250,7 @@ export function exportBaseplate(
   return runExport<BaseplateExportResult>(
     ctx,
     'export',
-    computeBaseplateTimeoutMs(params),
+    computeBaseplateExportTimeoutMs(params),
     (requestId) => ({
       type: 'EXPORT_BASEPLATE',
       payload: {
@@ -273,7 +277,7 @@ export function exportConnectorKey(
   return runExport<BaseplateExportResult>(
     ctx,
     'export',
-    computeBaseplateTimeoutMs(params),
+    computeBaseplateExportTimeoutMs(params),
     (requestId) => ({
       type: 'EXPORT_CONNECTOR_KEY',
       payload: {
@@ -290,9 +294,12 @@ export function exportConnectorKey(
 /**
  * Export the connector fit-sample tray. The tray's work (≈30 coupon booleans +
  * embossed labels) is fixed regardless of the user's baseplate footprint, so it
- * uses a fixed generous timeout rather than the footprint-derived budget.
+ * uses a fixed generous timeout rather than the footprint-derived budget. Like
+ * every other export it runs on the user's (possibly slow) hardware and is
+ * cancellable, so it shares the high export ceiling — the timeout only guards
+ * against a wedged worker, not interactive wait.
  */
-const CONNECTOR_SAMPLE_TIMEOUT_MS = 180_000;
+const CONNECTOR_SAMPLE_TIMEOUT_MS = EXPORT_MAX_TIMEOUT_MS;
 
 export function exportConnectorSample(
   ctx: BridgeExportContext,

--- a/src/features/generation/bridge/bridgeExports.ts
+++ b/src/features/generation/bridge/bridgeExports.ts
@@ -13,6 +13,7 @@ import type { WorkerMessage, ExportFormat } from './types';
 import {
   computeBaseplateExportTimeoutMs,
   computeExportTimeoutMs,
+  computeGenerationTimeoutMs,
   EXPORT_MAX_TIMEOUT_MS,
 } from './generationTimeout';
 import type {
@@ -169,7 +170,10 @@ export function generateSplitPreview(
   return runExport<SplitPreviewResult>(
     ctx,
     'splitPreview',
-    computeExportTimeoutMs(params),
+    // Interactive preview (re-runs as the user drags cut planes), not a
+    // user-committed export — keep the 3-minute preview clamp so a wedged
+    // worker is cancelled promptly rather than after the 15-minute export cap.
+    computeGenerationTimeoutMs(params),
     (requestId) => ({
       type: 'GENERATE_SPLIT_PREVIEW',
       payload: {
@@ -194,7 +198,8 @@ export function generateSplitPreviewRange(
   return runExport<SplitPreviewResult>(
     ctx,
     'splitPreview',
-    computeExportTimeoutMs(params),
+    // Interactive preview (see generateSplitPreview) — preview clamp, not export.
+    computeGenerationTimeoutMs(params),
     (requestId) => ({
       type: 'GENERATE_SPLIT_PREVIEW_RANGE',
       payload: {

--- a/src/features/generation/bridge/generationTimeout.test.ts
+++ b/src/features/generation/bridge/generationTimeout.test.ts
@@ -14,7 +14,11 @@ import {
   HEX_FOOTPRINT_BONUS_FLOOR_CELLS,
   HEIGHT_BONUS_MS,
   MAX_TIMEOUT_MS,
+  EXPORT_TIMEOUT_MULTIPLIER,
+  EXPORT_MAX_TIMEOUT_MS,
   computeBaseplateTimeoutMs,
+  computeBaseplateExportTimeoutMs,
+  computeExportTimeoutMs,
   computeGenerationTimeoutMs,
 } from './generationTimeout';
 
@@ -301,5 +305,99 @@ describe('computeBaseplateTimeoutMs', () => {
     // Honeycomb bins are now the heaviest pipeline, so baseplates no longer get a
     // higher ceiling than bins — both clamp at the agreed 3-minute cap.
     expect(BASEPLATE_MAX_TIMEOUT_MS).toBe(MAX_TIMEOUT_MS);
+  });
+});
+
+describe('computeExportTimeoutMs', () => {
+  it('scales a trivial bin by the export multiplier', () => {
+    // raw = BASE (30s); export = BASE × multiplier. Exports run on the user's
+    // possibly-slow hardware and are user-committed + cancellable, so they get a
+    // far more generous budget than the live preview.
+    expect(computeExportTimeoutMs(params({ height: 3 }))).toBe(
+      BASE_TIMEOUT_MS * EXPORT_TIMEOUT_MULTIPLIER
+    );
+  });
+
+  it('preserves the complexity ordering — a hex bin still gets more than a plain one', () => {
+    const plain = computeExportTimeoutMs(params({ height: 3 }));
+    const hex = computeExportTimeoutMs(params({ height: 3, wallPattern: HEX_ON }));
+    expect(hex).toBeGreaterThan(plain);
+    // Specifically: (BASE + hex bonus) × multiplier.
+    expect(hex).toBe((BASE_TIMEOUT_MS + HEX_PATTERN_BONUS_MS) * EXPORT_TIMEOUT_MULTIPLIER);
+  });
+
+  it('runs well past the preview ceiling for heavy bins', () => {
+    // A bin that clamps to the 3-minute preview cap should get a much larger
+    // export budget — the whole point of the change.
+    const t = computeExportTimeoutMs(
+      params({ width: 20, depth: 20, height: 20, wallPattern: HEX_ON })
+    );
+    expect(t).toBeGreaterThan(MAX_TIMEOUT_MS);
+  });
+
+  it('caps at the export ceiling', () => {
+    // 20×20×20 hex raw ≈ 261s; ×4 ≈ 1044s, above the 900s export ceiling → clamp.
+    const t = computeExportTimeoutMs(
+      params({ width: 20, depth: 20, height: 20, wallPattern: HEX_ON })
+    );
+    expect(t).toBe(EXPORT_MAX_TIMEOUT_MS);
+  });
+
+  it('clamps non-finite or invalid dimensions into the supported range', () => {
+    const cases = [
+      params({ width: Number.NaN, depth: 8, height: 6, wallPattern: HEX_ON }),
+      params({ width: 8, depth: Number.POSITIVE_INFINITY, height: 6, wallPattern: HEX_ON }),
+      params({ width: -4, depth: 8, height: 6, wallPattern: HEX_ON }),
+      params({ width: 8, depth: 8, height: Number.NaN, wallPattern: HEX_ON }),
+    ];
+    for (const p of cases) {
+      const t = computeExportTimeoutMs(p);
+      expect(Number.isFinite(t)).toBe(true);
+      expect(t).toBeGreaterThanOrEqual(BASE_TIMEOUT_MS);
+      expect(t).toBeLessThanOrEqual(EXPORT_MAX_TIMEOUT_MS);
+    }
+  });
+});
+
+describe('computeBaseplateExportTimeoutMs', () => {
+  it('scales a plain baseplate by the export multiplier', () => {
+    expect(computeBaseplateExportTimeoutMs(bpParams())).toBe(
+      BASE_TIMEOUT_MS * EXPORT_TIMEOUT_MULTIPLIER
+    );
+  });
+
+  it('scales the magnet bonus alongside the base', () => {
+    // (BASE + 9-cell magnet bonus) × multiplier.
+    const t = computeBaseplateExportTimeoutMs(bpParams({ width: 3, depth: 3, magnetHoles: true }));
+    expect(t).toBe(
+      (BASE_TIMEOUT_MS + 9 * BASEPLATE_MAGNET_MS_PER_CELL) * EXPORT_TIMEOUT_MULTIPLIER
+    );
+  });
+
+  it('never exceeds the export ceiling regardless of input', () => {
+    const t = computeBaseplateExportTimeoutMs(
+      bpParams({
+        width: 1000,
+        depth: 1000,
+        magnetHoles: true,
+        connectorNubs: true,
+        lightweight: true,
+      })
+    );
+    expect(t).toBeLessThanOrEqual(EXPORT_MAX_TIMEOUT_MS);
+  });
+
+  it('clamps non-finite and invalid dimensions into the supported range', () => {
+    const cases = [
+      bpParams({ width: Number.NaN, depth: 3, magnetHoles: true }),
+      bpParams({ width: 3, depth: Number.POSITIVE_INFINITY, magnetHoles: true }),
+      bpParams({ width: -1, depth: 3, magnetHoles: true }),
+    ];
+    for (const p of cases) {
+      const t = computeBaseplateExportTimeoutMs(p);
+      expect(Number.isFinite(t)).toBe(true);
+      expect(t).toBeGreaterThanOrEqual(BASE_TIMEOUT_MS);
+      expect(t).toBeLessThanOrEqual(EXPORT_MAX_TIMEOUT_MS);
+    }
   });
 });

--- a/src/features/generation/bridge/generationTimeout.ts
+++ b/src/features/generation/bridge/generationTimeout.ts
@@ -191,20 +191,15 @@ export const BASEPLATE_LIGHTWEIGHT_BONUS_MS = 5_000;
 export const BASEPLATE_MAX_TIMEOUT_MS = 180_000;
 
 /**
- * Compute the timeout budget for a baseplate generation, in milliseconds.
+ * Uncapped complexity budget for a baseplate, in milliseconds — the raw sum of
+ * the base budget plus every applicable bonus, before any ceiling is applied.
+ * Shared by the preview and export budgets (see {@link binRawBudgetMs}).
  *
  * Formula:
  *   BASE_TIMEOUT_MS
  * + min(BASEPLATE_MAGNET_BONUS_CAP_MS, ceil(w) * ceil(d) * BASEPLATE_MAGNET_MS_PER_CELL)  [if magnetHoles]
  * + BASEPLATE_CONNECTOR_BONUS_MS  [if connectorNubs]
  * + BASEPLATE_LIGHTWEIGHT_BONUS_MS  [if lightweight]
- *
- * Clamped to `[BASE_TIMEOUT_MS, BASEPLATE_MAX_TIMEOUT_MS]`.
- */
-/**
- * Uncapped complexity budget for a baseplate, in milliseconds — the raw sum of
- * the base budget plus every applicable bonus, before any ceiling is applied.
- * Shared by the preview and export budgets (see {@link binRawBudgetMs}).
  */
 function baseplateRawBudgetMs(params: BaseplateParams): number {
   // Defensive against transient bad inputs — mid-edit UI state can briefly

--- a/src/features/generation/bridge/generationTimeout.ts
+++ b/src/features/generation/bridge/generationTimeout.ts
@@ -73,6 +73,31 @@ export const HEIGHT_BONUS_BUCKET_UNITS = 2;
  */
 export const MAX_TIMEOUT_MS = 180_000;
 
+/**
+ * Multiplier applied to the complexity-derived budget when the request is a
+ * user-initiated **export** rather than a live preview.
+ *
+ * The preview ceilings ({@link MAX_TIMEOUT_MS}, {@link BASEPLATE_MAX_TIMEOUT_MS})
+ * are tuned for "how long a user should wait while iterating" on a *reference*
+ * machine. An export is different on two axes: the user has explicitly committed
+ * to it (clicked Export, will wait, can cancel) AND it runs on *their* hardware,
+ * which can be several times slower than the machine these budgets were measured
+ * on — a low-end laptop or a throttled mobile browser can easily take 3–4× as
+ * long on the single-threaded OCCT pipeline. A flat multiplier models exactly
+ * that hardware gap while preserving the relative ordering the complexity budget
+ * already encodes (a hex bin still gets proportionally more than a trivial one).
+ */
+export const EXPORT_TIMEOUT_MULTIPLIER = 4;
+
+/**
+ * Hard ceiling for exports — set far above the 3-minute preview cap because an
+ * export is terminal and cancellable, so the only job of this clamp is to stop a
+ * genuinely-wedged WASM heap from hanging forever, not to bound interactive
+ * wait. 15 minutes comfortably covers the heaviest known pipeline (a 6×6×20
+ * honeycomb's ~3-minute pattern cut, ×4 for slow hardware ≈ 12 min) with margin.
+ */
+export const EXPORT_MAX_TIMEOUT_MS = 900_000;
+
 function hasAnyActiveCutoutSide(params: BinParams): boolean {
   const { walls } = params;
   if (!walls.enabled) return false;
@@ -86,16 +111,17 @@ function hasAnyActiveCutoutSide(params: BinParams): boolean {
 }
 
 /**
- * Compute the timeout budget for a bin generation, in milliseconds.
- *
- * Clamped to `[BASE_TIMEOUT_MS, MAX_TIMEOUT_MS]`.
+ * Uncapped complexity budget for a bin, in milliseconds — the raw sum of the
+ * base budget plus every applicable bonus, before any ceiling is applied. Kept
+ * separate from the clamping so preview and export can share one cost model and
+ * differ only in their ceiling (and the export multiplier).
  */
-export function computeGenerationTimeoutMs(params: BinParams): number {
+function binRawBudgetMs(params: BinParams): number {
   // Defensive against transient bad inputs — mid-edit UI state can briefly
   // present NaN/negative dimensions. setTimeout(NaN) coerces to 0ms, which would
   // cancel the request before the worker can run. Floor bad dims to 0 (no
-  // footprint/height bonus) and clamp the result below. Mirrors
-  // computeBaseplateTimeoutMs.
+  // footprint/height bonus); callers clamp to BASE below. Mirrors
+  // baseplateRawBudgetMs.
   const safeWidth = Number.isFinite(params.width) && params.width > 0 ? params.width : 0;
   const safeDepth = Number.isFinite(params.depth) && params.depth > 0 ? params.depth : 0;
   const safeHeight = Number.isFinite(params.height) && params.height > 0 ? params.height : 0;
@@ -119,9 +145,28 @@ export function computeGenerationTimeoutMs(params: BinParams): number {
   const heightBuckets = Math.floor(heightOverFloor / HEIGHT_BONUS_BUCKET_UNITS);
   timeout += heightBuckets * HEIGHT_BONUS_MS;
 
-  // Clamp to [BASE, MAX] — the guards above keep `timeout` finite, and this
-  // makes the documented contract self-enforcing.
-  return Math.max(BASE_TIMEOUT_MS, Math.min(MAX_TIMEOUT_MS, timeout));
+  return timeout;
+}
+
+/**
+ * Compute the timeout budget for a live bin **preview** generation, in
+ * milliseconds. Clamped to `[BASE_TIMEOUT_MS, MAX_TIMEOUT_MS]`.
+ */
+export function computeGenerationTimeoutMs(params: BinParams): number {
+  // The raw budget is finite by construction (guards in binRawBudgetMs), so this
+  // clamp also makes the documented contract self-enforcing.
+  return Math.max(BASE_TIMEOUT_MS, Math.min(MAX_TIMEOUT_MS, binRawBudgetMs(params)));
+}
+
+/**
+ * Compute the timeout budget for a user-initiated bin **export**, in
+ * milliseconds. Same complexity cost model as the preview, scaled by
+ * {@link EXPORT_TIMEOUT_MULTIPLIER} for slower user hardware and clamped to
+ * `[BASE_TIMEOUT_MS, EXPORT_MAX_TIMEOUT_MS]`.
+ */
+export function computeExportTimeoutMs(params: BinParams): number {
+  const scaled = binRawBudgetMs(params) * EXPORT_TIMEOUT_MULTIPLIER;
+  return Math.max(BASE_TIMEOUT_MS, Math.min(EXPORT_MAX_TIMEOUT_MS, scaled));
 }
 
 /** Per-cell cost of magnet-hole boolean subtractions, in ms. */
@@ -156,7 +201,12 @@ export const BASEPLATE_MAX_TIMEOUT_MS = 180_000;
  *
  * Clamped to `[BASE_TIMEOUT_MS, BASEPLATE_MAX_TIMEOUT_MS]`.
  */
-export function computeBaseplateTimeoutMs(params: BaseplateParams): number {
+/**
+ * Uncapped complexity budget for a baseplate, in milliseconds — the raw sum of
+ * the base budget plus every applicable bonus, before any ceiling is applied.
+ * Shared by the preview and export budgets (see {@link binRawBudgetMs}).
+ */
+function baseplateRawBudgetMs(params: BaseplateParams): number {
   // Defensive against transient bad inputs — mid-edit UI state can briefly
   // present NaN/negative dimensions. The generator's sanitizeParams will
   // reject them, but the bridge computes this timeout first and setTimeout
@@ -181,7 +231,29 @@ export function computeBaseplateTimeoutMs(params: BaseplateParams): number {
     timeout += BASEPLATE_LIGHTWEIGHT_BONUS_MS;
   }
 
-  // Clamp to [BASE, MAX]. Redundant given the guards above, but makes the
-  // documented contract self-enforcing if bonuses are ever signed or reworked.
-  return Math.max(BASE_TIMEOUT_MS, Math.min(BASEPLATE_MAX_TIMEOUT_MS, timeout));
+  return timeout;
+}
+
+/**
+ * Compute the timeout budget for a live baseplate **preview** generation, in
+ * milliseconds. Clamped to `[BASE_TIMEOUT_MS, BASEPLATE_MAX_TIMEOUT_MS]`.
+ */
+export function computeBaseplateTimeoutMs(params: BaseplateParams): number {
+  // The raw budget is finite by construction (guards in baseplateRawBudgetMs),
+  // so this clamp also makes the documented contract self-enforcing.
+  return Math.max(
+    BASE_TIMEOUT_MS,
+    Math.min(BASEPLATE_MAX_TIMEOUT_MS, baseplateRawBudgetMs(params))
+  );
+}
+
+/**
+ * Compute the timeout budget for a user-initiated baseplate **export**, in
+ * milliseconds. Same complexity cost model as the preview, scaled by
+ * {@link EXPORT_TIMEOUT_MULTIPLIER} for slower user hardware and clamped to
+ * `[BASE_TIMEOUT_MS, EXPORT_MAX_TIMEOUT_MS]`.
+ */
+export function computeBaseplateExportTimeoutMs(params: BaseplateParams): number {
+  const scaled = baseplateRawBudgetMs(params) * EXPORT_TIMEOUT_MULTIPLIER;
+  return Math.max(BASE_TIMEOUT_MS, Math.min(EXPORT_MAX_TIMEOUT_MS, scaled));
 }


### PR DESCRIPTION
## Why

Exports shared the **live-preview** timeout, which clamps at a 3-minute ceiling. That ceiling is tuned for interactive iteration on a *reference* machine — but an export is a different beast:

- **User-committed** — they clicked Export and will wait.
- **Terminal & cancellable** — there's progress + a cancel affordance.
- **Runs on the user's hardware** — which can be several times slower than the dev machine the budgets were measured on.

A complex bin/baseplate that finishes in ~3 min on a fast machine could legitimately exceed it on a low-end laptop or throttled mobile browser and time out mid-export.

## What

Split the cost model from the clamp in `generationTimeout.ts`:

- Extracted the uncapped **raw budget** (`binRawBudgetMs` / `baseplateRawBudgetMs`) — base budget + all complexity bonuses.
- **Preview** functions (`computeGenerationTimeoutMs`, `computeBaseplateTimeoutMs`) clamp it at the unchanged 3-min ceiling — **behavior identical to before**.
- **Export** functions (`computeExportTimeoutMs`, `computeBaseplateExportTimeoutMs`) apply `EXPORT_TIMEOUT_MULTIPLIER` (×4, modeling slow hardware) and clamp to a new 15-min `EXPORT_MAX_TIMEOUT_MS`.

Every export path in `bridgeExports.ts` now uses the export budget — **bins and baseplates** (`exportBaseplate`, `exportConnectorKey`), plus split/combined/dividers and the connector fit-sample (shares the high ceiling).

A constant **multiplier** (not a flat value) is intentional: the preview budget already encodes *relative* complexity correctly, so ×4 just says "assume up to 4× slower hardware" while keeping a hex bin proportionally longer than a trivial one. The high ceiling is safe precisely because exports have progress + cancel — the clamp's only remaining job is to stop a genuinely-wedged WASM heap, not to bound interactive wait.

## Tests

- Added `describe` blocks for both new functions: multiplier scaling, complexity ordering preserved, runs past the preview ceiling, export-ceiling clamp, NaN/negative guards.
- Bumped the bridge export-timeout test's advance to clear the new 120s default-export boundary.
- Full unit/dom suite green (13,539 passed, 0 failed); typecheck + lint clean.