### PR TITLE
refactor(design-system): migrate baseplate buttons to Button/IconButton

### DIFF
--- a/scripts/design-system-allowlist.txt
+++ b/scripts/design-system-allowlist.txt
@@ -27,13 +27,6 @@
 # SegmentedControl/primitive for those in a dedicated effort rather than a
 # button-by-button swap.
 
-src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
-src/features/baseplate/components/BaseplatePanel/ConnectorPicker.tsx
-src/features/baseplate/components/BaseplatePanel/EditableDimensions.tsx
-src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
-src/features/baseplate/components/BaseplatePreview/BaseplatePreviewControls.tsx
-src/features/baseplate/components/PaddingAnchor/PaddingAnchor.tsx
-src/features/baseplate/components/PaddingStepper/PaddingStepper.tsx
 src/features/bin-designer/components/CompartmentEditor/DividerHitTargets.tsx
 src/features/bin-designer/components/CompartmentEditor/DividerTiltSubsection.tsx
 src/features/bin-designer/components/CutoutWorkspace/CutoutBoardSettings.tsx

--- a/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
+++ b/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
@@ -18,6 +18,7 @@ import { gridUnits } from '@/core/types';
 import { useTranslation } from '@/i18n';
 import { useResponsive } from '@/shared/hooks/useResponsive';
 
+import { Button } from '@/design-system';
 import { ToolSwitcher } from '@/shared/components/ToolSwitcher';
 import { HeaderSupportLinks } from '@/shared/components/HeaderSupportLinks';
 import { useBaseplateRouting } from '@/shared/hooks/useBaseplateRouting';
@@ -213,7 +214,9 @@ export function BaseplatePage() {
         <div className="flex items-center gap-3 min-w-0">
           <ToolSwitcher compact={isMobile} iconOnly={isMobile || isTablet} />
 
-          <button
+          <Button
+            type="button"
+            variant="ghost"
             onClick={() => setExportDialogOpen(true)}
             disabled={!canExport || isExporting}
             className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-content-secondary transition-all bg-transparent hover:bg-surface-hover hover:text-content disabled:opacity-50 disabled:pointer-events-none"
@@ -252,7 +255,7 @@ export function BaseplatePage() {
               </svg>
             )}
             <span className="hidden lg:inline">{t('common.export')}</span>
