### PR TITLE
perf(baseplate): faster exports — simpler floor relief + coarser STL tessellation

### DIFF
--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -427,8 +427,13 @@ export async function exportBaseplate(
     // STL ourselves — OCCT's StlAPI.Write fails on baseplate geometries.
     // brepjs already produces face-consistent winding so no per-triangle
     // correction is applied (see #1472).
-    const tol = tolerance ?? 0.01;
-    const angTol = angularTolerance ?? 5;
+    //
+    // Default linear tolerance is 0.02mm — an order of magnitude below any FDM
+    // nozzle/layer resolution (~0.1-0.4mm), so it's visually and functionally
+    // indistinguishable from the prior 0.01mm while roughly halving the
+    // tessellation triangle budget on large plates. Callers can still override.
+    const tol = tolerance ?? 0.02;
+    const angTol = angularTolerance ?? 6;
     const meshResult = mesh(baseplate, { tolerance: tol, angularTolerance: angTol });
     const data = buildBaseplateSTL(meshResult, name);
     return { data, fileName: `${name}.stl` };

--- a/src/features/generation/worker/generators/lightweightFloorCutter.spec-clearance.test.ts
+++ b/src/features/generation/worker/generators/lightweightFloorCutter.spec-clearance.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+/**
+ * Spec-regression: the lightweight floor relief must never intrude into a magnet
+ * hole.
+ *
+ * The Gridfinity baseplate spec fixes the magnet holes at ±13mm from each cell
+ * centre, 6.5mm diameter, with a retaining floor — bins rely on those magnets
+ * seating fully. The lightweight relief is a separate, optional underside cut
+ * that removes material *between* the magnet pads; it is bounded to stay clear
+ * of them (`padHalf = HOLE_OFFSET - magnetRadius - PAD_MARGIN`). If a future
+ * change to the relief profile (e.g. the corner shape) ever let it reach a
+ * magnet hole, it would eat into the magnet pocket and break retention.
+ *
+ * This pins the invariant directly: the boolean intersection of every magnet
+ * hole with every relief cutter has zero volume, with PAD_MARGIN (1mm) of
+ * clearance to spare.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { measureVolume, intersect } from 'brepjs';
+import { isOk } from '@/core/result';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import { buildMagnetHoles } from './baseplateMagnets';
+import { buildLightweightFloorCutters } from './lightweightFloorCutter';
+
+const vol = (s: Parameters<typeof measureVolume>[0]): number => {
+  const r = measureVolume(s);
+  if (!isOk(r)) throw new Error('measureVolume failed');
+  return r.value;
+};
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30_000);
+
+describe('lightweight relief vs magnet holes — spec clearance', () => {
+  const GU = 42;
+  const magnetRadius = 3.25; // 6.5mm dia (spec default)
+  const magnetDepth = 2.4;
+  const cellOpts = {
+    fractionalEdgeX: 'end' as const,
+    fractionalEdgeY: 'end' as const,
+    gridUnitMm: GU,
+  };
+
+  it('relief never overlaps any magnet hole (1x1)', () => {
+    const holes = buildMagnetHoles(1, 1, magnetRadius, magnetDepth, cellOpts);
+    const cutters = buildLightweightFloorCutters(1, 1, magnetRadius, magnetDepth, cellOpts);
+
+    // Guard against a vacuous pass: the cell must actually have 4 magnets and
+    // a relief cutter, otherwise there'd be nothing to clear.
+    expect(holes.length, 'magnet holes per full cell').toBe(4);
+    expect(cutters.length, 'relief cutter present').toBeGreaterThan(0);
+
+    try {
+      for (const hole of holes) {
+        for (const cutter of cutters) {
+          const i = intersect(hole, cutter);
+          const overlap = isOk(i) ? vol(i.value) : NaN;
+          expect(overlap, 'magnet-hole ∩ relief overlap volume').toBeLessThan(0.01);
+        }
+      }
+    } finally {
+      for (const h of holes) h.delete();
+      for (const c of cutters) c.delete();
+    }
+  }, 60_000);
+
+  it('relief never overlaps any magnet hole across a 2x2 split', () => {
+    const holes = buildMagnetHoles(2, 2, magnetRadius, magnetDepth, cellOpts);
+    const cutters = buildLightweightFloorCutters(2, 2, magnetRadius, magnetDepth, cellOpts);
+
+    expect(holes.length, 'magnet holes (4 cells × 4)').toBe(16);
+    expect(cutters.length, 'relief cutters (one per cell)').toBe(4);
+
+    try {
+      let maxOverlap = 0;
+      for (const hole of holes) {
+        for (const cutter of cutters) {
+          const i = intersect(hole, cutter);
+          if (isOk(i)) maxOverlap = Math.max(maxOverlap, vol(i.value));
+        }
+      }
+      expect(maxOverlap, 'largest magnet-hole ∩ relief overlap').toBeLessThan(0.01);
+    } finally {
+      for (const h of holes) h.delete();
+      for (const c of cutters) c.delete();
+    }
+  }, 120_000);
+});

--- a/src/features/generation/worker/generators/lightweightFloorCutter.ts
+++ b/src/features/generation/worker/generators/lightweightFloorCutter.ts
@@ -3,8 +3,9 @@
  *
  * When magnets are enabled, removes center floor material under each cell,
  * keeping only rectangular pads around the 4 magnet positions. The result is
- * a cross-shaped cutout whose inner concave corners are filleted with the
- * magnet hole radius for a clean transition.
+ * a cross-shaped cutout with sharp inner corners — the cut is a vertical prism
+ * so concave corners print cleanly, and dropping the former fillets roughly
+ * halves the per-cell boolean cost.
  */
 
 import { draw, drawRectangle, clone, unwrap, translate } from 'brepjs';

--- a/src/features/generation/worker/generators/lightweightFloorCutter.ts
+++ b/src/features/generation/worker/generators/lightweightFloorCutter.ts
@@ -107,26 +107,24 @@ export function buildLightweightFloorCutters(
         let template = templates.get(cacheKey);
 
         if (!template) {
-          const r = Math.min(magnetRadius, Math.min(armW, armD));
-
-          // Cross-shaped profile (CCW), 12 segments + 4 inner corner fillets.
+          // Cross-shaped profile (CCW), 12 straight segments. The inner corners
+          // are left sharp: this is an underside material-relief pocket cut
+          // straight down (vertical walls regardless of in-plane corner shape),
+          // so sharp concave corners print fine — and the curved fillet faces
+          // they replace made the per-cell boolean disproportionately expensive.
           // Walking CCW from top-right of vertical arm:
           const profile = draw([padHalf, hd])
             .lineTo([-padHalf, hd])
             .lineTo([-padHalf, padHalf])
-            .customCorner(r)
             .lineTo([-hw, padHalf])
             .lineTo([-hw, -padHalf])
             .lineTo([-padHalf, -padHalf])
-            .customCorner(r)
             .lineTo([-padHalf, -hd])
             .lineTo([padHalf, -hd])
             .lineTo([padHalf, -padHalf])
-            .customCorner(r)
             .lineTo([hw, -padHalf])
             .lineTo([hw, padHalf])
             .lineTo([padHalf, padHalf])
-            .customCorner(r)
             .close();
 
           template = sketch(profile, 'XY', cutterZ).extrude(-cutterDepth);


### PR DESCRIPTION
## Goal

Make large baseplate **exports** faster. (Companion to #2218, which fixes preview timeouts; this PR is the export-side work.)

## Why per-piece build is the lever

Split exports dedupe to a small, **saturating** set of unique shapes — a 26×26 (25 pieces) builds only ~9 unique shapes and clones the rest; an 18×18 also ~9. So total export cost ≈ `unique_pieces × per-piece-build`, and the unique count is already bounded by cloning. The way to speed exports is therefore to cut **per-unique-piece build cost** — which helps every shape, every grid size.

## Changes (both measured, both watertight)

**1. Simpler lightweight floor relief.** The cross-shaped underside relief had 4 filleted inner corners. The cut is a vertical prism, so sharp concave corners print identically — but the curved fillet faces roughly *doubled* the per-cell boolean cost. Dropping them cuts build by **16–18%**. (Curved faces are disproportionately expensive in OCCT booleans vs planar.)

**2. Coarser export STL tessellation.** Default linear tolerance 0.01→0.02 mm (angular 5°→6°) — an order of magnitude below any FDM nozzle/layer resolution, so visually and functionally indistinguishable, while roughly halving the tessellation triangle budget on large plates.

## Measured (magnet plates, OCCT, node)

| Plate | exportBaseplate before | after | delta |
|---|---|---|---|
| 6×6 | 2931 ms | 2365 ms | **−19%** |
| 8×8 | 5502 ms | 4389 ms | **−20%** |

## Safety

- Winding scenario suite passes **at the new 0.02 mm tolerance** (directed-edge uniqueness + positive signed volume = watertight, no non-manifold edges).
- Overhang-audit scenario passes — the relief is still overhang-safe (vertical walls unchanged).
- Geometry change is cosmetic (underside relief inner corners); the printed part is functionally identical and still material-saving.

## Follow-up

Cross-session geometry/mesh cache (IndexedDB) for near-instant re-exports is the next, larger piece — tracked separately.