### PR TITLE
refactor(design-system): migrate grid-editor/layers/snapshots controls to design system

### DIFF
--- a/scripts/design-system-allowlist.txt
+++ b/scripts/design-system-allowlist.txt
@@ -75,13 +75,6 @@ src/features/bin-designer/components/PreviewCanvas/previewCanvasOverlays.tsx
 src/features/cloud-share/components/ShareButton/DeleteShareConfirm.tsx
 src/features/cloud-share/components/ShareButton/ShareLinkSection.tsx
 src/features/cloud-share/components/ShareButton/SharePopover.tsx
-src/features/grid-editor/components/Grid/IsometricPreview/ExplodedLayerGroup/LayerLabel.tsx
-src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreviewControls.tsx
-src/features/grid-editor/components/Grid/SelectionToolbar/SelectionToolbar.tsx
-src/features/layers/components/ActiveLayerPanel/SizeSelectorPopover.tsx
-src/features/layers/components/LayerPanel/HeightCrossSectionDiagram.tsx
-src/features/snapshots/components/SnapshotEntry/SnapshotEntry.tsx
-src/features/snapshots/components/SnapshotHistory/SnapshotHistory.tsx
 src/shared/components/ExperimentalKernelBadge/ExperimentalKernelBadge.tsx
 src/shared/components/ExportDialog/ExportDialog.tsx
 src/shared/components/ExportDialog/ExportSupportPrompt.tsx

--- a/src/features/grid-editor/components/Grid/IsometricPreview/ExplodedLayerGroup/LayerLabel.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/ExplodedLayerGroup/LayerLabel.tsx
@@ -1,4 +1,5 @@
 import { Html } from '@react-three/drei';
