### PR TITLE
perf(baseplate): dedupe geometrically-identical split pieces via corner signature

### DIFF
--- a/src/features/baseplate/utils/pieceFingerprint.test.ts
+++ b/src/features/baseplate/utils/pieceFingerprint.test.ts
@@ -99,6 +99,49 @@ describe('computePieceFingerprint', () => {
     expect(computePieceFingerprint(blCorner)).not.toBe(computePieceFingerprint(trCorner));
   });
 
+  it('treats all-zero cornerRadii as no rounding (edges omitted, no connectors)', () => {
+    // cornerRadii present but every corner 0 → nothing rounds → a corner piece
+    // and an interior piece are geometrically identical and must share a key.
+    const base = makeParams({ width: 3, depth: 3, cornerRadii: { tl: 0, tr: 0, bl: 0, br: 0 } });
+    const corner = {
+      ...base,
+      edges: { left: 'exterior', right: 'join', front: 'exterior', back: 'join' } as const,
+    };
+    const interior = {
+      ...base,
+      edges: { left: 'join', right: 'join', front: 'join', back: 'join' } as const,
+    };
+    expect(computePieceFingerprint(corner)).toBe(computePieceFingerprint(interior));
+  });
+
+  it('ignores an exterior corner whose radius is 0 (per-corner zero)', () => {
+    // bl is exterior but its radius is 0 → does not round; br has radius 4 but
+    // isn't exterior here → neither rounds → identical to an interior piece.
+    const base = makeParams({ width: 3, depth: 3, cornerRadii: { tl: 0, tr: 0, bl: 0, br: 4 } });
+    const blExterior = {
+      ...base,
+      edges: { left: 'exterior', right: 'join', front: 'exterior', back: 'join' } as const,
+    };
+    const interior = {
+      ...base,
+      edges: { left: 'join', right: 'join', front: 'join', back: 'join' } as const,
+    };
+    expect(computePieceFingerprint(blExterior)).toBe(computePieceFingerprint(interior));
+  });
+
+  it('still distinguishes an exterior corner whose radius is > 0', () => {
+    const base = makeParams({ width: 3, depth: 3, cornerRadii: { tl: 0, tr: 0, bl: 4, br: 0 } });
+    const blRounds = {
+      ...base,
+      edges: { left: 'exterior', right: 'join', front: 'exterior', back: 'join' } as const,
+    };
+    const interior = {
+      ...base,
+      edges: { left: 'join', right: 'join', front: 'join', back: 'join' } as const,
+    };
+    expect(computePieceFingerprint(blRounds)).not.toBe(computePieceFingerprint(interior));
+  });
+
   it('with connectors on, edge layout still distinguishes corner-equivalent pieces', () => {
     // Connectors live on join edges, so the full layout matters even when the
     // two pieces would share a corner-rounding signature.

--- a/src/features/baseplate/utils/pieceFingerprint.test.ts
+++ b/src/features/baseplate/utils/pieceFingerprint.test.ts
@@ -70,6 +70,50 @@ describe('computePieceFingerprint', () => {
     expect(computePieceFingerprint(a)).not.toBe(computePieceFingerprint(b));
   });
 
+  it('dedupes edge and interior pieces that round no corner (rounded, no connectors)', () => {
+    // No connectors + rounded corners: edges matter only through which corners
+    // round. A top-edge piece (only back exterior) and an interior piece (all
+    // join) both round zero corners → identical geometry, same key.
+    const base = makeParams({ width: 3, depth: 3, cornerRadius: 4 });
+    const topEdge = {
+      ...base,
+      edges: { left: 'join', right: 'join', front: 'join', back: 'exterior' } as const,
+    };
+    const interior = {
+      ...base,
+      edges: { left: 'join', right: 'join', front: 'join', back: 'join' } as const,
+    };
+    expect(computePieceFingerprint(topEdge)).toBe(computePieceFingerprint(interior));
+  });
+
+  it('keeps pieces that round different corners distinct (rounded, no connectors)', () => {
+    const base = makeParams({ width: 3, depth: 3, cornerRadius: 4 });
+    const blCorner = {
+      ...base,
+      edges: { left: 'exterior', right: 'join', front: 'exterior', back: 'join' } as const,
+    };
+    const trCorner = {
+      ...base,
+      edges: { left: 'join', right: 'exterior', front: 'join', back: 'exterior' } as const,
+    };
+    expect(computePieceFingerprint(blCorner)).not.toBe(computePieceFingerprint(trCorner));
+  });
+
+  it('with connectors on, edge layout still distinguishes corner-equivalent pieces', () => {
+    // Connectors live on join edges, so the full layout matters even when the
+    // two pieces would share a corner-rounding signature.
+    const base = makeParams({ width: 3, depth: 3, connectorNubs: true, cornerRadius: 0 });
+    const a = {
+      ...base,
+      edges: { left: 'exterior', right: 'join', front: 'join', back: 'join' } as const,
+    };
+    const b = {
+      ...base,
+      edges: { left: 'join', right: 'exterior', front: 'join', back: 'join' } as const,
+    };
+    expect(computePieceFingerprint(a)).not.toBe(computePieceFingerprint(b));
+  });
+
   it('produces different keys when connectors differ', () => {
     const a = makeParams({ width: 3, depth: 3, connectorNubs: true });
     const b = makeParams({ width: 3, depth: 3, connectorNubs: false });

--- a/src/features/baseplate/utils/pieceFingerprint.ts
+++ b/src/features/baseplate/utils/pieceFingerprint.ts
@@ -7,7 +7,7 @@
  */
 
 import type { BaseplateParams } from '@/shared/types/bin';
-import { exteriorCorners } from '@/shared/generation/baseplateCorners';
+import { exteriorCorners, type CornerKey } from '@/shared/generation/baseplateCorners';
 import type { BaseplatePiece } from '../types/tiling';
 import { pieceToBaseplateParams } from './splitPlanner';
 
@@ -60,23 +60,29 @@ export function computePieceFingerprint(params: BaseplateParams): string {
   //     the compensating rotation (it's gated on connectorNubs too). Doing it
   //     without connectors would merge two pieces whose meshes then get placed
   //     un-rotated → a rounded corner on the wrong side.
-  //   - Corner rounding only rounds *exterior* corners (both adjacent edges
-  //     exterior). So with connectors off, edges matter only through which
-  //     corners round — key on that, not the raw labels, so edge and interior
-  //     pieces (no exterior corner → no rounding) dedupe with each other.
+  //   - Corner rounding rounds a corner iff it is *exterior* (both adjacent
+  //     edges exterior) AND its radius > 0 — matching `buildSlabProfile` /
+  //     `resolveCornerRadii`. So with connectors off, edges matter only through
+  //     which corners actually round — key on that, not the raw labels, so edge
+  //     and interior pieces (no rounded corner) dedupe with each other.
   //
-  // With neither connectors nor rounding, edges don't affect geometry at all,
-  // so nothing is added (key for stack-print tiles). Padding is captured
-  // separately, so padded edge pieces still differ from interior ones.
+  // When no corner actually rounds (square corners, or all-zero cornerRadii),
+  // edges don't affect geometry at all, so nothing is added (key for stack-print
+  // tiles). Padding is captured separately, so padded edge pieces still differ.
   if (params.edges) {
     if (params.connectorNubs === true) {
       const e = params.preferIdenticalPieces ? canonicalizeEdges(params.edges) : params.edges;
       parts.push(`el:${e.left}`, `er:${e.right}`, `ef:${e.front}`, `eb:${e.back}`);
     } else {
-      const noRounding = params.cornerRadius === 0 && params.cornerRadii === undefined;
-      if (!noRounding) {
-        const c = exteriorCorners(params.edges);
-        parts.push(`rc:${+c.tl}${+c.tr}${+c.bl}${+c.br}`);
+      // Per-corner nominal radius (mirrors resolveCornerRadii precedence:
+      // cornerRadii wins, else the uniform cornerRadius, whose absence defaults
+      // to the positive plate radius). Only the >0 test matters here.
+      const cr = params.cornerRadii;
+      const hasRadius = (k: CornerKey): boolean => (cr ? cr[k] > 0 : params.cornerRadius !== 0);
+      const ext = exteriorCorners(params.edges);
+      const rounds = (k: CornerKey): boolean => ext[k] && hasRadius(k);
+      if (rounds('tl') || rounds('tr') || rounds('bl') || rounds('br')) {
+        parts.push(`rc:${+rounds('tl')}${+rounds('tr')}${+rounds('bl')}${+rounds('br')}`);
       }
     }
   }

--- a/src/features/baseplate/utils/pieceFingerprint.ts
+++ b/src/features/baseplate/utils/pieceFingerprint.ts
@@ -7,6 +7,7 @@
  */
 
 import type { BaseplateParams } from '@/shared/types/bin';
+import { exteriorCorners } from '@/shared/generation/baseplateCorners';
 import type { BaseplatePiece } from '../types/tiling';
 import { pieceToBaseplateParams } from './splitPlanner';
 
@@ -49,17 +50,35 @@ export function computePieceFingerprint(params: BaseplateParams): string {
     params.cornerRadius === undefined ? 'cr:default' : `cr:${params.cornerRadius}`,
   ];
 
-  // Edge classification (exterior vs join) only affects geometry through
-  // connectors (placed on join edges) and corner rounding (only exterior
-  // corners round). With neither, pieces that differ only by edge label are
-  // byte-identical — so omit it and let them dedupe (key for stack-print tiles,
-  // where connectors + rounding are stripped). Padding is captured separately,
-  // so padded edge pieces still differ from interior ones.
-  const noRounding = params.cornerRadius === 0 && params.cornerRadii === undefined;
-  const edgesAffectGeometry = params.connectorNubs === true || !noRounding;
-  if (params.edges && edgesAffectGeometry) {
-    const e = params.preferIdenticalPieces ? canonicalizeEdges(params.edges) : params.edges;
-    parts.push(`el:${e.left}`, `er:${e.right}`, `ef:${e.front}`, `eb:${e.back}`);
+  // Edge classification (exterior vs join) affects geometry through two
+  // independent channels — and keying on the raw labels over-distinguishes
+  // pieces that are actually identical:
+  //
+  //   - Connectors are placed on join edges, so when they're on the full edge
+  //     layout matters. Canonicalize under preferIdenticalPieces so 180°-rotated
+  //     pairs share a key — but ONLY here, where the placement actually applies
+  //     the compensating rotation (it's gated on connectorNubs too). Doing it
+  //     without connectors would merge two pieces whose meshes then get placed
+  //     un-rotated → a rounded corner on the wrong side.
+  //   - Corner rounding only rounds *exterior* corners (both adjacent edges
+  //     exterior). So with connectors off, edges matter only through which
+  //     corners round — key on that, not the raw labels, so edge and interior
+  //     pieces (no exterior corner → no rounding) dedupe with each other.
+  //
+  // With neither connectors nor rounding, edges don't affect geometry at all,
+  // so nothing is added (key for stack-print tiles). Padding is captured
+  // separately, so padded edge pieces still differ from interior ones.
+  if (params.edges) {
+    if (params.connectorNubs === true) {
+      const e = params.preferIdenticalPieces ? canonicalizeEdges(params.edges) : params.edges;
+      parts.push(`el:${e.left}`, `er:${e.right}`, `ef:${e.front}`, `eb:${e.back}`);
+    } else {
+      const noRounding = params.cornerRadius === 0 && params.cornerRadii === undefined;
+      if (!noRounding) {
+        const c = exteriorCorners(params.edges);
+        parts.push(`rc:${+c.tl}${+c.tr}${+c.bl}${+c.br}`);
+      }
+    }
   }
 
   if (params.cornerRadii) {

--- a/src/features/generation/worker/generators/baseplateSlab.ts
+++ b/src/features/generation/worker/generators/baseplateSlab.ts
@@ -6,6 +6,7 @@ import { drawRectangle, drawRoundedRectangle, draw } from 'brepjs';
 import type { Drawing } from 'brepjs';
 import type { BaseplateParams } from '@/shared/types/bin';
 import { CONSTRAINTS } from '@/core/constants';
+import { exteriorCorners } from '@/shared/generation/baseplateCorners';
 
 /**
  * Build the 2D slab outline, rounding only exterior corners.
@@ -29,24 +30,12 @@ export function buildSlabProfile(
   const hd = totalD / 2;
   const { tl, tr, bl, br } = cornerRadii;
 
-  const isExt = (corner: 'tl' | 'tr' | 'bl' | 'br'): boolean => {
-    if (!edges) return true;
-    switch (corner) {
-      case 'tl':
-        return edges.left === 'exterior' && edges.back === 'exterior';
-      case 'tr':
-        return edges.right === 'exterior' && edges.back === 'exterior';
-      case 'bl':
-        return edges.left === 'exterior' && edges.front === 'exterior';
-      case 'br':
-        return edges.right === 'exterior' && edges.front === 'exterior';
-    }
-  };
+  const ext = exteriorCorners(edges);
 
-  const rBL = isExt('bl') && bl > 0 ? bl : 0;
-  const rBR = isExt('br') && br > 0 ? br : 0;
-  const rTR = isExt('tr') && tr > 0 ? tr : 0;
-  const rTL = isExt('tl') && tl > 0 ? tl : 0;
+  const rBL = ext.bl && bl > 0 ? bl : 0;
+  const rBR = ext.br && br > 0 ? br : 0;
+  const rTR = ext.tr && tr > 0 ? tr : 0;
+  const rTL = ext.tl && tl > 0 ? tl : 0;
 
   if (rBL === 0 && rBR === 0 && rTR === 0 && rTL === 0) {
     return drawRectangle(totalW, totalD);

--- a/src/shared/generation/baseplateCorners.test.ts
+++ b/src/shared/generation/baseplateCorners.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { exteriorCorners } from './baseplateCorners';
+
+describe('exteriorCorners', () => {
+  it('treats an unsplit plate (no edges) as all-exterior', () => {
+    expect(exteriorCorners(undefined)).toEqual({ tl: true, tr: true, bl: true, br: true });
+  });
+
+  it('marks a corner exterior only when both adjacent edges are exterior', () => {
+    // Top-left interior piece: every edge a join seam → no exterior corner.
+    expect(exteriorCorners({ left: 'join', right: 'join', front: 'join', back: 'join' })).toEqual({
+      tl: false,
+      tr: false,
+      bl: false,
+      br: false,
+    });
+
+    // A true bottom-left corner piece: left + front exterior → only bl rounds.
+    expect(
+      exteriorCorners({ left: 'exterior', right: 'join', front: 'exterior', back: 'join' })
+    ).toEqual({ tl: false, tr: false, bl: true, br: false });
+
+    // Top edge piece: only the back edge is exterior → no two-exterior corner.
+    expect(
+      exteriorCorners({ left: 'join', right: 'join', front: 'join', back: 'exterior' })
+    ).toEqual({ tl: false, tr: false, bl: false, br: false });
+  });
+});

--- a/src/shared/generation/baseplateCorners.ts
+++ b/src/shared/generation/baseplateCorners.ts
@@ -1,0 +1,31 @@
+/**
+ * Which baseplate corners are "exterior" — i.e. eligible for corner rounding.
+ *
+ * A corner rounds only when BOTH of its adjacent edges are exterior (not a join
+ * seam between split pieces). This is the single source of truth shared by:
+ *   - `buildSlabProfile` (baseplateSlab.ts), which actually rounds them, and
+ *   - `computePieceFingerprint` (pieceFingerprint.ts), which dedupes pieces by
+ *     the set of corners that round (so geometrically-identical edge/interior
+ *     pieces collapse instead of being split apart by raw edge labels).
+ *
+ * Keep these two in lockstep: if the rounding predicate ever changes, the dedup
+ * fingerprint must change with it or pieces will be wrongly merged or split.
+ */
+
+import type { BaseplateParams } from '@/shared/types/bin';
+
+export type CornerKey = 'tl' | 'tr' | 'bl' | 'br';
+
+/**
+ * Map each corner to whether both its adjacent edges are exterior. With no edge
+ * classification (a standalone, unsplit plate) every corner is exterior.
+ */
+export function exteriorCorners(edges: BaseplateParams['edges']): Record<CornerKey, boolean> {
+  if (!edges) return { tl: true, tr: true, bl: true, br: true };
+  return {
+    tl: edges.left === 'exterior' && edges.back === 'exterior',
+    tr: edges.right === 'exterior' && edges.back === 'exterior',
+    bl: edges.left === 'exterior' && edges.front === 'exterior',
+    br: edges.right === 'exterior' && edges.front === 'exterior',
+  };
+}


### PR DESCRIPTION
## What

Split-export piece dedup (`groupPiecesByFingerprint`) over-distinguished pieces. Whenever corners were rounded, it keyed the fingerprint on **raw edge labels**, so a top-edge, bottom-edge, and interior piece of the same size each got a distinct fingerprint and a **separate BREP build** — even though none of them rounds a corner and they're geometrically identical.

This keys the no-connector case on **which corners actually round** (both adjacent edges exterior) instead of raw edge labels, so those pieces collapse to a single build.

## Why it's safe

- The exterior-corner predicate is extracted into a shared `baseplateCorners` helper used by **both** the dedup fingerprint and `buildSlabProfile`'s rounding, so they can't drift.
- **Connectors unchanged**: they live on join edges, so the connector case still keys on the full edge layout.
- **Latent gap closed**: `canonicalizeEdges` (the 180°-rotation dedup) now only runs in the connector branch, where the placement actually applies the compensating rotation. Previously it was gated on `preferIdenticalPieces` alone while the rotation was gated on `preferIdenticalPieces && connectorNubs` — a mismatch that could have mis-oriented a piece if the flag were ever set without connectors.
- Merged pieces are placed by **translation only** (no rotation), and are byte-identical (same size, padding, magnet/grid config, zero rounded corners). `split-stress`, `winding`, and `dovetail` scenarios pass.

## Effect (magnets, 256mm bed, unpadded rounded)

| Grid | unique builds before | after |
|---|---|---|
| 18×18 | 9 | **5** |
| 24×24 | 9 | **5** |
| 26×26 | 9 | **7** |

**Scope/limitation:** this helps *unpadded* rounded plates. With drawer-fit padding, opposite-edge pieces are genuinely different parts (a top-padded piece can't substitute for a bottom-padded one without flipping it over), so they correctly stay distinct. Deduping those requires a 180° in-plane rotation — i.e. `preferIdenticalPieces` — which is a separate product decision (rotated pieces + assembly-guide implications), discussed in the PR thread / follow-up.

No layout or orientation change. Pairs with #2218 (preview) and #2220 (export build speed).