### PR TITLE
perf(generation): linear font fit + memoized text metrics

### DIFF
--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -42,6 +42,7 @@ graph TB
 - `worker/generators/insertBuilder.ts` — insert cavity cuts
 - `worker/generators/cutoutBuilder.ts` — solid-mode cutout cuts
 - `worker/generators/labelTabBuilder.ts` — label tab shelves + gussets
+- `worker/generators/textBuilder.ts` — engraved/embossed/through-cut text solids; auto-fits font size to the host (see Gotchas re: linear sizing) and resolves the stencil-font swap for through-cut
 - `worker/generators/scoopRampBuilder.ts` — scoop ramp geometry
 - `worker/generators/wallCutoutBuilder.ts` — wall U-notch cutouts
 - `worker/generators/handleBuilder.ts` — handle hole through-cuts in bin walls
@@ -123,6 +124,7 @@ Add new patterns by implementing `PatternCalculator` interface and registering i
 3. **Features fail silently** — tiny cells → feature skipped
 4. **WASM objects are ephemeral** — brepjs GC invalidates refs unpredictably
 5. **Wall pattern border rule** — any feature that cuts through a wall (cutouts, handles, future features) MUST have corresponding border clipping in `wallPatternBuilder.ts`. Without it, hex prisms overlap the cut region, producing jagged edges. Use `CUTOUT_BORDER_WIDTH` (1.5mm) for the expansion. See `wallPatternBuilder.ts` for the cutout and handle clipping implementations as reference.
+6. **Text auto-fit assumes linear metrics** — `textBuilder.ts` `fitFontSize` computes the font size from a single reference measurement because `textMetrics` scales _exactly_ linearly with `fontSize` in the pinned brepjs build (advance width + vertical metrics scale by `fontSize / unitsPerEm`; no hinting in this path). A `fitFontSizeBisect` fallback covers any non-linearity, but **re-verify this assumption on brepjs bumps** — if a future build introduces hinting, the one-shot estimate could mis-size before the fallback catches it.
 
 ## Adaptive Debounce
 

--- a/src/features/generation/worker/generators/shapeCache.ts
+++ b/src/features/generation/worker/generators/shapeCache.ts
@@ -23,6 +23,7 @@ import { LRUCache } from './lruCache';
 import { buildCacheKey, quantize, compactKey } from './cacheKeyUtils';
 import { GRIDFINITY } from '@/shared/constants/bin';
 import { clearSocketMeshCache } from './socketMeshCache';
+import { clearTextMetricsMemo } from './textBuilder';
 
 /** Dispose callback for LRU caches holding WASM-backed shapes. */
 const disposeShape = (_key: string, shape: Shape3D): void => {
@@ -224,6 +225,7 @@ export function clearAllCaches(): void {
     cache.dispose();
   }
   clearSocketMeshCache();
+  clearTextMetricsMemo();
   if (patternTemplateCache) {
     patternTemplateCache.shape.delete();
     patternTemplateCache = null;

--- a/src/features/generation/worker/generators/textBuilder.test.ts
+++ b/src/features/generation/worker/generators/textBuilder.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { fitFontSize, resolveEffectiveFont } from './textBuilder';
-import { loadFont } from 'brepjs';
-import { isErr } from '@/core/result';
+import { fitFontSize, resolveEffectiveFont, clearTextMetricsMemo } from './textBuilder';
+import { loadFont, textMetrics } from 'brepjs';
+import { isErr, isOk } from '@/core/result';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
@@ -62,6 +62,35 @@ describe('fitFontSize', () => {
     // @ts-expect-error — testing runtime guard with an unsupported family
     const fit = fitFontSize('A', 'comic-sans', 100, 100, 3, 20);
     expect(fit.fits).toBe(false);
+  });
+
+  it('chooses a near-maximal size: the rendered bbox fits and is bound by an axis', () => {
+    // The linear solver should land on the largest size that still fits, so the
+    // rendered bbox stays within budget and (when not clamped) touches a bound.
+    const availW = 30;
+    const availD = 10;
+    const fit = fitFontSize('SCREWS', 'atkinson', availW, availD, 3, 20);
+    expect(fit.fits).toBe(true);
+    const m = textMetrics('SCREWS', { fontSize: fit.fontSize, fontFamily: 'atkinson' });
+    expect(isOk(m)).toBe(true);
+    if (isOk(m)) {
+      expect(m.value.width).toBeLessThanOrEqual(availW + 1e-6);
+      expect(m.value.height).toBeLessThanOrEqual(availD + 1e-6);
+      // Not clamped to either bound → the limiting axis must sit right at budget.
+      if (fit.fontSize > 3 && fit.fontSize < 20) {
+        const touchesW = Math.abs(m.value.width - availW) < 0.05;
+        const touchesH = Math.abs(m.value.height - availD) < 0.05;
+        expect(touchesW || touchesH).toBe(true);
+      }
+    }
+  });
+
+  it('is deterministic and unaffected by clearing the metrics memo', () => {
+    const before = fitFontSize('BOLTS', 'atkinson', 30, 10, 3, 20);
+    clearTextMetricsMemo();
+    const after = fitFontSize('BOLTS', 'atkinson', 30, 10, 3, 20);
+    expect(after.fits).toBe(before.fits);
+    expect(after.fontSize).toBeCloseTo(before.fontSize, 6);
   });
 });
 