+import { Button } from '@/design-system';
 import type { LayerId } from '@/core/types';
 
 interface LayerLabelProps {
@@ -31,7 +32,8 @@ export function LayerLabel({
       zIndexRange={[50, 0]}
       style={{ pointerEvents: 'none' }}
     >
-      <button
+      <Button
+        variant="ghost"
         onClick={(e) => {
           e.stopPropagation();
           onLayerClick(layerId);
@@ -48,7 +50,7 @@ export function LayerLabel({
         }}
       >
         {layerName} · {layerHeightMm}mm
-      </button>
+      </Button>
     </Html>
   );
 }

--- a/src/features/grid-editor/components/Grid/IsometricPreview/ExplodedLayerGroup/LayerLabel.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/ExplodedLayerGroup/LayerLabel.tsx
@@ -40,7 +40,7 @@ export function LayerLabel({
         }}
         className={`rounded-md px-2 py-1 text-xs font-medium cursor-pointer whitespace-nowrap border transition-all ${
           isActive
-            ? 'bg-accent text-on-dark border-accent shadow-sm hover:bg-accent'
+            ? 'bg-accent text-on-dark border-accent shadow-sm hover:bg-accent hover:text-on-dark'
             : 'bg-surface-elevated/80 text-content-tertiary border-stroke-subtle hover:bg-surface-hover hover:text-content-secondary'
         }`}
         style={{

--- a/src/features/grid-editor/components/Grid/IsometricPreview/ExplodedLayerGroup/LayerLabel.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/ExplodedLayerGroup/LayerLabel.tsx
@@ -40,7 +40,7 @@ export function LayerLabel({
         }}
         className={`rounded-md px-2 py-1 text-xs font-medium cursor-pointer whitespace-nowrap border transition-all ${
           isActive
-            ? 'bg-accent text-on-dark border-accent shadow-sm'
+            ? 'bg-accent text-on-dark border-accent shadow-sm hover:bg-accent'
             : 'bg-surface-elevated/80 text-content-tertiary border-stroke-subtle hover:bg-surface-hover hover:text-content-secondary'
         }`}
         style={{

--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreviewControls.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreviewControls.tsx
@@ -163,8 +163,8 @@ export function IsometricPreviewControls({
             }}
             className={`flex items-center justify-center transition-colors ${
               isPreviewExpanded && !isMobile
-                ? `btn ${layerViewMode === 'focus' ? 'btn-primary' : 'btn-ghost'} gap-2 px-3 py-2 rounded-md`
-                : `w-7 h-7 ${layerViewMode === 'focus' ? 'bg-accent text-on-dark' : 'hover:bg-surface-elevated'}`
+                ? `gap-2 px-3 py-2 rounded-md ${layerViewMode === 'focus' ? 'bg-accent text-on-dark hover:bg-accent' : ''}`
+                : `w-7 h-7 ${layerViewMode === 'focus' ? 'bg-accent text-on-dark hover:bg-accent' : 'hover:bg-surface-elevated'}`
             }`}
             title={t('grid.focusShowOnlyActiveLayer')}
           >
@@ -191,8 +191,8 @@ export function IsometricPreviewControls({
             }}
             className={`flex items-center justify-center transition-colors ${
               isPreviewExpanded && !isMobile
-                ? `btn ${layerViewMode === 'stack' ? 'btn-primary' : 'btn-ghost'} gap-2 px-3 py-2 rounded-md`
-                : `w-7 h-7 ${layerViewMode === 'stack' ? 'bg-accent text-on-dark' : 'hover:bg-surface-elevated'}`
+                ? `gap-2 px-3 py-2 rounded-md ${layerViewMode === 'stack' ? 'bg-accent text-on-dark hover:bg-accent' : ''}`
+                : `w-7 h-7 ${layerViewMode === 'stack' ? 'bg-accent text-on-dark hover:bg-accent' : 'hover:bg-surface-elevated'}`
             }`}
             title={t('grid.stackShowActiveLayerAndBelow')}
           >
@@ -220,8 +220,8 @@ export function IsometricPreviewControls({
             }}
             className={`flex items-center justify-center transition-colors ${
               isPreviewExpanded && !isMobile
-                ? `btn ${layerViewMode === 'all' ? 'btn-primary' : 'btn-ghost'} gap-2 px-3 py-2 rounded-md`
-                : `w-7 h-7 ${layerViewMode === 'all' ? 'bg-accent text-on-dark' : 'hover:bg-surface-elevated'}`
+                ? `gap-2 px-3 py-2 rounded-md ${layerViewMode === 'all' ? 'bg-accent text-on-dark hover:bg-accent' : ''}`
+                : `w-7 h-7 ${layerViewMode === 'all' ? 'bg-accent text-on-dark hover:bg-accent' : 'hover:bg-surface-elevated'}`
             }`}
             title={t('grid.allShowAllLayers')}
           >
@@ -256,8 +256,8 @@ export function IsometricPreviewControls({
                 }}
                 className={`flex items-center justify-center transition-colors ${
                   isPreviewExpanded
-                    ? `btn ${isExplodedView ? 'btn-primary' : 'btn-ghost'} gap-2 px-3 py-2 rounded-md`
-                    : `w-7 h-7 ${isExplodedView ? 'bg-accent text-on-dark' : 'hover:bg-surface-elevated'}`
+                    ? `gap-2 px-3 py-2 rounded-md ${isExplodedView ? 'bg-accent text-on-dark hover:bg-accent' : ''}`
+                    : `w-7 h-7 ${isExplodedView ? 'bg-accent text-on-dark hover:bg-accent' : 'hover:bg-surface-elevated'}`
                 }`}
                 title={t('grid.explodedView.toggle')}
               >

--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreviewControls.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreviewControls.tsx
@@ -164,7 +164,7 @@ export function IsometricPreviewControls({
             className={`flex items-center justify-center transition-colors ${
               isPreviewExpanded && !isMobile
                 ? `gap-2 px-3 py-2 rounded-md ${layerViewMode === 'focus' ? 'bg-accent text-on-dark hover:bg-accent' : ''}`
-                : `w-7 h-7 ${layerViewMode === 'focus' ? 'bg-accent text-on-dark hover:bg-accent' : 'hover:bg-surface-elevated'}`
+                : `w-7 h-7 p-0 ${layerViewMode === 'focus' ? 'bg-accent text-on-dark hover:bg-accent' : 'hover:bg-surface-elevated'}`
             }`}
             title={t('grid.focusShowOnlyActiveLayer')}
           >
@@ -192,7 +192,7 @@ export function IsometricPreviewControls({
             className={`flex items-center justify-center transition-colors ${
               isPreviewExpanded && !isMobile
                 ? `gap-2 px-3 py-2 rounded-md ${layerViewMode === 'stack' ? 'bg-accent text-on-dark hover:bg-accent' : ''}`
-                : `w-7 h-7 ${layerViewMode === 'stack' ? 'bg-accent text-on-dark hover:bg-accent' : 'hover:bg-surface-elevated'}`
+                : `w-7 h-7 p-0 ${layerViewMode === 'stack' ? 'bg-accent text-on-dark hover:bg-accent' : 'hover:bg-surface-elevated'}`
             }`}
             title={t('grid.stackShowActiveLayerAndBelow')}
           >
@@ -221,7 +221,7 @@ export function IsometricPreviewControls({
             className={`flex items-center justify-center transition-colors ${
               isPreviewExpanded && !isMobile
                 ? `gap-2 px-3 py-2 rounded-md ${layerViewMode === 'all' ? 'bg-accent text-on-dark hover:bg-accent' : ''}`
-                : `w-7 h-7 ${layerViewMode === 'all' ? 'bg-accent text-on-dark hover:bg-accent' : 'hover:bg-surface-elevated'}`
+                : `w-7 h-7 p-0 ${layerViewMode === 'all' ? 'bg-accent text-on-dark hover:bg-accent' : 'hover:bg-surface-elevated'}`
             }`}
             title={t('grid.allShowAllLayers')}
           >
@@ -257,7 +257,7 @@ export function IsometricPreviewControls({
                 className={`flex items-center justify-center transition-colors ${
                   isPreviewExpanded
                     ? `gap-2 px-3 py-2 rounded-md ${isExplodedView ? 'bg-accent text-on-dark hover:bg-accent' : ''}`
-                    : `w-7 h-7 ${isExplodedView ? 'bg-accent text-on-dark hover:bg-accent' : 'hover:bg-surface-elevated'}`
+                    : `w-7 h-7 p-0 ${isExplodedView ? 'bg-accent text-on-dark hover:bg-accent' : 'hover:bg-surface-elevated'}`
                 }`}
                 title={t('grid.explodedView.toggle')}
               >

--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreviewControls.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreviewControls.tsx
@@ -2,6 +2,7 @@ import type { RefObject } from 'react';
 import type { LayerViewMode } from '@/core/store/view';
 import type { SceneHandle } from './Scene';
 import type { Layer } from '@/core/types';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 interface IsometricPreviewControlsProps {
@@ -52,14 +53,13 @@ export function IsometricPreviewControls({
         }`}
       >
         {/* Isometric view - 3D cube */}
-        <button
+        <Button
+          variant="ghost"
           onClick={(e) => {
             e.stopPropagation();
             sceneRef.current?.setPreset('isometric');
           }}
-          className={`btn btn-ghost ${
-            isPreviewExpanded && !isMobile ? 'gap-2 px-3 py-2' : 'w-8 h-8 p-0'
-          }`}
+          className={isPreviewExpanded && !isMobile ? 'gap-2 px-3 py-2' : 'w-8 h-8 p-0'}
           title={t('grid.isometricView')}
         >
           <svg
@@ -76,16 +76,15 @@ export function IsometricPreviewControls({
             />
           </svg>
           {isPreviewExpanded && !isMobile && <span className="text-xs font-medium">3D</span>}
-        </button>
+        </Button>
         {/* Front view - rectangle wider than tall */}
-        <button
+        <Button
+          variant="ghost"
           onClick={(e) => {
             e.stopPropagation();
             sceneRef.current?.setPreset('front');
           }}
-          className={`btn btn-ghost ${
-            isPreviewExpanded && !isMobile ? 'gap-2 px-3 py-2' : 'w-8 h-8 p-0'
-          }`}
+          className={isPreviewExpanded && !isMobile ? 'gap-2 px-3 py-2' : 'w-8 h-8 p-0'}
           title={t('grid.frontView')}
         >
           <svg
@@ -101,16 +100,15 @@ export function IsometricPreviewControls({
           {isPreviewExpanded && !isMobile && (
             <span className="text-xs font-medium">{t('grid.front')}</span>
           )}
-        </button>
+        </Button>
         {/* Side view - rectangle taller than wide */}
-        <button
+        <Button
+          variant="ghost"
           onClick={(e) => {
             e.stopPropagation();
             sceneRef.current?.setPreset('side');
           }}
-          className={`btn btn-ghost ${
-            isPreviewExpanded && !isMobile ? 'gap-2 px-3 py-2' : 'w-8 h-8 p-0'
-          }`}
+          className={isPreviewExpanded && !isMobile ? 'gap-2 px-3 py-2' : 'w-8 h-8 p-0'}
           title={t('grid.sideView')}
         >
           <svg
@@ -126,14 +124,15 @@ export function IsometricPreviewControls({
           {isPreviewExpanded && !isMobile && (
             <span className="text-xs font-medium">{t('grid.side')}</span>
           )}
-        </button>
+        </Button>
         {/* Banana for scale toggle */}
-        <button
+        <Button
+          variant="ghost"
           onClick={(e) => {
             e.stopPropagation();
             updateBananaScale(!showBananaScale);
           }}
-          className={`btn btn-ghost ${
+          className={`${
             isPreviewExpanded && !isMobile ? 'gap-2 px-3 py-2' : 'w-8 h-8 p-0'
           } ${showBananaScale ? 'text-yellow-400' : ''}`}
           title={t('grid.bananaForScale')}
@@ -143,7 +142,7 @@ export function IsometricPreviewControls({
           {isPreviewExpanded && !isMobile && (
             <span className="text-xs font-medium">{t('grid.bananaForScale')}</span>
           )}
-        </button>
+        </Button>
       </div>
 
       {/* Layer view mode selector - segmented control, only show when multiple layers */}
@@ -156,7 +155,8 @@ export function IsometricPreviewControls({
           }`}
         >
           {/* Focus - show only active layer */}
-          <button
+          <Button
+            variant="ghost"
             onClick={(e) => {
               e.stopPropagation();
               setLayerViewMode('focus');
@@ -181,9 +181,10 @@ export function IsometricPreviewControls({
               <path d="M12 2L2 7l10 5 10-5-10-5z" />
             </svg>
             {isPreviewExpanded && !isMobile && <span className="text-xs">{t('grid.focus')}</span>}
-          </button>
+          </Button>
           {/* Stack - show active layer and below */}
-          <button
+          <Button
+            variant="ghost"
             onClick={(e) => {
               e.stopPropagation();
               setLayerViewMode('stack');
@@ -209,9 +210,10 @@ export function IsometricPreviewControls({
               <path d="M2 12l10 5 10-5" />
             </svg>
             {isPreviewExpanded && !isMobile && <span className="text-xs">{t('grid.stack')}</span>}
-          </button>
+          </Button>
           {/* All - show all layers */}
-          <button
+          <Button
+            variant="ghost"
             onClick={(e) => {
               e.stopPropagation();
               setLayerViewMode('all');
@@ -238,7 +240,7 @@ export function IsometricPreviewControls({
               <path d="M2 12l10 5 10-5" />
             </svg>
             {isPreviewExpanded && !isMobile && <span className="text-xs">{t('grid.all')}</span>}
-          </button>
+          </Button>
           {/* Explode — separate layers vertically (desktop only) */}
           {!isMobile && !isTablet && (
             <>
@@ -246,7 +248,8 @@ export function IsometricPreviewControls({
               <div
                 className={`${isPreviewExpanded ? 'w-px h-6 mx-0.5' : 'w-px h-4 mx-0'} bg-stroke-subtle/50 self-center`}
               />
-              <button
+              <Button
+                variant="ghost"
                 onClick={(e) => {
                   e.stopPropagation();
                   toggleExplodedView();
@@ -275,7 +278,7 @@ export function IsometricPreviewControls({
                 {isPreviewExpanded && (
                   <span className="text-xs">{t('grid.explodedView.label')}</span>
                 )}
-              </button>
+              </Button>
             </>
           )}
         </div>
@@ -288,14 +291,13 @@ export function IsometricPreviewControls({
         }`}
       >
         {/* Expand/Collapse button */}
-        <button
+        <Button
+          variant="ghost"
           onClick={(e) => {
             e.stopPropagation();
             togglePreviewExpanded();
           }}
-          className={`btn btn-ghost ${
-            isPreviewExpanded && !isMobile ? 'gap-2 px-3 py-2' : 'w-8 h-8 p-0'
-          }`}
+          className={isPreviewExpanded && !isMobile ? 'gap-2 px-3 py-2' : 'w-8 h-8 p-0'}
           title={isPreviewExpanded ? t('grid.preview.collapse') : t('grid.preview.expand')}
         >
           {isPreviewExpanded ? (
@@ -325,9 +327,10 @@ export function IsometricPreviewControls({
               />
             </svg>
           )}
-        </button>
+        </Button>
         {/* Close button */}
-        <button
+        <Button
+          variant="ghost"
           onClick={(e) => {
             e.stopPropagation();
             if (isPreviewExpanded) {
@@ -336,9 +339,7 @@ export function IsometricPreviewControls({
               toggleIsometricPreview();
             }
           }}
-          className={`btn btn-ghost ${
-            isPreviewExpanded && !isMobile ? 'gap-2 px-3 py-2' : 'w-8 h-8 p-0'
-          }`}
+          className={isPreviewExpanded && !isMobile ? 'gap-2 px-3 py-2' : 'w-8 h-8 p-0'}
           title={isPreviewExpanded ? t('grid.preview.collapse') : t('grid.preview.close')}
         >
           <svg
@@ -357,7 +358,7 @@ export function IsometricPreviewControls({
           {isPreviewExpanded && !isMobile && (
             <span className="text-xs font-medium">{t('common.close')}</span>
           )}
-        </button>
+        </Button>
       </div>
 
       {/* Keyboard shortcuts indicator - only shown in expanded mode on desktop */}

--- a/src/features/grid-editor/components/Grid/SelectionToolbar/SelectionToolbar.tsx
+++ b/src/features/grid-editor/components/Grid/SelectionToolbar/SelectionToolbar.tsx
@@ -8,6 +8,7 @@
 
 import { useState } from 'react';
 import { useTranslation } from '@/i18n';
+import { IconButton, Select } from '@/design-system';
 import type { BinId, CategoryId, LayerId, Category, Layer } from '@/core/types';
 import type { AlignEdge } from '@/shared/utils/alignBins';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
@@ -112,15 +113,20 @@ export function SelectionToolbar({
 
         {/* Category section */}
         {categories.map((cat) => (
-          <button
+          <IconButton
             key={cat.id}
             type="button"
-            className="h-4 w-4 rounded-full border border-stroke-subtle transition-transform hover:scale-125"
+            variant="ghost"
+            size="sm"
+            touchTarget={false}
+            className="h-4 w-4 !min-h-0 !min-w-0 rounded-full border border-stroke-subtle transition-transform hover:scale-125"
             style={{ backgroundColor: cat.color }}
             onClick={() => onSetCategory(cat.id)}
             title={t('selectionToolbar.setCategory', { name: cat.name })}
             aria-label={t('selectionToolbar.setCategory', { name: cat.name })}
-          />
+          >
+            <span className="sr-only">{t('selectionToolbar.setCategory', { name: cat.name })}</span>
+          </IconButton>
         ))}
 
         <Divider />
@@ -159,9 +165,12 @@ export function SelectionToolbar({
 
         {/* Move to layer */}
         {otherLayers.length > 0 && (
-          <select
-            className="h-6 rounded border border-stroke-subtle bg-surface-secondary px-1 text-[11px] text-content-secondary hover:bg-surface-hover transition-colors cursor-pointer"
+          <Select
+            size="sm"
+            className="h-6 text-[11px] text-content-secondary"
             value=""
+            placeholder={t('selectionToolbar.moveToLayer')}
+            options={otherLayers.map((layer) => ({ id: layer.id, name: layer.name }))}
             onChange={(e) => {
               if (e.target.value) {
                 onMoveToLayer(e.target.value as LayerId);
@@ -170,16 +179,7 @@ export function SelectionToolbar({
             }}
             title={t('selectionToolbar.moveToLayer')}
             aria-label={t('selectionToolbar.moveToLayer')}
-          >
-            <option value="" disabled>
-              {t('selectionToolbar.moveToLayer')}
-            </option>
-            {otherLayers.map((layer) => (
-              <option key={layer.id} value={layer.id}>
-                {layer.name}
-              </option>
-            ))}
-          </select>
+          />
         )}
 
         {/* Move to stash */}
@@ -250,19 +250,18 @@ function ToolbarButton({
   children: React.ReactNode;
 }) {
   return (
-    <button
+    <IconButton
       type="button"
-      className={`rounded p-1.5 transition-colors ${
-        destructive
-          ? 'text-error hover:bg-error/10'
-          : 'text-content-tertiary hover:bg-surface-hover hover:text-content'
-      }`}
+      variant={destructive ? 'dangerGhost' : 'ghost'}
+      size="sm"
+      touchTarget={false}
+      className={destructive ? 'p-1.5 text-error' : 'p-1.5'}
       onClick={onClick}
       title={label}
       aria-label={label}
     >
       {children}
-    </button>
+    </IconButton>
   );
 }
 

--- a/src/features/grid-editor/components/Grid/SelectionToolbar/SelectionToolbar.tsx
+++ b/src/features/grid-editor/components/Grid/SelectionToolbar/SelectionToolbar.tsx
@@ -125,7 +125,7 @@ export function SelectionToolbar({
             title={t('selectionToolbar.setCategory', { name: cat.name })}
             aria-label={t('selectionToolbar.setCategory', { name: cat.name })}
           >
-            <span className="sr-only">{t('selectionToolbar.setCategory', { name: cat.name })}</span>
+            <span aria-hidden="true" />
           </IconButton>
         ))}
 

--- a/src/features/layers/components/ActiveLayerPanel/SizeSelectorPopover.tsx
+++ b/src/features/layers/components/ActiveLayerPanel/SizeSelectorPopover.tsx
@@ -1,5 +1,5 @@
 import { useState, type RefObject } from 'react';
-import { Popover } from '@/design-system';
+import { Button, Popover } from '@/design-system';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import { useTranslation } from '@/i18n';
 
@@ -50,8 +50,10 @@ function SizeButton({
   const previewHeight = d * 4;
 
   return (
-    <button
+    <Button
+      variant="ghost"
       onClick={onClick}
+      touchTarget={false}
       className={`flex flex-col items-center justify-end gap-1 h-[52px] p-1.5 rounded-lg border transition-colors ${
         isActive
           ? 'bg-accent/20 border-accent/40 ring-1 ring-accent/50'
@@ -77,7 +79,7 @@ function SizeButton({
       >
         {w}×{d}
       </span>
-    </button>
+    </Button>
   );
 }
 
@@ -148,7 +150,10 @@ export function SizeSelectorPopover({
           <span className="text-[11px] font-medium text-content-secondary uppercase tracking-wider">
             {t('layers.rectangles')}
           </span>
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
+            touchTarget={false}
             onClick={() => setRotated(!rotated)}
             className="text-[11px] text-content-tertiary hover:text-content flex items-center gap-1 transition-colors rounded px-1.5 py-0.5 hover:bg-surface-hover"
             title={rotated ? t('layers.showingTall') : t('layers.showingWide')}
@@ -163,7 +168,7 @@ export function SizeSelectorPopover({
               />
             </svg>
             {rotated ? t('layers.tall') : t('layers.wide')}
-          </button>
+          </Button>
         </div>
         <div className="grid grid-cols-5 gap-1">
           {RECTANGLE_SIZES.map(({ w, d }) => {

--- a/src/features/layers/components/ActiveLayerPanel/SizeSelectorPopover.tsx
+++ b/src/features/layers/components/ActiveLayerPanel/SizeSelectorPopover.tsx
@@ -54,9 +54,9 @@ function SizeButton({
       variant="ghost"
       onClick={onClick}
       touchTarget={false}
-      className={`flex flex-col items-center justify-end gap-1 h-[52px] p-1.5 rounded-lg border transition-colors ${
+      className={`flex flex-col items-center justify-end gap-1 h-[52px] p-1.5 rounded-lg border font-normal transition-colors ${
         isActive
-          ? 'bg-accent/20 border-accent/40 ring-1 ring-accent/50'
+          ? 'bg-accent/20 border-accent/40 ring-1 ring-accent/50 hover:bg-accent/20'
           : 'border-transparent hover:bg-surface-hover hover:border-stroke-subtle'
       }`}
       aria-label={t('layers.paintSizeAriaLabel', {

--- a/src/features/layers/components/LayerPanel/HeightCrossSectionDiagram.tsx
+++ b/src/features/layers/components/LayerPanel/HeightCrossSectionDiagram.tsx
@@ -441,7 +441,7 @@ export function HeightCrossSectionDiagram({
                               e.stopPropagation();
                               onDeleteLayer(layer.id);
                             }}
-                            className="w-5 h-5 !px-0 !py-0 rounded text-content-disabled hover:text-error hover:bg-surface-hover transition-colors ml-1"
+                            className="w-5 h-5 !px-0 !py-0 rounded text-content-disabled transition-colors ml-1"
                             title={t('layers.deleteTooltip')}
                             aria-label={t('layers.deleteLayerAria', { name: layer.name })}
                           >

--- a/src/features/layers/components/LayerPanel/HeightCrossSectionDiagram.tsx
+++ b/src/features/layers/components/LayerPanel/HeightCrossSectionDiagram.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import type { KeyboardEvent } from 'react';
 import type { Layer, LayerId } from '@/core/types';
 import { CONSTRAINTS } from '@/core/constants';
+import { IconButton } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 const HEIGHT_EXPONENT = 0.55;
@@ -369,13 +370,16 @@ export function HeightCrossSectionDiagram({
                         className="flex items-center gap-1 ml-1 flex-shrink-0"
                         onDoubleClick={(e) => e.stopPropagation()}
                       >
-                        <button
+                        <IconButton
+                          variant="ghost"
+                          size="sm"
+                          touchTarget={false}
                           onClick={(e) => {
                             e.stopPropagation();
                             handleDebouncedHeightChange(layer.id, -1);
                           }}
                           disabled={previewHeight <= CONSTRAINTS.MIN_LAYER_HEIGHT}
-                          className="w-5 h-5 flex items-center justify-center rounded text-content-disabled hover:text-content hover:bg-surface-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                          className="w-5 h-5 !px-0 !py-0 rounded text-content-disabled hover:text-content hover:bg-surface-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                           aria-label={t('layers.decreaseHeight', { name: layer.name })}
                         >
                           <svg
@@ -391,7 +395,7 @@ export function HeightCrossSectionDiagram({
                               d="M20 12H4"
                             />
                           </svg>
-                        </button>
+                        </IconButton>
                         <span
                           className="text-[10px] tabular-nums min-w-[20px] text-center"
                           style={{
@@ -402,12 +406,15 @@ export function HeightCrossSectionDiagram({
                         >
                           {previewHeight}u
                         </span>
-                        <button
+                        <IconButton
+                          variant="ghost"
+                          size="sm"
+                          touchTarget={false}
                           onClick={(e) => {
                             e.stopPropagation();
                             handleDebouncedHeightChange(layer.id, 1);
                           }}
-                          className="w-5 h-5 flex items-center justify-center rounded text-content-disabled hover:text-content hover:bg-surface-hover transition-colors"
+                          className="w-5 h-5 !px-0 !py-0 rounded text-content-disabled hover:text-content hover:bg-surface-hover transition-colors"
                           aria-label={t('layers.increaseHeight', { name: layer.name })}
                         >
                           <svg
@@ -423,15 +430,18 @@ export function HeightCrossSectionDiagram({
                               d="M12 4v16m8-8H4"
                             />
                           </svg>
-                        </button>
+                        </IconButton>
 
                         {hasMultipleLayers && (
-                          <button
+                          <IconButton
+                            variant="dangerGhost"
+                            size="sm"
+                            touchTarget={false}
                             onClick={(e) => {
                               e.stopPropagation();
                               onDeleteLayer(layer.id);
                             }}
-                            className="w-5 h-5 flex items-center justify-center rounded text-content-disabled hover:text-error hover:bg-surface-hover transition-colors ml-1"
+                            className="w-5 h-5 !px-0 !py-0 rounded text-content-disabled hover:text-error hover:bg-surface-hover transition-colors ml-1"
                             title={t('layers.deleteTooltip')}
                             aria-label={t('layers.deleteLayerAria', { name: layer.name })}
                           >
@@ -448,7 +458,7 @@ export function HeightCrossSectionDiagram({
                                 d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
                               />
                             </svg>
-                          </button>
+                          </IconButton>
                         )}
 
                         {showGrip && !isEditing && <GripIcon className="ml-0.5" />}

--- a/src/features/snapshots/components/SnapshotEntry/SnapshotEntry.tsx
+++ b/src/features/snapshots/components/SnapshotEntry/SnapshotEntry.tsx
@@ -106,7 +106,7 @@ export function SnapshotEntry({
           variant="ghost"
           size="sm"
           onClick={() => onRestore(snapshot.id)}
-          className="text-xs px-2 py-1 text-accent hover:bg-accent-muted h-auto"
+          className="text-xs font-normal px-2 py-1 rounded text-accent hover:bg-accent-muted h-auto"
           aria-label={t('snapshots.restore')}
         >
           {t('snapshots.restore')}

--- a/src/features/snapshots/components/SnapshotEntry/SnapshotEntry.tsx
+++ b/src/features/snapshots/components/SnapshotEntry/SnapshotEntry.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { Button, IconButton } from '@/design-system';
 import { LayoutThumbnail } from '@/shell/LayoutThumbnail';
 import { useRelativeTime } from '../../hooks/useRelativeTime';
 import { useTranslation } from '@/i18n';
@@ -75,16 +76,19 @@ export function SnapshotEntry({
             aria-label={t('snapshots.editLabel')}
           />
         ) : (
-          <button
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
             onClick={() => {
               setEditValue(snapshot.label ?? '');
               setIsEditing(true);
             }}
-            className="text-xs font-medium text-content truncate block max-w-full bg-transparent text-left"
+            className="text-xs font-medium text-content truncate block max-w-full bg-transparent text-left !px-0 h-auto"
             title={t('snapshots.editLabel')}
           >
             {snapshot.label ?? t('snapshots.autoSaved')}
-          </button>
+          </Button>
         )}
 
         <div className="text-[11px] text-content-tertiary mt-0.5">
@@ -97,16 +101,23 @@ export function SnapshotEntry({
       </div>
 
       <div className="flex-shrink-0 flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
-        <button
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
           onClick={() => onRestore(snapshot.id)}
-          className="text-xs px-2 py-1 rounded bg-transparent text-accent hover:bg-accent-muted transition-colors"
+          className="text-xs px-2 py-1 text-accent hover:bg-accent-muted h-auto"
           aria-label={t('snapshots.restore')}
         >
           {t('snapshots.restore')}
-        </button>
-        <button
+        </Button>
+        <IconButton
+          type="button"
+          variant="dangerGhost"
+          size="sm"
+          touchTarget={false}
           onClick={() => onDelete(snapshot.id)}
-          className="p-1 rounded bg-transparent text-content-tertiary hover:text-[var(--color-error)] hover:bg-surface-hover transition-colors"
+          className="text-content-tertiary"
           aria-label={t('snapshots.deleteSnapshot')}
         >
           <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -114,7 +125,7 @@ export function SnapshotEntry({
               <path key={d} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
             ))}
           </svg>
-        </button>
+        </IconButton>
       </div>
     </div>
   );

--- a/src/features/snapshots/components/SnapshotEntry/SnapshotEntry.tsx
+++ b/src/features/snapshots/components/SnapshotEntry/SnapshotEntry.tsx
@@ -84,7 +84,7 @@ export function SnapshotEntry({
               setEditValue(snapshot.label ?? '');
               setIsEditing(true);
             }}
-            className="text-xs font-medium text-content truncate block max-w-full bg-transparent text-left !px-0 h-auto"
+            className="text-xs font-medium text-content truncate block max-w-full bg-transparent hover:bg-transparent text-left !px-0 h-auto"
             title={t('snapshots.editLabel')}
           >
             {snapshot.label ?? t('snapshots.autoSaved')}
@@ -106,7 +106,7 @@ export function SnapshotEntry({
           variant="ghost"
           size="sm"
           onClick={() => onRestore(snapshot.id)}
-          className="text-xs font-normal px-2 py-1 rounded text-accent hover:bg-accent-muted h-auto"
+          className="text-xs font-normal px-2 py-1 rounded text-accent hover:bg-accent-muted hover:text-accent h-auto"
           aria-label={t('snapshots.restore')}
         >
           {t('snapshots.restore')}

--- a/src/features/snapshots/components/SnapshotHistory/SnapshotHistory.tsx
+++ b/src/features/snapshots/components/SnapshotHistory/SnapshotHistory.tsx
@@ -9,6 +9,7 @@ import { restoreSnapshot, createLayoutEntry, deleteSnapshotById } from '@/core/s
 import { SHARED_PREVIEW_ID } from '@/core/constants';
 import { useTranslation } from '@/i18n';
 import { isOk } from '@/core/result';
+import { Button } from '@/design-system';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import { SnapshotEntry } from '../SnapshotEntry/SnapshotEntry';
 import { RestoreDialog } from '../RestoreDialog/RestoreDialog';
@@ -199,13 +200,16 @@ export function SnapshotHistory() {
         <p className="text-sm text-content-secondary">{t('snapshots.empty')}</p>
         <p className="text-xs text-content-tertiary mt-1">{t('snapshots.emptyDescription')}</p>
         {isEditable && layout.bins.length > 0 && (
-          <button
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
             onClick={handleCreateSnapshotNow}
-            className="mt-3 text-xs text-accent hover:text-accent-hover transition-colors bg-transparent"
+            className="mt-3 text-xs text-accent hover:text-accent-hover h-auto"
             data-testid="create-snapshot-now"
           >
             {t('snapshots.createSnapshotNow')}
-          </button>
+          </Button>
         )}
       </div>
     );
@@ -217,19 +221,24 @@ export function SnapshotHistory() {
         <span className="text-xs font-medium text-content-secondary uppercase tracking-wider">
           {t('snapshots.title')}
         </span>
-        <button
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
           onClick={handleSaveCheckpoint}
-          className="flex items-center gap-1 text-xs text-accent hover:text-accent-hover transition-colors bg-transparent"
+          leftIcon={
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              {ICON_PATHS.plus.map((d) => (
+                <path key={d} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
+              ))}
+            </svg>
+          }
+          className="text-xs text-accent hover:text-accent-hover h-auto"
           aria-label={t('snapshots.saveCheckpoint')}
           data-testid="save-checkpoint"
         >
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            {ICON_PATHS.plus.map((d) => (
-              <path key={d} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
-            ))}
-          </svg>
           {t('snapshots.saveCheckpoint')}
-        </button>
+        </Button>
       </div>
 
       <div className="flex flex-col" data-testid="snapshot-history">

--- a/src/features/snapshots/components/SnapshotHistory/SnapshotHistory.tsx
+++ b/src/features/snapshots/components/SnapshotHistory/SnapshotHistory.tsx
@@ -205,7 +205,7 @@ export function SnapshotHistory() {
             variant="ghost"
             size="sm"
             onClick={handleCreateSnapshotNow}
-            className="mt-3 text-xs text-accent hover:text-accent-hover h-auto"
+            className="mt-3 text-xs font-normal text-accent hover:bg-transparent hover:text-accent-hover h-auto !px-0"
             data-testid="create-snapshot-now"
           >
             {t('snapshots.createSnapshotNow')}
@@ -233,7 +233,7 @@ export function SnapshotHistory() {
               ))}
             </svg>
           }
-          className="text-xs text-accent hover:text-accent-hover h-auto"
+          className="text-xs font-normal text-accent hover:bg-transparent hover:text-accent-hover h-auto !px-0"
           aria-label={t('snapshots.saveCheckpoint')}
           data-testid="save-checkpoint"
         >


### PR DESCRIPTION
## What

Batch 5 of the design-system migration. Migrates raw `<button>` across **7** components in `grid-editor`, `layers`, and `snapshots`, plus one raw `<select>` → `Select`. Drains 7 from `scripts/design-system-allowlist.txt`.

Files: IsometricPreviewControls (10-button overlay toolbar), LayerLabel, SelectionToolbar (2 buttons + move-to-layer `<select>`), SizeSelectorPopover, HeightCrossSectionDiagram, SnapshotEntry, SnapshotHistory.

- Buttons → `Button`/`IconButton` (delete actions → `dangerGhost`); dense diagram/swatch controls keep size via `!px-0`/`touchTarget={false}`.
- The move-to-layer `<select>` → `<Select options={...}>` **keeping native `onChange`** so the `value=''` reset after `onMoveToLayer` still fires (placeholder preserved as a disabled leading option).
- Pure markup swaps — no logic/behavior changes.

## Verification
- ✅ `check:design-system` 0 new violations · typecheck · lint clean
- ✅ Full suite: 13,583 passed, 7 skipped, 0 failed (no test edits needed — role/name/`selectOptions` queries survive)

## Visual notes (within "normalize, small shifts accepted")
- Move-to-layer Select restyles to the design-system chevron/`bg-surface` look in the dense toolbar — functionally identical.
- Category swatches kept at 16px (`!min-w-0/!min-h-0`); isometric segmented active state kept via tailwind-merge (`bg-accent`).

Draft until visually eyeballed + Greptile.