### PR TITLE
fix(design-system): restore card button styling regressed by button migration

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.tsx
@@ -117,7 +117,7 @@ export function ConnectorPicker({ value, onChange, renderExpanded }: ConnectorPi
                 onClick={() => {
                   if (!selected) onChange(optionValue);
                 }}
-                className="flex h-auto w-full cursor-pointer items-start gap-3 bg-transparent p-0 text-left font-normal hover:bg-transparent focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent"
+                className="flex h-auto w-full cursor-pointer items-start justify-start gap-3 bg-transparent p-0 text-left font-normal hover:bg-transparent focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent"
               >
                 <div className="mt-0.5 flex-shrink-0 text-content-secondary">
                   <Icon />

--- a/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.tsx
+++ b/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.tsx
@@ -74,7 +74,7 @@ function SolidModeContent() {
       type="button"
       variant="ghost"
       onClick={() => setCutoutEditorOpen(true)}
-      className="w-full rounded-lg bg-gradient-to-r from-accent/10 to-info/10 hover:from-accent/20 hover:to-info/20 border border-accent/20 p-3 text-left transition-all group"
+      className="group h-auto w-full justify-start rounded-lg border border-accent/20 bg-gradient-to-r from-accent/10 to-info/10 p-3 text-left font-normal transition-all hover:from-accent/20 hover:to-info/20 hover:bg-transparent"
     >
       <div className="flex w-full items-center gap-3">
         {/* Mini illustration: top-view of a bin with cutout shapes */}
@@ -134,7 +134,7 @@ export function InteriorModeCard({ mode, isExpanded, onSelect }: InteriorModeCar
         type="button"
         variant="ghost"
         onClick={onSelect}
-        className="flex w-full cursor-pointer items-start gap-3 text-left"
+        className="flex h-auto w-full cursor-pointer items-start justify-start gap-3 bg-transparent p-0 text-left font-normal hover:bg-transparent"
       >
         <div className="mt-0.5">{config.icon}</div>
         <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Problem

The combined button/select design-system migration (#2196) swapped the plain `<button>` in the **bin-designer interior cards** and **baseplate connector cards** for `<Button variant="ghost">`. The connector cards received neutralizing overrides; the interior cards did **not**, so `Button`'s intrinsic styles leaked in:

| Leaked style | Visible effect |
|---|---|
| `px-4 py-2` (size md) | Card header indented and taller, misaligned from the card's `p-3` edge and the expanded section below |
| `hover:bg-surface-hover` (ghost) | Inner rounded hover-fill nested inside the card's own hover |
| `font-medium` (base) | Description text rendered medium-weight instead of normal |

Both cards share the same root cause and regressed together.

## Fix

Neutralize the leaked `Button` defaults on the full-card click targets (keeping `<Button>`, since the design-system check now hard-fails on raw `<button>`):

- **`InteriorModeCard`** — header button: `h-auto justify-start bg-transparent p-0 font-normal hover:bg-transparent`; "Edit cutouts" button: `font-normal hover:bg-transparent justify-start` (gradient + gradient-hover preserved).
- **`ConnectorPicker`** — added `justify-start` to clear its one residual `justify-center` leak.

## Verification

- `pnpm run typecheck` ✅
- ESLint on changed files ✅
- `scripts/check-design-system-usage.sh` ✅
- Sibling tests: `InteriorModeCard.test.tsx` + `ConnectorPicker.test.tsx` — 22 passed ✅

## Follow-up (not in this PR)

Consider a `variant="unstyled"` (or `asChild`/Slot) escape hatch in the design-system `Button` so full-card click targets don't each have to hand-neutralize CVA defaults and drift apart.