### PR TITLE
refactor(design-system): migrate shell + cloud-share controls to design system

### DIFF
--- a/scripts/design-system-allowlist.txt
+++ b/scripts/design-system-allowlist.txt
@@ -72,9 +72,6 @@ src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
 src/features/bin-designer/components/PerfOverlay/PerfOverlay.tsx
 src/features/bin-designer/components/PreviewCanvas/ColorToolOverlay.tsx
 src/features/bin-designer/components/PreviewCanvas/previewCanvasOverlays.tsx
-src/features/cloud-share/components/ShareButton/DeleteShareConfirm.tsx
-src/features/cloud-share/components/ShareButton/ShareLinkSection.tsx
-src/features/cloud-share/components/ShareButton/SharePopover.tsx
 src/features/grid-editor/components/Grid/IsometricPreview/ExplodedLayerGroup/LayerLabel.tsx
 src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreviewControls.tsx
 src/features/grid-editor/components/Grid/SelectionToolbar/SelectionToolbar.tsx
@@ -91,9 +88,3 @@ src/shared/components/HeaderSupportLinks/HeaderSupportLinks.tsx
 src/shared/components/PrintBedInput/PrintBedInput.tsx
 src/shared/components/StickyGroupHeader/StickyGroupHeader.tsx
 src/shared/components/UserDock/UserDock.tsx
-src/shell/Mobile/BinContextMenu/BinContextMenu.tsx
-src/shell/Mobile/MobileLayoutsPanel/MobileCloudSharePanel.tsx
-src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsListItem.tsx
-src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.tsx
-src/shell/Modals/HalfGridModeBlockedModal/HalfGridModeBlockedModal.tsx
-src/shell/Modals/SettingsModal/tabs/AppearanceTab/AppearanceTab.tsx

--- a/src/features/cloud-share/components/ShareButton/DeleteShareConfirm.tsx
+++ b/src/features/cloud-share/components/ShareButton/DeleteShareConfirm.tsx
@@ -26,7 +26,7 @@ export function DeleteShareConfirm({ isDeleting, onConfirm }: DeleteShareConfirm
           e.stopPropagation();
           setShowConfirm(true);
         }}
-        className="text-sm text-content-tertiary hover:text-error transition-colors"
+        className="text-sm font-normal text-content-tertiary hover:text-error hover:bg-transparent transition-colors"
       >
         {t('share.deleteShareLink')}
       </Button>

