### PR TITLE
perf(bin-designer): defer compartment text commit to idle/blur

### DIFF
--- a/src/features/bin-designer/components/panel/LabelTabsSection/CompartmentTextInput.test.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/CompartmentTextInput.test.tsx
@@ -13,11 +13,14 @@ describe('CompartmentTextInput', () => {
     vi.useRealTimers();
   });
 
+  const COMPARTMENT_ID = 2;
+
   function setup(committedValue = '') {
     const onCommit = vi.fn();
     const utils = render(
       <CompartmentTextInput
         committedValue={committedValue}
+        compartmentId={COMPARTMENT_ID}
         placeholder="text"
         ariaLabel="Engraved text"
         onCommit={onCommit}
@@ -38,9 +41,9 @@ describe('CompartmentTextInput', () => {
     expect(input).toHaveValue('SCR');
 
     vi.advanceTimersByTime(COMMIT_IDLE_MS);
-    // One commit for the whole burst, with the final value.
+    // One commit for the whole burst, with the final value + compartment id.
     expect(onCommit).toHaveBeenCalledTimes(1);
-    expect(onCommit).toHaveBeenCalledWith('SCR');
+    expect(onCommit).toHaveBeenCalledWith(COMPARTMENT_ID, 'SCR');
   });
 
   it('commits immediately on blur and cancels the pending idle timer', () => {
@@ -48,7 +51,7 @@ describe('CompartmentTextInput', () => {
     fireEvent.change(input, { target: { value: 'BOLTS' } });
     fireEvent.blur(input);
     expect(onCommit).toHaveBeenCalledTimes(1);
-    expect(onCommit).toHaveBeenCalledWith('BOLTS');
+    expect(onCommit).toHaveBeenCalledWith(COMPARTMENT_ID, 'BOLTS');
     // The idle timer that was pending must not fire a second commit.
     vi.advanceTimersByTime(COMMIT_IDLE_MS);
     expect(onCommit).toHaveBeenCalledTimes(1);
@@ -61,6 +64,7 @@ describe('CompartmentTextInput', () => {
     rerender(
       <CompartmentTextInput
         committedValue="NEW"
+        compartmentId={COMPARTMENT_ID}
         placeholder="text"
         ariaLabel="Engraved text"
         onCommit={onCommit}
@@ -77,6 +81,7 @@ describe('CompartmentTextInput', () => {
     rerender(
       <CompartmentTextInput
         committedValue="EXTERNAL"
+        compartmentId={COMPARTMENT_ID}
         placeholder="text"
         ariaLabel="Engraved text"
         onCommit={onCommit}

--- a/src/features/bin-designer/components/panel/LabelTabsSection/CompartmentTextInput.test.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/CompartmentTextInput.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { CompartmentTextInput } from './CompartmentTextInput';
+
+const COMMIT_IDLE_MS = 450;
+
+describe('CompartmentTextInput', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  function setup(committedValue = '') {
+    const onCommit = vi.fn();
+    const utils = render(
+      <CompartmentTextInput
+        committedValue={committedValue}
+        placeholder="text"
+        ariaLabel="Engraved text"
+        onCommit={onCommit}
+      />
+    );
+    const input = screen.getByLabelText('Engraved text');
+    return { ...utils, input, onCommit };
+  }
+
+  it('does not commit while typing — only after the idle delay', () => {
+    const { input, onCommit } = setup();
+    fireEvent.change(input, { target: { value: 'S' } });
+    fireEvent.change(input, { target: { value: 'SC' } });
+    fireEvent.change(input, { target: { value: 'SCR' } });
+    // Mid-word keystrokes must not have committed.
+    expect(onCommit).not.toHaveBeenCalled();
+    // The displayed value tracks the draft immediately, though.
+    expect(input).toHaveValue('SCR');
+
+    vi.advanceTimersByTime(COMMIT_IDLE_MS);
+    // One commit for the whole burst, with the final value.
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith('SCR');
+  });
+
+  it('commits immediately on blur and cancels the pending idle timer', () => {
+    const { input, onCommit } = setup();
+    fireEvent.change(input, { target: { value: 'BOLTS' } });
+    fireEvent.blur(input);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith('BOLTS');
+    // The idle timer that was pending must not fire a second commit.
+    vi.advanceTimersByTime(COMMIT_IDLE_MS);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-syncs the draft when the committed value changes externally (while blurred)', () => {
+    const { input, rerender, onCommit } = setup('OLD');
+    expect(input).toHaveValue('OLD');
+    // Simulate undo/redo/load updating the committed value from outside.
+    rerender(
+      <CompartmentTextInput
+        committedValue="NEW"
+        placeholder="text"
+        ariaLabel="Engraved text"
+        onCommit={onCommit}
+      />
+    );
+    expect(input).toHaveValue('NEW');
+  });
+
+  it('does not clobber an in-progress draft when focused', () => {
+    const { input, rerender, onCommit } = setup('OLD');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'TYPING' } });
+    // An external committed-value change arrives mid-typing (focus guard).
+    rerender(
+      <CompartmentTextInput
+        committedValue="EXTERNAL"
+        placeholder="text"
+        ariaLabel="Engraved text"
+        onCommit={onCommit}
+      />
+    );
+    // The user's in-progress draft survives.
+    expect(input).toHaveValue('TYPING');
+  });
+});

--- a/src/features/bin-designer/components/panel/LabelTabsSection/CompartmentTextInput.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/CompartmentTextInput.tsx
@@ -24,14 +24,20 @@ const COMMIT_IDLE_MS = 450;
 interface CompartmentTextInputProps {
   /** The committed store value; the source of truth between edits. */
   readonly committedValue: string;
+  /** Compartment id passed straight back to `onCommit`. Kept a separate prop
+   *  (rather than baked into an `onCommit` closure by the parent) so the parent
+   *  can pass the store action by reference and this component's handlers stay
+   *  referentially stable across parent re-renders. */
+  readonly compartmentId: number;
   readonly placeholder: string;
   readonly ariaLabel: string;
   /** Writes the value to the store (clamps + dedups + pushes history). */
-  readonly onCommit: (value: string) => void;
+  readonly onCommit: (compartmentId: number, value: string) => void;
 }
 
 export function CompartmentTextInput({
   committedValue,
+  compartmentId,
   placeholder,
   ariaLabel,
   onCommit,
@@ -39,6 +45,13 @@ export function CompartmentTextInput({
   const [draft, setDraft] = useState(committedValue);
   const focusedRef = useRef(false);
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Stable as long as the store action and id are stable, so `onBlur`/`onChange`
+  // identities don't churn on every parent render.
+  const commit = useCallback(
+    (value: string) => onCommit(compartmentId, value),
+    [onCommit, compartmentId]
+  );
 
   const clearIdleTimer = useCallback(() => {
     if (idleTimerRef.current !== null) {
@@ -66,10 +79,10 @@ export function CompartmentTextInput({
       clearIdleTimer();
       idleTimerRef.current = setTimeout(() => {
         idleTimerRef.current = null;
-        onCommit(next);
+        commit(next);
       }, COMMIT_IDLE_MS);
     },
-    [clearIdleTimer, onCommit]
+    [clearIdleTimer, commit]
   );
 
   const handleFocus = useCallback(() => {
@@ -79,8 +92,8 @@ export function CompartmentTextInput({
   const handleBlur = useCallback(() => {
     focusedRef.current = false;
     clearIdleTimer();
-    onCommit(draft);
-  }, [clearIdleTimer, draft, onCommit]);
+    commit(draft);
+  }, [clearIdleTimer, draft, commit]);
 
   return (
     <Input

--- a/src/features/bin-designer/components/panel/LabelTabsSection/CompartmentTextInput.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/CompartmentTextInput.tsx
@@ -1,0 +1,98 @@
+/**
+ * Per-compartment engraved-text input with deferred commit.
+ *
+ * Typing updates only this input's local `draft` state — it does NOT touch the
+ * store, so it never bumps `generation.epoch` or triggers a 3D regeneration.
+ * The value commits (via `onCommit`, which writes `compartmentTexts` and pushes
+ * one history entry) only when the user pauses for `COMMIT_IDLE_MS` or blurs.
+ *
+ * Without this, every keystroke regenerated the bin — and because the label-tab
+ * cache key serializes the whole text array, each regen rebuilt *every* label's
+ * engraved geometry. Deferring the commit collapses a whole word's worth of
+ * regenerations into one.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Input } from '@/design-system';
+import { TEXT_MAX_LENGTH } from '../../../types';
+
+/** Idle gap after the last keystroke before an edit commits (and regenerates).
+ *  Long enough to skip intra-word keystrokes, short enough to feel responsive
+ *  on pause. Blur commits immediately regardless. */
+const COMMIT_IDLE_MS = 450;
+
+interface CompartmentTextInputProps {
+  /** The committed store value; the source of truth between edits. */
+  readonly committedValue: string;
+  readonly placeholder: string;
+  readonly ariaLabel: string;
+  /** Writes the value to the store (clamps + dedups + pushes history). */
+  readonly onCommit: (value: string) => void;
+}
+
+export function CompartmentTextInput({
+  committedValue,
+  placeholder,
+  ariaLabel,
+  onCommit,
+}: CompartmentTextInputProps) {
+  const [draft, setDraft] = useState(committedValue);
+  const focusedRef = useRef(false);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearIdleTimer = useCallback(() => {
+    if (idleTimerRef.current !== null) {
+      clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = null;
+    }
+  }, []);
+
+  // Re-sync the draft when the committed value changes from OUTSIDE this input
+  // (undo/redo, auto-fix, loading a design). Guarded on focus so an external
+  // change can't clobber what the user is actively typing.
+  useEffect(() => {
+    if (!focusedRef.current) setDraft(committedValue);
+  }, [committedValue]);
+
+  // Clear any pending idle timer on unmount. Deliberately does NOT commit — blur
+  // fires before unmount in normal flows, and committing here would regenerate
+  // geometry when the user merely collapses the section or navigates away.
+  useEffect(() => clearIdleTimer, [clearIdleTimer]);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const next = e.target.value;
+      setDraft(next);
+      clearIdleTimer();
+      idleTimerRef.current = setTimeout(() => {
+        idleTimerRef.current = null;
+        onCommit(next);
+      }, COMMIT_IDLE_MS);
+    },
+    [clearIdleTimer, onCommit]
+  );
+
+  const handleFocus = useCallback(() => {
+    focusedRef.current = true;
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    focusedRef.current = false;
+    clearIdleTimer();
+    onCommit(draft);
+  }, [clearIdleTimer, draft, onCommit]);
+
+  return (
+    <Input
+      type="text"
+      size="sm"
+      value={draft}
+      maxLength={TEXT_MAX_LENGTH}
+      onChange={handleChange}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      placeholder={placeholder}
+      aria-label={ariaLabel}
+    />
+  );
+}

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.test.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.test.tsx
@@ -28,10 +28,14 @@ describe('LabelTabsSection', () => {
     expect(screen.getByLabelText('Engraved text for compartment 2')).toBeInTheDocument();
   });
 
-  it('writes typed text to the store via setCompartmentText', () => {
+  it('commits typed text to the store on blur (deferred commit)', () => {
     render(<LabelTabsSection />);
     const input = screen.getByLabelText('Engraved text for compartment 1');
+    // Typing alone must NOT commit — that would regenerate the bin per keystroke.
     fireEvent.change(input, { target: { value: 'SCREWS' } });
+    expect(useDesignerStore.getState().params.compartments.compartmentTexts).toBeUndefined();
+    // Blur flushes the pending value to the store.
+    fireEvent.blur(input);
     expect(useDesignerStore.getState().params.compartments.compartmentTexts).toEqual(['SCREWS']);
   });
 

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
@@ -7,11 +7,10 @@
 
 import { FeatureToggle } from '../FeatureToggle';
 import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
-import { Button, Input, Select, Stepper, InfoIcon } from '@/design-system';
+import { Button, Select, Stepper, InfoIcon } from '@/design-system';
 import type { SelectOption } from '@/design-system';
 import { RulerIcon } from '@/design-system/Icon';
 import { DESIGNER_CONSTRAINTS } from '../../../constants';
-import { TEXT_MAX_LENGTH } from '../../../types';
 import type {
   LabelTabAlignment,
   LabelTabEdges,
@@ -19,6 +18,7 @@ import type {
   TextFontFamily,
   TextMode,
 } from '../../../types';
+import { CompartmentTextInput } from './CompartmentTextInput';
 import { useLabelTabsSection } from './useLabelTabsSection';
 
 const ALIGNMENT_OPTIONS: LabelTabAlignment[] = ['left', 'center', 'right'];
@@ -360,21 +360,20 @@ export function LabelTabsSection() {
           </div>
         </div>
 
-        {/* Per-compartment text inputs */}
+        {/* Per-compartment text inputs. Each input defers its commit (see
+            CompartmentTextInput) so typing doesn't regenerate the bin per
+            keystroke. */}
         <ul className="flex flex-col gap-1.5">
           {state.compartmentTextRows.map((row) => (
             <li key={row.id} className="flex items-center gap-2">
               <span className="w-20 shrink-0 text-xs text-content-tertiary tabular-nums">
                 {row.label}
               </span>
-              <Input
-                type="text"
-                size="sm"
-                value={row.value}
-                maxLength={TEXT_MAX_LENGTH}
-                onChange={(e) => handlers.setCompartmentText(row.id, e.target.value)}
+              <CompartmentTextInput
+                committedValue={row.value}
+                onCommit={(value) => handlers.setCompartmentText(row.id, value)}
                 placeholder={t('binDesigner.tabEngravedTextPlaceholder')}
-                aria-label={t('binDesigner.tabEngravedTextAriaLabel', { n: row.displayNumber })}
+                ariaLabel={t('binDesigner.tabEngravedTextAriaLabel', { n: row.displayNumber })}
               />
             </li>
           ))}

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
@@ -371,7 +371,8 @@ export function LabelTabsSection() {
               </span>
               <CompartmentTextInput
                 committedValue={row.value}
-                onCommit={(value) => handlers.setCompartmentText(row.id, value)}
+                compartmentId={row.id}
+                onCommit={handlers.setCompartmentText}
                 placeholder={t('binDesigner.tabEngravedTextPlaceholder')}
                 ariaLabel={t('binDesigner.tabEngravedTextAriaLabel', { n: row.displayNumber })}
               />

--- a/src/features/bin-designer/store/slices/paramSlice.ts
+++ b/src/features/bin-designer/store/slices/paramSlice.ts
@@ -390,8 +390,9 @@ export function createParamSlice(set: Set, get: Get) {
       const { params } = get();
       const clamped = text.slice(0, TEXT_MAX_LENGTH);
       const prev = params.compartments.compartmentTexts ?? [];
-      // No-op guard: the UI calls this on every keystroke, so an unchanged
-      // value must not push a history entry (would be one undo step per char).
+      // No-op guard: the input commits on both idle and blur (see
+      // CompartmentTextInput), so an idle-flushed value followed by a blur must
+      // not push a second, identical history entry / regeneration.
       if ((prev[compartmentId] ?? '') === clamped) return;
 
       set((state) => {


### PR DESCRIPTION
## Problem

Adding/editing text labels in the bin designer made generation feel very slow. One of three stacked causes (this PR fixes the **frequency** one):

Typing in a label-tab text input committed to the store on **every keystroke**, bumping \`generation.epoch\` and regenerating the whole bin per character. Because the \`labelTabs\` cache key serializes the entire \`compartmentTexts\` array, each regen also rebuilt every label's engraved geometry.

## Fix

Move the input into a \`CompartmentTextInput\` child that holds the value in local **draft** state and commits (via the existing \`setCompartmentText\`) only after a **450ms idle pause or on blur**. A focus-guarded \`useEffect\` re-syncs the draft with external changes (undo/redo/load).

- No store changes — the existing no-op guard in \`setCompartmentText\` makes idle-then-blur a free no-op.
- Undo granularity becomes per-commit (per-word-ish) instead of per-char — strictly better than before.
- Tradeoff (intended): the 3D preview updates ~450ms after a pause / on blur, not mid-word.

## Tests

- New \`CompartmentTextInput.test.tsx\` (fake timers): no commit while typing, commit after idle, immediate commit on blur (cancels pending idle), external re-sync while blurred, focus-guard protects an in-progress draft.
- Updated \`LabelTabsSection.test.tsx\` for the deferred-commit behavior.
- `pnpm exec eslint` clean.

## Related

Part of a 3-PR set addressing slow text-label generation (frequency / per-text compute / per-compartment caching). This PR is fully independent of the other two.