### PR TITLE
perf(baseplate): draft preview + defer BREP for large plates

### DIFF
--- a/src/features/baseplate/hooks/useBaseplateGeneration.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.ts
@@ -316,11 +316,15 @@ export function useBaseplateGeneration(): void {
       fullParams: FullBaseplateParams,
       bedWidthMm: number,
       bedDepthMm: number,
-      epoch: number
+      epoch: number,
+      // Callers that already computed the tiling pass it in to avoid a second
+      // computeBaseplateTiling pass (cheap, but redundant on large plates).
+      precomputedTiling?: BaseplateTiling
     ): BaseplateTiling => {
       directMeshStartRef.current = performance.now();
 
-      const tiling = computeBaseplateTiling(fullParams, bedWidthMm, bedDepthMm);
+      const tiling =
+        precomputedTiling ?? computeBaseplateTiling(fullParams, bedWidthMm, bedDepthMm);
       setTiling(tiling);
       setSplitProgress(null);
       setDedupStats(null);
@@ -616,7 +620,7 @@ export function useBaseplateGeneration(): void {
       // instant procedural mesh on screen and mark the preview complete. Export
       // rebuilds at full BREP fidelity via its own (larger-budget) path.
       if (shouldDeferBrepPreview(tiling, fullParams, lastBrepMsRef.current)) {
-        runDirectMeshPreview(fullParams, bedWidthMm, bedDepthMm, epoch);
+        runDirectMeshPreview(fullParams, bedWidthMm, bedDepthMm, epoch, tiling);
         // Claim this epoch as final so a late async draft can't overwrite it.
         finalizedEpochRef.current = epoch;
         setGenerationStatus('complete');
@@ -651,12 +655,12 @@ export function useBaseplateGeneration(): void {
               generationEpochRef.current === epoch &&
               epoch > finalizedEpochRef.current
             ) {
-              runDirectMeshPreview(fullParams, bedWidthMm, bedDepthMm, epoch);
+              runDirectMeshPreview(fullParams, bedWidthMm, bedDepthMm, epoch, tiling);
             }
           });
         }
       } else {
-        runDirectMeshPreview(fullParams, bedWidthMm, bedDepthMm, epoch);
+        runDirectMeshPreview(fullParams, bedWidthMm, bedDepthMm, epoch, tiling);
       }
 
       void runBrepGeneration(fullParams, tiling, epoch);

--- a/src/features/baseplate/hooks/useBaseplateGeneration.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.ts
@@ -45,6 +45,7 @@ import { generateBaseplateDirect } from '@/shared/generation/directMesh';
 import { useBaseplatePageStore } from '../store/baseplatePageStore';
 import { buildFullParams } from '../utils/buildFullParams';
 import { computeBaseplateTiling } from '../utils/splitPlanner';
+import { shouldDeferBrepPreview } from '../utils/previewComplexity';
 import { groupPiecesByFingerprint } from '../utils/pieceFingerprint';
 import type { BaseplateParams as FullBaseplateParams } from '@/shared/types/bin';
 import type { PieceMeshEntry } from '../store/baseplatePageStore';
@@ -607,12 +608,35 @@ export function useBaseplateGeneration(): void {
       // even though the user can see the draft preview.
       setGenerationStatus('generating');
 
+      const tiling = computeBaseplateTiling(fullParams, bedWidthMm, bedDepthMm);
+
+      // Large magnet plates can exceed the per-piece BREP budget on slower
+      // hardware — the user would wait out the whole timeout only to fall back
+      // to the (already faithful) direct-mesh. Skip that gamble: keep the
+      // instant procedural mesh on screen and mark the preview complete. Export
+      // rebuilds at full BREP fidelity via its own (larger-budget) path.
+      if (shouldDeferBrepPreview(tiling, fullParams, lastBrepMsRef.current)) {
+        runDirectMeshPreview(fullParams, bedWidthMm, bedDepthMm, epoch);
+        // Claim this epoch as final so a late async draft can't overwrite it.
+        finalizedEpochRef.current = epoch;
+        setGenerationStatus('complete');
+        trackBaseplatePreviewTiming({
+          directMeshMs: directMeshDurationRef.current,
+          previewKind: 'direct',
+          brepMs: 0,
+          pieceCount: tiling.pieces.length,
+          isSplit: tiling.isSplit,
+          wasmCold: !firstBrepDoneRef.current,
+          success: true,
+          deferred: true,
+        });
+        return;
+      }
+
       const preview = previewBridgeRef.current;
-      let tiling: BaseplateTiling;
       if (preview && !preview.isDestroyed) {
         // manifold_preview on: draft with the Manifold kernel (real generator,
         // draft quality) instead of the procedural direct-mesh.
-        tiling = computeBaseplateTiling(fullParams, bedWidthMm, bedDepthMm);
         setTiling(tiling);
         setSplitProgress(null);
         setDedupStats(null);
@@ -632,7 +656,7 @@ export function useBaseplateGeneration(): void {
           });
         }
       } else {
-        tiling = runDirectMeshPreview(fullParams, bedWidthMm, bedDepthMm, epoch);
+        runDirectMeshPreview(fullParams, bedWidthMm, bedDepthMm, epoch);
       }
 
       void runBrepGeneration(fullParams, tiling, epoch);
