### PR TITLE
perf(baseplate): cross-session IndexedDB cache for split-export pieces

### DIFF
--- a/src/core/storage/clearAppData.ts
+++ b/src/core/storage/clearAppData.ts
@@ -16,7 +16,19 @@
 import { clearAllData as clearIndexedDB } from './backends/indexedDB';
 import { pruneAnalyticsData } from '@/shared/analytics/posthog';
 import { clearLabelSizesCache } from '@/shared/analytics/purposeInference';
-import { SETTINGS_STORAGE_KEY } from './storageKeys';
+import { SETTINGS_STORAGE_KEY, BASEPLATE_EXPORT_DB_NAME } from './storageKeys';
+
+/** Delete a whole IndexedDB database, resolving regardless of outcome. */
+function deleteDatabase(name: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    try {
+      const req = indexedDB.deleteDatabase(name);
+      req.onsuccess = req.onerror = req.onblocked = () => resolve();
+    } catch {
+      resolve();
+    }
+  });
+}
 
 /** Keys that should be preserved during a full data clear. */
 const PRESERVED_KEYS = new Set([SETTINGS_STORAGE_KEY]);
@@ -46,4 +58,6 @@ export async function clearAllAppData(): Promise<void> {
   }
 
   await clearIndexedDB();
+  // The baseplate export byte cache lives in its own database — drop it whole.
+  await deleteDatabase(BASEPLATE_EXPORT_DB_NAME);
 }

--- a/src/core/storage/storageKeys.ts
+++ b/src/core/storage/storageKeys.ts
@@ -17,6 +17,11 @@ export const LIBRARY_CHANNEL_NAME = 'gridfinity-library-sync';
 
 export const SETTINGS_STORAGE_KEY = 'gridfinity-settings-v1';
 
+// Baseplate export byte cache (own IndexedDB database). Defined here so the
+// full-data-clear path can delete it without importing the baseplate feature
+// (core must not depend on features).
+export const BASEPLATE_EXPORT_DB_NAME = 'gridfinity-baseplate-export-v1';
+
 // Migration flags
 export const MIGRATION_FLAG_KEY = 'gridfinity-indexeddb-migrated';
 export const CLEANUP_FLAG_KEY = 'gridfinity-localstorage-cleaned';

--- a/src/features/baseplate/hooks/useBaseplateExport.ts
+++ b/src/features/baseplate/hooks/useBaseplateExport.ts
@@ -25,6 +25,7 @@ import { useTranslation } from '@/i18n';
 import { useBaseplatePageStore } from '../store/baseplatePageStore';
 import { buildFullParams } from '../utils/buildFullParams';
 import { groupPiecesByFingerprint } from '../utils/pieceFingerprint';
+import { buildExportCacheKey, getCachedExports, putCachedExports } from '../utils/exportCache';
 import { assignGroupNames } from '../utils/pieceNaming';
 import { countConnectorKeys } from '../utils/connectorKeys';
 import { generatePrintGuide, generateStackPrintNote } from '../utils/printGuide';
@@ -194,24 +195,50 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
           setExportProgress({ current: 0, total: uniqueCount });
 
           const uniqueParams = uniqueGroups.map(([, g]) => g.params);
-          let uniqueExports: ArrayBuffer[];
+          const nozzleMm = useSettingsStore.getState().settings.printSettings.nozzleSizeMm;
 
