### PR TITLE
fix(print): fix SplitPreview crash on half-grid (fractional) bin dimensions

### DIFF
--- a/src/shell/Print/SplitPreview/SplitPreview.test.tsx
+++ b/src/shell/Print/SplitPreview/SplitPreview.test.tsx
@@ -128,6 +128,27 @@ describe('SplitPreview', () => {
     });
   });
 
+  describe('half-grid (fractional) dimensions', () => {
+    it('renders without crashing when bin and pieces are fractional', () => {
+      const pieces = [createPiece(2.5, 0.5)];
+      expect(() => render(<SplitPreview width={2.5} depth={2.5} pieces={pieces} />)).not.toThrow();
+
+      expect(screen.getByText('2.5×0.5')).toBeInTheDocument();
+    });
+
+    it('places a fractional piece within the ceil-sized grid', () => {
+      const pieces = [createPiece(0.5, 0.5)];
+      const { container } = render(
+        <SplitPreview width={1.5} depth={1.5} pieces={pieces} cellSize={16} gap={2} />
+      );
+
+      const placed = container.querySelectorAll('[class*="absolute"]');
+      expect(placed).toHaveLength(1);
+      expect((placed[0] as HTMLElement).style.left).toBe('0px');
+      expect((placed[0] as HTMLElement).style.bottom).toBe('0px');
+    });
+  });
+
   describe('complex layouts', () => {
     it('handles mixed piece sizes', () => {
       const pieces = [createPiece(3, 2), createPiece(1, 2)];

--- a/src/shell/Print/SplitPreview/SplitPreview.tsx
+++ b/src/shell/Print/SplitPreview/SplitPreview.tsx
@@ -24,9 +24,14 @@ interface SplitPreviewProps {
  * Shows a grid diagram with the split pieces.
  */
 export function SplitPreview({ width, depth, pieces, cellSize = 16, gap = 2 }: SplitPreviewProps) {
+  // Half-grid bins yield fractional width/depth; allocate and scan whole cells so a
+  // fractional piece can't index a row/column the grid never allocated.
+  const cols = Math.max(0, Math.ceil(width));
+  const rows = Math.max(0, Math.ceil(depth));
+
   // Create a 2D grid to place pieces
-  const grid: (PrintPiece | null)[][] = Array.from({ length: depth }, () =>
-    Array.from({ length: width }, () => null)
+  const grid: (PrintPiece | null)[][] = Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => null)
   );
 
   // Place pieces using greedy left-to-right, bottom-to-top
@@ -36,8 +41,8 @@ export function SplitPreview({ width, depth, pieces, cellSize = 16, gap = 2 }: S
   );
 
   for (const piece of piecesToPlace) {
-    outer: for (let y = 0; y < depth; y++) {
-      for (let x = 0; x < width; x++) {
+    outer: for (let y = 0; y < rows; y++) {
+      for (let x = 0; x < cols; x++) {
         let fits = true;
         if (x + piece.width > width || y + piece.depth > depth) {
           fits = false;


### PR DESCRIPTION
## Summary

Fixes a `TypeError` crash in `SplitPreview` surfaced by PostHog error tracking ([issue](https://us.posthog.com/project/284234/error_tracking/019ec454-00f8-75d2-b936-74cba355c0b3)) — `can't access property 0, a[e] is undefined` at `SplitPreview.tsx`, hit on a shared layout with half-grid bins.

### Root cause
`RightPanel.tsx` / `MobilePrintList.tsx` pass `width`/`depth` parsed from `row.size` (e.g. `2.5×2.5` in half-grid mode). Inside `SplitPreview`:

- `Array.from({ length: depth })` truncates a fractional length to an integer, so the backing grid had fewer rows/cols than the placement loop assumed.
- The loop bounds (`y < depth`) and fits-guard (`y + piece.depth > depth`) kept using the **raw fractional** value, so a fractional piece slipped past the guard and indexed `grid[py]` (undefined) → crash.

### Fix
Allocate and scan the grid in whole cells via `Math.ceil(width)` / `Math.ceil(depth)`. Every integer index the scan can reach (`px < width ≤ cols`, `py < depth ≤ rows`) is now backed by an allocated cell. The fits-guard still uses the raw dimensions, so the real footprint check — and integer-dimension behavior — is unchanged.

## Testing
- Added a `half-grid (fractional) dimensions` test block (renders without throwing + correct placement within the ceil-sized grid).
- Full suite green (13,750 passed / 7 skipped), `typecheck` clean, `eslint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)