@@ -726,7 +750,15 @@ export function useBaseplateGeneration(): void {
         const bedD = layoutState.layout.printBedDepth ?? layoutState.layout.printBedSize;
         const epoch = ++generationEpochRef.current;
         const tiling = computeBaseplateTiling(params, bedW, bedD);
-        void runBrepGeneration(params, tiling, epoch);
+        // Mirror runGeneration's deferral: if the stored plate is predicted too
+        // expensive, don't kick off the doomed BREP on bridge-ready — the
+        // params-change effect already left the faithful direct-mesh on screen.
+        if (shouldDeferBrepPreview(tiling, params, lastBrepMsRef.current)) {
+          finalizedEpochRef.current = epoch;
+          setGenerationStatus('complete');
+        } else {
+          void runBrepGeneration(params, tiling, epoch);
+        }
       })
       .catch((e: unknown) => {
         if (cancelled) return;
@@ -751,7 +783,7 @@ export function useBaseplateGeneration(): void {
         workerPoolManager.release();
       }
     };
-  }, [setWasmStatus, runBrepGeneration, t]);
+  }, [setWasmStatus, setGenerationStatus, runBrepGeneration, t]);
 
   // Re-generate on every params change. Direct-mesh runs synchronously here
   // (renders before bridge is ready); BREP runs in background once bridge exists.