-          </button>
+          </Button>
         </div>
 
         {isDesktop && (

--- a/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
+++ b/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
@@ -219,7 +219,7 @@ export function BaseplatePage() {
             variant="ghost"
             onClick={() => setExportDialogOpen(true)}
             disabled={!canExport || isExporting}
-            className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-content-secondary transition-all bg-transparent hover:bg-surface-hover hover:text-content disabled:opacity-50 disabled:pointer-events-none"
+            className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm font-normal text-content-secondary transition-all bg-transparent hover:bg-surface-hover hover:text-content disabled:opacity-50 disabled:pointer-events-none"
             title={t('common.export')}
             aria-label={t('common.export')}
           >

--- a/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useCallback, useRef, type KeyboardEvent, type ReactNode } from 'react';
+import { Button } from '@/design-system';
 import { cn } from '@/design-system/cn';
 import { useTranslation } from '@/i18n';
 import {
@@ -106,8 +107,9 @@ export function ConnectorPicker({ value, onChange, renderExpanded }: ConnectorPi
                   : 'border-stroke-subtle bg-surface-elevated hover:bg-surface-hover'
               )}
             >
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 role="radio"
                 aria-checked={selected}
                 aria-label={t(titleKey)}
@@ -115,7 +117,7 @@ export function ConnectorPicker({ value, onChange, renderExpanded }: ConnectorPi
                 onClick={() => {
                   if (!selected) onChange(optionValue);
                 }}
-                className="flex w-full cursor-pointer items-start gap-3 text-left focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent"
+                className="flex h-auto w-full cursor-pointer items-start gap-3 bg-transparent p-0 text-left font-normal hover:bg-transparent focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent"
               >
                 <div className="mt-0.5 flex-shrink-0 text-content-secondary">
                   <Icon />
@@ -124,7 +126,7 @@ export function ConnectorPicker({ value, onChange, renderExpanded }: ConnectorPi
                   <h4 className="text-sm font-medium text-content-primary">{t(titleKey)}</h4>
                   <p className="mt-0.5 text-xs text-content-secondary">{t(descKey)}</p>
                 </div>
-              </button>
+              </Button>
 
               {expanded && (
                 <div className="mt-3 border-t border-stroke-subtle pt-3">{expanded}</div>

--- a/src/features/baseplate/components/BaseplatePanel/EditableDimensions.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/EditableDimensions.tsx
@@ -170,7 +170,7 @@ export function EditableDimensions({
       variant="ghost"
       type="button"
       onClick={enterEditMode}
-      className={`group inline-flex cursor-pointer items-center gap-1 !px-0 !py-0 underline decoration-dotted decoration-content-tertiary underline-offset-4 hover:decoration-content-secondary focus-visible:decoration-accent ${restClass} ${className ?? ''}`}
+      className={`group inline-flex cursor-pointer items-center gap-1 !px-0 !py-0 underline decoration-dotted decoration-content-tertiary underline-offset-4 hover:bg-transparent hover:text-content-secondary hover:decoration-content-secondary focus-visible:decoration-accent ${restClass} ${className ?? ''}`}
       aria-label={ariaLabel}
     >
       <span>

--- a/src/features/baseplate/components/BaseplatePanel/EditableDimensions.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/EditableDimensions.tsx
@@ -52,7 +52,7 @@ export function EditableDimensions({
 }: EditableDimensionsProps) {
   const restClass =
     variant === 'secondary'
-      ? 'text-xs tabular-nums text-content-secondary'
+      ? 'text-xs font-normal tabular-nums text-content-secondary'
       : 'text-sm font-semibold tabular-nums text-content';
   const separatorClass =
     variant === 'secondary' ? 'text-xs text-content-tertiary' : 'text-sm text-content-secondary';

--- a/src/features/baseplate/components/BaseplatePanel/EditableDimensions.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/EditableDimensions.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '@/design-system';
 import { PencilIcon } from '@/design-system/Icon';
 
 /** Format mm for display: minimum needed decimals, no trailing zeros. */
@@ -165,10 +166,11 @@ export function EditableDimensions({
   }
 
   return (
-    <button
+    <Button
+      variant="ghost"
       type="button"
       onClick={enterEditMode}
-      className={`group inline-flex cursor-pointer items-center gap-1 underline decoration-dotted decoration-content-tertiary underline-offset-4 hover:decoration-content-secondary focus-visible:decoration-accent ${restClass} ${className ?? ''}`}
+      className={`group inline-flex cursor-pointer items-center gap-1 !px-0 !py-0 underline decoration-dotted decoration-content-tertiary underline-offset-4 hover:decoration-content-secondary focus-visible:decoration-accent ${restClass} ${className ?? ''}`}
       aria-label={ariaLabel}
     >
       <span>
@@ -178,6 +180,6 @@ export function EditableDimensions({
         size="xs"
         className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
       />
-    </button>
+    </Button>
   );
 }

--- a/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
@@ -75,7 +75,7 @@ export function SplitViewStrip({
                   variant="ghost"
                   type="button"
                   touchTarget={false}
-                  className={`flex items-center justify-center rounded border bg-surface-elevated !px-0 py-1 text-[10px] font-mono font-normal transition-shadow ${
+                  className={`flex items-center justify-center rounded border bg-surface-elevated !px-0 py-1 text-[10px] font-mono font-normal transition-shadow hover:bg-surface-elevated ${
                     isSelected
                       ? 'ring-2 ring-accent border-accent text-content-primary'
                       : isHovered

--- a/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
@@ -3,6 +3,7 @@
  * Each cell is a hoverable/selectable button corresponding to one print-bed piece.
  */
 
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { colToLetter } from '../../utils/splitPlanner';
 import type { BaseplateTiling, PaddingReductionHint } from '../../types/tiling';
@@ -69,10 +70,12 @@ export function SplitViewStrip({
               const isHovered = hoveredPieceLabel === label;
               const isSelected = selectedPieceLabel === label;
               return (
-                <button
+                <Button
                   key={label}
+                  variant="ghost"
                   type="button"
-                  className={`flex items-center justify-center rounded border bg-surface-elevated py-1 text-[10px] font-mono transition-shadow ${
+                  touchTarget={false}
+                  className={`flex items-center justify-center rounded border bg-surface-elevated !px-0 py-1 text-[10px] font-mono transition-shadow ${
                     isSelected
                       ? 'ring-2 ring-accent border-accent text-content-primary'
                       : isHovered
@@ -86,7 +89,7 @@ export function SplitViewStrip({
                   aria-label={t('baseplate.pieceLabel', { label })}
                 >
                   {label}
-                </button>
+                </Button>
               );
             });
           })}

--- a/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
@@ -75,7 +75,7 @@ export function SplitViewStrip({
                   variant="ghost"
                   type="button"
                   touchTarget={false}
-                  className={`flex items-center justify-center rounded border bg-surface-elevated !px-0 py-1 text-[10px] font-mono transition-shadow ${
+                  className={`flex items-center justify-center rounded border bg-surface-elevated !px-0 py-1 text-[10px] font-mono font-normal transition-shadow ${
                     isSelected
                       ? 'ring-2 ring-accent border-accent text-content-primary'
                       : isHovered

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreviewControls.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreviewControls.tsx
@@ -333,7 +333,7 @@ export function BaseplatePreviewControls({
               type="button"
               variant="ghost"
               onClick={() => onCameraPreset(key)}
-              className={`flex items-center justify-center min-w-[44px] min-h-[44px] p-2 transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
+              className={`flex items-center justify-center min-w-[44px] min-h-[44px] p-2 rounded-none transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
                 isActive
                   ? 'bg-accent text-on-accent hover:bg-accent hover:text-on-accent'
                   : 'text-content-secondary hover:bg-surface-hover hover:text-content'
@@ -355,7 +355,7 @@ export function BaseplatePreviewControls({
           type="button"
           variant="ghost"
           onClick={onResetView}
-          className="flex items-center justify-center min-w-[44px] min-h-[44px] p-2 text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation"
+          className="flex items-center justify-center min-w-[44px] min-h-[44px] p-2 rounded-none text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation"
           title={t('baseplate.resetView')}
           aria-label={t('baseplate.resetView')}
         >
@@ -367,7 +367,7 @@ export function BaseplatePreviewControls({
           type="button"
           variant="ghost"
           onClick={onToggleXray}
-          className={`flex items-center justify-center min-w-[44px] min-h-[44px] p-2 transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
+          className={`flex items-center justify-center min-w-[44px] min-h-[44px] p-2 rounded-none transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
             xray
               ? 'bg-accent text-on-accent hover:bg-accent hover:text-on-accent'
               : 'text-content-secondary hover:bg-surface-hover hover:text-content'
@@ -384,7 +384,7 @@ export function BaseplatePreviewControls({
           type="button"
           variant="ghost"
           onClick={onToggleProjection}
-          className="flex items-center justify-center min-w-[44px] min-h-[44px] p-2 text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation"
+          className="flex items-center justify-center min-w-[44px] min-h-[44px] p-2 rounded-none text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation"
           title={t('baseplate.toggleProjection')}
           aria-label={t('baseplate.toggleProjectionKeyboardShortcut')}
           pressed={projection === 'orthographic'}
@@ -400,7 +400,7 @@ export function BaseplatePreviewControls({
           type="button"
           variant="ghost"
           onClick={() => setColorPickerOpen((v) => !v)}
-          className="flex items-center justify-center min-w-[44px] min-h-[44px] p-2 text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation"
+          className="flex items-center justify-center min-w-[44px] min-h-[44px] p-2 rounded-none text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation"
           title={t('baseplate.filamentColor')}
           aria-label={t('baseplate.filamentColor')}
           aria-expanded={colorPickerOpen}

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreviewControls.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreviewControls.tsx
@@ -50,13 +50,12 @@ function ColorPickerContent({
   return (
     <div className="grid grid-cols-7 gap-1.5">
       {FILAMENT_COLORS.map(({ color, nameKey }) => (
-        <IconButton
+        <Button
           key={color}
           type="button"
           variant="ghost"
-          touchTarget={false}
           onClick={() => onColorSelect(color)}
-          className={`rounded-md p-0.5 transition-colors hover:bg-surface-hover focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:outline-none ${
+          className={`h-auto w-auto rounded-md p-0.5 transition-colors hover:bg-surface-hover focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:outline-none ${
             previewColor === color ? 'ring-2 ring-accent bg-surface-hover' : ''
           }`}
           aria-label={t('colors.colorAriaLabel', { name: t(nameKey) })}
@@ -69,7 +68,7 @@ function ColorPickerContent({
             }`}
             style={{ backgroundColor: color }}
           />
-        </IconButton>
+        </Button>
       ))}
     </div>
   );

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreviewControls.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreviewControls.tsx
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useState, useCallback } from 'react';
+import { Button, IconButton } from '@/design-system';
 import { FILAMENT_COLORS } from '@/core/constants';
 import { useResponsive } from '@/shared/hooks/useResponsive';
 import { useTranslation } from '@/i18n';
@@ -49,9 +50,11 @@ function ColorPickerContent({
   return (
     <div className="grid grid-cols-7 gap-1.5">
       {FILAMENT_COLORS.map(({ color, nameKey }) => (
-        <button
+        <IconButton
           key={color}
           type="button"
+          variant="ghost"
+          touchTarget={false}
           onClick={() => onColorSelect(color)}
           className={`rounded-md p-0.5 transition-colors hover:bg-surface-hover focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:outline-none ${
             previewColor === color ? 'ring-2 ring-accent bg-surface-hover' : ''
@@ -66,7 +69,7 @@ function ColorPickerContent({
             }`}
             style={{ backgroundColor: color }}
           />
-        </button>
+        </IconButton>
       ))}
     </div>
   );
@@ -157,9 +160,10 @@ export function BaseplatePreviewControls({
               const Icon = VIEW_MODE_ICONS[value];
               const isActive = splitViewMode === value;
               return (
-                <button
+                <Button
                   key={value}
                   type="button"
+                  variant="ghost"
                   onClick={() => onViewModeChange(value)}
                   className={`flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
                     isActive
@@ -170,7 +174,7 @@ export function BaseplatePreviewControls({
                 >
                   <Icon />
                   <span>{t(labelKey)}</span>
-                </button>
+                </Button>
               );
             })}
           </div>
@@ -182,9 +186,10 @@ export function BaseplatePreviewControls({
             const Icon = PRESET_ICONS[key];
             const isActive = activePreset === key;
             return (
-              <button
+              <Button
                 key={key}
                 type="button"
+                variant="ghost"
                 onClick={() => onCameraPreset(key)}
                 className={`flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
                   isActive
@@ -197,7 +202,7 @@ export function BaseplatePreviewControls({
               >
                 <Icon />
                 <span>{t(labelKey)}</span>
-              </button>
+              </Button>
             );
           })}
 
@@ -205,8 +210,9 @@ export function BaseplatePreviewControls({
           <div className="w-px h-5 bg-stroke-subtle/50" />
 
           {/* Reset button */}
-          <button
+          <Button
             type="button"
+            variant="ghost"
             onClick={onResetView}
             className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
             title={t('baseplate.resetView')}
@@ -214,11 +220,12 @@ export function BaseplatePreviewControls({
           >
             <IconReset />
             <span>{t('common.reset')}</span>
-          </button>
+          </Button>
 
           {/* X-ray toggle */}
-          <button
+          <Button
             type="button"
+            variant="ghost"
             onClick={onToggleXray}
             className={`flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
               xray
@@ -231,11 +238,12 @@ export function BaseplatePreviewControls({
           >
             <IconXray />
             <span>{t('baseplate.xray')}</span>
-          </button>
+          </Button>
 
           {/* Projection toggle */}
-          <button
+          <Button
             type="button"
+            variant="ghost"
             onClick={onToggleProjection}
             className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
             title={t('baseplate.toggleProjection')}
@@ -248,14 +256,15 @@ export function BaseplatePreviewControls({
                 ? t('baseplate.projectionPerspective')
                 : t('baseplate.projectionOrthographic')}
             </span>
-          </button>
+          </Button>
 
           {/* Divider */}
           <div className="w-px h-5 bg-stroke-subtle/50" />
 
           {/* Color picker button */}
-          <button
+          <Button
             type="button"
+            variant="ghost"
             onClick={() => setColorPickerOpen((v) => !v)}
             className="flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
             title={t('baseplate.filamentColor')}
@@ -267,7 +276,7 @@ export function BaseplatePreviewControls({
               style={{ backgroundColor: filamentColor }}
             />
             <span>{t('common.color')}</span>
-          </button>
+          </Button>
         </div>
 
         {/* Color picker dropdown -- outside overflow-hidden container */}
@@ -294,9 +303,10 @@ export function BaseplatePreviewControls({
             const Icon = VIEW_MODE_ICONS[value];
             const isActive = splitViewMode === value;
             return (
-              <button
+              <Button
                 key={value}
                 type="button"
+                variant="ghost"
                 onClick={() => onViewModeChange(value)}
                 className={`flex items-center justify-center gap-1 px-3 min-h-[44px] text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
                   isActive
@@ -307,7 +317,7 @@ export function BaseplatePreviewControls({
               >
                 <Icon />
                 <span>{t(labelKey)}</span>
-              </button>
+              </Button>
             );
           })}
         </div>
@@ -319,9 +329,10 @@ export function BaseplatePreviewControls({
           const Icon = PRESET_ICONS[key];
           const isActive = activePreset === key;
           return (
-            <button
+            <IconButton
               key={key}
               type="button"
+              variant="ghost"
               onClick={() => onCameraPreset(key)}
               className={`flex items-center justify-center min-w-[44px] min-h-[44px] p-2 transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
                 isActive
@@ -330,10 +341,10 @@ export function BaseplatePreviewControls({
               }`}
               title={t(labelKey)}
               aria-label={t(labelKey)}
-              aria-pressed={isActive}
+              pressed={isActive}
             >
               <Icon />
-            </button>
+            </IconButton>
           );
         })}
 
@@ -341,19 +352,21 @@ export function BaseplatePreviewControls({
         <div className="w-px h-5 bg-stroke-subtle/50" />
 
         {/* Reset */}
-        <button
+        <IconButton
           type="button"
+          variant="ghost"
           onClick={onResetView}
           className="flex items-center justify-center min-w-[44px] min-h-[44px] p-2 text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation"
           title={t('baseplate.resetView')}
           aria-label={t('baseplate.resetView')}
         >
           <IconReset />
-        </button>
+        </IconButton>
 
         {/* X-ray */}
-        <button
+        <IconButton
           type="button"
+          variant="ghost"
           onClick={onToggleXray}
           className={`flex items-center justify-center min-w-[44px] min-h-[44px] p-2 transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
             xray
@@ -362,29 +375,31 @@ export function BaseplatePreviewControls({
           }`}
           title={t('baseplate.toggleXray')}
           aria-label={t('baseplate.toggleXrayKeyboardShortcut')}
-          aria-pressed={xray}
+          pressed={xray}
         >
           <IconXray />
-        </button>
+        </IconButton>
 
         {/* Projection toggle */}
-        <button
+        <IconButton
           type="button"
+          variant="ghost"
           onClick={onToggleProjection}
           className="flex items-center justify-center min-w-[44px] min-h-[44px] p-2 text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation"
           title={t('baseplate.toggleProjection')}
           aria-label={t('baseplate.toggleProjectionKeyboardShortcut')}
-          aria-pressed={projection === 'orthographic'}
+          pressed={projection === 'orthographic'}
         >
           {projection === 'perspective' ? <IconPerspective /> : <IconOrthographic />}
-        </button>
+        </IconButton>
 
         {/* Spacer to push color picker to right */}
         <div className="flex-1" />
 
         {/* Color picker */}
-        <button
+        <IconButton
           type="button"
+          variant="ghost"
           onClick={() => setColorPickerOpen((v) => !v)}
           className="flex items-center justify-center min-w-[44px] min-h-[44px] p-2 text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation"
           title={t('baseplate.filamentColor')}
@@ -395,7 +410,7 @@ export function BaseplatePreviewControls({
             className="inline-block h-4 w-4 rounded border border-stroke-subtle/50"
             style={{ backgroundColor: filamentColor }}
           />
-        </button>
+        </IconButton>
       </div>
 
       {/* Mobile color picker -- bottom sheet style overlay */}

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreviewControls.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreviewControls.tsx
@@ -164,9 +164,9 @@ export function BaseplatePreviewControls({
                   type="button"
                   variant="ghost"
                   onClick={() => onViewModeChange(value)}
-                  className={`flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
+                  className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
                     isActive
-                      ? 'bg-accent text-on-accent'
+                      ? 'bg-accent text-on-accent hover:bg-accent hover:text-on-accent'
                       : 'text-content-secondary hover:bg-surface-hover hover:text-content'
                   }`}
                   aria-pressed={isActive}
@@ -190,9 +190,9 @@ export function BaseplatePreviewControls({
                 type="button"
                 variant="ghost"
                 onClick={() => onCameraPreset(key)}
-                className={`flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
+                className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
                   isActive
-                    ? 'bg-accent text-on-accent'
+                    ? 'bg-accent text-on-accent hover:bg-accent hover:text-on-accent'
                     : 'text-content-secondary hover:bg-surface-hover hover:text-content'
                 }`}
                 title={t(labelKey)}
@@ -213,7 +213,7 @@ export function BaseplatePreviewControls({
             type="button"
             variant="ghost"
             onClick={onResetView}
-            className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
+            className="flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
             title={t('baseplate.resetView')}
             aria-label={t('baseplate.resetView')}
           >
@@ -226,9 +226,9 @@ export function BaseplatePreviewControls({
             type="button"
             variant="ghost"
             onClick={onToggleXray}
-            className={`flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
+            className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
               xray
-                ? 'bg-accent text-on-accent'
+                ? 'bg-accent text-on-accent hover:bg-accent hover:text-on-accent'
                 : 'text-content-secondary hover:bg-surface-hover hover:text-content'
             }`}
             title={t('baseplate.toggleXray')}
@@ -244,7 +244,7 @@ export function BaseplatePreviewControls({
             type="button"
             variant="ghost"
             onClick={onToggleProjection}
-            className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
+            className="flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
             title={t('baseplate.toggleProjection')}
             aria-label={t('baseplate.toggleProjectionKeyboardShortcut')}
             aria-pressed={projection === 'orthographic'}
@@ -265,7 +265,7 @@ export function BaseplatePreviewControls({
             type="button"
             variant="ghost"
             onClick={() => setColorPickerOpen((v) => !v)}
-            className="flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
+            className="flex items-center gap-1.5 rounded-none px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
             title={t('baseplate.filamentColor')}
             aria-label={t('baseplate.filamentColor')}
             aria-expanded={colorPickerOpen}
@@ -307,9 +307,9 @@ export function BaseplatePreviewControls({
                 type="button"
                 variant="ghost"
                 onClick={() => onViewModeChange(value)}
-                className={`flex items-center justify-center gap-1 px-3 min-h-[44px] text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
+                className={`flex items-center justify-center gap-1 rounded-none px-3 min-h-[44px] text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
                   isActive
-                    ? 'bg-accent text-on-accent'
+                    ? 'bg-accent text-on-accent hover:bg-accent hover:text-on-accent'
                     : 'text-content-secondary hover:bg-surface-hover hover:text-content'
                 }`}
                 aria-pressed={isActive}
@@ -335,7 +335,7 @@ export function BaseplatePreviewControls({
               onClick={() => onCameraPreset(key)}
               className={`flex items-center justify-center min-w-[44px] min-h-[44px] p-2 transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
                 isActive
-                  ? 'bg-accent text-on-accent'
+                  ? 'bg-accent text-on-accent hover:bg-accent hover:text-on-accent'
                   : 'text-content-secondary hover:bg-surface-hover hover:text-content'
               }`}
               title={t(labelKey)}
@@ -369,7 +369,7 @@ export function BaseplatePreviewControls({
           onClick={onToggleXray}
           className={`flex items-center justify-center min-w-[44px] min-h-[44px] p-2 transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none touch-manipulation ${
             xray
-              ? 'bg-accent text-on-accent'
+              ? 'bg-accent text-on-accent hover:bg-accent hover:text-on-accent'
               : 'text-content-secondary hover:bg-surface-hover hover:text-content'
           }`}
           title={t('baseplate.toggleXray')}

--- a/src/features/baseplate/components/PaddingAnchor/PaddingAnchor.tsx
+++ b/src/features/baseplate/components/PaddingAnchor/PaddingAnchor.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef, type KeyboardEvent } from 'react';
+import { Button } from '@/design-system';
 import { cn } from '@/design-system/cn';
 import { AlertTriangleIcon, ArrowLeftIcon } from '@/design-system/Icon';
 import { focusRing, interactiveTransition } from '@/design-system/variants';
@@ -107,8 +108,9 @@ export function PaddingAnchor({
         const selected = value === anchor;
         const cellLabel = t(`baseplate.paddingAnchor.${anchor}`);
         return (
-          <button
+          <Button
             key={anchor}
+            variant="ghost"
             ref={(el) => {
               if (el) buttonRefs.current.set(anchor, el);
               else buttonRefs.current.delete(anchor);
@@ -119,11 +121,12 @@ export function PaddingAnchor({
             aria-label={cellLabel}
             title={cellLabel}
             tabIndex={rovingTabIndex(anchor, value)}
+            touchTarget={false}
             disabled={disabled}
             onClick={() => onChange(anchor)}
             onKeyDown={(e) => handleKeyDown(anchor, e)}
             className={cn(
-              'flex h-5 w-5 items-center justify-center rounded-md border',
+              'flex h-5 w-5 items-center justify-center rounded-md border !px-0 !py-0',
               selected
                 ? 'border-content bg-content text-surface'
                 : 'border-transparent text-content-tertiary hover:border-stroke-subtle hover:bg-surface-hover hover:text-content-secondary',
@@ -133,7 +136,7 @@ export function PaddingAnchor({
             )}
           >
             <CellGlyph anchor={anchor} />
-          </button>
+          </Button>
         );
       })}
       {showClampWarning && (

--- a/src/features/baseplate/components/PaddingAnchor/PaddingAnchor.tsx
+++ b/src/features/baseplate/components/PaddingAnchor/PaddingAnchor.tsx
@@ -128,7 +128,7 @@ export function PaddingAnchor({
             className={cn(
               'flex h-5 w-5 items-center justify-center rounded-md border !px-0 !py-0',
               selected
-                ? 'border-content bg-content text-surface'
+                ? 'border-content bg-content text-surface hover:bg-content hover:text-surface'
                 : 'border-transparent text-content-tertiary hover:border-stroke-subtle hover:bg-surface-hover hover:text-content-secondary',
               'disabled:cursor-not-allowed disabled:opacity-50',
               interactiveTransition,


### PR DESCRIPTION
## What

Batch 4 of the design-system migration. Migrates raw `<button>` elements across **6** `src/features/baseplate` components to `Button`/`IconButton`, and removes the stale **PaddingStepper** entry (already clean). Drains 7 from `scripts/design-system-allowlist.txt`.

Files: BaseplatePreviewControls (13-button view/zoom toolbar), BaseplatePage, ConnectorPicker, EditableDimensions, SplitViewStrip, PaddingAnchor (+ PaddingStepper allowlist removal).

- Dense toolbar icon controls → `IconButton touchTarget={false}`; toggles use `pressed`; pads/segmented/inline-edit triggers → `<Button variant="ghost">` with padding-neutralizing overrides (`!px-0`) to preserve tight grid/inline layouts.
- Pure markup swaps — no logic/behavior changes.

## Verification
- ✅ `check:design-system` 0 new violations · typecheck · lint clean
- ✅ Full suite: 13,583 passed, 7 skipped, 0 failed (no test edits needed)

## Visual notes (within "normalize, small shifts accepted")
- PaddingAnchor 3×3 pad cells and SplitViewStrip mini-map cells kept at original size via `touchTarget={false}` + `!px-0/!py-0` (avoids grid distortion).
- Active toggles on mobile preview controls keep their `bg-accent` styling via tailwind-merge (worth confirming accent fill over the IconButton `pressed` grey).

Draft until visually eyeballed + Greptile.