### PR TITLE
perf(generation): cache deferred socket tessellation across edits

### DIFF
--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -70,6 +70,7 @@ graph TB
 - `worker/generators/generatorTypes.ts` — barrel re-export of constants/utilities
 - `worker/generators/hexGrid.ts` — hex grid layout calculations
 - `worker/generators/shapeCache.ts` — LRU cache for BREP solids
+- `worker/generators/socketMeshCache.ts` — LRU cache for the deferred socket's tessellated mesh (triangles + edge lines), keyed by socket geometry identity + tolerance; reused across edits that don't change the base
 - `worker/generators/patterns/` — pattern system (honeycomb, registry)
 - `worker/generators/scenarios/` — test scenario data by category
 - `export/stlExporter.ts` — STL file export
@@ -84,7 +85,7 @@ Composable stages in `pipeline/stages/`, orchestrated by `pipeline/runner.ts`:
 2. **Features** (`featuresStage`) — compartments, inserts, slots, labels, scoops, wall cutouts, patterns (cut the body only; the socket is never feature-cut)
 3. **Boolean** (`booleanStage`) — batch fuse additive + cut subtractive via `fuseAllBisect` / `cutAllBisect` (n-way batch first, recursive bisect on failure)
 4. **Translate** (`translateStage`) — Z-offset for socket-based bins (applied to `solid` **and** `deferredSolid` so they stay aligned)