--- a/src/features/baseplate/utils/previewComplexity.test.ts
+++ b/src/features/baseplate/utils/previewComplexity.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  estimatePreviewComplexity,
+  shouldDeferBrepPreview,
+  DEFER_MAX_PIECE_CELLS,
+  DEFER_TOTAL_CELLS,
+  DEFER_LAST_BREP_MS,
+} from './previewComplexity';
+import { computeBaseplateTiling } from './splitPlanner';
+import type { BaseplateParams } from '@/shared/types/bin';
+
+function makeParams(overrides: Partial<BaseplateParams> = {}): BaseplateParams {
+  return {
+    width: 6,
+    depth: 6,
+    gridUnitMm: 42,
+    magnetHoles: true,
+    magnetDiameter: 6.5,
+    magnetDepth: 2.4,
+    paddingLeft: 0,
+    paddingRight: 0,
+    paddingFront: 0,
+    paddingBack: 0,
+    fractionalEdgeX: 'end',
+    fractionalEdgeY: 'end',
+    ...overrides,
+  };
+}
+
+const defer = (p: BaseplateParams, bed = 256, lastMs: number | null = null): boolean =>
+  shouldDeferBrepPreview(computeBaseplateTiling(p, bed), p, lastMs);
+
+describe('estimatePreviewComplexity', () => {
+  it('counts a single unsplit plate as its own cells', () => {
+    const p = makeParams({ width: 6, depth: 6 });
+    const { maxPieceCells, totalCells } = estimatePreviewComplexity(
+      computeBaseplateTiling(p, 256),
+      p
+    );
+    expect(maxPieceCells).toBe(36);
+    expect(totalCells).toBe(36);
+  });
+
+  it('rounds fractional edges up (a half-unit edge carries full edge work)', () => {
+    const p = makeParams({ width: 5.5, depth: 4 });
+    const { maxPieceCells } = estimatePreviewComplexity(computeBaseplateTiling(p, 256), p);
+    expect(maxPieceCells).toBe(6 * 4);
+  });
+
+  it('keys off the deduped piece set, not every placement', () => {
+    // A large square plate splits into many pieces. With square corners and no
+    // connectors, edge labels don't affect geometry, so equal-sized pieces share
+    // a fingerprint — total unique cells stays far below pieces × cells.
+    const p = makeParams({ width: 18, depth: 18, cornerRadius: 0 });
+    const tiling = computeBaseplateTiling(p, 256);
+    const { totalCells } = estimatePreviewComplexity(tiling, p);
+    const naiveTotal = tiling.pieces.reduce(
+      (sum, pc) => sum + Math.ceil(pc.widthUnits) * Math.ceil(pc.depthUnits),
+      0
+    );
+    expect(tiling.isSplit).toBe(true);
+    expect(totalCells).toBeLessThan(naiveTotal);
+  });
+});
+
+describe('shouldDeferBrepPreview', () => {
+  it('never defers when magnets are off (BREP is fast without per-cell holes)', () => {
+    expect(defer(makeParams({ width: 20, depth: 20, magnetHoles: false }))).toBe(false);
+  });
+
+  it('does not defer a small magnet plate (gets the exact preview)', () => {
+    expect(defer(makeParams({ width: 6, depth: 6 }))).toBe(false);
+  });
+
+  it('does not defer bed-bounded split pieces (each piece stays small)', () => {
+    // A 12×12 plate on a 256mm bed tiles into ~6×6 pieces — none large enough,
+    // and the deduped total stays under budget.
+    expect(defer(makeParams({ width: 12, depth: 12 }))).toBe(false);
+  });
+
+  it('defers a large single plate on a big custom bed', () => {
+    // 10×10 fits a 460mm bed in one piece → 100 cells ≥ DEFER_MAX_PIECE_CELLS.
+    const p = makeParams({ width: 10, depth: 10 });
+    expect(estimatePreviewComplexity(computeBaseplateTiling(p, 460), p).maxPieceCells).toBe(100);
+    expect(defer(p, 460)).toBe(true);
+  });
+
+  it('defers a many-piece tiling whose total unique work is large', () => {
+    // A big square plate dedups but still sums past DEFER_TOTAL_CELLS.
+    const p = makeParams({ width: 26, depth: 26 });
+    const { maxPieceCells, totalCells } = estimatePreviewComplexity(
+      computeBaseplateTiling(p, 256),
+      p
+    );
+    expect(maxPieceCells).toBeLessThan(DEFER_MAX_PIECE_CELLS);
+    expect(totalCells).toBeGreaterThanOrEqual(DEFER_TOTAL_CELLS);
+    expect(defer(p)).toBe(true);
+  });
+
+  it('defers adaptively once a real BREP run on this machine was slow', () => {
+    const p = makeParams({ width: 6, depth: 6 }); // small, would not defer statically
+    expect(defer(p, 256, null)).toBe(false);
+    expect(defer(p, 256, DEFER_LAST_BREP_MS + 1)).toBe(true);
+  });
+});