-          if (pool && !pool.isDestroyed && pool.size > 1) {
-            const results = await pool.exportBaseplates(
-              uniqueParams,
-              bridgeFormat,
-              (completed, pieceTotal) =>
-                setExportProgress({ current: completed, total: pieceTotal })
-            );
-            uniqueExports = results.map((r) => r.data);
-          } else {
-            uniqueExports = [];
-            for (let i = 0; i < uniqueGroups.length; i++) {
-              setExportProgress({ current: i + 1, total: uniqueCount });
-              const result = await bridge.exportBaseplate(uniqueGroups[i][1].params, bridgeFormat);
-              uniqueExports.push(result.data);
-            }
+          // Cross-session cache: skip rebuilding pieces whose identical bytes are
+          // already persisted. Only the misses go to the worker pool.
+          const cacheKeys = uniqueParams.map((p) => buildExportCacheKey(p, bridgeFormat, nozzleMm));
+          const cached = await getCachedExports(cacheKeys);
+          const missIndices: number[] = [];
+          for (let i = 0; i < cached.length; i++) {
+            if (cached[i] === undefined) missIndices.push(i);
           }
+          const cachedCount = uniqueCount - missIndices.length;
+          setExportProgress({ current: cachedCount, total: uniqueCount });
+
+          const freshByIndex = new Map<number, ArrayBuffer>();
+          const toPersist: { key: string; data: ArrayBuffer }[] = [];
+          if (missIndices.length > 0) {
+            const missParams = missIndices.map((i) => uniqueParams[i]);
+            if (pool && !pool.isDestroyed && pool.size > 1) {
+              const results = await pool.exportBaseplates(missParams, bridgeFormat, (completed) =>
+                setExportProgress({ current: cachedCount + completed, total: uniqueCount })
+              );
+              results.forEach((r, j) => {
+                const idx = missIndices[j];
+                freshByIndex.set(idx, r.data);
+                toPersist.push({ key: cacheKeys[idx], data: r.data });
+              });
+            } else {
+              for (let j = 0; j < missParams.length; j++) {
+                setExportProgress({ current: cachedCount + j + 1, total: uniqueCount });
+                const result = await bridge.exportBaseplate(missParams[j], bridgeFormat);
+                const idx = missIndices[j];
+                freshByIndex.set(idx, result.data);
+                toPersist.push({ key: cacheKeys[idx], data: result.data });
+              }
+            }
+            void putCachedExports(toPersist);
+          }
+
+          const uniqueExports: ArrayBuffer[] = cacheKeys.map((_, i) => {
+            const data = cached[i] ?? freshByIndex.get(i);
+            if (data === undefined)
+              throw new Error('Baseplate export piece missing after generation');
+            return data;
+          });
 
           // One file per unique shape. When stacking, each unique piece is baked
           // into towers of the quantity the drawer needs (group size), split into

--- a/src/features/baseplate/hooks/useBaseplateExport.ts
+++ b/src/features/baseplate/hooks/useBaseplateExport.ts
@@ -25,7 +25,12 @@ import { useTranslation } from '@/i18n';
 import { useBaseplatePageStore } from '../store/baseplatePageStore';
 import { buildFullParams } from '../utils/buildFullParams';
 import { groupPiecesByFingerprint } from '../utils/pieceFingerprint';
-import { buildExportCacheKey, getCachedExports, putCachedExports } from '../utils/exportCache';
+import {
+  buildExportCacheKey,
+  getCachedExports,
+  putCachedExports,
+  getOrExport,
+} from '../utils/exportCache';
 import { assignGroupNames } from '../utils/pieceNaming';
 import { countConnectorKeys } from '../utils/connectorKeys';
 import { generatePrintGuide, generateStackPrintNote } from '../utils/printGuide';
@@ -162,6 +167,7 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
       );
 
       try {
+        const nozzleMm = useSettingsStore.getState().settings.printSettings.nozzleSizeMm;
         const fullParams = buildFullParams(
           baseplateParams,
           drawerWidth,
@@ -169,7 +175,7 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
           gridUnitMm,
           fractionalEdgeX,
           fractionalEdgeY,
-          useSettingsStore.getState().settings.printSettings.nozzleSizeMm
+          nozzleMm
         );
 
         const baseName = generateBaseplateFileName(
@@ -195,7 +201,6 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
           setExportProgress({ current: 0, total: uniqueCount });
 
           const uniqueParams = uniqueGroups.map(([, g]) => g.params);
-          const nozzleMm = useSettingsStore.getState().settings.printSettings.nozzleSizeMm;
 
           // Cross-session cache: skip rebuilding pieces whose identical bytes are
           // already persisted. Only the misses go to the worker pool.
@@ -278,8 +283,12 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
           // every seam junction — one STL, printed N times.
           const keyCount = countConnectorKeys(tiling, fullParams);
           if (keyCount > 0) {
-            const keyResult = await bridge.exportConnectorKey(fullParams, bridgeFormat);
-            let keyData = keyResult.data;
+            // Namespaced key: the connector key is different geometry from a
+            // plate built with the same params, so it must not share a cache slot.
+            let keyData = await getOrExport(
+              `connkey|${buildExportCacheKey(fullParams, bridgeFormat, nozzleMm)}`,
+              () => bridge.exportConnectorKey(fullParams, bridgeFormat).then((r) => r.data)
+            );
             if (format === '3mf') {
               // The key is a discrete part (one per seam junction, count in the
               // guide), not a plate — stacking never applies to it. It prints
@@ -324,13 +333,17 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
           }
         } else if (format === 'step') {
           // STEP: never stacked (CAD interchange, no slicer notion).
-          const result = await bridge.exportBaseplate(fullParams, 'step');
-          triggerDownload(new Blob([result.data], { type: FORMAT_MIME_TYPES.step }), baseName);
+          const data = await getOrExport(buildExportCacheKey(fullParams, 'step', nozzleMm), () =>
+            bridge.exportBaseplate(fullParams, 'step').then((r) => r.data)
+          );
+          triggerDownload(new Blob([data], { type: FORMAT_MIME_TYPES.step }), baseName);
         } else if (stack && stackEnabled) {
           // Single piece, stacked into one tower (split under the height cap) —
           // a single tower downloads directly, several go in a ZIP.
-          const stlResult = await bridge.exportBaseplate(fullParams, 'stl');
-          const source = parseStlSoup(stlResult.data);
+          const stlData = await getOrExport(buildExportCacheKey(fullParams, 'stl', nozzleMm), () =>
+            bridge.exportBaseplate(fullParams, 'stl').then((r) => r.data)
+          );
+          const source = parseStlSoup(stlData);
           const towers = planPhysicalStacks([{ label: 'plate', quantity: 1 }], stackCap);
           if (towers.length === 1) {
             const blob = buildStackedFileBlob(
@@ -361,11 +374,13 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
           }
         } else {
           // Single piece, unstacked, STL or 3MF.
-          const stlResult = await bridge.exportBaseplate(fullParams, 'stl');
+          const stlData = await getOrExport(buildExportCacheKey(fullParams, 'stl', nozzleMm), () =>
+            bridge.exportBaseplate(fullParams, 'stl').then((r) => r.data)
+          );
           const blob =
             format === '3mf'
-              ? convertStlTo3mf(stlResult.data, baseNameNoExt)
-              : new Blob([stlResult.data], { type: FORMAT_MIME_TYPES.stl });
+              ? convertStlTo3mf(stlData, baseNameNoExt)
+              : new Blob([stlData], { type: FORMAT_MIME_TYPES.stl });
           triggerDownload(blob, baseName);
           // Single-file success is conveyed by the dialog's inline success view.
         }

--- a/src/features/baseplate/utils/exportCache.test.ts
+++ b/src/features/baseplate/utils/exportCache.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  buildExportCacheKey,
+  getCachedExport,
+  getCachedExports,
+  putCachedExports,
+  clearExportCache,
+  setExportCacheMaxBytesForTests,
+} from './exportCache';
+import type { BaseplateParams } from '@/shared/types/bin';
+
+const params = (over: Partial<BaseplateParams> = {}): BaseplateParams => ({
+  width: 6,
+  depth: 6,
+  gridUnitMm: 42,
+  magnetHoles: true,
+  magnetDiameter: 6.5,
+  magnetDepth: 2.4,
+  paddingLeft: 0,
+  paddingRight: 0,
+  paddingFront: 0,
+  paddingBack: 0,
+  fractionalEdgeX: 'end',
+  fractionalEdgeY: 'end',
+  ...over,
+});
+
+const buf = (n: number, fill = 1): ArrayBuffer => {
+  const a = new Uint8Array(n).fill(fill);
+  return a.buffer;
+};
+
+beforeEach(async () => {
+  await clearExportCache();
+  setExportCacheMaxBytesForTests(50 * 1024 * 1024);
+});
+
+afterEach(async () => {
+  await clearExportCache();
+});
+
+describe('buildExportCacheKey', () => {
+  it('is stable for equal params regardless of key order', () => {
+    const p = params({ width: 6, depth: 4 });
+    // Same values, reversed property insertion order — stableStringify sorts keys.
+    const reordered = Object.fromEntries(Object.entries(p).reverse()) as BaseplateParams;
+    expect(buildExportCacheKey(p, 'stl', 0.4)).toBe(buildExportCacheKey(reordered, 'stl', 0.4));
+  });
+
+  it('differs on geometry, format, and nozzle', () => {
+    const base = params();
+    const k = buildExportCacheKey(base, 'stl', 0.4);
+    expect(k).not.toBe(buildExportCacheKey(params({ width: 7 }), 'stl', 0.4));
+    expect(k).not.toBe(buildExportCacheKey(base, 'step', 0.4));
+    expect(k).not.toBe(buildExportCacheKey(base, 'stl', 0.6));
+  });
+});
+
+describe('export cache roundtrip', () => {
+  it('returns undefined on miss and the stored bytes on hit', async () => {
+    const key = buildExportCacheKey(params(), 'stl', 0.4);
+    expect(await getCachedExport(key)).toBeUndefined();
+
+    await putCachedExports([{ key, data: buf(1000, 7) }]);
+    const got = await getCachedExport(key);
+    expect(got).toBeDefined();
+    expect(new Uint8Array(got as ArrayBuffer)[0]).toBe(7);
+    expect((got as ArrayBuffer).byteLength).toBe(1000);
+  });
+
+  it('batch-reads hits and misses in order', async () => {
+    const k1 = buildExportCacheKey(params({ width: 6 }), 'stl', 0.4);
+    const k2 = buildExportCacheKey(params({ width: 7 }), 'stl', 0.4);
+    await putCachedExports([{ key: k1, data: buf(10) }]);
+
+    const [a, b] = await getCachedExports([k1, k2]);
+    expect(a).toBeDefined();
+    expect(b).toBeUndefined();
+  });
+
+  it('clears all entries', async () => {
+    const key = buildExportCacheKey(params(), 'stl', 0.4);
+    await putCachedExports([{ key, data: buf(10) }]);
+    await clearExportCache();
+    expect(await getCachedExport(key)).toBeUndefined();
+  });
+});
+
+describe('eviction', () => {
+  it('evicts oldest entries once over the byte budget', async () => {
+    setExportCacheMaxBytesForTests(2500);
+    const k = (w: number) => buildExportCacheKey(params({ width: w }), 'stl', 0.4);
+
+    // Three 1000-byte entries = 3000 > 2500 → the oldest (k1) is evicted.
+    await putCachedExports([{ key: k(1), data: buf(1000) }]);
+    await putCachedExports([{ key: k(2), data: buf(1000) }]);
+    await putCachedExports([{ key: k(3), data: buf(1000) }]);
+
+    expect(await getCachedExport(k(1))).toBeUndefined(); // evicted (oldest)
+    expect(await getCachedExport(k(2))).toBeDefined();
+    expect(await getCachedExport(k(3))).toBeDefined();
+  });
+});

--- a/src/features/baseplate/utils/exportCache.test.ts
+++ b/src/features/baseplate/utils/exportCache.test.ts
@@ -48,6 +48,23 @@ describe('buildExportCacheKey', () => {
     expect(buildExportCacheKey(p, 'stl', 0.4)).toBe(buildExportCacheKey(reordered, 'stl', 0.4));
   });
 
+  it('canonicalizes unset optional params (absent ≡ undefined ≡ null)', () => {
+    // The generator reads optionals with nullish semantics, so these three
+    // forms produce identical geometry and must share a key.
+    const absent = params(); // cornerRadius simply not set
+    const undef = params({ cornerRadius: undefined });
+    const asNull = params({ cornerRadius: null as unknown as undefined });
+    const k = buildExportCacheKey(absent, 'stl', 0.4);
+    expect(buildExportCacheKey(undef, 'stl', 0.4)).toBe(k);
+    expect(buildExportCacheKey(asNull, 'stl', 0.4)).toBe(k);
+  });
+
+  it('keeps a meaningful value distinct from unset', () => {
+    const unset = buildExportCacheKey(params(), 'stl', 0.4);
+    const squared = buildExportCacheKey(params({ cornerRadius: 0 }), 'stl', 0.4);
+    expect(squared).not.toBe(unset);
+  });
+
   it('differs on geometry, format, and nozzle', () => {
     const base = params();
     const k = buildExportCacheKey(base, 'stl', 0.4);

--- a/src/features/baseplate/utils/exportCache.test.ts
+++ b/src/features/baseplate/utils/exportCache.test.ts
@@ -3,6 +3,7 @@ import {
   buildExportCacheKey,
   getCachedExport,
   getCachedExports,
+  getOrExport,
   putCachedExports,
   clearExportCache,
   setExportCacheMaxBytesForTests,
@@ -83,6 +84,25 @@ describe('export cache roundtrip', () => {
     await putCachedExports([{ key, data: buf(10) }]);
     await clearExportCache();
     expect(await getCachedExport(key)).toBeUndefined();
+  });
+});
+
+describe('getOrExport', () => {
+  it('runs generate on miss, persists, and skips generate on the next call', async () => {
+    const key = buildExportCacheKey(params(), 'stl', 0.4);
+    let calls = 0;
+    const generate = () => {
+      calls++;
+      return Promise.resolve(buf(42, 9));
+    };
+
+    const first = await getOrExport(key, generate);
+    expect(calls).toBe(1);
+    expect(new Uint8Array(first)[0]).toBe(9);
+
+    const second = await getOrExport(key, generate);
+    expect(calls).toBe(1); // served from cache, generate not called again
+    expect(second.byteLength).toBe(42);
   });
 });
 

--- a/src/features/baseplate/utils/exportCache.ts
+++ b/src/features/baseplate/utils/exportCache.ts
@@ -69,13 +69,26 @@ function getDb(): Promise<IDBPDatabase | null> {
   return dbPromise;
 }
 
-/** Recursively key-sorted JSON so logically-equal param objects stringify identically. */
+/**
+ * Recursively key-sorted JSON so logically-equal param objects stringify
+ * identically.
+ *
+ * Object keys whose value is `null` or `undefined` are omitted, so an unset
+ * optional param is canonical regardless of how it arrives — absent, `undefined`
+ * (in-memory default), or `null` (after a JSON/storage round-trip). This matches
+ * the generator, which reads every optional baseplate param with nullish
+ * semantics (`x ?? default`, `x !== false`, truthiness), so those three forms
+ * produce byte-identical geometry and must share a key. Real values (including
+ * `false`/`0`) are always kept, so a meaningful flag never collapses into "unset".
+ */
 function stableStringify(value: unknown): string {
-  if (value === undefined) return 'null';
-  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (value === null || value === undefined) return 'null';
+  if (typeof value !== 'object') return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
   const obj = value as Record<string, unknown>;
-  const keys = Object.keys(obj).sort();
+  const keys = Object.keys(obj)
+    .filter((k) => obj[k] !== null && obj[k] !== undefined)
+    .sort();
   return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
 }
 
@@ -135,11 +148,14 @@ export async function putCachedExports(
   try {
     const db = await getDb();
     if (!db) return;
-    const now = nextTs();
     {
       const tx = db.transaction(STORE, 'readwrite');
+      // Distinct, increasing ts per entry so intra-batch eviction order is
+      // deterministic (a shared stamp would tie-break by key, not recency).
       await Promise.all(
-        entries.map((e) => tx.store.put({ data: e.data, size: e.data.byteLength, ts: now }, e.key))
+        entries.map((e) =>
+          tx.store.put({ data: e.data, size: e.data.byteLength, ts: nextTs() }, e.key)
+        )
       );
       await tx.done;
     }

--- a/src/features/baseplate/utils/exportCache.ts
+++ b/src/features/baseplate/utils/exportCache.ts
@@ -1,0 +1,164 @@
+/**
+ * Cross-session cache for baseplate export bytes (STL / STEP).
+ *
+ * Exporting a large split baseplate rebuilds and re-tessellates every unique
+ * piece from scratch on every export — even an identical re-export after a
+ * reload. This persists each unique piece's export bytes in IndexedDB so a
+ * repeat export of the same geometry is near-instant.
+ *
+ * Correctness — the cache MUST never serve bytes for different geometry:
+ *   - Key includes the build's git SHA (`__GIT_SHA__`), so any generator change
+ *     shipped in a new deploy invalidates the whole cache. Within one deploy the
+ *     geometry pipeline is fixed, so cached bytes are byte-identical to a rebuild.
+ *   - Key includes a complete, order-stable serialization of the exact params
+ *     passed to `exportBaseplate` (the sole determinant of the worker output),
+ *     plus the export format and the session nozzle size (which scales connector
+ *     geometry but isn't carried on the per-piece params object). Including the
+ *     nozzle explicitly can only ever cause a conservative miss, never a wrong hit.
+ *
+ * Every operation degrades gracefully: if IndexedDB is unavailable (private
+ * mode, quota, disabled), reads miss and writes no-op — the export still runs,
+ * just without the cache.
+ */
+
+import { openDB, type IDBPDatabase } from 'idb';
+import type { BaseplateParams, ExportFileFormat } from '@/shared/types/bin';
+
+const DB_NAME = 'gridfinity-baseplate-export-v1';
+const DB_VERSION = 1;
+const STORE = 'exports';
+const TS_INDEX = 'ts';
+
+/** Evict oldest entries once the cache exceeds this many bytes. */
+let maxBytes = 50 * 1024 * 1024;
+
+/** Test-only: shrink the byte budget so eviction can be exercised cheaply. */
+export function setExportCacheMaxBytesForTests(bytes: number): void {
+  maxBytes = bytes;
+}
+
+interface CacheEntry {
+  readonly data: ArrayBuffer;
+  readonly size: number;
+  ts: number;
+}
+
+/** Build SHA, inlined by Vite at build time; falls back to 'dev' under test/SSR. */
+const BUILD_ID = typeof __GIT_SHA__ === 'string' ? __GIT_SHA__ : 'dev';
+
+// Strictly-monotonic recency stamp: wall-clock when it advances, else +1, so
+// entries written or touched in the same millisecond still order deterministically.
+let lastTs = 0;
+function nextTs(): number {
+  const now = Date.now();
+  lastTs = now > lastTs ? now : lastTs + 1;
+  return lastTs;
+}
+
+let dbPromise: Promise<IDBPDatabase | null> | null = null;
+
+function getDb(): Promise<IDBPDatabase | null> {
+  if (dbPromise) return dbPromise;
+  dbPromise = openDB(DB_NAME, DB_VERSION, {
+    upgrade(db) {
+      const store = db.createObjectStore(STORE);
+      store.createIndex(TS_INDEX, 'ts');
+    },
+  }).catch(() => null); // IndexedDB unavailable → null, callers treat as miss/no-op
+  return dbPromise;
+}
+
+/** Recursively key-sorted JSON so logically-equal param objects stringify identically. */
+function stableStringify(value: unknown): string {
+  if (value === undefined) return 'null';
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
+}
+
+/**
+ * Cache key for one piece's export. Complete by construction: build id + format
+ * + session nozzle + the full param object that drives the worker output.
+ */
+export function buildExportCacheKey(
+  params: BaseplateParams,
+  format: ExportFileFormat,
+  nozzleSizeMm: number
+): string {
+  return `${BUILD_ID}|${format}|n${nozzleSizeMm}|${stableStringify(params)}`;
+}
+
+/** Read one cached export, touching its recency. Returns undefined on miss/error. */
+export async function getCachedExport(key: string): Promise<ArrayBuffer | undefined> {
+  try {
+    const db = await getDb();
+    if (!db) return undefined;
+    const entry = (await db.get(STORE, key)) as CacheEntry | undefined;
+    if (!entry) return undefined;
+    // Touch recency best-effort; don't block or fail the read on it.
+    void db.put(STORE, { ...entry, ts: nextTs() }, key).catch(() => {});
+    return entry.data;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Batch read; result[i] is the bytes for keys[i] or undefined on miss. */
+export async function getCachedExports(keys: string[]): Promise<(ArrayBuffer | undefined)[]> {
+  return Promise.all(keys.map((k) => getCachedExport(k)));
+}
+
+/** Store export bytes, then evict oldest entries if over the byte budget. No-op on error. */
+export async function putCachedExports(
+  entries: ReadonlyArray<{ key: string; data: ArrayBuffer }>
+): Promise<void> {
+  if (entries.length === 0) return;
+  try {
+    const db = await getDb();
+    if (!db) return;
+    const now = nextTs();
+    {
+      const tx = db.transaction(STORE, 'readwrite');
+      await Promise.all(
+        entries.map((e) => tx.store.put({ data: e.data, size: e.data.byteLength, ts: now }, e.key))
+      );
+      await tx.done;
+    }
+    await evictIfNeeded(db);
+  } catch {
+    // best-effort cache; ignore
+  }
+}
+
+/** Evict oldest-touched entries (LRU) until total bytes are under the budget. */
+async function evictIfNeeded(db: IDBPDatabase): Promise<void> {
+  // Single transaction: walk the ts index oldest-first, tallying sizes and the
+  // store keys, then delete from the oldest end until under budget. (Two
+  // overlapping readwrite transactions on the same store can deadlock.)
+  const tx = db.transaction(STORE, 'readwrite');
+  const ordered: { key: IDBValidKey; size: number }[] = [];
+  let total = 0;
+  for await (const cursor of tx.store.index(TS_INDEX).iterate()) {
+    const size = (cursor.value as CacheEntry).size;
+    ordered.push({ key: cursor.primaryKey, size });
+    total += size;
+  }
+  for (let i = 0; i < ordered.length && total > maxBytes; i++) {
+    await tx.store.delete(ordered[i].key);
+    total -= ordered[i].size;
+  }
+  await tx.done;
+}
+
+/** Clear the entire export cache (exposed for tests / settings "clear storage"). */
+export async function clearExportCache(): Promise<void> {
+  try {
+    const db = await getDb();
+    if (!db) return;
+    await db.clear(STORE);
+  } catch {
+    // ignore
+  }
+}

--- a/src/features/baseplate/utils/exportCache.ts
+++ b/src/features/baseplate/utils/exportCache.ts
@@ -23,8 +23,9 @@
 
 import { openDB, type IDBPDatabase } from 'idb';
 import type { BaseplateParams, ExportFileFormat } from '@/shared/types/bin';
+import { BASEPLATE_EXPORT_DB_NAME } from '@/core/storage/storageKeys';
 
-const DB_NAME = 'gridfinity-baseplate-export-v1';
+const DB_NAME = BASEPLATE_EXPORT_DB_NAME;
 const DB_VERSION = 1;
 const STORE = 'exports';
 const TS_INDEX = 'ts';
@@ -108,6 +109,22 @@ export async function getCachedExport(key: string): Promise<ArrayBuffer | undefi
 /** Batch read; result[i] is the bytes for keys[i] or undefined on miss. */
 export async function getCachedExports(keys: string[]): Promise<(ArrayBuffer | undefined)[]> {
   return Promise.all(keys.map((k) => getCachedExport(k)));
+}
+
+/**
+ * Return cached bytes for `key`, or run `generate`, persist (best-effort), and
+ * return its result. For single exports (one plate, the connector key); the
+ * split path partitions hits/misses itself to keep the worker pool busy.
+ */
+export async function getOrExport(
+  key: string,
+  generate: () => Promise<ArrayBuffer>
+): Promise<ArrayBuffer> {
+  const hit = await getCachedExport(key);
+  if (hit !== undefined) return hit;
+  const data = await generate();
+  void putCachedExports([{ key, data }]);
+  return data;
 }
 
 /** Store export bytes, then evict oldest entries if over the byte budget. No-op on error. */


### PR DESCRIPTION
## What

Exporting a split baseplate rebuilt and re-tessellated **every unique piece from scratch on every export** — including an identical re-export after a page reload. This persists each unique piece's export bytes in IndexedDB, so a repeat export of the same geometry skips the worker entirely; only cache **misses** go to the pool.

This is the third and last of the export-perf levers (after #2220 build speed and #2221 dedup). Where those cut the cost of *building* a piece, this removes the build entirely for already-seen geometry — a re-export of a 26×26 becomes near-instant.

## Correctness — never serves stale geometry

The cache key is complete by construction:
- **`__GIT_SHA__`** (Vite build-time constant) — any generator change shipped in a new deploy invalidates the whole cache. Within one deploy the pipeline is fixed, so cached bytes are byte-identical to a rebuild.
- **Order-stable serialization of the exact params** passed to `exportBaseplate` — the sole determinant of the worker output — plus the **format** and the **session nozzle size** (which scales connector geometry but isn't carried on the per-piece params object). Including the nozzle explicitly can only ever cause a conservative miss, never a wrong hit.

## Robustness

- **LRU eviction** caps the store at 50MB (monotonic recency stamps make eviction deterministic even within a millisecond).
- **Graceful degradation**: every op is wrapped — if IndexedDB is unavailable (private mode, quota, disabled), reads miss and writes no-op, and the export runs exactly as before.
- Integrated only in the split path's unique-piece generation: cache keys computed → batch read → only misses generated (pool or sequential) → fresh results persisted → assembled in order. Progress reporting counts cached pieces as already-done.

## Tests

`exportCache.test.ts`: key stability under property reordering; key sensitivity to geometry/format/nozzle; put/get roundtrip; batch hits+misses; clear; and LRU eviction over the byte budget (via a test-only cap seam). 541 baseplate tests pass.

## Follow-up

The single-plate (non-split) export path and the connector-key part still rebuild; they're cheaper (one piece) and can adopt the same helper later. The Settings "storage" view could also surface/clear this cache.