### PR TITLE
refactor(design-system): migrate PrintBedInput toggle, empty the allowlist

### DIFF
--- a/scripts/design-system-allowlist.txt
+++ b/scripts/design-system-allowlist.txt
@@ -1,30 +1,12 @@
 # Design System Migration Allowlist
 #
-# Files listed here are grandfathered in and may use raw HTML elements.
-# The check:design-system gate is ENABLED — new raw elements are blocked,
-# but these pre-existing files are exempt until migrated. Migrate gradually
-# and delete each file from this list once it uses @/design-system.
+# Files listed here are grandfathered in and may use raw HTML elements
+# (<button>, <select>, <input type="checkbox">, text <input>). The
+# check:design-system gate is ENABLED — any new raw element is blocked.
 #
-# To migrate a file:
-# 1. Replace raw <button> with <Button>
-# 2. Replace raw <select> with <Select>
-# 3. Replace <input type="checkbox"> with <Checkbox>
-# 4. Replace text <input> with <Input>
-# 5. Remove the file from this list
+# Migration is complete: there are no grandfathered files. Feature and
+# component code uses the design system:
+#   import { Button, IconButton, Select, Input, Checkbox } from '@/design-system';
 #
-# Import design system components:
-#   import { Button, Checkbox, Select, Input } from '@/design-system';
-#
-# Migration policy (clean swaps only): migrate raw buttons that map directly
-# to <Button>/<IconButton> while preserving exact appearance. Most remaining
-# entries are intentionally raw — bespoke controls that do NOT map cleanly:
-# segmented controls / connected toolbars / pills with an active bg-accent
-# state, role=radio|tab grids with roving tabindex, custom toggle switches,
-# sliders, color-swatch grids, and connected steppers. Forcing these into
-# Button/IconButton breaks a11y semantics (e.g. IconButton emits aria-pressed
-# where a role=radio needs aria-checked) or needs many className overrides for
-# no visual gain. Adopt the DS
-# SegmentedControl/primitive for those in a dedicated effort rather than a
-# button-by-button swap.
-
-src/shared/components/PrintBedInput/PrintBedInput.tsx
+# To grant a temporary exception, add the file path below (one per line),
+# then delete it once the file is migrated.

--- a/src/shared/components/PrintBedInput/PrintBedInput.tsx
+++ b/src/shared/components/PrintBedInput/PrintBedInput.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { Button } from '@/design-system';
 import { DeferredNumberInput } from '@/shared/components/DeferredNumberInput';
 import { useTranslation } from '@/i18n';
 
@@ -82,8 +83,10 @@ export function PrintBedInput({
   const btnClass = `flex-shrink-0 rounded border border-stroke-subtle text-content-secondary hover:text-content hover:bg-surface-hover hover:border-stroke transition-colors focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent ${isCompact ? 'p-0.5' : 'p-1'}`;
 
   const linkButton = (
-    <button
+    <Button
       type="button"
+      variant="ghost"
+      touchTarget={false}
       onClick={handleToggleLink}
       className={btnClass}
       aria-label={
@@ -105,7 +108,7 @@ export function PrintBedInput({
           UNLINK_ICON_PATHS.map((d) => <path key={d} d={d} />)
         )}
       </svg>
-    </button>
+    </Button>
   );
 
   if (showSingleInput) {


### PR DESCRIPTION
## Migrate the last allowlisted control + empty the allowlist

The design-system allowlist was down to a single grandfathered entry — `PrintBedInput`'s compact link/unlink toggle. It had been reverted to a raw `<button>` during the migration because `IconButton` forces `aspect-square w-9` (36px) + `!px-0`, which can't reproduce the control's padding-based compact sizing (~16px).

**Fix:** migrate it to a plain `<Button variant="ghost" touchTarget={false}>` (not `IconButton`), keeping the original `btnClass`. A non-icon-only `Button` doesn't force the fixed square, and tailwind-merge resolves the original classes over Button's defaults — verified the merged output keeps `p-0.5`/`p-1` (drops `px-4 py-2`), `rounded` 4px (over `rounded-md`), and the border. So it renders pixel-identical.

**Also:** removed the now-empty entry and trimmed the allowlist header — the long "bespoke controls intentionally raw" paragraph (segmented controls, pills, sliders, swatch grids, steppers…) was stale; those were all migrated. The list is now empty.

### Result
`check:design-system` reports **"All files use design system components correctly"** — 0 violations, 0 grandfathered files. The migration is complete; the gate now blocks any new raw element with no exceptions.

- tsc clean · eslint clean · PrintBedInput tests 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