--- a/src/features/baseplate/utils/previewComplexity.ts
+++ b/src/features/baseplate/utils/previewComplexity.ts
@@ -1,0 +1,94 @@
+/**
+ * Predicts whether the high-fidelity BREP preview is worth running for a given
+ * baseplate, or whether the live preview should stay on the instant procedural
+ * direct-mesh and defer exact geometry to export.
+ *
+ * Why this exists: the BREP magnet-hole boolean pipeline scales with cell count
+ * and, on slower hardware, large magnet plates exceed the per-piece generation
+ * budget — the user waits out the whole timeout only to fall back to the
+ * direct-mesh anyway (production telemetry: ~150 users/30d hit baseplate preview
+ * timeouts, mostly warm desktop, brep times 10-40x the success median). The
+ * direct-mesh is already faithful (renders pockets, magnet holes, rounded
+ * corners), so for plates predicted too expensive we skip the gamble and keep
+ * it on screen. Export always rebuilds at full BREP fidelity (separate path,
+ * larger budget, deliberate user action).
+ *
+ * Split pieces are bed-bounded (≤ ~6 units/axis on a 256 mm bed), so the
+ * dangerous cases are large single plates on big custom beds and many-piece
+ * tilings whose total work is large — both captured below.
+ */
+
+import type { BaseplateParams } from '@/shared/types/bin';
+import { groupPiecesByFingerprint } from './pieceFingerprint';
+import type { BaseplateTiling } from '../types/tiling';
+
+/**
+ * Largest single unique piece (in whole grid cells) above which the live BREP
+ * preview is deferred. The per-piece boolean cost scales with cell count, and a
+ * single piece this large risks tripping its own generation budget on slower
+ * hardware. 64 = an 8×8 plate. Below this, draft-quality BREP previews land in a
+ * couple of seconds on reference hardware (see baseplateGenerator bench).
+ */
+export const DEFER_MAX_PIECE_CELLS = 64;
+
+/**
+ * Total unique work (summed whole grid cells across deduped pieces) above which
+ * the preview is deferred. Catches many-piece tilings that are individually
+ * small but collectively long — especially when the worker pool is unavailable
+ * and pieces generate sequentially. 200 ≈ six 6×6 pieces.
+ */
+export const DEFER_TOTAL_CELLS = 200;
+
+/**
+ * Last successful BREP wall-clock (ms) above which the preview is deferred for
+ * comparably-or-more complex plates. Adapts to the user's hardware: once a real
+ * generation on this machine has run long, stop gambling the preview on the
+ * next one. 25 s is well inside the per-piece budget but past the point where a
+ * live preview is a pleasant wait.
+ */
+export const DEFER_LAST_BREP_MS = 25_000;
+
+/** Whole-cell footprint of a piece (fractional edges round up — they still carry edge work). */
+function pieceCells(widthUnits: number, depthUnits: number): number {
+  return Math.ceil(widthUnits) * Math.ceil(depthUnits);
+}
+
+/**
+ * Per-plate BREP-preview cost proxy, in whole grid cells. Returns the largest
+ * unique piece and the summed unique work — both keyed off the deduped piece
+ * set so duplicates (cloned, not regenerated) don't inflate the estimate.
+ */
+export function estimatePreviewComplexity(
+  tiling: BaseplateTiling,
+  parentParams: BaseplateParams
+): { maxPieceCells: number; totalCells: number } {
+  const groups = groupPiecesByFingerprint(tiling.pieces, parentParams);
+  let maxPieceCells = 0;
+  let totalCells = 0;
+  for (const group of groups.values()) {
+    const cells = pieceCells(group.params.width, group.params.depth);
+    if (cells > maxPieceCells) maxPieceCells = cells;
+    totalCells += cells;
+  }
+  return { maxPieceCells, totalCells };
+}
+
+/**
+ * True when the live BREP preview should be skipped in favor of keeping the
+ * instant procedural direct-mesh on screen.
+ *
+ * Only magnet plates qualify — without magnets the BREP build is fast (through-
+ * cut pockets, no per-cell hole booleans) and never the source of timeouts.
+ */
+export function shouldDeferBrepPreview(
+  tiling: BaseplateTiling,
+  parentParams: BaseplateParams,
+  lastBrepMs: number | null
+): boolean {
+  if (!parentParams.magnetHoles) return false;
+
+  if (lastBrepMs !== null && lastBrepMs >= DEFER_LAST_BREP_MS) return true;
+
+  const { maxPieceCells, totalCells } = estimatePreviewComplexity(tiling, parentParams);
+  return maxPieceCells >= DEFER_MAX_PIECE_CELLS || totalCells >= DEFER_TOTAL_CELLS;
+}

