### PR TITLE
fix(deps): bump protobufjs to 7.6.3 to resolve OSV blocking scan

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ overrides:
   dompurify: ^3.4.9
   '@babel/core@<7.29.6': ^7.29.6
   js-yaml@<4.2.0: ^4.2.0
-  protobufjs: ^7.5.8
+  protobufjs: ^7.6.3
   eslint-plugin-i18next>lodash: ^4.18.1
   vitest-axe>lodash-es: ^4.18.1
   picomatch@>=4.0.0 <4.0.4: ^4.0.4
@@ -1730,8 +1730,8 @@ packages:
   '@protobufjs/codegen@2.0.5':
     resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
 
   '@protobufjs/fetch@1.1.1':
     resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
@@ -4629,8 +4629,8 @@ packages:
   property-graph@4.1.0:
     resolution: {integrity: sha512-AvPcP7XECNWy4LGmFQ77k7un4lSKM4eS29PTvW4ck95uYeLxXPWJM7hLuBqK91FaHqCcgJvIUCuNJjjxKE7VKQ==}
 
-  protobufjs@7.6.0:
-    resolution: {integrity: sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==}
+  protobufjs@7.6.3:
+    resolution: {integrity: sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==}
     engines: {node: '>=12.0.0'}
 
   punycode@2.3.1:
@@ -6519,7 +6519,7 @@ snapshots:
       mersenne-twister: 1.1.0
       meshoptimizer: 1.1.1
       pako: 2.1.0
-      protobufjs: 7.6.0
+      protobufjs: 7.6.3
       rbush: 4.0.1
       topojson-client: 3.1.0
       urijs: 1.19.11
@@ -7148,7 +7148,7 @@ snapshots:
 
   '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.1': {}
 
   '@protobufjs/fetch@1.1.1':
     dependencies:
@@ -9991,12 +9991,12 @@ snapshots:
 
   property-graph@4.1.0: {}
 
-  protobufjs@7.6.0:
+  protobufjs@7.6.3:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
       '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/eventemitter': 1.1.1
       '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
       '@protobufjs/inquire': 1.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,7 +67,7 @@ overrides:
   dompurify: '^3.4.9'
   '@babel/core@<7.29.6': '^7.29.6'
   'js-yaml@<4.2.0': '^4.2.0'
-  protobufjs: '^7.5.8'
+  protobufjs: '^7.6.3'
   'eslint-plugin-i18next>lodash': '^4.18.1'
   'vitest-axe>lodash-es': '^4.18.1'
   'picomatch@>=4.0.0 <4.0.4': '^4.0.4'


### PR DESCRIPTION
## Summary

The blocking OSV scan fails on \`protobufjs@7.6.0\` (transitive devDependency via \`gltf-pipeline → cesium\`):

| Advisory | CVSS | Fixed in |
| --- | --- | --- |
| [GHSA-wcpc-wj8m-hjx6](https://osv.dev/GHSA-wcpc-wj8m-hjx6) | 7.5 (High) | 7.6.1 |
| [GHSA-f38q-mgvj-vph7](https://osv.dev/GHSA-f38q-mgvj-vph7) | 5.3 (Medium) | 7.6.3 |

The existing \`protobufjs: ^7.5.8\` override permitted 7.6.3 but the lockfile was pinned to 7.6.0. Tightened the override floor to \`^7.6.3\` and re-resolved.

## Changes

- \`pnpm-workspace.yaml\`: \`protobufjs\` override \`^7.5.8\` → \`^7.6.3\`
- \`pnpm-lock.yaml\`: \`protobufjs\` 7.6.0 → 7.6.3 (and sub-dep \`@protobufjs/eventemitter\` 1.1.0 → 1.1.1)

\`protobufjs\` is already in \`minimumReleaseAgeExclude\`, so the 7-day cooldown does not block the patch.

## Test plan

- [ ] OSV Scan (blocking) passes