### PR TITLE
feat(baseplate): stack-print retains dovetail connectors

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
@@ -354,6 +354,52 @@ describe('BaseplatePanel', () => {
         expect.objectContaining({ connectorNubs: true, connectorStyle: undefined })
       );
     });
+
+    describe('while vertical stacking', () => {
+      const stacking = { enabled: true, gapMm: 0.2 } as const;
+
+      it('keeps the connector picker reachable but hides magnets and corner radius', () => {
+        mockLayoutState.layout.baseplateParams = {
+          ...DEFAULT_BASEPLATE_PARAMS,
+          connectorNubs: true,
+          stackPrint: stacking,
+        };
+        render(<BaseplatePanel />);
+        expect(
+          screen.getByRole('radio', { name: 'baseplate.connectorStyle.dovetail' })
+        ).toBeChecked();
+        expect(screen.queryByText('baseplate.magnetHoles')).toBeNull();
+        expect(screen.queryByText('baseplate.cornerRadius')).toBeNull();
+      });
+
+      it('disables the snap clip option with a reason', () => {
+        mockLayoutState.layout.baseplateParams = {
+          ...DEFAULT_BASEPLATE_PARAMS,
+          connectorNubs: true,
+          connectorStyle: 'dovetailKey',
+          stackPrint: stacking,
+        };
+        render(<BaseplatePanel />);
+        expect(
+          screen.getByRole('radio', { name: 'baseplate.connectorStyle.snapClip' })
+        ).toBeDisabled();
+        expect(screen.getByText('baseplate.connectors.snapClipNoStack')).toBeInTheDocument();
+      });
+
+      it('shows snap clip as effectively none (it is stripped while stacking)', () => {
+        mockLayoutState.layout.baseplateParams = {
+          ...DEFAULT_BASEPLATE_PARAMS,
+          connectorNubs: true,
+          connectorStyle: 'snapClip',
+          stackPrint: stacking,
+        };
+        render(<BaseplatePanel />);
+        expect(screen.getByRole('radio', { name: 'baseplate.connectors.none' })).toBeChecked();
+        expect(
+          screen.getByRole('radio', { name: 'baseplate.connectorStyle.snapClip' })
+        ).not.toBeChecked();
+      });
+    });
   });
 
   it('renders print bed size stepper', () => {

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -394,14 +394,15 @@ export function BaseplatePanel() {
             enabling it strips and hides the Base controls below. */}
         <StackPrintSection stackPrint={baseplateParams.stackPrint} onChange={setStackPrint} />
 
-        {/* 3. Base — connectors, magnets, corner radius. Hidden entirely while
-            stacking (which strips all of them; the Stack section's notice says
-            why), so it never shows as an empty collapsible group. */}
-        {!stackEnabled && (
+        {/* 3. Base — connectors, magnets, corner radius. While stacking, magnets
+            and corner rounding are stripped so they hide, but connectors stay
+            reachable (dovetail styles stack fine); the group only renders when it
+            still has content, so it never shows as an empty collapsible group. */}
+        {(tiling?.isSplit || !stackEnabled) && (
           <StickyGroupHeader
             title={t('baseplate.sectionBase')}
             summary={
-              baseplateParams.magnetHoles
+              !stackEnabled && baseplateParams.magnetHoles
                 ? `\u00f8${baseplateParams.magnetDiameter}mm \u00d7 ${baseplateParams.magnetDepth}mm`
                 : undefined
             }
@@ -410,9 +411,18 @@ export function BaseplatePanel() {
               {tiling?.isSplit && (
                 <ConnectorPicker
                   value={
-                    baseplateParams.connectorNubs === true
-                      ? (baseplateParams.connectorStyle ?? 'dovetail')
-                      : 'none'
+                    // Snap clip is stripped while stacking, so show it as None
+                    // (the effective state); the stored style returns on toggle-off.
+                    stackEnabled && baseplateParams.connectorStyle === 'snapClip'
+                      ? 'none'
+                      : baseplateParams.connectorNubs === true
+                        ? (baseplateParams.connectorStyle ?? 'dovetail')
+                        : 'none'
+                  }
+                  disabledOptions={
+                    stackEnabled
+                      ? { snapClip: t('baseplate.connectors.snapClipNoStack') }
+                      : undefined
                   }
                   onChange={(v: ConnectorChoice) => {
                     if (v === 'none') {
@@ -479,60 +489,64 @@ export function BaseplatePanel() {
                   }
                 />
               )}
-              <div className="border-t border-stroke-subtle pt-3">
-                <FeatureToggle
-                  label={t('baseplate.magnetHoles')}
-                  checked={baseplateParams.magnetHoles}
-                  onChange={() => updateParam('magnetHoles', !baseplateParams.magnetHoles)}
-                  valueSummary={`\u00f8${baseplateParams.magnetDiameter}mm \u00d7 ${baseplateParams.magnetDepth}mm`}
-                >
-                  <SliderInput
-                    label={t('baseplate.magnetDiameter')}
-                    value={baseplateParams.magnetDiameter}
-                    onChange={(v) => updateParam('magnetDiameter', mm(v))}
-                    min={1}
-                    max={20}
-                    step={0.1}
-                    unit="mm"
-                    info={t('baseplate.magnetDiameterInfo')}
-                  />
-                  <SliderInput
-                    label={t('baseplate.magnetDepth')}
-                    value={baseplateParams.magnetDepth}
-                    onChange={(v) => updateParam('magnetDepth', mm(v))}
-                    min={0.5}
-                    max={10}
-                    step={0.1}
-                    unit="mm"
-                    info={t('baseplate.magnetDepthInfo')}
-                  />
-                </FeatureToggle>
-              </div>
-              <div className="border-t border-stroke-subtle pt-3">
-                <CornerRadiusControl
-                  cornerRadius={baseplateParams.cornerRadius}
-                  cornerRadii={baseplateParams.cornerRadii}
-                  maxRadius={
-                    gridUnitMm / 2 +
-                    Math.min(
-                      Math.min(baseplateParams.paddingLeft, baseplateParams.paddingRight),
-                      Math.min(baseplateParams.paddingFront, baseplateParams.paddingBack)
-                    )
-                  }
-                  onUniformChange={(r) => {
-                    updateParam('cornerRadius', mm(r));
-                    updateParam('cornerRadii', undefined);
-                  }}
-                  onPerCornerChange={(radii) => {
-                    updateParam('cornerRadii', {
-                      tl: mm(radii.tl),
-                      tr: mm(radii.tr),
-                      bl: mm(radii.bl),
-                      br: mm(radii.br),
-                    });
-                  }}
-                />
-              </div>
+              {!stackEnabled && (
+                <>
+                  <div className="border-t border-stroke-subtle pt-3">
+                    <FeatureToggle
+                      label={t('baseplate.magnetHoles')}
+                      checked={baseplateParams.magnetHoles}
+                      onChange={() => updateParam('magnetHoles', !baseplateParams.magnetHoles)}
+                      valueSummary={`\u00f8${baseplateParams.magnetDiameter}mm \u00d7 ${baseplateParams.magnetDepth}mm`}
+                    >
+                      <SliderInput
+                        label={t('baseplate.magnetDiameter')}
+                        value={baseplateParams.magnetDiameter}
+                        onChange={(v) => updateParam('magnetDiameter', mm(v))}
+                        min={1}
+                        max={20}
+                        step={0.1}
+                        unit="mm"
+                        info={t('baseplate.magnetDiameterInfo')}
+                      />
+                      <SliderInput
+                        label={t('baseplate.magnetDepth')}
+                        value={baseplateParams.magnetDepth}
+                        onChange={(v) => updateParam('magnetDepth', mm(v))}
+                        min={0.5}
+                        max={10}
+                        step={0.1}
+                        unit="mm"
+                        info={t('baseplate.magnetDepthInfo')}
+                      />
+                    </FeatureToggle>
+                  </div>
+                  <div className="border-t border-stroke-subtle pt-3">
+                    <CornerRadiusControl
+                      cornerRadius={baseplateParams.cornerRadius}
+                      cornerRadii={baseplateParams.cornerRadii}
+                      maxRadius={
+                        gridUnitMm / 2 +
+                        Math.min(
+                          Math.min(baseplateParams.paddingLeft, baseplateParams.paddingRight),
+                          Math.min(baseplateParams.paddingFront, baseplateParams.paddingBack)
+                        )
+                      }
+                      onUniformChange={(r) => {
+                        updateParam('cornerRadius', mm(r));
+                        updateParam('cornerRadii', undefined);
+                      }}
+                      onPerCornerChange={(radii) => {
+                        updateParam('cornerRadii', {
+                          tl: mm(radii.tl),
+                          tr: mm(radii.tr),
+                          bl: mm(radii.bl),
+                          br: mm(radii.br),
+                        });
+                      }}
+                    />
+                  </div>
+                </>
+              )}
             </div>
           </StickyGroupHeader>
         )}

--- a/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.test.tsx
@@ -60,4 +60,48 @@ describe('ConnectorPicker', () => {
     fireEvent.keyDown(screen.getByRole('radiogroup'), { key: 'ArrowDown' });
     expect(onChange).toHaveBeenCalledWith('dovetail');
   });
+
+  describe('disabledOptions', () => {
+    it('renders the reason and marks the option disabled', () => {
+      render(
+        <ConnectorPicker
+          value="none"
+          onChange={vi.fn()}
+          disabledOptions={{ snapClip: 'No stacking' }}
+        />
+      );
+      const snap = screen.getByRole('radio', { name: 'baseplate.connectorStyle.snapClip' });
+      expect(snap).toBeDisabled();
+      expect(snap).toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByText('No stacking')).toBeInTheDocument();
+    });
+
+    it('does not call onChange when a disabled option is clicked', () => {
+      const onChange = vi.fn();
+      render(
+        <ConnectorPicker
+          value="none"
+          onChange={onChange}
+          disabledOptions={{ snapClip: 'No stacking' }}
+        />
+      );
+      fireEvent.click(screen.getByRole('radio', { name: 'baseplate.connectorStyle.snapClip' }));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('skips disabled options in keyboard navigation', () => {
+      const onChange = vi.fn();
+      // From dovetailKey, ArrowDown would land on snapClip — but it's disabled,
+      // so it wraps to the first selectable option instead.
+      render(
+        <ConnectorPicker
+          value="dovetailKey"
+          onChange={onChange}
+          disabledOptions={{ snapClip: 'No stacking' }}
+        />
+      );
+      fireEvent.keyDown(screen.getByRole('radiogroup'), { key: 'ArrowDown' });
+      expect(onChange).toHaveBeenCalledWith('none');
+    });
+  });
 });

--- a/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.test.tsx
@@ -89,6 +89,22 @@ describe('ConnectorPicker', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
+    it('treats an empty-string reason as disabled (render + keyboard agree)', () => {
+      const onChange = vi.fn();
+      render(
+        <ConnectorPicker
+          value="dovetailKey"
+          onChange={onChange}
+          disabledOptions={{ snapClip: '' }}
+        />
+      );
+      expect(
+        screen.getByRole('radio', { name: 'baseplate.connectorStyle.snapClip' })
+      ).toBeDisabled();
+      fireEvent.keyDown(screen.getByRole('radiogroup'), { key: 'ArrowDown' });
+      expect(onChange).toHaveBeenCalledWith('none');
+    });
+
     it('skips disabled options in keyboard navigation', () => {
       const onChange = vi.fn();
       // From dovetailKey, ArrowDown would land on snapClip — but it's disabled,

--- a/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.tsx
@@ -55,30 +55,43 @@ interface ConnectorPickerProps {
   readonly onChange: (value: ConnectorChoice) => void;
   /** Inline controls rendered inside the selected card (Interior-section style). */
   readonly renderExpanded?: (value: ConnectorChoice) => ReactNode;
+  /**
+   * Options that can't be selected right now, mapped to the reason shown under
+   * the card. Used to disable snap clip while vertical stacking is on.
+   */
+  readonly disabledOptions?: Partial<Record<ConnectorChoice, string>>;
 }
 
-export function ConnectorPicker({ value, onChange, renderExpanded }: ConnectorPickerProps) {
+export function ConnectorPicker({
+  value,
+  onChange,
+  renderExpanded,
+  disabledOptions,
+}: ConnectorPickerProps) {
   const t = useTranslation();
   const groupRef = useRef<HTMLDivElement>(null);
 
   // Radio keyboard model: arrows/Home/End move the selection and focus, matching
-  // the design-system SegmentedControl.
+  // the design-system SegmentedControl. Disabled options are skipped.
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {
-      const index = OPTIONS.findIndex((o) => o.value === value);
+      const selectable = OPTIONS.filter((o) => !disabledOptions?.[o.value]);
+      if (selectable.length === 0) return;
+      const pos = selectable.findIndex((o) => o.value === value);
       let next: number;
-      if (e.key === 'ArrowDown' || e.key === 'ArrowRight') next = (index + 1) % OPTIONS.length;
+      if (e.key === 'ArrowDown' || e.key === 'ArrowRight') next = (pos + 1) % selectable.length;
       else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft')
-        next = (index - 1 + OPTIONS.length) % OPTIONS.length;
+        next = (pos - 1 + selectable.length) % selectable.length;
       else if (e.key === 'Home') next = 0;
-      else if (e.key === 'End') next = OPTIONS.length - 1;
+      else if (e.key === 'End') next = selectable.length - 1;
       else return;
       e.preventDefault();
-      if (next !== index) onChange(OPTIONS[next].value);
+      const nextValue = selectable[next].value;
+      if (nextValue !== value) onChange(nextValue);
       const radios = groupRef.current?.querySelectorAll<HTMLButtonElement>('[role="radio"]');
-      radios?.[next]?.focus();
+      radios?.[OPTIONS.findIndex((o) => o.value === nextValue)]?.focus();
     },
-    [value, onChange]
+    [value, onChange, disabledOptions]
   );
 
   return (
@@ -95,16 +108,20 @@ export function ConnectorPicker({ value, onChange, renderExpanded }: ConnectorPi
         className="space-y-1.5"
       >
         {OPTIONS.map(({ value: optionValue, titleKey, descKey, Icon }) => {
+          const disabledReason = disabledOptions?.[optionValue];
+          const disabled = disabledReason !== undefined;
           const selected = optionValue === value;
-          const expanded = selected ? renderExpanded?.(optionValue) : null;
+          const expanded = selected && !disabled ? renderExpanded?.(optionValue) : null;
           return (
             <div
               key={optionValue}
               className={cn(
                 'w-full rounded-lg border p-3 transition-all duration-200 ease-in-out',
-                selected
-                  ? 'border-accent bg-accent/5'
-                  : 'border-stroke-subtle bg-surface-elevated hover:bg-surface-hover'
+                disabled
+                  ? 'border-stroke-subtle bg-surface-elevated opacity-50'
+                  : selected
+                    ? 'border-accent bg-accent/5'
+                    : 'border-stroke-subtle bg-surface-elevated hover:bg-surface-hover'
               )}
             >
               <Button
@@ -112,12 +129,17 @@ export function ConnectorPicker({ value, onChange, renderExpanded }: ConnectorPi
                 variant="ghost"
                 role="radio"
                 aria-checked={selected}
+                aria-disabled={disabled}
+                disabled={disabled}
                 aria-label={t(titleKey)}
-                tabIndex={selected ? 0 : -1}
+                tabIndex={selected && !disabled ? 0 : -1}
                 onClick={() => {
-                  if (!selected) onChange(optionValue);
+                  if (!selected && !disabled) onChange(optionValue);
                 }}
-                className="flex h-auto w-full cursor-pointer items-start justify-start gap-3 bg-transparent p-0 text-left font-normal hover:bg-transparent focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent"
+                className={cn(
+                  'flex h-auto w-full items-start justify-start gap-3 bg-transparent p-0 text-left font-normal hover:bg-transparent focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent',
+                  disabled ? 'cursor-not-allowed' : 'cursor-pointer'
+                )}
               >
                 <div className="mt-0.5 flex-shrink-0 text-content-secondary">
                   <Icon />
@@ -125,6 +147,9 @@ export function ConnectorPicker({ value, onChange, renderExpanded }: ConnectorPi
                 <div className="min-w-0 flex-1">
                   <h4 className="text-sm font-medium text-content-primary">{t(titleKey)}</h4>
                   <p className="mt-0.5 text-xs text-content-secondary">{t(descKey)}</p>
+                  {disabled && (
+                    <p className="mt-0.5 text-[11px] text-content-tertiary">{disabledReason}</p>
+                  )}
                 </div>
               </Button>
 

--- a/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.tsx
@@ -72,16 +72,21 @@ export function ConnectorPicker({
   const groupRef = useRef<HTMLDivElement>(null);
 
   // Radio keyboard model: arrows/Home/End move the selection and focus, matching
-  // the design-system SegmentedControl. Disabled options are skipped.
+  // the design-system SegmentedControl. Disabled options are skipped. An option
+  // is disabled when it has a reason entry (any string, including empty), so the
+  // keyboard filter and the per-card render agree.
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {
-      const selectable = OPTIONS.filter((o) => !disabledOptions?.[o.value]);
+      const selectable = OPTIONS.filter((o) => disabledOptions?.[o.value] === undefined);
       if (selectable.length === 0) return;
+      // If the current value is itself disabled, findIndex returns -1; treat that
+      // as "before the first selectable" so arrows land on a valid neighbour.
       const pos = selectable.findIndex((o) => o.value === value);
       let next: number;
-      if (e.key === 'ArrowDown' || e.key === 'ArrowRight') next = (pos + 1) % selectable.length;
+      if (e.key === 'ArrowDown' || e.key === 'ArrowRight')
+        next = pos < 0 ? 0 : (pos + 1) % selectable.length;
       else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft')
-        next = (pos - 1 + selectable.length) % selectable.length;
+        next = pos < 0 ? selectable.length - 1 : (pos - 1 + selectable.length) % selectable.length;
       else if (e.key === 'Home') next = 0;
       else if (e.key === 'End') next = selectable.length - 1;
       else return;

--- a/src/features/baseplate/components/BaseplatePanel/StackPrintSection.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/StackPrintSection.tsx
@@ -1,8 +1,10 @@
 /**
  * "Stack for printing" panel section (experimental): stack a drawer's baseplates
  * into vertical towers separated by an air gap — bottom plate upright, the rest
- * flipped. Connectors, magnet holes, and corner rounding are auto-disabled by
- * the parent when this is enabled. Rendered as a plain (non-collapsible) block.
+ * flipped. Magnet holes and corner rounding are auto-disabled by the parent when
+ * this is enabled (they bridge / break tile uniformity under the flip); dovetail
+ * connectors are kept, only snap clip is disabled. Rendered as a plain
+ * (non-collapsible) block.
  */
 
 import { mm } from '@/core/types';

--- a/src/features/baseplate/hooks/useBaseplateExport.ts
+++ b/src/features/baseplate/hooks/useBaseplateExport.ts
@@ -255,8 +255,8 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
             let keyData = keyResult.data;
             if (format === '3mf') {
               // The key is a discrete part (one per seam junction, count in the
-              // guide), not a plate — stacking never applies to it. Connectors
-              // are disabled while stacking, so this path only runs unstacked.
+              // guide), not a plate — stacking never applies to it. It prints
+              // flat on its own even when the plates are stacked into towers.
               const blob = convertStlTo3mf(keyData, `${baseNameNoExt}_key`);
               keyData = await blob.arrayBuffer();
             }

--- a/src/features/baseplate/utils/buildFullParams.test.ts
+++ b/src/features/baseplate/utils/buildFullParams.test.ts
@@ -166,18 +166,44 @@ describe('buildFullParams', () => {
       expect(result.magnetHoles).toBe(true);
     });
 
-    it('strips connectors and magnets when stacking is enabled (without mutating stored)', () => {
+    it('keeps dovetail connectors but strips magnets when stacking (vertical prisms flip cleanly)', () => {
+      const stored = {
+        ...storedBase,
+        connectorNubs: true,
+        connectorStyle: undefined, // plain dovetail
+        stackPrint: { enabled: true, gapMm: 0.2 as never },
+      };
+      const result = buildFullParams(stored, 10, 8, 42, 'end', 'end');
+      expect(result.connectorNubs).toBe(true);
+      expect(result.connectorStyle).toBeUndefined();
+      expect(result.magnetHoles).toBe(false); // magnet pockets bridge when flipped
+    });
+
+    it('keeps dovetail key connectors when stacking', () => {
       const stored = {
         ...withFeatures,
         stackPrint: { enabled: true, gapMm: 0.2 as never },
       };
       const result = buildFullParams(stored, 10, 8, 42, 'end', 'end');
+      expect(result.connectorNubs).toBe(true);
+      expect(result.connectorStyle).toBe('dovetailKey');
+      expect(result.magnetHoles).toBe(false);
+    });
+
+    it('strips snap clip connectors when stacking (its blind pocket bridges when flipped)', () => {
+      const stored = {
+        ...storedBase,
+        connectorNubs: true,
+        connectorStyle: 'snapClip' as const,
+        stackPrint: { enabled: true, gapMm: 0.2 as never },
+      };
+      const result = buildFullParams(stored, 10, 8, 42, 'end', 'end');
       expect(result.connectorNubs).toBe(false);
       expect(result.connectorStyle).toBeUndefined();
-      expect(result.magnetHoles).toBe(false); // magnet pockets bridge when flipped
-      // Stored params are untouched, so the features return when stacking is off.
+      expect(result.magnetHoles).toBe(false);
+      // Stored params are untouched, so the style returns when stacking is off.
       expect(stored.connectorNubs).toBe(true);
-      expect(stored.magnetHoles).toBe(true);
+      expect(stored.connectorStyle).toBe('snapClip');
     });
 
     it('keeps connectors and magnets when stackPrint exists but is disabled', () => {

--- a/src/features/baseplate/utils/buildFullParams.ts
+++ b/src/features/baseplate/utils/buildFullParams.ts
@@ -23,12 +23,17 @@ export function buildFullParams(
   const width = synced ? drawerWidth : (stored.baseplateWidth ?? drawerWidth);
   const depth = synced ? drawerDepth : (stored.baseplateDepth ?? drawerDepth);
 
-  // Stack printing strips connectors AND magnet holes: connectors are
-  // unsupportable overhangs in a vertical stack, and magnet pockets become
-  // downward bridges when printed upside down (audited ~10% bridge area, vs 0%
-  // for a magnet-free plate). Done here rather than by mutating stored params,
-  // so the user's settings return intact when stacking is turned off.
+  // Stack printing flips every plate above the bottom upside down. Magnet
+  // pockets become downward bridges when flipped (audited ~10% bridge area, vs
+  // 0% for a magnet-free plate), and corner rounding makes corner tiles differ
+  // from the rest, so both are stripped. Dovetail connectors survive: tongues,
+  // grooves, and the dovetail key are full-height vertical prisms that flip
+  // cleanly. Only snap clip is incompatible — its blind top pocket (sealed
+  // floor + undercut ledge) inverts into a downward bridge/overhang — so it
+  // alone is stripped. Done here rather than by mutating stored params, so the
+  // user's settings return intact when stacking is turned off.
   const stackingOn = stored.stackPrint?.enabled === true;
+  const stripConnectors = stackingOn && stored.connectorStyle === 'snapClip';
 
   return {
     width,
@@ -45,10 +50,10 @@ export function buildFullParams(
     fractionalEdgeX: synced ? fractionalEdgeX : (stored.fractionalEdgeX ?? 'end'),
     fractionalEdgeY: synced ? fractionalEdgeY : (stored.fractionalEdgeY ?? 'end'),
     overTile: stored.overTile,
-    connectorNubs: stackingOn ? false : stored.connectorNubs,
+    connectorNubs: stripConnectors ? false : stored.connectorNubs,
     invertDovetails: stored.invertDovetails,
     preferIdenticalPieces: stored.preferIdenticalPieces,
-    connectorStyle: stackingOn ? undefined : stored.connectorStyle,
+    connectorStyle: stripConnectors ? undefined : stored.connectorStyle,
     connectorFitOffset: stored.connectorFitOffset,
     lightweight: stored.lightweight,
     // Corner rounding only applies to the assembled drawer's outer corners, so

--- a/src/features/baseplate/utils/stackGrouping.test.ts
+++ b/src/features/baseplate/utils/stackGrouping.test.ts
@@ -35,6 +35,29 @@ describe('stack-print grouping', () => {
     expect(groups.length).toBeGreaterThan(1);
   });
 
+  it('retains dovetail connectors while stacking; preferIdenticalPieces shrinks the group count', () => {
+    const connectored: CoreBaseplateParams = {
+      ...DEFAULT_BASEPLATE_PARAMS,
+      connectorNubs: true, // dovetail (default style) — kept while stacking now
+      stackPrint: { enabled: true, gapMm: 0.2 as never },
+    };
+    // Connectors are no longer stripped, so edge position distinguishes
+    // interior/edge/corner tiles → more than one group (unlike the connector-free
+    // stack above, which dedupes to one).
+    const plain = plan(connectored, 16, 180);
+    expect(plain.groups.length).toBeGreaterThan(1);
+
+    // preferIdenticalPieces folds opposite-corner tiles together → fewer groups,
+    // recovering most of the dedup the bare stack would have had.
+    const paired = plan({ ...connectored, preferIdenticalPieces: true }, 16, 180);
+    expect(paired.groups.length).toBeLessThan(plain.groups.length);
+
+    // Every tile is still printed exactly once regardless of grouping.
+    const total = paired.groups.reduce((s, g) => s + g.quantity, 0);
+    expect(total).toBe(paired.tiling.pieces.length);
+    expect(paired.towers.reduce((s, t) => s + t.copies, 0)).toBe(total);
+  });
+
   it('leaves genuinely-unique pieces unmerged (14×14 @ 180mm has uneven tiles)', () => {
     // 14 = 4+4+3+3 → tiles of different sizes, so they can't all stack.
     const { groups, towers } = plan(stacking, 14, 180);

--- a/src/features/baseplate/utils/stackPrint.test.ts
+++ b/src/features/baseplate/utils/stackPrint.test.ts
@@ -212,4 +212,29 @@ describe('buildTowerLayers', () => {
     expect(buildTowerLayers(plate(), 0, 10.2)).toHaveLength(1);
     expect(buildTowerLayers(plate(), 3.9, 10.2)).toHaveLength(3);
   });
+
+  it('preserves an asymmetric connector protrusion through the flip', () => {
+    // A plate whose +Y edge carries a dovetail tongue protruding to Y=33 — an
+    // asymmetric footprint, the case that matters for stacked connectored tiles.
+    // The flip must keep the protrusion (not clip it) but mirror it to the -Y
+    // end so every layer still shares one bounding footprint.
+    const base: StackMeshArrays = {
+      // floor triangle (Y 0..30) + tongue tip triangle protruding to Y=33.
+      vertices: new Float32Array([0, 0, 0, 20, 0, 0, 0, 30, 0, 8, 33, 5, 12, 33, 5, 10, 30, 5]),
+      normals: new Float32Array([0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      indices: new Uint32Array([0, 1, 2, 3, 4, 5]),
+      edgeVertices: new Float32Array(0),
+    };
+    const layers = buildTowerLayers(base, 2, 10);
+    const upright = meshBounds(layers[0].vertices);
+    const flipped = meshBounds(layers[1].vertices);
+    // Footprint span survives the flip: Y still reaches the protrusion at 33.
+    expect(flipped.minY).toBeCloseTo(upright.minY, 5);
+    expect(flipped.maxY).toBeCloseTo(upright.maxY, 5);
+    expect(upright.maxY).toBeCloseTo(33, 5);
+    // Vertex 3 is a tongue tip: at +Y (33) when upright, mirrored to the -Y edge
+    // (0) after the flip — asymmetry is re-centered, not lost.
+    expect(layers[0].vertices[10]).toBeCloseTo(33, 5);
+    expect(layers[1].vertices[10]).toBeCloseTo(0, 5);
+  });
 });

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -34,6 +34,7 @@
   "baseplate.computingGeometry": "Verfeinere...",
   "baseplate.connectors.label": "Connectors",
   "baseplate.connectors.none": "None",
+  "baseplate.connectors.snapClipNoStack": "Nicht vertikal stapelbar",
   "baseplate.connectorStyle.dovetail": "Dovetail",
   "baseplate.connectorStyle.dovetailKey": "Dovetail key",
   "baseplate.connectorStyle.snapClip": "Snap clip",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2200,6 +2200,7 @@ const en: Record<string, string> = {
   'baseplate.isoView': 'Iso',
   'baseplate.connectors.label': 'Connectors',
   'baseplate.connectors.none': 'None',
+  'baseplate.connectors.snapClipNoStack': "Can't be vertically stacked",
   'baseplate.connectorStyle.dovetail': 'Dovetail',
   'baseplate.connectorStyle.dovetailKey': 'Dovetail key',
   'baseplate.connectorStyle.snapClip': 'Snap clip',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -34,6 +34,7 @@
   "baseplate.computingGeometry": "Refinando...",
   "baseplate.connectors.label": "Connectors",
   "baseplate.connectors.none": "None",
+  "baseplate.connectors.snapClipNoStack": "No se puede apilar verticalmente",
   "baseplate.connectorStyle.dovetail": "Dovetail",
   "baseplate.connectorStyle.dovetailKey": "Dovetail key",
   "baseplate.connectorStyle.snapClip": "Snap clip",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -34,6 +34,7 @@
   "baseplate.computingGeometry": "Affinage...",
   "baseplate.connectors.label": "Connectors",
   "baseplate.connectors.none": "None",
+  "baseplate.connectors.snapClipNoStack": "Empilage vertical impossible",
   "baseplate.connectorStyle.dovetail": "Dovetail",
   "baseplate.connectorStyle.dovetailKey": "Dovetail key",
   "baseplate.connectorStyle.snapClip": "Snap clip",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -34,6 +34,7 @@
   "baseplate.computingGeometry": "最適化中…",
   "baseplate.connectors.label": "Connectors",
   "baseplate.connectors.none": "None",
+  "baseplate.connectors.snapClipNoStack": "縦積みできません",
   "baseplate.connectorStyle.dovetail": "Dovetail",
   "baseplate.connectorStyle.dovetailKey": "Dovetail key",
   "baseplate.connectorStyle.snapClip": "Snap clip",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -34,6 +34,7 @@
   "baseplate.computingGeometry": "Forfiner...",
   "baseplate.connectors.label": "Connectors",
   "baseplate.connectors.none": "None",
+  "baseplate.connectors.snapClipNoStack": "Kan ikke stables vertikalt",
   "baseplate.connectorStyle.dovetail": "Dovetail",
   "baseplate.connectorStyle.dovetailKey": "Dovetail key",
   "baseplate.connectorStyle.snapClip": "Snap clip",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -34,6 +34,7 @@
   "baseplate.computingGeometry": "Verfijnen...",
   "baseplate.connectors.label": "Connectors",
   "baseplate.connectors.none": "None",
+  "baseplate.connectors.snapClipNoStack": "Kan niet verticaal worden gestapeld",
   "baseplate.connectorStyle.dovetail": "Dovetail",
   "baseplate.connectorStyle.dovetailKey": "Dovetail key",
   "baseplate.connectorStyle.snapClip": "Snap clip",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -34,6 +34,7 @@
   "baseplate.computingGeometry": "Refinando...",
   "baseplate.connectors.label": "Connectors",
   "baseplate.connectors.none": "None",
+  "baseplate.connectors.snapClipNoStack": "Não pode ser empilhado verticalmente",
   "baseplate.connectorStyle.dovetail": "Dovetail",
   "baseplate.connectorStyle.dovetailKey": "Dovetail key",
   "baseplate.connectorStyle.snapClip": "Snap clip",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -34,6 +34,7 @@
   "baseplate.computingGeometry": "Förfinar...",
   "baseplate.connectors.label": "Connectors",
   "baseplate.connectors.none": "None",
+  "baseplate.connectors.snapClipNoStack": "Kan inte staplas vertikalt",
   "baseplate.connectorStyle.dovetail": "Dovetail",
   "baseplate.connectorStyle.dovetailKey": "Dovetail key",
   "baseplate.connectorStyle.snapClip": "Snap clip",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -34,6 +34,7 @@
   "baseplate.computingGeometry": "Уточнення...",
   "baseplate.connectors.label": "Connectors",
   "baseplate.connectors.none": "None",
+  "baseplate.connectors.snapClipNoStack": "Не можна штабелювати вертикально",
   "baseplate.connectorStyle.dovetail": "Dovetail",
   "baseplate.connectorStyle.dovetailKey": "Dovetail key",
   "baseplate.connectorStyle.snapClip": "Snap clip",


### PR DESCRIPTION
## What

Vertical stack-printing of baseplates used to strip **all** connectors. That was over-cautious: only `snapClip` is geometrically incompatible with the print flip — its blind top pocket (sealed floor + undercut ledge) inverts into a downward bridge/overhang. Both dovetail styles are full-height **vertical prisms** (`makeTongue`/`makeGroove`/`buildDovetailKey` extrude a flat XY profile straight down), so they flip cleanly with zero overhang.

This lets `dovetail` and `dovetailKey` connectors stay on while stacking, so a stacked drawer still assembles into a connected baseplate.

## How

- **`buildFullParams`**: narrow the connector strip to `snapClip` only. Magnets (downward bridges when flipped) and corner rounding (tile uniformity) stay stripped — unchanged.
- **`ConnectorPicker`**: new `disabledOptions` prop greys out + skips snap clip in keyboard nav while stacking, with the reason *"Can't be vertically stacked."*
- **`BaseplatePanel`**: connector picker is now reachable while stacking; magnets + corner radius stay hidden. When the stored style is `snapClip` + stacking, the picker shows **None** (the effective state), and the stored choice returns when stacking is toggled off.
- **Export/preview**: no logic change. The `dovetailKey` key already exports flat alongside towers via `countConnectorKeys` (fixed a stale comment), and the preview already swaps in `StackedBaseplateMeshes` (which carries the baked tongue/groove geometry) instead of seated keys while stacking.
- **Dedup**: leans on the existing `preferIdenticalPieces` 180° canonicalization — connectored tilings produce more (shorter) towers, recovered by opposite-corner pairing.

## Geometry rationale

A 180° flip about X is a rigid transform of an already-watertight per-piece mesh, so per-tile validity (covered by `scenario.dovetail` / `scenario.dovetailKey`) carries over to the towers. The tongue is a vertical prism, not a cantilever — it survives the flip; the only asymmetry is the protrusion mirroring to the opposite edge, which `buildTowerLayers` re-centers.

## Tests

- `buildFullParams`: dovetail/dovetailKey retained under stacking, snapClip stripped, magnets stripped in all, stored never mutated
- `stackPrint`: asymmetric protrusion survives the flip + re-centers
- `stackGrouping`: connectored stacking stays multi-group; `preferIdenticalPieces` shrinks the group count
- `ConnectorPicker`: disabled option renders reason, is `aria-disabled`, click + keyboard skip it
- `BaseplatePanel`: while stacking — picker reachable, snap clip disabled, magnets/corner hidden, snapClip shows as None

Full suite: 13747 passed, 0 failed. Typecheck + all 4 i18n checks green.

## i18n

New key `baseplate.connectors.snapClipNoStack`, translated across all 10 locales.