--- a/src/features/baseplate/utils/previewComplexity.ts
+++ b/src/features/baseplate/utils/previewComplexity.ts
@@ -23,28 +23,30 @@ import { groupPiecesByFingerprint } from './pieceFingerprint';
 import type { BaseplateTiling } from '../types/tiling';
 
 /**
- * Largest single unique piece (in whole grid cells) above which the live BREP
- * preview is deferred. The per-piece boolean cost scales with cell count, and a
- * single piece this large risks tripping its own generation budget on slower
- * hardware. 64 = an 8×8 plate. Below this, draft-quality BREP previews land in a
- * couple of seconds on reference hardware (see baseplateGenerator bench).
+ * Largest single unique piece (in whole grid cells) at or above which the live
+ * BREP preview is deferred (the check is `>=`). The per-piece boolean cost
+ * scales with cell count, and a single piece this large risks tripping its own
+ * generation budget on slower hardware. 64 = an 8×8 plate. Below this,
+ * draft-quality BREP previews land in a couple of seconds on reference hardware
+ * (see baseplateGenerator bench).
  */
 export const DEFER_MAX_PIECE_CELLS = 64;
 
 /**
- * Total unique work (summed whole grid cells across deduped pieces) above which
- * the preview is deferred. Catches many-piece tilings that are individually
- * small but collectively long — especially when the worker pool is unavailable
- * and pieces generate sequentially. 200 ≈ six 6×6 pieces.
+ * Total unique work (summed whole grid cells across deduped pieces) at or above
+ * which the preview is deferred (the check is `>=`). Catches many-piece tilings
+ * that are individually small but collectively long — especially when the
+ * worker pool is unavailable and pieces generate sequentially. 200 ≈ six 6×6
+ * pieces.
  */
 export const DEFER_TOTAL_CELLS = 200;
 
 /**
- * Last successful BREP wall-clock (ms) above which the preview is deferred for
- * comparably-or-more complex plates. Adapts to the user's hardware: once a real
- * generation on this machine has run long, stop gambling the preview on the
- * next one. 25 s is well inside the per-piece budget but past the point where a
- * live preview is a pleasant wait.
+ * Last successful BREP wall-clock (ms) at or above which the preview is deferred
+ * for the next magnet plate, regardless of its complexity (the check is `>=`).
+ * Adapts to the user's hardware: once a real generation on this machine has run
+ * this long, stop gambling the preview on the next one. 25 s is well inside the
+ * per-piece budget but past the point where a live preview is a pleasant wait.
  */
 export const DEFER_LAST_BREP_MS = 25_000;
 

--- a/src/features/generation/worker/generators/__kernel-tests__/wasmInit.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/wasmInit.ts
@@ -61,7 +61,8 @@ export type GenerateBaseplateFn = (
   params: BaseplateParams,
   onProgress: (stage: string, progress: number) => void,
   forExport: boolean,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  draft?: boolean
 ) => MeshData;
 
 // ─── Split preview ───────────────────────────────────────────────────────────

--- a/src/features/generation/worker/generators/baseplateCacheKeys.test.ts
+++ b/src/features/generation/worker/generators/baseplateCacheKeys.test.ts
@@ -65,4 +65,15 @@ describe('meshCacheKey — draft preview', () => {
   it('defaults to the full-geometry key when draft is omitted', () => {
     expect(meshCacheKey(base(), false)).toBe(meshCacheKey(base(), false, false));
   });
+
+  it('does not fragment the cache when draft cannot change geometry', () => {
+    // No magnets ⇒ no lightweight floor cut ⇒ draft mesh == full mesh, so the
+    // draft flag must not split the LRU.
+    const noMag = (draft: boolean) => meshCacheKey(base({ magnetHoles: false }), false, draft);
+    expect(noMag(true)).toBe(noMag(false));
+    // lightweight explicitly off ⇒ likewise nothing for draft to skip.
+    const noLw = (draft: boolean) =>
+      meshCacheKey(base({ magnetHoles: true, lightweight: false }), false, draft);
+    expect(noLw(true)).toBe(noLw(false));
+  });
 });

--- a/src/features/generation/worker/generators/baseplateCacheKeys.test.ts
+++ b/src/features/generation/worker/generators/baseplateCacheKeys.test.ts
@@ -52,3 +52,17 @@ describe('meshCacheKey — connector fit offset (issue #2024)', () => {
     expect(key(-0.05)).not.toBe(key(-0.1));
   });
 });
+
+describe('meshCacheKey — draft preview', () => {
+  // The draft preview skips the lightweight floor cut, so its mesh differs from
+  // the full build; the two must not alias onto one cache entry.
+  it('produces distinct keys for draft vs full geometry', () => {
+    const full = meshCacheKey(base({ magnetHoles: true }), false, false);
+    const draft = meshCacheKey(base({ magnetHoles: true }), false, true);
+    expect(full).not.toBe(draft);
+  });
+
+  it('defaults to the full-geometry key when draft is omitted', () => {
+    expect(meshCacheKey(base(), false)).toBe(meshCacheKey(base(), false, false));
+  });
+});