-5. **Tessellate** (`tessellateStage`) — dynamic quality mesh + edge extraction; meshes `deferredSolid` separately and concatenates via `mergeShapeMeshes` (visually identical to the fused shell — socket meets the body only at a hidden interface)
+5. **Tessellate** (`tessellateStage`) — dynamic quality mesh + edge extraction; meshes `deferredSolid` separately and concatenates via `mergeShapeMeshes` (visually identical to the fused shell — socket meets the body only at a hidden interface). The socket mesh is cached by geometry identity (`socketMeshCache`, keyed via `deferredSolidKey`) so non-dimension edits skip re-tessellating the base.
 
 ## Worker Protocol
 

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -197,6 +197,7 @@ export function createInitialContext(
     onProgress,
     solid: null,
     deferredSolid: null,
+    deferredSolidKey: null,
     originToTag: new Map<number, number>(),
     fuseTargets: [],
     cutTargets: [],

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -16,13 +16,13 @@ import { unwrap, fuse, cut, translate, withScope, getKernelCapabilities } from '
 import type { DisposalScope, Shape3D, ValidSolid } from 'brepjs';
 import type { PipelineContext, PipelineStage } from '../types';
 import { checkCancelled, isAbortError } from '../../utils/abort';
-import { buildBaseSocket, buildOverhangFeet } from '../../socketBuilder';
+import { buildBaseSocket, buildOverhangFeet, baseSocketShapeKey } from '../../socketBuilder';
 import { buildLightweightBase } from '../../lightweightBaseBuilder';
 import type { LightweightBase } from '../../lightweightBaseBuilder';
 import { buildBinBox, buildTopShape } from '../../boxBuilder';
 import { buildBinBoxWithLip } from '../../integratedLipBuilder';
 import { maskHasHoles } from '../../maskPolygon';
-import { hasOverhang } from '../../overhang';
+import { hasOverhang, overhangKey } from '../../overhang';
 import {
   buildCompartmentCavityDrawings,
   buildCompartmentsCacheKey,
@@ -242,6 +242,7 @@ export const shellStage: PipelineStage = {
     // match the exception-safety the scoped code had: a failed OCCT fuse must
     // not leak the body/socket/feet WASM handles.
     let feet: Shape3D | null = null;
+    let feetFused = false;
     try {
       if (dim.overhang.feet && hasOverhang(dim.overhang)) {
         feet = buildOverhangFeet(params.width, params.depth, dim.overhang, params.gridUnitMm, true);
@@ -251,6 +252,7 @@ export const shellStage: PipelineStage = {
           feet.delete();
           feet = null;
           socket = withFeet;
+          feetFused = true;
         }
       }
       collectOrigins(socket, FeatureTag.SOCKET, originToTag);
@@ -267,7 +269,25 @@ export const shellStage: PipelineStage = {
       // final socket fuse (onto the featured body) stays manifold. The socket is
       // never feature-cut — it only meets the body at the hidden floor interface
       // — so order is geometrically equivalent, just numerically robust.
-      return { ...ctx, solid: body, deferredSolid: socket };
+      // The lightweight base (shelled cups) isn't a standard socket, so it can't
+      // share the socket mesh cache — leave its key null to force a fresh mesh.
+      const deferredSolidKey = liteBase
+        ? null
+        : `${baseSocketShapeKey(
+            params.width,
+            params.depth,
+            dim.withMagnet,
+            dim.withScrew,
+            params.base.magnetDiameter / 2,
+            params.base.magnetDepth,
+            params.base.screwDiameter / 2,
+            true,
+            dim.halfSockets,
+            params.gridUnitMm,
+            params.cellMask
+          )}|${feetFused ? overhangKey(dim.overhang) : 'nofeet'}`;
+
+      return { ...ctx, solid: body, deferredSolid: socket, deferredSolidKey };
     } catch (e: unknown) {
       socket.delete();
       body.delete();

--- a/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
@@ -14,6 +14,7 @@ import { toIndexedMeshData, mergeShapeMeshes, concatFloat32 } from '../../utils/
 import { creaseEdges } from '../../utils';
 import { computeTessellationTolerances } from '../../utils/tolerances';
 import { setLastSolid } from '../../shapeCache';
+import { getSocketMesh, setSocketMesh, socketMeshKey } from '../../socketMeshCache';
 import { keepOuterShell } from '../../utils/outerShell';
 
 export const tessellateStage: PipelineStage = {
@@ -81,15 +82,27 @@ export const tessellateStage: PipelineStage = {
     // separately and concatenate: the socket is never feature-cut and only
     // meets the body at a hidden interface, so the merged mesh is visually
     // identical to the fused shell (though not watertight at the seam).
-    const { deferredSolid } = ctx;
+    const { deferredSolid, deferredSolidKey } = ctx;
     if (deferredSolid) {
       try {
-        const socketMesh = mesh(deferredSolid, { tolerance, angularTolerance });
-        shapeMesh = mergeShapeMeshes(shapeMesh, socketMesh);
-        const socketEdges = buildTime
-          ? creaseEdges(socketMesh)
-          : meshEdges(deferredSolid, { tolerance, angularTolerance: edgeAngular }).lines;
-        edgeLines = concatFloat32(edgeLines, socketEdges);
+        // Reuse the socket's mesh across edits that don't change its geometry or
+        // the tessellation tolerance — the dominant case during interactive
+        // design, where the body's features change but the base does not. A null
+        // key (lightweight base) always re-meshes.
+        const cacheKey = deferredSolidKey
+          ? socketMeshKey(deferredSolidKey, tolerance, angularTolerance, buildTime)
+          : null;
+        let cached = cacheKey ? getSocketMesh(cacheKey) : null;
+        if (!cached) {
+          const socketMesh = mesh(deferredSolid, { tolerance, angularTolerance });
+          const socketEdges = buildTime
+            ? creaseEdges(socketMesh)
+            : meshEdges(deferredSolid, { tolerance, angularTolerance: edgeAngular }).lines;
+          cached = { mesh: socketMesh, edgeLines: socketEdges };
+          if (cacheKey) setSocketMesh(cacheKey, cached);
+        }
+        shapeMesh = mergeShapeMeshes(shapeMesh, cached.mesh);
+        edgeLines = concatFloat32(edgeLines, cached.edgeLines);
       } finally {
         // Dispose even if mesh/meshEdges throws, so the WASM handle never leaks.
         deferredSolid.delete();

--- a/src/features/generation/worker/generators/pipeline/types.ts
+++ b/src/features/generation/worker/generators/pipeline/types.ts
@@ -87,6 +87,13 @@ export interface PipelineContext {
    * for a watertight model.
    */
   readonly deferredSolid: Shape3D | null;
+  /**
+   * Geometry-identity key for {@link deferredSolid}, used by the tessellate
+   * stage to cache the socket's mesh across edits that don't change the base.
+   * Null when the deferred solid isn't a cacheable standard socket (e.g. the
+   * lightweight-base path), which forces a fresh tessellation.
+   */
+  readonly deferredSolidKey?: string | null;
   /** Face provenance tracking — intentionally mutable (passed by reference) */
   readonly originToTag: Map<number, number>;
   /** Additive feature shapes to fuse into the bin */

--- a/src/features/generation/worker/generators/pipeline/types.ts
+++ b/src/features/generation/worker/generators/pipeline/types.ts
@@ -90,10 +90,11 @@ export interface PipelineContext {
   /**
    * Geometry-identity key for {@link deferredSolid}, used by the tessellate
    * stage to cache the socket's mesh across edits that don't change the base.
-   * Null when the deferred solid isn't a cacheable standard socket (e.g. the
-   * lightweight-base path), which forces a fresh tessellation.
+   * Always present: `null` when there is no deferred solid yet or it isn't a
+   * cacheable standard socket (e.g. the lightweight-base path), which forces a
+   * fresh tessellation.
    */
-  readonly deferredSolidKey?: string | null;
+  readonly deferredSolidKey: string | null;
   /** Face provenance tracking — intentionally mutable (passed by reference) */
   readonly originToTag: Map<number, number>;
   /** Additive feature shapes to fuse into the bin */

--- a/src/features/generation/worker/generators/shapeCache.ts
+++ b/src/features/generation/worker/generators/shapeCache.ts
@@ -22,6 +22,7 @@ import type { CacheStats } from './lruCache';
 import { LRUCache } from './lruCache';
 import { buildCacheKey, quantize, compactKey } from './cacheKeyUtils';
 import { GRIDFINITY } from '@/shared/constants/bin';
+import { clearSocketMeshCache } from './socketMeshCache';
 
 /** Dispose callback for LRU caches holding WASM-backed shapes. */
 const disposeShape = (_key: string, shape: Shape3D): void => {
@@ -222,6 +223,7 @@ export function clearAllCaches(): void {
   for (const cache of featureToolCaches.values()) {
     cache.dispose();
   }
+  clearSocketMeshCache();
   if (patternTemplateCache) {
     patternTemplateCache.shape.delete();
     patternTemplateCache = null;

--- a/src/features/generation/worker/generators/socketBuilder.ts
+++ b/src/features/generation/worker/generators/socketBuilder.ts
@@ -247,6 +247,42 @@ function batchFuseAndCut(cellSockets: Shape3D[], holeTools: Shape3D[]): Shape3D 
  *
  * @param forExport If true, uses full 5-section socket profile. Preview uses 3-section.
  */
+/**
+ * Cache key for the base socket shape produced by {@link buildBaseSocket}.
+ *
+ * Exposed so the tessellate stage can key a *mesh* cache off the exact same
+ * geometry identity the shape cache uses — without re-deriving (and risking
+ * drift from) the masking logic below.
+ */
+export function baseSocketShapeKey(
+  gridW: number,
+  gridD: number,
+  withMagnet: boolean,
+  withScrew: boolean,
+  magnetRadius: number,
+  magnetDepth: number,
+  screwRadius: number,
+  forExport: boolean,
+  halfSockets: boolean,
+  gridUnitMm: number,
+  cellMask?: CellMask
+): string {
+  const usingMask = isPartialMask(cellMask);
+  return socketCacheKey(
+    gridW,
+    gridD,
+    withMagnet,
+    withScrew,
+    magnetRadius,
+    magnetDepth,
+    screwRadius,
+    forExport,
+    halfSockets,
+    gridUnitMm,
+    usingMask ? hashMask(cellMask) : undefined
+  );
+}
+
 export function buildBaseSocket(
   gridW: number,
   gridD: number,
@@ -265,7 +301,7 @@ export function buildBaseSocket(
   const usingMask = isPartialMask(cellMask);
 
   // Check socket cache -- skip entire build if params haven't changed
-  const key = socketCacheKey(
+  const key = baseSocketShapeKey(
     gridW,
     gridD,
     withMagnet,
@@ -276,7 +312,7 @@ export function buildBaseSocket(
     forExport,
     halfSockets,
     gridUnitMm,
-    usingMask ? hashMask(cellMask) : undefined
+    cellMask
   );
   const cached = getSocketCache(key);
   if (cached) {

--- a/src/features/generation/worker/generators/socketMeshCache.kernel.test.ts
+++ b/src/features/generation/worker/generators/socketMeshCache.kernel.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+/**
+ * Kernel-backed correctness gate for the deferred-socket mesh cache.
+ *
+ * The cache reuses a previously tessellated socket mesh across generations.
+ * These tests prove (1) a cache hit returns geometry byte-identical to a fresh
+ * tessellation, and (2) changing the socket's geometry (magnet holes) does not
+ * let a stale entry leak into an unrelated bin.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+import { buildParams } from './__kernel-tests__/scenarioTypes';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { clearAllCaches } from './shapeCache';
+import { getSocketMeshCacheStats } from './socketMeshCache';
+import type { MeshData } from '../../bridge/types';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 60_000);
+
+beforeEach(() => {
+  clearAllCaches();
+});
+
+function expectSameGeometry(a: MeshData, b: MeshData): void {
+  expect(a.vertices).toEqual(b.vertices);
+  expect(a.normals).toEqual(b.normals);
+  expect(a.indices).toEqual(b.indices);
+  expect(a.edgeVertices).toEqual(b.edgeVertices);
+}
+
+describe('socket mesh cache (kernel)', () => {
+  it('a cache hit produces geometry identical to a fresh tessellation', () => {
+    const generateBin = getGenerateBin();
+    const params = buildParams({ width: 2, depth: 2 });
+
+    const fresh = generateBin(params); // socket-mesh miss → tessellate + store
+    const hitsAfterFresh = getSocketMeshCacheStats().hits;
+
+    const hit = generateBin(params); // socket-mesh hit → reuse
+    expect(getSocketMeshCacheStats().hits).toBeGreaterThan(hitsAfterFresh);
+
+    expectSameGeometry(fresh, hit);
+  });
+
+  it('does not leak a stale socket mesh across a magnet-hole change', () => {
+    const generateBin = getGenerateBin();
+    const plain = buildParams({
+      width: 2,
+      depth: 2,
+      base: { ...DEFAULT_BIN_PARAMS.base, magnetHoles: false },
+    });
+    const magnets = buildParams({
+      width: 2,
+      depth: 2,
+      base: { ...DEFAULT_BIN_PARAMS.base, magnetHoles: true },
+    });
+
+    const plainRef = generateBin(plain);
+    generateBin(magnets); // different socket geometry → different key
+    const plainAgain = generateBin(plain); // must reuse the plain socket, not the magnet one
+
+    expectSameGeometry(plainRef, plainAgain);
+  });
+});

--- a/src/features/generation/worker/generators/socketMeshCache.test.ts
+++ b/src/features/generation/worker/generators/socketMeshCache.test.ts
@@ -67,4 +67,18 @@ describe('socket mesh cache', () => {
     expect(getSocketMesh(key)).toBeNull();
     expect(getSocketMeshCacheStats().size).toBe(0);
   });
+
+  it('resets hit/miss counters on clear (no stale cross-kernel totals)', () => {
+    const key = socketMeshKey('geo', 0.1, 8, false);
+    setSocketMesh(key, fakeEntry());
+    getSocketMesh(key); // hit
+    getSocketMesh(socketMeshKey('absent', 0.1, 8, false)); // miss
+    expect(getSocketMeshCacheStats().hits + getSocketMeshCacheStats().misses).toBeGreaterThan(0);
+
+    clearSocketMeshCache();
+    const stats = getSocketMeshCacheStats();
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+    expect(stats.evictions).toBe(0);
+  });
 });

--- a/src/features/generation/worker/generators/socketMeshCache.test.ts
+++ b/src/features/generation/worker/generators/socketMeshCache.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  socketMeshKey,
+  getSocketMesh,
+  setSocketMesh,
+  clearSocketMeshCache,
+  getSocketMeshCacheStats,
+  type CachedSocketMesh,
+} from './socketMeshCache';
+
+const fakeEntry = (): CachedSocketMesh => ({
+  mesh: {
+    vertices: new Float32Array([0, 0, 0]),
+    normals: new Float32Array([0, 0, 1]),
+    uvs: new Float32Array([0, 0]),
+    triangles: new Uint32Array([0, 0, 0]),
+    faceGroups: [],
+  },
+  edgeLines: new Float32Array([0, 0, 0, 1, 1, 1]),
+});
+
+afterEach(() => {
+  clearSocketMeshCache();
+});
+
+describe('socketMeshKey', () => {
+  it('changes with tolerance, angular tolerance, and extractor model', () => {
+    const base = socketMeshKey('geo', 0.1, 8, false);
+    expect(socketMeshKey('geo', 0.2, 8, false)).not.toBe(base);
+    expect(socketMeshKey('geo', 0.1, 12, false)).not.toBe(base);
+    expect(socketMeshKey('geo', 0.1, 8, true)).not.toBe(base);
+  });
+
+  it('changes with the geometry key', () => {
+    expect(socketMeshKey('geoA', 0.1, 8, false)).not.toBe(socketMeshKey('geoB', 0.1, 8, false));
+  });
+
+  it('is stable for identical inputs', () => {
+    expect(socketMeshKey('geo', 0.1, 8, false)).toBe(socketMeshKey('geo', 0.1, 8, false));
+  });
+});
+
+describe('socket mesh cache', () => {
+  it('returns null on miss and the stored entry on hit', () => {
+    const key = socketMeshKey('geo', 0.1, 8, false);
+    expect(getSocketMesh(key)).toBeNull();
+
+    const entry = fakeEntry();
+    setSocketMesh(key, entry);
+    expect(getSocketMesh(key)).toBe(entry);
+  });
+
+  it('isolates entries by key', () => {
+    const a = socketMeshKey('geoA', 0.1, 8, false);
+    const b = socketMeshKey('geoB', 0.1, 8, false);
+    const entry = fakeEntry();
+    setSocketMesh(a, entry);
+    expect(getSocketMesh(b)).toBeNull();
+  });
+
+  it('clears on clearSocketMeshCache (kernel switch)', () => {
+    const key = socketMeshKey('geo', 0.1, 8, false);
+    setSocketMesh(key, fakeEntry());
+    expect(getSocketMesh(key)).not.toBeNull();
+
+    clearSocketMeshCache();
+    expect(getSocketMesh(key)).toBeNull();
+    expect(getSocketMeshCacheStats().size).toBe(0);
+  });
+});

--- a/src/features/generation/worker/generators/socketMeshCache.ts
+++ b/src/features/generation/worker/generators/socketMeshCache.ts
@@ -54,4 +54,7 @@ export function getSocketMeshCacheStats(): CacheStats {
 
 export function clearSocketMeshCache(): void {
   socketMeshCache.dispose();
+  // Reset hit/miss/eviction counters too, so perf diagnostics read after a
+  // kernel switch (clearAllCaches) don't carry stale cross-kernel totals.
+  socketMeshCache.resetStats();
 }

--- a/src/features/generation/worker/generators/socketMeshCache.ts
+++ b/src/features/generation/worker/generators/socketMeshCache.ts
@@ -1,0 +1,57 @@
+/**
+ * Tessellation cache for the deferred base socket.
+ *
+ * The base socket is geometrically stable across most preview edits (it only
+ * tracks grid dimensions, magnet/screw holes, half-sockets, mask, and overhang
+ * feet — never the body's features). Yet every generation builds a fresh WASM
+ * solid for it, so brepjs's identity-keyed (WeakMap) mesh cache misses and the
+ * socket is re-tessellated each frame. This keys the socket's *mesh* (triangles
+ * + feature edge lines) by geometry identity instead, so a non-dimension edit
+ * (compartments, labels, dividers, magnets…) reuses the prior socket mesh.
+ *
+ * Stored arrays are JS-owned (brepjs copies them out of the WASM heap) and the
+ * tessellate stage only ever *reads* them — `mergeShapeMeshes`/`concatFloat32`
+ * allocate fresh output — so a cached entry is safe to hand back repeatedly.
+ */
+
+import { LRUCache } from './lruCache';
+import type { CacheStats } from './lruCache';
+import type { ShapeMesh } from './utils/mesh';
+
+export interface CachedSocketMesh {
+  readonly mesh: ShapeMesh;
+  readonly edgeLines: ArrayLike<number>;
+}
+
+const socketMeshCache = new LRUCache<CachedSocketMesh>('socket-mesh', 16);
+
+/**
+ * Compose the full mesh-cache key from the socket's geometry key (built in the
+ * shell stage) and the tessellation parameters that change its triangle output.
+ * `buildTime` distinguishes the analytic edge extractor from the crease-edge
+ * fallback so a kernel switch can't serve edges from the wrong extractor.
+ */
+export function socketMeshKey(
+  geometryKey: string,
+  tolerance: number,
+  angularTolerance: number,
+  buildTime: boolean
+): string {
+  return `${geometryKey}|${tolerance}:${angularTolerance}|${buildTime ? 'b' : 'e'}`;
+}
+
+export function getSocketMesh(key: string): CachedSocketMesh | null {
+  return socketMeshCache.get(key) ?? null;
+}
+
+export function setSocketMesh(key: string, value: CachedSocketMesh): void {
+  socketMeshCache.set(key, value);
+}
+
+export function getSocketMeshCacheStats(): CacheStats {
+  return socketMeshCache.getStats();
+}
+
+export function clearSocketMeshCache(): void {
+  socketMeshCache.dispose();
+}

--- a/src/features/generation/worker/generators/utils/mesh.ts
+++ b/src/features/generation/worker/generators/utils/mesh.ts
@@ -6,7 +6,7 @@ interface FaceGroup {
   faceId: number;
   origin: number;
 }
-interface ShapeMesh {
+export interface ShapeMesh {
   vertices: Float32Array;
   normals: Float32Array;
   uvs: Float32Array;

--- a/src/features/generation/worker/generators/utils/mesh.ts
+++ b/src/features/generation/worker/generators/utils/mesh.ts
@@ -1,6 +1,6 @@
 import type { MeshData } from '../../../bridge/types';
 
-interface FaceGroup {
+export interface FaceGroup {
   start: number;
   count: number;
   faceId: number;


### PR DESCRIPTION
## Summary

The base socket is geometrically stable across most preview edits — it only tracks grid dimensions, magnet/screw holes, half-sockets, mask, and overhang feet, **never the body's features**. Yet every generation builds a fresh WASM solid for it, so brepjs's identity-keyed (`WeakMap`) mesh cache misses and the socket is **re-tessellated on every frame**.

This keys the socket's *mesh* (triangles + feature edge lines) by geometry identity instead:

- `shellStage` stamps the deferred socket with a stable key (reusing the existing `socketCacheKey` plus an overhang-feet sub-key), threaded through the pipeline context.
- `tessellateStage` reuses the prior socket mesh when the key **and** tessellation tolerances match.
- The lightweight-base path stays uncached (its "socket" is shelled cups, not a standard socket).

So a non-dimension edit (compartments, labels, dividers, magnets, scoops…) — the common interactive case — skips re-meshing the base entirely.

## Why it's safe

Cached arrays are JS-owned (brepjs copies them out of the WASM heap) and the tessellate stage only ever *reads* them — `mergeShapeMeshes`/`concatFloat32` allocate fresh output — so a cached entry is safe to hand back repeatedly. The cache is cleared on kernel switch (`clearAllCaches`).

## Validation

- Full `generators` suite: **1539 passed** (snapshots + scenarios — would diverge on any stale-mesh bug)
- New unit tests for key sensitivity + cache lifecycle
- New kernel-backed tests proving a cache hit is **byte-identical** to a fresh tessellation, and that a magnet-hole change can't leak a stale socket mesh into an unrelated bin
- typecheck + eslint + all pre-commit gates green