### PR TITLE
perf(generation): cache per-text glyph solids across compartments

### DIFF
--- a/src/features/generation/worker/generators/shapeCache.ts
+++ b/src/features/generation/worker/generators/shapeCache.ts
@@ -24,6 +24,11 @@ import { buildCacheKey, quantize, compactKey } from './cacheKeyUtils';
 import { GRIDFINITY } from '@/shared/constants/bin';
 import { clearSocketMeshCache } from './socketMeshCache';
 import { clearTextMetricsMemo } from './textBuilder';
+import {
+  clearTextSolidCache,
+  getTextSolidCacheStats,
+  resetTextSolidCacheStats,
+} from './textSolidCache';
 
 /** Dispose callback for LRU caches holding WASM-backed shapes. */
 const disposeShape = (_key: string, shape: Shape3D): void => {
@@ -226,6 +231,7 @@ export function clearAllCaches(): void {
   }
   clearSocketMeshCache();
   clearTextMetricsMemo();
+  clearTextSolidCache();
   if (patternTemplateCache) {
     patternTemplateCache.shape.delete();
     patternTemplateCache = null;
@@ -250,6 +256,7 @@ export function getAllShapeCacheStats(): CacheStats[] {
   return [
     ...staticLruCaches.map((cache) => cache.getStats()),
     ...[...featureToolCaches.values()].map((cache) => cache.getStats()),
+    getTextSolidCacheStats(),
   ];
 }
 
@@ -261,4 +268,5 @@ export function resetAllShapeCacheStats(): void {
   for (const cache of featureToolCaches.values()) {
     cache.resetStats();
   }
+  resetTextSolidCacheStats();
 }

--- a/src/features/generation/worker/generators/textBuilder.ts
+++ b/src/features/generation/worker/generators/textBuilder.ts
@@ -28,6 +28,7 @@ import {
 } from 'brepjs';
 import { isOk } from '@/core/result';
 import type { TextFontFamily, TextMode } from '@/shared/types/bin';
+import { getTextSolid, setTextSolid, textSolidKey } from './textSolidCache';
 
 export interface FitResult {
   /** Rendered font size in mm; `0` if `fits` is false. */
@@ -268,20 +269,64 @@ export function buildTextSolid(
         ? -(options.hostThickness + 2 * TEXT_BOOLEAN_EPSILON)
         : -(options.depth + TEXT_BOOLEAN_EPSILON);
 
-  const sketches = sketchText(
+  // Reuse the canonical glyph solid (sketched at Z=0) when another compartment
+  // already built this exact text. The Z lift onto the host face is folded into
+  // the translate below — building at Z=0 then translating by `sketchOriginZ` is
+  // identical to sketching there, but the geometry is placement-independent and
+  // therefore shareable across compartments.
+  const canonical = getOrBuildCanonicalTextSolid(
+    scope,
     trimmed,
-    { fontSize: fit.fontSize, fontFamily },
-    { plane: 'XY' as PlaneName, origin: [0, 0, sketchOriginZ] }
+    fontFamily,
+    options.mode,
+    fit.fontSize,
+    options.depth,
+    options.hostThickness,
+    extrusion
   );
-  const extruded = scope.register(sketches.extrude(extrusion));
 
   // textMetrics: width is total advance; vertical bbox spans descender..ascender.
   // Visual centroid in the sketch frame = (width/2, (ascender + descender)/2).
   const visualCenterX = metrics.value.width / 2;
   const visualCenterY = (metrics.value.ascender + metrics.value.descender) / 2;
   const solid = scope.register(
-    translate(extruded, [options.centerX - visualCenterX, options.centerY - visualCenterY, 0])
+    translate(canonical, [
+      options.centerX - visualCenterX,
+      options.centerY - visualCenterY,
+      sketchOriginZ,
+    ])
   );
 
   return { solid, op: options.mode === 'emboss' ? 'fuse' : 'cut' };
+}
+
+/**
+ * Build the canonical glyph solid (sketch origin at Z=0) for the given text, or
+ * return a clone of the cached one. The returned shape is registered in `scope`
+ * so the caller can translate it and let the scope dispose it; an independent
+ * clone is what lives in the cache (never scope-registered — see textSolidCache).
+ */
+function getOrBuildCanonicalTextSolid(
+  scope: DisposalScope,
+  text: string,
+  fontFamily: TextFontFamily,
+  mode: TextMode,
+  fontSize: number,
+  depth: number,
+  hostThickness: number,
+  extrusion: number
+): Shape3D {
+  const key = textSolidKey(text, fontFamily, mode, fontSize, depth, hostThickness);
+  const hit = getTextSolid(key);
+  if (hit) return scope.register(hit);
+
+  const sketches = sketchText(
+    text,
+    { fontSize, fontFamily },
+    { plane: 'XY' as PlaneName, origin: [0, 0, 0] }
+  );
+  const extruded = sketches.extrude(extrusion);
+  // Cache an independent clone before handing the built shape to the scope.
+  setTextSolid(key, extruded);
+  return scope.register(extruded);
 }

--- a/src/features/generation/worker/generators/textSolidCache.test.ts
+++ b/src/features/generation/worker/generators/textSolidCache.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment node
+/**
+ * Per-text glyph-solid cache behavior, exercised through the real `buildTextSolid`
+ * path (brepjs WASM + a loaded font). The two properties that matter:
+ *  1. The cache key ignores placement, so the same text in different positions
+ *     reuses one canonical solid.
+ *  2. Cached entries are independent of the DisposalScope that built them — a hit
+ *     after the building scope has closed must still mesh to valid geometry
+ *     (the bug this guards against is caching a scope-registered handle, which
+ *     would be `.delete()`-ed at scope exit and dangle).
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { loadFont, isErr, withScope, mesh } from 'brepjs';
+import type { DisposalScope } from 'brepjs';
+import { buildTextSolid } from './textBuilder';
+import type { BuildTextSolidOptions } from './textBuilder';
+import { getTextSolidCacheStats, clearTextSolidCache } from './textSolidCache';
+
+const MESH_OPTS = { tolerance: 0.5, angularTolerance: 15 };
+
+const baseOptions: BuildTextSolidOptions = {
+  text: 'M8',
+  fontFamily: 'atkinson',
+  mode: 'engrave',
+  availW: 30,
+  availD: 12,
+  centerX: 15,
+  centerY: -6,
+  topZ: 5,
+  depth: 0.8,
+  hostThickness: 1.2,
+  margin: 1,
+  minFontSize: 3,
+  maxFontSize: 20,
+};
+
+beforeAll(async () => {
+  const { initBrepjs } = await import('./__kernel-tests__/wasmInit');
+  await initBrepjs();
+  const buffer = readFileSync(
+    resolve(__dirname, '../assets/fonts/AtkinsonHyperlegible-Regular.ttf')
+  );
+  const result = await loadFont(
+    buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
+    'atkinson'
+  );
+  if (isErr(result)) throw new Error(`Font load failed: ${result.error.message}`);
+}, 60_000);
+
+beforeEach(() => {
+  clearTextSolidCache();
+});
+
+/** Build a text solid in a fresh scope and return its mesh vertex count (0 if
+ *  the build returned null). The scope disposes everything it registered before
+ *  returning, so anything still valid afterward must live in the cache. */
+function meshTextSolid(overrides: Partial<BuildTextSolidOptions> = {}): number {
+  return withScope((scope: DisposalScope): number => {
+    const built = buildTextSolid(scope, { ...baseOptions, ...overrides });
+    if (!built) return 0;
+    return mesh(built.solid, MESH_OPTS).vertices.length;
+  });
+}
+
+describe('textSolidCache', () => {
+  it('builds a non-empty solid and records a miss + one entry', () => {
+    const verts = meshTextSolid();
+    expect(verts).toBeGreaterThan(0);
+    const stats = getTextSolidCacheStats();
+    expect(stats.misses).toBe(1);
+    expect(stats.size).toBe(1);
+  });
+
+  it('serves a cache hit for identical text and meshes to the same geometry', () => {
+    const first = meshTextSolid();
+    const second = meshTextSolid();
+    expect(second).toBe(first);
+    const stats = getTextSolidCacheStats();
+    expect(stats.hits).toBe(1);
+    expect(stats.misses).toBe(1);
+  });
+
+  it('reuses the cached solid across placements (key ignores center/topZ)', () => {
+    // The first scope builds and disposes its registered clone; the cache's
+    // independent clone must survive for the second (differently placed) build.
+    const first = meshTextSolid();
+    const second = meshTextSolid({ centerX: 20, centerY: -4, topZ: 9 });
+    expect(first).toBeGreaterThan(0);
+    // Placement is a rigid translate, so the vertex count is unchanged.
+    expect(second).toBe(first);
+    expect(getTextSolidCacheStats().hits).toBe(1);
+  });
+
+  it('treats different text as a distinct entry', () => {
+    meshTextSolid({ text: 'M8' });
+    meshTextSolid({ text: 'M4' });
+    const stats = getTextSolidCacheStats();
+    expect(stats.misses).toBe(2);
+    expect(stats.size).toBe(2);
+  });
+
+  it('clearTextSolidCache empties the cache and resets stats', () => {
+    meshTextSolid();
+    clearTextSolidCache();
+    const stats = getTextSolidCacheStats();
+    expect(stats.size).toBe(0);
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+  });
+});

--- a/src/features/generation/worker/generators/textSolidCache.ts
+++ b/src/features/generation/worker/generators/textSolidCache.ts
@@ -1,0 +1,91 @@
+/**
+ * Per-text glyph-solid cache for engraved/embossed/through-cut label text.
+ *
+ * The expensive part of materializing text is `sketchText` + `extrude` — it
+ * produces one solid per glyph. The label-tab feature cache key serializes the
+ * WHOLE `compartmentTexts` array, so editing one compartment's text invalidates
+ * the entire label-tab assembly and rebuilds every label's glyph geometry, even
+ * the unchanged ones.
+ *
+ * This caches the *canonical* glyph solid (sketch origin at Z=0, glyphs at their
+ * natural XY) keyed by the inputs that shape it — text, font, mode, fit size,
+ * and extrusion depth — independent of where it's later placed. Placement (the
+ * XY centering and the Z lift onto the host face) is a cheap per-call translate,
+ * so editing one label is a cache hit for every other compartment's text.
+ *
+ * Ownership mirrors the shape caches (see shapeCache.ts): entries are JS-cache-
+ * owned clones that are NEVER registered in a DisposalScope (a scope-registered
+ * shape would be `.delete()`-ed at scope exit, dangling the cached handle). The
+ * getter hands back an independent clone the caller registers; the setter stores
+ * an independent clone of whatever the caller built.
+ */
+
+import { clone, unwrap } from 'brepjs';
+import type { Shape3D } from 'brepjs';
+import { LRUCache } from './lruCache';
+import type { CacheStats } from './lruCache';
+import { quantize, compactKey } from './cacheKeyUtils';
+import type { TextFontFamily, TextMode } from '@/shared/types/bin';
+
+const disposeShape = (_key: string, shape: Shape3D): void => {
+  shape.delete();
+};
+
+// 32: a fully-labeled bin rarely exceeds ~30 compartments, so a whole design's
+// distinct text solids survive one regeneration — editing a single label keeps
+// the other N-1 warm for the immediate rebuild.
+const textSolidCache = new LRUCache<Shape3D>('text-solid', 32, disposeShape);
+
+/**
+ * Compose the cache key for a canonical text solid. `fontFamily` must already be
+ * resolved (post `resolveEffectiveFont`) so through-cut's stencil swap collapses
+ * onto one key. `depth` and `hostThickness` together pin the extrusion vector
+ * across the three modes; only one is load-bearing per mode, but including both
+ * is harmless and keeps the key mode-agnostic.
+ *
+ * `compactKey` hashes the key when it exceeds the length threshold — matching
+ * every other key builder in this directory (label text is the only unbounded
+ * segment, and it sits last so the fixed-format prefix can't collide).
+ */
+export function textSolidKey(
+  text: string,
+  fontFamily: TextFontFamily,
+  mode: TextMode,
+  fontSize: number,
+  depth: number,
+  hostThickness: number
+): string {
+  return compactKey(
+    `${fontFamily}|${mode}|${quantize(fontSize)}|${quantize(depth)}|${quantize(hostThickness)}|${text}`
+  );
+}
+
+/** Independent clone of a cached text solid, or null on miss. The clone is
+ *  JS-owned and unregistered — the caller must register or dispose it. */
+export function getTextSolid(key: string): Shape3D | null {
+  const shape = textSolidCache.get(key);
+  return shape !== undefined ? unwrap(clone(shape)) : null;
+}
+
+/** Store an independent (unregistered) clone of `shape`. The cache owns the
+ *  clone for its lifetime; `shape` itself stays the caller's to dispose. */
+export function setTextSolid(key: string, shape: Shape3D): void {
+  textSolidCache.set(key, unwrap(clone(shape)));
+}
+
+export function getTextSolidCacheStats(): CacheStats {
+  return textSolidCache.getStats();
+}
+
+/** Reset hit/miss/eviction counters without disposing entries — pairs with
+ *  `resetAllShapeCacheStats`, which reports this cache via `getAllShapeCacheStats`. */
+export function resetTextSolidCacheStats(): void {
+  textSolidCache.resetStats();
+}
+
+/** Dispose all cached text solids and reset counters. Required on kernel switch
+ *  (see clearAllCaches) — handles can't cross WASM kernels. */
+export function clearTextSolidCache(): void {
+  textSolidCache.dispose();
+  textSolidCache.resetStats();
+}


### PR DESCRIPTION
## Problem

Adding/editing text labels in the bin designer made generation feel very slow. One of three stacked causes (this PR fixes the **per-compartment amplification** one):

Editing one compartment's label invalidated the whole \`labelTabs\` feature (its cache key serializes the entire \`compartmentTexts\` array), rebuilding **every** label's glyph geometry — the expensive \`sketchText\` + per-glyph \`extrude\` — even for unchanged compartments.

## Fix

Cache the **canonical glyph solid** (sketched at Z=0, placement-independent) keyed by text + resolved font + mode + fit size + extrusion depths. The host-face Z lift and XY centering fold into a cheap per-call \`translate\`, so the same text in any compartment reuses one built solid. Editing one of N labels is now a cache hit for the other N-1.

- **Ownership** mirrors the shape caches: entries are JS-cache-owned clones **never** registered in a \`DisposalScope\` (a scope-registered handle would be \`.delete()\`-ed at scope exit and dangle). Getter hands back an independent clone the caller registers; setter stores an independent clone.
- Cleared on kernel switch via \`clearAllCaches\`; surfaced in \`getAllShapeCacheStats\`.
- The outer \`labelTabs\` cache key is **deliberately unchanged** — the two layers operate at different granularities (whole-assembly hit vs per-text-solid hit). Both kept intentionally.

## Tests

- New \`textSolidCache.test.ts\` (node env, real brepjs WASM + font): non-empty build records a miss; identical text → hit with equal mesh; **survives scope disposal** (a hit after the building scope closes still meshes correctly — the dangling-handle guard); placement-independent reuse; distinct text → distinct entry; clear resets.
- \`textEngraving.scenario\` + full \`binGenerator.scenario\` suite (870 tests) pass.
- `pnpm exec eslint` clean.

## Related

Part of a 3-PR set. Touches \`textBuilder.ts\` and \`shapeCache.ts\` (\`clearAllCaches\`), which also change in the linear-font-fit PR (#2210) — whichever merges second needs a trivial rebase.