--- a/src/features/generation/worker/generators/baseplateCacheKeys.ts
+++ b/src/features/generation/worker/generators/baseplateCacheKeys.ts
@@ -40,6 +40,11 @@ export function meshCacheKey(
   const connectorClearance = params.connectorNubs
     ? effectiveClearance(baseClearance, params.connectorFitOffset ?? 0, params.nozzleSizeMm)
     : 0;
+  // Draft only changes geometry when there's a lightweight floor cut to skip
+  // (magnets on AND lightweight not disabled). Otherwise the draft mesh is
+  // byte-identical to the full build, so folding `draft` to false keeps both
+  // sharing one LRU entry instead of fragmenting it.
+  const geometryAffectingDraft = draft && params.magnetHoles && params.lightweight !== false;
   // Nozzle scales connector feature sizes (snap-clip barb/leg) independently of
   // the clearance term, so it must key the cache or wider-nozzle geometry would
   // alias onto the 0.4mm build. Only meaningful when connectors are on; folded to
@@ -80,8 +85,8 @@ export function meshCacheKey(
     quantize(params.cornerRadii?.br ?? -1),
     forExport,
     // Draft preview skips the lightweight floor cut, so its mesh differs from
-    // the full-geometry build for otherwise-identical params.
-    draft
+    // the full-geometry build — but only when that cut would actually run.
+    geometryAffectingDraft
   );
 }
 

--- a/src/features/generation/worker/generators/baseplateCacheKeys.ts
+++ b/src/features/generation/worker/generators/baseplateCacheKeys.ts
@@ -21,7 +21,11 @@ import {
   effectiveClearance,
 } from './generatorConstants';
 
-export function meshCacheKey(params: BaseplateParams, forExport: boolean): string {
+export function meshCacheKey(
+  params: BaseplateParams,
+  forExport: boolean,
+  draft: boolean = false
+): string {
   // Key on the CLAMPED effective groove clearance, not the raw fit offset, so
   // offsets that collapse to identical geometry share a cache entry (e.g. any
   // tighter-than-floor value clamps to 0). Gated on connectorNubs because the
@@ -74,7 +78,10 @@ export function meshCacheKey(params: BaseplateParams, forExport: boolean): strin
     quantize(params.cornerRadii?.tr ?? -1),
     quantize(params.cornerRadii?.bl ?? -1),
     quantize(params.cornerRadii?.br ?? -1),
-    forExport
+    forExport,
+    // Draft preview skips the lightweight floor cut, so its mesh differs from
+    // the full-geometry build for otherwise-identical params.
+    draft
   );
 }
 