--- a/src/features/cloud-share/components/ShareButton/DeleteShareConfirm.tsx
+++ b/src/features/cloud-share/components/ShareButton/DeleteShareConfirm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
 interface DeleteShareConfirmProps {
@@ -19,7 +20,8 @@ export function DeleteShareConfirm({ isDeleting, onConfirm }: DeleteShareConfirm
 
   if (!showConfirm) {
     return (
-      <button
+      <Button
+        variant="ghost"
         onClick={(e) => {
           e.stopPropagation();
           setShowConfirm(true);
@@ -27,7 +29,7 @@ export function DeleteShareConfirm({ isDeleting, onConfirm }: DeleteShareConfirm
         className="text-sm text-content-tertiary hover:text-error transition-colors"
       >
         {t('share.deleteShareLink')}
-      </button>
+      </Button>
     );
   }
 
@@ -35,51 +37,28 @@ export function DeleteShareConfirm({ isDeleting, onConfirm }: DeleteShareConfirm
     <div className="bg-error/10 border border-error/30 rounded-lg p-3 space-y-2">
       <p className="text-sm text-content">{t('share.deleteConfirmMessage')}</p>
       <div className="flex gap-2">
-        <button
+        <Button
+          variant="danger"
+          loading={isDeleting}
           onClick={(e) => {
             e.stopPropagation();
             onConfirm();
           }}
-          disabled={isDeleting}
-          className="btn btn-secondary text-error border-error hover:bg-error hover:text-white text-sm px-3 py-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="text-sm px-3 py-1.5"
         >
-          {isDeleting ? (
-            <span className="flex items-center gap-2">
-              <svg
-                className="w-3 h-3 animate-spin motion-reduce:animate-none"
-                viewBox="0 0 24 24"
-                fill="none"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                />
-              </svg>
-              {t('share.deleting')}
-            </span>
-          ) : (
-            t('common.delete')
-          )}
-        </button>
-        <button
+          {isDeleting ? t('share.deleting') : t('common.delete')}
+        </Button>
+        <Button
+          variant="secondary"
           onClick={(e) => {
             e.stopPropagation();
             setShowConfirm(false);
           }}
           disabled={isDeleting}
-          className="btn btn-secondary text-sm px-3 py-1.5 disabled:opacity-50"
+          className="text-sm px-3 py-1.5"
         >
           {t('common.cancel')}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/features/cloud-share/components/ShareButton/ShareLinkSection.tsx
+++ b/src/features/cloud-share/components/ShareButton/ShareLinkSection.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import { Button, Select } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import type { SharePermission } from '@/core/types';
 
@@ -42,11 +43,10 @@ export function ShareLinkSection({
           onClick={() => inputRef.current?.select()}
           className="flex-1 bg-surface text-content text-xs px-3 py-2 rounded border border-stroke focus:outline-none font-mono truncate"
         />
-        <button
+        <Button
+          variant={urlCopied ? 'secondary' : 'primary'}
           onClick={onCopyUrl}
-          className={`btn px-3 text-sm whitespace-nowrap ${
-            urlCopied ? 'btn-secondary text-success' : 'btn-primary'
-          }`}
+          className={`px-3 text-sm whitespace-nowrap ${urlCopied ? 'text-success' : ''}`}
         >
           {urlCopied ? (
             <span className="flex items-center gap-1">
@@ -63,7 +63,7 @@ export function ShareLinkSection({
           ) : (
             t('common.copy')
           )}
-        </button>
+        </Button>
       </div>
 
       {readOnlyPermission ? (
@@ -72,16 +72,19 @@ export function ShareLinkSection({
           {permission}
         </div>
       ) : (
-        <select
+        <Select
+          fullWidth
           value={permission}
-          onChange={(e) => {
-            onPermissionChange(e.target.value as SharePermission);
+          onValueChange={(v) => {
+            onPermissionChange(v as SharePermission);
           }}
-          className="w-full bg-surface text-content text-sm px-3 py-2 rounded border border-stroke"
-        >
-          <option value="view">{t('share.anyoneWithLinkCanView')}</option>
-          <option value="edit">{t('share.anyoneWithLinkCanEdit')}</option>
-        </select>
+          options={[
+            { id: 'view', name: t('share.anyoneWithLinkCanView') },
+            { id: 'edit', name: t('share.anyoneWithLinkCanEdit') },
+          ]}
+          aria-label={t('share.anyoneWithLinkCan')}
+          className="text-sm"
+        />
       )}
     </>
   );

--- a/src/features/cloud-share/components/ShareButton/SharePopover.tsx
+++ b/src/features/cloud-share/components/ShareButton/SharePopover.tsx
@@ -220,6 +220,8 @@ export function SharePopover({ buttonRef, cloudShare }: SharePopoverProps) {
         <div className="text-sm text-content-secondary truncate flex-1 mr-2">{layoutName}</div>
         <IconButton
           variant="ghost"
+          size="sm"
+          touchTarget={false}
           onClick={onClose}
           className="text-content-tertiary hover:text-content"
           aria-label={t('common.close')}

--- a/src/features/cloud-share/components/ShareButton/SharePopover.tsx
+++ b/src/features/cloud-share/components/ShareButton/SharePopover.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { Button, IconButton, Select } from '@/design-system';
 import {
   useLayoutStore,
   useToastStore,
@@ -217,9 +218,10 @@ export function SharePopover({ buttonRef, cloudShare }: SharePopoverProps) {
     >
       <div className="flex items-center justify-between mb-3">
         <div className="text-sm text-content-secondary truncate flex-1 mr-2">{layoutName}</div>
-        <button
+        <IconButton
+          variant="ghost"
           onClick={onClose}
-          className="text-content-tertiary hover:text-content transition-colors p-1 -m-1"
+          className="text-content-tertiary hover:text-content"
           aria-label={t('common.close')}
         >
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -230,7 +232,7 @@ export function SharePopover({ buttonRef, cloudShare }: SharePopoverProps) {
               d="M6 18L18 6M6 6l12 12"
             />
           </svg>
-        </button>
+        </IconButton>
       </div>
 
       {(status === 'sharing' || status === 'updating') && (
@@ -265,34 +267,39 @@ export function SharePopover({ buttonRef, cloudShare }: SharePopoverProps) {
       {status === 'error' && error && (
         <div className="space-y-3">
           <div className="text-sm text-error">{error.message}</div>
-          <button onClick={reset} className="btn btn-secondary w-full text-sm">
+          <Button variant="secondary" fullWidth onClick={reset} className="text-sm">
             {t('error.tryAgain')}
-          </button>
+          </Button>
         </div>
       )}
 
       {status === 'idle' && !showSharedState && (
         <div className="space-y-3">
           <div className="flex items-center gap-2">
-            <select
+            <Select
+              fullWidth
               value={localPermission}
-              onChange={(e) => {
-                setLocalPermission(e.target.value as SharePermission);
+              onValueChange={(v) => {
+                setLocalPermission(v as SharePermission);
               }}
-              className="flex-1 bg-surface text-content text-sm px-3 py-2 rounded border border-stroke"
-            >
-              <option value="view">{t('share.anyoneWithLinkCanView')}</option>
-              <option value="edit">{t('share.anyoneWithLinkCanEdit')}</option>
-            </select>
+              options={[
+                { id: 'view', name: t('share.anyoneWithLinkCanView') },
+                { id: 'edit', name: t('share.anyoneWithLinkCanEdit') },
+              ]}
+              aria-label={t('share.anyoneWithLinkCan')}
+              className="flex-1 text-sm"
+            />
           </div>
-          <button
+          <Button
+            variant="primary"
+            fullWidth
             onClick={() => {
               void handleShare();
             }}
-            className="btn btn-primary w-full text-sm"
+            className="text-sm"
           >
             {t('share.createShareLink')}
-          </button>
+          </Button>
         </div>
       )}
 
@@ -323,9 +330,9 @@ export function SharePopover({ buttonRef, cloudShare }: SharePopoverProps) {
           )}
 
           <div className="pt-2">
-            <button onClick={onClose} className="btn btn-secondary w-full text-sm">
+            <Button variant="secondary" fullWidth onClick={onClose} className="text-sm">
               {t('common.done')}
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/src/shell/Mobile/BinContextMenu/BinContextMenu.tsx
+++ b/src/shell/Mobile/BinContextMenu/BinContextMenu.tsx
@@ -256,7 +256,7 @@ export function BinContextMenu({ bin, position, onClose, source }: BinContextMen
                   setShowLayerPicker(!showLayerPicker);
                 }
               }}
-              className="w-full px-4 py-3 flex items-center justify-between rounded-none text-content hover:bg-surface-hover"
+              className="w-full px-4 py-3 flex items-center justify-between rounded-none font-normal text-content hover:bg-surface-hover"
             >
               <div className="flex items-center gap-3">
                 <svg
@@ -297,7 +297,7 @@ export function BinContextMenu({ bin, position, onClose, source }: BinContextMen
                     key={layer.id}
                     variant="ghost"
                     onClick={() => handleMoveToGrid(layer.id)}
-                    className="w-full px-3 py-2 text-left justify-start items-start flex-col rounded hover:bg-surface-hover"
+                    className="w-full px-3 py-2 text-left justify-start items-start flex-col rounded font-normal hover:bg-surface-hover"
                   >
                     <div className="text-sm text-content">{layer.name}</div>
                     <div className="text-xs text-content-tertiary">

--- a/src/shell/Mobile/BinContextMenu/BinContextMenu.tsx
+++ b/src/shell/Mobile/BinContextMenu/BinContextMenu.tsx
@@ -23,6 +23,7 @@ import { findBinById } from '@/shared/utils/entity';
 import { isOk } from '@/core/result';
 import { useTranslation } from '@/i18n';
 import { lazyWithRetry, namedExport } from '@/shared/utils/lazyWithRetry';
+import { Button } from '@/design-system';
 import type { Bin, GridUnits, LayerId } from '@/core/types';
 
 const BinContextMenuDesignSection = lazyWithRetry(() =>
@@ -246,7 +247,8 @@ export function BinContextMenu({ bin, position, onClose, source }: BinContextMen
 
         {isInStash && (
           <div>
-            <button
+            <Button
+              variant="ghost"
               onClick={() => {
                 if (layout.layers.length === 1) {
                   handleMoveToGrid(layout.layers[0].id);
@@ -254,7 +256,7 @@ export function BinContextMenu({ bin, position, onClose, source }: BinContextMen
                   setShowLayerPicker(!showLayerPicker);
                 }
               }}
-              className="w-full px-4 py-3 flex items-center justify-between transition-colors text-content hover:bg-surface-hover"
+              className="w-full px-4 py-3 flex items-center justify-between rounded-none text-content hover:bg-surface-hover"
             >
               <div className="flex items-center gap-3">
                 <svg
@@ -287,20 +289,21 @@ export function BinContextMenu({ bin, position, onClose, source }: BinContextMen
                   />
                 </svg>
               )}
-            </button>
+            </Button>
             {showLayerPicker && (
               <div className="px-2 py-1 bg-surface-secondary">
                 {layout.layers.map((layer) => (
-                  <button
+                  <Button
                     key={layer.id}
+                    variant="ghost"
                     onClick={() => handleMoveToGrid(layer.id)}
-                    className="w-full px-3 py-2 text-left rounded transition-colors hover:bg-surface-hover"
+                    className="w-full px-3 py-2 text-left justify-start items-start flex-col rounded hover:bg-surface-hover"
                   >
                     <div className="text-sm text-content">{layer.name}</div>
                     <div className="text-xs text-content-tertiary">
                       {t('mobile.contextMenu.minHeight', { height: layer.height })}
                     </div>
-                  </button>
+                  </Button>
                 ))}
               </div>
             )}

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileCloudSharePanel.test.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileCloudSharePanel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MobileCloudSharePanel } from './MobileCloudSharePanel';
+import { resetAllStores } from '@/test/testUtils';
 import * as cloudShareHook from '@/features/cloud-share/hooks/useCloudShare';
 
 vi.mock('@/i18n', () => ({
@@ -23,6 +24,7 @@ const baseHook = {
 describe('MobileCloudSharePanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAllStores();
   });
 
   it('renders the cloud share sheet', () => {

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileCloudSharePanel.test.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileCloudSharePanel.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MobileCloudSharePanel } from './MobileCloudSharePanel';
+import * as cloudShareHook from '@/features/cloud-share/hooks/useCloudShare';
+
+vi.mock('@/i18n', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+const baseHook = {
+  status: 'idle' as const,
+  result: null,
+  error: null,
+  existingShare: null,
+  hasActiveShare: false,
+  share: vi.fn().mockResolvedValue(undefined),
+  updatePermission: vi.fn().mockResolvedValue(undefined),
+  remove: vi.fn().mockResolvedValue(false),
+  copyUrl: vi.fn().mockResolvedValue(true),
+  reset: vi.fn(),
+};
+
+describe('MobileCloudSharePanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the cloud share sheet', () => {
+    vi.spyOn(cloudShareHook, 'useCloudShare').mockReturnValue({ ...baseHook });
+    render(<MobileCloudSharePanel layoutId="layout-1" onClose={vi.fn()} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('calls share with the selected permission when the share button is clicked', () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(cloudShareHook, 'useCloudShare').mockReturnValue({ ...baseHook, share });
+    render(<MobileCloudSharePanel layoutId="layout-1" onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'share.shareToCloud' }));
+    expect(share).toHaveBeenCalledWith('view');
+  });
+
+  it('changing the permission select updates the shared value', () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(cloudShareHook, 'useCloudShare').mockReturnValue({ ...baseHook, share });
+    render(<MobileCloudSharePanel layoutId="layout-1" onClose={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText('mobile.layouts.permission'), {
+      target: { value: 'edit' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'share.shareToCloud' }));
+    expect(share).toHaveBeenCalledWith('edit');
+  });
+
+  it('calls onClose when the cancel button is clicked', () => {
+    const onClose = vi.fn();
+    vi.spyOn(cloudShareHook, 'useCloudShare').mockReturnValue({ ...baseHook });
+    render(<MobileCloudSharePanel layoutId="layout-1" onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.cancel' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileCloudSharePanel.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileCloudSharePanel.tsx
@@ -148,7 +148,7 @@ export function MobileCloudSharePanel({
               <span className="font-medium">{t('share.failedToShare')}</span>
             </div>
             <p className="text-sm text-content-secondary">{error.message}</p>
-            <Button variant="primary" fullWidth onClick={reset} className="py-3">
+            <Button variant="primary" fullWidth onClick={reset} className="py-3 rounded-lg">
               {t('mobile.layouts.tryAgain')}
             </Button>
           </div>
@@ -173,10 +173,10 @@ export function MobileCloudSharePanel({
             </p>
 
             <div className="flex gap-2">
-              <Button variant="primary" onClick={handleCopyUrl} className="flex-1 py-3">
+              <Button variant="primary" onClick={handleCopyUrl} className="flex-1 py-3 rounded-lg">
                 {urlCopied ? t('common.copied') : t('mobile.layouts.copyLinkAgain')}
               </Button>
-              <Button variant="secondary" onClick={onClose} className="flex-1 py-3">
+              <Button variant="secondary" onClick={onClose} className="flex-1 py-3 rounded-lg">
                 {t('common.done')}
               </Button>
             </div>
@@ -201,7 +201,7 @@ export function MobileCloudSharePanel({
               />
             </div>
 
-            <Button variant="primary" fullWidth onClick={handleShare} className="py-3">
+            <Button variant="primary" fullWidth onClick={handleShare} className="py-3 rounded-lg">
               {t('share.shareToCloud')}
             </Button>
           </div>
@@ -221,7 +221,7 @@ export function MobileCloudSharePanel({
               </p>
             </div>
 
-            <Button variant="primary" fullWidth onClick={handleCopyUrl} className="py-3">
+            <Button variant="primary" fullWidth onClick={handleCopyUrl} className="py-3 rounded-lg">
               {urlCopied ? t('common.copied') : t('share.copyLink')}
             </Button>
 
@@ -238,7 +238,7 @@ export function MobileCloudSharePanel({
               variant="ghost"
               fullWidth
               onClick={handleDelete}
-              className="py-2 text-sm text-content-tertiary hover:text-error"
+              className="py-2 text-sm font-normal text-content-tertiary hover:text-error hover:bg-transparent"
             >
               {t('mobile.layouts.deleteShare')}
             </Button>

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileCloudSharePanel.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileCloudSharePanel.tsx
@@ -250,7 +250,7 @@ export function MobileCloudSharePanel({
             variant="ghost"
             fullWidth
             onClick={onClose}
-            className="mt-4 py-3 text-content-secondary"
+            className="mt-4 py-3 text-content-secondary hover:bg-transparent hover:text-content-secondary"
           >
             {t('common.cancel')}
           </Button>

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileCloudSharePanel.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileCloudSharePanel.tsx
@@ -17,6 +17,7 @@ import { formatShareDate } from '@/features/cloud-share/utils/cloudShare';
 import type { SharePermission } from '@/core/types';
 import { useTranslation } from '@/i18n';
 import type { TFunction } from '@/i18n';
+import { Button } from '@/design-system';
 import { SvgIcon, LoadingSpinner, PermissionSelect, ICON_PATHS } from './MobileLayoutsPanelParts';
 
 function getLoadingLabel(status: CloudShareStatus, t: TFunction): string {
@@ -147,12 +148,9 @@ export function MobileCloudSharePanel({
               <span className="font-medium">{t('share.failedToShare')}</span>
             </div>
             <p className="text-sm text-content-secondary">{error.message}</p>
-            <button
-              onClick={reset}
-              className="w-full py-3 bg-accent text-on-dark font-medium rounded-lg"
-            >
+            <Button variant="primary" fullWidth onClick={reset} className="py-3">
               {t('mobile.layouts.tryAgain')}
-            </button>
+            </Button>
           </div>
         )}
 
@@ -175,18 +173,12 @@ export function MobileCloudSharePanel({
             </p>
 
             <div className="flex gap-2">
-              <button
-                onClick={handleCopyUrl}
-                className="flex-1 py-3 bg-accent text-on-dark font-medium rounded-lg"
-              >
+              <Button variant="primary" onClick={handleCopyUrl} className="flex-1 py-3">
                 {urlCopied ? t('common.copied') : t('mobile.layouts.copyLinkAgain')}
-              </button>
-              <button
-                onClick={onClose}
-                className="flex-1 py-3 bg-surface text-content font-medium rounded-lg"
-              >
+              </Button>
+              <Button variant="secondary" onClick={onClose} className="flex-1 py-3">
                 {t('common.done')}
-              </button>
+              </Button>
             </div>
           </div>
         )}
@@ -209,12 +201,9 @@ export function MobileCloudSharePanel({
               />
             </div>
 
-            <button
-              onClick={handleShare}
-              className="w-full py-3 bg-accent text-on-dark font-medium rounded-lg"
-            >
+            <Button variant="primary" fullWidth onClick={handleShare} className="py-3">
               {t('share.shareToCloud')}
-            </button>
+            </Button>
           </div>
         )}
 
@@ -232,12 +221,9 @@ export function MobileCloudSharePanel({
               </p>
             </div>
 
-            <button
-              onClick={handleCopyUrl}
-              className="w-full py-3 bg-accent text-on-dark font-medium rounded-lg"
-            >
+            <Button variant="primary" fullWidth onClick={handleCopyUrl} className="py-3">
               {urlCopied ? t('common.copied') : t('share.copyLink')}
-            </button>
+            </Button>
 
             <div className="flex items-center gap-3">
               <PermissionSelect
@@ -248,19 +234,26 @@ export function MobileCloudSharePanel({
               />
             </div>
 
-            <button
+            <Button
+              variant="ghost"
+              fullWidth
               onClick={handleDelete}
-              className="w-full py-2 text-sm text-content-tertiary hover:text-error transition-colors"
+              className="py-2 text-sm text-content-tertiary hover:text-error"
             >
               {t('mobile.layouts.deleteShare')}
-            </button>
+            </Button>
           </div>
         )}
 
         {status !== 'success' && (
-          <button onClick={onClose} className="w-full mt-4 py-3 text-content-secondary font-medium">
+          <Button
+            variant="ghost"
+            fullWidth
+            onClick={onClose}
+            className="mt-4 py-3 text-content-secondary"
+          >
             {t('common.cancel')}
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsListItem.test.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsListItem.test.tsx
@@ -1,11 +1,16 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { LayoutListItem, findEntry } from './MobileLayoutsListItem';
+import { resetAllStores } from '@/test/testUtils';
 import type { LayoutEntry } from '@/core/types';
 
 vi.mock('@/i18n', () => ({
   useTranslation: () => (key: string) => key,
 }));
+
+beforeEach(() => {
+  resetAllStores();
+});
 
 vi.mock('@/shell/LayoutThumbnail', () => ({
   LayoutThumbnail: () => <div data-testid="thumbnail" />,

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsListItem.test.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsListItem.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LayoutListItem, findEntry } from './MobileLayoutsListItem';
+import type { LayoutEntry } from '@/core/types';
+
+vi.mock('@/i18n', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+vi.mock('@/shell/LayoutThumbnail', () => ({
+  LayoutThumbnail: () => <div data-testid="thumbnail" />,
+}));
+
+function makeEntry(overrides: Partial<LayoutEntry> = {}): LayoutEntry {
+  return {
+    id: 'entry-1',
+    name: 'My Layout',
+    createdAt: 0,
+    modifiedAt: 0,
+    preview: {
+      drawerWidth: 10,
+      drawerDepth: 8,
+      drawerHeight: 12,
+      binCount: 4,
+      layerCount: 1,
+      binMap: [],
+    },
+    ...overrides,
+  };
+}
+
+const noopHandlers = {
+  onRename: vi.fn(),
+  onShare: vi.fn(),
+  onDuplicate: vi.fn(),
+  onDelete: vi.fn(),
+  onTouchStart: vi.fn(),
+  onTouchMove: vi.fn(),
+  onTouchEnd: vi.fn(),
+  formatRelativeDate: () => 'just now',
+};
+
+describe('findEntry', () => {
+  it('finds an entry by id', () => {
+    const entries = [makeEntry({ id: 'a' }), makeEntry({ id: 'b' })];
+    expect(findEntry(entries, 'b')?.id).toBe('b');
+  });
+
+  it('returns undefined when not found', () => {
+    expect(findEntry([makeEntry({ id: 'a' })], 'missing')).toBeUndefined();
+  });
+});
+
+describe('LayoutListItem', () => {
+  it('renders the layout name', () => {
+    render(
+      <LayoutListItem
+        entry={makeEntry()}
+        isActive={false}
+        isSwiping={false}
+        swipeX={0}
+        canDelete
+        onSelect={vi.fn()}
+        {...noopHandlers}
+      />
+    );
+    expect(screen.getByText('My Layout')).toBeInTheDocument();
+  });
+
+  it('calls onSelect when the row is clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <LayoutListItem
+        entry={makeEntry({ id: 'entry-1' })}
+        isActive={false}
+        isSwiping={false}
+        swipeX={0}
+        canDelete
+        onSelect={onSelect}
+        {...noopHandlers}
+      />
+    );
+    fireEvent.click(screen.getByText('My Layout'));
+    expect(onSelect).toHaveBeenCalledWith('entry-1');
+  });
+});

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsListItem.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsListItem.tsx
@@ -122,12 +122,12 @@ export function LayoutListItem({
 
               <LayoutPreviewInfo entry={entry} />
 
-              <div className="text-xs text-content-tertiary mt-0.5">
+              <div className="text-xs font-normal text-content-tertiary mt-0.5">
                 {formatRelativeDate(entry.modifiedAt)}
               </div>
 
               {entry.forkedFrom && (
-                <div className="text-xs text-content-disabled">
+                <div className="text-xs font-normal text-content-disabled">
                   {t('layouts.forkedFrom')}
                   {entry.forkedFrom.name}
                 </div>
@@ -160,7 +160,7 @@ function LayoutPreviewInfo({ entry }: { entry: LayoutEntry }) {
   const { preview } = entry;
 
   return (
-    <div className="flex items-center gap-3 text-sm text-content-secondary">
+    <div className="flex items-center gap-3 text-sm font-normal text-content-secondary">
       <span className="flex items-center gap-1">
         <SvgIcon path={ICON_PATHS.grid} className="w-4 h-4" />
         {preview.drawerWidth}×{preview.drawerDepth}

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsListItem.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsListItem.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useTranslation } from '@/i18n';
+import { Button } from '@/design-system';
 import { LayoutThumbnail } from '@/shell/LayoutThumbnail';
 import type { LayoutEntry } from '@/core/types';
 import {
@@ -95,8 +96,9 @@ export function LayoutListItem({
         onTouchMove={onTouchMove}
         onTouchEnd={onTouchEnd}
       >
-        <button
-          className="w-full p-4 text-left"
+        <Button
+          variant="ghost"
+          className="w-full p-4 text-left justify-start rounded-none hover:bg-transparent"
           onClick={() => onSelect(entry.id)}
           aria-current={isActive ? 'true' : undefined}
         >
@@ -132,7 +134,7 @@ export function LayoutListItem({
               )}
             </div>
           </div>
-        </button>
+        </Button>
 
         {isActive && (
           <ActiveLayoutActions

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.test.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import {
   PermissionSelect,
@@ -7,10 +7,15 @@ import {
   ActiveLayoutActions,
   ICON_PATHS,
 } from './MobileLayoutsPanelParts';
+import { resetAllStores } from '@/test/testUtils';
 
 vi.mock('@/i18n', () => ({
   useTranslation: () => (key: string) => key,
 }));
+
+beforeEach(() => {
+  resetAllStores();
+});
 
 describe('PermissionSelect', () => {
   it('renders both permission options', () => {

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.test.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  PermissionSelect,
+  ShareOptionButton,
+  SwipeActionButton,
+  ActiveLayoutActions,
+  ICON_PATHS,
+} from './MobileLayoutsPanelParts';
+
+vi.mock('@/i18n', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+describe('PermissionSelect', () => {
+  it('renders both permission options', () => {
+    render(<PermissionSelect value="view" onChange={vi.fn()} ariaLabel="Permission" />);
+    const select = screen.getByLabelText('Permission');
+    expect(select).toHaveValue('view');
+    expect(
+      screen.getByRole('option', { name: 'mobile.layouts.anyoneCanView' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'mobile.layouts.anyoneCanEdit' })
+    ).toBeInTheDocument();
+  });
+
+  it('fires onChange with the new permission', () => {
+    const onChange = vi.fn();
+    render(<PermissionSelect value="view" onChange={onChange} ariaLabel="Permission" />);
+    fireEvent.change(screen.getByLabelText('Permission'), { target: { value: 'edit' } });
+    expect(onChange).toHaveBeenCalledWith('edit');
+  });
+});
+
+describe('ShareOptionButton', () => {
+  it('fires onClick when activated', () => {
+    const onClick = vi.fn();
+    render(
+      <ShareOptionButton
+        onClick={onClick}
+        iconPath={ICON_PATHS.share}
+        iconColor="text-accent"
+        bgColor="bg-surface"
+        title="Share link"
+        description="Copy a link"
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Share link/ }));
+    expect(onClick).toHaveBeenCalled();
+  });
+});
+
+describe('SwipeActionButton', () => {
+  it('exposes its label and fires onClick', () => {
+    const onClick = vi.fn();
+    render(
+      <SwipeActionButton
+        onClick={onClick}
+        iconPath={ICON_PATHS.delete}
+        bgColor="bg-danger"
+        label="Delete layout"
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Delete layout' }));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('is disabled when disabled prop is set', () => {
+    const onClick = vi.fn();
+    render(
+      <SwipeActionButton
+        onClick={onClick}
+        iconPath={ICON_PATHS.delete}
+        bgColor="bg-danger"
+        label="Delete layout"
+        disabled
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Delete layout' })).toBeDisabled();
+  });
+});
+
+describe('ActiveLayoutActions', () => {
+  it('fires the matching handler with the entry id', () => {
+    const onRename = vi.fn();
+    render(
+      <ActiveLayoutActions
+        entryId="entry-9"
+        onRename={onRename}
+        onShare={vi.fn()}
+        onDuplicate={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'common.rename' }));
+    expect(onRename).toHaveBeenCalledWith('entry-9');
+  });
+});

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.tsx
@@ -8,6 +8,8 @@
  */
 
 import { createPortal } from 'react-dom';
+import { Button, IconButton, Select } from '@/design-system';
+import type { SelectOption } from '@/design-system';
 import type { SharePermission } from '@/core/types';
 import { useTranslation } from '@/i18n';
 
@@ -91,7 +93,8 @@ export function ShareOptionButton({
   description,
 }: ShareOptionButtonProps) {
   return (
-    <button
+    <Button
+      variant="ghost"
       onClick={onClick}
       className="w-full flex items-center gap-3 p-4 bg-surface rounded-lg active:bg-surface-hover"
     >
@@ -102,7 +105,7 @@ export function ShareOptionButton({
         <div className="font-medium text-content">{title}</div>
         <div className="text-sm text-content-secondary">{description}</div>
       </div>
-    </button>
+    </Button>
   );
 }
 
@@ -122,14 +125,15 @@ export function SwipeActionButton({
   disabled,
 }: SwipeActionButtonProps) {
   return (
-    <button
+    <IconButton
+      variant="ghost"
       onClick={onClick}
-      className={`w-15 flex items-center justify-center ${bgColor} text-on-dark`}
+      className={`w-15 h-full rounded-none ${bgColor} text-on-dark`}
       aria-label={label}
       disabled={disabled}
     >
       <SvgIcon path={iconPath} />
-    </button>
+    </IconButton>
   );
 }
 
@@ -157,14 +161,15 @@ export function ActiveLayoutActions({
   return (
     <div className="flex items-center gap-2 px-4 pb-4">
       {actions.map((action) => (
-        <button
+        <Button
           key={action.label}
+          variant="secondary"
           onClick={() => action.handler(entryId)}
-          className="btn btn-secondary flex-1 h-11"
+          className="flex-1 h-11"
         >
           <SvgIcon path={action.icon} className="w-4 h-4 mr-1.5" />
           {action.label}
-        </button>
+        </Button>
       ))}
     </div>
   );
@@ -216,16 +221,18 @@ export function PermissionSelect({
   className,
 }: PermissionSelectProps) {
   const t = useTranslation();
+  const options: SelectOption[] = [
+    { id: 'view', name: t('mobile.layouts.anyoneCanView') },
+    { id: 'edit', name: t('mobile.layouts.anyoneCanEdit') },
+  ];
   return (
-    <select
+    <Select
       id={id}
       value={value}
-      onChange={(e) => onChange(e.target.value as SharePermission)}
-      className={`flex-1 bg-surface text-content px-3 py-2 rounded border border-stroke ${className ?? ''}`}
+      onValueChange={(v) => onChange(v as SharePermission)}
+      options={options}
+      className={`flex-1 ${className ?? ''}`}
       aria-label={ariaLabel}
-    >
-      <option value="view">{t('mobile.layouts.anyoneCanView')}</option>
-      <option value="edit">{t('mobile.layouts.anyoneCanEdit')}</option>
-    </select>
+    />
   );
 }

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.tsx
@@ -109,10 +109,28 @@ export function ShareOptionButton({
   );
 }
 
+type SwipeActionBgColor = 'bg-warning' | 'bg-success' | 'bg-accent' | 'bg-danger';
+
+/**
+ * Literal `hover:` overrides for each swipe-action badge color.
+ *
+ * `IconButton variant="ghost"` injects `hover:bg-surface-hover hover:text-content`,
+ * which would replace the colored badge and its icon color on hover. We re-assert
+ * the badge color with matching literal hover classes so the badge keeps its color
+ * (the original raw <button> had no hover treatment). Tailwind's JIT only compiles
+ * literal class strings, so these must stay literal — never `hover:${bgColor}`.
+ */
+const SWIPE_HOVER_BG: Record<SwipeActionBgColor, string> = {
+  'bg-warning': 'hover:bg-warning',
+  'bg-success': 'hover:bg-success',
+  'bg-accent': 'hover:bg-accent',
+  'bg-danger': 'hover:bg-danger',
+};
+
 interface SwipeActionButtonProps {
   readonly onClick: () => void;
   readonly iconPath: string;
-  readonly bgColor: string;
+  readonly bgColor: SwipeActionBgColor;
   readonly label: string;
   readonly disabled?: boolean;
 }
@@ -128,7 +146,7 @@ export function SwipeActionButton({
     <IconButton
       variant="ghost"
       onClick={onClick}
-      className={`w-15 h-full rounded-none ${bgColor} text-on-dark`}
+      className={`w-15 h-full rounded-none ${bgColor} ${SWIPE_HOVER_BG[bgColor]} text-on-dark hover:text-on-dark`}
       aria-label={label}
       disabled={disabled}
     >
@@ -227,11 +245,12 @@ export function PermissionSelect({
   ];
   return (
     <Select
+      fullWidth
       id={id}
       value={value}
       onValueChange={(v) => onChange(v as SharePermission)}
       options={options}
-      className={`flex-1 ${className ?? ''}`}
+      className={className}
       aria-label={ariaLabel}
     />
   );

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.tsx
@@ -103,7 +103,7 @@ export function ShareOptionButton({
       </div>
       <div className="text-left">
         <div className="font-medium text-content">{title}</div>
-        <div className="text-sm text-content-secondary">{description}</div>
+        <div className="text-sm font-normal text-content-secondary">{description}</div>
       </div>
     </Button>
   );

--- a/src/shell/Modals/HalfGridModeBlockedModal/HalfGridModeBlockedModal.tsx
+++ b/src/shell/Modals/HalfGridModeBlockedModal/HalfGridModeBlockedModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { HalfGridConstraintViolation } from '@/shared/utils/halfGridConstraints';
 import { useTranslation } from '@/i18n';
+import { Button } from '@/design-system';
 
 interface HalfGridModeBlockedModalProps {
   isOpen: boolean;
@@ -177,59 +178,25 @@ export function HalfGridModeBlockedModal({
 
           {/* Actions */}
           <div className="flex items-center justify-end gap-3 mt-6">
-            <button
+            <Button
               ref={cancelButtonRef}
+              type="button"
+              variant="ghost"
               onClick={onClose}
               disabled={isRemediating}
-              className="px-4 py-2 text-sm font-medium rounded-md
-                     text-content-secondary hover:text-content
-                     hover:bg-surface-elevated
-                     disabled:opacity-50 disabled:cursor-not-allowed
-                     transition-colors"
               aria-label={t('halfBinBlocked.cancelAriaLabel')}
             >
               {t('common.cancel')}
-            </button>
+            </Button>
 
-            <button
+            <Button
+              type="button"
+              variant="primary"
               onClick={handleRemediate}
-              disabled={isRemediating}
-              className="px-4 py-2 text-sm font-medium rounded-md
-                     bg-accent text-on-dark
-                     hover:bg-accent/90
-                     disabled:opacity-50 disabled:cursor-not-allowed
-                     transition-colors
-                     flex items-center gap-2"
+              loading={isRemediating}
               aria-label={t('halfBinMode.remediate.ariaLabel', { count: violation.count })}
-            >
-              {isRemediating ? (
-                <>
-                  <svg
-                    className="animate-spin motion-reduce:animate-none h-4 w-4"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    />
-                  </svg>
-                  <span>{t('common.loading')}</span>
-                </>
-              ) : (
-                <>
-                  <span>{t('halfBinBlocked.close')}</span>
+              rightIcon={
+                isRemediating ? undefined : (
                   <svg
                     className="w-4 h-4"
                     fill="none"
@@ -244,9 +211,11 @@ export function HalfGridModeBlockedModal({
                       d="M13 7l5 5m0 0l-5 5m5-5H6"
                     />
                   </svg>
-                </>
-              )}
-            </button>
+                )
+              }
+            >
+              <span>{isRemediating ? t('common.loading') : t('halfBinBlocked.close')}</span>
+            </Button>
           </div>
         </div>
       </div>

--- a/src/shell/Modals/HalfGridModeBlockedModal/HalfGridModeBlockedModal.tsx
+++ b/src/shell/Modals/HalfGridModeBlockedModal/HalfGridModeBlockedModal.tsx
@@ -194,7 +194,11 @@ export function HalfGridModeBlockedModal({
               variant="primary"
               onClick={handleRemediate}
               loading={isRemediating}
-              aria-label={t('halfBinMode.remediate.ariaLabel', { count: violation.count })}
+              aria-label={
+                isRemediating
+                  ? undefined
+                  : t('halfBinMode.remediate.ariaLabel', { count: violation.count })
+              }
               rightIcon={
                 isRemediating ? undefined : (
                   <svg


### PR DESCRIPTION
## What

Batch 6 (final) of the design-system migration. Migrates raw `<button>` and **three** `SharePermission` `<select>` elements across **8** `shell` (Mobile + Modals) and `cloud-share` components to `Button`/`IconButton`/`Select`. Drains 9 from `scripts/design-system-allowlist.txt` (8 migrated + the stale, already-clean AppearanceTab entry).

Files: BinContextMenu, MobileCloudSharePanel, MobileLayoutsListItem, MobileLayoutsPanelParts (+ `<select>`), HalfGridModeBlockedModal, DeleteShareConfirm, ShareLinkSection (+ `<select>`), SharePopover (+ `<select>`).

- Buttons → `Button`/`IconButton` (delete-confirm → `Button variant="danger"` with `loading`; close X → `IconButton`). Mobile controls keep comfortable touch targets.
- The three `SharePermission` `<select>`s → `<Select options value onValueChange>`; each gains an `aria-label` (reusing the existing `share.anyoneWithLinkCan` key — no new i18n keys).
- Adds render+interaction smoke tests for the 3 mobile files that lacked sibling tests.

## Verification
- ✅ `check:design-system` 0 new violations · typecheck · lint · all i18n checks clean
- ✅ Full suite: 13,597 passed, 7 skipped, 0 failed

Draft until visually eyeballed + Greptile.