--- a/src/features/generation/worker/generators/textBuilder.ts
+++ b/src/features/generation/worker/generators/textBuilder.ts
@@ -36,10 +36,57 @@ export interface FitResult {
   readonly fits: boolean;
 }
 
+/** Reference size for the single linear measurement in `fitFontSize`. 1mm keeps
+ *  the per-unit-size width/height directly readable from the bbox. */
+const FIT_REFERENCE_SIZE = 1;
+/** Slack on the fit verification so float drift can't reject an exact fit. */
+const FIT_EPSILON = 1e-6;
+
+type Metrics = ReturnType<typeof textMetrics>;
+
+/** Memoize `textMetrics` — it's pure given (text, fontSize, fontFamily) and is
+ *  the dominant cost of auto-fit. Keyed on the exact size so a cache hit always
+ *  returns metrics for the size requested (the auto-fit verify and
+ *  `buildTextSolid`'s follow-up measurement use the same size, and uniform tabs
+ *  produce identical sizes for the same text). Bounded so a long session can't
+ *  grow it without limit. MUST be cleared when fonts (re)load or the kernel
+ *  switches — see `clearTextMetricsMemo`, wired into `clearAllCaches`. */
+const metricsMemo = new Map<string, Metrics>();
+const METRICS_MEMO_MAX = 512;
+
+function measureText(text: string, fontSize: number, fontFamily: TextFontFamily): Metrics {
+  const key = `${fontFamily}|${fontSize}|${text}`;
+  const cached = metricsMemo.get(key);
+  if (cached) return cached;
+  const result = textMetrics(text, { fontSize, fontFamily });
+  // Simple bounded eviction: drop the oldest entry once at capacity. Insertion
+  // order is preserved by Map, so the first key is the oldest.
+  if (metricsMemo.size >= METRICS_MEMO_MAX) {
+    const oldest = metricsMemo.keys().next().value;
+    if (oldest !== undefined) metricsMemo.delete(oldest);
+  }
+  metricsMemo.set(key, result);
+  return result;
+}
+
+/** Drop all memoized text metrics. Call when the font registry changes (font
+ *  (re)load, kernel switch) — `textMetrics` results depend on the loaded font. */
+export function clearTextMetricsMemo(): void {
+  metricsMemo.clear();
+}
+
 /**
  * Pick the largest font size whose rendered bbox fits the given width/depth
  * budget, clamped to [min, max]. Returns `{ fits: false }` if even `min`
  * overflows.
+ *
+ * `textMetrics` scales EXACTLY linearly with fontSize for the pinned brepjs
+ * build (width = glyph advance width, vertical metrics scale by
+ * `fontSize / unitsPerEm`; no hinting in this code path), so one measurement at
+ * a reference size yields the ideal size directly — no search needed. A single
+ * verify call covers the clamp-to-min overflow case and guards against any
+ * future non-linearity; if metrics ever stop being measurable we fall back to
+ * the robust binary search. Re-verify the linearity assumption on brepjs bumps.
  */
 export function fitFontSize(
   text: string,
@@ -52,20 +99,50 @@ export function fitFontSize(
   if (!text || availW <= 0 || availD <= 0 || min <= 0 || max < min) {
     return { fontSize: 0, fits: false };
   }
-  const minMetrics = textMetrics(text, { fontSize: min, fontFamily });
+  const ref = measureText(text, FIT_REFERENCE_SIZE, fontFamily);
+  if (!isOk(ref) || ref.value.width <= 0 || ref.value.height <= 0) {
+    // Degenerate measurement (missing glyphs, all-whitespace) — avoid dividing
+    // by zero and defer to the search, which has its own min-overflow guard.
+    return fitFontSizeBisect(text, fontFamily, availW, availD, min, max);
+  }
+  // width(s) = ref.width · s / FIT_REFERENCE_SIZE → solve each axis for its
+  // limiting size, take the smaller, then clamp to [min, max].
+  const sizeForW = (availW * FIT_REFERENCE_SIZE) / ref.value.width;
+  const sizeForH = (availD * FIT_REFERENCE_SIZE) / ref.value.height;
+  const size = Math.min(max, Math.max(min, Math.min(sizeForW, sizeForH)));
+
+  const check = measureText(text, size, fontFamily);
+  if (!isOk(check)) {
+    return fitFontSizeBisect(text, fontFamily, availW, availD, min, max);
+  }
+  const fits =
+    check.value.width <= availW + FIT_EPSILON && check.value.height <= availD + FIT_EPSILON;
+  return fits ? { fontSize: size, fits: true } : { fontSize: 0, fits: false };
+}
+
+/**
+ * Robust fallback: binary search to ~0.05mm precision. Only reached when a
+ * measurement isn't `isOk` (a font edge case) — kept so the builder degrades
+ * gracefully rather than producing geometry from an unverified size.
+ */
+function fitFontSizeBisect(
+  text: string,
+  fontFamily: TextFontFamily,
+  availW: number,
+  availD: number,
+  min: number,
+  max: number
+): FitResult {
+  const minMetrics = measureText(text, min, fontFamily);
   if (!isOk(minMetrics) || minMetrics.value.width > availW || minMetrics.value.height > availD) {
     return { fontSize: 0, fits: false };
   }
-  // Binary search to ~0.05mm precision. textMetrics scales linearly with
-  // fontSize so a ratio-based shortcut is possible, but the bounded loop
-  // (14 iterations) stays correct if metrics ever become non-linear
-  // (e.g. hinting changes between sizes).
   let lo = min;
   let hi = max;
   let best = min;
   for (let i = 0; i < 14; i++) {
     const mid = (lo + hi) / 2;
-    const m = textMetrics(text, { fontSize: mid, fontFamily });
+    const m = measureText(text, mid, fontFamily);
     if (!isOk(m)) break;
     if (m.value.width <= availW && m.value.height <= availD) {
       best = mid;
@@ -163,7 +240,8 @@ export function buildTextSolid(
   );
   if (!fit.fits) return null;
 
-  const metrics = textMetrics(trimmed, { fontSize: fit.fontSize, fontFamily });
+  // Reuses the memo entry from `fitFontSize`'s verify call at this exact size.
+  const metrics = measureText(trimmed, fit.fontSize, fontFamily);
   if (!isOk(metrics)) return null;
 
   // All three modes need the EPSILON lift to avoid coplanar boolean fragility:

--- a/src/features/generation/worker/generators/textBuilder.ts
+++ b/src/features/generation/worker/generators/textBuilder.ts
@@ -84,9 +84,10 @@ export function clearTextMetricsMemo(): void {
  * build (width = glyph advance width, vertical metrics scale by
  * `fontSize / unitsPerEm`; no hinting in this code path), so one measurement at
  * a reference size yields the ideal size directly — no search needed. A single
- * verify call covers the clamp-to-min overflow case and guards against any
- * future non-linearity; if metrics ever stop being measurable we fall back to
- * the robust binary search. Re-verify the linearity assumption on brepjs bumps.
+ * verify call confirms the pick fits; if it doesn't (clamp-to-min overflow, or
+ * hypothetically non-linear metrics) or a measurement isn't `isOk`, we fall back
+ * to the robust binary search rather than dropping the text. Re-verify the
+ * linearity assumption on brepjs bumps.
  */
 export function fitFontSize(
   text: string,
@@ -112,18 +113,25 @@ export function fitFontSize(
   const size = Math.min(max, Math.max(min, Math.min(sizeForW, sizeForH)));
 
   const check = measureText(text, size, fontFamily);
-  if (!isOk(check)) {
-    return fitFontSizeBisect(text, fontFamily, availW, availD, min, max);
-  }
   const fits =
-    check.value.width <= availW + FIT_EPSILON && check.value.height <= availD + FIT_EPSILON;
-  return fits ? { fontSize: size, fits: true } : { fontSize: 0, fits: false };
+    isOk(check) &&
+    check.value.width <= availW + FIT_EPSILON &&
+    check.value.height <= availD + FIT_EPSILON;
+  if (fits) return { fontSize: size, fits: true };
+  // The linear pick didn't verify as fitting. With exactly-linear metrics this
+  // only happens when `size` was clamped to `min` and `min` itself overflows.
+  // Defer to the search either way: it returns fits:false for that clamp case
+  // (matching the old behavior) and, were metrics ever non-linear, would still
+  // find a smaller fitting size instead of dropping the text. Costs nothing on
+  // the common path (the early return above).
+  return fitFontSizeBisect(text, fontFamily, availW, availD, min, max);
 }
 
 /**
- * Robust fallback: binary search to ~0.05mm precision. Only reached when a
- * measurement isn't `isOk` (a font edge case) — kept so the builder degrades
- * gracefully rather than producing geometry from an unverified size.
+ * Robust fallback: binary search to ~0.05mm precision. Reached when the linear
+ * pick doesn't verify as fitting or a measurement isn't `isOk` (a font edge
+ * case) — kept so the builder degrades gracefully rather than producing
+ * geometry from an unverified size.
  */
 function fitFontSizeBisect(
   text: string,


### PR DESCRIPTION
## Problem

Adding/editing text labels in the bin designer made generation feel very slow. One of three stacked causes (this PR fixes the **per-text compute** one):

\`fitFontSize\` ran a 14-iteration binary search — ~16 \`textMetrics\` calls per label — to auto-fit the font size.

## Fix

\`textMetrics\` is **exactly linear** in \`fontSize\` for the pinned brepjs build (advance width + vertical metrics scale by \`fontSize/unitsPerEm\`; no hinting in this code path). So a single reference measurement yields the ideal size directly:

- One measurement at a reference size → ideal size by ratio, clamped to [min, max].
- One **verify** call covers the clamp-to-min overflow case and guards against any future non-linearity.
- A \`!isOk\` measurement falls back to the original binary search (kept as \`fitFontSizeBisect\`).
- \`textMetrics\` is also **memoized** (pure given text/size/font), so the verify call and \`buildTextSolid\`'s follow-up measurement collapse to ~2 unique calls per label, with cross-compartment reuse for repeated words. The memo is bounded and cleared via \`clearTextMetricsMemo\`, wired into \`clearAllCaches\` (kernel switch / font reload).

Net: **~16 → ~2** \`textMetrics\` calls per label.

> Linearity verified against the pinned brepjs version — a comment flags it for re-check on dependency bumps.

## Tests

- Extended \`textBuilder.test.ts\`: near-maximal fit (rendered bbox within budget and bound by an axis), deterministic + unaffected by clearing the memo; existing overflow/empty/min>max cases still pass.
- \`textEngraving.scenario\` passes (geometry still valid).
- `pnpm exec eslint` clean.

## Related

Part of a 3-PR set. Touches \`textBuilder.ts\` and \`shapeCache.ts\` (\`clearAllCaches\`), which also change in the per-compartment text-solid cache PR — whichever merges second needs a trivial rebase.