--- a/src/features/generation/worker/generators/baseplateGenerator.bench.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.bench.ts
@@ -77,6 +77,14 @@ describe('baseplate generation', () => {
   );
 
   bench(
+    '6×6 magnets (split-piece)',
+    () => {
+      getGenerateBaseplate()(defaults({ width: 6, depth: 6, magnetHoles: true }), noop, false);
+    },
+    { iterations: 3, warmupIterations: 1 }
+  );
+
+  bench(
     '3×3 magnets + connectors',
     () => {
       getGenerateBaseplate()(

--- a/src/features/generation/worker/generators/baseplateGenerator.draft.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.draft.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+/**
+ * Draft-preview behavior for baseplate generation.
+ *
+ * The live preview builds at draft quality (`draft=true`), which skips the
+ * underside lightweight floor cutters — invisible when orbiting from above and
+ * ~⅓ of build time on magnet grids. The full build (`draft=false`, used by the
+ * scenario/winding suites and export) keeps them. These tests pin that contract:
+ * draft removes geometry on magnet plates and is a no-op without magnets.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { BaseplateParams } from '@/shared/types/bin';
+import { initBrepjs, getGenerateBaseplate } from './__kernel-tests__/wasmInit';
+import { clearBaseplateCaches } from './baseplateCaches';
+
+const noop = (): void => {};
+
+const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+  width: 4,
+  depth: 4,
+  gridUnitMm: 42,
+  magnetHoles: true,
+  magnetDiameter: 6.5,
+  magnetDepth: 2.4,
+  paddingLeft: 0,
+  paddingRight: 0,
+  paddingFront: 0,
+  paddingBack: 0,
+  fractionalEdgeX: 'end',
+  fractionalEdgeY: 'end',
+  lightweight: true,
+  ...overrides,
+});
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30_000);
+
+describe('generateBaseplate draft preview', () => {
+  it('draft skips lightweight floor cuts on magnet plates (fewer triangles)', () => {
+    const gen = getGenerateBaseplate();
+    clearBaseplateCaches();
+    const full = gen(defaults(), noop, false, undefined, false);
+    clearBaseplateCaches();
+    const draft = gen(defaults(), noop, false, undefined, true);
+
+    expect(full.triangleCount).toBeGreaterThan(0);
+    expect(draft.triangleCount).toBeGreaterThan(0);
+    // Lightweight cross cutters add interior faces; dropping them lowers the count.
+    expect(draft.triangleCount).toBeLessThan(full.triangleCount);
+  });
+
+  it('draft is geometrically identical to full when magnets are off', () => {
+    const gen = getGenerateBaseplate();
+    const p = defaults({ magnetHoles: false });
+    clearBaseplateCaches();
+    const full = gen(p, noop, false, undefined, false);
+    clearBaseplateCaches();
+    const draft = gen(p, noop, false, undefined, true);
+
+    // No magnets ⇒ no lightweight floor cut to skip ⇒ same tessellation.
+    expect(draft.triangleCount).toBe(full.triangleCount);
+  });
+});

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -87,29 +87,42 @@ export {
  */
 export type BaseplateProbe = (label: string, shape: Shape3D) => void;
 
-/** Generate baseplate mesh for preview or export. */
+/**
+ * Generate baseplate mesh for the live preview.
+ *
+ * `draft` builds a faster draft-quality solid (skips the underside lightweight
+ * floor cutters). The standalone-page preview passes `true`; the printed export
+ * goes through `exportBaseplate`, which always builds full geometry.
+ */
 export function generateBaseplate(
   rawParams: BaseplateParams,
   onProgress: ProgressFn,
   forExport: boolean,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  draft: boolean = false
 ): MeshData {
   const params = sanitizeParams(rawParams);
   onProgress('base', 0);
   checkCancelled(signal);
 
   // Mesh cache short-circuits BREP booleans + tessellation entirely
-  const cacheKey = meshCacheKey(params, forExport);
+  const cacheKey = meshCacheKey(params, forExport, draft);
   const cached = meshResultCache.get(cacheKey);
   if (cached !== undefined) {
     onProgress('base', 1);
     return cached;
   }
 
-  const baseplate = buildBaseplateSolid(params, forExport, (progress) => {
-    onProgress('base', progress);
-    checkCancelled(signal);
-  });
+  const baseplate = buildBaseplateSolid(
+    params,
+    forExport,
+    (progress) => {
+      onProgress('base', progress);
+      checkCancelled(signal);
+    },
+    undefined,
+    draft
+  );
 
   onProgress('base', 0.9);
   checkCancelled(signal);
@@ -194,7 +207,8 @@ export function buildBaseplateSolid(
   params: BaseplateParams,
   forExport: boolean = true,
   onProgress?: (progress: number) => void,
-  probe?: BaseplateProbe
+  probe?: BaseplateProbe,
+  draft: boolean = false
 ): Shape3D {
   const {
     width,
@@ -327,8 +341,13 @@ export function buildBaseplateSolid(
     probe?.('magnetHolesCut', baseplate);
   }
 
-  // Lightweight floor cutters (cross-shaped material removal)
-  if (magnetHoles && params.lightweight !== false) {
+  // Lightweight floor cutters (cross-shaped material removal). Skipped for the
+  // live preview (`draft`): they remove material only from the underside floor
+  // — invisible when orbiting from above — yet the filleted cross prisms are
+  // ~⅓ of build time on magnet grids. The procedural direct-mesh draft already
+  // renders a solid underside, so skipping them here also removes the
+  // direct→BREP underside pop. Export (`draft === false`) keeps them.
+  if (!draft && magnetHoles && params.lightweight !== false) {
     const floorCutters = buildLightweightFloorCutters(
       width,
       depth,

--- a/src/features/generation/worker/handlers/generateHandler.ts
+++ b/src/features/generation/worker/handlers/generateHandler.ts
@@ -71,7 +71,11 @@ export function handleGenerateBaseplate(message: GenerateBaseplateMessage): void
           reportProgress(requestId, stage as 'base' | 'shell' | 'features' | 'merge', progress);
         },
         false,
-        signal
+        signal,
+        // Live preview is draft-quality: skip the underside lightweight floor
+        // cut (invisible from above, ~⅓ of build). The export path rebuilds at
+        // full quality via `exportBaseplate`.
+        true
       ),
     requestId,
     'BaseplateGen',

--- a/src/shared/analytics/posthog/eventsPerformance.ts
+++ b/src/shared/analytics/posthog/eventsPerformance.ts
@@ -137,6 +137,9 @@ export function trackBooleanFallbacks(payload: {
  * `pieceCount` is 1 for unsplit baseplates; >1 for split tilings.
  * `success` distinguishes completed BREP from errored/timed-out runs so
  * failures are visible in PostHog dashboards.
+ * `deferred` is true when the BREP upgrade was intentionally skipped because the
+ * plate was predicted too expensive (the faithful direct-mesh stays on screen);
+ * `brepMs` is 0 in that case. Lets us measure the fallback rate vs. real timeouts.
  */
 export function trackBaseplatePreviewTiming(payload: {
   directMeshMs: number;
@@ -146,6 +149,7 @@ export function trackBaseplatePreviewTiming(payload: {
   isSplit: boolean;
   wasmCold: boolean;
   success: boolean;
+  deferred?: boolean;
 }): void {
   trackEvent('baseplate_preview_timing', {
     direct_mesh_ms: Math.round(payload.directMeshMs * 10) / 10,
@@ -155,5 +159,6 @@ export function trackBaseplatePreviewTiming(payload: {
     is_split: payload.isSplit,
     wasm_cold: payload.wasmCold,
     success: payload.success,
+    deferred: payload.deferred ?? false,
   });
 }


### PR DESCRIPTION
## Problem

Large magnet baseplates time out the live **preview** BREP build. PostHog `baseplate_preview_timing` (30d) shows ~150 distinct users hitting `success=false`, **mostly warm desktop** (so not cold-WASM) with brep times 10–40× the success median — sitting right at the per-piece magnet budget (`30s + cells×200ms + lightweight`). Biggest bucket is modest 2–9 piece splits (133 users); the 26×26 is the extreme tail.

## Root cause

The OCCT magnet-hole boolean pipeline is intrinsically expensive. Two "free perf" levers were **measured and rejected**: `cutAll({trackEvolution:false})` = 0% (metadata propagation isn't the bottleneck) and raising `BOOLEAN_BATCH_SIZE` = ~3% + reintroduces the OOM risk the 64-cap guards. The one real lever: the **lightweight floor cutters are ~⅓ of build time** on magnet grids — and they're underside-only material removal that the procedural draft mesh already omits.

## Changes (no impact on exported geometry)

**A. Draft-quality preview (measured −35%).** A `draft` flag threaded `generateHandler → generateBaseplate → buildBaseplateSolid` (+ mesh cache key) skips the lightweight floor cutters in the **live preview only**. Export is a separate function (`exportBaseplate`) and keeps full geometry. Measured: 6×6 preview 2688→1735 ms, 8×8 5048→3248 ms. Bonus: removes a direct→BREP underside "pop" (the procedural draft already renders a solid underside).

**B. Defer BREP for large plates.** New `previewComplexity.shouldDeferBrepPreview` (magnet-gated): defers when the largest unique piece ≥64 cells, total unique work ≥200 cells, or the last real BREP took ≥25 s (adaptive to slow hardware). On defer, keep the faithful instant procedural mesh and mark the preview complete — no doomed timeout. Wired into both `runGeneration` and the mount-effect bridge-ready path. Export rebuilds at full fidelity on its own larger budget.

Adds a `deferred` dimension to `baseplate_preview_timing` to measure the fallback rate post-launch.

## Why dedup doesn't already fix this

`groupPiecesByFingerprint` cuts the *number* of generations, but not single-piece cost or the per-piece timeout; the worst bucket (small splits of edge/corner pieces) barely dedups.

## Testing

- typecheck clean; lint 0 errors; `check:i18n` clean (no strings added)
- 547 baseplate tests pass — incl. overhang-audit + winding, which confirm **export** geometry is unchanged
- New tests: `previewComplexity` predictor (9), `baseplateGenerator.draft` (draft skips lightweight / no-op without magnets), cache-key draft keying, analytics `deferred` field